### PR TITLE
docs(on-oidc): clarify server-side dependency is a consumer responsibility (#37)

### DIFF
--- a/docs/subsystems/auth-landscape.md
+++ b/docs/subsystems/auth-landscape.md
@@ -97,6 +97,8 @@ Biometrics never *are* the secret — they gate access to a local credential. So
 
 All require **online at auth time**. All map to `on-oidc` with different issuer URLs. Differences are ecosystem fit and built-in 2FA strength, not protocol.
 
+> **Server-side dependency** — OIDC is the only `on-*` family that requires **consumer-operated infrastructure**. The split-key model needs an HTTP service that verifies ID tokens against the issuer's JWKS and stores the per-user `serverHalf` indexed by `sub`. noy-db documents the protocol (`PUT/GET /kek-fragment`) at [`packages/on-oidc/src/index.ts`](../../packages/on-oidc/src/index.ts) but does **not** ship a reference implementation, hosted instance, or deploy template — that's a deliberate boundary, not a backlog item. Consumers with no off-device infrastructure should prefer [`@noy-db/on-webauthn`](../../packages/on-webauthn) (platform passkey via Touch ID / Face ID / Windows Hello) — same UX as "Login with X" without the server, because the platform passkey IS the device-bound credential. See [issue #37](https://github.com/vLannaAi/noy-db/issues/37) for the discussion that closed this question.
+
 | Provider | Personal | Shared | Default factors | Notes / caveat | noy-db match |
 |---|:--:|:--:|---|---|---|
 | Google Sign-In | ✅ | ⚠️ leaves session | K + optional D (Google Prompt / TOTP / key) | Consumer + Workspace | `on-oidc` |

--- a/packages/on-oidc/README.md
+++ b/packages/on-oidc/README.md
@@ -14,7 +14,19 @@ pnpm add @noy-db/hub @noy-db/on-oidc
 
 ## What it is
 
-OAuth/OIDC bridge for noy-db — federated login (LINE, Google, Apple, Okta) with split-key key connector — server never sees plaintext
+OAuth/OIDC bridge for noy-db — federated login (LINE, Google, Apple, Okta, any OIDC-compliant provider) using a split-key model where the KEK is XOR-split between a device half and a server half. The server never sees the unwrapped KEK or any plaintext.
+
+## ⚠️ Server-side dependency
+
+**This package handles the CLIENT side only.** Using OIDC as a tier-2 unlock requires you to operate a **key-connector server** that:
+
+1. Verifies ID tokens against the issuer's JWKS (`PUT/GET /kek-fragment` endpoints).
+2. Stores per-user `serverHalf` indexed by the OIDC `sub` claim.
+3. Periodically rotates the encryption key used for stored serverHalves.
+
+The protocol is fully documented at the top of [`src/index.ts`](./src/index.ts). noy-db does **not** ship a reference implementation, hosted instance, or deployment template — implementing this server is a consumer responsibility (any runtime that can verify JWT signatures + has a KV-style store works: Cloudflare Worker, Lambda, Express, Go).
+
+**If you don't want to run a server**, use [`@noy-db/on-webauthn`](https://www.npmjs.com/package/@noy-db/on-webauthn) instead — platform passkey via Touch ID / Face ID / Windows Hello gives the same "Login with X" UX without server infrastructure, because the platform passkey IS the device-bound credential. See [issue #37](https://github.com/vLannaAi/noy-db/issues/37) for the discussion.
 
 ## Status
 


### PR DESCRIPTION
## Summary

#37 proposed shipping a reference key-connector server (Cloudflare Worker / Lambda template) so consumers don't have to deploy infra to use OIDC unlock.

After re-reading the tier model in `session-tiers.md` (line 27, 134) and `auth-landscape.md` (decision rules §13), the conclusion is that **shipping server infrastructure is outside noy-db's scope**:

- OIDC's tier-2 placement is settled in `session-tiers.md` — split-key with consumer-operated key-connector IS the documented design.
- The auth-landscape decision rules already classify "split-key vs gate-only composition" as the two honest answers when a provider can't carry wrap-key material on its own.
- noy-db is offline-first, server-less by philosophy. Adding even a reference Worker introduces operational surface that consumers would expect noy-db to maintain.
- WebAuthn (platform passkey via Touch ID / Face ID / Windows Hello) is the offline-first equivalent for the "Login with X" UX — consumers without server infrastructure should use that.

This PR polishes the framing in two places, no code change.

## Changes

### `docs/subsystems/auth-landscape.md` §6

Adds a callout paragraph clarifying that OIDC is the only `on-*` family requiring consumer-operated infrastructure, points consumers without that infrastructure at `on-webauthn` as the offline-first equivalent, and links #37 for the discussion.

### `packages/on-oidc/README.md`

Reframes "self-host the key-connector server" from a footnote in the docstring to a top-level **⚠️ Server-side dependency** section right under "What it is" — sets the expectation upfront so solo consumers don't get excited then bounce when they discover the requirement.

## Test plan

- [x] `pnpm validate:features` — passes (27 features, no registry change)
- [ ] Doc reads cleanly on GitHub (rendered tables + callout block)

## Disposition for #37

Close as wontfix on merge. The issue itself stays a useful artefact (the discussion of why the boundary is where it is — searchable for future consumers asking the same question).

Closes #37