### PR TITLE
in-pinia: forward persistJsonSchema + schemaUpdate from defineNoydbStore to vault.collection (#255)

### DIFF
--- a/packages/in-pinia/__tests__/defineNoydbStore.test.ts
+++ b/packages/in-pinia/__tests__/defineNoydbStore.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { setActivePinia, createPinia, storeToRefs } from 'pinia'
 import { effectScope } from 'vue'
-import { createNoydb, type Noydb, type NoydbStore, type EncryptedEnvelope, type VaultSnapshot, type StandardSchemaV1, ConflictError, Query } from '@noy-db/hub'
+import { createNoydb, additiveOnly, type Noydb, type NoydbStore, type EncryptedEnvelope, type VaultSnapshot, type StandardSchemaV1, ConflictError, Query } from '@noy-db/hub'
 import { defineNoydbStore, setActiveNoydb } from '../src/index.js'
 
 /** Inline memory adapter — same pattern as @noy-db/core integration tests. */
@@ -429,5 +429,51 @@ describe('attestation option forwarding', () => {
     expect(att.docId).toBeTruthy()
     expect(att.qr).toBeTruthy()
     expect(att.keyId).toBeTruthy()
+  })
+})
+
+describe('schema-update option forwarding (#255)', () => {
+  it('forwards `persistJsonSchema` and `schemaUpdate` to the underlying Collection', async () => {
+    setActivePinia(createPinia())
+    const db = await makeNoydb()
+    setActiveNoydb(db)
+
+    // `openVault` caches per name, so the store's internal `openVault('books')`
+    // resolves to this same instance. Spy on its prototype's `collection` to
+    // capture exactly the options the store forwards — this asserts the
+    // forwarding (the unit under test) without depending on persistJsonSchema's
+    // downstream baseline derivation.
+    const vault = await db.openVault('books')
+    const spy = vi.spyOn(Object.getPrototypeOf(vault) as { collection: unknown }, 'collection')
+
+    // Pass-through Standard Schema (in-pinia has no Zod dep); the store still
+    // installs it, but this test only checks the migration options forward.
+    const schema: StandardSchemaV1<unknown, Invoice> = {
+      '~standard': {
+        version: 1,
+        vendor: 'test',
+        validate: (value) => ({ value: value as Invoice }),
+      },
+    }
+
+    const useStore = defineNoydbStore<Invoice>('mig-invoices', {
+      vault: 'books',
+      collection: 'invoices',
+      schema,
+      persistJsonSchema: true,
+      schemaUpdate: [additiveOnly()],
+    })
+    const store = useStore()
+    // Swallow any downstream baseline-derivation outcome — the spy already
+    // captured the forwarded options at the synchronous collection() call.
+    await store.$ready.catch(() => {})
+
+    const call = spy.mock.calls.find((c) => c[0] === 'invoices')
+    expect(call, 'vault.collection("invoices", …) should have been called').toBeTruthy()
+    const opts = call![1] as { persistJsonSchema?: boolean; schemaUpdate?: readonly unknown[] }
+    expect(opts?.persistJsonSchema).toBe(true)
+    expect(opts?.schemaUpdate).toHaveLength(1)
+
+    spy.mockRestore()
   })
 })

--- a/packages/in-pinia/src/defineNoydbStore.ts
+++ b/packages/in-pinia/src/defineNoydbStore.ts
@@ -94,6 +94,21 @@ export interface NoydbStoreOptions<T> {
    * `@noy-db/attestation` `AttestationFieldSchema`. Stores without it behave as before.
    */
   attestation?: NonNullable<Parameters<Vault['collection']>[1]>['attestation']
+  /**
+   * If true, the collection persists a JSON Schema baseline of `schema` so the
+   * schema-update protocol can detect drift on later opens. Forwarded as-is to
+   * the underlying `Collection`. Required for `schemaUpdate` to take effect.
+   */
+  persistJsonSchema?: NonNullable<Parameters<Vault['collection']>[1]>['persistJsonSchema']
+  /**
+   * Ordered schema-update strategies (e.g. `coordinatedCutover`, `additiveOnly`,
+   * `lockSchema`) applied when a stored baseline differs from the current
+   * `schema`. Forwarded as-is to the underlying `Collection`. Requires
+   * `persistJsonSchema: true` (drift detection needs the persisted baseline).
+   * Lets a `defineNoydbStore`-defined collection opt into migration tracking
+   * declaratively, without a pre-registration `vault.collection(...)` call.
+   */
+  schemaUpdate?: NonNullable<Parameters<Vault['collection']>[1]>['schemaUpdate']
 }
 
 /**
@@ -156,6 +171,8 @@ export function defineNoydbStore<T>(
       const collOpts: Parameters<typeof cachedCompartment.collection<T>>[1] = {}
       if (options.schema !== undefined) collOpts.schema = options.schema
       if (options.attestation !== undefined) collOpts.attestation = options.attestation
+      if (options.persistJsonSchema !== undefined) collOpts.persistJsonSchema = options.persistJsonSchema
+      if (options.schemaUpdate !== undefined) collOpts.schemaUpdate = options.schemaUpdate
       cachedCollection = cachedCompartment.collection<T>(collectionName, collOpts)
       return cachedCollection
     }


### PR DESCRIPTION
Closes #255.

## Summary

`@noy-db/in-pinia`'s `defineNoydbStore` forwarded only `schema` and `attestation` to the underlying `vault.collection(name, opts)`. So a collection defined through the normal store pattern couldn't opt into the schema-cutover protocol (`persistJsonSchema` + `schemaUpdate`) declaratively — consumers had to pre-register the collection with a direct `vault.collection(...)` call before the store instantiated, which duplicated the validator and coupled migration setup to instantiation order.

This forwards both options through `NoydbStoreOptions`, mirroring the `attestation` forwarding pattern:

```ts
export const useThings = defineNoydbStore<Thing>('things', {
  vault: 'C101',
  schema,
  persistJsonSchema: true,
  schemaUpdate: [coordinatedCutover({ transform }), additiveOnly()],
})
```

- Two new optional fields on `NoydbStoreOptions<T>`, typed by deriving from the vault signature (`NonNullable<Parameters<Vault['collection']>[1]>['persistJsonSchema' | 'schemaUpdate']`) so they auto-track any future hub change — same idiom as the existing `attestation` field.
- Forwarded in `getCollection()` with the same `if (options.x !== undefined) collOpts.x = options.x` guard as `schema`/`attestation`.

No behavior change for stores that don't set these options.

## Test plan

- [x] New test asserts `defineNoydbStore` forwards `persistJsonSchema: true` and `schemaUpdate` (length 1) to `vault.collection` — spies on the vault prototype's `collection` to capture the forwarded options; fails if the forwarding is removed.
- [x] Full `@noy-db/in-pinia` suite — 59/59
- [x] `pnpm typecheck` clean; `pnpm lint` clean; `pnpm validate:features` OK

## Notes

Pure option-forwarding in one satellite package — no `features.yaml` entry needed (validator green), and store options are documented via interface JSDoc (the surface `attestation` also uses). Version bump / changelog left to the maintainer's manual lockstep release process.