### PR TITLE
feat(on-webauthn): webAuthnSlotRewrapCeremony for slotCeremonies (#56)

### DIFF
--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -337,6 +337,8 @@ export type {
   RecoverPassphraseInput,
   RecoverPassphraseResult,
   RecoveryProof,
+  SlotRewrapContext,
+  SlotRewrapCeremony,
 } from './team/rotate-recover.js'
 
 // Public envelope (docs/subsystems/public-envelope.md)

--- a/packages/on-webauthn/__tests__/slot-rewrap-ceremony.test.ts
+++ b/packages/on-webauthn/__tests__/slot-rewrap-ceremony.test.ts
@@ -1,0 +1,455 @@
+/**
+ * #56 — webAuthnSlotRewrapCeremony helper for rotatePassphrase slotCeremonies.
+ *
+ * Pinned behaviors:
+ *   1. End-to-end — enrollWebAuthn produces a slot whose wrappedPayload
+ *      decrypts back to the original keyring; webAuthnSlotRewrapCeremony
+ *      produces a NEW slot whose wrappedPayload decrypts back to the
+ *      same identity but with the supplied `ctx.newDeks`.
+ *   2. Identity carry-through — userId, displayName, role, permissions,
+ *      salt all flow through from the old payload to the new (these
+ *      don't change on phrase rotate).
+ *   3. Anti-slot-swap — returned slot has same `id` and `method` as
+ *      `oldSlot`. Hub validates these at slotCeremonies time.
+ *   4. Wrong method (e.g. `password`) → ValidationError.
+ *   5. wrap-DEKs variant → ValidationError (this helper handles wrap-KEK only).
+ *   6. Missing meta.credentialId / meta.wrapIv → ValidationError.
+ *   7. WebAuthnNotAvailable / Cancelled / MultiDevice errors propagate
+ *      from the inner assertion.
+ *   8. PRF and rawId-fallback paths both produce a working rewrap.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  enrollWebAuthn,
+  unlockWebAuthn,
+  webAuthnSlotRewrapCeremony,
+  WebAuthnCancelledError,
+  WebAuthnMultiDeviceError,
+  WebAuthnNotAvailableError,
+} from '../src/index.js'
+import { ValidationError } from '@noy-db/hub'
+import type { UnlockedKeyring, KeyringAuthenticator, SlotRewrapContext, WebAuthnEnrollment } from '../src/index.js'
+
+// ─── Fixtures ────────────────────────────────────────────────────────────
+
+async function makeDek(): Promise<CryptoKey> {
+  return globalThis.crypto.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt', 'decrypt'],
+  )
+}
+
+async function makeKeyring(deks: Map<string, CryptoKey>): Promise<UnlockedKeyring> {
+  return {
+    userId: 'alice',
+    displayName: 'Alice',
+    role: 'owner',
+    permissions: { invoices: 'rw', clients: 'ro' },
+    deks,
+    kek: null,
+    salt: new Uint8Array(32).fill(5),
+    authenticators: [],
+  }
+}
+
+function makeAuthData(beFlag = false): ArrayBuffer {
+  const bytes = new Uint8Array(37)
+  bytes[32] = beFlag ? 0b00001101 : 0b00000101
+  return bytes.buffer
+}
+
+const FIXED_PRF_OUTPUT = new Uint8Array(32).map((_, i) => i * 7 + 11).buffer
+
+function mockCreateCredential({
+  rawId = new Uint8Array(16).fill(0xab).buffer,
+  beFlag = false,
+  prfOutput = FIXED_PRF_OUTPUT as ArrayBuffer | null,
+} = {}): PublicKeyCredential {
+  return {
+    id: 'mock-credential-id',
+    type: 'public-key',
+    rawId,
+    response: {
+      clientDataJSON: new ArrayBuffer(0),
+      attestationObject: new ArrayBuffer(0),
+      getAuthenticatorData: () => makeAuthData(beFlag),
+      getPublicKey: () => null,
+      getPublicKeyAlgorithm: () => -7,
+      getTransports: () => [],
+    } as unknown as AuthenticatorAttestationResponse,
+    getClientExtensionResults: () => ({
+      prf: prfOutput != null ? { results: { first: prfOutput } } : undefined,
+    }),
+    authenticatorAttachment: 'platform' as AuthenticatorAttachment,
+    toJSON: () => ({}) as unknown as PublicKeyCredentialJSON,
+  } as unknown as PublicKeyCredential
+}
+
+function mockGetCredential({
+  rawId = new Uint8Array(16).fill(0xab).buffer,
+  beFlag = false,
+  prfOutput = FIXED_PRF_OUTPUT as ArrayBuffer | null,
+} = {}): PublicKeyCredential {
+  return {
+    id: 'mock-credential-id',
+    type: 'public-key',
+    rawId,
+    response: {
+      clientDataJSON: new ArrayBuffer(0),
+      authenticatorData: makeAuthData(beFlag),
+      signature: new ArrayBuffer(0),
+      userHandle: null,
+    } as unknown as AuthenticatorAssertionResponse,
+    getClientExtensionResults: () => ({
+      prf: prfOutput != null ? { results: { first: prfOutput } } : undefined,
+    }),
+    authenticatorAttachment: 'platform' as AuthenticatorAttachment,
+    toJSON: () => ({}) as unknown as PublicKeyCredentialJSON,
+  } as unknown as PublicKeyCredential
+}
+
+function stubWebAuthn({
+  createReturn = mockCreateCredential(),
+  getReturn = mockGetCredential(),
+}: {
+  createReturn?: PublicKeyCredential | null
+  getReturn?: PublicKeyCredential | null
+} = {}) {
+  const credsMock = {
+    create: vi.fn().mockResolvedValue(createReturn),
+    get: vi.fn().mockResolvedValue(getReturn),
+    preventSilentAccess: vi.fn(),
+    store: vi.fn(),
+  }
+  vi.stubGlobal('navigator', { ...navigator, credentials: credsMock })
+  vi.stubGlobal('PublicKeyCredential', class PublicKeyCredential {})
+  return credsMock
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * Build the on-disk `KeyringAuthenticator` slot from a `WebAuthnEnrollment`,
+ * matching how `db.enrollWebAuthn` shapes it (noydb.ts:1178).
+ */
+function slotFromEnrollment(enrollment: WebAuthnEnrollment): KeyringAuthenticator {
+  return {
+    id: `webauthn-${enrollment.credentialId.slice(0, 8)}`,
+    method: 'webauthn',
+    enrolled_at: enrollment.enrolledAt,
+    enrolled_via_tier: 1,
+    wrapKind: 'kek',
+    wrapped_kek: enrollment.wrappedPayload,
+    meta: {
+      credentialId: enrollment.credentialId,
+      wrapIv: enrollment.wrapIv,
+      prfUsed: enrollment.prfUsed,
+      beFlag: enrollment.beFlag,
+      requireSingleDevice: enrollment.requireSingleDevice,
+    },
+  }
+}
+
+// ─── Round-trip ──────────────────────────────────────────────────────────
+
+describe('webAuthnSlotRewrapCeremony — end-to-end (PRF path)', () => {
+  it('rewrap produces a slot whose payload decrypts to ctx.newDeks (rotation simulation)', async () => {
+    const rawId = new Uint8Array(16).fill(0xcd).buffer
+
+    // 1. Enroll under the OLD DEK set.
+    const oldDek = await makeDek()
+    const oldKeyring = await makeKeyring(new Map([['invoices', oldDek]]))
+    stubWebAuthn({
+      createReturn: mockCreateCredential({ rawId, prfOutput: FIXED_PRF_OUTPUT }),
+    })
+    const enrollment = await enrollWebAuthn(oldKeyring, 'acme')
+    const oldSlot = slotFromEnrollment(enrollment)
+
+    // 2. Simulate rotatePassphrase: hub generates fresh DEKs (rewrapped
+    //    under the new KEK in the keyring file). The ceremony receives
+    //    these via ctx.newDeks.
+    const newDek = await makeDek()
+    const newDeks = new Map([['invoices', newDek]])
+    const ctx: SlotRewrapContext = {
+      newKek: oldKeyring.salt as unknown as CryptoKey, // unused by webauthn ceremony
+      newDeks,
+      oldSlot,
+    }
+
+    // Re-stub for the rewrap ceremony's assertion.
+    vi.unstubAllGlobals()
+    stubWebAuthn({
+      getReturn: mockGetCredential({ rawId, prfOutput: FIXED_PRF_OUTPUT }),
+    })
+    const rewrapped = await webAuthnSlotRewrapCeremony(ctx)
+
+    // Anti-slot-swap — id + method preserved.
+    expect(rewrapped.id).toBe(oldSlot.id)
+    expect(rewrapped.method).toBe('webauthn')
+    expect(rewrapped.wrapKind).not.toBe('deks') // wrap-KEK preserved
+
+    // 3. Build a "new" enrollment record from the ceremony output and
+    //    unlock — should return ctx.newDeks, NOT the old ones.
+    if ('wrapped_kek' in rewrapped) {
+      const newEnrollment: WebAuthnEnrollment = {
+        _noydb_webauthn: 1,
+        vault: 'acme',
+        userId: 'alice',
+        credentialId: enrollment.credentialId,
+        prfUsed: true,
+        beFlag: false,
+        requireSingleDevice: false,
+        wrappedPayload: rewrapped.wrapped_kek,
+        wrapIv: (rewrapped.meta as { wrapIv: string }).wrapIv,
+        enrolledAt: enrollment.enrolledAt,
+      }
+
+      vi.unstubAllGlobals()
+      stubWebAuthn({
+        getReturn: mockGetCredential({ rawId, prfOutput: FIXED_PRF_OUTPUT }),
+      })
+      const unlocked = await unlockWebAuthn(newEnrollment)
+
+      // Identity carry-through.
+      expect(unlocked.userId).toBe('alice')
+      expect(unlocked.displayName).toBe('Alice')
+      expect(unlocked.role).toBe('owner')
+      expect(unlocked.permissions).toEqual({ invoices: 'rw', clients: 'ro' })
+
+      // The unlocked DEK must match ctx.newDeks (NOT oldDek).
+      const unlockedRaw = await globalThis.crypto.subtle.exportKey('raw', unlocked.deks.get('invoices')!)
+      const newRaw = await globalThis.crypto.subtle.exportKey('raw', newDek)
+      expect(new Uint8Array(unlockedRaw)).toEqual(new Uint8Array(newRaw))
+
+      // Sanity: it is NOT the old DEK.
+      const oldRaw = await globalThis.crypto.subtle.exportKey('raw', oldDek)
+      expect(new Uint8Array(unlockedRaw)).not.toEqual(new Uint8Array(oldRaw))
+    } else {
+      throw new Error('expected wrap-KEK rewrapped slot')
+    }
+  })
+})
+
+describe('webAuthnSlotRewrapCeremony — rawId fallback path', () => {
+  it('rewraps correctly when prfUsed: false (rawId-derived wrapping key)', async () => {
+    const rawId = new Uint8Array(16).fill(0xef).buffer
+
+    const oldDek = await makeDek()
+    const oldKeyring = await makeKeyring(new Map([['invoices', oldDek]]))
+    stubWebAuthn({
+      createReturn: mockCreateCredential({ rawId, prfOutput: null }),
+    })
+    const enrollment = await enrollWebAuthn(oldKeyring, 'acme')
+    expect(enrollment.prfUsed).toBe(false)
+    const oldSlot = slotFromEnrollment(enrollment)
+
+    const newDek = await makeDek()
+    const newDeks = new Map([['invoices', newDek]])
+    const ctx: SlotRewrapContext = {
+      newKek: oldKeyring.salt as unknown as CryptoKey,
+      newDeks,
+      oldSlot,
+    }
+
+    vi.unstubAllGlobals()
+    stubWebAuthn({
+      getReturn: mockGetCredential({ rawId, prfOutput: null }),
+    })
+    const rewrapped = await webAuthnSlotRewrapCeremony(ctx)
+    expect(rewrapped.id).toBe(oldSlot.id)
+    expect(rewrapped.method).toBe('webauthn')
+
+    if ('wrapped_kek' in rewrapped) {
+      const newEnrollment: WebAuthnEnrollment = {
+        _noydb_webauthn: 1,
+        vault: 'acme',
+        userId: 'alice',
+        credentialId: enrollment.credentialId,
+        prfUsed: false,
+        beFlag: false,
+        requireSingleDevice: false,
+        wrappedPayload: rewrapped.wrapped_kek,
+        wrapIv: (rewrapped.meta as { wrapIv: string }).wrapIv,
+        enrolledAt: enrollment.enrolledAt,
+      }
+      vi.unstubAllGlobals()
+      stubWebAuthn({
+        getReturn: mockGetCredential({ rawId, prfOutput: null }),
+      })
+      const unlocked = await unlockWebAuthn(newEnrollment)
+      const unlockedRaw = await globalThis.crypto.subtle.exportKey('raw', unlocked.deks.get('invoices')!)
+      const newRaw = await globalThis.crypto.subtle.exportKey('raw', newDek)
+      expect(new Uint8Array(unlockedRaw)).toEqual(new Uint8Array(newRaw))
+    } else {
+      throw new Error('expected wrap-KEK rewrapped slot')
+    }
+  })
+})
+
+// ─── Validation ──────────────────────────────────────────────────────────
+
+describe('webAuthnSlotRewrapCeremony — validation', () => {
+  it('throws ValidationError when oldSlot.method is not webauthn', async () => {
+    stubWebAuthn()
+    const oldDek = await makeDek()
+    const oldKeyring = await makeKeyring(new Map([['invoices', oldDek]]))
+
+    // Construct a non-webauthn slot to confirm the method check fires.
+    const wrongSlot: KeyringAuthenticator = {
+      id: 'password-x',
+      method: 'password',
+      enrolled_at: new Date().toISOString(),
+      enrolled_via_tier: 1,
+      wrapKind: 'deks',
+      wrapped_deks: 'YWFhYWE=',
+      iv: 'YWFhYQ==',
+      meta: { salt: 'cw==' },
+    }
+
+    await expect(
+      webAuthnSlotRewrapCeremony({
+        newKek: oldKeyring.salt as unknown as CryptoKey,
+        newDeks: oldKeyring.deks,
+        oldSlot: wrongSlot,
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it('throws ValidationError when oldSlot is wrap-DEKs variant', async () => {
+    stubWebAuthn()
+    const oldDek = await makeDek()
+    const oldKeyring = await makeKeyring(new Map([['invoices', oldDek]]))
+
+    // method is 'webauthn' but wrapKind is 'deks' — pathological mix
+    // that should be rejected so the helper doesn't try to decrypt
+    // a non-existent wrapped_kek field.
+    const wrongSlot: KeyringAuthenticator = {
+      id: 'webauthn-bad',
+      method: 'webauthn',
+      enrolled_at: new Date().toISOString(),
+      enrolled_via_tier: 1,
+      wrapKind: 'deks',
+      wrapped_deks: 'YWFhYWE=',
+      iv: 'YWFhYQ==',
+      meta: { credentialId: 'cred-bad', wrapIv: 'aXY=' },
+    }
+
+    await expect(
+      webAuthnSlotRewrapCeremony({
+        newKek: oldKeyring.salt as unknown as CryptoKey,
+        newDeks: oldKeyring.deks,
+        oldSlot: wrongSlot,
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it('throws ValidationError when meta.credentialId is missing', async () => {
+    stubWebAuthn()
+    const oldDek = await makeDek()
+    const oldKeyring = await makeKeyring(new Map([['invoices', oldDek]]))
+    const enrollment = await enrollWebAuthn(oldKeyring, 'acme')
+    const slot = slotFromEnrollment(enrollment)
+    // Strip credentialId.
+    const stripped: KeyringAuthenticator = {
+      ...slot,
+      meta: { wrapIv: (slot.meta as { wrapIv: string }).wrapIv },
+    }
+
+    await expect(
+      webAuthnSlotRewrapCeremony({
+        newKek: oldKeyring.salt as unknown as CryptoKey,
+        newDeks: oldKeyring.deks,
+        oldSlot: stripped,
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it('throws ValidationError when meta.wrapIv is missing (pre-#16 synthetic-keyring shape)', async () => {
+    stubWebAuthn()
+    const oldDek = await makeDek()
+    const oldKeyring = await makeKeyring(new Map([['invoices', oldDek]]))
+    const enrollment = await enrollWebAuthn(oldKeyring, 'acme')
+    const slot = slotFromEnrollment(enrollment)
+    const stripped: KeyringAuthenticator = {
+      ...slot,
+      meta: { credentialId: (slot.meta as { credentialId: string }).credentialId },
+    }
+
+    await expect(
+      webAuthnSlotRewrapCeremony({
+        newKek: oldKeyring.salt as unknown as CryptoKey,
+        newDeks: oldKeyring.deks,
+        oldSlot: stripped,
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it('propagates WebAuthnNotAvailableError when env lacks navigator.credentials', async () => {
+    // Build a valid slot first (with stubs), then drop the stubs and
+    // call the ceremony — env check fires before any other validation.
+    stubWebAuthn()
+    const oldDek = await makeDek()
+    const oldKeyring = await makeKeyring(new Map([['invoices', oldDek]]))
+    const enrollment = await enrollWebAuthn(oldKeyring, 'acme')
+    const slot = slotFromEnrollment(enrollment)
+
+    vi.unstubAllGlobals()
+    await expect(
+      webAuthnSlotRewrapCeremony({
+        newKek: oldKeyring.salt as unknown as CryptoKey,
+        newDeks: oldKeyring.deks,
+        oldSlot: slot,
+      }),
+    ).rejects.toBeInstanceOf(WebAuthnNotAvailableError)
+  })
+
+  it('propagates WebAuthnCancelledError when navigator.credentials.get returns null', async () => {
+    const rawId = new Uint8Array(16).fill(0xab).buffer
+    stubWebAuthn({
+      createReturn: mockCreateCredential({ rawId, prfOutput: FIXED_PRF_OUTPUT }),
+    })
+    const oldDek = await makeDek()
+    const oldKeyring = await makeKeyring(new Map([['invoices', oldDek]]))
+    const enrollment = await enrollWebAuthn(oldKeyring, 'acme')
+    const slot = slotFromEnrollment(enrollment)
+
+    vi.unstubAllGlobals()
+    stubWebAuthn({ getReturn: null })
+    await expect(
+      webAuthnSlotRewrapCeremony({
+        newKek: oldKeyring.salt as unknown as CryptoKey,
+        newDeks: oldKeyring.deks,
+        oldSlot: slot,
+      }),
+    ).rejects.toBeInstanceOf(WebAuthnCancelledError)
+  })
+
+  it('propagates WebAuthnMultiDeviceError when requireSingleDevice && BE=1 at rewrap time', async () => {
+    const rawId = new Uint8Array(16).fill(0xab).buffer
+    stubWebAuthn({
+      createReturn: mockCreateCredential({ rawId, prfOutput: FIXED_PRF_OUTPUT, beFlag: false }),
+    })
+    const oldDek = await makeDek()
+    const oldKeyring = await makeKeyring(new Map([['invoices', oldDek]]))
+    const enrollment = await enrollWebAuthn(oldKeyring, 'acme', { requireSingleDevice: true })
+    const slot = slotFromEnrollment(enrollment)
+
+    // At rewrap time, the authenticator now reports BE=1 (e.g. Touch ID
+    // got synced through iCloud since enrollment) — must reject.
+    vi.unstubAllGlobals()
+    stubWebAuthn({
+      getReturn: mockGetCredential({ rawId, prfOutput: FIXED_PRF_OUTPUT, beFlag: true }),
+    })
+    await expect(
+      webAuthnSlotRewrapCeremony({
+        newKek: oldKeyring.salt as unknown as CryptoKey,
+        newDeks: oldKeyring.deks,
+        oldSlot: slot,
+      }),
+    ).rejects.toBeInstanceOf(WebAuthnMultiDeviceError)
+  })
+})

--- a/packages/on-webauthn/src/index.ts
+++ b/packages/on-webauthn/src/index.ts
@@ -56,7 +56,7 @@
 
 import { bufferToBase64, base64ToBuffer } from '@noy-db/hub'
 import { ValidationError } from '@noy-db/hub'
-import type { UnlockedKeyring, Role } from '@noy-db/hub'
+import type { UnlockedKeyring, Role, EnrollAuthenticatorOptions, SlotRewrapContext } from '@noy-db/hub'
 
 // Re-export from core for convenience
 export { ValidationError } from '@noy-db/hub'
@@ -570,6 +570,217 @@ export async function unlockWebAuthn(
   }
 
   return unwrapKeyringSummary(enrollment, wrappingKey)
+}
+
+/**
+ * `SlotRewrapCeremony` for WebAuthn slots — used by hub's
+ * `rotatePassphrase({ slotCeremonies: { [slotId]: webAuthnSlotRewrapCeremony } })`
+ * to preserve a tier-2 WebAuthn enrollment across a tier-1 phrase
+ * rotation without requiring re-enrollment of the credential (#56).
+ *
+ * The credential itself is unaffected by phrase rotation — the
+ * wrapping key derived from PRF (or rawId fallback) is bound to the
+ * authenticator, not to the passphrase. What needs to change is the
+ * **wrapped payload**: the encrypted blob the slot's `wrapped_kek`
+ * field holds. After rotation, the old payload still has the old
+ * DEKs (now stale because rotatePassphrase rewrapped them under a
+ * fresh KEK); the new payload must hold the freshly rewrapped
+ * `ctx.newDeks`.
+ *
+ * Single ceremony, two operations:
+ *   1. Trigger one WebAuthn assertion to derive the wrapping key.
+ *   2. Decrypt the OLD `wrapped_kek` to extract identity fields
+ *      (userId, displayName, role, permissions, salt) — these don't
+ *      change on rotation, so they're carried verbatim into the new
+ *      payload.
+ *   3. Encrypt the NEW payload (same identity + `ctx.newDeks`) under
+ *      the same wrapping key, with a fresh IV.
+ *   4. Return `EnrollAuthenticatorOptions` preserving `oldSlot.id`
+ *      and `method: 'webauthn'` (hub validates these to prevent
+ *      slot-type swap mid-rotation).
+ *
+ * Niwat (consumer) shipped a workaround at #44 — detect dropped slots
+ * after rotate and offer "Re-enrol Touch ID" inline. This ceremony
+ * eliminates that step.
+ *
+ * Out of scope: tier-3 PIN. PIN state lives in `QuickUnlockStore`
+ * (RAM-only), not in `KeyringFile.authenticators[]`, so
+ * `slotCeremonies` doesn't apply. Clear PIN state on rotate; let
+ * the user set a fresh PIN via `db.enrollUnlock` immediately after.
+ *
+ * @throws {WebAuthnNotAvailableError} when the environment lacks WebAuthn.
+ * @throws {WebAuthnCancelledError} when the user dismisses the assertion.
+ * @throws {WebAuthnMultiDeviceError} when `meta.requireSingleDevice` was
+ *         set at enrollment and the authenticator now reports BE=1.
+ * @throws {ValidationError} when `oldSlot.method !== 'webauthn'`,
+ *         when required `meta` fields are missing, or when the old
+ *         payload fails to decrypt (credential changed / payload
+ *         tampered).
+ *
+ * @see #56 #29 — the ceremony plumbing this fills in.
+ */
+export async function webAuthnSlotRewrapCeremony(
+  ctx: SlotRewrapContext,
+  options: WebAuthnUnlockOptions = {},
+): Promise<EnrollAuthenticatorOptions> {
+  if (ctx.oldSlot.method !== 'webauthn') {
+    throw new ValidationError(
+      `webAuthnSlotRewrapCeremony: oldSlot.method is "${ctx.oldSlot.method}"; expected "webauthn". ` +
+        'This ceremony only handles WebAuthn slots — pair other methods with their own helpers.',
+    )
+  }
+  if (ctx.oldSlot.wrapKind === 'deks') {
+    throw new ValidationError(
+      'webAuthnSlotRewrapCeremony: oldSlot is a wrap-DEKs slot; expected wrap-KEK. ' +
+        'WebAuthn slots use the wrap-KEK variant; mismatch indicates the slot was ' +
+        'enrolled by a different on-* package.',
+    )
+  }
+  if (!isWebAuthnAvailable()) {
+    throw new WebAuthnNotAvailableError()
+  }
+
+  // Pull the per-slot fields needed for assertion + decrypt. These were
+  // written into `meta` by `enrollWebAuthn` (via `db.enrollWebAuthn`).
+  const meta = ctx.oldSlot.meta as {
+    credentialId?: unknown
+    wrapIv?: unknown
+    prfUsed?: unknown
+    beFlag?: unknown
+    requireSingleDevice?: unknown
+  }
+  if (typeof meta.credentialId !== 'string' || meta.credentialId.length === 0) {
+    throw new ValidationError(
+      'webAuthnSlotRewrapCeremony: oldSlot.meta.credentialId is missing or invalid. ' +
+        'The slot was not enrolled via @noy-db/on-webauthn.',
+    )
+  }
+  if (typeof meta.wrapIv !== 'string' || meta.wrapIv.length === 0) {
+    throw new ValidationError(
+      'webAuthnSlotRewrapCeremony: oldSlot.meta.wrapIv is missing — the slot may be ' +
+        'pre-#16 (synthetic-keyring shape) and must be re-enrolled via db.enrollWebAuthn.',
+    )
+  }
+  const prfUsed = meta.prfUsed === true
+
+  // 1. Trigger the assertion. Same path `unlockWebAuthn` uses.
+  const credentialIdBuf = base64ToBuffer(meta.credentialId)
+  const timeout = options.timeout ?? 60_000
+  const extensionsInput = (prfUsed
+    ? { prf: { eval: { first: PRF_SALT } } }
+    : {}
+  ) as AuthenticationExtensionsClientInputs
+
+  const assertion = await navigator.credentials.get({
+    publicKey: {
+      challenge: globalThis.crypto.getRandomValues(new Uint8Array(32)),
+      allowCredentials: [{ type: 'public-key', id: credentialIdBuf as BufferSource }],
+      userVerification: 'required',
+      extensions: extensionsInput,
+      timeout,
+    },
+  }) as PublicKeyCredential | null
+
+  if (!assertion) {
+    throw new WebAuthnCancelledError('assertion')
+  }
+
+  // BE-flag guard at assertion time — same rule unlockWebAuthn enforces.
+  const authData = (assertion.response as AuthenticatorAssertionResponse).authenticatorData
+  const beFlag = extractBEFlag(authData)
+  if (meta.requireSingleDevice === true && beFlag) {
+    throw new WebAuthnMultiDeviceError()
+  }
+
+  // 2. Derive the wrapping key — deterministic per credential, so this
+  //    is the SAME key the original enrollment used.
+  let wrappingKey: CryptoKey
+  if (prfUsed) {
+    const extensions = assertion.getClientExtensionResults() as {
+      prf?: { results?: { first?: ArrayBuffer } }
+    }
+    const prfOutput = extensions.prf?.results?.first
+    if (!prfOutput) {
+      throw new ValidationError(
+        'webAuthnSlotRewrapCeremony: PRF output missing at assertion time. ' +
+          'The authenticator may have lost PRF capability — re-enrol the slot via db.enrollWebAuthn.',
+      )
+    }
+    wrappingKey = await deriveKeyFromPRF(prfOutput)
+  } else {
+    wrappingKey = await deriveKeyFromRawId(assertion.rawId)
+  }
+
+  // 3. Decrypt the OLD wrapped_kek to extract carry-through identity
+  //    fields. The slot's wrapped_kek IS the old wrappedPayload
+  //    (mapping established by db.enrollWebAuthn at noydb.ts:1178).
+  const oldIv = base64ToBuffer(meta.wrapIv)
+  const oldCiphertext = base64ToBuffer(ctx.oldSlot.wrapped_kek)
+  let oldPlaintext: ArrayBuffer
+  try {
+    oldPlaintext = await globalThis.crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: oldIv },
+      wrappingKey,
+      oldCiphertext,
+    )
+  } catch {
+    throw new ValidationError(
+      'webAuthnSlotRewrapCeremony: failed to decrypt the old wrapped payload. ' +
+        'The wrapping key derived from this credential does not match — possible ' +
+        'cross-tenant slot mix-up or a corrupted enrollment.',
+    )
+  }
+  const oldPayload = JSON.parse(new TextDecoder().decode(oldPlaintext)) as {
+    userId: string
+    displayName: string
+    role: Role
+    permissions: Record<string, 'rw' | 'ro'>
+    deks: Record<string, string>
+    salt: string
+  }
+
+  // 4. Build the NEW payload — identity fields preserved, deks
+  //    replaced with ctx.newDeks (rewrapped under the new KEK in the
+  //    keyring file; here we serialize them as raw bytes for the
+  //    self-contained webauthn-side reconstruction).
+  const newDekMap: Record<string, string> = {}
+  for (const [collName, dek] of ctx.newDeks) {
+    const raw = await globalThis.crypto.subtle.exportKey('raw', dek)
+    newDekMap[collName] = bufferToBase64(raw)
+  }
+  const newPayload = JSON.stringify({
+    userId: oldPayload.userId,
+    displayName: oldPayload.displayName,
+    role: oldPayload.role,
+    permissions: oldPayload.permissions,
+    deks: newDekMap,
+    salt: oldPayload.salt,
+  })
+
+  // 5. Encrypt with the same wrapping key under a fresh IV.
+  const newIv = globalThis.crypto.getRandomValues(new Uint8Array(12))
+  const newCiphertext = await globalThis.crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: newIv },
+    wrappingKey,
+    new TextEncoder().encode(newPayload),
+  )
+
+  // 6. Return EnrollAuthenticatorOptions preserving id + method.
+  //    Hub's rotate validates these — a mismatch throws ValidationError
+  //    (slot-type swap defense; see SlotRewrapContext docstring).
+  return {
+    id: ctx.oldSlot.id,
+    method: 'webauthn',
+    wrapped_kek: bufferToBase64(newCiphertext),
+    enrolled_via_tier: ctx.oldSlot.enrolled_via_tier,
+    meta: {
+      credentialId: meta.credentialId,
+      wrapIv: bufferToBase64(newIv),
+      prfUsed,
+      beFlag,
+      requireSingleDevice: meta.requireSingleDevice === true,
+    },
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Exports `webAuthnSlotRewrapCeremony` from `@noy-db/on-webauthn` — fills the `/* re-prove WebAuthn, return slot */` placeholder in #29's `slotCeremonies` API.
- Helper lives in `@noy-db/on-webauthn` (NOT hub) per the peer-dep convention. Hub-side change is type-only: exports `SlotRewrapContext` + `SlotRewrapCeremony` so on-webauthn can type its parameter.

## Usage

```ts
import { rotatePassphrase } from '@noy-db/hub'
import { webAuthnSlotRewrapCeremony } from '@noy-db/on-webauthn'

await db.rotatePassphrase('acme', {
  oldPassphrase: oldPhrase,
  newPassphrase: newPhrase,
  slotCeremonies: {
    'webauthn-yubikey': webAuthnSlotRewrapCeremony,
  },
})
// → biometric slot survives the rotation; user touches the YubiKey once during rotate.
```

## Implementation

Single ceremony, two crypto operations under one assertion:

1. **One** WebAuthn assertion to derive the wrapping key (PRF or rawId fallback — same path `unlockWebAuthn` uses).
2. Decrypt the OLD `wrapped_kek` to extract identity carry-through fields (`userId`, `displayName`, `role`, `permissions`, `salt` — none of these change on phrase rotate).
3. Build NEW payload: same identity + `ctx.newDeks` (rewrapped DEK set hub generated under the new KEK).
4. Encrypt with the **same** wrapping key under a fresh IV.
5. Return `EnrollAuthenticatorOptions` preserving `oldSlot.id` and `method: 'webauthn'` — hub's rotate validates these (anti-slot-swap defense).

## Niwat's pre-#56 workaround retired

`niwat#44` detected dropped slots after rotate and offered an inline "Re-enrol Touch ID" panel. UX-equivalent for the user (one click), but not atomic — there was a brief window where the old slot was gone before the new one was enrolled. This ceremony eliminates the window.

## Out of scope

**Tier-3 PIN.** PIN state lives in `QuickUnlockStore` (RAM-only), not in `KeyringFile.authenticators[]`, so `slotCeremonies` doesn't apply. Clear PIN state on rotate and prompt for a fresh PIN via `db.enrollUnlock`.

## Test plan

- [x] `pnpm --filter @noy-db/hub typecheck` — clean
- [x] `pnpm --filter @noy-db/hub lint` — clean
- [x] `pnpm --filter @noy-db/on-webauthn typecheck` — clean (after hub rebuild)
- [x] `pnpm --filter @noy-db/on-webauthn lint` — clean
- [x] `pnpm vitest run packages/on-webauthn/__tests__/slot-rewrap-ceremony.test.ts` — 9/9 pass
- [x] `pnpm vitest run packages/on-webauthn packages/hub` — 1378/1378 pass (no regressions)

## Test coverage

| Scenario | Test |
|---|---|
| PRF path: rewrap → unlock returns ctx.newDeks (NOT old DEKs) | ✅ |
| rawId fallback path: same round-trip | ✅ |
| Identity carry-through (userId/displayName/role/permissions) | ✅ |
| Anti-slot-swap: id + method preserved on output | ✅ |
| `oldSlot.method !== 'webauthn'` → ValidationError | ✅ |
| `wrapKind: 'deks'` → ValidationError (helper handles wrap-KEK only) | ✅ |
| Missing meta.credentialId → ValidationError | ✅ |
| Missing meta.wrapIv (pre-#16 shape) → ValidationError | ✅ |
| WebAuthnNotAvailableError propagated | ✅ |
| WebAuthnCancelledError propagated | ✅ |
| WebAuthnMultiDeviceError propagated (BE flag at rewrap time) | ✅ |

## Milestone

[v0.1.0-pre.9](https://github.com/vLannaAi/noy-db/milestone/3)

Closes #56.
