### PR TITLE
fix(hub): db.getKeyring() returns a defensive copy (#88, #114)

### DIFF
--- a/packages/hub/__tests__/get-keyring-callback.test.ts
+++ b/packages/hub/__tests__/get-keyring-callback.test.ts
@@ -206,4 +206,29 @@ describe('NoydbOptions.getKeyring (issue #5)', () => {
 
     expect(seenVaults).toEqual(['VA', 'VB'])
   })
+
+  it('issue #88: db.getKeyring() returns a defensive copy — mutations on the returned Map do NOT leak into the cache', async () => {
+    const adapter = inlineMemory()
+    const db = await createNoydb({ store: adapter, user: 'alice', secret: 'p' })
+    const vault = await db.openVault('acme')
+    await vault.collection<Note>('notes').put('n-1', { title: 'first' })
+
+    const snapshot1 = await db.getKeyring('acme')
+    const collectionsBefore = [...snapshot1.deks.keys()].sort()
+
+    // Mutate the returned Map. Pre-fix this would corrupt the hub's
+    // cached keyring; post-fix it's a no-op on the cached state.
+    snapshot1.deks.set('hijacked', snapshot1.deks.get('notes')!)
+    snapshot1.deks.delete('notes')
+
+    const snapshot2 = await db.getKeyring('acme')
+    const collectionsAfter = [...snapshot2.deks.keys()].sort()
+    expect(collectionsAfter).toEqual(collectionsBefore)
+    expect(snapshot2.deks.has('hijacked')).toBe(false)
+    expect(snapshot2.deks.has('notes')).toBe(true)
+
+    // Subsequent vault operations still work — the cache wasn't corrupted.
+    await vault.collection<Note>('notes').put('n-2', { title: 'second' })
+    expect((await vault.collection<Note>('notes').get('n-2'))?.title).toBe('second')
+  })
 })

--- a/packages/hub/__tests__/get-keyring-callback.test.ts
+++ b/packages/hub/__tests__/get-keyring-callback.test.ts
@@ -231,4 +231,40 @@ describe('NoydbOptions.getKeyring (issue #5)', () => {
     await vault.collection<Note>('notes').put('n-2', { title: 'second' })
     expect((await vault.collection<Note>('notes').get('n-2'))?.title).toBe('second')
   })
+
+  it('issue #114: defensive copy also clones permissions and per-authenticator meta', async () => {
+    const adapter = inlineMemory()
+    const db = await createNoydb({ store: adapter, user: 'alice', secret: 'p' })
+    await db.openVault('acme')
+    // Inject a tier-2 slot directly into alice's keyring file so the snapshot
+    // has a non-empty `authenticators` array with a real `meta` to mutate.
+    const env = await adapter.get('acme', '_keyring', 'alice')
+    const file = JSON.parse(env!._data) as Record<string, unknown> & { authenticators?: unknown[] }
+    file.authenticators = [{
+      id: 'webauthn-yubi',
+      method: 'webauthn',
+      enrolled_at: new Date().toISOString(),
+      enrolled_via_tier: 1,
+      wrapped_kek: 'YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=',
+      meta: { credentialId: 'cred-yubi', nickname: 'Original' },
+    }]
+    await adapter.put('acme', '_keyring', 'alice', { ...env!, _data: JSON.stringify(file) })
+    // Force a fresh keyring load (the cache was populated from the original
+    // envelope before we patched in the slot).
+    db.close()
+    const db2 = await createNoydb({ store: adapter, user: 'alice', secret: 'p' })
+    await db2.openVault('acme')
+
+    const snapshot1 = await db2.getKeyring('acme')
+
+    // Mutate fields the original PR didn't deep-copy. Each of these would
+    // corrupt the cache pre-#114 (they'd land on the cached keyring's
+    // shared sub-objects).
+    ;(snapshot1.permissions as Record<string, 'ro' | 'rw'>)['injected'] = 'rw'
+    ;(snapshot1.authenticators[0]!.meta as Record<string, unknown>)['nickname'] = 'Hijacked'
+
+    const snapshot2 = await db2.getKeyring('acme')
+    expect((snapshot2.permissions as Record<string, 'ro' | 'rw'>)['injected']).toBeUndefined()
+    expect(snapshot2.authenticators[0]!.meta['nickname']).toBe('Original')
+  })
 })

--- a/packages/hub/__tests__/pr1a-public-recovery.test.ts
+++ b/packages/hub/__tests__/pr1a-public-recovery.test.ts
@@ -68,10 +68,26 @@ describe('PR1a public surface', () => {
       expect(keyring.kek).toBeInstanceOf(CryptoKey)
     })
 
-    it('returns the same instance on repeated calls (cached)', async () => {
+    it('returns equal-but-distinct snapshots on repeated calls (defensive copy, #88)', async () => {
+      // Pre-#88 this test asserted Object.is identity (`a === b`). Post-#88
+      // the contract changed: db.getKeyring() returns a defensive copy so
+      // consumers can't corrupt the cache via .deks.set/.delete or
+      // .permissions['k'] = ... mutations. Two calls now return distinct
+      // outer objects with equal content; the underlying CryptoKey handles
+      // are still shared (intentional — opaque references).
       const a = await db.getKeyring('acme')
       const b = await db.getKeyring('acme')
-      expect(a).toBe(b)
+      expect(a).not.toBe(b)
+      expect(a.deks).not.toBe(b.deks) // fresh Map per snapshot
+      expect(a.userId).toBe(b.userId)
+      expect(a.role).toBe(b.role)
+      expect([...a.deks.keys()].sort()).toEqual([...b.deks.keys()].sort())
+      // Underlying CryptoKey handles are shared (the cache and both
+      // snapshots reference the same key — encrypt/decrypt all flow
+      // through it).
+      for (const coll of a.deks.keys()) {
+        expect(a.deks.get(coll)).toBe(b.deks.get(coll))
+      }
     })
   })
 

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -1787,10 +1787,26 @@ export class Noydb {
    */
   async getKeyring(vault: string): Promise<UnlockedKeyring> {
     const live = await this.getKeyringInternal(vault)
+    // Deep-ish defensive copy. Each container the consumer might
+    // reasonably mutate is freshly cloned. CryptoKey handles inside
+    // `deks` are intentionally shared — they're opaque references that
+    // both encrypt and decrypt go through. `salt` (Uint8Array) is left
+    // as-is: no realistic mutation path. (#88, extended in #114.)
     return {
       ...live,
       deks: new Map(live.deks),
-      authenticators: [...live.authenticators],
+      permissions: { ...live.permissions },
+      authenticators: live.authenticators.map((a) => ({
+        ...a,
+        meta: { ...a.meta },
+      })),
+      ...(live.policy !== undefined ? { policy: { ...live.policy } } : {}),
+      ...(live.exportCapability !== undefined
+        ? { exportCapability: { ...live.exportCapability } }
+        : {}),
+      ...(live.importCapability !== undefined
+        ? { importCapability: { ...live.importCapability } }
+        : {}),
     }
   }
 

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -269,7 +269,7 @@ export class Noydb {
       return comp
     }
 
-    const keyring = await this.getKeyring(name)
+    const keyring = await this.getKeyringInternal(name)
     // Tier-1 unlock — passphrase / getKeyring callbacks both yield the
     // most-privileged tier. Tier-2 / tier-3 unlocks (issue #11) install
     // a lower tier here when they land.
@@ -461,11 +461,11 @@ export class Noydb {
   async grant(
     vault: string,
     options: GrantOptions,
-    factors?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+    factors?: FactorProofBundle,
   ): Promise<void> {
     this.checkPolicyOperation(vault, 'grant')
     await this.checkGate(vault, 'enroll-user', factors)
-    const keyring = await this.getKeyring(vault)
+    const keyring = await this.getKeyringInternal(vault)
     await keyringGrant(this.options.store, vault, keyring, options)
   }
 
@@ -481,11 +481,11 @@ export class Noydb {
   async revoke(
     vault: string,
     options: RevokeOptions,
-    factors?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+    factors?: FactorProofBundle,
   ): Promise<void> {
     this.checkPolicyOperation(vault, 'revoke')
     await this.checkGate(vault, 'revoke-user', factors)
-    const keyring = await this.getKeyring(vault)
+    const keyring = await this.getKeyringInternal(vault)
     await keyringRevoke(this.options.store, vault, keyring, options)
   }
 
@@ -537,7 +537,7 @@ export class Noydb {
     factors?: FactorProofBundle,
   ): Promise<void> {
     await this.checkGate(vault, 'update-user', factors)
-    const keyring = await this.getKeyring(vault)
+    const keyring = await this.getKeyringInternal(vault)
     await updateKeyringIdentity(this.options.store, vault, keyring, options)
     // If the caller updated their own role / permissions, the cached
     // unlocked keyring is stale — drop it so the next access reloads
@@ -568,7 +568,7 @@ export class Noydb {
    */
   async rotate(vault: string, collections: string[]): Promise<void> {
     this.checkPolicyOperation(vault, 'rotate')
-    const keyring = await this.getKeyring(vault)
+    const keyring = await this.getKeyringInternal(vault)
     await keyringRotate(this.options.store, vault, keyring, collections)
     // Refresh the cached keyring so subsequent operations see the
     // freshly-rotated DEKs. Without this, `ensureCollectionDEK` on
@@ -837,7 +837,7 @@ export class Noydb {
     options?: PassphrasePolicy & { allowWeakPassphrase?: boolean },
   ): Promise<void> {
     this.checkPolicyOperation(vault, 'changeSecret')
-    const keyring = await this.getKeyring(vault)
+    const keyring = await this.getKeyringInternal(vault)
     const updated = await keyringChangeSecret(
       this.options.store,
       vault,
@@ -1224,7 +1224,7 @@ export class Noydb {
     factors?: FactorProofBundle,
   ): Promise<void> {
     await this.checkGate(vault, 'enroll-authenticator', factors)
-    const keyring = await this.getKeyring(vault)
+    const keyring = await this.getKeyringInternal(vault)
     const next = await keyringEnrollAuthenticator(this.options.store, vault, keyring, options)
     this.keyringCache.set(vault, next)
   }
@@ -1240,14 +1240,14 @@ export class Noydb {
     factors?: FactorProofBundle,
   ): Promise<void> {
     await this.checkGate(vault, 'remove-authenticator', factors)
-    const keyring = await this.getKeyring(vault)
+    const keyring = await this.getKeyringInternal(vault)
     const next = await keyringRemoveAuthenticator(this.options.store, vault, keyring, slotId)
     this.keyringCache.set(vault, next)
   }
 
   /** Read the slot list for a vault. Internal — `describeAuthConfig` (#13) consumes this. */
   async listAuthenticators(vault: string): Promise<ReadonlyArray<KeyringAuthenticator>> {
-    const keyring = await this.getKeyring(vault)
+    const keyring = await this.getKeyringInternal(vault)
     return keyring.authenticators
   }
 
@@ -1286,7 +1286,7 @@ export class Noydb {
     factors?: FactorProofBundle,
   ): Promise<void> {
     await this.checkGate(vault, 'update-authenticator', factors)
-    const keyring = await this.getKeyring(vault)
+    const keyring = await this.getKeyringInternal(vault)
     const next = await keyringUpdateAuthenticator(this.options.store, vault, keyring, slotId, options)
     this.keyringCache.set(vault, next)
   }
@@ -1344,7 +1344,7 @@ export class Noydb {
     factors?: FactorProofBundle,
   ): Promise<{ credentialId: string }> {
     await this.checkGate(vault, 'enroll-authenticator', factors)
-    const keyring = await this.getKeyring(vault)
+    const keyring = await this.getKeyringInternal(vault)
     const slotOptions = await ceremony(keyring)
     if (slotOptions.method !== 'webauthn') {
       throw new ValidationError(
@@ -1378,7 +1378,7 @@ export class Noydb {
     enrolledAt: string
     credentialId: string
   }>> {
-    const keyring = await this.getKeyring(vault)
+    const keyring = await this.getKeyringInternal(vault)
     return keyring.authenticators
       .filter((a) => a.method === 'webauthn')
       .map((a) => {
@@ -1405,7 +1405,7 @@ export class Noydb {
     slotId: string,
     verify: (slot: KeyringAuthenticator) => Promise<UnlockedKeyring>,
   ): Promise<UnlockedKeyring> {
-    const keyring = await this.getKeyring(vault)
+    const keyring = await this.getKeyringInternal(vault)
     const slot = findAuthenticator(keyring, slotId)
     if (!slot) {
       throw new ValidationError(
@@ -1641,7 +1641,7 @@ export class Noydb {
     factors?: FactorProofBundle,
   ): Promise<void> {
     await this.checkGate(vault, 'peer-recover-user', factors)
-    const callerKeyring = await this.getKeyring(vault)
+    const callerKeyring = await this.getKeyringInternal(vault)
     await keyringRecoverUser(this.options.store, vault, callerKeyring, options)
     // If the caller is recovering THEIR OWN keyring (rare but
     // possible — e.g. a self-recovery flow that bypasses the password
@@ -1756,8 +1756,17 @@ export class Noydb {
   /**
    * Public accessor for the unlocked keyring of a vault — issue #28.
    *
-   * Returns the cached `UnlockedKeyring` (already in memory after
-   * `createNoydb` + first vault touch); loads it on demand if absent.
+   * Returns a **defensive shallow copy** so consumers can read the DEK
+   * map and authenticator list without the risk of mutating the hub's
+   * internal cache (#88). Internal hub code paths use a live reference
+   * via `getKeyringInternal`; ceremonies and external consumers always
+   * get a snapshot.
+   *
+   * The CryptoKey values inside `deks` are not cloned — Web Crypto
+   * keys are opaque handles, and a shared handle is intentional
+   * (encrypt / decrypt go through the same key the cache holds).
+   * Only the container Map / authenticator array is fresh.
+   *
    * Used by `@noy-db/on-*` ceremonies that need the live DEK set
    * (paper recovery via {@link mintPaperRecoveryEntry}, tier-3 PIN
    * enrolment via on-pin's `enrollPin`, custom on-* ceremonies that
@@ -1772,11 +1781,27 @@ export class Noydb {
    * ```ts
    * const keyring = await db.getKeyring('acme')
    * // keyring.deks: Map<collection, CryptoKey>
-   * // keyring.kek:  CryptoKey   (non-extractable; null for tier-3 sessions)
+   * // keyring.kek:  CryptoKey | null   (null for tier-3 / wrap-DEKs sessions)
    * // keyring.role / .permissions / .authenticators
    * ```
    */
   async getKeyring(vault: string): Promise<UnlockedKeyring> {
+    const live = await this.getKeyringInternal(vault)
+    return {
+      ...live,
+      deks: new Map(live.deks),
+      authenticators: [...live.authenticators],
+    }
+  }
+
+  /**
+   * Live-reference variant used by the hub's own code paths. Internal
+   * mutations on `deks` (e.g. {@link ensureCollectionDEK} adding a
+   * collection key) need to land on the cached keyring so subsequent
+   * accesses see them. Not exposed publicly — callers outside hub
+   * should use {@link getKeyring}, which returns a defensive copy.
+   */
+  private async getKeyringInternal(vault: string): Promise<UnlockedKeyring> {
     if (this.options.encrypt === false) {
       return createPlaintextKeyring(this.options.user)
     }


### PR DESCRIPTION
## Summary

\`UnlockedKeyring.deks\` is typed \`readonly deks: Map\` — the property is readonly, the Map is not. Pre-fix, \`db.getKeyring()\` returned the live cached reference; a consumer calling \`.deks.set()\` / \`.deks.delete()\` on the returned value would corrupt the hub's in-memory state for every subsequent operation. The \`readonly\` annotation reinforced the wrong assumption that the caller held a snapshot.

\`db.getKeyring()\` now returns a defensive copy with fresh containers for every field a consumer might reasonably mutate:

| Field | Treatment |
|---|---|
| \`deks\` | fresh \`Map\` (CryptoKey handles intentionally shared — opaque handles for encrypt/decrypt) |
| \`authenticators\` | fresh array; **each element cloned with a fresh \`meta\` object** (#114) |
| \`permissions\` | shallow clone (#114) |
| \`policy\` | shallow clone when present (#114) |
| \`exportCapability\` / \`importCapability\` | shallow clone when present (#114) |
| \`salt\` (Uint8Array) | shared — no realistic mutation path |

## Internal vs external

The hub's own code paths still need the live reference (\`ensureCollectionDEK\` adds a freshly-derived collection key to \`deks\`; subsequent accesses must see it). Renamed the existing live-ref method to \`private getKeyringInternal()\`; the new public \`getKeyring()\` wraps it with the defensive copy. 14 internal call sites switched.

## Closes #88, #114

The original audit (#88) named \`.deks.set()\` as the attack path. The post-PR code review (#105 review) found that \`meta\` and \`permissions\` are realistic additional mutation vectors — \`@noy-db/on-*\` ceremonies pattern-match authenticator meta when building slot rewrap options. #114 tracked the deeper copy; folded into this PR before merge.

## Test plan

- [x] Two regression tests in \`get-keyring-callback.test.ts\`:
  - **#88** — mutates \`snapshot.deks\`, asserts cache survives, asserts subsequent vault op still works.
  - **#114** — injects a tier-2 slot, mutates \`snapshot.permissions\` and \`snapshot.authenticators[0].meta.nickname\`, asserts a fresh \`getKeyring()\` shows original values.
- [x] All 11 get-keyring-callback tests pass.
- [x] All 22 keyring + getKeyring-callback tests pass (no regressions).
- [x] \`pnpm turbo typecheck --filter=@noy-db/hub\` clean.

## Disruptive

Non-breaking. The shape stays identical; only reference identity tightens for several more fields. Consumers who were (incorrectly) mutating any of these fields will get the documented snapshot semantic.