### PR TITLE
feat(hub): cross-tab write propagation (#228 sub-slice b)

### DIFF
--- a/docs/superpowers/plans/2026-06-01-228b-cross-tab-write-propagation.md
+++ b/docs/superpowers/plans/2026-06-01-228b-cross-tab-write-propagation.md
@@ -1,0 +1,625 @@
+# Cross-tab write propagation (#228 sub-slice b) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a write commits in one same-origin tab, every other tab that has the collection loaded refreshes its in-memory view of that document — no reload — via a ciphertext-blind signal over a `BroadcastChannel` plus a local re-read.
+
+**Architecture:** A self-contained `CrossTabWriteRelay` (own `noydb:tab-writes` channel) subscribes to `onAfterWrite` (#230) and broadcasts `{vault, collection, docId, action}`; receiving tabs resolve the loaded vault→collection and call a new `Collection._applyRemoteChange`, which re-reads the encrypted envelope from the shared store (`_invalidateCacheEntry`) and emits a `change` event. Role-agnostic; folded into `db.enableTabCoordination({ propagateWrites })`.
+
+**Tech Stack:** TypeScript, Vitest. Package: `packages/hub`. Reuses (a)'s `TabChannel`/`defaultChannel`. Browser `BroadcastChannel` via the existing `window`-gated `defaultChannel`.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-228b-cross-tab-write-propagation-design.md`. Issue #228.
+
+---
+
+## File structure
+
+- **Modify** `packages/hub/src/write-hooks.ts` — add `readonly vault: string` to `WriteEvent`.
+- **Modify** `packages/hub/src/collection.ts` — set `vault` at both `WriteEvent` build sites (put ~1109, delete ~1689); add `_applyRemoteChange(id, action)`.
+- **Create** `packages/hub/src/tab-write-relay.ts` — `TabWriteMsg`, `CrossTabWriteRelayOptions`, `CrossTabWriteRelay`.
+- **Modify** `packages/hub/src/vault.ts` — add `_applyRemoteWrite(collectionName, docId, action)`.
+- **Modify** `packages/hub/src/noydb.ts` — `propagateWrites`/`writeChannel` in `TabCoordinationOptions`; build/teardown the relay in `enableTabCoordination`/`disableTabCoordination`; `#applyRemoteWrite` resolver.
+- **Modify** `features.yaml` — `cross-tab-write-propagation` feature entry.
+- **Create** `packages/hub/__tests__/tab-write-relay.test.ts` (unit) + `packages/hub/__tests__/tab-write-propagation.test.ts` (integration).
+
+---
+
+## Task 1: `vault` on `WriteEvent`
+
+**Files:** Modify `packages/hub/src/write-hooks.ts`, `packages/hub/src/collection.ts:1109`, `:1689`; Test `packages/hub/__tests__/write-hooks-integration.test.ts`
+
+- [ ] **Step 1: Write the failing test** — append inside the `describe('write lifecycle hooks (#230)', ...)` block in `packages/hub/__tests__/write-hooks-integration.test.ts`:
+
+```ts
+  it('WriteEvent carries the vault name (#228b)', async () => {
+    const db = await setup()
+    const v = await db.openVault('demo')
+    const c = v.collection<Inv>('invoices')
+    const events: WriteEvent[] = []
+    db.onAfterWrite((e) => { events.push(e) })
+    await c.put('i1', { id: 'i1', amount: 1 })
+    expect(events).toHaveLength(1)
+    expect(events[0]!.vault).toBe('demo')
+    expect(events[0]!.collection).toBe('invoices')
+  })
+```
+
+- [ ] **Step 2: Run → fail** (`vault` is `undefined` / type error)
+
+Run: `cd packages/hub && npx vitest run __tests__/write-hooks-integration.test.ts -t "carries the vault"`
+Expected: FAIL (`expected undefined to be "demo"`).
+
+- [ ] **Step 3: Add the field** — in `packages/hub/src/write-hooks.ts`, add `vault` to the `WriteEvent` interface (right after `op`):
+
+```ts
+export interface WriteEvent {
+  readonly op: 'create' | 'update' | 'delete'
+  readonly vault: string
+  readonly collection: string
+  readonly docId: string
+  readonly before: unknown // decrypted prior record; null on 'create'
+  readonly after: unknown // the record written; null on 'delete'
+  readonly userId: string
+  readonly timestamp: number
+  readonly txId: string
+}
+```
+
+- [ ] **Step 4: Populate it at both emit sites** — in `packages/hub/src/collection.ts`.
+
+Put site (~line 1109), add `vault: this.vault,`:
+```ts
+      event = {
+        op: before === null ? 'create' : 'update',
+        vault: this.vault, collection: this.name, docId: id, before, after: record,
+        userId: this.keyring.userId, timestamp: Date.now(), txId: this.#txIdForHook(),
+      }
+```
+
+Delete site (~line 1689), add `vault: this.vault,`:
+```ts
+      event = {
+        op: 'delete', vault: this.vault, collection: this.name, docId: id, before, after: null,
+        userId: this.keyring.userId, timestamp: Date.now(), txId: this.#txIdForHook(),
+      }
+```
+
+- [ ] **Step 5: Run → pass + typecheck**
+
+Run: `cd packages/hub && npx vitest run __tests__/write-hooks-integration.test.ts && npx tsc --noEmit`
+Expected: PASS, clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/vicio/_github/noy-db && git add packages/hub/src/write-hooks.ts packages/hub/src/collection.ts packages/hub/__tests__/write-hooks-integration.test.ts
+git commit -m "feat(hub): add vault to WriteEvent (#228)"
+```
+
+---
+
+## Task 2: `CrossTabWriteRelay`
+
+**Files:** Create `packages/hub/src/tab-write-relay.ts`; Test `packages/hub/__tests__/tab-write-relay.test.ts`
+
+> Design note: the relay always has a channel (it's only constructed when one exists — see Task 4). The "no channel ⇒ inert" no-op from the spec lives at the wiring layer (Task 4's no-op test), not here.
+
+- [ ] **Step 1: Write the failing test** — `packages/hub/__tests__/tab-write-relay.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { CrossTabWriteRelay } from '../src/tab-write-relay.js'
+import type { TabChannel } from '../src/tab-coordination.js'
+import type { WriteEvent } from '../src/write-hooks.js'
+
+/** In-memory broadcast bus: each channel's send() reaches all OTHER channels. */
+function makeBus(n: number): TabChannel[] {
+  const listeners: Array<((p: string) => void) | null> = []
+  const chans: TabChannel[] = []
+  for (let i = 0; i < n; i++) {
+    const idx = i
+    chans.push({
+      isOpen: true,
+      send(payload) { for (let j = 0; j < listeners.length; j++) if (j !== idx && listeners[j]) queueMicrotask(() => listeners[j]!(payload)) },
+      on(event, l) { if (event === 'message') { listeners[idx] = l as (p: string) => void; return () => { listeners[idx] = null } } return () => {} },
+      close() { listeners[idx] = null },
+    })
+  }
+  return chans
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+/** A controllable onAfterWrite source: returns a subscribe fn + a fire fn. */
+function fakeAfterWrite() {
+  const handlers = new Set<(e: WriteEvent) => void>()
+  return {
+    subscribe: (h: (e: WriteEvent) => void) => { handlers.add(h); return () => handlers.delete(h) },
+    fire: (e: WriteEvent) => { for (const h of handlers) h(e) },
+  }
+}
+
+function ev(partial: Partial<WriteEvent>): WriteEvent {
+  return { op: 'update', vault: 'books', collection: 'invoices', docId: 'i1', before: null, after: { id: 'i1' }, userId: 'u', timestamp: 0, txId: 't', ...partial }
+}
+
+describe('CrossTabWriteRelay', () => {
+  it('broadcasts a tab-write signal on a local committed write', async () => {
+    const [chA, chB] = makeBus(2)
+    const srcA = fakeAfterWrite()
+    let received: unknown
+    const relayA = new CrossTabWriteRelay({ channel: chA!, writerId: 'A', subscribeAfterWrite: srcA.subscribe, applyRemoteWrite: () => {} })
+    chB!.on('message', (p) => { received = JSON.parse(p) })
+    relayA.start()
+    srcA.fire(ev({ op: 'create', docId: 'i9' }))
+    await flush()
+    expect(received).toEqual({ kind: 'tab-write', writerId: 'A', vault: 'books', collection: 'invoices', docId: 'i9', action: 'put' })
+    relayA.dispose()
+  })
+
+  it('maps op:delete to action:delete', async () => {
+    const [chA, chB] = makeBus(2)
+    const srcA = fakeAfterWrite()
+    let received: { action?: string } = {}
+    const relayA = new CrossTabWriteRelay({ channel: chA!, writerId: 'A', subscribeAfterWrite: srcA.subscribe, applyRemoteWrite: () => {} })
+    chB!.on('message', (p) => { received = JSON.parse(p) })
+    relayA.start()
+    srcA.fire(ev({ op: 'delete', after: null }))
+    await flush()
+    expect(received.action).toBe('delete')
+    relayA.dispose()
+  })
+
+  it('applies a foreign tab-write; ignores its own', async () => {
+    const [chA, chB] = makeBus(2)
+    const srcA = fakeAfterWrite(); const srcB = fakeAfterWrite()
+    const applied: Array<[string, string, string, string]> = []
+    const relayA = new CrossTabWriteRelay({ channel: chA!, writerId: 'A', subscribeAfterWrite: srcA.subscribe, applyRemoteWrite: () => {} })
+    const relayB = new CrossTabWriteRelay({ channel: chB!, writerId: 'B', subscribeAfterWrite: srcB.subscribe, applyRemoteWrite: (v, c, d, a) => { applied.push([v, c, d, a]) } })
+    relayA.start(); relayB.start()
+    srcA.fire(ev({ docId: 'i1' }))   // A writes → B should apply
+    await flush()
+    srcB.fire(ev({ docId: 'i2' }))   // B writes → B must NOT apply its own
+    await flush()
+    expect(applied).toEqual([['books', 'invoices', 'i1', 'put']])
+    relayA.dispose(); relayB.dispose()
+  })
+
+  it('does not broadcast or apply after dispose', async () => {
+    const [chA, chB] = makeBus(2)
+    const srcA = fakeAfterWrite()
+    let count = 0
+    const relayA = new CrossTabWriteRelay({ channel: chA!, writerId: 'A', subscribeAfterWrite: srcA.subscribe, applyRemoteWrite: () => {} })
+    chB!.on('message', () => { count++ })
+    relayA.start()
+    relayA.dispose()
+    srcA.fire(ev({ docId: 'i1' }))
+    await flush()
+    expect(count).toBe(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run → fail** (`cd packages/hub && npx vitest run __tests__/tab-write-relay.test.ts`) — module not found.
+
+- [ ] **Step 3: Implement** `packages/hub/src/tab-write-relay.ts`:
+
+```ts
+/**
+ * Cross-tab write propagation (#228b). A role-agnostic relay: it broadcasts
+ * a ciphertext-blind signal ({vault, collection, docId, action}) for every
+ * locally-committed write (via onAfterWrite, #230), and on receiving a peer
+ * tab's signal it asks the host to refresh that document's in-memory view by
+ * re-reading the shared encrypted store. Nothing decrypted crosses the wire.
+ */
+import type { TabChannel, Unsubscribe } from './tab-coordination.js'
+import type { WriteEvent } from './write-hooks.js'
+
+export interface TabWriteMsg {
+  readonly kind: 'tab-write'
+  readonly writerId: string
+  readonly vault: string
+  readonly collection: string
+  readonly docId: string
+  readonly action: 'put' | 'delete'
+}
+
+export interface CrossTabWriteRelayOptions {
+  /** The broadcast channel (its own — distinct from the presence channel). */
+  readonly channel: TabChannel
+  /** This tab's id — outgoing signals carry it; incoming self-signals are ignored. */
+  readonly writerId: string
+  /** Subscribe to committed writes (the host's onAfterWrite). */
+  readonly subscribeAfterWrite: (handler: (e: WriteEvent) => void) => Unsubscribe
+  /** Refresh a document's in-memory view from the shared store. */
+  readonly applyRemoteWrite: (vault: string, collection: string, docId: string, action: 'put' | 'delete') => void | Promise<void>
+  /** Close the channel on dispose (only when the relay created it). Default false. */
+  readonly closeChannelOnDispose?: boolean
+}
+
+export class CrossTabWriteRelay {
+  readonly #channel: TabChannel
+  readonly #writerId: string
+  readonly #subscribeAfterWrite: (handler: (e: WriteEvent) => void) => Unsubscribe
+  readonly #applyRemoteWrite: (vault: string, collection: string, docId: string, action: 'put' | 'delete') => void | Promise<void>
+  readonly #ownsChannel: boolean
+  #unsubMsg: Unsubscribe | undefined
+  #unsubWrite: Unsubscribe | undefined
+  #started = false
+  #disposed = false
+
+  constructor(opts: CrossTabWriteRelayOptions) {
+    this.#channel = opts.channel
+    this.#writerId = opts.writerId
+    this.#subscribeAfterWrite = opts.subscribeAfterWrite
+    this.#applyRemoteWrite = opts.applyRemoteWrite
+    this.#ownsChannel = opts.closeChannelOnDispose ?? false
+  }
+
+  start(): void {
+    if (this.#started || this.#disposed) return
+    this.#started = true
+    this.#unsubMsg = this.#channel.on('message', (p) => this.#onMessage(p))
+    this.#unsubWrite = this.#subscribeAfterWrite((e) => this.#onLocalWrite(e))
+  }
+
+  dispose(): void {
+    if (this.#disposed) return
+    this.#disposed = true
+    this.#unsubWrite?.()
+    this.#unsubMsg?.()
+    if (this.#ownsChannel) this.#channel.close()
+  }
+
+  #onLocalWrite(e: WriteEvent): void {
+    if (this.#disposed || !this.#channel.isOpen) return
+    const action: 'put' | 'delete' = e.op === 'delete' ? 'delete' : 'put'
+    const msg: TabWriteMsg = { kind: 'tab-write', writerId: this.#writerId, vault: e.vault, collection: e.collection, docId: e.docId, action }
+    this.#channel.send(JSON.stringify(msg))
+  }
+
+  #onMessage(payload: string): void {
+    if (this.#disposed) return
+    let msg: unknown
+    try { msg = JSON.parse(payload) } catch { return }
+    if (!isTabWriteMsg(msg) || msg.writerId === this.#writerId) return
+    void Promise.resolve(this.#applyRemoteWrite(msg.vault, msg.collection, msg.docId, msg.action)).catch((err) => {
+      console.warn(`[noy-db] cross-tab apply failed for ${msg.collection}/${msg.docId}: ` + (err instanceof Error ? err.message : String(err)))
+    })
+  }
+}
+
+function isTabWriteMsg(x: unknown): x is TabWriteMsg {
+  if (x === null || typeof x !== 'object') return false
+  const o = x as Record<string, unknown>
+  return o['kind'] === 'tab-write'
+    && typeof o['writerId'] === 'string'
+    && typeof o['vault'] === 'string'
+    && typeof o['collection'] === 'string'
+    && typeof o['docId'] === 'string'
+    && (o['action'] === 'put' || o['action'] === 'delete')
+}
+```
+
+- [ ] **Step 4: Run → pass + typecheck**
+
+Run: `cd packages/hub && npx vitest run __tests__/tab-write-relay.test.ts && npx tsc --noEmit && npx eslint src/tab-write-relay.ts`
+Expected: 4 tests pass, tsc + eslint clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/vicio/_github/noy-db && git add packages/hub/src/tab-write-relay.ts packages/hub/__tests__/tab-write-relay.test.ts
+git commit -m "feat(hub): CrossTabWriteRelay — broadcast/apply committed-write signals (#228)"
+```
+
+---
+
+## Task 3: apply primitives — `Collection._applyRemoteChange` + `Vault._applyRemoteWrite`
+
+**Files:** Modify `packages/hub/src/collection.ts` (near `_invalidateCacheEntry`, ~line 2781), `packages/hub/src/vault.ts` (near `#runCutoverTransform`, ~line 844); Test `packages/hub/__tests__/tab-write-propagation.test.ts`
+
+- [ ] **Step 1: Write the failing test** — `packages/hub/__tests__/tab-write-propagation.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { memory } from '../../to-memory/src/index.js'
+
+interface Inv extends Record<string, unknown> { id: string; amount: number }
+const SECRET = 'tab-prop-pass-1234'
+
+describe('apply primitives (#228b)', () => {
+  it('_applyRemoteChange refreshes the cache from the shared store and emits change', async () => {
+    const store = memory()
+    const db1 = await createNoydb({ store, user: 'alice', secret: SECRET })
+    const db2 = await createNoydb({ store, user: 'alice', secret: SECRET })
+    const v1 = await db1.openVault('books'); const c1 = v1.collection<Inv>('invoices')
+    const v2 = await db2.openVault('books'); const c2 = v2.collection<Inv>('invoices')
+
+    await c2.get('i1') // hydrate db2's eager cache (currently empty)
+    let changed = 0
+    db2.on('change', (e) => { if (e.id === 'i1') changed++ })
+
+    await c1.put('i1', { id: 'i1', amount: 7 })       // db1 persists to the shared store
+    expect(await c2.get('i1')).toBeNull()              // db2 hasn't seen it yet (stale cache)
+
+    await v2._applyRemoteWrite('invoices', 'i1', 'put') // simulate the relay's apply
+    expect(await c2.get('i1')).toMatchObject({ amount: 7 })
+    expect(changed).toBe(1)
+  })
+
+  it('_applyRemoteWrite is a no-op for an unloaded collection', async () => {
+    const store = memory()
+    const db = await createNoydb({ store, user: 'alice', secret: SECRET })
+    const v = await db.openVault('books')
+    await expect(v._applyRemoteWrite('not-loaded', 'x', 'put')).resolves.toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run → fail** (`_applyRemoteWrite` / `_applyRemoteChange` don't exist)
+
+Run: `cd packages/hub && npx vitest run __tests__/tab-write-propagation.test.ts -t "apply primitives"`
+Expected: FAIL (type error / not a function).
+
+- [ ] **Step 3a: Implement `Collection._applyRemoteChange`** — add to `packages/hub/src/collection.ts` immediately after `_invalidateCacheEntry` (the method ending ~line 2797):
+
+```ts
+  /**
+   * #228b — apply a peer tab's committed write to THIS tab's in-memory view:
+   * re-read the (already-persisted) envelope from the shared store + refresh
+   * cache/indexes, then emit a `change` event so reactive consumers re-render.
+   * Never writes to the store and never fires write hooks, so it cannot loop.
+   */
+  async _applyRemoteChange(id: string, action: 'put' | 'delete'): Promise<void> {
+    await this._invalidateCacheEntry(id)
+    this.emitter.emit('change', { vault: this.vault, collection: this.name, id, action })
+  }
+```
+
+- [ ] **Step 3b: Implement `Vault._applyRemoteWrite`** — add to `packages/hub/src/vault.ts` right after `#runCutoverTransform` (~line 848):
+
+```ts
+  /**
+   * #228b — refresh a loaded collection's view of one document from a peer
+   * tab's broadcast. No-op when the collection isn't loaded in this tab
+   * (it will read fresh on next open). Mirrors #runCutoverTransform's guard.
+   */
+  async _applyRemoteWrite(collectionName: string, docId: string, action: 'put' | 'delete'): Promise<void> {
+    const coll = this.collectionCache.get(collectionName)
+    if (!coll) return
+    await coll._applyRemoteChange(docId, action)
+  }
+```
+
+- [ ] **Step 4: Run → pass + typecheck**
+
+Run: `cd packages/hub && npx vitest run __tests__/tab-write-propagation.test.ts -t "apply primitives" && npx tsc --noEmit`
+Expected: 2 tests pass, tsc clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/vicio/_github/noy-db && git add packages/hub/src/collection.ts packages/hub/src/vault.ts packages/hub/__tests__/tab-write-propagation.test.ts
+git commit -m "feat(hub): _applyRemoteChange / _applyRemoteWrite apply primitives (#228)"
+```
+
+---
+
+## Task 4: wire the relay into `enableTabCoordination`
+
+**Files:** Modify `packages/hub/src/tab-coordination.ts` (options), `packages/hub/src/noydb.ts`; Test `packages/hub/__tests__/tab-write-propagation.test.ts` (add an end-to-end describe)
+
+- [ ] **Step 1: Write the failing test** — append a new describe to `packages/hub/__tests__/tab-write-propagation.test.ts`:
+
+```ts
+import type { TabChannel } from '../src/tab-coordination.js'
+
+/** In-memory broadcast bus (each send reaches all OTHER channels). */
+function makeBus(n: number): TabChannel[] {
+  const listeners: Array<((p: string) => void) | null> = []
+  const chans: TabChannel[] = []
+  for (let i = 0; i < n; i++) {
+    const idx = i
+    chans.push({
+      isOpen: true,
+      send(payload) { for (let j = 0; j < listeners.length; j++) if (j !== idx && listeners[j]) queueMicrotask(() => listeners[j]!(payload)) },
+      on(event, l) { if (event === 'message') { listeners[idx] = l as (p: string) => void; return () => { listeners[idx] = null } } return () => {} },
+      close() { listeners[idx] = null },
+    })
+  }
+  return chans
+}
+const settle = async () => { await new Promise((r) => setTimeout(r, 0)); await new Promise((r) => setTimeout(r, 0)) }
+
+describe('end-to-end cross-tab propagation (#228b)', () => {
+  it('a put in one tab refreshes the other; delete removes it', async () => {
+    const store = memory()
+    const db1 = await createNoydb({ store, user: 'alice', secret: SECRET })
+    const db2 = await createNoydb({ store, user: 'alice', secret: SECRET })
+    const [wA, wB] = makeBus(2) // shared write-bus
+    db1.enableTabCoordination({ writeChannel: wA!, tabId: 'A' })
+    db2.enableTabCoordination({ writeChannel: wB!, tabId: 'B' })
+
+    const c1 = (await db1.openVault('books')).collection<Inv>('invoices')
+    const c2 = (await db2.openVault('books')).collection<Inv>('invoices')
+    await c2.get('i1') // hydrate db2
+
+    await c1.put('i1', { id: 'i1', amount: 5 })
+    await settle()
+    expect(await c2.get('i1')).toMatchObject({ amount: 5 }) // propagated put
+
+    await c1.delete('i1')
+    await settle()
+    expect(await c2.get('i1')).toBeNull() // propagated delete
+
+    db1.close(); db2.close()
+  })
+
+  it('propagateWrites:false disables it; and it no-ops with no channel', async () => {
+    const store = memory()
+    const db1 = await createNoydb({ store, user: 'alice', secret: SECRET })
+    const db2 = await createNoydb({ store, user: 'alice', secret: SECRET })
+    const [wA, wB] = makeBus(2)
+    db1.enableTabCoordination({ writeChannel: wA!, tabId: 'A' })
+    db2.enableTabCoordination({ writeChannel: wB!, tabId: 'B', propagateWrites: false })
+
+    const c1 = (await db1.openVault('books')).collection<Inv>('invoices')
+    const c2 = (await db2.openVault('books')).collection<Inv>('invoices')
+    await c2.get('i1')
+    await c1.put('i1', { id: 'i1', amount: 9 })
+    await settle()
+    expect(await c2.get('i1')).toBeNull() // db2 opted out → no refresh
+
+    // no channel at all (node default) → enabling is a safe no-op, no throw
+    const db3 = await createNoydb({ store: memory(), user: 'bob', secret: SECRET })
+    expect(() => db3.enableTabCoordination()).not.toThrow()
+    db1.close(); db2.close(); db3.close()
+  })
+})
+```
+
+- [ ] **Step 2: Run → fail** (`writeChannel`/`propagateWrites` options don't exist; no relay wired → propagation doesn't happen)
+
+Run: `cd packages/hub && npx vitest run __tests__/tab-write-propagation.test.ts -t "end-to-end"`
+Expected: FAIL (db2 doesn't see the put).
+
+- [ ] **Step 3a: Add options** — in `packages/hub/src/tab-coordination.ts`, extend `TabCoordinationOptions` (after `closeChannelOnDispose`):
+
+```ts
+  /**
+   * Also propagate committed writes to other tabs (#228b). Default true:
+   * when tab coordination is enabled and a channel is available, a write in
+   * one tab refreshes that document in every other tab. Set false to opt out.
+   */
+  readonly propagateWrites?: boolean
+  /**
+   * Channel for write propagation (#228b) — distinct from the presence
+   * channel. Default: an inline BroadcastChannel on `noydb:tab-writes`.
+   */
+  readonly writeChannel?: TabChannel
+```
+
+- [ ] **Step 3b: Import the relay** — in `packages/hub/src/noydb.ts`, add near the tab-coordination import (line ~81):
+
+```ts
+import { CrossTabWriteRelay } from './tab-write-relay.js'
+```
+
+- [ ] **Step 3c: Add the field** — beside `private tabCoordinator` (line ~195):
+
+```ts
+  /** Cross-tab write relay (#228b); created on `enableTabCoordination()`. */
+  private writeRelay: CrossTabWriteRelay | undefined
+```
+
+- [ ] **Step 3d: Build the relay** — in `enableTabCoordination` (line ~1200), after `c.start()` and before the `return`:
+
+```ts
+    if (opts.propagateWrites !== false) {
+      const writeChannel = opts.writeChannel ?? defaultChannel('noydb:tab-writes')
+      if (writeChannel) {
+        const relay = new CrossTabWriteRelay({
+          channel: writeChannel,
+          writerId: c.tabId,
+          subscribeAfterWrite: (h) => this.onAfterWrite(h),
+          applyRemoteWrite: (vault, collection, docId, action) => this.#applyRemoteWrite(vault, collection, docId, action),
+          closeChannelOnDispose: opts.writeChannel === undefined && writeChannel !== undefined,
+        })
+        this.writeRelay = relay
+        relay.start()
+      }
+    }
+```
+
+- [ ] **Step 3e: Add the resolver + teardown** — add the private method beside `disableTabCoordination` (line ~1214), and a teardown line inside `disableTabCoordination`:
+
+```ts
+  #applyRemoteWrite(vaultName: string, collectionName: string, docId: string, action: 'put' | 'delete'): Promise<void> {
+    const v = this.vaultCache.get(vaultName)
+    if (!v) return Promise.resolve()
+    return v._applyRemoteWrite(collectionName, docId, action)
+  }
+```
+
+In `disableTabCoordination`, add the relay teardown:
+```ts
+  private disableTabCoordination(): void {
+    this.tabCoordinator?.dispose()
+    this.tabCoordinator = undefined
+    this.writeRelay?.dispose()
+    this.writeRelay = undefined
+  }
+```
+
+(`close()` already calls `disableTabCoordination()` — no extra change there.)
+
+- [ ] **Step 4: Run → pass + typecheck + lint + full suite**
+
+Run: `cd packages/hub && npx vitest run __tests__/tab-write-propagation.test.ts && npx tsc --noEmit && npx eslint src/noydb.ts src/tab-coordination.ts && npx vitest run`
+Expected: propagation tests pass; tsc + eslint clean; full suite green with a clean (non-hanging) exit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/vicio/_github/noy-db && git add packages/hub/src/tab-coordination.ts packages/hub/src/noydb.ts packages/hub/__tests__/tab-write-propagation.test.ts
+git commit -m "feat(hub): wire CrossTabWriteRelay into enableTabCoordination (#228)"
+```
+
+---
+
+## Task 5: register the feature + final verify
+
+**Files:** Modify `features.yaml`
+
+- [ ] **Step 1: Add the feature entry** — in `features.yaml`, immediately after the `tab-coordination` entry (its `related: [vault-and-collections]` line), add:
+
+```yaml
+  - id: cross-tab-write-propagation
+    name: Cross-tab write propagation
+    cluster: core
+    spec: docs/superpowers/specs/2026-06-01-228b-cross-tab-write-propagation-design.md
+    subsystem_doc: docs/superpowers/specs/2026-06-01-228b-cross-tab-write-propagation-design.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'a committed write in one tab refreshes that document in every other tab that has the collection loaded (cache + change event), no reload'
+      - 'only {vault, collection, docId, action} cross the channel — nothing decrypted; receivers re-read the shared encrypted store'
+      - 'applied remote writes never re-persist or re-fire write hooks, so they cannot loop'
+      - 'opt-in via db.enableTabCoordination({ propagateWrites }) (default true); graceful no-op outside browsers'
+    related: [tab-coordination, write-lifecycle-hooks]
+```
+
+> If the validator rejects an unknown id in `related` (`write-lifecycle-hooks`), grep `features.yaml` for the actual #230 feature id (`grep -n "id: .*write" features.yaml`) and use that, or drop it to `related: [tab-coordination]`.
+
+- [ ] **Step 2: Validate + full verify**
+
+```bash
+cd /Users/vicio/_github/noy-db && node scripts/validate-features.mjs
+cd packages/hub && npx vitest run && npx tsc --noEmit && npm run lint && npm run build
+```
+Expected: validator PASS; full suite PASS (clean exit); tsc + lint + build clean.
+
+- [ ] **Step 3: Commit + clean tree**
+
+```bash
+cd /Users/vicio/_github/noy-db && git add features.yaml
+git commit -m "chore(hub): register cross-tab-write-propagation feature (#228)"
+git status
+```
+
+---
+
+## Self-review checklist (applied)
+
+- **Spec coverage:** signal+re-read → Task 2 relay + Task 3 `_invalidateCacheEntry` reuse; role-agnostic broadcast → Task 2; `vault` on `WriteEvent` → Task 1; `_applyRemoteChange`/`_applyRemoteWrite` → Task 3; `enableTabCoordination({ propagateWrites })` wiring + teardown + no-op → Task 4; no-loop (apply skips put/hooks) → Task 3 method + Task 2 self-filter; put & delete propagation + unopened-vault ignored → Task 3/Task 4 tests; ciphertext-blind signal → `TabWriteMsg` shape (Task 2); features.yaml → Task 5.
+- **Type consistency:** `TabWriteMsg{kind,writerId,vault,collection,docId,action}`, `action:'put'|'delete'`, `CrossTabWriteRelayOptions{channel,writerId,subscribeAfterWrite,applyRemoteWrite,closeChannelOnDispose}`, `WriteEvent.vault`, `Collection._applyRemoteChange(id,action)`, `Vault._applyRemoteWrite(collectionName,docId,action)`, `Noydb.#applyRemoteWrite(vaultName,collectionName,docId,action)`, options `propagateWrites`/`writeChannel` — all consistent across tasks.
+- **Reuse, not reinvention:** apply path reuses `_invalidateCacheEntry` (verified collection.ts:2781) + the `change` emit shape (verified types.ts `ChangeEvent`); `_applyRemoteWrite` mirrors `#runCutoverTransform`'s loaded-collection guard (verified vault.ts:844); own-channel teardown mirrors (a)'s `closeChannelOnDispose`.
+- **Determinism:** in-memory bus + fake onAfterWrite (unit); shared `memory()` store + same user/secret + injected write-bus + `settle()` (integration). No real `BroadcastChannel`/timers.
+- **No placeholders:** every code step shows complete code; every run step states command + expected result. The one conditional (`related` id fallback in Task 5) gives the exact grep + both resolutions.

--- a/docs/superpowers/specs/2026-06-01-228b-cross-tab-write-propagation-design.md
+++ b/docs/superpowers/specs/2026-06-01-228b-cross-tab-write-propagation-design.md
@@ -1,0 +1,113 @@
+# Cross-tab write propagation (#228 sub-slice b) — design
+
+**Status:** design approved · **Date:** 2026-06-01 · **Issue:** #228 · **Epic:** hub coordination · **Builds on:** [#228(a) tab presence + roles](2026-06-01-228-tab-coordination-design.md), #230 write hooks
+
+Sub-slice **(b)** of multi-client write coordination. When a write commits in one same-origin tab, every *other* tab refreshes its in-memory view of that document — so a write in tab A appears in tab B's UI without a reload. Browser-only (same-origin `BroadcastChannel`), opt-in via the same `db.enableTabCoordination()` surface as (a), graceful no-op elsewhere.
+
+## Decisions (locked)
+
+| Decision | Choice | Why |
+|---|---|---|
+| **What crosses the channel** | **Signal + re-read** — broadcast `{vault, collection, docId, action}` only; receivers re-read the encrypted envelope from the shared IDB and decrypt locally | Keeps the channel ciphertext-blind (no decrypted data ever leaves a tab's memory); the receiver gets the authoritative record + `_v` for free; matches the issue's stated "broadcast changed document IDs" intent |
+| **Propagation model** | **Role-agnostic** — *any* tab that commits a write broadcasts; *every other* tab applies | Delivers the user-visible win (cross-tab live updates) now; needs no write-routing/RPC. Write serialization + conflict handling stay in later slices |
+| **Enable surface** | Folded into `db.enableTabCoordination({ propagateWrites? })` (default `true`) | One opt-in for "make this tab coordinate"; opt-out with `propagateWrites: false` |
+
+## Prerequisite: `vault` on `WriteEvent`
+
+`WriteEvent` (#230, `packages/hub/src/write-hooks.ts`) currently carries `collection` and `docId` but **not `vault`**. A receiving tab needs the vault to resolve which loaded collection to refresh. This slice adds a `readonly vault: string` field to `WriteEvent`, populated at the emit site (the Collection already knows `this.vault`). Backward-compatible: existing #230 consumers simply gain a field.
+
+## Architecture
+
+A self-contained **`CrossTabWriteRelay`** (`packages/hub/src/tab-write-relay.ts`), independent of `TabCoordinator` — role-agnostic propagation needs no election. It owns its **own** channel (`defaultChannel('noydb:tab-writes')`, distinct from the presence channel so each channel has a single listener, which keeps the deterministic in-memory test bus simple) and a `writerId` (the tab's id; defaults to the same id (a) uses).
+
+- **Broadcast side.** Subscribes to the instance's `onAfterWrite` (#230). On each committed write, sends:
+
+  ```ts
+  interface TabWriteMsg {
+    readonly kind: 'tab-write'
+    readonly writerId: string
+    readonly vault: string
+    readonly collection: string
+    readonly docId: string
+    readonly action: 'put' | 'delete'   // create|update → 'put'; delete → 'delete'
+  }
+  ```
+
+- **Apply side.** On a `tab-write` message from a **different** `writerId`, calls an injected `applyRemoteWrite(vault, collection, docId, action): Promise<void>`. Self-`writerId` messages are ignored (belt-and-suspenders — applies never re-broadcast anyway, see below).
+
+### Wiring (`Noydb.enableTabCoordination`)
+
+When `propagateWrites !== false` and a channel is available, `enableTabCoordination` constructs the relay alongside the `TabCoordinator` and supplies the apply callback:
+
+```
+applyRemoteWrite(vault, collection, docId, action):
+  resolve the *loaded* vault (skip if not open in this tab)
+  resolve the *loaded* collection (skip if not registered/loaded)
+  await coll._applyRemoteChange(docId, action)
+```
+
+The relay is torn down in the same `#disableTabCoordination()` / `close()` path as (a).
+
+### The apply primitive — `Collection._applyRemoteChange(id, action)`
+
+A thin new internal method:
+
+```
+await this._invalidateCacheEntry(id)   // re-read shared-IDB envelope, decrypt, update cache + indexes
+                                        // (already handles delete: missing envelope → cache delete)
+this.emitter.emit('change', { vault: this.vault, collection: this.name, id, action })
+```
+
+`_invalidateCacheEntry` (collection.ts) already does the re-read/decrypt/cache/index work but deliberately does **not** emit a change event; `_applyRemoteChange` adds exactly that emit so reactive consumers (in-vue) re-render. This is the single new piece of apply logic; everything else reuses existing machinery.
+
+### No re-broadcast loop
+
+Apply goes through `_invalidateCacheEntry`, **not** `put`/`delete` — so it never persists to the store and never fires `onAfterWrite`. Therefore an applied remote write cannot trigger another broadcast. The `writerId` self-filter is a redundant second guard.
+
+## Data flow
+
+```
+tab A: coll.put(id, rec) ─► persists to shared IDB ─► onAfterWrite{ vault, collection, docId, op }
+                                                          │
+                          relay.broadcast TabWriteMsg{ writerId:A, vault, collection, docId, action }
+                                                          │   BroadcastChannel 'noydb:tab-writes'
+                                                          ▼
+tab B: relay.onMessage ─► writerId ≠ B ─► applyRemoteWrite(vault, collection, docId, action)
+        └─► Noydb resolves loaded vault + collection (skip if absent)
+              └─► coll._applyRemoteChange(docId, action)
+                    ├─ _invalidateCacheEntry(docId)   // re-read + decrypt + cache/index update
+                    └─ emit 'change' { vault, collection, id, action }   // in-vue re-renders
+```
+
+The signal is sent **after** the primary's `put` persists (`onAfterWrite` is post-persist), and IndexedDB is read-committed across same-origin tabs, so the envelope a `put` signal refers to is visible to the receiver by the time it re-reads.
+
+## Error handling / edges
+
+- **Vault or collection not loaded in the receiving tab** → skip silently; the fresh state is read on next open.
+- **Re-read finds nothing** (e.g. a delete, or a not-yet-visible write) → `_invalidateCacheEntry` deletes the cache entry; benign.
+- **No channel** (Node/SSR, or `defaultChannel()` returns `undefined`) → relay inert, mirroring (a)'s no-op path. `propagateWrites` defaulting `true` is therefore still a safe no-op server-side.
+- **Apply errors** are caught and `console.warn`'d inside the message callback (mirrors `onAfterWrite`'s swallow-and-warn); never thrown into the channel handler.
+- **Lazy collections** → `_invalidateCacheEntry` evicts the LRU entry; the emitted `change` prompts a fresh read on next access.
+
+## Testing (deterministic, no real browser)
+
+- **Unit — `packages/hub/__tests__/tab-write-relay.test.ts`.** In-memory broadcast bus (same helper shape as (a)) + a fake `onAfterWrite` source + a spy `applyRemoteWrite`. Assert:
+  1. a committed write broadcasts a `TabWriteMsg` with the correct `vault/collection/docId/action`;
+  2. a foreign `tab-write` invokes `applyRemoteWrite` with the right args;
+  3. a self-`writerId` message is ignored;
+  4. with no channel, the relay is inert (no broadcast, no throw).
+- **Integration — `packages/hub/__tests__/tab-write-propagation.test.ts`.** Two `createNoydb` instances sharing **one `memory()` store instance**, **same `user` + `secret`** (a faithful same-origin/same-user multi-tab analog), each `enableTabCoordination` wired to a shared in-memory write-bus. Write in db1 → flush → assert db2's collection reflects it (`get`/`query` returns the new record; a `change` listener fired). Cover **put and delete** propagation, and that a write to a vault **not** open in db2 is harmlessly ignored.
+
+## Scope
+
+**In (b):** the relay (broadcast + apply), the `vault` field on `WriteEvent`, `Collection._applyRemoteChange`, the `enableTabCoordination({ propagateWrites })` wiring + teardown, the no-op path, unit + integration tests, `features.yaml` registration.
+
+**Out (later slices):** `_v` + `base`-ancestor in the signal and `WriteConflict` detection → (c) (the re-read already yields authoritative state, so `_v` is redundant for (b)'s refresh purpose); primary-routed/serialized writes (secondaries relaying intents to the primary) → a separate slice; cross-device propagation → the sync engine, explicitly out of #228's scope.
+
+## Success criteria
+
+1. A `put` committed in one tab refreshes the same document in every other tab that has the collection loaded — cache + a `change` event — without a reload, and without that tab re-persisting or re-firing write hooks.
+2. A `delete` committed in one tab removes the document from other tabs' loaded views the same way.
+3. Nothing decrypted crosses the channel — only `{vault, collection, docId, action}`.
+4. Opt-in via `enableTabCoordination` (`propagateWrites` default `true`); a graceful no-op outside browsers; `propagateWrites: false` disables it. Hubs that don't enable coordination start no relay.
+5. No broadcast loop: an applied remote write never triggers a re-broadcast.

--- a/features.yaml
+++ b/features.yaml
@@ -895,6 +895,25 @@ features:
       - 'opt-in via db.enableTabCoordination(); graceful no-op (role unknown) outside browsers'
     related: [vault-and-collections]
 
+  - id: cross-tab-write-propagation
+    name: Cross-tab write propagation
+    cluster: core
+    spec: docs/superpowers/specs/2026-06-01-228b-cross-tab-write-propagation-design.md
+    subsystem_doc: docs/superpowers/specs/2026-06-01-228b-cross-tab-write-propagation-design.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'a committed write in one tab refreshes that document in every other tab that has the collection loaded (cache + change event), no reload'
+      - 'only {vault, collection, docId, action} cross the channel — nothing decrypted; receivers re-read the shared encrypted store'
+      - 'applied remote writes never re-persist or re-fire write hooks, so they cannot loop'
+      - 'opt-in via db.enableTabCoordination({ propagateWrites }) (default true); graceful no-op outside browsers'
+    related: [tab-coordination, write-lifecycle-hooks]
+
 # ─── Storage adapters (phase 2) ──────────────────────────────────────
 
 adapters:

--- a/packages/hub/__tests__/tab-write-propagation.test.ts
+++ b/packages/hub/__tests__/tab-write-propagation.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, it } from 'vitest'
 import { createNoydb } from '../src/noydb.js'
 import { memory } from '../../to-memory/src/index.js'
+import type { TabChannel } from '../src/tab-coordination.js'
+
+/** In-memory broadcast bus (each send reaches all OTHER channels). */
+function makeBus(n: number): TabChannel[] {
+  const listeners: Array<((p: string) => void) | null> = []
+  const chans: TabChannel[] = []
+  for (let i = 0; i < n; i++) {
+    const idx = i
+    chans.push({
+      isOpen: true,
+      send(payload) { for (let j = 0; j < listeners.length; j++) if (j !== idx && listeners[j]) queueMicrotask(() => listeners[j]!(payload)) },
+      on(event, l) { if (event === 'message') { listeners[idx] = l as (p: string) => void; return () => { listeners[idx] = null } } return () => {} },
+      close() { listeners[idx] = null },
+    })
+  }
+  return chans
+}
+const settle = async () => { await new Promise((r) => setTimeout(r, 0)); await new Promise((r) => setTimeout(r, 0)) }
 
 interface Inv extends Record<string, unknown> { id: string; amount: number }
 const SECRET = 'tab-prop-pass-1234'
@@ -41,5 +59,42 @@ describe('apply primitives (#228b)', () => {
     const v = await db.openVault('books')
     await expect(v._applyRemoteWrite('not-loaded', 'x', 'put')).resolves.toBeUndefined()
     db.close()
+  })
+})
+
+describe('end-to-end cross-tab propagation (#228b)', () => {
+  it('a put in one tab refreshes the other; delete removes it', async () => {
+    const { db1, db2, c1, c2 } = await twoTabs()
+    const [wA, wB] = makeBus(2) // shared write-bus
+    db1.enableTabCoordination({ writeChannel: wA!, tabId: 'A' })
+    db2.enableTabCoordination({ writeChannel: wB!, tabId: 'B' })
+    await c2.get('seed') // hydrate db2
+
+    await c1.put('i1', { id: 'i1', amount: 5 })
+    await settle()
+    expect(await c2.get('i1')).toMatchObject({ amount: 5 }) // propagated put
+
+    await c1.delete('i1')
+    await settle()
+    expect(await c2.get('i1')).toBeNull() // propagated delete
+
+    db1.close(); db2.close()
+  })
+
+  it('propagateWrites:false disables it; and it no-ops with no channel', async () => {
+    const { db1, db2, c1, c2 } = await twoTabs()
+    const [wA, wB] = makeBus(2)
+    db1.enableTabCoordination({ writeChannel: wA!, tabId: 'A' })
+    db2.enableTabCoordination({ writeChannel: wB!, tabId: 'B', propagateWrites: false })
+    await c2.get('seed')
+
+    await c1.put('i1', { id: 'i1', amount: 9 })
+    await settle()
+    expect(await c2.get('i1')).toBeNull() // db2 opted out → no refresh
+
+    // no channel at all (node default) → enabling is a safe no-op, no throw
+    const db3 = await createNoydb({ store: memory(), user: 'bob', secret: SECRET })
+    expect(() => db3.enableTabCoordination()).not.toThrow()
+    db1.close(); db2.close(); db3.close()
   })
 })

--- a/packages/hub/__tests__/tab-write-propagation.test.ts
+++ b/packages/hub/__tests__/tab-write-propagation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { memory } from '../../to-memory/src/index.js'
+
+interface Inv extends Record<string, unknown> { id: string; amount: number }
+const SECRET = 'tab-prop-pass-1234'
+
+/**
+ * Two same-origin/same-user "tabs" sharing one store. db1 seeds a write FIRST
+ * so the per-collection DEK is minted + persisted; only then is db2 created, so
+ * it loads the same keyring + DEK (otherwise each tab mints its own DEK and the
+ * cross-read fails with TamperedError). See persistence.test.ts:41.
+ */
+async function twoTabs(store = memory()) {
+  const db1 = await createNoydb({ store, user: 'alice', secret: SECRET })
+  const v1 = await db1.openVault('books'); const c1 = v1.collection<Inv>('invoices')
+  await c1.put('seed', { id: 'seed', amount: 0 }) // mint + persist the invoices DEK
+  const db2 = await createNoydb({ store, user: 'alice', secret: SECRET })
+  const v2 = await db2.openVault('books'); const c2 = v2.collection<Inv>('invoices')
+  return { store, db1, db2, v1, v2, c1, c2 }
+}
+
+describe('apply primitives (#228b)', () => {
+  it('_applyRemoteChange refreshes the cache from the shared store and emits change', async () => {
+    const { db1, db2, v2, c1, c2 } = await twoTabs()
+    await c2.get('seed') // hydrate db2's eager cache (loads the shared DEK too)
+    let changed = 0
+    db2.on('change', (e) => { if (e.id === 'i1') changed++ })
+
+    await c1.put('i1', { id: 'i1', amount: 7 })       // db1 persists to the shared store
+    expect(await c2.get('i1')).toBeNull()              // db2 hasn't seen it yet (stale cache)
+
+    await v2._applyRemoteWrite('invoices', 'i1', 'put') // simulate the relay's apply
+    expect(await c2.get('i1')).toMatchObject({ amount: 7 })
+    expect(changed).toBe(1)
+    db1.close(); db2.close()
+  })
+
+  it('_applyRemoteWrite is a no-op for an unloaded collection', async () => {
+    const db = await createNoydb({ store: memory(), user: 'alice', secret: SECRET })
+    const v = await db.openVault('books')
+    await expect(v._applyRemoteWrite('not-loaded', 'x', 'put')).resolves.toBeUndefined()
+    db.close()
+  })
+})

--- a/packages/hub/__tests__/tab-write-relay.test.ts
+++ b/packages/hub/__tests__/tab-write-relay.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { CrossTabWriteRelay } from '../src/tab-write-relay.js'
+import type { TabChannel } from '../src/tab-coordination.js'
+import type { WriteEvent } from '../src/write-hooks.js'
+
+/** In-memory broadcast bus: each channel's send() reaches all OTHER channels. */
+function makeBus(n: number): TabChannel[] {
+  const listeners: Array<((p: string) => void) | null> = []
+  const chans: TabChannel[] = []
+  for (let i = 0; i < n; i++) {
+    const idx = i
+    chans.push({
+      isOpen: true,
+      send(payload) { for (let j = 0; j < listeners.length; j++) if (j !== idx && listeners[j]) queueMicrotask(() => listeners[j]!(payload)) },
+      on(event, l) { if (event === 'message') { listeners[idx] = l as (p: string) => void; return () => { listeners[idx] = null } } return () => {} },
+      close() { listeners[idx] = null },
+    })
+  }
+  return chans
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0))
+
+/** A controllable onAfterWrite source: returns a subscribe fn + a fire fn. */
+function fakeAfterWrite() {
+  const handlers = new Set<(e: WriteEvent) => void>()
+  return {
+    subscribe: (h: (e: WriteEvent) => void) => { handlers.add(h); return () => handlers.delete(h) },
+    fire: (e: WriteEvent) => { for (const h of handlers) h(e) },
+  }
+}
+
+function ev(partial: Partial<WriteEvent>): WriteEvent {
+  return { op: 'update', vault: 'books', collection: 'invoices', docId: 'i1', before: null, after: { id: 'i1' }, userId: 'u', timestamp: 0, txId: 't', ...partial }
+}
+
+describe('CrossTabWriteRelay', () => {
+  it('broadcasts a tab-write signal on a local committed write', async () => {
+    const [chA, chB] = makeBus(2)
+    const srcA = fakeAfterWrite()
+    let received: unknown
+    const relayA = new CrossTabWriteRelay({ channel: chA!, writerId: 'A', subscribeAfterWrite: srcA.subscribe, applyRemoteWrite: () => {} })
+    chB!.on('message', (p) => { received = JSON.parse(p) })
+    relayA.start()
+    srcA.fire(ev({ op: 'create', docId: 'i9' }))
+    await flush()
+    expect(received).toEqual({ kind: 'tab-write', writerId: 'A', vault: 'books', collection: 'invoices', docId: 'i9', action: 'put' })
+    relayA.dispose()
+  })
+
+  it('maps op:delete to action:delete', async () => {
+    const [chA, chB] = makeBus(2)
+    const srcA = fakeAfterWrite()
+    let received: { action?: string } = {}
+    const relayA = new CrossTabWriteRelay({ channel: chA!, writerId: 'A', subscribeAfterWrite: srcA.subscribe, applyRemoteWrite: () => {} })
+    chB!.on('message', (p) => { received = JSON.parse(p) })
+    relayA.start()
+    srcA.fire(ev({ op: 'delete', after: null }))
+    await flush()
+    expect(received.action).toBe('delete')
+    relayA.dispose()
+  })
+
+  it('applies a foreign tab-write; ignores its own', async () => {
+    const [chA, chB] = makeBus(2)
+    const srcA = fakeAfterWrite(); const srcB = fakeAfterWrite()
+    const applied: Array<[string, string, string, string]> = []
+    const relayA = new CrossTabWriteRelay({ channel: chA!, writerId: 'A', subscribeAfterWrite: srcA.subscribe, applyRemoteWrite: () => {} })
+    const relayB = new CrossTabWriteRelay({ channel: chB!, writerId: 'B', subscribeAfterWrite: srcB.subscribe, applyRemoteWrite: (v, c, d, a) => { applied.push([v, c, d, a]) } })
+    relayA.start(); relayB.start()
+    srcA.fire(ev({ docId: 'i1' }))   // A writes → B should apply
+    await flush()
+    srcB.fire(ev({ docId: 'i2' }))   // B writes → B must NOT apply its own
+    await flush()
+    expect(applied).toEqual([['books', 'invoices', 'i1', 'put']])
+    relayA.dispose(); relayB.dispose()
+  })
+
+  it('does not broadcast or apply after dispose', async () => {
+    const [chA, chB] = makeBus(2)
+    const srcA = fakeAfterWrite()
+    let count = 0
+    const relayA = new CrossTabWriteRelay({ channel: chA!, writerId: 'A', subscribeAfterWrite: srcA.subscribe, applyRemoteWrite: () => {} })
+    chB!.on('message', () => { count++ })
+    relayA.start()
+    relayA.dispose()
+    srcA.fire(ev({ docId: 'i1' }))
+    await flush()
+    expect(count).toBe(0)
+  })
+})

--- a/packages/hub/__tests__/write-hooks-integration.test.ts
+++ b/packages/hub/__tests__/write-hooks-integration.test.ts
@@ -28,6 +28,18 @@ describe('write lifecycle hooks (#230)', () => {
     expect(events[0]!.userId).toBe('alice')
   })
 
+  it('WriteEvent carries the vault name (#228b)', async () => {
+    const db = await setup()
+    const v = await db.openVault('demo')
+    const c = v.collection<Inv>('invoices')
+    const events: WriteEvent[] = []
+    db.onAfterWrite((e) => { events.push(e) })
+    await c.put('i1', { id: 'i1', amount: 1 })
+    expect(events).toHaveLength(1)
+    expect(events[0]!.vault).toBe('demo')
+    expect(events[0]!.collection).toBe('invoices')
+  })
+
   it('a throwing onBeforeWrite aborts the write', async () => {
     const db = await setup()
     const v = await db.openVault('demo')

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1108,7 +1108,7 @@ export class Collection<T> {
       const before = await this.#priorRecordForHook(id)
       event = {
         op: before === null ? 'create' : 'update',
-        collection: this.name, docId: id, before, after: record,
+        vault: this.vault, collection: this.name, docId: id, before, after: record,
         userId: this.keyring.userId, timestamp: Date.now(), txId: this.#txIdForHook(),
       }
       await this.writeHooks!.runBefore(event) // throw → aborts the write
@@ -1687,7 +1687,7 @@ export class Collection<T> {
     if (this.#hooksActive()) {
       const before = await this.#priorRecordForHook(id)
       event = {
-        op: 'delete', collection: this.name, docId: id, before, after: null,
+        op: 'delete', vault: this.vault, collection: this.name, docId: id, before, after: null,
         userId: this.keyring.userId, timestamp: Date.now(), txId: this.#txIdForHook(),
       }
       await this.writeHooks!.runBefore(event)

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -2796,6 +2796,17 @@ export class Collection<T> {
     this.indexes?.upsert(id, record, previous ? previous.record : null)
   }
 
+  /**
+   * #228b — apply a peer tab's committed write to THIS tab's in-memory view:
+   * re-read the (already-persisted) envelope from the shared store + refresh
+   * cache/indexes, then emit a `change` event so reactive consumers re-render.
+   * Never writes to the store and never fires write hooks, so it cannot loop.
+   */
+  async _applyRemoteChange(id: string, action: 'put' | 'delete'): Promise<void> {
+    await this._invalidateCacheEntry(id)
+    this.emitter.emit('change', { vault: this.vault, collection: this.name, id, action })
+  }
+
   private async ensureHydrated(): Promise<void> {
     if (this.hydrated) return
 

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -79,6 +79,7 @@ import { NoydbEventEmitter } from './events.js'
 import { WriteQueueTracker, type WriteQueue } from './write-queue.js'
 import { WriteHookRegistry, type WriteHook, type Unsubscribe } from './write-hooks.js'
 import { TabCoordinator, defaultLockManager, defaultChannel, type TabCoordinationOptions, type TabRole, type TabPresence } from './tab-coordination.js'
+import { CrossTabWriteRelay } from './tab-write-relay.js'
 import {
   loadKeyring,
   createOwnerKeyring,
@@ -193,6 +194,8 @@ export class Noydb {
   private sessionTimer: ReturnType<typeof setTimeout> | null = null
   /** Same-device multi-tab coordinator (#228); created on `enableTabCoordination()`. */
   private tabCoordinator: TabCoordinator | undefined
+  /** Cross-tab write relay (#228b); created on `enableTabCoordination()`. */
+  private writeRelay: CrossTabWriteRelay | undefined
   /** Per-vault policy enforcers. */
   private readonly policyEnforcers = new Map<string, PolicyEnforcer>()
   private readonly txStrategy: TxStrategy
@@ -1210,12 +1213,35 @@ export class Noydb {
     })
     this.tabCoordinator = c
     c.start()
+    if (opts.propagateWrites !== false) {
+      const writeChannel = opts.writeChannel ?? defaultChannel('noydb:tab-writes')
+      if (writeChannel) {
+        const relay = new CrossTabWriteRelay({
+          channel: writeChannel,
+          writerId: c.tabId,
+          subscribeAfterWrite: (h) => this.onAfterWrite(h),
+          applyRemoteWrite: (vault, collection, docId, action) => this.#applyRemoteWrite(vault, collection, docId, action),
+          // Own the channel only when we created the default (mirrors the presence channel).
+          closeChannelOnDispose: opts.writeChannel === undefined && writeChannel !== undefined,
+        })
+        this.writeRelay = relay
+        relay.start()
+      }
+    }
     return { dispose: () => this.disableTabCoordination() }
+  }
+
+  #applyRemoteWrite(vaultName: string, collectionName: string, docId: string, action: 'put' | 'delete'): Promise<void> {
+    const v = this.vaultCache.get(vaultName)
+    if (!v) return Promise.resolve()
+    return v._applyRemoteWrite(collectionName, docId, action)
   }
 
   private disableTabCoordination(): void {
     this.tabCoordinator?.dispose()
     this.tabCoordinator = undefined
+    this.writeRelay?.dispose()
+    this.writeRelay = undefined
   }
 
   get tabRole(): TabRole { return this.tabCoordinator?.role ?? 'unknown' }

--- a/packages/hub/src/tab-coordination.ts
+++ b/packages/hub/src/tab-coordination.ts
@@ -38,6 +38,17 @@ export interface TabCoordinationOptions {
    * channel it didn't create. Default: false.
    */
   readonly closeChannelOnDispose?: boolean
+  /**
+   * Also propagate committed writes to other tabs (#228b). Default true:
+   * when tab coordination is enabled and a channel is available, a write in
+   * one tab refreshes that document in every other tab. Set false to opt out.
+   */
+  readonly propagateWrites?: boolean
+  /**
+   * Channel for write propagation (#228b) — distinct from the presence
+   * channel. Default: an inline BroadcastChannel on `noydb:tab-writes`.
+   */
+  readonly writeChannel?: TabChannel
 }
 
 interface PresenceMsg { readonly kind: 'tab-presence'; readonly tabId: string; readonly lastSeen: number; readonly role: TabRole }

--- a/packages/hub/src/tab-write-relay.ts
+++ b/packages/hub/src/tab-write-relay.ts
@@ -1,0 +1,94 @@
+/**
+ * Cross-tab write propagation (#228b). A role-agnostic relay: it broadcasts
+ * a ciphertext-blind signal ({vault, collection, docId, action}) for every
+ * locally-committed write (via onAfterWrite, #230), and on receiving a peer
+ * tab's signal it asks the host to refresh that document's in-memory view by
+ * re-reading the shared encrypted store. Nothing decrypted crosses the wire.
+ */
+import type { TabChannel, Unsubscribe } from './tab-coordination.js'
+import type { WriteEvent } from './write-hooks.js'
+
+export interface TabWriteMsg {
+  readonly kind: 'tab-write'
+  readonly writerId: string
+  readonly vault: string
+  readonly collection: string
+  readonly docId: string
+  readonly action: 'put' | 'delete'
+}
+
+export interface CrossTabWriteRelayOptions {
+  /** The broadcast channel (its own — distinct from the presence channel). */
+  readonly channel: TabChannel
+  /** This tab's id — outgoing signals carry it; incoming self-signals are ignored. */
+  readonly writerId: string
+  /** Subscribe to committed writes (the host's onAfterWrite). */
+  readonly subscribeAfterWrite: (handler: (e: WriteEvent) => void) => Unsubscribe
+  /** Refresh a document's in-memory view from the shared store. */
+  readonly applyRemoteWrite: (vault: string, collection: string, docId: string, action: 'put' | 'delete') => void | Promise<void>
+  /** Close the channel on dispose (only when the relay created it). Default false. */
+  readonly closeChannelOnDispose?: boolean
+}
+
+export class CrossTabWriteRelay {
+  readonly #channel: TabChannel
+  readonly #writerId: string
+  readonly #subscribeAfterWrite: (handler: (e: WriteEvent) => void) => Unsubscribe
+  readonly #applyRemoteWrite: (vault: string, collection: string, docId: string, action: 'put' | 'delete') => void | Promise<void>
+  readonly #ownsChannel: boolean
+  #unsubMsg: Unsubscribe | undefined
+  #unsubWrite: Unsubscribe | undefined
+  #started = false
+  #disposed = false
+
+  constructor(opts: CrossTabWriteRelayOptions) {
+    this.#channel = opts.channel
+    this.#writerId = opts.writerId
+    this.#subscribeAfterWrite = opts.subscribeAfterWrite
+    this.#applyRemoteWrite = opts.applyRemoteWrite
+    this.#ownsChannel = opts.closeChannelOnDispose ?? false
+  }
+
+  start(): void {
+    if (this.#started || this.#disposed) return
+    this.#started = true
+    this.#unsubMsg = this.#channel.on('message', (p) => this.#onMessage(p))
+    this.#unsubWrite = this.#subscribeAfterWrite((e) => this.#onLocalWrite(e))
+  }
+
+  dispose(): void {
+    if (this.#disposed) return
+    this.#disposed = true
+    this.#unsubWrite?.()
+    this.#unsubMsg?.()
+    if (this.#ownsChannel) this.#channel.close()
+  }
+
+  #onLocalWrite(e: WriteEvent): void {
+    if (this.#disposed || !this.#channel.isOpen) return
+    const action: 'put' | 'delete' = e.op === 'delete' ? 'delete' : 'put'
+    const msg: TabWriteMsg = { kind: 'tab-write', writerId: this.#writerId, vault: e.vault, collection: e.collection, docId: e.docId, action }
+    this.#channel.send(JSON.stringify(msg))
+  }
+
+  #onMessage(payload: string): void {
+    if (this.#disposed) return
+    let msg: unknown
+    try { msg = JSON.parse(payload) } catch { return }
+    if (!isTabWriteMsg(msg) || msg.writerId === this.#writerId) return
+    void Promise.resolve(this.#applyRemoteWrite(msg.vault, msg.collection, msg.docId, msg.action)).catch((err) => {
+      console.warn(`[noy-db] cross-tab apply failed for ${msg.collection}/${msg.docId}: ` + (err instanceof Error ? err.message : String(err)))
+    })
+  }
+}
+
+function isTabWriteMsg(x: unknown): x is TabWriteMsg {
+  if (x === null || typeof x !== 'object') return false
+  const o = x as Record<string, unknown>
+  return o['kind'] === 'tab-write'
+    && typeof o['writerId'] === 'string'
+    && typeof o['vault'] === 'string'
+    && typeof o['collection'] === 'string'
+    && typeof o['docId'] === 'string'
+    && (o['action'] === 'put' || o['action'] === 'delete')
+}

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -847,6 +847,17 @@ export class Vault {
     await coll._applyCutoverTransform(transform)
   }
 
+  /**
+   * #228b — refresh a loaded collection's view of one document from a peer
+   * tab's broadcast. No-op when the collection isn't loaded in this tab
+   * (it will read fresh on next open). Mirrors #runCutoverTransform's guard.
+   */
+  async _applyRemoteWrite(collectionName: string, docId: string, action: 'put' | 'delete'): Promise<void> {
+    const coll = this.collectionCache.get(collectionName)
+    if (!coll) return
+    await coll._applyRemoteChange(docId, action)
+  }
+
   /** Recover a stuck cutover fence (#232) — reset to normal without bumping. */
   async abortSchemaCutover(): Promise<void> {
     await this.schemaFence.abort()

--- a/packages/hub/src/write-hooks.ts
+++ b/packages/hub/src/write-hooks.ts
@@ -6,6 +6,7 @@
  */
 export interface WriteEvent {
   readonly op: 'create' | 'update' | 'delete'
+  readonly vault: string
   readonly collection: string
   readonly docId: string
   readonly before: unknown // decrypted prior record; null on 'create'


### PR DESCRIPTION
## Summary

Sub-slice **(b)** of multi-client write coordination (#228): when a write commits in one same-origin tab, every other tab that has the collection loaded refreshes its in-memory view of that document — no reload. **Ciphertext-blind** (only `{vault, collection, docId, action}` cross the channel; receivers re-read the shared encrypted store), **role-agnostic**, opt-in via the same `db.enableTabCoordination()` surface as (a).

- **`CrossTabWriteRelay`** (`tab-write-relay.ts`, own `noydb:tab-writes` channel) — subscribes to `onAfterWrite` (#230) and broadcasts a signal on each committed write; on a foreign signal, asks the host to refresh that doc.
- **Apply primitives:** `Collection._applyRemoteChange` (re-read via `_invalidateCacheEntry` + emit `change`) and `Vault._applyRemoteWrite` (loaded-collection guard, mirrors `#runCutoverTransform`). Apply never calls `put`/hooks → **no broadcast loop**.
- **Wiring:** folded into `db.enableTabCoordination({ propagateWrites, writeChannel })` (default on); torn down in `disableTabCoordination`/`close`.
- **Prereq:** added `vault` to `WriteEvent` (#230) — backward-compatible; a receiver needs the vault to resolve the loaded collection.

## Scope

In: relay, apply primitives, `WriteEvent.vault`, the enable wiring + no-op, `features.yaml`. Out (later): `_v`/`base` in the signal + `WriteConflict` detection → (c); primary-routed/serialized writes; cross-device (sync engine).

## Notes

- The integration test seeds a write in db1 to mint+persist the per-collection DEK **before** creating db2, so both tabs share the same DEK (multi-instance keyring requirement; differs slightly from the plan's draft test ordering).

## Test Plan

- [x] 9 new tests: relay unit (4), apply primitives (2), end-to-end put/delete propagation + `propagateWrites:false` opt-out + no-channel no-op (3)
- [x] full hub suite **1977 pass** (200 files), clean exit
- [x] `tsc --noEmit` + lint + build clean; `features.yaml` validator OK (44 features)