### PR TITLE
feat(as-xlsx): expose widths on AsXlsxSheetOptions (#177)

### DIFF
--- a/packages/as-xlsx/__tests__/as-xlsx.test.ts
+++ b/packages/as-xlsx/__tests__/as-xlsx.test.ts
@@ -261,6 +261,46 @@ describe('as-xlsx — vault integration', () => {
     await db.close()
   })
 
+  it('threads AsXlsxSheetOptions.widths through to the emitted <cols> block (#177)', async () => {
+    const { adapter } = await seedVault()
+    await grantXlsx(adapter)
+
+    const db = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+    const vault = await db.openVault('acme')
+    const bytes = await toBytes(vault, {
+      sheets: [
+        {
+          name: 'Invoices',
+          collection: 'invoices',
+          columns: ['id', 'client', 'amount', 'paid', 'date'],
+          widths: [12, 24, 10, 6, 14],
+        },
+      ],
+    })
+
+    const sheet = readZipFile(bytes, 'xl/worksheets/sheet1.xml')!
+    expect(sheet).toContain('<cols>')
+    expect(sheet).toContain('<col min="1" max="1" width="12" customWidth="1"/>')
+    expect(sheet).toContain('<col min="2" max="2" width="24" customWidth="1"/>')
+    expect(sheet).toContain('<col min="5" max="5" width="14" customWidth="1"/>')
+    expect(sheet.indexOf('<cols>')).toBeLessThan(sheet.indexOf('<sheetData>'))
+    await db.close()
+  })
+
+  it('omits <cols> when AsXlsxSheetOptions.widths is not set (#177 default)', async () => {
+    const { adapter } = await seedVault()
+    await grantXlsx(adapter)
+
+    const db = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+    const vault = await db.openVault('acme')
+    const bytes = await toBytes(vault, {
+      sheets: [{ name: 'Invoices', collection: 'invoices', columns: ['id'] }],
+    })
+    const sheet = readZipFile(bytes, 'xl/worksheets/sheet1.xml')!
+    expect(sheet).not.toContain('<cols>')
+    await db.close()
+  })
+
   it('refuses owner without xlsx grant', async () => {
     const { db } = await seedVault()
     const vault = await db.openVault('acme')

--- a/packages/as-xlsx/src/index.ts
+++ b/packages/as-xlsx/src/index.ts
@@ -54,6 +54,21 @@ export interface AsXlsxSheetOptions {
    * decryption; doesn't reduce I/O.
    */
   readonly filter?: (record: unknown) => boolean
+  /**
+   * Optional per-column character widths (Excel `wch` units). When set,
+   * the emitted sheet opens with the requested column widths instead of
+   * Excel's default 10-character fallback. Index aligned with
+   * `columns` / inferred-column order.
+   *
+   * Non-finite or non-positive entries are skipped so consumers can
+   * mix explicit + auto (pass `undefined` for "auto").
+   *
+   * Length is NOT validated against `columns.length` — extra entries
+   * are harmless (no `<col>` is emitted past the column count) and a
+   * short array leaves trailing columns at Excel's default. This
+   * mirrors `XlsxSheet.widths`, which it threads through.
+   */
+  readonly widths?: ReadonlyArray<number | undefined>
 }
 
 /** Single-collection convenience — passed where a sheet-list is accepted. */
@@ -114,6 +129,7 @@ export async function toBytes(vault: Vault, options: AsXlsxOptions): Promise<Uin
       name: sheetOpt.name,
       header: columns,
       rows: records.map((r) => columns.map((c) => r[c] ?? null)),
+      ...(sheetOpt.widths !== undefined ? { widths: sheetOpt.widths } : {}),
     })
   }
 


### PR DESCRIPTION
Closes #177.

## Summary

The low-level \`XlsxSheet.widths\` was already implemented + tested (writes a \`<cols>\` block per OOXML), but the high-level \`toBytes(vault, { sheets })\` consumer API didn't expose it. Consumers going through the vault-integrated surface (niwat, etc.) got Excel's default 10-character columns with no way to override.

## Change

Add \`widths?: ReadonlyArray<number | undefined>\` to \`AsXlsxSheetOptions\`. Thread it through to the materialised \`XlsxSheet\` inside \`toBytes()\`. Same semantics as the low-level field: skip non-positive entries, mix-explicit-and-auto via \`undefined\`.

\`\`\`ts
// consumer side (niwat-style)
await toBytes(vault, {
  sheets: [{
    name: 'Invoices',
    collection: 'invoices',
    columns: ['id', 'client', 'amount', 'paid', 'date'],
    widths: [12, 24, 10, 6, 14],   // ← new
  }],
})
// emits <col min=\"1\" max=\"1\" width=\"12\" customWidth=\"1\"/> ...
\`\`\`

## Tests

+2 tests in the vault-integration section:
- Widths emit the expected \`<cols>\` block in sheet1.xml
- Absence of widths leaves \`<cols>\` omitted (no regression)

All 34 as-xlsx tests pass; typecheck + lint clean.

## Test plan

- [x] \`pnpm vitest run --filter @noy-db/as-xlsx\` — 34/34 pass
- [x] \`pnpm turbo typecheck --filter @noy-db/as-xlsx\` — clean
- [x] \`pnpm turbo lint --filter @noy-db/as-xlsx\` — clean