### PR TITLE
feat(hub): atomic db.recoverUser for peer-recovery (#33, #34)

### DIFF
--- a/packages/hub/__tests__/peer-recover.test.ts
+++ b/packages/hub/__tests__/peer-recover.test.ts
@@ -1,0 +1,335 @@
+/**
+ * PR2a — atomic peer-recovery (`db.recoverUser`, issues #33 + #34).
+ *
+ * Pinned behaviors:
+ *   1. Round-trip — alice (owner) recovers bob (admin); bob unlocks
+ *      with the temp phrase.
+ *   2. Owner→owner allowed — closes #33's hard block when both
+ *      principals are co-owners.
+ *   3. Admin→owner rejected — the structural rule survives recovery
+ *      (admin cannot use peer-recovery as a privilege-uplift vector).
+ *   4. Anti-privilege-escalation — caller without a target's DEK
+ *      throws PrivilegeEscalationError.
+ *   5. Tier-2 slots dropped — slots wrap the OLD KEK; recovery
+ *      invalidates them (matches rotatePassphrase precedent).
+ *   6. Identity preserved — userId / role / displayName / capabilities
+ *      survive unless explicitly overridden.
+ *   7. Atomic-by-construction — a failure mid-recovery (simulated via
+ *      a `put`-throwing wrapper store) leaves the original keyring
+ *      intact; recipient can still unlock with the OLD passphrase.
+ *   8. Hub-level gating — `db.recoverUser` runs `peer-recover-user`
+ *      gate before the team function.
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, KeyringFile, KeyringAuthenticator } from '../src/types.js'
+import { createOwnerKeyring, loadKeyring, grant, persistKeyring } from '../src/team/keyring.js'
+import { recoverUser } from '../src/team/peer-recover.js'
+import { generateDEK } from '../src/crypto.js'
+import { createNoydb } from '../src/noydb.js'
+import { NoAccessError, PermissionDeniedError, PrivilegeEscalationError, InvalidKeyError } from '../src/errors.js'
+import { PolicyDeniedError } from '../src/policy/errors.js'
+import { STRICT_POLICY } from '../src/policy/presets.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'inline-memory',
+    async get(c, col, id) { return gc(c, col).get(id) },
+    async put(c, col, id, env) { gc(c, col).set(id, env) },
+    async delete(c, col, id) { gc(c, col).delete(id) },
+    async list(c, col) { return [...gc(c, col).keys()] },
+    async loadAll() { return {} },
+    async saveAll() {},
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+  } as unknown as NoydbStore
+}
+
+const ALICE_PHRASE = 'correct horse battery staple printer toaster'
+const BOB_PHRASE = 'glasses cabinet bicycle umbrella thunder velvet'
+const TEMP_PHRASE = 'temporary umbrella cabinet bicycle thunder velvet glasses'
+
+describe('recoverUser (#34 atomicity, #33 owner→owner)', () => {
+  it('round-trips: owner recovers admin; recipient unlocks with temp phrase', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    aliceKr.deks.set('clients', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+      passphrase: BOB_PHRASE,
+    })
+
+    await recoverUser(store, 'acme', aliceKr, {
+      userId: 'bob',
+      passphrase: TEMP_PHRASE,
+    })
+
+    // Old phrase no longer unlocks bob's keyring.
+    await expect(loadKeyring(store, 'acme', 'bob', BOB_PHRASE)).rejects.toBeInstanceOf(InvalidKeyError)
+    // Temp phrase does.
+    const bobReloaded = await loadKeyring(store, 'acme', 'bob', TEMP_PHRASE)
+    expect(bobReloaded.userId).toBe('bob')
+    expect(bobReloaded.role).toBe('admin')
+    expect(bobReloaded.deks.size).toBe(aliceKr.deks.size)
+  }, 60_000)
+
+  it('owner → owner peer-recovery succeeds (closes #33)', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'owner',
+      passphrase: BOB_PHRASE,
+    })
+
+    // Now bob (also owner) forgets his phrase. Alice (owner) recovers him.
+    await expect(
+      recoverUser(store, 'acme', aliceKr, { userId: 'bob', passphrase: TEMP_PHRASE }),
+    ).resolves.toBeUndefined()
+
+    const bobReloaded = await loadKeyring(store, 'acme', 'bob', TEMP_PHRASE)
+    expect(bobReloaded.role).toBe('owner')
+  }, 60_000)
+
+  it('admin → owner peer-recovery rejected (the structural boundary survives recovery)', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'admin1',
+      displayName: 'Admin 1',
+      role: 'admin',
+      passphrase: 'admin-strong-phrase-with-enough-words-here',
+    })
+
+    // Admin tries to recover the owner (alice).
+    const adminKr = await loadKeyring(store, 'acme', 'admin1', 'admin-strong-phrase-with-enough-words-here')
+    await expect(
+      recoverUser(store, 'acme', adminKr, { userId: 'alice', passphrase: TEMP_PHRASE }),
+    ).rejects.toBeInstanceOf(PermissionDeniedError)
+  }, 60_000)
+
+  it('admin cannot uplift a target to owner under cover of recovery', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'admin1',
+      displayName: 'Admin 1',
+      role: 'admin',
+      passphrase: 'admin-strong-phrase-with-enough-words-here',
+    })
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'operator',
+      passphrase: BOB_PHRASE,
+    })
+
+    const adminKr = await loadKeyring(store, 'acme', 'admin1', 'admin-strong-phrase-with-enough-words-here')
+    await expect(
+      recoverUser(store, 'acme', adminKr, {
+        userId: 'bob',
+        role: 'owner', // ← role uplift attempt
+        passphrase: TEMP_PHRASE,
+      }),
+    ).rejects.toBeInstanceOf(PermissionDeniedError)
+  }, 60_000)
+
+  it('throws NoAccessError when the target has no keyring', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    await persistKeyring(store, 'acme', aliceKr)
+    await expect(
+      recoverUser(store, 'acme', aliceKr, { userId: 'ghost', passphrase: TEMP_PHRASE }),
+    ).rejects.toBeInstanceOf(NoAccessError)
+  })
+
+  it('throws PrivilegeEscalationError when caller lacks a target collection DEK', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+      passphrase: BOB_PHRASE,
+    })
+    // Drop the 'invoices' DEK from caller's in-memory keyring AFTER
+    // bob has it — simulates "the caller's DEK set is narrower than
+    // the target's." The persisted keyring file still has it, so
+    // canRecover passes; the in-memory check should catch it.
+    aliceKr.deks.delete('invoices')
+
+    await expect(
+      recoverUser(store, 'acme', aliceKr, { userId: 'bob', passphrase: TEMP_PHRASE }),
+    ).rejects.toBeInstanceOf(PrivilegeEscalationError)
+  }, 60_000)
+
+  it('drops tier-2 authenticator slots on recovery (matches rotatePassphrase precedent)', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+      passphrase: BOB_PHRASE,
+    })
+
+    // Simulate bob having enrolled a tier-2 slot before recovery —
+    // patch the persisted keyring file directly (faster than running
+    // the full enrollAuthenticator path).
+    const env = await store.get('acme', '_keyring', 'bob')
+    const file = JSON.parse(env!._data) as KeyringFile
+    const slot: KeyringAuthenticator = {
+      id: 'webauthn-old',
+      method: 'webauthn',
+      enrolled_at: new Date().toISOString(),
+      enrolled_via_tier: 1,
+      wrapped_kek: 'YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=',
+      meta: { credentialId: 'cred-old' },
+    }
+    const fileWithSlot: KeyringFile = { ...file, authenticators: [slot] }
+    await store.put('acme', '_keyring', 'bob', {
+      _noydb: 1, _v: 1, _ts: new Date().toISOString(), _iv: '',
+      _data: JSON.stringify(fileWithSlot),
+    })
+
+    await recoverUser(store, 'acme', aliceKr, { userId: 'bob', passphrase: TEMP_PHRASE })
+
+    const bobReloaded = await loadKeyring(store, 'acme', 'bob', TEMP_PHRASE)
+    expect(bobReloaded.authenticators).toHaveLength(0)
+  }, 60_000)
+
+  it('preserves identity (userId / displayName / role) when not overridden', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob the Original',
+      role: 'admin',
+      passphrase: BOB_PHRASE,
+    })
+
+    await recoverUser(store, 'acme', aliceKr, { userId: 'bob', passphrase: TEMP_PHRASE })
+
+    const bobReloaded = await loadKeyring(store, 'acme', 'bob', TEMP_PHRASE)
+    expect(bobReloaded.userId).toBe('bob')
+    expect(bobReloaded.displayName).toBe('Bob the Original')
+    expect(bobReloaded.role).toBe('admin')
+  }, 60_000)
+
+  it('honors displayName override when provided', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob the Original',
+      role: 'admin',
+      passphrase: BOB_PHRASE,
+    })
+
+    await recoverUser(store, 'acme', aliceKr, {
+      userId: 'bob',
+      passphrase: TEMP_PHRASE,
+      displayName: 'Bob the Recovered',
+    })
+
+    const bobReloaded = await loadKeyring(store, 'acme', 'bob', TEMP_PHRASE)
+    expect(bobReloaded.displayName).toBe('Bob the Recovered')
+  }, 60_000)
+
+  it('atomic-by-construction: pre-put failure leaves the original keyring intact', async () => {
+    const innerStore = inlineMemory()
+    const aliceKr = await createOwnerKeyring(innerStore, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    await persistKeyring(innerStore, 'acme', aliceKr)
+    await grant(innerStore, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+      passphrase: BOB_PHRASE,
+    })
+
+    // Wrap the store so any put against `_keyring` throws — simulates
+    // a backend write failure mid-recovery. recoverUser executes
+    // load/check/derive/wrap/build before the put; the put is the
+    // only mutation. Throwing here proves the invariant: the original
+    // keyring stays intact, no partial-failure window.
+    const failingStore: NoydbStore = {
+      ...innerStore,
+      put: async (vault: string, coll: string, id: string, env: EncryptedEnvelope) => {
+        if (coll === '_keyring') {
+          throw new Error('simulated backend write failure')
+        }
+        return innerStore.put(vault, coll, id, env)
+      },
+    } as unknown as NoydbStore
+
+    await expect(
+      recoverUser(failingStore, 'acme', aliceKr, { userId: 'bob', passphrase: TEMP_PHRASE }),
+    ).rejects.toThrow('simulated backend write failure')
+
+    // Original keyring still unlocks with the OLD phrase.
+    const bobReloaded = await loadKeyring(innerStore, 'acme', 'bob', BOB_PHRASE)
+    expect(bobReloaded.userId).toBe('bob')
+  }, 60_000)
+})
+
+describe('db.recoverUser (#33 + #34 hub-level integration)', () => {
+  it('runs the peer-recover-user policy gate before the team call', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({
+      store,
+      user: 'alice',
+      secret: ALICE_PHRASE,
+      // Strict policy requires a recovery / TOTP / email-OTP factor proof
+      // for peer-recover-user (per the preset's gate definition).
+      policy: STRICT_POLICY,
+    })
+    await db.openVault('acme')
+    await db.grant('acme', {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+      passphrase: BOB_PHRASE,
+    })
+
+    // Without a factor proof, the gate denies.
+    await expect(
+      db.recoverUser('acme', { userId: 'bob', passphrase: TEMP_PHRASE }),
+    ).rejects.toBeInstanceOf(PolicyDeniedError)
+
+    // With a recovery factor proof, recovery succeeds.
+    await db.recoverUser(
+      'acme',
+      { userId: 'bob', passphrase: TEMP_PHRASE },
+      { factors: [{ kind: 'recovery', mintedAt: new Date().toISOString() }] },
+    )
+
+    const bobReloaded = await loadKeyring(store, 'acme', 'bob', TEMP_PHRASE)
+    expect(bobReloaded.userId).toBe('bob')
+  }, 60_000)
+})

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -398,6 +398,13 @@ export {
 } from './team/recovery.js'
 export type { PaperRecoveryEntry, PaperRecoveryDoc } from './team/recovery.js'
 
+// Peer-recovery — issues #33 + #34 (atomic db.recoverUser primitive).
+// The team/peer-recover module also runs through Noydb.recoverUser for
+// the policy-gated path; consumers can use the lower-level function
+// directly when they don't want hub-level gating (e.g. in tests).
+export { recoverUser } from './team/peer-recover.js'
+export type { RecoverUserOptions } from './team/peer-recover.js'
+
 // Export-capability helpers
 export { hasExportCapability, evaluateExportCapability } from './team/keyring.js'
 export { hasImportCapability, evaluateImportCapability } from './team/keyring.js'

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -27,6 +27,10 @@ import {
   type RecoverPassphraseInput,
 } from './team/rotate-recover.js'
 import {
+  recoverUser as keyringRecoverUser,
+  type RecoverUserOptions,
+} from './team/peer-recover.js'
+import {
   loadPaperRecoveryEntries,
   savePaperRecoveryEntries,
   hasRecoveryEnrolled,
@@ -1401,6 +1405,66 @@ export class Noydb {
     const userId = this.options.user
     const next = await keyringRecoverPassphrase(this.options.store, vault, userId, input)
     this.keyringCache.set(vault, next)
+  }
+
+  /**
+   * Atomic peer-recovery — re-wraps an EXISTING user's keyring under
+   * a fresh temp passphrase in a single store write. Closes #34's
+   * partial-failure window (the previous compose-from-primitives
+   * pattern was `db.revoke + db.grant`, two writes — if the issuer
+   * cancelled between them the target was locked out entirely).
+   *
+   * Different from `db.revoke + db.grant`:
+   *
+   *   - Same `userId`, role, permissions, capabilities preserved.
+   *   - DEKs unchanged → every other principal in the vault keeps
+   *     access. No key rotation.
+   *   - Allows owner→owner natively (#33). The existing
+   *     `db.revoke` retains its block — peer-recovery is a separate,
+   *     intentionally-named operation.
+   *   - Tier-2 slots dropped (they wrap the old KEK).
+   *
+   * Gated by `peer-recover-user`; `STRICT_POLICY` requires a
+   * recovery / TOTP / email-OTP factor proof at the moment of
+   * recovery, so the issuer affirmatively re-asserts identity.
+   *
+   * The recipient should call `db.rotatePassphrase` on first session
+   * to choose their own phrase — the temp acts as a single-use
+   * bridge.
+   *
+   * ```ts
+   * await db.recoverUser('acme', {
+   *   userId: 'bob',
+   *   passphrase: 'temporary-correct-horse-battery-staple-printer',
+   * }, { factors: [{ kind: 'recovery' }] })
+   * // Bob opens createNoydb({ user: 'bob', secret: tempPhrase })
+   * // and immediately calls db.rotatePassphrase to set his own.
+   * ```
+   *
+   * @throws `NoAccessError` when no keyring exists for the target.
+   * @throws `PermissionDeniedError` when the caller's role can't
+   *         recover the target's role (admin→owner is blocked even
+   *         under recovery).
+   * @throws `PrivilegeEscalationError` when the caller lacks a DEK
+   *         the target previously had access to.
+   *
+   * @see #33 #34 — the issues this method closes.
+   */
+  async recoverUser(
+    vault: string,
+    options: RecoverUserOptions,
+    factors?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+  ): Promise<void> {
+    await this.checkGate(vault, 'peer-recover-user', factors)
+    const callerKeyring = await this.getKeyring(vault)
+    await keyringRecoverUser(this.options.store, vault, callerKeyring, options)
+    // If the caller is recovering THEIR OWN keyring (rare but
+    // possible — e.g. a self-recovery flow that bypasses the password
+    // ceremony), the keyringCache entry is now stale. Drop it so the
+    // next access reloads with the fresh wrapping.
+    if (options.userId === this.options.user) {
+      this.keyringCache.delete(vault)
+    }
   }
 
   /**

--- a/packages/hub/src/policy/presets.ts
+++ b/packages/hub/src/policy/presets.ts
@@ -32,6 +32,12 @@ export const PERSONAL_POLICY: VaultPolicy = Object.freeze({
     'rotate-unlock': { minTier: 2 },
     'enroll-user': { minTier: 1 },
     'revoke-user': { minTier: 1 },
+    // Peer-recovery is a high-trust intentional op — co-owners
+    // recovering each other should not need an off-device factor in
+    // the personal/SMB threat model (the partner is already vetted by
+    // virtue of being a co-owner). Tier-1 unlock is the floor; the
+    // STRICT preset adds a recovery/email-OTP requirement.
+    'peer-recover-user': { minTier: 1 },
     'export-bundle': { minTier: 1 },
     'export-plaintext': {
       minTier: 1,
@@ -92,6 +98,15 @@ export const STRICT_POLICY: VaultPolicy = Object.freeze({
     'revoke-user': {
       minTier: 1,
       factors: [{ anyOf: ['totp', 'email-otp'] }],
+    },
+    // STRICT peer-recovery: the issuer must present a recovery code
+    // OR a fresh second factor at the moment of recovery. This binds
+    // the high-trust operation to a verifiable proof (recovery sheet
+    // photographed by an attacker won't suffice — they'd also need
+    // tier-1 unlock first; this gate is the freshness binding on top).
+    'peer-recover-user': {
+      minTier: 1,
+      factors: [{ anyOf: ['recovery', 'totp', 'email-otp'] }],
     },
     'export-bundle': {
       minTier: 1,

--- a/packages/hub/src/policy/types.ts
+++ b/packages/hub/src/policy/types.ts
@@ -77,6 +77,16 @@ export type BuiltInGateName =
   | 'edit-own-profile'
   /** Authorize reading other principals' user envelopes (#22). */
   | 'view-team-profiles'
+  /**
+   * Authorize an atomic peer-recovery — `db.recoverUser` (#33, #34).
+   * Distinct from `revoke-user` because peer-recovery is intentional
+   * re-issuance of someone's keyring under a temp passphrase, NOT
+   * removal. Allows owner→owner natively (matches the threat model:
+   * a co-owner explicitly recovering another co-owner). Ships with a
+   * factor-proof default in `STRICT_POLICY` so the issuer must
+   * affirmatively prove identity at the moment of recovery.
+   */
+  | 'peer-recover-user'
 
 /** Either a built-in gate name or an `app:*` custom gate. */
 export type GateName = BuiltInGateName | `app:${string}`

--- a/packages/hub/src/team/peer-recover.ts
+++ b/packages/hub/src/team/peer-recover.ts
@@ -1,0 +1,197 @@
+/**
+ * Atomic peer-recovery primitive — issues #33 + #34.
+ *
+ * `recoverUser` is a SEPARATE operation from `revoke + grant`. It
+ * exists because peer-recovery has different semantics than account
+ * removal-then-reissue:
+ *
+ *   1. **Same identity preserved.** `userId`, `role`, `permissions`,
+ *      capability bits, user envelope (if any), policy override (if
+ *      any) all survive. Only the wrapping changes.
+ *   2. **No key rotation.** The existing DEKs stay valid — every
+ *      OTHER principal in the vault keeps their access. Rotating
+ *      keys would invalidate every co-user's wrapping.
+ *   3. **Atomic by construction.** A single `store.put` overwrites
+ *      `_keyring/<userId>` with the recovered file. No revoke step
+ *      means no partial-failure window.
+ *   4. **Owner→owner natively allowed.** Two co-owners recovering
+ *      each other is the explicitly-intentional case (a partner
+ *      forgot the master phrase). The existing `canRevoke` rule that
+ *      blocks owner→owner is correct for `revoke` (which is account
+ *      *removal*) and intentionally NOT replicated here. The policy
+ *      gate `peer-recover-user` carries the freshness requirement.
+ *   5. **Tier-2 slots dropped.** The slots wrap the OLD KEK under
+ *      method-derived keys; after recovery the KEK is re-derived
+ *      from the new temp passphrase. Match `rotatePassphrase`'s
+ *      precedent — the recovered user re-enrols slots after picking
+ *      their own phrase.
+ *
+ * Caller must be at least as privileged as the target. The hub
+ * `db.recoverUser` method gates this with the `peer-recover-user`
+ * policy gate (#33's factor-proof requirement); the function below
+ * enforces only the role + anti-privilege-escalation invariants.
+ *
+ * @module
+ */
+import type { NoydbStore, KeyringFile, Role } from '../types.js'
+import { NOYDB_KEYRING_VERSION } from '../types.js'
+import { deriveKey, generateSalt, wrapKey, bufferToBase64 } from '../crypto.js'
+import { NoAccessError, PermissionDeniedError, PrivilegeEscalationError } from '../errors.js'
+import { assertStrongPassphrase, type PassphrasePolicy } from '../validation.js'
+import type { UnlockedKeyring } from './keyring.js'
+
+const ADMIN_RECOVERABLE_TARGETS: readonly Role[] = ['operator', 'viewer', 'client', 'admin']
+
+/**
+ * Whether `callerRole` may recover `targetRole`.
+ *
+ * Differs from `canRevoke` (in `keyring.ts`) in one critical place:
+ * **owner→owner IS allowed**. Peer recovery is the explicitly
+ * intentional case (a co-owner forgot their phrase); the freshness
+ * binding lives in the `peer-recover-user` policy gate, not in the
+ * permission predicate.
+ *
+ * Admins can recover everyone they could grant (operator / viewer /
+ * client / admin) but NOT owners — that boundary stays as a hard
+ * structural rule even under recovery.
+ */
+function canRecover(callerRole: Role, targetRole: Role): boolean {
+  if (callerRole === 'owner') return true
+  if (callerRole === 'admin') return ADMIN_RECOVERABLE_TARGETS.includes(targetRole)
+  return false
+}
+
+/** Input shape for {@link recoverUser}. */
+export interface RecoverUserOptions {
+  /** Target user id whose keyring is being recovered. */
+  readonly userId: string
+  /**
+   * Temporary passphrase under which the new keyring is wrapped.
+   * The recipient should call `db.rotatePassphrase` immediately on
+   * acceptance to choose their own phrase — this temp acts as a
+   * single-use bridge in invite / peer-recovery flows.
+   */
+  readonly passphrase: string
+  /** Override the target's role. Defaults to the existing target's role. */
+  readonly role?: Role
+  /** Override the target's display name. Defaults to existing. */
+  readonly displayName?: string
+  /** Validate phrase strength against the configured policy. */
+  readonly validatePassphrase?: boolean
+  /**
+   * Skip phrase strength validation even when `validatePassphrase` is
+   * set. The escape hatch matches `grant`'s shape — used when the
+   * temp phrase is a high-entropy one-shot string that doesn't need
+   * to satisfy the human-typeable rules.
+   */
+  readonly allowWeakPassphrase?: boolean
+  /**
+   * Optional explicit phrase policy override (passed through to
+   * `assertStrongPassphrase`). Mirrors how `grant` accepts a custom
+   * `PassphrasePolicy` for app-specific tightening.
+   */
+  readonly passphrasePolicy?: PassphrasePolicy
+}
+
+/**
+ * Atomically rewrap the target user's keyring under a fresh temp
+ * passphrase. Single store write; no revoke step; no key rotation.
+ *
+ * Caller's responsibilities (NOT enforced here):
+ *   - Run the `peer-recover-user` policy gate first via
+ *     `Noydb.checkGate` to enforce the freshness factor proof.
+ *   - Communicate the temp passphrase to the recipient via a secure
+ *     channel (URL fragment, in-person, etc.) — the hub does not
+ *     transport secrets.
+ */
+export async function recoverUser(
+  store: NoydbStore,
+  vault: string,
+  callerKeyring: UnlockedKeyring,
+  options: RecoverUserOptions,
+): Promise<void> {
+  // 1. Load the target's existing keyring file (plaintext header).
+  const env = await store.get(vault, '_keyring', options.userId)
+  if (!env) {
+    throw new NoAccessError(
+      `recoverUser: user "${options.userId}" has no keyring in vault "${vault}".`,
+    )
+  }
+  const target = JSON.parse(env._data) as KeyringFile
+  const targetRole = options.role ?? target.role
+
+  // 2. Permission check — caller must be allowed to recover this role.
+  //    Owner→owner natively allowed; admin→admin allowed; admin→owner blocked.
+  if (!canRecover(callerKeyring.role, targetRole)) {
+    throw new PermissionDeniedError(
+      `Role "${callerKeyring.role}" cannot recover role "${targetRole}"`,
+    )
+  }
+  // Also guard against role-uplift via the override — admin cannot
+  // promote a target to owner under cover of recovery.
+  if (!canRecover(callerKeyring.role, target.role)) {
+    throw new PermissionDeniedError(
+      `Role "${callerKeyring.role}" cannot recover role "${target.role}"`,
+    )
+  }
+
+  // 3. Anti-privilege-escalation. Every collection the target had
+  //    access to must be in the caller's DEK set — the recoverer
+  //    cannot give the recovered user access to a collection the
+  //    recoverer themselves can't read. Mirrors `grant()`'s check.
+  for (const coll of Object.keys(target.deks)) {
+    if (!callerKeyring.deks.has(coll)) {
+      throw new PrivilegeEscalationError(coll)
+    }
+  }
+
+  // 4. Optional phrase strength validation (mirrors `grant` opt-in).
+  if (options.validatePassphrase && !options.allowWeakPassphrase) {
+    assertStrongPassphrase(options.passphrase, options.passphrasePolicy)
+  }
+
+  // 5. Mint a fresh salt + KEK from the temp passphrase. The DEKs
+  //    themselves are unchanged — only the wrapping is replaced.
+  const newSalt = generateSalt()
+  const newKek = await deriveKey(options.passphrase, newSalt)
+
+  const wrappedDeks: Record<string, string> = {}
+  for (const coll of Object.keys(target.deks)) {
+    const callerDek = callerKeyring.deks.get(coll)
+    if (!callerDek) {
+      // Already caught by the anti-privilege-escalation loop above.
+      // This branch is defensive belt-and-braces; if it ever fires,
+      // the target had a collection the caller's deks Map disagrees
+      // with — fail loud rather than silently dropping access.
+      throw new PrivilegeEscalationError(coll)
+    }
+    wrappedDeks[coll] = await wrapKey(callerDek, newKek)
+  }
+
+  // 6. Build the recovered keyring file. Identity preserved; wrapping
+  //    refreshed; tier-2 slots dropped (they wrap the OLD KEK and
+  //    can't survive a tier-1 phrase change — same precedent as
+  //    rotatePassphrase).
+  const next: KeyringFile = {
+    ...target,
+    _noydb_keyring: NOYDB_KEYRING_VERSION,
+    role: targetRole,
+    display_name: options.displayName ?? target.display_name,
+    deks: wrappedDeks,
+    salt: bufferToBase64(newSalt),
+    granted_by: callerKeyring.userId,
+    authenticators: [],
+  }
+
+  // 7. Single atomic write — overwrites the existing envelope.
+  //    Backend `put` is the canonical write primitive across every
+  //    `to-*` store; no partial-failure window between revoke + grant.
+  const envelope = {
+    _noydb: 1 as const,
+    _v: 1,
+    _ts: new Date().toISOString(),
+    _iv: '',
+    _data: JSON.stringify(next),
+  }
+  await store.put(vault, '_keyring', options.userId, envelope)
+}


### PR DESCRIPTION
## Summary

New API: `db.recoverUser(vault, { userId, passphrase, role?, displayName? }, factors?)` — atomic peer-recovery primitive.

Closes the partial-failure window of the previous `db.revoke + db.grant` compose-from-primitives pattern. The new primitive is structurally atomic: a single `store.put` overwrites `_keyring/<userId>` with the recovered file. No revoke step, no key rotation; the original keyring stays intact on any pre-write failure.

## Why this is a separate primitive (not a flag on revoke)

Peer-recovery has different semantics than account removal-then-reissue:

- **Same identity preserved** — `userId`, role, permissions, capability bits, user envelope, policy override survive. Only the wrapping changes.
- **No key rotation** — existing DEKs stay valid; every other principal in the vault keeps access. Rotating would invalidate every co-user's wrapping.
- **Owner→owner natively allowed** — peer-recovery is the explicitly-intentional case (a co-owner forgot their phrase). The existing `db.revoke` rule that blocks owner→owner is correct for *removal* and intentionally NOT replicated here. Closes #33.
- **Tier-2 slots dropped** — they wrap the OLD KEK; matches `rotatePassphrase` precedent.

## New policy gate

`peer-recover-user`:
- `PERSONAL_POLICY`: `minTier: 1` (no factor required — the partner is already vetted by virtue of being a co-owner).
- `STRICT_POLICY`: `minTier: 1, factors: anyOf [recovery, totp, email-otp]` — issuer affirmatively re-asserts identity at the moment of recovery.

## Permission rules

- **Owner** can recover any role (including owner). Closes #33.
- **Admin** can recover operator / viewer / client / admin; admin→owner blocked even under recovery.
- **Anti-privilege-escalation** — caller must hold a DEK for every collection the target had access to.
- **Role-uplift guard** — admin can't promote bob to owner under cover of recovery.

## Test plan

11 tests, all passing:

- [x] Round-trip: alice (owner) recovers bob (admin); bob unlocks with temp phrase
- [x] Owner → owner peer-recovery succeeds (closes #33)
- [x] Admin → owner rejected (boundary survives recovery)
- [x] Admin cannot uplift target to owner under cover of recovery
- [x] NoAccessError when target has no keyring
- [x] PrivilegeEscalationError when caller lacks a target collection's DEK
- [x] Tier-2 authenticator slots dropped on recovery
- [x] Identity preserved (userId / displayName / role) when not overridden
- [x] displayName override honored
- [x] **Atomic-by-construction**: pre-`put` failure leaves the original keyring intact (simulated via failing-store wrapper)
- [x] Hub-level `peer-recover-user` gate runs before the team call

### Verification commands

- [x] `pnpm vitest run packages/hub` — 1315 / 1315 pass
- [x] `pnpm vitest run` — 2356 / 2360 pass (+11 from baseline; 4 skipped IDB-perf)
- [x] `pnpm turbo typecheck` — clean
- [x] `pnpm turbo lint` — clean

## Follow-up

**PR2b** (separate): #32 — extend `@noy-db/on-magic-link` with `inviteUser` / `acceptInvite` / `peerRecoverUser` flows that compose `db.recoverUser` with URL-fragment transport, TTL, and single-use semantics.

Closes #33
Closes #34