### PR TITLE
feat(hub,as-*): ledger entry tagged 'import:<format>' via collection.put({ reason }) (#1)

### DIFF
--- a/packages/as-csv/src/index.ts
+++ b/packages/as-csv/src/index.ts
@@ -259,11 +259,11 @@ export async function fromString(
       await vault.noydb.transaction((tx) => {
         const txVault = tx.vault(vault.name)
         for (const entry of plan.added) {
-          txVault.collection(entry.collection).put(entry.id, entry.record)
+          txVault.collection(entry.collection).put(entry.id, entry.record, { reason: 'import:csv' })
         }
         if (policy !== 'insert-only') {
           for (const entry of plan.modified) {
-            txVault.collection(entry.collection).put(entry.id, entry.record)
+            txVault.collection(entry.collection).put(entry.id, entry.record, { reason: 'import:csv' })
           }
         }
         if (policy === 'replace') {

--- a/packages/as-json/__tests__/as-json-import.test.ts
+++ b/packages/as-json/__tests__/as-json-import.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect } from 'vitest'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '@noy-db/hub'
 import { ConflictError, createNoydb } from '@noy-db/hub'
 import { withTransactions } from '@noy-db/hub/tx'
+import { withHistory } from '@noy-db/hub/history'
 import { fromString, fromObject } from '../src/index.js'
 
 function memory(): NoydbStore {
@@ -162,6 +163,52 @@ describe('as-json fromObject — direct-object input', () => {
       invoices: [{ id: 'c', amount: 300, status: 'paid' }],
     })
     expect(importer.plan.added.map((e) => e.id)).toEqual(['c'])
+    db.close()
+  })
+})
+
+describe('as-json fromString — apply stamps `reason: "import:json"` on every ledger entry (#1)', () => {
+  it('imported rows are filterable from manual edits via ledger.reason', async () => {
+    const adapter = memory()
+    // Init: grant + seed an existing record manually (no reason — counts as manual edit).
+    const init = await createNoydb({ store: adapter, user: 'alice', secret: 'pw-2026', historyStrategy: withHistory() })
+    await init.openVault('demo')
+    await init.grant('demo', {
+      userId: 'alice', displayName: 'Alice', role: 'owner',
+      passphrase: 'pw-2026',
+      importCapability: { plaintext: ['json'] },
+    })
+    init.close()
+
+    const db = await createNoydb({
+      store: adapter, user: 'alice', secret: 'pw-2026',
+      historyStrategy: withHistory(),
+      txStrategy: withTransactions(),
+    })
+    const vault = await db.openVault('demo')
+    const inv = vault.collection<Invoice>('invoices')
+    await inv.put('manual', { id: 'manual', amount: 99, status: 'draft' })
+
+    // Import via apply() — every put inside is tagged 'import:json'
+    const importer = await fromString(vault, JSON.stringify({
+      invoices: [
+        { id: 'imp-1', amount: 100, status: 'paid' },
+        { id: 'imp-2', amount: 200, status: 'paid' },
+      ],
+    }))
+    await importer.apply()
+
+    const entries = await vault.ledger().entries()
+    const reasonByOrder = entries.map((e) => ({ id: e.id, reason: e.reason }))
+    expect(reasonByOrder).toEqual([
+      { id: 'manual', reason: undefined },
+      { id: 'imp-1', reason: 'import:json' },
+      { id: 'imp-2', reason: 'import:json' },
+    ])
+
+    // Audit filter — the documented use case.
+    const imports = entries.filter((e) => e.reason?.startsWith('import:'))
+    expect(imports.map((e) => e.id)).toEqual(['imp-1', 'imp-2'])
     db.close()
   })
 })

--- a/packages/as-json/src/index.ts
+++ b/packages/as-json/src/index.ts
@@ -213,11 +213,11 @@ export async function fromObject(
       await vault.noydb.transaction((tx) => {
         const txVault = tx.vault(vault.name)
         for (const entry of plan.added) {
-          txVault.collection(entry.collection).put(entry.id, entry.record)
+          txVault.collection(entry.collection).put(entry.id, entry.record, { reason: 'import:json' })
         }
         if (policy !== 'insert-only') {
           for (const entry of plan.modified) {
-            txVault.collection(entry.collection).put(entry.id, entry.record)
+            txVault.collection(entry.collection).put(entry.id, entry.record, { reason: 'import:json' })
           }
         }
         if (policy === 'replace') {

--- a/packages/as-ndjson/src/index.ts
+++ b/packages/as-ndjson/src/index.ts
@@ -186,11 +186,11 @@ export async function fromString(
       await vault.noydb.transaction((tx) => {
         const txVault = tx.vault(vault.name)
         for (const entry of plan.added) {
-          txVault.collection(entry.collection).put(entry.id, entry.record)
+          txVault.collection(entry.collection).put(entry.id, entry.record, { reason: 'import:ndjson' })
         }
         if (policy !== 'insert-only') {
           for (const entry of plan.modified) {
-            txVault.collection(entry.collection).put(entry.id, entry.record)
+            txVault.collection(entry.collection).put(entry.id, entry.record, { reason: 'import:ndjson' })
           }
         }
         if (policy === 'replace') {

--- a/packages/as-xlsx/src/index.ts
+++ b/packages/as-xlsx/src/index.ts
@@ -374,11 +374,11 @@ export async function fromBytes(
       await vault.noydb.transaction((tx) => {
         const txVault = tx.vault(vault.name)
         for (const entry of plan.added) {
-          txVault.collection(entry.collection).put(entry.id, entry.record)
+          txVault.collection(entry.collection).put(entry.id, entry.record, { reason: 'import:xlsx' })
         }
         if (policy !== 'insert-only') {
           for (const entry of plan.modified) {
-            txVault.collection(entry.collection).put(entry.id, entry.record)
+            txVault.collection(entry.collection).put(entry.id, entry.record, { reason: 'import:xlsx' })
           }
         }
         if (policy === 'replace') {

--- a/packages/as-xml/src/index.ts
+++ b/packages/as-xml/src/index.ts
@@ -341,11 +341,11 @@ export async function fromString(
       await vault.noydb.transaction((tx) => {
         const txVault = tx.vault(vault.name)
         for (const entry of plan.added) {
-          txVault.collection(entry.collection).put(entry.id, entry.record)
+          txVault.collection(entry.collection).put(entry.id, entry.record, { reason: 'import:xml' })
         }
         if (policy !== 'insert-only') {
           for (const entry of plan.modified) {
-            txVault.collection(entry.collection).put(entry.id, entry.record)
+            txVault.collection(entry.collection).put(entry.id, entry.record, { reason: 'import:xml' })
           }
         }
         if (policy === 'replace') {

--- a/packages/hub/__tests__/ledger-reason.test.ts
+++ b/packages/hub/__tests__/ledger-reason.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the `reason` option threaded through `collection.put(id, record, { reason })`
+ * down to the ledger entry. Audit consumers use this to distinguish manual
+ * edits from imported rows or other tagged operations.
+ *
+ * Spec: #1 (feat(as-*): ledger entry tagged 'import:<format>' on apply)
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import { createNoydb, type Noydb } from '../src/noydb.js'
+import { withHistory } from '../src/history/index.js'
+import { memory } from '../../to-memory/src/index.js'
+
+interface Invoice extends Record<string, unknown> {
+  id: string
+  amount: number
+}
+
+describe('collection.put(_, _, { reason }) — ledger entry carries `reason` (#1)', () => {
+  let db: Noydb
+
+  beforeEach(async () => {
+    db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'reason-test-passphrase-1234',
+      historyStrategy: withHistory(),
+    })
+  })
+
+  it('omits `reason` from the ledger entry when not passed (back-compat)', async () => {
+    const vault = await db.openVault('demo')
+    const invoices = vault.collection<Invoice>('invoices')
+    await invoices.put('i1', { id: 'i1', amount: 100 })
+    const entries = await vault.ledger().entries()
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.reason).toBeUndefined()
+  })
+
+  it('stamps `reason` on the put-ledger entry when passed', async () => {
+    const vault = await db.openVault('demo')
+    const invoices = vault.collection<Invoice>('invoices')
+    await invoices.put('i1', { id: 'i1', amount: 100 }, { reason: 'import:json' })
+    const entries = await vault.ledger().entries()
+    expect(entries).toHaveLength(1)
+    expect(entries[0]?.reason).toBe('import:json')
+  })
+
+  it('preserves `reason` across multiple puts with different reasons', async () => {
+    const vault = await db.openVault('demo')
+    const invoices = vault.collection<Invoice>('invoices')
+    await invoices.put('i1', { id: 'i1', amount: 100 }, { reason: 'import:csv' })
+    await invoices.put('i2', { id: 'i2', amount: 200 }) // no reason
+    await invoices.put('i3', { id: 'i3', amount: 300 }, { reason: 'import:xlsx' })
+    const entries = await vault.ledger().entries()
+    expect(entries.map(e => e.reason)).toEqual(['import:csv', undefined, 'import:xlsx'])
+  })
+
+  it('canonicalizes — different reason → different ledger hash, same hash chain still verifies', async () => {
+    const vault = await db.openVault('demo')
+    const invoices = vault.collection<Invoice>('invoices')
+    await invoices.put('i1', { id: 'i1', amount: 100 }, { reason: 'import:json' })
+    await invoices.put('i2', { id: 'i2', amount: 200 })
+    const ledger = vault.ledger()
+    const verify = await ledger.verify()
+    expect(verify.ok).toBe(true)
+  })
+
+  it('audit filter usage: vault.ledger().entries().filter(e => e.reason?.startsWith("import:"))', async () => {
+    const vault = await db.openVault('demo')
+    const invoices = vault.collection<Invoice>('invoices')
+    await invoices.put('manual-1', { id: 'manual-1', amount: 1 })
+    await invoices.put('imp-1', { id: 'imp-1', amount: 2 }, { reason: 'import:csv' })
+    await invoices.put('imp-2', { id: 'imp-2', amount: 3 }, { reason: 'import:json' })
+    await invoices.put('manual-2', { id: 'manual-2', amount: 4 })
+
+    const entries = await vault.ledger().entries()
+    const imports = entries.filter(e => e.reason?.startsWith('import:'))
+    expect(imports.map(e => e.id)).toEqual(['imp-1', 'imp-2'])
+  })
+})

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1048,8 +1048,18 @@ export class Collection<T> {
     return this.syncStrategy.buildPresence<P>(presenceOpts)
   }
 
-  /** Create or update a record. */
-  async put(id: string, record: T): Promise<void> {
+  /**
+   * Create or update a record.
+   *
+   * @param id      Record identifier.
+   * @param record  The record body (validated by the collection's schema
+   *                if one was attached at `vault.collection(...)` time).
+   * @param options Optional metadata for audit + import workflows.
+   *                `reason` is stamped onto the resulting ledger entry
+   *                (see #1) so audit consumers can filter via
+   *                `entries.filter(e => e.reason?.startsWith('import:'))`.
+   */
+  async put(id: string, record: T, options?: { readonly reason?: string }): Promise<void> {
     if (!hasWritePermission(this.keyring, this.name)) {
       throw new ReadOnlyError()
     }
@@ -1260,6 +1270,7 @@ export class Collection<T> {
           payloadHash: await this.historyStrategy.envelopePayloadHash(envelope),
         }
         if (existingResolved) appendInput.delta = this.historyStrategy.computePatch(resolvedRecord, existingResolved.record)
+        if (options?.reason !== undefined) appendInput.reason = options.reason
         await this.ledger.append(appendInput)
       }
 
@@ -1362,6 +1373,7 @@ export class Collection<T> {
         // delta scheme. See `LedgerStore.reconstruct` for the walk.
         appendInput.delta = this.historyStrategy.computePatch(record, existing.record)
       }
+      if (options?.reason !== undefined) appendInput.reason = options.reason
       await this.ledger.append(appendInput)
     }
 

--- a/packages/hub/src/history/ledger/entry.ts
+++ b/packages/hub/src/history/ledger/entry.ts
@@ -115,6 +115,18 @@ export interface LedgerEntry {
   readonly payloadHash: string
 
   /**
+   * Optional human-readable tag describing why this mutation happened
+   * (#1). Threaded through `collection.put(_, _, { reason })`. Common
+   * values include `'import:csv'`, `'import:json'`, `'import:xlsx'` from
+   * `as-*` ImportPlan.apply(), but consumers can use any string for
+   * domain-specific audit filtering. Auto-strip via `canonicalJson` —
+   * absent on the wire, never serialized as `null`.
+   *
+   * Audit consumers filter: `entries.filter(e => e.reason?.startsWith('import:'))`.
+   */
+  readonly reason?: string
+
+  /**
    * Optional hex-encoded sha256 of the encrypted JSON Patch delta
    * blob stored alongside this entry in `_ledger_deltas/`. Present
    * only for `put` operations that had a previous version — the

--- a/packages/hub/src/history/ledger/store.ts
+++ b/packages/hub/src/history/ledger/store.ts
@@ -103,6 +103,13 @@ export interface AppendInput {
    * resulting ledger entry.
    */
   amendment?: LedgerEntry['amendment']
+  /**
+   * Optional human-readable tag describing why this mutation happened
+   * (#1). Threaded from `collection.put(_, _, { reason })`.
+   * Carried verbatim onto the resulting ledger entry's `reason` field;
+   * omitted from canonical JSON when undefined.
+   */
+  reason?: string
 }
 
 /**
@@ -301,6 +308,7 @@ export class LedgerStore {
       ...entryBase,
       ...(deltaHash !== undefined ? { deltaHash } : {}),
       ...(input.amendment !== undefined ? { amendment: input.amendment } : {}),
+      ...(input.reason !== undefined ? { reason: input.reason } : {}),
     }
 
     const envelope = await this.encryptEntry(entry)

--- a/packages/hub/src/tx/transaction.ts
+++ b/packages/hub/src/tx/transaction.ts
@@ -78,6 +78,12 @@ export interface StagedOp {
   id: string
   record?: unknown
   expectedVersion?: number
+  /**
+   * Optional human-readable tag forwarded to the resulting ledger
+   * entry's `reason` field (#1). Set by callers via
+   * `tx.vault(v).collection(c).put(id, record, { reason })`.
+   */
+  reason?: string
 }
 
 /**
@@ -235,7 +241,7 @@ export class TxCollection<T> {
    * Supply `{ expectedVersion }` to enforce optimistic concurrency
    * during the commit pre-flight.
    */
-  put(id: string, record: T, options?: { expectedVersion?: number }): void {
+  put(id: string, record: T, options?: { expectedVersion?: number; reason?: string }): void {
     const op: StagedOp = {
       type: 'put',
       vaultName: this._vault.name,
@@ -244,6 +250,7 @@ export class TxCollection<T> {
       record,
     }
     if (options?.expectedVersion !== undefined) op.expectedVersion = options.expectedVersion
+    if (options?.reason !== undefined) op.reason = options.reason
     this._ctx._ops.push(op)
   }
 
@@ -369,7 +376,7 @@ export async function runTransaction<T>(
         ctx._executed.push({ op, priorEnvelope: prior })
         if (op.type === 'put') {
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          await coll.put(op.id, op.record as any)
+          await coll.put(op.id, op.record as any, op.reason !== undefined ? { reason: op.reason } : undefined)
         } else {
           await coll.delete(op.id)
         }


### PR DESCRIPTION
Closes #1.

## Summary

Threads an optional \`reason\` string through \`collection.put(id, record, { reason })\` down to the resulting ledger entry's new \`reason\` field. Audit consumers can now distinguish manual edits from imported rows without scanning record contents:

\`\`\`ts
entries.filter(e => e.reason?.startsWith('import:'))
\`\`\`

## Hub changes

- \`LedgerEntry.reason?: string\` added. Omitted on the wire when undefined (mirrors the \`deltaHash\` precedent — \`canonicalJson\` rejects \`undefined\`, so the build sites use \`...(reason !== undefined ? { reason } : {})\`).
- \`AppendInput.reason?\` added to \`LedgerStore.append\` and forwarded onto the entry.
- \`Collection.put(id, record, options?: { reason?: string })\` — new optional third arg. Threaded through both put-call sites that hit the ledger (CRDT path + main path).
- \`TxCollection.put(id, record, options?: { reason?, expectedVersion? })\` — reason added to \`StagedOp\` and forwarded at commit time so transactional imports tag their entries identically to direct puts. **Without this, ImportPlan.apply() inside \`vault.noydb.transaction(...)\` would have silently dropped the reason — caught by the integration test below.**

## ImportPlan.apply tagging

Each \`as-*\` importer's \`apply()\` method now passes a format-specific tag:

| Package | Reason |
|---|---|
| \`as-json\`   | \`'import:json'\` |
| \`as-csv\`    | \`'import:csv'\` |
| \`as-ndjson\` | \`'import:ndjson'\` |
| \`as-xml\`    | \`'import:xml'\` |
| \`as-xlsx\`   | \`'import:xlsx'\` |

## Tests

- **hub:** +5 tests in \`__tests__/ledger-reason.test.ts\` — back-compat (omitted by default), single-put stamping, mixed puts, hash-chain still verifies, canonical audit-filter usage.
- **as-json:** +1 integration test in \`as-json-import.test.ts\` — verifies \`ImportPlan.apply()\` stamps \`import:json\` on every put, audit filter cleanly separates manual edits from imported rows. (This was the test that caught the missing tx-wrapper threading.)

Full hub suite: **1647/1648 passing** (+5 from this PR; +1 pre-existing \`it.todo\` from pre.14, separately tracked as #181). All as-* suites green isolated; typecheck + lint clean across hub + every as-* package.

## Public API surface

Backward-compatible: \`reason\` is an optional third argument on both \`Collection.put\` and \`TxCollection.put\`. Existing call sites compile unchanged.

\`\`\`ts
// new — explicit tagging:
await invoices.put('inv-1', record, { reason: 'import:json' })

// existing — unchanged behaviour (no reason on the ledger entry):
await invoices.put('inv-1', record)
\`\`\`

## Deferred from the original issue

The optional follow-on (source file's SHA-256 hash on the ledger entry, so an audit can tie ledger ranges back to an exact file) is not in this PR — additive on top of the threading infrastructure that landed here. File separately if needed.

## Test plan

- [x] \`pnpm vitest run --filter @noy-db/hub\` — 1647/1648 pass
- [x] \`pnpm vitest run --filter "@noy-db/as-*"\` — all green isolated
- [x] \`pnpm turbo typecheck --filter @noy-db/hub --filter "@noy-db/as-*"\` — clean
- [x] \`pnpm turbo lint --filter @noy-db/hub --filter "@noy-db/as-*"\` — clean