### PR TITLE
fix(hub): reject wrapKind mismatch in rotatePassphrase slot ceremonies (#83)

### DIFF
--- a/packages/hub/__tests__/pr5-rotate-preserve-slots.test.ts
+++ b/packages/hub/__tests__/pr5-rotate-preserve-slots.test.ts
@@ -302,6 +302,75 @@ describe('rotatePassphrase slot preservation (#29)', () => {
     ).rejects.toBeInstanceOf(ValidationError)
   }, 60_000)
 
+  it('rejects wrapKind downgrade in ceremony result (anti-slot-swap, kek → deks)', async () => {
+    const store = await setupVaultWithSlots([
+      {
+        id: 'webauthn-touchid',
+        method: 'webauthn',
+        enrolled_at: '2026-01-01T00:00:00Z',
+        enrolled_via_tier: 1,
+        wrapped_kek: 'OLDWRAPPED',
+        meta: { credentialId: 'cred' },
+      },
+    ])
+
+    // Ceremony preserves id + method (matching webauthn) but flips
+    // wrapKind from absent (= 'kek') to 'deks'. Without the wrapKind
+    // guard this would silently change the slot's session-tier
+    // contract: a wrap-KEK slot produces `kek != null` at unlock,
+    // a wrap-DEKs slot produces `kek: null`.
+    const downgradeCeremony: SlotRewrapCeremony = async ({ oldSlot }) => ({
+      id: oldSlot.id,
+      method: oldSlot.method,
+      wrapKind: 'deks',
+      wrapped_deks: 'NEWWRAPPED',
+      iv: 'IV',
+      meta: { credentialId: 'cred' },
+    })
+
+    await expect(
+      rotatePassphrase(store, 'acme', 'alice', {
+        oldPassphrase: OLD_PHRASE,
+        newPassphrase: NEW_PHRASE,
+        slotCeremonies: { 'webauthn-touchid': downgradeCeremony },
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  }, 60_000)
+
+  it('rejects wrapKind upgrade in ceremony result (anti-slot-swap, deks → kek)', async () => {
+    const store = await setupVaultWithSlots([
+      {
+        id: 'password-daily',
+        method: 'password',
+        enrolled_at: '2026-01-01T00:00:00Z',
+        enrolled_via_tier: 1,
+        wrapKind: 'deks',
+        wrapped_deks: 'OLDWRAPPED',
+        iv: 'OLDIV',
+        meta: { salt: 'SALT' },
+      },
+    ])
+
+    // Ceremony preserves id + method (matching password) but flips
+    // wrapKind from 'deks' to absent (= 'kek'). The resulting slot
+    // would carry wrapped_kek that was never produced by AES-KW under
+    // a real KEK — the next unlock attempt would brick the slot.
+    const upgradeCeremony: SlotRewrapCeremony = async ({ oldSlot }) => ({
+      id: oldSlot.id,
+      method: oldSlot.method,
+      wrapped_kek: 'INVENTED',
+      meta: { salt: 'SALT' },
+    })
+
+    await expect(
+      rotatePassphrase(store, 'acme', 'alice', {
+        oldPassphrase: OLD_PHRASE,
+        newPassphrase: NEW_PHRASE,
+        slotCeremonies: { 'password-daily': upgradeCeremony },
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  }, 60_000)
+
   it('preserves enrolled_at across rotation (rotation is rewrapping, not re-enrollment)', async () => {
     const originalEnrolledAt = '2025-06-15T08:30:00.000Z'
     const store = await setupVaultWithSlots([

--- a/packages/hub/src/team/rotate-recover.ts
+++ b/packages/hub/src/team/rotate-recover.ts
@@ -191,6 +191,18 @@ export async function rotatePassphrase(
             '→ password) under cover of rotation.',
         )
       }
+      // wrapKind absent on legacy slots / wrap-KEK enroll inputs; treat as 'kek'.
+      const oldWrapKind = oldSlot.wrapKind ?? 'kek'
+      const newWrapKind = result.wrapKind ?? 'kek'
+      if (oldWrapKind !== newWrapKind) {
+        throw new ValidationError(
+          `slotCeremonies['${oldSlot.id}'] returned wrapKind="${newWrapKind}", ` +
+            `expected "${oldWrapKind}". The wrap format must match the rotated ` +
+            'slot — a ceremony cannot change the wrap shape (e.g. wrap-KEK → ' +
+            'wrap-DEKs) under cover of rotation, since that would silently ' +
+            'change the session tier produced at unlock.',
+        )
+      }
 
       // Build the persisted slot from the ceremony result. Mirrors
       // the same construction `enrollAuthenticator` does — wrap-DEKs


### PR DESCRIPTION
## Summary

- Extends the #29 anti-slot-swap guard with a third equality check on \`wrapKind\` alongside \`id\` and \`method\`.
- Closes a hole where a buggy or hostile ceremony could change the slot's session-tier contract under cover of rotation: \`'kek' → 'deks'\` downgrade silently produces \`kek: null\` at unlock; \`'deks' → 'kek'\` upgrade bricks the slot via an AES-KW failure.
- Normalizes \`wrapKind\` (\`'kek'\` default for legacy / wrap-KEK shapes that omit the field) so the check works against pre-pre.8 keyrings.

## Closes #83

## Test plan

- [x] Two new regression tests in \`pr5-rotate-preserve-slots.test.ts\`:
  - \`rejects wrapKind downgrade in ceremony result (anti-slot-swap, kek → deks)\` — webauthn slot, ceremony flips to wrap-DEKs.
  - \`rejects wrapKind upgrade in ceremony result (anti-slot-swap, deks → kek)\` — password slot, ceremony flips to wrap-KEK.
- [x] All 10 rotation tests pass (including pre-existing id-mismatch and method-mismatch guards).
- [x] \`pnpm turbo typecheck --filter=@noy-db/hub\` clean.

## Risk

Non-breaking. The check rejects a path that was never structurally legal — a well-formed ceremony preserves \`wrapKind\` because the wrap shape is bound to the auth method's crypto material.