### PR TITLE
feat(hub): db.rotateRecovery() — gated deliberate paper-code regeneration (#121)

### DIFF
--- a/packages/hub/__tests__/rotate-recovery.test.ts
+++ b/packages/hub/__tests__/rotate-recovery.test.ts
@@ -1,0 +1,176 @@
+/**
+ * #121 — `db.rotateRecovery(vault, options, factors?)`.
+ *
+ * Deliberate paper-recovery-code regeneration. The user remembers their
+ * passphrase but wants a fresh sheet (lost the printout, suspect compromise
+ * of the off-site copy). Symmetric to the other tier-1-modifying actions:
+ * gated, audit-trackable, ergonomic.
+ *
+ * Pinned behaviors:
+ *   1. Returns `newCodes` of length matching the existing sheet by default.
+ *   2. `count` override produces exactly that many codes.
+ *   3. Replaces the sheet (not appends) — old codes invalidated.
+ *   4. Newly minted codes round-trip through `db.recoverPassphrase`.
+ *   5. `codeGenerator` hook overrides the default ULID format.
+ *   6. The new `rotate-recovery` gate is enforced — PERSONAL allows
+ *      minTier: 1; STRICT requires an off-device factor.
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope } from '../src/types.js'
+import { createNoydb, type Noydb } from '../src/noydb.js'
+import {
+  generateULID,
+  mintPaperRecoveryEntry,
+  loadPaperRecoveryEntries,
+  type PaperRecoveryEntry,
+} from '../src/index.js'
+import { STRICT_POLICY } from '../src/policy/presets.js'
+import { PolicyDeniedError } from '../src/errors.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'inline-memory',
+    async get(c: string, col: string, id: string) { return gc(c, col).get(id) },
+    async put(c: string, col: string, id: string, env: EncryptedEnvelope) { gc(c, col).set(id, env) },
+    async delete(c: string, col: string, id: string) { gc(c, col).delete(id) },
+    async list(c: string, col: string) { return [...gc(c, col).keys()] },
+    async loadAll() { return {} },
+    async saveAll() {},
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+  } as unknown as NoydbStore
+}
+
+const ALICE_PHRASE = 'correct horse battery staple printer toaster'
+
+async function enrollCodes(db: Noydb, vault: string, count: number, prefix = 'CODE'): Promise<string[]> {
+  const keyring = await db.getKeyring(vault)
+  const codes: string[] = []
+  const entries: PaperRecoveryEntry[] = []
+  for (let i = 0; i < count; i++) {
+    const code = `${prefix}${i.toString().padStart(3, '0')}AAAAAAA`.toUpperCase()
+    codes.push(code)
+    entries.push(await mintPaperRecoveryEntry(keyring.deks, code, `${prefix}-${i}`))
+  }
+  await db.enrollRecovery(vault, { profile: 'paper', entries })
+  return codes
+}
+
+describe('db.rotateRecovery (#121)', () => {
+  it('returns new codes of length matching the existing sheet by default', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await db.openVault('acme')
+    await enrollCodes(db, 'acme', 6)
+
+    const result = await db.rotateRecovery('acme', { profile: 'paper' })
+    expect(result.newCodes).toHaveLength(6)
+    const post = await loadPaperRecoveryEntries(store, 'acme')
+    expect(post).toHaveLength(6)
+  }, 120_000)
+
+  it('count override produces exactly that many codes', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await db.openVault('acme')
+    await enrollCodes(db, 'acme', 8)
+
+    const result = await db.rotateRecovery('acme', { profile: 'paper', count: 12 })
+    expect(result.newCodes).toHaveLength(12)
+    const post = await loadPaperRecoveryEntries(store, 'acme')
+    expect(post).toHaveLength(12)
+  }, 120_000)
+
+  it('replaces (not appends): old codes invalidated, new codes recover', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await db.openVault('acme')
+    const oldCodes = await enrollCodes(db, 'acme', 4)
+
+    const result = await db.rotateRecovery('acme', { profile: 'paper' })
+    // Old codes no longer match any persisted entry — recovery with one should fail.
+    await expect(
+      db.recoverPassphrase('acme', {
+        newPassphrase: 'fresh passphrase after rotation today morning glass tower',
+        recoveryProof: { profile: 'paper', payload: { code: oldCodes[0]! } },
+      }),
+    ).rejects.toThrow()
+
+    // A new code DOES recover.
+    const recovered = await db.recoverPassphrase('acme', {
+      newPassphrase: 'fresh passphrase after rotation today morning glass tower',
+      recoveryProof: { profile: 'paper', payload: { code: result.newCodes[0]! } },
+    })
+    expect(recovered).toBeDefined()
+  }, 180_000)
+
+  it('codeGenerator hook overrides the default ULID format', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await db.openVault('acme')
+    await enrollCodes(db, 'acme', 3)
+
+    let counter = 0
+    const result = await db.rotateRecovery('acme', {
+      profile: 'paper',
+      codeGenerator: () => `CUSTOM-CODE-${counter++}`,
+    })
+    expect(result.newCodes).toEqual(['CUSTOM-CODE-0', 'CUSTOM-CODE-1', 'CUSTOM-CODE-2'])
+  }, 120_000)
+
+  it('PERSONAL policy (default): tier-1 caller can rotate without factors', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: ALICE_PHRASE })
+    await db.openVault('acme')
+    await enrollCodes(db, 'acme', 4)
+
+    // Default PERSONAL_POLICY — rotate-recovery: { minTier: 1 }
+    const result = await db.rotateRecovery('acme', { profile: 'paper' })
+    expect(result.newCodes).toHaveLength(4)
+  }, 120_000)
+
+  it('STRICT policy: rejects rotation without an off-device factor', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: ALICE_PHRASE,
+      policy: STRICT_POLICY,
+    })
+    await db.openVault('acme')
+    await enrollCodes(db, 'acme', 4)
+
+    await expect(
+      db.rotateRecovery('acme', { profile: 'paper' }),
+    ).rejects.toThrow(PolicyDeniedError)
+  }, 120_000)
+
+  it('rejects non-paper profiles (other profiles arrive with #10)', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: ALICE_PHRASE })
+    await db.openVault('acme')
+    await enrollCodes(db, 'acme', 3)
+
+    await expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      db.rotateRecovery('acme', { profile: 'shamir' as any }),
+    ).rejects.toThrow(/RecoveryProfileNotImplementedError|profile/i)
+  }, 120_000)
+
+  it('refuses to rotate when no paper sheet has been enrolled', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: ALICE_PHRASE })
+    await db.openVault('acme')
+    // NO enrollRecovery call — there is nothing to rotate.
+
+    await expect(
+      db.rotateRecovery('acme', { profile: 'paper' }),
+    ).rejects.toThrow(/no recovery codes|nothing to rotate|not enrolled/i)
+  }, 60_000)
+
+  // Suppress unused import warning when generateULID isn't referenced
+  void generateULID
+})

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -32,6 +32,8 @@ import {
   type RotatePassphraseInput,
   type RecoverPassphraseInput,
   type RecoverPassphraseResult,
+  type RotateRecoveryOptions,
+  type RotateRecoveryResult,
 } from './team/rotate-recover.js'
 import {
   recoverUser as keyringRecoverUser,
@@ -45,7 +47,7 @@ import {
   type PaperRecoveryEntry,
 } from './team/recovery.js'
 import { generateULID } from './bundle/ulid.js'
-import { RecoveryNotEnrolledError } from './policy/errors.js'
+import { RecoveryNotEnrolledError, RecoveryProfileNotImplementedError } from './policy/errors.js'
 import {
   describeAuthConfig as fnDescribeAuthConfig,
   diagramAuthConfig as fnDiagramAuthConfig,
@@ -1740,6 +1742,87 @@ export class Noydb {
     }
     // Single replace-all write — `savePaperRecoveryEntries` overwrites
     // `_meta/recovery-paper` atomically (one envelope `put`).
+    await savePaperRecoveryEntries(this.options.store, vault, newEntries)
+
+    return { newCodes: codes }
+  }
+
+  /**
+   * Deliberate paper-recovery-code regeneration (#121). User knows their
+   * passphrase but wants a fresh sheet — they lost the printout or
+   * suspect compromise of the off-site copy.
+   *
+   * Symmetric to {@link rotatePassphrase} for the recovery profile:
+   * gated, audit-trackable, ergonomic. Replaces (not appends) the
+   * paper sheet under `_meta/recovery-paper` in a single envelope `put`.
+   *
+   * Gated by the `rotate-recovery` policy gate:
+   *   - PERSONAL_POLICY: `{ minTier: 1 }` — knowing the passphrase
+   *     suffices, matching the pre-#121 low-level flow's bar.
+   *   - STRICT_POLICY: `{ minTier: 1, factors: [{ anyOf: ['totp',
+   *     'email-otp', 'webauthn-roaming'] }] }` — rotation is an
+   *     off-site-trust event; require an off-device factor so a
+   *     stolen unlocked laptop cannot silently mint a sheet for the
+   *     attacker.
+   *
+   * Defaults `count` to the existing sheet size so consumers aren't
+   * surprised by a different code count. Explicit `count` overrides.
+   *
+   * @throws {@link RecoveryProfileNotImplementedError} when `profile`
+   *         is anything other than `'paper'` (v1 dispatch limit).
+   * @throws {@link PolicyDeniedError} when the gate denies (missing
+   *         factor, tier mismatch, ...).
+   * @throws on missing paper sheet — "nothing to rotate" surfaces as
+   *         an error rather than silently minting an entire new sheet.
+   *
+   * @example Default count + show-once UI
+   * ```ts
+   * const { newCodes } = await db.rotateRecovery('acme', { profile: 'paper' })
+   * showCodesToUser(newCodes)
+   * ```
+   *
+   * @example STRICT-policy site with TOTP factor proof
+   * ```ts
+   * await db.rotateRecovery(
+   *   'acme',
+   *   { profile: 'paper', count: 10 },
+   *   { factors: [{ kind: 'totp', proof: '123456' }] },
+   * )
+   * ```
+   */
+  async rotateRecovery(
+    vault: string,
+    options: RotateRecoveryOptions,
+    factors?: FactorProofBundle,
+  ): Promise<RotateRecoveryResult> {
+    if (options.profile !== 'paper') {
+      throw new RecoveryProfileNotImplementedError(options.profile, '#10')
+    }
+    await this.checkGate(vault, 'rotate-recovery', factors)
+
+    const existing = await loadPaperRecoveryEntries(this.options.store, vault)
+    if (existing.length === 0) {
+      throw new Error(
+        `db.rotateRecovery: no recovery codes are enrolled for vault "${vault}". ` +
+        `Call db.enrollRecovery({ profile: 'paper', entries }) first; ` +
+        `rotateRecovery replaces an existing sheet rather than minting one from scratch.`,
+      )
+    }
+
+    const keyring = await this.getKeyring(vault)
+    const codeGen = options.codeGenerator ?? generateULID
+    const count = options.count ?? existing.length
+
+    const codes: string[] = []
+    const newEntries: PaperRecoveryEntry[] = []
+    for (let i = 0; i < count; i++) {
+      const rawCode = codeGen()
+      const entry = await mintPaperRecoveryEntry(keyring.deks, rawCode, generateULID())
+      codes.push(rawCode)
+      newEntries.push(entry)
+    }
+    // Atomic replace — `savePaperRecoveryEntries` overwrites
+    // `_meta/recovery-paper` in a single envelope `put`.
     await savePaperRecoveryEntries(this.options.store, vault, newEntries)
 
     return { newCodes: codes }

--- a/packages/hub/src/policy/presets.ts
+++ b/packages/hub/src/policy/presets.ts
@@ -39,6 +39,10 @@ export const PERSONAL_POLICY: VaultPolicy = Object.freeze({
       minTier: 1,
       enabled: true,
     },
+    // rotate-recovery (#121): deliberate paper-sheet regeneration
+    // when the user remembers their passphrase. PERSONAL matches the
+    // pre-#121 low-level flow's bar — knowing the passphrase is enough.
+    'rotate-recovery': { minTier: 1 },
     'enroll-authenticator': { minTier: 1 },
     'remove-authenticator': { minTier: 1 },
     // update-authenticator: meta-only mutation (slot rename, label
@@ -105,6 +109,14 @@ export const STRICT_POLICY: VaultPolicy = Object.freeze({
     'recover-passphrase': {
       minTier: 1,
       enabled: true,
+    },
+    // rotate-recovery (#121): STRICT requires an off-device factor —
+    // rotating recovery is an off-site-trust event; a stolen unlocked
+    // laptop must not be able to silently mint a new sheet for the
+    // attacker. Matches the `peer-recover-user` STRICT default.
+    'rotate-recovery': {
+      minTier: 1,
+      factors: [{ anyOf: ['totp', 'email-otp', 'webauthn-roaming'] }],
     },
     'enroll-authenticator': {
       minTier: 1,

--- a/packages/hub/src/policy/types.ts
+++ b/packages/hub/src/policy/types.ts
@@ -98,6 +98,16 @@ export type BuiltInGateName =
   | 'enroll-authenticator'
   | 'remove-authenticator'
   /**
+   * Authorize a deliberate paper-recovery-code regeneration —
+   * `db.rotateRecovery` (#121). Symmetric to `rotate-passphrase` for
+   * the case where the user remembers their passphrase but wants a
+   * fresh sheet (lost the printout, suspect compromise of the off-site
+   * copy). PERSONAL allows tier-1; STRICT requires an off-device
+   * factor so a stolen unlocked laptop cannot silently mint a new
+   * sheet for an attacker.
+   */
+  | 'rotate-recovery'
+  /**
    * Authorize a meta-only mutation on an existing authenticator slot —
    * `db.updateAuthenticator` (#55). The slot's wrap material, id, and
    * method are immutable through this gate; only the `meta` blob

--- a/packages/hub/src/team/rotate-recover.ts
+++ b/packages/hub/src/team/rotate-recover.ts
@@ -337,6 +337,38 @@ export interface RecoverPassphraseResult {
 }
 
 /**
+ * Input for {@link Noydb.rotateRecovery} (#121) — deliberate
+ * paper-recovery-code regeneration when the user knows their
+ * passphrase but wants a fresh sheet. Symmetric to
+ * {@link RotatePassphraseInput} for the recovery profile.
+ */
+export interface RotateRecoveryOptions {
+  /**
+   * Recovery profile to rotate. v0.1.0-pre.5 supports `'paper'`
+   * end-to-end; the other three profiles throw
+   * {@link RecoveryProfileNotImplementedError} (dispatch arrives with #10).
+   */
+  readonly profile: 'paper'
+  /**
+   * How many fresh codes to mint. Default: the existing sheet size,
+   * so consumers aren't surprised by a different code count after
+   * rotation. Explicit `count` overrides.
+   */
+  readonly count?: number
+  /**
+   * Optional code generator — mirrors
+   * {@link RecoverPassphraseInput.codeGenerator}. When omitted the
+   * implementation uses `generateULID()` (Crockford-base32, 26 chars).
+   */
+  readonly codeGenerator?: () => string
+}
+
+/** Result of {@link Noydb.rotateRecovery} — the show-once codes for the UI. */
+export interface RotateRecoveryResult {
+  readonly newCodes: readonly string[]
+}
+
+/**
  * Reset the user's passphrase using a recovery proof. v0.1.0-pre.5
  * supports the `'paper'` profile via `@noy-db/on-recovery` entries
  * persisted in `_meta/recovery-paper`. The other three profiles throw


### PR DESCRIPTION
Closes #121.

## Summary

Adds a high-level method for **deliberate** paper-recovery-code regeneration — when the user remembers their passphrase but wants a fresh sheet (lost printout, suspect compromise of the off-site copy). Symmetric to the other tier-1-modifying actions: gated, audit-trackable, ergonomic.

| Action | Public API | Policy gate |
|---|---|---|
| Passphrase rotation | \`db.rotatePassphrase\` | \`rotate-passphrase\` |
| Passphrase recovery | \`db.recoverPassphrase\` | \`recover-passphrase\` |
| Authenticator enroll/remove | \`db.enrollAuthenticator\` / \`db.removeAuthenticator\` | \`enroll-authenticator\` / \`remove-authenticator\` |
| **Recovery rotation** | **\`db.rotateRecovery\`** (NEW) | **\`rotate-recovery\`** (NEW) |

## Before / After

**Before — bypasses the policy DSL:**
\`\`\`ts
import { savePaperRecoveryEntries } from '@noy-db/hub'
import { generateRecoveryCodeSet } from '@noy-db/on-recovery'

const keyring = await db.getKeyring(vault)
const { codes, entries } = await generateRecoveryCodeSet({ deks: keyring.deks, count: 8 })
await savePaperRecoveryEntries(db.options.store, vault, entries)
showCodesToUser(codes)
\`\`\`

**After — gated, ergonomic:**
\`\`\`ts
const { newCodes } = await db.rotateRecovery('acme', { profile: 'paper' })
showCodesToUser(newCodes)
\`\`\`

## Policy semantics

- \`PERSONAL_POLICY\`: \`{ minTier: 1 }\` — knowing the passphrase suffices, matches the pre-#121 low-level flow's bar.
- \`STRICT_POLICY\`: \`{ minTier: 1, factors: [{ anyOf: ['totp', 'email-otp', 'webauthn-roaming'] }] }\` — rotation is an off-site-trust event; a stolen unlocked laptop must not be able to silently mint a new sheet for the attacker. Matches the \`peer-recover-user\` STRICT default.

## Implementation details

- Default \`count\` reads the existing entry count — consumers aren't surprised by a different sheet size. Explicit \`count\` overrides.
- "Nothing to rotate" (no paper sheet enrolled) surfaces as an error rather than silently minting an entire new sheet from scratch — protects against accidental "first rotation."
- Non-paper profiles throw \`RecoveryProfileNotImplementedError\` with tracking ref \`#10\` (same dispatch as \`enrollRecovery\` / \`recoverPassphrase\`).
- Atomic replace via \`savePaperRecoveryEntries\` — single envelope put.
- Low-level \`savePaperRecoveryEntries\` / \`mintPaperRecoveryEntry\` exports stay — still useful for migration scripts and tests. The high-level API is additive, not a replacement.

## Tests

+8 tests in \`__tests__/rotate-recovery.test.ts\`:

| Behavior |
|---|
| Returns codes of length matching the existing sheet (default) |
| \`count\` override produces exactly that many codes |
| Replaces (not appends) — old codes invalid; new codes recover |
| \`codeGenerator\` hook overrides the default ULID format |
| PERSONAL policy: tier-1 caller can rotate without factors |
| STRICT policy: rejects rotation without an off-device factor |
| Rejects non-paper profiles with \`RecoveryProfileNotImplementedError\` |
| Refuses to rotate when no paper sheet has been enrolled |

Full hub suite: **1650/1651** passing (+8 from this PR; +1 pre-existing \`it.todo\` from pre.14, separately tracked as #181). Typecheck clean; lint 0 errors (warnings predate).

## Deferred from the issue

- Auto-rotation hook into \`enrollAuthenticator\` ("should adding a passkey re-mint the paper sheet?") — separate decision, file separately if desired.
- Shamir / multi-channel / admin-mediated profiles — same dispatch as \`enrollRecovery\`; arrive with #10.

## Test plan

- [x] \`pnpm vitest run --filter @noy-db/hub\` — 1650/1651 pass
- [x] \`pnpm turbo typecheck --filter @noy-db/hub\` — clean
- [x] \`pnpm turbo lint --filter @noy-db/hub\` — 0 errors