### PR TITLE
chore(hub): clean up Adapter/Compartment naming residue + truncated comments (#92)

### DIFF
--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -90,7 +90,7 @@ function warnOnceFallback(adapterName: string): void {
   // Only warn in non-test environments — vitest runs are noisy enough.
   if (typeof process !== 'undefined' && process.env['NODE_ENV'] === 'test') return
   console.warn(
-    `[noy-db] Adapter "${adapterName}" does not implement listPage(); ` +
+    `[noy-db] Store "${adapterName}" does not implement listPage(); ` +
     `Collection.scan()/listPage() are using a synthetic fallback (slower). ` +
     `Add a listPage method to opt into the streaming fast path.`,
   )

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -295,7 +295,7 @@ export class KeyringExpiredError extends NoydbError {
 
 /**
  * Thrown when an `@noy-db/as-*` import is attempted but the invoking
- * keyring lacks the required import-capability bit (issue ).
+ * keyring lacks the required import-capability bit.
  *
  * - `tier: 'plaintext'` — a plaintext-tier import (`as-csv`, `as-json`,
  *   `as-ndjson`, `as-zip`, …) was attempted but the keyring's

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -517,8 +517,10 @@ export {
 } from './team/sync-credentials.js'
 export type { SyncCredential } from './team/sync-credentials.js'
 
-// Magic-link unlock — extracted to @noy-db/on-magic-link in.
-// Consumers should: `import { ... } from '@noy-db/on-magic-link'`.
+// Magic-link unlock — `@noy-db/on-magic-link` provides the high-level
+// invite / peer-recovery flows. The lower-level `MagicLinkGrant*`
+// primitives below stay in hub because `on-magic-link` consumes them;
+// direct use is supported but uncommon.
 
 // Session policies —
 export { PolicyEnforcer, createEnforcer, validateSessionPolicy } from './session/session-policy.js'

--- a/packages/hub/src/session/dev-unlock.ts
+++ b/packages/hub/src/session/dev-unlock.ts
@@ -196,7 +196,7 @@ export async function enableDevUnlock(
   console.warn(
     '%c⚠️ NOYDB DEV UNLOCK ACTIVE ⚠️',
     'color: red; font-size: 16px; font-weight: bold',
-    `\n\nCompartment "${vault}" user "${userId}" is stored in ` +
+    `\n\nVault "${vault}" user "${userId}" is stored in ` +
     `${options.persistAcrossTabs ? 'localStorage' : 'sessionStorage'} in PLAINTEXT DEKs.\n` +
     'This is ONLY safe for local development. Never use in production.\n' +
     'Call clearDevUnlock() to remove.',

--- a/packages/hub/src/team/index.ts
+++ b/packages/hub/src/team/index.ts
@@ -6,7 +6,8 @@
  * estimated at ~4-6 KB.
  *
  * The main `@noy-db/hub` entry still re-exports every symbol for
- * backward compatibility through.x.
+ * backward compatibility — direct subpath import is purely a
+ * tree-shaking opt-in.
  *
  * Named re-exports (not `export *`) so tsup keeps the barrel
  * populated even with `sideEffects: false`.

--- a/packages/hub/src/team/keyring.ts
+++ b/packages/hub/src/team/keyring.ts
@@ -117,8 +117,9 @@ export interface UnlockedKeyring {
    */
   readonly exportCapability?: ExportCapability
   /**
-   * `@noy-db/as-*` import capability (issue ). Absent when the
-   * keyring was written before  landed — default-closed semantics
+   * `@noy-db/as-*` import capability. Absent when the
+   * keyring was written before the import-capability extension
+   * landed — default-closed semantics
    * apply via `hasImportCapability` (no plaintext format granted, no
    * bundle import granted, regardless of role).
    */

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -85,7 +85,7 @@ export type Permissions = Record<string, Permission>
 
 // ─── Encrypted Envelope ────────────────────────────────────────────────
 
-/** The encrypted wrapper stored by adapters. Adapters only ever see this. */
+/** The encrypted wrapper stored by stores. Stores only ever see this. */
 export interface EncryptedEnvelope {
   readonly _noydb: typeof NOYDB_FORMAT_VERSION
   readonly _v: number
@@ -202,8 +202,8 @@ export interface ListPageResult {
 
 export interface NoydbStore {
   /**
-   * Optional human-readable adapter name (e.g. 'memory', 'file', 'dynamo').
-   * Used in diagnostic messages and the listPage fallback warning. Adapters
+   * Optional human-readable store name (e.g. 'memory', 'file', 'dynamo').
+   * Used in diagnostic messages and the listPage fallback warning. Stores
    * are encouraged to set this so logs are clearer about which backend is
    * involved when something goes wrong.
    */
@@ -238,23 +238,23 @@ export interface NoydbStore {
 
   /**
    * Optional: list record IDs in a collection that have `_ts` after `since`.
-   * Used by partial sync (`pull({ modifiedSince })`). Adapters that omit this
+   * Used by partial sync (`pull({ modifiedSince })`). Stores that omit this
    * fall back to a full `loadAll` + client-side timestamp filter.
    */
   listSince?(vault: string, collection: string, since: string): Promise<string[]>
 
   /**
-   * Optional pagination extension. Adapters that implement `listPage` get
-   * the streaming `Collection.scan()` fast path; adapters that don't are
+   * Optional pagination extension. Stores that implement `listPage` get
+   * the streaming `Collection.scan()` fast path; stores that don't are
    * silently fallen back to a full `loadAll()` + slice (with a one-time
    * console.warn).
    *
-   * `cursor` is opaque to the core — each adapter encodes its own paging
+   * `cursor` is opaque to the core — each store encodes its own paging
    * state (DynamoDB: base64 LastEvaluatedKey JSON; S3: ContinuationToken;
    * memory/file/browser: numeric offset of a sorted id list). Pass
    * `undefined` to start from the beginning.
    *
-   * `limit` is a soft upper bound on `items.length`. Adapters MAY return
+   * `limit` is a soft upper bound on `items.length`. Stores MAY return
    * fewer items even when more exist (e.g. if the underlying store has
    * its own page size cap), and MUST signal "no more pages" by returning
    * `nextCursor: null`.
@@ -873,7 +873,7 @@ export interface PullOptions {
   collections?: string[]
   /**
    * Only pull records with `_ts` strictly after this ISO timestamp.
-   * Adapters that implement `listSince` use it directly; others fall back
+   * Stores that implement `listSince` use it directly; others fall back
    * to a full scan with client-side filtering.
    */
   modifiedSince?: string
@@ -1106,8 +1106,8 @@ export interface AccessibleVault {
  */
 export interface ListAccessibleVaultsOptions {
   /**
-   * Minimum role the caller must hold to include a compartment in the
-   * result. Compartments where the caller's role is strictly *below*
+   * Minimum role the caller must hold to include a vault in the
+   * result. Vaults where the caller's role is strictly *below*
    * this threshold are silently excluded. Defaults to `'client'`,
    * which means "every vault I can unwrap is returned." Set to
    * `'admin'` for "vaults where I can grant/revoke," or


### PR DESCRIPTION
## Summary

The \`Adapter → Store\` / \`Compartment → Vault\` rename completed in v0.6 / pre.6, but residue remained in user-visible strings, JSDoc, and a handful of sed-truncated comments. This PR sweeps them.

### User-visible strings
- \`session/dev-unlock.ts:199\` \`Compartment ...\` → \`Vault ...\`
- \`collection.ts:93\` \`Adapter ...\` → \`Store ...\`

### JSDoc / comments (\`packages/hub/src/types.ts\`)
- \`EncryptedEnvelope\` description (\"Adapters only ever see this\")
- \`NoydbStore\` field docs (\`name\`, \`listSince\`, \`listPage\`, \`cursor\`, \`limit\`)
- \`PullOptions\` doc (\"Adapters that implement \`listSince\`...\")
- \`ListAccessibleVaultsOptions\` doc (\"Compartments where the caller's role...\")

### Truncation artefacts (sed sweep dropped version + issue numbers)
- \`team/index.ts:9\` \`through.x\` rewritten
- \`index.ts:520\` \`extracted to @noy-db/on-magic-link in.\` rewritten
- \`errors.ts:298\` \`(issue ).\` dropped
- \`team/keyring.ts:120-121\` \`issue ).\` / \`before  landed\` rewritten

## Closes #92

## Out of scope (deliberately deferred)

The internal \`syncAdapter\` field name on \`Collection\` / \`Vault\` / \`PresenceHandle\` is **NOT** renamed here — it's internal-only but touches multiple constructors and their tests. Folding it into this cosmetic PR would dilute the diff. Filing as a follow-up if anyone hits it.

The single deliberate \`NoydbBundleAdapter\` reference at \`types.ts:1356\` stays — it's *documenting* the historical rename (\"not \`NoydbBundleAdapter\` for consistency\"), not residue.

## Test plan

- [x] \`pnpm turbo typecheck --filter=@noy-db/hub\` clean.
- [x] \`pnpm vitest run packages/hub/__tests__/dev-unlock.test.ts\` — 23/23 pass (no test pinned the literal warning string).
- [x] No runtime change.