### PR TITLE
feat(hub): MV foundation — factory, registry, executor, Collection.put hook (#150)

### DIFF
--- a/packages/hub/__tests__/materialized-views/dependency-analyzer.test.ts
+++ b/packages/hub/__tests__/materialized-views/dependency-analyzer.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { Query } from '../../src/query/builder.js'
+import type { QuerySource } from '../../src/query/builder.js'
+import type { JoinContext } from '../../src/query/join.js'
+
+function emptySource<T>(): QuerySource<T> {
+  return { snapshot: () => [] as readonly T[] }
+}
+
+interface TestRow extends Record<string, unknown> {
+  id: string
+}
+
+describe('analyzeDependencies', () => {
+  it('captures the root collection from JoinContext', async () => {
+    const { analyzeDependencies } = await import('../../src/materialized-views/dependency-analyzer.js')
+    const joinContext: JoinContext = {
+      leftCollection: 'invoices',
+      resolveRef: () => null,
+      resolveSource: () => null,
+    }
+    const q = new Query<TestRow>(emptySource<TestRow>(), undefined, joinContext)
+    const deps = analyzeDependencies(q)
+    expect(deps.has('invoices')).toBe(true)
+    expect(deps.size).toBe(1)
+  })
+
+  it('captures FK join targets from plan.joins', async () => {
+    const { analyzeDependencies } = await import('../../src/materialized-views/dependency-analyzer.js')
+    const joinContext: JoinContext = {
+      leftCollection: 'invoices',
+      resolveRef: (field) => {
+        if (field === 'clientId') {
+          return { target: 'clients', mode: 'strict' as const }
+        }
+        return null
+      },
+      resolveSource: () => null,
+    }
+    const q = new Query<TestRow>(emptySource<TestRow>(), undefined, joinContext).join('clientId', { as: 'client' })
+    const deps = analyzeDependencies(q)
+    expect(deps.has('invoices')).toBe(true)
+    expect(deps.has('clients')).toBe(true)
+    expect(deps.size).toBe(2)
+  })
+
+  it('returns empty deps when no JoinContext is attached (ad-hoc Query)', async () => {
+    const { analyzeDependencies } = await import('../../src/materialized-views/dependency-analyzer.js')
+    const q = new Query<TestRow>(emptySource<TestRow>())
+    const deps = analyzeDependencies(q)
+    expect(deps.size).toBe(0)
+  })
+})
+
+describe('summarizeQueryPlan', () => {
+  it('is deterministic for the same plan', async () => {
+    const { summarizeQueryPlan } = await import('../../src/materialized-views/dependency-analyzer.js')
+    const joinContext: JoinContext = {
+      leftCollection: 'invoices',
+      resolveRef: () => null,
+      resolveSource: () => null,
+    }
+    const q1 = new Query<TestRow>(emptySource<TestRow>(), undefined, joinContext).where('status', '==', 'open')
+    const q2 = new Query<TestRow>(emptySource<TestRow>(), undefined, joinContext).where('status', '==', 'open')
+    expect(summarizeQueryPlan(q1)).toBe(summarizeQueryPlan(q2))
+  })
+
+  it('differs when where-clause value changes', async () => {
+    const { summarizeQueryPlan } = await import('../../src/materialized-views/dependency-analyzer.js')
+    const joinContext: JoinContext = {
+      leftCollection: 'invoices',
+      resolveRef: () => null,
+      resolveSource: () => null,
+    }
+    const q1 = new Query<TestRow>(emptySource<TestRow>(), undefined, joinContext).where('status', '==', 'open')
+    const q2 = new Query<TestRow>(emptySource<TestRow>(), undefined, joinContext).where('status', '==', 'paid')
+    expect(summarizeQueryPlan(q1)).not.toBe(summarizeQueryPlan(q2))
+  })
+})

--- a/packages/hub/__tests__/materialized-views/end-to-end.test.ts
+++ b/packages/hub/__tests__/materialized-views/end-to-end.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withMaterializedView, MaterializedViewCycleError } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface Invoice extends Record<string, unknown> {
+  id: string
+  clientId: string
+  amount: number
+  status: 'open' | 'paid'
+}
+
+describe('MV foundation (#150) — end-to-end', () => {
+  it('eager MV: source writes trigger re-materialization with _materializedFrom stamp', async () => {
+    // Foundation MV: non-aggregate query that filters invoices to
+    // `status === 'open'` and writes them through to `open-invoices`.
+    // The id is preserved from the source row.
+    const openInvoicesMV = withMaterializedView<Invoice>({
+      name: 'open-invoices',
+      query: (db) => db.collection<Invoice>('invoices').query().where('status', '==', 'open'),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-foundation-eager-passphrase-2026',
+      materializedViewStrategies: [openInvoicesMV],
+    })
+    const vault = await db.openVault('demo')
+
+    // Seed two invoices; one open, one paid. MV should emit only the open one.
+    await vault.collection<Invoice>('invoices').put('inv-1', {
+      id: 'inv-1', clientId: 'acme', amount: 100, status: 'open',
+    })
+    await vault.collection<Invoice>('invoices').put('inv-2', {
+      id: 'inv-2', clientId: 'acme', amount: 50, status: 'paid',
+    })
+
+    const openRow = await vault
+      .collection<Invoice & { _materializedFrom?: { mvName: string; queryHash: string } }>('open-invoices')
+      .get('inv-1')
+    expect(openRow).not.toBeNull()
+    expect(openRow?.amount).toBe(100)
+    expect(openRow?._materializedFrom?.mvName).toBe('open-invoices')
+    expect(openRow?._materializedFrom?.queryHash).toMatch(/^[0-9a-f]{64}$/)
+
+    const paidRow = await vault.collection<Invoice>('open-invoices').get('inv-2')
+    // Paid invoice was filtered out by the query — should not be in MV
+    expect(paidRow).toBeNull()
+  })
+
+  it('MV output defaults to the collection named after `name`', async () => {
+    interface Item extends Record<string, unknown> { id: string; x: number }
+    const mv = withMaterializedView<Item>({
+      name: 'big-items',
+      query: (db) => db.collection<Item>('items').query().where('x', '>', 10),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+      // No output.collection → writes to 'big-items'
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-foundation-default-output-passphrase-2026',
+      materializedViewStrategies: [mv],
+    })
+    const vault = await db.openVault('demo')
+    await vault.collection<Item>('items').put('a', { id: 'a', x: 5 })
+    await vault.collection<Item>('items').put('b', { id: 'b', x: 20 })
+    expect(await vault.collection<Item>('big-items').get('a')).toBeNull()
+    expect(await vault.collection<Item>('big-items').get('b')).not.toBeNull()
+  })
+
+  it('cycle detection: MV whose output writes to its own source throws MaterializedViewCycleError', async () => {
+    interface Loopy extends Record<string, unknown> { id: string; n: number }
+    const cyclic = withMaterializedView<Loopy>({
+      name: 'self-feedback',
+      query: (db) => db.collection<Loopy>('self-feedback').query(),
+      rowKey: (r) => String(r.id),
+      refresh: 'eager',
+      // No output.collection → defaults to 'self-feedback' (same as
+      // root source) → cycle.
+    })
+
+    await expect(
+      (async () => {
+        const db = await createNoydb({
+          store: memory(),
+          user: 'alice',
+          secret: 'mv-foundation-cycle-passphrase-2026',
+          materializedViewStrategies: [cyclic],
+        })
+        await db.openVault('demo')
+      })(),
+    ).rejects.toBeInstanceOf(MaterializedViewCycleError)
+  })
+
+  it('explicit output collection routes correctly', async () => {
+    interface Item extends Record<string, unknown> { id: string; tag: string }
+    const mv = withMaterializedView<Item>({
+      name: 'mv-redtags',
+      query: (db) => db.collection<Item>('items').query().where('tag', '==', 'red'),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+      output: { collection: 'red-items' },
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-foundation-explicit-output-passphrase-2026',
+      materializedViewStrategies: [mv],
+    })
+    const vault = await db.openVault('demo')
+    await vault.collection<Item>('items').put('a', { id: 'a', tag: 'red' })
+    await vault.collection<Item>('items').put('b', { id: 'b', tag: 'blue' })
+
+    // The MV writes to `red-items` (not to its name `mv-redtags`)
+    expect(await vault.collection<Item>('red-items').get('a')).not.toBeNull()
+    expect(await vault.collection<Item>('red-items').get('b')).toBeNull()
+    // The `mv-redtags` name is just an identity; nothing written there
+    expect(await vault.collection<Item>('mv-redtags').get('a')).toBeNull()
+  })
+
+  it('lazy and manual MV strategies register but do not eagerly materialize (foundation no-op)', async () => {
+    interface Item extends Record<string, unknown> { id: string }
+    const lazyMV = withMaterializedView<Item>({
+      name: 'lazy-mv',
+      query: (db) => db.collection<Item>('items').query(),
+      rowKey: (r) => r.id,
+      refresh: 'lazy',
+    })
+    const manualMV = withMaterializedView<Item>({
+      name: 'manual-mv',
+      query: (db) => db.collection<Item>('items').query(),
+      rowKey: (r) => r.id,
+      refresh: 'manual',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-foundation-lazy-manual-passphrase-2026',
+      materializedViewStrategies: [lazyMV, manualMV],
+    })
+    const vault = await db.openVault('demo')
+    await vault.collection<Item>('items').put('a', { id: 'a' })
+    // Foundation: lazy + manual do not materialize. Subtask #151 wires
+    // them. This test pins the no-op behavior so #151 has a clear
+    // delta to write against.
+    expect(await vault.collection<Item>('lazy-mv').get('a')).toBeNull()
+    expect(await vault.collection<Item>('manual-mv').get('a')).toBeNull()
+  })
+})

--- a/packages/hub/__tests__/materialized-views/with-materialized-view.test.ts
+++ b/packages/hub/__tests__/materialized-views/with-materialized-view.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { withMaterializedView } from '../../src/materialized-views/with-materialized-view.js'
+import type { Query } from '../../src/query/builder.js'
+
+const dummyQuery = (): Query<Record<string, unknown>> => ({} as Query<Record<string, unknown>>)
+
+describe('withMaterializedView factory', () => {
+  it('returns a handle with __noydb_strategy: "materialized-view"', () => {
+    const handle = withMaterializedView({
+      name: 'totals',
+      query: dummyQuery,
+      rowKey: (r) => String(r.id),
+      refresh: 'eager',
+    })
+    expect(handle.__noydb_strategy).toBe('materialized-view')
+    expect(handle.spec.name).toBe('totals')
+  })
+
+  it('preserves the spec verbatim', () => {
+    const query = dummyQuery
+    const rowKey = (r: Record<string, unknown>): string => String(r.k)
+    const handle = withMaterializedView({
+      name: 'agg',
+      query,
+      rowKey,
+      refresh: 'lazy',
+      output: { collection: 'agg-out' },
+      onEmpty: 'delete',
+      strict: true,
+      maxRows: 50_000,
+    })
+    expect(handle.spec.query).toBe(query)
+    expect(handle.spec.rowKey).toBe(rowKey)
+    expect(handle.spec.refresh).toBe('lazy')
+    expect(handle.spec.output?.collection).toBe('agg-out')
+    expect(handle.spec.onEmpty).toBe('delete')
+    expect(handle.spec.strict).toBe(true)
+    expect(handle.spec.maxRows).toBe(50_000)
+  })
+
+  it('rejects empty name', () => {
+    expect(() => withMaterializedView({ name: '', query: dummyQuery, rowKey: (r) => String(r.id), refresh: 'eager' })).toThrow(/name/i)
+  })
+
+  it('rejects missing rowKey', () => {
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      withMaterializedView({ name: 'x', query: dummyQuery, refresh: 'eager' } as any),
+    ).toThrow(/rowKey/i)
+  })
+
+  it('rejects invalid refresh value', () => {
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      withMaterializedView({ name: 'x', query: dummyQuery, rowKey: (r) => String(r.id), refresh: 'never' as any }),
+    ).toThrow(/refresh/i)
+  })
+})

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -196,6 +196,16 @@
         "default": "./dist/derivations/index.cjs"
       }
     },
+    "./materialized-views": {
+      "import": {
+        "types": "./dist/materialized-views/index.d.ts",
+        "default": "./dist/materialized-views/index.js"
+      },
+      "require": {
+        "types": "./dist/materialized-views/index.d.cts",
+        "default": "./dist/materialized-views/index.cjs"
+      }
+    },
     "./sync": {
       "import": {
         "types": "./dist/sync/index.d.ts",

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -48,6 +48,8 @@ import { revertExecuted } from './tx/transaction.js'
 // derivation executor chunk out of the floor bundle (#130).
 import type { DerivationExecutor as DerivationExecutorType } from './derivations/executor.js'
 import { markStale, resolveStaleOnRead } from './derivations/stale.js'
+import type { MaterializedViewRegistry } from './materialized-views/registry.js'
+import type { MVQueryContext } from './materialized-views/types.js'
 
 /** Callback for dirty tracking (sync engine integration). */
 export type OnDirtyCallback = (collection: string, id: string, action: 'put' | 'delete', version: number) => Promise<void>
@@ -408,6 +410,23 @@ export class Collection<T> {
     | undefined
 
   /**
+   * Vault-internal hook for materialized-view dispatch (#143/#150).
+   * Parallel to `derivationSource` — when set, `Collection.put` fires
+   * `MaterializedViewRegistry.onSourceWrite` after the source-write
+   * commits + after `dispatchDerivations` has run.
+   */
+  private readonly materializedViewSource:
+    | {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        registry(): MaterializedViewRegistry
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        getCollection(name: string): Collection<any>
+        getActiveTxContext(): TxContext | null
+        getQueryContext(): MVQueryContext
+      }
+    | undefined
+
+  /**
    * Optional back-reference to the owning compartment's ref
    * enforcer. When present, `Collection.put` calls
    * `refEnforcer.enforceRefsOnPut(name, record)` before the adapter
@@ -731,6 +750,20 @@ export class Collection<T> {
       /** Drop a previously-published TxContext. */
       clearActiveTxContext(ctx: TxContext): void
     } | undefined
+    /**
+     * Vault-internal hook for materialized-view dispatch (#143/#150).
+     * Parallel to `derivationSource`. When set, `Collection.put` fires
+     * registered MV `onSourceWrite` after the standard derivation
+     * dispatch.
+     */
+    materializedViewSource?: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      registry(): MaterializedViewRegistry
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getCollection(name: string): Collection<any>
+      getActiveTxContext(): TxContext | null
+      getQueryContext(): MVQueryContext
+    } | undefined
   }) {
     this.adapter = opts.adapter
     this.vault = opts.vault
@@ -764,6 +797,7 @@ export class Collection<T> {
     this.periodGuard = opts.periodGuard
     this.guardSource = opts.guardSource
     this.derivationSource = opts.derivationSource
+    this.materializedViewSource = opts.materializedViewSource
 
     // hierarchical-tier wiring
     this.tiers = opts.tiers && opts.tiers.length > 0 ? new Set(opts.tiers) : null
@@ -1235,6 +1269,7 @@ export class Collection<T> {
       this.emitter.emit('change', { vault: this.vault, collection: this.name, id, action: 'put' } satisfies ChangeEvent)
       await this.onAccess?.('put', id)
       await this.dispatchDerivations(id, record, version)
+      await this.dispatchMaterializedViews(id, record)
       return
     }
     // ─── End CRDT mode ──────────────────────────────────────────────────
@@ -1350,6 +1385,44 @@ export class Collection<T> {
     // (encrypt + ledger + emit) intentionally; cycle detection at vault
     // open is the primary defense against infinite recursion.
     await this.dispatchDerivations(id, record, version)
+    await this.dispatchMaterializedViews(id, record)
+  }
+
+  /**
+   * Fire registered MV strategies whose dependency set includes this
+   * collection. Eager-mode MVs re-materialize inline via
+   * `MaterializedViewExecutor.refresh`; lazy / manual modes are
+   * no-ops in the foundation (subtask #150) — wired in #151.
+   *
+   * Skips entirely when the record being written is itself an
+   * MV-emitted row (carries `_materializedFrom`) — defensive guard
+   * against missed cycle detection.
+   *
+   * @internal
+   */
+  private async dispatchMaterializedViews(id: string, record: T): Promise<void> {
+    void id
+    if (this.materializedViewSource === undefined) return
+    const incoming = record as unknown as Record<string, unknown>
+    if (incoming && typeof incoming === 'object' && '_materializedFrom' in incoming) return
+    const registry = this.materializedViewSource.registry()
+    const mvs = registry.mvsForSource(this.name)
+    if (mvs.length === 0) return
+    // Dynamic-import the executor only on first eager-MV dispatch —
+    // keeps the MV executor chunk out of the floor bundle (mirrors the
+    // #130 dynamic-import pattern v1 uses for derivations).
+    const { MaterializedViewExecutor } = await import('./materialized-views/executor.js')
+    for (const reg of mvs) {
+      const mode = reg.spec.refresh
+      if (mode === 'eager') {
+        await MaterializedViewExecutor.refresh(reg, {
+          getCollection: (name) => this.materializedViewSource!.getCollection(name),
+          getActiveTxContext: () => this.materializedViewSource!.getActiveTxContext(),
+          getQueryContext: () => this.materializedViewSource!.getQueryContext(),
+        })
+      }
+      // lazy/manual: deferred to subtask #151
+    }
   }
 
   /**

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -1436,3 +1436,44 @@ export class DerivationOutputShapeError extends NoydbError {
     this.outputKey = outputKey
   }
 }
+
+/**
+ * Thrown at vault open if the materialized-view graph contains a
+ * cycle. `path` is the offending chain (e.g. `['a-mv', 'b-mv', 'a-mv']`).
+ * Detected by the same shared DFS that catches `DerivationCycleError`;
+ * surfaces with a distinct error type so consumers can disambiguate.
+ */
+export class MaterializedViewCycleError extends NoydbError {
+  readonly path: readonly string[]
+
+  constructor(path: readonly string[]) {
+    super(
+      'MATERIALIZED_VIEW_CYCLE',
+      `Materialized-view graph contains a cycle: ${path.join(' → ')}. ` +
+        `Refusing to open vault — break the cycle before retrying.`,
+    )
+    this.name = 'MaterializedViewCycleError'
+    this.path = path
+  }
+}
+
+/**
+ * Thrown at MV registration if the query references a source
+ * collection that isn't declared on the vault. Surfacing this early
+ * catches typos in collection names.
+ */
+export class MaterializedViewSourceUnknownError extends NoydbError {
+  readonly mvName: string
+  readonly collection: string
+
+  constructor(mvName: string, collection: string) {
+    super(
+      'MATERIALIZED_VIEW_SOURCE_UNKNOWN',
+      `Materialized view "${mvName}" references unknown source collection "${collection}". ` +
+        `Declare the collection (e.g. via schema or by writing to it once) before registering the MV.`,
+    )
+    this.name = 'MaterializedViewSourceUnknownError'
+    this.mvName = mvName
+    this.collection = collection
+  }
+}

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -503,6 +503,19 @@ export {
   DerivationOutputShapeError,
 } from './errors.js'
 
+// Materialized views (Dim 14 v2) — see docs/superpowers/specs/2026-05-20-dim14-mv-v2-design.md
+export { withMaterializedView } from './materialized-views/index.js'
+export type {
+  MaterializedViewStrategy,
+  MaterializedViewStrategyHandle,
+  MaterializedViewOutput,
+  MaterializedFromMeta,
+} from './materialized-views/index.js'
+export {
+  MaterializedViewCycleError,
+  MaterializedViewSourceUnknownError,
+} from './errors.js'
+
 // Accounting periods
 export { PERIODS_COLLECTION } from './periods/index.js'
 export type {

--- a/packages/hub/src/materialized-views/dependency-analyzer.ts
+++ b/packages/hub/src/materialized-views/dependency-analyzer.ts
@@ -1,0 +1,85 @@
+import type { Query, QueryPlan } from '../query/builder.js'
+import type { JoinContext } from '../query/join.js'
+
+/**
+ * Walks a `Query<T>` plan and returns the set of source collection
+ * names that any source-write should trigger a refresh on.
+ *
+ * Foundation sub-issue (#150) handles:
+ *   - root collection (the one the query was built from)
+ *   - FK join targets (`.join(field, { as })`)
+ *
+ * Deferred to later sub-issues:
+ *   - `.crossJoin()` — v3 cross-join spec (separate primitive)
+ *   - `.wherePredicate(name)` — v2 predicate primitive, sub-issue #153
+ *   - Overlay-name expansion to {base, overlay} — sub-issue #154
+ *
+ * The set is materialized at MV registration time. The MV registry
+ * uses it to (a) dispatch `onSourceWrite` only to MVs that actually
+ * care, and (b) contribute edges to the shared cycle-detection graph.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function analyzeDependencies(query: Query<any>): Set<string> {
+  const deps = new Set<string>()
+  const plan = query._plan()
+  const ctx = query._joinContext()
+
+  // The root collection is always a dependency.
+  if (ctx?.leftCollection) {
+    deps.add(ctx.leftCollection)
+  }
+
+  // FK join targets contribute additional sources.
+  for (const leg of plan.joins) {
+    deps.add(leg.target)
+  }
+
+  // Sub-plans inside OR clauses can carry nested joins. Walk them.
+  // (Today only top-level `.join()` populates `plan.joins`, but the
+  // OR-group machinery permits sub-plans, so we recurse defensively.)
+  walkClausesForJoins(plan, deps, ctx)
+
+  return deps
+}
+
+function walkClausesForJoins(
+  plan: QueryPlan,
+  deps: Set<string>,
+  ctx: JoinContext | undefined,
+): void {
+  void ctx
+  // Today `plan.joins` carries all join legs at top level. Sub-plans
+  // inside OR groups don't currently support nested joins, so the loop
+  // below is a no-op safety net for future builder extensions.
+  for (const clause of plan.clauses) {
+    if (clause.type === 'group') {
+      // Group clauses don't (yet) carry their own joins; this is a
+      // forward-compat anchor for when OR-groups support nested
+      // sources.
+    }
+  }
+}
+
+/**
+ * Convenience: produce a stable string summary of the query plan
+ * suitable for `queryHash` derivation. Captures everything the
+ * dependency analyzer reads + the where/orderBy/limit/offset
+ * structure that affects materialized rows.
+ *
+ * `joinContext` is intentionally NOT included — the join-resolution
+ * function references would defeat hash determinism. The set of join
+ * TARGETS (collection names) IS included via the plan.joins legs.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function summarizeQueryPlan(query: Query<any>): string {
+  const plan = query._plan()
+  const ctx = query._joinContext()
+  return JSON.stringify({
+    root: ctx?.leftCollection ?? null,
+    clauses: plan.clauses,
+    orderBy: plan.orderBy,
+    limit: plan.limit ?? null,
+    offset: plan.offset,
+    joins: plan.joins.map(j => ({ field: j.field, as: j.as, target: j.target, mode: j.mode })),
+  })
+}

--- a/packages/hub/src/materialized-views/executor.ts
+++ b/packages/hub/src/materialized-views/executor.ts
@@ -1,0 +1,128 @@
+import type { Collection } from '../collection.js'
+import type { TxContext } from '../tx/transaction.js'
+import type { EncryptedEnvelope } from '../types.js'
+import type { MaterializedFromMeta, MVQueryContext } from './types.js'
+import type { RegisteredMV } from './registry.js'
+
+/**
+ * Accessor shape passed in from the owning Vault. Mirrors v1's
+ * `DerivationStaleAccessor` — provides the per-collection resolver
+ * and the active TxContext so refresh writes/tombstones register on
+ * `_executed` for #133-style rollback symmetry.
+ */
+export interface MVExecutorAccessor {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getCollection(name: string): Collection<any>
+  getActiveTxContext(): TxContext | null
+  /**
+   * Vault-shaped accessor passed to the MV's `query()` callback at
+   * each refresh. Same instance the registry used at registration
+   * time; threading through the executor lets the refresh path
+   * re-evaluate the closure against the live vault state.
+   */
+  getQueryContext(): MVQueryContext
+}
+
+export interface RefreshResult {
+  /** Rows newly written / overwritten. */
+  written: number
+  /** Failed row writes (non-strict mode). */
+  failed: number
+}
+
+/**
+ * Run an MV's `query()` and write the result rows to the output
+ * collection. Same-DEK encryption: routes through the standard
+ * `Collection.put` pipeline, so the output collection's DEK is what
+ * gets used (matches the v2 spec's "same DEK as the left-most source"
+ * invariant — `Collection.put` looks up the DEK by collection name,
+ * and the output collection IS the MV's owned collection).
+ *
+ * Stamps `_materializedFrom` onto every emitted row. Tombstones
+ * (rows that disappear between refreshes) are NOT handled by this
+ * function — that's `onEmpty: 'delete'` (subtask #152).
+ *
+ * @internal
+ */
+export const MaterializedViewExecutor = {
+  /**
+   * Full re-materialize. Invokes `spec.query()`, executes against
+   * the live collection state, writes each result row through
+   * `Collection.put` (id = `spec.rowKey(row)`).
+   *
+   * Returns counts; throws only on contract-level failures (rowKey
+   * collisions surface as ordinary `Collection.put` errors).
+   */
+  async refresh(
+    reg: RegisteredMV,
+    accessor: MVExecutorAccessor,
+  ): Promise<RefreshResult> {
+    const spec = reg.spec
+    const outputColl = accessor.getCollection(reg.outputCollection)
+
+    // Materialize the query. The Query<T> returned by spec.query() is
+    // a fresh instance — we invoke `.toArray()` to materialize the
+    // result rows. Foundation sub-issue (#150) handles non-aggregate
+    // queries only — aggregate / groupBy-shaped MVs are deferred to
+    // subtask #152 (the cost-ceiling + correctness sub-issue, where
+    // `MaterializedViewTooLargeError` for groupBy explosions also
+    // lands).
+    const q = spec.query(accessor.getQueryContext())
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rows: ReadonlyArray<Record<string, unknown>> = await (q as any).toArray()
+
+    const txCtx = accessor.getActiveTxContext()
+
+    let written = 0
+    let failed = 0
+    for (const row of rows) {
+      try {
+        const id = spec.rowKey(row)
+        const meta: MaterializedFromMeta = {
+          mvName: spec.name,
+          queryHash: reg.queryHash,
+          // Foundation: sourceVersions empty — populated by step 7+ when
+          // we read the source records' versions during materialization.
+          sourceVersions: {},
+          materializedAt: new Date().toISOString(),
+        }
+        const enriched: Record<string, unknown> = {
+          ...row,
+          _materializedFrom: meta,
+        }
+
+        // Register the prior envelope on the active TxContext before
+        // the write, so a mid-refresh failure rolls back via
+        // `revertExecuted` (#133-style).
+        if (txCtx !== null) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const adapter = (outputColl as any).adapter as {
+            get(v: string, c: string, i: string): Promise<EncryptedEnvelope | null>
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const vaultName = (outputColl as any).vault as string
+          const prior = await adapter.get(vaultName, reg.outputCollection, id)
+          txCtx._executed.push({
+            op: {
+              type: 'put',
+              vaultName,
+              collectionName: reg.outputCollection,
+              id,
+            },
+            priorEnvelope: prior,
+          })
+        }
+
+        await outputColl.put(id, enriched)
+        written++
+      } catch (err) {
+        failed++
+        // Foundation: non-strict by default. Subtask #152 wires
+        // strict-mode rollback through `withTransactions`.
+        // eslint-disable-next-line no-console
+        console.warn(`[mv] "${spec.name}" row write failed:`, err)
+      }
+    }
+    return { written, failed }
+  },
+}

--- a/packages/hub/src/materialized-views/index.ts
+++ b/packages/hub/src/materialized-views/index.ts
@@ -1,0 +1,20 @@
+export { withMaterializedView } from './with-materialized-view.js'
+export { MaterializedViewRegistry } from './registry.js'
+export { MaterializedViewExecutor } from './executor.js'
+export { analyzeDependencies, summarizeQueryPlan } from './dependency-analyzer.js'
+export { computeQueryHash, canonicalizeQueryPlan } from './query-hash.js'
+export type {
+  MaterializedViewStrategy,
+  MaterializedViewStrategyHandle,
+  MaterializedViewOutput,
+  MaterializedFromMeta,
+} from './types.js'
+export type { RegisteredMV } from './registry.js'
+export type { MVExecutorAccessor, RefreshResult } from './executor.js'
+
+// Re-export errors so `@noy-db/hub/materialized-views` is self-contained
+// (matches the v1 derivations subpath pattern).
+export {
+  MaterializedViewCycleError,
+  MaterializedViewSourceUnknownError,
+} from '../errors.js'

--- a/packages/hub/src/materialized-views/query-hash.ts
+++ b/packages/hub/src/materialized-views/query-hash.ts
@@ -1,0 +1,58 @@
+/**
+ * Deterministic hash of a materialized view strategy's "shape": MV
+ * name + canonical query-plan summary + sorted dependency-set.
+ *
+ * Used to detect strategy drift: a row whose `_materializedFrom.queryHash`
+ * doesn't match the current strategy is considered stale.
+ *
+ * Web Crypto SHA-256 — no extra deps. Mirrors the v1
+ * `computeStrategyHash` pattern.
+ */
+export async function computeQueryHash(
+  mvName: string,
+  /**
+   * Source-collection set the query depends on. Sorted before
+   * canonicalization so set iteration order doesn't affect the hash.
+   */
+  dependencies: ReadonlySet<string>,
+  /**
+   * Stringified query-plan summary. The caller produces this from the
+   * `Query<T>` builder — concretely: a JSON serialization of clauses +
+   * orderBy + limit + offset + joins. Function bodies inside
+   * `wherePredicate` are NOT included here (those carry their own
+   * `predicateHash` to be folded in by a later sub-issue).
+   */
+  queryPlanSummary: string,
+): Promise<string> {
+  const canonical = JSON.stringify({
+    mvName,
+    dependencies: [...dependencies].sort(),
+    queryPlanSummary,
+  })
+  const bytes = new TextEncoder().encode(canonical)
+  const digest = await crypto.subtle.digest('SHA-256', bytes)
+  return Array.from(new Uint8Array(digest))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/**
+ * Canonicalize a query plan for hashing. Walks the plan structure
+ * with sorted keys so insertion order doesn't perturb the result.
+ * Lives here rather than in `query/builder.ts` to keep that module
+ * stable across MV-specific evolutions.
+ *
+ * @internal exported for testing
+ */
+export function canonicalizeQueryPlan(plan: unknown): string {
+  return JSON.stringify(plan, (_key, value) => {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      const sorted: Record<string, unknown> = {}
+      for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+        sorted[k] = (value as Record<string, unknown>)[k]
+      }
+      return sorted
+    }
+    return value
+  })
+}

--- a/packages/hub/src/materialized-views/registry.ts
+++ b/packages/hub/src/materialized-views/registry.ts
@@ -1,0 +1,181 @@
+import { MaterializedViewCycleError, MaterializedViewSourceUnknownError } from '../errors.js'
+import type { DerivationRegistry } from '../derivations/registry.js'
+import { analyzeDependencies, summarizeQueryPlan } from './dependency-analyzer.js'
+import { computeQueryHash } from './query-hash.js'
+import type { MaterializedViewStrategy, MVQueryContext } from './types.js'
+
+/**
+ * One registered MV strategy alongside its derived metadata. Stored
+ * type-erased on `TRow` so the registry can hold heterogeneous MVs.
+ */
+export interface RegisteredMV {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly spec: MaterializedViewStrategy<any>
+  /** Output collection name (`spec.output?.collection ?? spec.name`). */
+  readonly outputCollection: string
+  /** Set of source collections; populated at registration via the analyzer. */
+  readonly dependencies: ReadonlySet<string>
+  /** Canonical `queryHash` — `_materializedFrom.queryHash` for every emitted row. */
+  readonly queryHash: string
+}
+
+/**
+ * Vault-internal registry of MV strategies. Owned by `Vault`; not
+ * exported. Parallel to v1's `DerivationRegistry`; the two graphs share
+ * a single cycle-detection pass at vault open (see `validate`).
+ *
+ * @internal
+ */
+export class MaterializedViewRegistry {
+  /** Keyed by `spec.name`. */
+  private readonly _byName = new Map<string, RegisteredMV>()
+  /** Keyed by dependency source-collection → MVs that depend on it. */
+  private readonly _bySource = new Map<string, RegisteredMV[]>()
+
+  /**
+   * Register an MV. Invokes `spec.query()` once at registration time to
+   * read the plan + join context; the resulting `Query<T>` is discarded
+   * after dependency extraction. `vault.collection(...)` must therefore
+   * be functional by the time this runs — typically wired from
+   * `Vault._initMaterializedViews` after collection bootstrap.
+   *
+   * Throws `MaterializedViewSourceUnknownError` if the analyzer
+   * surfaces a dependency the vault doesn't know about (when a
+   * `knownCollections` checker is supplied).
+   */
+  async register(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spec: MaterializedViewStrategy<any>,
+    db: MVQueryContext,
+    options?: { knownCollections?: (name: string) => boolean },
+  ): Promise<void> {
+    // Invoke the query callback once to inspect its plan.
+    const q = spec.query(db)
+    const dependencies = analyzeDependencies(q)
+    const queryPlanSummary = summarizeQueryPlan(q)
+
+    // Sanity-check declared dependencies against the vault's known
+    // collections. Optional — when the checker isn't supplied (test
+    // wiring, in-process composition) the registration succeeds and
+    // any typo surfaces at first onSourceWrite as a no-op.
+    if (options?.knownCollections) {
+      for (const dep of dependencies) {
+        if (!options.knownCollections(dep)) {
+          throw new MaterializedViewSourceUnknownError(spec.name, dep)
+        }
+      }
+    }
+
+    const outputCollection = spec.output?.collection ?? spec.name
+    const queryHash = await computeQueryHash(spec.name, dependencies, queryPlanSummary)
+    const reg: RegisteredMV = { spec, outputCollection, dependencies, queryHash }
+
+    this._byName.set(spec.name, reg)
+    for (const dep of dependencies) {
+      const arr = this._bySource.get(dep)
+      if (arr) arr.push(reg)
+      else this._bySource.set(dep, [reg])
+    }
+  }
+
+  /** All MVs that depend on `source`, in registration order. */
+  mvsForSource(source: string): ReadonlyArray<RegisteredMV> {
+    return this._bySource.get(source) ?? []
+  }
+
+  /** Single MV by name, or `undefined`. */
+  byName(name: string): RegisteredMV | undefined {
+    return this._byName.get(name)
+  }
+
+  /** Iterate over every registered MV. */
+  all(): ReadonlyArray<RegisteredMV> {
+    return [...this._byName.values()]
+  }
+
+  /**
+   * Cycle detection over the combined derivation + MV graph. Edges:
+   *   - Derivation: derivation.source → output.collection (each output)
+   *   - MV: every dep in MV.dependencies → MV.outputCollection
+   *
+   * Throws `MaterializedViewCycleError` if the cycle's terminal node
+   * is an MV output collection; otherwise (a pure-derivation cycle)
+   * the caller's `DerivationRegistry.validate()` will surface
+   * `DerivationCycleError` separately at vault open.
+   *
+   * Call AFTER all `register()` calls complete.
+   */
+  validate(derivationRegistry?: DerivationRegistry | null): void {
+    const visited = new Set<string>()
+    const stack: string[] = []
+    const mvOutputs = new Set<string>()
+    for (const reg of this._byName.values()) mvOutputs.add(reg.outputCollection)
+
+    const edges = new Map<string, string[]>()
+
+    // MV edges: every dep → output
+    for (const reg of this._byName.values()) {
+      for (const dep of reg.dependencies) {
+        const arr = edges.get(dep)
+        if (arr) arr.push(reg.outputCollection)
+        else edges.set(dep, [reg.outputCollection])
+      }
+    }
+
+    // Derivation edges: source → output collections
+    if (derivationRegistry) {
+      // The shared DerivationRegistry exposes its edges via the same
+      // `strategiesForSource` API its own `validate()` uses. We don't
+      // duplicate cycle detection — we add MV nodes to the graph and
+      // run the unified DFS, attributing cycles that touch an MV
+      // output to `MaterializedViewCycleError`.
+      for (const reg of this._byName.values()) {
+        // Walk every dependency through derivation edges too: a
+        // derivation whose output we depend on is itself a source.
+        void reg
+      }
+      // Pull derivation edges by scanning every MV dep + every MV
+      // output as potential derivation sources.
+      const sourcesToScan = new Set<string>()
+      for (const reg of this._byName.values()) {
+        for (const dep of reg.dependencies) sourcesToScan.add(dep)
+        sourcesToScan.add(reg.outputCollection)
+      }
+      for (const src of sourcesToScan) {
+        const strategies = derivationRegistry.strategiesForSource(src)
+        if (strategies.length === 0) continue
+        for (const s of strategies) {
+          for (const key of Object.keys(s.spec.outputs)) {
+            const o = s.spec.outputs[key]
+            if (!o) continue
+            const arr = edges.get(src)
+            if (arr) arr.push(o.collection)
+            else edges.set(src, [o.collection])
+          }
+        }
+      }
+    }
+
+    const visit = (node: string): void => {
+      if (stack.includes(node)) {
+        const cycle = stack.slice(stack.indexOf(node)).concat(node)
+        // If any node on the cycle is an MV output, attribute as MV
+        // cycle. Otherwise let DerivationRegistry.validate() surface it.
+        if (cycle.some(n => mvOutputs.has(n))) {
+          throw new MaterializedViewCycleError(cycle)
+        }
+        // Pure-derivation cycle — caller's DerivationRegistry.validate()
+        // will catch it separately. Don't double-report.
+        return
+      }
+      if (visited.has(node)) return
+      stack.push(node)
+      const outs = edges.get(node)
+      if (outs) for (const o of outs) visit(o)
+      stack.pop()
+      visited.add(node)
+    }
+
+    for (const node of edges.keys()) visit(node)
+  }
+}

--- a/packages/hub/src/materialized-views/types.ts
+++ b/packages/hub/src/materialized-views/types.ts
@@ -1,0 +1,110 @@
+import type { Query } from '../query/builder.js'
+import type { Collection } from '../collection.js'
+
+/**
+ * Minimal vault-shaped accessor passed to the MV `query()` callback.
+ * Defined as a structural interface so the strategy types don't have
+ * to import the full `Vault` class (avoids a circular import). The
+ * Vault implements this shape natively.
+ */
+export interface MVQueryContext {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  collection<T extends Record<string, unknown>>(name: string): Collection<T>
+}
+
+/**
+ * Metadata that travels inside the `_data` payload of a materialized
+ * row. Lives in encrypted payload, not in the unencrypted envelope —
+ * the storage backend cannot infer the MV graph from listing.
+ *
+ * Extends the `_derivedFrom` precedent from v1: same encryption shape,
+ * same "metadata-inside-data" location.
+ */
+export interface MaterializedFromMeta {
+  /** Stable identity for the MV that emitted this row. */
+  readonly mvName: string
+  /**
+   * SHA-256 of (mvName + canonical query plan + dependency-set).
+   * Changes when the query structure changes → forces refresh on
+   * next visit (parallels v1's `strategyHash`).
+   */
+  readonly queryHash: string
+  /**
+   * Map from source collection name → `_v` of the source row(s) that
+   * contributed to this MV row at materialization time. For aggregates
+   * over many rows, this is `max(_v)` per source collection — coarse
+   * but sufficient for stale detection.
+   */
+  readonly sourceVersions: Record<string, number>
+  /** ISO timestamp when this row was materialized. */
+  readonly materializedAt: string
+}
+
+/** Output routing for an MV. Optional — when omitted, writes to a collection named after `name`. */
+export interface MaterializedViewOutput {
+  /** Output collection name. Defaults to `name`. */
+  collection?: string
+  /**
+   * For same-collection-as-source MVs — see § Same-collection partition
+   * discriminator in the v2 spec. Deferred to subtask #152; declared
+   * here so the type is stable across PRs.
+   */
+  partition?: { field: string; value: unknown }
+}
+
+/**
+ * Registration shape passed to `withMaterializedView()`.
+ *
+ * @typeParam TRow - the materialized row type (the query's result row)
+ */
+export interface MaterializedViewStrategy<TRow extends Record<string, unknown>> {
+  /**
+   * Stable identity for this view. Used as the output collection name
+   * unless `output.collection` overrides. Must be unique within the vault.
+   */
+  name: string
+  /**
+   * Declared query. Called at registration time with a vault-shaped
+   * accessor so the closure can compose collections without
+   * pre-existing in-scope references; called again at each refresh.
+   *
+   * Built via the same `Query<T>` chainable builder used elsewhere —
+   * `.where()`, `.join()`, `.groupBy()`, `.aggregate()`. The
+   * dependency analyzer walks the returned plan to determine source
+   * collections.
+   */
+  query: (db: MVQueryContext) => Query<TRow>
+  /**
+   * Pure function from a materialized row → stable id used in the
+   * output collection. Required — explicit always beats default-with-pitfalls
+   * (see niwat-review of #149 round 1 for the slash-collision rationale).
+   */
+  rowKey: (row: TRow) => string
+  /**
+   * Refresh policy. Foundation sub-issue (#150) implements `'eager'`;
+   * `'lazy'` and `'manual'` are wired in sub-issues #151.
+   */
+  refresh: 'eager' | 'lazy' | 'manual'
+  /** Output routing. Optional; defaults to writing the collection named after `name`. */
+  output?: MaterializedViewOutput
+  /**
+   * What to do when a re-materialization produces zero rows for a key
+   * that previously had rows. Deferred to subtask #152.
+   */
+  onEmpty?: 'delete' | 'keep'
+  /**
+   * Strict-mode rollback inside `withTransactions`. Deferred to subtask #152.
+   */
+  strict?: boolean
+  /**
+   * Row-count ceiling for the materialized output. Deferred to subtask #152.
+   */
+  maxRows?: number
+}
+
+/** Returned by `withMaterializedView()` and consumed by `createNoydb`. */
+export interface MaterializedViewStrategyHandle {
+  readonly __noydb_strategy: 'materialized-view'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly spec: MaterializedViewStrategy<any>
+}

--- a/packages/hub/src/materialized-views/with-materialized-view.ts
+++ b/packages/hub/src/materialized-views/with-materialized-view.ts
@@ -1,0 +1,35 @@
+import { ValidationError } from '../errors.js'
+import type { MaterializedViewStrategy, MaterializedViewStrategyHandle } from './types.js'
+
+/**
+ * Register a materialized view: a declared query whose result is
+ * persisted as a queryable collection and kept fresh as sources
+ * change. Writes go through the standard `Collection.put` pipeline;
+ * refresh-driven deletes route through `Collection._internalDelete` so
+ * user `onDelete` guards on the output collection aren't tripped by
+ * housekeeping.
+ *
+ * See docs/superpowers/specs/2026-05-20-dim14-mv-v2-design.md.
+ */
+export function withMaterializedView<TRow extends Record<string, unknown>>(
+  spec: MaterializedViewStrategy<TRow>,
+): MaterializedViewStrategyHandle {
+  if (!spec.name || spec.name.length === 0) {
+    throw new ValidationError('withMaterializedView: name is required')
+  }
+  if (typeof spec.query !== 'function') {
+    throw new ValidationError('withMaterializedView: query must be a function returning a Query<T>')
+  }
+  if (typeof spec.rowKey !== 'function') {
+    throw new ValidationError('withMaterializedView: rowKey is required (no default; see spec § Type surface)')
+  }
+  if (spec.refresh !== 'eager' && spec.refresh !== 'lazy' && spec.refresh !== 'manual') {
+    throw new ValidationError(
+      `withMaterializedView: refresh must be 'eager' | 'lazy' | 'manual', got "${String(spec.refresh)}"`,
+    )
+  }
+  return {
+    __noydb_strategy: 'materialized-view',
+    spec,
+  }
+}

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -406,6 +406,7 @@ export class Noydb {
     // out of the floor bundle for consumers that don't use it (#130).
     await comp._initGuards(this.options.guardStrategies ?? [])
     await comp._initDerivations(this.options.derivationStrategies ?? [])
+    await comp._initMaterializedViews(this.options.materializedViewStrategies ?? [])
     this.vaultCache.set(name, comp)
     return comp
   }

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -115,6 +115,24 @@ export class Query<T> {
     this.aggregateStrategy = aggregateStrategy
   }
 
+  /**
+   * @internal — accessor for the materialized-view dependency
+   * analyzer. Not part of the public API; consumers should use the
+   * builder methods, not inspect the plan directly.
+   */
+  _plan(): QueryPlan {
+    return this.plan
+  }
+
+  /**
+   * @internal — accessor for the materialized-view dependency
+   * analyzer. Returns the join resolution context (or `undefined` for
+   * queries constructed without a Collection backing).
+   */
+  _joinContext(): JoinContext | undefined {
+    return this.joinContext
+  }
+
   /** Add a field comparison. Multiple where() calls are AND-combined. */
   where(field: string, op: Operator, value: unknown): Query<T> {
     const clause: FieldClause = { type: 'field', field, op, value }

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -42,6 +42,7 @@ import type { DerivationStrategyHandle } from './derivations/types.js'
 import type { UnlockedKeyring } from './team/keyring.js'
 import type { VaultPolicy } from './policy/types.js'
 import type { PublicEnvelopeSchema } from './meta/public-envelope/types.js'
+import type { MaterializedViewStrategyHandle } from './materialized-views/types.js'
 
 /** Format version for encrypted record envelopes. */
 export const NOYDB_FORMAT_VERSION = 1 as const
@@ -1756,6 +1757,14 @@ export interface NoydbOptions {
    * graph throws `DerivationCycleError`.
    */
   readonly derivationStrategies?: ReadonlyArray<DerivationStrategyHandle>
+  /**
+   * Optional materialized-view strategies (#143, foundation in #150).
+   * Each handle returned by `withMaterializedView()` from
+   * `@noy-db/hub/materialized-views`. The vault runs unified cycle
+   * detection across the MV + derivation graphs at `openVault`; a
+   * cyclic graph throws `MaterializedViewCycleError`.
+   */
+  readonly materializedViewStrategies?: ReadonlyArray<MaterializedViewStrategyHandle>
   /** Optional remote store(s) for sync. Accepts a single store, a SyncTarget, or an array. */
   readonly sync?: NoydbStore | SyncTarget | SyncTarget[]
   /** User identifier. */

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -20,6 +20,8 @@ import type { IndexDef } from './indexing/eager-indexes.js'
 import type { JoinableSource } from './query/index.js'
 import type { OnDirtyCallback } from './collection.js'
 import type { UnlockedKeyring, BundleRecipient } from './team/keyring.js'
+import type { MaterializedViewRegistry } from './materialized-views/registry.js'
+import type { MaterializedViewStrategyHandle, MVQueryContext } from './materialized-views/types.js'
 import type { PublicEnvelope } from './meta/public-envelope/types.js'
 import { buildRecipientKeyringFile } from './team/keyring.js'
 import { ensureCollectionDEK, hasAccess, hasExportCapability, hasImportCapability } from './team/keyring.js'
@@ -157,6 +159,12 @@ export class Vault {
    * least one strategy handle. See #130 for the bundle motivation.
    */
   private derivationRegistry: DerivationRegistry | null = null
+  /**
+   * Per-vault materialized-view registry (#143/#150). Same lazy-load
+   * contract as `derivationRegistry` — `null` until
+   * `_initMaterializedViews()` runs with at least one MV handle.
+   */
+  private materializedViewRegistry: MaterializedViewRegistry | null = null
   /**
    * Cached read-only facade handed to guard callbacks via `ctx.vault`,
    * and to derivation callbacks via `derive(source, ctx)`. Allocated
@@ -579,6 +587,17 @@ export class Vault {
                 createTxContext: () => this.noydb._createTxContext(),
                 setActiveTxContext: (ctx) => this.noydb._setActiveTxContext(ctx),
                 clearActiveTxContext: (ctx) => this.noydb._clearActiveTxContext(ctx),
+              },
+            }
+          : {}),
+        ...(this.materializedViewRegistry !== null
+          ? {
+              materializedViewSource: {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                registry: () => this.materializedViewRegistry!,
+                getCollection: (name: string) => this.collection(name),
+                getActiveTxContext: () => this.noydb._activeTxContextOrNull,
+                getQueryContext: () => this as unknown as MVQueryContext,
               },
             }
           : {}),
@@ -1417,6 +1436,54 @@ export class Vault {
    */
   _getDerivationRegistry(): DerivationRegistry | null {
     return this.derivationRegistry
+  }
+
+  /**
+   * @internal — called by `Noydb.openVault` after collections are
+   * wired. Dynamic-imports `MaterializedViewRegistry`, registers each
+   * MV spec (which invokes its `query()` once for dependency
+   * analysis), then runs the unified cycle detection across the MV +
+   * derivation graphs. No-op when the handles array is empty — keeps
+   * the MV subsystem out of the floor bundle (mirrors v1 #130).
+   * Throws `MaterializedViewCycleError` if a cycle is detected.
+   */
+  async _initMaterializedViews(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    handles: ReadonlyArray<MaterializedViewStrategyHandle>,
+  ): Promise<void> {
+    if (handles.length === 0) return
+    const { MaterializedViewRegistry } = await import('./materialized-views/registry.js')
+    const registry = new MaterializedViewRegistry()
+    // Phase 1: publish the (empty) registry on `this` BEFORE
+    // registering any spec. The user's `query(db)` callback runs at
+    // registration time and may construct source Collections via
+    // `db.collection(name)` — those Collections are cached in the
+    // vault and their `materializedViewSource` is populated from
+    // `this.materializedViewRegistry` AT CONSTRUCTION TIME. If we
+    // assigned `this.materializedViewRegistry` only after the
+    // register() loop, the source Collections would cache with an
+    // unset source and never dispatch MV refreshes on later writes.
+    this.materializedViewRegistry = registry
+    // Pass `this` Vault as the MVQueryContext — its `collection<T>()`
+    // method is what the user's `query(db)` callback consumes.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const db = this as unknown as MVQueryContext
+    for (const h of handles) {
+      await registry.register(h.spec, db)
+    }
+    // Phase 2: unified cycle detection across MV + derivation graphs.
+    // Runs after all `register()` calls so the analyzer has every
+    // dep-set; throws `MaterializedViewCycleError` on the first cycle.
+    registry.validate(this.derivationRegistry)
+  }
+
+  /**
+   * @internal — consumed by `Collection.put` at write-time. Returns
+   * `null` for vaults that never registered any MV strategy.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _getMaterializedViewRegistry(): MaterializedViewRegistry | null {
+    return this.materializedViewRegistry
   }
 
   /**

--- a/packages/hub/tsup.config.ts
+++ b/packages/hub/tsup.config.ts
@@ -41,6 +41,7 @@ const ENTRIES = {
   'shadow/index': 'src/shadow/index.ts',
   'tx/index': 'src/tx/index.ts',
   'derivations/index': 'src/derivations/index.ts',
+  'materialized-views/index': 'src/materialized-views/index.ts',
   'sync/index': 'src/sync/index.ts',
   'util/index': 'src/util/index.ts',
 }


### PR DESCRIPTION
## Summary

First PR of the #143 implementation epic. Lands the foundation for \`withMaterializedView\` (Dim 14 v2): a declared query whose result is persisted as a queryable collection and kept fresh on source-collection writes.

Foundation supports **eager refresh of non-aggregate queries**; lazy / manual / aggregate shapes / partition / onEmpty / ceiling / strict / predicates / overlay land in #151–#155 (independent sub-issues, can stack at the tail).

Spec: [\`2026-05-20-dim14-mv-v2-design.md\`](https://github.com/vLannaAi/noy-db/blob/main/docs/superpowers/specs/2026-05-20-dim14-mv-v2-design.md). Sequencing steps 1–6 of the 16-step plan.

## Surface added

- \`@noy-db/hub/materialized-views\` subpath (mirrors \`@noy-db/hub/derivations\`)
- \`createNoydb({ materializedViewStrategies: [...] })\` option
- \`withMaterializedView({ name, query, rowKey, refresh })\` factory
- \`MaterializedViewCycleError\`, \`MaterializedViewSourceUnknownError\`
- \`_materializedFrom\` payload metadata on every emitted row (lives inside \`_data\`, opaque to the storage backend — matches \`_derivedFrom\` precedent)

## One non-obvious wiring choice

\`Vault._initMaterializedViews\` publishes the registry on \`this\` **before** invoking the user's \`query(db)\` callback. Reason: the callback constructs source Collections via \`db.collection(name)\`, and those Collections cache their \`materializedViewSource\` AT CONSTRUCTION TIME. If we assigned the registry only after the register() loop, source Collections would cache with the source unset and never dispatch MV refreshes on subsequent writes. (Caught in test iteration; documented in the commit message.)

## Verification

- 1529 hub tests pass (was 1514 + 15 new)
- typecheck clean · lint clean
- Bundle within tolerance: floor +4.4% gz, all-on +2.1% gz
- Executor + registry are dynamic-imported on first dispatch — MV-free consumers don't pull in the chunk

## Test plan

- [x] \`pnpm --filter @noy-db/hub typecheck\`
- [x] \`pnpm --filter @noy-db/hub lint\`
- [x] \`pnpm --filter @noy-db/hub test\` — 1529 / 1529
- [x] \`pnpm --filter @noy-db/hub bundle-check\` — all four scenarios green
- [ ] niwat-consumer review pass against the foundation surface before #151 stacks on top

Closes #150. Unblocks #151–#155 (which stack on this).