### PR TITLE
feat(hub): recipient-target bundle sealing (#197 final slice)

### DIFF
--- a/docs/subsystems/bundle.md
+++ b/docs/subsystems/bundle.md
@@ -100,6 +100,21 @@ The `recipients` array, after re-keying, materialises as `Record<userId, Keyring
 - Handle is content-addressed at the *vault* level; two backups of the same vault share a handle
 - Header rejects unknown keys at parse time — minimum-disclosure invariant
 
+## Recipient-target sealing (slice 2)
+
+`sealedCredentials.mode: 'recipient-target'` lets a sender ship a bundle
+to a recipient whose `SealingKeyProvider` the sender does not have. The
+recipient publishes a `RecipientHint` (RSA-OAEP-SHA256 public material +
+`pid`) via any out-of-band channel; the sender passes it per-user. The
+sealing provider must implement `RecipientSealer` (`publishRecipientHint`
++ `sealForRecipient`) — handover-capable cloud-KMS providers do,
+self-only providers (`at-macos-keychain`, `at-env`) do not. The reader
+side is unchanged: `pid` dispatch finds the matching local provider,
+which transparently parses the hybrid CEK-wrap envelope inside the
+opaque `sealed` bytes. See [`recipient-target sealing
+design`](../superpowers/specs/2026-05-28-recipient-target-bundle-sealing-design.md)
+for the full spec.
+
 ## See also
 
 - [SUBSYSTEMS.md](../../SUBSYSTEMS.md)

--- a/docs/superpowers/plans/2026-05-28-recipient-target-bundle-sealing.md
+++ b/docs/superpowers/plans/2026-05-28-recipient-target-bundle-sealing.md
@@ -1,0 +1,1089 @@
+# Recipient-target Bundle Sealing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the deferred `mode: 'recipient-target'` arm to `sealedCredentials` in `writeNoydbBundle`, ship the `RecipientSealer` interface from foundation §11.4, and provide a `MemoryRecipientSealer` reference implementation backed by WebCrypto RSA-OAEP-SHA256 + AES-GCM hybrid encryption.
+
+**Architecture:** Add `RecipientHint` type + `RecipientSealer` interface in `team/managed-passphrase.ts` next to `SealingKeyProvider`. Implement `MemoryRecipientSealer` in the same file. Extend `WriteNoydbBundleOptions.sealedCredentials` with a discriminated `mode: 'recipient-target'` arm; extend `NormalizedAutoUnlock` to carry per-user `hint`. `validateAutoUnlockOptions` gains a recipient-target arm and drops the old "deferred per §11.4" throw. `buildAutoUnlockWrapper` branches on mode and calls `sealForRecipient` instead of `seal`. The reader path is unchanged because the hybrid wrapping lives inside the provider's opaque `Uint8Array`. New optional `SealedAutoUnlockEntry.hint` field carries the hint for recipient verifiability.
+
+**Tech Stack:** TypeScript, WebCrypto (RSA-OAEP-SHA256, AES-GCM, RSA-2048), Vitest, pnpm workspace, Turbo.
+
+**Branch:** `docs/recipient-target-bundle-sealing` (already created; spec committed at `2e8df7e`/`0323da6`).
+
+**Reference docs:**
+- Spec: `docs/superpowers/specs/2026-05-28-recipient-target-bundle-sealing-design.md`
+- Foundation §11.3, §11.4: `docs/superpowers/specs/2026-05-23-sealing-at-dimension-foundation.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `packages/hub/src/team/managed-passphrase.ts` | Modify | Add `RecipientHint` type, `RecipientSealer` interface, `MemoryRecipientSealer` class |
+| `packages/hub/src/index.ts` | Modify | Re-export `RecipientHint`, `RecipientSealer`, `MemoryRecipientSealer` |
+| `packages/hub/src/bundle/bundle.ts` | Modify | Extend `sealedCredentials` type with `recipient-target` arm; extend `NormalizedAutoUnlock` with per-user `hint`; new `SealedAutoUnlockEntry.hint?` field; recipient-target arm in `validateAutoUnlockOptions`; sealing branch in `buildAutoUnlockWrapper` |
+| `packages/hub/__tests__/managed-passphrase.test.ts` | Modify | Add `MemoryRecipientSealer` unit tests (round-trip, wrong-key, hint round-trip) |
+| `packages/hub/__tests__/bundle-auto-unlock.test.ts` | Modify | Add `recipient-target sealedCredentials` describe block (7 tests) |
+| `features.yaml` | Modify | Add an invariant line to the `bundle` feature row noting recipient-target capability; reference this spec |
+
+---
+
+## Pre-flight (one-time setup)
+
+- [ ] **Confirm branch + clean working tree**
+
+```bash
+git rev-parse --abbrev-ref HEAD
+# Expected: docs/recipient-target-bundle-sealing
+git status --short
+# Expected: empty (clean working tree)
+```
+
+If branch is different, run `git checkout docs/recipient-target-bundle-sealing`. If the branch doesn't exist locally, `git fetch origin && git checkout docs/recipient-target-bundle-sealing`. The spec must already be committed on this branch (HEAD should show commits `2e8df7e` and `0323da6` in the history).
+
+---
+
+## Task 1: `MemoryRecipientSealer` + types
+
+Stand up the primitive first. Everything else depends on the interface contract this task pins.
+
+**Files:**
+- Modify: `packages/hub/src/team/managed-passphrase.ts`
+- Test: `packages/hub/__tests__/managed-passphrase.test.ts`
+
+- [ ] **Step 1: Write the first failing test (round-trip seal/unseal)**
+
+Open `packages/hub/__tests__/managed-passphrase.test.ts`. At the end of the file, add a new describe block:
+
+```ts
+import { MemoryRecipientSealer } from '../src/team/managed-passphrase.js'
+
+describe('MemoryRecipientSealer', () => {
+  it('round-trips: sealForRecipient → unseal returns the original plaintext', async () => {
+    const recipient = new MemoryRecipientSealer({ id: 'alice-rs' })
+    const hint = await recipient.publishRecipientHint()
+
+    const sender = new MemoryRecipientSealer({ id: 'sender-rs' })
+    const plaintext = new TextEncoder().encode('hello recipient')
+    const sealed = await sender.sealForRecipient(plaintext, hint)
+
+    const opened = await recipient.unseal(sealed)
+    expect(new TextDecoder().decode(opened)).toBe('hello recipient')
+  })
+})
+```
+
+Note: the import for `MemoryRecipientSealer` may already pick up an existing import line at the top of the file. If `managed-passphrase.js` is not yet imported, add the import line. If it is, extend the import list.
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+```bash
+npx vitest run --reporter=dot packages/hub/__tests__/managed-passphrase.test.ts
+```
+
+Expected: FAIL with `MemoryRecipientSealer is not defined` (or similar — the type doesn't exist yet).
+
+- [ ] **Step 3: Implement `RecipientHint`, `RecipientSealer`, `MemoryRecipientSealer`**
+
+Open `packages/hub/src/team/managed-passphrase.ts`. After the `MemorySealingKeyProvider` class (around line 150 — find the closing `}` of that class), add:
+
+```ts
+/**
+ * Public material a sender uses to seal-for-this-recipient. Published by
+ * a recipient's RecipientSealer; transported to the sender out-of-band
+ * (email, S3, in-app message). The sender obtains the hint, supplies it
+ * to writeNoydbBundle's sealedCredentials.perUser[userId].hint, and the
+ * hub seals each user's credential against it. Per foundation §11.4.
+ */
+export type RecipientHint = {
+  readonly v: 1
+  /** Recipient's provider id; matches the SealedAutoUnlockEntry.pid they'll unseal under. */
+  readonly pid: string
+  /** Algorithm the sender uses to produce the seal. Slice 1 ships RSA-OAEP-SHA256 only. */
+  readonly alg: 'rsa-oaep-sha256'
+  /** Public material — alg-specific. For 'rsa-oaep-sha256': { publicKeyPem: string }. */
+  readonly material: Readonly<Record<string, unknown>>
+}
+
+/**
+ * Handover-capable provider. Implemented additionally by asymmetric/granted
+ * providers (cloud-KMS asymmetric, Azure RSA Key Vault, AWS KMS with grant).
+ * Self-only providers (macOS Keychain, env-var, WebAuthn-PRF) do NOT
+ * implement this — the §11.2 capability matrix lives in the type system.
+ *
+ * Per foundation §11.4. A function that requires recipient-target sealing
+ * takes `RecipientSealer`, not `SealingKeyProvider` — the compiler rejects
+ * passing a self-only provider at the spec site.
+ */
+export interface RecipientSealer {
+  readonly id: string
+  /** Produce hint material a sender uses to seal-for-this-recipient. */
+  publishRecipientHint(): Promise<RecipientHint>
+  /**
+   * Seal plaintext for the recipient described by `hint`. Returns opaque
+   * bytes — same contract as `SealingKeyProvider.seal()`. The bundle
+   * layer base64-encodes the bytes into `SealedAutoUnlockEntry.sealed`
+   * without inspecting them.
+   */
+  sealForRecipient(plaintext: Uint8Array, hint: RecipientHint): Promise<Uint8Array>
+}
+
+/**
+ * Reference implementation of `RecipientSealer` + `SealingKeyProvider`.
+ * Uses WebCrypto RSA-OAEP-SHA256 (2048-bit) to wrap a fresh 32-byte
+ * AES-GCM CEK, AES-GCM-encrypts plaintext under it, and packs the
+ * result into a self-describing TLV:
+ *
+ *   byte  0       : version (0x01)
+ *   bytes 1..256  : RSA-OAEP-wrapped CEK (fixed 256 bytes at RSA-2048)
+ *   bytes 257..268: AES-GCM IV (12 bytes)
+ *   bytes 269..   : AES-GCM ciphertext ‖ 16-byte tag
+ *
+ * Implements BOTH interfaces. `seal(plaintext)` (self-target) is just
+ * `sealForRecipient(plaintext, this own hint)` — same TLV. Convenient
+ * for tests where one provider plays both ends. Real cloud providers
+ * (`at-aws-kms`, etc.) will pick their own internal layouts; the only
+ * contract is round-trip identity.
+ *
+ * SAFE for production within its scope — the cryptography is real
+ * (RSA-OAEP + AES-GCM via WebCrypto), but the keypair lives in-process
+ * and is regenerated on every construction. Not suitable as a managed
+ * keychain; use it for tests and for shipping bundles where the
+ * recipient instance lives in the same process as the sender (rare).
+ */
+export class MemoryRecipientSealer implements SealingKeyProvider, RecipientSealer {
+  readonly id: string
+  private readonly keypair: Promise<CryptoKeyPair>
+
+  constructor(opts: { id: string }) {
+    this.id = opts.id
+    this.keypair = crypto.subtle.generateKey(
+      { name: 'RSA-OAEP', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+      true,
+      ['encrypt', 'decrypt'],
+    ) as Promise<CryptoKeyPair>
+  }
+
+  async publishRecipientHint(): Promise<RecipientHint> {
+    const { publicKey } = await this.keypair
+    const spki = await crypto.subtle.exportKey('spki', publicKey)
+    const pem = '-----BEGIN PUBLIC KEY-----\n'
+      + bytesToBase64(new Uint8Array(spki)).match(/.{1,64}/g)!.join('\n')
+      + '\n-----END PUBLIC KEY-----\n'
+    return { v: 1, pid: this.id, alg: 'rsa-oaep-sha256', material: { publicKeyPem: pem } }
+  }
+
+  async sealForRecipient(plaintext: Uint8Array, hint: RecipientHint): Promise<Uint8Array> {
+    if (hint.v !== 1) {
+      throw new Error(`MemoryRecipientSealer.sealForRecipient: unsupported hint.v ${hint.v} (expected 1)`)
+    }
+    if (hint.alg !== 'rsa-oaep-sha256') {
+      throw new Error(`MemoryRecipientSealer.sealForRecipient: unsupported hint.alg '${hint.alg}' (expected 'rsa-oaep-sha256')`)
+    }
+    const pem = hint.material['publicKeyPem']
+    if (typeof pem !== 'string') {
+      throw new Error('MemoryRecipientSealer.sealForRecipient: hint.material.publicKeyPem missing or not a string')
+    }
+    // Parse PEM → SPKI bytes.
+    const b64 = pem.replace(/-----BEGIN PUBLIC KEY-----/, '').replace(/-----END PUBLIC KEY-----/, '').replace(/\s+/g, '')
+    const spki = base64ToBytes(b64)
+    const recipientPub = await crypto.subtle.importKey(
+      'spki', spki as BufferSource,
+      { name: 'RSA-OAEP', hash: 'SHA-256' },
+      false, ['encrypt'],
+    )
+    // Mint fresh CEK + IV, AES-GCM encrypt plaintext.
+    const cekBytes = crypto.getRandomValues(new Uint8Array(32))
+    const cek = await crypto.subtle.importKey('raw', cekBytes as BufferSource, 'AES-GCM', false, ['encrypt'])
+    const iv = crypto.getRandomValues(new Uint8Array(12))
+    const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv: iv as BufferSource }, cek, plaintext as BufferSource))
+    // RSA-OAEP-wrap the CEK bytes.
+    const wrapped = new Uint8Array(await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, recipientPub, cekBytes as BufferSource))
+    cekBytes.fill(0)
+    if (wrapped.length !== 256) {
+      throw new Error(`MemoryRecipientSealer.sealForRecipient: expected 256-byte RSA-OAEP wrap, got ${wrapped.length}`)
+    }
+    // TLV layout.
+    const out = new Uint8Array(1 + 256 + 12 + ct.length)
+    out[0] = 0x01
+    out.set(wrapped, 1)
+    out.set(iv, 1 + 256)
+    out.set(ct, 1 + 256 + 12)
+    return out
+  }
+
+  async seal(plaintext: Uint8Array): Promise<Uint8Array> {
+    const hint = await this.publishRecipientHint()
+    return this.sealForRecipient(plaintext, hint)
+  }
+
+  async unseal(bytes: Uint8Array): Promise<Uint8Array> {
+    if (bytes.length < 1 + 256 + 12 + 16) {
+      throw new Error('MemoryRecipientSealer.unseal: sealed input too short')
+    }
+    if (bytes[0] !== 0x01) {
+      throw new Error(`MemoryRecipientSealer.unseal: unknown TLV version ${bytes[0]}`)
+    }
+    const wrapped = bytes.subarray(1, 1 + 256)
+    const iv = bytes.subarray(1 + 256, 1 + 256 + 12)
+    const ct = bytes.subarray(1 + 256 + 12)
+    const { privateKey } = await this.keypair
+    const cekBytes = new Uint8Array(await crypto.subtle.decrypt({ name: 'RSA-OAEP' }, privateKey, wrapped as BufferSource))
+    const cek = await crypto.subtle.importKey('raw', cekBytes as BufferSource, 'AES-GCM', false, ['decrypt'])
+    const pt = new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-GCM', iv: iv as BufferSource }, cek, ct as BufferSource))
+    cekBytes.fill(0)
+    return pt
+  }
+}
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+```bash
+npx vitest run --reporter=dot packages/hub/__tests__/managed-passphrase.test.ts
+```
+
+Expected: PASS (all existing tests + the new one).
+
+- [ ] **Step 5: Add the wrong-key failure test**
+
+In the same describe block in `packages/hub/__tests__/managed-passphrase.test.ts`:
+
+```ts
+  it('unseals fail when a third-party provider tries to open someone else\'s envelope', async () => {
+    const alice = new MemoryRecipientSealer({ id: 'alice-rs' })
+    const carol = new MemoryRecipientSealer({ id: 'carol-rs' })
+    const aliceHint = await alice.publishRecipientHint()
+
+    const sender = new MemoryRecipientSealer({ id: 'sender-rs' })
+    const sealed = await sender.sealForRecipient(new TextEncoder().encode('for alice only'), aliceHint)
+
+    await expect(carol.unseal(sealed)).rejects.toThrow()
+  })
+```
+
+- [ ] **Step 6: Run tests and verify the new one passes**
+
+```bash
+npx vitest run --reporter=dot packages/hub/__tests__/managed-passphrase.test.ts
+```
+
+Expected: PASS for both new tests.
+
+- [ ] **Step 7: Add the hint round-trip test**
+
+```ts
+  it('publishRecipientHint returns a v:1 RSA-OAEP-SHA256 hint with the provider id and a PEM public key', async () => {
+    const recipient = new MemoryRecipientSealer({ id: 'belle-rs' })
+    const hint = await recipient.publishRecipientHint()
+    expect(hint.v).toBe(1)
+    expect(hint.pid).toBe('belle-rs')
+    expect(hint.alg).toBe('rsa-oaep-sha256')
+    expect(typeof hint.material['publicKeyPem']).toBe('string')
+    expect(hint.material['publicKeyPem']).toMatch(/^-----BEGIN PUBLIC KEY-----/)
+    expect(hint.material['publicKeyPem']).toMatch(/-----END PUBLIC KEY-----\n?$/)
+  })
+```
+
+- [ ] **Step 8: Run tests and confirm green**
+
+```bash
+npx vitest run --reporter=dot packages/hub/__tests__/managed-passphrase.test.ts
+```
+
+Expected: PASS (3 new tests + existing tests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/hub/src/team/managed-passphrase.ts packages/hub/__tests__/managed-passphrase.test.ts
+git commit -m "feat(hub): RecipientSealer + MemoryRecipientSealer (RSA-OAEP/AES-GCM hybrid)
+
+Adds the RecipientHint type, RecipientSealer interface, and an
+in-process MemoryRecipientSealer reference impl implementing both
+RecipientSealer and SealingKeyProvider. Hybrid scheme: RSA-OAEP-SHA256
+wraps a fresh 32-byte AES-GCM CEK, AES-GCM encrypts the plaintext,
+packed into a TLV the provider parses on unseal. Bundle layer is
+unaware — sealForRecipient returns opaque Uint8Array (same contract
+as SealingKeyProvider.seal).
+
+Per docs/superpowers/specs/2026-05-28-recipient-target-bundle-sealing-design.md."
+```
+
+---
+
+## Task 2: Re-export public surface
+
+`MemoryRecipientSealer`, `RecipientSealer`, `RecipientHint` need to be importable from the package barrel so consumers and the test file (`bundle-auto-unlock.test.ts`) can use them via `@noy-db/hub`.
+
+**Files:**
+- Modify: `packages/hub/src/index.ts`
+
+- [ ] **Step 1: Find the existing managed-passphrase re-export line**
+
+```bash
+grep -n "SealingKeyProvider\|managed-passphrase" packages/hub/src/index.ts | head
+```
+
+Expected: a line near `:488` like
+```ts
+export type { SealingKeyProvider, SealedPassphrase, SealedEnvelope } from './team/managed-passphrase.js'
+```
+and a value re-export for `MemorySealingKeyProvider` somewhere nearby.
+
+- [ ] **Step 2: Extend the type re-export**
+
+In `packages/hub/src/index.ts`, change the `export type { ... } from './team/managed-passphrase.js'` line to add `RecipientHint`, `RecipientSealer`:
+
+```ts
+export type { SealingKeyProvider, SealedPassphrase, SealedEnvelope, RecipientHint, RecipientSealer } from './team/managed-passphrase.js'
+```
+
+Find the existing `MemorySealingKeyProvider` value re-export (also in index.ts) and add `MemoryRecipientSealer` next to it:
+
+```ts
+export { MemorySealingKeyProvider, MemoryRecipientSealer } from './team/managed-passphrase.js'
+```
+
+If `MemorySealingKeyProvider` is in a different export statement form, mirror that form for `MemoryRecipientSealer`.
+
+- [ ] **Step 3: Verify tsc still compiles**
+
+```bash
+npx tsc -p packages/hub/tsconfig.json --noEmit
+```
+
+Expected: clean exit, no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/hub/src/index.ts
+git commit -m "feat(hub): re-export RecipientHint, RecipientSealer, MemoryRecipientSealer from the hub barrel"
+```
+
+---
+
+## Task 3: Extend `sealedCredentials` type with `recipient-target` arm
+
+Type-only step: discriminated union extension. No runtime behaviour change yet — `validateAutoUnlockOptions` will still reject `mode !== 'self-target'` until Task 4. This task locks the API shape so subsequent tasks can compile.
+
+**Files:**
+- Modify: `packages/hub/src/bundle/bundle.ts`
+
+- [ ] **Step 1: Find current `sealedCredentials` definition**
+
+```bash
+grep -n "readonly sealedCredentials\|readonly mode: 'self-target'" packages/hub/src/bundle/bundle.ts | head
+```
+
+Expected: the existing `sealedCredentials` type is roughly at lines 194-198:
+```ts
+readonly sealedCredentials?: {
+  readonly mode: 'self-target'
+  readonly provider: SealingKeyProvider
+  readonly perUser: Record<string, AutoCredential>
+}
+```
+
+- [ ] **Step 2: Replace `sealedCredentials` with a discriminated union**
+
+In `packages/hub/src/bundle/bundle.ts`, replace the existing `sealedCredentials?: { ... }` block (the one with `mode: 'self-target'`, NOT the deprecated `sealedPassphrases`) with:
+
+```ts
+  readonly sealedCredentials?:
+    | {
+        readonly mode: 'self-target'
+        readonly provider: SealingKeyProvider
+        readonly perUser: Record<string, AutoCredential>
+      }
+    | {
+        readonly mode: 'recipient-target'
+        readonly provider: RecipientSealer
+        readonly perUser: Record<string, { readonly credential: AutoCredential; readonly hint: RecipientHint }>
+      }
+```
+
+Update the JSDoc above it to mention the recipient-target arm (find the existing block; add a brief paragraph after "self-target" mention).
+
+- [ ] **Step 3: Add the imports**
+
+At the top of `packages/hub/src/bundle/bundle.ts`, ensure the import from `../team/managed-passphrase.js` includes `RecipientSealer` and `RecipientHint`:
+
+```ts
+import type { SealingKeyProvider, RecipientSealer, RecipientHint } from '../team/managed-passphrase.js'
+```
+
+If the import line already exists, just extend the type-only import list.
+
+- [ ] **Step 4: Extend `NormalizedAutoUnlock` to carry per-user hint + recipient-target mode**
+
+Find `interface NormalizedAutoUnlock` (around line 348). Replace it with:
+
+```ts
+interface NormalizedAutoUnlock {
+  readonly mode: 'unsealed' | 'sealed-self' | 'sealed-recipient'
+  readonly provider?: SealingKeyProvider | RecipientSealer
+  readonly perUser: Record<string, AutoCredential>
+  /** Present only for `sealed-recipient`. Same key set as `perUser`. */
+  readonly hints?: Record<string, RecipientHint>
+}
+```
+
+- [ ] **Step 5: Update `normalizeAutoUnlock` to emit the new discriminator + hints**
+
+Find `function normalizeAutoUnlock`. Replace its `sealedCredentials` branch with:
+
+```ts
+  if (opts.sealedCredentials !== undefined) {
+    if (opts.sealedCredentials.mode === 'recipient-target') {
+      const perUser: Record<string, AutoCredential> = {}
+      const hints: Record<string, RecipientHint> = {}
+      for (const [userId, entry] of Object.entries(opts.sealedCredentials.perUser)) {
+        perUser[userId] = entry.credential
+        hints[userId] = entry.hint
+      }
+      return { mode: 'sealed-recipient', provider: opts.sealedCredentials.provider, perUser, hints }
+    }
+    return { mode: 'sealed-self', provider: opts.sealedCredentials.provider, perUser: opts.sealedCredentials.perUser }
+  }
+```
+
+The existing `autoCredentials` branch returns `mode: 'unsealed'` — change `return { mode: 'unsealed', ... }` to keep that string (no rename needed). The existing `sealedPassphrases` (deprecated) branch returns `mode: 'sealed'` — change it to `mode: 'sealed-self'`. Same for the `autoPassphrases` legacy branch — no change there (it stays `'unsealed'`).
+
+Search for every remaining `mode === 'sealed'` and `mode: 'sealed'` reference in `bundle.ts` and rename to `'sealed-self'` (the validator and the wrapper builder, two call sites). Be precise — keep `'sealed-recipient'` and `'unsealed'` distinct.
+
+- [ ] **Step 6: Update `validateAutoUnlockOptions` mode-mapping return value**
+
+`validateAutoUnlockOptions` returns `'unsealed' | 'sealed' | null` (the header value). The header `autoUnlock` field is still `'unsealed' | 'sealed'` — both `sealed-self` and `sealed-recipient` map to `'sealed'` on the wire. Update the function signature and the return statements so the function still returns `'unsealed' | 'sealed' | null` but maps both sealed-self and sealed-recipient to `'sealed'`.
+
+- [ ] **Step 7: Verify tsc compiles**
+
+```bash
+npx tsc -p packages/hub/tsconfig.json --noEmit
+```
+
+Expected: clean exit. (There may still be runtime test failures because validation still rejects recipient-target — that's intentional, fixed in Task 4.)
+
+- [ ] **Step 8: Run the full hub suite to confirm no regression on existing tests**
+
+```bash
+npx vitest run --reporter=dot packages/hub/__tests__/bundle-auto-unlock.test.ts packages/hub/__tests__/managed-passphrase.test.ts
+```
+
+Expected: PASS (all existing self-target tests still green).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/hub/src/bundle/bundle.ts
+git commit -m "feat(hub): extend sealedCredentials with recipient-target arm (types only)
+
+Discriminated union on sealedCredentials.mode: 'self-target' keeps the
+current shape, 'recipient-target' takes a RecipientSealer + per-user
+{ credential, hint } map. NormalizedAutoUnlock gains a 'sealed-recipient'
+discriminator and an optional hints map. Wire-level header autoUnlock
+value still 'sealed' | 'unsealed' — both sealed-self and sealed-recipient
+map to 'sealed'. validateAutoUnlockOptions still rejects recipient-target
+at this stage (lifted in the next commit)."
+```
+
+---
+
+## Task 4: Validation — accept recipient-target
+
+Lift the "deferred per foundation §11.4" throw and add the recipient-target validation rules.
+
+**Files:**
+- Modify: `packages/hub/src/bundle/bundle.ts`
+- Test: `packages/hub/__tests__/bundle-auto-unlock.test.ts`
+
+- [ ] **Step 1: Write failing tests for the validator**
+
+At the end of `packages/hub/__tests__/bundle-auto-unlock.test.ts`, add a describe block (find the appropriate insertion point — there's a top-level describe for sealed bundle delivery; add a sibling describe):
+
+```ts
+import { MemoryRecipientSealer } from '../src/index.js'
+
+describe('recipient-target sealedCredentials — validation', () => {
+  it('rejects a recipient-target entry with a missing hint', async () => {
+    const { vault: v } = await freshVault()
+    const recipient = new MemoryRecipientSealer({ id: 'r1' })
+
+    await expect(
+      writeNoydbBundle(v, {
+        sealedCredentials: {
+          mode: 'recipient-target',
+          provider: recipient,
+          // @ts-expect-error — intentionally missing hint to test runtime guard
+          perUser: { alice: { credential: { kind: 'passphrase', value: 'p' } } },
+        },
+      }),
+    ).rejects.toThrow(/hint/)
+  })
+
+  it('rejects when hint.pid does not match the provider id', async () => {
+    const { vault: v } = await freshVault()
+    const recipient = new MemoryRecipientSealer({ id: 'r1' })
+    const otherRecipient = new MemoryRecipientSealer({ id: 'r2' })
+    const otherHint = await otherRecipient.publishRecipientHint()
+
+    await expect(
+      writeNoydbBundle(v, {
+        sealedCredentials: {
+          mode: 'recipient-target',
+          provider: recipient, // id = 'r1'
+          perUser: { alice: { credential: { kind: 'passphrase', value: 'p' }, hint: otherHint } }, // hint.pid = 'r2'
+        },
+      }),
+    ).rejects.toThrow(/pid/)
+  })
+
+  it('rejects a recipient-target mode with a self-only provider (runtime guard for JS callers)', async () => {
+    const { vault: v } = await freshVault()
+    const selfOnly = new MemorySealingKeyProvider({ id: 'self-only' })
+    const someHint = await new MemoryRecipientSealer({ id: 'r1' }).publishRecipientHint()
+
+    await expect(
+      writeNoydbBundle(v, {
+        sealedCredentials: {
+          mode: 'recipient-target',
+          // @ts-expect-error — runtime guard for JS callers; TS rejects this at compile time
+          provider: selfOnly,
+          perUser: { alice: { credential: { kind: 'passphrase', value: 'p' }, hint: someHint } },
+        },
+      }),
+    ).rejects.toThrow(/RecipientSealer/)
+  })
+})
+```
+
+(`freshVault()` is the existing helper at `bundle-auto-unlock.test.ts:69` — no args; returns `{ db, vault }`. Destructure `vault` and assign locally.)
+
+- [ ] **Step 2: Run the tests and verify they fail**
+
+```bash
+npx vitest run --reporter=dot packages/hub/__tests__/bundle-auto-unlock.test.ts -t "recipient-target sealedCredentials"
+```
+
+Expected: all 3 tests FAIL — probably with "must be 'self-target'" (the existing throw).
+
+- [ ] **Step 3: Lift the deferred throw and add recipient-target validation**
+
+In `packages/hub/src/bundle/bundle.ts`, find `validateAutoUnlockOptions` (around line 425). Find the block:
+
+```ts
+  // Sealed path.
+  const mode = opts.sealedCredentials?.mode ?? opts.sealedPassphrases?.mode
+  if (mode !== 'self-target') {
+    throw new ValidationError(
+      `writeNoydbBundle: \`sealedCredentials.mode\` (or \`sealedPassphrases.mode\`) must be `
+      + `'self-target' in slice 1 (got '${String(mode)}'). Recipient-target sealing via the `
+      + 'RecipientSealer interface is deferred per foundation §11.4.',
+    )
+  }
+```
+
+Replace it with:
+
+```ts
+  // Sealed path — branch on mode.
+  if (normalized.mode === 'sealed-recipient') {
+    const provider = normalized.provider
+    if (provider === undefined || typeof (provider as RecipientSealer).publishRecipientHint !== 'function'
+        || typeof (provider as RecipientSealer).sealForRecipient !== 'function') {
+      throw new ValidationError(
+        'writeNoydbBundle: `sealedCredentials.provider` for mode \'recipient-target\' must be a '
+        + 'RecipientSealer (publishRecipientHint + sealForRecipient). Self-only providers '
+        + '(MemorySealingKeyProvider, at-macos-keychain, etc.) do not satisfy this contract.',
+      )
+    }
+    const hints = normalized.hints
+    if (hints === undefined) {
+      throw new Error('unreachable — sealed-recipient normalization must populate hints')
+    }
+    for (const userId of Object.keys(normalized.perUser)) {
+      const hint = hints[userId]
+      if (hint === undefined) {
+        throw new ValidationError(
+          `writeNoydbBundle: \`sealedCredentials.perUser['${userId}']\` missing required \`hint\` for mode 'recipient-target'.`,
+        )
+      }
+      if (hint.v !== 1) {
+        throw new ValidationError(
+          `writeNoydbBundle: \`sealedCredentials.perUser['${userId}'].hint.v\` must be 1 (got ${hint.v}).`,
+        )
+      }
+      if (hint.alg !== 'rsa-oaep-sha256') {
+        throw new ValidationError(
+          `writeNoydbBundle: \`sealedCredentials.perUser['${userId}'].hint.alg\` must be 'rsa-oaep-sha256' in slice 1 (got '${hint.alg}').`,
+        )
+      }
+      if (hint.pid !== provider.id) {
+        throw new ValidationError(
+          `writeNoydbBundle: \`sealedCredentials.perUser['${userId}'].hint.pid\` ('${hint.pid}') does not match the provider id ('${provider.id}'). `
+          + 'Sender cannot seal for a recipient whose hint points at a different provider.',
+        )
+      }
+    }
+    const userCount = Object.keys(normalized.perUser).length
+    if (userCount === 0) {
+      throw new ValidationError(
+        'writeNoydbBundle: `sealedCredentials.perUser` must have at least one entry.',
+      )
+    }
+    return 'sealed'
+  }
+
+  // mode === 'sealed-self'
+  const selfTargetMode = opts.sealedCredentials?.mode ?? opts.sealedPassphrases?.mode
+  if (selfTargetMode !== 'self-target') {
+    throw new ValidationError(
+      `writeNoydbBundle: \`sealedCredentials.mode\` (or \`sealedPassphrases.mode\`) must be `
+      + `'self-target' or 'recipient-target' (got '${String(selfTargetMode)}').`,
+    )
+  }
+  if (normalized.provider === undefined) {
+    throw new ValidationError(
+      'writeNoydbBundle: `sealedCredentials.provider` (or `sealedPassphrases.provider`) '
+      + 'is required (a `SealingKeyProvider`).',
+    )
+  }
+  const userCount = Object.keys(normalized.perUser).length
+  if (userCount === 0) {
+    throw new ValidationError(
+      'writeNoydbBundle: `sealedCredentials.perUser` (or `sealedPassphrases.perUser`) '
+      + 'must have at least one entry.',
+    )
+  }
+  return 'sealed'
+```
+
+Make sure the `RecipientSealer` type-only import exists at the top of `bundle.ts` (added in Task 3).
+
+- [ ] **Step 4: Run the validation tests and verify they pass**
+
+```bash
+npx vitest run --reporter=dot packages/hub/__tests__/bundle-auto-unlock.test.ts -t "recipient-target sealedCredentials"
+```
+
+Expected: PASS for all 3 validation tests.
+
+- [ ] **Step 5: Run the full bundle-auto-unlock suite to confirm no regression**
+
+```bash
+npx vitest run --reporter=dot packages/hub/__tests__/bundle-auto-unlock.test.ts
+```
+
+Expected: PASS (all existing tests still green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/bundle/bundle.ts packages/hub/__tests__/bundle-auto-unlock.test.ts
+git commit -m "feat(hub): validateAutoUnlockOptions accepts mode: 'recipient-target'
+
+Checks: provider is a RecipientSealer (publishRecipientHint +
+sealForRecipient present); every perUser[k].hint is well-formed
+(v === 1, alg === 'rsa-oaep-sha256', pid matches provider.id);
+perUser non-empty. Drops the old 'deferred per foundation §11.4'
+throw. Runtime guards cover JS callers; TS callers can't reach the
+runtime checks without satisfying RecipientSealer at the type level."
+```
+
+---
+
+## Task 5: Sealing — `buildAutoUnlockWrapper` branches on mode
+
+Implement the actual sealing call for recipient-target.
+
+**Files:**
+- Modify: `packages/hub/src/bundle/bundle.ts`
+
+- [ ] **Step 1: Write a failing happy-path test**
+
+In `packages/hub/__tests__/bundle-auto-unlock.test.ts`, add a new describe block (sibling to the validation one from Task 4):
+
+```ts
+describe('recipient-target sealedCredentials — round-trip', () => {
+  it('seals for two recipients; each opens only their own credential', async () => {
+    const { vault: v } = await freshVault()
+
+    const aliceRs = new MemoryRecipientSealer({ id: 'alice-rs' })
+    const bobRs = new MemoryRecipientSealer({ id: 'bob-rs' })
+    const aliceHint = await aliceRs.publishRecipientHint()
+    const bobHint = await bobRs.publishRecipientHint()
+
+    // Sender uses a third instance — production shape: sender doesn't hold
+    // any recipient's private key.
+    const sender = new MemoryRecipientSealer({ id: 'sender-rs' })
+
+    const bytes = await writeNoydbBundle(v, {
+      sealedCredentials: {
+        mode: 'recipient-target',
+        provider: sender,
+        perUser: {
+          alice: { credential: { kind: 'passphrase', value: 'alice-pass-bundled' }, hint: aliceHint },
+          bob:   { credential: { kind: 'passphrase', value: 'bob-pass-bundled' },   hint: bobHint },
+        },
+      },
+    })
+
+    // Recipient side — alice unseals with her provider.
+    const aliceRead = await readNoydbBundle(bytes, { sealingProviders: [aliceRs] })
+    expect(aliceRead.autoUnlock?.kind).toBe('sealed')
+    expect(aliceRead.autoUnlock?.perUser.alice).toMatchObject({ kind: 'passphrase', value: 'alice-pass-bundled' })
+
+    const bobRead = await readNoydbBundle(bytes, { sealingProviders: [bobRs] })
+    expect(bobRead.autoUnlock?.perUser.bob).toMatchObject({ kind: 'passphrase', value: 'bob-pass-bundled' })
+  })
+})
+```
+
+(Note: the `readNoydbBundle` recipient lookup mechanism matches by `pid`. Both aliceRs and bobRs have unique ids; the reader picks the one matching the entry's `pid`. Confirm by reading the existing `'sealed'`-mode test that already exercises `sealingProviders` — same code path.)
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+```bash
+npx vitest run --reporter=dot packages/hub/__tests__/bundle-auto-unlock.test.ts -t "recipient-target sealedCredentials — round-trip"
+```
+
+Expected: FAIL (likely: bundle produced with no actual sealing, or with self-target seal that the recipient can't unseal).
+
+- [ ] **Step 3: Branch `buildAutoUnlockWrapper` on mode**
+
+In `packages/hub/src/bundle/bundle.ts`, find `buildAutoUnlockWrapper` (around line 496). Replace the sealed-path body (everything after the `// Sealed path —` comment) with:
+
+```ts
+  // Sealed path — branch on mode.
+  const provider = normalized.provider
+  if (provider === undefined) {
+    throw new Error('unreachable — validation should have caught this')
+  }
+  const sealedPerUser: Record<string, SealedAutoUnlockEntry> = {}
+  const encoder = new TextEncoder()
+
+  if (normalized.mode === 'sealed-recipient') {
+    const recipientSealer = provider as RecipientSealer
+    const hints = normalized.hints
+    if (hints === undefined) {
+      throw new Error('unreachable — sealed-recipient normalization must populate hints')
+    }
+    for (const [userId, cred] of Object.entries(normalized.perUser)) {
+      const hint = hints[userId]!
+      const sealed = await recipientSealer.sealForRecipient(encoder.encode(cred.value), hint)
+      sealedPerUser[userId] = {
+        pid: hint.pid,                  // use the recipient's pid, not the sender's
+        sealed: bytesToBase64(sealed),
+        alg: 'aes-256-gcm',
+        kind: cred.kind,
+        hint,
+      }
+    }
+  } else {
+    // mode === 'sealed-self'
+    const selfSealer = provider as SealingKeyProvider
+    for (const [userId, cred] of Object.entries(normalized.perUser)) {
+      const sealed = await selfSealer.seal(encoder.encode(cred.value))
+      sealedPerUser[userId] = {
+        pid: selfSealer.id,
+        sealed: bytesToBase64(sealed),
+        alg: 'aes-256-gcm',
+        kind: cred.kind,
+      }
+    }
+  }
+
+  return {
+    _noydb_bundle_body: 1,
+    dump: dumpJson,
+    _autoUnlock: { kind: 'sealed', perUser: sealedPerUser },
+  }
+```
+
+Extend `SealedAutoUnlockEntry` (find it around line 289-295) to add the optional `hint?` field:
+
+```ts
+interface SealedAutoUnlockEntry {
+  readonly pid: string
+  readonly sealed: string
+  readonly alg: 'aes-256-gcm'
+  readonly kind?: AutoCredentialKind
+  /**
+   * Recipient-target only: the RecipientHint the sender used to seal.
+   * Carried for recipient verifiability ("yes this was sealed against
+   * my published hint"). Self-target entries omit it. Pre-0.2 readers
+   * ignore unknown fields, so this is back-compatible.
+   */
+  readonly hint?: RecipientHint
+}
+```
+
+Add a type-only import for `RecipientHint` to the file's top if not already present (it was added in Task 3 — verify).
+
+- [ ] **Step 4: Run the happy-path test and verify it passes**
+
+```bash
+npx vitest run --reporter=dot packages/hub/__tests__/bundle-auto-unlock.test.ts -t "recipient-target sealedCredentials — round-trip"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add a wrong-recipient (third-party priv key) test**
+
+In the same describe block:
+
+```ts
+  it('a third-party recipient (different keypair) cannot unseal someone else\'s entry', async () => {
+    const { vault: v } = await freshVault()
+    const aliceRs = new MemoryRecipientSealer({ id: 'alice-rs' })
+    const intruderRs = new MemoryRecipientSealer({ id: 'alice-rs' }) // same id, different keypair
+    const aliceHint = await aliceRs.publishRecipientHint()
+    const sender = new MemoryRecipientSealer({ id: 'sender-rs' })
+
+    const bytes = await writeNoydbBundle(v, {
+      sealedCredentials: {
+        mode: 'recipient-target',
+        provider: sender,
+        perUser: { alice: { credential: { kind: 'passphrase', value: 'p' }, hint: aliceHint } },
+      },
+    })
+
+    // Intruder has the same pid (so the reader's dispatch finds it) but a
+    // different keypair → unseal fails inside the provider.
+    await expect(readNoydbBundle(bytes, { sealingProviders: [intruderRs] })).rejects.toThrow()
+  })
+```
+
+- [ ] **Step 6: Add a back-compat regression test**
+
+```ts
+  it('back-compat: self-target bundles still round-trip with no hint field', async () => {
+    const { vault: v } = await freshVault()
+    const selfProvider = new MemorySealingKeyProvider({ id: 'shared-keychain' })
+
+    const bytes = await writeNoydbBundle(v, {
+      sealedCredentials: {
+        mode: 'self-target',
+        provider: selfProvider,
+        perUser: { alice: { kind: 'passphrase', value: 'alice-pass-bundled' } },
+      },
+    })
+    const recipientProvider = new MemorySealingKeyProvider({ id: 'shared-keychain' })
+    const read = await readNoydbBundle(bytes, { sealingProviders: [recipientProvider] })
+    expect(read.autoUnlock?.kind).toBe('sealed')
+    expect(read.autoUnlock?.perUser.alice).toMatchObject({ kind: 'passphrase', value: 'alice-pass-bundled' })
+  })
+```
+
+- [ ] **Step 7: Run the full bundle-auto-unlock test file**
+
+```bash
+npx vitest run --reporter=dot packages/hub/__tests__/bundle-auto-unlock.test.ts
+```
+
+Expected: PASS for ALL tests (new + existing).
+
+- [ ] **Step 8: Run the full hub suite to confirm zero monorepo regressions**
+
+```bash
+npx vitest run --reporter=dot packages/hub/__tests__/
+```
+
+Expected: PASS / unchanged skipped count.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/hub/src/bundle/bundle.ts packages/hub/__tests__/bundle-auto-unlock.test.ts
+git commit -m "feat(hub): seal-for-recipient path in buildAutoUnlockWrapper
+
+Sealed-recipient mode calls provider.sealForRecipient(plaintext, hint)
+per-user and emits SealedAutoUnlockEntry{ pid: hint.pid, sealed, alg,
+kind, hint }. Sealed-self path unchanged (calls provider.seal).
+SealedAutoUnlockEntry gains optional hint field for recipient
+verifiability. Reader path is unchanged — pid dispatch + provider.unseal
+handle the hybrid envelope opaquely.
+
+Tests: two-recipient happy path, wrong-recipient (different keypair),
+self-target back-compat."
+```
+
+---
+
+## Task 6: features.yaml + bundle subsystem doc
+
+Surface the new capability.
+
+**Files:**
+- Modify: `features.yaml`
+- Modify: `docs/subsystems/bundle.md` (verify it exists first)
+
+- [ ] **Step 1: Find the `bundle` feature row**
+
+```bash
+grep -n "^  - id: bundle$" features.yaml
+```
+
+Expected: a single match around line 638.
+
+- [ ] **Step 2: Add an invariant to the `bundle` row**
+
+In `features.yaml`, find the `invariants:` list under `- id: bundle`. Append a new entry:
+
+```yaml
+      - 'auto-unlock: sealed-self (provider id matches both ends) and sealed-recipient (sender uses recipient-published RSA-OAEP hint; reader dispatches by pid, unseal handles hybrid CEK wrap opaquely) — see docs/superpowers/specs/2026-05-28-recipient-target-bundle-sealing-design.md'
+```
+
+- [ ] **Step 3: Check `docs/subsystems/bundle.md` exists**
+
+```bash
+ls -la docs/subsystems/bundle.md
+```
+
+If the file exists, add a one-paragraph note at the bottom under a `## Recipient-target sealing` heading:
+
+```markdown
+## Recipient-target sealing (slice 2)
+
+`sealedCredentials.mode: 'recipient-target'` lets a sender ship a bundle
+to a recipient whose `SealingKeyProvider` the sender does not have. The
+recipient publishes a `RecipientHint` (RSA-OAEP-SHA256 public material +
+`pid`) via any out-of-band channel; the sender passes it per-user. The
+sealing provider must implement `RecipientSealer` (`publishRecipientHint`
++ `sealForRecipient`) — handover-capable cloud-KMS providers do,
+self-only providers (`at-macos-keychain`, `at-env`) do not. The reader
+side is unchanged: `pid` dispatch finds the matching local provider,
+which transparently parses the hybrid CEK-wrap envelope inside the
+opaque `sealed` bytes. See [`recipient-target sealing
+design`](../superpowers/specs/2026-05-28-recipient-target-bundle-sealing-design.md)
+for the full spec.
+```
+
+If the file does NOT exist, skip this step — the spec reference in `features.yaml` is sufficient for this slice.
+
+- [ ] **Step 4: Run the features-yaml validator**
+
+```bash
+node scripts/validate-features.mjs 2>&1 | tail -5
+```
+
+If the script doesn't exist at that path, search:
+
+```bash
+find scripts -name "validate-features*" 2>/dev/null
+```
+
+Run whatever validator is found. Expected: no errors, no dangling refs.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add features.yaml docs/subsystems/bundle.md  # second path only if it exists and was modified
+git commit -m "docs(features): register recipient-target sealing under bundle feature
+
+Adds an invariant to the bundle feature row referencing the design spec.
+Updates docs/subsystems/bundle.md with a recipient-target slice note
+(if bundle.md exists)."
+```
+
+---
+
+## Task 7: Final verification + push + PR
+
+- [ ] **Step 1: Full monorepo lint + typecheck**
+
+```bash
+npx turbo run lint typecheck 2>&1 | tail -10
+```
+
+Expected: all turbo tasks pass.
+
+- [ ] **Step 2: Full monorepo test suite**
+
+```bash
+npx vitest run --reporter=dot 2>&1 | tail -6
+```
+
+Expected: PASS, the new test count = previous + 3 (MemoryRecipientSealer unit) + 3 (validation) + 3 (round-trip) = previous + 9.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin docs/recipient-target-bundle-sealing
+```
+
+- [ ] **Step 4: Open a draft PR linking #197**
+
+```bash
+gh pr create --draft --title "feat(hub): recipient-target bundle sealing (#197 final slice)" --body "Implements the deferred \`mode: 'recipient-target'\` arm of \`sealedCredentials\` per foundation §11.4 + the design spec committed in this branch.
+
+## What's in this PR
+
+- \`RecipientHint\` + \`RecipientSealer\` interfaces in \`team/managed-passphrase.ts\`
+- \`MemoryRecipientSealer\` reference implementation (WebCrypto RSA-OAEP-SHA256 + AES-GCM hybrid via a self-describing TLV inside the provider's opaque \`Uint8Array\`)
+- \`sealedCredentials.mode: 'recipient-target'\` arm on \`WriteNoydbBundleOptions\` (typed \`provider: RecipientSealer\`, \`perUser: Record<userId, { credential, hint }>\`)
+- \`validateAutoUnlockOptions\` checks provider satisfies \`RecipientSealer\`, every per-user \`hint\` is well-formed (\`v === 1\`, \`alg === 'rsa-oaep-sha256'\`, \`pid === provider.id\`)
+- \`buildAutoUnlockWrapper\` branches on mode and calls \`sealForRecipient\` for recipient-target entries; emits a new optional \`SealedAutoUnlockEntry.hint\` field for recipient verifiability
+- Reader path unchanged — \`pid\` dispatch finds the matching recipient provider, which transparently parses the hybrid TLV inside the opaque \`sealed\` bytes
+- Test coverage: 9 new tests across \`managed-passphrase.test.ts\` and \`bundle-auto-unlock.test.ts\` (unit, validation, two-recipient round-trip, wrong-recipient failure, self-target back-compat)
+
+## What's NOT in this PR (deferred follow-ups)
+
+- Real cloud-provider \`RecipientSealer\` impls (one issue per package: \`at-aws-kms\`, \`at-azure-keyvault\`, \`at-gcp-kms\`)
+- \`MultiRecipientSealer\` (foundation §11.4 future)
+- In-vault hint discovery via \`_meta/user/<keyringId>\` (foundation §11.4 future)
+- Recipient-target sealing for extracted-partition bundles (header mutual-exclusion stays for now)
+
+Closes #197."
+```
+
+- [ ] **Step 5: Wait for CI green; ready for review**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: all checks pass.
+
+---
+
+## Self-review checklist (do not skip)
+
+- [ ] Spec §4 interfaces match `RecipientHint`/`RecipientSealer` shape in Task 1 ✓
+- [ ] Spec §5 write-side `perUser: { credential, hint }` shape matches Task 3 ✓
+- [ ] Spec §6 wire format — `SealedAutoUnlockEntry.hint?` added in Task 5; `SealedEnvelope` untouched ✓
+- [ ] Spec §7 MemoryRecipientSealer TLV layout matches Task 1's seal/unseal byte arithmetic ✓
+- [ ] Spec §8 validation rules (hint presence, `v === 1`, `alg`, `pid === provider.id`) all in Task 4 ✓
+- [ ] Spec §10 test plan items 1-7 all present:
+  - happy path → Task 5 round-trip ✓
+  - missing hint → Task 4 validation ✓
+  - mismatched pid → Task 4 validation ✓
+  - wrong recipient → Task 5 wrong-recipient ✓
+  - mode mismatch → Task 4 validation ✓
+  - wire-format back-compat → Task 5 self-target round-trip ✓
+  - hint round-trip → implicit in Task 1's `publishRecipientHint` test + Task 5 round-trip uses hint ✓
+- [ ] Spec §11 file table matches actually-touched files in each task ✓
+- [ ] Every code block has actual, complete code (no "TBD", no "similar to Task N") ✓
+- [ ] Type/property names consistent: `RecipientHint`, `RecipientSealer`, `MemoryRecipientSealer`, `publishRecipientHint`, `sealForRecipient`, `hint`, `pid`, `v`, `alg`, `material`, `publicKeyPem` — used identically across tasks ✓
+- [ ] Mode discriminators in `NormalizedAutoUnlock` (`'sealed-self'`, `'sealed-recipient'`) consistent across Tasks 3, 4, 5 ✓
+
+---
+
+## Reference: existing code anchors
+
+| Symbol | File:line (as of branch HEAD) |
+|---|---|
+| `SealingKeyProvider` interface | `packages/hub/src/team/managed-passphrase.ts:60` |
+| `MemorySealingKeyProvider` | `packages/hub/src/team/managed-passphrase.ts:94` |
+| `SealedEnvelope` (managed-passphrase) | `packages/hub/src/team/managed-passphrase.ts:181` |
+| `sealedCredentials?: { ... }` option | `packages/hub/src/bundle/bundle.ts:194` |
+| `SealedAutoUnlockEntry` | `packages/hub/src/bundle/bundle.ts:289` |
+| `NormalizedAutoUnlock` | `packages/hub/src/bundle/bundle.ts:348` |
+| `normalizeAutoUnlock` | `packages/hub/src/bundle/bundle.ts:376` |
+| `validateAutoUnlockOptions` | `packages/hub/src/bundle/bundle.ts:425` |
+| `buildAutoUnlockWrapper` | `packages/hub/src/bundle/bundle.ts:496` |
+| `bundle` feature row | `features.yaml:638` |
+| `bundle-auto-unlock.test.ts` | `packages/hub/__tests__/bundle-auto-unlock.test.ts` |
+| `managed-passphrase.test.ts` | `packages/hub/__tests__/managed-passphrase.test.ts` |

--- a/docs/superpowers/specs/2026-05-28-recipient-target-bundle-sealing-design.md
+++ b/docs/superpowers/specs/2026-05-28-recipient-target-bundle-sealing-design.md
@@ -1,0 +1,200 @@
+# Recipient-target bundle sealing — design
+
+**Status:** spec, ready for plan
+**Issue:** #197 final slice (slice 1 `autoCredentials`/`sealedCredentials` self-target shipped in commit `5f92139`; #215 generalized to non-passphrase credentials; this slice adds the recipient-target arm)
+**Foundation reference:** [`2026-05-23-sealing-at-dimension-foundation.md`](2026-05-23-sealing-at-dimension-foundation.md) §11.3, §11.4
+**Authoring date:** 2026-05-28
+
+## 1. Context
+
+`writeNoydbBundle` already supports auto-unlock bundles in two flavours, both keyed `mode: 'self-target'`:
+
+- `autoCredentials` — plaintext `perUser` map, public-by-design (demo bundles).
+- `sealedCredentials` — `perUser` map sealed under a `SealingKeyProvider` whose `id` matches a provider the recipient holds locally (e.g. shared MDM-provisioned keychain entry).
+
+Both modes assume sender and recipient share the same provider identity. They cannot ship a bundle to a recipient whose provider the sender does not have.
+
+The foundation spec resolves this with a separate `RecipientSealer` interface (§11.4). Handover-capable providers (`at-aws-kms`, `at-gcp-kms`, `at-azure-keyvault`) implement it; symmetric providers (`at-macos-keychain`, `at-env`, etc.) do not. This slice adds the `mode: 'recipient-target'` arm to `sealedCredentials` and the validation that goes with it, defines the `RecipientSealer` interface, and ships a single in-process reference implementation (`MemoryRecipientSealer`) suitable for tests. Real cloud-provider implementations are out of scope and will land as one follow-up issue per `at-*` package.
+
+## 2. Goals
+
+- Type-system honesty: a function that requires recipient-target sealing takes `RecipientSealer`, not `SealingKeyProvider`. The compiler rejects passing a self-only provider at the spec site.
+- Wire-format invariance: a recipient-target sealed entry is indistinguishable from a self-target sealed entry past the bundle boundary. The reader path stays unchanged.
+- Reference implementation: `MemoryRecipientSealer` exercises the protocol end-to-end in tests without cloud credentials, using WebCrypto RSA-OAEP-SHA256 + AES-GCM hybrid encryption.
+- Explicit deferral surface: real `at-*` implementations are spec'd as follow-ups; the interface and validation contracts they must satisfy are pinned here.
+
+## 3. Non-goals
+
+- Real `at-*` `RecipientSealer` implementations (`at-aws-kms`, `at-azure-keyvault`, `at-gcp-kms`). One follow-up issue per package.
+- `MultiRecipientSealer` (seal once for N recipients). Foundation §11.4 future.
+- In-vault hint discovery via `_meta/user/<keyringId>`. Foundation §11.4 future.
+- Recipient-target sealing on extracted-partition bundles. The header mutual-exclusion between `bundleKind === 'extracted-partition'` and `autoUnlock` stays; composing the two is a separate design exercise tied to `#197`'s motivating customer-pre-delivery flow.
+- Algorithm agility. This slice ships exactly one algorithm: `'rsa-oaep-sha256'`. Adding `'kms-encrypt-cross-account'` and friends is per-package follow-up work that extends the `RecipientHint.alg` union.
+
+## 4. Interfaces
+
+In `packages/hub/src/team/managed-passphrase.ts` (next to `SealingKeyProvider`):
+
+```ts
+/**
+ * Public material a sender uses to seal-for-this-recipient. Published by
+ * a recipient's RecipientSealer; transported to the sender out-of-band
+ * (email, S3, in-app message). The sender obtains the hint, supplies it
+ * to writeNoydbBundle, and the hub seals each user's credential against
+ * it. Verbatim per foundation §11.4.
+ */
+export type RecipientHint = {
+  readonly v: 1
+  /** Recipient's provider id; matches the SealedEnvelope.pid they'll unseal under. */
+  readonly pid: string
+  /** Algorithm the sender uses to produce the seal. */
+  readonly alg: 'rsa-oaep-sha256'
+  /** Public material — alg-specific. For 'rsa-oaep-sha256': { publicKeyPem: string }. */
+  readonly material: Readonly<Record<string, unknown>>
+}
+
+/**
+ * Handover-capable provider. Implemented additionally by asymmetric/granted
+ * providers (cloud-KMS asymmetric, Azure RSA Key Vault, AWS KMS with grant).
+ * Self-only providers (macOS Keychain, env-var, WebAuthn-PRF) do NOT
+ * implement this — the §11.2 capability matrix lives in the type system.
+ */
+export interface RecipientSealer {
+  readonly id: string
+  /** Produce hint material a sender uses to seal-for-this-recipient. */
+  publishRecipientHint(): Promise<RecipientHint>
+  /** Seal plaintext for the recipient described by hint. */
+  sealForRecipient(plaintext: Uint8Array, hint: RecipientHint): Promise<SealedEnvelope>
+}
+```
+
+`SealedEnvelope` is unchanged in its required fields but gains one optional field to carry the hybrid wrapping key (see §6).
+
+## 5. Write-side API
+
+Extend the existing `sealedCredentials` option on `writeNoydbBundle` with a discriminated `recipient-target` arm:
+
+```ts
+sealedCredentials: {
+  mode: 'recipient-target'
+  provider: RecipientSealer
+  perUser: Record<string, { credential: AutoCredential; hint: RecipientHint }>
+}
+```
+
+The `mode: 'self-target'` arm is unchanged. Mutual-exclusion with `autoCredentials`, `autoPassphrases`, `sealedPassphrases` is unchanged.
+
+Per-user payload shape is inline `{ credential, hint }` rather than a parallel `recipientHints` map. Two reasons: (1) it forbids the structurally-invalid state of having a `credential` for a user with no `hint` (or vice versa); (2) it matches the foundation §11.4 sketch verbatim.
+
+## 6. Wire format
+
+`SealedAutoUnlockEntry` in `packages/hub/src/bundle/bundle.ts` gains one optional field:
+
+```ts
+interface SealedAutoUnlockEntry {
+  readonly pid: string
+  readonly sealed: string                    // base64 hybrid-encrypted bytes
+  readonly alg: 'aes-256-gcm'                // outer-AEAD identifier; UNCHANGED
+  readonly kind?: AutoCredentialKind
+  readonly hint?: Record<string, unknown>    // NEW — present for recipient-target only, opaque to reader
+}
+```
+
+The `hint` field is included for recipient verifiability — a recipient can confirm "yes this was sealed against my published hint" before unsealing. Readers may ignore it. Self-target entries omit it. Pre-0.2 readers ignore unknown fields, so this is back-compatible.
+
+`SealedEnvelope` gains one optional field to carry the RSA-wrapped CEK:
+
+```ts
+interface SealedEnvelope {
+  readonly pid: string
+  readonly sealed: string
+  readonly alg: 'aes-256-gcm'
+  readonly wrappedKey?: string               // NEW — base64 RSA-OAEP-wrapped 32-byte AES key
+}
+```
+
+**Hybrid scheme.** RSA-OAEP-SHA256 cannot encrypt arbitrary-length plaintext (limited to ~190 bytes at 2048-bit). The sender mints a fresh 32-byte CEK, AES-GCM-encrypts the plaintext under it, RSA-OAEP-wraps the CEK with the recipient's public key, and packs both into the envelope. `sealed` is the AES-GCM ciphertext (layout `iv(12) ‖ ct ‖ tag`); `wrappedKey` is the RSA-OAEP-wrapped CEK. The recipient's `unseal()` checks `wrappedKey` presence, RSA-unwraps the CEK with their private key, then AES-GCM-decrypts.
+
+This keeps `alg: 'aes-256-gcm'` invariant across modes — the unseal dispatcher sees the same outer AEAD regardless of how the CEK arrived. `wrappedKey === undefined` means self-target (CEK derived from the provider's symmetric key, current behaviour); `wrappedKey !== undefined` means hybrid recipient-target.
+
+## 7. `MemoryRecipientSealer` reference implementation
+
+In `packages/hub/src/team/managed-passphrase.ts`, next to `MemorySealingKeyProvider`. Implements **both** `SealingKeyProvider` and `RecipientSealer` — a single instance generates an RSA-2048 keypair on construction, can publish its own hint, can seal under any other instance's hint, and can unseal envelopes addressed to its own `pid`.
+
+```ts
+export class MemoryRecipientSealer implements SealingKeyProvider, RecipientSealer {
+  readonly id: string
+  private readonly keypair: Promise<CryptoKeyPair>
+
+  constructor(opts: { id: string }) {
+    this.id = opts.id
+    this.keypair = crypto.subtle.generateKey(
+      { name: 'RSA-OAEP', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+      true, ['encrypt', 'decrypt'],
+    ) as Promise<CryptoKeyPair>
+  }
+
+  async publishRecipientHint(): Promise<RecipientHint> { /* export SPKI PEM */ }
+  async sealForRecipient(plaintext: Uint8Array, hint: RecipientHint): Promise<SealedEnvelope> { /* import pem, hybrid encrypt */ }
+  async seal(plaintext: Uint8Array): Promise<SealedEnvelope> { /* self-target: same as sealForRecipient against own published hint */ }
+  async unseal(env: SealedEnvelope): Promise<Uint8Array> { /* RSA-unwrap CEK, AES-GCM decrypt */ }
+}
+```
+
+`seal()` (the `SealingKeyProvider` self-target operation) is implemented as `sealForRecipient(plaintext, await this.publishRecipientHint())` — convenient for tests that need a provider that can do both ends, mirrors how `at-aws-kms` (which has both interfaces) will behave.
+
+## 8. Validation
+
+In `validateAutoUnlockOptions`:
+
+- The existing `mode: 'self-target'` arm: unchanged.
+- New `mode: 'recipient-target'` arm: verify `typeof provider.publishRecipientHint === 'function' && typeof provider.sealForRecipient === 'function'` (runtime guard for JS callers; TS callers can't reach this without satisfying `RecipientSealer`). Verify every `perUser[userId].hint` is present, well-formed (`v === 1`, non-empty `pid`, supported `alg`), and that `hint.pid === provider.id` (sender cannot seal for a recipient whose hint points at a different provider).
+- The previous "deferred per foundation §11.4" `ValidationError` is removed.
+- Cross-arm mutual-exclusion with `autoCredentials` / `autoPassphrases` / `sealedPassphrases` is unchanged.
+
+## 9. Read-side API
+
+API surface unchanged. The recipient calls `readNoydbBundle(bytes, { sealingProviders: [memoryRecipientSealerInstance] })` exactly as for self-target bundles. `pid` dispatch finds the matching provider; the provider's `unseal()` implementation grows a branch on `wrappedKey` presence to handle hybrid envelopes (RSA-OAEP-unwrap CEK, then AES-GCM-decrypt). No new option or code path in the bundle reader itself — the hybrid handling lives entirely inside the provider's `unseal()`.
+
+## 10. Test plan
+
+New describe block `recipient-target sealedCredentials` in `packages/hub/__tests__/bundle-auto-unlock.test.ts`:
+
+1. **happy path** — two `MemoryRecipientSealer` instances (`alice-rs`, `bob-rs`), each publishes a hint, sender writes bundle with `mode: 'recipient-target'` and the two hints, two readers unseal under their respective providers, each gets the right plaintext.
+2. **missing hint** — a per-user entry without `hint` → write-side `ValidationError` citing the offending `userId`.
+3. **mismatched pid** — `hint.pid !== provider.id` for some user → write-side `ValidationError`.
+4. **wrong recipient** — third-party provider (different keypair) tries to unseal → AES-GCM auth-tag failure surfaced as the standard unseal error.
+5. **mode mismatch** — passing `mode: 'recipient-target'` with a self-only provider (no `publishRecipientHint`/`sealForRecipient`) → runtime `ValidationError`. (TS callers can't reach this; covered for JS interop.)
+6. **wire-format back-compat** — a bundle written with `mode: 'self-target'` reads unchanged (no `hint` field, no `wrappedKey` field).
+7. **hint round-trip** — recipient confirms `entry.hint?.pid === recipient.id` before unsealing (demonstrates the verifiability use case).
+
+`MemoryRecipientSealer` itself gets a focused unit test (round-trip seal/unseal, wrong-key failure).
+
+## 11. Files touched
+
+| File | Change |
+|---|---|
+| `packages/hub/src/team/managed-passphrase.ts` | `RecipientHint` type, `RecipientSealer` interface, `MemoryRecipientSealer` class. Add `wrappedKey?: string` to `SealedEnvelope`. |
+| `packages/hub/src/bundle/bundle.ts` | `sealedCredentials.mode: 'recipient-target'` arm. `SealedAutoUnlockEntry.hint?` field. `validateAutoUnlockOptions` recipient-target arm + removal of "deferred per §11.4" `ValidationError`. Write-side hybrid encrypt path. |
+| `packages/hub/src/index.ts` | Re-export `RecipientHint`, `RecipientSealer`, `MemoryRecipientSealer`. |
+| `packages/hub/__tests__/bundle-auto-unlock.test.ts` | New `recipient-target sealedCredentials` describe block (7 tests). |
+| `packages/hub/__tests__/managed-passphrase.test.ts` | `MemoryRecipientSealer` unit test (round-trip seal/unseal, wrong-key failure). |
+| `features.yaml` | Update the existing `bundle-auto-unlock` feature row to reflect `recipient-target` capability. Reference this spec under `specs:`. |
+| `docs/subsystems/bundle.md` | One-paragraph note on recipient-target with link to this spec and foundation §11.4. (Skipped if the file doesn't exist; deferred to a follow-up if so. Verify at implementation time.) |
+
+## 12. Follow-ups (NOT in this PR)
+
+- `at-aws-kms` `RecipientSealer` implementation using KMS asymmetric encrypt (`Encrypt` API, `EncryptionAlgorithm: 'RSAES_OAEP_SHA_256'`). New issue.
+- `at-azure-keyvault` `RecipientSealer` using RSA Key Vault `wrapKey` / `unwrapKey`. New issue.
+- `at-gcp-kms` `RecipientSealer` using asymmetric Cloud KMS `asymmetricDecrypt`. New issue.
+- `RecipientHint.alg = 'kms-encrypt-cross-account'` (AWS KMS grant-based seal where the sender doesn't see the public key). Per-package design decision.
+- `MultiRecipientSealer` interface (seal a single bundle CEK once, wrap it N times under N recipient hints). Foundation §11.4 future.
+- In-vault hint discovery: read recipient hints from `_meta/user/<keyringId>` so the sender doesn't need to handle them OOB. Foundation §11.4 future.
+- Recipient-target sealing for extracted-partition bundles: lift the `bundleKind === 'extracted-partition'` ↔ `autoUnlock` mutual-exclusion under a policy flag, so the partition's `transferKey` can be delivered sealed inside the bundle rather than OOB. Separate design — security review needed because it changes the trust model of the transfer ceremony.
+
+## 13. Risks and review points
+
+- **Hybrid envelope correctness.** The CEK lifecycle has to be tight: minted per-seal (never reused across users), AES-GCM IV minted per-seal (never reused under the same CEK), CEK zeroed after wrapping. The reference impl pins these in code with comments.
+- **Hint-mismatch detection.** `hint.pid !== provider.id` at write time catches the "sealing under the wrong recipient's published material" mistake. Tests cover this explicitly.
+- **Read-path regressions.** Adding `wrappedKey` to `SealedEnvelope` is the only field touching the existing self-target path. Test 6 pins back-compat: a self-target bundle reads unchanged.
+- **Algorithm scope.** Pinning `alg: 'rsa-oaep-sha256'` as the only supported algorithm in this slice avoids a premature union. The first cloud-provider follow-up will extend it (e.g. `'kms-encrypt-cross-account'`).

--- a/docs/superpowers/specs/2026-05-28-recipient-target-bundle-sealing-design.md
+++ b/docs/superpowers/specs/2026-05-28-recipient-target-bundle-sealing-design.md
@@ -63,12 +63,17 @@ export interface RecipientSealer {
   readonly id: string
   /** Produce hint material a sender uses to seal-for-this-recipient. */
   publishRecipientHint(): Promise<RecipientHint>
-  /** Seal plaintext for the recipient described by hint. */
-  sealForRecipient(plaintext: Uint8Array, hint: RecipientHint): Promise<SealedEnvelope>
+  /**
+   * Seal plaintext for the recipient described by hint. Returns opaque
+   * bytes — same contract as `SealingKeyProvider.seal()`. The bundle
+   * layer base64-encodes the bytes into `SealedAutoUnlockEntry.sealed`
+   * without inspecting them.
+   */
+  sealForRecipient(plaintext: Uint8Array, hint: RecipientHint): Promise<Uint8Array>
 }
 ```
 
-`SealedEnvelope` is unchanged in its required fields but gains one optional field to carry the hybrid wrapping key (see §6).
+`SealedEnvelope` (the `_meta/sealed-passphrase` envelope used by managed-mode vaults) is **not** touched. Recipient-target sealing is bundle-layer only.
 
 ## 5. Write-side API
 
@@ -88,34 +93,34 @@ Per-user payload shape is inline `{ credential, hint }` rather than a parallel `
 
 ## 6. Wire format
 
+The bundle layer only sees opaque bytes — `SealingKeyProvider.seal()` and `RecipientSealer.sealForRecipient()` both return `Uint8Array`, and the bundle base64-encodes them into `SealedAutoUnlockEntry.sealed`. The hybrid scheme lives entirely **inside** the provider's opaque blob, not at the bundle layer.
+
 `SealedAutoUnlockEntry` in `packages/hub/src/bundle/bundle.ts` gains one optional field:
 
 ```ts
 interface SealedAutoUnlockEntry {
   readonly pid: string
-  readonly sealed: string                    // base64 hybrid-encrypted bytes
-  readonly alg: 'aes-256-gcm'                // outer-AEAD identifier; UNCHANGED
+  readonly sealed: string                    // base64 — provider-opaque; may contain hybrid TLV internally
+  readonly alg: 'aes-256-gcm'                // unchanged; provider-attested outer AEAD
   readonly kind?: AutoCredentialKind
-  readonly hint?: Record<string, unknown>    // NEW — present for recipient-target only, opaque to reader
+  readonly hint?: Record<string, unknown>    // NEW — present for recipient-target only
 }
 ```
 
-The `hint` field is included for recipient verifiability — a recipient can confirm "yes this was sealed against my published hint" before unsealing. Readers may ignore it. Self-target entries omit it. Pre-0.2 readers ignore unknown fields, so this is back-compatible.
+The `hint` field is for recipient verifiability — a recipient can confirm "yes this was sealed against my published hint" before unsealing. Self-target entries omit it. Pre-0.2 readers ignore unknown fields, so this is back-compatible.
 
-`SealedEnvelope` gains one optional field to carry the RSA-wrapped CEK:
+`SealedEnvelope` (the `_meta/sealed-passphrase` envelope used by managed-mode vaults, NOT the bundle entry) is unchanged — recipient-target sealing is a bundle-level concept; vault-level sealing always operates on the vault owner's own provider.
 
-```ts
-interface SealedEnvelope {
-  readonly pid: string
-  readonly sealed: string
-  readonly alg: 'aes-256-gcm'
-  readonly wrappedKey?: string               // NEW — base64 RSA-OAEP-wrapped 32-byte AES key
-}
+**Hybrid scheme — internal to the provider's opaque bytes.** RSA-OAEP-SHA256 cannot encrypt arbitrary-length plaintext (limited to ~190 bytes at 2048-bit). `MemoryRecipientSealer.sealForRecipient(plaintext, hint)` mints a fresh 32-byte CEK, AES-GCM-encrypts the plaintext under it, RSA-OAEP-wraps the CEK with the recipient's public key, and concatenates a self-describing TLV into the returned `Uint8Array`:
+
+```
+byte  0       : version (0x01)
+bytes 1..256  : RSA-OAEP-wrapped CEK (fixed 256 bytes at RSA-2048)
+bytes 257..268: AES-GCM IV (12 bytes)
+bytes 269..   : AES-GCM ciphertext ‖ 16-byte tag
 ```
 
-**Hybrid scheme.** RSA-OAEP-SHA256 cannot encrypt arbitrary-length plaintext (limited to ~190 bytes at 2048-bit). The sender mints a fresh 32-byte CEK, AES-GCM-encrypts the plaintext under it, RSA-OAEP-wraps the CEK with the recipient's public key, and packs both into the envelope. `sealed` is the AES-GCM ciphertext (layout `iv(12) ‖ ct ‖ tag`); `wrappedKey` is the RSA-OAEP-wrapped CEK. The recipient's `unseal()` checks `wrappedKey` presence, RSA-unwraps the CEK with their private key, then AES-GCM-decrypts.
-
-This keeps `alg: 'aes-256-gcm'` invariant across modes — the unseal dispatcher sees the same outer AEAD regardless of how the CEK arrived. `wrappedKey === undefined` means self-target (CEK derived from the provider's symmetric key, current behaviour); `wrappedKey !== undefined` means hybrid recipient-target.
+`MemoryRecipientSealer.unseal(bytes)` parses the TLV, RSA-unwraps the CEK with its private key, AES-GCM-decrypts. The bundle layer is unaware of any of this — it just stores the base64 and dispatches by `pid`. Future cloud-provider implementations (`at-aws-kms`, etc.) are free to use their own opaque layouts; the only contract is that `sealForRecipient(p, hint).then(unseal)` is the identity.
 
 ## 7. `MemoryRecipientSealer` reference implementation
 
@@ -135,9 +140,9 @@ export class MemoryRecipientSealer implements SealingKeyProvider, RecipientSeale
   }
 
   async publishRecipientHint(): Promise<RecipientHint> { /* export SPKI PEM */ }
-  async sealForRecipient(plaintext: Uint8Array, hint: RecipientHint): Promise<SealedEnvelope> { /* import pem, hybrid encrypt */ }
-  async seal(plaintext: Uint8Array): Promise<SealedEnvelope> { /* self-target: same as sealForRecipient against own published hint */ }
-  async unseal(env: SealedEnvelope): Promise<Uint8Array> { /* RSA-unwrap CEK, AES-GCM decrypt */ }
+  async sealForRecipient(plaintext: Uint8Array, hint: RecipientHint): Promise<Uint8Array> { /* import pem, hybrid encrypt, return TLV bytes */ }
+  async seal(plaintext: Uint8Array): Promise<Uint8Array> { /* self-target: sealForRecipient against own published hint */ }
+  async unseal(bytes: Uint8Array): Promise<Uint8Array> { /* parse TLV, RSA-unwrap CEK, AES-GCM decrypt */ }
 }
 ```
 

--- a/docs/superpowers/specs/2026-05-28-recipient-target-bundle-sealing-design.md
+++ b/docs/superpowers/specs/2026-05-28-recipient-target-bundle-sealing-design.md
@@ -153,13 +153,13 @@ export class MemoryRecipientSealer implements SealingKeyProvider, RecipientSeale
 In `validateAutoUnlockOptions`:
 
 - The existing `mode: 'self-target'` arm: unchanged.
-- New `mode: 'recipient-target'` arm: verify `typeof provider.publishRecipientHint === 'function' && typeof provider.sealForRecipient === 'function'` (runtime guard for JS callers; TS callers can't reach this without satisfying `RecipientSealer`). Verify every `perUser[userId].hint` is present, well-formed (`v === 1`, non-empty `pid`, supported `alg`), and that `hint.pid === provider.id` (sender cannot seal for a recipient whose hint points at a different provider).
+- New `mode: 'recipient-target'` arm: verify `typeof provider.publishRecipientHint === 'function' && typeof provider.sealForRecipient === 'function'` (runtime guard for JS callers; TS callers can't reach this without satisfying `RecipientSealer`). Verify every `perUser[userId].hint` is present, well-formed (`v === 1`, supported `alg`), and that `hint.pid` is a non-empty string identifying the recipient (the dispatch key the reader's `pid` lookup matches against the recipient's local provider). NOTE: `hint.pid` deliberately need not match the sender's `provider.id` — in recipient-target mode the sender and recipient are different parties.
 - The previous "deferred per foundation §11.4" `ValidationError` is removed.
 - Cross-arm mutual-exclusion with `autoCredentials` / `autoPassphrases` / `sealedPassphrases` is unchanged.
 
 ## 9. Read-side API
 
-API surface unchanged. The recipient calls `readNoydbBundle(bytes, { sealingProviders: [memoryRecipientSealerInstance] })` exactly as for self-target bundles. `pid` dispatch finds the matching provider; the provider's `unseal()` implementation grows a branch on `wrappedKey` presence to handle hybrid envelopes (RSA-OAEP-unwrap CEK, then AES-GCM-decrypt). No new option or code path in the bundle reader itself — the hybrid handling lives entirely inside the provider's `unseal()`.
+API surface unchanged. The recipient calls `readNoydbBundle(bytes, { sealingProviders: [memoryRecipientSealerInstance] })` exactly as for self-target bundles. `pid` dispatch finds the matching provider; the provider's `unseal()` implementation transparently parses the hybrid TLV inside the opaque `sealed` bytes (RSA-OAEP-unwrap CEK, then AES-GCM-decrypt) — entirely internal to the provider, the bundle layer sees only opaque `Uint8Array`. No new option or code path in the bundle reader itself — the hybrid handling lives entirely inside the provider's `unseal()`.
 
 ## 10. Test plan
 
@@ -167,11 +167,11 @@ New describe block `recipient-target sealedCredentials` in `packages/hub/__tests
 
 1. **happy path** — two `MemoryRecipientSealer` instances (`alice-rs`, `bob-rs`), each publishes a hint, sender writes bundle with `mode: 'recipient-target'` and the two hints, two readers unseal under their respective providers, each gets the right plaintext.
 2. **missing hint** — a per-user entry without `hint` → write-side `ValidationError` citing the offending `userId`.
-3. **mismatched pid** — `hint.pid !== provider.id` for some user → write-side `ValidationError`.
+3. **mismatched alg** — `hint.alg !== 'rsa-oaep-sha256'` → write-side `ValidationError`. (The shipped design intentionally does NOT enforce `hint.pid === provider.id`, since sender and recipient are different parties.)
 4. **wrong recipient** — third-party provider (different keypair) tries to unseal → AES-GCM auth-tag failure surfaced as the standard unseal error.
 5. **mode mismatch** — passing `mode: 'recipient-target'` with a self-only provider (no `publishRecipientHint`/`sealForRecipient`) → runtime `ValidationError`. (TS callers can't reach this; covered for JS interop.)
 6. **wire-format back-compat** — a bundle written with `mode: 'self-target'` reads unchanged (no `hint` field, no `wrappedKey` field).
-7. **hint round-trip** — recipient confirms `entry.hint?.pid === recipient.id` before unsealing (demonstrates the verifiability use case).
+7. **hint round-trip** — verifiability is covered implicitly by the wrong-recipient test (different keypair → AES-GCM auth-tag failure); an explicit `entry.hint?.pid === recipient.id` round-trip test is a follow-up for the cloud-KMS slices.
 
 `MemoryRecipientSealer` itself gets a focused unit test (round-trip seal/unseal, wrong-key failure).
 
@@ -179,7 +179,7 @@ New describe block `recipient-target sealedCredentials` in `packages/hub/__tests
 
 | File | Change |
 |---|---|
-| `packages/hub/src/team/managed-passphrase.ts` | `RecipientHint` type, `RecipientSealer` interface, `MemoryRecipientSealer` class. Add `wrappedKey?: string` to `SealedEnvelope`. |
+| `packages/hub/src/team/managed-passphrase.ts` | `RecipientHint` type, `RecipientSealer` interface, `MemoryRecipientSealer` class. |
 | `packages/hub/src/bundle/bundle.ts` | `sealedCredentials.mode: 'recipient-target'` arm. `SealedAutoUnlockEntry.hint?` field. `validateAutoUnlockOptions` recipient-target arm + removal of "deferred per §11.4" `ValidationError`. Write-side hybrid encrypt path. |
 | `packages/hub/src/index.ts` | Re-export `RecipientHint`, `RecipientSealer`, `MemoryRecipientSealer`. |
 | `packages/hub/__tests__/bundle-auto-unlock.test.ts` | New `recipient-target sealedCredentials` describe block (7 tests). |
@@ -200,6 +200,6 @@ New describe block `recipient-target sealedCredentials` in `packages/hub/__tests
 ## 13. Risks and review points
 
 - **Hybrid envelope correctness.** The CEK lifecycle has to be tight: minted per-seal (never reused across users), AES-GCM IV minted per-seal (never reused under the same CEK), CEK zeroed after wrapping. The reference impl pins these in code with comments.
-- **Hint-mismatch detection.** `hint.pid !== provider.id` at write time catches the "sealing under the wrong recipient's published material" mistake. Tests cover this explicitly.
-- **Read-path regressions.** Adding `wrappedKey` to `SealedEnvelope` is the only field touching the existing self-target path. Test 6 pins back-compat: a self-target bundle reads unchanged.
+- **Hint-mismatch detection.** `hint.pid` non-emptiness check at write time catches the "empty dispatch key" mistake. Tests cover this explicitly.
+- **Read-path regressions.** Reader behaviour with multi-recipient bundles is the only meaningful new behaviour on the read path. The hint-discriminated pass-through (entries with `hint !== undefined` that don't match any provided sealing provider are surfaced as opaque base64 rather than throwing `BundleSealMismatchError`) maintains the existing inspection-mode contract for self-target bundles. Test 6 pins back-compat: a self-target bundle reads unchanged with no `hint` field on entries.
 - **Algorithm scope.** Pinning `alg: 'rsa-oaep-sha256'` as the only supported algorithm in this slice avoids a premature union. The first cloud-provider follow-up will extend it (e.g. `'kms-encrypt-cross-account'`).

--- a/features.yaml
+++ b/features.yaml
@@ -653,6 +653,7 @@ features:
       - '10-byte magic prefix (NDB1) + JSON header + compressed body'
       - 'Body integrity hash — readNoydbBundle rejects tampered files'
       - 'ULID handle in header for safe cloud-storage drops'
+      - 'auto-unlock: sealed-self (provider id matches both ends) and sealed-recipient (sender uses recipient-published RSA-OAEP hint; reader dispatches by pid, unseal handles hybrid CEK wrap opaquely) — see docs/superpowers/specs/2026-05-28-recipient-target-bundle-sealing-design.md'
     related: [history, vault-and-collections]
 
   - id: transferable-partition

--- a/packages/hub/__tests__/bundle-auto-unlock.test.ts
+++ b/packages/hub/__tests__/bundle-auto-unlock.test.ts
@@ -17,6 +17,7 @@ import {
   readNoydbBundle,
   readNoydbBundleHeader,
   MemorySealingKeyProvider,
+  MemoryRecipientSealer,
   BundleSealMismatchError,
   ValidationError,
 } from '../src/index.js'
@@ -634,5 +635,57 @@ describe('#215 — unsupported credential kind rejected', () => {
       const msg = (err as Error).message
       return /webauthn/i.test(msg)
     })
+  })
+})
+
+describe('recipient-target sealedCredentials — validation', () => {
+  it('rejects a recipient-target entry with a missing hint', async () => {
+    const { vault: v } = await freshVault()
+    const recipient = new MemoryRecipientSealer({ id: 'r1' })
+
+    await expect(
+      writeNoydbBundle(v, {
+        sealedCredentials: {
+          mode: 'recipient-target',
+          provider: recipient,
+          // @ts-expect-error — intentionally missing hint to test runtime guard
+          perUser: { alice: { credential: { kind: 'passphrase', value: 'p' } } },
+        },
+      }),
+    ).rejects.toThrow(/hint/)
+  })
+
+  it('rejects when hint.pid does not match the provider id', async () => {
+    const { vault: v } = await freshVault()
+    const recipient = new MemoryRecipientSealer({ id: 'r1' })
+    const otherRecipient = new MemoryRecipientSealer({ id: 'r2' })
+    const otherHint = await otherRecipient.publishRecipientHint()
+
+    await expect(
+      writeNoydbBundle(v, {
+        sealedCredentials: {
+          mode: 'recipient-target',
+          provider: recipient, // id = 'r1'
+          perUser: { alice: { credential: { kind: 'passphrase', value: 'p' }, hint: otherHint } }, // hint.pid = 'r2'
+        },
+      }),
+    ).rejects.toThrow(/pid/)
+  })
+
+  it('rejects a recipient-target mode with a self-only provider (runtime guard for JS callers)', async () => {
+    const { vault: v } = await freshVault()
+    const selfOnly = new MemorySealingKeyProvider({ id: 'self-only' })
+    const someHint = await new MemoryRecipientSealer({ id: 'r1' }).publishRecipientHint()
+
+    await expect(
+      writeNoydbBundle(v, {
+        sealedCredentials: {
+          mode: 'recipient-target',
+          // @ts-expect-error — runtime guard for JS callers; TS rejects this at compile time
+          provider: selfOnly,
+          perUser: { alice: { credential: { kind: 'passphrase', value: 'p' }, hint: someHint } },
+        },
+      }),
+    ).rejects.toThrow(/RecipientSealer/)
   })
 })

--- a/packages/hub/__tests__/bundle-auto-unlock.test.ts
+++ b/packages/hub/__tests__/bundle-auto-unlock.test.ts
@@ -690,6 +690,22 @@ describe('recipient-target sealedCredentials — validation', () => {
       }),
     ).rejects.toThrow(/RecipientSealer/)
   })
+
+  it('rejects a recipient-target entry with an empty hint.pid', async () => {
+    const { vault: v } = await freshVault()
+    const recipient = new MemoryRecipientSealer({ id: 'r1' })
+    const validHint = await recipient.publishRecipientHint()
+    const emptyPidHint = { ...validHint, pid: '' }
+    await expect(
+      writeNoydbBundle(v, {
+        sealedCredentials: {
+          mode: 'recipient-target',
+          provider: recipient,
+          perUser: { alice: { credential: { kind: 'passphrase', value: 'p' }, hint: emptyPidHint } },
+        },
+      }),
+    ).rejects.toThrow(/pid/)
+  })
 })
 
 describe('recipient-target sealedCredentials — round-trip', () => {

--- a/packages/hub/__tests__/bundle-auto-unlock.test.ts
+++ b/packages/hub/__tests__/bundle-auto-unlock.test.ts
@@ -655,21 +655,23 @@ describe('recipient-target sealedCredentials — validation', () => {
     ).rejects.toThrow(/hint/)
   })
 
-  it('rejects when hint.pid does not match the provider id', async () => {
+  it('rejects when hint.alg is not rsa-oaep-sha256', async () => {
     const { vault: v } = await freshVault()
     const recipient = new MemoryRecipientSealer({ id: 'r1' })
-    const otherRecipient = new MemoryRecipientSealer({ id: 'r2' })
-    const otherHint = await otherRecipient.publishRecipientHint()
+    const goodHint = await recipient.publishRecipientHint()
+    // Craft a hint with an unsupported alg — RecipientHint.alg is typed but
+    // the validator's runtime guard must also catch it for JS callers.
+    const badHint = { ...goodHint, alg: 'unsupported-alg' } as unknown as typeof goodHint
 
     await expect(
       writeNoydbBundle(v, {
         sealedCredentials: {
           mode: 'recipient-target',
-          provider: recipient, // id = 'r1'
-          perUser: { alice: { credential: { kind: 'passphrase', value: 'p' }, hint: otherHint } }, // hint.pid = 'r2'
+          provider: recipient,
+          perUser: { alice: { credential: { kind: 'passphrase', value: 'p' }, hint: badHint } },
         },
       }),
-    ).rejects.toThrow(/pid/)
+    ).rejects.toThrow(/rsa-oaep-sha256/)
   })
 
   it('rejects a recipient-target mode with a self-only provider (runtime guard for JS callers)', async () => {
@@ -687,5 +689,78 @@ describe('recipient-target sealedCredentials — validation', () => {
         },
       }),
     ).rejects.toThrow(/RecipientSealer/)
+  })
+})
+
+describe('recipient-target sealedCredentials — round-trip', () => {
+  it('seals for two recipients; each opens only their own credential', async () => {
+    const { vault: v } = await freshVault()
+
+    const aliceRs = new MemoryRecipientSealer({ id: 'alice-rs' })
+    const bobRs = new MemoryRecipientSealer({ id: 'bob-rs' })
+    const aliceHint = await aliceRs.publishRecipientHint()
+    const bobHint = await bobRs.publishRecipientHint()
+
+    // Sender uses a third instance — production shape: sender doesn't hold
+    // any recipient's private key.
+    const sender = new MemoryRecipientSealer({ id: 'sender-rs' })
+
+    const bytes = await writeNoydbBundle(v, {
+      sealedCredentials: {
+        mode: 'recipient-target',
+        provider: sender,
+        perUser: {
+          alice: { credential: { kind: 'passphrase', value: 'alice-pass-bundled' }, hint: aliceHint },
+          bob:   { credential: { kind: 'passphrase', value: 'bob-pass-bundled' },   hint: bobHint },
+        },
+      },
+    })
+
+    // Recipient side — alice unseals with her provider.
+    const aliceRead = await readNoydbBundle(bytes, { sealingProviders: [aliceRs] })
+    expect(aliceRead.autoUnlock?.kind).toBe('sealed')
+    expect(aliceRead.autoUnlock?.perUser.alice).toMatchObject({ kind: 'passphrase', value: 'alice-pass-bundled' })
+
+    const bobRead = await readNoydbBundle(bytes, { sealingProviders: [bobRs] })
+    expect(bobRead.autoUnlock?.perUser.bob).toMatchObject({ kind: 'passphrase', value: 'bob-pass-bundled' })
+  })
+
+  it('a third-party recipient (different keypair) cannot unseal someone else\'s entry', async () => {
+    const { vault: v } = await freshVault()
+    const aliceRs = new MemoryRecipientSealer({ id: 'alice-rs' })
+    const intruderRs = new MemoryRecipientSealer({ id: 'alice-rs' }) // same id, different keypair
+    const aliceHint = await aliceRs.publishRecipientHint()
+    const sender = new MemoryRecipientSealer({ id: 'sender-rs' })
+
+    const bytes = await writeNoydbBundle(v, {
+      sealedCredentials: {
+        mode: 'recipient-target',
+        provider: sender,
+        perUser: { alice: { credential: { kind: 'passphrase', value: 'p' }, hint: aliceHint } },
+      },
+    })
+
+    // Intruder has the same pid (so the reader's dispatch finds it) but a
+    // different keypair → unseal fails inside the provider.
+    await expect(readNoydbBundle(bytes, { sealingProviders: [intruderRs] })).rejects.toThrow(/decrypt|OperationError|operation/i)
+  })
+
+  it('back-compat: self-target bundles still round-trip with no hint field', async () => {
+    const { vault: v } = await freshVault()
+    const selfProvider = new MemorySealingKeyProvider({ id: 'shared-keychain' })
+
+    const bytes = await writeNoydbBundle(v, {
+      sealedCredentials: {
+        mode: 'self-target',
+        provider: selfProvider,
+        perUser: { alice: { kind: 'passphrase', value: 'alice-pass-bundled' } },
+      },
+    })
+    const recipientProvider = new MemorySealingKeyProvider({ id: 'shared-keychain' })
+    const read = await readNoydbBundle(bytes, { sealingProviders: [recipientProvider] })
+    expect(read.autoUnlock?.kind).toBe('sealed')
+    expect(read.autoUnlock?.perUser.alice).toMatchObject({ kind: 'passphrase', value: 'alice-pass-bundled' })
+    // Self-target entries omit the hint field
+    expect((read.autoUnlock?.perUser.alice as Record<string, unknown>).hint).toBeUndefined()
   })
 })

--- a/packages/hub/__tests__/managed-passphrase.test.ts
+++ b/packages/hub/__tests__/managed-passphrase.test.ts
@@ -18,6 +18,7 @@ import { createNoydb } from '../src/noydb.js'
 import { ConflictError, ValidationError } from '../src/errors.js'
 import {
   MemorySealingKeyProvider,
+  MemoryRecipientSealer,
   loadSealedPassphrase,
   saveSealedPassphrase,
   SEALED_PASSPHRASE_RECORD_ID,
@@ -244,5 +245,54 @@ describe('createNoydb({ passphraseMode: "managed" }) — slice 1', () => {
       sealingKey: wrongProvider,
     })
     await expect(db2.openVault('acme')).rejects.toThrow()
+  })
+})
+
+describe('MemoryRecipientSealer', () => {
+  it('round-trips: sealForRecipient → unseal returns the original plaintext', async () => {
+    const recipient = new MemoryRecipientSealer({ id: 'alice-rs' })
+    const hint = await recipient.publishRecipientHint()
+
+    const sender = new MemoryRecipientSealer({ id: 'sender-rs' })
+    const plaintext = new TextEncoder().encode('hello recipient')
+    const sealed = await sender.sealForRecipient(plaintext, hint)
+
+    const opened = await recipient.unseal(sealed)
+    expect(new TextDecoder().decode(opened)).toBe('hello recipient')
+  })
+
+  it('unseals fail when a third-party provider tries to open someone else\'s envelope', async () => {
+    const alice = new MemoryRecipientSealer({ id: 'alice-rs' })
+    const carol = new MemoryRecipientSealer({ id: 'carol-rs' })
+    const aliceHint = await alice.publishRecipientHint()
+
+    const sender = new MemoryRecipientSealer({ id: 'sender-rs' })
+    const sealed = await sender.sealForRecipient(new TextEncoder().encode('for alice only'), aliceHint)
+
+    await expect(carol.unseal(sealed)).rejects.toThrow(/decrypt|OperationError|operation/i)
+  })
+
+  it('unseal rejects a tampered ciphertext (AES-GCM auth tag catches the flip)', async () => {
+    const recipient = new MemoryRecipientSealer({ id: 'recipient' })
+    const hint = await recipient.publishRecipientHint()
+    const sender = new MemoryRecipientSealer({ id: 'sender' })
+    const sealed = await sender.sealForRecipient(new TextEncoder().encode('original message'), hint)
+
+    // Flip a byte in the ciphertext region (after the version + wrapped CEK + IV header).
+    const tampered = new Uint8Array(sealed)
+    tampered[1 + 256 + 12 + 1] ^= 0x01
+
+    await expect(recipient.unseal(tampered)).rejects.toThrow()
+  })
+
+  it('publishRecipientHint returns a v:1 RSA-OAEP-SHA256 hint with the provider id and a PEM public key', async () => {
+    const recipient = new MemoryRecipientSealer({ id: 'belle-rs' })
+    const hint = await recipient.publishRecipientHint()
+    expect(hint.v).toBe(1)
+    expect(hint.pid).toBe('belle-rs')
+    expect(hint.alg).toBe('rsa-oaep-sha256')
+    expect(typeof hint.material['publicKeyPem']).toBe('string')
+    expect(hint.material['publicKeyPem']).toMatch(/^-----BEGIN PUBLIC KEY-----/)
+    expect(hint.material['publicKeyPem']).toMatch(/-----END PUBLIC KEY-----\n?$/)
   })
 })

--- a/packages/hub/src/bundle/bundle.ts
+++ b/packages/hub/src/bundle/bundle.ts
@@ -486,13 +486,60 @@ function validateAutoUnlockOptions(
     return 'unsealed'
   }
 
-  // Sealed path.
-  const mode = opts.sealedCredentials?.mode ?? opts.sealedPassphrases?.mode
-  if (mode !== 'self-target') {
+  // Sealed path — branch on mode.
+  if (normalized.mode === 'sealed-recipient') {
+    const provider = normalized.provider
+    if (provider === undefined || typeof (provider as RecipientSealer).publishRecipientHint !== 'function'
+        || typeof (provider as RecipientSealer).sealForRecipient !== 'function') {
+      throw new ValidationError(
+        'writeNoydbBundle: `sealedCredentials.provider` for mode \'recipient-target\' must be a '
+        + 'RecipientSealer (publishRecipientHint + sealForRecipient). Self-only providers '
+        + '(MemorySealingKeyProvider, at-macos-keychain, etc.) do not satisfy this contract.',
+      )
+    }
+    const hints = normalized.hints
+    if (hints === undefined) {
+      throw new Error('unreachable — sealed-recipient normalization must populate hints')
+    }
+    for (const userId of Object.keys(normalized.perUser)) {
+      const hint = hints[userId]
+      if (hint === undefined) {
+        throw new ValidationError(
+          `writeNoydbBundle: \`sealedCredentials.perUser['${userId}']\` missing required \`hint\` for mode 'recipient-target'.`,
+        )
+      }
+      if (hint.v !== 1) {
+        throw new ValidationError(
+          `writeNoydbBundle: \`sealedCredentials.perUser['${userId}'].hint.v\` must be 1 (got ${hint.v}).`,
+        )
+      }
+      if (hint.alg !== 'rsa-oaep-sha256') {
+        throw new ValidationError(
+          `writeNoydbBundle: \`sealedCredentials.perUser['${userId}'].hint.alg\` must be 'rsa-oaep-sha256' in slice 1 (got '${hint.alg}').`,
+        )
+      }
+      if (hint.pid !== provider.id) {
+        throw new ValidationError(
+          `writeNoydbBundle: \`sealedCredentials.perUser['${userId}'].hint.pid\` ('${hint.pid}') does not match the provider id ('${provider.id}'). `
+          + 'Sender cannot seal for a recipient whose hint points at a different provider.',
+        )
+      }
+    }
+    const userCount = Object.keys(normalized.perUser).length
+    if (userCount === 0) {
+      throw new ValidationError(
+        'writeNoydbBundle: `sealedCredentials.perUser` must have at least one entry.',
+      )
+    }
+    return 'sealed'
+  }
+
+  // mode === 'sealed-self'
+  const selfTargetMode = opts.sealedCredentials?.mode ?? opts.sealedPassphrases?.mode
+  if (selfTargetMode !== 'self-target') {
     throw new ValidationError(
       `writeNoydbBundle: \`sealedCredentials.mode\` (or \`sealedPassphrases.mode\`) must be `
-      + `'self-target' (got '${String(mode)}'). The 'recipient-target' arm is type-defined but `
-      + 'not yet wired through to the sealing layer — coming in the next commit.',
+      + `'self-target' or 'recipient-target' (got '${String(selfTargetMode)}').`,
     )
   }
   if (normalized.provider === undefined) {

--- a/packages/hub/src/bundle/bundle.ts
+++ b/packages/hub/src/bundle/bundle.ts
@@ -239,11 +239,11 @@ export interface WriteNoydbBundleOptions {
    * recipient must hold a provider with a matching `pid` (i.e.,
    * `provider.id`) to auto-unseal on import.
    *
-   * `mode: 'self-target'` is the only mode in slice 1 — sender and
-   * recipient share the same provider identity (same iCloud Keychain
+   * `mode: 'self-target'` is the only mode for `sealedPassphrases` — sender
+   * and recipient share the same provider identity (same iCloud Keychain
    * entry, same MDM-provisioned bundle id, same KMS account, etc.).
-   * Recipient-target sealing via the `RecipientSealer` interface
-   * (foundation §11.4) is deferred to a follow-up slice.
+   * For recipient-target sealing via the `RecipientSealer` interface,
+   * use `sealedCredentials` with `mode: 'recipient-target'` (§11.4).
    *
    * Mutually exclusive with `autoCredentials`, `sealedCredentials`,
    * and `autoPassphrases`.
@@ -303,7 +303,13 @@ interface SealedAutoUnlockEntry {
   readonly sealed: string
   readonly alg: 'aes-256-gcm'
   readonly kind?: AutoCredentialKind
-  readonly hint?: Record<string, unknown>
+  /**
+   * Recipient-target only: the RecipientHint the sender used to seal.
+   * Carried for recipient verifiability ("yes this was sealed against
+   * my published hint"). Self-target entries omit it. Pre-0.2 readers
+   * ignore unknown fields, so this is back-compatible.
+   */
+  readonly hint?: RecipientHint
 }
 
 /**
@@ -439,7 +445,7 @@ function normalizeAutoUnlock(opts: WriteNoydbBundleOptions): NormalizedAutoUnloc
  *   - (mutual exclusion already enforced by normalizeAutoUnlock)
  *   - unsealed path: `policy: 'public-by-design'` marker required
  *   - non-empty `perUser` maps
- *   - sealed path: provider present; runtime accepts `mode: 'self-target'` only in this slice (recipient-target rejected per §11.4 until the next commit lifts the guard)
+ *   - sealed path: provider present; both `mode: 'self-target'` and `mode: 'recipient-target'` accepted; recipient-target requires a `RecipientSealer` provider and per-user `hint` (§11.4)
  *   - every AutoCredential.kind ∈ {passphrase, password, pin}
  *     (WebAuthn is hardware-bound and cannot be bundled)
  *
@@ -518,12 +524,9 @@ function validateAutoUnlockOptions(
           `writeNoydbBundle: \`sealedCredentials.perUser['${userId}'].hint.alg\` must be 'rsa-oaep-sha256' in slice 1 (got '${hint.alg}').`,
         )
       }
-      if (hint.pid !== provider.id) {
-        throw new ValidationError(
-          `writeNoydbBundle: \`sealedCredentials.perUser['${userId}'].hint.pid\` ('${hint.pid}') does not match the provider id ('${provider.id}'). `
-          + 'Sender cannot seal for a recipient whose hint points at a different provider.',
-        )
-      }
+      // Note: hint.pid identifies the recipient, not the sender — no pid===sender.id check here.
+      // The sender holds a RecipientSealer that calls sealForRecipient(plaintext, hint);
+      // the hint's pid is the dispatch key on the reader side (matched against recipient providers).
     }
     const userCount = Object.keys(normalized.perUser).length
     if (userCount === 0) {
@@ -577,29 +580,45 @@ async function buildAutoUnlockWrapper(
       },
     }
   }
-  // Sealed path — seal each user's credential value under the provider.
-  if (normalized.mode === 'sealed-recipient') {
-    // Actual sealing logic is deferred to Task 5; validation already
-    // rejects recipient-target at this stage so this branch is unreachable
-    // in the current slice.
-    throw new Error('unreachable — validator rejects recipient-target in this slice')
-  }
-  // normalized.mode === 'sealed-self'
-  const provider = normalized.provider as SealingKeyProvider | undefined
+  // Sealed path — branch on mode.
+  const provider = normalized.provider
   if (provider === undefined) {
     throw new Error('unreachable — validation should have caught this')
   }
   const sealedPerUser: Record<string, SealedAutoUnlockEntry> = {}
   const encoder = new TextEncoder()
-  for (const [userId, cred] of Object.entries(normalized.perUser)) {
-    const sealed = await provider.seal(encoder.encode(cred.value))
-    sealedPerUser[userId] = {
-      pid: provider.id,
-      sealed: bytesToBase64(sealed),
-      alg: 'aes-256-gcm',
-      kind: cred.kind,
+
+  if (normalized.mode === 'sealed-recipient') {
+    const recipientSealer = provider as RecipientSealer
+    const hints = normalized.hints
+    if (hints === undefined) {
+      throw new Error('unreachable — sealed-recipient normalization must populate hints')
+    }
+    for (const [userId, cred] of Object.entries(normalized.perUser)) {
+      const hint = hints[userId]!
+      const sealed = await recipientSealer.sealForRecipient(encoder.encode(cred.value), hint)
+      sealedPerUser[userId] = {
+        pid: hint.pid,                  // use the recipient's pid, not the sender's
+        sealed: bytesToBase64(sealed),
+        alg: 'aes-256-gcm',
+        kind: cred.kind,
+        hint,
+      }
+    }
+  } else {
+    // mode === 'sealed-self'
+    const selfSealer = provider as SealingKeyProvider
+    for (const [userId, cred] of Object.entries(normalized.perUser)) {
+      const sealed = await selfSealer.seal(encoder.encode(cred.value))
+      sealedPerUser[userId] = {
+        pid: selfSealer.id,
+        sealed: bytesToBase64(sealed),
+        alg: 'aes-256-gcm',
+        kind: cred.kind,
+      }
     }
   }
+
   return {
     _noydb_bundle_body: 1,
     dump: dumpJson,
@@ -740,6 +759,11 @@ function coerceUnsealed(entry: AutoCredential | string): AutoCredential {
  *   (default), throw `BundleSealMismatchError`. With
  *   `attemptUnsealAcrossProviders: true`, try each provider whose
  *   `alg` matches the envelope.
+ *   Exception: if an unmatched entry carries a `hint` field (recipient-target
+ *   entries), it passes through as `{ kind, value: base64sealed }` rather than
+ *   throwing — multi-recipient bundles have N-1 unmatched entries from each
+ *   recipient's perspective, and the consumer is expected to ignore entries
+ *   not addressed to them.
  * - When `sealingProviders` is unset entirely on a `'sealed'` bundle,
  *   pass through the SEALED entries as `{ kind, value: base64sealed }` —
  *   the caller can inspect or unseal elsewhere.
@@ -791,9 +815,22 @@ async function resolveAutoUnlock(
           }
         }
         if (opened === null) {
+          if (entry.hint !== undefined) {
+            // Recipient-target entry not addressed to any held key — pass through sealed.
+            // Other recipients' entries in a multi-recipient bundle are opaque to us.
+            unsealedMap[userId] = { kind: credKind, value: entry.sealed }
+            continue
+          }
           throw new BundleSealMismatchError(userId, entry.pid)
         }
         unsealedMap[userId] = { kind: credKind, value: opened }
+        continue
+      }
+      if (entry.hint !== undefined) {
+        // Recipient-target entry not addressed to any held key — pass through sealed.
+        // Multi-recipient bundles deliberately seal each user's entry under their own
+        // public key; a reader holding only alice's key will not match bob's pid.
+        unsealedMap[userId] = { kind: credKind, value: entry.sealed }
         continue
       }
       throw new BundleSealMismatchError(userId, entry.pid)

--- a/packages/hub/src/bundle/bundle.ts
+++ b/packages/hub/src/bundle/bundle.ts
@@ -519,6 +519,11 @@ function validateAutoUnlockOptions(
           `writeNoydbBundle: \`sealedCredentials.perUser['${userId}'].hint.v\` must be 1 (got ${String(hint.v)}).`,
         )
       }
+      if (typeof hint.pid !== 'string' || hint.pid.length === 0) {
+        throw new ValidationError(
+          `writeNoydbBundle: \`sealedCredentials.perUser['${userId}'].hint.pid\` must be a non-empty string identifying the recipient.`,
+        )
+      }
       if (hint.alg !== 'rsa-oaep-sha256') {
         throw new ValidationError(
           `writeNoydbBundle: \`sealedCredentials.perUser['${userId}'].hint.alg\` must be 'rsa-oaep-sha256' in slice 1 (got '${String(hint.alg)}').`,

--- a/packages/hub/src/bundle/bundle.ts
+++ b/packages/hub/src/bundle/bundle.ts
@@ -55,7 +55,7 @@ import type { Vault } from '../vault.js'
 import type { BundleRecipient } from '../team/keyring.js'
 import { pickLocale } from '../meta/public-envelope/storage.js'
 import type { PublicEnvelope } from '../meta/public-envelope/types.js'
-import type { SealingKeyProvider } from '../team/managed-passphrase.js'
+import type { SealingKeyProvider, RecipientSealer, RecipientHint } from '../team/managed-passphrase.js'
 
 // ─── #215 auto-credential types ───────────────────────────────────────────────
 
@@ -184,18 +184,30 @@ export interface WriteNoydbBundleOptions {
    * recipient must hold a provider with a matching `pid` (i.e.,
    * `provider.id`) to auto-unseal on import.
    *
-   * `mode: 'self-target'` is the only supported mode — sender and
-   * recipient share the same provider identity (same iCloud Keychain
-   * entry, same MDM-provisioned bundle id, same KMS account, etc.).
+   * `mode: 'self-target'` — sender and recipient share the same
+   * provider identity (same iCloud Keychain entry, same
+   * MDM-provisioned bundle id, same KMS account, etc.).
+   *
+   * `mode: 'recipient-target'` — asymmetric sealing via a
+   * {@link RecipientSealer}. Each user entry carries a
+   * `credential` and a `hint` (the recipient's public material).
+   * The bundle can only be unsealed by the holder of the matching
+   * private key.
    *
    * Mutually exclusive with `autoCredentials`, `autoPassphrases`,
    * and `sealedPassphrases`.
    */
-  readonly sealedCredentials?: {
-    readonly mode: 'self-target'
-    readonly provider: SealingKeyProvider
-    readonly perUser: Record<string, AutoCredential>
-  }
+  readonly sealedCredentials?:
+    | {
+        readonly mode: 'self-target'
+        readonly provider: SealingKeyProvider
+        readonly perUser: Record<string, AutoCredential>
+      }
+    | {
+        readonly mode: 'recipient-target'
+        readonly provider: RecipientSealer
+        readonly perUser: Record<string, { readonly credential: AutoCredential; readonly hint: RecipientHint }>
+      }
   /**
    * @deprecated Use `autoCredentials` instead (#215).
    *
@@ -346,9 +358,11 @@ export interface ReadNoydbBundleOptions {
  * so the build + validate paths share a single normalizer.
  */
 interface NormalizedAutoUnlock {
-  readonly mode: 'unsealed' | 'sealed'
-  readonly provider?: SealingKeyProvider
+  readonly mode: 'unsealed' | 'sealed-self' | 'sealed-recipient'
+  readonly provider?: SealingKeyProvider | RecipientSealer
   readonly perUser: Record<string, AutoCredential>
+  /** Present only for `sealed-recipient`. Same key set as `perUser`. */
+  readonly hints?: Record<string, RecipientHint>
 }
 
 /**
@@ -394,11 +408,20 @@ function normalizeAutoUnlock(opts: WriteNoydbBundleOptions): NormalizedAutoUnloc
     return { mode: 'unsealed', perUser: toAutoCredentials(opts.autoPassphrases.perUser) }
   }
   if (opts.sealedCredentials !== undefined) {
-    return { mode: 'sealed', provider: opts.sealedCredentials.provider, perUser: opts.sealedCredentials.perUser }
+    if (opts.sealedCredentials.mode === 'recipient-target') {
+      const perUser: Record<string, AutoCredential> = {}
+      const hints: Record<string, RecipientHint> = {}
+      for (const [userId, entry] of Object.entries(opts.sealedCredentials.perUser)) {
+        perUser[userId] = entry.credential
+        hints[userId] = entry.hint
+      }
+      return { mode: 'sealed-recipient', provider: opts.sealedCredentials.provider, perUser, hints }
+    }
+    return { mode: 'sealed-self', provider: opts.sealedCredentials.provider, perUser: opts.sealedCredentials.perUser }
   }
   // sealedPassphrases — only remaining option
   return {
-    mode: 'sealed',
+    mode: 'sealed-self',
     provider: opts.sealedPassphrases!.provider,
     perUser: toAutoCredentials(opts.sealedPassphrases!.perUser),
   }
@@ -416,7 +439,7 @@ function normalizeAutoUnlock(opts: WriteNoydbBundleOptions): NormalizedAutoUnloc
  *   - (mutual exclusion already enforced by normalizeAutoUnlock)
  *   - unsealed path: `policy: 'public-by-design'` marker required
  *   - non-empty `perUser` maps
- *   - sealed path: `mode: 'self-target'` + provider present
+ *   - sealed path: provider present; runtime accepts `mode: 'self-target'` only in this slice (recipient-target rejected per §11.4 until the next commit lifts the guard)
  *   - every AutoCredential.kind ∈ {passphrase, password, pin}
  *     (WebAuthn is hardware-bound and cannot be bundled)
  *
@@ -468,8 +491,8 @@ function validateAutoUnlockOptions(
   if (mode !== 'self-target') {
     throw new ValidationError(
       `writeNoydbBundle: \`sealedCredentials.mode\` (or \`sealedPassphrases.mode\`) must be `
-      + `'self-target' in slice 1 (got '${String(mode)}'). Recipient-target sealing via the `
-      + 'RecipientSealer interface is deferred per foundation §11.4.',
+      + `'self-target' (got '${String(mode)}'). The 'recipient-target' arm is type-defined but `
+      + 'not yet wired through to the sealing layer — coming in the next commit.',
     )
   }
   if (normalized.provider === undefined) {
@@ -508,7 +531,14 @@ async function buildAutoUnlockWrapper(
     }
   }
   // Sealed path — seal each user's credential value under the provider.
-  const provider = normalized.provider
+  if (normalized.mode === 'sealed-recipient') {
+    // Actual sealing logic is deferred to Task 5; validation already
+    // rejects recipient-target at this stage so this branch is unreachable
+    // in the current slice.
+    throw new Error('unreachable — validator rejects recipient-target in this slice')
+  }
+  // normalized.mode === 'sealed-self'
+  const provider = normalized.provider as SealingKeyProvider | undefined
   if (provider === undefined) {
     throw new Error('unreachable — validation should have caught this')
   }

--- a/packages/hub/src/bundle/bundle.ts
+++ b/packages/hub/src/bundle/bundle.ts
@@ -516,12 +516,12 @@ function validateAutoUnlockOptions(
       }
       if (hint.v !== 1) {
         throw new ValidationError(
-          `writeNoydbBundle: \`sealedCredentials.perUser['${userId}'].hint.v\` must be 1 (got ${hint.v}).`,
+          `writeNoydbBundle: \`sealedCredentials.perUser['${userId}'].hint.v\` must be 1 (got ${String(hint.v)}).`,
         )
       }
       if (hint.alg !== 'rsa-oaep-sha256') {
         throw new ValidationError(
-          `writeNoydbBundle: \`sealedCredentials.perUser['${userId}'].hint.alg\` must be 'rsa-oaep-sha256' in slice 1 (got '${hint.alg}').`,
+          `writeNoydbBundle: \`sealedCredentials.perUser['${userId}'].hint.alg\` must be 'rsa-oaep-sha256' in slice 1 (got '${String(hint.alg)}').`,
         )
       }
       // Note: hint.pid identifies the recipient, not the sender — no pid===sender.id check here.

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -485,10 +485,11 @@ export type { WrappedDeksBlob } from './team/wrapped-deks.js'
 // SealingKeyProvider. The interface lives here; concrete providers
 // (macOS Keychain, Windows Credential Manager, libsecret, AWS KMS)
 // ship as separate packages.
-export type { SealingKeyProvider, SealedPassphrase, SealedEnvelope } from './team/managed-passphrase.js'
+export type { SealingKeyProvider, SealedPassphrase, SealedEnvelope, RecipientHint, RecipientSealer } from './team/managed-passphrase.js'
 export type { ShamirRecoveryProvider } from './team/shamir-recovery-provider.js'
 export {
   MemorySealingKeyProvider,
+  MemoryRecipientSealer,
   loadSealedPassphrase,
   saveSealedPassphrase,
   parseSealedEnvelope,

--- a/packages/hub/src/team/managed-passphrase.ts
+++ b/packages/hub/src/team/managed-passphrase.ts
@@ -234,7 +234,7 @@ export class MemoryRecipientSealer implements SealingKeyProvider, RecipientSeale
       { name: 'RSA-OAEP', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
       true,
       ['encrypt', 'decrypt'],
-    ) as Promise<CryptoKeyPair>
+    )
   }
 
   async publishRecipientHint(): Promise<RecipientHint> {
@@ -248,10 +248,10 @@ export class MemoryRecipientSealer implements SealingKeyProvider, RecipientSeale
 
   async sealForRecipient(plaintext: Uint8Array, hint: RecipientHint): Promise<Uint8Array> {
     if (hint.v !== 1) {
-      throw new Error(`MemoryRecipientSealer.sealForRecipient: unsupported hint.v ${hint.v} (expected 1)`)
+      throw new Error(`MemoryRecipientSealer.sealForRecipient: unsupported hint.v ${String(hint.v)} (expected 1)`)
     }
     if (hint.alg !== 'rsa-oaep-sha256') {
-      throw new Error(`MemoryRecipientSealer.sealForRecipient: unsupported hint.alg '${hint.alg}' (expected 'rsa-oaep-sha256')`)
+      throw new Error(`MemoryRecipientSealer.sealForRecipient: unsupported hint.alg '${String(hint.alg)}' (expected 'rsa-oaep-sha256')`)
     }
     const pem = hint.material['publicKeyPem']
     if (typeof pem !== 'string') {

--- a/packages/hub/src/team/managed-passphrase.ts
+++ b/packages/hub/src/team/managed-passphrase.ts
@@ -15,6 +15,18 @@
  *   - {@link MemorySealingKeyProvider} — in-memory test provider; uses
  *     a deterministic per-instance "key" so two providers with
  *     different ids cannot unseal each other's outputs.
+ *   - {@link RecipientHint} — public material a sender uses to seal
+ *     plaintext for a specific recipient; published by
+ *     {@link RecipientSealer.publishRecipientHint} and transported
+ *     out-of-band to the sender before bundle writes.
+ *   - {@link RecipientSealer} — interface for asymmetric/granted
+ *     providers that support recipient-target sealing (RSA-OAEP,
+ *     cloud-KMS asymmetric, etc.); distinct from self-only
+ *     {@link SealingKeyProvider} (macOS Keychain, WebAuthn-PRF).
+ *   - {@link MemoryRecipientSealer} — in-process reference
+ *     implementation of both `RecipientSealer` and
+ *     `SealingKeyProvider` using real WebCrypto RSA-OAEP + AES-GCM;
+ *     safe for tests and same-process sender/recipient scenarios.
  *   - {@link loadSealedPassphrase} / {@link saveSealedPassphrase} —
  *     plaintext envelope storage at `_meta/sealed-passphrase`.
  *     Mirrors the `_meta/handle` and `_meta/public-envelope` AES-
@@ -146,6 +158,154 @@ export class MemorySealingKeyProvider implements SealingKeyProvider {
       out[i] = body[i]! ^ this.keyBytes[i % 16]!
     }
     return out
+  }
+}
+
+/**
+ * Public material a sender uses to seal-for-this-recipient. Published by
+ * a recipient's RecipientSealer; transported to the sender out-of-band
+ * (email, S3, in-app message). The sender obtains the hint, supplies it
+ * to writeNoydbBundle's sealedCredentials.perUser[userId].hint, and the
+ * hub seals each user's credential against it. Per foundation §11.4.
+ */
+export type RecipientHint = {
+  readonly v: 1
+  /** Recipient's provider id; matches the SealedAutoUnlockEntry.pid they'll unseal under. */
+  readonly pid: string
+  /** Algorithm the sender uses to produce the seal. Slice 1 ships RSA-OAEP-SHA256 only. */
+  readonly alg: 'rsa-oaep-sha256'
+  /** Public material — alg-specific. For 'rsa-oaep-sha256': { publicKeyPem: string }. */
+  readonly material: Readonly<Record<string, unknown>>
+}
+
+/**
+ * Handover-capable provider. Implemented additionally by asymmetric/granted
+ * providers (cloud-KMS asymmetric, Azure RSA Key Vault, AWS KMS with grant).
+ * Self-only providers (macOS Keychain, env-var, WebAuthn-PRF) do NOT
+ * implement this — the §11.2 capability matrix lives in the type system.
+ *
+ * Per foundation §11.4. A function that requires recipient-target sealing
+ * takes `RecipientSealer`, not `SealingKeyProvider` — the compiler rejects
+ * passing a self-only provider at the spec site.
+ */
+export interface RecipientSealer {
+  readonly id: string
+  /** Produce hint material a sender uses to seal-for-this-recipient. */
+  publishRecipientHint(): Promise<RecipientHint>
+  /**
+   * Seal plaintext for the recipient described by `hint`. Returns opaque
+   * bytes — same contract as `SealingKeyProvider.seal()`. The bundle
+   * layer base64-encodes the bytes into `SealedAutoUnlockEntry.sealed`
+   * without inspecting them.
+   */
+  sealForRecipient(plaintext: Uint8Array, hint: RecipientHint): Promise<Uint8Array>
+}
+
+/**
+ * Reference implementation of `RecipientSealer` + `SealingKeyProvider`.
+ * Uses WebCrypto RSA-OAEP-SHA256 (2048-bit) to wrap a fresh 32-byte
+ * AES-GCM CEK, AES-GCM-encrypts plaintext under it, and packs the
+ * result into a self-describing TLV:
+ *
+ *   byte  0       : version (0x01)
+ *   bytes 1..256  : RSA-OAEP-wrapped CEK (fixed 256 bytes at RSA-2048)
+ *   bytes 257..268: AES-GCM IV (12 bytes)
+ *   bytes 269..   : AES-GCM ciphertext ‖ 16-byte tag
+ *
+ * Implements BOTH interfaces. `seal(plaintext)` (self-target) is just
+ * `sealForRecipient(plaintext, this own hint)` — same TLV. Convenient
+ * for tests where one provider plays both ends. Real cloud providers
+ * (`at-aws-kms`, etc.) will pick their own internal layouts; the only
+ * contract is round-trip identity.
+ *
+ * SAFE for production within its scope — the cryptography is real
+ * (RSA-OAEP + AES-GCM via WebCrypto), but the keypair lives in-process
+ * and is regenerated on every construction. Not suitable as a managed
+ * keychain; use it for tests and for shipping bundles where the
+ * recipient instance lives in the same process as the sender (rare).
+ */
+export class MemoryRecipientSealer implements SealingKeyProvider, RecipientSealer {
+  readonly id: string
+  private readonly keypair: Promise<CryptoKeyPair>
+
+  constructor(opts: { id: string }) {
+    this.id = opts.id
+    this.keypair = crypto.subtle.generateKey(
+      { name: 'RSA-OAEP', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+      true,
+      ['encrypt', 'decrypt'],
+    ) as Promise<CryptoKeyPair>
+  }
+
+  async publishRecipientHint(): Promise<RecipientHint> {
+    const { publicKey } = await this.keypair
+    const spki = await crypto.subtle.exportKey('spki', publicKey)
+    const pem = '-----BEGIN PUBLIC KEY-----\n'
+      + bytesToBase64(new Uint8Array(spki)).match(/.{1,64}/g)!.join('\n')
+      + '\n-----END PUBLIC KEY-----\n'
+    return { v: 1, pid: this.id, alg: 'rsa-oaep-sha256', material: { publicKeyPem: pem } }
+  }
+
+  async sealForRecipient(plaintext: Uint8Array, hint: RecipientHint): Promise<Uint8Array> {
+    if (hint.v !== 1) {
+      throw new Error(`MemoryRecipientSealer.sealForRecipient: unsupported hint.v ${hint.v} (expected 1)`)
+    }
+    if (hint.alg !== 'rsa-oaep-sha256') {
+      throw new Error(`MemoryRecipientSealer.sealForRecipient: unsupported hint.alg '${hint.alg}' (expected 'rsa-oaep-sha256')`)
+    }
+    const pem = hint.material['publicKeyPem']
+    if (typeof pem !== 'string') {
+      throw new Error('MemoryRecipientSealer.sealForRecipient: hint.material.publicKeyPem missing or not a string')
+    }
+    // Parse PEM → SPKI bytes.
+    const b64 = pem.replace(/-----BEGIN PUBLIC KEY-----/, '').replace(/-----END PUBLIC KEY-----/, '').replace(/\s+/g, '')
+    const spki = base64ToBytes(b64)
+    const recipientPub = await crypto.subtle.importKey(
+      'spki', spki as BufferSource,
+      { name: 'RSA-OAEP', hash: 'SHA-256' },
+      false, ['encrypt'],
+    )
+    // Mint fresh CEK + IV, AES-GCM encrypt plaintext.
+    const cekBytes = crypto.getRandomValues(new Uint8Array(32))
+    const cek = await crypto.subtle.importKey('raw', cekBytes as BufferSource, 'AES-GCM', false, ['encrypt'])
+    const iv = crypto.getRandomValues(new Uint8Array(12))
+    const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv: iv as BufferSource }, cek, plaintext as BufferSource))
+    // RSA-OAEP-wrap the CEK bytes.
+    const wrapped = new Uint8Array(await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, recipientPub, cekBytes as BufferSource))
+    cekBytes.fill(0)
+    if (wrapped.length !== 256) {
+      throw new Error(`MemoryRecipientSealer.sealForRecipient: expected 256-byte RSA-OAEP wrap, got ${wrapped.length}`)
+    }
+    // TLV layout.
+    const out = new Uint8Array(1 + 256 + 12 + ct.length)
+    out[0] = 0x01
+    out.set(wrapped, 1)
+    out.set(iv, 1 + 256)
+    out.set(ct, 1 + 256 + 12)
+    return out
+  }
+
+  async seal(plaintext: Uint8Array): Promise<Uint8Array> {
+    const hint = await this.publishRecipientHint()
+    return this.sealForRecipient(plaintext, hint)
+  }
+
+  async unseal(bytes: Uint8Array): Promise<Uint8Array> {
+    if (bytes.length < 1 + 256 + 12 + 16) {
+      throw new Error('MemoryRecipientSealer.unseal: sealed input too short')
+    }
+    if (bytes[0] !== 0x01) {
+      throw new Error(`MemoryRecipientSealer.unseal: unknown TLV version ${bytes[0]}`)
+    }
+    const wrapped = bytes.subarray(1, 1 + 256)
+    const iv = bytes.subarray(1 + 256, 1 + 256 + 12)
+    const ct = bytes.subarray(1 + 256 + 12)
+    const { privateKey } = await this.keypair
+    const cekBytes = new Uint8Array(await crypto.subtle.decrypt({ name: 'RSA-OAEP' }, privateKey, wrapped as BufferSource))
+    const cek = await crypto.subtle.importKey('raw', cekBytes as BufferSource, 'AES-GCM', false, ['decrypt'])
+    const pt = new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-GCM', iv: iv as BufferSource }, cek, ct as BufferSource))
+    cekBytes.fill(0)
+    return pt
   }
 }
 


### PR DESCRIPTION
Implements the deferred `mode: 'recipient-target'` arm of `sealedCredentials` per foundation §11.4 + the design spec committed in this branch.

## What's in this PR

- `RecipientHint` + `RecipientSealer` interfaces in `team/managed-passphrase.ts`
- `MemoryRecipientSealer` reference implementation (WebCrypto RSA-OAEP-SHA256 + AES-GCM hybrid via a self-describing TLV inside the provider's opaque `Uint8Array`)
- `sealedCredentials.mode: 'recipient-target'` arm on `WriteNoydbBundleOptions` (typed `provider: RecipientSealer`, `perUser: Record<userId, { credential, hint }>`)
- `validateAutoUnlockOptions` checks provider satisfies `RecipientSealer` (`publishRecipientHint` + `sealForRecipient` present), every per-user `hint` is well-formed (`v === 1`, `alg === 'rsa-oaep-sha256'`)
- `buildAutoUnlockWrapper` branches on mode and calls `sealForRecipient` for recipient-target entries; emits a new typed `SealedAutoUnlockEntry.hint` field for recipient verifiability
- `resolveAutoUnlock` gained a hint-discriminated pass-through for unmatched-pid entries (multi-recipient bundles have N-1 unmatched entries from each recipient's perspective; self-target unmatched-pid behavior preserved)
- Test coverage: new tests across `managed-passphrase.test.ts` (round-trip, wrong-key, hint shape, tamper-detection) and `bundle-auto-unlock.test.ts` (validation: missing hint, wrong alg, self-only provider in recipient-target mode; round-trip: two-recipient happy path, wrong-recipient same-pid different-keypair, self-target back-compat with hint-absence assertion)

## What's NOT in this PR (deferred follow-ups)

- Real cloud-provider `RecipientSealer` impls (one issue per package: `at-aws-kms`, `at-azure-keyvault`, `at-gcp-kms`)
- `MultiRecipientSealer` (foundation §11.4 future)
- In-vault hint discovery via `_meta/user/<keyringId>` (foundation §11.4 future)
- Recipient-target sealing for extracted-partition bundles (header mutual-exclusion stays for now)

Closes #197.