### PR TITLE
feat(in-pinia): forward attestation field schema to the collection

### DIFF
--- a/packages/in-pinia/__tests__/defineNoydbStore.test.ts
+++ b/packages/in-pinia/__tests__/defineNoydbStore.test.ts
@@ -403,3 +403,31 @@ describe('defineNoydbStore — greenfield path', () => {
     expect(direct[0]?.id).toBe('a')
   })
 })
+
+describe('attestation option forwarding', () => {
+  it('forwards `attestation` to the Collection so vault.issueAttestation works', async () => {
+    setActivePinia(createPinia())
+    const db = await makeNoydb()
+    setActiveNoydb(db)
+    const useStore = defineNoydbStore<Invoice>('att-invoices', {
+      vault: 'books',
+      collection: 'invoices',
+      attestation: {
+        fields: [
+          { path: 'amount', normalize: 'cents' },
+          { path: 'client', normalize: 'trim' },
+        ],
+      },
+    })
+    const store = useStore()
+    await store.$ready
+    await store.add('i1', { id: 'i1', amount: 100, status: 'open', client: 'ACME' })
+
+    // Without the forward the collection carries no attestation schema and this throws.
+    const vault = await db.openVault('books')
+    const att = await vault.issueAttestation('invoices', 'i1')
+    expect(att.docId).toBeTruthy()
+    expect(att.qr).toBeTruthy()
+    expect(att.keyId).toBeTruthy()
+  })
+})

--- a/packages/in-pinia/src/defineNoydbStore.ts
+++ b/packages/in-pinia/src/defineNoydbStore.ts
@@ -87,6 +87,13 @@ export interface NoydbStoreOptions<T> {
    * perf cost, backwards compatible with usage).
    */
   schema?: StandardSchemaV1<unknown, T>
+  /**
+   * Optional per-field attestation schema. When set, it's installed on the
+   * underlying `Collection` (alongside `schema`) so `vault.issueAttestation(name, id)`
+   * can commit the declared fields against the firm's signing key — see
+   * `@noy-db/attestation` `AttestationFieldSchema`. Stores without it behave as before.
+   */
+  attestation?: NonNullable<Parameters<Vault['collection']>[1]>['attestation']
 }
 
 /**
@@ -148,6 +155,7 @@ export function defineNoydbStore<T>(
       // old `options.schema.parse(record)` call in add() could not do).
       const collOpts: Parameters<typeof cachedCompartment.collection<T>>[1] = {}
       if (options.schema !== undefined) collOpts.schema = options.schema
+      if (options.attestation !== undefined) collOpts.attestation = options.attestation
       cachedCollection = cachedCompartment.collection<T>(collectionName, collOpts)
       return cachedCollection
     }


### PR DESCRIPTION
## Summary

`defineNoydbStore` now forwards an optional `attestation` option to `vault.collection()` (alongside `schema`), so `vault.issueAttestation(name, id)` works for Pinia-backed collections. Without the forward, the underlying `Collection` carries no attestation field-schema and `issueAttestation` throws.

- Typed off the collection's own option — `NonNullable<Parameters<Vault['collection']>[1]>['attestation']` — so it stays in sync with the hub's `AttestationFieldSchema` with **no new import** (in-pinia gains no `@noy-db/attestation` dependency).
- Mirrors the existing `schema` forwarding pattern exactly.

## Provenance

Extracted (cherry-pick) from a consumer (niwat) fix that had been committed onto the parked `feat/228a-tab-presence-roles` branch. Re-homed onto its own branch off `main` so it can ship independently of the in-progress #228 tab-coordination work.

## Test Plan

- [x] `npx tsc --noEmit` clean (in-pinia)
- [x] `npm run build` clean (CJS + DTS emit)
- [x] `npx vitest run` — 58/58 pass, incl. the new test issuing an attestation through a store-registered collection