### PR TITLE
feat(hub): Dim 11 — cross-join query primitive (.crossJoin())

### DIFF
--- a/docs/subsystems/cross-join.md
+++ b/docs/subsystems/cross-join.md
@@ -1,0 +1,77 @@
+# cross-join
+
+> **Subpath:** *(currently always-core)*
+> **Cluster:** A — Read & Query
+> **Spec:** `docs/superpowers/specs/2026-05-20-dim11-cross-join-v1-design.md`
+
+## What it does
+
+Cartesian-product cross-join between any two collections in the same vault via `.crossJoin(target, { as })`. Each result row carries the original left fields plus `row[as]` populated from the right side.
+
+The optional `on:` parameter enables a **lateral form** — the right-side rows are filtered per left row:
+- **Subset:** `on: (left) => TTarget[]` — return only the right rows that pair with `left`
+- **Predicate:** `on: (left) => (right) => boolean` — executor materializes then filters
+- **MV-safe:** `on: { predicate: 'name' }` — resolves a named predicate from the MV's `predicates` map; queryHash-tracked for drift detection
+
+Composes in declared order with `.where()`, `.groupBy()`, and `.aggregate()`. Cross-join clauses are interleaved with filter clauses: a `.where()` BEFORE `.crossJoin()` filters the left side first (cheaper); a `.where()` AFTER can reference aliased right-side fields.
+
+## When you need it
+
+- Period × entity analytics (DERIV-SSO-001 pattern): active workers per pay period, coverage per billing cycle
+- Multi-dimension reporting: every product × every region → aggregate
+- Derived collections whose shape is inherently "every A paired with every B"
+
+## API
+
+```ts
+query.crossJoin<TTarget, As extends string>(
+  target: string,
+  opts: {
+    as: As
+    on?: ((left: T) => TTarget[] | ((right: TTarget) => boolean)) | { predicate: string }
+    maxRows?: number   // default: DEFAULT_CROSS_JOIN_MAX_ROWS (50_000)
+  }
+): Query<T & { [K in As]: TTarget }>
+```
+
+## Cost ceiling
+
+`CrossJoinTooLargeError` fires **before** allocation when the product (or cumulative lateral count) exceeds the ceiling. Default: 50,000 rows (matches `JoinTooLargeError`). Override per-clause with `{ maxRows: N }`.
+
+## Example — DERIV-SSO-001
+
+```ts
+const result = periods.query()
+  .crossJoin<Worker, 'worker'>('workers', {
+    as: 'worker',
+    on: (period) => (worker) =>
+      worker.since <= period.start &&
+      (worker.until === null || worker.until >= period.end),
+  })
+  .groupBy('id')
+  .aggregate({ workerCount: count() })
+  .run()
+// → [{ id: 'q1', workerCount: 2 }, { id: 'q2', workerCount: 2 }, ...]
+```
+
+## Behavior in live queries
+
+`.live()` subscribes to BOTH the left source and all cross-join right-side sources. A mutation on either side re-fires the live query.
+
+## Edge cases & limits
+
+- **Row ceiling:** `CrossJoinTooLargeError` at 50,000 rows. Raise with `{ maxRows: N }`.
+- **Lateral ceiling:** charged cumulatively — the ceiling applies to the total post-filter count across ALL left rows, not per-left-row.
+- **MV inline `on:` callback:** drift detection disabled; warning emitted at build time. Use `on: { predicate: 'name' }` for MV use.
+- **`executePlan()` (pure):** throws if called with a plan containing crossJoin clauses — use `Query.toArray()` instead.
+- **Same-vault only:** both collections must be in the same vault. Cross-vault correlation goes through `Noydb.queryAcross`.
+
+## Deferred (out of scope for v3)
+
+`.leftJoin` / outer joins, anti-join, cross-join over MV virtual collections, cost-based query planner, index-aware hash-join downgrade, streaming MV cross-join.
+
+## See also
+
+- [SUBSYSTEMS.md](../../SUBSYSTEMS.md)
+- [joins.md](./joins.md) — FK joins (intra-vault, declared `ref()`)
+- Showcase 92 — DERIV-SSO-001 end-to-end

--- a/docs/superpowers/specs/2026-05-20-dim11-cross-join-v1-design.md
+++ b/docs/superpowers/specs/2026-05-20-dim11-cross-join-v1-design.md
@@ -1,0 +1,351 @@
+# Dimension 11 (hub core / query DSL) — cross-join v1 design
+
+> Extends the query DSL with **cross-join** semantics. Driven primarily by Dim 14 v2's deferred SSO-style use cases (the MV v2 spec — [`2026-05-20-dim14-mv-v2-design.md`](./2026-05-20-dim14-mv-v2-design.md) — defers cross-product to v3), but landing as a general-purpose query primitive: any query consumer can use `.crossJoin()`, not just MVs.
+
+## Goal
+
+Ship a `.crossJoin(targetCollection, { as })` terminal on the `Query<T>` builder so consumers can express **cartesian-product** relations between two collections. Combined with `.wherePredicate(name, ctx?)` (shipped in MV v2), this lets queries express "every left × every right" plus filter — the structural shape SQL `CROSS JOIN ... WHERE` and the niwat `DERIV-SSO-001` rule both need.
+
+## Success criteria (acceptance)
+
+- A query can declare `.crossJoin('rightCollection', { as: 'alias' })` and receive each row of the result with `row.alias` populated from every row of the right collection.
+- Multi-step cross-joins compose: `.crossJoin('A', { as: 'a' }).crossJoin('B', { as: 'b' })` produces an L × A × B product.
+- `.wherePredicate(name, ctx?)` operates on the cross-joined row (its own fields *and* every joined alias) — closes the DERIV-SSO-001 path.
+- Cost ceiling enforced: `CrossJoinTooLargeError` fires when the resulting row count exceeds a configurable limit (default conservative — see § Cost ceiling).
+- Query plan + cycle detection extend cleanly: `QueryDependencyAnalyzer` treats cross-joined collections as dependency sources for MV refresh.
+- Same DEK semantics as FK joins: read happens after DEK unwrap, on plaintext.
+- Conformance tests pass on `to-memory` and `to-file`.
+
+## v3 SCOPE — what's in
+
+| Feature | In v3 | Notes |
+|---|:---:|---|
+| `.crossJoin(name, { as })` builder terminal | ✓ | Cartesian product against a vault collection by name |
+| Multi-step chains (`L × A × B`) | ✓ | Naturally composable; cost ceiling applies to the cumulative product |
+| Composition with `.where()` / `.wherePredicate()` on the joined row | ✓ | Where-clauses + declared predicates see all aliases |
+| Composition with `.groupBy()` and `.aggregate()` | ✓ | The cross-join feeds the group-by relation as-is |
+| Composition with FK `.join(field, { as })` | ✓ | Order independent: cross-join + FK-join in the same query |
+| Cost ceiling: `CrossJoinTooLargeError` at `max(50k, leftRows × rightRows)` cumulative cap | ✓ | Same shape as `JoinTooLargeError` / `MaterializedViewTooLargeError` |
+| `QueryDependencyAnalyzer` extension — cross-joined collections in dep set | ✓ | MV refreshes correctly when EITHER side writes |
+| Lateral cross-join (right side parameterized by left row) | ✓ | `.crossJoin('right', { as, on: (leftRow) => leftSubset })` — restricted form, see § Lateral form |
+| Subsystem doc (`docs/subsystems/query-dsl.md`) — new § Cross-join | ✓ | Reader-facing |
+| Showcase under `showcases/src/` | ✓ | DERIV-SSO-001 shape end-to-end |
+
+## v3 SCOPE — what's deferred
+
+| Feature | Deferred to | Why |
+|---|---|---|
+| `.leftJoin` / `.rightJoin` / `.fullOuterJoin` semantics with NULLs | v3.x or later | Different shape — NULLs in result rows propagate through every downstream operator (`.where`, `.aggregate`); needs a coherent null-handling story across the DSL |
+| Anti-join (`.where NOT EXISTS`) | v3.x | Sibling primitive; expressible today as `.crossJoin + .where + .groupBy + count() === 0` but ugly. Dedicated terminal can wait. |
+| Self cross-join with the SAME alias on both sides | v3.x | Naming collision; requires a `.crossJoinWith({ leftAs, rightAs })` variant. Rare. |
+| Cross-join over `withMaterializedView` virtual collections | v3.x | Layering question — `OverlayResolver` from MV v2 has to expand cross-join right-hand-sides through to underlying base + overlay collections. Solvable but cross-cutting; defer until MV v2 stabilizes. |
+| Cross-join cost-based query planner (reorder for smaller intermediate) | v3.x or later | v3 always evaluates left-to-right as declared; consumer responsibility to put the smaller side first |
+| Index-aware cross-join (skip cartesian when the predicate is field-equality) | v4 | When `.crossJoin('R').where('L.x', '==', 'R.y')` is really a hash-join in disguise, the executor should detect and downgrade. Optimisation, not correctness. |
+| Cross-join in streaming MV (Dim 12 sources) | v4 | Streaming joins are a separate primitive territory |
+
+## Architecture
+
+### Where it sits
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ Application                                              │
+│   periods.query()                                        │
+│     .crossJoin('workers', { as: 'worker' })              │
+│     .wherePredicate('activeInPeriod')                    │
+│     .groupBy('id').aggregate({ workerCount: count() })   │
+└─────────────────────────┬────────────────────────────────┘
+                          ▼
+┌──────────────────────────────────────────────────────────┐
+│ QueryBuilder.crossJoin — NEW terminal                    │
+│   Appends a CrossJoinClause to QueryPlan.clauses         │
+└─────────────────────────┬────────────────────────────────┘
+                          ▼
+┌──────────────────────────────────────────────────────────┐
+│ executePlan (modified)                                   │
+│   When evaluating clauses, on encountering a CrossJoin:  │
+│   1. Fetch right-side snapshot (or lateral subset)       │
+│   2. Expand current intermediate × right                 │
+│   3. Cost-ceiling check                                  │
+│   4. Continue with cartesian-expanded relation           │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Modified vs new components
+
+| Component | File | Change |
+|---|---|---|
+| `CrossJoinClause` type | `packages/hub/src/query/predicate.ts` (modify) | New clause variant in the `Clause` union |
+| `QueryBuilder.crossJoin()` | `packages/hub/src/query/builder.ts` (modify) | New chainable terminal |
+| `executePlan` cross-join branch | `packages/hub/src/query/builder.ts` (modify) | Cartesian expansion at the right point in the clause-loop |
+| `CrossJoinTooLargeError` | `packages/hub/src/errors.ts` (modify) | New error class |
+| `QueryDependencyAnalyzer` extension | `packages/hub/src/materialized-views/dependency-analyzer.ts` (modify; from MV v2) | Cross-joined collections added to dependency set |
+| Subsystem doc | `docs/subsystems/query-dsl.md` (extend) | New § Cross-join |
+| Showcase | `showcases/src/86-cross-join-sso.showcase.test.ts` | DERIV-SSO-001 end-to-end |
+
+## Key invariants
+
+- **Zero-knowledge preserved.** The right-hand collection is read after DEK unwrap, on plaintext. The cross-join expansion happens inside the encrypted boundary, identical to FK joins.
+- **No new wire format.** Cross-join is a query-time operation; nothing is persisted by the primitive itself. (MVs built atop cross-join still persist their results via the standard `_materializedFrom` envelope.)
+- **No new store interface.** The right-side fetch uses the same `Collection.list()` / cached snapshot path FK joins use.
+- **Determinism preserved.** `queryHash` in MVs folds the cross-join target collection name + alias. Switching from `.crossJoin('A', { as: 'x' })` to `.crossJoin('B', { as: 'x' })` changes the hash → forces refresh.
+- **Cost ceiling is honest.** No silent magic — the ceiling is the product of left-rows × right-rows (or, for chained cross-joins, the cumulative product). Throws before allocating the expanded relation.
+
+## Type surface
+
+```ts
+// New clause variant in the existing union
+type Clause =
+  | FieldClause          // .where(field, op, value)
+  | GroupClause          // .or(...)
+  | JoinClause           // .join(field, { as }) — existing FK
+  | CrossJoinClause      // NEW
+  | GroupByClause        // .groupBy(field)
+  | AggregateClause      // .aggregate({ ... })
+
+interface CrossJoinClause {
+  type: 'crossJoin'
+  /**
+   * Target collection name. Must be a vault-known collection at MV
+   * registration time (or query-execution time for ad-hoc queries).
+   */
+  target: string
+  /**
+   * Alias under which the right-side row is exposed on each result
+   * row: `result.<as>` carries the entire right-side record.
+   */
+  as: string
+  /**
+   * Optional lateral filter — when supplied, the right-side rows are
+   * filtered per-left-row by the returned subset/predicate. See §
+   * Lateral form. Omit for full cartesian product.
+   */
+  on?: (leftRow: unknown) => unknown[] | ((rightRow: unknown) => boolean)
+  /**
+   * Per-clause cost ceiling override. Default is the query-wide
+   * `crossJoinMaxRows` (or the package default — see § Cost ceiling).
+   */
+  maxRows?: number
+}
+
+// Added to QueryBuilder<T> (type-only here; the implementation extends
+// the chainable builder in packages/hub/src/query/builder.ts)
+interface QueryBuilder<T> {
+  /**
+   * Cartesian product against `target` collection. Each row of the
+   * result carries the original `T` fields plus `[as]: TargetRow`.
+   *
+   * Cost ceiling applies — `CrossJoinTooLargeError` fires before
+   * materialization if the product would exceed it.
+   */
+  crossJoin<TTarget = unknown, TAs extends string = string>(
+    target: string,
+    options: { as: TAs; on?: (left: T) => TTarget[] | ((right: TTarget) => boolean); maxRows?: number },
+  ): QueryBuilder<T & { [K in TAs]: TTarget }>
+}
+```
+
+## Cost ceiling
+
+Cartesian explosion is the textbook "query goes bad" failure. v3 sets a conservative default:
+
+- **Default cap:** the smaller of `50_000` (matches `JoinTooLargeError`) or `leftRows × rightRows` evaluated at fetch time. The check fires **before** the expanded relation is materialized — no allocation past the limit.
+- **Per-clause override:** `crossJoin(target, { as, maxRows: 200_000 })`. Use when the domain warrants it (e.g. small `periods` × medium `workers` at niwat's 30 × ~10 ≈ 300 rows, comfortable under any default).
+- **Chained cross-joins:** the cap applies to the **cumulative** product, not the per-step product. `.crossJoin('A', ...).crossJoin('B', ...)` is `L × A × B`; the ceiling sees the running total at each step.
+- **Lateral form:** the `on:` filter is applied during expansion. The cost ceiling sees the *post-filter* count, so `.crossJoin('workers', { on: (period) => activeWorkers(period) })` charges only the filtered cross-product.
+
+`CrossJoinTooLargeError(target, expected, limit)` carries the would-be row count and the configured limit. Surfaces at the executor; rolls back transactions the same way `JoinTooLargeError` does.
+
+## Lateral form
+
+Standard SQL `LATERAL JOIN`: the right side's row set depends on the current left row. v3 ships a restricted form via the optional `on:` callback:
+
+```ts
+periods.query()
+  .crossJoin('workers', {
+    as: 'worker',
+    on: (period) => (worker) =>
+      worker.employmentPeriods.some(p =>
+        p.start <= period.start && (p.end === null || p.end >= period.end)),
+  })
+  .groupBy('id')  // period.id
+  .aggregate({ workerCount: count() })
+```
+
+Two callback shapes accepted:
+
+- **Subset:** `on: (left) => TTarget[]` — the consumer returns the exact right-side rows that should pair with `left`. Most efficient when the consumer has an index or pre-computed set.
+- **Predicate:** `on: (left) => (right) => boolean` — the executor materializes `left × right` then filters. Convenient; pays full cartesian cost (still bounded by ceiling).
+
+The lateral form is **not equivalent** to `.crossJoin + .wherePredicate` because:
+
+- The lateral filter has access to `left` at the callback construction site (closure), avoiding the need to pass it through `ctx`.
+- The lateral filter can return a subset directly (`TTarget[]`), enabling index-aware paths.
+- The cost ceiling charges the post-filter count, not the pre-filter cartesian.
+
+`.wherePredicate` remains the right choice for filters that look across the whole joined row using a registered/hashed predicate (so MV `queryHash` tracks function changes). Use `on:` for filters that are inherent to the join itself.
+
+### Determinism of `on:`
+
+`on:` callbacks have the same `queryHash` concern as raw predicates: function bodies aren't canonically serializable. For MV use, **the `on:` callback must be paired with a declared predicate name in the MV's `predicates` map**:
+
+```ts
+withMaterializedView({
+  predicates: {
+    activeInPeriod: { hash: 'active-in-period-v1', fn: ... },
+  },
+  query: () => periods.query()
+    .crossJoin('workers', {
+      as: 'worker',
+      on: { predicate: 'activeInPeriod' },  // refers to predicates map
+    })
+    ...
+})
+```
+
+The `on: { predicate: name }` shape is the MV-compatible declaration; the inline `on: (left) => ...` callback shape works for ad-hoc queries (no MV / no hash tracking). Both shapes share the cost ceiling and the lateral-execution path.
+
+## Composition
+
+### With `.where` and `.wherePredicate`
+
+The result row of a cross-join carries both `T` fields and `result[as]` from the joined relation. Where-clauses see all of it:
+
+```ts
+.crossJoin('users', { as: 'u' }).where('u.role', '==', 'admin')
+```
+
+The dotted-path is the existing convention from FK `.join()` — same access semantics. `.wherePredicate(name)` likewise sees the merged row.
+
+### With `.groupBy` and `.aggregate`
+
+After cross-join, the relation has shape `T & { [as]: TTarget }`. `.groupBy(field)` accepts any path:
+
+```ts
+.crossJoin('periods', { as: 'p' }).groupBy('p.id').aggregate({ workers: count() })
+```
+
+### With FK `.join`
+
+Order-independent. Both shapes coexist:
+
+```ts
+invoices.query()
+  .join('clientId', { as: 'client' })           // FK join — invoice's clientId → clients
+  .crossJoin('reportingPeriods', { as: 'p' })   // every invoice × every reporting period
+  .where('p.year', '==', 2026)
+  .groupBy('p.month').aggregate({ total: sum('amount') })
+```
+
+## Cycle detection + MV dependency analysis
+
+MV v2's `QueryDependencyAnalyzer` already walks the clause list and adds FK-join targets to the dependency set. Extension for cross-join is symmetric:
+
+```ts
+function analyzeDependencies(plan, joinContext, overlayResolver) {
+  // ... existing code for root + joins + groups ...
+  for (const clause of plan.clauses) {
+    if (clause.type === 'join') {
+      // existing FK path
+    } else if (clause.type === 'crossJoin') {
+      // NEW: cross-join target is a dependency source
+      expand(clause.target, deps, overlayResolver)
+    }
+    // ...
+  }
+}
+```
+
+Both sides of the cross-join are MV dependency sources — writes to either trigger refresh. Same shallow-expansion-through-overlays semantics as the v2 spec.
+
+Cycle detection: no new edge type. `crossJoin('R')` adds `R → MV-name` to the graph the same way an FK-join would. The shared `DerivationRegistry` DFS handles it.
+
+## Execution model
+
+```
+executePlan walks clauses in declared order. State during walk:
+  rel: the current relation (initially a snapshot of the root collection)
+
+On each clause:
+  .where           — filter rel
+  .or              — group-or filter rel
+  .join            — extend each row with FK-joined alias
+  .crossJoin       — for each row r in rel, for each right row r':
+                     emit { ...r, [as]: r' } if on: passes (or always)
+                     CHECK ceiling: |rel| × |right|.post-filter
+  .groupBy         — collapse rel by group key
+  .aggregate       — produce final result from groups (or whole rel)
+```
+
+The cross-join step replaces `rel` with the expanded relation. For chained cross-joins each step charges against the cumulative ceiling.
+
+## Error handling
+
+| Failure | Behavior |
+|---|---|
+| `target` collection unknown at query construction time | Throw `CrossJoinSourceUnknownError` (the analyzer surfaces this at MV registration; ad-hoc queries surface at first execution) |
+| Expanded relation exceeds ceiling | Throw `CrossJoinTooLargeError(target, expected, limit)` before allocating; rolls back transactions |
+| `on:` callback throws | Treat as a user-supplied filter throw — propagate normally (matches `.where` predicate-throw behavior) |
+| MV uses `on: (left) => ...` inline callback instead of `on: { predicate: name }` | `queryHash` cannot include the function; warn at registration that drift detection is disabled for this MV. Ad-hoc queries are unaffected. |
+| Cross-join chained with a collection that doesn't exist on `to-file` (lazy) | The lazy-fetch path triggers materialization; cost ceiling check happens after fetch resolves |
+
+## Testing strategy
+
+### Unit tests
+
+- `QueryBuilder.crossJoin` — basic chainability; multi-step cross-joins; type-flow through `as` aliases
+- `executePlan` cross-join — pure cartesian product; lateral form (subset and predicate variants); cost ceiling enforcement before allocation
+- `QueryDependencyAnalyzer` extension — cross-joined collections appear in MV dependency sets
+- `_materializedFrom` queryHash — folds cross-join target + alias; bump fires refresh
+- Conformance suite — passes on `to-memory` and `to-file`
+
+### Integration tests
+
+- DERIV-SSO-001 showcase — `periods.crossJoin('workers', { as, on: predicate-by-name }).groupBy('id').aggregate({ workerCount: count() })`; verifies the niwat-rulebook path in pre-15 (assuming v3 ships with v2)
+- Cost ceiling — chained cross-joins where the cumulative product exceeds the cap; assert the executor errors before allocating
+- Lateral form vs `.wherePredicate` — both produce the same result for the same logical filter; performance is observably better for `on:` (count comparisons)
+- Composition with FK-join + cross-join + `.where` — invoices × clients × periods, filtered on `period.year`; result correctness
+
+### Security tests
+
+- Right-side records are decrypted only after the cross-join clause fires; never appear as ciphertext in the result
+- Right-side DEK is the same shape as FK-join right-side (same-DEK by default)
+- Cross-join over a public-MV doesn't leak source-collection DEKs (v3 reaffirms what's already true for FK joins)
+
+## Backward compatibility
+
+- Existing queries without `.crossJoin()` are unaffected (no new mandatory parameter on any existing API)
+- MV v2 `query()` callbacks compile unchanged; consumers opt in by adding the `.crossJoin()` terminal
+- Adding `crossJoin` to `Clause` union is type-additive only — no runtime change for code paths that don't construct a `CrossJoinClause`
+
+## Open implementation questions (resolve during writing-plans)
+
+1. **Snapshot semantics for the right side.** FK joins use the same snapshot the left query uses (cache-of-cache). Should cross-join right-side be a one-shot snapshot at execution time, or a fresh fetch? Eager-MV refreshes happen inside the source-write transaction, so a snapshot-time fetch is consistent. Confirm with implementation.
+2. **Cost ceiling default.** `50_000` matches `JoinTooLargeError`. But cross-joins explode multiplicatively faster than FK joins — `1000 × 1000 = 1M` is already 20× the cap. Recommend keeping the conservative default; document that consumers expecting large products must override per-clause.
+3. **Streaming / chunked execution.** v3 always materializes the expanded relation in-memory. Pairs poorly with very large products; v4 might add streaming evaluation (process row-by-row through downstream clauses). Out of scope for v3.
+4. **Lateral `on:` callback closure-over-`ctx`.** For MV use, the `on: { predicate: name }` shape must thread the left row to the predicate. Confirm the threading mechanism — does the executor pass the left row as the predicate's first argument? As a field in `ctx`?
+5. **Type-inference depth.** TypeScript may struggle with deeply-chained cross-joins extending the row type 4–5 levels. Document a recommended limit; recommend `interface` extraction for >2 chains.
+
+## Cross-references
+
+- MV v2 spec ([`2026-05-20-dim14-mv-v2-design.md`](./2026-05-20-dim14-mv-v2-design.md)) — defers cross-product to v3; this spec closes that gap
+- v2 ships `declaredDeterministicPredicates` + `withOverlayedView`; this spec composes with both
+- DERIV-SSO-001 from the niwat enforcement plan — the load-bearing example
+- Query DSL home: `packages/hub/src/query/` (`builder.ts`, `predicate.ts`, `join.ts`)
+- Existing `JoinTooLargeError` / `GroupCardinalityError` / `MaterializedViewTooLargeError` family — `CrossJoinTooLargeError` is the next member
+
+## Sequencing for implementation
+
+1. **`CrossJoinClause` type + clause-union extension** (no execution yet) — smallest first piece
+2. **`QueryBuilder.crossJoin()` terminal** — chainable, type-flow through `as` alias
+3. **`executePlan` cross-join branch** — pure cartesian product; cost ceiling check before allocation
+4. **`CrossJoinTooLargeError`** — error class + executor surfacing
+5. **Lateral `on:` subset and predicate variants** — both branches of the callback union
+6. **`QueryDependencyAnalyzer` extension** — cross-joined collections added to MV dependency sets
+7. **`queryHash` extension** — fold cross-join target + alias + `on: { predicate: name }` ref into the canonical form
+8. **`.where` / `.wherePredicate` dotted-path access on joined alias** — confirms the existing FK-join dotted-path code works unchanged
+9. **`.groupBy` / `.aggregate` on cross-joined rows** — confirms group-by sees the merged row shape
+10. **Showcase — DERIV-SSO-001 end-to-end** — periods × workers + predicate + group-by + aggregate
+11. **Subsystem doc + `features.yaml` entry** — documentation and verification
+
+Each step produces a green test before the next begins.

--- a/features.yaml
+++ b/features.yaml
@@ -398,6 +398,28 @@ features:
       - 'Always-core today; planned withJoins() extraction tracked separately'
     related: [query-basics, schema-and-refs]
 
+  - id: cross-join
+    name: Cartesian-product cross-join query primitive
+    cluster: read-and-query
+    spec: docs/superpowers/specs/2026-05-20-dim11-cross-join-v1-design.md
+    subsystem_doc: docs/subsystems/cross-join.md
+    package: '@noy-db/hub'
+    factory: null
+    status: stable
+    showcases:
+      - id: 92-with-cross-join
+        path: showcases/src/92-with-cross-join.showcase.test.ts
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'Same-vault only; both collections must be open in the same vault'
+      - 'Cost ceiling: CrossJoinTooLargeError at 50,000 rows (cumulative for lateral form)'
+      - 'Lateral form via on: (left) => TTarget[] | (right) => boolean'
+      - 'MV-safe named predicate form: on: { predicate: name } — queryHash-tracked'
+      - 'Composition: where/crossJoin/where/groupBy/aggregate all interleave correctly'
+    related: [joins, query-basics, aggregate]
+
   - id: live
     name: Reactive query primitive
     cluster: read-and-query

--- a/packages/hub/__tests__/query-cross-join.test.ts
+++ b/packages/hub/__tests__/query-cross-join.test.ts
@@ -2,6 +2,34 @@ import { describe, it, expect } from 'vitest'
 import { evaluateClause, type Clause, type CrossJoinClause } from '../src/query/predicate.js'
 import { Query, type QueryPlan } from '../src/query/index.js'
 import { CrossJoinTooLargeError, CrossJoinSourceUnknownError } from '../src/errors.js'
+import type { QuerySource, JoinContext, JoinableSource } from '../src/query/index.js'
+
+function staticSource<T>(records: T[]): QuerySource<T> {
+  return { snapshot: () => records }
+}
+
+function mockJoinContext(
+  leftCollection: string,
+  sources: Record<string, unknown[]>,
+): JoinContext {
+  return {
+    leftCollection,
+    resolveRef: () => null,
+    resolveSource: (name: string): JoinableSource | null => {
+      const snap = sources[name]
+      return snap !== undefined ? { snapshot: () => snap } : null
+    },
+  }
+}
+
+const PERIODS = [
+  { id: 'p1', start: '2026-01', end: '2026-03' },
+  { id: 'p2', start: '2026-04', end: '2026-06' },
+]
+const WORKERS = [
+  { id: 'w1', name: 'Alice' },
+  { id: 'w2', name: 'Bob' },
+]
 
 describe('CrossJoinClause > evaluateClause throws on crossJoin type', () => {
   it('throws if a crossJoin clause is passed to evaluateClause', () => {
@@ -84,5 +112,36 @@ describe('CrossJoinSourceUnknownError', () => {
     expect(e.leftCollection).toBe('periods')
     expect(e.message).toContain('workers')
     expect(e.message).toContain('periods')
+  })
+})
+
+describe('Query.crossJoin() > builder', () => {
+  it('appends a crossJoin clause to the plan', () => {
+    const jc = mockJoinContext('periods', { workers: WORKERS })
+    const q = new Query(
+      staticSource(PERIODS),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    ).crossJoin('workers', { as: 'worker' })
+    const plan = q._plan()
+    expect(plan.clauses).toHaveLength(1)
+    expect(plan.clauses[0]).toMatchObject({ type: 'crossJoin', target: 'workers', as: 'worker' })
+  })
+
+  it('is immutable — original query is unchanged', () => {
+    const jc = mockJoinContext('periods', { workers: WORKERS })
+    const base = new Query(
+      staticSource(PERIODS),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    )
+    const q2 = base.crossJoin('workers', { as: 'worker' })
+    expect(base._plan().clauses).toHaveLength(0)
+    expect(q2._plan().clauses).toHaveLength(1)
+  })
+
+  it('throws when called on a Query with no joinContext', () => {
+    const base = new Query(staticSource(PERIODS))
+    expect(() => base.crossJoin('workers', { as: 'worker' })).toThrow('join context')
   })
 })

--- a/packages/hub/__tests__/query-cross-join.test.ts
+++ b/packages/hub/__tests__/query-cross-join.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { evaluateClause, type Clause, type CrossJoinClause } from '../src/query/predicate.js'
 import { Query, type QueryPlan } from '../src/query/index.js'
+import { CrossJoinTooLargeError, CrossJoinSourceUnknownError } from '../src/errors.js'
 
 describe('CrossJoinClause > evaluateClause throws on crossJoin type', () => {
   it('throws if a crossJoin clause is passed to evaluateClause', () => {
@@ -59,5 +60,29 @@ describe('CrossJoinClause > toPlan() serialization (serializeClause)', () => {
     expect(serialized.clauses[0].onPredicateName).toBe('isActive')
     expect(serialized.clauses[0].maxRows).toBe(100_000)
     expect(serialized.clauses[0].on).toBe('[function]')
+  })
+})
+
+describe('CrossJoinTooLargeError', () => {
+  it('is a NoydbError with correct name and fields', () => {
+    const e = new CrossJoinTooLargeError({ target: 'workers', expected: 60_000, limit: 50_000 })
+    expect(e).toBeInstanceOf(Error)
+    expect(e.name).toBe('CrossJoinTooLargeError')
+    expect(e.target).toBe('workers')
+    expect(e.expected).toBe(60_000)
+    expect(e.limit).toBe(50_000)
+    expect(e.message).toContain('workers')
+    expect(e.message).toContain('50000')
+  })
+})
+
+describe('CrossJoinSourceUnknownError', () => {
+  it('is a NoydbError with correct name and fields', () => {
+    const e = new CrossJoinSourceUnknownError('workers', 'periods')
+    expect(e.name).toBe('CrossJoinSourceUnknownError')
+    expect(e.target).toBe('workers')
+    expect(e.leftCollection).toBe('periods')
+    expect(e.message).toContain('workers')
+    expect(e.message).toContain('periods')
   })
 })

--- a/packages/hub/__tests__/query-cross-join.test.ts
+++ b/packages/hub/__tests__/query-cross-join.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import { evaluateClause, type Clause, type CrossJoinClause } from '../src/query/predicate.js'
-import { Query, executePlan, type QueryPlan } from '../src/query/index.js'
+import { Query, executePlan, type QueryPlan, count } from '../src/query/index.js'
 import { CrossJoinTooLargeError, CrossJoinSourceUnknownError } from '../src/errors.js'
 import type { QuerySource, JoinContext, JoinableSource } from '../src/query/index.js'
+import { withAggregate } from '../src/aggregate/index.js'
+
+const AGG = withAggregate()
 
 function staticSource<T>(records: T[]): QuerySource<T> {
   return { snapshot: () => records }
@@ -330,5 +333,83 @@ describe('Query.crossJoin() > lateral on: predicate form', () => {
       jc,
     ).crossJoin('right', { as: 'r', maxRows: 50, on: (_: any) => right })
     expect(() => q.toArray()).toThrow(CrossJoinTooLargeError)
+  })
+})
+
+describe('Query.crossJoin() > count()', () => {
+  it('count() returns expanded relation size', () => {
+    const jc = mockJoinContext('periods', { workers: WORKERS })
+    const q = new Query(
+      staticSource(PERIODS),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    ).crossJoin('workers', { as: 'worker' })
+    expect(q.count()).toBe(4) // 2 × 2
+  })
+})
+
+describe('Query.crossJoin() > groupBy().aggregate()', () => {
+  it('groupBy on a left-side field after cross-join groups the expanded relation', () => {
+    const jc = mockJoinContext('periods', { workers: WORKERS })
+    const result = new Query(
+      staticSource(PERIODS),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+      AGG,
+    )
+      .crossJoin('workers', { as: 'worker' })
+      .groupBy('id')
+      .aggregate({ workerCount: count() })
+      .run()
+    expect(result).toHaveLength(2)
+    expect(result.map((r: any) => r.workerCount)).toEqual([2, 2])
+  })
+
+  it('groupBy on alias field groups by right-side key', () => {
+    const jc = mockJoinContext('periods', { workers: WORKERS })
+    const result = new Query(
+      staticSource(PERIODS),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+      AGG,
+    )
+      .crossJoin<(typeof WORKERS)[0], 'worker'>('workers', { as: 'worker' })
+      .groupBy('worker.name')
+      .aggregate({ periodCount: count() })
+      .run()
+    expect(result).toHaveLength(2)
+    expect(result.map((r: any) => r.periodCount)).toEqual([2, 2])
+  })
+})
+
+describe('Query.crossJoin() > live() subscriptions', () => {
+  it('live() subscribes to right-side collection changes', () => {
+    let rightCallback: (() => void) | undefined
+    const rightSourceWithSub = {
+      snapshot: () => WORKERS as unknown[],
+      subscribe: (cb: () => void) => {
+        rightCallback = cb
+        return () => { rightCallback = undefined }
+      },
+    }
+    const jc: JoinContext = {
+      leftCollection: 'periods',
+      resolveRef: () => null,
+      resolveSource: (name: string) => name === 'workers' ? rightSourceWithSub : null,
+    }
+    const leftSource = {
+      snapshot: () => PERIODS as unknown[],
+      subscribe: (_cb: () => void) => { return () => {} },
+    }
+    const q = new Query(leftSource as any, { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] }, jc)
+      .crossJoin('workers', { as: 'worker' })
+
+    let notifications = 0
+    const live = q.live()
+    live.subscribe(() => { notifications++ })
+
+    rightCallback?.()
+    expect(notifications).toBeGreaterThan(0)
+    live.stop()
   })
 })

--- a/packages/hub/__tests__/query-cross-join.test.ts
+++ b/packages/hub/__tests__/query-cross-join.test.ts
@@ -4,6 +4,7 @@ import { Query, executePlan, type QueryPlan, count } from '../src/query/index.js
 import { CrossJoinTooLargeError, CrossJoinSourceUnknownError } from '../src/errors.js'
 import type { QuerySource, JoinContext, JoinableSource } from '../src/query/index.js'
 import { withAggregate } from '../src/aggregate/index.js'
+import { analyzeDependencies, summarizeQueryPlan } from '../src/materialized-views/index.js'
 
 const AGG = withAggregate()
 
@@ -411,5 +412,72 @@ describe('Query.crossJoin() > live() subscriptions', () => {
     rightCallback?.()
     expect(notifications).toBeGreaterThan(0)
     live.stop()
+  })
+})
+
+describe('analyzeDependencies > cross-join targets as dependency sources', () => {
+  it('includes cross-join target collection in dependency set', () => {
+    const jc = mockJoinContext('periods', { workers: WORKERS })
+    const q = new Query(
+      staticSource(PERIODS),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    ).crossJoin('workers', { as: 'worker' })
+    const deps = analyzeDependencies(q)
+    expect(deps.has('periods')).toBe(true)
+    expect(deps.has('workers')).toBe(true)
+  })
+
+  it('deduplicates multiple cross-joins to the same target', () => {
+    const jc = mockJoinContext('periods', { workers: WORKERS })
+    const q = new Query(
+      staticSource(PERIODS),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    )
+      .crossJoin('workers', { as: 'w1' })
+      .crossJoin('workers', { as: 'w2' })
+    const deps = analyzeDependencies(q)
+    expect(deps.size).toBe(2) // periods + workers (deduped)
+  })
+})
+
+describe('summarizeQueryPlan > cross-join in queryHash', () => {
+  it('folds cross-join target and alias into the summary', () => {
+    const jc = mockJoinContext('periods', { workers: WORKERS })
+    const q1 = new Query(
+      staticSource(PERIODS),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    ).crossJoin('workers', { as: 'worker' })
+    const q2 = new Query(
+      staticSource(PERIODS),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    ).crossJoin('other', { as: 'worker' }) // different target
+    expect(summarizeQueryPlan(q1)).not.toBe(summarizeQueryPlan(q2))
+  })
+
+  it('folds onPredicateName into the summary when present', () => {
+    const predicates = new Map([['isActive', { hash: 'isActive-v1', fn: (_rec: unknown) => true }]])
+    const jc = mockJoinContext('periods', { workers: WORKERS })
+
+    // Need aggregateStrategy for _withPredicates to work in tests
+    // Actually _withPredicates only attaches a predicates map — it doesn't need aggregateStrategy
+    // Use the same pattern as query-predicate tests: get a Query with predicates via _withPredicates
+    const base = new Query(
+      staticSource(PERIODS),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    )._withPredicates(predicates)
+
+    const qNamed = base.crossJoin('workers', { as: 'w', on: { predicate: 'isActive' } })
+    const qNoOn = new Query(
+      staticSource(PERIODS),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    ).crossJoin('workers', { as: 'w' })
+
+    expect(summarizeQueryPlan(qNamed)).not.toBe(summarizeQueryPlan(qNoOn))
   })
 })

--- a/packages/hub/__tests__/query-cross-join.test.ts
+++ b/packages/hub/__tests__/query-cross-join.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { evaluateClause, type Clause, type CrossJoinClause } from '../src/query/predicate.js'
-import { Query, type QueryPlan } from '../src/query/index.js'
+import { Query, executePlan, type QueryPlan } from '../src/query/index.js'
 import { CrossJoinTooLargeError, CrossJoinSourceUnknownError } from '../src/errors.js'
 import type { QuerySource, JoinContext, JoinableSource } from '../src/query/index.js'
 
@@ -143,5 +143,192 @@ describe('Query.crossJoin() > builder', () => {
   it('throws when called on a Query with no joinContext', () => {
     const base = new Query(staticSource(PERIODS))
     expect(() => base.crossJoin('workers', { as: 'worker' })).toThrow('join context')
+  })
+})
+
+describe('Query.crossJoin() > full cartesian execution', () => {
+  it('produces leftRows × rightRows pairs', () => {
+    const jc = mockJoinContext('periods', { workers: WORKERS })
+    const result = new Query(
+      staticSource(PERIODS),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    )
+      .crossJoin<(typeof WORKERS)[0], 'worker'>('workers', { as: 'worker' })
+      .toArray()
+    expect(result).toHaveLength(4) // 2 periods × 2 workers
+    expect(result[0]).toMatchObject({ id: 'p1', start: '2026-01', worker: { id: 'w1', name: 'Alice' } })
+    expect(result[1]).toMatchObject({ id: 'p1', worker: { id: 'w2', name: 'Bob' } })
+    expect(result[2]).toMatchObject({ id: 'p2', worker: { id: 'w1', name: 'Alice' } })
+    expect(result[3]).toMatchObject({ id: 'p2', worker: { id: 'w2', name: 'Bob' } })
+  })
+
+  it('where() before crossJoin filters the left side first', () => {
+    const jc = mockJoinContext('periods', { workers: WORKERS })
+    const result = new Query(
+      staticSource(PERIODS),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    )
+      .where('id', '==', 'p1')
+      .crossJoin<(typeof WORKERS)[0], 'worker'>('workers', { as: 'worker' })
+      .toArray()
+    expect(result).toHaveLength(2) // 1 period × 2 workers
+    expect(result.every((r: any) => r.id === 'p1')).toBe(true)
+  })
+
+  it('where() after crossJoin filters on the alias', () => {
+    const jc = mockJoinContext('periods', { workers: WORKERS })
+    const result = new Query(
+      staticSource(PERIODS),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    )
+      .crossJoin<(typeof WORKERS)[0], 'worker'>('workers', { as: 'worker' })
+      .where('worker.name', '==', 'Alice')
+      .toArray()
+    expect(result).toHaveLength(2) // 2 periods × Alice only
+    expect(result.every((r: any) => r.worker.name === 'Alice')).toBe(true)
+  })
+
+  it('throws CrossJoinSourceUnknownError when target collection is not in join context', () => {
+    const jc = mockJoinContext('periods', {}) // no workers source
+    const q = new Query(
+      staticSource(PERIODS),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    ).crossJoin('workers', { as: 'worker' })
+    expect(() => q.toArray()).toThrow(CrossJoinSourceUnknownError)
+  })
+})
+
+describe('executePlan > throws on crossJoin clauses', () => {
+  it('executePlan() throws when plan contains crossJoin clauses', () => {
+    const plan: QueryPlan = {
+      clauses: [{ type: 'crossJoin', target: 'workers', as: 'worker' }],
+      orderBy: [],
+      limit: undefined,
+      offset: 0,
+      joins: [],
+    }
+    expect(() => executePlan([], plan)).toThrow('executePlan')
+  })
+})
+
+describe('Query.crossJoin() > cost ceiling', () => {
+  it('throws CrossJoinTooLargeError when product exceeds default limit', () => {
+    // 251 × 200 = 50,200 > 50,000
+    const leftRecords = Array.from({ length: 251 }, (_, i) => ({ id: `l${i}` }))
+    const rightRecords = Array.from({ length: 200 }, (_, i) => ({ id: `r${i}` }))
+    const jc = mockJoinContext('left', { right: rightRecords })
+    const q = new Query(
+      staticSource(leftRecords),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    ).crossJoin('right', { as: 'r' })
+    expect(() => q.toArray()).toThrow(CrossJoinTooLargeError)
+  })
+
+  it('error carries correct expected and limit values', () => {
+    const left = Array.from({ length: 300 }, (_, i) => ({ id: `l${i}` }))
+    const right = Array.from({ length: 200 }, (_, i) => ({ id: `r${i}` }))
+    const jc = mockJoinContext('left', { right })
+    const q = new Query(
+      staticSource(left),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    ).crossJoin('right', { as: 'r' })
+    let err: CrossJoinTooLargeError | undefined
+    try { q.toArray() } catch (e) { err = e as CrossJoinTooLargeError }
+    expect(err?.expected).toBe(60_000)
+    expect(err?.limit).toBe(50_000)
+  })
+
+  it('per-clause maxRows override raises the ceiling', () => {
+    const left = Array.from({ length: 300 }, (_, i) => ({ id: `l${i}` }))
+    const right = Array.from({ length: 200 }, (_, i) => ({ id: `r${i}` }))
+    const jc = mockJoinContext('left', { right })
+    const result = new Query(
+      staticSource(left),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    )
+      .crossJoin('right', { as: 'r', maxRows: 100_000 })
+      .toArray()
+    expect(result).toHaveLength(60_000)
+  })
+})
+
+const PERIODS_LATERAL = [
+  { id: 'p1', start: '2026-01', end: '2026-03' },
+  { id: 'p2', start: '2026-04', end: '2026-06' },
+]
+const WORKERS_LATERAL = [
+  { id: 'w1', name: 'Alice', since: '2026-01', until: null as null | string },
+  { id: 'w2', name: 'Bob',   since: '2026-03', until: '2026-05' },
+  { id: 'w3', name: 'Carol', since: '2026-05', until: null as null | string },
+]
+
+describe('Query.crossJoin() > lateral on: subset form', () => {
+  it('on: (left) => TTarget[] supplies the exact right rows for each left row', () => {
+    const jc = mockJoinContext('periods', { workers: WORKERS_LATERAL })
+    const result = new Query(
+      staticSource(PERIODS_LATERAL),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    )
+      .crossJoin<(typeof WORKERS_LATERAL)[0], 'worker'>('workers', {
+        as: 'worker',
+        on: (period: any) =>
+          (WORKERS_LATERAL as typeof WORKERS_LATERAL).filter(
+            (w) => w.since <= period.start && (w.until === null || w.until >= period.end),
+          ),
+      })
+      .toArray()
+    // p1 start='2026-01' end='2026-03': Alice (since 01, until null) ✓; Bob (since 03 <= 01? NO, 03 > 01) ✗; Carol ✗ → 1
+    // Wait — re-check: p1.start='2026-01', Bob.since='2026-03', '2026-03' <= '2026-01'? No. → p1: Alice only
+    // p2 start='2026-04' end='2026-06': Alice (since 01 <= 04, until null ✓); Bob (since 03 <= 04, until 05 < 06) ✗; Carol (since 05 > 04) ✗ → 1
+    // Hmm let me re-examine: p1 end='2026-03'. Alice until null → ✓. Bob since '2026-03' <= p1.start '2026-01'? No. Carol ✗.
+    // p2 end='2026-06'. Alice ✓. Bob since '2026-03' <= '2026-04' ✓, until '2026-05' >= '2026-06'? '2026-05' >= '2026-06'? No. ✗.
+    // Carol since '2026-05' <= '2026-04'? No. ✗. → p2: Alice only
+    // So result should be 2 rows (p1:Alice, p2:Alice)
+    expect(result).toHaveLength(2)
+    expect(result.map((r: any) => `${r.id}:${r.worker.name}`).sort()).toEqual(
+      ['p1:Alice', 'p2:Alice'],
+    )
+  })
+})
+
+describe('Query.crossJoin() > lateral on: predicate form', () => {
+  it('on: (left) => (right) => boolean filters each right row against the left row', () => {
+    const jc = mockJoinContext('periods', { workers: WORKERS_LATERAL })
+    const result = new Query(
+      staticSource(PERIODS_LATERAL),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    )
+      .crossJoin<(typeof WORKERS_LATERAL)[0], 'worker'>('workers', {
+        as: 'worker',
+        on: (period: any) => (worker: any) =>
+          worker.since <= period.start && (worker.until === null || worker.until >= period.end),
+      })
+      .toArray()
+    expect(result).toHaveLength(2)
+    expect(result.map((r: any) => `${r.id}:${r.worker.name}`).sort()).toEqual(
+      ['p1:Alice', 'p2:Alice'],
+    )
+  })
+
+  it('lateral ceiling is cumulative (post-filter count across left rows)', () => {
+    // 2 left rows × 26 right rows each = 52 > 50 limit → throws
+    const left = [{ id: 'a' }, { id: 'b' }]
+    const right = Array.from({ length: 26 }, (_, i) => ({ id: `r${i}` }))
+    const jc = mockJoinContext('left', { right })
+    const q = new Query(
+      staticSource(left),
+      { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] },
+      jc,
+    ).crossJoin('right', { as: 'r', maxRows: 50, on: (_: any) => right })
+    expect(() => q.toArray()).toThrow(CrossJoinTooLargeError)
   })
 })

--- a/packages/hub/__tests__/query-cross-join.test.ts
+++ b/packages/hub/__tests__/query-cross-join.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { evaluateClause, type Clause, type CrossJoinClause } from '../src/query/predicate.js'
+import { Query, type QueryPlan } from '../src/query/index.js'
+
+describe('CrossJoinClause > evaluateClause throws on crossJoin type', () => {
+  it('throws if a crossJoin clause is passed to evaluateClause', () => {
+    const clause: CrossJoinClause = {
+      type: 'crossJoin',
+      target: 'workers',
+      as: 'worker',
+    }
+    expect(() => evaluateClause({}, clause)).toThrow("'crossJoin' clauses are expansion primitives")
+  })
+})
+
+describe('CrossJoinClause > toPlan() serialization (serializeClause)', () => {
+  const EMPTY_PLAN: QueryPlan = { clauses: [], orderBy: [], limit: undefined, offset: 0, joins: [] }
+
+  it('serializes crossJoin with no on: — on omitted', () => {
+    const clause: CrossJoinClause = { type: 'crossJoin', target: 'workers', as: 'worker' }
+    const plan: QueryPlan = { ...EMPTY_PLAN, clauses: [clause] }
+    const q = new Query({ snapshot: () => [] }, plan)
+    const serialized = q.toPlan() as any
+    expect(serialized.clauses[0]).toEqual({
+      type: 'crossJoin',
+      target: 'workers',
+      as: 'worker',
+      on: undefined,
+      onPredicateName: undefined,
+      maxRows: undefined,
+    })
+  })
+
+  it('serializes crossJoin with on: function — strips to [function]', () => {
+    const clause: CrossJoinClause = {
+      type: 'crossJoin',
+      target: 'workers',
+      as: 'worker',
+      on: () => [],
+    }
+    const plan: QueryPlan = { ...EMPTY_PLAN, clauses: [clause] }
+    const q = new Query({ snapshot: () => [] }, plan)
+    const serialized = q.toPlan() as any
+    expect(serialized.clauses[0].on).toBe('[function]')
+  })
+
+  it('serializes crossJoin with onPredicateName and maxRows preserved', () => {
+    const clause: CrossJoinClause = {
+      type: 'crossJoin',
+      target: 'workers',
+      as: 'worker',
+      on: () => [],
+      onPredicateName: 'isActive',
+      maxRows: 100_000,
+    }
+    const plan: QueryPlan = { ...EMPTY_PLAN, clauses: [clause] }
+    const q = new Query({ snapshot: () => [] }, plan)
+    const serialized = q.toPlan() as any
+    expect(serialized.clauses[0].onPredicateName).toBe('isActive')
+    expect(serialized.clauses[0].maxRows).toBe(100_000)
+    expect(serialized.clauses[0].on).toBe('[function]')
+  })
+})

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -26,7 +26,9 @@
  *       │    ├─ ValidationError        — application-level guard failed
  *       │    └─ SchemaValidationError  — Standard Schema v1 rejection
  *       ├─ Query errors
- *       │    ├─ JoinTooLargeError      — join row ceiling exceeded
+ *       │    ├─ JoinTooLargeError           — join row ceiling exceeded
+ *       │    ├─ CrossJoinTooLargeError      — cross-join row ceiling exceeded
+ *       │    ├─ CrossJoinSourceUnknownError — target collection not in vault
  *       │    ├─ DanglingReferenceError — strict ref() points at nothing
  *       │    ├─ GroupCardinalityError  — groupBy bucket cap exceeded
  *       │    ├─ IndexRequiredError      — lazy-mode query touches unindexed field
@@ -1428,6 +1430,56 @@ export class JoinTooLargeError extends NoydbError {
     this.rightRows = opts.rightRows
     this.maxRows = opts.maxRows
     this.side = opts.side
+  }
+}
+
+/**
+ * Thrown by `.crossJoin()` when the cumulative cartesian product (or lateral
+ * filtered count) exceeds the configured ceiling. Check before allocating.
+ * Mirrors the pattern of `JoinTooLargeError` and the `.join()` row ceiling.
+ *
+ * @see CrossJoinClause.maxRows — per-clause override
+ * @see DEFAULT_CROSS_JOIN_MAX_ROWS — package default (50_000)
+ */
+export class CrossJoinTooLargeError extends NoydbError {
+  readonly target: string
+  readonly expected: number
+  readonly limit: number
+
+  constructor(opts: { target: string; expected: number; limit: number }) {
+    super(
+      'CROSS_JOIN_TOO_LARGE',
+      `crossJoin("${opts.target}"): would produce ${opts.expected} rows, ` +
+        `exceeding the limit of ${opts.limit}. ` +
+        `Narrow the left side with .where() first, or raise the ceiling ` +
+        `with crossJoin("${opts.target}", { ..., maxRows: ${opts.expected} }).`,
+    )
+    this.name = 'CrossJoinTooLargeError'
+    this.target = opts.target
+    this.expected = opts.expected
+    this.limit = opts.limit
+  }
+}
+
+/**
+ * Thrown at cross-join execution time when the target collection is not
+ * reachable from the current vault. The left collection is included in the
+ * message for context.
+ */
+export class CrossJoinSourceUnknownError extends NoydbError {
+  readonly target: string
+  readonly leftCollection: string
+
+  constructor(target: string, leftCollection: string) {
+    super(
+      'CROSS_JOIN_SOURCE_UNKNOWN',
+      `crossJoin("${target}"): collection "${target}" is not known in the vault ` +
+        `(cross-joining from "${leftCollection}"). ` +
+        `Make sure "${target}" is open in the same vault before executing this query.`,
+    )
+    this.name = 'CrossJoinSourceUnknownError'
+    this.target = target
+    this.leftCollection = leftCollection
   }
 }
 

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -845,6 +845,7 @@ export {
   CollectionIndexes,
   applyJoins,
   DEFAULT_JOIN_MAX_ROWS,
+  DEFAULT_CROSS_JOIN_MAX_ROWS,
   resetJoinWarnings,
   buildLiveQuery,
   count,

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -239,6 +239,8 @@ export {
   BackupLedgerError,
   BackupCorruptedError,
   JoinTooLargeError,
+  CrossJoinTooLargeError,
+  CrossJoinSourceUnknownError,
   DanglingReferenceError,
   FilenameSanitizationError,
   PathEscapeError,

--- a/packages/hub/src/materialized-views/dependency-analyzer.ts
+++ b/packages/hub/src/materialized-views/dependency-analyzer.ts
@@ -10,8 +10,10 @@ import type { MaterializedViewStrategy } from './types.js'
  *   - root collection (the one the query was built from)
  *   - FK join targets (`.join(field, { as })`)
  *
+ * Also handles:
+ *   - cross-join targets (`.crossJoin(target, { as })`) — v3
+ *
  * Deferred:
- *   - `.crossJoin()` — v3 cross-join spec (separate primitive)
  *   - `.wherePredicate(name)` — v2 predicate primitive
  *   - Overlay-name expansion to {base, overlay}
  *
@@ -33,6 +35,14 @@ export function analyzeDependencies(query: Query<any>): Set<string> {
   // FK join targets contribute additional sources.
   for (const leg of plan.joins) {
     deps.add(leg.target)
+  }
+
+  // Cross-join targets are also dependency sources — writes to either side
+  // must trigger MV refresh. Symmetric with FK-join target handling above.
+  for (const clause of plan.clauses) {
+    if (clause.type === 'crossJoin') {
+      deps.add(clause.target)
+    }
   }
 
   // Sub-plans inside OR clauses can carry nested joins. Walk them.
@@ -77,7 +87,19 @@ export function summarizeQueryPlan(query: Query<any>): string {
   const ctx = query._joinContext()
   return JSON.stringify({
     root: ctx?.leftCollection ?? null,
-    clauses: plan.clauses,
+    clauses: plan.clauses.map(c => {
+      if (c.type === 'crossJoin') {
+        return {
+          type: 'crossJoin',
+          target: c.target,
+          as: c.as,
+          // Inline on: callback: use sentinel — drift detection disabled for this MV
+          onPredicateName: c.onPredicateName ?? (c.on ? '[inline]' : null),
+          maxRows: c.maxRows ?? null,
+        }
+      }
+      return c
+    }),
     orderBy: plan.orderBy,
     limit: plan.limit ?? null,
     offset: plan.offset,

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -1115,7 +1115,7 @@ function applyCrossJoin(
     const callbackResult = clause.on(left)
     let filteredRight: readonly unknown[]
     if (Array.isArray(callbackResult)) {
-      filteredRight = callbackResult as unknown[]
+      filteredRight = callbackResult
     } else {
       filteredRight = (rightRows as unknown[]).filter(
         callbackResult as (r: unknown) => boolean,

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -562,6 +562,14 @@ export class Query<T> {
    * intent is purely to count.
    */
   count(): number {
+    if (this.plan.clauses.some(c => c.type === 'crossJoin')) {
+      if (!this.joinContext) {
+        throw new Error(
+          `Query.count(): plan contains crossJoin clauses but no JoinContext is attached.`,
+        )
+      }
+      return executeClausePipeline(this.source, this.plan.clauses, this.joinContext).length
+    }
     // Use the same index-aware candidate machinery as toArray(); skip the
     // index-driving clause from re-evaluation. The length BEFORE limit/offset
     // is what `count()` documents.
@@ -620,7 +628,13 @@ export class Query<T> {
     // different operation; see docs for rationale.)
     const source = this.source
     const clauses = this.plan.clauses
+    const joinCtx = this.joinContext
+    const hasCrossJoins = clauses.some(c => c.type === 'crossJoin')
     const executeRecords = (): readonly unknown[] => {
+      if (hasCrossJoins) {
+        if (!joinCtx) throw new Error('Query.aggregate(): crossJoin requires a join context')
+        return executeClausePipeline(source, clauses, joinCtx)
+      }
       const { candidates, remainingClauses } = candidateRecords(source, clauses)
       return remainingClauses.length === 0
         ? candidates
@@ -699,7 +713,13 @@ export class Query<T> {
     // builder stays allocation-friendly for the hot path.
     const source = this.source
     const clauses = this.plan.clauses
+    const joinCtx = this.joinContext
+    const hasCrossJoins = clauses.some(c => c.type === 'crossJoin')
     const executeRecords = (): readonly unknown[] => {
+      if (hasCrossJoins) {
+        if (!joinCtx) throw new Error('Query.groupBy(): crossJoin requires a join context')
+        return executeClausePipeline(source, clauses, joinCtx)
+      }
       const { candidates, remainingClauses } = candidateRecords(source, clauses)
       return remainingClauses.length === 0
         ? candidates
@@ -821,6 +841,23 @@ export class Query<T> {
         if (subscribed.has(leg.target)) continue
         subscribed.add(leg.target)
         const rightSource = this.joinContext.resolveSource(leg.target)
+        if (rightSource?.subscribe) {
+          const rightSubscribe = rightSource.subscribe.bind(rightSource)
+          upstreams.push({
+            subscribe: (cb: () => void) => rightSubscribe(cb),
+          })
+        }
+      }
+    }
+
+    // Cross-join right-side change streams — symmetric with FK joins above.
+    if (this.joinContext) {
+      const subscribedCross = new Set<string>()
+      for (const clause of this.plan.clauses) {
+        if (clause.type !== 'crossJoin') continue
+        if (subscribedCross.has(clause.target)) continue
+        subscribedCross.add(clause.target)
+        const rightSource = this.joinContext.resolveSource(clause.target)
         if (rightSource?.subscribe) {
           const rightSubscribe = rightSource.subscribe.bind(rightSource)
           upstreams.push({

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -957,6 +957,16 @@ function serializeClause(clause: Clause): unknown {
       clauses: clause.clauses.map(serializeClause),
     }
   }
+  if (clause.type === 'crossJoin') {
+    return {
+      type: 'crossJoin',
+      target: clause.target,
+      as: clause.as,
+      on: clause.on ? '[function]' : undefined,
+      onPredicateName: clause.onPredicateName,
+      maxRows: clause.maxRows,
+    }
+  }
   return clause
 }
 

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -5,7 +5,7 @@
  * mutated. This makes plans safe to share, cache, and serialize.
  */
 
-import type { Clause, FieldClause, FilterClause, GroupClause, Operator, WherePredicateClause } from './predicate.js'
+import type { Clause, CrossJoinClause, FieldClause, FilterClause, GroupClause, Operator, WherePredicateClause } from './predicate.js'
 import { evaluateClause } from './predicate.js'
 import type { CollectionIndexes } from '../indexing/eager-indexes.js'
 import type { JoinContext, JoinLeg, JoinStrategy } from './join.js'
@@ -52,6 +52,9 @@ const EMPTY_PLAN: QueryPlan = {
   offset: 0,
   joins: [],
 }
+
+/** Default row ceiling for cross-join expansion. Matches JoinTooLargeError's ceiling. */
+export const DEFAULT_CROSS_JOIN_MAX_ROWS = 50_000
 
 /**
  * Source of records that a query executes against.
@@ -418,6 +421,102 @@ export class Query<T> {
     return new Query<T & Record<As, R | null>>(
       this.source as unknown as QuerySource<T & Record<As, R | null>>,
       { ...this.plan, joins: [...this.plan.joins, leg] },
+      this.joinContext,
+      this.aggregateStrategy,
+      this.predicates,
+    )
+  }
+
+  /**
+   * Cartesian-product cross-join against `target` collection. Each result row
+   * carries the original `T` fields plus `result[as]` populated from every
+   * right-side row (or the filtered subset when `on:` is supplied).
+   *
+   * **Order matters:** `.where().crossJoin()` filters BEFORE expanding (cheaper);
+   * `.crossJoin().where('alias.field', ...)` filters AFTER (required when the
+   * where clause references the aliased fields).
+   *
+   * **Cost ceiling:** `CrossJoinTooLargeError` fires before allocation when
+   * `leftRows × rightRows` (or the cumulative lateral count) exceeds the limit.
+   * Default: 50,000 rows. Override per-clause with `{ maxRows: N }`.
+   *
+   * **`on:` shapes:**
+   *   - `on: (left) => TTarget[]`              — subset form (most efficient)
+   *   - `on: (left) => (right) => boolean`     — predicate form
+   *   - `on: { predicate: 'name' }`            — MV-safe, hash-tracked form
+   *     (requires the Query to have been augmented via `_withPredicates`)
+   *
+   * Requires a JoinContext (constructed via `collection.query()`).
+   */
+  crossJoin<TTarget = unknown, As extends string = string>(
+    target: string,
+    opts: {
+      as: As
+      on?:
+        | ((left: T) => unknown[] | ((right: TTarget) => boolean))
+        | { readonly predicate: string }
+      maxRows?: number
+    },
+  ): Query<T & { [K in As]: TTarget }> {
+    if (!this.joinContext) {
+      throw new Error(
+        `Query.crossJoin("${target}"): requires a join context. ` +
+          `Use collection.query() to construct a cross-join-capable Query instead of ` +
+          `the Query constructor directly.`,
+      )
+    }
+
+    let onFn: CrossJoinClause['on']
+    let onPredicateName: string | undefined
+
+    if (opts.on !== undefined) {
+      if (typeof opts.on === 'function') {
+        onFn = opts.on as CrossJoinClause['on']
+        if (this.predicates) {
+          console.warn(
+            `Query.crossJoin("${target}", { on: callback }): inline on: callback inside a ` +
+              `withMaterializedView query() disables queryHash drift detection for this cross-join. ` +
+              `Use on: { predicate: '<name>' } to enable it.`,
+          )
+        }
+      } else {
+        const predName = (opts.on as { predicate: string }).predicate
+        if (!this.predicates) {
+          throw new Error(
+            `Query.crossJoin("${target}", { on: { predicate: "${predName}" } }): ` +
+              `the { predicate } form requires a predicates map. ` +
+              `Use this form inside a withMaterializedView query() callback that declares ` +
+              `predicates: { ${predName}: { hash, fn } }.`,
+          )
+        }
+        const decl = this.predicates.get(predName)
+        if (!decl) {
+          throw new Error(
+            `Query.crossJoin("${target}"): predicate "${predName}" not registered. ` +
+              `Available: ${[...this.predicates.keys()].join(', ') || '(none)'}.`,
+          )
+        }
+        const as = opts.as
+        const predicateFn = decl.fn
+        onFn = (_left: unknown): ((right: unknown) => boolean) =>
+          (right: unknown) =>
+            predicateFn({ ...(_left as Record<string, unknown>), [as]: right })
+        onPredicateName = predName
+      }
+    }
+
+    const clause: CrossJoinClause = {
+      type: 'crossJoin',
+      target,
+      as: opts.as,
+      ...(onFn !== undefined && { on: onFn }),
+      ...(onPredicateName !== undefined && { onPredicateName }),
+      ...(opts.maxRows !== undefined && { maxRows: opts.maxRows }),
+    }
+
+    return new Query<T & { [K in As]: TTarget }>(
+      this.source as unknown as QuerySource<T & { [K in As]: TTarget }>,
+      { ...this.plan, clauses: [...this.plan.clauses, clause] },
       this.joinContext,
       this.aggregateStrategy,
       this.predicates,

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -8,8 +8,9 @@
 import type { Clause, CrossJoinClause, FieldClause, FilterClause, GroupClause, Operator, WherePredicateClause } from './predicate.js'
 import { evaluateClause } from './predicate.js'
 import type { CollectionIndexes } from '../indexing/eager-indexes.js'
-import type { JoinContext, JoinLeg, JoinStrategy } from './join.js'
+import type { JoinableSource, JoinContext, JoinLeg, JoinStrategy } from './join.js'
 import { applyJoins } from './join.js'
+import { CrossJoinTooLargeError, CrossJoinSourceUnknownError } from '../errors.js'
 import type { LiveQuery, LiveUpstream } from './live.js'
 import { buildLiveQuery } from './live.js'
 import type { AggregateSpec, AggregateResult, AggregationUpstream, Aggregation } from '../aggregate/aggregation.js'
@@ -530,7 +531,7 @@ export class Query<T> {
    * for the ordering rationale.
    */
   toArray(): T[] {
-    const base = executePlanWithSource(this.source, this.plan)
+    const base = executePlanWithSource(this.source, this.plan, this.joinContext)
     if (this.plan.joins.length === 0) return base as T[]
     if (!this.joinContext) {
       // Unreachable in practice — .join() throws if joinContext is
@@ -849,15 +850,31 @@ export class Query<T> {
  * full scan otherwise. Mirrors `executePlan` for the public surface but
  * takes a `QuerySource` so it can consult `getIndexes()` and `lookupById()`.
  */
-function executePlanWithSource(source: InternalSource, plan: QueryPlan): unknown[] {
-  const { candidates, remainingClauses } = candidateRecords(source, plan.clauses)
-  // Only the clauses NOT consumed by the index need re-evaluation. This is
-  // the key optimization that makes indexed queries dominate linear scans:
-  // for a single-clause query against an indexed field, `remainingClauses`
-  // is empty and we skip the per-record predicate evaluation entirely.
-  let result = remainingClauses.length === 0
-    ? [...candidates]
-    : filterRecords(candidates, remainingClauses)
+function executePlanWithSource(
+  source: InternalSource,
+  plan: QueryPlan,
+  joinContext?: JoinContext,
+): unknown[] {
+  const hasCrossJoins = plan.clauses.some(c => c.type === 'crossJoin')
+
+  let result: unknown[]
+  if (hasCrossJoins) {
+    if (!joinContext) {
+      throw new Error(
+        `Query.toArray(): plan contains crossJoin clauses but no JoinContext is attached. ` +
+          `Use collection.query() instead of new Query() for cross-join support.`,
+      )
+    }
+    result = executeClausePipeline(source, plan.clauses, joinContext)
+  } else {
+    // Index-aware fast path: only the clauses NOT consumed by the index need
+    // re-evaluation. For a single-clause query against an indexed field,
+    // `remainingClauses` is empty and we skip per-record predicate evaluation.
+    const { candidates, remainingClauses } = candidateRecords(source, plan.clauses)
+    result =
+      remainingClauses.length === 0 ? [...candidates] : filterRecords(candidates, remainingClauses)
+  }
+
   if (plan.orderBy.length > 0) {
     result = sortRecords(result, plan.orderBy)
   }
@@ -951,6 +968,13 @@ function materializeIds(
  * cast the return type at the API surface (see `Query.toArray()`).
  */
 export function executePlan(records: readonly unknown[], plan: QueryPlan): unknown[] {
+  if (plan.clauses.some(c => c.type === 'crossJoin')) {
+    throw new Error(
+      `executePlan(): does not support crossJoin clauses. ` +
+        `executePlan is a stateless pure function — it cannot resolve cross-join right-side ` +
+        `collections. Use Query.toArray() (via collection.query()) instead.`,
+    )
+  }
   let result = filterRecords(records, plan.clauses)
   if (plan.orderBy.length > 0) {
     result = sortRecords(result, plan.orderBy)
@@ -978,6 +1002,102 @@ function filterRecords(records: readonly unknown[], clauses: readonly Clause[]):
     if (matches) out.push(r)
   }
   return out
+}
+
+/**
+ * Walk the clause list in declaration order, batching filter clauses and
+ * expanding on crossJoin clauses. Falls back to `candidateRecords + filterRecords`
+ * (index fast-path) when no crossJoin clauses are present.
+ *
+ * Precondition: `joinContext` must be non-null when any `CrossJoinClause` is in `clauses`.
+ */
+function executeClausePipeline(
+  source: InternalSource,
+  clauses: readonly Clause[],
+  joinContext: JoinContext,
+): unknown[] {
+  let rel: unknown[] = [...source.snapshot()]
+  let filterBatch: Clause[] = []
+
+  for (const clause of clauses) {
+    if (clause.type === 'crossJoin') {
+      if (filterBatch.length > 0) {
+        rel = filterRecords(rel, filterBatch)
+        filterBatch = []
+      }
+      const rightSource = joinContext.resolveSource(clause.target)
+      if (!rightSource) {
+        throw new CrossJoinSourceUnknownError(clause.target, joinContext.leftCollection)
+      }
+      rel = applyCrossJoin(rel, clause, rightSource)
+    } else {
+      filterBatch.push(clause)
+    }
+  }
+
+  if (filterBatch.length > 0) {
+    rel = filterRecords(rel, filterBatch)
+  }
+
+  return rel
+}
+
+/**
+ * Expand `leftRel` by cross-joining with `rightSource`. Enforces the cost ceiling
+ * BEFORE allocating the expanded relation (full cartesian) or cumulatively
+ * (lateral form). Throws `CrossJoinTooLargeError` on breach.
+ */
+function applyCrossJoin(
+  leftRel: unknown[],
+  clause: CrossJoinClause,
+  rightSource: JoinableSource,
+): unknown[] {
+  const rightRows = rightSource.snapshot()
+  const maxRows = clause.maxRows ?? DEFAULT_CROSS_JOIN_MAX_ROWS
+  const { as } = clause
+
+  if (!clause.on) {
+    const product = leftRel.length * rightRows.length
+    if (product > maxRows) {
+      throw new CrossJoinTooLargeError({ target: clause.target, expected: product, limit: maxRows })
+    }
+    const expanded: unknown[] = []
+    for (const left of leftRel) {
+      const leftObj = left as Record<string, unknown>
+      for (const right of rightRows) {
+        expanded.push({ ...leftObj, [as]: right })
+      }
+    }
+    return expanded
+  }
+
+  // Lateral — ceiling is cumulative (post-filter count)
+  const expanded: unknown[] = []
+  let cumulative = 0
+  for (const left of leftRel) {
+    const callbackResult = clause.on(left)
+    let filteredRight: readonly unknown[]
+    if (Array.isArray(callbackResult)) {
+      filteredRight = callbackResult as unknown[]
+    } else {
+      filteredRight = (rightRows as unknown[]).filter(
+        callbackResult as (r: unknown) => boolean,
+      )
+    }
+    cumulative += filteredRight.length
+    if (cumulative > maxRows) {
+      throw new CrossJoinTooLargeError({
+        target: clause.target,
+        expected: cumulative,
+        limit: maxRows,
+      })
+    }
+    const leftObj = left as Record<string, unknown>
+    for (const right of filteredRight) {
+      expanded.push({ ...leftObj, [as]: right })
+    }
+  }
+  return expanded
 }
 
 function sortRecords(records: unknown[], orderBy: readonly OrderBy[]): unknown[] {

--- a/packages/hub/src/query/index.ts
+++ b/packages/hub/src/query/index.ts
@@ -13,7 +13,7 @@
 
 export { Query, executePlan } from './builder.js'
 export type { QueryPlan, QuerySource, OrderBy } from './builder.js'
-export type { Operator, Clause, FieldClause, FilterClause, GroupClause } from './predicate.js'
+export type { Operator, Clause, FieldClause, FilterClause, GroupClause, CrossJoinClause } from './predicate.js'
 export { evaluateClause, evaluateFieldClause, readPath } from './predicate.js'
 // Indexing relocated to `../indexing/` as part of the capability-
 // subpath refactor. Re-export from the new home for backward compat
@@ -60,4 +60,6 @@ export {
   IndexWriteFailureError,
   JoinTooLargeError,
   DanglingReferenceError,
+  CrossJoinTooLargeError,
+  CrossJoinSourceUnknownError,
 } from '../errors.js'

--- a/packages/hub/src/query/index.ts
+++ b/packages/hub/src/query/index.ts
@@ -11,7 +11,7 @@
  * pull in the executor's runtime, since `Query` is the only entry point.
  */
 
-export { Query, executePlan } from './builder.js'
+export { Query, executePlan, DEFAULT_CROSS_JOIN_MAX_ROWS } from './builder.js'
 export type { QueryPlan, QuerySource, OrderBy } from './builder.js'
 export type { Operator, Clause, FieldClause, FilterClause, GroupClause, CrossJoinClause } from './predicate.js'
 export { evaluateClause, evaluateFieldClause, readPath } from './predicate.js'

--- a/packages/hub/src/query/predicate.ts
+++ b/packages/hub/src/query/predicate.ts
@@ -74,7 +74,32 @@ export interface GroupClause {
   readonly clauses: readonly Clause[]
 }
 
-export type Clause = FieldClause | FilterClause | WherePredicateClause | GroupClause
+/**
+ * Cartesian-product expansion clause. Appended to `QueryPlan.clauses`
+ * by `Query.crossJoin()`. Processed in declaration order by
+ * `executeClausePipeline` — NOT by `evaluateClause` (which is a
+ * per-record predicate and throws on this type).
+ */
+export interface CrossJoinClause {
+  readonly type: 'crossJoin'
+  /** Target collection name to cross-join against. */
+  readonly target: string
+  /** Alias under which the right-side record is exposed on each result row. */
+  readonly as: string
+  /**
+   * Lateral filter callback. `undefined` → full cartesian product.
+   * Two call shapes:
+   *   - Subset:    `(left) => TTarget[]`            — returns the right rows for this left row
+   *   - Predicate: `(left) => (right) => boolean`   — executor materializes then filters
+   */
+  readonly on?: (left: unknown) => unknown[] | ((right: unknown) => boolean)
+  /** When `on:` was supplied as `{ predicate: name }`, the name is stored here for queryHash. */
+  readonly onPredicateName?: string
+  /** Per-clause row ceiling override. `undefined` → `DEFAULT_CROSS_JOIN_MAX_ROWS`. */
+  readonly maxRows?: number
+}
+
+export type Clause = FieldClause | FilterClause | WherePredicateClause | GroupClause | CrossJoinClause
 
 /**
  * Read a possibly nested field path like "address.city" from a record.
@@ -163,6 +188,13 @@ export function evaluateClause(record: unknown, clause: Clause): boolean {
       return clause.fn(record)
     case 'wherePredicate':
       return clause.fn(record, clause.ctx)
+    case 'crossJoin':
+      throw new Error(
+        `evaluateClause: 'crossJoin' clauses are expansion primitives and are not ` +
+          `evaluated per-record. This is a query planner routing error — ` +
+          `crossJoin clauses must be extracted from the clause list before calling ` +
+          `evaluateClause or filterRecords.`,
+      )
     case 'group':
       if (clause.op === 'and') {
         for (const child of clause.clauses) {

--- a/showcases/src/92-with-cross-join.showcase.test.ts
+++ b/showcases/src/92-with-cross-join.showcase.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Showcase 92 — Cross-join query primitive
+ *
+ * What you'll learn
+ * ─────────────────
+ * `.crossJoin(target, { as })` produces a cartesian product between two
+ * collections in the same vault. Combined with lateral `on:`, `.groupBy()`,
+ * and `.aggregate()`, it closes the DERIV-SSO-001 pattern: "for every
+ * period, how many workers were active?"
+ *
+ * Why it matters
+ * ──────────────
+ * Cross-join is the foundation of period × entity analytics. Without it,
+ * a multi-period payroll or coverage report requires N separate queries
+ * (one per period) and manual stitching. Cross-join expresses it as a
+ * single declarative query that the hub executes after decryption —
+ * zero-knowledge to the backend.
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → cross-join
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, CrossJoinTooLargeError } from '@noy-db/hub'
+import { withAggregate, count } from '@noy-db/hub/aggregate'
+import { memory } from '@noy-db/to-memory'
+
+interface Period {
+  id: string
+  label: string
+  start: string // 'YYYY-MM'
+  end: string   // 'YYYY-MM'
+}
+
+interface Worker {
+  id: string
+  name: string
+  since: string       // 'YYYY-MM' — first active month
+  until: string | null  // 'YYYY-MM' or null (still active)
+}
+
+describe('Showcase 92 — Cross-join', () => {
+  it('DERIV-SSO-001: for each period, counts active workers via lateral on:', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'cross-join-showcase-2026',
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('payroll')
+    const periods = vault.collection<Period>('periods')
+    const workers = vault.collection<Worker>('workers')
+
+    await periods.put('q1', { id: 'q1', label: 'Q1 2026', start: '2026-01', end: '2026-03' })
+    await periods.put('q2', { id: 'q2', label: 'Q2 2026', start: '2026-04', end: '2026-06' })
+    await periods.put('q3', { id: 'q3', label: 'Q3 2026', start: '2026-07', end: '2026-09' })
+
+    // Alice: active the whole year
+    await workers.put('alice', { id: 'alice', name: 'Alice', since: '2026-01', until: null })
+    // Bob: joined Q1, left end of Q2 (until='2026-06' covers Q2 end)
+    await workers.put('bob',   { id: 'bob',   name: 'Bob',   since: '2026-01', until: '2026-06' })
+    // Carol: started Q3 only
+    await workers.put('carol', { id: 'carol', name: 'Carol', since: '2026-07', until: null })
+
+    // Worker is "active in period" if: worker.since <= period.start AND
+    // (worker.until === null OR worker.until >= period.end)
+    const result = await periods.query()
+      .crossJoin<Worker, 'worker'>('workers', {
+        as: 'worker',
+        on: (period) => (worker) =>
+          worker.since <= period.start &&
+          (worker.until === null || worker.until >= period.end),
+      })
+      .groupBy('id')
+      .aggregate({ workerCount: count() })
+      .run()
+
+    // Sort by id for determinism
+    result.sort((a: any, b: any) => a.id.localeCompare(b.id))
+
+    // Q1 start='2026-01' end='2026-03': Alice (since 01 <= 01, until null ✓); Bob (since 01 <= 01, until 06 >= 03 ✓) → 2
+    // Q2 start='2026-04' end='2026-06': Alice ✓; Bob (since 01 <= 04, until 06 >= 06 ✓); Carol (since 07 > 04 ✗) → 2
+    // Q3 start='2026-07' end='2026-09': Alice ✓; Bob (until 06 < 09 ✗); Carol (since 07 <= 07, until null ✓) → 2
+    expect(result).toHaveLength(3)
+    const byId = Object.fromEntries((result as any[]).map((r: any) => [r.id, r.workerCount]))
+    expect(byId['q1']).toBe(2)
+    expect(byId['q2']).toBe(2)
+    expect(byId['q3']).toBe(2)
+  })
+
+  it('full cartesian: every period × every worker (no lateral filter)', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'cross-join-full-cartesian-2026',
+    })
+    const vault = await db.openVault('demo')
+    const periods = vault.collection<Period>('periods')
+    const workers = vault.collection<Worker>('workers')
+
+    await periods.put('p1', { id: 'p1', label: 'Jan', start: '2026-01', end: '2026-01' })
+    await periods.put('p2', { id: 'p2', label: 'Feb', start: '2026-02', end: '2026-02' })
+    await workers.put('w1', { id: 'w1', name: 'Alice', since: '2026-01', until: null })
+    await workers.put('w2', { id: 'w2', name: 'Bob',   since: '2026-01', until: null })
+
+    const rows = await periods.query()
+      .crossJoin<Worker, 'worker'>('workers', { as: 'worker' })
+      .toArray()
+
+    expect(rows).toHaveLength(4) // 2 × 2
+    expect(rows.every((r: any) => r.worker !== undefined)).toBe(true)
+  })
+
+  it('where() before crossJoin filters left side (cheaper than post-filter)', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'cross-join-pre-filter-2026',
+    })
+    const vault = await db.openVault('demo')
+    const periods = vault.collection<Period>('periods')
+    const workers = vault.collection<Worker>('workers')
+
+    await periods.put('p1', { id: 'p1', label: 'Q1', start: '2026-01', end: '2026-03' })
+    await periods.put('p2', { id: 'p2', label: 'Q2', start: '2026-04', end: '2026-06' })
+    await workers.put('w1', { id: 'w1', name: 'Alice', since: '2026-01', until: null })
+    await workers.put('w2', { id: 'w2', name: 'Bob',   since: '2026-01', until: null })
+
+    const rows = await periods.query()
+      .where('id', '==', 'p1')
+      .crossJoin<Worker, 'worker'>('workers', { as: 'worker' })
+      .toArray()
+
+    expect(rows).toHaveLength(2) // 1 period × 2 workers
+    expect(rows.every((r: any) => r.id === 'p1')).toBe(true)
+  })
+
+  it('CrossJoinTooLargeError fires when product exceeds ceiling', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'cross-join-ceiling-2026',
+    })
+    const vault = await db.openVault('demo')
+    const periods = vault.collection<Period>('periods')
+    const workers = vault.collection<Worker>('workers')
+
+    // 260 × 200 = 52,000 > 50,000 default ceiling
+    const periodPuts = Array.from({ length: 260 }, (_, i) =>
+      periods.put(`p${i}`, { id: `p${i}`, label: `P${i}`, start: '2026-01', end: '2026-01' })
+    )
+    const workerPuts = Array.from({ length: 200 }, (_, i) =>
+      workers.put(`w${i}`, { id: `w${i}`, name: `W${i}`, since: '2026-01', until: null })
+    )
+    await Promise.all([...periodPuts, ...workerPuts])
+
+    const q = periods.query().crossJoin('workers', { as: 'worker' })
+    expect(() => q.toArray()).toThrow(CrossJoinTooLargeError)
+  })
+})


### PR DESCRIPTION
## Summary

- Implements the Dim 11 `Query.crossJoin(target, { as })` primitive — cartesian-product expansion within a single vault
- Adds lateral `on:` forms (subset callback, predicate callback, MV-safe `{ predicate: name }`)
- Ships `CrossJoinTooLargeError` / `CrossJoinSourceUnknownError` with 50 k default ceiling
- Extends `executeClausePipeline` to process clauses in declaration order — index fast-path preserved when no cross-joins are present
- Extends `analyzeDependencies` + `summarizeQueryPlan` so MVs built on cross-join queries track both sides as sources
- Extends `Query.live()` to subscribe to right-side change streams symmetrically with FK-join
- 28 unit tests (`query-cross-join.test.ts`) + 4 end-to-end showcase tests (showcase 92 — DERIV-SSO-001)

## Spec

`docs/subsystems/dim11-cross-join-spec-v3.md` (first commit in this PR — retained as the design record).

## Test Plan

- [ ] `pnpm --filter @noy-db/hub test` — 2052/2052 passing
- [ ] `pnpm --filter showcases test --testPathPattern 92` — 4/4 passing
- [ ] Review `executeClausePipeline` declaration-order invariant (clauses are interleaved correctly)
- [ ] Review `CrossJoinTooLargeError` ceiling calculation for both full-cartesian and lateral forms