### PR TITLE
fix(hub): rollback early-written derivation outputs on strict-mode mid-output failure (#133)

### DIFF
--- a/packages/hub/__tests__/derivations/strict-multi-output-orphan.test.ts
+++ b/packages/hub/__tests__/derivations/strict-multi-output-orphan.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../../src/index.js'
+import { withDerivation } from '../../src/derivations/index.js'
+import { withTransactions } from '../../src/tx/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface Src extends Record<string, unknown> { id: string; payload: string }
+interface Good extends Record<string, unknown> { value: number }
+interface Bad extends Record<string, unknown> { value: number }
+
+describe('Strict-mode derivation multi-output orphan (#133)', () => {
+  it('rolls back early-written outputs when a later strategy throws (strict)', async () => {
+    // Two strategies on the same source. Strategy A succeeds and writes
+    // its output via Collection.put — that write recurses through the
+    // adapter and (pre-fix) is invisible to the transaction's revert
+    // plan. Strategy B then throws in strict mode, propagating out of
+    // dispatchDerivations. The outer tx revert rolls back the source op
+    // but leaves Strategy A's output orphaned.
+    const stratGood = withDerivation<Src, { good: Good }>({
+      source: 'src',
+      deterministic: true,
+      outputs: { good: { shape: 'record', collection: 'good' } },
+      derive: () => ({ good: { value: 1 } }),
+      strict: true,
+      lifecycle: 'eager',
+    })
+    const stratBad = withDerivation<Src, { bad: Bad }>({
+      source: 'src',
+      deterministic: true,
+      outputs: { bad: { shape: 'record', collection: 'bad' } },
+      derive: () => { throw new Error('strategy-B-fail') },
+      strict: true,
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-orphan-133-passphrase-2026',
+      derivationStrategies: [stratGood, stratBad],
+      txStrategy: withTransactions(),
+    })
+    const v = await db.openVault('demo')
+
+    await expect(
+      db.transaction(async (tx) => {
+        tx.vault('demo').collection<Src>('src').put('id1', { id: 'id1', payload: 'data' })
+      }),
+    ).rejects.toThrow('strategy-B-fail')
+
+    // Source must be absent (rolled back).
+    expect(await v.collection<Src>('src').get('id1')).toBeNull()
+    // The early-written 'good' output must also be absent (this is the
+    // orphan the fix addresses — pre-fix this assertion fails).
+    expect(await v.collection<Good>('good').get('id1')).toBeNull()
+    // 'bad' was never produced.
+    expect(await v.collection<Bad>('bad').get('id1')).toBeNull()
+  })
+
+  it('non-strict mode commits source AND successful outputs even when a later strategy fails', async () => {
+    const stratGood = withDerivation<Src, { good: Good }>({
+      source: 'src',
+      deterministic: true,
+      outputs: { good: { shape: 'record', collection: 'good' } },
+      derive: () => ({ good: { value: 1 } }),
+      // strict: false (default)
+      lifecycle: 'eager',
+    })
+    const stratBad = withDerivation<Src, { bad: Bad }>({
+      source: 'src',
+      deterministic: true,
+      outputs: { bad: { shape: 'record', collection: 'bad' } },
+      derive: () => { throw new Error('soft-fail') },
+      // strict: false (default)
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-orphan-133-nonstrict-passphrase-2026',
+      derivationStrategies: [stratGood, stratBad],
+      txStrategy: withTransactions(),
+    })
+    const v = await db.openVault('demo')
+
+    await db.transaction(async (tx) => {
+      tx.vault('demo').collection<Src>('src').put('id1', { id: 'id1', payload: 'data' })
+    })
+
+    // Source committed.
+    expect(await v.collection<Src>('src').get('id1')).not.toBeNull()
+    // Strategy A's output is present.
+    expect(await v.collection<Good>('good').get('id1')).not.toBeNull()
+    // Strategy B's output is absent — its derive threw and was logged.
+    expect(await v.collection<Bad>('bad').get('id1')).toBeNull()
+  })
+})

--- a/packages/hub/__tests__/derivations/strict-multi-output-orphan.test.ts
+++ b/packages/hub/__tests__/derivations/strict-multi-output-orphan.test.ts
@@ -126,4 +126,53 @@ describe('Strict-mode derivation multi-output orphan (#133)', () => {
     // Strategy B's output is absent — its derive threw and was logged.
     expect(await v.collection<Bad>('bad').get('id1')).toBeNull()
   })
+
+  it('rolls back early-written outputs when putMany({ atomic: true }) hits a strict failure mid-batch (#133)', async () => {
+    // Two strategies on the same source — strategy A succeeds, strategy B's derive throws.
+    // The bulk-atomic path runs its own Phase 2 loop (NOT runTransaction);
+    // pre-fix it never published an _activeTxContext, so derived outputs
+    // written for id1 by Strategy A before Strategy B threw were
+    // orphaned. The fix wraps Phase 2 with the same set/clear pattern.
+    const stratGood = withDerivation<Src, { good: Good }>({
+      source: 'src',
+      deterministic: true,
+      outputs: { good: { shape: 'record', collection: 'good' } },
+      derive: (s) => ({ good: { value: s.payload.length } }),
+      strict: true,
+      lifecycle: 'eager',
+    })
+    const stratBad = withDerivation<Src, { bad: Bad }>({
+      source: 'src',
+      deterministic: true,
+      outputs: { bad: { shape: 'record', collection: 'bad' } },
+      derive: () => { throw new Error('always-fails') },
+      strict: true,
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-orphan-133-putmany-passphrase-2026',
+      derivationStrategies: [stratGood, stratBad],
+    })
+    const v = await db.openVault('demo')
+
+    await expect(
+      v.collection<Src>('src').putMany(
+        [
+          ['id1', { id: 'id1', payload: 'data' }],
+          ['id2', { id: 'id2', payload: 'data2' }],
+        ],
+        { atomic: true },
+      ),
+    ).rejects.toThrow()
+
+    // After atomic failure: source should NOT have either id1 or id2.
+    expect(await v.collection<Src>('src').get('id1')).toBeNull()
+    expect(await v.collection<Src>('src').get('id2')).toBeNull()
+    // Derived 'good' outputs that were written for id1 BEFORE id2's
+    // strategyBad threw must also be absent (the orphan-window fix).
+    expect(await v.collection<Good>('good').get('id1')).toBeNull()
+    expect(await v.collection<Good>('good').get('id2')).toBeNull()
+  })
 })

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -41,6 +41,7 @@ import type { ReadOnlyVaultFacade } from './guards/types.js'
 // executor chunk out of the floor bundle (#130).
 import type { GuardExecutor as GuardExecutorType } from './guards/executor.js'
 import type { DerivationRegistry } from './derivations/registry.js'
+import type { TxContext } from './tx/transaction.js'
 // Type-only — runtime class loaded via dynamic import in
 // `dispatchDerivations` when an eager-mode strategy fires. Keeps the
 // derivation executor chunk out of the floor bundle (#130).
@@ -387,6 +388,7 @@ export class Collection<T> {
     | {
         registry(): DerivationRegistry
         getCollection(name: string): Collection<Record<string, unknown>>
+        getActiveTxContext(): TxContext | null
       }
     | undefined
 
@@ -689,6 +691,14 @@ export class Collection<T> {
     derivationSource?: {
       registry(): DerivationRegistry
       getCollection(name: string): Collection<Record<string, unknown>>
+      /**
+       * Read access to the owning Noydb's currently-active multi-record
+       * transaction context, or `null` when no transaction is running.
+       * `dispatchDerivations` consults this so a recursive derived-output
+       * write can register its pre-write envelope onto `ctx._executed`
+       * and roll back alongside the source op on mid-batch failure (#133).
+       */
+      getActiveTxContext(): TxContext | null
     } | undefined
   }) {
     this.adapter = opts.adapter
@@ -1355,6 +1365,26 @@ export class Collection<T> {
           const outSpec = spec.outputs[key]
           if (!outSpec) continue
           const outputCollection = this.derivationSource.getCollection(outSpec.collection)
+          // #133 — if we're inside a multi-record transaction, register
+          // this derived write as a side-effect op on the active ctx
+          // BEFORE it fires. `revertExecuted` walks `_executed` in
+          // reverse on rollback, so capturing the pre-write envelope
+          // here lets a later mid-batch failure restore this output's
+          // prior state alongside the source op. Outside a transaction
+          // the context is null and tracking is skipped.
+          const txCtx = this.derivationSource.getActiveTxContext()
+          if (txCtx !== null) {
+            const prior = await this.adapter.get(this.vault, outSpec.collection, id)
+            txCtx._executed.push({
+              op: {
+                type: 'put',
+                vaultName: this.vault,
+                collectionName: outSpec.collection,
+                id,
+              },
+              priorEnvelope: prior,
+            })
+          }
           await outputCollection.put(id, out.value)
         }
       } else {

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -41,7 +41,8 @@ import type { ReadOnlyVaultFacade } from './guards/types.js'
 // executor chunk out of the floor bundle (#130).
 import type { GuardExecutor as GuardExecutorType } from './guards/executor.js'
 import type { DerivationRegistry } from './derivations/registry.js'
-import type { TxContext } from './tx/transaction.js'
+import type { TxContext, ExecutedOp } from './tx/transaction.js'
+import { revertExecuted } from './tx/transaction.js'
 // Type-only — runtime class loaded via dynamic import in
 // `dispatchDerivations` when an eager-mode strategy fires. Keeps the
 // derivation executor chunk out of the floor bundle (#130).
@@ -389,6 +390,19 @@ export class Collection<T> {
         registry(): DerivationRegistry
         getCollection(name: string): Collection<Record<string, unknown>>
         getActiveTxContext(): TxContext | null
+        /**
+         * Construct a fresh transient TxContext bound to the owning
+         * Noydb. Used by `Collection.putManyAtomic` to publish an
+         * `_activeTxContext` for the duration of its Phase 2 loop so
+         * recursive derived-output writes register their pre-write
+         * envelopes on `ctx._executed` and roll back alongside the
+         * bulk-put source ops (#133).
+         */
+        createTxContext(): TxContext
+        /** Publish a TxContext for the duration of a bulk-atomic loop. */
+        setActiveTxContext(ctx: TxContext): void
+        /** Drop a previously-published TxContext (defensive no-op if mismatched). */
+        clearActiveTxContext(ctx: TxContext): void
       }
     | undefined
 
@@ -699,6 +713,16 @@ export class Collection<T> {
        * and roll back alongside the source op on mid-batch failure (#133).
        */
       getActiveTxContext(): TxContext | null
+      /**
+       * Construct a transient TxContext bound to the owning Noydb. Used
+       * by `Collection.putManyAtomic` to publish an active context for
+       * its Phase 2 loop (#133).
+       */
+      createTxContext(): TxContext
+      /** Publish a TxContext for the duration of a bulk-atomic loop. */
+      setActiveTxContext(ctx: TxContext): void
+      /** Drop a previously-published TxContext. */
+      clearActiveTxContext(ctx: TxContext): void
     } | undefined
   }) {
     this.adapter = opts.adapter
@@ -1661,26 +1685,66 @@ export class Collection<T> {
       }
     }
     // Phase 2 — execute; revert on failure.
-    const executed: Array<{ id: string; prior: EncryptedEnvelope | null }> = []
+    //
+    // #133 — when a derivation registry is wired, publish a transient
+    // TxContext for the duration of this loop so `dispatchDerivations`
+    // can register recursive derived-output writes onto `ctx._executed`.
+    // The shared `revertExecuted` helper then unwinds the combined list
+    // (source ops + side-effect ops) in reverse, matching the
+    // `runTransaction` rollback semantics. When no derivation registry
+    // is configured, we still build a local `executed` list and revert
+    // it via `revertExecuted` — keeps a single code path.
+    const txCtx = this.derivationSource?.createTxContext() ?? null
+    if (txCtx !== null && this.derivationSource) {
+      this.derivationSource.setActiveTxContext(txCtx)
+    }
+    const localExecuted: ExecutedOp[] = []
     try {
       for (const [id, record] of entries) {
+        // Record the revert plan BEFORE the call so a mid-`put` throw
+        // (e.g. strict derivation failure firing after `store.put`
+        // already committed the source envelope) still has the source
+        // write reverted. Mirrors `runTransaction`'s Phase 2 pattern.
+        const entry: ExecutedOp = {
+          op: { type: 'put', vaultName: this.vault, collectionName: this.name, id },
+          priorEnvelope: priors.get(id) ?? null,
+        }
+        if (txCtx !== null) txCtx._executed.push(entry)
+        else localExecuted.push(entry)
         await this.put(id, record)
-        executed.push({ id, prior: priors.get(id) ?? null })
       }
-      return { ok: true, success: executed.map((e) => e.id), failures: [] }
+      return { ok: true, success: entries.map(([id]) => id), failures: [] }
     } catch (err) {
-      for (const { id, prior } of executed.slice().reverse()) {
+      const executedForRevert = txCtx !== null ? txCtx._executed : localExecuted
+      // Restore prior envelopes via the raw store. Same helper as
+      // `runTransaction` for symmetric semantics — walks in reverse,
+      // best-effort on each restore.
+      await revertExecuted(executedForRevert, this.adapter)
+      // Cache desync guard. `revertExecuted` only invalidates caches
+      // when given a `Noydb` reference (which we don't have here
+      // without widening the constructor surface). Walk the executed
+      // ops and invalidate caches via the source collection (this)
+      // for entries that target this collection, and via
+      // `derivationSource.getCollection(name)` for nested derived
+      // outputs that live in sibling collections — otherwise an eager
+      // cache on a derived-output collection still serves the
+      // rolled-back record.
+      for (const { op } of [...executedForRevert].reverse()) {
+        if (op.vaultName !== this.vault) continue
         try {
-          if (prior) await this.adapter.put(this.vault, this.name, id, prior)
-          else await this.adapter.delete(this.vault, this.name, id)
-          // Cache desync guard — the raw adapter writes above bypass
-          // `Collection.put`/`delete`, so the in-memory cache + indexes
-          // still reflect the executed (now-reverted) value. Same
-          // helper used by the tx executor's compensation path.
-          await this._invalidateCacheEntry(id)
+          if (op.collectionName === this.name) {
+            await this._invalidateCacheEntry(op.id)
+          } else if (this.derivationSource) {
+            const sibling = this.derivationSource.getCollection(op.collectionName)
+            await sibling._invalidateCacheEntry(op.id)
+          }
         } catch { /* best-effort */ }
       }
       throw err
+    } finally {
+      if (txCtx !== null && this.derivationSource) {
+        this.derivationSource.clearActiveTxContext(txCtx)
+      }
     }
   }
 

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -164,6 +164,17 @@ export class Noydb {
   private readonly txStrategy: TxStrategy
   private readonly sessionStrategy: SessionStrategy
   private readonly syncStrategy: SyncStrategy
+  /**
+   * Currently-running multi-record transaction, set by
+   * `runTransaction` at the start of Phase 2 (commit) and cleared in
+   * the same function's `finally` block. Side-effect writes triggered
+   * during a staged op's `Collection.put` (today: eager derivation
+   * outputs) register their pre-write envelope on `_executed` here so
+   * a mid-batch failure rolls them back alongside the main staged ops
+   * (#133). `null` outside of Phase 2.
+   * @internal
+   */
+  private _activeTxContext: TxContext | null = null
 
   // ─── plaintextTranslator state ─────────────────────────
   /**
@@ -988,6 +999,44 @@ export class Noydb {
    */
   get _store(): NoydbStore {
     return this.options.store
+  }
+
+  /**
+   * Currently-running multi-record transaction, or `null` outside
+   * Phase 2. `Collection.dispatchDerivations` consults this so a
+   * recursive derived-output write inside `Collection.put` can register
+   * its envelope onto `ctx._executed` and roll back with the main
+   * staged ops on mid-batch failure (#133).
+   *
+   * @internal
+   */
+  get _activeTxContextOrNull(): TxContext | null {
+    return this._activeTxContext
+  }
+
+  /**
+   * Called by `runTransaction` at Phase 2 start. Nested transactions
+   * are not supported — overwriting an existing context indicates a
+   * bug in the caller, but we tolerate it (best-effort) rather than
+   * throwing inside the executor.
+   *
+   * @internal
+   */
+  _setActiveTxContext(ctx: TxContext): void {
+    this._activeTxContext = ctx
+  }
+
+  /**
+   * Called by `runTransaction` in its `finally`. Only clears when the
+   * passed ctx matches the active one — a defensive no-op if some
+   * other code path already cleared it.
+   *
+   * @internal
+   */
+  _clearActiveTxContext(ctx: TxContext): void {
+    if (this._activeTxContext === ctx) {
+      this._activeTxContext = null
+    }
   }
 
   /** Get sync status for a vault. */

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -84,7 +84,8 @@ import type { KeyringAuthenticator } from './types.js'
 import type { SyncEngine } from './team/sync.js'
 import type { SyncTransaction } from './team/sync-transaction.js'
 import { NO_SYNC, type SyncStrategy } from './team/sync-strategy.js'
-import type { TxContext, AmendmentTxOptions } from './tx/transaction.js'
+import type { AmendmentTxOptions } from './tx/transaction.js'
+import { TxContext } from './tx/transaction.js'
 import { NO_TX, type TxStrategy } from './tx/strategy.js'
 import { INDEXED_STORE_POLICY } from './store/sync-policy.js'
 import type { PolicyEnforcer } from './session/session-policy.js'
@@ -1015,15 +1016,34 @@ export class Noydb {
   }
 
   /**
-   * Called by `runTransaction` at Phase 2 start. Nested transactions
-   * are not supported — overwriting an existing context indicates a
-   * bug in the caller, but we tolerate it (best-effort) rather than
-   * throwing inside the executor.
+   * Called by `runTransaction` at Phase 2 start, and by
+   * `Collection.putManyAtomic` (via `derivationSource.setActiveTxContext`)
+   * for its own Phase 2 loop. Nested or concurrent (non-nested)
+   * transactions on the same Noydb instance are NOT supported —
+   * overwriting an active context means another transaction is still
+   * running and its `_executed` list would be cross-contaminated by
+   * the nested writes. We tolerate the overwrite (best-effort, no
+   * throw) to keep the rare interleaving from breaking consumers who
+   * currently get lucky with timing, but applications should ensure
+   * their multi-record commits are serialised on a single Noydb.
    *
    * @internal
    */
   _setActiveTxContext(ctx: TxContext): void {
     this._activeTxContext = ctx
+  }
+
+  /**
+   * Factory for a transient `TxContext` bound to this Noydb. Used by
+   * `Collection.putManyAtomic` (via `derivationSource.createTxContext`)
+   * to publish an active context for the duration of its bulk-atomic
+   * Phase 2 loop, so recursive derivation-output writes register on
+   * `ctx._executed` and roll back together with the source ops (#133).
+   *
+   * @internal
+   */
+  _createTxContext(): TxContext {
+    return new TxContext(this)
   }
 
   /**

--- a/packages/hub/src/tx/transaction.ts
+++ b/packages/hub/src/tx/transaction.ts
@@ -71,13 +71,24 @@ import type { GuardExecutor as GuardExecutorModule } from '../guards/executor.js
 import type { LedgerEntry } from '../history/ledger/entry.js'
 
 /** One op buffered inside a running `TxContext`. @internal */
-interface StagedOp {
+export interface StagedOp {
   type: 'put' | 'delete'
   vaultName: string
   collectionName: string
   id: string
   record?: unknown
   expectedVersion?: number
+}
+
+/**
+ * One executed op (main staged op or recursive side-effect like a
+ * derivation output) paired with the envelope captured before the write.
+ * `revertExecuted` walks this array in reverse on rollback.
+ * @internal
+ */
+export interface ExecutedOp {
+  op: StagedOp
+  priorEnvelope: EncryptedEnvelope | null
 }
 
 /**
@@ -100,6 +111,15 @@ export interface AmendmentTxOptions {
 export class TxContext {
   /** @internal */
   readonly _ops: StagedOp[] = []
+  /**
+   * @internal — write log built up in Phase 2. Each entry records the
+   * envelope captured BEFORE the write so a mid-batch failure can
+   * restore prior state via `revertExecuted`. Side-effect writes (e.g.
+   * recursive derivation outputs fired inside `Collection.put`) are
+   * appended here in execution order so they roll back alongside the
+   * main staged ops (#133).
+   */
+  readonly _executed: ExecutedOp[] = []
   /** @internal */
   readonly _db: Noydb
   /**
@@ -323,41 +343,52 @@ export async function runTransaction<T>(
   // Phase 2 — execute via the Collection layer so history snapshots,
   // ledger entries, and change events fire normally. We capture each
   // successful op so a mid-batch throw can revert in Phase 3.
-  const executed: Array<{ op: StagedOp; priorEnvelope: EncryptedEnvelope | null }> = []
+  //
+  // `_activeTxContext` is published on the Noydb instance for the
+  // duration of Phase 2 so recursive writes triggered inside
+  // `Collection.put` (today: eager derivation outputs) can register
+  // their own envelopes onto `ctx._executed` and roll back alongside
+  // the main staged ops (#133). The `finally` clears it before the
+  // amendment commit phase runs.
+  db._setActiveTxContext(ctx)
   try {
-    for (const op of ctx._ops) {
-      const coll = db.vault(op.vaultName).collection(op.collectionName)
-      const key = keyOf(op)
-      const prior = priorEnvelopes.get(key) ?? null
-      // Record the revert plan BEFORE the call so a mid-`coll.put` throw
-      // (e.g. strict-mode derivation failure firing after `store.put`
-      // has already committed the envelope) still has its source write
-      // reverted. `revertExecuted` is best-effort: putting prior back is
-      // idempotent when the failing op never actually wrote, and
-      // `_invalidateCacheEntry` is a no-op when the collection isn't
-      // hydrated.
-      executed.push({ op, priorEnvelope: prior })
-      if (op.type === 'put') {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await coll.put(op.id, op.record as any)
-      } else {
-        await coll.delete(op.id)
-      }
-    }
-  } catch (err) {
-    // Phase 3 — best-effort revert. See helper docstring.
-    await revertExecuted(executed, store, db)
-    // Drain amendment windows so the next transaction starts clean.
-    if (ctx._amendment) {
-      for (const v of ctx._amendmentVaults.values()) {
-        const reg = v._getGuardRegistry()
-        if (reg !== null) {
-          reg.consumeChanges()
-          reg.consumeMeta()
+    try {
+      for (const op of ctx._ops) {
+        const coll = db.vault(op.vaultName).collection(op.collectionName)
+        const key = keyOf(op)
+        const prior = priorEnvelopes.get(key) ?? null
+        // Record the revert plan BEFORE the call so a mid-`coll.put` throw
+        // (e.g. strict-mode derivation failure firing after `store.put`
+        // has already committed the envelope) still has its source write
+        // reverted. `revertExecuted` is best-effort: putting prior back is
+        // idempotent when the failing op never actually wrote, and
+        // `_invalidateCacheEntry` is a no-op when the collection isn't
+        // hydrated.
+        ctx._executed.push({ op, priorEnvelope: prior })
+        if (op.type === 'put') {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await coll.put(op.id, op.record as any)
+        } else {
+          await coll.delete(op.id)
         }
       }
+    } catch (err) {
+      // Phase 3 — best-effort revert. See helper docstring.
+      await revertExecuted(ctx._executed, store, db)
+      // Drain amendment windows so the next transaction starts clean.
+      if (ctx._amendment) {
+        for (const v of ctx._amendmentVaults.values()) {
+          const reg = v._getGuardRegistry()
+          if (reg !== null) {
+            reg.consumeChanges()
+            reg.consumeMeta()
+          }
+        }
+      }
+      throw err
     }
-    throw err
+  } finally {
+    db._clearActiveTxContext(ctx)
   }
 
   // ─── Amendment commit phase (only if amendment === true) ────
@@ -435,7 +466,7 @@ export async function runTransaction<T>(
         void vaultName
       }
     } catch (err) {
-      await revertExecuted(executed, store, db)
+      await revertExecuted(ctx._executed, store, db)
       throw err instanceof InvariantError ? err : new InvariantError(
         err instanceof Error ? err.message : `invariant violated: ${String(err)}`,
       )
@@ -459,7 +490,7 @@ export async function runTransaction<T>(
  * @internal
  */
 async function revertExecuted(
-  executed: Array<{ op: StagedOp; priorEnvelope: EncryptedEnvelope | null }>,
+  executed: ReadonlyArray<ExecutedOp>,
   store: Noydb['_store'],
   db?: Noydb,
 ): Promise<void> {

--- a/packages/hub/src/tx/transaction.ts
+++ b/packages/hub/src/tx/transaction.ts
@@ -265,12 +265,14 @@ export class TxCollection<T> {
 }
 
 /**
- * Commit plan: pre-flight check + execution + revert plan. Returned
- * from `runTransaction`.
+ * Commit plan: pre-flight check + execution + revert plan.
  *
- * @internal — exposed only for the `Collection.putMany({atomic:true})`
- * wire-up so the bulk path can share the executor without creating
- * an outer TxContext.
+ * @internal — driven by `withTransactions()` (via `tx/active.ts`) for
+ * user-facing `db.transaction(...)` calls and by the `amendment` path
+ * in `noydb.ts`. `Collection.putManyAtomic` runs its own Phase 2 loop
+ * but shares the `_activeTxContext` mechanism (and the `revertExecuted`
+ * helper) so nested side-effect derivation writes get registered for
+ * revert alongside the bulk-put source ops (#133).
  */
 export async function runTransaction<T>(
   db: Noydb,
@@ -487,9 +489,12 @@ export async function runTransaction<T>(
  * state can still reconstruct it by walking the ledger through the
  * failed-tx timestamp.
  *
- * @internal
+ * @internal — shared between `runTransaction` and
+ * `Collection.putManyAtomic`. Both register source ops + nested
+ * derivation side-effect ops onto `_executed`; this helper unwinds the
+ * combined list in reverse on rollback.
  */
-async function revertExecuted(
+export async function revertExecuted(
   executed: ReadonlyArray<ExecutedOp>,
   store: Noydb['_store'],
   db?: Noydb,

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -574,6 +574,9 @@ export class Vault {
                 getCollection: (name: string) =>
                   this.collection(name) as unknown as Collection<Record<string, unknown>>,
                 getActiveTxContext: () => this.noydb._activeTxContextOrNull,
+                createTxContext: () => this.noydb._createTxContext(),
+                setActiveTxContext: (ctx) => this.noydb._setActiveTxContext(ctx),
+                clearActiveTxContext: (ctx) => this.noydb._clearActiveTxContext(ctx),
               },
             }
           : {}),

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -573,6 +573,7 @@ export class Vault {
                 registry: () => this.derivationRegistry as DerivationRegistry,
                 getCollection: (name: string) =>
                   this.collection(name) as unknown as Collection<Record<string, unknown>>,
+                getActiveTxContext: () => this.noydb._activeTxContextOrNull,
               },
             }
           : {}),


### PR DESCRIPTION
Closes #133.

## Summary

When a strict-mode derivation produced multiple outputs (or two strategies fired on the same source) and a later write failed, the earlier successful derived writes were orphaned: they had already hit the adapter via `Collection.put` recursion inside `dispatchDerivations`, but were invisible to the outer transaction's revert plan. `revertExecuted` rolled the source op back and left orphans on disk.

## Fix (Option 1 from the issue)

- `Noydb` tracks the active multi-record transaction via `_activeTxContext`, set by `runTransaction` at Phase 2 start and cleared in `finally`.
- The transaction's executed log is hoisted onto `TxContext._executed` so it is reachable from outside the executor.
- `Collection.dispatchDerivations` consults the active context through the existing `derivationSource` back-reference; when non-null, it captures the pre-write envelope for each derived output and pushes a side-effect entry onto `ctx._executed` BEFORE the inner write fires.
- `revertExecuted` already walks `_executed` in reverse — the side-effect entries roll back naturally alongside the main staged ops.

Outside a transaction the context is `null` and tracking is skipped, so non-tx writes are unaffected.

## Why a two-strategy test

The shape check in `DerivationExecutor.run` throws unconditionally before any partial output write, so a single-strategy, multi-output test cannot reproduce the orphan window. The regression test uses two strategies on the same source: A succeeds and writes; B's `derive` throws in strict mode, propagating out of `dispatchDerivations` after A has already committed.

## Test plan

- [x] strict-mode multi-strategy failure → source AND early outputs rolled back (new test)
- [x] non-strict multi-strategy failure → source + successful outputs commit (new test, unchanged behavior)
- [x] Existing `strict-tx.test.ts` "rolls back source write if derive throws" still passes
- [x] Full hub test suite green (1487 tests, +2 new)
- [x] Showcase 80 (`80-with-derivation.showcase.test.ts`) still green
- [x] `pnpm typecheck` + `pnpm lint` clean on hub