### PR TITLE
feat(on-magic-link): forward passphrasePolicy through acceptInvite (#53)

### DIFF
--- a/packages/on-magic-link/__tests__/invite-peer-recovery.test.ts
+++ b/packages/on-magic-link/__tests__/invite-peer-recovery.test.ts
@@ -286,6 +286,96 @@ describe('audit doc + payload encoding', () => {
     expect(typeof audit.acceptedAt).toBe('string')
   }, 180_000)
 
+  it('forwards passphrasePolicy to the inner rotation (#53)', async () => {
+    const store = inlineMemory()
+    const alice = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await alice.openVault('acme')
+
+    const { encoded } = await issueInvite(alice, 'acme', {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+    })
+
+    // Hyphen-separated phrase — rejected by the default lowercase+spaces
+    // validator, accepted by a customValidator. Without the #53 fix,
+    // the inner rotation throws WeakPassphraseError regardless of any
+    // policy plumbed through `noydbOptions`.
+    const HYPHENATED_PHRASE = 'mrs-niwat-her-own-phrase-2026'
+    const passphrase = {
+      customValidator: (phrase: string) =>
+        phrase.length >= 16 && /^[a-z0-9-]+$/.test(phrase)
+          ? ({ ok: true, words: 1 } as const)
+          : ({ ok: false, reason: 'invalid-chars' } as const),
+    }
+
+    const result = await acceptInvite(encoded, {
+      store,
+      newPhrase: HYPHENATED_PHRASE,
+      passphrasePolicy: passphrase,
+    })
+    expect(result.payload.userId).toBe('bob')
+
+    // Reopen with the hyphenated phrase to confirm it actually rotated.
+    const reopen = await createNoydb({
+      store,
+      user: 'bob',
+      secret: HYPHENATED_PHRASE,
+      policy: { passphrase, gates: {} },
+    })
+    await reopen.openVault('acme')
+    const verify = await reopen.getKeyring('acme')
+    expect(verify.userId).toBe('bob')
+  }, 180_000)
+
+  it('rejects newPhrase that violates the supplied passphrasePolicy (#53)', async () => {
+    const store = inlineMemory()
+    const alice = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await alice.openVault('acme')
+
+    const { encoded } = await issueInvite(alice, 'acme', {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+    })
+
+    // Strict customValidator: must contain a digit. Plain word-phrase
+    // newPhrase (default-validator-passing) must fail under this policy.
+    await expect(
+      acceptInvite(encoded, {
+        store,
+        newPhrase: BOB_NEW_PHRASE,
+        passphrasePolicy: {
+          customValidator: (phrase: string) =>
+            /\d/.test(phrase)
+              ? ({ ok: true, words: 1 } as const)
+              : ({ ok: false, reason: 'invalid-chars' } as const),
+        },
+      }),
+    ).rejects.toThrow(/invalid-chars/)
+  }, 60_000)
+
+  it('allowWeakPassphrase: true bypasses the rotation validator (#53)', async () => {
+    const store = inlineMemory()
+    const alice = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await alice.openVault('acme')
+
+    const { encoded } = await issueInvite(alice, 'acme', {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+    })
+
+    // 'short' would normally fail the strength validator. With
+    // allowWeakPassphrase: true, the rotation accepts it.
+    const result = await acceptInvite(encoded, {
+      store,
+      newPhrase: 'short',
+      allowWeakPassphrase: true,
+    })
+    expect(result.payload.userId).toBe('bob')
+  }, 120_000)
+
   it('encodeInvitePayload / decodeInvitePayload round-trip without loss', () => {
     const payload = {
       tokenId: '01HX6E1N0Q8WYK3F4A2J3D2F5G',

--- a/packages/on-magic-link/src/invite.ts
+++ b/packages/on-magic-link/src/invite.ts
@@ -36,6 +36,7 @@ import {
   type EncryptedEnvelope,
   type Role,
   type FactorProof,
+  type PassphrasePolicy,
 } from '@noy-db/hub'
 
 const INVITE_AUDIT_DOC_PREFIX = 'invite-audit-'
@@ -133,6 +134,32 @@ export interface AcceptInviteOptions {
    * `sessionPolicy` tweaks the application layer wants in scope.
    */
   readonly noydbOptions?: Omit<Parameters<typeof createNoydb>[0], 'store' | 'user' | 'secret'>
+  /**
+   * Forwarded to the inner `keyringRotatePassphrase` call so the
+   * recipient's `newPhrase` is validated against the same policy the
+   * vault uses elsewhere. Without this, the rotation step applies the
+   * default phrase validator (lowercase letters + spaces) regardless
+   * of any `customValidator` / `pattern` set on the vault — a
+   * consumer using non-default phrase shapes (e.g. hyphen-separated
+   * alphanumeric, BIP-39 word-lists, Thai/EN-mixed scripts) hits a
+   * spurious `WeakPassphraseError`.
+   *
+   * `noydbOptions.policy.passphrase` is NOT auto-derived because
+   * `noydbOptions` flows to the post-rotation `createNoydb`, not the
+   * rotation itself. Passing the same `PassphrasePolicy` here and
+   * (via `noydbOptions.policy.passphrase`) keeps both gates aligned.
+   *
+   * Added in pre.9 (#53).
+   */
+  readonly passphrasePolicy?: PassphrasePolicy
+  /**
+   * Skip phrase strength validation for the recipient's `newPhrase`.
+   * Forwarded to the inner rotation. Use sparingly — bypasses the
+   * structural rules that protect against weak phrases.
+   *
+   * Added in pre.9 (#53).
+   */
+  readonly allowWeakPassphrase?: boolean
 }
 
 export interface AcceptInviteResult {
@@ -400,6 +427,8 @@ export async function acceptInvite(
   await keyringRotatePassphrase(options.store, payload.vault, payload.userId, {
     oldPassphrase: payload.tempPhrase,
     newPassphrase: options.newPhrase,
+    ...(options.passphrasePolicy !== undefined && { passphrasePolicy: options.passphrasePolicy }),
+    ...(options.allowWeakPassphrase !== undefined && { allowWeakPassphrase: options.allowWeakPassphrase }),
   })
 
   // Mark accepted — second acceptInvite for this token throws.


### PR DESCRIPTION
## Summary

- Adds `passphrasePolicy?: PassphrasePolicy` and `allowWeakPassphrase?: boolean` to `AcceptInviteOptions`.
- Forwards both to the inner `keyringRotatePassphrase` so the recipient's `newPhrase` is validated against the same `customValidator` / `pattern` the vault uses elsewhere.
- Hub-side already supports both fields (`packages/hub/src/team/rotate-recover.ts:92-93`) — pure option-thread.
- 3 new tests in `invite-peer-recovery.test.ts` cover (a) hyphen-separated alphanumeric phrase accepted via `customValidator`, (b) `customValidator` rejection surfaces correctly, (c) `allowWeakPassphrase: true` bypasses the rotation validator.

## Why `noydbOptions.policy` is not auto-derived

`noydbOptions` flows to the post-rotation `createNoydb`, not the rotation itself. Auto-deriving would silently apply the vault policy to the rotation but leave the door open to drift if a consumer wanted to validate the rotation under a stricter policy than the opened session uses (or vice versa). Keeping the field explicit forces the consumer to pass it once, with a clear pointer in the docstring to keep both gates aligned.

## Test plan

- [x] `pnpm --filter @noy-db/on-magic-link typecheck` — clean
- [x] `pnpm --filter @noy-db/on-magic-link lint` — clean
- [x] `pnpm vitest run packages/on-magic-link` — 45 / 45 pass (3 new tests)
- [ ] Niwat to confirm the hyphen-separated `customValidator` flow on his side

## Milestone

[v0.1.0-pre.9](https://github.com/vLannaAi/noy-db/milestone/3)

Closes #53.
