### PR TITLE
feat(at-env): env-var sealing key provider — new `at-*` family debut

### DIFF
--- a/packages/at-env/LICENSE
+++ b/packages/at-env/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 vLannaAi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/at-env/README.md
+++ b/packages/at-env/README.md
@@ -1,0 +1,84 @@
+# @noy-db/at-env
+
+**Env-var sealing key provider for noy-db [managed-passphrase mode](https://github.com/vLannaAi/noy-db/issues/14).**
+
+The smallest production-shape provider in the `at-*` family. Reads a 32-byte AES-256-GCM key from an environment variable (base64-encoded) and uses it to seal the hub-generated random passphrase — so your users never see or type a passphrase, but the encryption keys are still under your control.
+
+## Install
+
+```bash
+pnpm add @noy-db/hub @noy-db/at-env
+# or: npm install @noy-db/hub @noy-db/at-env
+```
+
+## Setup
+
+```bash
+# 1. Generate a 256-bit key once. Store in your platform's secret manager
+#    (Kubernetes Secrets, Heroku env, Doppler, AWS Secrets Manager, etc.).
+export NOYDB_SEALING_KEY=$(openssl rand -base64 32)
+```
+
+```ts
+// 2. In your app:
+import { createNoydb } from '@noy-db/hub'
+import { envSealingProvider } from '@noy-db/at-env'
+
+const db = await createNoydb({
+  store,
+  user: 'alice',
+  passphraseMode: 'managed',
+  sealingKey: envSealingProvider(),  // reads NOYDB_SEALING_KEY by default
+})
+
+const vault = await db.openVault('acme')
+// Hub generated a 256-bit random on first open, sealed it under your env
+// key, and persisted to _meta/sealed-passphrase. The user never sees a
+// passphrase. On reopen, at-env unseals transparently.
+```
+
+## When to use this provider
+
+- ✅ Single-node SaaS where the env var comes from Kubernetes Secrets, Heroku env, Doppler, AWS Secrets Manager mounted at boot, systemd env, etc.
+- ✅ Local dev / CI where you want persistence across restarts (which `MemorySealingKeyProvider` can't do — it's in-process only).
+- ✅ Prototypes where setting up AWS KMS / GCP KMS isn't worth the effort.
+
+## When NOT to use this provider
+
+- ❌ Laptops or shared dev machines where other users have shell access. They can `echo $NOYDB_SEALING_KEY` and exfiltrate the key. Use [`@noy-db/at-macos-keychain`](../at-macos-keychain) / [`@noy-db/at-wincred`](../at-wincred) / [`@noy-db/at-libsecret`](../at-libsecret) for desktop apps. *(coming soon)*
+- ❌ Compliance regimes requiring auditable key access logs (FedRAMP, HIPAA with managed-encryption requirements). Use [`@noy-db/at-aws-kms`](../at-aws-kms) for KMS-backed key access auditing. *(coming soon)*
+
+## Key rotation
+
+Rotating the env-var key is currently manual:
+
+1. Open the vault under the OLD env key.
+2. Generate a new key: `NEW=$(openssl rand -base64 32)`.
+3. Read `_meta/sealed-passphrase` from the store.
+4. Unseal under the OLD provider, re-seal under a NEW provider (`envSealingProvider({ envVar: 'NOYDB_NEW_KEY' })`).
+5. Overwrite `_meta/sealed-passphrase`.
+6. Swap the env var to the new value.
+
+An automated `noydb seal rotate` CLI command is tracked as a follow-up. For lower-touch rotation, use `@noy-db/at-aws-kms` once it lands — KMS handles CMK rotation automatically.
+
+## Threat model
+
+The env var IS the security boundary. If an attacker gains read access to your process's environment, they can decrypt every record sealed under that key.
+
+This provider is suitable when your deployment platform's secret management is trusted (you trust Kubernetes Secrets, you trust Heroku's env injection, etc.) and unsuitable when the env var sits in a shell profile, a `.env` file in version control, or a multi-tenant host where other tenants can read your environment.
+
+## API
+
+```ts
+function envSealingProvider(opts?: {
+  envVar?: string  // default 'NOYDB_SEALING_KEY'
+}): SealingKeyProvider
+```
+
+Returns a [`SealingKeyProvider`](../hub/src/team/managed-passphrase.ts) — the contract `@noy-db/hub`'s managed-passphrase mode consumes. The provider validates the env var at construction time and caches the imported `CryptoKey` for the lifetime of the instance.
+
+Throws at construction when the env var is unset, not valid base64, or not 32 bytes.
+
+## License
+
+MIT

--- a/packages/at-env/__tests__/at-env.test.ts
+++ b/packages/at-env/__tests__/at-env.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for @noy-db/at-env — env-var sealing key provider for managed-passphrase mode.
+ *
+ * The provider implements the {@link SealingKeyProvider} contract from
+ * @noy-db/hub: seal(bytes) → sealed bytes; unseal(sealed) → bytes.
+ * Sealing is AES-256-GCM under a 32-byte key read from a configurable
+ * environment variable (default `NOYDB_SEALING_KEY`, base64-encoded).
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { envSealingProvider } from '../src/index.js'
+
+const TEST_ENV = 'NOYDB_TEST_SEALING_KEY'
+
+// 32 bytes of arbitrary but stable test material, base64-encoded.
+const TEST_KEY_BASE64 = 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8='
+
+describe('@noy-db/at-env — envSealingProvider', () => {
+  beforeEach(() => { process.env[TEST_ENV] = TEST_KEY_BASE64 })
+  afterEach(() => { delete process.env[TEST_ENV] })
+
+  it('id surfaces the envVar name for audit (non-secret)', () => {
+    const p = envSealingProvider({ envVar: TEST_ENV })
+    expect(p.id).toBe(`env:${TEST_ENV}`)
+  })
+
+  it('seal → unseal round-trips arbitrary bytes', async () => {
+    const p = envSealingProvider({ envVar: TEST_ENV })
+    const original = new TextEncoder().encode('the managed passphrase bytes')
+    const sealed = await p.seal(original)
+    expect(sealed).not.toEqual(original) // ciphertext differs
+    const unsealed = await p.unseal(sealed)
+    expect(new TextDecoder().decode(unsealed)).toBe('the managed passphrase bytes')
+  })
+
+  it('produces different ciphertext for the same plaintext (fresh IV per seal)', async () => {
+    const p = envSealingProvider({ envVar: TEST_ENV })
+    const plaintext = new TextEncoder().encode('same input')
+    const a = await p.seal(plaintext)
+    const b = await p.seal(plaintext)
+    expect(Array.from(a)).not.toEqual(Array.from(b)) // IVs differ → AES-GCM output differs
+  })
+
+  it('two provider instances built from the same env value unseal each other', async () => {
+    const p1 = envSealingProvider({ envVar: TEST_ENV })
+    const sealed = await p1.seal(new Uint8Array([1, 2, 3, 4]))
+    // Simulate a process restart: same env, fresh provider instance.
+    const p2 = envSealingProvider({ envVar: TEST_ENV })
+    const out = await p2.unseal(sealed)
+    expect(Array.from(out)).toEqual([1, 2, 3, 4])
+  })
+
+  it('rejects sealed bytes produced under a different env key', async () => {
+    const p1 = envSealingProvider({ envVar: TEST_ENV })
+    const sealed = await p1.seal(new TextEncoder().encode('secret'))
+    // Swap the env var to a different 32-byte key (reverse byte order of TEST_KEY).
+    process.env[TEST_ENV] = 'Hx4dHBsaGRgXFhUUExIREA8ODQwLCgkIBwYFBAMCAQA='
+    const p2 = envSealingProvider({ envVar: TEST_ENV })
+    await expect(p2.unseal(sealed)).rejects.toThrow()
+  })
+
+  it('throws clearly when the env var is not set', () => {
+    delete process.env[TEST_ENV]
+    expect(() => envSealingProvider({ envVar: TEST_ENV })).toThrow(/not set|missing/i)
+  })
+
+  it('throws clearly when the env var is valid base64 but wrong length', () => {
+    process.env[TEST_ENV] = 'AAAA' // valid base64, decodes to 3 bytes
+    expect(() => envSealingProvider({ envVar: TEST_ENV })).toThrow(/32 bytes|256-bit/i)
+  })
+
+  it('throws when the env var is not valid base64', () => {
+    process.env[TEST_ENV] = '!!!not-base64!!!'
+    expect(() => envSealingProvider({ envVar: TEST_ENV })).toThrow()
+  })
+
+  it('defaults to NOYDB_SEALING_KEY when envVar is omitted', () => {
+    process.env.NOYDB_SEALING_KEY = TEST_KEY_BASE64
+    try {
+      const p = envSealingProvider()
+      expect(p.id).toBe('env:NOYDB_SEALING_KEY')
+    } finally {
+      delete process.env.NOYDB_SEALING_KEY
+    }
+  })
+
+  it('rejects sealed bytes that are shorter than the IV (12 bytes)', async () => {
+    const p = envSealingProvider({ envVar: TEST_ENV })
+    await expect(p.unseal(new Uint8Array([1, 2, 3]))).rejects.toThrow(/too short|invalid/i)
+  })
+
+  it('detects tampered ciphertext via AES-GCM auth tag', async () => {
+    const p = envSealingProvider({ envVar: TEST_ENV })
+    const sealed = await p.seal(new Uint8Array([10, 20, 30, 40]))
+    // Flip a byte past the IV (offset 12) to break the GCM tag.
+    const tampered = new Uint8Array(sealed)
+    tampered[15] ^= 0xff
+    await expect(p.unseal(tampered)).rejects.toThrow()
+  })
+})
+
+describe('@noy-db/at-env — integration with @noy-db/hub managed-passphrase mode', () => {
+  beforeEach(() => { process.env[TEST_ENV] = TEST_KEY_BASE64 })
+  afterEach(() => { delete process.env[TEST_ENV] })
+
+  it('round-trips a managed-mode vault end-to-end (no user passphrase typed)', async () => {
+    const { createNoydb } = await import('@noy-db/hub')
+    const { memory } = await import('@noy-db/to-memory')
+
+    const store = memory()
+    const provider = envSealingProvider({ envVar: TEST_ENV })
+
+    // First open — hub mints + seals via at-env, persists, derives KEK.
+    const db1 = await createNoydb({
+      store, user: 'alice',
+      passphraseMode: 'managed',
+      sealingKey: provider,
+    })
+    const vault1 = await db1.openVault('demo')
+    await vault1.collection<{ id: string; note: string }>('notes').put('n1', {
+      id: 'n1', note: 'managed-mode write via at-env',
+    })
+    db1.close()
+
+    // Second open — fresh provider built from the same env, unseal works.
+    const db2 = await createNoydb({
+      store, user: 'alice',
+      passphraseMode: 'managed',
+      sealingKey: envSealingProvider({ envVar: TEST_ENV }),
+    })
+    const vault2 = await db2.openVault('demo')
+    const note = await vault2.collection<{ id: string; note: string }>('notes').get('n1')
+    expect(note).toEqual({ id: 'n1', note: 'managed-mode write via at-env' })
+    db2.close()
+  })
+})

--- a/packages/at-env/package.json
+++ b/packages/at-env/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@noy-db/at-env",
+  "version": "0.1.0-pre.15",
+  "description": "Env-var sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a key from process.env. Smallest production-shape provider; pair with Kubernetes Secrets / Heroku env / AWS Secrets Manager.",
+  "license": "MIT",
+  "author": "vLannaAi <vicio@lanna.ai>",
+  "homepage": "https://github.com/vLannaAi/noy-db/tree/main/packages/at-env#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vLannaAi/noy-db.git",
+    "directory": "packages/at-env"
+  },
+  "bugs": {
+    "url": "https://github.com/vLannaAi/noy-db/issues"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@noy-db/hub": "workspace:*"
+  },
+  "devDependencies": {
+    "@noy-db/hub": "workspace:*",
+    "@noy-db/to-memory": "workspace:*",
+    "@types/node": "^22.0.0"
+  },
+  "keywords": [
+    "noy-db",
+    "at-env",
+    "sealing-key-provider",
+    "managed-passphrase",
+    "env",
+    "rubber-hose-resistant",
+    "aes-256-gcm",
+    "encryption",
+    "zero-knowledge"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  }
+}

--- a/packages/at-env/src/index.ts
+++ b/packages/at-env/src/index.ts
@@ -1,0 +1,167 @@
+/**
+ * **@noy-db/at-env** — env-var sealing key provider for noy-db
+ * managed-passphrase mode (#14).
+ *
+ * The smallest production-shape provider in the `at-*` family. Reads a
+ * 32-byte AES-256-GCM key from an environment variable (base64-encoded)
+ * and uses it to seal / unseal the hub-generated random passphrase.
+ *
+ * ## When to use
+ *
+ * - Single-node SaaS where the env var comes from Kubernetes Secrets,
+ *   Heroku env, Doppler, AWS Secrets Manager (mounted at boot), systemd
+ *   service env, etc. — anywhere your platform already manages secrets.
+ * - Local dev / CI where you want persistence across process restarts
+ *   (which `MemorySealingKeyProvider` from `@noy-db/hub` can't do).
+ * - Prototypes where setting up AWS KMS / GCP KMS isn't worth the effort.
+ *
+ * ## When NOT to use
+ *
+ * - Laptops / shared dev machines where other users have shell access.
+ *   They can `echo $NOYDB_SEALING_KEY` and exfiltrate the key. Use
+ *   `@noy-db/at-macos-keychain` / `@noy-db/at-wincred` /
+ *   `@noy-db/at-libsecret` for desktop apps.
+ * - Compliance regimes requiring auditable key access (FedRAMP, HIPAA
+ *   with managed-encryption requirements). Use `@noy-db/at-aws-kms` for
+ *   KMS-backed key access logs.
+ *
+ * ## Setup
+ *
+ * ```bash
+ * # 1. Generate a 256-bit key once. Store in your platform's secret manager.
+ * export NOYDB_SEALING_KEY=$(openssl rand -base64 32)
+ * ```
+ *
+ * ```ts
+ * // 2. In your app:
+ * import { createNoydb } from '@noy-db/hub'
+ * import { envSealingProvider } from '@noy-db/at-env'
+ *
+ * const db = await createNoydb({
+ *   store,
+ *   user: 'alice',
+ *   passphraseMode: 'managed',
+ *   sealingKey: envSealingProvider(),  // reads NOYDB_SEALING_KEY by default
+ * })
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+import type { SealingKeyProvider } from '@noy-db/hub'
+
+/** Options for {@link envSealingProvider}. */
+export interface EnvSealingProviderOptions {
+  /**
+   * Environment variable name holding the base64-encoded 32-byte AES-256
+   * key. Default `'NOYDB_SEALING_KEY'`.
+   */
+  readonly envVar?: string
+}
+
+/**
+ * Build a {@link SealingKeyProvider} backed by an environment variable.
+ *
+ * The env var must contain a base64-encoded 32-byte (256-bit) key. The
+ * provider validates the value at construction time and caches the
+ * imported `CryptoKey` for the lifetime of the instance.
+ *
+ * @throws Error when the env var is unset, not base64, or not 32 bytes.
+ */
+export function envSealingProvider(
+  opts: EnvSealingProviderOptions = {},
+): SealingKeyProvider {
+  const envVar = opts.envVar ?? 'NOYDB_SEALING_KEY'
+  const raw = process.env[envVar]
+  if (!raw) {
+    throw new Error(
+      `@noy-db/at-env: env var "${envVar}" is not set. Generate a key via `
+      + '`openssl rand -base64 32` and export it before starting the process.',
+    )
+  }
+
+  let keyBytes: Uint8Array
+  try {
+    keyBytes = base64ToBytes(raw)
+  } catch (err) {
+    throw new Error(
+      `@noy-db/at-env: env var "${envVar}" is not valid base64 — `
+      + (err instanceof Error ? err.message : String(err)),
+    )
+  }
+
+  if (keyBytes.length !== 32) {
+    throw new Error(
+      `@noy-db/at-env: env var "${envVar}" decodes to ${keyBytes.length} bytes; `
+      + 'expected 32 bytes (256-bit AES key). Regenerate via `openssl rand -base64 32`.',
+    )
+  }
+
+  // Lazy + cached import — the CryptoKey is created on first seal/unseal
+  // and reused for the lifetime of the provider instance.
+  let cachedKey: Promise<CryptoKey> | null = null
+  const getKey = (): Promise<CryptoKey> => {
+    if (!cachedKey) {
+      cachedKey = globalThis.crypto.subtle.importKey(
+        'raw',
+        keyBytes as unknown as BufferSource,
+        'AES-GCM',
+        false,
+        ['encrypt', 'decrypt'],
+      )
+    }
+    return cachedKey
+  }
+
+  return {
+    id: `env:${envVar}`,
+
+    async seal(passphrase: Uint8Array): Promise<Uint8Array> {
+      const key = await getKey()
+      const iv = globalThis.crypto.getRandomValues(new Uint8Array(12))
+      const ciphertext = await globalThis.crypto.subtle.encrypt(
+        { name: 'AES-GCM', iv: iv as BufferSource },
+        key,
+        passphrase as unknown as BufferSource,
+      )
+      // Output format: [12-byte IV][ciphertext + 16-byte GCM tag]
+      const out = new Uint8Array(12 + ciphertext.byteLength)
+      out.set(iv, 0)
+      out.set(new Uint8Array(ciphertext), 12)
+      return out
+    },
+
+    async unseal(sealed: Uint8Array): Promise<Uint8Array> {
+      // 12-byte IV + ≥ 16-byte GCM tag minimum.
+      if (sealed.length < 12 + 16) {
+        throw new Error(
+          `@noy-db/at-env: sealed bytes too short (${sealed.length} < 28). `
+          + 'Input is not a valid at-env-sealed envelope.',
+        )
+      }
+      const iv = sealed.subarray(0, 12)
+      const body = sealed.subarray(12)
+      const key = await getKey()
+      const plaintext = await globalThis.crypto.subtle.decrypt(
+        { name: 'AES-GCM', iv: iv as BufferSource },
+        key,
+        body as unknown as BufferSource,
+      )
+      return new Uint8Array(plaintext)
+    },
+  }
+}
+
+// ─── base64 helpers (browser + node + cf-workers compatible) ──────────
+
+function base64ToBytes(b64: string): Uint8Array {
+  // Reject obviously malformed strings before atob throws InvalidCharacterError,
+  // so the wrapping error message is informative.
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(b64.trim())) {
+    throw new Error('input contains characters outside the base64 alphabet')
+  }
+  const binary = atob(b64)
+  const out = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i)
+  return out
+}

--- a/packages/at-env/tsconfig.json
+++ b/packages/at-env/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/at-env/tsup.config.ts
+++ b/packages/at-env/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  target: 'es2022',
+})

--- a/packages/at-env/vitest.config.ts
+++ b/packages/at-env/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'at-env',
+    include: ['__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,18 @@ importers:
         specifier: ^22.0.0
         version: 22.19.17
 
+  packages/at-env:
+    devDependencies:
+      '@noy-db/hub':
+        specifier: workspace:*
+        version: link:../hub
+      '@noy-db/to-memory':
+        specifier: workspace:*
+        version: link:../to-memory
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+
   packages/by-peer:
     devDependencies:
       '@noy-db/hub':


### PR DESCRIPTION
## Summary

Adds **\`@noy-db/at-env\`**, the first concrete sealing key provider for managed-passphrase mode (#14 / PR #186). Reads a 32-byte AES-256-GCM key from an environment variable (base64-encoded) and uses it to seal / unseal the hub-generated random passphrase — users never see or type a passphrase, but encryption keys stay under your control.

Debuts the **\`at-*\` package prefix family** for sealing key custodians.

## New family: \`at-*\`

The 2-letter preposition slots into the existing six-family taxonomy:

| Prefix | Reads as | Examples |
|---|---|---|
| \`to-\` | data goes **to** this storage | \`to-memory\`, \`to-postgres\` |
| \`in-\` | code runs **in** this framework | \`in-react\`, \`in-vue\` |
| \`on-\` | user authenticates **on** this method | \`on-password\`, \`on-totp\` |
| \`as-\` | data exports **as** this format | \`as-csv\`, \`as-xlsx\` |
| \`by-\` | clients sync **by** this transport | \`by-tabs\`, \`by-peer\` |
| **\`at-\`** | **passphrase is sealed at this key store** | **\`at-env\`** (this PR) |

Future siblings tracked under a new milestone (\`at-*\` sealing key providers) — I'll file that milestone + 7 issues as a separate task. Candidates: \`at-aws-kms\`, \`at-gcp-kms\`, \`at-azure-keyvault\`, \`at-macos-keychain\`, \`at-wincred\`, \`at-libsecret\`, \`at-webauthn-prf\`.

## Usage

\`\`\`bash
export NOYDB_SEALING_KEY=\$(openssl rand -base64 32)
\`\`\`

\`\`\`ts
import { createNoydb } from '@noy-db/hub'
import { envSealingProvider } from '@noy-db/at-env'

const db = await createNoydb({
  store, user: 'alice',
  passphraseMode: 'managed',
  sealingKey: envSealingProvider(),   // reads NOYDB_SEALING_KEY by default
})
\`\`\`

The user never sees or types a passphrase. Hub generates a 256-bit random on first open, seals under the env-var key (AES-256-GCM, fresh IV per seal), persists to \`_meta/sealed-passphrase\`. Reopen unseals transparently.

## Threat model

- ✅ Single-node SaaS where the env var comes from a managed secret store (Kubernetes Secrets, Heroku env, Doppler, AWS Secrets Manager mounted at boot, systemd env)
- ✅ Local dev / CI needing persistence across restarts (\`MemorySealingKeyProvider\` is in-process only)
- ❌ Laptops / shared dev — anyone with shell access can \`echo \$NOYDB_SEALING_KEY\`. Use \`at-macos-keychain\` family once available.
- ❌ Compliance regimes needing auditable key-access logs. Use \`at-aws-kms\` once available.

README has the full setup + key-rotation procedure.

## Tests

**+12 tests** in \`__tests__/at-env.test.ts\`:

| Group | Coverage |
|---|---|
| Provider contract | id surface; seal/unseal round-trip; fresh IV per seal; cross-instance unseal; wrong-env-key rejection |
| Construction | clear errors on unset / not-base64 / wrong-length env values; default envVar |
| Tamper detection | sealed-too-short rejection; AES-GCM auth-tag detects ciphertext tampering |
| Integration | end-to-end managed-mode vault round-trip through \`createNoydb\` + \`openVault\` (no user passphrase typed at any point) |

All pass. Typecheck clean; lint clean; build clean; architecture invariants OK; \`features.yaml\` validates.

## Public surface

\`\`\`ts
function envSealingProvider(opts?: {
  envVar?: string  // default 'NOYDB_SEALING_KEY'
}): SealingKeyProvider
\`\`\`

Validates the env var at construction time. Caches the imported \`CryptoKey\` for the lifetime of the instance. Zero runtime deps beyond Web Crypto (same as everything else in noydb).

## Test plan

- [x] \`pnpm vitest run --filter @noy-db/at-env\` — 12/12
- [x] \`pnpm turbo typecheck --filter @noy-db/at-env\` — clean
- [x] \`pnpm turbo lint --filter @noy-db/at-env\` — clean
- [x] \`pnpm turbo build --filter @noy-db/at-env\` — clean
- [x] \`node scripts/check-architecture.mjs\` — OK
- [x] \`node scripts/validate-features.mjs\` — OK