### PR TITLE
feat(hub): auto-rotate remaining recovery codes on db.recoverPassphrase (#36)

### DIFF
--- a/packages/hub/__tests__/pr4-auto-rotate-recovery-codes.test.ts
+++ b/packages/hub/__tests__/pr4-auto-rotate-recovery-codes.test.ts
@@ -1,0 +1,219 @@
+/**
+ * PR4 — auto-rotate remaining recovery codes (#36).
+ *
+ * After a successful paper-recovery, the hub-level
+ * `db.recoverPassphrase` defaults to replacing ALL remaining recovery
+ * entries with freshly-minted ones. This closes the window where a
+ * leaked-or-stolen recovery sheet has 7 still-valid codes after the
+ * user reset their phrase.
+ *
+ * Pinned behaviors:
+ *   1. Default auto-rotation — uses 1 of 8 codes; remaining 7 are
+ *      replaced; `newCodes` array of length 7 returned.
+ *   2. Old remaining codes are invalid post-rotation — the original 7
+ *      codes that the user did NOT consume can no longer recover.
+ *   3. New codes round-trip — using one of the `newCodes` works for
+ *      a subsequent `db.recoverPassphrase`.
+ *   4. Opt-out — `rotateRemainingCodes: false` preserves the
+ *      previous behavior (only the matched code burned).
+ *   5. Custom code count — `newCodeCount: 10` mints exactly 10 codes
+ *      regardless of remaining-count.
+ *   6. Custom generator — `codeGenerator` callback overrides the
+ *      default ULID format.
+ *   7. Empty case — single-code enrollment + recovery returns empty
+ *      `newCodes` (nothing to rotate).
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope } from '../src/types.js'
+import { createNoydb, type Noydb } from '../src/noydb.js'
+import { generateULID, mintPaperRecoveryEntry, loadPaperRecoveryEntries, type PaperRecoveryEntry } from '../src/index.js'
+import { InvalidKeyError } from '../src/errors.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'inline-memory',
+    async get(c: string, col: string, id: string) { return gc(c, col).get(id) },
+    async put(c: string, col: string, id: string, env: EncryptedEnvelope) { gc(c, col).set(id, env) },
+    async delete(c: string, col: string, id: string) { gc(c, col).delete(id) },
+    async list(c: string, col: string) { return [...gc(c, col).keys()] },
+    async loadAll() { return {} },
+    async saveAll() {},
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+  } as unknown as NoydbStore
+}
+
+const ALICE_PHRASE = 'correct horse battery staple printer toaster'
+const PHRASE_AFTER_RECOVERY_1 = 'glasses cabinet bicycle umbrella thunder velvet'
+const PHRASE_AFTER_RECOVERY_2 = 'evergreen marble lantern apricot velvet thunder'
+
+/** Helper: enroll N recovery codes for the current keyring. */
+async function enrollCodes(db: Noydb, vault: string, count: number, codePrefix: string): Promise<string[]> {
+  const keyring = await db.getKeyring(vault)
+  const codes: string[] = []
+  const entries: PaperRecoveryEntry[] = []
+  for (let i = 0; i < count; i++) {
+    const code = `${codePrefix}${i.toString().padStart(3, '0')}AAAAAAA`.toUpperCase()
+    codes.push(code)
+    entries.push(await mintPaperRecoveryEntry(keyring.deks, code, `${codePrefix}-${i}`))
+  }
+  await db.enrollRecovery(vault, { profile: 'paper', entries })
+  return codes
+}
+
+describe('db.recoverPassphrase auto-rotate (#36)', () => {
+  it('default: rotates 7 remaining codes after consuming 1 of 8', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await db.openVault('acme')
+    const enrolled = await enrollCodes(db, 'acme', 8, 'CODEA')
+
+    const result = await db.recoverPassphrase('acme', {
+      newPassphrase: PHRASE_AFTER_RECOVERY_1,
+      recoveryProof: { profile: 'paper', payload: { code: enrolled[0]! } },
+    })
+
+    expect(result.newCodes).toHaveLength(7)
+    // Newly minted entries are persisted (the post-burn entries are replaced).
+    const post = await loadPaperRecoveryEntries(store, 'acme')
+    expect(post).toHaveLength(7)
+  }, 120_000)
+
+  it('original remaining codes are invalid after rotation', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await db.openVault('acme')
+    const enrolled = await enrollCodes(db, 'acme', 4, 'CODEB')
+
+    await db.recoverPassphrase('acme', {
+      newPassphrase: PHRASE_AFTER_RECOVERY_1,
+      recoveryProof: { profile: 'paper', payload: { code: enrolled[0]! } },
+    })
+
+    // Trying to use enrolled[1] (an ORIGINAL remaining code) now fails —
+    // it was wiped by auto-rotation.
+    const reopen = await createNoydb({ store, user: 'alice', secret: PHRASE_AFTER_RECOVERY_1 })
+    await reopen.openVault('acme')
+    await expect(
+      reopen.recoverPassphrase('acme', {
+        newPassphrase: PHRASE_AFTER_RECOVERY_2,
+        recoveryProof: { profile: 'paper', payload: { code: enrolled[1]! } },
+      }),
+    ).rejects.toBeInstanceOf(InvalidKeyError)
+  }, 180_000)
+
+  it('newCodes round-trip through a subsequent recovery', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await db.openVault('acme')
+    const enrolled = await enrollCodes(db, 'acme', 3, 'CODEC')
+
+    const { newCodes } = await db.recoverPassphrase('acme', {
+      newPassphrase: PHRASE_AFTER_RECOVERY_1,
+      recoveryProof: { profile: 'paper', payload: { code: enrolled[0]! } },
+    })
+    expect(newCodes).toHaveLength(2)
+
+    // Re-open under the new phrase and use one of the new codes
+    // for a second recovery — proves the new entries are valid.
+    const reopen = await createNoydb({ store, user: 'alice', secret: PHRASE_AFTER_RECOVERY_1 })
+    await reopen.openVault('acme')
+    await expect(
+      reopen.recoverPassphrase('acme', {
+        newPassphrase: PHRASE_AFTER_RECOVERY_2,
+        recoveryProof: { profile: 'paper', payload: { code: newCodes[0]! } },
+      }),
+    ).resolves.toMatchObject({ newCodes: expect.any(Array) })
+  }, 180_000)
+
+  it('opt-out: rotateRemainingCodes:false preserves the original behavior', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await db.openVault('acme')
+    const enrolled = await enrollCodes(db, 'acme', 4, 'CODED')
+
+    const result = await db.recoverPassphrase('acme', {
+      newPassphrase: PHRASE_AFTER_RECOVERY_1,
+      recoveryProof: { profile: 'paper', payload: { code: enrolled[0]! } },
+      rotateRemainingCodes: false,
+    })
+
+    expect(result.newCodes).toHaveLength(0)
+
+    // Original remaining 3 codes are still valid (opt-out preserved
+    // pre-#36 behavior).
+    const post = await loadPaperRecoveryEntries(store, 'acme')
+    expect(post).toHaveLength(3)
+
+    // And one of those original codes still works.
+    const reopen = await createNoydb({ store, user: 'alice', secret: PHRASE_AFTER_RECOVERY_1 })
+    await reopen.openVault('acme')
+    await expect(
+      reopen.recoverPassphrase('acme', {
+        newPassphrase: PHRASE_AFTER_RECOVERY_2,
+        recoveryProof: { profile: 'paper', payload: { code: enrolled[1]! } },
+        rotateRemainingCodes: false,
+      }),
+    ).resolves.toMatchObject({ newCodes: expect.any(Array) })
+  }, 180_000)
+
+  it('newCodeCount: 10 mints exactly 10 codes regardless of remaining-count', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await db.openVault('acme')
+    const enrolled = await enrollCodes(db, 'acme', 3, 'CODEE')
+
+    const { newCodes } = await db.recoverPassphrase('acme', {
+      newPassphrase: PHRASE_AFTER_RECOVERY_1,
+      recoveryProof: { profile: 'paper', payload: { code: enrolled[0]! } },
+      newCodeCount: 10,
+    })
+
+    expect(newCodes).toHaveLength(10)
+    const post = await loadPaperRecoveryEntries(store, 'acme')
+    expect(post).toHaveLength(10)
+  }, 180_000)
+
+  it('codeGenerator override produces codes in the consumer\'s format', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await db.openVault('acme')
+    const enrolled = await enrollCodes(db, 'acme', 3, 'CODEF')
+
+    let counter = 0
+    const codeGenerator = () => `CUSTOMCODE${(counter++).toString().padStart(2, '0')}AAAA`
+
+    const { newCodes } = await db.recoverPassphrase('acme', {
+      newPassphrase: PHRASE_AFTER_RECOVERY_1,
+      recoveryProof: { profile: 'paper', payload: { code: enrolled[0]! } },
+      codeGenerator,
+    })
+
+    expect(newCodes).toHaveLength(2)
+    expect(newCodes[0]).toBe('CUSTOMCODE00AAAA')
+    expect(newCodes[1]).toBe('CUSTOMCODE01AAAA')
+  }, 180_000)
+
+  it('empty case: single-code enrollment + recovery returns empty newCodes', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await db.openVault('acme')
+    const enrolled = await enrollCodes(db, 'acme', 1, 'CODEG')
+
+    const { newCodes } = await db.recoverPassphrase('acme', {
+      newPassphrase: PHRASE_AFTER_RECOVERY_1,
+      recoveryProof: { profile: 'paper', payload: { code: enrolled[0]! } },
+    })
+
+    expect(newCodes).toHaveLength(0)
+    const post = await loadPaperRecoveryEntries(store, 'acme')
+    expect(post).toHaveLength(0)
+  }, 120_000)
+})

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -334,6 +334,7 @@ export {
 export type {
   RotatePassphraseInput,
   RecoverPassphraseInput,
+  RecoverPassphraseResult,
   RecoveryProof,
 } from './team/rotate-recover.js'
 

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -25,6 +25,7 @@ import {
   recoverPassphrase as keyringRecoverPassphrase,
   type RotatePassphraseInput,
   type RecoverPassphraseInput,
+  type RecoverPassphraseResult,
 } from './team/rotate-recover.js'
 import {
   recoverUser as keyringRecoverUser,
@@ -34,8 +35,10 @@ import {
   loadPaperRecoveryEntries,
   savePaperRecoveryEntries,
   hasRecoveryEnrolled,
+  mintPaperRecoveryEntry,
   type PaperRecoveryEntry,
 } from './team/recovery.js'
+import { generateULID } from './bundle/ulid.js'
 import { RecoveryNotEnrolledError } from './policy/errors.js'
 import {
   describeAuthConfig as fnDescribeAuthConfig,
@@ -1400,11 +1403,50 @@ export class Noydb {
     vault: string,
     input: RecoverPassphraseInput,
     factors?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
-  ): Promise<void> {
+  ): Promise<RecoverPassphraseResult> {
     await this.checkGate(vault, 'recover-passphrase', factors)
     const userId = this.options.user
+
+    // Snapshot the entries BEFORE recovery — the team function burns
+    // exactly one entry, so post-recovery `_meta/recovery-paper`
+    // contains `entriesBeforeRecovery.length - 1` entries (the ones
+    // the user did NOT just consume). Those are what we replace
+    // under the auto-rotation logic from #36.
+    const entriesBeforeRecovery = await loadPaperRecoveryEntries(this.options.store, vault)
+
     const next = await keyringRecoverPassphrase(this.options.store, vault, userId, input)
     this.keyringCache.set(vault, next)
+
+    const rotateRemaining = input.rotateRemainingCodes ?? true
+    const remainingAfterBurn = Math.max(0, entriesBeforeRecovery.length - 1)
+    if (!rotateRemaining || remainingAfterBurn === 0) {
+      return { newCodes: [] }
+    }
+
+    // Auto-rotate: replace the remaining entries with a fresh set
+    // minted under the new keyring's DEKs. Wraps the same DEK set the
+    // recovered keyring just got, so the new codes round-trip through
+    // a future `db.recoverPassphrase` cleanly.
+    //
+    // If this step fails (store error mid-mint), we leave the existing
+    // post-burn entries in place — the user falls back to the
+    // pre-#36 behavior (remaining N-1 codes still valid). Strictly
+    // safer than wiping then failing.
+    const codeGen = input.codeGenerator ?? generateULID
+    const newCodeCount = input.newCodeCount ?? remainingAfterBurn
+    const codes: string[] = []
+    const newEntries: PaperRecoveryEntry[] = []
+    for (let i = 0; i < newCodeCount; i++) {
+      const rawCode = codeGen()
+      const entry = await mintPaperRecoveryEntry(next.deks, rawCode, generateULID())
+      codes.push(rawCode)
+      newEntries.push(entry)
+    }
+    // Single replace-all write — `savePaperRecoveryEntries` overwrites
+    // `_meta/recovery-paper` atomically (one envelope `put`).
+    await savePaperRecoveryEntries(this.options.store, vault, newEntries)
+
+    return { newCodes: codes }
   }
 
   /**

--- a/packages/hub/src/team/rotate-recover.ts
+++ b/packages/hub/src/team/rotate-recover.ts
@@ -131,6 +131,59 @@ export interface RecoverPassphraseInput {
   readonly recoveryProof: RecoveryProof
   readonly passphrasePolicy?: PassphrasePolicy
   readonly allowWeakPassphrase?: boolean
+  /**
+   * After a successful paper-recovery, replace ALL remaining recovery
+   * entries with freshly-minted ones. Defaults to `true` (defensive).
+   *
+   * Rationale (issue #36): the user just demonstrated they had access
+   * to AT LEAST one code. The remaining codes from the same printed
+   * sheet may also be compromised — photographed, leaked via a
+   * screen-share slip, or in the hands of whoever stole the sheet.
+   * Auto-rotation closes the window without requiring consumer action.
+   *
+   * Set to `false` to preserve the original behavior (only the matched
+   * code is burned; the rest stay valid).
+   *
+   * Hub-side orchestration is non-atomic with the recovery itself:
+   * if the rotation step fails after a successful burn, the user
+   * falls back to the pre-rotation state (remaining codes still
+   * valid). Strictly safer than the previous default — a failed
+   * rotation degrades gracefully rather than leaving the vault
+   * locked or codes dual-existing.
+   */
+  readonly rotateRemainingCodes?: boolean
+  /**
+   * Number of fresh codes to mint when `rotateRemainingCodes` is on.
+   * Defaults to the count of remaining entries POST-burn (e.g. if
+   * the user enrolled 8 originally and just consumed 1, defaults to
+   * 7). Pass an explicit number to mint a different count — useful
+   * when the consumer wants to refresh to a target N regardless of
+   * how many were left.
+   */
+  readonly newCodeCount?: number
+  /**
+   * Override the default raw-code generator. The default is hub's
+   * {@link generateULID} — uppercase Crockford-Base32, 26 chars,
+   * passes through `normalizePaperCode` untouched.
+   *
+   * Pass `() => generateRawCode()` from `@noy-db/on-recovery` when
+   * the consumer prefers the Base32 + checksum format with hyphenated
+   * display. The `mintPaperRecoveryEntry` helper accepts any string —
+   * the generator just needs to produce a high-entropy unique value.
+   */
+  readonly codeGenerator?: () => string
+}
+
+/**
+ * Return shape of `db.recoverPassphrase`. `newCodes` is populated when
+ * `rotateRemainingCodes` was enabled and at least one entry was
+ * rotated; an empty array means no rotation happened (rotation
+ * disabled, or no remaining codes after burn). Show the codes to the
+ * user once — they are the canonical credential for future recovery
+ * and CANNOT be retrieved again.
+ */
+export interface RecoverPassphraseResult {
+  readonly newCodes: readonly string[]
 }
 
 /**


### PR DESCRIPTION
## Summary

After a successful paper-recovery, `db.recoverPassphrase` now defaults to replacing ALL remaining recovery entries with freshly-minted ones. Returns `{ newCodes: readonly string[] }` for the UI to show once.

## Why default-on

The user just demonstrated they had access to AT LEAST one code. The remaining codes from the same printed sheet may also be compromised — photographed, leaked via a screen-sharing slip, or in the hands of whoever stole the sheet. Auto-rotation closes the window without requiring consumer action — defense-in-depth that becomes invisible-by-omission without a default.

## API

`RecoverPassphraseInput` gains three optional knobs:

```ts
{
  rotateRemainingCodes?: boolean    // default true
  newCodeCount?: number              // default = remaining-after-burn
  codeGenerator?: () => string       // default = generateULID
}
```

`db.recoverPassphrase` return type changes from `Promise<void>` to `Promise<RecoverPassphraseResult>` where `RecoverPassphraseResult = { newCodes: readonly string[] }`. Existing callers awaiting the void return continue to compile.

## Atomicity caveat

If rotation fails after a successful burn (store error mid-mint), the user falls back to the pre-#36 state — post-burn N-1 entries stay valid. Strictly safer than wiping then failing: a backend write failure degrades gracefully to the original behavior.

## Custom code formats

Default `codeGenerator` is hub's `generateULID` — uppercase Crockford-Base32, 26 chars, passes through `normalizePaperCode` (uppercase + strip-separators) untouched. Consumers can pass `generateRawCode` from `@noy-db/on-recovery` for the Base32 + 4-char-checksum format.

## Test plan

7 tests in `packages/hub/__tests__/pr4-auto-rotate-recovery-codes.test.ts`:

- [x] Default rotation: 7 remaining codes replaced after consuming 1 of 8
- [x] Original remaining codes are invalid after rotation
- [x] New codes round-trip through a subsequent recovery
- [x] Opt-out: `rotateRemainingCodes:false` preserves pre-#36 behavior
- [x] `newCodeCount: 10` mints exactly 10 regardless of remaining-count
- [x] `codeGenerator` override produces consumer-format codes
- [x] Empty case: single-code enrollment returns empty `newCodes`

### Verification

- [x] 1322 / 1322 hub tests pass (+7 from PR2a baseline; existing `rotate-recover.test.ts` passes unchanged because the team-level function's signature is preserved)
- [x] Typecheck: clean
- [x] Lint: clean

## Branch base

Based on `feat/pr2a-recover-user-atomic` (PR #46). When PR #46 merges, retarget to `main`.

Closes #36