### PR TITLE
feat(on-password): export passwordSlotRewrapCeremony for rotatePassphrase slotCeremonies (#96)

### DIFF
--- a/packages/on-password/__tests__/on-password.test.ts
+++ b/packages/on-password/__tests__/on-password.test.ts
@@ -15,10 +15,12 @@ import {
   enrollPasswordAuthenticator,
   unwrapDeksWithPassword,
   verifyPasswordSlot,
+  passwordSlotRewrapCeremony,
   PasswordTooWeakError,
   PasswordInvalidError,
 } from '../src/index.js'
-import type { UnlockedKeyring, KeyringAuthenticator, NoydbStore, EncryptedEnvelope, KeyringFile } from '@noy-db/hub'
+import type { UnlockedKeyring, KeyringAuthenticator, NoydbStore, EncryptedEnvelope, KeyringFile, SlotRewrapContext } from '@noy-db/hub'
+import { ValidationError } from '@noy-db/hub'
 
 const subtle = globalThis.crypto.subtle
 
@@ -232,6 +234,95 @@ describe('@noy-db/on-password — wrap-DEKs enroll + verify (#26 Path C)', () =>
       ),
     ).rejects.toBeInstanceOf(PasswordInvalidError)
   }, 30_000)
+})
+
+describe('passwordSlotRewrapCeremony (#96)', () => {
+  /** Build a SlotRewrapContext with newly-rotated DEKs + the slot to preserve. */
+  async function buildContext(slot: KeyringAuthenticator): Promise<SlotRewrapContext> {
+    const newDek1 = await subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt'])
+    const newDek2 = await subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt'])
+    // newKek is required by SlotRewrapContext but the password ceremony
+    // doesn't use it (wrap-DEKs unlocks don't recover a KEK).
+    const newKek = await subtle.generateKey({ name: 'AES-KW', length: 256 }, true, ['wrapKey', 'unwrapKey'])
+    return {
+      newKek,
+      newDeks: new Map([['invoices', newDek1], ['clients', newDek2]]),
+      oldSlot: slot,
+    }
+  }
+
+  it('preserves slot id, method, wrapKind across rotation; new wrapping unlocks via the same password', async () => {
+    const keyring = await buildKeyring()
+    const opts = await enrollPasswordAuthenticator(keyring, {
+      id: 'password',
+      password: 'daily-password-2026',
+      minLength: 14,
+    })
+    const slot = slotFromOptions(opts)
+
+    const ctx = await buildContext(slot)
+    const ceremony = passwordSlotRewrapCeremony('daily-password-2026')
+    const result = await ceremony(ctx)
+
+    // Anti-slot-swap invariants — same id / method / wrapKind. Hub's
+    // rotate-recover validates these structurally; this test pins them
+    // at the ceremony layer too.
+    expect(result.id).toBe('password')
+    expect(result.method).toBe('password')
+    expect(result.wrapKind).toBe('deks')
+    if (result.wrapKind !== 'deks') throw new Error('unreachable')
+
+    // Strength config carried through.
+    expect(result.meta.minLength).toBe(14)
+
+    // The new slot unwraps to the rotated DEK set, not the original.
+    const recovered = await unwrapDeksWithPassword(slotFromOptions(result), 'daily-password-2026')
+    expect(recovered.size).toBe(2)
+    expect([...recovered.keys()].sort()).toEqual(['clients', 'invoices'])
+  }, 60_000)
+
+  it('rejects oldSlot.method !== "password" with ValidationError (anti-cross-method)', async () => {
+    const wrongMethodSlot: KeyringAuthenticator = {
+      id: 'webauthn-yubi',
+      method: 'webauthn',
+      enrolled_at: new Date().toISOString(),
+      enrolled_via_tier: 1,
+      wrapped_kek: 'YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=',
+      meta: { credentialId: 'cred' },
+    }
+    const ctx = await buildContext(wrongMethodSlot)
+    const ceremony = passwordSlotRewrapCeremony('daily-password-2026')
+    await expect(ceremony(ctx)).rejects.toBeInstanceOf(ValidationError)
+  }, 30_000)
+
+  it('rejects legacy wrap-KEK password slot with ValidationError', async () => {
+    const legacyWrapKekSlot: KeyringAuthenticator = {
+      id: 'password',
+      method: 'password',
+      enrolled_at: '2025-01-01T00:00:00Z',
+      enrolled_via_tier: 1,
+      wrapped_kek: 'YWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWE=',
+      meta: { salt: 'YWFh' },
+    }
+    const ctx = await buildContext(legacyWrapKekSlot)
+    const ceremony = passwordSlotRewrapCeremony('daily-password-2026')
+    await expect(ceremony(ctx)).rejects.toBeInstanceOf(ValidationError)
+  }, 30_000)
+
+  it('preserves enrolled_via_tier from the old slot', async () => {
+    const keyring = await buildKeyring()
+    const opts = await enrollPasswordAuthenticator(keyring, {
+      password: 'daily-password-2026',
+      enrolledViaTier: 2,
+    })
+    const slot = slotFromOptions(opts)
+    expect(slot.enrolled_via_tier).toBe(2)
+
+    const ctx = await buildContext(slot)
+    const ceremony = passwordSlotRewrapCeremony('daily-password-2026')
+    const result = await ceremony(ctx)
+    expect(result.enrolled_via_tier).toBe(2)
+  }, 60_000)
 })
 
 function inlineMemory(): NoydbStore {

--- a/packages/on-password/src/index.ts
+++ b/packages/on-password/src/index.ts
@@ -38,10 +38,13 @@ import {
   base64ToBuffer,
   mintWrappedDeksBlob,
   unwrapDeksFromBlob,
+  ValidationError,
   type EnrollAuthenticatorOptions,
   type KeyringAuthenticator,
   type KeyringFile,
   type NoydbStore,
+  type SlotRewrapCeremony,
+  type SlotRewrapContext,
   type UnlockedKeyring,
 } from '@noy-db/hub'
 
@@ -285,6 +288,100 @@ export interface VerifyPasswordSlotOptions {
   readonly vault: string
   /** User id — same value passed to `createNoydb({ user })`. */
   readonly userId: string
+}
+
+/**
+ * `SlotRewrapCeremony` factory for password slots — the password parallel
+ * to `webAuthnSlotRewrapCeremony` (#56). Used by hub's
+ * `rotatePassphrase({ slotCeremonies: { [slotId]: passwordSlotRewrapCeremony(pwd) } })`
+ * to preserve a tier-2 password enrollment across a tier-1 phrase
+ * rotation without forcing the user to re-enroll the password (#96).
+ *
+ * Returns a closure capturing the password so the result matches
+ * hub's `SlotRewrapCeremony` signature `(ctx) => Promise<EnrollAuthenticatorOptions>`
+ * directly. Pass into `slotCeremonies` keyed by the existing slot id:
+ *
+ * ```ts
+ * import { passwordSlotRewrapCeremony } from '@noy-db/on-password'
+ *
+ * await db.rotatePassphrase('acme', {
+ *   oldPassphrase: oldPhrase,
+ *   newPassphrase: newPhrase,
+ *   slotCeremonies: {
+ *     'password': passwordSlotRewrapCeremony('strong-password-2026'),
+ *   },
+ * })
+ * ```
+ *
+ * The password itself is unaffected by phrase rotation — what needs to
+ * change is the **wrapped DEK set**: the encrypted blob the slot's
+ * `wrapped_deks` field holds. After rotation, the old blob still has
+ * the old DEKs (now stale because rotatePassphrase rewrapped them
+ * under a fresh KEK); the new blob must hold the freshly rewrapped
+ * `ctx.newDeks`.
+ *
+ * Single ceremony, one operation:
+ *   1. Validate `oldSlot.method === 'password'` and `oldSlot.wrapKind === 'deks'`.
+ *   2. Re-mint the wrap-DEKs blob via {@link enrollPasswordAuthenticator}
+ *      using the supplied password against `ctx.newDeks`.
+ *   3. Return `EnrollAuthenticatorOptions` preserving `oldSlot.id`,
+ *      `method: 'password'`, and the strength config (`minLength`,
+ *      `pattern`) carried in the old slot's `meta`. Hub validates
+ *      `id` + `method` + `wrapKind` to prevent slot-type swap mid-
+ *      rotation.
+ *
+ * Pre-pre.8 wrap-KEK password slots (legacy) cannot be rewrapped via
+ * this ceremony — they must be re-enrolled fresh via
+ * {@link enrollPasswordAuthenticator}. The validation throws
+ * {@link ValidationError} for those.
+ *
+ * @throws {ValidationError} when `oldSlot.method !== 'password'` or
+ *         `oldSlot.wrapKind !== 'deks'`.
+ * @throws {PasswordTooWeakError} when the supplied password fails the
+ *         strength rules carried in `oldSlot.meta` (minLength, pattern).
+ *
+ * @see #56 webAuthnSlotRewrapCeremony — the WebAuthn parallel.
+ * @see #29 — the slotCeremonies plumbing this fills in.
+ */
+export function passwordSlotRewrapCeremony(password: string): SlotRewrapCeremony {
+  return async (ctx: SlotRewrapContext): Promise<EnrollAuthenticatorOptions> => {
+    if (ctx.oldSlot.method !== 'password') {
+      throw new ValidationError(
+        `passwordSlotRewrapCeremony: oldSlot.method is "${ctx.oldSlot.method}"; expected "password". ` +
+          'This ceremony only handles password slots — pair other methods with their own helpers.',
+      )
+    }
+    if (ctx.oldSlot.wrapKind !== 'deks') {
+      throw new ValidationError(
+        'passwordSlotRewrapCeremony: oldSlot is a wrap-KEK slot; expected wrap-DEKs. ' +
+          'Password slots use the wrap-DEKs variant since #26 Path C; legacy wrap-KEK ' +
+          'password slots are not supported here — re-enrol via enrollPasswordAuthenticator.',
+      )
+    }
+
+    // Preserve the strength config the slot was originally enrolled with —
+    // a rotation should not silently downgrade minLength or drop a pattern.
+    const oldMeta = ctx.oldSlot.meta as { minLength?: unknown; pattern?: unknown }
+    const minLength = typeof oldMeta.minLength === 'number' ? oldMeta.minLength : undefined
+    const pattern = typeof oldMeta.pattern === 'string' ? new RegExp(oldMeta.pattern) : undefined
+
+    return enrollPasswordAuthenticator(
+      // enrollPasswordAuthenticator only reads `keyring.deks`, so a
+      // synthetic minimal keyring is enough. The freshly-rewrapped DEKs
+      // come from hub via `ctx.newDeks`.
+      { deks: ctx.newDeks } as UnlockedKeyring,
+      {
+        id: ctx.oldSlot.id,
+        password,
+        ...(minLength !== undefined && { minLength }),
+        ...(pattern !== undefined && { pattern }),
+        // Carry the original tier so hub's anti-slot-swap guard plus
+        // the rotate-recover preservation rule keep the slot's
+        // provenance honest.
+        enrolledViaTier: ctx.oldSlot.enrolled_via_tier,
+      },
+    )
+  }
 }
 
 // All wrap-DEKs crypto helpers (PBKDF2 derivation, base64


### PR DESCRIPTION
## Summary

Parallel to \`webAuthnSlotRewrapCeremony\` shipped from \`@noy-db/on-webauthn\` in pre.9 (#56). Closes the on-webauthn ↔ on-password symmetry: a consumer can now preserve a tier-2 password enrollment across a tier-1 phrase rotation without forcing a re-enroll.

## Shape

Higher-order function (vs WebAuthn's direct \`(ctx) => Promise<...>\`) because the password is **required input** and a closure makes the call site clean:

\`\`\`ts
import { passwordSlotRewrapCeremony } from '@noy-db/on-password'

await db.rotatePassphrase('acme', {
  oldPassphrase,
  newPassphrase,
  slotCeremonies: {
    'password': passwordSlotRewrapCeremony('strong-password-2026'),
  },
})
\`\`\`

## What it does

1. Validates \`oldSlot.method === 'password'\` and \`oldSlot.wrapKind === 'deks'\`. Rejects WebAuthn slots and legacy pre-#26 wrap-KEK password slots with \`ValidationError\`.
2. Re-mints the wrap-DEKs blob via \`enrollPasswordAuthenticator\` using the supplied password against \`ctx.newDeks\` (the freshly-rewrapped DEK set hub computed during rotation).
3. Returns \`EnrollAuthenticatorOptions\` preserving:
   - \`oldSlot.id\`
   - \`method: 'password'\`
   - The strength config (\`minLength\`, \`pattern\`) carried in the old slot's \`meta\`
   - \`enrolled_via_tier\` from the old slot

Hub validates \`id\` + \`method\` + \`wrapKind\` (after #83) to prevent slot-type swap mid-rotation.

## Strength preservation matters

A slot enrolled with \`minLength: 14\` stays at \`minLength: 14\` across rotation. Without this preservation, rotation would silently downgrade to the package default of 12 — same shape as the audit's \"silent downgrade under cover of rotation\" patterns.

## Closes #96

## Test plan

Four regression tests in \`on-password.test.ts\`:

1. **Round-trip** — same \`id\`/\`method\`/\`wrapKind\` preserved; new wrapping unlocks to the rotated DEK set (not the original).
2. **Anti-cross-method** — rejects \`oldSlot.method !== 'password'\`.
3. **Anti-legacy** — rejects pre-#26 wrap-KEK password slots.
4. **enrolled_via_tier** preserved (tier-2 enrollment stays tier-2 after rotation).

All 13 on-password tests pass (9 existing + 4 new). \`pnpm turbo typecheck --filter=@noy-db/on-password\` clean.

## Disruptive

Non-breaking add. Existing \`enrollPasswordAuthenticator\` / \`verifyPasswordSlot\` / \`unwrapDeksWithPassword\` API unchanged. New export available for consumers who use \`db.rotatePassphrase\` with password slots enrolled.