### PR TITLE
Kernel-shrink groundwork: SubsystemBus observe bus (Track A slice 1) + comment provenance prune

### DIFF
--- a/docs/superpowers/plans/2026-06-01-track-a-subsystem-bus-slice-1.md
+++ b/docs/superpowers/plans/2026-06-01-track-a-subsystem-bus-slice-1.md
@@ -1,0 +1,454 @@
+# Track A — Subsystem Observe Bus (Slice 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce a generic, per-instance **observe bus** (`SubsystemBus`) and prove it end-to-end by firing one *observe* lifecycle point (`afterPut`) from the collection write path — the seam that Track B's devtools inspector and other observe-class subsystems (audit, sync-dirty notification) subscribe to.
+
+**Architecture:** The bus mirrors the existing per-instance registry pattern (`WriteHookRegistry`, `WriteQueueTracker`, `NoydbEventEmitter`): constructed once on `Noydb`, exposed via an internal `_subsystemBus` accessor, threaded into each `Collection` through `vault.collection()`. Slice 1 is purely **additive** — the bus does nothing unless a handler is registered, so behavior is preserved.
+
+**Scope — read this before coding.** This is an **observe** primitive only: handlers *react* to a write that already succeeded; they cannot abort it (errors are warned, not thrown). It is deliberately a **sibling of the #230 write-hooks** and shares their exact coverage envelope — it fires from the public `put()` and therefore inherits the documented gap (`collection.ts:1103-1105`: `putMany`/tx-execute/CRDT/blob writes are not yet fired through write-hooks). That is acceptable here because the consumers of slice 1 (the inspector, audit, sync-dirty) observe the same surface #230 already observes.
+
+**This slice is explicitly NOT the migration seam for guards / periods / consent.** Those subsystems are write-*gating*: they run at the top of `putInternal` (`collection.ts:1164`, `:1213`), **throw to abort**, and fire on all write paths including delete (`:1833`, `:1885`). Migrating them requires a *different* primitive — a `beforePut`/`beforeDelete` **gate bus** with throw-propagation dispatched from `putInternal` — which is the follow-on `track-a-gate-bus` plan and MUST land before any gating subsystem moves. Do not try to fold gating into this observe bus; the two policies (abort vs. observe) and altitudes (`putInternal` vs. `put()`) are genuinely different.
+
+**Tech Stack:** TypeScript (ESM, `.js` import specifiers), Vitest, pnpm workspace. Package: `packages/hub`. The hub must stay portable (no Node-only imports — `pnpm check:architecture` enforces it).
+
+**Not in this slice:** no public API export of the bus (it stays internal until a real subsystem validates its shape — see roadmap's API-stability gate); no `beforePut`/gate path; no subsystem migrated off its kernel branch; no kernel-surface CI gate. Each is a named follow-on plan at the end.
+
+---
+
+## File Structure
+
+- **Create** `packages/hub/src/subsystem-bus.ts` — the `SubsystemBus` class + its typed lifecycle map. Single responsibility: ordered registration + dispatch of *observe* lifecycle handlers.
+- **Create** `packages/hub/__tests__/subsystem-bus.test.ts` — unit tests for the bus in isolation.
+- **Create** `packages/hub/__tests__/subsystem-bus-integration.test.ts` — integration test: a bus handler fires on `collection.put()` with no write-hooks present (proves decoupling from #230).
+- **Modify** `packages/hub/src/noydb.ts` — construct the bus (near line 162) and expose `_subsystemBus` accessor (near line 1274).
+- **Modify** `packages/hub/src/vault.ts` — pass `subsystemBus` into the `Collection` options object (near lines 677–679).
+- **Modify** `packages/hub/src/collection.ts` — accept + store `subsystemBus` (ctor opts ~516, field ~137, assign ~808); broaden the `event`-build gate and dispatch `afterPut` in `put()` (~1106–1119).
+
+> The bus type is referenced internally only. Tests import it directly from `../src/subsystem-bus.js` and reach the instance via the internal `db._subsystemBus` accessor — no package-root export is added.
+
+---
+
+### Task 1: `SubsystemBus` class (observe primitive)
+
+**Files:**
+- Create: `packages/hub/src/subsystem-bus.ts`
+- Test: `packages/hub/__tests__/subsystem-bus.test.ts`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `packages/hub/__tests__/subsystem-bus.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { SubsystemBus } from '../src/subsystem-bus.js'
+import type { WriteEvent } from '../src/write-hooks.js'
+
+function ev(over: Partial<WriteEvent> = {}): WriteEvent {
+  return {
+    op: 'create', vault: 'v', collection: 'c', docId: 'd',
+    before: null, after: { x: 1 }, baseVersion: 0, version: 1,
+    userId: 'u', timestamp: 0, txId: 't', ...over,
+  }
+}
+
+describe('SubsystemBus (observe)', () => {
+  it('dispatches handlers in registration order', async () => {
+    const bus = new SubsystemBus()
+    const order: number[] = []
+    bus.register('afterPut', () => { order.push(1) })
+    bus.register('afterPut', () => { order.push(2) })
+    await bus.dispatch('afterPut', ev())
+    expect(order).toEqual([1, 2])
+  })
+
+  it('hasHandlers reflects registration and unsubscribe', async () => {
+    const bus = new SubsystemBus()
+    expect(bus.hasHandlers('afterPut')).toBe(false)
+    const off = bus.register('afterPut', () => {})
+    expect(bus.hasHandlers('afterPut')).toBe(true)
+    off()
+    expect(bus.hasHandlers('afterPut')).toBe(false)
+  })
+
+  it('awaits async handlers', async () => {
+    const bus = new SubsystemBus()
+    let done = false
+    bus.register('afterPut', async () => {
+      await new Promise((r) => setTimeout(r, 5))
+      done = true
+    })
+    await bus.dispatch('afterPut', ev())
+    expect(done).toBe(true)
+  })
+
+  it('isolates a throwing handler — others still run, dispatch never rejects (observe policy)', async () => {
+    const bus = new SubsystemBus()
+    const ran: string[] = []
+    bus.register('afterPut', () => { throw new Error('boom') })
+    bus.register('afterPut', () => { ran.push('second') })
+    await expect(bus.dispatch('afterPut', ev())).resolves.toBeUndefined()
+    expect(ran).toEqual(['second'])
+  })
+
+  it('dispatch is a no-op when no handler is registered', async () => {
+    const bus = new SubsystemBus()
+    await expect(bus.dispatch('afterPut', ev())).resolves.toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/subsystem-bus.test.ts`
+Expected: FAIL — `Cannot find module '../src/subsystem-bus.js'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `packages/hub/src/subsystem-bus.ts`:
+
+```ts
+/**
+ * Generic per-instance **observe** bus (Track A, slice 1). Observe-class
+ * subsystems (devtools inspector, audit, sync-dirty notification) register
+ * handlers against named lifecycle points instead of the kernel naming each
+ * subsystem. Mirrors the registry pattern of {@link WriteHookRegistry} but is
+ * internal and keyed by lifecycle point.
+ *
+ * OBSERVE SEMANTICS: handlers react to a write that already happened. A
+ * handler throw is warned, not propagated — it can never abort a write. Write-
+ * *gating* subsystems (guards, periods) need the separate throw-propagating
+ * gate bus (`beforePut`/`beforeDelete`, dispatched from `putInternal`); that is
+ * NOT this primitive. Add observe points by extending {@link LifecycleEventMap}.
+ *
+ * @module
+ */
+import type { WriteEvent } from './write-hooks.js'
+
+/** Typed map of OBSERVE lifecycle point → event payload. Extend by adding keys. */
+export interface LifecycleEventMap {
+  afterPut: WriteEvent
+}
+
+export type LifecyclePoint = keyof LifecycleEventMap
+export type BusHandler<P extends LifecyclePoint> = (event: LifecycleEventMap[P]) => void | Promise<void>
+export type Unsubscribe = () => void
+
+type AnyHandler = (event: unknown) => void | Promise<void>
+
+export class SubsystemBus {
+  readonly #handlers = new Map<LifecyclePoint, AnyHandler[]>()
+
+  /** Register a handler for an observe point. Returns an unsubscribe fn. */
+  register<P extends LifecyclePoint>(point: P, handler: BusHandler<P>): Unsubscribe {
+    let arr = this.#handlers.get(point)
+    if (!arr) { arr = []; this.#handlers.set(point, arr) }
+    arr.push(handler as AnyHandler)
+    return () => {
+      const a = this.#handlers.get(point)
+      if (!a) return
+      const i = a.indexOf(handler as AnyHandler)
+      if (i >= 0) a.splice(i, 1)
+    }
+  }
+
+  /** Cheap gate for the write path — true when any handler is registered for the point. */
+  hasHandlers(point: LifecyclePoint): boolean {
+    const a = this.#handlers.get(point)
+    return a !== undefined && a.length > 0
+  }
+
+  /**
+   * Dispatch in registration order, awaited. Per-handler errors are warned, not
+   * thrown — an observe handler must never abort a completed write.
+   */
+  async dispatch<P extends LifecyclePoint>(point: P, event: LifecycleEventMap[P]): Promise<void> {
+    const a = this.#handlers.get(point)
+    if (!a || a.length === 0) return
+    for (const h of a.slice()) {
+      try {
+        await h(event)
+      } catch (err) {
+        console.warn(
+          `[noy-db] subsystem observe handler failed at ${point} for ${event.collection}/${event.docId}: ` +
+          (err instanceof Error ? err.message : String(err)),
+        )
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/subsystem-bus.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/subsystem-bus.ts packages/hub/__tests__/subsystem-bus.test.ts
+git commit -m "feat(hub): SubsystemBus — internal observe-lifecycle dispatch (Track A slice 1)"
+```
+
+---
+
+### Task 2: Thread the bus through construction
+
+**Files:**
+- Modify: `packages/hub/src/noydb.ts` (construct + accessor)
+- Modify: `packages/hub/src/vault.ts` (pass into Collection opts)
+- Modify: `packages/hub/src/collection.ts` (ctor opts + field + assign)
+
+- [ ] **Step 1: Construct the bus on `Noydb`**
+
+In `packages/hub/src/noydb.ts`, add the import near the existing registry imports (lines ~79–81):
+
+```ts
+import { SubsystemBus } from './subsystem-bus.js'
+```
+
+Then, next to the existing per-instance registries (lines ~160–162, where `emitter`, `writeQueueTracker`, `writeHooks` are constructed), add:
+
+```ts
+  private readonly subsystemBus = new SubsystemBus()
+```
+
+- [ ] **Step 2: Expose the internal accessor**
+
+In `packages/hub/src/noydb.ts`, next to the existing `get _writeHooks()` accessor (near line 1274), add:
+
+```ts
+  /** @internal Track A — the observe bus, threaded into every Collection. */
+  get _subsystemBus(): SubsystemBus {
+    return this.subsystemBus
+  }
+```
+
+- [ ] **Step 3: Pass the bus into Collection options in `vault.ts`**
+
+In `packages/hub/src/vault.ts`, in the `collOpts` object that is passed to `new Collection<T>(collOpts)` (the block near lines 677–679 that already sets `emitter`, `writeQueue`, `writeHooks`), add:
+
+```ts
+        subsystemBus: this.noydb._subsystemBus,
+```
+
+- [ ] **Step 4: Accept + store the bus on `Collection`**
+
+In `packages/hub/src/collection.ts`:
+
+(a) Add the import near the other registry imports at the top of the file:
+
+```ts
+import type { SubsystemBus } from './subsystem-bus.js'
+```
+
+(b) Add the private field next to `writeHooks` (near line 137):
+
+```ts
+  private readonly subsystemBus: SubsystemBus | undefined
+```
+
+(c) Add to the constructor `opts` type next to `writeHooks?` (near line 516):
+
+```ts
+    subsystemBus?: SubsystemBus | undefined
+```
+
+(d) Assign it next to `this.writeHooks = opts.writeHooks` (near line 808):
+
+```ts
+    this.subsystemBus = opts.subsystemBus
+```
+
+- [ ] **Step 5: Run typecheck + full hub test suite to verify nothing broke**
+
+Run: `cd packages/hub && pnpm typecheck && pnpm vitest run`
+Expected: PASS — typecheck clean, all existing hub tests still green (the bus is threaded but never dispatched yet, so behavior is unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/noydb.ts packages/hub/src/vault.ts packages/hub/src/collection.ts
+git commit -m "feat(hub): thread SubsystemBus through Noydb→Vault→Collection (Track A slice 1)"
+```
+
+---
+
+### Task 3: Fire `afterPut` from the write path (decoupled from write-hooks)
+
+**Files:**
+- Test: `packages/hub/__tests__/subsystem-bus-integration.test.ts`
+- Modify: `packages/hub/src/collection.ts` (the `put()` method, lines ~1106–1119)
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `packages/hub/__tests__/subsystem-bus-integration.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { createNoydb, ConflictError } from '../src/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot, WriteEvent } from '../src/index.js'
+
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll() {},
+  }
+}
+
+describe('SubsystemBus integration — afterPut fires from put()', () => {
+  it('fires with no write-hooks registered (proves decoupling from #230)', async () => {
+    const db = await createNoydb({ store: memoryStore(), secret: 'pw', user: 'owner' })
+    const seen: WriteEvent[] = []
+    db._subsystemBus.register('afterPut', (e) => { seen.push(e) })
+
+    const docs = db.collection<{ id: string; n: number }>('docs')
+    await docs.put('a', { id: 'a', n: 1 })
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0].op).toBe('create')
+    expect(seen[0].collection).toBe('docs')
+    expect(seen[0].docId).toBe('a')
+    expect(seen[0].after).toEqual({ id: 'a', n: 1 })
+  })
+
+  it('does not fire when no handler is registered (zero-cost path)', async () => {
+    const db = await createNoydb({ store: memoryStore(), secret: 'pw', user: 'owner' })
+    const docs = db.collection<{ id: string; n: number }>('docs')
+    await expect(docs.put('a', { id: 'a', n: 1 })).resolves.toBeUndefined()
+  })
+})
+```
+
+> NOTE: confirm the no-arg `db.collection(...)` accessor and the `createNoydb({ store, secret, user })` shape match the version under test by glancing at an existing `__tests__/*.test.ts` (e.g. `hierarchical-tiers.test.ts`). If a vault must be opened explicitly in this version, replace the two `db.collection(...)` lines with the open-vault form used there; the bus assertions are unchanged.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/subsystem-bus-integration.test.ts`
+Expected: FAIL — first test gets `seen.length === 0` (the write path does not yet dispatch to the bus).
+
+- [ ] **Step 3: Broaden the event gate and dispatch `afterPut`**
+
+In `packages/hub/src/collection.ts`, replace the body of `put()` from the `let event` line through the `runAfter` line (currently lines ~1106–1119):
+
+Replace this:
+
+```ts
+    let event: WriteEvent | undefined
+    if (this.#hooksActive()) {
+      const prior = await this.#priorForHook(id)
+      event = {
+        op: prior.record === null ? 'create' : 'update',
+        vault: this.vault, collection: this.name, docId: id, before: prior.record, after: record,
+        userId: this.keyring.userId, timestamp: Date.now(), txId: this.#txIdForHook(),
+        baseVersion: prior.version, version: prior.version + 1,
+      }
+      await this.writeHooks!.runBefore(event) // throw → aborts the write
+    }
+    if (this.writeQueue) await this.writeQueue.track(() => this.putInternal(id, record, options))
+    else await this.putInternal(id, record, options)
+    if (event) await this.writeHooks!.runAfter(event)
+```
+
+With this:
+
+```ts
+    // #230 user write-hooks AND the Track A observe bus both need the
+    // WriteEvent. Build it if EITHER consumer is active so the bus is not
+    // coupled to write-hooks being present.
+    const hooksActive = this.#hooksActive()
+    const busAfterPut = this.subsystemBus?.hasHandlers('afterPut') ?? false
+    let event: WriteEvent | undefined
+    if (hooksActive || busAfterPut) {
+      const prior = await this.#priorForHook(id)
+      event = {
+        op: prior.record === null ? 'create' : 'update',
+        vault: this.vault, collection: this.name, docId: id, before: prior.record, after: record,
+        userId: this.keyring.userId, timestamp: Date.now(), txId: this.#txIdForHook(),
+        baseVersion: prior.version, version: prior.version + 1,
+      }
+      if (hooksActive) await this.writeHooks!.runBefore(event) // throw → aborts the write
+    }
+    if (this.writeQueue) await this.writeQueue.track(() => this.putInternal(id, record, options))
+    else await this.putInternal(id, record, options)
+    if (event) {
+      // Ordering: user afterWrite hooks run BEFORE observe-bus dispatch in
+      // slice 1. Revisit when internal observe subsystems (e.g. MV-refresh
+      // notification) need to settle before user hooks observe state —
+      // tracked for the gate-bus / migration slices.
+      if (hooksActive) await this.writeHooks!.runAfter(event)
+      if (busAfterPut) await this.subsystemBus!.dispatch('afterPut', event)
+    }
+```
+
+> Rationale: the original gated `event` on `#hooksActive()` alone, then relied on `event` truthiness to call `runAfter`. Because `event` can now exist for the bus when write-hooks are absent (`this.writeHooks` undefined), `runAfter` MUST be re-guarded with the captured `hooksActive` boolean — otherwise `this.writeHooks!` would throw. Capturing `hooksActive` once preserves the original single-evaluation semantics. The bus deliberately shares this `put()` altitude with #230, so it inherits the documented `putMany`/tx/CRDT/blob coverage gap (`collection.ts:1103-1105`); closing that gap for both #230 and the bus is a joint follow-on.
+
+- [ ] **Step 4: Run the integration test to verify it passes**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/subsystem-bus-integration.test.ts`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Run the full hub suite + architecture check to verify no regression**
+
+Run: `cd packages/hub && pnpm vitest run && cd ../.. && pnpm check:architecture`
+Expected: PASS — all existing hub tests green (write-hook behavior unchanged when no bus handler is registered) and architecture invariants hold (no Node-only import introduced; `subsystem-bus.ts` imports only a type from `write-hooks.js`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/collection.ts packages/hub/__tests__/subsystem-bus-integration.test.ts
+git commit -m "feat(hub): dispatch afterPut through observe bus, decoupled from write-hooks (Track A slice 1)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (against the proposal's Track A, honestly scoped):**
+- "Extension-point bus generalizing the three plumbing seeds" → Tasks 1–3 build `SubsystemBus` for the **observe** half and wire it via the same per-instance pattern as `WriteHookRegistry`. ✅
+- "Seam for observe-class subsystems + Track B inspector" → slice 1 delivers exactly this (`afterPut`), at the same coverage envelope as #230. ✅
+- "Migrate guards / periods / consent onto the bus" → **explicitly OUT and re-sequenced.** Validation (`collection.ts:1164/1213/1833/1885`) showed these are throw-to-abort gating dispatched from `putInternal` across all write paths — they need the `track-a-gate-bus` (`beforePut`/`beforeDelete`) primitive first. Listed as a prerequisite follow-on. ✅ (corrected after design review — slice 1 does not claim to be this seam.)
+- "keyring-grant → team", "lazy-mode → subsystem", "kernel-surface CI gate" → named follow-on plans. ✅
+- "Behavior-preserving" → bus is inert until a handler registers; Task 2 Step 5 and Task 3 Step 5 run the full hub suite. ✅
+- "No premature public API" → the bus is NOT exported from the package root (removed after review, per the roadmap API-stability gate); tests use the internal `_subsystemBus` accessor. ✅
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"/"similar to". The one NOTE in Task 3 Step 1 is a concrete version-shape verification with a concrete fallback. ✅
+
+**Type consistency:** `SubsystemBus`, `register`, `hasHandlers`, `dispatch`, `LifecyclePoint`, `LifecycleEventMap`, `BusHandler`, `Unsubscribe`, `_subsystemBus`, `subsystemBus` (opt + field) used identically across Tasks 1–3. The `afterPut` payload is `WriteEvent` (type-imported from `write-hooks.js`) everywhere. ✅
+
+---
+
+## Follow-on plans (not in this slice), in dependency order
+
+1. **`track-a-gate-bus`** — add `beforePut`/`beforeDelete` **gate** points with throw-propagation, dispatched from `putInternal` (and the internal delete method) so they cover all write paths. This is the prerequisite for migrating any write-gating subsystem. Distinct primitive from slice 1's observe bus.
+2. **`track-a-migrate-consent`** — move consent (~194 LOC) onto the appropriate point (observe-bus for its audit append; confirm whether any consent check must gate); remove its hard-coded kernel branch.
+3. **`track-a-migrate-gating`** — periods, guards onto the gate bus; remove their `putInternal` branches; one per commit, each green before the next, full showcase suite as the net.
+4. **`track-a-coverage-unification`** — close the documented `put()`-level coverage gap (`collection.ts:1103-1105`) for #230 write-hooks AND the observe bus by dispatching from `putInternal`, so observe events fire on `putMany`/tx/CRDT/blob writes too. Also settle internal-vs-user hook ordering.
+5. **`track-a-public-surface`** — once migrations validate the bus shape, decide and export the stable public registration surface (if any) behind the API-extractor gate.
+6. **`track-a-keyring-split`** — multi-user grant/revoke/rotate out of core into `team`.
+7. **`track-a-lazy-split`** — promote lazy-mode out of `routing` into its own subsystem.
+8. **`track-a-kernel-ci-gate`** — fail CI when the always-on root grows past a declared ceiling or a subsystem adds a hard-coded `collection.ts`/`vault.ts` reference.

--- a/docs/superpowers/specs/2026-06-01-kernel-shrink-and-devtools-proposal.md
+++ b/docs/superpowers/specs/2026-06-01-kernel-shrink-and-devtools-proposal.md
@@ -1,0 +1,148 @@
+# Proposal: Kernel Shrink + Devtools Inspector
+
+> **Status:** Proposal (high-level, two tracks) — pre-design
+> **Date:** 2026-06-01
+> **Author:** brainstorming session
+> **Scope:** Two independent efforts, each gets its own design → plan → implementation cycle after this proposal is accepted.
+
+This document sketches two enhancements and a recommended sequencing. It is deliberately high-level: each track below becomes its own focused spec before any code is written.
+
+---
+
+## Background: what the codebase already does well
+
+noy-db is **not** a poorly-organized codebase. The package families are already clean:
+
+| Prefix | Family | Examples |
+|--------|--------|----------|
+| `to-*` | storage destinations | `to-postgres`, `to-aws-s3`, `to-browser-idb` |
+| `on-*` | authenticators / IdP bridges | `on-webauthn`, `on-password`, `on-oidc` |
+| `at-*` | sealing-key providers | `at-aws-kms`, `at-env`, `at-macos-keychain` |
+| `as-*` | export/import codecs | `as-csv`, `as-xlsx`, `as-noydb` |
+| `in-*` | framework integrations | `in-react`, `in-vue`, `in-pinia` |
+| `by-*` | session-share transports | `by-tabs`, `by-peer` |
+| — | core + tooling | `hub`, `cli`, `attestation`, `create-noy-db` |
+
+The hub itself is a **minimal-core + opt-in-subsystem** design (`SUBSYSTEMS.md`): 21 subsystems, each with a `with<Name>()` strategy factory, a subpath export, a doc page, and a CI bundle-size gate. Heavy subsystem implementations are `await import()`-ed lazily, so a `createNoydb({ store, user })`-only consumer tree-shakes them out.
+
+**The families and the subsystem catalog do not need restructuring.** The two opportunities below are narrower and concrete.
+
+---
+
+## Track A — Shrink the kernel (architecture)
+
+### The problem, precisely
+
+Tree-shaking already removes subsystem *implementations* from the bundle. What it does **not** remove is subsystem *awareness* baked into the always-on kernel.
+
+`collection.ts` (3,955 LOC) and `vault.ts` (3,526 LOC) are always-on orchestration objects that hard-code a private field and an inline dispatch branch for **every** subsystem:
+
+```ts
+// collection.ts — a sample of the always-on coupling
+private readonly blobStrategy: BlobStrategy
+private readonly aggregateStrategy: AggregateStrategy
+private readonly crdtStrategy: CrdtStrategy
+private readonly historyStrategy: HistoryStrategy
+private readonly i18nStrategy: I18nStrategy
+private readonly syncStrategy: SyncStrategy
+private readonly periodGuard: ...
+private readonly guardSource: ...
+private readonly derivationSource: ...
+private readonly materializedViewSource: ...
+private readonly joinResolver: ...
+```
+
+`collection.ts` references `Strategy|Source|Resolver|Guard` **173 times**. Adding subsystem #22 means editing the kernel — an open/closed-principle violation. It is also why `SUBSYSTEMS.md` advertises a ~6,500-LOC core while the actual always-on root files total ~14k+ LOC (`collection.ts` 3,955, `vault.ts` 3,526, `noydb.ts` 2,722, `types.ts` 2,081, `errors.ts` 1,787). The bundle-size gates pass; the *kernel surface* aspiration has drifted from the code.
+
+### The proposal
+
+1. **Extension-point bus.** Generalize the three plumbing seeds that already exist — `NoydbEventEmitter` (`events.ts`), `WriteHookRegistry` (`write-hooks.ts`, #230), and `WriteQueueTracker` (`write-queue.ts`, #227) — into one named-lifecycle-point bus. Subsystems register handlers against named points instead of the kernel naming each subsystem:
+
+   - Write path: `beforePut`, `afterPut`, `beforeDelete`, `afterDelete`
+   - Read path: `onRead`, query-terminal hooks
+   - Lifecycle: `onVaultOpen`, `onCollectionOpen`
+
+   The kernel retains only: record CRUD, crypto envelope, the 6-method store contract, and the bus. Subsystem dispatch branches move out of `collection.ts`/`vault.ts` into the subsystems' own registration code.
+
+2. **Complete the two splits `SUBSYSTEMS.md` already lists as open:**
+   - **keyring-grant → `team`.** Move multi-user grant/revoke/rotate out of core so the floor is genuinely single-user.
+   - **lazy-mode → its own subsystem.** Promote the cache + on-demand fetch path currently buried inside `routing`.
+
+3. **Make the kernel claim CI-enforceable.** Add a kernel-surface invariant (alongside the existing bundle-size invariants) that fails CI if the always-on root grows past a declared ceiling, or if a new subsystem adds a hard-coded reference into `collection.ts`/`vault.ts`.
+
+### Payoff vs. risk
+
+- **Payoff:** the kernel stops growing per-subsystem; the catalog's "minimal core" claim becomes load-bearing on kernel surface, not just bundle bytes; `collection.ts`/`vault.ts` shrink to a size a single reader (human or model) can hold in context; subsystem #22+ is purely additive.
+- **Risk:** this touches the hottest paths — every `put`/`get`/`delete`. It MUST be strictly behavior-preserving. Mitigation: the existing 107-showcase suite plus the ~1,600 hub unit tests are the regression net; migrate one lifecycle point at a time, each migration green before the next.
+
+### Out of scope for Track A
+
+- No new subsystems (that's Track B).
+- No change to the public `createNoydb` / `with<Name>()` surface — this is an internal decomposition, not an API break. (If a break proves unavoidable, it escalates to its own decision.)
+
+---
+
+## Track B — Devtools / inspector (new feature)
+
+### Why this matches a common developer pattern
+
+Every adopter inspecting a noy-db vault today hand-rolls it: `console.log` on query results, manual `dumpSchema()` calls, eyeballing sync state. Mature data layers ship an inspector — Prisma Studio, Redux DevTools, React Query Devtools. Developers expect one.
+
+### Why it is low-risk and well-seated
+
+The inspector is almost entirely a **consumer** of seams that already exist:
+
+- `vault.dumpSchema()` → `SchemaIntrospection`, `CollectionDescriptor`, `CollectionStats` (records, bytes, oldest/newest)
+- live queries (`.live()` / `.subscribe()`)
+- the observable write-queue (#227) and write hooks (#230)
+- `to-probe` / `to-meter` store wrappers for backend timing/stats
+- the `noydb describe` CLI (schema dump already wired)
+
+It ships as a new package in the `in-*` family (`@noy-db/in-devtools`) plus an optional always-off `withInspector()` hook surface. **No kernel changes**, and it composes naturally with Track A's bus — the inspector becomes the canonical bus consumer.
+
+### Two delivery modes (confirmed)
+
+1. **Browser panel.** A framework-agnostic core that streams a read-only snapshot over the existing event surface, plus a browser UI:
+   - vault → collection → record tree
+   - schema + indexes + refs per collection
+   - live query results with re-run
+   - history timeline (when `withHistory` is on)
+   - sync / write-queue state
+2. **CLI / TUI mode.** Extends `noydb describe` into an interactive terminal inspector for headless / server / CI contexts (no browser).
+
+### Hard constraints (zero-knowledge respect)
+
+- **Read-only.** The inspector never writes through any path that isn't already a public, permission-checked API.
+- **Already-unlocked only.** It shows decrypted data solely within an already-open session; it never handles passphrases, never touches ciphertext semantics, and never bypasses the keyring or permission checks.
+- **No new always-on cost.** The hook surface is off unless `withInspector()` is opted into; the panel/CLI live in a separate package.
+
+### Out of scope for Track B
+
+- Editing data from the panel (read-only v1; mutation is a possible v2 behind explicit opt-in).
+- Remote/production telemetry shipping (this is a local dev tool, not an observability backend — that's the reserved `metrics` subsystem).
+
+---
+
+## Recommended sequencing
+
+**Track A first, then Track B.**
+
+The inspector (B) is the ideal *first consumer* of the extension bus (A). If the bus lands first, the panel subscribes to named lifecycle points instead of reaching into kernel internals, and building the inspector validates the bus design against a real workload. Building B first would couple it to the current god-object surface and create rework when A lands.
+
+| | Track A — Kernel shrink | Track B — Devtools inspector |
+|---|---|---|
+| Risk | High (hot paths) | Low (additive, consumer-only) |
+| Touches kernel | Yes | No |
+| Depends on | — | Track A's bus (soft) |
+| Net LOC effect | Kernel shrinks | New `in-devtools` package |
+| Sequence | **1st** | **2nd** |
+
+---
+
+## Next steps
+
+1. Accept / revise this proposal.
+2. Open the **Track A** design (`writing-plans`): enumerate every lifecycle point, the exact subsystem-by-subsystem migration order, and the kernel-surface CI gate.
+3. After Track A ships, open the **Track B** design: the `in-devtools` package API, the snapshot protocol over the bus, browser panel UX, and CLI/TUI mode.
+
+Each step gets its own spec → plan → implementation cycle. This document is the umbrella.

--- a/packages/at-aws-kms/src/index.ts
+++ b/packages/at-aws-kms/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * **@noy-db/at-aws-kms** — AWS KMS sealing key provider for noy-db
- * managed-passphrase mode (#188).
+ * managed-passphrase mode.
  *
  * An `at-*` provider that seals and unseals the hub-generated random
  * passphrase via AWS KMS Encrypt / Decrypt. Every seal and unseal is an

--- a/packages/at-azure-keyvault/src/index.ts
+++ b/packages/at-azure-keyvault/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * **@noy-db/at-azure-keyvault** — Azure Key Vault sealing key provider for noy-db
- * managed-passphrase mode (#190).
+ * managed-passphrase mode.
  *
  * An `at-*` provider that seals and unseals the hub-generated random
  * passphrase via Azure Key Vault Encrypt / Decrypt. Every seal and unseal is

--- a/packages/at-env/src/index.ts
+++ b/packages/at-env/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * **@noy-db/at-env** — env-var sealing key provider for noy-db
- * managed-passphrase mode (#14).
+ * managed-passphrase mode.
  *
  * The smallest production-shape provider in the `at-*` family. Reads a
  * 32-byte AES-256-GCM key from an environment variable (base64-encoded)

--- a/packages/at-gcp-kms/src/index.ts
+++ b/packages/at-gcp-kms/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * **@noy-db/at-gcp-kms** — Google Cloud KMS sealing key provider for noy-db
- * managed-passphrase mode (#189).
+ * managed-passphrase mode.
  *
  * An `at-*` provider that seals and unseals the hub-generated random
  * passphrase via Google Cloud KMS Encrypt / Decrypt. Every seal and unseal is

--- a/packages/hub/__tests__/subsystem-bus-integration.test.ts
+++ b/packages/hub/__tests__/subsystem-bus-integration.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb, ConflictError } from '../src/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot, WriteEvent } from '../src/index.js'
+
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll() {},
+  }
+}
+
+describe('SubsystemBus integration — afterPut fires from put()', () => {
+  it('fires with no write-hooks registered (proves decoupling from #230)', async () => {
+    const db = await createNoydb({ store: memoryStore(), secret: 'pw', user: 'owner' })
+    const seen: WriteEvent[] = []
+    db._subsystemBus.register('afterPut', (e) => { seen.push(e) })
+
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<{ id: string; n: number }>('docs')
+    await docs.put('a', { id: 'a', n: 1 })
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0].op).toBe('create')
+    expect(seen[0].collection).toBe('docs')
+    expect(seen[0].docId).toBe('a')
+    expect(seen[0].after).toEqual({ id: 'a', n: 1 })
+  })
+
+  it('does not fire when no handler is registered (zero-cost path)', async () => {
+    const db = await createNoydb({ store: memoryStore(), secret: 'pw', user: 'owner' })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<{ id: string; n: number }>('docs')
+    await expect(docs.put('a', { id: 'a', n: 1 })).resolves.toBeUndefined()
+  })
+})

--- a/packages/hub/__tests__/subsystem-bus-integration.test.ts
+++ b/packages/hub/__tests__/subsystem-bus-integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { createNoydb, ConflictError } from '../src/index.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot, WriteEvent } from '../src/index.js'
 
@@ -49,10 +49,12 @@ describe('SubsystemBus integration — afterPut fires from put()', () => {
     expect(seen[0].after).toEqual({ id: 'a', n: 1 })
   })
 
-  it('does not fire when no handler is registered (zero-cost path)', async () => {
+  it('does not dispatch when no handler is registered', async () => {
     const db = await createNoydb({ store: memoryStore(), secret: 'pw', user: 'owner' })
     const vault = await db.openVault('v1')
     const docs = vault.collection<{ id: string; n: number }>('docs')
-    await expect(docs.put('a', { id: 'a', n: 1 })).resolves.toBeUndefined()
+    const spy = vi.spyOn(db._subsystemBus, 'dispatch')
+    await docs.put('a', { id: 'a', n: 1 })
+    expect(spy).not.toHaveBeenCalled()
   })
 })

--- a/packages/hub/__tests__/subsystem-bus.test.ts
+++ b/packages/hub/__tests__/subsystem-bus.test.ts
@@ -53,4 +53,16 @@ describe('SubsystemBus (observe)', () => {
     const bus = new SubsystemBus()
     await expect(bus.dispatch('afterPut', ev())).resolves.toBeUndefined()
   })
+
+  it('tolerates handler unsubscribe during dispatch (snapshot semantics)', async () => {
+    const bus = new SubsystemBus()
+    const ran: string[] = []
+    let off = () => {}
+    off = bus.register('afterPut', () => { off(); ran.push('first') })
+    bus.register('afterPut', () => { ran.push('second') })
+    await bus.dispatch('afterPut', ev())
+    // Both handlers were in the dispatch snapshot; the first unsubscribing
+    // itself must not skip the second.
+    expect(ran).toEqual(['first', 'second'])
+  })
 })

--- a/packages/hub/__tests__/subsystem-bus.test.ts
+++ b/packages/hub/__tests__/subsystem-bus.test.ts
@@ -65,4 +65,18 @@ describe('SubsystemBus (observe)', () => {
     // itself must not skip the second.
     expect(ran).toEqual(['first', 'second'])
   })
+
+  it('delivers all events for concurrent dispatches with async handlers (no drop)', async () => {
+    const bus = new SubsystemBus()
+    const seen: string[] = []
+    bus.register('afterPut', async (e) => {
+      await new Promise((r) => setTimeout(r, 5))
+      seen.push(e.docId)
+    })
+    await Promise.all([
+      bus.dispatch('afterPut', ev({ docId: 'a' })),
+      bus.dispatch('afterPut', ev({ docId: 'b' })),
+    ])
+    expect([...seen].sort()).toEqual(['a', 'b'])
+  })
 })

--- a/packages/hub/__tests__/subsystem-bus.test.ts
+++ b/packages/hub/__tests__/subsystem-bus.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { SubsystemBus } from '../src/subsystem-bus.js'
+import type { WriteEvent } from '../src/write-hooks.js'
+
+function ev(over: Partial<WriteEvent> = {}): WriteEvent {
+  return {
+    op: 'create', vault: 'v', collection: 'c', docId: 'd',
+    before: null, after: { x: 1 }, baseVersion: 0, version: 1,
+    userId: 'u', timestamp: 0, txId: 't', ...over,
+  }
+}
+
+describe('SubsystemBus (observe)', () => {
+  it('dispatches handlers in registration order', async () => {
+    const bus = new SubsystemBus()
+    const order: number[] = []
+    bus.register('afterPut', () => { order.push(1) })
+    bus.register('afterPut', () => { order.push(2) })
+    await bus.dispatch('afterPut', ev())
+    expect(order).toEqual([1, 2])
+  })
+
+  it('hasHandlers reflects registration and unsubscribe', async () => {
+    const bus = new SubsystemBus()
+    expect(bus.hasHandlers('afterPut')).toBe(false)
+    const off = bus.register('afterPut', () => {})
+    expect(bus.hasHandlers('afterPut')).toBe(true)
+    off()
+    expect(bus.hasHandlers('afterPut')).toBe(false)
+  })
+
+  it('awaits async handlers', async () => {
+    const bus = new SubsystemBus()
+    let done = false
+    bus.register('afterPut', async () => {
+      await new Promise((r) => setTimeout(r, 5))
+      done = true
+    })
+    await bus.dispatch('afterPut', ev())
+    expect(done).toBe(true)
+  })
+
+  it('isolates a throwing handler — others still run, dispatch never rejects (observe policy)', async () => {
+    const bus = new SubsystemBus()
+    const ran: string[] = []
+    bus.register('afterPut', () => { throw new Error('boom') })
+    bus.register('afterPut', () => { ran.push('second') })
+    await expect(bus.dispatch('afterPut', ev())).resolves.toBeUndefined()
+    expect(ran).toEqual(['second'])
+  })
+
+  it('dispatch is a no-op when no handler is registered', async () => {
+    const bus = new SubsystemBus()
+    await expect(bus.dispatch('afterPut', ev())).resolves.toBeUndefined()
+  })
+})

--- a/packages/hub/src/auth-introspection/index.ts
+++ b/packages/hub/src/auth-introspection/index.ts
@@ -1,5 +1,5 @@
 /**
- * Authentication introspection — issue #13.
+ * Authentication introspection.
  *
  * Three surfaces over the configured tier model and the actual
  * per-user enrollment state:

--- a/packages/hub/src/bundle/adopt-partition.ts
+++ b/packages/hub/src/bundle/adopt-partition.ts
@@ -1,9 +1,9 @@
 /**
- * Partition adoption (#207). Recipient side: verify an extracted bundle,
+ * Partition adoption. Recipient side: verify an extracted bundle,
  * validate the transfer key, import the re-keyed collections into a
  * destination store, and record an `_meta/adoption` marker. The bundle
- * stays UNOWNED after adoption — `createOwnerOnAdoptedPartition` (#208)
- * mints the owner; `#209` destroys the seal.
+ * stays UNOWNED after adoption — `createOwnerOnAdoptedPartition`
+ * mints the owner; the transfer seal is then destroyed.
  *
  * @module
  */
@@ -21,7 +21,7 @@ import type { TransferSealPayload } from './bundle.js'
 import { readNoydbBundleHeader, readNoydbBundle, parseExtractedPartitionBody } from './bundle.js'
 
 /**
- * Reverse of `sealDeks` (#206). Imports the transfer key, decrypts the
+ * Reverse of `sealDeks`. Imports the transfer key, decrypts the
  * sealed `{ collection: base64(rawDEK) }` map (layout iv(12)‖ct‖tag), and
  * re-imports each DEK as an AES-GCM key. Throws `TransferSealError` on a
  * wrong key (AES-GCM auth-tag failure) or malformed payload.
@@ -58,7 +58,7 @@ export async function unsealDeks(
   const deks = new Map<string, CryptoKey>()
   for (const [collection, b64] of Object.entries(dekMap)) {
     // Extractable: the recipient must be able to re-wrap these under their
-    // own KEK (AES-KW) at owner-creation (#208). Matches generateDEK.
+    // own KEK (AES-KW) at owner-creation. Matches generateDEK.
     const dek = await crypto.subtle.importKey('raw', base64ToBuffer(b64) as BufferSource, 'AES-GCM', true, ['encrypt', 'decrypt'])
     deks.set(collection, dek)
   }
@@ -96,7 +96,7 @@ export async function adoptPartition(
 
   // Validate the transfer key by unsealing in memory; throws
   // TransferSealError on mismatch. DEKs are discarded here — they stay
-  // sealed at rest (in _meta/adoption) until #208 wraps them under the
+  // sealed at rest (in _meta/adoption) until owner-creation wraps them under the
   // recipient's KEK.
   await unsealDeks(seal, transferKey)
 
@@ -138,7 +138,7 @@ export async function adoptPartition(
   const backup = JSON.parse(dump) as { collections: VaultSnapshot; _internal?: VaultSnapshot }
   await destinationStore.saveAll(vaultName, backup.collections)
 
-  // Import carried internal collections (e.g. _schemas from #204 carrySchemas).
+  // Import carried internal collections (e.g. _schemas from carrySchemas).
   // saveAll only writes data collections; _internal is written per-record.
   if (backup._internal) {
     for (const [collection, records] of Object.entries(backup._internal)) {
@@ -170,10 +170,10 @@ export interface CreateOwnerStandardOptions {
 }
 
 /**
- * Managed-mode owner (#208 follow-up): the passphrase is minted + sealed under
+ * Managed-mode owner: the passphrase is minted + sealed under
  * a `SealingKeyProvider` (e.g. an `at-*` OS keychain) so the partition
  * auto-unlocks on the recipient's device. Managed mode mandates a strong
- * (Shamir) recovery profile at creation (#195), which needs the
+ * (Shamir) recovery profile at creation, which needs the
  * `shamirRecovery` provider injected.
  */
 export interface CreateOwnerManagedOptions {
@@ -192,12 +192,12 @@ function isManaged(o: CreateOwnerOptions): o is CreateOwnerManagedOptions {
 }
 
 /**
- * Mint the first owner keyring on an adopted-but-unowned partition (#208),
- * then destroy the transfer seal (#209).
+ * Mint the first owner keyring on an adopted-but-unowned partition,
+ * then destroy the transfer seal.
  *
  * Standard mode: the recipient supplies a passphrase. Managed mode: the
  * passphrase is minted + sealed under a `SealingKeyProvider` and a strong
- * (Shamir) recovery profile is enrolled (#195) — orchestrated via the existing
+ * (Shamir) recovery profile is enrolled — orchestrated via the existing
  * `openVaultAndEnrollRecovery` ceremony.
  *
  * Either way, reuses `createOwnerKeyring` to derive the KEK + write the base
@@ -220,7 +220,7 @@ export async function createOwnerOnAdoptedPartition(
   const { userId, transferKey } = opts
 
   // Managed mode requires a strong (Shamir) recovery profile, validated BEFORE
-  // any disk write (#195) — same gate as createNoydb.
+  // any disk write — same gate as createNoydb.
   if (isManaged(opts) && !opts.recovery.some((r) => r.profile === 'shamir')) {
     throw new AdoptionStateError(
       'managed-mode adoption requires at least one strong (shamir) recovery profile in '
@@ -302,7 +302,7 @@ export async function createOwnerOnAdoptedPartition(
     await store.put(vaultName, '_keyring', userId, { ...env, _data: JSON.stringify(mergedFile) })
   }
 
-  // Stage B — (#226 destination) record the ownership transition on the carried
+  // Stage B — record the ownership transition on the carried
   // audit chain (carryLedger sealed the _ledger DEK). No-op without that DEK.
   // Idempotent: appended only if the closing `transfer-seal-consumed` entry is
   // absent, so a retry does not duplicate the pair.
@@ -329,8 +329,8 @@ export async function createOwnerOnAdoptedPartition(
     }
   }
 
-  // Stage C — Managed mode (#208 follow-up): enroll the mandatory strong recovery
-  //    (#195) by orchestrating the existing public ceremony. The partition is
+  // Stage C — Managed mode: enroll the mandatory strong recovery
+  //    by orchestrating the existing public ceremony. The partition is
   //    now a managed-mode vault on disk (sealed passphrase + keyring), so we
   //    open it as a normal client and let openVaultAndEnrollRecovery do the
   //    gate-bypass + enroll + re-assert. Dynamic import keeps the Noydb class
@@ -348,7 +348,7 @@ export async function createOwnerOnAdoptedPartition(
     await db.openVaultAndEnrollRecovery(vaultName, { recovery: opts.recovery })
   }
 
-  // Stage D — (#209) Destroy the transfer seal LAST — the commit point. Everything
+  // Stage D — Destroy the transfer seal LAST — the commit point. Everything
   //    above is either idempotent or resumable, so the seal is only consumed
   //    once the owner keyring (and, in managed mode, strong recovery) is
   //    durably in place. Retain sealId + consumedAt for audit.

--- a/packages/hub/src/bundle/bundle.ts
+++ b/packages/hub/src/bundle/bundle.ts
@@ -57,7 +57,7 @@ import { pickLocale } from '../meta/public-envelope/storage.js'
 import type { PublicEnvelope } from '../meta/public-envelope/types.js'
 import type { SealingKeyProvider, RecipientSealer, RecipientHint } from '../team/managed-passphrase.js'
 
-// ─── #215 auto-credential types ───────────────────────────────────────────────
+// ─── Auto-credential types ────────────────────────────────────────────────────
 
 /**
  * The credential kinds that can be bundled for auto-unlock.
@@ -89,7 +89,7 @@ export interface AutoCredential {
  * - `compression: 'gzip'` — force gzip
  * - `compression: 'none'` — no compression (round-trip testing only)
  *
- * **Slice filtering** (added in ):
+ * **Slice filtering:**
  * - `collections` — allowlist of collection names to include. Internal
  *   collections (keyrings, ledger) and excluded user collections are
  *   dropped from the bundle. Records inside included collections are
@@ -152,7 +152,7 @@ export interface WriteNoydbBundleOptions {
    */
   readonly recipients?: readonly BundleRecipient[]
   /**
-   * Auto-unlock — unsealed per-user credentials (#215).
+   * Auto-unlock — unsealed per-user credentials.
    *
    * Generalises `autoPassphrases` to support any bundleable credential
    * kind (`passphrase` | `password` | `pin`).
@@ -174,7 +174,7 @@ export interface WriteNoydbBundleOptions {
   }
   /**
    * Auto-unlock — per-user credentials sealed under a
-   * {@link SealingKeyProvider} (#215).
+   * {@link SealingKeyProvider}.
    *
    * Generalises `sealedPassphrases` to support any bundleable
    * credential kind (`passphrase` | `password` | `pin`).
@@ -209,9 +209,9 @@ export interface WriteNoydbBundleOptions {
         readonly perUser: Record<string, { readonly credential: AutoCredential; readonly hint: RecipientHint }>
       }
   /**
-   * @deprecated Use `autoCredentials` instead (#215).
+   * @deprecated Use `autoCredentials` instead.
    *
-   * Auto-unlock — unsealed per-user passphrases (#197 slice 1).
+   * Auto-unlock — unsealed per-user passphrases.
    *
    * Public-by-design: anyone holding the bundle bytes can read these
    * plaintext credentials. Use for demo data, sample vaults,
@@ -229,10 +229,10 @@ export interface WriteNoydbBundleOptions {
     readonly perUser: Record<string, string>
   }
   /**
-   * @deprecated Use `sealedCredentials` instead (#215).
+   * @deprecated Use `sealedCredentials` instead.
    *
    * Auto-unlock — per-user passphrases sealed under a
-   * {@link SealingKeyProvider} (#197 slice 1, self-target only).
+   * {@link SealingKeyProvider} (self-target only).
    *
    * The hub seals each user's plaintext passphrase under `provider`
    * and embeds the resulting sealed envelopes in the bundle. The
@@ -265,7 +265,7 @@ export interface NoydbBundleReadResult {
   readonly header: NoydbBundleHeader
   readonly dumpJson: string
   /**
-   * Auto-unlock material (#197, widened in #215). Present only when
+   * Auto-unlock material. Present only when
    * the header's `autoUnlock` flag is set AND the body's wrapped
    * structure survived parsing. Values are typed credentials — either
    * delivered plain (`kind: 'unsealed'`) or unsealed at read time
@@ -295,7 +295,7 @@ export interface NoydbBundleReadResult {
  * metadata so the consumer can dispatch on credential type without
  * unsealing first.
  *
- * Back-compat: `kind` is absent in pre-0.2 bundles — readers must
+ * Back-compat: `kind` is absent in older bundles — readers must
  * default to `'passphrase'` when not present.
  */
 interface SealedAutoUnlockEntry {
@@ -315,9 +315,9 @@ interface SealedAutoUnlockEntry {
 /**
  * Discriminated wrapper carried in the bundle body when the header's
  * `autoUnlock` flag is set. Without the flag, the body is the raw
- * `vault.dump()` JSON string (the pre-#197 shape).
+ * `vault.dump()` JSON string.
  *
- * Back-compat: pre-0.2 bundles carry bare `string` values in the
+ * Back-compat: older bundles carry bare `string` values in the
  * unsealed `perUser` map. Readers must coerce those to
  * `{ kind: 'passphrase', value }`.
  */
@@ -330,9 +330,9 @@ interface AutoUnlockBody {
 }
 
 /**
- * Options accepted by {@link readNoydbBundle} for the #197
- * auto-unlock paths. Without these the reader behaves exactly as
- * pre-#197 (header parsed; body returned as `dumpJson`).
+ * Options accepted by {@link readNoydbBundle} for the
+ * auto-unlock paths. Without these the reader behaves exactly as before
+ * (header parsed; body returned as `dumpJson`).
  */
 export interface ReadNoydbBundleOptions {
   /**
@@ -355,7 +355,7 @@ export interface ReadNoydbBundleOptions {
   readonly attemptUnsealAcrossProviders?: boolean
 }
 
-// ─── #197/#215 auto-unlock helpers ────────────────────────────────────────────
+// ─── Auto-unlock helpers ──────────────────────────────────────────────────────
 
 /**
  * Internal normalized form of the auto-unlock options, computed once
@@ -441,7 +441,7 @@ function normalizeAutoUnlock(opts: WriteNoydbBundleOptions): NormalizedAutoUnloc
  * `writeNoydbBundle`) can pass the same object to `buildAutoUnlockWrapper`
  * without a second `normalizeAutoUnlock` call.
  *
- * Validation per spec (#197 + #215 §3):
+ * Validation per spec (§3):
  *   - (mutual exclusion already enforced by normalizeAutoUnlock)
  *   - unsealed path: `policy: 'public-by-design'` marker required
  *   - non-empty `perUser` maps
@@ -676,10 +676,10 @@ function parseAutoUnlockBody(bodyString: string): { dump: string; blob: AutoUnlo
 }
 
 /**
- * Transfer-seal payload (#206). The destination DEKs, exported to raw
+ * Transfer-seal payload. The destination DEKs, exported to raw
  * bytes and AES-256-GCM-sealed *as a set* under the one-time transfer
- * key. `adoptPartition` (#207) unseals this; `createOwnerOnAdoptedPartition`
- * (#208) re-wraps the raw DEKs under the recipient's KEK.
+ * key. `adoptPartition` unseals this; `createOwnerOnAdoptedPartition`
+ * re-wraps the raw DEKs under the recipient's KEK.
  */
 export interface TransferSealPayload {
   readonly v: 1
@@ -690,7 +690,7 @@ export interface TransferSealPayload {
 }
 
 /**
- * Body wrapper for an extracted, transfer-sealed partition (#203/#206).
+ * Body wrapper for an extracted, transfer-sealed partition.
  * Sibling to {@link AutoUnlockBody}; selected by `header.bundleKind ===
  * 'extracted-partition'`. The inner `dump` is a re-keyed projection with
  * an empty `keyrings` map.
@@ -745,8 +745,8 @@ export function parseExtractedPartitionBody(
 }
 
 /**
- * Coerce an unsealed perUser entry to `AutoCredential`. Pre-0.2 bundles
- * store bare strings; 0.2+ bundles store `{ kind, value }` objects.
+ * Coerce an unsealed perUser entry to `AutoCredential`. Older bundles
+ * store bare strings; newer bundles store `{ kind, value }` objects.
  */
 function coerceUnsealed(entry: AutoCredential | string): AutoCredential {
   if (typeof entry === 'string') return { kind: 'passphrase', value: entry }
@@ -1235,7 +1235,7 @@ export async function writeNoydbBundle(
     )
   }
 
-  // #197/#215 — auto-unlock: normalize once, validate + build from the
+  // Auto-unlock: normalize once, validate + build from the
   // same NormalizedAutoUnlock object so there's no double-normalize call.
   const normalizedAutoUnlock = normalizeAutoUnlock(opts)
   const autoUnlockMode = validateAutoUnlockOptions(opts, normalizedAutoUnlock)
@@ -1254,8 +1254,8 @@ export async function writeNoydbBundle(
   const plainFiltered = await applyPlaintextFilters(vault, rekeyed, opts)
   const filtered = applySliceFilters(plainFiltered, opts)
 
-  // If no auto-unlock requested, body remains the raw dump JSON
-  // (pre-#197 shape). Otherwise build the wrapped body containing the
+  // If no auto-unlock requested, body remains the raw dump JSON.
+  // Otherwise build the wrapped body containing the
   // dump + `_autoUnlock` blob and serialize.
   const bodyJsonStr = normalizedAutoUnlock === null
     ? filtered
@@ -1437,9 +1437,9 @@ export async function readNoydbBundle(
 
   const bodyString = new TextDecoder('utf-8', { fatal: true }).decode(dumpBytes)
 
-  // #197 — when the header signaled an auto-unlock, the body is a
+  // When the header signals auto-unlock, the body is a
   // JSON wrapper carrying the dump string + the auto-unlock blob.
-  // When absent, the body IS the raw dump JSON (pre-#197 shape).
+  // When absent, the body IS the raw dump JSON.
   if (header.autoUnlock === undefined) {
     return { header, dumpJson: bodyString }
   }

--- a/packages/hub/src/bundle/describe-extraction.ts
+++ b/packages/hub/src/bundle/describe-extraction.ts
@@ -1,5 +1,5 @@
 /**
- * Partition-extraction dry-run (#202). Read-only preview of what an
+ * Partition-extraction dry-run. Read-only preview of what an
  * `extractPartition` would move: record counts, byte totals, and the
  * timestamp span per collection — computed from raw encrypted
  * envelopes WITHOUT decrypting them. Writes nothing, mutates nothing.

--- a/packages/hub/src/bundle/extract-partition.ts
+++ b/packages/hub/src/bundle/extract-partition.ts
@@ -1,5 +1,5 @@
 /**
- * Partition extraction (#203 + #206). Walks the FK closure, re-encrypts
+ * Partition extraction. Walks the FK closure, re-encrypts
  * the selected records under fresh per-collection DEKs, seals those DEKs
  * under a one-time transfer key, and serializes an unowned
  * `extracted-partition` bundle.
@@ -65,7 +65,7 @@ export async function reKeyClosure(
 
 /**
  * Re-key the persisted JSON Schemas (`_schemas/<collection>`) for the
- * closure collections under the destination DEKs (#204). Returns a
+ * closure collections under the destination DEKs. Returns a
  * `{ collection: envelope }` map for the carried collections that actually
  * have a schema; collections without one are omitted.
  */
@@ -100,7 +100,7 @@ export interface ReKeyLedgerResult {
 }
 
 /**
- * Build the carried `_ledger` chain for an extracted partition (#205, slice 1).
+ * Build the carried `_ledger` chain for an extracted partition.
  * Filters source entries to the closure, RE-CHAINS them (fresh index + prevHash),
  * and re-encrypts under `ledgerDek`. The `payloadHash` is recomputed against the
  * re-keyed envelope ONLY for the latest `put` per (collection,id) — the entry
@@ -223,8 +223,8 @@ export interface ExtractPartitionResult {
 }
 
 /**
- * Extract a re-keyed, transfer-sealed partition (#203 + #206). Owner-only
- * (#198 invariant 5): producing a standalone re-keyed vault is an
+ * Extract a re-keyed, transfer-sealed partition. Owner-only
+ * (invariant 5): producing a standalone re-keyed vault is an
  * ownership operation. Non-destructive on the source.
  */
 export async function extractPartition(
@@ -252,8 +252,8 @@ export async function extractPartition(
   const { closure } = await walkClosure(vault, opts)
   const { collections, deks } = await reKeyClosure(vault, closure)
 
-  // carryLedger (#205): mint a fresh _ledger DEK, build the carried chain, and
-  // SEAL the ledger DEK alongside the data DEKs so #208 wraps it into the
+  // carryLedger: mint a fresh _ledger DEK, build the carried chain, and
+  // SEAL the ledger DEK alongside the data DEKs so owner-creation wraps it into the
   // recipient keyring (lets them decrypt + verify the chain). Must run BEFORE
   // sealDeks.
   let ledgerHead: { hash: string; index: number; ts: string } | undefined
@@ -273,7 +273,7 @@ export async function extractPartition(
     }
   }
 
-  // Build _internal (schemas #204 + ledger #205). reKeySchemas reads data-
+  // Build _internal (schemas + ledger). reKeySchemas reads data-
   // collection DEKs only, so it is unaffected by the _ledger DEK added above.
   const internalSchemas = opts.carrySchemas ? await reKeySchemas(vault, closure, deks) : {}
   const internal: Record<string, Record<string, EncryptedEnvelope>> = {}
@@ -283,7 +283,7 @@ export async function extractPartition(
 
   const { seal, transferKey } = await sealDeks(deks)
 
-  // Source-side audit (#226 / spec §4.2 / invariant 4): record that a partition
+  // Source-side audit (spec §4.2 / invariant 4): record that a partition
   // was handed over. Non-destructive — an audit append, no record touched.
   // No-op when the source vault has no history strategy. append() fills
   // index/prevHash/ts and (since actor is '') the ledger's configured actor.

--- a/packages/hub/src/bundle/format.ts
+++ b/packages/hub/src/bundle/format.ts
@@ -130,7 +130,7 @@ export interface NoydbBundleHeader {
    */
   readonly publicEnvelope?: PublicEnvelope
   /**
-   * Auto-unlock material indicator (#197). When present, the bundle
+   * Auto-unlock material indicator. When present, the bundle
    * body wraps the dump JSON in a structure carrying per-user
    * passphrases — either plaintext (`'unsealed'`, public-by-design)
    * or sealed under a `SealingKeyProvider` (`'sealed'`, requires
@@ -142,17 +142,17 @@ export interface NoydbBundleHeader {
    * (sealed).
    *
    * Absent → the body is a raw `vault.dump()` JSON string (the
-   * pre-#197 shape; back-compatible).
+   * the legacy shape; back-compatible).
    */
   readonly autoUnlock?: 'unsealed' | 'sealed'
   /**
-   * Bundle's role in the source → destination lifecycle (#203).
+   * Bundle's role in the source → destination lifecycle.
    *   - omitted / 'snapshot' (default): backup/copy of an existing vault.
    *   - 'extracted-partition': re-keyed projection awaiting adoption.
    */
   readonly bundleKind?: 'snapshot' | 'extracted-partition'
   /**
-   * Transfer-seal INDICATOR (#206) — metadata only, no payload (the
+   * Transfer-seal INDICATOR — metadata only, no payload (the
    * sealed DEKs live in the body). Present iff
    * bundleKind === 'extracted-partition'.
    */

--- a/packages/hub/src/bundle/index.ts
+++ b/packages/hub/src/bundle/index.ts
@@ -41,7 +41,7 @@ export type {
 
 export { generateULID, isULID } from './ulid.js'
 
-// ─── Partition extraction (#198 epic) ───────────────────
+// ─── Partition extraction ────────────────────────────────
 export { walkClosure } from './walk-closure.js'
 export type { WalkClosureOptions, ClosureResult } from './walk-closure.js'
 export { describeExtraction } from './describe-extraction.js'

--- a/packages/hub/src/bundle/walk-closure.ts
+++ b/packages/hub/src/bundle/walk-closure.ts
@@ -1,5 +1,5 @@
 /**
- * Transitive-closure FK walker (#201). Computes the set of
+ * Transitive-closure FK walker. Computes the set of
  * (collection, id) tuples reachable from seed predicates, so a
  * partition extraction ships a referentially-complete subset.
  *

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -14,6 +14,7 @@ import { hasWritePermission } from './team/keyring.js'
 import type { NoydbEventEmitter } from './events.js'
 import type { WriteQueueTracker } from './write-queue.js'
 import type { WriteHookRegistry, WriteEvent } from './write-hooks.js'
+import type { SubsystemBus } from './subsystem-bus.js'
 import type { SchemaUpdateGate } from './schema-update/gate.js'
 import type { SchemaFenceController } from './schema-update/fence-controller.js'
 import type { StandardSchemaV1 } from './schema.js'
@@ -135,6 +136,7 @@ export class Collection<T> {
   private readonly schemaUpdateGate: SchemaUpdateGate | undefined
   private readonly schemaFence: SchemaFenceController | undefined
   private readonly writeHooks: WriteHookRegistry | undefined
+  private readonly subsystemBus: SubsystemBus | undefined
   private readonly activeTxId: (() => string | null) | undefined
   private readonly getDEK: (collectionName: string) => Promise<CryptoKey>
   private readonly onDirty: OnDirtyCallback | undefined
@@ -514,6 +516,8 @@ export class Collection<T> {
     schemaFence?: SchemaFenceController | undefined
     /** #230 — hub-level write-hook registry; fired around put/delete. */
     writeHooks?: WriteHookRegistry | undefined
+    /** Track A — the observe bus, threaded from Noydb. */
+    subsystemBus?: SubsystemBus | undefined
     /** #230 — active transaction id supplier (null outside a transaction). */
     activeTxId?: (() => string | null) | undefined
     getDEK: (collectionName: string) => Promise<CryptoKey>
@@ -806,6 +810,7 @@ export class Collection<T> {
     this.schemaUpdateGate = opts.schemaUpdateGate
     this.schemaFence = opts.schemaFence
     this.writeHooks = opts.writeHooks
+    this.subsystemBus = opts.subsystemBus
     this.activeTxId = opts.activeTxId
     this.blobStrategy = opts.blobStrategy ?? NO_BLOBS
     this.aggregateStrategy = opts.aggregateStrategy ?? NO_AGGREGATE

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1108,8 +1108,13 @@ export class Collection<T> {
     // TODO(#232-slice2 / #230-followup): putManyAtomic / tx-execute / CRDT /
     // blob write paths are not yet tracked by writeQueue nor fired through
     // the write hooks.
+    // #230 user write-hooks AND the Track A observe bus both need the
+    // WriteEvent. Build it if EITHER consumer is active so the bus is not
+    // coupled to write-hooks being present.
+    const hooksActive = this.#hooksActive()
+    const busAfterPut = this.subsystemBus?.hasHandlers('afterPut') ?? false
     let event: WriteEvent | undefined
-    if (this.#hooksActive()) {
+    if (hooksActive || busAfterPut) {
       const prior = await this.#priorForHook(id)
       event = {
         op: prior.record === null ? 'create' : 'update',
@@ -1117,11 +1122,17 @@ export class Collection<T> {
         userId: this.keyring.userId, timestamp: Date.now(), txId: this.#txIdForHook(),
         baseVersion: prior.version, version: prior.version + 1,
       }
-      await this.writeHooks!.runBefore(event) // throw → aborts the write
+      if (hooksActive) await this.writeHooks!.runBefore(event) // throw → aborts the write
     }
     if (this.writeQueue) await this.writeQueue.track(() => this.putInternal(id, record, options))
     else await this.putInternal(id, record, options)
-    if (event) await this.writeHooks!.runAfter(event)
+    if (event) {
+      // Ordering: user afterWrite hooks run BEFORE observe-bus dispatch in
+      // slice 1. Revisit when internal observe subsystems (e.g. MV-refresh
+      // notification) need to settle before user hooks observe state.
+      if (hooksActive) await this.writeHooks!.runAfter(event)
+      if (busAfterPut) await this.subsystemBus!.dispatch('afterPut', event)
+    }
   }
 
   /** @internal #230 — true when hooks should fire for this write (handlers exist, not re-entrant). */

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1112,7 +1112,8 @@ export class Collection<T> {
     // WriteEvent. Build it if EITHER consumer is active so the bus is not
     // coupled to write-hooks being present.
     const hooksActive = this.#hooksActive()
-    const busAfterPut = this.subsystemBus?.hasHandlers('afterPut') ?? false
+    const busAfterPut = (this.subsystemBus?.hasHandlers('afterPut') ?? false)
+      && !(this.subsystemBus?.dispatching ?? false)
     let event: WriteEvent | undefined
     if (hooksActive || busAfterPut) {
       const prior = await this.#priorForHook(id)

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -43,14 +43,14 @@ import type { GuardRegistry } from './guards/registry.js'
 import type { ReadOnlyVaultFacade } from './guards/types.js'
 // Type-only — runtime class loaded via dynamic import in the
 // frozen-field branch of `put()` / amendment paths. Keeps the guard
-// executor chunk out of the floor bundle (#130).
+// executor chunk out of the floor bundle.
 import type { GuardExecutor as GuardExecutorType } from './guards/executor.js'
 import type { DerivationRegistry } from './derivations/registry.js'
 import type { TxContext, ExecutedOp } from './tx/transaction.js'
 import { revertExecuted } from './tx/transaction.js'
 // Type-only — runtime class loaded via dynamic import in
 // `dispatchDerivations` when an eager-mode strategy fires. Keeps the
-// derivation executor chunk out of the floor bundle (#130).
+// derivation executor chunk out of the floor bundle.
 import type { DerivationExecutor as DerivationExecutorType } from './derivations/executor.js'
 import type {
   loadFanoutSidecar as LoadFanoutSidecarType,
@@ -417,7 +417,7 @@ export class Collection<T> {
          * `_activeTxContext` for the duration of its Phase 2 loop so
          * recursive derived-output writes register their pre-write
          * envelopes on `ctx._executed` and roll back alongside the
-         * bulk-put source ops (#133).
+         * bulk-put source ops.
          */
         createTxContext(): TxContext
         /** Publish a TxContext for the duration of a bulk-atomic loop. */
@@ -428,7 +428,7 @@ export class Collection<T> {
     | undefined
 
   /**
-   * Vault-internal hook for materialized-view dispatch (#143/#150).
+   * Vault-internal hook for materialized-view dispatch.
    * Parallel to `derivationSource` — when set, `Collection.put` fires
    * `MaterializedViewRegistry.onSourceWrite` after the source-write
    * commits + after `dispatchDerivations` has run.
@@ -504,21 +504,21 @@ export class Collection<T> {
     encrypted: boolean
     emitter: NoydbEventEmitter
     /**
-     * Vault-level in-flight write tracker (#227). When present,
+     * Vault-level in-flight write tracker. When present,
      * `put`/`delete` run inside `writeQueue.track()` so `hub.writeQueue`
      * reflects outstanding writes. Optional so direct Collection
      * construction in tests still works untracked.
      */
     writeQueue?: WriteQueueTracker | undefined
-    /** #245 — per-collection schema-update gate; `put`/`delete` await it. */
+    /** Per-collection schema-update gate; `put`/`delete` await it. */
     schemaUpdateGate?: SchemaUpdateGate | undefined
-    /** #232 — vault-level fence controller; `put`/`delete` consult it. */
+    /** Vault-level fence controller; `put`/`delete` consult it. */
     schemaFence?: SchemaFenceController | undefined
-    /** #230 — hub-level write-hook registry; fired around put/delete. */
+    /** Hub-level write-hook registry; fired around put/delete. */
     writeHooks?: WriteHookRegistry | undefined
-    /** Track A — the observe bus, threaded from Noydb. */
+    /** The observe bus, threaded from Noydb. */
     subsystemBus?: SubsystemBus | undefined
-    /** #230 — active transaction id supplier (null outside a transaction). */
+    /** Active transaction id supplier (null outside a transaction). */
     activeTxId?: (() => string | null) | undefined
     getDEK: (collectionName: string) => Promise<CryptoKey>
     historyConfig?: HistoryConfig | undefined
@@ -762,7 +762,7 @@ export class Collection<T> {
       getCollection(name: string): Collection<Record<string, unknown>>
       /**
        * Read-only vault facade handed to `derive(source, ctx)` so a
-       * derivation can fetch sibling records (#147). Same shape and
+       * derivation can fetch sibling records. Same shape and
        * instance the guards subsystem uses for `check(incoming, ctx)`.
        */
       getReadOnlyFacade(): ReadOnlyVaultFacade
@@ -771,13 +771,13 @@ export class Collection<T> {
        * transaction context, or `null` when no transaction is running.
        * `dispatchDerivations` consults this so a recursive derived-output
        * write can register its pre-write envelope onto `ctx._executed`
-       * and roll back alongside the source op on mid-batch failure (#133).
+       * and roll back alongside the source op on mid-batch failure.
        */
       getActiveTxContext(): TxContext | null
       /**
        * Construct a transient TxContext bound to the owning Noydb. Used
        * by `Collection.putManyAtomic` to publish an active context for
-       * its Phase 2 loop (#133).
+       * its Phase 2 loop.
        */
       createTxContext(): TxContext
       /** Publish a TxContext for the duration of a bulk-atomic loop. */
@@ -786,7 +786,7 @@ export class Collection<T> {
       clearActiveTxContext(ctx: TxContext): void
     } | undefined
     /**
-     * Vault-internal hook for materialized-view dispatch (#143/#150).
+     * Vault-internal hook for materialized-view dispatch.
      * Parallel to `derivationSource`. When set, `Collection.put` fires
      * registered MV `onSourceWrite` after the standard derivation
      * dispatch.
@@ -1006,7 +1006,7 @@ export class Collection<T> {
       }
     }
 
-    // Lazy-MV resolve-on-read (#151). When the collection being read
+    // Lazy-MV resolve-on-read. When the collection being read
     // is the output of a registered lazy MV that has at least one
     // pending stale flag, run the executor before returning. No-op
     // when nothing is pending.
@@ -1089,26 +1089,26 @@ export class Collection<T> {
 
   /**
    * Create or update a record. Runs inside the hub's write-queue tracker
-   * (#227) so `hub.writeQueue.pending` reflects this write.
+   * so `hub.writeQueue.pending` reflects this write.
    *
    * @param id      Record identifier.
    * @param record  The record body (validated by the collection's schema
    *                if one was attached at `vault.collection(...)` time).
    * @param options Optional metadata for audit + import workflows.
    *                `reason` is stamped onto the resulting ledger entry
-   *                (see #1) so audit consumers can filter via
+   *                so audit consumers can filter via
    *                `entries.filter(e => e.reason?.startsWith('import:'))`.
    */
   async put(id: string, record: T, options?: { readonly reason?: string }): Promise<void> {
-    // #245 — refuse the write if an update strategy rejected the schema
+    // Refuse the write if an update strategy rejected the schema
     // change. Awaited OUTSIDE track() so a rejected write never counts
     // toward writeQueue.depth.
     await this.schemaUpdateGate?.assertWritable()
-    await this.schemaFence?.assertWritable(this.name) // #232
-    // TODO(#232-slice2 / #230-followup): putManyAtomic / tx-execute / CRDT /
+    await this.schemaFence?.assertWritable(this.name)
+    // TODO: putManyAtomic / tx-execute / CRDT /
     // blob write paths are not yet tracked by writeQueue nor fired through
     // the write hooks.
-    // #230 user write-hooks AND the Track A observe bus both need the
+    // User write-hooks AND the observe bus both need the
     // WriteEvent. Build it if EITHER consumer is active so the bus is not
     // coupled to write-hooks being present.
     const hooksActive = this.#hooksActive()
@@ -1136,18 +1136,18 @@ export class Collection<T> {
     }
   }
 
-  /** @internal #230 — true when hooks should fire for this write (handlers exist, not re-entrant). */
+  /** @internal — true when hooks should fire for this write (handlers exist, not re-entrant). */
   #hooksActive(): boolean {
     return this.writeHooks !== undefined && this.writeHooks.hasHandlers && !this.writeHooks.suppressed
   }
 
   /**
-   * @internal #230/#228c — resolve the prior record for a hook's `before` and
+   * @internal — resolve the prior record for a hook's `before` and
    * its version. Critically, this uses the SAME basis `putInternal` writes from
    * (the in-memory cache in eager mode; lru-then-adapter in lazy) — NOT a fresh
    * store read — so `baseVersion`/`version` match the version actually written.
    * A separate store read would diverge once another tab has advanced the shared
-   * store past this tab's cache, breaking #228c conflict detection.
+   * store past this tab's cache, breaking cross-tab conflict detection.
    */
   async #priorForHook(id: string): Promise<{ record: unknown; version: number }> {
     if (this.lazy && this.lru) {
@@ -1210,7 +1210,7 @@ export class Collection<T> {
           // Dynamic-import the executor only when at least one guard
           // is registered AND a non-amendment write fires. Consumers
           // who never call `withGuard()` never reach this branch and
-          // never pull `GuardExecutor` into their bundle (#130).
+          // never pull `GuardExecutor` into their bundle.
           const { GuardExecutor } = (await import('./guards/executor.js')) as { GuardExecutor: typeof GuardExecutorType }
           for (const g of guards) {
             await GuardExecutor.checkFrozenFields(g, id, existingRecord, incomingRecord)
@@ -1523,7 +1523,7 @@ export class Collection<T> {
    * Fire registered MV strategies whose dependency set includes this
    * collection. Eager-mode MVs re-materialize inline via
    * `MaterializedViewExecutor.refresh`; lazy / manual modes are
-   * no-ops in the foundation (subtask #150) — wired in #151.
+   * no-ops in the foundation; wired in the lazy-mode implementation.
    *
    * Skips entirely when the record being written is itself an
    * MV-emitted row (carries `_materializedFrom`) — defensive guard
@@ -1541,7 +1541,7 @@ export class Collection<T> {
     if (mvs.length === 0) return
     // Dynamic-import the executor only on first eager-MV dispatch —
     // keeps the MV executor chunk out of the floor bundle (mirrors the
-    // #130 dynamic-import pattern v1 uses for derivations). Lazy mode
+    // dynamic-import pattern used for derivations). Lazy mode
     // uses the pure-helper `markMVStale` which lives in `stale.js` and
     // is also dynamic-imported (only when at least one lazy MV depends
     // on this source).
@@ -1591,7 +1591,7 @@ export class Collection<T> {
     // dispatch. Lazy-mode dispatches use `markStale` (a pure helper)
     // which doesn't reach into the executor at all. Keeps the
     // derivation executor chunk out of the floor bundle for any
-    // consumer that doesn't fire an eager derivation (#130).
+    // consumer that doesn't fire an eager derivation.
     let DerivationExecutor: typeof DerivationExecutorType | null = null
     for (const { spec, strategyHash } of strategies) {
       const mode = typeof spec.lifecycle === 'string' ? spec.lifecycle : spec.lifecycle.mode
@@ -1614,7 +1614,7 @@ export class Collection<T> {
           const outSpec = spec.outputs[key]
           if (!outSpec) continue
           const outputCollection = this.derivationSource.getCollection(outSpec.collection)
-          // #133 — if we're inside a multi-record transaction, register
+          // If we're inside a multi-record transaction, register
           // derived writes as side-effect ops on the active ctx
           // BEFORE they fire. `revertExecuted` walks `_executed` in
           // reverse on rollback, so capturing the pre-write envelope
@@ -1623,7 +1623,7 @@ export class Collection<T> {
           // the context is null and tracking is skipped.
           const txCtx = this.derivationSource.getActiveTxContext()
 
-          // ── Array-shape branch (#200) ──────────────────────────
+          // ── Array-shape branch ─────────────────────────────────
           if (out.kind === 'array') {
             // Load the prior key set from the fanout sidecar.
             const { loadFanoutSidecar, saveFanoutSidecar } = await import('./derivations/fanout-sidecar.js')
@@ -1677,14 +1677,14 @@ export class Collection<T> {
 
           // ── Record-shape branch (existing v1 behavior) ─────────
           if (out.skipped === true) {
-            // #144: optional output returned null. Delete the
+            // Optional output returned null. Delete the
             // previously-emitted output at this id, if any. Routed
             // through `_internalDelete` so a user-registered
-            // `onDelete` (#145) on the output collection does NOT
+            // `onDelete` on the output collection does NOT
             // fire — this is a system-internal tombstone, not a
             // user-initiated delete. The txCtx hookup captures the
-            // prior envelope inside `_internalDelete` for #133-style
-            // rollback symmetry; delete-of-absent is a silent no-op.
+            // prior envelope inside `_internalDelete` for rollback
+            // symmetry; delete-of-absent is a silent no-op.
             await outputCollection._internalDelete(id, txCtx)
             continue
           }
@@ -1710,11 +1710,11 @@ export class Collection<T> {
 
   /**
    * Delete a record by ID. Runs inside the hub's write-queue tracker
-   * (#227) so `hub.writeQueue.pending` reflects this write.
+   * so `hub.writeQueue.pending` reflects this write.
    */
   async delete(id: string): Promise<void> {
-    await this.schemaUpdateGate?.assertWritable() // #245
-    await this.schemaFence?.assertWritable(this.name) // #232
+    await this.schemaUpdateGate?.assertWritable()
+    await this.schemaFence?.assertWritable(this.name)
     let event: WriteEvent | undefined
     if (this.#hooksActive()) {
       const prior = await this.#priorForHook(id)
@@ -1731,7 +1731,7 @@ export class Collection<T> {
   }
 
   /**
-   * @internal #232 — bulk-rewrite every record through a cutover transform.
+   * @internal — bulk-rewrite every record through a cutover transform.
    * Raw adapter path (bypasses the write gate + guards — the transform is
    * trusted and runs only during the `migrating` phase). Bumps each
    * record's `_v` and appends a ledger `op:'migration'` entry.
@@ -1769,7 +1769,7 @@ export class Collection<T> {
   /**
    * @internal — system-internal delete that bypasses user-facing
    * delete hooks (`onDelete`, accounting-period guard, FK ref
-   * enforcer). Used by derivation tombstones (#144) and MV refresh
+   * enforcer). Used by derivation tombstones and MV refresh
    * (Dim 14 v2) — system housekeeping shouldn't trip user invariants
    * registered against the output collection. The ledger entry and
    * history snapshot still fire so backup integrity and time-travel
@@ -1781,7 +1781,7 @@ export class Collection<T> {
    *
    * When a `txCtx` is supplied, the prior envelope is captured and
    * pushed onto `txCtx._executed` BEFORE the delete fires — mirrors
-   * the #133 rollback hardening for puts. Callers outside a
+   * the rollback hardening for puts. Callers outside a
    * multi-record transaction pass `null` and skip the tracking.
    *
    * Amendment composition: if `_internalDelete` runs while a vault's
@@ -1844,7 +1844,7 @@ export class Collection<T> {
     // amendment change-collection still runs if a window is open.
     // This means an `amendment.invariant` paired with `onDelete` for
     // "TRULY unconditional" rules sees the system delete and can
-    // reject it — closing the niwat-review gap where a derivation
+    // reject it — closing the gap where a derivation
     // tombstone fired during an admin amendment would otherwise
     // silently bypass both hooks.
     if (this.guardSource) {
@@ -1865,7 +1865,7 @@ export class Collection<T> {
             // and vAfter = same (the ledger entry's `op` discriminator
             // is `delete`, not `put`, so the consumer treats the
             // tombstone shape correctly). Fires for BOTH user and
-            // system-internal deletes (#145 follow-up).
+            // system-internal deletes.
             const vBefore = existingEnv._v
             registry.collectChange(
               this.name,
@@ -1876,7 +1876,7 @@ export class Collection<T> {
               vBefore,
             )
           } else if (!internal) {
-            // Dedicated delete-time hook (#145). `check` is put-only;
+            // Dedicated delete-time hook. `check` is put-only;
             // `onDelete(existing, ctx)` receives the currently-persisted
             // record and decides whether the deletion is permitted.
             // Skipped for internal deletes — housekeeping must not trip
@@ -2001,7 +2001,7 @@ export class Collection<T> {
 
     await this.onAccess?.('delete', id)
 
-    // Symmetric to put (#181): user-initiated deletes must fire MV
+    // Symmetric to put: user-initiated deletes must fire MV
     // refresh so `onEmpty: 'delete'` MVs tombstone their now-orphan
     // output rows. Gated on `!internal` to prevent recursion — the
     // MV executor's own tombstoning round-trips through
@@ -2011,7 +2011,7 @@ export class Collection<T> {
     // Record-shape derivations intentionally NOT dispatched on delete:
     // their derived-output id equals the source id, so the user can
     // delete the output directly with `outputCollection.delete(id)` if
-    // they want. Array-shape derivations (#200) DO cascade on delete
+    // they want. Array-shape derivations DO cascade on delete
     // because their derived ids are opaque (from the `key(out)`
     // extractor) — without cascade the rows become unfindable orphans.
     if (!internal) {
@@ -2022,7 +2022,7 @@ export class Collection<T> {
 
   /**
    * Cascade deletes of array-shape derived rows when a source row is
-   * deleted (#200). Reads each registered strategy's fanout sidecar
+   * deleted. Reads each registered strategy's fanout sidecar
    * for this source id, deletes every listed derived row, then
    * deletes the sidecar itself.
    *
@@ -2071,8 +2071,8 @@ export class Collection<T> {
   }
 
   /**
-   * Mirror of {@link dispatchMaterializedViews} for the delete path
-   * (#181). No record content is available (it's gone), so the
+   * Mirror of {@link dispatchMaterializedViews} for the delete path.
+   * No record content is available (it's gone), so the
    * `_materializedFrom` skip used by the put-side dispatch doesn't
    * apply here — instead, the recursion guard is the `internal` gate
    * at the `_doDelete` call site above.
@@ -2125,7 +2125,7 @@ export class Collection<T> {
         `Use collection.scan({ pageSize }) to iterate over the full collection.`,
       )
     }
-    // Lazy-MV resolve-on-read (#157 review): if this collection is the
+    // Lazy-MV resolve-on-read: if this collection is the
     // output of a registered lazy MV with a pending stale flag, run
     // the executor before returning so callers see fresh data. No-op
     // when nothing is pending — keeps the read path negligible.
@@ -2219,7 +2219,7 @@ export class Collection<T> {
     }
     // Phase 2 — execute; revert on failure.
     //
-    // #133 — when a derivation registry is wired, publish a transient
+    // When a derivation registry is wired, publish a transient
     // TxContext for the duration of this loop so `dispatchDerivations`
     // can register recursive derived-output writes onto `ctx._executed`.
     // The shared `revertExecuted` helper then unwinds the combined list
@@ -2328,7 +2328,7 @@ export class Collection<T> {
    * the filtered records directly (the API). Prefer the chainable
    * form for new code.
    *
-   * **Lazy-MV gap (#157):** `query()` is synchronous and does NOT
+   * **Lazy-MV gap:** `query()` is synchronous and does NOT
    * trigger lazy materialized-view resolve-on-read. If this
    * collection is a lazy MV's output and the MV is currently stale,
    * `query().toArray()` returns the pre-stale snapshot. To force a
@@ -2729,7 +2729,7 @@ export class Collection<T> {
    *   .aggregate({ total: sum('amount'), n: count() })
    * ```
    *
-   * **Lazy-MV gap (#157):** `scan()` is synchronous-build and does
+   * **Lazy-MV gap:** `scan()` is synchronous-build and does
    * NOT trigger lazy materialized-view resolve-on-read. For lazy
    * MVs, call `list()` (which DOES resolve) or `vault.refreshView(name)`
    * before scanning. Same shape as the `query()` limitation.
@@ -2830,7 +2830,7 @@ export class Collection<T> {
   }
 
   /**
-   * #228b — apply a peer tab's committed write to THIS tab's in-memory view:
+   * Apply a peer tab's committed write to THIS tab's in-memory view:
    * re-read the (already-persisted) envelope from the shared store + refresh
    * cache/indexes, then emit a `change` event so reactive consumers re-render.
    * Never writes to the store and never fires write hooks, so it cannot loop.
@@ -2840,7 +2840,7 @@ export class Collection<T> {
     this.emitter.emit('change', { vault: this.vault, collection: this.name, id, action })
   }
 
-  /** @internal #228c — the current in-memory record without a store read (for conflict capture). */
+  /** @internal — the current in-memory record without a store read (for conflict capture). */
   _peekCached(id: string): T | null {
     const entry = this.lazy && this.lru ? this.lru.get(id) : this.cache.get(id)
     return entry ? entry.record : null

--- a/packages/hub/src/derivations/executor.ts
+++ b/packages/hub/src/derivations/executor.ts
@@ -12,7 +12,7 @@ export interface RunResult {
  *
  * - `record` — the existing v1 shape: one value (or a "skipped"
  *   marker if the output was optional and `derive` returned null).
- * - `array` — the #200 shape: a list of `(key, value)` entries.
+ * - `array` — a list of `(key, value)` entries.
  *   The caller diffs these against the previously-emitted key set
  *   (loaded from the fanout sidecar) to compute deletes + upserts.
  */
@@ -26,7 +26,7 @@ export interface RecordOutputResult {
   value: Record<string, unknown>
   ok: true
   /**
-   * `true` when an optional output (#144) returned `null` /
+   * `true` when an optional output returned `null` /
    * `undefined`. The caller deletes any previously-emitted output at
    * the same id (mirrors "tombstone for derived data"); a never-emitted
    * output is a silent no-op. `ok: true` because skipping is a
@@ -102,7 +102,7 @@ export const DerivationExecutor = {
       if (!outSpec) continue
       const value = (derived as Record<string, unknown>)[key]
 
-      // ── Array-shape branch (#200 slice 1) ──────────────────────
+      // ── Array-shape branch ─────────────────────────────────────
       if (outSpec.shape === 'array') {
         if (value === undefined || value === null) {
           // Treat null/undefined as "empty array" — clears all prior
@@ -166,7 +166,7 @@ export const DerivationExecutor = {
       // ── Record-shape branch (existing v1 behavior) ─────────────
       if (value === undefined || value === null) {
         if (outSpec.optional === true) {
-          // #144: optional output explicitly skipped. Mark for caller
+          // Optional output explicitly skipped. Mark for caller
           // so any prior-emitted output at this id can be deleted.
           outputs[key] = { kind: 'record', value: {}, ok: true, skipped: true }
           continue

--- a/packages/hub/src/derivations/fanout-sidecar.ts
+++ b/packages/hub/src/derivations/fanout-sidecar.ts
@@ -1,5 +1,5 @@
 /**
- * Per-source-row fanout sidecar for `shape: 'array'` derivations (#200).
+ * Per-source-row fanout sidecar for `shape: 'array'` derivations.
  *
  * Each `(sourceCollection, sourceId, outputKey)` triple gets its own
  * envelope at:

--- a/packages/hub/src/derivations/stale.ts
+++ b/packages/hub/src/derivations/stale.ts
@@ -4,7 +4,7 @@ import type { TxContext } from '../tx/transaction.js'
 import type { DerivationRegistry } from './registry.js'
 // Type-only — runtime class loaded via dynamic import in
 // `resolveStaleOnRead` only when a stale flag actually fires. Keeps
-// the executor chunk out of the floor bundle (#130).
+// the executor chunk out of the floor bundle.
 import type { DerivationExecutor as DerivationExecutorType } from './executor.js'
 import type { DerivationStrategy } from './types.js'
 
@@ -21,16 +21,15 @@ export interface DerivationStaleAccessor {
   getCollection(name: string): Collection<any>
   /**
    * Read-only vault facade handed to `derive(source, ctx)` on the lazy
-   * resolve-on-read path. Same instance/shape as the eager path uses
-   * (#147).
+   * resolve-on-read path. Same instance/shape as the eager path uses.
    */
   getReadOnlyFacade(): ReadOnlyVaultFacade
   /**
    * Active multi-record TxContext or `null`. The lazy resolve-on-read
    * path uses this to register tombstone deletes on `_executed` so a
    * later rollback restores the prior emission. Mirrors the eager
-   * path's #133-style tracking; the lazy `put` was historically
-   * unregistered but #144's tombstone delete (a NEW write path)
+   * path's rollback tracking; the lazy `put` was historically
+   * unregistered but the tombstone delete (a NEW write path)
    * matches the eager registration for symmetry.
    */
   getActiveTxContext(): TxContext | null
@@ -98,7 +97,7 @@ export async function resolveStaleOnRead(
   // this function (gated on `derivationSource` in `Collection.get`);
   // vaults with strategies but no pending stale ids reach the
   // `pending.has(spec)` short-circuit below without ever touching
-  // the executor chunk. See #130.
+  // the executor chunk.
   let DerivationExecutor: typeof DerivationExecutorType | null = null
 
   for (const { spec, strategyHash } of producers) {
@@ -142,12 +141,12 @@ export async function resolveStaleOnRead(
       }
       if (out.kind === 'array') {
         // Defensive — array-shape requires `lifecycle: 'eager'`
-        // (validated at withDerivation registration, #200 slice 1).
+        // (validated at withDerivation registration).
         // Reaching the lazy-resolve path for array-shape would mean
         // a registration check was bypassed. Log and skip.
         console.warn(
           `[derivation] unexpected array-shape output "${key}" in lazy resolve path; `
-          + 'array-shape derivations require lifecycle: "eager" (#200 slice 1).',
+          + 'array-shape derivations require lifecycle: "eager".',
         )
         continue
       }
@@ -155,16 +154,15 @@ export async function resolveStaleOnRead(
       if (!outSpec) continue
       const outputColl = accessor.getCollection(outSpec.collection)
       if (out.skipped === true) {
-        // #144: optional output skipped on lazy resolve — delete any
+        // Optional output skipped on lazy resolve — delete any
         // prior emission so the read returns null (matches eager-path
         // tombstone semantics). Routed through `_internalDelete` so a
-        // user-registered `onDelete` (#145) on the output collection
+        // user-registered `onDelete` on the output collection
         // does NOT fire. The active TxContext (if any) is forwarded:
         // `resolveStaleOnRead` is reachable from `Collection.get()`
         // which can be called from inside a transaction, so the
         // tombstone must be observable to `revertExecuted` on
-        // rollback. Closes the #133-asymmetry surfaced in PR #148
-        // review.
+        // rollback.
         await outputColl._internalDelete(id, accessor.getActiveTxContext())
         continue
       }

--- a/packages/hub/src/derivations/types.ts
+++ b/packages/hub/src/derivations/types.ts
@@ -43,7 +43,7 @@ export interface RecordOutputSpec {
    * `undefined`) for this output key. The executor interprets that as
    * "no output for this invocation": a previously-emitted output at
    * the same id is deleted (mirroring the empty-group / empty-aggregate
-   * semantics flagged in #142); a never-emitted output is a silent
+   * semantics for empty groups); a never-emitted output is a silent
    * no-op. When `false` (default), returning `null` throws
    * `DerivationOutputShapeError` — same as v1.
    */
@@ -51,7 +51,7 @@ export interface RecordOutputSpec {
 }
 
 /**
- * Array-shape output (#200) — one source row produces a variable-length
+ * Array-shape output — one source row produces a variable-length
  * list of output rows, each with its own id (from the `key` extractor).
  *
  * On every source-row change, the dispatcher diffs the previously

--- a/packages/hub/src/derivations/with-derivation.ts
+++ b/packages/hub/src/derivations/with-derivation.ts
@@ -26,14 +26,14 @@ export function withDerivation<
     throw new ValidationError('withDerivation: derive must be a function')
   }
 
-  // #200 slice 1 — validate array-shape outputs.
+  // Validate array-shape outputs.
   const lifecycleMode = typeof spec.lifecycle === 'string' ? spec.lifecycle : spec.lifecycle.mode
   for (const [outputKey, outputSpec] of Object.entries(spec.outputs)) {
     if (outputSpec.shape === 'array') {
       if (lifecycleMode !== 'eager') {
         throw new ValidationError(
           `withDerivation: shape 'array' supports lifecycle 'eager' only in this release `
-          + `(#200 slice 1). Output "${outputKey}" declared lifecycle '${lifecycleMode}'. `
+          + `Output "${outputKey}" declared lifecycle '${lifecycleMode}'. `
           + 'Switch to `lifecycle: "eager"` or use shape: "record".',
         )
       }

--- a/packages/hub/src/directory/types.ts
+++ b/packages/hub/src/directory/types.ts
@@ -1,5 +1,5 @@
 /**
- * Type surface for the user-list visibility subsystem (#122).
+ * Type surface for the user-list visibility subsystem.
  *
  * Two complementary flags:
  *  - {@link DirectoryConfig} — vault-level "is the directory listing

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -823,7 +823,7 @@ export class SchemaValidationError extends NoydbError {
   }
 }
 
-/** Base for schema-evolution strategy rejections (#245). */
+/** Base for schema-evolution strategy rejections. */
 export class SchemaUpdateError extends NoydbError {
   constructor(code: string, message: string) {
     super(code, message)
@@ -1017,7 +1017,7 @@ export class BundleIntegrityError extends NoydbError {
 }
 
 /**
- * Thrown by `readNoydbBundle` (#197) when the bundle carries
+ * Thrown by `readNoydbBundle` when the bundle carries
  * sealed per-user passphrases but no supplied `SealingKeyProvider`
  * has a `.id` (= `pid`) matching the sealed entry's `pid`.
  *
@@ -1277,7 +1277,7 @@ export class BackupCorruptedError extends NoydbError {
 }
 
 /**
- * Thrown by partition-extraction primitives (#198 epic) when the
+ * Thrown by partition-extraction primitives when the
  * transitive-closure walk fails — e.g. the FK graph is deeper than
  * `maxDepth`, signalling a runaway or unexpectedly cyclic graph.
  */
@@ -1289,7 +1289,7 @@ export class PartitionExtractionError extends NoydbError {
 }
 
 /**
- * Thrown by `adoptPartition` (#207) when the transfer seal can't be
+ * Thrown by `adoptPartition` when the transfer seal can't be
  * opened — a wrong/short transfer key (AES-GCM auth-tag failure) or a
  * malformed sealed payload.
  */
@@ -1302,8 +1302,8 @@ export class TransferSealError extends NoydbError {
 
 /**
  * Thrown when an adoption-lifecycle precondition fails — re-adopting a
- * partition already consumed in this store (#207), or owner-creation on a
- * vault that isn't in the adopted-unowned state (#208).
+ * partition already consumed in this store, or owner-creation on a
+ * vault that isn't in the adopted-unowned state.
  */
 export class AdoptionStateError extends NoydbError {
   constructor(message: string) {
@@ -1575,7 +1575,7 @@ export class DerivationOutputShapeError extends NoydbError {
 }
 
 /**
- * Thrown by array-shape derivations (#200) when the `derive` function
+ * Thrown by array-shape derivations when the `derive` function
  * returns more rows than the output's `maxFanout` cap. The cap exists
  * to keep dispatch cost bounded — without it a single source-row
  * update could fan out to thousands of derived rows, dominating the
@@ -1681,7 +1681,7 @@ export class MaterializedViewTooLargeError extends NoydbError {
  * normalized.
  *
  * Today the trigger cases are all about the `query` / `unionSources`
- * dichotomy introduced by #165:
+ * dichotomy:
  *   - both `query` and `unionSources` were set (mutually exclusive),
  *   - neither `query` nor `unionSources` was set,
  *   - `unionSources` has fewer than 2 arms,

--- a/packages/hub/src/guards/registry.ts
+++ b/packages/hub/src/guards/registry.ts
@@ -44,7 +44,7 @@ export class GuardRegistry {
     return this._byCollection.get(collection) ?? []
   }
 
-  /** Per-collection guard counts, for introspection (#229). */
+  /** Per-collection guard counts, for introspection. */
   summary(): { collection: string; count: number }[] {
     return [...this._byCollection.entries()].map(([collection, guards]) => ({
       collection,

--- a/packages/hub/src/guards/types.ts
+++ b/packages/hub/src/guards/types.ts
@@ -121,8 +121,8 @@ export interface GuardStrategy<T extends Record<string, unknown>> {
    * })
    * ```
    *
-   * Also skipped on system-internal deletes (derivation tombstones from
-   * #144, MV refresh from Dim 14 v2) — those use `_internalDelete`
+   * Also skipped on system-internal deletes (derivation tombstones,
+   * MV refresh from Dim 14 v2) — those use `_internalDelete`
    * which bypasses every user-facing delete hook. Housekeeping ops are
    * NOT user-initiated and should not trip user invariants.
    *

--- a/packages/hub/src/history/ledger/entry.ts
+++ b/packages/hub/src/history/ledger/entry.ts
@@ -84,7 +84,7 @@ export interface LedgerEntry {
    * below for the structured payload.
    *
    * `'lifecycle'` records a non-data audit event (e.g. partition
-   * handover, #226) — `collection`/`id` are empty and the event detail
+   * handover) — `collection`/`id` are empty and the event detail
    * lives in `reason` (e.g. `'partition-handed-over:<sealId>'`). Like
    * `amendment`, it carries no data envelope, so `verifyBackupIntegrity`
    * skips it in the data cross-check (it still participates in the
@@ -122,8 +122,8 @@ export interface LedgerEntry {
   readonly payloadHash: string
 
   /**
-   * Optional human-readable tag describing why this mutation happened
-   * (#1). Threaded through `collection.put(_, _, { reason })`. Common
+   * Optional human-readable tag describing why this mutation happened.
+   * Threaded through `collection.put(_, _, { reason })`. Common
    * values include `'import:csv'`, `'import:json'`, `'import:xlsx'` from
    * `as-*` ImportPlan.apply(), but consumers can use any string for
    * domain-specific audit filtering. Auto-strip via `canonicalJson` —

--- a/packages/hub/src/history/ledger/store.ts
+++ b/packages/hub/src/history/ledger/store.ts
@@ -104,8 +104,8 @@ export interface AppendInput {
    */
   amendment?: LedgerEntry['amendment']
   /**
-   * Optional human-readable tag describing why this mutation happened
-   * (#1). Threaded from `collection.put(_, _, { reason })`.
+   * Optional human-readable tag describing why this mutation happened.
+   * Threaded from `collection.put(_, _, { reason })`.
    * Carried verbatim onto the resulting ledger entry's `reason` field;
    * omitted from canonical JSON when undefined.
    */

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -169,24 +169,24 @@ export { detectMimeType, detectMagic, isPreCompressed } from './blobs/mime-magic
 export { wrapBundleStore, createBundleStore } from './store/bundle-store.js'
 export type { WrappedBundleNoydbStore, WrapBundleStoreOptions } from './store/bundle-store.js'
 
-// Observable write-queue (#227)
+// Observable write-queue
 export type { WriteQueue } from './write-queue.js'
 
-// Write lifecycle hooks (#230)
+// Write lifecycle hooks
 export type { WriteEvent, WriteHook } from './write-hooks.js'
 
-// Runtime schema introspection (#229)
+// Runtime schema introspection
 export type { SchemaIntrospection } from './introspection/types.js'
 
-// Dry-run transactions (#231)
+// Dry-run transactions
 export type { DryRunResult, AffectedDocument, GuardViolation } from './tx/dry-run.js'
 
-// Multi-tab coordination (#228)
+// Multi-tab coordination
 export type { TabRole, TabPresence, TabCoordinationOptions, TabLockManager, TabChannel } from './tab-coordination.js'
-// Cross-tab write conflict (#228c)
+// Cross-tab write conflict
 export type { WriteConflict } from './types.js'
 
-// Schema-update strategies (#245)
+// Schema-update strategies
 export type {
   SchemaDelta,
   FieldChange,
@@ -394,7 +394,7 @@ export type {
 // Keyring types
 export type { UnlockedKeyring } from './team/keyring.js'
 
-// Tier-2 authenticator slots — issue #11
+// Tier-2 authenticator slots
 export {
   enrollAuthenticator,
   removeAuthenticator,
@@ -407,11 +407,11 @@ export type {
   UpdateAuthenticatorOptions,
 } from './team/authenticators.js'
 
-// Tier-3 quick-unlock state — issue #11
+// Tier-3 quick-unlock state
 export { QuickUnlockStore } from './session/unlock-state.js'
 export type { QuickUnlockState } from './session/unlock-state.js'
 
-// Tier-1 change flows — issue #10
+// Tier-1 change flows
 export {
   rotatePassphrase as keyringRotatePassphrase,
   recoverPassphrase as keyringRecoverPassphrase,
@@ -468,7 +468,7 @@ export type {
 } from './meta/user-envelope/api.js'
 export { UserApi } from './meta/user-envelope/api.js'
 
-// Auth introspection — issue #13
+// Auth introspection
 export {
   describeAuthConfig,
   diagramAuthConfig,
@@ -476,9 +476,7 @@ export {
   describeAllUsersAuth,
 } from './auth-introspection/index.js'
 
-// Recovery storage — issue #10 (paper, pre.5), Shamir slice (#196, pre.16).
-// Paper mint/unwrap helpers added in pre.8 (#39); Shamir mint/unwrap
-// added in #196 slice 1.
+// Recovery storage — paper and Shamir profiles.
 export {
   loadPaperRecoveryEntries,
   savePaperRecoveryEntries,
@@ -498,7 +496,7 @@ export type {
   ShamirRecoveryDoc,
 } from './team/recovery.js'
 
-// Recovery dispatch types added in #196 slice 1 — discriminated
+// Recovery dispatch types — discriminated
 // unions for the polymorphic enroll/rotate paths. (RecoveryProof /
 // RecoverPassphraseInput / RecoverPassphraseResult are already
 // exported above.)
@@ -508,14 +506,14 @@ export type {
   RotateRecoveryResult,
 } from './team/rotate-recover.js'
 
-// Canonical wrap-DEKs primitive (#44) — shared crypto for tier-0
+// Canonical wrap-DEKs primitive — shared crypto for tier-0
 // (paper recovery), tier-2 wrap-DEKs (password), tier-3 (on-pin).
 // `mintPaperRecoveryEntry` and `enrollPasswordAuthenticator` both
 // delegate to these helpers.
 export { mintWrappedDeksBlob, unwrapDeksFromBlob } from './team/wrapped-deks.js'
 export type { WrappedDeksBlob } from './team/wrapped-deks.js'
 
-// Managed-passphrase mode (#14) — rubber-hose-resistant vaults where
+// Managed-passphrase mode — rubber-hose-resistant vaults where
 // hub generates the passphrase and seals it under a developer-provided
 // SealingKeyProvider. The interface lives here; concrete providers
 // (macOS Keychain, Windows Credential Manager, libsecret, AWS KMS)
@@ -531,7 +529,7 @@ export {
   SEALED_PASSPHRASE_RECORD_ID,
 } from './team/managed-passphrase.js'
 
-// Peer-recovery — issues #33 + #34 (atomic db.recoverUser primitive).
+// Peer-recovery — atomic db.recoverUser primitive.
 // The team/peer-recover module also runs through Noydb.recoverUser for
 // the policy-gated path; consumers can use the lower-level function
 // directly when they don't want hub-level gating (e.g. in tests).
@@ -546,13 +544,13 @@ export { hasImportCapability, evaluateImportCapability } from './team/keyring.js
 export type { BundleRecipient } from './team/keyring.js'
 export { buildRecipientKeyringFile } from './team/keyring.js'
 
-// Team enumeration — joined view of keyrings and their user envelopes
-// (#23). Useful for admin UIs that want to render team-member lists
+// Team enumeration — joined view of keyrings and their user envelopes.
+// Useful for admin UIs that want to render team-member lists
 // with profile data in a single pass.
 export { listUsers, listUsersWithEnvelopes } from './team/keyring.js'
 export type { ListUsersOptions } from './team/keyring.js'
 
-// Directory visibility (#122) — vault-level user-list toggle +
+// Directory visibility — vault-level user-list toggle +
 // per-user opt-out.
 export {
   readDirectoryConfig,

--- a/packages/hub/src/indexing/persisted-indexes.ts
+++ b/packages/hub/src/indexing/persisted-indexes.ts
@@ -313,7 +313,7 @@ export class PersistedCollectionIndex {
 
   /**
    * Sorted iteration — return every entry on `field` as an
-   * `OrderedEntry[]`, sorted by the ORIGINAL TYPED value (#275: no more
+   * `OrderedEntry[]`, sorted by the ORIGINAL TYPED value (no more
    * `'10' < '2'` surprises on numeric fields). Consumers paginate with
    * a numeric offset. `OrderedEntry.value` is the typed value.
    */

--- a/packages/hub/src/introspection/types.ts
+++ b/packages/hub/src/introspection/types.ts
@@ -11,7 +11,7 @@
 import type { PersistedSchemaKind } from '../persisted-schemas/types.js'
 import type { Permission } from '../types.js'
 
-/** Flat snapshot of a vault's registered schema (#229). */
+/** Flat snapshot of a vault's registered schema. */
 export interface SchemaIntrospection {
   readonly collections: ReadonlyArray<{ name: string; docCount: number }>
   readonly guards: ReadonlyArray<{ collection: string; count: number }>

--- a/packages/hub/src/materialized-views/dependency-analyzer.ts
+++ b/packages/hub/src/materialized-views/dependency-analyzer.ts
@@ -6,14 +6,14 @@ import type { MaterializedViewStrategy } from './types.js'
  * Walks a `Query<T>` plan and returns the set of source collection
  * names that any source-write should trigger a refresh on.
  *
- * Foundation sub-issue (#150) handles:
+ * Handles:
  *   - root collection (the one the query was built from)
  *   - FK join targets (`.join(field, { as })`)
  *
- * Deferred to later sub-issues:
+ * Deferred:
  *   - `.crossJoin()` — v3 cross-join spec (separate primitive)
- *   - `.wherePredicate(name)` — v2 predicate primitive, sub-issue #153
- *   - Overlay-name expansion to {base, overlay} — sub-issue #154
+ *   - `.wherePredicate(name)` — v2 predicate primitive
+ *   - Overlay-name expansion to {base, overlay}
  *
  * The set is materialized at MV registration time. The MV registry
  * uses it to (a) dispatch `onSourceWrite` only to MVs that actually
@@ -89,7 +89,7 @@ export function summarizeQueryPlan(query: Query<any>): string {
  * Canonical string description of a UNION MV's plan, used as input to
  * `computeQueryHash`.
  *
- * Asymmetry note (#165 niwat review):
+ * Asymmetry note:
  *   - Arm collection names are NOT sorted. Declaration order is
  *     semantically meaningful for the dedup-only UNION path —
  *     `materializeUnionResult` iterates `spec.unionSources` in

--- a/packages/hub/src/materialized-views/executor.ts
+++ b/packages/hub/src/materialized-views/executor.ts
@@ -12,7 +12,7 @@ import { canonicalGroupKey } from '../aggregate/canonical-key.js'
  * Accessor shape passed in from the owning Vault. Mirrors v1's
  * `DerivationStaleAccessor` — provides the per-collection resolver
  * and the active TxContext so refresh writes/tombstones register on
- * `_executed` for #133-style rollback symmetry.
+ * `_executed` for rollback symmetry.
  */
 export interface MVExecutorAccessor {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -76,7 +76,7 @@ async function materializeQueryResult(
 }
 
 /**
- * Materialize a UNION-form MV (#165): read every arm's source
+ * Materialize a UNION-form MV: read every arm's source
  * collection, apply each arm's `map` to project rows into the unified
  * MV row shape, concatenate the mapped streams, then optionally run
  * `groupBy` + `aggregate` over the result.
@@ -142,22 +142,22 @@ async function materializeUnionResult<TRow extends Record<string, unknown>>(
  *
  * Stamps `_materializedFrom` onto every emitted row.
  *
- * **Tombstoning** (#152): when `spec.onEmpty: 'delete'` (default), rows
+ * **Tombstoning:** when `spec.onEmpty: 'delete'` (default), rows
  * that existed in a prior refresh but no longer appear in the new
  * materialized result are deleted via `Collection._internalDelete` —
- * the housekeeping bypass primitive added in PR #148 prevents user
+ * the housekeeping bypass primitive prevents user
  * `onDelete` guards on the output collection from firing on these
  * system-internal deletes. `onEmpty: 'keep'` opts out (rows from
  * prior refreshes linger even when the new result lacks them).
  *
- * **Cost ceiling** (#152): if the materialized row count exceeds
+ * **Cost ceiling:** if the materialized row count exceeds
  * `spec.maxRows` (default 100k), throws `MaterializedViewTooLargeError`
  * before any writes hit the store — so strict-mode rollback is
  * clean.
  *
- * **Strict mode** (#152): `spec.strict === true` re-throws on any
+ * **Strict mode:** `spec.strict === true` re-throws on any
  * row-write failure; the active TxContext registration means the
- * source-write rolls back atomically via `revertExecuted` (#133).
+ * source-write rolls back atomically via `revertExecuted`.
  *
  * @internal
  */
@@ -180,7 +180,7 @@ export const MaterializedViewExecutor = {
     const ctxForQuery: MVQueryContext = spec.predicates
       ? wrapDbWithPredicates(baseCtx, spec.predicates)
       : baseCtx
-    // UNION-form strategies (#165): read every arm, map to the unified
+    // UNION-form strategies: read every arm, map to the unified
     // row shape, concatenate, then optionally groupBy + aggregate. The
     // single-source `query()` path is untouched.
     let rows: ReadonlyArray<Record<string, unknown>>
@@ -246,8 +246,7 @@ export const MaterializedViewExecutor = {
     // 5. Tombstone rows that existed before but don't appear now.
     //    `onEmpty: 'keep'` skips this pass entirely. Uses
     //    `_internalDelete` so a user-registered `onDelete` on the
-    //    output collection does NOT fire on housekeeping (the #145
-    //    composition fix).
+    //    output collection does NOT fire on housekeeping (composition fix).
     let deleted = 0
     if (onEmpty === 'delete') {
       const priorIds = await listOutputIds(outputColl)

--- a/packages/hub/src/materialized-views/registry.ts
+++ b/packages/hub/src/materialized-views/registry.ts
@@ -23,7 +23,7 @@ export interface RegisteredMV {
    * Top-level FieldClauses on the partition field, captured at
    * registration time. Used by the cycle detector to resolve
    * same-collection-as-source edges via the partition-discriminator
-   * check (#152). Empty when `spec.output?.partition` is undefined.
+   * check. Empty when `spec.output?.partition` is undefined.
    */
   readonly partitionClauses: readonly FieldClause[]
 }
@@ -58,7 +58,7 @@ export class MaterializedViewRegistry {
     db: MVQueryContext,
     options?: { knownCollections?: (name: string) => boolean },
   ): Promise<void> {
-    // Build a predicate-aware db wrapper (#153). If `spec.predicates` is
+    // Build a predicate-aware db wrapper. If `spec.predicates` is
     // declared, the wrapper intercepts `.collection().query()` and
     // attaches the predicates map to the resulting Query<T>. With no
     // predicates declared, the wrapper is the original db unchanged.
@@ -70,7 +70,7 @@ export class MaterializedViewRegistry {
     // expose the underlying Query, so the spec must declare `sources`
     // explicitly. `partitionClauses` are only populated for Query<T>
     // since same-collection-partition is a non-aggregate concern.
-    // UNION-form strategies (#165): dependencies and plan summary come
+    // UNION-form strategies: dependencies and plan summary come
     // straight off the strategy — no `query` callback to introspect.
     // The dependency-analyzer + summarizer are bypassed entirely; the
     // executor handles materialization via `materializeUnionResult`.
@@ -136,7 +136,7 @@ export class MaterializedViewRegistry {
     // the partition field so cycle detection can prove disjointness.
     // Only applicable to Query<T> shapes — aggregate MVs don't carry
     // a chainable plan to inspect (and same-collection aggregation
-    // doesn't make sense in the niwat use cases that motivated #152).
+    // doesn't make sense for same-collection aggregation).
     const partitionClauses: FieldClause[] = []
     const partitionField = spec.output?.partition?.field
     if (partitionField !== undefined && isQuery) {
@@ -359,14 +359,14 @@ function extractPredicateRefs(
 
 /**
  * Provability check for the same-collection partition-discriminator
- * (#152, spec § Same-collection-as-source MV). Returns `true` when
+ * (spec § Same-collection-as-source MV). Returns `true` when
  * the captured partition clauses on the MV's query provably exclude
  * the partition's value — meaning the input filter and the output
  * partition are disjoint and the same-collection edge isn't really a
  * cycle.
  *
- * Supported provability shapes (narrow on purpose — niwat's DERIV-
- * PP30-001 is the load-bearing case):
+ * Supported provability shapes (narrow on purpose — DERIV-PP30-001
+ * is the load-bearing case):
  *
  * - `.where(field, '==', X)` where X !== partition.value → disjoint
  * - `.where(field, '!=', partition.value)` → disjoint

--- a/packages/hub/src/materialized-views/stale.ts
+++ b/packages/hub/src/materialized-views/stale.ts
@@ -3,7 +3,7 @@ import type { TxContext } from '../tx/transaction.js'
 import type { MaterializedViewRegistry } from './registry.js'
 // Type-only — runtime class loaded via dynamic import in
 // `resolveStaleMVOnRead` only when a stale flag actually fires.
-// Keeps the executor chunk out of the floor bundle (mirrors v1 #130).
+// Keeps the executor chunk out of the floor bundle (mirrors v1 floor-bundle isolation).
 import type { MaterializedViewExecutor as MVExecutorType } from './executor.js'
 import type { MVQueryContext } from './types.js'
 
@@ -70,7 +70,7 @@ export function isMVStale(registry: MaterializedViewRegistry, mvName: string): b
  *
  * Dynamic-imports the executor only when a stale flag actually fires
  * (the floor-bundle isolation pattern v1 derivations established in
- * #130).
+ * floor-bundle isolation pattern).
  */
 export async function resolveStaleMVOnRead(
   accessor: MVStaleAccessor,

--- a/packages/hub/src/materialized-views/types.ts
+++ b/packages/hub/src/materialized-views/types.ts
@@ -109,7 +109,7 @@ export interface MaterializedViewStrategy<TRow extends Record<string, unknown>> 
    */
   query?: (db: MVQueryContext) => Query<TRow>
   /**
-   * UNION-form sources (#165): an explicit list of sibling collections
+   * UNION-form sources: an explicit list of sibling collections
    * that contribute rows to a single MV. Each arm's `map` projects a
    * source row into the MV's unified row shape; the mapped streams are
    * concatenated, then {@link groupBy} + {@link aggregate} run on the
@@ -125,7 +125,7 @@ export interface MaterializedViewStrategy<TRow extends Record<string, unknown>> 
    */
   unionSources?: ReadonlyArray<UnionSource<TRow>>
   /**
-   * Group-key field(s) for UNION mode (#165). Applied to the
+   * Group-key field(s) for UNION mode. Applied to the
    * concatenated mapped-row stream from {@link unionSources} before
    * {@link aggregate} runs. Accepts a single field name or a tuple of
    * field names for multi-key grouping (same shape as
@@ -137,7 +137,7 @@ export interface MaterializedViewStrategy<TRow extends Record<string, unknown>> 
    */
   groupBy?: string | ReadonlyArray<string>
   /**
-   * Aggregation spec for UNION mode (#165). Applied per-group after
+   * Aggregation spec for UNION mode. Applied per-group after
    * {@link groupBy} buckets the concatenated mapped-row stream from
    * {@link unionSources}. Same shape as the `AggregateSpec` passed to
    * `Query.aggregate()`.
@@ -148,11 +148,11 @@ export interface MaterializedViewStrategy<TRow extends Record<string, unknown>> 
   /**
    * Pure function from a materialized row → stable id used in the
    * output collection. Required — explicit always beats default-with-pitfalls
-   * (see niwat-review of #149 round 1 for the slash-collision rationale).
+   * (explicit always beats default-with-pitfalls; see the slash-collision rationale).
    */
   rowKey: (row: TRow) => string
   /**
-   * Explicit source collections (#152). Required when `query()` returns
+   * Explicit source collections. Required when `query()` returns
    * an `Aggregation` or `GroupedAggregation` rather than a `Query<T>`
    * — the dependency analyzer can't introspect through `groupBy().aggregate()`
    * back to the source. Optional for plain `Query<T>` results — the
@@ -162,7 +162,7 @@ export interface MaterializedViewStrategy<TRow extends Record<string, unknown>> 
    */
   sources?: ReadonlyArray<string>
   /**
-   * Declared deterministic predicates (#153). Each entry pairs a
+   * Declared deterministic predicates. Each entry pairs a
    * consumer-stable `hash` with a function. The `query()` callback's
    * Query<T> can invoke them via `.wherePredicate(name, ctx?)`. The
    * predicate's `hash` + a canonical-JSON hash of `ctx` both fold
@@ -199,8 +199,8 @@ export interface MaterializedViewStrategy<TRow extends Record<string, unknown>> 
    *
    * - `'delete'` (default) — tombstone the prior MV row via
    *   `Collection._internalDelete` (system housekeeping bypasses user
-   *   `onDelete` guards on the output collection — see PR #148's
-   *   composition fix).
+   *   `onDelete` guards on the output collection — the housekeeping
+   *   bypass composition fix).
    * - `'keep'` — leave the prior MV row in place. Useful when zero
    *   is a meaningful state.
    */
@@ -208,7 +208,7 @@ export interface MaterializedViewStrategy<TRow extends Record<string, unknown>> 
   /**
    * `true` re-throws on any row-write failure → composes with
    * `withTransactions` to roll back the source-write atomically via
-   * `revertExecuted` (#133). Default `false` (failed rows are
+   * `revertExecuted`. Default `false` (failed rows are
    * isolated; other rows commit).
    */
   strict?: boolean

--- a/packages/hub/src/materialized-views/with-materialized-view.ts
+++ b/packages/hub/src/materialized-views/with-materialized-view.ts
@@ -12,7 +12,7 @@ import type { MaterializedViewStrategy, MaterializedViewStrategyHandle } from '.
  * Two registration modes:
  *   - **single-source** — declare `query: (db) => Query<TRow>`; the
  *     dependency analyzer derives source collections from the plan.
- *   - **UNION** (#165) — declare `unionSources: [{ collection, map }, ...]`
+ *   - **UNION** — declare `unionSources: [{ collection, map }, ...]`
  *     plus optional `groupBy` + `aggregate`; the executor reads each
  *     arm, maps to the unified row shape, concatenates, then groups
  *     and aggregates.

--- a/packages/hub/src/meta/user-envelope/api.ts
+++ b/packages/hub/src/meta/user-envelope/api.ts
@@ -6,7 +6,7 @@
  *    own keyringId. **Own-only write rule** is structural — no method
  *    exists to write someone else's envelope.
  *  - Read-anyone: `get` / `list` — read other principals' envelopes
- *    (subject to `view-team-profiles` policy gate, wired in #22).
+ *    (subject to `view-team-profiles` policy gate).
  *  - Reactive: `subscribe` / `live` — in-process event emission on local
  *    writes. Cross-instance updates land via the team/sync engine and
  *    surface to subscribers when the sync diff replays through this API.
@@ -41,7 +41,7 @@ export type DeepPartial<T> = T extends object
 
 /**
  * Recursive partial with `null` allowed at every level — used by
- * `updateMe` (#57) to express deletion intent in addition to merge.
+ * `updateMe` to express deletion intent in addition to merge.
  *
  * Semantics inside `updateMe`:
  *   - `undefined` (or absent key) — skip; source value preserved
@@ -50,8 +50,8 @@ export type DeepPartial<T> = T extends object
  *     replace for primitives / arrays)
  *
  * Matches lodash `_.merge` behavior on `null` and Firestore's
- * `FieldValue.delete()` semantics. Loosened from `DeepPartial<T>` per
- * #57; consumers wanting the original "merge-only" surface can keep
+ * `FieldValue.delete()` semantics. Loosened from `DeepPartial<T>`.
+ * Consumers wanting the original "merge-only" surface can keep
  * importing `DeepPartial` and avoid passing `null`.
  */
 export type DeepPartialOrNull<T> = T extends object
@@ -136,7 +136,7 @@ export class UserApi {
    * the envelope on first call. Optimistic-concurrency safe — a stale
    * `_v` (parallel writer on another device) throws `ConflictError`.
    *
-   * Patch semantics (#57):
+   * Patch semantics:
    *   - `undefined` (or omitted key) — skip; existing value preserved
    *   - `null` — delete the field from the merged result
    *   - any other value — overwrite (deep-merge for plain objects,
@@ -200,7 +200,7 @@ export class UserApi {
     return written
   }
 
-  // ─── Visibility (#122) ───────────────────────────────────────────────
+  // ─── Visibility ──────────────────────────────────────────────────────
 
   /**
    * Read the current user's visibility flag from
@@ -378,7 +378,7 @@ export class UserApi {
 }
 
 /**
- * Recursive plain-object deep merge with delete intent (#57).
+ * Recursive plain-object deep merge with delete intent.
  *
  * Patch semantics:
  *   - `undefined` — skip the key; source value preserved
@@ -404,7 +404,7 @@ function deepMerge<T>(source: T, patch: DeepPartialOrNull<T>): T {
   for (const [key, patchVal] of Object.entries(patch as Record<string, unknown>)) {
     if (patchVal === undefined) {
       // Skip — preserve the source value at this key. Matches the
-      // pre-#57 behavior so callers who never used `null` see no diff.
+      // pre-existing behavior so callers who never used `null` see no diff.
       continue
     }
     if (patchVal === null) {

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -168,7 +168,7 @@ export class Noydb {
   private readonly syncEngines = new Map<string, SyncEngine>()
   /**
    * Per-vault active session tier — defaults to `1` after a passphrase
-   * unlock; tier-2 / tier-3 unlocks (issue #11) downgrade it. Used by
+   * unlock; tier-2 / tier-3 unlocks downgrade it. Used by
    * {@link checkGate} to evaluate `gate.minTier`.
    */
   private readonly activeTier = new Map<string, ActiveTier>()
@@ -178,14 +178,14 @@ export class Noydb {
    */
   private readonly policyCache = new Map<string, VaultPolicy>()
   /**
-   * One-shot bypass for the managed-mode strong-recovery check (#195).
+   * One-shot bypass for the managed-mode strong-recovery check.
    * Set true by {@link openVaultAndEnrollRecovery} for the duration of
    * the bootstrap window so the keyring can be created before the
    * strong recovery is enrolled. Always cleared (try/finally).
    * @internal
    */
   private _skipNextManagedRecoveryCheck = false
-  /** Per-vault tier-3 (PIN / quick-resume) state — issue #11. */
+  /** Per-vault tier-3 (PIN / quick-resume) state. */
   private readonly quickUnlock = new QuickUnlockStore()
   /**
    * Resolved public-envelope schema. Lazily computed once from
@@ -195,9 +195,9 @@ export class Noydb {
   private readonly publicEnvelopeSchema: ResolvedPublicEnvelopeSchema | undefined
   private closed = false
   private sessionTimer: ReturnType<typeof setTimeout> | null = null
-  /** Same-device multi-tab coordinator (#228); created on `enableTabCoordination()`. */
+  /** Same-device multi-tab coordinator; created on `enableTabCoordination()`. */
   private tabCoordinator: TabCoordinator | undefined
-  /** Cross-tab write relay (#228b); created on `enableTabCoordination()`. */
+  /** Cross-tab write relay; created on `enableTabCoordination()`. */
   private writeRelay: CrossTabWriteRelay | undefined
   /** Per-vault policy enforcers. */
   private readonly policyEnforcers = new Map<string, PolicyEnforcer>()
@@ -210,8 +210,8 @@ export class Noydb {
    * the same function's `finally` block. Side-effect writes triggered
    * during a staged op's `Collection.put` (today: eager derivation
    * outputs) register their pre-write envelope on `_executed` here so
-   * a mid-batch failure rolls them back alongside the main staged ops
-   * (#133). `null` outside of Phase 2.
+   * a mid-batch failure rolls them back alongside the main staged ops.
+   * `null` outside of Phase 2.
    * @internal
    */
   private _activeTxContext: TxContext | null = null
@@ -322,7 +322,7 @@ export class Noydb {
 
     const keyring = await this.getKeyringInternal(name)
     // Tier-1 unlock — passphrase / getKeyring callbacks both yield the
-    // most-privileged tier. Tier-2 / tier-3 unlocks (issue #11) install
+    // most-privileged tier. Tier-2 / tier-3 unlocks install
     // a lower tier here when they land.
     if (!this.activeTier.has(name)) {
       this.activeTier.set(name, 1)
@@ -438,12 +438,12 @@ export class Noydb {
     // Initialise the optional guard + derivation registries via
     // dynamic-import. Both calls are no-ops when the corresponding
     // strategies array is empty / unset, leaving the subsystem code
-    // out of the floor bundle for consumers that don't use it (#130).
+    // out of the floor bundle for consumers that don't use it.
     await comp._initGuards(this.options.guardStrategies ?? [])
     await comp._initDerivations(this.options.derivationStrategies ?? [])
     await comp._initMaterializedViews(this.options.materializedViewStrategies ?? [])
     await comp._initOverlayedViews(this.options.overlayedViewStrategies ?? [])
-    // #232 — snapshot the schema-fence generation once per opened vault.
+    // Snapshot the schema-fence generation once per opened vault.
     await comp.schemaFence.init()
     this.vaultCache.set(name, comp)
     return comp
@@ -592,8 +592,6 @@ export class Noydb {
    * @throws `NoAccessError` when no keyring exists for the target.
    * @throws `PermissionDeniedError` when the role hierarchy rejects.
    * @throws `ValidationError` when no field is provided.
-   *
-   * @see #54
    */
   async updateUser(
     vault: string,
@@ -1000,7 +998,7 @@ export class Noydb {
     fn: (tx: TxContext) => Promise<T> | T,
   ): Promise<T>
   /**
-   * Dry-run a transaction (#231): run the body to stage ops, then return
+   * Dry-run a transaction: run the body to stage ops, then return
    * the directly-affected diff + collected guard violations WITHOUT
    * committing (no adapter writes, no write hooks). MV/derivation cascade
    * is not simulated. Requires `withTransactions()`.
@@ -1024,7 +1022,7 @@ export class Noydb {
       return this.txStrategy.runTransaction(this, arg)
     }
     if (typeof arg === 'object' && arg !== null && (arg as { dryRun?: boolean }).dryRun === true) {
-      // Dry-run form (#231): stage + diff, no commit.
+      // Dry-run form: stage + diff, no commit.
       if (typeof maybeFn !== 'function') {
         throw new ValidationError(
           'db.transaction({ dryRun: true }, fn) requires the callback as the second argument.',
@@ -1069,7 +1067,7 @@ export class Noydb {
    * Phase 2. `Collection.dispatchDerivations` consults this so a
    * recursive derived-output write inside `Collection.put` can register
    * its envelope onto `ctx._executed` and roll back with the main
-   * staged ops on mid-batch failure (#133).
+   * staged ops on mid-batch failure.
    *
    * @internal
    */
@@ -1100,7 +1098,7 @@ export class Noydb {
    * `Collection.putManyAtomic` (via `derivationSource.createTxContext`)
    * to publish an active context for the duration of its bulk-atomic
    * Phase 2 loop, so recursive derivation-output writes register on
-   * `ctx._executed` and roll back together with the source ops (#133).
+   * `ctx._executed` and roll back together with the source ops.
    *
    * @internal
    */
@@ -1182,7 +1180,7 @@ export class Noydb {
   }
 
   /**
-   * Register a hook that runs before each write (#230). Awaited; a throw
+   * Register a hook that runs before each write. Awaited; a throw
    * aborts the write. Returns an unsubscribe function.
    */
   onBeforeWrite(handler: WriteHook): Unsubscribe {
@@ -1190,21 +1188,21 @@ export class Noydb {
   }
 
   /**
-   * Register a hook that runs after each committed write (#230). Awaited;
+   * Register a hook that runs after each committed write. Awaited;
    * a handler error is warned, never rolled back. Returns an unsubscribe fn.
    */
   onAfterWrite(handler: WriteHook): Unsubscribe {
     return this.writeHooks.onAfterWrite(handler)
   }
 
-  /** Subscribe to cross-tab write conflicts (#228c). Returns an unsubscribe. */
+  /** Subscribe to cross-tab write conflicts. Returns an unsubscribe. */
   onWriteConflict(fn: (c: WriteConflict) => void): Unsubscribe {
     this.on('write:conflict', fn)
     return () => this.off('write:conflict', fn)
   }
 
   /**
-   * Enable same-device multi-tab coordination (#228): primary/secondary
+   * Enable same-device multi-tab coordination: primary/secondary
    * election + presence. Browser-only — a graceful no-op (role 'unknown')
    * when Web Locks / BroadcastChannel are unavailable and nothing is
    * injected. Idempotent; returns a disposer.
@@ -1277,12 +1275,12 @@ export class Noydb {
     return this.writeHooks
   }
 
-  /** @internal Track A — the observe bus, threaded into every Collection. */
+  /** @internal The observe bus, threaded into every Collection. */
   get _subsystemBus(): SubsystemBus {
     return this.subsystemBus
   }
 
-  /** @internal Stable per-instance id for schema-cutover coordination (#232). */
+  /** @internal Stable per-instance id for schema-cutover coordination. */
   get _clientId(): string {
     return this.clientId
   }
@@ -1303,10 +1301,6 @@ export class Noydb {
    * survives lock; nothing about it changes when DEKs are scrubbed).
    *
    * No-op when `vault` is not currently in cache (idempotent).
-   *
-   * Unblocks vLannaAi/niwat#33.
-   *
-   * @see #17
    */
   lockVault(vault: string): void {
     // Sync engine: stop autosync + drop the engine so the next openVault
@@ -1317,12 +1311,12 @@ export class Noydb {
     this.policyEnforcers.get(vault)?.destroy()
     this.policyEnforcers.delete(vault)
     // Live caches: scrub DEKs, vault instance, active tier.
-    this.vaultCache.get(vault)?._stopFenceCoordination() // #232 — stop heartbeat/watcher timers
+    this.vaultCache.get(vault)?._stopFenceCoordination() // stop heartbeat/watcher timers
     this.keyringCache.delete(vault)
     this.vaultCache.delete(vault)
     this.activeTier.delete(vault)
     // Intentionally NOT cleared:
-    //   - this.quickUnlock — preserves PIN resume (#17 contract).
+    //   - this.quickUnlock — preserves PIN resume.
     //   - this.policyCache — vault policy is on-disk data, survives lock.
     //   - this.sessionStrategy — no per-vault revoke; close() handles bulk.
   }
@@ -1345,8 +1339,8 @@ export class Noydb {
       engine.stopAutoSync()
     }
     this.syncEngines.clear()
-    for (const v of this.vaultCache.values()) v._stopFenceCoordination() // #232 — stop heartbeat/watcher timers
-    this.disableTabCoordination() // #228 — stop tab lock/heartbeat timers
+    for (const v of this.vaultCache.values()) v._stopFenceCoordination() // stop heartbeat/watcher timers
+    this.disableTabCoordination() // stop tab lock/heartbeat timers
     this.keyringCache.clear()
     this.vaultCache.clear()
     this.activeTier.clear()
@@ -1447,7 +1441,7 @@ export class Noydb {
   }
 
   /**
-   * Read the current vault-level user-directory toggle (#122). Returns
+   * Read the current vault-level user-directory toggle. Returns
    * the default-on shape (`{ enabled: true }`) when no `_meta/directory`
    * document has been persisted yet.
    *
@@ -1460,7 +1454,7 @@ export class Noydb {
   }
 
   /**
-   * Toggle the vault's user-directory listing on or off (#122).
+   * Toggle the vault's user-directory listing on or off.
    * Owner-only. When disabled, `listUsersWithEnvelopes()` throws
    * {@link import('./errors.js').DirectoryDisabledError} for callers
    * whose role is neither `owner` nor `admin`.
@@ -1537,7 +1531,7 @@ export class Noydb {
    *
    * Two enforcement modes:
    *
-   * 1. **Managed-mode mandatory strong-recovery (#195).** When
+   * 1. **Managed-mode mandatory strong-recovery.** When
    *    `passphraseMode === 'managed'`, the vault MUST have at least
    *    one **strong** recovery profile (Shamir today). Paper alone is
    *    rejected because under managed mode the user has no memorized
@@ -1576,7 +1570,7 @@ export class Noydb {
   }
 
   /**
-   * Internal accessor used by tier-2/tier-3 unlock paths (issue #11)
+   * Internal accessor used by tier-2/tier-3 unlock paths
    * to mark the active session tier.
    * @internal
    */
@@ -1584,7 +1578,7 @@ export class Noydb {
     this.activeTier.set(vault, tier)
   }
 
-  // ─── Tier-2 enroll / remove (issue #11) ────────────────────────
+  // ─── Tier-2 enroll / remove ─────────────────────────────────────
   /**
    * Add a tier-2 authenticator slot to the calling user's keyring.
    * Each slot independently wraps the SAME KEK under a method-specific
@@ -1624,7 +1618,7 @@ export class Noydb {
     this.keyringCache.set(vault, next)
   }
 
-  /** Read the slot list for a vault. Internal — `describeAuthConfig` (#13) consumes this. */
+  /** Read the slot list for a vault. Internal — `describeAuthConfig` consumes this. */
   async listAuthenticators(vault: string): Promise<ReadonlyArray<KeyringAuthenticator>> {
     const keyring = await this.getKeyringInternal(vault)
     return keyring.authenticators
@@ -1637,7 +1631,7 @@ export class Noydb {
    * are immutable through this method. Anti-slot-swap is structural,
    * not gate-driven.
    *
-   * `meta` patch semantics (#57-aligned):
+   * `meta` patch semantics (top-level merge):
    *   - Top-level merge — absent keys preserved
    *   - `null` value — delete that meta key
    *   - Other values — replace verbatim
@@ -1655,8 +1649,6 @@ export class Noydb {
    *
    * @throws `NoAccessError` when no slot with the given id exists.
    * @throws `ValidationError` when no patch field is provided.
-   *
-   * @see #55
    */
   async updateAuthenticator(
     vault: string,
@@ -1671,7 +1663,7 @@ export class Noydb {
   }
 
   /**
-   * Native WebAuthn enrollment using the **real** internal keyring (#16).
+   * Native WebAuthn enrollment using the **real** internal keyring.
    *
    * Why this exists: when a consumer is using `createNoydb({ secret })`,
    * they cannot reach the live `UnlockedKeyring` to feed it to
@@ -1714,8 +1706,6 @@ export class Noydb {
    * a server-side allowlist).
    *
    * Gated by `enroll-authenticator` like `enrollAuthenticator()` itself.
-   *
-   * @see #16
    */
   async enrollWebAuthn(
     vault: string,
@@ -1749,8 +1739,6 @@ export class Noydb {
    * deciding when a new device prompt should appear. Identity is
    * `id` + `enrolled_at`; the `meta.credentialId` (base64) is used by
    * `allowCredentials` at unlock time.
-   *
-   * @see #16
    */
   async listWebAuthnSlots(vault: string): Promise<ReadonlyArray<{
     id: string
@@ -1854,7 +1842,7 @@ export class Noydb {
     return fnReadPublicEnvelope(this.options.store, vault, opts)
   }
 
-  // ─── Auth introspection (issue #13) ────────────────────────────
+  // ─── Auth introspection ─────────────────────────────────────────
   /** English summary of the configured auth model. */
   async describeAuthConfig(vault: string): Promise<string> {
     return fnDescribeAuthConfig(this.options.store, vault)
@@ -1888,7 +1876,7 @@ export class Noydb {
     return fnDescribeAllUsersAuth(this.options.store, vault)
   }
 
-  // ─── Tier-1 change flows (issue #10) ───────────────────────────
+  // ─── Tier-1 change flows ────────────────────────────────────────
   /**
    * Rotate the user's passphrase (user remembers old). Validates the
    * new phrase against the configured `passphrase` policy, runs the
@@ -1896,8 +1884,7 @@ export class Noydb {
    *
    * Tier-2 authenticator slots are dropped — each slot wraps the old
    * KEK and would need its derivation key to be re-presented. Re-enrol
-   * via `db.enrollAuthenticator` after rotation. Tracked as a
-   * v0.1.0-pre.5 limitation.
+   * via `db.enrollAuthenticator` after rotation.
    *
    * @throws `WeakPassphraseError` on a weak new phrase.
    * @throws `PolicyDeniedError` when the gate denies (missing factor, …).
@@ -1908,7 +1895,7 @@ export class Noydb {
     input: RotatePassphraseInput,
     factors?: FactorProofBundle,
   ): Promise<void> {
-    // Managed-passphrase mode (#14): the user does NOT know the
+    // Managed-passphrase mode: the user does NOT know the
     // current passphrase (hub generated it and sealed it under the
     // provider). Manual rotation via this method is impossible by
     // construction — surface a clear error rather than fail mid-way
@@ -1935,8 +1922,8 @@ export class Noydb {
 
   /**
    * Reset the passphrase using a recovery proof (user forgot the old).
-   * v0.1.0-pre.5 supports the `'paper'` profile end-to-end; the
-   * other three profiles throw {@link RecoveryProfileNotImplementedError}.
+   * Currently supports the `'paper'` profile end-to-end; the
+   * other profiles throw {@link RecoveryProfileNotImplementedError}.
    *
    * Burns the used recovery entry on success.
    */
@@ -1952,7 +1939,7 @@ export class Noydb {
     // exactly one entry, so post-recovery `_meta/recovery-paper`
     // contains `entriesBeforeRecovery.length - 1` entries (the ones
     // the user did NOT just consume). Those are what we replace
-    // under the auto-rotation logic from #36.
+    // under the auto-rotation logic.
     const entriesBeforeRecovery = await loadPaperRecoveryEntries(this.options.store, vault)
 
     const next = await keyringRecoverPassphrase(this.options.shamirRecovery, this.options.store, vault, userId, input)
@@ -1971,7 +1958,7 @@ export class Noydb {
     //
     // If this step fails (store error mid-mint), we leave the existing
     // post-burn entries in place — the user falls back to the
-    // pre-#36 behavior (remaining N-1 codes still valid). Strictly
+    // fall back to prior behavior (remaining N-1 codes still valid). Strictly
     // safer than wiping then failing.
     const codeGen = input.codeGenerator ?? generateULID
     const newCodeCount = input.newCodeCount ?? remainingAfterBurn
@@ -1991,7 +1978,7 @@ export class Noydb {
   }
 
   /**
-   * Deliberate paper-recovery-code regeneration (#121). User knows their
+   * Deliberate paper-recovery-code regeneration. User knows their
    * passphrase but wants a fresh sheet — they lost the printout or
    * suspect compromise of the off-site copy.
    *
@@ -2001,7 +1988,7 @@ export class Noydb {
    *
    * Gated by the `rotate-recovery` policy gate:
    *   - PERSONAL_POLICY: `{ minTier: 1 }` — knowing the passphrase
-   *     suffices, matching the pre-#121 low-level flow's bar.
+   *     suffices, matching the lower-level flow's bar.
    *   - STRICT_POLICY: `{ minTier: 1, factors: [{ anyOf: ['totp',
    *     'email-otp', 'webauthn-roaming'] }] }` — rotation is an
    *     off-site-trust event; require an off-device factor so a
@@ -2145,7 +2132,7 @@ export class Noydb {
   }
 
   /**
-   * **Atomic create-and-enroll for managed-mode vaults (#195).**
+   * **Atomic create-and-enroll for managed-mode vaults.**
    *
    * Bootstraps a managed-mode vault and enrolls strong recovery in
    * a single ceremony. Under `passphraseMode: 'managed'`, every
@@ -2240,7 +2227,7 @@ export class Noydb {
   }
 
   /**
-   * **Recovery flow under managed-passphrase mode (#195).**
+   * **Recovery flow under managed-passphrase mode.**
    *
    * Replaces the sealed passphrase of a managed-mode vault with a
    * fresh 256-bit random, sealed under the configured
@@ -2257,7 +2244,7 @@ export class Noydb {
    *   5. Drop the keyring cache so the next operation re-derives.
    *
    * The vault's strong-recovery enrollment is preserved across
-   * recovery (Shamir entries are not burned on use — see #196).
+   * recovery (Shamir entries are not burned on use).
    *
    * @throws ValidationError if the Noydb instance is not in managed mode.
    */
@@ -2331,7 +2318,7 @@ export class Noydb {
 
   /**
    * Atomic peer-recovery — re-wraps an EXISTING user's keyring under
-   * a fresh temp passphrase in a single store write. Closes #34's
+   * a fresh temp passphrase in a single store write. Closes the
    * partial-failure window (the previous compose-from-primitives
    * pattern was `db.revoke + db.grant`, two writes — if the issuer
    * cancelled between them the target was locked out entirely).
@@ -2341,7 +2328,7 @@ export class Noydb {
    *   - Same `userId`, role, permissions, capabilities preserved.
    *   - DEKs unchanged → every other principal in the vault keeps
    *     access. No key rotation.
-   *   - Allows owner→owner natively (#33). The existing
+   *   - Allows owner→owner natively. The existing
    *     `db.revoke` retains its block — peer-recovery is a separate,
    *     intentionally-named operation.
    *   - Tier-2 slots dropped (they wrap the old KEK).
@@ -2370,7 +2357,6 @@ export class Noydb {
    * @throws `PrivilegeEscalationError` when the caller lacks a DEK
    *         the target previously had access to.
    *
-   * @see #33 #34 — the issues this method closes.
    */
   async recoverUser(
     vault: string,
@@ -2390,7 +2376,7 @@ export class Noydb {
   }
 
   /**
-   * Persist a recovery enrollment. v0.1.0-pre.5 accepts the `'paper'`
+   * Persist a recovery enrollment. Accepts the `'paper'`
    * profile.
    *
    * The hub wraps the user's DEK set (not the KEK) under a code-derived
@@ -2410,7 +2396,7 @@ export class Noydb {
    * showCodesToUser(codes)
    * ```
    *
-   * As of pre.8, `@noy-db/on-recovery`'s `generateRecoveryCodeSet`
+   * `@noy-db/on-recovery`'s `generateRecoveryCodeSet`
    * delegates to `mintPaperRecoveryEntry` internally — its output is
    * fed directly to this API. Pick whichever fits your code-gen layer:
    *
@@ -2460,7 +2446,7 @@ export class Noydb {
     )
   }
 
-  /** Read the persisted recovery entries (paper + Shamir). Used by `describeAuthConfig` (#13). */
+  /** Read the persisted recovery entries (paper + Shamir). Used by `describeAuthConfig`. */
   async listRecoveryEntries(
     vault: string,
   ): Promise<{
@@ -2472,7 +2458,7 @@ export class Noydb {
     return { paper, shamir }
   }
 
-  // ─── Tier-3 enroll / unlock (issue #11) ────────────────────────
+  // ─── Tier-3 enroll / unlock ─────────────────────────────────────
   /**
    * Register a tier-3 quick-unlock state for the vault. The state is
    * an opaque blob produced by `@noy-db/on-pin/enrollPin` (or any
@@ -2518,11 +2504,11 @@ export class Noydb {
   }
 
   /**
-   * Public accessor for the unlocked keyring of a vault — issue #28.
+   * Public accessor for the unlocked keyring of a vault.
    *
    * Returns a **defensive shallow copy** so consumers can read the DEK
    * map and authenticator list without the risk of mutating the hub's
-   * internal cache (#88). Internal hub code paths use a live reference
+   * internal cache. Internal hub code paths use a live reference
    * via `getKeyringInternal`; ceremonies and external consumers always
    * get a snapshot.
    *
@@ -2555,7 +2541,7 @@ export class Noydb {
     // reasonably mutate is freshly cloned. CryptoKey handles inside
     // `deks` are intentionally shared — they're opaque references that
     // both encrypt and decrypt go through. `salt` (Uint8Array) is left
-    // as-is: no realistic mutation path. (#88, extended in #114.)
+    // as-is: no realistic mutation path.
     return {
       ...live,
       deks: new Map(live.deks),
@@ -2598,7 +2584,7 @@ export class Noydb {
       return keyring
     }
 
-    // Managed-passphrase mode (#14) — resolve the effective secret
+    // Managed-passphrase mode — resolve the effective secret
     // before falling into the normal load/create path. The first call
     // mints + seals + persists; subsequent calls unseal what's there.
     // The returned string takes the place of `options.secret` for the
@@ -2677,7 +2663,7 @@ export async function createNoydb(options: NoydbOptions): Promise<Noydb> {
     throw new ValidationError('Provide either `secret` or `getKeyring`, not both')
   }
 
-  // Managed-passphrase mode (#14) — mutually exclusive with both
+  // Managed-passphrase mode — mutually exclusive with both
   // `secret` (the whole point is hub generates and seals; the user
   // doesn't supply one) and `getKeyring` (a custom unlock path that
   // bypasses the sealing flow entirely). Requires a SealingKeyProvider.

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -79,6 +79,7 @@ import { Vault } from './vault.js'
 import { NoydbEventEmitter } from './events.js'
 import { WriteQueueTracker, type WriteQueue } from './write-queue.js'
 import { WriteHookRegistry, type WriteHook, type Unsubscribe } from './write-hooks.js'
+import { SubsystemBus } from './subsystem-bus.js'
 import { TabCoordinator, defaultLockManager, defaultChannel, type TabCoordinationOptions, type TabRole, type TabPresence } from './tab-coordination.js'
 import { CrossTabWriteRelay } from './tab-write-relay.js'
 import {
@@ -160,6 +161,7 @@ export class Noydb {
   private readonly emitter = new NoydbEventEmitter()
   private readonly writeQueueTracker = new WriteQueueTracker()
   private readonly writeHooks = new WriteHookRegistry()
+  private readonly subsystemBus = new SubsystemBus()
   private readonly clientId = generateULID()
   private readonly vaultCache = new Map<string, Vault>()
   private readonly keyringCache = new Map<string, UnlockedKeyring>()
@@ -1273,6 +1275,11 @@ export class Noydb {
   /** @internal The write-hook registry, threaded into each Collection. */
   get _writeHooks(): WriteHookRegistry {
     return this.writeHooks
+  }
+
+  /** @internal Track A — the observe bus, threaded into every Collection. */
+  get _subsystemBus(): SubsystemBus {
+    return this.subsystemBus
   }
 
   /** @internal Stable per-instance id for schema-cutover coordination (#232). */

--- a/packages/hub/src/overlay-views/types.ts
+++ b/packages/hub/src/overlay-views/types.ts
@@ -1,5 +1,5 @@
 /**
- * Read-shadow overlay primitive (#154, MV v2 spec § Composition with
+ * Read-shadow overlay primitive (MV v2 spec § Composition with
  * operator-editable lifecycle). Binds an MV's read-only base output
  * to a separate user-writable overlay collection; reads merge via a
  * single shadow predicate, writes route to the overlay.

--- a/packages/hub/src/overlay-views/virtual-collection.ts
+++ b/packages/hub/src/overlay-views/virtual-collection.ts
@@ -4,7 +4,7 @@ import type { OverlayedViewStrategy } from './types.js'
 
 /**
  * Virtual-collection proxy returned by `vault.collection(overlayName)`
- * when `overlayName` is a registered `withOverlayedView` (#154).
+ * when `overlayName` is a registered `withOverlayedView`.
  *
  * Implements the core `Collection<T>`-shaped read/write surface with
  * merge-on-read semantics:
@@ -15,7 +15,7 @@ import type { OverlayedViewStrategy } from './types.js'
  *   - `delete(id)`: removes the overlay row only; base stays
  *
  * Reactive APIs (`live`, `subscribe`, `query().live()`) are out of
- * scope for #154 and surface as "not yet implemented" — wired in a
+ * scope for this release and surface as "not yet implemented" — wired in a
  * future sub-issue.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -153,7 +153,7 @@ export class OverlayedCollection<T extends Record<string, unknown> = any> {
   // error pointing at the relevant issue — so consumers don't hit a
   // cryptic `undefined is not a function` runtime crash.
   //
-  // Closes niwat-review of PR #160.
+  // Throw-stubs so consumers get actionable errors rather than cryptic crashes.
 
   /** @throws — chainable Query<T> over a virtual collection is deferred. */
   query(): never {

--- a/packages/hub/src/overlay-views/with-overlayed-view.ts
+++ b/packages/hub/src/overlay-views/with-overlayed-view.ts
@@ -4,7 +4,7 @@ import type { OverlayedViewStrategy, OverlayedViewStrategyHandle } from './types
 /**
  * Register a read-shadow overlay: bind an MV-owned base collection to
  * a user-writable overlay so consumers can express operator-editable
- * lifecycles as one declarative block (#154, MV v2 spec § Composition
+ * lifecycles as one declarative block (MV v2 spec § Composition
  * with operator-editable lifecycle).
  *
  * See docs/superpowers/specs/2026-05-20-dim14-mv-v2-design.md.

--- a/packages/hub/src/persisted-schemas/register.ts
+++ b/packages/hub/src/persisted-schemas/register.ts
@@ -29,7 +29,7 @@ export interface PersistSchemaResult {
   readonly skipped: boolean
   /** The envelope that was either written or matched. */
   readonly envelope: PersistedSchemaEnvelope
-  /** The update-strategy decision, present when strategies ran (#245). */
+  /** The update-strategy decision, present when strategies ran. */
   readonly decision?: UpdateDecision
 }
 
@@ -64,7 +64,7 @@ export async function persistSchemaIfNeeded(opts: {
   }
 
   if (decision.action !== 'allow') {
-    // reject (or, in #232, cutover): do NOT overwrite the baseline — the
+    // reject (or cutover): do NOT overwrite the baseline — the
     // old schema stays the source of truth until the change is resolved.
     return { written: false, skipped: false, envelope: stored ?? fresh, decision }
   }

--- a/packages/hub/src/policy/errors.ts
+++ b/packages/hub/src/policy/errors.ts
@@ -40,8 +40,7 @@ export class PolicyDeniedError extends NoydbError {
  * MUST have at least one recovery path enrolled before being
  * production-ready (paper, shamir, multi-channel, or admin-mediated).
  *
- * The error references issue #10 in its message so a developer hitting
- * it gets a one-line pointer to the design.
+ * The error message carries a pointer to the recovery design docs.
  */
 export class RecoveryNotEnrolledError extends NoydbError {
   constructor(
@@ -57,7 +56,7 @@ export class RecoveryNotEnrolledError extends NoydbError {
 
 /**
  * Raised by `openVault` when a managed-passphrase-mode vault has no
- * STRONG recovery profile enrolled (#195).
+ * STRONG recovery profile enrolled.
  *
  * Managed mode means the user never types a passphrase — the unlock
  * material lives in a `SealingKeyProvider` (`at-*` package). If that
@@ -97,9 +96,8 @@ export class ManagedRecoveryNotEnrolledError extends NoydbError {
  * `db.rotateRecovery` when the developer requests a recovery profile
  * not yet wired in this hub release.
  *
- * Implemented: `paper` (#10, pre.5) and `shamir` (#196 slice 1, pre.16).
- * Pending: `multi-channel` and `admin-mediated` (tracked under #196
- * follow-up slices).
+ * Implemented: `paper` and `shamir`.
+ * Pending: `multi-channel` and `admin-mediated` (follow-up slices).
  *
  * The carried `profile` and `tracking` fields let consumers steer the
  * UI ("multi-channel recovery is not yet wired up — open issue #N to follow").

--- a/packages/hub/src/policy/presets.ts
+++ b/packages/hub/src/policy/presets.ts
@@ -39,9 +39,9 @@ export const PERSONAL_POLICY: VaultPolicy = Object.freeze({
       minTier: 1,
       enabled: true,
     },
-    // rotate-recovery (#121): deliberate paper-sheet regeneration
-    // when the user remembers their passphrase. PERSONAL matches the
-    // pre-#121 low-level flow's bar — knowing the passphrase is enough.
+    // rotate-recovery: deliberate paper-sheet regeneration
+    // when the user remembers their passphrase. PERSONAL allows tier-1 —
+    // knowing the passphrase is enough.
     'rotate-recovery': { minTier: 1 },
     'enroll-authenticator': { minTier: 1 },
     'remove-authenticator': { minTier: 1 },
@@ -75,7 +75,7 @@ export const PERSONAL_POLICY: VaultPolicy = Object.freeze({
       minTier: 1,
       enabled: false,
     },
-    // ─── User envelope gates (#22) ────────────────────────────────────
+    // ─── User envelope gates ──────────────────────────────────────────
     // edit-own-profile: tier 3 floor — any active session can edit their
     //   own profile/preferences. Tightening to require a TOTP for
     //   profile changes is a one-line override.
@@ -110,7 +110,7 @@ export const STRICT_POLICY: VaultPolicy = Object.freeze({
       minTier: 1,
       enabled: true,
     },
-    // rotate-recovery (#121): STRICT requires an off-device factor —
+    // rotate-recovery: STRICT requires an off-device factor —
     // rotating recovery is an off-site-trust event; a stolen unlocked
     // laptop must not be able to silently mint a new sheet for the
     // attacker. Matches the `peer-recover-user` STRICT default.
@@ -183,7 +183,7 @@ export const STRICT_POLICY: VaultPolicy = Object.freeze({
       minTier: 1,
       enabled: false,
     },
-    // ─── User envelope gates (#22) ────────────────────────────────────
+    // ─── User envelope gates ──────────────────────────────────────────
     // STRICT: profile edits require a TOTP/email-OTP factor (typical
     // shared-workstation hardening — your name/avatar shouldn't change
     // without a fresh second-factor proof).

--- a/packages/hub/src/policy/types.ts
+++ b/packages/hub/src/policy/types.ts
@@ -1,5 +1,5 @@
 /**
- * Policy gate DSL types — issue #9.
+ * Policy gate DSL types.
  *
  * Sensitive operations (rotate the passphrase, enroll an authenticator,
  * export plaintext, grant a user, …) are gated by a typed policy
@@ -34,12 +34,10 @@ import type { PassphrasePolicy } from '../validation.js'
  * devices — policies can require ANY of them or insist on a count of 2
  * to force a mix.
  *
- * Added in pre.8 (#30): `webauthn-platform`, `password`, `pin` —
- * previously consumers with no off-device infrastructure (no TOTP,
- * no email-OTP, paper recovery not enrolled) had to disable the
- * factor requirement entirely on `rotate-passphrase`. Now they can
- * pin "any second factor I have wired" without losing the freshness
- * guarantee.
+ * `webauthn-platform`, `password`, `pin` — for consumers with no
+ * off-device infrastructure (no TOTP, no email-OTP, paper recovery not
+ * enrolled) who want to require "any second factor I have wired"
+ * without losing the freshness guarantee.
  */
 export type FactorKind =
   | 'totp'
@@ -99,7 +97,7 @@ export type BuiltInGateName =
   | 'remove-authenticator'
   /**
    * Authorize a deliberate paper-recovery-code regeneration —
-   * `db.rotateRecovery` (#121). Symmetric to `rotate-passphrase` for
+   * `db.rotateRecovery`. Symmetric to `rotate-passphrase` for
    * the case where the user remembers their passphrase but wants a
    * fresh sheet (lost the printout, suspect compromise of the off-site
    * copy). PERSONAL allows tier-1; STRICT requires an off-device
@@ -109,7 +107,7 @@ export type BuiltInGateName =
   | 'rotate-recovery'
   /**
    * Authorize a meta-only mutation on an existing authenticator slot —
-   * `db.updateAuthenticator` (#55). The slot's wrap material, id, and
+   * `db.updateAuthenticator`. The slot's wrap material, id, and
    * method are immutable through this gate; only the `meta` blob
    * (nicknames, method-specific labels) can change. Anti-slot-swap
    * guard is preserved structurally regardless of this gate's
@@ -122,12 +120,12 @@ export type BuiltInGateName =
   | 'export-bundle'
   | 'export-plaintext'
   | 'view-user-auth'
-  /** Authorize a write to one's own user envelope (#22). */
+  /** Authorize a write to one's own user envelope. */
   | 'edit-own-profile'
-  /** Authorize reading other principals' user envelopes (#22). */
+  /** Authorize reading other principals' user envelopes. */
   | 'view-team-profiles'
   /**
-   * Authorize an atomic peer-recovery — `db.recoverUser` (#33, #34).
+   * Authorize an atomic peer-recovery — `db.recoverUser`.
    * Distinct from `revoke-user` because peer-recovery is intentional
    * re-issuance of someone's keyring under a temp passphrase, NOT
    * removal. Allows owner→owner natively (matches the threat model:
@@ -137,7 +135,7 @@ export type BuiltInGateName =
    */
   | 'peer-recover-user'
   /**
-   * Authorize a post-grant identity mutation — `db.updateUser` (#54).
+   * Authorize a post-grant identity mutation — `db.updateUser`.
    * Covers `role`, `displayName`, `permissions` changes on an existing
    * keyring. Pure plaintext-header rewrite — no DEKs touched, no KEK
    * required. The role-elevation guard inside the implementation
@@ -152,7 +150,7 @@ export type GateName = BuiltInGateName | `app:${string}`
 /**
  * Top-level policy object. Persisted at `_meta/policy` once at vault
  * creation. The `passphrase` block configures the strength rules
- * applied at every passphrase ingress (issue #7); `gates` configures
+ * applied at every passphrase ingress; `gates` configures
  * the action-level requirements.
  */
 export interface VaultPolicy {
@@ -178,7 +176,7 @@ export interface FactorProof {
  * `db.recoverUser`, `db.enrollUnlock`, `db.describeUserAuth`,
  * `db.describeAllUsersAuth`.
  *
- * Pre-#89 this type was inlined at every call site as
+ * Previously this type was inlined at every call site as
  * `{ factors?: ReadonlyArray<FactorProof>; sharedDevice?: boolean }`
  * and parameter names alternated between `factors` and `presented`.
  * Now exported so consumers can name their helpers and so the param

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -98,7 +98,7 @@ interface InternalSource {
  * error. See `query/join.ts` for the full design.
  */
 /**
- * Declared deterministic predicate (#153). Carries the consumer's
+ * Declared deterministic predicate. Carries the consumer's
  * stable `hash` (for function-body identity), the function itself,
  * and is keyed by name when registered on a `Query<T>` via
  * `_withPredicates()`.
@@ -150,7 +150,7 @@ export class Query<T> {
   /**
    * @internal — clone this Query with a declared-predicate map
    * attached. Used by the materialized-view registry to enable
-   * `.wherePredicate(name, ctx?)` for the MV's query callback (#153).
+   * `.wherePredicate(name, ctx?)` for the MV's query callback.
    * Consumers don't call this directly.
    */
   _withPredicates(predicates: ReadonlyMap<string, DeclaredPredicate>): Query<T> {
@@ -164,7 +164,7 @@ export class Query<T> {
   }
 
   /**
-   * Filter by a registered deterministic predicate (#153). Requires
+   * Filter by a registered deterministic predicate. Requires
    * the Query to have been augmented with a predicates map (typically
    * via the materialized-view registry — bare Queries constructed
    * outside an MV throw on `.wherePredicate()`).
@@ -939,10 +939,8 @@ function serializeClause(clause: Clause): unknown {
     // identity-carrying fields so distinct predicates still serialize
     // distinctly. `predicateHash` + `ctxHash` are the hash identity;
     // `name` is the named predicate reference. This matters because
-    // niwat-review of #159 caught that the previous fall-through
-    // (return clause) exposed the live fn and produced identical
-    // serializations for distinct predicates with different ctx
-    // values.
+    // A previous fall-through (return clause) exposed the live fn and produced
+    // identical serializations for distinct predicates with different ctx values.
     return {
       type: 'wherePredicate',
       name: clause.name,

--- a/packages/hub/src/query/predicate.ts
+++ b/packages/hub/src/query/predicate.ts
@@ -43,7 +43,7 @@ export interface FilterClause {
 }
 
 /**
- * A declared deterministic predicate reference (#153). The query
+ * A declared deterministic predicate reference. The query
  * builder produces this via `.wherePredicate(name, ctx?)` when a
  * Query has been augmented with a predicates map (typically by the
  * materialized-view registry — see MV v2 spec § Function-based

--- a/packages/hub/src/schema-update/client-registry.ts
+++ b/packages/hub/src/schema-update/client-registry.ts
@@ -1,5 +1,5 @@
 /**
- * Schema-cutover client registry (#232 sub-slice 3b). Each client keeps a
+ * Schema-cutover client registry. Each client keeps a
  * heartbeat doc at `_meta/schema-fence:client:<clientId>` carrying its
  * liveness (`lastSeen`) and the fence generation it has quiesced for
  * (`quiescedAtVersion`). Plaintext envelope, like the fence doc.

--- a/packages/hub/src/schema-update/cutover.ts
+++ b/packages/hub/src/schema-update/cutover.ts
@@ -1,4 +1,4 @@
-/** The coordinatedCutover update strategy (#232, single-step — no from/to). */
+/** The coordinatedCutover update strategy (single-step — no from/to). */
 import type { SchemaUpdateStrategy, SchemaDelta, TransformFn } from './types.js'
 
 export function coordinatedCutover(opts: { readonly transform: TransformFn }): SchemaUpdateStrategy {

--- a/packages/hub/src/schema-update/delta.ts
+++ b/packages/hub/src/schema-update/delta.ts
@@ -1,5 +1,5 @@
 /**
- * Classify the difference between two derived JSON Schemas (#245).
+ * Classify the difference between two derived JSON Schemas.
  *
  * v1 ruleset — top-level object properties + required-ness:
  *   - additive  ⇔ only new OPTIONAL properties (no removals, no changed

--- a/packages/hub/src/schema-update/dispatch.ts
+++ b/packages/hub/src/schema-update/dispatch.ts
@@ -1,4 +1,4 @@
-/** Ordered strategy evaluation (#245): first non-`allow` decision wins. */
+/** Ordered strategy evaluation: first non-`allow` decision wins. */
 import type { SchemaDelta, SchemaUpdateStrategy, UpdateContext, UpdateDecision } from './types.js'
 
 export async function evaluateStrategies(

--- a/packages/hub/src/schema-update/fence-controller.ts
+++ b/packages/hub/src/schema-update/fence-controller.ts
@@ -1,5 +1,5 @@
 /**
- * Vault-level schema-fence controller (#232).
+ * Vault-level schema-fence controller.
  *
  * Owns the open-time generation snapshot, the pending-cutover registry,
  * and the cutover orchestration. 3a: single-client (the caller is the

--- a/packages/hub/src/schema-update/fence-watcher.ts
+++ b/packages/hub/src/schema-update/fence-watcher.ts
@@ -1,7 +1,7 @@
 /**
- * Per-client schema-fence watcher (#232 sub-slice 3b). Polls the fence;
+ * Per-client schema-fence watcher. Polls the fence;
  * on `draining` it drains in-flight writes and acks; emits a same-instance
- * signal on every state transition (for #233's UI). Driven by an interval
+ * signal on every state transition (for UI). Driven by an interval
  * in production and by explicit `check()`/`beat()` in tests.
  */
 import type { NoydbStore } from '../types.js'

--- a/packages/hub/src/schema-update/fence.ts
+++ b/packages/hub/src/schema-update/fence.ts
@@ -1,5 +1,5 @@
 /**
- * Schema-fence document (#232). Vault-level generation counter + drain
+ * Schema-fence document. Vault-level generation counter + drain
  * state, stored at `_meta/schema-fence` using the plaintext-envelope
  * pattern of `_meta/policy` (no PII — a counter + a state enum).
  */

--- a/packages/hub/src/schema-update/gate.ts
+++ b/packages/hub/src/schema-update/gate.ts
@@ -1,5 +1,5 @@
 /**
- * Per-collection write gate (#245). Holds the (async) update decision
+ * Per-collection write gate. Holds the (async) update decision
  * computed at registration; `Collection.put`/`delete` await it before
  * writing and throw the strategy's rejection error.
  *
@@ -23,6 +23,6 @@ export class SchemaUpdateGate {
     if (decision && decision.action === 'reject') {
       throw decision.error
     }
-    // 'cutover' write-gating is handled by #232's coordinatedCutover.
+    // 'cutover' write-gating is handled by coordinatedCutover.
   }
 }

--- a/packages/hub/src/schema-update/strategies.ts
+++ b/packages/hub/src/schema-update/strategies.ts
@@ -1,4 +1,4 @@
-/** Bundled light update strategies (#245). */
+/** Bundled light update strategies. */
 import { NonAdditiveSchemaChangeError, SchemaLockedError } from '../errors.js'
 import type { SchemaUpdateStrategy, SchemaDelta } from './types.js'
 

--- a/packages/hub/src/schema-update/types.ts
+++ b/packages/hub/src/schema-update/types.ts
@@ -1,5 +1,5 @@
 /**
- * Schema-update strategy framework types (#245, M12 §3a).
+ * Schema-update strategy framework types (M12 §3a).
  *
  * The hub core detects a schema change (SchemaDelta) and dispatches it
  * through a collection's ordered strategy list. Strategies decide what
@@ -32,14 +32,14 @@ export interface UpdateContext {
   readonly collection: string
 }
 
-/** Bulk transform run by the coordinatedCutover strategy (#232). */
+/** Bulk transform run by the coordinatedCutover strategy. */
 export type TransformFn = (doc: Record<string, unknown>) => Record<string, unknown>
 
 /**
  * A strategy's verdict on a detected schema change.
  * - `allow`   — no objection; the dispatcher falls through to the next strategy.
  * - `reject`  — terminal: refuse the change; `error` is thrown at the write path.
- * - `cutover` — terminal: run a coordinated drain-barrier (handled by #232).
+ * - `cutover` — terminal: run a coordinated drain-barrier (handled by coordinatedCutover).
  * New terminal actions may be added without breaking existing strategies.
  */
 export type UpdateDecision =

--- a/packages/hub/src/session/index.ts
+++ b/packages/hub/src/session/index.ts
@@ -10,7 +10,7 @@
  * backward compatibility through.x.
  *
  * NOTE: magic-link helpers are expected to extract into a new
- * `@noy-db/on-magic-link` package per Fork · On #8. Until that lands,
+ * `@noy-db/on-magic-link` package. Until that lands,
  * they live here alongside session primitives.
  */
 

--- a/packages/hub/src/session/unlock-state.ts
+++ b/packages/hub/src/session/unlock-state.ts
@@ -1,5 +1,5 @@
 /**
- * Per-vault tier-3 (PIN / quick-resume) state — issue #11.
+ * Per-vault tier-3 (PIN / quick-resume) state.
  *
  * The hub holds a `PinResumeState`-shaped record in memory, keyed by
  * vault. `enrollUnlock` populates it; `unlockViaPin` consumes it via

--- a/packages/hub/src/subsystem-bus.ts
+++ b/packages/hub/src/subsystem-bus.ts
@@ -1,0 +1,69 @@
+/**
+ * Generic per-instance **observe** bus (Track A, slice 1). Observe-class
+ * subsystems (devtools inspector, audit, sync-dirty notification) register
+ * handlers against named lifecycle points instead of the kernel naming each
+ * subsystem. Mirrors the registry pattern of {@link WriteHookRegistry} but is
+ * internal and keyed by lifecycle point.
+ *
+ * OBSERVE SEMANTICS: handlers react to a write that already happened. A
+ * handler throw is warned, not propagated — it can never abort a write. Write-
+ * *gating* subsystems (guards, periods) need the separate throw-propagating
+ * gate bus (`beforePut`/`beforeDelete`, dispatched from `putInternal`); that is
+ * NOT this primitive. Add observe points by extending {@link LifecycleEventMap}.
+ *
+ * @module
+ */
+import type { WriteEvent } from './write-hooks.js'
+
+/** Typed map of OBSERVE lifecycle point → event payload. Extend by adding keys. */
+export interface LifecycleEventMap {
+  afterPut: WriteEvent
+}
+
+export type LifecyclePoint = keyof LifecycleEventMap
+export type BusHandler<P extends LifecyclePoint> = (event: LifecycleEventMap[P]) => void | Promise<void>
+export type Unsubscribe = () => void
+
+type AnyHandler = (event: unknown) => void | Promise<void>
+
+export class SubsystemBus {
+  readonly #handlers = new Map<LifecyclePoint, AnyHandler[]>()
+
+  /** Register a handler for an observe point. Returns an unsubscribe fn. */
+  register<P extends LifecyclePoint>(point: P, handler: BusHandler<P>): Unsubscribe {
+    let arr = this.#handlers.get(point)
+    if (!arr) { arr = []; this.#handlers.set(point, arr) }
+    arr.push(handler as AnyHandler)
+    return () => {
+      const a = this.#handlers.get(point)
+      if (!a) return
+      const i = a.indexOf(handler as AnyHandler)
+      if (i >= 0) a.splice(i, 1)
+    }
+  }
+
+  /** Cheap gate for the write path — true when any handler is registered for the point. */
+  hasHandlers(point: LifecyclePoint): boolean {
+    const a = this.#handlers.get(point)
+    return a !== undefined && a.length > 0
+  }
+
+  /**
+   * Dispatch in registration order, awaited. Per-handler errors are warned, not
+   * thrown — an observe handler must never abort a completed write.
+   */
+  async dispatch<P extends LifecyclePoint>(point: P, event: LifecycleEventMap[P]): Promise<void> {
+    const a = this.#handlers.get(point)
+    if (!a || a.length === 0) return
+    for (const h of a.slice()) {
+      try {
+        await h(event)
+      } catch (err) {
+        console.warn(
+          `[noy-db] subsystem observe handler failed at ${point} for ${event.collection}/${event.docId}: ` +
+          (err instanceof Error ? err.message : String(err)),
+        )
+      }
+    }
+  }
+}

--- a/packages/hub/src/subsystem-bus.ts
+++ b/packages/hub/src/subsystem-bus.ts
@@ -28,6 +28,7 @@ type AnyHandler = (event: unknown) => void | Promise<void>
 
 export class SubsystemBus {
   readonly #handlers = new Map<LifecyclePoint, AnyHandler[]>()
+  #dispatching = false
 
   /** Register a handler for an observe point. Returns an unsubscribe fn. */
   register<P extends LifecyclePoint>(point: P, handler: BusHandler<P>): Unsubscribe {
@@ -48,22 +49,32 @@ export class SubsystemBus {
     return a !== undefined && a.length > 0
   }
 
+  /** True while handlers are running — lets the write path skip nested firing, mirroring WriteHookRegistry.#suppressed. */
+  get dispatching(): boolean { return this.#dispatching }
+
   /**
    * Dispatch in registration order, awaited. Per-handler errors are warned, not
-   * thrown — an observe handler must never abort a completed write.
+   * thrown — an observe handler must never abort a completed write. A
+   * re-entrancy guard suppresses nested firing so a handler that itself writes
+   * cannot loop (same rationale as WriteHookRegistry.#suppressed).
    */
   async dispatch<P extends LifecyclePoint>(point: P, event: LifecycleEventMap[P]): Promise<void> {
     const a = this.#handlers.get(point)
-    if (!a || a.length === 0) return
-    for (const h of a.slice()) {
-      try {
-        await h(event)
-      } catch (err) {
-        console.warn(
-          `[noy-db] subsystem observe handler failed at ${point} for ${event.collection}/${event.docId}: ` +
-          (err instanceof Error ? err.message : String(err)),
-        )
+    if (!a || a.length === 0 || this.#dispatching) return
+    this.#dispatching = true
+    try {
+      for (const h of a.slice()) {
+        try {
+          await h(event)
+        } catch (err) {
+          console.warn(
+            `[noy-db] subsystem observe handler failed at ${point}: ` +
+            (err instanceof Error ? err.message : String(err)),
+          )
+        }
       }
+    } finally {
+      this.#dispatching = false
     }
   }
 }

--- a/packages/hub/src/subsystem-bus.ts
+++ b/packages/hub/src/subsystem-bus.ts
@@ -1,5 +1,5 @@
 /**
- * Generic per-instance **observe** bus (Track A, slice 1). Observe-class
+ * Generic per-instance **observe** bus. Observe-class
  * subsystems (devtools inspector, audit, sync-dirty notification) register
  * handlers against named lifecycle points instead of the kernel naming each
  * subsystem. Mirrors the registry pattern of {@link WriteHookRegistry} but is

--- a/packages/hub/src/subsystem-bus.ts
+++ b/packages/hub/src/subsystem-bus.ts
@@ -28,7 +28,7 @@ type AnyHandler = (event: unknown) => void | Promise<void>
 
 export class SubsystemBus {
   readonly #handlers = new Map<LifecyclePoint, AnyHandler[]>()
-  #dispatching = false
+  #depth = 0
 
   /** Register a handler for an observe point. Returns an unsubscribe fn. */
   register<P extends LifecyclePoint>(point: P, handler: BusHandler<P>): Unsubscribe {
@@ -49,8 +49,18 @@ export class SubsystemBus {
     return a !== undefined && a.length > 0
   }
 
-  /** True while handlers are running — lets the write path skip nested firing, mirroring WriteHookRegistry.#suppressed. */
-  get dispatching(): boolean { return this.#dispatching }
+  /**
+   * True while one or more dispatches are in flight. Backed by a depth counter
+   * so that two concurrent async dispatches (`Promise.all([put('a'), put('b')])`
+   * each captured `busAfterPut=true` at their respective put() tops while depth
+   * was 0) both proceed independently — the counter stays > 0 until BOTH finish,
+   * so any nested write attempted by a handler still sees `dispatching === true`
+   * and is suppressed by the write-path gate in `collection.ts`
+   * (`busAfterPut = hasHandlers('afterPut') && !dispatching`). Re-entrancy
+   * suppression lives exclusively on that write-path gate; concurrent independent
+   * dispatches must not drop each other's events.
+   */
+  get dispatching(): boolean { return this.#depth > 0 }
 
   /**
    * Dispatch in registration order, awaited. Per-handler errors are warned, not
@@ -60,8 +70,8 @@ export class SubsystemBus {
    */
   async dispatch<P extends LifecyclePoint>(point: P, event: LifecycleEventMap[P]): Promise<void> {
     const a = this.#handlers.get(point)
-    if (!a || a.length === 0 || this.#dispatching) return
-    this.#dispatching = true
+    if (!a || a.length === 0) return
+    this.#depth++
     try {
       for (const h of a.slice()) {
         try {
@@ -74,7 +84,7 @@ export class SubsystemBus {
         }
       }
     } finally {
-      this.#dispatching = false
+      this.#depth--
     }
   }
 }

--- a/packages/hub/src/tab-coordination.ts
+++ b/packages/hub/src/tab-coordination.ts
@@ -1,5 +1,5 @@
 /**
- * Multi-tab coordination (#228a): primary/secondary election (Web Locks)
+ * Multi-tab coordination: primary/secondary election (Web Locks)
  * + presence heartbeat (BroadcastChannel). Browser-only; opt-in; no-op
  * when the APIs are absent. The lock/channel interfaces are hub-local
  * (structurally compatible with @noy-db/by-peer + @noy-db/by-tabs, but
@@ -39,13 +39,13 @@ export interface TabCoordinationOptions {
    */
   readonly closeChannelOnDispose?: boolean
   /**
-   * Also propagate committed writes to other tabs (#228b). Default true:
+   * Also propagate committed writes to other tabs. Default true:
    * when tab coordination is enabled and a channel is available, a write in
    * one tab refreshes that document in every other tab. Set false to opt out.
    */
   readonly propagateWrites?: boolean
   /**
-   * Channel for write propagation (#228b) — distinct from the presence
+   * Channel for write propagation — distinct from the presence
    * channel. Default: an inline BroadcastChannel on `noydb:tab-writes`.
    */
   readonly writeChannel?: TabChannel

--- a/packages/hub/src/tab-write-relay.ts
+++ b/packages/hub/src/tab-write-relay.ts
@@ -1,7 +1,7 @@
 /**
- * Cross-tab write propagation (#228b). A role-agnostic relay: it broadcasts
+ * Cross-tab write propagation. A role-agnostic relay: it broadcasts
  * a ciphertext-blind signal ({vault, collection, docId, action}) for every
- * locally-committed write (via onAfterWrite, #230), and on receiving a peer
+ * locally-committed write (via onAfterWrite), and on receiving a peer
  * tab's signal it asks the host to refresh that document's in-memory view by
  * re-reading the shared encrypted store. Nothing decrypted crosses the wire.
  */
@@ -28,7 +28,7 @@ export interface CrossTabWriteRelayOptions {
   readonly subscribeAfterWrite: (handler: (e: WriteEvent) => void) => Unsubscribe
   /** Refresh a document's in-memory view from the shared store. */
   readonly applyRemoteWrite: (vault: string, collection: string, docId: string, action: 'put' | 'delete') => void | Promise<void>
-  /** Report a detected conflict (host captures + converges + emits). #228c. */
+  /** Report a detected conflict (host captures + converges + emits). */
   readonly reportConflict?: (vault: string, collection: string, docId: string, action: 'put' | 'delete', baseV: number, v: number, ownV: number) => void | Promise<void>
   /** Close the channel on dispose (only when the relay created it). Default false. */
   readonly closeChannelOnDispose?: boolean

--- a/packages/hub/src/team/authenticators.ts
+++ b/packages/hub/src/team/authenticators.ts
@@ -1,5 +1,5 @@
 /**
- * Tier-2 authenticator slot management — issue #11.
+ * Tier-2 authenticator slot management.
  *
  * Each slot independently wraps the SAME KEK under a method-specific
  * derived key (LUKS pattern). Enrolling adds a slot; removing drops
@@ -97,15 +97,14 @@ export async function enrollAuthenticator(
 }
 
 /**
- * Caller payload for {@link updateAuthenticator} (#55). Mutates only
+ * Caller payload for {@link updateAuthenticator}. Mutates only
  * `meta` — the slot's id, method, and wrap material are immutable
  * through this primitive, preserving the anti-slot-swap guard.
  *
  * `meta` is **merged** at the top level: keys absent from the patch
  * are preserved, keys present overwrite. To clear a meta key, pass
- * `null` for that key explicitly. (Same semantics as #57's
- * `UserApi.updateMe`, scoped to this top-level merge — no recursion
- * into nested meta values.)
+ * `null` for that key explicitly. (Same top-level merge semantics as
+ * `UserApi.updateMe`, non-recursive — meta is a flat label bag.)
  */
 export interface UpdateAuthenticatorOptions {
   readonly meta?: Record<string, unknown>
@@ -128,7 +127,6 @@ export interface UpdateAuthenticatorOptions {
  * @throws `NoAccessError` when no slot with the given id exists.
  * @throws `ValidationError` when no patch field is provided.
  *
- * @see #55
  */
 export async function updateAuthenticator(
   store: NoydbStore,
@@ -152,9 +150,8 @@ export async function updateAuthenticator(
   }
   const existing = keyring.authenticators[idx]!
 
-  // Merge at the top level. Absent keys preserved (same as #57's
-  // updateMe semantics, but non-recursive — meta is a flat label
-  // bag in practice, no consumer nests it).
+  // Merge at the top level. Absent keys preserved (non-recursive —
+  // meta is a flat label bag in practice, no consumer nests it).
   const mergedMeta: Record<string, unknown> = { ...existing.meta }
   for (const [k, v] of Object.entries(options.meta)) {
     if (v === undefined) continue // skip

--- a/packages/hub/src/team/index.ts
+++ b/packages/hub/src/team/index.ts
@@ -30,7 +30,7 @@ export {
 } from './keyring.js'
 export type { BundleRecipient, ListUsersOptions } from './keyring.js'
 
-// ─── Tier-2 authenticator slots (#11) ───────────────────
+// ─── Tier-2 authenticator slots ─────────────────────────
 export {
   enrollAuthenticator,
   removeAuthenticator,
@@ -44,7 +44,7 @@ export type {
   UpdateAuthenticatorOptions,
 } from './authenticators.js'
 
-// ─── Tier-1 change flows (#10, #29, #36) ────────────────
+// ─── Tier-1 change flows ─────────────────────────────────
 export {
   rotatePassphrase,
   recoverPassphrase,
@@ -58,11 +58,11 @@ export type {
   SlotRewrapCeremony,
 } from './rotate-recover.js'
 
-// ─── Atomic peer-recovery (#33, #34) ────────────────────
+// ─── Atomic peer-recovery ────────────────────────────────
 export { recoverUser } from './peer-recover.js'
 export type { RecoverUserOptions } from './peer-recover.js'
 
-// ─── Paper recovery primitives (#28, #39) ───────────────
+// ─── Paper recovery primitives ───────────────────────────
 export {
   mintPaperRecoveryEntry,
   unwrapDeksFromPaperEntry,
@@ -72,7 +72,7 @@ export {
 } from './recovery.js'
 export type { PaperRecoveryEntry } from './recovery.js'
 
-// ─── Shared wrap-DEKs primitive (#26 Path C, #44) ───────
+// ─── Shared wrap-DEKs primitive ──────────────────────────
 export {
   mintWrappedDeksBlob,
   unwrapDeksFromBlob,

--- a/packages/hub/src/team/keyring.ts
+++ b/packages/hub/src/team/keyring.ts
@@ -64,7 +64,7 @@ function canRevoke(callerRole: Role, targetRole: Role): boolean {
 
 /**
  * Whether `callerRole` can mutate a keyring whose role is (or becomes)
- * `targetRole`. Used by `updateKeyringIdentity` (#54).
+ * `targetRole`. Used by `updateKeyringIdentity`.
  *
  * Mirrors `canGrant`'s hierarchy: admins manage admin/operator/viewer/
  * client laterally; admins cannot create or destroy `owner`-shaped
@@ -97,7 +97,7 @@ export interface UnlockedKeyring {
    *   - Unencrypted mode (no KEK exists)
    *   - Tier-3 PIN quick-resume (`@noy-db/on-pin`)
    *   - Wrap-DEKs tier-2 unlock (`@noy-db/on-password`'s
-   *     `verifyPasswordSlot` after #26 Path C)
+   *     `verifyPasswordSlot`)
    *   - Session-state restore (`session/session.ts`)
    *   - Dev-unlock fixture (`session/dev-unlock.ts`)
    *
@@ -106,9 +106,8 @@ export interface UnlockedKeyring {
    * null-check and throw a clear error if absent — re-authenticate
    * at tier 1 first to recover the KEK.
    *
-   * Tightened from `CryptoKey` to `CryptoKey | null` in pre.8 (#41).
-   * The runtime contract has always allowed null; the type now
-   * matches reality.
+   * Tightened from `CryptoKey` to `CryptoKey | null`; the runtime
+   * contract has always allowed null, the type now matches reality.
    */
   readonly kek: CryptoKey | null
   readonly salt: Uint8Array
@@ -129,7 +128,7 @@ export interface UnlockedKeyring {
   /**
    * Tier-2 authenticator slots — readonly snapshot loaded from the
    * keyring file. Mutations go through `enrollAuthenticator` /
-   * `removeAuthenticator` (issue #11), which write back via
+   * `removeAuthenticator`, which write back via
    * `persistKeyring`. Always defined; loads with an empty array for
    * keyrings written before the multi-slot extension landed.
    */
@@ -142,7 +141,7 @@ export interface UnlockedKeyring {
   readonly policy?: VaultPolicyOnDisk
 }
 
-// ─── Passphrase canary (#113) ──────────────────────────────────────────
+// ─── Passphrase canary ─────────────────────────────────────────────────
 //
 // The canary is a fixed 256-bit AES-GCM key (32 zero bytes), wrapped
 // under the keyring's KEK with AES-KW. Because AES-KW is deterministic
@@ -156,7 +155,7 @@ export interface UnlockedKeyring {
 // this distinguishes wrong-passphrase (canary fails AND every DEK fails)
 // from corruption (canary succeeds OR at least one DEK succeeds) —
 // closing the all-DEKs-corrupt and single-DEK ambiguities that the
-// pre-canary heuristic from #82 / #99 left open.
+// pre-canary heuristic left open.
 
 const CANARY_PLAINTEXT_BYTES = new Uint8Array(32)
 let canaryKeyPromise: Promise<CryptoKey> | null = null
@@ -226,9 +225,9 @@ export async function loadKeyring(
   // KEK is correct independent of any DEK byte — so subsequent DEK
   // unwrap failures are unambiguously corruption, not wrong-pass. A
   // canary failure with at least one DEK success indicates the KEK
-  // is correct but the canary itself is corrupt. (#113)
+  // is correct but the canary itself is corrupt.
   // `null` sentinel = legacy keyring without canary; falls back to the
-  // multi-DEK heuristic from #82 / #99.
+  // multi-DEK heuristic.
   const canaryOk: boolean | null = keyringFile.canary !== undefined
     ? await verifyKeyringCanary(keyringFile.canary, kek)
     : null
@@ -623,7 +622,7 @@ export async function revoke(
   }
 }
 
-// ─── Update User (#54) ─────────────────────────────────────────────────
+// ─── Update User ───────────────────────────────────────────────────────
 
 /**
  * Mutate `role`, `displayName`, and/or `permissions` on an existing
@@ -648,7 +647,6 @@ export async function revoke(
  * @throws `PermissionDeniedError` when the role hierarchy rejects.
  * @throws `ValidationError` when the diff is empty (nothing to update).
  *
- * @see #54
  */
 export async function updateKeyringIdentity(
   adapter: NoydbStore,
@@ -905,7 +903,7 @@ export async function changeSecret(
     // Tier-2 slots are NOT preserved through `changeSecret` —
     // each slot wraps the OLD KEK, so the new keyring has no
     // authenticator slots until the user re-enrolls. The higher-level
-    // `db.rotatePassphrase()` (#10) preserves slots by rewrapping the
+    // `db.rotatePassphrase()` preserves slots by rewrapping the
     // KEK reference, not the KEK itself.
     authenticators: [],
     ...(keyring.policy !== undefined && { policy: keyring.policy }),
@@ -1094,7 +1092,7 @@ export interface ListUsersOptions {
  * `userEnvelopeDek` is the vault's `_users` collection DEK
  * (`vault.getDEK('_users')`); used to decrypt every envelope.
  *
- * `callerRole` (#122) drives the directory-visibility checks:
+ * `callerRole` drives the directory-visibility checks:
  *
  *  - When the vault's `_meta/directory` document has `enabled: false`,
  *    only `owner` and `admin` callers may enumerate; anyone else gets
@@ -1104,7 +1102,7 @@ export interface ListUsersOptions {
  *    `{ includeHidden: true }` to see them; lower roles passing that
  *    option get `PermissionDeniedError`.
  *
- * Honest caveat (#122): these filters are a UX hint, not a security
+ * Honest caveat: these filters are a UX hint, not a security
  * boundary. The keyring file is still listed at `_keyring/*` and the
  * envelope ciphertext at `_users/*`. A caller with direct store access
  * — or a caller that calls this function with `callerRole: 'owner'`
@@ -1177,7 +1175,7 @@ export async function ensureCollectionDEK(
   // check (the Map is empty), both generate fresh DEKs, and the second
   // `set` overwrites the first — making any envelope encrypted with
   // the discarded DEK fail to decrypt later (TamperedError on read).
-  // Pre-existing race exposed by the multi-writer ledger work in #296.
+  // Pre-existing race exposed by the multi-writer ledger work.
   const inFlight = new Map<string, Promise<CryptoKey>>()
   return async (collectionName: string): Promise<CryptoKey> => {
     const existing = keyring.deks.get(collectionName)

--- a/packages/hub/src/team/managed-passphrase.ts
+++ b/packages/hub/src/team/managed-passphrase.ts
@@ -1,5 +1,5 @@
 /**
- * Managed-passphrase mode — issue #14, rubber-hose-resistant vaults.
+ * Managed-passphrase mode — rubber-hose-resistant vaults.
  *
  * A vault mode where the passphrase is machine-generated and never
  * exposed to the user, sealed under a developer-provided
@@ -38,9 +38,9 @@
  *     Returns the plaintext passphrase string that the rest of the
  *     `createNoydb` keyring path consumes.
  *
- * Slice 1 of #14. Deferred to follow-ups:
+ * Deferred to follow-ups:
  *   - Block `rotate-passphrase` policy gate under managed mode.
- *   - Mandatory strong-recovery enforcement (depends on #10).
+ *   - Mandatory strong-recovery enforcement.
  *   - Recovery flow under managed mode (generates fresh sealed phrase).
  *
  * @see docs/subsystems/session-tiers.md → Managed-passphrase mode
@@ -334,12 +334,12 @@ export interface SealedPassphrase {
  *
  * v1 shape (this release): `{ v: 1, _noydb_sealed: 1, pid, payload }`.
  *
- * Legacy shape (pre.14, pre.15): `{ _noydb_sealed: 1, providerId, sealed }`
+ * Legacy shape (earlier releases): `{ _noydb_sealed: 1, providerId, sealed }`
  * — accepted on read for backwards compatibility; never produced on
  * write going forward.
  */
 export interface SealedEnvelope {
-  /** Envelope schema version. v1 is the shape shipped in pre.16. */
+  /** Envelope schema version. v1 is the current shape. */
   readonly v: 1
   /** Magic marker for forensics + legacy-shape detection. */
   readonly _noydb_sealed: 1
@@ -367,9 +367,9 @@ function base64ToBytes(b64: string): Uint8Array {
  * in-memory {@link SealedPassphrase} representation. Accepts both:
  *
  *   1. v1 wire format `{ v: 1, _noydb_sealed: 1, pid, payload }` —
- *      the shape produced from pre.16 onward.
+ *      the current shape.
  *   2. Legacy wire format `{ _noydb_sealed: 1, providerId, sealed }` —
- *      the shape produced in pre.14/pre.15. Read-only; never written
+ *      read-only; never written
  *      going forward.
  *
  * Returns `undefined` for any input that doesn't match either shape,
@@ -395,7 +395,7 @@ export function parseSealedEnvelope(raw: unknown): SealedPassphrase | undefined 
     }
   }
 
-  // Legacy shape — pre.14 / pre.15. Accept on read for compat.
+  // Legacy shape — earlier releases. Accept on read for compat.
   if (
     typeof r.providerId === 'string'
     && typeof r.sealed === 'string'

--- a/packages/hub/src/team/peer-recover.ts
+++ b/packages/hub/src/team/peer-recover.ts
@@ -1,5 +1,5 @@
 /**
- * Atomic peer-recovery primitive — issues #33 + #34.
+ * Atomic peer-recovery primitive.
  *
  * `recoverUser` is a SEPARATE operation from `revoke + grant`. It
  * exists because peer-recovery has different semantics than account
@@ -28,7 +28,7 @@
  *
  * Caller must be at least as privileged as the target. The hub
  * `db.recoverUser` method gates this with the `peer-recover-user`
- * policy gate (#33's factor-proof requirement); the function below
+ * policy gate (the `peer-recover-user` factor-proof requirement); the function below
  * enforces only the role + anti-privilege-escalation invariants.
  *
  * @module
@@ -172,7 +172,7 @@ export async function recoverUser(
   // 6. Build the recovered keyring file. Identity preserved; wrapping
   //    refreshed; tier-2 slots dropped (they wrap the OLD KEK and
   //    can't survive a tier-1 phrase change — same precedent as
-  //    rotatePassphrase). Mint a fresh canary under newKek (#113); the
+  //    rotatePassphrase). Mint a fresh canary under newKek; the
   //    OLD canary on the spread `...target` would fail to verify against
   //    the new KEK and trip KeyringCorruptError on next load.
   const canary = await mintKeyringCanary(newKek)

--- a/packages/hub/src/team/recovery.ts
+++ b/packages/hub/src/team/recovery.ts
@@ -1,7 +1,7 @@
 /**
- * Recovery profile persistence + dispatch — issue #10.
+ * Recovery profile persistence + dispatch.
  *
- * v0.1.0-pre.5 wires the **paper** profile end-to-end through
+ * Wires the **paper** profile end-to-end through
  * `@noy-db/on-recovery`. The other three profiles (Shamir,
  * multi-channel, admin-mediated) ship the API surface and throw
  * {@link RecoveryProfileNotImplementedError} during use; per-profile
@@ -46,7 +46,7 @@ import type { ShamirRecoveryProvider } from './shamir-recovery-provider.js'
  * PBKDF2-derived key), and it sidesteps the non-extractable-KEK
  * constraint cleanly.
  *
- * Type-level composition (#44): `PaperRecoveryEntry extends
+ * Type-level composition: `PaperRecoveryEntry extends
  * WrappedDeksBlob` — the three crypto fields (`salt`, `iv`,
  * `wrappedDeks`) come from the shared primitive; `codeId` and
  * `enrolledAt` are paper-recovery's own metadata. Wire format
@@ -125,15 +125,15 @@ export async function hasRecoveryEnrolled(
 }
 
 /**
- * Whether at least one **strong** recovery profile is enrolled (#195).
+ * Whether at least one **strong** recovery profile is enrolled.
  *
  * "Strong" excludes paper-alone — under managed-passphrase mode the
  * user has no memorized passphrase, so a stolen/lost paper sheet
  * would be a single point of total loss. Strong profiles today:
  *
  *   - `shamir` (k-of-n threshold; survives loss of up to n-k shares)
- *   - `multi-channel` (when shipped — #196 follow-up slice)
- *   - `admin-mediated` (when shipped — #196 follow-up slice)
+ *   - `multi-channel` (when shipped — follow-up slice)
+ *   - `admin-mediated` (when shipped — follow-up slice)
  *
  * Managed mode requires this check to pass before `openVault` returns.
  */
@@ -146,7 +146,7 @@ export async function hasStrongRecoveryEnrolled(
   // When multi-channel / admin-mediated land, extend this check.
 }
 
-// ─── Shamir recovery (#196 slice 1) ──────────────────────────────────────
+// ─── Shamir recovery ─────────────────────────────────────────────────────
 
 /**
  * One Shamir-recovery entry as persisted in `_meta/recovery-shamir`.
@@ -320,7 +320,7 @@ function bytesToBase64(b: Uint8Array): string {
  * {@link savePaperRecoveryEntries}). The recovery flow unwraps the
  * DEK set, then mints a fresh KEK from the user's new passphrase.
  *
- * Thin wrapper over {@link mintWrappedDeksBlob} (#44) — the crypto
+ * Thin wrapper over {@link mintWrappedDeksBlob} — the crypto
  * lives in the shared primitive; this function just adds paper-
  * recovery's own metadata (`codeId`, `enrolledAt`).
  *
@@ -347,7 +347,7 @@ export async function mintPaperRecoveryEntry(
  * Decrypt a recovery entry to recover the raw DEK set. Used by the
  * `recoverPassphrase` flow after the user's code has been parsed.
  *
- * Thin wrapper over {@link unwrapDeksFromBlob} (#44).
+ * Thin wrapper over {@link unwrapDeksFromBlob}.
  *
  * @throws when the code does not match the entry (AES-GCM auth tag fail).
  */
@@ -359,6 +359,6 @@ export async function unwrapDeksFromPaperEntry(
 }
 
 // Legacy crypto helpers (deriveRecoveryWrappingKey, bytesToBase64,
-// base64ToBytes) were inlined here pre-#44. They now live in the
+// base64ToBytes) were previously inlined here. They now live in the
 // canonical wrap-DEKs primitive at `./wrapped-deks.ts` and are
 // reached via `mintWrappedDeksBlob` / `unwrapDeksFromBlob`.

--- a/packages/hub/src/team/rotate-recover.ts
+++ b/packages/hub/src/team/rotate-recover.ts
@@ -1,6 +1,6 @@
 /**
  * Tier-1 change flows — `rotatePassphrase` (user remembers old) and
- * `recoverPassphrase` (user supplies a recovery proof). Issue #10.
+ * `recoverPassphrase` (user supplies a recovery proof).
  *
  * The two flows share the post-verification half — fresh salt, fresh
  * KEK, rewrap every DEK — and differ only in how they re-derive the
@@ -100,10 +100,9 @@ export interface RotatePassphraseInput {
    * Map of slot id → re-enrolment ceremony. Slots whose id appears
    * here are PRESERVED across rotation (the ceremony re-derives the
    * method-specific wrapping under the new keyring); slots whose id
-   * is absent are DROPPED (the pre-#29 behavior).
+   * is absent are DROPPED (the pre-slot-ceremony behavior).
    *
-   * Without this map, `rotatePassphrase` retains the pre-pre.8
-   * behavior of wiping every tier-2 slot. Consumers building a
+   * Without this map, `rotatePassphrase` wipes every tier-2 slot. Consumers building a
    * "rotate without losing my biometric" flow supply ceremonies for
    * each slot they want to keep.
    *
@@ -111,7 +110,7 @@ export interface RotatePassphraseInput {
    * state. Callers wrap individual ceremonies in try/catch + return
    * a sentinel if they want graceful degradation per slot.
    *
-   * Added in pre.8 (#29).
+   * Added when slot-ceremony rewrapping landed.
    */
   readonly slotCeremonies?: { readonly [slotId: string]: SlotRewrapCeremony }
 }
@@ -121,10 +120,10 @@ export interface RotatePassphraseInput {
  * under a freshly-derived KEK from `newPassphrase`, and persist.
  *
  * Tier-2 authenticator slots are dropped UNLESS the caller supplies
- * a `slotCeremonies` map (#29) — each ceremony re-derives its
+ * a `slotCeremonies` map — each ceremony re-derives its
  * method-specific wrapping under the new keyring, and hub persists
  * the rewrapped slots atomically with the rotation. Slots whose id
- * isn't in the map are still dropped (pre-pre.8 behavior).
+ * isn't in the map are still dropped.
  *
  * @throws `InvalidKeyError` if `oldPassphrase` does not unwrap the keyring.
  * @throws `WeakPassphraseError` if `newPassphrase` fails the strength rule.
@@ -165,15 +164,15 @@ export async function rotatePassphrase(
     wrappedDeks[coll] = await wrapKey(dek, newKek)
   }
 
-  // Slot rewrap (#29). Without slotCeremonies, we drop every existing
-  // slot — the pre-pre.8 behavior. With a ceremony map, slots whose
-  // id appears in the map are preserved; the rest are dropped.
+  // Slot rewrap. Without slotCeremonies, we drop every existing
+  // slot. With a ceremony map, slots whose id appears in the map
+  // are preserved; the rest are dropped.
   const oldSlots = file.authenticators ?? []
   const newSlots: KeyringAuthenticator[] = []
   if (input.slotCeremonies && oldSlots.length > 0) {
     for (const oldSlot of oldSlots) {
       const ceremony = input.slotCeremonies[oldSlot.id]
-      if (!ceremony) continue // drop — same as pre-#29 behavior
+      if (!ceremony) continue // drop — not in slotCeremonies map
 
       const result = await ceremony({ newKek, newDeks: deks, oldSlot })
 
@@ -269,7 +268,7 @@ export async function rotatePassphrase(
 /**
  * Caller payload for {@link recoverPassphrase}.
  *
- * As of #196 slice 1, `paper` and `shamir` are wired end-to-end.
+ * `paper` and `shamir` are wired end-to-end.
  * The remaining two profiles (`multi-channel`, `admin-mediated`)
  * stay outside the union and throw
  * {@link RecoveryProfileNotImplementedError} at the runtime guard
@@ -294,7 +293,7 @@ export interface RecoverPassphraseInput {
    * After a successful paper-recovery, replace ALL remaining recovery
    * entries with freshly-minted ones. Defaults to `true` (defensive).
    *
-   * Rationale (issue #36): the user just demonstrated they had access
+   * Rationale: the user just demonstrated they had access
    * to AT LEAST one code. The remaining codes from the same printed
    * sheet may also be compromised — photographed, leaked via a
    * screen-share slip, or in the hands of whoever stole the sheet.
@@ -346,7 +345,7 @@ export interface RecoverPassphraseResult {
 }
 
 /**
- * Input for {@link Noydb.rotateRecovery} (#121) — deliberate
+ * Input for {@link Noydb.rotateRecovery} — deliberate
  * recovery-credential regeneration when the user knows their
  * passphrase but wants a fresh sheet (paper) or fresh shares
  * (shamir). Symmetric to {@link RotatePassphraseInput}.
@@ -402,7 +401,7 @@ export interface EnrollRecoveryResult {
 
 /**
  * Input shape for {@link Noydb.enrollRecovery} and
- * {@link Noydb.openVaultAndEnrollRecovery} (#195). Discriminated
+ * {@link Noydb.openVaultAndEnrollRecovery}. Discriminated
  * union over recovery profiles.
  *
  * - `paper`: caller pre-mints entries (typically via
@@ -428,9 +427,8 @@ export type RecoveryEnrollmentInput =
     }
 
 /**
- * Reset the user's passphrase using a recovery proof. v0.1.0-pre.5
- * supports the `'paper'` profile via `@noy-db/on-recovery` entries
- * persisted in `_meta/recovery-paper`. The other three profiles throw
+ * Reset the user's passphrase using a recovery proof.
+ * Supports `'paper'` and `'shamir'` profiles. The other profiles throw
  * {@link RecoveryProfileNotImplementedError}.
  *
  * On success, the used recovery entry is burned (deleted from the
@@ -447,8 +445,8 @@ export async function recoverPassphrase(
     assertStrongPassphrase(input.newPassphrase, input.passphrasePolicy)
   }
 
-  // Runtime defense-in-depth: the type narrows to 'paper' | 'shamir'
-  // (#86 + #196), but a consumer bypassing TS via
+  // Runtime defense-in-depth: the type narrows to 'paper' | 'shamir',
+  // but a consumer bypassing TS via
   // `as unknown as RecoveryProof` should still hit a clear error
   // rather than silently fall into a handler with a malformed payload.
   const profile = (input.recoveryProof as { profile: string }).profile
@@ -526,7 +524,7 @@ async function recoverViaPaperCode(
   }
 
   // Burn first, then rewrite the keyring. The two writes are not
-  // atomic — if the second fails (#84), the safer ordering is:
+  // atomic — if the second fails, the safer ordering is:
   //
   //   1. Code burned, keyring untouched: user keeps their old passphrase
   //      and loses one recovery code (recoverable: contact admin / use

--- a/packages/hub/src/team/wrapped-deks.ts
+++ b/packages/hub/src/team/wrapped-deks.ts
@@ -1,5 +1,5 @@
 /**
- * **Wrap-DEKs primitive (#44)** — a single canonical shape for the
+ * **Wrap-DEKs primitive** — a single canonical shape for the
  * pattern of "serialize a DEK set, encrypt it under a credential-derived
  * AES-GCM key." Used by:
  *
@@ -17,7 +17,7 @@
  * `PIN_PBKDF2_ITERATIONS` and the threat-model rationale in its
  * module docstring.
  *
- * Before #44, the same crypto lived in two places: `mintPaperRecoveryEntry`
+ * Previously, the same crypto lived in two places: `mintPaperRecoveryEntry`
  * (in `team/recovery.ts`) and `enrollPasswordAuthenticator` (in
  * `@noy-db/on-password`). Both functions did identical work — PBKDF2
  * the credential, AES-GCM-encrypt the JSON-serialized DEK set — but
@@ -53,7 +53,7 @@ const subtle = globalThis.crypto.subtle
  * Composition: `PaperRecoveryEntry extends WrappedDeksBlob` plus
  * `{ codeId, enrolledAt }`. `KeyringAuthenticatorWrappingDEKs`
  * carries the same three fields with `salt` stored in `meta` for
- * slot-format back-compat (#44 defers moving it to top-level).
+ * slot-format back-compat (defers moving it to top-level).
  */
 export interface WrappedDeksBlob {
   /** Base64 PBKDF2 salt for the credential-derived wrapping key. */

--- a/packages/hub/src/tx/dry-run.ts
+++ b/packages/hub/src/tx/dry-run.ts
@@ -1,5 +1,5 @@
 /**
- * Dry-run transactions (#231). Runs the tx body to STAGE ops, then builds
+ * Dry-run transactions. Runs the tx body to STAGE ops, then builds
  * the directly-affected diff (before = current committed via collection.get,
  * after = staged record) and collects guard violations — without executing
  * phase 2. No adapter writes, no write-hooks, no commit. MV/derivation

--- a/packages/hub/src/tx/transaction.ts
+++ b/packages/hub/src/tx/transaction.ts
@@ -81,7 +81,7 @@ export interface StagedOp {
   expectedVersion?: number
   /**
    * Optional human-readable tag forwarded to the resulting ledger
-   * entry's `reason` field (#1). Set by callers via
+   * entry's `reason` field. Set by callers via
    * `tx.vault(v).collection(c).put(id, record, { reason })`.
    */
   reason?: string
@@ -116,7 +116,7 @@ export interface AmendmentTxOptions {
  * facade; its `put`/`delete`/`get` calls stage ops against the tx.
  */
 export class TxContext {
-  /** Stable id for this transaction; shared by all writes it performs (#230). */
+  /** Stable id for this transaction; shared by all writes it performs. */
   readonly txId: string = generateULID()
   /** @internal */
   readonly _ops: StagedOp[] = []
@@ -126,7 +126,7 @@ export class TxContext {
    * restore prior state via `revertExecuted`. Side-effect writes (e.g.
    * recursive derivation outputs fired inside `Collection.put`) are
    * appended here in execution order so they roll back alongside the
-   * main staged ops (#133).
+   * main staged ops.
    */
   readonly _executed: ExecutedOp[] = []
   /** @internal */
@@ -282,7 +282,7 @@ export class TxCollection<T> {
  * in `noydb.ts`. `Collection.putManyAtomic` runs its own Phase 2 loop
  * but shares the `_activeTxContext` mechanism (and the `revertExecuted`
  * helper) so nested side-effect derivation writes get registered for
- * revert alongside the bulk-put source ops (#133).
+ * revert alongside the bulk-put source ops.
  */
 export async function runTransaction<T>(
   db: Noydb,
@@ -360,7 +360,7 @@ export async function runTransaction<T>(
   // duration of Phase 2 so recursive writes triggered inside
   // `Collection.put` (today: eager derivation outputs) can register
   // their own envelopes onto `ctx._executed` and roll back alongside
-  // the main staged ops (#133). The `finally` clears it before the
+  // the main staged ops. The `finally` clears it before the
   // amendment commit phase runs.
   db._setActiveTxContext(ctx)
   try {
@@ -411,7 +411,7 @@ export async function runTransaction<T>(
   if (ctx._amendment) {
     // Lazy-load GuardExecutor at the dispatch site — keeps the floor
     // bundle free of the guards subsystem when amendments aren't used.
-    // Mirrors the deferred-load pattern from #130 elsewhere in this PR.
+    // Mirrors the deferred-load pattern from elsewhere in this module.
     const { GuardExecutor } = (await import('../guards/executor.js')) as {
       GuardExecutor: typeof GuardExecutorModule
     }

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -465,9 +465,9 @@ export interface ImportCapability {
 export type VaultPolicyOnDisk = Record<string, unknown>
 
 /**
- * Recovery profile enrolled at vault creation (issue #10).
+ * Recovery profile enrolled at vault creation.
  *
- * - `paper` — `on-recovery` codes (the only end-to-end profile in v0.1.0-pre.5).
+ * - `paper` — `on-recovery` codes (the standard end-to-end profile).
  * - `shamir` / `multi-channel` / `admin-mediated` — API surface ships;
  *   per-profile dispatch lands in follow-up issues. Calling
  *   `db.recoverPassphrase` against these throws
@@ -536,7 +536,7 @@ interface KeyringAuthenticatorBase {
  * extractable KEK from its own credential — WebAuthn (PRF-derived
  * wrapping key) and split-key OIDC.
  *
- * `wrapKind` is optional/absent on slots written before pre.8 — those
+ * `wrapKind` is optional/absent on older slots — those
  * legacy slots are treated as wrap-KEK by default at unlock time.
  */
 export interface KeyringAuthenticatorWrappingKEK extends KeyringAuthenticatorBase {
@@ -604,11 +604,11 @@ export interface KeyringFile {
   readonly granted_by: string
   /**
    * Passphrase canary — base64 AES-KW-wrapped form of a known constant
-   * 256-bit value, wrapped under the keyring's KEK (#113).
+   * 256-bit value, wrapped under the keyring's KEK.
    *
-   * Optional: pre-#113 keyrings load with no canary and fall back to
-   * the multi-DEK corruption heuristic from #82. Keyrings written after
-   * #113 carry one and let `loadKeyring` distinguish wrong-passphrase
+   * Optional: older keyrings load with no canary and fall back to
+   * the multi-DEK corruption heuristic. Newer keyrings
+   * carry one and let `loadKeyring` distinguish wrong-passphrase
    * from corruption even when ALL DEKs (including a single-DEK keyring's
    * sole DEK) are corrupted.
    *
@@ -849,7 +849,7 @@ export interface Conflict {
 }
 
 /**
- * #228c — a same-device cross-tab write conflict: another tab overwrote a
+ * A same-device cross-tab write conflict: another tab overwrote a
  * document this tab had written, having diverged from an older base. Records
  * are decrypted (cross-tab handlers reconcile in plaintext). `base` is the
  * common ancestor from history, or null when history is unavailable.
@@ -981,8 +981,8 @@ export interface NoydbEventMap {
   'change': ChangeEvent
   'error': Error
   /**
-   * Same-instance signal that this vault's schema-fence state changed
-   * (#232). For UI integration (#233). Cross-client coordination goes
+   * Same-instance signal that this vault's schema-fence state changed.
+   * For UI integration. Cross-client coordination goes
    * through the store, not this event.
    */
   'schema:fence-changed': { vault: string; currentSchemaVersion: number; fenceState: 'normal' | 'draining' | 'migrating' | 'complete' }
@@ -1074,7 +1074,7 @@ export interface GrantOptions {
 }
 
 /**
- * Caller payload for `db.updateUser` (#54). Mutate one or more
+ * Caller payload for `db.updateUser`. Mutate one or more
  * identity fields on an existing keyring without rotating any keys.
  *
  * `role`, `displayName`, and `permissions` live in the plaintext header
@@ -1088,7 +1088,7 @@ export interface GrantOptions {
  * `null` on `displayName` clears the field (stored as the empty string;
  * UI consumers typically render the empty case by falling back to the
  * user id). `undefined` / absent leaves the field untouched. Mirrors
- * the `null`-as-clear convention `UserApi.updateMe` uses (#57).
+ * the `null`-as-clear convention `UserApi.updateMe` uses.
  *
  * `permissions`, however, is a **full replacement** at the map level —
  * passing `{ invoices: 'rw' }` REPLACES the entire permissions map,
@@ -1102,8 +1102,6 @@ export interface GrantOptions {
  * do anything. Non-admin callers (operator/viewer/client) cannot call
  * `db.updateUser` at all — for self-displayName changes, use
  * `vault.user.updateMe` (the user-envelope API).
- *
- * @see #54
  */
 export interface UpdateUserOptions {
   readonly userId: string
@@ -1785,7 +1783,7 @@ export interface NoydbOptions {
    */
   readonly derivationStrategies?: ReadonlyArray<DerivationStrategyHandle>
   /**
-   * Optional materialized-view strategies (#143, foundation in #150).
+   * Optional materialized-view strategies.
    * Each handle returned by `withMaterializedView()` from
    * `@noy-db/hub/materialized-views`. The vault runs unified cycle
    * detection across the MV + derivation graphs at `openVault`; a
@@ -1793,7 +1791,7 @@ export interface NoydbOptions {
    */
   readonly materializedViewStrategies?: ReadonlyArray<MaterializedViewStrategyHandle>
   /**
-   * Optional overlay strategies (#154). Each handle returned by
+   * Optional overlay strategies. Each handle returned by
    * `withOverlayedView()` from `@noy-db/hub/overlay-views`. The vault
    * validates name uniqueness + base concreteness + overlay
    * availability at `openVault`; a clash throws one of the
@@ -1846,7 +1844,7 @@ export interface NoydbOptions {
    */
   readonly getKeyring?: (vault: string) => Promise<UnlockedKeyring>
   /**
-   * Passphrase mode (#14). Default `'standard'`.
+   * Passphrase mode. Default `'standard'`.
    *
    *   - `'standard'` — the legacy flow. `secret` supplies the
    *     plaintext passphrase, the user knows it, and the policy gate
@@ -1907,14 +1905,14 @@ export interface NoydbOptions {
   readonly sessionPolicy?: SessionPolicy
   /**
    * Validate passphrase strength against the phrase format
-   * (`@noy-db/hub` issue #7) on first-time keyring creation. When
+   * on first-time keyring creation. When
    * `true`, weak phrases throw {@link WeakPassphraseError} from
    * `createNoydb()` / `db.rotatePassphrase()`. Default: `false` for
-   * back-compat in v0.1.x; planned to flip to `true` at v1.0.
+   * back-compat; planned to flip to `true` in a future major release.
    */
   readonly validatePassphrase?: boolean
   /**
-   * Vault-level policy gate document (issue #9). When present, the hub
+   * Vault-level policy gate document. When present, the hub
    * persists the merged policy at `_meta/policy` on first-time vault
    * creation and gates sensitive operations (`db.rotatePassphrase`,
    * `db.export*`, …) against it. Omitted ⇒ the engine uses
@@ -1930,14 +1928,14 @@ export interface NoydbOptions {
    */
   readonly policy?: VaultPolicy
   /**
-   * Mandatory recovery profile enrollment (issue #10). Vaults with
+   * Mandatory recovery profile enrollment. Vaults with
    * `recover-passphrase` enabled MUST register at least one profile
    * before being production-ready, otherwise `createNoydb()` throws
    * {@link RecoveryNotEnrolledError}. Set
    * `policy.gates['recover-passphrase'].enabled = false` to
    * deliberately opt out of recovery (passphrase loss = data loss).
    *
-   * v0.1.0-pre.5 supports the `'paper'` profile end-to-end. Other
+   * The `'paper'` profile is supported end-to-end. Other
    * profiles ship the API shape and throw
    * {@link RecoveryProfileNotImplementedError} during use.
    */
@@ -1945,9 +1943,9 @@ export interface NoydbOptions {
   /**
    * When `true`, `createNoydb` rejects vaults with no recovery
    * entries persisted (per the spec's mandatory-enrollment
-   * requirement). Default `false` for v0.1.x back-compat; planned to
-   * flip to `true` at v1.0. Apps in regulated environments should
-   * turn this on now.
+   * requirement). Default `false` for back-compat; planned to
+   * flip to `true` in a future major release. Apps in regulated
+   * environments should turn this on now.
    */
   readonly requireRecovery?: boolean
   /**

--- a/packages/hub/src/validation.ts
+++ b/packages/hub/src/validation.ts
@@ -60,7 +60,6 @@ export interface PassphrasePolicy {
    * double-space). For non-space-delimited word semantics, use
    * {@link customValidator} instead.
    *
-   * Added in pre.8 (#31).
    */
   readonly pattern?: RegExp
   /**
@@ -78,7 +77,6 @@ export interface PassphrasePolicy {
    * {@link assertStrongPassphrase} dispatches on — `ok: true` accepts;
    * `ok: false` throws `WeakPassphraseError` with the supplied reason.
    *
-   * Added in pre.8 (#31).
    */
   readonly customValidator?: (phrase: string) => PassphraseValidationResult
 }

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -677,6 +677,7 @@ export class Vault {
         emitter: this.emitter,
         writeQueue: this.noydb._writeQueueTracker,
         writeHooks: this.noydb._writeHooks,
+        subsystemBus: this.noydb._subsystemBus,
         activeTxId: () => this.noydb._activeTxContextOrNull?.txId ?? null,
         schemaUpdateGate,
         schemaFence: this.schemaFence,

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -74,8 +74,8 @@ import { NO_SYNC, type SyncStrategy } from './team/sync-strategy.js'
 // runtime classes are loaded on demand via `await import(...)` inside
 // `_initGuards` / `_initDerivations` (and the read-only-facade
 // accessor below) so consumers that never register a guard or
-// derivation strategy don't pay the chunk cost. See #130 for the
-// bundle regression this seam plugs.
+// derivation strategy don't pay the chunk cost. This seam prevents
+// the bundle regression that motivated the lazy-import pattern.
 import type { GuardRegistry } from './guards/registry.js'
 import type { GuardStrategyHandleAny } from './guards/types.js'
 import type { ReadOnlyVaultFacade } from './guards/read-only-facade.js'
@@ -166,23 +166,23 @@ export class Vault {
    * `null` for vaults that never register any guard strategy. The
    * runtime class is dynamic-imported on demand so consumers that
    * never use guards don't pull `GuardRegistry`/`GuardExecutor` into
-   * their bundle (#130).
+   * their bundle.
    */
   private guardRegistry: GuardRegistry | null = null
   /**
    * Per-vault derivation registry. Same lazy-load contract as
    * `guardRegistry` — `null` until `_initDerivations()` runs with at
-   * least one strategy handle. See #130 for the bundle motivation.
+   * least one strategy handle.
    */
   private derivationRegistry: DerivationRegistry | null = null
   /**
-   * Per-vault materialized-view registry (#143/#150). Same lazy-load
+   * Per-vault materialized-view registry. Same lazy-load
    * contract as `derivationRegistry` — `null` until
    * `_initMaterializedViews()` runs with at least one MV handle.
    */
   private materializedViewRegistry: MaterializedViewRegistry | null = null
   /**
-   * Per-vault overlay registry (#154). Same lazy-load contract as
+   * Per-vault overlay registry. Same lazy-load contract as
    * `materializedViewRegistry` — `null` until `_initOverlayedViews()`
    * runs with at least one handle.
    */
@@ -204,7 +204,7 @@ export class Vault {
    *   target this vault session's keyringId. There is no method to write
    *   another principal's envelope (own-only write rule, structural).
    * - Read-anyone: `get(keyringId)`, `list()` — read other principals'
-   *   envelopes, subject to the `view-team-profiles` policy gate (#22).
+   *   envelopes, subject to the `view-team-profiles` policy gate.
    * - Reactive: `subscribe(id, cb)`, `live(id)` — fire on local writes.
    *
    * @see docs/superpowers/specs/2026-05-05-user-envelope-design.md
@@ -225,12 +225,12 @@ export class Vault {
    */
   private readonly reloadKeyring: (() => Promise<UnlockedKeyring>) | undefined
   private readonly collectionCache = new Map<string, Collection<unknown>>()
-  /** #232 — vault-level schema cutover fence/controller. */
+  /** Vault-level schema cutover fence/controller. */
   readonly schemaFence: SchemaFenceController
-  /** #232 — per-client heartbeat/watcher; started lazily on cutover registration. */
+  /** Per-client heartbeat/watcher; started lazily on cutover registration. */
   #fenceWatcher: FenceWatcher | undefined
   #fenceCoordinationStarted = false
-  /** #229 — per-collection registered schema-update strategy names. */
+  /** Per-collection registered schema-update strategy names. */
   readonly #schemaUpdateNames = new Map<string, string[]>()
 
   /**
@@ -441,11 +441,10 @@ export class Vault {
     // `_initGuards()` / `_initDerivations()` from `Noydb.openVault()`.
     // The classes are dynamic-imported there so vaults that never
     // register a strategy don't pull the subsystem code into the
-    // floor bundle. See #130. The `opts.guardStrategies` argument is
+    // floor bundle. The `opts.guardStrategies` argument is
     // intentionally accepted but unused on the constructor — the sync
     // `vault()` fallback path in `noydb.ts` does NOT call `_initGuards`,
-    // matching the existing behaviour for `_initDerivations`. See #132
-    // for the follow-up that makes the fallback path async.
+    // matching the existing behaviour for `_initDerivations`.
     void opts.guardStrategies
     this.historyConfig = opts.historyConfig ?? { enabled: true }
     this.reloadKeyring = opts.reloadKeyring
@@ -463,7 +462,7 @@ export class Vault {
     // User envelope API — frozen writerKeyringId, dynamic DEK resolver
     // (so a post-load() keyring refresh transparently rotates the DEK
     // through the rebuilt this.getDEK), and a checkGate callback that
-    // delegates to Noydb's policy engine (#22 wires edit-own-profile +
+    // delegates to Noydb's policy engine (wires edit-own-profile +
     // view-team-profiles).
     this.user = new UserApi(
       this.adapter,
@@ -568,7 +567,7 @@ export class Vault {
      */
     persistJsonSchema?: boolean
     /**
-     * Ordered schema-update strategies (#245). On a detected schema
+     * Ordered schema-update strategies. On a detected schema
      * change, evaluated in order; the first non-`allow` decision wins.
      * A `reject` is enforced at the write path (`put`/`delete` throw).
      * Requires `persistJsonSchema: true` (detection needs the baseline).
@@ -577,12 +576,12 @@ export class Vault {
     /** — declare the per-field schema for document attestation (issue side). */
     attestation?: AttestationFieldSchema
   }): Collection<T> {
-    // Overlay intercept (#154). When the requested collection name
+    // Overlay intercept. When the requested collection name
     // matches a registered `withOverlayedView`, return the virtual
     // proxy that merges base + overlay on read and routes writes to
     // the overlay collection. The proxy implements the core
     // Collection<T> read/write surface (get, list, put, delete);
-    // reactive APIs (live, subscribe) are out of scope for #154.
+    // reactive APIs (live, subscribe) are out of scope.
     const overlayRegistry = this.overlayedViewRegistry
     if (overlayRegistry !== null && overlayRegistry.isOverlay(collectionName)) {
       const spec = overlayRegistry.byName(collectionName)
@@ -636,12 +635,12 @@ export class Vault {
         this.dictKeyFieldRegistry.set(collectionName, dictFieldMap)
       }
 
-      // #229 — capture registered schema-update strategy names for introspection.
+      // Capture registered schema-update strategy names for introspection.
       if ((options?.schemaUpdate?.length ?? 0) > 0) {
         this.#schemaUpdateNames.set(collectionName, (options!.schemaUpdate ?? []).map((s) => s.name))
       }
 
-      // #245 — schema-update gate. Built only when persistence + strategies
+      // Schema-update gate. Built only when persistence + strategies
       // are on. Detection runs in the same work pushed to the drain; the
       // gate caches the decision and the write path (put/delete) enforces it.
       let schemaUpdateGate: SchemaUpdateGate | undefined
@@ -783,7 +782,7 @@ export class Vault {
       // onto _pendingSchemaWrites so tests can drain before asserting;
       // production code ignores it (the writes are idempotent fingerprints).
       // When schemaUpdate strategies are present, persistence already ran
-      // inside the gate's work above (#245) — skip the un-gated path here.
+      // inside the gate's work above — skip the un-gated path here.
       if (
         options?.persistJsonSchema === true &&
         options.schema !== undefined &&
@@ -829,7 +828,7 @@ export class Vault {
   }
 
   /**
-   * Run a coordinated schema cutover (#232). Drains pending writes, waits
+   * Run a coordinated schema cutover. Drains pending writes, waits
    * for the active client set to quiesce (the ack-barrier), applies every
    * pending collection transform in bulk, bumps the vault schema generation,
    * and clears the fence. Returns the count of collections migrated.
@@ -849,9 +848,9 @@ export class Vault {
   }
 
   /**
-   * #228b — refresh a loaded collection's view of one document from a peer
+   * Refresh a loaded collection's view of one document from a peer
    * tab's broadcast. No-op when the collection isn't loaded in this tab
-   * (it will read fresh on next open). Mirrors #runCutoverTransform's guard.
+   * (it will read fresh on next open). Mirrors `#runCutoverTransform`'s guard.
    */
   async _applyRemoteWrite(collectionName: string, docId: string, action: 'put' | 'delete'): Promise<void> {
     const coll = this.collectionCache.get(collectionName)
@@ -860,9 +859,9 @@ export class Vault {
   }
 
   /**
-   * #228c — for a detected conflict: capture this tab's clobbered record,
+   * For a detected conflict: capture this tab's clobbered record,
    * read the common ancestor from history, converge the cache to the store's
-   * authoritative value (the (b) re-read), and return all three for the
+   * authoritative value (the re-read), and return all three for the
    * WriteConflict payload. Returns null when the collection isn't loaded.
    */
   async _captureAndConverge(
@@ -885,17 +884,17 @@ export class Vault {
     return { local, remote, base }
   }
 
-  /** Recover a stuck cutover fence (#232) — reset to normal without bumping. */
+  /** Recover a stuck cutover fence — reset to normal without bumping. */
   async abortSchemaCutover(): Promise<void> {
     await this.schemaFence.abort()
   }
 
-  /** Current schema-cutover fence state for this vault (#232/#233). Thin live read. */
+  /** Current schema-cutover fence state for this vault. Thin live read. */
   async schemaFenceState(): Promise<FenceDoc> {
     return loadFence(this.adapter, this.name)
   }
 
-  /** @internal Start the per-client heartbeat + fence watcher once a cutover is registered (#232). */
+  /** @internal Start the per-client heartbeat + fence watcher once a cutover is registered. */
   _ensureFenceCoordination(): void {
     if (this.#fenceCoordinationStarted) return
     this.#fenceCoordinationStarted = true
@@ -1723,7 +1722,7 @@ export class Vault {
    * Dynamic-imports `GuardRegistry` + `ReadOnlyVaultFacade` and seeds
    * the registry with the supplied strategy handles. No-op when the
    * handles array is empty — keeps the guard subsystem out of the
-   * floor bundle for consumers that don't use guards (#130).
+   * floor bundle for consumers that don't use guards.
    *
    * The read-only facade is eagerly instantiated here so the sync
    * accessor `_getReadOnlyFacade()` (called from the tx amendment
@@ -1757,7 +1756,7 @@ export class Vault {
    * derivation strategies (async because `strategyHash` computation
    * goes through `crypto.subtle.digest`). No-op when the handles
    * array is empty — keeps the derivation subsystem out of the floor
-   * bundle for consumers that don't use derivations (#130). Throws
+   * bundle for consumers that don't use derivations. Throws
    * `DerivationCycleError` if a cycle is detected after registration.
    */
   async _initDerivations(handles: ReadonlyArray<DerivationStrategyHandle>): Promise<void> {
@@ -1794,7 +1793,7 @@ export class Vault {
    * MV spec (which invokes its `query()` once for dependency
    * analysis), then runs the unified cycle detection across the MV +
    * derivation graphs. No-op when the handles array is empty — keeps
-   * the MV subsystem out of the floor bundle (mirrors v1 #130).
+   * the MV subsystem out of the floor bundle (mirrors the derivation lazy-import pattern).
    * Throws `MaterializedViewCycleError` if a cycle is detected.
    */
   async _initMaterializedViews(
@@ -1878,13 +1877,13 @@ export class Vault {
   }
 
   /**
-   * Manual re-materialize for a single registered MV (#151). Useful
+   * Manual re-materialize for a single registered MV. Useful
    * for `refresh: 'manual'` MVs (whose consumer drives refreshes
    * externally), for stale-bit recovery on vault re-open, and as the
    * explicit bulk-recompute escape hatch after a strategy change.
    *
-   * Returns `{ written, deleted, failed }`. `deleted` is always 0 in
-   * foundation + this sub-issue — tombstoning lands in #152.
+   * Returns `{ written, deleted, failed }`. `deleted` is always 0
+   * when tombstoning is not enabled.
    *
    * Throws if `name` is not a registered MV.
    */
@@ -1950,7 +1949,7 @@ export class Vault {
           if (!outSpec) continue
           const outputColl = this.collection(outSpec.collection)
 
-          // Array-shape branch (#200) — diff against the fanout sidecar.
+          // Array-shape branch — diff against the fanout sidecar.
           if (out.kind === 'array') {
             const { loadFanoutSidecar, saveFanoutSidecar } =
               await import('./derivations/fanout-sidecar.js')
@@ -1976,11 +1975,11 @@ export class Vault {
           }
 
           if (out.skipped === true) {
-            // #144: optional output skipped — delete any prior emission.
+            // Optional output skipped — delete any prior emission.
             // No txCtx hookup needed: `deriveAll` runs outside the
             // multi-record transaction window by design. Routed
             // through `_internalDelete` so the bulk recompute does not
-            // trip user `onDelete` (#145) on the output collection.
+            // trip user `onDelete` on the output collection.
             await outputColl._internalDelete(id)
             continue
           }
@@ -2651,7 +2650,7 @@ export class Vault {
   }
 
   /**
-   * Lightweight read of the vault's registered schema (#229): collections
+   * Lightweight read of the vault's registered schema: collections
    * (+ doc counts), guards, materialized views, schema-update strategies,
    * and the unlocked user's grants. Cheap — one `adapter.list` per
    * collection, no decryption. For a full snapshot + stats use dumpSchema().

--- a/packages/hub/src/write-hooks.ts
+++ b/packages/hub/src/write-hooks.ts
@@ -1,5 +1,5 @@
 /**
- * Hub-level write lifecycle hooks (#230). `onBeforeWrite` may abort (throw);
+ * Hub-level write lifecycle hooks. `onBeforeWrite` may abort (throw);
  * `onAfterWrite` is awaited and its errors are warned, not thrown. A
  * re-entrancy flag suppresses nested firing so a handler that writes can't
  * loop. Held on the Noydb instance, threaded into every Collection.
@@ -11,8 +11,8 @@ export interface WriteEvent {
   readonly docId: string
   readonly before: unknown // decrypted prior record; null on 'create'
   readonly after: unknown // the record written; null on 'delete'
-  readonly baseVersion: number // #228c — version the writer started from (0 on create)
-  readonly version: number // #228c — version the writer wrote (baseVersion + 1)
+  readonly baseVersion: number // version the writer started from (0 on create)
+  readonly version: number // version the writer wrote (baseVersion + 1)
   readonly userId: string
   readonly timestamp: number
   readonly txId: string

--- a/packages/hub/src/write-queue.ts
+++ b/packages/hub/src/write-queue.ts
@@ -1,5 +1,5 @@
 /**
- * Observable write-queue (#227, M12 Slice 1).
+ * Observable write-queue.
  *
  * Tracks outstanding in-flight *logical* writes (a full Collection.put /
  * delete, including ledger + cache + derivation + MV dispatch — not just

--- a/packages/in-nuxt/src/module.ts
+++ b/packages/in-nuxt/src/module.ts
@@ -197,7 +197,7 @@ export default defineNuxtModule<ModuleOptions>({
     // When `rest.enabled: true`, mount a catch-all Nitro server handler
     // at `basePath/**`. The handler delegates to `@noy-db/in-rest` via
     // the nitroAdapter. Store wiring (populating event.context.noydbStore)
-    // is a follow-up concern tracked in #273.
+    // is a follow-up concern tracked separately.
     if (options.rest?.enabled) {
       const basePath = options.rest.basePath ?? '/api/noydb'
       addServerHandler({

--- a/packages/in-vue/src/useMigrationState.ts
+++ b/packages/in-vue/src/useMigrationState.ts
@@ -10,7 +10,7 @@ export interface UseMigrationStateReturn {
 }
 
 /**
- * Reactive schema-cutover state (#233). Seeds from the current fence on
+ * Reactive schema-cutover state. Seeds from the current fence on
  * mount, then updates on every `schema:fence-changed` event for `vaultName`
  * (or any vault when omitted). Pass `db` explicitly, or rely on the injected
  * instance (`NoydbPlugin`).

--- a/packages/on-magic-link/src/index.ts
+++ b/packages/on-magic-link/src/index.ts
@@ -479,7 +479,7 @@ export async function readMagicLinkGrant(options: {
 export { MAGIC_LINK_GRANTS_COLLECTION, deriveMagicLinkContentKey }
 export type { MagicLinkGrantPayload }
 
-// ─── Invite + peer-recovery (#32) ─────────────────────────────────
+// ─── Invite + peer-recovery ────────────────────────────────────────
 // Parallel primitives in the same package, layered on top of db.grant
 // (invite mints a NEW user) and db.recoverUser (peer-recovery rewraps
 // an EXISTING user). Different threat model than delegation grants —

--- a/packages/on-magic-link/src/invite.ts
+++ b/packages/on-magic-link/src/invite.ts
@@ -1,5 +1,5 @@
 /**
- * **Invite + peer-recovery primitives** — issue #32.
+ * **Invite + peer-recovery primitives.**
  *
  * Layered on top of `db.grant` (for invite, mints a NEW user) and
  * `db.recoverUser` (for peer-recovery, rewraps an EXISTING user under
@@ -22,8 +22,6 @@
  * - Validate the invite under HTTPS (caller's responsibility)
  * - Coordinate with a server-held secret (delegation grants do that;
  *   invite is server-blind by design)
- *
- * @see #32 #33 #34
  *
  * @module
  */
@@ -148,16 +146,12 @@ export interface AcceptInviteOptions {
    * `noydbOptions` flows to the post-rotation `createNoydb`, not the
    * rotation itself. Passing the same `PassphrasePolicy` here and
    * (via `noydbOptions.policy.passphrase`) keeps both gates aligned.
-   *
-   * Added in pre.9 (#53).
    */
   readonly passphrasePolicy?: PassphrasePolicy
   /**
    * Skip phrase strength validation for the recipient's `newPhrase`.
    * Forwarded to the inner rotation. Use sparingly — bypasses the
    * structural rules that protect against weak phrases.
-   *
-   * Added in pre.9 (#53).
    */
   readonly allowWeakPassphrase?: boolean
 }
@@ -331,7 +325,7 @@ export async function issuePeerRecovery(
 /**
  * Mark an outstanding invite as revoked. After this, `acceptInvite`
  * for the same token rejects with `InviteRevokedError` BEFORE opening
- * any session — closes #32's "revoked-link silent shadow keyring"
+ * any session — closes the "revoked-link silent shadow keyring"
  * defense (without the audit doc check, a revoked link could fall
  * through to `createNoydb`'s no-keyring auto-create path and create
  * a fresh empty vault).
@@ -387,7 +381,7 @@ export async function revokeInvite(
  * @throws {@link InviteRevokedError} when the issuer has revoked.
  * @throws {@link InviteAlreadyAcceptedError} on second call.
  * @throws {@link InviteAuditMissingError} when no audit doc — closes
- *         #32's revoked-link-shadow-keyring defense.
+ *         the revoked-link-shadow-keyring defense.
  */
 export async function acceptInvite(
   encoded: string,
@@ -414,7 +408,7 @@ export async function acceptInvite(
     throw new InviteAlreadyAcceptedError(payload.tokenId, audit.acceptedAt)
   }
 
-  // Atomic rotate inside acceptInvite (per #32 spec). We call the
+  // Atomic rotate inside acceptInvite. We call the
   // team-level `keyringRotatePassphrase` directly rather than going
   // through `db.rotatePassphrase`, which is gated by the
   // `rotate-passphrase` policy gate (PERSONAL_POLICY requires a
@@ -472,7 +466,7 @@ export function decodeInvitePayload(encoded: string): InvitePayload {
 function getStore(db: Noydb): NoydbStore {
   // The store is configured at createNoydb time but not exposed via a
   // public getter; reaching into options is the documented escape
-  // hatch (the same pattern niwat-app uses for direct store access).
+  // hatch (the same pattern used for direct store access).
   return (db as unknown as { options: { store: NoydbStore } }).options.store
 }
 

--- a/packages/on-password/src/index.ts
+++ b/packages/on-password/src/index.ts
@@ -9,13 +9,13 @@
  * - **Different lifecycles** — the phrase rotates yearly; the password
  *   rotates per the developer's policy.
  * - **Different strength rules** — the phrase is validated against the
- *   phrase format (issue #7); the password is validated against a
+ *   phrase format; the password is validated against a
  *   length / regex rule the developer chooses.
  * - **Different storage** — the phrase derives the KEK; the password
  *   derives a wrapping key that wraps the SAME DEK SET in its own
  *   keyring slot (LUKS-like multi-slot, wrap-DEKs variant).
  *
- * ## Wrap-DEKs format (#26 Path C)
+ * ## Wrap-DEKs format (Path C)
  *
  * Slots produced by this package use the wrap-DEKs variant of
  * `KeyringAuthenticator` — they encrypt the serialized DEK set under
@@ -51,7 +51,7 @@ import {
 /**
  * PBKDF2 iteration count — matches the tier-1 phrase derivation.
  * Exported as a documented invariant; the actual derivation lives
- * in hub's canonical wrap-DEKs primitive (#44).
+ * in hub's canonical wrap-DEKs primitive.
  */
 export const PASSWORD_PBKDF2_ITERATIONS = 600_000
 
@@ -148,10 +148,10 @@ export async function enrollPasswordAuthenticator(
     )
   }
 
-  // Delegate the wrap-DEKs crypto to the canonical hub primitive (#44).
+  // Delegate the wrap-DEKs crypto to the canonical hub primitive.
   // The slot envelope still stores `salt` inside `meta` for backward
-  // compatibility with the pre-#44 slot format; the issue defers
-  // moving it to top-level for parity with PaperRecoveryEntry.
+  // compatibility with the legacy slot format; moving it to top-level
+  // for parity with PaperRecoveryEntry is deferred.
   const blob = await mintWrappedDeksBlob(keyring.deks, options.password)
 
   return {
@@ -176,7 +176,7 @@ export async function enrollPasswordAuthenticator(
  *
  * @throws {@link PasswordInvalidError} when the password is wrong or
  *   the slot is not a wrap-DEKs slot (e.g. a legacy wrap-KEK password
- *   slot from before pre.8 — those need re-enrollment).
+ *   legacy wrap-KEK slots — those need re-enrollment).
  */
 export async function unwrapDeksWithPassword(
   slot: KeyringAuthenticator,
@@ -196,10 +196,10 @@ export async function unwrapDeksWithPassword(
     )
   }
 
-  // Delegate to the canonical wrap-DEKs primitive (#44). The blob's
+  // Delegate to the canonical wrap-DEKs primitive. The blob's
   // three fields (salt / iv / wrappedDeks) are reconstructed from
   // the slot's split layout: salt lives in meta, iv + wrappedDeks
-  // at top level. Pre-#44, this code re-implemented the same crypto
+  // at top level. Previously, this code re-implemented the same crypto
   // inline.
   try {
     return await unwrapDeksFromBlob(
@@ -292,10 +292,10 @@ export interface VerifyPasswordSlotOptions {
 
 /**
  * `SlotRewrapCeremony` factory for password slots — the password parallel
- * to `webAuthnSlotRewrapCeremony` (#56). Used by hub's
+ * to `webAuthnSlotRewrapCeremony`. Used by hub's
  * `rotatePassphrase({ slotCeremonies: { [slotId]: passwordSlotRewrapCeremony(pwd) } })`
  * to preserve a tier-2 password enrollment across a tier-1 phrase
- * rotation without forcing the user to re-enroll the password (#96).
+ * rotation without forcing the user to re-enroll the password.
  *
  * Returns a closure capturing the password so the result matches
  * hub's `SlotRewrapCeremony` signature `(ctx) => Promise<EnrollAuthenticatorOptions>`
@@ -330,7 +330,7 @@ export interface VerifyPasswordSlotOptions {
  *      `id` + `method` + `wrapKind` to prevent slot-type swap mid-
  *      rotation.
  *
- * Pre-pre.8 wrap-KEK password slots (legacy) cannot be rewrapped via
+ * Legacy wrap-KEK password slots cannot be rewrapped via
  * this ceremony — they must be re-enrolled fresh via
  * {@link enrollPasswordAuthenticator}. The validation throws
  * {@link ValidationError} for those.
@@ -340,8 +340,7 @@ export interface VerifyPasswordSlotOptions {
  * @throws {PasswordTooWeakError} when the supplied password fails the
  *         strength rules carried in `oldSlot.meta` (minLength, pattern).
  *
- * @see #56 webAuthnSlotRewrapCeremony — the WebAuthn parallel.
- * @see #29 — the slotCeremonies plumbing this fills in.
+ * @see webAuthnSlotRewrapCeremony — the WebAuthn parallel.
  */
 export function passwordSlotRewrapCeremony(password: string): SlotRewrapCeremony {
   return async (ctx: SlotRewrapContext): Promise<EnrollAuthenticatorOptions> => {
@@ -385,5 +384,5 @@ export function passwordSlotRewrapCeremony(password: string): SlotRewrapCeremony
 }
 
 // All wrap-DEKs crypto helpers (PBKDF2 derivation, base64
-// codecs) moved to hub's `team/wrapped-deks.ts` in #44 — both this
-// package and `mintPaperRecoveryEntry` now share one implementation.
+// codecs) live in hub's `team/wrapped-deks.ts` — both this
+// package and `mintPaperRecoveryEntry` share one implementation.

--- a/packages/on-recovery/src/index.ts
+++ b/packages/on-recovery/src/index.ts
@@ -8,7 +8,7 @@
  *
  * Part of the `@noy-db/on-*` authentication family.
  *
- * ## Format (post pre.8, #38 Option A)
+ * ## Format (Option A)
  *
  * This package is now a **thin code-generator + parser layer over
  * the hub's `mintPaperRecoveryEntry` primitive**. Its job is exactly
@@ -23,8 +23,8 @@
  *
  * This delegation aligns recovery with the hub's wrap-DEKs primitive
  * (the same shape used by `@noy-db/on-pin` and now `@noy-db/on-password`
- * after #26 Path C). It eliminates the format mismatch that made the
- * pre.7 package unusable with `db.enrollRecovery` (#38).
+ * after the wrap-DEKs path change). It eliminates the format mismatch
+ * that made the previous package version unusable with `db.enrollRecovery`.
  *
  * ## Usage
  *

--- a/packages/on-webauthn/src/index.ts
+++ b/packages/on-webauthn/src/index.ts
@@ -576,7 +576,7 @@ export async function unlockWebAuthn(
  * `SlotRewrapCeremony` for WebAuthn slots — used by hub's
  * `rotatePassphrase({ slotCeremonies: { [slotId]: webAuthnSlotRewrapCeremony } })`
  * to preserve a tier-2 WebAuthn enrollment across a tier-1 phrase
- * rotation without requiring re-enrollment of the credential (#56).
+ * rotation without requiring re-enrollment of the credential.
  *
  * The credential itself is unaffected by phrase rotation — the
  * wrapping key derived from PRF (or rawId fallback) is bound to the
@@ -599,8 +599,8 @@ export async function unlockWebAuthn(
  *      and `method: 'webauthn'` (hub validates these to prevent
  *      slot-type swap mid-rotation).
  *
- * Niwat (consumer) shipped a workaround at #44 — detect dropped slots
- * after rotate and offer "Re-enrol Touch ID" inline. This ceremony
+ * Previously a workaround was needed — detect dropped slots after
+ * rotate and offer "Re-enrol Touch ID" inline. This ceremony
  * eliminates that step.
  *
  * Out of scope: tier-3 PIN. PIN state lives in `QuickUnlockStore`
@@ -617,7 +617,7 @@ export async function unlockWebAuthn(
  *         payload fails to decrypt (credential changed / payload
  *         tampered).
  *
- * @see #56 #29 — the ceremony plumbing this fills in.
+ * @see passwordSlotRewrapCeremony — the password parallel.
  */
 export async function webAuthnSlotRewrapCeremony(
   ctx: SlotRewrapContext,


### PR DESCRIPTION
## Summary

Two related strands of **kernel hygiene**, both behavior-preserving:

**1. SubsystemBus — observe-lifecycle bus (Track A, slice 1).** The first step toward shrinking the always-on kernel: a generic per-instance bus that subsystems will register against, instead of `collection.ts`/`vault.ts` hard-coding a field + dispatch branch per subsystem.
- New internal `SubsystemBus` (`register`/`hasHandlers`/`dispatch`) with observe semantics — handlers react to a write that already succeeded; a handler throw is warned, never propagated.
- Threaded `Noydb → Vault → Collection`, mirroring the existing `WriteHookRegistry`/`WriteQueueTracker` pattern.
- Fires the first observe point, `afterPut`, from `Collection.put()`, **decoupled** from the user write-hooks (event is built when either consumer is active; `writeHooks!` is only dereferenced when hooks are actually present).
- Depth-counter re-entrancy guard: suppresses a handler that itself writes (loop prevention) while **not** dropping genuinely concurrent observe events.
- Internal only — not exported from the package root; the public surface is deferred until a real subsystem validates the shape.

**2. Comment provenance prune.** Leaned source comments across the monorepo down to current-behavior definitions and warnings: dropped `#issue` refs, milestone names, pre-release version tags, and reviewer-name provenance from comments. Behavioral facts, design-spec terminology (`Dim 14`, spec `v1/v2`), and runtime error-message string literals are preserved. Comments-only; no code changed. (81 files, net −44 lines.)

Both build toward the kernel-shrink proposal and the devtools-inspector feature documented in `docs/superpowers/specs/2026-06-01-kernel-shrink-and-devtools-proposal.md`.

## Scope / non-goals (slice 1)

- NOT the seam for write-*gating* subsystems (guards/periods) — those throw-to-abort inside `putInternal` and need a separate `beforePut` gate bus (follow-on `track-a-gate-bus`).
- No subsystem migrated off its kernel branch yet; no kernel-surface CI gate yet. Follow-on plans are listed in the slice-1 plan doc.
- Known limitation (documented): observe dispatch shares the `put()` altitude with the user write-hooks, so it inherits their `putMany`/tx/CRDT/blob coverage gap, and the shared-flag re-entrancy guard cannot distinguish a write that *starts* mid-dispatch from true re-entrancy (parity with the existing write-hook behavior). Both are tracked for the gate-bus / coverage-unification follow-ons.

## Test plan

- [x] `pnpm typecheck` — 124/124 tasks green
- [x] `packages/hub` full suite — 1995/1995 tests pass (incl. new `subsystem-bus.test.ts` + `subsystem-bus-integration.test.ts`, and a concurrency regression test proving events aren't dropped under concurrent dispatch)
- [x] `pnpm check:architecture` — invariants OK
- [x] Comment prune verified comment-only (diff shows identical code tokens; typecheck + full suite green)
- [x] Security review (tree-shaking / minimal-core model + the diff): no findings at/above bar