### PR TITLE
fix(hub): Collection._doDelete dispatches eager MV refresh (#181)

### DIFF
--- a/packages/hub/__tests__/materialized-views/union.test.ts
+++ b/packages/hub/__tests__/materialized-views/union.test.ts
@@ -320,17 +320,65 @@ describe('UNION MV — edges (#165)', () => {
     expect(row?.n).toBe(7)
   })
 
-  // KNOWN GAP (pre.14 hangover, surfaced by #165 review):
-  // `Collection._doDelete` does NOT call `dispatchMaterializedViews` —
-  // only `put` does (collection.ts 1283/1399). This means source
-  // deletes never trigger eager MV refresh; tombstoning only fires
-  // when something *else* (a put on the source or a manual
-  // `vault.refreshView`) re-runs the executor. Affects ANY MV with
-  // `onEmpty: 'delete'` (the default), not just UNION-form. The
-  // executor + `listOutputIds` themselves are correct — the variant
-  // below uses an explicit `refreshView` to prove that, and the
-  // `it.todo` below pins the auto-dispatch gap for a future PR.
-  it.todo('onEmpty: delete tombstones MV row automatically when source rows are deleted (pending _doDelete → dispatchMaterializedViews wiring)')
+  // Fix for #181: `Collection._doDelete` now calls
+  // `dispatchMaterializedViews` (mirroring put), so source deletes
+  // trigger eager MV refresh automatically. The internal=true path
+  // (used by MV refresh tombstoning itself) still skips dispatch to
+  // avoid recursion. Affects ANY MV with `onEmpty: 'delete'` (the
+  // default), not just UNION-form. The manual-refresh variant below
+  // remains as a separate proof that the executor is correct in
+  // isolation.
+  it('onEmpty: delete tombstones MV row automatically when source rows are deleted (#181)', async () => {
+    const totals = withMaterializedView<TotalsRow>({
+      name: 'totals',
+      unionSources: [
+        {
+          collection: 'a',
+          map: r => {
+            const row = r as unknown as ArmRowA
+            return { k: row.k, n: row.n }
+          },
+        },
+        {
+          collection: 'b',
+          map: r => {
+            const row = r as unknown as ArmRowB
+            return { k: row.k, n: row.n }
+          },
+        },
+      ],
+      groupBy: 'k',
+      aggregate: { n: sum('n') },
+      rowKey: row => row.k,
+      refresh: 'eager',
+      onEmpty: 'delete',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-union-onempty-auto-tombstone-passphrase-2026',
+      materializedViewStrategies: [totals],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('demo')
+    const a = vault.collection<ArmRowA>('a')
+    const b = vault.collection<ArmRowB>('b')
+    const out = vault.collection<TotalsRow & { _materializedFrom?: unknown }>('totals')
+
+    await a.put('a-1', { id: 'a-1', k: 'x', n: 1 })
+    await b.put('b-1', { id: 'b-1', k: 'x', n: 2 })
+    expect((await out.list())).toHaveLength(1)
+
+    // Delete both contributing source rows — the auto-dispatch from
+    // `_doDelete` should run the executor, listOutputIds finds the
+    // now-orphan 'x' row, and `onEmpty: 'delete'` tombstones it.
+    // NO `vault.refreshView('totals')` call here — that's the point.
+    await a.delete('a-1')
+    await b.delete('b-1')
+
+    expect((await out.list())).toHaveLength(0)
+  })
 
   it('onEmpty: delete (default) tombstones MV row when all contributing source rows are deleted (manual refresh)', async () => {
     const totals = withMaterializedView<TotalsRow>({

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1773,6 +1773,59 @@ export class Collection<T> {
     } satisfies ChangeEvent)
 
     await this.onAccess?.('delete', id)
+
+    // Symmetric to put (#181): user-initiated deletes must fire MV
+    // refresh so `onEmpty: 'delete'` MVs tombstone their now-orphan
+    // output rows. Gated on `!internal` to prevent recursion — the
+    // MV executor's own tombstoning round-trips through
+    // `_internalDelete → _doDelete(_, true)` and must NOT re-fire
+    // dispatch (matches put's `_materializedFrom` skip in spirit).
+    //
+    // Derivations intentionally NOT dispatched on delete: D11
+    // derivations are forward-edge (source put → derived output);
+    // the delete-side semantics for derivations are tracked
+    // separately. This fix scope is materialized views only.
+    if (!internal) {
+      await this.dispatchMaterializedViewsOnDelete(id)
+    }
+  }
+
+  /**
+   * Mirror of {@link dispatchMaterializedViews} for the delete path
+   * (#181). No record content is available (it's gone), so the
+   * `_materializedFrom` skip used by the put-side dispatch doesn't
+   * apply here — instead, the recursion guard is the `internal` gate
+   * at the `_doDelete` call site above.
+   *
+   * @internal
+   */
+  private async dispatchMaterializedViewsOnDelete(id: string): Promise<void> {
+    void id
+    if (this.materializedViewSource === undefined) return
+    const registry = this.materializedViewSource.registry()
+    const mvs = registry.mvsForSource(this.name)
+    if (mvs.length === 0) return
+    let executor: typeof MVExecutorType | null = null
+    let staleHelpers: typeof MVStaleModule | null = null
+    for (const reg of mvs) {
+      const mode = reg.spec.refresh
+      if (mode === 'eager') {
+        if (executor === null) {
+          ;({ MaterializedViewExecutor: executor } = await import('./materialized-views/executor.js'))
+        }
+        await executor.refresh(reg, {
+          getCollection: (name) => this.materializedViewSource!.getCollection(name),
+          getActiveTxContext: () => this.materializedViewSource!.getActiveTxContext(),
+          getQueryContext: () => this.materializedViewSource!.getQueryContext(),
+        })
+      } else if (mode === 'lazy') {
+        if (staleHelpers === null) {
+          staleHelpers = await import('./materialized-views/stale.js')
+        }
+        staleHelpers.markMVStale(registry, reg.spec.name)
+      }
+      // manual: no-op — `vault.refreshView(name)` is the only path.
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #181.

## Summary

Pre.14 carry-over: \`_doDelete\` never called \`dispatchMaterializedViews\`, so \`onEmpty: 'delete'\` MVs didn't tombstone output rows when source records were deleted. Only a subsequent \`put\` on the same source or a manual \`vault.refreshView()\` would re-run the executor. Pinned by an \`it.todo\` at \`union.test.ts:333\` since the pre.15 UNION review.

## Fix

Add a delete-side dispatch \`dispatchMaterializedViewsOnDelete(id)\` mirroring the existing \`dispatchMaterializedViews(id, record)\`, called at the end of \`_doDelete\` and **gated on \`!internal\`** to prevent recursion — the MV executor's own tombstoning round-trips through \`_internalDelete → _doDelete(_, true)\` and must not re-fire dispatch (matches put-side's \`_materializedFrom\` skip in spirit).

Affects ALL \`onEmpty: 'delete'\` MVs (the default), not just UNION-form.

## Recursion gate visualized

\`\`\`
USER:    collection('invoices').delete('inv-1')
           ↓
         _doDelete('inv-1', false)              ← internal: false
           ↓
         dispatchMaterializedViewsOnDelete('inv-1')
           ↓
         executor.refresh(mv)
           ↓
         outputColl._internalDelete('row-1')   ← tombstones orphan output row
           ↓
         _doDelete('row-1', true)               ← internal: true
           ↓
         (dispatch skipped — recursion guard)   ✓
\`\`\`

## Tests

- Lift the pre.14 \`it.todo\` at \`union.test.ts:333\` to a real \`it()\` that asserts auto-tombstone on source delete (no manual \`refreshView\` call).
- The existing manual-refresh variant stays in place as the executor's isolated proof.

**Hub suite: 1643/1643 passing, zero \`it.todo\` remaining.** Typecheck clean; lint 0 errors (warnings predate).

## Why not derivations too?

Spec scope is materialized views only. D11 derivations are forward-edge (source put → derived output); the delete-side semantics for derivations are a separate decision tracked elsewhere.

## Test plan

- [x] \`pnpm vitest run --filter @noy-db/hub -t \"#181\"\` — passes
- [x] \`pnpm vitest run --filter @noy-db/hub\` — 1643/1643
- [x] \`pnpm turbo typecheck --filter @noy-db/hub\` — clean
- [x] \`pnpm turbo lint --filter @noy-db/hub\` — 0 errors