### PR TITLE
feat(hub): managed-passphrase mode v1 — SealingKeyProvider + sealed envelope (#14 slice 1)

### DIFF
--- a/packages/hub/__tests__/managed-passphrase.test.ts
+++ b/packages/hub/__tests__/managed-passphrase.test.ts
@@ -1,0 +1,229 @@
+/**
+ * #14 — Managed-passphrase mode (rubber-hose resistant).
+ *
+ * A vault mode where the passphrase is machine-generated and never
+ * exposed to the user, sealed under a developer-provided key store
+ * (macOS Keychain / Windows Credential Manager / libsecret / cloud KMS).
+ * The user has no secret to give up to coercion.
+ *
+ * Slice 1 of the issue's full scope. Deferred to follow-ups:
+ *   - Block rotate-passphrase under managed mode (policy gate override).
+ *   - Mandatory strong-recovery enforcement at creation (depends on #10).
+ *   - Recovery-under-managed flow that generates a fresh sealed phrase.
+ *   - Concrete providers (macOS Keychain, etc.) live outside hub.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope } from '../src/types.js'
+import { createNoydb } from '../src/noydb.js'
+import { ConflictError, ValidationError } from '../src/errors.js'
+import {
+  MemorySealingKeyProvider,
+  loadSealedPassphrase,
+  saveSealedPassphrase,
+  SEALED_PASSPHRASE_RECORD_ID,
+  type SealingKeyProvider,
+} from '../src/team/managed-passphrase.js'
+
+function inlineMemory(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const gc = (v: string, c: string) => {
+    let comp = data.get(v); if (!comp) { comp = new Map(); data.set(v, comp) }
+    let coll = comp.get(c); if (!coll) { coll = new Map(); comp.set(c, coll) }
+    return coll
+  }
+  return {
+    async get(v, c, id) { return gc(v, c).get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = gc(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { gc(v, c).delete(id) },
+    async list(v, c) { return [...gc(v, c).keys()] },
+    async loadAll() { return {} },
+    async saveAll() {},
+  }
+}
+
+interface Note extends Record<string, unknown> { id: string; body: string }
+
+describe('SealingKeyProvider — contract', () => {
+  it('seal → unseal round-trip yields identical bytes', async () => {
+    const provider = new MemorySealingKeyProvider({ id: 'test-1' })
+    const passphrase = new TextEncoder().encode('hunter2 garden palace cushion bridge')
+    const sealed = await provider.seal(passphrase)
+    expect(sealed).not.toEqual(passphrase) // sealed bytes differ from plaintext
+    const unsealed = await provider.unseal(sealed)
+    expect(new TextDecoder().decode(unsealed)).toBe('hunter2 garden palace cushion bridge')
+  })
+
+  it('different providers cannot unseal each other', async () => {
+    const a = new MemorySealingKeyProvider({ id: 'a' })
+    const b = new MemorySealingKeyProvider({ id: 'b' })
+    const sealed = await a.seal(new TextEncoder().encode('secret-A'))
+    await expect(b.unseal(sealed)).rejects.toThrow()
+  })
+
+  it('provider.id is the disclosed (non-sensitive) identifier', () => {
+    const p: SealingKeyProvider = new MemorySealingKeyProvider({ id: 'macos-keychain:com.example.app' })
+    expect(p.id).toBe('macos-keychain:com.example.app')
+  })
+})
+
+describe('_meta/sealed-passphrase envelope storage', () => {
+  it('round-trips a sealed-passphrase envelope through the store', async () => {
+    const store = inlineMemory()
+    const sealed = new Uint8Array([0xDE, 0xAD, 0xBE, 0xEF])
+    await saveSealedPassphrase(store, 'acme', { providerId: 'p-1', sealed })
+    const loaded = await loadSealedPassphrase(store, 'acme')
+    expect(loaded?.providerId).toBe('p-1')
+    expect(Array.from(loaded?.sealed ?? [])).toEqual([0xDE, 0xAD, 0xBE, 0xEF])
+  })
+
+  it('returns undefined when nothing has been persisted', async () => {
+    const store = inlineMemory()
+    expect(await loadSealedPassphrase(store, 'acme')).toBeUndefined()
+  })
+
+  it('uses the reserved record id `sealed-passphrase` under _meta', async () => {
+    expect(SEALED_PASSPHRASE_RECORD_ID).toBe('sealed-passphrase')
+    const store = inlineMemory()
+    const sealed = new Uint8Array([1, 2, 3])
+    await saveSealedPassphrase(store, 'acme', { providerId: 'p-1', sealed })
+    // Envelope is reachable via the standard _meta path.
+    const env = await store.get('acme', '_meta', 'sealed-passphrase')
+    expect(env).not.toBeNull()
+  })
+})
+
+describe('createNoydb({ passphraseMode: "managed" }) — slice 1', () => {
+  let store: NoydbStore
+  let provider: MemorySealingKeyProvider
+
+  beforeEach(() => {
+    store = inlineMemory()
+    provider = new MemorySealingKeyProvider({ id: 'test-keychain' })
+  })
+
+  it('rejects managed mode without a sealingKey', async () => {
+    await expect(
+      createNoydb({ store, user: 'alice', passphraseMode: 'managed' }),
+    ).rejects.toThrow(ValidationError)
+  })
+
+  it('rejects managed mode combined with secret', async () => {
+    await expect(
+      createNoydb({
+        store, user: 'alice',
+        secret: 'should-not-be-here',
+        passphraseMode: 'managed',
+        sealingKey: provider,
+      }),
+    ).rejects.toThrow(ValidationError)
+  })
+
+  it('rejects managed mode combined with getKeyring', async () => {
+    await expect(
+      createNoydb({
+        store, user: 'alice',
+        passphraseMode: 'managed',
+        sealingKey: provider,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        getKeyring: (async () => ({} as any)) as never,
+      }),
+    ).rejects.toThrow(ValidationError)
+  })
+
+  it('first openVault generates a random passphrase, seals it, and persists', async () => {
+    const db = await createNoydb({
+      store, user: 'alice',
+      passphraseMode: 'managed',
+      sealingKey: provider,
+    })
+    await db.openVault('acme')
+    const loaded = await loadSealedPassphrase(store, 'acme')
+    expect(loaded).toBeDefined()
+    expect(loaded!.providerId).toBe('test-keychain')
+    expect(loaded!.sealed.byteLength).toBeGreaterThan(0)
+  })
+
+  it('reopening reuses the persisted sealed passphrase (no new random generated)', async () => {
+    // First open — establishes the sealed envelope.
+    const db1 = await createNoydb({
+      store, user: 'alice',
+      passphraseMode: 'managed',
+      sealingKey: provider,
+    })
+    await db1.openVault('acme')
+    const sealed1 = (await loadSealedPassphrase(store, 'acme'))!.sealed
+    db1.close()
+
+    // Second open — same sealing provider, same store, must unseal + reuse.
+    const db2 = await createNoydb({
+      store, user: 'alice',
+      passphraseMode: 'managed',
+      sealingKey: provider,
+    })
+    await db2.openVault('acme')
+    const sealed2 = (await loadSealedPassphrase(store, 'acme'))!.sealed
+    expect(Array.from(sealed2)).toEqual(Array.from(sealed1))
+    db2.close()
+  })
+
+  it('round-trips records under managed mode (proves the unsealed phrase actually works)', async () => {
+    const db = await createNoydb({
+      store, user: 'alice',
+      passphraseMode: 'managed',
+      sealingKey: provider,
+    })
+    const vault = await db.openVault('acme')
+    const notes = vault.collection<Note>('notes')
+    await notes.put('n1', { id: 'n1', body: 'managed-mode record' })
+    db.close()
+
+    const db2 = await createNoydb({
+      store, user: 'alice',
+      passphraseMode: 'managed',
+      sealingKey: provider,
+    })
+    const vault2 = await db2.openVault('acme')
+    const notes2 = vault2.collection<Note>('notes')
+    expect(await notes2.get('n1')).toEqual({ id: 'n1', body: 'managed-mode record' })
+    db2.close()
+  })
+
+  it('db.rotatePassphrase throws PolicyDeniedError under managed mode', async () => {
+    const db = await createNoydb({
+      store, user: 'alice',
+      passphraseMode: 'managed',
+      sealingKey: provider,
+    })
+    await db.openVault('acme')
+    await expect(
+      db.rotatePassphrase('acme', {
+        oldPassphrase: 'irrelevant — user does not know it',
+        newPassphrase: 'also-irrelevant-but-policy-fires-first',
+        allowWeakPassphrase: true,
+      }),
+    ).rejects.toThrowError(/managed-passphrase mode|disabled/i)
+  })
+
+  it('a different sealing provider rejects the persisted envelope', async () => {
+    const db = await createNoydb({
+      store, user: 'alice',
+      passphraseMode: 'managed',
+      sealingKey: provider,
+    })
+    await db.openVault('acme')
+    db.close()
+
+    // Different provider id → unseal fails → reopen throws
+    const wrongProvider = new MemorySealingKeyProvider({ id: 'different-keychain' })
+    const db2 = await createNoydb({
+      store, user: 'alice',
+      passphraseMode: 'managed',
+      sealingKey: wrongProvider,
+    })
+    await expect(db2.openVault('acme')).rejects.toThrow()
+  })
+})

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -455,6 +455,19 @@ export type { PaperRecoveryEntry, PaperRecoveryDoc } from './team/recovery.js'
 export { mintWrappedDeksBlob, unwrapDeksFromBlob } from './team/wrapped-deks.js'
 export type { WrappedDeksBlob } from './team/wrapped-deks.js'
 
+// Managed-passphrase mode (#14) — rubber-hose-resistant vaults where
+// hub generates the passphrase and seals it under a developer-provided
+// SealingKeyProvider. The interface lives here; concrete providers
+// (macOS Keychain, Windows Credential Manager, libsecret, AWS KMS)
+// ship as separate packages.
+export type { SealingKeyProvider, SealedPassphrase } from './team/managed-passphrase.js'
+export {
+  MemorySealingKeyProvider,
+  loadSealedPassphrase,
+  saveSealedPassphrase,
+  SEALED_PASSPHRASE_RECORD_ID,
+} from './team/managed-passphrase.js'
+
 // Peer-recovery — issues #33 + #34 (atomic db.recoverUser primitive).
 // The team/peer-recover module also runs through Noydb.recoverUser for
 // the policy-gated path; consumers can use the lower-level function

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -46,8 +46,9 @@ import {
   mintPaperRecoveryEntry,
   type PaperRecoveryEntry,
 } from './team/recovery.js'
+import { resolveManagedSecret } from './team/managed-passphrase.js'
 import { generateULID } from './bundle/ulid.js'
-import { RecoveryNotEnrolledError, RecoveryProfileNotImplementedError } from './policy/errors.js'
+import { RecoveryNotEnrolledError, RecoveryProfileNotImplementedError, PolicyDeniedError } from './policy/errors.js'
 import {
   describeAuthConfig as fnDescribeAuthConfig,
   diagramAuthConfig as fnDiagramAuthConfig,
@@ -1684,6 +1685,25 @@ export class Noydb {
     input: RotatePassphraseInput,
     factors?: FactorProofBundle,
   ): Promise<void> {
+    // Managed-passphrase mode (#14): the user does NOT know the
+    // current passphrase (hub generated it and sealed it under the
+    // provider). Manual rotation via this method is impossible by
+    // construction — surface a clear error rather than fail mid-way
+    // with InvalidKeyError once `oldPassphrase` doesn't match the
+    // hub-generated one. Recovery-under-managed (which mints a fresh
+    // sealed passphrase via the provider) is the supported path; it
+    // lands in a follow-up.
+    if (this.options.passphraseMode === 'managed') {
+      throw new PolicyDeniedError(
+        'rotate-passphrase',
+        'disabled',
+        { minTier: 1, enabled: false },
+        'Managed-passphrase mode (#14): the passphrase is hub-generated '
+        + 'and sealed under the SealingKeyProvider — there is no '
+        + 'plaintext to rotate. Use the recovery flow (follow-up issue) '
+        + 'to mint a fresh sealed passphrase.',
+      )
+    }
     await this.checkGate(vault, 'rotate-passphrase', factors)
     const userId = this.options.user
     const next = await keyringRotatePassphrase(this.options.store, vault, userId, input)
@@ -2070,13 +2090,31 @@ export class Noydb {
       return keyring
     }
 
-    if (!this.options.secret) {
+    // Managed-passphrase mode (#14) — resolve the effective secret
+    // before falling into the normal load/create path. The first call
+    // mints + seals + persists; subsequent calls unseal what's there.
+    // The returned string takes the place of `options.secret` for the
+    // rest of this method (and is NOT persisted on `this.options`).
+    let effectiveSecret: string | undefined
+    if (this.options.passphraseMode === 'managed') {
+      // sealingKey presence was validated at createNoydb time.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      effectiveSecret = await resolveManagedSecret(
+        this.options.store,
+        vault,
+        this.options.sealingKey!,
+      )
+    } else {
+      effectiveSecret = this.options.secret
+    }
+
+    if (!effectiveSecret) {
       throw new ValidationError('A secret (passphrase) or getKeyring callback is required when encryption is enabled')
     }
 
     let keyring: UnlockedKeyring
     try {
-      keyring = await loadKeyring(this.options.store, vault, this.options.user, this.options.secret)
+      keyring = await loadKeyring(this.options.store, vault, this.options.user, effectiveSecret)
     } catch (err) {
       if (err instanceof NoAccessError) {
         // No keyring on disk — first boot or cleared store.
@@ -2084,8 +2122,16 @@ export class Noydb {
           this.options.store,
           vault,
           this.options.user,
-          this.options.secret,
-          { validate: this.options.validatePassphrase === true },
+          effectiveSecret,
+          {
+            // Managed mode generates 256-bit base64 strings that don't satisfy
+            // the human-passphrase strength rules (no spaces, no "words").
+            // Skip validation in managed mode — the entropy floor is already
+            // 256 bits by construction.
+            validate: this.options.passphraseMode === 'managed'
+              ? false
+              : this.options.validatePassphrase === true,
+          },
         )
       } else if (err instanceof InvalidKeyError && this.options.onInvalidKey === 'reset') {
         // Stale keyring: exists in the store but the current credentials can't
@@ -2097,8 +2143,12 @@ export class Noydb {
           this.options.store,
           vault,
           this.options.user,
-          this.options.secret,
-          { validate: this.options.validatePassphrase === true },
+          effectiveSecret,
+          {
+            validate: this.options.passphraseMode === 'managed'
+              ? false
+              : this.options.validatePassphrase === true,
+          },
         )
       } else {
         throw err
@@ -2113,12 +2163,38 @@ export class Noydb {
 /** Create a new NOYDB instance. */
 export async function createNoydb(options: NoydbOptions): Promise<Noydb> {
   const encrypted = options.encrypt !== false
+  const managed = options.passphraseMode === 'managed'
 
   if (options.secret && options.getKeyring) {
     throw new ValidationError('Provide either `secret` or `getKeyring`, not both')
   }
 
-  if (encrypted && !options.secret && !options.getKeyring) {
+  // Managed-passphrase mode (#14) — mutually exclusive with both
+  // `secret` (the whole point is hub generates and seals; the user
+  // doesn't supply one) and `getKeyring` (a custom unlock path that
+  // bypasses the sealing flow entirely). Requires a SealingKeyProvider.
+  if (managed) {
+    if (options.secret) {
+      throw new ValidationError(
+        '`passphraseMode: "managed"` is mutually exclusive with `secret` — '
+        + 'managed mode generates the passphrase itself. Drop `secret`.',
+      )
+    }
+    if (options.getKeyring) {
+      throw new ValidationError(
+        '`passphraseMode: "managed"` is mutually exclusive with `getKeyring` — '
+        + 'a custom unlock callback would bypass the sealing flow. Drop `getKeyring`.',
+      )
+    }
+    if (!options.sealingKey) {
+      throw new ValidationError(
+        '`passphraseMode: "managed"` requires `sealingKey: SealingKeyProvider` '
+        + '(see @noy-db/seal-macos-keychain / @noy-db/seal-aws-kms / etc.).',
+      )
+    }
+  }
+
+  if (encrypted && !managed && !options.secret && !options.getKeyring) {
     throw new ValidationError('A secret (passphrase) or getKeyring callback is required when encryption is enabled')
   }
 

--- a/packages/hub/src/team/managed-passphrase.ts
+++ b/packages/hub/src/team/managed-passphrase.ts
@@ -1,0 +1,273 @@
+/**
+ * Managed-passphrase mode — issue #14, rubber-hose-resistant vaults.
+ *
+ * A vault mode where the passphrase is machine-generated and never
+ * exposed to the user, sealed under a developer-provided
+ * {@link SealingKeyProvider} (macOS Keychain, Windows Credential
+ * Manager, libsecret, AWS KMS, …). The user has no secret to give
+ * up to coercion — they can't reveal what they don't know.
+ *
+ * ## Components in this file
+ *
+ *   - {@link SealingKeyProvider} — the interface concrete providers
+ *     implement. Provider implementations live OUTSIDE hub (per-
+ *     platform packages).
+ *   - {@link MemorySealingKeyProvider} — in-memory test provider; uses
+ *     a deterministic per-instance "key" so two providers with
+ *     different ids cannot unseal each other's outputs.
+ *   - {@link loadSealedPassphrase} / {@link saveSealedPassphrase} —
+ *     plaintext envelope storage at `_meta/sealed-passphrase`.
+ *     Mirrors the `_meta/handle` and `_meta/public-envelope` AES-
+ *     GCM-bypassed patterns. The sealing layer (provider's job)
+ *     is the security boundary; hub doesn't have a key to encrypt
+ *     with at this layer — that's the whole point of the design.
+ *   - {@link resolveManagedSecret} — orchestrates the "generate +
+ *     seal + persist on first open; unseal on reopen" flow.
+ *     Returns the plaintext passphrase string that the rest of the
+ *     `createNoydb` keyring path consumes.
+ *
+ * Slice 1 of #14. Deferred to follow-ups:
+ *   - Block `rotate-passphrase` policy gate under managed mode.
+ *   - Mandatory strong-recovery enforcement (depends on #10).
+ *   - Recovery flow under managed mode (generates fresh sealed phrase).
+ *
+ * @see docs/subsystems/session-tiers.md → Managed-passphrase mode
+ *
+ * @module
+ */
+
+import type { NoydbStore, EncryptedEnvelope } from '../types.js'
+import { NOYDB_FORMAT_VERSION } from '../types.js'
+
+/**
+ * The contract concrete providers (per-platform key stores) implement
+ * to seal and unseal a hub-generated random passphrase. The plaintext
+ * passphrase NEVER leaves hub-controlled memory in unsealed form —
+ * the provider receives the bytes, returns opaque sealed bytes, and
+ * later reverses the operation. Hub treats the sealed bytes as
+ * fully opaque.
+ *
+ * Implementations live OUTSIDE `@noy-db/hub` (separate packages
+ * per the issue's "Concrete providers (live outside hub)" note):
+ *
+ * | Platform | Package (TBD) | Backing |
+ * |---|---|---|
+ * | macOS | `@noy-db/seal-macos-keychain` | Security.framework |
+ * | Windows | `@noy-db/seal-wincred` | Credential Manager |
+ * | Linux | `@noy-db/seal-libsecret` | libsecret / secret-service |
+ * | Cloud / server | `@noy-db/seal-aws-kms` | AWS KMS Decrypt |
+ */
+export interface SealingKeyProvider {
+  /**
+   * Non-sensitive identifier disclosed in the persisted envelope.
+   * Surfaced to consumers via `loadSealedPassphrase().providerId` so
+   * a vault opened with the wrong provider class can detect the
+   * mismatch and surface a clear error. NOT secret — fine to log.
+   *
+   * Suggested format: `<family>:<scope>` — e.g. `macos-keychain:com.acme.app`,
+   * `aws-kms:arn:aws:kms:us-east-1:123:key/abc`. The hub never
+   * parses this; it's purely audit metadata.
+   */
+  readonly id: string
+
+  /** Seal raw passphrase bytes. Output bytes are opaque to hub. */
+  seal(passphrase: Uint8Array): Promise<Uint8Array>
+
+  /**
+   * Reverse {@link seal}. MUST throw on tamper, wrong-provider, or
+   * any other failure — hub treats a thrown error as "this provider
+   * cannot unlock this vault" and surfaces it to the caller.
+   */
+  unseal(sealed: Uint8Array): Promise<Uint8Array>
+}
+
+/**
+ * In-memory test provider. NOT secure — uses a deterministic
+ * per-instance "key" (16-byte SHA-256 of `id`) XOR'd over the
+ * passphrase plus a 4-byte provider-id fingerprint prefix. The XOR is
+ * sufficient to make different `id` values produce mutually-unsealable
+ * outputs (the contract tests for that), but offers ZERO real
+ * confidentiality — never use outside tests.
+ *
+ * Replace with a real platform provider in production.
+ */
+export class MemorySealingKeyProvider implements SealingKeyProvider {
+  readonly id: string
+  private readonly fingerprint: Uint8Array
+  private readonly keyBytes: Uint8Array
+
+  constructor(opts: { id: string }) {
+    this.id = opts.id
+    // Deterministic 4-byte fingerprint of the provider id, prepended
+    // to every sealed output so we can detect "wrong provider" at
+    // unseal time without leaking anything sensitive about either
+    // provider's actual key material.
+    const encoded = new TextEncoder().encode(opts.id)
+    let h = 0
+    for (let i = 0; i < encoded.length; i++) {
+      h = (h * 31 + encoded[i]!) >>> 0
+    }
+    this.fingerprint = new Uint8Array([
+      (h >>> 24) & 0xff, (h >>> 16) & 0xff, (h >>> 8) & 0xff, h & 0xff,
+    ])
+    // Deterministic 16-byte "key" derived from the id by repeating
+    // the fingerprint with offsets. Good enough for the XOR-stream
+    // test cipher; never confuse this with real key derivation.
+    this.keyBytes = new Uint8Array(16)
+    for (let i = 0; i < 16; i++) {
+      this.keyBytes[i] = this.fingerprint[i % 4]! ^ (i * 17)
+    }
+  }
+
+  async seal(passphrase: Uint8Array): Promise<Uint8Array> {
+    const out = new Uint8Array(4 + passphrase.length)
+    out.set(this.fingerprint, 0)
+    for (let i = 0; i < passphrase.length; i++) {
+      out[4 + i] = passphrase[i]! ^ this.keyBytes[i % 16]!
+    }
+    return out
+  }
+
+  async unseal(sealed: Uint8Array): Promise<Uint8Array> {
+    if (sealed.length < 4) {
+      throw new Error('MemorySealingKeyProvider: sealed input too short')
+    }
+    for (let i = 0; i < 4; i++) {
+      if (sealed[i] !== this.fingerprint[i]) {
+        throw new Error(
+          `MemorySealingKeyProvider("${this.id}"): provider-id mismatch on unseal `
+          + '(sealed bytes were produced by a different provider)',
+        )
+      }
+    }
+    const body = sealed.subarray(4)
+    const out = new Uint8Array(body.length)
+    for (let i = 0; i < body.length; i++) {
+      out[i] = body[i]! ^ this.keyBytes[i % 16]!
+    }
+    return out
+  }
+}
+
+// ─── Persisted envelope ────────────────────────────────────────────────
+
+/** Reserved id for the managed-passphrase envelope under `_meta`. */
+export const SEALED_PASSPHRASE_RECORD_ID = 'sealed-passphrase' as const
+
+/** Plaintext payload stored inside the `_meta/sealed-passphrase` envelope. */
+export interface SealedPassphrase {
+  readonly _noydb_sealed: 1
+  readonly providerId: string
+  /** Sealed bytes. Base64-encoded on the wire; decoded on load. */
+  readonly sealed: Uint8Array
+}
+
+interface PersistedShape {
+  readonly _noydb_sealed: 1
+  readonly providerId: string
+  readonly sealed: string // base64
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]!)
+  return btoa(binary)
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64)
+  const out = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i)
+  return out
+}
+
+export async function saveSealedPassphrase(
+  store: NoydbStore,
+  vault: string,
+  payload: { readonly providerId: string; readonly sealed: Uint8Array },
+): Promise<void> {
+  const persisted: PersistedShape = {
+    _noydb_sealed: 1,
+    providerId: payload.providerId,
+    sealed: bytesToBase64(payload.sealed),
+  }
+  const prior = await store.get(vault, '_meta', SEALED_PASSPHRASE_RECORD_ID)
+  const env: EncryptedEnvelope = {
+    _noydb: NOYDB_FORMAT_VERSION,
+    _v: (prior?._v ?? 0) + 1,
+    _ts: new Date().toISOString(),
+    // AES-GCM bypassed — the sealing layer is the security boundary.
+    _iv: '',
+    _data: JSON.stringify(persisted),
+  }
+  await store.put(vault, '_meta', SEALED_PASSPHRASE_RECORD_ID, env)
+}
+
+export async function loadSealedPassphrase(
+  store: NoydbStore,
+  vault: string,
+): Promise<SealedPassphrase | undefined> {
+  const envelope = await store.get(vault, '_meta', SEALED_PASSPHRASE_RECORD_ID)
+  if (!envelope) return undefined
+  try {
+    const parsed = JSON.parse(envelope._data) as PersistedShape
+    if (parsed._noydb_sealed !== 1) return undefined
+    return {
+      _noydb_sealed: 1,
+      providerId: parsed.providerId,
+      sealed: base64ToBytes(parsed.sealed),
+    }
+  } catch {
+    return undefined
+  }
+}
+
+// ─── createNoydb orchestration ─────────────────────────────────────────
+
+/**
+ * Resolve the effective plaintext passphrase string for a managed-mode
+ * vault. Two paths:
+ *
+ *   1. **First open (no envelope persisted):** generate a 256-bit random
+ *      via `crypto.getRandomValues`, base64-encode for use as a
+ *      passphrase string, seal the underlying bytes under the
+ *      provider, persist `_meta/sealed-passphrase`, return the
+ *      base64 string.
+ *
+ *   2. **Reopen (envelope exists):** read + unseal + decode → return.
+ *      A different provider whose `seal` output disagrees on the
+ *      stored bytes throws here, surfaced as a clear error.
+ *
+ * The returned string is the same shape that `secret:` would take in
+ * standard mode — the rest of the keyring path consumes it
+ * unchanged.
+ *
+ * @internal — called from `createNoydb` / `getKeyringInternal`.
+ */
+export async function resolveManagedSecret(
+  store: NoydbStore,
+  vault: string,
+  provider: SealingKeyProvider,
+): Promise<string> {
+  const existing = await loadSealedPassphrase(store, vault)
+  if (existing) {
+    if (existing.providerId !== provider.id) {
+      throw new Error(
+        `Managed-mode vault "${vault}" was sealed under provider id `
+        + `"${existing.providerId}" but the current SealingKeyProvider is `
+        + `"${provider.id}". Pass the same provider that originally enrolled `
+        + 'the vault, or treat this as a fresh enrollment and clear '
+        + '`_meta/sealed-passphrase` first.',
+      )
+    }
+    const plaintext = await provider.unseal(existing.sealed)
+    return bytesToBase64(plaintext)
+  }
+
+  // First open: mint a 256-bit random, seal, persist.
+  const random = new Uint8Array(32)
+  globalThis.crypto.getRandomValues(random)
+  const sealed = await provider.seal(random)
+  await saveSealedPassphrase(store, vault, { providerId: provider.id, sealed })
+  return bytesToBase64(random)
+}

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -44,6 +44,7 @@ import type { VaultPolicy } from './policy/types.js'
 import type { PublicEnvelopeSchema } from './meta/public-envelope/types.js'
 import type { MaterializedViewStrategyHandle } from './materialized-views/types.js'
 import type { OverlayedViewStrategyHandle } from './overlay-views/types.js'
+import type { SealingKeyProvider } from './team/managed-passphrase.js'
 
 /** Format version for encrypted record envelopes. */
 export const NOYDB_FORMAT_VERSION = 1 as const
@@ -1818,6 +1819,29 @@ export interface NoydbOptions {
    * subsequent sessions.
    */
   readonly getKeyring?: (vault: string) => Promise<UnlockedKeyring>
+  /**
+   * Passphrase mode (#14). Default `'standard'`.
+   *
+   *   - `'standard'` — the legacy flow. `secret` supplies the
+   *     plaintext passphrase, the user knows it, and the policy gate
+   *     `rotate-passphrase` is enabled.
+   *   - `'managed'` — rubber-hose-resistant mode. Hub generates a
+   *     256-bit random passphrase at first open and seals it under
+   *     the provided `sealingKey`. The user never sees or types the
+   *     passphrase, defeating the $5-wrench attack. Mutually
+   *     exclusive with `secret` and `getKeyring`.
+   *
+   * @see docs/subsystems/session-tiers.md → Managed-passphrase mode
+   */
+  readonly passphraseMode?: 'standard' | 'managed'
+  /**
+   * Provider that seals/unseals the auto-generated managed-mode
+   * passphrase. Required when `passphraseMode === 'managed'`; ignored
+   * otherwise. Implementations live in per-platform packages
+   * (`@noy-db/seal-macos-keychain`, `@noy-db/seal-wincred`,
+   * `@noy-db/seal-libsecret`, `@noy-db/seal-aws-kms`, …).
+   */
+  readonly sealingKey?: SealingKeyProvider
   /** Auth method. Default: 'passphrase'. */
   readonly auth?: 'passphrase' | 'biometric'
   /** Enable encryption. Default: true. */


### PR DESCRIPTION
Part of #14 (hub-side abstraction). Concrete providers + mandatory-recovery + recovery-under-managed land as separate follow-ups.

## Summary

Adds rubber-hose-resistant vault mode: hub generates a 256-bit random passphrase, seals it under a developer-provided \`SealingKeyProvider\`, persists at \`_meta/sealed-passphrase\`, and never exposes the plaintext to the user. **The user has no secret to give up to coercion — they cannot reveal what they do not know.**

\`\`\`ts
import { createNoydb, MemorySealingKeyProvider } from '@noy-db/hub'

// In production, replace MemorySealingKeyProvider with a real platform
// provider (@noy-db/seal-macos-keychain / @noy-db/seal-wincred / etc.)
const provider = new MemorySealingKeyProvider({ id: 'macos-keychain:com.acme.app' })

const db = await createNoydb({
  store,
  user: 'alice',
  passphraseMode: 'managed',   // ← new
  sealingKey: provider,         // ← new (required for managed mode)
})
const vault = await db.openVault('acme')
// First open: hub minted 256-bit random, sealed under provider, persisted.
// Reopen with same provider: unseals + uses transparently.
// rotatePassphrase throws PolicyDeniedError — the user has no phrase to rotate.
\`\`\`

## What landed

- \`SealingKeyProvider\` interface (id + seal + unseal).
- \`MemorySealingKeyProvider\` — in-memory test provider; deterministic fingerprint + XOR stream keyed by provider id. **Test-only; not secure.**
- \`_meta/sealed-passphrase\` envelope storage. AES-GCM bypassed — the sealing layer is the security boundary; hub has no key at this layer (that's the whole point).
- \`resolveManagedSecret\` — orchestrates "first open mints + seals + persists, reopen unseals" flow.
- \`NoydbOptions.passphraseMode\` + \`sealingKey\`.
- \`createNoydb\` validation: managed mode mutually exclusive with \`secret\` and \`getKeyring\`; requires \`sealingKey\`.
- Keyring path branches on managed mode (skips human-passphrase strength validation — 256-bit base64 entropy is already at floor).
- \`rotatePassphrase\` blocks managed mode with \`PolicyDeniedError(reason: 'disabled')\`.

## Tests

**+14 tests** in \`__tests__/managed-passphrase.test.ts\`:

| Group | Coverage |
|---|---|
| SealingKeyProvider contract | seal/unseal round-trip; cross-provider rejection; \`id\` surface |
| Envelope storage | round-trip; undefined-on-empty; reserved \`_meta/sealed-passphrase\` path |
| createNoydb wiring | rejects mode without sealingKey; rejects mode+secret; rejects mode+getKeyring; first-open mints+seals+persists; reopen reuses; round-trips records; wrong-provider rejection; rotatePassphrase blocked |

Full hub suite: **1656/1657** passing (+14; +1 pre-existing \`it.todo\` from pre.14, tracked as #181). Typecheck clean; lint 0 errors.

## Deferred to follow-up issues (will file)

1. **Mandatory strong-recovery enforcement at vault creation.** The issue body requires "at least one strong profile (Shamir or multi-channel)" but those profiles throw \`RecoveryProfileNotImplementedError\` pending #10. Without #10, no profile qualifies as "strong" by that bar. Punted to land *after* #10.
2. **Recovery flow under managed mode.** Recovery should mint a fresh 256-bit random, seal it, replace \`_meta/sealed-passphrase\`. Same dependency on #10 + new \`rotate-managed-passphrase\` policy gate.
3. **Concrete providers** (separate packages, outside hub per the issue's "live outside hub" note):
   - \`@noy-db/seal-macos-keychain\` — Security.framework via native binding
   - \`@noy-db/seal-wincred\` — Windows Credential Manager
   - \`@noy-db/seal-libsecret\` — Linux secret-service
   - \`@noy-db/seal-aws-kms\` — AWS KMS Encrypt/Decrypt for server-side managed-mode SaaS

## Test plan

- [x] \`pnpm vitest run --filter @noy-db/hub\` — 1656/1657 pass
- [x] \`pnpm turbo typecheck --filter @noy-db/hub\` — clean
- [x] \`pnpm turbo lint --filter @noy-db/hub\` — 0 errors