### PR TITLE
feat(attestation): @noy-db/attestation pure core + document-attestation specs

### DIFF
--- a/docs/superpowers/plans/2026-05-29-attestation-core-package.md
+++ b/docs/superpowers/plans/2026-05-29-attestation-core-package.md
@@ -1,0 +1,1079 @@
+# @noy-db/attestation (pure core) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `@noy-db/attestation` — the pure, zero-runtime-dependency package that owns the document-attestation cryptographic + format contracts: canonical hashing, the closed normalizer set, per-field salted commitment, Ed25519 sign/verify, the QR payload codec, and the revocation format + check. Runs in Node and the browser with no vault.
+
+**Architecture:** One new workspace package `packages/attestation/`, modeled on `packages/on-shamir/` (zero deps, dual ESM/CJS via tsup, vitest). All crypto uses WebCrypto globals (`globalThis.crypto.subtle`) — no native deps. The hub-side issue path (`@noy-db/hub/attestation`) is a **separate follow-up plan** that depends on this package; it is NOT in this plan.
+
+**Tech Stack:** TypeScript, WebCrypto (SHA-256, Ed25519), Vitest, tsup, pnpm workspace.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-attestation-core-and-issue-design.md` (§3 is this package; §4 is the deferred hub plan). Umbrella: `docs/superpowers/specs/2026-05-29-document-attestation-umbrella-design.md`.
+
+**Branch:** `docs/document-attestation-umbrella` (already checked out; both specs committed at `660ce05`/`c53c613`). Create work here or a fresh branch off it — confirm with `git rev-parse --abbrev-ref HEAD`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `packages/attestation/package.json` | Package manifest (mirror on-shamir; zero deps) |
+| `packages/attestation/tsup.config.ts` | Build config (copy on-shamir) |
+| `packages/attestation/vitest.config.ts` | Test config (copy on-shamir, `name: 'attestation'`) |
+| `packages/attestation/tsconfig.json` | TS config (copy on-shamir) |
+| `packages/attestation/src/encoding.ts` | `canonicalJson`, `sha256Bytes`, `sha256Hex`, `bytesToHex`, `bytesToB64url`, `b64urlToBytes`, `utf8` |
+| `packages/attestation/src/normalize.ts` | `Normalizer` type, `normalizeField`, `validateFieldSchema`, `getPath` |
+| `packages/attestation/src/hashing.ts` | `computeFieldHashes` |
+| `packages/attestation/src/ed25519.ts` | `generateDocSigningKeyPair`, `ed25519Sign`, `ed25519Verify` |
+| `packages/attestation/src/qr.ts` | `QrPayload`, `encodeQr`, `decodeQr` |
+| `packages/attestation/src/verify.ts` | `signPayloadCore`, `verifyAttestation`, types `VerifyInput`/`VerifyResult` |
+| `packages/attestation/src/revocation.ts` | `RevocationList`, `isRevoked`, `verifyRevocationList` |
+| `packages/attestation/src/types.ts` | `AttestationFieldSpec`, `AttestationFieldSchema` |
+| `packages/attestation/src/index.ts` | Barrel re-export of the public API |
+| `packages/attestation/__tests__/*.test.ts` | One test file per src module |
+
+---
+
+## Task 1: Package scaffold + encoding primitives
+
+**Files:**
+- Create: `packages/attestation/package.json`, `tsup.config.ts`, `vitest.config.ts`, `tsconfig.json`
+- Create: `packages/attestation/src/encoding.ts`
+- Test: `packages/attestation/__tests__/encoding.test.ts`
+
+- [ ] **Step 1: Scaffold the package files**
+
+`packages/attestation/package.json`:
+```json
+{
+  "name": "@noy-db/attestation",
+  "version": "0.2.0-pre.1",
+  "description": "Pure, zero-dependency document-attestation primitive for noy-db — per-field salted commitments, Ed25519 sign/verify, QR credential codec, and revocation checks. Runs in Node and the browser; the offline verifier imports only this.",
+  "license": "MIT",
+  "author": "vLannaAi <vicio@lanna.ai>",
+  "homepage": "https://github.com/vLannaAi/noy-db/tree/main/packages/attestation#readme",
+  "repository": { "type": "git", "url": "git+https://github.com/vLannaAi/noy-db.git", "directory": "packages/attestation" },
+  "bugs": { "url": "https://github.com/vLannaAi/noy-db/issues" },
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
+      "require": { "types": "./dist/index.d.cts", "default": "./dist/index.cjs" }
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist", "README.md", "LICENSE"],
+  "engines": { "node": ">=18.0.0" },
+  "scripts": { "build": "tsup", "test": "vitest run", "lint": "eslint src/", "typecheck": "tsc --noEmit" },
+  "keywords": ["noy-db", "attestation", "document", "commitment", "ed25519", "verification", "qr", "tamper-evident"],
+  "publishConfig": { "access": "public", "tag": "latest" }
+}
+```
+
+`packages/attestation/tsup.config.ts` (identical to on-shamir):
+```ts
+import { defineConfig } from 'tsup'
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  target: 'es2022',
+})
+```
+
+`packages/attestation/vitest.config.ts`:
+```ts
+import { defineConfig } from 'vitest/config'
+export default defineConfig({
+  test: { name: 'attestation', include: ['__tests__/**/*.test.ts'], environment: 'node' },
+})
+```
+
+`packages/attestation/tsconfig.json` — copy `packages/on-shamir/tsconfig.json` verbatim (read it first with `cat packages/on-shamir/tsconfig.json` and replicate).
+
+Copy `packages/on-shamir/LICENSE` to `packages/attestation/LICENSE`. Create a minimal `packages/attestation/README.md` with the package description (one paragraph from package.json).
+
+- [ ] **Step 2: Write the failing test**
+
+`packages/attestation/__tests__/encoding.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { canonicalJson, sha256Hex, sha256Bytes, bytesToHex, bytesToB64url, b64urlToBytes, utf8 } from '../src/encoding.js'
+
+describe('canonicalJson', () => {
+  it('sorts object keys and is deterministic regardless of literal order', () => {
+    expect(canonicalJson({ b: 1, a: 2 })).toBe('{"a":2,"b":1}')
+    expect(canonicalJson({ a: 2, b: 1 })).toBe('{"a":2,"b":1}')
+  })
+  it('encodes arrays in order and nests', () => {
+    expect(canonicalJson([1, 'x', { z: true }])).toBe('[1,"x",{"z":true}]')
+  })
+  it('matches a fixed conformance vector (shared contract with the ledger)', () => {
+    expect(canonicalJson(['s4lt', 'total', '123450'])).toBe('["s4lt","total","123450"]')
+  })
+  it('throws on non-finite numbers and undefined', () => {
+    expect(() => canonicalJson(Number.NaN)).toThrow(/non-finite/)
+    expect(() => canonicalJson(undefined)).toThrow(/undefined/)
+  })
+})
+
+describe('sha256', () => {
+  it('sha256Hex matches a known vector for the empty string', async () => {
+    expect(await sha256Hex('')).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+  })
+  it('sha256Hex matches a known vector for "abc"', async () => {
+    expect(await sha256Hex('abc')).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
+  })
+  it('sha256Bytes returns 32 bytes', async () => {
+    expect((await sha256Bytes('abc')).length).toBe(32)
+  })
+})
+
+describe('hex + base64url round-trips', () => {
+  it('bytesToHex of a known buffer', () => {
+    expect(bytesToHex(new Uint8Array([0, 1, 254, 255]))).toBe('0001feff')
+  })
+  it('base64url round-trips arbitrary bytes and is url-safe (no +,/,=)', () => {
+    const b = new Uint8Array([0, 1, 2, 250, 251, 252, 253, 254, 255])
+    const enc = bytesToB64url(b)
+    expect(enc).not.toMatch(/[+/=]/)
+    expect([...b64urlToBytes(enc)]).toEqual([...b])
+  })
+  it('utf8 encodes to bytes', () => {
+    expect([...utf8('A')]).toEqual([65])
+  })
+})
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd packages/attestation && npx vitest run __tests__/encoding.test.ts`
+Expected: FAIL — `Cannot find module '../src/encoding.js'`.
+
+- [ ] **Step 4: Implement `src/encoding.ts`**
+
+```ts
+/**
+ * Pure encoding + hashing primitives. Zero deps; WebCrypto only.
+ *
+ * `canonicalJson` and `sha256Hex` are intentionally byte-identical to
+ * hub's `history/ledger/entry.ts` implementations. They are REPLICATED
+ * here (not imported) because this package is upstream of hub — importing
+ * from hub would invert the dependency. The conformance test pins the
+ * shared contract via fixed vectors.
+ */
+
+export function utf8(s: string): Uint8Array {
+  return new TextEncoder().encode(s)
+}
+
+export function bytesToHex(bytes: Uint8Array): string {
+  let out = ''
+  for (const b of bytes) out += b.toString(16).padStart(2, '0')
+  return out
+}
+
+export function bytesToB64url(bytes: Uint8Array): string {
+  let s = ''
+  for (const b of bytes) s += String.fromCharCode(b)
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+export function b64urlToBytes(s: string): Uint8Array {
+  const pad = s.length % 4 === 0 ? '' : '='.repeat(4 - (s.length % 4))
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/') + pad
+  const bin = atob(b64)
+  const out = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+  return out
+}
+
+export function canonicalJson(value: unknown): string {
+  if (value === null) return 'null'
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error(`canonicalJson: refusing to encode non-finite number ${String(value)}`)
+    }
+    return JSON.stringify(value)
+  }
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (typeof value === 'bigint') throw new Error('canonicalJson: BigInt is not JSON-serializable')
+  if (typeof value === 'undefined' || typeof value === 'function') {
+    throw new Error(`canonicalJson: refusing to encode ${typeof value} — include all fields explicitly`)
+  }
+  if (Array.isArray(value)) return '[' + value.map((v) => canonicalJson(v)).join(',') + ']'
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>
+    const keys = Object.keys(obj).sort()
+    const parts: string[] = []
+    for (const key of keys) parts.push(JSON.stringify(key) + ':' + canonicalJson(obj[key]))
+    return '{' + parts.join(',') + '}'
+  }
+  throw new Error(`canonicalJson: unexpected value type: ${typeof value}`)
+}
+
+export async function sha256Bytes(input: string): Promise<Uint8Array> {
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', utf8(input))
+  return new Uint8Array(digest)
+}
+
+export async function sha256Hex(input: string): Promise<string> {
+  return bytesToHex(await sha256Bytes(input))
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd packages/attestation && pnpm install && npx vitest run __tests__/encoding.test.ts`
+Expected: PASS (all encoding tests). `pnpm install` registers the new workspace package.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/attestation/
+git commit -m "feat(attestation): scaffold @noy-db/attestation + encoding primitives
+
+New zero-dependency package (on-shamir template). canonicalJson +
+sha256 replicated hub-free with fixed-vector conformance tests; hex +
+base64url codecs."
+```
+
+---
+
+## Task 2: Normalizers + field-schema validation + path resolver
+
+**Files:**
+- Create: `packages/attestation/src/types.ts`, `packages/attestation/src/normalize.ts`
+- Test: `packages/attestation/__tests__/normalize.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/attestation/__tests__/normalize.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { normalizeField, validateFieldSchema, getPath } from '../src/normalize.js'
+
+describe('normalizeField', () => {
+  it('trim / lower / upper', () => {
+    expect(normalizeField('  Hi ', 'trim')).toBe('Hi')
+    expect(normalizeField(' Hi ', 'lower')).toBe('hi')
+    expect(normalizeField(' Hi ', 'upper')).toBe('HI')
+  })
+  it('alnum-upper strips punctuation and uppercases', () => {
+    expect(normalizeField('gb-12 34.56', 'alnum-upper')).toBe('GB123456')
+  })
+  it('digits keeps only digits', () => {
+    expect(normalizeField('+1 (415) 555', 'digits')).toBe('1415555')
+  })
+  it('cents converts money to integer-cents string', () => {
+    expect(normalizeField(1234.5, 'cents')).toBe('123450')
+    expect(normalizeField('19.99', 'cents')).toBe('1999')
+    expect(normalizeField(0, 'cents')).toBe('0')
+  })
+  it('cents throws on non-numeric', () => {
+    expect(() => normalizeField('abc', 'cents')).toThrow(/cents/)
+  })
+  it('iso-date normalizes Date and ISO string to YYYY-MM-DD', () => {
+    expect(normalizeField('2026-05-29T10:00:00Z', 'iso-date')).toBe('2026-05-29')
+    expect(normalizeField(new Date('2026-05-29T23:59:59Z'), 'iso-date')).toBe('2026-05-29')
+  })
+  it('iso-date throws on unparseable', () => {
+    expect(() => normalizeField('not-a-date', 'iso-date')).toThrow(/iso-date/)
+  })
+})
+
+describe('validateFieldSchema', () => {
+  it('accepts a valid schema', () => {
+    expect(() => validateFieldSchema({ fields: [{ path: 'total', normalize: 'cents' }] })).not.toThrow()
+  })
+  it('rejects an unknown normalizer', () => {
+    // @ts-expect-error testing runtime guard
+    expect(() => validateFieldSchema({ fields: [{ path: 'x', normalize: 'bogus' }] })).toThrow(/normalizer/)
+  })
+  it('rejects empty fields and duplicate paths', () => {
+    expect(() => validateFieldSchema({ fields: [] })).toThrow(/at least one/)
+    expect(() => validateFieldSchema({ fields: [{ path: 'a', normalize: 'trim' }, { path: 'a', normalize: 'upper' }] })).toThrow(/duplicate/)
+  })
+})
+
+describe('getPath', () => {
+  it('resolves dot paths', () => {
+    expect(getPath({ a: { b: 7 } }, 'a.b')).toBe(7)
+    expect(getPath({ total: 5 }, 'total')).toBe(5)
+  })
+  it('returns undefined for a missing path', () => {
+    expect(getPath({ a: {} }, 'a.b.c')).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/attestation && npx vitest run __tests__/normalize.test.ts`
+Expected: FAIL — `Cannot find module '../src/normalize.js'`.
+
+- [ ] **Step 3: Implement `src/types.ts` then `src/normalize.ts`**
+
+`packages/attestation/src/types.ts`:
+```ts
+export type Normalizer = 'trim' | 'lower' | 'upper' | 'alnum-upper' | 'digits' | 'cents' | 'iso-date'
+
+export interface AttestationFieldSpec {
+  readonly path: string
+  readonly normalize: Normalizer
+}
+export interface AttestationFieldSchema {
+  readonly fields: readonly AttestationFieldSpec[]
+}
+```
+
+`packages/attestation/src/normalize.ts`:
+```ts
+import type { AttestationFieldSchema, Normalizer } from './types.js'
+
+const NORMALIZERS: ReadonlySet<string> = new Set<Normalizer>([
+  'trim', 'lower', 'upper', 'alnum-upper', 'digits', 'cents', 'iso-date',
+])
+
+export function getPath(obj: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>((o, k) => (o == null ? undefined : (o as Record<string, unknown>)[k]), obj)
+}
+
+export function normalizeField(value: unknown, n: Normalizer): string {
+  switch (n) {
+    case 'trim': return String(value).trim()
+    case 'lower': return String(value).trim().toLowerCase()
+    case 'upper': return String(value).trim().toUpperCase()
+    case 'alnum-upper': return String(value).replace(/[^A-Za-z0-9]/g, '').toUpperCase()
+    case 'digits': return String(value).replace(/[^0-9]/g, '')
+    case 'cents': {
+      const num = typeof value === 'number' ? value : Number(String(value).replace(/[^0-9.\-]/g, ''))
+      if (!Number.isFinite(num)) throw new Error(`normalizeField(cents): not a finite number: ${String(value)}`)
+      return String(Math.round(num * 100))
+    }
+    case 'iso-date': {
+      const d = value instanceof Date ? value : new Date(String(value))
+      if (Number.isNaN(d.getTime())) throw new Error(`normalizeField(iso-date): unparseable date: ${String(value)}`)
+      return d.toISOString().slice(0, 10)
+    }
+    default: {
+      const exhaustive: never = n
+      throw new Error(`normalizeField: unknown normalizer ${String(exhaustive)}`)
+    }
+  }
+}
+
+export function validateFieldSchema(schema: AttestationFieldSchema): void {
+  if (!schema.fields || schema.fields.length === 0) {
+    throw new Error('validateFieldSchema: schema must declare at least one field')
+  }
+  const seen = new Set<string>()
+  for (const f of schema.fields) {
+    if (!NORMALIZERS.has(f.normalize)) {
+      throw new Error(`validateFieldSchema: unknown normalizer '${String(f.normalize)}' for path '${f.path}'`)
+    }
+    if (seen.has(f.path)) throw new Error(`validateFieldSchema: duplicate path '${f.path}'`)
+    seen.add(f.path)
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/attestation && npx vitest run __tests__/normalize.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/attestation/src/types.ts packages/attestation/src/normalize.ts packages/attestation/__tests__/normalize.test.ts
+git commit -m "feat(attestation): closed normalizer set + field-schema validation + dot-path resolver"
+```
+
+---
+
+## Task 3: Per-field salted hashing
+
+**Files:**
+- Create: `packages/attestation/src/hashing.ts`
+- Test: `packages/attestation/__tests__/hashing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/attestation/__tests__/hashing.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { computeFieldHashes } from '../src/hashing.js'
+import type { AttestationFieldSchema } from '../src/types.js'
+
+const schema: AttestationFieldSchema = {
+  fields: [
+    { path: 'invoiceNo', normalize: 'alnum-upper' },
+    { path: 'total', normalize: 'cents' },
+  ],
+}
+const salt = 'c2FsdHNhbHRzYWx0c2Fs' // base64url, arbitrary
+
+describe('computeFieldHashes', () => {
+  it('returns one base64url hash per field, in schema order', async () => {
+    const h = await computeFieldHashes(salt, schema, { invoiceNo: 'INV-1', total: 12.34 })
+    expect(h).toHaveLength(2)
+    for (const x of h) expect(x).not.toMatch(/[+/=]/)
+  })
+  it('is deterministic for the same salt+schema+values', async () => {
+    const a = await computeFieldHashes(salt, schema, { invoiceNo: 'INV-1', total: 12.34 })
+    const b = await computeFieldHashes(salt, schema, { invoiceNo: 'inv 1', total: '12.34' })
+    expect(a).toEqual(b) // normalization makes these equal
+  })
+  it('changes when a field value changes', async () => {
+    const a = await computeFieldHashes(salt, schema, { invoiceNo: 'INV-1', total: 12.34 })
+    const b = await computeFieldHashes(salt, schema, { invoiceNo: 'INV-1', total: 99.99 })
+    expect(a[0]).toBe(b[0])
+    expect(a[1]).not.toBe(b[1])
+  })
+  it('changes when the salt changes', async () => {
+    const a = await computeFieldHashes(salt, schema, { invoiceNo: 'INV-1', total: 12.34 })
+    const b = await computeFieldHashes('ZGlmZmVyZW50c2FsdGRpZmY', schema, { invoiceNo: 'INV-1', total: 12.34 })
+    expect(a[0]).not.toBe(b[0])
+  })
+  it('domain-separates fields with equal values (path is in the hash input)', async () => {
+    const s2: AttestationFieldSchema = { fields: [{ path: 'a', normalize: 'trim' }, { path: 'b', normalize: 'trim' }] }
+    const h = await computeFieldHashes(salt, s2, { a: 'same', b: 'same' })
+    expect(h[0]).not.toBe(h[1])
+  })
+  it('throws when a declared field is missing from the record', async () => {
+    await expect(computeFieldHashes(salt, schema, { invoiceNo: 'INV-1' })).rejects.toThrow(/missing/)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/attestation && npx vitest run __tests__/hashing.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `src/hashing.ts`**
+
+```ts
+import type { AttestationFieldSchema } from './types.js'
+import { canonicalJson, sha256Bytes, bytesToB64url } from './encoding.js'
+import { getPath, normalizeField } from './normalize.js'
+
+/**
+ * One salted, domain-separated hash per declared field, in schema order:
+ *   fieldHash[i] = base64url( sha256( canonicalJson([salt, path, normalizedValue]) ) )
+ * Per-document salt defeats brute-force of low-entropy fields and cross-
+ * document correlation; the path in the input domain-separates fields
+ * that happen to share a value.
+ */
+export async function computeFieldHashes(
+  saltB64: string,
+  schema: AttestationFieldSchema,
+  values: Record<string, unknown>,
+): Promise<string[]> {
+  const out: string[] = []
+  for (const f of schema.fields) {
+    const raw = getPath(values, f.path)
+    if (raw === undefined || raw === null) {
+      throw new Error(`computeFieldHashes: missing value at declared path '${f.path}'`)
+    }
+    const norm = normalizeField(raw, f.normalize)
+    const digest = await sha256Bytes(canonicalJson([saltB64, f.path, norm]))
+    out.push(bytesToB64url(digest))
+  }
+  return out
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/attestation && npx vitest run __tests__/hashing.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/attestation/src/hashing.ts packages/attestation/__tests__/hashing.test.ts
+git commit -m "feat(attestation): per-field salted, domain-separated commitment hashing"
+```
+
+---
+
+## Task 4: Ed25519 keygen / sign / verify
+
+**Files:**
+- Create: `packages/attestation/src/ed25519.ts`
+- Test: `packages/attestation/__tests__/ed25519.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/attestation/__tests__/ed25519.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { generateDocSigningKeyPair, ed25519Sign, ed25519Verify } from '../src/ed25519.js'
+import { utf8 } from '../src/encoding.js'
+
+describe('Ed25519', () => {
+  it('generates a keypair with a stable 16-char keyId and base64url keys', async () => {
+    const kp = await generateDocSigningKeyPair()
+    expect(kp.keyId).toHaveLength(16)
+    expect(kp.publicKeyB64).not.toMatch(/[+/=]/)
+    expect(kp.privateKeyPkcs8B64).not.toMatch(/[+/=]/)
+  })
+  it('sign → verify round-trips', async () => {
+    const kp = await generateDocSigningKeyPair()
+    const msg = utf8('hello document')
+    const sig = await ed25519Sign(kp.privateKeyPkcs8B64, msg)
+    expect(sig).not.toMatch(/[+/=]/)
+    expect(await ed25519Verify(kp.publicKeyB64, sig, msg)).toBe(true)
+  })
+  it('verify fails for a different message', async () => {
+    const kp = await generateDocSigningKeyPair()
+    const sig = await ed25519Sign(kp.privateKeyPkcs8B64, utf8('original'))
+    expect(await ed25519Verify(kp.publicKeyB64, sig, utf8('tampered'))).toBe(false)
+  })
+  it('verify fails for a different key', async () => {
+    const a = await generateDocSigningKeyPair()
+    const b = await generateDocSigningKeyPair()
+    const sig = await ed25519Sign(a.privateKeyPkcs8B64, utf8('m'))
+    expect(await ed25519Verify(b.publicKeyB64, sig, utf8('m'))).toBe(false)
+  })
+  it('the same public key yields the same keyId', async () => {
+    const kp = await generateDocSigningKeyPair()
+    const { keyIdFor } = await import('../src/ed25519.js')
+    expect(await keyIdFor(kp.publicKeyB64)).toBe(kp.keyId)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/attestation && npx vitest run __tests__/ed25519.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `src/ed25519.ts`**
+
+```ts
+import { bytesToB64url, b64urlToBytes, sha256Hex } from './encoding.js'
+
+const ALG = 'Ed25519'
+
+/** Stable key identifier: first 16 hex chars of sha256(publicKeyB64). */
+export async function keyIdFor(publicKeyB64: string): Promise<string> {
+  return (await sha256Hex(publicKeyB64)).slice(0, 16)
+}
+
+export async function generateDocSigningKeyPair(): Promise<{
+  keyId: string
+  publicKeyB64: string        // base64url raw (32 bytes) — non-secret, publishable
+  privateKeyPkcs8B64: string  // base64url pkcs8 — secret, wrap before persisting
+}> {
+  const kp = (await globalThis.crypto.subtle.generateKey(ALG, true, ['sign', 'verify'])) as CryptoKeyPair
+  const rawPub = new Uint8Array(await globalThis.crypto.subtle.exportKey('raw', kp.publicKey))
+  const pkcs8 = new Uint8Array(await globalThis.crypto.subtle.exportKey('pkcs8', kp.privateKey))
+  const publicKeyB64 = bytesToB64url(rawPub)
+  return { keyId: await keyIdFor(publicKeyB64), publicKeyB64, privateKeyPkcs8B64: bytesToB64url(pkcs8) }
+}
+
+export async function ed25519Sign(privateKeyPkcs8B64: string, message: Uint8Array): Promise<string> {
+  const key = await globalThis.crypto.subtle.importKey('pkcs8', b64urlToBytes(privateKeyPkcs8B64), ALG, false, ['sign'])
+  const sig = new Uint8Array(await globalThis.crypto.subtle.sign(ALG, key, message))
+  return bytesToB64url(sig)
+}
+
+export async function ed25519Verify(publicKeyB64: string, sigB64url: string, message: Uint8Array): Promise<boolean> {
+  try {
+    const key = await globalThis.crypto.subtle.importKey('raw', b64urlToBytes(publicKeyB64), ALG, false, ['verify'])
+    return await globalThis.crypto.subtle.verify(ALG, key, b64urlToBytes(sigB64url), message)
+  } catch {
+    return false
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/attestation && npx vitest run __tests__/ed25519.test.ts`
+Expected: PASS. If `exportKey('raw', publicKey)` throws on this runtime (older WebCrypto), fall back to `'spki'` export for the public key and `importKey('spki', ...)` in verify — adjust both sites together and note it in the commit. (Node 20 supports `'raw'` for Ed25519 public keys.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/attestation/src/ed25519.ts packages/attestation/__tests__/ed25519.test.ts
+git commit -m "feat(attestation): Ed25519 keygen/sign/verify via WebCrypto + stable keyId"
+```
+
+---
+
+## Task 5: QR payload codec
+
+**Files:**
+- Create: `packages/attestation/src/qr.ts`
+- Test: `packages/attestation/__tests__/qr.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/attestation/__tests__/qr.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { encodeQr, decodeQr } from '../src/qr.js'
+import type { QrPayload } from '../src/qr.js'
+
+const payload: QrPayload = {
+  v: 1, docId: '01J0ABCDEF', salt: 'c2FsdA', alg: 'ed25519', keyId: 'abcdef0123456789',
+  fieldHashes: ['aaa', 'bbb'], sig: 'c2ln',
+}
+
+describe('QR codec', () => {
+  it('encode → decode round-trips', () => {
+    expect(decodeQr(encodeQr(payload))).toEqual(payload)
+  })
+  it('encoded string is url-safe', () => {
+    expect(encodeQr(payload)).not.toMatch(/[+/=]/)
+  })
+  it('rejects a non-v1 payload on decode', () => {
+    const bad = encodeQr({ ...payload, v: 2 as unknown as 1 })
+    expect(() => decodeQr(bad)).toThrow(/version/)
+  })
+  it('rejects structurally invalid payloads', () => {
+    expect(() => decodeQr('not-base64url!!!')).toThrow()
+    const missing = encodeQr({ ...payload, sig: undefined as unknown as string })
+    expect(() => decodeQr(missing)).toThrow(/sig|invalid/)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/attestation && npx vitest run __tests__/qr.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `src/qr.ts`**
+
+```ts
+import { bytesToB64url, b64urlToBytes, utf8 } from './encoding.js'
+
+export interface QrPayload {
+  readonly v: 1
+  readonly docId: string
+  readonly salt: string
+  readonly alg: 'ed25519'
+  readonly keyId: string
+  readonly fieldHashes: readonly string[]
+  readonly sig: string
+}
+
+/** Compact JSON → base64url. (CBOR + base45 density optimisation deferred.) */
+export function encodeQr(p: QrPayload): string {
+  return bytesToB64url(utf8(JSON.stringify(p)))
+}
+
+export function decodeQr(s: string): QrPayload {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(b64urlToBytes(s)))
+  } catch {
+    throw new Error('decodeQr: not a valid base64url-encoded JSON payload')
+  }
+  const p = parsed as Record<string, unknown>
+  if (p['v'] !== 1) throw new Error(`decodeQr: unsupported version ${String(p['v'])} (expected 1)`)
+  if (typeof p['docId'] !== 'string' || typeof p['salt'] !== 'string' || p['alg'] !== 'ed25519'
+      || typeof p['keyId'] !== 'string' || typeof p['sig'] !== 'string'
+      || !Array.isArray(p['fieldHashes']) || !p['fieldHashes'].every((h) => typeof h === 'string')) {
+    throw new Error('decodeQr: invalid payload shape')
+  }
+  return {
+    v: 1, docId: p['docId'], salt: p['salt'], alg: 'ed25519',
+    keyId: p['keyId'], fieldHashes: p['fieldHashes'] as string[], sig: p['sig'],
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/attestation && npx vitest run __tests__/qr.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/attestation/src/qr.ts packages/attestation/__tests__/qr.test.ts
+git commit -m "feat(attestation): QR payload codec (compact-JSON → base64url) with structural validation"
+```
+
+---
+
+## Task 6: signPayloadCore + verifyAttestation
+
+**Files:**
+- Create: `packages/attestation/src/verify.ts`
+- Test: `packages/attestation/__tests__/verify.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/attestation/__tests__/verify.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { signPayloadCore, verifyAttestation } from '../src/verify.js'
+import { computeFieldHashes } from '../src/hashing.js'
+import { generateDocSigningKeyPair } from '../src/ed25519.js'
+import { encodeQr } from '../src/qr.js'
+import type { QrPayload } from '../src/qr.js'
+import type { AttestationFieldSchema } from '../src/types.js'
+
+const schema: AttestationFieldSchema = {
+  fields: [
+    { path: 'invoiceNo', normalize: 'alnum-upper' },
+    { path: 'total', normalize: 'cents' },
+    { path: 'issueDate', normalize: 'iso-date' },
+  ],
+}
+const fields = { invoiceNo: 'INV-1001', total: 1234.5, issueDate: '2026-05-29' }
+
+async function issue() {
+  const kp = await generateDocSigningKeyPair()
+  const salt = 'c2FsdHNhbHRzYWx0c2Fs'
+  const docId = '01J0DOC0001'
+  const fieldHashes = await computeFieldHashes(salt, schema, fields)
+  const sig = await signPayloadCore({ v: 1, docId, salt, keyId: kp.keyId, fieldHashes }, kp.privateKeyPkcs8B64)
+  const payload: QrPayload = { v: 1, docId, salt, alg: 'ed25519', keyId: kp.keyId, fieldHashes, sig }
+  return { kp, payload, qr: encodeQr(payload), salt, docId }
+}
+
+describe('verifyAttestation', () => {
+  it('valid: matching fields + correct key → valid', async () => {
+    const { kp, qr } = await issue()
+    const r = await verifyAttestation({ qr, claimedFields: fields, fieldSchema: schema, publicKeys: { [kp.keyId]: kp.publicKeyB64 } })
+    expect(r.valid).toBe(true)
+    expect(r.signatureValid).toBe(true)
+    expect(r.perField.every((f) => f.match)).toBe(true)
+    expect(r.revoked).toBeNull()
+  })
+  it('localizes a single altered field', async () => {
+    const { kp, qr } = await issue()
+    const r = await verifyAttestation({ qr, claimedFields: { ...fields, total: 9999.0 }, fieldSchema: schema, publicKeys: { [kp.keyId]: kp.publicKeyB64 } })
+    expect(r.valid).toBe(false)
+    expect(r.signatureValid).toBe(true)
+    expect(r.perField.find((f) => f.path === 'total')!.match).toBe(false)
+    expect(r.perField.find((f) => f.path === 'invoiceNo')!.match).toBe(true)
+    expect(r.reason).toMatch(/field/)
+  })
+  it('forged QR (attacker key not in publicKeys) → signatureValid false', async () => {
+    const { qr } = await issue()
+    const attacker = await generateDocSigningKeyPair()
+    const r = await verifyAttestation({ qr, claimedFields: fields, fieldSchema: schema, publicKeys: { [attacker.keyId]: attacker.publicKeyB64 } })
+    expect(r.signatureValid).toBe(false)
+    expect(r.valid).toBe(false)
+    expect(r.reason).toMatch(/keyId/)
+  })
+  it('schema/payload field-count mismatch → invalid', async () => {
+    const { kp, qr } = await issue()
+    const shortSchema: AttestationFieldSchema = { fields: [{ path: 'invoiceNo', normalize: 'alnum-upper' }] }
+    const r = await verifyAttestation({ qr, claimedFields: fields, fieldSchema: shortSchema, publicKeys: { [kp.keyId]: kp.publicKeyB64 } })
+    expect(r.valid).toBe(false)
+    expect(r.reason).toMatch(/count/)
+  })
+  it('revoked docId → valid false, revoked true', async () => {
+    const { kp, qr, docId } = await issue()
+    const r = await verifyAttestation({
+      qr, claimedFields: fields, fieldSchema: schema, publicKeys: { [kp.keyId]: kp.publicKeyB64 },
+      revocation: { list: { v: 1, revokedDocIds: [docId], asOf: '2026-06-01T00:00:00Z', keyId: kp.keyId, sig: 'x' } },
+    })
+    expect(r.revoked).toBe(true)
+    expect(r.valid).toBe(false)
+    expect(r.reason).toMatch(/revoked/)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/attestation && npx vitest run __tests__/verify.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `src/verify.ts`**
+
+```ts
+import type { AttestationFieldSchema } from './types.js'
+import type { QrPayload } from './qr.js'
+import type { RevocationList } from './revocation.js'
+import { canonicalJson, utf8 } from './encoding.js'
+import { ed25519Sign, ed25519Verify } from './ed25519.js'
+import { computeFieldHashes } from './hashing.js'
+import { decodeQr } from './qr.js'
+import { isRevoked } from './revocation.js'
+
+export interface VerifyInput {
+  readonly qr: string
+  readonly claimedFields: Record<string, unknown>
+  readonly fieldSchema: AttestationFieldSchema
+  readonly publicKeys: Readonly<Record<string, string>>
+  readonly revocation?: { list: RevocationList }
+}
+export interface VerifyResult {
+  readonly valid: boolean
+  readonly signatureValid: boolean
+  readonly perField: ReadonlyArray<{ path: string; match: boolean }>
+  readonly revoked: boolean | null
+  readonly reason?: string
+}
+
+/** The bytes the signature covers: canonicalJson of the payload minus `alg`/`sig`. */
+function signedCore(core: { v: 1; docId: string; salt: string; keyId: string; fieldHashes: readonly string[] }): Uint8Array {
+  return utf8(canonicalJson({ v: core.v, docId: core.docId, salt: core.salt, keyId: core.keyId, fieldHashes: core.fieldHashes }))
+}
+
+export async function signPayloadCore(
+  core: { v: 1; docId: string; salt: string; keyId: string; fieldHashes: readonly string[] },
+  privateKeyPkcs8B64: string,
+): Promise<string> {
+  return ed25519Sign(privateKeyPkcs8B64, signedCore(core))
+}
+
+export async function verifyAttestation(input: VerifyInput): Promise<VerifyResult> {
+  const p: QrPayload = decodeQr(input.qr)
+  const pub = input.publicKeys[p.keyId]
+  const signatureValid = pub
+    ? await ed25519Verify(pub, p.sig, signedCore({ v: p.v, docId: p.docId, salt: p.salt, keyId: p.keyId, fieldHashes: p.fieldHashes }))
+    : false
+
+  const schema = input.fieldSchema
+  const perField: Array<{ path: string; match: boolean }> = []
+  let allMatch = true
+  let countMismatch = false
+  if (schema.fields.length !== p.fieldHashes.length) {
+    countMismatch = true
+    allMatch = false
+    for (const f of schema.fields) perField.push({ path: f.path, match: false })
+  } else {
+    const recomputed = await computeFieldHashes(p.salt, schema, input.claimedFields)
+    for (let i = 0; i < schema.fields.length; i++) {
+      const match = recomputed[i] === p.fieldHashes[i]
+      perField.push({ path: schema.fields[i]!.path, match })
+      if (!match) allMatch = false
+    }
+  }
+
+  const revoked = input.revocation ? isRevoked(p.docId, input.revocation.list) : null
+  const valid = signatureValid && allMatch && revoked !== true
+
+  let reason: string | undefined
+  if (!signatureValid) reason = pub ? 'signature invalid' : 'unknown keyId'
+  else if (countMismatch) reason = 'schema/payload field-count mismatch'
+  else if (!allMatch) reason = 'field mismatch'
+  else if (revoked === true) reason = 'revoked'
+
+  return { valid, signatureValid, perField, revoked, reason }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/attestation && npx vitest run __tests__/verify.test.ts`
+Expected: PASS. (`revocation.ts` is created in Task 7; the import will fail until then. To keep this task green standalone, create a minimal `src/revocation.ts` stub now exporting `RevocationList` + `isRevoked` — Task 7 adds `verifyRevocationList` + its tests. If you prefer strict ordering, do Task 7 before Task 6's Step 4.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/attestation/src/verify.ts packages/attestation/__tests__/verify.test.ts
+git commit -m "feat(attestation): signPayloadCore + verifyAttestation (per-field localization, forgery + revocation gates)"
+```
+
+---
+
+## Task 7: Revocation format + check
+
+**Files:**
+- Create (or complete the stub from Task 6): `packages/attestation/src/revocation.ts`
+- Test: `packages/attestation/__tests__/revocation.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/attestation/__tests__/revocation.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { isRevoked, verifyRevocationList, signRevocationList } from '../src/revocation.js'
+import { generateDocSigningKeyPair } from '../src/ed25519.js'
+
+describe('revocation', () => {
+  it('isRevoked checks membership', () => {
+    const list = { v: 1 as const, revokedDocIds: ['a', 'b'], asOf: '2026-06-01T00:00:00Z', keyId: 'k', sig: 'x' }
+    expect(isRevoked('a', list)).toBe(true)
+    expect(isRevoked('z', list)).toBe(false)
+  })
+  it('signRevocationList → verifyRevocationList round-trips', async () => {
+    const kp = await generateDocSigningKeyPair()
+    const list = await signRevocationList(['01J0DOC0001', '01J0DOC0002'], '2026-06-01T00:00:00Z', kp.keyId, kp.privateKeyPkcs8B64)
+    expect(await verifyRevocationList(list, kp.publicKeyB64)).toBe(true)
+  })
+  it('verifyRevocationList fails on tamper', async () => {
+    const kp = await generateDocSigningKeyPair()
+    const list = await signRevocationList(['01J0DOC0001'], '2026-06-01T00:00:00Z', kp.keyId, kp.privateKeyPkcs8B64)
+    const tampered = { ...list, revokedDocIds: [...list.revokedDocIds, '01J0EVIL'] }
+    expect(await verifyRevocationList(tampered, kp.publicKeyB64)).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/attestation && npx vitest run __tests__/revocation.test.ts`
+Expected: FAIL — `signRevocationList`/`verifyRevocationList` not exported (or module missing).
+
+- [ ] **Step 3: Implement `src/revocation.ts`**
+
+```ts
+import { canonicalJson, utf8 } from './encoding.js'
+import { ed25519Sign, ed25519Verify } from './ed25519.js'
+
+export interface RevocationList {
+  readonly v: 1
+  readonly revokedDocIds: readonly string[]
+  readonly asOf: string
+  readonly keyId: string
+  readonly sig: string
+}
+
+function listCore(revokedDocIds: readonly string[], asOf: string, keyId: string): Uint8Array {
+  return utf8(canonicalJson({ v: 1, revokedDocIds: [...revokedDocIds].sort(), asOf, keyId }))
+}
+
+export function isRevoked(docId: string, list: RevocationList): boolean {
+  return list.revokedDocIds.includes(docId)
+}
+
+export async function signRevocationList(
+  revokedDocIds: readonly string[], asOf: string, keyId: string, privateKeyPkcs8B64: string,
+): Promise<RevocationList> {
+  const sorted = [...revokedDocIds].sort()
+  const sig = await ed25519Sign(privateKeyPkcs8B64, listCore(sorted, asOf, keyId))
+  return { v: 1, revokedDocIds: sorted, asOf, keyId, sig }
+}
+
+export async function verifyRevocationList(list: RevocationList, publicKeyB64: string): Promise<boolean> {
+  if (list.v !== 1) return false
+  return ed25519Verify(publicKeyB64, list.sig, listCore(list.revokedDocIds, list.asOf, list.keyId))
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/attestation && npx vitest run __tests__/revocation.test.ts && npx vitest run`
+Expected: PASS for revocation, and the full package suite green (verify.test.ts now resolves its `revocation.js` import against the real module).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/attestation/src/revocation.ts packages/attestation/__tests__/revocation.test.ts
+git commit -m "feat(attestation): signed revocation list — format, isRevoked, sign/verify"
+```
+
+---
+
+## Task 8: Barrel exports + integration (build, lint, typecheck, workspace, features)
+
+**Files:**
+- Create: `packages/attestation/src/index.ts`
+- Modify: `features.yaml` (only if the validator requires it)
+
+- [ ] **Step 1: Write the failing test**
+
+`packages/attestation/__tests__/index.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import * as api from '../src/index.js'
+
+describe('public API surface', () => {
+  it('exports the documented functions', () => {
+    for (const name of [
+      'canonicalJson', 'sha256Hex', 'normalizeField', 'validateFieldSchema',
+      'computeFieldHashes', 'generateDocSigningKeyPair', 'encodeQr', 'decodeQr',
+      'signPayloadCore', 'verifyAttestation', 'isRevoked', 'verifyRevocationList', 'signRevocationList',
+    ]) {
+      expect(typeof (api as Record<string, unknown>)[name]).toBe('function')
+    }
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/attestation && npx vitest run __tests__/index.test.ts`
+Expected: FAIL — `../src/index.js` not found.
+
+- [ ] **Step 3: Implement `src/index.ts`**
+
+```ts
+/**
+ * @noy-db/attestation — pure document-attestation primitive.
+ * @packageDocumentation
+ */
+export type { Normalizer, AttestationFieldSpec, AttestationFieldSchema } from './types.js'
+export type { QrPayload } from './qr.js'
+export type { RevocationList } from './revocation.js'
+export type { VerifyInput, VerifyResult } from './verify.js'
+
+export { canonicalJson, sha256Hex, sha256Bytes, bytesToHex, bytesToB64url, b64urlToBytes, utf8 } from './encoding.js'
+export { normalizeField, validateFieldSchema, getPath } from './normalize.js'
+export { computeFieldHashes } from './hashing.js'
+export { generateDocSigningKeyPair, ed25519Sign, ed25519Verify, keyIdFor } from './ed25519.js'
+export { encodeQr, decodeQr } from './qr.js'
+export { signPayloadCore, verifyAttestation } from './verify.js'
+export { isRevoked, verifyRevocationList, signRevocationList } from './revocation.js'
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/attestation && npx vitest run`
+Expected: PASS — all test files green.
+
+- [ ] **Step 5: Build + lint + typecheck the package**
+
+Run (from repo root):
+```bash
+npx turbo run build lint typecheck --filter=@noy-db/attestation
+```
+Expected: build emits `dist/index.{js,cjs,d.ts,d.cts}`; lint + typecheck clean. Fix any issues (e.g. eslint config inclusion for the new package — mirror on-shamir's setup if the package isn't picked up).
+
+- [ ] **Step 6: Spec-coverage / features registry**
+
+Run:
+```bash
+node scripts/validate-features.mjs 2>&1 | tail -10
+```
+If it passes with the new package present, no edit needed (this package has no user-facing hub feature row yet — that lands with the ①b hub plan). If it reports the new package as an unregistered/dangling artifact, add the minimal registration it asks for (likely an `exports`/package entry; mirror how `on-shamir` appears, if at all). Do NOT invent a hub `attestation` feature row here — the subsystem doesn't exist until ①b.
+
+- [ ] **Step 7: Full-suite smoke + commit**
+
+Run:
+```bash
+npx vitest run --reporter=dot --project attestation
+```
+Expected: all attestation tests pass.
+
+```bash
+git add packages/attestation/src/index.ts packages/attestation/__tests__/index.test.ts features.yaml
+git commit -m "feat(attestation): public API barrel + workspace/build integration
+
+@noy-db/attestation builds (ESM+CJS), lints, typechecks, and ships the
+full pure primitive: commitment, normalizers, per-field hashing, Ed25519
+sign/verify, QR codec, signed revocation list. Ready for the hub issue
+side (@noy-db/hub/attestation) to depend on."
+```
+
+---
+
+## Self-Review (completed)
+
+- **Spec coverage** (sub-spec §3): canonicalJson/sha256 (T1) ✓; normalizers + validateFieldSchema (T2) ✓; per-field salted hashing §3.2 (T3) ✓; Ed25519 + keyId §3.5 (T4) ✓; QR codec §3.5 (T5) ✓; signedCore §3.4 + verifyAttestation §3.6 (T6) ✓; revocation §3.1/§3.5 (T7) ✓; full public API §3.5 (T8) ✓. Deferred-by-design (sub-spec §4/§8): hub issue side, `_attestations`, collection option, QR image, list hosting — explicitly the ①b plan, not here.
+- **Placeholder scan:** none — every step has complete code.
+- **Type consistency:** `QrPayload` (T5) reused identically in T6; `signedCore` excludes `alg`+`sig` consistently in T6 sign + verify; `RevocationList` defined T7, forward-imported as a type in T6 (stub note in T6 Step 4 handles ordering); `keyId` = `sha256Hex(pub).slice(0,16)` consistent T4/T6/T7; `computeFieldHashes(salt, schema, values)` signature identical T3/T6.
+- **Known ordering dependency:** T6 imports `./revocation.js` (T7). Documented in T6 Step 4 with two resolutions (stub-first or reorder). The subagent executing T6 must create the revocation stub or do T7 first — called out explicitly.

--- a/docs/superpowers/specs/2026-05-29-attestation-core-and-issue-design.md
+++ b/docs/superpowers/specs/2026-05-29-attestation-core-and-issue-design.md
@@ -1,0 +1,210 @@
+# Attestation core + issue side — sub-spec ① (the spine)
+
+**Status:** sub-spec (ready for plan), under [document-attestation umbrella](2026-05-29-document-attestation-umbrella-design.md)
+**Authoring date:** 2026-05-29
+**Covers:** ①a `@noy-db/attestation` (pure, hub-free package) + ①b `@noy-db/hub/attestation` (vault-coupled issue side)
+**Out of this sub-spec:** HTML→PDF Lambda (③), QR *image* rendering (③/app), revocation-list *publishing/hosting* (⑤/app), in-browser vision extraction (④ enhancement). The pure revocation *check* IS in scope (it's pure).
+
+---
+
+## 1. Scope
+
+Two units, tightly coupled by a one-way dependency (`hub → attestation`):
+
+- **①a `@noy-db/attestation`** — pure, zero-runtime-dependency package (the `on-shamir` precedent). Owns the cryptographic + format contracts: commitment formula, normalizers, per-field hashing, Ed25519 sign/verify, QR payload codec, revocation format + check. Runs in any runtime (Node, browser) with no vault. The static verifier (④) imports **only** this.
+- **①b `@noy-db/hub/attestation`** — hub subpath subsystem (like `bundle`/`history`). The vault-coupled *issue* side: reads a collection's declared field-schema, extracts + normalizes the record's field values, mints `docId` + `salt`, computes per-field hashes via ①a, lazily mints + KEK-wraps the Ed25519 signing key in the keyring, signs via ①a, persists an encrypted `_attestations/<docId>` index record, returns the QR string.
+
+## 2. Decisions made in this sub-spec (flag on review)
+
+1. **Per-field commitment (not whole-document).** The QR carries one salted hash per committed field + one signature over the set. Enables offline "which field differs" localization. Cost: denser QR (~250 B for 5 fields). *Lighter alternative:* a single whole-document hash (~100 B QR, no localization). **Chosen: per-field**, matching the umbrella's `perField` result and the firm's dispute-resolution need.
+2. **Ed25519 via WebCrypto** (zero-dep; Node 20 + modern browsers). *Caveat:* Ed25519 in browser WebCrypto requires recent versions (Chrome 137+, Safari 17+, Firefox 129+). *Fallback if legacy browsers matter:* add `@noble/ed25519` (one tiny audited dep) behind the same internal signer interface. **Chosen: WebCrypto**, documented min-browser; fallback noted.
+3. **`_attestations` record is ENCRYPTED, not a plaintext bypass** (corrects umbrella §3.1). It is the firm's private index of issued documents, read only by the firm with their own keyring — there is no pre-auth or third-party-auditor reader (verification is offline via the QR, never touches this record). So it uses a normal collection DEK and needs **no** plaintext-bypass.md catalog entry.
+4. **`canonicalJson`/`sha256Hex` replicated** in ①a (hub-free) with a conformance test against fixed vectors. No import from hub; no change to the ledger.
+
+## 3. `@noy-db/attestation` (①a) — pure package
+
+### 3.1 Types
+```ts
+export type Normalizer = 'trim' | 'lower' | 'upper' | 'alnum-upper' | 'digits' | 'cents' | 'iso-date'
+
+export interface AttestationFieldSpec {
+  readonly path: string          // dot-path into the record, e.g. 'total' or 'issuer.taxId'
+  readonly normalize: Normalizer
+}
+export interface AttestationFieldSchema {
+  readonly fields: readonly AttestationFieldSpec[]   // ORDER IS PART OF THE CONTRACT
+}
+
+export interface QrPayload {
+  readonly v: 1
+  readonly docId: string                 // ULID
+  readonly salt: string                  // base64url, 16 bytes
+  readonly alg: 'ed25519'
+  readonly keyId: string
+  readonly fieldHashes: readonly string[]  // base64url sha256, one per field, in schema order
+  readonly sig: string                   // base64url Ed25519 over the signed core (§3.4)
+}
+
+export interface RevocationList {
+  readonly v: 1
+  readonly revokedDocIds: readonly string[]   // sorted ULIDs
+  readonly asOf: string                       // ISO-8601
+  readonly keyId: string
+  readonly sig: string                        // base64url Ed25519 over canonicalJson({v,revokedDocIds,asOf,keyId})
+}
+
+export interface VerifyInput {
+  readonly qr: string                                   // scanned QR string (decoded via decodeQr)
+  readonly claimedFields: Record<string, unknown>       // values read off the verifier's copy
+  readonly fieldSchema: AttestationFieldSchema          // must match issue-time (verifier-configured)
+  readonly publicKeys: Readonly<Record<string, string>> // keyId → base64url raw Ed25519 public key
+  readonly revocation?: { list: RevocationList }        // optional "still valid?" check
+}
+export interface VerifyResult {
+  readonly valid: boolean                               // signatureValid && allFieldsMatch && !revoked
+  readonly signatureValid: boolean
+  readonly perField: ReadonlyArray<{ path: string; match: boolean }>
+  readonly revoked: boolean | null                      // null when no revocation list supplied
+  readonly reason?: string                              // populated on the first failing gate
+}
+```
+
+### 3.2 Commitment & per-field hashing
+```
+fieldHash[i] = sha256Hex( canonicalJson([ salt_b64, fields[i].path, normalize(value[i], fields[i].normalize) ]) )  → base64url
+```
+- Domain-separated by `path` so two fields with equal values get distinct hashes.
+- Per-document random `salt` defeats brute-force of low-entropy fields (e.g. an amount) and cross-document correlation.
+- `normalize` is the **closed set** (§3.3) so issue-time and verify-time produce byte-identical inputs regardless of source format.
+
+### 3.3 Normalizers (closed set)
+| name | rule |
+|---|---|
+| `trim` | `String(v).trim()` |
+| `lower` | `trim` then lowercase |
+| `upper` | `trim` then uppercase |
+| `alnum-upper` | strip non-`[A-Za-z0-9]`, uppercase (tax-ids, doc numbers) |
+| `digits` | strip non-`[0-9]` (phone, account no.) |
+| `cents` | parse number, `Math.round(n*100)`, integer string — `1234.50` → `"123450"` (money, OCR-robust to thousands separators when paired with client pre-strip) |
+| `iso-date` | parse to `YYYY-MM-DD` (UTC), throw on unparseable |
+
+Unknown normalizer → throw at schema-validation time (fail fast, not silent).
+
+### 3.4 Signed core + signature
+```
+signedCore = canonicalJson({ v, docId, salt, keyId, fieldHashes })   // NOTE: excludes sig
+sig        = base64url( Ed25519_sign(privKey, utf8(signedCore)) )
+```
+`docId` is inside the signed core, so a signature cannot be transplanted to another document. The commitment (set of fieldHashes) is what's signed — the verifier proves authenticity by re-deriving `signedCore` from the QR's own fields and checking the signature; it proves integrity by recomputing each `fieldHash` from the document and comparing.
+
+### 3.5 Public API (pure functions)
+```ts
+export function validateFieldSchema(s: AttestationFieldSchema): void          // closed-normalizer check
+export function normalizeField(value: unknown, n: Normalizer): string
+export async function computeFieldHashes(saltB64: string, schema: AttestationFieldSchema, values: Record<string, unknown>): Promise<string[]>
+export async function signPayloadCore(core: Omit<QrPayload,'sig'|'alg'>, privKeyPkcs8B64: string): Promise<string>  // → sig
+export function encodeQr(p: QrPayload): string                                // compact-JSON → base64url
+export function decodeQr(s: string): QrPayload                                // + structural validation
+export async function verifyAttestation(input: VerifyInput): Promise<VerifyResult>
+export async function generateDocSigningKeyPair(): Promise<{ keyId: string; publicKeyB64: string; privateKeyPkcs8B64: string }>
+export function isRevoked(docId: string, list: RevocationList): boolean
+export async function verifyRevocationList(list: RevocationList, publicKeyB64: string): Promise<boolean>
+```
+- `keyId = sha256Hex(publicKeyB64).slice(0,16)` (stable, collision-safe enough for key selection).
+- Internal helpers (not exported): `canonicalJson`, `sha256Hex`, `bytesToHex`, `base64url` enc/dec, `ed25519Sign`/`ed25519Verify` (WebCrypto). All zero-dep.
+- **Encoding (v1):** compact JSON → base64url (universal, debuggable). *Density follow-up (noted, not built):* CBOR + base45 to exploit QR alphanumeric mode.
+
+### 3.6 `verifyAttestation` algorithm
+1. `decodeQr(qr)` → payload (structural + version check; reject `v !== 1`).
+2. Re-derive `signedCore` from the payload; `signatureValid = ed25519Verify(publicKeys[payload.keyId], payload.sig, signedCore)`. Missing keyId → `signatureValid=false`, reason `"unknown keyId"`.
+3. For each `fields[i]`: `expected = payload.fieldHashes[i]`; `actual = computeFieldHashes(payload.salt, schema, claimedFields)[i]`; `perField[i] = { path, match: expected===actual }`. Length mismatch between schema and `fieldHashes` → reason `"schema/payload field-count mismatch"`, all `match=false`.
+4. `revoked = revocation ? isRevoked(payload.docId, revocation.list) : null`. (Caller is responsible for having `verifyRevocationList`'d the list first; `verifyAttestation` does not re-verify it — keeps the gate explicit.)
+5. `valid = signatureValid && perField.every(f=>f.match) && revoked !== true`. `reason` = first failing gate.
+
+## 4. `@noy-db/hub/attestation` (①b) — vault-coupled issue side
+
+### 4.1 Collection declaration
+```ts
+company.collection<Invoice>('invoices', {
+  schema: InvoiceSchema,
+  attestation: { fields: [
+    { path: 'invoiceNo',   normalize: 'alnum-upper' },
+    { path: 'total',       normalize: 'cents' },
+    { path: 'issueDate',   normalize: 'iso-date' },
+    { path: 'vatAmount',   normalize: 'cents' },
+    { path: 'issuerTaxId', normalize: 'alnum-upper' },
+  ]},
+})
+```
+`attestation?: AttestationFieldSchema` is a new optional field on the collection options (sits beside `schema`/`refs`). `validateFieldSchema` runs at collection-definition time.
+
+### 4.2 Signing keypair in the keyring (lazy)
+New optional `KeyringFile` field:
+```ts
+readonly doc_signing_key?: {
+  readonly keyId: string
+  readonly alg: 'ed25519'
+  readonly publicKey: string        // base64url raw — non-secret, for publishing
+  readonly wrappedPrivKey: string   // base64url AES-GCM(iv‖ct‖tag) of the pkcs8 private key, under the owner KEK
+}
+```
+- **Lazy mint:** first `issueAttestation` on a vault with no `doc_signing_key` generates one (`generateDocSigningKeyPair`), AES-GCM-encrypts the pkcs8 private key under the owner KEK (fresh IV, same pattern as recovery blobs — NOT AES-KW, which is for fixed-length material), persists the merged keyring. Idempotent: a present key is reused.
+- **Owner-only:** issuing requires the owner role (the signing key is the firm's identity). Non-owners → `AttestationError`.
+- Publishing the public key is a separate explicit read: `vault.getDocumentSigningPublicKey() → { keyId, publicKey }`.
+
+### 4.3 `_attestations` index record (encrypted)
+```ts
+// _attestations/<docId>, encrypted under a dedicated `_attestations` collection DEK
+{ docId, sourceRefs: [{ collection, id, version }], issuedAt, keyId, fieldPaths: string[] }
+```
+The firm's private record of what was issued and against which record version(s). Encrypted (normal DEK) — no plaintext bypass. `version` pins the source record version so a later edit is detectable ("issued against v3; record is now v5").
+
+### 4.4 Issue API
+```ts
+const { docId, qr, payload } = await vault.issueAttestation('invoices', 'inv-1001')
+// docId: ULID
+// qr:    string to draw as a QR (encodeQr output)
+// payload: the QrPayload (for callers that want the structured form)
+```
+Steps: load record → resolve collection `attestation.fields` (throw if undeclared) → extract values at each `path` → `computeFieldHashes(salt, schema, values)` → build `{v,docId,salt,keyId,fieldHashes}` → unwrap signing privKey under KEK (lazy-mint if absent) → `signPayloadCore` → assemble `QrPayload` → write encrypted `_attestations/<docId>` → return.
+
+### 4.5 Errors
+New `AttestationError extends NoydbError` for: undeclared field-schema on the collection, non-owner issue attempt, missing field at a declared path, signing-key unwrap failure.
+
+## 5. Test plan (TDD, library-side — no AWS/PDF/QR-image)
+
+**①a pure package** (`packages/attestation/__tests__/`):
+- `canonicalJson`/`sha256Hex` conformance to fixed vectors (byte-identical, documents the shared contract).
+- each normalizer: representative + edge inputs (e.g. `cents` on `1234.5`, `1234.50`, `"1,234.50"` after client strip; `iso-date` on a Date and an ISO string; unparseable → throws).
+- `computeFieldHashes` deterministic given salt+schema+values; changes when any field changes; domain-separation (two fields, equal values → distinct hashes).
+- Ed25519 sign→verify round-trip; wrong key → invalid; tampered `signedCore` → invalid.
+- `encodeQr`→`decodeQr` round-trip; reject `v!==1`, malformed base64url, missing fields.
+- `verifyAttestation`: happy path (valid); one field altered → `valid=false`, that `perField.match=false`, others true (localization); forged QR (self-signed by attacker key not in `publicKeys`) → `signatureValid=false`; unknown keyId; schema/payload count mismatch; revoked docId → `valid=false, revoked=true`.
+- `verifyRevocationList`: valid signed list passes; tampered list fails; `isRevoked` membership.
+
+**①b hub subsystem** (`packages/hub/__tests__/attestation.test.ts`):
+- `issueAttestation` end-to-end against an in-memory vault: returns a QR that `verifyAttestation` accepts when fed the same field values + the published public key.
+- lazy keypair mint: first issue creates `doc_signing_key`; second issue reuses it (same keyId).
+- owner-only: non-owner issue → `AttestationError`.
+- undeclared schema → `AttestationError`.
+- altered record after issue: re-extract + verify against the old QR → field mismatch detected.
+- `_attestations/<docId>` is encrypted (envelope `_iv !== ''`) and round-trips with the firm's keyring; `sourceRefs[].version` pins the issued version.
+- integration: issue → `encodeQr`/`decodeQr` → `verifyAttestation` with `getDocumentSigningPublicKey()` → `{valid:true}`.
+
+## 6. Packaging
+
+- New package `packages/attestation/` — name `@noy-db/attestation`, zero runtime deps, dual ESM/CJS via tsup (mirror `on-shamir`'s package.json shape). `engines.node >=18`; browser-safe (only WebCrypto globals).
+- `@noy-db/hub` gains `dependencies: { "@noy-db/attestation": "workspace:*" }` and a new subpath export `./attestation` (mirror the `./bundle` subpath wiring in hub's package.json + tsup config).
+- `features.yaml`: new `attestation` feature row in cluster `time-and-audit`, `package: '@noy-db/hub/attestation'`, referencing this sub-spec + the umbrella. Invariants: per-field salted commitment; Ed25519-signed; docId in signed core; `_attestations` encrypted; offline verify.
+
+## 7. Build order within this sub-spec
+
+①a first (pure, no deps) → ①b (imports ①a, needs keyring). The plan slices: (1) package scaffold + canonical/hash + conformance, (2) normalizers, (3) per-field hashing, (4) Ed25519 sign/verify + keygen, (5) QR codec, (6) verifyAttestation + revocation check, (7) hub: collection `attestation` option + keyring `doc_signing_key` + lazy mint, (8) hub: `issueAttestation` + encrypted `_attestations` + errors, (9) features.yaml + subpath wiring.
+
+## 8. Deferred to other sub-specs / follow-ups
+- QR *image* drawing + HTML→PDF Lambda → ③.
+- Revocation list *production/hosting/fetch* → ⑤ (this sub-spec ships only the pure format + check).
+- In-browser vision field extraction → ④ enhancement (produces the same `claimedFields`).
+- CBOR + base45 QR density optimization.
+- KMS-backed `DocumentSigner` (sign via `at-aws-kms` asymmetric) — the `signPayloadCore` boundary is the injection point.
+- Whole-document (single-hash) mode as a lighter alternative to per-field, if QR density becomes a problem.

--- a/docs/superpowers/specs/2026-05-29-document-attestation-umbrella-design.md
+++ b/docs/superpowers/specs/2026-05-29-document-attestation-umbrella-design.md
@@ -1,0 +1,147 @@
+# Document Attestation — umbrella design
+
+**Status:** umbrella spec (cross-cutting contracts + decomposition; each sub-system gets its own spec → plan)
+**Authoring date:** 2026-05-29
+**Cluster:** `time-and-audit` (beside `history` / `consent` — provenance + tamper-evidence)
+**Relates to:** #197 (recipient-target sealed delivery — the `at-aws-kms` KMS path lands in sub-system ③), the ledger hash primitives (`canonicalJson`, `sha256Hex` in `history/ledger/entry.ts`)
+
+---
+
+## 1. Problem
+
+An accounting firm issues documents (invoices, statements) to clients. Three needs:
+
+1. **Render** an HTML document to a downloadable PDF. A static webapp cannot do HTML→PDF reliably client-side; server-side rendering is required.
+2. **Prove authenticity + integrity** of a printed/forwarded document — that the firm issued it and it has not been altered — *without publishing any document content anywhere*.
+3. **Verify** that proof from a third party's copy (the original PDF, a re-print, a phone photo, a scan) returning only a yes/no (+ per-field detail), and optionally check the document has not since been revoked.
+
+The hard constraint: the firm must expose **no document content** on any public endpoint. A permanent "verification URL" that returns document data would violate this.
+
+## 2. Key architectural decision — verification is offline, the commitment travels in the QR
+
+Rather than a server-side commitment store with a verification endpoint, the **signed commitment travels inside the QR code printed on the document**. Verification is then **fully client-side and offline**:
+
+- There is no public endpoint that holds or returns document data — so there is nothing to disclose. The "zero-knowledge" property the firm wants comes from the verifier *possessing the document* and only **hashes/signatures** ever being public.
+- The HTML→PDF render service (a Lambda) is **generation-time only**. It is NOT in the verification path.
+
+**Integrity is not authenticity.** A plain (or symmetric-"encrypted") hash in the QR proves only that the visible fields are self-consistent with the QR — a forger can fabricate a fake document, hash *its* fields, and print *their own* matching QR. The fix is a **digital signature**: the QR carries `sign(firm_private_key, commitment)`, checked against the firm's **public** key. A forger cannot produce a valid signature without the private key. Symmetric encryption cannot deliver public verifiability (the verifier would need the secret, which would leak), so the primitive is an **asymmetric signature**, not encryption.
+
+**Threat model (chosen):** forgery-resistant signed QR, verified offline, **plus** a signed revoked-`docId` list for "still valid today?" checks. Revocation is the one capability an offline QR cannot provide on its own; the published list reveals only opaque ULIDs (zero document disclosure).
+
+## 3. Cross-cutting contracts
+
+These are the contracts every sub-system must agree on. Locking them is the purpose of this umbrella.
+
+### 3.1 docId
+A ULID minted per **issued document** (a document may render from several records). The vault stores `docId → { sourceRefs: [{collection, id, version}], issuedAt, keyId }` in a plaintext-bypass `_attestations` collection (auditor-readable, like `_ledger`; see plaintext-bypass.md — adding it is a SPEC change and this umbrella is that spec). The docId is the anchor every other contract references.
+
+### 3.2 Commitment
+```
+C = sha256Hex( salt ‖ canonicalJson(orderedFields) )
+```
+- `salt` — 16 random bytes minted per document, printed in the QR.
+- `orderedFields` — the field values extracted per the collection's **verification field-schema** (§3.4), in declared order, each run through its per-field normalizer.
+- `canonicalJson` and `sha256Hex` — **reused verbatim** from `packages/hub/src/history/ledger/entry.ts`. Consistency with the ledger; already battle-tested.
+
+The commitment is **never** placed in the QR and **never** published. The verifier *recomputes* it from the visible document + the salt. This binds verification to possessing the document.
+
+### 3.3 Signature
+```
+sig = Ed25519_sign( firmDocSigningPrivKey, C )
+```
+- **Ed25519** — 64-byte signature, compact enough for a low-density QR. (RSA-PSS would be 256 bytes → denser QR; Ed25519 chosen for size. Pluggable — see §3.7.)
+- The firm's **document-signing keypair** is a new vault primitive: the private key is wrapped under the owner KEK and stored in the keyring beside the DEKs; the public key is published with a `keyId`.
+
+### 3.4 Verification field-schema (per collection)
+Declared per collection, alongside the existing `schema`/`refs`:
+```ts
+collection('invoices', {
+  schema: InvoiceSchema,
+  attestation: {
+    fields: [
+      { path: 'invoiceNo',    normalize: 'trim' },
+      { path: 'total',        normalize: 'cents' },     // 1234.50 → "123450"
+      { path: 'issueDate',    normalize: 'iso-date' },  // → "2026-05-29"
+      { path: 'vatAmount',    normalize: 'cents' },
+      { path: 'issuerTaxId',  normalize: 'alnum-upper' },
+    ],
+  },
+})
+```
+Field choice favours **OCR-stable, high-signal** values (numbers, ids, dates) over free text. Normalizers are a closed, declared set so issue-time and verify-time canonicalization are identical regardless of source format.
+
+### 3.5 QR payload
+```
+{ v: 1, docId, salt, alg: 'ed25519', keyId, sig }
+```
+base45-encoded for QR. ~100 bytes → comfortably scannable (~QR version 6–8). Contains **no commitment and no field values** — only what the verifier needs to recompute-and-check given the document in hand.
+
+### 3.6 Public-key distribution + rotation
+The firm publishes `{ keyId → publicKey }`. A static verifier **bundles the current public key(s) at build time** (most trustworthy — no fetch-time trust anchor) or fetches a **signed** key-list. The `keyId` in the QR selects the key, so rotating the signing key does not break previously issued documents (retain old public keys). Key rotation = a verifier app update or a re-published signed key-list.
+
+### 3.7 Pluggable signer (extension point, not built in v1)
+The signing operation is modeled behind a `DocumentSigner` interface (default: in-process Ed25519). A future KMS-backed signer (`at-aws-kms` asymmetric Sign/Verify) plugs in here — the same way `SealingKeyProvider` is pluggable. v1 ships only the in-process Ed25519 signer; the interface is defined so the KMS variant is an additive follow-up.
+
+### 3.8 Revocation list
+The firm signs and publishes `{ revokedDocIds: ULID[], asOf: ISO, sig }`. The verifier fetches it (cacheable; offline-capable with a cached copy, staleness bounded by cache TTL), checks the **firm's signature** on the list, then checks membership. Reveals only opaque ULIDs + that they are revoked — zero document disclosure.
+
+## 4. Sub-systems
+
+| # | Sub-system | Home | Depends on |
+|---|---|---|---|
+| **①a** | **Pure attestation core** — commitment formula, canonicalization, normalizers, Ed25519 sign+verify, QR payload codec, revocation format + `isRevoked()` | `@noy-db/attestation` (NEW unprefixed package, zero-dep, hub-free — `on-shamir`-style) | nothing |
+| **①b** | **Issue side (vault-coupled)** — docId mint + `_attestations` record, per-collection field-schema reading, KEK-wrapped signing key in the keyring, `issueAttestation(record) → {docId, salt, sig, keyId}` | `@noy-db/hub/attestation` (NEW hub subpath subsystem, like `bundle`/`history`) | `@noy-db/attestation`, hub keyring |
+| **②** | **QR codec** | folds **into** `@noy-db/attestation` (owns the payload byte-contract); QR *image drawing* is app-side | — |
+| **③** | **HTML→PDF render Lambda** — KMS-decrypt S3 doc, render HTML→PDF, embed ②'s QR, return download | `recipes/aws-kms-pdf-attestation/` (NEW recipes dir; deployable reference app, not published) + a showcase | `@noy-db/hub`, `@noy-db/to-aws-s3`, `@noy-db/at-aws-kms`, `@noy-db/attestation` |
+| **④** | **Offline verifier** — read QR + extract fields → recompute commitment → check sig vs. bundled public key → check ⑤ | a showcase + a `recipes/` snippet; consumes **only** `@noy-db/attestation` | `@noy-db/attestation` |
+| **⑤** | **Revocation** — format + `isRevoked()` are pure (in `@noy-db/attestation`); publish glue in the recipe/app | `@noy-db/attestation` + app | `@noy-db/attestation` |
+
+### Packaging footprint (the whole feature)
+- **1 new package:** `@noy-db/attestation` (pure primitive).
+- **1 new hub subpath:** `@noy-db/hub/attestation` (subsystem).
+- **1 new `recipes/` directory:** `recipes/aws-kms-pdf-attestation/` (first recipe).
+- **N showcases** in the existing `showcases/`.
+- **0 new prefix-family members.** Nothing in `to-/in-/on-/as-/by-/at-`. The KMS work *extends* the existing `at-aws-kms` package.
+
+Rationale: attestation is a **core verb of the engine** (issue/verify), like `history`/`consent`/`bundle` — those are hub subsystems, not prefixed packages. The six prefix families are **peripheral slots** (storage / runtime / identity / export-format / key-custodian / session-transport); none describe a core primitive. The pure core is split out as one package only because **verification must run hub-free** in a static page — the exact precedent set by `on-shamir` (pure Shamir math in the package, recovery orchestration in hub).
+
+## 5. End-to-end data flow
+
+**Issue (server / firm side):**
+1. `issueAttestation(record)` mints `docId`, reads the collection's `attestation.fields`, extracts + normalizes the field values, mints a 16-byte `salt`.
+2. Computes `C = sha256Hex(salt ‖ canonicalJson(orderedFields))`.
+3. Unwraps the firm signing private key under the owner KEK; `sig = Ed25519_sign(privKey, C)`.
+4. Writes the `_attestations/<docId>` record `{ sourceRefs, issuedAt, keyId }`.
+5. Returns `{ docId, salt, sig, keyId }`.
+
+**Render (③, Lambda, generation-time):**
+6. Lambda KMS-decrypts the S3-stored document, renders HTML→PDF, draws the QR from `{v,docId,salt,alg,keyId,sig}`, returns the PDF download.
+
+**Verify (④, client, offline):**
+7. Verifier extracts the same fields off their copy (typed, or vision-assisted client-side), normalizes identically, recomputes `C'`.
+8. Decodes the QR → `{docId, salt, alg, keyId, sig}`; checks `Ed25519_verify(pubKey[keyId], sig, C')`.
+9. (optional) Fetches the signed revocation list, checks `!isRevoked(docId)`.
+10. Result: `{ valid, perField, revoked }`.
+
+## 6. Build order
+
+`①a (pure core)` → `①b (issue side)` → `②` folds into ①a → (`④ verifier` + `⑤ revocation` in parallel) → `③ render recipe` (needs ①a, ①b, at-aws-kms).
+
+**First sub-spec:** ①a + ①b together (the `attestation` package + hub subsystem). It is the spine, fully library-side, no AWS/PDF/QR dependency, unit-testable end to end (issue → QR payload → verify → revoke) with in-process keys.
+
+## 7. Explicitly out of scope (this umbrella)
+
+- Server-side commitment store / verification endpoint (superseded by the offline-QR design).
+- Storing documents anywhere public (only signatures-in-QR and opaque revoked-ids are ever public).
+- Cryptographic ZKP (zk-SNARK et al.) — this is a commitment + signature scheme.
+- KMS-backed `DocumentSigner` — extension point defined (§3.7), implementation deferred to an `at-aws-kms` follow-up.
+- In-browser vision extraction — v1 verifier assumes manual field entry; vision is an additive client enhancement producing the same hash.
+- The actual QR *image* rendering library choice and the headless-Chromium Lambda layer — recipe-level decisions, made in ③'s spec.
+
+## 8. Open questions for the sub-specs (not blocking the umbrella)
+
+- ①: exact `_attestations` record shape + its plaintext-bypass catalog entry; the closed normalizer set; how `sourceRefs` pin record versions.
+- ①: whether the signing keypair is minted at owner-creation or lazily on first `issueAttestation`.
+- ②: base45 vs. base64url for the QR payload; CBOR vs. compact-JSON before encoding.
+- ③: headless-Chromium layer vs. a JS PDF lib; QR-drawing library; IAM least-privilege for the Lambda.
+- ⑤: revocation-list hosting + cache strategy; whether to support per-field "supersede" vs. whole-doc revoke.

--- a/packages/attestation/LICENSE
+++ b/packages/attestation/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 vLannaAi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/attestation/README.md
+++ b/packages/attestation/README.md
@@ -1,0 +1,3 @@
+# @noy-db/attestation
+
+Pure, zero-dependency document-attestation primitive for noy-db — per-field salted commitments, Ed25519 sign/verify, QR credential codec, and revocation checks. Runs in Node and the browser; the offline verifier imports only this.

--- a/packages/attestation/__tests__/ed25519.test.ts
+++ b/packages/attestation/__tests__/ed25519.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { generateDocSigningKeyPair, ed25519Sign, ed25519Verify } from '../src/ed25519.js'
+import { utf8 } from '../src/encoding.js'
+
+describe('Ed25519', () => {
+  it('generates a keypair with a stable 16-char keyId and base64url keys', async () => {
+    const kp = await generateDocSigningKeyPair()
+    expect(kp.keyId).toHaveLength(16)
+    expect(kp.publicKeyB64).not.toMatch(/[+/=]/)
+    expect(kp.privateKeyPkcs8B64).not.toMatch(/[+/=]/)
+  })
+  it('sign → verify round-trips', async () => {
+    const kp = await generateDocSigningKeyPair()
+    const msg = utf8('hello document')
+    const sig = await ed25519Sign(kp.privateKeyPkcs8B64, msg)
+    expect(sig).not.toMatch(/[+/=]/)
+    expect(await ed25519Verify(kp.publicKeyB64, sig, msg)).toBe(true)
+  })
+  it('verify fails for a different message', async () => {
+    const kp = await generateDocSigningKeyPair()
+    const sig = await ed25519Sign(kp.privateKeyPkcs8B64, utf8('original'))
+    expect(await ed25519Verify(kp.publicKeyB64, sig, utf8('tampered'))).toBe(false)
+  })
+  it('verify fails for a different key', async () => {
+    const a = await generateDocSigningKeyPair()
+    const b = await generateDocSigningKeyPair()
+    const sig = await ed25519Sign(a.privateKeyPkcs8B64, utf8('m'))
+    expect(await ed25519Verify(b.publicKeyB64, sig, utf8('m'))).toBe(false)
+  })
+  it('the same public key yields the same keyId', async () => {
+    const kp = await generateDocSigningKeyPair()
+    const { keyIdFor } = await import('../src/ed25519.js')
+    expect(await keyIdFor(kp.publicKeyB64)).toBe(kp.keyId)
+  })
+})

--- a/packages/attestation/__tests__/ed25519.test.ts
+++ b/packages/attestation/__tests__/ed25519.test.ts
@@ -32,4 +32,12 @@ describe('Ed25519', () => {
     const { keyIdFor } = await import('../src/ed25519.js')
     expect(await keyIdFor(kp.publicKeyB64)).toBe(kp.keyId)
   })
+  it('returns false (does not throw) on malformed key/sig input', async () => {
+    const kp = await generateDocSigningKeyPair()
+    const sig = await ed25519Sign(kp.privateKeyPkcs8B64, utf8('m'))
+    // malformed public key (not a valid 32-byte raw Ed25519 key)
+    expect(await ed25519Verify('not-valid-base64-key', sig, utf8('m'))).toBe(false)
+    // malformed signature string
+    expect(await ed25519Verify(kp.publicKeyB64, 'AA', utf8('m'))).toBe(false)
+  })
 })

--- a/packages/attestation/__tests__/encoding.test.ts
+++ b/packages/attestation/__tests__/encoding.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { canonicalJson, sha256Hex, sha256Bytes, bytesToHex, bytesToB64url, b64urlToBytes, utf8 } from '../src/encoding.js'
+
+describe('canonicalJson', () => {
+  it('sorts object keys and is deterministic regardless of literal order', () => {
+    expect(canonicalJson({ b: 1, a: 2 })).toBe('{"a":2,"b":1}')
+    expect(canonicalJson({ a: 2, b: 1 })).toBe('{"a":2,"b":1}')
+  })
+  it('encodes arrays in order and nests', () => {
+    expect(canonicalJson([1, 'x', { z: true }])).toBe('[1,"x",{"z":true}]')
+  })
+  it('matches a fixed conformance vector (shared contract with the ledger)', () => {
+    expect(canonicalJson(['s4lt', 'total', '123450'])).toBe('["s4lt","total","123450"]')
+  })
+  it('throws on non-finite numbers and undefined', () => {
+    expect(() => canonicalJson(Number.NaN)).toThrow(/non-finite/)
+    expect(() => canonicalJson(undefined)).toThrow(/undefined/)
+  })
+  it('conformance: object keys are sorted (the load-bearing difference vs JSON.stringify), and nested undefined throws', () => {
+    expect(canonicalJson({ b: 2, a: 1 })).toBe('{"a":1,"b":2}')
+    expect(canonicalJson({ z: { y: 1, x: 2 } })).toBe('{"z":{"x":2,"y":1}}')
+    expect(() => canonicalJson({ a: undefined })).toThrow(/undefined/)
+  })
+})
+
+describe('sha256', () => {
+  it('sha256Hex matches a known vector for the empty string', async () => {
+    expect(await sha256Hex('')).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')
+  })
+  it('sha256Hex matches a known vector for "abc"', async () => {
+    expect(await sha256Hex('abc')).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad')
+  })
+  it('sha256Bytes returns 32 bytes', async () => {
+    expect((await sha256Bytes('abc')).length).toBe(32)
+  })
+})
+
+describe('hex + base64url round-trips', () => {
+  it('bytesToHex of a known buffer', () => {
+    expect(bytesToHex(new Uint8Array([0, 1, 254, 255]))).toBe('0001feff')
+  })
+  it('base64url round-trips arbitrary bytes and is url-safe (no +,/,=)', () => {
+    const b = new Uint8Array([0, 1, 2, 250, 251, 252, 253, 254, 255])
+    const enc = bytesToB64url(b)
+    expect(enc).not.toMatch(/[+/=]/)
+    expect([...b64urlToBytes(enc)]).toEqual([...b])
+  })
+  it('utf8 encodes to bytes', () => {
+    expect([...utf8('A')]).toEqual([65])
+  })
+  it('base64url round-trips 1-byte and 2-byte inputs (padding restoration)', () => {
+    expect([...b64urlToBytes(bytesToB64url(new Uint8Array([0xab])))]).toEqual([0xab])
+    expect([...b64urlToBytes(bytesToB64url(new Uint8Array([0xab, 0xcd])))]).toEqual([0xab, 0xcd])
+  })
+})

--- a/packages/attestation/__tests__/hashing.test.ts
+++ b/packages/attestation/__tests__/hashing.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { computeFieldHashes } from '../src/hashing.js'
+import type { AttestationFieldSchema } from '../src/types.js'
+
+const schema: AttestationFieldSchema = {
+  fields: [
+    { path: 'invoiceNo', normalize: 'alnum-upper' },
+    { path: 'total', normalize: 'cents' },
+  ],
+}
+const salt = 'c2FsdHNhbHRzYWx0c2Fs' // base64url, arbitrary
+
+describe('computeFieldHashes', () => {
+  it('returns one base64url hash per field, in schema order', async () => {
+    const h = await computeFieldHashes(salt, schema, { invoiceNo: 'INV-1', total: 12.34 })
+    expect(h).toHaveLength(2)
+    for (const x of h) expect(x).not.toMatch(/[+/=]/)
+  })
+  it('is deterministic for the same salt+schema+values', async () => {
+    const a = await computeFieldHashes(salt, schema, { invoiceNo: 'INV-1', total: 12.34 })
+    const b = await computeFieldHashes(salt, schema, { invoiceNo: 'inv 1', total: '12.34' })
+    expect(a).toEqual(b) // normalization makes these equal
+  })
+  it('changes when a field value changes', async () => {
+    const a = await computeFieldHashes(salt, schema, { invoiceNo: 'INV-1', total: 12.34 })
+    const b = await computeFieldHashes(salt, schema, { invoiceNo: 'INV-1', total: 99.99 })
+    expect(a[0]).toBe(b[0])
+    expect(a[1]).not.toBe(b[1])
+  })
+  it('changes when the salt changes', async () => {
+    const a = await computeFieldHashes(salt, schema, { invoiceNo: 'INV-1', total: 12.34 })
+    const b = await computeFieldHashes('ZGlmZmVyZW50c2FsdGRpZmY', schema, { invoiceNo: 'INV-1', total: 12.34 })
+    expect(a[0]).not.toBe(b[0])
+  })
+  it('domain-separates fields with equal values (path is in the hash input)', async () => {
+    const s2: AttestationFieldSchema = { fields: [{ path: 'a', normalize: 'trim' }, { path: 'b', normalize: 'trim' }] }
+    const h = await computeFieldHashes(salt, s2, { a: 'same', b: 'same' })
+    expect(h[0]).not.toBe(h[1])
+  })
+  it('throws when a declared field is missing from the record', async () => {
+    await expect(computeFieldHashes(salt, schema, { invoiceNo: 'INV-1' })).rejects.toThrow(/missing/)
+  })
+})

--- a/packages/attestation/__tests__/index.test.ts
+++ b/packages/attestation/__tests__/index.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import * as api from '../src/index.js'
+
+describe('public API surface', () => {
+  it('exports the documented functions', () => {
+    for (const name of [
+      'canonicalJson', 'sha256Hex', 'normalizeField', 'validateFieldSchema',
+      'computeFieldHashes', 'generateDocSigningKeyPair', 'encodeQr', 'decodeQr',
+      'signPayloadCore', 'verifyAttestation', 'isRevoked', 'verifyRevocationList', 'signRevocationList',
+    ]) {
+      expect(typeof (api as Record<string, unknown>)[name]).toBe('function')
+    }
+  })
+})

--- a/packages/attestation/__tests__/normalize.test.ts
+++ b/packages/attestation/__tests__/normalize.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeField, validateFieldSchema, getPath } from '../src/normalize.js'
+
+describe('normalizeField', () => {
+  it('trim / lower / upper', () => {
+    expect(normalizeField('  Hi ', 'trim')).toBe('Hi')
+    expect(normalizeField(' Hi ', 'lower')).toBe('hi')
+    expect(normalizeField(' Hi ', 'upper')).toBe('HI')
+  })
+  it('alnum-upper strips punctuation and uppercases', () => {
+    expect(normalizeField('gb-12 34.56', 'alnum-upper')).toBe('GB123456')
+  })
+  it('digits keeps only digits', () => {
+    expect(normalizeField('+1 (415) 555', 'digits')).toBe('1415555')
+  })
+  it('cents converts money to integer-cents string', () => {
+    expect(normalizeField(1234.5, 'cents')).toBe('123450')
+    expect(normalizeField('19.99', 'cents')).toBe('1999')
+    expect(normalizeField(0, 'cents')).toBe('0')
+  })
+  it('cents throws on non-numeric', () => {
+    expect(() => normalizeField('abc', 'cents')).toThrow(/cents/)
+  })
+  it('iso-date normalizes Date and ISO string to YYYY-MM-DD', () => {
+    expect(normalizeField('2026-05-29T10:00:00Z', 'iso-date')).toBe('2026-05-29')
+    expect(normalizeField(new Date('2026-05-29T23:59:59Z'), 'iso-date')).toBe('2026-05-29')
+  })
+  it('iso-date throws on unparseable', () => {
+    expect(() => normalizeField('not-a-date', 'iso-date')).toThrow(/iso-date/)
+  })
+})
+
+describe('validateFieldSchema', () => {
+  it('accepts a valid schema', () => {
+    expect(() => validateFieldSchema({ fields: [{ path: 'total', normalize: 'cents' }] })).not.toThrow()
+  })
+  it('rejects an unknown normalizer', () => {
+    // @ts-expect-error testing runtime guard
+    expect(() => validateFieldSchema({ fields: [{ path: 'x', normalize: 'bogus' }] })).toThrow(/normalizer/)
+  })
+  it('rejects empty fields and duplicate paths', () => {
+    expect(() => validateFieldSchema({ fields: [] })).toThrow(/at least one/)
+    expect(() => validateFieldSchema({ fields: [{ path: 'a', normalize: 'trim' }, { path: 'a', normalize: 'upper' }] })).toThrow(/duplicate/)
+  })
+})
+
+describe('getPath', () => {
+  it('resolves dot paths', () => {
+    expect(getPath({ a: { b: 7 } }, 'a.b')).toBe(7)
+    expect(getPath({ total: 5 }, 'total')).toBe(5)
+  })
+  it('returns undefined for a missing path', () => {
+    expect(getPath({ a: {} }, 'a.b.c')).toBeUndefined()
+  })
+})

--- a/packages/attestation/__tests__/qr.test.ts
+++ b/packages/attestation/__tests__/qr.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { encodeQr, decodeQr } from '../src/qr.js'
+import type { QrPayload } from '../src/qr.js'
+import { bytesToB64url, utf8 } from '../src/encoding.js'
+
+const payload: QrPayload = {
+  v: 1, docId: '01J0ABCDEF', salt: 'c2FsdA', alg: 'ed25519', keyId: 'abcdef0123456789',
+  fieldHashes: ['aaa', 'bbb'], sig: 'c2ln',
+}
+
+describe('QR codec', () => {
+  it('encode → decode round-trips', () => {
+    expect(decodeQr(encodeQr(payload))).toEqual(payload)
+  })
+  it('encoded string is url-safe', () => {
+    expect(encodeQr(payload)).not.toMatch(/[+/=]/)
+  })
+  it('rejects a non-v1 payload on decode', () => {
+    const bad = encodeQr({ ...payload, v: 2 as unknown as 1 })
+    expect(() => decodeQr(bad)).toThrow(/version/)
+  })
+  it('rejects structurally invalid payloads', () => {
+    expect(() => decodeQr('not-base64url!!!')).toThrow(/invalid/)
+    const missing = encodeQr({ ...payload, sig: undefined as unknown as string })
+    expect(() => decodeQr(missing)).toThrow(/sig|invalid/)
+  })
+  it('rejects non-object JSON (null / array) with a controlled error, not a raw TypeError', () => {
+    expect(() => decodeQr(bytesToB64url(utf8('null')))).toThrow(/invalid/)
+    expect(() => decodeQr(bytesToB64url(utf8('[1,2,3]')))).toThrow(/invalid/)
+  })
+})

--- a/packages/attestation/__tests__/revocation.test.ts
+++ b/packages/attestation/__tests__/revocation.test.ts
@@ -19,4 +19,14 @@ describe('revocation', () => {
     const tampered = { ...list, revokedDocIds: [...list.revokedDocIds, '01J0EVIL'] }
     expect(await verifyRevocationList(tampered, kp.publicKeyB64)).toBe(false)
   })
+  it('fails closed on malformed lists (no raw TypeError)', async () => {
+    const kp = await generateDocSigningKeyPair()
+    // missing/!array revokedDocIds — must not throw
+    const bad = { v: 1, asOf: '2026-06-01T00:00:00Z', keyId: 'k', sig: 'x' } as unknown as Parameters<typeof isRevoked>[1]
+    expect(isRevoked('a', bad)).toBe(false)
+    expect(await verifyRevocationList(bad, kp.publicKeyB64)).toBe(false)
+    // null list — must not throw
+    expect(isRevoked('a', null as unknown as Parameters<typeof isRevoked>[1])).toBe(false)
+    expect(await verifyRevocationList(null as unknown as Parameters<typeof verifyRevocationList>[0], kp.publicKeyB64)).toBe(false)
+  })
 })

--- a/packages/attestation/__tests__/revocation.test.ts
+++ b/packages/attestation/__tests__/revocation.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { isRevoked, verifyRevocationList, signRevocationList } from '../src/revocation.js'
+import { generateDocSigningKeyPair } from '../src/ed25519.js'
+
+describe('revocation', () => {
+  it('isRevoked checks membership', () => {
+    const list = { v: 1 as const, revokedDocIds: ['a', 'b'], asOf: '2026-06-01T00:00:00Z', keyId: 'k', sig: 'x' }
+    expect(isRevoked('a', list)).toBe(true)
+    expect(isRevoked('z', list)).toBe(false)
+  })
+  it('signRevocationList → verifyRevocationList round-trips', async () => {
+    const kp = await generateDocSigningKeyPair()
+    const list = await signRevocationList(['01J0DOC0001', '01J0DOC0002'], '2026-06-01T00:00:00Z', kp.keyId, kp.privateKeyPkcs8B64)
+    expect(await verifyRevocationList(list, kp.publicKeyB64)).toBe(true)
+  })
+  it('verifyRevocationList fails on tamper', async () => {
+    const kp = await generateDocSigningKeyPair()
+    const list = await signRevocationList(['01J0DOC0001'], '2026-06-01T00:00:00Z', kp.keyId, kp.privateKeyPkcs8B64)
+    const tampered = { ...list, revokedDocIds: [...list.revokedDocIds, '01J0EVIL'] }
+    expect(await verifyRevocationList(tampered, kp.publicKeyB64)).toBe(false)
+  })
+})

--- a/packages/attestation/__tests__/verify.test.ts
+++ b/packages/attestation/__tests__/verify.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { signPayloadCore, verifyAttestation } from '../src/verify.js'
+import { computeFieldHashes } from '../src/hashing.js'
+import { generateDocSigningKeyPair } from '../src/ed25519.js'
+import { encodeQr } from '../src/qr.js'
+import type { QrPayload } from '../src/qr.js'
+import type { AttestationFieldSchema } from '../src/types.js'
+
+const schema: AttestationFieldSchema = {
+  fields: [
+    { path: 'invoiceNo', normalize: 'alnum-upper' },
+    { path: 'total', normalize: 'cents' },
+    { path: 'issueDate', normalize: 'iso-date' },
+  ],
+}
+const fields = { invoiceNo: 'INV-1001', total: 1234.5, issueDate: '2026-05-29' }
+
+async function issue() {
+  const kp = await generateDocSigningKeyPair()
+  const salt = 'c2FsdHNhbHRzYWx0c2Fs'
+  const docId = '01J0DOC0001'
+  const fieldHashes = await computeFieldHashes(salt, schema, fields)
+  const sig = await signPayloadCore({ v: 1, docId, salt, keyId: kp.keyId, fieldHashes }, kp.privateKeyPkcs8B64)
+  const payload: QrPayload = { v: 1, docId, salt, alg: 'ed25519', keyId: kp.keyId, fieldHashes, sig }
+  return { kp, payload, qr: encodeQr(payload), salt, docId }
+}
+
+describe('verifyAttestation', () => {
+  it('valid: matching fields + correct key → valid', async () => {
+    const { kp, qr } = await issue()
+    const r = await verifyAttestation({ qr, claimedFields: fields, fieldSchema: schema, publicKeys: { [kp.keyId]: kp.publicKeyB64 } })
+    expect(r.valid).toBe(true)
+    expect(r.signatureValid).toBe(true)
+    expect(r.perField.every((f) => f.match)).toBe(true)
+    expect(r.revoked).toBeNull()
+  })
+  it('localizes a single altered field', async () => {
+    const { kp, qr } = await issue()
+    const r = await verifyAttestation({ qr, claimedFields: { ...fields, total: 9999.0 }, fieldSchema: schema, publicKeys: { [kp.keyId]: kp.publicKeyB64 } })
+    expect(r.valid).toBe(false)
+    expect(r.signatureValid).toBe(true)
+    expect(r.perField.find((f) => f.path === 'total')!.match).toBe(false)
+    expect(r.perField.find((f) => f.path === 'invoiceNo')!.match).toBe(true)
+    expect(r.reason).toMatch(/field/)
+  })
+  it('forged QR (attacker key not in publicKeys) → signatureValid false', async () => {
+    const { qr } = await issue()
+    const attacker = await generateDocSigningKeyPair()
+    const r = await verifyAttestation({ qr, claimedFields: fields, fieldSchema: schema, publicKeys: { [attacker.keyId]: attacker.publicKeyB64 } })
+    expect(r.signatureValid).toBe(false)
+    expect(r.valid).toBe(false)
+    expect(r.reason).toMatch(/keyId/)
+  })
+  it('schema/payload field-count mismatch → invalid', async () => {
+    const { kp, qr } = await issue()
+    const shortSchema: AttestationFieldSchema = { fields: [{ path: 'invoiceNo', normalize: 'alnum-upper' }] }
+    const r = await verifyAttestation({ qr, claimedFields: fields, fieldSchema: shortSchema, publicKeys: { [kp.keyId]: kp.publicKeyB64 } })
+    expect(r.valid).toBe(false)
+    expect(r.reason).toMatch(/count/)
+  })
+  it('revoked docId → valid false, revoked true', async () => {
+    const { kp, qr, docId } = await issue()
+    const r = await verifyAttestation({
+      qr, claimedFields: fields, fieldSchema: schema, publicKeys: { [kp.keyId]: kp.publicKeyB64 },
+      revocation: { list: { v: 1, revokedDocIds: [docId], asOf: '2026-06-01T00:00:00Z', keyId: kp.keyId, sig: 'x' } },
+    })
+    expect(r.revoked).toBe(true)
+    expect(r.valid).toBe(false)
+    expect(r.reason).toMatch(/revoked/)
+  })
+})

--- a/packages/attestation/package.json
+++ b/packages/attestation/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@noy-db/attestation",
+  "version": "0.2.0-pre.1",
+  "description": "Pure, zero-dependency document-attestation primitive for noy-db — per-field salted commitments, Ed25519 sign/verify, QR credential codec, and revocation checks. Runs in Node and the browser; the offline verifier imports only this.",
+  "license": "MIT",
+  "author": "vLannaAi <vicio@lanna.ai>",
+  "homepage": "https://github.com/vLannaAi/noy-db/tree/main/packages/attestation#readme",
+  "repository": { "type": "git", "url": "git+https://github.com/vLannaAi/noy-db.git", "directory": "packages/attestation" },
+  "bugs": { "url": "https://github.com/vLannaAi/noy-db/issues" },
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
+      "require": { "types": "./dist/index.d.cts", "default": "./dist/index.cjs" }
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist", "README.md", "LICENSE"],
+  "engines": { "node": ">=18.0.0" },
+  "scripts": { "build": "tsup", "test": "vitest run", "lint": "eslint src/", "typecheck": "tsc --noEmit" },
+  "keywords": ["noy-db", "attestation", "document", "commitment", "ed25519", "verification", "qr", "tamper-evident"],
+  "publishConfig": { "access": "public", "tag": "latest" }
+}

--- a/packages/attestation/src/ed25519.ts
+++ b/packages/attestation/src/ed25519.ts
@@ -1,0 +1,57 @@
+import { bytesToB64url, b64urlToBytes, sha256Hex } from './encoding.js'
+
+const ALG = 'Ed25519'
+
+/** Cast a Uint8Array to the narrower ArrayBuffer WebCrypto expects. */
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer
+}
+
+/** Stable key identifier: first 16 hex chars of sha256(publicKeyB64). */
+export async function keyIdFor(publicKeyB64: string): Promise<string> {
+  return (await sha256Hex(publicKeyB64)).slice(0, 16)
+}
+
+export async function generateDocSigningKeyPair(): Promise<{
+  keyId: string
+  publicKeyB64: string        // base64url raw (32 bytes) — non-secret, publishable
+  privateKeyPkcs8B64: string  // base64url pkcs8 — secret, wrap before persisting
+}> {
+  const kp = (await globalThis.crypto.subtle.generateKey(ALG, true, ['sign', 'verify'])) as CryptoKeyPair
+  const rawPub = new Uint8Array(await globalThis.crypto.subtle.exportKey('raw', kp.publicKey))
+  const pkcs8 = new Uint8Array(await globalThis.crypto.subtle.exportKey('pkcs8', kp.privateKey))
+  const publicKeyB64 = bytesToB64url(rawPub)
+  return { keyId: await keyIdFor(publicKeyB64), publicKeyB64, privateKeyPkcs8B64: bytesToB64url(pkcs8) }
+}
+
+export async function ed25519Sign(privateKeyPkcs8B64: string, message: Uint8Array): Promise<string> {
+  const key = await globalThis.crypto.subtle.importKey(
+    'pkcs8',
+    toArrayBuffer(b64urlToBytes(privateKeyPkcs8B64)),
+    ALG,
+    false,
+    ['sign'],
+  )
+  const sig = new Uint8Array(await globalThis.crypto.subtle.sign(ALG, key, toArrayBuffer(message)))
+  return bytesToB64url(sig)
+}
+
+export async function ed25519Verify(publicKeyB64: string, sigB64url: string, message: Uint8Array): Promise<boolean> {
+  try {
+    const key = await globalThis.crypto.subtle.importKey(
+      'raw',
+      toArrayBuffer(b64urlToBytes(publicKeyB64)),
+      ALG,
+      false,
+      ['verify'],
+    )
+    return await globalThis.crypto.subtle.verify(
+      ALG,
+      key,
+      toArrayBuffer(b64urlToBytes(sigB64url)),
+      toArrayBuffer(message),
+    )
+  } catch {
+    return false
+  }
+}

--- a/packages/attestation/src/ed25519.ts
+++ b/packages/attestation/src/ed25519.ts
@@ -2,11 +2,6 @@ import { bytesToB64url, b64urlToBytes, sha256Hex } from './encoding.js'
 
 const ALG = 'Ed25519'
 
-/** Cast a Uint8Array to the narrower ArrayBuffer WebCrypto expects. */
-function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
-  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer
-}
-
 /** Stable key identifier: first 16 hex chars of sha256(publicKeyB64). */
 export async function keyIdFor(publicKeyB64: string): Promise<string> {
   return (await sha256Hex(publicKeyB64)).slice(0, 16)
@@ -27,12 +22,12 @@ export async function generateDocSigningKeyPair(): Promise<{
 export async function ed25519Sign(privateKeyPkcs8B64: string, message: Uint8Array): Promise<string> {
   const key = await globalThis.crypto.subtle.importKey(
     'pkcs8',
-    toArrayBuffer(b64urlToBytes(privateKeyPkcs8B64)),
+    b64urlToBytes(privateKeyPkcs8B64) as BufferSource,
     ALG,
     false,
     ['sign'],
   )
-  const sig = new Uint8Array(await globalThis.crypto.subtle.sign(ALG, key, toArrayBuffer(message)))
+  const sig = new Uint8Array(await globalThis.crypto.subtle.sign(ALG, key, message as BufferSource))
   return bytesToB64url(sig)
 }
 
@@ -40,7 +35,7 @@ export async function ed25519Verify(publicKeyB64: string, sigB64url: string, mes
   try {
     const key = await globalThis.crypto.subtle.importKey(
       'raw',
-      toArrayBuffer(b64urlToBytes(publicKeyB64)),
+      b64urlToBytes(publicKeyB64) as BufferSource,
       ALG,
       false,
       ['verify'],
@@ -48,8 +43,8 @@ export async function ed25519Verify(publicKeyB64: string, sigB64url: string, mes
     return await globalThis.crypto.subtle.verify(
       ALG,
       key,
-      toArrayBuffer(b64urlToBytes(sigB64url)),
-      toArrayBuffer(message),
+      b64urlToBytes(sigB64url) as BufferSource,
+      message as BufferSource,
     )
   } catch {
     return false

--- a/packages/attestation/src/ed25519.ts
+++ b/packages/attestation/src/ed25519.ts
@@ -12,7 +12,7 @@ export async function generateDocSigningKeyPair(): Promise<{
   publicKeyB64: string        // base64url raw (32 bytes) — non-secret, publishable
   privateKeyPkcs8B64: string  // base64url pkcs8 — secret, wrap before persisting
 }> {
-  const kp = (await globalThis.crypto.subtle.generateKey(ALG, true, ['sign', 'verify'])) as CryptoKeyPair
+  const kp = await globalThis.crypto.subtle.generateKey(ALG, true, ['sign', 'verify'])
   const rawPub = new Uint8Array(await globalThis.crypto.subtle.exportKey('raw', kp.publicKey))
   const pkcs8 = new Uint8Array(await globalThis.crypto.subtle.exportKey('pkcs8', kp.privateKey))
   const publicKeyB64 = bytesToB64url(rawPub)

--- a/packages/attestation/src/encoding.ts
+++ b/packages/attestation/src/encoding.ts
@@ -59,7 +59,7 @@ export function canonicalJson(value: unknown): string {
 }
 
 export async function sha256Bytes(input: string): Promise<Uint8Array> {
-  const digest = await globalThis.crypto.subtle.digest('SHA-256', utf8(input))
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', utf8(input) as BufferSource)
   return new Uint8Array(digest)
 }
 

--- a/packages/attestation/src/encoding.ts
+++ b/packages/attestation/src/encoding.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure encoding + hashing primitives. Zero deps; WebCrypto only.
+ *
+ * `canonicalJson` and `sha256Hex` are intentionally byte-identical to
+ * hub's `history/ledger/entry.ts` implementations. They are REPLICATED
+ * here (not imported) because this package is upstream of hub — importing
+ * from hub would invert the dependency. The conformance test pins the
+ * shared contract via fixed vectors.
+ */
+
+export function utf8(s: string): Uint8Array {
+  return new TextEncoder().encode(s)
+}
+
+export function bytesToHex(bytes: Uint8Array): string {
+  let out = ''
+  for (const b of bytes) out += b.toString(16).padStart(2, '0')
+  return out
+}
+
+export function bytesToB64url(bytes: Uint8Array): string {
+  let s = ''
+  for (const b of bytes) s += String.fromCharCode(b)
+  return btoa(s).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+export function b64urlToBytes(s: string): Uint8Array {
+  const pad = s.length % 4 === 0 ? '' : '='.repeat(4 - (s.length % 4))
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/') + pad
+  const bin = atob(b64)
+  const out = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i)
+  return out
+}
+
+export function canonicalJson(value: unknown): string {
+  if (value === null) return 'null'
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new Error(`canonicalJson: refusing to encode non-finite number ${String(value)}`)
+    }
+    return JSON.stringify(value)
+  }
+  if (typeof value === 'string') return JSON.stringify(value)
+  if (typeof value === 'bigint') throw new Error('canonicalJson: BigInt is not JSON-serializable')
+  if (typeof value === 'undefined' || typeof value === 'function') {
+    throw new Error(`canonicalJson: refusing to encode ${typeof value} — include all fields explicitly`)
+  }
+  if (Array.isArray(value)) return '[' + value.map((v) => canonicalJson(v)).join(',') + ']'
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>
+    const keys = Object.keys(obj).sort()
+    const parts: string[] = []
+    for (const key of keys) parts.push(JSON.stringify(key) + ':' + canonicalJson(obj[key]))
+    return '{' + parts.join(',') + '}'
+  }
+  throw new Error(`canonicalJson: unexpected value type: ${typeof value}`)
+}
+
+export async function sha256Bytes(input: string): Promise<Uint8Array> {
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', utf8(input))
+  return new Uint8Array(digest)
+}
+
+export async function sha256Hex(input: string): Promise<string> {
+  return bytesToHex(await sha256Bytes(input))
+}

--- a/packages/attestation/src/hashing.ts
+++ b/packages/attestation/src/hashing.ts
@@ -1,0 +1,28 @@
+import type { AttestationFieldSchema } from './types.js'
+import { canonicalJson, sha256Bytes, bytesToB64url } from './encoding.js'
+import { getPath, normalizeField } from './normalize.js'
+
+/**
+ * One salted, domain-separated hash per declared field, in schema order:
+ *   fieldHash[i] = base64url( sha256( canonicalJson([salt, path, normalizedValue]) ) )
+ * Per-document salt defeats brute-force of low-entropy fields and cross-
+ * document correlation; the path in the input domain-separates fields
+ * that happen to share a value.
+ */
+export async function computeFieldHashes(
+  saltB64: string,
+  schema: AttestationFieldSchema,
+  values: Record<string, unknown>,
+): Promise<string[]> {
+  const out: string[] = []
+  for (const f of schema.fields) {
+    const raw = getPath(values, f.path)
+    if (raw === undefined || raw === null) {
+      throw new Error(`computeFieldHashes: missing value at declared path '${f.path}'`)
+    }
+    const norm = normalizeField(raw, f.normalize)
+    const digest = await sha256Bytes(canonicalJson([saltB64, f.path, norm]))
+    out.push(bytesToB64url(digest))
+  }
+  return out
+}

--- a/packages/attestation/src/index.ts
+++ b/packages/attestation/src/index.ts
@@ -1,0 +1,1 @@
+export * from './encoding.js'

--- a/packages/attestation/src/index.ts
+++ b/packages/attestation/src/index.ts
@@ -1,1 +1,16 @@
-export * from './encoding.js'
+/**
+ * @noy-db/attestation — pure document-attestation primitive.
+ * @packageDocumentation
+ */
+export type { Normalizer, AttestationFieldSpec, AttestationFieldSchema } from './types.js'
+export type { QrPayload } from './qr.js'
+export type { RevocationList } from './revocation.js'
+export type { VerifyInput, VerifyResult } from './verify.js'
+
+export { canonicalJson, sha256Hex, sha256Bytes, bytesToHex, bytesToB64url, b64urlToBytes, utf8 } from './encoding.js'
+export { normalizeField, validateFieldSchema, getPath } from './normalize.js'
+export { computeFieldHashes } from './hashing.js'
+export { generateDocSigningKeyPair, ed25519Sign, ed25519Verify, keyIdFor } from './ed25519.js'
+export { encodeQr, decodeQr } from './qr.js'
+export { signPayloadCore, verifyAttestation } from './verify.js'
+export { isRevoked, verifyRevocationList, signRevocationList } from './revocation.js'

--- a/packages/attestation/src/normalize.ts
+++ b/packages/attestation/src/normalize.ts
@@ -1,0 +1,84 @@
+import type { AttestationFieldSchema, Normalizer } from './types.js'
+
+const NORMALIZERS: ReadonlySet<string> = new Set<Normalizer>([
+  'trim', 'lower', 'upper', 'alnum-upper', 'digits', 'cents', 'iso-date',
+])
+
+export function getPath(obj: unknown, path: string): unknown {
+  return path.split('.').reduce<unknown>(
+    (o, k) => (o == null ? undefined : (o as Record<string, unknown>)[k]),
+    obj,
+  )
+}
+
+/**
+ * Normalize a field value to a canonical string for hashing.
+ *
+ * `iso-date` returns the **UTC** calendar date (`toISOString().slice(0,10)`),
+ * so a local-time `Date` near midnight can shift by ±1 day in non-UTC
+ * environments — prefer passing an ISO date string (e.g. `'2026-05-29'`)
+ * over a local `new Date(2026, 4, 29)`. Issue and verify use this same
+ * function, so a value passed identically on both sides always round-trips.
+ */
+export function normalizeField(value: unknown, n: Normalizer): string {
+  switch (n) {
+    case 'trim':
+      return String(value).trim()
+    case 'lower':
+      return String(value).trim().toLowerCase()
+    case 'upper':
+      return String(value).trim().toUpperCase()
+    case 'alnum-upper':
+      return String(value).replace(/[^A-Za-z0-9]/g, '').toUpperCase()
+    case 'digits':
+      return String(value).replace(/[^0-9]/g, '')
+    case 'cents': {
+      if (typeof value === 'number') {
+        if (!Number.isFinite(value)) {
+          throw new Error(`normalizeField(cents): not a finite number: ${String(value)}`)
+        }
+        return String(Math.round(value * 100))
+      }
+      // For string values: strip currency symbols / spaces / commas but keep digits, dot, minus
+      const stripped = String(value).replace(/[^0-9.\-]/g, '')
+      // A valid numeric string must have at least one digit
+      if (!/[0-9]/.test(stripped)) {
+        throw new Error(`normalizeField(cents): not a finite number: ${String(value)}`)
+      }
+      const num = Number(stripped)
+      if (!Number.isFinite(num)) {
+        throw new Error(`normalizeField(cents): not a finite number: ${String(value)}`)
+      }
+      return String(Math.round(num * 100))
+    }
+    case 'iso-date': {
+      const d = value instanceof Date ? value : new Date(String(value))
+      if (Number.isNaN(d.getTime())) {
+        throw new Error(`normalizeField(iso-date): unparseable date: ${String(value)}`)
+      }
+      return d.toISOString().slice(0, 10)
+    }
+    default: {
+      const exhaustive: never = n
+      throw new Error(`normalizeField: unknown normalizer ${String(exhaustive)}`)
+    }
+  }
+}
+
+export function validateFieldSchema(schema: AttestationFieldSchema): void {
+  if (!schema.fields || schema.fields.length === 0) {
+    throw new Error('validateFieldSchema: schema must declare at least one field')
+  }
+  const seen = new Set<string>()
+  for (const f of schema.fields) {
+    if (!NORMALIZERS.has(f.normalize)) {
+      throw new Error(
+        `validateFieldSchema: unknown normalizer '${String(f.normalize)}' for path '${f.path}'`,
+      )
+    }
+    if (seen.has(f.path)) {
+      throw new Error(`validateFieldSchema: duplicate path '${f.path}'`)
+    }
+    seen.add(f.path)
+  }
+}

--- a/packages/attestation/src/normalize.ts
+++ b/packages/attestation/src/normalize.ts
@@ -40,7 +40,7 @@ export function normalizeField(value: unknown, n: Normalizer): string {
         return String(Math.round(value * 100))
       }
       // For string values: strip currency symbols / spaces / commas but keep digits, dot, minus
-      const stripped = String(value).replace(/[^0-9.\-]/g, '')
+      const stripped = String(value).replace(/[^0-9.-]/g, '')
       // A valid numeric string must have at least one digit
       if (!/[0-9]/.test(stripped)) {
         throw new Error(`normalizeField(cents): not a finite number: ${String(value)}`)

--- a/packages/attestation/src/qr.ts
+++ b/packages/attestation/src/qr.ts
@@ -1,0 +1,39 @@
+import { bytesToB64url, b64urlToBytes, utf8 } from './encoding.js'
+
+export interface QrPayload {
+  readonly v: 1
+  readonly docId: string
+  readonly salt: string
+  readonly alg: 'ed25519'
+  readonly keyId: string
+  readonly fieldHashes: readonly string[]
+  readonly sig: string
+}
+
+/** Compact JSON → base64url. (CBOR + base45 density optimisation deferred.) */
+export function encodeQr(p: QrPayload): string {
+  return bytesToB64url(utf8(JSON.stringify(p)))
+}
+
+export function decodeQr(s: string): QrPayload {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(b64urlToBytes(s)))
+  } catch {
+    throw new Error('decodeQr: invalid base64url-encoded JSON payload')
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('decodeQr: invalid payload — expected a JSON object')
+  }
+  const p = parsed as Record<string, unknown>
+  if (p['v'] !== 1) throw new Error(`decodeQr: unsupported version ${String(p['v'])} (expected 1)`)
+  if (typeof p['docId'] !== 'string' || typeof p['salt'] !== 'string' || p['alg'] !== 'ed25519'
+      || typeof p['keyId'] !== 'string' || typeof p['sig'] !== 'string'
+      || !Array.isArray(p['fieldHashes']) || !p['fieldHashes'].every((h) => typeof h === 'string')) {
+    throw new Error('decodeQr: invalid payload shape')
+  }
+  return {
+    v: 1, docId: p['docId'], salt: p['salt'], alg: 'ed25519',
+    keyId: p['keyId'], fieldHashes: p['fieldHashes'] as string[], sig: p['sig'],
+  }
+}

--- a/packages/attestation/src/qr.ts
+++ b/packages/attestation/src/qr.ts
@@ -34,6 +34,6 @@ export function decodeQr(s: string): QrPayload {
   }
   return {
     v: 1, docId: p['docId'], salt: p['salt'], alg: 'ed25519',
-    keyId: p['keyId'], fieldHashes: p['fieldHashes'] as string[], sig: p['sig'],
+    keyId: p['keyId'], fieldHashes: p['fieldHashes'], sig: p['sig'],
   }
 }

--- a/packages/attestation/src/revocation.ts
+++ b/packages/attestation/src/revocation.ts
@@ -1,0 +1,31 @@
+import { canonicalJson, utf8 } from './encoding.js'
+import { ed25519Sign, ed25519Verify } from './ed25519.js'
+
+export interface RevocationList {
+  readonly v: 1
+  readonly revokedDocIds: readonly string[]
+  readonly asOf: string
+  readonly keyId: string
+  readonly sig: string
+}
+
+function listCore(revokedDocIds: readonly string[], asOf: string, keyId: string): Uint8Array {
+  return utf8(canonicalJson({ v: 1, revokedDocIds: [...revokedDocIds].sort(), asOf, keyId }))
+}
+
+export function isRevoked(docId: string, list: RevocationList): boolean {
+  return list.revokedDocIds.includes(docId)
+}
+
+export async function signRevocationList(
+  revokedDocIds: readonly string[], asOf: string, keyId: string, privateKeyPkcs8B64: string,
+): Promise<RevocationList> {
+  const sorted = [...revokedDocIds].sort()
+  const sig = await ed25519Sign(privateKeyPkcs8B64, listCore(sorted, asOf, keyId))
+  return { v: 1, revokedDocIds: sorted, asOf, keyId, sig }
+}
+
+export async function verifyRevocationList(list: RevocationList, publicKeyB64: string): Promise<boolean> {
+  if (list.v !== 1) return false
+  return ed25519Verify(publicKeyB64, list.sig, listCore(list.revokedDocIds, list.asOf, list.keyId))
+}

--- a/packages/attestation/src/revocation.ts
+++ b/packages/attestation/src/revocation.ts
@@ -14,6 +14,9 @@ function listCore(revokedDocIds: readonly string[], asOf: string, keyId: string)
 }
 
 export function isRevoked(docId: string, list: RevocationList): boolean {
+  // The list is untrusted (typically network-fetched). Fail closed on a
+  // malformed shape rather than throwing a raw TypeError.
+  if (!Array.isArray(list?.revokedDocIds)) return false
   return list.revokedDocIds.includes(docId)
 }
 
@@ -26,6 +29,10 @@ export async function signRevocationList(
 }
 
 export async function verifyRevocationList(list: RevocationList, publicKeyB64: string): Promise<boolean> {
-  if (list.v !== 1) return false
+  // Untrusted input — validate the shape before touching it (no raw TypeError).
+  if (list?.v !== 1 || !Array.isArray(list.revokedDocIds)
+      || typeof list.asOf !== 'string' || typeof list.keyId !== 'string' || typeof list.sig !== 'string') {
+    return false
+  }
   return ed25519Verify(publicKeyB64, list.sig, listCore(list.revokedDocIds, list.asOf, list.keyId))
 }

--- a/packages/attestation/src/types.ts
+++ b/packages/attestation/src/types.ts
@@ -1,0 +1,9 @@
+export type Normalizer = 'trim' | 'lower' | 'upper' | 'alnum-upper' | 'digits' | 'cents' | 'iso-date'
+
+export interface AttestationFieldSpec {
+  readonly path: string
+  readonly normalize: Normalizer
+}
+export interface AttestationFieldSchema {
+  readonly fields: readonly AttestationFieldSpec[]
+}

--- a/packages/attestation/src/verify.ts
+++ b/packages/attestation/src/verify.ts
@@ -1,0 +1,81 @@
+import type { AttestationFieldSchema } from './types.js'
+import type { QrPayload } from './qr.js'
+import type { RevocationList } from './revocation.js'
+import { canonicalJson, utf8 } from './encoding.js'
+import { ed25519Sign, ed25519Verify } from './ed25519.js'
+import { computeFieldHashes } from './hashing.js'
+import { decodeQr } from './qr.js'
+import { isRevoked } from './revocation.js'
+
+export interface VerifyInput {
+  readonly qr: string
+  readonly claimedFields: Record<string, unknown>
+  readonly fieldSchema: AttestationFieldSchema
+  readonly publicKeys: Readonly<Record<string, string>>
+  readonly revocation?: { list: RevocationList }
+}
+export interface VerifyResult {
+  readonly valid: boolean
+  readonly signatureValid: boolean
+  readonly perField: ReadonlyArray<{ path: string; match: boolean }>
+  readonly revoked: boolean | null
+  readonly reason?: string
+}
+
+/**
+ * The bytes the signature covers: canonicalJson of the payload minus `alg`/`sig`.
+ * Excludes `alg` by design — v1 has exactly one algorithm (`ed25519`). If a `v:2`
+ * ever introduces a second algorithm, `alg` MUST be added here to prevent a
+ * downgrade attack.
+ */
+function signedCore(core: { v: 1; docId: string; salt: string; keyId: string; fieldHashes: readonly string[] }): Uint8Array {
+  return utf8(canonicalJson({ v: core.v, docId: core.docId, salt: core.salt, keyId: core.keyId, fieldHashes: core.fieldHashes }))
+}
+
+export async function signPayloadCore(
+  core: { v: 1; docId: string; salt: string; keyId: string; fieldHashes: readonly string[] },
+  privateKeyPkcs8B64: string,
+): Promise<string> {
+  return ed25519Sign(privateKeyPkcs8B64, signedCore(core))
+}
+
+export async function verifyAttestation(input: VerifyInput): Promise<VerifyResult> {
+  const p: QrPayload = decodeQr(input.qr)
+  const pub = input.publicKeys[p.keyId]
+  const signatureValid = pub
+    ? await ed25519Verify(pub, p.sig, signedCore({ v: p.v, docId: p.docId, salt: p.salt, keyId: p.keyId, fieldHashes: p.fieldHashes }))
+    : false
+
+  const schema = input.fieldSchema
+  const perField: Array<{ path: string; match: boolean }> = []
+  let allMatch = true
+  let countMismatch = false
+  if (schema.fields.length !== p.fieldHashes.length) {
+    countMismatch = true
+    allMatch = false
+    for (const f of schema.fields) perField.push({ path: f.path, match: false })
+  } else {
+    const recomputed = await computeFieldHashes(p.salt, schema, input.claimedFields)
+    for (let i = 0; i < schema.fields.length; i++) {
+      const match = recomputed[i] === p.fieldHashes[i]
+      perField.push({ path: schema.fields[i]!.path, match })
+      if (!match) allMatch = false
+    }
+  }
+
+  // Membership check only — the CALLER must have verified the list's own
+  // signature with `verifyRevocationList` before passing it here. A list that
+  // omits a genuinely-revoked id lets that doc pass; that risk is the caller's.
+  const revoked = input.revocation ? isRevoked(p.docId, input.revocation.list) : null
+  const valid = signatureValid && allMatch && revoked !== true
+
+  let reason: string | undefined
+  if (!signatureValid) reason = pub ? 'signature invalid' : 'unknown keyId'
+  else if (countMismatch) reason = 'schema/payload field-count mismatch'
+  else if (!allMatch) reason = 'field mismatch'
+  else if (revoked === true) reason = 'revoked'
+
+  return reason !== undefined
+    ? { valid, signatureValid, perField, revoked, reason }
+    : { valid, signatureValid, perField, revoked }
+}

--- a/packages/attestation/tsconfig.json
+++ b/packages/attestation/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/attestation/tsup.config.ts
+++ b/packages/attestation/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  target: 'es2022',
+})

--- a/packages/attestation/vitest.config.ts
+++ b/packages/attestation/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: { name: 'attestation', include: ['__tests__/**/*.test.ts'], environment: 'node' },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,8 @@ importers:
         specifier: ^22.0.0
         version: 22.19.17
 
+  packages/attestation: {}
+
   packages/by-peer:
     devDependencies:
       '@noy-db/hub':


### PR DESCRIPTION
First slice of the **document-attestation** feature (umbrella spec in this PR): offline, forgery-resistant verification that an issued document (invoice, statement) is authentic + unaltered, via a signed per-field commitment carried in a QR — no server holds or returns document content.

## What's in this PR

**New package `@noy-db/attestation`** — pure, zero runtime dependencies (on-shamir precedent), browser + Node, WebCrypto only:
- `canonicalJson` + `sha256` (replicated hub-free with fixed-vector conformance tests)
- closed normalizer set (`trim`/`lower`/`upper`/`alnum-upper`/`digits`/`cents`/`iso-date`) + field-schema validation
- per-field salted, domain-separated commitment hashing (offline "which field differs" localization)
- Ed25519 keygen/sign/verify via WebCrypto
- QR payload codec (compact-JSON → base64url) with hardened structural validation
- `signPayloadCore` + `verifyAttestation` (per-field localization, forgery + revocation gates)
- signed revocation list (format + `isRevoked` + sign/verify), fail-closed on malformed input

**Docs** — `docs/superpowers/specs/2026-05-29-document-attestation-umbrella-design.md` (5-subsystem umbrella), `…-attestation-core-and-issue-design.md` (sub-spec ①), and the implementation plan.

## Scope / what's NOT here
- Hub issue side `@noy-db/hub/attestation` (①b) — follow-up plan
- HTML→PDF Lambda recipe (③, with at-aws-kms), offline verifier (④), revocation publishing (⑤)
- No coupling to existing code — nothing imports this package yet.

## Test plan
- [x] 51 tests pass (`vitest run --project attestation`)
- [x] `tsc --noEmit` clean
- [x] `turbo run build lint typecheck --filter=@noy-db/attestation` green
- [x] zero runtime dependencies (no `dependencies` in package.json)
- [x] forgery gate traced: no path to `valid:true` without the private key or with an altered field