### PR TITLE
feat(hub): cross-tab write conflict detection (#228 sub-slice c)

### DIFF
--- a/docs/superpowers/plans/2026-06-01-228c-conflict-detection.md
+++ b/docs/superpowers/plans/2026-06-01-228c-conflict-detection.md
@@ -1,0 +1,556 @@
+# Cross-tab conflict detection (#228 sub-slice c) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When two same-origin tabs write the same document concurrently, each tab emits a `WriteConflict` (decrypted `local`/`remote`/`base` + versions) so the app can reconcile; the hub converges the cache to the store's authoritative value but never auto-resolves.
+
+**Architecture:** Extend the (b) propagation signal with `baseV`/`v` (sourced from two new `WriteEvent` fields). The relay keeps a per-doc own-write ledger and detects a conflict when an incoming write's `baseV` is below this tab's own-write version; it then calls a host `reportConflict` callback that captures the clobbered record, converges via the existing (b) re-read, reads the ancestor from history, and emits `write:conflict`. Post-hoc, role-agnostic, no write-path CAS.
+
+**Tech Stack:** TypeScript, Vitest. Package: `packages/hub`. Builds on (b)'s `CrossTabWriteRelay`, `_applyRemoteChange`, `_applyRemoteWrite`.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-228c-conflict-detection-design.md`. Issue #228 (final slice).
+
+---
+
+## File structure
+
+- **Modify** `packages/hub/src/write-hooks.ts` — `baseVersion` + `version` on `WriteEvent`.
+- **Modify** `packages/hub/src/collection.ts` — `#priorRecordForHook` → `#priorForHook` (also returns version); set the two new fields at both emit sites; add `_peekCached(id)`.
+- **Modify** `packages/hub/src/tab-write-relay.ts` — `baseV`/`v` on `TabWriteMsg`; own-write ledger; conflict rule; optional `reportConflict`.
+- **Modify** `packages/hub/src/vault.ts` — `_captureAndConverge(collectionName, docId, action, baseV)`.
+- **Modify** `packages/hub/src/types.ts` — `WriteConflict` interface + `'write:conflict'` in `NoydbEventMap`.
+- **Modify** `packages/hub/src/noydb.ts` — wire `reportConflict` → `#reportWriteConflict`; add `onWriteConflict`.
+- **Modify** `packages/hub/src/index.ts` — export `WriteConflict`.
+- **Modify** `features.yaml` — extend the `cross-tab-write-propagation` entry (or add a conflict entry).
+- **Tests:** extend `__tests__/write-hooks-integration.test.ts`, `__tests__/tab-write-relay.test.ts`, `__tests__/tab-write-propagation.test.ts`.
+
+---
+
+## Task 1: `baseVersion` + `version` on `WriteEvent`
+
+**Files:** Modify `packages/hub/src/write-hooks.ts`, `packages/hub/src/collection.ts:1106-1135`, `:1686-1692`; Test `packages/hub/__tests__/write-hooks-integration.test.ts`
+
+- [ ] **Step 1: Write the failing test** — append inside `describe('write lifecycle hooks (#230)', ...)`:
+
+```ts
+  it('WriteEvent carries baseVersion and version (#228c)', async () => {
+    const db = await setup()
+    const v = await db.openVault('demo')
+    const c = v.collection<Inv>('invoices')
+    const events: WriteEvent[] = []
+    db.onAfterWrite((e) => { events.push(e) })
+    await c.put('i1', { id: 'i1', amount: 1 }) // create
+    await c.put('i1', { id: 'i1', amount: 2 }) // update
+    expect(events[0]!.baseVersion).toBe(0)
+    expect(events[0]!.version).toBe(1)
+    expect(events[1]!.baseVersion).toBe(1)
+    expect(events[1]!.version).toBe(2)
+  })
+```
+
+- [ ] **Step 2: Run → fail** (`cd packages/hub && npx vitest run __tests__/write-hooks-integration.test.ts -t "baseVersion"`) — `undefined`.
+
+- [ ] **Step 3a: Add the fields** — `packages/hub/src/write-hooks.ts`, in `WriteEvent` after `after`:
+
+```ts
+  readonly after: unknown // the record written; null on 'delete'
+  readonly baseVersion: number // #228c — version the writer started from (0 on create)
+  readonly version: number // #228c — version the writer wrote (baseVersion + 1)
+```
+
+- [ ] **Step 3b: Refactor the prior-record helper** — `packages/hub/src/collection.ts`, replace `#priorRecordForHook` (~line 1127):
+
+```ts
+  async #priorForHook(id: string): Promise<{ record: unknown; version: number }> {
+    const env = await this.adapter.get(this.vault, this.name, id)
+    if (!env) return { record: null, version: 0 }
+    return { record: (await this.decryptRecord(env, { skipValidation: true })) as unknown, version: env._v }
+  }
+```
+
+- [ ] **Step 3c: Update the put emit site** (~line 1106-1113):
+
+```ts
+    let event: WriteEvent | undefined
+    if (this.#hooksActive()) {
+      const prior = await this.#priorForHook(id)
+      event = {
+        op: prior.record === null ? 'create' : 'update',
+        vault: this.vault, collection: this.name, docId: id, before: prior.record, after: record,
+        userId: this.keyring.userId, timestamp: Date.now(), txId: this.#txIdForHook(),
+        baseVersion: prior.version, version: prior.version + 1,
+      }
+      await this.writeHooks!.runBefore(event) // throw → aborts the write
+    }
+```
+
+- [ ] **Step 3d: Update the delete emit site** (~line 1686-1692):
+
+```ts
+    let event: WriteEvent | undefined
+    if (this.#hooksActive()) {
+      const prior = await this.#priorForHook(id)
+      event = {
+        op: 'delete', vault: this.vault, collection: this.name, docId: id, before: prior.record, after: null,
+        userId: this.keyring.userId, timestamp: Date.now(), txId: this.#txIdForHook(),
+        baseVersion: prior.version, version: prior.version + 1,
+      }
+      await this.writeHooks!.runBefore(event)
+    }
+```
+
+- [ ] **Step 4: Run → pass + typecheck** (`cd packages/hub && npx vitest run __tests__/write-hooks-integration.test.ts && npx tsc --noEmit`). Expected: PASS, clean. (tsc will confirm there are no other `WriteEvent` literals missing the new fields.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/vicio/_github/noy-db && git add packages/hub/src/write-hooks.ts packages/hub/src/collection.ts packages/hub/__tests__/write-hooks-integration.test.ts
+git commit -m "feat(hub): add baseVersion/version to WriteEvent (#228)"
+```
+
+---
+
+## Task 2: relay — own-write ledger + conflict rule
+
+**Files:** Modify `packages/hub/src/tab-write-relay.ts`; Test `packages/hub/__tests__/tab-write-relay.test.ts`
+
+- [ ] **Step 1: Update the unit test** — `packages/hub/__tests__/tab-write-relay.test.ts`. (a) extend `ev()` to set the new fields; (b) update the two broadcast-shape assertions to include `baseV`/`v`; (c) add three conflict-rule tests. Replace the `ev` helper and append the new tests:
+
+Replace the `ev` helper with:
+```ts
+function ev(partial: Partial<WriteEvent>): WriteEvent {
+  return { op: 'update', vault: 'books', collection: 'invoices', docId: 'i1', before: null, after: { id: 'i1' }, userId: 'u', timestamp: 0, txId: 't', baseVersion: 3, version: 4, ...partial }
+}
+```
+
+In the first test (`broadcasts a tab-write signal...`), change the expected object to:
+```ts
+    expect(received).toEqual({ kind: 'tab-write', writerId: 'A', vault: 'books', collection: 'invoices', docId: 'i9', action: 'put', baseV: 3, v: 4 })
+```
+
+In the second test (`maps op:delete...`) no change is needed (it only checks `received.action`).
+
+Append these tests inside the `describe('CrossTabWriteRelay', ...)` block:
+```ts
+  it('reports a conflict when a remote write predates this tab\'s own write', async () => {
+    const [chA, chB] = makeBus(2)
+    const srcA = fakeAfterWrite(); const srcB = fakeAfterWrite()
+    const applied: string[] = []; const conflicts: Array<[string, number, number, number]> = []
+    const relayA = new CrossTabWriteRelay({ channel: chA!, writerId: 'A', subscribeAfterWrite: srcA.subscribe, applyRemoteWrite: () => {} })
+    const relayB = new CrossTabWriteRelay({
+      channel: chB!, writerId: 'B', subscribeAfterWrite: srcB.subscribe,
+      applyRemoteWrite: (_v, _c, d) => { applied.push(d) },
+      reportConflict: (_v, _c, d, _a, baseV, v, ownV) => { conflicts.push([d, baseV, v, ownV]) },
+    })
+    relayA.start(); relayB.start()
+    srcB.fire(ev({ docId: 'i1', baseVersion: 3, version: 4 })) // B writes i1 @v4 → ledger[i1]=4
+    srcA.fire(ev({ docId: 'i1', baseVersion: 3, version: 4 })) // A wrote i1 from base 3 too
+    await flush()
+    expect(conflicts).toEqual([['i1', 3, 4, 4]]) // baseV 3 < ownV 4 → conflict
+    expect(applied).toEqual([])                  // conflict path does NOT also apply
+    relayA.dispose(); relayB.dispose()
+  })
+
+  it('no conflict when the remote incorporated our write (baseV >= ownV)', async () => {
+    const [chA, chB] = makeBus(2)
+    const srcA = fakeAfterWrite(); const srcB = fakeAfterWrite()
+    const applied: string[] = []; let conflictCount = 0
+    const relayA = new CrossTabWriteRelay({ channel: chA!, writerId: 'A', subscribeAfterWrite: srcA.subscribe, applyRemoteWrite: () => {} })
+    const relayB = new CrossTabWriteRelay({
+      channel: chB!, writerId: 'B', subscribeAfterWrite: srcB.subscribe,
+      applyRemoteWrite: (_v, _c, d) => { applied.push(d) },
+      reportConflict: () => { conflictCount++ },
+    })
+    relayA.start(); relayB.start()
+    srcB.fire(ev({ docId: 'i1', baseVersion: 3, version: 4 }))   // ledger[i1]=4
+    srcA.fire(ev({ docId: 'i1', baseVersion: 4, version: 5 }))   // A built on our v4
+    await flush()
+    expect(conflictCount).toBe(0)
+    expect(applied).toEqual(['i1'])
+    relayA.dispose(); relayB.dispose()
+  })
+
+  it('no conflict for a doc this tab never wrote', async () => {
+    const [chA, chB] = makeBus(2)
+    const srcA = fakeAfterWrite(); const srcB = fakeAfterWrite()
+    const applied: string[] = []; let conflictCount = 0
+    const relayA = new CrossTabWriteRelay({ channel: chA!, writerId: 'A', subscribeAfterWrite: srcA.subscribe, applyRemoteWrite: () => {} })
+    const relayB = new CrossTabWriteRelay({
+      channel: chB!, writerId: 'B', subscribeAfterWrite: srcB.subscribe,
+      applyRemoteWrite: (_v, _c, d) => { applied.push(d) },
+      reportConflict: () => { conflictCount++ },
+    })
+    relayA.start(); relayB.start()
+    srcA.fire(ev({ docId: 'i2', baseVersion: 3, version: 4 }))   // B never wrote i2
+    await flush()
+    expect(conflictCount).toBe(0)
+    expect(applied).toEqual(['i2'])
+    relayA.dispose(); relayB.dispose()
+  })
+```
+
+- [ ] **Step 2: Run → fail** (`cd packages/hub && npx vitest run __tests__/tab-write-relay.test.ts`) — `baseV`/`v` missing from msg; `reportConflict` not honored.
+
+- [ ] **Step 3: Implement** — edit `packages/hub/src/tab-write-relay.ts`:
+
+(a) `TabWriteMsg` — add the two fields:
+```ts
+export interface TabWriteMsg {
+  readonly kind: 'tab-write'
+  readonly writerId: string
+  readonly vault: string
+  readonly collection: string
+  readonly docId: string
+  readonly action: 'put' | 'delete'
+  readonly baseV: number
+  readonly v: number
+}
+```
+
+(b) `CrossTabWriteRelayOptions` — add:
+```ts
+  /** Report a detected conflict (host captures + converges + emits). #228c. */
+  readonly reportConflict?: (vault: string, collection: string, docId: string, action: 'put' | 'delete', baseV: number, v: number, ownV: number) => void | Promise<void>
+```
+
+(c) Fields — add to the class:
+```ts
+  readonly #reportConflict: CrossTabWriteRelayOptions['reportConflict']
+  readonly #ledger = new Map<string, number>()
+```
+and in the constructor: `this.#reportConflict = opts.reportConflict`.
+
+(d) A key helper (module scope, bottom of file):
+```ts
+function ledgerKey(vault: string, collection: string, docId: string): string {
+  return `${vault} ${collection} ${docId}`
+}
+```
+
+(e) `#onLocalWrite` — record the ledger and broadcast versions:
+```ts
+  #onLocalWrite(e: WriteEvent): void {
+    if (this.#disposed || !this.#channel.isOpen) return
+    this.#ledger.set(ledgerKey(e.vault, e.collection, e.docId), e.version)
+    const action: 'put' | 'delete' = e.op === 'delete' ? 'delete' : 'put'
+    const msg: TabWriteMsg = { kind: 'tab-write', writerId: this.#writerId, vault: e.vault, collection: e.collection, docId: e.docId, action, baseV: e.baseVersion, v: e.version }
+    this.#channel.send(JSON.stringify(msg))
+  }
+```
+
+(f) `#onMessage` — apply the conflict rule:
+```ts
+  #onMessage(payload: string): void {
+    if (this.#disposed) return
+    let msg: unknown
+    try { msg = JSON.parse(payload) } catch { return }
+    if (!isTabWriteMsg(msg) || msg.writerId === this.#writerId) return
+    const key = ledgerKey(msg.vault, msg.collection, msg.docId)
+    const ownV = this.#ledger.get(key)
+    if (ownV !== undefined && msg.baseV < ownV && this.#reportConflict) {
+      void Promise.resolve(this.#reportConflict(msg.vault, msg.collection, msg.docId, msg.action, msg.baseV, msg.v, ownV)).catch((err) => {
+        console.warn(`[noy-db] cross-tab conflict report failed for ${msg.collection}/${msg.docId}: ` + (err instanceof Error ? err.message : String(err)))
+      })
+      return
+    }
+    if (ownV !== undefined && msg.baseV >= ownV) this.#ledger.set(key, msg.v) // remote incorporated our write → advance
+    void Promise.resolve(this.#applyRemoteWrite(msg.vault, msg.collection, msg.docId, msg.action)).catch((err) => {
+      console.warn(`[noy-db] cross-tab apply failed for ${msg.collection}/${msg.docId}: ` + (err instanceof Error ? err.message : String(err)))
+    })
+  }
+```
+
+(g) `isTabWriteMsg` — validate the new fields (add to the boolean chain):
+```ts
+    && (o['action'] === 'put' || o['action'] === 'delete')
+    && typeof o['baseV'] === 'number'
+    && typeof o['v'] === 'number'
+```
+
+- [ ] **Step 4: Run → pass + typecheck + lint** (`cd packages/hub && npx vitest run __tests__/tab-write-relay.test.ts && npx tsc --noEmit && npx eslint src/tab-write-relay.ts`). Expected: all pass; clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/vicio/_github/noy-db && git add packages/hub/src/tab-write-relay.ts packages/hub/__tests__/tab-write-relay.test.ts
+git commit -m "feat(hub): relay own-write ledger + conflict rule (#228)"
+```
+
+---
+
+## Task 3: `Collection._peekCached` + `Vault._captureAndConverge`
+
+**Files:** Modify `packages/hub/src/collection.ts` (after `_applyRemoteChange`), `packages/hub/src/vault.ts` (after `_applyRemoteWrite`); Test `packages/hub/__tests__/tab-write-propagation.test.ts`
+
+- [ ] **Step 1: Write the failing test** — append a describe to `packages/hub/__tests__/tab-write-propagation.test.ts`:
+
+```ts
+describe('capture + converge primitive (#228c)', () => {
+  it('_captureAndConverge yields local (clobbered), remote (store), base (ancestor)', async () => {
+    const { db1, db2, v2, c1, c2 } = await twoTabs() // db1 seeded { seed, amount:0 } @v1
+    await c2.get('seed')              // db2 caches seed @v1
+    await c1.put('seed', { id: 'seed', amount: 99 }) // db1 overwrites in shared store @v2
+
+    const cap = await v2._captureAndConverge('invoices', 'seed', 'put', 1)
+    expect(cap).not.toBeNull()
+    expect((cap!.local as { amount: number }).amount).toBe(0)   // db2's pre-converge cache
+    expect((cap!.remote as { amount: number }).amount).toBe(99) // store after converge
+    expect((cap!.base as { amount: number }).amount).toBe(0)    // ancestor @v1 from history
+    db1.close(); db2.close()
+  })
+
+  it('_captureAndConverge returns null for an unloaded collection', async () => {
+    const db = await createNoydb({ store: memory(), user: 'alice', secret: SECRET })
+    const v = await db.openVault('books')
+    expect(await v._captureAndConverge('not-loaded', 'x', 'put', 0)).toBeNull()
+    db.close()
+  })
+})
+```
+
+- [ ] **Step 2: Run → fail** (`cd packages/hub && npx vitest run __tests__/tab-write-propagation.test.ts -t "capture"`) — methods don't exist.
+
+- [ ] **Step 3a: `Collection._peekCached`** — add to `packages/hub/src/collection.ts` immediately after `_applyRemoteChange`:
+
+```ts
+  /** @internal #228c — the current in-memory record without a store read (for conflict capture). */
+  _peekCached(id: string): T | null {
+    const entry = this.lazy && this.lru ? this.lru.get(id) : this.cache.get(id)
+    return entry ? entry.record : null
+  }
+```
+
+- [ ] **Step 3b: `Vault._captureAndConverge`** — add to `packages/hub/src/vault.ts` immediately after `_applyRemoteWrite`:
+
+```ts
+  /**
+   * #228c — for a detected conflict: capture this tab's clobbered record,
+   * read the common ancestor from history, converge the cache to the store's
+   * authoritative value (the (b) re-read), and return all three for the
+   * WriteConflict payload. Returns null when the collection isn't loaded.
+   */
+  async _captureAndConverge(
+    collectionName: string,
+    docId: string,
+    action: 'put' | 'delete',
+    baseV: number,
+  ): Promise<{ local: unknown; remote: unknown; base: unknown } | null> {
+    const coll = this.collectionCache.get(collectionName)
+    if (!coll) return null
+    const local = coll._peekCached(docId)
+    let base: unknown = null
+    try { base = await coll.getVersion(docId, baseV) } catch { base = null }
+    await coll._applyRemoteChange(docId, action)
+    const remote = coll._peekCached(docId)
+    return { local, remote, base }
+  }
+```
+
+- [ ] **Step 4: Run → pass + typecheck** (`cd packages/hub && npx vitest run __tests__/tab-write-propagation.test.ts -t "capture" && npx tsc --noEmit`). Expected: 2 pass, clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/vicio/_github/noy-db && git add packages/hub/src/collection.ts packages/hub/src/vault.ts packages/hub/__tests__/tab-write-propagation.test.ts
+git commit -m "feat(hub): _peekCached + _captureAndConverge for conflict capture (#228)"
+```
+
+---
+
+## Task 4: `WriteConflict` type, `noydb` wiring, `onWriteConflict`
+
+**Files:** Modify `packages/hub/src/types.ts`, `packages/hub/src/noydb.ts`, `packages/hub/src/index.ts`; Test `packages/hub/__tests__/tab-write-propagation.test.ts`
+
+- [ ] **Step 1: Write the failing integration test** — append to `packages/hub/__tests__/tab-write-propagation.test.ts`. Add a manual (deferred-delivery) bus + a conflict-counting describe:
+
+```ts
+/** A bus that QUEUES sends until deliver() — lets both tabs write before any delivery. */
+function makeManualBus(n: number): { chans: TabChannel[]; deliver: () => void } {
+  const listeners: Array<((p: string) => void) | null> = []
+  const queue: Array<{ from: number; payload: string }> = []
+  const chans: TabChannel[] = []
+  for (let i = 0; i < n; i++) {
+    const idx = i
+    chans.push({
+      isOpen: true,
+      send(payload) { queue.push({ from: idx, payload }) },
+      on(event, l) { if (event === 'message') { listeners[idx] = l as (p: string) => void; return () => { listeners[idx] = null } } return () => {} },
+      close() { listeners[idx] = null },
+    })
+  }
+  const deliver = () => { const q = queue.splice(0); for (const { from, payload } of q) for (let j = 0; j < listeners.length; j++) if (j !== from && listeners[j]) listeners[j]!(payload) }
+  return { chans, deliver }
+}
+
+describe('cross-tab conflict detection (#228c)', () => {
+  it('concurrent writes: both tabs emit WriteConflict; caches converge', async () => {
+    const { db1, db2, c1, c2 } = await twoTabs() // seed 'i1' @v1 in db1
+    const { chans: [wA, wB], deliver } = makeManualBus(2)
+    db1.enableTabCoordination({ writeChannel: wA!, tabId: 'A' })
+    db2.enableTabCoordination({ writeChannel: wB!, tabId: 'B' })
+    await c1.get('seed'); await c2.get('seed') // hydrate both
+
+    const seen1: import('../src/types.js').WriteConflict[] = []
+    const seen2: import('../src/types.js').WriteConflict[] = []
+    db1.onWriteConflict((cf) => seen1.push(cf))
+    db2.onWriteConflict((cf) => seen2.push(cf))
+
+    // Concurrent: both write 'seed' from base v1 before any signal is delivered.
+    await c1.put('seed', { id: 'seed', amount: 10 }) // db1 → store
+    await c2.put('seed', { id: 'seed', amount: 20 }) // db2 → store (wins LWW)
+    deliver()
+    await settle()
+
+    expect(seen1).toHaveLength(1)
+    expect(seen2).toHaveLength(1)
+    expect((seen1[0]!.local as { amount: number }).amount).toBe(10)  // db1 (loser) clobbered write
+    expect((seen1[0]!.remote as { amount: number }).amount).toBe(20) // store's winner
+    expect((seen1[0]!.base as { amount: number }).amount).toBe(0)    // ancestor (seed)
+    expect(seen1[0]!.baseVersion).toBe(1)
+    expect((await c1.get('seed'))!.amount).toBe(20)                  // db1 converged
+    expect((await c2.get('seed'))!.amount).toBe(20)
+    db1.close(); db2.close()
+  })
+
+  it('a write the other tab has already seen fires no conflict', async () => {
+    const { db1, db2, c1, c2 } = await twoTabs()
+    const { chans: [wA, wB], deliver } = makeManualBus(2)
+    db1.enableTabCoordination({ writeChannel: wA!, tabId: 'A' })
+    db2.enableTabCoordination({ writeChannel: wB!, tabId: 'B' })
+    await c2.get('seed')
+    let conflicts = 0
+    db2.onWriteConflict(() => { conflicts++ })
+
+    await c1.put('seed', { id: 'seed', amount: 5 }) // db2 never wrote 'seed'
+    deliver()
+    await settle()
+
+    expect(conflicts).toBe(0)
+    expect((await c2.get('seed'))!.amount).toBe(5) // applied, no conflict
+    db1.close(); db2.close()
+  })
+})
+```
+
+- [ ] **Step 2: Run → fail** (`onWriteConflict`/`WriteConflict` don't exist).
+
+- [ ] **Step 3a: `WriteConflict` + event** — `packages/hub/src/types.ts`. Add the interface next to `Conflict` (search `export interface Conflict`):
+
+```ts
+/**
+ * #228c — a same-device cross-tab write conflict: another tab overwrote a
+ * document this tab had written, having diverged from an older base. Records
+ * are decrypted (cross-tab handlers reconcile in plaintext). `base` is the
+ * common ancestor from history, or null when history is unavailable.
+ */
+export interface WriteConflict {
+  readonly vault: string
+  readonly collection: string
+  readonly docId: string
+  readonly local: unknown
+  readonly remote: unknown
+  readonly base: unknown | null
+  readonly localVersion: number
+  readonly remoteVersion: number
+  readonly baseVersion: number
+}
+```
+
+In `NoydbEventMap`, add (next to `'sync:conflict': Conflict`):
+```ts
+  'write:conflict': WriteConflict
+```
+
+- [ ] **Step 3b: noydb wiring** — `packages/hub/src/noydb.ts`.
+
+Import the type (extend the existing `types.js` type import, or add one):
+```ts
+import type { WriteConflict } from './types.js'
+```
+
+In `enableTabCoordination`, add `reportConflict` to the `CrossTabWriteRelay` options (alongside `applyRemoteWrite`):
+```ts
+          reportConflict: (vault, collection, docId, action, baseV, v, ownV) => this.#reportWriteConflict(vault, collection, docId, action, baseV, v, ownV),
+```
+
+Add the reporter beside `#applyRemoteWrite`:
+```ts
+  async #reportWriteConflict(vaultName: string, collectionName: string, docId: string, action: 'put' | 'delete', baseV: number, v: number, ownV: number): Promise<void> {
+    const vault = this.vaultCache.get(vaultName)
+    if (!vault) return
+    const cap = await vault._captureAndConverge(collectionName, docId, action, baseV)
+    if (!cap) return
+    const conflict: WriteConflict = {
+      vault: vaultName, collection: collectionName, docId,
+      local: cap.local, remote: cap.remote, base: cap.base,
+      localVersion: ownV, remoteVersion: v, baseVersion: baseV,
+    }
+    this.emitter.emit('write:conflict', conflict)
+  }
+```
+
+Add the subscription helper near `onAfterWrite` (~line 1190):
+```ts
+  /** Subscribe to cross-tab write conflicts (#228c). Returns an unsubscribe. */
+  onWriteConflict(fn: (c: WriteConflict) => void): Unsubscribe {
+    this.on('write:conflict', fn)
+    return () => this.off('write:conflict', fn)
+  }
+```
+
+- [ ] **Step 3c: export** — `packages/hub/src/index.ts`, in the multi-tab block:
+```ts
+// Cross-tab write conflict (#228c)
+export type { WriteConflict } from './types.js'
+```
+
+- [ ] **Step 4: Run → pass + typecheck + lint + full suite**
+
+Run: `cd packages/hub && npx vitest run __tests__/tab-write-propagation.test.ts && npx tsc --noEmit && npx eslint src/noydb.ts src/types.ts && npx vitest run`
+Expected: propagation suite passes; tsc + eslint clean; full suite green, clean exit.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/vicio/_github/noy-db && git add packages/hub/src/types.ts packages/hub/src/noydb.ts packages/hub/src/index.ts packages/hub/__tests__/tab-write-propagation.test.ts
+git commit -m "feat(hub): WriteConflict + onWriteConflict — cross-tab conflict detection (#228)"
+```
+
+---
+
+## Task 5: register the feature + final verify
+
+**Files:** Modify `features.yaml`
+
+- [ ] **Step 1: Add invariants** — in `features.yaml`, append two invariants to the existing `cross-tab-write-propagation` entry's `invariants:` list (just before its `related:` line):
+
+```yaml
+      - 'concurrent same-doc writes are detected: each tab emits a WriteConflict (decrypted local/remote/base + versions) when a remote write diverged from a base older than its own write (#228c)'
+      - 'conflict detection converges the cache to the store but never auto-resolves; a tab that never wrote the doc never reports a conflict'
+```
+
+- [ ] **Step 2: Validate + full verify**
+
+```bash
+cd /Users/vicio/_github/noy-db && node scripts/validate-features.mjs
+cd packages/hub && npx vitest run && npx tsc --noEmit && npm run lint && npm run build
+```
+Expected: validator PASS; full suite PASS (clean exit); tsc + lint + build clean.
+
+- [ ] **Step 3: Commit + clean tree**
+
+```bash
+cd /Users/vicio/_github/noy-db && git add features.yaml
+git commit -m "chore(hub): register cross-tab conflict-detection invariants (#228)"
+git status
+```
+
+---
+
+## Self-review checklist (applied)
+
+- **Spec coverage:** `baseV`/`v` signal + `baseVersion`/`version` on `WriteEvent` → Task 1 + Task 2; own-write ledger + `baseV < ownV` rule → Task 2; `WriteConflict` decrypted payload + `base` from history → Task 3 (`_captureAndConverge` via `getVersion`) + Task 4; `onWriteConflict` / `write:conflict` → Task 4; converge-then-notify → Task 3 (`_applyRemoteChange` inside capture) + Task 4 reporter ordering; false-positive guard (no own-write ⇒ no conflict) → Task 2 test 3 + Task 4 test 2; both-tabs-emit → Task 4 test 1; opt-in/no-op inherited from (b) wiring; features.yaml → Task 5.
+- **Type consistency:** `WriteEvent.{baseVersion,version}`, `TabWriteMsg.{baseV,v}`, `reportConflict(vault,collection,docId,action,baseV,v,ownV)`, `_captureAndConverge(collectionName,docId,action,baseV) → {local,remote,base}|null`, `_peekCached(id):T|null`, `WriteConflict.{local,remote,base,localVersion,remoteVersion,baseVersion}`, `#reportWriteConflict(...)`, `onWriteConflict→Unsubscribe` — consistent across tasks; the relay's `reportConflict` arg order matches noydb's lambda and `#reportWriteConflict`.
+- **Reuse:** `_applyRemoteChange` (b), `getVersion` (history), `_applyRemoteWrite`'s loaded-collection guard, `db.on/off` (events.ts), the `#priorRecordForHook` envelope read (now also yields `_v` at zero extra cost).
+- **Determinism:** relay unit uses the in-memory bus + `fakeAfterWrite`; integration uses a **manual deferred-delivery bus** so both tabs write before any signal is delivered (true concurrency), shared `memory()` store + (b)'s seed-write keyring pattern, `settle()` for the async report/apply chains.
+- **No placeholders:** every code step shows complete code; every run step states command + expected result.

--- a/docs/superpowers/specs/2026-06-01-228c-conflict-detection-design.md
+++ b/docs/superpowers/specs/2026-06-01-228c-conflict-detection-design.md
@@ -66,7 +66,7 @@ interface WriteConflict {
 ```
 
 - **Surface:** `db.onWriteConflict(fn: (c: WriteConflict) => void): Unsubscribe`, plus a `write:conflict` entry in `NoydbEventMap` (so `db.on('write:conflict', …)` also works) — mirroring `onAfterWrite` / `onTabRoleChange`.
-- **`base`:** from `collection.getVersion(docId, baseV)` (per-doc history is on by default); `null` when history is disabled or that version was pruned.
+- **`base`:** from `collection.getVersion(docId, baseV)` — **best-effort**: the default history strategy is `NO_HISTORY` (its `getVersionEnvelope` throws), so `base` is `null` unless the app opted into `withHistory()`; it is also `null` when that version was pruned. `getVersion` failures are caught and degrade to `null`. `local`/`remote` and the versions are always present.
 
 ## Convergence + no auto-resolution
 

--- a/docs/superpowers/specs/2026-06-01-228c-conflict-detection-design.md
+++ b/docs/superpowers/specs/2026-06-01-228c-conflict-detection-design.md
@@ -1,0 +1,105 @@
+# Cross-tab conflict detection (#228 sub-slice c) — design
+
+**Status:** design approved · **Date:** 2026-06-01 · **Issue:** #228 (final slice) · **Epic:** hub coordination · **Builds on:** [#228(b) cross-tab write propagation](2026-06-01-228b-cross-tab-write-propagation-design.md), #230 write hooks
+
+Sub-slice **(c)** completes #228. When two same-origin tabs write the same document concurrently, the loser's write is silently overwritten (`collection.put` is last-write-wins: it bumps `version = cachedVersion + 1` with no compare-and-swap). This slice **detects** that divergence and emits a `WriteConflict` event so the application can reconcile. Resolution is left to the app — the hub never auto-merges. Browser-only, rides the same opt-in (`db.enableTabCoordination`) and the same `noydb:tab-writes` channel as (b).
+
+## Decision (locked)
+
+**Post-hoc divergence detection** (issue's stated model: "the hub detects this on merge and emits a conflict event… resolution is left to the application"). The (b) propagation signal is extended with versions; a receiving tab detects when a remote write diverged from a base older than its own write. The rejected alternative — write-time optimistic CAS (`collection.put` passing `expectedVersion` so the idb adapter throws `ConflictError`) — changes write semantics (puts can throw), is adapter-dependent, and does not notify other tabs, so it does not fit the issue's `onConflict` model.
+
+## Detection mechanism
+
+### Signal + WriteEvent extension
+
+`TabWriteMsg` (b) gains two fields:
+
+```ts
+interface TabWriteMsg {
+  readonly kind: 'tab-write'
+  readonly writerId: string
+  readonly vault: string
+  readonly collection: string
+  readonly docId: string
+  readonly action: 'put' | 'delete'
+  readonly baseV: number   // version the writer started from (0 on create)
+  readonly v: number       // version the writer wrote
+}
+```
+
+To source these at broadcast time, `WriteEvent` (#230) gains `readonly baseVersion: number` and `readonly version: number`, computed at the emit site in `collection.ts`: `baseVersion` = the cache's pre-write version for the id (`0` when absent / on create), `version = baseVersion + 1`. (`WriteEvent` already gained `vault` in (b); this is a second backward-compatible addition.) `baseVersion` is the load-bearing value — it accurately reflects the version the writer *saw*; `version` is informational (receivers re-read the store for authoritative state).
+
+### Own-write ledger
+
+Each tab keeps `Map<"vault\0collection\0docId", number>` — the version of each doc *this tab* last wrote (recorded on its own `onAfterWrite`). Bounded by the tab's write working-set. An entry advances or clears when a remote write that incorporated it arrives (see rule). This is a per-document **version-vector-lite**: one integer plus "did I write this."
+
+### Conflict rule (receiver side, per incoming remote `tab-write`)
+
+Let `ownV = ledger.get(key)`.
+
+| Condition | Meaning | Action |
+|---|---|---|
+| no `ownV` | this tab never wrote this doc | apply (fast-forward); no conflict |
+| `baseV >= ownV` | the remote writer built on (or past) our write | apply; set `ledger[key] = v`; no conflict |
+| **`baseV < ownV`** | **remote diverged from a base older than our write — they didn't see it** | **conflict** (then converge; keep ledger entry) |
+
+Under LWW both concurrent writers detect the conflict (each sees the other's `baseV` below its own write) and each emits — acceptable: both apps learn of it; reconciliation is idempotent.
+
+## `WriteConflict` payload + surface
+
+A new cross-tab type — distinct from sync's `Conflict` (which carries *encrypted envelopes*); cross-tab app handlers want decrypted records to reconcile:
+
+```ts
+interface WriteConflict {
+  readonly vault: string
+  readonly collection: string
+  readonly docId: string
+  readonly local: unknown        // the record THIS tab wrote (clobbered) — captured pre-converge
+  readonly remote: unknown       // the record now authoritative in the store (the other tab's)
+  readonly base: unknown | null  // common ancestor at baseV (from history); null if unavailable
+  readonly localVersion: number  // this tab's own-write version (ownV)
+  readonly remoteVersion: number // the incoming write's v
+  readonly baseVersion: number   // the incoming write's baseV
+}
+```
+
+- **Surface:** `db.onWriteConflict(fn: (c: WriteConflict) => void): Unsubscribe`, plus a `write:conflict` entry in `NoydbEventMap` (so `db.on('write:conflict', …)` also works) — mirroring `onAfterWrite` / `onTabRoleChange`.
+- **`base`:** from `collection.getVersion(docId, baseV)` (per-doc history is on by default); `null` when history is disabled or that version was pruned.
+
+## Convergence + no auto-resolution
+
+On conflict the relay **captures `local` from the current cache, then converges** (the existing (b) re-read — the cache now holds the store's authoritative `remote`), **then emits** `WriteConflict`. The cache never lies about the store; the app is told "your write was overwritten — here is yours, theirs, and the ancestor," and may re-`put` a merged or own value if it wants "keep mine." The hub performs no automatic resolution.
+
+## Architecture / where it lives
+
+- **`collection.ts`** — populate `WriteEvent.baseVersion`/`version` at the two emit sites (reuse the pre-write cache lookup already done for the `before` record).
+- **`tab-write-relay.ts` — the coordination brain.** It owns the own-write ledger (records `ledger[key] = e.version` from each local `onAfterWrite`) and runs the conflict rule on each incoming message. On **no conflict** it calls the host's existing `applyRemoteWrite(vault, collection, docId, action)` (converge). On **conflict** it instead calls a new injected `reportConflict(vault, collection, docId, baseV, v, ownV)` and leaves the ledger entry intact. The relay stays storage-agnostic — it never touches records itself.
+- **`noydb.ts` — the storage/emit arm.** Implements `reportConflict`: resolve loaded vault→collection, capture `local` (current cached record) and `localVersion`, read `base` via `getVersion(baseV)`, converge (existing `_applyRemoteWrite`) to capture `remote`, then emit `write:conflict`. Adds `onWriteConflict`. Both `applyRemoteWrite` and `reportConflict` are passed to the relay when coordination is enabled.
+- **`vault.ts`** — a helper to read a loaded collection's current cached record + `getVersion(baseV)` for the conflict payload (mirrors `_applyRemoteWrite`'s loaded-collection guard; no-op when the collection isn't loaded).
+
+## Error handling / edges
+
+- **History disabled / base pruned** → `base: null`; the event still fires with versions + local/remote.
+- **Collection/vault not loaded in the receiving tab** → no conflict possible (the tab has no own-write ledger entry and nothing cached); skip, exactly like (b).
+- **Delete vs put** → a remote delete diverging from our write is still a conflict (`remote: null`); a remote delete with no own write fast-forwards (cache delete), no conflict.
+- **False-positive guard** → a tab that only ever *applied* remote writes (never wrote the doc itself) has no ledger entry, so a late/reordered message cannot manufacture a phantom conflict.
+- **Reentrancy** → conflict emission is a read-side notification; it never writes, so it cannot loop (same guarantee as (b)).
+
+## Testing (deterministic, no real browser)
+
+- **Unit — extend `packages/hub/__tests__/tab-write-relay.test.ts`.** Inject a spy `reportConflict`. Assert: a remote msg with `baseV < ownV` (after a recorded local write) triggers `reportConflict`; `baseV >= ownV` and no-prior-local-write cases do **not**; the ledger advances on incorporation (a later `baseV >= v` clears the conflict condition).
+- **Integration — extend `packages/hub/__tests__/tab-write-propagation.test.ts`.** Two tabs sharing one `memory()` store (the (b) seed pattern). Drive a concurrent write: both tabs write the same doc from the same base, pump both buses; assert each tab emits a `WriteConflict` with correct `{local, remote, base, localVersion, remoteVersion, baseVersion}`, and caches converge to the store's LWW winner. Add a **sequential** (non-concurrent) write that fires **no** conflict — the false-positive regression guard.
+
+## Scope
+
+**In (c):** `baseV`/`v` on the signal; `baseVersion`/`version` on `WriteEvent`; the own-write ledger + conflict rule; `WriteConflict` + `onWriteConflict` + `write:conflict`; `base` from history; converge-then-notify; unit + integration tests; `features.yaml` registration.
+
+**Out:** automatic resolution / merge strategies (the app's job); write-time CAS (the rejected Approach B); cross-device conflict (the sync engine already has its own `Conflict`/`ConflictStrategy` model).
+
+## Success criteria
+
+1. Two tabs writing the same doc concurrently each emit a `WriteConflict` carrying decrypted `local` (their clobbered write), `remote` (the store's authoritative value), and `base` (the common ancestor, or `null` if history is unavailable), plus the three versions.
+2. A sequential write a tab *did* see (its broadcast `baseV >= ownV`) fast-forwards with **no** conflict.
+3. A tab that never wrote the doc never emits a conflict for it (no false positives from reordered/late messages).
+4. On conflict, the receiving tab's cache converges to the store's authoritative value before the event fires; the hub performs no automatic resolution.
+5. Opt-in via `enableTabCoordination` (rides (b)'s `propagateWrites`); a graceful no-op outside browsers.

--- a/docs/superpowers/specs/2026-06-01-228c-conflict-detection-design.md
+++ b/docs/superpowers/specs/2026-06-01-228c-conflict-detection-design.md
@@ -45,6 +45,8 @@ Let `ownV = ledger.get(key)`.
 
 Under LWW both concurrent writers detect the conflict (each sees the other's `baseV` below its own write) and each emits — acceptable: both apps learn of it; reconciliation is idempotent.
 
+**Known limitation (3+ tabs).** With three tabs the single-counter ledger can surface a *false* conflict: if B's write is incorporated by A (B advances its ledger to A's `v`), a third tab C that also diverged from the older base can then trip B's `baseV < ownV` check even though B's own write was already seen. Precise 3-way detection needs per-writer version vectors, which is out of scope here — this slice targets the 2-tab success criteria. The false positive is safe (it only over-notifies; the app reconciles idempotently and the cache still converges), and is documented rather than solved.
+
 ## `WriteConflict` payload + surface
 
 A new cross-tab type — distinct from sync's `Conflict` (which carries *encrypted envelopes*); cross-tab app handlers want decrypted records to reconcile:

--- a/docs/superpowers/specs/2026-06-01-228c-conflict-detection-design.md
+++ b/docs/superpowers/specs/2026-06-01-228c-conflict-detection-design.md
@@ -58,7 +58,7 @@ interface WriteConflict {
   readonly docId: string
   readonly local: unknown        // the record THIS tab wrote (clobbered) — captured pre-converge
   readonly remote: unknown       // the record now authoritative in the store (the other tab's)
-  readonly base: unknown | null  // common ancestor at baseV (from history); null if unavailable
+  readonly base: unknown  // common ancestor at baseV (from history); `null` at runtime if unavailable (typed `unknown`: `unknown | null` trips no-redundant-type-constituents)
   readonly localVersion: number  // this tab's own-write version (ownV)
   readonly remoteVersion: number // the incoming write's v
   readonly baseVersion: number   // the incoming write's baseV

--- a/features.yaml
+++ b/features.yaml
@@ -914,6 +914,25 @@ features:
       - 'opt-in via db.enableTabCoordination({ propagateWrites }) (default true); graceful no-op outside browsers'
     related: [tab-coordination, write-lifecycle-hooks]
 
+  - id: cross-tab-conflict-detection
+    name: Cross-tab write conflict detection
+    cluster: core
+    spec: docs/superpowers/specs/2026-06-01-228c-conflict-detection-design.md
+    subsystem_doc: docs/superpowers/specs/2026-06-01-228c-conflict-detection-design.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'concurrent same-doc writes are detected: each tab emits a WriteConflict (decrypted local/remote/base + versions) when a remote write diverged from a base older than its own write'
+      - 'the WriteEvent baseVersion/version are sourced from the write basis (cache), matching the version actually written — not a separate store read'
+      - 'detection converges the cache to the store but never auto-resolves; a tab that never wrote the doc never reports a conflict'
+      - 'opt-in via db.onWriteConflict / db.enableTabCoordination; base is null when history is unavailable (default NO_HISTORY)'
+    related: [cross-tab-write-propagation, write-lifecycle-hooks]
+
 # ─── Storage adapters (phase 2) ──────────────────────────────────────
 
 adapters:

--- a/packages/hub/__tests__/tab-write-propagation.test.ts
+++ b/packages/hub/__tests__/tab-write-propagation.test.ts
@@ -182,6 +182,8 @@ describe('cross-tab conflict detection (#228c)', () => {
     expect((seen1[0]!.remote as { amount: number }).amount).toBe(20) // store's winner
     expect((seen1[0]!.base as { amount: number }).amount).toBe(0)    // ancestor (seed)
     expect(seen1[0]!.baseVersion).toBe(1)
+    expect(seen1[0]!.localVersion).toBe(2)                           // db1's own-write version (ownV)
+    expect(seen1[0]!.remoteVersion).toBe(2)                          // incoming v — collides under LWW
     expect((await c1.get('seed'))!.amount).toBe(20)                  // db1 converged
     expect((await c2.get('seed'))!.amount).toBe(20)
     db1.close(); db2.close()

--- a/packages/hub/__tests__/tab-write-propagation.test.ts
+++ b/packages/hub/__tests__/tab-write-propagation.test.ts
@@ -120,4 +120,21 @@ describe('capture + converge primitive (#228c)', () => {
     expect(await v._captureAndConverge('not-loaded', 'x', 'put', 0)).toBeNull()
     db.close()
   })
+
+  it('remote is read from the store in lazy mode (LRU evicted on converge)', async () => {
+    const store = memory()
+    const db1 = await createNoydb({ store, user: 'alice', secret: SECRET, historyStrategy: withHistory() })
+    const c1 = (await db1.openVault('books')).collection<Inv>('invoices', { prefetch: false, cache: { maxRecords: 100 } })
+    await c1.put('lz', { id: 'lz', amount: 1 })
+    const db2 = await createNoydb({ store, user: 'alice', secret: SECRET, historyStrategy: withHistory() })
+    const v2 = await db2.openVault('books')
+    const c2 = v2.collection<Inv>('invoices', { prefetch: false, cache: { maxRecords: 100 } })
+    await c2.get('lz')                               // hydrate db2's LRU @v1
+    await c1.put('lz', { id: 'lz', amount: 42 })     // db1 overwrites in the shared store
+
+    const cap = await v2._captureAndConverge('invoices', 'lz', 'put', 1)
+    expect((cap!.local as { amount: number }).amount).toBe(1)   // pre-converge LRU value
+    expect((cap!.remote as { amount: number }).amount).toBe(42) // read from store, NOT a null evicted LRU
+    db1.close(); db2.close()
+  })
 })

--- a/packages/hub/__tests__/tab-write-propagation.test.ts
+++ b/packages/hub/__tests__/tab-write-propagation.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { createNoydb } from '../src/noydb.js'
+import { withHistory } from '../src/history/index.js'
 import { memory } from '../../to-memory/src/index.js'
 import type { TabChannel } from '../src/tab-coordination.js'
 
@@ -30,10 +31,10 @@ const SECRET = 'tab-prop-pass-1234'
  * cross-read fails with TamperedError). See persistence.test.ts:41.
  */
 async function twoTabs(store = memory()) {
-  const db1 = await createNoydb({ store, user: 'alice', secret: SECRET })
+  const db1 = await createNoydb({ store, user: 'alice', secret: SECRET, historyStrategy: withHistory() })
   const v1 = await db1.openVault('books'); const c1 = v1.collection<Inv>('invoices')
   await c1.put('seed', { id: 'seed', amount: 0 }) // mint + persist the invoices DEK
-  const db2 = await createNoydb({ store, user: 'alice', secret: SECRET })
+  const db2 = await createNoydb({ store, user: 'alice', secret: SECRET, historyStrategy: withHistory() })
   const v2 = await db2.openVault('books'); const c2 = v2.collection<Inv>('invoices')
   return { store, db1, db2, v1, v2, c1, c2 }
 }
@@ -96,5 +97,27 @@ describe('end-to-end cross-tab propagation (#228b)', () => {
     const db3 = await createNoydb({ store: memory(), user: 'bob', secret: SECRET })
     expect(() => db3.enableTabCoordination()).not.toThrow()
     db1.close(); db2.close(); db3.close()
+  })
+})
+
+describe('capture + converge primitive (#228c)', () => {
+  it('_captureAndConverge yields local (clobbered), remote (store), base (ancestor)', async () => {
+    const { db1, db2, v2, c1, c2 } = await twoTabs() // db1 seeded { seed, amount:0 } @v1
+    await c2.get('seed')              // db2 caches seed @v1
+    await c1.put('seed', { id: 'seed', amount: 99 }) // db1 overwrites in shared store @v2
+
+    const cap = await v2._captureAndConverge('invoices', 'seed', 'put', 1)
+    expect(cap).not.toBeNull()
+    expect((cap!.local as { amount: number }).amount).toBe(0)   // db2's pre-converge cache
+    expect((cap!.remote as { amount: number }).amount).toBe(99) // store after converge
+    expect((cap!.base as { amount: number }).amount).toBe(0)    // ancestor @v1 from history
+    db1.close(); db2.close()
+  })
+
+  it('_captureAndConverge returns null for an unloaded collection', async () => {
+    const db = await createNoydb({ store: memory(), user: 'alice', secret: SECRET })
+    const v = await db.openVault('books')
+    expect(await v._captureAndConverge('not-loaded', 'x', 'put', 0)).toBeNull()
+    db.close()
   })
 })

--- a/packages/hub/__tests__/tab-write-propagation.test.ts
+++ b/packages/hub/__tests__/tab-write-propagation.test.ts
@@ -21,6 +21,24 @@ function makeBus(n: number): TabChannel[] {
 }
 const settle = async () => { await new Promise((r) => setTimeout(r, 0)); await new Promise((r) => setTimeout(r, 0)) }
 
+/** A bus that QUEUES sends until deliver() — lets both tabs write before any delivery. */
+function makeManualBus(n: number): { chans: TabChannel[]; deliver: () => void } {
+  const listeners: Array<((p: string) => void) | null> = []
+  const queue: Array<{ from: number; payload: string }> = []
+  const chans: TabChannel[] = []
+  for (let i = 0; i < n; i++) {
+    const idx = i
+    chans.push({
+      isOpen: true,
+      send(payload) { queue.push({ from: idx, payload }) },
+      on(event, l) { if (event === 'message') { listeners[idx] = l as (p: string) => void; return () => { listeners[idx] = null } } return () => {} },
+      close() { listeners[idx] = null },
+    })
+  }
+  const deliver = () => { const q = queue.splice(0); for (const { from, payload } of q) for (let j = 0; j < listeners.length; j++) if (j !== from && listeners[j]) listeners[j]!(payload) }
+  return { chans, deliver }
+}
+
 interface Inv extends Record<string, unknown> { id: string; amount: number }
 const SECRET = 'tab-prop-pass-1234'
 
@@ -135,6 +153,55 @@ describe('capture + converge primitive (#228c)', () => {
     const cap = await v2._captureAndConverge('invoices', 'lz', 'put', 1)
     expect((cap!.local as { amount: number }).amount).toBe(1)   // pre-converge LRU value
     expect((cap!.remote as { amount: number }).amount).toBe(42) // read from store, NOT a null evicted LRU
+    db1.close(); db2.close()
+  })
+})
+
+describe('cross-tab conflict detection (#228c)', () => {
+  it('concurrent writes: both tabs emit WriteConflict; caches converge', async () => {
+    const { db1, db2, c1, c2 } = await twoTabs() // seed 'seed' @v1 in db1
+    const { chans: [wA, wB], deliver } = makeManualBus(2)
+    db1.enableTabCoordination({ writeChannel: wA!, tabId: 'A' })
+    db2.enableTabCoordination({ writeChannel: wB!, tabId: 'B' })
+    await c1.get('seed'); await c2.get('seed') // hydrate both
+
+    const seen1: import('../src/types.js').WriteConflict[] = []
+    const seen2: import('../src/types.js').WriteConflict[] = []
+    db1.onWriteConflict((cf) => seen1.push(cf))
+    db2.onWriteConflict((cf) => seen2.push(cf))
+
+    // Concurrent: both write 'seed' from base v1 before any signal is delivered.
+    await c1.put('seed', { id: 'seed', amount: 10 }) // db1 → store
+    await c2.put('seed', { id: 'seed', amount: 20 }) // db2 → store (wins LWW)
+    deliver()
+    await settle()
+
+    expect(seen1).toHaveLength(1)
+    expect(seen2).toHaveLength(1)
+    expect((seen1[0]!.local as { amount: number }).amount).toBe(10)  // db1 (loser) clobbered write
+    expect((seen1[0]!.remote as { amount: number }).amount).toBe(20) // store's winner
+    expect((seen1[0]!.base as { amount: number }).amount).toBe(0)    // ancestor (seed)
+    expect(seen1[0]!.baseVersion).toBe(1)
+    expect((await c1.get('seed'))!.amount).toBe(20)                  // db1 converged
+    expect((await c2.get('seed'))!.amount).toBe(20)
+    db1.close(); db2.close()
+  })
+
+  it('a write the other tab has already seen fires no conflict', async () => {
+    const { db1, db2, c1, c2 } = await twoTabs()
+    const { chans: [wA, wB], deliver } = makeManualBus(2)
+    db1.enableTabCoordination({ writeChannel: wA!, tabId: 'A' })
+    db2.enableTabCoordination({ writeChannel: wB!, tabId: 'B' })
+    await c2.get('seed')
+    let conflicts = 0
+    db2.onWriteConflict(() => { conflicts++ })
+
+    await c1.put('seed', { id: 'seed', amount: 5 }) // db2 never wrote 'seed'
+    deliver()
+    await settle()
+
+    expect(conflicts).toBe(0)
+    expect((await c2.get('seed'))!.amount).toBe(5) // applied, no conflict
     db1.close(); db2.close()
   })
 })

--- a/packages/hub/__tests__/tab-write-relay.test.ts
+++ b/packages/hub/__tests__/tab-write-relay.test.ts
@@ -31,7 +31,7 @@ function fakeAfterWrite() {
 }
 
 function ev(partial: Partial<WriteEvent>): WriteEvent {
-  return { op: 'update', vault: 'books', collection: 'invoices', docId: 'i1', before: null, after: { id: 'i1' }, userId: 'u', timestamp: 0, txId: 't', ...partial }
+  return { op: 'update', vault: 'books', collection: 'invoices', docId: 'i1', before: null, after: { id: 'i1' }, userId: 'u', timestamp: 0, txId: 't', baseVersion: 3, version: 4, ...partial }
 }
 
 describe('CrossTabWriteRelay', () => {
@@ -44,7 +44,7 @@ describe('CrossTabWriteRelay', () => {
     relayA.start()
     srcA.fire(ev({ op: 'create', docId: 'i9' }))
     await flush()
-    expect(received).toEqual({ kind: 'tab-write', writerId: 'A', vault: 'books', collection: 'invoices', docId: 'i9', action: 'put' })
+    expect(received).toEqual({ kind: 'tab-write', writerId: 'A', vault: 'books', collection: 'invoices', docId: 'i9', action: 'put', baseV: 3, v: 4 })
     relayA.dispose()
   })
 
@@ -87,5 +87,61 @@ describe('CrossTabWriteRelay', () => {
     srcA.fire(ev({ docId: 'i1' }))
     await flush()
     expect(count).toBe(0)
+  })
+
+  it('reports a conflict when a remote write predates this tab\'s own write', async () => {
+    const [chA, chB] = makeBus(2)
+    const srcA = fakeAfterWrite(); const srcB = fakeAfterWrite()
+    const applied: string[] = []; const conflicts: Array<[string, number, number, number]> = []
+    const relayA = new CrossTabWriteRelay({ channel: chA!, writerId: 'A', subscribeAfterWrite: srcA.subscribe, applyRemoteWrite: () => {} })
+    const relayB = new CrossTabWriteRelay({
+      channel: chB!, writerId: 'B', subscribeAfterWrite: srcB.subscribe,
+      applyRemoteWrite: (_v, _c, d) => { applied.push(d) },
+      reportConflict: (_v, _c, d, _a, baseV, v, ownV) => { conflicts.push([d, baseV, v, ownV]) },
+    })
+    relayA.start(); relayB.start()
+    srcB.fire(ev({ docId: 'i1', baseVersion: 3, version: 4 })) // B writes i1 @v4 → ledger[i1]=4
+    srcA.fire(ev({ docId: 'i1', baseVersion: 3, version: 4 })) // A wrote i1 from base 3 too
+    await flush()
+    expect(conflicts).toEqual([['i1', 3, 4, 4]]) // baseV 3 < ownV 4 → conflict
+    expect(applied).toEqual([])                  // conflict path does NOT also apply
+    relayA.dispose(); relayB.dispose()
+  })
+
+  it('no conflict when the remote incorporated our write (baseV >= ownV)', async () => {
+    const [chA, chB] = makeBus(2)
+    const srcA = fakeAfterWrite(); const srcB = fakeAfterWrite()
+    const applied: string[] = []; let conflictCount = 0
+    const relayA = new CrossTabWriteRelay({ channel: chA!, writerId: 'A', subscribeAfterWrite: srcA.subscribe, applyRemoteWrite: () => {} })
+    const relayB = new CrossTabWriteRelay({
+      channel: chB!, writerId: 'B', subscribeAfterWrite: srcB.subscribe,
+      applyRemoteWrite: (_v, _c, d) => { applied.push(d) },
+      reportConflict: () => { conflictCount++ },
+    })
+    relayA.start(); relayB.start()
+    srcB.fire(ev({ docId: 'i1', baseVersion: 3, version: 4 }))   // ledger[i1]=4
+    srcA.fire(ev({ docId: 'i1', baseVersion: 4, version: 5 }))   // A built on our v4
+    await flush()
+    expect(conflictCount).toBe(0)
+    expect(applied).toEqual(['i1'])
+    relayA.dispose(); relayB.dispose()
+  })
+
+  it('no conflict for a doc this tab never wrote', async () => {
+    const [chA, chB] = makeBus(2)
+    const srcA = fakeAfterWrite(); const srcB = fakeAfterWrite()
+    const applied: string[] = []; let conflictCount = 0
+    const relayA = new CrossTabWriteRelay({ channel: chA!, writerId: 'A', subscribeAfterWrite: srcA.subscribe, applyRemoteWrite: () => {} })
+    const relayB = new CrossTabWriteRelay({
+      channel: chB!, writerId: 'B', subscribeAfterWrite: srcB.subscribe,
+      applyRemoteWrite: (_v, _c, d) => { applied.push(d) },
+      reportConflict: () => { conflictCount++ },
+    })
+    relayA.start(); relayB.start()
+    srcA.fire(ev({ docId: 'i2', baseVersion: 3, version: 4 }))   // B never wrote i2
+    await flush()
+    expect(conflictCount).toBe(0)
+    expect(applied).toEqual(['i2'])
+    relayA.dispose(); relayB.dispose()
   })
 })

--- a/packages/hub/__tests__/write-hooks-integration.test.ts
+++ b/packages/hub/__tests__/write-hooks-integration.test.ts
@@ -97,4 +97,18 @@ describe('write lifecycle hooks (#230)', () => {
     expect(ids[0]).toBe(ids[1])     // same transaction → same txId
     expect(ids[2]).not.toBe(ids[0]) // standalone write → different txId
   })
+
+  it('WriteEvent carries baseVersion and version (#228c)', async () => {
+    const db = await setup()
+    const v = await db.openVault('demo')
+    const c = v.collection<Inv>('invoices')
+    const events: WriteEvent[] = []
+    db.onAfterWrite((e) => { events.push(e) })
+    await c.put('i1', { id: 'i1', amount: 1 }) // create
+    await c.put('i1', { id: 'i1', amount: 2 }) // update
+    expect(events[0]!.baseVersion).toBe(0)
+    expect(events[0]!.version).toBe(1)
+    expect(events[1]!.baseVersion).toBe(1)
+    expect(events[1]!.version).toBe(2)
+  })
 })

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1124,11 +1124,25 @@ export class Collection<T> {
     return this.writeHooks !== undefined && this.writeHooks.hasHandlers && !this.writeHooks.suppressed
   }
 
-  /** @internal #230 — decrypt the current record for a hook's `before`, or null. */
+  /**
+   * @internal #230/#228c — resolve the prior record for a hook's `before` and
+   * its version. Critically, this uses the SAME basis `putInternal` writes from
+   * (the in-memory cache in eager mode; lru-then-adapter in lazy) — NOT a fresh
+   * store read — so `baseVersion`/`version` match the version actually written.
+   * A separate store read would diverge once another tab has advanced the shared
+   * store past this tab's cache, breaking #228c conflict detection.
+   */
   async #priorForHook(id: string): Promise<{ record: unknown; version: number }> {
-    const env = await this.adapter.get(this.vault, this.name, id)
-    if (!env) return { record: null, version: 0 }
-    return { record: (await this.decryptRecord(env, { skipValidation: true })) as unknown, version: env._v }
+    if (this.lazy && this.lru) {
+      const cached = this.lru.get(id)
+      if (cached) return { record: cached.record, version: cached.version }
+      const env = await this.adapter.get(this.vault, this.name, id)
+      if (!env) return { record: null, version: 0 }
+      return { record: (await this.decryptRecord(env, { skipValidation: true })) as unknown, version: env._v }
+    }
+    await this.ensureHydrated()
+    const cached = this.cache.get(id)
+    return cached ? { record: cached.record, version: cached.version } : { record: null, version: 0 }
   }
 
   #txIdForHook(): string {

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -2809,6 +2809,12 @@ export class Collection<T> {
     this.emitter.emit('change', { vault: this.vault, collection: this.name, id, action })
   }
 
+  /** @internal #228c — the current in-memory record without a store read (for conflict capture). */
+  _peekCached(id: string): T | null {
+    const entry = this.lazy && this.lru ? this.lru.get(id) : this.cache.get(id)
+    return entry ? entry.record : null
+  }
+
   private async ensureHydrated(): Promise<void> {
     if (this.hydrated) return
 

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1105,11 +1105,12 @@ export class Collection<T> {
     // the write hooks.
     let event: WriteEvent | undefined
     if (this.#hooksActive()) {
-      const before = await this.#priorRecordForHook(id)
+      const prior = await this.#priorForHook(id)
       event = {
-        op: before === null ? 'create' : 'update',
-        vault: this.vault, collection: this.name, docId: id, before, after: record,
+        op: prior.record === null ? 'create' : 'update',
+        vault: this.vault, collection: this.name, docId: id, before: prior.record, after: record,
         userId: this.keyring.userId, timestamp: Date.now(), txId: this.#txIdForHook(),
+        baseVersion: prior.version, version: prior.version + 1,
       }
       await this.writeHooks!.runBefore(event) // throw → aborts the write
     }
@@ -1124,10 +1125,10 @@ export class Collection<T> {
   }
 
   /** @internal #230 — decrypt the current record for a hook's `before`, or null. */
-  async #priorRecordForHook(id: string): Promise<unknown> {
+  async #priorForHook(id: string): Promise<{ record: unknown; version: number }> {
     const env = await this.adapter.get(this.vault, this.name, id)
-    if (!env) return null
-    return (await this.decryptRecord(env, { skipValidation: true })) as unknown
+    if (!env) return { record: null, version: 0 }
+    return { record: (await this.decryptRecord(env, { skipValidation: true })) as unknown, version: env._v }
   }
 
   #txIdForHook(): string {
@@ -1685,10 +1686,11 @@ export class Collection<T> {
     await this.schemaFence?.assertWritable(this.name) // #232
     let event: WriteEvent | undefined
     if (this.#hooksActive()) {
-      const before = await this.#priorRecordForHook(id)
+      const prior = await this.#priorForHook(id)
       event = {
-        op: 'delete', vault: this.vault, collection: this.name, docId: id, before, after: null,
+        op: 'delete', vault: this.vault, collection: this.name, docId: id, before: prior.record, after: null,
         userId: this.keyring.userId, timestamp: Date.now(), txId: this.#txIdForHook(),
+        baseVersion: prior.version, version: prior.version + 1,
       }
       await this.writeHooks!.runBefore(event)
     }

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -183,6 +183,8 @@ export type { DryRunResult, AffectedDocument, GuardViolation } from './tx/dry-ru
 
 // Multi-tab coordination (#228)
 export type { TabRole, TabPresence, TabCoordinationOptions, TabLockManager, TabChannel } from './tab-coordination.js'
+// Cross-tab write conflict (#228c)
+export type { WriteConflict } from './types.js'
 
 // Schema-update strategies (#245)
 export type {

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -19,6 +19,7 @@ import type {
   QueryAcrossResult,
   ReAuthOperation,
   TranslatorAuditEntry,
+  WriteConflict,
 } from './types.js'
 import { ValidationError, NoAccessError, InvalidKeyError, KeyringCorruptError, StoreCapabilityError, PermissionDeniedError } from './errors.js'
 import {
@@ -1194,6 +1195,12 @@ export class Noydb {
     return this.writeHooks.onAfterWrite(handler)
   }
 
+  /** Subscribe to cross-tab write conflicts (#228c). Returns an unsubscribe. */
+  onWriteConflict(fn: (c: WriteConflict) => void): Unsubscribe {
+    this.on('write:conflict', fn)
+    return () => this.off('write:conflict', fn)
+  }
+
   /**
    * Enable same-device multi-tab coordination (#228): primary/secondary
    * election + presence. Browser-only — a graceful no-op (role 'unknown')
@@ -1221,6 +1228,7 @@ export class Noydb {
           writerId: c.tabId,
           subscribeAfterWrite: (h) => this.onAfterWrite(h),
           applyRemoteWrite: (vault, collection, docId, action) => this.#applyRemoteWrite(vault, collection, docId, action),
+          reportConflict: (vault, collection, docId, action, baseV, v, ownV) => this.#reportWriteConflict(vault, collection, docId, action, baseV, v, ownV),
           // Own the channel only when we created the default (mirrors the presence channel).
           closeChannelOnDispose: opts.writeChannel === undefined && writeChannel !== undefined,
         })
@@ -1235,6 +1243,19 @@ export class Noydb {
     const v = this.vaultCache.get(vaultName)
     if (!v) return Promise.resolve()
     return v._applyRemoteWrite(collectionName, docId, action)
+  }
+
+  async #reportWriteConflict(vaultName: string, collectionName: string, docId: string, action: 'put' | 'delete', baseV: number, v: number, ownV: number): Promise<void> {
+    const vault = this.vaultCache.get(vaultName)
+    if (!vault) return
+    const cap = await vault._captureAndConverge(collectionName, docId, action, baseV)
+    if (!cap) return
+    const conflict: WriteConflict = {
+      vault: vaultName, collection: collectionName, docId,
+      local: cap.local, remote: cap.remote, base: cap.base,
+      localVersion: ownV, remoteVersion: v, baseVersion: baseV,
+    }
+    this.emitter.emit('write:conflict', conflict)
   }
 
   private disableTabCoordination(): void {

--- a/packages/hub/src/tab-write-relay.ts
+++ b/packages/hub/src/tab-write-relay.ts
@@ -15,6 +15,8 @@ export interface TabWriteMsg {
   readonly collection: string
   readonly docId: string
   readonly action: 'put' | 'delete'
+  readonly baseV: number
+  readonly v: number
 }
 
 export interface CrossTabWriteRelayOptions {
@@ -26,6 +28,8 @@ export interface CrossTabWriteRelayOptions {
   readonly subscribeAfterWrite: (handler: (e: WriteEvent) => void) => Unsubscribe
   /** Refresh a document's in-memory view from the shared store. */
   readonly applyRemoteWrite: (vault: string, collection: string, docId: string, action: 'put' | 'delete') => void | Promise<void>
+  /** Report a detected conflict (host captures + converges + emits). #228c. */
+  readonly reportConflict?: (vault: string, collection: string, docId: string, action: 'put' | 'delete', baseV: number, v: number, ownV: number) => void | Promise<void>
   /** Close the channel on dispose (only when the relay created it). Default false. */
   readonly closeChannelOnDispose?: boolean
 }
@@ -35,6 +39,8 @@ export class CrossTabWriteRelay {
   readonly #writerId: string
   readonly #subscribeAfterWrite: (handler: (e: WriteEvent) => void) => Unsubscribe
   readonly #applyRemoteWrite: (vault: string, collection: string, docId: string, action: 'put' | 'delete') => void | Promise<void>
+  readonly #reportConflict: CrossTabWriteRelayOptions['reportConflict']
+  readonly #ledger = new Map<string, number>()
   readonly #ownsChannel: boolean
   #unsubMsg: Unsubscribe | undefined
   #unsubWrite: Unsubscribe | undefined
@@ -46,6 +52,7 @@ export class CrossTabWriteRelay {
     this.#writerId = opts.writerId
     this.#subscribeAfterWrite = opts.subscribeAfterWrite
     this.#applyRemoteWrite = opts.applyRemoteWrite
+    this.#reportConflict = opts.reportConflict
     this.#ownsChannel = opts.closeChannelOnDispose ?? false
   }
 
@@ -66,8 +73,9 @@ export class CrossTabWriteRelay {
 
   #onLocalWrite(e: WriteEvent): void {
     if (this.#disposed || !this.#channel.isOpen) return
+    this.#ledger.set(ledgerKey(e.vault, e.collection, e.docId), e.version)
     const action: 'put' | 'delete' = e.op === 'delete' ? 'delete' : 'put'
-    const msg: TabWriteMsg = { kind: 'tab-write', writerId: this.#writerId, vault: e.vault, collection: e.collection, docId: e.docId, action }
+    const msg: TabWriteMsg = { kind: 'tab-write', writerId: this.#writerId, vault: e.vault, collection: e.collection, docId: e.docId, action, baseV: e.baseVersion, v: e.version }
     this.#channel.send(JSON.stringify(msg))
   }
 
@@ -76,10 +84,23 @@ export class CrossTabWriteRelay {
     let msg: unknown
     try { msg = JSON.parse(payload) } catch { return }
     if (!isTabWriteMsg(msg) || msg.writerId === this.#writerId) return
+    const key = ledgerKey(msg.vault, msg.collection, msg.docId)
+    const ownV = this.#ledger.get(key)
+    if (ownV !== undefined && msg.baseV < ownV && this.#reportConflict) {
+      void Promise.resolve(this.#reportConflict(msg.vault, msg.collection, msg.docId, msg.action, msg.baseV, msg.v, ownV)).catch((err) => {
+        console.warn(`[noy-db] cross-tab conflict report failed for ${msg.collection}/${msg.docId}: ` + (err instanceof Error ? err.message : String(err)))
+      })
+      return
+    }
+    if (ownV !== undefined && msg.baseV >= ownV) this.#ledger.set(key, msg.v) // remote incorporated our write → advance
     void Promise.resolve(this.#applyRemoteWrite(msg.vault, msg.collection, msg.docId, msg.action)).catch((err) => {
       console.warn(`[noy-db] cross-tab apply failed for ${msg.collection}/${msg.docId}: ` + (err instanceof Error ? err.message : String(err)))
     })
   }
+}
+
+function ledgerKey(vault: string, collection: string, docId: string): string {
+  return `${vault} ${collection} ${docId}`
 }
 
 function isTabWriteMsg(x: unknown): x is TabWriteMsg {
@@ -91,4 +112,6 @@ function isTabWriteMsg(x: unknown): x is TabWriteMsg {
     && typeof o['collection'] === 'string'
     && typeof o['docId'] === 'string'
     && (o['action'] === 'put' || o['action'] === 'delete')
+    && typeof o['baseV'] === 'number'
+    && typeof o['v'] === 'number'
 }

--- a/packages/hub/src/tab-write-relay.ts
+++ b/packages/hub/src/tab-write-relay.ts
@@ -100,7 +100,8 @@ export class CrossTabWriteRelay {
 }
 
 function ledgerKey(vault: string, collection: string, docId: string): string {
-  return `${vault} ${collection} ${docId}`
+  // NUL separator: it cannot appear in a vault/collection/docId, so keys never collide.
+  return `${vault}\0${collection}\0${docId}`
 }
 
 function isTabWriteMsg(x: unknown): x is TabWriteMsg {

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -848,6 +848,24 @@ export interface Conflict {
   readonly resolve?: (winner: EncryptedEnvelope | null) => void
 }
 
+/**
+ * #228c — a same-device cross-tab write conflict: another tab overwrote a
+ * document this tab had written, having diverged from an older base. Records
+ * are decrypted (cross-tab handlers reconcile in plaintext). `base` is the
+ * common ancestor from history, or null when history is unavailable.
+ */
+export interface WriteConflict {
+  readonly vault: string
+  readonly collection: string
+  readonly docId: string
+  readonly local: unknown
+  readonly remote: unknown
+  readonly base: unknown
+  readonly localVersion: number
+  readonly remoteVersion: number
+  readonly baseVersion: number
+}
+
 export type ConflictStrategy =
   | 'local-wins'
   | 'remote-wins'
@@ -971,6 +989,7 @@ export interface NoydbEventMap {
   'sync:push': PushResult
   'sync:pull': PullResult
   'sync:conflict': Conflict
+  'write:conflict': WriteConflict
   'sync:online': void
   'sync:offline': void
   'sync:backup-error': { vault: string; target: string; error: Error }

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -872,11 +872,15 @@ export class Vault {
   ): Promise<{ local: unknown; remote: unknown; base: unknown } | null> {
     const coll = this.collectionCache.get(collectionName)
     if (!coll) return null
+    // `local` is the pre-converge cached record (the clobbered write) — peek only, no store read.
+    // Consumers must not mutate the returned records: in eager mode they alias live cache entries.
     const local = coll._peekCached(docId)
     let base: unknown = null
     try { base = await coll.getVersion(docId, baseV) } catch { base = null }
     await coll._applyRemoteChange(docId, action)
-    const remote = coll._peekCached(docId)
+    // `remote` is the post-converge authoritative value via the universal read path
+    // (cache in eager mode; a store read in lazy mode, where the LRU entry was just evicted).
+    const remote = await coll.get(docId)
     return { local, remote, base }
   }
 

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -858,6 +858,28 @@ export class Vault {
     await coll._applyRemoteChange(docId, action)
   }
 
+  /**
+   * #228c — for a detected conflict: capture this tab's clobbered record,
+   * read the common ancestor from history, converge the cache to the store's
+   * authoritative value (the (b) re-read), and return all three for the
+   * WriteConflict payload. Returns null when the collection isn't loaded.
+   */
+  async _captureAndConverge(
+    collectionName: string,
+    docId: string,
+    action: 'put' | 'delete',
+    baseV: number,
+  ): Promise<{ local: unknown; remote: unknown; base: unknown } | null> {
+    const coll = this.collectionCache.get(collectionName)
+    if (!coll) return null
+    const local = coll._peekCached(docId)
+    let base: unknown = null
+    try { base = await coll.getVersion(docId, baseV) } catch { base = null }
+    await coll._applyRemoteChange(docId, action)
+    const remote = coll._peekCached(docId)
+    return { local, remote, base }
+  }
+
   /** Recover a stuck cutover fence (#232) — reset to normal without bumping. */
   async abortSchemaCutover(): Promise<void> {
     await this.schemaFence.abort()

--- a/packages/hub/src/write-hooks.ts
+++ b/packages/hub/src/write-hooks.ts
@@ -11,6 +11,8 @@ export interface WriteEvent {
   readonly docId: string
   readonly before: unknown // decrypted prior record; null on 'create'
   readonly after: unknown // the record written; null on 'delete'
+  readonly baseVersion: number // #228c — version the writer started from (0 on create)
+  readonly version: number // #228c — version the writer wrote (baseVersion + 1)
   readonly userId: string
   readonly timestamp: number
   readonly txId: string


### PR DESCRIPTION
## Summary

Final slice of multi-client write coordination (#228). When two same-origin tabs write the same document concurrently, each tab emits a `WriteConflict` so the app can reconcile; the hub converges the cache to the store's authoritative value but **never auto-resolves**. Post-hoc, role-agnostic, ciphertext-blind — builds on (a) presence/roles and (b) write propagation.

- **Detection:** `WriteEvent` gains `baseVersion`/`version`, sourced from the **write basis** (the cache `put` writes from — not a separate store read). The relay keeps a per-doc own-write ledger; an incoming write whose `baseV` is below this tab's own-write version is a conflict (`baseV < ownV`).
- **Payload:** `WriteConflict { vault, collection, docId, local, remote, base, localVersion, remoteVersion, baseVersion }` — decrypted records (`base` from history, or `null` when history is unavailable; default is `NO_HISTORY`). Surfaced via `db.onWriteConflict(fn)` + the `write:conflict` event.
- **Behavior:** capture the clobbered `local` → converge cache to the store (the (b) re-read) → emit. Lazy-safe (`remote` read via `get()`). No loop (apply never re-fires hooks).

## Design notes / review findings

- The load-bearing fix: the version had to come from the **write basis**, not a fresh store read — a store-sourced base was inflated once the shared store advanced, so the `baseV < ownV` check never fired. Now `#priorForHook` mirrors `putInternal`'s resolution (cache eager / lru-then-adapter lazy).
- `WriteEvent.before` is now cache-sourced too (consistent with `op`); no production consumer reads it (only user hooks).
- Ledger keys use a NUL separator (collision-safe). The 3-tab promotion path can over-notify (documented known limitation — full 3-way detection needs version vectors, out of scope).

## Scope

In: detection + `WriteConflict`/`onWriteConflict`/`write:conflict`, `base` from history, converge-then-notify. Out: auto-resolution/merge (app's job), write-time CAS, cross-device (sync engine).

## Test Plan

- [x] relay unit (conflict / no-conflict-on-incorporation / never-wrote / version broadcast) + integration (concurrent ⇒ both tabs emit, caches converge; seen-write ⇒ none) + lazy-mode regression
- [x] full hub suite **1986 pass** (200 files), clean exit
- [x] `tsc` + lint + build clean; `features.yaml` validator OK (45 features)