### PR TITLE
docs: 0.2 Workstream E — introduce the at-* family across README / catalog / ROADMAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ An encrypted, offline-first, **serverless** document store. The library lives in
 - **☁️ Serverless, runs anywhere.** No noy-db server. No Docker. No managed service. The library embeds in your app — ~30 KB, 0 runtime deps. Works in Node 18+, Bun, Deno, every modern browser, Cloudflare Workers, Electron, mobile PWAs.
 - **📴 Offline-first.** Every operation works without network. Sync when you want to, to whatever you want to. Single code path for online and offline — no "online mode" to toggle.
 - **👥 Multi-user, no auth server.** 5 roles (owner / admin / operator / viewer / client), per-collection permissions, key rotation on revoke. The keyring travels with the data.
-- **🧩 One core, many bridges.** `@noy-db/hub` is the encrypted document-store core. ~55 optional `to-*` / `in-*` / `on-*` / `as-*` / `by-*` packages let existing apps keep their preferred storage, framework, unlock method, export format, and session-share transport — without changing anything else.
+- **🧩 One core, many bridges.** `@noy-db/hub` is the encrypted document-store core. ~60 optional `to-*` / `in-*` / `on-*` / `as-*` / `by-*` / `at-*` packages let existing apps keep their preferred storage, framework, unlock method, export format, session-share transport, and server-side sealing host — without changing anything else.
 - **🔐 Advanced crypto features.** Hierarchical per-record tiers, deterministic encryption for searchable indexes, WebRTC peer-to-peer sync, AES-256-GCM blob store with deduplication, HKDF-keyed ETags, hash-chained audit ledger.
 - **🧪 Thousand-plus tests, CI in under a minute.** Every store / integration / auth / export package is mock-tested — CI runs without AWS, Google Drive, SFTP servers, or any real service.
 
-> **`@noy-db/hub` is the trust boundary.** Encryption happens in the core before data reaches any store. Every other package — `to-*`, `in-*`, `on-*`, `as-*`, `by-*` — is an optional adoption bridge that never sees plaintext.
+> **`@noy-db/hub` is the trust boundary.** Encryption happens in the core before data reaches any store. The `to-*`, `in-*`, `on-*`, `as-*`, and `by-*` bridges **never see plaintext** — zero-knowledge by construction.
+>
+> **Two trust boundaries.** The `at-*` family is the one deliberate exception: a sealing-key host *you* control (Lambda, EC2, a worker) **can decrypt the scoped slice it unseals** — that's the point, so you can run server-side work for users who never hold a key. You trust it because it's your infrastructure and the key lives in your managed key store; least privilege via per-user sealed credentials. Offline-first by default; online when you want.
 >
 > **Pre-1.0 stance.** The core privacy model, envelope format, keyrings, permissions, and query DSL are implemented and tested. Public APIs may still change based on adopter feedback before 1.0; data migrations and security-critical changes will be documented. No third-party cryptographic audit yet — that is a v1.0 target.
 
@@ -135,7 +137,7 @@ pnpm --filter @noy-db/showcases test           # run all showcase tests
 
 ---
 
-## The five package families
+## The six package families
 
 Each prefix reads as a preposition — the mental model stays the same as you scale from one-file vaults to multi-tenant cloud deployments.
 
@@ -146,6 +148,7 @@ Each prefix reads as a preposition — the mental model stays the same as you sc
 | **`on-`** | *"you get **on** via this method"* | **Unlock / auth** — composable primitives. Passkeys (WebAuthn), OIDC split-key, magic links, TOTP, email OTP, recovery codes, Shamir k-of-n, duress + honeypot. | [→ auth.md](docs/packages/on-auth.md) |
 | **`as-`** | *"export **as** XLSX / JSON / …"* | **Portable artefacts** — two-tier authorisation with audit ledger. CSV, Excel, XML, JSON, NDJSON, SQL dump, PDF blobs, ZIP, and the encrypted `.noydb` bundle. | [→ exports.md](docs/packages/as-exports.md) |
 | **`by-`** | *"sync **by** way of …"* | **Session-share transports** — live-state bridges between realms. `@noy-db/by-peer` (WebRTC peers, renamed from `@noy-db/p2p`) and `@noy-db/by-tabs` (BroadcastChannel multi-tab) ship today; `by-server`, `by-room` reserved. | [→ transports.md](docs/packages/by-transports.md) |
+| **`at-`** | *"sealed **at** a trusted host"* | **Sealing-key providers** — the online complement to offline-first. A host you control unseals a scoped slice for server-side work (it *can* decrypt what it unseals — the one non-zero-knowledge family). `at-env`, `at-macos-keychain`, `at-aws-kms`, `at-gcp-kms`, `at-azure-keyvault`. | [→ at-hosts.md](docs/packages/at-hosts.md) |
 
 Plus the hub (`@noy-db/hub`) and the standalone tools: `@noy-db/cli`, `create-noy-db` (scaffolder).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,13 +8,14 @@
 - **Bundle-size CI gate.** Pin the floor + per-subsystem allowances in `bundle-manifest.json`; CI fails on any unexplained regression.
 - **Showcase + recipe coverage.** A runnable end-to-end test for every `with*()` strategy and every storage destination so adopters pick a backend by reading working code.
 - **`by-*` session-share family.** `@noy-db/by-peer` (WebRTC, renamed from `@noy-db/p2p`) and `@noy-db/by-tabs` (BroadcastChannel multi-tab sync) shipped together with the family debut. Next: `@noy-db/by-server` (WebSocket / SSE relay) and `@noy-db/by-room` (Liveblocks / Yjs y-websocket).
-- **`at-*` sealing-key provider family.** `@noy-db/at-env` (env var) and `@noy-db/at-macos-keychain` (OS Keychain) debuted the family in `v0.1.0-pre.16` — sealing keys drawn from the environment for unattended / managed-host unlock. Next: the cloud/OS providers under the [at-\* sealing key providers](https://github.com/vLannaAi/noy-db/milestone/9) milestone (AWS/GCP/Azure KMS, wincred, libsecret, WebAuthn-PRF).
+- **`at-*` sealing-key provider family.** `@noy-db/at-env` (env var) and `@noy-db/at-macos-keychain` (OS Keychain) debuted the family in `v0.1.0-pre.16`; the cloud-KMS trio (`@noy-db/at-aws-kms`, `@noy-db/at-gcp-kms`, `@noy-db/at-azure-keyvault`) is on the `0.2` line. Next: the OS/hardware providers still under the [at-\* sealing key providers](https://github.com/vLannaAi/noy-db/milestone/9) milestone (wincred, libsecret, WebAuthn-PRF).
 
 ## In flight
 
 Active epics + next candidates (no firm sequencing):
 
-- **Sealing dimension — `at-*` providers + transferable bundles.** Foundation + managed-passphrase mode + the first two `at-*` providers shipped in `v0.1.0-pre.16`. In flight: more `at-*` providers ([milestone 9](https://github.com/vLannaAi/noy-db/milestone/9)), and the partition-extraction / owner-transfer ceremony ([Transferable bundles, milestone 10](https://github.com/vLannaAi/noy-db/milestone/10) — #198 steps, 12 issues). Several pre.16 features landed as "slice 1" with public API now locked (sealed-bundle, Shamir dispatch, variable-N derivations).
+- **`0.2` line — `at-*` family graduation (in flight).** On the `0.2` branch toward `0.2.0-pre.1`: hub↔on-shamir decouple (#211, the breaking change earning the minor bump), the cloud-KMS trio (#188/#189/#190), generalized bundle auto-unlock (`autoCredentials`/`sealedCredentials`, #215), and `at-*` registered in `features.yaml` (#214) + the `at-hosts.md` catalog. Then promote `0.2.0` → `latest`.
+- **Sealing dimension — transferable bundles.** Still ahead: the partition-extraction / owner-transfer ceremony ([Transferable bundles, milestone 10](https://github.com/vLannaAi/noy-db/milestone/10) — #198 steps, 12 issues), and the remaining `at-*` OS/hardware providers ([milestone 9](https://github.com/vLannaAi/noy-db/milestone/9)). Pre.16 "slice 1" features (sealed-bundle, Shamir dispatch, variable-N derivations) have public API locked.
 - **Dim 11 cross-join v3** — draft spec on branch `docs/dim11-cross-join-v1-spec`; not yet opened as a PR. Cross-join terminal on `Query<T>`, lateral form, cost ceiling, MV `queryHash` folding for cross-joined deps. Pattern follows the v2 cycle: spec PR → niwat review → multi-PR implementation epic.
 
 ## Backlog (deferred, no release target)

--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -20,5 +20,5 @@ The core is what NOYDB **is**, not what it **does**. A consumer using only the c
 - [SUBSYSTEMS.md](../../SUBSYSTEMS.md) — the 17-entry catalog of opt-in capabilities
 - [docs/subsystems/](../subsystems/) — one page per opt-in capability
 - [docs/recipes/](../recipes/) — 4 starter recipes that compose core + subsystems
-- [docs/packages/](../packages/) — the five prefix-family catalogs (`to-*`, `in-*`, `on-*`, `as-*`, `by-*`)
+- [docs/packages/](../packages/) — the six prefix-family catalogs (`to-*`, `in-*`, `on-*`, `as-*`, `by-*`, `at-*`)
 - [SPEC.md](../../SPEC.md) — placeholder skeleton; full spec rewrite deferred per 

--- a/docs/packages/README.md
+++ b/docs/packages/README.md
@@ -1,6 +1,6 @@
 # Package catalogs
 
-> NOYDB ships as one core (`@noy-db/hub`) plus five prefixed package families. Each prefix reads as a preposition — the mental model stays the same as you scale from one-file vaults to multi-tenant cloud deployments.
+> NOYDB ships as one core (`@noy-db/hub`) plus six prefixed package families. Each prefix reads as a preposition — the mental model stays the same as you scale from one-file vaults to multi-tenant cloud deployments.
 
 | Prefix | Reads as | Catalog | Count |
 |---|---|---|---:|
@@ -9,6 +9,7 @@
 | `on-` | *"you get **on** via this method"* | [on-auth.md](./on-auth.md) | 9 |
 | `as-` | *"export **as** XLSX / JSON / …"* | [as-exports.md](./as-exports.md) | 9 |
 | `by-` | *"sync **by** way of …"* | [by-transports.md](./by-transports.md) | 2 today, 4 planned |
+| `at-` | *"sealed **at** a trusted host"* | [at-hosts.md](./at-hosts.md) | 5 |
 
 ## Quick reference
 
@@ -42,9 +43,15 @@ Live-state bridges between realms (peers, tabs, rooms, relay servers). Today `@n
 
 → **[by-transports.md](./by-transports.md)**
 
+### `at-*` — Sealing-key providers (trusted hosts)
+
+The online complement to offline-first. A host you operate — Lambda, EC2, a worker — pulls a sealing key from its environment (env var, OS keychain, cloud KMS) and unseals a scoped slice of the vault to serve users who never hold its keys. The host *can* read what it unseals; you trust it because it's yours. `@noy-db/at-env`, `@noy-db/at-macos-keychain`, `@noy-db/at-aws-kms`, `@noy-db/at-gcp-kms`, `@noy-db/at-azure-keyvault`.
+
+→ **[at-hosts.md](./at-hosts.md)**
+
 ## Vs. subsystems
 
-The five families above are **separate npm packages** — `npm install` what you want, omit what you don't. They keep your *dependency graph* small.
+The six families above are **separate npm packages** — `npm install` what you want, omit what you don't. They keep your *dependency graph* small.
 
 The 17 [subsystems](../subsystems/) are **internal opt-ins** within `@noy-db/hub` — gated by `with*()` strategy seams. They keep the *core package's bundle* small.
 


### PR DESCRIPTION
Final build PR of the 0.2 epic — documents the `at-*` family now that the packages (B) and registry (D) are on main. Docs-only.

## Changes
- **`docs/packages/README.md`** — 6th catalog row (`at-` · *"sealed at a trusted host"* · `at-hosts.md` · 5) + a quick-reference blurb; intro/footer now say "six families".
- **`README.md`** — `at-*` added to the "many bridges" bullet and the family table; the trust-boundary note now states the **two trust boundaries**: `to-*/in-*/on-*/as-*/by-*` are zero-knowledge (never see plaintext); `at-*` is the deliberate exception — a host you control **can decrypt the scoped slice it unseals** (server-side work for users who never hold a key).
- **`docs/core/README.md`** — "six prefix-family catalogs".
- **`ROADMAP.md`** — `at-*` cloud trio on the `0.2` line; in-flight `0.2` entry.

## Note
The Thai README (`docs/th`) still lists five families — not inaccurate (the five it names remain zero-knowledge), but it should get an `at-*` sync in a dedicated translation pass (tracked separately).

## Verification
validate-features / build / lint green (docs-only; `at-hosts.md` already on main from #219 so the new catalog link resolves).

## Next (the release)
With A–E landed, the remaining step is the **lockstep bump to `0.2.0-pre.1`** (CHANGELOGs + ROADMAP "Recently shipped" entry) → GitHub Release `prerelease=true` → `@next`.