### PR TITLE
feat(hub): MV correctness — partition, onEmpty, ceiling, strict, aggregate (#152)

### DIFF
--- a/packages/hub/__tests__/materialized-views/correctness.test.ts
+++ b/packages/hub/__tests__/materialized-views/correctness.test.ts
@@ -1,0 +1,389 @@
+import { describe, it, expect } from 'vitest'
+import {
+  createNoydb,
+  withMaterializedView,
+  MaterializedViewCycleError,
+  MaterializedViewTooLargeError,
+  withGuard,
+  RecordLockedError,
+} from '../../src/index.js'
+import { withAggregate } from '../../src/aggregate/index.js'
+import { sum, count } from '../../src/aggregate/reducers.js'
+import { withTransactions } from '../../src/tx/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface Item extends Record<string, unknown> { id: string; tag?: string; n?: number }
+interface Disbursement extends Record<string, unknown> {
+  id: string
+  type: 'vatSales' | 'vatPurchase' | 'vatCredit' | 'pp30'
+  period: string
+  amount: number
+}
+interface Compensation extends Record<string, unknown> {
+  id: string
+  clientId: string
+  period: string
+  taxAmount: number
+}
+
+describe('MV correctness (#152)', () => {
+  describe('cost ceiling', () => {
+    it('throws MaterializedViewTooLargeError when row count exceeds maxRows', async () => {
+      const mv = withMaterializedView<Item>({
+        name: 'capped',
+        query: (db) => db.collection<Item>('items').query(),
+        rowKey: (r) => r.id,
+        refresh: 'eager',
+        maxRows: 3, // tight ceiling
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'mv-correctness-ceiling-passphrase-2026',
+        materializedViewStrategies: [mv],
+      })
+      const vault = await db.openVault('demo')
+      await vault.collection<Item>('items').put('a', { id: 'a' })
+      await vault.collection<Item>('items').put('b', { id: 'b' })
+      await vault.collection<Item>('items').put('c', { id: 'c' })
+      // Up to 3 rows OK.
+      expect(await vault.collection<Item>('capped').get('c')).not.toBeNull()
+      // 4th row → MV would emit 4 rows on next refresh → throws.
+      await expect(vault.collection<Item>('items').put('d', { id: 'd' }))
+        .rejects.toBeInstanceOf(MaterializedViewTooLargeError)
+    })
+
+    it('default ceiling is 100k (sanity — large default is fine)', async () => {
+      // Just registration-time sanity: maxRows undefined → no throw.
+      const mv = withMaterializedView<Item>({
+        name: 'default-cap',
+        query: (db) => db.collection<Item>('items').query(),
+        rowKey: (r) => r.id,
+        refresh: 'eager',
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'mv-correctness-default-cap-passphrase-2026',
+        materializedViewStrategies: [mv],
+      })
+      const vault = await db.openVault('demo')
+      await vault.collection<Item>('items').put('a', { id: 'a' })
+      expect(await vault.collection<Item>('default-cap').get('a')).not.toBeNull()
+    })
+  })
+
+  describe('onEmpty tombstoning', () => {
+    it('default onEmpty: "delete" — disappeared rows are tombstoned via _internalDelete', async () => {
+      const mv = withMaterializedView<Item>({
+        name: 'red-items',
+        query: (db) => db.collection<Item>('items').query().where('tag', '==', 'red'),
+        rowKey: (r) => r.id,
+        refresh: 'eager',
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'mv-correctness-tombstone-passphrase-2026',
+        materializedViewStrategies: [mv],
+      })
+      const vault = await db.openVault('demo')
+      await vault.collection<Item>('items').put('a', { id: 'a', tag: 'red' })
+      await vault.collection<Item>('items').put('b', { id: 'b', tag: 'red' })
+      expect(await vault.collection<Item>('red-items').get('a')).not.toBeNull()
+      expect(await vault.collection<Item>('red-items').get('b')).not.toBeNull()
+
+      // Flip 'a' to blue. Refresh re-runs the query (only 'b' is red);
+      // 'a' is tombstoned.
+      await vault.collection<Item>('items').put('a', { id: 'a', tag: 'blue' })
+      expect(await vault.collection<Item>('red-items').get('a')).toBeNull()
+      expect(await vault.collection<Item>('red-items').get('b')).not.toBeNull()
+    })
+
+    it('tombstone bypasses user onDelete on the output collection', async () => {
+      // The composition fix from PR #148 (#144 + #145 interaction)
+      // ensures refresh-driven tombstones use Collection._internalDelete,
+      // which skips user onDelete guards.
+      let onDeleteFired = 0
+      const guard = withGuard<Item>({
+        collection: 'red-items',
+        onDelete: () => {
+          onDeleteFired++
+          throw new RecordLockedError('red-items', '', 'no deletes!')
+        },
+      })
+      const mv = withMaterializedView<Item>({
+        name: 'red-items',
+        query: (db) => db.collection<Item>('items').query().where('tag', '==', 'red'),
+        rowKey: (r) => r.id,
+        refresh: 'eager',
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'mv-correctness-bypass-passphrase-2026',
+        guardStrategies: [guard],
+        materializedViewStrategies: [mv],
+      })
+      const vault = await db.openVault('demo')
+      await vault.collection<Item>('items').put('a', { id: 'a', tag: 'red' })
+      expect(await vault.collection<Item>('red-items').get('a')).not.toBeNull()
+
+      // Flip 'a' to blue → tombstone fires → onDelete should NOT fire
+      // (system-internal delete bypass).
+      await expect(vault.collection<Item>('items').put('a', { id: 'a', tag: 'blue' }))
+        .resolves.not.toThrow()
+      expect(onDeleteFired).toBe(0)
+      expect(await vault.collection<Item>('red-items').get('a')).toBeNull()
+
+      // User-initiated delete on the same collection DOES still fire
+      // onDelete — bypass is scoped to housekeeping.
+      await vault.collection<Item>('items').put('b', { id: 'b', tag: 'red' })
+      await expect(vault.collection<Item>('red-items').delete('b'))
+        .rejects.toBeInstanceOf(RecordLockedError)
+      expect(onDeleteFired).toBe(1)
+    })
+
+    it('onEmpty: "keep" — disappeared rows linger', async () => {
+      const mv = withMaterializedView<Item>({
+        name: 'red-items',
+        query: (db) => db.collection<Item>('items').query().where('tag', '==', 'red'),
+        rowKey: (r) => r.id,
+        refresh: 'eager',
+        onEmpty: 'keep',
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'mv-correctness-keep-passphrase-2026',
+        materializedViewStrategies: [mv],
+      })
+      const vault = await db.openVault('demo')
+      await vault.collection<Item>('items').put('a', { id: 'a', tag: 'red' })
+      expect(await vault.collection<Item>('red-items').get('a')).not.toBeNull()
+      await vault.collection<Item>('items').put('a', { id: 'a', tag: 'blue' })
+      // With onEmpty: 'keep', 'a' lingers despite no longer matching the query.
+      expect(await vault.collection<Item>('red-items').get('a')).not.toBeNull()
+    })
+  })
+
+  describe('same-collection partition (DERIV-PP30-001 shape)', () => {
+    it('accepts MV with output.partition + provably disjoint where-clause', async () => {
+      const mv = withMaterializedView<Disbursement>({
+        name: 'pp30-aggregate',
+        query: (db) => db.collection<Disbursement>('disbursements')
+          .query()
+          .where('type', 'in', ['vatSales', 'vatPurchase', 'vatCredit']),
+        rowKey: (r) => `pp30|${r.period}|${r.id}`,
+        refresh: 'eager',
+        output: { collection: 'disbursements', partition: { field: 'type', value: 'pp30' } },
+      })
+      // Registration succeeds — the input filter excludes the partition value.
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'mv-correctness-partition-ok-passphrase-2026',
+        materializedViewStrategies: [mv],
+      })
+      const vault = await db.openVault('demo')
+      await vault.collection<Disbursement>('disbursements').put('d1', {
+        id: 'd1', type: 'vatSales', period: '2026-05', amount: 1000,
+      })
+      // MV materializes — id format is the explicit rowKey output.
+      expect(await vault.collection<Disbursement>('disbursements').get('pp30|2026-05|d1')).not.toBeNull()
+    })
+
+    it('rejects same-collection MV WITHOUT a disjoint partition filter', async () => {
+      // Self-feedback without partition → cycle (covered by foundation),
+      // and WITH partition but no disjoint clause → also cycle.
+      const mv = withMaterializedView<Disbursement>({
+        name: 'pp30-bad',
+        query: (db) => db.collection<Disbursement>('disbursements').query(), // no where!
+        rowKey: (r) => r.id,
+        refresh: 'eager',
+        output: { collection: 'disbursements', partition: { field: 'type', value: 'pp30' } },
+      })
+      await expect(
+        (async () => {
+          const db = await createNoydb({
+            store: memory(),
+            user: 'alice',
+            secret: 'mv-correctness-partition-bad-passphrase-2026',
+            materializedViewStrategies: [mv],
+          })
+          await db.openVault('demo')
+        })(),
+      ).rejects.toBeInstanceOf(MaterializedViewCycleError)
+    })
+
+    it('accepts .where(field, "==", X) where X !== partition.value', async () => {
+      const mv = withMaterializedView<Disbursement>({
+        name: 'vatSales-mv',
+        query: (db) => db.collection<Disbursement>('disbursements').query().where('type', '==', 'vatSales'),
+        rowKey: (r) => `agg|${r.id}`,
+        refresh: 'eager',
+        output: { collection: 'disbursements', partition: { field: 'type', value: 'pp30' } },
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'mv-correctness-eq-partition-passphrase-2026',
+        materializedViewStrategies: [mv],
+      })
+      // Registration should not throw.
+      await db.openVault('demo')
+    })
+
+    it('accepts .where(field, "!=", partition.value)', async () => {
+      const mv = withMaterializedView<Disbursement>({
+        name: 'not-pp30',
+        query: (db) => db.collection<Disbursement>('disbursements').query().where('type', '!=', 'pp30'),
+        rowKey: (r) => `agg|${r.id}`,
+        refresh: 'eager',
+        output: { collection: 'disbursements', partition: { field: 'type', value: 'pp30' } },
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'mv-correctness-ne-partition-passphrase-2026',
+        materializedViewStrategies: [mv],
+      })
+      await db.openVault('demo')
+    })
+  })
+
+  describe('strict-mode rollback', () => {
+    it('strict: true rolls back the source-write when an MV refresh fails', async () => {
+      // We trigger failure via the cost ceiling — a small maxRows fires
+      // MaterializedViewTooLargeError mid-refresh; with strict + tx,
+      // the source-write rolls back too.
+      const mv = withMaterializedView<Item>({
+        name: 'tiny',
+        query: (db) => db.collection<Item>('items').query(),
+        rowKey: (r) => r.id,
+        refresh: 'eager',
+        maxRows: 2,
+        strict: true,
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'mv-correctness-strict-passphrase-2026',
+        materializedViewStrategies: [mv],
+        txStrategy: withTransactions(),
+      })
+      const vault = await db.openVault('demo')
+      await vault.collection<Item>('items').put('a', { id: 'a' })
+      await vault.collection<Item>('items').put('b', { id: 'b' })
+
+      // The third put fires the MV refresh, which exceeds maxRows.
+      // The error propagates and the source-write rolls back via the
+      // TxContext registration the executor performs.
+      await expect(
+        db.transaction(async (tx) => {
+          await tx.vault('demo').collection<Item>('items').put('c', { id: 'c' })
+        }),
+      ).rejects.toBeInstanceOf(MaterializedViewTooLargeError)
+
+      // Source 'c' should NOT be present — rolled back.
+      expect(await vault.collection<Item>('items').get('c')).toBeNull()
+    })
+  })
+
+  describe('aggregate query shape', () => {
+    it('materializes a groupBy + aggregate query into rows', async () => {
+      interface ClientTotalRow extends Record<string, unknown> {
+        clientId: string
+        taxTotal: number
+      }
+      const mv = withMaterializedView<ClientTotalRow>({
+        name: 'client-totals',
+        sources: ['compensations'],
+        query: (db) => db.collection<Compensation>('compensations')
+          .query()
+          .groupBy('clientId')
+          .aggregate({ taxTotal: sum<Compensation>('taxAmount') }),
+        rowKey: (r) => r.clientId,
+        refresh: 'eager',
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'mv-correctness-aggregate-passphrase-2026',
+        aggregateStrategy: withAggregate(),
+        materializedViewStrategies: [mv],
+      })
+      const vault = await db.openVault('demo')
+      await vault.collection<Compensation>('compensations').put('c1', {
+        id: 'c1', clientId: 'acme', period: '2026-05', taxAmount: 100,
+      })
+      await vault.collection<Compensation>('compensations').put('c2', {
+        id: 'c2', clientId: 'acme', period: '2026-05', taxAmount: 50,
+      })
+      await vault.collection<Compensation>('compensations').put('c3', {
+        id: 'c3', clientId: 'beta', period: '2026-05', taxAmount: 75,
+      })
+      expect((await vault.collection<ClientTotalRow>('client-totals').get('acme'))?.taxTotal).toBe(150)
+      expect((await vault.collection<ClientTotalRow>('client-totals').get('beta'))?.taxTotal).toBe(75)
+    })
+
+    it('non-grouped aggregate emits one row', async () => {
+      interface TotalRow extends Record<string, unknown> { totalAmount: number; n: number }
+      const mv = withMaterializedView<TotalRow>({
+        name: 'totals',
+        sources: ['items'],
+        query: (db) => db.collection<Item>('items')
+          .query()
+          .aggregate({ totalAmount: sum<Item>('n'), n: count<Item>() }),
+        rowKey: () => 'grand-total',
+        refresh: 'eager',
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'mv-correctness-single-agg-passphrase-2026',
+        aggregateStrategy: withAggregate(),
+        materializedViewStrategies: [mv],
+      })
+      const vault = await db.openVault('demo')
+      await vault.collection<Item>('items').put('a', { id: 'a', n: 10 })
+      await vault.collection<Item>('items').put('b', { id: 'b', n: 25 })
+      const row = await vault.collection<TotalRow>('totals').get('grand-total')
+      expect(row?.totalAmount).toBe(35)
+      expect(row?.n).toBe(2)
+    })
+  })
+})

--- a/packages/hub/__tests__/materialized-views/correctness.test.ts
+++ b/packages/hub/__tests__/materialized-views/correctness.test.ts
@@ -198,6 +198,36 @@ describe('MV correctness (#152)', () => {
       // With onEmpty: 'keep', 'a' lingers despite no longer matching the query.
       expect(await vault.collection<Item>('red-items').get('a')).not.toBeNull()
     })
+
+    it('refreshView returns the real deleted count (niwat-review of #157, verified in #158)', async () => {
+      // PR #157 added the deleted field to RefreshResult shape. This
+      // PR (#158) makes it carry the real tombstone count from the
+      // executor's diff-against-prior pass.
+      const mv = withMaterializedView<Item>({
+        name: 'red-items',
+        query: (db) => db.collection<Item>('items').query().where('tag', '==', 'red'),
+        rowKey: (r) => r.id,
+        refresh: 'manual',
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'mv-correctness-refresh-deleted-passphrase-2026',
+        materializedViewStrategies: [mv],
+      })
+      const vault = await db.openVault('demo')
+      await vault.collection<Item>('items').put('a', { id: 'a', tag: 'red' })
+      await vault.collection<Item>('items').put('b', { id: 'b', tag: 'red' })
+      const first = await vault.refreshView('red-items')
+      expect(first.written).toBe(2)
+      expect(first.deleted).toBe(0)
+
+      // Flip 'a' to blue → next refresh writes 1 (b) + tombstones 1 (a).
+      await vault.collection<Item>('items').put('a', { id: 'a', tag: 'blue' })
+      const second = await vault.refreshView('red-items')
+      expect(second.written).toBe(1) // 'b' re-emitted
+      expect(second.deleted).toBe(1) // 'a' tombstoned
+    })
   })
 
   describe('same-collection partition (DERIV-PP30-001 shape)', () => {

--- a/packages/hub/__tests__/materialized-views/lazy-and-manual.test.ts
+++ b/packages/hub/__tests__/materialized-views/lazy-and-manual.test.ts
@@ -101,9 +101,10 @@ describe('MV lazy lifecycle + vault.refreshView (#151)', () => {
     expect(await vault.collection<Item>('red-items').get('b')).not.toBeNull()
     // Stale cleared again.
     expect(isMVStale(reg, 'red-items')).toBe(false)
-    // Note: 'a' will still appear in the MV until subtask #152
-    // implements tombstoning (onEmpty: 'delete' / row removal on
-    // disappearance). The MV doesn't tombstone in this iteration.
+    // With #152's onEmpty: 'delete' default, 'a' (now blue) is
+    // tombstoned by the refresh diff — the row disappeared from the
+    // query result, so it's removed from the MV.
+    expect(await vault.collection<Item>('red-items').get('a')).toBeNull()
   })
 
   it('manual MV: source writes do NOT materialize; only refreshView(name) does', async () => {

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -1477,3 +1477,29 @@ export class MaterializedViewSourceUnknownError extends NoydbError {
     this.collection = collection
   }
 }
+
+/**
+ * Thrown by the MV executor when a refresh produces more rows than
+ * the configured ceiling. Default ceiling is 100k rows; override
+ * per-MV via `maxRows`. Mirrors `JoinTooLargeError` /
+ * `GroupCardinalityError` from the query DSL — the explosion is
+ * detected BEFORE writes hit the store, so the source-write
+ * transaction can roll back cleanly via strict-mode.
+ */
+export class MaterializedViewTooLargeError extends NoydbError {
+  readonly mvName: string
+  readonly expected: number
+  readonly limit: number
+
+  constructor(mvName: string, expected: number, limit: number) {
+    super(
+      'MATERIALIZED_VIEW_TOO_LARGE',
+      `Materialized view "${mvName}" would emit ${expected} rows, exceeding the configured limit of ${limit}. ` +
+        `Override via { maxRows: N } on the MV strategy if intentional, or tighten the query's filter/groupBy.`,
+    )
+    this.name = 'MaterializedViewTooLargeError'
+    this.mvName = mvName
+    this.expected = expected
+    this.limit = limit
+  }
+}

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -514,6 +514,7 @@ export type {
 export {
   MaterializedViewCycleError,
   MaterializedViewSourceUnknownError,
+  MaterializedViewTooLargeError,
 } from './errors.js'
 
 // Accounting periods

--- a/packages/hub/src/materialized-views/executor.ts
+++ b/packages/hub/src/materialized-views/executor.ts
@@ -1,6 +1,7 @@
 import type { Collection } from '../collection.js'
 import type { TxContext } from '../tx/transaction.js'
 import type { EncryptedEnvelope } from '../types.js'
+import { MaterializedViewTooLargeError } from '../errors.js'
 import type { MaterializedFromMeta, MVQueryContext } from './types.js'
 import type { RegisteredMV } from './registry.js'
 
@@ -26,15 +27,49 @@ export interface MVExecutorAccessor {
 export interface RefreshResult {
   /** Rows newly written / overwritten. */
   written: number
-  /**
-   * Rows tombstoned via `_internalDelete`. Always 0 in this iteration
-   * (foundation + lazy/manual sub-issues #150/#151); populated by
-   * #152's `onEmpty: 'delete'` tombstoning pass. Forward-compat shape
-   * so `vault.refreshView()` callers get a stable contract.
-   */
+  /** Rows tombstoned via `_internalDelete` (only when `onEmpty: 'delete'`). */
   deleted: number
   /** Failed row writes (non-strict mode). */
   failed: number
+}
+
+/** Default cost ceiling — overridable per-MV via `spec.maxRows`. */
+const DEFAULT_MAX_ROWS = 100_000
+
+/**
+ * Materialize a query terminal that may be a `Query<T>` (call
+ * `.toArray()`), an `Aggregation<R>` (call `.run()` returning a
+ * single object — wrap as a one-row array), or a `GroupedAggregation<R>`
+ * (call `.run()` returning an array of grouped rows). Branches on
+ * available terminal at runtime — no type-discrimination at registration.
+ */
+async function materializeQueryResult(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  q: any,
+  mvName: string,
+): Promise<ReadonlyArray<Record<string, unknown>>> {
+  if (typeof q?.toArray === 'function') {
+    // Query<T> — non-aggregate path. `.toArray()` returns Promise<T[]>.
+    return await q.toArray()
+  }
+  if (typeof q?.run === 'function') {
+    // Aggregation<R> or GroupedAggregation<R>. `.run()` is synchronous
+    // and returns either a single object (Aggregation) or an array of
+    // rows (GroupedAggregation). Promise.resolve() normalizes both
+    // sync and async (future) variants.
+    const result: unknown = await Promise.resolve(q.run())
+    if (Array.isArray(result)) {
+      return result as ReadonlyArray<Record<string, unknown>>
+    }
+    // Single-aggregate result — wrap as one-row array. The consumer's
+    // `rowKey()` should return a stable identity (often a literal
+    // constant like `'total'`) since there's only one row.
+    return [result as Record<string, unknown>]
+  }
+  throw new Error(
+    `MV "${mvName}": query() must return a Query<T>, Aggregation, or GroupedAggregation. ` +
+      `Got something without a .toArray() or .run() terminal.`,
+  )
 }
 
 /**
@@ -45,91 +80,151 @@ export interface RefreshResult {
  * invariant — `Collection.put` looks up the DEK by collection name,
  * and the output collection IS the MV's owned collection).
  *
- * Stamps `_materializedFrom` onto every emitted row. Tombstones
- * (rows that disappear between refreshes) are NOT handled by this
- * function — that's `onEmpty: 'delete'` (subtask #152).
+ * Stamps `_materializedFrom` onto every emitted row.
+ *
+ * **Tombstoning** (#152): when `spec.onEmpty: 'delete'` (default), rows
+ * that existed in a prior refresh but no longer appear in the new
+ * materialized result are deleted via `Collection._internalDelete` —
+ * the housekeeping bypass primitive added in PR #148 prevents user
+ * `onDelete` guards on the output collection from firing on these
+ * system-internal deletes. `onEmpty: 'keep'` opts out (rows from
+ * prior refreshes linger even when the new result lacks them).
+ *
+ * **Cost ceiling** (#152): if the materialized row count exceeds
+ * `spec.maxRows` (default 100k), throws `MaterializedViewTooLargeError`
+ * before any writes hit the store — so strict-mode rollback is
+ * clean.
+ *
+ * **Strict mode** (#152): `spec.strict === true` re-throws on any
+ * row-write failure; the active TxContext registration means the
+ * source-write rolls back atomically via `revertExecuted` (#133).
  *
  * @internal
  */
 export const MaterializedViewExecutor = {
-  /**
-   * Full re-materialize. Invokes `spec.query()`, executes against
-   * the live collection state, writes each result row through
-   * `Collection.put` (id = `spec.rowKey(row)`).
-   *
-   * Returns counts; throws only on contract-level failures (rowKey
-   * collisions surface as ordinary `Collection.put` errors).
-   */
   async refresh(
     reg: RegisteredMV,
     accessor: MVExecutorAccessor,
   ): Promise<RefreshResult> {
     const spec = reg.spec
     const outputColl = accessor.getCollection(reg.outputCollection)
+    const maxRows = spec.maxRows ?? DEFAULT_MAX_ROWS
+    const onEmpty = spec.onEmpty ?? 'delete'
+    const strict = spec.strict ?? false
 
-    // Materialize the query. The Query<T> returned by spec.query() is
-    // a fresh instance — we invoke `.toArray()` to materialize the
-    // result rows. Foundation sub-issue (#150) handles non-aggregate
-    // queries only — aggregate / groupBy-shaped MVs are deferred to
-    // subtask #152 (the cost-ceiling + correctness sub-issue, where
-    // `MaterializedViewTooLargeError` for groupBy explosions also
-    // lands).
+    // 1. Materialize the query (branches on terminal shape).
     const q = spec.query(accessor.getQueryContext())
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const rows: ReadonlyArray<Record<string, unknown>> = await (q as any).toArray()
+    const rows = await materializeQueryResult(q, spec.name)
+
+    // 2. Cost ceiling check BEFORE any writes — keeps the rollback
+    //    clean if the source-write is wrapped in a transaction.
+    if (rows.length > maxRows) {
+      throw new MaterializedViewTooLargeError(spec.name, rows.length, maxRows)
+    }
 
     const txCtx = accessor.getActiveTxContext()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const adapter = (outputColl as any).adapter as {
+      get(v: string, c: string, i: string): Promise<EncryptedEnvelope | null>
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const vaultName = (outputColl as any).vault as string
 
+    // 3. Compute the post-refresh id set so we can diff against the
+    //    prior-emitted id set for tombstoning (when onEmpty === 'delete').
+    const newIds = new Set<string>()
+    const enrichedRows: Array<{ id: string; record: Record<string, unknown> }> = []
+    for (const row of rows) {
+      const id = spec.rowKey(row)
+      newIds.add(id)
+      const meta: MaterializedFromMeta = {
+        mvName: spec.name,
+        queryHash: reg.queryHash,
+        sourceVersions: {},
+        materializedAt: new Date().toISOString(),
+      }
+      enrichedRows.push({ id, record: { ...row, _materializedFrom: meta } })
+    }
+
+    // 4. Write the new rows.
     let written = 0
     let failed = 0
-    for (const row of rows) {
+    for (const { id, record } of enrichedRows) {
       try {
-        const id = spec.rowKey(row)
-        const meta: MaterializedFromMeta = {
-          mvName: spec.name,
-          queryHash: reg.queryHash,
-          // Foundation: sourceVersions empty — populated by step 7+ when
-          // we read the source records' versions during materialization.
-          sourceVersions: {},
-          materializedAt: new Date().toISOString(),
-        }
-        const enriched: Record<string, unknown> = {
-          ...row,
-          _materializedFrom: meta,
-        }
-
-        // Register the prior envelope on the active TxContext before
-        // the write, so a mid-refresh failure rolls back via
-        // `revertExecuted` (#133-style).
         if (txCtx !== null) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const adapter = (outputColl as any).adapter as {
-            get(v: string, c: string, i: string): Promise<EncryptedEnvelope | null>
-          }
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const vaultName = (outputColl as any).vault as string
           const prior = await adapter.get(vaultName, reg.outputCollection, id)
           txCtx._executed.push({
-            op: {
-              type: 'put',
-              vaultName,
-              collectionName: reg.outputCollection,
-              id,
-            },
+            op: { type: 'put', vaultName, collectionName: reg.outputCollection, id },
             priorEnvelope: prior,
           })
         }
-
-        await outputColl.put(id, enriched)
+        await outputColl.put(id, record)
         written++
       } catch (err) {
         failed++
-        // Foundation: non-strict by default. Subtask #152 wires
-        // strict-mode rollback through `withTransactions`.
+        if (strict) throw err
         // eslint-disable-next-line no-console
         console.warn(`[mv] "${spec.name}" row write failed:`, err)
       }
     }
-    return { written, deleted: 0, failed }
+
+    // 5. Tombstone rows that existed before but don't appear now.
+    //    `onEmpty: 'keep'` skips this pass entirely. Uses
+    //    `_internalDelete` so a user-registered `onDelete` on the
+    //    output collection does NOT fire on housekeeping (the #145
+    //    composition fix).
+    let deleted = 0
+    if (onEmpty === 'delete') {
+      const priorIds = await listOutputIds(outputColl)
+      for (const priorId of priorIds) {
+        if (newIds.has(priorId)) continue
+        try {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const outAny = outputColl as any
+          if (typeof outAny._internalDelete === 'function') {
+            await outAny._internalDelete(priorId, txCtx)
+            deleted++
+          } else {
+            // Defensive fallback — should never hit in real flow since
+            // every Collection has `_internalDelete`.
+            await outputColl.delete(priorId)
+            deleted++
+          }
+        } catch (err) {
+          failed++
+          if (strict) throw err
+          // eslint-disable-next-line no-console
+          console.warn(`[mv] "${spec.name}" tombstone failed for id="${priorId}":`, err)
+        }
+      }
+    }
+
+    return { written, deleted, failed }
   },
+}
+
+/**
+ * List ids currently present in the MV's output collection via the
+ * adapter directly (avoids triggering the lazy resolve-on-read path
+ * we're INSIDE). Returns an empty array if the collection doesn't
+ * exist or the adapter doesn't surface a list method.
+ *
+ * @internal
+ */
+async function listOutputIds(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  outputColl: Collection<any>,
+): Promise<string[]> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const cAny = outputColl as any
+  const adapter = cAny.adapter as { list?: (v: string, c: string) => Promise<readonly string[]> }
+  const vault = cAny.vault as string
+  const name = cAny.name as string
+  if (typeof adapter?.list !== 'function') return []
+  try {
+    const ids = await adapter.list(vault, name)
+    return [...ids]
+  } catch {
+    return []
+  }
 }

--- a/packages/hub/src/materialized-views/index.ts
+++ b/packages/hub/src/materialized-views/index.ts
@@ -19,4 +19,5 @@ export type { MVExecutorAccessor, RefreshResult } from './executor.js'
 export {
   MaterializedViewCycleError,
   MaterializedViewSourceUnknownError,
+  MaterializedViewTooLargeError,
 } from '../errors.js'

--- a/packages/hub/src/materialized-views/registry.ts
+++ b/packages/hub/src/materialized-views/registry.ts
@@ -1,5 +1,6 @@
 import { MaterializedViewCycleError, MaterializedViewSourceUnknownError } from '../errors.js'
 import type { DerivationRegistry } from '../derivations/registry.js'
+import type { Clause, FieldClause } from '../query/predicate.js'
 import { analyzeDependencies, summarizeQueryPlan } from './dependency-analyzer.js'
 import { computeQueryHash } from './query-hash.js'
 import type { MaterializedViewStrategy, MVQueryContext } from './types.js'
@@ -17,6 +18,13 @@ export interface RegisteredMV {
   readonly dependencies: ReadonlySet<string>
   /** Canonical `queryHash` — `_materializedFrom.queryHash` for every emitted row. */
   readonly queryHash: string
+  /**
+   * Top-level FieldClauses on the partition field, captured at
+   * registration time. Used by the cycle detector to resolve
+   * same-collection-as-source edges via the partition-discriminator
+   * check (#152). Empty when `spec.output?.partition` is undefined.
+   */
+  readonly partitionClauses: readonly FieldClause[]
 }
 
 /**
@@ -49,10 +57,39 @@ export class MaterializedViewRegistry {
     db: MVQueryContext,
     options?: { knownCollections?: (name: string) => boolean },
   ): Promise<void> {
-    // Invoke the query callback once to inspect its plan.
+    // Invoke the query callback once to inspect its plan / dependencies.
+    // For Query<T> shapes the analyzer extracts deps + plan summary
+    // automatically. Aggregation / GroupedAggregation shapes don't
+    // expose the underlying Query, so the spec must declare `sources`
+    // explicitly. `partitionClauses` are only populated for Query<T>
+    // since same-collection-partition is a non-aggregate concern.
     const q = spec.query(db)
-    const dependencies = analyzeDependencies(q)
-    const queryPlanSummary = summarizeQueryPlan(q)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const qAny = q as any
+    const isQuery = typeof qAny._plan === 'function'
+    let dependencies: Set<string>
+    let queryPlanSummary: string
+    if (isQuery) {
+      dependencies = analyzeDependencies(q)
+      queryPlanSummary = summarizeQueryPlan(q)
+      // If `sources` is ALSO declared, take the union (consumer's
+      // explicit list extends the auto-analyzed set).
+      if (spec.sources) for (const s of spec.sources) dependencies.add(s)
+    } else {
+      // Aggregate shape: require explicit `sources`.
+      if (!spec.sources || spec.sources.length === 0) {
+        throw new Error(
+          `withMaterializedView "${spec.name}": query() returned an aggregate ` +
+            `(Aggregation or GroupedAggregation) but no \`sources\` field is declared. ` +
+            `The dependency analyzer cannot walk through groupBy().aggregate() ` +
+            `back to the source — declare sources: [...] explicitly.`,
+        )
+      }
+      dependencies = new Set(spec.sources)
+      // Aggregate plans don't carry a chainable query plan for summary
+      // purposes; the dep-set + spec.name serve as the queryHash inputs.
+      queryPlanSummary = JSON.stringify({ aggregate: true, sources: [...spec.sources].sort() })
+    }
 
     // Sanity-check declared dependencies against the vault's known
     // collections. Optional — when the checker isn't supplied (test
@@ -68,7 +105,20 @@ export class MaterializedViewRegistry {
 
     const outputCollection = spec.output?.collection ?? spec.name
     const queryHash = await computeQueryHash(spec.name, dependencies, queryPlanSummary)
-    const reg: RegisteredMV = { spec, outputCollection, dependencies, queryHash }
+    // For same-collection-as-source MVs, capture the where-clauses on
+    // the partition field so cycle detection can prove disjointness.
+    // Only applicable to Query<T> shapes — aggregate MVs don't carry
+    // a chainable plan to inspect (and same-collection aggregation
+    // doesn't make sense in the niwat use cases that motivated #152).
+    const partitionClauses: FieldClause[] = []
+    const partitionField = spec.output?.partition?.field
+    if (partitionField !== undefined && isQuery) {
+      const plan = qAny._plan()
+      for (const clause of plan.clauses) {
+        if (isFieldClauseOnField(clause, partitionField)) partitionClauses.push(clause)
+      }
+    }
+    const reg: RegisteredMV = { spec, outputCollection, dependencies, queryHash, partitionClauses }
 
     this._byName.set(spec.name, reg)
     for (const dep of dependencies) {
@@ -113,9 +163,15 @@ export class MaterializedViewRegistry {
 
     const edges = new Map<string, string[]>()
 
-    // MV edges: every dep → output
+    // MV edges: every dep → output. Same-collection edges (dep ===
+    // outputCollection) are skipped IFF the MV declares an
+    // `output.partition` discriminator AND the query has a where-clause
+    // that provably excludes the partition value. Otherwise the cycle
+    // detector treats the edge as real — naïve same-collection MVs
+    // surface as `MaterializedViewCycleError`.
     for (const reg of this._byName.values()) {
       for (const dep of reg.dependencies) {
+        if (dep === reg.outputCollection && partitionDisjoint(reg)) continue
         const arr = edges.get(dep)
         if (arr) arr.push(reg.outputCollection)
         else edges.set(dep, [reg.outputCollection])
@@ -178,4 +234,53 @@ export class MaterializedViewRegistry {
 
     for (const node of edges.keys()) visit(node)
   }
+}
+
+/**
+ * Type guard: is the clause a top-level `FieldClause` on the given
+ * field? Used by the partition-disjoint check.
+ *
+ * @internal
+ */
+function isFieldClauseOnField(clause: Clause, field: string): clause is FieldClause {
+  return clause.type === 'field' && clause.field === field
+}
+
+/**
+ * Provability check for the same-collection partition-discriminator
+ * (#152, spec § Same-collection-as-source MV). Returns `true` when
+ * the captured partition clauses on the MV's query provably exclude
+ * the partition's value — meaning the input filter and the output
+ * partition are disjoint and the same-collection edge isn't really a
+ * cycle.
+ *
+ * Supported provability shapes (narrow on purpose — niwat's DERIV-
+ * PP30-001 is the load-bearing case):
+ *
+ * - `.where(field, '==', X)` where X !== partition.value → disjoint
+ * - `.where(field, '!=', partition.value)` → disjoint
+ * - `.where(field, 'in', [...])` where partition.value NOT in list → disjoint
+ *
+ * Anything else (no clause on the partition field, an 'in' list that
+ * contains partition.value, unsupported operators) → not disjoint,
+ * the cycle detector surfaces `MaterializedViewCycleError`.
+ *
+ * @internal
+ */
+function partitionDisjoint(reg: RegisteredMV): boolean {
+  const partition = reg.spec.output?.partition
+  if (partition === undefined) return false
+  const value = partition.value
+  // The OR-semantics of multiple where-clauses on the same field
+  // would muddy this check. v2 only treats AND-chained clauses;
+  // any clause that proves disjoint is sufficient.
+  for (const c of reg.partitionClauses) {
+    if (c.op === '==' && c.value !== value) return true
+    if (c.op === '!=' && c.value === value) return true
+    if (c.op === 'in' && Array.isArray(c.value)) {
+      const list = c.value as readonly unknown[]
+      if (!list.includes(value)) return true
+    }
+  }
+  return false
 }

--- a/packages/hub/src/materialized-views/types.ts
+++ b/packages/hub/src/materialized-views/types.ts
@@ -46,8 +46,12 @@ export interface MaterializedViewOutput {
   collection?: string
   /**
    * For same-collection-as-source MVs — see § Same-collection partition
-   * discriminator in the v2 spec. Deferred to subtask #152; declared
-   * here so the type is stable across PRs.
+   * discriminator in the v2 spec. The cycle detector resolves the
+   * same-collection edge IFF the query has a where-clause that
+   * provably excludes `partition.value` (supports `==` against a
+   * different value, `!=` against the value, and `in` lists that
+   * don't contain it). Naïve same-collection MVs without a disjoint
+   * clause throw `MaterializedViewCycleError` at vault open.
    */
   partition?: { field: string; value: unknown }
 }
@@ -91,23 +95,44 @@ export interface MaterializedViewStrategy<TRow extends Record<string, unknown>> 
    */
   sources?: ReadonlyArray<string>
   /**
-   * Refresh policy. Foundation sub-issue (#150) implements `'eager'`;
-   * `'lazy'` and `'manual'` are wired in sub-issues #151.
+   * Refresh policy.
+   *
+   * - `'eager'` — re-materialize synchronously inside the source-write
+   *   transaction (composes with `withTransactions` for strict-mode
+   *   rollback).
+   * - `'lazy'` — mark stale on source-change; materialize on first
+   *   read of the MV.
+   * - `'manual'` — only materializes when `vault.refreshView(name)` is
+   *   called. Useful for very expensive MVs or time-dependent queries
+   *   whose `ctx` changes externally.
    */
   refresh: 'eager' | 'lazy' | 'manual'
   /** Output routing. Optional; defaults to writing the collection named after `name`. */
   output?: MaterializedViewOutput
   /**
    * What to do when a re-materialization produces zero rows for a key
-   * that previously had rows. Deferred to subtask #152.
+   * that previously had rows.
+   *
+   * - `'delete'` (default) — tombstone the prior MV row via
+   *   `Collection._internalDelete` (system housekeeping bypasses user
+   *   `onDelete` guards on the output collection — see PR #148's
+   *   composition fix).
+   * - `'keep'` — leave the prior MV row in place. Useful when zero
+   *   is a meaningful state.
    */
   onEmpty?: 'delete' | 'keep'
   /**
-   * Strict-mode rollback inside `withTransactions`. Deferred to subtask #152.
+   * `true` re-throws on any row-write failure → composes with
+   * `withTransactions` to roll back the source-write atomically via
+   * `revertExecuted` (#133). Default `false` (failed rows are
+   * isolated; other rows commit).
    */
   strict?: boolean
   /**
-   * Row-count ceiling for the materialized output. Deferred to subtask #152.
+   * Row-count ceiling for the materialized output. Throws
+   * `MaterializedViewTooLargeError` before any writes when exceeded
+   * — keeps the rollback clean. Default `100_000`; override per-MV
+   * when the domain warrants it.
    */
   maxRows?: number
 }

--- a/packages/hub/src/materialized-views/types.ts
+++ b/packages/hub/src/materialized-views/types.ts
@@ -81,6 +81,16 @@ export interface MaterializedViewStrategy<TRow extends Record<string, unknown>> 
    */
   rowKey: (row: TRow) => string
   /**
+   * Explicit source collections (#152). Required when `query()` returns
+   * an `Aggregation` or `GroupedAggregation` rather than a `Query<T>`
+   * — the dependency analyzer can't introspect through `groupBy().aggregate()`
+   * back to the source. Optional for plain `Query<T>` results — the
+   * analyzer extracts dependencies automatically from the query plan.
+   *
+   * When set, takes precedence over auto-analysis.
+   */
+  sources?: ReadonlyArray<string>
+  /**
    * Refresh policy. Foundation sub-issue (#150) implements `'eager'`;
    * `'lazy'` and `'manual'` are wired in sub-issues #151.
    */

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -1515,11 +1515,6 @@ export class Vault {
     // state matches the registered strategy.
     const { clearMVStale } = await import('./materialized-views/stale.js')
     clearMVStale(registry, name)
-    // Forward the executor's real counts including `deleted`.
-    // Tombstoning ships in #152 (sibling sub-issue); this PR's #151
-    // refresh path nonetheless honors whatever the executor returns
-    // so the API contract doesn't lie about the deleted count once
-    // #152 merges.
     return result
   }
 


### PR DESCRIPTION
## Summary

Stacks on PR #157 (lazy + manual). Closes #152 — sub-task 3 of the #143 implementation epic. Spec sequencing steps 9–12 + the aggregate-query shape (deferred from #150's foundation).

## What's new

- **Cost ceiling**: \`MaterializedViewTooLargeError\` fires before writes when row count exceeds \`maxRows\` (default 100k, overridable)
- **Tombstoning**: \`onEmpty: 'delete'\` (default) tombstones disappeared rows via \`_internalDelete\` (bypasses user \`onDelete\` per PR #148's composition fix); \`onEmpty: 'keep'\` opts out
- **Same-collection partition**: \`output.partition: { field, value }\` discriminator + cycle detector resolution via provability check (supports \`==\` / \`!=\` / \`in\`); rejects naïve same-collection MVs as \`MaterializedViewCycleError\`
- **Strict-mode rollback**: \`strict: true\` re-throws on row failure → TxContext rollback via \`revertExecuted\` (#133)
- **Aggregate query shape**: executor branches on \`.toArray()\` / \`.run()\` terminals; aggregate MVs require explicit \`sources\` since the analyzer can't walk through \`groupBy().aggregate()\` back to the source

## Bundle

Essentially flat (floor -0.1% vs the new baseline #151 established). #152 extends existing primitives — no new heavy files.

## Stacked PR base

Targets \`feat/mv-lazy-manual-151\` so the diff is the #152-only delta. GitHub auto-rebases onto main once #156 and #157 merge.

## Test plan

- [x] \`pnpm --filter @noy-db/hub typecheck\`
- [x] \`pnpm --filter @noy-db/hub lint\` — 0 errors
- [x] \`pnpm --filter @noy-db/hub test\` — 1546 / 1546 (was 1534 + 12 new)
- [x] \`pnpm --filter @noy-db/hub bundle-check\` — all four scenarios green

Closes #152.