### PR TITLE
feat: tier-2 wrap-DEKs unification (#26 Path C, #38 Option A)

### DIFF
--- a/packages/hub/__tests__/pr1b-authenticator-shapes.test.ts
+++ b/packages/hub/__tests__/pr1b-authenticator-shapes.test.ts
@@ -1,0 +1,130 @@
+/**
+ * PR1b — `KeyringAuthenticator` discriminated union for wrap-KEK and
+ * wrap-DEKs slot variants (#26 Path C).
+ *
+ * Pins the on-disk + type-level contract:
+ *   - WebAuthn / OIDC slots use `wrapped_kek` (legacy / wrapKind absent
+ *     or 'kek'); the existing format keeps working unchanged.
+ *   - Password slots use `wrapped_deks` + `iv` + `wrapKind: 'deks'`;
+ *     they sidestep the non-extractable-KEK constraint by wrapping the
+ *     DEK set under an AES-GCM key, mirroring `mintPaperRecoveryEntry`
+ *     and `@noy-db/on-pin`'s tier-3 pattern.
+ *
+ * The test does not exercise the actual unlock flow — that lives in
+ * `@noy-db/on-password`'s tests after the package refactor. This test
+ * pins the hub-level dispatch + persistence shape only.
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, KeyringAuthenticator } from '../src/types.js'
+import { createOwnerKeyring, loadKeyring, persistKeyring } from '../src/team/keyring.js'
+import { enrollAuthenticator } from '../src/team/authenticators.js'
+import { generateDEK } from '../src/crypto.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'inline-memory',
+    async get(c: string, col: string, id: string) { return gc(c, col).get(id) },
+    async put(c: string, col: string, id: string, env: EncryptedEnvelope) { gc(c, col).set(id, env) },
+    async delete(c: string, col: string, id: string) { gc(c, col).delete(id) },
+    async list(c: string, col: string) { return [...gc(c, col).keys()] },
+    async loadAll() { return {} },
+    async saveAll() {},
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+  } as unknown as NoydbStore
+}
+
+const PHRASE = 'correct horse battery staple printer toaster'
+
+describe('KeyringAuthenticator wrap-KEK / wrap-DEKs (#26 Path C)', () => {
+  it('round-trips a wrap-KEK slot through _keyring (legacy WebAuthn shape)', async () => {
+    const store = inlineMemory()
+    const keyring = await createOwnerKeyring(store, 'acme', 'alice', PHRASE)
+    keyring.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', keyring)
+
+    const next = await enrollAuthenticator(store, 'acme', keyring, {
+      id: 'webauthn-01',
+      method: 'webauthn',
+      meta: { credentialId: 'cred-base64', prfUsed: true },
+      wrapped_kek: 'YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=',
+    })
+    expect(next.authenticators).toHaveLength(1)
+
+    const reloaded = await loadKeyring(store, 'acme', 'alice', PHRASE)
+    expect(reloaded.authenticators).toHaveLength(1)
+    const slot = reloaded.authenticators[0]!
+    // Discriminator absence (or 'kek') → wrap-KEK
+    expect(slot.wrapKind).toBeUndefined()
+    if (slot.wrapKind !== 'deks') {
+      expect(slot.wrapped_kek).toBe('YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=')
+      // wrap-DEKs fields must NOT be present on a wrap-KEK slot
+      expect((slot as Partial<KeyringAuthenticator & { wrapped_deks?: string; iv?: string }>).wrapped_deks).toBeUndefined()
+    } else {
+      throw new Error('expected wrap-KEK slot, got wrap-DEKs')
+    }
+  })
+
+  it('round-trips a wrap-DEKs slot through _keyring (new password shape)', async () => {
+    const store = inlineMemory()
+    const keyring = await createOwnerKeyring(store, 'acme', 'alice', PHRASE)
+    keyring.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', keyring)
+
+    const next = await enrollAuthenticator(store, 'acme', keyring, {
+      id: 'password-daily',
+      method: 'password',
+      wrapKind: 'deks',
+      wrapped_deks: 'Y2lwaGVydGV4dC1iYXNlNjQ=',
+      iv: 'aXYtYmFzZTY0LTEy',
+      meta: { salt: 'c2FsdC1iYXNlNjQ=', minLength: 12 },
+    })
+    expect(next.authenticators).toHaveLength(1)
+
+    const reloaded = await loadKeyring(store, 'acme', 'alice', PHRASE)
+    expect(reloaded.authenticators).toHaveLength(1)
+    const slot = reloaded.authenticators[0]!
+    expect(slot.wrapKind).toBe('deks')
+    if (slot.wrapKind === 'deks') {
+      expect(slot.wrapped_deks).toBe('Y2lwaGVydGV4dC1iYXNlNjQ=')
+      expect(slot.iv).toBe('aXYtYmFzZTY0LTEy')
+      // wrap-KEK field must NOT be present on a wrap-DEKs slot
+      expect((slot as Partial<KeyringAuthenticator & { wrapped_kek?: string }>).wrapped_kek).toBeUndefined()
+    } else {
+      throw new Error('expected wrap-DEKs slot, got wrap-KEK')
+    }
+  })
+
+  it('coexists — both shapes can live in the same keyring', async () => {
+    const store = inlineMemory()
+    const keyring = await createOwnerKeyring(store, 'acme', 'alice', PHRASE)
+    await persistKeyring(store, 'acme', keyring)
+
+    const afterWebAuthn = await enrollAuthenticator(store, 'acme', keyring, {
+      id: 'webauthn-01',
+      method: 'webauthn',
+      meta: { credentialId: 'cred-1' },
+      wrapped_kek: 'd2VicGF5bG9hZA==',
+    })
+    const afterPassword = await enrollAuthenticator(store, 'acme', afterWebAuthn, {
+      id: 'password-daily',
+      method: 'password',
+      wrapKind: 'deks',
+      wrapped_deks: 'cHdkLXdyYXBwZWQ=',
+      iv: 'cHdkLWl2',
+      meta: { salt: 'cHdkLXNhbHQ=', minLength: 12 },
+    })
+    expect(afterPassword.authenticators).toHaveLength(2)
+
+    const reloaded = await loadKeyring(store, 'acme', 'alice', PHRASE)
+    const kinds = reloaded.authenticators.map((a) => a.wrapKind ?? 'kek')
+    expect(kinds).toEqual(['kek', 'deks'])
+  })
+})

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -1424,10 +1424,15 @@ export class Noydb {
    * showCodesToUser(codes)
    * ```
    *
-   * `@noy-db/on-recovery@<=0.1.0-pre.7`'s `generateRecoveryCodeSet`
-   * produces an incompatible `wrappedKEK` shape — see #38. Use
-   * `mintPaperRecoveryEntry` from hub directly until on-recovery is
-   * rewritten to delegate.
+   * As of pre.8, `@noy-db/on-recovery`'s `generateRecoveryCodeSet`
+   * delegates to `mintPaperRecoveryEntry` internally — its output is
+   * fed directly to this API. Pick whichever fits your code-gen layer:
+   *
+   * ```ts
+   * import { generateRecoveryCodeSet } from '@noy-db/on-recovery'
+   * const { codes, entries } = await generateRecoveryCodeSet({ deks: keyring.deks, count: 8 })
+   * await db.enrollRecovery('acme', { profile: 'paper', entries })
+   * ```
    */
   async enrollRecovery(
     vault: string,

--- a/packages/hub/src/team/authenticators.ts
+++ b/packages/hub/src/team/authenticators.ts
@@ -18,22 +18,44 @@ import { ValidationError } from '../errors.js'
 import type { UnlockedKeyring } from './keyring.js'
 import { persistKeyring } from './keyring.js'
 
-/** Input shape for `enrollAuthenticator`. */
-export interface EnrollAuthenticatorOptions {
+/** Fields shared across both wrap-KEK and wrap-DEKs enroll inputs. */
+interface EnrollAuthenticatorBase {
   readonly id: string
   readonly method: KeyringAuthenticator['method']
-  /** Already-wrapped KEK ciphertext (base64) — produced by the on-* package. */
-  readonly wrapped_kek: string
   /** Method-specific metadata (cred id, salt, …). */
   readonly meta: Record<string, unknown>
   /** Tier the active session held when enrolling. Defaults to 1. */
   readonly enrolled_via_tier?: 1 | 2
 }
 
+/** Wrap-KEK enroll input (WebAuthn, OIDC). */
+export interface EnrollAuthenticatorWrappingKEKOptions extends EnrollAuthenticatorBase {
+  /** Already-wrapped KEK ciphertext (base64) — produced by the on-* package. */
+  readonly wrapped_kek: string
+  readonly wrapKind?: 'kek'
+}
+
+/** Wrap-DEKs enroll input (password, future on-* using the unified wrap-DEKs primitive). */
+export interface EnrollAuthenticatorWrappingDEKsOptions extends EnrollAuthenticatorBase {
+  readonly wrapKind: 'deks'
+  /** Base64 AES-GCM ciphertext of `{ deks: { collection: base64rawDek } }`. */
+  readonly wrapped_deks: string
+  /** Base64 AES-GCM IV used for the `wrapped_deks` ciphertext. */
+  readonly iv: string
+}
+
+/** Discriminated union over the two enroll input shapes. */
+export type EnrollAuthenticatorOptions =
+  | EnrollAuthenticatorWrappingKEKOptions
+  | EnrollAuthenticatorWrappingDEKsOptions
+
 /**
  * Append a new authenticator slot to the keyring file. Throws
  * `ValidationError` if a slot with the same id already exists — the
  * caller decides whether to remove + re-enroll.
+ *
+ * Accepts either wrap-KEK (WebAuthn, OIDC) or wrap-DEKs (password)
+ * input. The variant is preserved verbatim into `KeyringAuthenticator`.
  */
 export async function enrollAuthenticator(
   store: NoydbStore,
@@ -49,14 +71,25 @@ export async function enrollAuthenticator(
     )
   }
 
-  const slot: KeyringAuthenticator = {
+  const base = {
     id: options.id,
     method: options.method,
     enrolled_at: new Date().toISOString(),
     enrolled_via_tier: options.enrolled_via_tier ?? 1,
-    wrapped_kek: options.wrapped_kek,
     meta: options.meta,
-  }
+  } as const
+
+  const slot: KeyringAuthenticator = options.wrapKind === 'deks'
+    ? {
+        ...base,
+        wrapKind: 'deks',
+        wrapped_deks: options.wrapped_deks,
+        iv: options.iv,
+      }
+    : {
+        ...base,
+        wrapped_kek: options.wrapped_kek,
+      }
 
   const next = appendSlot(keyring, slot)
   await persistKeyring(store, vault, next)

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -537,6 +537,10 @@ export interface KeyringAuthenticatorWrappingKEK extends KeyringAuthenticatorBas
   readonly wrapKind?: 'kek'
   /** Base64 wrapped-KEK ciphertext under the method-derived key. */
   readonly wrapped_kek: string
+  /** XOR guard — wrap-KEK slots must NOT carry wrap-DEKs material. */
+  readonly wrapped_deks?: never
+  /** XOR guard — wrap-KEK slots must NOT carry wrap-DEKs material. */
+  readonly iv?: never
 }
 
 /**
@@ -562,6 +566,8 @@ export interface KeyringAuthenticatorWrappingDEKs extends KeyringAuthenticatorBa
   readonly wrapped_deks: string
   /** Base64 AES-GCM IV used for the `wrapped_deks` ciphertext. */
   readonly iv: string
+  /** XOR guard — wrap-DEKs slots must NOT carry wrap-KEK material. */
+  readonly wrapped_kek?: never
 }
 
 /**

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -498,7 +498,13 @@ export type RecoveryEnrollment =
  *
  * @see docs/subsystems/session-tiers.md → Tier 2 — Authenticate (multi-slot)
  */
-export interface KeyringAuthenticator {
+/**
+ * Shared fields across all authenticator slot variants. The variant
+ * (`KeyringAuthenticatorWrappingKEK` vs `KeyringAuthenticatorWrappingDEKs`)
+ * carries the actual wrapped material; everything below is identity +
+ * metadata only.
+ */
+interface KeyringAuthenticatorBase {
   /** Caller-chosen identifier — e.g. `'webauthn-yubikey-blue'`, `'oidc-google'`, `'password-daily'`. */
   readonly id: string
   /** Method family — selects which `@noy-db/on-*` package handles unlock. */
@@ -510,8 +516,6 @@ export interface KeyringAuthenticator {
    * tier 2 may add a sibling slot when the active policy permits.
    */
   readonly enrolled_via_tier: 1 | 2
-  /** Base64 wrapped-KEK ciphertext under the method-derived key. */
-  readonly wrapped_kek: string
   /**
    * Method-specific metadata: WebAuthn cred id, OIDC issuer/sub, PBKDF2
    * salt for `on-password`, etc. The schema is open by design — the
@@ -519,6 +523,62 @@ export interface KeyringAuthenticator {
    */
   readonly meta: Record<string, unknown>
 }
+
+/**
+ * Slot that wraps the KEK directly under a method-derived AES-KW key.
+ * Used by ceremonies where the on-* package can produce/recover an
+ * extractable KEK from its own credential — WebAuthn (PRF-derived
+ * wrapping key) and split-key OIDC.
+ *
+ * `wrapKind` is optional/absent on slots written before pre.8 — those
+ * legacy slots are treated as wrap-KEK by default at unlock time.
+ */
+export interface KeyringAuthenticatorWrappingKEK extends KeyringAuthenticatorBase {
+  readonly wrapKind?: 'kek'
+  /** Base64 wrapped-KEK ciphertext under the method-derived key. */
+  readonly wrapped_kek: string
+}
+
+/**
+ * Slot that wraps the DEK set (not the KEK) under a method-derived
+ * AES-GCM key — sidesteps the non-extractable-KEK constraint by
+ * encrypting the serialized `{ deks: { collection: rawDekBase64 } }`
+ * directly. Mirrors the format used by `mintPaperRecoveryEntry`
+ * (`PaperRecoveryEntry`) and `@noy-db/on-pin`'s `PinResumeState` —
+ * the unified wrap-DEKs primitive across tier-0 / tier-2 / tier-3.
+ *
+ * Trade-off: a slot of this kind reconstructs `UnlockedKeyring` with
+ * `kek: null` after unlock. That is semantically correct for tier-2
+ * (sensitive ops like `enrollAuthenticator` / `rotatePassphrase`
+ * require a tier-1 unlock anyway) and matches how `@noy-db/on-pin`
+ * already behaves at tier 3.
+ *
+ * @see `mintPaperRecoveryEntry` in `team/recovery.ts` — same shape on
+ *      a different on-disk path (`_meta/recovery-paper`).
+ */
+export interface KeyringAuthenticatorWrappingDEKs extends KeyringAuthenticatorBase {
+  readonly wrapKind: 'deks'
+  /** Base64 AES-GCM ciphertext of `{ deks: { collection: base64rawDek } }`. */
+  readonly wrapped_deks: string
+  /** Base64 AES-GCM IV used for the `wrapped_deks` ciphertext. */
+  readonly iv: string
+}
+
+/**
+ * Discriminated union over the two wrap-format variants. Reads from
+ * disk should always go through this type so the variant is preserved.
+ *
+ * Discriminator: `wrapKind`. Absent → wrap-KEK (legacy / WebAuthn /
+ * OIDC). Present and `'deks'` → wrap-DEKs (password / future on-* that
+ * want to sidestep extractable-KEK).
+ *
+ * The type-level XOR enforces "exactly one of `wrapped_kek` /
+ * `wrapped_deks` is present" — a structural guarantee that the runtime
+ * dispatch is safe.
+ */
+export type KeyringAuthenticator =
+  | KeyringAuthenticatorWrappingKEK
+  | KeyringAuthenticatorWrappingDEKs
 
 export interface KeyringFile {
   readonly _noydb_keyring: typeof NOYDB_KEYRING_VERSION

--- a/packages/on-password/__tests__/on-password.test.ts
+++ b/packages/on-password/__tests__/on-password.test.ts
@@ -1,27 +1,31 @@
 /**
  * Cryptographic round-trip tests for the tier-2 password authenticator.
  *
- * The tests build a minimal `UnlockedKeyring` with a real AES-KW KEK
- * and verify:
- *   1. enroll → unlock with the same password recovers the KEK
+ * Post-PR1b (#26 Path C) the slot uses the **wrap-DEKs** variant — the
+ * password-derived AES-GCM key encrypts the DEK set, NOT the KEK.
+ * Verifies:
+ *   1. enroll → verify with the same password recovers the DEK set
  *   2. wrong password rejects with `PasswordInvalidError`
- *   3. tier-1 phrase ≠ tier-2 password (independent slot, independent strength)
+ *   3. tier-1 phrase ≠ tier-2 password (independent slot)
  *   4. weak password rejects with `PasswordTooWeakError`
- *   5. removing a slot does not affect other slots
+ *   5. verifyPasswordSlot returns kek:null (sensitive ops require tier-1)
  */
 import { describe, it, expect } from 'vitest'
 import {
   enrollPasswordAuthenticator,
-  unwrapKekWithPassword,
+  unwrapDeksWithPassword,
+  verifyPasswordSlot,
   PasswordTooWeakError,
   PasswordInvalidError,
 } from '../src/index.js'
-import type { UnlockedKeyring } from '@noy-db/hub'
+import type { UnlockedKeyring, KeyringAuthenticator } from '@noy-db/hub'
 
 const subtle = globalThis.crypto.subtle
 
 async function buildKeyring(): Promise<UnlockedKeyring> {
-  // Mint a real KEK so wrap/unwrap round-trips through AES-KW.
+  // Mint a real KEK (extractable=false matches hub's runtime invariant)
+  // and two DEKs so the wrap-DEKs round-trip exercises the JSON
+  // serialization path.
   const ikm = await subtle.importKey(
     'raw',
     new TextEncoder().encode('correct horse battery staple printer toaster'),
@@ -38,79 +42,69 @@ async function buildKeyring(): Promise<UnlockedKeyring> {
     },
     ikm,
     { name: 'AES-KW', length: 256 },
-    true,
+    false,
     ['wrapKey', 'unwrapKey'],
   )
+  const dek1 = await subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt'])
+  const dek2 = await subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt'])
   return {
     userId: 'alice',
     displayName: 'alice',
     role: 'owner',
     permissions: {},
-    deks: new Map(),
+    deks: new Map([['invoices', dek1], ['clients', dek2]]),
     kek,
     salt: new Uint8Array(32),
     authenticators: [],
   }
 }
 
-describe('@noy-db/on-password — enroll + unlock', () => {
-  it('enrolls a slot whose password unlocks the same KEK', async () => {
+function slotFromOptions(opts: Awaited<ReturnType<typeof enrollPasswordAuthenticator>>): KeyringAuthenticator {
+  if (opts.wrapKind !== 'deks') throw new Error('expected wrap-DEKs slot')
+  return {
+    id: opts.id,
+    method: opts.method,
+    enrolled_at: new Date().toISOString(),
+    enrolled_via_tier: opts.enrolled_via_tier ?? 1,
+    wrapKind: 'deks',
+    wrapped_deks: opts.wrapped_deks,
+    iv: opts.iv,
+    meta: opts.meta,
+  }
+}
+
+describe('@noy-db/on-password — wrap-DEKs enroll + verify (#26 Path C)', () => {
+  it('enrolls a wrap-DEKs slot whose password recovers the same DEK set', async () => {
     const keyring = await buildKeyring()
-    const slot = await enrollPasswordAuthenticator(keyring, {
+    const opts = await enrollPasswordAuthenticator(keyring, {
       password: 'daily-password-2026',
     })
-    expect(slot.method).toBe('password')
-    expect(slot.id).toBe('password-daily')
-    expect(typeof slot.wrapped_kek).toBe('string')
+    expect(opts.method).toBe('password')
+    expect(opts.id).toBe('password-daily')
+    expect(opts.wrapKind).toBe('deks')
+    if (opts.wrapKind !== 'deks') throw new Error('unreachable')
+    expect(typeof opts.wrapped_deks).toBe('string')
+    expect(typeof opts.iv).toBe('string')
 
-    const recoveredKek = await unwrapKekWithPassword(
-      {
-        id: slot.id,
-        method: 'password',
-        enrolled_at: new Date().toISOString(),
-        enrolled_via_tier: 1,
-        wrapped_kek: slot.wrapped_kek,
-        meta: slot.meta,
-      },
-      'daily-password-2026',
-    )
+    const recovered = await unwrapDeksWithPassword(slotFromOptions(opts), 'daily-password-2026')
+    expect(recovered.size).toBe(2)
+    expect(recovered.has('invoices')).toBe(true)
+    expect(recovered.has('clients')).toBe(true)
 
-    // Sanity: re-wrap a small DEK with the recovered KEK, then unwrap with the original.
-    const dek = await subtle.generateKey(
-      { name: 'AES-GCM', length: 256 },
-      true,
-      ['encrypt', 'decrypt'],
-    )
-    const wrapped = await subtle.wrapKey('raw', dek, recoveredKek, 'AES-KW')
-    const unwrapped = await subtle.unwrapKey(
-      'raw',
-      wrapped,
-      keyring.kek,
-      'AES-KW',
-      { name: 'AES-GCM', length: 256 },
-      true,
-      ['encrypt', 'decrypt'],
-    )
-    expect(unwrapped).toBeDefined()
+    // The recovered DEK must be byte-equivalent to the original — exportKey('raw')
+    // should yield identical bytes.
+    const originalRaw = new Uint8Array(await subtle.exportKey('raw', keyring.deks.get('invoices')!))
+    const recoveredRaw = new Uint8Array(await subtle.exportKey('raw', recovered.get('invoices')!))
+    expect(Array.from(recoveredRaw)).toEqual(Array.from(originalRaw))
   }, 30_000)
 
   it('rejects a wrong password with PasswordInvalidError', async () => {
     const keyring = await buildKeyring()
-    const slot = await enrollPasswordAuthenticator(keyring, {
+    const opts = await enrollPasswordAuthenticator(keyring, {
       password: 'daily-password-2026',
     })
     await expect(
-      unwrapKekWithPassword(
-        {
-          id: slot.id,
-          method: 'password',
-          enrolled_at: new Date().toISOString(),
-          enrolled_via_tier: 1,
-          wrapped_kek: slot.wrapped_kek,
-          meta: slot.meta,
-        },
-        'wrong-password-9999',
-      ),
+      unwrapDeksWithPassword(slotFromOptions(opts), 'wrong-password-9999'),
     ).rejects.toBeInstanceOf(PasswordInvalidError)
   }, 30_000)
 
@@ -135,7 +129,7 @@ describe('@noy-db/on-password — enroll + unlock', () => {
     const keyring = await buildKeyring()
     await expect(
       enrollPasswordAuthenticator(keyring, {
-        password: 'no-digits-here-2',  // satisfies, has '2'
+        password: 'no-digits-here-2',
         pattern: /[0-9]/,
       }),
     ).resolves.toBeDefined()
@@ -150,23 +144,45 @@ describe('@noy-db/on-password — enroll + unlock', () => {
 
   it('different password ≠ tier-1 phrase (independent storage)', async () => {
     const keyring = await buildKeyring()
-    const slot = await enrollPasswordAuthenticator(keyring, {
+    const opts = await enrollPasswordAuthenticator(keyring, {
       password: 'daily-password-2026',
     })
     // The tier-1 phrase used to derive the keyring is "correct horse...";
     // it must NOT unlock the password slot.
     await expect(
-      unwrapKekWithPassword(
-        {
-          id: slot.id,
-          method: 'password',
-          enrolled_at: new Date().toISOString(),
-          enrolled_via_tier: 1,
-          wrapped_kek: slot.wrapped_kek,
-          meta: slot.meta,
-        },
-        'correct horse battery staple printer toaster',
-      ),
+      unwrapDeksWithPassword(slotFromOptions(opts), 'correct horse battery staple printer toaster'),
     ).rejects.toBeInstanceOf(PasswordInvalidError)
+  }, 30_000)
+
+  it('rejects a wrap-KEK slot (legacy pre-pre.8 password slots) with a clear error', async () => {
+    // Construct a synthetic legacy slot that mimics the pre-PR1b shape.
+    const legacy: KeyringAuthenticator = {
+      id: 'password-legacy',
+      method: 'password',
+      enrolled_at: new Date().toISOString(),
+      enrolled_via_tier: 1,
+      wrapped_kek: 'd2hhdGV2ZXItbGVnYWN5LWJ5dGVz',
+      meta: { salt: 'c2FsdC1ub3JtYWw=', minLength: 12 },
+    }
+    await expect(
+      unwrapDeksWithPassword(legacy, 'daily-password-2026'),
+    ).rejects.toBeInstanceOf(PasswordInvalidError)
+  })
+
+  it('verifyPasswordSlot returns UnlockedKeyring with kek:null + reference identity fields', async () => {
+    const keyring = await buildKeyring()
+    const opts = await enrollPasswordAuthenticator(keyring, {
+      password: 'daily-password-2026',
+    })
+    const unlocked = await verifyPasswordSlot(
+      slotFromOptions(opts),
+      'daily-password-2026',
+      { keyring },
+    )
+    expect(unlocked.userId).toBe('alice')
+    expect(unlocked.role).toBe('owner')
+    expect(unlocked.deks.size).toBe(2)
+    // wrap-DEKs unlock cannot recover the KEK — must be null.
+    expect(unlocked.kek).toBeNull()
   }, 30_000)
 })

--- a/packages/on-password/__tests__/on-password.test.ts
+++ b/packages/on-password/__tests__/on-password.test.ts
@@ -18,7 +18,7 @@ import {
   PasswordTooWeakError,
   PasswordInvalidError,
 } from '../src/index.js'
-import type { UnlockedKeyring, KeyringAuthenticator } from '@noy-db/hub'
+import type { UnlockedKeyring, KeyringAuthenticator, NoydbStore, EncryptedEnvelope, KeyringFile } from '@noy-db/hub'
 
 const subtle = globalThis.crypto.subtle
 
@@ -154,7 +154,7 @@ describe('@noy-db/on-password — wrap-DEKs enroll + verify (#26 Path C)', () =>
     ).rejects.toBeInstanceOf(PasswordInvalidError)
   }, 30_000)
 
-  it('rejects a wrap-KEK slot (legacy pre-pre.8 password slots) with a clear error', async () => {
+  it('rejects a wrap-KEK slot (legacy pre-pre.8 password slots) with the re-enrol message', async () => {
     // Construct a synthetic legacy slot that mimics the pre-PR1b shape.
     const legacy: KeyringAuthenticator = {
       id: 'password-legacy',
@@ -164,25 +164,93 @@ describe('@noy-db/on-password — wrap-DEKs enroll + verify (#26 Path C)', () =>
       wrapped_kek: 'd2hhdGV2ZXItbGVnYWN5LWJ5dGVz',
       meta: { salt: 'c2FsdC1ub3JtYWw=', minLength: 12 },
     }
+    // Pin the user-facing recovery instruction — a future refactor that
+    // throws PasswordInvalidError for a different reason would silently
+    // regress the "re-enrol" UX. Per Niwat's PR #42 review point 4.
     await expect(
       unwrapDeksWithPassword(legacy, 'daily-password-2026'),
-    ).rejects.toBeInstanceOf(PasswordInvalidError)
+    ).rejects.toMatchObject({
+      name: 'PasswordInvalidError',
+      message: expect.stringMatching(/wrap-DEKs|re-enrol/),
+    })
   })
 
-  it('verifyPasswordSlot returns UnlockedKeyring with kek:null + reference identity fields', async () => {
+  it('verifyPasswordSlot returns UnlockedKeyring with kek:null + identity from disk (cold-start path)', async () => {
+    // Niwat PR #42 review point 3: verifier loads identity from
+    // `_keyring/<userId>` directly, so cold-start (createNoydb +
+    // getKeyring callback) works without a pre-existing keyring.
     const keyring = await buildKeyring()
     const opts = await enrollPasswordAuthenticator(keyring, {
       password: 'daily-password-2026',
     })
+
+    // Build a real store with a written keyring file to feed the verifier.
+    const store = inlineMemory()
+    const file: KeyringFile = {
+      _noydb_keyring: 1,
+      user_id: 'alice',
+      display_name: 'Alice Example',
+      role: 'owner',
+      permissions: {},
+      deks: {},
+      salt: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+      created_at: new Date().toISOString(),
+      granted_by: 'alice',
+    }
+    await store.put('acme', '_keyring', 'alice', {
+      _noydb: 1,
+      _v: 1,
+      _ts: new Date().toISOString(),
+      _iv: '',
+      _data: JSON.stringify(file),
+    })
+
     const unlocked = await verifyPasswordSlot(
       slotFromOptions(opts),
       'daily-password-2026',
-      { keyring },
+      { store, vault: 'acme', userId: 'alice' },
     )
     expect(unlocked.userId).toBe('alice')
+    expect(unlocked.displayName).toBe('Alice Example')
     expect(unlocked.role).toBe('owner')
     expect(unlocked.deks.size).toBe(2)
     // wrap-DEKs unlock cannot recover the KEK — must be null.
     expect(unlocked.kek).toBeNull()
   }, 30_000)
+
+  it('verifyPasswordSlot throws when the keyring file is missing', async () => {
+    const keyring = await buildKeyring()
+    const opts = await enrollPasswordAuthenticator(keyring, {
+      password: 'daily-password-2026',
+    })
+    const store = inlineMemory()
+    await expect(
+      verifyPasswordSlot(
+        slotFromOptions(opts),
+        'daily-password-2026',
+        { store, vault: 'acme', userId: 'ghost' },
+      ),
+    ).rejects.toBeInstanceOf(PasswordInvalidError)
+  }, 30_000)
 })
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'inline-memory',
+    async get(c: string, col: string, id: string) { return gc(c, col).get(id) },
+    async put(c: string, col: string, id: string, env: EncryptedEnvelope) { gc(c, col).set(id, env) },
+    async delete(c: string, col: string, id: string) { gc(c, col).delete(id) },
+    async list(c: string, col: string) { return [...gc(c, col).keys()] },
+    async loadAll() { return {} },
+    async saveAll() {},
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+  } as unknown as NoydbStore
+}

--- a/packages/on-password/src/index.ts
+++ b/packages/on-password/src/index.ts
@@ -12,12 +12,23 @@
  *   phrase format (issue #7); the password is validated against a
  *   length / regex rule the developer chooses.
  * - **Different storage** — the phrase derives the KEK; the password
- *   derives a wrapping key that wraps the SAME KEK in its own
- *   keyring slot (LUKS pattern).
+ *   derives a wrapping key that wraps the SAME DEK SET in its own
+ *   keyring slot (LUKS-like multi-slot, wrap-DEKs variant).
  *
- * The slot is added to the keyring via `db.enrollAuthenticator`; the
- * KEK is recovered via `db.unlockViaAuthenticator` — both routes hit
- * the policy gate engine (issue #9).
+ * ## Wrap-DEKs format (#26 Path C)
+ *
+ * Slots produced by this package use the wrap-DEKs variant of
+ * `KeyringAuthenticator` — they encrypt the serialized DEK set under
+ * a password-derived AES-GCM key, NOT the KEK. This unifies tier-2
+ * password slots with the tier-0 (paper recovery, `mintPaperRecoveryEntry`)
+ * and tier-3 (`@noy-db/on-pin`'s `wrappedKeyring`) primitives — all
+ * three sidestep the non-extractable-KEK constraint by wrapping the
+ * DEK set rather than the KEK itself.
+ *
+ * Trade-off: an `UnlockedKeyring` produced via password-slot unlock
+ * has `kek: null`. Sensitive operations (`enrollAuthenticator`,
+ * `rotatePassphrase`) require a tier-1 unlock anyway — re-enter the
+ * master phrase.
  *
  * @see docs/subsystems/session-tiers.md → Tier 2 — `on-password`
  *
@@ -37,6 +48,8 @@ export const PASSWORD_DEFAULT_MIN_LENGTH = 12
 
 /** Per-slot salt size. */
 const SALT_BYTES = 32
+/** AES-GCM IV size. */
+const IV_BYTES = 12
 
 const subtle = globalThis.crypto.subtle
 
@@ -88,12 +101,18 @@ export interface EnrollPasswordOptions {
  * step (this function) from the persistence step (the hub) keeps the
  * package small and lets the hub's policy gate run between the two.
  *
+ * The slot uses the **wrap-DEKs** variant of `KeyringAuthenticator`:
+ * the DEK set is serialized to JSON and encrypted with AES-GCM under
+ * a PBKDF2-derived key. No requirement on `keyring.kek` — works with
+ * tier-1 unlocked keyrings; throws if `keyring.deks` is empty.
+ *
  * Usage:
  *
  * ```ts
  * import { enrollPasswordAuthenticator } from '@noy-db/on-password'
  *
- * const slot = await enrollPasswordAuthenticator(unlocked, {
+ * const keyring = await db.getKeyring('acme')
+ * const slot = await enrollPasswordAuthenticator(keyring, {
  *   password: 'daily-password-2026',
  *   minLength: 14,
  * })
@@ -117,21 +136,36 @@ export async function enrollPasswordAuthenticator(
     )
   }
 
-  if (!keyring.kek) {
+  if (keyring.deks.size === 0) {
     throw new Error(
-      'enrollPasswordAuthenticator: the supplied keyring has no KEK in memory. ' +
-        'Tier-3 quick-resume keyrings cannot enrol new tier-2 slots; re-authenticate at tier 1 first.',
+      'enrollPasswordAuthenticator: the supplied keyring has no DEKs in memory. ' +
+        'Re-authenticate at tier 1 first.',
     )
   }
 
   const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES))
+  const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES))
   const wrappingKey = await derivePasswordWrappingKey(options.password, salt)
-  const wrapped = await subtle.wrapKey('raw', keyring.kek, wrappingKey, 'AES-KW')
+
+  // Serialize the DEK set as JSON `{ deks: { collection: base64 } }`.
+  const exported: Record<string, string> = {}
+  for (const [coll, dek] of keyring.deks) {
+    const raw = await subtle.exportKey('raw', dek)
+    exported[coll] = bytesToBase64(new Uint8Array(raw))
+  }
+  const plaintext = new TextEncoder().encode(JSON.stringify({ deks: exported }))
+  const ciphertext = await subtle.encrypt(
+    { name: 'AES-GCM', iv: iv as BufferSource },
+    wrappingKey,
+    plaintext as BufferSource,
+  )
 
   return {
     id: options.id ?? 'password-daily',
     method: 'password',
-    wrapped_kek: bytesToBase64(new Uint8Array(wrapped)),
+    wrapKind: 'deks',
+    wrapped_deks: bytesToBase64(new Uint8Array(ciphertext)),
+    iv: bytesToBase64(iv),
     meta: {
       salt: bytesToBase64(salt),
       minLength,
@@ -142,17 +176,25 @@ export async function enrollPasswordAuthenticator(
 }
 
 /**
- * Recover the KEK from a password slot's `wrapped_kek` ciphertext.
- * Returns the unwrapped KEK as a non-extractable `CryptoKey` ready for
- * AES-KW unwrap of DEKs. Used inside the verify callback passed to
- * `db.unlockViaAuthenticator`.
+ * Recover the DEK set from a wrap-DEKs password slot. Returns the raw
+ * DEK map; the hub-friendly verifier {@link verifyPasswordSlot} wraps
+ * this and produces a full `UnlockedKeyring`.
  *
- * @throws {@link PasswordInvalidError} when the password is wrong.
+ * @throws {@link PasswordInvalidError} when the password is wrong or
+ *   the slot is not a wrap-DEKs slot (e.g. a legacy wrap-KEK password
+ *   slot from before pre.8 — those need re-enrollment).
  */
-export async function unwrapKekWithPassword(
+export async function unwrapDeksWithPassword(
   slot: KeyringAuthenticator,
   password: string,
-): Promise<CryptoKey> {
+): Promise<Map<string, CryptoKey>> {
+  if (slot.wrapKind !== 'deks') {
+    throw new PasswordInvalidError(
+      'Password slot is not a wrap-DEKs slot. Pre-pre.8 wrap-KEK password ' +
+        'slots are no longer supported — re-enrol via enrollPasswordAuthenticator.',
+    )
+  }
+
   const meta = slot.meta as { salt?: unknown }
   if (typeof meta.salt !== 'string') {
     throw new PasswordInvalidError(
@@ -161,33 +203,54 @@ export async function unwrapKekWithPassword(
   }
   const salt = base64ToBytes(meta.salt)
   const wrappingKey = await derivePasswordWrappingKey(password, salt)
+
+  let plaintext: ArrayBuffer
   try {
-    return await subtle.unwrapKey(
-      'raw',
-      base64ToBytes(slot.wrapped_kek) as BufferSource,
+    plaintext = await subtle.decrypt(
+      { name: 'AES-GCM', iv: base64ToBytes(slot.iv) as BufferSource },
       wrappingKey,
-      'AES-KW',
-      { name: 'AES-KW', length: 256 },
-      false,
-      ['wrapKey', 'unwrapKey'],
+      base64ToBytes(slot.wrapped_deks) as BufferSource,
     )
   } catch {
     throw new PasswordInvalidError()
   }
+
+  const parsed = JSON.parse(new TextDecoder().decode(plaintext)) as { deks: Record<string, string> }
+  const deks = new Map<string, CryptoKey>()
+  for (const [coll, b64] of Object.entries(parsed.deks)) {
+    const raw = base64ToBytes(b64)
+    const key = await subtle.importKey(
+      'raw',
+      raw as BufferSource,
+      { name: 'AES-GCM', length: 256 },
+      true,
+      ['encrypt', 'decrypt'],
+    )
+    deks.set(coll, key)
+  }
+  return deks
 }
 
 /**
  * Hub-friendly verify callback. Pass to `db.unlockViaAuthenticator`:
  *
  * ```ts
+ * import { verifyPasswordSlot } from '@noy-db/on-password'
+ *
  * const unlocked = await db.unlockViaAuthenticator('acme', 'password-daily',
- *   (slot) => verifyPasswordSlot(slot, 'daily-password-2026', { adapter: store, vault: 'acme', userId: 'alice' }),
+ *   (slot) => verifyPasswordSlot(slot, 'daily-password-2026', { keyring }),
  * )
  * ```
  *
- * The callback re-loads the keyring file via the supplied adapter,
- * unwraps every DEK with the recovered KEK, and returns the
- * `UnlockedKeyring` the hub installs in its keyring cache.
+ * Unwraps the DEK set with the supplied password and returns an
+ * `UnlockedKeyring` the hub installs in its keyring cache. The
+ * returned keyring has `kek: null` — sensitive operations (enrol new
+ * slot, rotate phrase) require a tier-1 unlock from the master phrase.
+ *
+ * Pass the current `keyring` (from `db.getKeyring(vault)`) to copy
+ * identity fields (userId, role, permissions, authenticators) onto
+ * the recovered `UnlockedKeyring`. Those fields aren't recoverable
+ * from the wrapped-DEKs ciphertext alone.
  *
  * @throws {@link PasswordInvalidError} when the password is wrong.
  */
@@ -196,20 +259,35 @@ export async function verifyPasswordSlot(
   password: string,
   options: VerifyPasswordSlotOptions,
 ): Promise<UnlockedKeyring> {
-  const kek = await unwrapKekWithPassword(slot, password)
-  return options.materialize(kek)
+  const deks = await unwrapDeksWithPassword(slot, password)
+  const reference = options.keyring
+  return {
+    userId: reference.userId,
+    displayName: reference.displayName,
+    role: reference.role,
+    permissions: reference.permissions,
+    authenticators: reference.authenticators,
+    salt: reference.salt,
+    ...(reference.exportCapability !== undefined && { exportCapability: reference.exportCapability }),
+    ...(reference.importCapability !== undefined && { importCapability: reference.importCapability }),
+    ...(reference.policy !== undefined && { policy: reference.policy }),
+    deks,
+    // Wrap-DEKs unlock cannot recover the KEK. Sensitive ops route
+    // through tier-1 via re-entry of the master phrase. Matches the
+    // existing tier-3 (`@noy-db/on-pin`) pattern.
+    kek: null as unknown as CryptoKey,
+  }
 }
 
 /** Adapter shape required by {@link verifyPasswordSlot}. */
 export interface VerifyPasswordSlotOptions {
   /**
-   * Caller-supplied "given the recovered KEK, build the
-   * `UnlockedKeyring`" routine. The hub provides the standard
-   * implementation in {@link buildUnlockedKeyringFromKek}; consumers
-   * with non-standard storage (e.g. encrypted browser-extension
-   * stores) can pass their own.
+   * The current vault keyring (typically `await db.getKeyring(vault)`).
+   * Identity fields (`userId`, `role`, `permissions`, `authenticators`,
+   * `salt`) are copied onto the recovered `UnlockedKeyring`. The DEK
+   * map is replaced with the unwrapped contents of the password slot.
    */
-  readonly materialize: (kek: CryptoKey) => Promise<UnlockedKeyring>
+  readonly keyring: UnlockedKeyring
 }
 
 // ─── Helpers ───────────────────────────────────────────────────────────
@@ -233,9 +311,9 @@ async function derivePasswordWrappingKey(
       hash: 'SHA-256',
     },
     ikm,
-    { name: 'AES-KW', length: 256 },
+    { name: 'AES-GCM', length: 256 },
     false,
-    ['wrapKey', 'unwrapKey'],
+    ['encrypt', 'decrypt'],
   )
 }
 

--- a/packages/on-password/src/index.ts
+++ b/packages/on-password/src/index.ts
@@ -37,6 +37,8 @@
 import type {
   EnrollAuthenticatorOptions,
   KeyringAuthenticator,
+  KeyringFile,
+  NoydbStore,
   UnlockedKeyring,
 } from '@noy-db/hub'
 
@@ -238,7 +240,8 @@ export async function unwrapDeksWithPassword(
  * import { verifyPasswordSlot } from '@noy-db/on-password'
  *
  * const unlocked = await db.unlockViaAuthenticator('acme', 'password-daily',
- *   (slot) => verifyPasswordSlot(slot, 'daily-password-2026', { keyring }),
+ *   (slot) => verifyPasswordSlot(slot, 'daily-password-2026',
+ *     { store, vault: 'acme', userId: 'alice' }),
  * )
  * ```
  *
@@ -247,12 +250,22 @@ export async function unwrapDeksWithPassword(
  * returned keyring has `kek: null` — sensitive operations (enrol new
  * slot, rotate phrase) require a tier-1 unlock from the master phrase.
  *
- * Pass the current `keyring` (from `db.getKeyring(vault)`) to copy
- * identity fields (userId, role, permissions, authenticators) onto
- * the recovered `UnlockedKeyring`. Those fields aren't recoverable
- * from the wrapped-DEKs ciphertext alone.
+ * The `{ store, vault, userId }` shape works in both contexts:
+ *   - **Warm re-unlock** — db is alive; consumer already has identity
+ *     in memory but pays one cheap `_keyring/<userId>` read.
+ *   - **Cold-start** (`createNoydb({ getKeyring: ... })`) — consumer
+ *     does NOT have a keyring yet; the verifier loads identity from
+ *     disk before returning the unlocked keyring. This is the
+ *     primary cold-start tier-2 path (Niwat tier-2b uses this).
  *
- * @throws {@link PasswordInvalidError} when the password is wrong.
+ * Identity fields (userId, displayName, role, permissions,
+ * authenticators, salt, capability bits, per-keyring policy) are read
+ * directly from the `_keyring/<userId>` envelope's plaintext header —
+ * those fields are not encrypted because the sync engine + grant flow
+ * need them without a key.
+ *
+ * @throws {@link PasswordInvalidError} when the password is wrong or
+ *   the keyring file is missing.
  */
 export async function verifyPasswordSlot(
   slot: KeyringAuthenticator,
@@ -260,34 +273,44 @@ export async function verifyPasswordSlot(
   options: VerifyPasswordSlotOptions,
 ): Promise<UnlockedKeyring> {
   const deks = await unwrapDeksWithPassword(slot, password)
-  const reference = options.keyring
+
+  const env = await options.store.get(options.vault, '_keyring', options.userId)
+  if (!env) {
+    throw new PasswordInvalidError(
+      `verifyPasswordSlot: no keyring found at "${options.vault}/_keyring/${options.userId}". ` +
+        'Verify the vault and userId are correct.',
+    )
+  }
+  const file = JSON.parse(env._data) as KeyringFile
+  const salt = base64ToBytes(file.salt)
+
   return {
-    userId: reference.userId,
-    displayName: reference.displayName,
-    role: reference.role,
-    permissions: reference.permissions,
-    authenticators: reference.authenticators,
-    salt: reference.salt,
-    ...(reference.exportCapability !== undefined && { exportCapability: reference.exportCapability }),
-    ...(reference.importCapability !== undefined && { importCapability: reference.importCapability }),
-    ...(reference.policy !== undefined && { policy: reference.policy }),
+    userId: file.user_id,
+    displayName: file.display_name,
+    role: file.role,
+    permissions: file.permissions,
+    authenticators: file.authenticators ?? [],
+    salt,
+    ...(file.export_capability !== undefined && { exportCapability: file.export_capability }),
+    ...(file.import_capability !== undefined && { importCapability: file.import_capability }),
+    ...(file.policy !== undefined && { policy: file.policy }),
     deks,
     // Wrap-DEKs unlock cannot recover the KEK. Sensitive ops route
     // through tier-1 via re-entry of the master phrase. Matches the
     // existing tier-3 (`@noy-db/on-pin`) pattern.
+    // TODO(#41): drop the cast once UnlockedKeyring.kek is CryptoKey | null.
     kek: null as unknown as CryptoKey,
   }
 }
 
 /** Adapter shape required by {@link verifyPasswordSlot}. */
 export interface VerifyPasswordSlotOptions {
-  /**
-   * The current vault keyring (typically `await db.getKeyring(vault)`).
-   * Identity fields (`userId`, `role`, `permissions`, `authenticators`,
-   * `salt`) are copied onto the recovered `UnlockedKeyring`. The DEK
-   * map is replaced with the unwrapped contents of the password slot.
-   */
-  readonly keyring: UnlockedKeyring
+  /** The vault's NoydbStore — used to load `_keyring/<userId>`. */
+  readonly store: NoydbStore
+  /** Vault name — same value passed to `db.openVault(name)`. */
+  readonly vault: string
+  /** User id — same value passed to `createNoydb({ user })`. */
+  readonly userId: string
 }
 
 // ─── Helpers ───────────────────────────────────────────────────────────

--- a/packages/on-recovery/__tests__/on-recovery.test.ts
+++ b/packages/on-recovery/__tests__/on-recovery.test.ts
@@ -1,42 +1,35 @@
+/**
+ * @noy-db/on-recovery — post pre.8 (#38 Option A).
+ *
+ * The package is now a thin code-generator + parser layer over the
+ * hub's `mintPaperRecoveryEntry` primitive. These tests verify:
+ *   1. Code-set generation produces the expected count + format.
+ *   2. Codes round-trip through `parseRecoveryCode` (whitespace /
+ *      hyphens / case insensitive, checksum validation).
+ *   3. Entries delegate to the hub's wrap-DEKs format — round-tripping
+ *      via the hub's `unwrapDeksFromPaperEntry` recovers the same DEK
+ *      bytes that were enrolled.
+ *   4. Burn-on-use semantics work at the consumer layer.
+ */
 import { describe, expect, it } from 'vitest'
 import {
-  deriveRecoveryWrappingKey,
   formatRecoveryCode,
   generateRecoveryCodeSet,
   parseRecoveryCode,
-  unwrapKEKFromRecovery,
-  wrapKEKForRecovery,
 } from '../src/index.js'
+import { unwrapDeksFromPaperEntry } from '@noy-db/hub'
 
-async function freshKEK(): Promise<CryptoKey> {
-  return crypto.subtle.generateKey(
-    { name: 'AES-GCM', length: 256 },
-    true,  // extractable — let tests round-trip via exportKey
-    ['encrypt', 'decrypt'],
-  )
+const subtle = globalThis.crypto.subtle
+
+async function freshDeks(): Promise<Map<string, CryptoKey>> {
+  const dek1 = await subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt'])
+  const dek2 = await subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt'])
+  return new Map([['invoices', dek1], ['clients', dek2]])
 }
 
-/**
- * Functional-equivalence test: encrypt with `original`, decrypt with
- * `candidate`. If both operations succeed on the same plaintext, the
- * two CryptoKeys are identical (AES-GCM auth tag ensures this).
- * Works regardless of extractability.
- */
-async function assertSameKey(original: CryptoKey, candidate: CryptoKey): Promise<void> {
-  const iv = crypto.getRandomValues(new Uint8Array(12))
-  const plaintext = new TextEncoder().encode('noydb-functional-equivalence-probe')
-  const ciphertext = await crypto.subtle.encrypt(
-    { name: 'AES-GCM', iv: iv as BufferSource },
-    original,
-    plaintext as BufferSource,
-  )
-  const recovered = await crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv: iv as BufferSource },
-    candidate,
-    ciphertext,
-  )
-  const recoveredText = new TextDecoder().decode(recovered)
-  expect(recoveredText).toBe('noydb-functional-equivalence-probe')
+async function dekBytes(dek: CryptoKey): Promise<string> {
+  const raw = new Uint8Array(await subtle.exportKey('raw', dek))
+  return Array.from(raw).map((b) => b.toString(16).padStart(2, '0')).join('')
 }
 
 // PBKDF2 with 600K iterations is CPU-intensive. Under parallel vitest
@@ -44,60 +37,73 @@ async function assertSameKey(original: CryptoKey, candidate: CryptoKey): Promise
 // the worst-case 20-code-set generation under CPU contention.
 const KDF_TIMEOUT = 30_000
 
-describe('generateRecoveryCodeSet', () => {
+describe('generateRecoveryCodeSet (delegates to hub mintPaperRecoveryEntry)', () => {
   it('generates the default 10 codes', async () => {
-    const kek = await freshKEK()
-    const result = await generateRecoveryCodeSet({ kek })
+    const deks = await freshDeks()
+    const result = await generateRecoveryCodeSet({ deks })
     expect(result.codes).toHaveLength(10)
     expect(result.entries).toHaveLength(10)
   }, KDF_TIMEOUT)
 
   it('honours the count option', async () => {
-    const kek = await freshKEK()
-    const result = await generateRecoveryCodeSet({ kek, count: 5 })
+    const deks = await freshDeks()
+    const result = await generateRecoveryCodeSet({ deks, count: 5 })
     expect(result.codes).toHaveLength(5)
     expect(result.entries).toHaveLength(5)
   }, KDF_TIMEOUT)
 
   it('codes are formatted in groups of 4 separated by hyphens', async () => {
-    const kek = await freshKEK()
-    const { codes } = await generateRecoveryCodeSet({ kek, count: 1 })
+    const deks = await freshDeks()
+    const { codes } = await generateRecoveryCodeSet({ deks, count: 1 })
     // 28 chars = 7 groups of 4, hyphen-separated
     expect(codes[0]).toMatch(/^[A-Z2-7]{4}(-[A-Z2-7]{4}){6}$/)
   }, KDF_TIMEOUT)
 
   it('every code is unique across a single enrollment', async () => {
-    const kek = await freshKEK()
-    const { codes } = await generateRecoveryCodeSet({ kek, count: 20 })
+    const deks = await freshDeks()
+    const { codes } = await generateRecoveryCodeSet({ deks, count: 20 })
     expect(new Set(codes).size).toBe(20)
   }, KDF_TIMEOUT)
 
-  it('every entry has a unique codeId', async () => {
-    const kek = await freshKEK()
-    const { entries } = await generateRecoveryCodeSet({ kek, count: 10 })
-    const ids = entries.map(e => e.codeId)
+  it('every entry has a unique codeId (ULID)', async () => {
+    const deks = await freshDeks()
+    const { entries } = await generateRecoveryCodeSet({ deks, count: 10 })
+    const ids = entries.map((e) => e.codeId)
     expect(new Set(ids).size).toBe(10)
   }, KDF_TIMEOUT)
 
+  it('entries use the hub PaperRecoveryEntry shape (wrap-DEKs)', async () => {
+    const deks = await freshDeks()
+    const { entries } = await generateRecoveryCodeSet({ deks, count: 1 })
+    const e = entries[0]!
+    expect(typeof e.codeId).toBe('string')
+    expect(typeof e.salt).toBe('string')
+    expect(typeof e.iv).toBe('string')           // wrap-DEKs has IV (no wrappedKEK)
+    expect(typeof e.wrappedDeks).toBe('string')
+    expect(typeof e.enrolledAt).toBe('string')
+    // Anti-regression: the broken pre.7 shape had `wrappedKEK` instead.
+    expect((e as Record<string, unknown>).wrappedKEK).toBeUndefined()
+  }, KDF_TIMEOUT)
+
   it('rejects out-of-range count', async () => {
-    const kek = await freshKEK()
-    await expect(generateRecoveryCodeSet({ kek, count: 0 })).rejects.toThrow(/count must be/)
-    await expect(generateRecoveryCodeSet({ kek, count: -1 })).rejects.toThrow(/count must be/)
-    await expect(generateRecoveryCodeSet({ kek, count: 101 })).rejects.toThrow(/count must be/)
+    const deks = await freshDeks()
+    await expect(generateRecoveryCodeSet({ deks, count: 0 })).rejects.toThrow(/count must be/)
+    await expect(generateRecoveryCodeSet({ deks, count: -1 })).rejects.toThrow(/count must be/)
+    await expect(generateRecoveryCodeSet({ deks, count: 101 })).rejects.toThrow(/count must be/)
   })
 })
 
 describe('parseRecoveryCode', () => {
   it('accepts a well-formed code with hyphens', async () => {
-    const kek = await freshKEK()
-    const { codes } = await generateRecoveryCodeSet({ kek, count: 1 })
+    const deks = await freshDeks()
+    const { codes } = await generateRecoveryCodeSet({ deks, count: 1 })
     const result = parseRecoveryCode(codes[0]!)
     expect(result.status).toBe('valid')
   }, KDF_TIMEOUT)
 
   it('accepts whitespace, lowercase, and missing hyphens', async () => {
-    const kek = await freshKEK()
-    const { codes } = await generateRecoveryCodeSet({ kek, count: 1 })
+    const deks = await freshDeks()
+    const { codes } = await generateRecoveryCodeSet({ deks, count: 1 })
     const normalized = codes[0]!.replace(/-/g, '')
     expect(parseRecoveryCode(normalized).status).toBe('valid')
     expect(parseRecoveryCode(normalized.toLowerCase()).status).toBe('valid')
@@ -112,10 +118,9 @@ describe('parseRecoveryCode', () => {
   })
 
   it('rejects codes with wrong checksum', async () => {
-    const kek = await freshKEK()
-    const { codes } = await generateRecoveryCodeSet({ kek, count: 1 })
+    const deks = await freshDeks()
+    const { codes } = await generateRecoveryCodeSet({ deks, count: 1 })
     const normalized = codes[0]!.replace(/-/g, '')
-    // Flip the last char of checksum — probability of accidental validity ~1/32
     const lastChar = normalized[normalized.length - 1]!
     const flipped = lastChar === 'A' ? 'B' : 'A'
     const tampered = normalized.slice(0, -1) + flipped
@@ -123,7 +128,7 @@ describe('parseRecoveryCode', () => {
   }, KDF_TIMEOUT)
 
   it('rejects codes with non-Base32 characters', () => {
-    const bad = 'AAAA-0OIL-AAAA-AAAA-AAAA-AAAA'  // 0, O, I, L are not in Base32 alphabet
+    const bad = 'AAAA-0OIL-AAAA-AAAA-AAAA-AAAA'  // 0, O, I, L are not in Base32
     expect(parseRecoveryCode(bad).status).toBe('invalid-format')
   })
 })
@@ -134,65 +139,49 @@ describe('formatRecoveryCode', () => {
   })
 
   it('is the inverse of the strip in parseRecoveryCode', async () => {
-    const kek = await freshKEK()
-    const { codes } = await generateRecoveryCodeSet({ kek, count: 1 })
+    const deks = await freshDeks()
+    const { codes } = await generateRecoveryCodeSet({ deks, count: 1 })
     const parsed = parseRecoveryCode(codes[0]!)
     if (parsed.status !== 'valid') throw new Error('expected valid')
     expect(formatRecoveryCode(parsed.code)).toBe(codes[0])
   }, KDF_TIMEOUT)
 })
 
-describe('wrap + unwrap round-trip', () => {
-  it('unwraps a functionally-equivalent KEK when given the correct code', async () => {
-    const kek = await freshKEK()
-    const { codes, entries } = await generateRecoveryCodeSet({ kek, count: 1 })
+describe('hub-delegated round-trip (wrap-DEKs)', () => {
+  it('unwraps the same DEK bytes when given the correct code', async () => {
+    const deks = await freshDeks()
+    const { codes, entries } = await generateRecoveryCodeSet({ deks, count: 1 })
     const parsed = parseRecoveryCode(codes[0]!)
     if (parsed.status !== 'valid') throw new Error('expected valid')
 
-    const unwrapped = await unwrapKEKFromRecovery(parsed.code, entries[0]!)
-    await assertSameKey(kek, unwrapped)
-  }, 20_000)
+    const recovered = await unwrapDeksFromPaperEntry(entries[0]!, parsed.code)
+    expect(recovered.size).toBe(2)
+    for (const coll of deks.keys()) {
+      expect(recovered.has(coll)).toBe(true)
+      expect(await dekBytes(recovered.get(coll)!)).toBe(await dekBytes(deks.get(coll)!))
+    }
+  }, KDF_TIMEOUT)
 
   it('fails to unwrap when the code is wrong', async () => {
-    const kek = await freshKEK()
-    const { codes, entries } = await generateRecoveryCodeSet({ kek, count: 2 })
+    const deks = await freshDeks()
+    const { codes, entries } = await generateRecoveryCodeSet({ deks, count: 2 })
     const parsedA = parseRecoveryCode(codes[0]!)
     if (parsedA.status !== 'valid') throw new Error('expected valid')
 
-    // Try to unwrap entry 0 using code 1 — should fail (AES-KW auth)
-    await expect(unwrapKEKFromRecovery(parsedA.code, entries[1]!)).rejects.toThrow()
-  }, 20_000)
-
-  it('low-level wrap/unwrap produces a functionally-equivalent KEK', async () => {
-    const kek = await freshKEK()
-    const salt = crypto.getRandomValues(new Uint8Array(16))
-    // Any string works for the low-level wrap test; length matches the normalized code format.
-    const code = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAA'  // 28 chars
-    const wrapped = await wrapKEKForRecovery(kek, code, salt)
-    const wrappingKey = await deriveRecoveryWrappingKey(code, salt)
-    const unwrapped = await crypto.subtle.unwrapKey(
-      'raw',
-      wrapped as BufferSource,
-      wrappingKey,
-      'AES-KW',
-      { name: 'AES-GCM', length: 256 },
-      false,
-      ['encrypt', 'decrypt'],
-    )
-    await assertSameKey(kek, unwrapped)
-  }, 20_000)
+    // Try to unwrap entry 0 using code 1 — must fail (AES-GCM auth tag).
+    await expect(unwrapDeksFromPaperEntry(entries[1]!, parsedA.code)).rejects.toThrow()
+  }, KDF_TIMEOUT)
 })
 
 describe('burn-on-use semantics (application-layer)', () => {
   it('after the caller deletes the entry, the code is unusable', async () => {
-    const kek = await freshKEK()
-    const { codes, entries } = await generateRecoveryCodeSet({ kek, count: 3 })
+    const deks = await freshDeks()
+    const { codes, entries } = await generateRecoveryCodeSet({ deks, count: 3 })
 
-    // Consumer side: unlock with entry 0, then "delete" it from storage.
     const parsed0 = parseRecoveryCode(codes[0]!)
     if (parsed0.status !== 'valid') throw new Error('expected valid')
-    const unwrapped = await unwrapKEKFromRecovery(parsed0.code, entries[0]!)
-    expect(unwrapped).toBeDefined()
+    const unwrapped = await unwrapDeksFromPaperEntry(entries[0]!, parsed0.code)
+    expect(unwrapped.size).toBeGreaterThan(0)
 
     // Simulate burn: drop entry 0 from the stored list.
     const stillEnrolled = entries.slice(1)
@@ -201,7 +190,7 @@ describe('burn-on-use semantics (application-layer)', () => {
     let usableAgain = false
     for (const entry of stillEnrolled) {
       try {
-        await unwrapKEKFromRecovery(parsed0.code, entry)
+        await unwrapDeksFromPaperEntry(entry, parsed0.code)
         usableAgain = true
         break
       } catch {
@@ -209,6 +198,5 @@ describe('burn-on-use semantics (application-layer)', () => {
       }
     }
     expect(usableAgain).toBe(false)
-  }, 30_000)
+  }, KDF_TIMEOUT)
 })
-

--- a/packages/on-recovery/src/index.ts
+++ b/packages/on-recovery/src/index.ts
@@ -1,73 +1,55 @@
 /**
- * **@noy-db/on-recovery** — one-time printable recovery codes for noy-db.
+ * **@noy-db/on-recovery** — printable recovery codes for noy-db.
  *
- * The last-resort unlock path when the primary authentication
- * (passphrase, WebAuthn, OIDC) is unavailable. Codes are designed to
- * be printed on paper and stored in a safe — each code unlocks the
- * vault exactly once and then is burned by deleting its keyring entry.
+ * The last-resort unlock path when the primary authentication is
+ * unavailable. Codes are designed to be printed on paper and stored
+ * in a safe — each code unlocks the vault exactly once and then is
+ * burned by deleting its `_meta/recovery-paper` entry.
  *
  * Part of the `@noy-db/on-*` authentication family.
  *
- * ## Security model
+ * ## Format (post pre.8, #38 Option A)
  *
- * Each code is a random 100-bit value (20 Base32 characters) with a
- * 5-character checksum appended. The wrapping key is derived from
- * the code via:
+ * This package is now a **thin code-generator + parser layer over
+ * the hub's `mintPaperRecoveryEntry` primitive**. Its job is exactly
+ * three things:
  *
- * ```
- *   PBKDF2-SHA256(
- *     password = normalizeCode(code),
- *     salt     = perCodeRandomSalt,
- *     iter     = 600_000,
- *     length   = 32,
- *   )
- * ```
+ * 1. Generate printable Base32 codes with checksums (the user-facing
+ *    string format).
+ * 2. Parse user input back into a normalized code (whitespace /
+ *    hyphen / case insensitive).
+ * 3. Delegate the wrapping crypto to the hub via
+ *    `mintPaperRecoveryEntry(deks, code, codeId)`.
  *
- * The wrapping key is then used with AES-KW (RFC 3394) to wrap the
- * vault's KEK. The wrapped KEK + salt + code-ID land in the keyring
- * under a `_recovery_<N>` entry, alongside other unlock mechanisms.
- *
- * This package provides the CRYPTO layer only. Storage, burn, audit,
- * and rate-limiting are the caller's responsibility — typically
- * coordinated with `@noy-db/hub`'s keyring + audit-ledger APIs.
+ * This delegation aligns recovery with the hub's wrap-DEKs primitive
+ * (the same shape used by `@noy-db/on-pin` and now `@noy-db/on-password`
+ * after #26 Path C). It eliminates the format mismatch that made the
+ * pre.7 package unusable with `db.enrollRecovery` (#38).
  *
  * ## Usage
  *
  * ```ts
- * import {
- *   generateRecoveryCodeSet,
- *   parseRecoveryCode,
- *   deriveRecoveryWrappingKey,
- *   wrapKEKForRecovery,
- *   unwrapKEKFromRecovery,
- * } from '@noy-db/on-recovery'
+ * import { generateRecoveryCodeSet, parseRecoveryCode } from '@noy-db/on-recovery'
  *
- * // ENROLL — after user unlocks with passphrase, generate N codes
- * const { codes, entries } = await generateRecoveryCodeSet({ count: 10, kek })
- * // `codes` is what you show the user ONCE (to print/save).
- * // `entries` goes into the keyring file (persistent storage).
+ * // ENROLL — after the user unlocks at tier 1, mint N codes
+ * const keyring = await db.getKeyring('acme')
+ * const { codes, entries } = await generateRecoveryCodeSet({ deks: keyring.deks, count: 10 })
+ * showCodesToUser(codes)
+ * await db.enrollRecovery('acme', { profile: 'paper', entries })
  *
- * // UNLOCK — user types in a code later
+ * // RECOVER — user types one back later (handled by db.recoverPassphrase)
  * const parsed = parseRecoveryCode(userInput)
- * if (parsed.status !== 'valid') handleInvalidFormat(parsed.status)
- *
- * for (const entry of storedEntries) {
- *   try {
- *     const kek = await unwrapKEKFromRecovery(parsed.code, entry)
- *     // Match! Burn this entry: delete from keyring.
- *     await deleteKeyringEntry(entry.codeId)
- *     return kek
- *   } catch (e) {
- *     // Wrong entry, try next
- *   }
- * }
- * throw new Error('no matching recovery code')
+ * if (parsed.status !== 'valid') return handleInvalid(parsed.status)
+ * await db.recoverPassphrase('acme', {
+ *   newPassphrase,
+ *   recoveryProof: { profile: 'paper', payload: { code: parsed.code } },
+ * })
  * ```
  *
  * @packageDocumentation
  */
 
-import { generateULID } from '@noy-db/hub'
+import { generateULID, mintPaperRecoveryEntry, type PaperRecoveryEntry } from '@noy-db/hub'
 
 // Constants ────────────────────────────────────────────────────────────
 
@@ -83,38 +65,18 @@ const CODE_ENTROPY_BYTES = 15   // 15 bytes = 120 bits = exactly 24 Base32 chars
 /** Length of the checksum portion (Base32 chars). */
 const CHECKSUM_LEN = 4           // 24 body + 4 checksum = 28 chars = 7 groups of 4
 
-/** PBKDF2 iteration count — matches hub's passphrase-unlock derivation. */
-const PBKDF2_ITERATIONS = 600_000
-
-/** PBKDF2 output length — 32 bytes = 256-bit wrapping key. */
-const PBKDF2_KEY_LENGTH = 32 * 8
-
-/** Per-code salt length. */
-const SALT_BYTES = 16
-
 // Types ────────────────────────────────────────────────────────────────
-
-/**
- * A single recovery-code enrollment entry. The caller stores this in
- * the vault's keyring alongside other unlock mechanisms.
- */
-export interface RecoveryCodeEntry {
-  /** Stable identifier for this code (ULID). Used by the caller to delete the entry on burn. */
-  readonly codeId: string
-  /** PBKDF2 salt for this code, base64-encoded. */
-  readonly salt: string
-  /** Wrapped KEK, base64-encoded. Unwrap with AES-KW using the code-derived key. */
-  readonly wrappedKEK: string
-  /** Timestamp the code was enrolled. */
-  readonly enrolledAt: string
-}
 
 /** Options for `generateRecoveryCodeSet()`. */
 export interface GenerateRecoveryCodeSetOptions {
   /** Number of codes to generate. Default 10. Reasonable: 8-20. */
   count?: number
-  /** The vault's current KEK (unwrapped). Required — proves possession. */
-  kek: CryptoKey
+  /**
+   * The vault's current DEK set (typically `(await db.getKeyring(vault)).deks`).
+   * Required — proves possession and is the input the hub's
+   * `mintPaperRecoveryEntry` needs.
+   */
+  deks: Map<string, CryptoKey>
 }
 
 /** Result of `parseRecoveryCode()`. */
@@ -126,41 +88,35 @@ export type ParseResult =
 // Code generation ──────────────────────────────────────────────────────
 
 /**
- * Generate a fresh recovery-code set. The returned `codes` must be shown
- * to the user exactly once (print/save); the `entries` go into the
- * keyring for persistent storage.
+ * Generate a fresh recovery-code set. Returned `codes` must be shown
+ * to the user exactly once (print/save); `entries` go into the vault
+ * via `db.enrollRecovery({ profile: 'paper', entries })`.
  *
- * The caller is responsible for:
- * 1. Displaying the plaintext codes to the user ONCE.
- * 2. Writing `entries` into the vault's keyring.
- * 3. Writing an audit-ledger entry recording the enrollment.
+ * Internally calls the hub's `mintPaperRecoveryEntry` once per code.
+ * The hub's wrap-DEKs format is preserved end-to-end — `db.enrollRecovery`
+ * stores the entries verbatim and `db.recoverPassphrase` consumes them
+ * via `unwrapDeksFromPaperEntry`.
  */
 export async function generateRecoveryCodeSet(
   opts: GenerateRecoveryCodeSetOptions,
-): Promise<{ codes: string[]; entries: RecoveryCodeEntry[] }> {
+): Promise<{ codes: string[]; entries: PaperRecoveryEntry[] }> {
   const count = opts.count ?? 10
   if (!Number.isInteger(count) || count < 1 || count > 100) {
     throw new Error(`on-recovery: count must be 1-100 (got ${count})`)
   }
 
   const codes: string[] = []
-  const entries: RecoveryCodeEntry[] = []
-  const now = new Date().toISOString()
+  const entries: PaperRecoveryEntry[] = []
 
   for (let i = 0; i < count; i++) {
     const raw = generateRawCode()
     const formatted = formatCodeForDisplay(raw)
-    const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES))
-    const wrappingKey = await deriveRecoveryWrappingKey(raw, salt)
-    const wrappedKEK = await wrapKEK(opts.kek, wrappingKey)
-
+    // The hub stores entries keyed on the NORMALIZED code (raw, no
+    // hyphens). Mint with the normalized form so `db.recoverPassphrase`'s
+    // `normalizePaperCode(input)` matches at unlock time.
+    const entry = await mintPaperRecoveryEntry(opts.deks, raw, generateULID())
     codes.push(formatted)
-    entries.push({
-      codeId: generateULID(),
-      salt: base64Encode(salt),
-      wrappedKEK: base64Encode(wrappedKEK),
-      enrolledAt: now,
-    })
+    entries.push(entry)
   }
 
   return { codes, entries }
@@ -208,86 +164,6 @@ export function formatRecoveryCode(normalizedCode: string): string {
   return groups.join('-')
 }
 
-// Key derivation ───────────────────────────────────────────────────────
-
-/**
- * Derive the AES-KW wrapping key from a recovery code + salt. Used for
- * both enrollment (wrap the KEK) and unlock (unwrap the KEK).
- *
- * @param code - A normalized recovery code (uppercase Base32, no
- *   hyphens/whitespace, checksum included).
- * @param salt - Per-code random salt from the stored entry.
- */
-export async function deriveRecoveryWrappingKey(
-  code: string,
-  salt: Uint8Array,
-): Promise<CryptoKey> {
-  const password = new TextEncoder().encode(code)
-  const baseKey = await crypto.subtle.importKey(
-    'raw',
-    password as BufferSource,
-    'PBKDF2',
-    false,
-    ['deriveKey'],
-  )
-  return crypto.subtle.deriveKey(
-    {
-      name: 'PBKDF2',
-      hash: 'SHA-256',
-      salt: salt as BufferSource,
-      iterations: PBKDF2_ITERATIONS,
-    },
-    baseKey,
-    { name: 'AES-KW', length: PBKDF2_KEY_LENGTH },
-    false,
-    ['wrapKey', 'unwrapKey'],
-  )
-}
-
-// KEK wrap/unwrap ──────────────────────────────────────────────────────
-
-/**
- * Wrap a KEK with a recovery-code-derived wrapping key.
- * Returns raw bytes suitable for base64 encoding + storage.
- */
-export async function wrapKEKForRecovery(
-  kek: CryptoKey,
-  code: string,
-  salt: Uint8Array,
-): Promise<Uint8Array> {
-  const wrappingKey = await deriveRecoveryWrappingKey(code, salt)
-  return wrapKEK(kek, wrappingKey)
-}
-
-/**
- * Unwrap the KEK using a recovery code + a stored entry.
- *
- * Throws (AES-KW authentication failure) if the code doesn't match
- * this entry. The caller typically iterates all enrolled entries and
- * catches the failure until one succeeds.
- *
- * On success, the caller MUST burn the entry — deleting `entry.codeId`
- * from the keyring — so the code can never be replayed.
- */
-export async function unwrapKEKFromRecovery(
-  code: string,
-  entry: RecoveryCodeEntry,
-): Promise<CryptoKey> {
-  const salt = base64Decode(entry.salt)
-  const wrappedKEK = base64Decode(entry.wrappedKEK)
-  const wrappingKey = await deriveRecoveryWrappingKey(code, salt)
-
-  return crypto.subtle.unwrapKey(
-    'raw',
-    wrappedKEK as BufferSource,
-    wrappingKey,
-    'AES-KW',
-    { name: 'AES-GCM', length: 256 },
-    false,
-    ['encrypt', 'decrypt'],
-  )
-}
-
 // Internals ────────────────────────────────────────────────────────────
 
 function generateRawCode(): string {
@@ -315,7 +191,6 @@ function computeChecksum(body: string): string {
     const v = BASE32_ALPHABET.indexOf(body[i]!)
     h = (h * 33 + v) >>> 0
   }
-  // Extract 4 Base32 chars from the 20 low bits
   const chars: string[] = []
   for (let i = 0; i < CHECKSUM_LEN; i++) {
     chars.push(BASE32_ALPHABET[(h >>> (i * 5)) & 0x1f]!)
@@ -324,7 +199,6 @@ function computeChecksum(body: string): string {
 }
 
 function base32CharsForBytes(n: number): number {
-  // Each 5 bytes → 8 Base32 chars. Partial-byte handling via ceil.
   return Math.ceil((n * 8) / 5)
 }
 
@@ -343,24 +217,5 @@ function base32Encode(bytes: Uint8Array): string {
   if (bits > 0) {
     out += BASE32_ALPHABET[(value << (5 - bits)) & 0x1f]
   }
-  return out
-}
-
-async function wrapKEK(kek: CryptoKey, wrappingKey: CryptoKey): Promise<Uint8Array> {
-  const wrapped = await crypto.subtle.wrapKey('raw', kek, wrappingKey, 'AES-KW')
-  return new Uint8Array(wrapped)
-}
-
-function base64Encode(bytes: Uint8Array): string {
-  let s = ''
-  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]!)
-  // `btoa` is globally available in browsers, Node 16+, Deno, Bun.
-  return btoa(s)
-}
-
-function base64Decode(str: string): Uint8Array {
-  const s = atob(str)
-  const out = new Uint8Array(s.length)
-  for (let i = 0; i < s.length; i++) out[i] = s.charCodeAt(i)
   return out
 }

--- a/showcases/src/26-on-recovery.showcase.test.ts
+++ b/showcases/src/26-on-recovery.showcase.test.ts
@@ -3,17 +3,26 @@
  *
  * What you'll learn
  * ─────────────────
- * `generateRecoveryCodeSet({ kek, count })` produces N high-entropy,
+ * `generateRecoveryCodeSet({ deks, count })` produces N high-entropy,
  * human-readable codes (groups of 4 chars separated by `-`) plus a
- * matching `entries` array — each entry holds the code's salt and
- * wrapped-KEK ciphertext (safe to persist). Hand the codes to the user;
- * keep the entries with the vault. Any code + its matching entry
- * unwraps the KEK via `unwrapKEKFromRecovery()`.
+ * matching `entries` array — each entry holds the code's salt + IV +
+ * wrapped-DEKs ciphertext (safe to persist). Hand the codes to the
+ * user; the entries go to the vault via
+ * `db.enrollRecovery({ profile: 'paper', entries })`. Any code + its
+ * matching entry round-trips through `unwrapDeksFromPaperEntry()` to
+ * recover the same DEK set.
  *
  * Why it matters
  * ──────────────
  * The "I lost my phone" recovery path. PBKDF2 (600K iterations) over the
  * typed code keeps brute-force cost high even if the wrapped blob leaks.
+ *
+ * Format note (post pre.8 — #38 Option A)
+ * ───────────────────────────────────────
+ * Recovery now wraps the DEK set (not the KEK), matching the hub's
+ * unified wrap-DEKs primitive used by tier-0 (paper recovery), tier-2
+ * (`@noy-db/on-password`), and tier-3 (`@noy-db/on-pin`). The pre.7
+ * wrap-KEK shape is gone.
  *
  * Prerequisites
  * ─────────────
@@ -30,12 +39,18 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { generateRecoveryCodeSet, parseRecoveryCode, unwrapKEKFromRecovery } from '@noy-db/on-recovery'
+import { generateRecoveryCodeSet, parseRecoveryCode } from '@noy-db/on-recovery'
+import { unwrapDeksFromPaperEntry } from '@noy-db/hub'
+
+async function freshDeks(): Promise<Map<string, CryptoKey>> {
+  const dek = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt'])
+  return new Map([['invoices', dek]])
+}
 
 describe('Showcase 26 — Recovery codes', () => {
   it('generates N codes; every one parses cleanly', async () => {
-    const kek = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt'])
-    const set = await generateRecoveryCodeSet({ kek, count: 5 })
+    const deks = await freshDeks()
+    const set = await generateRecoveryCodeSet({ deks, count: 5 })
     expect(set.codes).toHaveLength(5)
     expect(set.entries).toHaveLength(5)
 
@@ -45,9 +60,9 @@ describe('Showcase 26 — Recovery codes', () => {
     }
   })
 
-  it('any code from the set unwraps the same KEK that was wrapped at enrollment', async () => {
-    const kek = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt'])
-    const set = await generateRecoveryCodeSet({ kek, count: 3 })
+  it('any code from the set recovers the same DEKs that were wrapped at enrollment', async () => {
+    const deks = await freshDeks()
+    const set = await generateRecoveryCodeSet({ deks, count: 3 })
 
     // The user types the first code on the recovery sheet; we look up the
     // matching entry by index (in production the entries are persisted
@@ -57,13 +72,13 @@ describe('Showcase 26 — Recovery codes', () => {
     if (parsed.status !== 'valid') throw new Error('parse failed')
 
     const entry = set.entries[0]!
-    const unwrapped = await unwrapKEKFromRecovery(parsed.code, entry)
+    const recovered = await unwrapDeksFromPaperEntry(entry, parsed.code)
 
     // Round-trip a payload through both the original and the recovered
-    // KEK — proves the unwrap reproduced the exact same key bytes.
+    // DEK — proves the unwrap reproduced the exact same key bytes.
     const iv = crypto.getRandomValues(new Uint8Array(12))
-    const ct = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, kek, new TextEncoder().encode('survived'))
-    const pt = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, unwrapped, ct)
+    const ct = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, deks.get('invoices')!, new TextEncoder().encode('survived'))
+    const pt = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, recovered.get('invoices')!, ct)
     expect(new TextDecoder().decode(pt)).toBe('survived')
   })
 })


### PR DESCRIPTION
## Summary

Niwat's review of the post-pre.7 auth surface surfaced a structural asymmetry: tier-0 (paper recovery, `mintPaperRecoveryEntry`) and tier-3 (`@noy-db/on-pin`) both wrap the **DEK SET** under a per-credential AES-GCM key, while tier-2 (`@noy-db/on-password`) was the only tier wrapping the **KEK** directly. That asymmetry forced the tier-2 ceremony to require an extractable KEK — which the hub's `deriveKey` deliberately disallows — making `@noy-db/on-password` unreachable from a real consumer.

This PR unifies all three tiers around the **wrap-DEKs primitive**.

## Why this approach (Path C, not Path A)

An earlier round of design considered Path A — flip `extractable: true` on the KEK at `crypto.ts:72` (one-line change). It works, but leaves tier-2 as the architectural outlier. Path C eliminates the outlier entirely — every tier-0/2/3 ceremony now follows the same shape: serialize the DEK set, encrypt under a credential-derived key, store the ciphertext in a keyring slot or `_meta/recovery-paper` document.

Trade-off: tier-2 unlocks now produce `UnlockedKeyring` with `kek: null`. Sensitive ops (`enrollAuthenticator`, `rotatePassphrase`) require a tier-1 unlock anyway, matching how `@noy-db/on-pin` already works at tier 3. Niwat accepted this trade-off in the #26 comment.

## What changed

### `@noy-db/hub` — minor
- `KeyringAuthenticator` is now a **discriminated union** over wrap-KEK and wrap-DEKs variants. Backward-compat: pre-pre.8 slots without `wrapKind` are treated as wrap-KEK at unlock.
- `EnrollAuthenticatorOptions` becomes the parallel union; `enrollAuthenticator` accepts either and persists the variant verbatim.
- `db.enrollRecovery` docstring updated — on-recovery now works end-to-end as the canonical example.

### `@noy-db/on-password` — minor (BREAKING)
- `enrollPasswordAuthenticator` wraps the DEK set under a PBKDF2-derived AES-GCM key (parallels `mintPaperRecoveryEntry`). No `keyring.kek` requirement.
- `verifyPasswordSlot` returns an `UnlockedKeyring` with `kek: null`. Drops the `materialize` callback — replaced by a single `keyring` reference for identity fields.
- `unwrapKekWithPassword` removed; replaced by `unwrapDeksWithPassword`.
- Pre-pre.8 wrap-KEK password slots throw `PasswordInvalidError` with a clear "re-enrol" message.

### `@noy-db/on-recovery` — minor (BREAKING)
- `generateRecoveryCodeSet({ deks, count })` (was: `{ kek, count }`). Delegates to hub's `mintPaperRecoveryEntry`.
- Removed: `unwrapKEKFromRecovery`, `wrapKEKForRecovery`, `deriveRecoveryWrappingKey`, `RecoveryCodeEntry` type.
- The package is now a thin code-generator + parser layer over the hub.

## Test plan

- [x] 2350 / 2350 tests pass (181 test files; 4 skipped IDB-perf benches)
- [x] Typecheck: 107 / 107 targets clean
- [x] Lint: 106 / 106 packages clean
- [x] New `pr1b-authenticator-shapes.test.ts` pins the discriminated union round-trip + coexistence in one keyring
- [x] Full on-password rewrite + legacy wrap-KEK rejection regression test
- [x] Full on-recovery rewrite + hub-delegated round-trip test
- [x] Showcase 26 updated to new API
- [ ] Niwat sanity-check: replace the vendored ~70 LOC + drop the synthetic `materialize` workaround for `verifyPasswordSlot`

## Branch base

This PR is based on `feat/pr1a-public-recovery-api` (PR #40). When PR #40 merges to main, retarget this PR to main — the diff against main should remain the architectural changes only.

## Follow-up

#41 tracks the `UnlockedKeyring.kek` type tightening (`CryptoKey | null`) — deliberately scoped out. The runtime already lies in 5 places (4 pre-existing + 1 new wrap-DEKs verifier); the audit is its own PR.

Closes #26
Closes #38