### PR TITLE
refactor(hub): narrow RecoverPassphraseInput.recoveryProof to 'paper' (#86)

### DIFF
--- a/packages/hub/src/team/rotate-recover.ts
+++ b/packages/hub/src/team/rotate-recover.ts
@@ -247,12 +247,19 @@ export async function rotatePassphrase(
   }
 }
 
-/** Caller payload for {@link recoverPassphrase}. */
-export type RecoveryProof =
-  | { readonly profile: 'paper'; readonly payload: { readonly code: string } }
-  | { readonly profile: 'shamir'; readonly payload: { readonly shares: ReadonlyArray<string> } }
-  | { readonly profile: 'multi-channel'; readonly payload: { readonly proofs: ReadonlyArray<unknown> } }
-  | { readonly profile: 'admin-mediated'; readonly payload: { readonly token: string; readonly factor?: unknown } }
+/**
+ * Caller payload for {@link recoverPassphrase}.
+ *
+ * **Narrowed to `'paper'` only (#86).** The other three profiles
+ * (`shamir`, `multi-channel`, `admin-mediated`) are documented in the
+ * spec but not yet wired end-to-end. Matching the discipline of
+ * {@link db.enrollRecovery}, the type rejects them at compile time
+ * rather than accepting them and throwing at runtime. The runtime
+ * guard ({@link RecoveryProfileNotImplementedError}) remains so
+ * consumers who bypass TS via `as unknown as RecoveryProof` still
+ * receive a clear error.
+ */
+export type RecoveryProof = { readonly profile: 'paper'; readonly payload: { readonly code: string } }
 
 export interface RecoverPassphraseInput {
   readonly newPassphrase: string
@@ -333,31 +340,18 @@ export async function recoverPassphrase(
     assertStrongPassphrase(input.newPassphrase, input.passphrasePolicy)
   }
 
-  switch (input.recoveryProof.profile) {
-    case 'paper':
-      return recoverViaPaperCode(store, vault, userId, input)
-    case 'shamir':
-      throw new RecoveryProfileNotImplementedError(
-        'shamir',
-        'https://github.com/vLannaAi/noy-db/issues/10',
-      )
-    case 'multi-channel':
-      throw new RecoveryProfileNotImplementedError(
-        'multi-channel',
-        'https://github.com/vLannaAi/noy-db/issues/10',
-      )
-    case 'admin-mediated':
-      throw new RecoveryProfileNotImplementedError(
-        'admin-mediated',
-        'https://github.com/vLannaAi/noy-db/issues/10',
-      )
-    default: {
-      // Exhaustiveness check — TS narrows to `never` if the union is
-      // covered. A missing branch surfaces here at compile time.
-      const _exhaustive: never = input.recoveryProof
-      throw new Error(`Unknown recovery profile: ${String(_exhaustive)}`)
-    }
+  // Runtime defense-in-depth: the type narrows to 'paper' (#86), but
+  // a consumer bypassing TS via `as unknown as RecoveryProof` should
+  // still hit a clear error rather than silently fall into the paper
+  // handler with a malformed payload.
+  const profile = (input.recoveryProof as { profile: string }).profile
+  if (profile !== 'paper') {
+    throw new RecoveryProfileNotImplementedError(
+      profile,
+      'https://github.com/vLannaAi/noy-db/issues/10',
+    )
   }
+  return recoverViaPaperCode(store, vault, userId, input)
 }
 
 async function recoverViaPaperCode(


### PR DESCRIPTION
## Summary

Aligns \`db.recoverPassphrase\`'s type with \`db.enrollRecovery\`'s TS-narrow discipline. Pre-fix, \`RecoveryProof\` accepted a 4-variant union (\`paper | shamir | multi-channel | admin-mediated\`); three of the four threw \`RecoveryProfileNotImplementedError\` at runtime. \`db.enrollRecovery\` is hard-typed to \`'paper'\` only — the sibling discipline mismatch surprised consumers who could enroll \`'paper'\` and recover \`'shamir'\` at the type level.

\`RecoveryProof\` now narrows to:

\`\`\`ts
type RecoveryProof = { profile: 'paper'; payload: { code: string } }
\`\`\`

The runtime guard stays — a consumer bypassing TS via \`as unknown as RecoveryProof\` still receives \`RecoveryProfileNotImplementedError\`. The dispatch switch collapses to a single profile-name check.

## Closes #86

## Test plan

- [x] All 9 rotate-recover tests pass (including the runtime-defense tests for \`'shamir'\` / \`'multi-channel'\` / \`'admin-mediated'\` — vitest doesn't strict-typecheck, so they exercise the runtime guard verbatim).
- [x] All 20 downstream recovery tests pass (\`pr4-auto-rotate-recovery-codes\`, \`pr1a-public-recovery\`).
- [x] \`pnpm turbo typecheck --filter=@noy-db/hub\` clean.

## Disruptive

**Breaking-but-narrowing.** A consumer with \`recoveryProof\` typed as the wide \`RecoveryProof\` union (e.g. ferrying it through helper code) will get a TS error after this lands. The fix on the consumer side: type as \`{ profile: 'paper'; payload: { code: string } }\` directly, or downcast the wider type at the call site.

The runtime contract is unchanged — \`recoverPassphrase\` still throws \`RecoveryProfileNotImplementedError\` for non-paper profiles. CHANGELOG entry to call out the TS-only narrowing.

## When the other profiles ship

Re-widen \`RecoveryProof\` to include the variant being implemented, in lockstep with the runtime handler. The wider \`RecoveryProfileNotImplementedError\` runtime guard stays for the still-unimplemented siblings until they all ship.