### PR TITLE
feat(hub): re-export KeyringAuthenticator + EnrollAuthenticatorOptions variant types (#91)

### DIFF
--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -81,6 +81,8 @@ export type {
   Permissions,
   EncryptedEnvelope,
   KeyringAuthenticator,
+  KeyringAuthenticatorWrappingKEK,
+  KeyringAuthenticatorWrappingDEKs,
   VaultPolicyOnDisk,
   VaultSnapshot,
   NoydbStore,
@@ -321,7 +323,12 @@ export {
   removeAuthenticator,
   findAuthenticator,
 } from './team/authenticators.js'
-export type { EnrollAuthenticatorOptions, UpdateAuthenticatorOptions } from './team/authenticators.js'
+export type {
+  EnrollAuthenticatorOptions,
+  EnrollAuthenticatorWrappingKEKOptions,
+  EnrollAuthenticatorWrappingDEKsOptions,
+  UpdateAuthenticatorOptions,
+} from './team/authenticators.js'
 
 // Tier-3 quick-unlock state — issue #11
 export { QuickUnlockStore } from './session/unlock-state.js'


### PR DESCRIPTION
## Summary

Adds the wrap-KEK / wrap-DEKs variant interfaces to the public surface so consumers can name the type they want directly:

\`\`\`ts
// before — reach for Extract<>
type DEKsSlot = Extract<KeyringAuthenticator, { wrapKind: 'deks' }>

// after — import the named variant
import type { KeyringAuthenticatorWrappingDEKs } from '@noy-db/hub'
\`\`\`

Same applies to enroll inputs: \`EnrollAuthenticatorWrappingKEKOptions\` / \`EnrollAuthenticatorWrappingDEKsOptions\`.

## Closes #91

## Test plan

- [x] \`pnpm turbo typecheck --filter=@noy-db/hub\` clean.
- [x] No runtime change — pure type re-export addition.

## Disruptive

Non-breaking add.