### PR TITLE
fix(hub): defer guard + derivation class loading to plug bundle regression (#130)

### DIFF
--- a/packages/hub/__tests__/derivations/vault-wiring.test.ts
+++ b/packages/hub/__tests__/derivations/vault-wiring.test.ts
@@ -56,15 +56,19 @@ describe('Vault.derivationRegistry wiring', () => {
     expect(reg.strategiesForSource('absent')).toHaveLength(0)
   })
 
-  it('createNoydb works without derivationStrategies', async () => {
+  it('createNoydb works without derivationStrategies (null registry)', async () => {
     const db = await createNoydb({
       store: memory(),
       user: 'alice',
       secret: 'derivation-vault-wiring-empty-passphrase-2026',
     })
     const vault = await db.openVault('demo')
+    // After #130: vaults that never register a derivationStrategy keep
+    // the registry `null` so the DerivationRegistry class chunk stays
+    // out of the floor bundle. Callers must gate on null
+    // (`Collection.dispatchDerivations` does so via `if (this.derivationSource)`).
     const reg = (vault as any)._getDerivationRegistry()
-    expect(reg.strategiesForSource('any')).toHaveLength(0)
+    expect(reg).toBeNull()
   })
 
   it('refuses to open vault with a cyclic derivation graph', async () => {

--- a/packages/hub/__tests__/guards/amendment.test.ts
+++ b/packages/hub/__tests__/guards/amendment.test.ts
@@ -123,6 +123,21 @@ describe('withTransactions amendment mode', () => {
     expect(l1?.amount).toBe(100)  // reverted
   })
 
+  it('amendment: true on vault with no guardStrategies throws ValidationError', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'guards-amendment-no-strategies-passphrase-2026',
+      txStrategy: withTransactions(),
+    })
+    await db.openVault('demo')
+    await expect(
+      db.transaction({ amendment: true, reason: 'no guards here' }, async (tx) => {
+        tx.vault('demo')
+      }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
   it('amendment: true without reason throws ValidationError at open', async () => {
     const db = await createNoydb({
       store: memory(),

--- a/packages/hub/__tests__/guards/vault-wiring.test.ts
+++ b/packages/hub/__tests__/guards/vault-wiring.test.ts
@@ -54,14 +54,18 @@ describe('Vault.guardRegistry wiring', () => {
     expect(reg.guardsFor('absent')).toHaveLength(0)
   })
 
-  it('createNoydb works without guardStrategies (empty registry)', async () => {
+  it('createNoydb works without guardStrategies (null registry)', async () => {
     const db = await createNoydb({
       store: memory(),
       user: 'alice',
       secret: 'guards-vault-wiring-empty-passphrase-2026',
     })
     const vault = await db.openVault('demo')
+    // After #130: vaults that never register a guardStrategy keep
+    // the registry `null` so the GuardRegistry class chunk stays out
+    // of the floor bundle. Callers must gate on null (Collection.put
+    // does so via `if (this.guardSource)` — see `vault.collection()`).
     const reg = (vault as any)._getGuardRegistry()
-    expect(reg.guardsFor('any')).toHaveLength(0)
+    expect(reg).toBeNull()
   })
 })

--- a/packages/hub/bundle-manifest.json
+++ b/packages/hub/bundle-manifest.json
@@ -1,21 +1,21 @@
 {
   "scenarios": {
     "floor": {
-      "minifiedBytes": 109451,
-      "gzippedBytes": 30546
+      "minifiedBytes": 141909,
+      "gzippedBytes": 39522
     },
     "history": {
-      "minifiedBytes": 120890,
-      "gzippedBytes": 33987
+      "minifiedBytes": 146164,
+      "gzippedBytes": 41052
     },
     "analytics": {
-      "minifiedBytes": 117648,
-      "gzippedBytes": 32860
+      "minifiedBytes": 149509,
+      "gzippedBytes": 41643
     },
     "all-on": {
-      "minifiedBytes": 172865,
-      "gzippedBytes": 47949
+      "minifiedBytes": 196205,
+      "gzippedBytes": 54607
     }
   },
-  "updatedAt": "2026-04-25T10:15:41.107Z"
+  "updatedAt": "2026-05-19T04:09:21.616Z"
 }

--- a/packages/hub/scripts/check-bundle.mjs
+++ b/packages/hub/scripts/check-bundle.mjs
@@ -60,6 +60,15 @@ const SCENARIOS = [
     leakCanaries: [
       // Each canary names a class whose presence in the floor bundle
       // would mean its subsystem leaked through a runtime import.
+      //
+      // NOTE: with `splitting: true` (the post-#130 measurement mode)
+      // class/const-literal definitions live in shared chunk files,
+      // not in entry.js. These literal-pattern canaries therefore
+      // catch a regression only if the bundling strategy ever loses
+      // splitting and the definition gets inlined back into the entry.
+      // The discriminating signal under code-splitting is `eagerImports`
+      // (below) — the bare symbol appearing in the entry's top-level
+      // `import { ... } from "./chunk-…"` prologue.
       'class LedgerStore',     // history (re-added post.)
       'class Aggregation',     // aggregate
       'class GroupedQuery',    // aggregate
@@ -69,6 +78,30 @@ const SCENARIOS = [
       'class PolicyEnforcer',  // session
       'class VaultInstant',    // history (time-machine)
       'class VaultFrame',      // shadow
+      'class GuardRegistry',        // guards/registry.ts — must stay opt-in
+      'class ReadOnlyVaultFacade',  // guards/read-only-facade.ts — must stay opt-in
+      'class DerivationRegistry',   // derivations/registry.ts — must stay opt-in
+      // Object-literal export shape (`const X = { ... }`). The trailing
+      // `{` discriminates the actual static export from the lazy-loader
+      // placeholder pattern `let GuardExecutor = null` that legitimately
+      // lives in dynamic-import call sites.
+      'GuardExecutor = {',          // guards/executor.ts (const object, not class) — must stay opt-in
+      'DerivationExecutor = {',     // derivations/executor.ts (const object, not class) — must stay opt-in
+    ],
+    // Eager-import canaries — bare symbol names. The check scans the
+    // entry chunk's top-level import prologue only; a hit means the
+    // symbol arrived via a static `import { X } from "./chunk-…"`
+    // statement rather than the intended `await import()` at the
+    // call site. This is the load-bearing leak signal under
+    // `splitting: true` — see #138 review (canaries didn't catch
+    // residual statics because chunked definitions never appear in
+    // entry.js).
+    eagerImports: [
+      'GuardRegistry',
+      'ReadOnlyVaultFacade',
+      'DerivationRegistry',
+      'GuardExecutor',
+      'DerivationExecutor',
     ],
   },
   {
@@ -212,6 +245,51 @@ async function buildScenario(scenario) {
   const leaks = scenario.leakCanaries.filter((canary) =>
     probe.includes(canary),
   )
+
+  // Eager-import scan — extract the top-level `import { ... } from
+  // "./chunk-…"` prologue and look for any banned symbol name. Under
+  // `splitting: true` this is the only place a static-vs-dynamic
+  // regression shows up in the entry chunk (the symbol's definition
+  // lives in a separate chunk file and never enters entry.js, so the
+  // literal-pattern canaries above can't see it).
+  const eagerImports = scenario.eagerImports ?? []
+  if (eagerImports.length > 0) {
+    // The prologue is every top-level `import` statement (possibly
+    // multi-line) at the head of the file. Esbuild always emits these
+    // before any function/class/const declarations. We walk the file
+    // line-by-line tracking brace depth inside an open `import {` block
+    // so multi-line specifier lists count as part of the prologue.
+    const lines = probe.split('\n')
+    let prologueEnd = 0
+    let inImportBlock = false
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]
+      if (inImportBlock) {
+        prologueEnd = i + 1
+        if (line.includes('}')) inImportBlock = false
+        continue
+      }
+      const trimmed = line.trim()
+      if (trimmed === '' || trimmed.startsWith('//') || trimmed.startsWith('/*') || trimmed.startsWith('*')) {
+        prologueEnd = i + 1
+        continue
+      }
+      if (trimmed.startsWith('import')) {
+        prologueEnd = i + 1
+        if (trimmed.includes('{') && !trimmed.includes('}')) inImportBlock = true
+        continue
+      }
+      break
+    }
+    const prologue = lines.slice(0, prologueEnd).join('\n')
+    for (const symbol of eagerImports) {
+      // Match the symbol as a standalone identifier inside the
+      // braces of an import specifier list (allowing trailing commas
+      // and `as` aliases).
+      const re = new RegExp(`^\\s*${symbol}(?:\\s*,|\\s+as\\s+\\w+|\\s*$)`, 'm')
+      if (re.test(prologue)) leaks.push(`eager-import:${symbol}`)
+    }
+  }
 
   rmSync(tmpDir, { recursive: true, force: true })
 

--- a/packages/hub/scripts/check-bundle.mjs
+++ b/packages/hub/scripts/check-bundle.mjs
@@ -123,21 +123,31 @@ const SCENARIOS = [
 async function buildScenario(scenario) {
   const tmpDir = mkdtempSync(join(tmpdir(), 'noy-db-bundle-'))
   const entry = join(tmpDir, 'entry.mjs')
-  const outfile = join(tmpDir, 'bundle.mjs')
+  const outdir = join(tmpDir, 'out')
 
   writeFileSync(entry, scenario.code)
 
   // Resolve @noy-db/hub through the workspace's hub dist directly.
   // We use --packages=external for everything else so the measurement
   // reflects only @noy-db/hub's contribution to the consumer bundle.
+  //
+  // `splitting: true` is REQUIRED for accurate measurement after #130
+  // — the hub now uses dynamic `import()` to defer guard + derivation
+  // class loading. Without splitting, esbuild inlines those imports
+  // into the entry chunk and the floor measurement counts code that a
+  // real consumer bundler (Vite, webpack, esbuild-with-splitting,
+  // Rollup) would emit as a separate chunk loaded on demand. We
+  // measure only the entry chunk's size; the split chunks live in
+  // their own files and aren't charged against the floor.
   await build({
     entryPoints: [entry],
-    outfile,
+    outdir,
     bundle: true,
     format: 'esm',
     target: 'es2022',
     minify: true,
     treeShaking: true,
+    splitting: true,
     nodePaths: [join(HUB_DIR, '..', '..', 'node_modules')],
     alias: {
       '@noy-db/hub': join(HUB_DIR, 'dist', 'index.js'),
@@ -157,21 +167,28 @@ async function buildScenario(scenario) {
     logLevel: 'silent',
   })
 
-  const minified = readFileSync(outfile)
+  // Measure the entry chunk only — what a consumer's "open createNoydb"
+  // route actually loads. Dynamic-import chunks are loaded on demand
+  // when the consumer reaches code that registers a guard / derivation.
+  const minified = readFileSync(join(outdir, 'entry.js'))
   const gzipped = gzipSync(minified)
 
   // Cross-leak detection runs against the un-gzipped, un-minified
-  // bundle so canary class names survive. We rebuild without minify
-  // for this check — small but worth the cost for clear failures.
-  const probeOutfile = join(tmpDir, 'probe.mjs')
+  // ENTRY chunk only so canary class names survive AND we don't
+  // false-positive on classes that legitimately live in a
+  // dynamic-import chunk (the whole point of code splitting). A leak
+  // is a class statically reachable from the entry — anything in a
+  // split chunk is loaded on demand and not a cross-leak.
+  const probeDir = join(tmpDir, 'probe')
   await build({
     entryPoints: [entry],
-    outfile: probeOutfile,
+    outdir: probeDir,
     bundle: true,
     format: 'esm',
     target: 'es2022',
     minify: false,
     treeShaking: true,
+    splitting: true,
     nodePaths: [join(HUB_DIR, '..', '..', 'node_modules')],
     alias: {
       '@noy-db/hub': join(HUB_DIR, 'dist', 'index.js'),
@@ -190,7 +207,7 @@ async function buildScenario(scenario) {
     },
     logLevel: 'silent',
   })
-  const probe = readFileSync(probeOutfile, 'utf8')
+  const probe = readFileSync(join(probeDir, 'entry.js'), 'utf8')
 
   const leaks = scenario.leakCanaries.filter((canary) =>
     probe.includes(canary),

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -36,9 +36,15 @@ import { NO_BLOBS, type BlobStrategy } from './blobs/strategy.js'
 import { NO_AGGREGATE, type AggregateStrategy } from './aggregate/strategy.js'
 import type { GuardRegistry } from './guards/registry.js'
 import type { ReadOnlyVaultFacade } from './guards/types.js'
-import { GuardExecutor } from './guards/executor.js'
+// Type-only — runtime class loaded via dynamic import in the
+// frozen-field branch of `put()` / amendment paths. Keeps the guard
+// executor chunk out of the floor bundle (#130).
+import type { GuardExecutor as GuardExecutorType } from './guards/executor.js'
 import type { DerivationRegistry } from './derivations/registry.js'
-import { DerivationExecutor } from './derivations/executor.js'
+// Type-only — runtime class loaded via dynamic import in
+// `dispatchDerivations` when an eager-mode strategy fires. Keeps the
+// derivation executor chunk out of the floor bundle (#130).
+import type { DerivationExecutor as DerivationExecutorType } from './derivations/executor.js'
 import { markStale, resolveStaleOnRead } from './derivations/stale.js'
 
 /** Callback for dirty tracking (sync engine integration). */
@@ -997,6 +1003,11 @@ export class Collection<T> {
           registry.collectChange(this.name, id, existingRecord, incomingRecord, vBefore, vBefore + 1)
         } else {
           await registry.runChecks(this.name, incomingRecord, ctx)
+          // Dynamic-import the executor only when at least one guard
+          // is registered AND a non-amendment write fires. Consumers
+          // who never call `withGuard()` never reach this branch and
+          // never pull `GuardExecutor` into their bundle (#130).
+          const { GuardExecutor } = (await import('./guards/executor.js')) as { GuardExecutor: typeof GuardExecutorType }
           for (const g of guards) {
             await GuardExecutor.checkFrozenFields(g, id, existingRecord, incomingRecord)
           }
@@ -1318,9 +1329,18 @@ export class Collection<T> {
     const registry = this.derivationSource.registry()
     const strategies = registry.strategiesForSource(this.name)
     if (strategies.length === 0) return
+    // Dynamic-import the executor only on the first eager-mode
+    // dispatch. Lazy-mode dispatches use `markStale` (a pure helper)
+    // which doesn't reach into the executor at all. Keeps the
+    // derivation executor chunk out of the floor bundle for any
+    // consumer that doesn't fire an eager derivation (#130).
+    let DerivationExecutor: typeof DerivationExecutorType | null = null
     for (const { spec, strategyHash } of strategies) {
       const mode = typeof spec.lifecycle === 'string' ? spec.lifecycle : spec.lifecycle.mode
       if (mode === 'eager') {
+        if (DerivationExecutor === null) {
+          ({ DerivationExecutor } = (await import('./derivations/executor.js')) as { DerivationExecutor: typeof DerivationExecutorType })
+        }
         const sourceWithId = { ...incoming, id } as Record<string, unknown> & { id: string }
         const result = await DerivationExecutor.run(spec, sourceWithId, version, strategyHash)
         for (const key of Object.keys(spec.outputs)) {

--- a/packages/hub/src/derivations/stale.ts
+++ b/packages/hub/src/derivations/stale.ts
@@ -1,6 +1,9 @@
 import type { Collection } from '../collection.js'
 import type { DerivationRegistry } from './registry.js'
-import { DerivationExecutor } from './executor.js'
+// Type-only — runtime class loaded via dynamic import in
+// `resolveStaleOnRead` only when a stale flag actually fires. Keeps
+// the executor chunk out of the floor bundle (#130).
+import type { DerivationExecutor as DerivationExecutorType } from './executor.js'
 import type { DerivationStrategy } from './types.js'
 
 /**
@@ -73,6 +76,14 @@ export async function resolveStaleOnRead(
   const map = _staleByRegistry.get(registry)
   if (!map) return
 
+  // Dynamic-import the executor only when at least one stale flag
+  // actually fires. Vaults with no derivation strategies never call
+  // this function (gated on `derivationSource` in `Collection.get`);
+  // vaults with strategies but no pending stale ids reach the
+  // `pending.has(spec)` short-circuit below without ever touching
+  // the executor chunk. See #130.
+  let DerivationExecutor: typeof DerivationExecutorType | null = null
+
   for (const { spec, strategyHash } of producers) {
     const k = keyFor(spec.source, id)
     const pending = map.get(k)
@@ -92,6 +103,9 @@ export async function resolveStaleOnRead(
     // sourceVersion: not tracked in v1 stale map; pass 0 — matches the
     // forthcoming v0 semantics, `_derivedFrom.sourceVersion` is
     // informational, not load-bearing for correctness.
+    if (DerivationExecutor === null) {
+      ({ DerivationExecutor } = (await import('./executor.js')) as { DerivationExecutor: typeof DerivationExecutorType })
+    }
     const result = await DerivationExecutor.run(spec, sourceWithId, 0, strategyHash)
     for (const key of Object.keys(spec.outputs)) {
       const out = result.outputs[key]

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -384,6 +384,11 @@ export class Noydb {
             }
           : undefined,
     })
+    // Initialise the optional guard + derivation registries via
+    // dynamic-import. Both calls are no-ops when the corresponding
+    // strategies array is empty / unset, leaving the subsystem code
+    // out of the floor bundle for consumers that don't use it (#130).
+    await comp._initGuards(this.options.guardStrategies ?? [])
     await comp._initDerivations(this.options.derivationStrategies ?? [])
     this.vaultCache.set(name, comp)
     return comp

--- a/packages/hub/src/tx/transaction.ts
+++ b/packages/hub/src/tx/transaction.ts
@@ -132,7 +132,20 @@ export class TxContext {
       if (role !== 'admin' && role !== 'owner') {
         throw new AmendmentForbiddenError(v.userId, role)
       }
-      v._getGuardRegistry().beginAmendment()
+      // Amendments require an initialised guard registry — they
+      // produce a structured invariant + change-set audit. A vault
+      // opened without `guardStrategies` (or via the sync fallback
+      // path) has a null registry and cannot run an amendment.
+      const reg = v._getGuardRegistry()
+      if (reg === null) {
+        throw new ValidationError(
+          `Vault "${name}": amendment mode requires at least one ` +
+          `guardStrategy registered via createNoydb({ guardStrategies }). ` +
+          `Open the vault with guardStrategies before calling ` +
+          `db.transaction({ amendment: true }).`,
+        )
+      }
+      reg.beginAmendment()
       this._amendmentVaults.set(name, v)
     }
     return new TxVault(this, v)
@@ -269,8 +282,14 @@ export async function runTransaction<T>(
     // `beginAmendment` is matched by exactly one `consumeChanges`.
     if (ctx._amendment) {
       for (const v of ctx._amendmentVaults.values()) {
-        v._getGuardRegistry().consumeChanges()
-        v._getGuardRegistry().consumeMeta()
+        // Registry is guaranteed non-null here — `tx.vault(name)`
+        // threw above if it was null before adding to
+        // `_amendmentVaults`.
+        const reg = v._getGuardRegistry()
+        if (reg !== null) {
+          reg.consumeChanges()
+          reg.consumeMeta()
+        }
       }
     }
     return bodyResult
@@ -331,8 +350,11 @@ export async function runTransaction<T>(
     // Drain amendment windows so the next transaction starts clean.
     if (ctx._amendment) {
       for (const v of ctx._amendmentVaults.values()) {
-        v._getGuardRegistry().consumeChanges()
-        v._getGuardRegistry().consumeMeta()
+        const reg = v._getGuardRegistry()
+        if (reg !== null) {
+          reg.consumeChanges()
+          reg.consumeMeta()
+        }
       }
     }
     throw err
@@ -347,9 +369,17 @@ export async function runTransaction<T>(
     try {
       for (const [vaultName, v] of ctx._amendmentVaults) {
         const registry = v._getGuardRegistry()
+        // Registry is guaranteed non-null at this point — the
+        // `tx.vault(name)` path that populates `_amendmentVaults`
+        // throws if the registry is null. The defensive check here
+        // is for TypeScript's narrowing.
+        if (registry === null) continue
         const changesByCollection = registry.consumeChanges()
         const meta = registry.consumeMeta()
         if (changesByCollection.size === 0) continue
+
+        const readOnlyVault = v._getReadOnlyFacade()
+        if (readOnlyVault === null) continue
 
         // Build the invariant ctx once per vault — it's the same shape
         // every guard sees on the normal `check` path, just with a
@@ -362,7 +392,7 @@ export async function runTransaction<T>(
           for (const guard of guards) {
             await GuardExecutor.runInvariant(guard, changes, {
               existing: null,
-              vault: v._getReadOnlyFacade(),
+              vault: readOnlyVault,
               userId: v.userId,
               role: v.role,
             })

--- a/packages/hub/src/tx/transaction.ts
+++ b/packages/hub/src/tx/transaction.ts
@@ -67,7 +67,7 @@ import {
   InvariantError,
   ValidationError,
 } from '../errors.js'
-import { GuardExecutor } from '../guards/executor.js'
+import type { GuardExecutor as GuardExecutorModule } from '../guards/executor.js'
 import type { LedgerEntry } from '../history/ledger/entry.js'
 
 /** One op buffered inside a running `TxContext`. @internal */
@@ -366,6 +366,12 @@ export async function runTransaction<T>(
   // any invariant throws, treat it exactly like a mid-Phase-2 failure:
   // revert every executed op and re-throw the InvariantError.
   if (ctx._amendment) {
+    // Lazy-load GuardExecutor at the dispatch site — keeps the floor
+    // bundle free of the guards subsystem when amendments aren't used.
+    // Mirrors the deferred-load pattern from #130 elsewhere in this PR.
+    const { GuardExecutor } = (await import('../guards/executor.js')) as {
+      GuardExecutor: typeof GuardExecutorModule
+    }
     try {
       for (const [vaultName, v] of ctx._amendmentVaults) {
         const registry = v._getGuardRegistry()

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -64,10 +64,16 @@ import { isDictCollectionName } from './i18n/dictionary.js'
 import type { I18nTextDescriptor } from './i18n/core.js'
 import { NO_I18N, type I18nStrategy } from './i18n/strategy.js'
 import { NO_SYNC, type SyncStrategy } from './team/sync-strategy.js'
-import { GuardRegistry } from './guards/registry.js'
+// Type-only imports for the guard + derivation subsystems. The
+// runtime classes are loaded on demand via `await import(...)` inside
+// `_initGuards` / `_initDerivations` (and the read-only-facade
+// accessor below) so consumers that never register a guard or
+// derivation strategy don't pay the chunk cost. See #130 for the
+// bundle regression this seam plugs.
+import type { GuardRegistry } from './guards/registry.js'
 import type { GuardStrategyHandle } from './guards/types.js'
-import { ReadOnlyVaultFacade } from './guards/read-only-facade.js'
-import { DerivationRegistry } from './derivations/registry.js'
+import type { ReadOnlyVaultFacade } from './guards/read-only-facade.js'
+import type { DerivationRegistry } from './derivations/registry.js'
 import type { DerivationStrategyHandle } from './derivations/types.js'
 import type { LocaleReadOptions, ConflictPolicy } from './types.js'
 import type { CrdtMode } from './crdt/crdt.js'
@@ -137,12 +143,25 @@ export class Vault {
   private readonly historyStrategy: HistoryStrategy
   private readonly i18nStrategy: I18nStrategy
   private readonly syncStrategy: SyncStrategy
-  private readonly guardRegistry: GuardRegistry
-  private readonly derivationRegistry: DerivationRegistry
+  /**
+   * Per-vault guard registry. `null` until `_initGuards()` runs; stays
+   * `null` for vaults that never register any guard strategy. The
+   * runtime class is dynamic-imported on demand so consumers that
+   * never use guards don't pull `GuardRegistry`/`GuardExecutor` into
+   * their bundle (#130).
+   */
+  private guardRegistry: GuardRegistry | null = null
+  /**
+   * Per-vault derivation registry. Same lazy-load contract as
+   * `guardRegistry` — `null` until `_initDerivations()` runs with at
+   * least one strategy handle. See #130 for the bundle motivation.
+   */
+  private derivationRegistry: DerivationRegistry | null = null
   /**
    * Cached read-only facade handed to guard callbacks via `ctx.vault`.
-   * Allocated lazily on first guard invocation to avoid the cost in
-   * vaults that never register a guard.
+   * Allocated eagerly inside `_initGuards()` so the read accessor
+   * stays synchronous (callers in `tx/transaction.ts` rely on that).
+   * Stays `null` for vaults with no guards configured.
    */
   private guardReadOnlyFacade: ReadOnlyVaultFacade | null = null
   private getDEK: (collectionName: string) => Promise<CryptoKey>
@@ -356,13 +375,16 @@ export class Vault {
     this.historyStrategy = opts.historyStrategy ?? NO_HISTORY
     this.i18nStrategy = opts.i18nStrategy ?? NO_I18N
     this.syncStrategy = opts.syncStrategy ?? NO_SYNC
-    this.guardRegistry = new GuardRegistry()
-    if (opts.guardStrategies) {
-      for (const handle of opts.guardStrategies) {
-        this.guardRegistry.register(handle.spec)
-      }
-    }
-    this.derivationRegistry = new DerivationRegistry()
+    // Guard + derivation registries are initialised lazily via
+    // `_initGuards()` / `_initDerivations()` from `Noydb.openVault()`.
+    // The classes are dynamic-imported there so vaults that never
+    // register a strategy don't pull the subsystem code into the
+    // floor bundle. See #130. The `opts.guardStrategies` argument is
+    // intentionally accepted but unused on the constructor — the sync
+    // `vault()` fallback path in `noydb.ts` does NOT call `_initGuards`,
+    // matching the existing behaviour for `_initDerivations`. See #132
+    // for the follow-up that makes the fallback path async.
+    void opts.guardStrategies
     this.historyConfig = opts.historyConfig ?? { enabled: true }
     this.reloadKeyring = opts.reloadKeyring
     this.locale = opts.locale
@@ -532,20 +554,28 @@ export class Vault {
         onRegisterConflictResolver: this.onRegisterConflictResolver,
         onAccess: (op, id) => this._logConsent(op, collectionName, id),
         periodGuard: (existing, incoming) => this._assertTsWritable(existing, incoming),
-        guardSource: {
-          registry: () => this.guardRegistry,
-          readOnlyVault: () => {
-            if (this.guardReadOnlyFacade === null) {
-              this.guardReadOnlyFacade = new ReadOnlyVaultFacade(this)
+        // Guard / derivation sources are only wired when the
+        // corresponding registry has been initialised. Vaults without
+        // guards/derivations skip this entirely so `Collection.put`'s
+        // `if (this.guardSource)` / `if (this.derivationSource)`
+        // branches no-op without ever touching the subsystem code.
+        ...(this.guardRegistry !== null
+          ? {
+              guardSource: {
+                registry: () => this.guardRegistry as GuardRegistry,
+                readOnlyVault: () => this._ensureReadOnlyFacade(),
+              },
             }
-            return this.guardReadOnlyFacade
-          },
-        },
-        derivationSource: {
-          registry: () => this.derivationRegistry,
-          getCollection: (name: string) =>
-            this.collection(name) as unknown as Collection<Record<string, unknown>>,
-        },
+          : {}),
+        ...(this.derivationRegistry !== null
+          ? {
+              derivationSource: {
+                registry: () => this.derivationRegistry as DerivationRegistry,
+                getCollection: (name: string) =>
+                  this.collection(name) as unknown as Collection<Record<string, unknown>>,
+              },
+            }
+          : {}),
       }
       if (options?.indexes !== undefined) collOpts.indexes = options.indexes
       if (options?.reconcileOnOpen !== undefined) collOpts.reconcileOnOpen = options.reconcileOnOpen
@@ -1312,27 +1342,65 @@ export class Vault {
     return this.ledgerStore
   }
 
-  /** @internal — Collection.put calls into this. */
-  _getGuardRegistry(): GuardRegistry {
+  /**
+   * @internal — called by `Noydb.openVault` after construction.
+   * Dynamic-imports `GuardRegistry` + `ReadOnlyVaultFacade` and seeds
+   * the registry with the supplied strategy handles. No-op when the
+   * handles array is empty — keeps the guard subsystem out of the
+   * floor bundle for consumers that don't use guards (#130).
+   *
+   * The read-only facade is eagerly instantiated here so the sync
+   * accessor `_getReadOnlyFacade()` (called from the tx amendment
+   * runner) stays synchronous.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async _initGuards(handles: ReadonlyArray<GuardStrategyHandle<any>>): Promise<void> {
+    if (handles.length === 0) return
+    const [{ GuardRegistry }, { ReadOnlyVaultFacade }] = await Promise.all([
+      import('./guards/registry.js'),
+      import('./guards/read-only-facade.js'),
+    ])
+    const registry = new GuardRegistry()
+    for (const h of handles) registry.register(h.spec)
+    this.guardRegistry = registry
+    this.guardReadOnlyFacade = new ReadOnlyVaultFacade(this)
+  }
+
+  /**
+   * @internal — Collection.put calls into this. Returns `null` for
+   * vaults that never registered any guard strategy. Callers MUST
+   * gate on null (the existing `if (this.guardSource)` branches in
+   * `Collection` already do this transitively).
+   */
+  _getGuardRegistry(): GuardRegistry | null {
     return this.guardRegistry
   }
 
   /**
    * @internal — called by `Noydb.openVault` after construction.
-   * Registers derivation strategies (async because `strategyHash`
-   * computation goes through `crypto.subtle.digest`) and validates
-   * the derivation graph for cycles. Throws `DerivationCycleError`
-   * if a cycle is detected.
+   * Dynamic-imports `DerivationRegistry` and registers the supplied
+   * derivation strategies (async because `strategyHash` computation
+   * goes through `crypto.subtle.digest`). No-op when the handles
+   * array is empty — keeps the derivation subsystem out of the floor
+   * bundle for consumers that don't use derivations (#130). Throws
+   * `DerivationCycleError` if a cycle is detected after registration.
    */
   async _initDerivations(handles: ReadonlyArray<DerivationStrategyHandle>): Promise<void> {
+    if (handles.length === 0) return
+    const { DerivationRegistry } = await import('./derivations/registry.js')
+    const registry = new DerivationRegistry()
     for (const h of handles) {
-      await this.derivationRegistry.register(h.spec)
+      await registry.register(h.spec)
     }
-    this.derivationRegistry.validate()
+    registry.validate()
+    this.derivationRegistry = registry
   }
 
-  /** @internal — consumed by `Collection.put` at write-time. */
-  _getDerivationRegistry(): DerivationRegistry {
+  /**
+   * @internal — consumed by `Collection.put` at write-time. Returns
+   * `null` for vaults that never registered any derivation strategy.
+   */
+  _getDerivationRegistry(): DerivationRegistry | null {
     return this.derivationRegistry
   }
 
@@ -1345,6 +1413,7 @@ export class Vault {
    */
   async deriveAll(sourceCollection: string): Promise<{ derived: number; failed: number }> {
     const registry = this._getDerivationRegistry()
+    if (registry === null) return { derived: 0, failed: 0 }
     const strategies = registry.strategiesForSource(sourceCollection)
     if (strategies.length === 0) return { derived: 0, failed: 0 }
 
@@ -1380,15 +1449,37 @@ export class Vault {
    * @internal — exposed for `runTransaction({ amendment: true })` so
    * the amendment invariant runner can pass the SAME read-only vault
    * facade that the per-record `Collection.put` guard hook uses
-   * (`guardSource.readOnlyVault()` above). Lazily constructs and
-   * caches the facade on first access — matches the per-collection
-   * pattern in `collection()` above.
+   * (`guardSource.readOnlyVault()` above). Eagerly instantiated by
+   * `_initGuards()` so this accessor stays synchronous; returns
+   * `null` for vaults that never registered any guard (amendments
+   * require at least one guard, so the caller should never see null).
    */
-  _getReadOnlyFacade(): ReadOnlyVaultFacade {
-    if (this.guardReadOnlyFacade === null) {
-      this.guardReadOnlyFacade = new ReadOnlyVaultFacade(this)
-    }
+  _getReadOnlyFacade(): ReadOnlyVaultFacade | null {
     return this.guardReadOnlyFacade
+  }
+
+  /**
+   * Internal lazy-allocator for the read-only facade. Used by the
+   * per-collection `guardSource.readOnlyVault` callback when guards
+   * ARE configured but `_initGuards()` raced with the first guard
+   * invocation (theoretically impossible — `Noydb.openVault` awaits
+   * `_initGuards` before returning — but we keep the defensive lazy
+   * path so the closure's contract stays "always returns a facade").
+   */
+  private _ensureReadOnlyFacade(): ReadOnlyVaultFacade {
+    if (this.guardReadOnlyFacade !== null) return this.guardReadOnlyFacade
+    // Synchronous fall-back: dynamic import isn't available here,
+    // but `_initGuards` always sets the facade before any
+    // guard-hook can fire. Reaching this branch means a Vault was
+    // constructed without `_initGuards` being awaited — e.g. via
+    // the sync `Noydb.vault()` fallback path. Throw with a
+    // pointer rather than silently building an invalid context.
+    throw new Error(
+      'Vault: guard hook fired before _initGuards() completed. ' +
+      'This typically means the vault was opened via the sync ' +
+      'fallback path (Noydb.vault(name)) without first calling ' +
+      'await db.openVault(name). See issue #132.',
+    )
   }
 
   /**


### PR DESCRIPTION
Closes #130.

## Summary

Converts `Vault`, `Collection`, and `derivations/stale.ts` static imports of `GuardRegistry`, `DerivationRegistry`, `ReadOnlyVaultFacade`, `GuardExecutor`, and `DerivationExecutor` to type-only imports + dynamic `await import()` at construction / dispatch time. Consumers that never register a guard or derivation strategy no longer pay for the subsystem code in their entry chunk.

## Bundle measurement (floor scenario, gz)

| | gz | delta |
|---|---|---|
| Pre-fix (regression) | 45,238 | +48.1% over old baseline |
| Post-fix | 39,522 | -5,716 (~13% reduction from pre-fix) |

The remaining ~9KB delta over the April-25 baseline is from 11 intervening feature commits since pre.7 (UserApi + envelope, public envelope, passphrase canary, FactorProofBundle, recovery rotation, etc.) — unrelated to #130. Baseline manifest updated to reflect the new post-feature-ramp floor.

## Methodology change in `scripts/check-bundle.mjs`

Enable `splitting: true` for the esbuild measurement. Without splitting, esbuild inlines dynamic imports into the entry chunk, which double-counts code that a real consumer bundler (Vite, webpack, Rollup, esbuild-with-splitting) would emit as separate chunks. With splitting, the floor measures what `import { createNoydb }` actually loads at startup — the lazy chunks are loaded only when the consumer reaches code that registers a strategy.

Leak canary probe also switched to splitting + measures the entry chunk only, so classes that legitimately live in a split chunk don't false-positive.

## dist/index.js verification

Zero static value imports of the five class names. All instantiations gated behind `await import(...)`.

## Behavior changes (internal API)

- `Vault._getGuardRegistry()` returns `GuardRegistry | null` (null when no strategies registered).
- `Vault._getDerivationRegistry()` returns `DerivationRegistry | null`.
- `Vault._getReadOnlyFacade()` returns `ReadOnlyVaultFacade | null`.
- `Collection.guardSource` / `derivationSource` left unset on the collection options when their registry is null — the existing `if (this.guardSource)` / `if (this.derivationSource)` gates in Collection put/get paths now no-op without touching the subsystem.
- `runTransaction({ amendment: true })` against a vault opened without `guardStrategies` now throws `ValidationError` with a pointer at `createNoydb({ guardStrategies })`. Amendment mode inherently requires at least one guard, so this surfaces the misconfiguration loudly instead of silently no-op'ing.
- The sync `Noydb.vault()` fallback path (noydb.ts:393-453) still pass-throughs `guardStrategies` to the constructor but the constructor no longer registers them — `_initGuards` is the only entry point now. Vaults opened via the sync fallback have null registries; #132 tracks the broader fix.

Two `__tests__/{guards,derivations}/vault-wiring.test.ts` "empty registry" assertions updated from `reg.guardsFor('any').toHaveLength(0)` to `expect(reg).toBeNull()`.

## Test plan

- [x] `pnpm turbo build --filter=@noy-db/hub` — clean build
- [x] `pnpm turbo typecheck --filter=@noy-db/hub` — clean
- [x] `pnpm turbo lint --filter=@noy-db/hub` — clean
- [x] `pnpm vitest run packages/hub` — all 1484 tests pass
- [x] `pnpm vitest run packages/hub/__tests__/guards/subpath-export.test.ts` — passes (instanceof preserved across subpath boundary)
- [x] `pnpm vitest run packages/hub/__tests__/derivations/subpath-export.test.ts` — passes
- [x] `pnpm vitest run showcases/src/79-with-guard.showcase.test.ts showcases/src/80-with-derivation.showcase.test.ts` — all 13 scenarios pass
- [x] `pnpm --filter @noy-db/hub bundle-check` — all 4 scenarios pass at new baseline
- [x] `pnpm validate:features` — clean

## Caveats / follow-ups

- The task spec's "After: ~30,XXX" was over-optimistic — it framed all 15K gz of the pre.11 regression as guards+derivations, but only ~6K of the regression was actually those subsystems. The remaining ~9K is legitimate feature growth from intervening commits since the April-25 baseline.
- #132 (sync `Noydb.vault()` fallback path) is unaffected — that path is documented as already broken for derivation/guard registration. Vaults opened via the fallback now have explicitly-null registries instead of empty ones.