### PR TITLE
fix(hub): grant/revoke params use FactorProofBundle (hotfix for main typecheck)

### DIFF
--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -461,7 +461,7 @@ export class Noydb {
   async grant(
     vault: string,
     options: GrantOptions,
-    factors?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+    factors?: FactorProofBundle,
   ): Promise<void> {
     this.checkPolicyOperation(vault, 'grant')
     await this.checkGate(vault, 'enroll-user', factors)
@@ -481,7 +481,7 @@ export class Noydb {
   async revoke(
     vault: string,
     options: RevokeOptions,
-    factors?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },
+    factors?: FactorProofBundle,
   ): Promise<void> {
     this.checkPolicyOperation(vault, 'revoke')
     await this.checkGate(vault, 'revoke-user', factors)


### PR DESCRIPTION
## Summary

Main is currently broken on typecheck — \`grant()\` and \`revoke()\` reference \`FactorProof\` but the import was correctly removed in #108 (FactorProofBundle unification). The references re-entered when PR #98 (STRICT_POLICY gates) merged AFTER #108, using the pre-unification inline shape that the PR was authored against.

## What changed

\`\`\`ts
// Before (broken on main):
async grant(
  vault: string,
  options: GrantOptions,
  factors?: { factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean },  // <-- FactorProof undefined
)

// After:
async grant(
  vault: string,
  options: GrantOptions,
  factors?: FactorProofBundle,  // <-- the unified type from #108
)
\`\`\`

Same change for \`revoke()\`.

## Why this matters now

Caught immediately during the pre.10 release-prep cascade — main was building red after #98 + #108 landed in this order. Without this hotfix, the rebased follow-up PRs (#105, #116) can't pass CI.

## Test plan

- [x] \`pnpm turbo lint typecheck --filter=@noy-db/hub\` — clean (was failing pre-hotfix)
- No behavior change. The two types are structurally identical; \`FactorProofBundle\` is the named alias #108 introduced.