### PR TITLE
feat(hub): multi-tab coordination — presence + roles (#228 sub-slice a)

### DIFF
--- a/docs/superpowers/plans/2026-06-01-228a-tab-presence-roles.md
+++ b/docs/superpowers/plans/2026-06-01-228a-tab-presence-roles.md
@@ -1,0 +1,497 @@
+# Tab coordination — roles + presence (#228 sub-slice a) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `db.enableTabCoordination()` elects a primary tab (Web Locks) and publishes a presence heartbeat (BroadcastChannel), exposing `db.tabRole` / `db.activeTabs()` + change emitters — opt-in, browser-only, graceful no-op elsewhere.
+
+**Architecture:** A self-contained `TabCoordinator` in hub core. It takes a `TabLockManager` (default `navigator.locks`) and a `TabChannel` (default: an inline `BroadcastChannel` wrapper) — both **hub-local minimal interfaces** (structurally compatible with `@noy-db/by-peer`'s `MinimalLockManager` / `PeerChannel`, but NOT imported, to avoid a circular dep since those packages depend on hub). Election: hold an exclusive lock = primary; queued = secondary; re-elect on release. Presence: heartbeat `{tabId,lastSeen,role}` over the channel, stale-filtered.
+
+**Tech Stack:** TypeScript, Vitest. Package: `packages/hub`. Browser APIs (`navigator.locks`, `BroadcastChannel`) accessed via `globalThis` with feature-detection. Own PR through CI.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-228-tab-coordination-design.md` (sub-slice a). Issue #228.
+
+---
+
+## File structure
+
+- **Create** `packages/hub/src/tab-coordination.ts` — `TabRole`/`TabPresence`/`TabLockManager`/`TabChannel`/`TabCoordinationOptions` types + `TabCoordinator` class + `defaultLockManager()`/`defaultChannel()` browser helpers.
+- **Modify** `packages/hub/src/noydb.ts` — `enableTabCoordination()` + `tabRole`/`activeTabs()`/`onTabRoleChange`/`onActiveTabsChange` + cleanup on `close`.
+- **Modify** `packages/hub/src/index.ts` — export the public types.
+- **Create** `packages/hub/__tests__/tab-coordination.test.ts` (multi-tab, deterministic) + a small `noydb` no-op test.
+
+---
+
+## Task 1: `TabCoordinator` + types
+
+**Files:** Create `packages/hub/src/tab-coordination.ts`; Test `packages/hub/__tests__/tab-coordination.test.ts`
+
+- [ ] **Step 1: Write the failing test** (N coordinators sharing a stub lock manager + an in-memory broadcast bus; explicit `now` + `_beat()`)
+
+```ts
+import { describe, expect, it, vi } from 'vitest'
+import { TabCoordinator, type TabLockManager, type TabChannel } from '../src/tab-coordination.js'
+
+/** FIFO exclusive lock manager (mirrors by-peer's createMockLocks). */
+function mockLocks(): TabLockManager {
+  const held = new Set<string>()
+  const queues = new Map<string, Array<() => void>>()
+  async function pump(name: string) {
+    if (held.has(name)) return
+    const q = queues.get(name) ?? []
+    const next = q.shift()
+    if (!next) return
+    held.add(name)
+    next()
+  }
+  return {
+    request(name, _opts, cb) {
+      return new Promise((resolve, reject) => {
+        const run = () => {
+          void Promise.resolve()
+            .then(() => cb(undefined))
+            .then((v) => { held.delete(name); void pump(name); resolve(v as never) },
+                  (e) => { held.delete(name); void pump(name); reject(e) })
+        }
+        const q = queues.get(name) ?? []
+        q.push(run); queues.set(name, q)
+        // abort: drop from queue if still waiting
+        _opts.signal?.addEventListener('abort', () => {
+          const qq = queues.get(name) ?? []
+          const i = qq.indexOf(run); if (i >= 0) qq.splice(i, 1)
+          reject(new Error('aborted'))
+        })
+        void pump(name)
+      })
+    },
+  }
+}
+
+/** In-memory broadcast bus: each channel's send() reaches all OTHER channels. */
+function makeBus(n: number): TabChannel[] {
+  const listeners: Array<((p: string) => void) | null> = []
+  const chans: TabChannel[] = []
+  for (let i = 0; i < n; i++) {
+    const idx = i
+    chans.push({
+      isOpen: true,
+      send(payload) { for (let j = 0; j < listeners.length; j++) if (j !== idx && listeners[j]) queueMicrotask(() => listeners[j]!(payload)) },
+      on(event, l) { if (event === 'message') { listeners[idx] = l as (p: string) => void; return () => { listeners[idx] = null } } return () => {} },
+      close() { listeners[idx] = null },
+    })
+  }
+  return chans
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+function mkCoordinator(lockManager: TabLockManager, channel: TabChannel, tabId: string, now: () => number) {
+  return new TabCoordinator({ lockManager, channel, tabId, heartbeatMs: 1_000_000, staleMs: 500, now })
+}
+
+describe('TabCoordinator', () => {
+  it('elects exactly one primary; the rest are secondary', async () => {
+    const locks = mockLocks()
+    const bus = makeBus(3)
+    let t = 1000
+    const tabs = bus.map((ch, i) => mkCoordinator(locks, ch, `tab${i}`, () => t))
+    tabs.forEach((c) => c.start())
+    await flush()
+    const roles = tabs.map((c) => c.role).sort()
+    expect(roles.filter((r) => r === 'primary')).toHaveLength(1)
+    expect(roles.filter((r) => r === 'secondary')).toHaveLength(2)
+  })
+
+  it('promotes a secondary when the primary disposes', async () => {
+    const locks = mockLocks()
+    const bus = makeBus(2)
+    let t = 1000
+    const tabs = bus.map((ch, i) => mkCoordinator(locks, ch, `tab${i}`, () => t))
+    tabs.forEach((c) => c.start())
+    await flush()
+    const primary = tabs.find((c) => c.role === 'primary')!
+    const secondary = tabs.find((c) => c.role === 'secondary')!
+    primary.dispose()
+    await flush()
+    expect(secondary.role).toBe('primary')
+  })
+
+  it('presence: a tab sees the others; stale tabs drop out', async () => {
+    const locks = mockLocks()
+    const bus = makeBus(2)
+    let t = 1000
+    const [a, b] = bus.map((ch, i) => mkCoordinator(locks, ch, `tab${i}`, () => t))
+    a!.start(); b!.start()
+    await flush()
+    a!._beat(); b!._beat()
+    await flush()
+    expect(a!.activeTabs().map((p) => p.tabId).sort()).toEqual(['tab0', 'tab1'])
+    t += 10_000 // advance past staleMs; b never beats again
+    a!._beat()
+    await flush()
+    expect(a!.activeTabs().map((p) => p.tabId)).toEqual(['tab0'])
+  })
+
+  it('emits onTabRoleChange', async () => {
+    const locks = mockLocks()
+    const bus = makeBus(1)
+    let t = 1000
+    const c = mkCoordinator(locks, bus[0]!, 'tab0', () => t)
+    const seen: string[] = []
+    c.onTabRoleChange((r) => seen.push(r))
+    c.start()
+    await flush()
+    expect(seen).toContain('primary')
+  })
+
+  it('no-op when no lock manager and no channel', async () => {
+    const c = new TabCoordinator({ heartbeatMs: 1_000_000, staleMs: 500, now: () => 0 })
+    c.start()
+    await flush()
+    expect(c.role).toBe('unknown')
+    expect(c.activeTabs()).toEqual([])
+    c.dispose()
+  })
+})
+```
+
+- [ ] **Step 2: Run → fail** (`cd packages/hub && npx vitest run __tests__/tab-coordination.test.ts`)
+
+- [ ] **Step 3: Implement** `tab-coordination.ts`
+
+```ts
+/**
+ * Multi-tab coordination (#228a): primary/secondary election (Web Locks)
+ * + presence heartbeat (BroadcastChannel). Browser-only; opt-in; no-op
+ * when the APIs are absent. The lock/channel interfaces are hub-local
+ * (structurally compatible with @noy-db/by-peer + @noy-db/by-tabs, but
+ * not imported — those packages depend on hub).
+ */
+export type TabRole = 'primary' | 'secondary' | 'unknown'
+export interface TabPresence { readonly tabId: string; readonly lastSeen: number; readonly role: TabRole }
+export type Unsubscribe = () => void
+
+/** Structural subset of the Web Locks API / by-peer's MinimalLockManager. */
+export interface TabLockManager {
+  request<T>(name: string, options: { mode?: 'exclusive' | 'shared'; signal?: AbortSignal }, callback: (lock: unknown) => Promise<T>): Promise<T>
+}
+
+/** Structural subset of by-peer's PeerChannel / a BroadcastChannel wrapper. */
+export interface TabChannel {
+  send(payload: string): void
+  on(event: 'message', listener: (payload: string) => void): Unsubscribe
+  on(event: 'close', listener: () => void): Unsubscribe
+  close(): void
+  readonly isOpen: boolean
+}
+
+export interface TabCoordinationOptions {
+  readonly lockManager?: TabLockManager
+  readonly channel?: TabChannel
+  readonly tabId?: string
+  readonly lockName?: string
+  readonly heartbeatMs?: number
+  readonly staleMs?: number
+  readonly now?: () => number
+}
+
+interface PresenceMsg { readonly kind: 'tab-presence'; readonly tabId: string; readonly lastSeen: number; readonly role: TabRole }
+
+export class TabCoordinator {
+  readonly tabId: string
+  role: TabRole = 'unknown'
+  readonly #lockManager: TabLockManager | undefined
+  readonly #channel: TabChannel | undefined
+  readonly #lockName: string
+  readonly #heartbeatMs: number
+  readonly #staleMs: number
+  readonly #now: () => number
+  readonly #peers = new Map<string, TabPresence>()
+  readonly #roleHandlers = new Set<(r: TabRole) => void>()
+  readonly #tabsHandlers = new Set<(t: TabPresence[]) => void>()
+  #ac: AbortController | undefined
+  #releaseLock: (() => void) | undefined
+  #unsub: Unsubscribe | undefined
+  #timer: ReturnType<typeof setInterval> | undefined
+  #disposed = false
+
+  constructor(opts: TabCoordinationOptions = {}) {
+    this.tabId = opts.tabId ?? `tab-${Math.trunc((opts.now ?? (() => 0))())}-${cheapRand()}`
+    this.#lockManager = opts.lockManager
+    this.#channel = opts.channel
+    this.#lockName = opts.lockName ?? 'noydb:tab-primary'
+    this.#heartbeatMs = opts.heartbeatMs ?? 2_000
+    this.#staleMs = opts.staleMs ?? 6_000
+    this.#now = opts.now ?? (() => Date.now())
+  }
+
+  start(): void {
+    if (this.#disposed) return
+    if (this.#channel) {
+      this.#unsub = this.#channel.on('message', (p) => this.#onMessage(p))
+      this.#beat()
+      this.#timer = setInterval(() => this.#beat(), this.#heartbeatMs)
+      const t = this.#timer as unknown as { unref?: () => void }
+      if (typeof t.unref === 'function') t.unref()
+    }
+    if (this.#lockManager) {
+      this.#ac = new AbortController()
+      this.#setRole('secondary')
+      void this.#lockManager
+        .request(this.#lockName, { mode: 'exclusive', signal: this.#ac.signal }, () => {
+          this.#setRole('primary')
+          return new Promise<void>((resolve) => { this.#releaseLock = resolve })
+        })
+        .catch(() => { /* aborted on dispose */ })
+    }
+  }
+
+  activeTabs(): TabPresence[] {
+    const cutoff = this.#now() - this.#staleMs
+    const self: TabPresence = { tabId: this.tabId, lastSeen: this.#now(), role: this.role }
+    const out = [self, ...[...this.#peers.values()].filter((p) => p.lastSeen >= cutoff)]
+    return out.sort((a, b) => a.tabId.localeCompare(b.tabId))
+  }
+
+  onTabRoleChange(fn: (r: TabRole) => void): Unsubscribe { this.#roleHandlers.add(fn); return () => this.#roleHandlers.delete(fn) }
+  onActiveTabsChange(fn: (t: TabPresence[]) => void): Unsubscribe { this.#tabsHandlers.add(fn); return () => this.#tabsHandlers.delete(fn) }
+
+  dispose(): void {
+    if (this.#disposed) return
+    this.#disposed = true
+    this.#releaseLock?.()
+    this.#ac?.abort()
+    if (this.#timer) clearInterval(this.#timer)
+    this.#unsub?.()
+    this.#setRole('unknown')
+  }
+
+  /** @internal test seam — broadcast one heartbeat now. */
+  _beat(): void { this.#beat() }
+
+  #beat(): void {
+    if (!this.#channel || !this.#channel.isOpen) return
+    const msg: PresenceMsg = { kind: 'tab-presence', tabId: this.tabId, lastSeen: this.#now(), role: this.role }
+    this.#channel.send(JSON.stringify(msg))
+  }
+
+  #onMessage(payload: string): void {
+    let msg: unknown
+    try { msg = JSON.parse(payload) } catch { return }
+    if (!isPresenceMsg(msg) || msg.tabId === this.tabId) return
+    this.#peers.set(msg.tabId, { tabId: msg.tabId, lastSeen: msg.lastSeen, role: msg.role })
+    this.#emitTabs()
+  }
+
+  #setRole(role: TabRole): void {
+    if (this.role === role) return
+    this.role = role
+    for (const h of this.#roleHandlers) h(role)
+    this.#beat() // announce promptly
+  }
+
+  #emitTabs(): void {
+    const tabs = this.activeTabs()
+    for (const h of this.#tabsHandlers) h(tabs)
+  }
+}
+
+function isPresenceMsg(x: unknown): x is PresenceMsg {
+  if (x === null || typeof x !== 'object') return false
+  const o = x as Record<string, unknown>
+  return o['kind'] === 'tab-presence' && typeof o['tabId'] === 'string' && typeof o['lastSeen'] === 'number'
+}
+
+function cheapRand(): string {
+  // Non-crypto, non-Date id suffix for a default tabId; callers pass a stable tabId in tests.
+  const g = globalThis as { crypto?: { randomUUID?: () => string } }
+  return g.crypto?.randomUUID ? g.crypto.randomUUID().slice(0, 8) : 'anon'
+}
+
+/** Browser default lock manager (navigator.locks) or undefined. */
+export function defaultLockManager(): TabLockManager | undefined {
+  const nav = (globalThis as { navigator?: { locks?: TabLockManager } }).navigator
+  return nav?.locks
+}
+
+/** Browser default channel: an inline BroadcastChannel wrapper, or undefined. */
+export function defaultChannel(name = 'noydb:tabs'): TabChannel | undefined {
+  const Bc = (globalThis as { BroadcastChannel?: typeof BroadcastChannel }).BroadcastChannel
+  if (!Bc) return undefined
+  const bc = new Bc(name)
+  const msgListeners = new Set<(p: string) => void>()
+  bc.onmessage = (e: MessageEvent) => { for (const l of msgListeners) l(String(e.data)) }
+  return {
+    isOpen: true,
+    send(payload) { bc.postMessage(payload) },
+    on(event, listener) {
+      if (event === 'message') { const l = listener as (p: string) => void; msgListeners.add(l); return () => msgListeners.delete(l) }
+      return () => {}
+    },
+    close() { msgListeners.clear(); bc.close() },
+  }
+}
+```
+
+(`Math.trunc`/`cheapRand` are fine in library code; only workflow *scripts* forbid `Date.now`/`Math.random` — and tests pass an explicit `tabId`/`now` so determinism holds.)
+
+- [ ] **Step 4: Run → pass** (`cd packages/hub && npx vitest run __tests__/tab-coordination.test.ts`) — 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/vicio/_github/noy-db && git add packages/hub/src/tab-coordination.ts packages/hub/__tests__/tab-coordination.test.ts
+git commit -m "feat(hub): TabCoordinator — Web-Locks election + presence heartbeat (#228)"
+```
+
+---
+
+## Task 2: Wire `enableTabCoordination` into Noydb
+
+**Files:** Modify `packages/hub/src/noydb.ts`; Test `packages/hub/__tests__/tab-coordination-noydb.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { memory } from '../../to-memory/src/index.js'
+import type { TabLockManager, TabChannel } from '../src/tab-coordination.js'
+
+describe('db.enableTabCoordination (#228)', () => {
+  it('no-op outside a browser: returns a disposer; role stays unknown', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'tab-pass-1234' })
+    const handle = db.enableTabCoordination() // no navigator.locks / BroadcastChannel in node
+    expect(db.tabRole).toBe('unknown')
+    expect(db.activeTabs()).toEqual([])
+    handle.dispose()
+  })
+
+  it('with injected lock manager + channel, becomes primary', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'tab-pass-1234' })
+    let resolveCb: (() => void) | undefined
+    const locks: TabLockManager = {
+      async request(_n, _o, cb) { return cb(undefined) }, // acquire immediately
+    }
+    const channel: TabChannel = { isOpen: true, send() {}, on() { return () => {} }, close() {} }
+    const handle = db.enableTabCoordination({ lockManager: locks, channel, tabId: 't1' })
+    await new Promise((r) => setTimeout(r, 0))
+    expect(db.tabRole).toBe('primary')
+    void resolveCb
+    handle.dispose()
+  })
+})
+```
+
+- [ ] **Step 2: Run → fail**
+
+- [ ] **Step 3: Implement** — in `noydb.ts`:
+
+Import:
+```ts
+import { TabCoordinator, defaultLockManager, defaultChannel, type TabCoordinationOptions, type TabRole, type TabPresence, type Unsubscribe } from './tab-coordination.js'
+```
+Field (beside the other coordinators):
+```ts
+  #tabCoordinator: TabCoordinator | undefined
+```
+Public API (in the Events section):
+```ts
+  /**
+   * Enable same-device multi-tab coordination (#228): primary/secondary
+   * election + presence. Browser-only — a graceful no-op (role 'unknown')
+   * when Web Locks / BroadcastChannel are unavailable and nothing is
+   * injected. Idempotent; returns a disposer.
+   */
+  enableTabCoordination(opts: TabCoordinationOptions = {}): { dispose: () => void } {
+    if (this.#tabCoordinator) return { dispose: () => this.#disableTabCoordination() }
+    const c = new TabCoordinator({
+      ...opts,
+      lockManager: opts.lockManager ?? defaultLockManager(),
+      channel: opts.channel ?? defaultChannel(),
+    })
+    this.#tabCoordinator = c
+    c.start()
+    return { dispose: () => this.#disableTabCoordination() }
+  }
+
+  #disableTabCoordination(): void {
+    this.#tabCoordinator?.dispose()
+    this.#tabCoordinator = undefined
+  }
+
+  get tabRole(): TabRole { return this.#tabCoordinator?.role ?? 'unknown' }
+  activeTabs(): TabPresence[] { return this.#tabCoordinator?.activeTabs() ?? [] }
+  onTabRoleChange(fn: (r: TabRole) => void): Unsubscribe { return this.#tabCoordinator?.onTabRoleChange(fn) ?? (() => {}) }
+  onActiveTabsChange(fn: (t: TabPresence[]) => void): Unsubscribe { return this.#tabCoordinator?.onActiveTabsChange(fn) ?? (() => {}) }
+```
+In `close()` (the instance teardown — `grep -n "async close\|close()" src/noydb.ts`), add `this.#disableTabCoordination()` so the lock/heartbeat stop.
+
+- [ ] **Step 4: Run → pass; typecheck**
+
+Run: `cd packages/hub && npx vitest run __tests__/tab-coordination-noydb.test.ts && npx tsc --noEmit`
+Expected: PASS, clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/vicio/_github/noy-db && git add packages/hub/src/noydb.ts packages/hub/__tests__/tab-coordination-noydb.test.ts
+git commit -m "feat(hub): db.enableTabCoordination + tabRole/activeTabs surface (#228)"
+```
+
+---
+
+## Task 3: Export types + features.yaml + final verify
+
+**Files:** Modify `packages/hub/src/index.ts`, `features.yaml`
+
+- [ ] **Step 1: Export public types** (`index.ts`, near the other coordination exports):
+```ts
+// Multi-tab coordination (#228)
+export type { TabRole, TabPresence, TabCoordinationOptions } from './tab-coordination.js'
+```
+
+- [ ] **Step 2: features.yaml entry** (mirror `dry-run-transactions`):
+```yaml
+  - id: tab-coordination
+    name: Multi-tab coordination (presence + roles)
+    cluster: core
+    spec: docs/superpowers/specs/2026-06-01-228-tab-coordination-design.md
+    subsystem_doc: docs/superpowers/specs/2026-06-01-228-tab-coordination-design.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'exactly one primary tab via an exclusive Web Lock; others secondary; re-elects on primary dispose'
+      - 'presence heartbeat lists active tabs; stale tabs (no heartbeat within staleMs) drop out'
+      - 'opt-in via db.enableTabCoordination(); graceful no-op (role unknown) outside browsers'
+    related: [vault-and-collections]
+```
+
+- [ ] **Step 3: Validate + full verify**
+```bash
+cd /Users/vicio/_github/noy-db && node scripts/validate-features.mjs
+cd packages/hub && npx vitest run && npx tsc --noEmit && npm run lint
+```
+Expected: validator PASS; full suite PASS (and vitest exits cleanly — the heartbeat timer is `unref()`'d and only starts when a channel is provided/available, so the existing suite — which never calls `enableTabCoordination` — starts none); typecheck + lint clean.
+
+- [ ] **Step 4: Commit + clean tree**
+```bash
+cd /Users/vicio/_github/noy-db && git add packages/hub/src/index.ts features.yaml
+git commit -m "chore(hub): export tab-coordination types; register feature (#228)"
+git status
+```
+
+---
+
+## Self-review checklist (already applied)
+
+- **Spec coverage:** election (primary/secondary + re-elect) → Task 1 tests 1-2; presence + stale drop → test 3; role-change emitter → test 4; no-op path → test 5 + Task 2 test 1; opt-in enable + disposer + getters → Task 2; type export → Task 3; existing-suite safety (opt-in, unref timer) → Task 3 note.
+- **Circular-dep avoidance:** hub defines its own `TabLockManager`/`TabChannel` (structural) + inline `defaultChannel` (BroadcastChannel wrapper) + `defaultLockManager` (navigator.locks) — **no import of `@noy-db/by-peer`/`by-tabs`** (they depend on hub). An app may still pass `tabsChannel()` (structurally compatible).
+- **Type consistency:** `TabRole`/`TabPresence`/`TabLockManager`/`TabChannel`/`TabCoordinationOptions`, `TabCoordinator.{start,dispose,activeTabs,onTabRoleChange,onActiveTabsChange,_beat,role,tabId}`, `enableTabCoordination`/`tabRole`/`activeTabs` consistent across tasks.
+- **Determinism:** injected `now` + explicit `_beat()` + stub lock manager + in-memory bus; no reliance on real timers/`navigator`. The one production timer is `unref()`'d and gated on a channel.
+- **Verify-before-trust:** Task 2 confirms the `close()` teardown site in noydb.ts. Real lookup.
+- **No placeholders:** every code step has complete code; every run step states command + expected result.

--- a/docs/superpowers/specs/2026-06-01-228-tab-coordination-design.md
+++ b/docs/superpowers/specs/2026-06-01-228-tab-coordination-design.md
@@ -1,0 +1,85 @@
+# Multi-tab coordination (#228) — design
+
+**Status:** decomposition + sub-slice (a) design · **Date:** 2026-06-01 · **Issue:** #228 · **Epic:** hub coordination
+
+Same-device, multi-tab coordination. Scoped to **browsers** — Web Locks (role election) + BroadcastChannel (presence/propagation), both same-origin. Cross-device is the sync engine's job, explicitly out of scope (per the issue's note). Opt-in and graceful no-op where those APIs are absent.
+
+## Sub-slice decomposition
+
+| Sub-slice | What | Builds on |
+|---|---|---|
+| **(a) presence + tab roles** | primary/secondary election + active-tab presence | this doc |
+| (b) cross-tab write propagation | primary broadcasts committed write diffs; secondaries apply to their in-memory view | (a) + #227 write-queue / #230 hooks |
+| (c) conflict detection | `WriteConflict` on `_v`-baseline divergence between tabs | (a) + (b) |
+
+Build order a → b → c. This doc details **(a)**; (b)/(c) get their own specs.
+
+---
+
+# Sub-slice (a): tab roles + presence
+
+**Goal:** Elect one primary tab (owns the write lock; others are secondary and re-elect when it closes) and publish a presence heartbeat so the app can see active tabs.
+
+## API
+
+Opt-in, returns a disposer (browser-only; no-op when Web Locks / BroadcastChannel are unavailable and nothing is injected):
+
+```ts
+db.enableTabCoordination(opts?: TabCoordinationOptions): { dispose(): void }
+
+interface TabCoordinationOptions {
+  readonly lockManager?: MinimalLockManager  // default: navigator.locks (browser)
+  readonly channel?: PeerChannel             // default: tabsChannel() (BroadcastChannel)
+  readonly tabId?: string                    // default: a fresh ULID
+  readonly lockName?: string                 // default: 'noydb:tab-primary'
+  readonly heartbeatMs?: number              // default: 2000
+  readonly staleMs?: number                  // default: 6000
+}
+
+// framework-agnostic getters/emitters (in-vue wraps into refs later)
+db.tabRole: TabRole                                  // 'primary' | 'secondary' | 'unknown'
+db.onTabRoleChange(fn: (role: TabRole) => void): Unsubscribe
+db.activeTabs(): TabPresence[]
+db.onActiveTabsChange(fn: (tabs: TabPresence[]) => void): Unsubscribe
+
+type TabRole = 'primary' | 'secondary' | 'unknown'
+interface TabPresence { readonly tabId: string; readonly lastSeen: number; readonly role: TabRole }
+```
+
+`MinimalLockManager` + `PeerChannel` are reused from `@noy-db/by-peer` (and `tabsChannel`/`isTabsChannelAvailable` from `@noy-db/by-tabs`).
+
+## Architecture
+
+A `TabCoordinator` (new, in hub core — small, browser-gated, lazily constructed by `enableTabCoordination`):
+
+- **Election (Web Locks).** Issues `lockManager.request(lockName, { mode: 'exclusive', signal }, cb)`. Set `role = 'secondary'` immediately after issuing (we either hold it imminently or are queued); when `cb` runs (lock acquired) set `role = 'primary'` and hold until dispose (the cb returns a promise resolved by `dispose()`). On `dispose()` before acquisition, the `AbortSignal` cancels the queued request. When a primary disposes/closes, its lock releases → the next queued tab's `cb` runs → it transitions to primary (emits `onTabRoleChange`). Mirrors `by-peer`'s `servePeerStore` leader-election, but standalone (no RPC).
+- **Presence (channel).** On a `heartbeatMs` interval, broadcast `{ kind: 'tab-presence', tabId, lastSeen: now, role }`. On receiving a peer heartbeat, upsert it; `activeTabs()` = self + peers with `lastSeen >= now - staleMs`, sorted by `tabId`. Broadcast immediately on role change too (so the set reflects promotion fast). Emit `onActiveTabsChange` when the active set changes.
+- **Hub surface.** `db.tabRole`/`activeTabs()` are getters reading the coordinator (or defaults `'unknown'`/`[]` when not enabled); `onTabRoleChange`/`onActiveTabsChange` are emitters. Enabling twice is idempotent (returns the same disposer / no-ops).
+- **No-op path.** If `opts.lockManager` is absent AND `navigator.locks` is undefined (Node/SSR), and/or no channel + `!isTabsChannelAvailable()`: `enableTabCoordination` returns a disposer but the coordinator stays inert (`role` 'unknown', `activeTabs()` []). This keeps server/test code that calls it harmless.
+
+## Determinism / testing
+
+In-process N-tab harness: N coordinators sharing **one stub `MinimalLockManager`** (FIFO exclusive queue, mirrors `by-peer`'s `createMockLocks`) + an in-memory **broadcast bus** of `PeerChannel`s (a tiny test helper: send → all other tabs receive). Heartbeats driven by an injected `now` + explicit `_beat()`/`_collect()` calls (no real timers). Assert:
+- First coordinator to acquire the lock = `primary`; the rest = `secondary`.
+- Disposing the primary promotes exactly one secondary to `primary` (role-change emitted).
+- Presence: each tab sees the others in `activeTabs()`; a tab whose `lastSeen` is older than `staleMs` drops out.
+- No-op path: with no lock manager + no channel, `enableTabCoordination()` returns a disposer, `tabRole` stays `'unknown'`, `activeTabs()` is `[]`.
+
+## Error handling / lifecycle
+
+- `dispose()` releases the lock (abort or resolve the held cb), stops the heartbeat timer, and unsubscribes the channel — idempotent.
+- A channel `close` event marks the coordinator inert (role 'unknown').
+- Enabling is **opt-in**; hubs that never call `enableTabCoordination()` start no timers/locks (existing suite untouched).
+
+## Scope
+
+**In (a):** election (primary/secondary + re-election), presence (activeTabs + heartbeat), the hub getters/emitters, opt-in enable + disposer, no-op path.
+
+**Out (later sub-slices / deferred):** cross-tab write-diff propagation → (b); `WriteConflict` detection → (c); the Vue `ref` wrappers (`useTabRole`/`useActiveTabs`) → a thin `in-vue` add after (a) lands; SharedWorker-based ordering (the issue floats it as an alternative — not pursued).
+
+## Success criteria
+
+1. Exactly one `primary` among N tabs; others `secondary`; disposing the primary promotes one secondary (role-change fired).
+2. `activeTabs()` lists live tabs with `{tabId, lastSeen, role}`; stale tabs (no heartbeat within `staleMs`) drop out.
+3. `enableTabCoordination()` is opt-in, returns a working `dispose()`, and is a safe no-op outside browsers (no throw, role `'unknown'`).
+4. Hubs that don't enable it incur zero new timers/locks — existing suite unaffected.

--- a/features.yaml
+++ b/features.yaml
@@ -877,6 +877,24 @@ features:
       - 'MV/derivation cascade is not simulated in v1 (direct ops only)'
     related: [transactions, guards]
 
+  - id: tab-coordination
+    name: Multi-tab coordination (presence + roles)
+    cluster: core
+    spec: docs/superpowers/specs/2026-06-01-228-tab-coordination-design.md
+    subsystem_doc: docs/superpowers/specs/2026-06-01-228-tab-coordination-design.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'exactly one primary tab via an exclusive Web Lock; others secondary; re-elects on primary dispose'
+      - 'presence heartbeat lists active tabs; stale tabs (no heartbeat within staleMs) drop out'
+      - 'opt-in via db.enableTabCoordination(); graceful no-op (role unknown) outside browsers'
+    related: [vault-and-collections]
+
 # ─── Storage adapters (phase 2) ──────────────────────────────────────
 
 adapters:

--- a/packages/hub/__tests__/tab-coordination-noydb.test.ts
+++ b/packages/hub/__tests__/tab-coordination-noydb.test.ts
@@ -14,7 +14,6 @@ describe('db.enableTabCoordination (#228)', () => {
 
   it('with injected lock manager + channel, becomes primary', async () => {
     const db = await createNoydb({ store: memory(), user: 'a', secret: 'tab-pass-1234' })
-    let resolveCb: (() => void) | undefined
     const locks: TabLockManager = {
       async request(_n, _o, cb) { return cb(undefined) }, // acquire immediately
     }
@@ -22,7 +21,15 @@ describe('db.enableTabCoordination (#228)', () => {
     const handle = db.enableTabCoordination({ lockManager: locks, channel, tabId: 't1' })
     await new Promise((r) => setTimeout(r, 0))
     expect(db.tabRole).toBe('primary')
-    void resolveCb
     handle.dispose()
+  })
+
+  it('does not close a caller-injected channel on dispose', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'tab-pass-1234' })
+    let closed = 0
+    const channel: TabChannel = { isOpen: true, send() {}, on() { return () => {} }, close() { closed++ } }
+    const handle = db.enableTabCoordination({ channel, tabId: 't1' })
+    handle.dispose()
+    expect(closed).toBe(0) // the coordinator must not close a channel it didn't create
   })
 })

--- a/packages/hub/__tests__/tab-coordination-noydb.test.ts
+++ b/packages/hub/__tests__/tab-coordination-noydb.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { memory } from '../../to-memory/src/index.js'
+import type { TabLockManager, TabChannel } from '../src/tab-coordination.js'
+
+describe('db.enableTabCoordination (#228)', () => {
+  it('no-op outside a browser: returns a disposer; role stays unknown', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'tab-pass-1234' })
+    const handle = db.enableTabCoordination() // no navigator.locks / BroadcastChannel in node
+    expect(db.tabRole).toBe('unknown')
+    expect(db.activeTabs()).toEqual([])
+    handle.dispose()
+  })
+
+  it('with injected lock manager + channel, becomes primary', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'tab-pass-1234' })
+    let resolveCb: (() => void) | undefined
+    const locks: TabLockManager = {
+      async request(_n, _o, cb) { return cb(undefined) }, // acquire immediately
+    }
+    const channel: TabChannel = { isOpen: true, send() {}, on() { return () => {} }, close() {} }
+    const handle = db.enableTabCoordination({ lockManager: locks, channel, tabId: 't1' })
+    await new Promise((r) => setTimeout(r, 0))
+    expect(db.tabRole).toBe('primary')
+    void resolveCb
+    handle.dispose()
+  })
+})

--- a/packages/hub/__tests__/tab-coordination.test.ts
+++ b/packages/hub/__tests__/tab-coordination.test.ts
@@ -121,4 +121,56 @@ describe('TabCoordinator', () => {
     expect(c.activeTabs()).toEqual([])
     c.dispose()
   })
+
+  it('disposing a tab does not broadcast a phantom heartbeat', async () => {
+    const locks = mockLocks()
+    const bus = makeBus(2)
+    let t = 1000
+    const [a, b] = bus.map((ch, i) => mkCoordinator(locks, ch, `tab${i}`, () => t))
+    a!.start(); b!.start()
+    await flush()
+    a!._beat(); b!._beat()
+    await flush()
+    b!.dispose()
+    await flush()
+    // No phantom 'unknown' refresh into a's view of tab1.
+    const after = a!.activeTabs().find((p) => p.tabId === 'tab1')
+    expect(after?.role).not.toBe('unknown')
+  })
+
+  it('goes inert (role unknown) when the channel closes', async () => {
+    const locks = mockLocks()
+    let closeListener: (() => void) | undefined
+    const channel: TabChannel = {
+      isOpen: true,
+      send() {},
+      on(event, l) {
+        if (event === 'close') { closeListener = l as () => void; return () => { closeListener = undefined } }
+        return () => {}
+      },
+      close() {},
+    }
+    let t = 1000
+    const c = new TabCoordinator({ lockManager: locks, channel, tabId: 't0', heartbeatMs: 1_000_000, staleMs: 500, now: () => t })
+    c.start()
+    await flush()
+    expect(c.role).toBe('primary')
+    closeListener?.()
+    expect(c.role).toBe('unknown')
+    c.dispose()
+  })
+
+  it('emits onActiveTabsChange when a peer appears', async () => {
+    const locks = mockLocks()
+    const bus = makeBus(2)
+    let t = 1000
+    const [a, b] = bus.map((ch, i) => mkCoordinator(locks, ch, `tab${i}`, () => t))
+    const seen: number[] = []
+    a!.onActiveTabsChange((tabs) => seen.push(tabs.length))
+    a!.start(); b!.start()
+    await flush()
+    b!._beat()
+    await flush()
+    expect(seen.some((n) => n >= 2)).toBe(true)
+  })
 })

--- a/packages/hub/__tests__/tab-coordination.test.ts
+++ b/packages/hub/__tests__/tab-coordination.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import { TabCoordinator, type TabLockManager, type TabChannel } from '../src/tab-coordination.js'
+
+/** FIFO exclusive lock manager (mirrors by-peer's createMockLocks). */
+function mockLocks(): TabLockManager {
+  const held = new Set<string>()
+  const queues = new Map<string, Array<() => void>>()
+  async function pump(name: string) {
+    if (held.has(name)) return
+    const q = queues.get(name) ?? []
+    const next = q.shift()
+    if (!next) return
+    held.add(name)
+    next()
+  }
+  return {
+    request(name, _opts, cb) {
+      return new Promise((resolve, reject) => {
+        const run = () => {
+          void Promise.resolve()
+            .then(() => cb(undefined))
+            .then((v) => { held.delete(name); void pump(name); resolve(v as never) },
+                  (e) => { held.delete(name); void pump(name); reject(e) })
+        }
+        const q = queues.get(name) ?? []
+        q.push(run); queues.set(name, q)
+        // abort: drop from queue if still waiting
+        _opts.signal?.addEventListener('abort', () => {
+          const qq = queues.get(name) ?? []
+          const i = qq.indexOf(run); if (i >= 0) qq.splice(i, 1)
+          reject(new Error('aborted'))
+        })
+        void pump(name)
+      })
+    },
+  }
+}
+
+/** In-memory broadcast bus: each channel's send() reaches all OTHER channels. */
+function makeBus(n: number): TabChannel[] {
+  const listeners: Array<((p: string) => void) | null> = []
+  const chans: TabChannel[] = []
+  for (let i = 0; i < n; i++) {
+    const idx = i
+    chans.push({
+      isOpen: true,
+      send(payload) { for (let j = 0; j < listeners.length; j++) if (j !== idx && listeners[j]) queueMicrotask(() => listeners[j]!(payload)) },
+      on(event, l) { if (event === 'message') { listeners[idx] = l as (p: string) => void; return () => { listeners[idx] = null } } return () => {} },
+      close() { listeners[idx] = null },
+    })
+  }
+  return chans
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+function mkCoordinator(lockManager: TabLockManager, channel: TabChannel, tabId: string, now: () => number) {
+  return new TabCoordinator({ lockManager, channel, tabId, heartbeatMs: 1_000_000, staleMs: 500, now })
+}
+
+describe('TabCoordinator', () => {
+  it('elects exactly one primary; the rest are secondary', async () => {
+    const locks = mockLocks()
+    const bus = makeBus(3)
+    let t = 1000
+    const tabs = bus.map((ch, i) => mkCoordinator(locks, ch, `tab${i}`, () => t))
+    tabs.forEach((c) => c.start())
+    await flush()
+    const roles = tabs.map((c) => c.role).sort()
+    expect(roles.filter((r) => r === 'primary')).toHaveLength(1)
+    expect(roles.filter((r) => r === 'secondary')).toHaveLength(2)
+  })
+
+  it('promotes a secondary when the primary disposes', async () => {
+    const locks = mockLocks()
+    const bus = makeBus(2)
+    let t = 1000
+    const tabs = bus.map((ch, i) => mkCoordinator(locks, ch, `tab${i}`, () => t))
+    tabs.forEach((c) => c.start())
+    await flush()
+    const primary = tabs.find((c) => c.role === 'primary')!
+    const secondary = tabs.find((c) => c.role === 'secondary')!
+    primary.dispose()
+    await flush()
+    expect(secondary.role).toBe('primary')
+  })
+
+  it('presence: a tab sees the others; stale tabs drop out', async () => {
+    const locks = mockLocks()
+    const bus = makeBus(2)
+    let t = 1000
+    const [a, b] = bus.map((ch, i) => mkCoordinator(locks, ch, `tab${i}`, () => t))
+    a!.start(); b!.start()
+    await flush()
+    a!._beat(); b!._beat()
+    await flush()
+    expect(a!.activeTabs().map((p) => p.tabId).sort()).toEqual(['tab0', 'tab1'])
+    t += 10_000 // advance past staleMs; b never beats again
+    a!._beat()
+    await flush()
+    expect(a!.activeTabs().map((p) => p.tabId)).toEqual(['tab0'])
+  })
+
+  it('emits onTabRoleChange', async () => {
+    const locks = mockLocks()
+    const bus = makeBus(1)
+    let t = 1000
+    const c = mkCoordinator(locks, bus[0]!, 'tab0', () => t)
+    const seen: string[] = []
+    c.onTabRoleChange((r) => seen.push(r))
+    c.start()
+    await flush()
+    expect(seen).toContain('primary')
+  })
+
+  it('no-op when no lock manager and no channel', async () => {
+    const c = new TabCoordinator({ heartbeatMs: 1_000_000, staleMs: 500, now: () => 0 })
+    c.start()
+    await flush()
+    expect(c.role).toBe('unknown')
+    expect(c.activeTabs()).toEqual([])
+    c.dispose()
+  })
+})

--- a/packages/hub/__tests__/tab-coordination.test.ts
+++ b/packages/hub/__tests__/tab-coordination.test.ts
@@ -173,4 +173,19 @@ describe('TabCoordinator', () => {
     await flush()
     expect(seen.some((n) => n >= 2)).toBe(true)
   })
+
+  it('closes the channel on dispose only when it owns it', async () => {
+    const locks = mockLocks()
+    let ownedClosed = 0
+    const ownedCh: TabChannel = { isOpen: true, send() {}, on() { return () => {} }, close() { ownedClosed++ } }
+    const owned = new TabCoordinator({ lockManager: locks, channel: ownedCh, tabId: 'o', closeChannelOnDispose: true, heartbeatMs: 1_000_000, staleMs: 500, now: () => 0 })
+    owned.start(); await flush(); owned.dispose()
+    expect(ownedClosed).toBe(1)
+
+    let injectedClosed = 0
+    const injectedCh: TabChannel = { isOpen: true, send() {}, on() { return () => {} }, close() { injectedClosed++ } }
+    const injected = new TabCoordinator({ lockManager: locks, channel: injectedCh, tabId: 'i', heartbeatMs: 1_000_000, staleMs: 500, now: () => 0 })
+    injected.start(); await flush(); injected.dispose()
+    expect(injectedClosed).toBe(0)
+  })
 })

--- a/packages/hub/__tests__/tab-coordination.test.ts
+++ b/packages/hub/__tests__/tab-coordination.test.ts
@@ -80,9 +80,12 @@ describe('TabCoordinator', () => {
     await flush()
     const primary = tabs.find((c) => c.role === 'primary')!
     const secondary = tabs.find((c) => c.role === 'secondary')!
+    const roleChanges: string[] = []
+    secondary.onTabRoleChange((r) => roleChanges.push(r))
     primary.dispose()
     await flush()
     expect(secondary.role).toBe('primary')
+    expect(roleChanges).toContain('primary') // criterion 1: role-change fired on re-election
   })
 
   it('presence: a tab sees the others; stale tabs drop out', async () => {

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -182,7 +182,7 @@ export type { SchemaIntrospection } from './introspection/types.js'
 export type { DryRunResult, AffectedDocument, GuardViolation } from './tx/dry-run.js'
 
 // Multi-tab coordination (#228)
-export type { TabRole, TabPresence, TabCoordinationOptions } from './tab-coordination.js'
+export type { TabRole, TabPresence, TabCoordinationOptions, TabLockManager, TabChannel } from './tab-coordination.js'
 
 // Schema-update strategies (#245)
 export type {

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -181,6 +181,9 @@ export type { SchemaIntrospection } from './introspection/types.js'
 // Dry-run transactions (#231)
 export type { DryRunResult, AffectedDocument, GuardViolation } from './tx/dry-run.js'
 
+// Multi-tab coordination (#228)
+export type { TabRole, TabPresence, TabCoordinationOptions } from './tab-coordination.js'
+
 // Schema-update strategies (#245)
 export type {
   SchemaDelta,

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -1205,6 +1205,8 @@ export class Noydb {
       ...opts,
       ...(lockManager ? { lockManager } : {}),
       ...(channel ? { channel } : {}),
+      // We own the channel only when we created the default; never close a caller-injected one.
+      closeChannelOnDispose: opts.channel === undefined,
     })
     this.tabCoordinator = c
     c.start()

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -1206,7 +1206,7 @@ export class Noydb {
       ...(lockManager ? { lockManager } : {}),
       ...(channel ? { channel } : {}),
       // We own the channel only when we created the default; never close a caller-injected one.
-      closeChannelOnDispose: opts.channel === undefined,
+      closeChannelOnDispose: opts.channel === undefined && channel !== undefined,
     })
     this.tabCoordinator = c
     c.start()

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -78,6 +78,7 @@ import { Vault } from './vault.js'
 import { NoydbEventEmitter } from './events.js'
 import { WriteQueueTracker, type WriteQueue } from './write-queue.js'
 import { WriteHookRegistry, type WriteHook, type Unsubscribe } from './write-hooks.js'
+import { TabCoordinator, defaultLockManager, defaultChannel, type TabCoordinationOptions, type TabRole, type TabPresence } from './tab-coordination.js'
 import {
   loadKeyring,
   createOwnerKeyring,
@@ -190,6 +191,8 @@ export class Noydb {
   private readonly publicEnvelopeSchema: ResolvedPublicEnvelopeSchema | undefined
   private closed = false
   private sessionTimer: ReturnType<typeof setTimeout> | null = null
+  /** Same-device multi-tab coordinator (#228); created on `enableTabCoordination()`. */
+  private tabCoordinator: TabCoordinator | undefined
   /** Per-vault policy enforcers. */
   private readonly policyEnforcers = new Map<string, PolicyEnforcer>()
   private readonly txStrategy: TxStrategy
@@ -1188,6 +1191,36 @@ export class Noydb {
     return this.writeHooks.onAfterWrite(handler)
   }
 
+  /**
+   * Enable same-device multi-tab coordination (#228): primary/secondary
+   * election + presence. Browser-only — a graceful no-op (role 'unknown')
+   * when Web Locks / BroadcastChannel are unavailable and nothing is
+   * injected. Idempotent; returns a disposer.
+   */
+  enableTabCoordination(opts: TabCoordinationOptions = {}): { dispose: () => void } {
+    if (this.tabCoordinator) return { dispose: () => this.disableTabCoordination() }
+    const lockManager = opts.lockManager ?? defaultLockManager()
+    const channel = opts.channel ?? defaultChannel()
+    const c = new TabCoordinator({
+      ...opts,
+      ...(lockManager ? { lockManager } : {}),
+      ...(channel ? { channel } : {}),
+    })
+    this.tabCoordinator = c
+    c.start()
+    return { dispose: () => this.disableTabCoordination() }
+  }
+
+  private disableTabCoordination(): void {
+    this.tabCoordinator?.dispose()
+    this.tabCoordinator = undefined
+  }
+
+  get tabRole(): TabRole { return this.tabCoordinator?.role ?? 'unknown' }
+  activeTabs(): TabPresence[] { return this.tabCoordinator?.activeTabs() ?? [] }
+  onTabRoleChange(fn: (r: TabRole) => void): Unsubscribe { return this.tabCoordinator?.onTabRoleChange(fn) ?? (() => {}) }
+  onActiveTabsChange(fn: (t: TabPresence[]) => void): Unsubscribe { return this.tabCoordinator?.onActiveTabsChange(fn) ?? (() => {}) }
+
   /** @internal The write-hook registry, threaded into each Collection. */
   get _writeHooks(): WriteHookRegistry {
     return this.writeHooks
@@ -1257,6 +1290,7 @@ export class Noydb {
     }
     this.syncEngines.clear()
     for (const v of this.vaultCache.values()) v._stopFenceCoordination() // #232 — stop heartbeat/watcher timers
+    this.disableTabCoordination() // #228 — stop tab lock/heartbeat timers
     this.keyringCache.clear()
     this.vaultCache.clear()
     this.activeTier.clear()

--- a/packages/hub/src/tab-coordination.ts
+++ b/packages/hub/src/tab-coordination.ts
@@ -31,6 +31,13 @@ export interface TabCoordinationOptions {
   readonly heartbeatMs?: number
   readonly staleMs?: number
   readonly now?: () => number
+  /**
+   * Close the channel on `dispose()`. Set this only for a channel the
+   * coordinator owns (e.g. the one `defaultChannel()` created); leave it
+   * false for a caller-injected channel so the coordinator never closes a
+   * channel it didn't create. Default: false.
+   */
+  readonly closeChannelOnDispose?: boolean
 }
 
 interface PresenceMsg { readonly kind: 'tab-presence'; readonly tabId: string; readonly lastSeen: number; readonly role: TabRole }
@@ -52,6 +59,7 @@ export class TabCoordinator {
   #unsub: Unsubscribe | undefined
   #closeUnsub: Unsubscribe | undefined
   #timer: ReturnType<typeof setInterval> | undefined
+  readonly #ownsChannel: boolean
   #started = false
   #disposed = false
   #lastTabsSig = ''
@@ -64,6 +72,7 @@ export class TabCoordinator {
     this.#heartbeatMs = opts.heartbeatMs ?? 2_000
     this.#staleMs = opts.staleMs ?? 6_000
     this.#now = opts.now ?? (() => Date.now())
+    this.#ownsChannel = opts.closeChannelOnDispose ?? false
   }
 
   start(): void {
@@ -108,6 +117,7 @@ export class TabCoordinator {
     if (this.#timer) { clearInterval(this.#timer); this.#timer = undefined }
     this.#unsub?.()
     this.#closeUnsub?.()
+    if (this.#ownsChannel) this.#channel?.close()
     this.#setRole('unknown')
   }
 

--- a/packages/hub/src/tab-coordination.ts
+++ b/packages/hub/src/tab-coordination.ts
@@ -186,6 +186,11 @@ export function defaultLockManager(): TabLockManager | undefined {
 
 /** Browser default channel: an inline BroadcastChannel wrapper, or undefined. */
 export function defaultChannel(name = 'noydb:tabs'): TabChannel | undefined {
+  // Gate on `window` — a real browser signal. Modern Node exposes a global
+  // BroadcastChannel (worker_threads), so presence of the constructor alone is
+  // NOT a browser signal; without this gate we'd start a heartbeat in Node.
+  // Symmetric with defaultLockManager()'s navigator gate.
+  if (typeof (globalThis as { window?: unknown }).window === 'undefined') return undefined
   const Bc = (globalThis as { BroadcastChannel?: typeof BroadcastChannel }).BroadcastChannel
   if (!Bc) return undefined
   const bc = new Bc(name)

--- a/packages/hub/src/tab-coordination.ts
+++ b/packages/hub/src/tab-coordination.ts
@@ -1,0 +1,172 @@
+/**
+ * Multi-tab coordination (#228a): primary/secondary election (Web Locks)
+ * + presence heartbeat (BroadcastChannel). Browser-only; opt-in; no-op
+ * when the APIs are absent. The lock/channel interfaces are hub-local
+ * (structurally compatible with @noy-db/by-peer + @noy-db/by-tabs, but
+ * not imported — those packages depend on hub).
+ */
+export type TabRole = 'primary' | 'secondary' | 'unknown'
+export interface TabPresence { readonly tabId: string; readonly lastSeen: number; readonly role: TabRole }
+export type Unsubscribe = () => void
+
+/** Structural subset of the Web Locks API / by-peer's MinimalLockManager. */
+export interface TabLockManager {
+  request<T>(name: string, options: { mode?: 'exclusive' | 'shared'; signal?: AbortSignal }, callback: (lock: unknown) => Promise<T>): Promise<T>
+}
+
+/** Structural subset of by-peer's PeerChannel / a BroadcastChannel wrapper. */
+export interface TabChannel {
+  send(payload: string): void
+  on(event: 'message', listener: (payload: string) => void): Unsubscribe
+  on(event: 'close', listener: () => void): Unsubscribe
+  close(): void
+  readonly isOpen: boolean
+}
+
+export interface TabCoordinationOptions {
+  readonly lockManager?: TabLockManager
+  readonly channel?: TabChannel
+  readonly tabId?: string
+  readonly lockName?: string
+  readonly heartbeatMs?: number
+  readonly staleMs?: number
+  readonly now?: () => number
+}
+
+interface PresenceMsg { readonly kind: 'tab-presence'; readonly tabId: string; readonly lastSeen: number; readonly role: TabRole }
+
+export class TabCoordinator {
+  readonly tabId: string
+  role: TabRole = 'unknown'
+  readonly #lockManager: TabLockManager | undefined
+  readonly #channel: TabChannel | undefined
+  readonly #lockName: string
+  readonly #heartbeatMs: number
+  readonly #staleMs: number
+  readonly #now: () => number
+  readonly #peers = new Map<string, TabPresence>()
+  readonly #roleHandlers = new Set<(r: TabRole) => void>()
+  readonly #tabsHandlers = new Set<(t: TabPresence[]) => void>()
+  #ac: AbortController | undefined
+  #releaseLock: (() => void) | undefined
+  #unsub: Unsubscribe | undefined
+  #timer: ReturnType<typeof setInterval> | undefined
+  #disposed = false
+
+  constructor(opts: TabCoordinationOptions = {}) {
+    this.tabId = opts.tabId ?? `tab-${Math.trunc((opts.now ?? (() => 0))())}-${cheapRand()}`
+    this.#lockManager = opts.lockManager
+    this.#channel = opts.channel
+    this.#lockName = opts.lockName ?? 'noydb:tab-primary'
+    this.#heartbeatMs = opts.heartbeatMs ?? 2_000
+    this.#staleMs = opts.staleMs ?? 6_000
+    this.#now = opts.now ?? (() => Date.now())
+  }
+
+  start(): void {
+    if (this.#disposed) return
+    if (this.#channel) {
+      this.#unsub = this.#channel.on('message', (p) => this.#onMessage(p))
+      this.#beat()
+      this.#timer = setInterval(() => this.#beat(), this.#heartbeatMs)
+      const t = this.#timer as unknown as { unref?: () => void }
+      if (typeof t.unref === 'function') t.unref()
+    }
+    if (this.#lockManager) {
+      this.#ac = new AbortController()
+      this.#setRole('secondary')
+      void this.#lockManager
+        .request(this.#lockName, { mode: 'exclusive', signal: this.#ac.signal }, () => {
+          this.#setRole('primary')
+          return new Promise<void>((resolve) => { this.#releaseLock = resolve })
+        })
+        .catch(() => { /* aborted on dispose */ })
+    }
+  }
+
+  activeTabs(): TabPresence[] {
+    if (!this.#channel) return []
+    const cutoff = this.#now() - this.#staleMs
+    const self: TabPresence = { tabId: this.tabId, lastSeen: this.#now(), role: this.role }
+    const out = [self, ...[...this.#peers.values()].filter((p) => p.lastSeen >= cutoff)]
+    return out.sort((a, b) => a.tabId.localeCompare(b.tabId))
+  }
+
+  onTabRoleChange(fn: (r: TabRole) => void): Unsubscribe { this.#roleHandlers.add(fn); return () => this.#roleHandlers.delete(fn) }
+  onActiveTabsChange(fn: (t: TabPresence[]) => void): Unsubscribe { this.#tabsHandlers.add(fn); return () => this.#tabsHandlers.delete(fn) }
+
+  dispose(): void {
+    if (this.#disposed) return
+    this.#disposed = true
+    this.#releaseLock?.()
+    this.#ac?.abort()
+    if (this.#timer) clearInterval(this.#timer)
+    this.#unsub?.()
+    this.#setRole('unknown')
+  }
+
+  /** @internal test seam — broadcast one heartbeat now. */
+  _beat(): void { this.#beat() }
+
+  #beat(): void {
+    if (!this.#channel || !this.#channel.isOpen) return
+    const msg: PresenceMsg = { kind: 'tab-presence', tabId: this.tabId, lastSeen: this.#now(), role: this.role }
+    this.#channel.send(JSON.stringify(msg))
+  }
+
+  #onMessage(payload: string): void {
+    let msg: unknown
+    try { msg = JSON.parse(payload) } catch { return }
+    if (!isPresenceMsg(msg) || msg.tabId === this.tabId) return
+    this.#peers.set(msg.tabId, { tabId: msg.tabId, lastSeen: msg.lastSeen, role: msg.role })
+    this.#emitTabs()
+  }
+
+  #setRole(role: TabRole): void {
+    if (this.role === role) return
+    this.role = role
+    for (const h of this.#roleHandlers) h(role)
+    this.#beat() // announce promptly
+  }
+
+  #emitTabs(): void {
+    const tabs = this.activeTabs()
+    for (const h of this.#tabsHandlers) h(tabs)
+  }
+}
+
+function isPresenceMsg(x: unknown): x is PresenceMsg {
+  if (x === null || typeof x !== 'object') return false
+  const o = x as Record<string, unknown>
+  return o['kind'] === 'tab-presence' && typeof o['tabId'] === 'string' && typeof o['lastSeen'] === 'number'
+}
+
+function cheapRand(): string {
+  // Non-crypto, non-Date id suffix for a default tabId; callers pass a stable tabId in tests.
+  const g = globalThis as { crypto?: { randomUUID?: () => string } }
+  return g.crypto?.randomUUID ? g.crypto.randomUUID().slice(0, 8) : 'anon'
+}
+
+/** Browser default lock manager (navigator.locks) or undefined. */
+export function defaultLockManager(): TabLockManager | undefined {
+  const nav = (globalThis as { navigator?: { locks?: TabLockManager } }).navigator
+  return nav?.locks
+}
+
+/** Browser default channel: an inline BroadcastChannel wrapper, or undefined. */
+export function defaultChannel(name = 'noydb:tabs'): TabChannel | undefined {
+  const Bc = (globalThis as { BroadcastChannel?: typeof BroadcastChannel }).BroadcastChannel
+  if (!Bc) return undefined
+  const bc = new Bc(name)
+  const msgListeners = new Set<(p: string) => void>()
+  bc.onmessage = (e: MessageEvent) => { for (const l of msgListeners) l(String(e.data)) }
+  return {
+    isOpen: true,
+    send(payload) { bc.postMessage(payload) },
+    on(event, listener) {
+      if (event === 'message') { const l = listener as (p: string) => void; msgListeners.add(l); return () => msgListeners.delete(l) }
+      return () => {}
+    },
+    close() { msgListeners.clear(); bc.close() },
+  }
+}

--- a/packages/hub/src/tab-coordination.ts
+++ b/packages/hub/src/tab-coordination.ts
@@ -50,8 +50,11 @@ export class TabCoordinator {
   #ac: AbortController | undefined
   #releaseLock: (() => void) | undefined
   #unsub: Unsubscribe | undefined
+  #closeUnsub: Unsubscribe | undefined
   #timer: ReturnType<typeof setInterval> | undefined
+  #started = false
   #disposed = false
+  #lastTabsSig = ''
 
   constructor(opts: TabCoordinationOptions = {}) {
     this.tabId = opts.tabId ?? `tab-${Math.trunc((opts.now ?? (() => 0))())}-${cheapRand()}`
@@ -64,11 +67,13 @@ export class TabCoordinator {
   }
 
   start(): void {
-    if (this.#disposed) return
+    if (this.#disposed || this.#started) return
+    this.#started = true
     if (this.#channel) {
       this.#unsub = this.#channel.on('message', (p) => this.#onMessage(p))
+      this.#closeUnsub = this.#channel.on('close', () => this.#onChannelClose())
       this.#beat()
-      this.#timer = setInterval(() => this.#beat(), this.#heartbeatMs)
+      this.#timer = setInterval(() => this.#tick(), this.#heartbeatMs)
       const t = this.#timer as unknown as { unref?: () => void }
       if (typeof t.unref === 'function') t.unref()
     }
@@ -100,18 +105,31 @@ export class TabCoordinator {
     this.#disposed = true
     this.#releaseLock?.()
     this.#ac?.abort()
-    if (this.#timer) clearInterval(this.#timer)
+    if (this.#timer) { clearInterval(this.#timer); this.#timer = undefined }
     this.#unsub?.()
+    this.#closeUnsub?.()
     this.#setRole('unknown')
   }
 
   /** @internal test seam — broadcast one heartbeat now. */
   _beat(): void { this.#beat() }
 
+  #tick(): void {
+    this.#prune()
+    this.#emitTabs()
+    this.#beat()
+  }
+
   #beat(): void {
+    if (this.#disposed) return
     if (!this.#channel || !this.#channel.isOpen) return
     const msg: PresenceMsg = { kind: 'tab-presence', tabId: this.tabId, lastSeen: this.#now(), role: this.role }
     this.#channel.send(JSON.stringify(msg))
+  }
+
+  #onChannelClose(): void {
+    if (this.#timer) { clearInterval(this.#timer); this.#timer = undefined }
+    this.#setRole('unknown')
   }
 
   #onMessage(payload: string): void {
@@ -119,7 +137,13 @@ export class TabCoordinator {
     try { msg = JSON.parse(payload) } catch { return }
     if (!isPresenceMsg(msg) || msg.tabId === this.tabId) return
     this.#peers.set(msg.tabId, { tabId: msg.tabId, lastSeen: msg.lastSeen, role: msg.role })
+    this.#prune()
     this.#emitTabs()
+  }
+
+  #prune(): void {
+    const cutoff = this.#now() - this.#staleMs
+    for (const [id, p] of this.#peers) if (p.lastSeen < cutoff) this.#peers.delete(id)
   }
 
   #setRole(role: TabRole): void {
@@ -127,10 +151,14 @@ export class TabCoordinator {
     this.role = role
     for (const h of this.#roleHandlers) h(role)
     this.#beat() // announce promptly
+    this.#emitTabs()
   }
 
   #emitTabs(): void {
     const tabs = this.activeTabs()
+    const sig = tabs.map((t) => `${t.tabId}:${t.role}`).join('|')
+    if (sig === this.#lastTabsSig) return
+    this.#lastTabsSig = sig
     for (const h of this.#tabsHandlers) h(tabs)
   }
 }
@@ -138,7 +166,10 @@ export class TabCoordinator {
 function isPresenceMsg(x: unknown): x is PresenceMsg {
   if (x === null || typeof x !== 'object') return false
   const o = x as Record<string, unknown>
-  return o['kind'] === 'tab-presence' && typeof o['tabId'] === 'string' && typeof o['lastSeen'] === 'number'
+  return o['kind'] === 'tab-presence'
+    && typeof o['tabId'] === 'string'
+    && typeof o['lastSeen'] === 'number'
+    && (o['role'] === 'primary' || o['role'] === 'secondary' || o['role'] === 'unknown')
 }
 
 function cheapRand(): string {


### PR DESCRIPTION
## Summary

Sub-slice **(a)** of multi-client write coordination (#228): same-device, multi-tab **primary/secondary election** + **presence**. Browser-only, opt-in, graceful no-op everywhere else.

- **`TabCoordinator`** (`packages/hub/src/tab-coordination.ts`) — exclusive **Web Lock** = primary; queued tabs = secondary; re-elects on primary dispose. Presence **heartbeat** over `BroadcastChannel`; stale tabs (no beat within `staleMs`) drop out. Hub-local `TabLockManager`/`TabChannel` interfaces — structurally compatible with `@noy-db/by-peer` / `by-tabs` but **not imported** (those depend on hub; importing back = circular dep).
- **`db.enableTabCoordination(opts?)`** → disposer; getters `db.tabRole` / `db.activeTabs()` + emitters `onTabRoleChange` / `onActiveTabsChange`. Idempotent; `close()` tears it down.
- Exported types `TabRole` / `TabPresence` / `TabCoordinationOptions` / `TabLockManager` / `TabChannel`; `features.yaml` entry `tab-coordination`.

## Design / review notes

Three review rounds caught and fixed real issues before this PR:
- **dispose phantom heartbeat** — a goodbye-beat refreshed peers' `lastSeen`, leaving a disposed tab "alive" for `staleMs`; guarded `#beat()` on `#disposed`.
- **unwired `'close'`** — channel close now marks the coordinator inert (role `unknown`).
- **Node `BroadcastChannel` no-op leak** — Node ships a global `BroadcastChannel`, so `defaultChannel()` now gates on `typeof window`, symmetric with `defaultLockManager()`'s `navigator` gate.
- **own-vs-injected channel teardown** — `dispose()` closes only a channel the coordinator created, never a caller-injected one.

## Scope

In: election, presence, the hub surface, opt-in enable + disposer, no-op path. Out (later sub-slices): (b) cross-tab write propagation, (c) `WriteConflict` detection.

## Test Plan

- [x] 12 new tests (9 `TabCoordinator` unit + 3 `noydb`): election, re-election + role-change emission, stale drop-out, presence emitter, no-op path, channel-close-inert, phantom-beat guard, own-vs-injected teardown
- [x] `features.yaml` validator OK
- [x] `tsc --noEmit` + lint clean; `npm run build` clean
- [x] full hub suite **1968 pass**, clean runner exit (opt-in + `unref()`'d timer ⇒ existing suite starts no timers/locks)