### PR TITLE
feat(hub): extend FactorKind + PassphrasePolicy escape hatches (#30, #31)

### DIFF
--- a/packages/hub/__tests__/pr3-policy-extensions.test.ts
+++ b/packages/hub/__tests__/pr3-policy-extensions.test.ts
@@ -1,0 +1,210 @@
+/**
+ * PR3 — FactorKind extension (#30) + PassphrasePolicy escape hatches (#31).
+ *
+ * Pinned behaviors:
+ *
+ * #30 — FactorKind:
+ *   - The new kinds (`webauthn-platform`, `password`, `pin`) are
+ *     accepted by `FactorRequirement.anyOf` and `FactorProof.kind`.
+ *   - PERSONAL_POLICY's `rotate-passphrase` accepts ALL kinds (the
+ *     "any second factor I have wired" semantics).
+ *   - STRICT_POLICY's `peer-recover-user` accepts only off-device
+ *     kinds (recovery / TOTP / email-OTP / roaming WebAuthn) — the
+ *     platform-bound kinds are intentionally excluded under STRICT
+ *     because they don't survive device theft.
+ *
+ * #31 — PassphrasePolicy escape hatches:
+ *   - Default behavior unchanged (lowercase-letters-and-spaces only).
+ *   - `pattern` override accepts digits / uppercase / non-Latin
+ *     scripts but other structural rules still apply.
+ *   - `customValidator` replaces the entire decision tree.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  PERSONAL_POLICY,
+  STRICT_POLICY,
+  type FactorKind,
+  type FactorProof,
+} from '../src/policy/index.js'
+import {
+  validatePassphrase,
+  assertStrongPassphrase,
+  WeakPassphraseError,
+  type PassphraseValidationResult,
+} from '../src/validation.js'
+
+describe('FactorKind extension (#30)', () => {
+  it('TypeScript accepts the three new kinds in FactorProof.kind', () => {
+    const proofs: FactorProof[] = [
+      { kind: 'webauthn-platform', mintedAt: new Date().toISOString() },
+      { kind: 'password', mintedAt: new Date().toISOString() },
+      { kind: 'pin', mintedAt: new Date().toISOString() },
+    ]
+    expect(proofs).toHaveLength(3)
+  })
+
+  it('preserves the original five kinds (no breakage)', () => {
+    const original: FactorKind[] = ['totp', 'email-otp', 'recovery', 'shamir', 'webauthn-roaming']
+    expect(original).toHaveLength(5)
+  })
+
+  it('PERSONAL_POLICY rotate-passphrase accepts ALL kinds (closes #30 default)', () => {
+    const gate = PERSONAL_POLICY.gates['rotate-passphrase']
+    expect(gate?.factors).toBeDefined()
+    const accepted = new Set(gate!.factors![0]!.anyOf)
+    // All 8 kinds present.
+    expect(accepted.has('totp')).toBe(true)
+    expect(accepted.has('email-otp')).toBe(true)
+    expect(accepted.has('recovery')).toBe(true)
+    expect(accepted.has('webauthn-roaming')).toBe(true)
+    expect(accepted.has('webauthn-platform')).toBe(true)
+    expect(accepted.has('password')).toBe(true)
+    expect(accepted.has('pin')).toBe(true)
+  })
+
+  it('STRICT_POLICY peer-recover-user excludes platform-bound kinds (off-device requirement)', () => {
+    const gate = STRICT_POLICY.gates['peer-recover-user']
+    expect(gate?.factors).toBeDefined()
+    const accepted = new Set(gate!.factors![0]!.anyOf)
+    // Off-device kinds accepted.
+    expect(accepted.has('recovery')).toBe(true)
+    expect(accepted.has('totp')).toBe(true)
+    expect(accepted.has('email-otp')).toBe(true)
+    expect(accepted.has('webauthn-roaming')).toBe(true)
+    // Platform-bound kinds NOT accepted under STRICT.
+    expect(accepted.has('webauthn-platform')).toBe(false)
+    expect(accepted.has('password')).toBe(false)
+    expect(accepted.has('pin')).toBe(false)
+  })
+})
+
+describe('PassphrasePolicy escape hatches (#31)', () => {
+  describe('default behavior unchanged', () => {
+    it('accepts the canonical 6-lowercase-words phrase', () => {
+      const r = validatePassphrase('correct horse battery staple printer toaster')
+      expect(r.ok).toBe(true)
+    })
+
+    it('rejects digits by default', () => {
+      const r = validatePassphrase('correct horse battery staple printer 2026')
+      expect(r.ok).toBe(false)
+      if (!r.ok) expect(r.reason).toBe('invalid-chars')
+    })
+
+    it('rejects uppercase by default', () => {
+      const r = validatePassphrase('Correct horse battery staple printer toaster')
+      expect(r.ok).toBe(false)
+      if (!r.ok) expect(r.reason).toBe('invalid-chars')
+    })
+  })
+
+  describe('pattern override (looser char class, tighter structure)', () => {
+    it('accepts digits when pattern allows them', () => {
+      const r = validatePassphrase('correct horse battery staple printer 2026', {
+        pattern: /^[a-z0-9]+( [a-z0-9]+)*$/,
+      })
+      expect(r.ok).toBe(true)
+    })
+
+    it('accepts uppercase when pattern allows it', () => {
+      const r = validatePassphrase('Correct Horse Battery Staple Printer Toaster', {
+        pattern: /^[A-Za-z]+( [A-Za-z]+)*$/,
+      })
+      expect(r.ok).toBe(true)
+    })
+
+    it('accepts Thai script when pattern uses Unicode property classes', () => {
+      // 6 Thai words, each ≥ 3 code points (default minWordLength).
+      // Thai requires both \p{L} (consonants/independent vowels) AND
+      // \p{M} (combining marks: vowel signs, tone marks). The pattern
+      // class [\p{L}\p{M}] captures complete Thai grapheme clusters.
+      const phrase = 'สวัสดี ทุกคน ขอบคุณ ครอบครัว ตำรวจ โรงเรียน'
+      const r = validatePassphrase(phrase, {
+        pattern: /^[\p{L}\p{M}]+( [\p{L}\p{M}]+)*$/u,
+      })
+      expect(r.ok).toBe(true)
+    })
+
+    it('still applies min-words even with permissive pattern', () => {
+      const r = validatePassphrase('correct horse 2026', {
+        pattern: /^[a-z0-9]+( [a-z0-9]+)*$/,
+      })
+      expect(r.ok).toBe(false)
+      if (!r.ok) expect(r.reason).toBe('too-few-words')
+    })
+
+    it('still applies min-word-length', () => {
+      const r = validatePassphrase('a b c d e f', {
+        pattern: /^[a-z]+( [a-z]+)*$/,
+      })
+      expect(r.ok).toBe(false)
+      if (!r.ok) expect(r.reason).toBe('word-too-short')
+    })
+
+    it('still applies repeated-adjacent', () => {
+      const r = validatePassphrase('correct correct battery staple printer toaster', {
+        pattern: /^[a-z]+( [a-z]+)*$/,
+      })
+      expect(r.ok).toBe(false)
+      if (!r.ok) expect(r.reason).toBe('repeated-adjacent')
+    })
+
+    it('still applies leading/trailing space and double-space rules', () => {
+      const lt = validatePassphrase(' correct horse battery staple printer toaster', {
+        pattern: /^[a-z]+( [a-z]+)*$/,
+      })
+      expect(lt.ok).toBe(false)
+      if (!lt.ok) expect(lt.reason).toBe('leading-or-trailing-space')
+
+      const ds = validatePassphrase('correct  horse battery staple printer toaster', {
+        pattern: /^[a-z]+( [a-z]+)*$/,
+      })
+      expect(ds.ok).toBe(false)
+      if (!ds.ok) expect(ds.reason).toBe('double-space')
+    })
+  })
+
+  describe('customValidator (replace everything)', () => {
+    it('takes over completely — none of the default rules run', () => {
+      // A custom validator that accepts ANYTHING non-empty.
+      const customValidator = (phrase: string): PassphraseValidationResult =>
+        phrase.length > 0 ? { ok: true, words: 1 } : { ok: false, reason: 'empty' }
+      // This phrase fails default rules (uppercase, digits, double space)
+      // but the custom validator accepts it.
+      const r = validatePassphrase('My-PASSWORD-2026', { customValidator })
+      expect(r.ok).toBe(true)
+    })
+
+    it('can REJECT a phrase the default would accept', () => {
+      // Custom validator demands the phrase contain a digit.
+      const customValidator = (phrase: string): PassphraseValidationResult =>
+        /[0-9]/.test(phrase)
+          ? { ok: true, words: phrase.split(' ').length }
+          : { ok: false, reason: 'invalid-chars' }
+      // The canonical 6-lowercase phrase has no digit — would normally pass,
+      // but the custom rule rejects it.
+      const r = validatePassphrase('correct horse battery staple printer toaster', { customValidator })
+      expect(r.ok).toBe(false)
+    })
+
+    it('flows through assertStrongPassphrase — custom rejection throws WeakPassphraseError', () => {
+      const customValidator = (): PassphraseValidationResult => ({
+        ok: false,
+        reason: 'invalid-chars',
+      })
+      expect(() =>
+        assertStrongPassphrase('anything-at-all', { customValidator }),
+      ).toThrow(WeakPassphraseError)
+    })
+
+    it('customValidator wins over pattern when both supplied (escape hatches don\'t compose)', () => {
+      const customValidator = (): PassphraseValidationResult => ({ ok: true, words: 1 })
+      // pattern would reject digits; customValidator accepts. customValidator wins.
+      const r = validatePassphrase('this 9000 should normally fail', {
+        pattern: /^[a-z]+( [a-z]+)*$/,
+        customValidator,
+      })
+      expect(r.ok).toBe(true)
+    })
+  })
+})

--- a/packages/hub/src/policy/presets.ts
+++ b/packages/hub/src/policy/presets.ts
@@ -21,7 +21,19 @@ export const PERSONAL_POLICY: VaultPolicy = Object.freeze({
   gates: {
     'rotate-passphrase': {
       minTier: 1,
-      factors: [{ anyOf: ['totp', 'email-otp', 'recovery'] }],
+      // Any second factor satisfies the gate — off-device kinds (TOTP,
+      // email-OTP, paper recovery, roaming WebAuthn) are the strongest;
+      // platform-bound kinds (platform WebAuthn, password, PIN) are
+      // accepted because requiring "something off-device" is overkill
+      // for personal/SMB threat models. Consumers needing the off-device
+      // guarantee should use STRICT_POLICY or override this gate.
+      factors: [{
+        anyOf: [
+          'totp', 'email-otp', 'recovery',
+          'webauthn-roaming', 'webauthn-platform',
+          'password', 'pin',
+        ],
+      }],
     },
     'recover-passphrase': {
       minTier: 1,
@@ -100,13 +112,17 @@ export const STRICT_POLICY: VaultPolicy = Object.freeze({
       factors: [{ anyOf: ['totp', 'email-otp'] }],
     },
     // STRICT peer-recovery: the issuer must present a recovery code
-    // OR a fresh second factor at the moment of recovery. This binds
-    // the high-trust operation to a verifiable proof (recovery sheet
-    // photographed by an attacker won't suffice — they'd also need
-    // tier-1 unlock first; this gate is the freshness binding on top).
+    // OR a fresh off-device second factor at the moment of recovery.
+    // This binds the high-trust operation to a verifiable proof
+    // (recovery sheet photographed by an attacker won't suffice —
+    // they'd also need tier-1 unlock first; this gate is the freshness
+    // binding on top). Roaming WebAuthn (YubiKey-class hardware key)
+    // accepted; platform-bound kinds (Touch ID, password, PIN)
+    // intentionally excluded under STRICT because they don't survive
+    // device theft — the off-device requirement is the whole point.
     'peer-recover-user': {
       minTier: 1,
-      factors: [{ anyOf: ['recovery', 'totp', 'email-otp'] }],
+      factors: [{ anyOf: ['recovery', 'totp', 'email-otp', 'webauthn-roaming'] }],
     },
     'export-bundle': {
       minTier: 1,

--- a/packages/hub/src/policy/types.ts
+++ b/packages/hub/src/policy/types.ts
@@ -13,13 +13,43 @@
  */
 import type { PassphrasePolicy } from '../validation.js'
 
-/** A single off-device factor surface — the proof an actor presents at gate time. */
+/**
+ * A single factor surface — the proof an actor presents at gate time.
+ *
+ * | Kind | Source | Off-device? |
+ * |---|---|---|
+ * | `totp` | RFC 6238 authenticator app (Google Auth, 1Password) | yes |
+ * | `email-otp` | one-time code mailed to the user | yes |
+ * | `recovery` | printable Base32 code (`@noy-db/on-recovery`) | yes (paper) |
+ * | `shamir` | k-of-n threshold share (`@noy-db/on-shamir`) | yes |
+ * | `webauthn-roaming` | hardware key (YubiKey, SoloKey, Titan) | yes (key portable) |
+ * | `webauthn-platform` | platform passkey (Touch ID, Face ID, Hello) | no (device-bound) |
+ * | `password` | tier-2 daily password (`@noy-db/on-password`) | no |
+ * | `pin` | tier-3 quick-resume PIN (`@noy-db/on-pin`) | no |
+ *
+ * Off-device kinds (TOTP, email-OTP, recovery, shamir, roaming WebAuthn)
+ * are the strongest factor proofs because they require something
+ * separate from the device the user just unlocked. Platform / password /
+ * PIN are useful for "fresh proof of *this* user" but don't bind across
+ * devices — policies can require ANY of them or insist on a count of 2
+ * to force a mix.
+ *
+ * Added in pre.8 (#30): `webauthn-platform`, `password`, `pin` —
+ * previously consumers with no off-device infrastructure (no TOTP,
+ * no email-OTP, paper recovery not enrolled) had to disable the
+ * factor requirement entirely on `rotate-passphrase`. Now they can
+ * pin "any second factor I have wired" without losing the freshness
+ * guarantee.
+ */
 export type FactorKind =
   | 'totp'
   | 'email-otp'
   | 'recovery'
   | 'shamir'
   | 'webauthn-roaming'
+  | 'webauthn-platform'
+  | 'password'
+  | 'pin'
 
 /**
  * One factor requirement entry. The default is "any one of the listed

--- a/packages/hub/src/validation.ts
+++ b/packages/hub/src/validation.ts
@@ -38,6 +38,49 @@ export interface PassphrasePolicy {
   readonly minWordLength?: number
   /** Reject adjacent identical words ("the the"). Default true. */
   readonly rejectRepeatedAdjacent?: boolean
+  /**
+   * Override the default character-class rule (`/^[a-z]+( [a-z]+)*$/`).
+   *
+   * The hub's strict default is lowercase-letters-and-single-spaces
+   * because that's what the EFF wordlist generator emits and what
+   * most attacker password lists are keyed on. Use this knob to allow
+   * digits, uppercase, hyphens, or non-Latin scripts when the
+   * consumer's audience needs them — e.g.:
+   *
+   * ```ts
+   * // Thai + English mix with digits permitted
+   * pattern: /^[\p{L}0-9 ]+( [\p{L}0-9 ]+)*$/u
+   *
+   * // Allow uppercase + hyphens (passphrase-with-hyphens style)
+   * pattern: /^[A-Za-z]+([- ][A-Za-z]+)*$/
+   * ```
+   *
+   * The OTHER structural rules still apply (min-words split by space,
+   * min-word-length, repeated-adjacent, leading/trailing whitespace,
+   * double-space). For non-space-delimited word semantics, use
+   * {@link customValidator} instead.
+   *
+   * Added in pre.8 (#31).
+   */
+  readonly pattern?: RegExp
+  /**
+   * Replace ALL validation entirely with a custom function. When set,
+   * none of the other PassphrasePolicy fields apply — the consumer
+   * owns every rule (word splitting, character classes, entropy
+   * thresholds, allowlist/denylist). Use sparingly; this is the
+   * escape hatch for domain-specific phrase formats:
+   *
+   *   - Localized wordlists with non-space word boundaries
+   *   - BIP-39 seed phrases (24 words, fixed wordlist, etc.)
+   *   - Organization-specific HR password policies
+   *
+   * The returned `PassphraseValidationResult` is what
+   * {@link assertStrongPassphrase} dispatches on — `ok: true` accepts;
+   * `ok: false` throws `WeakPassphraseError` with the supplied reason.
+   *
+   * Added in pre.8 (#31).
+   */
+  readonly customValidator?: (phrase: string) => PassphraseValidationResult
 }
 
 /** Result of a check. Discriminated union — compile-time exhaustive. */
@@ -90,6 +133,13 @@ export function validatePassphrase(
   s: string,
   opts?: PassphrasePolicy,
 ): PassphraseValidationResult {
+  // Escape hatch: customValidator owns the entire decision. None of
+  // the structural rules below run when this is set — the consumer is
+  // responsible for the full validation contract.
+  if (opts?.customValidator) {
+    return opts.customValidator(s)
+  }
+
   const minWords = opts?.minWords ?? DEFAULT_MIN_WORDS
   const minWordLength = opts?.minWordLength ?? DEFAULT_MIN_WORD_LENGTH
   const rejectRepeated = opts?.rejectRepeatedAdjacent ?? true
@@ -106,7 +156,13 @@ export function validatePassphrase(
     return { ok: false, reason: 'double-space' }
   }
 
-  if (!/^[a-z]+( [a-z]+)*$/.test(s)) {
+  // The default character class is lowercase-letters-and-spaces;
+  // consumers can override via PassphrasePolicy.pattern (e.g. to
+  // allow digits, uppercase, or non-Latin scripts). Word splitting
+  // below remains space-based — for non-space word semantics the
+  // consumer should use customValidator instead.
+  const charPattern = opts?.pattern ?? /^[a-z]+( [a-z]+)*$/
+  if (!charPattern.test(s)) {
     return { ok: false, reason: 'invalid-chars' }
   }
 


### PR DESCRIPTION
## Summary

Two small additive policy extensions, both no-behavior-change for existing consumers.

### #30 — FactorKind extension

Adds three new factor kinds to the policy DSL: `webauthn-platform` (Touch ID / Face ID / Windows Hello), `password` (`@noy-db/on-password` tier-2), `pin` (`@noy-db/on-pin` tier-3).

Preset updates:

- **PERSONAL_POLICY `rotate-passphrase`** accepts ALL kinds. Previously consumers without TOTP / email-OTP / paper recovery had to override the gate to drop factor enforcement entirely (Niwat documented this in `app/auth/policy.ts`). Now they can pin a real factor — biometric, password, PIN — without losing the freshness guarantee.
- **STRICT_POLICY `peer-recover-user`** adds `webauthn-roaming` (off-device, fits STRICT semantics). Platform-bound kinds intentionally excluded under STRICT because they don't survive device theft.

### #31 — PassphrasePolicy escape hatches

```ts
interface PassphrasePolicy {
  // existing knobs unchanged...
  pattern?: RegExp                                              // NEW
  customValidator?: (phrase) => PassphraseValidationResult       // NEW
}
```

`pattern` overrides the default lowercase-letters-and-spaces character class. Other structural rules (min-words, min-word-length, repeated-adjacent, leading/trailing whitespace, double-space) still apply.

`customValidator` replaces the entire decision tree — escape hatch for BIP-39 seed phrases, organization-specific HR password policies, non-space word boundaries.

Unblocks Thai/EN-mixed phrases (`/^[\p{L}\p{M}]+( [\p{L}\p{M}]+)*$/u`), digit-rich phrases, hyphenated styles. Niwat's existing `allowWeakPassphrase: true` workaround can be retired in favor of these scoped escape hatches.

## Test plan

18 tests in `packages/hub/__tests__/pr3-policy-extensions.test.ts`:

- [x] 4 FactorKind tests — type-level + preset shape (including STRICT exclusion of platform-bound kinds)
- [x] 14 PassphrasePolicy tests — defaults / pattern (digits / uppercase / Thai / structural rules) / customValidator (replace / reject / flow through assert / wins over pattern)

### Verification

- [x] 1333 / 1333 hub tests pass (+18 from PR2a baseline)
- [x] Typecheck: clean (107 / 107 targets)
- [x] Lint: clean

## Branch base

Based on `feat/pr2a-recover-user-atomic` (PR #46) so the STRICT preset can extend `peer-recover-user`'s factors. When PR #46 merges, retarget to `main`.

## Follow-up: STRICT defaults can tighten further once #29 lands

PR #46 + this PR establish the factor-kind vocabulary. Once #29 (preserve tier-2 slots across rotatePassphrase, PR5) lands, the STRICT `rotate-passphrase` preset can be re-evaluated — currently requires 2-of `[totp, email-otp, recovery]`; could optionally accept `webauthn-roaming` as one of the two.

Closes #30
Closes #31