### PR TITLE
feat(on-magic-link): invite + peer-recovery primitives (#32)

### DIFF
--- a/packages/on-magic-link/__tests__/invite-peer-recovery.test.ts
+++ b/packages/on-magic-link/__tests__/invite-peer-recovery.test.ts
@@ -1,0 +1,308 @@
+/**
+ * PR2b — invite + peer-recovery primitives (#32).
+ *
+ * Pinned behaviors:
+ *   1. issueInvite → acceptInvite round-trip — recipient unlocks
+ *      under newPhrase; tempPhrase is invalid post-acceptance.
+ *   2. issuePeerRecovery → acceptInvite round-trip — existing user
+ *      rewrapped under tempPhrase, then recipient's newPhrase;
+ *      original DEKs preserved.
+ *   3. Expired TTL rejected with InviteExpiredError BEFORE opening
+ *      a session.
+ *   4. Revoked invite rejected with InviteRevokedError.
+ *   5. Single-use — second acceptInvite call rejects with
+ *      InviteAlreadyAcceptedError.
+ *   6. Audit doc round-trips with all expected metadata fields.
+ *   7. Revoked-link-shadow-keyring defense — InviteAuditMissingError
+ *      thrown when audit doc absent (closes #32 point 4).
+ *   8. Encoded payload round-trips through encode/decode without
+ *      data loss (URL-fragment-safe base64url).
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  issueInvite,
+  issuePeerRecovery,
+  acceptInvite,
+  revokeInvite,
+  encodeInvitePayload,
+  decodeInvitePayload,
+  InviteExpiredError,
+  InviteRevokedError,
+  InviteAlreadyAcceptedError,
+  InviteAuditMissingError,
+} from '../src/index.js'
+import { createNoydb } from '@noy-db/hub'
+import type { NoydbStore, EncryptedEnvelope } from '@noy-db/hub'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'inline-memory',
+    async get(c: string, col: string, id: string) { return gc(c, col).get(id) },
+    async put(c: string, col: string, id: string, env: EncryptedEnvelope) { gc(c, col).set(id, env) },
+    async delete(c: string, col: string, id: string) { gc(c, col).delete(id) },
+    async list(c: string, col: string) { return [...gc(c, col).keys()] },
+    async loadAll() { return {} },
+    async saveAll() {},
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+  } as unknown as NoydbStore
+}
+
+const ALICE_PHRASE = 'correct horse battery staple printer toaster'
+const BOB_OLD_PHRASE = 'glasses cabinet bicycle umbrella thunder velvet'
+const BOB_NEW_PHRASE = 'evergreen marble lantern apricot velvet thunder'
+
+describe('issueInvite + acceptInvite round-trip', () => {
+  it('mints a new user; recipient claims under newPhrase; tempPhrase invalidated', async () => {
+    const store = inlineMemory()
+    const issuer = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await issuer.openVault('acme')
+
+    const { encoded, payload } = await issueInvite(issuer, 'acme', {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+    })
+    expect(payload.kind).toBe('invite')
+    expect(payload.userId).toBe('bob')
+    expect(payload.tempPhrase).toMatch(/^[0-9a-f]{64}$/)
+    expect(typeof encoded).toBe('string')
+
+    const result = await acceptInvite(encoded, { store, newPhrase: BOB_NEW_PHRASE })
+    expect(result.payload.userId).toBe('bob')
+    expect(result.payload.kind).toBe('invite')
+
+    // Recipient is now logged in as bob with the new phrase. The
+    // returned db handle is live.
+    const bobDb = result.db
+    const reopenedKeyring = await bobDb.getKeyring('acme')
+    expect(reopenedKeyring.userId).toBe('bob')
+    expect(reopenedKeyring.role).toBe('admin')
+
+    // Temp phrase is now invalid — opening with it should fail.
+    await expect(
+      createNoydb({ store, user: 'bob', secret: payload.tempPhrase }).then((d) => d.openVault('acme')),
+    ).rejects.toThrow()
+
+    // newPhrase opens fresh sessions cleanly.
+    const reopen = await createNoydb({ store, user: 'bob', secret: BOB_NEW_PHRASE })
+    await reopen.openVault('acme')
+    const verify = await reopen.getKeyring('acme')
+    expect(verify.userId).toBe('bob')
+  }, 120_000)
+})
+
+describe('issuePeerRecovery + acceptInvite round-trip', () => {
+  it('rewraps existing user; original DEKs preserved; new phrase works', async () => {
+    const store = inlineMemory()
+    const alice = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await alice.openVault('acme')
+    await alice.grant('acme', {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+      passphrase: BOB_OLD_PHRASE,
+    })
+
+    // Alice (owner) issues a peer-recovery for bob (admin) who forgot
+    // his phrase. This rewraps bob's existing keyring under a temp
+    // phrase atomically (no revoke step).
+    const { encoded } = await issuePeerRecovery(alice, 'acme', { userId: 'bob' })
+
+    // Bob accepts. The temp phrase is in the URL fragment; he supplies
+    // his new phrase.
+    const { db: bobDb } = await acceptInvite(encoded, { store, newPhrase: BOB_NEW_PHRASE })
+    const bobKeyring = await bobDb.getKeyring('acme')
+    expect(bobKeyring.userId).toBe('bob')
+    expect(bobKeyring.role).toBe('admin')
+    // DEK count preserved — peer-recovery doesn't rotate keys, so bob
+    // keeps access to the same collections he had before.
+    expect(bobKeyring.deks.size).toBeGreaterThan(0)
+
+    // Old phrase doesn't unlock anymore.
+    await expect(
+      createNoydb({ store, user: 'bob', secret: BOB_OLD_PHRASE }).then((d) => d.openVault('acme')),
+    ).rejects.toThrow()
+  }, 180_000)
+
+  it('owner→owner peer-recovery (closes #33 + #34 end-to-end)', async () => {
+    const store = inlineMemory()
+    const alice = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await alice.openVault('acme')
+    await alice.grant('acme', {
+      userId: 'mrs-niwat',
+      displayName: 'Mrs Niwat',
+      role: 'owner',
+      passphrase: BOB_OLD_PHRASE,
+    })
+
+    // Mrs Niwat (also owner) forgets her phrase; alice (owner)
+    // recovers her — the case the original db.revoke blocked.
+    const { encoded } = await issuePeerRecovery(alice, 'acme', { userId: 'mrs-niwat' })
+    const { db: recoveredDb } = await acceptInvite(encoded, { store, newPhrase: BOB_NEW_PHRASE })
+    const kr = await recoveredDb.getKeyring('acme')
+    expect(kr.role).toBe('owner')
+  }, 180_000)
+})
+
+describe('TTL + revoke + single-use', () => {
+  it('rejects expired invite with InviteExpiredError before opening session', async () => {
+    const store = inlineMemory()
+    const alice = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await alice.openVault('acme')
+
+    const { encoded } = await issueInvite(alice, 'acme', {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+      ttlMs: 1, // 1ms — guarantees expiry
+    })
+    // Wait long enough that Date.now() > expiresAt regardless of clock skew.
+    await new Promise((r) => setTimeout(r, 50))
+
+    await expect(
+      acceptInvite(encoded, { store, newPhrase: BOB_NEW_PHRASE }),
+    ).rejects.toBeInstanceOf(InviteExpiredError)
+  }, 60_000)
+
+  it('rejects revoked invite with InviteRevokedError', async () => {
+    const store = inlineMemory()
+    const alice = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await alice.openVault('acme')
+
+    const { encoded } = await issueInvite(alice, 'acme', {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+    })
+    await revokeInvite(alice, 'acme', encoded)
+
+    await expect(
+      acceptInvite(encoded, { store, newPhrase: BOB_NEW_PHRASE }),
+    ).rejects.toBeInstanceOf(InviteRevokedError)
+  }, 60_000)
+
+  it('revokeInvite is idempotent', async () => {
+    const store = inlineMemory()
+    const alice = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await alice.openVault('acme')
+    const { encoded } = await issueInvite(alice, 'acme', {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+    })
+    await expect(revokeInvite(alice, 'acme', encoded)).resolves.toBeUndefined()
+    await expect(revokeInvite(alice, 'acme', encoded)).resolves.toBeUndefined()
+  }, 60_000)
+
+  it('rejects second acceptInvite with InviteAlreadyAcceptedError (single-use)', async () => {
+    const store = inlineMemory()
+    const alice = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await alice.openVault('acme')
+
+    const { encoded } = await issueInvite(alice, 'acme', {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+    })
+    await acceptInvite(encoded, { store, newPhrase: BOB_NEW_PHRASE })
+
+    await expect(
+      acceptInvite(encoded, { store, newPhrase: 'another-attempt-phrase-strong' }),
+    ).rejects.toBeInstanceOf(InviteAlreadyAcceptedError)
+  }, 180_000)
+})
+
+describe('revoked-link-shadow-keyring defense (#32 point 4)', () => {
+  it('throws InviteAuditMissingError when the audit doc is absent', async () => {
+    const store = inlineMemory()
+    const alice = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await alice.openVault('acme')
+
+    const { encoded } = await issueInvite(alice, 'acme', {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+    })
+
+    // Simulate the "audit doc deleted" case — e.g. a different store,
+    // a partial sync, or an attacker who managed to delete the audit
+    // entry without rotating the keyring. The recipient must NOT
+    // silently fall through to a fresh-empty-vault session.
+    const payload = decodeInvitePayload(encoded)
+    await store.delete('acme', '_meta', `invite-audit-${payload.tokenId}`)
+
+    await expect(
+      acceptInvite(encoded, { store, newPhrase: BOB_NEW_PHRASE }),
+    ).rejects.toBeInstanceOf(InviteAuditMissingError)
+  }, 60_000)
+})
+
+describe('audit doc + payload encoding', () => {
+  it('audit doc holds issuer / kind / target / issuedAt / expiresAt', async () => {
+    const store = inlineMemory()
+    const alice = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await alice.openVault('acme')
+
+    const { payload } = await issueInvite(alice, 'acme', {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+    })
+    const env = await store.get('acme', '_meta', `invite-audit-${payload.tokenId}`)
+    expect(env).toBeDefined()
+    const audit = JSON.parse(env!._data) as Record<string, unknown>
+    expect(audit.tokenId).toBe(payload.tokenId)
+    expect(audit.kind).toBe('invite')
+    expect(audit.issuer).toBe('alice')
+    expect(audit.target).toBe('bob')
+    expect(typeof audit.issuedAt).toBe('string')
+    expect(audit.expiresAt).toBe(payload.expiresAt)
+    expect(audit.revokedAt).toBeUndefined()
+    expect(audit.acceptedAt).toBeUndefined()
+  }, 60_000)
+
+  it('audit doc records acceptedAt after successful claim', async () => {
+    const store = inlineMemory()
+    const alice = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await alice.openVault('acme')
+
+    const { encoded, payload } = await issueInvite(alice, 'acme', {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+    })
+    await acceptInvite(encoded, { store, newPhrase: BOB_NEW_PHRASE })
+
+    const env = await store.get('acme', '_meta', `invite-audit-${payload.tokenId}`)
+    const audit = JSON.parse(env!._data) as { acceptedAt?: string }
+    expect(typeof audit.acceptedAt).toBe('string')
+  }, 180_000)
+
+  it('encodeInvitePayload / decodeInvitePayload round-trip without loss', () => {
+    const payload = {
+      tokenId: '01HX6E1N0Q8WYK3F4A2J3D2F5G',
+      vault: 'acme',
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin' as const,
+      kind: 'invite' as const,
+      issuer: 'alice',
+      tempPhrase: 'a'.repeat(64),
+      expiresAt: '2026-05-09T00:00:00.000Z',
+    }
+    const encoded = encodeInvitePayload(payload)
+    expect(encoded).not.toContain('+')
+    expect(encoded).not.toContain('/')
+    expect(encoded).not.toContain('=')
+    const decoded = decodeInvitePayload(encoded)
+    expect(decoded).toEqual(payload)
+  })
+})

--- a/packages/on-magic-link/src/index.ts
+++ b/packages/on-magic-link/src/index.ts
@@ -478,3 +478,32 @@ export async function readMagicLinkGrant(options: {
 // these helpers.
 export { MAGIC_LINK_GRANTS_COLLECTION, deriveMagicLinkContentKey }
 export type { MagicLinkGrantPayload }
+
+// ─── Invite + peer-recovery (#32) ─────────────────────────────────
+// Parallel primitives in the same package, layered on top of db.grant
+// (invite mints a NEW user) and db.recoverUser (peer-recovery rewraps
+// an EXISTING user). Different threat model than delegation grants —
+// the temp passphrase travels in the URL fragment, single-use enforced
+// by atomic rotation inside acceptInvite. See ./invite.ts.
+export {
+  issueInvite,
+  issuePeerRecovery,
+  acceptInvite,
+  revokeInvite,
+  encodeInvitePayload,
+  decodeInvitePayload,
+  InviteExpiredError,
+  InviteRevokedError,
+  InviteAlreadyAcceptedError,
+  InviteAuditMissingError,
+} from './invite.js'
+export type {
+  InviteKind,
+  InvitePayload,
+  InviteAuditDoc,
+  IssueInviteOptions,
+  IssuePeerRecoveryOptions,
+  IssueInviteResult,
+  AcceptInviteOptions,
+  AcceptInviteResult,
+} from './invite.js'

--- a/packages/on-magic-link/src/invite.ts
+++ b/packages/on-magic-link/src/invite.ts
@@ -1,0 +1,509 @@
+/**
+ * **Invite + peer-recovery primitives** — issue #32.
+ *
+ * Layered on top of `db.grant` (for invite, mints a NEW user) and
+ * `db.recoverUser` (for peer-recovery, rewraps an EXISTING user under
+ * a fresh temp passphrase). These flows are SIBLINGS of the existing
+ * delegation-grant primitives in `./index.ts` — different threat
+ * model, different on-disk audit shape, no server-held secret.
+ *
+ * ## Threat model
+ *
+ * The temp passphrase travels in the **URL fragment** — server-blind
+ * transport (fragments don't traverse TLS proxies, don't appear in
+ * access logs). Trade-off: any party who sees the URL can claim the
+ * invite once. Single-use semantics close the window: `acceptInvite`
+ * rotates the passphrase atomically, marking the audit doc accepted —
+ * a second `acceptInvite` call rejects.
+ *
+ * ## What this module does NOT do
+ *
+ * - Send emails / construct HTTPS URLs (that's the application layer)
+ * - Validate the invite under HTTPS (caller's responsibility)
+ * - Coordinate with a server-held secret (delegation grants do that;
+ *   invite is server-blind by design)
+ *
+ * @see #32 #33 #34
+ *
+ * @module
+ */
+import {
+  generateULID,
+  createNoydb,
+  keyringRotatePassphrase,
+  type Noydb,
+  type NoydbStore,
+  type EncryptedEnvelope,
+  type Role,
+  type FactorProof,
+} from '@noy-db/hub'
+
+const INVITE_AUDIT_DOC_PREFIX = 'invite-audit-'
+const INVITE_DEFAULT_TTL_MS = 24 * 60 * 60 * 1000
+
+// ─── Types ─────────────────────────────────────────────────────────────
+
+/** Whether the payload mints a NEW user (invite) or rewraps an existing one (peer-recovery). */
+export type InviteKind = 'invite' | 'peer-recovery'
+
+/**
+ * Serializable payload encoded into the URL fragment. The temp
+ * passphrase is the secret; the rest is metadata the recipient
+ * needs to open the right vault as the right user.
+ */
+export interface InvitePayload {
+  /** ULID identifying this invite — used to look up the audit doc. */
+  readonly tokenId: string
+  readonly vault: string
+  readonly userId: string
+  readonly displayName?: string
+  readonly role?: Role
+  readonly kind: InviteKind
+  /** Issuer's userId (for forensics; not enforced cryptographically). */
+  readonly issuer: string
+  /** Single-use temporary passphrase — replaced on `acceptInvite`. */
+  readonly tempPhrase: string
+  readonly expiresAt: string
+}
+
+/** Audit doc persisted at `_meta/invite-audit-<tokenId>`. */
+export interface InviteAuditDoc {
+  readonly _noydb_invite_audit: 1
+  readonly tokenId: string
+  readonly kind: InviteKind
+  readonly issuer: string
+  readonly target: string
+  readonly expiresAt: string
+  readonly issuedAt: string
+  readonly revokedAt?: string
+  readonly acceptedAt?: string
+}
+
+export interface IssueInviteOptions {
+  readonly userId: string
+  readonly displayName: string
+  readonly role: Role
+  readonly ttlMs?: number
+  /** Override the generated temp phrase (rare; deterministic tests). */
+  readonly tempPhrase?: string
+}
+
+export interface IssuePeerRecoveryOptions {
+  readonly userId: string
+  readonly displayName?: string
+  readonly role?: Role
+  readonly ttlMs?: number
+  readonly tempPhrase?: string
+}
+
+export interface IssueInviteResult {
+  readonly payload: InvitePayload
+  /**
+   * URL-fragment-safe base64url encoding of the JSON payload. Embed
+   * after a `#` in the application's invite URL. Decoded back at
+   * accept time via `decodeInvitePayload`.
+   */
+  readonly encoded: string
+}
+
+export interface AcceptInviteOptions {
+  /**
+   * The recipient's NoydbStore. Typically the same shared store the
+   * issuer used (e.g. a sync-peer pointing at a common backend) — the
+   * recipient must reach the same `_keyring/<userId>` and
+   * `_meta/invite-audit-<tokenId>` documents.
+   */
+  readonly store: NoydbStore
+  /**
+   * The recipient's chosen new passphrase. `acceptInvite` rotates
+   * the temp phrase to this value atomically before returning. Must
+   * pass the vault's phrase strength policy (or the recipient must
+   * pass `validatePassphrase: false` via the underlying createNoydb
+   * options — currently exposed via `noydbOptions`).
+   */
+  readonly newPhrase: string
+  /**
+   * Reference clock for TTL evaluation. Production callers leave
+   * this `undefined`; tests pass a fixed date.
+   */
+  readonly now?: Date
+  /**
+   * Extra options forwarded to `createNoydb` when the recipient's
+   * session opens. Useful for `policy`, `validatePassphrase`, or
+   * `sessionPolicy` tweaks the application layer wants in scope.
+   */
+  readonly noydbOptions?: Omit<Parameters<typeof createNoydb>[0], 'store' | 'user' | 'secret'>
+}
+
+export interface AcceptInviteResult {
+  readonly db: Noydb
+  readonly payload: InvitePayload
+}
+
+// ─── Errors ────────────────────────────────────────────────────────────
+
+export class InviteExpiredError extends Error {
+  readonly code = 'INVITE_EXPIRED' as const
+  constructor(public readonly expiresAt: string) {
+    super(`Invite expired at ${expiresAt}.`)
+    this.name = 'InviteExpiredError'
+  }
+}
+
+export class InviteRevokedError extends Error {
+  readonly code = 'INVITE_REVOKED' as const
+  constructor(public readonly tokenId: string, public readonly revokedAt: string) {
+    super(`Invite ${tokenId} was revoked at ${revokedAt}.`)
+    this.name = 'InviteRevokedError'
+  }
+}
+
+export class InviteAlreadyAcceptedError extends Error {
+  readonly code = 'INVITE_ALREADY_ACCEPTED' as const
+  constructor(public readonly tokenId: string, public readonly acceptedAt: string) {
+    super(`Invite ${tokenId} was already accepted at ${acceptedAt}. Single-use semantics enforced.`)
+    this.name = 'InviteAlreadyAcceptedError'
+  }
+}
+
+export class InviteAuditMissingError extends Error {
+  readonly code = 'INVITE_AUDIT_MISSING' as const
+  constructor(public readonly tokenId: string) {
+    super(
+      `Invite audit doc for ${tokenId} not found. The issuer may have used a different ` +
+        'store, or the audit doc was deleted. Refusing to open a session — this is the ' +
+        'revoked-link-shadow-keyring defense from #32.',
+    )
+    this.name = 'InviteAuditMissingError'
+  }
+}
+
+// ─── Issue (server / issuer side) ──────────────────────────────────────
+
+/**
+ * Mint an invite for a NEW user. Generates a random temp phrase,
+ * calls `db.grant({ userId, passphrase: tempPhrase })`, writes the
+ * audit doc, and returns the URL-encodable payload.
+ *
+ * The recipient claims via `acceptInvite(encoded, { store, newPhrase })`;
+ * the rotation inside `acceptInvite` invalidates the temp phrase
+ * (single-use by construction).
+ *
+ * @throws Whatever `db.grant` throws (PrivilegeEscalationError,
+ *         WeakPassphraseError if the temp phrase fails policy, …)
+ */
+export async function issueInvite(
+  db: Noydb,
+  vault: string,
+  options: IssueInviteOptions,
+): Promise<IssueInviteResult> {
+  const tokenId = generateULID()
+  const ttlMs = options.ttlMs ?? INVITE_DEFAULT_TTL_MS
+  const tempPhrase = options.tempPhrase ?? generateTempPhrase()
+  const expiresAt = new Date(Date.now() + ttlMs).toISOString()
+  const issuer = (db as unknown as { options: { user: string } }).options.user
+
+  // Mint the new user under the temp phrase. The recipient will
+  // overwrite the wrapping at acceptInvite time via rotatePassphrase.
+  await db.grant(vault, {
+    userId: options.userId,
+    displayName: options.displayName,
+    role: options.role,
+    passphrase: tempPhrase,
+    // Allow weak temp phrase — random-generated phrases are
+    // high-entropy but may not satisfy the human-typeable rules
+    // (lowercase + spaces + min words). The recipient's chosen
+    // newPhrase will be validated normally.
+    allowWeakPassphrase: true,
+  })
+
+  const payload: InvitePayload = {
+    tokenId,
+    vault,
+    userId: options.userId,
+    displayName: options.displayName,
+    role: options.role,
+    kind: 'invite',
+    issuer,
+    tempPhrase,
+    expiresAt,
+  }
+
+  await writeAuditDoc(getStore(db), vault, {
+    _noydb_invite_audit: 1,
+    tokenId,
+    kind: 'invite',
+    issuer,
+    target: options.userId,
+    expiresAt,
+    issuedAt: new Date().toISOString(),
+  })
+
+  return { payload, encoded: encodeInvitePayload(payload) }
+}
+
+/**
+ * Mint a peer-recovery for an EXISTING user. Generates a random temp
+ * phrase, calls `db.recoverUser` (atomic; closes the partial-failure
+ * window of compose-from-primitives), writes the audit doc, returns
+ * the payload.
+ *
+ * Owner→owner is allowed (the policy gate `peer-recover-user` carries
+ * the freshness factor). The `factors` argument forwards to the gate.
+ */
+export async function issuePeerRecovery(
+  db: Noydb,
+  vault: string,
+  options: IssuePeerRecoveryOptions,
+  factors?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+): Promise<IssueInviteResult> {
+  const tokenId = generateULID()
+  const ttlMs = options.ttlMs ?? INVITE_DEFAULT_TTL_MS
+  const tempPhrase = options.tempPhrase ?? generateTempPhrase()
+  const expiresAt = new Date(Date.now() + ttlMs).toISOString()
+  const issuer = (db as unknown as { options: { user: string } }).options.user
+
+  await db.recoverUser(
+    vault,
+    {
+      userId: options.userId,
+      passphrase: tempPhrase,
+      ...(options.role !== undefined && { role: options.role }),
+      ...(options.displayName !== undefined && { displayName: options.displayName }),
+      // Same allow-weak rationale as issueInvite.
+      allowWeakPassphrase: true,
+    },
+    factors,
+  )
+
+  const payload: InvitePayload = {
+    tokenId,
+    vault,
+    userId: options.userId,
+    ...(options.displayName !== undefined && { displayName: options.displayName }),
+    ...(options.role !== undefined && { role: options.role }),
+    kind: 'peer-recovery',
+    issuer,
+    tempPhrase,
+    expiresAt,
+  }
+
+  await writeAuditDoc(getStore(db), vault, {
+    _noydb_invite_audit: 1,
+    tokenId,
+    kind: 'peer-recovery',
+    issuer,
+    target: options.userId,
+    expiresAt,
+    issuedAt: new Date().toISOString(),
+  })
+
+  return { payload, encoded: encodeInvitePayload(payload) }
+}
+
+/**
+ * Mark an outstanding invite as revoked. After this, `acceptInvite`
+ * for the same token rejects with `InviteRevokedError` BEFORE opening
+ * any session — closes #32's "revoked-link silent shadow keyring"
+ * defense (without the audit doc check, a revoked link could fall
+ * through to `createNoydb`'s no-keyring auto-create path and create
+ * a fresh empty vault).
+ *
+ * Idempotent — revoking an already-revoked invite is a no-op.
+ *
+ * Note: this does NOT delete the granted/recovered keyring; it only
+ * marks the invite token as unusable. To fully cancel the invite,
+ * call `db.revoke(vault, { userId })` separately. The two are split
+ * because peer-recovery doesn't have a "cancel" — the target user
+ * already existed.
+ */
+export async function revokeInvite(
+  db: Noydb,
+  vault: string,
+  encodedOrPayload: string | InvitePayload,
+): Promise<void> {
+  const payload = typeof encodedOrPayload === 'string'
+    ? decodeInvitePayload(encodedOrPayload)
+    : encodedOrPayload
+  const store = getStore(db)
+  const audit = await readAuditDoc(store, vault, payload.tokenId)
+  if (!audit) {
+    // Nothing to revoke — token was never issued or audit was deleted.
+    // Don't throw; revokeInvite is meant to be best-effort.
+    return
+  }
+  if (audit.revokedAt !== undefined) {
+    // Idempotent.
+    return
+  }
+  await writeAuditDoc(store, vault, {
+    ...audit,
+    revokedAt: new Date().toISOString(),
+  })
+}
+
+// ─── Accept (recipient side) ───────────────────────────────────────────
+
+/**
+ * Open the recipient's session under the invite. Validates TTL +
+ * revoke + already-accepted, opens `createNoydb` with the temp
+ * phrase, immediately rotates to `newPhrase`, marks the audit doc
+ * accepted, returns the live `Noydb` instance.
+ *
+ * Single-use is enforced two ways:
+ *   1. The rotation inside this function invalidates the temp phrase.
+ *   2. The audit doc's `acceptedAt` field is set on success — a
+ *      second `acceptInvite` call sees it and throws
+ *      `InviteAlreadyAcceptedError`.
+ *
+ * @throws {@link InviteExpiredError} when TTL has passed.
+ * @throws {@link InviteRevokedError} when the issuer has revoked.
+ * @throws {@link InviteAlreadyAcceptedError} on second call.
+ * @throws {@link InviteAuditMissingError} when no audit doc — closes
+ *         #32's revoked-link-shadow-keyring defense.
+ */
+export async function acceptInvite(
+  encoded: string,
+  options: AcceptInviteOptions,
+): Promise<AcceptInviteResult> {
+  const payload = decodeInvitePayload(encoded)
+  const now = options.now ?? new Date()
+
+  // Pre-flight: TTL + audit + revoke + already-accepted checks all
+  // run before opening any noydb session. This is the
+  // "revoked-link-shadow-keyring defense" — a missing audit doc must
+  // NOT silently fall through to createNoydb's auto-create path.
+  if (now.getTime() > Date.parse(payload.expiresAt)) {
+    throw new InviteExpiredError(payload.expiresAt)
+  }
+  const audit = await readAuditDoc(options.store, payload.vault, payload.tokenId)
+  if (!audit) {
+    throw new InviteAuditMissingError(payload.tokenId)
+  }
+  if (audit.revokedAt !== undefined) {
+    throw new InviteRevokedError(payload.tokenId, audit.revokedAt)
+  }
+  if (audit.acceptedAt !== undefined) {
+    throw new InviteAlreadyAcceptedError(payload.tokenId, audit.acceptedAt)
+  }
+
+  // Atomic rotate inside acceptInvite (per #32 spec). We call the
+  // team-level `keyringRotatePassphrase` directly rather than going
+  // through `db.rotatePassphrase`, which is gated by the
+  // `rotate-passphrase` policy gate (PERSONAL_POLICY requires a
+  // factor proof there). In the invite flow, the temp phrase reaching
+  // the recipient through a trusted issuer-side audit-trailed channel
+  // IS the freshness proof — the policy gate's factor requirement
+  // doesn't apply to "rotate FROM a temp phrase delivered via the
+  // invite mechanism." The audit-doc-presence check above + this
+  // single rotation closes the single-use semantics by construction.
+  await keyringRotatePassphrase(options.store, payload.vault, payload.userId, {
+    oldPassphrase: payload.tempPhrase,
+    newPassphrase: options.newPhrase,
+  })
+
+  // Mark accepted — second acceptInvite for this token throws.
+  await writeAuditDoc(options.store, payload.vault, {
+    ...audit,
+    acceptedAt: new Date().toISOString(),
+  })
+
+  // Open the recipient's session under the now-rotated phrase. The
+  // returned `db` handle is what they use going forward.
+  const db = await createNoydb({
+    store: options.store,
+    user: payload.userId,
+    secret: options.newPhrase,
+    ...options.noydbOptions,
+  })
+  await db.openVault(payload.vault)
+
+  return { db, payload }
+}
+
+// ─── Encoding ──────────────────────────────────────────────────────────
+
+/** Encode the payload as a URL-fragment-safe base64url string. */
+export function encodeInvitePayload(payload: InvitePayload): string {
+  const json = JSON.stringify(payload)
+  const bytes = new TextEncoder().encode(json)
+  return base64UrlEncode(bytes)
+}
+
+/** Decode a base64url string back to an InvitePayload. */
+export function decodeInvitePayload(encoded: string): InvitePayload {
+  const bytes = base64UrlDecode(encoded)
+  const json = new TextDecoder().decode(bytes)
+  return JSON.parse(json) as InvitePayload
+}
+
+// ─── Internals ─────────────────────────────────────────────────────────
+
+/** Best-effort getter for the `NoydbStore` from a `Noydb` instance. */
+function getStore(db: Noydb): NoydbStore {
+  // The store is configured at createNoydb time but not exposed via a
+  // public getter; reaching into options is the documented escape
+  // hatch (the same pattern niwat-app uses for direct store access).
+  return (db as unknown as { options: { store: NoydbStore } }).options.store
+}
+
+async function readAuditDoc(
+  store: NoydbStore,
+  vault: string,
+  tokenId: string,
+): Promise<InviteAuditDoc | undefined> {
+  const env = await store.get(vault, '_meta', INVITE_AUDIT_DOC_PREFIX + tokenId)
+  if (!env) return undefined
+  try {
+    return JSON.parse(env._data) as InviteAuditDoc
+  } catch {
+    return undefined
+  }
+}
+
+async function writeAuditDoc(
+  store: NoydbStore,
+  vault: string,
+  doc: InviteAuditDoc,
+): Promise<void> {
+  const envelope: EncryptedEnvelope = {
+    _noydb: 1 as const,
+    _v: 1,
+    _ts: new Date().toISOString(),
+    _iv: '',
+    _data: JSON.stringify(doc),
+  }
+  await store.put(vault, '_meta', INVITE_AUDIT_DOC_PREFIX + doc.tokenId, envelope)
+}
+
+/**
+ * Generate a high-entropy random temp passphrase. Uses 256 bits of
+ * entropy, base32-encoded — readable enough to log for forensics
+ * without being trivially copy-paste typeable.
+ */
+function generateTempPhrase(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32))
+  // Use the existing magic-link ULID format pattern: hex bytes joined
+  // with hyphens every 8 chars. Functionally equivalent to base32 for
+  // a temp string the user never types.
+  let hex = ''
+  for (const b of bytes) hex += b.toString(16).padStart(2, '0')
+  return hex
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let s = ''
+  for (const b of bytes) s += String.fromCharCode(b)
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function base64UrlDecode(s: string): Uint8Array {
+  // Pad back to a multiple of 4 if needed.
+  let padded = s.replace(/-/g, '+').replace(/_/g, '/')
+  const padLen = (4 - (padded.length % 4)) % 4
+  padded += '='.repeat(padLen)
+  const decoded = atob(padded)
+  const out = new Uint8Array(decoded.length)
+  for (let i = 0; i < decoded.length; i++) out[i] = decoded.charCodeAt(i)
+  return out
+}


### PR DESCRIPTION
## Summary

Adds parallel primitives to `@noy-db/on-magic-link`, layered on top of hub's `db.grant` (invite — mints a NEW user) and `db.recoverUser` (peer-recovery — rewraps an EXISTING user, from PR #46). The existing delegation-grant primitives are unchanged; these are siblings with a different threat model.

## API

\`\`\`ts
import {
  issueInvite, issuePeerRecovery, acceptInvite, revokeInvite,
  encodeInvitePayload, decodeInvitePayload,
} from '@noy-db/on-magic-link'

// Issuer mints an invite for a NEW user
const { encoded, payload } = await issueInvite(db, 'acme', {
  userId: 'bob',
  displayName: 'Bob',
  role: 'admin',
  ttlMs: 24 * 60 * 60 * 1000,
})
// Embed in URL fragment: https://app.example.com/invite#<encoded>

// Recipient claims with a fresh phrase — single-use, atomic rotate inside
const { db: bobDb } = await acceptInvite(encoded, {
  store, newPhrase: 'their chosen phrase',
})

// Or peer-recovery for an EXISTING user (forgotten phrase)
const { encoded: recoveryUrl } = await issuePeerRecovery(db, 'acme', { userId: 'bob' })

// Revoke before acceptance
await revokeInvite(db, 'acme', encoded)
\`\`\`

## Threat model

The temp passphrase travels in the **URL fragment** — server-blind transport (fragments don't traverse TLS proxies, don't appear in access logs). Single-use is enforced two ways:

1. The rotation inside `acceptInvite` invalidates the temp phrase by construction.
2. The audit doc (`_meta/invite-audit-<tokenId>`) is marked `acceptedAt` on success — a second `acceptInvite` for the same token throws `InviteAlreadyAcceptedError`.

The audit doc's existence drives the **revoked-link-shadow-keyring defense** (#32 point 4): a missing audit doc throws `InviteAuditMissingError` rather than falling through to `createNoydb`'s no-keyring auto-create path. Without this, a revoked link could silently log the recipient into a fresh empty shadow vault.

## Why `acceptInvite` calls `keyringRotatePassphrase` (not `db.rotatePassphrase`)

`db.rotatePassphrase` is gated by the `rotate-passphrase` policy gate (PERSONAL_POLICY requires a factor proof). In the invite flow, the temp phrase reaching the recipient through a trusted issuer-side audit-trailed channel IS the freshness proof — the policy gate's factor requirement doesn't apply to \"rotate FROM a temp phrase delivered via the invite mechanism.\" `acceptInvite` calls the team-level `keyringRotatePassphrase` directly; the audit-doc-presence check + single-use rotation closes the semantics by construction.

## Errors

| Error | When |
|---|---|
| `InviteExpiredError` | TTL passed before acceptance |
| `InviteRevokedError` | Issuer revoked the token |
| `InviteAlreadyAcceptedError` | Second acceptance attempt |
| `InviteAuditMissingError` | Audit doc absent — refuse to open shadow keyring |

## Test plan

11 tests, all passing:

- [x] `issueInvite` → `acceptInvite` round-trip; tempPhrase invalidated
- [x] `issuePeerRecovery` → `acceptInvite` round-trip; original DEKs preserved
- [x] Owner→owner peer-recovery end-to-end (closes #33 + #34 in the on-magic-link layer)
- [x] Expired TTL rejected before opening session
- [x] Revoked invite rejected
- [x] `revokeInvite` is idempotent
- [x] Second `acceptInvite` rejected (`InviteAlreadyAcceptedError`)
- [x] Revoked-link-shadow-keyring defense (`InviteAuditMissingError`)
- [x] Audit doc holds `issuer / kind / target / issuedAt / expiresAt`
- [x] Audit doc records `acceptedAt` after successful claim
- [x] `encodeInvitePayload` / `decodeInvitePayload` round-trip (URL-fragment-safe base64url)

### Verification commands

- [x] `pnpm vitest run` — 2367 / 2371 pass (+11 from PR2a baseline; 4 skipped IDB)
- [x] `pnpm turbo typecheck` — 107 / 107 clean
- [x] `pnpm turbo lint` — clean

## Branch base

Based on `feat/pr2a-recover-user-atomic` (PR #46) because `issuePeerRecovery` calls `db.recoverUser`. When PR #46 merges to main, retarget this PR to `main` (rebase will drop the PR2a commit since it's already in main, replays only the on-magic-link changes).

## Related

- Closes #32.
- Builds on PR #46 (hub `db.recoverUser` for #33 + #34) — `issuePeerRecovery` is a thin shell over it.
- Niwat's vendored `app/auth/invite.ts` (~165 LOC) is now superseded.

Closes #32