### PR TITLE
chore(showcases): drop leftover null-as-CryptoKey casts now that #41 shipped (#93)

### DIFF
--- a/showcases/src/23-on-webauthn.showcase.test.ts
+++ b/showcases/src/23-on-webauthn.showcase.test.ts
@@ -103,7 +103,7 @@ async function makeKeyring(userId: string): Promise<UnlockedKeyring> {
     role: 'owner',
     permissions: { invoices: 'rw' },
     deks: new Map([['invoices', dek]]),
-    kek: null as unknown as CryptoKey,
+    kek: null,
     salt: new Uint8Array(32).fill(7),
     authenticators: [],
   }

--- a/showcases/src/24-on-oidc.showcase.test.ts
+++ b/showcases/src/24-on-oidc.showcase.test.ts
@@ -51,7 +51,7 @@ async function makeKeyring(userId: string): Promise<UnlockedKeyring> {
   return {
     userId, displayName: userId, role: 'owner', permissions: { invoices: 'rw' },
     deks: new Map([['invoices', dek]]),
-    kek: null as unknown as CryptoKey, salt: new Uint8Array(32).fill(7),
+    kek: null, salt: new Uint8Array(32).fill(7),
     authenticators: [],
   }
 }

--- a/showcases/src/30-on-pin.showcase.test.ts
+++ b/showcases/src/30-on-pin.showcase.test.ts
@@ -39,7 +39,7 @@ async function makeKeyring(userId: string): Promise<UnlockedKeyring> {
   return {
     userId, displayName: userId, role: 'owner', permissions: { invoices: 'rw' },
     deks: new Map([['invoices', dek]]),
-    kek: null as unknown as CryptoKey, salt: new Uint8Array(32).fill(7),
+    kek: null, salt: new Uint8Array(32).fill(7),
     authenticators: [],
   }
 }


### PR DESCRIPTION
## Summary

\`UnlockedKeyring.kek\` was tightened to \`CryptoKey | null\` in pre.8 (#41). Three showcase fixtures still carried \`null as unknown as CryptoKey\` casts that the runtime always tolerated:

- \`showcases/src/23-on-webauthn.showcase.test.ts:106\`
- \`showcases/src/24-on-oidc.showcase.test.ts:54\`
- \`showcases/src/30-on-pin.showcase.test.ts:42\`

Replacing them with literal \`null\` lines the test fixtures up with the public type contract.

## Closes #93

The original audit framing was \"CLAUDE.md drift on closed #41\" — but \`CLAUDE.md\` is gitignored, so the project-memory copy is local-only and a no-op for the repo. The real drift this issue tracked was the leftover casts in tracked test fixtures; the deep-audit's \"zero hits in \`packages/hub/src/\`\" was correct, the sites just lived in \`showcases/src/\` and were missed by the pre.8 sweep.

## Test plan

- [x] \`pnpm turbo typecheck --filter=@noy-db/showcases\` clean.
- [x] No runtime change.