### PR TITLE
docs: schema layer design handoff bundle

### DIFF
--- a/docs/superpowers/noy-db-schema-handoff/BRIEF.md
+++ b/docs/superpowers/noy-db-schema-handoff/BRIEF.md
@@ -1,0 +1,112 @@
+# Schema layer — design brief
+
+Decisions already made. Don't relitigate; if you want the rationale, see
+`RATIONALE.md`.
+
+## Package
+
+- **Name:** `@noy-db/schema`
+- **Location:** `packages/schema/`
+- **Runtime deps:** zero. Peer deps on `yaml`, `zod`, `ajv` if used.
+- **Public API (v0.1):**
+  - `parseSchema(input: string | object): VaultSchema`
+  - `validateSchema(schema: VaultSchema): ValidationResult`
+  - `serializeSchema(schema: VaultSchema, format: 'yaml' | 'json'): string`
+  - `introspect(db: NoyDb, vault: string, opts?: { withStats?: boolean }): Promise<VaultSchema>`
+  - TypeScript types for every node in the schema tree
+
+## Format
+
+- **Human-edited source of truth:** YAML (`vault.noydb.yaml`)
+- **Machine-emitted equivalent:** JSON (`vault.noydb.json`)
+- **Validation:** one JSON Schema (`noydb-schema.schema.json`) validates both
+- **YAML parser:** `yaml` npm package by Eemeli Aro (preserves comments on round-trip). Not `js-yaml`.
+- **Editor integration:** `# yaml-language-server: $schema=...` header at top of every YAML file.
+
+## In scope (v0.1)
+
+- Collection declarations
+- Field declarations with embedded validation (Zod / JSON Schema)
+- Indexes
+- FK references — declared field-local, never positional
+- Materialized views (with refresh-key declarations)
+- Overlay views
+- Aggregates (sum, avg, count, groupBy)
+- Derivations
+- ACLs (5 known roles: owner / admin / operator / viewer / client)
+- i18n field annotations (BCP-47 language tags)
+- Tier classification
+- Subsystem opt-in flags (whether `withHistory()` etc. are active)
+
+## Out of scope (v0.1)
+
+These are **runtime configuration**, not schema:
+
+- Storage backend selection (`to-*` packages)
+- Unlock method (`on-*` packages)
+- Framework binding (`in-*` packages)
+- Transport (`by-*` packages)
+- Export format selection (`as-*` packages)
+- Refresh-strategy implementation choices (which scheduler, which queue)
+
+## Non-goals
+
+- A custom DSL with its own grammar (tree-sitter, parser combinators). Reconsider post-v0.1 if YAML proves insufficient.
+- A visual editor. Tracked in a separate milestone; depends on this one.
+- Mermaid / DBML / drawio emitter. Tracked in a separate milestone; depends on this one.
+- Migration tooling for existing implicit schemas. v0.1 is additive; users opt in.
+
+## Zod embedding strategy (pending ADR — issue #2)
+
+Three options were considered:
+
+- **A)** JSON Schema as primary; Zod generated at codegen time. Loses refinements/transforms.
+- **B)** Zod as primary; convert to JSON Schema for the YAML form. Requires Zod source files alongside YAML.
+- **C)** Hybrid: simple types and constraints in YAML; complex validations reference a Zod schema by path (e.g. `validate: "./schemas/invoice.ts#InvoiceSchema"`).
+
+**Tentative recommendation:** C. Most fields are scalar with simple constraints; YAML stays readable. Complex cases escape to TS. ADR to be written before implementation (issue #2).
+
+## Branching
+
+- **Branch:** `feat/schema` (long-running)
+- **Strategy:** vertical slices per issue. Each PR independently mergeable into `feat/schema`.
+- **Promotion:** merge `feat/schema` → `main` when milestone closes, or earlier if a slice is genuinely independent (e.g. the JSON Schema file from issue #1 can land on `main` immediately as docs).
+- **Subsystem development on `main` continues uninterrupted.** The schema layer is read-only with respect to existing code.
+
+## Issue ordering and dependencies
+
+```
+#1 Format design + JSON Schema      ──┬──→ #3 Package scaffold ──┬──→ #4 Semantic validator ──→ #6 CLI ──┐
+#2 Zod embedding ADR                ──┘                          ├──→ #5 Introspection ────────────────┤
+                                                                 └──→ #7 Codegen                       │
+                                                                                                       └──→ #8 Docs
+```
+
+## Naming conventions inside the codebase
+
+- `VaultSchema` — noy-db's schema definition (this package)
+- `JsonSchema` — the JSON Schema spec (used to validate `VaultSchema`)
+- `ZodSchema` — a Zod schema (used to validate individual records)
+
+Never just "Schema" in type names — too ambiguous given the three meanings.
+
+## Error codes
+
+Semantic validation errors have stable codes: `NOYDB_SCHEMA_E001`, etc.
+Each error includes file path, line, column, human-readable message, and
+suggested fix where possible.
+
+## What the YAML must read like
+
+- References are field-local and **named**, never positional:
+  ```yaml
+  fields:
+    client_id:
+      type: string
+      references: clients.id   # right here, next to the field
+  ```
+- Stable IDs (the YAML key) separate from display labels.
+- No "relationships:" section at the bottom of the file.
+- Comments preserved on round-trip.
+
+The design rule: **the YAML must be readable without the diagram.**

--- a/docs/superpowers/noy-db-schema-handoff/KICKOFF_PROMPT.md
+++ b/docs/superpowers/noy-db-schema-handoff/KICKOFF_PROMPT.md
@@ -1,0 +1,82 @@
+# Claude Code kickoff prompt
+
+Copy everything between the `---` markers into a Claude Code session
+started inside the noy-db repo root. The prompt assumes you have:
+
+- `gh` CLI authenticated with write access to `vLannaAi/noy-db`
+- The handoff bundle (`BRIEF.md`, `RATIONALE.md`, `create-schema-milestone.sh`, `vault.example.noydb.yaml`) accessible — either dropped into a scratch dir inside the repo, or in a sibling directory you can reference.
+
+---
+
+I'm starting work on a new declarative schema layer for noy-db. The
+design decisions are already made — they're captured in a handoff
+bundle I've placed alongside the repo (or inside it; check both).
+
+**Step 1 — Read the handoff bundle.**
+
+Locate and read these files (try `./schema-handoff/`, `../schema-handoff/`,
+or wherever they ended up):
+
+- `BRIEF.md` — settled design decisions. Do not relitigate these.
+- `RATIONALE.md` — why those decisions. Read for context, not for
+  re-debate.
+- `create-schema-milestone.sh` — milestone + 8 issue bodies.
+- `vault.example.noydb.yaml` — sketch of the YAML format.
+
+**Step 2 — Read the repo.**
+
+Read these to understand what we're integrating with:
+
+- `README.md`
+- `SPEC.md`
+- `SUBSYSTEMS.md`
+- `features.yaml`
+- `package.json`, `pnpm-workspace.yaml`, `turbo.json` (monorepo layout)
+- `packages/hub/` — at least the public API surface
+- One showcase, preferably `showcases/` for an accounting-app-shaped one,
+  to see how collections and validation are wired today
+
+**Step 3 — Confirm the plan back to me.**
+
+Before doing anything, summarize:
+
+- What package directory you'll create
+- What the eight issues are (titles only)
+- What you propose to commit in the first PR
+- Any conflicts you see between the brief and the current repo
+  structure
+
+Wait for me to say "go" before any writes or `gh` commands.
+
+**Step 4 — On my "go":**
+
+1. Run `bash create-schema-milestone.sh --dry-run`. Show me the output.
+2. After I confirm again, run it for real.
+3. Create the `feat/schema` branch from `main`.
+4. Scaffold `packages/schema/` with the public API from BRIEF.md.
+   Leave function bodies as `throw new Error('not implemented')` with
+   a TODO comment referencing the relevant issue number. Commit.
+5. Copy `vault.example.noydb.yaml` into `docs/schema/examples/accounting-app.vault.noydb.yaml`
+   and adapt it to whatever the accounting-app showcase actually looks
+   like in the repo. This is the design artifact for issue #1. Commit
+   on a separate PR-ready branch off `feat/schema`.
+6. Draft `docs/adr/0001-schema-format.md` covering the YAML + JSON
+   decision per RATIONALE.md. Commit.
+
+**Step 5 — Stop and check in.**
+
+Don't start on issues #2–#8 in this session. Open the first three PRs
+into `feat/schema`, summarize what landed, and wait for review.
+
+**Rules:**
+
+- Don't invent scope beyond what's in BRIEF.md. If something feels
+  missing, ask before adding it.
+- Don't touch `main` directly. Everything goes through `feat/schema`.
+- Don't add labels that don't already exist on the repo. If
+  `create-schema-milestone.sh` references missing labels, either
+  create them with `gh label create` (ask first) or strip them from
+  the script.
+- Keep commit messages tight and conventional (`feat(schema): scaffold package`).
+- If you find a real conflict between the brief and the current repo
+  (e.g. a package name collision), stop and ask. Don't paper over it.

--- a/docs/superpowers/noy-db-schema-handoff/RATIONALE.md
+++ b/docs/superpowers/noy-db-schema-handoff/RATIONALE.md
@@ -1,0 +1,154 @@
+# Schema layer — rationale
+
+The decisions in `BRIEF.md` are settled. This file explains *why*, for
+when someone asks. Skim or skip.
+
+## Why YAML + JSON, not Prisma or a custom DSL
+
+**YAML chosen for:** comments, multi-line strings, anchors/aliases (DRY
+ACL blocks), no syntactic noise from braces/quotes, indentation matches
+how humans think about nested structures. Editor support is excellent
+via `yaml-language-server` with the JSON Schema header. Convergence with
+dbt, Cube, OpenAPI, GitHub Actions, Kubernetes — adopters already know
+the shape.
+
+**JSON used as the machine-emitted equivalent:** every parser handles
+it, diff tools cope cleanly, JSON Schema validation is native. Same
+content as YAML, byte-shifted into a tool-friendly form.
+
+**Prisma considered and rejected:** beautiful syntax for the relational
+core, real ecosystem (GitHub highlighting, VS Code extension, formatter,
+validator). But:
+
+- Prisma's grammar is fixed. MVs, overlay views, vaults, derivations,
+  CRDTs, history strategies have no place in the language. Smuggling
+  them in as `@@` attributes works syntactically but reads as a hack
+  and breaks `prisma validate`.
+- The Prisma parser is Rust; the JS-side parser (`@mrleebo/prisma-ast`)
+  is community-maintained and lags. noy-db would depend on either a
+  third-party parser or shelling out to Prisma's CLI.
+- Adopters arriving with Prisma muscle memory will assume `prisma generate`
+  and `prisma migrate` apply. They don't. The syntactic familiarity
+  creates a semantic mismatch — an adoption tax paid on every
+  introduction.
+- ~60-70% of what noy-db needs to express fits Prisma's model. The
+  remaining 30-40% (MVs, overlays, vaults, derivations, subsystems)
+  splits the schema across multiple files.
+
+**Custom DSL (tree-sitter / parser combinators) considered and deferred:**
+the most readable result possible, owns the grammar, supports MVs and
+overlays as first-class block types. But: ~1 week of work for the parser,
+grammar, formatter, LSP, syntax highlighting. Investment only pays off
+if the schema file becomes a thing users spend serious time in.
+Reconsider post-v0.1 once we know whether YAML is actually painful.
+
+**TOML considered and rejected:** nice for flat config; awkward for
+deeply nested structures. Forces either `[[table.array]]` verbosity or
+inline tables (looks like JSON again). Schema is deeply nested.
+
+## Why `@noy-db/schema` and not `@noy-db/ddl` or `@noy-db/strategy`
+
+- `ddl` is technically accurate but carries SQL baggage. Users read it
+  as "SQL is hiding in here somewhere". Fights noy-db's positioning.
+- `strategy` collides with existing `with*Strategy()` seam pattern
+  (`historyStrategy`, `aggregateStrategy`). Confuses the mental model.
+- `schema` is what dbt, Prisma, Cube, Drizzle, OpenAPI, Kubernetes all
+  call this layer. Convergent terminology. Risk: within the codebase,
+  "Schema" is overloaded with JSON Schema and Zod schema. Mitigated by
+  using `VaultSchema`, `JsonSchema`, `ZodSchema` as distinct type names.
+
+## Why field-local FK references, not a separate relationships section
+
+The Mermaid `erDiagram` failure mode: `||--o{` notation forces mental
+decoding per relationship, and relationships are declared in a separate
+section from the entities — so reading the file means cross-referencing.
+
+Field-local references keep the FK next to the field it constrains.
+The eye is already there when you're reading the field. The YAML reads
+naturally without the diagram, which was the design goal.
+
+## Why declarative shape only, not runtime configuration
+
+The schema layer is a description of what exists. Runtime configuration
+(which storage backend, which unlock method, which transport) is per-
+deployment and per-environment. Same vault definition, different
+backends across dev/staging/prod.
+
+Mixing them in one file means the schema file becomes a god-config —
+the dbt path that adopters often regret. Prisma's separation (schema
+vs `prisma.config` vs env vars) is the better model.
+
+The borderline case is subsystem opt-in. We put it in scope because it
+affects what schema constructs are even legal (no `withHistory()` =
+no time-machine queries to validate). A subsystem either lights up
+schema constructs or it doesn't; that's a schema-time fact.
+
+## Why hybrid Zod embedding (tentative)
+
+JSON Schema can't express Zod's full API (refinements, transforms,
+discriminated unions). Three options:
+
+- Option A (JSON Schema primary): loses refinements/transforms entirely.
+  Most adopters don't need them, but the ones who do can't escape.
+- Option B (Zod primary): requires Zod source files alongside every YAML
+  schema. Doubles the surface area; the YAML becomes a partial mirror.
+- Option C (hybrid): YAML covers the 80% of simple cases (strings,
+  numbers, constraints, enums). Complex cases reference a Zod schema
+  by path. Both forms exist where they're each best.
+
+The cost of C is one extra concept ("how do I write a custom
+validation?"), paid only by the minority who need it. ADR to confirm in
+issue #2.
+
+## Why `feat/schema` long-running branch, not feature flags on main
+
+Schema work touches packaging, types, CLI, and docs. Vertical slices
+mean each PR can be reviewed independently, but landing them on main
+piecemeal would expose half-built APIs to adopters. A long-running
+branch keeps the surface clean until the slice is coherent.
+
+Counter-argument: long-running branches accumulate drift. Mitigated by
+the explicit "merge to main early if independent" clause — for example,
+the JSON Schema file from issue #1 is just documentation and can land
+on main immediately.
+
+## Why eight issues, not one or two
+
+The work is genuinely independent enough to parallelize after #1 and
+#3 land:
+
+- #4 (semantic validator) and #5 (introspection) share types from #3
+  but don't share code.
+- #6 (CLI) consumes #4 and #5 but adds no new logic.
+- #7 (codegen) consumes #3 but is independent of #4/#5/#6.
+- #8 (docs) consumes everything but lags one cycle.
+
+One issue would block parallelization. Two would lump independent work
+together. Eight matches the actual seams.
+
+## Why drawio for round-trip editing (when that work starts later)
+
+drawio's `.drawio` XML is parseable, supports arbitrary custom
+attributes on every shape (so noy-db can stamp `noydb:collection-id`,
+`noydb:kind="overlay-view"` etc.), has a free desktop app, web app,
+VS Code extension, and GitHub-native preview. Positions survive saves.
+
+DBML doesn't preserve positions; dbdiagram.io stores them server-side.
+Mermaid has no manual positioning at all. drawio is the only format
+that does all three things round-tripping needs.
+
+This is documented here because it informs how stable collection IDs
+need to be in the v0.1 schema — they're the join key between YAML and
+diagram XML.
+
+## What we explicitly chose not to think about yet
+
+- Schema versioning and migration between schema versions. Real concern
+  at v1.0. Not at v0.1.
+- Multi-vault references (cross-vault FK). Out of scope; `queryAcross`
+  remains explicit.
+- Permissions on the schema file itself (who can edit which collections
+  in a multi-tenant setup). Not a v0.1 concern; the file is a git
+  artifact, not a runtime object.
+- Streaming / progressive validation for very large schemas. Premature.
+  Most vaults will have <50 collections.

--- a/docs/superpowers/noy-db-schema-handoff/README.md
+++ b/docs/superpowers/noy-db-schema-handoff/README.md
@@ -1,0 +1,67 @@
+# noy-db schema layer — Claude Code handoff bundle
+
+This bundle is the work-in-progress carry-over from a chat-based design
+conversation. It contains everything needed to pick up work on a new
+declarative schema layer for noy-db without losing the prior context.
+
+## What this is
+
+A design and kickoff package for a new `@noy-db/schema` package and the
+`feat/schema` long-running branch. The schema layer will let users
+describe a vault's shape (collections, fields, validation, FKs, MVs,
+overlay views, ACLs, i18n) in a portable YAML/JSON format. It enables:
+
+- Introspection of live vaults
+- Static consistency checks
+- Diagram generation
+- Round-trip editing via external tools (Mermaid, drawio, custom viewer)
+- TypeScript codegen
+
+## Files in this bundle
+
+| File                          | Purpose                                                                       |
+| ----------------------------- | ----------------------------------------------------------------------------- |
+| `README.md`                   | This file. Orientation for whoever picks up the work.                         |
+| `BRIEF.md`                    | Design decisions already made. Don't relitigate these — they're settled.      |
+| `RATIONALE.md`                | Why those decisions, with the alternatives that were considered and rejected. |
+| `KICKOFF_PROMPT.md`           | Copy-paste prompt for starting a Claude Code session.                         |
+| `create-schema-milestone.sh`  | `gh` CLI script that creates the milestone and 8 issues on the GitHub repo.   |
+| `vault.example.noydb.yaml`    | Sketch of the YAML format for the accounting-app recipe. Design artifact for issue #1. |
+
+## How to use
+
+1. **Drop these into a scratch directory** (not the repo yet). They're a
+   working set, not part of the codebase.
+2. **Read `BRIEF.md` first.** Five minutes. It captures every decision
+   already made so you don't waste time re-deciding.
+3. **Skim `RATIONALE.md`** if you want to know why. Optional but useful
+   when adopters or contributors ask.
+4. **Open Claude Code in the noy-db repo** and paste `KICKOFF_PROMPT.md`.
+   It will read the repo, run the script, create the branch, scaffold
+   the package, and draft the first artifact.
+5. **Run `create-schema-milestone.sh --dry-run`** first to see what it
+   would do. Then run it for real to create the milestone and 8 issues.
+
+## Scope reminder
+
+**v0.1 is declarative shape only.** Storage backend, unlock method,
+framework binding, transport, and export format selection are *runtime
+configuration* and remain out of scope for the schema layer.
+
+The schema layer is read-only with respect to existing noy-db code:
+it describes what exists; it doesn't change how anything runs.
+
+## Status
+
+- [ ] Milestone and issues created on GitHub
+- [ ] `feat/schema` branch opened
+- [ ] `packages/schema/` scaffolded
+- [ ] ADR for format choice drafted (issue #1)
+- [ ] Accounting-app recipe expressed in YAML (issue #1)
+- [ ] JSON Schema published (issue #1)
+- [ ] Zod embedding ADR drafted (issue #2)
+- [ ] Parser + validator implemented (issues #3, #4)
+- [ ] Introspection API implemented (issue #5)
+- [ ] CLI commands implemented (issue #6)
+- [ ] Codegen implemented (issue #7)
+- [ ] Docs and migration guide (issue #8)

--- a/docs/superpowers/noy-db-schema-handoff/create-schema-milestone.sh
+++ b/docs/superpowers/noy-db-schema-handoff/create-schema-milestone.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+#
+# Creates the "Schema: declarative vault definition language" milestone
+# and 8 associated issues on vLannaAi/noy-db.
+#
+# Requirements:
+#   - gh CLI installed and authenticated (`gh auth status`)
+#   - Token has `repo` scope (write access to issues + milestones)
+#
+# Usage:
+#   bash create-schema-milestone.sh             # create everything
+#   bash create-schema-milestone.sh --dry-run   # print what would be created
+#
+# Safe to re-run: it checks for an existing milestone with the same title
+# and reuses it; existing issues with the same title are skipped.
+
+set -euo pipefail
+
+REPO="vLannaAi/noy-db"
+MILESTONE_TITLE="Schema: declarative vault definition language"
+DRY_RUN=false
+
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+  echo "DRY RUN — no changes will be made"
+  echo
+fi
+
+run() {
+  if $DRY_RUN; then
+    echo "would run: $*"
+  else
+    "$@"
+  fi
+}
+
+# --- Milestone ---------------------------------------------------------------
+
+MILESTONE_DESC=$(cat <<'EOF'
+Establish a declarative format for describing the shape of a noy-db vault:
+collections, fields with embedded validation, FK references, indexes,
+materialized views, overlay views, aggregates, ACLs, and i18n annotations.
+
+Goal: enable introspection, diagram generation, static consistency checks,
+and (eventually) round-trip editing via external tools — without coupling
+to any single storage backend, framework, or unlock method.
+
+Tracked in a long-running branch (`feat/schema`) so subsystem development
+on `main` is not blocked. Mergeable in vertical slices: format spec first,
+then introspector, then emitters, then validators.
+
+**Scope decisions (v0.1):**
+- Format: YAML as human-edited source of truth; JSON as machine-emitted equivalent. Both validated against the same JSON Schema.
+- Package: `@noy-db/schema` — parser, validator, type definitions, introspection API.
+- **IN SCOPE:** collection/field declarations, Zod/JSON Schema validation, indexes, FK references, MVs, overlay views, aggregates, derivations, ACLs, i18n annotations, tier classification, subsystem opt-in flags.
+- **OUT OF SCOPE for v0.1:** storage backend selection (`to-*`), unlock method (`on-*`), framework binding (`in-*`), transport (`by-*`), export format selection (`as-*`). These remain runtime configuration.
+
+**Non-goals:**
+- A custom DSL with its own grammar (tree-sitter, parser combinators). Reconsider post-v0.1 if the YAML form proves insufficient.
+- A visual editor. Tracked separately; depends on this milestone.
+- Round-trip with drawio/Mermaid. Tracked separately; depends on this milestone.
+
+**Branching:**
+- Branch: `feat/schema` (long-running)
+- Merge strategy: vertical slices per issue, each PR independently mergeable into `feat/schema`. Merge `feat/schema` → `main` when milestone closes, or earlier if a slice is genuinely independent.
+- Subsystem development on `main` continues uninterrupted. The schema layer is read-only with respect to existing code in v0.1.
+EOF
+)
+
+echo "Looking up milestone..."
+MILESTONE_NUMBER=$(gh api "repos/$REPO/milestones?state=open" --jq \
+  ".[] | select(.title == \"$MILESTONE_TITLE\") | .number" || true)
+
+if [[ -n "$MILESTONE_NUMBER" ]]; then
+  echo "Milestone already exists: #$MILESTONE_NUMBER"
+else
+  echo "Creating milestone..."
+  if $DRY_RUN; then
+    echo "would create milestone: $MILESTONE_TITLE"
+    MILESTONE_NUMBER="DRY_RUN"
+  else
+    MILESTONE_NUMBER=$(gh api "repos/$REPO/milestones" \
+      -f title="$MILESTONE_TITLE" \
+      -f description="$MILESTONE_DESC" \
+      -f state="open" \
+      --jq '.number')
+    echo "Created milestone #$MILESTONE_NUMBER"
+  fi
+fi
+
+# --- Helper: create issue if title doesn't already exist ---------------------
+
+create_issue() {
+  local title="$1"
+  local body="$2"
+  shift 2
+  local labels=("$@")
+
+  local existing
+  existing=$(gh issue list --repo "$REPO" --state all --search "in:title \"$title\"" --json title,number \
+    --jq ".[] | select(.title == \"$title\") | .number" || true)
+
+  if [[ -n "$existing" ]]; then
+    echo "  skip (exists as #$existing): $title"
+    return
+  fi
+
+  if $DRY_RUN; then
+    echo "  would create: $title  [labels: ${labels[*]}]"
+    return
+  fi
+
+  local label_args=()
+  for l in "${labels[@]}"; do
+    label_args+=(--label "$l")
+  done
+
+  gh issue create --repo "$REPO" \
+    --title "$title" \
+    --body "$body" \
+    --milestone "$MILESTONE_TITLE" \
+    "${label_args[@]}" >/dev/null
+  echo "  created: $title"
+}
+
+# --- Issues -----------------------------------------------------------------
+
+echo
+echo "Creating issues..."
+
+create_issue "schema: design YAML/JSON format and publish JSON Schema" "$(cat <<'EOF'
+Define the canonical shape of a vault schema document. Produce:
+
+- `vault.noydb.yaml` example covering all in-scope constructs
+- `vault.noydb.json` equivalent (machine-emitted form)
+- `noydb-schema.schema.json` JSON Schema that validates both
+- ADR explaining why YAML + JSON, why not Prisma/TOML/custom DSL
+
+**Design constraints:**
+- References are field-local and named, never positional (e.g. `references: clients.id` next to the field, not in a separate relationships section). Goal: readable without the diagram.
+- Stable IDs (the YAML key) separate from display labels.
+- Comments preserved on round-trip (use `yaml` npm package, not `js-yaml`).
+- Editor integration via `# yaml-language-server: $schema=...` header.
+
+**Deliverable:** example file checks into `docs/schema/examples/` and renders correctly in VS Code with the YAML extension installed.
+
+**Acceptance:**
+- [ ] Accounting-app recipe expressed as `vault.noydb.yaml`
+- [ ] Same recipe expressed as `vault.noydb.json`, byte-identical semantic content
+- [ ] JSON Schema validates both, rejects 5+ malformed examples
+- [ ] ADR in `docs/adr/` explains format choice
+
+Part of #MILESTONE: $MILESTONE_TITLE
+EOF
+)" "schema" "design"
+
+create_issue "schema: decide how Zod schemas are embedded in the schema format" "$(cat <<'EOF'
+YAML cannot natively express Zod's full API (refinements, transforms, discriminated unions). Three options to evaluate:
+
+**A)** JSON Schema as the schema language; Zod generated from JSON Schema via `json-schema-to-zod` at codegen time. Loses refinements/transforms.
+
+**B)** Zod as primary; convert to JSON Schema via `zod-to-json-schema` for the YAML form. Requires Zod source files alongside YAML.
+
+**C)** Hybrid: simple types and constraints in YAML (covers 80% of cases); complex validations reference a Zod schema by path (e.g. `validate: "./schemas/invoice.ts#InvoiceSchema"`).
+
+**Recommendation to evaluate:** (C). Most fields are scalar with simple constraints; the YAML stays readable. Complex cases escape to TS.
+
+**Acceptance:**
+- [ ] ADR comparing the three approaches
+- [ ] Chosen approach prototyped on 3 field types: simple string, constrained number, complex discriminated union
+- [ ] Decision on whether `validate:` references are resolved at schema-load time or codegen time
+
+Depends on #1
+EOF
+)" "schema" "design" "validation"
+
+create_issue "schema: scaffold @noy-db/schema package" "$(cat <<'EOF'
+Create the package under `packages/schema/` following monorepo conventions. Zero runtime deps (peer-dep on `yaml`, `zod`, `ajv` if used for JSON Schema validation).
+
+**Public API surface (v0.1):**
+- `parseSchema(input: string | object): VaultSchema` — YAML or JSON in, typed object out
+- `validateSchema(schema: VaultSchema): ValidationResult` — semantic checks beyond JSON Schema (FK targets exist, no circular MV dependencies, ACL roles are known, etc.)
+- `serializeSchema(schema: VaultSchema, format: 'yaml' | 'json'): string`
+- TypeScript types for every node in the schema tree
+
+**Acceptance:**
+- [ ] Package builds, exports types, passes type-check
+- [ ] Round-trip: parse → serialize → parse produces identical AST
+- [ ] Comments preserved on YAML round-trip
+- [ ] Published shape documented in `docs/packages/schema.md`
+
+Depends on #1, #2
+EOF
+)" "schema" "package"
+
+create_issue "schema: implement semantic validation beyond JSON Schema" "$(cat <<'EOF'
+JSON Schema covers structural validity. Semantic rules to implement:
+
+- FK targets exist (`references: clients.id` requires `clients` collection with `id` field)
+- No circular MV dependencies (overlay-of chains terminate)
+- ACL roles match the 5 known roles (owner / admin / operator / viewer / client)
+- Tier elevation references are well-formed
+- i18n languages are valid BCP-47 tags
+- Field names don't collide with reserved noy-db property names
+- Index field references exist on the collection
+- Aggregate measure fields exist and are of aggregatable types
+
+Each rule has a stable error code (e.g. `NOYDB_SCHEMA_E001`), human-readable message, and source location (line/column in YAML).
+
+**Acceptance:**
+- [ ] 12+ rules implemented with unit tests
+- [ ] Error messages include file path, line, column, and suggested fix where possible
+- [ ] CLI command `noydb schema validate ./vault.noydb.yaml` exits non-zero on failure
+
+Depends on #3
+EOF
+)" "schema" "validation"
+
+create_issue "schema: introspect a live vault and emit its schema" "$(cat <<'EOF'
+Given an opened vault, produce the schema document that describes its current shape. Powers the diagram tool and `noydb schema diff`.
+
+**API:**
+- `introspect(db: NoyDb, vault: string): Promise<VaultSchema>`
+- Same shape as a hand-written schema, plus optional stats (recordCount per collection/view, sizeBytes) when called with `{ withStats: true }`.
+
+**Implementation note:** introspection reads collection metadata and field shapes from existing records. Where Zod schemas are registered with the vault at runtime, they're emitted directly; where only data exists, a best-effort JSON Schema is inferred.
+
+**Acceptance:**
+- [ ] Introspect the accounting-app showcase vault, output matches hand-written schema (modulo statistics)
+- [ ] `withStats: true` populates counter and size fields
+- [ ] Documented limitations (inferred vs declared validation)
+
+Depends on #3
+EOF
+)" "schema" "introspection"
+
+create_issue "schema: CLI commands in @noy-db/cli" "$(cat <<'EOF'
+Add the following commands to the existing CLI:
+
+- `noydb schema validate <file>` — semantic + structural validation
+- `noydb schema format <file>` — canonical YAML formatting
+- `noydb schema introspect <vault-path>` — emit YAML from a live vault
+- `noydb schema diff <file> <vault-path>` — show drift between declared schema and live vault
+- `noydb schema convert <file> --to json|yaml` — format conversion
+
+All commands respect `--format=json` for machine-readable output.
+
+**Acceptance:**
+- [ ] All 5 commands implemented with `--help`
+- [ ] Exit codes documented (0 ok, 1 validation fail, 2 IO error)
+- [ ] Integration tests in `test-harnesses/`
+
+Depends on #4, #5
+EOF
+)" "schema" "cli"
+
+create_issue "schema: generate TypeScript types from vault schema" "$(cat <<'EOF'
+For TypeScript adopters, the schema should generate the same types they'd write by hand for `collection<T>()` calls.
+
+**Output:** `vault.noydb.ts` with a type per collection, a discriminated union of all collection names, and (where applicable) generated Zod schemas.
+
+- `noydb schema codegen <file> --out <path>`
+- Watch mode: `--watch` regenerates on YAML save
+
+**Acceptance:**
+- [ ] Generated types compile with strict mode
+- [ ] Accounting-app showcase migrates from hand-written types to generated ones without behavior change
+- [ ] Watch mode integrates with `pnpm dev`
+
+Depends on #3
+EOF
+)" "schema" "codegen" "dx"
+
+create_issue "schema: documentation, examples, migration guide" "$(cat <<'EOF'
+- `docs/schema/README.md` — overview, when to use, when not to
+- `docs/schema/reference.md` — every field, attribute, and block
+- `docs/schema/examples/` — one file per recipe (personal-notebook, accounting-app, realtime-crdt-app, analytics-app)
+- `docs/schema/migration.md` — how to introduce a schema file to an existing noy-db app without breaking anything (schema is additive in v0.1; not enforced unless `noydb schema validate` is wired into CI)
+- `SUBSYSTEMS.md` updated to reference the schema layer
+- Top-level README mentions the schema in the catalog
+
+**Acceptance:**
+- [ ] All four recipe schemas check into `docs/schema/examples/`
+- [ ] Reference docs auto-generated from JSON Schema where possible
+- [ ] Migration guide tested against the accounting-app showcase
+
+Depends on #6, #7
+EOF
+)" "schema" "docs"
+
+echo
+echo "Done."
+if $DRY_RUN; then
+  echo "(dry run — nothing was actually created)"
+fi

--- a/docs/superpowers/noy-db-schema-handoff/vault.example.noydb.yaml
+++ b/docs/superpowers/noy-db-schema-handoff/vault.example.noydb.yaml
@@ -1,0 +1,197 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/vLannaAi/noy-db/main/packages/schema/noydb-schema.schema.json
+#
+# DESIGN SKETCH — accounting-app recipe.
+#
+# This file is the v0 reference for what `vault.noydb.yaml` should
+# read like. Use it to validate the JSON Schema design in issue #1
+# and to drive the parser tests in issue #3.
+#
+# Design rule: this file must be readable without the diagram.
+# References are field-local. No "relationships:" section at the
+# bottom. Comments preserved on round-trip.
+
+version: 1
+vault: acme-accounting
+
+# Subsystem opt-in. Affects what constructs are legal below.
+# (In scope per BRIEF.md — schema layer needs to know what's lit up.)
+subsystems:
+  history: true        # withHistory() — enables history blocks on collections
+  aggregate: true      # withAggregate() — enables aggregate views
+  blobs: true          # withBlobs() — enables blob-typed fields
+  i18n: true           # withI18n() — enables i18n field annotations
+  derivations: true    # enables view / overlay declarations
+
+# Reusable ACL fragments (YAML anchors — one of the reasons we chose YAML)
+acl_defaults:
+  internal_rw: &acl_internal_rw
+    read: [owner, admin, operator, viewer]
+    write: [owner, admin, operator]
+  client_visible: &acl_client_visible
+    read: [owner, admin, operator, viewer, client]
+    write: [owner, admin, operator]
+
+# ────────────────────────────────────────────────────────────────────
+# Collections
+# ────────────────────────────────────────────────────────────────────
+collections:
+
+  clients:
+    description: External parties the firm invoices.
+    label: { en: Clients, th: ลูกค้า, zh: 客户 }
+    acl: *acl_internal_rw
+    fields:
+      id:
+        type: string
+        primary: true
+        format: ulid
+      display_name:
+        type: string
+        constraints: { minLength: 1, maxLength: 200 }
+      tax_id:
+        type: string
+        optional: true
+        # Complex validation escapes to TS (hybrid Zod strategy, option C).
+        validate: ./schemas/clients.ts#TaxIdSchema
+      country:
+        type: string
+        constraints: { pattern: "^[A-Z]{2}$" }   # ISO 3166-1 alpha-2
+      created_at:
+        type: timestamp
+        default: now
+    indexes:
+      - fields: [country, display_name]
+      - fields: [tax_id]
+        unique: true
+        when: "tax_id != null"
+
+  invoices:
+    description: Outbound invoices in dual EUR/THB currencies.
+    label: { en: Invoices, th: ใบกำกับภาษี, zh: 发票 }
+    acl: *acl_internal_rw
+    fields:
+      id:
+        type: string
+        primary: true
+        format: "INV-{YYYY}-{seq:06}"
+      client_id:
+        type: string
+        references: clients.id          # ← field-local FK, named, greppable
+        on_delete: restrict
+      issued_at:
+        type: date
+      due_at:
+        type: date
+      currency:
+        type: enum
+        values: [EUR, THB]
+      amount:
+        type: decimal
+        constraints: { precision: 12, scale: 2, min: 0 }
+      status:
+        type: enum
+        values: [draft, issued, paid, void]
+        default: draft
+      notes:
+        type: i18nText                    # multi-locale field (i18n subsystem)
+        languages: [en, th]
+        optional: true
+    indexes:
+      - fields: [client_id, issued_at]
+      - fields: [status, due_at]
+    history:
+      enabled: true
+      tier: standard
+
+  line_items:
+    description: Per-invoice line items.
+    acl: *acl_internal_rw
+    fields:
+      id:
+        type: string
+        primary: true
+        format: ulid
+      invoice_id:
+        type: string
+        references: invoices.id
+        on_delete: cascade
+      description:
+        type: i18nText
+        languages: [en, th]
+      quantity:
+        type: decimal
+        constraints: { precision: 10, scale: 3, min: 0 }
+      unit_price:
+        type: decimal
+        constraints: { precision: 12, scale: 2, min: 0 }
+      line_total:
+        type: decimal
+        computed: "quantity * unit_price"   # derived; not stored
+    indexes:
+      - fields: [invoice_id]
+
+  payments:
+    description: Inbound payment records, possibly across multiple invoices.
+    acl: *acl_internal_rw
+    fields:
+      id:
+        type: string
+        primary: true
+        format: ulid
+      received_at:
+        type: timestamp
+      amount:
+        type: decimal
+        constraints: { precision: 12, scale: 2, min: 0 }
+      currency:
+        type: enum
+        values: [EUR, THB]
+      method:
+        type: enum
+        values: [wire, card, cash, other]
+      attachment:
+        type: blob                          # blobs subsystem
+        mime: [application/pdf, image/png, image/jpeg]
+        optional: true
+    indexes:
+      - fields: [received_at]
+
+# ────────────────────────────────────────────────────────────────────
+# Materialized views (aggregate subsystem)
+# ────────────────────────────────────────────────────────────────────
+views:
+
+  invoices_by_month:
+    kind: materialized
+    source: invoices
+    refresh:
+      mode: on_write                        # alternatives: scheduled, manual
+      debounce_ms: 500
+    group_by:
+      - field: client_id
+      - field: issued_at
+        granularity: month
+      - field: currency
+    aggregate:
+      invoice_count: { fn: count }
+      total_amount:  { fn: sum, field: amount }
+      avg_amount:    { fn: avg, field: amount }
+    acl: *acl_internal_rw
+
+# ────────────────────────────────────────────────────────────────────
+# Overlay views
+# ────────────────────────────────────────────────────────────────────
+overlays:
+
+  paid_invoices_by_month:
+    kind: overlay
+    of: invoices_by_month                   # ← refers to the MV above
+    filter: "status == 'paid'"
+    description: |
+      Same shape as invoices_by_month but restricted to paid invoices.
+      Used by the client portal — separate ACL because clients are
+      allowed to see this slice of their own data.
+    acl:
+      read: [owner, admin, operator, viewer, client]
+      write: []
+      scope: own_records                    # clients see only their own


### PR DESCRIPTION
## Summary

- Adds `docs/superpowers/noy-db-schema-handoff/` — a self-contained design bundle for the upcoming `@noy-db/schema` declarative vault definition layer
- Carries forward all settled decisions from a prior design session so work can continue in Claude Code without losing context

## Contents

| File | Purpose |
|------|---------|
| `README.md` | Orientation — what this bundle is, how to use it |
| `BRIEF.md` | All settled design decisions (format, package API, in/out of scope, branching, issue ordering) — do not relitigate |
| `RATIONALE.md` | Why those decisions; alternatives considered and rejected |
| `KICKOFF_PROMPT.md` | Copy-paste prompt to start the `feat/schema` implementation session |
| `create-schema-milestone.sh` | `gh` CLI script to create the GitHub milestone + 8 issues |
| `vault.example.noydb.yaml` | Accounting-app recipe in the proposed YAML format — design artifact for issue #1 |

## What's next

Run `create-schema-milestone.sh --dry-run` to preview, then for real to create the milestone and 8 issues. Then open a `feat/schema` branch and follow `KICKOFF_PROMPT.md`.

## Test plan

- [ ] `BRIEF.md` is readable end-to-end without ambiguity
- [ ] `vault.example.noydb.yaml` passes YAML lint (`yamllint` or VS Code YAML extension)
- [ ] `create-schema-milestone.sh --dry-run` runs without error (requires `gh` auth)