### PR TITLE
chore(features.yaml): 0.2 Workstream D — register at-* sealing provider family (#214)

### DIFF
--- a/docs/packages/at-hosts.md
+++ b/docs/packages/at-hosts.md
@@ -1,0 +1,21 @@
+# `@noy-db/at-*` — Sealing-key providers (trusted hosts)
+
+> **How a vault goes online without giving up its keys.** Every other noy-db family keeps plaintext on the user's device. The `at-*` family is the deliberate exception: it lets a host *you* control — a Lambda, an EC2 box, a microservice — hold a sealing key and unseal a **scoped slice** of a vault, so you can run server-side work for a user who never logs in and never holds a key. The canonical shape: one worker's tax data, unsealed just enough for a serverless function to compute and return a filing.
+>
+> The `at-` prefix reads as *"sealed **at** a trusted host."* The sealing key comes from the host's environment — an env var (`at-env`), the OS keychain (`at-macos-keychain`), a cloud KMS (`at-aws-kms`, `at-gcp-kms`, `at-azure-keyvault`) — never hard-coded, always under your account's access controls and rotation.
+>
+> **Be clear about the trust boundary.** Unlike `to-*` stores and `by-*` transports — which never see plaintext — an `at-*` host **can decrypt the slice it unseals.** That is the point, and the safeguard is *scope*: per-user sealed credentials and partition extraction mean a host unseals only the slice it's authorized for, never the whole vault. Offline-first by default; online, least-privilege, on infrastructure you own.
+
+## Providers
+
+| Package | Backend | Status |
+|---|---|---|
+| `@noy-db/at-env` | environment variable | stable |
+| `@noy-db/at-macos-keychain` | macOS Keychain | stable |
+| `@noy-db/at-aws-kms` | AWS KMS | stable |
+| `@noy-db/at-gcp-kms` | Google Cloud KMS | stable |
+| `@noy-db/at-azure-keyvault` | Azure Key Vault (RSA-OAEP-256) | stable |
+
+All implement hub's `SealingKeyProvider` (`seal`/`unseal`). Pair with `createNoydb({ passphraseMode: 'managed', sealingKey, shamirRecovery })`. See each package's README for setup.
+
+> **Azure note:** Key Vault RSA decrypt is version-bound — pin a versioned key id; auto-rotation on a versionless key orphans previously-sealed vaults.

--- a/features.yaml
+++ b/features.yaml
@@ -1744,6 +1744,64 @@ transports:
       - 'Falls back to a no-op channel when BroadcastChannel is undefined (Node, older browsers)'
     related: [by-peer, sync]
 
+# ─── Sealing-key providers (Workstream D) — at-* family ──────────────
+
+sealers:
+  - id: at-env
+    name: Env-var sealing-key provider
+    package: '@noy-db/at-env'
+    backend: env
+    status: stable
+    subsystem_doc: docs/packages/at-hosts.md
+    showcases: []
+    invariants:
+      - 'Seals the hub-generated passphrase under a key read from the host environment variable; the provider never sees plaintext DEKs'
+    related: [auth-landscape, session-tiers]
+
+  - id: at-macos-keychain
+    name: macOS Keychain sealing-key provider
+    package: '@noy-db/at-macos-keychain'
+    backend: macos-keychain
+    status: stable
+    subsystem_doc: docs/packages/at-hosts.md
+    showcases: []
+    invariants:
+      - 'Seals the hub-generated passphrase under a key stored in the macOS Keychain; the provider never sees plaintext DEKs'
+    related: [auth-landscape, session-tiers]
+
+  - id: at-aws-kms
+    name: AWS KMS sealing-key provider
+    package: '@noy-db/at-aws-kms'
+    backend: aws-kms
+    status: stable
+    subsystem_doc: docs/packages/at-hosts.md
+    showcases: []
+    invariants:
+      - 'Seals and unseals via AWS KMS Encrypt/Decrypt API; key material never leaves KMS; IAM policy is the sole access gate'
+    related: [auth-landscape, session-tiers]
+
+  - id: at-gcp-kms
+    name: Google Cloud KMS sealing-key provider
+    package: '@noy-db/at-gcp-kms'
+    backend: gcp-kms
+    status: stable
+    subsystem_doc: docs/packages/at-hosts.md
+    showcases: []
+    invariants:
+      - 'Seals and unseals via Google Cloud KMS encrypt/decrypt RPC; key material never leaves Cloud KMS; IAM binding is the sole access gate'
+    related: [auth-landscape, session-tiers]
+
+  - id: at-azure-keyvault
+    name: Azure Key Vault sealing-key provider (RSA-OAEP-256)
+    package: '@noy-db/at-azure-keyvault'
+    backend: azure-keyvault
+    status: stable
+    subsystem_doc: docs/packages/at-hosts.md
+    showcases: []
+    invariants:
+      - 'Seals and unseals via Azure Key Vault RSA-OAEP-256 wrap/unwrap; always pin a versioned key id — auto-rotation on a versionless key orphans previously-sealed vaults'
+    related: [auth-landscape, session-tiers]
+
 # ─── Topologies (phase 8) — named compositions ───────────────────────
 #
 # A topology bundles together features + adapters + frameworks + auths +

--- a/scripts/feature-schema.json
+++ b/scripts/feature-schema.json
@@ -17,6 +17,7 @@
     "auths":      { "type": "array", "items": { "$ref": "#/$defs/auth" } },
     "exports":    { "type": "array", "items": { "$ref": "#/$defs/export" } },
     "transports": { "type": "array", "items": { "$ref": "#/$defs/transport" } },
+    "sealers":    { "type": "array", "items": { "$ref": "#/$defs/sealer" } },
     "topologies": { "type": "array", "items": { "$ref": "#/$defs/topology" } },
     "recipes":    { "type": "array", "items": { "$ref": "#/$defs/recipe" } }
   },
@@ -167,6 +168,22 @@
             "showcases": true, "recipes": true, "playground_pages": true,
             "diagrams": true, "invariants": true, "related": true,
             "channel":       { "enum": ["webrtc", "broadcast-channel", "websocket", "sse", "room", "custom"] },
+            "subsystem_doc": { "type": "string", "pattern": "^docs/.+\\.md$" }
+          }
+        }
+      ]
+    },
+    "sealer": {
+      "allOf": [
+        { "$ref": "#/$defs/baseEntry" },
+        {
+          "additionalProperties": false,
+          "required": ["backend"],
+          "properties": {
+            "id": true, "name": true, "package": true, "status": true, "experimental": true,
+            "showcases": true, "recipes": true, "playground_pages": true,
+            "diagrams": true, "invariants": true, "related": true,
+            "backend":       { "enum": ["env", "macos-keychain", "aws-kms", "gcp-kms", "azure-keyvault", "wincred", "libsecret", "webauthn-prf"] },
             "subsystem_doc": { "type": "string", "pattern": "^docs/.+\\.md$" }
           }
         }

--- a/scripts/validate-features.mjs
+++ b/scripts/validate-features.mjs
@@ -73,7 +73,7 @@ if (!validate(registry)) {
 
 // Sections that hold registry entries. `recipes` has its own shape; the
 // other six all derive from `baseEntry`.
-const ENTRY_SECTIONS = ['features', 'adapters', 'frameworks', 'auths', 'exports', 'transports']
+const ENTRY_SECTIONS = ['features', 'adapters', 'frameworks', 'auths', 'exports', 'transports', 'sealers']
 const ALL_SECTIONS = [...ENTRY_SECTIONS, 'topologies', 'recipes']
 
 function* allEntries() {


### PR DESCRIPTION
Fourth PR of the 0.2 epic. Registers the `at-*` family in the feature registry (the source-of-truth completeness gap #214 tracked) — a new top-level `sealers:` section, mirroring how `by-*` got `transports:`.

## Changes
- **`features.yaml`** — new `sealers:` section with all 5 providers: `at-env`, `at-macos-keychain`, `at-aws-kms`, `at-gcp-kms`, `at-azure-keyvault` (each: `package`, `backend`, `status`, `subsystem_doc: docs/packages/at-hosts.md`, an invariant, `related`).
- **`scripts/feature-schema.json`** — new `$defs.sealer` (mirrors `$defs.transport`: baseEntry + required `backend` enum + `subsystem_doc` pattern) + `sealers` top-level property.
- **`scripts/validate-features.mjs`** — `'sealers'` added to `ENTRY_SECTIONS` (auto-flows into path checks + the count summary).
- **`docs/packages/at-hosts.md`** (new) — the `at-*` family consumer doc (the locked "trusted host" copy + provider catalog), so `subsystem_doc` resolves.

## Verification
- `validate-features` green: `✓ features.yaml OK (… transports=2, sealers=5, topologies=10, recipes=6)`.
- **Negative test:** a bogus `backend` value is rejected with a clear schema error — confirms the new schema actually constrains (not a no-op). Restored → green.
- build / lint / typecheck / check-architecture all green.

This is the schema/validator change deliberately deferred out of pre.16; landed as its own PR with the validator verified in both directions. Closes #214.

## Not in this PR
No version bump. Remaining: E (README + catalog table + ROADMAP docs overhaul), then the lockstep `0.2.0-pre.1` release.