### PR TITLE
Track A: afterDelete observe point (completes observe-bus symmetry)

### DIFF
--- a/packages/hub/__tests__/subsystem-bus-integration.test.ts
+++ b/packages/hub/__tests__/subsystem-bus-integration.test.ts
@@ -57,4 +57,32 @@ describe('SubsystemBus integration — afterPut fires from put()', () => {
     await docs.put('a', { id: 'a', n: 1 })
     expect(spy).not.toHaveBeenCalled()
   })
+
+  it('fires afterDelete on delete() with no write-hooks registered (proves decoupling)', async () => {
+    const db = await createNoydb({ store: memoryStore(), secret: 'pw', user: 'owner' })
+    const seen: WriteEvent[] = []
+    db._subsystemBus.register('afterDelete', (e) => { seen.push(e) })
+
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<{ id: string; n: number }>('docs')
+    await docs.put('a', { id: 'a', n: 1 })
+    await docs.delete('a')
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0].op).toBe('delete')
+    expect(seen[0].collection).toBe('docs')
+    expect(seen[0].docId).toBe('a')
+    expect(seen[0].before).toEqual({ id: 'a', n: 1 })
+    expect(seen[0].after).toBeNull()
+  })
+
+  it('does not fire afterDelete when no afterDelete handler is registered (zero-cost)', async () => {
+    const db = await createNoydb({ store: memoryStore(), secret: 'pw', user: 'owner' })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<{ id: string; n: number }>('docs')
+    await docs.put('a', { id: 'a', n: 1 })
+    const spy = vi.spyOn(db._subsystemBus, 'dispatch')
+    await docs.delete('a')
+    expect(spy).not.toHaveBeenCalled()
+  })
 })

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1610,19 +1610,29 @@ export class Collection<T> {
   async delete(id: string): Promise<void> {
     await this.schemaUpdateGate?.assertWritable()
     await this.schemaFence?.assertWritable(this.name)
+    // #230 user write-hooks AND the Track A observe bus both need the
+    // WriteEvent. Build it if EITHER consumer is active so the bus is not
+    // coupled to write-hooks being present. Mirrors the put() path.
+    const hooksActive = this.#hooksActive()
+    const busAfterDelete = (this.subsystemBus?.hasHandlers('afterDelete') ?? false)
+      && !(this.subsystemBus?.dispatching ?? false)
     let event: WriteEvent | undefined
-    if (this.#hooksActive()) {
+    if (hooksActive || busAfterDelete) {
       const prior = await this.#priorForHook(id)
       event = {
         op: 'delete', vault: this.vault, collection: this.name, docId: id, before: prior.record, after: null,
         userId: this.keyring.userId, timestamp: Date.now(), txId: this.#txIdForHook(),
         baseVersion: prior.version, version: prior.version + 1,
       }
-      await this.writeHooks!.runBefore(event)
+      if (hooksActive) await this.writeHooks!.runBefore(event)
     }
     if (this.writeQueue) await this.writeQueue.track(() => this.deleteInternal(id))
     else await this.deleteInternal(id)
-    if (event) await this.writeHooks!.runAfter(event)
+    if (event) {
+      // Ordering: user afterWrite hooks run before observe-bus dispatch.
+      if (hooksActive) await this.writeHooks!.runAfter(event)
+      if (busAfterDelete) await this.subsystemBus!.dispatch('afterDelete', event)
+    }
   }
 
   /**

--- a/packages/hub/src/subsystem-bus.ts
+++ b/packages/hub/src/subsystem-bus.ts
@@ -20,6 +20,7 @@ import type { Role } from './types.js'
 /** Typed map of OBSERVE lifecycle point → event payload. Extend by adding keys. */
 export interface LifecycleEventMap {
   afterPut: WriteEvent
+  afterDelete: WriteEvent
 }
 
 export type LifecyclePoint = keyof LifecycleEventMap


### PR DESCRIPTION
> **Stacked on #260 → #259 → #257 → #256** (base = `proposal/track-a-migrate-guards`). Review/merge bottom-up; rebases automatically as each base merges.

## Summary

Completes the observe bus symmetry. Slice 1 (#256) wired only `afterPut`; this adds the matching `afterDelete` so the observe seam covers the full user write surface — the events Track B's devtools inspector subscribes to.

- Adds `afterDelete: WriteEvent` to the observe `LifecycleEventMap`.
- Dispatches `afterDelete` from the public `Collection.delete()` path, an exact mirror of the `afterPut` wiring in `put()`: event built when either #230 write-hooks OR the bus is active; `writeHooks!` only dereferenced under `hooksActive`; user `afterWrite` hooks run before the bus dispatch; re-entrancy suppressed via the bus `dispatching` flag. Zero-cost when no `afterDelete` handler is registered.

## Scope / correctness

- Fires from the **public** `delete()` only (user deletes) — housekeeping deletes (`_internalDelete → _doDelete(_, true)`) stay silent, consistent with `afterPut` firing only from public `put()`.
- Independent of the `beforeDelete` **gate** (slice 2/3b): the gate aborts pre-delete and throws before control returns, so a gated abort correctly suppresses `afterDelete`.
- Note for consumers (Track B): like `afterPut` on a create, the delete event's `version` is `baseVersion + 1` (a synthetic successor value — no envelope is written at it); `before` is the deleted record, `after` is `null`.

## Test plan

- [x] New integration tests — `afterDelete` fires on `delete()` with no write-hooks registered (decoupling) with correct event shape (`op:'delete'`, `before`=record, `after`=null); zero-cost when no handler
- [x] Full `packages/hub` suite — 2017/2017
- [x] `pnpm typecheck` clean

## Scope

Observe `afterDelete` only. No public API change.