### PR TITLE
fix(hub): wire db.grant / db.revoke through enroll-user / revoke-user gates (#79)

### DIFF
--- a/packages/hub/__tests__/peer-recover.test.ts
+++ b/packages/hub/__tests__/peer-recover.test.ts
@@ -310,12 +310,15 @@ describe('db.recoverUser (#33 + #34 hub-level integration)', () => {
       policy: STRICT_POLICY,
     })
     await db.openVault('acme')
+    // grant() under STRICT_POLICY requires a factor proof (#79 wired the
+    // enroll-user gate). Pass TOTP for the setup; the actual assertion
+    // below is about recoverUser's gate, not grant's.
     await db.grant('acme', {
       userId: 'bob',
       displayName: 'Bob',
       role: 'admin',
       passphrase: BOB_PHRASE,
-    })
+    }, { factors: [{ kind: 'totp', mintedAt: new Date().toISOString() }] })
 
     // Without a factor proof, the gate denies.
     await expect(

--- a/packages/hub/__tests__/strict-policy-grant-revoke.test.ts
+++ b/packages/hub/__tests__/strict-policy-grant-revoke.test.ts
@@ -1,0 +1,125 @@
+/**
+ * #79 — STRICT_POLICY enroll-user / revoke-user gates wired through
+ * db.grant and db.revoke.
+ *
+ * Pre-fix, both methods routed through the legacy
+ * checkPolicyOperation('grant'|'revoke') only — the gates defined in
+ * presets.ts were never invoked, so STRICT_POLICY silently failed to
+ * enforce TOTP / email-OTP requirements.
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope } from '../src/types.js'
+import { createNoydb } from '../src/noydb.js'
+import { PolicyDeniedError } from '../src/policy/errors.js'
+import { STRICT_POLICY } from '../src/policy/presets.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'inline-memory',
+    async get(c, col, id) { return gc(c, col).get(id) },
+    async put(c, col, id, env) { gc(c, col).set(id, env) },
+    async delete(c, col, id) { gc(c, col).delete(id) },
+    async list(c, col) { return [...gc(c, col).keys()] },
+    async loadAll() { return {} },
+    async saveAll() {},
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+  } as unknown as NoydbStore
+}
+
+const STRICT_PHRASE = 'correct horse battery staple printer toaster picnic'
+
+async function bootstrap(): Promise<{ db: Awaited<ReturnType<typeof createNoydb>>; store: NoydbStore }> {
+  const store = inlineMemory()
+  const db = await createNoydb({
+    store,
+    user: 'alice',
+    secret: STRICT_PHRASE,
+    policy: STRICT_POLICY,
+  })
+  await db.openVault('acme')
+  return { db, store }
+}
+
+describe('STRICT_POLICY enroll-user gate (#79)', () => {
+  it('rejects db.grant without factor proof', async () => {
+    const { db } = await bootstrap()
+    await expect(
+      db.grant('acme', {
+        userId: 'bob',
+        displayName: 'Bob',
+        role: 'operator',
+        passphrase: 'glasses cabinet bicycle umbrella thunder velvet',
+        permissions: { invoices: 'rw' },
+      }),
+    ).rejects.toBeInstanceOf(PolicyDeniedError)
+  }, 60_000)
+
+  it('accepts db.grant with a TOTP factor proof', async () => {
+    const { db } = await bootstrap()
+    await expect(
+      db.grant(
+        'acme',
+        {
+          userId: 'bob',
+          displayName: 'Bob',
+          role: 'operator',
+          passphrase: 'glasses cabinet bicycle umbrella thunder velvet',
+          permissions: { invoices: 'rw' },
+        },
+        { factors: [{ kind: 'totp', mintedAt: new Date().toISOString() }] },
+      ),
+    ).resolves.toBeUndefined()
+  }, 60_000)
+})
+
+describe('STRICT_POLICY revoke-user gate (#79)', () => {
+  it('rejects db.revoke without factor proof', async () => {
+    const { db } = await bootstrap()
+    await db.grant(
+      'acme',
+      {
+        userId: 'bob',
+        displayName: 'Bob',
+        role: 'operator',
+        passphrase: 'glasses cabinet bicycle umbrella thunder velvet',
+        permissions: { invoices: 'rw' },
+      },
+      { factors: [{ kind: 'totp', mintedAt: new Date().toISOString() }] },
+    )
+
+    await expect(
+      db.revoke('acme', { userId: 'bob' }),
+    ).rejects.toBeInstanceOf(PolicyDeniedError)
+  }, 60_000)
+
+  it('accepts db.revoke with a TOTP factor proof', async () => {
+    const { db } = await bootstrap()
+    await db.grant(
+      'acme',
+      {
+        userId: 'bob',
+        displayName: 'Bob',
+        role: 'operator',
+        passphrase: 'glasses cabinet bicycle umbrella thunder velvet',
+        permissions: { invoices: 'rw' },
+      },
+      { factors: [{ kind: 'totp', mintedAt: new Date().toISOString() }] },
+    )
+
+    await expect(
+      db.revoke(
+        'acme',
+        { userId: 'bob' },
+        { factors: [{ kind: 'totp', mintedAt: new Date().toISOString() }] },
+      ),
+    ).resolves.toBeUndefined()
+  }, 60_000)
+})

--- a/packages/hub/__tests__/update-user.test.ts
+++ b/packages/hub/__tests__/update-user.test.ts
@@ -398,12 +398,15 @@ describe('Noydb.updateUser (hub-level wiring, #54)', () => {
       policy: STRICT_POLICY,
     })
     await alice.openVault('acme')
+    // grant() under STRICT_POLICY requires a factor proof (#79 wired the
+    // enroll-user gate). Pass TOTP for the setup; the actual assertion
+    // below is about updateUser's gate, not grant's.
     await alice.grant('acme', {
       userId: 'bob',
       displayName: 'Bob',
       role: 'admin',
       passphrase: 'glasses cabinet bicycle umbrella thunder velvet picnic',
-    })
+    }, { factors: [{ kind: 'totp', mintedAt: new Date().toISOString() }] })
 
     // No factor proof — STRICT_POLICY's update-user gate requires totp/email-otp.
     await expect(

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -447,16 +447,43 @@ export class Noydb {
     return comp
   }
 
-  /** Grant access to a user for a vault. */
-  async grant(vault: string, options: GrantOptions): Promise<void> {
+  /**
+   * Grant access to a user for a vault.
+   *
+   * Gated by `enroll-user`. `STRICT_POLICY` requires a TOTP / email-OTP
+   * factor proof so the operator affirmatively re-asserts identity at
+   * the moment of grant; `PERSONAL_POLICY` accepts a tier-1 unlock alone.
+   *
+   * The legacy `requireReAuthFor: ['grant']` session-policy check still
+   * fires on top — both are independent opt-ins.
+   */
+  async grant(
+    vault: string,
+    options: GrantOptions,
+    factors?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+  ): Promise<void> {
     this.checkPolicyOperation(vault, 'grant')
+    await this.checkGate(vault, 'enroll-user', factors)
     const keyring = await this.getKeyring(vault)
     await keyringGrant(this.options.store, vault, keyring, options)
   }
 
-  /** Revoke a user's access to a vault. */
-  async revoke(vault: string, options: RevokeOptions): Promise<void> {
+  /**
+   * Revoke a user's access to a vault.
+   *
+   * Gated by `revoke-user`. `STRICT_POLICY` requires a TOTP / email-OTP
+   * factor proof; `PERSONAL_POLICY` accepts a tier-1 unlock alone.
+   *
+   * The legacy `requireReAuthFor: ['revoke']` session-policy check still
+   * fires on top — both are independent opt-ins.
+   */
+  async revoke(
+    vault: string,
+    options: RevokeOptions,
+    factors?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+  ): Promise<void> {
     this.checkPolicyOperation(vault, 'revoke')
+    await this.checkGate(vault, 'revoke-user', factors)
     const keyring = await this.getKeyring(vault)
     await keyringRevoke(this.options.store, vault, keyring, options)
   }


### PR DESCRIPTION
## Summary

- The \`enroll-user\` and \`revoke-user\` gates were defined in \`policy/presets.ts:51-52,127-134\` but never invoked. \`db.grant\` / \`db.revoke\` routed through the legacy \`checkPolicyOperation\` only, so STRICT_POLICY's documented TOTP/email-OTP requirement was a silent contract lie at runtime.
- Both methods now layer \`checkGate(...)\` on top of the legacy session-policy check. PERSONAL_POLICY (default) is unchanged — gate config is \`minTier: 1\`, no factors required. STRICT_POLICY now enforces its documented requirement.
- Adds optional \`factors\` parameter matching the shape of \`db.updateUser\`, \`db.rotatePassphrase\`, etc.

## Closes #79

## Test plan

- [x] New regression file \`strict-policy-grant-revoke.test.ts\` (4 tests):
  - STRICT_POLICY rejects \`db.grant\` without factor proof → \`PolicyDeniedError\`
  - STRICT_POLICY accepts \`db.grant\` with TOTP factor proof
  - STRICT_POLICY rejects \`db.revoke\` without factor proof → \`PolicyDeniedError\`
  - STRICT_POLICY accepts \`db.revoke\` with TOTP factor proof
- [x] All 35 existing grant/revoke tests under PERSONAL_POLICY default still pass.
- [x] \`pnpm turbo typecheck --filter=@noy-db/hub\` clean.

## Disruptive

Behavior change for any consumer that explicitly opts into STRICT_POLICY (or a custom policy that defines the \`enroll-user\` / \`revoke-user\` gates with non-default factor requirements) — \`db.grant\` / \`db.revoke\` calls without factor proof will now throw \`PolicyDeniedError\`. CHANGELOG entry to call out under \"Breaking changes for STRICT_POLICY consumers\".

PERSONAL_POLICY consumers (the default) see no behavior change.

\`db.rotate\` (DEK rotation) and \`db.changeSecret\` are deliberately out of scope — they need new gate definitions (\`rotate-deks\` / \`rotate-secret\`) which the audit explicitly punted to a follow-up. Filed as part of #79's \"add or fold\" wording.