### PR TITLE
feat(hub): vault.dumpSchema() introspection primitive (slice 2)

### DIFF
--- a/packages/hub/__tests__/introspection/dump-schema-stats.test.ts
+++ b/packages/hub/__tests__/introspection/dump-schema-stats.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/types.js'
+import { ConflictError } from '../../src/errors.js'
+import { createNoydb } from '../../src/noydb.js'
+import type { Noydb } from '../../src/noydb.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) }
+    },
+  }
+}
+
+interface Invoice { id: string; amount: number }
+
+describe('vault.dumpSchema({ withStats: true })', () => {
+  const COMP = 'acme'
+  let adapter: NoydbStore
+  let db: Noydb
+
+  beforeEach(async () => {
+    adapter = inlineMemory()
+    db = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+  })
+
+  it('omits stats when withStats is not set', async () => {
+    const comp = await db.openVault(COMP)
+    comp.collection<Invoice>('invoices')
+    await comp.collection<Invoice>('invoices').put('i1', { id: 'i1', amount: 100 })
+    const snap = await comp.dumpSchema()
+    expect(snap.collections.invoices?.stats).toBeUndefined()
+    expect(snap.internal).toBeUndefined()
+  })
+
+  it('computes records + bytes + bytesAvg/Min/Max + oldest/newest per collection', async () => {
+    const comp = await db.openVault(COMP)
+    const invoices = comp.collection<Invoice>('invoices')
+    await invoices.put('i1', { id: 'i1', amount: 100 })
+    await invoices.put('i2', { id: 'i2', amount: 200 })
+    await invoices.put('i3', { id: 'i3', amount: 300 })
+
+    const snap = await comp.dumpSchema({ withStats: true })
+    const stats = snap.collections.invoices?.stats
+    expect(stats).toBeDefined()
+    expect(stats!.records).toBe(3)
+    expect(stats!.bytes).toBeGreaterThan(0)
+    expect(stats!.bytesAvg).toBeGreaterThan(0)
+    expect(stats!.bytesMin).toBeLessThanOrEqual(stats!.bytesAvg)
+    expect(stats!.bytesMax).toBeGreaterThanOrEqual(stats!.bytesAvg)
+    expect(stats!.oldest).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    expect(stats!.newest).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    expect(stats!.oldest <= stats!.newest).toBe(true)
+  })
+
+  it('zero-record collection emits stats with all zeros + empty timestamps', async () => {
+    const comp = await db.openVault(COMP)
+    comp.collection<Invoice>('invoices')
+    const snap = await comp.dumpSchema({ withStats: true })
+    const stats = snap.collections.invoices?.stats
+    expect(stats).toEqual({
+      records: 0, bytes: 0, bytesAvg: 0, bytesMin: 0, bytesMax: 0,
+      oldest: '', newest: '',
+    })
+  })
+
+  it('reports internal collections under `internal:` block when withStats=true', async () => {
+    const comp = await db.openVault(COMP)
+    const invoices = comp.collection<Invoice>('invoices')
+    await invoices.put('i1', { id: 'i1', amount: 100 })
+
+    const snap = await comp.dumpSchema({ withStats: true })
+    expect(snap.internal).toBeDefined()
+    // _keyring always populated for any vault opened with credentials
+    expect(snap.internal!._keyring).toBeDefined()
+    expect(snap.internal!._keyring!.records).toBeGreaterThan(0)
+    expect(snap.internal!._keyring!.bytes).toBeGreaterThan(0)
+  })
+})

--- a/packages/hub/__tests__/introspection/dump-schema-views.test.ts
+++ b/packages/hub/__tests__/introspection/dump-schema-views.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/types.js'
+import { ConflictError } from '../../src/errors.js'
+import { createNoydb, withMaterializedView, sum } from '../../src/index.js'
+import { withAggregate } from '../../src/aggregate/index.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) }
+    },
+  }
+}
+
+interface Invoice extends Record<string, unknown> { id: string; client_id: string; amount: number }
+
+describe('vault.dumpSchema() — materialized views', () => {
+  it('emits an empty materializedViews map when none are registered', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw' })
+    const vault = await db.openVault('acme')
+    const snap = await vault.dumpSchema()
+    expect(snap.materializedViews).toEqual({})
+    expect(snap.subsystems.materializedViews).toBe(false)
+  })
+
+  it('describes a registered query-form MV with sources + refresh', async () => {
+    const totals = withMaterializedView<{ client_id: string; total: number }>({
+      name: 'invoice-totals',
+      sources: ['invoices'],
+      query: (db) => db.collection<Invoice>('invoices').query()
+        .groupBy('client_id').aggregate({ total: sum('amount') }),
+      rowKey: (r) => r.client_id,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: inlineMemory(),
+      user: 'alice',
+      secret: 'pw',
+      aggregateStrategy: withAggregate(),
+      materializedViewStrategies: [totals],
+    })
+    const vault = await db.openVault('acme')
+    await vault.collection<Invoice>('invoices').put('i1', { id: 'i1', client_id: 'c1', amount: 100 })
+
+    const snap = await vault.dumpSchema()
+    expect(snap.subsystems.materializedViews).toBe(true)
+    const mv = snap.materializedViews['invoice-totals']
+    expect(mv).toBeDefined()
+    expect(mv!.sources).toContain('invoices')
+    expect(mv!.refresh).toBe('eager')
+  })
+
+  it('describes a registered UNION MV with sources, groupBy, aggregate', async () => {
+    const monthlyVat = withMaterializedView<{ client_id: string; period: string; vat: number }>({
+      name: 'monthly-vat',
+      unionSources: [
+        { collection: 'receipts', map: (r: Record<string, unknown>) => ({
+          client_id: r.client_id as string, period: r.period as string, vat: r.vat as number,
+        }) },
+        { collection: 'credit-notes', map: (r: Record<string, unknown>) => ({
+          client_id: r.client_id as string, period: r.period as string, vat: -(r.vat as number),
+        }) },
+      ],
+      groupBy: ['client_id', 'period'],
+      aggregate: { vat: sum('vat') },
+      rowKey: (r) => `${r.client_id}|${r.period}`,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: inlineMemory(),
+      user: 'alice',
+      secret: 'pw',
+      aggregateStrategy: withAggregate(),
+      materializedViewStrategies: [monthlyVat],
+    })
+    const vault = await db.openVault('acme')
+
+    const snap = await vault.dumpSchema()
+    const mv = snap.materializedViews['monthly-vat']
+    expect(mv).toBeDefined()
+    expect(mv!.sources.sort()).toEqual(['credit-notes', 'receipts'])
+    expect(mv!.groupBy).toEqual(['client_id', 'period'])
+    expect(mv!.aggregate).toBeDefined()
+    expect(typeof mv!.aggregate!.vat).toBe('string')
+  })
+})

--- a/packages/hub/__tests__/introspection/dump-schema.test.ts
+++ b/packages/hub/__tests__/introspection/dump-schema.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { z } from 'zod'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/types.js'
+import { ConflictError } from '../../src/errors.js'
+import { createNoydb } from '../../src/noydb.js'
+import type { Noydb } from '../../src/noydb.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) }
+    },
+  }
+}
+
+interface Invoice { id: string; amount: number; status: string }
+interface Client { id: string; name: string }
+
+describe('vault.dumpSchema() — baseline', () => {
+  const COMP = 'acme'
+  let adapter: NoydbStore
+  let db: Noydb
+
+  beforeEach(async () => {
+    adapter = inlineMemory()
+    db = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+  })
+
+  it('returns _noydb_snapshot version + vault name + emittedAt', async () => {
+    const comp = await db.openVault(COMP)
+    const snap = await comp.dumpSchema()
+    expect(snap._noydb_snapshot).toBe(1)
+    expect(snap.vault).toBe(COMP)
+    expect(snap.emittedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+  })
+
+  it('lists user collections (without internals) alphabetically', async () => {
+    const comp = await db.openVault(COMP)
+    comp.collection<Invoice>('invoices')
+    comp.collection<Client>('clients')
+    await comp.collection<Invoice>('invoices').put('i1', { id: 'i1', amount: 100, status: 'draft' })
+    await comp.collection<Client>('clients').put('c1', { id: 'c1', name: 'Acme' })
+
+    const snap = await comp.dumpSchema()
+    expect(Object.keys(snap.collections)).toEqual(['clients', 'invoices'])
+    // internals never appear at top level
+    expect(snap.collections).not.toHaveProperty('_keyring')
+    expect(snap.collections).not.toHaveProperty('_meta')
+    expect(snap.collections).not.toHaveProperty('_schemas')
+  })
+
+  it('emits a field block sourced from the persisted JSON Schema (Route B)', async () => {
+    const Invoice = z.object({
+      id: z.string(),
+      amount: z.number().positive(),
+      status: z.enum(['draft', 'paid']),
+    })
+    const comp = await db.openVault(COMP)
+    comp.collection<Invoice>('invoices', { schema: Invoice, persistJsonSchema: true })
+    await comp.collection<Invoice>('invoices').put('i1', { id: 'i1', amount: 100, status: 'draft' })
+    await comp._drainPendingSchemaWrites()
+
+    const snap = await comp.dumpSchema()
+    const inv = snap.collections.invoices
+    expect(inv).toBeDefined()
+    expect(inv!.validator).toEqual({ kind: 'Zod', source: 'persisted' })
+    expect(Object.keys(inv!.fields).sort()).toEqual(['amount', 'id', 'status'])
+    expect(inv!.fields.id?.source).toBe('persisted')
+    expect(inv!.fields.amount?.type).toBe('number')
+  })
+
+  it('emits a field block sourced from the LIVE validator when no persisted snapshot exists', async () => {
+    const Invoice = z.object({ id: z.string(), amount: z.number() })
+    const comp = await db.openVault(COMP)
+    comp.collection<Invoice>('invoices', { schema: Invoice }) // no persistJsonSchema
+    await comp.collection<Invoice>('invoices').put('i1', { id: 'i1', amount: 100, status: 'draft' })
+
+    const snap = await comp.dumpSchema()
+    const inv = snap.collections.invoices
+    expect(inv!.validator).toEqual({ kind: 'Zod', source: 'live-validator' })
+    expect(inv!.fields.id?.source).toBe('live-validator')
+    expect(inv!.fields.amount?.type).toBe('number')
+  })
+
+  it('marks fields source=unknown when no schema is available and sampling is disabled', async () => {
+    const comp = await db.openVault(COMP)
+    comp.collection<Invoice>('invoices')
+    await comp.collection<Invoice>('invoices').put('i1', { id: 'i1', amount: 100, status: 'draft' })
+
+    const snap = await comp.dumpSchema({ sampleSize: 0 })
+    const inv = snap.collections.invoices
+    expect(inv!.validator).toBeUndefined()
+    expect(inv!.fields).toEqual({})
+  })
+
+  it('reports the subsystems opt-in matrix (presence of registries)', async () => {
+    const comp = await db.openVault(COMP)
+    const snap = await comp.dumpSchema()
+    expect(snap.subsystems).toEqual(expect.objectContaining({
+      guards: expect.any(Boolean),
+      derivations: expect.any(Boolean),
+      materializedViews: expect.any(Boolean),
+      overlayViews: expect.any(Boolean),
+    }))
+  })
+})

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -265,6 +265,22 @@ export type {
 } from './schema.js'
 export { validateSchemaInput, validateSchemaOutput } from './schema.js'
 
+// Introspection — vault.dumpSchema() returns a structured snapshot.
+// The CLI `noydb describe` command consumes this; programmatic callers
+// can use it directly from app code (admin pages, audit tooling).
+export type {
+  VaultSchemaSnapshot,
+  DumpSchemaOptions,
+  CollectionDescriptor,
+  CollectionStats,
+  FieldDescriptor,
+  FieldSource,
+  MaterializedViewDescriptor,
+  OverlayViewDescriptor,
+  DerivationDescriptor,
+  InternalCollectionStats,
+} from './introspection/index.js'
+
 // Persisted JSON Schema — opt-in per-collection encrypted snapshot
 // of the developer's Zod (or other Standard Schema) validator. Powers
 // `noydb describe` audit output from a bundle alone.

--- a/packages/hub/src/introspection/fields.ts
+++ b/packages/hub/src/introspection/fields.ts
@@ -1,0 +1,78 @@
+/**
+ * Map a JSON Schema (Draft 2020-12 produced by `zod-to-json-schema`) into
+ * the {@link FieldDescriptor} map consumed by {@link VaultSchemaSnapshot}.
+ *
+ * Used by both the persisted-schema path (decrypted envelope body) and the
+ * live-validator path (in-process derivation).
+ *
+ * @module
+ */
+
+import type { FieldDescriptor, FieldSource } from './types.js'
+
+interface JsonSchemaShape {
+  type?: string | string[]
+  properties?: Record<string, JsonSchemaShape>
+  required?: string[]
+  enum?: unknown[]
+  minLength?: number
+  maxLength?: number
+  pattern?: string
+  minimum?: number
+  maximum?: number
+  exclusiveMinimum?: number
+  exclusiveMaximum?: number
+  format?: string
+  items?: JsonSchemaShape
+}
+
+function jsonSchemaType(node: JsonSchemaShape): string {
+  if (Array.isArray(node.type)) {
+    const non = node.type.filter((t) => t !== 'null')
+    return non[0] ?? 'opaque'
+  }
+  if (node.enum && Array.isArray(node.enum)) return 'enum'
+  if (typeof node.type === 'string') return node.type
+  return 'opaque'
+}
+
+function constraintsFor(node: JsonSchemaShape): Record<string, unknown> | undefined {
+  const out: Record<string, unknown> = {}
+  if (node.enum) out.values = node.enum
+  if (node.minLength !== undefined) out.minLength = node.minLength
+  if (node.maxLength !== undefined) out.maxLength = node.maxLength
+  if (node.pattern !== undefined) out.pattern = node.pattern
+  if (node.format !== undefined) out.format = node.format
+  if (node.minimum !== undefined) out.minimum = node.minimum
+  if (node.maximum !== undefined) out.maximum = node.maximum
+  if (node.exclusiveMinimum !== undefined) out.gt = node.exclusiveMinimum
+  if (node.exclusiveMaximum !== undefined) out.lt = node.exclusiveMaximum
+  return Object.keys(out).length === 0 ? undefined : out
+}
+
+export function jsonSchemaToFields(
+  jsonSchema: unknown,
+  source: FieldSource,
+  refs?: Record<string, { target: string; mode: string }>,
+): Record<string, FieldDescriptor> {
+  if (!jsonSchema || typeof jsonSchema !== 'object') return {}
+  const root = jsonSchema as JsonSchemaShape
+  if (!root.properties || typeof root.properties !== 'object') return {}
+
+  const required = new Set(Array.isArray(root.required) ? root.required : [])
+  const out: Record<string, FieldDescriptor> = {}
+
+  for (const [name, node] of Object.entries(root.properties)) {
+    const descriptor: FieldDescriptor = {
+      type: jsonSchemaType(node),
+      source,
+      ...(required.has(name) ? {} : { optional: true }),
+      ...(refs?.[name] ? { references: `${refs[name].target}.id` } : {}),
+    }
+    const constraints = constraintsFor(node)
+    if (constraints) (descriptor as { constraints?: Record<string, unknown> }).constraints = constraints
+    out[name] = descriptor
+  }
+
+  return out
+}

--- a/packages/hub/src/introspection/index.ts
+++ b/packages/hub/src/introspection/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Introspection — `Vault.dumpSchema()` produces a structured
+ * {@link VaultSchemaSnapshot} describing the vault's shape and (optional)
+ * stats. Consumed by `noydb describe` for human-readable audit output.
+ *
+ * @see docs/superpowers/specs/2026-05-22-schema-dump-design.md
+ *
+ * @module
+ */
+
+export type {
+  VaultSchemaSnapshot,
+  DumpSchemaOptions,
+  CollectionDescriptor,
+  CollectionStats,
+  FieldDescriptor,
+  FieldSource,
+  MaterializedViewDescriptor,
+  OverlayViewDescriptor,
+  DerivationDescriptor,
+  InternalCollectionStats,
+} from './types.js'
+export { dumpVaultSchema } from './walk.js'
+export { jsonSchemaToFields } from './fields.js'

--- a/packages/hub/src/introspection/types.ts
+++ b/packages/hub/src/introspection/types.ts
@@ -1,0 +1,94 @@
+/**
+ * Types for {@link VaultSchemaSnapshot} — the structured object returned
+ * by `vault.dumpSchema()`. Consumed by the upcoming `noydb describe`
+ * CLI to emit human-readable YAML/JSON audit output.
+ *
+ * @see docs/superpowers/specs/2026-05-22-schema-dump-design.md
+ *
+ * @module
+ */
+
+import type { PersistedSchemaKind } from '../persisted-schemas/types.js'
+
+/** Where the field-level info in the snapshot came from. */
+export type FieldSource = 'persisted' | 'live-validator' | 'sampled' | 'unknown'
+
+export interface FieldDescriptor {
+  /** Inferred type tag: 'string' | 'number' | 'boolean' | 'enum' | 'object' | 'array' | 'null' | 'opaque'. */
+  readonly type: string
+  /** Where this field info was sourced from. */
+  readonly source: FieldSource
+  /** Optional constraints — minLength, maxLength, enum values, gt, etc. */
+  readonly constraints?: Record<string, unknown>
+  /** True when the schema marks this field optional. */
+  readonly optional?: boolean
+  /** Foreign-key target as `<collection>.<field>` when declared. */
+  readonly references?: string
+}
+
+export interface CollectionStats {
+  readonly records: number
+  readonly bytes: number
+  readonly bytesAvg: number
+  readonly bytesMin: number
+  readonly bytesMax: number
+  /** ISO-8601 from min(_ts) across envelopes. Empty string when no records. */
+  readonly oldest: string
+  /** ISO-8601 from max(_ts) across envelopes. Empty string when no records. */
+  readonly newest: string
+}
+
+export interface CollectionDescriptor {
+  readonly fields: Record<string, FieldDescriptor>
+  readonly indexes: ReadonlyArray<{ readonly fields: ReadonlyArray<string>; readonly unique?: boolean }>
+  readonly refs: Record<string, { readonly target: string; readonly mode: 'strict' | 'warn' | 'cascade' }>
+  readonly validator?: {
+    readonly kind: PersistedSchemaKind
+    readonly source: 'persisted' | 'live-validator'
+  }
+  readonly stats?: CollectionStats
+}
+
+export interface MaterializedViewDescriptor {
+  readonly sources: ReadonlyArray<string>
+  readonly groupBy?: ReadonlyArray<string>
+  readonly aggregate?: Record<string, string>
+  readonly refresh: string
+  readonly stats?: CollectionStats
+}
+
+export interface OverlayViewDescriptor {
+  readonly base: string
+  readonly overlay: string
+}
+
+export interface DerivationDescriptor {
+  readonly source: string
+  readonly outputs: ReadonlyArray<string>
+}
+
+export interface InternalCollectionStats {
+  readonly records: number
+  readonly bytes: number
+}
+
+export interface VaultSchemaSnapshot {
+  readonly _noydb_snapshot: 1
+  readonly vault: string
+  readonly emittedAt: string
+  readonly subsystems: Record<string, boolean>
+  readonly aclRoles?: ReadonlyArray<string>
+  readonly collections: Record<string, CollectionDescriptor>
+  readonly materializedViews: Record<string, MaterializedViewDescriptor>
+  readonly overlayViews: Record<string, OverlayViewDescriptor>
+  readonly derivations: Record<string, DerivationDescriptor>
+  /** Only present when `dumpSchema({ withStats: true })` was called. */
+  readonly internal?: Record<string, InternalCollectionStats>
+}
+
+export interface DumpSchemaOptions {
+  /** When true, walk every collection's envelopes to compute counters. Default `false`. */
+  readonly withStats?: boolean
+  /** Sample N records per collection lacking a persisted/live schema. Default 50. `0` disables sampling. */
+  readonly sampleSize?: number
+}

--- a/packages/hub/src/introspection/walk.ts
+++ b/packages/hub/src/introspection/walk.ts
@@ -1,0 +1,304 @@
+/**
+ * Orchestrate the structural walk of a Vault, producing a
+ * {@link VaultSchemaSnapshot}. Called from `Vault.dumpSchema()`.
+ *
+ * @module
+ */
+
+import { derivePersistedSchema } from '../persisted-schemas/derive.js'
+import { loadPersistedSchema } from '../persisted-schemas/storage.js'
+import { jsonSchemaToFields } from './fields.js'
+import type {
+  CollectionDescriptor,
+  CollectionStats,
+  DumpSchemaOptions,
+  FieldDescriptor,
+  InternalCollectionStats,
+  MaterializedViewDescriptor,
+  OverlayViewDescriptor,
+  DerivationDescriptor,
+  VaultSchemaSnapshot,
+} from './types.js'
+import type { Collection } from '../collection.js'
+import type { NoydbStore } from '../types.js'
+import type { RefRegistry } from '../refs.js'
+
+/**
+ * The minimal slice of Vault internal state the walker needs.
+ * Exposed via `vault._introspectState()` to keep the public Vault
+ * surface narrow.
+ *
+ * @internal
+ */
+export interface VaultIntrospectState {
+  readonly name: string
+  readonly adapter: NoydbStore
+  readonly collectionCache: Map<string, Collection<unknown>>
+  readonly refRegistry: RefRegistry
+  readonly getDEK: (collectionName: string) => Promise<CryptoKey>
+  readonly subsystems: Record<string, boolean>
+  // Typed loosely on purpose — these are private subsystem registries
+  // accessed only for "is anything registered" enumeration.
+  readonly mvRegistry: unknown
+  readonly overlayRegistry: unknown
+  readonly derivationRegistry: unknown
+}
+
+const INTERNAL_PREFIX = '_'
+
+/** Reserved internal collections always present in any real vault. */
+const KNOWN_INTERNAL_NAMES = ['_keyring', '_ledger', '_meta', '_schemas', '_deltas']
+
+export async function dumpVaultSchema(
+  vault: { _introspectState(): VaultIntrospectState },
+  opts: DumpSchemaOptions,
+): Promise<VaultSchemaSnapshot> {
+  const state = vault._introspectState()
+  const sampleSize = opts.sampleSize ?? 50
+  const withStats = opts.withStats === true
+
+  // 1. User-facing collections — alphabetical for diff stability
+  const cacheNames = [...state.collectionCache.keys()]
+  const storageNames = (await safeListAllCollections(state.adapter, state.name))
+    .filter((n) => !n.startsWith(INTERNAL_PREFIX))
+  const allNames = Array.from(new Set([...cacheNames, ...storageNames])).sort()
+
+  const collections: Record<string, CollectionDescriptor> = {}
+  for (const name of allNames) {
+    collections[name] = await describeCollection(state, name, sampleSize, withStats)
+  }
+
+  // 2. Materialized views (placeholder — real walk in MV slice 2 follow-up)
+  const materializedViews = describeMVs(state.mvRegistry)
+  // 3. Overlay views
+  const overlayViews = describeOverlays(state.overlayRegistry)
+  // 4. Derivations
+  const derivations = describeDerivations(state.derivationRegistry)
+
+  // 5. Internal collections — only with stats
+  let internal: Record<string, InternalCollectionStats> | undefined
+  if (withStats) {
+    internal = {}
+    for (const name of KNOWN_INTERNAL_NAMES) {
+      const stats = await statsForCollection(state.adapter, state.name, name)
+      if (stats.records > 0) {
+        internal[name] = { records: stats.records, bytes: stats.bytes }
+      }
+    }
+  }
+
+  const snap: VaultSchemaSnapshot = {
+    _noydb_snapshot: 1,
+    vault: state.name,
+    emittedAt: new Date().toISOString(),
+    subsystems: state.subsystems,
+    collections,
+    materializedViews,
+    overlayViews,
+    derivations,
+    ...(internal !== undefined ? { internal } : {}),
+  }
+  return snap
+}
+
+async function safeListAllCollections(adapter: NoydbStore, vault: string): Promise<string[]> {
+  try {
+    const snap = await adapter.loadAll(vault)
+    return Object.keys(snap)
+  } catch {
+    return []
+  }
+}
+
+async function describeCollection(
+  state: VaultIntrospectState,
+  collectionName: string,
+  sampleSize: number,
+  withStats: boolean,
+): Promise<CollectionDescriptor> {
+  let fields: Record<string, FieldDescriptor> = {}
+  let validator: CollectionDescriptor['validator']
+
+  const refsRaw = state.refRegistry.getOutbound(collectionName)
+  const refs: CollectionDescriptor['refs'] = {}
+  for (const [name, desc] of Object.entries(refsRaw)) {
+    refs[name] = { target: desc.target, mode: desc.mode }
+  }
+
+  // 1. Try the persisted Route B envelope first.
+  try {
+    const dek = await state.getDEK(collectionName)
+    const persisted = await loadPersistedSchema(state.adapter, state.name, collectionName, dek)
+    if (persisted) {
+      validator = { kind: persisted.kind, source: 'persisted' }
+      if (persisted.jsonSchema) {
+        fields = jsonSchemaToFields(persisted.jsonSchema, 'persisted', refsRaw)
+      }
+    }
+  } catch {
+    // No DEK or decrypt failure — fall through to live-validator
+  }
+
+  // 2. Try the live in-process validator (when no persisted envelope).
+  if (!validator) {
+    const coll = state.collectionCache.get(collectionName)
+    const schema = coll?.getSchema()
+    if (schema) {
+      try {
+        const derived = await derivePersistedSchema(schema)
+        validator = { kind: derived.kind, source: 'live-validator' }
+        if (derived.jsonSchema) {
+          fields = jsonSchemaToFields(derived.jsonSchema, 'live-validator', refsRaw)
+        }
+      } catch {
+        // Derivation failed (e.g. missing peer-dep) — silently leave fields empty
+      }
+    }
+  }
+
+  // 3. Sampling fallback — deferred to a follow-up. For now: empty when no schema.
+  if (Object.keys(fields).length === 0 && sampleSize > 0) {
+    // Sampling path not implemented in baseline slice 2; reserved for follow-up.
+  }
+
+  const descriptor: CollectionDescriptor = {
+    fields,
+    indexes: [],
+    refs,
+    ...(validator ? { validator } : {}),
+  }
+  if (withStats) {
+    const stats = await statsForCollection(state.adapter, state.name, collectionName)
+    ;(descriptor as { stats?: CollectionStats }).stats = stats
+  }
+  return descriptor
+}
+
+async function statsForCollection(
+  adapter: NoydbStore,
+  vault: string,
+  collection: string,
+): Promise<CollectionStats> {
+  const ids = await adapter.list(vault, collection)
+  if (ids.length === 0) {
+    return { records: 0, bytes: 0, bytesAvg: 0, bytesMin: 0, bytesMax: 0, oldest: '', newest: '' }
+  }
+  let total = 0
+  let min = Number.POSITIVE_INFINITY
+  let max = 0
+  let oldest = '￿'
+  let newest = ''
+  for (const id of ids) {
+    const env = await adapter.get(vault, collection, id)
+    if (!env) continue
+    const size = env._data.length
+    total += size
+    if (size < min) min = size
+    if (size > max) max = size
+    if (env._ts < oldest) oldest = env._ts
+    if (env._ts > newest) newest = env._ts
+  }
+  return {
+    records: ids.length,
+    bytes: total,
+    bytesAvg: Math.round(total / ids.length),
+    bytesMin: min === Number.POSITIVE_INFINITY ? 0 : min,
+    bytesMax: max,
+    oldest: oldest === '￿' ? '' : oldest,
+    newest,
+  }
+}
+
+function describeMVs(registry: unknown): Record<string, MaterializedViewDescriptor> {
+  if (!registry || typeof registry !== 'object') return {}
+  const items = listFromRegistry(registry as Record<string, unknown>)
+  const out: Record<string, MaterializedViewDescriptor> = {}
+  // Each item is RegisteredMV { spec, dependencies, outputCollection, ... }
+  for (const item of items) {
+    const reg = item as {
+      spec?: {
+        name?: string
+        unionSources?: ReadonlyArray<{ collection: string }>
+        groupBy?: string | ReadonlyArray<string>
+        aggregate?: Record<string, unknown>
+        refresh?: string
+      }
+      dependencies?: ReadonlySet<string>
+    }
+    const spec = reg.spec
+    if (!spec?.name) continue
+    const sources = spec.unionSources
+      ? spec.unionSources.map((u) => u.collection)
+      : (reg.dependencies ? [...reg.dependencies].sort() : [])
+    const groupBy = spec.groupBy
+      ? Array.isArray(spec.groupBy) ? [...spec.groupBy] : [spec.groupBy]
+      : undefined
+    const aggregate = spec.aggregate ? Object.fromEntries(
+      Object.entries(spec.aggregate).map(([k, v]) => [k, summariseAggregateOp(v)]),
+    ) : undefined
+    out[spec.name] = {
+      sources,
+      ...(groupBy ? { groupBy } : {}),
+      ...(aggregate ? { aggregate } : {}),
+      refresh: spec.refresh ?? 'eager',
+    }
+  }
+  return out
+}
+
+function describeOverlays(registry: unknown): Record<string, OverlayViewDescriptor> {
+  if (!registry || typeof registry !== 'object') return {}
+  const specs = listFromRegistry(registry as Record<string, unknown>)
+  const out: Record<string, OverlayViewDescriptor> = {}
+  for (const spec of specs) {
+    const s = spec as { name?: string; base?: string; overlay?: string }
+    if (!s.name || !s.base || !s.overlay) continue
+    out[s.name] = { base: s.base, overlay: s.overlay }
+  }
+  return out
+}
+
+function describeDerivations(registry: unknown): Record<string, DerivationDescriptor> {
+  if (!registry || typeof registry !== 'object') return {}
+  const specs = listFromRegistry(registry as Record<string, unknown>)
+  const out: Record<string, DerivationDescriptor> = {}
+  for (const spec of specs) {
+    const s = spec as { name?: string; source?: string; outputs?: ReadonlyArray<string> }
+    if (!s.name) continue
+    out[s.name] = {
+      source: s.source ?? '',
+      outputs: s.outputs ?? [],
+    }
+  }
+  return out
+}
+
+function listFromRegistry(reg: Record<string, unknown>): readonly unknown[] {
+  // Registries expose different accessor methods; try the common ones.
+  for (const method of ['all', 'list', 'specs', 'values']) {
+    const fn = reg[method]
+    if (typeof fn === 'function') {
+      try {
+        const out = (fn as () => unknown).call(reg)
+        if (Array.isArray(out)) return out
+        if (out && typeof (out as { values?: () => unknown }).values === 'function') {
+          return [...(out as { values: () => Iterable<unknown> }).values()]
+        }
+      } catch {
+        continue
+      }
+    }
+  }
+  return []
+}
+
+function summariseAggregateOp(value: unknown): string {
+  if (value && typeof value === 'object') {
+    const op = (value as { op?: string; kind?: string; field?: string }).op
+      ?? (value as { kind?: string }).kind
+    const field = (value as { field?: string }).field
+    if (op && field) return `${op}(${field})`
+    if (op) return op
+  }
+  return String(value)
+}

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -105,6 +105,8 @@ import {
 } from './team/magic-link-grant.js'
 import { UserApi } from './meta/user-envelope/api.js'
 import { persistSchemaIfNeeded } from './persisted-schemas/register.js'
+import type { DumpSchemaOptions, VaultSchemaSnapshot } from './introspection/types.js'
+import { dumpVaultSchema, type VaultIntrospectState } from './introspection/walk.js'
 import { USER_ENVELOPE_COLLECTION } from './meta/user-envelope/types.js'
 
 /** A vault (tenant namespace) containing collections. */
@@ -2339,6 +2341,56 @@ export class Vault {
   async collections(): Promise<string[]> {
     const snapshot = await this.adapter.loadAll(this.name)
     return Object.keys(snapshot)
+  }
+
+  /**
+   * Emit a structured introspection snapshot of this vault — vault name,
+   * subsystem opt-in matrix, collections + their fields, materialized
+   * views, overlay views, derivations. With `withStats: true`, walks
+   * every collection's envelopes to compute record counts, byte totals,
+   * and oldest/newest timestamps.
+   *
+   * Consumed by the `noydb describe` CLI to produce human-readable
+   * audit YAML/JSON from a `.noydb` bundle.
+   *
+   * Field provenance:
+   *   - `persisted`: read from `_schemas/<col>` envelope (Route B opt-in)
+   *   - `live-validator`: derived in-process from a Zod schema attached
+   *     to the live `Collection`
+   *   - `sampled`: inferred from decrypted records (deferred to a follow-up)
+   *   - `unknown`: no schema info available
+   *
+   * @see docs/superpowers/specs/2026-05-22-schema-dump-design.md
+   */
+  async dumpSchema(opts: DumpSchemaOptions = {}): Promise<VaultSchemaSnapshot> {
+    return dumpVaultSchema(this, opts)
+  }
+
+  /**
+   * Internal accessor for {@link dumpVaultSchema}. Exposes the structural
+   * state the walker needs (collection cache, registries, ref registry,
+   * adapter) without widening the public Vault surface.
+   *
+   * @internal
+   */
+  _introspectState(): VaultIntrospectState {
+    return {
+      name: this.name,
+      adapter: this.adapter,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      collectionCache: this.collectionCache as Map<string, any>,
+      refRegistry: this.refRegistry,
+      getDEK: this.getDEK,
+      subsystems: {
+        guards: this.guardRegistry !== null,
+        derivations: this.derivationRegistry !== null,
+        materializedViews: this.materializedViewRegistry !== null,
+        overlayViews: this.overlayedViewRegistry !== null,
+      },
+      mvRegistry: this.materializedViewRegistry,
+      overlayRegistry: this.overlayedViewRegistry,
+      derivationRegistry: this.derivationRegistry,
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds `vault.dumpSchema({ withStats?, sampleSize? })` returning a structured `VaultSchemaSnapshot` describing the vault's full shape — collections, MVs, overlay views, derivations, subsystem opt-in matrix, optional stats. Consumed by the upcoming `noydb describe` CLI (slice 3).

Slice 2 of three. Builds on #174 (Route B persisted JSON Schema). Full design: [`docs/superpowers/specs/2026-05-22-schema-dump-design.md`](https://github.com/vLannaAi/noy-db/blob/main/docs/superpowers/specs/2026-05-22-schema-dump-design.md).

> [!NOTE]
> This PR is **stacked on #174**. Merge #174 first, then rebase this PR onto main (or merge as-is once #174 lands).

## Mechanics

**Field source provenance** per collection (in priority order):
1. `'persisted'` — decrypt the Route B envelope at `_schemas/<col>` with the collection's DEK.
2. `'live-validator'` — derive in-process from the live Zod schema attached to `Collection`.
3. `'unknown'` — no schema available; sampling fallback is reserved for a follow-up.

**Counters** (with `withStats: true`) — records, bytes, bytesAvg/Min/Max, oldest/newest from `_ts`. **Envelope-walk only — no decrypt needed.**

**MV walk** handles both:
- query-form (sources from dependency analyzer)
- UNION-form (sources from `unionSources[]`, strategy-level `groupBy` + `aggregate`)

**Internal collections** (`_keyring`, `_ledger`, `_meta`, `_schemas`, `_deltas`) surface under a separate `internal:` block ONLY when `withStats: true`. The default snapshot is user-facing only.

**Top-level keys alphabetical** for diff stability across runs; field order inside each collection preserves the validator's declaration order.

## Public surface

```ts
import { createNoydb } from '@noy-db/hub'

const db = await createNoydb({ /* ... */ })
const vault = await db.openVault('acme')

// Structure-only dump (default)
const snap = await vault.dumpSchema()

// With counters
const snapWithStats = await vault.dumpSchema({ withStats: true })

// snap.collections.invoices = {
//   validator: { kind: 'Zod', source: 'persisted' },
//   fields: { id: { type: 'string', source: 'persisted' }, ... },
//   indexes: [...], refs: { client_id: { target: 'clients', mode: 'strict' } },
//   stats: { records: 1247, bytes: 428612, ... }   // when withStats
// }
// snap.materializedViews['monthly-vat'] = { sources, groupBy, aggregate, refresh }
// snap.internal._keyring = { records: 4, bytes: 8120 }   // when withStats
```

Also re-exported from `@noy-db/hub`:
- Types: `VaultSchemaSnapshot`, `DumpSchemaOptions`, `CollectionDescriptor`, `CollectionStats`, `FieldDescriptor`, `FieldSource`, `MaterializedViewDescriptor`, `OverlayViewDescriptor`, `DerivationDescriptor`, `InternalCollectionStats`

## Tests

+13 tests across 3 new modules under `packages/hub/__tests__/introspection/`:

- `dump-schema.test.ts` (6) — baseline: vault name, collection enumeration, persisted/live-validator/unknown provenance, subsystem matrix
- `dump-schema-stats.test.ts` (4) — withStats counters, zero-record edge case, internal-collection block
- `dump-schema-views.test.ts` (3) — empty MV map, query-form MV, UNION-form MV with groupBy + aggregate

Full hub suite: 1639 / 1640 passing (+1 pre-existing `it.todo`). Typecheck clean; lint clean (warnings predate). Build + architecture + features.yaml validation all pass.

## Deferred to follow-up

- Sampling fallback for `'unknown'` fields when no persisted/live schema (smart-auto path per spec; needs decrypted record iteration)
- ACL roles + public envelope summary in the snapshot
- Indexes (currently `indexes: []` — collection-cache instances would have them via `getIndexes()`; non-cached storage-only collections wouldn't)
- Guards / history-strategy / blob-fields / i18n labels per collection

These are additive to the snapshot shape and can land independently without breaking slice 3.

## Test plan

- [x] `pnpm vitest run --filter @noy-db/hub` — all hub tests pass
- [x] `pnpm turbo typecheck --filter @noy-db/hub` — no type errors
- [x] `pnpm turbo lint --filter @noy-db/hub` — no errors
- [x] `pnpm turbo build --filter @noy-db/hub` — builds clean
- [x] `node scripts/check-architecture.mjs` + `validate-features.mjs` — both pass