### PR TITLE
feat(hub): withDerivation — deterministic derived data (Dim 14, #129)

### DIFF
--- a/docs/subsystems/derivations.md
+++ b/docs/subsystems/derivations.md
@@ -1,0 +1,195 @@
+# derivations
+
+> **Subpath:** `@noy-db/hub/derivations`
+> **Factory:** `withDerivation()`
+> **Cluster:** B — Write & Mutate
+> **LOC cost:** ~preview (off-bundle when not opted in)
+> **Status:** preview, ships in 0.1.0-pre.11
+
+## What it does
+
+`withDerivation` lets a vault declare deterministic data derivations of one or
+more typed outputs from a source record. The derive function runs on plaintext
+(after DEK unwrap, inside the encrypted boundary) and its outputs are encrypted
+with the same DEK before reaching the store — listing the storage backend
+cannot reveal the derivation graph.
+
+## When you need it
+
+- Splitting a large source record into derived projections for faster reads
+  (e.g. PDF source → extracted metadata + searchable text)
+- Materialized side-data that must stay encrypted under the same DEK as its
+  source
+- Workflows where some outputs are expensive (lazy) and others cheap (eager)
+- Bulk recompute paths after a strategy change (`vault.deriveAll`)
+
+## Opt-in
+
+```ts
+import { createNoydb } from '@noy-db/hub'
+import { withDerivation } from '@noy-db/hub/derivations'
+
+const pdfDerivation = withDerivation<Pdf, { meta: PdfMeta; text: PdfText }>({
+  source: 'pdfs',
+  deterministic: true,
+  outputs: {
+    meta: { shape: 'record', collection: 'pdf-meta' },
+    text: { shape: 'record', collection: 'pdf-text' },
+  },
+  derive: (pdf) => ({
+    meta: { len: pdf.body.length, pages: pdf.pages.length },
+    text: { content: extractText(pdf.body) },
+  }),
+  lifecycle: 'eager', // or 'lazy'
+})
+
+const db = await createNoydb({
+  store: ...,
+  user: ...,
+  derivationStrategies: [pdfDerivation],
+})
+```
+
+## API
+
+### Lifecycles
+
+- **`eager`** — derive runs synchronously inside the source-write transaction.
+  Outputs are written via the same `Collection.put` pipeline. Recommended for
+  small, fast derive functions.
+- **`lazy`** — source-write marks output ids stale; first read of any output
+  triggers the derive. Recommended when the derive is expensive and most
+  sources are written without being read.
+
+### Strict vs non-strict
+
+Default (`strict: false`): per-output failures are isolated. Other outputs
+commit; the failed output is absent from the store and re-attempts on next
+`vault.deriveAll`.
+
+`strict: true`: a single output failure rolls back the source write (only
+when wrapped in `withTransactions`). Use for outputs that must remain
+consistent with the source.
+
+### `vault.deriveAll(collection)`
+
+Re-derive every record in the named source collection. Useful after a strategy
+change (the strategyHash mismatch forces a recompute on next visit, but
+`deriveAll` is the explicit bulk path).
+
+```ts
+const { derived, failed } = await vault.deriveAll('pdfs')
+```
+
+### `_derivedFrom` metadata
+
+Every derived record carries:
+
+```ts
+{
+  _derivedFrom: {
+    source: 'pdfs',
+    sourceId: 'abc',
+    sourceVersion: 3,
+    derivedAt: '2026-05-18T...',
+    strategyHash: 'sha256-...', // changes when the strategy changes
+  }
+}
+```
+
+`strategyHash` is the v1 mechanism for detecting strategy drift: a record
+whose hash doesn't match the current strategy is recomputed by
+`vault.deriveAll`.
+
+### Composition order
+
+Derivations fire **after** the store write and ledger append. A guard that
+blocks a source write also blocks the derivation that would have fired from
+it.
+
+```
+Collection.put
+  1. Permission check
+  2. GuardRegistry.check
+  3. Encrypt + store.put
+  4. Ledger append
+  5. DerivationRegistry           ← this doc
+```
+
+### Errors
+
+All extend `NoydbError`:
+
+- `DerivationCycleError(path[])` — graph contains a cycle
+- `DerivationDepthError(limit, attempted)` — cascade exceeded `maxDepth`
+- `DerivationOutputUnknownError(collection)` — output collection unknown
+- `DerivationOutputShapeError(outputKey, detail)` — derive returned wrong shape
+
+## Behavior when NOT opted in
+
+- `createNoydb({ derivationStrategies: [...] })` is the only way to register
+  derivations; without it, no derive function fires
+- `vault.deriveAll(collection)` throws with a pointer to
+  `@noy-db/hub/derivations`
+- `DerivationCycleError` / `DerivationDepthError` /
+  `DerivationOutputUnknownError` / `DerivationOutputShapeError` are still
+  importable from `@noy-db/hub/derivations` but are never thrown by core
+
+## Pairs well with
+
+- **guards** — guards run before encryption; a blocked source write
+  short-circuits the derivation that would have fired
+- **transactions** — `strict: true` derivations require `withTransactions` so
+  output failures can roll back the source write
+- **history** — every committed derivation output fires its own ledger entry
+  through the standard `Collection.put` pipeline
+
+## Edge cases & limits
+
+### Zero-knowledge guarantee
+
+The derive function executes after DEK unwrap, on plaintext. The store never
+sees plaintext. Outputs are encrypted with the same DEK as the source before
+they reach the store. `_derivedFrom` metadata lives inside the encrypted
+payload, not in the plaintext envelope.
+
+### Cycle detection
+
+Cyclic graphs (A → B → A, self-loops, etc.) are rejected at `vault.openVault`
+with `DerivationCycleError`. The graph is the union of every strategy's
+source + output collection set.
+
+### Behavior notes
+
+- **Lazy stale-tracking is in-memory only in v1.** A vault close-and-reopen
+  loses pending stale flags. Derived records with a matching `strategyHash`
+  are treated as fresh; `vault.deriveAll()` is the explicit recompute path
+  after strategy changes.
+- **`sourceVersion: 0` on bulk recomputes.** `vault.deriveAll()` and the
+  lazy-resolution path stamp `_derivedFrom.sourceVersion = 0` because the
+  envelope `_v` isn't easily plumbed through `Collection.list()`. v2 may
+  thread the version through.
+- **Recursion guard.** The dispatch hook in `Collection.put` skips when the
+  incoming record carries a `_derivedFrom` field — a defense-in-depth check
+  alongside the openVault cycle validator.
+
+### Deferred to v2
+
+- Cache-tier backends (`to-cache-*`)
+- Built-in derivers (PDF, image, etc.)
+- `withMaterializedView` (collection-level query derivation)
+- Scheduled / cron-style refresh
+- Non-deterministic derivations with persistence
+- External / sandboxed derivation runtimes
+- Public CDN derivations
+- Streaming materialized views (over Dim 12)
+- Stale-flag persistence across vault close
+- Per-record `sourceVersion` in bulk recompute paths
+
+See the spec for the full deferred list.
+
+## See also
+
+- [SUBSYSTEMS.md](../../SUBSYSTEMS.md)
+- `docs/superpowers/specs/2026-05-01-dim14-derivation-v1-design.md`
+- `__tests__/derivations/*.test.ts`, `showcases/src/80-with-derivation.showcase.test.ts`

--- a/features.yaml
+++ b/features.yaml
@@ -467,6 +467,28 @@ features:
       - 'casAtomic stores: genuine atomicity. casAtomic:false: ordered-with-rollback'
     related: [vault-and-collections]
 
+  - id: derivations
+    name: Deterministic derived data
+    cluster: write-and-mutate
+    spec: docs/subsystems/derivations.md#derivations
+    subsystem_doc: docs/subsystems/derivations.md
+    package: '@noy-db/hub/derivations'
+    factory: withDerivation
+    status: preview
+    showcases:
+      - id: 80-with-derivation
+        path: showcases/src/80-with-derivation.showcase.test.ts
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'derive runs on plaintext, after DEK unwrap, before encrypt'
+      - 'outputs encrypted with same DEK as source by default'
+      - '_derivedFrom lives in encrypted payload, not unencrypted envelope'
+      - 'strict: true rolls back source write on output failure inside withTransactions'
+      - 'cycle detection at vault open — refuses cyclic graphs'
+    related: [guards, transactions]
+
   - id: guards
     name: Record lock, field freeze, amendment invariant
     cluster: time-and-audit

--- a/packages/hub/__tests__/derivations/cross-store.test.ts
+++ b/packages/hub/__tests__/derivations/cross-store.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { mkdtemp, rm, mkdir, writeFile, readFile, readdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, dirname } from 'node:path'
+import { createNoydb, withDerivation } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+// Inline file-backed store — same pattern as packages/hub/__tests__/guards/cross-store.test.ts
+function fileStore(dir: string): NoydbStore {
+  const filePath = (v: string, c: string, i: string) => join(dir, v, c, `${i}.json`)
+  return {
+    capabilities: { casAtomic: false, auth: { kind: 'none' } },
+    async get(v, c, i) {
+      try {
+        const raw = await readFile(filePath(v, c, i), 'utf8')
+        return JSON.parse(raw) as EncryptedEnvelope
+      } catch {
+        return null
+      }
+    },
+    async put(v, c, i, env) {
+      const fp = filePath(v, c, i)
+      await mkdir(dirname(fp), { recursive: true })
+      await writeFile(fp, JSON.stringify(env))
+    },
+    async delete(v, c, i) {
+      try {
+        await rm(filePath(v, c, i))
+      } catch { /* idempotent */ }
+    },
+    async list(v, c) {
+      try {
+        const entries = await readdir(join(dir, v, c))
+        return entries.filter(e => e.endsWith('.json')).map(e => e.slice(0, -5))
+      } catch {
+        return []
+      }
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      try {
+        const colls = await readdir(join(dir, v))
+        for (const c of colls) {
+          const ids = await readdir(join(dir, v, c)).catch(() => [])
+          for (const f of ids) {
+            if (!f.endsWith('.json')) continue
+            const id = f.slice(0, -5)
+            const raw = await readFile(join(dir, v, c, f), 'utf8')
+            out[c] = out[c] ?? {}
+            out[c][id] = JSON.parse(raw)
+          }
+        }
+      } catch { /* empty vault */ }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          await this.put(v, c, i, payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface Pdf extends Record<string, unknown> { id: string; body: string }
+interface PdfMeta extends Record<string, unknown> { len: number }
+
+describe('Derivation conformance on file-backed store', () => {
+  let dir: string
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'noydb-derivations-'))
+  })
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('eager derivation survives vault re-open', async () => {
+    const strategy = withDerivation<Pdf, { meta: PdfMeta }>({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: { meta: { shape: 'record', collection: 'pdf-meta' } },
+      derive: (s) => ({ meta: { len: s.body.length } }),
+      lifecycle: 'eager',
+    })
+    const open = () => createNoydb({
+      store: fileStore(dir),
+      user: 'alice',
+      secret: 'derivation-tofile-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const db1 = await open()
+    const v1 = await db1.openVault('demo')
+    await v1.collection<Pdf>('pdfs').put('p1', { id: 'p1', body: 'hello' })
+
+    const db2 = await open()
+    const v2 = await db2.openVault('demo')
+    const meta = await v2.collection<PdfMeta>('pdf-meta').get('p1')
+    expect(meta?.len).toBe(5)
+  })
+})

--- a/packages/hub/__tests__/derivations/cycle.test.ts
+++ b/packages/hub/__tests__/derivations/cycle.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withDerivation, DerivationCycleError } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+describe('Derivation cycle detection at vault open', () => {
+  it('refuses to open a vault with a self-cycle', async () => {
+    const bad = withDerivation({
+      source: 'a',
+      deterministic: true,
+      outputs: { o: { shape: 'record', collection: 'a' } },
+      derive: () => ({ o: {} }),
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-cycle-self-passphrase-2026',
+      derivationStrategies: [bad],
+    })
+    await expect(db.openVault('demo')).rejects.toBeInstanceOf(DerivationCycleError)
+  })
+
+  it('refuses A -> B -> A', async () => {
+    const a = withDerivation({
+      source: 'a',
+      deterministic: true,
+      outputs: { o: { shape: 'record', collection: 'b' } },
+      derive: () => ({ o: {} }),
+      lifecycle: 'eager',
+    })
+    const b = withDerivation({
+      source: 'b',
+      deterministic: true,
+      outputs: { o: { shape: 'record', collection: 'a' } },
+      derive: () => ({ o: {} }),
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-cycle-ab-passphrase-2026',
+      derivationStrategies: [a, b],
+    })
+    await expect(db.openVault('demo')).rejects.toBeInstanceOf(DerivationCycleError)
+  })
+
+  it('refuses A -> B -> C -> A', async () => {
+    const make = (source: string, output: string) => withDerivation({
+      source,
+      deterministic: true,
+      outputs: { o: { shape: 'record', collection: output } },
+      derive: () => ({ o: {} }),
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-cycle-abc-passphrase-2026',
+      derivationStrategies: [make('a', 'b'), make('b', 'c'), make('c', 'a')],
+    })
+    await expect(db.openVault('demo')).rejects.toBeInstanceOf(DerivationCycleError)
+  })
+
+  it('accepts an acyclic graph (A -> B -> C)', async () => {
+    const make = (source: string, output: string) => withDerivation({
+      source,
+      deterministic: true,
+      outputs: { o: { shape: 'record', collection: output } },
+      derive: () => ({ o: {} }),
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-cycle-acyclic-passphrase-2026',
+      derivationStrategies: [make('a', 'b'), make('b', 'c')],
+    })
+    await expect(db.openVault('demo')).resolves.toBeDefined()
+  })
+
+  it('cycle error carries the path', async () => {
+    const make = (source: string, output: string) => withDerivation({
+      source,
+      deterministic: true,
+      outputs: { o: { shape: 'record', collection: output } },
+      derive: () => ({ o: {} }),
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-cycle-path-passphrase-2026',
+      derivationStrategies: [make('a', 'b'), make('b', 'a')],
+    })
+    try {
+      await db.openVault('demo')
+      throw new Error('expected throw')
+    } catch (e) {
+      expect(e).toBeInstanceOf(DerivationCycleError)
+      const cycle = (e as DerivationCycleError).path
+      // path should include 'a' and 'b' and end where it started
+      expect(cycle.length).toBeGreaterThanOrEqual(2)
+      expect(cycle).toContain('a')
+      expect(cycle).toContain('b')
+    }
+  })
+})

--- a/packages/hub/__tests__/derivations/derive-all.test.ts
+++ b/packages/hub/__tests__/derivations/derive-all.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withDerivation } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface Pdf extends Record<string, unknown> { id: string; body: string }
+
+describe('vault.deriveAll', () => {
+  it('re-derives every record in the source collection', async () => {
+    let version = 1
+    const strategy = withDerivation({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: { meta: { shape: 'record', collection: 'pdf-meta' } },
+      derive: (s: Pdf) => ({ meta: { len: s.body.length, version } }),
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-deriveall-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+    await v.collection<Pdf>('pdfs').put('p1', { id: 'p1', body: 'a' })
+    await v.collection<Pdf>('pdfs').put('p2', { id: 'p2', body: 'bb' })
+    version = 2
+    const result = await v.deriveAll('pdfs')
+    expect(result.derived).toBe(2)
+    expect(result.failed).toBe(0)
+    const m1 = await v.collection<any>('pdf-meta').get('p1')
+    const m2 = await v.collection<any>('pdf-meta').get('p2')
+    expect(m1.version).toBe(2)
+    expect(m2.version).toBe(2)
+  })
+
+  it('returns zero counts when no strategy targets the collection', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-deriveall-empty-passphrase-2026',
+    })
+    const v = await db.openVault('demo')
+    const result = await v.deriveAll('absent')
+    expect(result.derived).toBe(0)
+    expect(result.failed).toBe(0)
+  })
+})

--- a/packages/hub/__tests__/derivations/eager.test.ts
+++ b/packages/hub/__tests__/derivations/eager.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withDerivation } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface Pdf extends Record<string, unknown> { id: string; body: string }
+interface PdfMeta extends Record<string, unknown> { len: number; _derivedFrom?: unknown }
+
+describe('Derivation — eager lifecycle', () => {
+  it('writes derived outputs immediately after source write', async () => {
+    const strategy = withDerivation<Pdf, { meta: PdfMeta }>({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: { meta: { shape: 'record', collection: 'pdf-meta' } },
+      derive: (s) => ({ meta: { len: s.body.length } }),
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-eager-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+    await v.collection<Pdf>('pdfs').put('p1', { id: 'p1', body: 'hello' })
+    const meta = await v.collection<PdfMeta>('pdf-meta').get('p1')
+    expect(meta?.len).toBe(5)
+    expect((meta as any)?._derivedFrom?.source).toBe('pdfs')
+  })
+
+  it('re-derives on source change', async () => {
+    const strategy = withDerivation<Pdf, { meta: PdfMeta }>({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: { meta: { shape: 'record', collection: 'pdf-meta' } },
+      derive: (s) => ({ meta: { len: s.body.length } }),
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-rederive-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+    await v.collection<Pdf>('pdfs').put('p1', { id: 'p1', body: 'hi' })
+    await v.collection<Pdf>('pdfs').put('p1', { id: 'p1', body: 'longer text' })
+    const meta = await v.collection<PdfMeta>('pdf-meta').get('p1')
+    expect(meta?.len).toBe('longer text'.length)
+  })
+
+  it('writes multiple outputs', async () => {
+    interface Text extends Record<string, unknown> { content: string }
+    const strategy = withDerivation<Pdf, { meta: PdfMeta; text: Text }>({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: {
+        meta: { shape: 'record', collection: 'pdf-meta' },
+        text: { shape: 'record', collection: 'pdf-text' },
+      },
+      derive: (s) => ({ meta: { len: s.body.length }, text: { content: s.body.toUpperCase() } }),
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-multi-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+    await v.collection<Pdf>('pdfs').put('p1', { id: 'p1', body: 'hi' })
+    const meta = await v.collection<PdfMeta>('pdf-meta').get('p1')
+    const text = await v.collection<Text>('pdf-text').get('p1')
+    expect(meta?.len).toBe(2)
+    expect(text?.content).toBe('HI')
+  })
+})

--- a/packages/hub/__tests__/derivations/errors.test.ts
+++ b/packages/hub/__tests__/derivations/errors.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import {
+  NoydbError,
+  DerivationCycleError,
+  DerivationDepthError,
+  DerivationOutputUnknownError,
+  DerivationOutputShapeError,
+} from '../../src/errors.js'
+
+describe('derivation errors', () => {
+  it('DerivationCycleError lists the cycle path', () => {
+    const e = new DerivationCycleError(['a', 'b', 'c', 'a'])
+    expect(e).toBeInstanceOf(NoydbError)
+    expect(e.code).toBe('DERIVATION_CYCLE')
+    expect(e.path).toEqual(['a', 'b', 'c', 'a'])
+    expect(e.message).toContain('a → b → c → a')
+  })
+
+  it('DerivationDepthError reports limit + current depth', () => {
+    const e = new DerivationDepthError(5, 7)
+    expect(e.code).toBe('DERIVATION_DEPTH')
+    expect(e.limit).toBe(5)
+    expect(e.attempted).toBe(7)
+  })
+
+  it('DerivationOutputUnknownError names the missing output collection', () => {
+    const e = new DerivationOutputUnknownError('pdf-text-NOT-REGISTERED')
+    expect(e.code).toBe('DERIVATION_OUTPUT_UNKNOWN')
+    expect(e.collection).toBe('pdf-text-NOT-REGISTERED')
+  })
+
+  it('DerivationOutputShapeError names the offending output key', () => {
+    const e = new DerivationOutputShapeError('metadata', 'expected object, got string')
+    expect(e.code).toBe('DERIVATION_OUTPUT_SHAPE')
+    expect(e.outputKey).toBe('metadata')
+  })
+})

--- a/packages/hub/__tests__/derivations/executor.test.ts
+++ b/packages/hub/__tests__/derivations/executor.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { DerivationExecutor } from '../../src/derivations/executor.js'
+import { withDerivation } from '../../src/derivations/with-derivation.js'
+import { DerivationOutputShapeError } from '../../src/errors.js'
+
+interface Source { id: string; body: string }
+interface Meta { len: number }
+interface Text { content: string }
+
+describe('DerivationExecutor.run', () => {
+  it('runs derive, returns per-output success/failure', async () => {
+    const strategy = withDerivation<Source, { meta: Meta; text: Text }>({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: {
+        meta: { shape: 'record', collection: 'pdf-meta' },
+        text: { shape: 'record', collection: 'pdf-text' },
+      },
+      derive: (s) => ({ meta: { len: s.body.length }, text: { content: s.body.toUpperCase() } }),
+      lifecycle: 'eager',
+    }).spec
+    const result = await DerivationExecutor.run(strategy, { id: 'p1', body: 'hi' }, 1, 'hash')
+    expect(result.outputs.meta.ok).toBe(true)
+    expect(result.outputs.text.ok).toBe(true)
+    // value contains both the derived data AND the _derivedFrom stamp
+    const metaVal = result.outputs.meta.value as Meta & { _derivedFrom: any }
+    expect(metaVal.len).toBe(2)
+    expect(metaVal._derivedFrom).toBeDefined()
+  })
+
+  it('captures per-output exceptions in non-strict mode', async () => {
+    const strategy = withDerivation<Source, { good: Meta; bad: Meta }>({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: {
+        good: { shape: 'record', collection: 'g' },
+        bad: { shape: 'record', collection: 'b' },
+      },
+      derive: () => { throw new Error('boom') },
+      lifecycle: 'eager',
+    }).spec
+    const result = await DerivationExecutor.run(strategy, { id: 'p1', body: '' }, 1, 'hash')
+    expect(result.failed).toBe(true)
+    expect(result.outputs.good.ok).toBe(false)
+  })
+
+  it('throws DerivationOutputShapeError when derive returns missing keys', async () => {
+    const strategy = withDerivation<Source, { meta: Meta; text: Text }>({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: {
+        meta: { shape: 'record', collection: 'pdf-meta' },
+        text: { shape: 'record', collection: 'pdf-text' },
+      },
+      // missing 'text' in the returned object
+      derive: ((s: Source) => ({ meta: { len: s.body.length } })) as any,
+      lifecycle: 'eager',
+    }).spec
+    await expect(
+      DerivationExecutor.run(strategy, { id: 'p1', body: 'x' }, 1, 'h'),
+    ).rejects.toBeInstanceOf(DerivationOutputShapeError)
+  })
+
+  it('stamps _derivedFrom onto every output', async () => {
+    const strategy = withDerivation<Source, { meta: Meta }>({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: { meta: { shape: 'record', collection: 'pdf-meta' } },
+      derive: (s) => ({ meta: { len: s.body.length } }),
+      lifecycle: 'eager',
+    }).spec
+    const result = await DerivationExecutor.run(strategy, { id: 'p1', body: 'hi' }, 3, 'STRAT')
+    const out = result.outputs.meta.value as Meta & { _derivedFrom: any }
+    expect(out._derivedFrom.source).toBe('pdfs')
+    expect(out._derivedFrom.sourceId).toBe('p1')
+    expect(out._derivedFrom.sourceVersion).toBe(3)
+    expect(out._derivedFrom.strategyHash).toBe('STRAT')
+  })
+})

--- a/packages/hub/__tests__/derivations/lazy.test.ts
+++ b/packages/hub/__tests__/derivations/lazy.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from 'vitest'
+import { createNoydb, withDerivation } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface Pdf extends Record<string, unknown> { id: string; body: string }
+interface PdfText extends Record<string, unknown> { content: string }
+
+describe('Derivation — lazy lifecycle', () => {
+  it('does NOT derive on source write', async () => {
+    const derive = vi.fn((s: Pdf) => ({ text: { content: s.body.toUpperCase() } }))
+    const strategy = withDerivation<Pdf, { text: PdfText }>({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: { text: { shape: 'record', collection: 'pdf-text' } },
+      derive,
+      lifecycle: 'lazy',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-lazy-noderive-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+    await v.collection<Pdf>('pdfs').put('p1', { id: 'p1', body: 'hello' })
+    expect(derive).not.toHaveBeenCalled()
+  })
+
+  it('derives on first read of the stale output', async () => {
+    const derive = vi.fn((s: Pdf) => ({ text: { content: s.body.toUpperCase() } }))
+    const strategy = withDerivation<Pdf, { text: PdfText }>({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: { text: { shape: 'record', collection: 'pdf-text' } },
+      derive,
+      lifecycle: 'lazy',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-lazy-onread-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+    await v.collection<Pdf>('pdfs').put('p1', { id: 'p1', body: 'hi' })
+    const text = await v.collection<PdfText>('pdf-text').get('p1')
+    expect(derive).toHaveBeenCalledTimes(1)
+    expect(text?.content).toBe('HI')
+  })
+
+  it('does not re-derive on a second read', async () => {
+    const derive = vi.fn((s: Pdf) => ({ text: { content: s.body.toUpperCase() } }))
+    const strategy = withDerivation<Pdf, { text: PdfText }>({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: { text: { shape: 'record', collection: 'pdf-text' } },
+      derive,
+      lifecycle: 'lazy',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-lazy-twice-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+    await v.collection<Pdf>('pdfs').put('p1', { id: 'p1', body: 'hi' })
+    await v.collection<PdfText>('pdf-text').get('p1')
+    await v.collection<PdfText>('pdf-text').get('p1')
+    expect(derive).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/hub/__tests__/derivations/registry.test.ts
+++ b/packages/hub/__tests__/derivations/registry.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { DerivationRegistry } from '../../src/derivations/registry.js'
+import { withDerivation } from '../../src/derivations/with-derivation.js'
+import { DerivationCycleError } from '../../src/errors.js'
+
+describe('DerivationRegistry', () => {
+  it('register + lookup by source', async () => {
+    const reg = new DerivationRegistry()
+    await reg.register(withDerivation({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: { meta: { shape: 'record', collection: 'pdf-meta' } },
+      derive: () => ({ meta: {} }),
+      lifecycle: 'eager',
+    }).spec)
+    expect(reg.strategiesForSource('pdfs')).toHaveLength(1)
+    expect(reg.strategiesForSource('nope')).toHaveLength(0)
+  })
+
+  it('reverse lookup — output collection → source strategies', async () => {
+    const reg = new DerivationRegistry()
+    await reg.register(withDerivation({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: { meta: { shape: 'record', collection: 'pdf-meta' } },
+      derive: () => ({ meta: {} }),
+      lifecycle: 'eager',
+    }).spec)
+    expect(reg.strategiesProducingOutput('pdf-meta')).toHaveLength(1)
+  })
+
+  it('detects self-cycle at register-and-validate', async () => {
+    const reg = new DerivationRegistry()
+    await reg.register(withDerivation({
+      source: 'a',
+      deterministic: true,
+      outputs: { o: { shape: 'record', collection: 'a' } }, // a → a
+      derive: () => ({ o: {} }),
+      lifecycle: 'eager',
+    }).spec)
+    expect(() => reg.validate()).toThrow(DerivationCycleError)
+  })
+
+  it('detects A → B → A cycle', async () => {
+    const reg = new DerivationRegistry()
+    await reg.register(withDerivation({
+      source: 'a',
+      deterministic: true,
+      outputs: { o: { shape: 'record', collection: 'b' } },
+      derive: () => ({ o: {} }),
+      lifecycle: 'eager',
+    }).spec)
+    await reg.register(withDerivation({
+      source: 'b',
+      deterministic: true,
+      outputs: { o: { shape: 'record', collection: 'a' } },
+      derive: () => ({ o: {} }),
+      lifecycle: 'eager',
+    }).spec)
+    expect(() => reg.validate()).toThrow(DerivationCycleError)
+  })
+
+  it('accepts an acyclic graph', async () => {
+    const reg = new DerivationRegistry()
+    await reg.register(withDerivation({
+      source: 'a',
+      deterministic: true,
+      outputs: { o: { shape: 'record', collection: 'b' } },
+      derive: () => ({ o: {} }),
+      lifecycle: 'eager',
+    }).spec)
+    await reg.register(withDerivation({
+      source: 'b',
+      deterministic: true,
+      outputs: { o: { shape: 'record', collection: 'c' } },
+      derive: () => ({ o: {} }),
+      lifecycle: 'eager',
+    }).spec)
+    expect(() => reg.validate()).not.toThrow()
+  })
+})

--- a/packages/hub/__tests__/derivations/strategy-hash.test.ts
+++ b/packages/hub/__tests__/derivations/strategy-hash.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { computeStrategyHash } from '../../src/derivations/strategy-hash.js'
+
+describe('computeStrategyHash', () => {
+  it('returns identical hash for identical inputs', async () => {
+    const fn = (s: { x: number }) => ({ out: { y: s.x + 1 } })
+    const h1 = await computeStrategyHash('src', ['out'], fn)
+    const h2 = await computeStrategyHash('src', ['out'], fn)
+    expect(h1).toBe(h2)
+  })
+
+  it('changes when source name changes', async () => {
+    const fn = (s: { x: number }) => ({ out: { y: s.x } })
+    const a = await computeStrategyHash('src-a', ['out'], fn)
+    const b = await computeStrategyHash('src-b', ['out'], fn)
+    expect(a).not.toBe(b)
+  })
+
+  it('changes when output keys change', async () => {
+    const fn = (_s: any) => ({} as any)
+    const a = await computeStrategyHash('src', ['out1'], fn)
+    const b = await computeStrategyHash('src', ['out1', 'out2'], fn)
+    expect(a).not.toBe(b)
+  })
+
+  it('changes when derive function body changes', async () => {
+    const a = await computeStrategyHash('src', ['out'], (s: any) => ({ out: { y: s.x + 1 } }))
+    const b = await computeStrategyHash('src', ['out'], (s: any) => ({ out: { y: s.x + 2 } }))
+    expect(a).not.toBe(b)
+  })
+
+  it('returns a hex string', async () => {
+    const h = await computeStrategyHash('s', ['o'], () => ({ o: {} } as any))
+    expect(h).toMatch(/^[0-9a-f]+$/)
+  })
+})

--- a/packages/hub/__tests__/derivations/strict-tx.test.ts
+++ b/packages/hub/__tests__/derivations/strict-tx.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../../src/index.js'
+import { withDerivation } from '../../src/derivations/index.js'
+import { withTransactions } from '../../src/tx/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface Pdf extends Record<string, unknown> { id: string; body: string }
+
+describe('Derivation strict mode + withTransactions', () => {
+  it('rolls back source write if derive throws', async () => {
+    const strategy = withDerivation<Pdf, { meta: { len: number } }>({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: { meta: { shape: 'record', collection: 'pdf-meta' } },
+      derive: () => { throw new Error('always-fails') },
+      lifecycle: 'eager',
+      strict: true,
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-strict-passphrase-2026',
+      derivationStrategies: [strategy],
+      txStrategy: withTransactions(),
+    })
+    const v = await db.openVault('demo')
+    await expect(
+      db.transaction(async (tx) => {
+        tx.vault('demo').collection<Pdf>('pdfs').put('p1', { id: 'p1', body: 'x' })
+      }),
+    ).rejects.toThrow('always-fails')
+    const pdf = await v.collection<Pdf>('pdfs').get('p1')
+    expect(pdf).toBeNull()  // rolled back
+  })
+
+  it('non-strict mode commits source even if derive fails', async () => {
+    const strategy = withDerivation<Pdf, { meta: { len: number } }>({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: { meta: { shape: 'record', collection: 'pdf-meta' } },
+      derive: () => { throw new Error('soft-fail') },
+      lifecycle: 'eager',
+      // strict: false (default)
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-nonstrict-passphrase-2026',
+      derivationStrategies: [strategy],
+      txStrategy: withTransactions(),
+    })
+    const v = await db.openVault('demo')
+    await db.transaction(async (tx) => {
+      tx.vault('demo').collection<Pdf>('pdfs').put('p1', { id: 'p1', body: 'x' })
+    })
+    const pdf = await v.collection<Pdf>('pdfs').get('p1')
+    expect(pdf).not.toBeNull()  // committed
+    const meta = await v.collection('pdf-meta').get('p1')
+    expect(meta).toBeNull()  // derive failed, output absent
+  })
+})

--- a/packages/hub/__tests__/derivations/subpath-export.test.ts
+++ b/packages/hub/__tests__/derivations/subpath-export.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+
+describe('@noy-db/hub/derivations subpath', () => {
+  it('exposes withDerivation + error classes via subpath import', async () => {
+    const mod = await import('@noy-db/hub/derivations')
+    expect(typeof mod.withDerivation).toBe('function')
+    expect(typeof mod.DerivationCycleError).toBe('function')
+    expect(typeof mod.DerivationDepthError).toBe('function')
+    expect(typeof mod.DerivationOutputUnknownError).toBe('function')
+    expect(typeof mod.DerivationOutputShapeError).toBe('function')
+  })
+
+  it('instanceof works across main + subpath imports (ESM splitting)', async () => {
+    const main = await import('@noy-db/hub')
+    const sub = await import('@noy-db/hub/derivations')
+    const e = new sub.DerivationCycleError(['a', 'b', 'a'])
+    expect(e).toBeInstanceOf(main.DerivationCycleError)
+  })
+})

--- a/packages/hub/__tests__/derivations/types.test.ts
+++ b/packages/hub/__tests__/derivations/types.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import type { DerivedFromMeta, DerivationStrategy, OutputSpec } from '../../src/derivations/types.js'
+
+describe('Derivation types', () => {
+  it('DerivedFromMeta has the documented fields', () => {
+    const meta: DerivedFromMeta = {
+      source: 'pdfs',
+      sourceId: 'abc',
+      sourceVersion: 3,
+      derivedAt: '2026-05-18T00:00:00.000Z',
+      strategyHash: 'sha256-x',
+    }
+    expect(meta.source).toBe('pdfs')
+    expect(meta.strategyHash).toBe('sha256-x')
+  })
+
+  it('DerivationStrategy carries source, outputs map, derive, lifecycle', () => {
+    const strategy: DerivationStrategy<{ body: string }, { meta: { len: number } }> = {
+      source: 'pdfs',
+      deterministic: true,
+      outputs: { meta: { shape: 'record', collection: 'pdf-meta' } },
+      derive: (s) => ({ meta: { len: s.body.length } }),
+      lifecycle: 'eager',
+    }
+    expect(strategy.source).toBe('pdfs')
+    expect(strategy.outputs.meta.collection).toBe('pdf-meta')
+  })
+
+  it('OutputSpec has shape and collection', () => {
+    const spec: OutputSpec = { shape: 'record', collection: 'pdf-meta' }
+    expect(spec.shape).toBe('record')
+  })
+})

--- a/packages/hub/__tests__/derivations/vault-wiring.test.ts
+++ b/packages/hub/__tests__/derivations/vault-wiring.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withDerivation, DerivationCycleError } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+describe('Vault.derivationRegistry wiring', () => {
+  it('createNoydb accepts derivationStrategies', async () => {
+    const handle = withDerivation({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: { meta: { shape: 'record', collection: 'pdf-meta' } },
+      derive: () => ({ meta: { len: 0 } }),
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-vault-wiring-passphrase-2026',
+      derivationStrategies: [handle],
+    })
+    const vault = await db.openVault('demo')
+    const reg = (vault as any)._getDerivationRegistry()
+    expect(reg.strategiesForSource('pdfs')).toHaveLength(1)
+    expect(reg.strategiesForSource('absent')).toHaveLength(0)
+  })
+
+  it('createNoydb works without derivationStrategies', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-vault-wiring-empty-passphrase-2026',
+    })
+    const vault = await db.openVault('demo')
+    const reg = (vault as any)._getDerivationRegistry()
+    expect(reg.strategiesForSource('any')).toHaveLength(0)
+  })
+
+  it('refuses to open vault with a cyclic derivation graph', async () => {
+    const bad = withDerivation({
+      source: 'a',
+      deterministic: true,
+      outputs: { o: { shape: 'record', collection: 'a' } }, // self-cycle
+      derive: () => ({ o: {} }),
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-vault-wiring-cycle-passphrase-2026',
+      derivationStrategies: [bad],
+    })
+    await expect(db.openVault('demo')).rejects.toBeInstanceOf(DerivationCycleError)
+  })
+})

--- a/packages/hub/__tests__/derivations/with-derivation.test.ts
+++ b/packages/hub/__tests__/derivations/with-derivation.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { withDerivation } from '../../src/derivations/with-derivation.js'
+
+describe('withDerivation factory', () => {
+  it('returns a handle with __noydb_strategy: "derivation"', () => {
+    const h = withDerivation({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: { meta: { shape: 'record', collection: 'pdf-meta' } },
+      derive: (s: { body: string }) => ({ meta: { len: s.body.length } }),
+      lifecycle: 'eager',
+    })
+    expect(h.__noydb_strategy).toBe('derivation')
+    expect(h.spec.source).toBe('pdfs')
+  })
+
+  it('rejects missing source', () => {
+    expect(() =>
+      withDerivation({
+        source: '',
+        deterministic: true,
+        outputs: { o: { shape: 'record', collection: 'x' } },
+        derive: () => ({ o: {} } as any),
+        lifecycle: 'eager',
+      } as any),
+    ).toThrow(/source/i)
+  })
+
+  it('rejects empty outputs map', () => {
+    expect(() =>
+      withDerivation({
+        source: 's',
+        deterministic: true,
+        outputs: {},
+        derive: () => ({} as any),
+        lifecycle: 'eager',
+      } as any),
+    ).toThrow(/outputs/i)
+  })
+
+  it('rejects non-deterministic spec in v1', () => {
+    expect(() =>
+      withDerivation({
+        source: 's',
+        deterministic: false as unknown as true,
+        outputs: { o: { shape: 'record', collection: 'x' } },
+        derive: () => ({ o: {} } as any),
+        lifecycle: 'eager',
+      } as any),
+    ).toThrow(/deterministic/i)
+  })
+})

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -186,6 +186,16 @@
         "default": "./dist/tx/index.cjs"
       }
     },
+    "./derivations": {
+      "import": {
+        "types": "./dist/derivations/index.d.ts",
+        "default": "./dist/derivations/index.js"
+      },
+      "require": {
+        "types": "./dist/derivations/index.d.cts",
+        "default": "./dist/derivations/index.cjs"
+      }
+    },
     "./sync": {
       "import": {
         "types": "./dist/sync/index.d.ts",

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -39,7 +39,7 @@ import type { ReadOnlyVaultFacade } from './guards/types.js'
 import { GuardExecutor } from './guards/executor.js'
 import type { DerivationRegistry } from './derivations/registry.js'
 import { DerivationExecutor } from './derivations/executor.js'
-import { markStale } from './derivations/stale.js'
+import { markStale, resolveStaleOnRead } from './derivations/stale.js'
 
 /** Callback for dirty tracking (sync engine integration). */
 export type OnDirtyCallback = (collection: string, id: string, action: 'put' | 'delete', version: number) => Promise<void>
@@ -872,6 +872,18 @@ export class Collection<T> {
    *          `null` if not found.
    */
   async get(id: string, locale?: LocaleReadOptions): Promise<T | null> {
+    // --- Lazy derivation resolution ---
+    // If this collection is the output of a lazy-mode derivation
+    // strategy, consult the stale map and re-derive on demand before
+    // reading. No-op when nothing is pending — keeps the read fast
+    // path cheap.
+    if (this.derivationSource !== undefined) {
+      const registry = this.derivationSource.registry()
+      if (registry.strategiesProducingOutput(this.name).length > 0) {
+        await resolveStaleOnRead(this.derivationSource, this.name, id)
+      }
+    }
+
     let record: T | null
 
     if (this.lazy && this.lru) {
@@ -1326,7 +1338,7 @@ export class Collection<T> {
           await outputCollection.put(id, out.value)
         }
       } else {
-        await markStale(this.vault, spec, id)
+        await markStale(registry, spec, id)
       }
     }
   }

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1327,9 +1327,9 @@ export class Collection<T> {
           const out = result.outputs[key]
           if (!out) continue
           if (!out.ok) {
-            if (spec.strict) throw out.error
-            // eslint-disable-next-line no-console
-            console.warn(`[derivation] output "${key}" for source "${spec.source}" id="${id}" failed:`, out.error)
+            const err = out.error ?? new Error(`derivation output "${key}" failed`)
+            if (spec.strict) throw err
+            console.warn(`[derivation] output "${key}" for source "${spec.source}" id="${id}" failed:`, err)
             continue
           }
           const outSpec = spec.outputs[key]

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -37,6 +37,9 @@ import { NO_AGGREGATE, type AggregateStrategy } from './aggregate/strategy.js'
 import type { GuardRegistry } from './guards/registry.js'
 import type { ReadOnlyVaultFacade } from './guards/types.js'
 import { GuardExecutor } from './guards/executor.js'
+import type { DerivationRegistry } from './derivations/registry.js'
+import { DerivationExecutor } from './derivations/executor.js'
+import { markStale } from './derivations/stale.js'
 
 /** Callback for dirty tracking (sync engine integration). */
 export type OnDirtyCallback = (collection: string, id: string, action: 'put' | 'delete', version: number) => Promise<void>
@@ -368,6 +371,20 @@ export class Collection<T> {
     | undefined
 
   /**
+   * Vault-internal hook for derivation dispatch. When set,
+   * `Collection.put` consults the registry after the source-write
+   * commits and writes derived outputs through `getCollection(name).put`.
+   * Same structural-interface pattern as `guardSource` to avoid a
+   * circular Vault import.
+   */
+  private readonly derivationSource:
+    | {
+        registry(): DerivationRegistry
+        getCollection(name: string): Collection<Record<string, unknown>>
+      }
+    | undefined
+
+  /**
    * Optional back-reference to the owning compartment's ref
    * enforcer. When present, `Collection.put` calls
    * `refEnforcer.enforceRefsOnPut(name, record)` before the adapter
@@ -656,6 +673,17 @@ export class Collection<T> {
       registry(): GuardRegistry
       readOnlyVault(): ReadOnlyVaultFacade
     } | undefined
+    /**
+     * Optional back-reference to the owning vault's derivation
+     * registry + collection accessor. When present, successful
+     * `put()` dispatches registered derivation strategies for the
+     * source collection. Same structural-interface pattern as
+     * `guardSource` to avoid a circular Vault import.
+     */
+    derivationSource?: {
+      registry(): DerivationRegistry
+      getCollection(name: string): Collection<Record<string, unknown>>
+    } | undefined
   }) {
     this.adapter = opts.adapter
     this.vault = opts.vault
@@ -688,6 +716,7 @@ export class Collection<T> {
     this.onAccess = opts.onAccess
     this.periodGuard = opts.periodGuard
     this.guardSource = opts.guardSource
+    this.derivationSource = opts.derivationSource
 
     // hierarchical-tier wiring
     this.tiers = opts.tiers && opts.tiers.length > 0 ? new Set(opts.tiers) : null
@@ -1141,6 +1170,7 @@ export class Collection<T> {
       await this.onDirty?.(this.name, id, 'put', version)
       this.emitter.emit('change', { vault: this.vault, collection: this.name, id, action: 'put' } satisfies ChangeEvent)
       await this.onAccess?.('put', id)
+      await this.dispatchDerivations(id, record, version)
       return
     }
     // ─── End CRDT mode ──────────────────────────────────────────────────
@@ -1249,6 +1279,56 @@ export class Collection<T> {
     } satisfies ChangeEvent)
 
     await this.onAccess?.('put', id)
+
+    // Derivation dispatch — AFTER store + ledger + emitter commit so a
+    // failed source-write never produces orphan derived outputs. The
+    // recursive `put` into output collections re-enters this pipeline
+    // (encrypt + ledger + emit) intentionally; cycle detection at vault
+    // open is the primary defense against infinite recursion.
+    await this.dispatchDerivations(id, record, version)
+  }
+
+  /**
+   * Fire registered derivation strategies for this source collection.
+   * Eager mode runs `derive` inline and writes each output via the
+   * sibling `Collection.put`; lazy mode marks dependent outputs stale
+   * (D11 stub today). Errors in non-strict mode are logged and
+   * skipped; strict mode propagates the first failing output's error.
+   *
+   * Skips entirely when the record being written is itself a derived
+   * output (carries `_derivedFrom`) — defensive guard against missed
+   * cycle detection.
+   */
+  private async dispatchDerivations(id: string, record: T, version: number): Promise<void> {
+    if (this.derivationSource === undefined) return
+    const incoming = record as unknown as Record<string, unknown>
+    if (incoming && typeof incoming === 'object' && '_derivedFrom' in incoming) return
+    const registry = this.derivationSource.registry()
+    const strategies = registry.strategiesForSource(this.name)
+    if (strategies.length === 0) return
+    for (const { spec, strategyHash } of strategies) {
+      const mode = typeof spec.lifecycle === 'string' ? spec.lifecycle : spec.lifecycle.mode
+      if (mode === 'eager') {
+        const sourceWithId = { ...incoming, id } as Record<string, unknown> & { id: string }
+        const result = await DerivationExecutor.run(spec, sourceWithId, version, strategyHash)
+        for (const key of Object.keys(spec.outputs)) {
+          const out = result.outputs[key]
+          if (!out) continue
+          if (!out.ok) {
+            if (spec.strict) throw out.error
+            // eslint-disable-next-line no-console
+            console.warn(`[derivation] output "${key}" for source "${spec.source}" id="${id}" failed:`, out.error)
+            continue
+          }
+          const outSpec = spec.outputs[key]
+          if (!outSpec) continue
+          const outputCollection = this.derivationSource.getCollection(outSpec.collection)
+          await outputCollection.put(id, out.value)
+        }
+      } else {
+        await markStale(this.vault, spec, id)
+      }
+    }
   }
 
   /** Delete a record by ID. */

--- a/packages/hub/src/derivations/executor.ts
+++ b/packages/hub/src/derivations/executor.ts
@@ -1,0 +1,75 @@
+import { DerivationOutputShapeError } from '../errors.js'
+import type { DerivationStrategy, DerivedFromMeta } from './types.js'
+
+export interface RunResult {
+  outputs: Record<string, OutputResult>
+  failed: boolean
+}
+
+export interface OutputResult {
+  value: Record<string, unknown>
+  ok: boolean
+  error?: Error
+}
+
+/**
+ * Stateless functions that execute a derivation strategy. Persistence
+ * (encrypt + store.put) is the caller's job — typically
+ * `DerivationRegistry.onSourceWrite` which iterates run() results and
+ * writes each output via `Collection.put`.
+ */
+export const DerivationExecutor = {
+  /**
+   * Run `derive` once, validate output shape against the spec, stamp
+   * `_derivedFrom` onto every output. Returns per-output success or
+   * failure; throws only for shape mismatches (a contract violation).
+   */
+  async run<
+    TSource extends Record<string, unknown>,
+    TOutputs extends Record<string, Record<string, unknown>>,
+  >(
+    strategy: DerivationStrategy<TSource, TOutputs>,
+    source: TSource & { id: string },
+    sourceVersion: number,
+    strategyHash: string,
+  ): Promise<RunResult> {
+    const outputs: Record<string, OutputResult> = {}
+    let derived: Partial<TOutputs>
+
+    try {
+      derived = await Promise.resolve(strategy.derive(source as TSource))
+    } catch (err) {
+      for (const key of Object.keys(strategy.outputs)) {
+        outputs[key] = {
+          value: {},
+          ok: false,
+          error: err instanceof Error ? err : new Error(String(err)),
+        }
+      }
+      return { outputs, failed: true }
+    }
+
+    const meta: DerivedFromMeta = {
+      source: strategy.source,
+      sourceId: source.id,
+      sourceVersion,
+      derivedAt: new Date().toISOString(),
+      strategyHash,
+    }
+
+    for (const key of Object.keys(strategy.outputs)) {
+      const value = (derived as Record<string, unknown>)[key]
+      if (value === undefined || value === null || typeof value !== 'object') {
+        throw new DerivationOutputShapeError(
+          key,
+          `expected object, got ${value === undefined ? 'undefined' : typeof value}`,
+        )
+      }
+      outputs[key] = {
+        value: { ...(value as Record<string, unknown>), _derivedFrom: meta },
+        ok: true,
+      }
+    }
+    return { outputs, failed: false }
+  },
+}

--- a/packages/hub/src/derivations/index.ts
+++ b/packages/hub/src/derivations/index.ts
@@ -7,3 +7,13 @@ export type {
   DerivedFromMeta,
   OutputSpec,
 } from './types.js'
+
+// Re-export error classes so `@noy-db/hub/derivations` is self-contained.
+// Splitting: true in tsup.config.ts deduplicates the class definitions
+// across subpath boundaries, so `instanceof` works.
+export {
+  DerivationCycleError,
+  DerivationDepthError,
+  DerivationOutputUnknownError,
+  DerivationOutputShapeError,
+} from '../errors.js'

--- a/packages/hub/src/derivations/index.ts
+++ b/packages/hub/src/derivations/index.ts
@@ -1,0 +1,9 @@
+export { withDerivation } from './with-derivation.js'
+export { DerivationRegistry } from './registry.js'
+export { DerivationExecutor } from './executor.js'
+export type {
+  DerivationStrategy,
+  DerivationStrategyHandle,
+  DerivedFromMeta,
+  OutputSpec,
+} from './types.js'

--- a/packages/hub/src/derivations/registry.ts
+++ b/packages/hub/src/derivations/registry.ts
@@ -1,0 +1,82 @@
+import { DerivationCycleError } from '../errors.js'
+import { computeStrategyHash } from './strategy-hash.js'
+import type { DerivationStrategy } from './types.js'
+
+interface RegisteredStrategy {
+  // Type-erased to allow the registry to hold heterogeneous strategies.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  spec: DerivationStrategy<any, any>
+  strategyHash: string
+}
+
+/**
+ * Vault-internal registry of derivation strategies. Owned by `Vault`;
+ * not exported.
+ *
+ * @internal
+ */
+export class DerivationRegistry {
+  private readonly _bySource = new Map<string, RegisteredStrategy[]>()
+  private readonly _byOutput = new Map<string, RegisteredStrategy[]>()
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async register(spec: DerivationStrategy<any, any>): Promise<void> {
+    const outputKeys = Object.keys(spec.outputs)
+    const strategyHash = await computeStrategyHash(spec.source, outputKeys, spec.derive)
+    const reg: RegisteredStrategy = { spec, strategyHash }
+
+    const fromSource = this._bySource.get(spec.source)
+    if (fromSource) fromSource.push(reg)
+    else this._bySource.set(spec.source, [reg])
+
+    for (const key of outputKeys) {
+      const output = spec.outputs[key]
+      if (!output) continue
+      const outputCollection = output.collection
+      const arr = this._byOutput.get(outputCollection)
+      if (arr) arr.push(reg)
+      else this._byOutput.set(outputCollection, [reg])
+    }
+  }
+
+  strategiesForSource(source: string): ReadonlyArray<RegisteredStrategy> {
+    return this._bySource.get(source) ?? []
+  }
+
+  strategiesProducingOutput(collection: string): ReadonlyArray<RegisteredStrategy> {
+    return this._byOutput.get(collection) ?? []
+  }
+
+  /**
+   * Cycle detection over the source → output → … graph. Call after all
+   * `register()` calls complete (i.e. at vault open). Throws
+   * `DerivationCycleError` on the first cycle found.
+   */
+  validate(): void {
+    const visited = new Set<string>()
+    const stack: string[] = []
+
+    const visit = (node: string): void => {
+      if (stack.includes(node)) {
+        const cycle = stack.slice(stack.indexOf(node)).concat(node)
+        throw new DerivationCycleError(cycle)
+      }
+      if (visited.has(node)) return
+      stack.push(node)
+      const strategies = this._bySource.get(node)
+      if (strategies) {
+        for (const s of strategies) {
+          for (const key of Object.keys(s.spec.outputs)) {
+            const output = s.spec.outputs[key]
+            if (!output) continue
+            visit(output.collection)
+          }
+        }
+      }
+      stack.pop()
+      visited.add(node)
+    }
+
+    for (const src of this._bySource.keys()) visit(src)
+  }
+}

--- a/packages/hub/src/derivations/stale.ts
+++ b/packages/hub/src/derivations/stale.ts
@@ -1,0 +1,21 @@
+import type { DerivationStrategy } from './types.js'
+
+/**
+ * Mark every output id stale for this source-id. v1: in-memory only;
+ * Task D11 (lazy lifecycle) fills this in.
+ *
+ * Typed structurally on the vault parameter to avoid a circular
+ * `vault.ts → derivations → vault.ts` import. The caller (Collection.put)
+ * passes `this.vault` (a string) or a vault-like accessor — the stub
+ * ignores both arguments today.
+ *
+ * @internal
+ */
+export async function markStale(
+  _vault: unknown,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _strategy: DerivationStrategy<any, any>,
+  _sourceId: string,
+): Promise<void> {
+  // Stub — filled in by D11 (lazy lifecycle).
+}

--- a/packages/hub/src/derivations/stale.ts
+++ b/packages/hub/src/derivations/stale.ts
@@ -1,21 +1,119 @@
+import type { Collection } from '../collection.js'
+import type { DerivationRegistry } from './registry.js'
+import { DerivationExecutor } from './executor.js'
 import type { DerivationStrategy } from './types.js'
 
 /**
- * Mark every output id stale for this source-id. v1: in-memory only;
- * Task D11 (lazy lifecycle) fills this in.
+ * Accessor shape passed through from the owning Vault. Provides the
+ * registry (used to look up strategies and as the WeakMap key) and a
+ * resolver from collection name to the live `Collection` instance.
+ * Same shape as `Collection.derivationSource` so callers can pass it
+ * through directly.
+ */
+export interface DerivationStaleAccessor {
+  registry(): DerivationRegistry
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getCollection(name: string): Collection<any>
+}
+
+/**
+ * In-memory stale map keyed by `DerivationRegistry` instance (stable
+ * per vault). Maps `${source}/${sourceId}` → set of pending strategies.
  *
- * Typed structurally on the vault parameter to avoid a circular
- * `vault.ts → derivations → vault.ts` import. The caller (Collection.put)
- * passes `this.vault` (a string) or a vault-like accessor — the stub
- * ignores both arguments today.
+ * Persistence across vault close is NOT implemented in v1 (concern
+ * flagged in the dim14 spec). On vault re-open, derived records'
+ * `_derivedFrom.strategyHash` will still match the registered
+ * strategies' hash, so an unset stale flag is interpreted as "fresh."
+ * `vault.deriveAll()` (Task D13) is the explicit recompute escape
+ * hatch.
  *
  * @internal
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const _staleByRegistry = new WeakMap<DerivationRegistry, Map<string, Set<DerivationStrategy<any, any>>>>()
+
+const keyFor = (source: string, sourceId: string): string => `${source}/${sourceId}`
+
+/** Mark every output of (strategy, sourceId) as stale. */
 export async function markStale(
-  _vault: unknown,
+  registry: DerivationRegistry,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  _strategy: DerivationStrategy<any, any>,
-  _sourceId: string,
+  strategy: DerivationStrategy<any, any>,
+  sourceId: string,
 ): Promise<void> {
-  // Stub — filled in by D11 (lazy lifecycle).
+  let map = _staleByRegistry.get(registry)
+  if (!map) {
+    map = new Map()
+    _staleByRegistry.set(registry, map)
+  }
+  const k = keyFor(strategy.source, sourceId)
+  let set = map.get(k)
+  if (!set) {
+    set = new Set()
+    map.set(k, set)
+  }
+  set.add(strategy)
+}
+
+/**
+ * Called from `Collection.get` on lazy-mode output collections. If the
+ * id has a pending stale flag for any strategy producing this output
+ * collection, re-derive before returning the record. No-op when there
+ * is no pending work — keeps the read fast path negligible.
+ */
+export async function resolveStaleOnRead(
+  accessor: DerivationStaleAccessor,
+  outputCollection: string,
+  id: string,
+): Promise<void> {
+  const registry = accessor.registry()
+  const producers = registry.strategiesProducingOutput(outputCollection)
+  if (producers.length === 0) return
+
+  const map = _staleByRegistry.get(registry)
+  if (!map) return
+
+  for (const { spec, strategyHash } of producers) {
+    const k = keyFor(spec.source, id)
+    const pending = map.get(k)
+    if (!pending || !pending.has(spec)) continue
+
+    // Read the source record from the source collection and re-derive.
+    // We use the same getCollection accessor that eager dispatch uses
+    // — it returns the live `Collection<any>` instance with full
+    // crypto / keyring wiring.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sourceColl = accessor.getCollection(spec.source) as Collection<any>
+    const source = await sourceColl.get(id)
+    if (!source) {
+      pending.delete(spec)
+      continue
+    }
+    const sourceWithId = { ...(source as Record<string, unknown>), id } as Record<string, unknown> & { id: string }
+    // sourceVersion: not tracked in v1 stale map; pass 0 — matches the
+    // forthcoming v0 semantics, `_derivedFrom.sourceVersion` is
+    // informational, not load-bearing for correctness.
+    const result = await DerivationExecutor.run(spec, sourceWithId, 0, strategyHash)
+    for (const key of Object.keys(spec.outputs)) {
+      const out = result.outputs[key]
+      if (!out) continue
+      if (!out.ok) {
+        if (spec.strict) {
+          // Leave the stale flag set so a future read retries.
+          throw out.error
+        }
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[derivation] lazy output "${key}" for source "${spec.source}" id="${id}" failed:`,
+          out.error,
+        )
+        continue
+      }
+      const outSpec = spec.outputs[key]
+      if (!outSpec) continue
+      const outputColl = accessor.getCollection(outSpec.collection)
+      await outputColl.put(id, out.value)
+    }
+    pending.delete(spec)
+  }
 }

--- a/packages/hub/src/derivations/stale.ts
+++ b/packages/hub/src/derivations/stale.ts
@@ -82,8 +82,7 @@ export async function resolveStaleOnRead(
     // We use the same getCollection accessor that eager dispatch uses
     // — it returns the live `Collection<any>` instance with full
     // crypto / keyring wiring.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const sourceColl = accessor.getCollection(spec.source) as Collection<any>
+    const sourceColl = accessor.getCollection(spec.source)
     const source = await sourceColl.get(id)
     if (!source) {
       pending.delete(spec)
@@ -98,14 +97,14 @@ export async function resolveStaleOnRead(
       const out = result.outputs[key]
       if (!out) continue
       if (!out.ok) {
+        const err = out.error ?? new Error(`derivation output "${key}" failed`)
         if (spec.strict) {
           // Leave the stale flag set so a future read retries.
-          throw out.error
+          throw err
         }
-        // eslint-disable-next-line no-console
         console.warn(
           `[derivation] lazy output "${key}" for source "${spec.source}" id="${id}" failed:`,
-          out.error,
+          err,
         )
         continue
       }

--- a/packages/hub/src/derivations/strategy-hash.ts
+++ b/packages/hub/src/derivations/strategy-hash.ts
@@ -1,0 +1,24 @@
+/**
+ * Deterministic hash of a derivation strategy's "shape": source
+ * collection, output keys, derive function source. Used to detect
+ * strategy drift: a record whose `_derivedFrom.strategyHash` doesn't
+ * match the current strategy is considered stale.
+ *
+ * Web Crypto SHA-256 — no extra deps.
+ */
+export async function computeStrategyHash(
+  source: string,
+  outputKeys: readonly string[],
+  derive: (...args: any[]) => any,
+): Promise<string> {
+  const canonical = JSON.stringify({
+    source,
+    outputs: [...outputKeys].sort(),
+    derive: derive.toString(),
+  })
+  const bytes = new TextEncoder().encode(canonical)
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  return Array.from(new Uint8Array(digest))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}

--- a/packages/hub/src/derivations/strategy-hash.ts
+++ b/packages/hub/src/derivations/strategy-hash.ts
@@ -9,6 +9,7 @@
 export async function computeStrategyHash(
   source: string,
   outputKeys: readonly string[],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   derive: (...args: any[]) => any,
 ): Promise<string> {
   const canonical = JSON.stringify({

--- a/packages/hub/src/derivations/types.ts
+++ b/packages/hub/src/derivations/types.ts
@@ -68,5 +68,6 @@ export interface DerivationStrategy<
 /** Returned by `withDerivation()` and consumed by `createNoydb`. */
 export interface DerivationStrategyHandle {
   readonly __noydb_strategy: 'derivation'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly spec: DerivationStrategy<any, any>
 }

--- a/packages/hub/src/derivations/types.ts
+++ b/packages/hub/src/derivations/types.ts
@@ -1,0 +1,72 @@
+/**
+ * Metadata that travels inside the `_data` payload of a derived record.
+ * Lives in encrypted payload, not in the unencrypted envelope — the
+ * storage backend cannot infer the derivation graph from listing.
+ */
+export interface DerivedFromMeta {
+  /** Source collection name. */
+  readonly source: string
+  /** Source record id. */
+  readonly sourceId: string
+  /** `_v` of the source at derivation time. */
+  readonly sourceVersion: number
+  /** ISO timestamp when this output was derived. */
+  readonly derivedAt: string
+  /**
+   * SHA-256 of (source + outputs map keys + derive function source).
+   * Changes when the strategy changes → forces `vault.deriveAll` to
+   * recompute on next visit.
+   */
+  readonly strategyHash: string
+}
+
+/** Per-output declaration. v1: only `'record'` shape. */
+export interface OutputSpec {
+  shape: 'record'
+  collection: string
+}
+
+/**
+ * Registration shape passed to `withDerivation()`.
+ *
+ * @typeParam TSource - the source record type
+ * @typeParam TOutputs - map of output-key → output record type
+ */
+export interface DerivationStrategy<
+  TSource extends Record<string, unknown>,
+  TOutputs extends Record<string, Record<string, unknown>>,
+> {
+  /** Source collection name. */
+  source: string
+  /** v1: only deterministic derivations supported. */
+  deterministic: true
+  /**
+   * Output declarations keyed by name. The `derive` function's return
+   * value must have the same keys.
+   */
+  outputs: { [K in keyof TOutputs]: OutputSpec }
+  /**
+   * Pure function from source to outputs. Runs on plaintext, after DEK
+   * unwrap. Returns a map of named outputs. Each output is encrypted +
+   * stored via the existing `Collection.put` pipeline.
+   */
+  derive: (source: TSource) => Promise<TOutputs> | TOutputs
+  /**
+   * `'eager'` runs `derive` synchronously inside the source-write
+   * transaction. `'lazy'` marks outputs stale on source-change and
+   * derives on first read.
+   */
+  lifecycle: 'eager' | 'lazy' | { mode: 'eager' | 'lazy'; maxDepth?: number }
+  /**
+   * `true` = any output failure rolls back the source write (only with
+   * `withTransactions`). `false` = isolate per-output failure, log,
+   * continue. Default `false`.
+   */
+  strict?: boolean
+}
+
+/** Returned by `withDerivation()` and consumed by `createNoydb`. */
+export interface DerivationStrategyHandle {
+  readonly __noydb_strategy: 'derivation'
+  readonly spec: DerivationStrategy<any, any>
+}

--- a/packages/hub/src/derivations/with-derivation.ts
+++ b/packages/hub/src/derivations/with-derivation.ts
@@ -1,0 +1,32 @@
+import { ValidationError } from '../errors.js'
+import type { DerivationStrategy, DerivationStrategyHandle } from './types.js'
+
+/**
+ * Register a deterministic derivation: one source collection → one or
+ * more typed outputs, computed by the user's `derive` function on
+ * plaintext after DEK unwrap. Outputs are encrypted with the same DEK
+ * as the source and written via the standard `Collection.put` path.
+ *
+ * See docs/superpowers/specs/2026-05-01-dim14-derivation-v1-design.md.
+ */
+export function withDerivation<
+  TSource extends Record<string, unknown>,
+  TOutputs extends Record<string, Record<string, unknown>>,
+>(spec: DerivationStrategy<TSource, TOutputs>): DerivationStrategyHandle {
+  if (!spec.source || spec.source.length === 0) {
+    throw new ValidationError('withDerivation: source collection name is required')
+  }
+  if (!spec.outputs || Object.keys(spec.outputs).length === 0) {
+    throw new ValidationError('withDerivation: outputs map must declare at least one output')
+  }
+  if (spec.deterministic !== true) {
+    throw new ValidationError('withDerivation: v1 only supports deterministic derivations')
+  }
+  if (typeof spec.derive !== 'function') {
+    throw new ValidationError('withDerivation: derive must be a function')
+  }
+  return {
+    __noydb_strategy: 'derivation',
+    spec: spec as DerivationStrategy<any, any>,
+  }
+}

--- a/packages/hub/src/derivations/with-derivation.ts
+++ b/packages/hub/src/derivations/with-derivation.ts
@@ -27,6 +27,7 @@ export function withDerivation<
   }
   return {
     __noydb_strategy: 'derivation',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     spec: spec as DerivationStrategy<any, any>,
   }
 }

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -1332,3 +1332,79 @@ export class PathEscapeError extends NoydbError {
     this.targetDir = opts.targetDir
   }
 }
+
+// ─── Derivation Errors ──────────────────────────────
+
+/**
+ * Thrown at vault open if the derivation graph contains a cycle.
+ * `path` is the offending chain (e.g. `['a', 'b', 'c', 'a']`).
+ */
+export class DerivationCycleError extends NoydbError {
+  readonly path: readonly string[]
+
+  constructor(path: readonly string[]) {
+    super(
+      'DERIVATION_CYCLE',
+      `Derivation graph contains a cycle: ${path.join(' → ')}. ` +
+        `Refusing to open vault — break the cycle before retrying.`,
+    )
+    this.name = 'DerivationCycleError'
+    this.path = path
+  }
+}
+
+/**
+ * Thrown when a cascade of source → output → source → … exceeds the
+ * configured `maxDepth` (default 5).
+ */
+export class DerivationDepthError extends NoydbError {
+  readonly limit: number
+  readonly attempted: number
+
+  constructor(limit: number, attempted: number) {
+    super(
+      'DERIVATION_DEPTH',
+      `Derivation cascade exceeded max depth ${limit} (attempted ${attempted}). ` +
+        `Pass lifecycle: { maxDepth: N } to raise the limit if intentional.`,
+    )
+    this.name = 'DerivationDepthError'
+    this.limit = limit
+    this.attempted = attempted
+  }
+}
+
+/**
+ * Thrown at registration if a `withDerivation` strategy references an
+ * output `collection` that isn't otherwise declared (no schema, no use
+ * elsewhere). Surfacing this early catches typos in collection names.
+ */
+export class DerivationOutputUnknownError extends NoydbError {
+  readonly collection: string
+
+  constructor(collection: string) {
+    super(
+      'DERIVATION_OUTPUT_UNKNOWN',
+      `Derivation output collection "${collection}" is not declared on the vault. ` +
+        `Register the collection (e.g. via schema) before registering a derivation that writes to it.`,
+    )
+    this.name = 'DerivationOutputUnknownError'
+    this.collection = collection
+  }
+}
+
+/**
+ * Thrown when the user's `derive` function returns a value that doesn't
+ * match the declared output spec (e.g. wrong shape, wrong key set).
+ */
+export class DerivationOutputShapeError extends NoydbError {
+  readonly outputKey: string
+
+  constructor(outputKey: string, detail: string) {
+    super(
+      'DERIVATION_OUTPUT_SHAPE',
+      `Derivation output "${outputKey}" has invalid shape: ${detail}.`,
+    )
+    this.name = 'DerivationOutputShapeError'
+    this.outputKey = outputKey
+  }
+}

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -472,6 +472,21 @@ export type {
   GuardChange,
 } from './guards/index.js'
 
+// Derivations (Dim 14) — see docs/superpowers/specs/2026-05-01-dim14-derivation-v1-design.md
+export { withDerivation } from './derivations/index.js'
+export type {
+  DerivationStrategy,
+  DerivationStrategyHandle,
+  DerivedFromMeta,
+  OutputSpec,
+} from './derivations/index.js'
+export {
+  DerivationCycleError,
+  DerivationDepthError,
+  DerivationOutputUnknownError,
+  DerivationOutputShapeError,
+} from './errors.js'
+
 // Accounting periods
 export { PERIODS_COLLECTION } from './periods/index.js'
 export type {

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -384,6 +384,7 @@ export class Noydb {
             }
           : undefined,
     })
+    await comp._initDerivations(this.options.derivationStrategies ?? [])
     this.vaultCache.set(name, comp)
     return comp
   }

--- a/packages/hub/src/tx/transaction.ts
+++ b/packages/hub/src/tx/transaction.ts
@@ -310,13 +310,20 @@ export async function runTransaction<T>(
       const coll = db.vault(op.vaultName).collection(op.collectionName)
       const key = keyOf(op)
       const prior = priorEnvelopes.get(key) ?? null
+      // Record the revert plan BEFORE the call so a mid-`coll.put` throw
+      // (e.g. strict-mode derivation failure firing after `store.put`
+      // has already committed the envelope) still has its source write
+      // reverted. `revertExecuted` is best-effort: putting prior back is
+      // idempotent when the failing op never actually wrote, and
+      // `_invalidateCacheEntry` is a no-op when the collection isn't
+      // hydrated.
+      executed.push({ op, priorEnvelope: prior })
       if (op.type === 'put') {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         await coll.put(op.id, op.record as any)
       } else {
         await coll.delete(op.id)
       }
-      executed.push({ op, priorEnvelope: prior })
     }
   } catch (err) {
     // Phase 3 — best-effort revert. See helper docstring.

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -38,6 +38,7 @@ import type { I18nStrategy } from './i18n/strategy.js'
 import type { SessionStrategy } from './session/strategy.js'
 import type { SyncStrategy } from './team/sync-strategy.js'
 import type { GuardStrategyHandle } from './guards/types.js'
+import type { DerivationStrategyHandle } from './derivations/types.js'
 import type { UnlockedKeyring } from './team/keyring.js'
 import type { VaultPolicy } from './policy/types.js'
 import type { PublicEnvelopeSchema } from './meta/public-envelope/types.js'
@@ -1747,6 +1748,14 @@ export interface NoydbOptions {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   readonly guardStrategies?: ReadonlyArray<GuardStrategyHandle<any>>
+  /**
+   * Optional derivation strategies — source-to-output projections that
+   * fire on `collection.put()`. Each handle is the output of
+   * `withDerivation()` from `@noy-db/hub/derivations`. The vault
+   * validates the derivation graph for cycles on `openVault`; a cyclic
+   * graph throws `DerivationCycleError`.
+   */
+  readonly derivationStrategies?: ReadonlyArray<DerivationStrategyHandle>
   /** Optional remote store(s) for sync. Accepts a single store, a SyncTarget, or an array. */
   readonly sync?: NoydbStore | SyncTarget | SyncTarget[]
   /** User identifier. */

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -541,6 +541,11 @@ export class Vault {
             return this.guardReadOnlyFacade
           },
         },
+        derivationSource: {
+          registry: () => this.derivationRegistry,
+          getCollection: (name: string) =>
+            this.collection(name) as unknown as Collection<Record<string, unknown>>,
+        },
       }
       if (options?.indexes !== undefined) collOpts.indexes = options.indexes
       if (options?.reconcileOnOpen !== undefined) collOpts.reconcileOnOpen = options.reconcileOnOpen

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -67,6 +67,8 @@ import { NO_SYNC, type SyncStrategy } from './team/sync-strategy.js'
 import { GuardRegistry } from './guards/registry.js'
 import type { GuardStrategyHandle } from './guards/types.js'
 import { ReadOnlyVaultFacade } from './guards/read-only-facade.js'
+import { DerivationRegistry } from './derivations/registry.js'
+import type { DerivationStrategyHandle } from './derivations/types.js'
 import type { LocaleReadOptions, ConflictPolicy } from './types.js'
 import type { CrdtMode } from './crdt/crdt.js'
 import { ReservedCollectionNameError } from './errors.js'
@@ -136,6 +138,7 @@ export class Vault {
   private readonly i18nStrategy: I18nStrategy
   private readonly syncStrategy: SyncStrategy
   private readonly guardRegistry: GuardRegistry
+  private readonly derivationRegistry: DerivationRegistry
   /**
    * Cached read-only facade handed to guard callbacks via `ctx.vault`.
    * Allocated lazily on first guard invocation to avoid the cost in
@@ -359,6 +362,7 @@ export class Vault {
         this.guardRegistry.register(handle.spec)
       }
     }
+    this.derivationRegistry = new DerivationRegistry()
     this.historyConfig = opts.historyConfig ?? { enabled: true }
     this.reloadKeyring = opts.reloadKeyring
     this.locale = opts.locale
@@ -1306,6 +1310,25 @@ export class Vault {
   /** @internal — Collection.put calls into this. */
   _getGuardRegistry(): GuardRegistry {
     return this.guardRegistry
+  }
+
+  /**
+   * @internal — called by `Noydb.openVault` after construction.
+   * Registers derivation strategies (async because `strategyHash`
+   * computation goes through `crypto.subtle.digest`) and validates
+   * the derivation graph for cycles. Throws `DerivationCycleError`
+   * if a cycle is detected.
+   */
+  async _initDerivations(handles: ReadonlyArray<DerivationStrategyHandle>): Promise<void> {
+    for (const h of handles) {
+      await this.derivationRegistry.register(h.spec)
+    }
+    this.derivationRegistry.validate()
+  }
+
+  /** @internal — consumed by `Collection.put` at write-time. */
+  _getDerivationRegistry(): DerivationRegistry {
+    return this.derivationRegistry
   }
 
   /**

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -1359,7 +1359,7 @@ export class Vault {
       const id = (record as { id?: unknown }).id
       if (typeof id !== 'string') continue
       for (const { spec, strategyHash } of strategies) {
-        const sourceWithId = { ...(record as Record<string, unknown>), id }
+        const sourceWithId = { ...record, id }
         const result = await DerivationExecutor.run(spec, sourceWithId, 0, strategyHash)
         let anyFailed = false
         for (const key of Object.keys(spec.outputs)) {
@@ -1367,7 +1367,7 @@ export class Vault {
           if (!out || !out.ok) { anyFailed = true; continue }
           const outSpec = spec.outputs[key]
           if (!outSpec) continue
-          await this.collection(outSpec.collection).put(id, out.value as Record<string, unknown>)
+          await this.collection(outSpec.collection).put(id, out.value)
         }
         if (anyFailed) failed++
         else derived++

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -1337,6 +1337,46 @@ export class Vault {
   }
 
   /**
+   * Re-derive every record in the named source collection. Useful
+   * after a strategy change to bring previously-derived records
+   * up-to-date.
+   *
+   * Sequential in v1; parallelisation deferred to v2.
+   */
+  async deriveAll(sourceCollection: string): Promise<{ derived: number; failed: number }> {
+    const registry = this._getDerivationRegistry()
+    const strategies = registry.strategiesForSource(sourceCollection)
+    if (strategies.length === 0) return { derived: 0, failed: 0 }
+
+    const { DerivationExecutor } = await import('./derivations/executor.js')
+
+    const sourceColl = this.collection<Record<string, unknown>>(sourceCollection)
+    const records = await sourceColl.list()
+    let derived = 0
+    let failed = 0
+    for (const record of records) {
+      if (typeof record !== 'object' || record === null) continue
+      const id = (record as { id?: unknown }).id
+      if (typeof id !== 'string') continue
+      for (const { spec, strategyHash } of strategies) {
+        const sourceWithId = { ...(record as Record<string, unknown>), id }
+        const result = await DerivationExecutor.run(spec, sourceWithId, 0, strategyHash)
+        let anyFailed = false
+        for (const key of Object.keys(spec.outputs)) {
+          const out = result.outputs[key]
+          if (!out || !out.ok) { anyFailed = true; continue }
+          const outSpec = spec.outputs[key]
+          if (!outSpec) continue
+          await this.collection(outSpec.collection).put(id, out.value as Record<string, unknown>)
+        }
+        if (anyFailed) failed++
+        else derived++
+      }
+    }
+    return { derived, failed }
+  }
+
+  /**
    * @internal — exposed for `runTransaction({ amendment: true })` so
    * the amendment invariant runner can pass the SAME read-only vault
    * facade that the per-record `Collection.put` guard hook uses

--- a/packages/hub/tsup.config.ts
+++ b/packages/hub/tsup.config.ts
@@ -40,6 +40,7 @@ const ENTRIES = {
   'guards/index': 'src/guards/index.ts',
   'shadow/index': 'src/shadow/index.ts',
   'tx/index': 'src/tx/index.ts',
+  'derivations/index': 'src/derivations/index.ts',
   'sync/index': 'src/sync/index.ts',
   'util/index': 'src/util/index.ts',
 }

--- a/showcases/src/80-with-derivation.showcase.test.ts
+++ b/showcases/src/80-with-derivation.showcase.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Showcase 80 — withDerivation (Dim 14)
+ *
+ * What you'll learn
+ * ─────────────────
+ * `withDerivation` declares a deterministic, plaintext-only transform
+ * from one source collection into N output collections. The hub runs
+ * `derive` AFTER DEK unwrap, stamps `_derivedFrom` onto every output,
+ * and encrypts the outputs with the same DEK as the source — the store
+ * sees only ciphertext on both sides.
+ *
+ * This showcase walks through the five mechanics:
+ *
+ *   1. **Eager mode** — source-write triggers derive inline; outputs
+ *      land in their declared collections in the same call.
+ *   2. **Re-derive on update** — putting the source again recomputes
+ *      every output (deterministic = the only stable contract).
+ *   3. **`_derivedFrom` stamp** — each output carries an immutable
+ *      back-pointer to `{ source, sourceId, sourceVersion, derivedAt,
+ *      strategyHash }`. Lives inside the encrypted payload, so the
+ *      derivation graph is not visible to the storage backend.
+ *   4. **`vault.deriveAll`** — bulk recompute escape hatch for when a
+ *      strategy changes or a source collection is imported.
+ *   5. **Strict-mode rollback** — `strict: true` + `withTransactions`
+ *      causes a failing `derive` to roll back the source write. The
+ *      source is gone, the broken output never landed.
+ *
+ * Why it matters
+ * ──────────────
+ * A regulated-domain consumer (accounting firm) ingests opaque source
+ * documents (PDFs, scans) and needs query-friendly projections (text,
+ * page count, OCR result) without ever exposing plaintext to the
+ * storage backend. Derivations are the mechanism; the projection
+ * policy lives in product code. The hub guarantees the crypto and the
+ * lifecycle; the consumer guarantees determinism.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 00 (basics) + 20 (transactions).
+ *
+ * What to read next
+ * ─────────────────
+ *   - docs/superpowers/specs/2026-05-01-dim14-derivation-v1-design.md
+ *   - docs/subsystems/derivations.md
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → derivations
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withDerivation } from '@noy-db/hub'
+import { withTransactions } from '@noy-db/hub/tx'
+import { memory } from '@noy-db/to-memory'
+
+interface Pdf extends Record<string, unknown> {
+  id: string
+  filename: string
+  body: string
+}
+
+interface PdfMeta extends Record<string, unknown> {
+  len: number
+  pages: number
+  filename: string
+  _derivedFrom?: unknown
+}
+
+interface PdfText extends Record<string, unknown> {
+  content: string
+  _derivedFrom?: unknown
+}
+
+const pdfDerivation = withDerivation<Pdf, { meta: PdfMeta; text: PdfText }>({
+  source: 'pdfs',
+  deterministic: true,
+  outputs: {
+    meta: { shape: 'record', collection: 'pdf-meta' },
+    text: { shape: 'record', collection: 'pdf-text' },
+  },
+  derive: (pdf) => ({
+    meta: {
+      len: pdf.body.length,
+      pages: Math.ceil(pdf.body.length / 1000),
+      filename: pdf.filename,
+    },
+    text: { content: pdf.body },
+  }),
+  lifecycle: 'eager',
+})
+
+async function open(passphrase: string) {
+  const db = await createNoydb({
+    store: memory(),
+    user: 'alice',
+    secret: passphrase,
+    derivationStrategies: [pdfDerivation],
+    txStrategy: withTransactions(),
+  })
+  const vault = await db.openVault('library')
+  return { db, vault }
+}
+
+describe('Showcase 80 — withDerivation', () => {
+  it('writes derived outputs after source write (eager)', async () => {
+    const { vault } = await open('showcase-80-eager-passphrase-2026')
+    await vault.collection<Pdf>('pdfs').put('p1', {
+      id: 'p1',
+      filename: 'a.pdf',
+      body: 'hello world',
+    })
+    const meta = await vault.collection<PdfMeta>('pdf-meta').get('p1')
+    const text = await vault.collection<PdfText>('pdf-text').get('p1')
+    expect(meta?.len).toBe('hello world'.length)
+    expect(meta?.filename).toBe('a.pdf')
+    expect(text?.content).toBe('hello world')
+  })
+
+  it('re-derives on source update', async () => {
+    const { vault } = await open('showcase-80-update-passphrase-2026')
+    await vault.collection<Pdf>('pdfs').put('p1', {
+      id: 'p1',
+      filename: 'a.pdf',
+      body: 'first',
+    })
+    await vault.collection<Pdf>('pdfs').put('p1', {
+      id: 'p1',
+      filename: 'a.pdf',
+      body: 'second-longer',
+    })
+    const meta = await vault.collection<PdfMeta>('pdf-meta').get('p1')
+    expect(meta?.len).toBe('second-longer'.length)
+  })
+
+  it('stamps _derivedFrom onto every output', async () => {
+    const { vault } = await open('showcase-80-meta-passphrase-2026')
+    await vault.collection<Pdf>('pdfs').put('p1', {
+      id: 'p1',
+      filename: 'a.pdf',
+      body: 'x',
+    })
+    const meta = await vault
+      .collection<PdfMeta & { _derivedFrom: { source: string; sourceId: string } }>('pdf-meta')
+      .get('p1')
+    expect(meta?._derivedFrom.source).toBe('pdfs')
+    expect(meta?._derivedFrom.sourceId).toBe('p1')
+  })
+
+  it('vault.deriveAll re-derives every record', async () => {
+    const { vault } = await open('showcase-80-deriveall-passphrase-2026')
+    await vault.collection<Pdf>('pdfs').put('p1', { id: 'p1', filename: 'a.pdf', body: 'a' })
+    await vault.collection<Pdf>('pdfs').put('p2', { id: 'p2', filename: 'b.pdf', body: 'bb' })
+    const { derived } = await vault.deriveAll('pdfs')
+    expect(derived).toBe(2)
+  })
+
+  it('strict mode rolls back source on derive failure', async () => {
+    const failing = withDerivation<Pdf, { meta: PdfMeta }>({
+      source: 'pdfs',
+      deterministic: true,
+      outputs: { meta: { shape: 'record', collection: 'pdf-meta' } },
+      derive: () => {
+        throw new Error('mock failure')
+      },
+      lifecycle: 'eager',
+      strict: true,
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'showcase-80-strict-passphrase-2026',
+      derivationStrategies: [failing],
+      txStrategy: withTransactions(),
+    })
+    const vault = await db.openVault('library')
+    await expect(
+      db.transaction(async (tx) => {
+        tx.vault('library').collection<Pdf>('pdfs').put('p1', {
+          id: 'p1',
+          filename: 'a.pdf',
+          body: 'x',
+        })
+      }),
+    ).rejects.toThrow('mock failure')
+    expect(await vault.collection('pdfs').get('p1')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Ships the `withDerivation` primitive in `@noy-db/hub`: declares deterministic data derivations of one or more typed outputs from a source record, with eager / lazy lifecycle, automatic invalidation on source change, cycle detection at vault open, and strict-mode rollback inside `withTransactions`.

Closes #129.

Spec: `docs/superpowers/specs/2026-05-01-dim14-derivation-v1-design.md`
Plan: `docs/superpowers/plans/2026-05-18-derivation.md`
Subsystem doc: `docs/subsystems/derivations.md`

## What ships

**New subsystem at `@noy-db/hub/derivations`** (tree-shakable subpath, sibling of `tx` in the `write-and-mutate` cluster):

```ts
import { withDerivation } from '@noy-db/hub/derivations'

const pdfDerivation = withDerivation<Pdf, { meta: PdfMeta; text: PdfText }>({
  source: 'pdfs',
  deterministic: true,
  outputs: {
    meta: { shape: 'record', collection: 'pdf-meta' },
    text: { shape: 'record', collection: 'pdf-text' },
  },
  derive: (pdf) => ({
    meta: { len: pdf.body.length, pages: pdf.pages.length },
    text: { content: extractText(pdf.body) },
  }),
  lifecycle: 'eager',  // or 'lazy'
})

const db = await createNoydb({
  store: memory(),
  user: 'alice',
  secret: '...',
  derivationStrategies: [pdfDerivation],
})

// On source write: outputs derived + written automatically
await vault.collection('pdfs').put('p1', { id: 'p1', body: 'hello world' })
const meta = await vault.collection('pdf-meta').get('p1')  // { len: 11, pages: 1, _derivedFrom: {...} }

// Bulk recompute after strategy change
const { derived, failed } = await vault.deriveAll('pdfs')
```

### Lifecycles

- **`eager`** — derive runs synchronously inside the source-write transaction; outputs written via the same `Collection.put` pipeline
- **`lazy`** — source-write marks outputs stale; first read of any output triggers derive on demand

### Strict vs non-strict

- Default (`strict: false`) — per-output failures isolated, log + continue
- `strict: true` — output failure rolls back the source write (only inside `withTransactions`)

### Cycle detection

Cyclic graphs (A → B → A, self-loops) rejected at `vault.openVault` with `DerivationCycleError`.

## Architecture

- **Zero-knowledge preserved.** `derive` runs after DEK unwrap, on plaintext, before encrypt. Outputs encrypted with the same DEK as the source. `_derivedFrom` metadata lives inside the encrypted payload, not in the unencrypted envelope.
- **`strategyHash`** — SHA-256 of `(source + sorted output keys + derive.toString())`. Stamped onto every derived record; mismatch on next visit forces recompute.
- **Recursion guard.** Dispatch hook skips when the incoming record carries `_derivedFrom` — defense-in-depth alongside the openVault cycle validator.

## Composition with guards (#134)

```
Collection.put
  1. Permission check
  2. GuardRegistry.check       ← #134
  3. Encrypt + store.put
  4. Ledger append
  5. DerivationRegistry        ← this PR
```

Guard blocks write → derivation never fires. The two run on opposite sides of the encrypt boundary.

## Errors (all extend NoydbError)

- `DerivationCycleError(path[])` — code `DERIVATION_CYCLE`
- `DerivationDepthError(limit, attempted)` — code `DERIVATION_DEPTH`
- `DerivationOutputUnknownError(collection)` — code `DERIVATION_OUTPUT_UNKNOWN`
- `DerivationOutputShapeError(outputKey, detail)` — code `DERIVATION_OUTPUT_SHAPE`

## Test plan

- [ ] **Hub unit tests** — 1484/1484 pass, including:
  - [ ] `derivations/errors.test.ts` — 4 error types
  - [ ] `derivations/types.test.ts` — type surface
  - [ ] `derivations/strategy-hash.test.ts` — 5 hash determinism scenarios
  - [ ] `derivations/with-derivation.test.ts` — factory + 4 validation paths
  - [ ] `derivations/registry.test.ts` — 5 registry + cycle scenarios
  - [ ] `derivations/executor.test.ts` — 4 executor scenarios
  - [ ] `derivations/vault-wiring.test.ts` — 3 Vault wiring scenarios
  - [ ] `derivations/eager.test.ts` — 3 eager dispatch scenarios
  - [ ] `derivations/cycle.test.ts` — 5 cycle detection scenarios
  - [ ] `derivations/lazy.test.ts` — 3 lazy lifecycle scenarios
  - [ ] `derivations/strict-tx.test.ts` — 2 strict-mode + tx rollback scenarios
  - [ ] `derivations/derive-all.test.ts` — 2 bulk recompute scenarios
  - [ ] `derivations/subpath-export.test.ts` — `instanceof` works across `@noy-db/hub` + `@noy-db/hub/derivations`
  - [ ] `derivations/cross-store.test.ts` — derivation survives vault re-open on file store
- [ ] **Showcase 80** — `showcases/src/80-with-derivation.showcase.test.ts`, 5/5 scenarios pass (eager, re-derive, _derivedFrom stamp, deriveAll, strict-mode rollback)
- [ ] `pnpm validate:features` — features=29 (was 28 after guards)
- [ ] `pnpm turbo typecheck` — clean
- [ ] `pnpm turbo lint` — clean (after fixup commit `3d121f1`)

## Side fix (during review iteration)

- **`runTransaction` push-before-execute reorder** (commit `51720cc`) — caught by code review of D12. The revert plan previously missed ops that threw mid-`Collection.put`, so strict-mode derivation failures couldn't rollback the source. Fix is general — benefits any mid-put throw scenario (ledger, history, etc.).

## Deferred / follow-up

- **#132** Make `withDerivation` handle pre-hashed so `register()` becomes sync — would plug the `Noydb.vault()` backwards-compat-accessor gap (currently `_initDerivations` only fires from `openVault`)
- **#133** Strict-mode multi-output partial-write orphans — early outputs that succeed before a later output throws are left on disk; needs `revertExecuted` to track derived puts
- **#130** Bundle regression (~30-48% gz) primarily from guards T6, derivation adds ~3-6 pp on top
- Cache-tier backends, built-in derivers, `withMaterializedView`, scheduled refresh, non-deterministic derivations, external runtimes, public CDN derivations, streaming materialized views, stale-flag persistence, per-record `sourceVersion` in bulk recompute — all deferred per spec

## Renumbering note

Showcase planned at `70-with-derivation` bumped to `80-with-derivation` because `70-user-envelope.showcase.test.ts` already exists in `main`. Plan + features.yaml updated accordingly.
