### PR TITLE
chore: release 0.1.0-pre.16 — sealing dimension foundation + at-* family debut

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,21 +8,32 @@
 - **Bundle-size CI gate.** Pin the floor + per-subsystem allowances in `bundle-manifest.json`; CI fails on any unexplained regression.
 - **Showcase + recipe coverage.** A runnable end-to-end test for every `with*()` strategy and every storage destination so adopters pick a backend by reading working code.
 - **`by-*` session-share family.** `@noy-db/by-peer` (WebRTC, renamed from `@noy-db/p2p`) and `@noy-db/by-tabs` (BroadcastChannel multi-tab sync) shipped together with the family debut. Next: `@noy-db/by-server` (WebSocket / SSE relay) and `@noy-db/by-room` (Liveblocks / Yjs y-websocket).
+- **`at-*` sealing-key provider family.** `@noy-db/at-env` (env var) and `@noy-db/at-macos-keychain` (OS Keychain) debuted the family in `v0.1.0-pre.16` — sealing keys drawn from the environment for unattended / managed-host unlock. Next: the cloud/OS providers under the [at-\* sealing key providers](https://github.com/vLannaAi/noy-db/milestone/9) milestone (AWS/GCP/Azure KMS, wincred, libsecret, WebAuthn-PRF).
 
 ## In flight
 
-No active release milestone. Next candidates (no firm sequencing):
+Active epics + next candidates (no firm sequencing):
 
+- **Sealing dimension — `at-*` providers + transferable bundles.** Foundation + managed-passphrase mode + the first two `at-*` providers shipped in `v0.1.0-pre.16`. In flight: more `at-*` providers ([milestone 9](https://github.com/vLannaAi/noy-db/milestone/9)), and the partition-extraction / owner-transfer ceremony ([Transferable bundles, milestone 10](https://github.com/vLannaAi/noy-db/milestone/10) — #198 steps, 12 issues). Several pre.16 features landed as "slice 1" with public API now locked (sealed-bundle, Shamir dispatch, variable-N derivations).
 - **Dim 11 cross-join v3** — draft spec on branch `docs/dim11-cross-join-v1-spec`; not yet opened as a PR. Cross-join terminal on `Query<T>`, lateral form, cost ceiling, MV `queryHash` folding for cross-joined deps. Pattern follows the v2 cycle: spec PR → niwat review → multi-PR implementation epic.
 
 ## Backlog (deferred, no release target)
 
 **Real-provider showcase batch (Apple/Google/LINE).** Originally scoped as `0.1.0-pre.13`; deferred 2026-05-20 because showcase coverage is a 1.0 gate (not a pre-release gate). Milestone renamed to [Backlog: Real-provider showcases (env-gated)](https://github.com/vLannaAi/noy-db/milestone/6). Six issues stay open at `priority: low` to close opportunistically when real-provider creds are in hand: [#64](https://github.com/vLannaAi/noy-db/issues/64), [#65](https://github.com/vLannaAi/noy-db/issues/65), [#73](https://github.com/vLannaAi/noy-db/issues/73), [#74](https://github.com/vLannaAi/noy-db/issues/74), [#75](https://github.com/vLannaAi/noy-db/issues/75), [#76](https://github.com/vLannaAi/noy-db/issues/76).
 
+**Decouple hub from `@noy-db/on-shamir` ([#211](https://github.com/vLannaAi/noy-db/issues/211)).** pre.16 broke the `hub ↔ on-shamir` build cycle by dropping on-shamir's dead hub deps, but hub still hard-depends on the on-shamir package (its secret-sharing engine is bundled into core). The proper fix — invert via an injected `ShamirRecoveryProvider` so hub holds no static import — is deferred; it properly delivers #196's "dispatch" intent and carries a breaking surface change (hub re-exports the share codecs today).
+
 ## Recently shipped (and what's deferred)
 
 The following capabilities are now in main:
 
+- **Sealing dimension foundation + `at-*` family debut (v0.1.0-pre.16).** The first sealing-key providers plus managed-passphrase mode and the schema-introspection trio.
+  - **`at-*` family debut** — `@noy-db/at-env` ([#187](https://github.com/vLannaAi/noy-db/issues/187)) + `@noy-db/at-macos-keychain` ([#191](https://github.com/vLannaAi/noy-db/issues/191)), built on a new `SealingKeyProvider` contract + sealed envelope ([#14](https://github.com/vLannaAi/noy-db/issues/14) / [#186](https://github.com/vLannaAi/noy-db/issues/186)).
+  - **Recovery** — `db.rotateRecovery()` ([#121](https://github.com/vLannaAi/noy-db/issues/121)), managed-mode mandatory strong-recovery + `recoverManagedPassphrase` ([#195](https://github.com/vLannaAi/noy-db/issues/195)), Shamir recovery-profile dispatch ([#196](https://github.com/vLannaAi/noy-db/issues/196) slice 1).
+  - **Slice-1s (public API now locked)** — sealed bundle delivery `autoPassphrases`/`sealedPassphrases` ([#197](https://github.com/vLannaAi/noy-db/issues/197)), variable-N derivations `shape: 'array'` ([#200](https://github.com/vLannaAi/noy-db/issues/200)).
+  - **Schema introspection** — persisted JSON Schema ([#174](https://github.com/vLannaAi/noy-db/issues/174)), `vault.dumpSchema()` ([#175](https://github.com/vLannaAi/noy-db/issues/175)), `noydb describe` CLI ([#176](https://github.com/vLannaAi/noy-db/issues/176)).
+  - **Fixes** — `Collection._doDelete` eager MV refresh ([#183](https://github.com/vLannaAi/noy-db/issues/183), closing the pre.15 known follow-up), `import:<format>` ledger tagging ([#184](https://github.com/vLannaAi/noy-db/issues/184)), and the `hub ↔ on-shamir` build cycle (decouple tracked in [#211](https://github.com/vLannaAi/noy-db/issues/211)).
+  - **Process note:** the cycle reddened `main` from #196 through #197 — four PRs merged on a failing build. Branch protection should require the build check to pass before merge.
 - **Dim 14 v2 follow-up — multi-key groupBy + UNION MV + guards variance (v0.1.0-pre.15).** Small fast-follow on pre.14 driven by the niwat refactor. 5 issues closed in 1 PR ([#167](https://github.com/vLannaAi/noy-db/pull/167)), 28 new hub tests, 1601 hub tests on the tip.
   - **Multi-key groupBy** ([#166](https://github.com/vLannaAi/noy-db/issues/166)) — variadic `Query.groupBy(...fields)`, declaration-order row shape, shared `GroupedQueryBase` abstract, `canonicalGroupKey` helper.
   - **UNION MV** ([#165](https://github.com/vLannaAi/noy-db/issues/165)) — `unionSources: [{ collection, map }, ...]` on `withMaterializedView`. Composes with multi-key groupBy for the niwat monthly-VAT shape. New `MaterializedViewConfigError`.

--- a/features.yaml
+++ b/features.yaml
@@ -246,9 +246,9 @@ features:
     playground_pages: []
     diagrams: []
     invariants:
-      - 'Three functions never conflated: authenticator (on-*), identity provider (on-oidc bridge), sealing-key store (seal-*)'
+      - 'Three functions never conflated: authenticator (on-*), identity provider (on-oidc bridge), sealing-key store (at-*)'
       - 'Vendor-flavored OIDC providers route through on-oidc with different issuers — no per-vendor on-* packages'
-      - 'OS keychains (DPAPI, Keychain, Keystore, libsecret) are sealing-key stores, not authenticators — they belong in the planned seal-* family'
+      - 'OS keychains (DPAPI, Keychain, Keystore, libsecret) are sealing-key stores, not authenticators — they belong in the at-* sealing-key provider family (debuted with at-env + at-macos-keychain)'
       - 'SMS / security questions / pattern lock deliberately omitted — unfit for vault auth (NIST SP 800-63B SMS deprecation, low entropy, social-engineerable)'
     related: [session-tiers, on-passphrase, on-webauthn, on-oidc, on-pin, on-totp, on-email-otp, on-recovery, on-shamir, on-magic-link, on-threat]
 

--- a/packages/as-blob/CHANGELOG.md
+++ b/packages/as-blob/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/as-blob
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/as-blob/package.json
+++ b/packages/as-blob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-blob",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Single-attachment plaintext export for noy-db — extracts one blob from BlobSet as native MIME bytes. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier, document sub-family).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-csv/CHANGELOG.md
+++ b/packages/as-csv/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @noy-db/as-csv
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Imports now tag the ledger entry `import:csv` via `collection.put({ reason })` ([#184](https://github.com/vLannaAi/noy-db/issues/184)).
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/as-csv/package.json
+++ b/packages/as-csv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-csv",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "CSV plaintext export for noy-db — decrypts records and formats as comma-separated values. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-json/CHANGELOG.md
+++ b/packages/as-json/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @noy-db/as-json
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Imports now tag the ledger entry `import:json` via `collection.put({ reason })` ([#184](https://github.com/vLannaAi/noy-db/issues/184)).
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/as-json/package.json
+++ b/packages/as-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-json",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Structured JSON plaintext export for noy-db — decrypts records and emits one JSON document per vault. Gated by RFC #249 canExportPlaintext capability; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-ndjson/CHANGELOG.md
+++ b/packages/as-ndjson/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @noy-db/as-ndjson
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Imports now tag the ledger entry `import:ndjson` via `collection.put({ reason })` ([#184](https://github.com/vLannaAi/noy-db/issues/184)).
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/as-ndjson/package.json
+++ b/packages/as-ndjson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-ndjson",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Newline-delimited JSON export for noy-db — streaming plaintext export suitable for data pipelines, warehouse ingestion, and jq pipelines. Gated by RFC #249 canExportPlaintext. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-noydb/CHANGELOG.md
+++ b/packages/as-noydb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/as-noydb
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/as-noydb/package.json
+++ b/packages/as-noydb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-noydb",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Encrypted .noydb bundle export for noy-db — wraps writeNoydbBundle() with the RFC #249 canExportBundle authorization gate and ergonomic browser/node helpers. Sole member of the @noy-db/as-* encrypted tier — ciphertext in, ciphertext out.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-sql/CHANGELOG.md
+++ b/packages/as-sql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/as-sql
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/as-sql/package.json
+++ b/packages/as-sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-sql",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "SQL dump export for noy-db — decrypts records and emits dialect-aware CREATE TABLE + INSERT statements for postgres / mysql / sqlite. One-way migration helper. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xlsx/CHANGELOG.md
+++ b/packages/as-xlsx/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/as-xlsx
 
+## 0.1.0-pre.16
+
+### Minor Changes
+
+- Expose column `widths` on `AsXlsxSheetOptions` ([#182](https://github.com/vLannaAi/noy-db/issues/182)).
+
+### Patch Changes
+
+- Imports now tag the ledger entry `import:xlsx` via `collection.put({ reason })` ([#184](https://github.com/vLannaAi/noy-db/issues/184)).
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/as-xlsx/package.json
+++ b/packages/as-xlsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xlsx",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Excel spreadsheet plaintext export for noy-db — produces a real .xlsx (Office Open XML) from one or more collections. Multi-sheet, Unicode-safe via shared-strings table. Zero runtime deps beyond the workspace zip encoder. Gated by RFC #249 `canExportPlaintext` with format `'xlsx'`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xml/CHANGELOG.md
+++ b/packages/as-xml/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @noy-db/as-xml
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Imports now tag the ledger entry `import:xml` via `collection.put({ reason })` ([#184](https://github.com/vLannaAi/noy-db/issues/184)).
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/as-xml/package.json
+++ b/packages/as-xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xml",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "XML plaintext export for noy-db — decrypts records and formats as XML with RFC-compliant entity escaping. For legacy systems, banking batch imports, SOAP endpoints, and accounting software that requires XML. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-zip/CHANGELOG.md
+++ b/packages/as-zip/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/as-zip
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/as-zip/package.json
+++ b/packages/as-zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-zip",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Composite record + blob archive export for noy-db — bundles a collection's records plus every attached blob into one zip. Zero dependencies (STORE-only zip encoder). Gated by the RFC #249 `canExportPlaintext` capability bit with format `'zip'`. Part of the @noy-db/as-* portable-artefact family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-env/CHANGELOG.md
+++ b/packages/at-env/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog — at-env
+
+## 0.1.0-pre.16
+
+First release. Debuts the `at-*` sealing-key provider family.
+
+- Env-var `SealingKeyProvider` ([#187](https://github.com/vLannaAi/noy-db/issues/187)) — derives a vault sealing key from an environment variable, for unattended / managed-host unlock where no human is present to type a passphrase.
+- Carries AES-256-GCM sealed wrap material; the provider never sees plaintext DEKs.

--- a/packages/at-env/package.json
+++ b/packages/at-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-env",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Env-var sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a key from process.env. Smallest production-shape provider; pair with Kubernetes Secrets / Heroku env / AWS Secrets Manager.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-macos-keychain/CHANGELOG.md
+++ b/packages/at-macos-keychain/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog — at-macos-keychain
+
+## 0.1.0-pre.16
+
+First release. Part of the `at-*` sealing-key provider family debut.
+
+- macOS Keychain `SealingKeyProvider` ([#191](https://github.com/vLannaAi/noy-db/issues/191)) — stores the vault sealing key in the OS Keychain via `@napi-rs/keyring` (peer dependency), so unlock is gated by the OS account rather than a typed passphrase.
+- Envelope aligned with the hub sealed-envelope format.
+- Carries AES-256-GCM sealed wrap material; the provider never sees plaintext DEKs.

--- a/packages/at-macos-keychain/package.json
+++ b/packages/at-macos-keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-macos-keychain",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "macOS Keychain sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a 32-byte key stored in the user's login Keychain. Desktop-app provider in the at-* family; pairs with Touch ID via Keychain Access UI.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-peer/CHANGELOG.md
+++ b/packages/by-peer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — by-peer
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/by-peer/package.json
+++ b/packages/by-peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-peer",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "WebRTC peer-to-peer transport for noy-db — direct browser-to-browser channel with signaling-agnostic handshake",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-tabs/CHANGELOG.md
+++ b/packages/by-tabs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/by-tabs
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/by-tabs/package.json
+++ b/packages/by-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-tabs",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "BroadcastChannel multi-tab transport for noy-db — sync between tabs of the same browser without round-tripping the storage backend",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @noy-db/cli
 
+## 0.1.0-pre.16
+
+### Minor Changes
+
+- `noydb describe` — read a `.noydb` bundle and emit a YAML/JSON audit of its structure ([#176](https://github.com/vLannaAi/noy-db/issues/176)).
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/cli",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Command-line tool for noy-db — inspect .noydb bundles without decrypting, verify integrity, validate config objects, scaffold topology profiles, and monitor a live vault's store metrics.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/create-noy-db/CHANGELOG.md
+++ b/packages/create-noy-db/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — create-noy-db
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/create-noy-db/package.json
+++ b/packages/create-noy-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-noy-db",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Wizard + CLI tool for noy-db: scaffold a fresh Nuxt 4 + Pinia encrypted store, or add collections to an existing project. Invoke via `npm create @noy-db`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/hub/CHANGELOG.md
+++ b/packages/hub/CHANGELOG.md
@@ -1,5 +1,44 @@
 # Changelog — hub
 
+## 0.1.0-pre.16
+
+The **sealing dimension foundation** + the **`at-*` sealing-key provider family debut**. Where every prior tier protected the vault with something the user *knows* or *has* (passphrase, WebAuthn, PIN), `at-*` providers seal it with a key drawn from the *environment* — an env var, an OS keychain — for unattended / managed-host scenarios. Shipped alongside managed-passphrase mode, the recovery-profile dispatch groundwork, and the persisted-schema introspection trio.
+
+This release also lands a build fix: `main` had been red since [#196](https://github.com/vLannaAi/noy-db/issues/196) — see "Build" below.
+
+### Sealing dimension + managed-passphrase mode ([#14](https://github.com/vLannaAi/noy-db/issues/14) slice 1, [#186](https://github.com/vLannaAi/noy-db/issues/186))
+
+- New `SealingKeyProvider` contract + sealed envelope. A provider supplies a sealing key from outside the user's head; the vault's wrap material is sealed under it for hands-off unlock.
+- `@noy-db/at-env` ([#187](https://github.com/vLannaAi/noy-db/issues/187)) and `@noy-db/at-macos-keychain` ([#191](https://github.com/vLannaAi/noy-db/issues/191)) are the first two providers — the `at-*` family debut. Cloud/OS providers (AWS/GCP/Azure KMS, wincred, libsecret, WebAuthn-PRF) are tracked under the [at-\* sealing key providers](https://github.com/vLannaAi/noy-db/milestone/9) milestone.
+- Managed-passphrase mode mandates **at least one strong recovery profile** and disables the rotate-passphrase gate ([#195](https://github.com/vLannaAi/noy-db/issues/195)); `recoverManagedPassphrase` added.
+
+### Recovery + rotation
+
+- `db.rotateRecovery()` — gated, deliberate paper-code regeneration ([#121](https://github.com/vLannaAi/noy-db/issues/121), [#185](https://github.com/vLannaAi/noy-db/issues/185)).
+- Shamir recovery-profile dispatch ([#196](https://github.com/vLannaAi/noy-db/issues/196) slice 1) — the recovery path can route to a `shamir` profile.
+
+### Bundles + derivations (slice 1s)
+
+- Sealed bundle delivery: `autoPassphrases` + `sealedPassphrases` on `writeNoydbBundle` ([#197](https://github.com/vLannaAi/noy-db/issues/197) slice 1).
+- Variable-N derivations — `shape: 'array'` ([#200](https://github.com/vLannaAi/noy-db/issues/200) slice 1).
+
+> **Public-API surface lock.** `autoPassphrases`, `sealedPassphrases`, `recoverManagedPassphrase`, `rotateRecovery`, and the `managedPassphrase` option are exported public API as of this release — future slices of #196/#197/#200/#14 must extend, not rename, them.
+
+### Schema introspection trio
+
+- Persisted JSON Schema — opt-in encrypted `_schemas/<col>` envelope ([#174](https://github.com/vLannaAi/noy-db/issues/174)).
+- `vault.dumpSchema()` introspection primitive ([#175](https://github.com/vLannaAi/noy-db/issues/175)).
+- `noydb describe` CLI — bundle → YAML/JSON audit ([#176](https://github.com/vLannaAi/noy-db/issues/176), in `@noy-db/cli`).
+
+### Fixes
+
+- `Collection._doDelete` now dispatches eager MV refresh ([#181](https://github.com/vLannaAi/noy-db/issues/181), [#183](https://github.com/vLannaAi/noy-db/issues/183)).
+- Ledger entries can be tagged `import:<format>` via `collection.put({ reason })` ([#1](https://github.com/vLannaAi/noy-db/issues/1), [#184](https://github.com/vLannaAi/noy-db/issues/184)).
+
+### Build
+
+- Removed `@noy-db/on-shamir`'s spurious `peer`+`dev` dependencies on `@noy-db/hub`. #196 made hub import on-shamir's secret-sharing engine at runtime; combined with on-shamir's (never-imported) hub deps, turbo saw a `hub ↔ on-shamir` build cycle and **`main` failed CI from #196 through #197**. on-shamir is a self-contained primitive *consumed by* hub, so its hub deps were dead metadata. Properly decoupling hub from the on-shamir package (via injected provider) is tracked in [#211](https://github.com/vLannaAi/noy-db/issues/211) (deferred).
+
 ## 0.1.0-pre.15
 
 A small fast-follow to pre.14's Dim 14 v2: extends `withMaterializedView` along two consumer-driven axes ([#165](https://github.com/vLannaAi/noy-db/issues/165) + [#166](https://github.com/vLannaAi/noy-db/issues/166)), folds in a pre.14 type-only cleanup ([#131](https://github.com/vLannaAi/noy-db/issues/131)), and resolves two niwat-review follow-ups ([#169](https://github.com/vLannaAi/noy-db/issues/169) + [#170](https://github.com/vLannaAi/noy-db/issues/170)). 5 issues closed, 1 PR merged ([#167](https://github.com/vLannaAi/noy-db/pull/167)), 28 new hub tests, 1601 hub tests on the tip.

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/hub",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Zero-knowledge, offline-first, encrypted document store — core library with AES-256-GCM, PBKDF2, multi-user keyring, and sync engine",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-ai/CHANGELOG.md
+++ b/packages/in-ai/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-ai
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/in-ai/package.json
+++ b/packages/in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-ai",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "LLM function-calling adapter for noy-db — expose ACL-scoped collections as tool definitions, then dispatch tool calls back to the vault. Format-agnostic (OpenAI, Anthropic, Vercel AI SDK).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-nextjs/CHANGELOG.md
+++ b/packages/in-nextjs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-nextjs
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/in-nextjs/package.json
+++ b/packages/in-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nextjs",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Next.js App Router helpers for noy-db — server components, route handlers, client hooks, and cookie-based session. Thin bridge that composes @noy-db/in-react with Next's cookies()/headers() APIs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-nuxt/CHANGELOG.md
+++ b/packages/in-nuxt/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — in-nuxt
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/in-nuxt/package.json
+++ b/packages/in-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nuxt",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Nuxt 4 module for noy-db — auto-imports, SSR-safe runtime plugin, and the @noy-db/in-pinia bridge",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-pinia/CHANGELOG.md
+++ b/packages/in-pinia/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — in-pinia
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/in-pinia/package.json
+++ b/packages/in-pinia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-pinia",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Pinia integration for noy-db — defineNoydbStore() and the augmentation plugin for existing stores",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-react/CHANGELOG.md
+++ b/packages/in-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-react
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/in-react/package.json
+++ b/packages/in-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-react",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "React hooks for noy-db — useNoydb, useVault, useCollection, useQuery, useSync. Uses useSyncExternalStore for reactive subscriptions. Zero deps beyond React.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-rest/CHANGELOG.md
+++ b/packages/in-rest/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-rest
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/in-rest/package.json
+++ b/packages/in-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-rest",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Framework-neutral REST API integration for noy-db — createRestHandler with Hono, Express, Fastify, and Nitro subpath adapters.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-solid/CHANGELOG.md
+++ b/packages/in-solid/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-solid
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/in-solid/package.json
+++ b/packages/in-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-solid",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "SolidJS signal primitives for noy-db — createCollectionSignal, createQuerySignal, createSyncSignal backed by noy-db change events.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-svelte/CHANGELOG.md
+++ b/packages/in-svelte/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-svelte
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/in-svelte/package.json
+++ b/packages/in-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-svelte",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Svelte stores for noy-db — collectionStore / queryStore / syncStore backed by noy-db change events. Works with Svelte 4 store contract and Svelte 5 runes (via $store subscription interop).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-query/CHANGELOG.md
+++ b/packages/in-tanstack-query/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-tanstack-query
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/in-tanstack-query/package.json
+++ b/packages/in-tanstack-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-query",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "TanStack Query adapter for noy-db — queryFn + mutationFn helpers that speak the Collection API, plus automatic invalidation from noy-db change events. Framework-agnostic (React / Vue / Solid / Svelte).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-table/CHANGELOG.md
+++ b/packages/in-tanstack-table/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-tanstack-table
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/in-tanstack-table/package.json
+++ b/packages/in-tanstack-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-table",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "TanStack Table bridge for noy-db — map Collection query state (sort, filter, pagination) into Table state and back, so a useSmartTable pattern drives the DB's query DSL without glue code.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-vue/CHANGELOG.md
+++ b/packages/in-vue/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — in-vue
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/in-vue/package.json
+++ b/packages/in-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-vue",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Vue 3 / Nuxt composables for noy-db — reactive useNoydb, useCollection, useSync, and biometric plugin",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-yjs/CHANGELOG.md
+++ b/packages/in-yjs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — in-yjs
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/in-yjs/package.json
+++ b/packages/in-yjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-yjs",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Yjs Y.Doc interop for noy-db — collaborative rich-text fields with encrypted-at-rest Yjs state",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-zustand/CHANGELOG.md
+++ b/packages/in-zustand/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-zustand
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/in-zustand/package.json
+++ b/packages/in-zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-zustand",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Zustand adapter for noy-db — factory that mirrors defineNoydbStore for Zustand users, auto-syncs state from noy-db change events, and supports optimistic mutations.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-email-otp/CHANGELOG.md
+++ b/packages/on-email-otp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/on-email-otp
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/on-email-otp/package.json
+++ b/packages/on-email-otp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-email-otp",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Email OTP second factor for noy-db — generates time-boxed one-time codes, delivers via a user-supplied transport (SMTP / SES / Postmark / any fn), and verifies in constant time. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-magic-link/CHANGELOG.md
+++ b/packages/on-magic-link/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/on-magic-link
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/on-magic-link/package.json
+++ b/packages/on-magic-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-magic-link",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Magic-link unlock for noy-db — one-time URL that opens a vault in a viewer-scoped session without a passphrase. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-oidc/CHANGELOG.md
+++ b/packages/on-oidc/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — on-oidc
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/on-oidc/package.json
+++ b/packages/on-oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-oidc",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "OAuth/OIDC bridge for noy-db — federated login (LINE, Google, Apple, Okta) with split-key key connector — server never sees plaintext",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-password/CHANGELOG.md
+++ b/packages/on-password/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/on-password
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/on-password/package.json
+++ b/packages/on-password/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-password",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Tier-2 password authenticator slot for noy-db. PBKDF2-SHA256 600K wraps the DEK set in its own keyring slot, distinct from the rarely-typed tier-1 phrase. Pair with @noy-db/on-email-otp or @noy-db/on-totp for the SaaS UX.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-pin/CHANGELOG.md
+++ b/packages/on-pin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/on-pin
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/on-pin/package.json
+++ b/packages/on-pin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-pin",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Session-resume PIN quick-lock for noy-db — after a full passphrase unlock, a short-lived PIN (or a per-device biometric) re-unlocks the cached DEKs without re-typing the passphrase. PIN never replaces the passphrase; only resumes an already-unlocked session.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-recovery/CHANGELOG.md
+++ b/packages/on-recovery/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/on-recovery
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/on-recovery/package.json
+++ b/packages/on-recovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-recovery",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "One-time printable recovery codes for noy-db — last-resort vault unlock when the passphrase, passkey, and OIDC provider are all unavailable. Base32 + checksum codes, PBKDF2-derived wrapping keys, burn-on-use. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-shamir/CHANGELOG.md
+++ b/packages/on-shamir/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @noy-db/on-shamir
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Removed the spurious `peer`+`dev` dependencies on `@noy-db/hub`. on-shamir is a self-contained primitive consumed by hub and never imported hub; the dead deps formed a `hub ↔ on-shamir` build cycle (see hub#211).
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/on-shamir/package.json
+++ b/packages/on-shamir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-shamir",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "k-of-n Shamir Secret Sharing of the vault KEK for multi-party unlock. Any K of N shares recombines the key; fewer than K leaks zero bits. Composable — each share can be protected by any other on-* method. Zero runtime dependencies.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",
@@ -43,12 +43,6 @@
     "test": "vitest run",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit"
-  },
-  "peerDependencies": {
-    "@noy-db/hub": "workspace:*"
-  },
-  "devDependencies": {
-    "@noy-db/hub": "workspace:*"
   },
   "keywords": [
     "noy-db",

--- a/packages/on-threat/CHANGELOG.md
+++ b/packages/on-threat/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/on-threat
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/on-threat/package.json
+++ b/packages/on-threat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-threat",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Threat-response primitives for noy-db — multi-attempt lockout, duress-passphrase data destruction, duress-passphrase honeypot decoy. Pure stateful helpers; the caller coordinates keyring + audit-ledger integration. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-totp/CHANGELOG.md
+++ b/packages/on-totp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/on-totp
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/on-totp/package.json
+++ b/packages/on-totp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-totp",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "TOTP (RFC 6238) authenticator-app second factor for noy-db — generate secrets, otpauth:// provisioning URIs, and constant-time code verification. Zero dependencies (HMAC-SHA1 via Web Crypto). Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-webauthn/CHANGELOG.md
+++ b/packages/on-webauthn/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — on-webauthn
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/on-webauthn/package.json
+++ b/packages/on-webauthn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-webauthn",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "WebAuthn hardware-key keyrings for noy-db — Touch ID, Face ID, Windows Hello, YubiKey, FIDO2 passkeys",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-aws-dynamo/CHANGELOG.md
+++ b/packages/to-aws-dynamo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — to-aws-dynamo
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-aws-dynamo/package.json
+++ b/packages/to-aws-dynamo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-aws-dynamo",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "AWS DynamoDB adapter for noy-db — single-table design, zero-knowledge cloud sync",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-aws-s3/CHANGELOG.md
+++ b/packages/to-aws-s3/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — to-aws-s3
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-aws-s3/package.json
+++ b/packages/to-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-aws-s3",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "AWS S3 adapter for noy-db — encrypted object storage with zero-knowledge cloud sync",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-browser-idb/CHANGELOG.md
+++ b/packages/to-browser-idb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — to-browser-idb
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-browser-idb/package.json
+++ b/packages/to-browser-idb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-browser-idb",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "IndexedDB adapter for noy-db with optional key obfuscation",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-browser-local/CHANGELOG.md
+++ b/packages/to-browser-local/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — to-browser-local
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-browser-local/package.json
+++ b/packages/to-browser-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-browser-local",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "localStorage adapter for noy-db with optional key obfuscation",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-cloudflare-d1/CHANGELOG.md
+++ b/packages/to-cloudflare-d1/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-cloudflare-d1
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-cloudflare-d1/package.json
+++ b/packages/to-cloudflare-d1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-cloudflare-d1",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Cloudflare D1 adapter for noy-db — SQLite at the edge, running inside Cloudflare Workers. Accepts a D1Database binding and speaks the noy-db store contract via D1's prepare/bind API.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-cloudflare-r2/CHANGELOG.md
+++ b/packages/to-cloudflare-r2/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-cloudflare-r2
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-cloudflare-r2/package.json
+++ b/packages/to-cloudflare-r2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-cloudflare-r2",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Cloudflare R2 adapter for noy-db — S3-compatible object storage with zero egress fees. Thin wrapper around @noy-db/to-aws-s3 configured for the R2 endpoint. casAtomic: false (same caveat as S3).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-drive/CHANGELOG.md
+++ b/packages/to-drive/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-drive
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-drive/package.json
+++ b/packages/to-drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-drive",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Google Drive bundle store for noy-db. Stores the whole vault as a single .noydb file in Drive's hidden appDataFolder; opaque ULID filenames never leak compartment names. Driver-agnostic — bring your own OAuth token.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-file/CHANGELOG.md
+++ b/packages/to-file/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — to-file
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-file/package.json
+++ b/packages/to-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-file",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "JSON file adapter for noy-db — encrypted document store on local disk, USB sticks, or network drives",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-icloud/CHANGELOG.md
+++ b/packages/to-icloud/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-icloud
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-icloud/package.json
+++ b/packages/to-icloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-icloud",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "iCloud Drive bundle store for noy-db — macOS-aware persistence that detects eviction stubs (.icloud) and conflict files automatically. Treats each vault as a single .noydb bundle, safe for the Apple ecosystem.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-memory/CHANGELOG.md
+++ b/packages/to-memory/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — to-memory
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-memory/package.json
+++ b/packages/to-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-memory",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "In-memory adapter for noy-db — ideal for testing, development, and ephemeral workloads",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-meter/CHANGELOG.md
+++ b/packages/to-meter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-meter
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-meter/package.json
+++ b/packages/to-meter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-meter",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Pass-through meter for @noy-db/to-* stores — wraps any NoydbStore and records per-method latency percentiles, error rates, and byte counts on real traffic. Optional synthetic liveness probe emits degraded / restored events. No synthetic benchmarks (see @noy-db/to-probe for that) — this measures what your app is actually doing.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-mysql/CHANGELOG.md
+++ b/packages/to-mysql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-mysql
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-mysql/package.json
+++ b/packages/to-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-mysql",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "MySQL / MariaDB adapter for noy-db — encrypted-envelope KV with JSON column. Works with any duck-typed mysql2-style pool/connection. casAtomic: true via UPDATE … WHERE v = ?.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-nfs/CHANGELOG.md
+++ b/packages/to-nfs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-nfs
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-nfs/package.json
+++ b/packages/to-nfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-nfs",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "NFS network-file store for noy-db. Same indexed layout as @noy-db/to-file, with pre-flight checks for nolock / noac mount options that silently break versioning guarantees on stock NFS mounts.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-postgres/CHANGELOG.md
+++ b/packages/to-postgres/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-postgres
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-postgres/package.json
+++ b/packages/to-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-postgres",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "PostgreSQL adapter for noy-db — encrypted-envelope KV with jsonb column. Works with any duck-typed pg-style Client (node-postgres, postgres.js, pg-native, Supabase, Neon serverless). casAtomic: true via UPDATE … WHERE _v = ?.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-probe/CHANGELOG.md
+++ b/packages/to-probe/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-probe
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-probe/package.json
+++ b/packages/to-probe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-probe",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Diagnostic companion for the @noy-db/to-* store family — not itself a storage backend. Setup-time suitability test + topology check + runtime reliability monitor. Exercises the 6-method NoydbStore contract across five axes (write latency, CAS integrity, hydration cost, sync economics, network resilience) and produces a structured risk-scored report.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-smb/CHANGELOG.md
+++ b/packages/to-smb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-smb
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-smb/package.json
+++ b/packages/to-smb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-smb",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "SMB/CIFS network file store for noy-db. Works against Windows file servers, NAS devices (Synology/QNAP/Netgear), and corporate shared drives via NTLM or Kerberos auth — no OS mount required.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-sqlite/CHANGELOG.md
+++ b/packages/to-sqlite/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-sqlite
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-sqlite/package.json
+++ b/packages/to-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-sqlite",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "SQLite adapter for noy-db — single-file local encrypted document store. Works with better-sqlite3, node:sqlite (Node 22+), or bun:sqlite via a duck-typed Database interface. casAtomic: true (BEGIN IMMEDIATE + UPDATE WHERE _v=?).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-ssh/CHANGELOG.md
+++ b/packages/to-ssh/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-ssh
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-ssh/package.json
+++ b/packages/to-ssh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-ssh",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "SSH/SFTP store for noy-db — remote encrypted document storage over SSH using public-key auth. Any Linux/macOS server with sshd running becomes a noy-db backend; leverages existing ~/.ssh keys or ssh-agent. Key-only auth (no passwords).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-supabase/CHANGELOG.md
+++ b/packages/to-supabase/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-supabase
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-supabase/package.json
+++ b/packages/to-supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-supabase",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Supabase adapter for noy-db — Postgres + Storage combo. Routes records to @noy-db/to-postgres via the Supabase Postgres pool and optional blob routing via Supabase Storage.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-turso/CHANGELOG.md
+++ b/packages/to-turso/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-turso
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-turso/package.json
+++ b/packages/to-turso/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-turso",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "Turso / libSQL adapter for noy-db — edge SQLite with built-in replication. Wraps @libsql/client through a small async shim that speaks the same noy-db store contract as @noy-db/to-sqlite.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-webdav/CHANGELOG.md
+++ b/packages/to-webdav/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-webdav
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/packages/to-webdav/package.json
+++ b/packages/to-webdav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-webdav",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "description": "WebDAV adapter for noy-db — encrypted object storage over the WebDAV protocol. Works with Nextcloud, ownCloud, Apache mod_dav, and any RFC 4918 server. Pure fetch()-based, zero dependencies.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/playground/cli/CHANGELOG.md
+++ b/playground/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/playground-cli
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/playground/cli/package.json
+++ b/playground/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/playground-cli",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "private": true,
   "type": "module",
   "description": "Interactive guided CLI demo of noy-db's hub + storage backends",

--- a/playground/nuxt/CHANGELOG.md
+++ b/playground/nuxt/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/playground-nuxt
 
+## 0.1.0-pre.16
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Patch Changes

--- a/playground/nuxt/package.json
+++ b/playground/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/playground-nuxt",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "private": true,
   "description": "Reference Nuxt 4 + @noy-db/in-nuxt accounting demo — integration against a real Vue/Pinia consumer",
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -476,11 +476,7 @@ importers:
         specifier: workspace:*
         version: link:../hub
 
-  packages/on-shamir:
-    devDependencies:
-      '@noy-db/hub':
-        specifier: workspace:*
-        version: link:../hub
+  packages/on-shamir: {}
 
   packages/on-threat:
     devDependencies:

--- a/showcases/CHANGELOG.md
+++ b/showcases/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/showcases
 
+## 0.1.0-pre.16
+
+### Minor Changes
+
+- New showcase `87-noydb-describe.showcase.test.ts` — `noydb describe` bundle audit walkthrough ([#176](https://github.com/vLannaAi/noy-db/issues/176)).
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.1.0-pre.16
+
 ## 0.1.0-pre.15
 
 ### Minor Changes

--- a/showcases/package.json
+++ b/showcases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/showcases",
-  "version": "0.1.0-pre.15",
+  "version": "0.1.0-pre.16",
   "private": true,
   "description": "Automated end-to-end showcases for noy-db — each showcase doubles as a test, demo, and tutorial covering a specific topology pattern.",
   "type": "module",


### PR DESCRIPTION
Lockstep bump of all 63 workspace packages `0.1.0-pre.15` → `0.1.0-pre.16`.

## Headline
- **Sealing dimension foundation** + **`at-*` provider family debut** (`@noy-db/at-env` #187, `@noy-db/at-macos-keychain` #191) on a new `SealingKeyProvider` contract + sealed envelope (#14/#186).
- Managed-passphrase mode, `db.rotateRecovery()` (#121), Shamir recovery dispatch (#196 s1), sealed bundle delivery (#197 s1), variable-N derivations (#200 s1).
- Schema introspection trio: persisted JSON Schema (#174), `vault.dumpSchema()` (#175), `noydb describe` (#176).

## Build fix — unblocks main
`main` has been **red since #196**: hub began importing on-shamir's secret-sharing engine at runtime, and on-shamir's never-imported `peer`+`dev` deps on hub closed a `hub ↔ on-shamir` turbo build cycle (#196 → #197 all failed CI). on-shamir is a self-contained primitive *consumed by* hub, so those deps were dead metadata — removed. Proper decoupling via an injected provider is deferred to **#211**.

## API surface lock
`autoPassphrases`, `sealedPassphrases`, `recoverManagedPassphrase`, `rotateRecovery`, `managedPassphrase` are now public API — future slices extend, not rename.

## Verification
All gates green locally: build (61), lint, typecheck, check-architecture, validate-features, `--frozen-lockfile`. Only `package.json` / `CHANGELOG.md` / `ROADMAP.md` / `features.yaml` / lockfile changed — no source changes.

Release: tag `v0.1.0-pre.16` → GitHub Release with **prerelease=true** publishes `@next`.