### PR TITLE
feat(at-*): 0.2 Workstream B — cloud-KMS sealing providers (at-aws-kms / at-gcp-kms / at-azure-keyvault)

### DIFF
--- a/docs/superpowers/plans/2026-05-24-0.2-workstream-B-cloud-kms.md
+++ b/docs/superpowers/plans/2026-05-24-0.2-workstream-B-cloud-kms.md
@@ -1,0 +1,315 @@
+# 0.2 Workstream B — cloud-KMS sealing providers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Three new `at-*` packages — `@noy-db/at-aws-kms`, `@noy-db/at-gcp-kms`, `@noy-db/at-azure-keyvault` — each a `SealingKeyProvider` whose `seal`/`unseal` call a cloud KMS encrypt/decrypt API. No hub changes (the `SealingKeyProvider` contract already fits).
+
+**Architecture:** Each package mirrors `@noy-db/at-env`'s structure exactly. The only conceptual difference: instead of local AES-GCM with an env key, `seal(passphrase)` → KMS encrypt → opaque ciphertext, `unseal(bytes)` → KMS decrypt → passphrase. The cloud SDK client is **dependency-injected** (a `client?` option) so unit tests pass a fake; the default constructs the real client and credentials come from the SDK's ambient chain (env/role/managed identity) — **the package never accepts raw credentials**.
+
+**Tech Stack:** TypeScript strict, pnpm workspace, turbo, tsup, vitest. Peer deps: `@aws-sdk/client-kms`, `@google-cloud/kms`, `@azure/keyvault-keys` + `@azure/identity`.
+
+**Spec:** `docs/superpowers/specs/2026-05-24-0.2-at-family-and-auto-unlock-design.md` (Workstream B). Build order: after A (merged), independent of C.
+
+> **SDK verification note for the implementer:** the SDK call signatures below are accurate as of the named major versions, but BEFORE coding each provider, confirm the current API via the package's README/types (or the context7 docs tool). If a signature differs, follow the SDK's current shape — the contract (`seal: Uint8Array→Uint8Array`, `unseal: Uint8Array→Uint8Array`, async, throw-on-failure) is what matters.
+
+---
+
+## Shared scaffold (applies to all three packages)
+
+Each `packages/at-<x>/` is a copy of `packages/at-env/` with these files, identical except where noted:
+- `tsconfig.json` — **identical** to at-env's.
+- `tsup.config.ts` — **identical** to at-env's.
+- `vitest.config.ts` — identical except `name: 'at-<x>'`.
+- `LICENSE` — copy at-env's.
+- `package.json` — copy at-env's; change `name`, `description`, `keywords`, `homepage`/`repository.directory`, and the **peer/dev deps** (the cloud SDK as a `peerDependency`; keep `@noy-db/hub` peer + `@noy-db/hub`/`@noy-db/on-shamir`/`@noy-db/to-memory`/`@types/node` dev — the on-shamir dev dep is needed because the integration test drives managed mode, which requires a `shamirRecovery` provider; see Workstream A's MIGRATING note). Keep `publishConfig.access: public`.
+- `README.md` — provider-specific (setup, when-to-use, the trusted-host framing).
+- `CHANGELOG.md` — `## 0.1.0-pre.16`-style first entry is NOT needed; these debut at the 0.2 release, so add a `# Changelog — at-<x>` header + a placeholder section the release step will fill. (Minimal: just the header; the lockstep release adds the version section.)
+- `src/index.ts` — the provider (per-task below).
+- `__tests__/<x>.test.ts` — mock-client round-trip + an env-gated real-cloud test.
+
+> Verify version: all package.json `version` must match the current monorepo version (`0.1.0-pre.16` today — the 0.2 lockstep bump happens at release). Set `"version": "0.1.0-pre.16"`.
+
+---
+
+### Task 1: `@noy-db/at-aws-kms`
+
+**Files:** Create `packages/at-aws-kms/` (full package per shared scaffold) + `src/index.ts` + `__tests__/at-aws-kms.test.ts`.
+
+- [ ] **Step 1: Scaffold the package** — copy at-env's `tsconfig.json`, `tsup.config.ts`, `LICENSE`; write `vitest.config.ts` with `name: 'at-aws-kms'`; write `package.json` (copy at-env, set `name: '@noy-db/at-aws-kms'`, description e.g. *"AWS KMS sealing key provider for noy-db managed-passphrase mode — seal/unseal via KMS Encrypt/Decrypt, with KMS access logs."*, keywords incl. `aws-kms`, `kms`; `peerDependencies` add `"@aws-sdk/client-kms": "^3.0.0"`, keep `@noy-db/hub`; `devDependencies` add `"@aws-sdk/client-kms": "^3.0.0"` + keep hub/on-shamir/to-memory/@types/node). `version: "0.1.0-pre.16"`.
+
+- [ ] **Step 2: Write the failing mock test** at `__tests__/at-aws-kms.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest'
+import { awsKmsSealingProvider } from '../src/index.js'
+
+// Fake KMS client: encrypt prefixes a tag, decrypt strips it — round-trips, verifies wiring.
+function fakeKmsClient() {
+  return {
+    send: vi.fn(async (cmd: any) => {
+      const name = cmd.constructor.name
+      if (name === 'EncryptCommand') {
+        const pt: Uint8Array = cmd.input.Plaintext
+        const blob = new Uint8Array(4 + pt.length)
+        blob.set([1, 2, 3, 4], 0); blob.set(pt, 4)
+        return { CiphertextBlob: blob }
+      }
+      if (name === 'DecryptCommand') {
+        const blob: Uint8Array = cmd.input.CiphertextBlob
+        return { Plaintext: blob.subarray(4) }
+      }
+      throw new Error('unexpected command ' + name)
+    }),
+  }
+}
+
+describe('awsKmsSealingProvider', () => {
+  it('round-trips a passphrase via injected client', async () => {
+    const p = awsKmsSealingProvider({ keyId: 'arn:aws:kms:us-east-1:1:key/abc', client: fakeKmsClient() as any })
+    const phrase = new TextEncoder().encode('hunter2-master')
+    const sealed = await p.seal(phrase)
+    expect(sealed).not.toEqual(phrase)
+    expect(await p.unseal(sealed)).toEqual(phrase)
+    expect(p.id).toBe('aws-kms:arn:aws:kms:us-east-1:1:key/abc')
+  })
+
+  it('unseal throws on a KMS failure', async () => {
+    const client = { send: vi.fn(async () => { throw new Error('AccessDenied') }) }
+    const p = awsKmsSealingProvider({ keyId: 'k', client: client as any })
+    await expect(p.unseal(new Uint8Array(8))).rejects.toThrow()
+  })
+})
+```
+
+Run `pnpm --filter @noy-db/at-aws-kms test` → FAIL (module not found).
+
+- [ ] **Step 3: Implement `src/index.ts`**:
+
+```ts
+import type { SealingKeyProvider } from '@noy-db/hub'
+import { KMSClient, EncryptCommand, DecryptCommand } from '@aws-sdk/client-kms'
+
+export interface AwsKmsSealingProviderOptions {
+  /** KMS key id or ARN (e.g. `arn:aws:kms:us-east-1:123:key/abc`). */
+  readonly keyId: string
+  /** Optional pre-built client (DI for tests). Default: `new KMSClient({})` (ambient creds). */
+  readonly client?: Pick<KMSClient, 'send'>
+}
+
+export function awsKmsSealingProvider(opts: AwsKmsSealingProviderOptions): SealingKeyProvider {
+  const client = opts.client ?? new KMSClient({})
+  return {
+    id: `aws-kms:${opts.keyId}`,
+    async seal(passphrase) {
+      const out = await client.send(new EncryptCommand({ KeyId: opts.keyId, Plaintext: passphrase }) as any)
+      const blob = (out as any).CiphertextBlob as Uint8Array | undefined
+      if (!blob) throw new Error('@noy-db/at-aws-kms: KMS Encrypt returned no CiphertextBlob')
+      return blob instanceof Uint8Array ? blob : new Uint8Array(blob)
+    },
+    async unseal(sealed) {
+      const out = await client.send(new DecryptCommand({ CiphertextBlob: sealed, KeyId: opts.keyId }) as any)
+      const pt = (out as any).Plaintext as Uint8Array | undefined
+      if (!pt) throw new Error('@noy-db/at-aws-kms: KMS Decrypt returned no Plaintext')
+      return pt instanceof Uint8Array ? pt : new Uint8Array(pt)
+    },
+  }
+}
+```
+
+Run `pnpm --filter @noy-db/at-aws-kms test` → PASS. Then `pnpm --filter @noy-db/at-aws-kms typecheck` and `lint` → clean.
+
+- [ ] **Step 4: Add an env-gated real-cloud test** (skips without creds) to the same test file:
+
+```ts
+const RUN_REAL = !!process.env.NOYDB_TEST_AWS_KMS_KEY_ID
+describe.skipIf(!RUN_REAL)('awsKmsSealingProvider (real KMS)', () => {
+  it('round-trips against real KMS', async () => {
+    const p = awsKmsSealingProvider({ keyId: process.env.NOYDB_TEST_AWS_KMS_KEY_ID! })
+    const phrase = new TextEncoder().encode('real-key-test')
+    expect(await p.unseal(await p.seal(phrase))).toEqual(phrase)
+  })
+})
+```
+
+- [ ] **Step 5: README** — provider setup (create a KMS key, grant Encrypt/Decrypt, set ambient creds), the trusted-host framing (this is an `at-*` provider — a host you control unseals a scoped slice), `awsKmsSealingProvider({ keyId })` usage with `createNoydb({ passphraseMode: 'managed', sealingKey, shamirRecovery })`. `CHANGELOG.md` header only.
+
+- [ ] **Step 6: Build + commit**
+
+```bash
+pnpm install && pnpm --filter @noy-db/at-aws-kms build
+git add packages/at-aws-kms pnpm-lock.yaml
+git commit -m "feat(at-aws-kms): AWS KMS sealing key provider (#188)"
+```
+
+---
+
+### Task 2: `@noy-db/at-gcp-kms`
+
+Same scaffold + test pattern as Task 1, with GCP's SDK. Issue #189.
+
+- [ ] **Step 1: Scaffold** — `name: '@noy-db/at-gcp-kms'`, description *"Google Cloud KMS sealing key provider for noy-db managed-passphrase mode."*, keywords incl. `gcp-kms`, `kms`; peer + dev dep `"@google-cloud/kms": "^4.0.0"`.
+
+- [ ] **Step 2: Failing mock test** `__tests__/at-gcp-kms.test.ts` — GCP client shape is `{ encrypt(req) => [resp], decrypt(req) => [resp] }`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest'
+import { gcpKmsSealingProvider } from '../src/index.js'
+
+function fakeKms() {
+  return {
+    encrypt: vi.fn(async (req: any) => {
+      const pt: Uint8Array = req.plaintext
+      const c = new Uint8Array(4 + pt.length); c.set([9,9,9,9],0); c.set(pt,4)
+      return [{ ciphertext: c }]
+    }),
+    decrypt: vi.fn(async (req: any) => [{ plaintext: (req.ciphertext as Uint8Array).subarray(4) }]),
+  }
+}
+
+describe('gcpKmsSealingProvider', () => {
+  it('round-trips via injected client', async () => {
+    const p = gcpKmsSealingProvider({ keyName: 'projects/p/locations/l/keyRings/r/cryptoKeys/k', client: fakeKms() as any })
+    const phrase = new TextEncoder().encode('hunter2')
+    expect(await p.unseal(await p.seal(phrase))).toEqual(phrase)
+    expect(p.id).toBe('gcp-kms:projects/p/locations/l/keyRings/r/cryptoKeys/k')
+  })
+})
+```
+
+- [ ] **Step 3: Implement** `src/index.ts`:
+
+```ts
+import type { SealingKeyProvider } from '@noy-db/hub'
+import { KeyManagementServiceClient } from '@google-cloud/kms'
+
+export interface GcpKmsSealingProviderOptions {
+  /** Full crypto-key resource name `projects/*/locations/*/keyRings/*/cryptoKeys/*`. */
+  readonly keyName: string
+  readonly client?: Pick<KeyManagementServiceClient, 'encrypt' | 'decrypt'>
+}
+
+export function gcpKmsSealingProvider(opts: GcpKmsSealingProviderOptions): SealingKeyProvider {
+  const client = opts.client ?? new KeyManagementServiceClient()
+  return {
+    id: `gcp-kms:${opts.keyName}`,
+    async seal(passphrase) {
+      const [resp] = await client.encrypt({ name: opts.keyName, plaintext: passphrase })
+      const c = resp.ciphertext
+      if (!c) throw new Error('@noy-db/at-gcp-kms: encrypt returned no ciphertext')
+      return c instanceof Uint8Array ? c : new Uint8Array(c as Buffer)
+    },
+    async unseal(sealed) {
+      const [resp] = await client.decrypt({ name: opts.keyName, ciphertext: sealed })
+      const p = resp.plaintext
+      if (!p) throw new Error('@noy-db/at-gcp-kms: decrypt returned no plaintext')
+      return p instanceof Uint8Array ? p : new Uint8Array(p as Buffer)
+    },
+  }
+}
+```
+
+- [ ] **Step 4-6:** env-gated real test (`process.env.NOYDB_TEST_GCP_KMS_KEY_NAME`); README; build; commit `feat(at-gcp-kms): Google Cloud KMS sealing key provider (#189)`.
+
+---
+
+### Task 3: `@noy-db/at-azure-keyvault`
+
+Same pattern, Azure Key Vault CryptographyClient. Issue #190.
+
+- [ ] **Step 1: Scaffold** — `name: '@noy-db/at-azure-keyvault'`, description *"Azure Key Vault sealing key provider for noy-db managed-passphrase mode."*, keywords incl. `azure-keyvault`, `kms`; peer + dev deps `"@azure/keyvault-keys": "^4.0.0"`, `"@azure/identity": "^4.0.0"`.
+
+- [ ] **Step 2: Failing mock test** `__tests__/at-azure-keyvault.test.ts` — inject a fake `CryptographyClient` with `encrypt`/`decrypt`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest'
+import { azureKeyVaultSealingProvider } from '../src/index.js'
+
+function fakeCrypto() {
+  return {
+    encrypt: vi.fn(async ({ plaintext }: any) => {
+      const c = new Uint8Array(4 + plaintext.length); c.set([7,7,7,7],0); c.set(plaintext,4)
+      return { result: c }
+    }),
+    decrypt: vi.fn(async ({ ciphertext }: any) => ({ result: (ciphertext as Uint8Array).subarray(4) })),
+  }
+}
+
+describe('azureKeyVaultSealingProvider', () => {
+  it('round-trips via injected client', async () => {
+    const p = azureKeyVaultSealingProvider({ keyId: 'https://v.vault.azure.net/keys/k/ver', cryptographyClient: fakeCrypto() as any })
+    const phrase = new TextEncoder().encode('hunter2')
+    expect(await p.unseal(await p.seal(phrase))).toEqual(phrase)
+    expect(p.id).toBe('azure-kv:https://v.vault.azure.net/keys/k/ver')
+  })
+})
+```
+
+- [ ] **Step 3: Implement** `src/index.ts` (RSA-OAEP-256 — passphrase is small, well within RSA limits):
+
+```ts
+import type { SealingKeyProvider } from '@noy-db/hub'
+import { CryptographyClient, type EncryptResult } from '@azure/keyvault-keys'
+import { DefaultAzureCredential } from '@azure/identity'
+
+type CryptoLike = Pick<CryptographyClient, 'encrypt' | 'decrypt'>
+
+export interface AzureKeyVaultSealingProviderOptions {
+  /** Full key identifier URL `https://<vault>.vault.azure.net/keys/<name>/<version>`. */
+  readonly keyId: string
+  readonly algorithm?: 'RSA-OAEP-256' | 'RSA-OAEP'
+  /** DI for tests; default builds a CryptographyClient with DefaultAzureCredential. */
+  readonly cryptographyClient?: CryptoLike
+}
+
+export function azureKeyVaultSealingProvider(opts: AzureKeyVaultSealingProviderOptions): SealingKeyProvider {
+  const algorithm = opts.algorithm ?? 'RSA-OAEP-256'
+  const client: CryptoLike = opts.cryptographyClient
+    ?? new CryptographyClient(opts.keyId, new DefaultAzureCredential())
+  return {
+    id: `azure-kv:${opts.keyId}`,
+    async seal(passphrase) {
+      const res = await client.encrypt({ algorithm, plaintext: passphrase } as any)
+      return res.result instanceof Uint8Array ? res.result : new Uint8Array(res.result)
+    },
+    async unseal(sealed) {
+      const res = await client.decrypt({ algorithm, ciphertext: sealed } as any)
+      return res.result instanceof Uint8Array ? res.result : new Uint8Array(res.result)
+    },
+  }
+}
+```
+
+- [ ] **Step 4-6:** env-gated real test (`process.env.NOYDB_TEST_AZURE_KEY_ID`); README; build; commit `feat(at-azure-keyvault): Azure Key Vault sealing key provider (#190)`.
+
+---
+
+### Task 4: Workspace gate + cross-check
+
+- [ ] **Step 1: Full gate** (the 3 new packages are non-private → they'll publish at release):
+
+```bash
+pnpm install --frozen-lockfile && pnpm turbo build && pnpm turbo lint && pnpm turbo typecheck && node scripts/check-architecture.mjs && node scripts/validate-features.mjs
+```
+Expected: all exit 0; no cycle. (validate-features still passes — the 3 packages aren't registered yet; that's Workstream D.)
+
+- [ ] **Step 2: Confirm publishability** — each package: `private` absent/false, `publishConfig.access: public`, `files` includes `dist`/`README.md`/`LICENSE`, README + LICENSE present, `dist/` built. Run:
+```bash
+for p in at-aws-kms at-gcp-kms at-azure-keyvault; do echo "== $p =="; test -f packages/$p/README.md && test -f packages/$p/LICENSE && test -f packages/$p/dist/index.js && echo "files ok"; node -p "require('./packages/$p/package.json').publishConfig"; done
+```
+
+- [ ] **Step 3: Full workspace test** (catch any integration fallout — learned from Workstream A):
+```bash
+pnpm turbo test --concurrency=1 --filter '!@noy-db/showcases'
+```
+Expected: all green.
+
+- [ ] **Step 4: Commit any remaining + ready for PR.**
+
+---
+
+## Self-Review
+
+- **Spec coverage (Workstream B):** 3 packages mirroring at-env (T1-3) ✓; SealingKeyProvider via cloud encrypt/decrypt, no hub change ✓; DI client for testing ✓; ambient creds, never raw creds ✓ (no credential params in any options interface); mock tests + env-gated real tests ✓; publishable (T4) ✓.
+- **Placeholders:** SDK signatures given concretely per provider; the implementer note flags confirming against current SDK docs (a verification instruction, not a placeholder). No "similar to Task N".
+- **Type consistency:** factory names (`awsKmsSealingProvider`/`gcpKmsSealingProvider`/`azureKeyVaultSealingProvider`), option field names (`keyId`/`keyName`/`keyId`), and `id` formats (`aws-kms:`/`gcp-kms:`/`azure-kv:`) are consistent between each task's impl, test, and the spec's Workstream B table.
+- **Credential safety:** no options interface accepts secrets/credentials — only key identifiers + an optional pre-built client. Honors the project credential-handling rules.

--- a/packages/at-aws-kms/CHANGELOG.md
+++ b/packages/at-aws-kms/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog — at-aws-kms

--- a/packages/at-aws-kms/LICENSE
+++ b/packages/at-aws-kms/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 vLannaAi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/at-aws-kms/README.md
+++ b/packages/at-aws-kms/README.md
@@ -1,0 +1,79 @@
+# @noy-db/at-aws-kms
+
+**AWS KMS sealing key provider for noy-db [managed-passphrase mode](https://github.com/vLannaAi/noy-db/issues/14).**
+
+An `at-*` provider that seals and unseals the hub-generated random passphrase via AWS KMS Encrypt / Decrypt. Every seal and unseal is an authenticated KMS API call — giving you a CloudTrail-backed access log of every time a user's vault is opened, with no additional instrumentation required.
+
+Like all `at-*` providers, this is a *trusted host* provider: the host you deploy it on CAN decrypt what it unseals. The security boundary is your AWS IAM policy — access is controlled by which roles hold `kms:Decrypt` on the KMS key, not by a secret the host keeps in memory.
+
+## Install
+
+```bash
+pnpm add @noy-db/hub @noy-db/at-aws-kms @noy-db/on-shamir
+# or: npm install @noy-db/hub @noy-db/at-aws-kms @noy-db/on-shamir
+```
+
+## Setup
+
+```bash
+# 1. Create a KMS key once (or reuse an existing ENCRYPT_DECRYPT key):
+aws kms create-key --description "noy-db sealing key"
+# Note the KeyId or ARN from the output.
+
+# 2. Grant your host's IAM role kms:Encrypt + kms:Decrypt on that key.
+#    Credentials are picked up automatically from the SDK's ambient chain
+#    (IAM instance role, ECS task role, ~/.aws/credentials, env vars, etc.).
+```
+
+```ts
+// 3. In your app:
+import { createNoydb } from '@noy-db/hub'
+import { awsKmsSealingProvider } from '@noy-db/at-aws-kms'
+import { shamirRecoveryProvider } from '@noy-db/on-shamir'
+
+const db = await createNoydb({
+  store,
+  user: 'alice',
+  passphraseMode: 'managed',
+  sealingKey: awsKmsSealingProvider({ keyId: 'arn:aws:kms:us-east-1:123456789012:key/abc' }),
+  shamirRecovery: shamirRecoveryProvider(),
+})
+
+const vault = await db.openVault('acme')
+// Hub generated a 256-bit random on first open, sealed it via KMS Encrypt,
+// and persisted to _meta/sealed-passphrase. The user never sees a passphrase.
+// On reopen, at-aws-kms calls KMS Decrypt transparently.
+// CloudTrail logs every Encrypt/Decrypt call with caller identity + key ARN.
+```
+
+## When to use this provider
+
+- ✅ Compliance regimes requiring auditable key access logs (FedRAMP, HIPAA with managed-encryption requirements, SOC 2 Type II).
+- ✅ Workloads already running on AWS where a KMS key costs less than engineering an equivalent audit trail.
+- ✅ Any case where you want automatic CMK rotation without rotating app-side key material.
+
+## When NOT to use this provider
+
+- ❌ Non-AWS or multi-cloud deployments where adding an AWS dependency is undesirable. Use [`@noy-db/at-env`](../at-env) for a zero-extra-dependency option.
+- ❌ Local dev / CI where you don't want real KMS calls or AWS credentials in CI. Use [`@noy-db/at-env`](../at-env) or `MemorySealingKeyProvider` from `@noy-db/hub` instead.
+
+## Key rotation
+
+KMS supports automatic key rotation for symmetric keys. Enable it on the CMK and KMS handles the rest — your `keyId` stays the same, no app changes needed. Cross-key migration (moving sealed passphrases to a different CMK) requires manual re-sealing with `unseal` + `seal` under the new key.
+
+## API
+
+```ts
+function awsKmsSealingProvider(opts: {
+  keyId: string                    // KMS key id or full ARN
+  client?: Pick<KMSClient, 'send'> // optional pre-built client (useful for tests)
+}): SealingKeyProvider
+```
+
+Never pass raw AWS credentials in the options — inject a pre-configured `KMSClient` for non-default auth. The default `new KMSClient({})` resolves credentials via the SDK's ambient chain.
+
+Returns a [`SealingKeyProvider`](../hub/src/team/managed-passphrase.ts) — the contract `@noy-db/hub`'s managed-passphrase mode consumes.
+
+## License
+
+MIT

--- a/packages/at-aws-kms/__tests__/at-aws-kms.test.ts
+++ b/packages/at-aws-kms/__tests__/at-aws-kms.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest'
+import { awsKmsSealingProvider } from '../src/index.js'
+
+function fakeKmsClient() {
+  return {
+    send: vi.fn(async (cmd: any) => {
+      const name = cmd.constructor.name
+      if (name === 'EncryptCommand') {
+        const pt: Uint8Array = cmd.input.Plaintext
+        const blob = new Uint8Array(4 + pt.length)
+        blob.set([1, 2, 3, 4], 0); blob.set(pt, 4)
+        return { CiphertextBlob: blob }
+      }
+      if (name === 'DecryptCommand') {
+        const blob: Uint8Array = cmd.input.CiphertextBlob
+        return { Plaintext: blob.subarray(4) }
+      }
+      throw new Error('unexpected command ' + name)
+    }),
+  }
+}
+
+describe('awsKmsSealingProvider', () => {
+  it('round-trips a passphrase via injected client', async () => {
+    const p = awsKmsSealingProvider({ keyId: 'arn:aws:kms:us-east-1:1:key/abc', client: fakeKmsClient() as any })
+    const phrase = new TextEncoder().encode('hunter2-master')
+    const sealed = await p.seal(phrase)
+    expect(sealed).not.toEqual(phrase)
+    expect(await p.unseal(sealed)).toEqual(phrase)
+    expect(p.id).toBe('aws-kms:arn:aws:kms:us-east-1:1:key/abc')
+  })
+
+  it('unseal throws on a KMS failure', async () => {
+    const client = { send: vi.fn(async () => { throw new Error('AccessDenied') }) }
+    const p = awsKmsSealingProvider({ keyId: 'k', client: client as any })
+    await expect(p.unseal(new Uint8Array(8))).rejects.toThrow()
+  })
+
+  it('seal throws when KMS Encrypt returns no CiphertextBlob', async () => {
+    const client = { send: vi.fn(async () => ({})) }
+    const p = awsKmsSealingProvider({ keyId: 'k', client: client as any })
+    await expect(p.seal(new Uint8Array([1, 2, 3]))).rejects.toThrow(/no CiphertextBlob/)
+  })
+
+  it('unseal throws when KMS Decrypt returns no Plaintext', async () => {
+    const client = { send: vi.fn(async () => ({})) }
+    const p = awsKmsSealingProvider({ keyId: 'k', client: client as any })
+    await expect(p.unseal(new Uint8Array([1, 2, 3]))).rejects.toThrow(/no Plaintext/)
+  })
+})
+
+describe('@noy-db/at-aws-kms — integration with @noy-db/hub managed-passphrase mode', () => {
+  it('round-trips a managed-mode vault end-to-end using fake KMS client', async () => {
+    const { createNoydb } = await import('@noy-db/hub')
+    const { memory } = await import('@noy-db/to-memory')
+    const { shamirRecoveryProvider } = await import('@noy-db/on-shamir')
+
+    const store = memory()
+    const keyId = 'arn:aws:kms:us-east-1:1:key/abc'
+    // One shared fake client — deterministic prefix-tag cipher is stateless,
+    // so the same instance can seal in db1 and unseal in db2.
+    const sharedFake = fakeKmsClient()
+
+    // First open — hub mints + seals via at-aws-kms, derives KEK, and
+    // atomically enrolls the strong recovery required for managed-mode vaults.
+    const db1 = await createNoydb({
+      store, user: 'alice',
+      passphraseMode: 'managed',
+      sealingKey: awsKmsSealingProvider({ keyId, client: sharedFake as any }),
+      shamirRecovery: shamirRecoveryProvider(),
+    })
+    const { vault: vault1 } = await db1.openVaultAndEnrollRecovery('demo', {
+      recovery: [{ profile: 'shamir', k: 2, n: 3 }],
+    })
+    await vault1.collection<{ id: string; note: string }>('notes').put('n1', {
+      id: 'n1', note: 'managed-mode write via at-aws-kms',
+    })
+    db1.close()
+
+    // Second open — fresh db instance, SAME fake client, SAME store.
+    // unseal must reconstruct the passphrase so the vault decrypts correctly.
+    const db2 = await createNoydb({
+      store, user: 'alice',
+      passphraseMode: 'managed',
+      sealingKey: awsKmsSealingProvider({ keyId, client: sharedFake as any }),
+      shamirRecovery: shamirRecoveryProvider(),
+    })
+    const vault2 = await db2.openVault('demo')
+    const note = await vault2.collection<{ id: string; note: string }>('notes').get('n1')
+    expect(note).toEqual({ id: 'n1', note: 'managed-mode write via at-aws-kms' })
+    db2.close()
+  })
+})
+
+const RUN_REAL = !!process.env.NOYDB_TEST_AWS_KMS_KEY_ID
+describe.skipIf(!RUN_REAL)('awsKmsSealingProvider (real KMS)', () => {
+  it('round-trips against real KMS', async () => {
+    const p = awsKmsSealingProvider({ keyId: process.env.NOYDB_TEST_AWS_KMS_KEY_ID! })
+    const phrase = new TextEncoder().encode('real-key-test')
+    expect(await p.unseal(await p.seal(phrase))).toEqual(phrase)
+  })
+})

--- a/packages/at-aws-kms/package.json
+++ b/packages/at-aws-kms/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@noy-db/at-aws-kms",
+  "version": "0.1.0-pre.16",
+  "description": "AWS KMS sealing key provider for noy-db managed-passphrase mode — seal/unseal via KMS Encrypt/Decrypt, with KMS access logs.",
+  "license": "MIT",
+  "author": "vLannaAi <vicio@lanna.ai>",
+  "homepage": "https://github.com/vLannaAi/noy-db/tree/main/packages/at-aws-kms#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vLannaAi/noy-db.git",
+    "directory": "packages/at-aws-kms"
+  },
+  "bugs": {
+    "url": "https://github.com/vLannaAi/noy-db/issues"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@noy-db/hub": "workspace:*",
+    "@aws-sdk/client-kms": "^3.0.0"
+  },
+  "devDependencies": {
+    "@noy-db/hub": "workspace:*",
+    "@noy-db/on-shamir": "workspace:*",
+    "@noy-db/to-memory": "workspace:*",
+    "@types/node": "^22.0.0",
+    "@aws-sdk/client-kms": "^3.0.0"
+  },
+  "keywords": [
+    "noy-db",
+    "at-aws-kms",
+    "aws-kms",
+    "kms",
+    "sealing-key-provider",
+    "managed-passphrase",
+    "encryption",
+    "zero-knowledge"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  }
+}

--- a/packages/at-aws-kms/src/index.ts
+++ b/packages/at-aws-kms/src/index.ts
@@ -1,0 +1,101 @@
+/**
+ * **@noy-db/at-aws-kms** — AWS KMS sealing key provider for noy-db
+ * managed-passphrase mode (#188).
+ *
+ * An `at-*` provider that seals and unseals the hub-generated random
+ * passphrase via AWS KMS Encrypt / Decrypt. Every seal and unseal is an
+ * authenticated KMS API call, giving you a CloudTrail-backed access log of
+ * every time a user's vault is opened — no additional instrumentation
+ * required.
+ *
+ * ## When to use
+ *
+ * - Compliance regimes requiring auditable key access logs (FedRAMP, HIPAA
+ *   with managed-encryption requirements, SOC 2 Type II).
+ * - Workloads already running on AWS where a KMS key costs less than
+ *   engineering an equivalent audit trail.
+ * - Any case where you want automatic CMK rotation without rotating your
+ *   app's sealing key material manually.
+ *
+ * ## Setup
+ *
+ * ```bash
+ * # 1. Create a KMS key (one-time, in your AWS console or CLI):
+ * aws kms create-key --description "noy-db sealing key"
+ * # Note the KeyId/ARN from the output.
+ *
+ * # 2. Grant the host's IAM role kms:Encrypt + kms:Decrypt on that key.
+ * # Credentials are picked up automatically from the SDK's ambient chain
+ * # (IAM role, ~/.aws/credentials, env vars — see AWS SDK docs).
+ * ```
+ *
+ * ```ts
+ * // 3. In your app:
+ * import { createNoydb } from '@noy-db/hub'
+ * import { awsKmsSealingProvider } from '@noy-db/at-aws-kms'
+ * import { shamirRecoveryProvider } from '@noy-db/on-shamir'
+ *
+ * const db = await createNoydb({
+ *   store,
+ *   user: 'alice',
+ *   passphraseMode: 'managed',
+ *   sealingKey: awsKmsSealingProvider({ keyId: 'arn:aws:kms:us-east-1:123:key/abc' }),
+ *   shamirRecovery: shamirRecoveryProvider(),
+ * })
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+import type { SealingKeyProvider } from '@noy-db/hub'
+import {
+  KMSClient,
+  EncryptCommand,
+  DecryptCommand,
+  type EncryptCommandOutput,
+  type DecryptCommandOutput,
+} from '@aws-sdk/client-kms'
+
+/** Options for {@link awsKmsSealingProvider}. */
+export interface AwsKmsSealingProviderOptions {
+  /** KMS key id or ARN (e.g. `arn:aws:kms:us-east-1:123:key/abc`). */
+  readonly keyId: string
+  /** Optional pre-built client (DI for tests). Default `new KMSClient({})` (ambient creds). */
+  readonly client?: Pick<KMSClient, 'send'>
+}
+
+/**
+ * Build a {@link SealingKeyProvider} backed by AWS KMS Encrypt / Decrypt.
+ *
+ * Credentials are resolved by the SDK's ambient chain — IAM instance roles,
+ * environment variables, or `~/.aws/credentials`. Never pass raw credentials
+ * in the options; inject a pre-configured client for non-default auth instead.
+ *
+ * @throws Error when KMS returns no ciphertext or no plaintext (guards
+ * against unexpected SDK-response shapes).
+ * Any KMS API error (AccessDenied, InvalidKeyUsage, etc.) propagates as-is.
+ */
+export function awsKmsSealingProvider(opts: AwsKmsSealingProviderOptions): SealingKeyProvider {
+  const client = opts.client ?? new KMSClient({})
+  return {
+    id: `aws-kms:${opts.keyId}`,
+
+    async seal(passphrase) {
+      const out: EncryptCommandOutput = await client.send(
+        new EncryptCommand({ KeyId: opts.keyId, Plaintext: passphrase }),
+      )
+      const blob = out.CiphertextBlob
+      if (!blob) throw new Error('@noy-db/at-aws-kms: KMS Encrypt returned no CiphertextBlob')
+      return blob instanceof Uint8Array ? blob : new Uint8Array(blob)
+    },
+
+    async unseal(sealed) {
+      const out: DecryptCommandOutput = await client.send(
+        new DecryptCommand({ CiphertextBlob: sealed, KeyId: opts.keyId }),
+      )
+      const pt = out.Plaintext
+      if (!pt) throw new Error('@noy-db/at-aws-kms: KMS Decrypt returned no Plaintext')
+      return pt instanceof Uint8Array ? pt : new Uint8Array(pt)
+    },
+  }
+}

--- a/packages/at-aws-kms/tsconfig.json
+++ b/packages/at-aws-kms/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/at-aws-kms/tsup.config.ts
+++ b/packages/at-aws-kms/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  target: 'es2022',
+})

--- a/packages/at-aws-kms/vitest.config.ts
+++ b/packages/at-aws-kms/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'at-aws-kms',
+    include: ['__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+})

--- a/packages/at-azure-keyvault/CHANGELOG.md
+++ b/packages/at-azure-keyvault/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog — at-azure-keyvault

--- a/packages/at-azure-keyvault/LICENSE
+++ b/packages/at-azure-keyvault/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 vLannaAi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/at-azure-keyvault/README.md
+++ b/packages/at-azure-keyvault/README.md
@@ -1,0 +1,102 @@
+# @noy-db/at-azure-keyvault
+
+**Azure Key Vault sealing key provider for noy-db [managed-passphrase mode](https://github.com/vLannaAi/noy-db/issues/14).**
+
+An `at-*` provider that seals and unseals the hub-generated random passphrase via Azure Key Vault Encrypt / Decrypt. Every seal and unseal is an authenticated Key Vault API call — giving you an Azure Monitor / Key Vault audit-log-backed access record of every time a user's vault is opened, with no additional instrumentation required.
+
+Like all `at-*` providers, this is a *trusted host* provider: the host you deploy it on CAN decrypt what it unseals. The security boundary is your Azure RBAC / Key Vault access policy — access is controlled by which managed identities or service principals hold the `encrypt` + `decrypt` key permissions on the Key Vault key, not by a secret the host keeps in memory.
+
+## Install
+
+```bash
+pnpm add @noy-db/hub @noy-db/at-azure-keyvault @noy-db/on-shamir
+# or: npm install @noy-db/hub @noy-db/at-azure-keyvault @noy-db/on-shamir
+```
+
+## Setup
+
+```bash
+# 1. Create a Key Vault and an RSA key (one-time):
+az keyvault create --name my-noydb-vault --resource-group my-rg --location eastus
+az keyvault key create --vault-name my-noydb-vault --name noydb-sealing --kty RSA --size 2048
+# Note the full key identifier URL from the output (the "id" field).
+
+# 2. Grant the host's managed identity or service principal encrypt + decrypt
+#    key permissions on the vault:
+az keyvault set-policy --name my-noydb-vault \
+  --object-id <MANAGED_IDENTITY_OBJECT_ID> \
+  --key-permissions encrypt decrypt
+# Credentials are resolved automatically via DefaultAzureCredential:
+# managed identity attached to the Azure host, AZURE_CLIENT_ID /
+# AZURE_TENANT_ID / AZURE_CLIENT_SECRET env vars, or `az login` for
+# local dev.
+```
+
+```ts
+// 3. In your app:
+import { createNoydb } from '@noy-db/hub'
+import { azureKeyVaultSealingProvider } from '@noy-db/at-azure-keyvault'
+import { shamirRecoveryProvider } from '@noy-db/on-shamir'
+
+const db = await createNoydb({
+  store,
+  user: 'alice',
+  passphraseMode: 'managed',
+  sealingKey: azureKeyVaultSealingProvider({
+    keyId: 'https://my-noydb-vault.vault.azure.net/keys/noydb-sealing/<version>',
+  }),
+  shamirRecovery: shamirRecoveryProvider(),
+})
+
+const vault = await db.openVault('acme')
+// Hub generated a 256-bit random on first open, sealed it via Key Vault Encrypt,
+// and persisted to _meta/sealed-passphrase. The user never sees a passphrase.
+// On reopen, at-azure-keyvault calls Key Vault Decrypt transparently.
+// Azure Key Vault audit logs record every Encrypt/Decrypt call with caller
+// identity + key identifier.
+```
+
+## When to use this provider
+
+- Compliance regimes requiring auditable key access logs (FedRAMP, HIPAA with managed-encryption requirements, SOC 2 Type II).
+- Workloads already running on Azure where a Key Vault RSA key costs less than engineering an equivalent audit trail.
+- Any case where you need an auditable, Azure-native key custody record for every vault open.
+
+## When NOT to use this provider
+
+- Non-Azure or multi-cloud deployments where adding an Azure dependency is undesirable. Use [`@noy-db/at-env`](../at-env) for a zero-extra-dependency option.
+- Local dev / CI where you don't want real Key Vault calls or Azure credentials in CI. Use [`@noy-db/at-env`](../at-env) or `MemorySealingKeyProvider` from `@noy-db/hub` instead.
+
+## Key rotation
+
+**Azure RSA decrypt is version-bound.** Unlike AWS/GCP symmetric KMS — where the key version travels inside the ciphertext blob — Azure's `CryptographyClient` resolves the key version at construction time and every decrypt call is pinned to that version. This has a critical consequence:
+
+- **Always use a versioned `keyId`** (`https://<vault>.vault.azure.net/keys/<name>/<version>`). The version in the URL is your guarantee that every sealed passphrase can be decrypted by the exact key material used to encrypt it.
+- **Do NOT enable Key Vault auto-rotation on a versionless `keyId`.** If the key rotates while you are using a versionless URL, the `CryptographyClient` will resolve to the new version, and every passphrase sealed under the previous version becomes **permanently undecryptable** — every managed-mode vault is locked out with no recovery path.
+
+**To rotate your sealing key** (e.g. for scheduled cryptographic hygiene):
+
+1. Create a new key version (or a new key) in Key Vault.
+2. For each vault, call `unseal` with the old versioned `keyId` to recover the plaintext passphrase.
+3. Call `seal` with a provider configured for the **new** versioned `keyId` to produce a new ciphertext.
+4. Persist the new sealed blob and update your app configuration to the new versioned `keyId`.
+
+This is a deliberate migration step — not transparent rotation. Treat it the same way you would a secret rotation in any other system.
+
+## API
+
+```ts
+function azureKeyVaultSealingProvider(opts: {
+  keyId: string                           // Full key identifier URL
+  algorithm?: 'RSA-OAEP-256' | 'RSA-OAEP'  // default: 'RSA-OAEP-256'
+  cryptographyClient?: CryptoLike         // optional pre-built client (useful for tests)
+}): SealingKeyProvider
+```
+
+Never pass raw Azure credentials in the options — inject a pre-configured `CryptographyClient` for non-default auth. The default builds a `CryptographyClient` with `DefaultAzureCredential`.
+
+Returns a [`SealingKeyProvider`](../hub/src/team/managed-passphrase.ts) — the contract `@noy-db/hub`'s managed-passphrase mode consumes.
+
+## License
+
+MIT

--- a/packages/at-azure-keyvault/__tests__/at-azure-keyvault.test.ts
+++ b/packages/at-azure-keyvault/__tests__/at-azure-keyvault.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import { azureKeyVaultSealingProvider } from '../src/index.js'
+
+function fakeCrypto() {
+  return {
+    encrypt: async ({ plaintext }: { algorithm: string; plaintext: Uint8Array }) => {
+      const c = new Uint8Array(4 + plaintext.length)
+      c.set([7, 7, 7, 7], 0)
+      c.set(plaintext, 4)
+      return { result: c, algorithm: 'RSA-OAEP-256' as const, keyID: 'fake-key' }
+    },
+    decrypt: async ({ ciphertext }: { algorithm: string; ciphertext: Uint8Array }) => ({
+      result: (ciphertext as Uint8Array).subarray(4),
+      algorithm: 'RSA-OAEP-256' as const,
+      keyID: 'fake-key',
+    }),
+  }
+}
+
+describe('azureKeyVaultSealingProvider', () => {
+  it('round-trips a passphrase via injected client', async () => {
+    const keyId = 'https://my-vault.vault.azure.net/keys/noydb-sealing/abc123'
+    const p = azureKeyVaultSealingProvider({ keyId, cryptographyClient: fakeCrypto() as any })
+    const phrase = new TextEncoder().encode('hunter2-master')
+    const sealed = await p.seal(phrase)
+    expect(sealed).not.toEqual(phrase)
+    expect(await p.unseal(sealed)).toEqual(phrase)
+    expect(p.id).toBe(`azure-kv:${keyId}`)
+  })
+
+  it('unseal throws on a Key Vault failure', async () => {
+    const client = {
+      encrypt: async () => { throw new Error('Forbidden') },
+      decrypt: async () => { throw new Error('Forbidden') },
+    }
+    const p = azureKeyVaultSealingProvider({ keyId: 'k', cryptographyClient: client as any })
+    await expect(p.unseal(new Uint8Array(8))).rejects.toThrow()
+  })
+
+  it('seal throws when Key Vault encrypt returns no result', async () => {
+    const client = {
+      encrypt: async () => ({}) as any,
+      decrypt: async () => ({}) as any,
+    }
+    const p = azureKeyVaultSealingProvider({ keyId: 'k', cryptographyClient: client as any })
+    await expect(p.seal(new Uint8Array([1, 2, 3]))).rejects.toThrow(/no result/)
+  })
+
+  it('unseal throws when Key Vault decrypt returns no result', async () => {
+    const client = {
+      encrypt: async () => ({}) as any,
+      decrypt: async () => ({}) as any,
+    }
+    const p = azureKeyVaultSealingProvider({ keyId: 'k', cryptographyClient: client as any })
+    await expect(p.unseal(new Uint8Array([1, 2, 3]))).rejects.toThrow(/no result/)
+  })
+})
+
+describe('@noy-db/at-azure-keyvault — integration with @noy-db/hub managed-passphrase mode', () => {
+  it('round-trips a managed-mode vault end-to-end using fake Key Vault client', async () => {
+    const { createNoydb } = await import('@noy-db/hub')
+    const { memory } = await import('@noy-db/to-memory')
+    const { shamirRecoveryProvider } = await import('@noy-db/on-shamir')
+
+    const store = memory()
+    const keyId = 'https://my-vault.vault.azure.net/keys/noydb-sealing/abc123'
+    // One shared fake client — deterministic prefix-tag cipher is stateless,
+    // so the same instance can seal in db1 and unseal in db2.
+    const sharedFake = fakeCrypto()
+
+    // First open — hub mints + seals via at-azure-keyvault, derives KEK, and
+    // atomically enrolls the strong recovery required for managed-mode vaults.
+    const db1 = await createNoydb({
+      store, user: 'alice',
+      passphraseMode: 'managed',
+      sealingKey: azureKeyVaultSealingProvider({ keyId, cryptographyClient: sharedFake as any }),
+      shamirRecovery: shamirRecoveryProvider(),
+    })
+    const { vault: vault1 } = await db1.openVaultAndEnrollRecovery('demo', {
+      recovery: [{ profile: 'shamir', k: 2, n: 3 }],
+    })
+    await vault1.collection<{ id: string; note: string }>('notes').put('n1', {
+      id: 'n1', note: 'managed-mode write via at-azure-keyvault',
+    })
+    db1.close()
+
+    // Second open — fresh db instance, SAME fake client, SAME store.
+    // unseal must reconstruct the passphrase so the vault decrypts correctly.
+    const db2 = await createNoydb({
+      store, user: 'alice',
+      passphraseMode: 'managed',
+      sealingKey: azureKeyVaultSealingProvider({ keyId, cryptographyClient: sharedFake as any }),
+      shamirRecovery: shamirRecoveryProvider(),
+    })
+    const vault2 = await db2.openVault('demo')
+    const note = await vault2.collection<{ id: string; note: string }>('notes').get('n1')
+    expect(new Uint8Array(Buffer.from(JSON.stringify(note)))).toEqual(
+      new Uint8Array(Buffer.from(JSON.stringify({ id: 'n1', note: 'managed-mode write via at-azure-keyvault' })))
+    )
+    expect(note).toEqual({ id: 'n1', note: 'managed-mode write via at-azure-keyvault' })
+    db2.close()
+  })
+})
+
+const RUN_REAL = !!process.env.NOYDB_TEST_AZURE_KEY_ID
+describe.skipIf(!RUN_REAL)('azureKeyVaultSealingProvider (real Azure Key Vault)', () => {
+  it('round-trips against real Azure Key Vault', async () => {
+    const p = azureKeyVaultSealingProvider({ keyId: process.env.NOYDB_TEST_AZURE_KEY_ID! })
+    const phrase = new TextEncoder().encode('real-key-test')
+    expect(await p.unseal(await p.seal(phrase))).toEqual(phrase)
+  })
+})

--- a/packages/at-azure-keyvault/package.json
+++ b/packages/at-azure-keyvault/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@noy-db/at-azure-keyvault",
+  "version": "0.1.0-pre.16",
+  "description": "Azure Key Vault sealing key provider for noy-db managed-passphrase mode.",
+  "license": "MIT",
+  "author": "vLannaAi <vicio@lanna.ai>",
+  "homepage": "https://github.com/vLannaAi/noy-db/tree/main/packages/at-azure-keyvault#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vLannaAi/noy-db.git",
+    "directory": "packages/at-azure-keyvault"
+  },
+  "bugs": {
+    "url": "https://github.com/vLannaAi/noy-db/issues"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@noy-db/hub": "workspace:*",
+    "@azure/keyvault-keys": "^4.0.0",
+    "@azure/identity": "^4.0.0"
+  },
+  "devDependencies": {
+    "@noy-db/hub": "workspace:*",
+    "@noy-db/on-shamir": "workspace:*",
+    "@noy-db/to-memory": "workspace:*",
+    "@types/node": "^22.0.0",
+    "@azure/keyvault-keys": "^4.0.0",
+    "@azure/identity": "^4.0.0"
+  },
+  "keywords": [
+    "noy-db",
+    "at-azure-keyvault",
+    "azure-keyvault",
+    "kms",
+    "sealing-key-provider",
+    "managed-passphrase",
+    "encryption",
+    "zero-knowledge"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  }
+}

--- a/packages/at-azure-keyvault/src/index.ts
+++ b/packages/at-azure-keyvault/src/index.ts
@@ -1,0 +1,133 @@
+/**
+ * **@noy-db/at-azure-keyvault** — Azure Key Vault sealing key provider for noy-db
+ * managed-passphrase mode (#190).
+ *
+ * An `at-*` provider that seals and unseals the hub-generated random
+ * passphrase via Azure Key Vault Encrypt / Decrypt. Every seal and unseal is
+ * an authenticated Key Vault API call, giving you an Azure Monitor / Key Vault
+ * audit-log-backed access record of every time a user's vault is opened —
+ * no additional instrumentation required.
+ *
+ * ## When to use
+ *
+ * - Compliance regimes requiring auditable key access logs (FedRAMP, HIPAA
+ *   with managed-encryption requirements, SOC 2 Type II).
+ * - Workloads already running on Azure where a Key Vault RSA key costs less
+ *   than engineering an equivalent audit trail.
+ * - Any case where you need an auditable, Azure-native key custody record
+ *   for every vault open.
+ *
+ * ## Setup
+ *
+ * ```bash
+ * # 1. Create a Key Vault and an RSA key (one-time):
+ * az keyvault create --name my-noydb-vault --resource-group my-rg --location eastus
+ * az keyvault key create --vault-name my-noydb-vault --name noydb-sealing --kty RSA --size 2048
+ * # Note the full key identifier URL from the output (id field).
+ *
+ * # 2. Grant the host's managed identity or service principal the
+ * #    encrypt + decrypt (or wrapKey + unwrapKey) permissions on the key:
+ * az keyvault set-policy --name my-noydb-vault \
+ *   --object-id <MANAGED_IDENTITY_OBJECT_ID> \
+ *   --key-permissions encrypt decrypt
+ * # Credentials are resolved automatically via DefaultAzureCredential:
+ * # managed identity attached to the Azure host, AZURE_CLIENT_ID /
+ * # AZURE_TENANT_ID / AZURE_CLIENT_SECRET env vars, or `az login` for
+ * # local dev.
+ * ```
+ *
+ * ```ts
+ * // 3. In your app:
+ * import { createNoydb } from '@noy-db/hub'
+ * import { azureKeyVaultSealingProvider } from '@noy-db/at-azure-keyvault'
+ * import { shamirRecoveryProvider } from '@noy-db/on-shamir'
+ *
+ * const db = await createNoydb({
+ *   store,
+ *   user: 'alice',
+ *   passphraseMode: 'managed',
+ *   sealingKey: azureKeyVaultSealingProvider({
+ *     keyId: 'https://my-noydb-vault.vault.azure.net/keys/noydb-sealing/<version>',
+ *   }),
+ *   shamirRecovery: shamirRecoveryProvider(),
+ * })
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+import type { SealingKeyProvider } from '@noy-db/hub'
+import {
+  CryptographyClient,
+  type EncryptResult,
+  type DecryptResult,
+  type RsaEncryptParameters,
+  type RsaDecryptParameters,
+} from '@azure/keyvault-keys'
+import { DefaultAzureCredential } from '@azure/identity'
+
+/** Minimal client surface required by {@link azureKeyVaultSealingProvider}. */
+interface CryptoLike {
+  encrypt(params: RsaEncryptParameters): Promise<EncryptResult>
+  decrypt(params: RsaDecryptParameters): Promise<DecryptResult>
+}
+
+/** Options for {@link azureKeyVaultSealingProvider}. */
+export interface AzureKeyVaultSealingProviderOptions {
+  /**
+   * Full **versioned** key identifier URL, e.g.
+   * `https://<vault>.vault.azure.net/keys/<name>/<version>`.
+   *
+   * Azure RSA decrypt is version-bound: the `CryptographyClient` resolves the
+   * key version at construction time and every decrypt call is pinned to it.
+   * A versionless URL (`.../keys/<name>`) resolves to "latest" — if the key
+   * auto-rotates, all passphrases sealed under the previous version become
+   * **permanently undecryptable**. Always pin to an explicit version.
+   */
+  readonly keyId: string
+  /** RSA encryption algorithm. Defaults to `'RSA-OAEP-256'`. */
+  readonly algorithm?: 'RSA-OAEP-256' | 'RSA-OAEP'
+  /**
+   * Optional pre-built CryptographyClient (DI for tests).
+   * Default: builds one with `DefaultAzureCredential`.
+   * Never pass raw Azure credentials in these options.
+   */
+  readonly cryptographyClient?: CryptoLike
+}
+
+/**
+ * Build a {@link SealingKeyProvider} backed by Azure Key Vault Encrypt / Decrypt.
+ *
+ * Credentials are resolved via `DefaultAzureCredential` — managed identities
+ * on Azure hosts, `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_CLIENT_SECRET`
+ * env vars, or `az login` for local dev. Never pass raw credentials in the
+ * options; inject a pre-configured `CryptographyClient` for non-default auth
+ * instead.
+ *
+ * @throws Error when Key Vault returns no result (guards against unexpected
+ * SDK-response shapes). Any Key Vault API error (Forbidden, NotFound, etc.)
+ * propagates as-is.
+ */
+export function azureKeyVaultSealingProvider(opts: AzureKeyVaultSealingProviderOptions): SealingKeyProvider {
+  const algorithm = opts.algorithm ?? 'RSA-OAEP-256'
+  const client: CryptoLike = opts.cryptographyClient
+    ?? new CryptographyClient(opts.keyId, new DefaultAzureCredential())
+
+  return {
+    id: `azure-kv:${opts.keyId}`,
+
+    async seal(passphrase) {
+      const res = await client.encrypt({ algorithm, plaintext: passphrase })
+      const c = res?.result
+      if (!c) throw new Error('@noy-db/at-azure-keyvault: Key Vault encrypt returned no result')
+      return c instanceof Uint8Array ? c : new Uint8Array(c)
+    },
+
+    async unseal(sealed) {
+      const res = await client.decrypt({ algorithm, ciphertext: sealed })
+      const p = res?.result
+      if (!p) throw new Error('@noy-db/at-azure-keyvault: Key Vault decrypt returned no result')
+      return p instanceof Uint8Array ? p : new Uint8Array(p)
+    },
+  }
+}

--- a/packages/at-azure-keyvault/tsconfig.json
+++ b/packages/at-azure-keyvault/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/at-azure-keyvault/tsup.config.ts
+++ b/packages/at-azure-keyvault/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  target: 'es2022',
+})

--- a/packages/at-azure-keyvault/vitest.config.ts
+++ b/packages/at-azure-keyvault/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'at-azure-keyvault',
+    include: ['__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+})

--- a/packages/at-gcp-kms/CHANGELOG.md
+++ b/packages/at-gcp-kms/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog — at-gcp-kms

--- a/packages/at-gcp-kms/LICENSE
+++ b/packages/at-gcp-kms/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 vLannaAi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/at-gcp-kms/README.md
+++ b/packages/at-gcp-kms/README.md
@@ -1,0 +1,92 @@
+# @noy-db/at-gcp-kms
+
+**Google Cloud KMS sealing key provider for noy-db [managed-passphrase mode](https://github.com/vLannaAi/noy-db/issues/14).**
+
+An `at-*` provider that seals and unseals the hub-generated random passphrase via Google Cloud KMS Encrypt / Decrypt. Every seal and unseal is an authenticated KMS API call — giving you a Cloud Audit Logs-backed access log of every time a user's vault is opened, with no additional instrumentation required.
+
+Like all `at-*` providers, this is a *trusted host* provider: the host you deploy it on CAN decrypt what it unseals. The security boundary is your GCP IAM policy — access is controlled by which service accounts hold `roles/cloudkms.cryptoKeyEncrypterDecrypter` on the KMS key, not by a secret the host keeps in memory.
+
+## Install
+
+```bash
+pnpm add @noy-db/hub @noy-db/at-gcp-kms @noy-db/on-shamir
+# or: npm install @noy-db/hub @noy-db/at-gcp-kms @noy-db/on-shamir
+```
+
+## Setup
+
+```bash
+# 1. Create a key ring and symmetric crypto key once:
+gcloud kms keyrings create noy-db-ring --location global
+gcloud kms keys create noy-db-sealing \
+  --location global \
+  --keyring noy-db-ring \
+  --purpose encryption
+# Note the full resource name from the output.
+
+# 2. Grant your host's service account the Cloud KMS CryptoKey Encrypter/Decrypter role:
+gcloud kms keys add-iam-policy-binding noy-db-sealing \
+  --location global \
+  --keyring noy-db-ring \
+  --member serviceAccount:HOST_SA@PROJECT.iam.gserviceaccount.com \
+  --role roles/cloudkms.cryptoKeyEncrypterDecrypter
+#    Credentials are resolved automatically via Application Default Credentials (ADC):
+#    service account attached to GCE/GKE node, Workload Identity for GKE,
+#    GOOGLE_APPLICATION_CREDENTIALS env var, or `gcloud auth application-default login`
+#    for local dev.
+```
+
+```ts
+// 3. In your app:
+import { createNoydb } from '@noy-db/hub'
+import { gcpKmsSealingProvider } from '@noy-db/at-gcp-kms'
+import { shamirRecoveryProvider } from '@noy-db/on-shamir'
+
+const db = await createNoydb({
+  store,
+  user: 'alice',
+  passphraseMode: 'managed',
+  sealingKey: gcpKmsSealingProvider({
+    keyName: 'projects/my-project/locations/global/keyRings/noy-db-ring/cryptoKeys/noy-db-sealing',
+  }),
+  shamirRecovery: shamirRecoveryProvider(),
+})
+
+const vault = await db.openVault('acme')
+// Hub generated a 256-bit random on first open, sealed it via KMS Encrypt,
+// and persisted to _meta/sealed-passphrase. The user never sees a passphrase.
+// On reopen, at-gcp-kms calls KMS Decrypt transparently.
+// Cloud Audit Logs record every Encrypt/Decrypt call with caller identity + key resource name.
+```
+
+## When to use this provider
+
+- Compliance regimes requiring auditable key access logs (FedRAMP, HIPAA with managed-encryption requirements, SOC 2 Type II).
+- Workloads already running on GCP where a Cloud KMS key costs less than engineering an equivalent audit trail.
+- Any case where you want automatic key version rotation without rotating app-side key material.
+
+## When NOT to use this provider
+
+- Non-GCP or multi-cloud deployments where adding a GCP dependency is undesirable. Use [`@noy-db/at-env`](../at-env) for a zero-extra-dependency option.
+- Local dev / CI where you don't want real KMS calls or GCP credentials in CI. Use [`@noy-db/at-env`](../at-env) or `MemorySealingKeyProvider` from `@noy-db/hub` instead.
+
+## Key rotation
+
+Cloud KMS supports automatic key version rotation for symmetric keys. Enable it on the crypto key and KMS handles the rest — your `keyName` stays the same, no app changes needed. Cross-key migration (moving sealed passphrases to a different key) requires manual re-sealing with `unseal` + `seal` under the new key.
+
+## API
+
+```ts
+function gcpKmsSealingProvider(opts: {
+  keyName: string                       // Full crypto-key resource name
+  client?: KmsClientLike                // optional pre-built client (useful for tests)
+}): SealingKeyProvider
+```
+
+Never pass raw GCP credentials in the options — inject a pre-configured `KeyManagementServiceClient` for non-default auth. The default `new KeyManagementServiceClient()` resolves credentials via Application Default Credentials.
+
+Returns a [`SealingKeyProvider`](../hub/src/team/managed-passphrase.ts) — the contract `@noy-db/hub`'s managed-passphrase mode consumes.
+
+## License
+
+MIT

--- a/packages/at-gcp-kms/__tests__/at-gcp-kms.test.ts
+++ b/packages/at-gcp-kms/__tests__/at-gcp-kms.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import { gcpKmsSealingProvider } from '../src/index.js'
+
+function fakeKms() {
+  return {
+    encrypt: async (req: { name?: string | null; plaintext?: Uint8Array | string | null }) => {
+      const pt = req.plaintext as Uint8Array
+      const c = new Uint8Array(4 + pt.length)
+      c.set([9, 9, 9, 9], 0)
+      c.set(pt, 4)
+      return [{ ciphertext: c }] as [{ ciphertext: Uint8Array }, undefined, undefined]
+    },
+    decrypt: async (req: { name?: string | null; ciphertext?: Uint8Array | string | null }) => {
+      const ct = req.ciphertext as Uint8Array
+      return [{ plaintext: ct.subarray(4) }] as [{ plaintext: Uint8Array }, undefined, undefined]
+    },
+  }
+}
+
+describe('gcpKmsSealingProvider', () => {
+  it('round-trips a passphrase via injected client', async () => {
+    const keyName = 'projects/my-project/locations/global/keyRings/ring/cryptoKeys/key'
+    const p = gcpKmsSealingProvider({ keyName, client: fakeKms() as any })
+    const phrase = new TextEncoder().encode('hunter2-master')
+    const sealed = await p.seal(phrase)
+    expect(sealed).not.toEqual(phrase)
+    expect(await p.unseal(sealed)).toEqual(phrase)
+    expect(p.id).toBe(`gcp-kms:${keyName}`)
+  })
+
+  it('unseal throws on a KMS failure', async () => {
+    const client = {
+      encrypt: async () => { throw new Error('PermissionDenied') },
+      decrypt: async () => { throw new Error('PermissionDenied') },
+    }
+    const p = gcpKmsSealingProvider({ keyName: 'k', client: client as any })
+    await expect(p.unseal(new Uint8Array(8))).rejects.toThrow()
+  })
+
+  it('seal throws when KMS encrypt returns no ciphertext', async () => {
+    const client = {
+      encrypt: async () => [{}] as [Record<string, never>, undefined, undefined],
+      decrypt: async () => [{}] as [Record<string, never>, undefined, undefined],
+    }
+    const p = gcpKmsSealingProvider({ keyName: 'k', client: client as any })
+    await expect(p.seal(new Uint8Array([1, 2, 3]))).rejects.toThrow(/no ciphertext/)
+  })
+
+  it('unseal throws when KMS decrypt returns no plaintext', async () => {
+    const client = {
+      encrypt: async () => [{}] as [Record<string, never>, undefined, undefined],
+      decrypt: async () => [{}] as [Record<string, never>, undefined, undefined],
+    }
+    const p = gcpKmsSealingProvider({ keyName: 'k', client: client as any })
+    await expect(p.unseal(new Uint8Array([1, 2, 3]))).rejects.toThrow(/no plaintext/)
+  })
+
+  it('handles base64-string responses from GCP (real-REST shape)', async () => {
+    const toB64 = (u: Uint8Array) => Buffer.from(u).toString('base64')
+    const stringFake = {
+      encrypt: async (req: any) => {
+        const pt: Uint8Array = req.plaintext
+        const c = new Uint8Array(4 + pt.length); c.set([9, 9, 9, 9], 0); c.set(pt, 4)
+        return [{ ciphertext: toB64(c) }]            // <-- base64 STRING, not Uint8Array
+      },
+      decrypt: async (req: any) => {
+        // req.ciphertext is a Uint8Array (what seal returned, normalized); strip prefix, return as base64 string
+        const blob: Uint8Array = req.ciphertext
+        return [{ plaintext: toB64(blob.subarray(4)) }]   // <-- base64 STRING
+      },
+    }
+    const p = gcpKmsSealingProvider({ keyName: 'projects/p/locations/l/keyRings/r/cryptoKeys/k', client: stringFake as any })
+    const phrase = new TextEncoder().encode('hunter2-string-path')
+    const sealed = await p.seal(phrase)
+    expect(sealed).toBeInstanceOf(Uint8Array)
+    expect(new Uint8Array(await p.unseal(sealed))).toEqual(phrase)
+  })
+})
+
+describe('@noy-db/at-gcp-kms — integration with @noy-db/hub managed-passphrase mode', () => {
+  it('round-trips a managed-mode vault end-to-end using fake KMS client', async () => {
+    const { createNoydb } = await import('@noy-db/hub')
+    const { memory } = await import('@noy-db/to-memory')
+    const { shamirRecoveryProvider } = await import('@noy-db/on-shamir')
+
+    const store = memory()
+    const keyName = 'projects/my-project/locations/global/keyRings/ring/cryptoKeys/key'
+    // One shared fake client — deterministic prefix-tag cipher is stateless,
+    // so the same instance can seal in db1 and unseal in db2.
+    const sharedFake = fakeKms()
+
+    // First open — hub mints + seals via at-gcp-kms, derives KEK, and
+    // atomically enrolls the strong recovery required for managed-mode vaults.
+    const db1 = await createNoydb({
+      store, user: 'alice',
+      passphraseMode: 'managed',
+      sealingKey: gcpKmsSealingProvider({ keyName, client: sharedFake as any }),
+      shamirRecovery: shamirRecoveryProvider(),
+    })
+    const { vault: vault1 } = await db1.openVaultAndEnrollRecovery('demo', {
+      recovery: [{ profile: 'shamir', k: 2, n: 3 }],
+    })
+    await vault1.collection<{ id: string; note: string }>('notes').put('n1', {
+      id: 'n1', note: 'managed-mode write via at-gcp-kms',
+    })
+    db1.close()
+
+    // Second open — fresh db instance, SAME fake client, SAME store.
+    // unseal must reconstruct the passphrase so the vault decrypts correctly.
+    const db2 = await createNoydb({
+      store, user: 'alice',
+      passphraseMode: 'managed',
+      sealingKey: gcpKmsSealingProvider({ keyName, client: sharedFake as any }),
+      shamirRecovery: shamirRecoveryProvider(),
+    })
+    const vault2 = await db2.openVault('demo')
+    const note = await vault2.collection<{ id: string; note: string }>('notes').get('n1')
+    expect(note).toEqual({ id: 'n1', note: 'managed-mode write via at-gcp-kms' })
+    db2.close()
+  })
+})
+
+const RUN_REAL = !!process.env.NOYDB_TEST_GCP_KMS_KEY_NAME
+describe.skipIf(!RUN_REAL)('gcpKmsSealingProvider (real GCP KMS)', () => {
+  it('round-trips against real GCP KMS', async () => {
+    const p = gcpKmsSealingProvider({ keyName: process.env.NOYDB_TEST_GCP_KMS_KEY_NAME! })
+    const phrase = new TextEncoder().encode('real-key-test')
+    expect(await p.unseal(await p.seal(phrase))).toEqual(phrase)
+  })
+})

--- a/packages/at-gcp-kms/package.json
+++ b/packages/at-gcp-kms/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@noy-db/at-gcp-kms",
+  "version": "0.1.0-pre.16",
+  "description": "Google Cloud KMS sealing key provider for noy-db managed-passphrase mode.",
+  "license": "MIT",
+  "author": "vLannaAi <vicio@lanna.ai>",
+  "homepage": "https://github.com/vLannaAi/noy-db/tree/main/packages/at-gcp-kms#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vLannaAi/noy-db.git",
+    "directory": "packages/at-gcp-kms"
+  },
+  "bugs": {
+    "url": "https://github.com/vLannaAi/noy-db/issues"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@noy-db/hub": "workspace:*",
+    "@google-cloud/kms": "^4.0.0"
+  },
+  "devDependencies": {
+    "@noy-db/hub": "workspace:*",
+    "@noy-db/on-shamir": "workspace:*",
+    "@noy-db/to-memory": "workspace:*",
+    "@types/node": "^22.0.0",
+    "@google-cloud/kms": "^4.0.0"
+  },
+  "keywords": [
+    "noy-db",
+    "at-gcp-kms",
+    "gcp-kms",
+    "kms",
+    "sealing-key-provider",
+    "managed-passphrase",
+    "encryption",
+    "zero-knowledge"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  }
+}

--- a/packages/at-gcp-kms/src/index.ts
+++ b/packages/at-gcp-kms/src/index.ts
@@ -1,0 +1,126 @@
+/**
+ * **@noy-db/at-gcp-kms** — Google Cloud KMS sealing key provider for noy-db
+ * managed-passphrase mode (#189).
+ *
+ * An `at-*` provider that seals and unseals the hub-generated random
+ * passphrase via Google Cloud KMS Encrypt / Decrypt. Every seal and unseal is
+ * an authenticated KMS API call, giving you a Cloud Audit Logs-backed access
+ * log of every time a user's vault is opened — no additional instrumentation
+ * required.
+ *
+ * ## When to use
+ *
+ * - Compliance regimes requiring auditable key access logs (FedRAMP, HIPAA
+ *   with managed-encryption requirements, SOC 2 Type II).
+ * - Workloads already running on GCP where a Cloud KMS key costs less than
+ *   engineering an equivalent audit trail.
+ * - Any case where you want automatic key rotation without rotating your
+ *   app's sealing key material manually.
+ *
+ * ## Setup
+ *
+ * ```bash
+ * # 1. Create a key ring and symmetric crypto key once:
+ * gcloud kms keyrings create noy-db-ring --location global
+ * gcloud kms keys create noy-db-sealing \
+ *   --location global \
+ *   --keyring noy-db-ring \
+ *   --purpose encryption
+ * # Note the full resource name from the output.
+ *
+ * # 2. Grant your host's service account the Cloud KMS CryptoKey Encrypter/Decrypter role:
+ * gcloud kms keys add-iam-policy-binding noy-db-sealing \
+ *   --location global \
+ *   --keyring noy-db-ring \
+ *   --member serviceAccount:HOST_SA@PROJECT.iam.gserviceaccount.com \
+ *   --role roles/cloudkms.cryptoKeyEncrypterDecrypter
+ * # Credentials are picked up automatically via Application Default Credentials
+ * # (ADC): service account attached to GCE/GKE, GOOGLE_APPLICATION_CREDENTIALS
+ * # env var, or `gcloud auth application-default login` for local dev.
+ * ```
+ *
+ * ```ts
+ * // 3. In your app:
+ * import { createNoydb } from '@noy-db/hub'
+ * import { gcpKmsSealingProvider } from '@noy-db/at-gcp-kms'
+ * import { shamirRecoveryProvider } from '@noy-db/on-shamir'
+ *
+ * const db = await createNoydb({
+ *   store,
+ *   user: 'alice',
+ *   passphraseMode: 'managed',
+ *   sealingKey: gcpKmsSealingProvider({
+ *     keyName: 'projects/my-project/locations/global/keyRings/noy-db-ring/cryptoKeys/noy-db-sealing',
+ *   }),
+ *   shamirRecovery: shamirRecoveryProvider(),
+ * })
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+import type { SealingKeyProvider } from '@noy-db/hub'
+import { KeyManagementServiceClient } from '@google-cloud/kms'
+import type { protos } from '@google-cloud/kms'
+
+type IEncryptRequest = protos.google.cloud.kms.v1.IEncryptRequest
+type IDecryptRequest = protos.google.cloud.kms.v1.IDecryptRequest
+type IEncryptResponse = protos.google.cloud.kms.v1.IEncryptResponse
+type IDecryptResponse = protos.google.cloud.kms.v1.IDecryptResponse
+
+/** Minimal client surface required by {@link gcpKmsSealingProvider}. */
+interface KmsClientLike {
+  encrypt(request: IEncryptRequest): Promise<[IEncryptResponse, IEncryptRequest | undefined, unknown]>
+  decrypt(request: IDecryptRequest): Promise<[IDecryptResponse, IDecryptRequest | undefined, unknown]>
+}
+
+/** Options for {@link gcpKmsSealingProvider}. */
+export interface GcpKmsSealingProviderOptions {
+  /**
+   * Full crypto-key resource name, e.g.
+   * `projects/PROJECT/locations/LOCATION/keyRings/RING/cryptoKeys/KEY`.
+   */
+  readonly keyName: string
+  /** Optional pre-built client (DI for tests). Default: `new KeyManagementServiceClient()` (ambient ADC). */
+  readonly client?: KmsClientLike
+}
+
+function toUint8Array(value: Uint8Array | string | null | undefined): Uint8Array | undefined {
+  if (value == null) return undefined
+  if (value instanceof Uint8Array) return value
+  // protobuf may return a base64 string in some environments
+  return Buffer.from(value, 'base64')
+}
+
+/**
+ * Build a {@link SealingKeyProvider} backed by Google Cloud KMS Encrypt / Decrypt.
+ *
+ * Credentials are resolved via Application Default Credentials (ADC) — attached
+ * service accounts, `GOOGLE_APPLICATION_CREDENTIALS`, or local gcloud login.
+ * Never pass raw credentials in the options; inject a pre-configured client for
+ * non-default auth instead.
+ *
+ * @throws Error when KMS returns no ciphertext or no plaintext (guards
+ * against unexpected SDK-response shapes).
+ * Any KMS API error (PermissionDenied, NotFound, etc.) propagates as-is.
+ */
+export function gcpKmsSealingProvider(opts: GcpKmsSealingProviderOptions): SealingKeyProvider {
+  const client: KmsClientLike = opts.client ?? new KeyManagementServiceClient()
+  return {
+    id: `gcp-kms:${opts.keyName}`,
+
+    async seal(passphrase) {
+      const [resp] = await client.encrypt({ name: opts.keyName, plaintext: passphrase })
+      const blob = toUint8Array(resp?.ciphertext)
+      if (!blob) throw new Error('@noy-db/at-gcp-kms: KMS encrypt returned no ciphertext')
+      return blob
+    },
+
+    async unseal(sealed) {
+      const [resp] = await client.decrypt({ name: opts.keyName, ciphertext: sealed })
+      const pt = toUint8Array(resp?.plaintext)
+      if (!pt) throw new Error('@noy-db/at-gcp-kms: KMS decrypt returned no plaintext')
+      return pt
+    },
+  }
+}

--- a/packages/at-gcp-kms/tsconfig.json
+++ b/packages/at-gcp-kms/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/at-gcp-kms/tsup.config.ts
+++ b/packages/at-gcp-kms/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  target: 'es2022',
+})

--- a/packages/at-gcp-kms/vitest.config.ts
+++ b/packages/at-gcp-kms/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'at-gcp-kms',
+    include: ['__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,27 @@ importers:
         specifier: ^22.0.0
         version: 22.19.17
 
+  packages/at-azure-keyvault:
+    devDependencies:
+      '@azure/identity':
+        specifier: ^4.0.0
+        version: 4.13.1
+      '@azure/keyvault-keys':
+        specifier: ^4.0.0
+        version: 4.10.0(@azure/core-client@1.10.1)
+      '@noy-db/hub':
+        specifier: workspace:*
+        version: link:../hub
+      '@noy-db/on-shamir':
+        specifier: workspace:*
+        version: link:../on-shamir
+      '@noy-db/to-memory':
+        specifier: workspace:*
+        version: link:../to-memory
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+
   packages/at-env:
     devDependencies:
       '@noy-db/hub':
@@ -356,7 +377,7 @@ importers:
         version: 1.15.11
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
+        version: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
 
   packages/in-pinia:
     devDependencies:
@@ -810,7 +831,7 @@ importers:
         version: 0.11.3(magicast@0.5.2)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
+        version: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
       pinia:
         specifier: ^3.0.1
         version: 3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3))
@@ -1398,6 +1419,77 @@ packages:
   '@aws/lambda-invoke-store@0.2.4':
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
+
+  '@azure-rest/core-client@2.6.0':
+    resolution: {integrity: sha512-iuFKDm8XPzNxPfRjhyU5/xKZmcRDzSuEghXDHHk4MjBV/wFL34GmYVBZnn9wmuoLBeS1qAw9ceMdaeJBPcB1QQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/abort-controller@2.1.2':
+    resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-auth@1.10.1':
+    resolution: {integrity: sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-client@1.10.1':
+    resolution: {integrity: sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-http-compat@2.4.0':
+    resolution: {integrity: sha512-f1P96IB399YiN2ARYHP7EpZi3Bf3wH4SN2lGzrw7JVwm7bbsVYtf2iKSBwTywD2P62NOPZGHFSZi+6jjb75JuA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@azure/core-client': ^1.10.0
+      '@azure/core-rest-pipeline': ^1.22.0
+
+  '@azure/core-lro@2.7.2':
+    resolution: {integrity: sha512-0YIpccoX8m/k00O7mDDMdJpbr6mf1yWo2dfmxt5A8XVZVVMz2SSKaEbMCeJRvgQ0IaSlqhjT47p4hVIRRy90xw==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-paging@1.6.2':
+    resolution: {integrity: sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/core-rest-pipeline@1.23.0':
+    resolution: {integrity: sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-tracing@1.3.1':
+    resolution: {integrity: sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/core-util@1.13.1':
+    resolution: {integrity: sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/identity@4.13.1':
+    resolution: {integrity: sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/keyvault-common@2.1.0':
+    resolution: {integrity: sha512-aCDidWuKY06LWQ4x7/8TIXK6iRqTaRWRL3t7T+LC+j1b07HtoIsOxP/tU90G4jCSBn5TAyUTCtA4MS/y5Hudaw==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/keyvault-keys@4.10.0':
+    resolution: {integrity: sha512-eDT7iXoBTRZ2n3fLiftuGJFD+yjkiB1GNqzU2KbY1TLYeXeSPVTVgn2eJ5vmRTZ11978jy2Kg2wI7xa9Tyr8ag==}
+    engines: {node: '>=18.0.0'}
+
+  '@azure/logger@1.3.0':
+    resolution: {integrity: sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==}
+    engines: {node: '>=20.0.0'}
+
+  '@azure/msal-browser@5.11.0':
+    resolution: {integrity: sha512-zkGNYS3TwY8lUpPIafAmsFCYZbgFixY9y/LZB9GUg0IILoHTqpN26j5OrkL1AQThh/YdZsawe4iWXfp85lFVxg==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-common@16.6.2':
+    resolution: {integrity: sha512-hQjjsekAjB00cM1EmatWJlzhEoK2Qhz7Rj5gvM6tYf8iL7RM3tkxlpU9fG0+ofkulzg9AEEA6dIEnSmDr5ZqUA==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-node@5.2.2':
+    resolution: {integrity: sha512-toS+2AePxqyzb0YOKttDOOiSl3jrkK9aiqIvpurpis0O34QcIS5gToqrgT39p04Dpxw3YoUU0lxJKTpSFFfA6Q==}
+    engines: {node: '>=20'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -4190,6 +4282,10 @@ packages:
     resolution: {integrity: sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typespec/ts-http-runtime@0.3.5':
+    resolution: {integrity: sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==}
+    engines: {node: '>=20.0.0'}
+
   '@unhead/vue@2.1.13':
     resolution: {integrity: sha512-HYy0shaHRnLNW9r85gppO8IiGz0ONWVV3zGdlT8CQ0tbTwixznJCIiyqV4BSV1aIF1jJIye0pd1p/k6Eab8Z/A==}
     peerDependencies:
@@ -5702,6 +5798,10 @@ packages:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   http-shutdown@1.2.2:
     resolution: {integrity: sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -5976,6 +6076,10 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
@@ -6064,14 +6168,35 @@ packages:
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
   lodash.isarguments@3.1.0:
     resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
 
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
@@ -8997,6 +9122,149 @@ snapshots:
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
+  '@azure-rest/core-client@2.6.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@typespec/ts-http-runtime': 0.3.5
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/abort-controller@2.1.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-auth@1.10.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-util': 1.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-client@1.10.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-http-compat@2.4.0(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.23.0)':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-client': 1.10.1
+      '@azure/core-rest-pipeline': 1.23.0
+
+  '@azure/core-lro@2.7.2':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-paging@1.6.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-rest-pipeline@1.23.0':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      '@typespec/ts-http-runtime': 0.3.5
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/core-tracing@1.3.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/core-util@1.13.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@typespec/ts-http-runtime': 0.3.5
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/identity@4.13.1':
+    dependencies:
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-client': 1.10.1
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      '@azure/msal-browser': 5.11.0
+      '@azure/msal-node': 5.2.2
+      open: 10.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/keyvault-common@2.1.0':
+    dependencies:
+      '@azure-rest/core-client': 2.6.0
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/keyvault-keys@4.10.0(@azure/core-client@1.10.1)':
+    dependencies:
+      '@azure-rest/core-client': 2.6.0
+      '@azure/abort-controller': 2.1.2
+      '@azure/core-auth': 1.10.1
+      '@azure/core-http-compat': 2.4.0(@azure/core-client@1.10.1)(@azure/core-rest-pipeline@1.23.0)
+      '@azure/core-lro': 2.7.2
+      '@azure/core-paging': 1.6.2
+      '@azure/core-rest-pipeline': 1.23.0
+      '@azure/core-tracing': 1.3.1
+      '@azure/core-util': 1.13.1
+      '@azure/keyvault-common': 2.1.0
+      '@azure/logger': 1.3.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@azure/core-client'
+      - supports-color
+
+  '@azure/logger@1.3.0':
+    dependencies:
+      '@typespec/ts-http-runtime': 0.3.5
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@azure/msal-browser@5.11.0':
+    dependencies:
+      '@azure/msal-common': 16.6.2
+
+  '@azure/msal-common@16.6.2': {}
+
+  '@azure/msal-node@5.2.2':
+    dependencies:
+      '@azure/msal-common': 16.6.2
+      jsonwebtoken: 9.0.3
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -10382,7 +10650,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0))(typescript@5.9.3)':
+  '@nuxt/nitro-server@4.4.2(3illoki4ycqbjkoacagmmdv7m4)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -10400,8 +10668,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.3(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17))(srvx@0.11.15)
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
+      nitropack: 2.13.3(@azure/identity@4.13.1)(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17))(srvx@0.11.15)
+      nuxt: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -10410,7 +10678,7 @@ snapshots:
       std-env: 4.0.0
       ufo: 1.6.3
       unctx: 2.5.0
-      unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(ioredis@5.10.1)
+      unstorage: 1.17.5(@azure/identity@4.13.1)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(ioredis@5.10.1)
       vue: 3.5.32(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
@@ -10452,7 +10720,7 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@nuxt/nitro-server@4.4.2(ove33jcvna5zpg6qfonubipisi)':
+  '@nuxt/nitro-server@4.4.2(x3nxv74o3tqmacatqhe2agzdfq)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -10470,8 +10738,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.3(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17))(srvx@0.11.15)
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
+      nitropack: 2.13.3(@azure/identity@4.13.1)(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17))(srvx@0.11.15)
+      nuxt: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -10480,7 +10748,7 @@ snapshots:
       std-env: 4.0.0
       ufo: 1.6.3
       unctx: 2.5.0
-      unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(ioredis@5.10.1)
+      unstorage: 1.17.5(@azure/identity@4.13.1)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(ioredis@5.10.1)
       vue: 3.5.32(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
@@ -10539,7 +10807,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.0.0
 
-  '@nuxt/vite-builder@4.4.2(gxtqoc3zy7hpg5vdx6ao3wm6x4)':
+  '@nuxt/vite-builder@4.4.2(grarc57phrecko2onpjaonvwtu)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.1)
@@ -10557,7 +10825,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
+      nuxt: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -10599,7 +10867,7 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.4.2(wbuhlnbsmblc2rgtpexwdgzpue)':
+  '@nuxt/vite-builder@4.4.2(sdvsdkhflqs2ybsvzjzioenq6e)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.1)
@@ -10617,7 +10885,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
+      nuxt: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -11805,6 +12073,14 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.58.0
       eslint-visitor-keys: 5.0.1
+
+  '@typespec/ts-http-runtime@0.3.5':
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@unhead/vue@2.1.13(vue@3.5.32(typescript@5.9.3))':
     dependencies:
@@ -13600,6 +13876,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   http-shutdown@1.2.2: {}
 
   https-proxy-agent@5.0.1:
@@ -13845,6 +14128,19 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
+
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -13967,11 +14263,25 @@ snapshots:
 
   lodash.defaults@4.2.0: {}
 
+  lodash.includes@4.3.0: {}
+
   lodash.isarguments@3.1.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
 
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   lodash.startcase@4.4.0: {}
 
@@ -14215,7 +14525,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nitropack@2.13.3(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17))(srvx@0.11.15):
+  nitropack@2.13.3(@azure/identity@4.13.1)(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17))(srvx@0.11.15):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.60.1)
@@ -14282,7 +14592,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 6.0.2
       unplugin-utils: 0.3.1
-      unstorage: 1.17.5(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(ioredis@5.10.1)
+      unstorage: 1.17.5(@azure/identity@4.13.1)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(ioredis@5.10.1)
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.1
@@ -14370,16 +14680,16 @@ snapshots:
 
   ntlm@0.1.3: {}
 
-  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0):
+  nuxt@4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
       '@nuxt/devtools': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(ove33jcvna5zpg6qfonubipisi)
+      '@nuxt/nitro-server': 4.4.2(x3nxv74o3tqmacatqhe2agzdfq)
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(gxtqoc3zy7hpg5vdx6ao3wm6x4)
+      '@nuxt/vite-builder': 4.4.2(sdvsdkhflqs2ybsvzjzioenq6e)
       '@unhead/vue': 2.1.13(vue@3.5.32(typescript@5.9.3))
       '@vue/shared': 3.5.32
       c12: 3.3.4(magicast@0.5.2)
@@ -14503,16 +14813,16 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0):
+  nuxt@4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
       '@nuxt/devtools': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0))(typescript@5.9.3)
+      '@nuxt/nitro-server': 4.4.2(3illoki4ycqbjkoacagmmdv7m4)
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(wbuhlnbsmblc2rgtpexwdgzpue)
+      '@nuxt/vite-builder': 4.4.2(grarc57phrecko2onpjaonvwtu)
       '@unhead/vue': 2.1.13(vue@3.5.32(typescript@5.9.3))
       '@vue/shared': 3.5.32
       c12: 3.3.4(magicast@0.5.2)
@@ -16109,7 +16419,7 @@ snapshots:
       escape-string-regexp: 5.0.0
       ufo: 1.6.3
 
-  unstorage@1.17.5(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(ioredis@5.10.1):
+  unstorage@1.17.5(@azure/identity@4.13.1)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(ioredis@5.10.1):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -16120,6 +16430,7 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.3
     optionalDependencies:
+      '@azure/identity': 4.13.1
       db0: 0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17))
       ioredis: 5.10.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,24 @@ importers:
         specifier: ^22.0.0
         version: 22.19.17
 
+  packages/at-gcp-kms:
+    devDependencies:
+      '@google-cloud/kms':
+        specifier: ^4.0.0
+        version: 4.5.0
+      '@noy-db/hub':
+        specifier: workspace:*
+        version: link:../hub
+      '@noy-db/on-shamir':
+        specifier: workspace:*
+        version: link:../on-shamir
+      '@noy-db/to-memory':
+        specifier: workspace:*
+        version: link:../to-memory
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+
   packages/at-macos-keychain:
     devDependencies:
       '@napi-rs/keyring':
@@ -2314,6 +2332,24 @@ packages:
   '@gerrit0/mini-shiki@1.27.2':
     resolution: {integrity: sha512-GeWyHz8ao2gBiUW4OJnQDxXQnFgZQwwQk05t/CVVgNBN7/rK8XZ7xY6YhLVv9tH3VppWWmr9DCl3MwemB/i+Og==}
 
+  '@google-cloud/kms@4.5.0':
+    resolution: {integrity: sha512-i2vC0DI7bdfEhQszqASTw0KVvbB7HsO2CwTBod423NawAu7FWi+gVVa7NLfXVNGJaZZayFfci2Hu+om/HmyEjQ==}
+    engines: {node: '>=14.0.0'}
+
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  '@grpc/proto-loader@0.8.1':
+    resolution: {integrity: sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -2617,6 +2653,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
   '@kwsites/file-exists@1.1.1':
     resolution: {integrity: sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==}
@@ -3402,6 +3441,36 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
+
   '@rolldown/pluginutils@1.0.0-rc.13':
     resolution: {integrity: sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==}
 
@@ -3923,6 +3992,10 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@tootallnate/once@2.0.1':
+    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
+    engines: {node: '>= 10'}
+
   '@turbo/darwin-64@2.9.3':
     resolution: {integrity: sha512-P8foouaP+y/p+hhEGBoZpzMbpVvUMwPjDpcy6wN7EYfvvyISD1USuV27qWkczecihwuPJzQ1lDBuL8ERcavTyg==}
     cpu: [x64]
@@ -3965,6 +4038,9 @@ packages:
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
+  '@types/caseless@0.12.5':
+    resolution: {integrity: sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -3994,6 +4070,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/long@4.0.2':
+    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
 
   '@types/node-fetch@2.6.13':
     resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
@@ -4028,6 +4107,9 @@ packages:
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
+  '@types/request@2.48.13':
+    resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
+
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
@@ -4036,6 +4118,9 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -4342,6 +4427,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -4543,6 +4632,9 @@ packages:
     resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
@@ -4593,6 +4685,9 @@ packages:
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -5053,8 +5148,14 @@ packages:
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   editorconfig@1.0.7:
     resolution: {integrity: sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==}
@@ -5260,6 +5361,9 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
@@ -5381,6 +5485,10 @@ packages:
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
+  form-data@2.5.5:
+    resolution: {integrity: sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==}
+    engines: {node: '>= 0.12'}
+
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -5430,6 +5538,14 @@ packages:
 
   fzf@0.5.2:
     resolution: {integrity: sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==}
+
+  gaxios@6.7.1:
+    resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
+    engines: {node: '>=14'}
+
+  gcp-metadata@6.1.1:
+    resolution: {integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==}
+    engines: {node: '>=14'}
 
   generate-function@2.3.1:
     resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
@@ -5503,12 +5619,28 @@ packages:
     resolution: {integrity: sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==}
     engines: {node: '>=20'}
 
+  google-auth-library@9.15.1:
+    resolution: {integrity: sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==}
+    engines: {node: '>=14'}
+
+  google-gax@4.6.1:
+    resolution: {integrity: sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==}
+    engines: {node: '>=14'}
+
+  google-logging-utils@0.0.2:
+    resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gtoken@7.1.0:
+    resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
+    engines: {node: '>=14.0.0'}
 
   gzip-size@7.0.0:
     resolution: {integrity: sha512-O1Ld7Dr+nqPnmGpdhzLmMTQ4vAsD+rHwMm1NLUmoUFFymBOMKxCCrtDxqdBRYXdeEPEi3SyoR4TizJLQrnKBNA==}
@@ -5566,9 +5698,17 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+
   http-shutdown@1.2.2:
     resolution: {integrity: sha512-S9wWkJ/VSY9/k4qcjG318bqJNruzE4HySUhFYknwmu6LBP97KLLfwNf+n4V1BHurvFNkSKLFnK/RsuUnRTf9Vw==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -5810,6 +5950,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -5832,6 +5975,12 @@ packages:
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -5908,6 +6057,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
@@ -6279,6 +6431,10 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -6803,6 +6959,14 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
+  proto3-json-serializer@2.0.2:
+    resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
+    engines: {node: '>=14.0.0'}
+
+  protobufjs@7.6.1:
+    resolution: {integrity: sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==}
+    engines: {node: '>=12.0.0'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -6927,6 +7091,10 @@ packages:
   ret@0.5.0:
     resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
     engines: {node: '>=10'}
+
+  retry-request@7.0.2:
+    resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
+    engines: {node: '>=14'}
 
   retry@0.12.0:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
@@ -7212,6 +7380,12 @@ packages:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
     engines: {node: '>=4', npm: '>=6'}
 
+  stream-events@1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
@@ -7264,6 +7438,9 @@ packages:
 
   structured-clone-es@2.0.0:
     resolution: {integrity: sha512-5UuAHmBLXYPCl22xWJrFuGmIhBKQzxISPVz6E7nmTmTcAOpUzlbjKJsRrCE4vADmMQ0dzeCnlWn9XufnAGf76Q==}
+
+  stubs@3.0.0:
+    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -7327,6 +7504,10 @@ packages:
   tar@7.5.13:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
     engines: {node: '>=18'}
+
+  teeny-request@9.0.0:
+    resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
+    engines: {node: '>=14'}
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
@@ -7656,6 +7837,11 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -9607,6 +9793,32 @@ snapshots:
       '@shikijs/types': 1.29.2
       '@shikijs/vscode-textmate': 10.0.2
 
+  '@google-cloud/kms@4.5.0':
+    dependencies:
+      google-gax: 4.6.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@grpc/grpc-js@1.14.4':
+    dependencies:
+      '@grpc/proto-loader': 0.8.1
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.1
+      yargs: 17.7.2
+
+  '@grpc/proto-loader@0.8.1':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.1
+      yargs: 17.7.2
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -9842,6 +10054,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
@@ -10735,6 +10949,28 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
+
   '@rolldown/pluginutils@1.0.0-rc.13': {}
 
   '@rolldown/pluginutils@1.0.0-rc.2': {}
@@ -11335,6 +11571,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
+  '@tootallnate/once@2.0.1': {}
+
   '@turbo/darwin-64@2.9.3':
     optional: true
 
@@ -11368,6 +11606,8 @@ snapshots:
     dependencies:
       '@types/connect': 3.4.38
       '@types/node': 22.19.17
+
+  '@types/caseless@0.12.5': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -11404,6 +11644,8 @@ snapshots:
   '@types/http-errors@2.0.5': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/long@4.0.2': {}
 
   '@types/node-fetch@2.6.13':
     dependencies:
@@ -11445,6 +11687,13 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
+  '@types/request@2.48.13':
+    dependencies:
+      '@types/caseless': 0.12.5
+      '@types/node': 22.19.17
+      '@types/tough-cookie': 4.0.5
+      form-data: 2.5.5
+
   '@types/resolve@1.20.2': {}
 
   '@types/send@1.2.1':
@@ -11455,6 +11704,8 @@ snapshots:
     dependencies:
       '@types/http-errors': 2.0.5
       '@types/node': 22.19.17
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@types/unist@3.0.3': {}
 
@@ -11903,6 +12154,12 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   agentkeepalive@4.6.0:
@@ -12088,6 +12345,8 @@ snapshots:
       bindings: 1.5.0
       prebuild-install: 7.1.3
 
+  bignumber.js@9.3.1: {}
+
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
@@ -12150,6 +12409,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-crc32@1.0.0: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -12573,7 +12834,18 @@ snapshots:
 
   duplexer@0.1.2: {}
 
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   editorconfig@1.0.7:
     dependencies:
@@ -12894,6 +13166,8 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  extend@3.0.2: {}
+
   extendable-error@0.1.7: {}
 
   fake-indexeddb@6.2.5: {}
@@ -13048,6 +13322,15 @@ snapshots:
 
   form-data-encoder@1.7.2: {}
 
+  form-data@2.5.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+      safe-buffer: 5.2.1
+
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -13092,6 +13375,26 @@ snapshots:
   fuse.js@7.3.0: {}
 
   fzf@0.5.2: {}
+
+  gaxios@6.7.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      is-stream: 2.0.1
+      node-fetch: 2.7.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  gcp-metadata@6.1.1:
+    dependencies:
+      gaxios: 6.7.1
+      google-logging-utils: 0.0.2
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   generate-function@2.3.1:
     dependencies:
@@ -13181,9 +13484,49 @@ snapshots:
       slash: 5.1.0
       unicorn-magic: 0.4.0
 
+  google-auth-library@9.15.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 6.7.1
+      gcp-metadata: 6.1.1
+      gtoken: 7.1.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  google-gax@4.6.1:
+    dependencies:
+      '@grpc/grpc-js': 1.14.4
+      '@grpc/proto-loader': 0.7.15
+      '@types/long': 4.0.2
+      abort-controller: 3.0.0
+      duplexify: 4.1.3
+      google-auth-library: 9.15.1
+      node-fetch: 2.7.0
+      object-hash: 3.0.0
+      proto3-json-serializer: 2.0.2
+      protobufjs: 7.6.1
+      retry-request: 7.0.2
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  google-logging-utils@0.0.2: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  gtoken@7.1.0:
+    dependencies:
+      gaxios: 6.7.1
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   gzip-size@7.0.0:
     dependencies:
@@ -13249,7 +13592,22 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@5.0.0:
+    dependencies:
+      '@tootallnate/once': 2.0.1
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   http-shutdown@1.2.2: {}
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -13465,6 +13823,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-schema-ref-resolver@3.0.0:
@@ -13482,6 +13844,17 @@ snapshots:
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -13589,6 +13962,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.camelcase@4.3.0: {}
 
   lodash.defaults@4.2.0: {}
 
@@ -14269,6 +14644,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  object-hash@3.0.0: {}
+
   object-inspect@1.13.4: {}
 
   obliterator@1.6.1: {}
@@ -14813,6 +15190,25 @@ snapshots:
 
   proto-list@1.2.4: {}
 
+  proto3-json-serializer@2.0.2:
+    dependencies:
+      protobufjs: 7.6.1
+
+  protobufjs@7.6.1:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.19.17
+      long: 5.3.2
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -14936,6 +15332,15 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   ret@0.5.0: {}
+
+  retry-request@7.0.2:
+    dependencies:
+      '@types/request': 2.48.13
+      extend: 3.0.2
+      teeny-request: 9.0.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   retry@0.12.0: {}
 
@@ -15294,6 +15699,12 @@ snapshots:
 
   stoppable@1.1.0: {}
 
+  stream-events@1.0.5:
+    dependencies:
+      stubs: 3.0.0
+
+  stream-shift@1.0.3: {}
+
   streamx@2.25.0:
     dependencies:
       events-universal: 1.0.1
@@ -15348,6 +15759,8 @@ snapshots:
   strnum@2.3.0: {}
 
   structured-clone-es@2.0.0: {}
+
+  stubs@3.0.0: {}
 
   styled-jsx@5.1.6(react@18.3.1):
     dependencies:
@@ -15427,6 +15840,17 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  teeny-request@9.0.0:
+    dependencies:
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      stream-events: 1.0.5
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   teex@1.0.1:
     dependencies:
@@ -15735,6 +16159,8 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  uuid@9.0.1: {}
 
   vary@1.1.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,24 @@ importers:
         specifier: ^22.0.0
         version: 22.19.17
 
+  packages/at-aws-kms:
+    devDependencies:
+      '@aws-sdk/client-kms':
+        specifier: ^3.0.0
+        version: 3.1053.0
+      '@noy-db/hub':
+        specifier: workspace:*
+        version: link:../hub
+      '@noy-db/on-shamir':
+        specifier: workspace:*
+        version: link:../on-shamir
+      '@noy-db/to-memory':
+        specifier: workspace:*
+        version: link:../to-memory
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+
   packages/at-env:
     devDependencies:
       '@noy-db/hub':
@@ -1143,12 +1161,20 @@ packages:
     resolution: {integrity: sha512-IJ4uM5i8z6hO7FRT7kngl/boqrZdyczxLKobCSHaxbFtxDu68QEfhn9D95FdkOENMmC2TIglnSlBqn5cG8qMTQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-kms@3.1053.0':
+    resolution: {integrity: sha512-U7dr+jGnAV2UpQesHBan4lgI8TAgFyWhvcWAon8Ub4UjIQz5RDbP5eyU7DU2qjmgGe7iL0U0/jYvQpBj2TkelA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-s3@3.1024.0':
     resolution: {integrity: sha512-8qdO5aLCzaf9l0RdrSBW1iIroRKP2QBqtZ6lkrtHKiaaH0B18xEn+lrEgiN/eCf3uRAYk4cqbnI2XcWzm+7dDQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.973.26':
     resolution: {integrity: sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.13':
+    resolution: {integrity: sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/crc64-nvme@3.972.5':
@@ -1159,32 +1185,64 @@ packages:
     resolution: {integrity: sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.39':
+    resolution: {integrity: sha512-29wX9zpAvEt1vcj0psha+y6ygBHy2V/S72mp6e7q0KARLWXq+pwE/lR6qGkwknQvruh52lXvlqZIga8Hdxkucw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.26':
     resolution: {integrity: sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.41':
+    resolution: {integrity: sha512-IA3CQTjtJkb6u1H4mE4936c8OPBMa9Jggtwe8U2Mqw/vvb/tZ5Ebd0mcZcX0uKWQhOyYo/+qNIwkV5Xh+FeJJA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.28':
     resolution: {integrity: sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.43':
+    resolution: {integrity: sha512-4mzII+3mZEVXXE1xzrLQrCJL7/r62A63bA6SVzZoNL5rqCJghpf+xgGltVrIBBs0n+mOZBKrQl2tRREtvZ5l6A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.28':
     resolution: {integrity: sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.43':
+    resolution: {integrity: sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.29':
     resolution: {integrity: sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.44':
+    resolution: {integrity: sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.24':
     resolution: {integrity: sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.39':
+    resolution: {integrity: sha512-2k/amBifLd75eXNwgvPw/2lKYSQ3NhvHQgkVKVjfUq13/eJ3JRtHmznuFenn74OK3sSfp4SMy1YB2w+UVXoKqA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.28':
     resolution: {integrity: sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.43':
+    resolution: {integrity: sha512-LPc3+Y4vhH1T4x6CMqwCM6hk5+SRf/Lwmgm8INm95wxTtIRHcMwQUVkDzWu4Iw/RSncxYM2BC01OrYbxOPZvyg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.28':
     resolution: {integrity: sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.43':
+    resolution: {integrity: sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/dynamodb-codec@3.972.27':
@@ -1249,6 +1307,10 @@ packages:
     resolution: {integrity: sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.11':
+    resolution: {integrity: sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/region-config-resolver@3.972.10':
     resolution: {integrity: sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==}
     engines: {node: '>=20.0.0'}
@@ -1257,12 +1319,24 @@ packages:
     resolution: {integrity: sha512-Ukw2RpqvaL96CjfH/FgfBmy/ZosHBqoHBCFsN61qGg99F33vpntIVii8aNeh65XuOja73arSduskoa4OJea9RQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.28':
+    resolution: {integrity: sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1021.0':
     resolution: {integrity: sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1052.0':
+    resolution: {integrity: sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.6':
     resolution: {integrity: sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.9':
+    resolution: {integrity: sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-arn-parser@3.972.3':
@@ -1297,6 +1371,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.16':
     resolution: {integrity: sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.25':
+    resolution: {integrity: sha512-GH+Kjz4nPKWKHnsiQpnhP1MJdTGIcK4rAka6tzakgjjUkVgNsmPeEbbRAf09SzS1hjGu6duGHCBsxYke0BhHjQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -2754,6 +2832,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -3563,8 +3644,16 @@ packages:
     resolution: {integrity: sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.24.4':
+    resolution: {integrity: sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.12':
     resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.4':
+    resolution: {integrity: sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.2.12':
@@ -3589,6 +3678,10 @@ packages:
 
   '@smithy/fetch-http-handler@5.3.15':
     resolution: {integrity: sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.4':
+    resolution: {integrity: sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-blob-browser@4.2.13':
@@ -3647,6 +3740,10 @@ packages:
     resolution: {integrity: sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.7.4':
+    resolution: {integrity: sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.2.12':
     resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
     engines: {node: '>=18.0.0'}
@@ -3675,12 +3772,20 @@ packages:
     resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.4.4':
+    resolution: {integrity: sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/smithy-client@4.12.8':
     resolution: {integrity: sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.13.1':
     resolution: {integrity: sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.2':
+    resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.2.12':
@@ -5206,8 +5311,15 @@ packages:
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
   fast-xml-parser@5.5.8:
     resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
+    hasBin: true
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
 
   fastify@5.8.5:
@@ -6294,6 +6406,10 @@ packages:
     resolution: {integrity: sha512-d7gQQmLvAKXKXE2GeP9apIGbMYKz88zWdsn/BN2HRWVQsDFdUY36WSLTY0Jvd4HWi7Fb30gQ62oAOzdgJA6fZw==}
     engines: {node: '>=14.0.0'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
@@ -7143,6 +7259,9 @@ packages:
   strnum@2.2.2:
     resolution: {integrity: sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==}
 
+  strnum@2.3.0:
+    resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
+
   structured-clone-es@2.0.0:
     resolution: {integrity: sha512-5UuAHmBLXYPCl22xWJrFuGmIhBKQzxISPVz6E7nmTmTcAOpUzlbjKJsRrCE4vADmMQ0dzeCnlWn9XufnAGf76Q==}
 
@@ -7919,6 +8038,10 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -8035,7 +8158,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.9
       '@aws-sdk/util-locate-window': 3.965.5
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -8043,7 +8166,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.9
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -8102,6 +8225,19 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/client-kms@3.1053.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/credential-provider-node': 3.972.44
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
 
   '@aws-sdk/client-s3@3.1024.0':
     dependencies:
@@ -8179,6 +8315,17 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/xml-builder': 3.972.25
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.4
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/crc64-nvme@3.972.5':
     dependencies:
       '@smithy/types': 4.13.1
@@ -8192,6 +8339,14 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.39':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.26':
     dependencies:
       '@aws-sdk/core': 3.973.26
@@ -8203,6 +8358,16 @@ snapshots:
       '@smithy/smithy-client': 4.12.8
       '@smithy/types': 4.13.1
       '@smithy/util-stream': 4.5.21
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.28':
@@ -8224,6 +8389,22 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/credential-provider-env': 3.972.39
+      '@aws-sdk/credential-provider-http': 3.972.41
+      '@aws-sdk/credential-provider-login': 3.972.43
+      '@aws-sdk/credential-provider-process': 3.972.39
+      '@aws-sdk/credential-provider-sso': 3.972.43
+      '@aws-sdk/credential-provider-web-identity': 3.972.43
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/credential-provider-imds': 4.3.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.28':
     dependencies:
       '@aws-sdk/core': 3.973.26
@@ -8236,6 +8417,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.29':
     dependencies:
@@ -8254,6 +8444,20 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.972.44':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.39
+      '@aws-sdk/credential-provider-http': 3.972.41
+      '@aws-sdk/credential-provider-ini': 3.972.43
+      '@aws-sdk/credential-provider-process': 3.972.39
+      '@aws-sdk/credential-provider-sso': 3.972.43
+      '@aws-sdk/credential-provider-web-identity': 3.972.43
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/credential-provider-imds': 4.3.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.24':
     dependencies:
       '@aws-sdk/core': 3.973.26
@@ -8261,6 +8465,14 @@ snapshots:
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.39':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.28':
@@ -8276,6 +8488,16 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/token-providers': 3.1052.0
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.28':
     dependencies:
       '@aws-sdk/core': 3.973.26
@@ -8287,6 +8509,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
 
   '@aws-sdk/dynamodb-codec@3.972.27':
     dependencies:
@@ -8459,6 +8690,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/nested-clients@3.997.11':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.28
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/fetch-http-handler': 5.4.4
+      '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/region-config-resolver@3.972.10':
     dependencies:
       '@aws-sdk/types': 3.973.6
@@ -8476,6 +8720,14 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.28':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/signature-v4': 5.4.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1021.0':
     dependencies:
       '@aws-sdk/core': 3.973.26
@@ -8488,9 +8740,23 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/token-providers@3.1052.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/nested-clients': 3.997.11
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.973.6':
     dependencies:
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.9':
+    dependencies:
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@aws-sdk/util-arn-parser@3.972.3':
@@ -8534,6 +8800,13 @@ snapshots:
     dependencies:
       '@smithy/types': 4.13.1
       fast-xml-parser: 5.5.8
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.25':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.4': {}
@@ -9756,6 +10029,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.15':
     optional: true
 
+  '@nodable/entities@2.1.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -10655,12 +10930,24 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
+  '@smithy/core@3.24.4':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.12':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
       '@smithy/property-provider': 4.2.12
       '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.12
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.12':
@@ -10699,6 +10986,12 @@ snapshots:
       '@smithy/querystring-builder': 4.2.12
       '@smithy/types': 4.13.1
       '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
 
   '@smithy/hash-blob-browser@4.2.13':
@@ -10795,6 +11088,12 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.7.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
@@ -10836,6 +11135,12 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.4.4':
+    dependencies:
+      '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/smithy-client@4.12.8':
     dependencies:
       '@smithy/core': 3.23.13
@@ -10847,6 +11152,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.13.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.2':
     dependencies:
       tslib: 2.8.1
 
@@ -12638,11 +12947,23 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.2.1
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
   fast-xml-parser@5.5.8:
     dependencies:
       fast-xml-builder: 1.1.4
       path-expression-matcher: 1.2.1
       strnum: 2.2.2
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.3.0
 
   fastify@5.8.5:
     dependencies:
@@ -14134,6 +14455,8 @@ snapshots:
 
   path-expression-matcher@1.2.1: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
@@ -15022,6 +15345,8 @@ snapshots:
 
   strnum@2.2.2: {}
 
+  strnum@2.3.0: {}
+
   structured-clone-es@2.0.0: {}
 
   styled-jsx@5.1.6(react@18.3.1):
@@ -15773,6 +16098,8 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
+
+  xml-naming@0.1.0: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
Second PR of the 0.2 epic. Three new `at-*` sealing-key providers backed by cloud KMS, so a trusted host you control can unseal a managed-mode vault using keys held in your cloud key service. Additive — no hub change, no breaking change.

## Packages (each mirrors `@noy-db/at-env`)
| Package | seal / unseal | peer dep | issue |
|---|---|---|---|
| `@noy-db/at-aws-kms` | KMS `Encrypt`/`Decrypt` | `@aws-sdk/client-kms` | #188 |
| `@noy-db/at-gcp-kms` | Cloud KMS `encrypt`/`decrypt` | `@google-cloud/kms` | #189 |
| `@noy-db/at-azure-keyvault` | Key Vault RSA-OAEP-256 `encrypt`/`decrypt` | `@azure/keyvault-keys` + `@azure/identity` | #190 |

## Design
- No hub change — the `SealingKeyProvider` contract (`seal`/`unseal`, opaque bytes) already fits remote encrypt/decrypt.
- **Credential-safe:** no options interface accepts raw credentials — only a key identifier + an optional pre-built client (DI for tests). Defaults use the SDK's ambient credential chain (env / IAM role / managed identity / ADC).
- `unseal` fails closed (throws on missing output / SDK error).
- GCP handles the base64-string response shape (real GCP-over-REST); Azure docs warn that RSA decrypt is **version-bound** — pin a versioned keyId (auto-rotation on a versionless key would orphan sealed vaults).

## Tests
Each package: mock round-trip + id, both output-guard tests, throw-on-failure, **hub managed-mode integration round-trip** (createNoydb managed + `shamirRecovery` + in-memory store: enroll+write, reopen+read), and an env-gated real-cloud test (skips without creds). Full workspace test 134/134; build/lint/typecheck/check-architecture/validate-features all green.

## Reviews
Per-package spec+quality reviews (aws, gcp) + an opus final holistic review of the trio; the one finding (Azure rotation docs steering users into RSA-version lockout) is fixed.

## Not in this PR
No version bump (lockstep `0.2.0-pre.1` at release). features.yaml registration of these providers is Workstream D (#214). Next: C (#215 auto-unlock), D, E.

Plan: `docs/superpowers/plans/2026-05-24-0.2-workstream-B-cloud-kms.md`