### PR TITLE
refactor(hub): introduce FactorProofBundle, unify param name to factors (#89)

### DIFF
--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -619,6 +619,7 @@ export type {
   FactorKind,
   FactorRequirement,
   FactorProof,
+  FactorProofBundle,
   WarningRules,
   ActiveTier,
   PolicyDenyReason,

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -95,7 +95,6 @@ import {
   PERSONAL_POLICY,
   mergePolicy,
   type ActiveTier,
-  type FactorProof,
   type FactorProofBundle,
   type GateName,
   type VaultPolicy,

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -96,6 +96,7 @@ import {
   mergePolicy,
   type ActiveTier,
   type FactorProof,
+  type FactorProofBundle,
   type GateName,
   type VaultPolicy,
 } from './policy/index.js'
@@ -506,7 +507,7 @@ export class Noydb {
   async updateUser(
     vault: string,
     options: UpdateUserOptions,
-    factors?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+    factors?: FactorProofBundle,
   ): Promise<void> {
     await this.checkGate(vault, 'update-user', factors)
     const keyring = await this.getKeyring(vault)
@@ -1104,15 +1105,15 @@ export class Noydb {
   async checkGate(
     vault: string,
     gate: GateName,
-    presented?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+    factors?: FactorProofBundle,
   ): Promise<void> {
     const policy = await this.getPolicy(vault)
     const tier = this.activeTier.get(vault) ?? 1
     await policyCheckGate(policy, gate, {
       activeTier: tier,
-      ...(presented?.factors !== undefined ? { factors: presented.factors } : {}),
-      ...(presented?.sharedDevice !== undefined
-        ? { sharedDevice: presented.sharedDevice }
+      ...(factors?.factors !== undefined ? { factors: factors.factors } : {}),
+      ...(factors?.sharedDevice !== undefined
+        ? { sharedDevice: factors.sharedDevice }
         : {}),
     })
   }
@@ -1181,9 +1182,9 @@ export class Noydb {
   async enrollAuthenticator(
     vault: string,
     options: EnrollAuthenticatorOptions,
-    presented?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+    factors?: FactorProofBundle,
   ): Promise<void> {
-    await this.checkGate(vault, 'enroll-authenticator', presented)
+    await this.checkGate(vault, 'enroll-authenticator', factors)
     const keyring = await this.getKeyring(vault)
     const next = await keyringEnrollAuthenticator(this.options.store, vault, keyring, options)
     this.keyringCache.set(vault, next)
@@ -1197,9 +1198,9 @@ export class Noydb {
   async removeAuthenticator(
     vault: string,
     slotId: string,
-    presented?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+    factors?: FactorProofBundle,
   ): Promise<void> {
-    await this.checkGate(vault, 'remove-authenticator', presented)
+    await this.checkGate(vault, 'remove-authenticator', factors)
     const keyring = await this.getKeyring(vault)
     const next = await keyringRemoveAuthenticator(this.options.store, vault, keyring, slotId)
     this.keyringCache.set(vault, next)
@@ -1243,9 +1244,9 @@ export class Noydb {
     vault: string,
     slotId: string,
     options: UpdateAuthenticatorOptions,
-    presented?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+    factors?: FactorProofBundle,
   ): Promise<void> {
-    await this.checkGate(vault, 'update-authenticator', presented)
+    await this.checkGate(vault, 'update-authenticator', factors)
     const keyring = await this.getKeyring(vault)
     const next = await keyringUpdateAuthenticator(this.options.store, vault, keyring, slotId, options)
     this.keyringCache.set(vault, next)
@@ -1301,9 +1302,9 @@ export class Noydb {
   async enrollWebAuthn(
     vault: string,
     ceremony: (keyring: UnlockedKeyring) => Promise<EnrollAuthenticatorOptions>,
-    presented?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+    factors?: FactorProofBundle,
   ): Promise<{ credentialId: string }> {
-    await this.checkGate(vault, 'enroll-authenticator', presented)
+    await this.checkGate(vault, 'enroll-authenticator', factors)
     const keyring = await this.getKeyring(vault)
     const slotOptions = await ceremony(keyring)
     if (slotOptions.method !== 'webauthn') {
@@ -1454,7 +1455,7 @@ export class Noydb {
   async describeUserAuth(
     vault: string,
     userId: string,
-    factors?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+    factors?: FactorProofBundle,
   ): Promise<string> {
     await this.checkGate(vault, 'view-user-auth', factors)
     return fnDescribeUserAuth(this.options.store, vault, userId)
@@ -1463,7 +1464,7 @@ export class Noydb {
   /** Bulk variant for owner dashboards. Gated by `view-user-auth`. */
   async describeAllUsersAuth(
     vault: string,
-    factors?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+    factors?: FactorProofBundle,
   ): Promise<Array<{ userId: string; description: string }>> {
     await this.checkGate(vault, 'view-user-auth', factors)
     return fnDescribeAllUsersAuth(this.options.store, vault)
@@ -1487,7 +1488,7 @@ export class Noydb {
   async rotatePassphrase(
     vault: string,
     input: RotatePassphraseInput,
-    factors?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+    factors?: FactorProofBundle,
   ): Promise<void> {
     await this.checkGate(vault, 'rotate-passphrase', factors)
     const userId = this.options.user
@@ -1505,7 +1506,7 @@ export class Noydb {
   async recoverPassphrase(
     vault: string,
     input: RecoverPassphraseInput,
-    factors?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+    factors?: FactorProofBundle,
   ): Promise<RecoverPassphraseResult> {
     await this.checkGate(vault, 'recover-passphrase', factors)
     const userId = this.options.user
@@ -1598,7 +1599,7 @@ export class Noydb {
   async recoverUser(
     vault: string,
     options: RecoverUserOptions,
-    factors?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+    factors?: FactorProofBundle,
   ): Promise<void> {
     await this.checkGate(vault, 'peer-recover-user', factors)
     const callerKeyring = await this.getKeyring(vault)
@@ -1681,9 +1682,9 @@ export class Noydb {
   async enrollUnlock(
     vault: string,
     state: QuickUnlockState,
-    presented?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+    factors?: FactorProofBundle,
   ): Promise<void> {
-    await this.checkGate(vault, 'rotate-unlock', presented)
+    await this.checkGate(vault, 'rotate-unlock', factors)
     this.quickUnlock.set(vault, state)
   }
 

--- a/packages/hub/src/policy/index.ts
+++ b/packages/hub/src/policy/index.ts
@@ -9,6 +9,7 @@ export type {
   FactorKind,
   FactorRequirement,
   FactorProof,
+  FactorProofBundle,
   GatePolicy,
   WarningRules,
   GateName,

--- a/packages/hub/src/policy/types.ts
+++ b/packages/hub/src/policy/types.ts
@@ -159,5 +159,25 @@ export interface FactorProof {
   readonly payload?: unknown
 }
 
+/**
+ * Bundle of factor proofs + session-context flags passed to a gated
+ * Noydb method. Used as the optional last parameter of every method
+ * that runs through `checkGate`: `db.grant`, `db.revoke`, `db.updateUser`,
+ * `db.enrollAuthenticator`, `db.removeAuthenticator`, `db.updateAuthenticator`,
+ * `db.enrollWebAuthn`, `db.rotatePassphrase`, `db.recoverPassphrase`,
+ * `db.recoverUser`, `db.enrollUnlock`, `db.describeUserAuth`,
+ * `db.describeAllUsersAuth`.
+ *
+ * Pre-#89 this type was inlined at every call site as
+ * `{ factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean }`
+ * and parameter names alternated between `factors` and `presented`.
+ * Now exported so consumers can name their helpers and so the param
+ * name converges to `factors` everywhere.
+ */
+export interface FactorProofBundle {
+  readonly factors?: ReadonlyArray<FactorProof>
+  readonly sharedDevice?: boolean
+}
+
 /** Active session tier — what the engine compares against `gate.minTier`. */
 export type ActiveTier = 1 | 2 | 3


### PR DESCRIPTION
## Summary

The \"factor proofs + sharedDevice\" parameter was inlined at 12 sites as
\`{ factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean }\`, with the
**parameter name** alternating between \`factors\` and \`presented\` (7 vs 5).
Same shape, different name — pure inconsistency for consumers reading
sibling methods.

This PR:

- Introduces \`FactorProofBundle\` in \`policy/types.ts\` with JSDoc enumerating every Noydb method that uses it.
- Re-exports through \`policy/index.ts\` and the root \`index.ts\` so consumers can name their helpers.
- Replaces all 12 inline shapes with \`FactorProofBundle\`.
- Renames the 5 \`presented\` parameters to \`factors\`. Internal \`checkGate\` body and call sites updated.

\`factors\` was the existing majority (7 of 12) and matches the field name on \`GatePolicy.factors\`, so consolidating there is the lower-churn choice.

## Closes #89

## Disruptive

Parameter NAME at TS call sites is positional — renaming is non-breaking. The type alias is a non-breaking add. Consumers writing \`db.enrollAuthenticator(vault, opts, { factors: [...] })\` work identically before and after.

## Test plan

- [x] \`pnpm turbo typecheck --filter=@noy-db/hub\` clean.
- [x] All gate-using tests (\`update-user\`, \`update-authenticator\`) pass — 23/23.
- [x] No runtime change.