### PR TITLE
fix(attestation): harden signer mint — concurrent-race convergence + owner-gated mint-on-read

### DIFF
--- a/packages/hub/__tests__/attestation-signer.test.ts
+++ b/packages/hub/__tests__/attestation-signer.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { loadOrCreateSigner } from '../src/attestation/signer.js'
-import { generateDEK } from '../src/crypto.js'
-import { ed25519Verify, signPayloadCore } from '@noy-db/attestation'
+import { loadOrCreateSigner, loadSigner, SIGNER_RECORD_ID, ATTESTATIONS_COLLECTION, type DocSigner } from '../src/attestation/signer.js'
+import { generateDEK, encrypt } from '../src/crypto.js'
+import { ed25519Verify, signPayloadCore, generateDocSigningKeyPair } from '@noy-db/attestation'
+import { NOYDB_FORMAT_VERSION } from '../src/types.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
 import { ConflictError } from '../src/errors.js'
 
@@ -53,5 +54,85 @@ describe('loadOrCreateSigner', () => {
     const { utf8, canonicalJson } = await import('@noy-db/attestation')
     const core = utf8(canonicalJson({ v: 1, docId: 'd', salt: 's', keyId: signer.keyId, fieldHashes: ['h'] }))
     expect(await ed25519Verify(signer.publicKeyB64, sig, core)).toBe(true)
+  })
+})
+
+/**
+ * Models the exact lost-race sequence deterministically (no Promise.all
+ * interleaving): the first `get` returns null (winner hasn't committed from
+ * this caller's view, so it proceeds to mint), the `put(…, 0)` throws
+ * ConflictError (another writer committed in between), and the re-read `get`
+ * now returns the winner. With `winnerEnv: null` the winner stays invisible
+ * even after the put — the pathological "record vanished" case.
+ */
+function lostRaceStore(winnerEnv: EncryptedEnvelope | null): { store: NoydbStore; putCalls: number } {
+  const state = { putCalls: 0 }
+  const store: NoydbStore = {
+    name: 'lost-race',
+    async get(_v, c, id) {
+      if (c !== ATTESTATIONS_COLLECTION || id !== SIGNER_RECORD_ID) return null
+      return state.putCalls > 0 ? winnerEnv : null // winner visible only after the losing put
+    },
+    async put() { state.putCalls++; throw new ConflictError(1, 'Version conflict: expected 0, found 1') },
+    async delete() {},
+    async list() { return [] },
+    async loadAll() { return {} as VaultSnapshot },
+    async saveAll() {},
+  }
+  return { store, get putCalls() { return state.putCalls } }
+}
+
+async function sealSigner(signer: DocSigner, dek: CryptoKey): Promise<EncryptedEnvelope> {
+  const { iv, data } = await encrypt(JSON.stringify(signer), dek)
+  return { _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: '2026-05-31T00:00:00.000Z', _iv: iv, _data: data }
+}
+
+describe('loadOrCreateSigner — concurrent first-mint (lost race)', () => {
+  it('on ConflictError, re-reads and returns the winner signer (convergence, not its own mint)', async () => {
+    const dek = await generateDEK()
+    const getDEK = async () => dek
+    const winner = await generateDocSigningKeyPair()
+    const race = lostRaceStore(await sealSigner(winner, dek))
+
+    const result = await loadOrCreateSigner(race.store, 'v1', getDEK)
+
+    // The loser minted its own keypair in memory, but converges on the winner.
+    expect(result.keyId).toBe(winner.keyId)
+    expect(result.publicKeyB64).toBe(winner.publicKeyB64)
+    expect(result.privateKeyPkcs8B64).toBe(winner.privateKeyPkcs8B64)
+    expect(race.putCalls).toBe(1) // attempted once, did not retry/clobber
+  })
+
+  it('throws (not null) if the conflicting record vanishes before re-read', async () => {
+    const dek = await generateDEK()
+    const getDEK = async () => dek
+    // get returns null (record gone), but put still throws ConflictError →
+    // pathological: must surface a clear error, never let null escape.
+    const { store } = lostRaceStore(null)
+
+    await expect(loadOrCreateSigner(store, 'v1', getDEK)).rejects.toThrow()
+  })
+})
+
+describe('loadSigner — pure read (never mints)', () => {
+  it('returns null when no signer exists and writes nothing', async () => {
+    const store = memory()
+    const dek = await generateDEK()
+    const getDEK = async () => dek
+
+    const result = await loadSigner(store, 'v1', getDEK)
+
+    expect(result).toBeNull()
+    expect(await store.get('v1', ATTESTATIONS_COLLECTION, SIGNER_RECORD_ID)).toBeNull()
+  })
+
+  it('returns the persisted signer when one exists', async () => {
+    const store = memory()
+    const dek = await generateDEK()
+    const getDEK = async () => dek
+    const minted = await loadOrCreateSigner(store, 'v1', getDEK)
+
+    const loaded = await loadSigner(store, 'v1', getDEK)
+    expect(loaded?.keyId).toBe(minted.keyId)
   })
 })

--- a/packages/hub/__tests__/attestation-vault.test.ts
+++ b/packages/hub/__tests__/attestation-vault.test.ts
@@ -106,3 +106,53 @@ describe('vault.issueAttestation (integration)', () => {
     expect(r.perField.find(f => f.path === 'vendorName')?.match).toBe(true)
   })
 })
+
+describe('vault.getDocumentSigningPublicKey (mint-on-read role gate)', () => {
+  it('owner: mints the signing key on first read and returns it', async () => {
+    const db = await createNoydb({ store: memory(), user: 'firm', secret: 'firm-passphrase-2026' })
+    const vault = await db.openVault('books')
+
+    const { keyId, publicKeyB64 } = await vault.getDocumentSigningPublicKey()
+    expect(keyId).toHaveLength(16)
+    expect(publicKeyB64).toBeTruthy()
+
+    // Idempotent: a second read returns the same key (no re-mint).
+    const again = await vault.getDocumentSigningPublicKey()
+    expect(again.keyId).toBe(keyId)
+  })
+
+  it('non-owner on a fresh vault: refuses to mint and throws AttestationError (no signer written)', async () => {
+    const adapter = memory()
+    const ownerDb = await createNoydb({ store: adapter, user: 'firm', secret: 'firm-passphrase-2026' })
+    await ownerDb.openVault('books')
+    await ownerDb.grant('books', { userId: 'viewer-01', displayName: 'Viewer', role: 'viewer', passphrase: 'viewer-pass' })
+
+    const viewerDb = await createNoydb({ store: adapter, user: 'viewer-01', secret: 'viewer-pass' })
+    const viewerVault = await viewerDb.openVault('books')
+
+    await expect(viewerVault.getDocumentSigningPublicKey()).rejects.toThrow(AttestationError)
+    // Crucially: no _signer record was minted as a side effect of the read.
+    expect(await adapter.get('books', '_attestations', '_signer')).toBeNull()
+  })
+
+  it('non-owner after the owner has minted: the read does NOT mint (gate only guards minting)', async () => {
+    const adapter = memory()
+    const ownerDb = await createNoydb({ store: adapter, user: 'firm', secret: 'firm-passphrase-2026' })
+    const ownerVault = await ownerDb.openVault('books')
+    const minted = await ownerVault.getDocumentSigningPublicKey() // owner mints
+    await ownerDb.grant('books', { userId: 'viewer-01', displayName: 'Viewer', role: 'viewer', passphrase: 'viewer-pass' })
+
+    const viewerDb = await createNoydb({ store: adapter, user: 'viewer-01', secret: 'viewer-pass' })
+    const viewerVault = await viewerDb.openVault('books')
+
+    // The signer already exists, so loadSigner short-circuits before the gate —
+    // a non-owner read returns the owner's public key (a viewer holds the
+    // _attestations DEK and can decrypt it) and never reaches the mint branch.
+    const before = await adapter.get('books', '_attestations', '_signer')
+    const result = await viewerVault.getDocumentSigningPublicKey()
+    const after = await adapter.get('books', '_attestations', '_signer')
+    expect(result.keyId).toBe(minted.keyId)
+    expect(result.publicKeyB64).toBe(minted.publicKeyB64)
+    expect(after).toEqual(before) // read did not mint or mutate
+  })
+})

--- a/packages/hub/src/attestation/signer.ts
+++ b/packages/hub/src/attestation/signer.ts
@@ -1,6 +1,7 @@
 import type { NoydbStore, EncryptedEnvelope } from '../types.js'
 import { NOYDB_FORMAT_VERSION } from '../types.js'
 import { encrypt, decrypt } from '../crypto.js'
+import { ConflictError } from '../errors.js'
 import { generateDocSigningKeyPair } from '@noy-db/attestation'
 
 export const ATTESTATIONS_COLLECTION = '_attestations'
@@ -14,31 +15,62 @@ export interface DocSigner {
 }
 
 /**
- * Lazily mint (or load) the firm's Ed25519 document-signing keypair.
+ * Pure read: return the firm's persisted document-signing keypair, or `null`
+ * if none has been minted yet. Never writes — callers that must NOT mint
+ * (e.g. an ungated public-key getter) use this instead of `loadOrCreateSigner`.
  *
  * Stored as an encrypted record `_attestations/_signer` under the
  * `_attestations` collection DEK (resolved via `getDEK`, which is
- * AES-KW-wrapped under the owner KEK + persisted by the keyring). The
- * KEK itself is AES-KW-only and cannot AES-GCM-encrypt these bytes —
- * hence storage under a normal collection DEK.
+ * AES-KW-wrapped under the owner KEK + persisted by the keyring). The KEK
+ * itself is AES-KW-only and cannot AES-GCM-encrypt these bytes — hence
+ * storage under a normal collection DEK.
+ */
+export async function loadSigner(
+  store: NoydbStore,
+  vault: string,
+  getDEK: (collection: string) => Promise<CryptoKey>,
+): Promise<DocSigner | null> {
+  const existing = await store.get(vault, ATTESTATIONS_COLLECTION, SIGNER_RECORD_ID)
+  if (!existing) return null
+  const dek = await getDEK(ATTESTATIONS_COLLECTION)
+  const json = await decrypt(existing._iv, existing._data, dek)
+  return JSON.parse(json) as DocSigner
+}
+
+/**
+ * Lazily mint (or load) the firm's Ed25519 document-signing keypair.
+ *
+ * On a concurrent first-mint, two callers can both read `null` and both mint
+ * distinct keypairs. The `put(…, expectedVersion: 0)` ("must not already
+ * exist") lets exactly one win; the loser catches `ConflictError`, re-reads,
+ * and returns the winner's signer — converging on a single keypair rather than
+ * clobbering it or surfacing a raw conflict. (All real stores treat a missing
+ * record + `ev: 0` as a no-conflict write, so the catch fires on lost-race only.)
  */
 export async function loadOrCreateSigner(
   store: NoydbStore,
   vault: string,
   getDEK: (collection: string) => Promise<CryptoKey>,
 ): Promise<DocSigner> {
+  const existing = await loadSigner(store, vault, getDEK)
+  if (existing) return existing
+
   const dek = await getDEK(ATTESTATIONS_COLLECTION)
-  const existing = await store.get(vault, ATTESTATIONS_COLLECTION, SIGNER_RECORD_ID)
-  if (existing) {
-    const json = await decrypt(existing._iv, existing._data, dek)
-    return JSON.parse(json) as DocSigner
-  }
   const signer = await generateDocSigningKeyPair()
   const { iv, data } = await encrypt(JSON.stringify(signer), dek)
   const env: EncryptedEnvelope = {
     _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: new Date().toISOString(), _iv: iv, _data: data,
   }
-  // expectedVersion 0 = "must not already exist" — guards a concurrent first-mint race.
-  await store.put(vault, ATTESTATIONS_COLLECTION, SIGNER_RECORD_ID, env, 0)
-  return signer
+  try {
+    await store.put(vault, ATTESTATIONS_COLLECTION, SIGNER_RECORD_ID, env, 0)
+    return signer
+  } catch (e) {
+    if (!(e instanceof ConflictError)) throw e
+    // Lost the race — another writer minted first. Adopt the winner.
+    const winner = await loadSigner(store, vault, getDEK)
+    if (!winner) {
+      throw new ConflictError(0, 'loadOrCreateSigner: signer mint lost a concurrent race but the winning record could not be re-read.')
+    }
+    return winner
+  }
 }

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -1160,7 +1160,16 @@ export class Vault {
   }
 
   async getDocumentSigningPublicKey(): Promise<{ keyId: string; publicKeyB64: string }> {
-    const { loadOrCreateSigner } = await import('./attestation/signer.js')
+    const { loadSigner, loadOrCreateSigner } = await import('./attestation/signer.js')
+    // Reading an existing public key is open to any role that holds the
+    // _attestations DEK — the public key is not secret. But MINTING the
+    // signer is the firm's identity operation (same rule as issueAttestation):
+    // a non-owner read must not silently create it.
+    const existing = await loadSigner(this.adapter, this.name, this.getDEK)
+    if (existing) return { keyId: existing.keyId, publicKeyB64: existing.publicKeyB64 }
+    if (this.keyring.role !== 'owner') {
+      throw new AttestationError(`getDocumentSigningPublicKey: no document-signing key exists yet; only the 'owner' may mint it. Caller is '${this.keyring.role}'. Have the owner issue an attestation (or call this) first.`)
+    }
     const signer = await loadOrCreateSigner(this.adapter, this.name, this.getDEK)
     return { keyId: signer.keyId, publicKeyB64: signer.publicKeyB64 }
   }


### PR DESCRIPTION
## Summary

Two `@noy-db/hub` attestation hardening fixes — the deferred follow-ups identified during the ①b hub-issue-side review (#236). Both are small, internal, TDD'd, and covered by the existing 1864-test hub suite plus new targeted tests.

### FU1 — converge concurrent first-mint on the winning signer (`signer.ts`)

`loadOrCreateSigner` had a latent gap: two callers could both read `null`, mint **distinct** Ed25519 keypairs, and the loser's `put(…, expectedVersion: 0)` would surface a raw `ConflictError` — leaving the caller with a different key than the one actually persisted.

- Extract a pure-read **`loadSigner()`** (`DocSigner | null`, never writes).
- `loadOrCreateSigner()` now catches the lost-race conflict, **re-reads, and returns the winner's signer** — converging on one keypair instead of clobbering it or throwing.
- Catch narrowed to `instanceof ConflictError`; throws (never `null`) if the winning record can't be re-read.
- Confirmed safe across real adapters: `to-memory`/`to-postgres`/`to-sqlite` all treat a missing record + `expectedVersion: 0` as a no-conflict write (guard behind `if (existing)`), so the catch fires on **lost-race only** — first mint never throws.

### FU2 — gate document-signing key mint to `owner` on read (`vault.ts`)

`getDocumentSigningPublicKey()` called `loadOrCreateSigner`, so **any role holding the `_attestations` DEK (e.g. a `viewer`) could mint the firm's identity signing key just by reading it** — a write side-effect on a getter, ungated. (Verified pre-fix: a viewer minted a real key.)

- Read an existing key first via `loadSigner` — open to any DEK-holder (the public key is not secret; a viewer reading the owner's key is **proven** by test).
- Only fall through to the **owner-gated mint** when no signer exists. Non-owner reads on a fresh vault now raise `AttestationError` instead of silently minting.
- Consistent with the existing rule (`issueAttestation` is owner-only because the signing key is the firm's identity). `revoke.ts` already `requireOwner`-gates before minting — unchanged.

## Test plan

- [x] `attestation-signer.test.ts`: deterministic lost-race test (store reveals the winner only *after* the losing `put`) → loser converges on winner's `keyId`; pathological re-read-null → throws; `loadSigner` pure-read returns `null`/existing.
- [x] `attestation-vault.test.ts`: owner mints on first read (idempotent); non-owner on fresh vault → `AttestationError` + **no `_signer` written**; non-owner after owner minted → **returns the owner's key** (un-swallowed assertion) and does not mutate.
- [x] Full hub suite **1864/1864**; attestation **31/31**; hub `tsc --noEmit` clean.
- [x] Grepped `showcases/` + `recipes/` for `getDocumentSigningPublicKey` callers — all 3 are owner-side; ran them → **5/5 pass**.
