### PR TITLE
feat(recipe): document attestation ③ — AWS-KMS PDF render recipe

### DIFF
--- a/docs/recipes/aws-kms-pdf-attestation.md
+++ b/docs/recipes/aws-kms-pdf-attestation.md
@@ -1,0 +1,31 @@
+# AWS-KMS PDF attestation (generation side)
+
+The generation-time half of document attestation: a deployable AWS Lambda that
+takes a firm-sealed document record from S3, KMS-decrypts it, renders an HTML
+invoice → PDF with the attestation **QR embedded as vector**, and returns the
+PDF. Pairs with the offline verifier (recipe `attestation-verifier`).
+
+## What it exercises
+- `@noy-db/hub` issue side (`vault.issueAttestation`) — firm mints the signed QR.
+- `@noy-db/at-aws-kms` — seals the render payload `{docId, fields, qr}` with the
+  firm's KMS key (the original `at-aws-kms` use case).
+- A hub-free render Lambda: S3 GetObject → KMS Decrypt → HTML+inline-SVG QR →
+  headless Chromium (`@sparticuz/chromium`) → PDF.
+- `@noy-db/recipe-attestation-verifier` — proves the embedded QR verifies offline.
+
+## Data flow
+1. **Issue (firm, hub):** `issueAttestation` → `{ docId, qr, keyId }`.
+2. **Seal (firm):** `sealAndUpload({docId, fields, qr})` → KMS-encrypt → S3 `docs/<docId>`.
+3. **Render (Lambda):** GET `…/?docId=<docId>` → decrypt → render PDF with the vector QR.
+4. **Verify (third party, offline):** scan the QR → `verifyDocument` (recipe ④).
+
+## Trust + scope
+The QR carries the signed per-field commitment; the PDF is generated, never
+verified server-side. The render payload is capped at 4 KB (KMS plaintext limit).
+The Function URL is `authType: NONE` for the demo — **production must add IAM /
+JWT authz** since it returns rendered PDFs. Deploy/verify/teardown is
+profile-driven; see `recipes/aws-kms-pdf-attestation/RUNBOOK.md`.
+
+The CI showcase (`showcases/src/recipe-aws-kms-pdf-attestation.recipe.test.ts`)
+covers the data path with a mock KMS; the Chromium render + real AWS run only
+via the runbook.

--- a/docs/superpowers/plans/2026-05-30-attestation-kms-pdf-recipe.md
+++ b/docs/superpowers/plans/2026-05-30-attestation-kms-pdf-recipe.md
@@ -1,0 +1,893 @@
+# Document Attestation ③ — AWS-KMS PDF Render Recipe Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **CRITICAL GIT RULE for every subagent:** NEVER run `git stash`, `git stash pop`, `git reset`, `git checkout HEAD -- <files>`, or `git clean`. A pre-existing user stash (`stash@{0}: WIP on main`) must never be touched. Only `git add <scoped paths>` + `git commit` + read-only git. If you think you need anything else, STOP and report.
+>
+> **TYPECHECK before committing** — vitest uses esbuild and does NOT typecheck. Run the recipe's `npx tsc --noEmit` (or the workspace tsc) before each commit.
+>
+> **NO REAL AWS in any task here.** Every task is CI/local-safe: unit tests with mocked AWS clients, `cdk synth`, `docker build` is optional/skippable. The real deploy → verify → `cdk destroy` happens later, profile-driven, per the RUNBOOK (Task 6 writes it; it is NOT executed as part of plan implementation).
+
+**Goal:** A deployable reference Lambda (recipe `aws-kms-pdf-attestation`) that KMS-decrypts a firm-sealed document record from S3, renders an HTML invoice → PDF with the attestation QR embedded as vector, and returns the PDF — plus the CI-testable core, CDK stack, showcase, and deploy runbook.
+
+**Architecture:** New private workspace package `recipes/aws-kms-pdf-attestation/` (sibling to ④'s `recipes/attestation-verifier`). Five seams: payload codec, render-core (HTML builder + isolated puppeteer renderer), firm-side seal helper (uses `@noy-db/at-aws-kms`), hub-free Lambda handler (raw `@aws-sdk/client-kms` Decrypt), and a CDK-TS stack. Everything novel is unit-tested with mocked AWS; Chromium + real AWS are runbook-only.
+
+**Tech Stack:** TypeScript, Vitest, `@aws-sdk/client-kms` + `@aws-sdk/client-s3` (already in the monorepo at ^3), `@noy-db/at-aws-kms` (seal helper), `qrcode` (SVG QR), `puppeteer-core` + `@sparticuz/chromium` (render), `aws-cdk-lib` (infra), Docker (Lambda container, arm64, Node 22). Depends on merged `@noy-db/attestation`/`@noy-db/hub`/`@noy-db/recipe-attestation-verifier`.
+
+**Spec:** `docs/superpowers/specs/2026-05-30-attestation-kms-pdf-recipe-design.md`.
+
+**Branch:** `feat/attestation-kms-pdf-recipe` (already checked out, off `main` incl. #238; the spec + the `NOYDB_SHOWCASE_AWS_DOCS` `.env.example` entry are already committed on it).
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `recipes/aws-kms-pdf-attestation/package.json` | Create | private pkg; deps + scripts (test/typecheck/synth) |
+| `recipes/aws-kms-pdf-attestation/tsconfig.json` | Create | extends base; lib ES2022 (+DOM for puppeteer types) |
+| `recipes/aws-kms-pdf-attestation/vitest.config.ts` | Create | project `aws-kms-pdf-attestation`, node env |
+| `recipes/aws-kms-pdf-attestation/src/payload.ts` | Create | `RenderPayload` + encode/decode + 4 KB guard |
+| `recipes/aws-kms-pdf-attestation/src/render-core.ts` | Create | `buildInvoiceHtml` (CI) + `renderPdf` (Chromium, not CI) |
+| `recipes/aws-kms-pdf-attestation/src/seal.ts` | Create | firm-side `sealAndUpload` (at-aws-kms + S3) |
+| `recipes/aws-kms-pdf-attestation/src/handler.ts` | Create | Lambda Function-URL handler + `makeHandler(deps)` |
+| `recipes/aws-kms-pdf-attestation/infra/stack.ts` + `app.ts` + `cdk.json` | Create | CDK-TS stack (KMS, S3, container Lambda, Function URL, IAM) |
+| `recipes/aws-kms-pdf-attestation/Dockerfile` | Create | arm64 Node22 Lambda container |
+| `recipes/aws-kms-pdf-attestation/src/*.test.ts` | Create | payload/render-core/seal/handler unit tests (mock AWS) |
+| `recipes/aws-kms-pdf-attestation/infra/synth.test.ts` | Create | `cdk synth` smoke test |
+| `recipes/aws-kms-pdf-attestation/README.md` + `RUNBOOK.md` | Create | usage + profile-driven deploy/verify/teardown |
+| `vitest.config.ts` (root) | (already globs `recipes/*/vitest.config.ts` from ④) | — |
+| `showcases/src/90-attestation-kms-pdf.recipe... ` see Task 6 | Create | CI-safe showcase |
+| `features.yaml` | Modify | new `recipes:` entry |
+
+---
+
+## Task 1: Package skeleton + payload codec (TDD)
+
+**Files:** create `recipes/aws-kms-pdf-attestation/{package.json,tsconfig.json,vitest.config.ts,src/payload.ts,src/payload.test.ts}`.
+
+- [ ] **Step 1: Create `recipes/aws-kms-pdf-attestation/package.json`**
+```json
+{
+  "name": "@noy-db/recipe-aws-kms-pdf-attestation",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Deployable reference: KMS-decrypt an S3 doc record, render HTML→PDF with the attestation QR as vector. Recipe, not published.",
+  "exports": {
+    ".": "./src/payload.ts",
+    "./seal": "./src/seal.ts",
+    "./render-core": "./src/render-core.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "synth": "cdk synth --app 'npx tsx infra/app.ts'"
+  },
+  "dependencies": {
+    "@noy-db/at-aws-kms": "workspace:*",
+    "@aws-sdk/client-kms": "^3.0.0",
+    "@aws-sdk/client-s3": "^3.0.0",
+    "qrcode": "^1.5.4",
+    "puppeteer-core": "^24.0.0",
+    "@sparticuz/chromium": "^138.0.0"
+  },
+  "peerDependencies": {
+    "@noy-db/hub": "workspace:*"
+  },
+  "devDependencies": {
+    "@noy-db/hub": "workspace:*",
+    "@noy-db/attestation": "workspace:*",
+    "@noy-db/recipe-attestation-verifier": "workspace:*",
+    "@noy-db/to-memory": "workspace:*",
+    "@types/qrcode": "^1.5.5",
+    "@types/node": "^22.0.0",
+    "aws-cdk-lib": "^2.160.0",
+    "constructs": "^10.3.0",
+    "aws-cdk": "^2.160.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}
+```
+NOTE: `@noy-db/hub` is a peerDependency because `at-aws-kms` needs it as a peer (the seal helper runs in a hub context). Confirm the latest `@sparticuz/chromium` + `puppeteer-core` majors resolve on `pnpm install` (the registry may have moved past these — if `pnpm install` errors on an unresolvable version, relax to the nearest existing major and report it). The Lambda `handler.ts` will NOT import `@noy-db/hub` or `@noy-db/at-aws-kms` (it uses raw `@aws-sdk/client-kms`) — the peer is only for `seal.ts`.
+
+- [ ] **Step 2: Create `tsconfig.json`**
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "infra/**/*.ts"]
+}
+```
+
+- [ ] **Step 3: Create `vitest.config.ts`**
+```ts
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'aws-kms-pdf-attestation',
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'infra/**/*.test.ts'],
+    globals: false,
+  },
+})
+```
+
+- [ ] **Step 4: Install.** Run from repo root: `pnpm install`. Expected: links the package. (Pre-existing peer warnings from other packages are unrelated — ignore as long as this package links and the new deps resolve.)
+
+- [ ] **Step 5: Write the failing test `src/payload.test.ts`**
+```ts
+import { describe, it, expect } from 'vitest'
+import { encodeRenderPayload, decodeRenderPayload, type RenderPayload } from './payload.js'
+
+const payload: RenderPayload = {
+  docId: '01J0000000000000000000DEMO',
+  fields: { invoiceNo: 'INV-1042', total: 1234.5, issueDate: '2026-05-29' },
+  qr: 'eyJ2IjoxfQ',
+}
+
+describe('render payload codec', () => {
+  it('round-trips through encode/decode', () => {
+    const bytes = encodeRenderPayload(payload)
+    expect(bytes).toBeInstanceOf(Uint8Array)
+    expect(decodeRenderPayload(bytes)).toEqual(payload)
+  })
+
+  it('throws when the encoded payload exceeds the 4 KB KMS plaintext limit', () => {
+    const huge: RenderPayload = { ...payload, fields: { blob: 'x'.repeat(5000) } }
+    expect(() => encodeRenderPayload(huge)).toThrow(/4 ?KB|4096/)
+  })
+
+  it('decode rejects malformed JSON', () => {
+    expect(() => decodeRenderPayload(new TextEncoder().encode('not json'))).toThrow()
+  })
+
+  it('decode rejects a payload missing required fields', () => {
+    const bad = new TextEncoder().encode(JSON.stringify({ docId: 'x' }))
+    expect(() => decodeRenderPayload(bad)).toThrow(/docId|fields|qr|shape/)
+  })
+})
+```
+
+- [ ] **Step 6: Run, verify FAIL** (module not found): `npx vitest run --project aws-kms-pdf-attestation`
+
+- [ ] **Step 7: Implement `src/payload.ts`**
+```ts
+/** The decrypted record the render Lambda turns into a PDF. */
+export interface RenderPayload {
+  docId: string
+  fields: Record<string, string | number>
+  qr: string
+}
+
+const KMS_PLAINTEXT_LIMIT = 4096 // AWS KMS Encrypt caps plaintext at 4 KB.
+
+export function encodeRenderPayload(p: RenderPayload): Uint8Array {
+  const bytes = new TextEncoder().encode(JSON.stringify(p))
+  if (bytes.length > KMS_PLAINTEXT_LIMIT) {
+    throw new Error(
+      `render payload exceeds the 4 KB KMS plaintext limit (${bytes.length} > ${KMS_PLAINTEXT_LIMIT} bytes). ` +
+        'Attestation payloads (declared fields + QR) are normally far under; envelope encryption for larger payloads is out of scope.',
+    )
+  }
+  return bytes
+}
+
+export function decodeRenderPayload(bytes: Uint8Array): RenderPayload {
+  const parsed = JSON.parse(new TextDecoder().decode(bytes)) as unknown
+  if (
+    parsed === null || typeof parsed !== 'object' ||
+    typeof (parsed as RenderPayload).docId !== 'string' ||
+    typeof (parsed as RenderPayload).qr !== 'string' ||
+    typeof (parsed as RenderPayload).fields !== 'object' || (parsed as RenderPayload).fields === null
+  ) {
+    throw new Error('decodeRenderPayload: invalid payload shape (need { docId, fields, qr })')
+  }
+  return parsed as RenderPayload
+}
+```
+
+- [ ] **Step 8: Run, verify PASS (4 tests):** `npx vitest run --project aws-kms-pdf-attestation`
+
+- [ ] **Step 9: Typecheck + commit**
+```bash
+cd /Users/vicio/_github/noy-db && (cd recipes/aws-kms-pdf-attestation && npx tsc --noEmit)
+git add pnpm-lock.yaml recipes/aws-kms-pdf-attestation/package.json recipes/aws-kms-pdf-attestation/tsconfig.json recipes/aws-kms-pdf-attestation/vitest.config.ts recipes/aws-kms-pdf-attestation/src/payload.ts recipes/aws-kms-pdf-attestation/src/payload.test.ts
+git commit -m "feat(recipe/aws-kms-pdf): package skeleton + render-payload codec
+
+New private recipes/aws-kms-pdf-attestation package. RenderPayload encode/decode
+with the 4 KB KMS-plaintext guard + shape validation."
+```
+
+---
+
+## Task 2: render-core — `buildInvoiceHtml` (vector QR) + isolated `renderPdf`
+
+**Files:** create `recipes/aws-kms-pdf-attestation/src/render-core.ts`, `src/render-core.test.ts`.
+
+- [ ] **Step 1: Write the failing test `src/render-core.test.ts`**
+```ts
+import { describe, it, expect } from 'vitest'
+import { buildInvoiceHtml } from './render-core.js'
+import { decodeQr } from '@noy-db/attestation'
+import type { RenderPayload } from './payload.js'
+
+// A real QR string so the embedded SVG is built from a decodable payload.
+import { encodeQr } from '@noy-db/attestation'
+const qr = encodeQr({ v: 1, docId: '01J0DEMO', salt: 'c2FsdA', alg: 'ed25519', keyId: 'k1', fieldHashes: ['h'], sig: 's' })
+const payload: RenderPayload = { docId: '01J0DEMO', fields: { invoiceNo: 'INV-1042', total: 1234.5, issueDate: '2026-05-29' }, qr }
+
+describe('buildInvoiceHtml', () => {
+  it('renders every field value into the HTML', async () => {
+    const html = await buildInvoiceHtml(payload)
+    expect(html).toContain('INV-1042')
+    expect(html).toContain('1234.5')
+    expect(html).toContain('2026-05-29')
+  })
+
+  it('embeds the QR as inline vector <svg>, not a raster <img>', async () => {
+    const html = await buildInvoiceHtml(payload)
+    expect(html).toMatch(/<svg[\s>]/i)            // inline SVG present
+    expect(html).not.toMatch(/<img[^>]+src=["']data:image\/png/i)  // not a raster image
+  })
+
+  it('the embedded QR SVG was generated from the payload qr string', async () => {
+    const html = await buildInvoiceHtml(payload)
+    // qrcode emits a <path> whose `d` encodes the modules; assert the decode of
+    // the SOURCE qr still yields the right docId (guards we passed the right string).
+    expect(decodeQr(payload.qr).docId).toBe('01J0DEMO')
+    expect(html).toContain('<svg')
+  })
+})
+```
+
+- [ ] **Step 2: Run, verify FAIL:** `npx vitest run --project aws-kms-pdf-attestation`
+
+- [ ] **Step 3: Implement `src/render-core.ts`**
+```ts
+import QRCode from 'qrcode'
+import type { RenderPayload } from './payload.js'
+
+/** Build the invoice HTML with the QR embedded as inline (vector) SVG. */
+export async function buildInvoiceHtml(payload: RenderPayload): Promise<string> {
+  const qrSvg = await QRCode.toString(payload.qr, { type: 'svg', margin: 1, width: 160 })
+  const rows = Object.entries(payload.fields)
+    .map(([k, v]) => `<tr><th style="text-align:left;padding:4px 12px 4px 0">${escapeHtml(k)}</th><td>${escapeHtml(String(v))}</td></tr>`)
+    .join('')
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8" />
+<style>
+  body { font-family: system-ui, sans-serif; margin: 40px; color: #1f2733; }
+  h1 { font-size: 20px; } .meta { color: #667; font-size: 12px; }
+  table { margin: 20px 0; border-collapse: collapse; }
+  .qr { margin-top: 24px; } .qr svg { width: 160px; height: 160px; }
+  .doc { color: #889; font-size: 11px; }
+</style></head>
+<body>
+  <h1>Invoice</h1>
+  <p class="meta">Issued by the firm · attestation document ${escapeHtml(payload.docId)}</p>
+  <table>${rows}</table>
+  <div class="qr">${qrSvg}</div>
+  <p class="doc">Scan / verify offline — the QR carries a signed per-field commitment.</p>
+</body></html>`
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+/**
+ * Render HTML → PDF via headless Chromium. NOT exercised in CI (needs the
+ * @sparticuz/chromium binary); isolated so the handler can stub it. The browser
+ * is created lazily and reused across warm Lambda invocations.
+ */
+let browserPromise: Promise<import('puppeteer-core').Browser> | null = null
+export async function renderPdf(html: string): Promise<Uint8Array> {
+  const [{ default: chromium }, puppeteer] = await Promise.all([
+    import('@sparticuz/chromium'),
+    import('puppeteer-core'),
+  ])
+  if (!browserPromise) {
+    browserPromise = puppeteer.launch({
+      args: chromium.args,
+      executablePath: await chromium.executablePath(),
+      headless: true,
+    })
+  }
+  const browser = await browserPromise
+  const page = await browser.newPage()
+  try {
+    await page.setContent(html, { waitUntil: 'networkidle0' })
+    const pdf = await page.pdf({ format: 'A4', printBackground: true })
+    return new Uint8Array(pdf)
+  } finally {
+    await page.close()
+  }
+}
+```
+NOTE: import `@noy-db/attestation`'s `encodeQr`/`decodeQr` are only used in the TEST (devDep). If tsc flags the dynamic `import('puppeteer-core').Browser` type, add `import type { Browser } from 'puppeteer-core'` at top and use `Browser` directly. Keep tsc clean; report any adjustment.
+
+- [ ] **Step 4: Run, verify PASS (3 tests):** `npx vitest run --project aws-kms-pdf-attestation`
+
+- [ ] **Step 5: Typecheck + commit**
+```bash
+cd /Users/vicio/_github/noy-db && (cd recipes/aws-kms-pdf-attestation && npx tsc --noEmit)
+git add recipes/aws-kms-pdf-attestation/src/render-core.ts recipes/aws-kms-pdf-attestation/src/render-core.test.ts
+git commit -m "feat(recipe/aws-kms-pdf): render-core — invoice HTML + inline vector QR; isolated renderPdf
+
+buildInvoiceHtml embeds the QR as inline <svg> (vector). renderPdf
+(puppeteer-core + @sparticuz/chromium) is isolated + warm-reused; not CI-run."
+```
+
+---
+
+## Task 3: seal helper + Lambda handler (mock-AWS tested)
+
+**Files:** create `recipes/aws-kms-pdf-attestation/src/seal.ts`, `src/seal.test.ts`, `src/handler.ts`, `src/handler.test.ts`.
+
+- [ ] **Step 1: Write the failing test `src/seal.test.ts`**
+```ts
+import { describe, it, expect } from 'vitest'
+import { sealAndUpload } from './seal.js'
+import { decodeRenderPayload, type RenderPayload } from './payload.js'
+
+const payload: RenderPayload = { docId: 'd1', fields: { invoiceNo: 'INV-1' }, qr: 'qr-string' }
+
+describe('sealAndUpload', () => {
+  it('seals the payload via KMS Encrypt and PUTs it to the given bucket/key', async () => {
+    const kmsCalls: any[] = []
+    const s3Calls: any[] = []
+    // Mock KMS: "seal" = wrap bytes; mock S3: capture the PutObject.
+    const kmsClient = { send: async (cmd: any) => { kmsCalls.push(cmd); return { CiphertextBlob: cmd.input.Plaintext } } }
+    const s3Client = { send: async (cmd: any) => { s3Calls.push(cmd); return {} } }
+
+    await sealAndUpload(payload, { keyId: 'arn:key', bucket: 'b', key: 'docs/d1', kmsClient: kmsClient as any, s3Client: s3Client as any })
+
+    expect(kmsCalls).toHaveLength(1)
+    const put = s3Calls[0].input
+    expect(put.Bucket).toBe('b')
+    expect(put.Key).toBe('docs/d1')
+    // The stored body is the KMS ciphertext; our mock seal is identity, so it
+    // decodes back to the original payload.
+    expect(decodeRenderPayload(put.Body)).toEqual(payload)
+  })
+})
+```
+
+- [ ] **Step 2: Run, verify FAIL.**
+
+- [ ] **Step 3: Implement `src/seal.ts`**
+```ts
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
+import { awsKmsSealingProvider } from '@noy-db/at-aws-kms'
+import { encodeRenderPayload, type RenderPayload } from './payload.js'
+
+export interface SealAndUploadOptions {
+  keyId: string
+  bucket: string
+  key: string
+  /** DI for tests. Defaults to ambient-cred clients. */
+  kmsClient?: { send: (cmd: unknown) => Promise<unknown> }
+  s3Client?: Pick<S3Client, 'send'>
+}
+
+/**
+ * Firm-side (hub context): seal a RenderPayload with the firm's KMS key via
+ * at-aws-kms and upload the ciphertext to S3. The render Lambda later decrypts
+ * + renders it. This is the @noy-db/at-aws-kms feature in action.
+ */
+export async function sealAndUpload(payload: RenderPayload, opts: SealAndUploadOptions): Promise<void> {
+  const sealer = awsKmsSealingProvider({ keyId: opts.keyId, client: opts.kmsClient as never })
+  const sealed = await sealer.seal(encodeRenderPayload(payload))
+  const s3 = opts.s3Client ?? new S3Client({})
+  await s3.send(new PutObjectCommand({ Bucket: opts.bucket, Key: opts.key, Body: sealed }) as never)
+}
+```
+NOTE: `awsKmsSealingProvider`'s `client` option type is `Pick<KMSClient,'send'>` — the test's mock satisfies it structurally; the `as never` casts bridge the structural mock to the SDK command types without pulling real client typing into the test. If tsc objects, type the mock as `Pick<KMSClient,'send'>`/`Pick<S3Client,'send'>` in the test instead of `any`, and drop the `as never`. Keep tsc clean.
+
+- [ ] **Step 4: Run, verify PASS.**
+
+- [ ] **Step 5: Write the failing test `src/handler.test.ts`**
+```ts
+import { describe, it, expect, vi } from 'vitest'
+import { makeHandler } from './handler.js'
+import { encodeRenderPayload, type RenderPayload } from './payload.js'
+
+const payload: RenderPayload = { docId: 'd1', fields: { invoiceNo: 'INV-1', total: 5 }, qr: 'qr-string' }
+
+function deps(over: Partial<{ getObjectBody: Uint8Array | null }> = {}) {
+  const body = 'getObjectBody' in over ? over.getObjectBody : encodeRenderPayload(payload)
+  const s3 = { send: async () => {
+    if (body === null) { const e: any = new Error('NoSuchKey'); e.name = 'NoSuchKey'; throw e }
+    return { Body: { transformToByteArray: async () => body } }
+  } }
+  // mock KMS Decrypt = identity (our test S3 body is already plaintext).
+  const kms = { send: async (cmd: any) => ({ Plaintext: cmd.input.CiphertextBlob }) }
+  const renderPdf = vi.fn(async (_html: string) => new Uint8Array([0x25, 0x50, 0x44, 0x46])) // "%PDF"
+  return { s3: s3 as any, kms: kms as any, renderPdf, bucket: 'b', keyId: 'k', prefix: 'docs' }
+}
+
+describe('makeHandler', () => {
+  it('returns a base64 application/pdf for a known docId', async () => {
+    const d = deps()
+    const handler = makeHandler(d)
+    const res = await handler({ rawPath: '/d1', queryStringParameters: {} } as any)
+    expect(res.statusCode).toBe(200)
+    expect(res.headers!['content-type']).toBe('application/pdf')
+    expect(res.isBase64Encoded).toBe(true)
+    // renderPdf received HTML containing the sealed field
+    expect(d.renderPdf).toHaveBeenCalledOnce()
+    expect(d.renderPdf.mock.calls[0][0]).toContain('INV-1')
+  })
+
+  it('404 when the object is missing', async () => {
+    const handler = makeHandler(deps({ getObjectBody: null }))
+    const res = await handler({ rawPath: '/missing', queryStringParameters: {} } as any)
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('400 when no docId is provided', async () => {
+    const handler = makeHandler(deps())
+    const res = await handler({ rawPath: '/', queryStringParameters: {} } as any)
+    expect(res.statusCode).toBe(400)
+  })
+})
+```
+
+- [ ] **Step 6: Run, verify FAIL.**
+
+- [ ] **Step 7: Implement `src/handler.ts`**
+```ts
+import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
+import { KMSClient, DecryptCommand } from '@aws-sdk/client-kms'
+import { decodeRenderPayload } from './payload.js'
+import { buildInvoiceHtml, renderPdf as defaultRenderPdf } from './render-core.js'
+
+interface FnUrlEvent { rawPath?: string; queryStringParameters?: Record<string, string | undefined> | null }
+interface FnUrlResult { statusCode: number; headers?: Record<string, string>; body?: string; isBase64Encoded?: boolean }
+
+export interface HandlerDeps {
+  s3: Pick<S3Client, 'send'>
+  kms: Pick<KMSClient, 'send'>
+  renderPdf: (html: string) => Promise<Uint8Array>
+  bucket: string
+  keyId: string
+  prefix: string
+}
+
+/** Build a Function-URL handler. Deps are injected so it unit-tests with mocks. */
+export function makeHandler(deps: HandlerDeps) {
+  return async function handler(event: FnUrlEvent): Promise<FnUrlResult> {
+    const docId = (event.queryStringParameters?.['docId'] ?? event.rawPath?.replace(/^\/+/, '') ?? '').trim()
+    if (!docId) return { statusCode: 400, headers: { 'content-type': 'text/plain' }, body: 'missing docId' }
+
+    let sealed: Uint8Array
+    try {
+      const obj = await deps.s3.send(new GetObjectCommand({ Bucket: deps.bucket, Key: `${deps.prefix}/${docId}` }) as never) as { Body?: { transformToByteArray(): Promise<Uint8Array> } }
+      if (!obj.Body) return { statusCode: 404, headers: { 'content-type': 'text/plain' }, body: 'not found' }
+      sealed = await obj.Body.transformToByteArray()
+    } catch (e) {
+      if (e instanceof Error && (e.name === 'NoSuchKey' || e.name === 'NotFound')) {
+        return { statusCode: 404, headers: { 'content-type': 'text/plain' }, body: 'not found' }
+      }
+      return { statusCode: 500, headers: { 'content-type': 'text/plain' }, body: 'storage error' }
+    }
+
+    try {
+      const dec = await deps.kms.send(new DecryptCommand({ CiphertextBlob: sealed, KeyId: deps.keyId }) as never) as { Plaintext?: Uint8Array }
+      if (!dec.Plaintext) return { statusCode: 500, headers: { 'content-type': 'text/plain' }, body: 'decrypt error' }
+      const payload = decodeRenderPayload(dec.Plaintext)
+      const html = await buildInvoiceHtml(payload)
+      const pdf = await deps.renderPdf(html)
+      return {
+        statusCode: 200,
+        headers: { 'content-type': 'application/pdf' },
+        body: Buffer.from(pdf).toString('base64'),
+        isBase64Encoded: true,
+      }
+    } catch {
+      return { statusCode: 500, headers: { 'content-type': 'text/plain' }, body: 'render error' }
+    }
+  }
+}
+
+/** The deployed Lambda entry point: ambient-cred clients + the real renderPdf. */
+export const handler = makeHandler({
+  s3: new S3Client({}),
+  kms: new KMSClient({}),
+  renderPdf: defaultRenderPdf,
+  bucket: process.env['DOCS_BUCKET'] ?? '',
+  keyId: process.env['KMS_KEY_ID'] ?? '',
+  prefix: process.env['DOCS_PREFIX'] ?? 'docs',
+})
+```
+
+- [ ] **Step 8: Run, verify PASS (seal + handler).** `npx vitest run --project aws-kms-pdf-attestation`
+
+- [ ] **Step 9: Typecheck + commit**
+```bash
+cd /Users/vicio/_github/noy-db && (cd recipes/aws-kms-pdf-attestation && npx tsc --noEmit)
+git add recipes/aws-kms-pdf-attestation/src/seal.ts recipes/aws-kms-pdf-attestation/src/seal.test.ts recipes/aws-kms-pdf-attestation/src/handler.ts recipes/aws-kms-pdf-attestation/src/handler.test.ts
+git commit -m "feat(recipe/aws-kms-pdf): firm-side seal helper (at-aws-kms) + hub-free Lambda handler
+
+sealAndUpload seals via @noy-db/at-aws-kms + S3 PUT (mock-AWS tested). makeHandler
+does S3 get → raw KMS Decrypt → render-core → base64 PDF; hub-free, dep-injected,
+mock-AWS tested (200/404/400)."
+```
+
+---
+
+## Task 4: CDK stack + Dockerfile + synth smoke test
+
+**Files:** create `recipes/aws-kms-pdf-attestation/infra/{stack.ts,app.ts,synth.test.ts}`, `cdk.json`, `Dockerfile`.
+
+- [ ] **Step 1: Create `Dockerfile`** (arm64 Node 22 Lambda container)
+```dockerfile
+# Lambda container for the KMS-PDF render recipe (arm64, Node 22).
+FROM public.ecr.aws/lambda/nodejs:22-arm64
+# @sparticuz/chromium needs these shared libs present in the image.
+RUN dnf install -y tar bzip2 && dnf clean all
+WORKDIR ${LAMBDA_TASK_ROOT}
+COPY package.json ./
+# Install only the runtime deps the handler needs (no hub, no cdk, no test deps).
+RUN npm install --omit=dev --no-package-lock \
+    @aws-sdk/client-s3@^3 @aws-sdk/client-kms@^3 qrcode@^1 puppeteer-core@^24 @sparticuz/chromium@^138
+COPY dist/ ./
+CMD [ "handler.handler" ]
+```
+NOTE: this assumes a `dist/` build of `src/` (esbuild/tsc) before `docker build`; the RUNBOOK (Task 6) documents `npm run bundle` → `dist/handler.js`. Add a `bundle` script to package.json scripts: `"bundle": "esbuild src/handler.ts --bundle --platform=node --format=esm --target=node22 --outfile=dist/handler.js --external:@sparticuz/chromium --external:puppeteer-core"` (and add `esbuild` to devDependencies). Keep `@sparticuz/chromium` + `puppeteer-core` external (installed in the image). If you add the bundle script + esbuild dep, include `package.json` in this task's commit.
+
+- [ ] **Step 2: Create `cdk.json`**
+```json
+{
+  "app": "npx tsx infra/app.ts",
+  "context": { "@aws-cdk/core:newStyleStackSynthesis": true }
+}
+```
+
+- [ ] **Step 3: Create `infra/stack.ts`**
+```ts
+import { Stack, type StackProps, RemovalPolicy, Duration, CfnOutput } from 'aws-cdk-lib'
+import type { Construct } from 'constructs'
+import * as s3 from 'aws-cdk-lib/aws-s3'
+import * as kms from 'aws-cdk-lib/aws-kms'
+import * as lambda from 'aws-cdk-lib/aws-lambda'
+
+const DOCS_PREFIX = 'docs'
+
+export class KmsPdfAttestationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props)
+
+    const key = new kms.Key(this, 'DocSealingKey', {
+      description: 'noy-db attestation: seals render payloads for the PDF Lambda',
+      enableKeyRotation: true,
+      removalPolicy: RemovalPolicy.DESTROY, // recipe/demo: destroy on teardown
+    })
+
+    const bucket = new s3.Bucket(this, 'DocsBucket', {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true, // recipe/demo
+    })
+
+    const fn = new lambda.DockerImageFunction(this, 'RenderFn', {
+      code: lambda.DockerImageCode.fromImageAsset(__dirname + '/..'),
+      architecture: lambda.Architecture.ARM_64,
+      memorySize: 2048,
+      timeout: Duration.seconds(30),
+      environment: { DOCS_BUCKET: bucket.bucketName, KMS_KEY_ID: key.keyArn, DOCS_PREFIX },
+    })
+
+    // Least privilege: decrypt with the one key + read the one prefix.
+    key.grantDecrypt(fn)
+    bucket.grantRead(fn, `${DOCS_PREFIX}/*`)
+
+    const url = fn.addFunctionUrl({ authType: lambda.FunctionUrlAuthType.NONE })
+    new CfnOutput(this, 'FunctionUrl', { value: url.url })
+    new CfnOutput(this, 'BucketName', { value: bucket.bucketName })
+    new CfnOutput(this, 'KeyArn', { value: key.keyArn })
+  }
+}
+```
+NOTE: confirm the `aws-cdk-lib` import paths resolve at the installed version. If `grantDecrypt`/`grantRead` signatures differ, match the installed cdk's API (read `node_modules/aws-cdk-lib/aws-kms/...d.ts`). Keep tsc clean.
+
+- [ ] **Step 4: Create `infra/app.ts`**
+```ts
+import { App } from 'aws-cdk-lib'
+import { KmsPdfAttestationStack } from './stack.js'
+
+const app = new App()
+new KmsPdfAttestationStack(app, 'NoydbKmsPdfAttestation')
+app.synth()
+```
+
+- [ ] **Step 5: Write the synth smoke test `infra/synth.test.ts`**
+```ts
+import { describe, it, expect } from 'vitest'
+import { App } from 'aws-cdk-lib'
+import { Template } from 'aws-cdk-lib/assertions'
+import { KmsPdfAttestationStack } from './stack.js'
+
+describe('CDK stack synthesizes', () => {
+  it('declares the KMS key, private bucket, container Lambda, and Function URL', () => {
+    const app = new App()
+    const stack = new KmsPdfAttestationStack(app, 'Test')
+    const t = Template.fromStack(stack)
+    t.resourceCountIs('AWS::KMS::Key', 1)
+    t.resourceCountIs('AWS::S3::Bucket', 1)
+    t.hasResourceProperties('AWS::Lambda::Function', { PackageType: 'Image', Architectures: ['arm64'], MemorySize: 2048 })
+    t.resourceCountIs('AWS::Lambda::Url', 1)
+    // Bucket blocks public access
+    t.hasResourceProperties('AWS::S3::Bucket', {
+      PublicAccessBlockConfiguration: { BlockPublicAcls: true, RestrictPublicBuckets: true },
+    })
+  })
+})
+```
+NOTE: `Template.fromStack` synthesizes WITHOUT building the Docker image (it references the asset, doesn't build it), so this runs in CI with no Docker. If the test runner tries to bundle the asset, set `DockerImageCode.fromImageAsset` is lazy — it should be fine; if synth complains about a missing Dockerfile path, ensure `__dirname + '/..'` resolves (the Dockerfile is at the package root). Report any deviation.
+
+- [ ] **Step 6: Run, verify PASS:** `npx vitest run --project aws-kms-pdf-attestation` (now payload + render-core + seal + handler + synth all pass)
+
+- [ ] **Step 7: Typecheck + commit**
+```bash
+cd /Users/vicio/_github/noy-db && (cd recipes/aws-kms-pdf-attestation && npx tsc --noEmit)
+git add recipes/aws-kms-pdf-attestation/infra recipes/aws-kms-pdf-attestation/cdk.json recipes/aws-kms-pdf-attestation/Dockerfile recipes/aws-kms-pdf-attestation/package.json pnpm-lock.yaml
+git commit -m "feat(recipe/aws-kms-pdf): CDK stack + Dockerfile + synth smoke test
+
+CDK-TS: KMS key, private S3 bucket, arm64 container Lambda (2GB), Function URL
+(authType NONE, demo), least-priv IAM (decrypt one key + read one prefix).
+Synth smoke test asserts the resource shape; no Docker/AWS in CI."
+```
+
+---
+
+## Task 5: Showcase + features.yaml
+
+**Files:** create `showcases/src/90-attestation-kms-pdf.showcase.test.ts`; modify `showcases/package.json`, `features.yaml`. (Recipe-pair naming: the spec calls for `recipe-aws-kms-pdf-attestation.recipe.test.ts` — use the **recipe** form so the validator's recipe-pair check passes; see Step 2.)
+
+- [ ] **Step 1: Add the recipe pkg as a showcases devDependency**
+
+In `showcases/package.json` `devDependencies`, add (alphabetical with siblings): `"@noy-db/recipe-aws-kms-pdf-attestation": "workspace:*"`. Then `pnpm install` from repo root.
+
+- [ ] **Step 2: Write `showcases/src/recipe-aws-kms-pdf-attestation.recipe.test.ts`**
+
+(Use the `recipe-<id>.recipe.test.ts` name so the features.yaml recipe-pair check passes — id/doc/showcase slugs all = `aws-kms-pdf-attestation`.)
+```ts
+/**
+ * Recipe — AWS-KMS PDF attestation (generation side, CI-safe slice)
+ *
+ * The firm issues a signed attestation, seals the render payload with its KMS
+ * key (@noy-db/at-aws-kms), and a Lambda would later decrypt + render it to a
+ * PDF with the QR embedded as vector. This CI slice proves the data path with a
+ * MOCK KMS (no real AWS, no Chromium): issue → seal → unseal → buildInvoiceHtml,
+ * and confirms the embedded QR still verifies offline via the ④ verifier.
+ * Real deploy → invoke → teardown is in the recipe's RUNBOOK.md (profile-driven).
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { sealAndUpload } from '@noy-db/recipe-aws-kms-pdf-attestation/seal'
+import { buildInvoiceHtml } from '@noy-db/recipe-aws-kms-pdf-attestation/render-core'
+import { decodeRenderPayload, type RenderPayload } from '@noy-db/recipe-aws-kms-pdf-attestation'
+import { verifyDocument } from '@noy-db/recipe-attestation-verifier'
+import { decodeQr, type AttestationFieldSchema } from '@noy-db/attestation'
+
+interface Invoice { id: string; invoiceNo: string; total: number; issueDate: string }
+const attestation: AttestationFieldSchema = {
+  fields: [
+    { path: 'invoiceNo', normalize: 'alnum-upper' },
+    { path: 'total', normalize: 'cents' },
+    { path: 'issueDate', normalize: 'iso-date' },
+  ],
+}
+
+describe('recipe: aws-kms-pdf-attestation (CI slice, mock KMS)', () => {
+  it('issue → seal → unseal → render HTML; the embedded QR still verifies offline', async () => {
+    // 1. Firm issues an attestation through the hub.
+    const db = await createNoydb({ store: memory(), user: 'firm', secret: 'firm-pass-2026' })
+    const vault = await db.openVault('books')
+    await vault.collection<Invoice>('invoices', { attestation }).put('inv-1', { id: 'inv-1', invoiceNo: 'INV-1042', total: 1234.5, issueDate: '2026-05-29' })
+    const { docId, qr, keyId } = await vault.issueAttestation('invoices', 'inv-1')
+    const { publicKeyB64 } = await vault.getDocumentSigningPublicKey()
+
+    // 2. Firm seals the render payload + "uploads" it (mock KMS=identity, mock S3 captures).
+    const payload: RenderPayload = { docId, qr, fields: { invoiceNo: 'INV-1042', total: 1234.5, issueDate: '2026-05-29' } }
+    let stored: Uint8Array | undefined
+    const kmsClient = { send: async (cmd: any) => ({ CiphertextBlob: cmd.input.Plaintext }) }
+    const s3Client = { send: async (cmd: any) => { stored = cmd.input.Body; return {} } }
+    await sealAndUpload(payload, { keyId: 'arn:demo', bucket: 'b', key: `docs/${docId}`, kmsClient: kmsClient as any, s3Client: s3Client as any })
+    expect(stored).toBeTruthy()
+
+    // 3. Lambda side (mock decrypt=identity) → render HTML.
+    const decoded = decodeRenderPayload(stored!)
+    const html = await buildInvoiceHtml(decoded)
+    expect(html).toContain('INV-1042')
+    expect(html).toMatch(/<svg[\s>]/i)              // QR is vector
+    expect(decodeQr(decoded.qr).docId).toBe(docId)  // the right QR rode along
+
+    // 4. A third party verifies the embedded QR OFFLINE → authentic-valid.
+    const printed = { invoiceNo: 'INV-1042', total: '1234.50', issueDate: '2026-05-29' }
+    const v = await verifyDocument(decoded.qr, printed, { publicKeys: { [keyId]: publicKeyB64 }, fieldSchema: attestation })
+    expect(v.outcome).toBe('authentic-valid')
+  })
+})
+```
+If `@noy-db/recipe-aws-kms-pdf-attestation/seal` / `/render-core` subpath imports don't resolve, confirm the recipe `package.json` `exports` map has `./seal` and `./render-core` (Task 1 Step 1 added them). If `memory`/`verifyDocument` don't resolve, they're existing showcases deps (④ added the latter; `@noy-db/to-memory` is a sibling dep).
+
+- [ ] **Step 3: Run the showcase**
+
+Run: `cd showcases && npx vitest run src/recipe-aws-kms-pdf-attestation.recipe.test.ts`
+Expected: PASS (1 test). (Showcases resolve workspace `@noy-db/*` from source via exports, not dist, so no build needed for the recipe pkg. If it fails on `@noy-db/hub` being stale dist, run `pnpm --filter @noy-db/hub build` first — hub IS consumed via dist by showcases.)
+
+- [ ] **Step 4: Register in `features.yaml`**
+
+Read the `recipes:` section + the `attestation-verifier` entry to match shape. Add a new `recipes:` entry:
+```yaml
+  - id: aws-kms-pdf-attestation
+    name: AWS-KMS PDF attestation render (generation side)
+    doc: docs/recipes/aws-kms-pdf-attestation.md
+    showcase_path: showcases/src/recipe-aws-kms-pdf-attestation.recipe.test.ts
+    status: preview
+    exercises:
+      features: [attestation]
+```
+(doc written in Task 6; create the file there. The validator checks the doc PATH exists — so Task 6 must land the doc before `validate-features` runs. Order: do Task 6's doc Step BEFORE running the validator, or run the validator in Task 6. To keep this task green, defer the `validate-features` run to Task 6 Step.)
+
+- [ ] **Step 5: Run the recipe pkg tests + typecheck + commit**
+```bash
+cd /Users/vicio/_github/noy-db && (cd recipes/aws-kms-pdf-attestation && npx tsc --noEmit)
+cd showcases && npx vitest run src/recipe-aws-kms-pdf-attestation.recipe.test.ts && cd ..
+git add showcases/package.json pnpm-lock.yaml showcases/src/recipe-aws-kms-pdf-attestation.recipe.test.ts features.yaml
+git commit -m "test(showcase) + docs(features): aws-kms-pdf-attestation recipe (CI slice)
+
+Showcase: issue → seal (at-aws-kms, mock KMS) → unseal → buildInvoiceHtml →
+the embedded vector QR still verifies offline (authentic-valid). Registers the
+recipe in features.yaml (doc lands in the next commit)."
+```
+
+---
+
+## Task 6: Recipe doc + RUNBOOK + README + full gate
+
+**Files:** create `docs/recipes/aws-kms-pdf-attestation.md`, `recipes/aws-kms-pdf-attestation/README.md`, `recipes/aws-kms-pdf-attestation/RUNBOOK.md`.
+
+- [ ] **Step 1: Write `docs/recipes/aws-kms-pdf-attestation.md`**
+
+Read `docs/recipes/attestation-verifier.md` to match tone. Content:
+```markdown
+# AWS-KMS PDF attestation (generation side)
+
+The generation-time half of document attestation: a deployable AWS Lambda that
+takes a firm-sealed document record from S3, KMS-decrypts it, renders an HTML
+invoice → PDF with the attestation **QR embedded as vector**, and returns the
+PDF. Pairs with the offline verifier (recipe `attestation-verifier`).
+
+## What it exercises
+- `@noy-db/hub` issue side (`vault.issueAttestation`) — firm mints the signed QR.
+- `@noy-db/at-aws-kms` — seals the render payload `{docId, fields, qr}` with the
+  firm's KMS key (the original `at-aws-kms` use case).
+- A hub-free render Lambda: S3 GetObject → KMS Decrypt → HTML+inline-SVG QR →
+  headless Chromium (`@sparticuz/chromium`) → PDF.
+- `@noy-db/recipe-attestation-verifier` — proves the embedded QR verifies offline.
+
+## Data flow
+1. **Issue (firm, hub):** `issueAttestation` → `{ docId, qr, keyId }`.
+2. **Seal (firm):** `sealAndUpload({docId, fields, qr})` → KMS-encrypt → S3 `docs/<docId>`.
+3. **Render (Lambda):** GET `…/?docId=<docId>` → decrypt → render PDF with the vector QR.
+4. **Verify (third party, offline):** scan the QR → `verifyDocument` (recipe ④).
+
+## Trust + scope
+The QR carries the signed per-field commitment; the PDF is generated, never
+verified server-side. The render payload is capped at 4 KB (KMS plaintext limit).
+The Function URL is `authType: NONE` for the demo — **production must add IAM /
+JWT authz** since it returns rendered PDFs. Deploy/verify/teardown is
+profile-driven; see `recipes/aws-kms-pdf-attestation/RUNBOOK.md`.
+
+The CI showcase (`showcases/src/recipe-aws-kms-pdf-attestation.recipe.test.ts`)
+covers the data path with a mock KMS; the Chromium render + real AWS run only
+via the runbook.
+```
+
+- [ ] **Step 2: Write `recipes/aws-kms-pdf-attestation/README.md`** (short — points at the doc + runbook)
+```markdown
+# @noy-db/recipe-aws-kms-pdf-attestation
+
+Deployable reference Lambda: KMS-decrypt a firm-sealed S3 doc record, render an
+HTML invoice → PDF with the attestation QR as vector. Private recipe, not published.
+
+- Narrative + data flow: `docs/recipes/aws-kms-pdf-attestation.md`
+- Deploy / verify / teardown (real AWS, profile-driven): `RUNBOOK.md`
+- CI-safe data-path test: `pnpm --filter @noy-db/recipe-aws-kms-pdf-attestation test`
+
+Render stack: puppeteer-core + @sparticuz/chromium (arm64), container Lambda,
+Node 22, ≥2 GB, QR as inline `<svg>` (vector).
+```
+
+- [ ] **Step 3: Write `recipes/aws-kms-pdf-attestation/RUNBOOK.md`** (the profile-driven lifecycle)
+```markdown
+# RUNBOOK — deploy, verify, teardown (real AWS)
+
+All AWS access uses a NAMED PROFILE you provide (`export AWS_PROFILE=<name>`),
+never raw or shared credentials. Each resource-creating step is confirmed first.
+
+## Prereqs
+- An AWS profile with permission to create KMS/S3/Lambda/IAM + run CDK.
+- Docker (for the arm64 Lambda container image).
+- `export AWS_PROFILE=<your-profile>` and `export AWS_REGION=<region>`.
+
+## 1. Build the handler bundle + image-deploy
+```bash
+pnpm --filter @noy-db/recipe-aws-kms-pdf-attestation run bundle   # → dist/handler.js
+cd recipes/aws-kms-pdf-attestation
+npx cdk bootstrap   # one-time per account/region
+npx cdk deploy      # creates KMS key + private S3 bucket + container Lambda + Function URL
+```
+Note the `FunctionUrl`, `BucketName`, `KeyArn` outputs.
+
+## 2. Seal + upload a sample document
+Use `sealAndUpload` (a tiny script or REPL) with the deployed `KeyArn` + `BucketName`:
+```ts
+import { sealAndUpload } from '@noy-db/recipe-aws-kms-pdf-attestation/seal'
+await sealAndUpload(
+  { docId: '<docId-from-issueAttestation>', fields: {/* invoice fields */}, qr: '<qr>' },
+  { keyId: '<KeyArn>', bucket: '<BucketName>', key: 'docs/<docId>' },
+)
+```
+
+## 3. Invoke + verify
+```bash
+curl -s "<FunctionUrl>?docId=<docId>" -o invoice.pdf
+file invoice.pdf   # → PDF document
+```
+Open `invoice.pdf`; scan the QR with the offline verifier (recipe ④) — it must
+read `authentic-valid` for the printed fields.
+
+## 4. Teardown (after you confirm "done")
+```bash
+npx cdk destroy   # removes the key, bucket (auto-deletes objects), Lambda, URL
+```
+```
+
+- [ ] **Step 4: Full gate**
+```bash
+cd /Users/vicio/_github/noy-db
+node scripts/validate-features.mjs 2>&1 | tail -8
+(cd recipes/aws-kms-pdf-attestation && npx tsc --noEmit)
+npx vitest run --project aws-kms-pdf-attestation --reporter=dot 2>&1 | tail -8
+cd showcases && npx vitest run src/recipe-aws-kms-pdf-attestation.recipe.test.ts --reporter=dot 2>&1 | tail -6
+```
+Expected: validator passes (recipes +1, recipe-pair satisfied, the doc path now exists); tsc clean; recipe pkg tests all pass (payload + render-core + seal + handler + synth); showcase passes. Report any pre-existing/unrelated failures as pre-existing.
+
+- [ ] **Step 5: Commit**
+```bash
+cd /Users/vicio/_github/noy-db
+git add docs/recipes/aws-kms-pdf-attestation.md recipes/aws-kms-pdf-attestation/README.md recipes/aws-kms-pdf-attestation/RUNBOOK.md
+git commit -m "docs(recipe): aws-kms-pdf-attestation doc + README + deploy RUNBOOK
+
+Recipe doc (data flow + trust model), package README, and the profile-driven
+deploy → seal → invoke → verify → destroy runbook for the real-AWS steps."
+```
+
+---
+
+## Self-Review (completed)
+
+- **Spec coverage** (spec §2–§12): §2 five parts + dep corrections → Tasks 1-4 (payload/render-core/seal/handler/CDK), Lambda hub-free via raw DecryptCommand → T3 handler; §3 RenderPayload + 4 KB guard + at-aws-kms byte sealer → T1 + T3 seal; §4 render-core buildInvoiceHtml(vector SVG) + isolated renderPdf → T2; §5 handler makeHandler + error codes → T3; §6 least-priv IAM (grantDecrypt one key + grantRead one prefix) + private bucket + Function URL NONE → T4 stack; §7 profile-driven deploy lifecycle → T6 RUNBOOK (not executed in plan); §8 testing (payload/render-core/seal/handler mock-AWS + cdk synth + showcase) → T1-T5; §9 features.yaml → T5/T6; §10 render stack (puppeteer-core + @sparticuz/chromium container arm64 Node22) → T2 + T4 Dockerfile; §11 YAGNI → respected; §12 build order → task order (T6 step 6 real-AWS deferred to runbook).
+- **Placeholder scan:** none. Showcase number is concrete (90 / `recipe-aws-kms-pdf-attestation.recipe.test.ts`); the recipe-pair name uses the `recipe-` form for the validator. Dep version majors flagged with a "relax if registry moved" instruction (not a placeholder — a real install-time guard).
+- **Type consistency:** `RenderPayload` (`docId`/`fields`/`qr`) defined T1, imported by render-core (T2), seal (T3), handler (T3 via decode), showcase (T5); `encodeRenderPayload`/`decodeRenderPayload` consistent; `sealAndUpload(payload, {keyId,bucket,key,kmsClient?,s3Client?})` consistent T3↔T5; `makeHandler(HandlerDeps)` consistent; `buildInvoiceHtml`/`renderPdf` consistent T2↔T3; `KmsPdfAttestationStack` consistent T4. The Lambda uses raw `DecryptCommand` (NOT `at-aws-kms.unseal`) per spec §2 — seal side uses `at-aws-kms`.
+- **Known risks:** (1) external dep majors (`@sparticuz/chromium`, `puppeteer-core`, `aws-cdk-lib`) may have moved — T1 instructs relax-and-report on install failure. (2) `cdk synth`/`Template.fromStack` must not require Docker build in CI (it references the asset lazily) — T4 notes verify. (3) the recipe `exports` subpaths (`./seal`, `./render-core`) must exist for the showcase's subpath imports — T1 adds them. (4) `aws-cdk-lib` import-path/API drift — T4 instructs matching the installed version. (5) `features.yaml` doc-path must exist before `validate-features` — deferred to T6.

--- a/docs/superpowers/specs/2026-05-30-attestation-kms-pdf-recipe-design.md
+++ b/docs/superpowers/specs/2026-05-30-attestation-kms-pdf-recipe-design.md
@@ -1,0 +1,103 @@
+# Document Attestation — ③ AWS-KMS PDF Render Recipe design
+
+**Status:** sub-system spec (③ of the document-attestation umbrella) → ready for plan
+**Date:** 2026-05-30
+**Relates to:** umbrella `docs/superpowers/specs/2026-05-29-document-attestation-umbrella-design.md` §3.7/§4/§5/§7/§8; issue side `…attestation-core-and-issue-design.md`; verifier `…attestation-verifier-design.md`. Depends on the merged `@noy-db/attestation` (①a), `@noy-db/hub/attestation` (①b, #236), `@noy-db/at-aws-kms` (the byte-sealer), and (verify step) `@noy-db/recipe-attestation-verifier` (④, #237).
+
+## 1. Goal
+
+The generation-time half of document attestation: a **deployable reference Lambda** that takes a firm-sealed document record from S3, KMS-decrypts it, renders an HTML invoice → PDF with the issued attestation **QR embedded as vector**, and returns the PDF. This is where the firm's original `at-aws-kms` ask lands — but as a **byte-sealer**, not a bundle ceremony (see §3). Delivered as a new `recipes/aws-kms-pdf-attestation/` package (deployable, **not published**), a recipe doc + showcase, and a deploy/teardown runbook.
+
+**Scope decision (locked in brainstorming):** the user chose a **full deployable Lambda verified against real AWS**. The slice is bounded hard inside that: one sample invoice template, minimal IAM, the novel parts (at-aws-kms byte seal/unseal + vector-QR-on-PDF + the render Lambda) are the point; everything else stays thin. This is the largest slice of the epic; expect a ~6-task plan.
+
+## 2. Architecture
+
+A reference app under `recipes/aws-kms-pdf-attestation/` (private, `recipes/*` workspace glob from ④). Five parts with clean seams:
+
+| Part | File(s) | CI-testable? | Responsibility |
+|---|---|---|---|
+| **render-core** | `src/render-core.ts` | YES (builder) / NO (pdf) | `buildInvoiceHtml(payload) → string` (sample template + QR as inline `<svg>` via `qrcode`) and `renderPdf(html) → Uint8Array` (puppeteer-core + @sparticuz/chromium, isolated so the builder tests without Chromium) |
+| **seal payload** | `src/payload.ts` | YES | `RenderPayload` type + `encodeRenderPayload`/`decodeRenderPayload` (JSON↔utf8) + the ≤4 KB guard |
+| **seal helper** | `src/seal.ts` | YES (mock KMS) | firm-side: `sealAndUpload(payload, { keyId, bucket, key, kmsClient?, s3Client? })` — `awsKmsSealingProvider.seal` → S3 PutObject |
+| **Lambda handler** | `src/handler.ts` | YES (mock AWS) | Function-URL handler: parse docId → S3 GetObject → **raw `@aws-sdk/client-kms` `DecryptCommand`** (the inverse of at-aws-kms's Encrypt envelope — keeps the Lambda hub-free; see §2 note) → `decodeRenderPayload` → render-core → `application/pdf` base64 response |
+| **CDK stack** | `infra/*.ts`, `cdk.json` | YES (`cdk synth`) | KMS key, private S3 bucket, container `DockerImageFunction` (arm64, Node 22, ≥2 GB, Function URL), least-priv IAM |
+
+Plus: `Dockerfile` (Lambda container, arm64), `docs/recipes/aws-kms-pdf-attestation.md`, `showcases/src/recipe-aws-kms-pdf-attestation.recipe.test.ts`, a `RUNBOOK.md` (deploy → seal → invoke → teardown).
+
+**Dependency corrections vs the umbrella:** (a) the umbrella listed `@noy-db/to-aws-s3`, but that's the vault **store** adapter — not applicable; a single sealed object is plain S3, so seal-helper + handler use `@aws-sdk/client-s3` directly. (b) **The Lambda imports neither `@noy-db/hub` nor `@noy-db/attestation` nor `@noy-db/at-aws-kms`** — it renders the QR string verbatim from the sealed payload, and unseals with the raw `@aws-sdk/client-kms` `DecryptCommand`. This matters because `@noy-db/at-aws-kms` declares `@noy-db/hub` as a **peerDependency** (its `SealingKeyProvider` type comes from hub), so importing at-aws-kms into the Lambda would require providing hub in the container image; the render Lambda has no other reason to carry hub, and puppeteer/Chromium containers are best kept minimal. The raw `DecryptCommand` is the exact inverse of at-aws-kms's Encrypt envelope (a symmetric KMS CMK), so the round-trip is identical — the Lambda just uses the lower-level call to stay hub-free and minimal. **`@noy-db/at-aws-kms` IS featured — on the firm-side seal helper** (`sealAndUpload` uses `awsKmsSealingProvider.seal`), which is the original `at-aws-kms` ask and runs in a hub context. Hub/`issueAttestation` is only in the firm-side seal helper (and the showcase).
+
+## 3. The seal model — `at-aws-kms` as a byte sealer
+
+`@noy-db/at-aws-kms` exposes `awsKmsSealingProvider({ keyId, client? }): SealingKeyProvider` with a generic byte envelope: `seal(bytes) → KMS-ciphertext`, `unseal(ciphertext) → bytes` (KMS Encrypt/Decrypt). It is **not** a bundle recipient-sealer and needs **no `adoptPartition`/owner-minting ceremony** — exactly the stateless per-invocation primitive a render Lambda needs. **No extension to `at-aws-kms` is required.** The `client?` DI seam lets both seal and unseal unit-test against a **mock KMS client**.
+
+**RenderPayload** (`src/payload.ts`):
+```ts
+interface RenderPayload {
+  docId: string
+  fields: Record<string, string | number>   // the declared attestation fields (printed on the invoice)
+  qr: string                                 // the QR payload string from issueAttestation
+}
+```
+`encodeRenderPayload(p) → Uint8Array` = `utf8(JSON.stringify(p))`. **KMS Encrypt caps plaintext at 4 KB** — `encodeRenderPayload` throws a plain `Error` with a clear message (`render payload exceeds the 4 KB KMS plaintext limit…`) if the encoded bytes exceed 4096 (declared fields + a ~250 B QR are far under; envelope encryption for larger payloads is out of scope, §8). This is a private recipe package, so a local `Error` is sufficient — no exported error class. `decodeRenderPayload(bytes)` parses + shape-validates (throws on malformed JSON or a missing `docId`/`fields`/`qr`).
+
+## 4. Render core (`src/render-core.ts`)
+
+- `buildInvoiceHtml(payload: RenderPayload): string` — fills a single hard-coded sample invoice template (firm header, the `fields` as a table, total) and embeds the QR as **inline `<svg>`** generated by `qrcode` (`QRCode.toString(qr, { type: 'svg' })`) so Chromium's print-to-PDF emits it as **vector** (crisp at any print DPI / when photographed for verification). Pure string-building — fully CI-testable.
+- `renderPdf(html: string): Promise<Uint8Array>` — launches `@sparticuz/chromium` via `puppeteer-core`, `page.setContent(html)`, `page.pdf({ format: 'A4', printBackground: true })`. The browser is created lazily + reused across warm invocations (module-scope singleton). Not CI-testable (needs the Chromium binary) — isolated behind this one function so the handler can be unit-tested with a stubbed `renderPdf`.
+
+## 5. Lambda handler (`src/handler.ts`)
+
+Function-URL handler (`{ rawPath / queryStringParameters }` → docId). Flow: validate docId → `s3.GetObject({ Bucket, Key: <prefix>/<docId> })` → `kms.send(new DecryptCommand({ CiphertextBlob, KeyId }))` → `Plaintext` bytes → `decodeRenderPayload` → `buildInvoiceHtml` → `renderPdf` → return `{ statusCode: 200, headers: { 'content-type': 'application/pdf' }, body: base64(pdf), isBase64Encoded: true }`. (Raw `DecryptCommand` rather than `awsKmsSealingProvider.unseal` to keep the Lambda hub-free — §2 note.) Errors map to 400 (bad docId) / 404 (no object) / 500 (decrypt/render failure) with no secret leakage in the body. Clients (KMS, S3) are constructed at module scope from ambient creds (the Lambda role) but injectable via an internal `makeHandler(deps)` factory so the handler logic unit-tests with mocked S3+KMS + a stubbed `renderPdf`.
+
+## 6. IAM (least-privilege)
+
+- **Lambda execution role:** `kms:Decrypt` on the one key ARN + `s3:GetObject` on `arn:aws:s3:::<bucket>/<prefix>/*` + the basic Lambda logging policy. Nothing else.
+- **Firm-side sealer identity** (documented in the runbook, NOT the Lambda role): `kms:Encrypt` on the key + `s3:PutObject` on the prefix.
+- The S3 bucket is private (block-all-public-access, SSE on). The Function URL uses `authType: NONE` (public) for the demo — a deliberate simplification so the user can `curl` the URL directly during verification; the recipe doc + runbook flag that production must switch to `AWS_IAM` (or a Lambda authorizer / JWT) since the endpoint returns rendered PDFs.
+
+## 7. Deploy / verify lifecycle (profile-driven)
+
+Per the user's standing credential rule, all AWS access is via a **named profile the user provides** (`AWS_PROFILE=<name>`, e.g. from `NOYDB_SHOWCASE_AWS_DOCS`) — never raw credentials, never a shared default. Each AWS-mutating command is confirmed before running. Lifecycle (in `RUNBOOK.md`):
+1. `cdk deploy` (KMS key + private S3 bucket + container Lambda + Function URL + IAM) — **I run, with per-resource confirmation.**
+2. Seal + upload a sample sealed record (`sealAndUpload`).
+3. Invoke the Function URL for that docId → receive the PDF.
+4. **I verify:** the PDF is valid; its embedded QR decodes back to the issued payload; ④'s `verifyDocument(qr, fields, …)` returns `authentic-valid`.
+5. **User tests** independently.
+6. On the user's "done": **`cdk destroy`** (I run, confirmed) — tears down all created resources.
+
+CI never deploys; CI runs the unit tests + `cdk synth` + cfn-lint only.
+
+## 8. Testing
+
+**CI / local (no AWS):**
+- `payload.test.ts` — encode/decode round-trip; the 4 KB guard throws; shape validation rejects junk.
+- `render-core.test.ts` — `buildInvoiceHtml` includes every field value + an inline `<svg>` (vector, not `<img>`); the embedded QR SVG round-trips (extract the QR string the template was given). `renderPdf` is NOT exercised in CI.
+- `seal.test.ts` — `sealAndUpload` with a **mock KMS + mock S3 client**: asserts seal → the exact `PutObject` (bucket/key/body) round-trips through a mock `unseal`.
+- `handler.test.ts` — `makeHandler({ s3, kms, renderPdf: stub })` with mocked AWS: happy path returns a base64 `application/pdf`; missing object → 404; bad docId → 400; the stubbed `renderPdf` receives HTML containing the sealed fields.
+- `cdk synth` produces a valid template (a CI step; cfn-lint if available).
+
+**Integration (real AWS, profile-driven, in `RUNBOOK.md` — not CI):** the §7 deploy → seal → invoke → verify (`verifyDocument` authentic-valid) → teardown.
+
+**Showcase** (`showcases/src/recipe-aws-kms-pdf-attestation.recipe.test.ts`, CI-safe slice): firm issues via the hub (`vault.issueAttestation`) → build a `RenderPayload` → **seal+unseal with a mock KMS** → `buildInvoiceHtml` → assert the HTML carries the fields + an inline-SVG QR whose decoded string equals the issued QR, and that ④'s `verifyDocument(issuedQr, fields, { publicKeys, fieldSchema })` returns `authentic-valid`. (The Chromium PDF pass + real AWS are exercised only via the runbook, noted in the showcase docblock.)
+
+## 9. features.yaml
+
+Register a `recipes:` entry (`id: aws-kms-pdf-attestation`, `doc: docs/recipes/aws-kms-pdf-attestation.md`, `showcase_path: showcases/src/recipe-aws-kms-pdf-attestation.recipe.test.ts`, `status: preview`, `exercises.features: [attestation]`). The recipe-pair check needs doc-slug = showcase-slug = id = `aws-kms-pdf-attestation` (so the showcase file is `recipe-aws-kms-pdf-attestation.recipe.test.ts`). No new feature row.
+
+## 10. Render stack (locked)
+
+`puppeteer-core` + `@sparticuz/chromium` (arm64), packaged as a **container image** Lambda on `nodejs22.x` (Node 20 hit Lambda EOL 2026-04-30), ≥2048 MB memory, browser reused across warm invocations, QR embedded as inline `<svg>` → vector. (`pdf-lib`/`svg-to-pdfkit` was considered and set aside in favour of HTML/CSS template fidelity; that trade-off is recorded in the umbrella + this spec's history.)
+
+## 11. Scope (YAGNI)
+
+**In:** the five parts in §2, one sample invoice template, the CDK stack + Dockerfile, the unit tests + `cdk synth`, the recipe doc + showcase + runbook, the `NOYDB_SHOWCASE_AWS_DOCS` `.env.example` entry (already added).
+**Out:** KMS-backed `DocumentSigner` (deferred per umbrella §7 — signing stays in-process via `issueAttestation`; ③ uses KMS only to *decrypt the source record*); envelope encryption for >4 KB payloads; multiple/themed invoice templates; API Gateway / custom authorizers; non-arm64 builds; Lambda provisioned-concurrency / warming beyond the warm-browser singleton; any vault store on S3 (single sealed objects only).
+
+## 12. Build order within the slice
+
+1. `payload.ts` (RenderPayload + encode/decode + 4 KB guard) + `render-core.ts` `buildInvoiceHtml` (the CI-testable spine), TDD.
+2. `render-core.ts` `renderPdf` (puppeteer-core + @sparticuz/chromium) + `Dockerfile` — buildable, not CI-run.
+3. `seal.ts` (`sealAndUpload`, mock-KMS tested) + `handler.ts` (`makeHandler`, mock-AWS tested).
+4. CDK stack (`infra/`) + `cdk synth` CI step.
+5. `docs/recipes/…md` + showcase + `features.yaml` + `RUNBOOK.md` + full local gate.
+6. (Execution-time, profile-driven, separate from CI) real-AWS deploy → verify → teardown per the runbook.

--- a/features.yaml
+++ b/features.yaml
@@ -2133,3 +2133,10 @@ recipes:
     status: preview
     exercises:
       features: [attestation]
+  - id: aws-kms-pdf-attestation
+    name: AWS-KMS PDF attestation render (generation side)
+    doc: docs/recipes/aws-kms-pdf-attestation.md
+    showcase_path: showcases/src/recipe-aws-kms-pdf-attestation.recipe.test.ts
+    status: preview
+    exercises:
+      features: [attestation]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 4.1.1
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.9.0)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0)
       turbo:
         specifier: ^2.4.0
         version: 2.9.3
@@ -43,7 +43,7 @@ importers:
         version: 8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.17)(happy-dom@18.0.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
+        version: 3.2.4(@types/node@22.19.17)(happy-dom@18.0.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
 
   packages/as-blob:
     devDependencies:
@@ -383,7 +383,7 @@ importers:
         version: 1.15.11
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
+        version: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(tsx@4.22.3)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
 
   packages/in-pinia:
     devDependencies:
@@ -837,7 +837,7 @@ importers:
         version: 0.11.3(magicast@0.5.2)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
+        version: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.22.3)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
       pinia:
         specifier: ^3.0.1
         version: 3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3))
@@ -862,7 +862,68 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.17)(happy-dom@18.0.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
+        version: 3.2.4(@types/node@22.19.17)(happy-dom@18.0.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
+
+  recipes/aws-kms-pdf-attestation:
+    dependencies:
+      '@aws-sdk/client-kms':
+        specifier: ^3.0.0
+        version: 3.1053.0
+      '@aws-sdk/client-s3':
+        specifier: ^3.0.0
+        version: 3.1024.0
+      '@noy-db/at-aws-kms':
+        specifier: workspace:*
+        version: link:../../packages/at-aws-kms
+      '@sparticuz/chromium':
+        specifier: ^138.0.0
+        version: 138.0.2
+      puppeteer-core:
+        specifier: ^24.0.0
+        version: 24.43.1
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
+    devDependencies:
+      '@noy-db/attestation':
+        specifier: workspace:*
+        version: link:../../packages/attestation
+      '@noy-db/hub':
+        specifier: workspace:*
+        version: link:../../packages/hub
+      '@noy-db/recipe-attestation-verifier':
+        specifier: workspace:*
+        version: link:../attestation-verifier
+      '@noy-db/to-memory':
+        specifier: workspace:*
+        version: link:../../packages/to-memory
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      '@types/qrcode':
+        specifier: ^1.5.5
+        version: 1.5.6
+      aws-cdk:
+        specifier: ^2.160.0
+        version: 2.1125.0
+      aws-cdk-lib:
+        specifier: ^2.160.0
+        version: 2.257.0(constructs@10.6.0)
+      constructs:
+        specifier: ^10.3.0
+        version: 10.6.0
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
+      tsx:
+        specifier: ^4.19.0
+        version: 4.22.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.17)(happy-dom@18.0.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
 
   showcases:
     dependencies:
@@ -1157,7 +1218,7 @@ importers:
         version: link:../../packages/hub
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.17)(happy-dom@18.0.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
+        version: 3.2.4(@types/node@22.19.17)(happy-dom@18.0.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
 
   test-harnesses/benchmarks:
     devDependencies:
@@ -1200,6 +1261,19 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@aws-cdk/asset-awscli-v1@2.2.273':
+    resolution: {integrity: sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2':
+    resolution: {integrity: sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==}
+
+  '@aws-cdk/cloud-assembly-schema@53.28.0':
+    resolution: {integrity: sha512-pZS+9bLGv2tCqcgxfA0WD3XjcqT3yE4ICvKeJEicw6aTdCxBl8FQ/AUsorY/6f2JrMS3kUQgvhXxA30MWcji0A==}
+    engines: {node: '>= 18.0.0'}
+    bundledDependencies:
+      - jsonschema
+      - semver
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -1825,6 +1899,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.17.19':
     resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
     engines: {node: '>=12'}
@@ -1845,6 +1925,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -1873,6 +1959,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.17.19':
     resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
     engines: {node: '>=12'}
@@ -1893,6 +1985,12 @@ packages:
 
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -1921,6 +2019,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.17.19':
     resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
     engines: {node: '>=12'}
@@ -1941,6 +2045,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.7':
     resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -1969,6 +2079,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.17.19':
     resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
     engines: {node: '>=12'}
@@ -1989,6 +2105,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.7':
     resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -2017,6 +2139,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.17.19':
     resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
     engines: {node: '>=12'}
@@ -2037,6 +2165,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.7':
     resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -2065,6 +2199,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.17.19':
     resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
     engines: {node: '>=12'}
@@ -2085,6 +2225,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.7':
     resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -2113,6 +2259,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.17.19':
     resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
     engines: {node: '>=12'}
@@ -2133,6 +2285,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.7':
     resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -2161,6 +2319,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.17.19':
     resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
     engines: {node: '>=12'}
@@ -2181,6 +2345,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -2209,6 +2379,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
@@ -2217,6 +2393,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -2245,6 +2427,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
@@ -2253,6 +2441,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -2281,6 +2475,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
@@ -2289,6 +2489,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -2317,6 +2523,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.17.19':
     resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
     engines: {node: '>=12'}
@@ -2337,6 +2549,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -2365,6 +2583,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.17.19':
     resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
     engines: {node: '>=12'}
@@ -2385,6 +2609,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -3591,6 +3821,11 @@ packages:
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
+  '@puppeteer/browsers@2.13.2':
+    resolution: {integrity: sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@rolldown/pluginutils@1.0.0-rc.13':
     resolution: {integrity: sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==}
 
@@ -4053,6 +4288,10 @@ packages:
     resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
     engines: {node: '>=18.0.0'}
 
+  '@sparticuz/chromium@138.0.2':
+    resolution: {integrity: sha512-vs5qUiK6kFCzLCxZ2buWONcB6jdF3VWdYp6kH1tt56tZ78p51dMAxfWsfk9P62z/jAeqbVg4V6Rb3Ic4aAeOKQ==}
+    engines: {node: '>=20.11.0'}
+
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
@@ -4115,6 +4354,9 @@ packages:
   '@tootallnate/once@2.0.1':
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
+
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
   '@turbo/darwin-64@2.9.3':
     resolution: {integrity: sha512-P8foouaP+y/p+hhEGBoZpzMbpVvUMwPjDpcy6wN7EYfvvyISD1USuV27qWkczecihwuPJzQ1lDBuL8ERcavTyg==}
@@ -4218,6 +4460,9 @@ packages:
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
+  '@types/qrcode@1.5.6':
+    resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
+
   '@types/qs@6.15.0':
     resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
 
@@ -4250,6 +4495,9 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript-eslint/eslint-plugin@8.58.0':
     resolution: {integrity: sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==}
@@ -4650,6 +4898,10 @@ packages:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
     engines: {node: '>=20.19.0'}
 
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
   ast-walker-scope@0.8.3:
     resolution: {integrity: sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==}
     engines: {node: '>=20.19.0'}
@@ -4676,6 +4928,30 @@ packages:
 
   avvio@9.2.0:
     resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
+
+  aws-cdk-lib@2.257.0:
+    resolution: {integrity: sha512-GoHfWklrBJcMwLtDlY64pvaT7cD2KyDXC8sik89DR6jHl6nQsBtYTKSJCM+C/k4jgXaecbv8myNX75FySejq0A==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      constructs: ^10.5.0
+    bundledDependencies:
+      - '@balena/dockerignore'
+      - '@aws-cdk/cloud-assembly-api'
+      - case
+      - fs-extra
+      - ignore
+      - jsonschema
+      - minimatch
+      - punycode
+      - semver
+      - table
+      - yaml
+      - mime-types
+
+  aws-cdk@2.1125.0:
+    resolution: {integrity: sha512-QAvsE2XQMcyNOjMMqAS7eDADR9t6vcFcMQvhOmtLfDqgfJXSyTkHvzM5zgwZCdJ4FNqWr5Y/zXvL1Cv5ECKXwQ==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
 
   aws-ssl-profiles@1.1.2:
     resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
@@ -4745,6 +5021,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
+    engines: {node: '>=10.0.0'}
+
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
@@ -4806,6 +5086,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
@@ -4864,6 +5147,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
   caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
 
@@ -4900,6 +5187,11 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
+  chromium-bidi@14.0.0:
+    resolution: {integrity: sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==}
+    peerDependencies:
+      devtools-protocol: '*'
+
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
@@ -4911,6 +5203,9 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -4985,6 +5280,9 @@ packages:
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  constructs@10.6.0:
+    resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==}
 
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
@@ -5115,6 +5413,10 @@ packages:
   data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
 
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
   db0@0.3.4:
     resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
     peerDependencies:
@@ -5149,6 +5451,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -5188,6 +5494,10 @@ packages:
   defu@6.1.6:
     resolution: {integrity: sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==}
 
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -5225,6 +5535,9 @@ packages:
   devalue@5.6.4:
     resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
 
+  devtools-protocol@0.0.1608973:
+    resolution: {integrity: sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==}
+
   diff@7.0.0:
     resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
     engines: {node: '>=0.3.1'}
@@ -5232,6 +5545,9 @@ packages:
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -5372,6 +5688,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -5386,6 +5707,11 @@ packages:
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -5491,6 +5817,11 @@ packages:
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
   fake-indexeddb@6.2.5:
     resolution: {integrity: sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==}
     engines: {node: '>=18'}
@@ -5556,6 +5887,9 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -5601,6 +5935,15 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -5696,9 +6039,17 @@ packages:
   get-source@2.0.12:
     resolution: {integrity: sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-stream@8.0.1:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
 
   giget@3.2.0:
     resolution: {integrity: sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==}
@@ -6255,6 +6606,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
   lru.min@1.1.4:
     resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
     engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
@@ -6456,6 +6811,10 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
+
+  netmask@2.1.1:
+    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
+    engines: {node: '>= 0.4.0'}
 
   next@15.5.15:
     resolution: {integrity: sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ==}
@@ -6690,6 +7049,14 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
+
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
@@ -6757,6 +7124,9 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   perfect-debounce@1.0.0:
     resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
@@ -6851,6 +7221,10 @@ packages:
     resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
 
   postcss-calc@10.1.1:
     resolution: {integrity: sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==}
@@ -7102,6 +7476,10 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   promise-limit@2.7.0:
     resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
 
@@ -7124,6 +7502,13 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -7134,6 +7519,15 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  puppeteer-core@24.43.1:
+    resolution: {integrity: sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==}
+    engines: {node: '>=18'}
+
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
 
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
@@ -7227,6 +7621,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -7366,6 +7763,9 @@ packages:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
 
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
@@ -7449,6 +7849,10 @@ packages:
   smob@1.6.1:
     resolution: {integrity: sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==}
     engines: {node: '>=20.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
 
   socks@2.8.8:
     resolution: {integrity: sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==}
@@ -7647,6 +8051,9 @@ packages:
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
@@ -7787,6 +8194,11 @@ packages:
       typescript:
         optional: true
 
+  tsx@4.22.3:
+    resolution: {integrity: sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
@@ -7811,6 +8223,9 @@ packages:
 
   type-level-regexp@0.1.17:
     resolution: {integrity: sha512-wTk4DH3cxwk196uGLK/E9pE45aLfeKJacKmcEgEOA/q5dnPGNxXt0cfYdFxb57L+sEpf1oJH4Dnx/pnRcku9jg==}
+
+  typed-query-selector@2.12.2:
+    resolution: {integrity: sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==}
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
@@ -8287,6 +8702,9 @@ packages:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
 
+  webdriver-bidi-protocol@0.4.1:
+    resolution: {integrity: sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -8303,6 +8721,9 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -8337,6 +8758,10 @@ packages:
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -8385,6 +8810,9 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -8406,13 +8834,24 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
+
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yjs@13.6.30:
     resolution: {integrity: sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==}
@@ -8470,6 +8909,12 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@aws-cdk/asset-awscli-v1@2.2.273': {}
+
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.2': {}
+
+  '@aws-cdk/cloud-assembly-schema@53.28.0': {}
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -9730,6 +10175,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.17.19':
     optional: true
 
@@ -9740,6 +10188,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.17.19':
@@ -9754,6 +10205,9 @@ snapshots:
   '@esbuild/android-arm@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.17.19':
     optional: true
 
@@ -9764,6 +10218,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.17.19':
@@ -9778,6 +10235,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.17.19':
     optional: true
 
@@ -9788,6 +10248,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.17.19':
@@ -9802,6 +10265,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.17.19':
     optional: true
 
@@ -9812,6 +10278,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.17.19':
@@ -9826,6 +10295,9 @@ snapshots:
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.17.19':
     optional: true
 
@@ -9836,6 +10308,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.17.19':
@@ -9850,6 +10325,9 @@ snapshots:
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.17.19':
     optional: true
 
@@ -9860,6 +10338,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.17.19':
@@ -9874,6 +10355,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.17.19':
     optional: true
 
@@ -9884,6 +10368,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.17.19':
@@ -9898,6 +10385,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.17.19':
     optional: true
 
@@ -9908,6 +10398,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.17.19':
@@ -9922,10 +10415,16 @@ snapshots:
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.17.19':
@@ -9940,10 +10439,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.17.19':
@@ -9958,10 +10463,16 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.17.19':
@@ -9976,6 +10487,9 @@ snapshots:
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.17.19':
     optional: true
 
@@ -9986,6 +10500,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.17.19':
@@ -10000,6 +10517,9 @@ snapshots:
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.17.19':
     optional: true
 
@@ -10010,6 +10530,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
@@ -10593,11 +11116,11 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@3.2.4(magicast@0.5.2)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))':
+  '@nuxt/devtools-kit@3.2.4(magicast@0.5.2)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       execa: 8.0.1
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - magicast
 
@@ -10612,9 +11135,9 @@ snapshots:
       pkg-types: 2.3.0
       semver: 7.7.4
 
-  '@nuxt/devtools@3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))':
+  '@nuxt/devtools@3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
-      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))
+      '@nuxt/devtools-kit': 3.2.4(magicast@0.5.2)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))
       '@nuxt/devtools-wizard': 3.2.4
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@5.9.3))
@@ -10642,9 +11165,9 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 2.0.0
       tinyglobby: 0.2.15
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
-      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))
-      vite-plugin-vue-tracer: 1.3.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite-plugin-inspect: 11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))
+      vite-plugin-vue-tracer: 1.3.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))
       which: 6.0.1
       ws: 8.20.0
     transitivePeerDependencies:
@@ -10678,7 +11201,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.2(3illoki4ycqbjkoacagmmdv7m4)':
+  '@nuxt/nitro-server@4.4.2(dtko5xnnslxhjwrgnnxnseform)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -10697,7 +11220,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.3(@azure/identity@4.13.1)(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17))(srvx@0.11.15)
-      nuxt: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
+      nuxt: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(tsx@4.22.3)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -10748,7 +11271,7 @@ snapshots:
       - uploadthing
       - xml2js
 
-  '@nuxt/nitro-server@4.4.2(x3nxv74o3tqmacatqhe2agzdfq)':
+  '@nuxt/nitro-server@4.4.2(mrrpwrr2u45v562j4p72oekgvq)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@nuxt/devalue': 2.0.2
@@ -10767,7 +11290,7 @@ snapshots:
       klona: 2.0.6
       mocked-exports: 0.1.1
       nitropack: 2.13.3(@azure/identity@4.13.1)(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17))(srvx@0.11.15)
-      nuxt: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
+      nuxt: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.22.3)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -10835,12 +11358,12 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.0.0
 
-  '@nuxt/vite-builder@4.4.2(grarc57phrecko2onpjaonvwtu)':
+  '@nuxt/vite-builder@4.4.2(5sgt6v7zt5emaxaykruzu545bq)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.1)
-      '@vitejs/plugin-vue': 6.0.5(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))
+      '@vitejs/plugin-vue': 6.0.5(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))
       autoprefixer: 10.4.27(postcss@8.5.8)
       consola: 3.4.2
       cssnano: 7.1.4(postcss@8.5.8)
@@ -10853,7 +11376,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
+      nuxt: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.22.3)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -10862,9 +11385,9 @@ snapshots:
       std-env: 4.0.0
       ufo: 1.6.3
       unenv: 2.0.0-rc.24
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
-      vite-node: 5.3.0(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
-      vite-plugin-checker: 0.12.0(eslint@9.39.4(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite-node: 5.3.0(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite-plugin-checker: 0.12.0(eslint@9.39.4(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))
       vue: 3.5.32(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
@@ -10895,12 +11418,12 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@nuxt/vite-builder@4.4.2(sdvsdkhflqs2ybsvzjzioenq6e)':
+  '@nuxt/vite-builder@4.4.2(z4ppgxsalutfzadp6me4ot3xsi)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.1)
-      '@vitejs/plugin-vue': 6.0.5(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))
-      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))
+      '@vitejs/plugin-vue': 6.0.5(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))
       autoprefixer: 10.4.27(postcss@8.5.8)
       consola: 3.4.2
       cssnano: 7.1.4(postcss@8.5.8)
@@ -10913,7 +11436,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
+      nuxt: 4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(tsx@4.22.3)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -10922,9 +11445,9 @@ snapshots:
       std-env: 4.0.0
       ufo: 1.6.3
       unenv: 2.0.0-rc.24
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
-      vite-node: 5.3.0(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
-      vite-plugin-checker: 0.12.0(eslint@9.39.4(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite-node: 5.3.0(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite-plugin-checker: 0.12.0(eslint@9.39.4(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))
       vue: 3.5.32(typescript@5.9.3)
       vue-bundle-renderer: 2.2.0
     optionalDependencies:
@@ -11266,6 +11789,21 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.1': {}
+
+  '@puppeteer/browsers@2.13.2':
+    dependencies:
+      debug: 4.4.3
+      extract-zip: 2.0.1
+      progress: 2.0.3
+      proxy-agent: 6.5.0
+      semver: 7.7.4
+      tar-fs: 3.1.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+      - supports-color
 
   '@rolldown/pluginutils@1.0.0-rc.13': {}
 
@@ -11797,6 +12335,16 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@sparticuz/chromium@138.0.2':
+    dependencies:
+      follow-redirects: 1.16.0
+      tar-fs: 3.1.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - debug
+      - react-native-b4a
+
   '@speed-highlight/core@1.2.15': {}
 
   '@supabase/auth-js@2.105.1':
@@ -11868,6 +12416,8 @@ snapshots:
       '@types/react': 18.3.28
 
   '@tootallnate/once@2.0.1': {}
+
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@turbo/darwin-64@2.9.3':
     optional: true
@@ -11974,6 +12524,10 @@ snapshots:
 
   '@types/prop-types@15.7.15': {}
 
+  '@types/qrcode@1.5.6':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@types/qs@6.15.0': {}
 
   '@types/range-parser@1.2.7': {}
@@ -12010,6 +12564,11 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.17
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 22.19.17
+    optional: true
 
   '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -12135,22 +12694,22 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))':
+  '@vitejs/plugin-vue-jsx@5.1.5(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
       '@rolldown/pluginutils': 1.0.0-rc.13
       '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
       vue: 3.5.32(typescript@5.9.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@6.0.5(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.5(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.2
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
       vue: 3.5.32(typescript@5.9.3)
 
   '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.19.17)(happy-dom@16.8.1)(terser@5.46.1))':
@@ -12194,13 +12753,13 @@ snapshots:
     optionalDependencies:
       vite: 5.4.21(@types/node@22.19.17)(terser@5.46.1)
 
-  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))':
+  '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
+      vite: 6.4.1(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -12565,6 +13124,10 @@ snapshots:
       '@babel/parser': 7.29.2
       pathe: 2.0.3
 
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+
   ast-walker-scope@0.8.3:
     dependencies:
       '@babel/parser': 7.29.2
@@ -12591,6 +13154,15 @@ snapshots:
     dependencies:
       '@fastify/error': 4.2.0
       fastq: 1.20.1
+
+  aws-cdk-lib@2.257.0(constructs@10.6.0):
+    dependencies:
+      '@aws-cdk/asset-awscli-v1': 2.2.273
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.1.2
+      '@aws-cdk/cloud-assembly-schema': 53.28.0
+      constructs: 10.6.0
+
+  aws-cdk@2.1125.0: {}
 
   aws-ssl-profiles@1.1.2: {}
 
@@ -12635,6 +13207,8 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.15: {}
+
+  basic-ftp@5.3.1: {}
 
   bcrypt-pbkdf@1.0.2:
     dependencies:
@@ -12712,6 +13286,8 @@ snapshots:
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  buffer-crc32@0.2.13: {}
+
   buffer-crc32@1.0.0: {}
 
   buffer-equal-constant-time@1.0.1: {}
@@ -12773,6 +13349,8 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase@5.3.1: {}
+
   caniuse-api@3.0.0:
     dependencies:
       browserslist: 4.28.2
@@ -12811,6 +13389,12 @@ snapshots:
 
   chownr@3.0.0: {}
 
+  chromium-bidi@14.0.0(devtools-protocol@0.0.1608973):
+    dependencies:
+      devtools-protocol: 0.0.1608973
+      mitt: 3.0.1
+      zod: 3.25.76
+
   citty@0.1.6:
     dependencies:
       consola: 3.4.2
@@ -12820,6 +13404,12 @@ snapshots:
   cjs-module-lexer@1.4.3: {}
 
   client-only@0.0.1: {}
+
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
 
   cliui@8.0.1:
     dependencies:
@@ -12902,6 +13492,8 @@ snapshots:
       proto-list: 1.2.4
 
   consola@3.4.2: {}
+
+  constructs@10.6.0: {}
 
   content-disposition@1.1.0: {}
 
@@ -13036,6 +13628,8 @@ snapshots:
 
   data-uri-to-buffer@2.0.2: {}
 
+  data-uri-to-buffer@6.0.2: {}
+
   db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)):
     optionalDependencies:
       '@libsql/client': 0.17.3
@@ -13048,6 +13642,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decamelize@1.2.0: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -13074,6 +13670,12 @@ snapshots:
 
   defu@6.1.6: {}
 
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+
   delayed-stream@1.0.0: {}
 
   denque@2.1.0: {}
@@ -13094,9 +13696,13 @@ snapshots:
 
   devalue@5.6.4: {}
 
+  devtools-protocol@0.0.1608973: {}
+
   diff@7.0.0: {}
 
   diff@8.0.4: {}
+
+  dijkstrajs@1.0.3: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -13317,6 +13923,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -13324,6 +13959,14 @@ snapshots:
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
 
   eslint-scope@8.4.0:
     dependencies:
@@ -13474,6 +14117,16 @@ snapshots:
 
   extendable-error@0.1.7: {}
 
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
   fake-indexeddb@6.2.5: {}
 
   fast-decode-uri-component@1.0.1: {}
@@ -13565,6 +14218,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -13618,6 +14275,8 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.4.2: {}
+
+  follow-redirects@1.16.0: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -13733,7 +14392,19 @@ snapshots:
       data-uri-to-buffer: 2.0.2
       source-map: 0.6.1
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
   get-stream@8.0.1: {}
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.3.1
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   giget@3.2.0: {}
 
@@ -14333,6 +15004,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lru-cache@7.18.3: {}
+
   lru.min@1.1.4: {}
 
   lunr@2.3.9: {}
@@ -14530,6 +15203,8 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  netmask@2.1.1: {}
+
   next@15.5.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 15.5.15
@@ -14708,16 +15383,16 @@ snapshots:
 
   ntlm@0.1.3: {}
 
-  nuxt@4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0):
+  nuxt@4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(srvx@0.11.15)(terser@5.46.1)(tsx@4.22.3)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))
+      '@nuxt/devtools': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(x3nxv74o3tqmacatqhe2agzdfq)
+      '@nuxt/nitro-server': 4.4.2(dtko5xnnslxhjwrgnnxnseform)
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(sdvsdkhflqs2ybsvzjzioenq6e)
+      '@nuxt/vite-builder': 4.4.2(z4ppgxsalutfzadp6me4ot3xsi)
       '@unhead/vue': 2.1.13(vue@3.5.32(typescript@5.9.3))
       '@vue/shared': 3.5.32
       c12: 3.3.4(magicast@0.5.2)
@@ -14841,16 +15516,16 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0):
+  nuxt@4.4.2(@azure/identity@4.13.1)(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@libsql/client@0.17.3)(@parcel/watcher@2.5.6)(@types/node@22.19.17)(@vue/compiler-sfc@3.5.32)(better-sqlite3@12.9.0)(cac@6.7.14)(db0@0.3.4(@libsql/client@0.17.3)(better-sqlite3@12.9.0)(mysql2@3.22.3(@types/node@22.19.17)))(eslint@9.39.4(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(mysql2@3.22.3(@types/node@22.19.17))(optionator@0.9.4)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.32(typescript@5.9.3)))(rollup-plugin-visualizer@5.14.0(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.22.3)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
-      '@nuxt/devtools': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))
+      '@nuxt/devtools': 3.2.4(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(3illoki4ycqbjkoacagmmdv7m4)
+      '@nuxt/nitro-server': 4.4.2(mrrpwrr2u45v562j4p72oekgvq)
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(grarc57phrecko2onpjaonvwtu)
+      '@nuxt/vite-builder': 4.4.2(5sgt6v7zt5emaxaykruzu545bq)
       '@unhead/vue': 2.1.13(vue@3.5.32(typescript@5.9.3))
       '@vue/shared': 3.5.32
       c12: 3.3.4(magicast@0.5.2)
@@ -15151,6 +15826,24 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.1.1
+
   package-json-from-dist@1.0.1: {}
 
   package-manager-detector@0.2.11:
@@ -15199,6 +15892,8 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  pend@1.2.0: {}
 
   perfect-debounce@1.0.0: {}
 
@@ -15296,6 +15991,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  pngjs@5.0.0: {}
+
   postcss-calc@10.1.1(postcss@8.5.8):
     dependencies:
       postcss: 8.5.8
@@ -15333,12 +16030,13 @@ snapshots:
     dependencies:
       postcss: 8.5.8
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
       postcss: 8.5.8
+      tsx: 4.22.3
       yaml: 2.9.0
 
   postcss-merge-longhand@7.0.5(postcss@8.5.8):
@@ -15519,6 +16217,8 @@ snapshots:
 
   process@0.11.10: {}
 
+  progress@2.0.3: {}
+
   promise-limit@2.7.0: {}
 
   promise-retry@2.0.1:
@@ -15552,6 +16252,21 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-from-env@1.1.0: {}
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -15560,6 +16275,29 @@ snapshots:
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
+
+  puppeteer-core@24.43.1:
+    dependencies:
+      '@puppeteer/browsers': 2.13.2
+      chromium-bidi: 14.0.0(devtools-protocol@0.0.1608973)
+      debug: 4.4.3
+      devtools-protocol: 0.0.1608973
+      typed-query-selector: 2.12.2
+      webdriver-bidi-protocol: 0.4.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
 
   qs@6.15.1:
     dependencies:
@@ -15658,6 +16396,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  require-main-filename@2.0.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -15821,6 +16561,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  set-blocking@2.0.0: {}
+
   set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
@@ -15962,6 +16704,14 @@ snapshots:
   smart-buffer@4.2.0: {}
 
   smob@1.6.1: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.8
+    transitivePeerDependencies:
+      - supports-color
 
   socks@2.8.8:
     dependencies:
@@ -16152,6 +16902,18 @@ snapshots:
       pump: 3.0.4
       tar-stream: 2.2.0
 
+  tar-fs@3.1.2:
+    dependencies:
+      pump: 3.0.4
+      tar-stream: 3.1.8
+    optionalDependencies:
+      bare-fs: 4.6.0
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   tar-stream@2.2.0:
     dependencies:
       bl: 4.1.0
@@ -16277,7 +17039,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.9.0):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.22.3)(typescript@5.9.3)(yaml@2.9.0):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -16288,7 +17050,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.22.3)(yaml@2.9.0)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.7.6
@@ -16304,6 +17066,12 @@ snapshots:
       - supports-color
       - tsx
       - yaml
+
+  tsx@4.22.3:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -16335,6 +17103,8 @@ snapshots:
       mime-types: 3.0.2
 
   type-level-regexp@0.1.17: {}
+
+  typed-query-selector@2.12.2: {}
 
   typedarray@0.0.6: {}
 
@@ -16503,15 +17273,15 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-dev-rpc@1.1.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)):
+  vite-dev-rpc@1.1.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       birpc: 2.9.0
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
-      vite-hot-client: 2.1.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite-hot-client: 2.1.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))
 
-  vite-hot-client@2.1.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)):
+  vite-hot-client@2.1.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
 
   vite-node@2.1.9(@types/node@22.19.17)(terser@5.46.1):
     dependencies:
@@ -16531,13 +17301,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
+      vite: 6.4.1(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -16552,13 +17322,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@5.3.0(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0):
+  vite-node@5.3.0(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       es-module-lexer: 2.0.0
       obug: 2.1.1
       pathe: 2.0.3
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -16572,7 +17342,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.12.0(eslint@9.39.4(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3)):
+  vite-plugin-checker@0.12.0(eslint@9.39.4(jiti@2.6.1))(optionator@0.9.4)(typescript@5.9.3)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue-tsc@2.2.12(typescript@5.9.3)):
     dependencies:
       '@babel/code-frame': 7.29.0
       chokidar: 4.0.3
@@ -16581,7 +17351,7 @@ snapshots:
       picomatch: 4.0.4
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.15
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
       vscode-uri: 3.1.0
     optionalDependencies:
       eslint: 9.39.4(jiti@2.6.1)
@@ -16589,7 +17359,7 @@ snapshots:
       typescript: 5.9.3
       vue-tsc: 2.2.12(typescript@5.9.3)
 
-  vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)):
+  vite-plugin-inspect@11.3.3(@nuxt/kit@4.4.2(magicast@0.5.2))(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       ansis: 4.2.0
       debug: 4.4.3
@@ -16599,21 +17369,21 @@ snapshots:
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       unplugin-utils: 0.3.1
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
-      vite-dev-rpc: 1.1.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite-dev-rpc: 1.1.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-tracer@1.3.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3)):
+  vite-plugin-vue-tracer@1.3.0(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))(vue@3.5.32(typescript@5.9.3)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.8
       magic-string: 0.30.21
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
       vue: 3.5.32(typescript@5.9.3)
 
   vite@5.4.21(@types/node@22.19.17)(terser@5.46.1):
@@ -16626,7 +17396,7 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.46.1
 
-  vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0):
+  vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -16639,9 +17409,10 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.46.1
+      tsx: 4.22.3
       yaml: 2.9.0
 
-  vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0):
+  vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -16654,6 +17425,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.46.1
+      tsx: 4.22.3
       yaml: 2.9.0
 
   vitest@2.1.9(@types/node@22.19.17)(happy-dom@16.8.1)(terser@5.46.1):
@@ -16692,11 +17464,11 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.2.4(@types/node@22.19.17)(happy-dom@18.0.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0):
+  vitest@3.2.4(@types/node@22.19.17)(happy-dom@18.0.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.4(vite@6.4.1(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -16714,8 +17486,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
+      vite: 6.4.1(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
@@ -16787,6 +17559,8 @@ snapshots:
 
   web-streams-polyfill@4.0.0-beta.3: {}
 
+  webdriver-bidi-protocol@0.4.1: {}
+
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0: {}
@@ -16799,6 +17573,8 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  which-module@2.0.1: {}
 
   which@2.0.2:
     dependencies:
@@ -16842,6 +17618,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -16868,6 +17650,8 @@ snapshots:
 
   xtend@4.0.2: {}
 
+  y18n@4.0.3: {}
+
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
@@ -16878,7 +17662,26 @@ snapshots:
 
   yaml@2.9.0: {}
 
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
   yargs-parser@21.1.1: {}
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   yargs@17.7.2:
     dependencies:
@@ -16889,6 +17692,11 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yjs@13.6.30:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1132,6 +1132,9 @@ importers:
       '@noy-db/recipe-attestation-verifier':
         specifier: workspace:*
         version: link:../recipes/attestation-verifier
+      '@noy-db/recipe-aws-kms-pdf-attestation':
+        specifier: workspace:*
+        version: link:../recipes/aws-kms-pdf-attestation
       '@tanstack/query-core':
         specifier: ^5.59.0
         version: 5.99.2

--- a/recipes/aws-kms-pdf-attestation/.gitignore
+++ b/recipes/aws-kms-pdf-attestation/.gitignore
@@ -1,0 +1,2 @@
+.scratch/
+cdk.out/

--- a/recipes/aws-kms-pdf-attestation/Dockerfile
+++ b/recipes/aws-kms-pdf-attestation/Dockerfile
@@ -3,8 +3,15 @@ FROM public.ecr.aws/lambda/nodejs:22-arm64
 # @sparticuz/chromium needs these shared libs present in the image.
 RUN dnf install -y tar bzip2 && dnf clean all
 WORKDIR ${LAMBDA_TASK_ROOT}
-COPY package.json ./
+# A minimal package.json that only declares ESM. We deliberately do NOT copy the
+# workspace package.json — it has `workspace:*` deps npm cannot install
+# (EUNSUPPORTEDPROTOCOL). The handler bundle is self-contained except for the
+# externalized native/runtime deps installed below; node resolves those from
+# node_modules regardless of what package.json lists.
+RUN printf '{"type":"module"}' > package.json
 # Install only the runtime deps the handler needs (no hub, no cdk, no test deps).
+# NOTE: pinned majors here are decoupled from the workspace lockfile — pin exact
+# versions before any production use (see PR #239 known limitations).
 RUN npm install --omit=dev --no-package-lock \
     @aws-sdk/client-s3@^3 @aws-sdk/client-kms@^3 qrcode@^1 puppeteer-core@^24 @sparticuz/chromium@^138
 COPY dist/ ./

--- a/recipes/aws-kms-pdf-attestation/Dockerfile
+++ b/recipes/aws-kms-pdf-attestation/Dockerfile
@@ -1,4 +1,8 @@
-# Lambda container for the KMS-PDF render recipe (arm64, Node 22).
+# ALTERNATIVE packaging — self-contained container image (no public layer).
+# The DEFAULT deploy is an arm64 zip + public Chromium layer (see infra/stack.ts
+# + RUNBOOK.md "Container alternative"). This Dockerfile is x86_64 because the npm
+# @sparticuz/chromium binary is x86-only; bundle with
+# `--external:@sparticuz/chromium --external:puppeteer-core` if you use it.
 FROM public.ecr.aws/lambda/nodejs:22-x86_64
 # @sparticuz/chromium needs these shared libs present in the image. The
 # Amazon Linux 2023 Lambda base lacks Chromium's runtime deps (libnss3.so et al);

--- a/recipes/aws-kms-pdf-attestation/Dockerfile
+++ b/recipes/aws-kms-pdf-attestation/Dockerfile
@@ -1,7 +1,15 @@
 # Lambda container for the KMS-PDF render recipe (arm64, Node 22).
-FROM public.ecr.aws/lambda/nodejs:22-arm64
-# @sparticuz/chromium needs these shared libs present in the image.
-RUN dnf install -y tar bzip2 && dnf clean all
+FROM public.ecr.aws/lambda/nodejs:22-x86_64
+# @sparticuz/chromium needs these shared libs present in the image. The
+# Amazon Linux 2023 Lambda base lacks Chromium's runtime deps (libnss3.so et al);
+# install the documented set so the headless browser can launch.
+RUN dnf install -y tar bzip2 \
+      nss nss-util nspr \
+      atk at-spi2-atk at-spi2-core cups-libs \
+      libdrm libxkbcommon libXcomposite libXdamage libXext libXfixes \
+      libXrandr libXScrnSaver libxshmfence mesa-libgbm \
+      pango cairo alsa-lib gtk3 \
+    && dnf clean all
 WORKDIR ${LAMBDA_TASK_ROOT}
 # A minimal package.json that only declares ESM. We deliberately do NOT copy the
 # workspace package.json — it has `workspace:*` deps npm cannot install

--- a/recipes/aws-kms-pdf-attestation/Dockerfile
+++ b/recipes/aws-kms-pdf-attestation/Dockerfile
@@ -1,0 +1,11 @@
+# Lambda container for the KMS-PDF render recipe (arm64, Node 22).
+FROM public.ecr.aws/lambda/nodejs:22-arm64
+# @sparticuz/chromium needs these shared libs present in the image.
+RUN dnf install -y tar bzip2 && dnf clean all
+WORKDIR ${LAMBDA_TASK_ROOT}
+COPY package.json ./
+# Install only the runtime deps the handler needs (no hub, no cdk, no test deps).
+RUN npm install --omit=dev --no-package-lock \
+    @aws-sdk/client-s3@^3 @aws-sdk/client-kms@^3 qrcode@^1 puppeteer-core@^24 @sparticuz/chromium@^138
+COPY dist/ ./
+CMD [ "handler.handler" ]

--- a/recipes/aws-kms-pdf-attestation/README.md
+++ b/recipes/aws-kms-pdf-attestation/README.md
@@ -1,0 +1,11 @@
+# @noy-db/recipe-aws-kms-pdf-attestation
+
+Deployable reference Lambda: KMS-decrypt a firm-sealed S3 doc record, render an
+HTML invoice → PDF with the attestation QR as vector. Private recipe, not published.
+
+- Narrative + data flow: `docs/recipes/aws-kms-pdf-attestation.md`
+- Deploy / verify / teardown (real AWS, profile-driven): `RUNBOOK.md`
+- CI-safe data-path test: `pnpm --filter @noy-db/recipe-aws-kms-pdf-attestation test`
+
+Render stack: puppeteer-core + @sparticuz/chromium (arm64), container Lambda,
+Node 22, ≥2 GB, QR as inline `<svg>` (vector).

--- a/recipes/aws-kms-pdf-attestation/README.md
+++ b/recipes/aws-kms-pdf-attestation/README.md
@@ -7,5 +7,6 @@ HTML invoice → PDF with the attestation QR as vector. Private recipe, not publ
 - Deploy / verify / teardown (real AWS, profile-driven): `RUNBOOK.md`
 - CI-safe data-path test: `pnpm --filter @noy-db/recipe-aws-kms-pdf-attestation test`
 
-Render stack: puppeteer-core + @sparticuz/chromium (arm64), container Lambda,
-Node 22, ≥2 GB, QR as inline `<svg>` (vector).
+Render stack: puppeteer-core + @sparticuz/chromium, **arm64 zip Lambda + public
+Chromium layer** (no Docker/ECR), Node 22, ≥2 GB, QR as inline `<svg>` (vector).
+A self-contained container variant is documented in `RUNBOOK.md` (and `Dockerfile`).

--- a/recipes/aws-kms-pdf-attestation/RUNBOOK.md
+++ b/recipes/aws-kms-pdf-attestation/RUNBOOK.md
@@ -1,0 +1,41 @@
+# RUNBOOK — deploy, verify, teardown (real AWS)
+
+All AWS access uses a NAMED PROFILE you provide (`export AWS_PROFILE=<name>`),
+never raw or shared credentials. Each resource-creating step is confirmed first.
+
+## Prereqs
+- An AWS profile with permission to create KMS/S3/Lambda/IAM + run CDK.
+- Docker (for the arm64 Lambda container image).
+- `export AWS_PROFILE=<your-profile>` and `export AWS_REGION=<region>`.
+
+## 1. Build the handler bundle + image-deploy
+```bash
+pnpm --filter @noy-db/recipe-aws-kms-pdf-attestation run bundle   # → dist/handler.js
+cd recipes/aws-kms-pdf-attestation
+npx cdk bootstrap   # one-time per account/region
+npx cdk deploy      # creates KMS key + private S3 bucket + container Lambda + Function URL
+```
+Note the `FunctionUrl`, `BucketName`, `KeyArn` outputs.
+
+## 2. Seal + upload a sample document
+Use `sealAndUpload` (a tiny script or REPL) with the deployed `KeyArn` + `BucketName`:
+```ts
+import { sealAndUpload } from '@noy-db/recipe-aws-kms-pdf-attestation/seal'
+await sealAndUpload(
+  { docId: '<docId-from-issueAttestation>', fields: {/* invoice fields */}, qr: '<qr>' },
+  { keyId: '<KeyArn>', bucket: '<BucketName>', key: 'docs/<docId>' },
+)
+```
+
+## 3. Invoke + verify
+```bash
+curl -s "<FunctionUrl>?docId=<docId>" -o invoice.pdf
+file invoice.pdf   # → PDF document
+```
+Open `invoice.pdf`; scan the QR with the offline verifier (recipe ④) — it must
+read `authentic-valid` for the printed fields.
+
+## 4. Teardown (after you confirm "done")
+```bash
+npx cdk destroy   # removes the key, bucket (auto-deletes objects), Lambda, URL
+```

--- a/recipes/aws-kms-pdf-attestation/RUNBOOK.md
+++ b/recipes/aws-kms-pdf-attestation/RUNBOOK.md
@@ -3,19 +3,32 @@
 All AWS access uses a NAMED PROFILE you provide (`export AWS_PROFILE=<name>`),
 never raw or shared credentials. Each resource-creating step is confirmed first.
 
+The default deploy is a **ZIP function on arm64 (Graviton) with Chromium supplied
+by a public Lambda layer** — no Docker, no ECR. (A self-contained container
+alternative is documented at the bottom.)
+
 ## Prereqs
 - An AWS profile with permission to create KMS/S3/Lambda/IAM + run CDK.
-- Docker (for the arm64 Lambda container image).
-- `export AWS_PROFILE=<your-profile>` and `export AWS_REGION=<region>`.
+- Node 22 + pnpm (to build the handler bundle). **No Docker required.**
+- `export AWS_PROFILE=<your-profile>` and `export AWS_REGION=ap-southeast-1`.
+  - The Chromium layer ARN in `infra/stack.ts` is **region-pinned** to
+    `ap-southeast-1`. Deploying elsewhere → swap the ARN from the per-region
+    table at https://github.com/shelfio/chrome-aws-lambda-layer
 
-## 1. Build the handler bundle + image-deploy
+## 1. Build the handler bundle + deploy
 ```bash
-pnpm --filter @noy-db/recipe-aws-kms-pdf-attestation run bundle   # → dist/handler.js
+pnpm --filter @noy-db/recipe-aws-kms-pdf-attestation run bundle   # → dist/handler.cjs
 cd recipes/aws-kms-pdf-attestation
 npx cdk bootstrap   # one-time per account/region
-npx cdk deploy      # creates KMS key + private S3 bucket + container Lambda + Function URL
+npx cdk deploy      # creates KMS key + private S3 bucket + arm64 zip Lambda
+                    # (+ Chromium layer) + Function URL
 ```
 Note the `FunctionUrl`, `BucketName`, `KeyArn` outputs.
+
+The bundle externalizes `@sparticuz/chromium` (the layer provides it at
+`/opt/nodejs/node_modules`) and inlines `puppeteer-core`. The layer ships
+Chromium v149 / `@sparticuz/chromium@149` — newer than the `^138` dev dep, which
+is fine (the layer's JS shim + binary are self-consistent at runtime).
 
 ## 2. Seal + upload a sample document
 Use `sealAndUpload` (a tiny script or REPL) with the deployed `KeyArn` + `BucketName`:
@@ -39,3 +52,30 @@ read `authentic-valid` for the printed fields.
 ```bash
 npx cdk destroy   # removes the key, bucket (auto-deletes objects), Lambda, URL
 ```
+(The one-time `cdk bootstrap` CDKToolkit stack is left in place; delete it
+separately if you want it gone.)
+
+## Measured numbers (ap-southeast-1, 2026-05)
+
+| | arm64 zip + layer (default) | x86_64 container (alternative) |
+|---|---|---|
+| Deploy artifact | ~1.7 MB zip + AWS-hosted 66 MB layer | ~527 MB ECR image |
+| Cold (Init + first render) | ~505 ms + ~2.9 s | ~537 ms + ~2.9 s |
+| Warm render | sub-second (browser reused) | sub-second |
+| Memory used | ~515 MB / 2048 | ~515 MB / 2048 |
+
+Cold/warm are effectively equal — the dominant cost is Chromium's
+decompress-to-`/tmp` + launch, which is identical (same `@sparticuz` mechanism).
+The layer route wins on **arm64 (~20% cheaper GB-s)**, a 300× smaller artifact,
+and no Docker/ECR build chain.
+
+## Container alternative (self-contained, no third-party layer)
+
+The repo keeps a `Dockerfile` for an air-gapped/self-contained deploy that
+doesn't depend on a public layer. It builds an **x86_64** image (the npm
+`@sparticuz/chromium` binary is x86-only). To use it, point the CDK function at
+a `DockerImageFunction` instead of the zip+layer (see git history for the
+container `stack.ts`), build the bundle with
+`--external:@sparticuz/chromium --external:puppeteer-core`, and `cdk deploy`
+with a running Docker daemon. Trade-offs: larger artifact, x86_64 only, needs
+Docker — but no external-ARN dependency.

--- a/recipes/aws-kms-pdf-attestation/cdk.json
+++ b/recipes/aws-kms-pdf-attestation/cdk.json
@@ -1,0 +1,4 @@
+{
+  "app": "npx tsx infra/app.ts",
+  "context": { "@aws-cdk/core:newStyleStackSynthesis": true }
+}

--- a/recipes/aws-kms-pdf-attestation/infra/app.ts
+++ b/recipes/aws-kms-pdf-attestation/infra/app.ts
@@ -1,0 +1,6 @@
+import { App } from 'aws-cdk-lib'
+import { KmsPdfAttestationStack } from './stack.js'
+
+const app = new App()
+new KmsPdfAttestationStack(app, 'NoydbKmsPdfAttestation')
+app.synth()

--- a/recipes/aws-kms-pdf-attestation/infra/stack.ts
+++ b/recipes/aws-kms-pdf-attestation/infra/stack.ts
@@ -1,0 +1,46 @@
+import { Stack, type StackProps, RemovalPolicy, Duration, CfnOutput } from 'aws-cdk-lib'
+import type { Construct } from 'constructs'
+import * as s3 from 'aws-cdk-lib/aws-s3'
+import * as kms from 'aws-cdk-lib/aws-kms'
+import * as lambda from 'aws-cdk-lib/aws-lambda'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const DOCS_PREFIX = 'docs'
+const here = dirname(fileURLToPath(import.meta.url))
+
+export class KmsPdfAttestationStack extends Stack {
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props)
+
+    const key = new kms.Key(this, 'DocSealingKey', {
+      description: 'noy-db attestation: seals render payloads for the PDF Lambda',
+      enableKeyRotation: true,
+      removalPolicy: RemovalPolicy.DESTROY, // recipe/demo: destroy on teardown
+    })
+
+    const bucket = new s3.Bucket(this, 'DocsBucket', {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      removalPolicy: RemovalPolicy.DESTROY,
+      autoDeleteObjects: true, // recipe/demo
+    })
+
+    const fn = new lambda.DockerImageFunction(this, 'RenderFn', {
+      code: lambda.DockerImageCode.fromImageAsset(join(here, '..')),
+      architecture: lambda.Architecture.ARM_64,
+      memorySize: 2048,
+      timeout: Duration.seconds(30),
+      environment: { DOCS_BUCKET: bucket.bucketName, KMS_KEY_ID: key.keyArn, DOCS_PREFIX },
+    })
+
+    // Least privilege: decrypt with the one key + read the one prefix.
+    key.grantDecrypt(fn)
+    bucket.grantRead(fn, `${DOCS_PREFIX}/*`)
+
+    const url = fn.addFunctionUrl({ authType: lambda.FunctionUrlAuthType.NONE })
+    new CfnOutput(this, 'FunctionUrl', { value: url.url })
+    new CfnOutput(this, 'BucketName', { value: bucket.bucketName })
+    new CfnOutput(this, 'KeyArn', { value: key.keyArn })
+  }
+}

--- a/recipes/aws-kms-pdf-attestation/infra/stack.ts
+++ b/recipes/aws-kms-pdf-attestation/infra/stack.ts
@@ -3,13 +3,35 @@ import type { Construct } from 'constructs'
 import * as s3 from 'aws-cdk-lib/aws-s3'
 import * as kms from 'aws-cdk-lib/aws-kms'
 import * as lambda from 'aws-cdk-lib/aws-lambda'
-import * as ecrAssets from 'aws-cdk-lib/aws-ecr-assets'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const DOCS_PREFIX = 'docs'
 const here = dirname(fileURLToPath(import.meta.url))
 
+// shelfio chrome-aws-lambda arm64 layer — Chromium v149 / @sparticuz/chromium@149,
+// region ap-southeast-1. Verified live via get-layer-version-by-arn
+// (CompatibleArchitectures=arm64; provides nodejs/node_modules/@sparticuz/chromium).
+// A region-pinned ARN: change it if you deploy elsewhere (see the recipe's README
+// for the full per-region table) — https://github.com/shelfio/chrome-aws-lambda-layer
+const CHROMIUM_LAYER_ARN =
+  'arn:aws:lambda:ap-southeast-1:764866452798:layer:chrome-aws-lambda-arm64:9'
+
+/**
+ * KMS-PDF render Lambda — ZIP function on arm64 (Graviton) with Chromium supplied
+ * by a public Lambda layer (no container image / ECR).
+ *
+ * Why this shape (measured trade-off vs. a container image):
+ *  - arm64: ~20% cheaper GB-s at identical render performance. The npm
+ *    @sparticuz/chromium binary is x86-only, but the layer ships a native arm64
+ *    build, so the layer route is what unlocks Graviton here.
+ *  - artifact: ~1.7 MB zip + the AWS-hosted 66 MB layer (you store/push nothing),
+ *    vs. a ~527 MB ECR image.
+ *  - no Docker in the deploy path.
+ * The container variant remains available in `Dockerfile` (see RUNBOOK.md
+ * "Container alternative") for air-gapped/self-contained deployments that can't
+ * depend on a third-party public layer.
+ */
 export class KmsPdfAttestationStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props)
@@ -27,14 +49,17 @@ export class KmsPdfAttestationStack extends Stack {
       autoDeleteObjects: true, // recipe/demo
     })
 
-    // x86_64: @sparticuz/chromium ships an x86_64 Chromium binary via npm (no
-    // arm64 build), so the Lambda arch + image platform must be x86_64 or the
-    // browser fails to launch (qemu can't run the x86 binary on arm64).
-    const fn = new lambda.DockerImageFunction(this, 'RenderFn', {
-      code: lambda.DockerImageCode.fromImageAsset(join(here, '..'), {
-        platform: ecrAssets.Platform.LINUX_AMD64,
-      }),
-      architecture: lambda.Architecture.X86_64,
+    const fn = new lambda.Function(this, 'RenderFn', {
+      runtime: lambda.Runtime.NODEJS_22_X,
+      architecture: lambda.Architecture.ARM_64,
+      handler: 'handler.handler',
+      // dist/handler.cjs bundles puppeteer-core but externalizes
+      // @sparticuz/chromium, which the layer provides at /opt/nodejs/node_modules.
+      // Run `pnpm --filter @noy-db/recipe-aws-kms-pdf-attestation run bundle` first.
+      code: lambda.Code.fromAsset(join(here, '..', 'dist')),
+      layers: [
+        lambda.LayerVersion.fromLayerVersionArn(this, 'ChromiumLayer', CHROMIUM_LAYER_ARN),
+      ],
       memorySize: 2048,
       timeout: Duration.seconds(30),
       environment: { DOCS_BUCKET: bucket.bucketName, KMS_KEY_ID: key.keyArn, DOCS_PREFIX },

--- a/recipes/aws-kms-pdf-attestation/infra/stack.ts
+++ b/recipes/aws-kms-pdf-attestation/infra/stack.ts
@@ -3,6 +3,7 @@ import type { Construct } from 'constructs'
 import * as s3 from 'aws-cdk-lib/aws-s3'
 import * as kms from 'aws-cdk-lib/aws-kms'
 import * as lambda from 'aws-cdk-lib/aws-lambda'
+import * as ecrAssets from 'aws-cdk-lib/aws-ecr-assets'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -26,9 +27,14 @@ export class KmsPdfAttestationStack extends Stack {
       autoDeleteObjects: true, // recipe/demo
     })
 
+    // x86_64: @sparticuz/chromium ships an x86_64 Chromium binary via npm (no
+    // arm64 build), so the Lambda arch + image platform must be x86_64 or the
+    // browser fails to launch (qemu can't run the x86 binary on arm64).
     const fn = new lambda.DockerImageFunction(this, 'RenderFn', {
-      code: lambda.DockerImageCode.fromImageAsset(join(here, '..')),
-      architecture: lambda.Architecture.ARM_64,
+      code: lambda.DockerImageCode.fromImageAsset(join(here, '..'), {
+        platform: ecrAssets.Platform.LINUX_AMD64,
+      }),
+      architecture: lambda.Architecture.X86_64,
       memorySize: 2048,
       timeout: Duration.seconds(30),
       environment: { DOCS_BUCKET: bucket.bucketName, KMS_KEY_ID: key.keyArn, DOCS_PREFIX },

--- a/recipes/aws-kms-pdf-attestation/infra/synth.test.ts
+++ b/recipes/aws-kms-pdf-attestation/infra/synth.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { App } from 'aws-cdk-lib'
+import { Template } from 'aws-cdk-lib/assertions'
+import { KmsPdfAttestationStack } from './stack.js'
+
+describe('CDK stack synthesizes', () => {
+  it('declares the KMS key, private bucket, container Lambda, and Function URL', () => {
+    const app = new App()
+    const stack = new KmsPdfAttestationStack(app, 'Test')
+    const t = Template.fromStack(stack)
+    t.resourceCountIs('AWS::KMS::Key', 1)
+    t.resourceCountIs('AWS::S3::Bucket', 1)
+    t.hasResourceProperties('AWS::Lambda::Function', { PackageType: 'Image', Architectures: ['arm64'], MemorySize: 2048 })
+    t.resourceCountIs('AWS::Lambda::Url', 1)
+    t.hasResourceProperties('AWS::S3::Bucket', {
+      PublicAccessBlockConfiguration: { BlockPublicAcls: true, RestrictPublicBuckets: true },
+    })
+    expect(true).toBe(true)
+  })
+})

--- a/recipes/aws-kms-pdf-attestation/infra/synth.test.ts
+++ b/recipes/aws-kms-pdf-attestation/infra/synth.test.ts
@@ -10,7 +10,7 @@ describe('CDK stack synthesizes', () => {
     const t = Template.fromStack(stack)
     t.resourceCountIs('AWS::KMS::Key', 1)
     t.resourceCountIs('AWS::S3::Bucket', 1)
-    t.hasResourceProperties('AWS::Lambda::Function', { PackageType: 'Image', Architectures: ['arm64'], MemorySize: 2048 })
+    t.hasResourceProperties('AWS::Lambda::Function', { PackageType: 'Image', Architectures: ['x86_64'], MemorySize: 2048 })
     t.resourceCountIs('AWS::Lambda::Url', 1)
     t.hasResourceProperties('AWS::S3::Bucket', {
       PublicAccessBlockConfiguration: { BlockPublicAcls: true, RestrictPublicBuckets: true },

--- a/recipes/aws-kms-pdf-attestation/infra/synth.test.ts
+++ b/recipes/aws-kms-pdf-attestation/infra/synth.test.ts
@@ -1,20 +1,48 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeAll } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { App } from 'aws-cdk-lib'
 import { Template } from 'aws-cdk-lib/assertions'
 import { KmsPdfAttestationStack } from './stack.js'
 
+const here = dirname(fileURLToPath(import.meta.url))
+const distDir = join(here, '..', 'dist')
+
 describe('CDK stack synthesizes', () => {
-  it('declares the KMS key, private bucket, container Lambda, and Function URL', () => {
+  beforeAll(() => {
+    // Code.fromAsset('dist') needs a non-empty dir at synth time. The real
+    // handler is produced by `npm run bundle`; for a hermetic test we just
+    // ensure a placeholder exists if the bundle hasn't been built.
+    if (!existsSync(join(distDir, 'handler.cjs'))) {
+      mkdirSync(distDir, { recursive: true })
+      writeFileSync(join(distDir, 'handler.cjs'), 'exports.handler = async () => ({})\n')
+    }
+  })
+
+  it('declares the KMS key, private bucket, arm64 zip Lambda + Chromium layer, and Function URL', () => {
     const app = new App()
     const stack = new KmsPdfAttestationStack(app, 'Test')
     const t = Template.fromStack(stack)
     t.resourceCountIs('AWS::KMS::Key', 1)
     t.resourceCountIs('AWS::S3::Bucket', 1)
-    t.hasResourceProperties('AWS::Lambda::Function', { PackageType: 'Image', Architectures: ['x86_64'], MemorySize: 2048 })
+    // Zip package (no PackageType: Image), arm64, with at least one layer attached.
+    t.hasResourceProperties('AWS::Lambda::Function', {
+      Architectures: ['arm64'],
+      MemorySize: 2048,
+      Runtime: 'nodejs22.x',
+    })
     t.resourceCountIs('AWS::Lambda::Url', 1)
     t.hasResourceProperties('AWS::S3::Bucket', {
       PublicAccessBlockConfiguration: { BlockPublicAcls: true, RestrictPublicBuckets: true },
     })
-    expect(true).toBe(true)
+    // The render function references the public Chromium layer ARN.
+    const fns = t.findResources('AWS::Lambda::Function')
+    const hasLayer = Object.values(fns).some(
+      (r) => Array.isArray((r as { Properties?: { Layers?: unknown[] } }).Properties?.Layers)
+        && ((r as { Properties: { Layers: unknown[] } }).Properties.Layers.length > 0),
+    )
+    expect(hasLayer).toBe(true)
   })
 })

--- a/recipes/aws-kms-pdf-attestation/package.json
+++ b/recipes/aws-kms-pdf-attestation/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "bundle": "esbuild src/handler.ts --bundle --platform=node --format=esm --target=node22 --outfile=dist/handler.js --external:@sparticuz/chromium --external:puppeteer-core",
+    "bundle": "esbuild src/handler.ts --bundle --platform=node --format=cjs --target=node22 --outfile=dist/handler.cjs --external:@sparticuz/chromium --external:puppeteer-core",
     "synth": "cdk synth --app 'npx tsx infra/app.ts'"
   },
   "dependencies": {

--- a/recipes/aws-kms-pdf-attestation/package.json
+++ b/recipes/aws-kms-pdf-attestation/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@noy-db/recipe-aws-kms-pdf-attestation",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Deployable reference: KMS-decrypt an S3 doc record, render HTML→PDF with the attestation QR as vector. Recipe, not published.",
+  "exports": {
+    ".": "./src/payload.ts",
+    "./seal": "./src/seal.ts",
+    "./render-core": "./src/render-core.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "bundle": "esbuild src/handler.ts --bundle --platform=node --format=esm --target=node22 --outfile=dist/handler.js --external:@sparticuz/chromium --external:puppeteer-core",
+    "synth": "cdk synth --app 'npx tsx infra/app.ts'"
+  },
+  "dependencies": {
+    "@noy-db/at-aws-kms": "workspace:*",
+    "@aws-sdk/client-kms": "^3.0.0",
+    "@aws-sdk/client-s3": "^3.0.0",
+    "qrcode": "^1.5.4",
+    "puppeteer-core": "^24.0.0",
+    "@sparticuz/chromium": "^138.0.0"
+  },
+  "peerDependencies": {
+    "@noy-db/hub": "workspace:*"
+  },
+  "devDependencies": {
+    "@noy-db/hub": "workspace:*",
+    "@noy-db/attestation": "workspace:*",
+    "@noy-db/recipe-attestation-verifier": "workspace:*",
+    "@noy-db/to-memory": "workspace:*",
+    "@types/qrcode": "^1.5.5",
+    "@types/node": "^22.0.0",
+    "aws-cdk-lib": "^2.160.0",
+    "constructs": "^10.3.0",
+    "aws-cdk": "^2.160.0",
+    "esbuild": "^0.25.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/recipes/aws-kms-pdf-attestation/package.json
+++ b/recipes/aws-kms-pdf-attestation/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "test": "vitest run",
     "typecheck": "tsc --noEmit",
-    "bundle": "esbuild src/handler.ts --bundle --platform=node --format=cjs --target=node22 --outfile=dist/handler.cjs --external:@sparticuz/chromium --external:puppeteer-core",
+    "bundle": "esbuild src/handler.ts --bundle --platform=node --format=cjs --target=node22 --outfile=dist/handler.cjs --external:@sparticuz/chromium",
     "synth": "cdk synth --app 'npx tsx infra/app.ts'"
   },
   "dependencies": {

--- a/recipes/aws-kms-pdf-attestation/src/handler.test.ts
+++ b/recipes/aws-kms-pdf-attestation/src/handler.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest'
+import { makeHandler } from './handler.js'
+import { encodeRenderPayload, type RenderPayload } from './payload.js'
+
+const payload: RenderPayload = { docId: 'd1', fields: { invoiceNo: 'INV-1', total: 5 }, qr: 'qr-string' }
+
+function deps(over: Partial<{ getObjectBody: Uint8Array | null }> = {}) {
+  const body = 'getObjectBody' in over ? over.getObjectBody : encodeRenderPayload(payload)
+  const s3 = { send: async () => {
+    if (body === null) { const e = new Error('NoSuchKey'); e.name = 'NoSuchKey'; throw e }
+    return { Body: { transformToByteArray: async () => body } }
+  } }
+  // mock KMS Decrypt = identity (our test S3 body is already plaintext).
+  const kms = { send: async (cmd: { input: { CiphertextBlob: Uint8Array } }) => ({ Plaintext: cmd.input.CiphertextBlob }) }
+  const renderPdf = vi.fn(async (_html: string) => new Uint8Array([0x25, 0x50, 0x44, 0x46])) // "%PDF"
+  return { s3: s3 as never, kms: kms as never, renderPdf, bucket: 'b', keyId: 'k', prefix: 'docs' }
+}
+
+describe('makeHandler', () => {
+  it('returns a base64 application/pdf for a known docId', async () => {
+    const d = deps()
+    const handler = makeHandler(d)
+    const res = await handler({ rawPath: '/d1', queryStringParameters: {} })
+    expect(res.statusCode).toBe(200)
+    expect(res.headers!['content-type']).toBe('application/pdf')
+    expect(res.isBase64Encoded).toBe(true)
+    expect(d.renderPdf).toHaveBeenCalledOnce()
+    expect(d.renderPdf.mock.calls[0]![0]).toContain('INV-1')
+  })
+
+  it('404 when the object is missing', async () => {
+    const handler = makeHandler(deps({ getObjectBody: null }))
+    const res = await handler({ rawPath: '/missing', queryStringParameters: {} })
+    expect(res.statusCode).toBe(404)
+  })
+
+  it('400 when no docId is provided', async () => {
+    const handler = makeHandler(deps())
+    const res = await handler({ rawPath: '/', queryStringParameters: {} })
+    expect(res.statusCode).toBe(400)
+  })
+})

--- a/recipes/aws-kms-pdf-attestation/src/handler.ts
+++ b/recipes/aws-kms-pdf-attestation/src/handler.ts
@@ -1,0 +1,66 @@
+import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
+import { KMSClient, DecryptCommand } from '@aws-sdk/client-kms'
+import { decodeRenderPayload } from './payload.js'
+import { buildInvoiceHtml, renderPdf as defaultRenderPdf } from './render-core.js'
+
+interface FnUrlEvent { rawPath?: string; queryStringParameters?: Record<string, string | undefined> | null }
+interface FnUrlResult { statusCode: number; headers?: Record<string, string>; body?: string; isBase64Encoded?: boolean }
+
+export interface HandlerDeps {
+  s3: Pick<S3Client, 'send'>
+  kms: Pick<KMSClient, 'send'>
+  renderPdf: (html: string) => Promise<Uint8Array>
+  bucket: string
+  keyId: string
+  prefix: string
+}
+
+/** Build a Function-URL handler. Deps are injected so it unit-tests with mocks. */
+export function makeHandler(deps: HandlerDeps) {
+  return async function handler(event: FnUrlEvent): Promise<FnUrlResult> {
+    const docId = (event.queryStringParameters?.['docId'] ?? event.rawPath?.replace(/^\/+/, '') ?? '').trim()
+    if (!docId) return { statusCode: 400, headers: { 'content-type': 'text/plain' }, body: 'missing docId' }
+
+    let sealed: Uint8Array
+    try {
+      const obj = (await deps.s3.send(
+        new GetObjectCommand({ Bucket: deps.bucket, Key: `${deps.prefix}/${docId}` }) as never,
+      )) as { Body?: { transformToByteArray(): Promise<Uint8Array> } }
+      if (!obj.Body) return { statusCode: 404, headers: { 'content-type': 'text/plain' }, body: 'not found' }
+      sealed = await obj.Body.transformToByteArray()
+    } catch (e) {
+      if (e instanceof Error && (e.name === 'NoSuchKey' || e.name === 'NotFound')) {
+        return { statusCode: 404, headers: { 'content-type': 'text/plain' }, body: 'not found' }
+      }
+      return { statusCode: 500, headers: { 'content-type': 'text/plain' }, body: 'storage error' }
+    }
+
+    try {
+      const dec = (await deps.kms.send(
+        new DecryptCommand({ CiphertextBlob: sealed, KeyId: deps.keyId }) as never,
+      )) as { Plaintext?: Uint8Array }
+      if (!dec.Plaintext) return { statusCode: 500, headers: { 'content-type': 'text/plain' }, body: 'decrypt error' }
+      const payload = decodeRenderPayload(dec.Plaintext)
+      const html = await buildInvoiceHtml(payload)
+      const pdf = await deps.renderPdf(html)
+      return {
+        statusCode: 200,
+        headers: { 'content-type': 'application/pdf' },
+        body: Buffer.from(pdf).toString('base64'),
+        isBase64Encoded: true,
+      }
+    } catch {
+      return { statusCode: 500, headers: { 'content-type': 'text/plain' }, body: 'render error' }
+    }
+  }
+}
+
+/** The deployed Lambda entry point: ambient-cred clients + the real renderPdf. */
+export const handler = makeHandler({
+  s3: new S3Client({}),
+  kms: new KMSClient({}),
+  renderPdf: defaultRenderPdf,
+  bucket: process.env['DOCS_BUCKET'] ?? '',
+  keyId: process.env['KMS_KEY_ID'] ?? '',
+  prefix: process.env['DOCS_PREFIX'] ?? 'docs',
+})

--- a/recipes/aws-kms-pdf-attestation/src/payload.test.ts
+++ b/recipes/aws-kms-pdf-attestation/src/payload.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { encodeRenderPayload, decodeRenderPayload, type RenderPayload } from './payload.js'
+
+const payload: RenderPayload = {
+  docId: '01J0000000000000000000DEMO',
+  fields: { invoiceNo: 'INV-1042', total: 1234.5, issueDate: '2026-05-29' },
+  qr: 'eyJ2IjoxfQ',
+}
+
+describe('render payload codec', () => {
+  it('round-trips through encode/decode', () => {
+    const bytes = encodeRenderPayload(payload)
+    expect(bytes).toBeInstanceOf(Uint8Array)
+    expect(decodeRenderPayload(bytes)).toEqual(payload)
+  })
+
+  it('throws when the encoded payload exceeds the 4 KB KMS plaintext limit', () => {
+    const huge: RenderPayload = { ...payload, fields: { blob: 'x'.repeat(5000) } }
+    expect(() => encodeRenderPayload(huge)).toThrow(/4 ?KB|4096/)
+  })
+
+  it('decode rejects malformed JSON', () => {
+    expect(() => decodeRenderPayload(new TextEncoder().encode('not json'))).toThrow()
+  })
+
+  it('decode rejects a payload missing required fields', () => {
+    const bad = new TextEncoder().encode(JSON.stringify({ docId: 'x' }))
+    expect(() => decodeRenderPayload(bad)).toThrow(/docId|fields|qr|shape/)
+  })
+})

--- a/recipes/aws-kms-pdf-attestation/src/payload.ts
+++ b/recipes/aws-kms-pdf-attestation/src/payload.ts
@@ -1,0 +1,32 @@
+/** The decrypted record the render Lambda turns into a PDF. */
+export interface RenderPayload {
+  docId: string
+  fields: Record<string, string | number>
+  qr: string
+}
+
+const KMS_PLAINTEXT_LIMIT = 4096 // AWS KMS Encrypt caps plaintext at 4 KB.
+
+export function encodeRenderPayload(p: RenderPayload): Uint8Array {
+  const bytes = new TextEncoder().encode(JSON.stringify(p))
+  if (bytes.length > KMS_PLAINTEXT_LIMIT) {
+    throw new Error(
+      `render payload exceeds the 4 KB KMS plaintext limit (${bytes.length} > ${KMS_PLAINTEXT_LIMIT} bytes). ` +
+        'Attestation payloads (declared fields + QR) are normally far under; envelope encryption for larger payloads is out of scope.',
+    )
+  }
+  return bytes
+}
+
+export function decodeRenderPayload(bytes: Uint8Array): RenderPayload {
+  const parsed = JSON.parse(new TextDecoder().decode(bytes)) as unknown
+  if (
+    parsed === null || typeof parsed !== 'object' ||
+    typeof (parsed as RenderPayload).docId !== 'string' ||
+    typeof (parsed as RenderPayload).qr !== 'string' ||
+    typeof (parsed as RenderPayload).fields !== 'object' || (parsed as RenderPayload).fields === null
+  ) {
+    throw new Error('decodeRenderPayload: invalid payload shape (need { docId, fields, qr })')
+  }
+  return parsed as RenderPayload
+}

--- a/recipes/aws-kms-pdf-attestation/src/render-core.test.ts
+++ b/recipes/aws-kms-pdf-attestation/src/render-core.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { buildInvoiceHtml } from './render-core.js'
+import { decodeQr, encodeQr } from '@noy-db/attestation'
+import type { RenderPayload } from './payload.js'
+
+// A real QR string so the embedded SVG is built from a decodable payload.
+const qr = encodeQr({ v: 1, docId: '01J0DEMO', salt: 'c2FsdA', alg: 'ed25519', keyId: 'k1', fieldHashes: ['h'], sig: 's' })
+const payload: RenderPayload = { docId: '01J0DEMO', fields: { invoiceNo: 'INV-1042', total: 1234.5, issueDate: '2026-05-29' }, qr }
+
+describe('buildInvoiceHtml', () => {
+  it('renders every field value into the HTML', async () => {
+    const html = await buildInvoiceHtml(payload)
+    expect(html).toContain('INV-1042')
+    expect(html).toContain('1234.5')
+    expect(html).toContain('2026-05-29')
+  })
+
+  it('embeds the QR as inline vector <svg>, not a raster <img>', async () => {
+    const html = await buildInvoiceHtml(payload)
+    expect(html).toMatch(/<svg[\s>]/i)
+    expect(html).not.toMatch(/<img[^>]+src=["']data:image\/png/i)
+  })
+
+  it('the embedded QR SVG was generated from the payload qr string', async () => {
+    const html = await buildInvoiceHtml(payload)
+    expect(decodeQr(payload.qr).docId).toBe('01J0DEMO')
+    expect(html).toContain('<svg')
+  })
+})

--- a/recipes/aws-kms-pdf-attestation/src/render-core.ts
+++ b/recipes/aws-kms-pdf-attestation/src/render-core.ts
@@ -51,7 +51,10 @@ export async function renderPdf(html: string): Promise<Uint8Array> {
   const browser = await browserPromise
   const page = await browser.newPage()
   try {
-    await page.setContent(html, { waitUntil: 'networkidle0' })
+    // 'load' is sufficient: the invoice HTML has no network resources (inline
+    // SVG QR + inline CSS). puppeteer-core's setContent only accepts
+    // 'load' | 'domcontentloaded' (networkidle* are navigation-only).
+    await page.setContent(html, { waitUntil: 'load' })
     const pdf = await page.pdf({ format: 'A4', printBackground: true })
     return new Uint8Array(pdf)
   } finally {

--- a/recipes/aws-kms-pdf-attestation/src/render-core.ts
+++ b/recipes/aws-kms-pdf-attestation/src/render-core.ts
@@ -1,0 +1,60 @@
+import QRCode from 'qrcode'
+import type { Browser } from 'puppeteer-core'
+import type { RenderPayload } from './payload.js'
+
+/** Build the invoice HTML with the QR embedded as inline (vector) SVG. */
+export async function buildInvoiceHtml(payload: RenderPayload): Promise<string> {
+  const qrSvg = await QRCode.toString(payload.qr, { type: 'svg', margin: 1, width: 160 })
+  const rows = Object.entries(payload.fields)
+    .map(([k, v]) => `<tr><th style="text-align:left;padding:4px 12px 4px 0">${escapeHtml(k)}</th><td>${escapeHtml(String(v))}</td></tr>`)
+    .join('')
+  return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8" />
+<style>
+  body { font-family: system-ui, sans-serif; margin: 40px; color: #1f2733; }
+  h1 { font-size: 20px; } .meta { color: #667; font-size: 12px; }
+  table { margin: 20px 0; border-collapse: collapse; }
+  .qr { margin-top: 24px; } .qr svg { width: 160px; height: 160px; }
+  .doc { color: #889; font-size: 11px; }
+</style></head>
+<body>
+  <h1>Invoice</h1>
+  <p class="meta">Issued by the firm · attestation document ${escapeHtml(payload.docId)}</p>
+  <table>${rows}</table>
+  <div class="qr">${qrSvg}</div>
+  <p class="doc">Scan / verify offline — the QR carries a signed per-field commitment.</p>
+</body></html>`
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+/**
+ * Render HTML → PDF via headless Chromium. NOT exercised in CI (needs the
+ * @sparticuz/chromium binary); isolated so the handler can stub it. The browser
+ * is created lazily and reused across warm Lambda invocations.
+ */
+let browserPromise: Promise<Browser> | null = null
+export async function renderPdf(html: string): Promise<Uint8Array> {
+  const [{ default: chromium }, puppeteer] = await Promise.all([
+    import('@sparticuz/chromium'),
+    import('puppeteer-core'),
+  ])
+  if (!browserPromise) {
+    browserPromise = puppeteer.launch({
+      args: chromium.args,
+      executablePath: await chromium.executablePath(),
+      headless: true,
+    }) as Promise<Browser>
+  }
+  const browser = await browserPromise
+  const page = await browser.newPage()
+  try {
+    await page.setContent(html, { waitUntil: 'networkidle0' })
+    const pdf = await page.pdf({ format: 'A4', printBackground: true })
+    return new Uint8Array(pdf)
+  } finally {
+    await page.close()
+  }
+}

--- a/recipes/aws-kms-pdf-attestation/src/seal.test.ts
+++ b/recipes/aws-kms-pdf-attestation/src/seal.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { sealAndUpload } from './seal.js'
+import { decodeRenderPayload, type RenderPayload } from './payload.js'
+
+const payload: RenderPayload = { docId: 'd1', fields: { invoiceNo: 'INV-1' }, qr: 'qr-string' }
+
+describe('sealAndUpload', () => {
+  it('seals the payload via KMS Encrypt and PUTs it to the given bucket/key', async () => {
+    const kmsCalls: { input: { Plaintext: Uint8Array } }[] = []
+    const s3Calls: { input: { Bucket: string; Key: string; Body: Uint8Array } }[] = []
+    // Mock KMS: "seal" = wrap bytes (identity); mock S3: capture the PutObject.
+    const kmsClient = { send: async (cmd: { input: { Plaintext: Uint8Array } }) => { kmsCalls.push(cmd); return { CiphertextBlob: cmd.input.Plaintext } } }
+    const s3Client = { send: async (cmd: { input: { Bucket: string; Key: string; Body: Uint8Array } }) => { s3Calls.push(cmd); return {} } }
+
+    await sealAndUpload(payload, { keyId: 'arn:key', bucket: 'b', key: 'docs/d1', kmsClient: kmsClient as never, s3Client: s3Client as never })
+
+    expect(kmsCalls).toHaveLength(1)
+    const put = s3Calls[0]!.input
+    expect(put.Bucket).toBe('b')
+    expect(put.Key).toBe('docs/d1')
+    // The stored body is the KMS ciphertext; our mock seal is identity, so it
+    // decodes back to the original payload.
+    expect(decodeRenderPayload(put.Body)).toEqual(payload)
+  })
+})

--- a/recipes/aws-kms-pdf-attestation/src/seal.ts
+++ b/recipes/aws-kms-pdf-attestation/src/seal.ts
@@ -1,0 +1,24 @@
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
+import { awsKmsSealingProvider } from '@noy-db/at-aws-kms'
+import { encodeRenderPayload, type RenderPayload } from './payload.js'
+
+export interface SealAndUploadOptions {
+  keyId: string
+  bucket: string
+  key: string
+  /** DI for tests. Defaults to ambient-cred clients. */
+  kmsClient?: { send: (cmd: unknown) => Promise<unknown> }
+  s3Client?: Pick<S3Client, 'send'>
+}
+
+/**
+ * Firm-side (hub context): seal a RenderPayload with the firm's KMS key via
+ * at-aws-kms and upload the ciphertext to S3. The render Lambda later decrypts
+ * + renders it. This is the @noy-db/at-aws-kms feature in action.
+ */
+export async function sealAndUpload(payload: RenderPayload, opts: SealAndUploadOptions): Promise<void> {
+  const sealer = awsKmsSealingProvider({ keyId: opts.keyId, client: opts.kmsClient as never })
+  const sealed = await sealer.seal(encodeRenderPayload(payload))
+  const s3 = opts.s3Client ?? new S3Client({})
+  await s3.send(new PutObjectCommand({ Bucket: opts.bucket, Key: opts.key, Body: sealed }) as never)
+}

--- a/recipes/aws-kms-pdf-attestation/tsconfig.json
+++ b/recipes/aws-kms-pdf-attestation/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "infra/**/*.ts"]
+}

--- a/recipes/aws-kms-pdf-attestation/vitest.config.ts
+++ b/recipes/aws-kms-pdf-attestation/vitest.config.ts
@@ -6,5 +6,8 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.test.ts', 'infra/**/*.test.ts'],
     globals: false,
+    // CDK Template.fromStack bundles the S3-autodelete custom resource via
+    // esbuild on first synth (~15s cold), well past vitest's 5s default.
+    testTimeout: 60_000,
   },
 })

--- a/recipes/aws-kms-pdf-attestation/vitest.config.ts
+++ b/recipes/aws-kms-pdf-attestation/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'aws-kms-pdf-attestation',
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'infra/**/*.test.ts'],
+    globals: false,
+  },
+})

--- a/showcases/.env.example
+++ b/showcases/.env.example
@@ -24,6 +24,13 @@ NOYDB_SHOWCASE_AWS_CLEANUP=1
 # NOYDB_SHOWCASE_DYNAMO_TABLE=noydb-showcase
 # NOYDB_SHOWCASE_S3_BUCKET=noydb-showcase-blobs
 
+# NOYDB_SHOWCASE_AWS_DOCS — AWS configuration for the document-attestation
+# recipe (③ aws-kms-pdf-attestation): the named AWS profile / target used to
+# provision and exercise the KMS key, S3 bucket, and HTML→PDF render Lambda
+# during the recipe's real-AWS integration steps. Placeholder only — set the
+# real value in showcases/.env (gitignored), never here.
+NOYDB_SHOWCASE_AWS_DOCS=
+
 # ─── Cloudflare R2 (S3-compatible, zero egress) ─────────────────────────
 # 1. Account ID: any page in dash.cloudflare.com → right sidebar.
 # 2. Bucket: dash → R2 Object Storage → Create bucket (default name below

--- a/showcases/package.json
+++ b/showcases/package.json
@@ -81,6 +81,7 @@
     "@noy-db/attestation": "workspace:*",
     "@noy-db/cli": "workspace:*",
     "@noy-db/recipe-attestation-verifier": "workspace:*",
+    "@noy-db/recipe-aws-kms-pdf-attestation": "workspace:*",
     "@tanstack/query-core": "^5.59.0",
     "@tanstack/table-core": "^8.20.0",
     "@testing-library/react": "^16.0.0",

--- a/showcases/src/recipe-aws-kms-pdf-attestation.recipe.test.ts
+++ b/showcases/src/recipe-aws-kms-pdf-attestation.recipe.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Recipe — AWS-KMS PDF attestation (generation side, CI-safe slice)
+ *
+ * The firm issues a signed attestation, seals the render payload with its KMS
+ * key (@noy-db/at-aws-kms), and a Lambda would later decrypt + render it to a
+ * PDF with the QR embedded as vector. This CI slice proves the data path with a
+ * MOCK KMS (no real AWS, no Chromium): issue → seal → unseal → buildInvoiceHtml,
+ * and confirms the embedded QR still verifies offline via the ④ verifier.
+ * Real deploy → invoke → teardown is in the recipe's RUNBOOK.md (profile-driven).
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { sealAndUpload } from '@noy-db/recipe-aws-kms-pdf-attestation/seal'
+import { buildInvoiceHtml } from '@noy-db/recipe-aws-kms-pdf-attestation/render-core'
+import { decodeRenderPayload, type RenderPayload } from '@noy-db/recipe-aws-kms-pdf-attestation'
+import { verifyDocument } from '@noy-db/recipe-attestation-verifier'
+import { decodeQr, type AttestationFieldSchema } from '@noy-db/attestation'
+
+interface Invoice { id: string; invoiceNo: string; total: number; issueDate: string }
+const attestation: AttestationFieldSchema = {
+  fields: [
+    { path: 'invoiceNo', normalize: 'alnum-upper' },
+    { path: 'total', normalize: 'cents' },
+    { path: 'issueDate', normalize: 'iso-date' },
+  ],
+}
+
+describe('recipe: aws-kms-pdf-attestation (CI slice, mock KMS)', () => {
+  it('issue → seal → unseal → render HTML; the embedded QR still verifies offline', async () => {
+    // 1. Firm issues an attestation through the hub.
+    const db = await createNoydb({ store: memory(), user: 'firm', secret: 'firm-pass-2026' })
+    const vault = await db.openVault('books')
+    await vault.collection<Invoice>('invoices', { attestation }).put('inv-1', { id: 'inv-1', invoiceNo: 'INV-1042', total: 1234.5, issueDate: '2026-05-29' })
+    const { docId, qr, keyId } = await vault.issueAttestation('invoices', 'inv-1')
+    const { publicKeyB64 } = await vault.getDocumentSigningPublicKey()
+
+    // 2. Firm seals the render payload + "uploads" it (mock KMS=identity, mock S3 captures).
+    const payload: RenderPayload = { docId, qr, fields: { invoiceNo: 'INV-1042', total: 1234.5, issueDate: '2026-05-29' } }
+    let stored: Uint8Array | undefined
+    const kmsClient = { send: async (cmd: { input: { Plaintext: Uint8Array } }) => ({ CiphertextBlob: cmd.input.Plaintext }) }
+    const s3Client = { send: async (cmd: { input: { Body: Uint8Array } }) => { stored = cmd.input.Body; return {} } }
+    await sealAndUpload(payload, { keyId: 'arn:demo', bucket: 'b', key: `docs/${docId}`, kmsClient: kmsClient as never, s3Client: s3Client as never })
+    expect(stored).toBeTruthy()
+
+    // 3. Lambda side (mock decrypt=identity) → render HTML.
+    const decoded = decodeRenderPayload(stored!)
+    const html = await buildInvoiceHtml(decoded)
+    expect(html).toContain('INV-1042')
+    expect(html).toMatch(/<svg[\s>]/i)              // QR is vector
+    expect(decodeQr(decoded.qr).docId).toBe(docId)  // the right QR rode along
+
+    // 4. A third party verifies the embedded QR OFFLINE → authentic-valid.
+    const printed = { invoiceNo: 'INV-1042', total: '1234.50', issueDate: '2026-05-29' }
+    const v = await verifyDocument(decoded.qr, printed, { publicKeys: { [keyId]: publicKeyB64 }, fieldSchema: attestation })
+    expect(v.outcome).toBe('authentic-valid')
+  })
+})


### PR DESCRIPTION
> **Update (post-merge, 2026-05-31):** verified end-to-end against **real AWS**
> (ap-southeast-1: deploy → seal → invoke Function URL → real PDF → offline
> `verifyDocument` = `authentic-valid`), then torn down. That live run surfaced
> four deploy bugs (all fixed in this branch) and a packaging decision:
>
> **The default deploy was switched from an x86_64 container image to an
> arm64 (Graviton) ZIP function + a public Chromium layer** (shelfio
> `chrome-aws-lambda-arm64`, Chromium v149). The container is kept as a
> documented self-contained alternative (`Dockerfile` + RUNBOOK).
>
> *Measured layer vs container:* cold/warm render ~equal (dominant cost is
> `@sparticuz` Chromium decompress-to-`/tmp` + launch, identical either way),
> but the layer route wins on **arm64 (~20% cheaper GB-s — the npm
> `@sparticuz/chromium` binary is x86-only, so the container was forced to
> x86_64), a ~1.7 MB zip vs a 527 MB ECR image, and no Docker/ECR build chain.**
> Bugs caught by the live deploy: (1) Dockerfile must not copy the workspace
> `package.json` (`workspace:*` → npm EUNSUPPORTEDPROTOCOL); (2) the handler
> bundle must be CJS, not ESM (AWS SDK dynamic-requires `buffer`); (3) Chromium
> needs OS shared libs (nss, etc.) in the image; (4) arm64 image + x86-only
> Chromium binary mismatch. The sections below describe the original container
> design; see `infra/stack.ts` + RUNBOOK.md for the final layer-based shape.

---

## Summary

Slice ③ (final) of document attestation — the **generation-time** half: a deployable reference Lambda that KMS-decrypts a firm-sealed document record from S3, renders an HTML invoice → PDF with the attestation **QR embedded as vector**, and returns the PDF. This is where the original `@noy-db/at-aws-kms` ask lands — as a **byte sealer** (no bundle ceremony). New private package `recipes/aws-kms-pdf-attestation/`. Builds on merged #235/#236/#237/#238.

- **render-core** (`src/render-core.ts`) — `buildInvoiceHtml` (sample template + QR as inline `<svg>` via `qrcode` → **vector**, CI-tested) + isolated `renderPdf` (puppeteer-core + @sparticuz/chromium, warm-reused; not CI-run).
- **payload** (`src/payload.ts`) — `RenderPayload {docId,fields,qr}` encode/decode + the **4 KB KMS-plaintext guard**.
- **seal helper** (`src/seal.ts`) — firm-side `sealAndUpload` using `@noy-db/at-aws-kms` (`awsKmsSealingProvider.seal`) → S3 PutObject. Mock-KMS tested.
- **Lambda handler** (`src/handler.ts`) — hub-free Function-URL handler: S3 GetObject → raw `@aws-sdk/client-kms` `DecryptCommand` → render-core → base64 `application/pdf`. Dep-injected `makeHandler` → mock-AWS tested (200/404/400).
- **CDK-TS stack** (`infra/`) — KMS key, private S3 bucket, **arm64 ZIP Lambda + public Chromium layer** (final; originally an arm64 container), Node 22, 2 GB, Function URL (`authType: NONE`, demo), least-priv IAM (decrypt one key + read one prefix). `cdk synth` smoke test.
- **Showcase + features.yaml** — CI slice: issue → seal → unseal (mock KMS) → render HTML → the embedded vector QR still verifies offline (`authentic-valid`) via ④'s `verifyDocument`. recipes 7→8.
- **Docs** — recipe doc + README + a profile-driven deploy/verify/teardown **RUNBOOK** (incl. the container alternative + measured comparison), plus the `NOYDB_SHOWCASE_AWS_DOCS` `.env.example` placeholder.

## Key design points

- **`at-aws-kms` is a byte sealer**, not a bundle recipient-sealer — its `seal`/`unseal` is a generic KMS envelope, so the stateless Lambda needs no `adoptPartition`/owner-minting and **no extension to at-aws-kms**.
- **The Lambda is hub-free** — imports neither `@noy-db/hub`/`@noy-db/attestation`/`@noy-db/at-aws-kms` (raw `DecryptCommand` is the inverse of at-aws-kms's Encrypt envelope), keeping the function minimal. at-aws-kms is featured on the **firm-side seal helper** (hub context).
- **No real AWS in CI.** Everything CI runs is unit tests (mocked KMS+S3) + `cdk synth`. The Chromium render + real deploy are RUNBOOK-only.

## Test plan

- [x] `recipe` suite 12/12 (payload 4 + render-core 3 + seal 1 + handler 3 + cdk-synth 1); `tsc --noEmit` clean
- [x] Showcase 1/1 (issue → seal → unseal → render → offline-verify)
- [x] `validate-features.mjs` passes (recipes=8); showcases tsc clean (no regression)
- [x] **Real-AWS deploy → seal → invoke → verify → `cdk destroy`** — done post-merge (profile-driven; see Update note); not part of CI

## Known limitations (reference app, eyes-open)

1. **The render path (Chromium) is never built/exercised in CI** — only the real-AWS run does. The default (layer) route depends on a **third-party public layer** (shelfio); the container alternative's `Dockerfile` is likewise CI-unbuilt.
2. **Versions are loosely pinned** — the layer ships Chromium v149 while the dev dep is `@sparticuz/chromium@^138`; the container's Dockerfile installs `puppeteer-core@^24` / `@sparticuz/chromium@^138` unpinned. Pin exact versions (and the layer ARN version) before production use.
3. **Function URL is `authType: NONE`** (demo); production must add IAM/JWT authz since it returns rendered PDFs.

This completes the document-attestation epic (①a, ①b, ②, ③, ④, ⑤ all shipped).
