### PR TITLE
feat(hub): populate subpath barrels — team functions + per-domain error re-exports (#90)

### DIFF
--- a/packages/hub/src/bundle/index.ts
+++ b/packages/hub/src/bundle/index.ts
@@ -39,3 +39,13 @@ export type {
 } from './format.js'
 
 export { generateULID, isULID } from './ulid.js'
+
+// ─── Bundle / backup errors ─────────────────────────────
+// Re-exported from the central errors module so subpath consumers can
+// `instanceof BundleIntegrityError` without falling back to the root barrel.
+export {
+  BundleIntegrityError,
+  BundleVersionConflictError,
+  BackupLedgerError,
+  BackupCorruptedError,
+} from '../errors.js'

--- a/packages/hub/src/i18n/index.ts
+++ b/packages/hub/src/i18n/index.ts
@@ -17,3 +17,16 @@ export * from './dictionary.js'
 // ─── Strategy seam ─────────────────────────────────────
 export { withI18n } from './active.js'
 export type { I18nStrategy } from './strategy.js'
+
+// ─── i18n errors ───────────────────────────────────────
+// Re-exported from the central errors module so subpath consumers can
+// `instanceof MissingTranslationError` without falling back to the
+// root barrel. Tree-shakers drop the names a consumer doesn't reference.
+export {
+  ReservedCollectionNameError,
+  DictKeyMissingError,
+  DictKeyInUseError,
+  MissingTranslationError,
+  LocaleNotSpecifiedError,
+  TranslatorNotConfiguredError,
+} from '../errors.js'

--- a/packages/hub/src/query/index.ts
+++ b/packages/hub/src/query/index.ts
@@ -49,3 +49,14 @@ export type { ScanPageProvider } from './scan-builder.js'
 // Re-export note: QueryPlan, Clause, FilterClause, GroupClause are intentionally
 // non-parametric — their `T` was removed for variance reasons. The Query<T> type
 // at the public API surface still flows the record type through generic methods.
+
+// ─── Query / aggregate errors ────────────────────────
+// Re-exported from the central errors module so subpath consumers can
+// `instanceof JoinTooLargeError` without falling back to the root barrel.
+export {
+  GroupCardinalityError,
+  IndexRequiredError,
+  IndexWriteFailureError,
+  JoinTooLargeError,
+  DanglingReferenceError,
+} from '../errors.js'

--- a/packages/hub/src/session/index.ts
+++ b/packages/hub/src/session/index.ts
@@ -47,3 +47,13 @@ export type { DevUnlockOptions } from './dev-unlock.js'
 // ─── Strategy seam ─────────────────────────────────────
 export { withSession } from './active.js'
 export type { SessionStrategy } from './strategy.js'
+
+// ─── Session errors ────────────────────────────────────
+// Re-exported from the central errors module so subpath consumers can
+// `instanceof SessionExpiredError` without falling back to the root
+// barrel. Tree-shakers drop the names a consumer doesn't reference.
+export {
+  SessionExpiredError,
+  SessionNotFoundError,
+  SessionPolicyError,
+} from '../errors.js'

--- a/packages/hub/src/store/index.ts
+++ b/packages/hub/src/store/index.ts
@@ -62,6 +62,11 @@ export type {
   SyncSchedulerStatus,
 } from './sync-policy.js'
 
+// ─── Store errors ────────────────────────────────────────────
+// Re-exported from the central errors module so subpath consumers can
+// `instanceof StoreCapabilityError` without falling back to the root barrel.
+export { StoreCapabilityError } from '../errors.js'
+
 // ─── Blob primitives relocated to packages/hub/src/blobs/ ──────────
 //
 // refactor: blob-set, mime-magic, attachments, compaction, and

--- a/packages/hub/src/team/index.ts
+++ b/packages/hub/src/team/index.ts
@@ -14,6 +14,81 @@
 
 // ─── Keyring / multi-user ───────────────────────────────────
 export type { UnlockedKeyring } from './keyring.js'
+export {
+  loadKeyring,
+  createOwnerKeyring,
+  grant,
+  revoke,
+  changeSecret,
+  listUsers,
+  listUsersWithEnvelopes,
+  ensureCollectionDEK,
+  persistKeyring,
+  updateKeyringIdentity,
+  buildRecipientKeyringFile,
+} from './keyring.js'
+export type { BundleRecipient } from './keyring.js'
+
+// ─── Tier-2 authenticator slots (#11) ───────────────────
+export {
+  enrollAuthenticator,
+  removeAuthenticator,
+  updateAuthenticator,
+  findAuthenticator,
+} from './authenticators.js'
+export type {
+  EnrollAuthenticatorOptions,
+  EnrollAuthenticatorWrappingKEKOptions,
+  EnrollAuthenticatorWrappingDEKsOptions,
+  UpdateAuthenticatorOptions,
+} from './authenticators.js'
+
+// ─── Tier-1 change flows (#10, #29, #36) ────────────────
+export {
+  rotatePassphrase,
+  recoverPassphrase,
+} from './rotate-recover.js'
+export type {
+  RotatePassphraseInput,
+  RecoverPassphraseInput,
+  RecoverPassphraseResult,
+  RecoveryProof,
+  SlotRewrapContext,
+  SlotRewrapCeremony,
+} from './rotate-recover.js'
+
+// ─── Atomic peer-recovery (#33, #34) ────────────────────
+export { recoverUser } from './peer-recover.js'
+export type { RecoverUserOptions } from './peer-recover.js'
+
+// ─── Paper recovery primitives (#28, #39) ───────────────
+export {
+  mintPaperRecoveryEntry,
+  unwrapDeksFromPaperEntry,
+  loadPaperRecoveryEntries,
+  savePaperRecoveryEntries,
+  burnPaperRecoveryEntry,
+} from './recovery.js'
+export type { PaperRecoveryEntry } from './recovery.js'
+
+// ─── Shared wrap-DEKs primitive (#26 Path C, #44) ───────
+export {
+  mintWrappedDeksBlob,
+  unwrapDeksFromBlob,
+} from './wrapped-deks.js'
+export type { WrappedDeksBlob } from './wrapped-deks.js'
+
+// ─── Magic-link grant primitives (consumed by @noy-db/on-magic-link) ─
+export {
+  writeMagicLinkGrant,
+  readMagicLinkGrantRecord,
+  listMagicLinkGrants,
+  unwrapMagicLinkGrant,
+  revokeMagicLinkGrant,
+  deriveMagicLinkContentKey,
+  magicLinkGrantRecordId,
+  isMagicLinkGrantExpired,
+} from './magic-link-grant.js'
 
 // ─── Export-capability helpers ───────────────────────────
 export {
@@ -21,7 +96,7 @@ export {
   evaluateExportCapability,
 } from './keyring.js'
 
-// ─── Import-capability helpers (issue ) ─────────────────────────
+// ─── Import-capability helpers ─────────────────────────
 export {
   hasImportCapability,
   evaluateImportCapability,


### PR DESCRIPTION
## Summary

The audit (#90) flagged that subpath imports leaked ~80% of the relevant public surface to the root barrel only. Two patterns:

1. **\`team/index.ts\`** (49 lines) exported only \`UnlockedKeyring\` + sync/credentials helpers. Functions consumers actually call — \`rotatePassphrase\`, \`recoverPassphrase\`, \`recoverUser\`, the authenticator family, \`mintPaperRecoveryEntry\`, \`listUsers\`, magic-link primitives — were reachable only through the root.
2. **Per-domain errors** (\`SessionExpiredError\`, \`JoinTooLargeError\`, \`BundleIntegrityError\`, \`StoreCapabilityError\`, the i18n trio) were defined in the central \`errors.ts\` and never re-exported by the subpath that thematically owns them. Subpath consumers couldn't \`instanceof\` without falling back to the root barrel — defeating the tree-shaking purpose.

## What changed

| Subpath | Adds |
|---|---|
| \`team\` | Keyring API (loadKeyring, createOwnerKeyring, grant, revoke, changeSecret, listUsers, listUsersWithEnvelopes, ensureCollectionDEK, persistKeyring, updateKeyringIdentity, buildRecipientKeyringFile), authenticator family (4 fns + variant option types), rotate/recover (2 fns + types + SlotRewrapContext/Ceremony), peer-recover, paper-recovery primitives, shared wrap-DEKs primitive, magic-link grant primitives |
| \`i18n\` | \`ReservedCollectionNameError\`, \`DictKeyMissingError\`, \`DictKeyInUseError\`, \`MissingTranslationError\`, \`LocaleNotSpecifiedError\`, \`TranslatorNotConfiguredError\` |
| \`session\` | \`SessionExpiredError\`, \`SessionNotFoundError\`, \`SessionPolicyError\` |
| \`query\` | \`GroupCardinalityError\`, \`IndexRequiredError\`, \`IndexWriteFailureError\`, \`JoinTooLargeError\`, \`DanglingReferenceError\` |
| \`bundle\` | \`BundleIntegrityError\`, \`BundleVersionConflictError\`, \`BackupLedgerError\`, \`BackupCorruptedError\` |
| \`store\` | \`StoreCapabilityError\` |

Tree-shakers drop unreferenced names — these are purely additive surface for consumers that opt into a subpath import for bundle savings.

## Closes #90

## Test plan

- [x] \`pnpm turbo typecheck --filter=@noy-db/hub\` clean.
- [x] All 44 team-area tests (\`keyring\`, \`access-control\`, \`rotate-recover\`) pass.
- [x] No runtime change.

## Disruptive

Non-breaking adds.