### PR TITLE
feat(hub): public surface for native paper recovery (#28, #39)

### DIFF
--- a/packages/hub/__tests__/pr1a-public-recovery.test.ts
+++ b/packages/hub/__tests__/pr1a-public-recovery.test.ts
@@ -1,0 +1,124 @@
+/**
+ * PR1a — public-API exposure for paper recovery + db.getKeyring.
+ *
+ * Covers:
+ *   - issue #28: db.getKeyring(vault) is reachable from outside the hub
+ *     and returns the live UnlockedKeyring (same shape on-* packages
+ *     expect — .deks Map, .kek CryptoKey, .role).
+ *   - issue #39: mintPaperRecoveryEntry + unwrapDeksFromPaperEntry are
+ *     re-exported from @noy-db/hub and produce entries that survive
+ *     the full db.enrollRecovery → db.recoverPassphrase round-trip.
+ *
+ * The test imports from '../src/index.js' (the barrel) — not from
+ * 'team/recovery.js' — so it pins the public-surface contract that
+ * pre.8 ships. Removing either export would break this test.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope } from '../src/types.js'
+import {
+  createNoydb,
+  type Noydb,
+  mintPaperRecoveryEntry,
+  unwrapDeksFromPaperEntry,
+  type PaperRecoveryEntry,
+} from '../src/index.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'inline-memory',
+    async get(c: string, col: string, id: string) { return gc(c, col).get(id) },
+    async put(c: string, col: string, id: string, env: EncryptedEnvelope) { gc(c, col).set(id, env) },
+    async delete(c: string, col: string, id: string) { gc(c, col).delete(id) },
+    async list(c: string, col: string) { return [...gc(c, col).keys()] },
+    async loadAll() { return {} },
+    async saveAll() {},
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+  } as unknown as NoydbStore
+}
+
+const STRONG_OLD = 'correct horse battery staple printer toaster'
+const STRONG_NEW = 'glasses cabinet bicycle umbrella thunder velvet'
+
+describe('PR1a public surface', () => {
+  let db: Noydb
+
+  beforeEach(async () => {
+    db = await createNoydb({
+      store: inlineMemory(),
+      user: 'alice',
+      secret: STRONG_OLD,
+    })
+    await db.openVault('acme')
+  })
+
+  describe('db.getKeyring (#28)', () => {
+    it('returns the live UnlockedKeyring with non-empty DEK map', async () => {
+      const keyring = await db.getKeyring('acme')
+      expect(keyring.userId).toBe('alice')
+      expect(keyring.role).toBe('owner')
+      expect(keyring.deks.size).toBeGreaterThan(0)
+      expect(keyring.kek).toBeInstanceOf(CryptoKey)
+    })
+
+    it('returns the same instance on repeated calls (cached)', async () => {
+      const a = await db.getKeyring('acme')
+      const b = await db.getKeyring('acme')
+      expect(a).toBe(b)
+    })
+  })
+
+  describe('mintPaperRecoveryEntry / unwrapDeksFromPaperEntry (#39)', () => {
+    it('mints an entry whose DEKs round-trip via the public unwrap helper', async () => {
+      const keyring = await db.getKeyring('acme')
+      const code = 'TESTCODE-PR1A-001'
+
+      const entry = await mintPaperRecoveryEntry(keyring.deks, code, 'code-001')
+      expect(entry.codeId).toBe('code-001')
+      expect(entry.salt).toMatch(/^[A-Za-z0-9+/=]+$/)
+      expect(entry.iv).toMatch(/^[A-Za-z0-9+/=]+$/)
+      expect(entry.wrappedDeks).toMatch(/^[A-Za-z0-9+/=]+$/)
+
+      const recovered = await unwrapDeksFromPaperEntry(entry, code)
+      expect(recovered.size).toBe(keyring.deks.size)
+      for (const collName of keyring.deks.keys()) {
+        expect(recovered.has(collName)).toBe(true)
+      }
+    })
+
+    it('round-trips through db.enrollRecovery + db.recoverPassphrase', async () => {
+      const keyring = await db.getKeyring('acme')
+      // Codes must be already-normalized (uppercase, no separators) so they
+      // round-trip through recoverPassphrase's normalizePaperCode step.
+      const codes = ['CODEAAA001', 'CODEBBB002', 'CODECCC003']
+      const entries: PaperRecoveryEntry[] = await Promise.all(
+        codes.map((c, i) => mintPaperRecoveryEntry(keyring.deks, c, `code-${i}`)),
+      )
+
+      await db.enrollRecovery('acme', { profile: 'paper', entries })
+
+      // Use one code to recover under a new phrase.
+      await db.recoverPassphrase('acme', {
+        newPassphrase: STRONG_NEW,
+        recoveryProof: { profile: 'paper', payload: { code: codes[0] } },
+      })
+
+      // After recovery, a fresh client with the new phrase can open the vault.
+      const reopen = await createNoydb({
+        store: (db as unknown as { options: { store: NoydbStore } }).options.store,
+        user: 'alice',
+        secret: STRONG_NEW,
+      })
+      const reopenKeyring = await reopen.getKeyring('acme')
+      expect(reopenKeyring.userId).toBe('alice')
+      expect(reopenKeyring.deks.size).toBe(keyring.deks.size)
+    }, 60_000)
+  })
+})

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -387,12 +387,14 @@ export {
   describeAllUsersAuth,
 } from './auth-introspection/index.js'
 
-// Recovery storage — issue #10
+// Recovery storage — issue #10, mint/unwrap helpers added in pre.8 (#39)
 export {
   loadPaperRecoveryEntries,
   savePaperRecoveryEntries,
   burnPaperRecoveryEntry,
   hasRecoveryEnrolled,
+  mintPaperRecoveryEntry,
+  unwrapDeksFromPaperEntry,
 } from './team/recovery.js'
 export type { PaperRecoveryEntry, PaperRecoveryDoc } from './team/recovery.js'
 

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -1405,17 +1405,29 @@ export class Noydb {
 
   /**
    * Persist a recovery enrollment. v0.1.0-pre.5 accepts the `'paper'`
-   * profile — the developer first calls
-   * `@noy-db/on-recovery/generateRecoveryCodeSet` to mint codes +
-   * entries, shows the codes to the user once, then hands the entries
-   * here.
+   * profile.
+   *
+   * The hub wraps the user's DEK set (not the KEK) under a code-derived
+   * AES-GCM key — see `team/recovery.ts` for the rationale. The mint
+   * helper {@link mintPaperRecoveryEntry} is the canonical primitive;
+   * pair it with `db.getKeyring(vault)` to obtain the live DEK set:
    *
    * ```ts
-   * import { generateRecoveryCodeSet } from '@noy-db/on-recovery'
-   * const { codes, entries } = await generateRecoveryCodeSet({ kek, count: 10 })
+   * import { mintPaperRecoveryEntry } from '@noy-db/hub'
+   *
+   * const keyring = await db.getKeyring('acme')
+   * const codes: string[] = ['CORRECT-HORSE-1', 'BATTERY-STAPLE-2', ...]
+   * const entries = await Promise.all(
+   *   codes.map((code, i) => mintPaperRecoveryEntry(keyring.deks, code, `code-${i}`)),
+   * )
    * await db.enrollRecovery('acme', { profile: 'paper', entries })
    * showCodesToUser(codes)
    * ```
+   *
+   * `@noy-db/on-recovery@<=0.1.0-pre.7`'s `generateRecoveryCodeSet`
+   * produces an incompatible `wrappedKEK` shape — see #38. Use
+   * `mintPaperRecoveryEntry` from hub directly until on-recovery is
+   * rewritten to delegate.
    */
   async enrollRecovery(
     vault: string,
@@ -1487,8 +1499,30 @@ export class Noydb {
     this.quickUnlock.delete(vault)
   }
 
-  /** Get or load the keyring for a vault. */
-  private async getKeyring(vault: string): Promise<UnlockedKeyring> {
+  /**
+   * Public accessor for the unlocked keyring of a vault — issue #28.
+   *
+   * Returns the cached `UnlockedKeyring` (already in memory after
+   * `createNoydb` + first vault touch); loads it on demand if absent.
+   * Used by `@noy-db/on-*` ceremonies that need the live DEK set
+   * (paper recovery via {@link mintPaperRecoveryEntry}, tier-3 PIN
+   * enrolment via on-pin's `enrollPin`, custom on-* ceremonies that
+   * don't have a hub-side wrapper).
+   *
+   * No new permission gate — this is an accessor over already-unlocked
+   * state. The keyring is materialized only after the calling session
+   * has unlocked the vault at tier 1, 2, or 3, so exposing it does not
+   * widen access. Throws `ValidationError` when encryption is enabled
+   * and no `secret` / `getKeyring` is configured.
+   *
+   * ```ts
+   * const keyring = await db.getKeyring('acme')
+   * // keyring.deks: Map<collection, CryptoKey>
+   * // keyring.kek:  CryptoKey   (non-extractable; null for tier-3 sessions)
+   * // keyring.role / .permissions / .authenticators
+   * ```
+   */
+  async getKeyring(vault: string): Promise<UnlockedKeyring> {
     if (this.options.encrypt === false) {
       return createPlaintextKeyring(this.options.user)
     }


### PR DESCRIPTION
## Summary

- **#28** — `db.getKeyring(vault)` is now public. Required by every `@noy-db/on-*` ceremony that needs the live DEK set; consumers were reaching in via `(db as unknown as { getKeyring }).getKeyring`.
- **#39** — `mintPaperRecoveryEntry` + `unwrapDeksFromPaperEntry` (+ `PaperRecoveryEntry` / `PaperRecoveryDoc` types) are now exported from `@noy-db/hub`. Niwat had been vendoring ~70 LOC locally as a workaround.
- **`db.enrollRecovery` docstring fix** — the previous example pointed at `@noy-db/on-recovery@<=pre.7`'s `generateRecoveryCodeSet`, but the formats are incompatible (tracked as #38). Updated to point at `mintPaperRecoveryEntry` from hub directly.

## Why now

Niwat reviewed the post-pre.7 auth surface and discovered the format mismatch + missing exports — native paper recovery had no working path despite `db.enrollRecovery({ profile: 'paper', entries })` shipping in pre.5. This PR is the small, self-contained unblock.

## Not in this PR

- **#26** (tier-2 wrap-DEKs `KeyringAuthenticator` variant — Niwat's Path C proposal that unifies tier-0/2/3 around the wrap-DEKs primitive)
- **#38** (rewrite `@noy-db/on-recovery` to delegate to `mintPaperRecoveryEntry`)

Both ship as PR1b — that's the architectural unification, this is the consumer-unblock.

## Test plan

- [x] `pnpm vitest run packages/hub` — 1304 tests pass (89 files)
- [x] `pnpm turbo typecheck --filter=@noy-db/hub` — clean
- [x] `pnpm turbo lint --filter=@noy-db/hub` — clean
- [x] New file `packages/hub/__tests__/pr1a-public-recovery.test.ts` pins the public-surface contract — imports from `../src/index.js` (the barrel) so removing either export breaks the test
- [ ] Niwat sanity-check: replace the vendored ~70 LOC with `import { mintPaperRecoveryEntry } from '@noy-db/hub'` and verify the full enroll → recover round-trip

Closes #28
Closes #39
References #38 (docstring fix; full resolution in PR1b)