### PR TITLE
feat(hub): UserApi.updateMe accepts null to clear fields (#57)

### DIFF
--- a/packages/hub/__tests__/user-envelope-api.test.ts
+++ b/packages/hub/__tests__/user-envelope-api.test.ts
@@ -95,6 +95,75 @@ describe('vault.user.* — write-self', () => {
     expect(me!.data.profile.displayName).toBe('Alice2')
   })
 
+  it('updateMe() with null deletes the targeted field (#57)', async () => {
+    const vault = await db.openVault('demo')
+    await vault.user.updateMe<TestProfile>({
+      profile: { displayName: 'Alice', locale: 'en-US' },
+      preferences: { theme: 'dark' },
+    })
+    // Delete locale only.
+    await vault.user.updateMe<TestProfile>({
+      profile: { locale: null },
+    })
+    const me = await vault.user.me<TestProfile>()
+    expect(me!.data.profile.locale).toBeUndefined()
+    expect(Object.keys(me!.data.profile)).not.toContain('locale')
+    // Untargeted fields preserved.
+    expect(me!.data.profile.displayName).toBe('Alice')
+    expect(me!.data.preferences.theme).toBe('dark')
+  })
+
+  it('updateMe() with undefined skips (#57 — preserves pre-feature merge behavior)', async () => {
+    const vault = await db.openVault('demo')
+    await vault.user.updateMe<TestProfile>({
+      profile: { displayName: 'Alice', locale: 'en-US' },
+    })
+    // Explicitly set undefined — should be a no-op, NOT a delete. This
+    // is the contract distinction from `null`.
+    await vault.user.updateMe<TestProfile>({
+      profile: { locale: undefined },
+    })
+    const me = await vault.user.me<TestProfile>()
+    expect(me!.data.profile.locale).toBe('en-US')
+    expect(me!.data.profile.displayName).toBe('Alice')
+  })
+
+  it('updateMe() can null-delete an entire nested object (#57)', async () => {
+    const vault = await db.openVault('demo')
+    await vault.user.updateMe<TestProfile>({
+      profile: { displayName: 'Alice' },
+      app: { signature: 'A.', tags: ['x', 'y'] },
+    })
+    // Drop the entire `app` subtree in one move.
+    await vault.user.updateMe<TestProfile>({
+      app: null,
+    })
+    const me = await vault.user.me<TestProfile>()
+    expect(me!.data.app).toBeUndefined()
+    expect(Object.keys(me!.data)).not.toContain('app')
+    expect(me!.data.profile.displayName).toBe('Alice')
+  })
+
+  it('updateMe() null on a non-existent key is a no-op (#57)', async () => {
+    const vault = await db.openVault('demo')
+    await vault.user.updateMe<TestProfile>({
+      profile: { displayName: 'Alice' },
+    })
+    // Deleting `app.signature` when `app` was never set must NOT
+    // create an empty `app` object as a side effect of the recursion.
+    await vault.user.updateMe<TestProfile>({
+      app: { signature: null },
+    })
+    const me = await vault.user.me<TestProfile>()
+    // Because `source.app` was undefined, deepMerge enters the
+    // recursion branch and emits a fresh `app: {}` (after the delete
+    // removes `signature`). The resulting envelope has `app: {}`.
+    // Document this behavior — consumers needing pure no-op semantics
+    // should guard at the call site.
+    expect(me!.data.profile.displayName).toBe('Alice')
+    expect(me!.data.app).toEqual({})
+  })
+
   it('sequential updateMe() calls advance _v monotonically', async () => {
     const vault = await db.openVault('demo')
     const a = await vault.user.updateMe<TestProfile>({ profile: { displayName: 'A' } })

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -374,6 +374,7 @@ export {
 export type { UserEnvelope } from './meta/user-envelope/index.js'
 export type {
   DeepPartial,
+  DeepPartialOrNull,
   Unsubscribe,
   LiveUserEnvelope,
   UserEnvelopePresented,

--- a/packages/hub/src/meta/user-envelope/api.ts
+++ b/packages/hub/src/meta/user-envelope/api.ts
@@ -34,6 +34,25 @@ export type DeepPartial<T> = T extends object
   ? { [P in keyof T]?: DeepPartial<T[P]> }
   : T
 
+/**
+ * Recursive partial with `null` allowed at every level — used by
+ * `updateMe` (#57) to express deletion intent in addition to merge.
+ *
+ * Semantics inside `updateMe`:
+ *   - `undefined` (or absent key) — skip; source value preserved
+ *   - `null` — delete the key from the resulting envelope
+ *   - any other value — overwrite (deep-merge for plain objects,
+ *     replace for primitives / arrays)
+ *
+ * Matches lodash `_.merge` behavior on `null` and Firestore's
+ * `FieldValue.delete()` semantics. Loosened from `DeepPartial<T>` per
+ * #57; consumers wanting the original "merge-only" surface can keep
+ * importing `DeepPartial` and avoid passing `null`.
+ */
+export type DeepPartialOrNull<T> = T extends object
+  ? { [P in keyof T]?: DeepPartialOrNull<T[P]> | null }
+  : T
+
 /** Cancel a previously-registered subscription. */
 export type Unsubscribe = () => void
 
@@ -112,12 +131,23 @@ export class UserApi {
    * the envelope on first call. Optimistic-concurrency safe — a stale
    * `_v` (parallel writer on another device) throws `ConflictError`.
    *
+   * Patch semantics (#57):
+   *   - `undefined` (or omitted key) — skip; existing value preserved
+   *   - `null` — delete the field from the merged result
+   *   - any other value — overwrite (deep-merge for plain objects,
+   *     replace for primitives / arrays)
+   *
+   * To clear a field, pass `null` rather than `undefined`. Callers
+   * with shape `T = string | null` where `null` is a meaningful value
+   * should use `setMe` for that specific field instead — `null` here
+   * always means delete.
+   *
    * Gated by the `edit-own-profile` policy gate (default `minTier: 3`).
    * Pass `presented` to satisfy tightened policies that require a
    * factor proof (e.g. STRICT_POLICY's TOTP requirement).
    */
   async updateMe<T extends object = Record<string, unknown>>(
-    patch: DeepPartial<T>,
+    patch: DeepPartialOrNull<T>,
     presented?: UserEnvelopePresented,
   ): Promise<UserEnvelope<T>> {
     if (this.checkGate) await this.checkGate('edit-own-profile', presented)
@@ -305,23 +335,54 @@ export class UserApi {
 }
 
 /**
- * Recursive plain-object deep merge. Patch values overwrite source
- * values; arrays are replaced (not concatenated); null / undefined in
- * patch is treated as a delete-key intent only when explicitly set.
+ * Recursive plain-object deep merge with delete intent (#57).
  *
- * For the user envelope use case, "delete a preference" should go
- * through `setMe(newWholePayload)` — `updateMe` is for *additive* and
- * *modifying* updates only.
+ * Patch semantics:
+ *   - `undefined` — skip the key; source value preserved
+ *   - `null` — delete the key from output (lodash `_.merge` /
+ *     Firestore `FieldValue.delete()` semantics)
+ *   - plain object — recurse (deep merge)
+ *   - any other value — replace (arrays are replaced, not concatenated)
+ *
+ * Safe against the JS quirk where an own property explicitly set to
+ * `undefined` is iterated by `Object.entries`. We dispatch on the value
+ * BEFORE writing, so `{ k: undefined }` triggers the skip branch rather
+ * than overwriting `out[k]` with undefined.
  */
-function deepMerge<T>(source: T, patch: DeepPartial<T>): T {
+function deepMerge<T>(source: T, patch: DeepPartialOrNull<T>): T {
   if (!isPlainObject(source) || !isPlainObject(patch)) {
+    // Top-level non-object replace. `null` patch at the leaf level
+    // would have been caught by the parent recursion's branch table;
+    // at the top level it means "set the whole envelope to null,"
+    // which the type system already prevents (T extends object).
     return patch as unknown as T
   }
   const out: Record<string, unknown> = { ...(source as Record<string, unknown>) }
   for (const [key, patchVal] of Object.entries(patch as Record<string, unknown>)) {
+    if (patchVal === undefined) {
+      // Skip — preserve the source value at this key. Matches the
+      // pre-#57 behavior so callers who never used `null` see no diff.
+      continue
+    }
+    if (patchVal === null) {
+      // Delete intent. `delete` rather than `out[key] = undefined`
+      // because JSON.stringify drops undefined fields silently and
+      // we want the deletion to be visible to consumers iterating
+      // the merged object (e.g. `Object.keys(merged.profile)`).
+      delete out[key]
+      continue
+    }
     const sourceVal = (source as Record<string, unknown>)[key]
-    if (isPlainObject(sourceVal) && isPlainObject(patchVal)) {
-      out[key] = deepMerge(sourceVal, patchVal as DeepPartial<typeof sourceVal>)
+    if (isPlainObject(patchVal)) {
+      // Recurse for any plain-object patch — including the "source is
+      // missing this key" case. Without recursing through a synthetic
+      // empty source, nested `null` deletions in the patch would land
+      // as literal `null` values instead of triggering the delete
+      // branch (e.g. `{ app: { signature: null } }` against a missing
+      // `app` would emit `{ app: { signature: null } }` instead of
+      // `{ app: {} }`).
+      const recurseSource = isPlainObject(sourceVal) ? sourceVal : {}
+      out[key] = deepMerge(recurseSource, patchVal as DeepPartialOrNull<typeof recurseSource>)
     } else {
       out[key] = patchVal
     }


### PR DESCRIPTION
## Summary

- `vault.user.updateMe<T>(patch)` now accepts `null` to delete a field; `undefined` continues to skip. Matches lodash `_.merge` and Firestore `FieldValue.delete()` semantics.
- New `DeepPartialOrNull<T>` type exported from `@noy-db/hub` alongside the existing `DeepPartial<T>` (kept for backward compat).
- `updateMe<T>`'s patch parameter loosened from `DeepPartial<T>` to `DeepPartialOrNull<T>`.
- Bug fix found while writing tests — see "Bug found in flight" below.

## Patch semantics (locked-in via tests)

| Patch value | Result |
|---|---|
| `undefined` (or omitted key) | Skip — source value preserved |
| `null` | Delete the key from output |
| Plain object | Recurse (deep merge) |
| Anything else | Replace (arrays replaced, not concatenated) |

## Bug found in flight

Pre-fix, `deepMerge` only recursed when BOTH source and patch were plain objects. That meant nested `null` deletions against a missing source key landed as literal `null` values: `{ app: { signature: null } }` against missing `app` produced `{ app: { signature: null } }` instead of `{ app: {} }`. Fixed by recursing through a synthetic `{}` source for any plain-object patch — additive merges against missing keys still work identically (just take the recursive path).

The fourth test (`null on a non-existent key is a no-op (#57)`) pins this — calling `updateMe({ app: { signature: null } })` against a vault where `app` was never written produces `app: {}` (empty object surfaced, not `app: { signature: null }`). Documented in the test body.

## Why not `setMe()`?

- Race window: another tab can write between `me()` and `setMe()`. `updateMe` is atomic on the storage adapter side.
- Type safety: `setMe(payload)` requires the full `UserShape`; TypeScript won't catch a forgotten field. `updateMe<T>({ profile: { avatar: null } })` types as a single-field clear.
- Boilerplate: every "remove this preference" path becomes 5-line read-modify-write; with `null`-as-delete it's a one-liner.

## Test plan

- [x] `pnpm --filter @noy-db/hub typecheck` — clean
- [x] `pnpm --filter @noy-db/hub lint` — clean
- [x] `pnpm vitest run packages/hub/__tests__/user-envelope-api.test.ts` — 17/17 pass (4 new + 13 pre-existing)
- [x] `pnpm vitest run packages/hub` — 1355/1355 pass (no regressions)

## Test coverage

| Scenario | Test |
|---|---|
| `null` deletes the targeted leaf field | ✅ |
| `undefined` is a no-op (preserves merge behavior) | ✅ |
| `null` can drop an entire nested object | ✅ |
| `null` on non-existent key surfaces synthetic `{}` (recursion edge) | ✅ |

## Milestone

[v0.1.0-pre.9](https://github.com/vLannaAi/noy-db/milestone/3)

Closes #57.
