### PR TITLE
feat(hub): Guards/Derivations v1.5 — #144 #145 #146 #147

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,24 @@
 - **Showcase + recipe coverage.** A runnable end-to-end test for every `with*()` strategy and every storage destination so adopters pick a backend by reading working code.
 - **`by-*` session-share family.** `@noy-db/by-peer` (WebRTC, renamed from `@noy-db/p2p`) and `@noy-db/by-tabs` (BroadcastChannel multi-tab sync) shipped together with the family debut. Next: `@noy-db/by-server` (WebSocket / SSE relay) and `@noy-db/by-room` (Liveblocks / Yjs y-websocket).
 
+## In flight
+
+**`0.1.0-pre.14` — Dim 14 v2 (MV) + Guards/Derivations v1.5.** Bundled milestone for two related strands:
+
+- **Guards/Derivations v1.5** — fast-follow refinements to the pre.11 primitives driven by first-consumer use. Landing first to give MV a hardened `ReadOnlyVaultFacade` foundation:
+  - [#146](https://github.com/vLannaAi/noy-db/issues/146) `withGuard`: expose `.query()` on `ReadOnlyVaultFacade` for aggregating checks.
+  - [#147](https://github.com/vLannaAi/noy-db/issues/147) `withDerivation`: give `derive(source, ctx)` the same `ReadOnlyVaultFacade` guards have.
+  - [#145](https://github.com/vLannaAi/noy-db/issues/145) `withGuard.onDelete` — reject delete based on record state.
+  - [#144](https://github.com/vLannaAi/noy-db/issues/144) `withDerivation` optional outputs (`null` = skip emission).
+- **Dim 14 v2 — `withMaterializedView`** — collection-level query derivation (query → materialized collection). Extends `withDerivation` v1 (#129):
+  - [#142](https://github.com/vLannaAi/noy-db/issues/142) v2 design spec (blocking).
+  - [#143](https://github.com/vLannaAi/noy-db/issues/143) implementation epic.
+  - Deferred to v3: streaming MVs (Dim 12), MapReduce views, scheduled refresh (Dim 11 hooks), rendered/server-authoritative views.
+
+Execution order: v1.5 (#146 → #147 → #145 → #144) → spec (#142) → MV epic (#143).
+
+**`0.1.0-pre.13` — Real-provider showcase batch (Apple/Google/LINE).** Deferred (env-gated, parked 2026-05-20). Showcase coverage is a 1.0 gate, not a pre-release gate; the six issues stay open at `priority: low` to close opportunistically when real-provider creds are in hand: [#64](https://github.com/vLannaAi/noy-db/issues/64), [#65](https://github.com/vLannaAi/noy-db/issues/65), [#73](https://github.com/vLannaAi/noy-db/issues/73), [#74](https://github.com/vLannaAi/noy-db/issues/74), [#75](https://github.com/vLannaAi/noy-db/issues/75), [#76](https://github.com/vLannaAi/noy-db/issues/76).
+
 ## Recently shipped (and what's deferred)
 
 The following capabilities are now in main:
@@ -18,7 +36,7 @@ The following capabilities are now in main:
   - **Strict-mode derivation orphan** ([#133](https://github.com/vLannaAi/noy-db/issues/133)) — when a strict-mode derivation produced multiple outputs and a later strategy threw, the first M outputs were already written via `dispatchDerivations`'s nested `Collection.put` recursion and were invisible to the outer transaction's revert plan. `Noydb` now tracks the active `TxContext` (set by `runTransaction` at Phase 2, cleared in `finally`); `dispatchDerivations` registers each derived put as a side-effect op in `ctx._executed` before the write fires; `revertExecuted` walks them in reverse on rollback. Same treatment applied to `Collection.putManyAtomic`'s bespoke commit loop (caught in review). (PR [#139](https://github.com/vLannaAi/noy-db/pull/139))
   - **User-list visibility flags** ([#122](https://github.com/vLannaAi/noy-db/issues/122)) — per-user `hidden` flag at `_meta/visibility/<keyringId>` (sidecar plaintext bypass, mirrors `_meta/policy`) set via `vault.user.setMyVisibility({ hidden: true })` (own-only); vault-level `directory.enabled` at `_meta/directory` toggled via `Noydb.setDirectoryEnabled(vault, enabled)` (owner-only). `listUsersWithEnvelopes` filters hidden envelopes by default; admin/owner pass `{ includeHidden: true }`. New `DirectoryDisabledError`. **Breaking API surface change**: `listUsersWithEnvelopes` gained a required `callerRole: Role` parameter. Honest caveat documented: visibility is a UX flag, not a privacy guarantee — keyring count + envelope ciphertext remain observable to anyone with store-read access. Lifecycle: `revoke()` also deletes the visibility sidecar (commit `6f5543c`, caught in review). (PR [#140](https://github.com/vLannaAi/noy-db/pull/140))
   - **Closed without code** ([#132](https://github.com/vLannaAi/noy-db/issues/132)) — `withDerivation` pre-hashed register was superseded by #130: plugging the bundle regression dynamically imports `DerivationRegistry`, so the `Vault` constructor can no longer reference `new DerivationRegistry()` directly. Closed with rationale; revisit if anyone hits the `Noydb.vault()` sync fallback gap in practice.
-  - **Known follow-ups for pre.13** — remaining real-provider showcase batch (Apple / Google / LINE): [#64](https://github.com/vLannaAi/noy-db/issues/64), [#65](https://github.com/vLannaAi/noy-db/issues/65), [#73](https://github.com/vLannaAi/noy-db/issues/73), [#74](https://github.com/vLannaAi/noy-db/issues/74), [#75](https://github.com/vLannaAi/noy-db/issues/75), [#76](https://github.com/vLannaAi/noy-db/issues/76).
+  - **Follow-ups (see § In flight above)** — pre.13 deferred; pre.14 reframed as Dim 14 v2 + Guards/Derivations v1.5.
 - **Guards + Derivations subsystems (v0.1.0-pre.11).** Two new write-path primitives land in the same release, plus tier-2 auth showcase coverage.
   - **`withGuard`** ([#123](https://github.com/vLannaAi/noy-db/issues/123)) — record-level lock + field-level freeze + role-gated amendment invariant, dispatched inside `Collection.put` / `.delete`. Amendments write a dedicated `op: 'amendment'` ledger entry; `verifyBackupIntegrity` and `reconstructAtVersion` skip them when reconstructing the canonical record stream. Four error classes: `RecordLockedError` / `FieldFrozenError` / `InvariantError` / `AmendmentForbiddenError`. Cross-collection invariants get a `ReadOnlyVaultFacade` for sibling reads. New `@noy-db/hub/guards` subpath. (#123, #124, #125, #126, #127, #128)
   - **`withDerivation`** ([#129](https://github.com/vLannaAi/noy-db/issues/129)) — Dim 14 v1. Deterministic source → outputs with eager dispatch on `Collection.put` + lazy resolution on `Collection.get`. `computeStrategyHash` (SHA-256 over source + sorted outputs + derive.toString()) detects drift; `DerivationRegistry` runs DFS cycle detection at vault open. `vault.deriveAll(collection)` provides the bulk recompute primitive. Four error classes: `DerivationCycleError` / `DerivationDepthError` / `DerivationOutputUnknownError` / `DerivationOutputShapeError`. New `@noy-db/hub/derivations` subpath. (#129)

--- a/docs/subsystems/derivations.md
+++ b/docs/subsystems/derivations.md
@@ -119,6 +119,28 @@ Semantics:
 
 Same behavior on eager and lazy lifecycles, and through `vault.deriveAll()`.
 
+#### Tombstone-vs-onDelete composition
+
+A tombstone is a **system-internal** delete: the derivation engine
+revoking its own prior emission because the source flipped to the
+"no output" branch. User `onDelete` guards registered on the output
+collection are **not** consulted on tombstones — same way amendments
+bypass user-facing hooks. If they fired, a consumer registering both
+(a) an `optional: true` derivation and (b) an `onDelete: () => throw`
+on the output collection would deadlock: every flip-to-null source
+write would block on the user's own append-only rule.
+
+Concretely: if you ship a `paymentAllocation → receipt` derivation with
+`optional: true`, AND `receipts.onDelete: throw` for legal-document
+immutability, **the tombstone bypass keeps both coherent**. Users can
+no longer manually delete a receipt (good), and the system can still
+revoke its own prior emission when the underlying allocation
+restructures (also good).
+
+The bypass is scoped to the system-internal delete path
+(`Collection._internalDelete`); a user-initiated `Collection.delete`
+on the same record still fires `onDelete` normally.
+
 ### Lifecycles
 
 - **`eager`** — derive runs synchronously inside the source-write transaction.

--- a/docs/subsystems/derivations.md
+++ b/docs/subsystems/derivations.md
@@ -90,6 +90,35 @@ fingerprint sibling-record content).
 Available on both lifecycles: the eager dispatch and the lazy
 resolve-on-read paths both pass the same facade.
 
+### Optional outputs (#144)
+
+Declare an output as `optional: true` to let `derive` return `null` for
+that key:
+
+```ts
+outputs: {
+  receipt: { shape: 'record', collection: 'receipts', optional: true },
+},
+derive: (alloc) => ({
+  receipt: alloc.servicesNetPortion > 0
+    ? { id: alloc.id, paymentId: alloc.paymentId, appliedAmount: alloc.appliedAmount }
+    : null,
+})
+```
+
+Semantics:
+
+- `null` (or `undefined`) for an optional output → no write fires.
+- If a previous derivation emitted an output at this id, it's **deleted**
+  (tombstone for derived data). The eager path captures the prior
+  envelope on the active TxContext so the delete rolls back alongside
+  the source op on transaction failure (#133).
+- A never-emitted optional output is a silent no-op.
+- Returning `null` for a required output (default — no `optional` flag)
+  still throws `DerivationOutputShapeError`.
+
+Same behavior on eager and lazy lifecycles, and through `vault.deriveAll()`.
+
 ### Lifecycles
 
 - **`eager`** — derive runs synchronously inside the source-write transaction.

--- a/docs/subsystems/derivations.md
+++ b/docs/subsystems/derivations.md
@@ -52,6 +52,44 @@ const db = await createNoydb({
 
 ## API
 
+### `derive(source, ctx)` and the read-only vault facade
+
+The `derive` function receives a second argument: a `DerivationContext`
+carrying the same `ReadOnlyVaultFacade` guards see as `ctx.vault`. Use it
+to fetch sibling records without denormalising them onto the source row.
+
+```ts
+withDerivation<Allocation, { receipt: Receipt }>({
+  source: 'allocations',
+  deterministic: true,
+  outputs: { receipt: { shape: 'record', collection: 'receipts' } },
+  derive: async (alloc, ctx) => {
+    const payment = await ctx.vault.collection<Payment>('payments').get(alloc.paymentId)
+    const bill = await ctx.vault.collection<Bill>('bills').get(alloc.billId)
+    return {
+      receipt: {
+        id: alloc.id,
+        paymentId: alloc.paymentId,
+        issuedAt: payment!.paymentDate,
+        clientId: bill!.clientId,
+        appliedAmount: alloc.appliedAmount,
+      },
+    }
+  },
+  lifecycle: 'eager',
+})
+```
+
+`ctx.vault` exposes `.get(id)`, `.list()`, and `.query()` — no write
+capability is reachable from the facade. The strategy hash incorporates
+`derive.toString()`, so the function source pins the inputs; whatever
+sibling reads happen inside `derive` must be deterministic given the
+same source record (the consumer's responsibility — the hash does not
+fingerprint sibling-record content).
+
+Available on both lifecycles: the eager dispatch and the lazy
+resolve-on-read paths both pass the same facade.
+
 ### Lifecycles
 
 - **`eager`** — derive runs synchronously inside the source-write transaction.

--- a/docs/subsystems/guards.md
+++ b/docs/subsystems/guards.md
@@ -159,6 +159,48 @@ boundary**. The store sees only ciphertext envelopes. The
 `ReadOnlyVaultFacade` passed as `ctx.vault` decrypts on access — no
 plaintext leaks to the store.
 
+### `ReadOnlyVaultFacade` surface
+
+```ts
+ctx.vault.collection<T>(name).get(id)    // single record
+ctx.vault.collection<T>(name).list()     // every record (decrypts all)
+ctx.vault.collection<T>(name).query()    // chainable read-only builder
+```
+
+`query()` returns the same `Query<T>` builder used elsewhere in the
+library. Its terminals (`toArray`, `first`, `count`, `aggregate`,
+`groupBy`, `live`) are read-only — there is no `.update()` / `.delete()`
+on a `Query`. Prefer `.query().aggregate({ ... })` over `.list()` +
+manual reduce when enforcing Σ-style invariants: only the records the
+predicate touches get materialised, and the aggregate path is the same
+one used by the rest of the library.
+
+```ts
+// Σ-over-siblings invariant — payment-allocation sum must not exceed payment
+import { sum } from '@noy-db/hub'
+
+withGuard<Allocation>({
+  collection: 'allocations',
+  check: async (incoming, { vault, existing }) => {
+    const payment = await vault.collection<Payment>('payments').get(incoming.paymentId)
+    const { total } = await vault
+      .collection<Allocation>('allocations')
+      .query()
+      .where('paymentId', '==', incoming.paymentId)
+      .aggregate({ total: sum<Allocation>('appliedAmount') })
+      .run()
+    const otherTotal = total - (existing?.appliedAmount ?? 0)
+    if (otherTotal + incoming.appliedAmount > payment.amount) {
+      throw new InvariantError('allocations', incoming.id, '…')
+    }
+  },
+})
+```
+
+Aggregates require the `aggregateStrategy: withAggregate()` opt-in (the
+same opt-in everything else in the query DSL respects) — `query()`
+itself is always present on the facade.
+
 ### Audit-entry shape
 
 ```ts

--- a/docs/subsystems/guards.md
+++ b/docs/subsystems/guards.md
@@ -59,13 +59,19 @@ const db = await createNoydb({
 
 ## API
 
-Three primitives, one strategy:
+Four primitives, one strategy:
 
 | Primitive | When it fires | Throws |
 |---|---|---|
-| `check` | Every `put()` / `delete()` (skipped in amendment mode) | Anything; conventionally `RecordLockedError` |
+| `check` | Every `put()` (skipped in amendment mode) | Anything; conventionally `RecordLockedError` |
+| `onDelete` | Every `delete()` of an existing record (skipped in amendment mode); skipped for delete-of-absent | Anything; conventionally `RecordLockedError` |
 | `frozenFields` | Every `put()` after `when(existing)` becomes true | `FieldFrozenError` listing changed frozen fields |
 | `amendment` | Inside `withTransactions({ amendment: true, reason })` | `InvariantError` if the rule fails |
+
+`check` is put-only — `onDelete` is the dedicated delete-time hook. The
+argument shapes mirror each other but the semantics are explicit:
+`check(incoming, ctx)` validates a record being **written**;
+`onDelete(existing, ctx)` validates a record being **removed**.
 
 ### Amendment flow
 

--- a/docs/subsystems/guards.md
+++ b/docs/subsystems/guards.md
@@ -75,15 +75,24 @@ argument shapes mirror each other but the semantics are explicit:
 
 ### `onDelete` bypass paths
 
-Two paths skip `onDelete`. Both are by design:
+Two paths skip the `onDelete` callback. Both are by design:
 
 1. **Amendment transactions** (`db.transaction({ amendment: true })`)
    for admin/owner — amendments are the generic unlock primitive,
-   consistent with how `frozenFields` lets staged writes through.
+   consistent with how `frozenFields` lets staged writes through. The
+   `amendment.invariant` block (if declared) DOES still see the
+   `{ before, after: null }` change pair and can reject the delete at
+   commit time.
 2. **System-internal deletes** — derivation tombstones (#144) and MV
    refresh deletes (Dim 14 v2) route through an internal-only delete
    path. Housekeeping ops are not user-initiated and would otherwise
-   trip user invariants registered against output collections.
+   trip user invariants registered against output collections. **If
+   the internal delete fires while an amendment window is open**
+   (e.g. an admin amendment edits a source row → triggers a
+   derivation cascade → cascades a tombstone), the change pair IS
+   pushed onto the amendment's change-set and surfaces to
+   `amendment.invariant`. This keeps the "truly unconditional" paired
+   pattern below honest.
 
 ### Truly unconditional delete-block — pair the two hooks
 

--- a/docs/subsystems/guards.md
+++ b/docs/subsystems/guards.md
@@ -73,6 +73,49 @@ argument shapes mirror each other but the semantics are explicit:
 `check(incoming, ctx)` validates a record being **written**;
 `onDelete(existing, ctx)` validates a record being **removed**.
 
+### `onDelete` bypass paths
+
+Two paths skip `onDelete`. Both are by design:
+
+1. **Amendment transactions** (`db.transaction({ amendment: true })`)
+   for admin/owner — amendments are the generic unlock primitive,
+   consistent with how `frozenFields` lets staged writes through.
+2. **System-internal deletes** — derivation tombstones (#144) and MV
+   refresh deletes (Dim 14 v2) route through an internal-only delete
+   path. Housekeeping ops are not user-initiated and would otherwise
+   trip user invariants registered against output collections.
+
+### Truly unconditional delete-block — pair the two hooks
+
+`onDelete: () => { throw }` alone is NOT unconditional. An admin
+amendment can still bypass it. For legal-document immutability rules
+(e.g. Thai Revenue Code §86: receipts are append-only forever) pair
+`onDelete` with an `amendment.invariant` that re-throws on any
+delete-shaped change:
+
+```ts
+withGuard<Receipt>({
+  collection: 'receipts',
+  onDelete: () => {
+    throw new RecordLockedError('receipts', '', 'receipts are append-only')
+  },
+  amendment: {
+    roles: ['admin', 'owner'],
+    invariant: (changes) => {
+      for (const c of changes) {
+        if (c.before !== null && c.after === null) {
+          throw new RecordLockedError('receipts', '', 'amendment cannot delete')
+        }
+      }
+    },
+  },
+})
+```
+
+The thrown `RecordLockedError` inside `invariant` is wrapped in
+`InvariantError` by `GuardExecutor.runInvariant` (the message survives);
+the staged delete rolls back, the record stays.
+
 ### Amendment flow
 
 ```

--- a/packages/hub/__tests__/derivations/ctx-vault.test.ts
+++ b/packages/hub/__tests__/derivations/ctx-vault.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withDerivation } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface Payment extends Record<string, unknown> { id: string; paymentDate: string; amount: number }
+interface Bill extends Record<string, unknown> { id: string; clientId: string; netRemaining: number }
+interface Allocation extends Record<string, unknown> { id: string; paymentId: string; billId: string; appliedAmount: number }
+interface Receipt extends Record<string, unknown> {
+  id: string
+  paymentId: string
+  billId: string
+  clientId: string
+  issuedAt: string
+  appliedAmount: number
+}
+
+describe('Derivation — ctx.vault facade (#147)', () => {
+  it('derive(source, ctx) can read sibling collections via ctx.vault.collection().get()', async () => {
+    const strategy = withDerivation<Allocation, { receipt: Receipt }>({
+      source: 'allocations',
+      deterministic: true,
+      outputs: { receipt: { shape: 'record', collection: 'receipts' } },
+      derive: async (alloc, ctx) => {
+        // Without ctx, paymentDate/clientId would have to be denormalised
+        // onto the Allocation row and frozen by a paired withGuard.
+        // With ctx.vault we read them directly off the sibling records.
+        const payment = await ctx.vault.collection<Payment>('payments').get(alloc.paymentId)
+        const bill = await ctx.vault.collection<Bill>('bills').get(alloc.billId)
+        if (!payment) throw new Error(`allocation ${alloc.id}: unknown paymentId ${alloc.paymentId}`)
+        if (!bill) throw new Error(`allocation ${alloc.id}: unknown billId ${alloc.billId}`)
+        return {
+          receipt: {
+            id: alloc.id,
+            paymentId: alloc.paymentId,
+            billId: alloc.billId,
+            clientId: bill.clientId,
+            issuedAt: payment.paymentDate,
+            appliedAmount: alloc.appliedAmount,
+          },
+        }
+      },
+      lifecycle: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-ctx-vault-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+
+    await v.collection<Payment>('payments').put('p1', { id: 'p1', paymentDate: '2026-05-19', amount: 1000 })
+    await v.collection<Bill>('bills').put('b1', { id: 'b1', clientId: 'c-acme', netRemaining: 600 })
+    await v.collection<Allocation>('allocations').put('a1', {
+      id: 'a1', paymentId: 'p1', billId: 'b1', appliedAmount: 400,
+    })
+
+    const receipt = await v.collection<Receipt>('receipts').get('a1')
+    expect(receipt).toMatchObject({
+      id: 'a1',
+      paymentId: 'p1',
+      billId: 'b1',
+      clientId: 'c-acme',
+      issuedAt: '2026-05-19',
+      appliedAmount: 400,
+    })
+  })
+
+  it('ctx.vault has no write capability — no .put / .delete reachable through the facade', async () => {
+    let capturedCtx: unknown = null
+    const strategy = withDerivation<{ id: string; v: number }, { out: { id: string; v: number } }>({
+      source: 'src',
+      deterministic: true,
+      outputs: { out: { shape: 'record', collection: 'out' } },
+      derive: (s, ctx) => {
+        capturedCtx = ctx
+        return { out: { id: s.id, v: s.v } }
+      },
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-ctx-no-writes-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+    await v.collection<{ id: string; v: number }>('src').put('s1', { id: 's1', v: 42 })
+
+    const ctx = capturedCtx as { vault: { collection: (n: string) => Record<string, unknown> } }
+    expect(typeof ctx.vault.collection).toBe('function')
+    const accessor = ctx.vault.collection('out')
+    expect(Object.prototype.hasOwnProperty.call(accessor, 'put')).toBe(false)
+    expect(Object.prototype.hasOwnProperty.call(accessor, 'delete')).toBe(false)
+    expect(typeof (accessor as { get?: unknown }).get).toBe('function')
+    expect(typeof (accessor as { list?: unknown }).list).toBe('function')
+    expect(typeof (accessor as { query?: unknown }).query).toBe('function')
+  })
+
+  it('lazy lifecycle: ctx.vault is available on resolve-on-read too', async () => {
+    const strategy = withDerivation<Allocation, { receipt: Receipt }>({
+      source: 'allocations',
+      deterministic: true,
+      outputs: { receipt: { shape: 'record', collection: 'receipts' } },
+      derive: async (alloc, ctx) => {
+        const payment = await ctx.vault.collection<Payment>('payments').get(alloc.paymentId)
+        const bill = await ctx.vault.collection<Bill>('bills').get(alloc.billId)
+        return {
+          receipt: {
+            id: alloc.id,
+            paymentId: alloc.paymentId,
+            billId: alloc.billId,
+            clientId: bill?.clientId ?? '',
+            issuedAt: payment?.paymentDate ?? '',
+            appliedAmount: alloc.appliedAmount,
+          },
+        }
+      },
+      lifecycle: 'lazy',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-ctx-vault-lazy-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+
+    await v.collection<Payment>('payments').put('p1', { id: 'p1', paymentDate: '2026-05-20', amount: 500 })
+    await v.collection<Bill>('bills').put('b1', { id: 'b1', clientId: 'c-beta', netRemaining: 250 })
+    await v.collection<Allocation>('allocations').put('a1', {
+      id: 'a1', paymentId: 'p1', billId: 'b1', appliedAmount: 250,
+    })
+    // Force a re-derive on read: lazy mode marks stale on source write,
+    // resolves the receipt on first get(). The sibling reads through
+    // ctx.vault prove the facade is wired into the lazy path too.
+    await v.collection<Allocation>('allocations').put('a1', {
+      id: 'a1', paymentId: 'p1', billId: 'b1', appliedAmount: 250,
+    })
+
+    const receipt = await v.collection<Receipt>('receipts').get('a1')
+    expect(receipt?.clientId).toBe('c-beta')
+    expect(receipt?.issuedAt).toBe('2026-05-20')
+  })
+})

--- a/packages/hub/__tests__/derivations/optional-outputs.test.ts
+++ b/packages/hub/__tests__/derivations/optional-outputs.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { createNoydb, withDerivation, DerivationOutputShapeError } from '../../src/index.js'
+import { createNoydb, withDerivation, withGuard, DerivationOutputShapeError, RecordLockedError } from '../../src/index.js'
+import { withTransactions } from '../../src/tx/index.js'
 import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
 
 function memory(): NoydbStore {
@@ -142,6 +143,170 @@ describe('withDerivation — optional outputs (#144)', () => {
     await expect(
       v.collection<Pdf>('pdfs').put('p1', { id: 'p1', body: 'hello' }),
     ).rejects.toBeInstanceOf(DerivationOutputShapeError)
+  })
+
+  it('tombstone does NOT fire user onDelete on the output collection — eager path (PR #148 review)', async () => {
+    // The RCT-CANCEL-001 + RCT-TRIGGER-001 combination:
+    //   - `receipts` declares onDelete: throw (receipts are append-only)
+    //   - `paymentAllocation → receipt` has optional: true (expense-only
+    //     allocations emit null)
+    // Naïve impl: tombstone of an expense-only allocation calls public
+    // `Collection.delete` on receipts, which fires onDelete, which throws,
+    // which fails every expense-only allocation put. Niwat's blocker.
+    let onDeleteFired = 0
+    const allocationDerivation = withDerivation<Allocation, { receipt: Receipt }>({
+      source: 'allocations',
+      deterministic: true,
+      outputs: { receipt: { shape: 'record', collection: 'receipts', optional: true } },
+      derive: (alloc) => ({
+        receipt: alloc.servicesNetPortion > 0
+          ? { id: alloc.id, paymentId: alloc.paymentId, appliedAmount: alloc.appliedAmount }
+          : null,
+      }) as { receipt: Receipt | null },
+      lifecycle: 'eager',
+    })
+    const receiptGuard = withGuard<Receipt>({
+      collection: 'receipts',
+      onDelete: () => {
+        onDeleteFired++
+        throw new RecordLockedError('receipts', '', 'receipts are append-only (RCT-CANCEL-001)')
+      },
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-tombstone-bypasses-ondelete-passphrase-2026',
+      derivationStrategies: [allocationDerivation],
+      guardStrategies: [receiptGuard],
+    })
+    const v = await db.openVault('demo')
+
+    // First put: services-touching → receipt emitted (no delete, onDelete idle)
+    await v.collection<Allocation>('allocations').put('a1', {
+      id: 'a1', paymentId: 'p1', appliedAmount: 500, servicesNetPortion: 400,
+    })
+    expect(await v.collection<Receipt>('receipts').get('a1')).not.toBeNull()
+    expect(onDeleteFired).toBe(0)
+
+    // Flip to expense-only: tombstone must delete the receipt WITHOUT
+    // firing the user's onDelete (system-internal op).
+    await expect(
+      v.collection<Allocation>('allocations').put('a1', {
+        id: 'a1', paymentId: 'p1', appliedAmount: 500, servicesNetPortion: 0,
+      }),
+    ).resolves.not.toThrow()
+    expect(await v.collection<Receipt>('receipts').get('a1')).toBeNull()
+    expect(onDeleteFired).toBe(0) // user onDelete must NOT have fired
+
+    // User-initiated delete: onDelete SHOULD fire and block the call —
+    // proves the system-internal bypass is scoped to tombstones, not a
+    // global escape hatch.
+    await v.collection<Receipt>('receipts').put('manual-r', { id: 'manual-r', paymentId: 'px', appliedAmount: 1 })
+    await expect(
+      v.collection('receipts').delete('manual-r'),
+    ).rejects.toBeInstanceOf(RecordLockedError)
+    expect(onDeleteFired).toBe(1)
+  })
+
+  it('tombstone does NOT fire user onDelete — lazy path', async () => {
+    let onDeleteFired = 0
+    const allocationDerivation = withDerivation<Allocation, { receipt: Receipt }>({
+      source: 'allocations',
+      deterministic: true,
+      outputs: { receipt: { shape: 'record', collection: 'receipts', optional: true } },
+      derive: (alloc) => ({
+        receipt: alloc.servicesNetPortion > 0
+          ? { id: alloc.id, paymentId: alloc.paymentId, appliedAmount: alloc.appliedAmount }
+          : null,
+      }) as { receipt: Receipt | null },
+      lifecycle: 'lazy',
+    })
+    const receiptGuard = withGuard<Receipt>({
+      collection: 'receipts',
+      onDelete: () => {
+        onDeleteFired++
+        throw new RecordLockedError('receipts', '', 'append-only')
+      },
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-tombstone-lazy-bypasses-ondelete-passphrase-2026',
+      derivationStrategies: [allocationDerivation],
+      guardStrategies: [receiptGuard],
+    })
+    const v = await db.openVault('demo')
+    await v.collection<Allocation>('allocations').put('a1', {
+      id: 'a1', paymentId: 'p1', appliedAmount: 500, servicesNetPortion: 400,
+    })
+    expect(await v.collection<Receipt>('receipts').get('a1')).not.toBeNull()
+
+    // Flip + re-read: tombstone must fire silently inside resolveStaleOnRead
+    await v.collection<Allocation>('allocations').put('a1', {
+      id: 'a1', paymentId: 'p1', appliedAmount: 500, servicesNetPortion: 0,
+    })
+    expect(await v.collection<Receipt>('receipts').get('a1')).toBeNull()
+    expect(onDeleteFired).toBe(0)
+  })
+
+  it('lazy tombstone is tx-aware — DerivationStaleAccessor.getActiveTxContext is wired', async () => {
+    // The lazy path's tombstone was historically untracked. PR #148's
+    // first round shipped a new write path on the lazy side without
+    // hooking it into the same #133 TxContext machinery that the eager
+    // path uses. Niwat-review (a) called for closing the gap.
+    //
+    // End-to-end rollback of body-phase lazy tombstones is currently
+    // not architecturally reachable — `_activeTxContext` is set on the
+    // Noydb instance only during runTransaction's Phase 2, not during
+    // the body where `Collection.get()` (and hence resolveStaleOnRead)
+    // runs against the committed store. The fix in this PR is the
+    // INTERFACE wiring: `DerivationStaleAccessor.getActiveTxContext()`
+    // exists, `stale.ts` forwards it into `_internalDelete`, and any
+    // future call path that publishes an active context during a lazy
+    // resolve will correctly register the tombstone for revert.
+    //
+    // This test asserts the wiring: a lazy tombstone fires cleanly
+    // and the underlying `_internalDelete` signature accepts a
+    // TxContext argument (the source-code change that closes the
+    // interface asymmetry).
+    const allocationDerivation = withDerivation<Allocation, { receipt: Receipt }>({
+      source: 'allocations',
+      deterministic: true,
+      outputs: { receipt: { shape: 'record', collection: 'receipts', optional: true } },
+      derive: (alloc) => ({
+        receipt: alloc.servicesNetPortion > 0
+          ? { id: alloc.id, paymentId: alloc.paymentId, appliedAmount: alloc.appliedAmount }
+          : null,
+      }) as { receipt: Receipt | null },
+      lifecycle: 'lazy',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-tombstone-lazy-tx-wiring-passphrase-2026',
+      derivationStrategies: [allocationDerivation],
+      txStrategy: withTransactions(),
+    })
+    const v = await db.openVault('demo')
+
+    await v.collection<Allocation>('allocations').put('a1', {
+      id: 'a1', paymentId: 'p1', appliedAmount: 500, servicesNetPortion: 400,
+    })
+    expect(await v.collection<Receipt>('receipts').get('a1')).not.toBeNull()
+
+    // Flip + lazy re-resolve → tombstone (outside any tx, txCtx = null)
+    await v.collection<Allocation>('allocations').put('a1', {
+      id: 'a1', paymentId: 'p1', appliedAmount: 500, servicesNetPortion: 0,
+    })
+    expect(await v.collection<Receipt>('receipts').get('a1')).toBeNull()
+
+    // Inside a tx body, `_activeTxContext` is null until Phase 2 — the
+    // lazy resolve sees null and skips registration. That matches the
+    // committed-state read semantics of body-phase `tx.vault(...).get()`.
+    await db.transaction(async (tx) => {
+      const r = await tx.vault('demo').collection<Receipt>('receipts').get('a1')
+      expect(r).toBeNull()
+    })
   })
 
   it('lazy lifecycle: skipped output reads as null + a prior emission is removed on re-resolve', async () => {

--- a/packages/hub/__tests__/derivations/optional-outputs.test.ts
+++ b/packages/hub/__tests__/derivations/optional-outputs.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withDerivation, DerivationOutputShapeError } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface Allocation extends Record<string, unknown> {
+  id: string
+  paymentId: string
+  appliedAmount: number
+  servicesNetPortion: number
+}
+interface Receipt extends Record<string, unknown> {
+  id: string
+  paymentId: string
+  appliedAmount: number
+}
+
+describe('withDerivation — optional outputs (#144)', () => {
+  it('omits the output entirely when derive returns null for an optional key', async () => {
+    // RCT-TRIGGER-001: receipts only exist for services-touching allocations
+    const strategy = withDerivation<Allocation, { receipt: Receipt }>({
+      source: 'allocations',
+      deterministic: true,
+      outputs: { receipt: { shape: 'record', collection: 'receipts', optional: true } },
+      derive: (alloc) => ({
+        receipt: alloc.servicesNetPortion > 0
+          ? { id: alloc.id, paymentId: alloc.paymentId, appliedAmount: alloc.appliedAmount }
+          : null,
+        // Type assertion: TS sees the union via the runtime branch above.
+      }) as { receipt: Receipt | null },
+      lifecycle: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-optional-outputs-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+
+    // Services-touching → receipt emitted
+    await v.collection<Allocation>('allocations').put('a1', {
+      id: 'a1', paymentId: 'p1', appliedAmount: 500, servicesNetPortion: 400,
+    })
+    expect(await v.collection<Receipt>('receipts').get('a1')).toMatchObject({
+      id: 'a1', appliedAmount: 500,
+    })
+
+    // Expense-only (servicesNetPortion === 0) → no receipt
+    await v.collection<Allocation>('allocations').put('a2', {
+      id: 'a2', paymentId: 'p1', appliedAmount: 100, servicesNetPortion: 0,
+    })
+    expect(await v.collection<Receipt>('receipts').get('a2')).toBeNull()
+  })
+
+  it('deletes a previously-emitted output when the next derivation returns null', async () => {
+    const strategy = withDerivation<Allocation, { receipt: Receipt }>({
+      source: 'allocations',
+      deterministic: true,
+      outputs: { receipt: { shape: 'record', collection: 'receipts', optional: true } },
+      derive: (alloc) => ({
+        receipt: alloc.servicesNetPortion > 0
+          ? { id: alloc.id, paymentId: alloc.paymentId, appliedAmount: alloc.appliedAmount }
+          : null,
+      }) as { receipt: Receipt | null },
+      lifecycle: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-optional-delete-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+
+    // First put: emits receipt
+    await v.collection<Allocation>('allocations').put('a1', {
+      id: 'a1', paymentId: 'p1', appliedAmount: 500, servicesNetPortion: 400,
+    })
+    expect(await v.collection<Receipt>('receipts').get('a1')).not.toBeNull()
+
+    // Update: flips to expense-only → receipt should be deleted
+    await v.collection<Allocation>('allocations').put('a1', {
+      id: 'a1', paymentId: 'p1', appliedAmount: 500, servicesNetPortion: 0,
+    })
+    expect(await v.collection<Receipt>('receipts').get('a1')).toBeNull()
+  })
+
+  it('returning null for a NON-optional output still throws DerivationOutputShapeError', async () => {
+    interface Pdf extends Record<string, unknown> { id: string; body: string }
+    interface PdfMeta extends Record<string, unknown> { len: number }
+    const strategy = withDerivation<Pdf, { meta: PdfMeta }>({
+      source: 'pdfs',
+      deterministic: true,
+      // optional NOT set — defaults to required
+      outputs: { meta: { shape: 'record', collection: 'pdf-meta' } },
+      derive: () => ({ meta: null as unknown as PdfMeta }),
+      lifecycle: 'eager',
+      strict: true,
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-required-null-rejects-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+    await expect(
+      v.collection<Pdf>('pdfs').put('p1', { id: 'p1', body: 'hello' }),
+    ).rejects.toBeInstanceOf(DerivationOutputShapeError)
+  })
+
+  it('lazy lifecycle: skipped output reads as null + a prior emission is removed on re-resolve', async () => {
+    const strategy = withDerivation<Allocation, { receipt: Receipt }>({
+      source: 'allocations',
+      deterministic: true,
+      outputs: { receipt: { shape: 'record', collection: 'receipts', optional: true } },
+      derive: (alloc) => ({
+        receipt: alloc.servicesNetPortion > 0
+          ? { id: alloc.id, paymentId: alloc.paymentId, appliedAmount: alloc.appliedAmount }
+          : null,
+      }) as { receipt: Receipt | null },
+      lifecycle: 'lazy',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-optional-lazy-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+
+    // Emission: services-touching
+    await v.collection<Allocation>('allocations').put('a1', {
+      id: 'a1', paymentId: 'p1', appliedAmount: 500, servicesNetPortion: 400,
+    })
+    expect(await v.collection<Receipt>('receipts').get('a1')).not.toBeNull()
+
+    // Flip to skipped: lazy mode marks stale; re-derive on read should
+    // delete the prior receipt.
+    await v.collection<Allocation>('allocations').put('a1', {
+      id: 'a1', paymentId: 'p1', appliedAmount: 500, servicesNetPortion: 0,
+    })
+    expect(await v.collection<Receipt>('receipts').get('a1')).toBeNull()
+  })
+})

--- a/packages/hub/__tests__/derivations/optional-outputs.test.ts
+++ b/packages/hub/__tests__/derivations/optional-outputs.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { createNoydb, withDerivation, withGuard, DerivationOutputShapeError, RecordLockedError } from '../../src/index.js'
 import { withTransactions } from '../../src/tx/index.js'
+import { withHistory } from '../../src/history/index.js'
 import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
 
 function memory(): NoydbStore {
@@ -307,6 +308,127 @@ describe('withDerivation — optional outputs (#144)', () => {
       const r = await tx.vault('demo').collection<Receipt>('receipts').get('a1')
       expect(r).toBeNull()
     })
+  })
+
+  it('idempotency: _internalDelete on absent record writes no ledger entry (deriveAll mass-recompute clean)', async () => {
+    // Niwat-review on #144 (concern A): vault.deriveAll() invokes
+    // _internalDelete(id) without a txCtx for every optional output
+    // that resolves to null. For a vault recomputing thousands of
+    // paymentAllocation → receipt derivations, the ones where the
+    // source never had a services portion (= never emitted a receipt)
+    // should be silent no-ops, not write v0 ledger entries.
+    const strategy = withDerivation<Allocation, { receipt: Receipt }>({
+      source: 'allocations',
+      deterministic: true,
+      outputs: { receipt: { shape: 'record', collection: 'receipts', optional: true } },
+      derive: (alloc) => ({
+        receipt: alloc.servicesNetPortion > 0
+          ? { id: alloc.id, paymentId: alloc.paymentId, appliedAmount: alloc.appliedAmount }
+          : null,
+      }) as { receipt: Receipt | null },
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-deriveAll-idempotency-passphrase-2026',
+      derivationStrategies: [strategy],
+      historyStrategy: withHistory(),
+    })
+    const v = await db.openVault('demo')
+
+    // Seed 3 expense-only allocations — none emit a receipt
+    for (let i = 1; i <= 3; i++) {
+      await v.collection<Allocation>('allocations').put(`a${i}`, {
+        id: `a${i}`, paymentId: 'p1', appliedAmount: 100, servicesNetPortion: 0,
+      })
+    }
+    expect(await v.collection<Receipt>('receipts').get('a1')).toBeNull()
+
+    // Snapshot ledger length, run deriveAll, compare. Should write NO
+    // new entries — every tombstone is delete-of-absent, must be silent.
+    const ledgerBefore = (await v.ledger().entries()).length
+    await v.deriveAll('allocations')
+    const ledgerAfter = (await v.ledger().entries()).length
+    expect(ledgerAfter).toBe(ledgerBefore)
+  })
+
+  it('derivation tombstone inside an admin amendment is visible to amendment.invariant', async () => {
+    // Niwat-review on #145 (concern B): the docs' "TRULY unconditional"
+    // pairing must protect against derivation-driven tombstones fired
+    // during admin amendments, not just direct user deletes.
+    //
+    // Path: admin amendment edits an allocation → re-fires derivation →
+    // emits null → receipt tombstoned. Before the fix the amendment
+    // invariant never saw the change. After the fix collectChange runs
+    // even for system-internal deletes, so the invariant can reject.
+    let invariantSeenDelete = false
+    const allocationDerivation = withDerivation<Allocation, { receipt: Receipt }>({
+      source: 'allocations',
+      deterministic: true,
+      outputs: { receipt: { shape: 'record', collection: 'receipts', optional: true } },
+      derive: (alloc) => ({
+        receipt: alloc.servicesNetPortion > 0
+          ? { id: alloc.id, paymentId: alloc.paymentId, appliedAmount: alloc.appliedAmount }
+          : null,
+      }) as { receipt: Receipt | null },
+      lifecycle: 'eager',
+    })
+    const receiptGuard = withGuard<Receipt>({
+      collection: 'receipts',
+      onDelete: () => {
+        throw new RecordLockedError('receipts', '', 'append-only (normal mode)')
+      },
+      amendment: {
+        roles: ['admin', 'owner'],
+        invariant: (changes) => {
+          for (const c of changes) {
+            if (c.before !== null && c.after === null) {
+              invariantSeenDelete = true
+              throw new RecordLockedError(
+                'receipts',
+                '',
+                'append-only — even amendments cannot delete (RCT-CANCEL-001)',
+              )
+            }
+          }
+        },
+      },
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      role: 'owner',
+      secret: 'derivation-tombstone-in-amendment-passphrase-2026',
+      derivationStrategies: [allocationDerivation],
+      guardStrategies: [receiptGuard],
+      txStrategy: withTransactions(),
+    })
+    const v = await db.openVault('demo')
+
+    // Seed an allocation that DOES emit a receipt
+    await v.collection<Allocation>('allocations').put('a1', {
+      id: 'a1', paymentId: 'p1', appliedAmount: 500, servicesNetPortion: 400,
+    })
+    expect(await v.collection<Receipt>('receipts').get('a1')).not.toBeNull()
+
+    // Admin amendment edits the allocation to expense-only → derivation
+    // re-fires, emits null, tombstones the receipt. The invariant MUST
+    // see the {before, after: null} change and reject.
+    await expect(
+      db.transaction(
+        { vault: 'demo', amendment: true, reason: 'zero out services portion' },
+        async (tx) => {
+          await tx.vault('demo').collection('allocations').put('a1', {
+            id: 'a1', paymentId: 'p1', appliedAmount: 500, servicesNetPortion: 0,
+          })
+        },
+      ),
+    ).rejects.toThrow(/RCT-CANCEL-001/)
+
+    expect(invariantSeenDelete).toBe(true)
+    // Receipt should be restored — invariant rejection rolled back the tombstone
+    expect(await v.collection<Receipt>('receipts').get('a1')).not.toBeNull()
   })
 
   it('lazy lifecycle: skipped output reads as null + a prior emission is removed on re-resolve', async () => {

--- a/packages/hub/__tests__/guards/collection-put.test.ts
+++ b/packages/hub/__tests__/guards/collection-put.test.ts
@@ -103,11 +103,11 @@ describe('Collection.put — guard hook integration', () => {
     ).resolves.not.toThrow()
   })
 
-  it('blocks a delete on a locked record', async () => {
+  it('blocks a delete via onDelete hook (#145)', async () => {
     const guard = withGuard<Line>({
       collection: 'lines',
-      check: async (_incoming, { existing }) => {
-        if (existing) throw new RecordLockedError('lines', 'l1', 'no deletes')
+      onDelete: async (existing) => {
+        throw new RecordLockedError('lines', existing.id, 'no deletes')
       },
     })
     const db = await createNoydb({
@@ -119,5 +119,24 @@ describe('Collection.put — guard hook integration', () => {
     const v = await db.openVault('demo')
     await v.collection<Line>('lines').put('l1', { id: 'l1', invoiceId: 'x', amount: 10 })
     await expect(v.collection('lines').delete('l1')).rejects.toBeInstanceOf(RecordLockedError)
+  })
+
+  it('check is put-only — does not fire on delete', async () => {
+    let checkCalls = 0
+    const guard = withGuard<Line>({
+      collection: 'lines',
+      check: () => { checkCalls++ },
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'guards-check-put-only-passphrase-2026',
+      guardStrategies: [guard],
+    })
+    const v = await db.openVault('demo')
+    await v.collection<Line>('lines').put('l1', { id: 'l1', invoiceId: 'x', amount: 10 })
+    expect(checkCalls).toBe(1)
+    await v.collection('lines').delete('l1')
+    expect(checkCalls).toBe(1) // delete did NOT re-invoke check
   })
 })

--- a/packages/hub/__tests__/guards/on-delete.test.ts
+++ b/packages/hub/__tests__/guards/on-delete.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withGuard, RecordLockedError } from '../../src/index.js'
+import { withTransactions } from '../../src/tx/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface Invoice extends Record<string, unknown> {
+  id: string
+  status: 'new' | 'draft' | 'sent' | 'paid' | 'cancelled'
+  total: number
+}
+
+describe('withGuard.onDelete (#145)', () => {
+  it('rejects delete when onDelete throws — BILL-DELETE-001 shape', async () => {
+    // Only unsent / cancelled invoices may be deleted.
+    const guard = withGuard<Invoice>({
+      collection: 'invoices',
+      onDelete: (existing) => {
+        if (!['new', 'draft', 'cancelled'].includes(existing.status)) {
+          throw new RecordLockedError(
+            'invoices',
+            existing.id,
+            `cannot delete invoice in status "${existing.status}"`,
+          )
+        }
+      },
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'guards-ondelete-bill-delete-passphrase-2026',
+      guardStrategies: [guard],
+    })
+    const v = await db.openVault('demo')
+    const invs = v.collection<Invoice>('invoices')
+
+    await invs.put('inv1', { id: 'inv1', status: 'draft', total: 100 })
+    await invs.put('inv2', { id: 'inv2', status: 'sent', total: 200 })
+    await invs.put('inv3', { id: 'inv3', status: 'cancelled', total: 300 })
+
+    // draft → allowed
+    await expect(invs.delete('inv1')).resolves.not.toThrow()
+    // sent → rejected
+    await expect(invs.delete('inv2')).rejects.toBeInstanceOf(RecordLockedError)
+    // cancelled → allowed
+    await expect(invs.delete('inv3')).resolves.not.toThrow()
+    // record still present after rejected delete
+    expect(await invs.get('inv2')).not.toBeNull()
+  })
+
+  it('skips onDelete entirely when target record is absent (idempotent delete)', async () => {
+    let onDeleteCalls = 0
+    const guard = withGuard<Invoice>({
+      collection: 'invoices',
+      onDelete: () => { onDeleteCalls++ },
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'guards-ondelete-absent-passphrase-2026',
+      guardStrategies: [guard],
+    })
+    const v = await db.openVault('demo')
+    await v.collection<Invoice>('invoices').delete('never-existed')
+    expect(onDeleteCalls).toBe(0)
+  })
+
+  it('receives ctx.vault — cross-collection check on delete', async () => {
+    interface Receipt extends Record<string, unknown> { id: string; invoiceId: string }
+    // Reject delete of an invoice if a receipt references it.
+    const guard = withGuard<Invoice>({
+      collection: 'invoices',
+      onDelete: async (existing, ctx) => {
+        const receipts = await ctx.vault.collection<Receipt>('receipts').list()
+        if (receipts.some(r => r.invoiceId === existing.id)) {
+          throw new RecordLockedError(
+            'invoices',
+            existing.id,
+            'has receipts referencing it',
+          )
+        }
+      },
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'guards-ondelete-cross-collection-passphrase-2026',
+      guardStrategies: [guard],
+    })
+    const v = await db.openVault('demo')
+    await v.collection<Invoice>('invoices').put('inv1', { id: 'inv1', status: 'paid', total: 500 })
+    await v.collection<Invoice>('invoices').put('inv2', { id: 'inv2', status: 'cancelled', total: 100 })
+    await v.collection<Receipt>('receipts').put('r1', { id: 'r1', invoiceId: 'inv1' })
+
+    await expect(v.collection('invoices').delete('inv1')).rejects.toBeInstanceOf(RecordLockedError)
+    await expect(v.collection('invoices').delete('inv2')).resolves.not.toThrow()
+  })
+
+  it('bypassed inside an amendment transaction (admin override)', async () => {
+    let onDeleteCalls = 0
+    const guard = withGuard<Invoice>({
+      collection: 'invoices',
+      onDelete: () => { onDeleteCalls++; throw new RecordLockedError('invoices', '', 'no normal-mode deletes') },
+      amendment: {
+        roles: ['admin', 'owner'],
+        invariant: () => {/* allow */},
+      },
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      role: 'owner',
+      secret: 'guards-ondelete-amendment-passphrase-2026',
+      guardStrategies: [guard],
+      txStrategy: withTransactions(),
+    })
+    const v = await db.openVault('demo')
+    const invs = v.collection<Invoice>('invoices')
+    await invs.put('inv1', { id: 'inv1', status: 'paid', total: 999 })
+
+    // Normal-mode delete: onDelete fires and rejects
+    await expect(invs.delete('inv1')).rejects.toBeInstanceOf(RecordLockedError)
+    expect(onDeleteCalls).toBe(1)
+
+    // Amendment delete: onDelete skipped, invariant runs at commit
+    await db.transaction(
+      { vault: 'demo', amendment: true, reason: 'historical correction' },
+      async (tx) => {
+        await tx.vault('demo').collection('invoices').delete('inv1')
+      },
+    )
+    expect(onDeleteCalls).toBe(1) // not incremented during amendment
+    expect(await invs.get('inv1')).toBeNull()
+  })
+})

--- a/packages/hub/__tests__/guards/on-delete.test.ts
+++ b/packages/hub/__tests__/guards/on-delete.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { createNoydb, withGuard, RecordLockedError } from '../../src/index.js'
+import { createNoydb, withGuard, RecordLockedError, InvariantError } from '../../src/index.js'
 import { withTransactions } from '../../src/tx/index.js'
 import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
 
@@ -163,5 +163,72 @@ describe('withGuard.onDelete (#145)', () => {
     )
     expect(onDeleteCalls).toBe(1) // not incremented during amendment
     expect(await invs.get('inv1')).toBeNull()
+  })
+
+  it('unconditional delete-block — pair onDelete + amendment.invariant (RCT-CANCEL-001 shape)', async () => {
+    // Niwat-review on #145: `onDelete: () => throw` alone is NOT
+    // unconditional — admin amendments still bypass it. For
+    // legal-document immutability (e.g. Thai Revenue Code §86: receipts
+    // are append-only forever), the consumer must pair the two hooks:
+    //
+    //   - `onDelete` blocks normal-mode user deletes
+    //   - `amendment.invariant` re-throws on any `before !== null &&
+    //     after === null` change, blocking the amendment escape too
+    //
+    // This test pins the canonical pairing so consumers copying the
+    // worked example don't ship with a silent amendment-shaped gap.
+    interface Receipt extends Record<string, unknown> { id: string; amount: number }
+    const guard = withGuard<Receipt>({
+      collection: 'receipts',
+      onDelete: () => {
+        throw new RecordLockedError('receipts', '', 'receipts are append-only (RCT-CANCEL-001)')
+      },
+      amendment: {
+        roles: ['admin', 'owner'],
+        invariant: (changes) => {
+          for (const c of changes) {
+            if (c.before !== null && c.after === null) {
+              throw new RecordLockedError(
+                'receipts',
+                '',
+                'receipts are append-only — amendment cannot delete (RCT-CANCEL-001)',
+              )
+            }
+          }
+        },
+      },
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      role: 'owner',
+      secret: 'guards-ondelete-unconditional-passphrase-2026',
+      guardStrategies: [guard],
+      txStrategy: withTransactions(),
+    })
+    const v = await db.openVault('demo')
+    await v.collection<Receipt>('receipts').put('r1', { id: 'r1', amount: 100 })
+
+    // Normal-mode delete: blocked by onDelete
+    await expect(
+      v.collection('receipts').delete('r1'),
+    ).rejects.toBeInstanceOf(RecordLockedError)
+    expect(await v.collection<Receipt>('receipts').get('r1')).not.toBeNull()
+
+    // Amendment delete: blocked by invariant at commit (onDelete IS
+    // bypassed as designed; invariant catches it). The thrown
+    // RecordLockedError is wrapped in InvariantError by
+    // GuardExecutor.runInvariant — the message survives.
+    await expect(
+      db.transaction(
+        { vault: 'demo', amendment: true, reason: 'attempt to delete' },
+        async (tx) => {
+          await tx.vault('demo').collection('receipts').delete('r1')
+        },
+      ),
+    ).rejects.toThrow(/RCT-CANCEL-001/)
+    expect(InvariantError).toBeDefined() // sanity import
+    // Record still present — invariant rolled back the staged delete
+    expect(await v.collection<Receipt>('receipts').get('r1')).not.toBeNull()
   })
 })

--- a/packages/hub/__tests__/guards/read-only-facade.test.ts
+++ b/packages/hub/__tests__/guards/read-only-facade.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { createNoydb } from '../../src/index.js'
+import { createNoydb, withGuard, InvariantError } from '../../src/index.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/types.js'
 import { ConflictError } from '../../src/errors.js'
 import { ReadOnlyVaultFacade } from '../../src/guards/read-only-facade.js'
+import { sum } from '../../src/aggregate/reducers.js'
+import { withAggregate } from '../../src/aggregate/index.js'
 
 function memory(): NoydbStore {
   const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
@@ -73,5 +75,90 @@ describe('ReadOnlyVaultFacade', () => {
     // No put/delete methods exposed
     expect((facade.collection('widgets') as object).hasOwnProperty('put')).toBe(false)
     expect((facade.collection('widgets') as object).hasOwnProperty('delete')).toBe(false)
+  })
+
+  it('exposes query() returning a chainable Query builder', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'guards-readonly-facade-query-passphrase-2026',
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('demo')
+    const widgets = vault.collection<{ name: string; price: number }>('widgets')
+    await widgets.put('w1', { name: 'red', price: 100 })
+    await widgets.put('w2', { name: 'blue', price: 200 })
+    await widgets.put('w3', { name: 'red', price: 150 })
+
+    const facade = new ReadOnlyVaultFacade(vault)
+    const q = facade.collection<{ name: string; price: number }>('widgets').query()
+
+    const reds = await q.where('name', '==', 'red').toArray()
+    expect(reds).toHaveLength(2)
+
+    const total = await facade
+      .collection<{ name: string; price: number }>('widgets')
+      .query()
+      .where('name', '==', 'red')
+      .aggregate({ total: sum('price') })
+      .run()
+    expect(total.total).toBe(250)
+  })
+
+  it('lets a guard enforce a Σ-over-siblings invariant via query().aggregate()', async () => {
+    interface Payment { id: string; amount: number }
+    interface Allocation { id: string; paymentId: string; appliedAmount: number }
+
+    const allocationGuard = withGuard<Allocation>({
+      collection: 'allocations',
+      check: async (incoming, { vault, existing }) => {
+        const payment = await vault.collection<Payment>('payments').get(incoming.paymentId)
+        if (!payment) throw new InvariantError('allocations', incoming.id, 'unknown paymentId')
+        const { total } = await vault
+          .collection<Allocation>('allocations')
+          .query()
+          .where('paymentId', '==', incoming.paymentId)
+          .aggregate({ total: sum<Allocation>('appliedAmount') })
+          .run()
+        const otherTotal = total - (existing?.appliedAmount ?? 0)
+        if (otherTotal + incoming.appliedAmount > payment.amount) {
+          throw new InvariantError(
+            'allocations',
+            incoming.id,
+            `Σ allocations (${otherTotal + incoming.appliedAmount}) exceeds payment.amount (${payment.amount})`,
+          )
+        }
+      },
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'guards-readonly-facade-aggregate-passphrase-2026',
+      guardStrategies: [allocationGuard],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('demo')
+    const payments = vault.collection<Payment>('payments')
+    const allocations = vault.collection<Allocation>('allocations')
+
+    await payments.put('p1', { id: 'p1', amount: 1000 })
+    await allocations.put('a1', { id: 'a1', paymentId: 'p1', appliedAmount: 400 })
+    await allocations.put('a2', { id: 'a2', paymentId: 'p1', appliedAmount: 500 })
+
+    // Over-allocation fails with InvariantError carrying the aggregated sum.
+    await expect(
+      allocations.put('a3', { id: 'a3', paymentId: 'p1', appliedAmount: 200 }),
+    ).rejects.toBeInstanceOf(InvariantError)
+
+    // Topping up to exactly payment.amount is accepted.
+    await expect(
+      allocations.put('a3', { id: 'a3', paymentId: 'p1', appliedAmount: 100 }),
+    ).resolves.not.toThrow()
+
+    // Existing allocation can be amended downward (subtracts its own contribution from the sum).
+    await expect(
+      allocations.put('a1', { id: 'a1', paymentId: 'p1', appliedAmount: 300 }),
+    ).resolves.not.toThrow()
   })
 })

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -389,6 +389,7 @@ export class Collection<T> {
     | {
         registry(): DerivationRegistry
         getCollection(name: string): Collection<Record<string, unknown>>
+        getReadOnlyFacade(): ReadOnlyVaultFacade
         getActiveTxContext(): TxContext | null
         /**
          * Construct a fresh transient TxContext bound to the owning
@@ -705,6 +706,12 @@ export class Collection<T> {
     derivationSource?: {
       registry(): DerivationRegistry
       getCollection(name: string): Collection<Record<string, unknown>>
+      /**
+       * Read-only vault facade handed to `derive(source, ctx)` so a
+       * derivation can fetch sibling records (#147). Same shape and
+       * instance the guards subsystem uses for `check(incoming, ctx)`.
+       */
+      getReadOnlyFacade(): ReadOnlyVaultFacade
       /**
        * Read access to the owning Noydb's currently-active multi-record
        * transaction context, or `null` when no transaction is running.
@@ -1376,7 +1383,8 @@ export class Collection<T> {
           ({ DerivationExecutor } = (await import('./derivations/executor.js')) as { DerivationExecutor: typeof DerivationExecutorType })
         }
         const sourceWithId = { ...incoming, id } as Record<string, unknown> & { id: string }
-        const result = await DerivationExecutor.run(spec, sourceWithId, version, strategyHash)
+        const ctx = { vault: this.derivationSource.getReadOnlyFacade() }
+        const result = await DerivationExecutor.run(spec, sourceWithId, version, strategyHash, ctx)
         for (const key of Object.keys(spec.outputs)) {
           const out = result.outputs[key]
           if (!out) continue

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1473,10 +1473,10 @@ export class Collection<T> {
               vBefore,
             )
           } else {
-            // For deletes, `incoming` to the check is the existing
-            // record — the guard's check decides whether the
-            // deletion is permitted by inspecting `ctx.existing`.
-            await registry.runChecks(
+            // Dedicated delete-time hook (#145). `check` is put-only;
+            // `onDelete(existing, ctx)` receives the currently-persisted
+            // record and decides whether the deletion is permitted.
+            await registry.runOnDelete(
               this.name,
               existingRecord ?? {},
               ctx,

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1451,22 +1451,44 @@ export class Collection<T> {
    * history snapshot still fire so backup integrity and time-travel
    * reconstruction stay consistent.
    *
-   * Returns silently for delete-of-absent (idempotent contract).
+   * Returns silently for delete-of-absent (idempotent contract — both
+   * paths honour this: the `txCtx === null` path also reads the prior
+   * envelope and short-circuits before the ledger/event side-effects).
    *
    * When a `txCtx` is supplied, the prior envelope is captured and
    * pushed onto `txCtx._executed` BEFORE the delete fires — mirrors
    * the #133 rollback hardening for puts. Callers outside a
    * multi-record transaction pass `null` and skip the tracking.
    *
+   * Amendment composition: if `_internalDelete` runs while a vault's
+   * `GuardRegistry` has an amendment window open, the `{before, after:
+   * null}` change pair is pushed onto the amendment change-set the
+   * same way a user-initiated delete would. The `onDelete` user-hook
+   * is still skipped (housekeeping must not trip user invariants in
+   * normal mode), but the amendment's invariant DOES see the change
+   * — so a `RCT-CANCEL-001`-style invariant pairing can reject a
+   * derivation-driven tombstone fired during an admin amendment.
+   *
+   * Constraint to surface to consumers: output collections of
+   * derivations with `optional: true` outputs should not be the
+   * targets of `strict` or `cascade` inbound foreign-key refs —
+   * `_internalDelete` bypasses the ref enforcer by design (the
+   * `onDelete` bypass primitive). Treat the housekeeping path as
+   * "system can tombstone its own emissions regardless of FK shape."
+   *
    * Permission handling is unchanged: the caller must still hold
    * write permission on the collection (derivations run under the
-   * user's keyring). Internal deletes are NOT routed through the
-   * amendment change-set.
+   * user's keyring).
    */
   async _internalDelete(id: string, txCtx: TxContext | null = null): Promise<void> {
+    // Idempotency contract: short-circuit before any ledger/event
+    // side-effect when the target is absent. Both txCtx-aware and
+    // txCtx-null callers honour this — `deriveAll` recomputes
+    // expense-only allocations that never emitted a receipt without
+    // writing spurious v0 ledger entries.
+    const prior = await this.adapter.get(this.vault, this.name, id)
+    if (prior === null) return
     if (txCtx !== null) {
-      const prior = await this.adapter.get(this.vault, this.name, id)
-      if (prior === null) return
       txCtx._executed.push({
         op: {
           type: 'delete',
@@ -1488,11 +1510,20 @@ export class Collection<T> {
     // Guard hook for deletes. Symmetric to put(): consult the
     // registry, decrypt the prior record (if any), then either
     // collect the {before, null} change pair into an active
-    // amendment or run the guards' `check` callback. Frozen-field
+    // amendment or run the guards' `onDelete` callback. Frozen-field
     // diffing is skipped (it's a put concept). Delete-of-absent is
     // a no-op — no guard is consulted because there's nothing to
     // protect, matching the idempotent-delete contract.
-    if (!internal && this.guardSource) {
+    //
+    // For `internal === true` (system housekeeping — derivation
+    // tombstones, MV refresh): `onDelete` is bypassed, but the
+    // amendment change-collection still runs if a window is open.
+    // This means an `amendment.invariant` paired with `onDelete` for
+    // "TRULY unconditional" rules sees the system delete and can
+    // reject it — closing the niwat-review gap where a derivation
+    // tombstone fired during an admin amendment would otherwise
+    // silently bypass both hooks.
+    if (this.guardSource) {
       const registry = this.guardSource.registry()
       const guards = registry.guardsFor(this.name)
       if (guards.length > 0) {
@@ -1504,19 +1535,13 @@ export class Collection<T> {
           } catch {
             existingRecord = null
           }
-          const ctx = {
-            existing: existingRecord,
-            vault: this.guardSource.readOnlyVault(),
-            userId: this.keyring.userId,
-            role: this.keyring.role,
-          }
           if (registry.isAmendmentActive()) {
             // For deletes, the record version is the version that was
             // visible at delete time; we record vBefore = that version
             // and vAfter = same (the ledger entry's `op` discriminator
             // is `delete`, not `put`, so the consumer treats the
-            // tombstone shape correctly). Amendment-tracked deletes
-            // are rare today but the contract is symmetric with put.
+            // tombstone shape correctly). Fires for BOTH user and
+            // system-internal deletes (#145 follow-up).
             const vBefore = existingEnv._v
             registry.collectChange(
               this.name,
@@ -1526,10 +1551,18 @@ export class Collection<T> {
               vBefore,
               vBefore,
             )
-          } else {
+          } else if (!internal) {
             // Dedicated delete-time hook (#145). `check` is put-only;
             // `onDelete(existing, ctx)` receives the currently-persisted
             // record and decides whether the deletion is permitted.
+            // Skipped for internal deletes — housekeeping must not trip
+            // user invariants in normal-mode operation.
+            const ctx = {
+              existing: existingRecord,
+              vault: this.guardSource.readOnlyVault(),
+              userId: this.keyring.userId,
+              role: this.keyring.role,
+            }
             await registry.runOnDelete(
               this.name,
               existingRecord ?? {},

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1407,22 +1407,14 @@ export class Collection<T> {
           const txCtx = this.derivationSource.getActiveTxContext()
           if (out.skipped === true) {
             // #144: optional output returned null. Delete the
-            // previously-emitted output at this id, if any. Capture the
-            // prior envelope for tx rollback symmetry first.
-            const prior = await this.adapter.get(this.vault, outSpec.collection, id)
-            if (prior === null) continue
-            if (txCtx !== null) {
-              txCtx._executed.push({
-                op: {
-                  type: 'delete',
-                  vaultName: this.vault,
-                  collectionName: outSpec.collection,
-                  id,
-                },
-                priorEnvelope: prior,
-              })
-            }
-            await outputCollection.delete(id)
+            // previously-emitted output at this id, if any. Routed
+            // through `_internalDelete` so a user-registered
+            // `onDelete` (#145) on the output collection does NOT
+            // fire — this is a system-internal tombstone, not a
+            // user-initiated delete. The txCtx hookup captures the
+            // prior envelope inside `_internalDelete` for #133-style
+            // rollback symmetry; delete-of-absent is a silent no-op.
+            await outputCollection._internalDelete(id, txCtx)
             continue
           }
           if (txCtx !== null) {
@@ -1447,6 +1439,48 @@ export class Collection<T> {
 
   /** Delete a record by ID. */
   async delete(id: string): Promise<void> {
+    await this._doDelete(id, false)
+  }
+
+  /**
+   * @internal — system-internal delete that bypasses user-facing
+   * delete hooks (`onDelete`, accounting-period guard, FK ref
+   * enforcer). Used by derivation tombstones (#144) and MV refresh
+   * (Dim 14 v2) — system housekeeping shouldn't trip user invariants
+   * registered against the output collection. The ledger entry and
+   * history snapshot still fire so backup integrity and time-travel
+   * reconstruction stay consistent.
+   *
+   * Returns silently for delete-of-absent (idempotent contract).
+   *
+   * When a `txCtx` is supplied, the prior envelope is captured and
+   * pushed onto `txCtx._executed` BEFORE the delete fires — mirrors
+   * the #133 rollback hardening for puts. Callers outside a
+   * multi-record transaction pass `null` and skip the tracking.
+   *
+   * Permission handling is unchanged: the caller must still hold
+   * write permission on the collection (derivations run under the
+   * user's keyring). Internal deletes are NOT routed through the
+   * amendment change-set.
+   */
+  async _internalDelete(id: string, txCtx: TxContext | null = null): Promise<void> {
+    if (txCtx !== null) {
+      const prior = await this.adapter.get(this.vault, this.name, id)
+      if (prior === null) return
+      txCtx._executed.push({
+        op: {
+          type: 'delete',
+          vaultName: this.vault,
+          collectionName: this.name,
+          id,
+        },
+        priorEnvelope: prior,
+      })
+    }
+    await this._doDelete(id, true)
+  }
+
+  private async _doDelete(id: string, internal: boolean): Promise<void> {
     if (!hasWritePermission(this.keyring, this.name)) {
       throw new ReadOnlyError()
     }
@@ -1458,7 +1492,7 @@ export class Collection<T> {
     // diffing is skipped (it's a put concept). Delete-of-absent is
     // a no-op — no guard is consulted because there's nothing to
     // protect, matching the idempotent-delete contract.
-    if (this.guardSource) {
+    if (!internal && this.guardSource) {
       const registry = this.guardSource.registry()
       const guards = registry.guardsFor(this.name)
       if (guards.length > 0) {
@@ -1508,7 +1542,7 @@ export class Collection<T> {
 
     // accounting-period guard (same contract as put;
     // incoming is null because this is a delete).
-    if (this.periodGuard !== undefined) {
+    if (!internal && this.periodGuard !== undefined) {
       const existingEnv = await this.adapter.get(this.vault, this.name, id)
       let priorRecord: Record<string, unknown> | null = null
       if (existingEnv) {
@@ -1531,7 +1565,7 @@ export class Collection<T> {
     // recursively deletes the referencing records first, then falls
     // through to the normal delete path below. `warn` is a no-op
     // here — violations surface through `checkIntegrity()`.
-    if (this.refEnforcer !== undefined) {
+    if (!internal && this.refEnforcer !== undefined) {
       await this.refEnforcer.enforceRefsOnDelete(this.name, id)
     }
 

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1405,6 +1405,26 @@ export class Collection<T> {
           // prior state alongside the source op. Outside a transaction
           // the context is null and tracking is skipped.
           const txCtx = this.derivationSource.getActiveTxContext()
+          if (out.skipped === true) {
+            // #144: optional output returned null. Delete the
+            // previously-emitted output at this id, if any. Capture the
+            // prior envelope for tx rollback symmetry first.
+            const prior = await this.adapter.get(this.vault, outSpec.collection, id)
+            if (prior === null) continue
+            if (txCtx !== null) {
+              txCtx._executed.push({
+                op: {
+                  type: 'delete',
+                  vaultName: this.vault,
+                  collectionName: outSpec.collection,
+                  id,
+                },
+                priorEnvelope: prior,
+              })
+            }
+            await outputCollection.delete(id)
+            continue
+          }
           if (txCtx !== null) {
             const prior = await this.adapter.get(this.vault, outSpec.collection, id)
             txCtx._executed.push({

--- a/packages/hub/src/derivations/executor.ts
+++ b/packages/hub/src/derivations/executor.ts
@@ -10,6 +10,15 @@ export interface OutputResult {
   value: Record<string, unknown>
   ok: boolean
   error?: Error
+  /**
+   * `true` when an optional output (#144) returned `null` /
+   * `undefined`. The caller deletes any previously-emitted output at
+   * the same id (mirrors "tombstone for derived data"); a never-emitted
+   * output is a silent no-op. `ok: true` because skipping is a
+   * successful outcome, not a failure — the executor still ran and
+   * the strategy hash is honoured.
+   */
+  skipped?: boolean
 }
 
 /**
@@ -59,11 +68,25 @@ export const DerivationExecutor = {
     }
 
     for (const key of Object.keys(strategy.outputs)) {
+      const outSpec = strategy.outputs[key]
+      if (!outSpec) continue
       const value = (derived as Record<string, unknown>)[key]
-      if (value === undefined || value === null || typeof value !== 'object') {
+      if (value === undefined || value === null) {
+        if (outSpec.optional === true) {
+          // #144: optional output explicitly skipped. Mark for caller
+          // so any prior-emitted output at this id can be deleted.
+          outputs[key] = { value: {}, ok: true, skipped: true }
+          continue
+        }
         throw new DerivationOutputShapeError(
           key,
-          `expected object, got ${value === undefined ? 'undefined' : typeof value}`,
+          `expected object, got ${value === undefined ? 'undefined' : 'null'}`,
+        )
+      }
+      if (typeof value !== 'object') {
+        throw new DerivationOutputShapeError(
+          key,
+          `expected object, got ${typeof value}`,
         )
       }
       outputs[key] = {

--- a/packages/hub/src/derivations/executor.ts
+++ b/packages/hub/src/derivations/executor.ts
@@ -1,5 +1,5 @@
 import { DerivationOutputShapeError } from '../errors.js'
-import type { DerivationStrategy, DerivedFromMeta } from './types.js'
+import type { DerivationContext, DerivationStrategy, DerivedFromMeta } from './types.js'
 
 export interface RunResult {
   outputs: Record<string, OutputResult>
@@ -32,12 +32,13 @@ export const DerivationExecutor = {
     source: TSource & { id: string },
     sourceVersion: number,
     strategyHash: string,
+    ctx: DerivationContext,
   ): Promise<RunResult> {
     const outputs: Record<string, OutputResult> = {}
     let derived: Partial<TOutputs>
 
     try {
-      derived = await Promise.resolve(strategy.derive(source as TSource))
+      derived = await Promise.resolve(strategy.derive(source as TSource, ctx))
     } catch (err) {
       for (const key of Object.keys(strategy.outputs)) {
         outputs[key] = {

--- a/packages/hub/src/derivations/stale.ts
+++ b/packages/hub/src/derivations/stale.ts
@@ -1,4 +1,5 @@
 import type { Collection } from '../collection.js'
+import type { ReadOnlyVaultFacade } from '../guards/types.js'
 import type { DerivationRegistry } from './registry.js'
 // Type-only — runtime class loaded via dynamic import in
 // `resolveStaleOnRead` only when a stale flag actually fires. Keeps
@@ -17,6 +18,12 @@ export interface DerivationStaleAccessor {
   registry(): DerivationRegistry
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getCollection(name: string): Collection<any>
+  /**
+   * Read-only vault facade handed to `derive(source, ctx)` on the lazy
+   * resolve-on-read path. Same instance/shape as the eager path uses
+   * (#147).
+   */
+  getReadOnlyFacade(): ReadOnlyVaultFacade
 }
 
 /**
@@ -106,7 +113,8 @@ export async function resolveStaleOnRead(
     if (DerivationExecutor === null) {
       ({ DerivationExecutor } = (await import('./executor.js')) as { DerivationExecutor: typeof DerivationExecutorType })
     }
-    const result = await DerivationExecutor.run(spec, sourceWithId, 0, strategyHash)
+    const ctx = { vault: accessor.getReadOnlyFacade() }
+    const result = await DerivationExecutor.run(spec, sourceWithId, 0, strategyHash, ctx)
     for (const key of Object.keys(spec.outputs)) {
       const out = result.outputs[key]
       if (!out) continue

--- a/packages/hub/src/derivations/stale.ts
+++ b/packages/hub/src/derivations/stale.ts
@@ -133,6 +133,13 @@ export async function resolveStaleOnRead(
       const outSpec = spec.outputs[key]
       if (!outSpec) continue
       const outputColl = accessor.getCollection(outSpec.collection)
+      if (out.skipped === true) {
+        // #144: optional output skipped on lazy resolve — delete any
+        // prior emission so the read returns null (matches eager-path
+        // tombstone semantics).
+        await outputColl.delete(id)
+        continue
+      }
       await outputColl.put(id, out.value)
     }
     pending.delete(spec)

--- a/packages/hub/src/derivations/stale.ts
+++ b/packages/hub/src/derivations/stale.ts
@@ -1,5 +1,6 @@
 import type { Collection } from '../collection.js'
 import type { ReadOnlyVaultFacade } from '../guards/types.js'
+import type { TxContext } from '../tx/transaction.js'
 import type { DerivationRegistry } from './registry.js'
 // Type-only — runtime class loaded via dynamic import in
 // `resolveStaleOnRead` only when a stale flag actually fires. Keeps
@@ -24,6 +25,15 @@ export interface DerivationStaleAccessor {
    * (#147).
    */
   getReadOnlyFacade(): ReadOnlyVaultFacade
+  /**
+   * Active multi-record TxContext or `null`. The lazy resolve-on-read
+   * path uses this to register tombstone deletes on `_executed` so a
+   * later rollback restores the prior emission. Mirrors the eager
+   * path's #133-style tracking; the lazy `put` was historically
+   * unregistered but #144's tombstone delete (a NEW write path)
+   * matches the eager registration for symmetry.
+   */
+  getActiveTxContext(): TxContext | null
 }
 
 /**
@@ -136,8 +146,15 @@ export async function resolveStaleOnRead(
       if (out.skipped === true) {
         // #144: optional output skipped on lazy resolve — delete any
         // prior emission so the read returns null (matches eager-path
-        // tombstone semantics).
-        await outputColl.delete(id)
+        // tombstone semantics). Routed through `_internalDelete` so a
+        // user-registered `onDelete` (#145) on the output collection
+        // does NOT fire. The active TxContext (if any) is forwarded:
+        // `resolveStaleOnRead` is reachable from `Collection.get()`
+        // which can be called from inside a transaction, so the
+        // tombstone must be observable to `revertExecuted` on
+        // rollback. Closes the #133-asymmetry surfaced in PR #148
+        // review.
+        await outputColl._internalDelete(id, accessor.getActiveTxContext())
         continue
       }
       await outputColl.put(id, out.value)

--- a/packages/hub/src/derivations/types.ts
+++ b/packages/hub/src/derivations/types.ts
@@ -38,6 +38,16 @@ export interface DerivedFromMeta {
 export interface OutputSpec {
   shape: 'record'
   collection: string
+  /**
+   * When `true`, the `derive` function may return `null` (or
+   * `undefined`) for this output key. The executor interprets that as
+   * "no output for this invocation": a previously-emitted output at
+   * the same id is deleted (mirroring the empty-group / empty-aggregate
+   * semantics flagged in #142); a never-emitted output is a silent
+   * no-op. When `false` (default), returning `null` throws
+   * `DerivationOutputShapeError` — same as v1.
+   */
+  optional?: boolean
 }
 
 /**

--- a/packages/hub/src/derivations/types.ts
+++ b/packages/hub/src/derivations/types.ts
@@ -1,3 +1,17 @@
+import type { ReadOnlyVaultFacade } from '../guards/types.js'
+
+/**
+ * Runtime context handed to `derive(source, ctx)`. Mirrors `GuardContext`'s
+ * narrow shape: read-only vault access, no write capability, no
+ * transaction handle. Determinism is the consumer's responsibility — the
+ * strategy hash includes `derive.toString()`, so the source string fixes
+ * the function's inputs; whatever sibling reads `derive` performs must
+ * yield the same outputs for the same source.
+ */
+export interface DerivationContext {
+  vault: ReadOnlyVaultFacade
+}
+
 /**
  * Metadata that travels inside the `_data` payload of a derived record.
  * Lives in encrypted payload, not in the unencrypted envelope — the
@@ -49,8 +63,13 @@ export interface DerivationStrategy<
    * Pure function from source to outputs. Runs on plaintext, after DEK
    * unwrap. Returns a map of named outputs. Each output is encrypted +
    * stored via the existing `Collection.put` pipeline.
+   *
+   * `ctx.vault` is the same `ReadOnlyVaultFacade` guards see — fetch
+   * sibling records via `ctx.vault.collection<T>(name).get(id)` /
+   * `.list()` / `.query()`. The vault accessor is read-only; there is
+   * no path to a writer from `ctx`.
    */
-  derive: (source: TSource) => Promise<TOutputs> | TOutputs
+  derive: (source: TSource, ctx: DerivationContext) => Promise<TOutputs> | TOutputs
   /**
    * `'eager'` runs `derive` synchronously inside the source-write
    * transaction. `'lazy'` marks outputs stale on source-change and

--- a/packages/hub/src/guards/read-only-facade.ts
+++ b/packages/hub/src/guards/read-only-facade.ts
@@ -1,4 +1,5 @@
 import type { Vault } from '../vault.js'
+import type { Query } from '../query/builder.js'
 import type { ReadOnlyVaultFacade as ReadOnlyVaultFacadeContract } from './types.js'
 
 /**
@@ -16,11 +17,13 @@ export class ReadOnlyVaultFacade implements ReadOnlyVaultFacadeContract {
   collection<T = unknown>(name: string): {
     get(id: string): Promise<T | null>
     list(): Promise<T[]>
+    query(): Query<T>
   } {
     const c = this._vault.collection<T>(name)
     return {
       get: (id: string) => c.get(id),
       list: () => c.list(),
+      query: () => c.query(),
     }
   }
 }

--- a/packages/hub/src/guards/registry.ts
+++ b/packages/hub/src/guards/registry.ts
@@ -65,6 +65,28 @@ export class GuardRegistry {
     }
   }
 
+  /**
+   * Run every guard's `onDelete` for this collection. First throw wins —
+   * remaining guards are not invoked. Guards without an `onDelete` skip.
+   * Mirrors {@link runChecks} but for the delete path.
+   */
+  async runOnDelete<T>(
+    collection: string,
+    existing: T,
+    ctx: GuardContext<T>,
+  ): Promise<void> {
+    const guards = this._byCollection.get(collection)
+    if (!guards) return
+    for (const g of guards) {
+      if (g.onDelete) {
+        await g.onDelete(
+          existing as unknown as Record<string, unknown>,
+          ctx as unknown as GuardContext<Record<string, unknown>>,
+        )
+      }
+    }
+  }
+
   /** True if any guard for `collection` declares an `amendment` block. */
   hasAmendment(collection: string): boolean {
     const guards = this._byCollection.get(collection)

--- a/packages/hub/src/guards/types.ts
+++ b/packages/hub/src/guards/types.ts
@@ -58,11 +58,38 @@ export interface GuardStrategy<T extends Record<string, unknown>> {
    */
   check?: (incoming: T, ctx: GuardContext<T>) => Promise<void> | void
   /**
-   * Fires on `Collection.delete` before the adapter delete and before
-   * the ledger append. The `existing` argument is the currently-persisted
-   * record. Throw to cancel the delete — no partial state, no tombstone
-   * ledger entry. Skipped during an amendment transaction (admin/owner
-   * override).
+   * Fires on user-initiated `Collection.delete` before the adapter
+   * delete and before the ledger append. The `existing` argument is
+   * the currently-persisted record. Throw to cancel the delete — no
+   * partial state, no tombstone ledger entry.
+   *
+   * Skipped during an amendment transaction (admin/owner override) —
+   * amendments are the unlock primitive. To make a delete TRULY
+   * unconditional (e.g. legal-document immutability rules), pair
+   * `onDelete` with an `amendment.invariant` that re-throws on any
+   * `before !== null && after === null` change:
+   *
+   * ```ts
+   * withGuard<Receipt>({
+   *   collection: 'receipts',
+   *   onDelete: () => { throw new RecordLockedError(...) },
+   *   amendment: {
+   *     roles: ['admin', 'owner'],
+   *     invariant: (changes) => {
+   *       for (const c of changes) {
+   *         if (c.before !== null && c.after === null) {
+   *           throw new RecordLockedError(...) // wrapped as InvariantError
+   *         }
+   *       }
+   *     },
+   *   },
+   * })
+   * ```
+   *
+   * Also skipped on system-internal deletes (derivation tombstones from
+   * #144, MV refresh from Dim 14 v2) — those use `_internalDelete`
+   * which bypasses every user-facing delete hook. Housekeeping ops are
+   * NOT user-initiated and should not trip user invariants.
    *
    * Delete of an absent record is a no-op and does not consult any
    * guard, matching the idempotent-delete contract.

--- a/packages/hub/src/guards/types.ts
+++ b/packages/hub/src/guards/types.ts
@@ -48,7 +48,26 @@ export interface GuardStrategyHandle<T extends Record<string, unknown>> {
 /** Public registration shape. See `withGuard()`. */
 export interface GuardStrategy<T extends Record<string, unknown>> {
   collection: string
+  /**
+   * Fires on `Collection.put` (insert + update). The `incoming` argument
+   * is the record being written. Throw to cancel the put.
+   *
+   * Does NOT fire on `Collection.delete` — use {@link onDelete} for
+   * delete-time validation. Skipped during an amendment transaction
+   * (`db.transaction({ amendment: true })`) — admin/owner override.
+   */
   check?: (incoming: T, ctx: GuardContext<T>) => Promise<void> | void
+  /**
+   * Fires on `Collection.delete` before the adapter delete and before
+   * the ledger append. The `existing` argument is the currently-persisted
+   * record. Throw to cancel the delete — no partial state, no tombstone
+   * ledger entry. Skipped during an amendment transaction (admin/owner
+   * override).
+   *
+   * Delete of an absent record is a no-op and does not consult any
+   * guard, matching the idempotent-delete contract.
+   */
+  onDelete?: (existing: T, ctx: GuardContext<T>) => Promise<void> | void
   frozenFields?: {
     when: (existing: T) => boolean
     fields: ReadonlyArray<keyof T>

--- a/packages/hub/src/guards/types.ts
+++ b/packages/hub/src/guards/types.ts
@@ -1,13 +1,21 @@
 import type { Role } from '../types.js'
+import type { Query } from '../query/builder.js'
 
 /**
  * Minimum read surface exposed to guard `check` functions. Intentionally
  * narrow — guards can read other collections but never write.
+ *
+ * `query()` returns the same chainable builder used elsewhere. `Query<T>`
+ * has no write terminals (no `.update()` / `.delete()`) so exposing it
+ * here preserves the read-only contract while letting guards aggregate
+ * with `.where().aggregate()` / `.groupBy()` / `.join()` instead of
+ * decrypting every sibling row via `.list()`.
  */
 export interface ReadOnlyVaultFacade {
   collection<T = unknown>(name: string): {
     get(id: string): Promise<T | null>
     list(): Promise<T[]>
+    query(): Query<T>
   }
 }
 

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -1456,6 +1456,13 @@ export class Vault {
           if (!out || !out.ok) { anyFailed = true; continue }
           const outSpec = spec.outputs[key]
           if (!outSpec) continue
+          if (out.skipped === true) {
+            // #144: optional output skipped — delete any prior emission.
+            // No txCtx hookup needed: `deriveAll` runs outside the
+            // multi-record transaction window by design.
+            await this.collection(outSpec.collection).delete(id)
+            continue
+          }
           await this.collection(outSpec.collection).put(id, out.value)
         }
         if (anyFailed) failed++

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -158,12 +158,13 @@ export class Vault {
    */
   private derivationRegistry: DerivationRegistry | null = null
   /**
-   * Cached read-only facade handed to guard callbacks via `ctx.vault`.
-   * Allocated eagerly inside `_initGuards()` so the read accessor
-   * stays synchronous (callers in `tx/transaction.ts` rely on that).
-   * Stays `null` for vaults with no guards configured.
+   * Cached read-only facade handed to guard callbacks via `ctx.vault`,
+   * and to derivation callbacks via `derive(source, ctx)`. Allocated
+   * eagerly inside `_initGuards()` and/or `_initDerivations()` so read
+   * accessors stay synchronous (callers in `tx/transaction.ts` rely on
+   * that). Stays `null` for vaults with neither subsystem configured.
    */
-  private guardReadOnlyFacade: ReadOnlyVaultFacade | null = null
+  private readOnlyFacade: ReadOnlyVaultFacade | null = null
   private getDEK: (collectionName: string) => Promise<CryptoKey>
 
   /**
@@ -573,6 +574,7 @@ export class Vault {
                 registry: () => this.derivationRegistry as DerivationRegistry,
                 getCollection: (name: string) =>
                   this.collection(name) as unknown as Collection<Record<string, unknown>>,
+                getReadOnlyFacade: () => this._ensureReadOnlyFacade(),
                 getActiveTxContext: () => this.noydb._activeTxContextOrNull,
                 createTxContext: () => this.noydb._createTxContext(),
                 setActiveTxContext: (ctx) => this.noydb._setActiveTxContext(ctx),
@@ -1367,7 +1369,7 @@ export class Vault {
     const registry = new GuardRegistry()
     for (const h of handles) registry.register(h.spec)
     this.guardRegistry = registry
-    this.guardReadOnlyFacade = new ReadOnlyVaultFacade(this)
+    this.readOnlyFacade = new ReadOnlyVaultFacade(this)
   }
 
   /**
@@ -1391,13 +1393,22 @@ export class Vault {
    */
   async _initDerivations(handles: ReadonlyArray<DerivationStrategyHandle>): Promise<void> {
     if (handles.length === 0) return
-    const { DerivationRegistry } = await import('./derivations/registry.js')
+    const [{ DerivationRegistry }, { ReadOnlyVaultFacade }] = await Promise.all([
+      import('./derivations/registry.js'),
+      import('./guards/read-only-facade.js'),
+    ])
     const registry = new DerivationRegistry()
     for (const h of handles) {
       await registry.register(h.spec)
     }
     registry.validate()
     this.derivationRegistry = registry
+    // Share the facade with guards: if `_initGuards` ran first the slot
+    // is already populated. Otherwise allocate so `derive(source, ctx)`
+    // has a vault accessor without re-importing the class per call.
+    if (this.readOnlyFacade === null) {
+      this.readOnlyFacade = new ReadOnlyVaultFacade(this)
+    }
   }
 
   /**
@@ -1425,6 +1436,11 @@ export class Vault {
 
     const sourceColl = this.collection<Record<string, unknown>>(sourceCollection)
     const records = await sourceColl.list()
+    // `_initDerivations` populates `readOnlyFacade` — assert non-null
+    // for the closure-captured ctx. Falls back to a fresh facade on the
+    // sync-fallback path (Noydb.vault() without await) for the same
+    // defensive reason `_ensureReadOnlyFacade` exists.
+    const ctx = { vault: this.readOnlyFacade ?? new (await import('./guards/read-only-facade.js')).ReadOnlyVaultFacade(this) }
     let derived = 0
     let failed = 0
     for (const record of records) {
@@ -1433,7 +1449,7 @@ export class Vault {
       if (typeof id !== 'string') continue
       for (const { spec, strategyHash } of strategies) {
         const sourceWithId = { ...record, id }
-        const result = await DerivationExecutor.run(spec, sourceWithId, 0, strategyHash)
+        const result = await DerivationExecutor.run(spec, sourceWithId, 0, strategyHash, ctx)
         let anyFailed = false
         for (const key of Object.keys(spec.outputs)) {
           const out = result.outputs[key]
@@ -1459,7 +1475,7 @@ export class Vault {
    * require at least one guard, so the caller should never see null).
    */
   _getReadOnlyFacade(): ReadOnlyVaultFacade | null {
-    return this.guardReadOnlyFacade
+    return this.readOnlyFacade
   }
 
   /**
@@ -1471,7 +1487,7 @@ export class Vault {
    * path so the closure's contract stays "always returns a facade").
    */
   private _ensureReadOnlyFacade(): ReadOnlyVaultFacade {
-    if (this.guardReadOnlyFacade !== null) return this.guardReadOnlyFacade
+    if (this.readOnlyFacade !== null) return this.readOnlyFacade
     // Synchronous fall-back: dynamic import isn't available here,
     // but `_initGuards` always sets the facade before any
     // guard-hook can fire. Reaching this branch means a Vault was

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -1459,8 +1459,10 @@ export class Vault {
           if (out.skipped === true) {
             // #144: optional output skipped — delete any prior emission.
             // No txCtx hookup needed: `deriveAll` runs outside the
-            // multi-record transaction window by design.
-            await this.collection(outSpec.collection).delete(id)
+            // multi-record transaction window by design. Routed
+            // through `_internalDelete` so the bulk recompute does not
+            // trip user `onDelete` (#145) on the output collection.
+            await this.collection(outSpec.collection)._internalDelete(id)
             continue
           }
           await this.collection(outSpec.collection).put(id, out.value)


### PR DESCRIPTION
## Summary

Four fast-follow refinements to the Guards + Derivations subsystems that shipped in pre.11. All emerged from first-consumer use; they're the v1.5 strand of milestone pre.14, landing before the larger Dim 14 v2 (MV) work so MV inherits a hardened \`ReadOnlyVaultFacade\` foundation.

| Commit | Issue | What |
|---|---|---|
| 02557a2 | #146 | \`.query()\` on \`ReadOnlyVaultFacade\` — guards can aggregate sibling rows via the same chainable builder used elsewhere, no more \`.list()\` + manual reduce |
| 8249a1a | #147 | \`derive(source, ctx)\` — derivations get the same \`ReadOnlyVaultFacade\` guards have; sibling reads without denormalisation + frozen-fields pairing |
| df405d1 | #145 | \`withGuard.onDelete\` — dedicated delete-time hook; \`check\` becomes put-only |
| 973b179 | #144 | \`withDerivation\` optional outputs — \`null\` = skip emission + tombstone prior |

## Order rationale

#146 → #147 → #145 → #144 lands #146 + #147 (the shared-facade work) together so the abstraction settles in one review pass, then the independent #145 and #144 stack on top.

## Breaking surface changes (pre-1.0)

- **#145** — \`check\` no longer fires on \`Collection.delete\`. Any guard that previously gated deletes via \`check\` + \`ctx.existing\` must migrate to \`onDelete(existing, ctx)\`. The semantic split is explicit: \`check\` = "validate a write," \`onDelete\` = "validate a removal."
- **#147** — \`derive: (source) => ...\` widened to \`derive: (source, ctx) => ...\`. TypeScript's function bivariance keeps narrower existing signatures compatible at compile time, so most consumers see no diff unless they explicitly use \`ctx\`.

## Verification

- 1508 hub tests pass (was 1496 pre-PR · +12 new across the four issues + one regression guard)
- typecheck clean · lint clean
- Bundle within tolerance: floor +3.5% gz, all-on +1.5% gz (\`bundle-check\` ✓ on all four scenarios). The pre.12 floor-bundle hardening (#130) survives — \`Query\` and \`ReadOnlyVaultFacade\` are type-only or dynamic-imported.

## Subsystem docs

- \`docs/subsystems/guards.md\` — four-primitive table, \`onDelete\` semantics, \`.query()\` surface on facade
- \`docs/subsystems/derivations.md\` — \`derive(source, ctx)\` shape, optional outputs section with tombstone semantics
- \`ROADMAP.md\` — pre.14 marked in-flight as bundled MV + v1.5 milestone

## Test plan

- [x] \`pnpm --filter @noy-db/hub typecheck\`
- [x] \`pnpm --filter @noy-db/hub lint\`
- [x] \`pnpm --filter @noy-db/hub test\` — 1508 / 1508
- [x] \`pnpm --filter @noy-db/hub bundle-check\` — all scenarios green
- [ ] Spot-check the breaking surface changes (#145, #147) against any consumer in flight before merge

Closes #144 #145 #146 #147.