### PR TITLE
fix(hub): db.changeSecret validates passphrase strength by default (#80)

### DIFF
--- a/packages/hub/__tests__/keyring.test.ts
+++ b/packages/hub/__tests__/keyring.test.ts
@@ -289,8 +289,8 @@ describe('keyring', () => {
       // Encrypt something
       const { iv, data } = await encrypt('test-data', dek)
 
-      // Change passphrase
-      const updated = await changeSecret(adapter, COMP, owner, 'new-pass')
+      // Change passphrase (test exercises rewrap, not strength validation)
+      const updated = await changeSecret(adapter, COMP, owner, 'new-pass', { allowWeakPassphrase: true })
 
       // Old passphrase should fail to load (DEKs present, wrong KEK)
       await expect(
@@ -305,6 +305,26 @@ describe('keyring', () => {
       const newDek = loaded.deks.get('invoices')!
       const decrypted = await decrypt(iv, data, newDek)
       expect(decrypted).toBe('test-data')
+    })
+
+    it('rejects a weak new passphrase by default', async () => {
+      const owner = await createOwnerKeyring(adapter, COMP, 'owner-01', 'correct horse battery staple printer toaster')
+      const getDEK = await ensureCollectionDEK(adapter, COMP, owner)
+      await getDEK('invoices')
+
+      await expect(
+        changeSecret(adapter, COMP, owner, 'weak'),
+      ).rejects.toThrow()
+    })
+
+    it('accepts a weak new passphrase when allowWeakPassphrase: true', async () => {
+      const owner = await createOwnerKeyring(adapter, COMP, 'owner-01', 'correct horse battery staple printer toaster')
+      const getDEK = await ensureCollectionDEK(adapter, COMP, owner)
+      await getDEK('invoices')
+
+      await expect(
+        changeSecret(adapter, COMP, owner, 'weak', { allowWeakPassphrase: true }),
+      ).resolves.toBeDefined()
     })
   })
 

--- a/packages/hub/__tests__/persistence.test.ts
+++ b/packages/hub/__tests__/persistence.test.ts
@@ -162,7 +162,7 @@ describe('persistence round-trip (simulated page reload)', () => {
     const db1 = await createNoydb({ store: adapter, user: USER, secret: PASS })
     const comp1 = await db1.openVault(COMP)
     await comp1.collection<Invoice>('invoices').put('inv-1', { amount: 7000, status: 'sent' })
-    await db1.changeSecret(COMP, 'new-passphrase')
+    await db1.changeSecret(COMP, 'new-passphrase', { allowWeakPassphrase: true })
     db1.close()
 
     // Session 2: old passphrase fails

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -21,6 +21,7 @@ import type {
   TranslatorAuditEntry,
 } from './types.js'
 import { ValidationError, NoAccessError, InvalidKeyError, StoreCapabilityError } from './errors.js'
+import type { PassphrasePolicy } from './validation.js'
 import {
   rotatePassphrase as keyringRotatePassphrase,
   recoverPassphrase as keyringRecoverPassphrase,
@@ -795,8 +796,19 @@ export class Noydb {
     return results
   }
 
-  /** Change the current user's passphrase for a vault. */
-  async changeSecret(vault: string, newPassphrase: string): Promise<void> {
+  /**
+   * Change the current user's passphrase for a vault.
+   *
+   * Validates the new passphrase against the strength rules. Pass
+   * `{ allowWeakPassphrase: true }` to skip — typically only useful for
+   * fixtures and migrations. Pass a `PassphrasePolicy` to override the
+   * default rules (e.g. consumer-tunable `pattern` / `customValidator`).
+   */
+  async changeSecret(
+    vault: string,
+    newPassphrase: string,
+    options?: PassphrasePolicy & { allowWeakPassphrase?: boolean },
+  ): Promise<void> {
     this.checkPolicyOperation(vault, 'changeSecret')
     const keyring = await this.getKeyring(vault)
     const updated = await keyringChangeSecret(
@@ -804,6 +816,7 @@ export class Noydb {
       vault,
       keyring,
       newPassphrase,
+      options,
     )
     this.keyringCache.set(vault, updated)
   }

--- a/packages/hub/src/team/keyring.ts
+++ b/packages/hub/src/team/keyring.ts
@@ -731,19 +731,23 @@ export async function rotateKeys(
 /**
  * Change the user's passphrase. Re-wraps every DEK under the new KEK.
  *
- * Pass `{ validate: true }` (or a `PassphrasePolicy`) to gate the new
- * phrase on the strength rules. `db.rotatePassphrase()` adds a
- * `checkGate('rotate-passphrase')` step on top of this primitive and
- * always validates.
+ * Validates the new passphrase against the strength rules unless
+ * `allowWeakPassphrase: true` is passed. Mirrors `rotatePassphrase`'s
+ * default-on validation contract.
+ *
+ * `db.rotatePassphrase()` adds a `checkGate('rotate-passphrase')` step
+ * on top of this primitive and additionally requires the OLD passphrase
+ * for re-derivation; `changeSecret` reuses the cached unlocked KEK so
+ * the OLD passphrase is not retyped.
  */
 export async function changeSecret(
   adapter: NoydbStore,
   vault: string,
   keyring: UnlockedKeyring,
   newPassphrase: string,
-  passphraseOpts?: PassphrasePolicy & { validate?: boolean; allowWeakPassphrase?: boolean },
+  passphraseOpts?: PassphrasePolicy & { allowWeakPassphrase?: boolean },
 ): Promise<UnlockedKeyring> {
-  if (passphraseOpts?.validate && !passphraseOpts.allowWeakPassphrase) {
+  if (!passphraseOpts?.allowWeakPassphrase) {
     assertStrongPassphrase(newPassphrase, passphraseOpts)
   }
   const newSalt = generateSalt()


### PR DESCRIPTION
## Summary

- Mirror \`rotatePassphrase\`'s contract on \`changeSecret\` — \`assertStrongPassphrase\` fires unconditionally unless \`allowWeakPassphrase: true\`.
- Previously \`changeSecret\` was opt-in (\`validate: true\`) and the public \`db.changeSecret\` never opted in — bypassable from the consumer surface even after #7 shipped phrase strength validation.
- \`db.changeSecret\` gains the same \`PassphrasePolicy & { allowWeakPassphrase? }\` options shape \`rotatePassphrase\` already uses.
- Lower-level \`keyring.changeSecret()\` drops its vestigial \`validate\` flag.

## Closes #80

## Test plan

- [x] Two new regression tests in \`keyring.test.ts\`:
  - \`rejects a weak new passphrase by default\`
  - \`accepts a weak new passphrase when allowWeakPassphrase: true\`
- [x] Existing \`changeSecret\` test in \`keyring.test.ts\` and \`persistence.test.ts\` updated to pass \`allowWeakPassphrase: true\` (those tests exercise rewrap, not strength validation).
- [x] All 21 changeSecret-adjacent tests pass.
- [x] \`pnpm turbo typecheck --filter=@noy-db/hub\` clean.

## Disruptive

Breaking for consumers calling \`db.changeSecret\` with a passphrase that fails the default validator (lowercase letters and spaces, 6+ words). Escape hatch \`allowWeakPassphrase: true\` preserves any pre-existing flow that needs to pass through. CHANGELOG entry will call this out under \"Breaking changes\".

The audit (#80) recommended either deleting \`changeSecret\` or routing it through validation. This PR takes the additive path — no removed API. A future minor can deprecate \`changeSecret\` in favor of \`rotatePassphrase\` if the redundancy concern resurfaces.