### PR TITLE
feat(hub): db.updateAuthenticator(slotId, { meta }) for slot rename (#55)

### DIFF
--- a/packages/hub/__tests__/update-authenticator.test.ts
+++ b/packages/hub/__tests__/update-authenticator.test.ts
@@ -1,0 +1,255 @@
+/**
+ * #55 — db.updateAuthenticator(slotId, { meta }) for slot nickname rename.
+ *
+ * Pinned behaviors:
+ *   1. Round-trip — meta keys merged, wrap material preserved.
+ *   2. Anti-slot-swap is structural — id, method, wrapped_kek (or
+ *      wrapped_deks + iv) cannot change through this entry point;
+ *      only `meta` is mutable.
+ *   3. null-as-delete on meta keys (#57-aligned semantics, scoped to
+ *      the top-level meta merge).
+ *   4. Non-existent slot → NoAccessError.
+ *   5. Empty diff → ValidationError.
+ *   6. Idempotent meta merge — re-applying the same patch is a no-op.
+ *   7. Hub-level gating — `db.updateAuthenticator` runs the
+ *      `update-authenticator` gate. STRICT_POLICY without factor proof
+ *      rejects.
+ *   8. wrap-KEK and wrap-DEKs slots both round-trip identically (the
+ *      rename path is variant-agnostic).
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, KeyringAuthenticator } from '../src/types.js'
+import { createOwnerKeyring, loadKeyring, persistKeyring } from '../src/team/keyring.js'
+import { enrollAuthenticator, updateAuthenticator } from '../src/team/authenticators.js'
+import { generateDEK } from '../src/crypto.js'
+import { createNoydb } from '../src/noydb.js'
+import { NoAccessError, ValidationError } from '../src/errors.js'
+import { PolicyDeniedError } from '../src/policy/errors.js'
+import { STRICT_POLICY } from '../src/policy/presets.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'inline-memory',
+    async get(c, col, id) { return gc(c, col).get(id) },
+    async put(c, col, id, env) { gc(c, col).set(id, env) },
+    async delete(c, col, id) { gc(c, col).delete(id) },
+    async list(c, col) { return [...gc(c, col).keys()] },
+    async loadAll() { return {} },
+    async saveAll() {},
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+  } as unknown as NoydbStore
+}
+
+const PHRASE = 'correct horse battery staple printer toaster'
+const STRICT_PHRASE = 'correct horse battery staple printer toaster picnic'
+
+describe('updateAuthenticator (team layer, #55)', () => {
+  it('merges meta keys, preserves wrap material (wrap-KEK)', async () => {
+    const store = inlineMemory()
+    const keyring = await createOwnerKeyring(store, 'acme', 'alice', PHRASE)
+    keyring.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', keyring)
+
+    const enrolled = await enrollAuthenticator(store, 'acme', keyring, {
+      id: 'webauthn-yubi',
+      method: 'webauthn',
+      meta: { credentialId: 'cred-yubi', prfUsed: true },
+      wrapped_kek: 'YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=',
+    })
+
+    const next = await updateAuthenticator(store, 'acme', enrolled, 'webauthn-yubi', {
+      meta: { nickname: 'Blue YubiKey' },
+    })
+
+    const reloaded = await loadKeyring(store, 'acme', 'alice', PHRASE)
+    expect(reloaded.authenticators).toHaveLength(1)
+    const slot = reloaded.authenticators[0]!
+    // Original meta keys preserved (top-level merge).
+    expect(slot.meta.credentialId).toBe('cred-yubi')
+    expect(slot.meta.prfUsed).toBe(true)
+    // New meta key landed.
+    expect(slot.meta.nickname).toBe('Blue YubiKey')
+    // Wrap material UNCHANGED — anti-slot-swap structural guard.
+    if (slot.wrapKind !== 'deks') {
+      expect(slot.wrapped_kek).toBe('YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=')
+    } else {
+      throw new Error('expected wrap-KEK slot, got wrap-DEKs')
+    }
+    expect(next.authenticators[0]!.id).toBe('webauthn-yubi')
+    expect(next.authenticators[0]!.method).toBe('webauthn')
+  }, 60_000)
+
+  it('round-trips on wrap-DEKs slots without crossing the variant boundary', async () => {
+    const store = inlineMemory()
+    const keyring = await createOwnerKeyring(store, 'acme', 'alice', PHRASE)
+    keyring.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', keyring)
+
+    await enrollAuthenticator(store, 'acme', keyring, {
+      id: 'password-daily',
+      method: 'password',
+      wrapKind: 'deks',
+      wrapped_deks: 'YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmI=',
+      iv: 'aWl2aXZpdml2aXY=',
+      meta: { salt: 'cmFuZG9tc2FsdA==', minLength: 12 },
+    })
+    // Reload to pick up the persisted slot in a fresh keyring snapshot.
+    const fresh = await loadKeyring(store, 'acme', 'alice', PHRASE)
+    await updateAuthenticator(store, 'acme', fresh, 'password-daily', {
+      meta: { nickname: 'Daily password' },
+    })
+
+    const reloaded = await loadKeyring(store, 'acme', 'alice', PHRASE)
+    const slot = reloaded.authenticators[0]!
+    expect(slot.wrapKind).toBe('deks')
+    if (slot.wrapKind === 'deks') {
+      expect(slot.wrapped_deks).toBe('YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmI=')
+      expect(slot.iv).toBe('aWl2aXZpdml2aXY=')
+    }
+    expect(slot.meta.salt).toBe('cmFuZG9tc2FsdA==')
+    expect(slot.meta.minLength).toBe(12)
+    expect(slot.meta.nickname).toBe('Daily password')
+  }, 60_000)
+
+  it('null in a meta key deletes that key (#55 ↔ #57 semantics)', async () => {
+    const store = inlineMemory()
+    const keyring = await createOwnerKeyring(store, 'acme', 'alice', PHRASE)
+    keyring.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', keyring)
+
+    await enrollAuthenticator(store, 'acme', keyring, {
+      id: 'webauthn-mac',
+      method: 'webauthn',
+      meta: { credentialId: 'cred-mac', nickname: 'MacBook Touch ID', prfUsed: true },
+      wrapped_kek: 'YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=',
+    })
+    const fresh = await loadKeyring(store, 'acme', 'alice', PHRASE)
+
+    // Drop the nickname; preserve the rest.
+    await updateAuthenticator(store, 'acme', fresh, 'webauthn-mac', {
+      meta: { nickname: null },
+    })
+
+    const reloaded = await loadKeyring(store, 'acme', 'alice', PHRASE)
+    const slot = reloaded.authenticators[0]!
+    expect(slot.meta.nickname).toBeUndefined()
+    expect(Object.keys(slot.meta)).not.toContain('nickname')
+    expect(slot.meta.credentialId).toBe('cred-mac')
+    expect(slot.meta.prfUsed).toBe(true)
+  }, 60_000)
+
+  it('throws NoAccessError when slot id is unknown', async () => {
+    const store = inlineMemory()
+    const keyring = await createOwnerKeyring(store, 'acme', 'alice', PHRASE)
+    await persistKeyring(store, 'acme', keyring)
+
+    await expect(
+      updateAuthenticator(store, 'acme', keyring, 'webauthn-ghost', {
+        meta: { nickname: 'Ghost' },
+      }),
+    ).rejects.toBeInstanceOf(NoAccessError)
+  }, 30_000)
+
+  it('throws ValidationError on empty diff', async () => {
+    const store = inlineMemory()
+    const keyring = await createOwnerKeyring(store, 'acme', 'alice', PHRASE)
+    keyring.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', keyring)
+
+    const enrolled = await enrollAuthenticator(store, 'acme', keyring, {
+      id: 'webauthn-x',
+      method: 'webauthn',
+      meta: { credentialId: 'cred-x' },
+      wrapped_kek: 'YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=',
+    })
+
+    await expect(
+      updateAuthenticator(store, 'acme', enrolled, 'webauthn-x', {}),
+    ).rejects.toBeInstanceOf(ValidationError)
+  }, 30_000)
+
+  it('idempotent meta merge — re-applying the same patch yields the same slot', async () => {
+    const store = inlineMemory()
+    const keyring = await createOwnerKeyring(store, 'acme', 'alice', PHRASE)
+    keyring.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', keyring)
+
+    const enrolled = await enrollAuthenticator(store, 'acme', keyring, {
+      id: 'webauthn-x',
+      method: 'webauthn',
+      meta: { credentialId: 'cred-x' },
+      wrapped_kek: 'YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=',
+    })
+
+    const a = await updateAuthenticator(store, 'acme', enrolled, 'webauthn-x', {
+      meta: { nickname: 'X' },
+    })
+    const b = await updateAuthenticator(store, 'acme', a, 'webauthn-x', {
+      meta: { nickname: 'X' },
+    })
+    expect(b.authenticators[0]!.meta.nickname).toBe('X')
+  }, 60_000)
+})
+
+describe('Noydb.updateAuthenticator (hub-level wiring, #55)', () => {
+  // Fixture helper: bootstrap the keyring + inject a slot via the team
+  // layer BEFORE creating the Noydb instance, so the keyring cache
+  // populates with the injected slot already present on disk.
+  async function bootstrapVaultWithSlot(
+    store: NoydbStore,
+    phrase: string,
+    slotId: string,
+  ): Promise<void> {
+    const keyring = await createOwnerKeyring(store, 'acme', 'alice', phrase)
+    keyring.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', keyring)
+    await enrollAuthenticator(store, 'acme', keyring, {
+      id: slotId,
+      method: 'webauthn',
+      meta: { credentialId: `cred-${slotId}` },
+      wrapped_kek: 'YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=',
+    })
+  }
+
+  it('round-trip via the public Noydb method', async () => {
+    const store = inlineMemory()
+    await bootstrapVaultWithSlot(store, PHRASE, 'webauthn-test')
+
+    const alice = await createNoydb({ store, user: 'alice', secret: PHRASE })
+    await alice.openVault('acme')
+
+    await alice.updateAuthenticator('acme', 'webauthn-test', {
+      meta: { nickname: 'Test slot' },
+    })
+
+    const slots = await alice.listAuthenticators('acme')
+    expect(slots).toHaveLength(1)
+    expect(slots[0]!.meta.nickname).toBe('Test slot')
+    expect(slots[0]!.meta.credentialId).toBe('cred-webauthn-test')
+  }, 120_000)
+
+  it('STRICT_POLICY rejects updateAuthenticator without factor proof', async () => {
+    const store = inlineMemory()
+    await bootstrapVaultWithSlot(store, STRICT_PHRASE, 'webauthn-strict')
+
+    const alice = await createNoydb({
+      store,
+      user: 'alice',
+      secret: STRICT_PHRASE,
+      policy: STRICT_POLICY,
+    })
+    await alice.openVault('acme')
+
+    await expect(
+      alice.updateAuthenticator('acme', 'webauthn-strict', { meta: { nickname: 'X' } }),
+    ).rejects.toBeInstanceOf(PolicyDeniedError)
+  }, 120_000)
+})

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -321,7 +321,7 @@ export {
   removeAuthenticator,
   findAuthenticator,
 } from './team/authenticators.js'
-export type { EnrollAuthenticatorOptions } from './team/authenticators.js'
+export type { EnrollAuthenticatorOptions, UpdateAuthenticatorOptions } from './team/authenticators.js'
 
 // Tier-3 quick-unlock state — issue #11
 export { QuickUnlockStore } from './session/unlock-state.js'

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -73,8 +73,10 @@ import type { UnlockedKeyring } from './team/keyring.js'
 import {
   enrollAuthenticator as keyringEnrollAuthenticator,
   removeAuthenticator as keyringRemoveAuthenticator,
+  updateAuthenticator as keyringUpdateAuthenticator,
   findAuthenticator,
   type EnrollAuthenticatorOptions,
+  type UpdateAuthenticatorOptions,
 } from './team/authenticators.js'
 import { QuickUnlockStore, type QuickUnlockState } from './session/unlock-state.js'
 import type { KeyringAuthenticator } from './types.js'
@@ -1207,6 +1209,46 @@ export class Noydb {
   async listAuthenticators(vault: string): Promise<ReadonlyArray<KeyringAuthenticator>> {
     const keyring = await this.getKeyring(vault)
     return keyring.authenticators
+  }
+
+  /**
+   * Mutate the `meta` blob on an existing authenticator slot — slot
+   * rename, label change, attachment of UI hints. The slot's `id`,
+   * `method`, and wrap material (`wrapped_kek` / `wrapped_deks` + `iv`)
+   * are immutable through this method. Anti-slot-swap is structural,
+   * not gate-driven.
+   *
+   * `meta` patch semantics (#57-aligned):
+   *   - Top-level merge — absent keys preserved
+   *   - `null` value — delete that meta key
+   *   - Other values — replace verbatim
+   *
+   * Use case: per-slot nickname for "iPhone Touch ID" vs "MacBook
+   * Touch ID" disambiguation in admin UIs. The slot id (auto-derived
+   * from credentialId prefix) is not human-friendly; `meta.nickname`
+   * is.
+   *
+   * Gated by `update-authenticator`. PERSONAL_POLICY: tier-1 unlock
+   * alone (matches enroll/remove). STRICT_POLICY: tier-1 +
+   * TOTP/email-OTP factor proof — a malicious rename on a shared
+   * workstation could mislead the user about which device a slot
+   * corresponds to, so STRICT requires fresh factor binding.
+   *
+   * @throws `NoAccessError` when no slot with the given id exists.
+   * @throws `ValidationError` when no patch field is provided.
+   *
+   * @see #55
+   */
+  async updateAuthenticator(
+    vault: string,
+    slotId: string,
+    options: UpdateAuthenticatorOptions,
+    presented?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+  ): Promise<void> {
+    await this.checkGate(vault, 'update-authenticator', presented)
+    const keyring = await this.getKeyring(vault)
+    const next = await keyringUpdateAuthenticator(this.options.store, vault, keyring, slotId, options)
+    this.keyringCache.set(vault, next)
   }
 
   /**

--- a/packages/hub/src/policy/presets.ts
+++ b/packages/hub/src/policy/presets.ts
@@ -41,6 +41,12 @@ export const PERSONAL_POLICY: VaultPolicy = Object.freeze({
     },
     'enroll-authenticator': { minTier: 1 },
     'remove-authenticator': { minTier: 1 },
+    // update-authenticator: meta-only mutation (slot rename, label
+    // changes). Symmetric with enroll/remove under PERSONAL — tier-1
+    // unlock alone. The structural anti-slot-swap guard inside the
+    // implementation enforces wrap-material/id/method immutability
+    // regardless of this gate's settings.
+    'update-authenticator': { minTier: 1 },
     'rotate-unlock': { minTier: 2 },
     'enroll-user': { minTier: 1 },
     'revoke-user': { minTier: 1 },
@@ -105,6 +111,15 @@ export const STRICT_POLICY: VaultPolicy = Object.freeze({
       factors: [{ anyOf: ['totp', 'email-otp'] }],
     },
     'remove-authenticator': {
+      minTier: 1,
+      factors: [{ anyOf: ['totp', 'email-otp'] }],
+    },
+    // STRICT update-authenticator: same factor floor as enroll/remove.
+    // Even though meta changes don't touch wrap material, a malicious
+    // rename could mislead the user about which device a slot
+    // corresponds to ("MacBook Touch ID" → "iPhone Touch ID" on a
+    // shared workstation). STRICT requires a fresh factor proof.
+    'update-authenticator': {
       minTier: 1,
       factors: [{ anyOf: ['totp', 'email-otp'] }],
     },

--- a/packages/hub/src/policy/types.ts
+++ b/packages/hub/src/policy/types.ts
@@ -97,6 +97,15 @@ export type BuiltInGateName =
   | 'recover-passphrase'
   | 'enroll-authenticator'
   | 'remove-authenticator'
+  /**
+   * Authorize a meta-only mutation on an existing authenticator slot —
+   * `db.updateAuthenticator` (#55). The slot's wrap material, id, and
+   * method are immutable through this gate; only the `meta` blob
+   * (nicknames, method-specific labels) can change. Anti-slot-swap
+   * guard is preserved structurally regardless of this gate's
+   * settings.
+   */
+  | 'update-authenticator'
   | 'rotate-unlock'
   | 'enroll-user'
   | 'revoke-user'

--- a/packages/hub/src/team/authenticators.ts
+++ b/packages/hub/src/team/authenticators.ts
@@ -14,7 +14,7 @@
  * @module
  */
 import type { NoydbStore, KeyringAuthenticator } from '../types.js'
-import { ValidationError } from '../errors.js'
+import { NoAccessError, ValidationError } from '../errors.js'
 import type { UnlockedKeyring } from './keyring.js'
 import { persistKeyring } from './keyring.js'
 
@@ -94,6 +94,90 @@ export async function enrollAuthenticator(
   const next = appendSlot(keyring, slot)
   await persistKeyring(store, vault, next)
   return next
+}
+
+/**
+ * Caller payload for {@link updateAuthenticator} (#55). Mutates only
+ * `meta` — the slot's id, method, and wrap material are immutable
+ * through this primitive, preserving the anti-slot-swap guard.
+ *
+ * `meta` is **merged** at the top level: keys absent from the patch
+ * are preserved, keys present overwrite. To clear a meta key, pass
+ * `null` for that key explicitly. (Same semantics as #57's
+ * `UserApi.updateMe`, scoped to this top-level merge — no recursion
+ * into nested meta values.)
+ */
+export interface UpdateAuthenticatorOptions {
+  readonly meta?: Record<string, unknown>
+}
+
+/**
+ * Mutate a tier-2 authenticator slot's `meta` blob (slot rename,
+ * label changes). The slot's `id`, `method`, and wrap material
+ * (`wrapped_kek` for wrap-KEK; `wrapped_deks` + `iv` for wrap-DEKs)
+ * are immutable through this entry point — the anti-slot-swap guard
+ * is structural, not gate-driven, so even if the policy gate is
+ * weakened a future caller cannot use this path to swap one slot's
+ * crypto for another's.
+ *
+ * `meta` patch semantics:
+ *   - Top-level merge — absent keys preserved, present keys overwrite
+ *   - `null` value — delete that meta key
+ *   - Non-object values (string, number, boolean, array) — replace verbatim
+ *
+ * @throws `NoAccessError` when no slot with the given id exists.
+ * @throws `ValidationError` when no patch field is provided.
+ *
+ * @see #55
+ */
+export async function updateAuthenticator(
+  store: NoydbStore,
+  vault: string,
+  keyring: UnlockedKeyring,
+  slotId: string,
+  options: UpdateAuthenticatorOptions,
+): Promise<UnlockedKeyring> {
+  if (options.meta === undefined) {
+    throw new ValidationError(
+      `updateAuthenticator: at least one of meta must be provided ` +
+        `(slotId: "${slotId}").`,
+    )
+  }
+
+  const idx = keyring.authenticators.findIndex((a) => a.id === slotId)
+  if (idx === -1) {
+    throw new NoAccessError(
+      `updateAuthenticator: slot "${slotId}" not found in vault "${vault}".`,
+    )
+  }
+  const existing = keyring.authenticators[idx]!
+
+  // Merge at the top level. Absent keys preserved (same as #57's
+  // updateMe semantics, but non-recursive — meta is a flat label
+  // bag in practice, no consumer nests it).
+  const mergedMeta: Record<string, unknown> = { ...existing.meta }
+  for (const [k, v] of Object.entries(options.meta)) {
+    if (v === undefined) continue // skip
+    if (v === null) {
+      delete mergedMeta[k]
+      continue
+    }
+    mergedMeta[k] = v
+  }
+
+  // Reconstruct the slot preserving wrapKind discrimination. The
+  // immutable fields (id, method, wrapped_kek / wrapped_deks + iv,
+  // enrolled_at, enrolled_via_tier) all flow through ...existing.
+  const next: KeyringAuthenticator = { ...existing, meta: mergedMeta }
+  const nextSlots = [...keyring.authenticators]
+  nextSlots[idx] = next
+
+  const nextKeyring: UnlockedKeyring = {
+    ...keyring,
+    authenticators: nextSlots,
+  }
+  await persistKeyring(store, vault, nextKeyring)
+  return nextKeyring
 }
 
 /**


### PR DESCRIPTION
## Summary

- New `db.updateAuthenticator(vault, slotId, { meta }, factors?)` for meta-only slot mutation (rename, label tweaks).
- Anti-slot-swap is **structural** — `UpdateAuthenticatorOptions` only carries `meta`; id, method, and wrap material are unreachable through this surface regardless of the gate's settings.
- Top-level merge semantics aligned with #57: absent meta keys preserved, present overwrite, `null` deletes.
- New `update-authenticator` policy gate (PERSONAL: tier-1 unlock; STRICT: tier-1 + TOTP/email-OTP — same as enroll/remove).
- Mirrors the #54 pattern at the authenticator layer.

## Why structural anti-slot-swap

The issue called out that wrap material / slot id / method must remain immutable. Two ways to enforce: (a) check at runtime inside the team helper, or (b) restrict the type so the caller literally cannot pass them. (b) is stronger — even if a future contributor weakens the gate to `enabled: false`, an attacker can't smuggle a wrap-material swap through this entry point because the type system doesn't permit it. The team helper just does `{ ...existing, meta: mergedMeta }`; everything else flows from `existing` verbatim.

## Use case

Per-slot nickname for "iPhone Touch ID" vs "MacBook Touch ID" disambiguation. The auto-derived slot id (`webauthn-<credentialId-prefix>`) isn't human-friendly; consumers need `meta.nickname` to render a usable list.

## STRICT factor floor

Even though meta-only changes don't touch wrap material, a malicious rename on a shared workstation could mislead a user about which device a slot corresponds to. STRICT requires the same TOTP/email-OTP factor as enroll/remove — symmetric across the trio of authenticator-slot operations.

## Test plan

- [x] `pnpm --filter @noy-db/hub typecheck` — clean
- [x] `pnpm --filter @noy-db/hub lint` — clean
- [x] `pnpm vitest run packages/hub/__tests__/update-authenticator.test.ts` — 8/8 pass
- [x] `pnpm vitest run packages/hub` — 1359/1359 pass (no regressions)

## Test coverage

| Scenario | Test |
|---|---|
| Round-trip on wrap-KEK slot (legacy WebAuthn shape) | ✅ |
| Round-trip on wrap-DEKs slot (password shape) | ✅ |
| `null` in meta key deletes that key | ✅ |
| Wrap material preserved across update (anti-slot-swap) | ✅ |
| Missing slot id → NoAccessError | ✅ |
| Empty diff → ValidationError | ✅ |
| Idempotent meta merge | ✅ |
| Hub round-trip via Noydb method | ✅ |
| STRICT_POLICY rejects without factor proof | ✅ |

## Milestone

[v0.1.0-pre.9](https://github.com/vLannaAi/noy-db/milestone/3)

Closes #55.
