### PR TITLE
fix(hub): reject buildRecipientKeyringFile when caller's kek is null (#112)

### DIFF
--- a/packages/hub/__tests__/keyring.test.ts
+++ b/packages/hub/__tests__/keyring.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
-import { ConflictError } from '../src/errors.js'
+import { ConflictError, ValidationError } from '../src/errors.js'
 import {
   createOwnerKeyring,
   loadKeyring,
@@ -10,6 +10,7 @@ import {
   listUsers,
   ensureCollectionDEK,
   persistKeyring,
+  buildRecipientKeyringFile,
 } from '../src/team/keyring.js'
 import { encrypt, decrypt } from '../src/crypto.js'
 
@@ -328,6 +329,48 @@ describe('keyring', () => {
       expect(users.map(u => u.userId).sort()).toEqual(['op-01', 'owner-01', 'viewer-01'])
       expect(users.find(u => u.userId === 'op-01')?.role).toBe('operator')
       expect(users.find(u => u.userId === 'viewer-01')?.role).toBe('viewer')
+    })
+  })
+
+  describe('buildRecipientKeyringFile (issue #112)', () => {
+    it('rejects when caller kek is null (tier-2 wrap-DEKs / tier-3 PIN-resume sessions cannot mint bundle recipients)', async () => {
+      const owner = await createOwnerKeyring(adapter, COMP, 'owner-01', 'ownerpass')
+      const getDEK = await ensureCollectionDEK(adapter, COMP, owner)
+      await getDEK('invoices')
+
+      // Same shape as the grant() tier-2 test: simulate an
+      // @noy-db/on-password unlock or tier-3 PIN-resume by spreading
+      // the owner keyring with kek replaced by null. The DEKs are still
+      // in memory; only the KEK is missing — exactly the state #81's
+      // grant guard rejected. buildRecipientKeyringFile shipped without
+      // the same guard until #112.
+      const tier2Caller = { ...owner, kek: null }
+
+      await expect(
+        buildRecipientKeyringFile(tier2Caller, {
+          id: 'recipient-01',
+          displayName: 'Recipient',
+          role: 'admin',
+          passphrase: 'a strong recipient passphrase here',
+        }),
+      ).rejects.toThrow(ValidationError)
+    })
+
+    it('still works for legitimate tier-1 callers', async () => {
+      const owner = await createOwnerKeyring(adapter, COMP, 'owner-01', 'ownerpass')
+      const getDEK = await ensureCollectionDEK(adapter, COMP, owner)
+      await getDEK('invoices')
+
+      const file = await buildRecipientKeyringFile(owner, {
+        id: 'recipient-01',
+        displayName: 'Recipient',
+        role: 'viewer',
+        passphrase: 'a strong recipient passphrase here',
+      })
+
+      expect(file.user_id).toBe('recipient-01')
+      expect(file.role).toBe('viewer')
+      expect(Object.keys(file.deks).length).toBeGreaterThan(0)
     })
   })
 })

--- a/packages/hub/src/team/keyring.ts
+++ b/packages/hub/src/team/keyring.ts
@@ -848,6 +848,14 @@ export async function buildRecipientKeyringFile(
   callerKeyring: UnlockedKeyring,
   recipient: BundleRecipient,
 ): Promise<KeyringFile> {
+  if (!callerKeyring.kek) {
+    throw new ValidationError(
+      'buildRecipientKeyringFile: caller keyring has no KEK — tier-2 wrap-DEKs ' +
+        'and tier-3 PIN-resume sessions cannot create bundle recipients. ' +
+        'Re-authenticate at tier 1 (passphrase) before building a bundle.',
+    )
+  }
+
   const role: Role = recipient.role ?? 'viewer'
   const permissions = resolvePermissions(role, recipient.permissions)
 


### PR DESCRIPTION
## Summary

Same fix shape as #81 / PR #94 (grant() guard), one function over.

\`buildRecipientKeyringFile\` (used by \`writeNoydbBundle({ recipients: [...] })\`) iterates \`callerKeyring.deks\` and wraps under the recipient's \`newKek\`. Pre-fix, it never read \`callerKeyring.kek\`, so a tier-2 wrap-DEKs session (\`kek: null\`) or tier-3 PIN-resume session could mint encrypted bundles granting full DEK access to arbitrary recipients — exactly the contract #81 closed for \`grant()\`.

This PR adds the same kek-null guard at the head of \`buildRecipientKeyringFile\` with a parallel error message ('re-authenticate at tier 1 before building a bundle').

## Closes #112

## Test plan

- [x] Two new regression tests in \`keyring.test.ts\`:
  - **tier-2 caller (\`kek: null\`)** — asserts \`ValidationError\` (matches the #81 grant guard's test pattern).
  - **tier-1 caller** — asserts the function still succeeds and produces a valid recipient keyring file (verifies the guard isn't over-broad).
- [x] All 21 keyring tests pass (19 pre-existing + 2 new).
- [x] All bundle-recipients tests still pass (no regression on the public bundle path).
- [x] \`pnpm turbo typecheck --filter=@noy-db/hub\` clean.

## Disruptive

Non-breaking. Tier-1 sessions (the only legitimate caller of this function) are unaffected. Tier-2 / tier-3 sessions attempting to mint bundle recipients now get a clear \`ValidationError\` with re-authentication guidance — exactly the documented capability matrix from \`docs/subsystems/auth-landscape.md\`.

## Provenance

Found by independent code review of PR #94. The reviewer flagged this as HIGH (confidence 95) — same audit-pattern recognition that surfaced the original #81: *"every privileged DEK-wrapping entry point needs the same guard."*