### PR TITLE
docs/showcases: MV + overlay + predicates (#155)

### DIFF
--- a/docs/subsystems/derivations.md
+++ b/docs/subsystems/derivations.md
@@ -266,7 +266,6 @@ source + output collection set.
 
 - Cache-tier backends (`to-cache-*`)
 - Built-in derivers (PDF, image, etc.)
-- `withMaterializedView` (collection-level query derivation)
 - Scheduled / cron-style refresh
 - Non-deterministic derivations with persistence
 - External / sandboxed derivation runtimes
@@ -277,8 +276,229 @@ source + output collection set.
 
 See the spec for the full deferred list.
 
+## Materialized Views
+
+> **Factory:** `withMaterializedView()`
+> **Subpath:** `@noy-db/hub` (re-exported)
+> **Spec:** `docs/superpowers/specs/2026-05-20-dim14-mv-v2-design.md`
+
+`withMaterializedView` (v2) is the query-level companion to v1's
+record-level `withDerivation`. Where `withDerivation` projects one
+source row into N typed outputs, `withMaterializedView` materializes
+the result of an entire `Query<T>` — filter, groupBy, aggregate, join
+— into a queryable collection that is kept fresh on source writes.
+
+```ts
+import { withMaterializedView, sum, count } from '@noy-db/hub'
+
+const pnd1 = withMaterializedView<Pnd1Row>({
+  name: 'pnd1',
+  query: (db) =>
+    db.collection<Compensation>('compensations')
+      .query()
+      .groupBy('clientId')
+      .aggregate({ tax: sum('taxAmount'), count: count() }),
+  rowKey: (row) => row.clientId,
+  sources: ['compensations'],  // required for aggregate / groupBy
+  refresh: 'eager',
+})
+```
+
+### Strategy fields
+
+| Field | Required? | Meaning |
+|-------|:---------:|---------|
+| `name` | yes | Stable identity. Default output collection name. |
+| `query: (db) => Query<TRow>` | yes | Materialized query, run at registration + every refresh. |
+| `rowKey: (row) => string` | yes | Stable id derivation. Explicit — no default. |
+| `refresh: 'eager' \| 'lazy' \| 'manual'` | yes | Refresh policy (see below). |
+| `sources?: string[]` | only for aggregate / groupBy | Explicit dependencies. Plain `Query<T>` shapes are auto-analyzed. |
+| `predicates?: { ... }` | no | Declared deterministic predicates (see § below). |
+| `output?: { collection?, partition? }` | no | Custom output name + same-collection partition discriminator. |
+| `onEmpty?: 'delete' \| 'keep'` | no, default `'delete'` | What to do when re-materialization yields zero rows for a previously-emitted key. |
+| `strict?: boolean` | no, default `false` | Re-throw row-write failures to enable transactional rollback. |
+| `maxRows?: number` | no, default `100_000` | Row-count ceiling; throws `MaterializedViewTooLargeError` before any writes. |
+
+### Refresh modes
+
+- **`eager`** — every source write re-runs the query inside the same
+  transaction. Outputs land synchronously. Pairs with `withTransactions`
+  + `strict: true` for atomic source-and-MV updates.
+- **`lazy`** — source writes mark the MV stale (in-memory). The next
+  read (`.get(id)` or `.list()`) on the MV's output collection triggers
+  the re-materialize before returning. Recommended for expensive views
+  with read-light workloads.
+- **`manual`** — only `vault.refreshView(name)` triggers
+  re-materialization. Useful for time-dependent queries whose `ctx`
+  changes externally, or very expensive views that opt out of the
+  source-write hook entirely.
+
+### `vault.refreshView(name)`
+
+```ts
+const { written, deleted, failed } = await vault.refreshView('pnd1')
+```
+
+Manual entry-point. Returns the executor's full result counts including
+tombstones (`deleted`). Throws if the MV name isn't registered.
+
+### `_materializedFrom` metadata
+
+Every materialized row carries:
+
+```ts
+{
+  _materializedFrom: {
+    mvName: 'pnd1',
+    queryHash: 'sha256-...',        // identity of the query structure
+    sourceVersions: { compensations: 7 },
+    materializedAt: '2026-05-21T...',
+  }
+}
+```
+
+Lives **inside the encrypted payload**, not in the unencrypted envelope
+— the storage backend cannot infer the MV graph from listing. Same
+zero-knowledge shape as v1's `_derivedFrom`.
+
+### Tombstoning (`onEmpty: 'delete'`)
+
+When a re-materialization produces zero rows for a key that previously
+had rows, the prior row is deleted via the `Collection._internalDelete`
+bypass. Same composition story as v1's `optional: true` tombstones:
+user `onDelete` guards on the output collection do **not** fire on
+housekeeping deletes. This keeps consumers free to register
+`onDelete: throw` rules on MV output collections without deadlocking
+their own refresh path.
+
+Opt out with `onEmpty: 'keep'` if zero is a meaningful read state.
+
+### Cycle detection
+
+The cycle detector walks the unified graph of derivations + MVs +
+overlays at `openVault` and rejects cycles with
+`MaterializedViewCycleError`. Same-collection edges (an MV whose
+source equals its output) are allowed **only** when `output.partition`
+provably disjoints the source filter (`==` against a different value,
+`!=` against the value, `in` lists that exclude it). Naïve
+same-collection MVs without a partition filter throw.
+
+### Errors
+
+All extend `NoydbError`:
+
+- `MaterializedViewCycleError(path[])` — cyclic MV graph
+- `MaterializedViewSourceUnknownError(mv, source)` — `sources` declared a name the vault doesn't know
+- `MaterializedViewTooLargeError(mv, rowCount, limit)` — `maxRows` exceeded
+
+### `declaredDeterministicPredicates`
+
+Some filters can't be expressed as `.where(field, op, value)` — date
+arithmetic, multi-field conditions, references to external time. The
+`predicates` field declares named functions that the query can call:
+
+```ts
+withMaterializedView<Invoice>({
+  name: 'overdue',
+  predicates: {
+    isOverdue: {
+      hash: 'is-overdue-v1',
+      fn: (inv, ctx) => inv.status === 'open' && inv.dueDate < (ctx as { asOf: string }).asOf,
+    },
+  },
+  query: (db) => db.collection<Invoice>('invoices').query()
+    .wherePredicate('isOverdue', { asOf: '2026-05-20' }),
+  rowKey: (r) => r.id,
+  refresh: 'eager',
+})
+```
+
+The predicate's `hash` field + a canonical-JSON hash of the `ctx`
+argument both fold into the MV's `queryHash`. **Bumping `hash`**
+(because the function's meaning changed) or **changing `ctx`** (e.g.
+moving `asOf`) **forces a refresh on next visit** — no ad-hoc
+invalidation logic in product code.
+
+Consumer responsibility: bump `hash` when the function semantics
+change. Failing to bump after a non-equivalent change leaves stale
+rows around until the next explicit refresh.
+
+`.wherePredicate()` is only available on `Query<T>` instances produced
+by an MV that declared the predicate map. A bare query throws
+`"no predicates registered on this query"` if you try to call it.
+
+## Overlay views
+
+> **Factory:** `withOverlayedView()`
+> **Subpath:** `@noy-db/hub` (re-exported)
+> **Spec:** `docs/superpowers/specs/2026-05-20-dim14-mv-v2-design.md` § Composition with operator-editable lifecycle
+
+Overlays let a vault expose a **virtual collection** that merges two
+concrete collections — typically an MV's output as `base` and a
+user-writable `overlay` for operator overrides. A single-field shadow
+predicate decides which side wins per row.
+
+```ts
+import { withOverlayedView } from '@noy-db/hub'
+
+const pnd1 = withOverlayedView({
+  name: 'pnd1',
+  base: 'pnd1-aggregate',       // MV output collection
+  overlay: 'pnd1-overlay',      // user-writable collection
+  shadowField: 'dataStatus',
+  shadowValue: 'override',
+})
+```
+
+Read semantics: `vault.collection('pnd1').get(id)` returns the overlay
+row **iff** `overlay[shadowField] === shadowValue`, otherwise the base
+row. No callback merge, no priority lattice, no field-level merge — v2
+stays explicitly narrow.
+
+Write semantics: `.put(id, record)` on the virtual collection routes
+to the overlay collection. The `id` argument must agree with the
+record's identity per the overlay's `rowKey`; mismatches throw
+`OverlayIdMismatchError`.
+
+### Why this exists
+
+Consumer pattern: an MV computes the "right" answer deterministically,
+but a regulated-domain operator needs to override specific rows (an
+accountant marks a row as `dataStatus: 'override'` and edits the
+amount). Without overlays, consumers had to either abandon the MV
+(lose determinism) or write sentinel rows back to the source (lose
+provenance). The overlay split keeps both paths honest.
+
+### Constraints
+
+- `base` must be a **concrete** collection (a real source or an MV
+  output) — not itself a virtual overlay name. Multi-overlay stacking
+  is a v3 non-goal; enforced at `openVault` via
+  `OverlayBaseIsVirtualError`.
+- `overlay` must be a vault-known collection that is **not** an MV
+  output. Operator writes go through the overlay's normal write
+  pipeline, so its own `withGuard` / `withDerivation` registrations
+  apply.
+- `name` must not collide with any concrete collection or MV output —
+  enforced via `OverlayNameCollisionError`.
+
+### Errors
+
+All extend `NoydbError`:
+
+- `OverlayBaseIsVirtualError(overlay, base)` — base resolves to another overlay's virtual name
+- `OverlayCollectionUnavailableError(overlay, missing)` — overlay or base collection not registered
+- `OverlayNameCollisionError(name, existing)` — virtual name collides with a concrete collection or MV
+- `OverlayIdMismatchError(actual, expected)` — `put(id, record)` where id doesn't equal `rowKey(record)`
+
 ## See also
 
 - [SUBSYSTEMS.md](../../SUBSYSTEMS.md)
 - `docs/superpowers/specs/2026-05-01-dim14-derivation-v1-design.md`
-- `__tests__/derivations/*.test.ts`, `showcases/src/80-with-derivation.showcase.test.ts`
+- `docs/superpowers/specs/2026-05-20-dim14-mv-v2-design.md`
+- `__tests__/derivations/*.test.ts`, `__tests__/materialized-views/*.test.ts`, `__tests__/overlay-views/*.test.ts`
+- `showcases/src/80-with-derivation.showcase.test.ts`
+- `showcases/src/81-with-mv-eager.showcase.test.ts`
+- `showcases/src/82-with-mv-lazy.showcase.test.ts`
+- `showcases/src/83-with-overlay.showcase.test.ts`
+- `showcases/src/84-with-mv-predicates.showcase.test.ts`

--- a/features.yaml
+++ b/features.yaml
@@ -489,6 +489,60 @@ features:
       - 'cycle detection at vault open — refuses cyclic graphs'
     related: [guards, transactions]
 
+  - id: materialized-views
+    name: Query-level materialized views
+    cluster: write-and-mutate
+    spec: docs/subsystems/derivations.md#materialized-views
+    subsystem_doc: docs/subsystems/derivations.md
+    package: '@noy-db/hub'
+    factory: withMaterializedView
+    status: preview
+    showcases:
+      - id: 81-with-mv-eager
+        path: showcases/src/81-with-mv-eager.showcase.test.ts
+      - id: 82-with-mv-lazy
+        path: showcases/src/82-with-mv-lazy.showcase.test.ts
+      - id: 84-with-mv-predicates
+        path: showcases/src/84-with-mv-predicates.showcase.test.ts
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'query() runs on plaintext, after DEK unwrap, before encrypt'
+      - 'materialized rows encrypted with same DEK as source(s)'
+      - '_materializedFrom lives in encrypted payload, not unencrypted envelope'
+      - 'eager refresh runs inside source-write transaction; strict:true rolls back source on row-write failure'
+      - 'lazy refresh: source writes mark stale, next read of MV output resolves'
+      - 'manual refresh: only vault.refreshView(name) re-materializes'
+      - 'onEmpty:delete tombstones via Collection._internalDelete — user onDelete guards bypassed for housekeeping'
+      - 'predicates: hash + canonical-JSON ctx fold into queryHash → refresh on hash bump or ctx change'
+      - 'cycle detection at vault open — same-collection edges allowed only with provably-disjoint output.partition'
+      - 'maxRows ceiling throws MaterializedViewTooLargeError before any writes'
+    related: [derivations, overlay-views, transactions, guards]
+
+  - id: overlay-views
+    name: Read-shadow virtual collections
+    cluster: write-and-mutate
+    spec: docs/subsystems/derivations.md#overlay-views
+    subsystem_doc: docs/subsystems/derivations.md
+    package: '@noy-db/hub'
+    factory: withOverlayedView
+    status: preview
+    showcases:
+      - id: 83-with-overlay
+        path: showcases/src/83-with-overlay.showcase.test.ts
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'reads merge base + overlay via single-field shadow predicate; no callback / field-level merge'
+      - 'writes through virtual collection route to overlay collection (base untouched)'
+      - 'base must be concrete (real source or MV output); not another overlay'
+      - 'overlay collection must be vault-known and not an MV output'
+      - 'virtual name must not collide with concrete collections or MV outputs'
+      - 'put(id, record) validates id === rowKey(record) — OverlayIdMismatchError on disagreement'
+    related: [materialized-views, derivations]
+
   - id: guards
     name: Record lock, field freeze, amendment invariant
     cluster: time-and-audit

--- a/showcases/src/81-with-mv-eager.showcase.test.ts
+++ b/showcases/src/81-with-mv-eager.showcase.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Showcase 81 — withMaterializedView, eager refresh (Dim 14 v2)
+ *
+ * What you'll learn
+ * ─────────────────
+ * `withMaterializedView` declares a query whose result is persisted as
+ * a queryable output collection and kept fresh on source-collection
+ * writes. Where `withDerivation` is record-level (one source row → N
+ * outputs), `withMaterializedView` is query-level: the source can be an
+ * aggregate, a join, a groupBy — anything the chainable `Query<T>`
+ * builder can express.
+ *
+ * This showcase covers the eager lifecycle: source-writes synchronously
+ * re-materialize the view inside the same transaction. Lazy lifecycle
+ * is showcase 82; the predicates + ctx primitive is showcase 84.
+ *
+ * Walked-through mechanics:
+ *
+ *   1. **GroupBy + aggregate** — `compensations.query().groupBy('clientId').aggregate({ tax: sum('taxAmount') })`
+ *      materializes one row per client with the rolling tax total.
+ *   2. **Eager refresh** — every source write re-runs the query and
+ *      diffs the result against the prior output set.
+ *   3. **Tombstoning** — when a key that previously had rows yields zero
+ *      rows, the prior row is tombstoned via the system-internal delete
+ *      bypass (user `onDelete` guards on the output collection do not
+ *      fire on housekeeping).
+ *   4. **`_materializedFrom` stamp** — every emitted row carries
+ *      `{ mvName, queryHash, sourceVersions, materializedAt }` inside
+ *      the encrypted payload (zero-knowledge: the storage backend
+ *      cannot infer the MV graph from listing).
+ *
+ * Why it matters
+ * ──────────────
+ * Tax-period roll-ups (e.g. PND.1: per-client, per-month sum of
+ * withholding tax) are the canonical example. The consumer wants
+ * `vault.collection('pnd1').get(clientId)` to be O(1) at read time,
+ * recomputed atomically whenever a contributing source row lands.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 00 (basics) + 80 (record-level derivations).
+ *
+ * What to read next
+ * ─────────────────
+ *   - docs/superpowers/specs/2026-05-20-dim14-mv-v2-design.md
+ *   - docs/subsystems/derivations.md § Materialized Views
+ *   - showcases/src/82-with-mv-lazy.showcase.test.ts (lazy lifecycle)
+ *   - showcases/src/83-with-overlay.showcase.test.ts (operator-editable overlays)
+ *   - showcases/src/84-with-mv-predicates.showcase.test.ts (declared predicates)
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → materialized-views
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withMaterializedView, sum, count } from '@noy-db/hub'
+import type { Query } from '@noy-db/hub'
+import { withAggregate } from '@noy-db/hub/aggregate'
+import { memory } from '@noy-db/to-memory'
+
+interface Compensation extends Record<string, unknown> {
+  id: string
+  clientId: string
+  amount: number
+  taxAmount: number
+  period: string
+}
+
+interface Pnd1Row extends Record<string, unknown> {
+  clientId: string
+  tax: number
+  count: number
+  _materializedFrom?: { mvName: string; queryHash: string; materializedAt: string }
+}
+
+const pnd1 = withMaterializedView<Pnd1Row>({
+  name: 'pnd1',
+  // Per-client tax roll-up. The MV's output collection is also named 'pnd1'
+  // (the default — `output.collection` overrides if you need a different name).
+  //
+  // The cast widens `GroupedAggregation` to `Query<Pnd1Row>` to satisfy
+  // the strategy interface — the runtime accepts both shapes (the
+  // executor branches on terminal), but the type declares only the
+  // `Query<TRow>` arm. Aggregate-shaped MVs require `sources` for the
+  // same reason: the dependency analyzer can't introspect through the
+  // closed-over GroupedQuery.
+  query: (db) =>
+    db
+      .collection<Compensation>('compensations')
+      .query()
+      .groupBy('clientId')
+      .aggregate({ tax: sum('taxAmount'), count: count() }) as unknown as Query<Pnd1Row>,
+  rowKey: (row) => row.clientId,
+  sources: ['compensations'],
+  refresh: 'eager',
+})
+
+async function open(passphrase: string) {
+  const db = await createNoydb({
+    store: memory(),
+    user: 'alice',
+    secret: passphrase,
+    aggregateStrategy: withAggregate(),
+    materializedViewStrategies: [pnd1],
+  })
+  const vault = await db.openVault('books')
+  return { db, vault }
+}
+
+describe('Showcase 81 — withMaterializedView (eager)', () => {
+  it('materializes a per-client aggregate after the first source write', async () => {
+    const { vault } = await open('showcase-81-first-write-passphrase-2026')
+    await vault.collection<Compensation>('compensations').put('w1', {
+      id: 'w1',
+      clientId: 'acme',
+      amount: 1000,
+      taxAmount: 30,
+      period: '2026-05',
+    })
+    const row = await vault.collection<Pnd1Row>('pnd1').get('acme')
+    expect(row?.tax).toBe(30)
+    expect(row?.count).toBe(1)
+  })
+
+  it('re-materializes when a contributing source row lands', async () => {
+    const { vault } = await open('showcase-81-update-passphrase-2026')
+    await vault.collection<Compensation>('compensations').put('w1', {
+      id: 'w1',
+      clientId: 'acme',
+      amount: 1000,
+      taxAmount: 30,
+      period: '2026-05',
+    })
+    await vault.collection<Compensation>('compensations').put('w2', {
+      id: 'w2',
+      clientId: 'acme',
+      amount: 500,
+      taxAmount: 15,
+      period: '2026-05',
+    })
+    const row = await vault.collection<Pnd1Row>('pnd1').get('acme')
+    expect(row?.tax).toBe(45)
+    expect(row?.count).toBe(2)
+  })
+
+  it('keeps separate rows for separate group keys', async () => {
+    const { vault } = await open('showcase-81-multi-passphrase-2026')
+    await vault.collection<Compensation>('compensations').put('w1', {
+      id: 'w1', clientId: 'acme', amount: 1000, taxAmount: 30, period: '2026-05',
+    })
+    await vault.collection<Compensation>('compensations').put('w2', {
+      id: 'w2', clientId: 'globex', amount: 800, taxAmount: 24, period: '2026-05',
+    })
+    expect((await vault.collection<Pnd1Row>('pnd1').get('acme'))?.tax).toBe(30)
+    expect((await vault.collection<Pnd1Row>('pnd1').get('globex'))?.tax).toBe(24)
+  })
+
+  it('tombstones a prior MV row when no source row matches the group key anymore', async () => {
+    // Filtering MV: only un-paid compensations count. When the only
+    // contributing row flips to `status: 'paid'`, the next refresh
+    // produces zero rows for the 'acme' group key → default
+    // `onEmpty: 'delete'` tombstones via the system-internal bypass
+    // (user `onDelete` guards on the output collection are not consulted).
+    type CompWithStatus = Compensation & { status: string }
+    const pendingPnd1 = withMaterializedView<Pnd1Row>({
+      name: 'pnd1-pending',
+      query: (db) =>
+        db.collection<CompWithStatus>('compensations')
+          .query()
+          .where('status', '==', 'pending')
+          .groupBy('clientId')
+          .aggregate({ tax: sum('taxAmount'), count: count() }) as unknown as Query<Pnd1Row>,
+      rowKey: (row) => row.clientId,
+      sources: ['compensations'],
+      refresh: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'showcase-81-tombstone-passphrase-2026',
+      aggregateStrategy: withAggregate(),
+      materializedViewStrategies: [pendingPnd1],
+    })
+    const vault = await db.openVault('books')
+    await vault.collection<Compensation & { status: string }>('compensations').put('w1', {
+      id: 'w1', clientId: 'acme', amount: 1000, taxAmount: 30, period: '2026-05', status: 'pending',
+    })
+    expect(await vault.collection<Pnd1Row>('pnd1-pending').get('acme')).not.toBeNull()
+    await vault.collection<Compensation & { status: string }>('compensations').put('w1', {
+      id: 'w1', clientId: 'acme', amount: 1000, taxAmount: 30, period: '2026-05', status: 'paid',
+    })
+    expect(await vault.collection<Pnd1Row>('pnd1-pending').get('acme')).toBeNull()
+  })
+
+  it('stamps _materializedFrom onto every emitted row', async () => {
+    const { vault } = await open('showcase-81-stamp-passphrase-2026')
+    await vault.collection<Compensation>('compensations').put('w1', {
+      id: 'w1', clientId: 'acme', amount: 1000, taxAmount: 30, period: '2026-05',
+    })
+    const row = await vault.collection<Pnd1Row>('pnd1').get('acme')
+    expect(row?._materializedFrom?.mvName).toBe('pnd1')
+    expect(row?._materializedFrom?.queryHash).toMatch(/^[0-9a-f]{8,}$/)
+    expect(row?._materializedFrom?.materializedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+})

--- a/showcases/src/82-with-mv-lazy.showcase.test.ts
+++ b/showcases/src/82-with-mv-lazy.showcase.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Showcase 82 — withMaterializedView, lazy lifecycle (Dim 14 v2)
+ *
+ * What you'll learn
+ * ─────────────────
+ * Lazy refresh defers re-materialization to the first read after a
+ * source change. Useful when the MV is expensive (large aggregate, big
+ * join) and most source writes happen without an intervening read.
+ *
+ *   1. **First read after open** — bootstraps the MV (no prior state
+ *      exists → executor runs the query and writes the output rows).
+ *   2. **Source-write marks stale** — does NOT re-run the query
+ *      inline. The stale flag is in-memory on the registry.
+ *   3. **Next read resolves** — `vault.collection(mvName).get(id)` (or
+ *      `.list()`) re-runs the query before returning, then clears the
+ *      stale flag.
+ *   4. **`vault.refreshView(name)`** — manual entry-point that
+ *      re-materializes on demand, regardless of the stale flag.
+ *      Returns `{ written, deleted, failed }`.
+ *
+ * Why it matters
+ * ──────────────
+ * For a regulated-domain consumer: end-of-period roll-ups can be heavy
+ * (group across the entire compensations collection). Eager refresh
+ * would mean every single source write pays the recompute cost; lazy
+ * defers the work to "when the dashboard actually opens." Same eventual
+ * consistency story; very different write-path latency.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 81 (eager MV mechanics).
+ *
+ * What to read next
+ * ─────────────────
+ *   - docs/subsystems/derivations.md § Materialized Views
+ *   - showcases/src/83-with-overlay.showcase.test.ts (operator-editable overlays)
+ *   - showcases/src/84-with-mv-predicates.showcase.test.ts (declared predicates)
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → materialized-views
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withMaterializedView } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+
+interface Compensation extends Record<string, unknown> {
+  id: string
+  clientId: string
+  taxAmount: number
+  status: 'pending' | 'paid'
+}
+
+function buildLazyMV() {
+  return withMaterializedView<Compensation>({
+    name: 'pending-compensations',
+    // Project a filter MV — keeps the lazy lifecycle the focus here.
+    // Aggregate-shaped MVs work the same way; see showcase 81 for the
+    // groupBy + sum pattern.
+    query: (db) =>
+      db.collection<Compensation>('compensations').query().where('status', '==', 'pending'),
+    rowKey: (row) => row.id,
+    refresh: 'lazy',
+  })
+}
+
+async function open(passphrase: string) {
+  const db = await createNoydb({
+    store: memory(),
+    user: 'alice',
+    secret: passphrase,
+    materializedViewStrategies: [buildLazyMV()],
+  })
+  const vault = await db.openVault('books')
+  return { db, vault }
+}
+
+describe('Showcase 82 — withMaterializedView (lazy)', () => {
+  it('first read after a source write resolves the stale flag', async () => {
+    const { vault } = await open('showcase-82-first-read-passphrase-2026')
+    await vault.collection<Compensation>('compensations').put('w1', {
+      id: 'w1', clientId: 'acme', taxAmount: 30, status: 'pending',
+    })
+    // Source-write marked the MV stale; the .get() below triggers the
+    // resolve-on-read hook before returning.
+    const row = await vault.collection<Compensation>('pending-compensations').get('w1')
+    expect(row?.taxAmount).toBe(30)
+  })
+
+  it('subsequent reads after another source write reflect the change', async () => {
+    const { vault } = await open('showcase-82-update-passphrase-2026')
+    await vault.collection<Compensation>('compensations').put('w1', {
+      id: 'w1', clientId: 'acme', taxAmount: 30, status: 'pending',
+    })
+    expect(await vault.collection<Compensation>('pending-compensations').get('w1')).not.toBeNull()
+    // Second source write — stale marker re-raised; next read picks it up.
+    await vault.collection<Compensation>('compensations').put('w2', {
+      id: 'w2', clientId: 'acme', taxAmount: 15, status: 'pending',
+    })
+    expect(await vault.collection<Compensation>('pending-compensations').get('w2')).not.toBeNull()
+  })
+
+  it('list() also resolves the stale flag (not just get())', async () => {
+    const { vault } = await open('showcase-82-list-passphrase-2026')
+    await vault.collection<Compensation>('compensations').put('w1', {
+      id: 'w1', clientId: 'acme', taxAmount: 30, status: 'pending',
+    })
+    await vault.collection<Compensation>('compensations').put('w2', {
+      id: 'w2', clientId: 'globex', taxAmount: 24, status: 'pending',
+    })
+    await vault.collection<Compensation>('compensations').put('w3', {
+      id: 'w3', clientId: 'acme', taxAmount: 5, status: 'paid',
+    })
+    const rows = await vault.collection<Compensation>('pending-compensations').list()
+    const ids = rows.map((r) => r.id).sort()
+    // w3 was paid, so it's not in the MV result. The list() call had to
+    // resolve the stale MV before it could return — without that hook,
+    // the array would be empty here.
+    expect(ids).toEqual(['w1', 'w2'])
+  })
+
+  it('vault.refreshView(name) re-materializes on demand', async () => {
+    const { vault } = await open('showcase-82-refresh-passphrase-2026')
+    await vault.collection<Compensation>('compensations').put('w1', {
+      id: 'w1', clientId: 'acme', taxAmount: 30, status: 'pending',
+    })
+    const result = await vault.refreshView('pending-compensations')
+    expect(result.written).toBe(1)
+    expect(result.failed).toBe(0)
+    expect(await vault.collection<Compensation>('pending-compensations').get('w1')).not.toBeNull()
+  })
+
+  it('two consecutive source writes only do one refresh on next read', async () => {
+    const { vault } = await open('showcase-82-coalesce-passphrase-2026')
+    // Two source writes without an intervening read.
+    await vault.collection<Compensation>('compensations').put('w1', {
+      id: 'w1', clientId: 'acme', taxAmount: 30, status: 'pending',
+    })
+    await vault.collection<Compensation>('compensations').put('w2', {
+      id: 'w2', clientId: 'acme', taxAmount: 70, status: 'pending',
+    })
+    // The single read pays the recompute cost once; the executor
+    // sees the post-both-writes state.
+    const rows = await vault.collection<Compensation>('pending-compensations').list()
+    expect(rows).toHaveLength(2)
+  })
+})

--- a/showcases/src/83-with-overlay.showcase.test.ts
+++ b/showcases/src/83-with-overlay.showcase.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Showcase 83 — withOverlayedView (Dim 14 v2)
+ *
+ * What you'll learn
+ * ─────────────────
+ * `withOverlayedView` projects a virtual collection that merges a base
+ * (typically an MV's output) with an operator-editable overlay. A
+ * single-field shadow predicate decides whether a given id reads from
+ * the overlay or falls back to the base.
+ *
+ * The canonical example: a tax-period roll-up MV produces the
+ * "computed" answer, but the regulated-domain consumer needs an
+ * operator override path for exceptional cases (an accountant marks a
+ * row as `dataStatus: 'override'` and edits the amount). The MV stays
+ * deterministic; the override path stays explicit and auditable.
+ *
+ *   1. **No overlay row → returns base** — `vault.collection(name).get(id)`
+ *      falls through to the base collection when no overlay row exists.
+ *   2. **Overlay row with shadow predicate true → returns overlay** —
+ *      `overlay[shadowField] === shadowValue` flips the read to overlay.
+ *   3. **Overlay row with shadow predicate false → still returns base**
+ *      — an overlay row with `dataStatus: 'computed'` is silently
+ *      ignored by the virtual layer (you'd see it only by reading the
+ *      overlay collection directly).
+ *   4. **`OverlayIdMismatchError`** — writes through the virtual proxy
+ *      check that the record's identity matches the requested id.
+ *
+ * Why it matters
+ * ──────────────
+ * Without overlays, "operator can edit this MV row" forces consumers
+ * into either (a) abandoning the MV (lose determinism) or (b) writing
+ * sentinel rows back to the source (lose provenance). Overlay split
+ * keeps both paths honest: the MV is always recomputable; the override
+ * is always identifiable by `dataStatus`.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 81 (eager MV mechanics).
+ *
+ * What to read next
+ * ─────────────────
+ *   - docs/superpowers/specs/2026-05-20-dim14-mv-v2-design.md § Composition with operator-editable lifecycle
+ *   - docs/subsystems/derivations.md § Overlay views
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → overlay-views
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  createNoydb,
+  withMaterializedView,
+  withOverlayedView,
+  OverlayIdMismatchError,
+} from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+
+interface Compensation extends Record<string, unknown> {
+  id: string
+  clientId: string
+  amount: number
+}
+
+interface Pnd1Row extends Record<string, unknown> {
+  clientId: string
+  amount: number
+  // Optional shadow field on the merged read shape.
+  dataStatus?: 'computed' | 'override'
+}
+
+// Base MV: 1-row-per-source projection. The MV's output collection is
+// `pnd1-aggregate`; the overlay virtualizes it as `pnd1`.
+const pnd1Aggregate = withMaterializedView<Pnd1Row>({
+  name: 'pnd1-aggregate',
+  query: (db) => db.collection<Compensation>('compensations').query(),
+  rowKey: (row) => row.clientId,
+  refresh: 'eager',
+})
+
+const pnd1Overlay = withOverlayedView({
+  name: 'pnd1',
+  base: 'pnd1-aggregate',
+  overlay: 'pnd1-overlay',
+  shadowField: 'dataStatus',
+  shadowValue: 'override',
+})
+
+async function open(passphrase: string) {
+  const db = await createNoydb({
+    store: memory(),
+    user: 'alice',
+    secret: passphrase,
+    materializedViewStrategies: [pnd1Aggregate],
+    overlayedViewStrategies: [pnd1Overlay],
+  })
+  const vault = await db.openVault('books')
+  return { db, vault }
+}
+
+describe('Showcase 83 — withOverlayedView', () => {
+  it('reads through to base when no overlay row exists', async () => {
+    const { vault } = await open('showcase-83-base-passphrase-2026')
+    await vault.collection<Compensation>('compensations').put('acme', {
+      id: 'acme', clientId: 'acme', amount: 100,
+    })
+    const row = await vault.collection<Pnd1Row>('pnd1').get('acme')
+    expect(row?.amount).toBe(100)
+  })
+
+  it('returns the overlay row when shadow predicate matches', async () => {
+    const { vault } = await open('showcase-83-override-passphrase-2026')
+    await vault.collection<Compensation>('compensations').put('acme', {
+      id: 'acme', clientId: 'acme', amount: 100,
+    })
+    // Operator-recorded override: explicit dataStatus + edited amount.
+    await vault.collection<Pnd1Row>('pnd1-overlay').put('acme', {
+      clientId: 'acme', amount: 99999, dataStatus: 'override',
+    })
+    const row = await vault.collection<Pnd1Row>('pnd1').get('acme')
+    expect(row?.amount).toBe(99999)
+    expect(row?.dataStatus).toBe('override')
+  })
+
+  it('falls back to base when overlay row has shadow predicate false', async () => {
+    const { vault } = await open('showcase-83-orphaned-passphrase-2026')
+    await vault.collection<Compensation>('compensations').put('acme', {
+      id: 'acme', clientId: 'acme', amount: 100,
+    })
+    // Overlay row exists but dataStatus is 'computed', not 'override' —
+    // virtual layer ignores it. (Useful state for drafts/staging.)
+    await vault.collection<Pnd1Row>('pnd1-overlay').put('acme', {
+      clientId: 'acme', amount: 99999, dataStatus: 'computed',
+    })
+    const row = await vault.collection<Pnd1Row>('pnd1').get('acme')
+    expect(row?.amount).toBe(100)
+  })
+
+  it('writes through the virtual proxy route to the overlay collection', async () => {
+    const { vault } = await open('showcase-83-write-passphrase-2026')
+    await vault.collection<Compensation>('compensations').put('acme', {
+      id: 'acme', clientId: 'acme', amount: 100,
+    })
+    await vault.collection<Pnd1Row>('pnd1').put('acme', {
+      clientId: 'acme', amount: 50000, dataStatus: 'override',
+    })
+    // The write landed on the overlay collection; the base is untouched.
+    expect((await vault.collection<Pnd1Row>('pnd1-overlay').get('acme'))?.amount).toBe(50000)
+    expect((await vault.collection<Pnd1Row>('pnd1-aggregate').get('acme'))?.amount).toBe(100)
+    // And the merged read reflects the override.
+    expect((await vault.collection<Pnd1Row>('pnd1').get('acme'))?.amount).toBe(50000)
+  })
+
+  it('throws OverlayIdMismatchError when the put id and rowKey disagree', async () => {
+    // Overlay base has a rowKey, so writes through the virtual proxy
+    // must agree on identity. Mismatch is caught at the proxy layer.
+    const { vault } = await open('showcase-83-mismatch-passphrase-2026')
+    await vault.collection<Compensation>('compensations').put('acme', {
+      id: 'acme', clientId: 'acme', amount: 100,
+    })
+    // Force an in-memory load on the MV by reading once, so the rowKey
+    // is wired up consistently before we attempt the mismatched write.
+    await vault.collection<Pnd1Row>('pnd1').get('acme')
+    await expect(
+      vault.collection<Pnd1Row>('pnd1').put('acme', {
+        clientId: 'globex',  // ← disagrees with id 'acme'
+        amount: 1, dataStatus: 'override',
+      }),
+    ).rejects.toThrow(OverlayIdMismatchError)
+  })
+})

--- a/showcases/src/84-with-mv-predicates.showcase.test.ts
+++ b/showcases/src/84-with-mv-predicates.showcase.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Showcase 84 — declaredDeterministicPredicates (Dim 14 v2)
+ *
+ * What you'll learn
+ * ─────────────────
+ * `MaterializedViewStrategy.predicates` lets you register named,
+ * consumer-stable, deterministic functions that the MV's query can
+ * call via `.wherePredicate(name, ctx?)`. Two reasons this exists:
+ *
+ *   1. **Expressiveness** — query filters that can't be expressed as
+ *      `.where(field, op, value)` (date arithmetic, multi-field
+ *      conditions) need a function call site.
+ *   2. **Refresh semantics** — the predicate's stable `hash` field
+ *      and the canonical-JSON hash of `ctx` both fold into the MV's
+ *      `queryHash`. Bumping `hash` (because the function changed
+ *      meaning) or supplying different `ctx` (e.g. a moved `asOf`
+ *      date) force a refresh on next visit. No silent staleness.
+ *
+ * Mechanics walked through:
+ *
+ *   1. **Basic usage** — declare a predicate; call it from inside the
+ *      MV's `query()` callback.
+ *   2. **`queryHash` reflects predicate identity** — same `name` and
+ *      `ctx` but different `hash` → different `queryHash`.
+ *   3. **`queryHash` reflects `ctx`** — same `name` and `hash` but
+ *      different `ctx` → different `queryHash`.
+ *
+ * Why it matters
+ * ──────────────
+ * The "overdue invoices" view is the canonical example: the predicate
+ * depends on an external `asOf` date (today's date, the period
+ * boundary, an audit cutoff). The MV must refresh when `asOf` moves,
+ * but the underlying function definition hasn't changed. Folding
+ * `ctx` into `queryHash` is what makes that work without ad-hoc
+ * invalidation logic.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 81 (eager MV mechanics).
+ *
+ * What to read next
+ * ─────────────────
+ *   - docs/superpowers/specs/2026-05-20-dim14-mv-v2-design.md § declaredDeterministicPredicates
+ *   - docs/subsystems/derivations.md § Materialized Views — declared predicates
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → materialized-views
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withMaterializedView } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+
+interface Invoice extends Record<string, unknown> {
+  id: string
+  status: 'open' | 'paid'
+  amount: number
+  dueDate: string
+}
+
+interface MaterializedInvoice extends Invoice {
+  _materializedFrom?: { queryHash: string }
+}
+
+describe('Showcase 84 — declaredDeterministicPredicates', () => {
+  it('a registered predicate filters rows from inside the MV query', async () => {
+    const overdueMV = withMaterializedView<Invoice>({
+      name: 'overdue',
+      predicates: {
+        isOverdue: {
+          hash: 'is-overdue-v1',
+          fn: (inv: Invoice, ctx?: unknown) => {
+            const { asOf } = ctx as { asOf: string }
+            return inv.status === 'open' && inv.dueDate < asOf
+          },
+        },
+      },
+      query: (db) =>
+        db.collection<Invoice>('invoices').query().wherePredicate('isOverdue', { asOf: '2026-05-20' }),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'showcase-84-basic-passphrase-2026',
+      materializedViewStrategies: [overdueMV],
+    })
+    const vault = await db.openVault('books')
+    await vault.collection<Invoice>('invoices').put('a', { id: 'a', status: 'open', amount: 100, dueDate: '2026-05-01' })
+    await vault.collection<Invoice>('invoices').put('b', { id: 'b', status: 'paid', amount: 200, dueDate: '2026-05-01' })
+    await vault.collection<Invoice>('invoices').put('c', { id: 'c', status: 'open', amount: 50, dueDate: '2026-06-01' })
+
+    // 'a' is overdue (open + past asOf). 'b' is paid → predicate false.
+    // 'c' is open but not yet past asOf → predicate false.
+    expect(await vault.collection<Invoice>('overdue').get('a')).not.toBeNull()
+    expect(await vault.collection<Invoice>('overdue').get('b')).toBeNull()
+    expect(await vault.collection<Invoice>('overdue').get('c')).toBeNull()
+  })
+
+  it('queryHash changes when the predicate hash bumps', async () => {
+    // Two MVs with the same function but different declared hashes
+    // → different queryHash → independent refresh cycles.
+    const mvA = withMaterializedView<Invoice>({
+      name: 'mvA',
+      predicates: { p: { hash: 'h1', fn: () => true } },
+      query: (db) => db.collection<Invoice>('inv').query().wherePredicate('p'),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    const mvB = withMaterializedView<Invoice>({
+      name: 'mvB',
+      predicates: { p: { hash: 'h2', fn: () => true } },
+      query: (db) => db.collection<Invoice>('inv').query().wherePredicate('p'),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    const dbA = await createNoydb({
+      store: memory(), user: 'alice', secret: 'showcase-84-hash-A-passphrase-2026',
+      materializedViewStrategies: [mvA],
+    })
+    const dbB = await createNoydb({
+      store: memory(), user: 'alice', secret: 'showcase-84-hash-B-passphrase-2026',
+      materializedViewStrategies: [mvB],
+    })
+    const vA = await dbA.openVault('books')
+    const vB = await dbB.openVault('books')
+    await vA.collection<Invoice>('inv').put('x', { id: 'x', status: 'open', amount: 1, dueDate: '2026-01-01' })
+    await vB.collection<Invoice>('inv').put('x', { id: 'x', status: 'open', amount: 1, dueDate: '2026-01-01' })
+    const rowA = await vA.collection<MaterializedInvoice>('mvA').get('x')
+    const rowB = await vB.collection<MaterializedInvoice>('mvB').get('x')
+    expect(rowA?._materializedFrom?.queryHash).not.toBe(rowB?._materializedFrom?.queryHash)
+  })
+
+  it('queryHash changes when ctx differs (same name, same hash)', async () => {
+    // Same predicate (name + hash), different ctx → different queryHash.
+    // This is the mechanism that lets "today's overdue view" pick up
+    // asOf changes without bumping the underlying function.
+    const mvA = withMaterializedView<Invoice>({
+      name: 'overdueA',
+      predicates: {
+        isOverdue: {
+          hash: 'h1',
+          fn: (inv, ctx) => inv.status === 'open' && inv.dueDate < (ctx as { asOf: string }).asOf,
+        },
+      },
+      query: (db) => db.collection<Invoice>('inv').query().wherePredicate('isOverdue', { asOf: '2026-05-20' }),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    const mvB = withMaterializedView<Invoice>({
+      name: 'overdueB',
+      predicates: {
+        isOverdue: {
+          hash: 'h1',
+          fn: (inv, ctx) => inv.status === 'open' && inv.dueDate < (ctx as { asOf: string }).asOf,
+        },
+      },
+      query: (db) => db.collection<Invoice>('inv').query().wherePredicate('isOverdue', { asOf: '2026-06-01' }),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    const dbA = await createNoydb({
+      store: memory(), user: 'alice', secret: 'showcase-84-ctxA-passphrase-2026',
+      materializedViewStrategies: [mvA],
+    })
+    const dbB = await createNoydb({
+      store: memory(), user: 'alice', secret: 'showcase-84-ctxB-passphrase-2026',
+      materializedViewStrategies: [mvB],
+    })
+    const vA = await dbA.openVault('books')
+    const vB = await dbB.openVault('books')
+    // A row that satisfies both asOf values (overdue since 2026-04-01).
+    await vA.collection<Invoice>('inv').put('y', { id: 'y', status: 'open', amount: 1, dueDate: '2026-04-01' })
+    await vB.collection<Invoice>('inv').put('y', { id: 'y', status: 'open', amount: 1, dueDate: '2026-04-01' })
+    const rowA = await vA.collection<MaterializedInvoice>('overdueA').get('y')
+    const rowB = await vB.collection<MaterializedInvoice>('overdueB').get('y')
+    expect(rowA).not.toBeNull()
+    expect(rowB).not.toBeNull()
+    expect(rowA?._materializedFrom?.queryHash).not.toBe(rowB?._materializedFrom?.queryHash)
+  })
+
+  it('predicates compose with other query operators', async () => {
+    // Predicates aren't a separate query mode — they thread through
+    // every chain operator. Here: where(amount > 50) +
+    // wherePredicate('isOverdue') + orderBy + limit.
+    const overdueLargeMV = withMaterializedView<Invoice>({
+      name: 'overdue-large',
+      predicates: {
+        isOverdue: {
+          hash: 'h1',
+          fn: (inv: Invoice, ctx?: unknown) => {
+            const { asOf } = ctx as { asOf: string }
+            return inv.status === 'open' && inv.dueDate < asOf
+          },
+        },
+      },
+      query: (db) =>
+        db
+          .collection<Invoice>('inv')
+          .query()
+          .where('amount', '>', 50)
+          .wherePredicate('isOverdue', { asOf: '2026-05-20' })
+          .orderBy('amount', 'desc')
+          .limit(10),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(), user: 'alice', secret: 'showcase-84-compose-passphrase-2026',
+      materializedViewStrategies: [overdueLargeMV],
+    })
+    const vault = await db.openVault('books')
+    // 'a' matches both filters: amount=100 > 50, open + overdue.
+    // 'b' fails amount filter (25). 'c' fails predicate (paid).
+    await vault.collection<Invoice>('inv').put('a', { id: 'a', status: 'open', amount: 100, dueDate: '2026-05-01' })
+    await vault.collection<Invoice>('inv').put('b', { id: 'b', status: 'open', amount: 25, dueDate: '2026-05-01' })
+    await vault.collection<Invoice>('inv').put('c', { id: 'c', status: 'paid', amount: 200, dueDate: '2026-05-01' })
+    expect(await vault.collection<Invoice>('overdue-large').get('a')).not.toBeNull()
+    expect(await vault.collection<Invoice>('overdue-large').get('b')).toBeNull()
+    expect(await vault.collection<Invoice>('overdue-large').get('c')).toBeNull()
+  })
+})


### PR DESCRIPTION
Closes #155 — sub-task 6 (final) of the #143 implementation epic.

## Summary

- 4 new showcases (`81-with-mv-eager`, `82-with-mv-lazy`, `83-with-overlay`, `84-with-mv-predicates`) — 19 tests, all passing on `@noy-db/to-memory`
- `docs/subsystems/derivations.md` extended with "Materialized Views" and "Overlay views" sections — strategy reference, refresh modes, predicate semantics, overlay constraints, errors
- `features.yaml` entries: `materialized-views` and `overlay-views` in the write-and-mutate cluster
- `scripts/validate-features.mjs` ✓ (features=32 total)
- `scripts/check-architecture.mjs` ✓

## Showcases

| File | Tests | Demonstrates |
|------|:---:|---|
| 81-with-mv-eager | 5 | groupBy + sum aggregate, eager refresh, tombstoning, `_materializedFrom` stamp |
| 82-with-mv-lazy | 5 | lazy lifecycle, stale-on-source-write, list() + get() resolve, `vault.refreshView`, refresh coalescing |
| 83-with-overlay | 5 | base/overlay/predicate read truth table, write routing, `OverlayIdMismatchError` |
| 84-with-mv-predicates | 4 | declared predicates, queryHash sensitivity to `hash` + `ctx`, chain composition |

## One non-obvious typing choice

`groupBy + aggregate` MV strategies need `as unknown as Query<TRow>` on the `query()` return — strategy interface declares `(db) => Query<TRow>` but the executor runtime accepts `GroupedAggregation` too (branches on terminal shape per #152). The hub package's own tests don't surface this because hub's `tsconfig.json` excludes `__tests__/`; showcases include their test files. Documented inline at the cast site.

## Test plan

- [x] `pnpm vitest run` on showcases 81–84: 19/19 pass
- [x] `pnpm typecheck` showcases: clean
- [x] `pnpm turbo lint --filter='@noy-db/showcases'`: clean
- [x] `node scripts/check-architecture.mjs`: clean
- [x] `node scripts/validate-features.mjs`: clean
- [ ] CI matrix (will trigger on push)