### PR TITLE
fix(hub): reject grant() when caller's kek is null (#81)

### DIFF
--- a/packages/hub/__tests__/keyring.test.ts
+++ b/packages/hub/__tests__/keyring.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
-import { ConflictError } from '../src/errors.js'
+import { ConflictError, ValidationError } from '../src/errors.js'
 import {
   createOwnerKeyring,
   loadKeyring,
@@ -196,6 +196,26 @@ describe('keyring', () => {
           passphrase: 'pass',
         }),
       ).rejects.toThrow('cannot grant')
+    })
+
+    it('rejects when caller kek is null (tier-2 wrap-DEKs / tier-3 PIN-resume sessions cannot grant)', async () => {
+      const owner = await createOwnerKeyring(adapter, COMP, 'owner-01', 'ownerpass')
+      const getDEK = await ensureCollectionDEK(adapter, COMP, owner)
+      await getDEK('invoices')
+
+      // Simulate a tier-2 wrap-DEKs unlock (e.g. @noy-db/on-password) or tier-3
+      // PIN-resume: same DEKs in memory, but kek is null because the slot
+      // wraps DEKs directly without producing a KEK.
+      const tier2Caller = { ...owner, kek: null }
+
+      await expect(
+        grant(adapter, COMP, tier2Caller, {
+          userId: 'mallory',
+          displayName: 'Mallory',
+          role: 'admin',
+          passphrase: 'attacker-pass',
+        }),
+      ).rejects.toThrow(ValidationError)
     })
   })
 

--- a/packages/hub/src/team/keyring.ts
+++ b/packages/hub/src/team/keyring.ts
@@ -260,6 +260,14 @@ export async function grant(
   callerKeyring: UnlockedKeyring,
   options: GrantOptions,
 ): Promise<void> {
+  if (!callerKeyring.kek) {
+    throw new ValidationError(
+      'grant: caller keyring has no KEK — tier-2 wrap-DEKs and tier-3 PIN-resume ' +
+        'sessions cannot grant access to other users. Re-authenticate at tier 1 ' +
+        '(passphrase) before granting.',
+    )
+  }
+
   if (!canGrant(callerKeyring.role, options.role)) {
     throw new PermissionDeniedError(
       `Role "${callerKeyring.role}" cannot grant role "${options.role}"`,


### PR DESCRIPTION
## Summary

- Mirror \`persistKeyring\`'s tier-1/2 capability check at the head of \`grant()\` so tier-2 wrap-DEKs and tier-3 PIN-resume sessions cannot create new user keyrings.
- Previously \`grant()\` iterated \`callerKeyring.deks\` directly and never read \`kek\`, so a null-kek session could grant successfully — violating the capability matrix documented in \`auth-landscape.md\`.

## Closes #81

## Test plan

- [x] New regression test \`rejects when caller kek is null\` in \`keyring.test.ts\` — constructs a \`{ ...owner, kek: null }\` caller and asserts \`grant\` rejects with \`ValidationError\`.
- [x] All 13 keyring tests pass.
- [x] All 55 grant-adjacent tests pass (\`access-control\`, \`dev-unlock\`, \`get-keyring-callback\`).
- [x] \`pnpm turbo typecheck --filter=@noy-db/hub\` clean.

## Risk

Low. The fix is fail-closed: a tier-2/tier-3 session attempting \`grant\` now receives a clear \`ValidationError\` with re-authentication guidance. Tier-1 sessions (the only legitimate \`grant\` caller) are unaffected.