### PR TITLE
feat(hub): db.updateUser for post-grant role / displayName / permissions (#54)

### DIFF
--- a/packages/hub/__tests__/update-user.test.ts
+++ b/packages/hub/__tests__/update-user.test.ts
@@ -1,0 +1,431 @@
+/**
+ * #54 — db.updateUser for post-grant role / displayName / permissions mutation.
+ *
+ * Pinned behaviors:
+ *   1. Round-trip — owner promotes a viewer to admin; new role + displayName
+ *      + permissions persist; userId unchanged.
+ *   2. Pure header rewrite — DEKs preserved (count + keys identical
+ *      pre/post update). No re-encrypt of any record. Optimistic
+ *      concurrency via the existing envelope put.
+ *   3. Partial diff — only specified fields move. Omitted fields untouched.
+ *   4. Tier-2 slots survive — wrapped DEKs / authenticators[] not affected.
+ *   5. Empty diff — ValidationError.
+ *   6. Missing keyring — NoAccessError.
+ *   7. Role-elevation guard — admin cannot promote target to owner;
+ *      admin cannot demote an owner; owner can do anything.
+ *   8. Self-elevation blocked — admin cannot upgrade their OWN role to
+ *      owner via updateUser.
+ *   9. Hub-level gating — `db.updateUser` runs `update-user` gate.
+ *      STRICT_POLICY without factor proof rejects.
+ *  10. Post-update self-targeting refreshes the cached keyring so the
+ *      caller sees their own updated header on subsequent reads.
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, KeyringFile, KeyringAuthenticator } from '../src/types.js'
+import { createOwnerKeyring, loadKeyring, grant, persistKeyring, updateKeyringIdentity } from '../src/team/keyring.js'
+import { generateDEK } from '../src/crypto.js'
+import { createNoydb } from '../src/noydb.js'
+import { NoAccessError, PermissionDeniedError, ValidationError } from '../src/errors.js'
+import { PolicyDeniedError } from '../src/policy/errors.js'
+import { STRICT_POLICY } from '../src/policy/presets.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'inline-memory',
+    async get(c, col, id) { return gc(c, col).get(id) },
+    async put(c, col, id, env) { gc(c, col).set(id, env) },
+    async delete(c, col, id) { gc(c, col).delete(id) },
+    async list(c, col) { return [...gc(c, col).keys()] },
+    async loadAll() { return {} },
+    async saveAll() {},
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+  } as unknown as NoydbStore
+}
+
+const ALICE_PHRASE = 'correct horse battery staple printer toaster'
+const BOB_PHRASE = 'glasses cabinet bicycle umbrella thunder velvet'
+const CAROL_PHRASE = 'evergreen marble lantern apricot velvet thunder'
+
+describe('updateKeyringIdentity (team layer, #54)', () => {
+  it('owner updates role + displayName + permissions in one call', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    aliceKr.deks.set('clients', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'viewer',
+      passphrase: BOB_PHRASE,
+    })
+
+    const bobBefore = await loadKeyring(store, 'acme', 'bob', BOB_PHRASE)
+    const dekKeysBefore = [...bobBefore.deks.keys()].sort()
+
+    await updateKeyringIdentity(store, 'acme', aliceKr, {
+      userId: 'bob',
+      role: 'operator',
+      displayName: 'Bob the Operator',
+      permissions: { invoices: 'rw' },
+    })
+
+    // Same passphrase still unlocks — KEK / salt / DEKs unchanged.
+    const bobAfter = await loadKeyring(store, 'acme', 'bob', BOB_PHRASE)
+    expect(bobAfter.userId).toBe('bob')
+    expect(bobAfter.displayName).toBe('Bob the Operator')
+    expect(bobAfter.role).toBe('operator')
+    expect(bobAfter.permissions).toEqual({ invoices: 'rw' })
+
+    // Pure header rewrite — DEK set identical (same collection names, same count).
+    const dekKeysAfter = [...bobAfter.deks.keys()].sort()
+    expect(dekKeysAfter).toEqual(dekKeysBefore)
+  }, 60_000)
+
+  it('partial diff — only specified field changes', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob the Original',
+      role: 'admin',
+      passphrase: BOB_PHRASE,
+    })
+
+    await updateKeyringIdentity(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob the Renamed',
+    })
+
+    const bob = await loadKeyring(store, 'acme', 'bob', BOB_PHRASE)
+    expect(bob.displayName).toBe('Bob the Renamed')
+    // Untouched fields survive.
+    expect(bob.role).toBe('admin')
+  }, 60_000)
+
+  it('tier-2 authenticator slots survive the update (#54 vs peer-recover)', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+      passphrase: BOB_PHRASE,
+    })
+
+    // Inject a tier-2 slot directly into bob's keyring file (no real
+    // ceremony needed — the test only asserts persistence semantics).
+    const env = await store.get('acme', '_keyring', 'bob')
+    const file = JSON.parse(env!._data) as KeyringFile
+    const slot: KeyringAuthenticator = {
+      id: 'webauthn-yubikey',
+      method: 'webauthn',
+      enrolled_at: new Date().toISOString(),
+      enrolled_via_tier: 1,
+      wrapKind: 'kek',
+      wrapped_kek: 'YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=',
+      meta: { credentialId: 'cred-yubi' },
+    }
+    const withSlot: KeyringFile = { ...file, authenticators: [slot] }
+    await store.put('acme', '_keyring', 'bob', {
+      _noydb: 1, _v: 1, _ts: new Date().toISOString(), _iv: '',
+      _data: JSON.stringify(withSlot),
+    })
+
+    await updateKeyringIdentity(store, 'acme', aliceKr, {
+      userId: 'bob',
+      role: 'operator',
+    })
+
+    const bob = await loadKeyring(store, 'acme', 'bob', BOB_PHRASE)
+    expect(bob.role).toBe('operator')
+    expect(bob.authenticators).toHaveLength(1)
+    expect(bob.authenticators[0]?.id).toBe('webauthn-yubikey')
+  }, 60_000)
+
+  it('empty diff throws ValidationError', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+      passphrase: BOB_PHRASE,
+    })
+
+    await expect(
+      updateKeyringIdentity(store, 'acme', aliceKr, { userId: 'bob' }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  }, 30_000)
+
+  it('missing target keyring throws NoAccessError', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    await persistKeyring(store, 'acme', aliceKr)
+
+    await expect(
+      updateKeyringIdentity(store, 'acme', aliceKr, {
+        userId: 'ghost',
+        role: 'operator',
+      }),
+    ).rejects.toBeInstanceOf(NoAccessError)
+  }, 30_000)
+
+  it('admin cannot promote target to owner (PermissionDeniedError on new role)', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    // Alice grants Bob admin; Bob then tries to promote Carol (operator) to owner.
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+      passphrase: BOB_PHRASE,
+    })
+    await grant(store, 'acme', aliceKr, {
+      userId: 'carol',
+      displayName: 'Carol',
+      role: 'operator',
+      passphrase: CAROL_PHRASE,
+    })
+    const bobKr = await loadKeyring(store, 'acme', 'bob', BOB_PHRASE)
+
+    await expect(
+      updateKeyringIdentity(store, 'acme', bobKr, {
+        userId: 'carol',
+        role: 'owner',
+      }),
+    ).rejects.toBeInstanceOf(PermissionDeniedError)
+  }, 60_000)
+
+  it('admin cannot demote an owner (PermissionDeniedError on old role)', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    // Alice (owner) grants Bob admin. Bob tries to demote Alice (owner)
+    // to operator — blocked because the OLD role is owner, which Bob
+    // (admin) cannot manage.
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+      passphrase: BOB_PHRASE,
+    })
+    const bobKr = await loadKeyring(store, 'acme', 'bob', BOB_PHRASE)
+
+    await expect(
+      updateKeyringIdentity(store, 'acme', bobKr, {
+        userId: 'alice',
+        role: 'operator',
+      }),
+    ).rejects.toBeInstanceOf(PermissionDeniedError)
+  }, 60_000)
+
+  it('admin cannot self-promote to owner', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+      passphrase: BOB_PHRASE,
+    })
+    const bobKr = await loadKeyring(store, 'acme', 'bob', BOB_PHRASE)
+
+    await expect(
+      updateKeyringIdentity(store, 'acme', bobKr, {
+        userId: 'bob',
+        role: 'owner',
+      }),
+    ).rejects.toBeInstanceOf(PermissionDeniedError)
+  }, 60_000)
+
+  it('non-admin callers cannot call updateUser even on themselves (use vault.user.updateMe instead)', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'operator',
+      passphrase: BOB_PHRASE,
+    })
+    const bobKr = await loadKeyring(store, 'acme', 'bob', BOB_PHRASE)
+
+    // Operator tries to rename themselves via updateUser. The
+    // role-elevation guard rejects (operator role can't manage any
+    // role, including its own). Self-display-name editing should go
+    // through vault.user.updateMe (the user-envelope API), not the
+    // keyring identity API.
+    await expect(
+      updateKeyringIdentity(store, 'acme', bobKr, {
+        userId: 'bob',
+        displayName: 'Bob the Self-Renamed',
+      }),
+    ).rejects.toBeInstanceOf(PermissionDeniedError)
+  }, 60_000)
+
+  it('permissions: {} clears all collection ACLs', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    aliceKr.deks.set('clients', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'operator',
+      passphrase: BOB_PHRASE,
+      permissions: { invoices: 'rw', clients: 'rw' },
+    })
+
+    await updateKeyringIdentity(store, 'acme', aliceKr, {
+      userId: 'bob',
+      permissions: {},
+    })
+
+    const bob = await loadKeyring(store, 'acme', 'bob', BOB_PHRASE)
+    expect(bob.permissions).toEqual({})
+  }, 60_000)
+
+  it('permissions is full-replacement at the map level (not deep merge)', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    aliceKr.deks.set('clients', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'operator',
+      passphrase: BOB_PHRASE,
+      permissions: { invoices: 'rw', clients: 'rw' },
+    })
+
+    // Pass only `invoices` — the resulting permissions map has ONLY
+    // `invoices`. `clients` is dropped silently. This is the
+    // documented contract; consumers who want a partial merge must
+    // construct it themselves.
+    await updateKeyringIdentity(store, 'acme', aliceKr, {
+      userId: 'bob',
+      permissions: { invoices: 'ro' },
+    })
+
+    const bob = await loadKeyring(store, 'acme', 'bob', BOB_PHRASE)
+    expect(bob.permissions).toEqual({ invoices: 'ro' })
+    expect(bob.permissions).not.toHaveProperty('clients')
+  }, 60_000)
+
+  it('admin can manage admin/operator/viewer/client laterally', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+      passphrase: BOB_PHRASE,
+    })
+    await grant(store, 'acme', aliceKr, {
+      userId: 'carol',
+      displayName: 'Carol',
+      role: 'client',
+      passphrase: CAROL_PHRASE,
+    })
+    const bobKr = await loadKeyring(store, 'acme', 'bob', BOB_PHRASE)
+
+    // Bob (admin) promotes Carol (client → operator). Allowed.
+    await updateKeyringIdentity(store, 'acme', bobKr, {
+      userId: 'carol',
+      role: 'operator',
+    })
+
+    const carol = await loadKeyring(store, 'acme', 'carol', CAROL_PHRASE)
+    expect(carol.role).toBe('operator')
+  }, 60_000)
+})
+
+describe('Noydb.updateUser (hub-level wiring, #54)', () => {
+  it('round-trip via the public Noydb method', async () => {
+    const store = inlineMemory()
+    const alice = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await alice.openVault('acme')
+    await alice.grant('acme', {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'viewer',
+      passphrase: BOB_PHRASE,
+    })
+
+    await alice.updateUser('acme', {
+      userId: 'bob',
+      role: 'operator',
+      displayName: 'Bob the Promoted',
+    })
+
+    const reopen = await createNoydb({ store, user: 'bob', secret: BOB_PHRASE })
+    await reopen.openVault('acme')
+    const bob = await reopen.getKeyring('acme')
+    expect(bob.role).toBe('operator')
+    expect(bob.displayName).toBe('Bob the Promoted')
+  }, 120_000)
+
+  it('STRICT_POLICY rejects updateUser without factor proof', async () => {
+    const store = inlineMemory()
+    const alice = await createNoydb({
+      store,
+      user: 'alice',
+      secret: 'correct horse battery staple printer toaster picnic',
+      policy: STRICT_POLICY,
+    })
+    await alice.openVault('acme')
+    await alice.grant('acme', {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'admin',
+      passphrase: 'glasses cabinet bicycle umbrella thunder velvet picnic',
+    })
+
+    // No factor proof — STRICT_POLICY's update-user gate requires totp/email-otp.
+    await expect(
+      alice.updateUser('acme', { userId: 'bob', role: 'operator' }),
+    ).rejects.toBeInstanceOf(PolicyDeniedError)
+  }, 120_000)
+
+  it('refreshes the cached keyring after self-update', async () => {
+    const store = inlineMemory()
+    const alice = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await alice.openVault('acme')
+
+    // Alice updates her OWN displayName (any role can update displayName
+    // on their own keyring under the role-elevation guard since old/new
+    // role match → owner can update owner). The cached keyring snapshot
+    // is then stale; the test asserts the cache invalidation hook fires.
+    await alice.updateUser('acme', {
+      userId: 'alice',
+      displayName: 'Alice the Updated',
+    })
+
+    const krAfter = await alice.getKeyring('acme')
+    expect(krAfter.displayName).toBe('Alice the Updated')
+  }, 120_000)
+})

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -103,6 +103,7 @@ export type {
   NoydbEventMap,
   GrantOptions,
   RevokeOptions,
+  UpdateUserOptions,
   UserInfo,
   NoydbOptions,
   HistoryConfig,

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -3,6 +3,7 @@ import type {
   NoydbEventMap,
   GrantOptions,
   RevokeOptions,
+  UpdateUserOptions,
   UserInfo,
   PushResult,
   PullResult,
@@ -66,6 +67,7 @@ import {
   rotateKeys as keyringRotate,
   changeSecret as keyringChangeSecret,
   listUsers as keyringListUsers,
+  updateKeyringIdentity,
 } from './team/keyring.js'
 import type { UnlockedKeyring } from './team/keyring.js'
 import {
@@ -455,6 +457,65 @@ export class Noydb {
     this.checkPolicyOperation(vault, 'revoke')
     const keyring = await this.getKeyring(vault)
     await keyringRevoke(this.options.store, vault, keyring, options)
+  }
+
+  /**
+   * Mutate post-grant identity fields on an existing keyring — `role`,
+   * `displayName`, and/or `permissions`. Pure plaintext-header rewrite:
+   * no DEK rewrap, no KEK required, no authenticator slots touched.
+   * Tier-2 enrollments and recovery codes survive.
+   *
+   * Different from `db.revoke + db.grant`:
+   *
+   *   - Same `userId`, same DEK wrappings, same `granted_by`, same
+   *     `_users/<keyringId>` envelope. Only the specified header
+   *     fields move. Last-write-wins via the standard keyring put.
+   *   - No cascade on role demotion (admins demoted to operator keep
+   *     the keyrings they previously granted; the cascade rules are
+   *     a `db.revoke` concern, not `db.updateUser`).
+   *   - Tier-2 slots NOT dropped — the wrapping is unaffected.
+   *
+   * Role-elevation guard: BOTH the old and new role must satisfy
+   * `db.grant`'s hierarchy. Owner can do anything; admin manages
+   * admin/operator/viewer/client laterally; admin cannot promote to
+   * owner OR demote from owner. The guard runs regardless of the
+   * `update-user` policy gate's settings — gates can only be more
+   * permissive than the structural floor, never less.
+   *
+   * Gated by `update-user`. `STRICT_POLICY` requires a TOTP/email-OTP
+   * factor proof so the operator affirmatively re-asserts identity at
+   * the moment of mutation; `PERSONAL_POLICY` accepts a tier-1 unlock
+   * alone.
+   *
+   * ```ts
+   * await db.updateUser('acme', {
+   *   userId: 'bob',
+   *   role: 'operator',                 // promote
+   *   permissions: { invoices: 'rw' },
+   * }, { factors: [{ kind: 'totp' }] })
+   * ```
+   *
+   * @throws `NoAccessError` when no keyring exists for the target.
+   * @throws `PermissionDeniedError` when the role hierarchy rejects.
+   * @throws `ValidationError` when no field is provided.
+   *
+   * @see #54
+   */
+  async updateUser(
+    vault: string,
+    options: UpdateUserOptions,
+    factors?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+  ): Promise<void> {
+    await this.checkGate(vault, 'update-user', factors)
+    const keyring = await this.getKeyring(vault)
+    await updateKeyringIdentity(this.options.store, vault, keyring, options)
+    // If the caller updated their own role / permissions, the cached
+    // unlocked keyring is stale — drop it so the next access reloads
+    // with the new header fields. (DEKs unchanged, so the cached
+    // unlock still works; only the role-gated checks would diverge.)
+    if (options.userId === this.options.user) {
+      this.keyringCache.delete(vault)
+    }
   }
 
   /**

--- a/packages/hub/src/policy/presets.ts
+++ b/packages/hub/src/policy/presets.ts
@@ -50,6 +50,12 @@ export const PERSONAL_POLICY: VaultPolicy = Object.freeze({
     // virtue of being a co-owner). Tier-1 unlock is the floor; the
     // STRICT preset adds a recovery/email-OTP requirement.
     'peer-recover-user': { minTier: 1 },
+    // update-user: post-grant identity mutation (role/displayName/
+    // permissions). PERSONAL_POLICY treats this on par with enroll-user
+    // / revoke-user — tier-1 unlock alone. The role-elevation guard
+    // inside the implementation is the structural backstop that this
+    // gate's settings cannot weaken.
+    'update-user': { minTier: 1 },
     'export-bundle': { minTier: 1 },
     'export-plaintext': {
       minTier: 1,
@@ -123,6 +129,18 @@ export const STRICT_POLICY: VaultPolicy = Object.freeze({
     'peer-recover-user': {
       minTier: 1,
       factors: [{ anyOf: ['recovery', 'totp', 'email-otp', 'webauthn-roaming'] }],
+    },
+    // STRICT update-user: matches the enroll-user / revoke-user shape
+    // (off-device factor required). Update-user is admin-shaped — it
+    // mutates someone else's role/permissions; STRICT requires a fresh
+    // off-device factor proof so the operator affirmatively re-asserts
+    // identity at the moment of mutation. Platform-bound factors
+    // (Touch ID / password / PIN) intentionally excluded: same logic as
+    // peer-recover-user — the off-device requirement is the whole
+    // point under STRICT.
+    'update-user': {
+      minTier: 1,
+      factors: [{ anyOf: ['totp', 'email-otp'] }],
     },
     'export-bundle': {
       minTier: 1,

--- a/packages/hub/src/policy/types.ts
+++ b/packages/hub/src/policy/types.ts
@@ -117,6 +117,15 @@ export type BuiltInGateName =
    * affirmatively prove identity at the moment of recovery.
    */
   | 'peer-recover-user'
+  /**
+   * Authorize a post-grant identity mutation — `db.updateUser` (#54).
+   * Covers `role`, `displayName`, `permissions` changes on an existing
+   * keyring. Pure plaintext-header rewrite — no DEKs touched, no KEK
+   * required. The role-elevation guard inside the implementation
+   * mirrors `db.grant`'s hierarchy (admin cannot promote to owner)
+   * regardless of this gate's settings.
+   */
+  | 'update-user'
 
 /** Either a built-in gate name or an `app:*` custom gate. */
 export type GateName = BuiltInGateName | `app:${string}`

--- a/packages/hub/src/team/keyring.ts
+++ b/packages/hub/src/team/keyring.ts
@@ -1,4 +1,4 @@
-import type { NoydbStore, KeyringFile, KeyringAuthenticator, Role, Permissions, GrantOptions, RevokeOptions, UserInfo, EncryptedEnvelope, ExportCapability, ExportFormat, ImportCapability, VaultPolicyOnDisk } from '../types.js'
+import type { NoydbStore, KeyringFile, KeyringAuthenticator, Role, Permissions, GrantOptions, RevokeOptions, UpdateUserOptions, UserInfo, EncryptedEnvelope, ExportCapability, ExportFormat, ImportCapability, VaultPolicyOnDisk } from '../types.js'
 import { NOYDB_KEYRING_VERSION, NOYDB_FORMAT_VERSION } from '../types.js'
 import {
   deriveKey,
@@ -55,6 +55,24 @@ function canGrant(callerRole: Role, targetRole: Role): boolean {
 
 function canRevoke(callerRole: Role, targetRole: Role): boolean {
   if (targetRole === 'owner') return false // owner cannot be revoked
+  if (callerRole === 'owner') return true
+  if (callerRole === 'admin') return ADMIN_GRANTABLE_TARGETS.includes(targetRole)
+  return false
+}
+
+/**
+ * Whether `callerRole` can mutate a keyring whose role is (or becomes)
+ * `targetRole`. Used by `updateKeyringIdentity` (#54).
+ *
+ * Mirrors `canGrant`'s hierarchy: admins manage admin/operator/viewer/
+ * client laterally; admins cannot create or destroy `owner`-shaped
+ * keyrings. Owner can do anything.
+ *
+ * Both the OLD role and the NEW role must satisfy this check —
+ * otherwise admin could elevate themselves (`admin → owner`) or demote
+ * an owner (`owner → admin`) under cover of "update."
+ */
+function canUpdateRole(callerRole: Role, targetRole: Role): boolean {
   if (callerRole === 'owner') return true
   if (callerRole === 'admin') return ADMIN_GRANTABLE_TARGETS.includes(targetRole)
   return false
@@ -487,6 +505,87 @@ export async function revoke(
   if (options.rotateKeys !== false && affectedCollections.size > 0) {
     await rotateKeys(adapter, vault, callerKeyring, [...affectedCollections])
   }
+}
+
+// ─── Update User (#54) ─────────────────────────────────────────────────
+
+/**
+ * Mutate `role`, `displayName`, and/or `permissions` on an existing
+ * keyring. Pure plaintext-header rewrite — no DEK rewrap, no KEK
+ * required, no authenticator slots touched. Tier-2 enrollments and
+ * recovery codes survive the operation.
+ *
+ * Role-elevation guard: BOTH the old role AND the new role must
+ * satisfy `canUpdateRole(callerRole, _)`. This blocks the two
+ * privilege-escalation shapes:
+ *   - admin elevates someone (or themselves) to owner
+ *   - admin demotes an owner to a role they then control
+ *
+ * Owner is always allowed. Admin manages admin / operator / viewer /
+ * client laterally.
+ *
+ * Identity preserved: same userId, same DEK wrappings. Last-write-wins
+ * through the standard keyring put (same concurrency story as `grant`
+ * and `revoke`).
+ *
+ * @throws `NoAccessError` when no keyring exists for the target.
+ * @throws `PermissionDeniedError` when the role hierarchy rejects.
+ * @throws `ValidationError` when the diff is empty (nothing to update).
+ *
+ * @see #54
+ */
+export async function updateKeyringIdentity(
+  adapter: NoydbStore,
+  vault: string,
+  callerKeyring: UnlockedKeyring,
+  options: UpdateUserOptions,
+): Promise<void> {
+  if (
+    options.role === undefined &&
+    options.displayName === undefined &&
+    options.permissions === undefined
+  ) {
+    throw new ValidationError(
+      `updateUser: at least one of role / displayName / permissions must be provided ` +
+        `(userId: "${options.userId}").`,
+    )
+  }
+
+  const env = await adapter.get(vault, '_keyring', options.userId)
+  if (!env) {
+    throw new NoAccessError(
+      `updateUser: user "${options.userId}" has no keyring in vault "${vault}".`,
+    )
+  }
+  const target = JSON.parse(env._data) as KeyringFile
+
+  // Role-elevation guard. The OLD role must be one this caller is
+  // allowed to manage, AND the NEW role (if changing) must be too.
+  // Two-sided check: blocks admin→owner promotion (new side) and
+  // demoting an owner (old side).
+  if (!canUpdateRole(callerKeyring.role, target.role)) {
+    throw new PermissionDeniedError(
+      `Role "${callerKeyring.role}" cannot update a keyring with role "${target.role}"`,
+    )
+  }
+  if (
+    options.role !== undefined &&
+    options.role !== target.role &&
+    !canUpdateRole(callerKeyring.role, options.role)
+  ) {
+    throw new PermissionDeniedError(
+      `Role "${callerKeyring.role}" cannot promote target to role "${options.role}"`,
+    )
+  }
+
+  const next: KeyringFile = {
+    ...target,
+    ...(options.role !== undefined && { role: options.role }),
+    ...(options.displayName !== undefined && { display_name: options.displayName }),
+    ...(options.permissions !== undefined && { permissions: options.permissions }),
+  }
+
+  await writeKeyringFile(adapter, vault, options.userId, next)
 }
 
 // ─── Key Rotation ──────────────────────────────────────────────────────

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -1027,6 +1027,40 @@ export interface GrantOptions {
   readonly initialProfile?: unknown
 }
 
+/**
+ * Caller payload for `db.updateUser` (#54). Mutate one or more
+ * identity fields on an existing keyring without rotating any keys.
+ *
+ * `role`, `displayName`, and `permissions` live in the plaintext header
+ * of `_keyring/<userId>` (the sync engine reads them without keys).
+ * Mutating them is a JSON header swap — no DEK rewrap, no KEK
+ * required, no authenticator slots touched. Tier-2 slots and recovery
+ * enrollments survive unchanged. Last-write-wins through the existing
+ * keyring put (same concurrency story as `db.grant` / `db.revoke`).
+ *
+ * Top-level fields are partial-merge: absent fields are not modified.
+ * `permissions`, however, is a **full replacement** at the map level —
+ * passing `{ invoices: 'rw' }` REPLACES the entire permissions map,
+ * silently dropping any other entries. To partially update, read the
+ * current keyring and merge: `permissions: { ...current, invoices: 'rw' }`.
+ * To clear all permissions, pass `permissions: {}` explicitly.
+ *
+ * Role-elevation guard: the same hierarchy as `db.grant`. Admins can
+ * change `admin` / `operator` / `viewer` / `client` to and from each
+ * other; admins cannot promote to or demote from `owner`. Owners can
+ * do anything. Non-admin callers (operator/viewer/client) cannot call
+ * `db.updateUser` at all — for self-displayName changes, use
+ * `vault.user.updateMe` (the user-envelope API).
+ *
+ * @see #54
+ */
+export interface UpdateUserOptions {
+  readonly userId: string
+  readonly role?: Role
+  readonly displayName?: string
+  readonly permissions?: Permissions
+}
+
 export interface RevokeOptions {
   readonly userId: string
   readonly rotateKeys?: boolean


### PR DESCRIPTION
## Summary

- New `db.updateUser(vault, options, factors?)` method for post-grant identity mutation.
- Pure plaintext-header rewrite — no DEK rewrap, no KEK required, no authenticator slots touched. Tier-2 enrollments and recovery codes survive.
- New `update-user` policy gate (PERSONAL: `minTier: 1`; STRICT: `minTier: 1` + TOTP/email-OTP factor).
- Role-elevation guard mirroring `db.grant`'s hierarchy. Two-sided check on old AND new role blocks the four privilege-escalation shapes (admin self-promote, admin promote-others-to-owner, admin demote-owner, non-admin self-edit).

## Surface change checklist

- `UpdateUserOptions` interface (new). Fields: `userId`, optional `role` / `displayName` / `permissions`.
- `BuiltInGateName` adds `'update-user'`.
- `PERSONAL_POLICY` and `STRICT_POLICY` both gain a default for `update-user`.
- `Noydb.updateUser` method (new public surface).
- `updateKeyringIdentity` exported from `team/keyring.ts` (tested directly at the team layer).
- `UpdateUserOptions` re-exported from `@noy-db/hub`.

## Design choices flagged for reviewers

**STRICT factor surface.** Issue #54 proposed `['totp','email-otp','recovery','webauthn-roaming']` mirroring `peer-recover-user`. The shipped surface is tighter — `['totp','email-otp']` mirroring `enroll-user` / `revoke-user`. Update-user is admin-shaped (mutating someone else's role/permissions), closer to enroll/revoke than to recovery — recovery factors carry a "the user lost something" semantic that doesn't fit a routine role change. Override per-vault if your threat model needs the wider set.

**`permissions` is full-replacement.** Passing `permissions: { invoices: 'rw' }` REPLACES the entire map, silently dropping any other entries. The alternative (deep-merge) requires consumers to opt out of replacement to clear permissions; the chosen shape requires opt-in to merge but makes "clear all" trivial (`permissions: {}`). Documented on `UpdateUserOptions`.

**Concurrency.** Last-write-wins through the standard keyring put — same story as `db.grant` / `db.revoke`. The keyring write path doesn't yet thread `expectedVersion`; that's a pre-existing gap and not in scope here.

**Cache invalidation.** Self-update invalidates `keyringCache[vault]` so the caller's next access reloads the new header. Same pattern as `recoverUser` (`noydb.ts:1507`). `policyCache` / `policyEnforcers` are not invalidated because role isn't currently policy-cache-keyed.

## Test plan

- [x] `pnpm --filter @noy-db/hub typecheck` — clean
- [x] `pnpm --filter @noy-db/hub lint` — clean
- [x] `pnpm vitest run packages/hub/__tests__/update-user.test.ts` — 15 / 15 pass
- [x] `pnpm vitest run packages/hub` — 1363 / 1363 pass (no regressions)
- [x] `pnpm vitest run packages/on-magic-link packages/on-password packages/on-recovery` — 68 / 68 pass (downstream sanity)

## Test coverage map

| Scenario | Test |
|---|---|
| Round-trip (role + displayName + permissions) | ✅ |
| Partial diff (only displayName changes) | ✅ |
| DEKs preserved, no re-encrypt | ✅ |
| Tier-2 authenticator slots survive | ✅ |
| Empty diff → ValidationError | ✅ |
| Missing keyring → NoAccessError | ✅ |
| admin → promote target to owner: blocked | ✅ |
| admin → demote owner: blocked | ✅ |
| admin → self-promote to owner: blocked | ✅ |
| operator → self-displayName via updateUser: blocked | ✅ (use vault.user.updateMe) |
| admin → lateral admin/operator/viewer/client moves: allowed | ✅ |
| permissions: {} clears all ACLs | ✅ |
| permissions: { x: ... } drops other entries (full-replace) | ✅ |
| db.updateUser hub round-trip | ✅ |
| STRICT_POLICY rejects without factor proof | ✅ |
| Self-update refreshes keyring cache | ✅ |

## Milestone

[v0.1.0-pre.9](https://github.com/vLannaAi/noy-db/milestone/3)

Closes #54.
