### PR TITLE
docs(attestation): mark epic shipped + register hardening invariants

### DIFF
--- a/docs/superpowers/specs/2026-05-29-document-attestation-umbrella-design.md
+++ b/docs/superpowers/specs/2026-05-29-document-attestation-umbrella-design.md
@@ -1,6 +1,6 @@
 # Document Attestation — umbrella design
 
-**Status:** umbrella spec (cross-cutting contracts + decomposition; each sub-system gets its own spec → plan)
+**Status:** SHIPPED (preview) — all five sub-systems merged. ① pure core `@noy-db/attestation` (#235) · ①b hub issue side `@noy-db/hub/attestation` (#236) · ④ offline verifier recipe (#237) · ⑤ revocation publishing (#238) · ③ AWS-KMS HTML→PDF render recipe (#239, real-AWS verified). Post-epic hardening: magic-link share gate for ③ (#240) + Secrets-Manager deploy fix (#241), and signer hardening — owner-gated mint-on-read + concurrent-first-mint convergence (#242). This remains the cross-cutting design of record; per-sub-system specs/plans live alongside it.
 **Authoring date:** 2026-05-29
 **Cluster:** `time-and-audit` (beside `history` / `consent` — provenance + tamper-evidence)
 **Relates to:** #197 (recipient-target sealed delivery — the `at-aws-kms` KMS path lands in sub-system ③), the ledger hash primitives (`canonicalJson`, `sha256Hex` in `history/ledger/entry.ts`)

--- a/features.yaml
+++ b/features.yaml
@@ -691,13 +691,15 @@ features:
     showcases:
       - id: 89-attestation-revocation
         path: showcases/src/89-attestation-revocation.showcase.test.ts
-    recipes: [attestation-verifier]
+    recipes: [attestation-verifier, aws-kms-pdf-attestation]
     playground_pages: []
     diagrams: []
     invariants:
       - 'verification is offline: the signed per-field commitment travels in the QR; no server holds or returns document content'
       - 'authenticity via Ed25519 signature over the per-field commitment (a plain hash would be forgeable); integrity via per-field salted hashes enabling which-field-differs localization'
       - 'issue is owner-only; the signing keypair is stored encrypted under the _attestations collection DEK (not the KEK, which is AES-KW-only)'
+      - 'the signing key is minted exactly once and only by the owner: getDocumentSigningPublicKey reads an existing key for any DEK-holder (the public key is not secret) but only the owner may mint a missing one; a non-owner read on a fresh vault raises AttestationError instead of silently minting'
+      - 'concurrent first-mints converge: loadOrCreateSigner guards the mint with put(expectedVersion:0) ("must not exist") and, on the losing race, re-reads and returns the winning keypair rather than surfacing a raw ConflictError'
       - '_attestations index records are encrypted and pin the source record version'
       - 'revocation is whole-doc: vault.revokeAttestation tracks an encrypted _attestations/_revoked set; publishRevocationList signs it with the firm key (same keyId as issued docs) — the offline verifier bundles the signed list to gate "still valid today?"'
     related: [history, bundle]


### PR DESCRIPTION
## Summary

Registry + docs housekeeping after the document-attestation epic completed (#235–#242).

- **`features.yaml`** — the `attestation` feature now links **both** recipes (`attestation-verifier`, `aws-kms-pdf-attestation`); previously only the verifier was listed. Added two invariants capturing the #242 signer hardening:
  - owner-gated mint-on-read (`getDocumentSigningPublicKey` reads for any DEK-holder, but only `owner` mints a missing key — non-owner read on a fresh vault → `AttestationError`);
  - concurrent-first-mint convergence (`put(expectedVersion:0)` + lost-race re-read returns the winning keypair).
- **Umbrella spec** — `Status:` → `SHIPPED (preview)` with the per-sub-system + hardening PR map.

No code change. `pnpm validate:features` passes (recipes=8).

## Test plan
- [x] `pnpm validate:features` → OK