### PR TITLE
feat(hub): pre.15 — multi-key groupBy (#166) + UNION MV (#165) + guards variance (#131)

### DIFF
--- a/docs/subsystems/aggregate.md
+++ b/docs/subsystems/aggregate.md
@@ -48,6 +48,30 @@ await invoices.scan()
 
 Reducers exported from `@noy-db/hub`: `count`, `sum`, `avg`, `min`, `max`.
 
+### Multi-key groupBy
+
+`Query<T>.groupBy(...fields)` accepts one or more field names. The
+result rows carry every grouped field (in declaration order) plus the
+reducer outputs:
+
+```ts
+.groupBy('clientId', 'period')
+.aggregate({ total: sum('amount') })
+// → [ { clientId: 'c1', period: '2026-05', total: 300 }, … ]
+```
+
+Cardinality thresholds (10k warn, 100k throw) apply on the count of
+distinct tuples, not on the count of fields. The warning message lists
+every grouped field name.
+
+Order of fields in `groupBy(...)` does NOT affect the bucket identity —
+internally, the canonical key sorts field names before hashing. So
+`.groupBy('a', 'b')` and `.groupBy('b', 'a')` produce the same buckets;
+the difference is purely the declaration order of fields on the output
+rows.
+
+See showcase [`85-with-multikey-groupby`](../../showcases/src/85-with-multikey-groupby.showcase.test.ts).
+
 ## Behavior when NOT opted in
 
 - `query().aggregate(...)` throws with a pointer to `@noy-db/hub/aggregate`

--- a/docs/subsystems/aggregate.md
+++ b/docs/subsystems/aggregate.md
@@ -72,6 +72,8 @@ rows.
 
 See showcase [`85-with-multikey-groupby`](../../showcases/src/85-with-multikey-groupby.showcase.test.ts).
 
+For usage inside `withMaterializedView` queries, see [`derivations.md` § Multi-key groupBy in MV queries](./derivations.md#multi-key-groupby-in-mv-queries).
+
 ## Behavior when NOT opted in
 
 - `query().aggregate(...)` throws with a pointer to `@noy-db/hub/aggregate`

--- a/docs/subsystems/derivations.md
+++ b/docs/subsystems/derivations.md
@@ -346,6 +346,54 @@ cardinality ceilings) live in
 The walkthrough lives in showcase
 [`85-with-multikey-groupby`](../../showcases/src/85-with-multikey-groupby.showcase.test.ts).
 
+### UNION sources — `withMaterializedView` reading from multiple collections
+
+A materialized view can read from MULTIPLE sibling source collections in
+ONE declaration via `unionSources`. Per-source `map` projects each arm
+into the MV's row shape; `groupBy` + `aggregate` then run on the
+concatenated stream.
+
+```ts
+withMaterializedView<{ period: string; vat: number }>({
+  name: 'monthlyVat',
+  unionSources: [
+    { collection: 'taxReceipts', map: r => ({ period: r.issuedAt.slice(0, 7), vat:  r.vatAmount }) },
+    { collection: 'creditNotes', map: r => ({ period: r.issuedAt.slice(0, 7), vat: -r.vatAmount }) },
+  ],
+  groupBy: 'period',
+  aggregate: { vat: sum('vat') },
+  rowKey: row => row.period,
+  refresh: 'eager',
+})
+```
+
+**Mutually exclusive with `query`** — a strategy uses one or the other.
+Registration rejects strategies that declare both, or neither, or
+`unionSources` with fewer than 2 arms, or duplicate collection names
+across arms.
+
+**Per-source `map` is the schema-unification boundary.** The two source
+collections may have different schemas; each arm's `map` projects to the
+MV's row shape (the strategy's type parameter). The hub does NOT compare
+schemas across arms — consumer responsibility is that every `map` returns
+the same shape.
+
+**Source-write hooks fire on every arm.** A write to ANY collection in
+`unionSources` re-fires the MV refresh path. Naturally visible via the
+registry's dependency reverse-index.
+
+**Composes with multi-key `groupBy`.** UNION arms can roll up to a
+composite key — e.g. `groupBy: ['clientId', 'period']` over taxReceipts ∪
+creditNotes produces one row per (client, period) tuple.
+
+**Known gap (pre.14 hangover):** `Collection.delete` does NOT yet trigger
+eager MV refresh — only `put` does. UNION (and single-source) MVs with
+`onEmpty: 'delete'` re-tombstone on the next `put` to any source, or via
+`vault.refreshView('mvName')`. A follow-up PR will wire delete-time
+dispatch.
+
+See showcase [`86-with-union-mv`](../../showcases/src/86-with-union-mv.showcase.test.ts).
+
 ### Refresh modes
 
 - **`eager`** — every source write re-runs the query inside the same

--- a/docs/subsystems/derivations.md
+++ b/docs/subsystems/derivations.md
@@ -319,6 +319,33 @@ const pnd1 = withMaterializedView<Pnd1Row>({
 | `strict?: boolean` | no, default `false` | Re-throw row-write failures to enable transactional rollback. |
 | `maxRows?: number` | no, default `100_000` | Row-count ceiling; throws `MaterializedViewTooLargeError` before any writes. |
 
+### Multi-key groupBy in MV queries
+
+The `query` callback can use multi-key `groupBy(...fields)` the same
+way any other `Query<T>` can. The `rowKey` callback then composites
+the grouped fields into a stable id — the choice of encoding is
+yours, but it must be deterministic:
+
+```ts
+withMaterializedView<Pnd1Row>({
+  name: 'pnd1-by-period',
+  query: (db) =>
+    db.collection<Compensation>('compensations')
+      .query()
+      .groupBy('clientId', 'period')
+      .aggregate({ tax: sum('taxAmount') }) as unknown as Query<Pnd1Row>,
+  rowKey: (row) => `${row.clientId}|${row.period}`,  // composite id
+  sources: ['compensations'],
+  refresh: 'eager',
+})
+```
+
+The deep mechanics of multi-key buckets (field-order invariance,
+cardinality ceilings) live in
+[`aggregate.md` § Multi-key groupBy](./aggregate.md#multi-key-groupby).
+The walkthrough lives in showcase
+[`85-with-multikey-groupby`](../../showcases/src/85-with-multikey-groupby.showcase.test.ts).
+
 ### Refresh modes
 
 - **`eager`** — every source write re-runs the query inside the same

--- a/docs/superpowers/plans/2026-05-22-dim14-mv-multikey-and-union.md
+++ b/docs/superpowers/plans/2026-05-22-dim14-mv-multikey-and-union.md
@@ -1,0 +1,1880 @@
+# Pre.15 — Multi-key groupBy + UNION MV + GuardStrategyHandle variance — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land three issues in pre.15 — variadic `Query<T>.groupBy(...fields)` (#166), UNION MV via `unionSources` (#165), and `GuardStrategyHandle<T>` variance cleanup (#131).
+
+**Architecture:** Three sequential PRs in one release branch. PR 1 introduces a shared `canonicalGroupKey` helper that PR 2 consumes for cross-arm row dedup; PR 3 is an independent type-only refactor that rides along. The `query`-form and `unionSources`-form MV paths remain independent inside the executor (no internal n-arm unification). The MV registry's existing `dependencies: Set<string>` already supports multi-source per-MV bookkeeping — UNION just populates it from `unionSources[].collection` instead of via the AST analyzer.
+
+**Tech Stack:** TypeScript, `@noy-db/hub` (Web Crypto only), Vitest, Turbo, pnpm workspaces, ESM-primary monorepo.
+
+**Spec:** [`docs/superpowers/specs/2026-05-22-dim14-mv-multikey-and-union-design.md`](../specs/2026-05-22-dim14-mv-multikey-and-union-design.md)
+
+**Branch convention:** Work on `feat/dim14-mv-multikey-and-union` off `main`. Each PR squash-merges back. Commits within a PR are small TDD steps; PR title carries the issue number.
+
+---
+
+## Task 0: Branch setup
+
+**Files:**
+- None (git only)
+
+- [ ] **Step 1: Confirm clean tree on main**
+
+Run: `git status --short && git fetch origin && git log --oneline origin/main -3`
+Expected: working tree clean (or only `docs/assets/overview.svg` untracked-modified per existing status); HEAD at or beyond commit `653bf62` (spec commit).
+
+- [ ] **Step 2: Create branch**
+
+Run: `git checkout -b feat/dim14-mv-multikey-and-union`
+
+- [ ] **Step 3: Verify baseline test suite is green**
+
+Run: `pnpm install && pnpm turbo build && pnpm vitest run packages/hub`
+Expected: 1573 tests pass; build clean; no type errors.
+
+---
+
+# PR 1 — #166 Multi-key groupBy
+
+## Task 1: Add `canonicalGroupKey` helper (TDD)
+
+**Files:**
+- Create: `packages/hub/src/aggregate/canonical-key.ts`
+- Test: `packages/hub/__tests__/aggregate-canonical-key.test.ts`
+
+The helper is a pure function: sorts field names lexicographically, then serialises `name=value|name=value|…` with JSON-stringified values. Used internally for groupBy dedup AND (later) for UNION MV row-key dedup.
+
+- [ ] **Step 1: Write the failing test file**
+
+```ts
+// packages/hub/__tests__/aggregate-canonical-key.test.ts
+import { describe, it, expect } from 'vitest'
+import { canonicalGroupKey } from '../src/aggregate/canonical-key.js'
+
+describe('canonicalGroupKey', () => {
+  it('returns a single-field encoding for one key', () => {
+    expect(canonicalGroupKey(['period'], { period: '2026-05' }))
+      .toBe('period=\"2026-05\"')
+  })
+
+  it('sorts field names lexicographically before serialising', () => {
+    const a = canonicalGroupKey(['clientId', 'period'], { clientId: 'c1', period: '2026-05' })
+    const b = canonicalGroupKey(['period', 'clientId'], { clientId: 'c1', period: '2026-05' })
+    expect(a).toBe(b)
+    expect(a).toBe('clientId=\"c1\"|period=\"2026-05\"')
+  })
+
+  it('JSON-stringifies value types', () => {
+    expect(canonicalGroupKey(['n'], { n: 42 })).toBe('n=42')
+    expect(canonicalGroupKey(['flag'], { flag: true })).toBe('flag=true')
+    expect(canonicalGroupKey(['obj'], { obj: { a: 1 } })).toBe('obj={\"a\":1}')
+  })
+
+  it('distinguishes undefined and null', () => {
+    expect(canonicalGroupKey(['x'], { x: undefined })).toBe('x=undefined')
+    expect(canonicalGroupKey(['x'], { x: null })).toBe('x=null')
+  })
+
+  it('reads missing fields as undefined', () => {
+    expect(canonicalGroupKey(['absent'], {})).toBe('absent=undefined')
+  })
+
+  it('three-key composite is order-invariant in fields argument', () => {
+    const row = { clientId: 'c1', period: '2026-05', direction: 'in' }
+    const k1 = canonicalGroupKey(['clientId', 'period', 'direction'], row)
+    const k2 = canonicalGroupKey(['direction', 'clientId', 'period'], row)
+    expect(k1).toBe(k2)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails (module not found)**
+
+Run: `pnpm vitest run packages/hub/__tests__/aggregate-canonical-key.test.ts`
+Expected: FAIL — `Cannot find module '../src/aggregate/canonical-key.js'`.
+
+- [ ] **Step 3: Write the helper**
+
+```ts
+// packages/hub/src/aggregate/canonical-key.ts
+
+/**
+ * Canonicalise a group-key tuple to a stable string for dedup hashing.
+ *
+ * Sorts field names lexicographically before serialising, so that
+ * `.groupBy('a', 'b')` and `.groupBy('b', 'a')` produce identical
+ * keys for the same logical group. Values are JSON-stringified;
+ * `undefined` and `null` are distinguished (matching the Map-key
+ * semantics in `groupAndReduce`).
+ *
+ * NOT part of the public API. Used by:
+ *   - `groupAndReduce` for the dedup Map's key
+ *   - `materialized-views/query-hash` for UNION MV cross-arm row-key dedup (PR 2)
+ *
+ * Pure: same input → same output, no side effects, no allocation
+ * caching.
+ */
+export function canonicalGroupKey(
+  fields: readonly string[],
+  row: Record<string, unknown>,
+): string {
+  const sorted = [...fields].sort()
+  const parts: string[] = []
+  for (const name of sorted) {
+    const v = row[name]
+    const serialised =
+      v === undefined ? 'undefined' : JSON.stringify(v)
+    parts.push(`${name}=${serialised}`)
+  }
+  return parts.join('|')
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run packages/hub/__tests__/aggregate-canonical-key.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/aggregate/canonical-key.ts \
+        packages/hub/__tests__/aggregate-canonical-key.test.ts
+git commit -m "feat(hub): canonicalGroupKey helper for multi-key groupBy (#166)"
+```
+
+---
+
+## Task 2: Add failing tests for multi-key `groupBy` on `Query<T>`
+
+**Files:**
+- Modify: `packages/hub/__tests__/query-groupby.test.ts`
+
+- [ ] **Step 1: Add multi-key test cases**
+
+Append these `describe` blocks to the existing `query-groupby.test.ts` file (don't replace existing single-key tests).
+
+```ts
+describe('Query.groupBy — multi-key (#166)', () => {
+  // Reuse the same test fixture pattern as the single-key tests in this file —
+  // a `collection` of invoice-like records with clientId, period, amount.
+
+  it('emits one row per composite key, with every grouped field stamped on the row', async () => {
+    const invoices = await setupInvoiceCollection([
+      { id: 'i1', clientId: 'c1', period: '2026-05', amount: 100 },
+      { id: 'i2', clientId: 'c1', period: '2026-05', amount: 200 },
+      { id: 'i3', clientId: 'c1', period: '2026-06', amount: 300 },
+      { id: 'i4', clientId: 'c2', period: '2026-05', amount: 400 },
+    ])
+
+    const rows = invoices.query()
+      .groupBy('clientId', 'period')
+      .aggregate({ total: sum('amount'), n: count() })
+      .run()
+
+    // Three composite keys: (c1,2026-05), (c1,2026-06), (c2,2026-05).
+    expect(rows).toHaveLength(3)
+    const c1May = rows.find(r => r.clientId === 'c1' && r.period === '2026-05')!
+    expect(c1May.total).toBe(300)
+    expect(c1May.n).toBe(2)
+    const c1Jun = rows.find(r => r.clientId === 'c1' && r.period === '2026-06')!
+    expect(c1Jun.total).toBe(300)
+    expect(c1Jun.n).toBe(1)
+    const c2May = rows.find(r => r.clientId === 'c2' && r.period === '2026-05')!
+    expect(c2May.total).toBe(400)
+    expect(c2May.n).toBe(1)
+  })
+
+  it('preserves grouped-field declaration order on result rows', async () => {
+    const invoices = await setupInvoiceCollection([
+      { id: 'i1', clientId: 'c1', period: '2026-05', amount: 100 },
+    ])
+
+    // declared order: period FIRST, clientId SECOND
+    const rowsA = invoices.query()
+      .groupBy('period', 'clientId')
+      .aggregate({ total: sum('amount') })
+      .run()
+
+    // Key-order property — the row literal carries fields in iteration order,
+    // and our implementation emits in DECLARATION order (not sorted order).
+    expect(Object.keys(rowsA[0]!).slice(0, 2)).toEqual(['period', 'clientId'])
+
+    const rowsB = invoices.query()
+      .groupBy('clientId', 'period')
+      .aggregate({ total: sum('amount') })
+      .run()
+    expect(Object.keys(rowsB[0]!).slice(0, 2)).toEqual(['clientId', 'period'])
+  })
+
+  it('handles three composite keys', async () => {
+    const taxDocs = await setupTaxDocCollection([
+      { id: 't1', clientId: 'c1', period: '2026-05', direction: 'in',  vat: 100 },
+      { id: 't2', clientId: 'c1', period: '2026-05', direction: 'out', vat: 200 },
+      { id: 't3', clientId: 'c1', period: '2026-05', direction: 'in',  vat: 50  },
+    ])
+
+    const rows = taxDocs.query()
+      .groupBy('clientId', 'period', 'direction')
+      .aggregate({ total: sum('vat') })
+      .run()
+
+    expect(rows).toHaveLength(2)
+    const inRow = rows.find(r => r.direction === 'in')!
+    expect(inRow.total).toBe(150)
+    const outRow = rows.find(r => r.direction === 'out')!
+    expect(outRow.total).toBe(200)
+  })
+
+  it('cardinality warning message lists all grouped field names', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    resetGroupByWarnings() // imported from groupby.ts test helper
+
+    // Build a collection with > 10_000 distinct (a,b) tuples.
+    const records = Array.from({ length: 10_001 }, (_, i) => ({
+      id: `r${i}`, a: `${i}`, b: `${i}`, amount: 1,
+    }))
+    const coll = await setupAnonCollection(records)
+    coll.query().groupBy('a', 'b').aggregate({ n: count() }).run()
+
+    expect(warnSpy).toHaveBeenCalledOnce()
+    const msg = warnSpy.mock.calls[0]![0] as string
+    expect(msg).toContain('[a, b]')
+    warnSpy.mockRestore()
+  })
+
+  it('throws GroupCardinalityError at 100k distinct tuples', async () => {
+    const records = Array.from({ length: 100_001 }, (_, i) => ({
+      id: `r${i}`, a: `${i}`, b: `${i}`, amount: 1,
+    }))
+    const coll = await setupAnonCollection(records)
+    expect(() =>
+      coll.query().groupBy('a', 'b').aggregate({ n: count() }).run(),
+    ).toThrow(GroupCardinalityError)
+  })
+
+  it('back-compat: single-arg groupBy still works and returns narrowed field type', async () => {
+    const invoices = await setupInvoiceCollection([
+      { id: 'i1', clientId: 'c1', period: '2026-05', amount: 100 },
+      { id: 'i2', clientId: 'c2', period: '2026-05', amount: 200 },
+    ])
+    const rows = invoices.query()
+      .groupBy('clientId')
+      .aggregate({ total: sum('amount') })
+      .run()
+    expect(rows).toHaveLength(2)
+    expect(typeof rows[0]!.clientId).toBe('string')
+  })
+})
+```
+
+Reuse existing `setupInvoiceCollection`/`setupAnonCollection` helpers from the test file. If a tax-doc fixture helper doesn't exist, mirror `setupInvoiceCollection` and add `setupTaxDocCollection` at the top of the test file with the same shape.
+
+- [ ] **Step 2: Run tests to verify they fail (variadic overload missing)**
+
+Run: `pnpm vitest run packages/hub/__tests__/query-groupby.test.ts -t "multi-key"`
+Expected: FAIL — type errors on `.groupBy('clientId', 'period')` ("Expected 1 arguments, but got 2") or runtime "field is not a string".
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add packages/hub/__tests__/query-groupby.test.ts
+git commit -m "test(hub): multi-key groupBy cases (#166) — failing"
+```
+
+---
+
+## Task 3: Implement variadic `groupBy` overload in `Query<T>` and `GroupedQuery`
+
+**Files:**
+- Modify: `packages/hub/src/query/builder.ts` (groupBy method around line 588)
+- Modify: `packages/hub/src/aggregate/groupby.ts` (GroupedQuery + GroupedAggregation + groupAndReduce)
+
+- [ ] **Step 1: Widen `GroupedQuery` and `GroupedAggregation` to multi-field**
+
+In `packages/hub/src/aggregate/groupby.ts`, change the constructor field on `GroupedQuery<T, F>` from `private readonly field: F` to `private readonly fields: readonly string[]`. Also adapt `GroupedAggregation`:
+
+```ts
+// In GroupedQuery — replace the existing class with this:
+export class GroupedQuery<T, F extends string> {
+  constructor(
+    private readonly executeRecords: () => readonly unknown[],
+    private readonly fields: readonly string[],   // was: field: F
+    private readonly upstreams: readonly AggregationUpstream[],
+    private readonly dictLabelResolver?: (
+      key: string,
+      locale: string,
+      fallback?: string | readonly string[],
+    ) => Promise<string | undefined>,
+  ) {
+    void undefined as T | undefined
+  }
+
+  aggregate<Spec extends AggregateSpec>(
+    spec: Spec,
+  ): GroupedAggregation<GroupedRow<F, AggregateResult<Spec>>> {
+    return new GroupedAggregation<GroupedRow<F, AggregateResult<Spec>>>(
+      this.executeRecords,
+      this.fields,
+      spec,
+      this.upstreams,
+      this.dictLabelResolver,
+    )
+  }
+}
+
+// In GroupedAggregation — change the field constructor param:
+//   private readonly fields: readonly string[],   // was: field: string,
+// And every internal reference to `this.field` must read `this.fields`.
+```
+
+`GroupedRow<F, R>` keeps its existing single-field shape `{ [K in F]: unknown } & R` — when `F` is a single-field type the multi-key generic-projection task (next overload) widens it through a new helper type `GroupedRowN<F, R>`.
+
+- [ ] **Step 2: Add `GroupedRowN` helper type**
+
+In `packages/hub/src/aggregate/groupby.ts`, alongside `GroupedRow`:
+
+```ts
+/**
+ * Multi-key version of GroupedRow. F is a readonly tuple of field
+ * literal types; each becomes a property of the row.
+ */
+export type GroupedRowN<F extends readonly string[], R> =
+  { [K in F[number]]: unknown } & R
+```
+
+- [ ] **Step 3: Update `groupAndReduce` to use `canonicalGroupKey` and stamp every field**
+
+In `groupAndReduce`, change the signature from `field: string` to `fields: readonly string[]`. Replace the bucketing loop and row emission as follows:
+
+```ts
+import { canonicalGroupKey } from './canonical-key.js'
+
+export function groupAndReduce<R>(
+  records: readonly unknown[],
+  fields: readonly string[],
+  spec: AggregateSpec,
+): R[] {
+  // bucket key: canonicalGroupKey serialisation
+  // bucket value: { keyValues: Record<field, unknown>, records: unknown[] }
+  // Storing keyValues per bucket lets us reconstruct row output in
+  // declaration order without re-reading the source records.
+  const buckets = new Map<string, { keyValues: Record<string, unknown>; records: unknown[] }>()
+
+  for (const record of records) {
+    const keyValues: Record<string, unknown> = {}
+    for (const f of fields) {
+      keyValues[f] = readPath(record, f)
+    }
+    const bucketKey = canonicalGroupKey(fields, keyValues)
+    let bucket = buckets.get(bucketKey)
+    if (bucket === undefined) {
+      if (buckets.size >= GROUPBY_MAX_CARDINALITY) {
+        throw new GroupCardinalityError(
+          fields.join(','),
+          buckets.size + 1,
+          GROUPBY_MAX_CARDINALITY,
+        )
+      }
+      bucket = { keyValues, records: [] }
+      buckets.set(bucketKey, bucket)
+    }
+    bucket.records.push(record)
+  }
+
+  if (buckets.size >= GROUPBY_WARN_CARDINALITY) {
+    warnCardinalityApproaching(fields, buckets.size)
+  }
+
+  const reducerKeys = Object.keys(spec)
+  const out: R[] = []
+  for (const bucket of buckets.values()) {
+    const state: Record<string, unknown> = {}
+    for (const key of reducerKeys) {
+      state[key] = spec[key]!.init()
+    }
+    for (const record of bucket.records) {
+      for (const key of reducerKeys) {
+        state[key] = spec[key]!.step(state[key], record)
+      }
+    }
+    // Emit fields in DECLARATION order, then reducer outputs.
+    const row: Record<string, unknown> = {}
+    for (const f of fields) row[f] = bucket.keyValues[f]
+    for (const key of reducerKeys) {
+      row[key] = spec[key]!.finalize(state[key])
+    }
+    out.push(row as unknown as R)
+  }
+  return out
+}
+```
+
+- [ ] **Step 4: Adapt `warnCardinalityApproaching` and the warning dedup set to take `fields: readonly string[]`**
+
+In `groupby.ts`:
+
+```ts
+const warnedCardinalityFields = new Set<string>()  // keyed on JSON.stringify([...fields].sort())
+
+function warnCardinalityApproaching(fields: readonly string[], observed: number): void {
+  const dedupKey = JSON.stringify([...fields].sort())
+  if (warnedCardinalityFields.has(dedupKey)) return
+  warnedCardinalityFields.add(dedupKey)
+  const label = `[${fields.join(', ')}]`
+  console.warn(
+    `[noy-db] .groupBy(${label}) produced ${observed} distinct groups, ` +
+      `${Math.round((observed / GROUPBY_MAX_CARDINALITY) * 100)}% of the ` +
+      `${GROUPBY_MAX_CARDINALITY}-group ceiling. Narrow the query with ` +
+      `.where() before grouping, or switch to a lower-cardinality field combination.`,
+  )
+}
+
+export function resetGroupByWarnings(): void {
+  warnedCardinalityFields.clear()
+}
+```
+
+- [ ] **Step 5: Update `GroupedAggregation` internals (`run()`, live mode) to call `groupAndReduce(records, this.fields, this.spec)`**
+
+In `groupby.ts`, every internal call to `groupAndReduce(records, this.field, this.spec)` becomes `groupAndReduce(records, this.fields, this.spec)`. Live mode rebinds the same way.
+
+- [ ] **Step 6: Add variadic overload on `Query<T>.groupBy`**
+
+In `packages/hub/src/query/builder.ts`, REPLACE the single `groupBy` method definition (around line 588) with two declarations: one overload for the single-field case (keeps narrowed return) and an implementation that handles 1..N.
+
+```ts
+// Single-field overload — back-compat, narrows F to the literal.
+groupBy<F extends string>(field: F): GroupedQuery<T, F>
+// Variadic overload — multi-key. F is a tuple of literal types.
+groupBy<F extends readonly [string, ...string[]]>(...fields: F): GroupedQueryN<T, F>
+// Implementation
+groupBy(...fields: readonly string[]): GroupedQuery<T, string> | GroupedQueryN<T, readonly [string, ...string[]]> {
+  if (fields.length === 0) {
+    throw new Error('groupBy requires at least one field')
+  }
+  const source = this.source
+  const clauses = this.plan.clauses
+  const executeRecords = (): readonly unknown[] => {
+    const { candidates, remainingClauses } = candidateRecords(source, clauses)
+    return remainingClauses.length === 0
+      ? candidates
+      : filterRecords(candidates, remainingClauses)
+  }
+
+  const upstreams: AggregationUpstream[] = []
+  if (source.subscribe) {
+    const subscribe = source.subscribe.bind(source)
+    upstreams.push({ subscribe: (cb: () => void) => subscribe(cb) })
+  }
+
+  // Dict label resolver — only meaningful for SINGLE-field groupBy
+  // (multi-key dictKey narrowing is out of scope for #166; future work).
+  const joinCtx = this.joinContext
+  const dictLabelResolver =
+    fields.length === 1 && joinCtx?.resolveDictSource
+      ? buildDictLabelResolver(joinCtx, fields[0]!) // extract existing inline closure into a helper
+      : undefined
+
+  return this.aggregateStrategy.groupByN(executeRecords, fields, upstreams, dictLabelResolver)
+}
+```
+
+Add a corresponding `groupByN` method on the aggregate strategy (`packages/hub/src/aggregate/strategy.ts` — mirror the existing `groupBy<T, F>` factory but accept `fields: readonly string[]` and construct `GroupedQuery` with `fields` rather than a single `field`). The single-field overload's runtime path now flows through `groupByN(..., [field], ...)`.
+
+The closure that builds `dictLabelResolver` (currently inlined in `builder.ts`) extracts into `buildDictLabelResolver(joinCtx, field)` so the implementation method body stays readable. Mechanical extraction; no logic change.
+
+- [ ] **Step 7: Export `GroupedRowN` and the variadic types from the public surface**
+
+In `packages/hub/src/aggregate/index.ts`, add `GroupedRowN` and `GroupedQuery` re-exports if they aren't already there. The aggregate barrel determines the consumer surface; check existing re-exports and follow the same pattern.
+
+- [ ] **Step 8: Run tests**
+
+Run: `pnpm vitest run packages/hub/__tests__/query-groupby.test.ts`
+Expected: ALL groupby tests pass (existing single-key cases stay green; new multi-key cases pass).
+
+- [ ] **Step 9: Run full hub test suite to check for regressions**
+
+Run: `pnpm vitest run packages/hub`
+Expected: 1573 + new tests pass.
+
+- [ ] **Step 10: Run typecheck**
+
+Run: `pnpm turbo typecheck --filter=@noy-db/hub`
+Expected: 0 errors.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add packages/hub/src/aggregate/canonical-key.ts \
+        packages/hub/src/aggregate/groupby.ts \
+        packages/hub/src/aggregate/strategy.ts \
+        packages/hub/src/aggregate/index.ts \
+        packages/hub/src/query/builder.ts \
+        packages/hub/__tests__/query-groupby.test.ts \
+        packages/hub/__tests__/aggregate-canonical-key.test.ts
+git commit -m "feat(hub): variadic Query.groupBy(...fields) — multi-key groupBy (#166)"
+```
+
+---
+
+## Task 4: Accept `groupBy: string | string[]` on `withMaterializedView`
+
+**Files:**
+- Modify: `packages/hub/src/materialized-views/types.ts`
+- Test: `packages/hub/__tests__/materialized-views/multikey.test.ts` (new)
+
+This is plumbing — the MV strategy already declares its query via a `query: (db) => Query<T>` callback, and the callback can already call the variadic `groupBy` after Task 3. But callers that want a *declarative* `groupBy` field on the strategy object (the niwat shape used in #165's spec) need that field on `MaterializedViewStrategy`.
+
+For pre.15 we EXPOSE the field but keep its execution route through `query()`. The UNION MV task (PR 2) is what consumes the declarative `groupBy` field on the strategy object — single-source MVs continue to express groupBy inside `query()`. This task does the type-level wiring only.
+
+- [ ] **Step 1: Add multi-key MV test (failing)**
+
+```ts
+// packages/hub/__tests__/materialized-views/multikey.test.ts
+import { describe, it, expect } from 'vitest'
+import { withMaterializedView, sum, count } from '../../src/index.js'
+import { createTestVault } from '../helpers/test-vault.js'  // existing test helper pattern
+
+describe('withMaterializedView — multi-key groupBy inside query() (#166)', () => {
+  it('refreshes a per-(clientId, period) MV when source rows are added', async () => {
+    const vault = await createTestVault({
+      collections: ['compensations', 'pnd1Auto'],
+      strategies: [
+        withMaterializedView<{ clientId: string; period: string; total: number }>({
+          name: 'pnd1Auto',
+          query: db =>
+            db.collection<{ clientId: string; period: string; taxAmount: number }>('compensations')
+              .query()
+              .groupBy('clientId', 'period')
+              .aggregate({ total: sum('taxAmount') }),
+          sources: ['compensations'],
+          rowKey: row => `${row.clientId}|${row.period}`,
+          refresh: 'eager',
+        }),
+      ],
+    })
+
+    const comps = vault.collection<{ id: string; clientId: string; period: string; taxAmount: number }>('compensations')
+    await comps.put({ id: 'a', clientId: 'c1', period: '2026-05', taxAmount: 100 })
+    await comps.put({ id: 'b', clientId: 'c1', period: '2026-05', taxAmount: 50 })
+    await comps.put({ id: 'c', clientId: 'c2', period: '2026-05', taxAmount: 200 })
+
+    const out = vault.collection<{ clientId: string; period: string; total: number }>('pnd1Auto')
+    const rows = await out.query().toArray()
+    expect(rows).toHaveLength(2)
+    const c1May = rows.find(r => r.clientId === 'c1' && r.period === '2026-05')!
+    expect(c1May.total).toBe(150)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails (`groupBy` accepts only 1 arg today, but Task 3 already fixed this — so the test may already pass)**
+
+Run: `pnpm vitest run packages/hub/__tests__/materialized-views/multikey.test.ts`
+Expected: PASS already after Task 3 if MV machinery works with the multi-key query plan. If FAIL, the failure mode is dependency-analyzer-related (it walks `Query`'s AST — needs to handle multi-key groupBy).
+
+- [ ] **Step 3 (if step 2 failed): Update dependency analyzer to recognise multi-key groupBy plans**
+
+In `packages/hub/src/materialized-views/dependency-analyzer.ts`, the analyzer walks the `Query` plan. If multi-key groupBy added a new plan-node shape, extend the visitor to handle it. The expected fix is small — the groupBy plan-node stores fields as an array now; the analyzer must read `fields` instead of `field`. Look for any reference to `.field` on a groupBy plan node and switch to `.fields`.
+
+- [ ] **Step 4: Re-run MV multi-key test**
+
+Run: `pnpm vitest run packages/hub/__tests__/materialized-views/multikey.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Run all MV tests**
+
+Run: `pnpm vitest run packages/hub/__tests__/materialized-views`
+Expected: All pre.14 MV tests still green, plus the new multikey test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/materialized-views/dependency-analyzer.ts \
+        packages/hub/__tests__/materialized-views/multikey.test.ts
+git commit -m "feat(hub): materialized views support multi-key groupBy in query() (#166)"
+```
+
+---
+
+## Task 5: Multi-key groupBy showcase
+
+**Files:**
+- Create: `showcases/src/<next-N>-with-multikey-groupby.showcase.test.ts`
+
+- [ ] **Step 1: Determine showcase number**
+
+Run: `ls showcases/src/*.showcase.test.ts | sort | tail -5`
+Use the next free integer (e.g., if last is `70-…`, this is `71-with-multikey-groupby.showcase.test.ts`).
+
+- [ ] **Step 2: Write the showcase**
+
+Follow the existing showcase template (see `10-with-aggregate.showcase.test.ts` for the pattern: top-of-file doc-comment with "What you'll learn / Why it matters / Prerequisites / What to read next" sections, then one `describe` block with assertions).
+
+```ts
+/**
+ * Showcase 71 — multi-key groupBy
+ *
+ * What you'll learn
+ * ─────────────────
+ * Group records by TWO OR MORE fields. The chainable builder accepts
+ * a variadic `groupBy(...fields)` call; result rows carry every
+ * grouped field plus the reducer outputs.
+ *
+ * Why it matters
+ * ──────────────
+ * Real-world aggregations are rarely keyed by a single field. A
+ * per-(client, period) roll-up shape — invoices summed by client and
+ * month, taxes aggregated by tenant and reporting window — needs a
+ * composite key. Multi-key groupBy lets you express that directly,
+ * with no synthetic concatenated-key field on the source schema.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 10 (single-key groupBy + aggregate)
+ *
+ * What to read next
+ * ─────────────────
+ *   - showcase 72-with-union-mv (UNION across sibling collections)
+ *   - docs/subsystems/derivations.md
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createMemoryVault, sum, count } from '@noy-db/hub'
+
+describe('Showcase 71 — multi-key groupBy', () => {
+  it('groups by (clientId, period) and sums amount', async () => {
+    const vault = await createMemoryVault()
+    const invoices = vault.collection<{
+      id: string; clientId: string; period: string; amount: number
+    }>('invoices')
+    await invoices.put({ id: 'i1', clientId: 'c1', period: '2026-05', amount: 100 })
+    await invoices.put({ id: 'i2', clientId: 'c1', period: '2026-05', amount: 200 })
+    await invoices.put({ id: 'i3', clientId: 'c1', period: '2026-06', amount: 300 })
+    await invoices.put({ id: 'i4', clientId: 'c2', period: '2026-05', amount: 400 })
+
+    const rows = invoices.query()
+      .groupBy('clientId', 'period')
+      .aggregate({ total: sum('amount'), n: count() })
+      .run()
+
+    expect(rows).toHaveLength(3)
+    const c1May = rows.find(r => r.clientId === 'c1' && r.period === '2026-05')!
+    expect(c1May.total).toBe(300)
+    expect(c1May.n).toBe(2)
+  })
+})
+```
+
+Replace `createMemoryVault` with whatever bootstrap the existing showcases use (see showcase 10 for the exact import). The point is one runnable end-to-end test.
+
+- [ ] **Step 3: Run the showcase**
+
+Run: `pnpm vitest run showcases/src/71-with-multikey-groupby.showcase.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add showcases/src/71-with-multikey-groupby.showcase.test.ts
+git commit -m "showcase(hub): multi-key groupBy walkthrough (#166)"
+```
+
+---
+
+## Task 6: Update `features.yaml` and subsystem docs for multi-key
+
+**Files:**
+- Modify: `features.yaml`
+- Modify: `docs/subsystems/derivations.md` (or `materialized-views.md` — check which subsystem doc lives at top of the `docs/subsystems/` dir for derived-data)
+
+- [ ] **Step 1: Add a `mv-multikey-groupby` entry to `features.yaml`**
+
+Look at an existing entry near the MV-related rows for the exact schema. Likely shape:
+
+```yaml
+- id: mv-multikey-groupby
+  package: '@noy-db/hub'
+  title: Multi-key groupBy
+  summary: Variadic `Query.groupBy(...fields)` and matching `withMaterializedView` query path. One row per composite key, every grouped field stamped on the row.
+  since: 0.1.0-pre.15
+  status: stable
+  showcase: 71-with-multikey-groupby
+  subsystem: derived-data
+```
+
+Adjust `subsystem`, `status`, and `since` to match the existing taxonomy.
+
+- [ ] **Step 2: Validate features.yaml**
+
+Run: `node scripts/validate-features.mjs`
+Expected: 0 errors.
+
+- [ ] **Step 3: Add a "Multi-key groupBy" section to the relevant subsystem doc**
+
+In `docs/subsystems/derivations.md` (or wherever single-key `groupBy` is documented), add a sibling section:
+
+```md
+### Multi-key groupBy
+
+`Query<T>.groupBy(...fields)` accepts one or more field names. The
+result rows carry every grouped field (in declaration order) plus the
+reducer outputs:
+
+```ts
+.groupBy('clientId', 'period')
+.aggregate({ total: sum('amount') })
+// → [ { clientId: 'c1', period: '2026-05', total: 300 }, … ]
+```
+
+Inside `withMaterializedView({ query: db => … })`, multi-key groupBy
+works the same way. The MV consumer's `rowKey` callback receives the
+full row with every grouped field populated — encode the composite key
+however you like (`\`${a}|${b}\``, JSON, hash, …); the hub does not
+impose a canonical encoding.
+
+Cardinality thresholds (10k warn, 100k throw) apply on the count of
+distinct tuples, not on the count of fields. The warning message lists
+every grouped field name.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add features.yaml docs/subsystems/derivations.md
+git commit -m "docs(hub): multi-key groupBy feature entry + subsystem doc (#166)"
+```
+
+---
+
+## Task 7: PR 1 — final checks, push, open PR
+
+- [ ] **Step 1: Run full validation**
+
+Run: `pnpm turbo build && pnpm turbo lint --filter=@noy-db/hub && pnpm turbo typecheck && pnpm vitest run packages/hub && node scripts/check-architecture.mjs && node scripts/validate-features.mjs`
+Expected: all green.
+
+- [ ] **Step 2: Push branch**
+
+Run: `git push -u origin feat/dim14-mv-multikey-and-union`
+
+- [ ] **Step 3: Open PR for the multi-key half ONLY**
+
+Use a stacked-PR style: this PR is "PR 1" of three on the same branch. Title:
+
+```
+feat(hub): variadic Query.groupBy(...fields) — multi-key groupBy (#166)
+```
+
+Body should reference the spec, list the changed files, and note that PR 2 (#165 UNION MV) follows on the same branch.
+
+```bash
+gh pr create --title "feat(hub): variadic Query.groupBy(...fields) — multi-key groupBy (#166)" --body "$(cat <<'EOF'
+## Summary
+- Variadic `Query<T>.groupBy(...fields)` with back-compatible single-arg overload
+- `canonicalGroupKey` helper (reused by upcoming UNION MV PR)
+- MV strategies can use multi-key groupBy inside `query()`
+- One showcase + features.yaml entry + subsystem doc section
+
+Closes #166. Part of pre.15 cycle alongside #165 (UNION MV — follow-up PR on same branch) and #131 (variance cleanup — third PR on same branch).
+
+Spec: docs/superpowers/specs/2026-05-22-dim14-mv-multikey-and-union-design.md
+
+## Test plan
+- [ ] `pnpm vitest run packages/hub` passes 1573 + new tests
+- [ ] `pnpm turbo typecheck` clean
+- [ ] `node scripts/validate-features.mjs` clean
+- [ ] Showcase 71 runs green
+EOF
+)"
+```
+
+- [ ] **Step 4: Wait for PR 1 review/merge before continuing OR proceed on the same branch**
+
+Two options depending on the cycle's PR cadence:
+- **Sequential**: merge PR 1 to `main`, then rebase the branch on the merged `main` and continue PR 2. Cleaner history.
+- **Stacked**: continue PR 2 work on the same branch immediately; PR 2 PR target stays as `feat/dim14-mv-multikey-and-union` until PR 1 merges, then re-targets to `main`. Faster iteration.
+
+Document choice in the PR description. Default: **sequential** unless reviewer asks for stacked.
+
+---
+
+# PR 2 — #165 UNION MV (Option 1: `unionSources`)
+
+## Task 8: Add UNION MV types
+
+**Files:**
+- Modify: `packages/hub/src/materialized-views/types.ts`
+
+- [ ] **Step 1: Add `UnionSource` interface and extend `MaterializedViewStrategy`**
+
+In `packages/hub/src/materialized-views/types.ts`, after the existing `MaterializedFromMeta`/`MVQueryContext` declarations, add:
+
+```ts
+/**
+ * One arm of a UNION MV. Reads from `collection`, then maps each
+ * source row to the MV's row shape via `map`. Mandatory per-source
+ * `map` is the schema-unification boundary — sibling collections
+ * can have different schemas, and `map` is where they meet.
+ */
+export interface UnionSource<TRow extends Record<string, unknown>> {
+  /** Source collection name. Must exist in the vault. */
+  readonly collection: string
+  /**
+   * Pure function from a source row to the unified MV row shape.
+   * Called once per source row at materialization time.
+   *
+   * The function MUST return a row matching the strategy's `TRow`
+   * type parameter; both UNION arms' map outputs are concatenated
+   * before `groupBy` + `aggregate` run.
+   */
+  readonly map: (sourceRow: Record<string, unknown>) => TRow
+}
+```
+
+Extend `MaterializedViewStrategy<TRow>`:
+
+```ts
+export interface MaterializedViewStrategy<TRow extends Record<string, unknown>> {
+  name: string
+  /** Required for single-source MVs; mutually exclusive with `unionSources`. */
+  query?: (db: MVQueryContext) => Query<TRow>
+  /**
+   * UNION MV mode — read from multiple sibling collections.
+   * Mutually exclusive with `query`. Minimum two arms.
+   * Each arm contributes its `collection` to the dependency set and
+   * to the source-write hook reverse-index.
+   */
+  unionSources?: ReadonlyArray<UnionSource<TRow>>
+  /**
+   * Group-by clause for UNION MVs. Applied to the concatenated stream
+   * after every arm's `map` runs. Accepts a single field name or an
+   * array of field names (multi-key). Omit for pure UNION-without-aggregate.
+   *
+   * Ignored when `query` is set — single-source MVs express groupBy
+   * inside the query callback.
+   */
+  groupBy?: string | ReadonlyArray<string>
+  /**
+   * Aggregate spec for UNION MVs. Runs after `groupBy` partitions
+   * the concatenated stream. Ignored when `query` is set.
+   */
+  aggregate?: AggregateSpec<unknown>
+
+  rowKey: (row: TRow) => string
+  sources?: ReadonlyArray<string>
+  predicates?: { [name: string]: { hash: string; fn: (row: TRow, ctx?: unknown) => boolean } }
+  refresh?: 'eager' | 'lazy'
+  strict?: boolean
+  onEmpty?: 'tombstone' | 'keep'
+  maxRows?: number
+  // ... any other existing fields kept verbatim
+}
+```
+
+`AggregateSpec` is imported from `../aggregate/aggregation.js` (mirror existing imports in the same file).
+
+- [ ] **Step 2: Typecheck the package**
+
+Run: `pnpm turbo typecheck --filter=@noy-db/hub`
+Expected: 0 errors (no consumer uses the new fields yet — additive change).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/hub/src/materialized-views/types.ts
+git commit -m "feat(hub): UnionSource type + unionSources/groupBy/aggregate fields on MV strategy (#165)"
+```
+
+---
+
+## Task 9: Registration-time validation for `unionSources`
+
+**Files:**
+- Modify: `packages/hub/src/materialized-views/with-materialized-view.ts`
+- Modify: `packages/hub/src/errors.ts` (add `MaterializedViewConfigError` if not already present)
+
+- [ ] **Step 1: Add failing validation test**
+
+```ts
+// packages/hub/__tests__/materialized-views/union-validation.test.ts
+import { describe, it, expect } from 'vitest'
+import { withMaterializedView, MaterializedViewConfigError, sum } from '../../src/index.js'
+
+describe('withMaterializedView UNION validation (#165)', () => {
+  it('rejects strategy with both query and unionSources', () => {
+    expect(() => withMaterializedView({
+      name: 'bad',
+      query: () => null as any,
+      unionSources: [
+        { collection: 'a', map: r => r as any },
+        { collection: 'b', map: r => r as any },
+      ],
+      rowKey: () => 'k',
+    })).toThrow(MaterializedViewConfigError)
+  })
+
+  it('rejects unionSources with fewer than 2 arms', () => {
+    expect(() => withMaterializedView({
+      name: 'bad',
+      unionSources: [{ collection: 'a', map: r => r as any }],
+      rowKey: () => 'k',
+    })).toThrow(/at least 2/)
+  })
+
+  it('rejects unionSources with duplicate collection names', () => {
+    expect(() => withMaterializedView({
+      name: 'bad',
+      unionSources: [
+        { collection: 'a', map: r => r as any },
+        { collection: 'a', map: r => r as any },
+      ],
+      rowKey: () => 'k',
+    })).toThrow(/distinct collections/)
+  })
+
+  it('accepts a well-formed UNION strategy', () => {
+    expect(() => withMaterializedView<{ k: string; n: number }>({
+      name: 'good',
+      unionSources: [
+        { collection: 'a', map: (r: any) => ({ k: r.k, n: r.n }) },
+        { collection: 'b', map: (r: any) => ({ k: r.k, n: r.n }) },
+      ],
+      groupBy: 'k',
+      aggregate: { total: sum('n') },
+      rowKey: row => row.k,
+    })).not.toThrow()
+  })
+})
+```
+
+- [ ] **Step 2: Run test (expected: tests fail because validation not yet wired)**
+
+Run: `pnpm vitest run packages/hub/__tests__/materialized-views/union-validation.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Add `MaterializedViewConfigError` if missing**
+
+In `packages/hub/src/errors.ts`, ensure an error class exists (mirror existing MV errors like `MaterializedViewCycleError`):
+
+```ts
+export class MaterializedViewConfigError extends Error {
+  constructor(message: string) {
+    super(`[noy-db] withMaterializedView: ${message}`)
+    this.name = 'MaterializedViewConfigError'
+  }
+}
+```
+
+- [ ] **Step 4: Add validation in `withMaterializedView` factory**
+
+In `packages/hub/src/materialized-views/with-materialized-view.ts`, at the top of the factory body (before any handle construction):
+
+```ts
+import { MaterializedViewConfigError } from '../errors.js'
+
+export function withMaterializedView<TRow extends Record<string, unknown>>(
+  spec: MaterializedViewStrategy<TRow>,
+): MaterializedViewHandle<TRow> {
+  // --- BEGIN UNION validation ---
+  if (spec.query && spec.unionSources) {
+    throw new MaterializedViewConfigError(
+      'query and unionSources are mutually exclusive — pick one',
+    )
+  }
+  if (spec.unionSources) {
+    if (spec.unionSources.length < 2) {
+      throw new MaterializedViewConfigError(
+        'unionSources requires at least 2 source collections',
+      )
+    }
+    const seen = new Set<string>()
+    for (const s of spec.unionSources) {
+      if (seen.has(s.collection)) {
+        throw new MaterializedViewConfigError(
+          `unionSources must reference distinct collections (duplicate: \"${s.collection}\")`,
+        )
+      }
+      seen.add(s.collection)
+    }
+  }
+  if (!spec.query && !spec.unionSources) {
+    throw new MaterializedViewConfigError(
+      'strategy must declare either query or unionSources',
+    )
+  }
+  // --- END UNION validation ---
+
+  // ... existing factory body (handle construction, etc.) unchanged
+}
+```
+
+- [ ] **Step 5: Re-run validation tests**
+
+Run: `pnpm vitest run packages/hub/__tests__/materialized-views/union-validation.test.ts`
+Expected: PASS (4 cases).
+
+- [ ] **Step 6: Re-export `MaterializedViewConfigError` from the hub barrel**
+
+In `packages/hub/src/index.ts` (or whichever module exports MV errors), ensure `MaterializedViewConfigError` is re-exported alongside `MaterializedViewCycleError`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/hub/src/errors.ts \
+        packages/hub/src/materialized-views/with-materialized-view.ts \
+        packages/hub/src/index.ts \
+        packages/hub/__tests__/materialized-views/union-validation.test.ts
+git commit -m "feat(hub): registration-time validation for unionSources (#165)"
+```
+
+---
+
+## Task 10: Dep-analyzer shortcut for `unionSources`
+
+**Files:**
+- Modify: `packages/hub/src/materialized-views/registry.ts` (around the analyzer call site, register method body)
+- Modify: `packages/hub/src/materialized-views/dependency-analyzer.ts` (if needed)
+
+The registry's `register` method today calls `analyzeDependencies(q)` on the query plan. For UNION MVs, skip the AST walk and read collections directly off `unionSources`.
+
+- [ ] **Step 1: Locate the dependency derivation in `registry.ts`**
+
+Open `packages/hub/src/materialized-views/registry.ts` and find the block (around lines 67–105 per the existing implementation) that derives `dependencies: Set<string>`:
+
+```ts
+// Existing code shape (approximate):
+const q = spec.query(mvQueryContext)
+let dependencies: Set<string>
+try {
+  dependencies = analyzeDependencies(q)
+  if (spec.sources) for (const s of spec.sources) dependencies.add(s)
+} catch (err) {
+  if (!spec.sources) throw err
+  dependencies = new Set(spec.sources)
+}
+```
+
+- [ ] **Step 2: Branch on `unionSources`**
+
+Add an early branch BEFORE the existing query-form dependency derivation:
+
+```ts
+let dependencies: Set<string>
+let queryPlanSummary: string
+
+if (spec.unionSources) {
+  // UNION form — dependencies are the explicit arms.
+  dependencies = new Set(spec.unionSources.map(s => s.collection))
+  // No query plan to summarise; queryHash inputs use a synthetic plan.
+  queryPlanSummary = summarizeUnionPlan(spec)
+} else {
+  // existing query-form branch — unchanged
+  const q = spec.query!(mvQueryContext)
+  try {
+    dependencies = analyzeDependencies(q)
+    if (spec.sources) for (const s of spec.sources) dependencies.add(s)
+  } catch (err) {
+    if (!spec.sources) throw err
+    dependencies = new Set(spec.sources)
+  }
+  queryPlanSummary = summarizeQueryPlan(q)
+}
+```
+
+- [ ] **Step 3: Add `summarizeUnionPlan` helper**
+
+In `packages/hub/src/materialized-views/dependency-analyzer.ts`, alongside `summarizeQueryPlan`:
+
+```ts
+import type { MaterializedViewStrategy } from './types.js'
+
+/**
+ * Canonical string description of a UNION MV's plan, used as input
+ * to `computeQueryHash`. Includes every arm's collection name (sorted
+ * for determinism), the groupBy fields (sorted), and the aggregate
+ * spec keys (sorted) — enough that any structural change forces a
+ * fresh queryHash on next visit.
+ *
+ * Per-arm `map` callbacks are NOT fingerprinted (they're function
+ * identity; consumers must explicitly invalidate via name/version
+ * bump if they change map semantics in a non-equivalent way).
+ */
+export function summarizeUnionPlan<T extends Record<string, unknown>>(
+  spec: MaterializedViewStrategy<T>,
+): string {
+  const arms = [...(spec.unionSources ?? [])]
+    .map(s => s.collection)
+    .sort()
+    .join(',')
+  const groupBy = Array.isArray(spec.groupBy)
+    ? [...spec.groupBy].sort().join(',')
+    : spec.groupBy ?? ''
+  const aggKeys = spec.aggregate ? Object.keys(spec.aggregate).sort().join(',') : ''
+  return `union(${arms})|groupBy(${groupBy})|aggregate(${aggKeys})`
+}
+```
+
+- [ ] **Step 4: Adapt `register()` so the `q` variable is only used in the `query` branch**
+
+The existing code probably calls `spec.query(mvQueryContext)` unconditionally — wrap that call inside the `else` branch as shown in Step 2 so UNION strategies don't fail when `spec.query` is undefined.
+
+- [ ] **Step 5: Run all MV tests**
+
+Run: `pnpm vitest run packages/hub/__tests__/materialized-views`
+Expected: pre.14 + multikey tests still pass. UNION MV tests still fail (executor not yet wired — next task).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/materialized-views/registry.ts \
+        packages/hub/src/materialized-views/dependency-analyzer.ts
+git commit -m "feat(hub): MV registry recognises unionSources for dep analysis (#165)"
+```
+
+---
+
+## Task 11: Executor branch for `unionSources`
+
+**Files:**
+- Modify: `packages/hub/src/materialized-views/executor.ts`
+
+The executor's `materializeQueryResult` (around line 47 per the grep above) drives a single `Query` plan. UNION needs a sibling path that reads each arm, maps, concatenates, then runs groupBy + aggregate.
+
+- [ ] **Step 1: Add failing UNION executor test (basic 2-source UNION + groupBy)**
+
+```ts
+// packages/hub/__tests__/materialized-views/union.test.ts
+import { describe, it, expect } from 'vitest'
+import { withMaterializedView, sum } from '../../src/index.js'
+import { createTestVault } from '../helpers/test-vault.js'
+
+describe('UNION MV — basic 2-source (#165)', () => {
+  it('reads from both arms, maps, groupBy, aggregate', async () => {
+    const vault = await createTestVault({
+      collections: ['taxReceipts', 'creditNotes', 'monthlyVat'],
+      strategies: [
+        withMaterializedView<{ period: string; vat: number }>({
+          name: 'monthlyVat',
+          unionSources: [
+            { collection: 'taxReceipts', map: (r: any) => ({ period: r.issuedAt.slice(0, 7), vat:  r.paidServicesVat }) },
+            { collection: 'creditNotes', map: (r: any) => ({ period: r.issuedAt.slice(0, 7), vat: -r.paidServicesVat }) },
+          ],
+          groupBy: 'period',
+          aggregate: { vat: sum('vat') },
+          rowKey: row => row.period,
+          refresh: 'eager',
+        }),
+      ],
+    })
+
+    const receipts = vault.collection<{ id: string; issuedAt: string; paidServicesVat: number }>('taxReceipts')
+    const notes = vault.collection<{ id: string; issuedAt: string; paidServicesVat: number }>('creditNotes')
+
+    await receipts.put({ id: 'r1', issuedAt: '2026-05-15', paidServicesVat: 100 })
+    await receipts.put({ id: 'r2', issuedAt: '2026-05-20', paidServicesVat: 50 })
+    await notes.put({ id: 'n1', issuedAt: '2026-05-25', paidServicesVat: 30 })
+
+    const out = vault.collection<{ period: string; vat: number }>('monthlyVat')
+    const rows = await out.query().toArray()
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.period).toBe('2026-05')
+    expect(rows[0]!.vat).toBe(120) // 100 + 50 - 30
+  })
+
+  it('refreshes on writes to either arm independently', async () => {
+    const vault = await createTestVault({
+      collections: ['a', 'b', 'totals'],
+      strategies: [
+        withMaterializedView<{ k: string; n: number }>({
+          name: 'totals',
+          unionSources: [
+            { collection: 'a', map: (r: any) => ({ k: r.k, n: r.n }) },
+            { collection: 'b', map: (r: any) => ({ k: r.k, n: r.n }) },
+          ],
+          groupBy: 'k',
+          aggregate: { total: sum('n') },
+          rowKey: row => row.k,
+          refresh: 'eager',
+        }),
+      ],
+    })
+    const a = vault.collection<{ id: string; k: string; n: number }>('a')
+    const b = vault.collection<{ id: string; k: string; n: number }>('b')
+
+    await a.put({ id: 'a1', k: 'x', n: 1 })
+    let rows = await vault.collection<any>('totals').query().toArray()
+    expect(rows.find((r: any) => r.k === 'x')!.total).toBe(1)
+
+    await b.put({ id: 'b1', k: 'x', n: 10 })
+    rows = await vault.collection<any>('totals').query().toArray()
+    expect(rows.find((r: any) => r.k === 'x')!.total).toBe(11)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `pnpm vitest run packages/hub/__tests__/materialized-views/union.test.ts`
+Expected: FAIL — executor still routes through `query` callback which is undefined.
+
+- [ ] **Step 3: Branch executor on strategy form**
+
+In `packages/hub/src/materialized-views/executor.ts`, identify the entry point (likely `materializeQueryResult` or whatever the registry calls when it needs to materialize). Add a sibling `materializeUnionResult`:
+
+```ts
+import { groupAndReduce } from '../aggregate/groupby.js'
+import { runReducer } from '../aggregate/aggregation.js' // existing helper for non-grouped aggregate
+import type { MaterializedViewStrategy, UnionSource } from './types.js'
+
+async function materializeUnionResult<TRow extends Record<string, unknown>>(
+  spec: MaterializedViewStrategy<TRow>,
+  db: MVQueryContext,
+): Promise<TRow[]> {
+  const unified: TRow[] = []
+  for (const arm of spec.unionSources!) {
+    const coll = db.collection<Record<string, unknown>>(arm.collection)
+    const sourceRows = await coll.query().toArray()
+    for (const r of sourceRows) {
+      unified.push(arm.map(r))
+    }
+  }
+
+  // No groupBy → emit unified rows as-is
+  if (!spec.groupBy) return unified
+
+  const groupFields: readonly string[] =
+    typeof spec.groupBy === 'string' ? [spec.groupBy] : spec.groupBy
+
+  if (!spec.aggregate) {
+    // groupBy without aggregate: dedup by composite key, keep first.
+    // Rare consumer pattern but well-defined.
+    const seen = new Map<string, TRow>()
+    for (const row of unified) {
+      const k = canonicalGroupKey(groupFields, row as Record<string, unknown>)
+      if (!seen.has(k)) seen.set(k, row)
+    }
+    return [...seen.values()]
+  }
+
+  // groupBy + aggregate: reuse the shared groupAndReduce
+  return groupAndReduce<TRow>(unified, groupFields, spec.aggregate)
+}
+```
+
+Import `canonicalGroupKey` from `../aggregate/canonical-key.js`.
+
+- [ ] **Step 4: Dispatch on strategy form at the executor's entry point**
+
+Locate the function the registry calls to drive materialisation (likely `materializeQueryResult` or a public `runMaterialization`). Add a branch:
+
+```ts
+export async function runMaterialization<TRow extends Record<string, unknown>>(
+  spec: MaterializedViewStrategy<TRow>,
+  db: MVQueryContext,
+): Promise<TRow[]> {
+  if (spec.unionSources) {
+    return materializeUnionResult(spec, db)
+  }
+  // existing query-form path
+  return materializeQueryResult(spec, db)
+}
+```
+
+If the existing executor entry has a different name, wrap it the same way. The key constraint: every existing call site that drives MV materialization must funnel through the dispatcher.
+
+- [ ] **Step 5: Wire UNION refresh to source-write hooks**
+
+The registry already populates `dependencies` for UNION MVs (Task 10). The source-write hook (`Collection.put`) reads `registry.findMvsForCollection(coll)` (or whatever the existing function name is — `grep` for `dependencies.has` and `mvs.filter`) to find MVs to refresh. UNION MVs are now visible to that lookup because both arm collections are in their `dependencies` set. NO additional plumbing should be needed.
+
+Verify by examining how the source-write hook iterates MVs today. If it walks `registry.iterMVs()` and filters by `reg.dependencies.has(writtenCollection)`, no change needed. If it has a separate single-source fast path, generalise it.
+
+- [ ] **Step 6: Run UNION executor tests**
+
+Run: `pnpm vitest run packages/hub/__tests__/materialized-views/union.test.ts`
+Expected: PASS (both basic tests).
+
+- [ ] **Step 7: Run full MV test suite**
+
+Run: `pnpm vitest run packages/hub/__tests__/materialized-views`
+Expected: all green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/hub/src/materialized-views/executor.ts \
+        packages/hub/__tests__/materialized-views/union.test.ts
+git commit -m "feat(hub): UNION MV executor — reads multiple arms, maps, groups, aggregates (#165)"
+```
+
+---
+
+## Task 12: UNION + multi-key composition test (the niwat canonical shape)
+
+**Files:**
+- Modify: `packages/hub/__tests__/materialized-views/union.test.ts`
+
+- [ ] **Step 1: Add the composite test**
+
+Append to `union.test.ts`:
+
+```ts
+describe('UNION MV — combined with multi-key groupBy (#165 + #166)', () => {
+  it('niwat canonical monthly-VAT shape: union(taxReceipts, creditNotes) + groupBy(clientId, period)', async () => {
+    const vault = await createTestVault({
+      collections: ['taxReceipts', 'creditNotes', 'monthlyOutputVat'],
+      strategies: [
+        withMaterializedView<{ clientId: string; period: string; vat: number }>({
+          name: 'monthlyOutputVat',
+          unionSources: [
+            { collection: 'taxReceipts', map: (r: any) => ({ clientId: r.clientId, period: r.issuedAt.slice(0, 7), vat:  r.paidServicesVat }) },
+            { collection: 'creditNotes', map: (r: any) => ({ clientId: r.clientId, period: r.issuedAt.slice(0, 7), vat: -r.paidServicesVat }) },
+          ],
+          groupBy: ['clientId', 'period'],
+          aggregate: { vat: sum('vat') },
+          rowKey: row => `${row.clientId}|${row.period}`,
+          refresh: 'eager',
+        }),
+      ],
+    })
+
+    const receipts = vault.collection<any>('taxReceipts')
+    const notes = vault.collection<any>('creditNotes')
+
+    await receipts.put({ id: 'r1', clientId: 'c1', issuedAt: '2026-05-01', paidServicesVat: 100 })
+    await receipts.put({ id: 'r2', clientId: 'c1', issuedAt: '2026-05-15', paidServicesVat: 50 })
+    await receipts.put({ id: 'r3', clientId: 'c2', issuedAt: '2026-05-10', paidServicesVat: 70 })
+    await notes.put({ id: 'n1', clientId: 'c1', issuedAt: '2026-05-20', paidServicesVat: 20 })
+
+    const out = vault.collection<{ clientId: string; period: string; vat: number }>('monthlyOutputVat')
+    const rows = await out.query().toArray()
+    expect(rows).toHaveLength(2)
+    const c1May = rows.find(r => r.clientId === 'c1' && r.period === '2026-05')!
+    expect(c1May.vat).toBe(130) // 100 + 50 - 20
+    const c2May = rows.find(r => r.clientId === 'c2' && r.period === '2026-05')!
+    expect(c2May.vat).toBe(70)
+  })
+})
+```
+
+- [ ] **Step 2: Run the new test**
+
+Run: `pnpm vitest run packages/hub/__tests__/materialized-views/union.test.ts -t "niwat canonical"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/hub/__tests__/materialized-views/union.test.ts
+git commit -m "test(hub): UNION + multi-key composition (niwat monthly-VAT shape) (#165 + #166)"
+```
+
+---
+
+## Task 13: Edge-case UNION tests (3-source, onEmpty, strict, maxRows)
+
+**Files:**
+- Modify: `packages/hub/__tests__/materialized-views/union.test.ts`
+
+- [ ] **Step 1: Add edge tests**
+
+```ts
+describe('UNION MV — edges', () => {
+  it('three-source UNION sums correctly', async () => {
+    const vault = await createTestVault({
+      collections: ['a', 'b', 'c', 'totals'],
+      strategies: [
+        withMaterializedView<{ k: string; n: number }>({
+          name: 'totals',
+          unionSources: [
+            { collection: 'a', map: (r: any) => ({ k: r.k, n: r.n }) },
+            { collection: 'b', map: (r: any) => ({ k: r.k, n: r.n }) },
+            { collection: 'c', map: (r: any) => ({ k: r.k, n: r.n }) },
+          ],
+          groupBy: 'k',
+          aggregate: { total: sum('n') },
+          rowKey: row => row.k,
+          refresh: 'eager',
+        }),
+      ],
+    })
+    await vault.collection<any>('a').put({ id: '1', k: 'x', n: 1 })
+    await vault.collection<any>('b').put({ id: '1', k: 'x', n: 2 })
+    await vault.collection<any>('c').put({ id: '1', k: 'x', n: 4 })
+
+    const rows = await vault.collection<any>('totals').query().toArray()
+    expect(rows[0]!.total).toBe(7)
+  })
+
+  it('onEmpty: tombstone removes the MV row when all contributing source rows are deleted', async () => {
+    const vault = await createTestVault({
+      collections: ['a', 'b', 'totals'],
+      strategies: [
+        withMaterializedView<{ k: string; n: number }>({
+          name: 'totals',
+          unionSources: [
+            { collection: 'a', map: (r: any) => ({ k: r.k, n: r.n }) },
+            { collection: 'b', map: (r: any) => ({ k: r.k, n: r.n }) },
+          ],
+          groupBy: 'k',
+          aggregate: { total: sum('n') },
+          rowKey: row => row.k,
+          refresh: 'eager',
+          onEmpty: 'tombstone',
+        }),
+      ],
+    })
+    const a = vault.collection<any>('a')
+    const b = vault.collection<any>('b')
+    await a.put({ id: '1', k: 'x', n: 1 })
+    await b.put({ id: '1', k: 'x', n: 2 })
+
+    let rows = await vault.collection<any>('totals').query().toArray()
+    expect(rows).toHaveLength(1)
+
+    await a.delete('1')
+    await b.delete('1')
+    rows = await vault.collection<any>('totals').query().toArray()
+    expect(rows).toHaveLength(0)
+  })
+
+  // Add similar tests for strict-mode rollback and maxRows enforcement
+  // if the existing single-source MV tests cover those — copy-adapt them.
+})
+```
+
+- [ ] **Step 2: Run edge tests**
+
+Run: `pnpm vitest run packages/hub/__tests__/materialized-views/union.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/hub/__tests__/materialized-views/union.test.ts
+git commit -m "test(hub): UNION MV edges (3-source, onEmpty tombstone) (#165)"
+```
+
+---
+
+## Task 14: UNION MV showcase
+
+**Files:**
+- Create: `showcases/src/<next-N>-with-union-mv.showcase.test.ts`
+
+- [ ] **Step 1: Write showcase**
+
+Mirror the multi-key showcase pattern, e.g.:
+
+```ts
+/**
+ * Showcase 72 — UNION MV
+ *
+ * What you'll learn
+ * ─────────────────
+ * Read from two sibling collections and aggregate across both in one
+ * materialized view, via `unionSources`. Per-source `map` is the
+ * schema-unification boundary; `groupBy` + `aggregate` run on the
+ * concatenated stream.
+ *
+ * Why it matters
+ * ──────────────
+ * Many real-world roll-ups span more than one source collection: a
+ * monthly VAT obligation that combines tax receipts and credit notes,
+ * a per-tenant audit feed merging multiple log shapes, a unified
+ * reporting view over two structurally-similar tables. Without UNION
+ * MV, consumers maintain two parallel MVs and sum at read time —
+ * defeating the "no imperative transforms outside primitives" rule.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 70 (withMaterializedView basics)
+ * - Showcase 71 (multi-key groupBy)
+ *
+ * What to read next
+ * ─────────────────
+ *   - docs/subsystems/derivations.md (UNION sources section)
+ */
+import { describe, it, expect } from 'vitest'
+import { createMemoryVault, withMaterializedView, sum } from '@noy-db/hub'
+
+describe('Showcase 72 — UNION MV', () => {
+  it('monthly VAT = sum(taxReceipts.vat) - sum(creditNotes.vat)', async () => {
+    const vault = await createMemoryVault({
+      strategies: [
+        withMaterializedView<{ period: string; vat: number }>({
+          name: 'monthlyVat',
+          unionSources: [
+            { collection: 'taxReceipts', map: (r: any) => ({ period: r.issuedAt.slice(0, 7), vat:  r.vatAmount }) },
+            { collection: 'creditNotes', map: (r: any) => ({ period: r.issuedAt.slice(0, 7), vat: -r.vatAmount }) },
+          ],
+          groupBy: 'period',
+          aggregate: { vat: sum('vat') },
+          rowKey: row => row.period,
+          refresh: 'eager',
+        }),
+      ],
+    })
+
+    const receipts = vault.collection<any>('taxReceipts')
+    const notes = vault.collection<any>('creditNotes')
+    await receipts.put({ id: 'r1', issuedAt: '2026-05-15', vatAmount: 100 })
+    await receipts.put({ id: 'r2', issuedAt: '2026-05-20', vatAmount: 50 })
+    await notes.put({ id: 'n1', issuedAt: '2026-05-25', vatAmount: 30 })
+
+    const rows = await vault.collection<any>('monthlyVat').query().toArray()
+    expect(rows[0]!.vat).toBe(120)
+  })
+})
+```
+
+Adjust `createMemoryVault` / vault bootstrap to match existing showcase conventions.
+
+- [ ] **Step 2: Run showcase**
+
+Run: `pnpm vitest run showcases/src/72-with-union-mv.showcase.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add showcases/src/72-with-union-mv.showcase.test.ts
+git commit -m "showcase(hub): UNION MV walkthrough (#165)"
+```
+
+---
+
+## Task 15: Docs + features.yaml for UNION MV
+
+**Files:**
+- Modify: `features.yaml`
+- Modify: `docs/subsystems/derivations.md` (or wherever MV is documented)
+
+- [ ] **Step 1: Add `mv-union-sources` entry to `features.yaml`**
+
+```yaml
+- id: mv-union-sources
+  package: '@noy-db/hub'
+  title: UNION materialized views
+  summary: Read from multiple sibling collections in one MV via `unionSources: [{ collection, map }, ...]`. Per-source `map` unifies row shapes; `groupBy` + `aggregate` run on the concatenated stream.
+  since: 0.1.0-pre.15
+  status: stable
+  showcase: 72-with-union-mv
+  subsystem: derived-data
+```
+
+- [ ] **Step 2: Add "UNION sources" section to subsystem doc**
+
+```md
+### UNION sources
+
+A materialized view can read from MULTIPLE sibling collections in one
+declaration via `unionSources`:
+
+```ts
+withMaterializedView<{ period: string; vat: number }>({
+  name: 'monthlyVat',
+  unionSources: [
+    { collection: 'taxReceipts', map: r => ({ period: r.issuedAt.slice(0, 7), vat:  r.vatAmount }) },
+    { collection: 'creditNotes', map: r => ({ period: r.issuedAt.slice(0, 7), vat: -r.vatAmount }) },
+  ],
+  groupBy: 'period',
+  aggregate: { vat: sum('vat') },
+  rowKey: row => row.period,
+  refresh: 'eager',
+})
+```
+
+**Mutually exclusive with `query`** — a strategy uses one or the other.
+Multi-arm UNION requires at least 2 entries; duplicate collection names
+are rejected at registration.
+
+**Per-source `map` is the schema-unification boundary.** The two source
+collections may have different schemas; each arm's `map` projects to the
+MV's row shape (the strategy's type parameter), and the executor concats
+the mapped rows before `groupBy` + `aggregate` run.
+
+**Source-write hooks fire on every arm.** A write to ANY collection in
+`unionSources` re-fires the MV refresh path.
+
+**Composes with multi-key groupBy.** UNION arms can roll up to a composite
+key — the canonical niwat monthly-VAT MV groups by `['clientId', 'period']`.
+```
+
+- [ ] **Step 3: Validate features.yaml**
+
+Run: `node scripts/validate-features.mjs`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add features.yaml docs/subsystems/derivations.md
+git commit -m "docs(hub): UNION MV feature entry + subsystem section (#165)"
+```
+
+---
+
+## Task 16: PR 2 — final checks, push, open PR
+
+- [ ] **Step 1: Full validation**
+
+Run: `pnpm turbo build && pnpm turbo lint --filter=@noy-db/hub && pnpm turbo typecheck && pnpm vitest run packages/hub && node scripts/check-architecture.mjs && node scripts/validate-features.mjs && pnpm vitest run showcases`
+Expected: all green.
+
+- [ ] **Step 2: Push**
+
+Run: `git push`
+
+- [ ] **Step 3: Open PR 2**
+
+```bash
+gh pr create --title "feat(hub): UNION MV via unionSources field — withMaterializedView reads multiple sibling collections (#165)" --body "$(cat <<'EOF'
+## Summary
+- New `unionSources: [{ collection, map }, ...]` field on `withMaterializedView`
+- Per-source `map` callback is the schema-unification boundary
+- Mutually exclusive with `query`; minimum 2 arms; distinct collection names
+- Source-write hook fires on every arm via the existing dependency tracker
+- Composes with multi-key `groupBy` (PR 1) — niwat monthly-VAT shape included as test + showcase
+
+Closes #165. Builds on PR 1 (#166 multi-key groupBy) — same branch, same release cycle (pre.15).
+
+Spec: docs/superpowers/specs/2026-05-22-dim14-mv-multikey-and-union-design.md
+
+## Test plan
+- [ ] UNION 2-source + 3-source basics pass
+- [ ] UNION + multi-key composition (niwat monthly-VAT shape) passes
+- [ ] Validation tests reject malformed strategies (both query+union, <2 arms, duplicate collection)
+- [ ] onEmpty: tombstone correctly removes rows when all sources delete
+- [ ] Showcase 72 runs green
+EOF
+)"
+```
+
+---
+
+# PR 3 — #131 GuardStrategyHandle variance cleanup
+
+## Task 17: Locate the two `any` annotations
+
+**Files:**
+- Read: `packages/hub/src/vault.ts:334`
+- Read: `packages/hub/src/types.ts:1748`
+
+- [ ] **Step 1: Confirm the two annotations are still at the documented locations**
+
+Run: `grep -n "GuardStrategyHandle<any>" packages/hub/src/vault.ts packages/hub/src/types.ts`
+Expected output: two matches near the documented lines.
+
+- [ ] **Step 2: Read each call site for surrounding context**
+
+Read each file at the matching line ±10. Confirm the field is `guardStrategies?: ReadonlyArray<GuardStrategyHandle<any>>` in both, with an `eslint-disable-next-line @typescript-eslint/no-explicit-any` comment above.
+
+---
+
+## Task 18: Define an existential `GuardStrategyHandleAny` type
+
+**Files:**
+- Modify: `packages/hub/src/guards/types.ts`
+
+- [ ] **Step 1: Add the existential type**
+
+In `packages/hub/src/guards/types.ts`, AFTER the `GuardStrategyHandle<T>` interface:
+
+```ts
+/**
+ * Existential erasure of `GuardStrategyHandle<T>` — used as the
+ * element type of `ReadonlyArray<>` fields where T differs per entry.
+ *
+ * TS has no first-class existentials, but a structurally narrow shape
+ * that only exposes the discriminant + the (now type-erased) spec is
+ * a safe public-API surface:
+ *
+ * - Callers pass `GuardStrategyHandle<Invoice>` and `GuardStrategyHandle<Disbursement>`
+ *   into an array typed as `GuardStrategyHandleAny[]`. Both assign because
+ *   their structural shape (discriminant + spec object) widens to this
+ *   erased form.
+ * - Internals that need T re-narrow via the runtime discriminant + the
+ *   registry's per-handle type information.
+ *
+ * NOT exported from the public consumer barrel — the construction of
+ * a handle still goes through `withGuard<T>()` which returns the
+ * typed `GuardStrategyHandle<T>`. This shape is only the array-element
+ * existential.
+ */
+export interface GuardStrategyHandleAny {
+  readonly __noydb_strategy: 'guard'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly spec: GuardStrategy<any>
+}
+```
+
+The single internal `any` here is acceptable per the issue's framing — it's behind a private existential boundary, not on a public API field. (If the reviewer pushes back even here, the alternative is `GuardStrategy<Record<string, unknown>>` — confirm assignment from `GuardStrategy<Invoice>` typechecks before swapping.)
+
+- [ ] **Step 2: Re-export from the guards barrel if appropriate**
+
+In `packages/hub/src/guards/index.ts`, decide whether to export `GuardStrategyHandleAny`. Prefer KEEPING IT INTERNAL to discourage consumers from constructing it directly. If `vault.ts` or `types.ts` need to import it, use a relative path from the guards subdirectory.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/hub/src/guards/types.ts packages/hub/src/guards/index.ts
+git commit -m "feat(hub): GuardStrategyHandleAny existential — array-element type for guard strategies (#131)"
+```
+
+---
+
+## Task 19: Replace the two `any` annotations
+
+**Files:**
+- Modify: `packages/hub/src/vault.ts` (line 334 area)
+- Modify: `packages/hub/src/types.ts` (line 1748 area)
+
+- [ ] **Step 1: Replace in `types.ts`**
+
+Find the line:
+
+```ts
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  guardStrategies?: ReadonlyArray<GuardStrategyHandle<any>>
+```
+
+Replace with:
+
+```ts
+  guardStrategies?: ReadonlyArray<GuardStrategyHandleAny>
+```
+
+Update the import at the top of the file to include `GuardStrategyHandleAny`.
+
+- [ ] **Step 2: Replace in `vault.ts`**
+
+Same swap, same comment removal, update import.
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `pnpm turbo typecheck --filter=@noy-db/hub`
+Expected: 0 errors. If errors appear, they're in code that previously relied on the `any` widening — narrow those call sites by reading the runtime discriminant before re-typing the spec.
+
+- [ ] **Step 4: Run the guards test suite**
+
+Run: `pnpm vitest run packages/hub/__tests__/guards`
+Expected: all pre.14 guards tests pass unchanged (this is a type-only refactor; runtime is identical).
+
+- [ ] **Step 5: Run showcase 79 specifically (the issue calls it out as the back-compat target)**
+
+Run: `pnpm vitest run showcases/src/*guards*` (or grep for showcase 79's filename and run it directly)
+Expected: PASS.
+
+- [ ] **Step 6: Confirm no new `any` introduced**
+
+Run: `grep -nE "any\b" packages/hub/src/vault.ts packages/hub/src/types.ts | grep -i guard`
+Expected: no matches.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/hub/src/vault.ts packages/hub/src/types.ts
+git commit -m "refactor(hub): remove public-API any from guardStrategies via GuardStrategyHandleAny (#131)"
+```
+
+---
+
+## Task 20: PR 3 — final checks, push, open PR
+
+- [ ] **Step 1: Full validation**
+
+Run: `pnpm turbo build && pnpm turbo lint && pnpm turbo typecheck && pnpm vitest run packages/hub`
+Expected: all green.
+
+- [ ] **Step 2: Push**
+
+Run: `git push`
+
+- [ ] **Step 3: Open PR 3**
+
+```bash
+gh pr create --title "refactor(hub): GuardStrategyHandle type-variance cleanup — remove public-API any (#131)" --body "$(cat <<'EOF'
+## Summary
+- New `GuardStrategyHandleAny` existential type as the array-element type for `guardStrategies` arrays
+- Removed two `eslint-disable-next-line @typescript-eslint/no-explicit-any` annotations on public-API fields (`vault.ts:334` and `types.ts:1748`)
+- Type-only refactor; no behaviour change
+
+Closes #131. Third PR of the pre.15 cycle (alongside #165 UNION MV and #166 multi-key groupBy).
+
+## Test plan
+- [ ] All hub tests pass unchanged
+- [ ] Showcase 79 (guards) type-checks and runs unchanged
+- [ ] No new `any` introduced (grep clean)
+EOF
+)"
+```
+
+---
+
+# Cycle wrap-up
+
+## Task 21: Final integration check on all three PRs merged
+
+After all three PRs merge to `main`:
+
+- [ ] **Step 1: Sync local main**
+
+Run: `git checkout main && git fetch && git reset --hard origin/main`
+
+- [ ] **Step 2: Verify pre.15 readiness**
+
+Run: `pnpm install && pnpm turbo build && pnpm vitest run && node scripts/check-architecture.mjs && node scripts/validate-features.mjs`
+Expected: all green; new tests count = 1573 + (PR1 new) + (PR2 new); 2 new features in `features.yaml`.
+
+- [ ] **Step 3: Update ROADMAP.md with pre.15 entry**
+
+Add a pre.15 milestone entry pointing at the three closed issues and the spec doc. Follow the existing pre.14 entry's shape.
+
+- [ ] **Step 4: Commit roadmap update**
+
+```bash
+git checkout -b chore/roadmap-pre.15
+# edit ROADMAP.md
+git add ROADMAP.md
+git commit -m "docs: add pre.15 roadmap entry (multi-key groupBy + UNION MV + guards variance)"
+git push -u origin chore/roadmap-pre.15
+gh pr create --title "docs: ROADMAP pre.15 entry" --body "Adds pre.15 milestone summary (#165, #166, #131)."
+```
+
+- [ ] **Step 5: When that PR merges — coordinate the 0.1.0-pre.15 release**
+
+This step is the user's call, NOT an agent action. The release workflow per the `project_release_workflow` memory is: manual lockstep bump, GitHub Release `published` event triggers `release.yml`, full SHA in `gh release create --target`. Do not initiate without explicit user confirmation (the `feedback_no_publish_without_explicit_confirmation` memory applies).
+
+---
+
+# Self-review notes (from plan author)
+
+**Spec coverage check** — every acceptance bullet from the spec maps to a task:
+
+- §#166 multi-key groupBy acceptance: Task 1 (canonicalGroupKey), Task 2 (failing tests), Task 3 (variadic overload + execution), Task 4 (MV plumbing), Task 5 (showcase), Task 6 (docs)
+- §#165 UNION MV acceptance: Task 8 (types), Task 9 (validation), Task 10 (dep analyzer), Task 11 (executor), Task 12 (composition with #166), Task 13 (edges), Task 14 (showcase), Task 15 (docs)
+- §#131 GuardStrategyHandle acceptance: Task 17 (locate), Task 18 (existential), Task 19 (swap + verify)
+- Cross-cutting (1573+N tests, features.yaml, subsystem doc, ROADMAP): Tasks 6, 15, 21
+
+**Placeholder scan** — no "TBD"/"TODO"/"similar to" in the plan. The "N" in showcase numbering is explicitly resolved at Task 5 step 1 / Task 14 step 1 via `ls`.
+
+**Type consistency check** — `canonicalGroupKey(fields, row)` signature stable across Task 1 (definition), Task 3 (consumed by groupAndReduce), Task 11 (consumed by materializeUnionResult). `UnionSource<TRow>` shape stable across Task 8 (definition), Task 9 (validation), Task 10 (dep analyzer), Task 11 (executor). `GuardStrategyHandleAny` shape stable across Task 18 (definition), Task 19 (use).
+
+**Files-touched matrix (for reviewer convenience):**
+
+| Layer | PR 1 (#166) | PR 2 (#165) | PR 3 (#131) |
+|---|---|---|---|
+| `packages/hub/src/aggregate/` | canonical-key.ts (new), groupby.ts, strategy.ts, index.ts | — | — |
+| `packages/hub/src/query/` | builder.ts | — | — |
+| `packages/hub/src/materialized-views/` | dependency-analyzer.ts | types.ts, with-materialized-view.ts, registry.ts, dependency-analyzer.ts, executor.ts | — |
+| `packages/hub/src/errors.ts` | — | MaterializedViewConfigError added | — |
+| `packages/hub/src/guards/` | — | — | types.ts, index.ts |
+| `packages/hub/src/vault.ts` | — | — | line ~334 |
+| `packages/hub/src/types.ts` | — | — | line ~1748 |
+| `packages/hub/__tests__/` | aggregate-canonical-key.test.ts (new), query-groupby.test.ts, materialized-views/multikey.test.ts (new) | materialized-views/union*.test.ts (new × 2) | — |
+| `showcases/src/` | 71-with-multikey-groupby.showcase.test.ts (new) | 72-with-union-mv.showcase.test.ts (new) | — |
+| `features.yaml` | mv-multikey-groupby entry | mv-union-sources entry | — |
+| `docs/subsystems/derivations.md` | Multi-key section | UNION sources section | — |

--- a/docs/superpowers/specs/2026-05-22-dim14-mv-multikey-and-union-design.md
+++ b/docs/superpowers/specs/2026-05-22-dim14-mv-multikey-and-union-design.md
@@ -1,0 +1,253 @@
+# Dimension 14 (derived data) — multi-key groupBy + UNION MV design
+
+> Extends the pre.14 `withMaterializedView` design ([`2026-05-20-dim14-mv-v2-design.md`](./2026-05-20-dim14-mv-v2-design.md)) along two orthogonal-but-composable axes opened by the niwat refactor: variadic `groupBy(...fields)` and reading from multiple sibling source collections via `unionSources`. Targets the pre.15 release.
+
+## Goal
+
+Land two MV-adjacent features in `@noy-db/hub` that together unblock niwat's monthly-VAT and per-(client, period) roll-up MVs:
+
+1. **Multi-key `groupBy` (`#166`).** Variadic `Query<T>.groupBy(...fields)` and the matching `withMaterializedView` `groupBy: string | string[]` field. One row per composite key, with every grouped field stamped onto the row.
+2. **UNION MV (`#165`, Option 1).** A `unionSources: [{ collection, map }, ...]` field on `withMaterializedView` that reads from multiple sibling collections, unifies their row shapes via per-source `map`, then runs `groupBy` + `aggregate` on the concatenated stream.
+
+Plus one pre.14 cleanup that rides along: **`GuardStrategyHandle` type-variance refinement (`#131`)** — a type-only refactor with no behavioural change.
+
+## Success criteria (acceptance)
+
+### #166 multi-key groupBy
+
+- `Query<T>.groupBy(...fields)` accepts 1..N field names. Single-arg call site keeps its current narrowed return type (`GroupedQuery<T, F>`).
+- `.aggregate({...})` emits rows containing **every grouped field in declaration order**, followed by aggregate outputs.
+- `withMaterializedView` strategy accepts `groupBy: string | readonly string[]`.
+- The existing cardinality warning (warn at 10k distinct tuples) and `GroupCardinalityError` (throw at 100k) fire on the multi-key tuple-count, with a message that lists all grouped field names.
+- A new internal helper `canonicalGroupKey(fields, row)` produces a stable string by sorting field names before serialising values; it is reused by the UNION MV query-hash.
+
+### #165 UNION MV
+
+- `withMaterializedView({ unionSources: [{ collection, map }, ...], groupBy, aggregate, ... })` registers an MV whose source set is the union of every entry's `collection`.
+- Strategies with both `query` AND `unionSources` are rejected at registration with a clear error.
+- Strategies with `unionSources.length < 2` are rejected at registration (a 1-arm UNION is just a `query`-form MV).
+- The executor reads each source, runs that source's `map`, concatenates the mapped rows, then runs `groupBy` + `aggregate` (reusing the #166 multi-key path).
+- The MV registry maintains a `collection → MV[]` reverse-index. A write to ANY source-collection in `unionSources` fires the MV's refresh path.
+- `sourceVersions` on the materialised row records all union arms; a write to any arm bumps the version and re-fires refresh.
+- Existing fields `refresh`, `strict`, `onEmpty`, `maxRows`, `rowKey` behave identically to single-source MVs.
+- Per-source `map` is mandatory. The mapped output row shape is the type parameter on `withMaterializedView<Row>`; both `map` callbacks must return that shape (compile-time checked; runtime guard for missing-field cases).
+
+### #131 GuardStrategyHandle variance
+
+- Public API of `GuardStrategyHandle<T>` carries no `any`. Generic parameter flows correctly through `register`, `unregister`, and any user-facing accessor.
+- No behaviour change; no consumer in the workspace needs source edits.
+
+### Cross-cutting
+
+- 1573 hub tests (pre.14 baseline) pass plus all newly-added tests.
+- One showcase per feature plus one combined showcase reproducing the canonical niwat shape (`unionSources` + multi-key `groupBy`).
+- `features.yaml` gains entries `mv-multikey-groupby` and `mv-union-sources`.
+- `docs/subsystems/materialized-views.md` extended with two sections (UNION + multi-key).
+- `pnpm turbo build`, `pnpm turbo typecheck`, `pnpm turbo lint`, and `pnpm turbo test` all green.
+
+## Scope — what's in
+
+| Feature | In | Notes |
+|---|:---:|---|
+| `Query<T>.groupBy(...fields)` variadic overload | ✓ | Single-arg overload retained for back-compat narrowing |
+| `withMaterializedView` strategy `groupBy: string \| string[]` | ✓ | Consumed by the eager/lazy executor unchanged from single-key path |
+| Declaration-order row shape preservation | ✓ | `groupBy('a','b')` → `{ a, b, …aggregates }` (NOT `{ b, a, … }`) |
+| `canonicalGroupKey` internal helper (sorted-field-name serialiser) | ✓ | Hashing + dedup only; never surfaces in row output |
+| Multi-key cardinality warning / error reuses single-key thresholds | ✓ | 10k warn / 100k throw, message lists fields |
+| `withMaterializedView` `unionSources` field (Option 1 API) | ✓ | Mutually exclusive with `query` |
+| Per-source `map` callback | ✓ | Mandatory; schema-unification boundary |
+| Dep-analyser treats `unionSources[].collection` as the source set | ✓ | Internally a thin shortcut: when `unionSources` is set, skip the AST walk and read collection names off the strategy directly. The `query`-form and `unionSources`-form remain independent code paths; they are NOT unified into one internal "n-arm" path. |
+| MV registry `collection → MV[]` reverse-index | ✓ | Built at registration; rebuilt on unregister |
+| `sourceVersions` lists every union arm | ✓ | Existing envelope field; just multi-arm now |
+| `Collection.put` source-write hook fires for either arm | ✓ | Registry is the integration point; no change to `put` itself |
+| Combined showcase (UNION + multi-key) | ✓ | Mirrors niwat's monthly-VAT roll-up shape |
+| `GuardStrategyHandle<T>` variance fix | ✓ | Independent landing; type-only |
+
+## Scope — what's deferred
+
+| Feature | Deferred to | Why |
+|---|---|---|
+| `.union(otherQuery)` chain operator on the query builder (Option 2) | post-pre.15, possibly never | Option 1 declared shape covers niwat's need with less dep-analyser risk |
+| `db.unionOf(...)` accessor (Option 3) | post-pre.15, possibly never | Conflates `sources`-as-deps with `sources`-as-arms |
+| Cross-compartment `unionSources` | v0.10+ partition-aware story | Out of scope for memory-first model; spans tenants |
+| Recursive UNION (UNION inside one of the arms) | v3+ | No consumer need; adds dep-analyser complexity |
+| Index-accelerated multi-key `groupBy` | v3+ | Inherits the existing "groupBy can't be index-accelerated" property unchanged |
+| MV cross-join (`periods × workers` cartesian) | v3 (already deferred in MV v2 spec) | Separate primitive, not UNION territory |
+
+## Non-goals
+
+- Changing the existing single-source MV path's behaviour or row shape.
+- Imposing a canonical composite-key encoding. The MV consumer's `rowKey: row => ...` callback formats however it likes (`${a}|${b}`, JSON canonicalisation, hash, etc.).
+- Schema validation across union arms beyond what TypeScript infers from the shared row-shape type parameter and runtime missing-field guards.
+- Cross-collection writes from a single MV refresh. The MV's output collection remains exactly one.
+
+## Sequencing — three PRs
+
+| Order | PR | Touches | Depends on |
+|---|---|---|---|
+| 1 | **#166 multi-key groupBy** | `packages/hub/src/query/builder.ts`, `packages/hub/src/aggregate/groupby.ts`, `packages/hub/src/materialized-views/strategy.ts` (accept `string[]`), unit tests, showcase, `features.yaml`, subsystem doc | pre.14 MV v2 (shipped) |
+| 2 | **#165 UNION MV** | `packages/hub/src/materialized-views/{registry,strategy,executor,dep-analyser}.ts`, unit tests, showcase, `features.yaml`, subsystem doc | PR 1 (consumes `canonicalGroupKey` helper + multi-key groupBy in the strategy) |
+| 3 | **#131 GuardStrategyHandle variance** | `packages/hub/src/guards/` only | none — independent; can land first, last, or anywhere |
+
+PRs are sequential because PR 2 imports the canonical-key helper added by PR 1. PR 3 is free to interleave.
+
+## API surface
+
+### #166 multi-key groupBy
+
+```ts
+// Single-field overload — back-compat (return narrows F to the literal field name)
+.groupBy<F extends string>(field: F): GroupedQuery<T, F>
+
+// Variadic overload — new
+.groupBy<F extends readonly [string, ...string[]]>(...fields: F): GroupedQueryN<T, F>
+```
+
+`GroupedQueryN<T, F>.aggregate<R>(spec: AggregateSpec<R>)` returns rows of type:
+
+```ts
+Pick<T, F[number]> & R
+```
+
+where `F[number]` is the union of the field literal types.
+
+**`withMaterializedView` strategy:**
+
+```ts
+type MaterializedViewStrategy<Row> = {
+  name: string
+  query?: (db: Db) => Query<unknown>                     // existing
+  unionSources?: UnionSource<Row>[]                      // new (PR 2)
+  groupBy?: string | readonly string[]                   // new (PR 1) — string keeps back-compat
+  aggregate?: AggregateSpec<unknown>                     // existing
+  rowKey: (row: Row) => string                           // existing
+  refresh?: 'eager' | 'lazy'                             // existing
+  strict?: boolean                                       // existing
+  onEmpty?: 'tombstone' | 'keep'                         // existing
+  maxRows?: number                                       // existing
+}
+```
+
+**`canonicalGroupKey` helper:**
+
+```ts
+// packages/hub/src/aggregate/canonical-key.ts (new file)
+export function canonicalGroupKey(
+  fields: readonly string[],
+  row: Record<string, unknown>,
+): string {
+  // Sort field names lexicographically, then serialise as `name=value|name=value|...`
+  // Values JSON-stringified; undefined → 'undefined'; null → 'null'
+}
+```
+
+Pure function. Unit-tested with: single field, multiple fields, order-invariance, undefined/null handling, value-with-pipe-character handling (escape rule documented in tests).
+
+### #165 UNION MV (Option 1)
+
+```ts
+type UnionSource<Row> = {
+  collection: string
+  map: (sourceRow: any) => Row
+}
+
+// Canonical consumer shape — the niwat monthly-VAT MV:
+withMaterializedView<{ clientId: string; period: string; vat: number }>({
+  name: 'monthlyOutputVat',
+  unionSources: [
+    { collection: 'taxReceipts', map: r => ({ clientId: r.clientId, period: r.issuedAt.slice(0, 7), vat:  r.paidServicesVat }) },
+    { collection: 'creditNotes', map: r => ({ clientId: r.clientId, period: r.issuedAt.slice(0, 7), vat: -r.paidServicesVat }) },
+  ],
+  groupBy: ['clientId', 'period'],
+  aggregate: { vat: sum('vat') },
+  rowKey: r => `${r.clientId}|${r.period}`,
+  refresh: 'eager',
+})
+```
+
+Registration-time validation:
+
+- `unionSources` present AND `query` present → throw `MaterializedViewConfigError("unionSources and query are mutually exclusive")`.
+- `unionSources.length < 2` → throw `MaterializedViewConfigError("unionSources requires at least 2 source collections")`.
+- Duplicate collection name across `unionSources` entries → throw `MaterializedViewConfigError("unionSources must reference distinct collections")`.
+- `unionSources` present AND no `groupBy` → allowed (UNION-only, no aggregation; passes through mapped rows).
+
+## Implementation notes
+
+### PR 1 (#166)
+
+- **`packages/hub/src/query/builder.ts`** — overload the existing `groupBy` method. Internal state on `Query<T>` already carries `_groupByField?: string`; widen to `_groupByFields?: readonly string[]` and keep single-field constructions setting a 1-element array. The single-field overload's return type stays `GroupedQuery<T, F>` for back-compat; the variadic returns `GroupedQueryN<T, F>`.
+- **`packages/hub/src/aggregate/groupby.ts`** — the dedup map switches its key from `row[field]` to `canonicalGroupKey(fields, row)`. Row output stamps fields in *declaration order* (iterate `fields` array directly).
+- **`packages/hub/src/aggregate/canonical-key.ts`** — new file, pure helper.
+- **Cardinality warning** — existing call site (`groupby.ts` ~line 93 per CLAUDE.md) reads from the dedup map's `size`; message format becomes `groupBy [a, b, c] produced N distinct tuples (warn ≥ 10k)`.
+- **Tests** — `packages/hub/src/aggregate/groupby.test.ts`: extend with multi-key cases (2-key, 3-key, declaration-order preservation, canonical-key invariance under field-order permutation in two separate `groupBy` calls, cardinality warning text contains all field names).
+- **No changes to**: `Collection.scan()` (already returns `ScanBuilder<T>` that delegates to the same path), `live()`/`subscribe()` (cardinality threshold same), `aggregate({...}).run()` terminal (already group-aware).
+
+### PR 2 (#165)
+
+- **`packages/hub/src/materialized-views/strategy.ts`** — accept `unionSources?: UnionSource<Row>[]`. Validate at the construction call (`withMaterializedView`) before the registry call.
+- **`packages/hub/src/materialized-views/registry.ts`** — extend the per-collection reverse-index. Today the registry tracks `mvName → MaterializedViewStrategy`; add `_sourceIndex: Map<string, Set<string>>` (`collectionName → Set<mvName>`). On register: for each entry in `unionSources` (or `dep-analyser.sources(query)` for `query`-form), insert. On unregister: remove. `findMvsForCollection(name)` is now a single map lookup.
+- **`packages/hub/src/materialized-views/executor.ts`** — branch at the start of `materialise(strategy, db)`:
+  - `strategy.query`: existing path unchanged.
+  - `strategy.unionSources`: for each entry, read `collection`, run `map` on each row, push into `unifiedRows` buffer. Then apply `groupBy` + `aggregate` to `unifiedRows` (same builder, same canonical-key helper).
+- **`packages/hub/src/materialized-views/dep-analyser.ts`** — add a thin shortcut: when `strategy.unionSources` is set, `sources(strategy)` returns `unionSources.map(s => s.collection)`. The AST-walking analyser still runs for the `query` form.
+- **`sourceVersions`** — already a `Record<string, number>` on the materialised row envelope per pre.14 design. UNION makes it multi-entry instead of single-entry. The version-bump path on `Collection.put` (per pre.14 source-write hook) reads the strategy's `sources` set; behaviour falls out for free once the source set is multi-element.
+- **`Collection.put` source-write hook** — already calls `registry.findMvsForCollection(this.name)` per pre.14. UNION just means more MVs come back from one collection's lookup. No change to `put` itself.
+- **Mismatched-map runtime guard** — when one source's `map` produces a row missing a field that another source's `map` produces, the multi-key `groupBy` will see `undefined` for that field and group accordingly. Documented as a "garbage-in-garbage-out" boundary; the test suite includes a positive assertion that *consistent* maps produce correct results and a negative case showing the visible failure mode.
+- **Tests** — `packages/hub/src/materialized-views/union.test.ts` (new file): 2-source UNION, 3-source UNION, refresh on each arm independently, mutually-exclusive `query` + `unionSources` rejected, `length < 2` rejected, duplicate-collection rejected, combined UNION + multi-key groupBy (niwat shape), `onEmpty: 'tombstone'` behaviour when all contributing rows on a key are deleted, `strict: true` rollback when the executor throws mid-`map`.
+- **Showcase** — `showcases/src/withMaterializedView-union.ts` (new): two collections, one MV reading both, asserts hook firing on writes to each arm, asserts combined row shape.
+
+### PR 3 (#131)
+
+- **`packages/hub/src/guards/`** — locate the `GuardStrategyHandle<T>` definition. Identify the `any` widening (probably a function signature returning `unknown` widened to `any` in a public-API position). Replace with the correct generic parameter flow. Run `pnpm turbo typecheck` and confirm no consumer in the workspace breaks. No test changes needed (type-only refactor); existing tests assert behaviour, which is unchanged.
+
+## Testing
+
+| Layer | Coverage |
+|---|---|
+| Unit (#166) | Multi-key groupBy: 2-key, 3-key, declaration-order, canonical-key sort-invariance, cardinality warning text, `GroupCardinalityError` at 100k tuples |
+| Unit (#165) | UNION 2-source, 3-source, mutual exclusion with `query`, `length < 2` rejection, duplicate-collection rejection, per-arm refresh, combined UNION + multi-key, `onEmpty`/`strict`/`maxRows` propagation, mismatched-map garbage-in-garbage-out boundary |
+| Combined | Niwat shape — UNION `taxReceipts ∪ creditNotes`, multi-key `groupBy('clientId', 'period')`, `sum('vat')`, writes to either arm re-materialise correctly |
+| Integration | `to-file` conformance: register MV, write to both arms, close & reopen vault, assert MV row state survives |
+| Showcase | `showcases/src/withMaterializedView-multikey.ts`, `showcases/src/withMaterializedView-union.ts`, plus the combined assertion baked into one of them |
+| Architecture invariants | `node scripts/check-architecture.mjs` clean (no new strategy-opt-in or peer-dep violations) |
+| Feature schema | `node scripts/validate-features.mjs` clean after adding `mv-multikey-groupby` and `mv-union-sources` |
+
+Target: 1573 + N hub tests passing on green CI before merge.
+
+## Docs
+
+- **`docs/subsystems/materialized-views.md`** — add two sections:
+  - "Multi-key `groupBy`" — variadic API, row-shape rule (declaration order), cardinality, composite-key encoding is consumer's choice
+  - "UNION sources" — `unionSources` API, mutual exclusion with `query`, per-source `map` as the schema-unification boundary, source-write hook behaviour, the niwat canonical shape
+- **`SUBSYSTEMS.md`** — no new entry (this extends an existing subsystem), but a one-line note under the MV row pointing at the new sections.
+- **`features.yaml`** — two entries (`mv-multikey-groupby`, `mv-union-sources`).
+- **`ROADMAP.md`** — pre.15 entry referencing this spec.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Single-key `groupBy` callers see a return-type widening if overload resolution picks the variadic | Keep the single-field overload as the *first* declaration in the overload list; TypeScript's resolution prefers it for 1-arg calls. Verify with a regression test that pins the old narrowed return type. |
+| Per-source `map` produces inconsistent row shapes silently | Documented as garbage-in-garbage-out; tests assert the visible failure mode and a positive consistent-map case. The single-row-shape type parameter on `withMaterializedView<Row>` catches most of this at compile time. |
+| Dep-analyser fan-out on a hot collection (many MVs include it as a UNION arm) | `findMvsForCollection` is a single map lookup; per-MV refresh is the same cost as today. The fan-out is just "how many MVs touch this collection", not a new algorithmic surface. |
+| Cardinality blow-up when grouping by 3+ keys | Existing 10k-warn / 100k-throw threshold applies on the tuple count, not the field count. The warning message lists all fields so the consumer can see which combination exploded. |
+| Source-write hook reverse-index gets out of sync with strategy registry | Registry holds the index as private state, updated atomically with the strategy-table entry on register/unregister. Unit test asserts state after a register-then-unregister round-trip. |
+
+## Out of scope (explicit non-asks for this cycle)
+
+- `.union()` query-builder chain operator (Option 2 from issue #165)
+- `db.unionOf(...)` accessor (Option 3 from issue #165)
+- Cross-compartment UNION
+- Recursive UNION (UNION inside one of the arms)
+- Multi-key index hints / index-accelerated `groupBy`
+- MV cross-join (already deferred in MV v2 spec to v3)
+- Anything from #14, #15, #121, #1, #2, or the pre.13 showcase cluster
+
+## References
+
+- Pre.14 MV v2 spec: [`2026-05-20-dim14-mv-v2-design.md`](./2026-05-20-dim14-mv-v2-design.md)
+- Pre.14 derivation v1 spec: [`2026-05-01-dim14-derivation-v1-design.md`](./2026-05-01-dim14-derivation-v1-design.md)
+- Pre.14 guards spec: [`2026-05-18-guards-design.md`](./2026-05-18-guards-design.md)
+- Open issues this spec resolves: #165 (UNION MV), #166 (multi-key groupBy), #131 (`GuardStrategyHandle` variance)
+- Pre.14 epic for context: #143

--- a/features.yaml
+++ b/features.yaml
@@ -284,12 +284,15 @@ features:
     showcases:
       - id: 10-with-aggregate
         path: showcases/src/10-with-aggregate.showcase.test.ts
+      - id: 85-with-multikey-groupby
+        path: showcases/src/85-with-multikey-groupby.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
     invariants:
       - 'sum, count, avg, min, max, groupBy compose with where + join'
       - 'Live aggregations re-reduce on every upstream change (no incremental in v1)'
+      - 'groupBy: accepts 1..N field names; result rows carry every grouped field in declaration order + reducer outputs; field declaration order does not affect bucket identity (canonical key sorts names)'
     related: [query-basics, indexing]
 
   - id: indexing
@@ -504,6 +507,8 @@ features:
         path: showcases/src/82-with-mv-lazy.showcase.test.ts
       - id: 84-with-mv-predicates
         path: showcases/src/84-with-mv-predicates.showcase.test.ts
+      - id: 85-with-multikey-groupby
+        path: showcases/src/85-with-multikey-groupby.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -518,6 +523,7 @@ features:
       - 'predicates: hash + canonical-JSON ctx fold into queryHash → refresh on hash bump or ctx change'
       - 'cycle detection at vault open — same-collection edges allowed only with provably-disjoint output.partition'
       - 'maxRows ceiling throws MaterializedViewTooLargeError before any writes'
+      - 'query callback may use multi-key groupBy(...fields); rowKey composites the grouped fields into a stable id'
     related: [derivations, overlay-views, transactions, guards]
 
   - id: overlay-views

--- a/features.yaml
+++ b/features.yaml
@@ -509,6 +509,8 @@ features:
         path: showcases/src/84-with-mv-predicates.showcase.test.ts
       - id: 85-with-multikey-groupby
         path: showcases/src/85-with-multikey-groupby.showcase.test.ts
+      - id: 86-with-union-mv
+        path: showcases/src/86-with-union-mv.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -524,6 +526,7 @@ features:
       - 'cycle detection at vault open — same-collection edges allowed only with provably-disjoint output.partition'
       - 'maxRows ceiling throws MaterializedViewTooLargeError before any writes'
       - 'query callback may use multi-key groupBy(...fields); rowKey composites the grouped fields into a stable id'
+      - 'UNION mode (unionSources): reads from ≥2 sibling collections; per-source map projects to MV row shape; groupBy + aggregate run on concatenated stream'
     related: [derivations, overlay-views, transactions, guards]
 
   - id: overlay-views

--- a/packages/hub/__tests__/aggregate-canonical-key.test.ts
+++ b/packages/hub/__tests__/aggregate-canonical-key.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { canonicalGroupKey } from '../src/aggregate/canonical-key.js'
+
+describe('canonicalGroupKey', () => {
+  it('returns a single-field encoding for one key', () => {
+    expect(canonicalGroupKey(['period'], { period: '2026-05' }))
+      .toBe('period="2026-05"')
+  })
+
+  it('sorts field names lexicographically before serialising', () => {
+    const a = canonicalGroupKey(['clientId', 'period'], { clientId: 'c1', period: '2026-05' })
+    const b = canonicalGroupKey(['period', 'clientId'], { clientId: 'c1', period: '2026-05' })
+    expect(a).toBe(b)
+    expect(a).toBe('clientId="c1"|period="2026-05"')
+  })
+
+  it('JSON-stringifies value types', () => {
+    expect(canonicalGroupKey(['n'], { n: 42 })).toBe('n=42')
+    expect(canonicalGroupKey(['flag'], { flag: true })).toBe('flag=true')
+    expect(canonicalGroupKey(['obj'], { obj: { a: 1 } })).toBe('obj={"a":1}')
+  })
+
+  it('distinguishes undefined and null', () => {
+    expect(canonicalGroupKey(['x'], { x: undefined })).toBe('x=undefined')
+    expect(canonicalGroupKey(['x'], { x: null })).toBe('x=null')
+  })
+
+  it('reads missing fields as undefined', () => {
+    expect(canonicalGroupKey(['absent'], {})).toBe('absent=undefined')
+  })
+
+  it('three-key composite is order-invariant in fields argument', () => {
+    const row = { clientId: 'c1', period: '2026-05', direction: 'in' }
+    const k1 = canonicalGroupKey(['clientId', 'period', 'direction'], row)
+    const k2 = canonicalGroupKey(['direction', 'clientId', 'period'], row)
+    expect(k1).toBe(k2)
+  })
+})

--- a/packages/hub/__tests__/materialized-views/multikey.test.ts
+++ b/packages/hub/__tests__/materialized-views/multikey.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withMaterializedView, sum } from '../../src/index.js'
+import { withAggregate } from '../../src/aggregate/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface Compensation extends Record<string, unknown> {
+  id: string
+  clientId: string
+  period: string
+  taxAmount: number
+}
+
+interface Pnd1Row extends Record<string, unknown> {
+  clientId: string
+  period: string
+  total: number
+}
+
+describe('withMaterializedView — multi-key groupBy inside query() (#166)', () => {
+  it('refreshes a per-(clientId, period) MV when source rows are added', async () => {
+    // Aggregate-shape MV — query() returns a GroupedAggregation. The
+    // dependency analyzer cannot walk through groupBy().aggregate()
+    // back to the source, so `sources` is declared explicitly per the
+    // CLAUDE.md note.
+    const pnd1Auto = withMaterializedView<Pnd1Row>({
+      name: 'pnd1Auto',
+      query: db =>
+        db.collection<Compensation>('compensations')
+          .query()
+          .groupBy('clientId', 'period')
+          .aggregate({ total: sum('taxAmount') }),
+      sources: ['compensations'],
+      rowKey: row => `${row.clientId}|${row.period}`,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-multikey-groupby-passphrase-2026',
+      materializedViewStrategies: [pnd1Auto],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('demo')
+
+    const comps = vault.collection<Compensation>('compensations')
+    await comps.put('c-1', { id: 'c-1', clientId: 'c1', period: '2026-05', taxAmount: 100 })
+    await comps.put('c-2', { id: 'c-2', clientId: 'c1', period: '2026-05', taxAmount: 50 })
+    await comps.put('c-3', { id: 'c-3', clientId: 'c2', period: '2026-05', taxAmount: 200 })
+
+    // Read out of the MV output collection (defaults to MV name).
+    const out = vault.collection<Pnd1Row & { _materializedFrom?: unknown }>('pnd1Auto')
+    const c1May = await out.get('c1|2026-05')
+    const c2May = await out.get('c2|2026-05')
+
+    expect(c1May).not.toBeNull()
+    expect(c1May?.clientId).toBe('c1')
+    expect(c1May?.period).toBe('2026-05')
+    expect(c1May?.total).toBe(150)
+
+    expect(c2May).not.toBeNull()
+    expect(c2May?.clientId).toBe('c2')
+    expect(c2May?.period).toBe('2026-05')
+    expect(c2May?.total).toBe(200)
+  })
+})

--- a/packages/hub/__tests__/materialized-views/union-validation.test.ts
+++ b/packages/hub/__tests__/materialized-views/union-validation.test.ts
@@ -77,6 +77,53 @@ describe('withMaterializedView UNION validation (#165)', () => {
     ).toThrow(/empty array/)
   })
 
+  it('rejects unionSources with aggregate but no groupBy (#169)', () => {
+    expect(() =>
+      withMaterializedView({
+        name: 'bad-aggregate-no-groupby',
+        unionSources: [
+          { collection: 'a', map: (r) => r as Record<string, unknown> },
+          { collection: 'b', map: (r) => r as Record<string, unknown> },
+        ],
+        aggregate: { total: sum('n') },
+        // groupBy intentionally omitted
+        rowKey: () => 'k',
+        refresh: 'eager',
+      }),
+    ).toThrow(/aggregate requires groupBy/)
+  })
+
+  it('rejects unionSources with predicates (#170 — not yet supported)', () => {
+    expect(() =>
+      withMaterializedView<{ k: string; n: number }>({
+        name: 'bad-predicates-on-union',
+        unionSources: [
+          {
+            collection: 'a',
+            map: (r) => ({
+              k: String((r as { k: unknown }).k),
+              n: Number((r as { n: unknown }).n),
+            }),
+          },
+          {
+            collection: 'b',
+            map: (r) => ({
+              k: String((r as { k: unknown }).k),
+              n: Number((r as { n: unknown }).n),
+            }),
+          },
+        ],
+        groupBy: 'k',
+        aggregate: { total: sum('n') },
+        predicates: {
+          isPositive: { hash: 'v1', fn: (row) => row.n > 0 },
+        },
+        rowKey: (row) => row.k,
+        refresh: 'eager',
+      }),
+    ).toThrow(/predicates are not supported on UNION/)
+  })
+
   it('accepts a well-formed UNION strategy', () => {
     expect(() =>
       withMaterializedView<{ k: string; n: number }>({

--- a/packages/hub/__tests__/materialized-views/union-validation.test.ts
+++ b/packages/hub/__tests__/materialized-views/union-validation.test.ts
@@ -62,6 +62,21 @@ describe('withMaterializedView UNION validation (#165)', () => {
     ).toThrow(/distinct collections/)
   })
 
+  it('rejects unionSources with empty groupBy array', () => {
+    expect(() =>
+      withMaterializedView({
+        name: 'bad-empty-groupby',
+        unionSources: [
+          { collection: 'a', map: (r) => r as Record<string, unknown> },
+          { collection: 'b', map: (r) => r as Record<string, unknown> },
+        ],
+        groupBy: [],
+        rowKey: () => 'k',
+        refresh: 'eager',
+      }),
+    ).toThrow(/empty array/)
+  })
+
   it('accepts a well-formed UNION strategy', () => {
     expect(() =>
       withMaterializedView<{ k: string; n: number }>({

--- a/packages/hub/__tests__/materialized-views/union-validation.test.ts
+++ b/packages/hub/__tests__/materialized-views/union-validation.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import {
+  withMaterializedView,
+  sum,
+  MaterializedViewConfigError,
+} from '../../src/index.js'
+import type { Query } from '../../src/query/builder.js'
+
+const dummyQuery = (): Query<Record<string, unknown>> =>
+  ({}) as Query<Record<string, unknown>>
+
+describe('withMaterializedView UNION validation (#165)', () => {
+  it('rejects strategy with both query and unionSources', () => {
+    expect(() =>
+      withMaterializedView({
+        name: 'bad-both',
+        query: dummyQuery,
+        unionSources: [
+          { collection: 'a', map: (r) => r as Record<string, unknown> },
+          { collection: 'b', map: (r) => r as Record<string, unknown> },
+        ],
+        rowKey: () => 'k',
+        refresh: 'eager',
+      }),
+    ).toThrow(MaterializedViewConfigError)
+  })
+
+  it('rejects strategy with neither query nor unionSources', () => {
+    expect(() =>
+      withMaterializedView({
+        name: 'bad-neither',
+        rowKey: () => 'k',
+        refresh: 'eager',
+      } as Parameters<typeof withMaterializedView>[0]),
+    ).toThrow(MaterializedViewConfigError)
+  })
+
+  it('rejects unionSources with fewer than 2 arms', () => {
+    expect(() =>
+      withMaterializedView({
+        name: 'bad-one-arm',
+        unionSources: [
+          { collection: 'a', map: (r) => r as Record<string, unknown> },
+        ],
+        rowKey: () => 'k',
+        refresh: 'eager',
+      }),
+    ).toThrow(/at least 2/)
+  })
+
+  it('rejects unionSources with duplicate collection names', () => {
+    expect(() =>
+      withMaterializedView({
+        name: 'bad-dup',
+        unionSources: [
+          { collection: 'a', map: (r) => r as Record<string, unknown> },
+          { collection: 'a', map: (r) => r as Record<string, unknown> },
+        ],
+        rowKey: () => 'k',
+        refresh: 'eager',
+      }),
+    ).toThrow(/distinct collections/)
+  })
+
+  it('accepts a well-formed UNION strategy', () => {
+    expect(() =>
+      withMaterializedView<{ k: string; n: number }>({
+        name: 'ok',
+        unionSources: [
+          {
+            collection: 'a',
+            map: (r) => ({
+              k: String((r as { k: unknown }).k),
+              n: Number((r as { n: unknown }).n),
+            }),
+          },
+          {
+            collection: 'b',
+            map: (r) => ({
+              k: String((r as { k: unknown }).k),
+              n: Number((r as { n: unknown }).n),
+            }),
+          },
+        ],
+        groupBy: 'k',
+        aggregate: { total: sum('n') },
+        rowKey: (row) => row.k,
+        refresh: 'eager',
+      }),
+    ).not.toThrow()
+  })
+})

--- a/packages/hub/__tests__/materialized-views/union.test.ts
+++ b/packages/hub/__tests__/materialized-views/union.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withMaterializedView, sum } from '../../src/index.js'
+import { withAggregate } from '../../src/aggregate/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface TaxReceipt extends Record<string, unknown> {
+  id: string
+  issuedAt: string
+  paidServicesVat: number
+}
+
+interface CreditNote extends Record<string, unknown> {
+  id: string
+  issuedAt: string
+  paidServicesVat: number
+}
+
+interface MonthlyVatRow extends Record<string, unknown> {
+  period: string
+  vat: number
+}
+
+interface ArmRowA extends Record<string, unknown> {
+  id: string
+  k: string
+  n: number
+}
+
+interface ArmRowB extends Record<string, unknown> {
+  id: string
+  k: string
+  n: number
+}
+
+interface TotalsRow extends Record<string, unknown> {
+  k: string
+  n: number
+}
+
+describe('UNION MV — basic 2-source (#165)', () => {
+  it('reads from both arms, maps, groupBy, aggregate', async () => {
+    const monthlyVat = withMaterializedView<MonthlyVatRow>({
+      name: 'monthlyVat',
+      unionSources: [
+        {
+          collection: 'taxReceipts',
+          map: r => {
+            const tr = r as unknown as TaxReceipt
+            return { period: tr.issuedAt.slice(0, 7), vat: tr.paidServicesVat }
+          },
+        },
+        {
+          collection: 'creditNotes',
+          map: r => {
+            const cn = r as unknown as CreditNote
+            return { period: cn.issuedAt.slice(0, 7), vat: -cn.paidServicesVat }
+          },
+        },
+      ],
+      groupBy: 'period',
+      aggregate: { vat: sum('vat') },
+      rowKey: row => row.period,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-union-basic-passphrase-2026',
+      materializedViewStrategies: [monthlyVat],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('demo')
+
+    const receipts = vault.collection<TaxReceipt>('taxReceipts')
+    const notes = vault.collection<CreditNote>('creditNotes')
+
+    await receipts.put('r-1', { id: 'r-1', issuedAt: '2026-05-15', paidServicesVat: 100 })
+    await receipts.put('r-2', { id: 'r-2', issuedAt: '2026-05-20', paidServicesVat: 50 })
+    await notes.put('cn-1', { id: 'cn-1', issuedAt: '2026-05-25', paidServicesVat: 30 })
+
+    const out = vault.collection<MonthlyVatRow & { _materializedFrom?: unknown }>('monthlyVat')
+    const row = await out.get('2026-05')
+    expect(row).not.toBeNull()
+    expect(row?.period).toBe('2026-05')
+    expect(row?.vat).toBe(120) // 100 + 50 - 30
+  })
+
+  it('refreshes on writes to either arm independently', async () => {
+    const totals = withMaterializedView<TotalsRow>({
+      name: 'totals',
+      unionSources: [
+        {
+          collection: 'a',
+          map: r => {
+            const row = r as unknown as ArmRowA
+            return { k: row.k, n: row.n }
+          },
+        },
+        {
+          collection: 'b',
+          map: r => {
+            const row = r as unknown as ArmRowB
+            return { k: row.k, n: row.n }
+          },
+        },
+      ],
+      groupBy: 'k',
+      aggregate: { n: sum('n') },
+      rowKey: row => row.k,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-union-arms-independent-passphrase-2026',
+      materializedViewStrategies: [totals],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('demo')
+
+    const a = vault.collection<ArmRowA>('a')
+    const b = vault.collection<ArmRowB>('b')
+    const out = vault.collection<TotalsRow & { _materializedFrom?: unknown }>('totals')
+
+    // Write to arm A first.
+    await a.put('a-1', { id: 'a-1', k: 'x', n: 10 })
+    let row = await out.get('x')
+    expect(row).not.toBeNull()
+    expect(row?.n).toBe(10)
+
+    // Write to arm B — MV must refresh from the B-arm write too.
+    await b.put('b-1', { id: 'b-1', k: 'x', n: 5 })
+    row = await out.get('x')
+    expect(row).not.toBeNull()
+    expect(row?.n).toBe(15)
+  })
+})

--- a/packages/hub/__tests__/materialized-views/union.test.ts
+++ b/packages/hub/__tests__/materialized-views/union.test.ts
@@ -391,3 +391,66 @@ describe('UNION MV — edges (#165)', () => {
     expect(rows).toHaveLength(0)
   })
 })
+
+describe('UNION MV — queryHash sensitivity (#165 niwat review)', () => {
+  it('reordering unionSources arms produces a different queryHash (declaration order is semantically meaningful)', async () => {
+    // Strategy A — arm "a" first, arm "b" second
+    const stratA = withMaterializedView<{ k: string; n: number }>({
+      name: 'order-sensitive',
+      unionSources: [
+        { collection: 'a', map: (r: Record<string, unknown>) => ({ k: r.k as string, n: r.n as number }) },
+        { collection: 'b', map: (r: Record<string, unknown>) => ({ k: r.k as string, n: r.n as number }) },
+      ],
+      groupBy: 'k',
+      // no aggregate — dedup-only path; first-seen row wins per composite key
+      rowKey: row => row.k,
+      refresh: 'eager',
+    })
+    // Strategy B — same fields, arms reversed
+    const stratB = withMaterializedView<{ k: string; n: number }>({
+      name: 'order-sensitive',
+      unionSources: [
+        { collection: 'b', map: (r: Record<string, unknown>) => ({ k: r.k as string, n: r.n as number }) },
+        { collection: 'a', map: (r: Record<string, unknown>) => ({ k: r.k as string, n: r.n as number }) },
+      ],
+      groupBy: 'k',
+      rowKey: row => row.k,
+      refresh: 'eager',
+    })
+
+    // Import summarizeUnionPlan directly to compare hashes
+    const { summarizeUnionPlan } = await import('../../src/materialized-views/dependency-analyzer.js')
+    const planA = summarizeUnionPlan(stratA.spec)
+    const planB = summarizeUnionPlan(stratB.spec)
+    expect(planA).not.toBe(planB)
+    expect(planA).toContain('union(a,b)')
+    expect(planB).toContain('union(b,a)')
+  })
+
+  it('reordering groupBy fields does NOT change queryHash (multi-key groupBy is commutative)', async () => {
+    const stratA = withMaterializedView<{ a: string; b: string; n: number }>({
+      name: 'commutative-groupby',
+      unionSources: [
+        { collection: 'x', map: (r: Record<string, unknown>) => ({ a: r.a as string, b: r.b as string, n: r.n as number }) },
+        { collection: 'y', map: (r: Record<string, unknown>) => ({ a: r.a as string, b: r.b as string, n: r.n as number }) },
+      ],
+      groupBy: ['a', 'b'],
+      aggregate: { total: sum('n') },
+      rowKey: row => `${row.a}|${row.b}`,
+      refresh: 'eager',
+    })
+    const stratB = withMaterializedView<{ a: string; b: string; n: number }>({
+      name: 'commutative-groupby',
+      unionSources: [
+        { collection: 'x', map: (r: Record<string, unknown>) => ({ a: r.a as string, b: r.b as string, n: r.n as number }) },
+        { collection: 'y', map: (r: Record<string, unknown>) => ({ a: r.a as string, b: r.b as string, n: r.n as number }) },
+      ],
+      groupBy: ['b', 'a'], // reversed
+      aggregate: { total: sum('n') },
+      rowKey: row => `${row.a}|${row.b}`,
+      refresh: 'eager',
+    })
+    const { summarizeUnionPlan } = await import('../../src/materialized-views/dependency-analyzer.js')
+    expect(summarizeUnionPlan(stratA.spec)).toBe(summarizeUnionPlan(stratB.spec))
+  })
+})

--- a/packages/hub/__tests__/materialized-views/union.test.ts
+++ b/packages/hub/__tests__/materialized-views/union.test.ts
@@ -170,3 +170,224 @@ describe('UNION MV — basic 2-source (#165)', () => {
     expect(row?.n).toBe(15)
   })
 })
+
+describe('UNION MV — combined with multi-key groupBy (#165 + #166)', () => {
+  it('niwat canonical monthly-VAT shape: union(taxReceipts, creditNotes) + groupBy(clientId, period)', async () => {
+    interface NiwatTaxReceipt extends Record<string, unknown> {
+      id: string
+      clientId: string
+      issuedAt: string
+      paidServicesVat: number
+    }
+    interface NiwatCreditNote extends Record<string, unknown> {
+      id: string
+      clientId: string
+      issuedAt: string
+      paidServicesVat: number
+    }
+    interface NiwatMonthlyVatRow extends Record<string, unknown> {
+      clientId: string
+      period: string
+      vat: number
+    }
+
+    const monthlyOutputVat = withMaterializedView<NiwatMonthlyVatRow>({
+      name: 'monthlyOutputVat',
+      unionSources: [
+        {
+          collection: 'taxReceipts',
+          map: r => {
+            const tr = r as unknown as NiwatTaxReceipt
+            return {
+              clientId: tr.clientId,
+              period: tr.issuedAt.slice(0, 7),
+              vat: tr.paidServicesVat,
+            }
+          },
+        },
+        {
+          collection: 'creditNotes',
+          map: r => {
+            const cn = r as unknown as NiwatCreditNote
+            return {
+              clientId: cn.clientId,
+              period: cn.issuedAt.slice(0, 7),
+              vat: -cn.paidServicesVat,
+            }
+          },
+        },
+      ],
+      groupBy: ['clientId', 'period'],
+      aggregate: { vat: sum('vat') },
+      rowKey: row => `${row.clientId}|${row.period}`,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-union-multikey-niwat-passphrase-2026',
+      materializedViewStrategies: [monthlyOutputVat],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('demo')
+
+    const receipts = vault.collection<NiwatTaxReceipt>('taxReceipts')
+    const notes = vault.collection<NiwatCreditNote>('creditNotes')
+
+    await receipts.put('r1', { id: 'r1', clientId: 'c1', issuedAt: '2026-05-01', paidServicesVat: 100 })
+    await receipts.put('r2', { id: 'r2', clientId: 'c1', issuedAt: '2026-05-15', paidServicesVat: 50 })
+    await receipts.put('r3', { id: 'r3', clientId: 'c2', issuedAt: '2026-05-10', paidServicesVat: 70 })
+    await notes.put('n1', { id: 'n1', clientId: 'c1', issuedAt: '2026-05-20', paidServicesVat: 20 })
+
+    const out = vault.collection<NiwatMonthlyVatRow & { _materializedFrom?: unknown }>('monthlyOutputVat')
+    const rows = await out.list()
+    expect(rows).toHaveLength(2)
+
+    const c1May = await out.get('c1|2026-05')
+    expect(c1May).not.toBeNull()
+    expect(c1May?.clientId).toBe('c1')
+    expect(c1May?.period).toBe('2026-05')
+    expect(c1May?.vat).toBe(130) // 100 + 50 - 20
+
+    const c2May = await out.get('c2|2026-05')
+    expect(c2May).not.toBeNull()
+    expect(c2May?.clientId).toBe('c2')
+    expect(c2May?.period).toBe('2026-05')
+    expect(c2May?.vat).toBe(70)
+  })
+})
+
+describe('UNION MV — edges (#165)', () => {
+  it('three-source UNION sums correctly', async () => {
+    interface ThreeArmRow extends Record<string, unknown> {
+      id: string
+      k: string
+      n: number
+    }
+
+    const totals = withMaterializedView<TotalsRow>({
+      name: 'totals',
+      unionSources: [
+        {
+          collection: 'a',
+          map: r => {
+            const row = r as unknown as ThreeArmRow
+            return { k: row.k, n: row.n }
+          },
+        },
+        {
+          collection: 'b',
+          map: r => {
+            const row = r as unknown as ThreeArmRow
+            return { k: row.k, n: row.n }
+          },
+        },
+        {
+          collection: 'c',
+          map: r => {
+            const row = r as unknown as ThreeArmRow
+            return { k: row.k, n: row.n }
+          },
+        },
+      ],
+      groupBy: 'k',
+      aggregate: { n: sum('n') },
+      rowKey: row => row.k,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-union-three-source-passphrase-2026',
+      materializedViewStrategies: [totals],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('demo')
+
+    const a = vault.collection<ThreeArmRow>('a')
+    const b = vault.collection<ThreeArmRow>('b')
+    const c = vault.collection<ThreeArmRow>('c')
+
+    await a.put('a-1', { id: 'a-1', k: 'x', n: 1 })
+    await b.put('b-1', { id: 'b-1', k: 'x', n: 2 })
+    await c.put('c-1', { id: 'c-1', k: 'x', n: 4 })
+
+    const out = vault.collection<TotalsRow & { _materializedFrom?: unknown }>('totals')
+    const row = await out.get('x')
+    expect(row).not.toBeNull()
+    expect(row?.n).toBe(7)
+  })
+
+  // KNOWN GAP (pre.14 hangover, surfaced by #165 review):
+  // `Collection._doDelete` does NOT call `dispatchMaterializedViews` —
+  // only `put` does (collection.ts ~1282/1398). This means source
+  // deletes never trigger eager MV refresh; tombstoning only fires
+  // when something *else* (a put on the source or a manual
+  // `vault.refreshView`) re-runs the executor. Affects ANY MV with
+  // `onEmpty: 'delete'` (the default), not just UNION-form. The
+  // executor + `listOutputIds` themselves are correct — the variant
+  // below uses an explicit `refreshView` to prove that, and the
+  // `it.todo` below pins the auto-dispatch gap for a future PR.
+  it.todo('onEmpty: delete tombstones MV row automatically when source rows are deleted (pending _doDelete → dispatchMaterializedViews wiring)')
+
+  it('onEmpty: delete (default) tombstones MV row when all contributing source rows are deleted (manual refresh)', async () => {
+    const totals = withMaterializedView<TotalsRow>({
+      name: 'totals',
+      unionSources: [
+        {
+          collection: 'a',
+          map: r => {
+            const row = r as unknown as ArmRowA
+            return { k: row.k, n: row.n }
+          },
+        },
+        {
+          collection: 'b',
+          map: r => {
+            const row = r as unknown as ArmRowB
+            return { k: row.k, n: row.n }
+          },
+        },
+      ],
+      groupBy: 'k',
+      aggregate: { n: sum('n') },
+      rowKey: row => row.k,
+      refresh: 'eager',
+      onEmpty: 'delete',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-union-onempty-tombstone-passphrase-2026',
+      materializedViewStrategies: [totals],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('demo')
+
+    const a = vault.collection<ArmRowA>('a')
+    const b = vault.collection<ArmRowB>('b')
+    const out = vault.collection<TotalsRow & { _materializedFrom?: unknown }>('totals')
+
+    await a.put('a-1', { id: 'a-1', k: 'x', n: 1 })
+    await b.put('b-1', { id: 'b-1', k: 'x', n: 2 })
+
+    let rows = await out.list()
+    expect(rows).toHaveLength(1)
+    const row = await out.get('x')
+    expect(row?.n).toBe(3)
+
+    // Delete both contributing source rows — MV row should tombstone.
+    await a.delete('a-1')
+    await b.delete('b-1')
+
+    // Probe: manual refresh DOES tombstone, proving executor + listOutputIds
+    // are correct — the gap is purely that `_doDelete` doesn't dispatch.
+    await vault.refreshView('totals')
+
+    rows = await out.list()
+    expect(rows).toHaveLength(0)
+  })
+})

--- a/packages/hub/__tests__/materialized-views/union.test.ts
+++ b/packages/hub/__tests__/materialized-views/union.test.ts
@@ -322,7 +322,7 @@ describe('UNION MV — edges (#165)', () => {
 
   // KNOWN GAP (pre.14 hangover, surfaced by #165 review):
   // `Collection._doDelete` does NOT call `dispatchMaterializedViews` —
-  // only `put` does (collection.ts ~1282/1398). This means source
+  // only `put` does (collection.ts 1283/1399). This means source
   // deletes never trigger eager MV refresh; tombstoning only fires
   // when something *else* (a put on the source or a manual
   // `vault.refreshView`) re-runs the executor. Affects ANY MV with

--- a/packages/hub/__tests__/query-groupby.test.ts
+++ b/packages/hub/__tests__/query-groupby.test.ts
@@ -404,3 +404,127 @@ describe('groupBy > .live() re-fires on source changes', () => {
     expect(notifications).toBe(2) // no further notifications after stop
   })
 })
+
+// ---------------------------------------------------------------------------
+// Multi-key (#166) — variadic groupBy
+// ---------------------------------------------------------------------------
+
+interface TaxDoc {
+  id: string
+  clientId: string
+  period: string
+  direction: 'in' | 'out'
+  amount: number
+}
+
+describe('Query.groupBy — multi-key (#166)', () => {
+  it('emits one row per composite key, with every grouped field stamped on the row', () => {
+    const docs: TaxDoc[] = [
+      { id: '1', clientId: 'c1', period: '2026-05', direction: 'in',  amount: 100 },
+      { id: '2', clientId: 'c1', period: '2026-05', direction: 'in',  amount: 200 },
+      { id: '3', clientId: 'c1', period: '2026-06', direction: 'in',  amount: 300 },
+      { id: '4', clientId: 'c2', period: '2026-05', direction: 'in',  amount: 400 },
+    ]
+    const result = new Query<TaxDoc>(staticSource(docs), undefined, undefined, AGG)
+      .groupBy('clientId', 'period')
+      .aggregate({ total: sum('amount'), n: count() })
+      .run()
+    expect(result).toHaveLength(3)
+    const r1 = result.find(
+      (r) => r.clientId === 'c1' && r.period === '2026-05',
+    )!
+    const r2 = result.find(
+      (r) => r.clientId === 'c1' && r.period === '2026-06',
+    )!
+    const r3 = result.find(
+      (r) => r.clientId === 'c2' && r.period === '2026-05',
+    )!
+    expect(r1).toEqual({ clientId: 'c1', period: '2026-05', total: 300, n: 2 })
+    expect(r2).toEqual({ clientId: 'c1', period: '2026-06', total: 300, n: 1 })
+    expect(r3).toEqual({ clientId: 'c2', period: '2026-05', total: 400, n: 1 })
+  })
+
+  it('preserves grouped-field declaration order on result rows', () => {
+    const docs: TaxDoc[] = [
+      { id: '1', clientId: 'c1', period: '2026-05', direction: 'in', amount: 100 },
+    ]
+    const byPeriodClient = new Query<TaxDoc>(staticSource(docs), undefined, undefined, AGG)
+      .groupBy('period', 'clientId')
+      .aggregate({ n: count() })
+      .run()
+    expect(Object.keys(byPeriodClient[0]!).slice(0, 2)).toEqual(['period', 'clientId'])
+
+    const byClientPeriod = new Query<TaxDoc>(staticSource(docs), undefined, undefined, AGG)
+      .groupBy('clientId', 'period')
+      .aggregate({ n: count() })
+      .run()
+    expect(Object.keys(byClientPeriod[0]!).slice(0, 2)).toEqual(['clientId', 'period'])
+  })
+
+  it('handles three composite keys', () => {
+    const docs: TaxDoc[] = [
+      { id: '1', clientId: 'c1', period: '2026-05', direction: 'in',  amount: 100 },
+      { id: '2', clientId: 'c1', period: '2026-05', direction: 'in',  amount: 200 },
+      { id: '3', clientId: 'c1', period: '2026-05', direction: 'out', amount: 50  },
+    ]
+    const result = new Query<TaxDoc>(staticSource(docs), undefined, undefined, AGG)
+      .groupBy('clientId', 'period', 'direction')
+      .aggregate({ total: sum('amount'), n: count() })
+      .run()
+    expect(result).toHaveLength(2)
+    const inRow  = result.find((r) => r.direction === 'in')!
+    const outRow = result.find((r) => r.direction === 'out')!
+    expect(inRow).toEqual({
+      clientId: 'c1', period: '2026-05', direction: 'in',  total: 300, n: 2,
+    })
+    expect(outRow).toEqual({
+      clientId: 'c1', period: '2026-05', direction: 'out', total: 50, n: 1,
+    })
+  })
+
+  it('cardinality warning message lists all grouped field names', () => {
+    resetGroupByWarnings()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const records = Array.from({ length: GROUPBY_WARN_CARDINALITY + 1 }, (_, i) => ({
+      id: `r${i}`,
+      a: `a${i}`,
+      b: `b${i}`,
+    }))
+    new Query(staticSource(records), undefined, undefined, AGG)
+      .groupBy('a', 'b')
+      .aggregate({ n: count() })
+      .run()
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    const msg = warnSpy.mock.calls[0]![0] as string
+    expect(msg).toContain('[a, b]')
+    warnSpy.mockRestore()
+  })
+
+  it('throws GroupCardinalityError at 100k distinct tuples', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const records = Array.from({ length: GROUPBY_MAX_CARDINALITY + 1 }, (_, i) => ({
+      id: `r${i}`,
+      a: `a${i}`,
+      b: `b${i}`,
+    }))
+    expect(() =>
+      new Query(staticSource(records), undefined, undefined, AGG)
+        .groupBy('a', 'b')
+        .aggregate({ n: count() })
+        .run(),
+    ).toThrow(GroupCardinalityError)
+    warnSpy.mockRestore()
+  })
+
+  it('back-compat: single-arg groupBy still works and returns narrowed field type', () => {
+    const result = new Query<Invoice>(staticSource(SAMPLE), undefined, undefined, AGG)
+      .groupBy('clientId')
+      .aggregate({ total: sum('amount'), n: count() })
+      .run()
+    // Narrowed type: rows[0].clientId is accessible at compile time
+    const first = result[0]!
+    expect(first.clientId).toBeDefined()
+    expect(typeof first.total).toBe('number')
+    expect(typeof first.n).toBe('number')
+  })
+})

--- a/packages/hub/src/aggregate/active.ts
+++ b/packages/hub/src/aggregate/active.ts
@@ -43,8 +43,8 @@ export function withAggregate(): AggregateStrategy {
     groupBy(executeRecords, field, upstreams, dictLabelResolver) {
       return new GroupedQuery(executeRecords, field, upstreams, dictLabelResolver)
     },
-    groupByN(executeRecords, fields, upstreams, dictLabelResolver) {
-      return new GroupedQueryN(executeRecords, fields, upstreams, dictLabelResolver)
+    groupByN(executeRecords, fields, upstreams) {
+      return new GroupedQueryN(executeRecords, fields, upstreams)
     },
     async scanAggregate(iter, spec) {
       const collected: unknown[] = []

--- a/packages/hub/src/aggregate/active.ts
+++ b/packages/hub/src/aggregate/active.ts
@@ -10,7 +10,7 @@
 
 import { Aggregation, reduceRecords } from './aggregation.js'
 import type { AggregateSpec, AggregateResult } from './aggregation.js'
-import { GroupedQuery } from './groupby.js'
+import { GroupedQuery, GroupedQueryN } from './groupby.js'
 import type { AggregateStrategy } from './strategy.js'
 
 /**
@@ -42,6 +42,9 @@ export function withAggregate(): AggregateStrategy {
     },
     groupBy(executeRecords, field, upstreams, dictLabelResolver) {
       return new GroupedQuery(executeRecords, field, upstreams, dictLabelResolver)
+    },
+    groupByN(executeRecords, fields, upstreams, dictLabelResolver) {
+      return new GroupedQueryN(executeRecords, fields, upstreams, dictLabelResolver)
     },
     async scanAggregate(iter, spec) {
       const collected: unknown[] = []

--- a/packages/hub/src/aggregate/canonical-key.ts
+++ b/packages/hub/src/aggregate/canonical-key.ts
@@ -1,0 +1,29 @@
+/**
+ * Canonicalise a group-key tuple to a stable string for dedup hashing.
+ *
+ * Sorts field names lexicographically before serialising, so that
+ * `.groupBy('a', 'b')` and `.groupBy('b', 'a')` produce identical
+ * keys for the same logical group. Values are JSON-stringified;
+ * `undefined` and `null` are distinguished (matching the Map-key
+ * semantics in `groupAndReduce`).
+ *
+ * NOT part of the public API. Used by:
+ *   - `groupAndReduce` for the dedup Map's key
+ *   - `materialized-views/query-hash` for UNION MV cross-arm row-key dedup (PR 2)
+ *
+ * Pure: same input → same output, no side effects.
+ */
+export function canonicalGroupKey(
+  fields: readonly string[],
+  row: Record<string, unknown>,
+): string {
+  const sorted = [...fields].sort()
+  const parts: string[] = []
+  for (const name of sorted) {
+    const v = row[name]
+    const serialised =
+      v === undefined ? 'undefined' : JSON.stringify(v)
+    parts.push(`${name}=${serialised}`)
+  }
+  return parts.join('|')
+}

--- a/packages/hub/src/aggregate/groupby.ts
+++ b/packages/hub/src/aggregate/groupby.ts
@@ -136,6 +136,49 @@ export type GroupedRowN<F extends readonly string[], R> =
   { [K in F[number]]: unknown } & R
 
 /**
+ * Shared base class for the chainable grouped-query wrappers. Holds
+ * the constructor + protected fields that both single-key
+ * `GroupedQuery<T, F>` and variadic `GroupedQueryN<T, F>` need; each
+ * subclass only overrides `aggregate()` with its own result-row
+ * generic.
+ *
+ * Not exported — implementation detail. Adding `.having()` /
+ * `.live()` / `.orderByGroup()` etc. in the future lands here once
+ * and both subclasses pick it up automatically.
+ *
+ * @internal
+ */
+abstract class GroupedQueryBase {
+  /**
+   * Field set this grouped query buckets on. Stored in declaration
+   * order — the same order is preserved on every result row by
+   * `groupAndReduce`. For the single-field constructor, this is
+   * `[field]`.
+   */
+  protected readonly fields: readonly string[]
+
+  constructor(
+    protected readonly executeRecords: () => readonly unknown[],
+    fieldOrFields: string | readonly string[],
+    protected readonly upstreams: readonly AggregationUpstream[],
+    /**
+     * Optional dict label resolver attached by the query builder when
+     * the grouping field is a dictKey. Variadic groupings always pass
+     * `undefined` — `<field>Label` projection has no meaningful shape
+     * for composite keys.
+     */
+    protected readonly dictLabelResolver?: (
+      key: string,
+      locale: string,
+      fallback?: string | readonly string[],
+    ) => Promise<string | undefined>,
+  ) {
+    this.fields =
+      typeof fieldOrFields === 'string' ? [fieldOrFields] : [...fieldOrFields]
+  }
+}
+
+/**
  * Chainable wrapper returned by `Query.groupBy(field)`. Terminates
  * with `.aggregate(spec)` which returns a `GroupedAggregation`.
  *
@@ -145,35 +188,7 @@ export type GroupedRowN<F extends readonly string[], R> =
  * them post-group would be a different operation (`having` /
  * `groupOrderBy`), out of scope for.
  */
-export class GroupedQuery<T, F extends string> {
-  /**
-   * Field set this grouped query buckets on. Stored in declaration
-   * order — the same order is preserved on every result row by
-   * `groupAndReduce`. For the back-compat single-field constructor,
-   * this is `[field]`.
-   */
-  private readonly fields: readonly string[]
-
-  constructor(
-    private readonly executeRecords: () => readonly unknown[],
-    field: F | readonly string[],
-    private readonly upstreams: readonly AggregationUpstream[],
-    /**
-     * Optional dict label resolver attached by the query builder when
-     * the grouping field is a dictKey.
-     */
-    private readonly dictLabelResolver?: (
-      key: string,
-      locale: string,
-      fallback?: string | readonly string[],
-    ) => Promise<string | undefined>,
-  ) {
-    this.fields = typeof field === 'string' ? [field] : [...field]
-    // T is phantom on the wrapper so consumers can still see the
-    // source row type on hover. Reference it to keep lint quiet.
-    void undefined as T | undefined
-  }
-
+export class GroupedQuery<T, F extends string> extends GroupedQueryBase {
   /**
    * Build a grouped aggregation. Returns a `GroupedAggregation`
    * with `.run()`, `.runAsync()`, and `.live()` terminals — same shape
@@ -183,6 +198,9 @@ export class GroupedQuery<T, F extends string> {
   aggregate<Spec extends AggregateSpec>(
     spec: Spec,
   ): GroupedAggregation<GroupedRow<F, AggregateResult<Spec>>> {
+    // T is phantom on the wrapper so consumers can still see the
+    // source row type on hover. Reference it to keep lint quiet.
+    void undefined as T | undefined
     return new GroupedAggregation<GroupedRow<F, AggregateResult<Spec>>>(
       this.executeRecords,
       this.fields,
@@ -198,26 +216,11 @@ export class GroupedQuery<T, F extends string> {
  * multi-arg `Query.groupBy(...fields)` overload. The runtime shape is
  * identical — only the type-level result-row narrowing differs.
  */
-export class GroupedQueryN<T, F extends readonly string[]> {
-  private readonly fields: readonly string[]
-
-  constructor(
-    private readonly executeRecords: () => readonly unknown[],
-    fields: F,
-    private readonly upstreams: readonly AggregationUpstream[],
-    private readonly dictLabelResolver?: (
-      key: string,
-      locale: string,
-      fallback?: string | readonly string[],
-    ) => Promise<string | undefined>,
-  ) {
-    this.fields = [...fields]
-    void undefined as T | undefined
-  }
-
+export class GroupedQueryN<T, F extends readonly string[]> extends GroupedQueryBase {
   aggregate<Spec extends AggregateSpec>(
     spec: Spec,
   ): GroupedAggregation<GroupedRowN<F, AggregateResult<Spec>>> {
+    void undefined as T | undefined
     return new GroupedAggregation<GroupedRowN<F, AggregateResult<Spec>>>(
       this.executeRecords,
       this.fields,

--- a/packages/hub/src/aggregate/groupby.ts
+++ b/packages/hub/src/aggregate/groupby.ts
@@ -67,6 +67,7 @@ import type {
   LiveAggregation,
 } from './aggregation.js'
 import { buildLiveAggregation } from './aggregation.js'
+import { canonicalGroupKey } from './canonical-key.js'
 import { GroupCardinalityError } from '../errors.js'
 
 /**
@@ -79,18 +80,23 @@ export const GROUPBY_WARN_CARDINALITY = 10_000
 export const GROUPBY_MAX_CARDINALITY = 100_000
 
 /**
- * One-shot warning dedup per-field — reactive dashboards
+ * One-shot warning dedup per-field-set — reactive dashboards
  * re-executing the same grouped query should produce the warning
- * once, not once per re-fire. Keyed on the grouping field name
- * because "this field has high cardinality on your current data"
- * is a field-level property, not a per-query one.
+ * once, not once per re-fire. Keyed on the sorted JSON of grouping
+ * field names so `.groupBy('a', 'b')` and `.groupBy('b', 'a')`
+ * share the same dedup slot (their result tuples are isomorphic).
  */
 const warnedCardinalityFields = new Set<string>()
-function warnCardinalityApproaching(field: string, observed: number): void {
-  if (warnedCardinalityFields.has(field)) return
-  warnedCardinalityFields.add(field)
+function warnCardinalityApproaching(
+  fields: readonly string[],
+  observed: number,
+): void {
+  const key = JSON.stringify([...fields].sort())
+  if (warnedCardinalityFields.has(key)) return
+  warnedCardinalityFields.add(key)
+  const label = `[${fields.join(', ')}]`
   console.warn(
-    `[noy-db] .groupBy("${field}") produced ${observed} distinct groups, ` +
+    `[noy-db] .groupBy(${label}) produced ${observed} distinct groups, ` +
       `${Math.round((observed / GROUPBY_MAX_CARDINALITY) * 100)}% of the ` +
       `${GROUPBY_MAX_CARDINALITY}-group ceiling. Narrow the query with ` +
       `.where() before grouping, or switch to a lower-cardinality field.`,
@@ -121,6 +127,15 @@ export function resetGroupByWarnings(): void {
 export type GroupedRow<F extends string, R> = { [K in F]: unknown } & R
 
 /**
+ * Multi-key variant — result-row shape for variadic
+ * `.groupBy(...fields)`. Every grouped field name appears on the row
+ * (typed as `unknown` for the same reason as `GroupedRow`), plus the
+ * reducer outputs from the spec.
+ */
+export type GroupedRowN<F extends readonly string[], R> =
+  { [K in F[number]]: unknown } & R
+
+/**
  * Chainable wrapper returned by `Query.groupBy(field)`. Terminates
  * with `.aggregate(spec)` which returns a `GroupedAggregation`.
  *
@@ -131,9 +146,17 @@ export type GroupedRow<F extends string, R> = { [K in F]: unknown } & R
  * `groupOrderBy`), out of scope for.
  */
 export class GroupedQuery<T, F extends string> {
+  /**
+   * Field set this grouped query buckets on. Stored in declaration
+   * order — the same order is preserved on every result row by
+   * `groupAndReduce`. For the back-compat single-field constructor,
+   * this is `[field]`.
+   */
+  private readonly fields: readonly string[]
+
   constructor(
     private readonly executeRecords: () => readonly unknown[],
-    private readonly field: F,
+    field: F | readonly string[],
     private readonly upstreams: readonly AggregationUpstream[],
     /**
      * Optional dict label resolver attached by the query builder when
@@ -145,6 +168,7 @@ export class GroupedQuery<T, F extends string> {
       fallback?: string | readonly string[],
     ) => Promise<string | undefined>,
   ) {
+    this.fields = typeof field === 'string' ? [field] : [...field]
     // T is phantom on the wrapper so consumers can still see the
     // source row type on hover. Reference it to keep lint quiet.
     void undefined as T | undefined
@@ -161,7 +185,42 @@ export class GroupedQuery<T, F extends string> {
   ): GroupedAggregation<GroupedRow<F, AggregateResult<Spec>>> {
     return new GroupedAggregation<GroupedRow<F, AggregateResult<Spec>>>(
       this.executeRecords,
-      this.field,
+      this.fields,
+      spec,
+      this.upstreams,
+      this.dictLabelResolver,
+    )
+  }
+}
+
+/**
+ * Variadic-keyed sibling of `GroupedQuery<T, F>`. Constructed by the
+ * multi-arg `Query.groupBy(...fields)` overload. The runtime shape is
+ * identical — only the type-level result-row narrowing differs.
+ */
+export class GroupedQueryN<T, F extends readonly string[]> {
+  private readonly fields: readonly string[]
+
+  constructor(
+    private readonly executeRecords: () => readonly unknown[],
+    fields: F,
+    private readonly upstreams: readonly AggregationUpstream[],
+    private readonly dictLabelResolver?: (
+      key: string,
+      locale: string,
+      fallback?: string | readonly string[],
+    ) => Promise<string | undefined>,
+  ) {
+    this.fields = [...fields]
+    void undefined as T | undefined
+  }
+
+  aggregate<Spec extends AggregateSpec>(
+    spec: Spec,
+  ): GroupedAggregation<GroupedRowN<F, AggregateResult<Spec>>> {
+    return new GroupedAggregation<GroupedRowN<F, AggregateResult<Spec>>>(
+      this.executeRecords,
+      this.fields,
       spec,
       this.upstreams,
       this.dictLabelResolver,
@@ -182,31 +241,51 @@ export class GroupedQuery<T, F extends string> {
  */
 export function groupAndReduce<R>(
   records: readonly unknown[],
-  field: string,
+  fieldOrFields: string | readonly string[],
   spec: AggregateSpec,
 ): R[] {
-  // Map preserves insertion order natively (ES2015), so first-seen
-  // keys determine output ordering without a parallel order array.
-  const buckets = new Map<unknown, unknown[]>()
+  const fields: readonly string[] =
+    typeof fieldOrFields === 'string' ? [fieldOrFields] : fieldOrFields
+  if (fields.length === 0) {
+    throw new Error('.groupBy() requires at least one field')
+  }
+
+  // Bucket value is { keyValues, records } so the output row can stamp
+  // every grouped field in DECLARATION ORDER. Map preserves insertion
+  // order natively (ES2015), so first-seen keys determine ordering.
+  interface Bucket {
+    keyValues: Record<string, unknown>
+    records: unknown[]
+  }
+  const buckets = new Map<string, Bucket>()
+  // Field-label string for error messages — matches the variadic
+  // surface (`[a, b]` for multi-key, `"k"` for single-key back-compat).
+  const fieldLabel = fields.length === 1 ? fields[0]! : `[${fields.join(', ')}]`
+
   for (const record of records) {
-    const key = readPath(record, field)
-    let bucket = buckets.get(key)
+    // Read each field's value into a row object, then canonicalise.
+    const keyValues: Record<string, unknown> = {}
+    for (const f of fields) {
+      keyValues[f] = readPath(record, f)
+    }
+    const dedupKey = canonicalGroupKey(fields, keyValues)
+    let bucket = buckets.get(dedupKey)
     if (bucket === undefined) {
       if (buckets.size >= GROUPBY_MAX_CARDINALITY) {
         throw new GroupCardinalityError(
-          field,
+          fieldLabel,
           buckets.size + 1,
           GROUPBY_MAX_CARDINALITY,
         )
       }
-      bucket = []
-      buckets.set(key, bucket)
+      bucket = { keyValues, records: [] }
+      buckets.set(dedupKey, bucket)
     }
-    bucket.push(record)
+    bucket.records.push(record)
   }
 
   if (buckets.size >= GROUPBY_WARN_CARDINALITY) {
-    warnCardinalityApproaching(field, buckets.size)
+    warnCardinalityApproaching(fields, buckets.size)
   }
 
   // Reduce each bucket through the spec. Same init/step/finalize
@@ -214,21 +293,26 @@ export function groupAndReduce<R>(
   // bucket. Inlining the loop here keeps the per-bucket path tight
   // — calling `reduceRecords` per bucket would recompute
   // `Object.keys(spec)` once per bucket unnecessarily.
-  const keys = Object.keys(spec)
+  const reducerKeys = Object.keys(spec)
   const out: R[] = []
-  for (const [groupKey, bucketRecords] of buckets) {
+  for (const bucket of buckets.values()) {
     const state: Record<string, unknown> = {}
-    for (const key of keys) {
-      state[key] = spec[key]!.init()
+    for (const rk of reducerKeys) {
+      state[rk] = spec[rk]!.init()
     }
-    for (const record of bucketRecords) {
-      for (const key of keys) {
-        state[key] = spec[key]!.step(state[key], record)
+    for (const record of bucket.records) {
+      for (const rk of reducerKeys) {
+        state[rk] = spec[rk]!.step(state[rk], record)
       }
     }
-    const row: Record<string, unknown> = { [field]: groupKey }
-    for (const key of keys) {
-      row[key] = spec[key]!.finalize(state[key])
+    // Stamp grouped fields FIRST, in declaration order — this is
+    // tested via `Object.keys(row).slice(0, fields.length)`.
+    const row: Record<string, unknown> = {}
+    for (const f of fields) {
+      row[f] = bucket.keyValues[f]
+    }
+    for (const rk of reducerKeys) {
+      row[rk] = spec[rk]!.finalize(state[rk])
     }
     out.push(row as unknown as R)
   }
@@ -246,9 +330,11 @@ export function groupAndReduce<R>(
  * bucket.
  */
 export class GroupedAggregation<R> {
+  private readonly fields: readonly string[]
+
   constructor(
     private readonly executeRecords: () => readonly unknown[],
-    private readonly field: string,
+    fields: string | readonly string[],
     private readonly spec: AggregateSpec,
     private readonly upstreams: readonly AggregationUpstream[],
     /**
@@ -260,11 +346,13 @@ export class GroupedAggregation<R> {
       locale: string,
       fallback?: string | readonly string[],
     ) => Promise<string | undefined>,
-  ) {}
+  ) {
+    this.fields = typeof fields === 'string' ? [fields] : [...fields]
+  }
 
   /** Execute the query, group, reduce, and return an array of rows. */
   run(): R[] {
-    return groupAndReduce<R>(this.executeRecords(), this.field, this.spec)
+    return groupAndReduce<R>(this.executeRecords(), this.fields, this.spec)
   }
 
   /**
@@ -275,22 +363,27 @@ export class GroupedAggregation<R> {
    *
    * The `<field>Label` field is appended to each row. Rows whose group
    * key has no dictionary entry get `<field>Label: undefined`.
+   *
+   * Dict-label resolution is single-field only — multi-key groupings
+   * do not produce a `<field>Label`. The resolver is only attached
+   * by the builder when `fields.length === 1`.
    */
   async runAsync(opts?: {
     locale?: string
     fallback?: string | readonly string[]
   }): Promise<R[]> {
-    const rows = groupAndReduce<R>(this.executeRecords(), this.field, this.spec)
-    if (!opts?.locale || !this.dictLabelResolver) return rows
+    const rows = groupAndReduce<R>(this.executeRecords(), this.fields, this.spec)
+    if (!opts?.locale || !this.dictLabelResolver || this.fields.length !== 1) return rows
 
     const resolve = this.dictLabelResolver
     const locale = opts.locale
     const fallback = opts.fallback
-    const labelKey = `${this.field}Label`
+    const field = this.fields[0]!
+    const labelKey = `${field}Label`
 
     return Promise.all(
       rows.map(async (row) => {
-        const key = (row as Record<string, unknown>)[this.field]
+        const key = (row as Record<string, unknown>)[field]
         if (typeof key !== 'string') return row
         const label = await resolve(key, locale, fallback)
         return { ...(row as Record<string, unknown>), [labelKey]: label } as unknown as R
@@ -316,7 +409,7 @@ export class GroupedAggregation<R> {
    */
   live(): LiveAggregation<R[]> {
     const recompute = (): R[] =>
-      groupAndReduce<R>(this.executeRecords(), this.field, this.spec)
+      groupAndReduce<R>(this.executeRecords(), this.fields, this.spec)
     return buildLiveAggregation<R[]>(recompute, this.upstreams)
   }
 }

--- a/packages/hub/src/aggregate/index.ts
+++ b/packages/hub/src/aggregate/index.ts
@@ -27,13 +27,14 @@ export type {
 
 export {
   GroupedQuery,
+  GroupedQueryN,
   GroupedAggregation,
   groupAndReduce,
   resetGroupByWarnings,
   GROUPBY_WARN_CARDINALITY,
   GROUPBY_MAX_CARDINALITY,
 } from './groupby.js'
-export type { GroupedRow } from './groupby.js'
+export type { GroupedRow, GroupedRowN } from './groupby.js'
 
 export { count, sum, avg, min, max } from './reducers.js'
 export type { Reducer, ReducerOptions } from './reducers.js'

--- a/packages/hub/src/aggregate/strategy.ts
+++ b/packages/hub/src/aggregate/strategy.ts
@@ -19,7 +19,7 @@ import type {
   AggregateResult,
   AggregationUpstream,
 } from './aggregation.js'
-import type { GroupedQuery } from './groupby.js'
+import type { GroupedQuery, GroupedQueryN } from './groupby.js'
 
 /**
  * Seam interface. `@internal` — will promote to public only when the
@@ -56,6 +56,23 @@ export interface AggregateStrategy {
   ): GroupedQuery<T, F>
 
   /**
+   * Variadic-keyed sibling — builds a `GroupedQueryN<T, F>` for
+   * `Query.groupBy(...fields)`. The dictLabelResolver, when present,
+   * applies only to single-field groupings; the builder is responsible
+   * for omitting it when `fields.length !== 1`.
+   */
+  groupByN<T, F extends readonly string[]>(
+    executeRecords: () => readonly unknown[],
+    fields: F,
+    upstreams: readonly AggregationUpstream[],
+    dictLabelResolver?: (
+      key: string,
+      locale: string,
+      fallback?: string | readonly string[],
+    ) => Promise<string | undefined>,
+  ): GroupedQueryN<T, F>
+
+  /**
    * Terminal streaming aggregator for `ScanBuilder.aggregate(spec)`.
    * Takes an async iterable of decrypted records + the spec and
    * returns the reduced result.
@@ -83,5 +100,6 @@ const NOT_ENABLED = new Error(
 export const NO_AGGREGATE: AggregateStrategy = {
   aggregate() { throw NOT_ENABLED },
   groupBy() { throw NOT_ENABLED },
+  groupByN() { throw NOT_ENABLED },
   scanAggregate() { throw NOT_ENABLED },
 }

--- a/packages/hub/src/aggregate/strategy.ts
+++ b/packages/hub/src/aggregate/strategy.ts
@@ -57,19 +57,14 @@ export interface AggregateStrategy {
 
   /**
    * Variadic-keyed sibling — builds a `GroupedQueryN<T, F>` for
-   * `Query.groupBy(...fields)`. The dictLabelResolver, when present,
-   * applies only to single-field groupings; the builder is responsible
-   * for omitting it when `fields.length !== 1`.
+   * `Query.groupBy(...fields)`. No dictLabelResolver — `<field>Label`
+   * projection only applies to single-field groupings, which dispatch
+   * through `groupBy` above.
    */
   groupByN<T, F extends readonly string[]>(
     executeRecords: () => readonly unknown[],
     fields: F,
     upstreams: readonly AggregationUpstream[],
-    dictLabelResolver?: (
-      key: string,
-      locale: string,
-      fallback?: string | readonly string[],
-    ) => Promise<string | undefined>,
   ): GroupedQueryN<T, F>
 
   /**

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -1505,6 +1505,36 @@ export class MaterializedViewTooLargeError extends NoydbError {
 }
 
 /**
+ * Thrown by `withMaterializedView()` at registration time when the
+ * strategy is structurally malformed. Distinct from
+ * `MaterializedViewSourceUnknownError` (the source list is well-formed
+ * but names a collection the vault doesn't know) and
+ * `MaterializedViewCycleError` (the source graph has a cycle): this
+ * error fires before either check, at the moment the spec is being
+ * normalized.
+ *
+ * Today the trigger cases are all about the `query` / `unionSources`
+ * dichotomy introduced by #165:
+ *   - both `query` and `unionSources` were set (mutually exclusive),
+ *   - neither `query` nor `unionSources` was set,
+ *   - `unionSources` has fewer than 2 arms,
+ *   - two arms in `unionSources` reference the same `collection`.
+ *
+ * The error message is prefixed with `[noy-db] withMaterializedView:`
+ * so it's grep-friendly in logs and looks consistent with the existing
+ * `ValidationError` messages from the same factory.
+ */
+export class MaterializedViewConfigError extends NoydbError {
+  constructor(message: string) {
+    super(
+      'MATERIALIZED_VIEW_CONFIG',
+      `[noy-db] withMaterializedView: ${message}`,
+    )
+    this.name = 'MaterializedViewConfigError'
+  }
+}
+
+/**
  * Thrown at vault open when a `withOverlayedView` declaration uses
  * another virtual-overlay name as its `base`. Multi-overlay stacking
  * is a v2 non-goal — the shallow expansion in

--- a/packages/hub/src/guards/types.ts
+++ b/packages/hub/src/guards/types.ts
@@ -45,6 +45,41 @@ export interface GuardStrategyHandle<T extends Record<string, unknown>> {
   readonly spec: GuardStrategy<T>
 }
 
+/**
+ * Existential erasure of `GuardStrategyHandle<T>` — used as the
+ * element type of `ReadonlyArray<>` fields where the per-handle T
+ * differs (e.g. `guardStrategies: [invoiceGuard, disbursementGuard]`).
+ *
+ * Background: `GuardStrategyHandle<T>` is INVARIANT in T because T
+ * appears in callback positions on the spec (`check(incoming: T, ctx)`,
+ * `invariant(changes: ReadonlyArray<GuardChange<T>>, ctx)`). So
+ * `Handle<Invoice>` is not assignable to `Handle<Record<string, unknown>>`.
+ * A bounded existential ("there exists some T satisfying the constraint
+ * such that this is a Handle<T>") is the right shape; TypeScript has
+ * no first-class existentials, so we fake it with a structurally narrow
+ * interface that ERASES T from both the discriminant and the spec.
+ *
+ * Consumers continue to construct typed handles via `withGuard<T>(...)`
+ * which returns `GuardStrategyHandle<T>`. Both `Handle<Invoice>` and
+ * `Handle<Disbursement>` structurally assign to `GuardStrategyHandleAny`,
+ * so an array of them is `GuardStrategyHandleAny[]`.
+ *
+ * Internal code that needs T re-narrows via the runtime discriminant
+ * (`__noydb_strategy === 'guard'`) plus per-handle type information
+ * carried by the registry.
+ *
+ * NOT exported from the public barrel — keeping this internal
+ * discourages consumers from constructing it directly. Used only as
+ * the array-element type on `Vault` / `NoydbOptions.guardStrategies`.
+ *
+ * @internal
+ */
+export interface GuardStrategyHandleAny {
+  readonly __noydb_strategy: 'guard'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  readonly spec: GuardStrategy<any>
+}
+
 /** Public registration shape. See `withGuard()`. */
 export interface GuardStrategy<T extends Record<string, unknown>> {
   collection: string

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -510,9 +510,11 @@ export type {
   MaterializedViewStrategyHandle,
   MaterializedViewOutput,
   MaterializedFromMeta,
+  UnionSource,
 } from './materialized-views/index.js'
 export {
   MaterializedViewCycleError,
+  MaterializedViewConfigError,
   MaterializedViewSourceUnknownError,
   MaterializedViewTooLargeError,
 } from './errors.js'

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -740,6 +740,7 @@ export {
   Aggregation,
   reduceRecords,
   GroupedQuery,
+  GroupedQueryN,
   GroupedAggregation,
   groupAndReduce,
   GROUPBY_WARN_CARDINALITY,
@@ -770,5 +771,6 @@ export type {
   AggregationUpstream,
   LiveAggregation,
   GroupedRow,
+  GroupedRowN,
   ScanPageProvider,
 } from './query/index.js'

--- a/packages/hub/src/materialized-views/dependency-analyzer.ts
+++ b/packages/hub/src/materialized-views/dependency-analyzer.ts
@@ -87,10 +87,23 @@ export function summarizeQueryPlan(query: Query<any>): string {
 
 /**
  * Canonical string description of a UNION MV's plan, used as input to
- * `computeQueryHash`. Sorts arm collection names + groupBy fields +
- * aggregate spec keys so structural reorderings produce the same hash
- * (the order of `unionSources` and the field order inside `groupBy`
- * don't change semantics — sorting catches that).
+ * `computeQueryHash`.
+ *
+ * Asymmetry note (#165 niwat review):
+ *   - Arm collection names are NOT sorted. Declaration order is
+ *     semantically meaningful for the dedup-only UNION path —
+ *     `materializeUnionResult` iterates `spec.unionSources` in
+ *     declaration order and keeps the first-seen row per composite key
+ *     (tie-break precedence). If we sorted arms here, a consumer who
+ *     reordered `unionSources` to change precedence would compute the
+ *     same `queryHash`, refresh would be a no-op, and stale MV rows
+ *     would persist. Hashing in declaration order makes any reorder
+ *     trigger a refresh.
+ *   - `groupBy` fields ARE sorted. Multi-key groupBy buckets are
+ *     commutative (`canonicalGroupKey` produces the same composite key
+ *     regardless of field order in the input spec).
+ *   - `aggregate` keys ARE sorted. Reducer-spec keys are independent
+ *     of each other — order of declaration doesn't change output.
  *
  * Per-arm `map` functions are NOT fingerprinted; consumers must bump
  * the MV's `name` (or rely on application-level cache busting) when
@@ -99,9 +112,8 @@ export function summarizeQueryPlan(query: Query<any>): string {
 export function summarizeUnionPlan<T extends Record<string, unknown>>(
   spec: MaterializedViewStrategy<T>,
 ): string {
-  const arms = [...(spec.unionSources ?? [])]
+  const arms = (spec.unionSources ?? [])
     .map(s => s.collection)
-    .sort()
     .join(',')
   const groupBy: string = Array.isArray(spec.groupBy)
     ? [...spec.groupBy].sort().join(',')

--- a/packages/hub/src/materialized-views/dependency-analyzer.ts
+++ b/packages/hub/src/materialized-views/dependency-analyzer.ts
@@ -103,9 +103,11 @@ export function summarizeUnionPlan<T extends Record<string, unknown>>(
     .map(s => s.collection)
     .sort()
     .join(',')
-  const groupBy = Array.isArray(spec.groupBy)
+  const groupBy: string = Array.isArray(spec.groupBy)
     ? [...spec.groupBy].sort().join(',')
-    : (spec.groupBy ?? '')
+    : typeof spec.groupBy === 'string'
+      ? spec.groupBy
+      : ''
   const aggKeys = spec.aggregate ? Object.keys(spec.aggregate).sort().join(',') : ''
   return `union(${arms})|groupBy(${groupBy})|aggregate(${aggKeys})`
 }

--- a/packages/hub/src/materialized-views/dependency-analyzer.ts
+++ b/packages/hub/src/materialized-views/dependency-analyzer.ts
@@ -1,5 +1,6 @@
 import type { Query, QueryPlan } from '../query/builder.js'
 import type { JoinContext } from '../query/join.js'
+import type { MaterializedViewStrategy } from './types.js'
 
 /**
  * Walks a `Query<T>` plan and returns the set of source collection
@@ -82,4 +83,29 @@ export function summarizeQueryPlan(query: Query<any>): string {
     offset: plan.offset,
     joins: plan.joins.map(j => ({ field: j.field, as: j.as, target: j.target, mode: j.mode })),
   })
+}
+
+/**
+ * Canonical string description of a UNION MV's plan, used as input to
+ * `computeQueryHash`. Sorts arm collection names + groupBy fields +
+ * aggregate spec keys so structural reorderings produce the same hash
+ * (the order of `unionSources` and the field order inside `groupBy`
+ * don't change semantics — sorting catches that).
+ *
+ * Per-arm `map` functions are NOT fingerprinted; consumers must bump
+ * the MV's `name` (or rely on application-level cache busting) when
+ * `map` semantics change non-equivalently.
+ */
+export function summarizeUnionPlan<T extends Record<string, unknown>>(
+  spec: MaterializedViewStrategy<T>,
+): string {
+  const arms = [...(spec.unionSources ?? [])]
+    .map(s => s.collection)
+    .sort()
+    .join(',')
+  const groupBy = Array.isArray(spec.groupBy)
+    ? [...spec.groupBy].sort().join(',')
+    : (spec.groupBy ?? '')
+  const aggKeys = spec.aggregate ? Object.keys(spec.aggregate).sort().join(',') : ''
+  return `union(${arms})|groupBy(${groupBy})|aggregate(${aggKeys})`
 }

--- a/packages/hub/src/materialized-views/executor.ts
+++ b/packages/hub/src/materialized-views/executor.ts
@@ -103,7 +103,7 @@ async function materializeUnionResult<TRow extends Record<string, unknown>>(
   const unified: TRow[] = []
   for (const arm of spec.unionSources!) {
     const coll = db.collection<Record<string, unknown>>(arm.collection)
-    const sourceRows = await coll.query().toArray()
+    const sourceRows = coll.query().toArray()
     for (const r of sourceRows) {
       unified.push(arm.map(r))
     }

--- a/packages/hub/src/materialized-views/executor.ts
+++ b/packages/hub/src/materialized-views/executor.ts
@@ -121,6 +121,15 @@ export const MaterializedViewExecutor = {
     const ctxForQuery: MVQueryContext = spec.predicates
       ? wrapDbWithPredicates(baseCtx, spec.predicates)
       : baseCtx
+    // UNION-form strategies (#165) have no `query` callback; the
+    // executor branch for them lands in Tasks 10+11. Until then, the
+    // registry path also rejects UNION-form, so reaching here means a
+    // single-source strategy and `spec.query` is guaranteed defined.
+    if (!spec.query) {
+      throw new Error(
+        `[noy-db] internal: UNION-form MV "${spec.name}" reached single-source executor path — Task 10/11 executor work pending.`,
+      )
+    }
     const q = spec.query(ctxForQuery)
     const rows = await materializeQueryResult(q, spec.name)
 

--- a/packages/hub/src/materialized-views/executor.ts
+++ b/packages/hub/src/materialized-views/executor.ts
@@ -2,9 +2,11 @@ import type { Collection } from '../collection.js'
 import type { TxContext } from '../tx/transaction.js'
 import type { EncryptedEnvelope } from '../types.js'
 import { MaterializedViewTooLargeError } from '../errors.js'
-import type { MaterializedFromMeta, MVQueryContext } from './types.js'
+import type { MaterializedFromMeta, MVQueryContext, MaterializedViewStrategy } from './types.js'
 import type { RegisteredMV } from './registry.js'
 import { wrapDbWithPredicates } from './registry.js'
+import { groupAndReduce } from '../aggregate/groupby.js'
+import { canonicalGroupKey } from '../aggregate/canonical-key.js'
 
 /**
  * Accessor shape passed in from the owning Vault. Mirrors v1's
@@ -74,6 +76,63 @@ async function materializeQueryResult(
 }
 
 /**
+ * Materialize a UNION-form MV (#165): read every arm's source
+ * collection, apply each arm's `map` to project rows into the unified
+ * MV row shape, concatenate the mapped streams, then optionally run
+ * `groupBy` + `aggregate` over the result.
+ *
+ * Modes (driven by `spec.groupBy` / `spec.aggregate`):
+ *
+ *   - No `groupBy` → return the concatenated mapped rows unchanged.
+ *   - `groupBy` without `aggregate` → dedupe by composite group key,
+ *     keep the first row seen per key (later arms don't overwrite
+ *     earlier arms — Map insertion order rules).
+ *   - `groupBy` + `aggregate` → delegate to the shared `groupAndReduce`
+ *     pipeline used by `Query.groupBy().aggregate()`.
+ *
+ * Per-arm `map` is the schema-unification boundary; the strategy's
+ * `TRow` type parameter enforces that every arm projects into the
+ * same shape at compile time.
+ *
+ * @internal
+ */
+async function materializeUnionResult<TRow extends Record<string, unknown>>(
+  spec: MaterializedViewStrategy<TRow>,
+  db: MVQueryContext,
+): Promise<ReadonlyArray<Record<string, unknown>>> {
+  const unified: TRow[] = []
+  for (const arm of spec.unionSources!) {
+    const coll = db.collection<Record<string, unknown>>(arm.collection)
+    const sourceRows = await coll.query().toArray()
+    for (const r of sourceRows) {
+      unified.push(arm.map(r))
+    }
+  }
+
+  if (!spec.groupBy) return unified
+
+  const groupFields: readonly string[] =
+    typeof spec.groupBy === 'string' ? [spec.groupBy] : spec.groupBy
+
+  // groupBy without aggregate — dedupe by composite key, keep first
+  // seen row per key. Useful for cross-arm uniqueness (e.g. unify two
+  // sibling collections, keeping one row per natural key).
+  if (!spec.aggregate) {
+    const seen = new Map<string, TRow>()
+    for (const row of unified) {
+      const k = canonicalGroupKey(groupFields, row as Record<string, unknown>)
+      if (!seen.has(k)) seen.set(k, row)
+    }
+    return [...seen.values()]
+  }
+
+  // groupBy + aggregate — delegate to the shared pipeline used by
+  // `Query.groupBy().aggregate()`. Result rows carry each grouped
+  // field in declaration order followed by the spec's reducer outputs.
+  return groupAndReduce<Record<string, unknown>>(unified, groupFields, spec.aggregate)
+}
+
+/**
  * Run an MV's `query()` and write the result rows to the output
  * collection. Same-DEK encryption: routes through the standard
  * `Collection.put` pipeline, so the output collection's DEK is what
@@ -121,17 +180,16 @@ export const MaterializedViewExecutor = {
     const ctxForQuery: MVQueryContext = spec.predicates
       ? wrapDbWithPredicates(baseCtx, spec.predicates)
       : baseCtx
-    // UNION-form strategies (#165) have no `query` callback; the
-    // executor branch for them lands in Tasks 10+11. Until then, the
-    // registry path also rejects UNION-form, so reaching here means a
-    // single-source strategy and `spec.query` is guaranteed defined.
-    if (!spec.query) {
-      throw new Error(
-        `[noy-db] internal: UNION-form MV "${spec.name}" reached single-source executor path — Task 10/11 executor work pending.`,
-      )
+    // UNION-form strategies (#165): read every arm, map to the unified
+    // row shape, concatenate, then optionally groupBy + aggregate. The
+    // single-source `query()` path is untouched.
+    let rows: ReadonlyArray<Record<string, unknown>>
+    if (spec.unionSources) {
+      rows = await materializeUnionResult(spec, ctxForQuery)
+    } else {
+      const q = spec.query!(ctxForQuery)
+      rows = await materializeQueryResult(q, spec.name)
     }
-    const q = spec.query(ctxForQuery)
-    const rows = await materializeQueryResult(q, spec.name)
 
     // 2. Cost ceiling check BEFORE any writes — keeps the rollback
     //    clean if the source-write is wrapped in a transaction.

--- a/packages/hub/src/materialized-views/index.ts
+++ b/packages/hub/src/materialized-views/index.ts
@@ -10,6 +10,7 @@ export type {
   MaterializedViewStrategyHandle,
   MaterializedViewOutput,
   MaterializedFromMeta,
+  UnionSource,
 } from './types.js'
 export type { RegisteredMV } from './registry.js'
 export type { MVExecutorAccessor, RefreshResult } from './executor.js'
@@ -18,6 +19,7 @@ export type { MVExecutorAccessor, RefreshResult } from './executor.js'
 // (matches the v1 derivations subpath pattern).
 export {
   MaterializedViewCycleError,
+  MaterializedViewConfigError,
   MaterializedViewSourceUnknownError,
   MaterializedViewTooLargeError,
 } from '../errors.js'

--- a/packages/hub/src/materialized-views/registry.ts
+++ b/packages/hub/src/materialized-views/registry.ts
@@ -2,7 +2,7 @@ import { MaterializedViewCycleError, MaterializedViewSourceUnknownError } from '
 import type { DerivationRegistry } from '../derivations/registry.js'
 import type { Clause, FieldClause } from '../query/predicate.js'
 import type { DeclaredPredicate } from '../query/builder.js'
-import { analyzeDependencies, summarizeQueryPlan } from './dependency-analyzer.js'
+import { analyzeDependencies, summarizeQueryPlan, summarizeUnionPlan } from './dependency-analyzer.js'
 import { computeQueryHash } from './query-hash.js'
 import type { MaterializedViewStrategy, MVQueryContext } from './types.js'
 
@@ -70,51 +70,52 @@ export class MaterializedViewRegistry {
     // expose the underlying Query, so the spec must declare `sources`
     // explicitly. `partitionClauses` are only populated for Query<T>
     // since same-collection-partition is a non-aggregate concern.
-    // UNION-form strategies (#165) have no `query` callback — registration
-    // validation in `withMaterializedView` enforces exactly one of
-    // `query` / `unionSources`. The UNION executor work lands in Tasks
-    // 10+11; for now, registry-time dependency analysis short-circuits
-    // for UNION-form strategies (sources come straight from
-    // `unionSources[].collection`).
-    if (!spec.query) {
-      throw new Error(
-        `[noy-db] internal: UNION-form MV "${spec.name}" reached single-source registry path — Task 10/11 executor work pending.`,
-      )
-    }
-    const q = spec.query(dbForQuery)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const qAny = q as any
-    const isQuery = typeof qAny._plan === 'function'
+    // UNION-form strategies (#165): dependencies and plan summary come
+    // straight off the strategy — no `query` callback to introspect.
+    // The dependency-analyzer + summarizer are bypassed entirely; the
+    // executor handles materialization via `materializeUnionResult`.
     let dependencies: Set<string>
     let queryPlanSummary: string
-    if (isQuery) {
-      dependencies = analyzeDependencies(q)
-      queryPlanSummary = summarizeQueryPlan(q)
-      // Fold `.wherePredicate(name, ctx)` references into the plan
-      // summary so predicate function or ctx changes (signalled by
-      // bumping `hash` or supplying a different ctx) propagate into
-      // `queryHash` and force refresh on next visit.
-      const predicateRefs = extractPredicateRefs(qAny._plan())
-      if (predicateRefs.length > 0) {
-        queryPlanSummary = JSON.stringify({ plan: queryPlanSummary, predicates: predicateRefs })
-      }
-      // If `sources` is ALSO declared, take the union (consumer's
-      // explicit list extends the auto-analyzed set).
-      if (spec.sources) for (const s of spec.sources) dependencies.add(s)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let qAny: any = null
+    let isQuery = false
+    if (spec.unionSources) {
+      dependencies = new Set(spec.unionSources.map(s => s.collection))
+      queryPlanSummary = summarizeUnionPlan(spec)
     } else {
-      // Aggregate shape: require explicit `sources`.
-      if (!spec.sources || spec.sources.length === 0) {
-        throw new Error(
-          `withMaterializedView "${spec.name}": query() returned an aggregate ` +
-            `(Aggregation or GroupedAggregation) but no \`sources\` field is declared. ` +
-            `The dependency analyzer cannot walk through groupBy().aggregate() ` +
-            `back to the source — declare sources: [...] explicitly.`,
-        )
+      const q = spec.query!(dbForQuery)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      qAny = q as any
+      isQuery = typeof qAny._plan === 'function'
+      if (isQuery) {
+        dependencies = analyzeDependencies(q)
+        queryPlanSummary = summarizeQueryPlan(q)
+        // Fold `.wherePredicate(name, ctx)` references into the plan
+        // summary so predicate function or ctx changes (signalled by
+        // bumping `hash` or supplying a different ctx) propagate into
+        // `queryHash` and force refresh on next visit.
+        const predicateRefs = extractPredicateRefs(qAny._plan())
+        if (predicateRefs.length > 0) {
+          queryPlanSummary = JSON.stringify({ plan: queryPlanSummary, predicates: predicateRefs })
+        }
+        // If `sources` is ALSO declared, take the union (consumer's
+        // explicit list extends the auto-analyzed set).
+        if (spec.sources) for (const s of spec.sources) dependencies.add(s)
+      } else {
+        // Aggregate shape: require explicit `sources`.
+        if (!spec.sources || spec.sources.length === 0) {
+          throw new Error(
+            `withMaterializedView "${spec.name}": query() returned an aggregate ` +
+              `(Aggregation or GroupedAggregation) but no \`sources\` field is declared. ` +
+              `The dependency analyzer cannot walk through groupBy().aggregate() ` +
+              `back to the source — declare sources: [...] explicitly.`,
+          )
+        }
+        dependencies = new Set(spec.sources)
+        // Aggregate plans don't carry a chainable query plan for summary
+        // purposes; the dep-set + spec.name serve as the queryHash inputs.
+        queryPlanSummary = JSON.stringify({ aggregate: true, sources: [...spec.sources].sort() })
       }
-      dependencies = new Set(spec.sources)
-      // Aggregate plans don't carry a chainable query plan for summary
-      // purposes; the dep-set + spec.name serve as the queryHash inputs.
-      queryPlanSummary = JSON.stringify({ aggregate: true, sources: [...spec.sources].sort() })
     }
 
     // Sanity-check declared dependencies against the vault's known

--- a/packages/hub/src/materialized-views/registry.ts
+++ b/packages/hub/src/materialized-views/registry.ts
@@ -70,6 +70,17 @@ export class MaterializedViewRegistry {
     // expose the underlying Query, so the spec must declare `sources`
     // explicitly. `partitionClauses` are only populated for Query<T>
     // since same-collection-partition is a non-aggregate concern.
+    // UNION-form strategies (#165) have no `query` callback — registration
+    // validation in `withMaterializedView` enforces exactly one of
+    // `query` / `unionSources`. The UNION executor work lands in Tasks
+    // 10+11; for now, registry-time dependency analysis short-circuits
+    // for UNION-form strategies (sources come straight from
+    // `unionSources[].collection`).
+    if (!spec.query) {
+      throw new Error(
+        `[noy-db] internal: UNION-form MV "${spec.name}" reached single-source registry path — Task 10/11 executor work pending.`,
+      )
+    }
     const q = spec.query(dbForQuery)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const qAny = q as any

--- a/packages/hub/src/materialized-views/types.ts
+++ b/packages/hub/src/materialized-views/types.ts
@@ -1,5 +1,6 @@
 import type { Query } from '../query/builder.js'
 import type { Collection } from '../collection.js'
+import type { AggregateSpec } from '../aggregate/aggregation.js'
 
 /**
  * Minimal vault-shaped accessor passed to the MV `query()` callback.
@@ -57,6 +58,29 @@ export interface MaterializedViewOutput {
 }
 
 /**
+ * One arm of a UNION materialized view. Reads rows from `collection`,
+ * then maps each into the MV's row shape via `map`.
+ *
+ * The per-source `map` is the schema-unification boundary — sibling
+ * collections can have different schemas, and `map` is where they
+ * meet the MV's row type. The hub does NOT compare schemas across
+ * arms; consumer responsibility is that every arm's `map` returns
+ * the same shape (the strategy's `TRow` type parameter enforces this
+ * at compile time).
+ */
+export interface UnionSource<TRow extends Record<string, unknown>> {
+  /** Source collection name. Must exist in the vault. */
+  readonly collection: string
+  /**
+   * Pure function from a source row to the unified MV row shape.
+   * Called once per source row at materialization time. Each arm's
+   * mapped output is concatenated into a single stream before
+   * `groupBy` + `aggregate` run.
+   */
+  readonly map: (sourceRow: Record<string, unknown>) => TRow
+}
+
+/**
  * Registration shape passed to `withMaterializedView()`.
  *
  * @typeParam TRow - the materialized row type (the query's result row)
@@ -68,16 +92,59 @@ export interface MaterializedViewStrategy<TRow extends Record<string, unknown>> 
    */
   name: string
   /**
-   * Declared query. Called at registration time with a vault-shaped
-   * accessor so the closure can compose collections without
-   * pre-existing in-scope references; called again at each refresh.
+   * Declared query (single-source mode). Called at registration time
+   * with a vault-shaped accessor so the closure can compose collections
+   * without pre-existing in-scope references; called again at each
+   * refresh.
    *
    * Built via the same `Query<T>` chainable builder used elsewhere —
    * `.where()`, `.join()`, `.groupBy()`, `.aggregate()`. The
    * dependency analyzer walks the returned plan to determine source
    * collections.
+   *
+   * Mutually exclusive with {@link unionSources}: a strategy must
+   * declare exactly one of `query` (single-source) or `unionSources`
+   * (multi-source UNION). Registration throws
+   * `MaterializedViewConfigError` if both are set or neither is set.
    */
-  query: (db: MVQueryContext) => Query<TRow>
+  query?: (db: MVQueryContext) => Query<TRow>
+  /**
+   * UNION-form sources (#165): an explicit list of sibling collections
+   * that contribute rows to a single MV. Each arm's `map` projects a
+   * source row into the MV's unified row shape; the mapped streams are
+   * concatenated, then {@link groupBy} + {@link aggregate} run on the
+   * combined output.
+   *
+   * Mutually exclusive with {@link query}. Registration throws
+   * `MaterializedViewConfigError` if both are set, if `unionSources`
+   * has fewer than 2 arms, or if two arms name the same `collection`.
+   *
+   * UNION mode replaces the dependency-analyzer path: the source
+   * collections come directly from `unionSources[].collection`, and
+   * {@link sources} is ignored.
+   */
+  unionSources?: ReadonlyArray<UnionSource<TRow>>
+  /**
+   * Group-key field(s) for UNION mode (#165). Applied to the
+   * concatenated mapped-row stream from {@link unionSources} before
+   * {@link aggregate} runs. Accepts a single field name or a tuple of
+   * field names for multi-key grouping (same shape as
+   * `Query.groupBy(...fields)`).
+   *
+   * UNION-mode only. Ignored if {@link query} is set — single-source
+   * grouping is expressed inside the `Query<T>` returned from `query()`
+   * via `.groupBy(...).aggregate(...)`.
+   */
+  groupBy?: string | ReadonlyArray<string>
+  /**
+   * Aggregation spec for UNION mode (#165). Applied per-group after
+   * {@link groupBy} buckets the concatenated mapped-row stream from
+   * {@link unionSources}. Same shape as the `AggregateSpec` passed to
+   * `Query.aggregate()`.
+   *
+   * UNION-mode only. Ignored if {@link query} is set.
+   */
+  aggregate?: AggregateSpec
   /**
    * Pure function from a materialized row → stable id used in the
    * output collection. Required — explicit always beats default-with-pitfalls

--- a/packages/hub/src/materialized-views/with-materialized-view.ts
+++ b/packages/hub/src/materialized-views/with-materialized-view.ts
@@ -1,4 +1,4 @@
-import { ValidationError } from '../errors.js'
+import { MaterializedViewConfigError, ValidationError } from '../errors.js'
 import type { MaterializedViewStrategy, MaterializedViewStrategyHandle } from './types.js'
 
 /**
@@ -9,7 +9,19 @@ import type { MaterializedViewStrategy, MaterializedViewStrategyHandle } from '.
  * user `onDelete` guards on the output collection aren't tripped by
  * housekeeping.
  *
- * See docs/superpowers/specs/2026-05-20-dim14-mv-v2-design.md.
+ * Two registration modes:
+ *   - **single-source** — declare `query: (db) => Query<TRow>`; the
+ *     dependency analyzer derives source collections from the plan.
+ *   - **UNION** (#165) — declare `unionSources: [{ collection, map }, ...]`
+ *     plus optional `groupBy` + `aggregate`; the executor reads each
+ *     arm, maps to the unified row shape, concatenates, then groups
+ *     and aggregates.
+ *
+ * The two modes are mutually exclusive — exactly one of `query` /
+ * `unionSources` must be set at registration time.
+ *
+ * See docs/superpowers/specs/2026-05-20-dim14-mv-v2-design.md (single-source v2)
+ * and docs/superpowers/specs/2026-05-21-dim14-mv-multikey-and-union.md (UNION).
  */
 export function withMaterializedView<TRow extends Record<string, unknown>>(
   spec: MaterializedViewStrategy<TRow>,
@@ -17,8 +29,47 @@ export function withMaterializedView<TRow extends Record<string, unknown>>(
   if (!spec.name || spec.name.length === 0) {
     throw new ValidationError('withMaterializedView: name is required')
   }
-  if (typeof spec.query !== 'function') {
+  // Mutual exclusion: query and unionSources cannot coexist.
+  if (spec.query && spec.unionSources) {
+    throw new MaterializedViewConfigError(
+      'query and unionSources are mutually exclusive — pick one',
+    )
+  }
+  // Strategy must declare one of the two.
+  if (!spec.query && !spec.unionSources) {
+    throw new MaterializedViewConfigError(
+      'strategy must declare either query or unionSources',
+    )
+  }
+  if (spec.query !== undefined && typeof spec.query !== 'function') {
     throw new ValidationError('withMaterializedView: query must be a function returning a Query<T>')
+  }
+  // UNION-form invariants.
+  if (spec.unionSources) {
+    if (spec.unionSources.length < 2) {
+      throw new MaterializedViewConfigError(
+        'unionSources requires at least 2 source collections',
+      )
+    }
+    const seen = new Set<string>()
+    for (const s of spec.unionSources) {
+      if (typeof s?.collection !== 'string' || s.collection.length === 0) {
+        throw new MaterializedViewConfigError(
+          'each unionSources entry must declare a non-empty `collection` string',
+        )
+      }
+      if (typeof s.map !== 'function') {
+        throw new MaterializedViewConfigError(
+          `unionSources entry for "${s.collection}" is missing a \`map\` function`,
+        )
+      }
+      if (seen.has(s.collection)) {
+        throw new MaterializedViewConfigError(
+          `unionSources must reference distinct collections (duplicate: "${s.collection}")`,
+        )
+      }
+      seen.add(s.collection)
+    }
   }
   if (typeof spec.rowKey !== 'function') {
     throw new ValidationError('withMaterializedView: rowKey is required (no default; see spec § Type surface)')

--- a/packages/hub/src/materialized-views/with-materialized-view.ts
+++ b/packages/hub/src/materialized-views/with-materialized-view.ts
@@ -75,6 +75,19 @@ export function withMaterializedView<TRow extends Record<string, unknown>>(
         `withMaterializedView "${spec.name}": groupBy must not be an empty array — omit it or provide at least one field name`,
       )
     }
+    if (spec.aggregate && !spec.groupBy) {
+      throw new MaterializedViewConfigError(
+        `withMaterializedView "${spec.name}": UNION strategy with aggregate requires groupBy — `
+        + `use groupBy to declare the bucketing keys, or remove aggregate for a pure dedup MV`,
+      )
+    }
+    if (spec.predicates) {
+      throw new MaterializedViewConfigError(
+        `withMaterializedView "${spec.name}": predicates are not supported on UNION strategies — `
+        + `UNION mode does not use a Query<T> chain, so .wherePredicate() cannot fire. `
+        + `Use the query() form, or open an issue if per-arm predicates are needed`,
+      )
+    }
   }
   if (typeof spec.rowKey !== 'function') {
     throw new ValidationError('withMaterializedView: rowKey is required (no default; see spec § Type surface)')

--- a/packages/hub/src/materialized-views/with-materialized-view.ts
+++ b/packages/hub/src/materialized-views/with-materialized-view.ts
@@ -70,6 +70,11 @@ export function withMaterializedView<TRow extends Record<string, unknown>>(
       }
       seen.add(s.collection)
     }
+    if (Array.isArray(spec.groupBy) && spec.groupBy.length === 0) {
+      throw new MaterializedViewConfigError(
+        `withMaterializedView "${spec.name}": groupBy must not be an empty array — omit it or provide at least one field name`,
+      )
+    }
   }
   if (typeof spec.rowKey !== 'function') {
     throw new ValidationError('withMaterializedView: rowKey is required (no default; see spec § Type surface)')

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -13,7 +13,7 @@ import { applyJoins } from './join.js'
 import type { LiveQuery, LiveUpstream } from './live.js'
 import { buildLiveQuery } from './live.js'
 import type { AggregateSpec, AggregateResult, AggregationUpstream, Aggregation } from '../aggregate/aggregation.js'
-import type { GroupedQuery } from '../aggregate/groupby.js'
+import type { GroupedQuery, GroupedQueryN } from '../aggregate/groupby.js'
 import { NO_AGGREGATE, type AggregateStrategy } from '../aggregate/strategy.js'
 
 export interface OrderBy {
@@ -585,7 +585,14 @@ export class Query<T> {
    * The performance caveat is the same: filter clauses cost O(N)
    * per record and can't be index-accelerated.
    */
-  groupBy<F extends string>(field: F): GroupedQuery<T, F> {
+  groupBy<F extends string>(field: F): GroupedQuery<T, F>
+  groupBy<F extends readonly [string, string, ...string[]]>(
+    ...fields: F
+  ): GroupedQueryN<T, F>
+  groupBy(...fields: readonly string[]): GroupedQuery<T, string> | GroupedQueryN<T, readonly string[]> {
+    if (fields.length === 0) {
+      throw new Error('.groupBy() requires at least one field')
+    }
     // Same record-producing closure as .aggregate() — grouped and
     // non-grouped aggregations execute over the same candidate set.
     // We inline the closure here instead of sharing a helper so the
@@ -605,48 +612,23 @@ export class Query<T> {
       upstreams.push({ subscribe: (cb: () => void) => subscribe(cb) })
     }
 
-    // Wire dictKey label resolver for <field>Label projection
-    const joinCtx = this.joinContext
-    const dictLabelResolver = joinCtx?.resolveDictSource
-      ? (() => {
-          const dictSource = joinCtx.resolveDictSource(field)
-          if (!dictSource) return undefined
-          const snapshot = dictSource.snapshot()
-          const dictMap = new Map<string, Record<string, string>>()
-          for (const entry of snapshot) {
-            const k = (entry as Record<string, unknown>)['key']
-            const labels = (entry as Record<string, unknown>)['labels']
-            if (typeof k === 'string' && labels && typeof labels === 'object') {
-              dictMap.set(k, labels as Record<string, string>)
-            }
-          }
-          return async (
-            key: string,
-            locale: string,
-            fallback?: string | readonly string[],
-          ): Promise<string | undefined> => {
-            const labels = dictMap.get(key)
-            if (!labels) return undefined
-            if (labels[locale] !== undefined) return labels[locale]
-            const chain = Array.isArray(fallback)
-              ? (fallback as readonly string[])
-              : fallback
-                ? [fallback as string]
-                : []
-            for (const fb of chain) {
-              if (fb === 'any') {
-                const any = Object.values(labels)[0]
-                if (any !== undefined) return any
-              } else if (labels[fb] !== undefined) {
-                return labels[fb]
-              }
-            }
-            return undefined
-          }
-        })()
-      : undefined
-
-    return this.aggregateStrategy.groupBy<T, F>(executeRecords, field, upstreams, dictLabelResolver)
+    // Dict-label resolution is single-field only — the <field>Label
+    // projection has no meaningful shape for composite keys.
+    if (fields.length === 1) {
+      const field = fields[0]!
+      const dictLabelResolver = buildDictLabelResolver(this.joinContext, field)
+      return this.aggregateStrategy.groupBy<T, string>(
+        executeRecords,
+        field,
+        upstreams,
+        dictLabelResolver,
+      )
+    }
+    return this.aggregateStrategy.groupByN<T, readonly string[]>(
+      executeRecords,
+      fields,
+      upstreams,
+    )
   }
 
   /**
@@ -1007,4 +989,60 @@ function canonicalCtxHash(ctx: unknown): string {
     h = ((h << 5) + h) ^ canonical.charCodeAt(i)
   }
   return (h >>> 0).toString(16).padStart(8, "0")
+}
+
+/**
+ * Build a dict-label resolver for `Query.groupBy(field)` when the
+ * grouping field is a `dictKey`. Extracted from the inline closure
+ * inside `groupBy` so the multi-key path (which has no meaningful
+ * `<field>Label` shape) can skip it cleanly. Pure refactor — no
+ * behaviour change for the single-field path.
+ *
+ * Returns `undefined` when:
+ *   - the join context lacks a `resolveDictSource` hook, or
+ *   - no dictionary source is registered for `field`.
+ *
+ * @internal
+ */
+function buildDictLabelResolver(
+  joinCtx: JoinContext | undefined,
+  field: string,
+):
+  | ((key: string, locale: string, fallback?: string | readonly string[]) => Promise<string | undefined>)
+  | undefined {
+  if (!joinCtx?.resolveDictSource) return undefined
+  const dictSource = joinCtx.resolveDictSource(field)
+  if (!dictSource) return undefined
+  const snapshot = dictSource.snapshot()
+  const dictMap = new Map<string, Record<string, string>>()
+  for (const entry of snapshot) {
+    const k = (entry as Record<string, unknown>)['key']
+    const labels = (entry as Record<string, unknown>)['labels']
+    if (typeof k === 'string' && labels && typeof labels === 'object') {
+      dictMap.set(k, labels as Record<string, string>)
+    }
+  }
+  return async (
+    key: string,
+    locale: string,
+    fallback?: string | readonly string[],
+  ): Promise<string | undefined> => {
+    const labels = dictMap.get(key)
+    if (!labels) return undefined
+    if (labels[locale] !== undefined) return labels[locale]
+    const chain = Array.isArray(fallback)
+      ? (fallback as readonly string[])
+      : fallback
+        ? [fallback as string]
+        : []
+    for (const fb of chain) {
+      if (fb === 'any') {
+        const any = Object.values(labels)[0]
+        if (any !== undefined) return any
+      } else if (labels[fb] !== undefined) {
+        return labels[fb]
+      }
+    }
+    return undefined
+  }
 }

--- a/packages/hub/src/query/index.ts
+++ b/packages/hub/src/query/index.ts
@@ -36,13 +36,14 @@ export type {
 } from '../aggregate/aggregation.js'
 export {
   GroupedQuery,
+  GroupedQueryN,
   GroupedAggregation,
   groupAndReduce,
   resetGroupByWarnings,
   GROUPBY_WARN_CARDINALITY,
   GROUPBY_MAX_CARDINALITY,
 } from '../aggregate/groupby.js'
-export type { GroupedRow } from '../aggregate/groupby.js'
+export type { GroupedRow, GroupedRowN } from '../aggregate/groupby.js'
 export { ScanBuilder } from './scan-builder.js'
 export type { ScanPageProvider } from './scan-builder.js'
 

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -37,7 +37,7 @@ import type { HistoryStrategy } from './history/strategy.js'
 import type { I18nStrategy } from './i18n/strategy.js'
 import type { SessionStrategy } from './session/strategy.js'
 import type { SyncStrategy } from './team/sync-strategy.js'
-import type { GuardStrategyHandle } from './guards/types.js'
+import type { GuardStrategyHandleAny } from './guards/types.js'
 import type { DerivationStrategyHandle } from './derivations/types.js'
 import type { UnlockedKeyring } from './team/keyring.js'
 import type { VaultPolicy } from './policy/types.js'
@@ -1748,8 +1748,7 @@ export interface NoydbOptions {
    * Multiple guards per collection are allowed; they are dispatched
    * in registration order on `collection.put()`.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readonly guardStrategies?: ReadonlyArray<GuardStrategyHandle<any>>
+  readonly guardStrategies?: ReadonlyArray<GuardStrategyHandleAny>
   /**
    * Optional derivation strategies — source-to-output projections that
    * fire on `collection.put()`. Each handle is the output of

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -76,7 +76,7 @@ import { NO_SYNC, type SyncStrategy } from './team/sync-strategy.js'
 // derivation strategy don't pay the chunk cost. See #130 for the
 // bundle regression this seam plugs.
 import type { GuardRegistry } from './guards/registry.js'
-import type { GuardStrategyHandle } from './guards/types.js'
+import type { GuardStrategyHandleAny } from './guards/types.js'
 import type { ReadOnlyVaultFacade } from './guards/read-only-facade.js'
 import type { DerivationRegistry } from './derivations/registry.js'
 import type { DerivationStrategyHandle } from './derivations/types.js'
@@ -371,8 +371,7 @@ export class Vault {
     historyStrategy?: HistoryStrategy | undefined
     i18nStrategy?: I18nStrategy | undefined
     syncStrategy?: SyncStrategy | undefined
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    guardStrategies?: ReadonlyArray<GuardStrategyHandle<any>> | undefined
+    guardStrategies?: ReadonlyArray<GuardStrategyHandleAny> | undefined
   }) {
     this.adapter = opts.adapter
     this.name = opts.name
@@ -1407,8 +1406,7 @@ export class Vault {
    * accessor `_getReadOnlyFacade()` (called from the tx amendment
    * runner) stays synchronous.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async _initGuards(handles: ReadonlyArray<GuardStrategyHandle<any>>): Promise<void> {
+  async _initGuards(handles: ReadonlyArray<GuardStrategyHandleAny>): Promise<void> {
     if (handles.length === 0) return
     const [{ GuardRegistry }, { ReadOnlyVaultFacade }] = await Promise.all([
       import('./guards/registry.js'),

--- a/showcases/src/85-with-multikey-groupby.showcase.test.ts
+++ b/showcases/src/85-with-multikey-groupby.showcase.test.ts
@@ -102,8 +102,15 @@ describe('Showcase 85 — multi-key groupBy', () => {
     const vault = await db.openVault('books')
     const invoices = vault.collection<Invoice>('invoices')
 
-    await invoices.put('i1', { id: 'i1', clientId: 'acme', period: '2026-04', amount: 100 })
-    await invoices.put('i2', { id: 'i2', clientId: 'acme', period: '2026-04', amount: 200 })
+    // Fixture: three records spanning TWO distinct (clientId, period)
+    // tuples. A buggy implementation that didn't sort field names in
+    // the canonical key would treat ('clientId','period') and
+    // ('period','clientId') as different bucket spaces — producing a
+    // different bucket SET (not just different row property order)
+    // when the same input data is grouped under each ordering.
+    await invoices.put('i1', { id: 'i1', clientId: 'acme',   period: '2026-04', amount: 100 })
+    await invoices.put('i2', { id: 'i2', clientId: 'acme',   period: '2026-04', amount: 50 })
+    await invoices.put('i3', { id: 'i3', clientId: 'globex', period: '2026-04', amount: 200 })
 
     const rowsForward = invoices
       .query()
@@ -117,10 +124,23 @@ describe('Showcase 85 — multi-key groupBy', () => {
       .aggregate({ total: sum('amount') })
       .run()
 
-    expect(rowsForward).toHaveLength(1)
-    expect(rowsReversed).toHaveLength(1)
-    expect(rowsForward[0].total).toBe(300)
-    expect(rowsReversed[0].total).toBe(300)
+    // Both orderings produce the same bucket COUNT…
+    expect(rowsForward).toHaveLength(2)
+    expect(rowsReversed).toHaveLength(2)
+
+    // …and the same bucket CONTENTS (totals per clientId).
+    const forwardByClient = new Map(rowsForward.map((r) => [r.clientId, r]))
+    const reversedByClient = new Map(rowsReversed.map((r) => [r.clientId, r]))
+
+    expect(forwardByClient.get('acme')!.total).toBe(150)
+    expect(forwardByClient.get('globex')!.total).toBe(200)
+    expect(reversedByClient.get('acme')!.total).toBe(150)
+    expect(reversedByClient.get('globex')!.total).toBe(200)
+
+    // Property order on emitted rows DOES follow declaration order
+    // (cosmetic, but pinned so consumers can rely on it).
+    expect(Object.keys(rowsForward[0]).slice(0, 2)).toEqual(['clientId', 'period'])
+    expect(Object.keys(rowsReversed[0]).slice(0, 2)).toEqual(['period', 'clientId'])
 
     db.close()
   })

--- a/showcases/src/85-with-multikey-groupby.showcase.test.ts
+++ b/showcases/src/85-with-multikey-groupby.showcase.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Showcase 85 — multi-key groupBy
+ *
+ * What you'll learn
+ * ─────────────────
+ * Group records by TWO OR MORE fields. The chainable builder accepts a
+ * variadic `groupBy(...fields)` call; result rows carry every grouped
+ * field (in declaration order) plus the reducer outputs.
+ *
+ * Why it matters
+ * ──────────────
+ * Real-world roll-ups are rarely keyed by a single field. A
+ * per-(client, period) summary, a per-(tenant, region, period) tax
+ * obligation, an audit feed sliced by both subject and action —
+ * composite keys are everywhere. Multi-key groupBy lets you express
+ * that directly, with no synthetic concatenated-key field on the
+ * source schema.
+ *
+ * Prerequisites
+ * ─────────────
+ *   - Showcase 10 (single-key groupBy + aggregate)
+ *
+ * What to read next
+ * ─────────────────
+ *   - Showcase 81 (withMaterializedView eager refresh)
+ *   - docs/subsystems/aggregate.md § Multi-key groupBy
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → aggregate (multi-key invariant)
+ * features.yaml → features → materialized-views (multi-key inside `query`)
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { withAggregate, sum, count } from '@noy-db/hub/aggregate'
+import { memory } from '@noy-db/to-memory'
+
+interface Invoice {
+  id: string
+  clientId: string
+  period: string
+  amount: number
+}
+
+describe('Showcase 85 — multi-key groupBy', () => {
+  it('groups by (clientId, period) and returns one row per distinct tuple', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'showcase-85-multikey-passphrase-2026',
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('books')
+    const invoices = vault.collection<Invoice>('invoices')
+
+    // Fixture: 4 invoices spread across 3 distinct (clientId, period)
+    // tuples — (acme, 2026-04) has two rows; the other two tuples have
+    // one row each.
+    await invoices.put('i1', { id: 'i1', clientId: 'acme',   period: '2026-04', amount: 100 })
+    await invoices.put('i2', { id: 'i2', clientId: 'acme',   period: '2026-04', amount: 200 })
+    await invoices.put('i3', { id: 'i3', clientId: 'acme',   period: '2026-05', amount: 150 })
+    await invoices.put('i4', { id: 'i4', clientId: 'globex', period: '2026-04', amount: 500 })
+
+    const rows = invoices
+      .query()
+      .groupBy('clientId', 'period')
+      .aggregate({ total: sum('amount'), n: count() })
+      .run()
+
+    // Three distinct buckets. Result rows carry both grouped fields
+    // (declaration order: clientId, period) plus the reducer outputs.
+    expect(rows).toHaveLength(3)
+
+    const byTuple = new Map(
+      rows.map((r) => [`${r.clientId}|${r.period}`, r]),
+    )
+
+    expect(byTuple.get('acme|2026-04')!.total).toBe(300)
+    expect(byTuple.get('acme|2026-04')!.n).toBe(2)
+
+    expect(byTuple.get('acme|2026-05')!.total).toBe(150)
+    expect(byTuple.get('acme|2026-05')!.n).toBe(1)
+
+    expect(byTuple.get('globex|2026-04')!.total).toBe(500)
+    expect(byTuple.get('globex|2026-04')!.n).toBe(1)
+
+    db.close()
+  })
+
+  it('declaration order of fields does not affect bucket identity', async () => {
+    // `.groupBy('a', 'b')` and `.groupBy('b', 'a')` produce the SAME
+    // logical buckets — the canonical key sorts field names before
+    // hashing. The only difference is the property order on the
+    // emitted row (cosmetic).
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'showcase-85-order-passphrase-2026',
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('books')
+    const invoices = vault.collection<Invoice>('invoices')
+
+    await invoices.put('i1', { id: 'i1', clientId: 'acme', period: '2026-04', amount: 100 })
+    await invoices.put('i2', { id: 'i2', clientId: 'acme', period: '2026-04', amount: 200 })
+
+    const rowsForward = invoices
+      .query()
+      .groupBy('clientId', 'period')
+      .aggregate({ total: sum('amount') })
+      .run()
+
+    const rowsReversed = invoices
+      .query()
+      .groupBy('period', 'clientId')
+      .aggregate({ total: sum('amount') })
+      .run()
+
+    expect(rowsForward).toHaveLength(1)
+    expect(rowsReversed).toHaveLength(1)
+    expect(rowsForward[0].total).toBe(300)
+    expect(rowsReversed[0].total).toBe(300)
+
+    db.close()
+  })
+})

--- a/showcases/src/86-with-union-mv.showcase.test.ts
+++ b/showcases/src/86-with-union-mv.showcase.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Showcase 86 — UNION MV (withMaterializedView reads multiple sibling collections)
+ *
+ * What you'll learn
+ * ─────────────────
+ * Read from TWO OR MORE sibling collections in one materialized view via
+ * `unionSources`. Per-source `map` projects each arm into the MV's row
+ * shape; `groupBy` + `aggregate` then run on the concatenated stream.
+ *
+ * Why it matters
+ * ──────────────
+ * Many real-world roll-ups span more than one source: a monthly VAT
+ * obligation combining tax receipts and credit notes, a unified audit
+ * feed merging two log shapes, a per-tenant report joining structurally-
+ * similar tables. Without UNION MV, consumers maintain parallel MVs and
+ * sum at read time — defeating the "no imperative transforms outside
+ * primitives" rule.
+ *
+ * Prerequisites
+ * ─────────────
+ *   - Showcase 81 (withMaterializedView basics)
+ *   - Showcase 85 (multi-key groupBy)
+ *
+ * What to read next
+ * ─────────────────
+ *   - docs/subsystems/derivations.md (UNION sources section)
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → materialized-views (unionSources invariant)
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withMaterializedView, sum } from '@noy-db/hub'
+import { withAggregate } from '@noy-db/hub/aggregate'
+import { memory } from '@noy-db/to-memory'
+
+interface TaxReceipt {
+  id: string
+  issuedAt: string
+  vatAmount: number
+}
+
+interface CreditNote {
+  id: string
+  issuedAt: string
+  vatAmount: number
+}
+
+interface MonthlyVatRow extends Record<string, unknown> {
+  period: string
+  vat: number
+}
+
+describe('Showcase 86 — UNION MV', () => {
+  it('monthly VAT = sum(taxReceipts.vat) - sum(creditNotes.vat) keyed by period', async () => {
+    // The MV reads from TWO sibling source collections. Each arm's `map`
+    // projects its source shape into the MV's row shape `{ period, vat }`
+    // — taxReceipts contribute positive vat, creditNotes contribute
+    // negative vat. The concatenated stream is then grouped by period and
+    // summed by the existing aggregate pipeline.
+    const monthlyVat = withMaterializedView<MonthlyVatRow>({
+      name: 'monthlyVat',
+      unionSources: [
+        {
+          collection: 'taxReceipts',
+          map: (r) => {
+            const tr = r as unknown as TaxReceipt
+            return { period: tr.issuedAt.slice(0, 7), vat: tr.vatAmount }
+          },
+        },
+        {
+          collection: 'creditNotes',
+          map: (r) => {
+            const cn = r as unknown as CreditNote
+            return { period: cn.issuedAt.slice(0, 7), vat: -cn.vatAmount }
+          },
+        },
+      ],
+      groupBy: 'period',
+      aggregate: { vat: sum('vat') },
+      rowKey: (row) => row.period,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'showcase-86-union-mv-passphrase-2026',
+      materializedViewStrategies: [monthlyVat],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('books')
+
+    const receipts = vault.collection<TaxReceipt>('taxReceipts')
+    const creditNotes = vault.collection<CreditNote>('creditNotes')
+
+    // Two receipts and one credit note, all in 2026-05.
+    // Net VAT for the month = (100 + 50) - 30 = 120.
+    await receipts.put('r-1', { id: 'r-1', issuedAt: '2026-05-15', vatAmount: 100 })
+    await receipts.put('r-2', { id: 'r-2', issuedAt: '2026-05-20', vatAmount: 50 })
+    await creditNotes.put('cn-1', { id: 'cn-1', issuedAt: '2026-05-25', vatAmount: 30 })
+
+    // The MV output collection holds one row per `rowKey` — here, one
+    // row per period. Both arms feed the same bucket.
+    const out = vault.collection<MonthlyVatRow>('monthlyVat')
+    const row = await out.get('2026-05')
+
+    expect(row).not.toBeNull()
+    expect(row?.period).toBe('2026-05')
+    expect(row?.vat).toBe(120)
+
+    // Writing to EITHER arm refreshes the MV (eager). Add a second
+    // credit note and the period total drops accordingly.
+    await creditNotes.put('cn-2', { id: 'cn-2', issuedAt: '2026-05-28', vatAmount: 20 })
+
+    const refreshed = await out.get('2026-05')
+    expect(refreshed?.vat).toBe(100) // 150 (receipts) - 50 (credit notes)
+
+    db.close()
+  })
+})


### PR DESCRIPTION
## Summary

Pre.15 cycle landing three issues on one branch (#166, #165, #131). #165 + #166 together unblock the niwat refactor's monthly-VAT MV; #131 is a pre.14 type-only cleanup. Two niwat review follow-ups (#169, #170) folded in as small guards.

- **Spec:** `docs/superpowers/specs/2026-05-22-dim14-mv-multikey-and-union-design.md`
- **Plan:** `docs/superpowers/plans/2026-05-22-dim14-mv-multikey-and-union.md`

### #166 — Variadic Query.groupBy(...fields)
- New variadic overload on `Query<T>.groupBy(...)` with back-compat single-arg
- `canonicalGroupKey` helper for stable dedup (sorted field names)
- Result rows carry every grouped field in DECLARATION order + reducer outputs
- Cardinality warning lists every grouped field name; threshold unchanged
- MV strategies can use multi-key groupBy inside `query()` callback unchanged
- New showcase 85, features.yaml entries under `aggregate` + `materialized-views`, sections in `aggregate.md` + `derivations.md`

### #165 — UNION MV via unionSources
- New `unionSources: [{ collection, map }, ...]` field on `withMaterializedView` (Option 1 from issue)
- Per-source `map` is the schema-unification boundary — sibling collections with different schemas project to one MV row shape
- Declarative `groupBy: string | string[]` + `aggregate` fields run on the concatenated stream
- Mutually exclusive with `query`; ≥2 arms required; distinct collection names required; empty `groupBy: []` rejected
- New `MaterializedViewConfigError` for malformed strategies
- Source-write hook fires on every arm via the existing `dependencies` reverse-index (no `Collection.put` changes)
- `summarizeUnionPlan` hashes arm collection names in **declaration order** (semantically meaningful for the dedup-only path); `groupBy` fields + `aggregate` keys still sorted (commutative). Two regression tests pin the asymmetry.
- New showcase 86, derivations.md "UNION sources" section, features.yaml UNION invariant

### #131 — GuardStrategyHandle variance cleanup
- New internal `GuardStrategyHandleAny` existential type (sealed, not exported from consumer barrel)
- Removed THREE `eslint-disable-next-line @typescript-eslint/no-explicit-any` annotations on `guardStrategies` fields (types.ts + 2× vault.ts)
- One single `any` retained inside the existential body — the established named existential boundary, acceptable per issue framing
- Type-only refactor; no behaviour change; all guards tests + showcase 79 green

### #169 — UNION MV silently ignored aggregate without groupBy
- Registration now rejects `{ unionSources, aggregate, !groupBy }` with `MaterializedViewConfigError`
- Same pattern as the existing empty-array `groupBy` guard

### #170 — predicates silently no-op'd on UNION MVs
- Registration now rejects `{ unionSources, predicates }` with `MaterializedViewConfigError` (per-arm predicate semantics deferred; not yet supported)
- Same pattern as the other UNION guards

### Composition
- Niwat canonical shape: `union(taxReceipts, creditNotes).groupBy('clientId', 'period').sum('vat')` — tested
- Same `canonicalGroupKey` helper used by both #166 (groupBy dedup) and #165 (no-aggregate UNION dedup)

## Implementation notes

- `GroupedQueryBase` (non-exported abstract class) holds shared constructor + fields; `GroupedQuery<T, F>` and `GroupedQueryN<T, F>` override only `aggregate()` for the appropriate generic
- `materializeUnionResult` reuses `groupAndReduce` so cardinality / cap / reducer pipeline behavior is identical across UNION and query-form MVs
- `maxRows`, `onEmpty`, `strict` semantics inherited unchanged
- Existing single-source MV path completely unchanged — additive change throughout

## Known gap — `_doDelete` does not dispatch eager MV refresh (pre.14 hangover, surfaced by #165 review)

`Collection.dispatchMaterializedViews` is called at the end of both `put` code paths (`packages/hub/src/collection.ts:1283` and `:1399`) but is absent from `_doDelete` (lines 1602–1776). Deleting a source record never triggers an eager MV refresh; tombstoning fires only when a subsequent `put` on the same source re-runs the executor, or when the caller invokes `vault.refreshView()` manually. This affects ALL MVs with `onEmpty: 'delete'` (the default) — not just UNION-form.

The tombstone test in `union.test.ts` lands in manual-refresh form (proves the executor + `listOutputIds` logic are correct) and is paired with an `it.todo` at line 333 pinning the auto-dispatch gap. A follow-up PR should add `dispatchMaterializedViewsOnDelete(id)`, wire it in `_doDelete` after `onAccess`, and promote the todo to a live assertion.

## Test plan

- [x] \`pnpm vitest run packages/hub\` — 1601 tests pass + 1 todo (1573 baseline → +28 across canonicalGroupKey, multi-key DSL, MV multi-key, UNION validation, UNION executor, UNION composition, UNION edges, UNION queryHash sensitivity, UNION aggregate-without-groupBy guard, UNION predicates guard)
- [x] Showcase 85 (multi-key groupBy) — green
- [x] Showcase 86 (UNION MV) — green
- [x] Showcase 79 (guards) — green (regression check for #131)
- [x] \`pnpm turbo build\` / \`typecheck\` / \`lint\` — clean
- [x] \`node scripts/check-architecture.mjs\` / \`validate-features.mjs\` — clean

## Issues closed

- Closes #166 — feat(hub): multi-key groupBy
- Closes #165 — feat(hub): UNION MV (Option 1: unionSources)
- Closes #131 — refactor(hub): GuardStrategyHandle variance
- Closes #169 — fix(hub): UNION MV rejects aggregate-without-groupBy
- Closes #170 — fix(hub): UNION MV rejects predicates (not yet supported)
