### PR TITLE
docs: post-pre.5 cleanup — Track A spec status + SUBSYSTEMS count fix

### DIFF
--- a/SUBSYSTEMS.md
+++ b/SUBSYSTEMS.md
@@ -21,7 +21,7 @@ const db = await createNoydb({
 
 When a subsystem is not opted into, its real implementation is replaced by a NO-OP stub (or a throwing stub on opt-in surfaces) and the heavy code is fully tree-shaken from the bundle.
 
-This document lists the always-on core and the 19 subsystems. It is the table of contents for the rest of the documentation.
+This document lists the always-on core and the 21 subsystems. It is the table of contents for the rest of the documentation.
 
 ---
 

--- a/docs/superpowers/specs/2026-06-01-kernel-shrink-and-devtools-proposal.md
+++ b/docs/superpowers/specs/2026-06-01-kernel-shrink-and-devtools-proposal.md
@@ -1,7 +1,7 @@
 # Proposal: Kernel Shrink + Devtools Inspector
 
-> **Status:** Proposal (high-level, two tracks) — pre-design
-> **Date:** 2026-06-01
+> **Status:** Accepted. **Track A — shipped in `0.2.0-pre.5`** (PR #262; SubsystemBus + periods/guards migration + kernel-surface CI gate; reduced scope — the two subsystem splits + prior-read opt were deferred to #267, epic #264 closed). **Track B — pending** (devtools inspector #265, targeted `0.2.0-pre.6`; not yet started).
+> **Date:** 2026-06-01 (proposal) · updated 2026-06-02 (Track A landed)
 > **Author:** brainstorming session
 > **Scope:** Two independent efforts, each gets its own design → plan → implementation cycle after this proposal is accepted.
 


### PR DESCRIPTION
Documentation reconciliation after the **0.2.0-pre.5** release (Track A kernel shrink). Part of the post-release cleanup of issues / milestones / docs.

- **`docs/superpowers/.../kernel-shrink-and-devtools-proposal.md`** — status line updated from "Proposal — pre-design" to reflect that **Track A shipped in `0.2.0-pre.5`** (PR #262; reduced scope, tail deferred to #267, epic #264 closed) and **Track B is pending** (#265, targeted `0.2.0-pre.6`).
- **`SUBSYSTEMS.md`** — fixed a stale self-contradiction: the intro said "the **19** subsystems" while the section header and totals both say **21**. The catalog is numbered 1–21 (21 distinct subsystems; `16a` user-envelope is always-on, not counted), so 21 is correct.

Docs-only; no code, no `features.yaml` change (Track A is internal — no public feature). Spec-coverage gate verified locally.