### PR TITLE
feat(hub): UpdateUserOptions.displayName accepts null to clear (#85)

### DIFF
--- a/packages/hub/__tests__/update-user.test.ts
+++ b/packages/hub/__tests__/update-user.test.ts
@@ -113,6 +113,53 @@ describe('updateKeyringIdentity (team layer, #54)', () => {
     expect(bob.role).toBe('admin')
   }, 60_000)
 
+  it('issue #85: displayName: null clears the field (matches UserApi.updateMe convention)', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob the Original',
+      role: 'admin',
+      passphrase: BOB_PHRASE,
+    })
+
+    await updateKeyringIdentity(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: null,
+    })
+
+    const bob = await loadKeyring(store, 'acme', 'bob', BOB_PHRASE)
+    expect(bob.displayName).toBe('')
+    // Other fields untouched.
+    expect(bob.role).toBe('admin')
+  }, 60_000)
+
+  it('issue #85: displayName: undefined leaves the field untouched (preserve semantics)', async () => {
+    const store = inlineMemory()
+    const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)
+    aliceKr.deks.set('invoices', await generateDEK())
+    await persistKeyring(store, 'acme', aliceKr)
+    await grant(store, 'acme', aliceKr, {
+      userId: 'bob',
+      displayName: 'Bob the Original',
+      role: 'admin',
+      passphrase: BOB_PHRASE,
+    })
+
+    // Update only role — displayName should survive.
+    await updateKeyringIdentity(store, 'acme', aliceKr, {
+      userId: 'bob',
+      role: 'operator',
+      permissions: { invoices: 'rw' },
+    })
+
+    const bob = await loadKeyring(store, 'acme', 'bob', BOB_PHRASE)
+    expect(bob.displayName).toBe('Bob the Original')
+    expect(bob.role).toBe('operator')
+  }, 60_000)
+
   it('tier-2 authenticator slots survive the update (#54 vs peer-recover)', async () => {
     const store = inlineMemory()
     const aliceKr = await createOwnerKeyring(store, 'acme', 'alice', ALICE_PHRASE)

--- a/packages/hub/src/team/keyring.ts
+++ b/packages/hub/src/team/keyring.ts
@@ -581,7 +581,10 @@ export async function updateKeyringIdentity(
   const next: KeyringFile = {
     ...target,
     ...(options.role !== undefined && { role: options.role }),
-    ...(options.displayName !== undefined && { display_name: options.displayName }),
+    ...(options.displayName !== undefined && {
+      // null clears the field (stored as ""); a string sets it.
+      display_name: options.displayName ?? '',
+    }),
     ...(options.permissions !== undefined && { permissions: options.permissions }),
   }
 

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -1039,6 +1039,11 @@ export interface GrantOptions {
  * keyring put (same concurrency story as `db.grant` / `db.revoke`).
  *
  * Top-level fields are partial-merge: absent fields are not modified.
+ * `null` on `displayName` clears the field (stored as the empty string;
+ * UI consumers typically render the empty case by falling back to the
+ * user id). `undefined` / absent leaves the field untouched. Mirrors
+ * the `null`-as-clear convention `UserApi.updateMe` uses (#57).
+ *
  * `permissions`, however, is a **full replacement** at the map level —
  * passing `{ invoices: 'rw' }` REPLACES the entire permissions map,
  * silently dropping any other entries. To partially update, read the
@@ -1057,7 +1062,7 @@ export interface GrantOptions {
 export interface UpdateUserOptions {
   readonly userId: string
   readonly role?: Role
-  readonly displayName?: string
+  readonly displayName?: string | null
   readonly permissions?: Permissions
 }
 


### PR DESCRIPTION
## Summary

Aligns \`db.updateUser\` with the \`null\`-as-clear convention \`UserApi.updateMe\` shipped in #57. Type widens from \`string | undefined\` to \`string | null | undefined\`:

| Value | Behavior |
|---|---|
| absent / \`undefined\` | field untouched (preserve) |
| \`string\` | field set |
| \`null\` | field cleared — stored as the empty string |

UI consumers typically render the empty case by falling back to the user id (the same default \`createOwnerKeyring\` uses).

\`permissions\` stays full-replacement at the map level — that semantic is documented in the existing JSDoc and is intentionally not changed here. \`role\` does not accept \`null\` (there is no \"no role\" state).

## Closes #85

## Test plan

- [x] New regression tests in \`update-user.test.ts\`:
  - \`displayName: null\` clears the field (asserts \`bob.displayName === ''\`).
  - \`displayName: undefined\` preserves the field (asserts the original value survives).
- [x] All 17 existing update-user tests pass.
- [x] \`pnpm turbo typecheck --filter=@noy-db/hub\` clean.

## Disruptive

Non-breaking type widening. Existing callers passing \`displayName: string\` or omitting the field see no change. New \`null\` callers get the documented clear semantic.