### PR TITLE
feat(hub): passphrase canary disambiguates single-DEK + all-DEKs corruption (#113)

### DIFF
--- a/packages/hub/__tests__/persistence.test.ts
+++ b/packages/hub/__tests__/persistence.test.ts
@@ -223,6 +223,83 @@ describe('persistence round-trip (simulated page reload)', () => {
     db3.close()
   })
 
+  it('issue #113: canary distinguishes single-DEK corruption from wrong passphrase', async () => {
+    // Pre-#113 (with #99 only), a keyring with exactly one corrupted DEK
+    // could not be distinguished from a wrong passphrase — both surfaced
+    // as InvalidKeyError, and onInvalidKey: 'reset' would silently
+    // destroy the user's only DEK. Post-#113, the canary proves the KEK
+    // is correct; the corrupted DEK is reported as KeyringCorruptError.
+    const adapter = persistentMemory()
+    const db1 = await createNoydb({ store: adapter, user: USER, secret: PASS })
+    const comp1 = await db1.openVault(COMP)
+    await comp1.collection<Invoice>('invoices').put('inv-1', { amount: 100, status: 'paid' })
+    db1.close()
+
+    const env = await adapter.get(COMP, '_keyring', USER)
+    const file = JSON.parse(env!._data) as { deks: Record<string, string>; canary?: string }
+    expect(file.canary).toBeDefined() // sanity: canary minted on owner-create
+    const original = file.deks['invoices']!
+    file.deks['invoices'] = Buffer.from(new Uint8Array(original.length).fill(0))
+      .toString('base64')
+      .slice(0, original.length)
+    await adapter.put(COMP, '_keyring', USER, { ...env!, _data: JSON.stringify(file) })
+
+    // Correct passphrase + onInvalidKey: 'reset': the canary proves the
+    // KEK is right, the corrupt DEK becomes KeyringCorruptError, reset
+    // does NOT fire.
+    const db2 = await createNoydb({
+      store: adapter, user: USER, secret: PASS, onInvalidKey: 'reset',
+    })
+    await expect(db2.openVault(COMP)).rejects.toBeInstanceOf(KeyringCorruptError)
+    db2.close()
+
+    // Wrong passphrase still throws InvalidKeyError — keyring on disk
+    // wasn't reset.
+    const dbWrong = await createNoydb({ store: adapter, user: USER, secret: 'wrong-pass' })
+    await expect(dbWrong.openVault(COMP)).rejects.toThrow(InvalidKeyError)
+    dbWrong.close()
+  })
+
+  it('issue #113: canary corruption with intact DEKs surfaces as KeyringCorruptError', async () => {
+    const adapter = persistentMemory()
+    const db1 = await createNoydb({ store: adapter, user: USER, secret: PASS })
+    const comp1 = await db1.openVault(COMP)
+    await comp1.collection<Invoice>('invoices').put('inv-1', { amount: 100, status: 'paid' })
+    db1.close()
+
+    const env = await adapter.get(COMP, '_keyring', USER)
+    const file = JSON.parse(env!._data) as { canary?: string }
+    expect(file.canary).toBeDefined()
+    file.canary = Buffer.from(new Uint8Array(file.canary!.length).fill(0))
+      .toString('base64')
+      .slice(0, file.canary!.length)
+    await adapter.put(COMP, '_keyring', USER, { ...env!, _data: JSON.stringify(file) })
+
+    const db2 = await createNoydb({ store: adapter, user: USER, secret: PASS })
+    await expect(db2.openVault(COMP)).rejects.toBeInstanceOf(KeyringCorruptError)
+    db2.close()
+  })
+
+  it('issue #113: legacy keyring without canary still loads via the multi-DEK heuristic', async () => {
+    const adapter = persistentMemory()
+    const db1 = await createNoydb({ store: adapter, user: USER, secret: PASS })
+    const comp1 = await db1.openVault(COMP)
+    await comp1.collection<Invoice>('invoices').put('inv-1', { amount: 100, status: 'paid' })
+    db1.close()
+
+    // Strip the canary to simulate a pre-#113 keyring.
+    const env = await adapter.get(COMP, '_keyring', USER)
+    const file = JSON.parse(env!._data) as Record<string, unknown>
+    delete file['canary']
+    await adapter.put(COMP, '_keyring', USER, { ...env!, _data: JSON.stringify(file) })
+
+    // Correct passphrase still works (no canary, all DEKs unwrap).
+    const db2 = await createNoydb({ store: adapter, user: USER, secret: PASS })
+    const comp2 = await db2.openVault(COMP)
+    expect((await comp2.collection<Invoice>('invoices').get('inv-1'))?.amount).toBe(100)
+    db2.close()
+  })
+
   it('count and list on fresh instance reflect adapter state', async () => {
     const adapter = persistentMemory()
 

--- a/packages/hub/src/team/keyring.ts
+++ b/packages/hub/src/team/keyring.ts
@@ -11,7 +11,7 @@ import {
   bufferToBase64,
   base64ToBuffer,
 } from '../crypto.js'
-import { NoAccessError, PermissionDeniedError, PrivilegeEscalationError, KeyringExpiredError, KeyringCorruptError, ValidationError } from '../errors.js'
+import { NoAccessError, PermissionDeniedError, PrivilegeEscalationError, KeyringExpiredError, KeyringCorruptError, InvalidKeyError, ValidationError } from '../errors.js'
 import { assertStrongPassphrase, type PassphrasePolicy } from '../validation.js'
 import {
   saveUserEnvelope,
@@ -140,6 +140,54 @@ export interface UnlockedKeyring {
   readonly policy?: VaultPolicyOnDisk
 }
 
+// ─── Passphrase canary (#113) ──────────────────────────────────────────
+//
+// The canary is a fixed 256-bit AES-GCM key (32 zero bytes), wrapped
+// under the keyring's KEK with AES-KW. Because AES-KW is deterministic
+// (RFC 3394 fixed IV), wrapping the same constant under the same KEK
+// always yields the same ciphertext — so every write site can mint
+// fresh on each persist without round-tripping a `canary` field
+// through UnlockedKeyring.
+//
+// On load, the canary unwraps cleanly iff the KEK is correct AND the
+// canary bytes on disk are intact. Combined with each-DEK try/catch,
+// this distinguishes wrong-passphrase (canary fails AND every DEK fails)
+// from corruption (canary succeeds OR at least one DEK succeeds) —
+// closing the all-DEKs-corrupt and single-DEK ambiguities that the
+// pre-canary heuristic from #82 / #99 left open.
+
+const CANARY_PLAINTEXT_BYTES = new Uint8Array(32)
+let canaryKeyPromise: Promise<CryptoKey> | null = null
+
+function getCanaryKey(): Promise<CryptoKey> {
+  if (canaryKeyPromise === null) {
+    canaryKeyPromise = globalThis.crypto.subtle.importKey(
+      'raw',
+      CANARY_PLAINTEXT_BYTES as BufferSource,
+      { name: 'AES-GCM', length: 256 },
+      true, // extractable so AES-KW can wrap it
+      ['encrypt', 'decrypt'],
+    )
+  }
+  return canaryKeyPromise
+}
+
+/** Mint a fresh wrapped-canary string. Deterministic for a given KEK. */
+export async function mintKeyringCanary(kek: CryptoKey): Promise<string> {
+  const canaryKey = await getCanaryKey()
+  return wrapKey(canaryKey, kek)
+}
+
+/** Try to unwrap the canary. Returns true iff KEK + canary bytes are intact. */
+async function verifyKeyringCanary(wrappedCanary: string, kek: CryptoKey): Promise<boolean> {
+  try {
+    await unwrapKey(wrappedCanary, kek)
+    return true
+  } catch {
+    return false
+  }
+}
+
 // ─── Load / Create ─────────────────────────────────────────────────────
 
 /** Load and unlock a user's keyring for a vault. */
@@ -172,10 +220,18 @@ export async function loadKeyring(
   const salt = base64ToBuffer(keyringFile.salt)
   const kek = await deriveKey(passphrase, salt)
 
-  // Unwrap each DEK independently — if some succeed and some fail, the
-  // passphrase is correct (the KEK derives) but specific entries are
-  // corrupted. Surface that as KeyringCorruptError so onInvalidKey:
-  // 'reset' does NOT fire and destroy the intact DEKs.
+  // Verify the canary first when present. A canary success proves the
+  // KEK is correct independent of any DEK byte — so subsequent DEK
+  // unwrap failures are unambiguously corruption, not wrong-pass. A
+  // canary failure with at least one DEK success indicates the KEK
+  // is correct but the canary itself is corrupt. (#113)
+  // `null` sentinel = legacy keyring without canary; falls back to the
+  // multi-DEK heuristic from #82 / #99.
+  const canaryOk: boolean | null = keyringFile.canary !== undefined
+    ? await verifyKeyringCanary(keyringFile.canary, kek)
+    : null
+
+  // Unwrap each DEK independently — collect successes and failures.
   const deks = new Map<string, CryptoKey>()
   const failedCollections: string[] = []
   let firstUnwrapError: unknown = null
@@ -188,18 +244,33 @@ export async function loadKeyring(
       if (firstUnwrapError === null) firstUnwrapError = err
     }
   }
-  if (failedCollections.length > 0) {
+
+  if (canaryOk === true) {
+    // KEK proven correct by the canary. Any DEK failure is corruption.
+    if (failedCollections.length > 0) {
+      throw new KeyringCorruptError({ failedCollections, intactCount: deks.size })
+    }
+  } else if (canaryOk === false) {
+    // Canary failed. If any DEK unwrapped, KEK is correct → canary bytes
+    // are corrupted (rare; reported under the '_canary' sentinel).
     if (deks.size > 0) {
       throw new KeyringCorruptError({
-        failedCollections,
+        failedCollections: [...failedCollections, '_canary'],
         intactCount: deks.size,
       })
     }
-    // No DEKs unwrapped — KEK is wrong (or every DEK is corrupt, which
-    // looks identical from here). Surface the original InvalidKeyError
-    // so onInvalidKey: 'reset' can fire its documented stale-credential
-    // recovery path.
-    throw firstUnwrapError
+    // Canary failed AND no DEK unwrapped — wrong KEK (or whole-file
+    // corruption). Surface the original InvalidKeyError so
+    // onInvalidKey: 'reset' can fire its documented recovery path.
+    throw firstUnwrapError instanceof Error ? firstUnwrapError : new InvalidKeyError()
+  } else {
+    // Legacy keyring (no canary). Fall back to the multi-DEK heuristic.
+    if (failedCollections.length > 0) {
+      if (deks.size > 0) {
+        throw new KeyringCorruptError({ failedCollections, intactCount: deks.size })
+      }
+      throw firstUnwrapError instanceof Error ? firstUnwrapError : new InvalidKeyError()
+    }
   }
 
   return {
@@ -249,6 +320,7 @@ export async function createOwnerKeyring(
   // pre-existing keyrings" rollout note in the spec).
   const userEnvelopeDek = await generateDEK()
   const wrappedUserEnvelopeDek = await wrapKey(userEnvelopeDek, kek)
+  const canary = await mintKeyringCanary(kek)
 
   const keyringFile: KeyringFile = {
     _noydb_keyring: NOYDB_KEYRING_VERSION,
@@ -260,6 +332,7 @@ export async function createOwnerKeyring(
     salt: bufferToBase64(salt),
     created_at: new Date().toISOString(),
     granted_by: userId,
+    canary,
   }
 
   await writeKeyringFile(adapter, vault, userId, keyringFile)
@@ -369,6 +442,7 @@ export async function grant(
     }
   }
 
+  const canary = await mintKeyringCanary(newKek)
   const keyringFile: KeyringFile = {
     _noydb_keyring: NOYDB_KEYRING_VERSION,
     user_id: options.userId,
@@ -379,6 +453,7 @@ export async function grant(
     salt: bufferToBase64(newSalt),
     created_at: new Date().toISOString(),
     granted_by: callerKeyring.userId,
+    canary,
     ...(options.exportCapability !== undefined && { export_capability: options.exportCapability }),
     ...(options.importCapability !== undefined && { import_capability: options.importCapability }),
   }
@@ -795,6 +870,7 @@ export async function changeSecret(
     wrappedDeks[collName] = await wrapKey(dek, newKek)
   }
 
+  const canary = await mintKeyringCanary(newKek)
   const keyringFile: KeyringFile = {
     _noydb_keyring: NOYDB_KEYRING_VERSION,
     user_id: keyring.userId,
@@ -805,6 +881,7 @@ export async function changeSecret(
     salt: bufferToBase64(newSalt),
     created_at: new Date().toISOString(),
     granted_by: keyring.userId,
+    canary,
   }
 
   await writeKeyringFile(adapter, vault, keyring.userId, keyringFile)
@@ -937,6 +1014,7 @@ export async function buildRecipientKeyringFile(
     }
   }
 
+  const canary = await mintKeyringCanary(newKek)
   return {
     _noydb_keyring: NOYDB_KEYRING_VERSION,
     user_id: recipient.id,
@@ -947,6 +1025,7 @@ export async function buildRecipientKeyringFile(
     salt: bufferToBase64(newSalt),
     created_at: new Date().toISOString(),
     granted_by: callerKeyring.userId,
+    canary,
     ...(recipient.exportCapability !== undefined
       ? { export_capability: recipient.exportCapability }
       : {}),
@@ -1094,6 +1173,7 @@ export async function persistKeyring(
   for (const [collName, dek] of keyring.deks) {
     wrappedDeks[collName] = await wrapKey(dek, keyring.kek)
   }
+  const canary = await mintKeyringCanary(keyring.kek)
 
   const keyringFile: KeyringFile = {
     _noydb_keyring: NOYDB_KEYRING_VERSION,
@@ -1105,6 +1185,7 @@ export async function persistKeyring(
     salt: bufferToBase64(keyring.salt),
     created_at: new Date().toISOString(),
     granted_by: keyring.userId,
+    canary,
     ...(keyring.exportCapability !== undefined && { export_capability: keyring.exportCapability }),
     ...(keyring.importCapability !== undefined && { import_capability: keyring.importCapability }),
     ...(keyring.authenticators.length > 0 && { authenticators: keyring.authenticators }),

--- a/packages/hub/src/team/peer-recover.ts
+++ b/packages/hub/src/team/peer-recover.ts
@@ -39,6 +39,7 @@ import { deriveKey, generateSalt, wrapKey, bufferToBase64 } from '../crypto.js'
 import { NoAccessError, PermissionDeniedError, PrivilegeEscalationError } from '../errors.js'
 import { assertStrongPassphrase, type PassphrasePolicy } from '../validation.js'
 import type { UnlockedKeyring } from './keyring.js'
+import { mintKeyringCanary } from './keyring.js'
 
 const ADMIN_RECOVERABLE_TARGETS: readonly Role[] = ['operator', 'viewer', 'client', 'admin']
 
@@ -171,7 +172,10 @@ export async function recoverUser(
   // 6. Build the recovered keyring file. Identity preserved; wrapping
   //    refreshed; tier-2 slots dropped (they wrap the OLD KEK and
   //    can't survive a tier-1 phrase change — same precedent as
-  //    rotatePassphrase).
+  //    rotatePassphrase). Mint a fresh canary under newKek (#113); the
+  //    OLD canary on the spread `...target` would fail to verify against
+  //    the new KEK and trip KeyringCorruptError on next load.
+  const canary = await mintKeyringCanary(newKek)
   const next: KeyringFile = {
     ...target,
     _noydb_keyring: NOYDB_KEYRING_VERSION,
@@ -181,6 +185,7 @@ export async function recoverUser(
     salt: bufferToBase64(newSalt),
     granted_by: callerKeyring.userId,
     authenticators: [],
+    canary,
   }
 
   // 7. Single atomic write — overwrites the existing envelope.

--- a/packages/hub/src/team/rotate-recover.ts
+++ b/packages/hub/src/team/rotate-recover.ts
@@ -38,6 +38,7 @@ import {
 } from './recovery.js'
 import { assertStrongPassphrase, type PassphrasePolicy } from '../validation.js'
 import type { UnlockedKeyring } from './keyring.js'
+import { mintKeyringCanary } from './keyring.js'
 import type { KeyringAuthenticator } from '../types.js'
 import type { EnrollAuthenticatorOptions } from './authenticators.js'
 import { ValidationError } from '../errors.js'
@@ -235,12 +236,14 @@ export async function rotatePassphrase(
     }
   }
 
+  const canary = await mintKeyringCanary(newKek)
   const next: KeyringFile = {
     ...file,
     _noydb_keyring: NOYDB_KEYRING_VERSION,
     deks: wrappedDeks,
     salt: bufferToBase64(newSalt),
     authenticators: newSlots,
+    canary,
   }
 
   await writeKeyringFile(store, vault, userId, next)
@@ -417,12 +420,14 @@ async function recoverViaPaperCode(
     wrappedDeks[coll] = await wrapKey(dek, newKek)
   }
 
+  const canary = await mintKeyringCanary(newKek)
   const next: KeyringFile = {
     ...file,
     _noydb_keyring: NOYDB_KEYRING_VERSION,
     deks: wrappedDeks,
     salt: bufferToBase64(newSalt),
     authenticators: [], // tier-2 slots wrap old KEK, drop them
+    canary,
   }
 
   // Burn first, then rewrite the keyring. The two writes are not

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -597,6 +597,21 @@ export interface KeyringFile {
   readonly created_at: string
   readonly granted_by: string
   /**
+   * Passphrase canary — base64 AES-KW-wrapped form of a known constant
+   * 256-bit value, wrapped under the keyring's KEK (#113).
+   *
+   * Optional: pre-#113 keyrings load with no canary and fall back to
+   * the multi-DEK corruption heuristic from #82. Keyrings written after
+   * #113 carry one and let `loadKeyring` distinguish wrong-passphrase
+   * from corruption even when ALL DEKs (including a single-DEK keyring's
+   * sole DEK) are corrupted.
+   *
+   * AES-KW is deterministic — every write site mints fresh on each
+   * persist; same KEK + same constant input always produces the same
+   * ciphertext, so this round-trips without state.
+   */
+  readonly canary?: string
+  /**
    * Tier-2 authenticator slots (multi-slot keyring extension).
    * Optional / append-only: keyring files written before the
    * extension load with an empty list. Each slot independently wraps


### PR DESCRIPTION
## Summary

Closes the deferred limitation flagged when [#82](https://github.com/vLannaAi/noy-db/issues/82) / PR #99 shipped: a keyring with **all DEKs corrupted**, or a **single-DEK keyring** with that DEK corrupted, was indistinguishable from wrong-passphrase. \`onInvalidKey: 'reset'\` would silently destroy the user's keyring even when the passphrase was right.

The canary is a fixed 256-bit AES-GCM key (32 zero bytes) wrapped under the keyring's KEK using AES-KW. AES-KW is deterministic (RFC 3394 fixed IV), so wrapping the same constant under the same KEK always yields the same ciphertext — every write site can mint fresh on each persist without round-tripping a \`canary\` field through \`UnlockedKeyring\`.

\`loadKeyring\` verifies the canary first, then unwraps each DEK independently:

| canary | DEKs | Outcome |
|---|---|---|
| ✓ | all unwrap | normal load |
| ✓ | some fail | \`KeyringCorruptError\` (corrupt DEKs; KEK proven correct by canary) |
| ✗ | some succeed | \`KeyringCorruptError\` (canary listed under \`'_canary'\` sentinel; KEK proven by DEK successes) |
| ✗ | none succeed | \`InvalidKeyError\` (wrong KEK / whole-file corruption — \`reset\` can fire) |
| absent | mixed | falls back to #99 multi-DEK heuristic (legacy keyring) |

## What changes on disk

\`KeyringFile.canary?: string\` — additive, optional. Pre-#113 keyrings load fine via the legacy heuristic. New keyrings get a canary on every write at every fresh-KEK site (\`createOwnerKeyring\`, \`grant\`, \`changeSecret\`, \`persistKeyring\`, \`buildRecipientKeyringFile\`, \`rotatePassphrase\`, \`recoverPassphrase\`).

## Closes #113

## Test plan

Three regression tests in \`persistence.test.ts\`:

1. **Single-DEK corruption with correct passphrase + \`onInvalidKey: 'reset'\`** — \`KeyringCorruptError\`, NOT a reset. (The case #82/#99 couldn't distinguish from wrong-pass.)
2. **Canary corruption with intact DEKs** — \`KeyringCorruptError\` listing \`'_canary'\` as a corrupted entry.
3. **Legacy keyring without canary** — falls back to multi-DEK heuristic and loads correctly.

\`pnpm turbo lint typecheck --filter=@noy-db/hub\` clean.

## Note on the original PR #116

This PR was previously opened as #116 stacked on PR #99. When #99 squash-merged, GitHub auto-closed #116 because its base branch was deleted. Re-opened against \`main\` after rebasing — the canary commit dropped #99's already-upstream commits cleanly, applied the in-PR fixups for the \`FactorProof\` → \`FactorProofBundle\` cascade and the \`@typescript-eslint/only-throw-error\` lint rule.

## Disruptive

Format-additive. Old keyrings load unchanged. New keyrings get the canary; sessions opening either type unwrap correctly.