### PR TITLE
fix(hub): burn paper recovery entry before rewriting keyring (atomicity window) (#84)

### DIFF
--- a/packages/hub/__tests__/rotate-recover.test.ts
+++ b/packages/hub/__tests__/rotate-recover.test.ts
@@ -21,6 +21,7 @@ import {
 import {
   savePaperRecoveryEntries,
   mintPaperRecoveryEntry,
+  loadPaperRecoveryEntries,
 } from '../src/team/recovery.js'
 import { generateDEK } from '../src/crypto.js'
 import { persistKeyring } from '../src/team/keyring.js'
@@ -146,6 +147,43 @@ describe('recoverPassphrase (paper profile)', () => {
         recoveryProof: { profile: 'paper', payload: { code } },
       }),
     ).rejects.toThrow()
+  }, 60_000)
+
+  it('issue #84: burn happens before keyring rewrite — failed rewrite leaves code BURNED, old phrase intact', async () => {
+    // Pre-fix ordering (write keyring → burn code) made store-side failure
+    // between the two writes leave the consumed code reusable: keyring is
+    // already on the new passphrase, but the burn step never landed. After
+    // #84, burn comes first — so a failure on the keyring write leaves the
+    // user on their OLD passphrase with the code GONE.
+    const { store, code } = await buildVaultWithPaperRecovery()
+
+    // Wrap the store: every put to `_keyring` fails. The recovery call's
+    // first `_keyring` put is the rewrap (the initial create has already
+    // happened in buildVaultWithPaperRecovery via persistKeyring on the
+    // unwrapped base). The burn write is a put to `_meta/recovery-paper`,
+    // not `_keyring`, so it succeeds.
+    const wrapped: NoydbStore = {
+      ...(store as NoydbStore),
+      async put(c, col, id, env, ev) {
+        if (col === '_keyring') throw new Error('simulated store failure on keyring write')
+        return store.put(c, col, id, env, ev)
+      },
+    } as NoydbStore
+
+    await expect(
+      recoverPassphrase(wrapped, 'acme', 'alice', {
+        newPassphrase: STRONG_NEW,
+        recoveryProof: { profile: 'paper', payload: { code } },
+      }),
+    ).rejects.toThrow()
+
+    // Code is GONE — burned before the failing keyring write.
+    const remaining = await loadPaperRecoveryEntries(store, 'acme')
+    expect(remaining).toHaveLength(0)
+
+    // Old passphrase still works — the keyring was never rewritten.
+    const reloaded = await loadKeyring(store, 'acme', 'alice', STRONG_OLD)
+    expect(reloaded.userId).toBe('alice')
   }, 60_000)
 
   it('rejects an unknown paper code', async () => {

--- a/packages/hub/src/team/rotate-recover.ts
+++ b/packages/hub/src/team/rotate-recover.ts
@@ -419,8 +419,20 @@ async function recoverViaPaperCode(
     authenticators: [], // tier-2 slots wrap old KEK, drop them
   }
 
-  await writeKeyringFile(store, vault, userId, next)
+  // Burn first, then rewrite the keyring. The two writes are not
+  // atomic — if the second fails (#84), the safer ordering is:
+  //
+  //   1. Code burned, keyring untouched: user keeps their old passphrase
+  //      and loses one recovery code (recoverable: contact admin / use
+  //      another code).
+  //
+  //   2. Keyring rewritten, code unburned: user has rotated, but the
+  //      consumed code REMAINS VALID. Anyone with access to the paper
+  //      sheet can use it again. Security regression.
+  //
+  // Burning first picks (1) over (2).
   await burnPaperRecoveryEntry(store, vault, recovered.entry.codeId)
+  await writeKeyringFile(store, vault, userId, next)
 
   return {
     userId: file.user_id,


### PR DESCRIPTION
## Summary

Pre-fix order: \`writeKeyringFile\` → \`burnPaperRecoveryEntry\`. The two writes are not atomic; if the burn failed (store error after the keyring write succeeded), the user was on the new passphrase but the **consumed paper code remained valid**. Anyone with access to the same paper sheet could use it again — security regression in the recovery flow.

New order: burn first, then rewrite the keyring. Both writes still non-atomic, but the failure mode flips from security to usability:

| Failure point | Old behavior | New behavior |
|---|---|---|
| After burn, before rewrite | (couldn't happen — burn was last) | Old passphrase still works. Code is gone — recoverable via admin or another code. **Usability issue.** |
| After rewrite, before burn | New passphrase + reusable code. **Security issue.** | (can't happen — rewrite is last) |

## Closes #84

## Test plan

- [x] New regression test \`issue #84: burn happens before keyring rewrite — failed rewrite leaves code BURNED, old phrase intact\`:
  - Wraps the store with a fail-on-keyring-put adapter.
  - Calls \`recoverPassphrase\` — burn succeeds, keyring write throws.
  - Asserts: code is gone (\`loadPaperRecoveryEntries\` returns 0), old passphrase still unwraps the keyring.
- [x] All 10 rotate-recover tests pass (including the existing happy-path that asserts code burned + new passphrase works).
- [x] All 11 downstream tests pass (\`pr4-auto-rotate-recovery-codes.test.ts\`, \`pr1a-public-recovery.test.ts\`).
- [x] \`pnpm turbo typecheck --filter=@noy-db/hub\` clean.

## Disruptive

Non-breaking. Behavior change is only observable on the partial-failure path, which produces a strictly safer end state.