### PR TITLE
chore: release 0.2.0-pre.1 — at-* family graduation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@
 
 Active epics + next candidates (no firm sequencing):
 
-- **`0.2` line — `at-*` family graduation (in flight).** On the `0.2` branch toward `0.2.0-pre.1`: hub↔on-shamir decouple (#211, the breaking change earning the minor bump), the cloud-KMS trio (#188/#189/#190), generalized bundle auto-unlock (`autoCredentials`/`sealedCredentials`, #215), and `at-*` registered in `features.yaml` (#214) + the `at-hosts.md` catalog. Then promote `0.2.0` → `latest`.
+- **Promote `0.2.0` → `latest`.** `0.2.0-pre.1` ships to `@next`; once it bakes (esp. real-cloud `at-*` provider validation), promote the stable `0.2.0` to the default install channel.
 - **Sealing dimension — transferable bundles.** Still ahead: the partition-extraction / owner-transfer ceremony ([Transferable bundles, milestone 10](https://github.com/vLannaAi/noy-db/milestone/10) — #198 steps, 12 issues), and the remaining `at-*` OS/hardware providers ([milestone 9](https://github.com/vLannaAi/noy-db/milestone/9)). Pre.16 "slice 1" features (sealed-bundle, Shamir dispatch, variable-N derivations) have public API locked.
 - **Dim 11 cross-join v3** — draft spec on branch `docs/dim11-cross-join-v1-spec`; not yet opened as a PR. Cross-join terminal on `Query<T>`, lateral form, cost ceiling, MV `queryHash` folding for cross-joined deps. Pattern follows the v2 cycle: spec PR → niwat review → multi-PR implementation epic.
 
@@ -22,11 +22,15 @@ Active epics + next candidates (no firm sequencing):
 
 **Real-provider showcase batch (Apple/Google/LINE).** Originally scoped as `0.1.0-pre.13`; deferred 2026-05-20 because showcase coverage is a 1.0 gate (not a pre-release gate). Milestone renamed to [Backlog: Real-provider showcases (env-gated)](https://github.com/vLannaAi/noy-db/milestone/6). Six issues stay open at `priority: low` to close opportunistically when real-provider creds are in hand: [#64](https://github.com/vLannaAi/noy-db/issues/64), [#65](https://github.com/vLannaAi/noy-db/issues/65), [#73](https://github.com/vLannaAi/noy-db/issues/73), [#74](https://github.com/vLannaAi/noy-db/issues/74), [#75](https://github.com/vLannaAi/noy-db/issues/75), [#76](https://github.com/vLannaAi/noy-db/issues/76).
 
-**Decouple hub from `@noy-db/on-shamir` ([#211](https://github.com/vLannaAi/noy-db/issues/211)).** pre.16 broke the `hub ↔ on-shamir` build cycle by dropping on-shamir's dead hub deps, but hub still hard-depends on the on-shamir package (its secret-sharing engine is bundled into core). The proper fix — invert via an injected `ShamirRecoveryProvider` so hub holds no static import — is deferred; it properly delivers #196's "dispatch" intent and carries a breaking surface change (hub re-exports the share codecs today).
-
 ## Recently shipped (and what's deferred)
 
 The following capabilities are now in main:
+
+- **`at-*` family graduation (v0.2.0-pre.1).** The minor bump (`0.1 → 0.2`) is earned by the breaking decouple. Five issues + 3 new packages across five PRs (#216/#217/#218/#219/#220).
+  - **hub ↔ on-shamir decouple** ([#211](https://github.com/vLannaAi/noy-db/issues/211)) — **breaking:** hub no longer re-exports the Shamir codecs; Shamir recovery takes an injected `ShamirRecoveryProvider`. Resolves the layering inversion (hub no longer depends on the on-shamir package).
+  - **Cloud-KMS provider trio** — `@noy-db/at-aws-kms` ([#188](https://github.com/vLannaAi/noy-db/issues/188)), `@noy-db/at-gcp-kms` ([#189](https://github.com/vLannaAi/noy-db/issues/189)), `@noy-db/at-azure-keyvault` ([#190](https://github.com/vLannaAi/noy-db/issues/190)).
+  - **Generalized bundle auto-unlock** ([#215](https://github.com/vLannaAi/noy-db/issues/215)) — `autoCredentials`/`sealedCredentials` carry `{ kind, value }` (passphrase/password/pin); old options deprecated-but-working; back-compatible reads.
+  - **Catalog** — `at-*` registered in `features.yaml` (`sealers:` section) + `docs/packages/at-hosts.md` ([#214](https://github.com/vLannaAi/noy-db/issues/214)); README names the two trust boundaries.
 
 - **Sealing dimension foundation + `at-*` family debut (v0.1.0-pre.16).** The first sealing-key providers plus managed-passphrase mode and the schema-introspection trio.
   - **`at-*` family debut** — `@noy-db/at-env` ([#187](https://github.com/vLannaAi/noy-db/issues/187)) + `@noy-db/at-macos-keychain` ([#191](https://github.com/vLannaAi/noy-db/issues/191)), built on a new `SealingKeyProvider` contract + sealed envelope ([#14](https://github.com/vLannaAi/noy-db/issues/14) / [#186](https://github.com/vLannaAi/noy-db/issues/186)).

--- a/packages/as-blob/CHANGELOG.md
+++ b/packages/as-blob/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/as-blob
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/as-blob/package.json
+++ b/packages/as-blob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-blob",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Single-attachment plaintext export for noy-db — extracts one blob from BlobSet as native MIME bytes. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier, document sub-family).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-csv/CHANGELOG.md
+++ b/packages/as-csv/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/as-csv
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/as-csv/package.json
+++ b/packages/as-csv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-csv",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "CSV plaintext export for noy-db — decrypts records and formats as comma-separated values. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-json/CHANGELOG.md
+++ b/packages/as-json/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/as-json
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/as-json/package.json
+++ b/packages/as-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-json",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Structured JSON plaintext export for noy-db — decrypts records and emits one JSON document per vault. Gated by RFC #249 canExportPlaintext capability; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-ndjson/CHANGELOG.md
+++ b/packages/as-ndjson/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/as-ndjson
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/as-ndjson/package.json
+++ b/packages/as-ndjson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-ndjson",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Newline-delimited JSON export for noy-db — streaming plaintext export suitable for data pipelines, warehouse ingestion, and jq pipelines. Gated by RFC #249 canExportPlaintext. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-noydb/CHANGELOG.md
+++ b/packages/as-noydb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/as-noydb
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/as-noydb/package.json
+++ b/packages/as-noydb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-noydb",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Encrypted .noydb bundle export for noy-db — wraps writeNoydbBundle() with the RFC #249 canExportBundle authorization gate and ergonomic browser/node helpers. Sole member of the @noy-db/as-* encrypted tier — ciphertext in, ciphertext out.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-sql/CHANGELOG.md
+++ b/packages/as-sql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/as-sql
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/as-sql/package.json
+++ b/packages/as-sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-sql",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "SQL dump export for noy-db — decrypts records and emits dialect-aware CREATE TABLE + INSERT statements for postgres / mysql / sqlite. One-way migration helper. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xlsx/CHANGELOG.md
+++ b/packages/as-xlsx/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/as-xlsx
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Minor Changes

--- a/packages/as-xlsx/package.json
+++ b/packages/as-xlsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xlsx",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Excel spreadsheet plaintext export for noy-db — produces a real .xlsx (Office Open XML) from one or more collections. Multi-sheet, Unicode-safe via shared-strings table. Zero runtime deps beyond the workspace zip encoder. Gated by RFC #249 `canExportPlaintext` with format `'xlsx'`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xml/CHANGELOG.md
+++ b/packages/as-xml/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/as-xml
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/as-xml/package.json
+++ b/packages/as-xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xml",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "XML plaintext export for noy-db — decrypts records and formats as XML with RFC-compliant entity escaping. For legacy systems, banking batch imports, SOAP endpoints, and accounting software that requires XML. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-zip/CHANGELOG.md
+++ b/packages/as-zip/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/as-zip
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/as-zip/package.json
+++ b/packages/as-zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-zip",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Composite record + blob archive export for noy-db — bundles a collection's records plus every attached blob into one zip. Zero dependencies (STORE-only zip encoder). Gated by the RFC #249 `canExportPlaintext` capability bit with format `'zip'`. Part of the @noy-db/as-* portable-artefact family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-aws-kms/CHANGELOG.md
+++ b/packages/at-aws-kms/CHANGELOG.md
@@ -1,1 +1,8 @@
 # Changelog — at-aws-kms
+
+## 0.2.0-pre.1
+
+### Minor Changes
+
+- First release. AWS KMS `SealingKeyProvider` — `seal`/`unseal` via KMS Encrypt/Decrypt; dependency-injected client; ambient credentials only ([#188](https://github.com/vLannaAi/noy-db/issues/188)).
+

--- a/packages/at-aws-kms/package.json
+++ b/packages/at-aws-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-aws-kms",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "AWS KMS sealing key provider for noy-db managed-passphrase mode — seal/unseal via KMS Encrypt/Decrypt, with KMS access logs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-azure-keyvault/CHANGELOG.md
+++ b/packages/at-azure-keyvault/CHANGELOG.md
@@ -1,1 +1,8 @@
 # Changelog — at-azure-keyvault
+
+## 0.2.0-pre.1
+
+### Minor Changes
+
+- First release. Azure Key Vault `SealingKeyProvider` — RSA-OAEP-256 encrypt/decrypt. RSA decrypt is version-bound: pin a versioned keyId (auto-rotation on a versionless key orphans sealed vaults) ([#190](https://github.com/vLannaAi/noy-db/issues/190)).
+

--- a/packages/at-azure-keyvault/package.json
+++ b/packages/at-azure-keyvault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-azure-keyvault",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Azure Key Vault sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-env/CHANGELOG.md
+++ b/packages/at-env/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — at-env
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Managed-mode vaults now also require a `shamirRecovery` provider passed to `createNoydb` (managed mode mandates strong recovery; [#211](https://github.com/vLannaAi/noy-db/issues/211)). No API change to this package.
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 First release. Debuts the `at-*` sealing-key provider family.

--- a/packages/at-env/package.json
+++ b/packages/at-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-env",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Env-var sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a key from process.env. Smallest production-shape provider; pair with Kubernetes Secrets / Heroku env / AWS Secrets Manager.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-gcp-kms/CHANGELOG.md
+++ b/packages/at-gcp-kms/CHANGELOG.md
@@ -1,1 +1,8 @@
 # Changelog — at-gcp-kms
+
+## 0.2.0-pre.1
+
+### Minor Changes
+
+- First release. Google Cloud KMS `SealingKeyProvider` — `seal`/`unseal` via Cloud KMS encrypt/decrypt; handles base64-string responses; ambient ADC ([#189](https://github.com/vLannaAi/noy-db/issues/189)).
+

--- a/packages/at-gcp-kms/package.json
+++ b/packages/at-gcp-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-gcp-kms",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Google Cloud KMS sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-macos-keychain/CHANGELOG.md
+++ b/packages/at-macos-keychain/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — at-macos-keychain
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Managed-mode vaults now also require a `shamirRecovery` provider passed to `createNoydb` (managed mode mandates strong recovery; [#211](https://github.com/vLannaAi/noy-db/issues/211)). No API change to this package.
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 First release. Part of the `at-*` sealing-key provider family debut.

--- a/packages/at-macos-keychain/package.json
+++ b/packages/at-macos-keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-macos-keychain",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "macOS Keychain sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a 32-byte key stored in the user's login Keychain. Desktop-app provider in the at-* family; pairs with Touch ID via Keychain Access UI.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-peer/CHANGELOG.md
+++ b/packages/by-peer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — by-peer
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/by-peer/package.json
+++ b/packages/by-peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-peer",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "WebRTC peer-to-peer transport for noy-db — direct browser-to-browser channel with signaling-agnostic handshake",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-tabs/CHANGELOG.md
+++ b/packages/by-tabs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/by-tabs
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/by-tabs/package.json
+++ b/packages/by-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-tabs",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "BroadcastChannel multi-tab transport for noy-db — sync between tabs of the same browser without round-tripping the storage backend",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/cli
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/cli",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Command-line tool for noy-db — inspect .noydb bundles without decrypting, verify integrity, validate config objects, scaffold topology profiles, and monitor a live vault's store metrics.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/create-noy-db/CHANGELOG.md
+++ b/packages/create-noy-db/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — create-noy-db
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/create-noy-db/package.json
+++ b/packages/create-noy-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-noy-db",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Wizard + CLI tool for noy-db: scaffold a fresh Nuxt 4 + Pinia encrypted store, or add collections to an existing project. Invoke via `npm create @noy-db`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/hub/CHANGELOG.md
+++ b/packages/hub/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog — hub
 
+## 0.2.0-pre.1
+
+The **`at-*` family graduation** line. Minor bump (`0.1 → 0.2`) because it carries a **breaking change** (#211). The `at-*` sealing-key family — debuted in pre.16 — is now first-class: a cloud-KMS provider trio ships, bundle auto-unlock generalizes beyond passphrases, hub is decoupled from the Shamir plugin, and the family is registered in the catalog.
+
+### ⚠️ Breaking — hub ↔ on-shamir decouple ([#211](https://github.com/vLannaAi/noy-db/issues/211))
+
+- `@noy-db/hub` **no longer re-exports** the Shamir share codecs (`encodeShareBase32` / `decodeShareBase32`) — import them from `@noy-db/on-shamir` instead.
+- Shamir recovery now requires an **injected provider**: `createNoydb({ shamirRecovery: shamirRecoveryProvider() })` (from `@noy-db/on-shamir`). Managed-passphrase mode mandates strong recovery, so managed-mode vaults now also need this provider.
+- hub holds no static import of on-shamir — the layering inversion + build-cycle risk are gone. See `MIGRATING.md`.
+
+### Bundle auto-unlock generalized ([#215](https://github.com/vLannaAi/noy-db/issues/215))
+
+- New `autoCredentials` / `sealedCredentials` on `writeNoydbBundle`, carrying `{ kind: 'passphrase' | 'password' | 'pin', value }` — a delivered bundle one-click-unlocks whatever tier the user enrolled.
+- `autoPassphrases` / `sealedPassphrases` remain as **deprecated sugar** (`kind: 'passphrase'`). On read, `autoUnlock.perUser[user]` is now `{ kind, value }`; dispatch login by `kind` (PIN is a prefill, not an enrollment). WebAuthn is rejected (hardware-bound). Pre-0.2 bundles read back unchanged.
+
+### `at-*` cloud-KMS provider trio (new packages)
+
+- `@noy-db/at-aws-kms` ([#188](https://github.com/vLannaAi/noy-db/issues/188)), `@noy-db/at-gcp-kms` ([#189](https://github.com/vLannaAi/noy-db/issues/189)), `@noy-db/at-azure-keyvault` ([#190](https://github.com/vLannaAi/noy-db/issues/190)) — `SealingKeyProvider`s backed by cloud KMS encrypt/decrypt. Ambient credentials only.
+
+### Catalog
+
+- `at-*` registered in `features.yaml` (new `sealers:` section) + `docs/packages/at-hosts.md` ([#214](https://github.com/vLannaAi/noy-db/issues/214)). The README now names the **two trust boundaries**: zero-knowledge (`to-*`/`by-*`) vs trusted-compute (`at-*`, which *can* decrypt the scoped slice it unseals).
+
 ## 0.1.0-pre.16
 
 The **sealing dimension foundation** + the **`at-*` sealing-key provider family debut**. Where every prior tier protected the vault with something the user *knows* or *has* (passphrase, WebAuthn, PIN), `at-*` providers seal it with a key drawn from the *environment* — an env var, an OS keychain — for unattended / managed-host scenarios. Shipped alongside managed-passphrase mode, the recovery-profile dispatch groundwork, and the persisted-schema introspection trio.

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/hub",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Zero-knowledge, offline-first, encrypted document store — core library with AES-256-GCM, PBKDF2, multi-user keyring, and sync engine",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-ai/CHANGELOG.md
+++ b/packages/in-ai/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-ai
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/in-ai/package.json
+++ b/packages/in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-ai",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "LLM function-calling adapter for noy-db — expose ACL-scoped collections as tool definitions, then dispatch tool calls back to the vault. Format-agnostic (OpenAI, Anthropic, Vercel AI SDK).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-nextjs/CHANGELOG.md
+++ b/packages/in-nextjs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-nextjs
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/in-nextjs/package.json
+++ b/packages/in-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nextjs",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Next.js App Router helpers for noy-db — server components, route handlers, client hooks, and cookie-based session. Thin bridge that composes @noy-db/in-react with Next's cookies()/headers() APIs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-nuxt/CHANGELOG.md
+++ b/packages/in-nuxt/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — in-nuxt
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/in-nuxt/package.json
+++ b/packages/in-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nuxt",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Nuxt 4 module for noy-db — auto-imports, SSR-safe runtime plugin, and the @noy-db/in-pinia bridge",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-pinia/CHANGELOG.md
+++ b/packages/in-pinia/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — in-pinia
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/in-pinia/package.json
+++ b/packages/in-pinia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-pinia",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Pinia integration for noy-db — defineNoydbStore() and the augmentation plugin for existing stores",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-react/CHANGELOG.md
+++ b/packages/in-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-react
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/in-react/package.json
+++ b/packages/in-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-react",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "React hooks for noy-db — useNoydb, useVault, useCollection, useQuery, useSync. Uses useSyncExternalStore for reactive subscriptions. Zero deps beyond React.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-rest/CHANGELOG.md
+++ b/packages/in-rest/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-rest
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/in-rest/package.json
+++ b/packages/in-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-rest",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Framework-neutral REST API integration for noy-db — createRestHandler with Hono, Express, Fastify, and Nitro subpath adapters.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-solid/CHANGELOG.md
+++ b/packages/in-solid/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-solid
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/in-solid/package.json
+++ b/packages/in-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-solid",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "SolidJS signal primitives for noy-db — createCollectionSignal, createQuerySignal, createSyncSignal backed by noy-db change events.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-svelte/CHANGELOG.md
+++ b/packages/in-svelte/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-svelte
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/in-svelte/package.json
+++ b/packages/in-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-svelte",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Svelte stores for noy-db — collectionStore / queryStore / syncStore backed by noy-db change events. Works with Svelte 4 store contract and Svelte 5 runes (via $store subscription interop).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-query/CHANGELOG.md
+++ b/packages/in-tanstack-query/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-tanstack-query
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/in-tanstack-query/package.json
+++ b/packages/in-tanstack-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-query",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "TanStack Query adapter for noy-db — queryFn + mutationFn helpers that speak the Collection API, plus automatic invalidation from noy-db change events. Framework-agnostic (React / Vue / Solid / Svelte).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-table/CHANGELOG.md
+++ b/packages/in-tanstack-table/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-tanstack-table
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/in-tanstack-table/package.json
+++ b/packages/in-tanstack-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-table",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "TanStack Table bridge for noy-db — map Collection query state (sort, filter, pagination) into Table state and back, so a useSmartTable pattern drives the DB's query DSL without glue code.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-vue/CHANGELOG.md
+++ b/packages/in-vue/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — in-vue
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/in-vue/package.json
+++ b/packages/in-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-vue",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Vue 3 / Nuxt composables for noy-db — reactive useNoydb, useCollection, useSync, and biometric plugin",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-yjs/CHANGELOG.md
+++ b/packages/in-yjs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — in-yjs
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/in-yjs/package.json
+++ b/packages/in-yjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-yjs",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Yjs Y.Doc interop for noy-db — collaborative rich-text fields with encrypted-at-rest Yjs state",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-zustand/CHANGELOG.md
+++ b/packages/in-zustand/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/in-zustand
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/in-zustand/package.json
+++ b/packages/in-zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-zustand",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Zustand adapter for noy-db — factory that mirrors defineNoydbStore for Zustand users, auto-syncs state from noy-db change events, and supports optimistic mutations.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-email-otp/CHANGELOG.md
+++ b/packages/on-email-otp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/on-email-otp
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/on-email-otp/package.json
+++ b/packages/on-email-otp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-email-otp",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Email OTP second factor for noy-db — generates time-boxed one-time codes, delivers via a user-supplied transport (SMTP / SES / Postmark / any fn), and verifies in constant time. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-magic-link/CHANGELOG.md
+++ b/packages/on-magic-link/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/on-magic-link
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/on-magic-link/package.json
+++ b/packages/on-magic-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-magic-link",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Magic-link unlock for noy-db — one-time URL that opens a vault in a viewer-scoped session without a passphrase. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-oidc/CHANGELOG.md
+++ b/packages/on-oidc/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — on-oidc
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/on-oidc/package.json
+++ b/packages/on-oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-oidc",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "OAuth/OIDC bridge for noy-db — federated login (LINE, Google, Apple, Okta) with split-key key connector — server never sees plaintext",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-password/CHANGELOG.md
+++ b/packages/on-password/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/on-password
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/on-password/package.json
+++ b/packages/on-password/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-password",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Tier-2 password authenticator slot for noy-db. PBKDF2-SHA256 600K wraps the DEK set in its own keyring slot, distinct from the rarely-typed tier-1 phrase. Pair with @noy-db/on-email-otp or @noy-db/on-totp for the SaaS UX.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-pin/CHANGELOG.md
+++ b/packages/on-pin/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/on-pin
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/on-pin/package.json
+++ b/packages/on-pin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-pin",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Session-resume PIN quick-lock for noy-db — after a full passphrase unlock, a short-lived PIN (or a per-device biometric) re-unlocks the cached DEKs without re-typing the passphrase. PIN never replaces the passphrase; only resumes an already-unlocked session.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-recovery/CHANGELOG.md
+++ b/packages/on-recovery/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/on-recovery
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/on-recovery/package.json
+++ b/packages/on-recovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-recovery",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "One-time printable recovery codes for noy-db — last-resort vault unlock when the passphrase, passkey, and OIDC provider are all unavailable. Base32 + checksum codes, PBKDF2-derived wrapping keys, burn-on-use. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-shamir/CHANGELOG.md
+++ b/packages/on-shamir/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @noy-db/on-shamir
 
+## 0.2.0-pre.1
+
+### Minor Changes
+
+- New `shamirRecoveryProvider()` export — implements hub's `ShamirRecoveryProvider` (string-level split/combine wrapping the existing share codecs), so hub uses Shamir recovery without importing this package ([#211](https://github.com/vLannaAi/noy-db/issues/211)).
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/on-shamir/package.json
+++ b/packages/on-shamir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-shamir",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "k-of-n Shamir Secret Sharing of the vault KEK for multi-party unlock. Any K of N shares recombines the key; fewer than K leaks zero bits. Composable — each share can be protected by any other on-* method. Zero runtime dependencies.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-threat/CHANGELOG.md
+++ b/packages/on-threat/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/on-threat
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/on-threat/package.json
+++ b/packages/on-threat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-threat",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Threat-response primitives for noy-db — multi-attempt lockout, duress-passphrase data destruction, duress-passphrase honeypot decoy. Pure stateful helpers; the caller coordinates keyring + audit-ledger integration. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-totp/CHANGELOG.md
+++ b/packages/on-totp/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/on-totp
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/on-totp/package.json
+++ b/packages/on-totp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-totp",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "TOTP (RFC 6238) authenticator-app second factor for noy-db — generate secrets, otpauth:// provisioning URIs, and constant-time code verification. Zero dependencies (HMAC-SHA1 via Web Crypto). Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-webauthn/CHANGELOG.md
+++ b/packages/on-webauthn/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — on-webauthn
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/on-webauthn/package.json
+++ b/packages/on-webauthn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-webauthn",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "WebAuthn hardware-key keyrings for noy-db — Touch ID, Face ID, Windows Hello, YubiKey, FIDO2 passkeys",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-aws-dynamo/CHANGELOG.md
+++ b/packages/to-aws-dynamo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — to-aws-dynamo
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-aws-dynamo/package.json
+++ b/packages/to-aws-dynamo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-aws-dynamo",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "AWS DynamoDB adapter for noy-db — single-table design, zero-knowledge cloud sync",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-aws-s3/CHANGELOG.md
+++ b/packages/to-aws-s3/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — to-aws-s3
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-aws-s3/package.json
+++ b/packages/to-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-aws-s3",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "AWS S3 adapter for noy-db — encrypted object storage with zero-knowledge cloud sync",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-browser-idb/CHANGELOG.md
+++ b/packages/to-browser-idb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — to-browser-idb
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-browser-idb/package.json
+++ b/packages/to-browser-idb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-browser-idb",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "IndexedDB adapter for noy-db with optional key obfuscation",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-browser-local/CHANGELOG.md
+++ b/packages/to-browser-local/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — to-browser-local
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-browser-local/package.json
+++ b/packages/to-browser-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-browser-local",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "localStorage adapter for noy-db with optional key obfuscation",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-cloudflare-d1/CHANGELOG.md
+++ b/packages/to-cloudflare-d1/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-cloudflare-d1
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-cloudflare-d1/package.json
+++ b/packages/to-cloudflare-d1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-cloudflare-d1",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Cloudflare D1 adapter for noy-db — SQLite at the edge, running inside Cloudflare Workers. Accepts a D1Database binding and speaks the noy-db store contract via D1's prepare/bind API.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-cloudflare-r2/CHANGELOG.md
+++ b/packages/to-cloudflare-r2/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-cloudflare-r2
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-cloudflare-r2/package.json
+++ b/packages/to-cloudflare-r2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-cloudflare-r2",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Cloudflare R2 adapter for noy-db — S3-compatible object storage with zero egress fees. Thin wrapper around @noy-db/to-aws-s3 configured for the R2 endpoint. casAtomic: false (same caveat as S3).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-drive/CHANGELOG.md
+++ b/packages/to-drive/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-drive
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-drive/package.json
+++ b/packages/to-drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-drive",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Google Drive bundle store for noy-db. Stores the whole vault as a single .noydb file in Drive's hidden appDataFolder; opaque ULID filenames never leak compartment names. Driver-agnostic — bring your own OAuth token.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-file/CHANGELOG.md
+++ b/packages/to-file/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — to-file
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-file/package.json
+++ b/packages/to-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-file",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "JSON file adapter for noy-db — encrypted document store on local disk, USB sticks, or network drives",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-icloud/CHANGELOG.md
+++ b/packages/to-icloud/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-icloud
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-icloud/package.json
+++ b/packages/to-icloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-icloud",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "iCloud Drive bundle store for noy-db — macOS-aware persistence that detects eviction stubs (.icloud) and conflict files automatically. Treats each vault as a single .noydb bundle, safe for the Apple ecosystem.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-memory/CHANGELOG.md
+++ b/packages/to-memory/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog — to-memory
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-memory/package.json
+++ b/packages/to-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-memory",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "In-memory adapter for noy-db — ideal for testing, development, and ephemeral workloads",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-meter/CHANGELOG.md
+++ b/packages/to-meter/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-meter
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-meter/package.json
+++ b/packages/to-meter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-meter",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Pass-through meter for @noy-db/to-* stores — wraps any NoydbStore and records per-method latency percentiles, error rates, and byte counts on real traffic. Optional synthetic liveness probe emits degraded / restored events. No synthetic benchmarks (see @noy-db/to-probe for that) — this measures what your app is actually doing.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-mysql/CHANGELOG.md
+++ b/packages/to-mysql/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-mysql
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-mysql/package.json
+++ b/packages/to-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-mysql",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "MySQL / MariaDB adapter for noy-db — encrypted-envelope KV with JSON column. Works with any duck-typed mysql2-style pool/connection. casAtomic: true via UPDATE … WHERE v = ?.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-nfs/CHANGELOG.md
+++ b/packages/to-nfs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-nfs
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-nfs/package.json
+++ b/packages/to-nfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-nfs",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "NFS network-file store for noy-db. Same indexed layout as @noy-db/to-file, with pre-flight checks for nolock / noac mount options that silently break versioning guarantees on stock NFS mounts.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-postgres/CHANGELOG.md
+++ b/packages/to-postgres/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-postgres
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-postgres/package.json
+++ b/packages/to-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-postgres",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "PostgreSQL adapter for noy-db — encrypted-envelope KV with jsonb column. Works with any duck-typed pg-style Client (node-postgres, postgres.js, pg-native, Supabase, Neon serverless). casAtomic: true via UPDATE … WHERE _v = ?.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-probe/CHANGELOG.md
+++ b/packages/to-probe/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-probe
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-probe/package.json
+++ b/packages/to-probe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-probe",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Diagnostic companion for the @noy-db/to-* store family — not itself a storage backend. Setup-time suitability test + topology check + runtime reliability monitor. Exercises the 6-method NoydbStore contract across five axes (write latency, CAS integrity, hydration cost, sync economics, network resilience) and produces a structured risk-scored report.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-smb/CHANGELOG.md
+++ b/packages/to-smb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-smb
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-smb/package.json
+++ b/packages/to-smb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-smb",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "SMB/CIFS network file store for noy-db. Works against Windows file servers, NAS devices (Synology/QNAP/Netgear), and corporate shared drives via NTLM or Kerberos auth — no OS mount required.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-sqlite/CHANGELOG.md
+++ b/packages/to-sqlite/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-sqlite
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-sqlite/package.json
+++ b/packages/to-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-sqlite",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "SQLite adapter for noy-db — single-file local encrypted document store. Works with better-sqlite3, node:sqlite (Node 22+), or bun:sqlite via a duck-typed Database interface. casAtomic: true (BEGIN IMMEDIATE + UPDATE WHERE _v=?).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-ssh/CHANGELOG.md
+++ b/packages/to-ssh/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-ssh
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-ssh/package.json
+++ b/packages/to-ssh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-ssh",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "SSH/SFTP store for noy-db — remote encrypted document storage over SSH using public-key auth. Any Linux/macOS server with sshd running becomes a noy-db backend; leverages existing ~/.ssh keys or ssh-agent. Key-only auth (no passwords).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-supabase/CHANGELOG.md
+++ b/packages/to-supabase/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-supabase
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-supabase/package.json
+++ b/packages/to-supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-supabase",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Supabase adapter for noy-db — Postgres + Storage combo. Routes records to @noy-db/to-postgres via the Supabase Postgres pool and optional blob routing via Supabase Storage.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-turso/CHANGELOG.md
+++ b/packages/to-turso/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-turso
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-turso/package.json
+++ b/packages/to-turso/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-turso",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "Turso / libSQL adapter for noy-db — edge SQLite with built-in replication. Wraps @libsql/client through a small async shim that speaks the same noy-db store contract as @noy-db/to-sqlite.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-webdav/CHANGELOG.md
+++ b/packages/to-webdav/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/to-webdav
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/packages/to-webdav/package.json
+++ b/packages/to-webdav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-webdav",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "description": "WebDAV adapter for noy-db — encrypted object storage over the WebDAV protocol. Works with Nextcloud, ownCloud, Apache mod_dav, and any RFC 4918 server. Pure fetch()-based, zero dependencies.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/playground/cli/CHANGELOG.md
+++ b/playground/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/playground-cli
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/playground/cli/package.json
+++ b/playground/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/playground-cli",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "private": true,
   "type": "module",
   "description": "Interactive guided CLI demo of noy-db's hub + storage backends",

--- a/playground/nuxt/CHANGELOG.md
+++ b/playground/nuxt/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/playground-nuxt
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Patch Changes

--- a/playground/nuxt/package.json
+++ b/playground/nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/playground-nuxt",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "private": true,
   "description": "Reference Nuxt 4 + @noy-db/in-nuxt accounting demo — integration against a real Vue/Pinia consumer",
   "type": "module",

--- a/showcases/CHANGELOG.md
+++ b/showcases/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @noy-db/showcases
 
+## 0.2.0-pre.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.2.0-pre.1
+
 ## 0.1.0-pre.16
 
 ### Minor Changes

--- a/showcases/package.json
+++ b/showcases/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/showcases",
-  "version": "0.1.0-pre.16",
+  "version": "0.2.0-pre.1",
   "private": true,
   "description": "Automated end-to-end showcases for noy-db — each showcase doubles as a test, demo, and tutorial covering a specific topology pattern.",
   "type": "module",


### PR DESCRIPTION
Lockstep bump of all 66 workspace packages `0.1.0-pre.16` → `0.2.0-pre.1`. Minor bump earned by the breaking change in #211.

## What's in 0.2.0-pre.1 (5 merged PRs)
- **#216 / #211** — hub↔on-shamir decouple **[BREAKING]**: hub no longer re-exports the Shamir codecs; Shamir recovery takes an injected `ShamirRecoveryProvider`.
- **#217** — cloud-KMS provider trio: `@noy-db/at-aws-kms` (#188), `@noy-db/at-gcp-kms` (#189), `@noy-db/at-azure-keyvault` (#190) — **first publishes**.
- **#218 / #215** — generalized bundle auto-unlock (`autoCredentials` / `sealedCredentials`, `{kind,value}`; old options deprecated-but-working; back-compatible reads).
- **#219 / #214** — `at-*` registered in `features.yaml` (`sealers:` section) + `docs/packages/at-hosts.md`.
- **#220** — README/catalog/ROADMAP overhaul; the two-trust-boundaries note.

## Breaking change → `MIGRATING.md`
hub no longer re-exports `encodeShareBase32`/`decodeShareBase32`; Shamir recovery (incl. managed-passphrase mode) requires `shamirRecovery: shamirRecoveryProvider()`.

## Release
Tag `v0.2.0-pre.1` → GitHub Release **prerelease=true** → publishes `@next`. Staged: promote `0.2.0` → `latest` after it bakes. `latest` is unaffected by this release.

## Verification
All gates green: build (no cycle), lint, typecheck, check-architecture, validate-features, `--frozen-lockfile`. Diff is version/CHANGELOG/ROADMAP/lockfile only — no source changes (the code landed in #216–#220).