### PR TITLE
fix(hub): distinguish keyring corruption from wrong passphrase in loadKeyring (#82)

### DIFF
--- a/packages/hub/__tests__/cross-vault.test.ts
+++ b/packages/hub/__tests__/cross-vault.test.ts
@@ -162,6 +162,29 @@ describe('cross-vault queries.', () => {
       expect(accessible.find((c) => c.id === 'T-mismatched')).toBeUndefined()
     })
 
+    it('issue #82 follow-up: a partially-corrupted vault is silently skipped, not surfaced as KeyringCorruptError', async () => {
+      // Without this, `listAccessibleVaults()` would throw the moment it
+      // hit the corrupted vault, and the caller would not be able to
+      // enumerate ANY of their healthy vaults — a single corruption would
+      // poison the whole list.
+      // Surgically corrupt one wrapped DEK in T2's _keyring/alice envelope
+      // so loadKeyring throws KeyringCorruptError (mixed-success path).
+      const env = await adapter.get('T2', '_keyring', 'alice')
+      const file = JSON.parse(env!._data) as { deks: Record<string, string> }
+      const collNames = Object.keys(file.deks).filter((n) => !n.startsWith('_'))
+      const victim = collNames[0]!
+      const original = file.deks[victim]!
+      file.deks[victim] = Buffer.from(new Uint8Array(original.length).fill(0))
+        .toString('base64')
+        .slice(0, original.length)
+      await adapter.put('T2', '_keyring', 'alice', { ...env!, _data: JSON.stringify(file) })
+
+      // Enumeration must succeed and include T1 + T7. T2 is silently dropped.
+      const accessible = await aliceDb.listAccessibleVaults()
+      expect(accessible.map((c) => c.id).sort()).toEqual(['T1', 'T7'])
+      expect(accessible.find((c) => c.id === 'T2')).toBeUndefined()
+    })
+
     it('throws StoreCapabilityError against adapters without listVaults', async () => {
       const dumb = memoryWithoutEnumeration()
       const db = await createNoydb({ store: dumb, user: 'alice', secret: 'alice-pass' })

--- a/packages/hub/__tests__/persistence.test.ts
+++ b/packages/hub/__tests__/persistence.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
-import { ConflictError, InvalidKeyError } from '../src/errors.js'
+import { ConflictError, InvalidKeyError, KeyringCorruptError } from '../src/errors.js'
 import { createNoydb } from '../src/noydb.js'
 
 /** Shared memory adapter — persists across createNoydb calls. */
@@ -175,6 +175,51 @@ describe('persistence round-trip (simulated page reload)', () => {
     const comp3 = await db3.openVault(COMP)
     const inv = await comp3.collection<Invoice>('invoices').get('inv-1')
     expect(inv).toEqual({ amount: 7000, status: 'sent' })
+    db3.close()
+  })
+
+  it('issue #82: partial DEK corruption throws KeyringCorruptError, NOT onInvalidKey: "reset"', async () => {
+    // Build a vault with multiple DEKs (one per collection + system).
+    const adapter = persistentMemory()
+    const db1 = await createNoydb({ store: adapter, user: USER, secret: PASS })
+    const comp1 = await db1.openVault(COMP)
+    await comp1.collection<Invoice>('invoices').put('inv-1', { amount: 100, status: 'paid' })
+    await comp1.collection<Invoice>('payments').put('pay-1', { amount: 50, status: 'cleared' })
+    db1.close()
+
+    // Surgically corrupt ONE wrapped DEK in the keyring file. Pick a
+    // collection name (any one — they all wrap with AES-KW under the
+    // same KEK), replace its base64 ciphertext with garbage of the
+    // same length. The other DEKs remain valid.
+    const env = await adapter.get(COMP, '_keyring', USER)
+    const file = JSON.parse(env!._data) as { deks: Record<string, string> }
+    const collNames = Object.keys(file.deks).filter((n) => !n.startsWith('_'))
+    const victim = collNames[0]!
+    const original = file.deks[victim]!
+    file.deks[victim] = Buffer.from(new Uint8Array(original.length).fill(0)).toString('base64').slice(0, original.length)
+    await adapter.put(COMP, '_keyring', USER, {
+      ...env!,
+      _data: JSON.stringify(file),
+    })
+
+    // Reload with the CORRECT passphrase + onInvalidKey: 'reset'. Pre-fix,
+    // the loop's first failure threw InvalidKeyError, the reset path fired,
+    // and the keyring was destroyed. Post-fix, the partial unwrap is
+    // recognized as corruption and KeyringCorruptError is raised — the
+    // reset path does NOT fire.
+    const db2 = await createNoydb({
+      store: adapter,
+      user: USER,
+      secret: PASS,
+      onInvalidKey: 'reset',
+    })
+    await expect(db2.openVault(COMP)).rejects.toBeInstanceOf(KeyringCorruptError)
+    db2.close()
+
+    // The keyring on disk was NOT replaced — opening with a different
+    // passphrase still fails, proving the original keyring survives.
+    const db3 = await createNoydb({ store: adapter, user: USER, secret: 'wrong-pass' })
+    await expect(db3.openVault(COMP)).rejects.toThrow(InvalidKeyError)
     db3.close()
   })
 

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -134,6 +134,35 @@ export class InvalidKeyError extends NoydbError {
   }
 }
 
+/**
+ * Thrown when a keyring's wrapped-DEK set unwraps partially — at least
+ * one DEK succeeds (proving the KEK is correct) but at least one fails.
+ * The passphrase is right; the failed entries are corrupted.
+ *
+ * This is distinct from {@link InvalidKeyError} so that
+ * `NoydbOptions.onInvalidKey: 'reset'` does NOT fire — resetting on
+ * partial corruption would destroy the still-valid DEKs and the data
+ * they protect, which is silent data loss in response to a feature
+ * designed for stale-credential recovery.
+ */
+export class KeyringCorruptError extends NoydbError {
+  readonly failedCollections: readonly string[]
+  readonly intactCount: number
+  constructor(opts: { failedCollections: readonly string[]; intactCount: number; message?: string }) {
+    super(
+      'KEYRING_CORRUPT',
+      opts.message ??
+        `Keyring has ${opts.failedCollections.length} corrupted wrapped DEK(s) ` +
+          `(${opts.failedCollections.join(', ')}); ${opts.intactCount} other DEK(s) ` +
+          `unwrapped successfully — the passphrase is correct, the entries are damaged. ` +
+          `Do NOT use onInvalidKey: 'reset' here — that would destroy the intact DEKs.`,
+    )
+    this.name = 'KeyringCorruptError'
+    this.failedCollections = opts.failedCollections
+    this.intactCount = opts.intactCount
+  }
+}
+
 // ─── Access Errors ─────────────────────────────────────────────────────
 
 /**

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -196,6 +196,7 @@ export {
   DecryptionError,
   TamperedError,
   InvalidKeyError,
+  KeyringCorruptError,
   NoAccessError,
   ReadOnlyError,
   PermissionDeniedError,

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -20,7 +20,7 @@ import type {
   ReAuthOperation,
   TranslatorAuditEntry,
 } from './types.js'
-import { ValidationError, NoAccessError, InvalidKeyError, StoreCapabilityError } from './errors.js'
+import { ValidationError, NoAccessError, InvalidKeyError, KeyringCorruptError, StoreCapabilityError } from './errors.js'
 import type { PassphrasePolicy } from './validation.js'
 import {
   rotatePassphrase as keyringRotatePassphrase,
@@ -667,8 +667,17 @@ export class Noydb {
           this.options.secret,
         )
       } catch (err) {
-        if (err instanceof NoAccessError || err instanceof InvalidKeyError) {
-          continue // silent: caller has no key material for this vault
+        if (
+          err instanceof NoAccessError ||
+          err instanceof InvalidKeyError ||
+          err instanceof KeyringCorruptError
+        ) {
+          // No accessible key material for this vault. KeyringCorruptError
+          // is included so a single partially-corrupted vault does NOT
+          // poison the enumeration of every other healthy vault — the
+          // caller can probe a corrupted vault directly via openVault()
+          // / loadKeyring() if they want to act on it.
+          continue
         }
         throw err // unexpected error — surface it
       }

--- a/packages/hub/src/team/keyring.ts
+++ b/packages/hub/src/team/keyring.ts
@@ -11,7 +11,7 @@ import {
   bufferToBase64,
   base64ToBuffer,
 } from '../crypto.js'
-import { NoAccessError, PermissionDeniedError, PrivilegeEscalationError, KeyringExpiredError, ValidationError } from '../errors.js'
+import { NoAccessError, PermissionDeniedError, PrivilegeEscalationError, KeyringExpiredError, KeyringCorruptError, ValidationError } from '../errors.js'
 import { assertStrongPassphrase, type PassphrasePolicy } from '../validation.js'
 import {
   saveUserEnvelope,
@@ -172,10 +172,34 @@ export async function loadKeyring(
   const salt = base64ToBuffer(keyringFile.salt)
   const kek = await deriveKey(passphrase, salt)
 
+  // Unwrap each DEK independently — if some succeed and some fail, the
+  // passphrase is correct (the KEK derives) but specific entries are
+  // corrupted. Surface that as KeyringCorruptError so onInvalidKey:
+  // 'reset' does NOT fire and destroy the intact DEKs.
   const deks = new Map<string, CryptoKey>()
+  const failedCollections: string[] = []
+  let firstUnwrapError: unknown = null
   for (const [collName, wrappedDek] of Object.entries(keyringFile.deks)) {
-    const dek = await unwrapKey(wrappedDek, kek)
-    deks.set(collName, dek)
+    try {
+      const dek = await unwrapKey(wrappedDek, kek)
+      deks.set(collName, dek)
+    } catch (err) {
+      failedCollections.push(collName)
+      if (firstUnwrapError === null) firstUnwrapError = err
+    }
+  }
+  if (failedCollections.length > 0) {
+    if (deks.size > 0) {
+      throw new KeyringCorruptError({
+        failedCollections,
+        intactCount: deks.size,
+      })
+    }
+    // No DEKs unwrapped — KEK is wrong (or every DEK is corrupt, which
+    // looks identical from here). Surface the original InvalidKeyError
+    // so onInvalidKey: 'reset' can fire its documented stale-credential
+    // recovery path.
+    throw firstUnwrapError
   }
 
   return {


### PR DESCRIPTION
## Summary

Pre-fix, \`loadKeyring\` walked the wrapped-DEK set in a bare \`for...of\` — the first unwrap failure killed the load with \`InvalidKeyError\` even when the KEK was correct and only one DEK was corrupt. Combined with \`NoydbOptions.onInvalidKey: 'reset'\` (#6), this turned a single-byte store-side corruption into **silent data loss**: the keyring (and access to every still-valid DEK) was destroyed in response to a feature designed for stale-credential recovery.

Each DEK unwrap is now independent:

| Result | Throws | \`onInvalidKey: 'reset'\` fires? |
|---|---|:---:|
| All succeed | — | n/a |
| All fail | \`InvalidKeyError\` (existing) | yes — documented stale-credentials path |
| Mixed (some succeed, some fail) | **\`KeyringCorruptError\` (new)** | **no** |

\`KeyringCorruptError\` carries \`failedCollections: readonly string[]\` and \`intactCount: number\` so the consumer can show targeted recovery UI without nuking the rest of the vault.

## Closes #82

## Why this is the highest-impact P0 from the audit

Silent data loss in response to a feature designed for recovery is the worst failure mode I found. A user with \`onInvalidKey: 'reset'\` configured (per #6's docs) and a single bit-flip in their \`_keyring/<userId>\` blob — from an IDB upgrade gone wrong, an SD card error, a partial cloud sync — would lose everything on next reload. After this fix, the same scenario throws a typed error pointing at the corrupted collection and preserves access to the rest.

## Test plan

- [x] New test \`issue #82: partial DEK corruption throws KeyringCorruptError, NOT onInvalidKey: 'reset'\` in \`persistence.test.ts\`:
  - Builds a vault with two collections (multiple DEKs).
  - Surgically corrupts one wrapped DEK in the store.
  - Reloads with the correct passphrase + \`onInvalidKey: 'reset'\`.
  - Asserts \`KeyringCorruptError\`, not reset.
  - Verifies the original keyring on disk survives (a wrong-passphrase reload still throws \`InvalidKeyError\`).
- [x] Existing #6 test (\`onInvalidKey: 'reset' recovers a stale keyring\`) still passes — the wrong-passphrase path is unchanged.
- [x] All 66 keyring/access-control/persistence/dev-unlock tests pass.
- [x] \`pnpm turbo typecheck --filter=@noy-db/hub\` clean.

## Single-DEK ambiguity (documented limitation)

A keyring with exactly one DEK + that DEK corrupted still looks like a wrong passphrase from \`loadKeyring\`'s vantage point. In practice every production keyring has multiple DEKs (per-collection + system collections like \`_users\`, \`_ledger\`, \`_sync\` propagated by \`grant\`), so the all-fail path is genuinely reserved for wrong-key cases.

A passphrase canary on the keyring file would resolve the single-DEK case but requires a format change. Deferring that to a follow-up if the ambiguity becomes a real issue.

## Disruptive

Non-breaking for the all-success and all-fail paths (the only paths reachable in tests pre-fix). The mixed path was previously unreachable in tests (it only fires on real corruption); consumers catching \`InvalidKeyError\` to trigger reset will now see \`KeyringCorruptError\` instead in those rare cases — exactly the intended fix.

\`KeyringCorruptError\` is exported from \`@noy-db/hub\` for \`instanceof\` checks.