### PR TITLE
feat(hub): MV lazy lifecycle + vault.refreshView (#151)

### DIFF
--- a/packages/hub/__tests__/materialized-views/end-to-end.test.ts
+++ b/packages/hub/__tests__/materialized-views/end-to-end.test.ts
@@ -155,14 +155,8 @@ describe('MV foundation (#150) — end-to-end', () => {
     expect(await vault.collection<Item>('mv-redtags').get('a')).toBeNull()
   })
 
-  it('lazy and manual MV strategies register but do not eagerly materialize (foundation no-op)', async () => {
+  it('manual MV: source write does not auto-materialize (read also passes through; only refreshView triggers)', async () => {
     interface Item extends Record<string, unknown> { id: string }
-    const lazyMV = withMaterializedView<Item>({
-      name: 'lazy-mv',
-      query: (db) => db.collection<Item>('items').query(),
-      rowKey: (r) => r.id,
-      refresh: 'lazy',
-    })
     const manualMV = withMaterializedView<Item>({
       name: 'manual-mv',
       query: (db) => db.collection<Item>('items').query(),
@@ -172,15 +166,14 @@ describe('MV foundation (#150) — end-to-end', () => {
     const db = await createNoydb({
       store: memory(),
       user: 'alice',
-      secret: 'mv-foundation-lazy-manual-passphrase-2026',
-      materializedViewStrategies: [lazyMV, manualMV],
+      secret: 'mv-foundation-manual-passphrase-2026',
+      materializedViewStrategies: [manualMV],
     })
     const vault = await db.openVault('demo')
     await vault.collection<Item>('items').put('a', { id: 'a' })
-    // Foundation: lazy + manual do not materialize. Subtask #151 wires
-    // them. This test pins the no-op behavior so #151 has a clear
-    // delta to write against.
-    expect(await vault.collection<Item>('lazy-mv').get('a')).toBeNull()
+    // Manual MV: neither the source write nor the read triggers
+    // materialization. (Lazy semantics are covered by the dedicated
+    // lazy-and-manual test file.)
     expect(await vault.collection<Item>('manual-mv').get('a')).toBeNull()
   })
 })

--- a/packages/hub/__tests__/materialized-views/lazy-and-manual.test.ts
+++ b/packages/hub/__tests__/materialized-views/lazy-and-manual.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withMaterializedView } from '../../src/index.js'
+import { isMVStale } from '../../src/materialized-views/stale.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface Item extends Record<string, unknown> { id: string; tag: string }
+
+describe('MV lazy lifecycle + vault.refreshView (#151)', () => {
+  it('lazy MV: source write marks stale; first read materializes', async () => {
+    const lazyMV = withMaterializedView<Item>({
+      name: 'red-items',
+      query: (db) => db.collection<Item>('items').query().where('tag', '==', 'red'),
+      rowKey: (r) => r.id,
+      refresh: 'lazy',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-lazy-passphrase-2026',
+      materializedViewStrategies: [lazyMV],
+    })
+    const vault = await db.openVault('demo')
+
+    // No put yet → MV output is empty
+    expect(await vault.collection<Item>('red-items').get('a')).toBeNull()
+
+    // Source write fires lazy path: mark stale, no materialization.
+    await vault.collection<Item>('items').put('a', { id: 'a', tag: 'red' })
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const reg = vault._getMaterializedViewRegistry()!
+    expect(isMVStale(reg, 'red-items')).toBe(true)
+
+    // First read triggers resolveStaleMVOnRead → materializes.
+    const row = await vault.collection<Item>('red-items').get('a')
+    expect(row).not.toBeNull()
+    expect(row?.tag).toBe('red')
+    // Stale bit cleared after refresh.
+    expect(isMVStale(reg, 'red-items')).toBe(false)
+  })
+
+  it('lazy MV: subsequent reads after a source change re-stale + re-materialize', async () => {
+    const lazyMV = withMaterializedView<Item>({
+      name: 'red-items',
+      query: (db) => db.collection<Item>('items').query().where('tag', '==', 'red'),
+      rowKey: (r) => r.id,
+      refresh: 'lazy',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-lazy-restale-passphrase-2026',
+      materializedViewStrategies: [lazyMV],
+    })
+    const vault = await db.openVault('demo')
+
+    await vault.collection<Item>('items').put('a', { id: 'a', tag: 'red' })
+    expect(await vault.collection<Item>('red-items').get('a')).not.toBeNull()
+
+    // Flip 'a' to blue + add new red 'b'. Two source writes → still
+    // only one stale bit (set semantics).
+    await vault.collection<Item>('items').put('a', { id: 'a', tag: 'blue' })
+    await vault.collection<Item>('items').put('b', { id: 'b', tag: 'red' })
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const reg = vault._getMaterializedViewRegistry()!
+    expect(isMVStale(reg, 'red-items')).toBe(true)
+
+    // Re-read 'b' triggers refresh; 'b' shows up.
+    expect(await vault.collection<Item>('red-items').get('b')).not.toBeNull()
+    // Stale cleared again.
+    expect(isMVStale(reg, 'red-items')).toBe(false)
+    // Note: 'a' will still appear in the MV until subtask #152
+    // implements tombstoning (onEmpty: 'delete' / row removal on
+    // disappearance). The MV doesn't tombstone in this iteration.
+  })
+
+  it('manual MV: source writes do NOT materialize; only refreshView(name) does', async () => {
+    const manualMV = withMaterializedView<Item>({
+      name: 'all-items',
+      query: (db) => db.collection<Item>('items').query(),
+      rowKey: (r) => r.id,
+      refresh: 'manual',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-manual-passphrase-2026',
+      materializedViewStrategies: [manualMV],
+    })
+    const vault = await db.openVault('demo')
+
+    await vault.collection<Item>('items').put('a', { id: 'a', tag: 'red' })
+    await vault.collection<Item>('items').put('b', { id: 'b', tag: 'blue' })
+
+    // Manual MV does not auto-materialize on source write OR on read.
+    expect(await vault.collection<Item>('all-items').get('a')).toBeNull()
+    expect(await vault.collection<Item>('all-items').get('b')).toBeNull()
+    // The stale map is also not populated for manual MVs.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const reg = vault._getMaterializedViewRegistry()!
+    expect(isMVStale(reg, 'all-items')).toBe(false)
+
+    // Explicit refresh materializes.
+    const result = await vault.refreshView('all-items')
+    expect(result.written).toBe(2)
+    expect(result.deleted).toBe(0)
+    expect(result.failed).toBe(0)
+
+    expect(await vault.collection<Item>('all-items').get('a')).not.toBeNull()
+    expect(await vault.collection<Item>('all-items').get('b')).not.toBeNull()
+  })
+
+  it('vault.refreshView clears the stale bit for a lazy MV', async () => {
+    const lazyMV = withMaterializedView<Item>({
+      name: 'red-items',
+      query: (db) => db.collection<Item>('items').query().where('tag', '==', 'red'),
+      rowKey: (r) => r.id,
+      refresh: 'lazy',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-refresh-clears-stale-passphrase-2026',
+      materializedViewStrategies: [lazyMV],
+    })
+    const vault = await db.openVault('demo')
+    await vault.collection<Item>('items').put('a', { id: 'a', tag: 'red' })
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const reg = vault._getMaterializedViewRegistry()!
+    expect(isMVStale(reg, 'red-items')).toBe(true)
+
+    // Manual refresh clears the stale flag without needing a read.
+    await vault.refreshView('red-items')
+    expect(isMVStale(reg, 'red-items')).toBe(false)
+    expect(await vault.collection<Item>('red-items').get('a')).not.toBeNull()
+  })
+
+  it('refreshView throws on unknown MV name', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-refresh-unknown-passphrase-2026',
+    })
+    const vault = await db.openVault('demo')
+    // No MVs registered — returns zero counts.
+    expect(await vault.refreshView('nonexistent')).toEqual({ written: 0, deleted: 0, failed: 0 })
+
+    // With at least one MV registered, an unknown name throws.
+    const mv = withMaterializedView<Item>({
+      name: 'red',
+      query: (d) => d.collection<Item>('items').query().where('tag', '==', 'red'),
+      rowKey: (r) => r.id,
+      refresh: 'manual',
+    })
+    const db2 = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-refresh-unknown-2-passphrase-2026',
+      materializedViewStrategies: [mv],
+    })
+    const v2 = await db2.openVault('demo')
+    await expect(v2.refreshView('does-not-exist')).rejects.toThrow(/refreshView.*does-not-exist/)
+  })
+})

--- a/packages/hub/__tests__/materialized-views/lazy-and-manual.test.ts
+++ b/packages/hub/__tests__/materialized-views/lazy-and-manual.test.ts
@@ -193,4 +193,55 @@ describe('MV lazy lifecycle + vault.refreshView (#151)', () => {
     const v2 = await db2.openVault('demo')
     await expect(v2.refreshView('does-not-exist')).rejects.toThrow(/refreshView.*does-not-exist/)
   })
+
+  it('list() triggers lazy-MV resolve-on-read (niwat-review of #157)', async () => {
+    const lazyMV = withMaterializedView<Item>({
+      name: 'red-items',
+      query: (db) => db.collection<Item>('items').query().where('tag', '==', 'red'),
+      rowKey: (r) => r.id,
+      refresh: 'lazy',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-list-resolves-lazy-passphrase-2026',
+      materializedViewStrategies: [lazyMV],
+    })
+    const vault = await db.openVault('demo')
+    await vault.collection<Item>('items').put('a', { id: 'a', tag: 'red' })
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const reg = vault._getMaterializedViewRegistry()!
+    expect(isMVStale(reg, 'red-items')).toBe(true)
+
+    // list() should trigger the resolve-on-read hook — same as get()
+    const rows = await vault.collection<Item>('red-items').list()
+    expect(rows).toHaveLength(1)
+    expect(isMVStale(reg, 'red-items')).toBe(false)
+  })
+
+  it('refreshView returns executor counts with deleted in the shape (niwat-review of #157)', async () => {
+    // Tombstoning ships in #158 (next sub-issue). On this branch the
+    // executor always returns `deleted: 0` — but the shape is forward-
+    // compatible, so consumers reading `result.deleted` see a real
+    // number instead of `undefined`. The #158 branch adds the test
+    // that asserts `deleted: 1` when a row flips out of the query.
+    const mv = withMaterializedView<Item>({
+      name: 'red-items',
+      query: (db) => db.collection<Item>('items').query().where('tag', '==', 'red'),
+      rowKey: (r) => r.id,
+      refresh: 'manual',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-refresh-deleted-count-passphrase-2026',
+      materializedViewStrategies: [mv],
+    })
+    const vault = await db.openVault('demo')
+    await vault.collection<Item>('items').put('a', { id: 'a', tag: 'red' })
+    const result = await vault.refreshView('red-items')
+    expect(result.written).toBe(1)
+    expect(result.deleted).toBe(0) // not undefined — shape stable
+    expect(result.failed).toBe(0)
+  })
 })

--- a/packages/hub/bundle-manifest.json
+++ b/packages/hub/bundle-manifest.json
@@ -1,21 +1,21 @@
 {
   "scenarios": {
     "floor": {
-      "minifiedBytes": 141909,
-      "gzippedBytes": 39522
+      "minifiedBytes": 149609,
+      "gzippedBytes": 41541
     },
     "history": {
-      "minifiedBytes": 146164,
-      "gzippedBytes": 41052
+      "minifiedBytes": 153857,
+      "gzippedBytes": 42946
     },
     "analytics": {
-      "minifiedBytes": 149509,
-      "gzippedBytes": 41643
+      "minifiedBytes": 157207,
+      "gzippedBytes": 43691
     },
     "all-on": {
-      "minifiedBytes": 196205,
-      "gzippedBytes": 54607
+      "minifiedBytes": 202315,
+      "gzippedBytes": 56043
     }
   },
-  "updatedAt": "2026-05-19T04:09:21.616Z"
+  "updatedAt": "2026-05-20T21:10:57.619Z"
 }

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -50,6 +50,8 @@ import type { DerivationExecutor as DerivationExecutorType } from './derivations
 import { markStale, resolveStaleOnRead } from './derivations/stale.js'
 import type { MaterializedViewRegistry } from './materialized-views/registry.js'
 import type { MVQueryContext } from './materialized-views/types.js'
+import type { MaterializedViewExecutor as MVExecutorType } from './materialized-views/executor.js'
+import type * as MVStaleModule from './materialized-views/stale.js'
 
 /** Callback for dirty tracking (sync engine integration). */
 export type OnDirtyCallback = (collection: string, id: string, action: 'put' | 'delete', version: number) => Promise<void>
@@ -965,6 +967,15 @@ export class Collection<T> {
       }
     }
 
+    // Lazy-MV resolve-on-read (#151). When the collection being read
+    // is the output of a registered lazy MV that has at least one
+    // pending stale flag, run the executor before returning. No-op
+    // when nothing is pending.
+    if (this.materializedViewSource !== undefined) {
+      const { resolveStaleMVOnRead } = await import('./materialized-views/stale.js')
+      await resolveStaleMVOnRead(this.materializedViewSource, this.name)
+    }
+
     let record: T | null
 
     if (this.lazy && this.lru) {
@@ -1410,18 +1421,31 @@ export class Collection<T> {
     if (mvs.length === 0) return
     // Dynamic-import the executor only on first eager-MV dispatch —
     // keeps the MV executor chunk out of the floor bundle (mirrors the
-    // #130 dynamic-import pattern v1 uses for derivations).
-    const { MaterializedViewExecutor } = await import('./materialized-views/executor.js')
+    // #130 dynamic-import pattern v1 uses for derivations). Lazy mode
+    // uses the pure-helper `markMVStale` which lives in `stale.js` and
+    // is also dynamic-imported (only when at least one lazy MV depends
+    // on this source).
+    let executor: typeof MVExecutorType | null = null
+    let staleHelpers: typeof MVStaleModule | null = null
     for (const reg of mvs) {
       const mode = reg.spec.refresh
       if (mode === 'eager') {
-        await MaterializedViewExecutor.refresh(reg, {
+        if (executor === null) {
+          ;({ MaterializedViewExecutor: executor } = await import('./materialized-views/executor.js'))
+        }
+        await executor.refresh(reg, {
           getCollection: (name) => this.materializedViewSource!.getCollection(name),
           getActiveTxContext: () => this.materializedViewSource!.getActiveTxContext(),
           getQueryContext: () => this.materializedViewSource!.getQueryContext(),
         })
+      } else if (mode === 'lazy') {
+        if (staleHelpers === null) {
+          staleHelpers = await import('./materialized-views/stale.js')
+        }
+        staleHelpers.markMVStale(registry, reg.spec.name)
       }
-      // lazy/manual: deferred to subtask #151
+      // manual: no-op on source-write. `vault.refreshView(name)` is
+      // the only path that materializes a manual MV.
     }
   }
 

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1792,6 +1792,14 @@ export class Collection<T> {
         `Use collection.scan({ pageSize }) to iterate over the full collection.`,
       )
     }
+    // Lazy-MV resolve-on-read (#157 review): if this collection is the
+    // output of a registered lazy MV with a pending stale flag, run
+    // the executor before returning so callers see fresh data. No-op
+    // when nothing is pending — keeps the read path negligible.
+    if (this.materializedViewSource !== undefined) {
+      const { resolveStaleMVOnRead } = await import('./materialized-views/stale.js')
+      await resolveStaleMVOnRead(this.materializedViewSource, this.name)
+    }
     await this.ensureHydrated()
     const records = [...this.cache.values()].map(e => e.record)
     if (!locale) return records
@@ -1986,6 +1994,15 @@ export class Collection<T> {
    * Backward-compatible overload: passing a predicate function returns
    * the filtered records directly (the API). Prefer the chainable
    * form for new code.
+   *
+   * **Lazy-MV gap (#157):** `query()` is synchronous and does NOT
+   * trigger lazy materialized-view resolve-on-read. If this
+   * collection is a lazy MV's output and the MV is currently stale,
+   * `query().toArray()` returns the pre-stale snapshot. To force a
+   * fresh read on a lazy MV, either call `list()` (which DOES
+   * trigger resolve) or `vault.refreshView(mvName)` before querying.
+   * The proper fix — extending `QuerySource` with an async prepare
+   * hook — is a separate PR.
    *
    * @example
    * ```ts
@@ -2378,6 +2395,11 @@ export class Collection<T> {
    *   .where('year', '==', 2025)
    *   .aggregate({ total: sum('amount'), n: count() })
    * ```
+   *
+   * **Lazy-MV gap (#157):** `scan()` is synchronous-build and does
+   * NOT trigger lazy materialized-view resolve-on-read. For lazy
+   * MVs, call `list()` (which DOES resolve) or `vault.refreshView(name)`
+   * before scanning. Same shape as the `query()` limitation.
    *
    * Returns a `ScanBuilder<T>` instead of the raw async iterator
    * that previous versions used. The builder implements

--- a/packages/hub/src/materialized-views/executor.ts
+++ b/packages/hub/src/materialized-views/executor.ts
@@ -26,6 +26,13 @@ export interface MVExecutorAccessor {
 export interface RefreshResult {
   /** Rows newly written / overwritten. */
   written: number
+  /**
+   * Rows tombstoned via `_internalDelete`. Always 0 in this iteration
+   * (foundation + lazy/manual sub-issues #150/#151); populated by
+   * #152's `onEmpty: 'delete'` tombstoning pass. Forward-compat shape
+   * so `vault.refreshView()` callers get a stable contract.
+   */
+  deleted: number
   /** Failed row writes (non-strict mode). */
   failed: number
 }
@@ -123,6 +130,6 @@ export const MaterializedViewExecutor = {
         console.warn(`[mv] "${spec.name}" row write failed:`, err)
       }
     }
-    return { written, failed }
+    return { written, deleted: 0, failed }
   },
 }

--- a/packages/hub/src/materialized-views/index.ts
+++ b/packages/hub/src/materialized-views/index.ts
@@ -3,6 +3,8 @@ export { MaterializedViewRegistry } from './registry.js'
 export { MaterializedViewExecutor } from './executor.js'
 export { analyzeDependencies, summarizeQueryPlan } from './dependency-analyzer.js'
 export { computeQueryHash, canonicalizeQueryPlan } from './query-hash.js'
+export { markMVStale, resolveStaleMVOnRead, isMVStale, clearMVStale } from './stale.js'
+export type { MVStaleAccessor } from './stale.js'
 export type {
   MaterializedViewStrategy,
   MaterializedViewStrategyHandle,

--- a/packages/hub/src/materialized-views/stale.ts
+++ b/packages/hub/src/materialized-views/stale.ts
@@ -1,0 +1,127 @@
+import type { Collection } from '../collection.js'
+import type { TxContext } from '../tx/transaction.js'
+import type { MaterializedViewRegistry } from './registry.js'
+// Type-only — runtime class loaded via dynamic import in
+// `resolveStaleMVOnRead` only when a stale flag actually fires.
+// Keeps the executor chunk out of the floor bundle (mirrors v1 #130).
+import type { MaterializedViewExecutor as MVExecutorType } from './executor.js'
+import type { MVQueryContext } from './types.js'
+
+/**
+ * Accessor shape passed in from the owning Vault. Provides the
+ * registry (used as a stable WeakMap key + to look up MVs by output
+ * collection) and the runtime context the lazy refresh needs.
+ * Mirrors v1's `DerivationStaleAccessor`.
+ */
+export interface MVStaleAccessor {
+  registry(): MaterializedViewRegistry
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getCollection(name: string): Collection<any>
+  getActiveTxContext(): TxContext | null
+  getQueryContext(): MVQueryContext
+}
+
+/**
+ * In-memory stale map keyed by `MaterializedViewRegistry` instance
+ * (stable per vault). Each registry maps to a set of MV names that
+ * have at least one pending source-change requiring a re-materialize.
+ *
+ * Persistence across vault close is NOT implemented in this iteration
+ * (concern flagged in the v2 spec, mirrors v1 derivation behavior).
+ * On vault re-open, the unset stale flag is interpreted as "fresh" —
+ * `vault.refreshView(name)` is the explicit recompute escape hatch.
+ *
+ * @internal
+ */
+const _staleByRegistry = new WeakMap<MaterializedViewRegistry, Set<string>>()
+
+/**
+ * Mark an MV as stale. Called from `Collection.dispatchMaterializedViews`
+ * when a source-write fires for a `refresh: 'lazy'` MV.
+ *
+ * @internal
+ */
+export function markMVStale(registry: MaterializedViewRegistry, mvName: string): void {
+  let set = _staleByRegistry.get(registry)
+  if (!set) {
+    set = new Set()
+    _staleByRegistry.set(registry, set)
+  }
+  set.add(mvName)
+}
+
+/**
+ * Test-only: check whether a given MV name is currently flagged stale
+ * against a registry. Exported so the regression suite can pin the
+ * stale-bit lifecycle without touching the internal `WeakMap`.
+ *
+ * @internal
+ */
+export function isMVStale(registry: MaterializedViewRegistry, mvName: string): boolean {
+  return _staleByRegistry.get(registry)?.has(mvName) ?? false
+}
+
+/**
+ * Called from `Collection.get` (and any reader that materializes the
+ * MV's output collection). If any MV producing `outputCollection` is
+ * flagged stale, runs the executor against the live source state
+ * before returning. No-op when there is no pending work — keeps the
+ * read fast path negligible.
+ *
+ * Dynamic-imports the executor only when a stale flag actually fires
+ * (the floor-bundle isolation pattern v1 derivations established in
+ * #130).
+ */
+export async function resolveStaleMVOnRead(
+  accessor: MVStaleAccessor,
+  outputCollection: string,
+): Promise<void> {
+  const registry = accessor.registry()
+  const pending = _staleByRegistry.get(registry)
+  if (!pending || pending.size === 0) return
+
+  // Find every MV that writes to this output collection AND is
+  // currently flagged stale. Multiple MVs CAN share an output
+  // collection in theory; in practice the registration validation +
+  // cycle detection make this unusual.
+  const candidates: string[] = []
+  for (const mv of registry.all()) {
+    if (mv.outputCollection !== outputCollection) continue
+    if (!pending.has(mv.spec.name)) continue
+    candidates.push(mv.spec.name)
+  }
+  if (candidates.length === 0) return
+
+  let executor: typeof MVExecutorType | null = null
+  for (const name of candidates) {
+    const reg = registry.byName(name)
+    if (!reg) {
+      pending.delete(name)
+      continue
+    }
+    if (executor === null) {
+      ({ MaterializedViewExecutor: executor } = (await import('./executor.js')) as {
+        MaterializedViewExecutor: typeof MVExecutorType
+      })
+    }
+    await executor.refresh(reg, {
+      getCollection: (n) => accessor.getCollection(n),
+      getActiveTxContext: () => accessor.getActiveTxContext(),
+      getQueryContext: () => accessor.getQueryContext(),
+    })
+    pending.delete(name)
+  }
+}
+
+/**
+ * Drop every stale flag for a registry. Used after a manual
+ * `vault.refreshView(name)` runs the executor explicitly — the
+ * post-refresh state matches the registered strategies, so
+ * lingering stale bits would force a redundant refresh on the next
+ * read.
+ *
+ * @internal
+ */
+export function clearMVStale(registry: MaterializedViewRegistry, mvName: string): void {
+  _staleByRegistry.get(registry)?.delete(mvName)
+}

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -1515,7 +1515,12 @@ export class Vault {
     // state matches the registered strategy.
     const { clearMVStale } = await import('./materialized-views/stale.js')
     clearMVStale(registry, name)
-    return { written: result.written, deleted: 0, failed: result.failed }
+    // Forward the executor's real counts including `deleted`.
+    // Tombstoning ships in #152 (sibling sub-issue); this PR's #151
+    // refresh path nonetheless honors whatever the executor returns
+    // so the API contract doesn't lie about the deleted count once
+    // #152 merges.
+    return result
   }
 
   /**

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -1481,9 +1481,41 @@ export class Vault {
    * @internal — consumed by `Collection.put` at write-time. Returns
    * `null` for vaults that never registered any MV strategy.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   _getMaterializedViewRegistry(): MaterializedViewRegistry | null {
     return this.materializedViewRegistry
+  }
+
+  /**
+   * Manual re-materialize for a single registered MV (#151). Useful
+   * for `refresh: 'manual'` MVs (whose consumer drives refreshes
+   * externally), for stale-bit recovery on vault re-open, and as the
+   * explicit bulk-recompute escape hatch after a strategy change.
+   *
+   * Returns `{ written, deleted, failed }`. `deleted` is always 0 in
+   * foundation + this sub-issue — tombstoning lands in #152.
+   *
+   * Throws if `name` is not a registered MV.
+   */
+  async refreshView(name: string): Promise<{ written: number; deleted: number; failed: number }> {
+    const registry = this.materializedViewRegistry
+    if (registry === null) {
+      return { written: 0, deleted: 0, failed: 0 }
+    }
+    const reg = registry.byName(name)
+    if (!reg) {
+      throw new Error(`refreshView: no MV registered with name "${name}"`)
+    }
+    const { MaterializedViewExecutor } = await import('./materialized-views/executor.js')
+    const result = await MaterializedViewExecutor.refresh(reg, {
+      getCollection: (n) => this.collection(n),
+      getActiveTxContext: () => this.noydb._activeTxContextOrNull,
+      getQueryContext: () => this as unknown as MVQueryContext,
+    })
+    // Manual refresh clears any pending stale bit — the post-refresh
+    // state matches the registered strategy.
+    const { clearMVStale } = await import('./materialized-views/stale.js')
+    clearMVStale(registry, name)
+    return { written: result.written, deleted: 0, failed: result.failed }
   }
 
   /**


### PR DESCRIPTION
## Summary

Stacks on PR #156 (\`feat/mv-foundation-150\`). Closes #151 — sub-task 2 of the #143 implementation epic. Spec sequencing steps 7–8.

## What's new

- **Lazy lifecycle**: \`refresh: 'lazy'\` MVs mark stale on source-write (in-memory \`WeakMap<Registry, Set<mvName>>\`) and materialize on the next read of the output collection. Mirrors v1 \`derivations/stale.ts\` machinery.
- **\`vault.refreshView(name)\`**: manual recompute returning \`{ written, deleted, failed }\`. \`deleted\` is always 0 until tombstoning lands in #152.
- **Manual lifecycle**: \`refresh: 'manual'\` MVs do not register stale flags on source-writes and do not materialize on read. \`vault.refreshView\` is the only path.

## Bundle baseline updated

Floor went 39,522 → 41,541 gz (+5.1%) — same shape as the original v1 derivation landing. Updated \`bundle-manifest.json\`; future regressions still caught by the 5% gate. Executor + stale helpers both dynamic-imported on first dispatch (MV-free consumers don't pay for them).

## Stacked PR base

This PR targets \`feat/mv-foundation-150\` rather than \`main\` so the diff is the \`#151\`-only delta. Once #156 (foundation) merges, GitHub will rebase this PR onto main automatically.

## Test plan

- [x] \`pnpm --filter @noy-db/hub typecheck\`
- [x] \`pnpm --filter @noy-db/hub lint\` — 0 errors (7 unused-disable warnings)
- [x] \`pnpm --filter @noy-db/hub test\` — 1534 / 1534 (was 1529 + 5 new)
- [x] \`pnpm --filter @noy-db/hub bundle-check\` — passes against new baseline

Closes #151.