### PR TITLE
fix(hub,in-pinia): nested i18nField path resolution + pinia i18nFields forwarding

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -333,6 +333,7 @@ features:
       - 'Records store stable keys; dictionary stores per-locale labels'
       - 'resolveLabel(key, locale, fallback) walks the fallback chain'
       - 'No transliteration (locale-specific lossy mappings stay in userland)'
+      - 'i18nField paths support dot notation (address.lineOne) and array wildcards (contacts[].title)'
     related: [vault-and-collections]
 
   - id: aggregate
@@ -1352,6 +1353,7 @@ frameworks:
     invariants:
       - 'defineNoydbStore exposes items, count, add, update, remove'
       - 'Standard Schema v1 validator installed on the underlying collection'
+      - 'i18nFields and dictKeyFields options forwarded to the underlying collection (no pre-registration needed)'
     related: [in-vue]
 
   - id: in-devtools

--- a/packages/hub/CHANGELOG.md
+++ b/packages/hub/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — hub
 
+## 0.2.0-pre.6
+
+### Fix: nested i18nField paths not resolved on read ([#273](https://github.com/vLannaAi/noy-db/issues/273))
+
+- `applyI18nLocale` now traverses **dot-notation paths** (`address.lineOne`) and **array-wildcard paths** (`contacts[].title`) when resolving i18nText fields on read. Previously only top-level keys resolved; nested paths returned the raw `{ [locale]: string }` map.
+- `enforceI18nOnPut` (required-translation validation) updated to the same path-aware traversal so nested required fields are validated on `put()`, not silently skipped.
+- Auto-translate (`autoTranslate: true`) updated to traverse dot paths; array-wildcard paths are silently skipped (unsupported for auto-translate).
+
 ## 0.2.0-pre.5
 
 ### Track A — kernel shrink ([#262](https://github.com/vLannaAi/noy-db/pull/262))

--- a/packages/hub/__tests__/i18n.test.ts
+++ b/packages/hub/__tests__/i18n.test.ts
@@ -17,15 +17,13 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { createNoydb } from '../src/noydb.js'
 import { withI18n } from '../src/i18n/index.js'
 import type { Noydb } from '../src/noydb.js'
-import { withI18n } from '../src/i18n/index.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
 import { ConflictError } from '../src/errors.js'
 import {
   MissingTranslationError,
   LocaleNotSpecifiedError,
 } from '../src/errors.js'
-import { i18nText } from '../src/i18n/core.js'
-import { resolveI18nText, validateI18nTextValue } from '../src/i18n/core.js'
+import { i18nText, applyI18nLocale, resolveI18nText, validateI18nTextValue } from '../src/i18n/core.js'
 
 // ─── Inline memory adapter ─────────────────────────────────────────────
 
@@ -409,5 +407,123 @@ describe('i18nText — Collection integration', () => {
     await expect(
       items.get('li-1', { locale: 'th' }),
     ).rejects.toThrow(LocaleNotSpecifiedError)
+  })
+})
+
+// ─── Nested i18n field paths (#273) ───────────────────────────────────
+
+describe('applyI18nLocale — nested paths (unit)', () => {
+  const desc = i18nText({ languages: ['en', 'th'], required: 'any' })
+
+  it('resolves a dot-notation path (address.lineOne)', () => {
+    const record = { address: { lineOne: { th: 'ถนนไทย', en: 'Thai Rd' } } }
+    const result = applyI18nLocale(
+      record as Record<string, unknown>,
+      { 'address.lineOne': desc },
+      'th',
+    )
+    expect((result.address as Record<string, unknown>).lineOne).toBe('ถนนไทย')
+  })
+
+  it('resolves a deeply nested dot-notation path (a.b.c)', () => {
+    const record = { a: { b: { c: { en: 'deep', th: 'ลึก' } } } }
+    const result = applyI18nLocale(
+      record as Record<string, unknown>,
+      { 'a.b.c': desc },
+      'en',
+    )
+    expect(((result.a as Record<string, unknown>).b as Record<string, unknown>).c).toBe('deep')
+  })
+
+  it('resolves an array-notation path (contacts[].title)', () => {
+    const record = {
+      contacts: [
+        { name: 'Alice', title: { th: 'นาง', en: 'Mrs.' } },
+        { name: 'Bob', title: { th: 'นาย', en: 'Mr.' } },
+      ],
+    }
+    const result = applyI18nLocale(
+      record as Record<string, unknown>,
+      { 'contacts[].title': desc },
+      'en',
+    )
+    const contacts = result.contacts as Array<Record<string, unknown>>
+    expect(contacts[0].title).toBe('Mrs.')
+    expect(contacts[1].title).toBe('Mr.')
+  })
+
+  it('leaves unrelated fields unchanged for dot-path record', () => {
+    const record = { address: { lineOne: { en: 'Main St', th: 'ถนนหลัก' }, lineTwo: 'Apt 1' } }
+    const result = applyI18nLocale(
+      record as Record<string, unknown>,
+      { 'address.lineOne': desc },
+      'en',
+    )
+    expect((result.address as Record<string, unknown>).lineTwo).toBe('Apt 1')
+  })
+})
+
+describe('i18nText — nested field paths (Collection integration)', () => {
+  let db: Noydb
+
+  beforeEach(async () => {
+    db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      i18nStrategy: withI18n(),
+      secret: 'test-passphrase-nested-i18n',
+    })
+  })
+
+  it('put and get resolves a dot-notation i18n field', async () => {
+    const vault = await db.openVault('v-nested-1')
+    type Doc = { id: string; address: { lineOne: Record<string, string> | string } }
+    const docs = vault.collection<Doc>('docs', {
+      i18nFields: {
+        'address.lineOne': i18nText({ languages: ['th', 'en'], required: ['th'] }),
+      },
+    })
+    await docs.put('d1', { id: 'd1', address: { lineOne: { th: 'ถนนไทย', en: 'Thai Rd' } } })
+    const row = await docs.get('d1', { locale: 'th' }) as { id: string; address: { lineOne: string } }
+    expect(row?.address.lineOne).toBe('ถนนไทย')
+  })
+
+  it('put validates a required dot-notation i18n field (enforceI18nOnPut)', async () => {
+    const vault = await db.openVault('v-nested-2')
+    type Doc = { id: string; address: { lineOne: Record<string, string> } }
+    const docs = vault.collection<Doc>('docs', {
+      i18nFields: {
+        'address.lineOne': i18nText({ languages: ['th', 'en'], required: ['th'] }),
+      },
+    })
+    await expect(
+      docs.put('d1', { id: 'd1', address: { lineOne: { en: 'Thai Rd' } } }),
+    ).rejects.toThrow(MissingTranslationError)
+  })
+
+  it('put and get resolves an array-path i18n field (contacts[].title)', async () => {
+    const vault = await db.openVault('v-nested-3')
+    type Doc = {
+      id: string
+      contacts: Array<{ name: string; title: Record<string, string> | string }>
+    }
+    const docs = vault.collection<Doc>('docs', {
+      i18nFields: {
+        'contacts[].title': i18nText({ languages: ['th', 'en'], required: 'any' }),
+      },
+    })
+    await docs.put('d1', {
+      id: 'd1',
+      contacts: [
+        { name: 'Alice', title: { th: 'นาง', en: 'Mrs.' } },
+        { name: 'Bob', title: { th: 'นาย', en: 'Mr.' } },
+      ],
+    })
+    const row = await docs.get('d1', { locale: 'en' }) as {
+      id: string
+      contacts: Array<{ name: string; title: string }>
+    }
+    expect(row?.contacts[0].title).toBe('Mrs.')
+    expect(row?.contacts[1].title).toBe('Mr.')
   })
 })

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -3,6 +3,7 @@ import { NOYDB_FORMAT_VERSION } from './types.js'
 import type { CrdtMode, CrdtState, LwwMapState, RgaState } from './crdt/crdt.js'
 import { NO_CRDT, type CrdtStrategy } from './crdt/strategy.js'
 import type { I18nTextDescriptor } from './i18n/core.js'
+import { getAtPath, setAtPathInPlace } from './i18n/core.js'
 import type { DictKeyDescriptor } from './i18n/dictionary.js'
 import { NO_I18N, type I18nStrategy } from './i18n/strategy.js'
 import { encrypt, decrypt, encryptDeterministic } from './crypto.js'
@@ -1157,7 +1158,11 @@ export class Collection<T> {
       const obj = record as Record<string, unknown>
       for (const [field, descriptor] of Object.entries(this.i18nFields)) {
         if (!descriptor.options.autoTranslate) continue
-        const value = obj[field]
+        // getAtPath returns [] for array-wildcard paths — auto-translate on
+        // 'contacts[].field' style paths is not supported; skip silently.
+        const leafValues = getAtPath(obj, field)
+        if (leafValues.length !== 1) continue
+        const value = leafValues[0]
         if (!value || typeof value !== 'object' || Array.isArray(value)) continue
         const map = value as Record<string, string>
         // Determine which locales need translation. For 'all', translate all
@@ -1191,7 +1196,7 @@ export class Collection<T> {
             this.name,
           )
         }
-        ;(record as Record<string, unknown>)[field] = translated
+        setAtPathInPlace(obj, field, translated)
       }
     }
 

--- a/packages/hub/src/i18n/core.ts
+++ b/packages/hub/src/i18n/core.ts
@@ -253,18 +253,117 @@ export function resolveI18nText(
   )
 }
 
+// ─── Path helpers (nested i18nFields like 'address.lineOne') ──────────
+
 /**
- * Apply locale resolution to a single record, in-place over a copy.
+ * Return all leaf values at `path`, expanding `[].` array wildcards.
+ *
+ * - `'name'`              → `[obj.name]`
+ * - `'address.lineOne'`   → `[obj.address.lineOne]`
+ * - `'contacts[].title'`  → `[obj.contacts[0].title, obj.contacts[1].title, …]`
+ *
+ * Returns an empty array when the path does not resolve (missing key,
+ * wrong type, etc.). Used by `enforceI18nOnPut` to validate nested fields.
+ */
+export function getAtPath(obj: Record<string, unknown>, path: string): unknown[] {
+  const arrayIdx = path.indexOf('[].')
+  if (arrayIdx !== -1) {
+    const arrayKey = path.slice(0, arrayIdx)
+    const restPath = path.slice(arrayIdx + 3)
+    const arr = obj[arrayKey]
+    if (!Array.isArray(arr)) return []
+    return arr.flatMap(item => {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) return []
+      return getAtPath(item as Record<string, unknown>, restPath)
+    })
+  }
+  const dotIdx = path.indexOf('.')
+  if (dotIdx !== -1) {
+    const head = path.slice(0, dotIdx)
+    const rest = path.slice(dotIdx + 1)
+    const nested = obj[head]
+    if (!nested || typeof nested !== 'object' || Array.isArray(nested)) return []
+    return getAtPath(nested as Record<string, unknown>, rest)
+  }
+  const val = obj[path]
+  return val !== undefined ? [val] : []
+}
+
+/**
+ * Mutate `obj` in-place, setting `value` at the nested `path`.
+ * Supports dot notation (`'address.lineOne'`) but not array wildcards —
+ * auto-translate on `contacts[].title` style paths is not supported.
+ */
+export function setAtPathInPlace(
+  obj: Record<string, unknown>,
+  path: string,
+  value: unknown,
+): void {
+  const dotIdx = path.indexOf('.')
+  if (dotIdx !== -1) {
+    const head = path.slice(0, dotIdx)
+    const rest = path.slice(dotIdx + 1)
+    const nested = obj[head]
+    if (!nested || typeof nested !== 'object' || Array.isArray(nested)) return
+    setAtPathInPlace(nested as Record<string, unknown>, rest, value)
+    return
+  }
+  obj[path] = value
+}
+
+/** Recursively resolve i18nText at a single path within a record copy. */
+function applyAtPath(
+  obj: Record<string, unknown>,
+  path: string,
+  locale: string,
+  fallback: string | readonly string[] | undefined,
+): Record<string, unknown> {
+  const arrayIdx = path.indexOf('[].')
+  if (arrayIdx !== -1) {
+    const arrayKey = path.slice(0, arrayIdx)
+    const restPath = path.slice(arrayIdx + 3)
+    const arr = obj[arrayKey]
+    if (!Array.isArray(arr)) return obj
+    return {
+      ...obj,
+      [arrayKey]: arr.map(item => {
+        if (!item || typeof item !== 'object' || Array.isArray(item)) return item
+        return applyAtPath(item as Record<string, unknown>, restPath, locale, fallback)
+      }),
+    }
+  }
+  const dotIdx = path.indexOf('.')
+  if (dotIdx !== -1) {
+    const head = path.slice(0, dotIdx)
+    const rest = path.slice(dotIdx + 1)
+    const nested = obj[head]
+    if (!nested || typeof nested !== 'object' || Array.isArray(nested)) return obj
+    return {
+      ...obj,
+      [head]: applyAtPath(nested as Record<string, unknown>, rest, locale, fallback),
+    }
+  }
+  const raw = obj[path]
+  if (raw === undefined || raw === null) return obj
+  if (typeof raw !== 'object' || Array.isArray(raw)) return obj
+  return {
+    ...obj,
+    [path]: resolveI18nText(raw as Record<string, string>, locale, fallback, path),
+  }
+}
+
+/**
+ * Apply locale resolution to a single record, returning a new copy.
  *
  * For each field registered as an `i18nText` descriptor:
  * - If `locale === 'raw'`, the field value is left as the stored map.
  * - Otherwise, the field value is replaced with the resolved string.
  *
- * Records that are not plain objects (null, array, primitives) are
- * returned unchanged.
+ * Field paths support dot notation (`'address.lineOne'`) and array
+ * wildcards (`'contacts[].title'`). Top-level fields work as before.
  *
  * @param record      The decrypted record.
- * @param i18nFields  Map of field name → `I18nTextDescriptor`.
+ * @param i18nFields  Map of field path → `I18nTextDescriptor`.
  * @param locale      The requested locale (or `'raw'`).
  * @param fallback    Fallback chain (optional).
  */
@@ -277,19 +376,10 @@ export function applyI18nLocale(
   const fieldNames = Object.keys(i18nFields)
   if (fieldNames.length === 0) return record
 
-  const result = { ...record }
+  let result = record
 
   for (const field of fieldNames) {
-    const raw = result[field]
-    if (raw === undefined || raw === null) continue
-    if (typeof raw !== 'object' || Array.isArray(raw)) continue
-
-    result[field] = resolveI18nText(
-      raw as Record<string, string>,
-      locale,
-      fallback,
-      field,
-    )
+    result = applyAtPath(result, field, locale, fallback)
   }
 
   return result

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -68,6 +68,7 @@ import {
 import type { DictionaryHandle, DictionaryOptions, DictKeyDescriptor } from './i18n/dictionary.js'
 import { isDictCollectionName } from './i18n/dictionary.js'
 import type { I18nTextDescriptor } from './i18n/core.js'
+import { getAtPath } from './i18n/core.js'
 import { NO_I18N, type I18nStrategy } from './i18n/strategy.js'
 import { NO_SYNC, type SyncStrategy } from './team/sync-strategy.js'
 // Type-only imports for the guard + derivation subsystems. The
@@ -925,9 +926,11 @@ export class Vault {
 
     const obj = record as Record<string, unknown>
     for (const [field, descriptor] of Object.entries(i18nFields)) {
-      const value = obj[field]
-      if (value === undefined || value === null) continue
-      this.i18nStrategy.validateI18nTextValue(value, field, descriptor)
+      const values = getAtPath(obj, field)
+      for (const value of values) {
+        if (value === undefined || value === null) continue
+        this.i18nStrategy.validateI18nTextValue(value, field, descriptor)
+      }
     }
   }
 

--- a/packages/in-pinia/CHANGELOG.md
+++ b/packages/in-pinia/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog — in-pinia
 
+## 0.2.0-pre.6
+
+### Fix: i18nFields / dictKeyFields not forwarded to collection ([#274](https://github.com/vLannaAi/noy-db/issues/274))
+
+- `NoydbStoreOptions` now accepts `i18nFields` and `dictKeyFields`, forwarded to the underlying `Collection` exactly like the existing `schemaUpdate`/`attestation` pass-through. Apps with i18n or dictionary collections no longer need a separate `vault.collection(name, { i18nFields })` pre-registration call before the store initialises.
+
 ## 0.2.0-pre.5
 
 Version-only lockstep bump; no source changes since pre.4.

--- a/packages/in-pinia/__tests__/defineNoydbStore.test.ts
+++ b/packages/in-pinia/__tests__/defineNoydbStore.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { setActivePinia, createPinia, storeToRefs } from 'pinia'
 import { effectScope } from 'vue'
-import { createNoydb, additiveOnly, type Noydb, type NoydbStore, type EncryptedEnvelope, type VaultSnapshot, type StandardSchemaV1, ConflictError, Query } from '@noy-db/hub'
+import { createNoydb, additiveOnly, i18nText, type Noydb, type NoydbStore, type EncryptedEnvelope, type VaultSnapshot, type StandardSchemaV1, ConflictError, Query } from '@noy-db/hub'
+import { withI18n } from '@noy-db/hub/i18n'
 import { defineNoydbStore, setActiveNoydb } from '../src/index.js'
 
 /** Inline memory adapter — same pattern as @noy-db/core integration tests. */
@@ -475,5 +476,62 @@ describe('schema-update option forwarding (#255)', () => {
     expect(opts?.schemaUpdate).toHaveLength(1)
 
     spy.mockRestore()
+  })
+})
+
+// ─── i18nFields / dictKeyFields forwarding (#274) ──────────────────────
+
+describe('defineNoydbStore — i18nFields / dictKeyFields forwarding', () => {
+  let db: Noydb
+
+  beforeEach(async () => {
+    setActivePinia(createPinia())
+    db = await createNoydb({
+      store: memory(),
+      user: 'owner',
+      i18nStrategy: withI18n(),
+      secret: 'pinia-i18n-test-passphrase',
+    })
+    setActiveNoydb(db)
+  })
+
+  it('forwards i18nFields to vault.collection', async () => {
+    const vault = await db.openVault('shop')
+    const spy = vi.spyOn(Object.getPrototypeOf(vault) as { collection: unknown }, 'collection')
+
+    const nameDesc = i18nText({ languages: ['en', 'th'], required: 'any' })
+    const useProducts = defineNoydbStore('products-i18n-fwd', {
+      vault: 'shop',
+      collection: 'products',
+      i18nFields: { name: nameDesc },
+    })
+    const store = useProducts()
+    await store.$ready.catch(() => {})
+
+    const call = spy.mock.calls.find((c) => c[0] === 'products')
+    expect(call, 'vault.collection("products", …) should have been called').toBeTruthy()
+    const opts = call![1] as { i18nFields?: Record<string, unknown> }
+    expect(opts?.i18nFields).toBeDefined()
+    expect(opts?.i18nFields?.name).toBe(nameDesc)
+
+    spy.mockRestore()
+  })
+
+  it('resolves i18n field on read when forwarded', async () => {
+    type Product = { id: string; name: Record<string, string> | string }
+    const nameDesc = i18nText({ languages: ['en', 'th'], required: 'any' })
+    const useProducts = defineNoydbStore<Product>('products-i18n-read', {
+      vault: 'shop2',
+      i18nFields: { name: nameDesc },
+    })
+    const store = useProducts()
+    await store.$ready
+
+    await store.add('p1', { id: 'p1', name: { en: 'Widget', th: 'วิดเจ็ต' } })
+
+    const vault = await db.openVault('shop2')
+    const col = vault.collection<Product>('products-i18n-read')
+    const row = await col.get('p1', { locale: 'th' }) as { id: string; name: string }
+    expect(row.name).toBe('วิดเจ็ต')
   })
 })

--- a/packages/in-pinia/src/defineNoydbStore.ts
+++ b/packages/in-pinia/src/defineNoydbStore.ts
@@ -33,6 +33,8 @@ import type {
   Collection,
   Query,
   StandardSchemaV1,
+  I18nTextDescriptor,
+  DictKeyDescriptor,
 } from '@noy-db/hub'
 import { resolveNoydb } from './context.js'
 
@@ -109,6 +111,18 @@ export interface NoydbStoreOptions<T> {
    * declaratively, without a pre-registration `vault.collection(...)` call.
    */
   schemaUpdate?: NonNullable<Parameters<Vault['collection']>[1]>['schemaUpdate']
+  /**
+   * Per-field `i18nText()` descriptors. Forwarded to the underlying
+   * `Collection` so locale resolution and required-translation validation
+   * run declaratively without a separate `vault.collection(name, { i18nFields })`
+   * pre-registration call.
+   */
+  i18nFields?: Record<string, I18nTextDescriptor>
+  /**
+   * Per-field `dictKey()` descriptors. Forwarded to the underlying
+   * `Collection` so dictionary label resolution runs declaratively.
+   */
+  dictKeyFields?: Record<string, DictKeyDescriptor>
 }
 
 /**
@@ -173,6 +187,8 @@ export function defineNoydbStore<T>(
       if (options.attestation !== undefined) collOpts.attestation = options.attestation
       if (options.persistJsonSchema !== undefined) collOpts.persistJsonSchema = options.persistJsonSchema
       if (options.schemaUpdate !== undefined) collOpts.schemaUpdate = options.schemaUpdate
+      if (options.i18nFields !== undefined) collOpts.i18nFields = options.i18nFields
+      if (options.dictKeyFields !== undefined) collOpts.dictKeyFields = options.dictKeyFields
       cachedCollection = cachedCompartment.collection<T>(collectionName, collOpts)
       return cachedCollection
     }


### PR DESCRIPTION
Fixes two i18n gaps found while adopting native i18n in the niwat app.

## #273 — Nested i18nField paths not resolved on read (`@noy-db/hub`)

**Root cause:** `applyI18nLocale` did `result[field]` where `field` is the full path string (e.g. `"address.lineOne"`), so the lookup always returned `undefined` and the raw map was returned unchanged.

**Fix:** Recursive `applyAtPath` helper handles:
- Dot notation: `address.lineOne` — traverses into the nested object, resolves the leaf
- Array wildcards: `contacts[].title` — maps over the array, resolves the field in each element

Both `enforceI18nOnPut` (required-translation validation) and the auto-translate loop are fixed with the same `getAtPath` path-aware helper so nested fields are validated on `put()` and auto-translated on dot paths. Array-wildcard auto-translate is silently skipped (unsupported).

**Tests:** 7 new tests — 4 unit (`applyI18nLocale` direct) + 3 Collection integration (dot-path read, dot-path put-validation, array-path read). All watched fail before implementation.

## #274 — `defineNoydbStore` can't forward `i18nFields` / `dictKeyFields` (`@noy-db/in-pinia`)

**Root cause:** `NoydbStoreOptions` and `getCollection()` only forwarded `schema`, `attestation`, `persistJsonSchema`, `schemaUpdate` to the underlying `Collection`.

**Fix:** Added `i18nFields?` and `dictKeyFields?` to `NoydbStoreOptions`, forwarded in `getCollection()` mirroring the existing `schemaUpdate` pass-through pattern.

**Tests:** 2 new tests — spy-based forwarding check + end-to-end locale resolution via a store-declared `i18nFields`.

## Verification

Full suite: **3269 tests passed, 0 regressions**. Typecheck + lint clean. features.yaml + changelogs updated.