### PR TITLE
docs: catalog new MV + overlay subsystems (pre.14 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ store: s3({ bucket: 'my-vaults', client: myS3Client })
 
 ---
 
-## The 19-subsystem catalog
+## The 21-subsystem catalog
 
-A minimalist core (~6,500 LOC) plus 19 opt-in capabilities behind `with*()` strategy seams. Apps that don't import a strategy ship none of its code.
+A minimalist core (~6,500 LOC) plus 21 opt-in capabilities behind `with*()` strategy seams. Apps that don't import a strategy ship none of its code.
 
 ```ts
 import { createNoydb } from '@noy-db/hub'
@@ -99,14 +99,14 @@ const db = await createNoydb({
   historyStrategy: withHistory(),     // versioning + ledger + time-machine
   aggregateStrategy: withAggregate(), // sum/groupBy/avg
   blobStrategy: withBlobs(),          // file attachments
-  // ... 14 more available
+  // ... 18 more available
 })
 ```
 
 | Cluster | Subsystems |
 |---|---|
 | **Read & Query** | [indexing](docs/subsystems/indexing.md) · [joins](docs/subsystems/joins.md) · [aggregate](docs/subsystems/aggregate.md) · [live](docs/subsystems/live.md) |
-| **Write & Mutate** | [history](docs/subsystems/history.md) · [transactions](docs/subsystems/transactions.md) · [crdt](docs/subsystems/crdt.md) · [derivations](docs/subsystems/derivations.md) |
+| **Write & Mutate** | [history](docs/subsystems/history.md) · [transactions](docs/subsystems/transactions.md) · [crdt](docs/subsystems/crdt.md) · [derivations](docs/subsystems/derivations.md) · [materialized-views](docs/subsystems/derivations.md#materialized-views) · [overlay-views](docs/subsystems/derivations.md#overlay-views) |
 | **Data Shape** | [blobs](docs/subsystems/blobs.md) · [i18n](docs/subsystems/i18n.md) |
 | **Time & Audit** | [periods](docs/subsystems/periods.md) · [consent](docs/subsystems/consent.md) · [guards](docs/subsystems/guards.md) |
 | **Snapshot & Portability** | [shadow](docs/subsystems/shadow.md) · [bundle](docs/subsystems/bundle.md) |

--- a/SUBSYSTEMS.md
+++ b/SUBSYSTEMS.md
@@ -63,7 +63,9 @@ Each subsystem has its own subpath export under `@noy-db/hub/<name>`, a `with<Na
 | 5 | `@noy-db/hub/history` | Versioning, diff, revert, time-machine, audit ledger (hash-chained) | 1,880 | `periods`, `consent`, `shadow`, `guards` |
 | 6 | `@noy-db/hub/transactions` | Multi-record atomic writes (`db.transaction(fn)`) | 280 | `history`, `sync`, `derivations`, `guards` |
 | 7 | `@noy-db/hub/crdt` | LWW-Map / RGA / Yjs interop | 221 | `live`, `sync` |
-| 18 | `@noy-db/hub/derivations` | Deterministic derived data — source → outputs (eager / lazy) with cycle detection and strict-mode rollback (Dim 14) | ~550 | `transactions` (strict-mode rollback), `guards` |
+| 18 | `@noy-db/hub/derivations` | Deterministic derived data — source → outputs (eager / lazy) with cycle detection and strict-mode rollback (Dim 14 v1) | ~550 | `transactions` (strict-mode rollback), `guards` |
+| 20 | `@noy-db/hub/materialized-views` | Query-level materialized views — `Query<T>` → output collection with eager / lazy / manual refresh, partition cycle-break, declared deterministic predicates with `queryHash` folding (Dim 14 v2) | ~1,400 | `derivations` (shared envelope shape), `transactions` (strict-mode), `overlay-views` (composition) |
+| 21 | `@noy-db/hub/overlay-views` | Read-shadow virtual collections — merges base (typically MV output) + user-writable overlay via single-field shadow predicate; operator-editable layer over deterministic MVs | ~600 | `materialized-views`, `guards` (overlay-side write hooks), `derivations` |
 
 ### Cluster C — Data Shape
 
@@ -329,6 +331,9 @@ consent ──► history            (consent audit appends ledger entries)
 guards ───► history            (successful amendment appends `op: 'amendment'` ledger entry)
 guards ───► transactions       (amendment mode set via `db.transaction({ amendment, reason }, fn)`)
 derivations ► transactions     (strict-mode failure triggers source rollback via shared revert plan)
+materialized-views ► derivations (shares the encrypted-payload metadata envelope; reuses housekeeping bypass)
+materialized-views ► transactions (strict-mode + `withTransactions` triggers source rollback)
+overlay-views ► materialized-views (typical base; cycle detector unifies the graph)
 ```
 
 Soft pairings (mentioned in "Pairs well with" but not enforced) are listed per page.

--- a/docs/subsystems/README.md
+++ b/docs/subsystems/README.md
@@ -1,6 +1,6 @@
 # Subsystems — the catalog
 
-The 19 opt-in capabilities that compose with the always-on core. Each entry is a tree-shake-able module behind a `with*()` strategy seam — when you don't import the factory, none of the subsystem's code reaches your bundle.
+The 21 opt-in capabilities that compose with the always-on core. Each entry is a tree-shake-able module behind a `with*()` strategy seam — when you don't import the factory, none of the subsystem's code reaches your bundle.
 
 See [SUBSYSTEMS.md](../../SUBSYSTEMS.md) for the catalog overview, dependency graph, starter recipes, and CI invariants.
 
@@ -20,7 +20,9 @@ See [SUBSYSTEMS.md](../../SUBSYSTEMS.md) for the catalog overview, dependency gr
 | [history](./history.md) | Versioning, diff, revert, time-machine, audit ledger |
 | [transactions](./transactions.md) | Multi-record atomic writes |
 | [crdt](./crdt.md) | LWW-Map / RGA / Yjs interop |
-| [derivations](./derivations.md) | Deterministic derived data (eager / lazy) — Dim 14 |
+| [derivations](./derivations.md) | Deterministic derived data (eager / lazy) — Dim 14 v1 |
+| [materialized-views](./derivations.md#materialized-views) | Query-level materialized views with eager / lazy / manual refresh — Dim 14 v2 |
+| [overlay-views](./derivations.md#overlay-views) | Read-shadow virtual collections (base + overlay) — Dim 14 v2 |
 
 ## Cluster C — Data Shape
 


### PR DESCRIPTION
Found during release verification: README.md, SUBSYSTEMS.md, and docs/subsystems/README.md still claimed "19 subsystems" and didn't list materialized-views or overlay-views.

- SUBSYSTEMS.md — entries #20 + #21 added under Cluster B; 3 new dependency-graph edges.
- README.md — count bump (19 → 21), comment fix (14 → 18 more), Write & Mutate row updated.
- docs/subsystems/README.md — count bump + two new rows linking to derivations.md.

Pure docs fix. No package-version changes.

CI:
- [x] \`node scripts/check-architecture.mjs\` clean
- [x] \`node scripts/validate-features.mjs\` clean (32 features)