### PR TITLE
Track A slice 3b: migrate guards onto the gate bus

### DIFF
--- a/docs/superpowers/plans/2026-06-01-track-a-migrate-guards-slice-3b.md
+++ b/docs/superpowers/plans/2026-06-01-track-a-migrate-guards-slice-3b.md
@@ -1,0 +1,311 @@
+# Track A — Migrate Guards onto the Gate Bus (Slice 3b) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the guards subsystem (record-lock / field-freeze / `onDelete` / amendment-collect) off the per-`Collection` `guardSource` callback (+ the inline `putInternal`/`_doDelete` guard blocks) onto the `beforePut`/`beforeDelete` gate bus, registered once per `Noydb` when `guardStrategies` is opted in — resolving the live vault's `GuardRegistry` per dispatch (same pattern as periods, slice 3a).
+
+**Architecture:** A guard gate handler pair is registered on the per-`Noydb` `SubsystemBus` iff `guardStrategies` was supplied. Each handler resolves the live vault (`vaultCache.get(e.vault)`), reads its `GuardRegistry` via `_getGuardRegistry()` (null → return) and `ReadOnlyVaultFacade` via `_getReadOnlyFacade()`, and reproduces the kernel block's two-mode logic: **amendment-active** → `registry.collectChange(...)` (a stateful side-effect, no throw); **normal** → `runChecks` + `GuardExecutor.checkFrozenFields` on put / `runOnDelete` on delete (throws to abort). The guard handler is registered **before** the period handler so guard checks run first — restoring the guard-before-period order that slice 3a temporarily flipped.
+
+**Two structural facts that shape this slice:**
+1. **Amendment-collect is a side-effect, so register+remove must be ATOMIC.** Unlike periods (`assertTsWritable` is a pure check, safe to run twice), running `collectChange` at both the gate handler AND the still-present kernel block during an amendment would double-collect changes. Therefore Task 2 registers the gate handler AND removes the kernel guard blocks in a single commit — there is no "additive, redundant" intermediate. The existing comprehensive guard + amendment test suite is the safety net; full-suite-green after the atomic swap is the proof.
+2. **The delete gate must fire for INTERNAL deletes.** The kernel `_doDelete` guard block runs `collectChange` for system-internal (housekeeping) deletes too — so an amendment invariant sees a derivation/MV tombstone fired mid-amendment. But slice 2's `beforeDelete` gate only dispatches when `!internal`. Task 1 evolves the gate `beforeDelete` to fire for **all** deletes carrying a new `internal: boolean` flag; handlers branch on it (period skips internal; guard collects always but runs `onDelete` only when `!internal`). No internal delete is ever *aborted* (collect doesn't throw; onDelete/period are skipped) — behavior is preserved, just relocated.
+
+**Verified guard-invocation call sites (the safety-net is valid):** A full sweep (`grep -rn "collectChange|isAmendmentActive|runChecks|runOnDelete|checkFrozenFields|consumeChanges"`) confirms:
+- Per-write guard logic (`collectChange`/`runChecks`/`runOnDelete`/`checkFrozenFields`) lives ONLY in `collection.ts` `putInternal`/`_doDelete` — the two blocks this slice migrates. `putManyAtomic`/tx-executor do NOT invoke per-write guard logic (consistent with periods). So amendment-`collectChange` fires only through the migrated methods → the amendment/transaction suite genuinely exercises the gate handler after the swap.
+- `tx/transaction.ts` holds the amendment LIFECYCLE only (`beginAmendment` to open the window, `consumeChanges`/`consumeMeta` to drain + run invariants at commit) — not per-write collection. Untouched by this slice.
+- **`tx/dry-run.ts` is a THIRD, independent guard path** (`runChecks` + `checkFrozenFields`, dry-run.ts:82-85). It resolves the registry directly via `v._getGuardRegistry()` + `v._getReadOnlyFacade()` (NOT via `Collection.guardSource`), so removing `guardSource` does NOT affect it. **Do NOT touch dry-run.ts** — it stays in sync through the unchanged registry API, and its existing `{ existing, vault: facade, userId, role }` ctx shape is the proven template the gate handler mirrors.
+
+**One real behavior change (document, do not block):** The kernel guard block gated its `adapter.get`+decrypt behind `guards.length > 0` (collection.ts:1187) — a collection with no guards skipped the prior read. The gate dispatches whenever `hasGateHandlers('beforePut')` is true (any guard registered on the Noydb), builds the event (read+decrypt), and the handler then checks `guardsFor` and returns. So in a guards-enabled vault, a write to a collection that has NO guards now pays one encrypted prior read it previously skipped. Not a correctness issue and no test will fail; periods (3a) didn't have this because its kernel callback was unconditional. Note it; the clean fix (a lazy `existing`/`existingTs` thunk on the gate event, read only if a handler touches it) is a separate follow-on, out of scope for 3b.
+
+**Tech Stack:** TypeScript (ESM, `.js` specifiers), Vitest, pnpm. Package `packages/hub`. Hub portable; `pnpm check:architecture` must pass.
+
+**Scope:** guards only (periods already migrated in 3a). No public API change. Builds on slices 1/2/3a (stacked branch).
+
+---
+
+## File Structure
+
+- **Modify** `packages/hub/src/subsystem-bus.ts` — add `readonly internal: boolean` to `GateDeleteEvent`.
+- **Modify** `packages/hub/src/collection.ts` — `_doDelete` gate dispatch fires for all deletes (drop the `!internal` precondition), passing `internal`; (Task 2) remove the `guardSource` field/ctor-opt/assignment and the two inline guard blocks.
+- **Modify** `packages/hub/src/noydb.ts` — period `beforeDelete` handler early-returns on `e.internal` (Task 1); add `#registerGuardGate()` called before `#registerPeriodGate()` (Task 2).
+- **Modify** `packages/hub/src/vault.ts` — (Task 2) remove the `guardSource:` wiring passed to `Collection`.
+- **Modify** `packages/hub/__tests__/subsystem-bus-gate.test.ts` — `deleteEv` fixture gains `internal: false`.
+- **Modify** `packages/hub/__tests__/subsystem-bus-gate-integration.test.ts` — rewrite the "beforeDelete does not fire for internal" test to the new contract (it fires with `internal: true`; a handler branching on `!e.internal` does not abort).
+- **Create** `packages/hub/__tests__/guards-gate-migration.test.ts` — guard enforcement via the gate (lock/freeze/onDelete/amendment) + zero-cost registration check.
+
+---
+
+### Task 1: Evolve gate `beforeDelete` to fire for internal deletes (behavior-preserving)
+
+**Files:** `subsystem-bus.ts`, `collection.ts` (_doDelete dispatch only), `noydb.ts` (period handler), `subsystem-bus-gate.test.ts`, `subsystem-bus-gate-integration.test.ts`.
+
+- [ ] **Step 1: Update the failing test to the new contract**
+
+In `packages/hub/__tests__/subsystem-bus-gate-integration.test.ts`, replace the existing `beforeDelete does NOT fire for internal (system housekeeping) deletes` test with:
+
+```ts
+  it('beforeDelete fires for internal deletes carrying internal:true; a handler that branches on !internal does not abort', async () => {
+    const db = await createNoydb({ store: memoryStore(), user: 'owner', secret: 'pw' })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<{ id: string; n: number }>('docs')
+    await docs.put('a', { id: 'a', n: 1 })
+    const seen: boolean[] = []
+    db._subsystemBus.registerGate('beforeDelete', (e) => {
+      seen.push(e.internal)
+      if (!e.internal) throw new Error('user-delete blocked')
+    })
+    // Internal/housekeeping delete: handler fires (records internal:true) but does NOT throw.
+    await (docs as unknown as { _internalDelete(id: string): Promise<void> })._internalDelete('a')
+    expect(seen).toEqual([true])
+    expect(await docs.get('a')).toBeNull() // internal delete succeeded (not aborted)
+  })
+```
+
+> Confirm the `createNoydb`/`openVault` arg shape matches the other tests in this file (e.g. `encrypt`/`secret`) before finalizing; the file already opens DBs this way.
+
+In `packages/hub/__tests__/subsystem-bus-gate.test.ts`, update the `deleteEv` helper to include the new required field:
+
+```ts
+function deleteEv(over: Partial<GateDeleteEvent> = {}): GateDeleteEvent {
+  return {
+    vault: 'v', collection: 'c', docId: 'd',
+    existing: { x: 1 }, existingVersion: 1, existingTs: undefined, internal: false,
+    userId: 'u', role: 'owner', ...over,
+  }
+}
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/subsystem-bus-gate-integration.test.ts __tests__/subsystem-bus-gate.test.ts`
+Expected: FAIL — `GateDeleteEvent` has no `internal` field (typecheck/compile error in `deleteEv`) and the integration test's internal delete does not yet dispatch `beforeDelete`.
+
+- [ ] **Step 3: Add `internal` to `GateDeleteEvent`**
+
+In `packages/hub/src/subsystem-bus.ts`, add to the `GateDeleteEvent` interface (after `docId`):
+
+```ts
+  /** True for system-internal (housekeeping) deletes — handlers branch on this. */
+  readonly internal: boolean
+```
+
+- [ ] **Step 4: Fire `beforeDelete` for all deletes, passing `internal`**
+
+In `packages/hub/src/collection.ts` `_doDelete`, change the gate dispatch block. Replace:
+
+```ts
+    if (!internal && this.subsystemBus?.hasGateHandlers('beforeDelete')) {
+      const existingEnv = await this.adapter.get(this.vault, this.name, id)
+      if (existingEnv) {
+        let existingRecord: unknown = null
+        try {
+          existingRecord = await this.decryptRecord(existingEnv, { skipValidation: true })
+        } catch {
+          existingRecord = null
+        }
+        await this.subsystemBus.dispatchGate('beforeDelete', {
+          vault: this.vault, collection: this.name, docId: id,
+          existing: existingRecord,
+          existingVersion: existingEnv._v,
+          existingTs: existingEnv._ts,
+          userId: this.keyring.userId,
+          role: this.keyring.role,
+        })
+      }
+    }
+```
+
+with (drop the `!internal` precondition; add `internal` to the payload; update the comment):
+
+```ts
+    // Gate bus (Track A) — fires for ALL deletes (carrying `internal`), so a
+    // gate handler can collect amendment changes on system-internal deletes
+    // while branching off `onDelete`/period checks for them. Delete-of-absent
+    // (no envelope) does not fire.
+    if (this.subsystemBus?.hasGateHandlers('beforeDelete')) {
+      const existingEnv = await this.adapter.get(this.vault, this.name, id)
+      if (existingEnv) {
+        let existingRecord: unknown = null
+        try {
+          existingRecord = await this.decryptRecord(existingEnv, { skipValidation: true })
+        } catch {
+          existingRecord = null
+        }
+        await this.subsystemBus.dispatchGate('beforeDelete', {
+          vault: this.vault, collection: this.name, docId: id,
+          existing: existingRecord,
+          existingVersion: existingEnv._v,
+          existingTs: existingEnv._ts,
+          internal,
+          userId: this.keyring.userId,
+          role: this.keyring.role,
+        })
+      }
+    }
+```
+
+- [ ] **Step 5: Period handler must skip internal deletes**
+
+In `packages/hub/src/noydb.ts`, in `#registerPeriodGate`, the `beforeDelete` handler currently relied on the gate's `!internal` gating. Add an early return at the top of that handler body so periods still skips internal deletes:
+
+```ts
+    this.subsystemBus.registerGate('beforeDelete', async (e) => {
+      if (e.internal) return
+      const v = this.vaultCache.get(e.vault)
+      if (!v) return
+      await v._assertTsWritable(
+        { ts: e.existingTs ?? null, record: (e.existing ?? null) as Record<string, unknown> | null },
+        null,
+      )
+    })
+```
+
+- [ ] **Step 6: Run the updated tests + full suite**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/subsystem-bus-gate-integration.test.ts __tests__/subsystem-bus-gate.test.ts`
+Expected: PASS.
+
+Run: `cd packages/hub && pnpm typecheck && pnpm vitest run`
+Expected: typecheck clean; full suite green (periods still skips internal; no guard handler yet, so the only behavior change is the gate now dispatching beforeDelete on internal deletes to handlers that all early-return for internal — net no behavior change).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/hub/src/subsystem-bus.ts packages/hub/src/collection.ts packages/hub/src/noydb.ts packages/hub/__tests__/subsystem-bus-gate.test.ts packages/hub/__tests__/subsystem-bus-gate-integration.test.ts
+git commit -m "feat(hub): gate beforeDelete fires for internal deletes with an internal flag (Track A slice 3b)"
+```
+
+---
+
+### Task 2: Register guard gate handlers AND remove the kernel guard blocks (atomic)
+
+**Files:** `noydb.ts` (register), `collection.ts` (remove field/opt/assignment + 2 blocks), `vault.ts` (remove wiring), new `guards-gate-migration.test.ts`.
+
+> ATOMIC: register + remove in one commit. The amendment `collectChange` side-effect must not run at both the gate and the kernel block (double-collect), so we never leave both in place.
+
+- [ ] **Step 1: Write the new guard-gate test**
+
+Create `packages/hub/__tests__/guards-gate-migration.test.ts`. Model store/`createNoydb`/`withGuard` setup on an existing guards test — find one: `grep -rln "withGuard\|guardStrategies" packages/hub/__tests__` and READ it to copy the exact `createNoydb({ ..., guardStrategies: [withGuard(...)] })` shape, the lock/freeze/onDelete/amendment APIs, and how a locked-record write is attempted + its error type. Do NOT invent the guard API. Assert at least:
+- A no-guards Noydb registers no guard gate handler: `expect(plain._subsystemBus.hasGateHandlers('beforePut')).toBe(false)` (and `beforeDelete`) — only when NEITHER guards nor periods are configured.
+- A `guardStrategies` Noydb: `hasGateHandlers('beforePut')` is true.
+- A record-locked write is rejected (reuse the existing test's lock scenario + expected error).
+- (If the existing suite already covers freeze/onDelete/amendment thoroughly, this new test can be a thin "still enforced via gate" check — the existing guard + amendment suite is the real safety net.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/guards-gate-migration.test.ts`
+Expected: FAIL — `hasGateHandlers('beforePut')` is false even with `guardStrategies` (no guard handler registered yet).
+
+- [ ] **Step 3: Register the guard gate handlers in `Noydb` (before the period handler)**
+
+In `packages/hub/src/noydb.ts`, in the constructor, call `this.#registerGuardGate()` IMMEDIATELY BEFORE the existing `this.#registerPeriodGate()` call (so guard checks dispatch before period checks — restoring guard-before-period order). Define the method:
+
+```ts
+  // Track A — guards migration. Registers record-lock / field-freeze / onDelete
+  // / amendment-collect as gate-bus handlers (only when guards are opted in, so
+  // the write path is zero-cost otherwise). Resolves the live vault's
+  // GuardRegistry per dispatch. Registered BEFORE the period gate so guard
+  // checks run first. The amendment branch is a side-effect (collectChange),
+  // NOT a throw — and runs even for internal deletes (an amendment invariant
+  // must see system housekeeping tombstones); onDelete/checks run only for
+  // user (non-internal) operations.
+  #registerGuardGate(): void {
+    if (this.options.guardStrategies === undefined) return
+    this.subsystemBus.registerGate('beforePut', async (e) => {
+      const v = this.vaultCache.get(e.vault)
+      if (!v) return
+      const registry = v._getGuardRegistry()
+      if (!registry) return
+      const guards = registry.guardsFor(e.collection)
+      if (guards.length === 0) return
+      const existing = (e.existing ?? null) as Record<string, unknown> | null
+      const incoming = e.incoming as Record<string, unknown>
+      if (registry.isAmendmentActive()) {
+        registry.collectChange(e.collection, e.docId, existing, incoming, e.existingVersion, e.existingVersion + 1)
+        return
+      }
+      const facade = v._getReadOnlyFacade()
+      if (!facade) return
+      const ctx = { existing, vault: facade, userId: e.userId, role: e.role }
+      await registry.runChecks(e.collection, incoming, ctx)
+      const { GuardExecutor } = await import('./guards/executor.js')
+      for (const g of guards) {
+        await GuardExecutor.checkFrozenFields(g, e.docId, existing, incoming)
+      }
+    })
+    this.subsystemBus.registerGate('beforeDelete', async (e) => {
+      const v = this.vaultCache.get(e.vault)
+      if (!v) return
+      const registry = v._getGuardRegistry()
+      if (!registry) return
+      const guards = registry.guardsFor(e.collection)
+      if (guards.length === 0) return
+      const existing = (e.existing ?? null) as Record<string, unknown> | null
+      if (registry.isAmendmentActive()) {
+        // Fires for BOTH user and system-internal deletes (matches the kernel block).
+        registry.collectChange(e.collection, e.docId, existing, null as unknown as Record<string, unknown>, e.existingVersion, e.existingVersion)
+        return
+      }
+      if (e.internal) return // housekeeping deletes don't run onDelete
+      const facade = v._getReadOnlyFacade()
+      if (!facade) return
+      const ctx = { existing, vault: facade, userId: e.userId, role: e.role }
+      await registry.runOnDelete(e.collection, existing ?? {}, ctx)
+    })
+  }
+```
+
+> Match the exact signatures by reading the kernel guard blocks (`collection.ts` ~1184 and ~1850) and `guards/registry.ts`: `runChecks(collection, incoming, ctx)`, `collectChange(collection, id, before, after, vBefore, vAfter)`, `runOnDelete(collection, existing, ctx)`, `guardsFor(collection)`, `isAmendmentActive()`. `GuardExecutor.checkFrozenFields(guard, id, existing, incoming)` is dynamic-imported from `./guards/executor.js`. `_getGuardRegistry()` (`vault.ts:1749`) and `_getReadOnlyFacade()` (`vault.ts:2002`) are the accessors. The `ctx` shape `{ existing, vault, userId, role }` mirrors the kernel exactly.
+
+- [ ] **Step 4: Remove the kernel guard blocks + `guardSource` (same commit)**
+
+(a) `packages/hub/src/vault.ts`: remove the `guardSource:` property from the `collOpts` passed to `new Collection(...)` (the conditional `...(this.guardRegistry !== null ? { guardSource: { registry: ..., readOnlyVault: ... } } : {})` spread around line 708). Keep `guardRegistry`, `_getGuardRegistry`, `_getReadOnlyFacade`, and `readOnlyFacade` — the gate handler uses them.
+
+(b) `packages/hub/src/collection.ts`: delete the `guardSource` private field (~line 375, including its JSDoc), the ctor option (~line 726), and the assignment `this.guardSource = opts.guardSource` (~line 815).
+
+(c) `packages/hub/src/collection.ts`: delete the entire `putInternal` guard block (`if (this.guardSource) { ... }`, lines ~1184-1223) and the entire `_doDelete` guard block (`if (this.guardSource) { ... }`, lines ~1850-1898), along with their leading explanatory comments. Leave surrounding code (the gate dispatch above, schema validation / ref enforcement below) intact.
+
+- [ ] **Step 5: Typecheck + grep**
+
+Run: `cd packages/hub && pnpm typecheck`
+Expected: clean. Then `grep -n "guardSource" packages/hub/src/collection.ts packages/hub/src/vault.ts` → ZERO matches. `grep -n "GuardExecutorType\|GuardExecutor" packages/hub/src/collection.ts` → if the `GuardExecutorType` type-only import is now unused in collection.ts (it was only used by the removed block), remove that import.
+
+- [ ] **Step 6: Full suite + architecture — the proof (esp. guard + amendment tests)**
+
+Run: `cd packages/hub && pnpm vitest run && cd ../.. && pnpm check:architecture`
+Expected: ALL hub tests green — critically the guards suite (lock/freeze/onDelete) AND the amendment/transaction tests (the amendment-collect path now runs via the gate; a double-collect or missing-collect would fail these). Architecture OK.
+IF an amendment test fails on collected-change COUNT or ordering: investigate — the gate handler's `collectChange` must fire exactly once per write (no kernel block remains) and for internal deletes during amendments. If a guards+periods precedence test now expects period-first (from slice 3a), it should now get guard-first again (restored) — update if needed and note it.
+IF a pure guard/amendment regression appears (enforcement lost): STOP, report BLOCKED with the failing test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/hub/src/noydb.ts packages/hub/src/collection.ts packages/hub/src/vault.ts packages/hub/__tests__/guards-gate-migration.test.ts
+git commit -m "refactor(hub): migrate guards (lock/freeze/onDelete/amendment) onto the gate bus (Track A slice 3b)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Gate `beforeDelete` fires for internal deletes with `internal` flag; period handler skips internal → Task 1. ✅
+- Guard gate handlers (amendment-collect side-effect + normal runChecks/checkFrozenFields/onDelete), registered per-Noydb when `guardStrategies` set, before periods → Task 2 Step 3. ✅
+- Kernel guard blocks + `guardSource` removed atomically with registration (no double-collect window) → Task 2 Step 4. ✅
+- Guard-before-period order restored → guard handler registered before period handler. ✅
+- Zero-cost when no guards → handler registered only when `guardStrategies` set. ✅
+- Behavior preserved → existing guards + amendment suite green after the atomic swap (Task 2 Step 6). ✅
+
+**Placeholder scan:** none. The "copy the existing guards test setup" instruction is a concrete `grep` locator (the guard API must match the real one).
+
+**Type consistency:** `collectChange(collection, id, before, after, vBefore, vAfter)`, `runChecks(collection, incoming, ctx)`, `runOnDelete(collection, existing, ctx)`, `guardsFor`, `isAmendmentActive`, `_getGuardRegistry`, `_getReadOnlyFacade`, `GuardExecutor.checkFrozenFields` — all used as defined in `guards/registry.ts` / `guards/executor.ts` / `vault.ts`. `GateDeleteEvent.internal` used consistently in the event, dispatch site, and both handlers. ✅
+
+---
+
+## Follow-on (Track A remaining, after 3b)
+
+- **Lazy gate-event prior read** — make the gate event's `existing`/`existingTs` a thunk so the `adapter.get`+decrypt only runs if a handler actually reads it. Removes the extra read this slice introduces for non-guarded collections in a guards-enabled vault (documented above), and benefits periods too.
+- `afterDelete` observe point (symmetry with `afterPut`) for the inspector/audit.
+- keyring-grant → `team` split; lazy-mode → own subsystem.
+- Kernel-surface CI gate (fail when always-on root grows or a subsystem adds a hard-coded `collection.ts`/`vault.ts` reference) — now enforceable since guards + periods no longer hard-code into the kernel.
+- Then Track B (devtools inspector) consuming the observe bus.

--- a/packages/hub/__tests__/guards-gate-migration.test.ts
+++ b/packages/hub/__tests__/guards-gate-migration.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withGuard, RecordLockedError } from '../src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../src/types.js'
+
+// Minimal in-test memory store — follows the hub convention (see __tests__/guards/*.test.ts)
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface Invoice { id: string; status: 'draft' | 'issued'; total: number }
+
+describe('guards-gate-migration — gate handler registration', () => {
+  it('plain Noydb (no guardStrategies, no periods) registers no beforePut gate handlers', async () => {
+    const plain = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'guards-gate-plain-passphrase-2026',
+    })
+    expect((plain as any)._subsystemBus.hasGateHandlers('beforePut')).toBe(false)
+  })
+
+  it('guardStrategies Noydb registers a beforePut gate handler', async () => {
+    const guard = withGuard<Invoice>({
+      collection: 'invoices',
+      check: async () => { /* no-op */ },
+    })
+    const g = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'guards-gate-registered-passphrase-2026',
+      guardStrategies: [guard],
+    })
+    expect((g as any)._subsystemBus.hasGateHandlers('beforePut')).toBe(true)
+  })
+
+  it('guardStrategies Noydb registers a beforeDelete gate handler', async () => {
+    const guard = withGuard<Invoice>({
+      collection: 'invoices',
+      onDelete: async () => { /* no-op */ },
+    })
+    const g = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'guards-gate-delete-registered-passphrase-2026',
+      guardStrategies: [guard],
+    })
+    expect((g as any)._subsystemBus.hasGateHandlers('beforeDelete')).toBe(true)
+  })
+})
+
+describe('guards-gate-migration — enforcement via gate', () => {
+  it('a record-locked write is rejected (check via gate)', async () => {
+    // Reuse the same scenario as __tests__/guards/collection-put.test.ts:
+    // a guard's `check` throws RecordLockedError when a cross-collection
+    // condition is violated. After migration, this fires via the gate bus.
+    const invoiceGuard = withGuard<Invoice>({
+      collection: 'invoices',
+      check: async (incoming) => {
+        if (incoming.status === 'issued') {
+          throw new RecordLockedError('invoices', (incoming as Invoice).id, 'already issued')
+        }
+      },
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'guards-gate-enforcement-passphrase-2026',
+      guardStrategies: [invoiceGuard],
+    })
+    const v = await db.openVault('demo')
+    // First put should succeed (draft)
+    await v.collection<Invoice>('invoices').put('inv1', { id: 'inv1', status: 'draft', total: 100 })
+    // Second put with status=issued triggers the check
+    await expect(
+      v.collection<Invoice>('invoices').put('inv2', { id: 'inv2', status: 'issued', total: 200 }),
+    ).rejects.toBeInstanceOf(RecordLockedError)
+  })
+})

--- a/packages/hub/__tests__/subsystem-bus-gate-integration.test.ts
+++ b/packages/hub/__tests__/subsystem-bus-gate-integration.test.ts
@@ -78,19 +78,18 @@ describe('SubsystemBus gate integration — beforePut/beforeDelete', () => {
     await expect(docs.delete('a')).resolves.toBeUndefined()
   })
 
-  it('beforeDelete does NOT fire for internal (system housekeeping) deletes', async () => {
+  it('beforeDelete fires for internal deletes carrying internal:true; a handler that branches on !internal does not abort', async () => {
     const db = await createNoydb({ store: memoryStore(), secret: 'pw', user: 'owner' })
     const vault = await db.openVault('v1')
     const docs = vault.collection<{ id: string; n: number }>('docs')
     await docs.put('a', { id: 'a', n: 1 })
-    let fired = false
-    db._subsystemBus.registerGate('beforeDelete', () => {
-      fired = true
-      throw new Error('gate should not fire for internal deletes')
+    const seen: boolean[] = []
+    db._subsystemBus.registerGate('beforeDelete', (e) => {
+      seen.push(e.internal)
+      if (!e.internal) throw new Error('user-delete blocked')
     })
-    // Internal/housekeeping delete must bypass the gate (matching guard/period bypass).
-    await docs._internalDelete('a')
-    expect(fired).toBe(false)
-    expect(await docs.get('a')).toBeNull() // the internal delete still succeeded
+    await (docs as unknown as { _internalDelete(id: string): Promise<void> })._internalDelete('a')
+    expect(seen).toEqual([true])
+    expect(await docs.get('a')).toBeNull()
   })
 })

--- a/packages/hub/__tests__/subsystem-bus-gate.test.ts
+++ b/packages/hub/__tests__/subsystem-bus-gate.test.ts
@@ -13,7 +13,7 @@ function putEv(over: Partial<GatePutEvent> = {}): GatePutEvent {
 function deleteEv(over: Partial<GateDeleteEvent> = {}): GateDeleteEvent {
   return {
     vault: 'v', collection: 'c', docId: 'd',
-    existing: { x: 1 }, existingVersion: 1, existingTs: undefined,
+    existing: { x: 1 }, existingVersion: 1, existingTs: undefined, internal: false,
     userId: 'u', role: 'owner', ...over,
   }
 }

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -39,12 +39,7 @@ import { NO_SYNC, type SyncStrategy } from './team/sync-strategy.js'
 import type { BlobSet } from './blobs/blob-set.js'
 import { NO_BLOBS, type BlobStrategy } from './blobs/strategy.js'
 import { NO_AGGREGATE, type AggregateStrategy } from './aggregate/strategy.js'
-import type { GuardRegistry } from './guards/registry.js'
 import type { ReadOnlyVaultFacade } from './guards/types.js'
-// Type-only — runtime class loaded via dynamic import in the
-// frozen-field branch of `put()` / amendment paths. Keeps the guard
-// executor chunk out of the floor bundle.
-import type { GuardExecutor as GuardExecutorType } from './guards/executor.js'
 import type { DerivationRegistry } from './derivations/registry.js'
 import type { TxContext, ExecutedOp } from './tx/transaction.js'
 import { revertExecuted } from './tx/transaction.js'
@@ -361,30 +356,9 @@ export class Collection<T> {
     | undefined
 
   /**
-   * Optional back-reference to the owning vault's guard registry + a
-   * read-only vault facade. When present, `Collection.put` and
-   * `Collection.delete` consult the registry for guards declared
-   * against this collection and run their `check` + `frozenFields`
-   * before the adapter write. Absent in unit tests that construct
-   * a Collection directly; production code always sets it via
-   * `Vault.collection()`.
-   *
-   * Typed structurally rather than as `Vault` to avoid a circular
-   * import (mirrors the `refEnforcer` / `joinResolver` pattern).
-   */
-  private readonly guardSource:
-    | {
-        registry(): GuardRegistry
-        readOnlyVault(): ReadOnlyVaultFacade
-      }
-    | undefined
-
-  /**
    * Vault-internal hook for derivation dispatch. When set,
    * `Collection.put` consults the registry after the source-write
    * commits and writes derived outputs through `getCollection(name).put`.
-   * Same structural-interface pattern as `guardSource` to avoid a
-   * circular Vault import.
    */
   private readonly derivationSource:
     | {
@@ -718,21 +692,11 @@ export class Collection<T> {
      */
     onCrossTierAccess?: ((event: CrossTierAccessEvent) => void) | undefined
     /**
-     * Optional back-reference to the owning vault's guard registry +
-     * read-only facade. When present, put/delete consult registered
-     * guards for this collection. Same structural-interface pattern
-     * as `refEnforcer` to avoid a circular Vault import.
-     */
-    guardSource?: {
-      registry(): GuardRegistry
-      readOnlyVault(): ReadOnlyVaultFacade
-    } | undefined
     /**
      * Optional back-reference to the owning vault's derivation
      * registry + collection accessor. When present, successful
      * `put()` dispatches registered derivation strategies for the
-     * source collection. Same structural-interface pattern as
-     * `guardSource` to avoid a circular Vault import.
+     * source collection.
      */
     derivationSource?: {
       registry(): DerivationRegistry
@@ -812,7 +776,6 @@ export class Collection<T> {
     this.crdtMode = opts.crdt
     this.syncAdapter = opts.syncAdapter
     this.onAccess = opts.onAccess
-    this.guardSource = opts.guardSource
     this.derivationSource = opts.derivationSource
     this.materializedViewSource = opts.materializedViewSource
 
@@ -1173,53 +1136,6 @@ export class Collection<T> {
         userId: this.keyring.userId,
         role: this.keyring.role,
       })
-    }
-
-    // Guard hook (record lock + field freeze). Runs BEFORE the
-    // period guard so a guard-blocked write fails before any
-    // schema work, i18n translation, history, or ledger churn.
-    // Inside an active amendment we skip the synchronous check
-    // and frozen-field diff — those run at commit time on the
-    // collected change-set instead.
-    if (this.guardSource) {
-      const registry = this.guardSource.registry()
-      const guards = registry.guardsFor(this.name)
-      if (guards.length > 0) {
-        const existingEnv = await this.adapter.get(this.vault, this.name, id)
-        let existingRecord: Record<string, unknown> | null = null
-        if (existingEnv) {
-          try {
-            existingRecord = (await this.decryptRecord(existingEnv, { skipValidation: true })) as unknown as Record<string, unknown>
-          } catch {
-            existingRecord = null
-          }
-        }
-        const incomingRecord = record as unknown as Record<string, unknown>
-        const ctx = {
-          existing: existingRecord,
-          vault: this.guardSource.readOnlyVault(),
-          userId: this.keyring.userId,
-          role: this.keyring.role,
-        }
-        if (registry.isAmendmentActive()) {
-          const vBefore = existingEnv?._v ?? 0
-          // `put` deterministically bumps version by 1 — see the
-          // `version = existing.version + 1` line further down in this
-          // method. Computing vAfter here keeps the audit math local
-          // to the call site that decides it.
-          registry.collectChange(this.name, id, existingRecord, incomingRecord, vBefore, vBefore + 1)
-        } else {
-          await registry.runChecks(this.name, incomingRecord, ctx)
-          // Dynamic-import the executor only when at least one guard
-          // is registered AND a non-amendment write fires. Consumers
-          // who never call `withGuard()` never reach this branch and
-          // never pull `GuardExecutor` into their bundle.
-          const { GuardExecutor } = (await import('./guards/executor.js')) as { GuardExecutor: typeof GuardExecutorType }
-          for (const g of guards) {
-            await GuardExecutor.checkFrozenFields(g, id, existingRecord, incomingRecord)
-          }
-        }
-      }
     }
 
     // Schema validation — runs BEFORE encryption so invalid records are
@@ -1831,72 +1747,6 @@ export class Collection<T> {
           userId: this.keyring.userId,
           role: this.keyring.role,
         })
-      }
-    }
-
-    // Guard hook for deletes. Symmetric to put(): consult the
-    // registry, decrypt the prior record (if any), then either
-    // collect the {before, null} change pair into an active
-    // amendment or run the guards' `onDelete` callback. Frozen-field
-    // diffing is skipped (it's a put concept). Delete-of-absent is
-    // a no-op — no guard is consulted because there's nothing to
-    // protect, matching the idempotent-delete contract.
-    //
-    // For `internal === true` (system housekeeping — derivation
-    // tombstones, MV refresh): `onDelete` is bypassed, but the
-    // amendment change-collection still runs if a window is open.
-    // This means an `amendment.invariant` paired with `onDelete` for
-    // "TRULY unconditional" rules sees the system delete and can
-    // reject it — closing the gap where a derivation
-    // tombstone fired during an admin amendment would otherwise
-    // silently bypass both hooks.
-    if (this.guardSource) {
-      const registry = this.guardSource.registry()
-      const guards = registry.guardsFor(this.name)
-      if (guards.length > 0) {
-        const existingEnv = await this.adapter.get(this.vault, this.name, id)
-        if (existingEnv) {
-          let existingRecord: Record<string, unknown> | null = null
-          try {
-            existingRecord = (await this.decryptRecord(existingEnv, { skipValidation: true })) as unknown as Record<string, unknown>
-          } catch {
-            existingRecord = null
-          }
-          if (registry.isAmendmentActive()) {
-            // For deletes, the record version is the version that was
-            // visible at delete time; we record vBefore = that version
-            // and vAfter = same (the ledger entry's `op` discriminator
-            // is `delete`, not `put`, so the consumer treats the
-            // tombstone shape correctly). Fires for BOTH user and
-            // system-internal deletes.
-            const vBefore = existingEnv._v
-            registry.collectChange(
-              this.name,
-              id,
-              existingRecord,
-              null as unknown as Record<string, unknown>,
-              vBefore,
-              vBefore,
-            )
-          } else if (!internal) {
-            // Dedicated delete-time hook. `check` is put-only;
-            // `onDelete(existing, ctx)` receives the currently-persisted
-            // record and decides whether the deletion is permitted.
-            // Skipped for internal deletes — housekeeping must not trip
-            // user invariants in normal-mode operation.
-            const ctx = {
-              existing: existingRecord,
-              vault: this.guardSource.readOnlyVault(),
-              userId: this.keyring.userId,
-              role: this.keyring.role,
-            }
-            await registry.runOnDelete(
-              this.name,
-              existingRecord ?? {},
-              ctx,
-            )
-          }
-        }
       }
     }
 

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1809,9 +1809,11 @@ export class Collection<T> {
       throw new ReadOnlyError()
     }
 
-    // Gate bus (Track A) — symmetric to putInternal. Skipped for internal
-    // (system housekeeping) deletes, matching the guard/period bypass below.
-    if (!internal && this.subsystemBus?.hasGateHandlers('beforeDelete')) {
+    // Gate bus (Track A) — fires for ALL deletes (carrying `internal`), so a
+    // gate handler can collect amendment changes on system-internal deletes
+    // while branching off `onDelete`/period checks for them. Delete-of-absent
+    // (no envelope) does not fire.
+    if (this.subsystemBus?.hasGateHandlers('beforeDelete')) {
       const existingEnv = await this.adapter.get(this.vault, this.name, id)
       if (existingEnv) {
         let existingRecord: unknown = null
@@ -1825,6 +1827,7 @@ export class Collection<T> {
           existing: existingRecord,
           existingVersion: existingEnv._v,
           existingTs: existingEnv._ts,
+          internal,
           userId: this.keyring.userId,
           role: this.keyring.role,
         })

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1111,11 +1111,11 @@ export class Collection<T> {
       throw new ReadOnlyError()
     }
 
-    // Gate bus (Track A) — write-gating subsystems can abort here, before any
-    // guard/period/schema/i18n/history work, at the same altitude guards run.
-    // A throwing gate handler propagates and aborts the write. Zero-cost when
-    // no gate handler is registered. The existing guard/period blocks below are
-    // NOT yet migrated onto this seam — that is a later slice.
+    // Gate bus (Track A) — write-gating subsystems (guards: record-lock /
+    // field-freeze / amendment-collect; periods: closed-period guard) run here,
+    // before any schema/i18n/history work. A throwing gate handler propagates
+    // and aborts the write; the amendment branch collects without throwing.
+    // Zero-cost when no gate handler is registered.
     if (this.subsystemBus?.hasGateHandlers('beforePut')) {
       const existingEnv = await this.adapter.get(this.vault, this.name, id)
       let existingRecord: unknown = null

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -237,8 +237,61 @@ export class Noydb {
     if (options.sessionPolicy) {
       this.sessionStrategy.validateSessionPolicy(options.sessionPolicy)
     }
+    this.#registerGuardGate()
     this.#registerPeriodGate()
     this.resetSessionTimer()
+  }
+
+  // Track A — guards migration. Registers record-lock / field-freeze / onDelete
+  // / amendment-collect as gate-bus handlers (only when guards are opted in, so
+  // the write path is zero-cost otherwise). Resolves the live vault's
+  // GuardRegistry per dispatch. Registered BEFORE the period gate so guard
+  // checks run first. The amendment branch is a side-effect (collectChange),
+  // NOT a throw — and runs even for internal deletes (an amendment invariant
+  // must see system housekeeping tombstones); onDelete/checks run only for
+  // user (non-internal) operations.
+  #registerGuardGate(): void {
+    if (this.options.guardStrategies === undefined) return
+    this.subsystemBus.registerGate('beforePut', async (e) => {
+      const v = this.vaultCache.get(e.vault)
+      if (!v) return
+      const registry = v._getGuardRegistry()
+      if (!registry) return
+      const guards = registry.guardsFor(e.collection)
+      if (guards.length === 0) return
+      const existing = (e.existing ?? null) as Record<string, unknown> | null
+      const incoming = e.incoming as Record<string, unknown>
+      if (registry.isAmendmentActive()) {
+        registry.collectChange(e.collection, e.docId, existing, incoming, e.existingVersion, e.existingVersion + 1)
+        return
+      }
+      const facade = v._getReadOnlyFacade()
+      if (!facade) return
+      const ctx = { existing, vault: facade, userId: e.userId, role: e.role }
+      await registry.runChecks(e.collection, incoming, ctx)
+      const { GuardExecutor } = await import('./guards/executor.js') as { GuardExecutor: typeof import('./guards/executor.js').GuardExecutor }
+      for (const g of guards) {
+        await GuardExecutor.checkFrozenFields(g, e.docId, existing, incoming)
+      }
+    })
+    this.subsystemBus.registerGate('beforeDelete', async (e) => {
+      const v = this.vaultCache.get(e.vault)
+      if (!v) return
+      const registry = v._getGuardRegistry()
+      if (!registry) return
+      const guards = registry.guardsFor(e.collection)
+      if (guards.length === 0) return
+      const existing = (e.existing ?? null) as Record<string, unknown> | null
+      if (registry.isAmendmentActive()) {
+        registry.collectChange(e.collection, e.docId, existing, null as unknown as Record<string, unknown>, e.existingVersion, e.existingVersion)
+        return
+      }
+      if (e.internal) return
+      const facade = v._getReadOnlyFacade()
+      if (!facade) return
+      const ctx = { existing, vault: facade, userId: e.userId, role: e.role }
+      await registry.runOnDelete(e.collection, existing ?? {}, ctx)
+    })
   }
 
   /**

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -268,6 +268,7 @@ export class Noydb {
       await v._assertTsWritable(existing, e.incoming as Record<string, unknown>)
     })
     this.subsystemBus.registerGate('beforeDelete', async (e) => {
+      if (e.internal) return
       const v = this.vaultCache.get(e.vault)
       if (!v) return
       await v._assertTsWritable(

--- a/packages/hub/src/subsystem-bus.ts
+++ b/packages/hub/src/subsystem-bus.ts
@@ -51,6 +51,8 @@ export interface GateDeleteEvent {
   readonly vault: string
   readonly collection: string
   readonly docId: string
+  /** True for system-internal (housekeeping) deletes — handlers branch on this. */
+  readonly internal: boolean
   readonly existing: unknown
   readonly existingVersion: number
   readonly existingTs: string | undefined

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -698,19 +698,12 @@ export class Vault {
         defaultLocale: this.locale,
         onRegisterConflictResolver: this.onRegisterConflictResolver,
         onAccess: (op, id) => this._logConsent(op, collectionName, id),
-        // Guard / derivation sources are only wired when the
-        // corresponding registry has been initialised. Vaults without
-        // guards/derivations skip this entirely so `Collection.put`'s
-        // `if (this.guardSource)` / `if (this.derivationSource)`
-        // branches no-op without ever touching the subsystem code.
-        ...(this.guardRegistry !== null
-          ? {
-              guardSource: {
-                registry: () => this.guardRegistry as GuardRegistry,
-                readOnlyVault: () => this._ensureReadOnlyFacade(),
-              },
-            }
-          : {}),
+        // Derivation source is only wired when the corresponding registry
+        // has been initialised. Guard source was removed in Track A slice 3b
+        // — guards now run via the gate bus in Noydb.#registerGuardGate.
+        // Vaults without derivations skip this so `Collection.put`'s
+        // `if (this.derivationSource)` branch no-ops without touching the
+        // derivation subsystem code.
         ...(this.derivationRegistry !== null
           ? {
               derivationSource: {
@@ -1739,10 +1732,9 @@ export class Vault {
   }
 
   /**
-   * @internal — Collection.put calls into this. Returns `null` for
-   * vaults that never registered any guard strategy. Callers MUST
-   * gate on null (the existing `if (this.guardSource)` branches in
-   * `Collection` already do this transitively).
+   * @internal — The gate handler in Noydb.#registerGuardGate calls into
+   * this. Returns `null` for vaults that never registered any guard
+   * strategy. Callers MUST gate on null.
    */
   _getGuardRegistry(): GuardRegistry | null {
     return this.guardRegistry
@@ -1993,23 +1985,20 @@ export class Vault {
   /**
    * @internal — exposed for `runTransaction({ amendment: true })` so
    * the amendment invariant runner can pass the SAME read-only vault
-   * facade that the per-record `Collection.put` guard hook uses
-   * (`guardSource.readOnlyVault()` above). Eagerly instantiated by
-   * `_initGuards()` so this accessor stays synchronous; returns
-   * `null` for vaults that never registered any guard (amendments
-   * require at least one guard, so the caller should never see null).
+   * facade that the gate handler in Noydb.#registerGuardGate uses.
+   * Eagerly instantiated by `_initGuards()` so this accessor stays
+   * synchronous; returns `null` for vaults that never registered any
+   * guard (amendments require at least one guard, so the caller should
+   * never see null).
    */
   _getReadOnlyFacade(): ReadOnlyVaultFacade | null {
     return this.readOnlyFacade
   }
 
   /**
-   * Internal lazy-allocator for the read-only facade. Used by the
-   * per-collection `guardSource.readOnlyVault` callback when guards
-   * ARE configured but `_initGuards()` raced with the first guard
-   * invocation (theoretically impossible — `Noydb.openVault` awaits
-   * `_initGuards` before returning — but we keep the defensive lazy
-   * path so the closure's contract stays "always returns a facade").
+   * Internal lazy-allocator for the read-only facade. Used as a
+   * defensive fallback; in practice `_initGuards()` eagerly
+   * instantiates this, so the lazy path is a no-op.
    */
   private _ensureReadOnlyFacade(): ReadOnlyVaultFacade {
     if (this.readOnlyFacade !== null) return this.readOnlyFacade


### PR DESCRIPTION
> **Stacked on #259 → #257 → #256** (base = `proposal/track-a-migrate-periods`). Review/merge the chain bottom-up; this rebases automatically as each base merges.

## Summary

The milestone slice: with this, **no write-gating subsystem is hard-coded into `collection.ts`/`vault.ts` anymore**. Migrates guards (record-lock / field-freeze / `onDelete` / amendment-collect) off the per-`Collection` `guardSource` callback onto the `beforePut`/`beforeDelete` gate bus, completing the pattern periods started in #259.

Two parts:
1. **Gate `beforeDelete` now fires for all deletes** carrying an `internal: boolean` flag (was `!internal`-gated). Necessary because the kernel collected amendment changes on *internal* (housekeeping) deletes too — an amendment invariant must see system tombstones. Handlers branch on `internal`: the period handler skips internal; the guard handler collects always but runs `onDelete` only for user deletes. No internal delete is ever *aborted*.
2. **Guard gate handlers** registered once per `Noydb` when `guardStrategies` is opted in (zero-cost otherwise), resolving the live vault's `GuardRegistry` per dispatch. Registered **before** the period handler, restoring the guard-before-period order #259 temporarily flipped. The kernel `guardSource` field + both inline guard blocks are removed in the **same commit** as the registration — atomic, because the amendment branch (`collectChange`) is a side-effect that would double-collect if it ran at both sites.

## Behavior preservation (verified against the removed kernel block via git)

- **Amendment-collect fires exactly once** per write (kernel block gone), still on internal deletes during amendments. `vBefore`/`vAfter` formulas identical (put: `v`/`v+1`; delete: `v`/`v`).
- **Guards run pre-schema on the raw record** — same as the kernel block (which sat at line 1184, above `validateSchemaInput` at 1233). No pre/post-schema change.
- **`collectChange` gated by `guards.length > 0`** — same as the kernel (which wrapped its collect in `if (guards.length > 0)`); unguarded collections were never collected, before or after.
- Normal-mode `runChecks` + `checkFrozenFields` (put) / `runOnDelete` (delete, user-only) reproduce the kernel ctx `{ existing, vault: facade, userId, role }` exactly.
- `tx/dry-run.ts` is a separate guard path (resolves the registry directly) — untouched and unaffected.

## Documented behavior changes / follow-ons

- **Extra read for non-guarded collections in a guarded vault.** The kernel gated its prior read behind `guards.length > 0`; the gate reads at dispatch top whenever any guard is registered. A guarded vault now pays one prior read on writes to collections that have no guards. No correctness impact. Follow-on: make the gate event's `existing`/`existingTs` a lazy thunk (also benefits periods).
- Guard+transforming-schema interaction is untested repo-wide (no guarded collection defines a `schema:`) — pre-existing gap, optional hardening test noted.

## Test plan

- [x] New `guards-gate-migration.test.ts` — zero-cost registration + record-lock enforcement via the gate
- [x] Gate `beforeDelete` internal-flag tests (unit + integration) updated to the new contract
- [x] Full `packages/hub` suite — 2015/2015 (incl. guards lock/freeze/onDelete + amendment/transaction tests — the real safety net for this behavior-preserving migration)
- [x] `pnpm typecheck` clean; `pnpm check:architecture` OK

## Scope

Guards only (periods already in #259). No public API change.