### PR TITLE
feat(hub): 0.2 Workstream C — generalized bundle auto-unlock to autoCredentials/sealedCredentials (#215)

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -14,3 +14,5 @@ Shamir recovery now requires an injected provider.
 > Note: when multiple Shamir recovery entries are enrolled, supply the shares for a **single** entry per recovery attempt (optionally with `entryId`). Mixing shares from different entries in one call no longer recovers.
 
 > Managed-passphrase mode mandates a strong recovery profile, and Shamir is the only one — so **managed-mode vaults now also require a `shamirRecovery` provider**. Add `@noy-db/on-shamir` and pass `shamirRecovery: shamirRecoveryProvider()` to `createNoydb`.
+
+> **Bundle auto-unlock generalized (#215):** `autoCredentials` / `sealedCredentials` carry `{ kind: 'passphrase' | 'password' | 'pin', value }`, so a delivered bundle can one-click-unlock whatever tier the user enrolled. `autoPassphrases` / `sealedPassphrases` still work (deprecated sugar for `kind: 'passphrase'`). On read, `autoUnlock.perUser[user]` is now `{ kind, value }` — dispatch your login by `kind` (PIN is a prefill, not an enrollment). WebAuthn is not auto-unlockable (hardware-bound) and is rejected at write time. Pre-0.2 bundles read back unchanged (bare-string entries coerce to `kind: 'passphrase'`).

--- a/docs/superpowers/plans/2026-05-24-0.2-workstream-C-auto-unlock.md
+++ b/docs/superpowers/plans/2026-05-24-0.2-workstream-C-auto-unlock.md
@@ -1,0 +1,190 @@
+# 0.2 Workstream C — generalized bundle auto-unlock (#215) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generalize bundle auto-unlock from passphrase-only to any non-hardware credential kind (`passphrase` / `password` / `pin`), so a delivered bundle one-click-unlocks whatever tier the user enrolled — the live niwat request (niwat#92). `autoPassphrases` / `sealedPassphrases` (pre.16) become deprecated sugar over the new `autoCredentials` / `sealedCredentials`.
+
+**Architecture:** A bounded generalization of `packages/hub/src/bundle/bundle.ts`'s existing #197 auto-unlock layer. The per-user value widens from a bare passphrase `string` to `{ kind, value }`. `bundle.ts` stays a pure **format layer** — it carries the credential kind+value (sealed or plaintext); the consuming app performs the actual login/prefill dispatch by reading `kind`. PIN is therefore "carry the value tagged `pin`"; whether the app enrolls or prefills is the app's concern (documented).
+
+**Tech Stack:** TypeScript strict, vitest. Single file + its tests.
+
+**Spec:** `docs/superpowers/specs/2026-05-24-0.2-at-family-and-auto-unlock-design.md` (Workstream C). Build order: after B (merged), independent of D/E.
+
+**Anchor functions in `packages/hub/src/bundle/bundle.ts` (read them first):**
+- `WriteNoydbBundleOptions` (~L80) with `autoPassphrases?` (~L143) / `sealedPassphrases?` (~L164)
+- `NoydbBundleReadResult.autoUnlock` (~L188); `SealedAutoUnlockEntry` (~L201); `AutoUnlockBody` (~L213); `ReadNoydbBundleOptions` (~L226)
+- `validateAutoUnlockOptions` (~L262); `buildAutoUnlockWrapper` (~L314); `parseAutoUnlockBody` (~L355); `resolveAutoUnlock` (~L407)
+
+---
+
+### Task 1: Type surface — `AutoCredential` + new options (with sugar)
+
+**Files:** Modify `packages/hub/src/bundle/bundle.ts`; export new types from `packages/hub/src/index.ts` if the existing auto-unlock types are exported (match).
+
+- [ ] **Step 1: Add the credential types** near the auto-unlock types:
+```ts
+export type AutoCredentialKind = 'passphrase' | 'password' | 'pin'
+
+/** One user's auto-unlock material. `value` is the secret for `kind`. */
+export interface AutoCredential {
+  readonly kind: AutoCredentialKind
+  readonly value: string
+}
+```
+
+- [ ] **Step 2: Add the new write options** to `WriteNoydbBundleOptions`, keeping the old two as deprecated sugar (do NOT delete them — back-compat):
+```ts
+  /**
+   * Auto-unlock — per-user credentials, plaintext (public-by-design).
+   * Generalizes `autoPassphrases` across tiers (passphrase/password/pin). #215
+   */
+  readonly autoCredentials?: {
+    readonly policy: 'public-by-design'
+    readonly perUser: Record<string, AutoCredential>
+  }
+  /**
+   * Auto-unlock — per-user credentials sealed under a SealingKeyProvider. #215
+   */
+  readonly sealedCredentials?: {
+    readonly mode: 'self-target'
+    readonly provider: SealingKeyProvider
+    readonly perUser: Record<string, AutoCredential>
+  }
+  /** @deprecated Use `autoCredentials` (kind:'passphrase'). Retained for back-compat. */
+  readonly autoPassphrases?: { readonly policy: 'public-by-design'; readonly perUser: Record<string, string> }
+  /** @deprecated Use `sealedCredentials` (kind:'passphrase'). Retained for back-compat. */
+  readonly sealedPassphrases?: { readonly mode: 'self-target'; readonly provider: SealingKeyProvider; readonly perUser: Record<string, string> }
+```
+
+- [ ] **Step 3: typecheck** `pnpm --filter @noy-db/hub typecheck` — expect clean (additive types).
+
+- [ ] **Step 4: Commit** `git commit -m "feat(hub): AutoCredential types + autoCredentials/sealedCredentials options (#215)"`
+
+---
+
+### Task 2: Normalize sugar → credentials at the top of the write path
+
+**Files:** `packages/hub/src/bundle/bundle.ts`.
+
+- [ ] **Step 1: Add a normalizer** that folds the deprecated sugar into the new shape, and rejects mixing sugar with the new options:
+```ts
+interface NormalizedAutoUnlock {
+  readonly mode: 'unsealed' | 'sealed'
+  readonly provider?: SealingKeyProvider
+  readonly perUser: Record<string, AutoCredential>
+}
+
+/** Collapse autoCredentials/sealedCredentials/autoPassphrases/sealedPassphrases into one shape. */
+function normalizeAutoUnlock(opts: WriteNoydbBundleOptions): NormalizedAutoUnlock | null {
+  const set = [opts.autoCredentials, opts.sealedCredentials, opts.autoPassphrases, opts.sealedPassphrases]
+    .filter(v => v !== undefined).length
+  if (set === 0) return null
+  if (set > 1) {
+    throw new ValidationError(
+      'writeNoydbBundle: only one of autoCredentials / sealedCredentials / autoPassphrases / sealedPassphrases may be set.',
+    )
+  }
+  const toCreds = (m: Record<string, string>): Record<string, AutoCredential> =>
+    Object.fromEntries(Object.entries(m).map(([u, value]) => [u, { kind: 'passphrase' as const, value }]))
+  if (opts.autoCredentials) return { mode: 'unsealed', perUser: opts.autoCredentials.perUser }
+  if (opts.autoPassphrases) return { mode: 'unsealed', perUser: toCreds(opts.autoPassphrases.perUser) }
+  if (opts.sealedCredentials) return { mode: 'sealed', provider: opts.sealedCredentials.provider, perUser: opts.sealedCredentials.perUser }
+  // sealedPassphrases
+  return { mode: 'sealed', provider: opts.sealedPassphrases!.provider, perUser: toCreds(opts.sealedPassphrases!.perUser) }
+}
+```
+
+- [ ] **Step 2: Rewrite `validateAutoUnlockOptions`** to operate on the normalized shape: it now takes `WriteNoydbBundleOptions`, calls `normalizeAutoUnlock`, and validates: `policy === 'public-by-design'` for the unsealed path (check `opts.autoCredentials?.policy ?? opts.autoPassphrases?.policy`), non-empty `perUser`, `mode === 'self-target'` + provider present for sealed, and that every `AutoCredential.kind` is one of `passphrase|password|pin` (reject `webauthn`/unknown with a clear message). Return `'unsealed' | 'sealed' | null` as before. Keep the existing error wording where it still applies; add the kind-validation error.
+
+- [ ] **Step 3: Run existing bundle tests** `pnpm --filter @noy-db/hub test -- bundle` — the pre.16 `autoPassphrases`/`sealedPassphrases` tests MUST still pass (proving sugar back-compat). Fix only if they break due to the refactor.
+
+- [ ] **Step 4: Commit** `git commit -m "feat(hub): normalize auto-unlock sugar into AutoCredential shape (#215)"`
+
+---
+
+### Task 3: Carry `kind` through body + read result
+
+**Files:** `packages/hub/src/bundle/bundle.ts`.
+
+- [ ] **Step 1: Widen the body shapes** so each entry carries `kind`:
+```ts
+interface SealedAutoUnlockEntry {
+  readonly pid: string
+  readonly sealed: string          // sealed VALUE
+  readonly alg: 'aes-256-gcm'
+  readonly kind: AutoCredentialKind // plaintext metadata — which tier this unlocks
+  readonly hint?: Record<string, unknown>
+}
+
+interface AutoUnlockBody {
+  readonly _noydb_bundle_body: 1
+  readonly dump: string
+  readonly _autoUnlock:
+    | { readonly kind: 'unsealed'; readonly perUser: Record<string, AutoCredential> }
+    | { readonly kind: 'sealed'; readonly perUser: Record<string, SealedAutoUnlockEntry> }
+}
+```
+(Note the OUTER `kind` is the unsealed/sealed discriminant — unchanged; the INNER per-entry `kind` is the new credential tier.)
+
+- [ ] **Step 2: Update `buildAutoUnlockWrapper`** to take the `NormalizedAutoUnlock` and write the widened entries: unsealed → `perUser: normalized.perUser` (already `AutoCredential`); sealed → for each user seal `cred.value` under the provider and write `{ pid, sealed, alg, kind: cred.kind }`.
+
+- [ ] **Step 3: Update `NoydbBundleReadResult.autoUnlock`** to:
+```ts
+  readonly autoUnlock?: {
+    readonly kind: 'unsealed' | 'sealed'
+    readonly perUser: Record<string, AutoCredential>  // value is plaintext after unseal; kind tells the app how to use it
+  }
+```
+
+- [ ] **Step 4: Update `parseAutoUnlockBody`** validation to accept the widened entries (it already only checks the outer structure + outer `kind`; ensure it doesn't reject the new inner fields). **Back-compat read:** if an unsealed entry is a bare `string` (pre-0.2 bundle), coerce to `{ kind: 'passphrase', value }`; if a sealed entry lacks `kind`, default `kind: 'passphrase'`. Add this coercion in `parseAutoUnlockBody` or `resolveAutoUnlock`.
+
+- [ ] **Step 5: Update `resolveAutoUnlock`** to return `Record<string, AutoCredential>`: unsealed → pass through (with the back-compat string→`{kind:'passphrase',value}` coercion); sealed-without-providers inspection passthrough → `{ kind: entry.kind ?? 'passphrase', value: entry.sealed }`; sealed-with-providers → unseal `entry.sealed` to the plaintext value, return `{ kind: entry.kind ?? 'passphrase', value: plaintext }`. Keep strict-pid + `attemptUnsealAcrossProviders` logic unchanged.
+
+- [ ] **Step 6: typecheck + existing bundle tests** — both green (sugar tests still pass, now flowing through the widened path).
+
+- [ ] **Step 7: Commit** `git commit -m "feat(hub): carry credential kind through bundle body + read result; back-compat reads (#215)"`
+
+---
+
+### Task 4: Tests for the new credential kinds + back-compat
+
+**Files:** add to `packages/hub/__tests__/bundle/` (find the existing #197 auto-unlock test file — likely `auto-unlock.test.ts` or within a bundle test; mirror its setup).
+
+- [ ] **Step 1: Write tests** (TDD — write, watch fail if behavior missing, then they pass against Tasks 1-3):
+  - `autoCredentials` with a `password`-kind entry: write → read → `autoUnlock.perUser[user]` is `{ kind: 'password', value }`.
+  - `autoCredentials` with a `pin`-kind entry: round-trips with `kind: 'pin'`.
+  - `sealedCredentials` with a `password` entry + a `MemorySealingKeyProvider`: write → read with the provider → unsealed `{ kind: 'password', value }`; read WITHOUT the provider → `kind: 'sealed'` passthrough still carries the inner `kind: 'password'`.
+  - **Sugar back-compat:** `autoPassphrases` (old API) → read → `{ kind: 'passphrase', value }`. `sealedPassphrases` (old API) → same.
+  - **Mixing rejected:** setting both `autoCredentials` and `autoPassphrases` throws the "only one of…" ValidationError.
+  - **Bad kind rejected:** an `AutoCredential` with `kind: 'webauthn' as any` → write throws the kind-validation error.
+  - **Old-bundle read:** craft/serialize a body whose unsealed `perUser` value is a bare string (pre-0.2 shape) → `resolveAutoUnlock` coerces to `{ kind: 'passphrase', value }`. (If hard to craft a raw body, assert the coercion via a unit test of the parse/resolve path.)
+
+- [ ] **Step 2: Run** `pnpm --filter @noy-db/hub test -- bundle` → all green.
+
+- [ ] **Step 3: Commit** `git commit -m "test(hub): bundle auto-unlock across credential kinds + sugar/old-bundle back-compat (#215)"`
+
+---
+
+### Task 5: Docs + MIGRATING + full gate
+
+- [ ] **Step 1: Append to `MIGRATING.md`** under `## 0.1 → 0.2`:
+```markdown
+> Bundle auto-unlock generalized: `autoCredentials` / `sealedCredentials` carry `{ kind: 'passphrase'|'password'|'pin', value }`. `autoPassphrases` / `sealedPassphrases` still work (deprecated sugar for `kind:'passphrase'`). On read, `autoUnlock.perUser[user]` is now `{ kind, value }` — dispatch your login by `kind` (PIN is a prefill, not an enrollment). WebAuthn is not auto-unlockable (hardware-bound).
+```
+
+- [ ] **Step 2: Full gate**:
+```bash
+pnpm install --frozen-lockfile && pnpm turbo build && pnpm turbo lint && pnpm turbo typecheck && node scripts/check-architecture.mjs && node scripts/validate-features.mjs && pnpm turbo test --concurrency=1 --filter '!@noy-db/showcases'
+```
+Expected: all exit 0.
+
+- [ ] **Step 3: Commit** any remaining; ready for PR.
+
+---
+
+## Self-Review
+
+- **Spec coverage (Workstream C):** `autoCredentials`/`sealedCredentials` umbrella (T1) ✓; `autoPassphrases`/`sealedPassphrases` deprecated sugar (T1-2) ✓; PIN carried (kind:'pin'), prefill-not-enroll documented as a consumer concern (T5) ✓; WebAuthn excluded via kind-validation (T2) ✓; back-compat reads of pre-0.2 bundles (T3) ✓; MIGRATING note (T5) ✓.
+- **Placeholders:** anchor functions named with line numbers; the only "find the test file" is a real existing-file lookup (mirror its setup) — not a content placeholder.
+- **Type consistency:** `AutoCredential`/`AutoCredentialKind` names + `{kind,value}` shape consistent across options (T1), body (T3), result (T3), and tests (T4). `NormalizedAutoUnlock` used by validate (T2) + build (T3).
+- **Format-layer discipline:** bundle.ts only carries credentials; no login/prefill logic added there (that's the consumer) — matches the file's stated "purely a format layer" design.

--- a/packages/hub/__tests__/bundle-auto-unlock.test.ts
+++ b/packages/hub/__tests__/bundle-auto-unlock.test.ts
@@ -83,8 +83,8 @@ describe('#197 — autoPassphrases (unsealed, public-by-design)', () => {
     expect(result.autoUnlock).toBeDefined()
     expect(result.autoUnlock!.kind).toBe('unsealed')
     expect(result.autoUnlock!.perUser).toEqual({
-      'demo-customer': 'demo-pass-1',
-      'demo-prospect': 'demo-pass-2',
+      'demo-customer': { kind: 'passphrase', value: 'demo-pass-1' },
+      'demo-prospect': { kind: 'passphrase', value: 'demo-pass-2' },
     })
   })
 
@@ -162,7 +162,7 @@ describe('#197 — sealedPassphrases (self-target)', () => {
     expect(result.autoUnlock).toBeDefined()
     expect(result.autoUnlock!.kind).toBe('sealed')
     expect(result.autoUnlock!.perUser).toEqual({
-      alice: 'alice-passphrase-here',
+      alice: { kind: 'passphrase', value: 'alice-passphrase-here' },
     })
   })
 
@@ -181,9 +181,9 @@ describe('#197 — sealedPassphrases (self-target)', () => {
     const result = await readNoydbBundle(bytes)
     expect(result.autoUnlock).toBeDefined()
     expect(result.autoUnlock!.kind).toBe('sealed')
-    // perUser values are base64 sealed bytes — opaque, not the plaintext.
-    expect(result.autoUnlock!.perUser['alice']).not.toBe('a-pass')
-    expect(result.autoUnlock!.perUser['alice'].length).toBeGreaterThan(0)
+    // perUser values are AutoCredential — value is opaque base64 sealed bytes, not the plaintext.
+    expect(result.autoUnlock!.perUser['alice']!.value).not.toBe('a-pass')
+    expect(result.autoUnlock!.perUser['alice']!.value.length).toBeGreaterThan(0)
   })
 
   it('throws BundleSealMismatchError when no provider matches pid (strict)', async () => {

--- a/packages/hub/__tests__/bundle-auto-unlock.test.ts
+++ b/packages/hub/__tests__/bundle-auto-unlock.test.ts
@@ -4,6 +4,9 @@
  *
  * Covers the contract documented in
  * docs/superpowers/specs/2026-05-23-sealed-bundle-delivery.md.
+ *
+ * Extended for #215 — generalized auto-unlock across credential kinds
+ * (password, pin) + sugar/back-compat regression tests.
  */
 import { describe, it, expect } from 'vitest'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
@@ -17,6 +20,13 @@ import {
   BundleSealMismatchError,
   ValidationError,
 } from '../src/index.js'
+import {
+  encodeBundleHeader,
+  decodeBundleHeader,
+  NOYDB_BUNDLE_PREFIX_BYTES,
+  readUint32BE,
+  writeUint32BE,
+} from '../src/bundle/format.js'
 
 function memory(): NoydbStore {
   const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
@@ -321,5 +331,308 @@ describe('#197 — composes with publicEnvelope', () => {
     // publicEnvelope is undefined because the vault has none —
     // that's correct back-compat. The header just carries the new flag.
     expect(header.publicEnvelope).toBeUndefined()
+  })
+})
+
+// ─── #215 — generalized auto-unlock (new credential kinds + sugar/back-compat) ──
+
+describe('#215 — autoCredentials, password kind (unsealed)', () => {
+  it('round-trips password credential as { kind:"password", value }', async () => {
+    const { vault } = await freshVault()
+    const bytes = await writeNoydbBundle(vault, {
+      autoCredentials: {
+        policy: 'public-by-design',
+        perUser: { carol: { kind: 'password', value: 'hunter2' } },
+      },
+    })
+
+    const header = readNoydbBundleHeader(bytes)
+    expect(header.autoUnlock).toBe('unsealed')
+
+    const result = await readNoydbBundle(bytes)
+    expect(result.autoUnlock).toBeDefined()
+    expect(result.autoUnlock!.kind).toBe('unsealed')
+    expect(result.autoUnlock!.perUser['carol']).toEqual({ kind: 'password', value: 'hunter2' })
+  })
+})
+
+describe('#215 — autoCredentials, pin kind (unsealed)', () => {
+  it('round-trips pin credential as { kind:"pin", value }', async () => {
+    const { vault } = await freshVault()
+    const bytes = await writeNoydbBundle(vault, {
+      autoCredentials: {
+        policy: 'public-by-design',
+        perUser: { dave: { kind: 'pin', value: '1234' } },
+      },
+    })
+
+    const result = await readNoydbBundle(bytes)
+    expect(result.autoUnlock).toBeDefined()
+    expect(result.autoUnlock!.kind).toBe('unsealed')
+    expect(result.autoUnlock!.perUser['dave']).toEqual({ kind: 'pin', value: '1234' })
+  })
+})
+
+describe('#215 — autoCredentials, passphrase kind (unsealed)', () => {
+  it('round-trips passphrase credential via autoCredentials same as sugar path', async () => {
+    const { vault } = await freshVault()
+    const bytes = await writeNoydbBundle(vault, {
+      autoCredentials: {
+        policy: 'public-by-design',
+        perUser: { eve: { kind: 'passphrase', value: 'correct-horse' } },
+      },
+    })
+
+    const result = await readNoydbBundle(bytes)
+    expect(result.autoUnlock).toBeDefined()
+    expect(result.autoUnlock!.kind).toBe('unsealed')
+    expect(result.autoUnlock!.perUser['eve']).toEqual({ kind: 'passphrase', value: 'correct-horse' })
+  })
+})
+
+describe('#215 — sealedCredentials, password kind (sealed)', () => {
+  it('seals password credential and unseals to { kind:"password", value } when provider matches', async () => {
+    const { vault } = await freshVault()
+    const pid = 'macos-keychain:com.acme/carol'
+    const senderProvider = new MemorySealingKeyProvider({ id: pid })
+
+    const bytes = await writeNoydbBundle(vault, {
+      sealedCredentials: {
+        mode: 'self-target',
+        provider: senderProvider,
+        perUser: { carol: { kind: 'password', value: 'hunter2' } },
+      },
+    })
+
+    const header = readNoydbBundleHeader(bytes)
+    expect(header.autoUnlock).toBe('sealed')
+
+    // WITH matching provider — should unseal to { kind:'password', value }
+    const recipientProvider = new MemorySealingKeyProvider({ id: pid })
+    const result = await readNoydbBundle(bytes, { sealingProviders: [recipientProvider] })
+
+    expect(result.autoUnlock).toBeDefined()
+    expect(result.autoUnlock!.kind).toBe('sealed')
+    expect(result.autoUnlock!.perUser['carol']).toEqual({ kind: 'password', value: 'hunter2' })
+  })
+
+  it('passes through sealed entry with kind preserved when no sealingProviders supplied', async () => {
+    const { vault } = await freshVault()
+    const senderProvider = new MemorySealingKeyProvider({ id: 'test-sealed-password-pid' })
+
+    const bytes = await writeNoydbBundle(vault, {
+      sealedCredentials: {
+        mode: 'self-target',
+        provider: senderProvider,
+        perUser: { carol: { kind: 'password', value: 'hunter2' } },
+      },
+    })
+
+    // WITHOUT provider — kind is preserved in passthrough, value is the opaque sealed bytes
+    const result = await readNoydbBundle(bytes)
+    expect(result.autoUnlock).toBeDefined()
+    expect(result.autoUnlock!.kind).toBe('sealed')
+    const entry = result.autoUnlock!.perUser['carol']!
+    expect(entry.kind).toBe('password')
+    // value is the opaque base64 sealed blob, NOT the plaintext
+    expect(entry.value).not.toBe('hunter2')
+    expect(entry.value.length).toBeGreaterThan(0)
+  })
+})
+
+describe('#215 — sugar back-compat', () => {
+  it('autoPassphrases sugar round-trips as { kind:"passphrase", value }', async () => {
+    const { vault } = await freshVault()
+    const bytes = await writeNoydbBundle(vault, {
+      autoPassphrases: {
+        policy: 'public-by-design',
+        perUser: { 'legacy-user': 'legacy-pass' },
+      },
+    })
+
+    const result = await readNoydbBundle(bytes)
+    expect(result.autoUnlock).toBeDefined()
+    expect(result.autoUnlock!.kind).toBe('unsealed')
+    expect(result.autoUnlock!.perUser['legacy-user']).toEqual({
+      kind: 'passphrase',
+      value: 'legacy-pass',
+    })
+  })
+
+  it('sealedPassphrases sugar unseals as { kind:"passphrase", value }', async () => {
+    const { vault } = await freshVault()
+    const pid = 'macos-keychain:com.acme/legacy'
+    const senderProvider = new MemorySealingKeyProvider({ id: pid })
+
+    const bytes = await writeNoydbBundle(vault, {
+      sealedPassphrases: {
+        mode: 'self-target',
+        provider: senderProvider,
+        perUser: { 'legacy-user': 'legacy-pass' },
+      },
+    })
+
+    const recipientProvider = new MemorySealingKeyProvider({ id: pid })
+    const result = await readNoydbBundle(bytes, { sealingProviders: [recipientProvider] })
+
+    expect(result.autoUnlock).toBeDefined()
+    expect(result.autoUnlock!.kind).toBe('sealed')
+    expect(result.autoUnlock!.perUser['legacy-user']).toEqual({
+      kind: 'passphrase',
+      value: 'legacy-pass',
+    })
+  })
+
+  /**
+   * Pre-0.2 bundles stored bare strings in the unsealed `perUser` map.
+   * We verify the `coerceUnsealed` path by injecting a crafted bundle body
+   * (written with compression:'none' so the body is accessible without
+   * decompression, then surgically patching the perUser entry to a bare
+   * string and recomputing the header hash).
+   */
+  it('pre-0.2 bare-string entry in unsealed body coerces to { kind:"passphrase", value }', async () => {
+    const { vault } = await freshVault()
+
+    // Write an uncompressed unsealed bundle so the body bytes are raw UTF-8 JSON.
+    const originalBytes = await writeNoydbBundle(vault, {
+      compression: 'none',
+      autoCredentials: {
+        policy: 'public-by-design',
+        perUser: { bob: { kind: 'passphrase', value: 'old-secret' } },
+      },
+    })
+
+    // ── Parse the prefix to locate header + body ──────────────────────────
+    const headerLen = readUint32BE(originalBytes, 6)
+    const bodyOffset = NOYDB_BUNDLE_PREFIX_BYTES + headerLen
+    const headerBytes = originalBytes.slice(NOYDB_BUNDLE_PREFIX_BYTES, bodyOffset)
+    const header = decodeBundleHeader(headerBytes)
+    const bodyBytes = originalBytes.slice(bodyOffset)
+
+    // ── Patch: replace the AutoCredential object with a bare string ───────
+    const bodyStr = new TextDecoder().decode(bodyBytes)
+    const bodyObj = JSON.parse(bodyStr) as {
+      _noydb_bundle_body: 1
+      dump: string
+      _autoUnlock: { kind: 'unsealed'; perUser: Record<string, unknown> }
+    }
+    // Simulate a pre-0.2 bundle: store a bare string instead of { kind, value }
+    bodyObj._autoUnlock.perUser['bob'] = 'old-secret'
+    const patchedBodyBytes = new TextEncoder().encode(JSON.stringify(bodyObj))
+
+    // ── Recompute body SHA-256 for the patched body ───────────────────────
+    const copy = new Uint8Array(patchedBodyBytes.length)
+    copy.set(patchedBodyBytes)
+    const digestBuf = await crypto.subtle.digest('SHA-256', copy)
+    const digestView = new Uint8Array(digestBuf)
+    let newSha = ''
+    for (let i = 0; i < digestView.length; i++) newSha += digestView[i]!.toString(16).padStart(2, '0')
+
+    // ── Rebuild header with updated bodyBytes + bodySha256 ────────────────
+    const patchedHeader = {
+      ...header,
+      bodyBytes: patchedBodyBytes.length,
+      bodySha256: newSha,
+    }
+    const patchedHeaderBytes = encodeBundleHeader(patchedHeader)
+
+    // ── Reassemble: prefix (first 6 bytes keep flags/algo) + new headerLen + new header + body ──
+    const patchedPrefix = new Uint8Array(NOYDB_BUNDLE_PREFIX_BYTES)
+    // Copy magic + flags + algo bytes unchanged
+    patchedPrefix.set(originalBytes.slice(0, 6))
+    writeUint32BE(patchedPrefix, 6, patchedHeaderBytes.length)
+
+    const patchedBundle = new Uint8Array(
+      patchedPrefix.length + patchedHeaderBytes.length + patchedBodyBytes.length,
+    )
+    let off = 0
+    patchedBundle.set(patchedPrefix, off); off += patchedPrefix.length
+    patchedBundle.set(patchedHeaderBytes, off); off += patchedHeaderBytes.length
+    patchedBundle.set(patchedBodyBytes, off)
+
+    // ── Read back — coerceUnsealed should promote the bare string ─────────
+    const result = await readNoydbBundle(patchedBundle)
+    expect(result.autoUnlock).toBeDefined()
+    expect(result.autoUnlock!.kind).toBe('unsealed')
+    expect(result.autoUnlock!.perUser['bob']).toEqual({ kind: 'passphrase', value: 'old-secret' })
+  })
+})
+
+describe('#215 — mutual exclusion (mixing rejected)', () => {
+  it('autoCredentials + autoPassphrases together throw ValidationError matching /only one of/', async () => {
+    const { vault } = await freshVault()
+    await expect(
+      writeNoydbBundle(vault, {
+        autoCredentials: {
+          policy: 'public-by-design',
+          perUser: { alice: { kind: 'passphrase', value: 'a' } },
+        },
+        autoPassphrases: {
+          policy: 'public-by-design',
+          perUser: { bob: 'b' },
+        },
+      }),
+    ).rejects.toSatisfy(
+      (err: unknown) => err instanceof ValidationError && /only one of/i.test((err as Error).message),
+    )
+  })
+
+  it('autoCredentials + sealedCredentials together throw ValidationError matching /only one of/', async () => {
+    const { vault } = await freshVault()
+    const provider = new MemorySealingKeyProvider({ id: 'test-mix' })
+    await expect(
+      writeNoydbBundle(vault, {
+        autoCredentials: {
+          policy: 'public-by-design',
+          perUser: { alice: { kind: 'passphrase', value: 'a' } },
+        },
+        sealedCredentials: {
+          mode: 'self-target',
+          provider,
+          perUser: { bob: { kind: 'password', value: 'b' } },
+        },
+      }),
+    ).rejects.toSatisfy(
+      (err: unknown) => err instanceof ValidationError && /only one of/i.test((err as Error).message),
+    )
+  })
+})
+
+describe('#215 — unsupported credential kind rejected', () => {
+  it('autoCredentials with kind:"webauthn" rejects with ValidationError naming the kind and valid kinds', async () => {
+    const { vault } = await freshVault()
+    await expect(
+      writeNoydbBundle(vault, {
+        autoCredentials: {
+          policy: 'public-by-design',
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          perUser: { alice: { kind: 'webauthn' as any, value: 'x' } },
+        },
+      }),
+    ).rejects.toSatisfy((err: unknown) => {
+      if (!(err instanceof ValidationError)) return false
+      const msg = (err as Error).message
+      // Error must name the bad kind and at minimum mention passphrase/password/pin
+      return /webauthn/i.test(msg) && /passphrase/i.test(msg)
+    })
+  })
+
+  it('sealedCredentials with kind:"webauthn" rejects with ValidationError', async () => {
+    const { vault } = await freshVault()
+    const provider = new MemorySealingKeyProvider({ id: 'test-bad-kind' })
+    await expect(
+      writeNoydbBundle(vault, {
+        sealedCredentials: {
+          mode: 'self-target',
+          provider,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          perUser: { alice: { kind: 'webauthn' as any, value: 'x' } },
+        },
+      }),
+    ).rejects.toSatisfy((err: unknown) => {
+      if (!(err instanceof ValidationError)) return false
+      const msg = (err as Error).message
+      return /webauthn/i.test(msg)
+    })
   })
 })

--- a/packages/hub/src/bundle/bundle.ts
+++ b/packages/hub/src/bundle/bundle.ts
@@ -253,30 +253,44 @@ export interface NoydbBundleReadResult {
   readonly header: NoydbBundleHeader
   readonly dumpJson: string
   /**
-   * Auto-unlock material (#197). Present only when the header's
-   * `autoUnlock` flag is set AND the body's wrapped structure
-   * survived parsing. Values are **plaintext** passphrases ready to
-   * pass to `createNoydb({ secret })` — either delivered plain
-   * (`kind: 'unsealed'`) or unsealed at read time using one of the
-   * supplied `sealingProviders` (`kind: 'sealed'`).
+   * Auto-unlock material (#197, widened in #215). Present only when
+   * the header's `autoUnlock` flag is set AND the body's wrapped
+   * structure survived parsing. Values are typed credentials — either
+   * delivered plain (`kind: 'unsealed'`) or unsealed at read time
+   * using one of the supplied `sealingProviders` (`kind: 'sealed'`).
+   *
+   * Consumers dispatch on `cred.kind` to choose the correct login /
+   * prefill path. Pre-0.2 bundles (bare string entries) are coerced
+   * to `{ kind: 'passphrase', value }` on read for back-compat.
+   *
+   * For `kind: 'sealed'` bundles read without `sealingProviders`, the
+   * `value` field is the raw base64 sealed bytes — opaque to the
+   * consumer until unsealed elsewhere.
    */
   readonly autoUnlock?: {
     readonly kind: 'unsealed' | 'sealed'
-    readonly perUser: Record<string, string>
+    readonly perUser: Record<string, AutoCredential>
   }
 }
 
 /**
- * Sealed-passphrase entry as it appears in the bundle body's
+ * Sealed credential entry as it appears in the bundle body's
  * `_autoUnlock.perUser` map when the bundle was written with
- * `sealedPassphrases`. Provider's sealed output is base64-encoded;
- * the `pid` is the dispatch key matched against
- * recipient-supplied `SealingKeyProvider.id`.
+ * `sealedCredentials` (or the deprecated `sealedPassphrases`).
+ * Provider's sealed output is base64-encoded; the `pid` is the
+ * dispatch key matched against recipient-supplied
+ * `SealingKeyProvider.id`. The `kind` carries the plaintext-tier
+ * metadata so the consumer can dispatch on credential type without
+ * unsealing first.
+ *
+ * Back-compat: `kind` is absent in pre-0.2 bundles — readers must
+ * default to `'passphrase'` when not present.
  */
 interface SealedAutoUnlockEntry {
   readonly pid: string
   readonly sealed: string
   readonly alg: 'aes-256-gcm'
+  readonly kind?: AutoCredentialKind
   readonly hint?: Record<string, unknown>
 }
 
@@ -284,12 +298,16 @@ interface SealedAutoUnlockEntry {
  * Discriminated wrapper carried in the bundle body when the header's
  * `autoUnlock` flag is set. Without the flag, the body is the raw
  * `vault.dump()` JSON string (the pre-#197 shape).
+ *
+ * Back-compat: pre-0.2 bundles carry bare `string` values in the
+ * unsealed `perUser` map. Readers must coerce those to
+ * `{ kind: 'passphrase', value }`.
  */
 interface AutoUnlockBody {
   readonly _noydb_bundle_body: 1
   readonly dump: string
   readonly _autoUnlock:
-    | { readonly kind: 'unsealed'; readonly perUser: Record<string, string> }
+    | { readonly kind: 'unsealed'; readonly perUser: Record<string, AutoCredential | string> }
     | { readonly kind: 'sealed'; readonly perUser: Record<string, SealedAutoUnlockEntry> }
 }
 
@@ -468,35 +486,37 @@ function validateAutoUnlockOptions(opts: WriteNoydbBundleOptions): 'unsealed' | 
 
 /**
  * Build the body wrapper carrying the dump + `_autoUnlock` blob.
- * The `autoUnlockMode` was already validated by the time we get here.
+ * Takes the pre-computed `NormalizedAutoUnlock` so both validate and
+ * build work off the same normalized form (no double-normalize).
  */
 async function buildAutoUnlockWrapper(
   dumpJson: string,
-  opts: WriteNoydbBundleOptions,
+  normalized: NormalizedAutoUnlock,
 ): Promise<AutoUnlockBody> {
-  if (opts.autoPassphrases !== undefined) {
+  if (normalized.mode === 'unsealed') {
     return {
       _noydb_bundle_body: 1,
       dump: dumpJson,
       _autoUnlock: {
         kind: 'unsealed',
-        perUser: { ...opts.autoPassphrases.perUser },
+        perUser: { ...normalized.perUser },
       },
     }
   }
-  // sealedPassphrases path — seal each user's passphrase under the provider.
-  if (opts.sealedPassphrases === undefined) {
+  // Sealed path — seal each user's credential value under the provider.
+  const provider = normalized.provider
+  if (provider === undefined) {
     throw new Error('unreachable — validation should have caught this')
   }
-  const { provider, perUser } = opts.sealedPassphrases
   const sealedPerUser: Record<string, SealedAutoUnlockEntry> = {}
   const encoder = new TextEncoder()
-  for (const [userId, passphrase] of Object.entries(perUser)) {
-    const sealed = await provider.seal(encoder.encode(passphrase))
+  for (const [userId, cred] of Object.entries(normalized.perUser)) {
+    const sealed = await provider.seal(encoder.encode(cred.value))
     sealedPerUser[userId] = {
       pid: provider.id,
       sealed: bytesToBase64(sealed),
       alg: 'aes-256-gcm',
+      kind: cred.kind,
     }
   }
   return {
@@ -551,32 +571,50 @@ function parseAutoUnlockBody(bodyString: string): { dump: string; blob: AutoUnlo
 }
 
 /**
- * Resolve the `_autoUnlock` blob into a plaintext per-user map.
+ * Coerce an unsealed perUser entry to `AutoCredential`. Pre-0.2 bundles
+ * store bare strings; 0.2+ bundles store `{ kind, value }` objects.
+ */
+function coerceUnsealed(entry: AutoCredential | string): AutoCredential {
+  if (typeof entry === 'string') return { kind: 'passphrase', value: entry }
+  return entry
+}
+
+/**
+ * Resolve the `_autoUnlock` blob into a typed per-user credential map.
  *
- * - For `kind: 'unsealed'`: pass through unchanged.
+ * - For `kind: 'unsealed'`: pass through, coercing pre-0.2 bare strings
+ *   to `{ kind: 'passphrase', value }`.
  * - For `kind: 'sealed'`: pick a `SealingKeyProvider` from
  *   `opts.sealingProviders` whose `.id` matches each entry's `pid`;
- *   unseal to plaintext. When no provider matches AND strict mode
+ *   unseal to `AutoCredential`. When no provider matches AND strict mode
  *   (default), throw `BundleSealMismatchError`. With
  *   `attemptUnsealAcrossProviders: true`, try each provider whose
  *   `alg` matches the envelope.
  * - When `sealingProviders` is unset entirely on a `'sealed'` bundle,
- *   pass through SEALED entries unchanged (caller can inspect).
+ *   pass through the SEALED entries as `{ kind, value: base64sealed }` —
+ *   the caller can inspect or unseal elsewhere.
+ *
+ * Pre-0.2 sealed entries missing `kind` default to `'passphrase'`.
  */
 async function resolveAutoUnlock(
   blob: AutoUnlockBody['_autoUnlock'],
   opts: ReadNoydbBundleOptions,
-): Promise<{ kind: 'unsealed' | 'sealed'; perUser: Record<string, string> }> {
+): Promise<{ kind: 'unsealed' | 'sealed'; perUser: Record<string, AutoCredential> }> {
   if (blob.kind === 'unsealed') {
-    return { kind: 'unsealed', perUser: { ...blob.perUser } }
+    const resolved: Record<string, AutoCredential> = {}
+    for (const [userId, entry] of Object.entries(blob.perUser)) {
+      resolved[userId] = coerceUnsealed(entry)
+    }
+    return { kind: 'unsealed', perUser: resolved }
   }
   // Sealed path.
   if (opts.sealingProviders === undefined || opts.sealingProviders.length === 0) {
-    // Inspection mode — pass the sealed payload through unchanged as
-    // an opaque base64 string. The caller is signalled by `kind: 'sealed'`.
-    const passthrough: Record<string, string> = {}
+    // Inspection mode — pass the sealed payload through as a typed
+    // credential whose `value` is the opaque base64 sealed bytes.
+    // The caller is signalled by `kind: 'sealed'` on the outer result.
+    const passthrough: Record<string, AutoCredential> = {}
     for (const [userId, entry] of Object.entries(blob.perUser)) {
-      passthrough[userId] = entry.sealed
+      passthrough[userId] = { kind: entry.kind ?? 'passphrase', value: entry.sealed }
     }
     return { kind: 'sealed', perUser: passthrough }
   }
@@ -584,9 +622,10 @@ async function resolveAutoUnlock(
   for (const p of opts.sealingProviders) providersByPid.set(p.id, p)
 
   const decoder = new TextDecoder()
-  const unsealedMap: Record<string, string> = {}
+  const unsealedMap: Record<string, AutoCredential> = {}
 
   for (const [userId, entry] of Object.entries(blob.perUser)) {
+    const credKind: AutoCredentialKind = entry.kind ?? 'passphrase'
     const provider = providersByPid.get(entry.pid)
     if (provider === undefined) {
       if (opts.attemptUnsealAcrossProviders === true) {
@@ -604,13 +643,13 @@ async function resolveAutoUnlock(
         if (opened === null) {
           throw new BundleSealMismatchError(userId, entry.pid)
         }
-        unsealedMap[userId] = opened
+        unsealedMap[userId] = { kind: credKind, value: opened }
         continue
       }
       throw new BundleSealMismatchError(userId, entry.pid)
     }
     const plaintextBytes = await provider.unseal(base64ToBytes(entry.sealed))
-    unsealedMap[userId] = decoder.decode(plaintextBytes)
+    unsealedMap[userId] = { kind: credKind, value: decoder.decode(plaintextBytes) }
   }
   return { kind: 'sealed', perUser: unsealedMap }
 }
@@ -962,9 +1001,11 @@ export async function writeNoydbBundle(
     )
   }
 
-  // #197 — auto-unlock validation. Mutual exclusion + opt-in marker
-  // for autoPassphrases. Reject empty perUser maps. Slice 1 supports
-  // only mode: 'self-target' for sealedPassphrases.
+  // #197/#215 — auto-unlock validation. Normalizes the four option
+  // fields, enforces mutual exclusion, validates the policy marker,
+  // perUser size, mode, provider, and credential kind allowlist.
+  // Compute normalized once so validate + build share the same object.
+  const normalizedAutoUnlock = normalizeAutoUnlock(opts)
   const autoUnlockMode = validateAutoUnlockOptions(opts)
 
   const handle = await vault.getBundleHandle()
@@ -984,9 +1025,9 @@ export async function writeNoydbBundle(
   // If no auto-unlock requested, body remains the raw dump JSON
   // (pre-#197 shape). Otherwise build the wrapped body containing the
   // dump + `_autoUnlock` blob and serialize.
-  const bodyJsonStr = autoUnlockMode === null
+  const bodyJsonStr = normalizedAutoUnlock === null
     ? filtered
-    : JSON.stringify(await buildAutoUnlockWrapper(filtered, opts))
+    : JSON.stringify(await buildAutoUnlockWrapper(filtered, normalizedAutoUnlock))
   const dumpBytes = new TextEncoder().encode(bodyJsonStr)
 
   const { format, streamFormat } = selectCompression(opts.compression)

--- a/packages/hub/src/bundle/bundle.ts
+++ b/packages/hub/src/bundle/bundle.ts
@@ -408,9 +408,12 @@ function normalizeAutoUnlock(opts: WriteNoydbBundleOptions): NormalizedAutoUnloc
  * Validate the auto-unlock options and return the resulting header
  * `autoUnlock` value (or null when no auto-unlock requested).
  *
+ * Takes the pre-computed `NormalizedAutoUnlock` so the caller (i.e.
+ * `writeNoydbBundle`) can pass the same object to `buildAutoUnlockWrapper`
+ * without a second `normalizeAutoUnlock` call.
+ *
  * Validation per spec (#197 + #215 §3):
- *   - exactly one of autoCredentials / sealedCredentials /
- *     autoPassphrases / sealedPassphrases may be set
+ *   - (mutual exclusion already enforced by normalizeAutoUnlock)
  *   - unsealed path: `policy: 'public-by-design'` marker required
  *   - non-empty `perUser` maps
  *   - sealed path: `mode: 'self-target'` + provider present
@@ -419,9 +422,10 @@ function normalizeAutoUnlock(opts: WriteNoydbBundleOptions): NormalizedAutoUnloc
  *
  * Throws {@link ValidationError} on any violation.
  */
-function validateAutoUnlockOptions(opts: WriteNoydbBundleOptions): 'unsealed' | 'sealed' | null {
-  // normalizeAutoUnlock enforces mutual exclusion and promotes sugar.
-  const normalized = normalizeAutoUnlock(opts)
+function validateAutoUnlockOptions(
+  opts: WriteNoydbBundleOptions,
+  normalized: NormalizedAutoUnlock | null,
+): 'unsealed' | 'sealed' | null {
   if (normalized === null) return null
 
   const VALID_KINDS: ReadonlySet<string> = new Set(['passphrase', 'password', 'pin'])
@@ -1001,12 +1005,10 @@ export async function writeNoydbBundle(
     )
   }
 
-  // #197/#215 — auto-unlock validation. Normalizes the four option
-  // fields, enforces mutual exclusion, validates the policy marker,
-  // perUser size, mode, provider, and credential kind allowlist.
-  // Compute normalized once so validate + build share the same object.
+  // #197/#215 — auto-unlock: normalize once, validate + build from the
+  // same NormalizedAutoUnlock object so there's no double-normalize call.
   const normalizedAutoUnlock = normalizeAutoUnlock(opts)
-  const autoUnlockMode = validateAutoUnlockOptions(opts)
+  const autoUnlockMode = validateAutoUnlockOptions(opts, normalizedAutoUnlock)
 
   const handle = await vault.getBundleHandle()
   const dumpJson = await vault.dump()

--- a/packages/hub/src/bundle/bundle.ts
+++ b/packages/hub/src/bundle/bundle.ts
@@ -319,67 +319,151 @@ export interface ReadNoydbBundleOptions {
   readonly attemptUnsealAcrossProviders?: boolean
 }
 
-// ─── #197 auto-unlock helpers ──────────────────────────────────────
+// ─── #197/#215 auto-unlock helpers ────────────────────────────────────────────
 
 /**
- * Validate the #197 auto-unlock options and return the resulting
- * header `autoUnlock` value (or null when no auto-unlock requested).
+ * Internal normalized form of the auto-unlock options, computed once
+ * from the four public-facing fields (autoCredentials, sealedCredentials,
+ * autoPassphrases, sealedPassphrases). Callers work against this shape
+ * so the build + validate paths share a single normalizer.
+ */
+interface NormalizedAutoUnlock {
+  readonly mode: 'unsealed' | 'sealed'
+  readonly provider?: SealingKeyProvider
+  readonly perUser: Record<string, AutoCredential>
+}
+
+/**
+ * Coerce a `Record<string, string>` (legacy passphrase-only map) into
+ * a `Record<string, AutoCredential>` by tagging each entry as
+ * `kind: 'passphrase'`. Used by the normalizer to promote the deprecated
+ * `autoPassphrases`/`sealedPassphrases` sugar.
+ */
+function toAutoCredentials(m: Record<string, string>): Record<string, AutoCredential> {
+  return Object.fromEntries(
+    Object.entries(m).map(([u, value]) => [u, { kind: 'passphrase' as const, value }]),
+  )
+}
+
+/**
+ * Normalize the four auto-unlock option fields into a single
+ * `NormalizedAutoUnlock` (or `null` when none is set). Enforces mutual
+ * exclusion — exactly one of the four may be present. Promotes the
+ * deprecated sugar fields to `AutoCredential` shape.
  *
- * Validation per spec §3:
- *   - autoPassphrases + sealedPassphrases mutually exclusive
- *   - autoPassphrases requires `policy: 'public-by-design'`
- *   - non-empty perUser maps
- *   - sealedPassphrases.mode = 'self-target' (slice 1 only)
- *   - sealedPassphrases.provider must be supplied
+ * Does NOT validate field-level constraints (policy marker, perUser
+ * length, mode, provider presence, kind allowlist) — those are checked
+ * in `validateAutoUnlockOptions` after normalization.
+ */
+function normalizeAutoUnlock(opts: WriteNoydbBundleOptions): NormalizedAutoUnlock | null {
+  const set = [
+    opts.autoCredentials,
+    opts.sealedCredentials,
+    opts.autoPassphrases,
+    opts.sealedPassphrases,
+  ].filter(v => v !== undefined).length
+  if (set === 0) return null
+  if (set > 1) {
+    throw new ValidationError(
+      'writeNoydbBundle: only one of autoCredentials / sealedCredentials / '
+      + 'autoPassphrases / sealedPassphrases may be set.',
+    )
+  }
+  if (opts.autoCredentials !== undefined) {
+    return { mode: 'unsealed', perUser: opts.autoCredentials.perUser }
+  }
+  if (opts.autoPassphrases !== undefined) {
+    return { mode: 'unsealed', perUser: toAutoCredentials(opts.autoPassphrases.perUser) }
+  }
+  if (opts.sealedCredentials !== undefined) {
+    return { mode: 'sealed', provider: opts.sealedCredentials.provider, perUser: opts.sealedCredentials.perUser }
+  }
+  // sealedPassphrases — only remaining option
+  return {
+    mode: 'sealed',
+    provider: opts.sealedPassphrases!.provider,
+    perUser: toAutoCredentials(opts.sealedPassphrases!.perUser),
+  }
+}
+
+/**
+ * Validate the auto-unlock options and return the resulting header
+ * `autoUnlock` value (or null when no auto-unlock requested).
+ *
+ * Validation per spec (#197 + #215 §3):
+ *   - exactly one of autoCredentials / sealedCredentials /
+ *     autoPassphrases / sealedPassphrases may be set
+ *   - unsealed path: `policy: 'public-by-design'` marker required
+ *   - non-empty `perUser` maps
+ *   - sealed path: `mode: 'self-target'` + provider present
+ *   - every AutoCredential.kind ∈ {passphrase, password, pin}
+ *     (WebAuthn is hardware-bound and cannot be bundled)
  *
  * Throws {@link ValidationError} on any violation.
  */
 function validateAutoUnlockOptions(opts: WriteNoydbBundleOptions): 'unsealed' | 'sealed' | null {
-  if (opts.autoPassphrases !== undefined && opts.sealedPassphrases !== undefined) {
-    throw new ValidationError(
-      'writeNoydbBundle: `autoPassphrases` and `sealedPassphrases` are mutually exclusive. '
-      + 'Choose one or the other.',
-    )
-  }
-  if (opts.autoPassphrases !== undefined) {
-    if (opts.autoPassphrases.policy !== 'public-by-design') {
+  // normalizeAutoUnlock enforces mutual exclusion and promotes sugar.
+  const normalized = normalizeAutoUnlock(opts)
+  if (normalized === null) return null
+
+  const VALID_KINDS: ReadonlySet<string> = new Set(['passphrase', 'password', 'pin'])
+
+  // Validate every credential kind before any further checks.
+  for (const [userId, cred] of Object.entries(normalized.perUser)) {
+    if (!VALID_KINDS.has(cred.kind)) {
       throw new ValidationError(
-        'writeNoydbBundle: `autoPassphrases` requires `policy: "public-by-design"`. '
-        + 'This is an explicit opt-in marker — bundling plaintext credentials is '
-        + 'safe only when those credentials are intended to be public (demo data, '
-        + 'sample vaults). For production credentials, use `sealedPassphrases` instead.',
+        `writeNoydbBundle: credential for user '${userId}' has unsupported kind '${cred.kind}'. `
+        + 'auto-unlock supports passphrase/password/pin only; WebAuthn is hardware-bound '
+        + 'and cannot be bundled.',
       )
     }
-    const userCount = Object.keys(opts.autoPassphrases.perUser).length
+  }
+
+  if (normalized.mode === 'unsealed') {
+    // Read the policy marker from whichever active option carries it.
+    const policy = opts.autoCredentials?.policy ?? opts.autoPassphrases?.policy
+    if (policy !== 'public-by-design') {
+      throw new ValidationError(
+        'writeNoydbBundle: `autoCredentials` (or `autoPassphrases`) requires '
+        + '`policy: "public-by-design"`. '
+        + 'This is an explicit opt-in marker — bundling plaintext credentials is '
+        + 'safe only when those credentials are intended to be public (demo data, '
+        + 'sample vaults). For production credentials, use `sealedCredentials` instead.',
+      )
+    }
+    const userCount = Object.keys(normalized.perUser).length
     if (userCount === 0) {
       throw new ValidationError(
-        'writeNoydbBundle: `autoPassphrases.perUser` must have at least one entry.',
+        'writeNoydbBundle: `autoCredentials.perUser` (or `autoPassphrases.perUser`) '
+        + 'must have at least one entry.',
       )
     }
     return 'unsealed'
   }
-  if (opts.sealedPassphrases !== undefined) {
-    if (opts.sealedPassphrases.mode !== 'self-target') {
-      throw new ValidationError(
-        `writeNoydbBundle: \`sealedPassphrases.mode\` must be 'self-target' in slice 1 `
-        + `(got '${opts.sealedPassphrases.mode as string}'). Recipient-target sealing via the `
-        + 'RecipientSealer interface is deferred per foundation §11.4.',
-      )
-    }
-    if (opts.sealedPassphrases.provider === undefined) {
-      throw new ValidationError(
-        'writeNoydbBundle: `sealedPassphrases.provider` is required (a `SealingKeyProvider`).',
-      )
-    }
-    const userCount = Object.keys(opts.sealedPassphrases.perUser).length
-    if (userCount === 0) {
-      throw new ValidationError(
-        'writeNoydbBundle: `sealedPassphrases.perUser` must have at least one entry.',
-      )
-    }
-    return 'sealed'
+
+  // Sealed path.
+  const mode = opts.sealedCredentials?.mode ?? opts.sealedPassphrases?.mode
+  if (mode !== 'self-target') {
+    throw new ValidationError(
+      `writeNoydbBundle: \`sealedCredentials.mode\` (or \`sealedPassphrases.mode\`) must be `
+      + `'self-target' in slice 1 (got '${String(mode)}'). Recipient-target sealing via the `
+      + 'RecipientSealer interface is deferred per foundation §11.4.',
+    )
   }
-  return null
+  if (normalized.provider === undefined) {
+    throw new ValidationError(
+      'writeNoydbBundle: `sealedCredentials.provider` (or `sealedPassphrases.provider`) '
+      + 'is required (a `SealingKeyProvider`).',
+    )
+  }
+  const userCount = Object.keys(normalized.perUser).length
+  if (userCount === 0) {
+    throw new ValidationError(
+      'writeNoydbBundle: `sealedCredentials.perUser` (or `sealedPassphrases.perUser`) '
+      + 'must have at least one entry.',
+    )
+  }
+  return 'sealed'
 }
 
 /**

--- a/packages/hub/src/bundle/bundle.ts
+++ b/packages/hub/src/bundle/bundle.ts
@@ -57,6 +57,30 @@ import { pickLocale } from '../meta/public-envelope/storage.js'
 import type { PublicEnvelope } from '../meta/public-envelope/types.js'
 import type { SealingKeyProvider } from '../team/managed-passphrase.js'
 
+// ─── #215 auto-credential types ───────────────────────────────────────────────
+
+/**
+ * The credential kinds that can be bundled for auto-unlock.
+ * WebAuthn is intentionally excluded — it is hardware-bound and
+ * cannot be embedded as a portable credential.
+ */
+export type AutoCredentialKind = 'passphrase' | 'password' | 'pin'
+
+/**
+ * A typed credential for auto-unlock. Carries the credential `kind`
+ * alongside the plaintext `value`, so consumers can dispatch the
+ * correct login/prefill path rather than treating all credentials
+ * as passphrases.
+ *
+ * `bundle.ts` is a pure format layer — it carries the credential
+ * without interpreting it. The consumer is responsible for
+ * dispatching on `kind`.
+ */
+export interface AutoCredential {
+  readonly kind: AutoCredentialKind
+  readonly value: string
+}
+
 /**
  * Options accepted by `writeNoydbBundle`.
  *
@@ -128,6 +152,53 @@ export interface WriteNoydbBundleOptions {
    */
   readonly recipients?: readonly BundleRecipient[]
   /**
+   * Auto-unlock — unsealed per-user credentials (#215).
+   *
+   * Generalises `autoPassphrases` to support any bundleable credential
+   * kind (`passphrase` | `password` | `pin`).
+   *
+   * Public-by-design: anyone holding the bundle bytes can read these
+   * plaintext credentials. Use for demo data, sample vaults,
+   * prospect onboarding.
+   *
+   * The `policy: 'public-by-design'` discriminant is mandatory. A
+   * bare `{ perUser }` without it is rejected at write time — the
+   * safety net against a careless call against a production vault.
+   *
+   * Mutually exclusive with `sealedCredentials`, `autoPassphrases`,
+   * and `sealedPassphrases`.
+   */
+  readonly autoCredentials?: {
+    readonly policy: 'public-by-design'
+    readonly perUser: Record<string, AutoCredential>
+  }
+  /**
+   * Auto-unlock — per-user credentials sealed under a
+   * {@link SealingKeyProvider} (#215).
+   *
+   * Generalises `sealedPassphrases` to support any bundleable
+   * credential kind (`passphrase` | `password` | `pin`).
+   *
+   * The hub seals each user's plaintext credential under `provider`
+   * and embeds the resulting sealed envelopes in the bundle. The
+   * recipient must hold a provider with a matching `pid` (i.e.,
+   * `provider.id`) to auto-unseal on import.
+   *
+   * `mode: 'self-target'` is the only supported mode — sender and
+   * recipient share the same provider identity (same iCloud Keychain
+   * entry, same MDM-provisioned bundle id, same KMS account, etc.).
+   *
+   * Mutually exclusive with `autoCredentials`, `autoPassphrases`,
+   * and `sealedPassphrases`.
+   */
+  readonly sealedCredentials?: {
+    readonly mode: 'self-target'
+    readonly provider: SealingKeyProvider
+    readonly perUser: Record<string, AutoCredential>
+  }
+  /**
+   * @deprecated Use `autoCredentials` instead (#215).
+   *
    * Auto-unlock — unsealed per-user passphrases (#197 slice 1).
    *
    * Public-by-design: anyone holding the bundle bytes can read these
@@ -138,13 +209,16 @@ export interface WriteNoydbBundleOptions {
    * bare `{ perUser }` without it is rejected at write time — the
    * safety net against a careless call against a production vault.
    *
-   * Mutually exclusive with `sealedPassphrases`.
+   * Mutually exclusive with `autoCredentials`, `sealedCredentials`,
+   * and `sealedPassphrases`.
    */
   readonly autoPassphrases?: {
     readonly policy: 'public-by-design'
     readonly perUser: Record<string, string>
   }
   /**
+   * @deprecated Use `sealedCredentials` instead (#215).
+   *
    * Auto-unlock — per-user passphrases sealed under a
    * {@link SealingKeyProvider} (#197 slice 1, self-target only).
    *
@@ -159,7 +233,8 @@ export interface WriteNoydbBundleOptions {
    * Recipient-target sealing via the `RecipientSealer` interface
    * (foundation §11.4) is deferred to a follow-up slice.
    *
-   * Mutually exclusive with `autoPassphrases`.
+   * Mutually exclusive with `autoCredentials`, `sealedCredentials`,
+   * and `autoPassphrases`.
    */
   readonly sealedPassphrases?: {
     readonly mode: 'self-target'

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -249,6 +249,8 @@ export type {
   WriteNoydbBundleOptions,
   ReadNoydbBundleOptions,
   NoydbBundleReadResult,
+  AutoCredentialKind,
+  AutoCredential,
 } from './bundle/bundle.js'
 export {
   NOYDB_BUNDLE_MAGIC,


### PR DESCRIPTION
Third PR of the 0.2 epic. Generalizes bundle auto-unlock from passphrase-only to any non-hardware credential, so a delivered bundle one-click-unlocks whatever tier the user enrolled — the live niwat request (niwat#92). Additive + back-compatible.

## What
- New `autoCredentials` / `sealedCredentials` options on `writeNoydbBundle`, carrying `{ kind: 'passphrase' | 'password' | 'pin', value }`.
- `autoPassphrases` / `sealedPassphrases` (pre.16) kept as **deprecated sugar** (normalized to `kind: 'passphrase'`) — no break.
- On read, `autoUnlock.perUser[user]` is now `{ kind, value }`; the app dispatches login by `kind`.
- WebAuthn rejected at write time (hardware-bound, nothing portable to carry).
- **Pre-0.2 bundles read back unchanged** (bare-string entries coerce to `kind: 'passphrase'`; sealed entries missing `kind` default to `passphrase`).

## Design
`bundle.ts` stays a pure **format layer** — it carries credential `{kind,value}` (sealing the `value`, leaving `kind` as non-secret tier metadata for dispatch). No login/prefill/enroll logic added; PIN-prefill-vs-enroll is the consumer's concern (documented in MIGRATING).

## Tests
+12 cases (97 bundle tests total): password/pin/passphrase round-trips, sealed-credential round-trip + provider-less passthrough, sugar back-compat (both old options), mutual-exclusion rejection, webauthn rejection, and the **pre-0.2 bare-string read** (proven via body-surgery: patch JSON, recompute SHA + header, reassemble). Full workspace test 134/134; build/lint/typecheck/check-architecture/validate-features green.

## Reviews
Per-task implementation + an **opus review** of the refactor: spec fully met, back-compat traced and sound, format-layer discipline confirmed, no `any`, sugar tests unweakened.

## Not in this PR
No version bump (lockstep `0.2.0-pre.1` at release). Remaining: D (#214 features.yaml registration of the at-* family), E (docs overhaul), then the release.

Plan: `docs/superpowers/plans/2026-05-24-0.2-workstream-C-auto-unlock.md`