### PR TITLE
fix(recipe/aws-kms-pdf): share secret via Secrets Manager (deploy-blocking #240 fix)

### DIFF
--- a/docs/recipes/aws-kms-pdf-attestation.md
+++ b/docs/recipes/aws-kms-pdf-attestation.md
@@ -24,7 +24,7 @@ The QR carries the signed per-field commitment; the PDF is generated, never
 verified server-side. The render payload is capped at 4 KB (KMS plaintext limit).
 
 The render endpoint is gated by a **stateless signed magic link** — an
-HMAC-SHA256 over `canonicalJson({v, docId, exp})` with a KMS-sealed secret. A
+HMAC-SHA256 over `canonicalJson({v, docId, exp})` with a Secrets Manager secret. A
 data-holder mints a self-expiring, shareable URL (`?d=&exp=&sig=`); the hub-free
 Lambda verifies it with **no AWS authorizer / Cognito / IdP**. A bare `?docId=`
 is rejected (403) — there is no unauthenticated path. Links are **multi-use

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -872,6 +872,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.0.0
         version: 3.1024.0
+      '@aws-sdk/client-secrets-manager':
+        specifier: ^3.0.0
+        version: 3.1057.0
       '@noy-db/at-aws-kms':
         specifier: workspace:*
         version: link:../../packages/at-aws-kms
@@ -1313,12 +1316,20 @@ packages:
     resolution: {integrity: sha512-8qdO5aLCzaf9l0RdrSBW1iIroRKP2QBqtZ6lkrtHKiaaH0B18xEn+lrEgiN/eCf3uRAYk4cqbnI2XcWzm+7dDQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-secrets-manager@3.1057.0':
+    resolution: {integrity: sha512-2AsQ+7SChrQamIe68nMvMpZfXpHWnjwkcaFPFWf9E21+iTnEdIXRqC5v1P2NATrKn0BI6MaG/KlNrOhPOknk8w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.973.26':
     resolution: {integrity: sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.974.13':
     resolution: {integrity: sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.15':
+    resolution: {integrity: sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/crc64-nvme@3.972.5':
@@ -1333,12 +1344,20 @@ packages:
     resolution: {integrity: sha512-29wX9zpAvEt1vcj0psha+y6ygBHy2V/S72mp6e7q0KARLWXq+pwE/lR6qGkwknQvruh52lXvlqZIga8Hdxkucw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.41':
+    resolution: {integrity: sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.26':
     resolution: {integrity: sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.41':
     resolution: {integrity: sha512-IA3CQTjtJkb6u1H4mE4936c8OPBMa9Jggtwe8U2Mqw/vvb/tZ5Ebd0mcZcX0uKWQhOyYo/+qNIwkV5Xh+FeJJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.43':
+    resolution: {integrity: sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.28':
@@ -1349,12 +1368,20 @@ packages:
     resolution: {integrity: sha512-4mzII+3mZEVXXE1xzrLQrCJL7/r62A63bA6SVzZoNL5rqCJghpf+xgGltVrIBBs0n+mOZBKrQl2tRREtvZ5l6A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.46':
+    resolution: {integrity: sha512-hvcgcwOiS0nb2XFb5Op1Pz/vYaWz5K8kKullziGpdNRuG0NwzRXseuPt2CoBqknHGaSPVesu1aOn2OcctEYdCA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.28':
     resolution: {integrity: sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.43':
     resolution: {integrity: sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.45':
+    resolution: {integrity: sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.29':
@@ -1365,12 +1392,20 @@ packages:
     resolution: {integrity: sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.47':
+    resolution: {integrity: sha512-HrId+C0DWA5qDIyLG64/kjUB2RNtPypxmABnIctK+TA1P1kHlOYoE/Wf5T5tKOMKgb08P7k/zNyhvfJ3lh5Oag==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.24':
     resolution: {integrity: sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.39':
     resolution: {integrity: sha512-2k/amBifLd75eXNwgvPw/2lKYSQ3NhvHQgkVKVjfUq13/eJ3JRtHmznuFenn74OK3sSfp4SMy1YB2w+UVXoKqA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.41':
+    resolution: {integrity: sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.28':
@@ -1381,12 +1416,20 @@ packages:
     resolution: {integrity: sha512-LPc3+Y4vhH1T4x6CMqwCM6hk5+SRf/Lwmgm8INm95wxTtIRHcMwQUVkDzWu4Iw/RSncxYM2BC01OrYbxOPZvyg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.45':
+    resolution: {integrity: sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.28':
     resolution: {integrity: sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.43':
     resolution: {integrity: sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.45':
+    resolution: {integrity: sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/dynamodb-codec@3.972.27':
@@ -1455,6 +1498,10 @@ packages:
     resolution: {integrity: sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.13':
+    resolution: {integrity: sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/region-config-resolver@3.972.10':
     resolution: {integrity: sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==}
     engines: {node: '>=20.0.0'}
@@ -1467,12 +1514,20 @@ packages:
     resolution: {integrity: sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.30':
+    resolution: {integrity: sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1021.0':
     resolution: {integrity: sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1052.0':
     resolution: {integrity: sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1056.0':
+    resolution: {integrity: sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.6':
@@ -1519,6 +1574,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.25':
     resolution: {integrity: sha512-GH+Kjz4nPKWKHnsiQpnhP1MJdTGIcK4rAka6tzakgjjUkVgNsmPeEbbRAf09SzS1hjGu6duGHCBsxYke0BhHjQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.26':
+    resolution: {integrity: sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -4075,12 +4134,20 @@ packages:
     resolution: {integrity: sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.24.5':
+    resolution: {integrity: sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.12':
     resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/credential-provider-imds@4.3.4':
     resolution: {integrity: sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.6':
+    resolution: {integrity: sha512-tHhdiWZfG1ZIh2YcRfPJmY2gHcBmqbAzqm3ER4TIDFYsSEqTD5tICT7cgQ/kI8LRakxp12myOYyK68XPn7MnHw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.2.12':
@@ -4109,6 +4176,10 @@ packages:
 
   '@smithy/fetch-http-handler@5.4.4':
     resolution: {integrity: sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.5':
+    resolution: {integrity: sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-blob-browser@4.2.13':
@@ -4171,6 +4242,10 @@ packages:
     resolution: {integrity: sha512-HIeF+1vrDGzPkkv39Hj2vlHSXHY3p958jd/8ZnePIY6+ZOsQX8coyEUKO5yQu4r0bQIVsbpotVIrXXwyycMStQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.7.5':
+    resolution: {integrity: sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.2.12':
     resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
     engines: {node: '>=18.0.0'}
@@ -4201,6 +4276,10 @@ packages:
 
   '@smithy/signature-v4@5.4.4':
     resolution: {integrity: sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.4.5':
+    resolution: {integrity: sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/smithy-client@4.12.8':
@@ -9086,6 +9165,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-secrets-manager@3.1057.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/credential-provider-node': 3.972.47
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/fetch-http-handler': 5.4.5
+      '@smithy/node-http-handler': 4.7.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.973.26':
     dependencies:
       '@aws-sdk/types': 3.973.6
@@ -9113,6 +9205,17 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.15':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@aws-sdk/xml-builder': 3.972.26
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.5
+      '@smithy/signature-v4': 5.4.5
+      '@smithy/types': 4.14.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/crc64-nvme@3.972.5':
     dependencies:
       '@smithy/types': 4.13.1
@@ -9131,6 +9234,14 @@ snapshots:
       '@aws-sdk/core': 3.974.13
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -9154,6 +9265,16 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/fetch-http-handler': 5.4.4
       '@smithy/node-http-handler': 4.7.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/fetch-http-handler': 5.4.5
+      '@smithy/node-http-handler': 4.7.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -9192,6 +9313,22 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.972.46':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/credential-provider-env': 3.972.41
+      '@aws-sdk/credential-provider-http': 3.972.43
+      '@aws-sdk/credential-provider-login': 3.972.45
+      '@aws-sdk/credential-provider-process': 3.972.41
+      '@aws-sdk/credential-provider-sso': 3.972.45
+      '@aws-sdk/credential-provider-web-identity': 3.972.45
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/credential-provider-imds': 4.3.6
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.28':
     dependencies:
       '@aws-sdk/core': 3.973.26
@@ -9211,6 +9348,15 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.11
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -9245,6 +9391,20 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.47':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.41
+      '@aws-sdk/credential-provider-http': 3.972.43
+      '@aws-sdk/credential-provider-ini': 3.972.46
+      '@aws-sdk/credential-provider-process': 3.972.41
+      '@aws-sdk/credential-provider-sso': 3.972.45
+      '@aws-sdk/credential-provider-web-identity': 3.972.45
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/credential-provider-imds': 4.3.6
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.24':
     dependencies:
       '@aws-sdk/core': 3.973.26
@@ -9259,6 +9419,14 @@ snapshots:
       '@aws-sdk/core': 3.974.13
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -9285,6 +9453,16 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/token-providers': 3.1056.0
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.28':
     dependencies:
       '@aws-sdk/core': 3.973.26
@@ -9303,6 +9481,15 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.11
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.45':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -9490,6 +9677,19 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.13':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/signature-v4-multi-region': 3.996.30
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
+      '@smithy/fetch-http-handler': 5.4.5
+      '@smithy/node-http-handler': 4.7.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/region-config-resolver@3.972.10':
     dependencies:
       '@aws-sdk/types': 3.973.6
@@ -9515,6 +9715,13 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.30':
+    dependencies:
+      '@aws-sdk/types': 3.973.9
+      '@smithy/signature-v4': 5.4.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1021.0':
     dependencies:
       '@aws-sdk/core': 3.973.26
@@ -9533,6 +9740,15 @@ snapshots:
       '@aws-sdk/nested-clients': 3.997.11
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1056.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/nested-clients': 3.997.13
+      '@aws-sdk/types': 3.973.9
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -9592,6 +9808,12 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.25':
     dependencies:
       '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.26':
+    dependencies:
       '@smithy/types': 4.14.2
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
@@ -12009,6 +12231,12 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@smithy/core@3.24.5':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.12':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
@@ -12020,6 +12248,12 @@ snapshots:
   '@smithy/credential-provider-imds@4.3.4':
     dependencies:
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.6':
+    dependencies:
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -12064,6 +12298,12 @@ snapshots:
   '@smithy/fetch-http-handler@5.4.4':
     dependencies:
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.5':
+    dependencies:
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -12167,6 +12407,12 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.7.5':
+    dependencies:
+      '@smithy/core': 3.24.5
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
@@ -12211,6 +12457,12 @@ snapshots:
   '@smithy/signature-v4@5.4.4':
     dependencies:
       '@smithy/core': 3.24.4
+      '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.4.5':
+    dependencies:
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 

--- a/recipes/aws-kms-pdf-attestation/RUNBOOK.md
+++ b/recipes/aws-kms-pdf-attestation/RUNBOOK.md
@@ -42,19 +42,19 @@ await sealAndUpload(
 
 ## 3. Invoke + verify (via a magic link)
 The endpoint requires a signed share link — a bare `?docId=` is rejected (403).
-Mint a link firm-side. You need the plaintext share secret: decrypt the
-function's `SHARE_SECRET_CIPHERTEXT` env var once with the recipe KMS key, e.g.
+Mint a link firm-side. You need the share secret string from Secrets Manager
+(the function's `SHARE_SECRET_ARN`):
 ```bash
-CIPH=$(aws lambda get-function-configuration --function-name <RenderFn> \
-  --query 'Environment.Variables.SHARE_SECRET_CIPHERTEXT' --output text)
-aws kms decrypt --ciphertext-blob "fileb://<(printf %s "$CIPH" | base64 -d)" \
-  --query Plaintext --output text | base64 -d > /tmp/share.secret   # 32 raw bytes
+ARN=$(aws lambda get-function-configuration --function-name <RenderFn> \
+  --query 'Environment.Variables.SHARE_SECRET_ARN' --output text)
+SECRET=$(aws secretsmanager get-secret-value --secret-id "$ARN" \
+  --query SecretString --output text)   # the ASCII share-signing secret
 ```
-Then mint + fetch:
+Then mint + fetch (the secret bytes are the utf8 encoding of that string —
+identical to how the Lambda derives them):
 ```ts
 import { mintShareLink } from '@noy-db/recipe-aws-kms-pdf-attestation/share-link'
-import { readFileSync } from 'node:fs'
-const secret = new Uint8Array(readFileSync('/tmp/share.secret'))
+const secret = new TextEncoder().encode(process.env.SECRET!) // the SECRET above
 const url = await mintShareLink('<docId>', { secret, baseUrl: '<FunctionUrl>' })
 // → https://<fn-url>/?d=<docId>&exp=<ms>&sig=<...>
 ```
@@ -66,8 +66,8 @@ Open `invoice.pdf`; scan the QR with the offline verifier (recipe ④) — it mu
 read `authentic-valid` for the printed fields.
 
 Links are **multi-use until `exp`** (default 24h, 7d cap). **Revocation = rotate
-the share secret** (re-deploy so the AwsCustomResource regenerates it) — this
-invalidates all live links at once. There is no per-link revocation.
+the Secrets Manager secret** (`aws secretsmanager rotate-secret`, or re-deploy a
+fresh stack) — this invalidates all live links at once. No per-link revocation.
 
 ## 4. Teardown (after you confirm "done")
 ```bash

--- a/recipes/aws-kms-pdf-attestation/infra/stack.ts
+++ b/recipes/aws-kms-pdf-attestation/infra/stack.ts
@@ -3,8 +3,7 @@ import type { Construct } from 'constructs'
 import * as s3 from 'aws-cdk-lib/aws-s3'
 import * as kms from 'aws-cdk-lib/aws-kms'
 import * as lambda from 'aws-cdk-lib/aws-lambda'
-import * as iam from 'aws-cdk-lib/aws-iam'
-import * as cr from 'aws-cdk-lib/custom-resources'
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -51,34 +50,21 @@ export class KmsPdfAttestationStack extends Stack {
       autoDeleteObjects: true, // recipe/demo
     })
 
-    // Deploy-time: ask KMS for 32 random bytes, then encrypt them under our key.
-    // The ciphertext (base64) becomes the function's SHARE_SECRET_CIPHERTEXT env
-    // var; the function KMS-decrypts it lazily at runtime to verify share links.
-    // The plaintext secret never appears in the template (only the ciphertext).
-    const genSecret = new cr.AwsCustomResource(this, 'GenShareSecret', {
-      onCreate: {
-        service: 'KMS',
-        action: 'generateRandom',
-        parameters: { NumberOfBytes: 32 },
-        physicalResourceId: cr.PhysicalResourceId.of('share-secret-plaintext'),
+    // Deploy-time: Secrets Manager generates a random share-signing secret. The
+    // plaintext appears in NEITHER the template NOR CloudFormation state (the
+    // native construct holds only an ARN reference); the function reads the value
+    // at cold-start via GetSecretValue. Separate from the doc-sealing KMS key, so
+    // rotating share-signing never touches data access.
+    const shareSecret = new secretsmanager.Secret(this, 'ShareSecret', {
+      description: 'noy-db attestation: HMAC secret for share-link minting/verification',
+      removalPolicy: RemovalPolicy.DESTROY, // recipe/demo: destroy on teardown
+      generateSecretString: {
+        // 64 hex chars = 256 bits of entropy; ASCII so it round-trips as utf8.
+        excludePunctuation: true,
+        includeSpace: false,
+        passwordLength: 64,
       },
-      policy: cr.AwsCustomResourcePolicy.fromSdkCalls({ resources: cr.AwsCustomResourcePolicy.ANY_RESOURCE }),
     })
-    const plaintextB64 = genSecret.getResponseField('Plaintext') // base64 (SDK returns blobs base64)
-
-    const sealSecret = new cr.AwsCustomResource(this, 'SealShareSecret', {
-      onCreate: {
-        service: 'KMS',
-        action: 'encrypt',
-        parameters: { KeyId: key.keyId, Plaintext: plaintextB64 },
-        physicalResourceId: cr.PhysicalResourceId.of('share-secret-ciphertext'),
-      },
-      policy: cr.AwsCustomResourcePolicy.fromStatements([
-        new iam.PolicyStatement({ actions: ['kms:Encrypt'], resources: [key.keyArn] }),
-      ]),
-    })
-    sealSecret.node.addDependency(genSecret)
-    const shareSecretCiphertext = sealSecret.getResponseField('CiphertextBlob') // base64
 
     const fn = new lambda.Function(this, 'RenderFn', {
       runtime: lambda.Runtime.NODEJS_22_X,
@@ -97,13 +83,15 @@ export class KmsPdfAttestationStack extends Stack {
         DOCS_BUCKET: bucket.bucketName,
         KMS_KEY_ID: key.keyArn,
         DOCS_PREFIX,
-        SHARE_SECRET_CIPHERTEXT: shareSecretCiphertext,
+        // ARN, not the value — the function reads it via GetSecretValue at init.
+        SHARE_SECRET_ARN: shareSecret.secretArn,
       },
     })
 
-    // Least privilege: decrypt with the one key + read the one prefix.
+    // Least privilege: decrypt with the one key + read the one prefix + read the secret.
     key.grantDecrypt(fn)
     bucket.grantRead(fn, `${DOCS_PREFIX}/*`)
+    shareSecret.grantRead(fn)
 
     const url = fn.addFunctionUrl({ authType: lambda.FunctionUrlAuthType.NONE })
     new CfnOutput(this, 'FunctionUrl', { value: url.url })

--- a/recipes/aws-kms-pdf-attestation/infra/synth.test.ts
+++ b/recipes/aws-kms-pdf-attestation/infra/synth.test.ts
@@ -45,10 +45,12 @@ describe('CDK stack synthesizes', () => {
     )
     expect(hasLayer).toBe(true)
 
-    // The render function carries the KMS-sealed share secret as an env var.
+    // A Secrets Manager secret holds the share-signing secret (plaintext never in
+    // the template / CFN state), and the render fn references it by ARN env var.
+    t.resourceCountIs('AWS::SecretsManager::Secret', 1)
     const renderFn = Object.values(fns).find(
       (r) => (r as { Properties?: { Environment?: { Variables?: Record<string, unknown> } } })
-        .Properties?.Environment?.Variables?.['SHARE_SECRET_CIPHERTEXT'] !== undefined,
+        .Properties?.Environment?.Variables?.['SHARE_SECRET_ARN'] !== undefined,
     )
     expect(renderFn).toBeDefined()
   })

--- a/recipes/aws-kms-pdf-attestation/package.json
+++ b/recipes/aws-kms-pdf-attestation/package.json
@@ -21,6 +21,7 @@
     "@noy-db/at-aws-kms": "workspace:*",
     "@aws-sdk/client-kms": "^3.0.0",
     "@aws-sdk/client-s3": "^3.0.0",
+    "@aws-sdk/client-secrets-manager": "^3.0.0",
     "qrcode": "^1.5.4",
     "puppeteer-core": "^24.0.0",
     "@sparticuz/chromium": "^138.0.0"

--- a/recipes/aws-kms-pdf-attestation/src/handler.ts
+++ b/recipes/aws-kms-pdf-attestation/src/handler.ts
@@ -1,5 +1,6 @@
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3'
 import { KMSClient, DecryptCommand } from '@aws-sdk/client-kms'
+import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager'
 import { decodeRenderPayload } from './payload.js'
 import { buildInvoiceHtml, renderPdf as defaultRenderPdf } from './render-core.js'
 import { verifyShareToken } from './share-link.js'
@@ -62,21 +63,24 @@ export function makeHandler(deps: HandlerDeps) {
 }
 
 /** The deployed Lambda entry point: ambient-cred clients + the real renderPdf. */
-// The share-signing secret is stored KMS-encrypted in SHARE_SECRET_CIPHERTEXT
-// (base64). Module scope can't await, so decrypt it lazily on first invoke and
-// cache it for the life of the warm environment.
+// The share-signing secret lives in Secrets Manager (ARN in SHARE_SECRET_ARN).
+// Module scope can't await, so fetch it lazily on first invoke and cache it for
+// the warm environment. The secret is an ASCII string; the shareSecret bytes are
+// its utf8 encoding — mint + verify must use the identical encoding.
 let cachedSecret: Uint8Array | null = null
-async function resolveShareSecret(kms: Pick<KMSClient, 'send'>): Promise<Uint8Array> {
+async function resolveShareSecret(sm: Pick<SecretsManagerClient, 'send'>): Promise<Uint8Array> {
   if (cachedSecret) return cachedSecret
-  const blob = Buffer.from(process.env['SHARE_SECRET_CIPHERTEXT'] ?? '', 'base64')
-  const out = (await kms.send(new DecryptCommand({ CiphertextBlob: blob }) as never)) as { Plaintext?: Uint8Array }
-  if (!out.Plaintext) throw new Error('SHARE_SECRET_CIPHERTEXT decrypt returned no plaintext')
-  cachedSecret = new Uint8Array(out.Plaintext)
+  const out = (await sm.send(
+    new GetSecretValueCommand({ SecretId: process.env['SHARE_SECRET_ARN'] ?? '' }) as never,
+  )) as { SecretString?: string }
+  if (!out.SecretString) throw new Error('SHARE_SECRET_ARN: GetSecretValue returned no SecretString')
+  cachedSecret = new TextEncoder().encode(out.SecretString)
   return cachedSecret
 }
 
 const s3 = new S3Client({})
 const kms = new KMSClient({})
+const sm = new SecretsManagerClient({})
 const baseDeps = {
   s3,
   kms,
@@ -87,6 +91,6 @@ const baseDeps = {
 }
 
 export async function handler(event: FnUrlEvent): Promise<FnUrlResult> {
-  const shareSecret = await resolveShareSecret(kms)
+  const shareSecret = await resolveShareSecret(sm)
   return makeHandler({ ...baseDeps, shareSecret })(event)
 }


### PR DESCRIPTION
## Summary

**Fixes a deploy-blocking defect in #240.** The magic-link share secret was provisioned via an `AwsCustomResource` calling `kms:GenerateRandom` → `kms:Encrypt`. On a real `cdk deploy` this **failed** (`GenShareSecret … Response object is too long`) — and even had it fit, capturing the KMS `Plaintext` response field would have **stored the plaintext secret in CloudFormation state**. CI/synth could not catch this (a synth-level assertion structurally can't exercise a custom-resource deploy).

**Fix:** drop the custom resources; use a native **`secretsmanager.Secret` (`generateSecretString`)**. The plaintext is in **neither the template nor CFN state**; the function reads it at cold-start via `GetSecretValue` (ARN passed in the `SHARE_SECRET_ARN` env var) and uses the **utf8 bytes of the secret string** as the HMAC key. Mint, verify, and the test mock all use that identical encoding.

- `infra/stack.ts` — `AwsCustomResource` ×2 → one `secretsmanager.Secret` (64-char alphanumeric, `removalPolicy: DESTROY`); env `SHARE_SECRET_CIPHERTEXT` → `SHARE_SECRET_ARN`; `shareSecret.grantRead(fn)`.
- `src/handler.ts` — deployed entry resolves the secret via `SecretsManagerClient.GetSecretValue` (was KMS `Decrypt` of a ciphertext blob); `new TextEncoder().encode(secretString)` as the key bytes. `makeHandler` + `HandlerDeps` unchanged (the DI seam keeps it CI-testable).
- `infra/synth.test.ts` — assert an `AWS::SecretsManager::Secret` + the `SHARE_SECRET_ARN` env var.
- RUNBOOK + recipe doc — fetch via `secretsmanager get-secret-value`; revoke = rotate the secret.

## Verified on real AWS (ap-southeast-1, then torn down)

`cdk deploy` **succeeded** (the prior custom-resource approach rolled back). Live Function URL gate, end-to-end:

- **unsigned `?docId=` → `403`** (the open door is closed — the headline property, proven live)
- **minted link → `200 application/pdf`, 36 KB**, valid `%PDF-`, vector QR
- **tampered sig → `403`**

Then `cdk destroy` + full residual cleanup (stack, bucket, SM secret, CDKToolkit, staging bucket — all gone).

## Test plan

- [x] Recipe suite 22/22 (share-link 9 + handler path-closure 4 + synth + showcase 2 + render-core/payload/seal); `tsc --noEmit` clean; `validate-features` passing
- [x] **Real-AWS deploy → mint → 403/200/403 gate → destroy** (done; not in CI)

Stacks on `fix/attestation-share-secret-secretsmanager` off `main` (which already has #240). This makes the recipe actually deployable.
