### PR TITLE
feat(hub): 0.2 Workstream A — decouple hub↔on-shamir via injected ShamirRecoveryProvider (#211) [BREAKING]

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -12,3 +12,5 @@ Shamir recovery now requires an injected provider.
    ```
 
 > Note: when multiple Shamir recovery entries are enrolled, supply the shares for a **single** entry per recovery attempt (optionally with `entryId`). Mixing shares from different entries in one call no longer recovers.
+
+> Managed-passphrase mode mandates a strong recovery profile, and Shamir is the only one — so **managed-mode vaults now also require a `shamirRecovery` provider**. Add `@noy-db/on-shamir` and pass `shamirRecovery: shamirRecoveryProvider()` to `createNoydb`.

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,0 +1,12 @@
+## 0.1 → 0.2
+
+**Breaking:** `@noy-db/hub` no longer re-exports the Shamir share codecs, and
+Shamir recovery now requires an injected provider.
+
+1. If you imported `encodeShareBase32` / `decodeShareBase32` from `@noy-db/hub`,
+   import them from `@noy-db/on-shamir` instead.
+2. If you use `profile: 'shamir'` recovery, pass the provider:
+   ```ts
+   import { shamirRecoveryProvider } from '@noy-db/on-shamir'
+   const db = await createNoydb({ store, shamirRecovery: shamirRecoveryProvider() })
+   ```

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -10,3 +10,5 @@ Shamir recovery now requires an injected provider.
    import { shamirRecoveryProvider } from '@noy-db/on-shamir'
    const db = await createNoydb({ store, shamirRecovery: shamirRecoveryProvider() })
    ```
+
+> Note: when multiple Shamir recovery entries are enrolled, supply the shares for a **single** entry per recovery attempt (optionally with `entryId`). Mixing shares from different entries in one call no longer recovers.

--- a/docs/superpowers/plans/2026-05-24-0.2-workstream-A-shamir-decouple.md
+++ b/docs/superpowers/plans/2026-05-24-0.2-workstream-A-shamir-decouple.md
@@ -1,0 +1,427 @@
+# 0.2 Workstream A — Shamir decouple (#211) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove hub's static dependency on `@noy-db/on-shamir` by injecting a string-level `ShamirRecoveryProvider`, eliminating the `hub ↔ on-shamir` build cycle and the consumer-visible codec re-export (the breaking change that earns `0.2`).
+
+**Architecture:** Mirror the existing `SealingKeyProvider` pattern — interface in hub, implementation in the `on-*` package, injected via a `createNoydb` option. The interface is *string-level* (`splitToShares`/`combineShares`) so hub never references `RawShare` or the codecs. on-shamir gains a `shamirRecoveryProvider()` factory.
+
+**Tech Stack:** TypeScript (strict), pnpm workspace, turbo, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-05-24-0.2-at-family-and-auto-unlock-design.md` (Workstream A). Build order: this lands **first**.
+
+---
+
+### Task 1: `ShamirRecoveryProvider` interface + on-shamir implementation
+
+**Files:**
+- Create: `packages/hub/src/team/shamir-recovery-provider.ts`
+- Modify: `packages/hub/src/index.ts` (export the type)
+- Modify: `packages/on-shamir/src/index.ts` (add `shamirRecoveryProvider()`)
+- Test: `packages/on-shamir/__tests__/recovery-provider.test.ts`
+
+- [ ] **Step 1: Write the interface in hub**
+
+```ts
+// packages/hub/src/team/shamir-recovery-provider.ts
+/**
+ * String-level Shamir provider injected into hub for `profile: 'shamir'`
+ * recovery. Keeps hub free of any `@noy-db/on-shamir` import — hub never
+ * sees `RawShare` or the share codecs. Implemented by
+ * `shamirRecoveryProvider()` from `@noy-db/on-shamir`.
+ */
+export interface ShamirRecoveryProvider {
+  /** Split `secret` into `n` base32 share strings; any `k` recombine it. */
+  splitToShares(secret: Uint8Array, k: number, n: number): string[]
+  /**
+   * Recombine `k`+ share strings into the secret. MUST throw on malformed,
+   * truncated, insufficient, or mismatched shares.
+   */
+  combineShares(shares: readonly string[]): Uint8Array
+}
+```
+
+- [ ] **Step 2: Export the type from hub index**
+
+In `packages/hub/src/index.ts`, add alongside the other team-type exports:
+
+```ts
+export type { ShamirRecoveryProvider } from './team/shamir-recovery-provider.js'
+```
+
+- [ ] **Step 3: Write the failing on-shamir contract test**
+
+```ts
+// packages/on-shamir/__tests__/recovery-provider.test.ts
+import { describe, it, expect } from 'vitest'
+import { shamirRecoveryProvider } from '../src/index.js'
+
+describe('shamirRecoveryProvider', () => {
+  it('round-trips a secret through split/combine (2-of-3)', () => {
+    const p = shamirRecoveryProvider()
+    const secret = new Uint8Array(32).map((_, i) => i + 1)
+    const shares = p.splitToShares(secret, 2, 3)
+    expect(shares).toHaveLength(3)
+    expect(p.combineShares([shares[0]!, shares[2]!])).toEqual(secret)
+  })
+
+  it('throws when below threshold / on garbage', () => {
+    const p = shamirRecoveryProvider()
+    expect(() => p.combineShares(['not-a-share'])).toThrow()
+  })
+})
+```
+
+- [ ] **Step 4: Run it; expect FAIL (shamirRecoveryProvider not exported)**
+
+Run: `pnpm --filter @noy-db/on-shamir test -- recovery-provider`
+Expected: FAIL — `shamirRecoveryProvider is not a function`.
+
+- [ ] **Step 5: Implement `shamirRecoveryProvider()` in on-shamir**
+
+```ts
+// packages/on-shamir/src/index.ts  (add near the other exports)
+import { splitSecret, combineSecret } from './shamir.js'
+import { encodeShareBase32, decodeShareBase32 } from './share-format.js'
+
+/** Structural match for hub's ShamirRecoveryProvider (no hub import — avoids the cycle). */
+export interface ShamirRecoveryProvider {
+  splitToShares(secret: Uint8Array, k: number, n: number): string[]
+  combineShares(shares: readonly string[]): Uint8Array
+}
+
+export function shamirRecoveryProvider(): ShamirRecoveryProvider {
+  return {
+    splitToShares: (secret, k, n) => splitSecret(secret, k, n).map(encodeShareBase32),
+    combineShares: (shares) => combineSecret(shares.map(decodeShareBase32)),
+  }
+}
+```
+
+- [ ] **Step 6: Run; expect PASS**
+
+Run: `pnpm --filter @noy-db/on-shamir test -- recovery-provider`
+Expected: PASS (2 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/hub/src/team/shamir-recovery-provider.ts packages/hub/src/index.ts packages/on-shamir/src/index.ts packages/on-shamir/__tests__/recovery-provider.test.ts
+git commit -m "feat(hub,on-shamir): ShamirRecoveryProvider interface + shamirRecoveryProvider() impl (#211)"
+```
+
+---
+
+### Task 2: Refactor hub recovery functions to use the provider
+
+**Files:**
+- Modify: `packages/hub/src/team/recovery.ts` (`mintShamirRecoveryEntry`, `unwrapDeksFromShamirEntry`, `ShamirRecoveryEntry` type, drop re-export + import)
+- Modify: `packages/hub/src/team/rotate-recover.ts` (`recoverViaShamir`, drop import)
+
+- [ ] **Step 1: Make `xCoords` optional on the entry type**
+
+In `recovery.ts`, change `ShamirRecoveryEntry`:
+
+```ts
+  /** x-coordinates of the n minted shares. Informational. Omitted as of 0.2
+   *  (string-level provider doesn't expose share x-coords); kept optional so
+   *  pre-0.2 entries still read. */
+  readonly xCoords?: ReadonlyArray<number>
+```
+
+- [ ] **Step 2: Rewrite `mintShamirRecoveryEntry` to take the provider**
+
+Replace its signature + body (the `splitSecret`/`encodeShareBase32`/`xCoords` block):
+
+```ts
+export async function mintShamirRecoveryEntry(
+  provider: ShamirRecoveryProvider,
+  deks: Map<string, CryptoKey>,
+  entryId: string,
+  k: number,
+  n: number,
+  label?: string,
+): Promise<{ entry: ShamirRecoveryEntry; shareStrings: string[] }> {
+  const recoverySecret = crypto.getRandomValues(new Uint8Array(32))
+  try {
+    const credential = bytesToBase64(recoverySecret)
+    const blob = await mintWrappedDeksBlob(deks, credential)
+    const shareStrings = provider.splitToShares(recoverySecret, k, n)
+    const entry: ShamirRecoveryEntry = {
+      ...blob, entryId, k, n,
+      enrolledAt: new Date().toISOString(),
+      ...(label !== undefined && { label }),
+    }
+    return { entry, shareStrings }
+  } finally {
+    recoverySecret.fill(0)
+  }
+}
+```
+
+Add the import at the top of `recovery.ts`:
+
+```ts
+import type { ShamirRecoveryProvider } from './shamir-recovery-provider.js'
+```
+
+- [ ] **Step 3: Rewrite `unwrapDeksFromShamirEntry` to take provider + share strings**
+
+```ts
+export async function unwrapDeksFromShamirEntry(
+  provider: ShamirRecoveryProvider,
+  entry: ShamirRecoveryEntry,
+  shareStrings: readonly string[],
+): Promise<Map<string, CryptoKey>> {
+  if (shareStrings.length < entry.k) {
+    throw new Error(
+      `Insufficient shares: this Shamir entry needs ${entry.k} of ${entry.n}, `
+      + `but ${shareStrings.length} were provided.`,
+    )
+  }
+  const secret = provider.combineShares(shareStrings)
+  try {
+    return await unwrapDeksFromBlob(entry, bytesToBase64(secret))
+  } finally {
+    secret.fill(0)
+  }
+}
+```
+
+- [ ] **Step 4: Delete the on-shamir import and the re-export in `recovery.ts`**
+
+Remove the top-of-file block:
+```ts
+import { splitSecret, combineSecret, encodeShareBase32, type RawShare } from '@noy-db/on-shamir'
+```
+and the re-export line (was `recovery.ts:327`):
+```ts
+export { encodeShareBase32, decodeShareBase32 } from '@noy-db/on-shamir'
+```
+
+- [ ] **Step 5: Rewrite `recoverViaShamir` in `rotate-recover.ts` to use strings + provider**
+
+Change its signature to accept the provider, delete the `decodeShareBase32` block (lines ~607-618), and pass strings straight through. The threshold/iterate logic stays, but `unwrapDeksFromShamirEntry` now takes `(provider, entry, shareStrings)`:
+
+```ts
+async function recoverViaShamir(
+  provider: ShamirRecoveryProvider,
+  store: NoydbStore,
+  vault: string,
+  userId: string,
+  input: /* existing shamir RecoverPassphraseInput */,
+): Promise<...> {
+  // (keep keyring load + empty-entries guard)
+  // DELETE the decodeShareBase32 try/catch — combineShares validates strings.
+  const shareStrings = input.payload.shares
+  const allEntries = await loadShamirRecoveryEntries(store, vault)
+  // ...for each candidate entry:
+  //   const deks = await unwrapDeksFromShamirEntry(provider, entry, shareStrings)
+  // (replace the old `matchingShares: RawShare[]` plumbing with shareStrings)
+}
+```
+
+Remove `unwrapDeksFromShamirEntry` from the `@noy-db/on-shamir`-adjacent imports and delete the `decodeShareBase32`/`RawShare` import from `'@noy-db/on-shamir'` at the top of `rotate-recover.ts`. Add:
+```ts
+import type { ShamirRecoveryProvider } from './shamir-recovery-provider.js'
+```
+
+- [ ] **Step 6: Typecheck hub (will fail at call sites — expected, fixed in Task 3)**
+
+Run: `pnpm --filter @noy-db/hub typecheck`
+Expected: errors only at `noydb.ts` call sites + `recoverViaShamir` caller (Task 3 fixes them). No errors inside `recovery.ts`/`rotate-recover.ts` bodies.
+
+- [ ] **Step 7: Commit (WIP)**
+
+```bash
+git add packages/hub/src/team/recovery.ts packages/hub/src/team/rotate-recover.ts
+git commit -m "refactor(hub): shamir recovery fns take ShamirRecoveryProvider (string-level) (#211)"
+```
+
+---
+
+### Task 3: Thread the provider through `noydb.ts` + add the option
+
+**Files:**
+- Modify: `packages/hub/src/types.ts` (add `shamirRecovery?` to `NoydbOptions`)
+- Modify: `packages/hub/src/noydb.ts` (pass `this.options.shamirRecovery` into the 3 call sites; clear error when absent)
+- Modify: `packages/hub/src/team/rotate-recover.ts` (dispatch passes provider to `recoverViaShamir`)
+
+- [ ] **Step 1: Add the option to `NoydbOptions`**
+
+In `types.ts` (near `sealingKey?: SealingKeyProvider`):
+
+```ts
+  /** Required to use `profile: 'shamir'` recovery. Pass
+   *  `shamirRecoveryProvider()` from `@noy-db/on-shamir`. */
+  readonly shamirRecovery?: ShamirRecoveryProvider
+```
+
+Add the import: `import type { ShamirRecoveryProvider } from './team/shamir-recovery-provider.js'`.
+
+- [ ] **Step 2: Add a guard helper in `noydb.ts`**
+
+```ts
+private requireShamirProvider(): ShamirRecoveryProvider {
+  const p = this.options.shamirRecovery
+  if (!p) {
+    throw new Error(
+      "shamir recovery requires a ShamirRecoveryProvider — pass "
+      + "shamirRecovery: shamirRecoveryProvider() from '@noy-db/on-shamir' to createNoydb()",
+    )
+  }
+  return p
+}
+```
+
+- [ ] **Step 3: Pass the provider at the two `mintShamirRecoveryEntry` call sites**
+
+At `noydb.ts:1950` and `:2260`, change:
+```ts
+const { entry, shareStrings } = await mintShamirRecoveryEntry(
+  this.requireShamirProvider(),
+  deks, entryId, k, n, label,
+)
+```
+(insert `this.requireShamirProvider()` as the new first arg).
+
+- [ ] **Step 4: Pass the provider into the recover dispatch**
+
+At `rotate-recover.ts:458` (`return recoverViaShamir(store, vault, userId, input)`), thread the provider from the recover entrypoint's caller. The `recoverPassphrase` method in `noydb.ts` calls into rotate-recover — pass `this.requireShamirProvider()` down to the `recoverViaShamir` call so it becomes `recoverViaShamir(provider, store, vault, userId, input)`.
+
+- [ ] **Step 5: Typecheck hub — expect PASS**
+
+Run: `pnpm --filter @noy-db/hub typecheck`
+Expected: PASS (0 errors).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/types.ts packages/hub/src/noydb.ts packages/hub/src/team/rotate-recover.ts
+git commit -m "feat(hub): createNoydb({ shamirRecovery }) option threads provider to recovery (#211)"
+```
+
+---
+
+### Task 4: Drop the hub→on-shamir dependency; verify no cycle
+
+**Files:**
+- Modify: `packages/hub/package.json` (remove `@noy-db/on-shamir` from `dependencies`)
+- Modify: `packages/hub/src/index.ts` (remove any `encodeShareBase32`/`decodeShareBase32` re-exports if present)
+
+- [ ] **Step 1: Remove the dependency**
+
+In `packages/hub/package.json`, delete the `"@noy-db/on-shamir": "workspace:*"` line from `dependencies`.
+
+- [ ] **Step 2: Remove stale codec re-exports from hub index (if any)**
+
+Run: `grep -n "encodeShareBase32\|decodeShareBase32\|on-shamir" packages/hub/src/index.ts`
+Delete any line that re-exports those from on-shamir.
+
+- [ ] **Step 3: Reinstall + build; verify no cycle**
+
+Run: `pnpm install && pnpm turbo build`
+Expected: PASS, no `Cyclic dependency` warning, all package builds succeed.
+
+- [ ] **Step 4: Confirm hub has zero on-shamir references**
+
+Run: `grep -rn "on-shamir" packages/hub/src/ || echo CLEAN`
+Expected: `CLEAN`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/package.json packages/hub/src/index.ts pnpm-lock.yaml
+git commit -m "refactor(hub): drop @noy-db/on-shamir dependency — cycle broken (#211)"
+```
+
+---
+
+### Task 5: Fix existing tests + add new ones + MIGRATING.md
+
+**Files:**
+- Modify: `packages/hub/__tests__/shamir-recovery.test.ts` (+ any other suite constructing a vault that exercises shamir)
+- Create: `MIGRATING.md` (or append a `0.2` section)
+
+- [ ] **Step 1: Inject the provider in existing shamir tests**
+
+Every `createNoydb({...})` in shamir-exercising tests must now pass the provider:
+
+```ts
+import { shamirRecoveryProvider } from '@noy-db/on-shamir'
+const db = await createNoydb({ store, shamirRecovery: shamirRecoveryProvider() })
+```
+
+Add `@noy-db/on-shamir` to `packages/hub`'s **devDependencies** (tests may import it; it's not a runtime dep).
+
+- [ ] **Step 2: Add the "no provider wired" test**
+
+```ts
+it('shamir enroll throws a clear error when no provider is configured', async () => {
+  const db = await createNoydb({ store })            // no shamirRecovery
+  await expect(
+    db.enrollRecovery(vault, { profile: 'shamir', k: 2, n: 3 }),
+  ).rejects.toThrow(/requires a ShamirRecoveryProvider/)
+})
+```
+
+- [ ] **Step 3: Run the hub shamir suite — expect PASS**
+
+Run: `pnpm --filter @noy-db/hub test -- shamir`
+Expected: PASS (existing round-trips green via injected provider + the new error test).
+
+- [ ] **Step 4: Write the MIGRATING note**
+
+```markdown
+## 0.1 → 0.2
+
+**Breaking:** `@noy-db/hub` no longer re-exports the Shamir share codecs, and
+Shamir recovery now requires an injected provider.
+
+1. If you imported `encodeShareBase32` / `decodeShareBase32` from `@noy-db/hub`,
+   import them from `@noy-db/on-shamir` instead.
+2. If you use `profile: 'shamir'` recovery, pass the provider:
+   ```ts
+   import { shamirRecoveryProvider } from '@noy-db/on-shamir'
+   const db = await createNoydb({ store, shamirRecovery: shamirRecoveryProvider() })
+   ```
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/__tests__ packages/hub/package.json MIGRATING.md
+git commit -m "test(hub): inject ShamirRecoveryProvider in tests + no-provider error; MIGRATING note (#211)"
+```
+
+---
+
+### Task 6: Full gate green
+
+- [ ] **Step 1: Run the full gate**
+
+Run:
+```bash
+pnpm install --frozen-lockfile && pnpm turbo build && pnpm turbo lint && pnpm turbo typecheck && node scripts/check-architecture.mjs && node scripts/validate-features.mjs
+```
+Expected: all exit 0; build has no cycle.
+
+- [ ] **Step 2: Confirm the breaking change is real**
+
+Run: `node -e "const h=require('./packages/hub/dist/index.cjs'); console.log('encodeShareBase32' in h ? 'STILL EXPORTED (bug)' : 'removed OK')"`
+Expected: `removed OK`.
+
+- [ ] **Step 3: Final commit if anything pending**
+
+```bash
+git add -A && git commit -m "chore(hub): workstream A green — shamir decoupled (#211)" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage (Workstream A):** interface (T1) ✓, on-shamir impl (T1) ✓, string-level so hub never touches RawShare (T2) ✓, injection option (T3) ✓, no-provider error (T3/T5) ✓, drop import + re-export (T2/T4) ✓, drop hub dep + cycle gone (T4) ✓, migration note (T5) ✓.
+- **Placeholders:** `recoverViaShamir`'s input type is referenced as "existing shamir RecoverPassphraseInput" — that's an existing type at the call site, not a new one to define; the engineer reads it in `rotate-recover.ts`. All new types (`ShamirRecoveryProvider`) are defined in T1.
+- **Type consistency:** `splitToShares`/`combineShares` names used identically across T1 (hub interface), T1 (on-shamir impl), T2 (call sites), T3 (option). `shamirRecovery` option name consistent T3↔T5↔MIGRATING.
+- **xCoords decision:** made optional (T2.1), omitted from new entries — reading-compatible with pre-0.2 entries.

--- a/docs/superpowers/specs/2026-05-24-0.2-at-family-and-auto-unlock-design.md
+++ b/docs/superpowers/specs/2026-05-24-0.2-at-family-and-auto-unlock-design.md
@@ -1,0 +1,228 @@
+# `0.2.0-pre.1` — `at-*` family graduation + bundle auto-unlock
+
+> Umbrella design for the `0.1 → 0.2` line. Introduces the `at-*` sealing-key
+> provider family as a first-class catalog member, decouples hub from
+> `@noy-db/on-shamir` (the breaking change that earns the minor bump), adds the
+> cloud-KMS providers, and generalises bundle auto-unlock to the credential the
+> consumer's login surface actually defaults to (the live niwat request, #215).
+
+## 0. Status
+
+- Date: 2026-05-24
+- Line: `0.1.0-pre.16` → **`0.2.0-pre.1`** (staged: `@next` now; promote `0.2.0` → `latest` later)
+- Consumer driver: **niwat #92 / #215** — one-click `/login` from a delivered bundle, across the user's enrolled tier. NOT a recovery feature.
+- Tracks: #211 (decouple), #214 (features.yaml), #215 (auto-unlock), milestone #9 (cloud-KMS subset)
+
+### 0.1 Explicitly OUT of scope (anti-drift)
+
+These came up during design and are **deliberately excluded** — do not build them here:
+
+- **Multi-channel recovery profile** — no consumer request; #196's remnant. Stays `RecoveryProfileNotImplementedError`.
+- **Admin-mediated recovery profile (#210)** — same.
+- **A general profile-keyed recovery-provider *registry*** — #211 is a *minimal* shamir decouple, not an extensible registry. (Multi-channel/admin-mediated, if ever built, compose hub's existing factor engine and need no injection seam — so a registry would be speculative.)
+- **WebAuthn auto-unlock** — hardware-bound; nothing portable to carry in a bundle. Auto-unlock covers knowledge factors only.
+
+## 1. Version rationale
+
+The `0.1 → 0.2` minor bump is **earned by the breaking change in Workstream A**: hub stops re-exporting the Shamir share codecs and now requires an injected provider for Shamir recovery. In `0.x` semver a minor bump is the breaking-change signal. Everything else (providers, auto-unlock, docs) is additive and could have been a `pre.17`; #211 is what makes it `0.2`.
+
+Staged release: cut `0.2.0-pre.1` to `@next`, let the breaking refactor + 3 new cloud integrations bake on the early-adopter channel (esp. real-cloud provider tests), then promote `0.2.0` → `latest`.
+
+## 2. Build order
+
+```
+A. #211 decouple (breaking, keystone)  →  B. cloud-KMS trio  →  C. #215 auto-unlock  →  D. #214 features.yaml + E. docs  →  release
+```
+
+Each workstream is its own PR. A goes first (sets the API shape + the version story). B and C are independent of each other; D/E land last (they document/register what A–C produced).
+
+---
+
+## Workstream A — #211: minimal Shamir decouple *(breaking, keystone)*
+
+### A.1 Problem
+`hub/src/team/recovery.ts` + `rotate-recover.ts` import `splitSecret`/`combineSecret`/`encodeShareBase32`/`RawShare` from `@noy-db/on-shamir` and re-export the codecs (`recovery.ts:327`). That makes hub runtime-depend on the on-shamir package; combined with on-shamir's (now-removed) hub deps it formed a build cycle, and it inverts the core→plugin layering.
+
+### A.2 Design — string-level provider injection (no registry)
+Define a **single, minimal** provider interface in hub. It is string-level so hub never touches `RawShare` or the codecs:
+
+```ts
+// packages/hub/src/team/shamir-recovery-provider.ts (new)
+export interface ShamirRecoveryProvider {
+  /** Split a secret into `n` base32 share strings; any `k` recombine it. */
+  splitToShares(secret: Uint8Array, k: number, n: number): string[]
+  /** Recombine `k`+ share strings back to the secret. MUST throw on
+   *  insufficient/garbage/tampered input. */
+  combineShares(shares: string[]): Uint8Array
+}
+```
+
+`@noy-db/on-shamir` exports the implementation (wrapping `splitSecret`/`combineSecret`/`encodeShareBase32`/`decodeShareBase32` internally):
+
+```ts
+// packages/on-shamir/src/index.ts (add)
+export function shamirRecoveryProvider(): ShamirRecoveryProvider
+```
+
+> on-shamir does **not** import the interface type from hub (that would re-introduce the cycle). It either declares a structurally-identical local type or imports it `import type` only if a future shared types package exists. For 0.2: structural local type + a contract test asserting assignability. Document the duplication.
+
+### A.3 Injection surface
+Mirror the existing `sealingKey?: SealingKeyProvider` option (`types.ts:1844`):
+
+```ts
+interface NoydbOptions {
+  // …existing…
+  /** Required to use `profile: 'shamir'` recovery. Pass
+   *  `shamirRecoveryProvider()` from `@noy-db/on-shamir`. */
+  readonly shamirRecovery?: ShamirRecoveryProvider
+}
+```
+
+The Shamir branches in `recovery.ts`/`rotate-recover.ts` read `this.options.shamirRecovery`. If a `profile: 'shamir'` enroll/recover/rotate is attempted with no provider wired → throw a clear error:
+
+> `shamir recovery requires a ShamirRecoveryProvider — pass shamirRecovery: shamirRecoveryProvider() from '@noy-db/on-shamir' to createNoydb()`
+
+### A.4 The breaking change
+- **Remove** `import { … } from '@noy-db/on-shamir'` in `recovery.ts` + `rotate-recover.ts`.
+- **Remove** the re-export at `recovery.ts:327` (`export { encodeShareBase32, decodeShareBase32 } from '@noy-db/on-shamir'`). **← consumer-visible break.**
+- **Remove** `@noy-db/on-shamir` from hub's `dependencies`.
+
+Migration (→ `MIGRATING.md` + CHANGELOG, prominent):
+1. Consumers importing `encodeShareBase32` / `decodeShareBase32` via `@noy-db/hub` → import from `@noy-db/on-shamir` instead.
+2. Consumers using Shamir recovery → add `shamirRecovery: shamirRecoveryProvider()` to `createNoydb({...})`.
+
+### A.5 Files
+- new `packages/hub/src/team/shamir-recovery-provider.ts` (interface + export from index)
+- edit `packages/hub/src/team/recovery.ts`, `rotate-recover.ts` (use provider, drop import + re-export)
+- edit `packages/hub/src/types.ts` (`shamirRecovery?` option)
+- edit `packages/hub/package.json` (drop on-shamir dep)
+- add `packages/on-shamir/src/index.ts` (`shamirRecoveryProvider()`)
+- tests: hub shamir-recovery suite passes via injected provider; a "no provider wired → clear error" case; on-shamir contract test for assignability.
+
+### A.6 Acceptance
+- [ ] `pnpm turbo build` has no `hub ↔ on-shamir` cycle; hub has zero on-shamir imports.
+- [ ] Shamir enroll/recover/rotate work when `shamirRecovery` is injected.
+- [ ] Clear error when Shamir recovery is used without the provider.
+- [ ] `@noy-db/hub` no longer exports the share codecs (break documented).
+
+---
+
+## Workstream B — cloud-KMS provider trio
+
+Three new packages, same shape as `at-env`/`at-macos-keychain`. **No hub interface change** — `SealingKeyProvider.seal/unseal` already abstracts a remote encrypt/decrypt.
+
+| Package | `seal` / `unseal` | Peer dep | `id` format |
+|---|---|---|---|
+| `@noy-db/at-aws-kms` | KMS `Encrypt` / `Decrypt` | `@aws-sdk/client-kms` | `aws-kms:<keyArn>` |
+| `@noy-db/at-gcp-kms` | Cloud KMS `encrypt` / `decrypt` | `@google-cloud/kms` | `gcp-kms:<resourceName>` |
+| `@noy-db/at-azure-keyvault` | Key Vault wrapKey / unwrapKey | `@azure/keyvault-keys` + `@azure/identity` | `azure-kv:<keyId>` |
+
+Each package:
+- `export function <provider>SealingProvider(options): SealingKeyProvider` — `options` carry the key identifier + an optional pre-constructed SDK client (DI for testing); credentials come from the SDK's ambient chain (env/role/managed identity) — **the package never takes raw credentials**.
+- `seal(passphrase)` → remote encrypt → opaque ciphertext bytes; `unseal(bytes)` → remote decrypt → passphrase. `unseal` throws on any failure (hub treats as "cannot unlock").
+- `private: false`, `publishConfig.access: public`, `tag: latest`; README; LICENSE; CHANGELOG (debut).
+- Tests: **mock the SDK client** for CI (default), with **env-gated real-cloud tests** matching the existing showcase pattern (skip when creds absent).
+
+### B.1 Acceptance
+- [ ] Each provider round-trips seal→unseal against a mocked client.
+- [ ] Real-cloud tests are env-gated and skip cleanly without creds.
+- [ ] No raw credentials accepted; SDK ambient chain only. (Honors the project credential-handling rules.)
+
+---
+
+## Workstream C — #215: generalised bundle auto-unlock
+
+### C.1 Problem
+`autoPassphrases` (shipped pre.16) only auto-unlocks **passphrase-tier** users. niwat's login surface defaults to **password** (tier-2b) when enrolled, with passphrase as the "forgot?" fallback. So password-enrolled users have no first-class one-click delivery; niwat fakes it with a `_meta/demo-hints` plaintext envelope.
+
+### C.2 Design — `autoCredentials` umbrella
+On `writeNoydbBundle` options:
+
+```ts
+type AutoCredentialKind = 'passphrase' | 'password' | 'pin'
+
+interface AutoCredential { readonly kind: AutoCredentialKind; readonly value: string }
+
+interface WriteNoydbBundleOptions {
+  // …existing…
+  /** Per-user auto-unlock material, plaintext (public-by-design). */
+  readonly autoCredentials?: Readonly<Record<string /*userId*/, AutoCredential>>
+  /** Sealed equivalent — values sealed under a SealingKeyProvider; only a
+   *  recipient with the matching provider can unseal. */
+  readonly sealedCredentials?: Readonly<Record<string, AutoCredential>>
+  /** @deprecated sugar — equivalent to autoCredentials with kind:'passphrase'. Retained for back-compat. */
+  readonly autoPassphrases?: Readonly<Record<string, string>>
+  /** @deprecated sugar over sealedCredentials kind:'passphrase'. */
+  readonly sealedPassphrases?: /* existing pre.16 shape */
+}
+```
+
+- `autoPassphrases`/`sealedPassphrases` (pre.16) become **sugar** over the umbrella — no break; normalised internally to `kind:'passphrase'`.
+- `sealedCredentials` seals each `value` via the configured `SealingKeyProvider` (same path as `sealedPassphrases`).
+
+### C.3 Read side — `readNoydbBundle` + unlock
+On load, for each user the bundle carries a credential:
+- `passphrase` / `password` → perform the matching auto-login (`loginWithPassphrase` / password unlock) without surfacing the secret.
+- `pin` → **prefill** the in-RAM `QuickUnlockStore` one-shot; does **not** persist a PIN enrollment. (PIN is per-device quick-unlock; bundling an enrollment would be wrong.)
+- Sealed variant → unseal via the provider first; if no matching provider, surface a clear "sealed credential present but no provider configured" error.
+
+### C.4 Decisions (resolving #215's open questions)
+- **PIN = prefill, not enroll** (C.3). Documented.
+- **Umbrella name = `autoCredentials` / `sealedCredentials`**; the per-passphrase forms are kept as deprecated sugar.
+- **WebAuthn excluded** (hardware-bound).
+
+### C.5 Files
+- `packages/hub/src/bundle/bundle.ts` — write-side options + normalisation of the sugar; read-side credential dispatch.
+- `packages/hub/src/team/managed-passphrase.ts` — reuse `SealingKeyProvider` for `sealedCredentials`.
+- tests: per-kind round-trip (passphrase/password auto-login; PIN prefill); sealed round-trip with a `MemorySealingKeyProvider`; sealed-without-provider error; sugar back-compat (`autoPassphrases` still works).
+
+### C.6 Acceptance
+- [ ] A password-enrolled user auto-logs-in from a delivered bundle (the niwat gap).
+- [ ] `autoPassphrases`/`sealedPassphrases` still behave exactly as in pre.16.
+- [ ] `sealedCredentials` unseals only with the matching provider; clear error otherwise.
+- [ ] PIN prefills quick-unlock without persisting an enrollment.
+
+---
+
+## Workstream D — #214: `features.yaml` registration
+
+- Add a new top-level **`sealers:`** section (functional parallel to `transports:`/`adapters:`).
+- Extend `scripts/feature-schema.json` + `scripts/validate-features.mjs` to validate it (mirror the `transports` validation rules).
+- Register all five `at-*` providers: `at-env`, `at-macos-keychain`, `at-aws-kms`, `at-gcp-kms`, `at-azure-keyvault` — each with `package`, `subsystem_doc: docs/packages/at-hosts.md`, `status`, `showcases` (`[]` is allowed), `invariants`.
+- `node scripts/validate-features.mjs` green.
+
+> Schema/validator changes carry their own bug surface; this lands as its own PR **after** the providers exist, and the validator is run before commit. (This is why it was deliberately deferred out of pre.16.)
+
+---
+
+## Workstream E — docs overhaul (locked copy)
+
+The `at-*` copy was settled in brainstorming; place it:
+
+- **`docs/packages/README.md`** — add the 6th table row and quick-ref blurb:
+  - table: `` `at-` `` · *sealed **at** a trusted host* · `at-hosts.md` · `5`
+  - quick-ref (**brief**): *"The online complement to offline-first. A host you operate — Lambda, EC2, a worker — pulls a sealing key from its environment (env var, OS keychain, cloud KMS) and unseals a scoped slice of the vault to serve users who never hold its keys. The host can read what it unseals; you trust it because it's yours."*
+- **`docs/packages/at-hosts.md`** (new) — opens with the **long** copy (the "How a vault goes online without giving up its keys" passage, incl. the explicit trust-boundary paragraph). Catalog of the five providers.
+- **`README.md`** — add `at-*` to both family lists ("One core, many bridges" bullet + the trust-boundary note), and a sentence naming the **two trust boundaries**: zero-knowledge (`to-*`/`by-*`, never see plaintext) vs trusted-compute (`at-*`, *can* decrypt the scoped slice it unseals).
+- **`ROADMAP.md`** — `at-*` graduation + cloud-KMS + #215 under "Recently shipped" on release; carry milestone-9 remainder forward.
+
+> `at-*` "reads as" = **sealed `at` a trusted host**. The host/online story lives in the prose; "trusted host" is the noun (the package is the *provider*, the host is where unsealing happens — accurate across env/keychain/KMS).
+
+---
+
+## 3. Release mechanics
+
+Lockstep bump **all** packages → `0.2.0-pre.1` (now incl. the 3 new `at-aws-kms`/`at-gcp-kms`/`at-azure-keyvault`); manual lockstep (NOT changeset). CHANGELOGs (substantive for hub/on-shamir/the 3 new providers/bundle; stub elsewhere). Full gate — now with the required-status-checks from #213 (Build/Lint+typecheck/Spec coverage/Architecture invariants). PR → merge → `git fetch` → tag the **merged full SHA** → `gh release create v0.2.0-pre.1 --target <SHA> --prerelease` → `@next`. **The #211 breaking change is called out prominently in the release notes + `MIGRATING.md`.**
+
+## 4. Acceptance (release-level)
+- [ ] All workstream acceptance boxes checked.
+- [ ] `npm view @noy-db/hub@next version` → `0.2.0-pre.1`; `latest` unchanged.
+- [ ] 3 new `at-*` packages first-published to `@next`.
+- [ ] `MIGRATING.md` documents the Shamir breaking change.
+- [ ] `features.yaml` validator green with the `sealers:` section.
+
+## 5. Cross-references
+- Consumer: niwat #92, this-repo #215 (auto-unlock), #197 (parent)
+- Decouple: #211 · Registration: #214 · Providers: milestone #9 (#188/#189/#190 = the trio)
+- Foundation: `2026-05-23-sealing-at-dimension-foundation.md`; Shamir: `2026-05-23-shamir-recovery-dispatch.md`
+- Pattern mirror: `SealingKeyProvider` (`team/managed-passphrase.ts`), `by-*` family debut (`docs/packages/by-transports.md`)

--- a/packages/at-env/__tests__/at-env.test.ts
+++ b/packages/at-env/__tests__/at-env.test.ts
@@ -105,6 +105,7 @@ describe('@noy-db/at-env — integration with @noy-db/hub managed-passphrase mod
   it('round-trips a managed-mode vault end-to-end (no user passphrase typed)', async () => {
     const { createNoydb } = await import('@noy-db/hub')
     const { memory } = await import('@noy-db/to-memory')
+    const { shamirRecoveryProvider } = await import('@noy-db/on-shamir')
 
     const store = memory()
     const provider = envSealingProvider({ envVar: TEST_ENV })
@@ -116,6 +117,7 @@ describe('@noy-db/at-env — integration with @noy-db/hub managed-passphrase mod
       store, user: 'alice',
       passphraseMode: 'managed',
       sealingKey: provider,
+      shamirRecovery: shamirRecoveryProvider(),
     })
     const { vault: vault1 } = await db1.openVaultAndEnrollRecovery('demo', {
       recovery: [{ profile: 'shamir', k: 2, n: 3 }],
@@ -130,6 +132,7 @@ describe('@noy-db/at-env — integration with @noy-db/hub managed-passphrase mod
       store, user: 'alice',
       passphraseMode: 'managed',
       sealingKey: envSealingProvider({ envVar: TEST_ENV }),
+      shamirRecovery: shamirRecoveryProvider(),
     })
     const vault2 = await db2.openVault('demo')
     const note = await vault2.collection<{ id: string; note: string }>('notes').get('n1')

--- a/packages/at-env/package.json
+++ b/packages/at-env/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@noy-db/hub": "workspace:*",
+    "@noy-db/on-shamir": "workspace:*",
     "@noy-db/to-memory": "workspace:*",
     "@types/node": "^22.0.0"
   },

--- a/packages/at-macos-keychain/__tests__/integration.test.ts
+++ b/packages/at-macos-keychain/__tests__/integration.test.ts
@@ -10,6 +10,7 @@
 import { describe, it, expect } from 'vitest'
 import { createNoydb } from '@noy-db/hub'
 import { memory } from '@noy-db/to-memory'
+import { shamirRecoveryProvider } from '@noy-db/on-shamir'
 import type { KeychainEntry } from '../src/index.js'
 import { macosKeychainSealingProvider } from '../src/index.js'
 
@@ -38,6 +39,7 @@ describe('@noy-db/at-macos-keychain — integration with @noy-db/hub managed-pas
         account: 'alice@acme.example',
         entry: sharedEntry,
       }),
+      shamirRecovery: shamirRecoveryProvider(),
     })
     const { vault: vault1 } = await db1.openVaultAndEnrollRecovery('demo', {
       recovery: [{ profile: 'shamir', k: 2, n: 3 }],
@@ -58,6 +60,7 @@ describe('@noy-db/at-macos-keychain — integration with @noy-db/hub managed-pas
         account: 'alice@acme.example',
         entry: sharedEntry,
       }),
+      shamirRecovery: shamirRecoveryProvider(),
     })
     const vault2 = await db2.openVault('demo')
     const note = await vault2.collection<{ id: string; note: string }>('notes').get('n1')
@@ -78,6 +81,7 @@ describe('@noy-db/at-macos-keychain — integration with @noy-db/hub managed-pas
         account: 'alice',
         entry: memoryEntry(),
       }),
+      shamirRecovery: shamirRecoveryProvider(),
     })
     const { vault: vault1 } = await db1.openVaultAndEnrollRecovery('demo', {
       recovery: [{ profile: 'shamir', k: 2, n: 3 }],
@@ -99,6 +103,7 @@ describe('@noy-db/at-macos-keychain — integration with @noy-db/hub managed-pas
         account: 'bob', // different!
         entry: memoryEntry(),
       }),
+      shamirRecovery: shamirRecoveryProvider(),
     })
     await expect(db2.openVault('demo')).rejects.toThrow(/sealed under provider id|provider/i)
     db2.close()
@@ -117,6 +122,7 @@ describe('@noy-db/at-macos-keychain — integration with @noy-db/hub managed-pas
         account: 'persist-test',
         entry: sharedEntry,
       }),
+      shamirRecovery: shamirRecoveryProvider(),
     })
     const { vault: v1 } = await db1.openVaultAndEnrollRecovery('persist', {
       recovery: [{ profile: 'shamir', k: 2, n: 3 }],
@@ -138,6 +144,7 @@ describe('@noy-db/at-macos-keychain — integration with @noy-db/hub managed-pas
         account: 'persist-test',
         entry: sharedEntry,
       }),
+      shamirRecovery: shamirRecoveryProvider(),
     })
     const v2 = await db2.openVault('persist')
     const item = await v2.collection<{ id: string; v: number }>('items').get('i1')

--- a/packages/at-macos-keychain/package.json
+++ b/packages/at-macos-keychain/package.json
@@ -59,6 +59,7 @@
   "devDependencies": {
     "@napi-rs/keyring": "^1.1.0",
     "@noy-db/hub": "workspace:*",
+    "@noy-db/on-shamir": "workspace:*",
     "@noy-db/to-memory": "workspace:*",
     "@types/node": "^22.0.0"
   },

--- a/packages/hub/__tests__/managed-mode-strong-recovery.test.ts
+++ b/packages/hub/__tests__/managed-mode-strong-recovery.test.ts
@@ -26,6 +26,7 @@ import {
 } from '../src/index.js'
 import { ConflictError, ValidationError } from '../src/errors.js'
 import { ManagedRecoveryNotEnrolledError } from '../src/policy/errors.js'
+import { shamirRecoveryProvider } from '@noy-db/on-shamir'
 
 function inlineMemory(): NoydbStore {
   const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
@@ -103,6 +104,7 @@ describe('#195 — managed-mode strong-recovery enforcement', () => {
         user: ALICE,
         passphraseMode: 'managed',
         sealingKey: freshProvider('test-3'),
+        shamirRecovery: shamirRecoveryProvider(),
       })
 
       const result = await db.openVaultAndEnrollRecovery('acme', {
@@ -122,6 +124,7 @@ describe('#195 — managed-mode strong-recovery enforcement', () => {
       const db1 = await createNoydb({
         store, user: ALICE,
         passphraseMode: 'managed', sealingKey: provider,
+        shamirRecovery: shamirRecoveryProvider(),
       })
       await db1.openVaultAndEnrollRecovery('acme', {
         recovery: [{ profile: 'shamir', k: 2, n: 3 }],
@@ -168,6 +171,7 @@ describe('#195 — managed-mode strong-recovery enforcement', () => {
         user: ALICE,
         passphraseMode: 'managed',
         sealingKey: freshProvider('test-7'),
+        shamirRecovery: shamirRecoveryProvider(),
       })
       // Empty paper entries array — the paper profile is allowed
       // alongside shamir; the shamir profile is the one carrying the
@@ -187,6 +191,7 @@ describe('#195 — managed-mode strong-recovery enforcement', () => {
         user: ALICE,
         passphraseMode: 'managed',
         sealingKey: freshProvider('test-8'),
+        shamirRecovery: shamirRecoveryProvider(),
       })
       // First openVault throws (no strong recovery).
       await expect(db.openVault('acme')).rejects.toBeInstanceOf(ManagedRecoveryNotEnrolledError)
@@ -220,6 +225,7 @@ describe('#195 — managed-mode strong-recovery enforcement', () => {
       const db = await createNoydb({
         store, user: ALICE,
         passphraseMode: 'managed', sealingKey: provider,
+        shamirRecovery: shamirRecoveryProvider(),
       })
       const enroll = await db.openVaultAndEnrollRecovery('acme', {
         recovery: [{ profile: 'shamir', k: 2, n: 3 }],
@@ -262,6 +268,7 @@ describe('#195 — managed-mode strong-recovery enforcement', () => {
       const db = await createNoydb({
         store, user: ALICE,
         passphraseMode: 'managed', sealingKey: provider,
+        shamirRecovery: shamirRecoveryProvider(),
       })
       const enroll = await db.openVaultAndEnrollRecovery('acme', {
         recovery: [{ profile: 'shamir', k: 2, n: 3 }],
@@ -273,6 +280,7 @@ describe('#195 — managed-mode strong-recovery enforcement', () => {
       const db2 = await createNoydb({
         store, user: ALICE,
         passphraseMode: 'managed', sealingKey: provider,
+        shamirRecovery: shamirRecoveryProvider(),
       })
       await db2.recoverManagedPassphrase('acme', {
         recoveryProof: {
@@ -298,6 +306,7 @@ describe('#195 — managed-mode strong-recovery enforcement', () => {
       const db = await createNoydb({
         store, user: ALICE,
         passphraseMode: 'managed', sealingKey: provider,
+        shamirRecovery: shamirRecoveryProvider(),
       })
       const enroll = await db.openVaultAndEnrollRecovery('acme', {
         recovery: [{ profile: 'shamir', k: 2, n: 3 }],

--- a/packages/hub/__tests__/managed-passphrase.test.ts
+++ b/packages/hub/__tests__/managed-passphrase.test.ts
@@ -23,6 +23,7 @@ import {
   SEALED_PASSPHRASE_RECORD_ID,
   type SealingKeyProvider,
 } from '../src/team/managed-passphrase.js'
+import { shamirRecoveryProvider } from '@noy-db/on-shamir'
 
 function inlineMemory(): NoydbStore {
   const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
@@ -142,6 +143,7 @@ describe('createNoydb({ passphraseMode: "managed" }) — slice 1', () => {
       store, user: 'alice',
       passphraseMode: 'managed',
       sealingKey: provider,
+      shamirRecovery: shamirRecoveryProvider(),
     })
     await db.openVaultAndEnrollRecovery('acme', {
       recovery: [{ profile: 'shamir', k: 2, n: 3 }],
@@ -158,6 +160,7 @@ describe('createNoydb({ passphraseMode: "managed" }) — slice 1', () => {
       store, user: 'alice',
       passphraseMode: 'managed',
       sealingKey: provider,
+      shamirRecovery: shamirRecoveryProvider(),
     })
     await db1.openVaultAndEnrollRecovery('acme', {
       recovery: [{ profile: 'shamir', k: 2, n: 3 }],
@@ -182,6 +185,7 @@ describe('createNoydb({ passphraseMode: "managed" }) — slice 1', () => {
       store, user: 'alice',
       passphraseMode: 'managed',
       sealingKey: provider,
+      shamirRecovery: shamirRecoveryProvider(),
     })
     const { vault } = await db.openVaultAndEnrollRecovery('acme', {
       recovery: [{ profile: 'shamir', k: 2, n: 3 }],
@@ -206,6 +210,7 @@ describe('createNoydb({ passphraseMode: "managed" }) — slice 1', () => {
       store, user: 'alice',
       passphraseMode: 'managed',
       sealingKey: provider,
+      shamirRecovery: shamirRecoveryProvider(),
     })
     await db.openVaultAndEnrollRecovery('acme', {
       recovery: [{ profile: 'shamir', k: 2, n: 3 }],
@@ -224,6 +229,7 @@ describe('createNoydb({ passphraseMode: "managed" }) — slice 1', () => {
       store, user: 'alice',
       passphraseMode: 'managed',
       sealingKey: provider,
+      shamirRecovery: shamirRecoveryProvider(),
     })
     await db.openVaultAndEnrollRecovery('acme', {
       recovery: [{ profile: 'shamir', k: 2, n: 3 }],

--- a/packages/hub/__tests__/rotate-recover.test.ts
+++ b/packages/hub/__tests__/rotate-recover.test.ts
@@ -132,7 +132,7 @@ describe('recoverPassphrase (paper profile)', () => {
   it('recovers via a paper code, unlocks with the new phrase, burns the code', async () => {
     const { store, code } = await buildVaultWithPaperRecovery()
 
-    await recoverPassphrase(store, 'acme', 'alice', {
+    await recoverPassphrase(undefined, store, 'acme', 'alice', {
       newPassphrase: STRONG_NEW,
       recoveryProof: { profile: 'paper', payload: { code } },
     })
@@ -142,7 +142,7 @@ describe('recoverPassphrase (paper profile)', () => {
 
     // Code was burned — second use must fail with no entries left.
     await expect(
-      recoverPassphrase(store, 'acme', 'alice', {
+      recoverPassphrase(undefined, store, 'acme', 'alice', {
         newPassphrase: 'glasses cabinet bicycle umbrella thunder oranges',
         recoveryProof: { profile: 'paper', payload: { code } },
       }),
@@ -171,7 +171,7 @@ describe('recoverPassphrase (paper profile)', () => {
     } as NoydbStore
 
     await expect(
-      recoverPassphrase(wrapped, 'acme', 'alice', {
+      recoverPassphrase(undefined, wrapped, 'acme', 'alice', {
         newPassphrase: STRONG_NEW,
         recoveryProof: { profile: 'paper', payload: { code } },
       }),
@@ -189,7 +189,7 @@ describe('recoverPassphrase (paper profile)', () => {
   it('rejects an unknown paper code', async () => {
     const { store } = await buildVaultWithPaperRecovery()
     await expect(
-      recoverPassphrase(store, 'acme', 'alice', {
+      recoverPassphrase(undefined, store, 'acme', 'alice', {
         newPassphrase: STRONG_NEW,
         recoveryProof: { profile: 'paper', payload: { code: 'WRONGCODE0000' } },
       }),
@@ -207,7 +207,7 @@ describe('recoverPassphrase (paper profile)', () => {
     const store = inlineMemory()
     await createOwnerKeyring(store, 'acme', 'alice', STRONG_OLD)
     await expect(
-      recoverPassphrase(store, 'acme', 'alice', {
+      recoverPassphrase(undefined, store, 'acme', 'alice', {
         newPassphrase: STRONG_NEW,
         recoveryProof: {
           profile: 'shamir',
@@ -219,8 +219,8 @@ describe('recoverPassphrase (paper profile)', () => {
           ] },
         },
       }),
-      // No Shamir entries → NoAccessError from the handler;
-      // a strict RecoveryProfileNotImplementedError would mean the
+      // No Shamir entries → NoAccessError (or the provider-missing error) from
+      // the handler; a strict RecoveryProfileNotImplementedError would mean the
       // dispatch is broken.
     ).rejects.not.toBeInstanceOf(RecoveryProfileNotImplementedError)
   })
@@ -262,14 +262,14 @@ describe('recoverPassphrase (paper profile)', () => {
     const store = inlineMemory()
     await createOwnerKeyring(store, 'acme', 'alice', STRONG_OLD)
     await expect(
-      recoverPassphrase(store, 'acme', 'alice', {
+      recoverPassphrase(undefined, store, 'acme', 'alice', {
         newPassphrase: STRONG_NEW,
         recoveryProof: { profile: 'multi-channel', payload: { proofs: [] } },
       }),
     ).rejects.toBeInstanceOf(RecoveryProfileNotImplementedError)
 
     await expect(
-      recoverPassphrase(store, 'acme', 'alice', {
+      recoverPassphrase(undefined, store, 'acme', 'alice', {
         newPassphrase: STRONG_NEW,
         recoveryProof: { profile: 'admin-mediated', payload: { token: 'x' } },
       }),

--- a/packages/hub/__tests__/shamir-recovery.test.ts
+++ b/packages/hub/__tests__/shamir-recovery.test.ts
@@ -15,6 +15,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import type { NoydbStore, EncryptedEnvelope } from '../src/types.js'
 import { createNoydb, type Noydb } from '../src/index.js'
 import { ConflictError } from '../src/errors.js'
+import { shamirRecoveryProvider } from '@noy-db/on-shamir'
 
 function inlineMemory(): NoydbStore {
   const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
@@ -46,6 +47,7 @@ async function freshDb(): Promise<Noydb> {
     store: inlineMemory(),
     user: 'alice',
     secret: STRONG_OLD,
+    shamirRecovery: shamirRecoveryProvider(),
   })
   await db.openVault('acme')
   return db
@@ -213,7 +215,7 @@ describe('Shamir recovery — recoverPassphrase round-trip', () => {
     })
     // The Shamir entry is preserved (unlike paper-burn). Re-open
     // under the new passphrase, then the same shares can recover again.
-    const db2 = await createNoydb({ store: (db as any).options.store, user: 'alice', secret: STRONG_NEW })
+    const db2 = await createNoydb({ store: (db as any).options.store, user: 'alice', secret: STRONG_NEW, shamirRecovery: shamirRecoveryProvider() })
     await db2.openVault('acme')
     await db2.recoverPassphrase('acme', {
       newPassphrase: STRONG_NEW_2,
@@ -359,5 +361,20 @@ describe('Shamir recovery — error reporting at error class level', () => {
     await expect(
       db.enrollRecovery('acme', { profile: 'shamir', k: 2, n: 3 }),
     ).resolves.toBeDefined()
+  })
+})
+
+describe('Shamir recovery — no-provider guard', () => {
+  it('shamir enroll throws a clear error when no provider is configured', async () => {
+    const db = await createNoydb({
+      store: inlineMemory(),
+      user: 'alice',
+      secret: STRONG_OLD,
+      // intentionally NO shamirRecovery
+    })
+    await db.openVault('acme')
+    await expect(
+      db.enrollRecovery('acme', { profile: 'shamir', k: 2, n: 3 }),
+    ).rejects.toThrow(/requires a ShamirRecoveryProvider/)
   })
 })

--- a/packages/hub/__tests__/shamir-recovery.test.ts
+++ b/packages/hub/__tests__/shamir-recovery.test.ts
@@ -296,6 +296,36 @@ describe('Shamir recovery — multiple coexisting entries', () => {
       }),
     ).rejects.toThrow(/no.*entry|entryId|not.*found/i)
   })
+
+  it('rejects a mixed-bag of shares from two different entries (per-entry contract, #211)', async () => {
+    // Enroll two separate Shamir entries, each 2-of-3.
+    const a = await db.enrollRecovery('acme', { profile: 'shamir', k: 2, n: 3, entryId: 'board' })
+    const b = await db.enrollRecovery('acme', { profile: 'shamir', k: 2, n: 3, entryId: 'spouse' })
+
+    // Mixed bag: one share from entry A + one share from entry B, no entryId.
+    // AES-GCM auth-tag will reject for every candidate entry — fails closed.
+    await expect(
+      db.recoverPassphrase('acme', {
+        newPassphrase: STRONG_NEW,
+        recoveryProof: {
+          profile: 'shamir',
+          payload: { shares: [a.shares![0]!, b.shares![0]!] },
+        },
+      }),
+    ).rejects.toThrow()
+
+    // Supplying a same-entry pair for entry A (no entryId) DOES recover —
+    // the contract is "group shares per entry," not "shamir is broken."
+    await db.recoverPassphrase('acme', {
+      newPassphrase: STRONG_NEW,
+      recoveryProof: {
+        profile: 'shamir',
+        payload: { shares: [a.shares![0]!, a.shares![1]!] },
+      },
+    })
+    const db2 = await createNoydb({ store: storeRef, user: 'alice', secret: STRONG_NEW, shamirRecovery: shamirRecoveryProvider() })
+    expect((await db2.getKeyring('acme')).userId).toBe('alice')
+  })
 })
 
 describe('Shamir recovery — rotateRecovery', () => {

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -257,6 +257,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@noy-db/on-shamir": "workspace:*",
     "@types/node": "^22.0.0",
     "esbuild": "^0.25.0",
     "zod": "^3.23.0",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -255,9 +255,7 @@
     "typecheck": "tsc --noEmit",
     "bundle-check": "node scripts/check-bundle.mjs"
   },
-  "dependencies": {
-    "@noy-db/on-shamir": "workspace:*"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/node": "^22.0.0",
     "esbuild": "^0.25.0",

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -453,8 +453,6 @@ export {
   saveShamirRecoveryEntries,
   mintShamirRecoveryEntry,
   unwrapDeksFromShamirEntry,
-  encodeShareBase32,
-  decodeShareBase32,
 } from './team/recovery.js'
 export type {
   PaperRecoveryEntry,

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -486,6 +486,7 @@ export type { WrappedDeksBlob } from './team/wrapped-deks.js'
 // (macOS Keychain, Windows Credential Manager, libsecret, AWS KMS)
 // ship as separate packages.
 export type { SealingKeyProvider, SealedPassphrase, SealedEnvelope } from './team/managed-passphrase.js'
+export type { ShamirRecoveryProvider } from './team/shamir-recovery-provider.js'
 export {
   MemorySealingKeyProvider,
   loadSealedPassphrase,

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -55,6 +55,7 @@ import {
   type ShamirRecoveryEntry,
 } from './team/recovery.js'
 import { resolveManagedSecret, saveSealedPassphrase } from './team/managed-passphrase.js'
+import type { ShamirRecoveryProvider } from './team/shamir-recovery-provider.js'
 import { generateULID } from './bundle/ulid.js'
 import { RecoveryNotEnrolledError, RecoveryProfileNotImplementedError, ManagedRecoveryNotEnrolledError, PolicyDeniedError } from './policy/errors.js'
 import {
@@ -1093,6 +1094,17 @@ export class Noydb {
     return engine.status()
   }
 
+  private requireShamirProvider(): ShamirRecoveryProvider {
+    const p = this.options.shamirRecovery
+    if (!p) {
+      throw new Error(
+        "shamir recovery requires a ShamirRecoveryProvider — pass "
+        + "shamirRecovery: shamirRecoveryProvider() from '@noy-db/on-shamir' to createNoydb()",
+      )
+    }
+    return p
+  }
+
   private getSyncEngine(vault: string): SyncEngine {
     const engine = this.syncEngines.get(vault)
     if (!engine) {
@@ -1776,7 +1788,7 @@ export class Noydb {
     // under the auto-rotation logic from #36.
     const entriesBeforeRecovery = await loadPaperRecoveryEntries(this.options.store, vault)
 
-    const next = await keyringRecoverPassphrase(this.options.store, vault, userId, input)
+    const next = await keyringRecoverPassphrase(this.options.shamirRecovery, this.options.store, vault, userId, input)
     this.keyringCache.set(vault, next)
 
     const rotateRemaining = input.rotateRemainingCodes ?? true
@@ -1948,6 +1960,7 @@ export class Noydb {
 
     const keyring = await this.getKeyring(vault)
     const { entry, shareStrings } = await mintShamirRecoveryEntry(
+      this.requireShamirProvider(),
       keyring.deks,
       targetEntryId,
       options.k,
@@ -2118,6 +2131,7 @@ export class Noydb {
       // rewraps DEKs under the new KEK derived from the random bytes.
       const sealed = await provider.seal(randomBytes)
       await keyringRecoverPassphrase(
+        this.options.shamirRecovery,
         this.options.store,
         vault,
         this.options.user,
@@ -2258,6 +2272,7 @@ export class Noydb {
       const keyring = await this.getKeyring(vault)
       const entryId = enrollment.entryId ?? generateULID()
       const { entry, shareStrings } = await mintShamirRecoveryEntry(
+        this.requireShamirProvider(),
         keyring.deks,
         entryId,
         enrollment.k,

--- a/packages/hub/src/team/recovery.ts
+++ b/packages/hub/src/team/recovery.ts
@@ -29,12 +29,7 @@ import {
   unwrapDeksFromBlob,
   type WrappedDeksBlob,
 } from './wrapped-deks.js'
-import {
-  splitSecret,
-  combineSecret,
-  encodeShareBase32,
-  type RawShare,
-} from '@noy-db/on-shamir'
+import type { ShamirRecoveryProvider } from './shamir-recovery-provider.js'
 
 /**
  * One paper recovery code as persisted in `_meta/recovery-paper`.
@@ -178,8 +173,10 @@ export interface ShamirRecoveryEntry extends WrappedDeksBlob {
   readonly k: number
   /** Total shares minted at enrollment. */
   readonly n: number
-  /** x-coordinates of the n minted shares (audit metadata; not used at unlock). */
-  readonly xCoords: ReadonlyArray<number>
+  /** x-coordinates of the n minted shares. Informational. Omitted as of 0.2
+   *  (string-level provider doesn't expose share x-coords); kept optional so
+   *  pre-0.2 entries still read. */
+  readonly xCoords?: ReadonlyArray<number>
   /** ISO timestamp. */
   readonly enrolledAt: string
   /** Optional caller-supplied label (e.g., "2-of-3 board escrow"). */
@@ -257,37 +254,25 @@ export async function saveShamirRecoveryEntries(
  * @param label - Optional caller label.
  */
 export async function mintShamirRecoveryEntry(
+  provider: ShamirRecoveryProvider,
   deks: Map<string, CryptoKey>,
   entryId: string,
   k: number,
   n: number,
   label?: string,
 ): Promise<{ entry: ShamirRecoveryEntry; shareStrings: string[] }> {
-  // 1. Fresh 32-byte recovery secret.
   const recoverySecret = crypto.getRandomValues(new Uint8Array(32))
   try {
-    // 2. Wrap DEKs under base64-encoded secret as the credential.
     const credential = bytesToBase64(recoverySecret)
     const blob = await mintWrappedDeksBlob(deks, credential)
-
-    // 3. Shamir-split.
-    const shares = splitSecret(recoverySecret, k, n)
-    const shareStrings = shares.map(encodeShareBase32)
-    const xCoords = shares.map(s => s.x)
-
+    const shareStrings = provider.splitToShares(recoverySecret, k, n)
     const entry: ShamirRecoveryEntry = {
-      ...blob,
-      entryId,
-      k,
-      n,
-      xCoords,
+      ...blob, entryId, k, n,
       enrolledAt: new Date().toISOString(),
       ...(label !== undefined && { label }),
     }
-
     return { entry, shareStrings }
   } finally {
-    // 4. Best-effort zero of the in-memory secret. GC will reclaim either way.
     recoverySecret.fill(0)
   }
 }
@@ -304,27 +289,23 @@ export async function mintShamirRecoveryEntry(
  * with. Callers iterating multiple entries should catch.
  */
 export async function unwrapDeksFromShamirEntry(
+  provider: ShamirRecoveryProvider,
   entry: ShamirRecoveryEntry,
-  shares: readonly RawShare[],
+  shareStrings: readonly string[],
 ): Promise<Map<string, CryptoKey>> {
-  if (shares.length < entry.k) {
+  if (shareStrings.length < entry.k) {
     throw new Error(
       `Insufficient shares: this Shamir entry needs ${entry.k} of ${entry.n}, `
-      + `but ${shares.length} were provided.`,
+      + `but ${shareStrings.length} were provided.`,
     )
   }
-  const secret = combineSecret(shares)
+  const secret = provider.combineShares(shareStrings)
   try {
-    const credential = bytesToBase64(secret)
-    return await unwrapDeksFromBlob(entry, credential)
+    return await unwrapDeksFromBlob(entry, bytesToBase64(secret))
   } finally {
     secret.fill(0)
   }
 }
-
-// Re-export the on-shamir share-string codecs so consumers don't
-// need a direct on-shamir import for the common share-handling path.
-export { encodeShareBase32, decodeShareBase32 } from '@noy-db/on-shamir'
 
 function bytesToBase64(b: Uint8Array): string {
   let s = ''

--- a/packages/hub/src/team/rotate-recover.ts
+++ b/packages/hub/src/team/rotate-recover.ts
@@ -437,7 +437,7 @@ export type RecoveryEnrollmentInput =
  * stored set).
  */
 export async function recoverPassphrase(
-  provider: ShamirRecoveryProvider,
+  provider: ShamirRecoveryProvider | undefined,
   store: NoydbStore,
   vault: string,
   userId: string,
@@ -583,7 +583,7 @@ function normalizePaperCode(input: string): string {
  *    explicit {@link Noydb.rotateRecovery} is the refresh ceremony.
  */
 async function recoverViaShamir(
-  provider: ShamirRecoveryProvider,
+  provider: ShamirRecoveryProvider | undefined,
   store: NoydbStore,
   vault: string,
   userId: string,
@@ -609,6 +609,13 @@ async function recoverViaShamir(
     throw new NoAccessError(
       `No Shamir-recovery entries enrolled for vault "${vault}". `
       + 'Enroll via `db.enrollRecovery({ profile: "shamir", k, n })` before relying on recovery.',
+    )
+  }
+
+  if (!provider) {
+    throw new Error(
+      "shamir recovery requires a ShamirRecoveryProvider — pass "
+      + "shamirRecovery: shamirRecoveryProvider() from '@noy-db/on-shamir' to createNoydb()",
     )
   }
 

--- a/packages/hub/src/team/rotate-recover.ts
+++ b/packages/hub/src/team/rotate-recover.ts
@@ -39,7 +39,7 @@ import {
   type PaperRecoveryEntry,
   type ShamirRecoveryEntry,
 } from './recovery.js'
-import { decodeShareBase32, type RawShare } from '@noy-db/on-shamir'
+import type { ShamirRecoveryProvider } from './shamir-recovery-provider.js'
 import { assertStrongPassphrase, type PassphrasePolicy } from '../validation.js'
 import type { UnlockedKeyring } from './keyring.js'
 import { mintKeyringCanary } from './keyring.js'
@@ -281,7 +281,7 @@ export type RecoveryProof =
       /** Optional disambiguator when multiple Shamir entries are enrolled.
        *  When omitted, hub tries each entry until one combines. */
       readonly entryId?: string
-      /** K or more share strings (Base32-encoded per @noy-db/on-shamir). */
+      /** K or more opaque share strings, as returned by `ShamirRecoveryProvider.splitToShares`. */
       readonly shares: ReadonlyArray<string>
     } }
 
@@ -437,6 +437,7 @@ export type RecoveryEnrollmentInput =
  * stored set).
  */
 export async function recoverPassphrase(
+  provider: ShamirRecoveryProvider,
   store: NoydbStore,
   vault: string,
   userId: string,
@@ -455,7 +456,7 @@ export async function recoverPassphrase(
     return recoverViaPaperCode(store, vault, userId, input)
   }
   if (profile === 'shamir') {
-    return recoverViaShamir(store, vault, userId, input)
+    return recoverViaShamir(provider, store, vault, userId, input)
   }
   throw new RecoveryProfileNotImplementedError(
     profile,
@@ -582,6 +583,7 @@ function normalizePaperCode(input: string): string {
  *    explicit {@link Noydb.rotateRecovery} is the refresh ceremony.
  */
 async function recoverViaShamir(
+  provider: ShamirRecoveryProvider,
   store: NoydbStore,
   vault: string,
   userId: string,
@@ -601,20 +603,6 @@ async function recoverViaShamir(
     throw new NoAccessError(`No keyring found for user "${userId}" in vault "${vault}".`)
   }
   const file = JSON.parse(env._data) as KeyringFile
-
-  // Decode share strings up front. A malformed string here is a
-  // validation error, not a per-entry try-next.
-  let decodedShares: RawShare[]
-  try {
-    decodedShares = shareStrings.map(s => decodeShareBase32(s))
-  } catch (err) {
-    throw new ValidationError(
-      'One or more Shamir shares could not be decoded. They may be '
-      + 'malformed, truncated, or from an incompatible version. '
-      + 'Original error: '
-      + (err instanceof Error ? err.message : String(err)),
-    )
-  }
 
   const allEntries = await loadShamirRecoveryEntries(store, vault)
   if (allEntries.length === 0) {
@@ -639,25 +627,22 @@ async function recoverViaShamir(
     candidates = allEntries
   }
 
-  // Try each candidate entry. For each, the supplied shares must
-  // include at least k of the entry's xCoords for combine to succeed.
+  // Try each candidate entry. Pass all share strings to the provider;
+  // provider.combineShares validates and throws on mismatch — the
+  // AES-GCM auth-tag is an additional guard.
   let recoveredDeks: Map<string, CryptoKey> | undefined
   for (const entry of candidates) {
-    // Filter shares whose x-coordinates match this entry's set, so
-    // that mixing shares from different entries doesn't poison
-    // combineSecret.
-    const xCoordSet = new Set(entry.xCoords)
-    const matchingShares = decodedShares.filter(s => xCoordSet.has(s.x))
-    if (matchingShares.length < entry.k) {
+    if (shareStrings.length < entry.k) {
       // Not enough shares for this entry — could still match another.
       continue
     }
     try {
-      const deks = await unwrapDeksFromShamirEntry(entry, matchingShares)
+      const deks = await unwrapDeksFromShamirEntry(provider, entry, shareStrings)
       recoveredDeks = deks
       break
     } catch {
-      // AES-GCM auth-tag failure → shares don't belong to this entry → try the next.
+      // provider.combineShares threw (malformed/mismatched shares) or
+      // AES-GCM auth-tag failure → try the next entry.
     }
   }
 
@@ -665,10 +650,10 @@ async function recoverViaShamir(
     // Distinguish "below-threshold" from "no entry matches" so the
     // error message is actionable.
     const minK = Math.min(...candidates.map(e => e.k))
-    if (decodedShares.length < minK) {
+    if (shareStrings.length < minK) {
       throw new InvalidKeyError(
         `Insufficient Shamir shares to combine: the smallest enrolled threshold is ${minK}, `
-        + `but only ${decodedShares.length} share${decodedShares.length === 1 ? ' was' : 's were'} provided.`,
+        + `but only ${shareStrings.length} share${shareStrings.length === 1 ? ' was' : 's were'} provided.`,
       )
     }
     throw new InvalidKeyError(

--- a/packages/hub/src/team/shamir-recovery-provider.ts
+++ b/packages/hub/src/team/shamir-recovery-provider.ts
@@ -1,0 +1,15 @@
+/**
+ * String-level Shamir provider injected into hub for `profile: 'shamir'`
+ * recovery. Keeps hub free of any `@noy-db/on-shamir` import — hub never
+ * sees `RawShare` or the share codecs. Implemented by
+ * `shamirRecoveryProvider()` from `@noy-db/on-shamir`.
+ */
+export interface ShamirRecoveryProvider {
+  /** Split `secret` into `n` base32 share strings; any `k` recombine it. */
+  splitToShares(secret: Uint8Array, k: number, n: number): string[]
+  /**
+   * Recombine `k`+ share strings into the secret. MUST throw on malformed,
+   * truncated, insufficient, or mismatched shares.
+   */
+  combineShares(shares: readonly string[]): Uint8Array
+}

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -45,6 +45,7 @@ import type { PublicEnvelopeSchema } from './meta/public-envelope/types.js'
 import type { MaterializedViewStrategyHandle } from './materialized-views/types.js'
 import type { OverlayedViewStrategyHandle } from './overlay-views/types.js'
 import type { SealingKeyProvider } from './team/managed-passphrase.js'
+import type { ShamirRecoveryProvider } from './team/shamir-recovery-provider.js'
 
 /** Format version for encrypted record envelopes. */
 export const NOYDB_FORMAT_VERSION = 1 as const
@@ -1842,6 +1843,9 @@ export interface NoydbOptions {
    * `@noy-db/seal-libsecret`, `@noy-db/seal-aws-kms`, …).
    */
   readonly sealingKey?: SealingKeyProvider
+  /** Required to use `profile: 'shamir'` recovery. Pass
+   *  `shamirRecoveryProvider()` from `@noy-db/on-shamir`. */
+  readonly shamirRecovery?: ShamirRecoveryProvider
   /** Auth method. Default: 'passphrase'. */
   readonly auth?: 'passphrase' | 'biometric'
   /** Enable encryption. Default: true. */

--- a/packages/on-shamir/__tests__/recovery-provider.test.ts
+++ b/packages/on-shamir/__tests__/recovery-provider.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { shamirRecoveryProvider } from '../src/index.js'
+
+describe('shamirRecoveryProvider', () => {
+  it('round-trips a secret through split/combine (2-of-3)', () => {
+    const p = shamirRecoveryProvider()
+    const secret = new Uint8Array(32).map((_, i) => i + 1)
+    const shares = p.splitToShares(secret, 2, 3)
+    expect(shares).toHaveLength(3)
+    expect(p.combineShares([shares[0]!, shares[2]!])).toEqual(secret)
+  })
+
+  it('throws when below threshold / on garbage', () => {
+    const p = shamirRecoveryProvider()
+    expect(() => p.combineShares(['not-a-share'])).toThrow()
+  })
+})

--- a/packages/on-shamir/src/index.ts
+++ b/packages/on-shamir/src/index.ts
@@ -79,6 +79,7 @@ export {
 
 import type { RawShare } from './shamir.js'
 import { combineSecret, splitSecret } from './shamir.js'
+import { encodeShareBase32, decodeShareBase32 } from './share-format.js'
 
 // ── High-level KEK API ──────────────────────────────────────────────────
 
@@ -112,6 +113,21 @@ export async function splitKEK(kek: CryptoKey, options: SplitKEKOptions): Promis
   } finally {
     // Zero the secret buffer — best-effort, GC will also reclaim.
     secret.fill(0)
+  }
+}
+
+// ── ShamirRecoveryProvider ─────────────────────────────────────────────
+
+/** Structural match for hub's ShamirRecoveryProvider (no hub import — avoids the cycle). */
+export interface ShamirRecoveryProvider {
+  splitToShares(secret: Uint8Array, k: number, n: number): string[]
+  combineShares(shares: readonly string[]): Uint8Array
+}
+
+export function shamirRecoveryProvider(): ShamirRecoveryProvider {
+  return {
+    splitToShares: (secret, k, n) => splitSecret(secret, k, n).map(encodeShareBase32),
+    combineShares: (shares) => combineSecret(shares.map(decodeShareBase32)),
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ importers:
       '@noy-db/hub':
         specifier: workspace:*
         version: link:../hub
+      '@noy-db/on-shamir':
+        specifier: workspace:*
+        version: link:../on-shamir
       '@noy-db/to-memory':
         specifier: workspace:*
         version: link:../to-memory
@@ -166,6 +169,9 @@ importers:
       '@noy-db/hub':
         specifier: workspace:*
         version: link:../hub
+      '@noy-db/on-shamir':
+        specifier: workspace:*
+        version: link:../on-shamir
       '@noy-db/to-memory':
         specifier: workspace:*
         version: link:../to-memory

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,9 @@ importers:
 
   packages/hub:
     devDependencies:
+      '@noy-db/on-shamir':
+        specifier: workspace:*
+        version: link:../on-shamir
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,10 +250,6 @@ importers:
         version: 22.19.17
 
   packages/hub:
-    dependencies:
-      '@noy-db/on-shamir':
-        specifier: workspace:*
-        version: link:../on-shamir
     devDependencies:
       '@types/node':
         specifier: ^22.0.0


### PR DESCRIPTION
**Keystone of the `0.2` line.** First PR of the `at-*`-graduation epic — carries the 0.2 design spec, the Workstream A plan, and the #211 implementation.

## What & why
hub no longer statically depends on `@noy-db/on-shamir`. Shamir recovery is now provided via an injected, string-level `ShamirRecoveryProvider` (`splitToShares`/`combineShares`), passed as `createNoydb({ shamirRecovery: shamirRecoveryProvider() })`. hub's `dependencies` for on-shamir is now empty (devDependency for tests only); the layering inversion + the build-cycle risk are gone for good.

## ⚠️ Breaking change (earns the `0.2` minor bump)
`@noy-db/hub` no longer re-exports `encodeShareBase32` / `decodeShareBase32`. Shamir recovery now requires the injected provider. Both documented in `MIGRATING.md`.

## Behavior preserved / pinned
- Paper recovery works with **no** provider configured (the "no provider" error fires only in the shamir branch) — proven by passing paper tests.
- Shamir enroll/recover/rotate semantics unchanged; multi-entry **iterate-and-try** intact.
- Per-entry share contract pinned by a new test: a mixed bag of shares from different entries fails **closed** (AES-GCM rejects — never wrong-entry unlock); migration note added.

## Verification
- 1743 hub tests pass; on-shamir 44/44.
- `turbo build` green, **no cycle**; lint, typecheck, check-architecture, validate-features all green; `--frozen-lockfile` 0.
- Built bundle confirmed to no longer export the codecs.

## Not in this PR
No version bump (lockstep `0.2.0-pre.1` happens at release time after all workstreams land). Next: Workstream B (cloud-KMS trio), C (#215 auto-unlock), D (#214 features.yaml), E (docs).

Design: `docs/superpowers/specs/2026-05-24-0.2-at-family-and-auto-unlock-design.md` · Plan: `docs/superpowers/plans/2026-05-24-0.2-workstream-A-shamir-decouple.md`