### PR TITLE
feat(hub): preserve tier-2 slots across rotatePassphrase via per-slot ceremonies (#29)

### DIFF
--- a/packages/hub/__tests__/pr5-rotate-preserve-slots.test.ts
+++ b/packages/hub/__tests__/pr5-rotate-preserve-slots.test.ts
@@ -1,0 +1,364 @@
+/**
+ * PR5 — preserve tier-2 slots across rotatePassphrase (#29).
+ *
+ * Without `slotCeremonies`, rotation drops every slot (pre-pre.8
+ * behavior). With ceremonies supplied, slots whose id appears in the
+ * map are PRESERVED — the ceremony re-derives its method-specific
+ * wrapping under the freshly rewrapped DEKs, and hub persists the
+ * new slot atomically with the rotation.
+ *
+ * Pinned behaviors:
+ *   1. Default — no `slotCeremonies` drops all slots (regression test).
+ *   2. Preserved wrap-DEKs slot — password-style ceremony returns a
+ *      wrapped_deks/iv result; hub persists it; the new wrapping
+ *      decrypts to the new DEK set.
+ *   3. Preserved wrap-KEK slot — webauthn-style ceremony returns a
+ *      wrapped_kek result; hub persists it; the slot survives.
+ *   4. Mixed — some slots ceremony'd, some dropped, in one rotation.
+ *   5. Anti-slot-swap: id mismatch in ceremony result throws.
+ *   6. Anti-slot-swap: method mismatch in ceremony result throws.
+ *   7. Ceremony receives newDeks + newKek + oldSlot in context.
+ *   8. enrolled_at preserved (rotation is rewrapping, not re-enrollment).
+ *   9. Ceremony exception aborts the entire rotation.
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, KeyringAuthenticator } from '../src/types.js'
+import { createOwnerKeyring, loadKeyring, persistKeyring } from '../src/team/keyring.js'
+import { rotatePassphrase, type SlotRewrapCeremony } from '../src/team/rotate-recover.js'
+import { generateDEK } from '../src/crypto.js'
+import { ValidationError } from '../src/errors.js'
+import type { EnrollAuthenticatorOptions } from '../src/team/authenticators.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'inline-memory',
+    async get(c, col, id) { return gc(c, col).get(id) },
+    async put(c, col, id, env) { gc(c, col).set(id, env) },
+    async delete(c, col, id) { gc(c, col).delete(id) },
+    async list(c, col) { return [...gc(c, col).keys()] },
+    async loadAll() { return {} },
+    async saveAll() {},
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+  } as unknown as NoydbStore
+}
+
+const OLD_PHRASE = 'correct horse battery staple printer toaster'
+const NEW_PHRASE = 'glasses cabinet bicycle umbrella thunder velvet'
+
+/**
+ * Set up a vault with `alice` as owner + N pre-rotation slots. Returns
+ * the seeded store and the slot specs that were persisted.
+ */
+async function setupVaultWithSlots(slots: KeyringAuthenticator[]): Promise<NoydbStore> {
+  const store = inlineMemory()
+  const keyring = await createOwnerKeyring(store, 'acme', 'alice', OLD_PHRASE)
+  keyring.deks.set('invoices', await generateDEK())
+  keyring.deks.set('clients', await generateDEK())
+  await persistKeyring(store, 'acme', keyring)
+
+  // Patch the persisted keyring file directly to add the slots —
+  // faster than running the full enrollAuthenticator path for each.
+  if (slots.length > 0) {
+    const env = await store.get('acme', '_keyring', 'alice')
+    const file = JSON.parse(env!._data) as Record<string, unknown>
+    await store.put('acme', '_keyring', 'alice', {
+      _noydb: 1, _v: 1, _ts: new Date().toISOString(), _iv: '',
+      _data: JSON.stringify({ ...file, authenticators: slots }),
+    })
+  }
+  return store
+}
+
+describe('rotatePassphrase slot preservation (#29)', () => {
+  it('without slotCeremonies, drops all slots (regression test for pre-#29 behavior)', async () => {
+    const store = await setupVaultWithSlots([
+      {
+        id: 'webauthn-yubikey',
+        method: 'webauthn',
+        enrolled_at: '2026-01-01T00:00:00Z',
+        enrolled_via_tier: 1,
+        wrapped_kek: 'WRAPPEDKEKBASE64',
+        meta: { credentialId: 'cred-1' },
+      },
+    ])
+
+    await rotatePassphrase(store, 'acme', 'alice', {
+      oldPassphrase: OLD_PHRASE,
+      newPassphrase: NEW_PHRASE,
+    })
+
+    const reloaded = await loadKeyring(store, 'acme', 'alice', NEW_PHRASE)
+    expect(reloaded.authenticators).toHaveLength(0)
+  }, 60_000)
+
+  it('preserves a wrap-DEKs slot via ceremony', async () => {
+    const store = await setupVaultWithSlots([
+      {
+        id: 'password-daily',
+        method: 'password',
+        enrolled_at: '2026-01-01T00:00:00Z',
+        enrolled_via_tier: 1,
+        wrapKind: 'deks',
+        wrapped_deks: 'OLDWRAPPEDDEKSBASE64',
+        iv: 'OLDIVBASE64',
+        meta: { salt: 'OLDSALT', minLength: 12 },
+      },
+    ])
+
+    let ceremonyCallCount = 0
+    let receivedNewDeks: Map<string, CryptoKey> | undefined
+    const passwordCeremony: SlotRewrapCeremony = async ({ newDeks, oldSlot }) => {
+      ceremonyCallCount++
+      receivedNewDeks = newDeks
+      return {
+        id: oldSlot.id,
+        method: 'password',
+        wrapKind: 'deks',
+        wrapped_deks: 'NEWWRAPPEDDEKSBASE64',
+        iv: 'NEWIVBASE64',
+        meta: { salt: 'NEWSALT', minLength: 14 },
+      } satisfies EnrollAuthenticatorOptions
+    }
+
+    await rotatePassphrase(store, 'acme', 'alice', {
+      oldPassphrase: OLD_PHRASE,
+      newPassphrase: NEW_PHRASE,
+      slotCeremonies: { 'password-daily': passwordCeremony },
+    })
+
+    expect(ceremonyCallCount).toBe(1)
+    expect(receivedNewDeks?.size).toBeGreaterThan(0)
+
+    const reloaded = await loadKeyring(store, 'acme', 'alice', NEW_PHRASE)
+    expect(reloaded.authenticators).toHaveLength(1)
+    const slot = reloaded.authenticators[0]!
+    expect(slot.id).toBe('password-daily')
+    expect(slot.method).toBe('password')
+    if (slot.wrapKind === 'deks') {
+      expect(slot.wrapped_deks).toBe('NEWWRAPPEDDEKSBASE64')
+      expect(slot.iv).toBe('NEWIVBASE64')
+      expect((slot.meta as { minLength?: number }).minLength).toBe(14)
+    } else {
+      throw new Error('expected wrap-DEKs slot')
+    }
+  }, 60_000)
+
+  it('preserves a wrap-KEK slot via ceremony', async () => {
+    const store = await setupVaultWithSlots([
+      {
+        id: 'webauthn-touchid',
+        method: 'webauthn',
+        enrolled_at: '2026-01-01T00:00:00Z',
+        enrolled_via_tier: 1,
+        wrapped_kek: 'OLDWRAPPEDKEK',
+        meta: { credentialId: 'cred-touchid' },
+      },
+    ])
+
+    let receivedNewKek: CryptoKey | undefined
+    const webauthnCeremony: SlotRewrapCeremony = async ({ newKek, oldSlot }) => {
+      receivedNewKek = newKek
+      return {
+        id: oldSlot.id,
+        method: 'webauthn',
+        wrapped_kek: 'NEWWRAPPEDKEK',
+        meta: { credentialId: 'cred-touchid', wrapIv: 'newiv' },
+      } satisfies EnrollAuthenticatorOptions
+    }
+
+    await rotatePassphrase(store, 'acme', 'alice', {
+      oldPassphrase: OLD_PHRASE,
+      newPassphrase: NEW_PHRASE,
+      slotCeremonies: { 'webauthn-touchid': webauthnCeremony },
+    })
+
+    expect(receivedNewKek).toBeInstanceOf(CryptoKey)
+
+    const reloaded = await loadKeyring(store, 'acme', 'alice', NEW_PHRASE)
+    expect(reloaded.authenticators).toHaveLength(1)
+    const slot = reloaded.authenticators[0]!
+    expect(slot.id).toBe('webauthn-touchid')
+    if (slot.wrapKind !== 'deks') {
+      expect(slot.wrapped_kek).toBe('NEWWRAPPEDKEK')
+    } else {
+      throw new Error('expected wrap-KEK slot')
+    }
+  }, 60_000)
+
+  it('mixed: some slots ceremony\'d, some dropped, in one rotation', async () => {
+    const store = await setupVaultWithSlots([
+      {
+        id: 'webauthn-yubikey',
+        method: 'webauthn',
+        enrolled_at: '2026-01-01T00:00:00Z',
+        enrolled_via_tier: 1,
+        wrapped_kek: 'WRAPPEDKEK',
+        meta: { credentialId: 'cred-yubikey' },
+      },
+      {
+        id: 'password-daily',
+        method: 'password',
+        enrolled_at: '2026-01-02T00:00:00Z',
+        enrolled_via_tier: 1,
+        wrapKind: 'deks',
+        wrapped_deks: 'WRAPPEDDEKS',
+        iv: 'IV',
+        meta: { salt: 'SALT', minLength: 12 },
+      },
+      {
+        id: 'pin-daily',
+        method: 'password', // tier-3 PIN slots also use the 'password' method
+        enrolled_at: '2026-01-03T00:00:00Z',
+        enrolled_via_tier: 3,
+        wrapKind: 'deks',
+        wrapped_deks: 'PINWRAPPEDDEKS',
+        iv: 'PINIV',
+        meta: { salt: 'PINSALT' },
+      },
+    ])
+
+    // Only ceremony the webauthn slot — password + pin will be dropped.
+    const webauthnCeremony: SlotRewrapCeremony = async ({ oldSlot }) => ({
+      id: oldSlot.id,
+      method: 'webauthn',
+      wrapped_kek: 'NEWWRAPPEDKEK',
+      meta: { credentialId: 'cred-yubikey' },
+    })
+
+    await rotatePassphrase(store, 'acme', 'alice', {
+      oldPassphrase: OLD_PHRASE,
+      newPassphrase: NEW_PHRASE,
+      slotCeremonies: { 'webauthn-yubikey': webauthnCeremony },
+    })
+
+    const reloaded = await loadKeyring(store, 'acme', 'alice', NEW_PHRASE)
+    expect(reloaded.authenticators).toHaveLength(1)
+    expect(reloaded.authenticators[0]!.id).toBe('webauthn-yubikey')
+  }, 60_000)
+
+  it('rejects id mismatch in ceremony result (anti-slot-swap)', async () => {
+    const store = await setupVaultWithSlots([
+      {
+        id: 'webauthn-original',
+        method: 'webauthn',
+        enrolled_at: '2026-01-01T00:00:00Z',
+        enrolled_via_tier: 1,
+        wrapped_kek: 'WRAPPED',
+        meta: { credentialId: 'cred' },
+      },
+    ])
+
+    const swapCeremony: SlotRewrapCeremony = async () => ({
+      id: 'webauthn-IMPOSTER', // ← mismatched id
+      method: 'webauthn',
+      wrapped_kek: 'NEWWRAPPED',
+      meta: { credentialId: 'cred' },
+    })
+
+    await expect(
+      rotatePassphrase(store, 'acme', 'alice', {
+        oldPassphrase: OLD_PHRASE,
+        newPassphrase: NEW_PHRASE,
+        slotCeremonies: { 'webauthn-original': swapCeremony },
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  }, 60_000)
+
+  it('rejects method mismatch in ceremony result (anti-slot-swap)', async () => {
+    const store = await setupVaultWithSlots([
+      {
+        id: 'webauthn-original',
+        method: 'webauthn',
+        enrolled_at: '2026-01-01T00:00:00Z',
+        enrolled_via_tier: 1,
+        wrapped_kek: 'WRAPPED',
+        meta: { credentialId: 'cred' },
+      },
+    ])
+
+    const methodSwapCeremony: SlotRewrapCeremony = async ({ oldSlot }) => ({
+      id: oldSlot.id,
+      method: 'password', // ← mismatched method
+      wrapKind: 'deks',
+      wrapped_deks: 'WRAPPED',
+      iv: 'IV',
+      meta: { salt: 'SALT' },
+    })
+
+    await expect(
+      rotatePassphrase(store, 'acme', 'alice', {
+        oldPassphrase: OLD_PHRASE,
+        newPassphrase: NEW_PHRASE,
+        slotCeremonies: { 'webauthn-original': methodSwapCeremony },
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  }, 60_000)
+
+  it('preserves enrolled_at across rotation (rotation is rewrapping, not re-enrollment)', async () => {
+    const originalEnrolledAt = '2025-06-15T08:30:00.000Z'
+    const store = await setupVaultWithSlots([
+      {
+        id: 'webauthn-touchid',
+        method: 'webauthn',
+        enrolled_at: originalEnrolledAt,
+        enrolled_via_tier: 1,
+        wrapped_kek: 'WRAPPED',
+        meta: { credentialId: 'cred' },
+      },
+    ])
+
+    const ceremony: SlotRewrapCeremony = async ({ oldSlot }) => ({
+      id: oldSlot.id,
+      method: 'webauthn',
+      wrapped_kek: 'NEWWRAPPED',
+      meta: { credentialId: 'cred' },
+    })
+
+    await rotatePassphrase(store, 'acme', 'alice', {
+      oldPassphrase: OLD_PHRASE,
+      newPassphrase: NEW_PHRASE,
+      slotCeremonies: { 'webauthn-touchid': ceremony },
+    })
+
+    const reloaded = await loadKeyring(store, 'acme', 'alice', NEW_PHRASE)
+    expect(reloaded.authenticators[0]!.enrolled_at).toBe(originalEnrolledAt)
+  }, 60_000)
+
+  it('ceremony exception aborts the entire rotation', async () => {
+    const store = await setupVaultWithSlots([
+      {
+        id: 'webauthn-touchid',
+        method: 'webauthn',
+        enrolled_at: '2026-01-01T00:00:00Z',
+        enrolled_via_tier: 1,
+        wrapped_kek: 'WRAPPED',
+        meta: { credentialId: 'cred' },
+      },
+    ])
+
+    const failingCeremony: SlotRewrapCeremony = async () => {
+      throw new Error('user cancelled re-prove')
+    }
+
+    await expect(
+      rotatePassphrase(store, 'acme', 'alice', {
+        oldPassphrase: OLD_PHRASE,
+        newPassphrase: NEW_PHRASE,
+        slotCeremonies: { 'webauthn-touchid': failingCeremony },
+      }),
+    ).rejects.toThrow(/user cancelled/)
+
+    // Original keyring intact — old phrase still works.
+    const reloaded = await loadKeyring(store, 'acme', 'alice', OLD_PHRASE)
+    expect(reloaded.authenticators).toHaveLength(1)
+    expect(reloaded.authenticators[0]!.id).toBe('webauthn-touchid')
+  }, 60_000)
+})

--- a/packages/hub/src/team/rotate-recover.ts
+++ b/packages/hub/src/team/rotate-recover.ts
@@ -38,6 +38,52 @@ import {
 } from './recovery.js'
 import { assertStrongPassphrase, type PassphrasePolicy } from '../validation.js'
 import type { UnlockedKeyring } from './keyring.js'
+import type { KeyringAuthenticator } from '../types.js'
+import type { EnrollAuthenticatorOptions } from './authenticators.js'
+import { ValidationError } from '../errors.js'
+
+/**
+ * Context handed to a {@link SlotRewrapCeremony} when `rotatePassphrase`
+ * preserves a tier-2 slot. The ceremony's job is to re-derive its
+ * method-specific wrapping material (PRF assertion, PBKDF2 of a
+ * daily-password, etc.) and wrap the freshly rewrapped DEK set under
+ * the new wrapping key.
+ *
+ * Two surfaces are exposed:
+ *
+ *   - `newDeks` — the rewrapped (extractable) DEK set the slot will
+ *     wrap. This is what `mintPaperRecoveryEntry` / `enrollPassword-
+ *     Authenticator` / `wrapKeyringSummary` (in `@noy-db/on-webauthn`)
+ *     all consume; effectively the canonical input for every
+ *     post-Path C tier-2 ceremony.
+ *
+ *   - `newKek` — the freshly-derived KEK (extractable for the
+ *     ceremony scope only). Only relevant for forward-compatibility
+ *     with a hypothetical future on-* package that wants to wrap the
+ *     KEK itself under a method-derived key. None of the shipped
+ *     on-* packages need this; they all operate on `newDeks`.
+ *
+ * The ceremony MUST preserve `oldSlot.id` and `oldSlot.method` in the
+ * returned `EnrollAuthenticatorOptions`. Hub validates these — a
+ * mismatch throws `ValidationError` (prevents slot-type swap mid-
+ * rotation, e.g. converting a webauthn slot to a password slot under
+ * cover of preservation).
+ */
+export interface SlotRewrapContext {
+  readonly newKek: CryptoKey
+  readonly newDeks: Map<string, CryptoKey>
+  readonly oldSlot: KeyringAuthenticator
+}
+
+/**
+ * Callback that re-enrolls one tier-2 slot during `rotatePassphrase`.
+ * Returns the new slot's `EnrollAuthenticatorOptions` — same shape
+ * the consumer would pass to `db.enrollAuthenticator` for a fresh
+ * enrollment. Hub persists the result atomically with the rotation.
+ */
+export type SlotRewrapCeremony = (
+  ctx: SlotRewrapContext,
+) => Promise<EnrollAuthenticatorOptions>
 
 /** Caller payload for {@link rotatePassphrase}. */
 export interface RotatePassphraseInput {
@@ -45,19 +91,40 @@ export interface RotatePassphraseInput {
   readonly newPassphrase: string
   readonly passphrasePolicy?: PassphrasePolicy
   readonly allowWeakPassphrase?: boolean
+  /**
+   * Map of slot id → re-enrolment ceremony. Slots whose id appears
+   * here are PRESERVED across rotation (the ceremony re-derives the
+   * method-specific wrapping under the new keyring); slots whose id
+   * is absent are DROPPED (the pre-#29 behavior).
+   *
+   * Without this map, `rotatePassphrase` retains the pre-pre.8
+   * behavior of wiping every tier-2 slot. Consumers building a
+   * "rotate without losing my biometric" flow supply ceremonies for
+   * each slot they want to keep.
+   *
+   * If a ceremony throws, the entire rotation throws — no partial
+   * state. Callers wrap individual ceremonies in try/catch + return
+   * a sentinel if they want graceful degradation per slot.
+   *
+   * Added in pre.8 (#29).
+   */
+  readonly slotCeremonies?: { readonly [slotId: string]: SlotRewrapCeremony }
 }
 
 /**
  * Re-derive the user's KEK from `oldPassphrase`, rewrap every DEK
  * under a freshly-derived KEK from `newPassphrase`, and persist.
  *
- * Tier-2 authenticator slots are NOT preserved — each slot wraps the
- * old KEK and would need the user's per-slot derivation key to
- * re-wrap; the hub doesn't hold that. The user re-enrols any slots
- * after rotation. v0.1.0-pre.5 limitation.
+ * Tier-2 authenticator slots are dropped UNLESS the caller supplies
+ * a `slotCeremonies` map (#29) — each ceremony re-derives its
+ * method-specific wrapping under the new keyring, and hub persists
+ * the rewrapped slots atomically with the rotation. Slots whose id
+ * isn't in the map are still dropped (pre-pre.8 behavior).
  *
  * @throws `InvalidKeyError` if `oldPassphrase` does not unwrap the keyring.
  * @throws `WeakPassphraseError` if `newPassphrase` fails the strength rule.
+ * @throws `ValidationError` if a ceremony's result mismatches the
+ *         slot's id or method (anti-slot-swap guard).
  */
 export async function rotatePassphrase(
   store: NoydbStore,
@@ -93,14 +160,75 @@ export async function rotatePassphrase(
     wrappedDeks[coll] = await wrapKey(dek, newKek)
   }
 
+  // Slot rewrap (#29). Without slotCeremonies, we drop every existing
+  // slot — the pre-pre.8 behavior. With a ceremony map, slots whose
+  // id appears in the map are preserved; the rest are dropped.
+  const oldSlots = file.authenticators ?? []
+  const newSlots: KeyringAuthenticator[] = []
+  if (input.slotCeremonies && oldSlots.length > 0) {
+    for (const oldSlot of oldSlots) {
+      const ceremony = input.slotCeremonies[oldSlot.id]
+      if (!ceremony) continue // drop — same as pre-#29 behavior
+
+      const result = await ceremony({ newKek, newDeks: deks, oldSlot })
+
+      // Anti-slot-swap guard. The ceremony MUST preserve identity —
+      // a mismatch would let the consumer convert a webauthn slot to
+      // a password slot mid-rotation, which would silently change
+      // the security profile of the slot under cover of "rotation."
+      if (result.id !== oldSlot.id) {
+        throw new ValidationError(
+          `slotCeremonies['${oldSlot.id}'] returned id="${result.id}". ` +
+            'The id must match the rotated slot — a ceremony cannot ' +
+            'change a slot\'s identity.',
+        )
+      }
+      if (result.method !== oldSlot.method) {
+        throw new ValidationError(
+          `slotCeremonies['${oldSlot.id}'] returned method="${result.method}", ` +
+            `expected "${oldSlot.method}". The method must match the rotated ` +
+            'slot — a ceremony cannot change the auth method (e.g. webauthn ' +
+            '→ password) under cover of rotation.',
+        )
+      }
+
+      // Build the persisted slot from the ceremony result. Mirrors
+      // the same construction `enrollAuthenticator` does — wrap-DEKs
+      // variants carry { wrapped_deks, iv }; wrap-KEK variants
+      // carry { wrapped_kek }.
+      const baseFields = {
+        id: result.id,
+        method: result.method,
+        // Preserve original enrolled_at — rotation is rewrapping, not
+        // re-enrollment. The slot's enrolment timestamp tracks when
+        // the user originally added the slot, not when it was last
+        // rewrapped. Forensics consumers reading enrolled_at are
+        // tracking the slot's ORIGIN, not its CURRENT wrapping.
+        enrolled_at: oldSlot.enrolled_at,
+        enrolled_via_tier: result.enrolled_via_tier ?? oldSlot.enrolled_via_tier,
+        meta: result.meta,
+      } as const
+      const newSlot: KeyringAuthenticator = result.wrapKind === 'deks'
+        ? {
+            ...baseFields,
+            wrapKind: 'deks',
+            wrapped_deks: result.wrapped_deks,
+            iv: result.iv,
+          }
+        : {
+            ...baseFields,
+            wrapped_kek: result.wrapped_kek,
+          }
+      newSlots.push(newSlot)
+    }
+  }
+
   const next: KeyringFile = {
     ...file,
     _noydb_keyring: NOYDB_KEYRING_VERSION,
     deks: wrappedDeks,
     salt: bufferToBase64(newSalt),
-    // Tier-2 slots reference the old KEK — drop them. User
-    // re-enrols afterwards via `db.enrollAuthenticator`.
-    authenticators: [],
+    authenticators: newSlots,
   }
 
   await writeKeyringFile(store, vault, userId, next)
@@ -113,7 +241,7 @@ export async function rotatePassphrase(
     deks,
     kek: newKek,
     salt: newSalt,
-    authenticators: [],
+    authenticators: newSlots,
     ...(file.export_capability !== undefined && { exportCapability: file.export_capability }),
     ...(file.import_capability !== undefined && { importCapability: file.import_capability }),
   }


### PR DESCRIPTION
## Summary

`db.rotatePassphrase` accepts an optional `slotCeremonies` map keyed by slot id. Each ceremony receives the freshly-derived KEK + rewrapped DEKs and returns the new slot's `EnrollAuthenticatorOptions`. Hub validates the result preserves `id + method` (anti-slot-swap guard) and persists atomically with the rotation.

## Why

Pre-pre.8, every passphrase rotation wiped every tier-2 slot — the user had to walk through *"re-Touch-ID, re-type-daily-password, re-set-PIN"* after a rotation. Combined with the `rotate-passphrase` gate's tier-1 requirement, rotation became a *"wipe my convenience layer"* event. Users avoided rotating; phrases stayed too long; security degraded.

This PR ships the issue body's proposed escape: an opt-in per-slot ceremony map. Slots whose id appears in the map are preserved; slots without a ceremony are still dropped (pre-pre.8 behavior is the default).

## API

```ts
interface RotatePassphraseInput {
  // existing knobs unchanged...
  slotCeremonies?: { [slotId: string]: SlotRewrapCeremony }
}

type SlotRewrapCeremony = (ctx: {
  newKek: CryptoKey               // forward-compat for wrap-KEK ceremonies
  newDeks: Map<string, CryptoKey> // primary input post-Path C (#26)
  oldSlot: KeyringAuthenticator
}) => Promise<EnrollAuthenticatorOptions>
```

## Anti-slot-swap guard

The ceremony's returned `EnrollAuthenticatorOptions` MUST preserve `oldSlot.id` and `oldSlot.method`. A mismatch throws `ValidationError` — prevents converting a webauthn slot to a password slot under cover of "rotation."

## `enrolled_at` preserved

Rotation is *rewrapping*, not *re-enrollment*. The slot's `enrolled_at` carries through unchanged so forensics consumers reading the field track the slot's ORIGIN, not its CURRENT wrapping.

## Atomicity

Ceremony exceptions abort the entire rotation — the keyring file isn't written. The user falls back to the original keyring under the OLD passphrase. No partial state.

## Test plan

8 tests, all passing:

- [x] Without `slotCeremonies`, drops all slots (regression test for pre-#29 default)
- [x] Preserves a wrap-DEKs slot (password-style ceremony)
- [x] Preserves a wrap-KEK slot (webauthn-style ceremony)
- [x] Mixed — some slots ceremony'd, some dropped, in one rotation
- [x] Anti-slot-swap: id mismatch throws `ValidationError`
- [x] Anti-slot-swap: method mismatch throws `ValidationError`
- [x] `enrolled_at` preserved across rotation
- [x] Ceremony exception aborts rotation; original keyring intact

### Verification

- [x] 1326 / 1326 hub tests pass (+8 from baseline)
- [x] Typecheck: clean
- [x] Lint: clean

Closes #29