### PR TITLE
chore: drop 'daily' qualifier from on-password naming + docs

### DIFF
--- a/docs/subsystems/auth-landscape.md
+++ b/docs/subsystems/auth-landscape.md
@@ -42,7 +42,7 @@ Conflating these is the single most common source of misdesign in this space. A 
 | Method | Online? | Personal | Shared | Factor | noy-db match |
 |---|:--:|:--:|:--:|:--:|---|
 | Master passphrase (Diceware) | ❌ | ✅ | ⚠️ shoulder-surf | K | **tier-1, internal to hub** (no `on-*`) |
-| Daily password | ❌ | ✅ | ⚠️ | K | `on-password` |
+| Password (tier-2) | ❌ | ✅ | ⚠️ | K | `on-password` |
 | Numeric PIN (4–6 digits) | ❌ | ✅ | ❌ low entropy | K | `on-pin` (**tier 3 only**) |
 | Pattern lock (Android-style) | ❌ | ⚠️ | ❌ | K weak | ❌ deliberately omitted |
 | Security questions | varies | ⚠️ | ❌ | K weak | ❌ deliberately omitted (social-engineerable, low entropy) |

--- a/docs/subsystems/session-tiers.md
+++ b/docs/subsystems/session-tiers.md
@@ -14,7 +14,7 @@ noy-db's authentication is structured as a **three-tier privilege ladder**. Each
 The model exists to satisfy three competing constraints at once:
 
 1. **Zero-knowledge.** The admin must never know the user's passphrase. The user controls the root secret.
-2. **Ergonomic daily use.** Users do not type the master passphrase every time they open the vault. Daily login goes through tier 2; quick resume after idle goes through tier 3.
+2. **Ergonomic frequent use.** Users do not type the master passphrase every time they open the vault. Routine login goes through tier 2; quick resume after idle goes through tier 3.
 3. **Robust failure modes.** Lost device, lost passkey, forgotten passphrase, coerced user — each has a recovery path that does not collapse the security model.
 
 The `@noy-db/on-*` family already provides the cryptographic primitives. This document specifies how they compose into a coherent session lifecycle and how a developer configures it.
@@ -24,7 +24,7 @@ The `@noy-db/on-*` family already provides the cryptographic primitives. This do
 | Tier | Name | Role | Lifetime | Storage of the factor |
 |---|---|---|---|---|
 | **1** | **Passphrase** (root) | Master key — derives the KEK via PBKDF2. **Factory-fixed in `@noy-db/hub` core**, no `on-passphrase` package. | Years; touched only at enrollment, recovery, and tier-1-gated actions. | User's head (default) or `SealingKeyProvider` (managed mode). |
-| **2** | **Authenticate** | Daily login — replaces passphrase entry. **Multi-slot** (LUKS pattern): any one enrolled method unlocks. | Days/weeks (configurable). On expiry → re-authenticate. | `on-webauthn` / `on-oidc` / `on-password` slots in the keyring file. |
+| **2** | **Authenticate** | Routine login — replaces passphrase entry. **Multi-slot** (LUKS pattern): any one enrolled method unlocks. | Days/weeks (configurable). On expiry → re-authenticate. | `on-webauthn` / `on-oidc` / `on-password` slots in the keyring file. |
 | **3** | **Unlock** | Quick-resume after idle. Idle-timeout configurable per app. | Minutes (e.g. 15 min). On expiry → fall back to tier 2. | `on-pin` (the canonical tier-3 primitive). |
 
 A privileged auxiliary layer sits alongside the ladder:
@@ -117,7 +117,7 @@ interface KeyringFile {
 }
 
 interface KeyringAuthenticator {
-  id: string                                // 'webauthn-yubikey-blue', 'oidc-google', 'password-daily'
+  id: string                                // 'webauthn-yubikey-blue', 'oidc-google', 'password'
   method: 'webauthn' | 'oidc' | 'password'
   enrolled_at: string                        // ISO 8601
   enrolled_via_tier: 1 | 2                   // tier-1 enrolls a fresh slot; tier-2 may add a sibling per policy
@@ -132,9 +132,9 @@ interface KeyringAuthenticator {
 |---|---|---|---|
 | `webauthn` | [`@noy-db/on-webauthn`](../packages/on-webauthn) | device (platform passkey) or possession (roaming key) | PRF extension preferred. Distinguish platform vs roaming via `requireSingleDevice` / `BE` flag. |
 | `oidc` | [`@noy-db/on-oidc`](../packages/on-oidc) | possession (provider session) + knowledge (split-key passphrase half) | Half the KEK lives on the device, half is fetched from the OIDC provider's key connector on successful federated login. |
-| `password` | `@noy-db/on-password` (TBD — design-only) | knowledge (separate from tier-1 phrase) | Tier-2 daily password — distinct secret from the tier-1 phrase. PBKDF2-derived wrapping key in its own slot. Pair with `on-email-otp` or `on-totp` for the SaaS UX. |
+| `password` | `@noy-db/on-password` (TBD — design-only) | knowledge (separate from tier-1 phrase) | Tier-2 password — distinct secret from the tier-1 phrase. PBKDF2-derived wrapping key in its own slot. Pair with `on-email-otp` or `on-totp` for the SaaS UX. |
 
-`on-password` is interpreted as **tier-2 daily password as separate secret** (locked 2026-05-04). It is not a rebrand of the tier-1 phrase. Users have two distinct credentials: a rarely-typed master phrase (tier 1) and a daily password (tier 2). Failure-mode mitigation: enforce different minimum strength rules (tier 1 = phrase format; tier 2 = ≥12 chars or a developer-defined regex).
+`on-password` is interpreted as **tier-2 password as a separate secret** (locked 2026-05-04). It is not a rebrand of the tier-1 phrase. Users have two distinct credentials: a rarely-typed master phrase (tier 1) and a routinely-typed password (tier 2). Failure-mode mitigation: enforce different minimum strength rules (tier 1 = phrase format; tier 2 = ≥12 chars or a developer-defined regex).
 
 ### API
 
@@ -445,7 +445,7 @@ Tracked under milestone [`v0.1.0-pre.5`](https://github.com/vLannaAi/noy-db/mile
 | `packages/hub/src/policy/` module + gate engine + `checkGate()` | ✅ shipped | `0.1.0-pre.5` ([#9](https://github.com/vLannaAi/noy-db/issues/9)) |
 | `rotatePassphrase` / `recoverPassphrase` APIs (paper profile end-to-end; other 3 throw `RecoveryProfileNotImplementedError`) | ✅ shipped (paper) / 🟡 partial | `0.1.0-pre.5` ([#10](https://github.com/vLannaAi/noy-db/issues/10)) |
 | `enrollAuthenticator` / `removeAuthenticator` / `unlockViaAuthenticator` / `enrollUnlock` / `unlockViaPin` APIs | ✅ shipped | `0.1.0-pre.5` ([#11](https://github.com/vLannaAi/noy-db/issues/11)) |
-| `@noy-db/on-password` package (tier-2 daily password) | ✅ shipped | `0.1.0-pre.5` ([#12](https://github.com/vLannaAi/noy-db/issues/12)) |
+| `@noy-db/on-password` package (tier-2 password) | ✅ shipped | `0.1.0-pre.5` ([#12](https://github.com/vLannaAi/noy-db/issues/12)) |
 | `describeAuthConfig` / `diagramAuthConfig` + per-user views (gated by `view-user-auth`) | ✅ shipped | `0.1.0-pre.5` ([#13](https://github.com/vLannaAi/noy-db/issues/13)) |
 | Managed-passphrase mode + `SealingKeyProvider` | ⏸ backlog (post-1.0) | [#14](https://github.com/vLannaAi/noy-db/issues/14) |
 | Per-keyring policy override merge engine (Option C runtime) | ⏸ backlog (deferred) | [#15](https://github.com/vLannaAi/noy-db/issues/15) |

--- a/packages/hub/__tests__/enroll-webauthn.test.ts
+++ b/packages/hub/__tests__/enroll-webauthn.test.ts
@@ -151,7 +151,7 @@ describe('db.listWebAuthnSlots() (#16)', () => {
 
     // Mix in a password slot via the existing enrollAuthenticator path.
     await db.enrollAuthenticator('demo', {
-      id: 'password-daily',
+      id: 'password',
       method: 'password',
       wrapped_kek: FAKE_WRAPPED_PAYLOAD,
       meta: { salt: 'fake-salt-base64' },

--- a/packages/hub/__tests__/pr1b-authenticator-shapes.test.ts
+++ b/packages/hub/__tests__/pr1b-authenticator-shapes.test.ts
@@ -79,7 +79,7 @@ describe('KeyringAuthenticator wrap-KEK / wrap-DEKs (#26 Path C)', () => {
     await persistKeyring(store, 'acme', keyring)
 
     const next = await enrollAuthenticator(store, 'acme', keyring, {
-      id: 'password-daily',
+      id: 'password',
       method: 'password',
       wrapKind: 'deks',
       wrapped_deks: 'Y2lwaGVydGV4dC1iYXNlNjQ=',
@@ -114,7 +114,7 @@ describe('KeyringAuthenticator wrap-KEK / wrap-DEKs (#26 Path C)', () => {
       wrapped_kek: 'd2VicGF5bG9hZA==',
     })
     const afterPassword = await enrollAuthenticator(store, 'acme', afterWebAuthn, {
-      id: 'password-daily',
+      id: 'password',
       method: 'password',
       wrapKind: 'deks',
       wrapped_deks: 'cHdkLXdyYXBwZWQ=',

--- a/packages/hub/__tests__/pr5-rotate-preserve-slots.test.ts
+++ b/packages/hub/__tests__/pr5-rotate-preserve-slots.test.ts
@@ -102,7 +102,7 @@ describe('rotatePassphrase slot preservation (#29)', () => {
   it('preserves a wrap-DEKs slot via ceremony', async () => {
     const store = await setupVaultWithSlots([
       {
-        id: 'password-daily',
+        id: 'password',
         method: 'password',
         enrolled_at: '2026-01-01T00:00:00Z',
         enrolled_via_tier: 1,
@@ -131,7 +131,7 @@ describe('rotatePassphrase slot preservation (#29)', () => {
     await rotatePassphrase(store, 'acme', 'alice', {
       oldPassphrase: OLD_PHRASE,
       newPassphrase: NEW_PHRASE,
-      slotCeremonies: { 'password-daily': passwordCeremony },
+      slotCeremonies: { 'password': passwordCeremony },
     })
 
     expect(ceremonyCallCount).toBe(1)
@@ -140,7 +140,7 @@ describe('rotatePassphrase slot preservation (#29)', () => {
     const reloaded = await loadKeyring(store, 'acme', 'alice', NEW_PHRASE)
     expect(reloaded.authenticators).toHaveLength(1)
     const slot = reloaded.authenticators[0]!
-    expect(slot.id).toBe('password-daily')
+    expect(slot.id).toBe('password')
     expect(slot.method).toBe('password')
     if (slot.wrapKind === 'deks') {
       expect(slot.wrapped_deks).toBe('NEWWRAPPEDDEKSBASE64')
@@ -204,7 +204,7 @@ describe('rotatePassphrase slot preservation (#29)', () => {
         meta: { credentialId: 'cred-yubikey' },
       },
       {
-        id: 'password-daily',
+        id: 'password',
         method: 'password',
         enrolled_at: '2026-01-02T00:00:00Z',
         enrolled_via_tier: 1,
@@ -214,7 +214,7 @@ describe('rotatePassphrase slot preservation (#29)', () => {
         meta: { salt: 'SALT', minLength: 12 },
       },
       {
-        id: 'pin-daily',
+        id: 'pin-resume',
         method: 'password', // tier-3 PIN slots also use the 'password' method
         enrolled_at: '2026-01-03T00:00:00Z',
         enrolled_via_tier: 3,

--- a/packages/hub/__tests__/update-authenticator.test.ts
+++ b/packages/hub/__tests__/update-authenticator.test.ts
@@ -94,7 +94,7 @@ describe('updateAuthenticator (team layer, #55)', () => {
     await persistKeyring(store, 'acme', keyring)
 
     await enrollAuthenticator(store, 'acme', keyring, {
-      id: 'password-daily',
+      id: 'password',
       method: 'password',
       wrapKind: 'deks',
       wrapped_deks: 'YmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmJiYmI=',
@@ -103,8 +103,8 @@ describe('updateAuthenticator (team layer, #55)', () => {
     })
     // Reload to pick up the persisted slot in a fresh keyring snapshot.
     const fresh = await loadKeyring(store, 'acme', 'alice', PHRASE)
-    await updateAuthenticator(store, 'acme', fresh, 'password-daily', {
-      meta: { nickname: 'Daily password' },
+    await updateAuthenticator(store, 'acme', fresh, 'password', {
+      meta: { nickname: 'My password' },
     })
 
     const reloaded = await loadKeyring(store, 'acme', 'alice', PHRASE)
@@ -116,7 +116,7 @@ describe('updateAuthenticator (team layer, #55)', () => {
     }
     expect(slot.meta.salt).toBe('cmFuZG9tc2FsdA==')
     expect(slot.meta.minLength).toBe(12)
-    expect(slot.meta.nickname).toBe('Daily password')
+    expect(slot.meta.nickname).toBe('My password')
   }, 60_000)
 
   it('null in a meta key deletes that key (#55 ↔ #57 semantics)', async () => {

--- a/packages/hub/src/auth-introspection/index.ts
+++ b/packages/hub/src/auth-introspection/index.ts
@@ -37,7 +37,7 @@ export async function describeAuthConfig(
   lines.push(`  Phrase format: ${policy.passphrase?.minWords ?? 6}+ words, lowercase letters, ≥${policy.passphrase?.minWordLength ?? 3} chars/word`)
   lines.push('  Strength validator: enforced (override available for tests only)')
   lines.push('')
-  lines.push('Tier 2 — Authenticate (daily login)')
+  lines.push('Tier 2 — Authenticate (routine login)')
   lines.push('  Allowed methods: WebAuthn (passkey), OIDC, Password')
   lines.push('  Slots per user: unlimited')
   lines.push('')

--- a/packages/hub/src/policy/types.ts
+++ b/packages/hub/src/policy/types.ts
@@ -24,7 +24,7 @@ import type { PassphrasePolicy } from '../validation.js'
  * | `shamir` | k-of-n threshold share (`@noy-db/on-shamir`) | yes |
  * | `webauthn-roaming` | hardware key (YubiKey, SoloKey, Titan) | yes (key portable) |
  * | `webauthn-platform` | platform passkey (Touch ID, Face ID, Hello) | no (device-bound) |
- * | `password` | tier-2 daily password (`@noy-db/on-password`) | no |
+ * | `password` | tier-2 password (`@noy-db/on-password`) | no |
  * | `pin` | tier-3 quick-resume PIN (`@noy-db/on-pin`) | no |
  *
  * Off-device kinds (TOTP, email-OTP, recovery, shamir, roaming WebAuthn)

--- a/packages/hub/src/team/rotate-recover.ts
+++ b/packages/hub/src/team/rotate-recover.ts
@@ -45,8 +45,8 @@ import { ValidationError } from '../errors.js'
 /**
  * Context handed to a {@link SlotRewrapCeremony} when `rotatePassphrase`
  * preserves a tier-2 slot. The ceremony's job is to re-derive its
- * method-specific wrapping material (PRF assertion, PBKDF2 of a
- * daily-password, etc.) and wrap the freshly rewrapped DEK set under
+ * method-specific wrapping material (PRF assertion, PBKDF2 of the
+ * password, etc.) and wrap the freshly rewrapped DEK set under
  * the new wrapping key.
  *
  * Two surfaces are exposed:

--- a/packages/hub/src/team/wrapped-deks.ts
+++ b/packages/hub/src/team/wrapped-deks.ts
@@ -6,7 +6,7 @@
  *   - **tier-0** — paper recovery entries (`_meta/recovery-paper`),
  *     credential = the printed code.
  *   - **tier-2** — password authenticator slots (`KeyringFile.authenticators`,
- *     `wrapKind: 'deks'`), credential = the daily password.
+ *     `wrapKind: 'deks'`), credential = the user's password.
  *
  * **Not** used by `@noy-db/on-pin` — tier-3 wraps the DEK set under
  * the same conceptual pattern but at **100,000 PBKDF2 iterations**
@@ -73,8 +73,8 @@ export interface WrappedDeksBlob {
  * PBKDF2-SHA256(credential, salt, 600K), serializes the DEK set as
  * `{ deks: { coll: rawBase64 } }`, and AES-GCM-encrypts.
  *
- * The `credential` is the user-typed string (recovery code, daily
- * password, PIN). Caller normalization rules apply (e.g. paper
+ * The `credential` is the user-typed string (recovery code, password,
+ * PIN). Caller normalization rules apply (e.g. paper
  * recovery uppercase-strips the code before reaching this function).
  *
  * @param deks - DEK set to wrap. Each DEK must be exportable via

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -505,7 +505,7 @@ export type RecoveryEnrollment =
  * metadata only.
  */
 interface KeyringAuthenticatorBase {
-  /** Caller-chosen identifier — e.g. `'webauthn-yubikey-blue'`, `'oidc-google'`, `'password-daily'`. */
+  /** Caller-chosen identifier — e.g. `'webauthn-yubikey-blue'`, `'oidc-google'`, `'password'`. */
   readonly id: string
   /** Method family — selects which `@noy-db/on-*` package handles unlock. */
   readonly method: 'webauthn' | 'oidc' | 'password'

--- a/packages/on-password/__tests__/on-password.test.ts
+++ b/packages/on-password/__tests__/on-password.test.ts
@@ -77,16 +77,16 @@ describe('@noy-db/on-password — wrap-DEKs enroll + verify (#26 Path C)', () =>
   it('enrolls a wrap-DEKs slot whose password recovers the same DEK set', async () => {
     const keyring = await buildKeyring()
     const opts = await enrollPasswordAuthenticator(keyring, {
-      password: 'daily-password-2026',
+      password: 'strong-password-2026',
     })
     expect(opts.method).toBe('password')
-    expect(opts.id).toBe('password-daily')
+    expect(opts.id).toBe('password')
     expect(opts.wrapKind).toBe('deks')
     if (opts.wrapKind !== 'deks') throw new Error('unreachable')
     expect(typeof opts.wrapped_deks).toBe('string')
     expect(typeof opts.iv).toBe('string')
 
-    const recovered = await unwrapDeksWithPassword(slotFromOptions(opts), 'daily-password-2026')
+    const recovered = await unwrapDeksWithPassword(slotFromOptions(opts), 'strong-password-2026')
     expect(recovered.size).toBe(2)
     expect(recovered.has('invoices')).toBe(true)
     expect(recovered.has('clients')).toBe(true)
@@ -101,7 +101,7 @@ describe('@noy-db/on-password — wrap-DEKs enroll + verify (#26 Path C)', () =>
   it('rejects a wrong password with PasswordInvalidError', async () => {
     const keyring = await buildKeyring()
     const opts = await enrollPasswordAuthenticator(keyring, {
-      password: 'daily-password-2026',
+      password: 'strong-password-2026',
     })
     await expect(
       unwrapDeksWithPassword(slotFromOptions(opts), 'wrong-password-9999'),
@@ -145,7 +145,7 @@ describe('@noy-db/on-password — wrap-DEKs enroll + verify (#26 Path C)', () =>
   it('different password ≠ tier-1 phrase (independent storage)', async () => {
     const keyring = await buildKeyring()
     const opts = await enrollPasswordAuthenticator(keyring, {
-      password: 'daily-password-2026',
+      password: 'strong-password-2026',
     })
     // The tier-1 phrase used to derive the keyring is "correct horse...";
     // it must NOT unlock the password slot.
@@ -168,7 +168,7 @@ describe('@noy-db/on-password — wrap-DEKs enroll + verify (#26 Path C)', () =>
     // throws PasswordInvalidError for a different reason would silently
     // regress the "re-enrol" UX. Per Niwat's PR #42 review point 4.
     await expect(
-      unwrapDeksWithPassword(legacy, 'daily-password-2026'),
+      unwrapDeksWithPassword(legacy, 'strong-password-2026'),
     ).rejects.toMatchObject({
       name: 'PasswordInvalidError',
       message: expect.stringMatching(/wrap-DEKs|re-enrol/),
@@ -181,7 +181,7 @@ describe('@noy-db/on-password — wrap-DEKs enroll + verify (#26 Path C)', () =>
     // getKeyring callback) works without a pre-existing keyring.
     const keyring = await buildKeyring()
     const opts = await enrollPasswordAuthenticator(keyring, {
-      password: 'daily-password-2026',
+      password: 'strong-password-2026',
     })
 
     // Build a real store with a written keyring file to feed the verifier.
@@ -207,7 +207,7 @@ describe('@noy-db/on-password — wrap-DEKs enroll + verify (#26 Path C)', () =>
 
     const unlocked = await verifyPasswordSlot(
       slotFromOptions(opts),
-      'daily-password-2026',
+      'strong-password-2026',
       { store, vault: 'acme', userId: 'alice' },
     )
     expect(unlocked.userId).toBe('alice')
@@ -221,13 +221,13 @@ describe('@noy-db/on-password — wrap-DEKs enroll + verify (#26 Path C)', () =>
   it('verifyPasswordSlot throws when the keyring file is missing', async () => {
     const keyring = await buildKeyring()
     const opts = await enrollPasswordAuthenticator(keyring, {
-      password: 'daily-password-2026',
+      password: 'strong-password-2026',
     })
     const store = inlineMemory()
     await expect(
       verifyPasswordSlot(
         slotFromOptions(opts),
-        'daily-password-2026',
+        'strong-password-2026',
         { store, vault: 'acme', userId: 'ghost' },
       ),
     ).rejects.toBeInstanceOf(PasswordInvalidError)

--- a/packages/on-password/package.json
+++ b/packages/on-password/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@noy-db/on-password",
   "version": "0.1.0-pre.9",
-  "description": "Tier-2 daily-password authenticator slot for noy-db. PBKDF2-SHA256 600K wraps the KEK in its own keyring slot, distinct from the rarely-typed tier-1 phrase. Pair with @noy-db/on-email-otp or @noy-db/on-totp for the SaaS UX.",
+  "description": "Tier-2 password authenticator slot for noy-db. PBKDF2-SHA256 600K wraps the DEK set in its own keyring slot, distinct from the rarely-typed tier-1 phrase. Pair with @noy-db/on-email-otp or @noy-db/on-totp for the SaaS UX.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",
   "homepage": "https://github.com/vLannaAi/noy-db/tree/main/packages/on-password#readme",

--- a/packages/on-password/src/index.ts
+++ b/packages/on-password/src/index.ts
@@ -1,10 +1,10 @@
 /**
- * **@noy-db/on-password** — tier-2 daily-password authenticator slot.
+ * **@noy-db/on-password** — tier-2 password authenticator slot.
  *
  * The user's tier-1 *phrase* is the rarely-typed master that derives
- * the KEK. This package adds a SEPARATE secret — a daily-typed
- * password — as a tier-2 slot in the multi-slot keyring. The two
- * credentials have:
+ * the KEK. This package adds a SEPARATE secret — a password the user
+ * types at each unlock — as a tier-2 slot in the multi-slot keyring.
+ * The two credentials have:
  *
  * - **Different lifecycles** — the phrase rotates yearly; the password
  *   rotates per the developer's policy.
@@ -84,9 +84,9 @@ export class PasswordInvalidError extends Error {
 
 /** Options for {@link enrollPasswordAuthenticator}. */
 export interface EnrollPasswordOptions {
-  /** Slot id. Default: `'password-daily'`. */
+  /** Slot id. Default: `'password'`. */
   readonly id?: string
-  /** Daily password the user will type. Distinct from the tier-1 phrase. */
+  /** Password the user will type at unlock. Distinct from the tier-1 phrase. */
   readonly password: string
   /** Minimum length. Default 12. */
   readonly minLength?: number
@@ -115,7 +115,7 @@ export interface EnrollPasswordOptions {
  *
  * const keyring = await db.getKeyring('acme')
  * const slot = await enrollPasswordAuthenticator(keyring, {
- *   password: 'daily-password-2026',
+ *   password: 'strong-password-2026',
  *   minLength: 14,
  * })
  * await db.enrollAuthenticator('acme', slot, {
@@ -152,7 +152,7 @@ export async function enrollPasswordAuthenticator(
   const blob = await mintWrappedDeksBlob(keyring.deks, options.password)
 
   return {
-    id: options.id ?? 'password-daily',
+    id: options.id ?? 'password',
     method: 'password',
     wrapKind: 'deks',
     wrapped_deks: blob.wrappedDeks,
@@ -214,8 +214,8 @@ export async function unwrapDeksWithPassword(
  * ```ts
  * import { verifyPasswordSlot } from '@noy-db/on-password'
  *
- * const unlocked = await db.unlockViaAuthenticator('acme', 'password-daily',
- *   (slot) => verifyPasswordSlot(slot, 'daily-password-2026',
+ * const unlocked = await db.unlockViaAuthenticator('acme', 'password',
+ *   (slot) => verifyPasswordSlot(slot, 'strong-password-2026',
  *     { store, vault: 'acme', userId: 'alice' }),
  * )
  * ```


### PR DESCRIPTION
## Summary

The \"daily password\" framing was meant to signal *\"the password the user types day-to-day\"* (in contrast to the rarely-typed master phrase) but English readers can equally read \"daily\" as *\"rotates every 24 hours\"* or *\"expires daily\"*. Two completely different meanings — confusing enough that it's worth a sweep before pre.10.

## What changed

### Default slot id

\`'password-daily'\` → **\`'password'\`** (on-password source + 5 hub test files that asserted on the slot id).

### JSDoc + package description

- \`@noy-db/on-password\` package description: \"Tier-2 daily-password\" → \"Tier-2 password\"
- Source JSDoc: \"daily-typed password\" → \"password the user types at unlock\"
- \`KeyringAuthenticatorBase.id\` example list: \`'password-daily'\` → \`'password'\`
- \`policy/types.ts\` factor table: \"tier-2 daily password\" → \"tier-2 password\"
- \`team/wrapped-deks.ts\` credential list: \"recovery code, daily password, PIN\" → \"recovery code, password, PIN\"
- \`team/rotate-recover.ts\`: \"PBKDF2 of a daily-password\" → \"PBKDF2 of the password\"

### Test fixture password values

\`'daily-password-2026'\` → \`'strong-password-2026'\` (these are arbitrary password strings used in test fixtures, not identifiers).

### Test fixture nickname

One test asserted \`meta.nickname === 'Daily password'\` — bumped to \`'My password'\` for the same reason.

### Docs (\`docs/subsystems/\`)

- \`session-tiers.md\`: \"Ergonomic daily use\" → \"Ergonomic frequent use\"; \"Daily login\" → \"Routine login\" (in two places); \"Tier-2 daily password\" → \"Tier-2 password\"; \"a daily password (tier 2)\" → \"a routinely-typed password (tier 2)\"
- \`auth-landscape.md\` factor table row: \"Daily password\" → \"Password (tier-2)\"

### auth-introspection diagnostic output

\`Tier 2 — Authenticate (daily login)\` → \`(routine login)\` (no test pins this string literally).

## Risk

**Low.** Pre-1.0; no in-the-wild keyrings have \`'password-daily'\` enrolled. A consumer who hand-picked that id can keep their wire format by passing \`enrollPasswordAuthenticator({ id: 'password-daily', ... })\` explicitly — the slot id is caller-overridable; only the **default** changed.

The doc and JSDoc pass is purely cosmetic.

## Test plan

- [x] \`pnpm turbo typecheck --filter=@noy-db/hub --filter=@noy-db/on-password\` clean (3 packages typechecked).
- [x] All 40 affected tests pass: \`on-password/__tests__/\`, plus 5 hub test files that referenced the slot id (\`pr1b-authenticator-shapes\`, \`pr5-rotate-preserve-slots\`, \`update-authenticator\`, \`enroll-webauthn\`, \`auth-introspection\`).
- [x] No remaining \"daily\" mentions in tracked source / docs (\`grep -rn -i daily packages/ docs/ SPEC.md ROADMAP.md\` returns empty).