### PR TITLE
feat(hub): runtime schema introspection — vault.introspect() (#229)

### DIFF
--- a/docs/superpowers/plans/2026-06-01-229-schema-introspection.md
+++ b/docs/superpowers/plans/2026-06-01-229-schema-introspection.md
@@ -1,0 +1,304 @@
+# Runtime Schema Introspection (#229) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `vault.introspect()` returning a flat snapshot of the vault's registered schema — collections (+ doc counts), guards, materialized views, schema-update strategies, and the unlocked user's grants.
+
+**Architecture:** Reuse existing registries where they enumerate (`MaterializedViewRegistry.all()`, `vault.collections()`, `keyring.permissions`); add a `GuardRegistry.summary()` accessor and a vault-level capture of per-collection `schemaUpdate` strategy names (the only data not stored today). `introspect()` assembles these; it's post-unlock by construction (a `Vault` only exists with an `UnlockedKeyring`).
+
+**Tech Stack:** TypeScript, Vitest, `@noy-db/to-memory`. Package: `packages/hub`. Own PR through CI.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-schema-introspection-design.md`. Issue #229.
+
+---
+
+## File structure
+
+- **Modify** `packages/hub/src/guards/registry.ts` — add `summary(): { collection: string; count: number }[]`.
+- **Modify** `packages/hub/src/introspection/types.ts` — add the `SchemaIntrospection` interface.
+- **Modify** `packages/hub/src/vault.ts` — `#schemaUpdateNames` capture at registration; `introspect()`.
+- **Modify** `packages/hub/src/index.ts` — export `SchemaIntrospection`.
+- **Create** tests: `guards/registry-summary.test.ts` (unit), `schema-introspection.test.ts` (E2E).
+
+---
+
+## Task 1: `GuardRegistry.summary()`
+
+**Files:** Modify `packages/hub/src/guards/registry.ts`; Test `packages/hub/__tests__/guards/registry-summary.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { GuardRegistry } from '../../src/guards/registry.js'
+
+// Minimal guard strategies (only `collection` matters for summary()).
+const g = (collection: string) => ({ collection }) as never
+
+describe('GuardRegistry.summary()', () => {
+  it('returns [] when empty', () => {
+    expect(new GuardRegistry().summary()).toEqual([])
+  })
+  it('counts guards per collection', () => {
+    const r = new GuardRegistry()
+    r.register(g('invoices'))
+    r.register(g('invoices'))
+    r.register(g('payments'))
+    const s = r.summary().sort((a, b) => a.collection.localeCompare(b.collection))
+    expect(s).toEqual([
+      { collection: 'invoices', count: 2 },
+      { collection: 'payments', count: 1 },
+    ])
+  })
+})
+```
+
+(Confirm the registration method name with `grep -n "register\|add(" packages/hub/src/guards/registry.ts` — the spec map shows `_byCollection.set/get` inside a register-style method; use the real method name in the test. If registration is `add(spec)`, change `r.register` → `r.add`.)
+
+- [ ] **Step 2: Run → fail** (`cd packages/hub && npx vitest run __tests__/guards/registry-summary.test.ts`)
+
+- [ ] **Step 3: Implement** — add to the `GuardRegistry` class (beside `guardsFor`):
+
+```ts
+  /** Per-collection guard counts, for introspection (#229). */
+  summary(): { collection: string; count: number }[] {
+    return [...this._byCollection.entries()].map(([collection, guards]) => ({
+      collection,
+      count: guards.length,
+    }))
+  }
+```
+
+- [ ] **Step 4: Run → pass; commit**
+
+```bash
+cd /Users/vicio/_github/noy-db && git add packages/hub/src/guards/registry.ts packages/hub/__tests__/guards/registry-summary.test.ts
+git commit -m "feat(hub): GuardRegistry.summary() per-collection counts (#229)"
+```
+
+---
+
+## Task 2: Capture schema-update strategy names on the Vault
+
+**Files:** Modify `packages/hub/src/vault.ts`
+
+- [ ] **Step 1: Add the field** — beside the other vault registries (e.g. near `i18nFieldRegistry`):
+
+```ts
+  /** #229 — per-collection registered schema-update strategy names. */
+  readonly #schemaUpdateNames = new Map<string, string[]>()
+```
+
+- [ ] **Step 2: Capture at registration** — in the `collection()` body, inside the block that already reads `options.schemaUpdate` (the `if (... (options.schemaUpdate?.length ?? 0) > 0)` gate that builds the `SchemaUpdateGate`), add as the first line of that block:
+
+```ts
+        this.#schemaUpdateNames.set(collectionName, (options.schemaUpdate ?? []).map((s) => s.name))
+```
+
+(Locate with `grep -n "options.schemaUpdate" packages/hub/src/vault.ts`. Place the capture where `options.schemaUpdate` is in scope and non-empty.)
+
+- [ ] **Step 3: Typecheck** (`cd packages/hub && npx tsc --noEmit`) — expect clean (the map is unused until Task 3; that's fine — it's a private field that's written). If tsc flags "declared but never read" for `#schemaUpdateNames`, proceed to Task 3 which reads it, and commit together. Otherwise commit now:
+
+```bash
+cd /Users/vicio/_github/noy-db && git add packages/hub/src/vault.ts
+git commit -m "feat(hub): capture per-collection schemaUpdate strategy names (#229)"
+```
+
+---
+
+## Task 3: `SchemaIntrospection` type + `vault.introspect()`
+
+**Files:** Modify `packages/hub/src/introspection/types.ts`, `packages/hub/src/vault.ts`, `packages/hub/src/index.ts`; Test `packages/hub/__tests__/schema-introspection.test.ts`
+
+- [ ] **Step 1: Add the type** — in `packages/hub/src/introspection/types.ts`:
+
+```ts
+import type { Permission } from '../types.js'
+
+/** Flat snapshot of a vault's registered schema (#229). */
+export interface SchemaIntrospection {
+  readonly collections: ReadonlyArray<{ name: string; docCount: number }>
+  readonly guards: ReadonlyArray<{ collection: string; count: number }>
+  readonly materializedViews: ReadonlyArray<{ name: string; sourceCollections: string[] }>
+  readonly schemaUpdate: ReadonlyArray<{ collection: string; strategies: string[] }>
+  readonly grants: ReadonlyArray<{ collection: string; permission: Permission }>
+}
+```
+
+(If `introspection/types.ts` already imports from `../types.js`, fold `Permission` into that import.)
+
+- [ ] **Step 2: Write the failing E2E test** `packages/hub/__tests__/schema-introspection.test.ts`
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { createNoydb, type NoydbStore } from '../src/noydb.js'
+import { memory } from '../../to-memory/src/index.js'
+import { withGuard } from '../src/guards/with-guard.js'
+import { withMaterializedView } from '../src/materialized-views/with-materialized-view.js'
+import { additiveOnly, coordinatedCutover } from '../src/schema-update/index.js'
+
+interface Inv extends Record<string, unknown> { id: string; amount: number }
+
+describe('vault.introspect() (#229)', () => {
+  it('reports collections with counts, guards, MVs, schemaUpdate, and grants', async () => {
+    const store: NoydbStore = memory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: 'introspect-pass-1234',
+      guardStrategies: [withGuard<Inv>({ collection: 'invoices', check: () => {} })],
+    })
+    const v = await db.openVault('demo')
+    const invoices = v.collection<Inv>('invoices', {
+      schema: z.object({ id: z.string(), amount: z.number() }),
+      persistJsonSchema: true,
+      schemaUpdate: [coordinatedCutover({ transform: (d) => d }), additiveOnly()],
+    })
+    await v._drainPendingSchemaWrites()
+    v.collection('notes')
+    await invoices.put('i1', { id: 'i1', amount: 1 })
+    await invoices.put('i2', { id: 'i2', amount: 2 })
+
+    const snap = await v.introspect()
+
+    const invCol = snap.collections.find(c => c.name === 'invoices')
+    expect(invCol?.docCount).toBe(2)
+    expect(snap.collections.map(c => c.name)).toContain('notes')
+
+    expect(snap.guards).toContainEqual({ collection: 'invoices', count: 1 })
+    expect(snap.schemaUpdate).toContainEqual({ collection: 'invoices', strategies: ['coordinatedCutover', 'additiveOnly'] })
+
+    const inv = snap.grants.find(g => g.collection === 'invoices')
+    expect(inv).toBeDefined()
+    expect(['rw', 'ro']).toContain(inv!.permission)
+  })
+
+  it('a subsystems-off vault yields empty guard/MV/schemaUpdate arrays without error', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'introspect-pass-1234' })
+    const v = await db.openVault('demo')
+    v.collection('plain')
+    const snap = await v.introspect()
+    expect(snap.guards).toEqual([])
+    expect(snap.materializedViews).toEqual([])
+    expect(snap.schemaUpdate).toEqual([])
+    expect(snap.collections.map(c => c.name)).toContain('plain')
+  })
+})
+```
+
+(Confirm `withGuard`'s option shape with `grep -n "export function withGuard" packages/hub/src/guards/with-guard.js` and the MV/guard helper import paths; adjust the `withGuard`/strategy construction to the real signature. The MV assertion is omitted from test 1 to avoid coupling to the MV query-builder API; if a simple MV is easy to register, add a `materializedViews` assertion.)
+
+- [ ] **Step 3: Run → fail** (no `introspect`)
+
+- [ ] **Step 4: Implement `introspect()`** — in `vault.ts`. Import the type:
+
+```ts
+import type { SchemaIntrospection } from './introspection/types.js'
+```
+
+Add the method (beside `dumpSchema`):
+
+```ts
+  /**
+   * Lightweight read of the vault's registered schema (#229): collections
+   * (+ doc counts), guards, materialized views, schema-update strategies,
+   * and the unlocked user's grants. Cheap — one `adapter.list` per
+   * collection, no decryption. For a full snapshot + stats use dumpSchema().
+   * Post-unlock by construction.
+   */
+  async introspect(): Promise<SchemaIntrospection> {
+    const byCol = (a: { collection: string }, b: { collection: string }) => a.collection.localeCompare(b.collection)
+
+    const names = [...(await this.collections())].sort((a, b) => a.localeCompare(b))
+    const collections: { name: string; docCount: number }[] = []
+    for (const name of names) {
+      const ids = await this.adapter.list(this.name, name)
+      collections.push({ name, docCount: ids.length })
+    }
+
+    const guards = (this._getGuardRegistry()?.summary() ?? []).slice().sort(byCol)
+
+    const materializedViews = (this._getMaterializedViewRegistry()?.all() ?? [])
+      .map((mv) => ({ name: mv.spec.name, sourceCollections: [...mv.dependencies].sort() }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+
+    const schemaUpdate = [...this.#schemaUpdateNames.entries()]
+      .map(([collection, strategies]) => ({ collection, strategies }))
+      .sort(byCol)
+
+    const grants = Object.entries(this.keyring.permissions)
+      .map(([collection, permission]) => ({ collection, permission }))
+      .sort(byCol)
+
+    return { collections, guards, materializedViews, schemaUpdate, grants }
+  }
+```
+
+(Confirm `_getMaterializedViewRegistry()` / `_getGuardRegistry()` names + that `mv.spec.name` is accessible — the registry map is keyed by `spec.name`, so it is. If `this.collections()` already excludes internal `_`-prefixed collections, no extra filter is needed; verify and add `.filter(n => !n.startsWith('_'))` only if internal collections leak through.)
+
+- [ ] **Step 5: Export the type** — in `packages/hub/src/index.ts`, near the introspection / write-queue exports:
+
+```ts
+export type { SchemaIntrospection } from './introspection/types.js'
+```
+
+- [ ] **Step 6: Run → pass; typecheck**
+
+Run: `cd packages/hub && npx vitest run __tests__/schema-introspection.test.ts && npx tsc --noEmit`
+Expected: PASS, clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/vicio/_github/noy-db && git add packages/hub/src/introspection/types.ts packages/hub/src/vault.ts packages/hub/src/index.ts packages/hub/__tests__/schema-introspection.test.ts
+git commit -m "feat(hub): vault.introspect() runtime schema introspection (#229)"
+```
+
+---
+
+## Task 4: features.yaml + final verification
+
+**Files:** Modify `features.yaml`
+
+- [ ] **Step 1: Add the feature entry** (mirror `write-lifecycle-hooks`):
+
+```yaml
+  - id: schema-introspection
+    name: Runtime schema introspection
+    cluster: core
+    spec: docs/superpowers/specs/2026-06-01-schema-introspection-design.md
+    subsystem_doc: docs/superpowers/specs/2026-06-01-schema-introspection-design.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'vault.introspect() reports collection doc counts via adapter.list, without decryption'
+      - 'guards / materializedViews / schemaUpdate arrays are empty (not errors) when the subsystem is off'
+      - 'schemaUpdate strategy names are captured at collection() registration time'
+    related: [dump-schema-introspection, schema-update-strategies]
+```
+
+- [ ] **Step 2: Validate** — `node scripts/validate-features.mjs` (Expected: PASS; if `related: [dump-schema-introspection]` doesn't resolve, check the exact id with `grep -n "id: dump-schema" features.yaml` and fix).
+
+- [ ] **Step 3: Full verify** — `cd packages/hub && npx vitest run && npx tsc --noEmit && npm run lint` (Expected: all PASS).
+
+- [ ] **Step 4: Commit + clean tree**
+
+```bash
+cd /Users/vicio/_github/noy-db && git add features.yaml
+git commit -m "chore(features): register schema-introspection (#229)"
+git status
+```
+
+---
+
+## Self-review checklist (already applied)
+
+- **Spec coverage:** collections+counts → Task 3; guards → Tasks 1,3; MVs → Task 3 (reuse `.all()`); schemaUpdate capture+report → Tasks 2,3; grants → Task 3; post-unlock-by-construction → documented on the method; subsystems-off → empty arrays (Task 3 + test 2); type export → Task 3.
+- **Type consistency:** `SchemaIntrospection` shape matches the builder; `Permission` is `'rw'|'ro'` (per `types.ts`); `GuardRegistry.summary()` return shape matches its consumer; `mv.spec.name`/`mv.dependencies` match `RegisteredMV`.
+- **Verify-before-trust:** Task 1 confirms the guard registration method name; Task 3 confirms `withGuard`/MV helper signatures + `_get*Registry` names + whether `collections()` filters internal names. Real lookups, flagged.
+- **Existing-suite safety:** purely additive (a new method + a new registry accessor + a written-only map); no existing path changes → the 1948-test suite is untouched.
+- **No placeholders:** every code step has complete code; every run step states command + expected result.

--- a/docs/superpowers/specs/2026-06-01-schema-introspection-design.md
+++ b/docs/superpowers/specs/2026-06-01-schema-introspection-design.md
@@ -1,0 +1,68 @@
+# Runtime schema introspection (#229) — design
+
+**Status:** approved (autonomous build) · **Date:** 2026-06-01 · **Issue:** #229 · **Milestone:** #12 (independent follow-up)
+
+**Goal:** A read-only `vault.introspect()` that enumerates a vault's live registered schema — collections, guards, materialized views, schema-update strategies, and the current user's grants — so apps can build diagnostics/audit tooling without hard-coding names.
+
+## Context — what already exists
+
+`vault.dumpSchema()` already returns a rich `VaultSchemaSnapshot` (collections, materialized views, overlays, derivations, subsystem on/off flags, optional stats) — see `packages/hub/src/introspection/`. This feature does **not** duplicate it. Instead it adds a focused, cheap `introspect()` that surfaces the **gaps** `dumpSchema()` doesn't cover (guards enumeration, schema-update strategies, user grants) plus the two most-asked lightweight fields (collection names + doc counts, MV source mapping), in a flat shape convenient for a dashboard.
+
+`dumpSchema()` stays the heavyweight "full snapshot + stats" tool; `introspect()` is the lightweight "what's registered right now" read.
+
+## Scope (decided)
+
+**In:**
+- `collections`: `{ name, docCount }[]` — names from `vault.collections()`, count from `adapter.list(name).length`.
+- `guards`: `{ collection, count }[]` — from `GuardRegistry` (new `summary()` accessor; today it only has `guardsFor(name)`).
+- `materializedViews`: `{ name, sourceCollections }[]` — reuse `MaterializedViewRegistry.all()` (`outputCollection` + `dependencies`).
+- `schemaUpdate`: `{ collection, strategies: string[] }[]` — strategy `.name`s. **Not stored anywhere today** — captured into a vault-level map at `collection({ schemaUpdate })` registration.
+- `grants`: `{ collection, permission }[]` — from `vault.keyring.permissions` (a plain `Record<string, Permission>`), for the unlocked user.
+
+**Out (deferred):**
+- i18n bilingual fields (smaller win; private registries; add later if a UI needs it).
+- Overlays + derivations enumeration — already in `dumpSchema()`; don't duplicate.
+- `byteSize` / violation counts — `dumpSchema({ withStats })` is the place for expensive walks; `introspect()` stays cheap (one `adapter.list` per collection, no decryption).
+
+## API
+
+```ts
+vault.introspect(): Promise<SchemaIntrospection>
+
+interface SchemaIntrospection {
+  readonly collections: ReadonlyArray<{ name: string; docCount: number }>
+  readonly guards: ReadonlyArray<{ collection: string; count: number }>
+  readonly materializedViews: ReadonlyArray<{ name: string; sourceCollections: string[] }>
+  readonly schemaUpdate: ReadonlyArray<{ collection: string; strategies: string[] }>
+  readonly grants: ReadonlyArray<{ collection: string; permission: Permission }>
+}
+```
+
+`Permission` is the existing `'r' | 'rw' | 'admin'`-style type from `types.ts`. All arrays are sorted by name/collection for deterministic output (testability).
+
+## Architecture
+
+- **`GuardRegistry.summary()`** (new): `{ collection: string; count: number }[]` from its `_byCollection` map. Keeps the introspection read off the registry's internals.
+- **Vault `#schemaUpdateNames: Map<string, string[]>`** (new): populated in the `collection()` registration path whenever `options.schemaUpdate` is present — stores `strategies.map(s => s.name)`. This is the only new *capture* (strategies are otherwise closed over in the gate).
+- **`vault.introspect()`** (new): assembles the snapshot from `this.collections()` + `adapter.list`, `_getGuardRegistry()?.summary()`, `_getMaterializedViewRegistry()?.all()`, `#schemaUpdateNames`, and `this.keyring.permissions`. Registries are `null` when their subsystem isn't enabled → those arrays are empty.
+- Lives on `Vault`; **post-unlock by construction** (a `Vault` only exists with an `UnlockedKeyring`), so no extra lock guard is needed — documented.
+- Optional: re-export the `SchemaIntrospection` type from `@noy-db/hub`.
+
+## Error handling
+
+- No throws in the happy path. A collection with no guards / no MV / no schemaUpdate simply doesn't appear in those arrays. Registries absent (subsystem off) → empty arrays, not errors.
+
+## Testing
+
+- `GuardRegistry.summary()` unit test (registered guards across 2 collections → correct counts; empty registry → `[]`).
+- Integration (`createNoydb` + memory): `introspect()` on a vault with 2 collections (one with N docs), a guard, an MV, and a `coordinatedCutover`/`additiveOnly` schemaUpdate list → asserts each array's contents; `docCount` matches; `schemaUpdate` lists the strategy names; `grants` reflects the owner's permissions; arrays are sorted.
+- Subsystems-off vault → `guards`/`materializedViews`/`schemaUpdate` are `[]`, `collections`/`grants` still populated.
+
+## Success criteria
+
+1. `vault.introspect()` returns collection names with correct `docCount` (cheap `adapter.list`, no decryption).
+2. Guards enumerated as `{collection, count}` via the new `GuardRegistry.summary()`.
+3. Materialized views enumerated as `{name, sourceCollections}` from the existing registry.
+4. `schemaUpdate` lists each collection's registered strategy names (captured at registration).
+5. `grants` reflects the unlocked user's per-collection permissions.
+6. Subsystems-off vault yields empty arrays for the optional sections without error; no behaviour change for the existing suite.

--- a/docs/superpowers/specs/2026-06-01-schema-introspection-design.md
+++ b/docs/superpowers/specs/2026-06-01-schema-introspection-design.md
@@ -17,7 +17,7 @@
 - `guards`: `{ collection, count }[]` — from `GuardRegistry` (new `summary()` accessor; today it only has `guardsFor(name)`).
 - `materializedViews`: `{ name, sourceCollections }[]` — reuse `MaterializedViewRegistry.all()` (`outputCollection` + `dependencies`).
 - `schemaUpdate`: `{ collection, strategies: string[] }[]` — strategy `.name`s. **Not stored anywhere today** — captured into a vault-level map at `collection({ schemaUpdate })` registration.
-- `grants`: `{ collection, permission }[]` — from `vault.keyring.permissions` (a plain `Record<string, Permission>`), for the unlocked user.
+- `grants`: `{ collection, permission }[]` — the collections the unlocked user can actually access (their `keyring.deks` keys), with the level from `keyring.permissions[col]` falling back to `'rw'` for implicit/owner access (owners carry an empty `permissions` map). Internal `_`-collections excluded.
 
 **Out (deferred):**
 - i18n bilingual fields (smaller win; private registries; add later if a UI needs it).

--- a/features.yaml
+++ b/features.yaml
@@ -841,6 +841,24 @@ features:
       - 'txId is shared across all writes in one db.transaction(); a fresh ULID per standalone write'
     related: [vault-and-collections, observable-write-queue]
 
+  - id: schema-introspection
+    name: Runtime schema introspection
+    cluster: core
+    spec: docs/superpowers/specs/2026-06-01-schema-introspection-design.md
+    subsystem_doc: docs/superpowers/specs/2026-06-01-schema-introspection-design.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'vault.introspect() reports collection doc counts via adapter.list, without decryption'
+      - 'guards / materializedViews / schemaUpdate arrays are empty (not errors) when the subsystem is off'
+      - 'schemaUpdate strategy names are captured at collection() registration time'
+    related: [dump-schema-introspection, schema-update-strategies]
+
 # ─── Storage adapters (phase 2) ──────────────────────────────────────
 
 adapters:

--- a/packages/hub/__tests__/guards/registry-summary.test.ts
+++ b/packages/hub/__tests__/guards/registry-summary.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { GuardRegistry } from '../../src/guards/registry.js'
+
+// Minimal guard strategies (only `collection` matters for summary()).
+const g = (collection: string) => ({ collection }) as never
+
+describe('GuardRegistry.summary()', () => {
+  it('returns [] when empty', () => {
+    expect(new GuardRegistry().summary()).toEqual([])
+  })
+  it('counts guards per collection', () => {
+    const r = new GuardRegistry()
+    r.register(g('invoices'))
+    r.register(g('invoices'))
+    r.register(g('payments'))
+    const s = r.summary().sort((a, b) => a.collection.localeCompare(b.collection))
+    expect(s).toEqual([
+      { collection: 'invoices', count: 2 },
+      { collection: 'payments', count: 1 },
+    ])
+  })
+})

--- a/packages/hub/__tests__/schema-introspection.test.ts
+++ b/packages/hub/__tests__/schema-introspection.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { createNoydb, type NoydbStore } from '../src/noydb.js'
+import { memory } from '../../to-memory/src/index.js'
+import { withGuard } from '../src/guards/with-guard.js'
+import { additiveOnly, coordinatedCutover } from '../src/schema-update/index.js'
+
+interface Inv extends Record<string, unknown> { id: string; amount: number }
+
+describe('vault.introspect() (#229)', () => {
+  it('reports collections with counts, guards, schemaUpdate, and grants', async () => {
+    const store: NoydbStore = memory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: 'introspect-pass-1234',
+      guardStrategies: [withGuard<Inv>({ collection: 'invoices', check: () => {} })],
+    })
+    const v = await db.openVault('demo')
+    const invoices = v.collection<Inv>('invoices', {
+      schema: z.object({ id: z.string(), amount: z.number() }),
+      persistJsonSchema: true,
+      schemaUpdate: [coordinatedCutover({ transform: (d) => d }), additiveOnly()],
+    })
+    await v._drainPendingSchemaWrites()
+    v.collection('notes')
+    await invoices.put('i1', { id: 'i1', amount: 1 })
+    await invoices.put('i2', { id: 'i2', amount: 2 })
+
+    const snap = await v.introspect()
+
+    expect(snap.collections.find(c => c.name === 'invoices')?.docCount).toBe(2)
+    expect(snap.collections.map(c => c.name)).toContain('notes')
+    expect(snap.guards).toContainEqual({ collection: 'invoices', count: 1 })
+    expect(snap.schemaUpdate).toContainEqual({ collection: 'invoices', strategies: ['coordinatedCutover', 'additiveOnly'] })
+
+    const inv = snap.grants.find(g => g.collection === 'invoices')
+    expect(inv).toBeDefined()
+    expect(['rw', 'ro']).toContain(inv!.permission)
+  })
+
+  it('a subsystems-off vault yields empty guard/MV/schemaUpdate arrays without error', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'introspect-pass-1234' })
+    const v = await db.openVault('demo')
+    v.collection('plain')
+    const snap = await v.introspect()
+    expect(snap.guards).toEqual([])
+    expect(snap.materializedViews).toEqual([])
+    expect(snap.schemaUpdate).toEqual([])
+    expect(snap.collections.map(c => c.name)).toContain('plain')
+  })
+})

--- a/packages/hub/src/guards/registry.ts
+++ b/packages/hub/src/guards/registry.ts
@@ -44,6 +44,14 @@ export class GuardRegistry {
     return this._byCollection.get(collection) ?? []
   }
 
+  /** Per-collection guard counts, for introspection (#229). */
+  summary(): { collection: string; count: number }[] {
+    return [...this._byCollection.entries()].map(([collection, guards]) => ({
+      collection,
+      count: guards.length,
+    }))
+  }
+
   /**
    * Run every guard's `check` for this collection. First throw wins —
    * remaining guards are not invoked. Guards without a `check` skip.

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -175,6 +175,9 @@ export type { WriteQueue } from './write-queue.js'
 // Write lifecycle hooks (#230)
 export type { WriteEvent, WriteHook } from './write-hooks.js'
 
+// Runtime schema introspection (#229)
+export type { SchemaIntrospection } from './introspection/types.js'
+
 // Schema-update strategies (#245)
 export type {
   SchemaDelta,

--- a/packages/hub/src/introspection/types.ts
+++ b/packages/hub/src/introspection/types.ts
@@ -9,6 +9,16 @@
  */
 
 import type { PersistedSchemaKind } from '../persisted-schemas/types.js'
+import type { Permission } from '../types.js'
+
+/** Flat snapshot of a vault's registered schema (#229). */
+export interface SchemaIntrospection {
+  readonly collections: ReadonlyArray<{ name: string; docCount: number }>
+  readonly guards: ReadonlyArray<{ collection: string; count: number }>
+  readonly materializedViews: ReadonlyArray<{ name: string; sourceCollections: string[] }>
+  readonly schemaUpdate: ReadonlyArray<{ collection: string; strategies: string[] }>
+  readonly grants: ReadonlyArray<{ collection: string; permission: Permission }>
+}
 
 /** Where the field-level info in the snapshot came from. */
 export type FieldSource = 'persisted' | 'live-validator' | 'sampled' | 'unknown'

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -115,7 +115,7 @@ import { SCHEMAS_COLLECTION } from './persisted-schemas/storage.js'
 import type { AttestationFieldSchema, RevocationList } from '@noy-db/attestation'
 import type { IssueContext } from './attestation/issue.js'
 import type { RevokeContext } from './attestation/revoke.js'
-import type { DumpSchemaOptions, VaultSchemaSnapshot } from './introspection/types.js'
+import type { DumpSchemaOptions, VaultSchemaSnapshot, SchemaIntrospection } from './introspection/types.js'
 import { dumpVaultSchema, type VaultIntrospectState } from './introspection/walk.js'
 import { USER_ENVELOPE_COLLECTION } from './meta/user-envelope/types.js'
 
@@ -230,6 +230,8 @@ export class Vault {
   /** #232 — per-client heartbeat/watcher; started lazily on cutover registration. */
   #fenceWatcher: FenceWatcher | undefined
   #fenceCoordinationStarted = false
+  /** #229 — per-collection registered schema-update strategy names. */
+  readonly #schemaUpdateNames = new Map<string, string[]>()
 
   /**
    * per-collection `blobFields` retention/TTL config.
@@ -632,6 +634,11 @@ export class Vault {
           dictFieldMap[field] = desc.name
         }
         this.dictKeyFieldRegistry.set(collectionName, dictFieldMap)
+      }
+
+      // #229 — capture registered schema-update strategy names for introspection.
+      if ((options?.schemaUpdate?.length ?? 0) > 0) {
+        this.#schemaUpdateNames.set(collectionName, (options!.schemaUpdate ?? []).map((s) => s.name))
       }
 
       // #245 — schema-update gate. Built only when persistence + strategies
@@ -2603,6 +2610,50 @@ export class Vault {
    */
   async dumpSchema(opts: DumpSchemaOptions = {}): Promise<VaultSchemaSnapshot> {
     return dumpVaultSchema(this, opts)
+  }
+
+  /**
+   * Lightweight read of the vault's registered schema (#229): collections
+   * (+ doc counts), guards, materialized views, schema-update strategies,
+   * and the unlocked user's grants. Cheap — one `adapter.list` per
+   * collection, no decryption. For a full snapshot + stats use dumpSchema().
+   * Post-unlock by construction (a Vault only exists with an unlocked keyring).
+   */
+  async introspect(): Promise<SchemaIntrospection> {
+    const byCol = (a: { collection: string }, b: { collection: string }) =>
+      a.collection.localeCompare(b.collection)
+
+    // Union of collections registered this session (collectionCache) and
+    // collections with persisted records (collections()), so registered-but-
+    // empty collections are reported too.
+    const names = [...new Set([...this.collectionCache.keys(), ...(await this.collections())])]
+      .filter((n) => !n.startsWith('_'))
+      .sort((a, b) => a.localeCompare(b))
+    const collections: { name: string; docCount: number }[] = []
+    for (const name of names) {
+      const ids = await this.adapter.list(this.name, name)
+      collections.push({ name, docCount: ids.length })
+    }
+
+    const guards = (this._getGuardRegistry()?.summary() ?? []).slice().sort(byCol)
+
+    const materializedViews = (this._getMaterializedViewRegistry()?.all() ?? [])
+      .map((mv) => ({ name: mv.spec.name, sourceCollections: [...mv.dependencies].sort() }))
+      .sort((a, b) => a.name.localeCompare(b.name))
+
+    const schemaUpdate = [...this.#schemaUpdateNames.entries()]
+      .map(([collection, strategies]) => ({ collection, strategies }))
+      .sort(byCol)
+
+    // Grants reflect what the unlocked user can actually access: the
+    // collections they hold a DEK for, with the level from `permissions`
+    // (absent ⇒ implicit full access for owner/admin → 'rw').
+    const grants = [...this.keyring.deks.keys()]
+      .filter((collection) => !collection.startsWith('_'))
+      .map((collection) => ({ collection, permission: this.keyring.permissions[collection] ?? 'rw' as const }))
+      .sort(byCol)
+
+    return { collections, guards, materializedViews, schemaUpdate, grants }
   }
 
   /**


### PR DESCRIPTION
Closes #229.

A lightweight `vault.introspect()` for diagnostics/audit tooling — enumerates the vault's registered schema without hard-coding names.

Design: `docs/superpowers/specs/2026-06-01-schema-introspection-design.md`

## API
```ts
vault.introspect(): Promise<SchemaIntrospection>
// { collections: {name, docCount}[], guards: {collection, count}[],
//   materializedViews: {name, sourceCollections}[],
//   schemaUpdate: {collection, strategies}[], grants: {collection, permission}[] }
```

## Design
- **Complements, not duplicates, `dumpSchema()`** — that stays the heavyweight full-snapshot+stats tool; `introspect()` is the cheap "what's registered right now" read (one `adapter.list` per collection, no decryption), and adds the gaps `dumpSchema` lacks (guards enumeration, schema-update strategies, grants).
- **Reuses** existing registries (`MaterializedViewRegistry.all()`, `keyring`); **adds** `GuardRegistry.summary()` and a vault-level capture of per-collection `schemaUpdate` strategy names (the only data not stored before).
- **Collections** = union of registered (`collectionCache`) + persisted (`collections()`), so registered-but-empty collections show too; internal `_`-collections excluded.
- **Grants** derive from the user's accessible DEK set + permission level (owners carry an empty `permissions` map → implicit `rw`).
- **Post-unlock by construction**; subsystems-off vault → empty arrays, never errors.
- **Purely additive** — a new method + a registry accessor + a written-only map; no existing path changes.

## Verification
- `@noy-db/hub`: 1952 tests pass; typecheck + lint clean; `features.yaml` validator green (`schema-introspection` registered).

## Deferred
- i18n bilingual fields; overlays/derivations enumeration (already in `dumpSchema()`); `byteSize`/violation counts (that's `dumpSchema({ withStats })`).