### PR TITLE
docs: split Write & Mutate cluster — new "Derived data" cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ const db = await createNoydb({
 | Cluster | Subsystems |
 |---|---|
 | **Read & Query** | [indexing](docs/subsystems/indexing.md) · [joins](docs/subsystems/joins.md) · [aggregate](docs/subsystems/aggregate.md) · [live](docs/subsystems/live.md) |
-| **Write & Mutate** | [history](docs/subsystems/history.md) · [transactions](docs/subsystems/transactions.md) · [crdt](docs/subsystems/crdt.md) · [derivations](docs/subsystems/derivations.md) · [materialized-views](docs/subsystems/derivations.md#materialized-views) · [overlay-views](docs/subsystems/derivations.md#overlay-views) |
+| **Write & Mutate** | [history](docs/subsystems/history.md) · [transactions](docs/subsystems/transactions.md) · [crdt](docs/subsystems/crdt.md) |
+| **Derived data** | [derivations](docs/subsystems/derivations.md) · [materialized-views](docs/subsystems/derivations.md#materialized-views) · [overlay-views](docs/subsystems/derivations.md#overlay-views) |
 | **Data Shape** | [blobs](docs/subsystems/blobs.md) · [i18n](docs/subsystems/i18n.md) |
 | **Time & Audit** | [periods](docs/subsystems/periods.md) · [consent](docs/subsystems/consent.md) · [guards](docs/subsystems/guards.md) |
 | **Snapshot & Portability** | [shadow](docs/subsystems/shadow.md) · [bundle](docs/subsystems/bundle.md) |

--- a/SUBSYSTEMS.md
+++ b/SUBSYSTEMS.md
@@ -43,7 +43,7 @@ Anything outside this floor is a subsystem.
 
 ---
 
-## The 19 subsystems
+## The 21 subsystems
 
 Each subsystem has its own subpath export under `@noy-db/hub/<name>`, a `with<Name>()` factory, and a doc page in `docs/subsystems/<name>.md`. The "LOC saved" column is the bundle weight a consumer avoids by **not** opting in.
 
@@ -63,18 +63,25 @@ Each subsystem has its own subpath export under `@noy-db/hub/<name>`, a `with<Na
 | 5 | `@noy-db/hub/history` | Versioning, diff, revert, time-machine, audit ledger (hash-chained) | 1,880 | `periods`, `consent`, `shadow`, `guards` |
 | 6 | `@noy-db/hub/transactions` | Multi-record atomic writes (`db.transaction(fn)`) | 280 | `history`, `sync`, `derivations`, `guards` |
 | 7 | `@noy-db/hub/crdt` | LWW-Map / RGA / Yjs interop | 221 | `live`, `sync` |
-| 18 | `@noy-db/hub/derivations` | Deterministic derived data — source → outputs (eager / lazy) with cycle detection and strict-mode rollback (Dim 14 v1) | ~550 | `transactions` (strict-mode rollback), `guards` |
+
+### Cluster C — Derived data
+
+The Dim 14 family. All three share the same encrypted-payload metadata envelope, the same housekeeping-delete bypass (so user `onDelete` guards on output collections don't deadlock system-internal tombstones), and a unified cycle detector at vault open.
+
+| # | Subpath | Headline | LOC saved | Pairs with |
+|---|---|---|---:|---|
+| 18 | `@noy-db/hub/derivations` | Deterministic derived data — source row → typed outputs (eager / lazy) with cycle detection and strict-mode rollback (Dim 14 v1) | ~550 | `transactions` (strict-mode rollback), `guards` |
 | 20 | `@noy-db/hub/materialized-views` | Query-level materialized views — `Query<T>` → output collection with eager / lazy / manual refresh, partition cycle-break, declared deterministic predicates with `queryHash` folding (Dim 14 v2) | ~1,400 | `derivations` (shared envelope shape), `transactions` (strict-mode), `overlay-views` (composition) |
 | 21 | `@noy-db/hub/overlay-views` | Read-shadow virtual collections — merges base (typically MV output) + user-writable overlay via single-field shadow predicate; operator-editable layer over deterministic MVs | ~600 | `materialized-views`, `guards` (overlay-side write hooks), `derivations` |
 
-### Cluster C — Data Shape
+### Cluster D — Data Shape
 
 | # | Subpath | Headline | LOC saved | Pairs with |
 |---|---|---|---:|---|
 | 8 | `@noy-db/hub/blobs` | Binary attachments + compaction + MIME-magic | 2,376 | `bundle`, `routing` |
 | 9 | `@noy-db/hub/i18n` | Multi-locale records + dict-key resolution + auto-translate hook | 854 | `aggregate` (groupBy on dict-key) |
 
-### Cluster D — Time & Audit
+### Cluster E — Time & Audit
 
 | # | Subpath | Headline | LOC saved | Pairs with |
 |---|---|---|---:|---|
@@ -82,14 +89,14 @@ Each subsystem has its own subpath export under `@noy-db/hub/<name>`, a `with<Na
 | 11 | `@noy-db/hub/consent` | Consent audit log (GDPR/PIPL-friendly) | 194 | `history` |
 | 19 | `@noy-db/hub/guards` | Record lock + field-level freeze + role-gated amendment invariant with `op: 'amendment'` ledger entry | ~700 | `history` (amendment audit), `transactions` (amendment-mode rollback), `team` (role check) |
 
-### Cluster E — Snapshot & Portability
+### Cluster F — Snapshot & Portability
 
 | # | Subpath | Headline | LOC saved | Pairs with |
 |---|---|---|---:|---|
 | 12 | `@noy-db/hub/shadow` | Read-only `vault.frame()` views | 129 | `history` (time-machine) |
 | 13 | `@noy-db/hub/bundle` | `.noydb` encrypted container format (backup, transport) | 846 | `blobs`, `routing` |
 
-### Cluster F — Collaboration & Auth
+### Cluster G — Collaboration & Auth
 
 | # | Subpath | Headline | LOC saved | Pairs with |
 |---|---|---|---:|---|
@@ -100,13 +107,13 @@ Each subsystem has its own subpath export under `@noy-db/hub/<name>`, a `with<Na
 
 <a id="user-envelope"></a>**`user-envelope`** is included in the always-on core because it has zero peer-dep cost and the policy gates (`edit-own-profile`, `view-team-profiles`) are valuable even for single-user vaults. See `docs/subsystems/user-envelope.md`.
 
-### Cluster G — Operations
+### Cluster H — Operations
 
 | # | Subpath | Headline | LOC saved | Pairs with |
 |---|---|---|---:|---|
 | 17 | `@noy-db/hub/routing` | Multi-store routing + middleware + sync-policy + lazy-mode + LRU cache | ~1,985 | `indexing`, `bundle` |
 
-**Totals:** ~14,450 LOC across all 19 subsystems are tree-shake-able. A consumer using only the core ships ~6,500 LOC. A consumer opting into all 19 ships ~29,500 LOC.
+**Totals:** ~16,450 LOC across all 21 subsystems are tree-shake-able. A consumer using only the core ships ~6,500 LOC. A consumer opting into all 21 ships ~31,500 LOC.
 
 ---
 
@@ -119,7 +126,7 @@ Every subsystem doc page (`docs/subsystems/<name>.md`) follows the same template
 
 > **Subpath:** `@noy-db/hub/<name>`
 > **Factory:** `with<Name>()`
-> **Cluster:** <A–G>
+> **Cluster:** <A–H>
 > **LOC cost:** ~<n> (off-bundle when not opted in)
 
 ## What it does

--- a/docs/subsystems/README.md
+++ b/docs/subsystems/README.md
@@ -20,18 +20,23 @@ See [SUBSYSTEMS.md](../../SUBSYSTEMS.md) for the catalog overview, dependency gr
 | [history](./history.md) | Versioning, diff, revert, time-machine, audit ledger |
 | [transactions](./transactions.md) | Multi-record atomic writes |
 | [crdt](./crdt.md) | LWW-Map / RGA / Yjs interop |
-| [derivations](./derivations.md) | Deterministic derived data (eager / lazy) — Dim 14 v1 |
-| [materialized-views](./derivations.md#materialized-views) | Query-level materialized views with eager / lazy / manual refresh — Dim 14 v2 |
-| [overlay-views](./derivations.md#overlay-views) | Read-shadow virtual collections (base + overlay) — Dim 14 v2 |
 
-## Cluster C — Data Shape
+## Cluster C — Derived data
+
+| Page | What it adds |
+|---|---|
+| [derivations](./derivations.md) | Deterministic derived data — source row → typed outputs (eager / lazy / strict-mode rollback) — Dim 14 v1 |
+| [materialized-views](./derivations.md#materialized-views) | Query-level materialized views — `Query<T>` → output collection (eager / lazy / manual refresh; declared deterministic predicates) — Dim 14 v2 |
+| [overlay-views](./derivations.md#overlay-views) | Read-shadow virtual collections — merges base + user-writable overlay via shadow predicate — Dim 14 v2 |
+
+## Cluster D — Data Shape
 
 | Page | What it adds |
 |---|---|
 | [blobs](./blobs.md) | Binary attachments + compaction + MIME-magic |
 | [i18n](./i18n.md) | Multi-locale records + dict-key resolution + auto-translate |
 
-## Cluster D — Time & Audit
+## Cluster E — Time & Audit
 
 | Page | What it adds |
 |---|---|
@@ -39,14 +44,14 @@ See [SUBSYSTEMS.md](../../SUBSYSTEMS.md) for the catalog overview, dependency gr
 | [consent](./consent.md) | Consent audit log (GDPR/PIPL-friendly) |
 | [guards](./guards.md) | Record lock + field-level freeze + role-gated amendment invariant with ledger audit |
 
-## Cluster E — Snapshot & Portability
+## Cluster F — Snapshot & Portability
 
 | Page | What it adds |
 |---|---|
 | [shadow](./shadow.md) | Read-only `vault.frame()` views |
 | [bundle](./bundle.md) | `.noydb` encrypted container format |
 
-## Cluster F — Collaboration & Auth
+## Cluster G — Collaboration & Auth
 
 | Page | What it adds |
 |---|---|
@@ -54,7 +59,7 @@ See [SUBSYSTEMS.md](../../SUBSYSTEMS.md) for the catalog overview, dependency gr
 | [team](./team.md) | Multi-user grant/revoke + magic-link + delegation + tiers |
 | [session](./session.md) | Token sessions, dev-unlock, policy enforcement |
 
-## Cluster G — Operations
+## Cluster H — Operations
 
 | Page | What it adds |
 |---|---|

--- a/docs/subsystems/_template.md
+++ b/docs/subsystems/_template.md
@@ -2,7 +2,7 @@
 
 > **Subpath:** `@noy-db/hub/<name>`
 > **Factory:** `with<Name>()`
-> **Cluster:** <A–G>
+> **Cluster:** <A–H>
 > **LOC cost:** ~<n> (off-bundle when not opted in)
 
 ## What it does

--- a/docs/subsystems/blobs.md
+++ b/docs/subsystems/blobs.md
@@ -2,7 +2,7 @@
 
 > **Subpath:** `@noy-db/hub/blobs`
 > **Factory:** `withBlobs()`
-> **Cluster:** C — Data Shape
+> **Cluster:** D — Data Shape
 > **LOC cost:** ~2,376 (off-bundle when not opted in)
 
 ## What it does

--- a/docs/subsystems/bundle.md
+++ b/docs/subsystems/bundle.md
@@ -2,7 +2,7 @@
 
 > **Subpath:** `@noy-db/hub/bundle`
 > **Factory:** none — direct named imports
-> **Cluster:** E — Snapshot & Portability
+> **Cluster:** F — Snapshot & Portability
 > **LOC cost:** ~846 (off-bundle when not opted in)
 
 ## What it does

--- a/docs/subsystems/consent.md
+++ b/docs/subsystems/consent.md
@@ -2,7 +2,7 @@
 
 > **Subpath:** `@noy-db/hub/consent`
 > **Factory:** `withConsent()`
-> **Cluster:** D — Time & Audit
+> **Cluster:** E — Time & Audit
 > **LOC cost:** ~194 (off-bundle when not opted in)
 
 ## What it does

--- a/docs/subsystems/derivations.md
+++ b/docs/subsystems/derivations.md
@@ -2,7 +2,7 @@
 
 > **Subpath:** `@noy-db/hub/derivations`
 > **Factory:** `withDerivation()`
-> **Cluster:** B — Write & Mutate
+> **Cluster:** C — Derived data
 > **LOC cost:** ~preview (off-bundle when not opted in)
 > **Status:** preview, ships in 0.1.0-pre.11
 

--- a/docs/subsystems/guards.md
+++ b/docs/subsystems/guards.md
@@ -2,7 +2,7 @@
 
 > **Subpath:** `@noy-db/hub/guards`
 > **Factory:** `withGuard()`
-> **Cluster:** B — Write & Mutate
+> **Cluster:** E — Time & Audit
 > **LOC cost:** ~310 (off-bundle when not opted in)
 
 ## What it does

--- a/docs/subsystems/i18n.md
+++ b/docs/subsystems/i18n.md
@@ -2,7 +2,7 @@
 
 > **Subpath:** `@noy-db/hub/i18n`
 > **Factory:** `withI18n()`
-> **Cluster:** C — Data Shape
+> **Cluster:** D — Data Shape
 > **LOC cost:** ~854 (off-bundle when not opted in)
 
 ## What it does

--- a/docs/subsystems/periods.md
+++ b/docs/subsystems/periods.md
@@ -2,7 +2,7 @@
 
 > **Subpath:** `@noy-db/hub/periods`
 > **Factory:** `withPeriods()`
-> **Cluster:** D — Time & Audit
+> **Cluster:** E — Time & Audit
 > **LOC cost:** ~334 (off-bundle when not opted in)
 
 ## What it does

--- a/docs/subsystems/routing.md
+++ b/docs/subsystems/routing.md
@@ -2,7 +2,7 @@
 
 > **Subpath:** *(currently always-core; `@noy-db/hub/routing` extraction is a planned follow-up)*
 > **Factory:** `withRouting()` *(planned)*
-> **Cluster:** G — Operations
+> **Cluster:** H — Operations
 > **LOC cost:** ~1,985 (planned — off-bundle when not opted in)
 
 ## What it does

--- a/docs/subsystems/session.md
+++ b/docs/subsystems/session.md
@@ -2,7 +2,7 @@
 
 > **Subpath:** `@noy-db/hub/session`
 > **Factory:** `withSession()`
-> **Cluster:** F — Collaboration & Auth
+> **Cluster:** G — Collaboration & Auth
 > **LOC cost:** ~495 (off-bundle when not opted in)
 
 ## What it does

--- a/docs/subsystems/shadow.md
+++ b/docs/subsystems/shadow.md
@@ -2,7 +2,7 @@
 
 > **Subpath:** `@noy-db/hub/shadow`
 > **Factory:** `withShadow()`
-> **Cluster:** E — Snapshot & Portability
+> **Cluster:** F — Snapshot & Portability
 > **LOC cost:** ~129 (off-bundle when not opted in)
 
 ## What it does

--- a/docs/subsystems/sync.md
+++ b/docs/subsystems/sync.md
@@ -2,7 +2,7 @@
 
 > **Subpath:** `@noy-db/hub/sync`
 > **Factory:** `withSync()`
-> **Cluster:** F — Collaboration & Auth
+> **Cluster:** G — Collaboration & Auth
 > **LOC cost:** ~856 (off-bundle when not opted in)
 
 ## What it does

--- a/docs/subsystems/team.md
+++ b/docs/subsystems/team.md
@@ -2,7 +2,7 @@
 
 > **Subpath:** `@noy-db/hub/team`
 > **Factory:** `withTeam()` *(planned — keyring stays in core today; team subsystem extraction tracked separately)*
-> **Cluster:** F — Collaboration & Auth
+> **Cluster:** G — Collaboration & Auth
 > **LOC cost:** ~1,000 (off-bundle when not opted in)
 
 ## What it does

--- a/docs/subsystems/user-envelope.md
+++ b/docs/subsystems/user-envelope.md
@@ -2,7 +2,7 @@
 
 > **Subpath:** none — included in always-on core
 > **Factory:** none — exposed as `vault.user.*`
-> **Cluster:** F — Collaboration & Auth
+> **Cluster:** G — Collaboration & Auth
 > **LOC cost:** ~600 (always-on; trivially small)
 > **Spec:** `docs/superpowers/specs/2026-05-05-user-envelope-design.md`
 

--- a/features.yaml
+++ b/features.yaml
@@ -469,7 +469,7 @@ features:
 
   - id: derivations
     name: Deterministic derived data
-    cluster: write-and-mutate
+    cluster: derived-data
     spec: docs/subsystems/derivations.md#derivations
     subsystem_doc: docs/subsystems/derivations.md
     package: '@noy-db/hub/derivations'
@@ -491,7 +491,7 @@ features:
 
   - id: materialized-views
     name: Query-level materialized views
-    cluster: write-and-mutate
+    cluster: derived-data
     spec: docs/subsystems/derivations.md#materialized-views
     subsystem_doc: docs/subsystems/derivations.md
     package: '@noy-db/hub'
@@ -522,7 +522,7 @@ features:
 
   - id: overlay-views
     name: Read-shadow virtual collections
-    cluster: write-and-mutate
+    cluster: derived-data
     spec: docs/subsystems/derivations.md#overlay-views
     subsystem_doc: docs/subsystems/derivations.md
     package: '@noy-db/hub'


### PR DESCRIPTION
The Write & Mutate row had grown to 6 items, more than any other cluster, and conceptually two distinct ideas:

- **"How writes happen"** — history, transactions, crdt
- **"What gets computed from writes"** — derivations, materialized-views, overlay-views (the Dim 14 family)

Splits Cluster B into B (Write & Mutate trio) + new C (Derived data). Renumbers C–G downstream. Fixes an existing inconsistency where `guards.md` claimed Cluster B even though SUBSYSTEMS.md placed it under Time & Audit.

## Files

| Bucket | Files |
|---|---|
| Catalog tables | README.md, SUBSYSTEMS.md, docs/subsystems/README.md |
| Schema config | features.yaml (3 entries moved to \`cluster: derived-data\`) |
| Template + headers | _template.md + 13 subsystem .md pages |

## Validation

- [x] \`node scripts/check-architecture.mjs\` clean
- [x] \`node scripts/validate-features.mjs\` clean (32 features)

## Context

Fast-follow on PR #163 (which catalogued MV + overlay under the old shared row). The user requested the split during release verification — landing this BEFORE the GitHub Release tag so v0.1.0-pre.14 points at the correctly-structured docs.