### PR TITLE
feat(hub): persisted JSON Schema — opt-in encrypted _schemas/<col> envelope (slice 1)

### DIFF
--- a/docs/superpowers/specs/2026-05-22-schema-dump-design.md
+++ b/docs/superpowers/specs/2026-05-22-schema-dump-design.md
@@ -1,0 +1,614 @@
+# Schema dump — human-readable vault audit (CLI + persisted JSON Schema)
+
+> Adds a CLI command `noydb describe` that emits a human-readable YAML/JSON description of a `.noydb` bundle's structure (collections, fields, indexes, FKs, MVs, overlays, derivations, guards, history, blobs, i18n, ACLs, subsystem matrix), with optional counters (records, bytes total/avg/min/max, oldest/newest). To make field-level intent visible from a bundle alone, opt-in **persisted JSON Schema** snapshots are written to a new `_schemas/<collection>` envelope at `collection()` registration. Targets the pre.16 release.
+
+## Goal
+
+Give an auditor — typically the firm's accounting/IT lead handed a `.noydb` file — a single command that produces a self-contained, readable description of what's inside, without needing to run the application code that produced the file:
+
+```bash
+$ noydb describe ./acme-vault.noydb --with-stats -o vault.shape.yaml
+```
+
+The output is the answer to "what's in this thing?" — every collection's purpose and shape, plus how big they are. Output is single-file YAML or JSON, with stats inlined when requested.
+
+Three vertical landings:
+
+1. **Hub: persisted JSON Schema (Route B).** Opt-in `collection({ persistJsonSchema: true })` derives a JSON Schema from Zod validators at registration time and writes it to a `_schemas/<collection>` envelope. Hash-based skip avoids write churn on every open.
+2. **Hub: introspection primitive.** `compartment.dumpSchema({ withStats })` walks every registered subsystem and returns a structured `VaultSchemaSnapshot` object. Used by the CLI; available programmatically for app-side audit pages.
+3. **CLI: `noydb describe` command.** Loads a bundle, resolves the passphrase (env → flag → prompt), calls the introspection primitive, emits YAML/JSON.
+
+## Success criteria (acceptance)
+
+### Hub: Route B persisted JSON Schema
+
+- `collection({ schema: zodSchema, persistJsonSchema: true })` accepted at registration with no behaviour change to record-level validation (Zod still runs on `put`/read).
+- For Zod validators, hub derives a JSON Schema via `zod-to-json-schema` (optional peer-dep) and writes `_schemas/<collection>` with `{ kind: 'Zod', jsonSchema, hash, derivedAt, _noydb_schema: 1 }` — **AES-GCM encrypted with the collection's DEK** (same encryption envelope as the collection's records; the schema body is sensitive metadata, not public).
+- For non-Zod Standard Schema validators (Valibot, ArkType, Effect Schema), hub writes a stub envelope `{ kind: 'Valibot' | 'ArkType' | 'Effect', jsonSchema: null, reason: 'derivation not yet supported in v0', _noydb_schema: 1 }`, also encrypted with the collection's DEK for consistency.
+- On every `collection()` registration with `persistJsonSchema: true`: derive → canonicalise → SHA-256 hash → compare to stored envelope's `hash`. If equal, skip write. If different (or no envelope), write fresh.
+- `vault.exportJSON()`'s currently-always-null `schema` field is populated from `_schemas/<collection>` when the envelope exists. Existing tests against `schema: null` remain valid for vaults that have NOT opted in.
+- `compartment.dump()` chunk stream emits the persisted JSON Schema (when present) in a new `chunk.persistedSchema` field. Independent of the existing `chunk.schema` (live validator object).
+- `zod-to-json-schema` is declared as an **optional peer-dep**; absent at install time → calling `persistJsonSchema: true` with a Zod validator throws `PersistedSchemaError` at registration with a clear "install zod-to-json-schema" message.
+- Hub bundle size grows by ≤ 2 KB (the derivation glue + envelope plumbing only; converter library is peer-dep).
+
+### Hub: introspection primitive
+
+- `compartment.dumpSchema(opts?: { withStats?: boolean; sampleSize?: number }): Promise<VaultSchemaSnapshot>` exposed from `@noy-db/hub`.
+- Snapshot includes: vault name, subsystem opt-in matrix, ACL roles, public envelope (if present), every collection with fields/indexes/FK refs/guards/history-strategy/blob-fields/i18n-labels, every MV (sources, groupBy, aggregate, refresh mode), every overlay view, every derivation.
+- Field source per collection: (1) persisted JSON Schema decrypted from `_schemas/<collection>` (`source: 'persisted'`) — **requires passphrase** since the envelope is now AES-GCM encrypted with the collection's DEK; (2) live validator introspected via Standard Schema's `~standard` protocol (`source: 'live-validator'`) when the call site is in-process and a validator is attached; (3) sampled from up to `sampleSize` decrypted records (`source: 'sampled'`) when neither is available; (4) empty with `source: 'unknown'` when no passphrase is provided (both persisted-schema decryption AND sampling become unavailable).
+- With `withStats: true`: each collection/MV/overlay block carries `stats: { records, bytes, bytesAvg, bytesMin, bytesMax, oldest, newest }`. `oldest`/`newest` derive from the unencrypted `_ts` envelope field (**no decrypt required** — stats work without passphrase). `bytes` totals come from envelope `_data` lengths (also no decrypt). `bytesAvg/Min/Max` are computed in the same envelope walk. **Stats are the only thing that works zero-auth.**
+- Field order within a collection preserves the validator's declaration order (Zod source order). Top-level snapshot keys (collections list, MVs list, overlays) are alphabetical for diff stability.
+- Internal collections (`_keyring`, `_ledger`, `_meta`, `_schemas`, `_deltas`, ...) are excluded from the user-visible `collections` section but counted in a separate `internal:` block when `withStats: true`.
+- Walking a 100-collection / 1 M-record vault runs in under 5 seconds end-to-end (in-memory backend) with `withStats: true`.
+
+### CLI: `noydb describe`
+
+- New subcommand: `noydb describe <bundle-path> [--with-stats] [--format yaml|json] [-o <file>] [--passphrase <p>] [--sample <n>]`.
+- Bundle path is required; missing file exits 2 with usage.
+- Format default: `yaml`. JSON output is `JSON.stringify(snapshot, null, 2)`. YAML output uses the `yaml` npm package as a CLI-scoped peer-dep (hub stays zero-dep; `yaml` is only required by `@noy-db/cli`).
+- Both formats emit a structured top-level `_provenance` field (no YAML-only comment header): `{ generatedBy: 'noydb describe v0.1.0', source: '<bundle-path>', sourceSha256: '<hex>', emittedAt: '<ISO-8601>' }`. Single source of truth across yaml/json. Numbers are emitted as plain integers (JSON-compatible) — no underscore separators.
+- Output destination: stdout by default; `-o <file>` writes file.
+- Passphrase resolution: `--passphrase` flag OR `NOYDB_PASSPHRASE` env. **No interactive prompt.** Absence of both = no decryption attempted (sampling silently skipped; collections without persisted schema show `source: unknown`). `--passphrase` use logs a one-time stderr warning about shell history.
+- Auth failure (wrong passphrase) → exit 3 with `decryption failed: check passphrase` to stderr.
+- Sampling is **smart-auto**: when passphrase is available (flag or env), sample up to 50 records per collection that lacks a persisted/live schema. When no passphrase, sampling is silently skipped and those collections show `source: 'unknown'`. Override sample size via `--sample <n>` (still requires passphrase); `--sample 0` forces skip even when passphrase is present.
+- Exit codes: 0 ok; 1 internal error; 2 usage error; 3 auth failure.
+- `noydb --help` lists the new `schema dump` subcommand.
+
+### Cross-cutting
+
+- Hub tests pass (current 1601 baseline + new tests for Route B + introspection).
+- CLI tests pass (new tests for `schema dump` against fixture bundles).
+- One showcase under `showcases/` exercises a vault with persisted JSON Schema enabled, opens the bundle, runs the CLI, asserts the emitted YAML round-trips through `JSON.parse(JSON.stringify(yaml-parsed))` to the expected shape.
+- `features.yaml` gains entries `persisted-json-schema` and `cli-schema-dump`.
+- `docs/subsystems/` gains `schema-dump.md` (CLI usage + Route B opt-in).
+- `docs/core/05-schema-and-refs.md` cross-links to Route B opt-in and clarifies the runtime-vs-persisted distinction.
+- `pnpm turbo build`, `pnpm turbo typecheck`, `pnpm turbo lint`, `pnpm turbo test` all green.
+
+## Scope — what's in
+
+| Feature | In | Notes |
+|---|:---:|---|
+| `CollectionOptions.persistJsonSchema: boolean` | ✓ | Default `false`. Backward-compatible. |
+| `_schemas/<collection>` envelope (plaintext, AES-GCM-bypassed) | ✓ | Mirrors `_meta/handle` / `_meta/public-envelope` / `_keyring` storage pattern |
+| Zod → JSON Schema derivation via `zod-to-json-schema` peer-dep | ✓ | Optional peer-dep; absent → clear error at registration |
+| Stub envelope for non-Zod validators | ✓ | `{ kind, jsonSchema: null, reason }` so the slot exists for follow-up |
+| Hash-based skip on registration | ✓ | SHA-256 of canonicalised JSON Schema; written only on mismatch |
+| `compartment.dumpSchema({ withStats })` | ✓ | Public hub API; returns typed snapshot |
+| Field source provenance (`persisted` / `live-validator` / `sampled` / `unknown`) | ✓ | Each field carries a `source:` marker in the emitted snapshot |
+| Counter walk via envelope metadata only (no decrypt for bytes/`_ts`) | ✓ | Byte totals + oldest/newest computable without passphrase |
+| Sampling fallback for fields when no schema is available | ✓ | Default `--sample 50`; configurable; `--sample 0` opts out |
+| Single combined YAML/JSON output | ✓ | `stats:` inline per collection when `--with-stats` |
+| Field order = validator declaration order; top-level keys alphabetical | ✓ | Reads like the Zod source; top-level still diff-stable |
+| `--schemas <full\|sidecar\|none>` flag for JSON Schema body inclusion | ✓ | Default `none` (summary only); `full` inlines; `sidecar` writes `<out>.schemas/<col>.schema.json` |
+| Internal-collection stats under separate `internal:` block | ✓ | Visible only with `--with-stats`; user-facing collections list omits internals |
+| CLI passphrase resolution: flag → env → prompt | ✓ | One-time stderr warning when `--passphrase` used |
+| `vault.exportJSON()` `schema` slot populated from persisted envelope | ✓ | Backfill the forward-compat slot that's currently always null |
+| `yaml` peer-dep in `@noy-db/cli` only (hub stays zero-dep) | ✓ | Battle-tested emitter; scoped to the package that needs it |
+
+## Scope — what's deferred
+
+| Feature | Deferred to | Why |
+|---|---|---|
+| JSON Schema derivation for Valibot / ArkType / Effect Schema | v0.2 follow-up | Each needs its own converter; v0 ships Zod (the 80% case) with stub envelopes flagging the rest |
+| Round-trip schema → vault scaffolding (`noydb schema apply`) | post-v1 | This is `prisma migrate` territory; out of scope for an audit tool |
+| Schema diff (`noydb schema diff <live> <file>`) | v0.3 | Useful but additive on top of the v0 emitter |
+| TypeScript codegen from emitted schema (`noydb schema codegen`) | post-v1 | Codegen needs the validator surface to round-trip; not in v0 |
+| Visual / diagram emit (Mermaid, dbml, drawio) | separate milestone | Tracked separately; depends on this milestone landing first |
+| Multi-vault dump (one CLI call, multiple bundles) | follow-up | v0 is one bundle in / one snapshot out |
+| Streaming output for huge vaults | premature | Memory-first design caps individual vaults at 1K–50K records per collection; in-memory snapshot is fine |
+| Per-keyring / per-tier stats breakdown | v0.2 follow-up | Distribution stats (avg/min/max) ship in v0; finer slicing waits for real audit demand |
+| Schema versioning + migration of `_schemas/<collection>` between hub versions | with `@noy-db/hub/migrations` reserved subsystem | Premature at v0; envelope carries `_noydb_schema: 1` so a v2 can migrate cleanly |
+| Encrypted JSON Schemas (for vaults where field names themselves are sensitive) | future opt-in | Default is plaintext (auditor convenience); encrypted variant is a v0.3+ option behind a flag |
+| Live in-process introspection without opening a bundle | partial today | `compartment.dumpSchema()` works in-process; v0 just doesn't add a CLI mode for it |
+
+## Non-goals
+
+- Replacing Standard Schema validators with a native noy-db DSL. Zod stays the recommended validator; Route B just snapshots its derived shape for portability.
+- Making persisted schemas authoritative for validation. They're a portability record; record validation still runs through the live validator on `put`/read. Drift between persisted and live is **not** a runtime error.
+- Auto-persisting schemas without opt-in. `persistJsonSchema: true` is required per collection; default behaviour is unchanged.
+- Recovering field-level data from a corrupt bundle. Out of scope; `noydb verify` handles integrity, not recovery.
+- Hiding the existence of internal collections. `_keyring` / `_ledger` / `_schemas` etc. show up under `internal:` with `--with-stats`. The intent is audit visibility, not secrecy.
+
+## Type surface
+
+### Hub additions (`@noy-db/hub`)
+
+```ts
+// packages/hub/src/types.ts
+export interface CollectionOptions<T> {
+  schema?: StandardSchemaV1<unknown, T>
+  refs?: Record<string, Ref>
+  // ...existing fields...
+
+  /**
+   * When true and `schema` is a Zod schema, derive a JSON Schema at
+   * registration and persist it to `_schemas/<collection>`. Enables
+   * `noydb describe` to surface field-level intent from a bundle
+   * without needing the app code that registered the collection.
+   *
+   * Default: false. No behavioural change to record-level validation
+   * either way — Zod still runs on put/read.
+   *
+   * Requires `zod-to-json-schema` peer-dep when used with a Zod schema.
+   * Non-Zod Standard Schema validators write a stub envelope flagging
+   * the kind without a JSON Schema body.
+   */
+  persistJsonSchema?: boolean
+}
+
+// packages/hub/src/meta/persisted-schemas/types.ts
+export interface PersistedSchemaEnvelope {
+  readonly _noydb_schema: 1
+  /** Detected validator family. */
+  readonly kind: 'Zod' | 'Valibot' | 'ArkType' | 'Effect' | 'Unknown'
+  /**
+   * JSON Schema (Draft 2020-12) derived from the validator. Null when
+   * derivation isn't yet supported for `kind`, with `reason` populated.
+   */
+  readonly jsonSchema: object | null
+  /** SHA-256 of the canonicalised JSON Schema. Used for hash-based skip. */
+  readonly hash: string | null
+  /** Human-readable reason when `jsonSchema` is null. */
+  readonly reason?: string
+  /** ISO-8601 timestamp of the most recent derivation write. */
+  readonly derivedAt: string
+}
+
+// packages/hub/src/introspection/types.ts
+export interface VaultSchemaSnapshot {
+  readonly _noydb_snapshot: 1
+  readonly vault: string
+  readonly emittedAt: string
+  readonly subsystems: Record<string, boolean>     // { history: true, guards: true, ... }
+  readonly aclRoles: ReadonlyArray<string>          // ['admin', 'client', 'operator', ...]
+  readonly publicEnvelope?: PublicEnvelopeSummary
+  readonly collections: Record<string, CollectionDescriptor>
+  readonly materializedViews: Record<string, MaterializedViewDescriptor>
+  readonly overlayViews: Record<string, OverlayViewDescriptor>
+  readonly derivations: Record<string, DerivationDescriptor>
+  readonly internal?: Record<string, InternalCollectionStats>  // only with withStats
+}
+
+export interface CollectionDescriptor {
+  readonly description?: string
+  readonly fields: Record<string, FieldDescriptor>
+  readonly indexes: ReadonlyArray<IndexDescriptor>
+  readonly refs: Record<string, RefDescriptor>
+  readonly guards: ReadonlyArray<string>            // guard names
+  readonly history?: { strategy: string }
+  readonly blobFields: ReadonlyArray<string>
+  readonly i18nLabels?: Record<string, string>      // { en: 'Invoices', th: '...' }
+  readonly aclRoles?: Record<string, ReadonlyArray<'read'|'write'>>
+  readonly validator?: {
+    readonly kind: PersistedSchemaEnvelope['kind']
+    readonly source: 'persisted' | 'live-validator' | 'sampled' | 'unknown'
+  }
+  readonly stats?: CollectionStats                  // only with withStats
+}
+
+export interface FieldDescriptor {
+  readonly type: string                             // 'string' | 'number' | 'boolean' | 'enum' | 'object' | 'array' | 'opaque'
+  readonly source: 'persisted' | 'live-validator' | 'sampled' | 'unknown'
+  readonly constraints?: Record<string, unknown>    // { minLength, maxLength, enum, pattern, gt, ... }
+  readonly optional?: boolean
+  readonly references?: string                      // 'clients.id'
+}
+
+export interface CollectionStats {
+  readonly records: number
+  readonly bytes: number
+  readonly bytesAvg: number
+  readonly bytesMin: number
+  readonly bytesMax: number
+  readonly oldest: string                           // ISO-8601 from _ts
+  readonly newest: string                           // ISO-8601 from _ts
+}
+
+// Compartment API
+export interface Compartment {
+  // ...existing methods...
+  dumpSchema(opts?: { withStats?: boolean; sampleSize?: number }): Promise<VaultSchemaSnapshot>
+}
+```
+
+### CLI additions (`@noy-db/cli`)
+
+```ts
+// packages/cli/src/commands/schema.ts
+export interface SchemaDumpOptions {
+  readonly bundlePath: string
+  readonly format: 'yaml' | 'json'
+  readonly withStats: boolean
+  readonly outPath?: string
+  readonly passphrase?: string
+  readonly sampleSize: number
+}
+
+export async function runSchemaDump(argv: readonly string[]): Promise<number>
+```
+
+```
+usage: noydb describe <bundle-path> [options]
+  --format <yaml|json>     output format (default: yaml)
+  --with-stats             include records / bytes / oldest / newest per collection
+  --schemas <mode>         JSON Schema body inclusion (default: none)
+                           - none:    summary only (terse audit view)
+                           - full:    inline complete JSON Schema per collection
+                           - sidecar: separate files `<out>.schemas/<col>.schema.json`
+  -o, --out <file>         write to file instead of stdout
+  --passphrase <p>         passphrase (also: NOYDB_PASSPHRASE env, or prompt)
+  --sample <n>             max records to sample for fields fallback (default: 50; 0 = disable)
+```
+
+## Storage / envelope format
+
+Persisted JSON Schemas live in a new reserved `_schemas` collection. One record per user-facing collection, keyed by the collection's name. **AES-GCM encrypted with the same DEK as the collection's records** — the schema body is sensitive metadata (field names, enum values, constraints can reveal domain-specific intent), so it gets the same encryption envelope as the data. Unlocking access to the collection's records unlocks access to its schema; nothing more.
+
+| Field | Type | Notes |
+|---|---|---|
+| `_noydb` | `1` | Envelope format version (existing) |
+| `_v` | `number` | Monotonic per-record version (existing) |
+| `_ts` | `ISO-8601` | Last write timestamp (existing) |
+| `_iv` | `string` | Random 12-byte AES-GCM IV (base64) — standard envelope |
+| `_data` | `string` | AES-GCM ciphertext (base64) of JSON-stringified `PersistedSchemaEnvelope` |
+
+The `_schemas` collection name is reserved alongside the existing `_keyring`, `_ledger`, `_meta`, `_deltas` set. Store implementations need no changes — it's just another collection from the store's perspective.
+
+Path inside a bundle:
+
+```
+_schemas/
+  invoices         (envelope holding the JSON Schema for the `invoices` collection)
+  clients          (...)
+  payments         (...)
+```
+
+## Algorithms
+
+### Route B: derivation + hash-based skip
+
+At `vault.collection(name, opts)` when `opts.persistJsonSchema === true`:
+
+```
+1. Detect validator kind from opts.schema via Standard Schema introspection:
+   - Zod:    presence of `_def.typeName` (`ZodObject`, `ZodString`, ...)
+   - Valibot: presence of `kind === 'schema'` + `type` discriminant
+   - ArkType: presence of `.toJsonSchema` method
+   - Effect: presence of Schema marker symbol
+   - else: kind = 'Unknown'
+2. If kind === 'Zod':
+   - Lazy-require 'zod-to-json-schema'. Absent → throw PersistedSchemaError.
+   - jsonSchema = zodToJsonSchema(opts.schema, { target: 'jsonSchema2020-12' })
+   - hash = sha256(canonicalize(jsonSchema))
+3. Else: jsonSchema = null, hash = null, reason = `derivation not yet supported for ${kind}`
+4. Read existing _schemas/<name> envelope. If exists and stored.hash === hash, skip step 5.
+5. Write _schemas/<name> envelope with { _noydb_schema: 1, kind, jsonSchema, hash, derivedAt: now(), reason? }.
+```
+
+`canonicalize(obj)` is a deterministic JSON serializer: sort object keys lexicographically, preserve array order. Implemented as a small recursive helper inside `meta/persisted-schemas/`.
+
+The lazy-require for `zod-to-json-schema` keeps hub's required-dep count at zero. The optional peer is declared in `package.json` `peerDependenciesMeta` with `optional: true`.
+
+### Introspection walk
+
+`compartment.dumpSchema(opts)` runs in three phases:
+
+```
+Phase 1 — assemble structure (no decrypt needed for skeleton; persisted schemas need DEK)
+  - vault name from compartment
+  - subsystems opt-in from compartment's registered with*() seams
+  - acl roles from policy module
+  - publicEnvelope from _meta/public-envelope (plaintext)
+  - per user-facing collection:
+      - persisted JSON Schema from _schemas/<name> DECRYPTED with collection's DEK
+        if present AND the compartment is unlocked; else mark source = 'live-validator'
+        if validator in scope, else 'sampled' (deferred to phase 3), else 'unknown'
+      - indexes, refs, guards, history-strategy, blobFields, i18nLabels, aclRoles
+        from the collection's runtime descriptor (in-memory; no decrypt)
+  - per MV: sources, groupBy, aggregate, refresh from withMaterializedView spec
+  - per overlay view: source, where-clause, fields from withOverlayView spec
+  - per derivation: kind, inputs, outputs from withDerivation spec
+
+Phase 2 — counters (when opts.withStats; no decrypt needed)
+  - for each collection: store.list(compartment, collection) → envelopes
+    - records = envelopes.length
+    - bytes = sum(env._data.length for env in envelopes)
+    - bytesAvg / Min / Max = derived from same walk
+    - oldest = min(env._ts), newest = max(env._ts)
+  - same walk for _keyring, _ledger, _schemas, _meta, _deltas
+    → emitted under snapshot.internal
+
+Phase 3 — field sampling fallback (only when no persisted/live schema)
+  - for each collection lacking a field source:
+    - take up to sampleSize envelopes
+    - decrypt (requires passphrase to have unlocked the compartment)
+    - merge inferred field types from sampled records
+    - mark fields source = 'sampled'
+```
+
+Phase 1 + 2 run without decrypting any record bodies. Phase 3 needs a decrypted view, which is already available via the in-memory compartment cache after the bundle is opened.
+
+### Sampling type inference
+
+```
+For each sampled record:
+  for each (key, value) pair:
+    case typeof value:
+      'string':  field.type = 'string'; track maxLen, detect format (iso8601, ulid, uuid)
+      'number':  field.type = 'number'; track min, max
+      'boolean': field.type = 'boolean'
+      'object':  field.type = value === null ? 'null' : 'object'
+                 if Array.isArray(value): field.type = 'array'
+
+Merge across samples:
+  - if any sample has a field absent: mark optional: true
+  - if types disagree: collapse to 'opaque' (rare; record is malformed)
+  - enum detection: if ≤ 12 unique string values across all samples,
+    emit { type: 'enum', values: sorted unique }
+```
+
+## CLI surface — full grammar
+
+```
+$ noydb describe <bundle-path> [options]
+
+Positional:
+  bundle-path                 path to .noydb file (required)
+
+Options:
+  --format <yaml|json>        output format (default: yaml)
+  --with-stats                include counters per collection / MV / overlay
+  -o, --out <file>            write to file instead of stdout
+  --passphrase <p>            decryption passphrase (warns about shell history)
+                              (also: NOYDB_PASSPHRASE env, or TTY prompt)
+  --sample <n>                max records sampled per collection for field
+                              inference when no persisted/live schema exists
+                              (default: 50; 0 disables sampling)
+  -h, --help                  show this help
+
+Exit codes:
+   0   ok
+   1   internal error (printed to stderr)
+   2   usage error (missing args, bad option)
+   3   auth failure (wrong passphrase / no passphrase available)
+```
+
+Examples:
+
+```bash
+# basic structural dump to stdout
+noydb describe ./acme.noydb
+
+# with counters, write to file
+NOYDB_PASSPHRASE='hunter2' noydb describe ./acme.noydb --with-stats -o vault.shape.yaml
+
+# JSON for tooling
+noydb describe ./acme.noydb --format json | jq '.collections | keys'
+
+# CI audit: prompt for passphrase, no sampling fallback
+noydb describe ./acme.noydb --with-stats --sample 0 -o ci-audit.yaml
+```
+
+## Sample output
+
+```yaml
+_noydb_snapshot: 1
+_provenance:
+  generatedBy: noydb describe v0.1.0
+  source: acme-vault.noydb
+  sourceSha256: 4a7c...
+  emittedAt: 2026-05-22T14:31:42Z
+vault: acme-accounting
+emittedAt: 2026-05-22T14:31:42Z
+
+subsystems:
+  blobs: true
+  derivations: true
+  guards: true
+  history: true
+  i18n: true
+  materializedViews: true
+  overlayViews: true
+
+aclRoles: [admin, client, operator, owner, viewer]
+
+publicEnvelope:
+  name: { en: 'Acme Accounting', th: 'แอคเม' }
+  description: { en: 'Q2 2026 books' }
+
+collections:
+  clients:
+    description: External parties the firm invoices.
+    validator: { kind: Zod, source: persisted }
+    fields:
+      country:
+        type: string
+        source: persisted
+        constraints: { pattern: '^[A-Z]{2}$' }
+      created_at:
+        type: string
+        source: persisted
+        constraints: { format: 'iso8601' }
+      display_name:
+        type: string
+        source: persisted
+        constraints: { minLength: 1, maxLength: 200 }
+      id:
+        type: string
+        source: persisted
+      tax_id:
+        type: string
+        source: persisted
+        optional: true
+    indexes:
+      - fields: [country, display_name]
+      - fields: [tax_id]
+        unique: true
+    refs: {}
+    guards: []
+    blobFields: []
+    i18nLabels: { en: Clients, th: ลูกค้า }
+    stats:
+      records: 412
+      bytes: 138640
+      bytesAvg: 336
+      bytesMin: 180
+      bytesMax: 1204
+      oldest: 2024-03-01T08:12:00Z
+      newest: 2026-05-20T18:22:11Z
+
+  invoices:
+    description: Outbound invoices in dual EUR/THB currencies.
+    validator: { kind: Zod, source: persisted }
+    fields:
+      amount:
+        type: number
+        source: persisted
+        constraints: { gt: 0 }
+      client_id:
+        type: string
+        source: persisted
+        references: clients.id
+      status:
+        type: enum
+        source: persisted
+        constraints: { values: [draft, open, overdue, paid] }
+      # ...
+    indexes:
+      - fields: [client_id, date]
+    refs:
+      client_id: { target: clients, mode: strict }
+    guards: [recordLock, fieldFreeze]
+    history: { strategy: fullAudit }
+    blobFields: []
+    i18nLabels: { en: Invoices, th: ใบกำกับภาษี }
+    stats:
+      records: 1247
+      bytes: 428612
+      bytesAvg: 344
+      bytesMin: 200
+      bytesMax: 8204
+      oldest: 2024-03-01T08:14:32Z
+      newest: 2026-05-22T14:31:42Z
+
+materializedViews:
+  monthlyByClient:
+    sources: [invoices]
+    groupBy: [client_id, period]
+    aggregate: { total: 'sum(amount)' }
+    refresh: eager
+    stats:
+      records: 84
+      bytes: 24192
+      bytesAvg: 288
+
+overlayViews:
+  paidInvoices:
+    source: invoices
+    where: 'status == "paid"'
+
+derivations: {}
+
+internal:
+  _keyring:   { records: 4, bytes: 8120 }
+  _ledger:    { records: 1843, bytes: 412004 }
+  _schemas:   { records: 3,  bytes: 14280 }
+  _meta:      { records: 2,  bytes: 1104 }
+```
+
+## Showcases
+
+One end-to-end showcase under `showcases/` (numbered per the existing convention):
+
+| Showcase | Purpose |
+|---|---|
+| `schema-dump-with-persisted-validators/` | Build a small vault with three collections, two with `persistJsonSchema: true` (Zod) and one without, save as `.noydb`, run `noydb describe --with-stats`, assert the emitted YAML's structure (parsed back to JSON) matches an expected snapshot. Demonstrates persisted vs sampled provenance side-by-side. |
+
+The accounting-app showcase (existing) gets a docs update referencing how to opt in to `persistJsonSchema` per collection, but no code change.
+
+## Testing strategy
+
+| Surface | Test focus |
+|---|---|
+| Route B derivation | Zod schema → JSON Schema shape exactly; hash determinism across runs; hash skip on identical re-derive; hash mismatch triggers rewrite; non-Zod validator writes stub envelope; missing `zod-to-json-schema` peer-dep → clear error |
+| `_schemas` envelope | Read-after-write round-trip; survives compartment close/reopen; survives `.noydb` bundle write/read; absent envelope handled gracefully |
+| `vault.exportJSON()` integration | `schema` field populated when `_schemas/<col>` exists; `schema: null` preserved when not |
+| `dumpSchema()` no-stats | Snapshot shape matches `VaultSchemaSnapshot` type; alphabetical ordering at every level; field source provenance correct across persisted/live/sampled/unknown |
+| `dumpSchema({ withStats })` | Counters correct (records, bytes, avg/min/max from envelope walk); oldest/newest from `_ts`; no decrypt required for stats; internal collections emitted under `internal:` |
+| Sampling fallback | `--sample 50` produces correct inferred types from data; `--sample 0` produces `source: 'unknown'` with no field bodies; enum detection at ≤ 12 unique string values |
+| CLI command | Each exit code path; format default; format override; `-o` writes file; stdout default; passphrase resolution priority (flag → env → prompt); auth failure exit 3 |
+| YAML emitter | Round-trips through `yaml.parse` to identical structure; alphabetical keys preserved; no comment/anchor edge cases (since we don't emit them) |
+| Performance | 100-collection vault dumps in under 5 s with `--with-stats`; hash-skip path measurably faster than write path on no-op re-derive |
+
+## Open questions
+
+1. **Stable field ordering inside a collection.** Spec says alphabetical at every level for diff stability. The persisted JSON Schema may carry its own field order (Zod preserves declaration order). Trade-off: alphabetical = diff-stable; declaration = matches Zod source. **Proposed:** alphabetical in the snapshot; persisted envelope's JSON Schema can keep its declaration order (it's just JSON the emitter doesn't normalise).
+2. **Stub envelope for non-opted-in collections.** Should `_schemas/<col>` exist with `{ jsonSchema: null, reason: 'not opted in' }` for collections lacking `persistJsonSchema: true`? **Proposed:** No. Absence of envelope means "not opted in"; presence with `jsonSchema: null` means "opted in but derivation unavailable". Clean distinction.
+3. **CLI command name.** `noydb describe <bundle>` is the working name. Alternatives: `noydb dump` (shorter, but `dump` is overloaded with `compartment.dump()`), `noydb describe` (more descriptive of intent), `noydb introspect` (matches the hub primitive). **Proposed:** keep `schema dump` — it parallels `noydb config validate / scaffold` subcommand grouping.
+4. **`--with-stats` cost on huge vaults.** Phase 2 walks every envelope to sum bytes. For a 1 M-record vault this is O(n) but the in-memory backend has already loaded everything; cost is iteration, not I/O. Real-cloud adapters (DynamoDB, S3) would pay round-trips. **Proposed:** in v0, `noydb describe` is bundle-only — the bundle is local, so the cost is bounded. A future programmatic call on a live cloud-backed vault is a separate decision.
+5. **Subsystem opt-in detection.** Hub doesn't centrally register which `with*()` seams a vault opted into. We'd need to either (a) plumb a registry through hub or (b) inspect compartment state for evidence (presence of MV registry, guard registry, history registry, etc.). **Proposed:** (b) for v0 — read symptoms, not a registry. Simpler; matches what already exists.
+
+## Implementation slices (PR plan)
+
+Three PRs, each independently mergeable into `main` (no long-running branch):
+
+| Slice | Scope | Touches | Est. LOC |
+|---|---|---|---|
+| **#1 Hub: Route B persistence** | `CollectionOptions.persistJsonSchema`, `_schemas/<coll>` envelope, hash-based dedup, Zod derivation via `zod-to-json-schema` peer-dep, stub envelopes for non-Zod, `vault.exportJSON()` slot fill | `packages/hub/src/collection.ts`, new `packages/hub/src/meta/persisted-schemas/`, `vault.ts` export tweak, `types.ts`, tests | ~250 |
+| **#2 Hub: introspection primitive** | `compartment.dumpSchema({ withStats, sampleSize })`, `VaultSchemaSnapshot` types, three-phase walk, sampling fallback, alphabetical ordering | new `packages/hub/src/introspection/`, public re-export, tests | ~400 |
+| **#3 CLI: `noydb describe`** | New `schema` subcommand, bundle load + auth resolution, hand-written YAML emitter, JSON emitter, `--with-stats`, `--sample`, `-o`, exit codes | `packages/cli/src/commands/schema.ts`, `bin/noydb.ts` dispatch, tests, showcase | ~250 + showcase |
+
+Each slice has its own success criteria; this spec's "Success criteria" section serves as the umbrella.
+
+## File touchpoints summary
+
+```
+packages/hub/
+  src/
+    collection.ts                                    [edit: CollectionOptions, registration hook]
+    vault.ts                                          [edit: exportJSON slot fill, dumpSchema export]
+    types.ts                                          [edit: CollectionOptions type]
+    meta/
+      persisted-schemas/                              [NEW]
+        index.ts
+        types.ts
+        storage.ts
+        derive.ts
+        canonicalize.ts
+    introspection/                                    [NEW]
+      index.ts
+      types.ts
+      walk.ts
+      sample.ts
+  __tests__/
+    meta/persisted-schemas/*.test.ts                  [NEW]
+    introspection/*.test.ts                           [NEW]
+  package.json                                        [edit: peerDependenciesMeta zod-to-json-schema]
+
+packages/cli/
+  src/
+    bin/noydb.ts                                      [edit: dispatch 'schema' subcommand]
+    commands/
+      schema.ts                                       [NEW]
+    emit/                                             [NEW]
+      yaml.ts
+      json.ts
+  __tests__/
+    schema-dump.test.ts                               [NEW]
+
+showcases/
+  schema-dump-with-persisted-validators/              [NEW]
+    package.json
+    src/index.ts
+    expected.yaml
+
+docs/
+  subsystems/
+    schema-dump.md                                    [NEW]
+  core/
+    05-schema-and-refs.md                             [edit: cross-link to Route B]
+  superpowers/specs/
+    2026-05-22-schema-dump-design.md                  [this file]
+
+features.yaml                                         [edit: persisted-json-schema, cli-schema-dump]
+```

--- a/features.yaml
+++ b/features.yaml
@@ -110,6 +110,25 @@ features:
       - 'Validation runs before encryption (write) and after decryption (read)'
     related: [vault-and-collections]
 
+  - id: persisted-json-schema
+    name: Persisted JSON Schema (opt-in)
+    cluster: core
+    spec: docs/superpowers/specs/2026-05-22-schema-dump-design.md
+    subsystem_doc: docs/core/05-schema-and-refs.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'opt-in per collection via collection({ persistJsonSchema: true })'
+      - 'envelope stored encrypted with the collection DEK under _schemas/<col>'
+      - 'hash-based skip on every collection() registration — no _v churn on no-op re-derive'
+      - 'v0 supports Zod via optional zod-to-json-schema peer-dep; other Standard Schema validators write a stub envelope flagging the kind'
+    related: [schema-and-refs]
+
   - id: query-basics
     name: Always-on query DSL
     cluster: core

--- a/packages/as-xlsx/__tests__/as-xlsx.test.ts
+++ b/packages/as-xlsx/__tests__/as-xlsx.test.ts
@@ -173,6 +173,46 @@ describe('writeXlsx — low-level', () => {
   it('throws on empty sheet list', async () => {
     await expect(writeXlsx([])).rejects.toThrow(/at least one sheet/)
   })
+
+  it('emits a <cols> block when widths are provided', async () => {
+    const bytes = await writeXlsx([
+      {
+        name: 'Widths',
+        header: ['short', 'long'],
+        rows: [['a', 'b']],
+        widths: [8, 32.5],
+      },
+    ])
+    const sheet = readZipFile(bytes, 'xl/worksheets/sheet1.xml')!
+    expect(sheet).toContain('<cols>')
+    expect(sheet).toMatch(/<col min="1" max="1" width="8" customWidth="1"\/>/)
+    expect(sheet).toMatch(/<col min="2" max="2" width="32\.5" customWidth="1"\/>/)
+    // `<cols>` must precede `<sheetData>` per the OOXML schema.
+    expect(sheet.indexOf('<cols>')).toBeLessThan(sheet.indexOf('<sheetData>'))
+  })
+
+  it('omits the <cols> block when widths are absent', async () => {
+    const bytes = await writeXlsx([
+      { name: 'NoWidths', rows: [[1]] },
+    ])
+    const sheet = readZipFile(bytes, 'xl/worksheets/sheet1.xml')!
+    expect(sheet).not.toContain('<cols>')
+  })
+
+  it('skips undefined / non-positive entries so widths can mix auto + explicit', async () => {
+    const bytes = await writeXlsx([
+      {
+        name: 'Mixed',
+        rows: [[1, 2, 3, 4]],
+        widths: [10, undefined, 0, 15],
+      },
+    ])
+    const sheet = readZipFile(bytes, 'xl/worksheets/sheet1.xml')!
+    expect(sheet).toMatch(/<col min="1" max="1" width="10"/)
+    expect(sheet).not.toMatch(/<col min="2"/)
+    expect(sheet).not.toMatch(/<col min="3"/)
+    expect(sheet).toMatch(/<col min="4" max="4" width="15"/)
+  })
 })
 
 describe('as-xlsx — vault integration', () => {

--- a/packages/as-xlsx/src/xlsx.ts
+++ b/packages/as-xlsx/src/xlsx.ts
@@ -54,6 +54,17 @@ export interface XlsxSheet {
   readonly header?: readonly string[]
   /** Data rows — each is an array aligned with `header` if present. */
   readonly rows: readonly XlsxRow[]
+  /**
+   * Optional per-column widths in Excel character units (same scale as
+   * SheetJS's `wch`). When set, emits a `<cols>` block so Excel opens
+   * the file with the columns sized as specified instead of the default
+   * 10-character width. Index aligned with `header` / row cells.
+   *
+   * Non-finite or non-positive entries are skipped (column falls back
+   * to Excel's default width). A consumer typically passes `undefined`
+   * for "auto" columns and a number for explicit widths.
+   */
+  readonly widths?: ReadonlyArray<number | undefined>
 }
 
 /**
@@ -95,8 +106,23 @@ export async function writeXlsx(sheets: readonly XlsxSheet[]): Promise<Uint8Arra
     const lines: string[] = [
       XML_HEADER,
       '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">',
-      '<sheetData>',
     ]
+    // `<cols>` must precede `<sheetData>` per OOXML schema. Emit one
+    // `<col>` element per defined width; skip entries that are not
+    // positive finite numbers so consumers can mix explicit + auto.
+    if (sheet.widths && sheet.widths.length > 0) {
+      const colLines: string[] = []
+      for (let i = 0; i < sheet.widths.length; i++) {
+        const w = sheet.widths[i]
+        if (typeof w !== 'number' || !Number.isFinite(w) || w <= 0) continue
+        const n = i + 1
+        colLines.push(`<col min="${n}" max="${n}" width="${w}" customWidth="1"/>`)
+      }
+      if (colLines.length > 0) {
+        lines.push('<cols>', ...colLines, '</cols>')
+      }
+    }
+    lines.push('<sheetData>')
     let rowNum = 0
     if (sheet.header && sheet.header.length > 0) {
       rowNum++

--- a/packages/hub/__tests__/persisted-schemas/canonicalize.test.ts
+++ b/packages/hub/__tests__/persisted-schemas/canonicalize.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { canonicalize } from '../../src/persisted-schemas/canonicalize.js'
+
+describe('canonicalize', () => {
+  it('sorts object keys lexicographically at every depth', () => {
+    const a = canonicalize({ b: 1, a: { y: 2, x: 1 } })
+    const b = canonicalize({ a: { x: 1, y: 2 }, b: 1 })
+    expect(a).toBe(b)
+    expect(a).toBe('{"a":{"x":1,"y":2},"b":1}')
+  })
+
+  it('preserves array order (arrays are semantically ordered)', () => {
+    const out = canonicalize({ items: [3, 1, 2] })
+    expect(out).toBe('{"items":[3,1,2]}')
+  })
+
+  it('handles nested arrays of objects', () => {
+    const out = canonicalize({ rows: [{ b: 2, a: 1 }, { d: 4, c: 3 }] })
+    expect(out).toBe('{"rows":[{"a":1,"b":2},{"c":3,"d":4}]}')
+  })
+
+  it('handles primitives + null', () => {
+    expect(canonicalize(null)).toBe('null')
+    expect(canonicalize(42)).toBe('42')
+    expect(canonicalize('hi')).toBe('"hi"')
+    expect(canonicalize(true)).toBe('true')
+  })
+})

--- a/packages/hub/__tests__/persisted-schemas/derive.test.ts
+++ b/packages/hub/__tests__/persisted-schemas/derive.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { derivePersistedSchema, isZodSchema } from '../../src/persisted-schemas/derive.js'
+
+describe('isZodSchema', () => {
+  it('identifies a Zod schema via _def.typeName', () => {
+    expect(isZodSchema(z.object({ id: z.string() }))).toBe(true)
+    expect(isZodSchema(z.string())).toBe(true)
+  })
+
+  it('rejects non-Zod values', () => {
+    expect(isZodSchema(null)).toBe(false)
+    expect(isZodSchema({})).toBe(false)
+    expect(isZodSchema({ '~standard': { version: 1 } })).toBe(false)
+    expect(isZodSchema('string')).toBe(false)
+  })
+})
+
+describe('derivePersistedSchema', () => {
+  it('derives a Zod envelope with JSON Schema body and a 64-char hex hash', async () => {
+    const Invoice = z.object({
+      id: z.string(),
+      amount: z.number().positive(),
+    })
+    const env = await derivePersistedSchema(Invoice)
+    expect(env._noydb_schema).toBe(1)
+    expect(env.kind).toBe('Zod')
+    expect(env.jsonSchema).toMatchObject({
+      type: 'object',
+      properties: {
+        id: expect.objectContaining({ type: 'string' }),
+        amount: expect.objectContaining({ type: 'number' }),
+      },
+    })
+    expect(env.hash).toMatch(/^[0-9a-f]{64}$/)
+    expect(env.derivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    expect(env.reason).toBeUndefined()
+  })
+
+  it('produces an identical hash for two equivalent Zod schemas', async () => {
+    const a = await derivePersistedSchema(z.object({ a: z.string(), b: z.number() }))
+    const b = await derivePersistedSchema(z.object({ a: z.string(), b: z.number() }))
+    expect(a.hash).toBe(b.hash)
+  })
+
+  it('produces a different hash when the schema shape changes', async () => {
+    const a = await derivePersistedSchema(z.object({ id: z.string() }))
+    const b = await derivePersistedSchema(z.object({ id: z.string(), extra: z.number() }))
+    expect(a.hash).not.toBe(b.hash)
+  })
+
+  it('writes a stub envelope (jsonSchema: null + reason) for a non-Zod Standard Schema validator', async () => {
+    const fakeValibot = { '~standard': { version: 1, vendor: 'valibot', validate: () => ({}) } }
+    const env = await derivePersistedSchema(fakeValibot as unknown as never)
+    expect(env._noydb_schema).toBe(1)
+    expect(env.kind).toBe('Unknown')
+    expect(env.jsonSchema).toBeNull()
+    expect(env.hash).toBeNull()
+    expect(env.reason).toMatch(/derivation not yet supported/i)
+  })
+})

--- a/packages/hub/__tests__/persisted-schemas/registration.test.ts
+++ b/packages/hub/__tests__/persisted-schemas/registration.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { z } from 'zod'
+import { generateDEK } from '../../src/crypto.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/types.js'
+import { ConflictError } from '../../src/errors.js'
+import { persistSchemaIfNeeded } from '../../src/persisted-schemas/register.js'
+import { loadPersistedSchema } from '../../src/persisted-schemas/storage.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll() { /* unused */ },
+  }
+}
+
+describe('persistSchemaIfNeeded', () => {
+  const VAULT = 'acme'
+  const COLLECTION = 'invoices'
+  let store: NoydbStore
+  let dek: CryptoKey
+
+  beforeEach(async () => {
+    store = inlineMemory()
+    dek = await generateDEK()
+  })
+
+  it('writes a fresh envelope on first call for a Zod-validated collection', async () => {
+    const Invoice = z.object({ id: z.string(), amount: z.number() })
+    const result = await persistSchemaIfNeeded({
+      store, vault: VAULT, collectionName: COLLECTION, validator: Invoice, dek,
+    })
+    expect(result.written).toBe(true)
+    expect(result.skipped).toBe(false)
+    expect(result.envelope.kind).toBe('Zod')
+    expect(result.envelope.hash).toMatch(/^[0-9a-f]{64}$/)
+
+    const stored = await loadPersistedSchema(store, VAULT, COLLECTION, dek)
+    expect(stored?.hash).toBe(result.envelope.hash)
+  })
+
+  it('skips the write when the validator hash matches what is already stored', async () => {
+    const Invoice = z.object({ id: z.string(), amount: z.number() })
+    await persistSchemaIfNeeded({ store, vault: VAULT, collectionName: COLLECTION, validator: Invoice, dek })
+    const before = (await store.get(VAULT, '_schemas', COLLECTION))!._v
+
+    const result = await persistSchemaIfNeeded({ store, vault: VAULT, collectionName: COLLECTION, validator: Invoice, dek })
+    expect(result.written).toBe(false)
+    expect(result.skipped).toBe(true)
+
+    const after = (await store.get(VAULT, '_schemas', COLLECTION))!._v
+    expect(after).toBe(before) // no _v bump on skip
+  })
+
+  it('writes fresh when the validator shape changes (hash mismatch)', async () => {
+    const v1 = z.object({ id: z.string() })
+    const v2 = z.object({ id: z.string(), amount: z.number() })
+
+    await persistSchemaIfNeeded({ store, vault: VAULT, collectionName: COLLECTION, validator: v1, dek })
+    const before = (await store.get(VAULT, '_schemas', COLLECTION))!._v
+
+    const result = await persistSchemaIfNeeded({ store, vault: VAULT, collectionName: COLLECTION, validator: v2, dek })
+    expect(result.written).toBe(true)
+    expect(result.skipped).toBe(false)
+
+    const after = (await store.get(VAULT, '_schemas', COLLECTION))!._v
+    expect(after).toBe(before + 1)
+  })
+
+  it('writes a stub envelope for non-Zod validators (kind=Unknown, jsonSchema=null)', async () => {
+    const fakeArktype = { '~standard': { version: 1, vendor: 'arktype', validate: () => ({}) } }
+    const result = await persistSchemaIfNeeded({
+      store, vault: VAULT, collectionName: COLLECTION,
+      validator: fakeArktype as unknown,
+      dek,
+    })
+    expect(result.written).toBe(true)
+    expect(result.envelope.kind).toBe('Unknown')
+    expect(result.envelope.jsonSchema).toBeNull()
+    expect(result.envelope.reason).toMatch(/derivation not yet supported/i)
+  })
+
+  it('subsequent call with the same non-Zod validator also skips on hash equality', async () => {
+    // Stub envelopes have hash=null, so the skip path falls back to: if the
+    // existing stored envelope has the same kind + null hash, skip.
+    const fake = { '~standard': { version: 1, vendor: 'valibot', validate: () => ({}) } }
+    await persistSchemaIfNeeded({ store, vault: VAULT, collectionName: COLLECTION, validator: fake, dek })
+    const before = (await store.get(VAULT, '_schemas', COLLECTION))!._v
+
+    const result = await persistSchemaIfNeeded({ store, vault: VAULT, collectionName: COLLECTION, validator: fake, dek })
+    expect(result.skipped).toBe(true)
+    const after = (await store.get(VAULT, '_schemas', COLLECTION))!._v
+    expect(after).toBe(before)
+  })
+})

--- a/packages/hub/__tests__/persisted-schemas/storage.test.ts
+++ b/packages/hub/__tests__/persisted-schemas/storage.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { generateDEK } from '../../src/crypto.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/types.js'
+import { ConflictError } from '../../src/errors.js'
+import {
+  SCHEMAS_COLLECTION,
+  loadPersistedSchema,
+  savePersistedSchema,
+} from '../../src/persisted-schemas/storage.js'
+import type { PersistedSchemaEnvelope } from '../../src/persisted-schemas/types.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll() { /* not needed here */ },
+  }
+}
+
+describe('persisted-schema storage', () => {
+  const VAULT = 'acme'
+  let store: NoydbStore
+  let dek: CryptoKey
+
+  beforeEach(async () => {
+    store = inlineMemory()
+    dek = await generateDEK()
+  })
+
+  it('reserved collection name is `_schemas`', () => {
+    expect(SCHEMAS_COLLECTION).toBe('_schemas')
+  })
+
+  it('returns undefined when no envelope has been saved', async () => {
+    const out = await loadPersistedSchema(store, VAULT, 'invoices', dek)
+    expect(out).toBeUndefined()
+  })
+
+  it('round-trips an envelope through encrypted storage', async () => {
+    const payload: PersistedSchemaEnvelope = {
+      _noydb_schema: 1,
+      kind: 'Zod',
+      jsonSchema: { type: 'object', properties: { id: { type: 'string' } } },
+      hash: 'a'.repeat(64),
+      derivedAt: '2026-05-22T14:31:42Z',
+    }
+    await savePersistedSchema(store, VAULT, 'invoices', dek, payload)
+    const loaded = await loadPersistedSchema(store, VAULT, 'invoices', dek)
+    expect(loaded).toEqual(payload)
+  })
+
+  it('stores ciphertext, not plaintext (envelope `_data` is not JSON-parseable as the payload)', async () => {
+    const payload: PersistedSchemaEnvelope = {
+      _noydb_schema: 1,
+      kind: 'Zod',
+      jsonSchema: { type: 'string' },
+      hash: 'b'.repeat(64),
+      derivedAt: '2026-05-22T14:31:42Z',
+    }
+    await savePersistedSchema(store, VAULT, 'invoices', dek, payload)
+    const raw = await store.get(VAULT, '_schemas', 'invoices')
+    expect(raw).not.toBeNull()
+    // _iv must be a non-empty base64 string (AES-GCM IV present)
+    expect(raw!._iv.length).toBeGreaterThan(0)
+    // _data must NOT parse as the original payload (i.e. it's ciphertext)
+    expect(() => {
+      const parsed = JSON.parse(raw!._data) as Record<string, unknown>
+      // ciphertext won't match — if it parses to an object with our shape, encryption is broken
+      if (parsed._noydb_schema === 1) throw new Error('payload stored in plaintext!')
+    }).toThrow()
+  })
+
+  it('bumps _v on rewrite (idempotent overwrite semantics)', async () => {
+    const env: PersistedSchemaEnvelope = {
+      _noydb_schema: 1, kind: 'Zod', jsonSchema: { type: 'string' },
+      hash: 'c'.repeat(64), derivedAt: '2026-05-22T14:31:42Z',
+    }
+    await savePersistedSchema(store, VAULT, 'invoices', dek, env)
+    const v1 = (await store.get(VAULT, '_schemas', 'invoices'))!._v
+    await savePersistedSchema(store, VAULT, 'invoices', dek, env)
+    const v2 = (await store.get(VAULT, '_schemas', 'invoices'))!._v
+    expect(v2).toBe(v1 + 1)
+  })
+
+  it('returns undefined for an envelope that fails to decrypt (wrong key)', async () => {
+    const env: PersistedSchemaEnvelope = {
+      _noydb_schema: 1, kind: 'Zod', jsonSchema: { type: 'string' },
+      hash: 'd'.repeat(64), derivedAt: '2026-05-22T14:31:42Z',
+    }
+    await savePersistedSchema(store, VAULT, 'invoices', dek, env)
+    const otherDek = await generateDEK()
+    const out = await loadPersistedSchema(store, VAULT, 'invoices', otherDek)
+    expect(out).toBeUndefined()
+  })
+})

--- a/packages/hub/__tests__/persisted-schemas/vault-integration.test.ts
+++ b/packages/hub/__tests__/persisted-schemas/vault-integration.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { z } from 'zod'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/types.js'
+import { ConflictError } from '../../src/errors.js'
+import { createNoydb } from '../../src/noydb.js'
+import type { Noydb } from '../../src/noydb.js'
+import { SCHEMAS_COLLECTION } from '../../src/persisted-schemas/storage.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) }
+    },
+  }
+}
+
+interface Invoice { id: string; amount: number }
+
+describe('persistJsonSchema option on vault.collection()', () => {
+  const COMP = 'acme'
+  let adapter: NoydbStore
+  let db: Noydb
+
+  beforeEach(async () => {
+    adapter = inlineMemory()
+    db = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+  })
+
+  it('does NOT write _schemas/<col> when persistJsonSchema is omitted (default)', async () => {
+    const InvoiceSchema = z.object({ id: z.string(), amount: z.number() })
+    const comp = await db.openVault(COMP)
+    comp.collection<Invoice>('invoices', { schema: InvoiceSchema })
+    await comp._drainPendingSchemaWrites()
+    const stored = await adapter.get(COMP, SCHEMAS_COLLECTION, 'invoices')
+    expect(stored).toBeNull()
+  })
+
+  it('writes _schemas/<col> encrypted envelope when persistJsonSchema: true with a Zod validator', async () => {
+    const InvoiceSchema = z.object({ id: z.string(), amount: z.number() })
+    const comp = await db.openVault(COMP)
+    comp.collection<Invoice>('invoices', { schema: InvoiceSchema, persistJsonSchema: true })
+    await comp._drainPendingSchemaWrites()
+
+    const stored = await adapter.get(COMP, SCHEMAS_COLLECTION, 'invoices')
+    expect(stored).not.toBeNull()
+    expect(stored!._iv.length).toBeGreaterThan(0)
+    expect(stored!._data.length).toBeGreaterThan(0)
+  })
+
+  it('reopening the vault with an unchanged schema does NOT bump _v (hash-skip)', async () => {
+    const InvoiceSchema = z.object({ id: z.string(), amount: z.number() })
+
+    let comp = await db.openVault(COMP)
+    comp.collection<Invoice>('invoices', { schema: InvoiceSchema, persistJsonSchema: true })
+    await comp._drainPendingSchemaWrites()
+    const v1 = (await adapter.get(COMP, SCHEMAS_COLLECTION, 'invoices'))!._v
+
+    // Re-open the same vault as a fresh session
+    const db2 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+    comp = await db2.openVault(COMP)
+    comp.collection<Invoice>('invoices', { schema: InvoiceSchema, persistJsonSchema: true })
+    await comp._drainPendingSchemaWrites()
+    const v2 = (await adapter.get(COMP, SCHEMAS_COLLECTION, 'invoices'))!._v
+
+    expect(v2).toBe(v1)
+  })
+
+  it('reopening with a changed schema DOES bump _v', async () => {
+    let comp = await db.openVault(COMP)
+    comp.collection<Invoice>('invoices', {
+      schema: z.object({ id: z.string(), amount: z.number() }),
+      persistJsonSchema: true,
+    })
+    await comp._drainPendingSchemaWrites()
+    const v1 = (await adapter.get(COMP, SCHEMAS_COLLECTION, 'invoices'))!._v
+
+    const db2 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+    comp = await db2.openVault(COMP)
+    comp.collection<Invoice>('invoices', {
+      schema: z.object({ id: z.string(), amount: z.number(), note: z.string() }), // shape changed
+      persistJsonSchema: true,
+    })
+    await comp._drainPendingSchemaWrites()
+    const v2 = (await adapter.get(COMP, SCHEMAS_COLLECTION, 'invoices'))!._v
+
+    expect(v2).toBe(v1 + 1)
+  })
+})

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -258,7 +258,16 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "esbuild": "^0.25.0",
-    "zod": "^3.23.0"
+    "zod": "^3.23.0",
+    "zod-to-json-schema": "^3.25.2"
+  },
+  "peerDependencies": {
+    "zod-to-json-schema": "^3.25.0"
+  },
+  "peerDependenciesMeta": {
+    "zod-to-json-schema": {
+      "optional": true
+    }
   },
   "keywords": [
     "noy-db",

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -265,6 +265,23 @@ export type {
 } from './schema.js'
 export { validateSchemaInput, validateSchemaOutput } from './schema.js'
 
+// Persisted JSON Schema — opt-in per-collection encrypted snapshot
+// of the developer's Zod (or other Standard Schema) validator. Powers
+// `noydb describe` audit output from a bundle alone.
+export type {
+  PersistedSchemaEnvelope,
+  PersistedSchemaKind,
+  PersistSchemaResult,
+} from './persisted-schemas/index.js'
+export {
+  SCHEMAS_COLLECTION,
+  derivePersistedSchema,
+  isZodSchema,
+  loadPersistedSchema,
+  savePersistedSchema,
+  persistSchemaIfNeeded,
+} from './persisted-schemas/index.js'
+
 // Time-machine queries — vault.at(ts) method lives on
 // Vault; these classes are the return types.
 export { VaultInstant, CollectionInstant } from './history/time-machine.js'

--- a/packages/hub/src/persisted-schemas/canonicalize.ts
+++ b/packages/hub/src/persisted-schemas/canonicalize.ts
@@ -1,0 +1,23 @@
+/**
+ * Deterministic JSON serializer: sorts object keys lexicographically at every
+ * depth so structurally-equivalent objects produce identical strings. Array
+ * order is preserved (arrays are semantically ordered).
+ *
+ * Used by {@link sha256Hex} to fingerprint a derived JSON Schema for
+ * hash-based skip on persisted-schema writes.
+ *
+ * @module
+ */
+
+export function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map(canonicalize).join(',') + ']'
+  }
+  const obj = value as Record<string, unknown>
+  const keys = Object.keys(obj).sort()
+  const parts = keys.map((k) => JSON.stringify(k) + ':' + canonicalize(obj[k]))
+  return '{' + parts.join(',') + '}'
+}

--- a/packages/hub/src/persisted-schemas/derive.ts
+++ b/packages/hub/src/persisted-schemas/derive.ts
@@ -1,0 +1,74 @@
+/**
+ * Derive a {@link PersistedSchemaEnvelope} from a Standard Schema v1
+ * validator. v0 supports Zod via `zod-to-json-schema` (optional peer-dep);
+ * other families write a stub envelope flagging the kind.
+ *
+ * @see docs/superpowers/specs/2026-05-22-schema-dump-design.md
+ *
+ * @module
+ */
+
+import { canonicalize } from './canonicalize.js'
+import { sha256Hex } from '../crypto.js'
+import type { PersistedSchemaEnvelope, PersistedSchemaKind } from './types.js'
+
+/**
+ * Heuristic Zod detection — Zod schemas carry a `_def.typeName` property
+ * starting with `Zod` (e.g. `ZodObject`, `ZodString`). This survives Zod's
+ * minor-version bumps because the typeName naming is stable across v3.
+ */
+export function isZodSchema(value: unknown): boolean {
+  if (value === null || typeof value !== 'object') return false
+  const def = (value as { _def?: { typeName?: unknown } })._def
+  if (!def || typeof def !== 'object') return false
+  return typeof def.typeName === 'string' && def.typeName.startsWith('Zod')
+}
+
+function detectKind(validator: unknown): PersistedSchemaKind {
+  if (isZodSchema(validator)) return 'Zod'
+  return 'Unknown'
+}
+
+/**
+ * Lazy-require `zod-to-json-schema`. Returns the converter, or throws a
+ * clear error if the peer-dep isn't installed.
+ */
+async function loadZodConverter(): Promise<(s: unknown) => object> {
+  try {
+    const mod = (await import('zod-to-json-schema')) as { zodToJsonSchema?: (s: unknown) => object }
+    if (!mod.zodToJsonSchema) {
+      throw new Error('zod-to-json-schema export missing')
+    }
+    return mod.zodToJsonSchema
+  } catch (err) {
+    throw new Error(
+      'persistJsonSchema requires the optional peer-dep `zod-to-json-schema`. '
+      + 'Install it: `pnpm add zod-to-json-schema` (or npm/yarn equivalent). '
+      + `Original error: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+}
+
+export async function derivePersistedSchema(
+  validator: unknown,
+): Promise<PersistedSchemaEnvelope> {
+  const kind = detectKind(validator)
+  const derivedAt = new Date().toISOString()
+
+  if (kind === 'Zod') {
+    const convert = await loadZodConverter()
+    const jsonSchema = convert(validator)
+    const canonical = canonicalize(jsonSchema)
+    const hash = await sha256Hex(new TextEncoder().encode(canonical))
+    return { _noydb_schema: 1, kind, jsonSchema, hash, derivedAt }
+  }
+
+  return {
+    _noydb_schema: 1,
+    kind,
+    jsonSchema: null,
+    hash: null,
+    reason: `derivation not yet supported for kind=${kind} (v0 supports Zod only)`,
+    derivedAt,
+  }
+}

--- a/packages/hub/src/persisted-schemas/index.ts
+++ b/packages/hub/src/persisted-schemas/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Persisted JSON Schema — opt-in encrypted per-collection schema snapshot.
+ *
+ * Enable per collection via `vault.collection(name, { schema, persistJsonSchema: true })`.
+ * The derived JSON Schema is written to a `_schemas/<collection>` envelope
+ * encrypted with the collection's DEK; the next opening of the vault
+ * re-derives, hashes, and skips the write when nothing has changed.
+ *
+ * v0 supports Zod via the optional `zod-to-json-schema` peer-dep. Other
+ * Standard Schema validators (Valibot, ArkType, Effect Schema) write a
+ * stub envelope flagging the kind without a JSON Schema body.
+ *
+ * @see docs/superpowers/specs/2026-05-22-schema-dump-design.md
+ *
+ * @module
+ */
+
+export type { PersistedSchemaEnvelope, PersistedSchemaKind } from './types.js'
+export { derivePersistedSchema, isZodSchema } from './derive.js'
+export {
+  SCHEMAS_COLLECTION,
+  loadPersistedSchema,
+  savePersistedSchema,
+} from './storage.js'
+export { persistSchemaIfNeeded } from './register.js'
+export type { PersistSchemaResult } from './register.js'

--- a/packages/hub/src/persisted-schemas/register.ts
+++ b/packages/hub/src/persisted-schemas/register.ts
@@ -1,0 +1,57 @@
+/**
+ * Orchestrate the derive → hash → skip-or-write cycle for a collection's
+ * persisted JSON Schema. Called by the Vault at collection-registration
+ * time when the developer opts in via `collection({ persistJsonSchema:
+ * true })`.
+ *
+ * Skip semantics:
+ *
+ *   - Zod validators: skip when the new hash equals the stored hash.
+ *   - Non-Zod (stub envelopes have hash=null): skip when the stored
+ *     envelope's `kind` matches the freshly-detected kind (since there's
+ *     no body to compare yet — a kind change is the only signal).
+ *
+ * @module
+ */
+
+import { derivePersistedSchema } from './derive.js'
+import { loadPersistedSchema, savePersistedSchema } from './storage.js'
+import type { NoydbStore } from '../types.js'
+import type { PersistedSchemaEnvelope } from './types.js'
+
+export interface PersistSchemaResult {
+  /** True when a fresh envelope was written to storage. */
+  readonly written: boolean
+  /** True when an existing envelope matched and the write was skipped. */
+  readonly skipped: boolean
+  /** The envelope that was either written or matched. */
+  readonly envelope: PersistedSchemaEnvelope
+}
+
+export async function persistSchemaIfNeeded(opts: {
+  readonly store: NoydbStore
+  readonly vault: string
+  readonly collectionName: string
+  readonly validator: unknown
+  readonly dek: CryptoKey
+}): Promise<PersistSchemaResult> {
+  const fresh = await derivePersistedSchema(opts.validator)
+  const stored = await loadPersistedSchema(opts.store, opts.vault, opts.collectionName, opts.dek)
+
+  if (stored && isEquivalent(stored, fresh)) {
+    return { written: false, skipped: true, envelope: stored }
+  }
+
+  await savePersistedSchema(opts.store, opts.vault, opts.collectionName, opts.dek, fresh)
+  return { written: true, skipped: false, envelope: fresh }
+}
+
+function isEquivalent(a: PersistedSchemaEnvelope, b: PersistedSchemaEnvelope): boolean {
+  if (a.kind !== b.kind) return false
+  // Zod path: real hashes — compare directly.
+  if (a.hash && b.hash) return a.hash === b.hash
+  // Stub path: both have hash=null. Kind equality is the only signal we have.
+  if (a.hash === null && b.hash === null) return true
+  // Mixed (one has a hash, the other doesn't) — treat as changed.
+  return false
+}

--- a/packages/hub/src/persisted-schemas/storage.ts
+++ b/packages/hub/src/persisted-schemas/storage.ts
@@ -1,0 +1,73 @@
+/**
+ * Read / write the per-collection persisted-schema envelope. Mirrors the
+ * standard noy-db record envelope shape and is **AES-GCM encrypted with
+ * the collection's DEK** — the schema body (field names, enum values,
+ * constraints) is sensitive metadata, so it gets the same encryption
+ * envelope as the records it describes.
+ *
+ * Storage layout:
+ *
+ *   <vault>/_schemas/<collection>   →   EncryptedEnvelope
+ *
+ * The DEK passed to {@link savePersistedSchema} / {@link loadPersistedSchema}
+ * is the same key the collection uses for its records.
+ *
+ * @module
+ */
+
+import { encrypt, decrypt } from '../crypto.js'
+import { NOYDB_FORMAT_VERSION } from '../types.js'
+import type { NoydbStore, EncryptedEnvelope } from '../types.js'
+import type { PersistedSchemaEnvelope } from './types.js'
+
+/** Reserved collection name where persisted schemas live. */
+export const SCHEMAS_COLLECTION = '_schemas' as const
+
+/**
+ * Read and decrypt the persisted-schema envelope for one collection.
+ * Returns `undefined` when no envelope has been written or when decryption
+ * fails (e.g. wrong DEK passed). Tolerates corrupted records — JSON parse
+ * failures surface as `undefined`, mirroring `_meta/handle`'s contract.
+ */
+export async function loadPersistedSchema(
+  store: NoydbStore,
+  vault: string,
+  collection: string,
+  dek: CryptoKey,
+): Promise<PersistedSchemaEnvelope | undefined> {
+  const envelope = await store.get(vault, SCHEMAS_COLLECTION, collection)
+  if (!envelope) return undefined
+  try {
+    const plaintext = await decrypt(envelope._iv, envelope._data, dek)
+    const parsed = JSON.parse(plaintext) as PersistedSchemaEnvelope
+    if (parsed._noydb_schema !== 1) return undefined
+    return parsed
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Encrypt and persist a schema envelope for one collection. Always
+ * overwrites any prior write (callers gate on hash equality before calling
+ * to avoid no-op writes).
+ */
+export async function savePersistedSchema(
+  store: NoydbStore,
+  vault: string,
+  collection: string,
+  dek: CryptoKey,
+  payload: PersistedSchemaEnvelope,
+): Promise<void> {
+  const json = JSON.stringify(payload)
+  const { iv, data } = await encrypt(json, dek)
+  const prior = await store.get(vault, SCHEMAS_COLLECTION, collection)
+  const env: EncryptedEnvelope = {
+    _noydb: NOYDB_FORMAT_VERSION,
+    _v: (prior?._v ?? 0) + 1,
+    _ts: new Date().toISOString(),
+    _iv: iv,
+    _data: data,
+  }
+  await store.put(vault, SCHEMAS_COLLECTION, collection, env)
+}

--- a/packages/hub/src/persisted-schemas/types.ts
+++ b/packages/hub/src/persisted-schemas/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Persisted-schema envelope shape.
+ *
+ * Stored encrypted under `_schemas/<collection>` with the same DEK as the
+ * collection's records. Auditors who can unlock the collection's data can
+ * also read its schema; nothing more.
+ *
+ * @see docs/superpowers/specs/2026-05-22-schema-dump-design.md
+ *
+ * @module
+ */
+
+/** Family of Standard Schema v1 validator the persisted snapshot was derived from. */
+export type PersistedSchemaKind = 'Zod' | 'Valibot' | 'ArkType' | 'Effect' | 'Unknown'
+
+/**
+ * Plaintext payload encrypted into the `_data` field of the
+ * `_schemas/<collection>` envelope. The wrapper `EncryptedEnvelope` adds
+ * `_noydb`, `_v`, `_ts`, `_iv`, `_data` per the standard noy-db record
+ * format.
+ */
+export interface PersistedSchemaEnvelope {
+  readonly _noydb_schema: 1
+  /** Detected validator family. */
+  readonly kind: PersistedSchemaKind
+  /**
+   * JSON Schema (Draft 2020-12) derived from the validator. Null when
+   * derivation isn't yet supported for `kind`; in that case `reason` is
+   * populated.
+   */
+  readonly jsonSchema: object | null
+  /** SHA-256 (hex) of the canonicalised JSON Schema, or null when unavailable. */
+  readonly hash: string | null
+  /** Human-readable reason when `jsonSchema` is null. */
+  readonly reason?: string
+  /** ISO-8601 timestamp of the most recent derivation write. */
+  readonly derivedAt: string
+}

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -104,6 +104,7 @@ import {
   type MagicLinkGrantRecord,
 } from './team/magic-link-grant.js'
 import { UserApi } from './meta/user-envelope/api.js'
+import { persistSchemaIfNeeded } from './persisted-schemas/register.js'
 import { USER_ENVELOPE_COLLECTION } from './meta/user-envelope/types.js'
 
 /** A vault (tenant namespace) containing collections. */
@@ -233,6 +234,17 @@ export class Vault {
    * docstring.
    */
   private ledgerStore: LedgerStore | null = null
+
+  /**
+   * Background writes for persisted-schema envelopes (#schema-dump v0
+   * slice 1). One promise per `collection({ persistJsonSchema: true })`
+   * registration that actually fired a derive call. Fire-and-forget
+   * from the collection factory; tests await
+   * {@link _drainPendingSchemaWrites} before asserting on storage.
+   * Production code does not need to drain — the writes are
+   * idempotent fingerprints, not correctness invariants.
+   */
+  private _pendingSchemaWrites: Promise<void>[] = []
 
   /**
    * Per-vault foreign-key reference registry. Collections
@@ -509,6 +521,19 @@ export class Vault {
     tiers?: readonly number[]
     /**  — how lower-tier reads see above-tier records. */
     tierMode?: TierMode
+    /**
+     * Opt-in persisted JSON Schema. When `true` AND a Zod `schema` is
+     * provided, hub derives a JSON Schema via `zod-to-json-schema`
+     * (optional peer-dep) and writes an encrypted snapshot to
+     * `_schemas/<collectionName>`. Re-runs on every open; hash-skip
+     * avoids write churn when the schema is unchanged.
+     *
+     * Default: `false`. Non-Zod Standard Schema validators receive a
+     * stub envelope flagging the kind without a JSON Schema body.
+     *
+     * @see docs/superpowers/specs/2026-05-22-schema-dump-design.md
+     */
+    persistJsonSchema?: boolean
   }): Collection<T> {
     // Overlay intercept (#154). When the requested collection name
     // matches a registered `withOverlayedView`, return the virtual
@@ -668,8 +693,48 @@ export class Vault {
       }
       coll = new Collection<T>(collOpts)
       this.collectionCache.set(collectionName, coll)
+
+      // Fire-and-forget persisted-schema write when opted in. Pushed
+      // onto _pendingSchemaWrites so tests can drain before asserting;
+      // production code ignores it (the writes are idempotent fingerprints).
+      if (options?.persistJsonSchema === true && options.schema !== undefined) {
+        const validator: unknown = options.schema
+        const work = (async () => {
+          try {
+            const dek = await this.getDEK(collectionName)
+            await persistSchemaIfNeeded({
+              store: this.adapter,
+              vault: this.name,
+              collectionName,
+              validator,
+              dek,
+            })
+          } catch (err) {
+            // Schema persistence is a fingerprint, not a correctness
+            // invariant — log and continue. Production callers can
+            // still detect failures via _drainPendingSchemaWrites.
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[noy-db] persisted-schema write failed for "${collectionName}": `
+              + (err instanceof Error ? err.message : String(err)),
+            )
+          }
+        })()
+        this._pendingSchemaWrites.push(work)
+      }
     }
     return coll as Collection<T>
+  }
+
+  /**
+   * Await all background persisted-schema writes triggered by
+   * `collection({ persistJsonSchema: true })` calls on this vault.
+   * Used in tests; production code does not need to call this.
+   */
+  async _drainPendingSchemaWrites(): Promise<void> {
+    const pending = this._pendingSchemaWrites
+    this._pendingSchemaWrites = []
+    await Promise.allSettled(pending)
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       zod:
         specifier: ^3.23.0
         version: 3.25.76
+      zod-to-json-schema:
+        specifier: ^3.25.2
+        version: 3.25.2(zod@3.25.76)
 
   packages/in-ai:
     devDependencies:
@@ -5636,6 +5639,7 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
+    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   light-my-request@6.6.0:
@@ -7841,6 +7845,11 @@ packages:
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod@3.22.3:
     resolution: {integrity: sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==}
@@ -15639,6 +15648,10 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.22.3: {}
 


### PR DESCRIPTION
## Summary

Adds `collection({ persistJsonSchema: true })` — an opt-in per-collection feature that derives a JSON Schema snapshot from a Zod validator at registration time and writes it to a new reserved `_schemas/<collection>` envelope, **AES-GCM encrypted with the collection's DEK**. Designed to power the upcoming `noydb describe` CLI (slice 3) without requiring the consumer to ship their app code alongside the bundle for an audit.

Slice 1 of three. Full design: [`docs/superpowers/specs/2026-05-22-schema-dump-design.md`](https://github.com/vLannaAi/noy-db/blob/feat/persisted-json-schema/docs/superpowers/specs/2026-05-22-schema-dump-design.md).

## Mechanics

- **Derivation:** Zod via `zod-to-json-schema` (declared as an **optional peer-dep**, lazy-required at runtime). Absent → clear install-hint error. Non-Zod Standard Schema validators write a stub envelope `{ kind: 'Unknown', jsonSchema: null, reason }`.
- **Encryption:** same envelope shape as records (`_iv`, `_data` ciphertext). Schema body is sensitive metadata (field names, enum values, constraints) — same disclosure surface as the data, no second tier.
- **Hash-based skip:** every `collection()` registration recomputes the canonicalised SHA-256. Match → skip write. No `_v` churn on no-op re-derive.
- **Fire-and-forget plumbing:** `vault.collection()` stays synchronous; the persist runs in the background and is tracked via `_pendingSchemaWrites: Promise<void>[]`. Tests await `_drainPendingSchemaWrites()` before asserting on storage; production code can ignore the promise (the write is a fingerprint, not a correctness invariant).

## Public surface

```ts
import { z } from 'zod'

const Invoice = z.object({ id: z.string(), amount: z.number() })

const comp = await db.openVault('acme')
comp.collection<Invoice>('invoices', {
  schema: Invoice,
  persistJsonSchema: true,   // ← new
})
// → writes encrypted _schemas/invoices envelope on first open
//   subsequent opens with same Zod shape skip the write
```

Also re-exported from `@noy-db/hub`:
- `derivePersistedSchema`, `isZodSchema`
- `loadPersistedSchema`, `savePersistedSchema`, `SCHEMAS_COLLECTION`
- `persistSchemaIfNeeded`
- Types: `PersistedSchemaEnvelope`, `PersistedSchemaKind`, `PersistSchemaResult`

## Tests

+25 tests across 5 new modules under `packages/hub/__tests__/persisted-schemas/`:

- `canonicalize.test.ts` (4) — deterministic key ordering for hash input
- `derive.test.ts` (6) — Zod detection, derivation, hash determinism, stub for non-Zod
- `storage.test.ts` (6) — encrypted envelope round-trip, ciphertext verification, `_v` bump on rewrite, wrong-DEK returns undefined
- `registration.test.ts` (5) — hash-based skip semantics, fresh-write on change, stub-envelope skip
- `vault-integration.test.ts` (4) — end-to-end via `createNoydb` → `openVault` → `collection({ persistJsonSchema })`

Full hub suite: 1626 / 1627 passing (+1 pre-existing `it.todo` carried from pre.14). Typecheck clean. Lint clean (one unrelated pre-existing error in `derive.ts` fixed; remaining warnings predate this slice).

## What this enables — and what it does NOT change

- **Enables:** slice 2 (hub introspection primitive) and slice 3 (`noydb describe` CLI) can surface field-level schema intent from a bundle alone, without requiring the consumer to share their TypeScript source.
- **No behavioural change** to record-level validation. Zod still runs on `put` / read; the persisted JSON Schema is a separate snapshot.
- **No effect on existing collections.** `persistJsonSchema` defaults to `false`; collections that don't opt in behave identically.
- **`vault.exportJSON()`'s `schema: null` slot** is unchanged in this slice — the export integration is part of slice 2.

## Test plan

- [x] `pnpm vitest run --filter @noy-db/hub` — all hub tests pass
- [x] `pnpm turbo typecheck --filter @noy-db/hub` — no type errors
- [x] `pnpm turbo lint --filter @noy-db/hub` — no errors (warnings predate)
- [x] `pnpm turbo build --filter @noy-db/hub` — builds clean
- [x] `node scripts/check-architecture.mjs` — invariants OK
- [x] `node scripts/validate-features.mjs` — features.yaml validates