### PR TITLE
feat(hub): MV declaredDeterministicPredicates + .wherePredicate (#153)

### DIFF
--- a/packages/hub/__tests__/materialized-views/predicates.test.ts
+++ b/packages/hub/__tests__/materialized-views/predicates.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withMaterializedView } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface Invoice extends Record<string, unknown> {
+  id: string
+  status: 'open' | 'paid'
+  amount: number
+  dueDate: string
+}
+
+describe('MV declaredDeterministicPredicates (#153)', () => {
+  it('wherePredicate filters rows via the registered fn', async () => {
+    const mv = withMaterializedView<Invoice>({
+      name: 'overdue',
+      predicates: {
+        isOverdue: {
+          hash: 'is-overdue-v1',
+          fn: (inv: Invoice, ctx?: unknown) => {
+            const { asOf } = ctx as { asOf: string }
+            return inv.status === 'open' && inv.dueDate < asOf
+          },
+        },
+      },
+      query: (db) => db.collection<Invoice>('invoices').query().wherePredicate('isOverdue', { asOf: '2026-05-20' }),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-predicates-basic-passphrase-2026',
+      materializedViewStrategies: [mv],
+    })
+    const vault = await db.openVault('demo')
+    await vault.collection<Invoice>('invoices').put('a', { id: 'a', status: 'open', amount: 100, dueDate: '2026-05-01' })
+    await vault.collection<Invoice>('invoices').put('b', { id: 'b', status: 'paid', amount: 200, dueDate: '2026-05-01' })
+    await vault.collection<Invoice>('invoices').put('c', { id: 'c', status: 'open', amount: 50, dueDate: '2026-06-01' })
+
+    // 'a' is overdue. 'b' is paid (filtered by predicate). 'c' due-in-future (filtered).
+    expect(await vault.collection<Invoice>('overdue').get('a')).not.toBeNull()
+    expect(await vault.collection<Invoice>('overdue').get('b')).toBeNull()
+    expect(await vault.collection<Invoice>('overdue').get('c')).toBeNull()
+  })
+
+  it('queryHash changes when predicate hash bumps — forces refresh', async () => {
+    // Two MVs differing only by predicate.hash should produce different queryHash.
+    const v1 = withMaterializedView<Invoice>({
+      name: 'mv1',
+      predicates: { p: { hash: 'h1', fn: () => true } },
+      query: (db) => db.collection<Invoice>('inv').query().wherePredicate('p'),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    const v2 = withMaterializedView<Invoice>({
+      name: 'mv2',
+      predicates: { p: { hash: 'h2', fn: () => true } },
+      query: (db) => db.collection<Invoice>('inv').query().wherePredicate('p'),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    // Two separate vaults to isolate, then compare _materializedFrom queryHash
+    const dbA = await createNoydb({
+      store: memory(), user: 'alice',
+      secret: 'mv-predicates-hash-A-passphrase-2026',
+      materializedViewStrategies: [v1],
+    })
+    const dbB = await createNoydb({
+      store: memory(), user: 'alice',
+      secret: 'mv-predicates-hash-B-passphrase-2026',
+      materializedViewStrategies: [v2],
+    })
+    const vA = await dbA.openVault('demo')
+    const vB = await dbB.openVault('demo')
+    await vA.collection<Invoice>('inv').put('x', { id: 'x', status: 'open', amount: 1, dueDate: '2026-01-01' })
+    await vB.collection<Invoice>('inv').put('x', { id: 'x', status: 'open', amount: 1, dueDate: '2026-01-01' })
+
+    const rowA = await vA.collection<Invoice & { _materializedFrom: { queryHash: string } }>('mv1').get('x')
+    const rowB = await vB.collection<Invoice & { _materializedFrom: { queryHash: string } }>('mv2').get('x')
+    expect(rowA?._materializedFrom.queryHash).not.toBe(rowB?._materializedFrom.queryHash)
+  })
+
+  it('queryHash changes when ctx differs (same name + hash) — proves ctx folding', async () => {
+    const mvA = withMaterializedView<Invoice>({
+      name: 'overdueA',
+      predicates: { isOverdue: { hash: 'h1', fn: (inv, ctx) => inv.status === 'open' && inv.dueDate < (ctx as { asOf: string }).asOf } },
+      query: (db) => db.collection<Invoice>('inv').query().wherePredicate('isOverdue', { asOf: '2026-05-20' }),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    const mvB = withMaterializedView<Invoice>({
+      name: 'overdueB',
+      predicates: { isOverdue: { hash: 'h1', fn: (inv, ctx) => inv.status === 'open' && inv.dueDate < (ctx as { asOf: string }).asOf } },
+      query: (db) => db.collection<Invoice>('inv').query().wherePredicate('isOverdue', { asOf: '2026-06-01' }),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    const dbA = await createNoydb({
+      store: memory(), user: 'alice',
+      secret: 'mv-predicates-ctxA-passphrase-2026',
+      materializedViewStrategies: [mvA],
+    })
+    const dbB = await createNoydb({
+      store: memory(), user: 'alice',
+      secret: 'mv-predicates-ctxB-passphrase-2026',
+      materializedViewStrategies: [mvB],
+    })
+    const vA = await dbA.openVault('demo')
+    const vB = await dbB.openVault('demo')
+    await vA.collection<Invoice>('inv').put('y', { id: 'y', status: 'open', amount: 1, dueDate: '2026-05-25' })
+    await vB.collection<Invoice>('inv').put('y', { id: 'y', status: 'open', amount: 1, dueDate: '2026-05-25' })
+
+    const rowA = await vA.collection<Invoice & { _materializedFrom: { queryHash: string } }>('overdueA').get('y')
+    // mvB's asOf is '2026-06-01' → 'y' due '2026-05-25' is overdue.
+    const rowB = await vB.collection<Invoice & { _materializedFrom: { queryHash: string } }>('overdueB').get('y')
+    expect(rowB).not.toBeNull()
+    // mvA's asOf is '2026-05-20' → 'y' (due 05-25) is NOT yet overdue.
+    expect(rowA).toBeNull()
+    // Different ctx → different queryHash on whatever rows DID materialize.
+    // Force matching rows by re-using vB with a permissive predicate, but
+    // the simpler proof: the canonical-JSON of `{asOf: 'A'}` differs from
+    // `{asOf: 'B'}` and that flows into the hash. We assert that
+    // materialized rows from each vault carry different queryHash values
+    // when the ctx differs (rowB is non-null; instantiate a parallel row
+    // for vA with a later due date to compare).
+    await vA.collection<Invoice>('inv').put('z', { id: 'z', status: 'open', amount: 1, dueDate: '2026-04-01' })
+    const rowA2 = await vA.collection<Invoice & { _materializedFrom: { queryHash: string } }>('overdueA').get('z')
+    expect(rowA2?._materializedFrom.queryHash).not.toBe(rowB?._materializedFrom.queryHash)
+  })
+
+  it('throws helpful error when .wherePredicate is called on a Query without predicates', async () => {
+    // A bare Query (outside an MV) shouldn't support .wherePredicate().
+    const db = await createNoydb({
+      store: memory(), user: 'alice',
+      secret: 'mv-predicates-bare-passphrase-2026',
+    })
+    const vault = await db.openVault('demo')
+    await vault.collection<Invoice>('inv').put('a', { id: 'a', status: 'open', amount: 1, dueDate: '2026-01-01' })
+    const q = vault.collection<Invoice>('inv').query()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(() => (q as any).wherePredicate('whatever')).toThrow(/no predicates registered/i)
+  })
+
+  it('throws when wherePredicate references an unknown name', async () => {
+    const mv = withMaterializedView<Invoice>({
+      name: 'mv-unknown',
+      predicates: { existsP: { hash: 'h1', fn: () => true } },
+      query: (db) => db.collection<Invoice>('inv').query().wherePredicate('doesNotExist' as 'existsP'),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    await expect((async () => {
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'mv-predicates-unknown-passphrase-2026',
+        materializedViewStrategies: [mv],
+      })
+      await db.openVault('demo')
+    })()).rejects.toThrow(/not registered/i)
+  })
+})

--- a/packages/hub/__tests__/materialized-views/predicates.test.ts
+++ b/packages/hub/__tests__/materialized-views/predicates.test.ts
@@ -192,4 +192,53 @@ describe('MV declaredDeterministicPredicates (#153)', () => {
       await db.openVault('demo')
     })()).rejects.toThrow(/not registered/i)
   })
+
+  it('predicates thread through chain methods (where/orderBy/limit/etc) (niwat-review of #159)', async () => {
+    // The original implementation only threaded `predicates` through
+    // `_withPredicates()` and `.wherePredicate()` itself — every other
+    // chain method (where, or, and, filter, orderBy, limit, offset,
+    // join) dropped the predicates map by constructing the new Query
+    // with only 4 args. Composition like .where().wherePredicate()
+    // would throw "no predicates registered". Fix passes `predicates`
+    // to every chain construction.
+    const mv = withMaterializedView<Invoice>({
+      name: 'overdue-chained',
+      predicates: {
+        isOverdue: {
+          hash: 'h1',
+          fn: (inv: Invoice, ctx?: unknown) => {
+            const { asOf } = ctx as { asOf: string }
+            return inv.status === 'open' && inv.dueDate < asOf
+          },
+        },
+      },
+      // Chain: where → wherePredicate → orderBy → limit
+      // Predicates must survive through each step.
+      query: (db) => db
+        .collection<Invoice>('inv')
+        .query()
+        .where('amount', '>', 50)
+        .wherePredicate('isOverdue', { asOf: '2026-05-20' })
+        .orderBy('amount', 'desc')
+        .limit(10),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-predicates-chained-passphrase-2026',
+      materializedViewStrategies: [mv],
+    })
+    const vault = await db.openVault('demo')
+    // 'a' matches both (amount=100, overdue); 'b' fails amount filter;
+    // 'c' fails overdue filter (paid).
+    await vault.collection<Invoice>('inv').put('a', { id: 'a', status: 'open', amount: 100, dueDate: '2026-05-01' })
+    await vault.collection<Invoice>('inv').put('b', { id: 'b', status: 'open', amount: 25, dueDate: '2026-05-01' })
+    await vault.collection<Invoice>('inv').put('c', { id: 'c', status: 'paid', amount: 200, dueDate: '2026-05-01' })
+
+    expect(await vault.collection<Invoice>('overdue-chained').get('a')).not.toBeNull()
+    expect(await vault.collection<Invoice>('overdue-chained').get('b')).toBeNull()
+    expect(await vault.collection<Invoice>('overdue-chained').get('c')).toBeNull()
+  })
 })

--- a/packages/hub/src/materialized-views/executor.ts
+++ b/packages/hub/src/materialized-views/executor.ts
@@ -4,6 +4,7 @@ import type { EncryptedEnvelope } from '../types.js'
 import { MaterializedViewTooLargeError } from '../errors.js'
 import type { MaterializedFromMeta, MVQueryContext } from './types.js'
 import type { RegisteredMV } from './registry.js'
+import { wrapDbWithPredicates } from './registry.js'
 
 /**
  * Accessor shape passed in from the owning Vault. Mirrors v1's
@@ -112,8 +113,15 @@ export const MaterializedViewExecutor = {
     const onEmpty = spec.onEmpty ?? 'delete'
     const strict = spec.strict ?? false
 
-    // 1. Materialize the query (branches on terminal shape).
-    const q = spec.query(accessor.getQueryContext())
+    // 1. Materialize the query (branches on terminal shape). If the
+    //    MV declared predicates, wrap the query context the same way
+    //    the registry did at registration time so `.wherePredicate()`
+    //    calls resolve to the registered functions.
+    const baseCtx = accessor.getQueryContext()
+    const ctxForQuery: MVQueryContext = spec.predicates
+      ? wrapDbWithPredicates(baseCtx, spec.predicates)
+      : baseCtx
+    const q = spec.query(ctxForQuery)
     const rows = await materializeQueryResult(q, spec.name)
 
     // 2. Cost ceiling check BEFORE any writes — keeps the rollback

--- a/packages/hub/src/materialized-views/registry.ts
+++ b/packages/hub/src/materialized-views/registry.ts
@@ -1,6 +1,7 @@
 import { MaterializedViewCycleError, MaterializedViewSourceUnknownError } from '../errors.js'
 import type { DerivationRegistry } from '../derivations/registry.js'
 import type { Clause, FieldClause } from '../query/predicate.js'
+import type { DeclaredPredicate } from '../query/builder.js'
 import { analyzeDependencies, summarizeQueryPlan } from './dependency-analyzer.js'
 import { computeQueryHash } from './query-hash.js'
 import type { MaterializedViewStrategy, MVQueryContext } from './types.js'
@@ -57,13 +58,19 @@ export class MaterializedViewRegistry {
     db: MVQueryContext,
     options?: { knownCollections?: (name: string) => boolean },
   ): Promise<void> {
+    // Build a predicate-aware db wrapper (#153). If `spec.predicates` is
+    // declared, the wrapper intercepts `.collection().query()` and
+    // attaches the predicates map to the resulting Query<T>. With no
+    // predicates declared, the wrapper is the original db unchanged.
+    const dbForQuery = spec.predicates ? wrapDbWithPredicates(db, spec.predicates) : db
+
     // Invoke the query callback once to inspect its plan / dependencies.
     // For Query<T> shapes the analyzer extracts deps + plan summary
     // automatically. Aggregation / GroupedAggregation shapes don't
     // expose the underlying Query, so the spec must declare `sources`
     // explicitly. `partitionClauses` are only populated for Query<T>
     // since same-collection-partition is a non-aggregate concern.
-    const q = spec.query(db)
+    const q = spec.query(dbForQuery)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const qAny = q as any
     const isQuery = typeof qAny._plan === 'function'
@@ -72,6 +79,14 @@ export class MaterializedViewRegistry {
     if (isQuery) {
       dependencies = analyzeDependencies(q)
       queryPlanSummary = summarizeQueryPlan(q)
+      // Fold `.wherePredicate(name, ctx)` references into the plan
+      // summary so predicate function or ctx changes (signalled by
+      // bumping `hash` or supplying a different ctx) propagate into
+      // `queryHash` and force refresh on next visit.
+      const predicateRefs = extractPredicateRefs(qAny._plan())
+      if (predicateRefs.length > 0) {
+        queryPlanSummary = JSON.stringify({ plan: queryPlanSummary, predicates: predicateRefs })
+      }
       // If `sources` is ALSO declared, take the union (consumer's
       // explicit list extends the auto-analyzed set).
       if (spec.sources) for (const s of spec.sources) dependencies.add(s)
@@ -244,6 +259,90 @@ export class MaterializedViewRegistry {
  */
 function isFieldClauseOnField(clause: Clause, field: string): clause is FieldClause {
   return clause.type === 'field' && clause.field === field
+}
+
+/**
+ * Wrap an `MVQueryContext` so its `.collection().query()` returns a
+ * Query<T> with the MV's declared predicates attached. Bare Queries
+ * (outside of any MV) don't gain `.wherePredicate()` — only Queries
+ * obtained through this wrapped db do.
+ *
+ * @internal
+ */
+export function wrapDbWithPredicates(
+  db: MVQueryContext,
+  predicates: NonNullable<MaterializedViewStrategy<Record<string, unknown>>['predicates']>,
+): MVQueryContext {
+  // Build the predicate map once — the fn signature in the MV spec
+  // is row-typed but the QueryBuilder casts to unknown, so we widen
+  // here for the Map.
+  const map = new Map<string, DeclaredPredicate>()
+  for (const [name, decl] of Object.entries(predicates)) {
+    map.set(name, {
+      hash: decl.hash,
+      fn: decl.fn as (record: unknown, ctx?: unknown) => boolean,
+    })
+  }
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    collection<T extends Record<string, unknown>>(name: string): any {
+      const c = db.collection<T>(name)
+      // Return an object that delegates everything to `c` but
+      // overrides `.query()` to attach predicates via the new
+      // `Query._withPredicates()` accessor.
+      return new Proxy(c, {
+        get(target, prop, receiver) {
+          if (prop === 'query') {
+            return (...args: unknown[]) => {
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              const q = (target.query as any)(...args)
+              // For non-aggregate Query<T>, attach predicates. For
+              // legacy predicate-arg overload that returns T[] (sync
+              // filter), pass through unchanged.
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              if (q && typeof q._withPredicates === 'function') {
+                return q._withPredicates(map)
+              }
+              return q
+            }
+          }
+          return Reflect.get(target, prop, receiver)
+        },
+      })
+    },
+  }
+}
+
+/**
+ * Walk a QueryPlan's clauses and collect predicate-reference markers
+ * for `queryHash` derivation. Returns a sorted array (deterministic
+ * order) of `{ name, predicateHash, ctxHash }` tuples — these are the
+ * hashable identity of each `.wherePredicate()` call site.
+ *
+ * @internal
+ */
+function extractPredicateRefs(
+  plan: { clauses: readonly Clause[] },
+): Array<{ name: string; predicateHash: string; ctxHash: string }> {
+  const refs: Array<{ name: string; predicateHash: string; ctxHash: string }> = []
+  const walk = (clauses: readonly Clause[]): void => {
+    for (const c of clauses) {
+      if (c.type === 'wherePredicate') {
+        refs.push({ name: c.name, predicateHash: c.predicateHash, ctxHash: c.ctxHash })
+      } else if (c.type === 'group') {
+        walk(c.clauses)
+      }
+    }
+  }
+  walk(plan.clauses)
+  // Stable-sort by (name, predicateHash, ctxHash) — same predicate
+  // appearing twice with different ctx hashes both flow through.
+  refs.sort((a, b) => {
+    if (a.name !== b.name) return a.name < b.name ? -1 : 1
+    if (a.predicateHash !== b.predicateHash) return a.predicateHash < b.predicateHash ? -1 : 1
+    return a.ctxHash < b.ctxHash ? -1 : a.ctxHash > b.ctxHash ? 1 : 0
+  })
+  return refs
 }
 
 /**

--- a/packages/hub/src/materialized-views/types.ts
+++ b/packages/hub/src/materialized-views/types.ts
@@ -95,6 +95,23 @@ export interface MaterializedViewStrategy<TRow extends Record<string, unknown>> 
    */
   sources?: ReadonlyArray<string>
   /**
+   * Declared deterministic predicates (#153). Each entry pairs a
+   * consumer-stable `hash` with a function. The `query()` callback's
+   * Query<T> can invoke them via `.wherePredicate(name, ctx?)`. The
+   * predicate's `hash` + a canonical-JSON hash of `ctx` both fold
+   * into `queryHash` — bumping either forces refresh on next visit.
+   *
+   * Consumer responsibility: bump `hash` when the function's semantics
+   * change. Failing to bump after a non-equivalent change leaves
+   * stale rows around until the next explicit refresh.
+   */
+  predicates?: {
+    [name: string]: {
+      hash: string
+      fn: (row: TRow, ctx?: unknown) => boolean
+    }
+  }
+  /**
    * Refresh policy.
    *
    * - `'eager'` — re-materialize synchronously inside the source-write

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -215,6 +215,7 @@ export class Query<T> {
       { ...this.plan, clauses: [...this.plan.clauses, clause] },
       this.joinContext,
       this.aggregateStrategy,
+      this.predicates,
     )
   }
 
@@ -225,7 +226,7 @@ export class Query<T> {
    */
   or(builder: (q: Query<T>) => Query<T>): Query<T> {
     const sub = builder(
-      new Query<T>(this.source as QuerySource<T>, EMPTY_PLAN, this.joinContext, this.aggregateStrategy),
+      new Query<T>(this.source as QuerySource<T>, EMPTY_PLAN, this.joinContext, this.aggregateStrategy, this.predicates),
     )
     const group: GroupClause = {
       type: 'group',
@@ -237,6 +238,7 @@ export class Query<T> {
       { ...this.plan, clauses: [...this.plan.clauses, group] },
       this.joinContext,
       this.aggregateStrategy,
+      this.predicates,
     )
   }
 
@@ -246,7 +248,7 @@ export class Query<T> {
    */
   and(builder: (q: Query<T>) => Query<T>): Query<T> {
     const sub = builder(
-      new Query<T>(this.source as QuerySource<T>, EMPTY_PLAN, this.joinContext, this.aggregateStrategy),
+      new Query<T>(this.source as QuerySource<T>, EMPTY_PLAN, this.joinContext, this.aggregateStrategy, this.predicates),
     )
     const group: GroupClause = {
       type: 'group',
@@ -258,6 +260,7 @@ export class Query<T> {
       { ...this.plan, clauses: [...this.plan.clauses, group] },
       this.joinContext,
       this.aggregateStrategy,
+      this.predicates,
     )
   }
 
@@ -272,6 +275,7 @@ export class Query<T> {
       { ...this.plan, clauses: [...this.plan.clauses, clause] },
       this.joinContext,
       this.aggregateStrategy,
+      this.predicates,
     )
   }
 
@@ -282,6 +286,7 @@ export class Query<T> {
       { ...this.plan, orderBy: [...this.plan.orderBy, { field, direction }] },
       this.joinContext,
       this.aggregateStrategy,
+      this.predicates,
     )
   }
 
@@ -292,6 +297,7 @@ export class Query<T> {
       { ...this.plan, limit: n },
       this.joinContext,
       this.aggregateStrategy,
+      this.predicates,
     )
   }
 
@@ -302,6 +308,7 @@ export class Query<T> {
       { ...this.plan, offset: n },
       this.joinContext,
       this.aggregateStrategy,
+      this.predicates,
     )
   }
 
@@ -413,6 +420,7 @@ export class Query<T> {
       { ...this.plan, joins: [...this.plan.joins, leg] },
       this.joinContext,
       this.aggregateStrategy,
+      this.predicates,
     )
   }
 
@@ -943,6 +951,24 @@ function serializePlan(plan: QueryPlan): unknown {
 function serializeClause(clause: Clause): unknown {
   if (clause.type === 'filter') {
     return { type: 'filter', fn: '[function]' }
+  }
+  if (clause.type === 'wherePredicate') {
+    // Strip the live `fn` reference (non-serializable) but keep the
+    // identity-carrying fields so distinct predicates still serialize
+    // distinctly. `predicateHash` + `ctxHash` are the hash identity;
+    // `name` is the named predicate reference. This matters because
+    // niwat-review of #159 caught that the previous fall-through
+    // (return clause) exposed the live fn and produced identical
+    // serializations for distinct predicates with different ctx
+    // values.
+    return {
+      type: 'wherePredicate',
+      name: clause.name,
+      ctx: clause.ctx,
+      predicateHash: clause.predicateHash,
+      ctxHash: clause.ctxHash,
+      fn: '[function]',
+    }
   }
   if (clause.type === 'group') {
     return {

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -5,7 +5,7 @@
  * mutated. This makes plans safe to share, cache, and serialize.
  */
 
-import type { Clause, FieldClause, FilterClause, GroupClause, Operator } from './predicate.js'
+import type { Clause, FieldClause, FilterClause, GroupClause, Operator, WherePredicateClause } from './predicate.js'
 import { evaluateClause } from './predicate.js'
 import type { CollectionIndexes } from '../indexing/eager-indexes.js'
 import type { JoinContext, JoinLeg, JoinStrategy } from './join.js'
@@ -97,22 +97,36 @@ interface InternalSource {
  * joinContext, and calling `.join()` on it throws with an actionable
  * error. See `query/join.ts` for the full design.
  */
+/**
+ * Declared deterministic predicate (#153). Carries the consumer's
+ * stable `hash` (for function-body identity), the function itself,
+ * and is keyed by name when registered on a `Query<T>` via
+ * `_withPredicates()`.
+ */
+export interface DeclaredPredicate {
+  hash: string
+  fn: (record: unknown, ctx?: unknown) => boolean
+}
+
 export class Query<T> {
   private readonly source: InternalSource
   private readonly plan: QueryPlan
   private readonly joinContext: JoinContext | undefined
   private readonly aggregateStrategy: AggregateStrategy
+  private readonly predicates: ReadonlyMap<string, DeclaredPredicate> | undefined
 
   constructor(
     source: QuerySource<T>,
     plan: QueryPlan = EMPTY_PLAN,
     joinContext?: JoinContext,
     aggregateStrategy: AggregateStrategy = NO_AGGREGATE,
+    predicates?: ReadonlyMap<string, DeclaredPredicate>,
   ) {
     this.source = source as InternalSource
     this.plan = plan
     this.joinContext = joinContext
     this.aggregateStrategy = aggregateStrategy
+    this.predicates = predicates
   }
 
   /**
@@ -131,6 +145,66 @@ export class Query<T> {
    */
   _joinContext(): JoinContext | undefined {
     return this.joinContext
+  }
+
+  /**
+   * @internal — clone this Query with a declared-predicate map
+   * attached. Used by the materialized-view registry to enable
+   * `.wherePredicate(name, ctx?)` for the MV's query callback (#153).
+   * Consumers don't call this directly.
+   */
+  _withPredicates(predicates: ReadonlyMap<string, DeclaredPredicate>): Query<T> {
+    return new Query<T>(
+      this.source as QuerySource<T>,
+      this.plan,
+      this.joinContext,
+      this.aggregateStrategy,
+      predicates,
+    )
+  }
+
+  /**
+   * Filter by a registered deterministic predicate (#153). Requires
+   * the Query to have been augmented with a predicates map (typically
+   * via the materialized-view registry — bare Queries constructed
+   * outside an MV throw on `.wherePredicate()`).
+   *
+   * `ctx` is an optional opaque value passed verbatim to the predicate
+   * function. Both `predicateHash` (from the registration) and a
+   * canonical-JSON hash of `ctx` fold into the MV's `queryHash`, so
+   * either changing forces refresh on next visit.
+   */
+  wherePredicate(name: string, ctx?: unknown): Query<T> {
+    if (!this.predicates) {
+      throw new Error(
+        `.wherePredicate("${name}"): no predicates registered on this Query. ` +
+          `Function-based predicates require the Query to be obtained from ` +
+          `inside a materialized-view query() callback whose strategy declares ` +
+          `\`predicates: { ${name}: { hash, fn } }\`.`,
+      )
+    }
+    const decl = this.predicates.get(name)
+    if (!decl) {
+      throw new Error(
+        `.wherePredicate("${name}"): predicate not registered. ` +
+          `Available: ${[...this.predicates.keys()].join(', ') || '(none)'}.`,
+      )
+    }
+    const clause: WherePredicateClause = {
+      type: 'wherePredicate',
+      name,
+      ctx,
+      predicateHash: decl.hash,
+      ctxHash: canonicalCtxHash(ctx),
+      fn: decl.fn,
+    }
+    return new Query<T>(
+      this.source as QuerySource<T>,
+      { ...this.plan, clauses: [...this.plan.clauses, clause] },
+      this.joinContext,
+      this.aggregateStrategy,
+      this.predicates,
+    )
   }
 
   /** Add a field comparison. Multiple where() calls are AND-combined. */
@@ -878,4 +952,33 @@ function serializeClause(clause: Clause): unknown {
     }
   }
   return clause
+}
+
+/**
+ * Compute a stable hash of a `ctx` value supplied to
+ * `.wherePredicate(name, ctx)`. Canonical-JSON: keys sorted at each
+ * level so `{a, b}` and `{b, a}` hash to the same value. Undefined ctx
+ * hashes to the empty string. The hash is sync because it just runs
+ * a cheap djb2-style fold — used at builder time, not security-sensitive.
+ *
+ * @internal
+ */
+function canonicalCtxHash(ctx: unknown): string {
+  if (ctx === undefined) return ""
+  const canonical = JSON.stringify(ctx, (_key, value) => {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      const sorted: Record<string, unknown> = {}
+      for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+        sorted[k] = (value as Record<string, unknown>)[k]
+      }
+      return sorted
+    }
+    return value
+  })
+  // djb2 fold over the canonical string; converted to hex.
+  let h = 5381
+  for (let i = 0; i < canonical.length; i++) {
+    h = ((h << 5) + h) ^ canonical.charCodeAt(i)
+  }
+  return (h >>> 0).toString(16).padStart(8, "0")
 }

--- a/packages/hub/src/query/predicate.ts
+++ b/packages/hub/src/query/predicate.ts
@@ -42,6 +42,31 @@ export interface FilterClause {
   readonly fn: (record: unknown) => boolean
 }
 
+/**
+ * A declared deterministic predicate reference (#153). The query
+ * builder produces this via `.wherePredicate(name, ctx?)` when a
+ * Query has been augmented with a predicates map (typically by the
+ * materialized-view registry — see MV v2 spec § Function-based
+ * source-row predicates).
+ *
+ * `predicateHash` is the consumer-supplied stable hash for the
+ * function body; `ctxHash` is the canonical-JSON SHA-256 of `ctx`.
+ * Both fold into the MV's `queryHash` so a function or ctx change
+ * forces refresh on next visit.
+ *
+ * `fn` is resolved at builder time from the predicates map and
+ * embedded directly — so `evaluateClause` can fire it without a
+ * runtime lookup.
+ */
+export interface WherePredicateClause {
+  readonly type: 'wherePredicate'
+  readonly name: string
+  readonly ctx: unknown
+  readonly predicateHash: string
+  readonly ctxHash: string
+  readonly fn: (record: unknown, ctx?: unknown) => boolean
+}
+
 /** A logical group of clauses combined by AND or OR. */
 export interface GroupClause {
   readonly type: 'group'
@@ -49,7 +74,7 @@ export interface GroupClause {
   readonly clauses: readonly Clause[]
 }
 
-export type Clause = FieldClause | FilterClause | GroupClause
+export type Clause = FieldClause | FilterClause | WherePredicateClause | GroupClause
 
 /**
  * Read a possibly nested field path like "address.city" from a record.
@@ -136,6 +161,8 @@ export function evaluateClause(record: unknown, clause: Clause): boolean {
       return evaluateFieldClause(record, clause)
     case 'filter':
       return clause.fn(record)
+    case 'wherePredicate':
+      return clause.fn(record, clause.ctx)
     case 'group':
       if (clause.op === 'and') {
         for (const child of clause.clauses) {


### PR DESCRIPTION
Stacks on PR #158. Closes #153 — sub-task 4 of #143. Spec sequencing step 13.

## What's new

- `MaterializedViewStrategy.predicates: { [name]: { hash, fn } }` field
- `Query.wherePredicate(name, ctx?)` builder terminal
- New `WherePredicateClause` in the query DSL — carries resolved fn + hashes at construction time
- queryHash folds both `predicate.hash` and a canonical-JSON `ctxHash` symmetrically

## How it composes

The MV registry wraps the `db` passed to `spec.query(db)` so `.collection().query()` returns a Query<T> with predicates attached. Bare Queries (outside an MV) throw on `.wherePredicate()` with an actionable error pointing to the strategy field.

## Verification

- 1551 hub tests pass (was 1546 + 5 new)
- typecheck clean · lint clean
- Bundle essentially flat — predicate machinery is just two new clause-case branches and a wrapper proxy

Closes #153.