### PR TITLE
feat(hub/i18n): multilingual-field hardening — per-layer onMissing, substitute, script enforcement, dictKey parity

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -18,6 +18,10 @@ maps exactly as before. Resolution is strictly opt-in:
   **state-only** by default — they never call `vault.setLocale`. Keep it
   that way (don't pass `setLocale`'s `syncVault`) so guard/MV/export reads
   stay raw. (#286)
+- **`liveQuery` is not locale-aware yet.** On a `'follow'` store,
+  `store.items` are resolved but `store.liveQuery(...).items` still carry
+  raw `{ [locale]: string }` maps — resolve those rows at the edge with
+  `useI18nField` / `useDictLabel`. (Tracked follow-up.)
 
 ### Shamir recovery
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,26 @@
 ## 0.1 → 0.2
 
+### `@noy-db/in-pinia` reactive i18n (non-breaking, opt-in)
+
+`@noy-db/in-pinia` now ships a reactive locale layer: `useNoydbI18n`
+(active-locale store), `useI18nField` (reactive `pickLang`), and an
+exported `useDictLabel`. **Non-breaking** — `defineNoydbStore` defaults to
+`i18n: 'raw'`, so existing stores keep returning `{ [locale]: string }`
+maps exactly as before. Resolution is strictly opt-in:
+
+- **Display-only stores:** add `i18n: 'follow'` to resolve items to the
+  global locale and re-render on `useNoydbI18n().setLocale(...)`.
+- **Leave `'raw'` (the default)** for any store whose maps feed identity
+  reads (joins/derivations reading `.th`), export/filing projections, or a
+  per-cell bilingual toggle bound to the map. Resolve those at the edge
+  with `useI18nField` / `useDictLabel`.
+- **Locale-less vaults:** `setLocale` and `bindTo(uiLocaleRef)` are
+  **state-only** by default — they never call `vault.setLocale`. Keep it
+  that way (don't pass `setLocale`'s `syncVault`) so guard/MV/export reads
+  stay raw. (#286)
+
+### Shamir recovery
+
 **Breaking:** `@noy-db/hub` no longer re-exports the Shamir share codecs, and
 Shamir recovery now requires an injected provider.
 

--- a/docs/subsystems/i18n.md
+++ b/docs/subsystems/i18n.md
@@ -57,6 +57,52 @@ vault.collection<Invoice>('invoices', {
 - `validateI18nTextValue` throws when a collection declared `i18nFields` (misconfiguration: declared but didn't opt in)
 - `vault.dictionary(name)` throws with a pointer to `@noy-db/hub/i18n`
 
+## Hardening (per-layer policy, substitute, script, dictKey parity)
+
+Optional, opt-in extensions on `i18nText()` / `dictKey()`. Fields that
+don't set them behave exactly as before (zero breaking change). Full
+design: `docs/superpowers/specs/2026-06-05-i18n-multilingual-field-hardening-design.md`.
+
+**`onMissing` + `substitute` — missing-locale policy.** When a field is
+resolved to an absent locale, `onMissing` decides: `'substitute'` (walk
+the declared `substitute` chain, then `null`), `'null'`, or `'throw'`
+(the default — today's behavior). `onMissing` may be a scalar or a
+per-layer map (`read`/`guard`/`join`/`mv`/`derivation`/`export`); the
+`guard` layer defaults to lenient `'substitute'`. A caller-supplied
+`fallback` at read time overrides the declared `substitute`.
+
+```ts
+i18nText({
+  languages: ['th', 'en'], required: 'any',
+  substitute: ['en', 'th', 'any'],
+  onMissing: { read: 'substitute', mv: 'throw', derivation: 'null' },
+})
+```
+
+> **Current wiring:** only the `read` layer (`get`/`list`) is enforced.
+> Guard/derivation/join/export reads resolve through the same read path
+> (so they observe the `read`/scalar policy); `mv`/`join` additionally
+> read raw maps in the query pipeline. Dedicated per-layer enforcement
+> is a tracked follow-up under milestone #17.
+
+**Script enforcement (`script`, `onScriptViolation`).** Write-time
+per-locale validation. `script: 'auto'` infers allowed Unicode scripts
+with **asymmetric Latin tolerance**: non-Latin locales also allow
+`Latin` (so `'9/9 อาคาร TCM ถนนรัชดาภิเษก'` passes), while Latin locales
+reject other scripts (so Thai text in an `en` slot is rejected).
+`Common`/`Inherited`/`Mark` (digits, combining marks) are always
+allowed. Violations `'reject'` (default, `ScriptViolationError`),
+`'filter'` (strip), or `'warn'`. Tighten a field with an explicit set:
+`script: { th: ['Thai'] }`.
+
+**dictKey parity.** `dictKey()` accepts the same `onMissing`/`substitute`
+(default stays `'null'` = legacy omit-on-miss). An **array-of-keys**
+field resolves to `[{ key, label }]` pair objects; a **wildcard path**
+(`contacts[].title`) adds a per-element sibling `<leaf>Label`. The
+stable key is preserved through resolution, so identity operations
+(`groupBy`, dedup) bind to the key even when labels collapse across
+locales (`Mr.`/`Ms.` → `คุณ`).
+
 ## Pairs well with
 
 - **aggregate** — `groupBy(dictKeyField)` resolves labels in the result on render

--- a/docs/subsystems/i18n.md
+++ b/docs/subsystems/i18n.md
@@ -95,6 +95,22 @@ allowed. Violations `'reject'` (default, `ScriptViolationError`),
 `'filter'` (strip), or `'warn'`. Tighten a field with an explicit set:
 `script: { th: ['Thai'] }`.
 
+**`I18nMap<Langs, Required>` type helper.** Types the stored locale-map
+from the `required` mode so the compiler forces you to handle an absent
+optional locale (`string | undefined`) instead of silently reading
+`undefined` — the right fix for bare `.th` access at raw-reading
+(identity/guard/export) layers. `'all'` (default) → every locale
+required; `'any'` → every locale optional; `readonly L[]` → listed
+required, rest optional.
+
+```ts
+type Lang = 'th' | 'en'
+interface Contact {
+  name: I18nMap<Lang, 'any'>        // { th?: string; en?: string }
+  legalName: I18nMap<Lang, ['th']>  // { th: string; en?: string }
+}
+```
+
 **dictKey parity.** `dictKey()` accepts the same `onMissing`/`substitute`
 (default stays `'null'` = legacy omit-on-miss). An **array-of-keys**
 field resolves to `[{ key, label }]` pair objects; a **wildcard path**

--- a/docs/superpowers/plans/2026-06-06-i18n-multilingual-field-hardening.md
+++ b/docs/superpowers/plans/2026-06-06-i18n-multilingual-field-hardening.md
@@ -1,0 +1,277 @@
+# i18n multilingual-field hardening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (inline) to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. TDD throughout; commit per task.
+
+**Goal:** Harden the `i18nText`/`dictKey` subsystem with per-layer `onMissing` policy, declared `substitute` ordering, per-locale script enforcement, and dictKey parity — all as *opt-in* additions with zero behavior change for non-opting fields.
+
+**Architecture:** Extend `I18nTextOptions`/`DictKeyOptions` with new optional fields; route all map→string collapsing through one policy-aware `resolveI18nText()` choke point; thread a `Layer` tag from each read context (app read / guard / derivation / mv / export) into resolution. All new code lives inside the tree-shaken `withI18n()` strategy.
+
+**Tech Stack:** TypeScript, Vitest (`pnpm --filter @noy-db/hub test`), monorepo (pnpm + turbo). Spec: `docs/superpowers/specs/2026-06-05-i18n-multilingual-field-hardening-design.md`. Milestone #17. Resolves #282, #283.
+
+**Durability-first ordering:** Phases A→C are low-risk and independently valuable (land first); Phase D is the invasive per-layer threading; Phase E (dictKey) depends on A. If the run is cut short, A+B+C are shippable on their own.
+
+---
+
+## File structure
+
+| File | Responsibility | Phase |
+|---|---|---|
+| `src/i18n/policy.ts` (NEW) | `OnMissing`, `Layer` types; `resolvePolicy()`; `LATIN_SCRIPT_LOCALES`/script helpers kept separate | A |
+| `src/i18n/core.ts` (MOD) | extend `I18nTextOptions`; policy-aware `resolveI18nText()`; `applyI18nLocale(..., layer)` | A,B |
+| `src/i18n/strategy.ts` (MOD) | add `layer` param to `applyI18nLocale`; `NO_I18N` unchanged behavior | B |
+| `src/errors.ts` (MOD) | add `ScriptViolationError` | C |
+| `src/i18n/script.ts` (NEW) | BCP-47 lang→script table (asymmetric Latin), `validateI18nScript()`, `applyScriptFilter()` | C |
+| `src/collection.ts` (MOD) | call `validateI18nScript` on put; pass `layer` through `applyLocaleToRecord`; dictKey resolution wildcard + array + policy | C,D,E |
+| `src/guards/read-only-facade.ts` (MOD) | carry `layer` tag; inject into reads | D |
+| `src/vault.ts` (MOD) | construct layer-tagged facades for guard vs derivation | D |
+| `src/i18n/dictionary.ts` (MOD) | extend `DictKeyOptions`; policy-aware `resolveLabel`; array/pair resolution | E |
+| `src/query/groupby.ts` + join planner (MOD) | dictKey key-vs-label binding (`{ by }`) | E |
+| `features.yaml` (MOD) | register capability nodes | F |
+| `docs/subsystems/*i18n*` (MOD) + `showcases/src/*` (NEW) | docs + showcase | F |
+
+---
+
+## Phase A — Policy core (pure, no integration)
+
+### Task A1: Policy types + `resolvePolicy()`
+
+**Files:** Create `src/i18n/policy.ts`; Test `__tests__/i18n-policy.test.ts`
+
+- [ ] **Step 1: Failing tests** — cover the spec's effective-policy table:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { resolvePolicy } from '../src/i18n/policy.js'
+
+describe('resolvePolicy', () => {
+  it('undefined onMissing → throw for every layer except guard', () => {
+    expect(resolvePolicy(undefined, 'read')).toBe('throw')
+    expect(resolvePolicy(undefined, 'mv')).toBe('throw')
+    expect(resolvePolicy(undefined, 'guard')).toBe('substitute') // lenient default
+  })
+  it('scalar applies to all non-guard layers; guard stays lenient', () => {
+    expect(resolvePolicy('throw', 'read')).toBe('throw')
+    expect(resolvePolicy('substitute', 'mv')).toBe('substitute')
+    expect(resolvePolicy('throw', 'guard')).toBe('substitute') // never inherits scalar
+  })
+  it('explicit guard override beats the lenient default', () => {
+    expect(resolvePolicy({ guard: 'throw' }, 'guard')).toBe('throw')
+  })
+  it('partial object: listed layers use value; unlisted non-guard → throw; guard → substitute', () => {
+    const p = { read: 'substitute', mv: 'throw' } as const
+    expect(resolvePolicy(p, 'read')).toBe('substitute')
+    expect(resolvePolicy(p, 'mv')).toBe('throw')
+    expect(resolvePolicy(p, 'join')).toBe('throw')       // unlisted non-guard
+    expect(resolvePolicy(p, 'guard')).toBe('substitute') // unlisted guard
+  })
+})
+```
+
+- [ ] **Step 2:** Run → FAIL (module missing). `pnpm --filter @noy-db/hub exec vitest run __tests__/i18n-policy.test.ts`
+- [ ] **Step 3: Implement** `src/i18n/policy.ts`:
+
+```ts
+export type OnMissing = 'substitute' | 'null' | 'throw'
+export type Layer = 'read' | 'guard' | 'join' | 'mv' | 'derivation' | 'export'
+
+export function resolvePolicy(
+  onMissing: OnMissing | Partial<Record<Layer, OnMissing>> | undefined,
+  layer: Layer,
+): OnMissing {
+  const explicit = onMissing && typeof onMissing === 'object' ? onMissing[layer] : undefined
+  const scalar = typeof onMissing === 'string' ? onMissing : undefined
+  const layerDefault: OnMissing | undefined = layer === 'guard' ? 'substitute' : undefined
+  return explicit ?? layerDefault ?? scalar ?? 'throw'
+}
+```
+
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5: Commit** `feat(hub/i18n): policy types + resolvePolicy (per-layer onMissing)`
+
+### Task A2: Extend `I18nTextOptions` + policy-aware `resolveI18nText`
+
+**Files:** Modify `src/i18n/core.ts`; Test `__tests__/i18n-resolve-policy.test.ts`
+
+Semantics to encode (from spec decision table + backward-compat):
+- caller `fallback` ALWAYS applies first (backward compat + read-time override), any policy.
+- declared `substitute` applies ONLY under policy `'substitute'`.
+- after exhaustion: `'throw'` → throw `LocaleNotSpecifiedError`; `'null'`/`'substitute'` → `null`.
+- `locale:'raw'` → return map. Existing 4-arg calls (`value, locale, fallback, field`) must behave exactly as today (default policy `'throw'`, no declared substitute).
+
+- [ ] **Step 1: Failing tests:**
+
+```ts
+// resolveI18nText(value, locale, fallback?, field?, opts?: { policy?, substitute? })
+const v = { th: 'สมชาย' }
+// present
+expect(resolveI18nText({en:'A',th:'B'}, 'en')).toBe('A')
+// throw (default) — backward compat
+expect(() => resolveI18nText(v, 'en')).toThrow(/locale/i)
+// substitute via declared list
+expect(resolveI18nText(v, 'en', undefined, 'firstName', { policy:'substitute', substitute:['th','any'] })).toBe('สมชาย')
+// null policy → null, no throw, declared substitute ignored
+expect(resolveI18nText(v, 'en', undefined, 'firstName', { policy:'null', substitute:['th'] })).toBeNull()
+// caller fallback always wins, even under throw
+expect(resolveI18nText(v, 'en', ['th'], 'firstName')).toBe('สมชาย')
+// substitute exhausted → null
+expect(resolveI18nText({}, 'en', undefined, 'f', { policy:'substitute', substitute:['th','any'] })).toBeNull()
+// raw passthrough
+expect(resolveI18nText(v, 'raw')).toEqual(v)
+```
+
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3: Implement.** Add to `I18nTextOptions`: `readonly onMissing?: OnMissing | Partial<Record<Layer, OnMissing>>; readonly substitute?: readonly string[]`. Rewrite `resolveI18nText` to the 5th optional-arg signature with the semantics above. Return type widens to `string | Record<string,string> | null`. Keep a private `pickFromChain(value, chain)` helper handling `'any'`.
+- [ ] **Step 4:** Run → PASS; also run existing `__tests__/i18n.test.ts` → PASS (no regression).
+- [ ] **Step 5: Commit** `feat(hub/i18n): policy-aware resolveI18nText (substitute/null/throw)`
+
+---
+
+## Phase B — Wire the `read` layer (app-facing get/list)
+
+### Task B1: `applyI18nLocale` honors per-field policy at layer 'read'
+
+**Files:** Modify `src/i18n/core.ts` (`applyI18nLocale`, `applyAtPath`), `src/i18n/strategy.ts`; Test `__tests__/i18n-read-layer.test.ts`
+
+- [ ] **Step 1: Failing test** through a real collection: define `firstName` i18nText with `required:'any', substitute:['en','th','any'], onMissing:{read:'substitute'}`; put `{th:'สมชาย'}`; `get` under active locale `en` returns `'สมชาย'`; a field with default policy still throws on missing locale.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3: Implement.** Thread `layer: Layer = 'read'` param into `applyI18nLocale(record, fields, locale, fallback, layer='read')` and `applyAtPath`. For each field, compute `policy = resolvePolicy(desc.options.onMissing, layer)` and call `resolveI18nText(raw, locale, fallback, path, { policy, substitute: desc.options.substitute })`. When result is `null`, set the field to `null` (don't drop the key). Update `I18nStrategy.applyI18nLocale` signature (append optional `layer`); `NO_I18N` stays identity.
+- [ ] **Step 4:** Run → PASS; existing i18n tests PASS.
+- [ ] **Step 5: Commit** `feat(hub/i18n): read-layer onMissing/substitute resolution on get/list`
+
+---
+
+## Phase C — Script enforcement (independent, resolves #283)
+
+### Task C1: `ScriptViolationError`
+
+**Files:** Modify `src/errors.ts`; Test `__tests__/i18n-script.test.ts` (start)
+
+- [ ] **Step 1:** Failing test: `new ScriptViolationError('firstName','en',['Latin'],'ส').message` contains field, expected scripts, offending sample; `instanceof NoydbError`.
+- [ ] **Step 2:** FAIL.
+- [ ] **Step 3:** Add `ScriptViolationError extends NoydbError` mirroring `MissingTranslationError` shape (fields: `field`, `expected: readonly string[]`, `sample?: string`).
+- [ ] **Step 4:** PASS.
+- [ ] **Step 5: Commit** `feat(hub): ScriptViolationError`
+
+### Task C2: script table + `validateI18nScript` (asymmetric Latin)
+
+**Files:** Create `src/i18n/script.ts`; Test `__tests__/i18n-script.test.ts`
+
+- [ ] **Step 1: Failing tests:**
+
+```ts
+// inferScripts(locale) — asymmetric Latin tolerance (#283)
+expect(inferScripts('en')).toEqual(['Latin'])
+expect(inferScripts('th')).toEqual(['Thai','Latin'])
+expect(inferScripts('ja')).toEqual(['Han','Hiragana','Katakana','Latin'])
+expect(inferScripts('th-Latn')).toEqual(['Latin'])
+// validateI18nScript: Common (digits) always ok; Thai+embedded-Latin ok; Thai-in-en rejected
+const desc = i18nText({ languages:['th','en'], required:'any', script:'auto' })
+expect(() => validateI18nScript({ th:'9/9 อาคาร TCM ถนนรัชดาภิเษก' }, 'firstName', desc)).not.toThrow()
+expect(() => validateI18nScript({ en:'สมชาย' }, 'firstName', desc)).toThrow(ScriptViolationError)
+expect(() => validateI18nScript({ th:'สมชาย 2024' }, 'firstName', desc)).not.toThrow() // Latin digits = Common
+// explicit tightening
+const strict = i18nText({ languages:['th'], required:'any', script:{ th:['Thai'] } })
+expect(() => validateI18nScript({ th:'อาคาร TCM' }, 'f', strict)).toThrow(ScriptViolationError)
+// onScriptViolation:'filter' strips; 'warn' allows
+```
+
+- [ ] **Step 2:** FAIL.
+- [ ] **Step 3: Implement** `src/i18n/script.ts`:
+  - `LATIN_LOCALES` set + `inferScripts(locale)`: if locale or its `-Xxxx` subtag is Latin → `['Latin']`; Cyrl subtag → `['Cyrillic','Latin']`; else base-language table (`th→['Thai','Latin']`, `ja→['Han','Hiragana','Katakana','Latin']`, `ko→['Hangul','Han','Latin']`, `ar→['Arabic','Latin']`, `ru/uk→['Cyrillic','Latin']`, Latin-base langs `en/fr/de/es/it/pt/nl/...→['Latin']`). Always conceptually `+ Common` in the matcher.
+  - `allowedFor(desc, locale)`: explicit `desc.options.script[locale]` if object; else `inferScripts(locale)`.
+  - matcher: build `new RegExp(\`^[\\p{Script=Common}\\s${scripts.map(s=>`\\p{Script=${s}}`).join('')}]*$\`, 'u')`. (Whitespace explicit for safety.)
+  - `validateI18nScript(value, field, desc)`: skip if `!desc.options.script`. For each locale slot string, test matcher; on violation honor `onScriptViolation`: `'reject'`(default)→throw `ScriptViolationError` (compute offending chars sample), `'filter'`→return a cleaned copy (strip disallowed), `'warn'`→return value + emit (return a `{ value, warnings }` tuple consumed by put). Provide both a throwing validate and a `applyScriptFilter` for the filter/warn paths.
+  - Extend `I18nTextOptions`: `readonly script?: 'auto' | Partial<Record<string, readonly string[]>>; readonly onScriptViolation?: 'reject'|'filter'|'warn'`.
+- [ ] **Step 4:** PASS (verify `\p{Script=...}` works under the repo's TS/node target; tsconfig `target` ≥ ES2018 + `u` flag — confirm).
+- [ ] **Step 5: Commit** `feat(hub/i18n): per-locale script enforcement (asymmetric Latin, #283)`
+
+### Task C3: wire `validateI18nScript` into `Collection.put`
+
+**Files:** Modify `src/collection.ts` (put pipeline, beside `validateI18nTextValue`); Test extends C2 via a real put.
+
+- [ ] **Step 1:** Failing test: put a record with `{en:'สมชาย'}` on a `script:'auto'` field → rejects with `ScriptViolationError`; valid Thai-with-Latin address puts fine; `filter` mode stores stripped value.
+- [ ] **Step 2:** FAIL.
+- [ ] **Step 3:** In put, where i18n fields are validated, also call the i18n strategy's script validator (add `validateI18nScript` to `I18nStrategy` + `withI18n()`; `NO_I18N` no-op since fields require strategy anyway). For `filter`/`warn`, mutate/keep the record value before encryption.
+- [ ] **Step 4:** PASS; existing tests PASS.
+- [ ] **Step 5: Commit** `feat(hub): enforce i18n script on put`
+
+---
+
+## Phase D — Per-layer threading (guard / derivation / mv / export)
+
+### Task D1: layer-tagged `ReadOnlyVaultFacade`
+
+**Files:** Modify `src/guards/read-only-facade.ts`, `src/guards/types.ts`, `src/vault.ts`; Test `__tests__/i18n-layers.test.ts`
+
+- [ ] **Step 1: Failing tests:** a field `onMissing:{read:'substitute', mv:'throw', derivation:'null', guard:'substitute'}`, stored `{th:..}` only; a derivation reading `firstName` (en active) sees `null`; an MV bucketing on the en value throws on refresh; a guard reading it substitutes.
+- [ ] **Step 2:** FAIL.
+- [ ] **Step 3: Implement.** Give `ReadOnlyVaultFacade` a `readonly layer: Layer` ctor arg (default `'read'`). Its `collection().get/list/query` inject `layer` into the resolution path (extend `LocaleReadOptions` with optional `_layer`, OR have the facade pass a layer-bearing option that `applyLocaleToRecord` reads). In `vault.ts`, construct distinct facades: guard-seeding → `layer:'guard'`, derivation-seeding → `layer:'derivation'`. (Keep the cached default-`read` facade for general use.)
+- [ ] **Step 4:** PASS.
+- [ ] **Step 5: Commit** `feat(hub/i18n): layer-tagged read facades (guard/derivation)`
+
+### Task D2: MV refresh + export layers
+
+**Files:** Modify MV executor (`src/materialized-views/executor.ts`) read context + `src/bundle/bundle.ts` / public-envelope export to pass `layer:'mv'` / `'export'`.
+
+- [ ] **Step 1:** Failing test: MV query reading an i18n field resolves at layer `'mv'` (throws when policy says so); export/bundle resolves at `'export'`.
+- [ ] **Step 2:** FAIL.
+- [ ] **Step 3:** Thread the layer into the MV read context (the MV's `query(db)` uses a facade — give it `layer:'mv'`) and the export collapse (`pickLocale` path → policy at `'export'`).
+- [ ] **Step 4:** PASS.
+- [ ] **Step 5: Commit** `feat(hub/i18n): mv + export resolution layers`
+
+### Task D3: join layer
+
+**Files:** Modify `src/query/join.ts` expansion to resolve joined i18n fields at layer `'join'`.
+
+- [ ] **Step 1:** Failing test: a join that expands a record with an i18n field, active locale missing → substitutes under `join:'substitute'`.
+- [ ] **Step 2:** FAIL → **Step 3:** thread layer into join right-side record resolution → **Step 4:** PASS → **Step 5: Commit** `feat(hub/i18n): join resolution layer`
+
+---
+
+## Phase E — dictKey parity (Slice 3; depends on Phase A)
+
+### Task E1: policy on `resolveLabel`
+
+**Files:** Modify `src/i18n/dictionary.ts` (`DictKeyOptions`, `resolveLabel`); Test `__tests__/dictkey-policy.test.ts`
+
+- [ ] **Step 1:** Failing tests: `resolveLabel` under `'null'` returns `undefined` (today's behavior); `'substitute'` walks declared `substitute`; `'throw'` raises `LocaleNotSpecifiedError`.
+- [ ] **Step 2:** FAIL → **Step 3:** add `onMissing`/`substitute` to `DictKeyOptions`; in `resolveLabel`, compute policy (needs the layer — thread from the dictLabelResolver call in collection.ts, default `'read'`) and apply identical semantics to `resolveI18nText`. Reuse a shared `pickFromChain`. → **Step 4:** PASS → **Step 5: Commit** `feat(hub/i18n): dictKey resolveLabel honors onMissing/substitute`
+
+### Task E2: array-of-keys → `[{key,label}]` pair objects
+
+**Files:** Modify `src/collection.ts` dictKey label populator (`~3031`); Test extends E1.
+
+- [ ] **Step 1:** Failing test: field `tags:['urgent','vip','x']` (x dangling) under `'null'` → `tagsLabel = [{key:'urgent',label:'..'},{key:'vip',label:null},{key:'x',label:null}]`; `'throw'` fails on first missing; `'substitute'` per-element.
+- [ ] **Step 2:** FAIL → **Step 3:** in the populator, when `result[field]` is an array, map element-wise to pair objects (resolve each key's label under policy). When scalar string, keep current `<field>Label` string behavior. → **Step 4:** PASS → **Step 5: Commit** `feat(hub/i18n): dictKey array-of-keys → pair objects`
+
+### Task E3: wildcard-path dictKey (`contacts[].title`, #282)
+
+**Files:** Modify `src/collection.ts` populator to walk `[].` paths (reuse `getAtPath`/`applyAtPath` from core); Test extends E1.
+
+- [ ] **Step 1:** Failing test: `dictKeyFields: { 'contacts[].title': dictKey('contactTitle',['mr','ms']) }`; put `contacts:[{name,title:'mr'},{name,title:'ms'}]`; get (th active) → each element gains `titleLabel:'คุณ'`, keeps `title`.
+- [ ] **Step 2:** FAIL → **Step 3:** detect `[].` in field path; traverse arrays, set per-element sibling `<leaf>Label`. → **Step 4:** PASS → **Step 5: Commit** `feat(hub/i18n): wildcard-path dictKey resolution (#282)`
+
+### Task E4: key-vs-label binding for groupBy/orderBy
+
+**Files:** Modify `src/query/groupby.ts` / order path; Test `__tests__/dictkey-groupby.test.ts`
+
+- [ ] **Step 1:** Failing test: `groupBy('title')` on a dictKey field buckets by KEY (mr≠ms, locale-independent); `orderBy('title',{by:'label'})` sorts by resolved label in active locale (Mr./Ms.→คุณ adjacent). Verify default is key.
+- [ ] **Step 2:** FAIL → **Step 3:** teach groupBy/orderBy that a dictKey field defaults to key binding; add `{ by:'label' }` option resolving the label (active locale) for the sort/group key. Confirm current behavior already keys on stored key (likely) → make explicit + add label opt-in. → **Step 4:** PASS → **Step 5: Commit** `feat(hub/i18n): dictKey groupBy/orderBy key-vs-label binding`
+
+---
+
+## Phase F — Registry, docs, showcase, verification
+
+- [ ] **F1:** Update `features.yaml` — register capability nodes for onMissing/substitute, script enforcement, dictKey parity (link spec + plan). Run the spec-coverage check (`pnpm ...` / the CI job script) → green.
+- [ ] **F2:** Extend `docs/subsystems/` i18n section with the policy table, script model (asymmetric Latin), dictKey parity.
+- [ ] **F3:** Add showcase under `showcases/src/`: bilingual person-name + honorific-on-`contacts[]` + Thai-address-with-Latin; exercise write/substitute-read/strict-MV-throw/lenient-guard/script-reject. Register in `features.yaml` if showcases are tracked there.
+- [ ] **F4:** Full suite: `pnpm --filter @noy-db/hub test` + `pnpm --filter @noy-db/hub typecheck` + `pnpm lint` (or repo equivalents) → all green. Verify `NO_I18N` default bundle unaffected.
+- [ ] **F5:** Open PR against `main` with `Closes #282`, `Closes #283`, milestone #17. (Do NOT merge — main is protected; leave for review.)
+
+---
+
+## Self-review
+
+- **Spec coverage:** onMissing per-layer (A1,B1,D1-3) ✓; substitute (A2) ✓; script asymmetric-Latin (C2) ✓; onScriptViolation reject/filter/warn (C2,C3) ✓; error taxonomy (A2,C1) ✓; dictKey policy (E1) ✓; array pair-objects (E2) ✓; wildcard-path #282 (E3) ✓; key-vs-label #283-adjacent binding (E4) ✓; densifyOnWrite — deferred, not planned ✓; in-pinia reactive — companion, out of scope ✓.
+- **Type consistency:** `OnMissing`/`Layer`/`resolvePolicy` defined in A1, reused everywhere; `resolveI18nText` 5-arg signature fixed in A2 and used by B1/E-shared.
+- **Risk notes:** Phase D is the invasive one — if facade-layer threading proves deeper than D1-3 assume, land A+B+C and open the PR with D/E as follow-up tasks under the milestone. Confirm `\p{Script}` regex support against tsconfig target before C2.

--- a/docs/superpowers/plans/2026-06-06-i18n-multilingual-field-hardening.md
+++ b/docs/superpowers/plans/2026-06-06-i18n-multilingual-field-hardening.md
@@ -203,9 +203,8 @@ expect(() => validateI18nScript({ th:'อาคาร TCM' }, 'f', strict)).toTh
 
 **Advisor finding:** query resolution is NOT automatic — caller passes `{locale}` at the chain terminal. So inside an MV's `query(db).groupBy('firstName')`, `firstName` may still be the raw `{locale:string}` map, never resolved — meaning `mv:'throw'` has **no call site to fire from**, and tagging a facade `layer:'mv'` does nothing. Guard/derivation reads DO have call sites (`facade → get() → applyLocaleToRecord(defaultLocale)`); MV/join are the suspects.
 
-- [ ] **D0 spike:** write a throwaway test — an MV that `groupBy`s an i18nText field — and inspect whether the bucket key is a resolved string or the raw map. Also check the join expansion path. **Decision gate:**
-  - If resolution already runs in MV/join → D2/D3 are small (just thread the layer tag).
-  - If it does NOT → **do not invent resolution-injection under autonomy.** Land D1 (guard/derivation, real call sites) + A+B+C+E1–E3, and convert D2 (mv/export) and D3 (join) into documented follow-up tasks under milestone #17. A clean partial beats a forced aggregation-pipeline change.
+- [x] **D0 spike — DONE (2026-06-06). VERDICT: MV/join read RAW, no resolution call site.** `materialized-views/executor.ts:106` reads source rows via `coll.query().toArray()` with **no locale**, so i18n fields are raw `{locale:string}` maps in the MV pipeline — `mv:'throw'` has nothing to fire from, and `groupAndReduce` would bucket on the raw map. Tagging a facade `layer:'mv'` would be inert.
+  - **Decision:** D1 (guard/derivation, real call sites) is IN. **D2 (mv/export) and D3 (join) are DEFERRED** as follow-ups under milestone #17 — they require a deliberate design to inject i18n resolution into the query/aggregate pipeline (touches `groupAndReduce`, every MV's `query().toArray()`), which is not safe to do unattended. Documented in the PR + handoff.
 
 ### Task D1: layer-tagged `ReadOnlyVaultFacade`
 

--- a/docs/superpowers/plans/2026-06-06-i18n-multilingual-field-hardening.md
+++ b/docs/superpowers/plans/2026-06-06-i18n-multilingual-field-hardening.md
@@ -120,7 +120,7 @@ expect(resolveI18nText(v, 'raw')).toEqual(v)
 ```
 
 - [ ] **Step 2:** Run → FAIL.
-- [ ] **Step 3: Implement.** Add to `I18nTextOptions`: `readonly onMissing?: OnMissing | Partial<Record<Layer, OnMissing>>; readonly substitute?: readonly string[]`. Rewrite `resolveI18nText` to the 5th optional-arg signature with the semantics above. Return type widens to `string | Record<string,string> | null`. Keep a private `pickFromChain(value, chain)` helper handling `'any'`.
+- [ ] **Step 3: Implement.** Add to `I18nTextOptions`: `readonly onMissing?: OnMissing | Partial<Record<Layer, OnMissing>>; readonly substitute?: readonly string[]`. Rewrite `resolveI18nText` to the 5th optional-arg signature with the semantics above. Return type widens to `string | Record<string,string> | null`. Keep a private `pickFromChain(value, chain)` helper handling `'any'`. **Null-widening (advisor):** the `| null` only occurs under new opt-in policies, but TS will flag existing callers — give `resolveI18nText` a function **overload** so the legacy 4-arg form keeps return type `string | Record<string,string>` (it can only throw or return, never null), and the 5-arg opts form returns `… | null`. Verify with `typecheck` at Step 4.
 - [ ] **Step 4:** Run → PASS; also run existing `__tests__/i18n.test.ts` → PASS (no regression).
 - [ ] **Step 5: Commit** `feat(hub/i18n): policy-aware resolveI18nText (substitute/null/throw)`
 
@@ -179,7 +179,7 @@ expect(() => validateI18nScript({ th:'อาคาร TCM' }, 'f', strict)).toTh
 - [ ] **Step 3: Implement** `src/i18n/script.ts`:
   - `LATIN_LOCALES` set + `inferScripts(locale)`: if locale or its `-Xxxx` subtag is Latin → `['Latin']`; Cyrl subtag → `['Cyrillic','Latin']`; else base-language table (`th→['Thai','Latin']`, `ja→['Han','Hiragana','Katakana','Latin']`, `ko→['Hangul','Han','Latin']`, `ar→['Arabic','Latin']`, `ru/uk→['Cyrillic','Latin']`, Latin-base langs `en/fr/de/es/it/pt/nl/...→['Latin']`). Always conceptually `+ Common` in the matcher.
   - `allowedFor(desc, locale)`: explicit `desc.options.script[locale]` if object; else `inferScripts(locale)`.
-  - matcher: build `new RegExp(\`^[\\p{Script=Common}\\s${scripts.map(s=>`\\p{Script=${s}}`).join('')}]*$\`, 'u')`. (Whitespace explicit for safety.)
+  - matcher: build `new RegExp(\`^[\\p{Script=Common}\\p{Script=Inherited}\\p{Mark}\\s${scripts.map(s=>`\\p{Script=${s}}`).join('')}]*$\`, 'u')`. **`Inherited`/`Mark` are always-on baseline alongside `Common`** — combining diacritics, joiners, Arabic harakat, Thai tone marks are `Script=Inherited`, NOT `Common`; omitting them false-rejects valid in-script text (advisor finding). Add tests: Thai tone-mark word `น้ำ` and an IPA-with-diacritics sample must PASS under their allowed scripts.
   - `validateI18nScript(value, field, desc)`: skip if `!desc.options.script`. For each locale slot string, test matcher; on violation honor `onScriptViolation`: `'reject'`(default)→throw `ScriptViolationError` (compute offending chars sample), `'filter'`→return a cleaned copy (strip disallowed), `'warn'`→return value + emit (return a `{ value, warnings }` tuple consumed by put). Provide both a throwing validate and a `applyScriptFilter` for the filter/warn paths.
   - Extend `I18nTextOptions`: `readonly script?: 'auto' | Partial<Record<string, readonly string[]>>; readonly onScriptViolation?: 'reject'|'filter'|'warn'`.
 - [ ] **Step 4:** PASS (verify `\p{Script=...}` works under the repo's TS/node target; tsconfig `target` ≥ ES2018 + `u` flag — confirm).
@@ -198,6 +198,14 @@ expect(() => validateI18nScript({ th:'อาคาร TCM' }, 'f', strict)).toTh
 ---
 
 ## Phase D — Per-layer threading (guard / derivation / mv / export)
+
+### Task D0 (GATE): spike whether MV/join resolution even has a call site
+
+**Advisor finding:** query resolution is NOT automatic — caller passes `{locale}` at the chain terminal. So inside an MV's `query(db).groupBy('firstName')`, `firstName` may still be the raw `{locale:string}` map, never resolved — meaning `mv:'throw'` has **no call site to fire from**, and tagging a facade `layer:'mv'` does nothing. Guard/derivation reads DO have call sites (`facade → get() → applyLocaleToRecord(defaultLocale)`); MV/join are the suspects.
+
+- [ ] **D0 spike:** write a throwaway test — an MV that `groupBy`s an i18nText field — and inspect whether the bucket key is a resolved string or the raw map. Also check the join expansion path. **Decision gate:**
+  - If resolution already runs in MV/join → D2/D3 are small (just thread the layer tag).
+  - If it does NOT → **do not invent resolution-injection under autonomy.** Land D1 (guard/derivation, real call sites) + A+B+C+E1–E3, and convert D2 (mv/export) and D3 (join) into documented follow-up tasks under milestone #17. A clean partial beats a forced aggregation-pipeline change.
 
 ### Task D1: layer-tagged `ReadOnlyVaultFacade`
 

--- a/docs/superpowers/plans/2026-06-06-in-pinia-reactive-i18n.md
+++ b/docs/superpowers/plans/2026-06-06-in-pinia-reactive-i18n.md
@@ -1,0 +1,332 @@
+# @noy-db/in-pinia reactive i18n — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (inline) to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax. TDD throughout; commit per task.
+
+**Goal:** Make locale reactive in a Pinia/Vue app over the shipped hub i18n surface — one reactive active-locale (`useNoydbI18n`) drives opt-in store resolution and reactive field/label selectors, so a consumer's UI is language-agnostic.
+
+**Architecture:** A `useNoydbI18n` Pinia store holds the active locale (state-only by default; `vault.setLocale` is opt-in). `defineNoydbStore` gains an `i18n` option (default `'raw'` = today's behavior; `'follow'` re-reads `c.list({locale})` and re-reads on locale change). `useDictLabel` is exported and defaults to the shared locale; `useI18nField` is a new reactive `pickLang`. No hub changes.
+
+**Tech Stack:** Vue 3, Pinia, Vitest + happy-dom. Spec: `docs/superpowers/specs/2026-06-06-in-pinia-reactive-i18n-design.md`. Milestone #17. Resolves #286.
+
+**Non-breaking:** default `i18n:'raw'` means existing stores are untouched; resolution is strictly opt-in.
+
+---
+
+## File structure
+
+| File | Responsibility | Slice |
+|---|---|---|
+| `src/useNoydbI18n.ts` (NEW) | `defineStore('noydb-i18n')` — `locale`, `fallback`, `setLocale(l,{syncVault?})`, `setFallback`, `bindTo(ref)` (state-only) | 1 |
+| `src/useI18nField.ts` (NEW) | reactive `pickLang` — `computed` over `resolveI18nText(..., {policy:'null'})` | 2 |
+| `src/useDictLabel.ts` (MOD) | default `locale`/`fallback` to `useNoydbI18n` | 3 |
+| `src/defineNoydbStore.ts` (MOD) | `i18n: 'raw'|'follow'|{locale,fallback?}` option; locale-aware `refresh`/`add`/`remove`; `watch` under `'follow'` | 4 |
+| `src/index.ts` (MOD) | export `useNoydbI18n`, `useI18nField`, `useDictLabel` + types | 1–4 |
+| `__tests__/useNoydbI18n.test.ts` etc. (NEW) | unit tests per unit | 1–4 |
+| `showcases/src/95-in-pinia-i18n.showcase.test.ts` (NEW) | end-to-end flip | 5 |
+| `features.yaml`, `MIGRATING.md` (MOD) | registration + opt-in note | 5 |
+
+Test harness (established): `setActivePinia(createPinia())`, inline `memory()` adapter, `createNoydb({store,user,secret,i18nStrategy:withI18n()})`, `setActiveNoydb(db)`, `effectScope()` for composables. Run: `pnpm --filter @noy-db/in-pinia exec vitest run <file>`.
+
+---
+
+## Slice 1 — `useNoydbI18n` store
+
+**Files:** Create `src/useNoydbI18n.ts`, `__tests__/useNoydbI18n.test.ts`; Modify `src/index.ts`
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { ref } from 'vue'
+import { useNoydbI18n } from '../src/useNoydbI18n.js'
+
+beforeEach(() => setActivePinia(createPinia()))
+
+it('defaults to en + [en,any]', () => {
+  const i = useNoydbI18n()
+  expect(i.locale).toBe('en')
+  expect(i.fallback).toEqual(['en', 'any'])
+})
+it('setLocale updates state (state-only, no vault arg required)', () => {
+  const i = useNoydbI18n()
+  i.setLocale('th')
+  expect(i.locale).toBe('th')
+})
+it('setFallback updates the chain', () => {
+  const i = useNoydbI18n()
+  i.setFallback(['th', 'any'])
+  expect(i.fallback).toEqual(['th', 'any'])
+})
+it('bindTo mirrors an external ref one-way', () => {
+  const i = useNoydbI18n()
+  const ext = ref('ja')
+  i.bindTo(ext)           // immediate
+  expect(i.locale).toBe('ja')
+  ext.value = 'th'
+  expect(i.locale).toBe('th')
+})
+```
+
+- [ ] **Step 2: Run → FAIL** (module missing). `pnpm --filter @noy-db/in-pinia exec vitest run __tests__/useNoydbI18n.test.ts`
+- [ ] **Step 3: Implement** `src/useNoydbI18n.ts` (setup store):
+
+```ts
+import { defineStore } from 'pinia'
+import { ref, watch, type Ref } from 'vue'
+import { resolveNoydb } from './context.js'
+
+export const useNoydbI18n = defineStore('noydb-i18n', () => {
+  const locale = ref<string>('en')
+  const fallback = ref<string[]>(['en', 'any'])
+
+  /**
+   * Set the active locale. State-only by default — in-pinia readers pass
+   * {locale} explicitly, so the vault ambient locale is never required.
+   * `syncVault: true` additionally calls vault.setLocale for non-in-pinia
+   * imperative reads (footgun for locale-less vaults — opt-in only).
+   */
+  function setLocale(l: string, opts?: { syncVault?: boolean }): void {
+    locale.value = l
+    if (opts?.syncVault) {
+      try {
+        const db = resolveNoydb(null) as unknown as { openVaults?: () => Iterable<{ setLocale(l: string): void }> }
+        for (const v of db.openVaults?.() ?? []) v.setLocale(l)
+      } catch { /* no active instance yet — state still updated */ }
+    }
+  }
+  function setFallback(chain: string[]): void { fallback.value = chain }
+
+  /** One-way, state-only follow of an external locale ref (e.g. vue-i18n). */
+  function bindTo(ref_: Ref<string>, opts?: { immediate?: boolean }): () => void {
+    return watch(ref_, (v) => { locale.value = v }, { immediate: opts?.immediate ?? true })
+  }
+
+  return { locale, fallback, setLocale, setFallback, bindTo }
+})
+```
+
+> **Verify during impl:** confirm the Noydb instance's open-vaults accessor name (grep hub for `openVaults`/`vaults`). If absent, change `syncVault` to accept an explicit `Vault | Vault[]`. `syncVault` is opt-in/secondary — don't block the slice on it; the state-only path (the default + all tests) is the contract that matters.
+
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5:** Add to `src/index.ts`: `export { useNoydbI18n } from './useNoydbI18n.js'`.
+- [ ] **Step 6: Commit** `feat(in-pinia): useNoydbI18n reactive locale store (state-only; vault sync opt-in)`
+
+---
+
+## Slice 2 — `useI18nField` reactive resolver
+
+**Files:** Create `src/useI18nField.ts`, `__tests__/useI18nField.test.ts`; Modify `src/index.ts`
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { ref } from 'vue'
+import { useNoydbI18n } from '../src/useNoydbI18n.js'
+import { useI18nField } from '../src/useI18nField.js'
+
+beforeEach(() => setActivePinia(createPinia()))
+
+it('resolves a map to the global locale and recomputes on flip', () => {
+  const i = useNoydbI18n()
+  const name = useI18nField({ th: 'สมชาย', en: 'Somchai' })
+  expect(name.value).toBe('Somchai')   // default en
+  i.setLocale('th')
+  expect(name.value).toBe('สมชาย')
+})
+it('returns null on miss (policy null, never throws)', () => {
+  const name = useI18nField({ th: 'สมชาย' }) // en active, no en, fallback en,any → th? fallback applies
+  // fallback default ['en','any'] → 'any' picks th
+  expect(name.value).toBe('สมชาย')
+})
+it('null when truly empty', () => {
+  const name = useI18nField({})
+  expect(name.value).toBeNull()
+})
+it('per-call locale override ignores global', () => {
+  const i = useNoydbI18n(); i.setLocale('en')
+  const th = useI18nField({ th: 'สมชาย', en: 'Somchai' }, { locale: 'th' })
+  expect(th.value).toBe('สมชาย')
+})
+it('reactive getter source recomputes', () => {
+  const src = ref<Record<string,string>>({ en: 'A' })
+  const v = useI18nField(() => src.value)
+  expect(v.value).toBe('A')
+  src.value = { en: 'B' }
+  expect(v.value).toBe('B')
+})
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** `src/useI18nField.ts`:
+
+```ts
+import { computed, unref, isRef, type Ref } from 'vue'
+import { resolveI18nText } from '@noy-db/hub/i18n'
+import { useNoydbI18n } from './useNoydbI18n.js'
+
+type MapSource =
+  | Record<string, string>
+  | (() => Record<string, string> | undefined | null)
+
+export interface UseI18nFieldOptions {
+  readonly locale?: string | Ref<string>
+  readonly fallback?: string | readonly string[]
+}
+
+export function useI18nField(
+  source: MapSource,
+  opts: UseI18nFieldOptions = {},
+): Ref<string | null> {
+  const i18n = useNoydbI18n()
+  return computed<string | null>(() => {
+    const map = typeof source === 'function' ? source() : source
+    if (!map || typeof map !== 'object') return null
+    const locale = opts.locale !== undefined ? unref(opts.locale) : i18n.locale
+    const fallback = opts.fallback ?? i18n.fallback
+    const out = resolveI18nText(map as Record<string, string>, locale, fallback, undefined, { policy: 'null' })
+    return typeof out === 'string' ? out : null   // 'raw' (object) can't occur with a real locale
+  })
+}
+```
+
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5:** `src/index.ts`: `export { useI18nField } from './useI18nField.js'; export type { UseI18nFieldOptions } from './useI18nField.js'`.
+- [ ] **Step 6: Commit** `feat(in-pinia): useI18nField reactive i18nText resolver (pickLang)`
+
+---
+
+## Slice 3 — export + default-locale `useDictLabel`
+
+**Files:** Modify `src/useDictLabel.ts`, `src/index.ts`; Test `__tests__/useDictLabel.test.ts` (extend)
+
+- [ ] **Step 1: Failing test** (new case appended to existing file — all 9 existing tests must keep passing):
+
+```ts
+it('defaults its locale to the shared useNoydbI18n', async () => {
+  setActivePinia(createPinia())               // ensure store available
+  const i = useNoydbI18n()
+  // dict 'invoiceStatus' seeded with { en:'Paid', th:'ชำระแล้ว' } in the harness
+  const label = useDictLabel('invoiceStatus', { vault })   // no locale passed
+  const paid = label('paid')
+  await nextTick()
+  expect(paid.value).toBe('Paid')             // follows global default 'en'
+  i.setLocale('th')
+  await nextTick()
+  expect(paid.value).toBe('ชำระแล้ว')          // recomputes on global flip
+})
+```
+
+- [ ] **Step 2: Run → FAIL** (current default is a private `ref('en')`, won't follow the store).
+- [ ] **Step 3: Implement.** In `src/useDictLabel.ts` `normaliseLocale` / option defaults: when `options.locale === undefined`, use `useNoydbI18n().locale`-backed ref instead of `ref('en')`; when `options.fallback === undefined`, use `useNoydbI18n().fallback`. Keep the existing `watch(localeRef, …)` (now watches the store-backed ref). Concretely:
+
+```ts
+import { useNoydbI18n } from './useNoydbI18n.js'
+// …
+function normaliseLocale(locale: UseDictLabelOptions['locale']): Ref<string> {
+  if (locale === undefined) {
+    const i18n = useNoydbI18n()
+    return toRef(i18n, 'locale')          // reactive, follows the store
+  }
+  if (typeof locale === 'string') return ref(locale)
+  return locale
+}
+const fallback = options.fallback ?? useNoydbI18n().fallback
+```
+(Import `toRef` from vue. `useNoydbI18n()` requires an active Pinia — the composable already runs in a setup/effect context, so this holds; document that.)
+
+- [ ] **Step 4: Run → PASS**; re-run the whole file → all existing 9 tests PASS.
+- [ ] **Step 5:** `src/index.ts`: `export { useDictLabel } from './useDictLabel.js'; export type { UseDictLabelOptions } from './useDictLabel.js'`.
+- [ ] **Step 6: Commit** `feat(in-pinia): export useDictLabel; default its locale/fallback to useNoydbI18n`
+
+---
+
+## Slice 4 — `defineNoydbStore` i18n option (default 'raw')
+
+**Files:** Modify `src/defineNoydbStore.ts`; Test `__tests__/defineNoydbStore.test.ts` (extend)
+
+- [ ] **Step 1: Failing tests**
+
+```ts
+// store with i18nFields: firstName i18nText({languages:['th','en'], required:'any'})
+it("default ('raw') keeps {th,en} maps (non-breaking)", async () => {
+  setActivePinia(createPinia())
+  const store = useStore()                       // no i18n option
+  await store.$ready
+  expect(store.items[0]?.firstName).toEqual({ th: 'สมชาย', en: 'Somchai' })
+})
+it("i18n:'follow' resolves to the global locale and re-reads on flip", async () => {
+  setActivePinia(createPinia())
+  const i = useNoydbI18n(); i.setLocale('en')
+  const store = useFollowStore()                 // defineNoydbStore(..., { i18n:'follow' })
+  await store.$ready
+  expect(store.items[0]?.firstName).toBe('Somchai')
+  i.setLocale('th')
+  await flushPromises()                          // watch → async refresh
+  expect(store.items[0]?.firstName).toBe('สมชาย')
+})
+it("i18n:{locale:'th'} pins regardless of global", async () => {
+  setActivePinia(createPinia())
+  const i = useNoydbI18n(); i.setLocale('en')
+  const store = usePinnedStore()                 // { i18n: { locale: 'th' } }
+  await store.$ready
+  expect(store.items[0]?.firstName).toBe('สมชาย')
+})
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement.**
+  1. Add to `NoydbStoreOptions<T>`: `i18n?: 'raw' | 'follow' | { locale: string | Ref<string>; fallback?: string | readonly string[] }`.
+  2. In the store setup, resolve the read options + optional locale source:
+
+```ts
+// near top of the setup body
+const i18nMode = options.i18n ?? 'raw'
+const i18nStore = i18nMode === 'follow' ? useNoydbI18n() : null
+function localeOpts(): { locale: string; fallback?: string | readonly string[] } {
+  if (i18nMode === 'raw') return { locale: 'raw' }
+  if (i18nMode === 'follow') return { locale: i18nStore!.locale, fallback: i18nStore!.fallback }
+  const l = i18nMode.locale
+  return { locale: typeof l === 'string' ? l : l.value, ...(i18nMode.fallback ? { fallback: i18nMode.fallback } : {}) }
+}
+```
+  3. Pass `localeOpts()` to all three reads: `refresh()` → `c.list(localeOpts())`; `add()`/`remove()` re-list → `c.list(localeOpts())`.
+  4. Re-read on locale change (follow + ref-pinned):
+
+```ts
+if (i18nMode === 'follow') {
+  watch(() => [i18nStore!.locale, i18nStore!.fallback], () => { void refresh() })
+} else if (typeof i18nMode === 'object' && isRef(i18nMode.locale)) {
+  watch(i18nMode.locale, () => { void refresh() })
+}
+```
+  Import `watch`, `isRef` from vue; `useNoydbI18n` from `./useNoydbI18n.js`. `liveQuery` is unchanged (raw) — out of scope per spec.
+
+- [ ] **Step 4: Run → PASS**; re-run the whole `defineNoydbStore.test.ts` → all existing tests PASS (default `'raw'` ≡ old `c.list()` for a locale-less vault; verify the existing i18n-forwarding test still sees maps).
+- [ ] **Step 5:** export the new option type if needed (it's part of `NoydbStoreOptions`, already exported).
+- [ ] **Step 6: Commit** `feat(in-pinia): defineNoydbStore i18n option (raw default; follow re-reads on locale change)`
+
+---
+
+## Slice 5 — showcase, features.yaml, MIGRATING, verification
+
+- [ ] **Step 1:** Create `showcases/src/95-in-pinia-i18n.showcase.test.ts` — set up pinia + a noydb with `withI18n()`, seed a person with `{th,en}` name and a dict; assert: (a) `i18n:'follow'` store resolves + re-resolves after `setLocale('th')`; (b) default `i18n:'raw'` store keeps the `{th,en}` map (feeds a bilingual toggle); (c) `useI18nField` + `useDictLabel` follow the flip. Model imports/harness on `showcases/src/38-in-pinia.showcase.test.ts` + `94-with-i18n-hardening`.
+- [ ] **Step 2:** Run the showcase → PASS (build in-pinia first if it resolves to dist: `pnpm --filter @noy-db/in-pinia build`).
+- [ ] **Step 3:** Register in `features.yaml` under the in-pinia framework entry: add showcase `95-in-pinia-i18n` + invariants (reactive `useNoydbI18n`; `defineNoydbStore` default `'raw'`, opt-in `'follow'`; `bindTo`/`setLocale` state-only, `syncVault` opt-in; `useI18nField`/`useDictLabel` follow global). Run `node scripts/validate-features.mjs` → OK.
+- [ ] **Step 4:** Add a MIGRATING.md note: in-pinia i18n is non-breaking (default `'raw'`); opt into `i18n:'follow'` for display-only stores; keep map/identity/export stores `'raw'`; locale-less vaults use `bindTo`/state-only `setLocale`, avoid `syncVault` (#286).
+- [ ] **Step 5:** Full verification:
+  - `pnpm --filter @noy-db/in-pinia test` → all green (existing + new)
+  - `pnpm --filter @noy-db/in-pinia typecheck` + `lint` → clean
+  - `pnpm --filter @noy-db/in-pinia build` → ok (new exports in dist)
+  - the new showcase passes; `node scripts/validate-features.mjs` OK
+- [ ] **Step 6: Commit** `feat(in-pinia): showcase 95 + features.yaml + MIGRATING (reactive i18n)` and push (updates the branch).
+
+---
+
+## Self-review
+
+- **Spec coverage:** `useNoydbI18n` (S1) ✓; state-only `setLocale`/`bindTo` + `syncVault` opt-in (S1) ✓; `useI18nField` (S2) ✓; export+default `useDictLabel` (S3) ✓; `defineNoydbStore` `i18n` default `'raw'`/`'follow'`/`{locale}` + re-read (S4) ✓; liveQuery deferred (noted) ✓; showcase + features.yaml + MIGRATING #286 (S5) ✓; no hub changes ✓.
+- **Type consistency:** `useNoydbI18n` returns `{ locale, fallback, setLocale, setFallback, bindTo }` — used identically in S2/S3/S4. `i18n` option union matches across S4 + spec. `useI18nField(source, opts)` signature stable.
+- **Risk:** `syncVault`'s open-vaults accessor is unverified — flagged inline; default state-only path (the contract) is unaffected. `useDictLabel` default-locale change must keep all 9 existing tests green — explicit in S3 Step 4.

--- a/docs/superpowers/specs/2026-06-05-i18n-multilingual-field-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-05-i18n-multilingual-field-hardening-design.md
@@ -37,8 +37,8 @@ Solved in user land, each of these becomes per-call-site boilerplate with weak, 
 - A field can declare an ordered `substitute` preference list (with `'any'` catch-all); a caller-supplied `fallback` overrides it per read.
 - The driving trace passes (see § Worked example): write `{ th }` under `required:'any'`; `get`/`join` substitute; `mv` throws; `derivation` sees `null`; `guard` is lenient.
 - A field can declare `script: 'auto'` (inferred per locale) or an explicit per-locale script set; values violating the allowed scripts are **rejected** by default at write, with `filter`/`warn` opt-outs.
-- Latin digits inside a Thai value pass; Latin *letters* inside the `en` slot's wrong-script value (Thai text) are rejected.
-- **dictKey parity:** the same `onMissing` + `substitute` policy governs `resolveLabel`; an array-of-keys field resolves to `[{ key, label }]` pair objects (key preserved through resolution); `groupBy`/`orderBy`/MV on a dictKey field bind to the **key** by default, with `{ by: 'label' }` as an explicit active-locale-scoped opt-in.
+- `auto` is **asymmetrically Latin-tolerant** (#283): a Thai address with embedded Latin (`'9/9 อาคาร TCM ถนนรัชดาภิเษก'`) passes the `th` slot, while Thai text in the `en` slot is still rejected. Latin digits pass everywhere (`Common`).
+- **dictKey parity:** the same `onMissing` + `substitute` policy governs `resolveLabel`; an array-of-keys field resolves to `[{ key, label }]` pair objects (key preserved through resolution); a **wildcard path** (`contacts[].title`, #282) adds a per-element sibling `<leaf>Label`; `groupBy`/`orderBy`/MV on a dictKey field bind to the **key** by default, with `{ by: 'label' }` as an explicit active-locale-scoped opt-in.
 - **No behavior change** for any existing `i18nText` or `dictKey` field that does not set a new option. Conformance tests for current i18n behavior stay green.
 - New code is fully inside the tree-shaken `withI18n()` strategy.
 
@@ -58,6 +58,7 @@ Solved in user land, each of these becomes per-call-site boilerplate with weak, 
 | `ScriptViolationError` distinct from `MissingTranslationError` / `LocaleNotSpecifiedError` | ✓ | Callers distinguish write-shape / read-hole / wrong-script |
 | **dictKey parity:** `onMissing` + `substitute` on `DictKeyOptions`, applied in `resolveLabel` | ✓ | Same policy engine, async caller; `'null'` is today's behavior (return `undefined`) |
 | **dictKey array-of-keys → `[{ key, label }]` pair objects**, element-wise policy | ✓ | Key preserved through resolution (defeats many-to-one label collapse) |
+| **dictKey wildcard-path** (`contacts[].title`) → per-element sibling `<leaf>Label` (#282) | ✓ | Closes asymmetry vs i18nText wildcards (#273); reuses `getAtPath`/`applyAtPath` |
 | **dictKey identity-vs-presentation binding:** `groupBy`/`orderBy`/MV bind to **key** by default; `{ by: 'label' }` opt-in | ✓ | Label-sort is active-locale-scoped (collation); key-bucketing is stable & locale-independent |
 | Subsystem doc + showcase | ✓ | Reader-facing; bilingual person-name + honorific (Mr./Ms.→คุณ) end-to-end |
 
@@ -176,21 +177,23 @@ type Script =
 
 - Validation runs **write-time**, in `Collection.put()` beside `validateI18nTextValue()`, via a new `validateI18nScript(value, field, descriptor)` in the `withI18n()` strategy.
 - Each provided locale slot's string is tested character-by-character (or via a compiled `RegExp` of allowed scripts) using `\p{Script=…}` with the `u` flag.
-- **`Common` is always in the allowed baseline** — digits `0-9`, whitespace, and common punctuation are `Script=Common`, so Latin digits inside a Thai value pass while Latin *letters* in the `en`-expected `th` content are rejected. (Thai digits `๐-๙` are `Script=Thai`; allowed in Thai slots.)
+- **`Common` is always in the allowed baseline** — digits `0-9`, whitespace, and common punctuation are `Script=Common`, so Latin digits pass in *every* slot regardless of script. (Thai digits `๐-๙` are `Script=Thai`; allowed in Thai slots.) Note `Common` covers only digits/punct/space — Latin *letters* are `Script=Latin`, governed by the per-locale set below, not the baseline.
 - `script: 'auto'` derives the allowed set per locale from a built-in table:
 
   | Locale | Inferred allowed (+ `Common`) |
   |---|---|
   | `en`, `fr`, `de`, … (Latin langs) | `Latin` |
-  | `th` | `Thai` |
-  | `ko` | `Hangul`, `Han` |
-  | `ja` | `Han`, `Hiragana`, `Katakana` |
-  | `ar` | `Arabic` |
-  | `ru`, `uk`, … | `Cyrillic` |
+  | `th` | `Thai`, **`Latin`** |
+  | `ko` | `Hangul`, `Han`, **`Latin`** |
+  | `ja` | `Han`, `Hiragana`, `Katakana`, **`Latin`** |
+  | `ar` | `Arabic`, **`Latin`** |
+  | `ru`, `uk`, … | `Cyrillic`, **`Latin`** |
   | any `*-Latn` (e.g. `th-Latn`, `ja-Latn` romaji, IPA-style) | `Latin` (subtag wins) |
-  | any `*-Cyrl` | `Cyrillic` (subtag wins) |
+  | any `*-Cyrl` | `Cyrillic`, `Latin` (subtag wins) |
 
-- `script: { en: ['Latin'], ja: ['Han','Hiragana','Katakana','Latin'] }` overrides per slot (e.g. a `ja` field that tolerates embedded Latin brand names).
+  **Asymmetric Latin tolerance (resolves #283).** Every *non-Latin*-script locale's `auto` set **includes `Latin`**, because proper names and addresses in those locales routinely embed Latin brand/building/technical names (`"9/9 อาคาร TCM ถนนรัชดาภิเษก"`, `"GT Tower ชั้น 15"`). *Latin*-script locales (`en`, …) do **not** get other scripts — so the common, real error (Thai text dumped into the `en` slot) is **still rejected**. The gate keeps its value (catch the en/th mixup) and drops its footgun (false-rejecting valid mixed-script identity fields). A field that must be *pure* primary-script tightens explicitly: `script: { th: ['Thai'] }`.
+
+- `script: { th: ['Thai'], en: ['Latin'] }` overrides per slot — here *tightening* `th` to forbid even embedded Latin (e.g. a strict code field), while a normal address field relies on `auto`'s Latin-tolerant default.
 - `onScriptViolation`:
   - `'reject'` (default) — throw `ScriptViolationError` naming the slot, expected scripts, and the offending characters; the write fails.
   - `'filter'` — strip disallowed characters before storing (resilient to messy paste; risk of silent loss — documented).
@@ -227,6 +230,21 @@ tagsResolved: [
 
 The pair-object shape is deliberate: **the stable `key` survives resolution**, which is what defeats the many-to-one collapse below.
 
+**Wildcard-path fields (resolves #282).** Distinct from an array-of-keys *value* is a **wildcard path over an array of objects**, each holding a *scalar* key — e.g. `dictKeyFields: { 'contacts[].title': dictKey('contactTitle', ['mr','ms']) }`, where `Entity.contacts: ClientContact[]`. Today this does **not** resolve: the label loop (`collection.ts:3031`) does `result[field]` (flat access) and skips non-string values, so `result['contacts[].title']` is `undefined` and no per-element label is added — even though i18nText array wildcards *do* resolve (`applyAtPath`, #273). Slice 3 closes this asymmetry:
+
+- The label populator walks `[].` wildcard paths (reusing the `getAtPath`/`applyAtPath` traversal from `i18n/core.ts`), resolving each array element's scalar key.
+- **Output shape:** each element gains a sibling virtual `<leaf>Label` (here `titleLabel`), paralleling both the scalar `<field>Label` convention and i18nText's in-place wildcard resolution — the element keeps its `title` key, so identity survives (same key-vs-label rule as below).
+
+```ts
+// 'contacts[].title', active locale 'th'
+contacts: [
+  { name: 'Somchai', title: 'mr', titleLabel: 'คุณ' },   // titleLabel added per element
+  { name: 'Jane',    title: 'ms', titleLabel: 'คุณ' },   // collapses for display; keys stay mr/ms
+]
+```
+
+This is the exact shape the niwat contact/worker honorifics need — the difference between delegating honorific resolution to noy-db vs. a user-land sync helper. The honorific showcase must exercise the honorific **nested on an array of contact objects**, not only a top-level field. (Per-element policy + collapse semantics are identical to the array-of-keys and many-to-one rules.)
+
 **Many-to-one label collapse (the `Mr.`/`Ms.` → `คุณ` case).** Distinct keys may share a label string in some locale (`mr → {en:'Mr.', th:'คุณ'}`, `ms → {en:'Ms.', th:'คุณ'}`). This is **not** a storage conflict — the keys stay distinct; only the *displayed label* coincides. It is a hazard solely when a resolved label is used as an **identity** (group / filter / dedup / reverse-lookup). The rule:
 
 - **Identity operations bind to the KEY.** `groupBy('title')`, `orderBy('title')`, MV bucketing, and join keys on a dictKey field operate on the stable key by default. `mr` and `ms` are always two buckets, locale-independent, deterministic, never missing. (A dictKey field is *safer* than i18nText for MV/groupBy precisely because it carries this key; i18nText has none — its value *is* the data — which is why i18nText MV-on-missing-locale throws.)
@@ -249,8 +267,10 @@ Field `firstName`: `languages:['th','en']`, `required:'any'`, `substitute:['en',
 | Step | Input / context | Outcome |
 |---|---|---|
 | Write | `{ th: 'สมชาย' }` (no `en`) | passes `required:'any'`; `th` is valid Thai script ✅ |
-| Write (bad script) | `{ en: 'สมชาย' }` | `ScriptViolationError` — `en` expects `Latin`, got `Thai` ✅ |
+| Write (bad script) | `{ en: 'สมชาย' }` | `ScriptViolationError` — `en` expects `Latin`, got `Thai` ✅ (the common error still caught) |
 | Write (digits) | `{ th: 'สมชาย 2024' }` | passes — Latin digits are `Common` ✅ |
+| Write (embedded Latin, #283) | address `th: '9/9 อาคาร TCM ถนนรัชดาภิเษก'` | passes — `auto` infers `th → [Thai, Latin, Common]`; Latin building names tolerated ✅ |
+| Write (pure-Thai override) | field with `script:{ th:['Thai'] }`, `th: 'อาคาร TCM'` | `ScriptViolationError` — explicit tightening forbids Latin in this field ✅ |
 | `get`, active `en` | `en` absent → `read:'substitute'` → chain `en,th,any` | returns `'สมชาย'` (Thai shown to en reader — acceptable for a name) ✅ |
 | `join` onto invoice, active `en` | `join:'substitute'` | `'สมชาย'` ✅ |
 | `mv` bucketed by `en` name | `en` absent → `mv:'throw'` | **`LocaleNotSpecifiedError`** — MV refresh fails loudly ✅ |
@@ -261,7 +281,7 @@ Field `firstName`: `languages:['th','en']`, `required:'any'`, `substitute:['en',
 
 1. **Resolution policy** — `onMissing` (per-layer) + `substitute`; thread a `Layer` tag through `resolveI18nText()` and every read path (read / join / mv / derivation / export / guard). Includes `LocaleNotSpecifiedError` reuse and the lenient-guard default. *(Slice 1)*
 2. **Script enforcement** — `script` + `onScriptViolation` + `ScriptViolationError` + BCP-47 inference table + `validateI18nScript()`. *(Slice 2, independent of Slice 1)*
-3. **dictKey parity** — `onMissing` + `substitute` on `DictKeyOptions` applied in `resolveLabel`; array-of-keys → `[{ key, label }]`; `groupBy`/`orderBy`/MV key-vs-label binding (`{ by }` option). *(Slice 3 — depends on Slice 1's policy engine; the query-binding part touches `query/groupby` + join planner)*
+3. **dictKey parity** — `onMissing` + `substitute` on `DictKeyOptions` applied in `resolveLabel`; array-of-keys → `[{ key, label }]`; **wildcard-path `contacts[].title` → per-element `<leaf>Label`** (#282, reuse `getAtPath`/`applyAtPath`); `groupBy`/`orderBy`/MV key-vs-label binding (`{ by }` option). *(Slice 3 — depends on Slice 1's policy engine; the query-binding part touches `query/groupby` + join planner)*
 4. **`densifyOnWrite` eager-fill** — deferred; optional follow-on. *(Slice 4)*
 
 Slice 3's policy half (resolveLabel) is small once Slice 1 lands; its query-binding half (key-vs-label `groupBy`/`orderBy`) is the larger, more cross-cutting piece and may sub-split.
@@ -270,7 +290,7 @@ Slice 3's policy half (resolveLabel) is small once Slice 1 lands; its query-bind
 
 - **`features.yaml`** — register the new capability nodes (spec ↔ artefact) or CI's "Spec coverage" job fails on dangling refs. Touch this in the implementation PR.
 - **Subsystem doc** — extend `docs/subsystems/` i18n section with the policy table + script model.
-- **Showcase** — add a bilingual showcase under `showcases/src/` exercising the full worked trace (write, substitute read, strict-MV throw, lenient guard, script reject) **plus** a dictKey honorific case (`Mr.`/`Ms.`→`คุณ`) proving key-bucketing stays distinct while label-sort collapses.
+- **Showcase** — add a bilingual showcase under `showcases/src/` exercising the full worked trace (write, substitute read, strict-MV throw, lenient guard, script reject, **Thai address with embedded Latin passing under `auto`** per #283) **plus** a dictKey honorific case (`Mr.`/`Ms.`→`คุณ`) **nested on an array of contact objects** (`contacts[].title`, #282) proving per-element label resolution and that key-bucketing stays distinct while label-sort collapses.
 - **Companion spec** — `@noy-db/in-pinia` reactive-binding spec is a *separate* brainstorm → spec → plan cycle (see intro). Not blocked by, but built on top of, this hub work. Open it after Slice 1 lands so the reactive selectors have a stable resolution API to wrap.
 - **Conformance** — new behavior tested on `to-memory` and `to-file`; existing i18n conformance must stay green to prove zero-breaking-change.
 - **Tree-shaking** — all new logic inside `withI18n()`; verify `NO_I18N` default bundle size is unchanged.

--- a/docs/superpowers/specs/2026-06-05-i18n-multilingual-field-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-05-i18n-multilingual-field-hardening-design.md
@@ -2,7 +2,9 @@
 
 > Extends the existing `i18nText` subsystem ([`packages/hub/src/i18n/core.ts`](../../../packages/hub/src/i18n/core.ts)) with **per-layer missing-value policy**, **declared substitute ordering**, and **per-locale script enforcement** — so that proper-name / multi-script identity fields are managed by noy-db with strong schema enforcement, instead of proliferating thousands of lines of brittle locale-handling in user land.
 >
-> **Foundation decision: extend in place, not rebuild.** Every capability lands as new *optional* fields on `I18nTextOptions`. Fields that don't opt in behave exactly as they do today — zero breaking change.
+> **Foundation decision: extend in place, not rebuild.** Every capability lands as new *optional* fields on `I18nTextOptions` (and, for parity, `DictKeyOptions`). Fields that don't opt in behave exactly as they do today — zero breaking change.
+>
+> **Companion spec (separate cycle): reactive binding.** Single-language "language-agnostic caller" mode also needs a *reactive locale → reactive resolved selectors* layer. That is a framework-binding concern and must NOT enter this zero-framework-dependency hub/core spec — it belongs in `@noy-db/in-pinia` as its own brainstorm → spec → plan cycle. This hub spec is the pure, synchronous resolution engine; the in-pinia spec wraps it reactively. Together they get single-language modes to near-agnostic. Tracked separately; only referenced here so the dependency is visible.
 
 ## Motivation — the practical issue
 
@@ -36,7 +38,8 @@ Solved in user land, each of these becomes per-call-site boilerplate with weak, 
 - The driving trace passes (see § Worked example): write `{ th }` under `required:'any'`; `get`/`join` substitute; `mv` throws; `derivation` sees `null`; `guard` is lenient.
 - A field can declare `script: 'auto'` (inferred per locale) or an explicit per-locale script set; values violating the allowed scripts are **rejected** by default at write, with `filter`/`warn` opt-outs.
 - Latin digits inside a Thai value pass; Latin *letters* inside the `en` slot's wrong-script value (Thai text) are rejected.
-- **No behavior change** for any existing `i18nText` field that does not set a new option. Conformance tests for current i18n behavior stay green.
+- **dictKey parity:** the same `onMissing` + `substitute` policy governs `resolveLabel`; an array-of-keys field resolves to `[{ key, label }]` pair objects (key preserved through resolution); `groupBy`/`orderBy`/MV on a dictKey field bind to the **key** by default, with `{ by: 'label' }` as an explicit active-locale-scoped opt-in.
+- **No behavior change** for any existing `i18nText` or `dictKey` field that does not set a new option. Conformance tests for current i18n behavior stay green.
 - New code is fully inside the tree-shaken `withI18n()` strategy.
 
 ## v1 SCOPE — what's in
@@ -53,7 +56,10 @@ Solved in user land, each of these becomes per-call-site boilerplate with weak, 
 | BCP-47 lang→script inference table + `-Latn`/`-Cyrl` subtag awareness | ✓ | Small maintained table inside `withI18n()` |
 | `onScriptViolation: 'reject' \| 'filter' \| 'warn'`, default `'reject'` | ✓ | New `ScriptViolationError`; validated write-time beside `validateI18nTextValue()` |
 | `ScriptViolationError` distinct from `MissingTranslationError` / `LocaleNotSpecifiedError` | ✓ | Callers distinguish write-shape / read-hole / wrong-script |
-| Subsystem doc + showcase | ✓ | Reader-facing; bilingual person-name end-to-end |
+| **dictKey parity:** `onMissing` + `substitute` on `DictKeyOptions`, applied in `resolveLabel` | ✓ | Same policy engine, async caller; `'null'` is today's behavior (return `undefined`) |
+| **dictKey array-of-keys → `[{ key, label }]` pair objects**, element-wise policy | ✓ | Key preserved through resolution (defeats many-to-one label collapse) |
+| **dictKey identity-vs-presentation binding:** `groupBy`/`orderBy`/MV bind to **key** by default; `{ by: 'label' }` opt-in | ✓ | Label-sort is active-locale-scoped (collation); key-bucketing is stable & locale-independent |
+| Subsystem doc + showcase | ✓ | Reader-facing; bilingual person-name + honorific (Mr./Ms.→คุณ) end-to-end |
 
 ## v1 SCOPE — what's deferred
 
@@ -190,12 +196,49 @@ type Script =
   - `'filter'` — strip disallowed characters before storing (resilient to messy paste; risk of silent loss — documented).
   - `'warn'` — store as-is and emit an `i18n:script-violation` diagnostic event (migration/audit mode).
 
+### dictKey parity (label resolution)
+
+dictKey labels are stored as the **same** `{ [locale]: string }` map as i18nText values (`dictionary.ts`, `DictEntry.labels`), reached by a different path: `DictionaryHandle.resolveLabel()` (`dictionary.ts:537`) is **async** (dictionary lookup) and populates a virtual `<field>Label` rather than replacing the field in place. Parity therefore reuses the *same policy engine*, only at a second call site.
+
+```ts
+interface DictKeyOptions {
+  // existing: dictionary name, optional key set …
+  readonly onMissing?: OnMissing | Partial<Record<Layer, OnMissing>>   // NEW — same type as i18nText
+  readonly substitute?: readonly string[]                              // NEW — same semantics
+}
+```
+
+- `resolveLabel(key, locale, …)` applies `policy(λ)` exactly as the resolution decision table: `'substitute'` walks `callerFallback ?? substitute` then degrades to `null`; `'null'` returns `undefined`/`null` (**today's exact behavior** — so existing dictKey reads are unchanged); `'throw'` raises `LocaleNotSpecifiedError` (reused; message carries field + key + dictionary).
+- The same `Layer` taxonomy applies: a dictKey label resolved inside an MV under `mv:'throw'` fails the refresh; under a lenient `guard` it substitutes.
+
+**Array-of-keys fields.** A dictKey field may hold an array of keys (e.g. `tags: ['urgent','vip']`). It resolves to an array of **pair objects** `[{ key, label }]`, policy applied **element-wise**:
+
+```ts
+// field 'tags', active locale 'th', onMissing:'null'
+tags:       ['urgent', 'vip', 'x']           // 'x' = dangling key
+tagsResolved: [
+  { key: 'urgent', label: 'ด่วน' },
+  { key: 'vip',    label: null },             // no 'th' label → 'null' policy
+  { key: 'x',      label: null },             // dangling key → also null
+]
+// 'throw' → fails on the first element with no label
+// 'substitute' → each element walks its own substitute chain, then null
+```
+
+The pair-object shape is deliberate: **the stable `key` survives resolution**, which is what defeats the many-to-one collapse below.
+
+**Many-to-one label collapse (the `Mr.`/`Ms.` → `คุณ` case).** Distinct keys may share a label string in some locale (`mr → {en:'Mr.', th:'คุณ'}`, `ms → {en:'Ms.', th:'คุณ'}`). This is **not** a storage conflict — the keys stay distinct; only the *displayed label* coincides. It is a hazard solely when a resolved label is used as an **identity** (group / filter / dedup / reverse-lookup). The rule:
+
+- **Identity operations bind to the KEY.** `groupBy('title')`, `orderBy('title')`, MV bucketing, and join keys on a dictKey field operate on the stable key by default. `mr` and `ms` are always two buckets, locale-independent, deterministic, never missing. (A dictKey field is *safer* than i18nText for MV/groupBy precisely because it carries this key; i18nText has none — its value *is* the data — which is why i18nText MV-on-missing-locale throws.)
+- **Presentation sort binds to the LABEL, explicitly.** `orderBy('title', { by: 'label' })` sorts by the resolved label in the **active locale**, with that locale's collation. This is where `Mr.`/`Ms.` legitimately become adjacent under `คุณ`, and where sort order is expected to differ per locale.
+- **Reverse lookup (label → key) is not a primitive.** It is ambiguous in collapsing locales (`คุณ` → `{mr, ms}`); callers hold the key (the pair object preserves it) and never round-trip through the label.
+
 ### Error taxonomy
 
 | Error | Raised at | Means |
 |---|---|---|
 | `MissingTranslationError` (exists) | write | `required` presence floor violated, or value not a `{ [locale]: string }` map |
-| `LocaleNotSpecifiedError` (exists) | read | target locale absent and policy is `'throw'` with no usable substitute |
+| `LocaleNotSpecifiedError` (exists) | read | target locale absent and policy is `'throw'` with no usable substitute — covers **both** i18nText values and dictKey labels (message carries field, and key+dictionary for dictKey) |
 | `ScriptViolationError` (NEW) | write | a slot's string contains characters outside its allowed script set under `onScriptViolation: 'reject'` |
 
 ## Worked example (the driving trace)
@@ -218,13 +261,17 @@ Field `firstName`: `languages:['th','en']`, `required:'any'`, `substitute:['en',
 
 1. **Resolution policy** — `onMissing` (per-layer) + `substitute`; thread a `Layer` tag through `resolveI18nText()` and every read path (read / join / mv / derivation / export / guard). Includes `LocaleNotSpecifiedError` reuse and the lenient-guard default. *(Slice 1)*
 2. **Script enforcement** — `script` + `onScriptViolation` + `ScriptViolationError` + BCP-47 inference table + `validateI18nScript()`. *(Slice 2, independent of Slice 1)*
-3. **`densifyOnWrite` eager-fill** — deferred; optional follow-on. *(Slice 3)*
+3. **dictKey parity** — `onMissing` + `substitute` on `DictKeyOptions` applied in `resolveLabel`; array-of-keys → `[{ key, label }]`; `groupBy`/`orderBy`/MV key-vs-label binding (`{ by }` option). *(Slice 3 — depends on Slice 1's policy engine; the query-binding part touches `query/groupby` + join planner)*
+4. **`densifyOnWrite` eager-fill** — deferred; optional follow-on. *(Slice 4)*
+
+Slice 3's policy half (resolveLabel) is small once Slice 1 lands; its query-binding half (key-vs-label `groupBy`/`orderBy`) is the larger, more cross-cutting piece and may sub-split.
 
 ## Integration & non-code obligations
 
 - **`features.yaml`** — register the new capability nodes (spec ↔ artefact) or CI's "Spec coverage" job fails on dangling refs. Touch this in the implementation PR.
 - **Subsystem doc** — extend `docs/subsystems/` i18n section with the policy table + script model.
-- **Showcase** — add a bilingual person-name showcase under `showcases/src/` exercising the full worked trace (write, substitute read, strict-MV throw, lenient guard, script reject).
+- **Showcase** — add a bilingual showcase under `showcases/src/` exercising the full worked trace (write, substitute read, strict-MV throw, lenient guard, script reject) **plus** a dictKey honorific case (`Mr.`/`Ms.`→`คุณ`) proving key-bucketing stays distinct while label-sort collapses.
+- **Companion spec** — `@noy-db/in-pinia` reactive-binding spec is a *separate* brainstorm → spec → plan cycle (see intro). Not blocked by, but built on top of, this hub work. Open it after Slice 1 lands so the reactive selectors have a stable resolution API to wrap.
 - **Conformance** — new behavior tested on `to-memory` and `to-file`; existing i18n conformance must stay green to prove zero-breaking-change.
 - **Tree-shaking** — all new logic inside `withI18n()`; verify `NO_I18N` default bundle size is unchanged.
 

--- a/docs/superpowers/specs/2026-06-05-i18n-multilingual-field-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-05-i18n-multilingual-field-hardening-design.md
@@ -1,0 +1,233 @@
+# i18n multilingual-field hardening (hub core / i18n) — design
+
+> Extends the existing `i18nText` subsystem ([`packages/hub/src/i18n/core.ts`](../../../packages/hub/src/i18n/core.ts)) with **per-layer missing-value policy**, **declared substitute ordering**, and **per-locale script enforcement** — so that proper-name / multi-script identity fields are managed by noy-db with strong schema enforcement, instead of proliferating thousands of lines of brittle locale-handling in user land.
+>
+> **Foundation decision: extend in place, not rebuild.** Every capability lands as new *optional* fields on `I18nTextOptions`. Fields that don't opt in behave exactly as they do today — zero breaking change.
+
+## Motivation — the practical issue
+
+A person's first name is **mandatory**, but in a bilingual interface (assume `th`, `en`) the value is not a *translation* — it is a **proper name** written in one script. The library must answer questions that today have no first-class home and leak into application code:
+
+- What is required on write? (both languages, one, or one-present-other-derivable?)
+- On read in the active locale, if that locale's value is absent — substitute another language? return `null`? throw?
+- With 3+ languages, is there a *preferred* substitute order?
+- Must enforcement differ by **layer** — lenient at the store/guard boundary, strict inside a derivation or materialized view?
+- For script-specific languages (Thai, Korean, Japanese, Arabic, Cyrillic…), can the field **reject the wrong script** in a slot (no Thai letters in the `en` slot) while still tolerating common usage (Latin digits inside Thai text)?
+
+Solved in user land, each of these becomes per-call-site boilerplate with weak, inconsistent enforcement. Solved in noy-db, they become **field-level declarations** honored uniformly by every read/write path — the USP for any multi-language, and especially multi-script, deployment.
+
+## What already exists (and is reused, not rebuilt)
+
+| Capability | Where | Reused as |
+|---|---|---|
+| `{ [locale]: string }` storage + descriptor pattern | `i18n/core.ts` | unchanged storage shape |
+| `required: 'all' \| 'any' \| string[]` write-time presence | `validateI18nTextValue()` | **the write-time presence floor** — independent of new `onMissing` |
+| Single map→string collapse function | `resolveI18nText()` | **the one resolution choke point** every layer routes through |
+| Caller fallback chain + `'any'` | `resolveI18nText()` | becomes the per-read override of the new declared `substitute` |
+| `locale: 'raw'` escape hatch | `resolveI18nText()` | unchanged; bypasses all policy |
+| Ambient active locale | `vault.setLocale()`, `openVault(name, { locale })`, `collection.defaultLocale` (`collection.ts:3018`) | "store in one language, `get` returns the active language" — **already built** |
+| Write-time `autoTranslate` + `plaintextTranslator` hook | `core.ts` / `createNoydb` | unchanged; translation stays write-time only |
+| Tree-shake seam | `i18n/strategy.ts` (`NO_I18N`) / `i18n/active.ts` (`withI18n()`) | all new code lives here; non-i18n bundles pay nothing |
+
+## Success criteria (acceptance)
+
+- A field can declare `onMissing` as a single policy **or a per-layer map**, and each read/validation path honors the policy for *its* layer.
+- A field can declare an ordered `substitute` preference list (with `'any'` catch-all); a caller-supplied `fallback` overrides it per read.
+- The driving trace passes (see § Worked example): write `{ th }` under `required:'any'`; `get`/`join` substitute; `mv` throws; `derivation` sees `null`; `guard` is lenient.
+- A field can declare `script: 'auto'` (inferred per locale) or an explicit per-locale script set; values violating the allowed scripts are **rejected** by default at write, with `filter`/`warn` opt-outs.
+- Latin digits inside a Thai value pass; Latin *letters* inside the `en` slot's wrong-script value (Thai text) are rejected.
+- **No behavior change** for any existing `i18nText` field that does not set a new option. Conformance tests for current i18n behavior stay green.
+- New code is fully inside the tree-shaken `withI18n()` strategy.
+
+## v1 SCOPE — what's in
+
+| Feature | In v1 | Notes |
+|---|:---:|---|
+| `onMissing: OnMissing \| Partial<Record<Layer, OnMissing>>` | ✓ | `OnMissing = 'substitute' \| 'null' \| 'throw'`; default `'throw'` (today's behavior) |
+| `Layer = 'read' \| 'guard' \| 'join' \| 'mv' \| 'derivation' \| 'export'` | ✓ | No `store` key — writes governed by `required` (see § Layer taxonomy) |
+| `substitute: readonly string[]` declared preference | ✓ | `'any'` = first non-empty; caller `fallback` overrides per-read |
+| Route join / mv / derivation / export read paths through `resolveI18nText()` with a `Layer` tag | ✓ | The single-choke-point discipline is the core of the feature |
+| `guard` layer defaults to lenient `'substitute'` | ✓ | Even when top-level `onMissing` is `'throw'`; overridable |
+| `'substitute'` exhausted ⇒ `null` | ✓ | Best-effort by definition; not an error |
+| `script: 'auto' \| Partial<Record<locale, Script[]>>` | ✓ | Absent ⇒ no check (backward-compat). `Common` always in baseline |
+| BCP-47 lang→script inference table + `-Latn`/`-Cyrl` subtag awareness | ✓ | Small maintained table inside `withI18n()` |
+| `onScriptViolation: 'reject' \| 'filter' \| 'warn'`, default `'reject'` | ✓ | New `ScriptViolationError`; validated write-time beside `validateI18nTextValue()` |
+| `ScriptViolationError` distinct from `MissingTranslationError` / `LocaleNotSpecifiedError` | ✓ | Callers distinguish write-shape / read-hole / wrong-script |
+| Subsystem doc + showcase | ✓ | Reader-facing; bilingual person-name end-to-end |
+
+## v1 SCOPE — what's deferred
+
+| Feature | Deferred to | Why |
+|---|---|---|
+| `densifyOnWrite?: boolean` (eager-fill empty slots from substitute at write) | v1.x | Changes stored bytes + provenance; mutually exclusive with strict-MV (a substituted copy is not a real translation). Clean as its own opt-in slice. |
+| Nearest-script **smart** substitution (prefer same-or-readable script: Thai→Latin over CJK) | v2 | Strongest multi-script USP, but needs a richer script-relation map. Declared-list mechanism ships first; smart selection layers on top. |
+| Lazy auto-translation **on read** | — (out) | Read stays pure/synchronous; network I/O + caching must not poison `get()`. Translation remains write-time `autoTranslate`. |
+| Per-locale CRDT merge | — (out) | Already out of scope in current i18n; unchanged. |
+| Pluralization, RTL, date/number formatting | — (out) | Rendering concerns; belong in the view layer. |
+| Native-digits-only enforcement (reject Latin digits in Thai) | v2 | `Common` baseline permits Latin digits, which is the common-usage default. A strict `digits: 'native'` toggle can come later. |
+
+## Architecture
+
+### Where it sits
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ Application                                                    │
+│   people.collection('people', {                                │
+│     i18nFields: { firstName: i18nText({                        │
+│       languages: ['th','en'], required: 'any',                 │
+│       substitute: ['en','th','any'],                           │
+│       onMissing: { read:'substitute', join:'substitute',       │
+│                    mv:'throw', derivation:'null' },            │
+│       script: 'auto', onScriptViolation: 'reject',             │
+│     }) } })                                                     │
+└───────────────┬───────────────────────────────┬────────────────┘
+        write path                        read paths (per layer)
+                ▼                                 ▼
+┌────────────────────────────┐   ┌──────────────────────────────────┐
+│ Collection.put()           │   │ get/list  → Layer 'read'          │
+│  ├ validateSchemaInput      │   │ join expand → Layer 'join'        │
+│  ├ validateI18nTextValue ◄──┼─┐ │ MV input   → Layer 'mv'           │
+│  │   (required floor)       │ │ │ deriv input→ Layer 'derivation'   │
+│  └ validateI18nScript ◄─────┼─┤ │ guard read → Layer 'guard'        │
+│      (NEW, write-time)      │ │ │ bundle/exp → Layer 'export'       │
+└────────────────────────────┘ │ └──────────────┬───────────────────┘
+                               │                ▼
+                               │   ┌──────────────────────────────────┐
+            withI18n() strategy└──►│ resolveI18nText(value, {          │
+            (tree-shaken)          │   locale, layer, policy,          │
+                                   │   substitute, callerFallback })   │
+                                   │   ── the ONE choke point ──       │
+                                   └──────────────────────────────────┘
+```
+
+### Resolution policy model
+
+```ts
+type OnMissing = 'substitute' | 'null' | 'throw'        // default 'throw'
+type Layer = 'read' | 'guard' | 'join' | 'mv' | 'derivation' | 'export'
+
+interface I18nTextOptions {
+  readonly languages: readonly string[]
+  readonly required: 'all' | 'any' | readonly string[]   // UNCHANGED — write-time floor
+  readonly autoTranslate?: boolean                        // UNCHANGED
+
+  // NEW — resolution policy
+  readonly onMissing?: OnMissing | Partial<Record<Layer, OnMissing>>
+  readonly substitute?: readonly string[]                 // ordered; 'any' = first non-empty
+
+  // NEW — script enforcement
+  readonly script?: 'auto' | Partial<Record<string, readonly Script[]>>
+  readonly onScriptViolation?: 'reject' | 'filter' | 'warn'   // default 'reject'
+}
+```
+
+**Effective policy resolution** for layer `λ`:
+
+```
+explicit(λ) = typeof onMissing === 'object' ? onMissing[λ] : undefined   // per-layer override only
+scalar      = typeof onMissing === 'string' ? onMissing : undefined      // shared scalar policy
+
+policy(λ)   = explicit(λ) ?? layerDefault(λ) ?? scalar ?? 'throw'
+
+layerDefault('guard') = 'substitute'   // lenient unless EXPLICITLY overridden — never inherits a scalar
+layerDefault(other)   = undefined      // non-guard layers inherit the scalar, else 'throw'
+```
+
+Consequences (all intentional):
+- `onMissing: 'throw'` (scalar) ⇒ every layer throws **except** `guard`, which stays `'substitute'`. This is the R5 lenient-guard rule: a guard reading a display value must not hard-fail on a missing locale unless you ask it to (`onMissing: { guard: 'throw' }`).
+- `onMissing: { read: 'substitute', mv: 'throw' }` (partial object) ⇒ listed layers use their value; `guard` ⇒ `'substitute'` (its default); every **other** unlisted non-guard layer (`join`, `derivation`, `export`) ⇒ `'throw'`. Per-layer opt-in is explicit; the safe default is strict.
+
+### Resolution decision table
+
+For a field resolved to target locale `L` in layer `λ`, with `p = policy(λ)`:
+
+| State | `p = 'substitute'` | `p = 'null'` | `p = 'throw'` |
+|---|---|---|---|
+| `L` present (non-empty) | `value[L]` | `value[L]` | `value[L]` |
+| `L` absent, substitute chain hits | first non-empty in `callerFallback ?? substitute` | `null` | **throw `LocaleNotSpecifiedError`** |
+| `L` absent, chain exhausted | `null` | `null` | **throw `LocaleNotSpecifiedError`** |
+| `locale: 'raw'` | full map (policy bypassed) | full map | full map |
+
+- Caller `fallback` (passed to `get`/`list`/query terminal) **takes precedence** over the declared `substitute` list.
+- `'substitute'` never throws — it degrades to `null` when nothing is available.
+- `'throw'` is the default, preserving today's exact semantics for non-opting fields.
+
+### Layer taxonomy — the `store` reconciliation
+
+`onMissing` governs **resolution** (collapsing the map to a string when the target locale is absent), which only happens on **reads**. Write-time presence is a *separate* concern already owned by `required`. Therefore:
+
+- There is **no `store` key** in the `onMissing` map. A write missing a non-required language is simply stored sparse; `required` decides whether the write is legal at all.
+- The optional desire to *materialize* a substitute into empty slots at write time (so storage is dense and downstream layers never hit a hole) is the **deferred** `densifyOnWrite` boolean — separated because it changes stored bytes and provenance, and is **mutually exclusive with strict-MV** (an eager-filled `th` slot would make `mv:'throw'` on missing `th` unreachable).
+
+### Script enforcement model
+
+```ts
+type Script =
+  | 'Latin' | 'Thai' | 'Han' | 'Hiragana' | 'Katakana'
+  | 'Hangul' | 'Arabic' | 'Cyrillic' | 'Common' | string  // Unicode script names
+```
+
+- Validation runs **write-time**, in `Collection.put()` beside `validateI18nTextValue()`, via a new `validateI18nScript(value, field, descriptor)` in the `withI18n()` strategy.
+- Each provided locale slot's string is tested character-by-character (or via a compiled `RegExp` of allowed scripts) using `\p{Script=…}` with the `u` flag.
+- **`Common` is always in the allowed baseline** — digits `0-9`, whitespace, and common punctuation are `Script=Common`, so Latin digits inside a Thai value pass while Latin *letters* in the `en`-expected `th` content are rejected. (Thai digits `๐-๙` are `Script=Thai`; allowed in Thai slots.)
+- `script: 'auto'` derives the allowed set per locale from a built-in table:
+
+  | Locale | Inferred allowed (+ `Common`) |
+  |---|---|
+  | `en`, `fr`, `de`, … (Latin langs) | `Latin` |
+  | `th` | `Thai` |
+  | `ko` | `Hangul`, `Han` |
+  | `ja` | `Han`, `Hiragana`, `Katakana` |
+  | `ar` | `Arabic` |
+  | `ru`, `uk`, … | `Cyrillic` |
+  | any `*-Latn` (e.g. `th-Latn`, `ja-Latn` romaji, IPA-style) | `Latin` (subtag wins) |
+  | any `*-Cyrl` | `Cyrillic` (subtag wins) |
+
+- `script: { en: ['Latin'], ja: ['Han','Hiragana','Katakana','Latin'] }` overrides per slot (e.g. a `ja` field that tolerates embedded Latin brand names).
+- `onScriptViolation`:
+  - `'reject'` (default) — throw `ScriptViolationError` naming the slot, expected scripts, and the offending characters; the write fails.
+  - `'filter'` — strip disallowed characters before storing (resilient to messy paste; risk of silent loss — documented).
+  - `'warn'` — store as-is and emit an `i18n:script-violation` diagnostic event (migration/audit mode).
+
+### Error taxonomy
+
+| Error | Raised at | Means |
+|---|---|---|
+| `MissingTranslationError` (exists) | write | `required` presence floor violated, or value not a `{ [locale]: string }` map |
+| `LocaleNotSpecifiedError` (exists) | read | target locale absent and policy is `'throw'` with no usable substitute |
+| `ScriptViolationError` (NEW) | write | a slot's string contains characters outside its allowed script set under `onScriptViolation: 'reject'` |
+
+## Worked example (the driving trace)
+
+Field `firstName`: `languages:['th','en']`, `required:'any'`, `substitute:['en','th','any']`,
+`onMissing:{ read:'substitute', join:'substitute', mv:'throw', derivation:'null' }`, `script:'auto'`.
+
+| Step | Input / context | Outcome |
+|---|---|---|
+| Write | `{ th: 'สมชาย' }` (no `en`) | passes `required:'any'`; `th` is valid Thai script ✅ |
+| Write (bad script) | `{ en: 'สมชาย' }` | `ScriptViolationError` — `en` expects `Latin`, got `Thai` ✅ |
+| Write (digits) | `{ th: 'สมชาย 2024' }` | passes — Latin digits are `Common` ✅ |
+| `get`, active `en` | `en` absent → `read:'substitute'` → chain `en,th,any` | returns `'สมชาย'` (Thai shown to en reader — acceptable for a name) ✅ |
+| `join` onto invoice, active `en` | `join:'substitute'` | `'สมชาย'` ✅ |
+| `mv` bucketed by `en` name | `en` absent → `mv:'throw'` | **`LocaleNotSpecifiedError`** — MV refresh fails loudly ✅ |
+| `derivation` reads `firstName.en` | `derivation:'null'` | derive fn receives `null`, branches explicitly ✅ |
+| `guard` compares `firstName` | not in map → `layerDefault('guard') = 'substitute'` | `'สมชาย'`, guard does not hard-fail on a display hole ✅ |
+
+## Build sequence (independently shippable slices)
+
+1. **Resolution policy** — `onMissing` (per-layer) + `substitute`; thread a `Layer` tag through `resolveI18nText()` and every read path (read / join / mv / derivation / export / guard). Includes `LocaleNotSpecifiedError` reuse and the lenient-guard default. *(Slice 1)*
+2. **Script enforcement** — `script` + `onScriptViolation` + `ScriptViolationError` + BCP-47 inference table + `validateI18nScript()`. *(Slice 2, independent of Slice 1)*
+3. **`densifyOnWrite` eager-fill** — deferred; optional follow-on. *(Slice 3)*
+
+## Integration & non-code obligations
+
+- **`features.yaml`** — register the new capability nodes (spec ↔ artefact) or CI's "Spec coverage" job fails on dangling refs. Touch this in the implementation PR.
+- **Subsystem doc** — extend `docs/subsystems/` i18n section with the policy table + script model.
+- **Showcase** — add a bilingual person-name showcase under `showcases/src/` exercising the full worked trace (write, substitute read, strict-MV throw, lenient guard, script reject).
+- **Conformance** — new behavior tested on `to-memory` and `to-file`; existing i18n conformance must stay green to prove zero-breaking-change.
+- **Tree-shaking** — all new logic inside `withI18n()`; verify `NO_I18N` default bundle size is unchanged.
+
+## Out-of-scope (restated)
+
+Nearest-script smart substitution (v2), lazy on-read translation (out), per-locale CRDT merge (out), pluralization / RTL / formatting (out), native-digits-only enforcement (v2), `densifyOnWrite` (v1.x).

--- a/docs/superpowers/specs/2026-06-06-in-pinia-reactive-i18n-design.md
+++ b/docs/superpowers/specs/2026-06-06-in-pinia-reactive-i18n-design.md
@@ -18,8 +18,8 @@
 
 ## Success criteria (acceptance)
 
-- A single `useNoydbI18n().setLocale('th')` flips the language app-wide: every `i18n:'follow'` store re-reads resolved, every `useDictLabel`/`useI18nField` recomputes, and `vault.setLocale` is updated so imperative hub reads agree.
-- `useNoydbI18n` can `bindTo(externalRef)` (e.g. vue-i18n's `locale`) — one-way follow, no second source of truth.
+- A single `useNoydbI18n().setLocale('th')` flips the language app-wide: every `i18n:'follow'` store re-reads resolved, every `useDictLabel`/`useI18nField` recomputes. Resolution works via in-pinia's explicit per-read `{locale}` — **no vault mutation required**. `setLocale(l, { syncVault: true })` additionally syncs the vault ambient locale for non-in-pinia imperative reads.
+- `useNoydbI18n` can `bindTo(externalRef)` (e.g. vue-i18n's `locale`) — one-way, **state-only** follow (never touches the vault), so a locale-less-vault consumer can adopt it cleanly (#286).
 - `defineNoydbStore` accepts `i18n: 'follow' | 'raw' | { locale, fallback? }`; **default is `'follow'`** (resolved to the global locale).
 - A `i18n:'raw'` store yields `{th,en}` maps unchanged, feeding a bilingual per-cell toggle (Case 1) — the components own the toggle, the store owns the raw data.
 - `useDictLabel` is exported and defaults its locale to the shared `useNoydbI18n.locale`.
@@ -30,7 +30,7 @@
 
 | Feature | In | Notes |
 |---|:---:|---|
-| `useNoydbI18n` Pinia store (`locale`, `fallback`, `setLocale`, `setFallback`, `bindTo`) | ✓ | `setLocale` also calls `vault.setLocale` on the active instance's open vaults |
+| `useNoydbI18n` Pinia store (`locale`, `fallback`, `setLocale`, `setFallback`, `bindTo`) | ✓ | state-only by default; `setLocale(l,{syncVault:true})` opt-in syncs `vault.setLocale`; `bindTo` never touches the vault (#286) |
 | `defineNoydbStore` `i18n` option (`'follow'` default / `'raw'` / `{locale,fallback?}`) | ✓ | `'follow'` watches the global locale and re-reads `c.list({locale,fallback})` |
 | Export `useDictLabel`; default its locale to `useNoydbI18n` | ✓ | otherwise unchanged; existing 9 tests stay green |
 | `useI18nField(mapOrGetter, opts?)` reactive resolver (the reactive `pickLang`) | ✓ | `resolveI18nText(..., {policy:'null'})`; sync recompute on locale/source change |
@@ -51,10 +51,11 @@
 ```
             ┌─────────────────────────── useNoydbI18n (Pinia store) ──────────────────────────┐
             │  state: { locale: Ref<string>, fallback: Ref<string[]> }                          │
-            │  actions: setLocale(l) · setFallback(c) · bindTo(externalRef)                      │
+            │  actions: setLocale(l, {syncVault?}) · setFallback(c) · bindTo(externalRef)        │
+            │  (state-only by default; vault.setLocale only on opt-in syncVault — never bindTo)  │
             └───────────────┬─────────────────────────────────────────────┬────────────────────┘
-        setLocale(l):       │ watch(locale)                                 │ reads {locale,fallback}
-          vault.setLocale(l)▼                                               ▼
+                            │ watch(locale)                                 │ reads {locale,fallback}
+                            ▼                                               ▼
    ┌──────────────────────────────────┐   ┌──────────────────────┐   ┌──────────────────────────┐
    │ defineNoydbStore(i18n:'follow')   │   │ useDictLabel(key)     │   │ useI18nField(mapOrGetter)│
    │  watch(locale) → refresh()        │   │  watch(locale) →      │   │  computed →              │
@@ -67,9 +68,11 @@
 ### `useNoydbI18n` (`src/useNoydbI18n.ts`, new)
 A `defineStore('noydb-i18n', ...)`:
 - **state** `locale: string` (default `'en'`), `fallback: string[]` (default `['en','any']`).
-- **`setLocale(l)`** — sets state; resolves the active Noydb (`resolveNoydb()`) and calls `vault.setLocale(l)` on each open vault so imperative reads agree.
+- **`setLocale(l, opts?: { syncVault?: boolean })`** — sets the reactive `locale` state. **State-only by default** (`syncVault: false`). in-pinia readers pass `{locale}` explicitly on every read, so the reactive state alone drives all in-pinia resolution; the vault's ambient locale is never required. Only when `syncVault: true` does it resolve the active Noydb and call `vault.setLocale(l)` — for apps that *also* do imperative (non-in-pinia) hub reads and want those to follow. **Locale-less-vault consumers (guards/MV/export read raw) leave `syncVault` off** so the vault stays locale-less (resolves Hazard 2 / #286).
 - **`setFallback(chain)`** — sets the default fallback chain used by `'follow'` stores + composables.
-- **`bindTo(ref, { immediate=true })`** — `watch`es an external `Ref<string>` and mirrors it into `locale` (one-way). Returns the stop handle.
+- **`bindTo(ref, { immediate=true })`** — `watch`es an external `Ref<string>` (e.g. vue-i18n's `locale`) and mirrors it into `locale` **state-only** (one-way; never touches the vault, regardless of any `syncVault` use elsewhere). This is the clean path for a locale-less deployment: `bindTo(uiLocaleRef)` gives reactive display resolution while the vault stays untouched. Returns the stop handle.
+
+> **`bindTo` vault-side contract (#286):** `bindTo` is **state-only** — it mirrors the external ref into `useNoydbI18n.locale` and never fires `vault.setLocale`. A locale-less consumer can `bindTo(uiLocaleRef)` safely.
 
 ### `defineNoydbStore` locale wiring (`src/defineNoydbStore.ts`, modify)
 - Resolve the effective i18n mode: option `i18n` (default `'follow'`).
@@ -93,11 +96,26 @@ A `computed` that reads the (optionally getter-wrapped, reactive) map and return
 ## Error handling
 - `useI18nField` uses `{policy:'null'}` → never throws; returns `null` for an absent locale with no fallback hit.
 - `useDictLabel` keeps its `onMissing: 'key'|'empty'|'placeholder'` render policy.
-- `setLocale` calling `vault.setLocale` is best-effort across open vaults; if no instance is bound yet it no-ops (the reactive state still updates; stores read it on next refresh).
+- `setLocale` is state-only by default; under `{syncVault:true}` the `vault.setLocale` calls are best-effort across open vaults; if no instance is bound yet they no-op (the reactive state still updates; stores read it on next refresh).
+
+## MIGRATING guidance (locale-less / map-consuming consumers — #286)
+
+Two adoption hazards for a consumer that runs a **locale-less vault** and reads raw `{th,en}` maps out of stores (e.g. niwat). Both are guidance, not capability gaps — the `'raw'` mode + `useI18nField` already cover the case.
+
+**Hazard 1 — the `'follow'` default is for DISPLAY-ONLY stores.** Because `'follow'` re-reads *resolved strings*, any store whose **map** feeds a non-display read breaks on upgrade (`store.byId(id).name` becomes `"…"`, so `.name.th` is `undefined`). MIGRATING must state the rule explicitly with examples:
+> A `defineNoydbStore` is `'follow'` (resolved) by default. Set **`i18n:'raw'`** on any store whose maps feed:
+> - identity / view-model joins or derivation helpers reading `.th` (`entity.name.th`)
+> - export / filing projections (`worker.address.lineOne.th` → a tax filing) — **compliance-sensitive; do not let these silently resolve**
+> - a per-cell bilingual toggle bound to the map (`:value="entity.name"`)
+>
+> `'follow'` is only for stores whose values are consumed purely for display.
+
+**Hazard 2 — keep the vault locale-less; don't use `setLocale`'s vault sync.** A locale-less-vault consumer (so guards / MVs / strategies / exports read raw `.name.th`) must **not** set an ambient vault locale. MIGRATING note:
+> If you deliberately keep the vault locale-less, drive resolution with the reactive `useNoydbI18n.locale` (which in-pinia passes per-read) and `bindTo(uiLocaleRef)` — both **state-only**. Do **not** call `setLocale(l, { syncVault: true })`; the default `setLocale(l)` and `bindTo` never touch the vault, so your raw identity/guard/MV/export reads stay raw (latent today, load-bearing once #285 wires those layers).
 
 ## Testing
 Vitest + happy-dom (existing). Per-unit tests with `ref()`/`effectScope()` (no component mount, matching the package):
-- `useNoydbI18n`: `setLocale` updates state + calls `vault.setLocale`; `bindTo` follows an external ref.
+- `useNoydbI18n`: `setLocale(l)` updates state and does **not** call `vault.setLocale`; `setLocale(l,{syncVault:true})` does; `bindTo` follows an external ref **and never touches the vault** (assert `vault.setLocale` not called).
 - `defineNoydbStore`: `i18n:'follow'` store re-reads resolved on `setLocale`; `i18n:'raw'` keeps maps; `{locale}` pin ignores global; non-i18n store unchanged.
 - `useDictLabel`: existing 9 tests stay green; new test for "defaults to global locale".
 - `useI18nField`: resolves to global locale; recomputes on flip; `null` on miss; per-call override.
@@ -105,7 +123,7 @@ Vitest + happy-dom (existing). Per-unit tests with `ref()`/`effectScope()` (no c
 
 ## Integration & non-code obligations
 - **`features.yaml`** — register the new exports/showcase under the in-pinia framework entry (CI "Spec coverage").
-- **MIGRATING.md** — note the `defineNoydbStore` default-`'follow'` behavior change for i18n-bearing stores.
+- **MIGRATING.md** — the default-`'follow'` behavior change for i18n-bearing stores **and** the two locale-less/map-consumer hazards spelled out in § MIGRATING guidance above (Hazard 1: map-feeding stores → `i18n:'raw'`; Hazard 2: keep the vault locale-less, avoid `syncVault`). Resolves #286.
 - **Release** — this is the last item before the lockstep `0.2.0-pre.8` bump (manual release PR; main protected).
 
 ## Build sequence (slices)

--- a/docs/superpowers/specs/2026-06-06-in-pinia-reactive-i18n-design.md
+++ b/docs/superpowers/specs/2026-06-06-in-pinia-reactive-i18n-design.md
@@ -1,0 +1,116 @@
+# @noy-db/in-pinia — reactive i18n binding — design
+
+> The companion to the hub i18n hardening epic ([`2026-06-05-i18n-multilingual-field-hardening-design.md`](./2026-06-05-i18n-multilingual-field-hardening-design.md)). Hub is the pure synchronous resolution engine; this layer makes locale **reactive** in a Pinia/Vue app: a single reactive active-locale drives store re-reads and resolved selectors, so a consumer's UI becomes *language-agnostic* — flip the locale, everything re-renders resolved. Together they close the niwat "language-agnostic consumer" goal.
+
+## Motivation
+
+`@noy-db/in-pinia` already forwards `i18nFields`/`dictKeyFields` to collections, and ships a `useDictLabel` composable — but i18n is **not actually wired**: `defineNoydbStore` calls `c.list()` with no locale (so `store.items` hold raw `{th,en}` maps and unlabeled keys), `useDictLabel` is **not exported**, each call invents its own `ref('en')`, and there is **no shared reactive active-locale**. A consumer cannot flip one switch and have stores + labels re-render. This upgrade supplies the reactive spine and is the last piece before the lockstep release.
+
+## What already exists (reused)
+
+| Piece | File | Status |
+|---|---|---|
+| `defineNoydbStore` (items via `shallowRef` + `refresh()`/`list()`) | `src/defineNoydbStore.ts` | reads raw (`c.list()`, no locale) — to make locale-aware |
+| `useDictLabel` (reactive label factory, watches a locale ref, `db.on('change')`) | `src/useDictLabel.ts` (+9 tests) | built, **not exported**, owns a private `ref('en')` — to export + bind to shared locale |
+| `liveQuery` (wraps hub `LiveQuery.subscribe`) | `src/defineNoydbStore.ts` | raw — i18n resolution deferred (see scope-out) |
+| active-instance binding | `src/context.ts` | reused |
+| hub i18n surface: `resolveI18nText(map, locale, fb, field, {policy})`, `applyLocaleToRecord`, `<field>Label` on `get`/`list`, `vault.setLocale`/`getLocale`, `I18nMap` | `@noy-db/hub` / `@noy-db/hub/i18n` | shipped (PR #284) — **no new hub work** |
+
+## Success criteria (acceptance)
+
+- A single `useNoydbI18n().setLocale('th')` flips the language app-wide: every `i18n:'follow'` store re-reads resolved, every `useDictLabel`/`useI18nField` recomputes, and `vault.setLocale` is updated so imperative hub reads agree.
+- `useNoydbI18n` can `bindTo(externalRef)` (e.g. vue-i18n's `locale`) — one-way follow, no second source of truth.
+- `defineNoydbStore` accepts `i18n: 'follow' | 'raw' | { locale, fallback? }`; **default is `'follow'`** (resolved to the global locale).
+- A `i18n:'raw'` store yields `{th,en}` maps unchanged, feeding a bilingual per-cell toggle (Case 1) — the components own the toggle, the store owns the raw data.
+- `useDictLabel` is exported and defaults its locale to the shared `useNoydbI18n.locale`.
+- `useI18nField(mapOrGetter, opts?)` returns a reactive `Ref<string | null>` resolving one i18nText map, following the global locale unless overridden.
+- No breaking change for stores **without** i18n fields. Behavior change is limited to stores **with** `i18nFields`/`dictKeyFields` that don't set `i18n` (they now resolve instead of returning raw) — acceptable in the `0.2.0-pre` line and documented in MIGRATING.
+
+## SCOPE — in
+
+| Feature | In | Notes |
+|---|:---:|---|
+| `useNoydbI18n` Pinia store (`locale`, `fallback`, `setLocale`, `setFallback`, `bindTo`) | ✓ | `setLocale` also calls `vault.setLocale` on the active instance's open vaults |
+| `defineNoydbStore` `i18n` option (`'follow'` default / `'raw'` / `{locale,fallback?}`) | ✓ | `'follow'` watches the global locale and re-reads `c.list({locale,fallback})` |
+| Export `useDictLabel`; default its locale to `useNoydbI18n` | ✓ | otherwise unchanged; existing 9 tests stay green |
+| `useI18nField(mapOrGetter, opts?)` reactive resolver (the reactive `pickLang`) | ✓ | `resolveI18nText(..., {policy:'null'})`; sync recompute on locale/source change |
+| In-pinia i18n showcase | ✓ | global flip → re-resolve; `'raw'` store → bilingual toggle; field + dict label follow |
+| `features.yaml` registration + MIGRATING note | ✓ | new exports + showcase |
+
+## SCOPE — out (YAGNI / follow-ups)
+
+| Feature | Why |
+|---|---|
+| `liveQuery` i18n resolution | Live queries are subscriptions; re-reading on locale change is a separate design, and client-side mapping would contradict the chosen re-read model. v1: live queries return raw; resolve in-component via `useI18nField`. Documented. |
+| Fixing dict-mutation reactivity (dict `put()` bypasses the collection emitter) | Pre-existing hub limitation; `useDictLabel`'s workaround (locale change / re-create) stays. Tracked separately. |
+| Per-store **independent** reactive locale machinery beyond `{locale: ref}` | The `{locale}` override already covers "this section is always TH". |
+| Any hub change | This layer is purely a reactive wrapper over the shipped hub surface. |
+
+## Architecture
+
+```
+            ┌─────────────────────────── useNoydbI18n (Pinia store) ──────────────────────────┐
+            │  state: { locale: Ref<string>, fallback: Ref<string[]> }                          │
+            │  actions: setLocale(l) · setFallback(c) · bindTo(externalRef)                      │
+            └───────────────┬─────────────────────────────────────────────┬────────────────────┘
+        setLocale(l):       │ watch(locale)                                 │ reads {locale,fallback}
+          vault.setLocale(l)▼                                               ▼
+   ┌──────────────────────────────────┐   ┌──────────────────────┐   ┌──────────────────────────┐
+   │ defineNoydbStore(i18n:'follow')   │   │ useDictLabel(key)     │   │ useI18nField(mapOrGetter)│
+   │  watch(locale) → refresh()        │   │  watch(locale) →      │   │  computed →              │
+   │  c.list({locale,fallback})        │   │  resolveLabel(...)    │   │  resolveI18nText(...)    │
+   │  → items: resolved strings        │   │  → Ref<string>        │   │  → Ref<string|null>      │
+   └──────────────────────────────────┘   └──────────────────────┘   └──────────────────────────┘
+   i18n:'raw' → c.list({locale:'raw'}) → items keep {th,en}  ──▶ bilingual component owns the toggle
+```
+
+### `useNoydbI18n` (`src/useNoydbI18n.ts`, new)
+A `defineStore('noydb-i18n', ...)`:
+- **state** `locale: string` (default `'en'`), `fallback: string[]` (default `['en','any']`).
+- **`setLocale(l)`** — sets state; resolves the active Noydb (`resolveNoydb()`) and calls `vault.setLocale(l)` on each open vault so imperative reads agree.
+- **`setFallback(chain)`** — sets the default fallback chain used by `'follow'` stores + composables.
+- **`bindTo(ref, { immediate=true })`** — `watch`es an external `Ref<string>` and mirrors it into `locale` (one-way). Returns the stop handle.
+
+### `defineNoydbStore` locale wiring (`src/defineNoydbStore.ts`, modify)
+- Resolve the effective i18n mode: option `i18n` (default `'follow'`).
+- `mode === 'follow'`: `const i18n = useNoydbI18n()`; `refresh()` reads `c.list({ locale: i18n.locale, fallback: i18n.fallback })`; add `watch(() => i18n.locale, refresh)` (and `i18n.fallback`). `liveQuery` unchanged (raw).
+- `mode === 'raw'`: reads `c.list({ locale: 'raw' })`; no locale watch.
+- `mode === { locale, fallback? }`: reads with the fixed/own-ref locale; if `locale` is a ref, watch it.
+- Stores **without** any i18n/dictKey fields behave identically regardless (nothing to resolve), so the only observable change is for i18n-bearing stores — call this out in MIGRATING.
+
+### `useDictLabel` (`src/useDictLabel.ts`, modify + export)
+- Default `options.locale` to `useNoydbI18n().locale` (was `ref('en')`); default `options.fallback` to `useNoydbI18n().fallback`. All else unchanged. Add to `src/index.ts`.
+
+### `useI18nField` (`src/useI18nField.ts`, new)
+```ts
+function useI18nField(
+  source: Record<string,string> | (() => Record<string,string> | undefined),
+  opts?: { locale?: string | Ref<string>; fallback?: string | readonly string[] },
+): Ref<string | null>
+```
+A `computed` that reads the (optionally getter-wrapped, reactive) map and returns `resolveI18nText(map, locale, fallback, undefined, { policy: 'null' })` — locale/fallback default to `useNoydbI18n`. Pure, synchronous, recomputes on map or locale change. `null` when absent (never throws, never `undefined`).
+
+## Error handling
+- `useI18nField` uses `{policy:'null'}` → never throws; returns `null` for an absent locale with no fallback hit.
+- `useDictLabel` keeps its `onMissing: 'key'|'empty'|'placeholder'` render policy.
+- `setLocale` calling `vault.setLocale` is best-effort across open vaults; if no instance is bound yet it no-ops (the reactive state still updates; stores read it on next refresh).
+
+## Testing
+Vitest + happy-dom (existing). Per-unit tests with `ref()`/`effectScope()` (no component mount, matching the package):
+- `useNoydbI18n`: `setLocale` updates state + calls `vault.setLocale`; `bindTo` follows an external ref.
+- `defineNoydbStore`: `i18n:'follow'` store re-reads resolved on `setLocale`; `i18n:'raw'` keeps maps; `{locale}` pin ignores global; non-i18n store unchanged.
+- `useDictLabel`: existing 9 tests stay green; new test for "defaults to global locale".
+- `useI18nField`: resolves to global locale; recomputes on flip; `null` on miss; per-call override.
+- Showcase (`showcases/src/95-in-pinia-i18n.showcase.test.ts`): the end-to-end flip.
+
+## Integration & non-code obligations
+- **`features.yaml`** — register the new exports/showcase under the in-pinia framework entry (CI "Spec coverage").
+- **MIGRATING.md** — note the `defineNoydbStore` default-`'follow'` behavior change for i18n-bearing stores.
+- **Release** — this is the last item before the lockstep `0.2.0-pre.8` bump (manual release PR; main protected).
+
+## Build sequence (slices)
+1. `useNoydbI18n` store + tests. *(no consumers yet — safe)*
+2. `useI18nField` + tests. *(pure, depends on #1)*
+3. Export `useDictLabel` + default it to the shared locale + test. *(small)*
+4. `defineNoydbStore` `i18n` option + locale watch/re-read + tests. *(the behavior-changing slice)*
+5. Showcase + `features.yaml` + MIGRATING note + full verification.

--- a/docs/superpowers/specs/2026-06-06-in-pinia-reactive-i18n-design.md
+++ b/docs/superpowers/specs/2026-06-06-in-pinia-reactive-i18n-design.md
@@ -20,18 +20,18 @@
 
 - A single `useNoydbI18n().setLocale('th')` flips the language app-wide: every `i18n:'follow'` store re-reads resolved, every `useDictLabel`/`useI18nField` recomputes. Resolution works via in-pinia's explicit per-read `{locale}` — **no vault mutation required**. `setLocale(l, { syncVault: true })` additionally syncs the vault ambient locale for non-in-pinia imperative reads.
 - `useNoydbI18n` can `bindTo(externalRef)` (e.g. vue-i18n's `locale`) — one-way, **state-only** follow (never touches the vault), so a locale-less-vault consumer can adopt it cleanly (#286).
-- `defineNoydbStore` accepts `i18n: 'follow' | 'raw' | { locale, fallback? }`; **default is `'follow'`** (resolved to the global locale).
+- `defineNoydbStore` accepts `i18n: 'follow' | 'raw' | { locale, fallback? }`; **default is `'raw'`** (today's behavior — items stay `{th,en}` maps; zero breaking change). Display stores opt into `'follow'`.
 - A `i18n:'raw'` store yields `{th,en}` maps unchanged, feeding a bilingual per-cell toggle (Case 1) — the components own the toggle, the store owns the raw data.
 - `useDictLabel` is exported and defaults its locale to the shared `useNoydbI18n.locale`.
 - `useI18nField(mapOrGetter, opts?)` returns a reactive `Ref<string | null>` resolving one i18nText map, following the global locale unless overridden.
-- No breaking change for stores **without** i18n fields. Behavior change is limited to stores **with** `i18nFields`/`dictKeyFields` that don't set `i18n` (they now resolve instead of returning raw) — acceptable in the `0.2.0-pre` line and documented in MIGRATING.
+- **Zero breaking change** — the `'raw'` default means every existing store (with or without i18n fields) returns exactly what it does today. Resolution is strictly opt-in (`i18n:'follow'` or a composable). No silent break of map-consuming identity/export reads.
 
 ## SCOPE — in
 
 | Feature | In | Notes |
 |---|:---:|---|
 | `useNoydbI18n` Pinia store (`locale`, `fallback`, `setLocale`, `setFallback`, `bindTo`) | ✓ | state-only by default; `setLocale(l,{syncVault:true})` opt-in syncs `vault.setLocale`; `bindTo` never touches the vault (#286) |
-| `defineNoydbStore` `i18n` option (`'follow'` default / `'raw'` / `{locale,fallback?}`) | ✓ | `'follow'` watches the global locale and re-reads `c.list({locale,fallback})` |
+| `defineNoydbStore` `i18n` option (`'raw'` default / `'follow'` / `{locale,fallback?}`) | ✓ | `'raw'` = today's behavior (maps); `'follow'` watches the global locale and re-reads `c.list({locale,fallback})` |
 | Export `useDictLabel`; default its locale to `useNoydbI18n` | ✓ | otherwise unchanged; existing 9 tests stay green |
 | `useI18nField(mapOrGetter, opts?)` reactive resolver (the reactive `pickLang`) | ✓ | `resolveI18nText(..., {policy:'null'})`; sync recompute on locale/source change |
 | In-pinia i18n showcase | ✓ | global flip → re-resolve; `'raw'` store → bilingual toggle; field + dict label follow |
@@ -75,11 +75,11 @@ A `defineStore('noydb-i18n', ...)`:
 > **`bindTo` vault-side contract (#286):** `bindTo` is **state-only** — it mirrors the external ref into `useNoydbI18n.locale` and never fires `vault.setLocale`. A locale-less consumer can `bindTo(uiLocaleRef)` safely.
 
 ### `defineNoydbStore` locale wiring (`src/defineNoydbStore.ts`, modify)
-- Resolve the effective i18n mode: option `i18n` (default `'follow'`).
+- Resolve the effective i18n mode: option `i18n` (default `'raw'` — unchanged from today).
 - `mode === 'follow'`: `const i18n = useNoydbI18n()`; `refresh()` reads `c.list({ locale: i18n.locale, fallback: i18n.fallback })`; add `watch(() => i18n.locale, refresh)` (and `i18n.fallback`). `liveQuery` unchanged (raw).
-- `mode === 'raw'`: reads `c.list({ locale: 'raw' })`; no locale watch.
+- `mode === 'raw'` (**default**): reads `c.list({ locale: 'raw' })` — items stay `{th,en}` maps; no locale watch. Identical to today's `c.list()` behavior, so upgrading changes nothing until a store opts into `'follow'`.
 - `mode === { locale, fallback? }`: reads with the fixed/own-ref locale; if `locale` is a ref, watch it.
-- Stores **without** any i18n/dictKey fields behave identically regardless (nothing to resolve), so the only observable change is for i18n-bearing stores — call this out in MIGRATING.
+- Because the default is `'raw'`, the upgrade is **non-breaking**: every existing store keeps returning maps; resolution only happens where a store explicitly sets `i18n:'follow'`.
 
 ### `useDictLabel` (`src/useDictLabel.ts`, modify + export)
 - Default `options.locale` to `useNoydbI18n().locale` (was `ref('en')`); default `options.fallback` to `useNoydbI18n().fallback`. All else unchanged. Add to `src/index.ts`.
@@ -102,13 +102,13 @@ A `computed` that reads the (optionally getter-wrapped, reactive) map and return
 
 Two adoption hazards for a consumer that runs a **locale-less vault** and reads raw `{th,en}` maps out of stores (e.g. niwat). Both are guidance, not capability gaps — the `'raw'` mode + `useI18nField` already cover the case.
 
-**Hazard 1 — the `'follow'` default is for DISPLAY-ONLY stores.** Because `'follow'` re-reads *resolved strings*, any store whose **map** feeds a non-display read breaks on upgrade (`store.byId(id).name` becomes `"…"`, so `.name.th` is `undefined`). MIGRATING must state the rule explicitly with examples:
-> A `defineNoydbStore` is `'follow'` (resolved) by default. Set **`i18n:'raw'`** on any store whose maps feed:
+**Hazard 1 — RESOLVED BY THE `'raw'` DEFAULT (#286).** The default is `'raw'`, so the upgrade is non-breaking: stores keep returning `{th,en}` maps, and map-consuming identity/export reads (the compliance-sensitive ones) are never silently resolved. The guidance is therefore the safe inverse — *opt in* for display:
+> `defineNoydbStore` returns raw `{th,en}` maps by default (unchanged). Set **`i18n:'follow'`** only on **display-only** stores — those whose values are rendered, not read as maps. Leave the default `'raw'` for any store whose maps feed:
 > - identity / view-model joins or derivation helpers reading `.th` (`entity.name.th`)
-> - export / filing projections (`worker.address.lineOne.th` → a tax filing) — **compliance-sensitive; do not let these silently resolve**
+> - export / filing projections (`worker.address.lineOne.th` → a tax filing)
 > - a per-cell bilingual toggle bound to the map (`:value="entity.name"`)
 >
-> `'follow'` is only for stores whose values are consumed purely for display.
+> When in doubt, leave it `'raw'` and resolve at the edge with `useI18nField` / `useDictLabel`.
 
 **Hazard 2 — keep the vault locale-less; don't use `setLocale`'s vault sync.** A locale-less-vault consumer (so guards / MVs / strategies / exports read raw `.name.th`) must **not** set an ambient vault locale. MIGRATING note:
 > If you deliberately keep the vault locale-less, drive resolution with the reactive `useNoydbI18n.locale` (which in-pinia passes per-read) and `bindTo(uiLocaleRef)` — both **state-only**. Do **not** call `setLocale(l, { syncVault: true })`; the default `setLocale(l)` and `bindTo` never touch the vault, so your raw identity/guard/MV/export reads stay raw (latent today, load-bearing once #285 wires those layers).
@@ -123,12 +123,12 @@ Vitest + happy-dom (existing). Per-unit tests with `ref()`/`effectScope()` (no c
 
 ## Integration & non-code obligations
 - **`features.yaml`** — register the new exports/showcase under the in-pinia framework entry (CI "Spec coverage").
-- **MIGRATING.md** — the default-`'follow'` behavior change for i18n-bearing stores **and** the two locale-less/map-consumer hazards spelled out in § MIGRATING guidance above (Hazard 1: map-feeding stores → `i18n:'raw'`; Hazard 2: keep the vault locale-less, avoid `syncVault`). Resolves #286.
+- **MIGRATING.md** — the upgrade is non-breaking (default `'raw'`); document the opt-in: `i18n:'follow'` for display-only stores, plus the two locale-less notes from § MIGRATING guidance (Hazard 1: leave map-feeding stores `'raw'`; Hazard 2: keep the vault locale-less, avoid `syncVault`). Resolves #286.
 - **Release** — this is the last item before the lockstep `0.2.0-pre.8` bump (manual release PR; main protected).
 
 ## Build sequence (slices)
 1. `useNoydbI18n` store + tests. *(no consumers yet — safe)*
 2. `useI18nField` + tests. *(pure, depends on #1)*
 3. Export `useDictLabel` + default it to the shared locale + test. *(small)*
-4. `defineNoydbStore` `i18n` option + locale watch/re-read + tests. *(the behavior-changing slice)*
+4. `defineNoydbStore` `i18n` option (default `'raw'` = today's behavior) + `'follow'` locale watch/re-read + tests. *(additive; default path unchanged)*
 5. Showcase + `features.yaml` + MIGRATING note + full verification.

--- a/docs/superpowers/specs/2026-06-06-in-pinia-reactive-i18n-design.md
+++ b/docs/superpowers/specs/2026-06-06-in-pinia-reactive-i18n-design.md
@@ -18,7 +18,7 @@
 
 ## Success criteria (acceptance)
 
-- A single `useNoydbI18n().setLocale('th')` flips the language app-wide: every `i18n:'follow'` store re-reads resolved, every `useDictLabel`/`useI18nField` recomputes. Resolution works via in-pinia's explicit per-read `{locale}` — **no vault mutation required**. `setLocale(l, { syncVault: true })` additionally syncs the vault ambient locale for non-in-pinia imperative reads.
+- A single `useNoydbI18n().setLocale('th')` flips the language app-wide: every `i18n:'follow'` store re-reads resolved, every `useDictLabel`/`useI18nField` recomputes. Resolution works via in-pinia's explicit per-read `{locale}` — **no vault mutation required**. `setLocale(l, { syncVault: vault })` additionally syncs the given vault's ambient locale for non-in-pinia imperative reads.
 - `useNoydbI18n` can `bindTo(externalRef)` (e.g. vue-i18n's `locale`) — one-way, **state-only** follow (never touches the vault), so a locale-less-vault consumer can adopt it cleanly (#286).
 - `defineNoydbStore` accepts `i18n: 'follow' | 'raw' | { locale, fallback? }`; **default is `'raw'`** (today's behavior — items stay `{th,en}` maps; zero breaking change). Display stores opt into `'follow'`.
 - A `i18n:'raw'` store yields `{th,en}` maps unchanged, feeding a bilingual per-cell toggle (Case 1) — the components own the toggle, the store owns the raw data.
@@ -30,7 +30,7 @@
 
 | Feature | In | Notes |
 |---|:---:|---|
-| `useNoydbI18n` Pinia store (`locale`, `fallback`, `setLocale`, `setFallback`, `bindTo`) | ✓ | state-only by default; `setLocale(l,{syncVault:true})` opt-in syncs `vault.setLocale`; `bindTo` never touches the vault (#286) |
+| `useNoydbI18n` Pinia store (`locale`, `fallback`, `setLocale`, `setFallback`, `bindTo`) | ✓ | state-only by default; `setLocale(l,{syncVault:vault})` opt-in syncs the given vault(s); `bindTo` never touches the vault (#286) |
 | `defineNoydbStore` `i18n` option (`'raw'` default / `'follow'` / `{locale,fallback?}`) | ✓ | `'raw'` = today's behavior (maps); `'follow'` watches the global locale and re-reads `c.list({locale,fallback})` |
 | Export `useDictLabel`; default its locale to `useNoydbI18n` | ✓ | otherwise unchanged; existing 9 tests stay green |
 | `useI18nField(mapOrGetter, opts?)` reactive resolver (the reactive `pickLang`) | ✓ | `resolveI18nText(..., {policy:'null'})`; sync recompute on locale/source change |
@@ -68,7 +68,7 @@
 ### `useNoydbI18n` (`src/useNoydbI18n.ts`, new)
 A `defineStore('noydb-i18n', ...)`:
 - **state** `locale: string` (default `'en'`), `fallback: string[]` (default `['en','any']`).
-- **`setLocale(l, opts?: { syncVault?: boolean })`** — sets the reactive `locale` state. **State-only by default** (`syncVault: false`). in-pinia readers pass `{locale}` explicitly on every read, so the reactive state alone drives all in-pinia resolution; the vault's ambient locale is never required. Only when `syncVault: true` does it resolve the active Noydb and call `vault.setLocale(l)` — for apps that *also* do imperative (non-in-pinia) hub reads and want those to follow. **Locale-less-vault consumers (guards/MV/export read raw) leave `syncVault` off** so the vault stays locale-less (resolves Hazard 2 / #286).
+- **`setLocale(l, opts?: { syncVault?: Vault | Vault[] })`** — sets the reactive `locale` state. **State-only by default** (omit `syncVault`). in-pinia readers pass `{locale}` explicitly on every read, so the reactive state alone drives all in-pinia resolution; the vault's ambient locale is never required. Passing `syncVault: vault` (or an array) additionally calls `vault.setLocale(l)` on those vault(s) — for apps that *also* do imperative (non-in-pinia) hub reads and want those to follow. (Implementation note: `syncVault` takes explicit vault(s) rather than a boolean because the Noydb instance exposes no synchronous open-vaults accessor.) **Locale-less-vault consumers (guards/MV/export read raw) omit `syncVault`** so the vault stays locale-less (resolves Hazard 2 / #286).
 - **`setFallback(chain)`** — sets the default fallback chain used by `'follow'` stores + composables.
 - **`bindTo(ref, { immediate=true })`** — `watch`es an external `Ref<string>` (e.g. vue-i18n's `locale`) and mirrors it into `locale` **state-only** (one-way; never touches the vault, regardless of any `syncVault` use elsewhere). This is the clean path for a locale-less deployment: `bindTo(uiLocaleRef)` gives reactive display resolution while the vault stays untouched. Returns the stop handle.
 
@@ -96,7 +96,7 @@ A `computed` that reads the (optionally getter-wrapped, reactive) map and return
 ## Error handling
 - `useI18nField` uses `{policy:'null'}` → never throws; returns `null` for an absent locale with no fallback hit.
 - `useDictLabel` keeps its `onMissing: 'key'|'empty'|'placeholder'` render policy.
-- `setLocale` is state-only by default; under `{syncVault:true}` the `vault.setLocale` calls are best-effort across open vaults; if no instance is bound yet they no-op (the reactive state still updates; stores read it on next refresh).
+- `setLocale` is state-only by default; under `{syncVault: vault}` it calls `vault.setLocale(l)` on the explicit vault(s) passed (the reactive state updates regardless).
 
 ## MIGRATING guidance (locale-less / map-consuming consumers — #286)
 
@@ -111,11 +111,11 @@ Two adoption hazards for a consumer that runs a **locale-less vault** and reads 
 > When in doubt, leave it `'raw'` and resolve at the edge with `useI18nField` / `useDictLabel`.
 
 **Hazard 2 — keep the vault locale-less; don't use `setLocale`'s vault sync.** A locale-less-vault consumer (so guards / MVs / strategies / exports read raw `.name.th`) must **not** set an ambient vault locale. MIGRATING note:
-> If you deliberately keep the vault locale-less, drive resolution with the reactive `useNoydbI18n.locale` (which in-pinia passes per-read) and `bindTo(uiLocaleRef)` — both **state-only**. Do **not** call `setLocale(l, { syncVault: true })`; the default `setLocale(l)` and `bindTo` never touch the vault, so your raw identity/guard/MV/export reads stay raw (latent today, load-bearing once #285 wires those layers).
+> If you deliberately keep the vault locale-less, drive resolution with the reactive `useNoydbI18n.locale` (which in-pinia passes per-read) and `bindTo(uiLocaleRef)` — both **state-only**. Do **not** pass `setLocale`'s `syncVault`; the default `setLocale(l)` and `bindTo` never touch the vault, so your raw identity/guard/MV/export reads stay raw (latent today, load-bearing once #285 wires those layers).
 
 ## Testing
 Vitest + happy-dom (existing). Per-unit tests with `ref()`/`effectScope()` (no component mount, matching the package):
-- `useNoydbI18n`: `setLocale(l)` updates state and does **not** call `vault.setLocale`; `setLocale(l,{syncVault:true})` does; `bindTo` follows an external ref **and never touches the vault** (assert `vault.setLocale` not called).
+- `useNoydbI18n`: `setLocale(l)` updates state and does **not** call `vault.setLocale`; `setLocale(l,{syncVault:vault})` calls it on the given vault(s); `bindTo` follows an external ref **and never touches the vault** (assert `vault.setLocale` not called).
 - `defineNoydbStore`: `i18n:'follow'` store re-reads resolved on `setLocale`; `i18n:'raw'` keeps maps; `{locale}` pin ignores global; non-i18n store unchanged.
 - `useDictLabel`: existing 9 tests stay green; new test for "defaults to global locale".
 - `useI18nField`: resolves to global locale; recomputes on flip; `null` on miss; per-call override.

--- a/features.yaml
+++ b/features.yaml
@@ -1399,6 +1399,8 @@ frameworks:
     showcases:
       - id: 38-in-pinia
         path: showcases/src/38-in-pinia.showcase.test.ts
+      - id: 95-in-pinia-i18n
+        path: showcases/src/95-in-pinia-i18n.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -1406,6 +1408,9 @@ frameworks:
       - 'defineNoydbStore exposes items, count, add, update, remove'
       - 'Standard Schema v1 validator installed on the underlying collection'
       - 'i18nFields and dictKeyFields options forwarded to the underlying collection (no pre-registration needed)'
+      - 'useNoydbI18n is the reactive active-locale; setLocale is state-only by default (vault.setLocale opt-in via syncVault); bindTo follows an external ref state-only and never touches a vault'
+      - 'defineNoydbStore i18n option defaults to raw (today behavior; non-breaking); follow re-reads c.list({locale}) on locale change; {locale} pins'
+      - 'useI18nField is a reactive pickLang (resolveI18nText policy:null → string|null); useDictLabel defaults its locale/fallback to useNoydbI18n and follows a global flip'
     related: [in-vue]
 
   - id: in-devtools

--- a/features.yaml
+++ b/features.yaml
@@ -326,6 +326,8 @@ features:
     showcases:
       - id: 09-with-i18n
         path: showcases/src/09-with-i18n.showcase.test.ts
+      - id: 94-with-i18n-hardening
+        path: showcases/src/94-with-i18n-hardening.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -334,6 +336,11 @@ features:
       - 'resolveLabel(key, locale, fallback) walks the fallback chain'
       - 'No transliteration (locale-specific lossy mappings stay in userland)'
       - 'i18nField paths support dot notation (address.lineOne) and array wildcards (contacts[].title)'
+      - 'onMissing policy (substitute/null/throw) is per-layer; default throw preserves legacy behavior; only the read layer is wired (guard/mv/derivation/join/export are tracked follow-ups)'
+      - 'substitute: declared ordered preferred-locale chain; caller fallback overrides it per read'
+      - 'script enforcement is asymmetric-Latin: non-Latin locales also allow Latin (embedded brand/building names); Latin locales reject other scripts; Common/Inherited/Mark always allowed'
+      - 'onScriptViolation reject (default) | filter | warn; ScriptViolationError distinct from MissingTranslationError / LocaleNotSpecifiedError'
+      - 'dictKey array-of-keys resolves to [{key,label}] pair objects; wildcard-path contacts[].title adds per-element <leaf>Label; identity ops bind to the stable key'
     related: [vault-and-collections]
 
   - id: aggregate

--- a/packages/hub/__tests__/dictkey-parity.test.ts
+++ b/packages/hub/__tests__/dictkey-parity.test.ts
@@ -1,0 +1,108 @@
+/**
+ * dictKey parity (Slice 3): array-of-keys pair objects, wildcard-path
+ * resolution (#282), and substitute for labels.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { withI18n } from '../src/i18n/index.js'
+import { dictKey } from '../src/i18n/dictionary.js'
+import { ConflictError } from '../src/errors.js'
+import type { Noydb } from '../src/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) if (!n.startsWith('_')) {
+        const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) for (const [name, coll] of existing) if (name.startsWith('_')) comp.set(name, coll)
+      store.set(c, comp)
+    },
+  }
+}
+
+async function setup() {
+  const db: Noydb = await createNoydb({ store: memory(), user: 'a', secret: 'pw-dictkey', i18nStrategy: withI18n() })
+  const vault = await db.openVault('v', { locale: 'th' })
+  // honorific dictionary: mr/ms both → คุณ in Thai
+  const dict = vault.dictionary('contactTitle')
+  await dict.put('mr', { en: 'Mr.', th: 'คุณ' })
+  await dict.put('ms', { en: 'Ms.', th: 'คุณ' })
+  const tags = vault.dictionary('tag')
+  await tags.put('urgent', { en: 'Urgent', th: 'ด่วน' })
+  await tags.put('vip', { en: 'VIP' }) // no th label
+  return { db, vault }
+}
+
+describe('dictKey parity', () => {
+  it('wildcard-path contacts[].title adds per-element titleLabel (#282)', async () => {
+    const { vault } = await setup()
+    interface Entity { id: string; contacts: { name: string; title: string }[] }
+    const entities = vault.collection<Entity>('entities', {
+      dictKeyFields: { 'contacts[].title': dictKey('contactTitle', ['mr', 'ms'] as const) },
+    })
+    await entities.put('e1', {
+      id: 'e1',
+      contacts: [{ name: 'Somchai', title: 'mr' }, { name: 'Jane', title: 'ms' }],
+    })
+    const e = await entities.get('e1') as unknown as Record<string, unknown>
+    const contacts = e.contacts as Record<string, unknown>[]
+    expect(contacts[0]).toMatchObject({ title: 'mr', titleLabel: 'คุณ' })
+    expect(contacts[1]).toMatchObject({ title: 'ms', titleLabel: 'คุณ' })
+    // identity preserved: keys stay distinct even though labels collapse
+    expect(contacts[0]!.title).not.toBe(contacts[1]!.title)
+  })
+
+  it('array-of-keys resolves to [{key,label}] pair objects', async () => {
+    const { vault } = await setup()
+    interface Doc { id: string; tags: string[] }
+    const docs = vault.collection<Doc>('docs', {
+      dictKeyFields: { tags: dictKey('tag') },
+    })
+    await docs.put('d1', { id: 'd1', tags: ['urgent', 'vip', 'x'] })
+    const d = await docs.get('d1') as unknown as Record<string, unknown>
+    expect(d.tagsLabel).toEqual([
+      { key: 'urgent', label: 'ด่วน' },
+      { key: 'vip', label: null }, // no th label
+      { key: 'x', label: null },   // dangling key
+    ])
+  })
+
+  it('scalar dictKey still adds <field>Label (unchanged)', async () => {
+    const { vault } = await setup()
+    interface Doc { id: string; title: string }
+    const docs = vault.collection<Doc>('docs2', {
+      dictKeyFields: { title: dictKey('contactTitle', ['mr', 'ms'] as const) },
+    })
+    await docs.put('d1', { id: 'd1', title: 'mr' })
+    const d = await docs.get('d1') as unknown as Record<string, unknown>
+    expect(d.titleLabel).toBe('คุณ')
+  })
+})

--- a/packages/hub/__tests__/i18n-map-type.test-d.ts
+++ b/packages/hub/__tests__/i18n-map-type.test-d.ts
@@ -1,0 +1,33 @@
+/**
+ * I18nMap<Langs, Required> — type-level tests (vitest --typecheck).
+ *
+ * Infers the stored locale-map shape from the `required` mode so that
+ * accessing an absent-optional locale is a compile error
+ * (`string | undefined`) rather than a silent `undefined`.
+ *
+ * Run: `pnpm exec vitest --run --typecheck.enabled --typecheck.only`
+ */
+import { describe, it, expectTypeOf } from 'vitest'
+import type { I18nMap } from '../src/i18n/core.js'
+
+type Lang = 'th' | 'en' | 'ja'
+
+describe('I18nMap', () => {
+  it('all (default) → every locale required', () => {
+    expectTypeOf<I18nMap<Lang>>().toEqualTypeOf<{ th: string; en: string; ja: string }>()
+    expectTypeOf<I18nMap<Lang, 'all'>>().toEqualTypeOf<{ th: string; en: string; ja: string }>()
+    expectTypeOf<I18nMap<Lang>['th']>().toEqualTypeOf<string>()
+  })
+
+  it('any → every locale optional (bare access is string | undefined)', () => {
+    expectTypeOf<I18nMap<Lang, 'any'>>().toEqualTypeOf<{ th?: string; en?: string; ja?: string }>()
+    expectTypeOf<I18nMap<Lang, 'any'>['th']>().toEqualTypeOf<string | undefined>()
+  })
+
+  it('string[] → listed locales required, the rest optional', () => {
+    expectTypeOf<I18nMap<Lang, ['th']>>().toEqualTypeOf<{ th: string; en?: string; ja?: string }>()
+    expectTypeOf<I18nMap<Lang, ['th', 'en']>>().toEqualTypeOf<{ th: string; en: string; ja?: string }>()
+    expectTypeOf<I18nMap<Lang, ['th']>['th']>().toEqualTypeOf<string>()
+    expectTypeOf<I18nMap<Lang, ['th']>['en']>().toEqualTypeOf<string | undefined>()
+  })
+})

--- a/packages/hub/__tests__/i18n-policy.test.ts
+++ b/packages/hub/__tests__/i18n-policy.test.ts
@@ -1,0 +1,44 @@
+/**
+ * resolvePolicy — per-layer onMissing resolution.
+ *
+ * Encodes the spec's effective-policy table:
+ *   policy(λ) = explicit(λ) ?? layerDefault(λ) ?? scalar ?? 'throw'
+ *   layerDefault('guard') = 'substitute'  (lenient, never inherits a scalar)
+ *   layerDefault(other)   = undefined
+ */
+import { describe, it, expect } from 'vitest'
+import { resolvePolicy } from '../src/i18n/policy.js'
+
+describe('resolvePolicy', () => {
+  it('undefined onMissing → throw for every layer except guard', () => {
+    expect(resolvePolicy(undefined, 'read')).toBe('throw')
+    expect(resolvePolicy(undefined, 'mv')).toBe('throw')
+    expect(resolvePolicy(undefined, 'derivation')).toBe('throw')
+    expect(resolvePolicy(undefined, 'export')).toBe('throw')
+    expect(resolvePolicy(undefined, 'join')).toBe('throw')
+    expect(resolvePolicy(undefined, 'guard')).toBe('substitute')
+  })
+
+  it('scalar applies to all non-guard layers; guard stays lenient', () => {
+    expect(resolvePolicy('throw', 'read')).toBe('throw')
+    expect(resolvePolicy('substitute', 'mv')).toBe('substitute')
+    expect(resolvePolicy('null', 'join')).toBe('null')
+    // guard never inherits the scalar
+    expect(resolvePolicy('throw', 'guard')).toBe('substitute')
+    expect(resolvePolicy('null', 'guard')).toBe('substitute')
+  })
+
+  it('explicit guard override beats the lenient default', () => {
+    expect(resolvePolicy({ guard: 'throw' }, 'guard')).toBe('throw')
+    expect(resolvePolicy({ guard: 'null' }, 'guard')).toBe('null')
+  })
+
+  it('partial object: listed→value; unlisted non-guard→throw; guard→substitute', () => {
+    const p = { read: 'substitute', mv: 'throw' } as const
+    expect(resolvePolicy(p, 'read')).toBe('substitute')
+    expect(resolvePolicy(p, 'mv')).toBe('throw')
+    expect(resolvePolicy(p, 'join')).toBe('throw') // unlisted non-guard
+    expect(resolvePolicy(p, 'export')).toBe('throw')
+    expect(resolvePolicy(p, 'guard')).toBe('substitute') // unlisted guard
+  })
+})

--- a/packages/hub/__tests__/i18n-read-layer.test.ts
+++ b/packages/hub/__tests__/i18n-read-layer.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Read-layer policy: get/list honor a field's onMissing/substitute.
+ *
+ * The driving example — a person's firstName stored in one language,
+ * read under an active locale that's absent — substitutes per the
+ * declared chain, while a default (no onMissing) field still throws.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { withI18n } from '../src/i18n/index.js'
+import { i18nText } from '../src/i18n/core.js'
+import { ConflictError } from '../src/errors.js'
+import type { Noydb } from '../src/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) {
+        for (const [name, coll] of existing) {
+          if (name.startsWith('_')) comp.set(name, coll)
+        }
+      }
+      store.set(c, comp)
+    },
+  }
+}
+
+interface Person { id: string; firstName: Record<string, string> }
+
+async function freshDb(): Promise<Noydb> {
+  return createNoydb({
+    store: memory(),
+    user: 'alice',
+    secret: 'test-passphrase-read-layer',
+    i18nStrategy: withI18n(),
+  })
+}
+
+describe('read-layer onMissing/substitute', () => {
+  let db: Noydb
+  beforeEach(async () => { db = await freshDb() })
+
+  it("substitutes on get when active locale absent (read:'substitute')", async () => {
+    const vault = await db.openVault('v', { locale: 'en' })
+    const people = vault.collection<Person>('people', {
+      i18nFields: {
+        firstName: i18nText({
+          languages: ['th', 'en'],
+          required: 'any',
+          substitute: ['en', 'th', 'any'],
+          onMissing: { read: 'substitute' },
+        }),
+      },
+    })
+    await people.put('p1', { id: 'p1', firstName: { th: 'สมชาย' } })
+    const p = await people.get('p1')
+    expect(p?.firstName).toBe('สมชาย')
+  })
+
+  it("returns null on get under read:'null'", async () => {
+    const vault = await db.openVault('v2', { locale: 'en' })
+    const people = vault.collection<Person>('people', {
+      i18nFields: {
+        firstName: i18nText({
+          languages: ['th', 'en'],
+          required: 'any',
+          onMissing: { read: 'null' },
+        }),
+      },
+    })
+    await people.put('p1', { id: 'p1', firstName: { th: 'สมชาย' } })
+    const p = await people.get('p1')
+    expect(p?.firstName).toBeNull()
+  })
+
+  it('default (no onMissing) field still throws on missing locale', async () => {
+    const vault = await db.openVault('v3', { locale: 'en' })
+    const people = vault.collection<Person>('people', {
+      i18nFields: {
+        firstName: i18nText({ languages: ['th', 'en'], required: 'any' }),
+      },
+    })
+    await people.put('p1', { id: 'p1', firstName: { th: 'สมชาย' } })
+    await expect(people.get('p1')).rejects.toThrow(/locale/i)
+  })
+})

--- a/packages/hub/__tests__/i18n-resolve-policy.test.ts
+++ b/packages/hub/__tests__/i18n-resolve-policy.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Policy-aware resolveI18nText — the resolution decision table.
+ *
+ * - caller `fallback` ALWAYS applies first (backward compat + read override)
+ * - declared `substitute` applies ONLY under policy 'substitute'
+ * - exhaustion: 'throw' → throw; 'null'/'substitute' → null
+ * - locale:'raw' → return the map; legacy 4-arg form unchanged
+ */
+import { describe, it, expect } from 'vitest'
+import { resolveI18nText } from '../src/i18n/core.js'
+
+const v = { th: 'สมชาย' }
+
+describe('resolveI18nText — policy semantics', () => {
+  it('returns the present locale', () => {
+    expect(resolveI18nText({ en: 'A', th: 'B' }, 'en')).toBe('A')
+  })
+
+  it('legacy 4-arg form throws on miss (backward compat, default policy throw)', () => {
+    expect(() => resolveI18nText(v, 'en')).toThrow(/locale/i)
+  })
+
+  it('caller fallback always wins, even with default (throw) policy', () => {
+    expect(resolveI18nText(v, 'en', ['th'])).toBe('สมชาย')
+    expect(resolveI18nText(v, 'en', 'th')).toBe('สมชาย')
+  })
+
+  it("declared substitute applies under policy 'substitute'", () => {
+    expect(
+      resolveI18nText(v, 'en', undefined, 'firstName', {
+        policy: 'substitute',
+        substitute: ['th', 'any'],
+      }),
+    ).toBe('สมชาย')
+  })
+
+  it("policy 'null' returns null and ignores declared substitute", () => {
+    expect(
+      resolveI18nText(v, 'en', undefined, 'firstName', {
+        policy: 'null',
+        substitute: ['th'],
+      }),
+    ).toBeNull()
+  })
+
+  it("policy 'null' still honors an explicit caller fallback", () => {
+    expect(
+      resolveI18nText(v, 'en', ['th'], 'firstName', { policy: 'null' }),
+    ).toBe('สมชาย')
+  })
+
+  it("policy 'substitute' exhausted → null (not throw)", () => {
+    expect(
+      resolveI18nText({}, 'en', undefined, 'f', {
+        policy: 'substitute',
+        substitute: ['th', 'any'],
+      }),
+    ).toBeNull()
+  })
+
+  it("declared substitute is ignored under policy 'throw' (strict)", () => {
+    expect(() =>
+      resolveI18nText(v, 'en', undefined, 'f', {
+        policy: 'throw',
+        substitute: ['th'],
+      }),
+    ).toThrow(/locale/i)
+  })
+
+  it("'any' in a chain picks the first non-empty value", () => {
+    expect(
+      resolveI18nText({ ja: 'X' }, 'en', undefined, 'f', {
+        policy: 'substitute',
+        substitute: ['any'],
+      }),
+    ).toBe('X')
+  })
+
+  it('raw passthrough returns the full map', () => {
+    expect(resolveI18nText(v, 'raw')).toEqual(v)
+  })
+})

--- a/packages/hub/__tests__/i18n-script-put.test.ts
+++ b/packages/hub/__tests__/i18n-script-put.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Script enforcement wired into Collection.put (#283).
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { withI18n } from '../src/i18n/index.js'
+import { i18nText } from '../src/i18n/core.js'
+import { ScriptViolationError, ConflictError } from '../src/errors.js'
+import type { Noydb } from '../src/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) if (!n.startsWith('_')) {
+        const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) for (const [name, coll] of existing) if (name.startsWith('_')) comp.set(name, coll)
+      store.set(c, comp)
+    },
+  }
+}
+
+interface Co { id: string; name: Record<string, string> }
+
+async function freshDb(): Promise<Noydb> {
+  return createNoydb({ store: memory(), user: 'a', secret: 'pw-script-put', i18nStrategy: withI18n() })
+}
+
+describe('script enforcement on put', () => {
+  let db: Noydb
+  beforeEach(async () => { db = await freshDb() })
+
+  it('rejects Thai text in an en slot', async () => {
+    const v = await db.openVault('v', { locale: 'th' })
+    const co = v.collection<Co>('co', {
+      i18nFields: { name: i18nText({ languages: ['th', 'en'], required: 'any', script: 'auto' }) },
+    })
+    await expect(co.put('c1', { id: 'c1', name: { en: 'สมชาย' } })).rejects.toThrow(ScriptViolationError)
+  })
+
+  it('accepts a Thai address with embedded Latin (#283)', async () => {
+    const v = await db.openVault('v2', { locale: 'th' })
+    const co = v.collection<Co>('co', {
+      i18nFields: { name: i18nText({ languages: ['th'], required: 'any', script: 'auto' }) },
+    })
+    await expect(
+      co.put('c1', { id: 'c1', name: { th: '9/9 อาคาร TCM ถนนรัชดาภิเษก' } }),
+    ).resolves.not.toThrow()
+  })
+
+  it("filter mode stores the stripped value", async () => {
+    const v = await db.openVault('v3', { locale: 'en' })
+    const co = v.collection<Co>('co', {
+      i18nFields: {
+        name: i18nText({ languages: ['en'], required: 'any', script: 'auto', onScriptViolation: 'filter' }),
+      },
+    })
+    await co.put('c1', { id: 'c1', name: { en: 'John สมชาย' } })
+    const got = await co.get('c1', { locale: 'raw' })
+    expect((got!.name as Record<string, string>).en.trim()).toBe('John')
+  })
+})

--- a/packages/hub/__tests__/i18n-script.test.ts
+++ b/packages/hub/__tests__/i18n-script.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Per-locale script enforcement (#283).
+ *
+ * - inferScripts: asymmetric Latin tolerance (non-Latin locales include Latin)
+ * - Common (digits/punct) + Inherited + Mark always in baseline
+ * - onScriptViolation: reject (default) / filter / warn
+ */
+import { describe, it, expect } from 'vitest'
+import { i18nText } from '../src/i18n/core.js'
+import { inferScripts, enforceScript } from '../src/i18n/script.js'
+import { ScriptViolationError } from '../src/errors.js'
+
+describe('inferScripts — asymmetric Latin (#283)', () => {
+  it('Latin locales stay Latin-only', () => {
+    expect(inferScripts('en')).toEqual(['Latin'])
+    expect(inferScripts('fr')).toEqual(['Latin'])
+  })
+  it('non-Latin locales include Latin', () => {
+    expect(inferScripts('th')).toEqual(['Thai', 'Latin'])
+    expect(inferScripts('ja')).toEqual(['Han', 'Hiragana', 'Katakana', 'Latin'])
+    expect(inferScripts('ko')).toEqual(['Hangul', 'Han', 'Latin'])
+    expect(inferScripts('ar')).toEqual(['Arabic', 'Latin'])
+    expect(inferScripts('ru')).toEqual(['Cyrillic', 'Latin'])
+  })
+  it('script subtag wins', () => {
+    expect(inferScripts('th-Latn')).toEqual(['Latin'])
+    expect(inferScripts('ja-Latn')).toEqual(['Latin'])
+  })
+})
+
+describe('enforceScript — reject (default)', () => {
+  const desc = i18nText({ languages: ['th', 'en'], required: 'any', script: 'auto' })
+
+  it('Thai address with embedded Latin passes (#283 driving case)', () => {
+    expect(() =>
+      enforceScript({ th: '9/9 อาคาร TCM ถนนรัชดาภิเษก' }, 'address', desc),
+    ).not.toThrow()
+  })
+  it('Latin digits pass in a Thai slot (Common)', () => {
+    expect(() => enforceScript({ th: 'สมชาย 2024' }, 'firstName', desc)).not.toThrow()
+  })
+  it('Thai tone marks pass (combining marks)', () => {
+    // น้ำ contains a Thai tone mark (combining) — must not false-reject
+    expect(() => enforceScript({ th: 'น้ำดื่ม' }, 'product', desc)).not.toThrow()
+  })
+  it('Thai text in the en slot is rejected (the real error)', () => {
+    expect(() => enforceScript({ en: 'สมชาย' }, 'firstName', desc)).toThrow(ScriptViolationError)
+  })
+  it('explicit tightening forbids embedded Latin in Thai', () => {
+    const strict = i18nText({ languages: ['th'], required: 'any', script: { th: ['Thai'] } })
+    expect(() => enforceScript({ th: 'อาคาร TCM' }, 'pureThai', strict)).toThrow(ScriptViolationError)
+  })
+  it('no script option ⇒ no check', () => {
+    const plain = i18nText({ languages: ['th', 'en'], required: 'any' })
+    expect(() => enforceScript({ en: 'สมชาย' }, 'firstName', plain)).not.toThrow()
+  })
+})
+
+describe('enforceScript — filter / warn', () => {
+  it("filter strips disallowed characters", () => {
+    const desc = i18nText({
+      languages: ['en'], required: 'any', script: 'auto', onScriptViolation: 'filter',
+    })
+    const { value, warnings } = enforceScript({ en: 'John สมชาย' }, 'name', desc)
+    expect(value.en.trim()).toBe('John')
+    expect(warnings).toHaveLength(1)
+  })
+  it("warn keeps the value and records a warning", () => {
+    const desc = i18nText({
+      languages: ['en'], required: 'any', script: 'auto', onScriptViolation: 'warn',
+    })
+    const { value, warnings } = enforceScript({ en: 'John สมชาย' }, 'name', desc)
+    expect(value.en).toBe('John สมชาย')
+    expect(warnings[0]?.locale).toBe('en')
+  })
+})

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -272,7 +272,8 @@
     "build": "tsup",
     "test": "vitest run",
     "lint": "eslint src/",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.typetest.json",
+    "typecheck:types": "tsc --noEmit -p tsconfig.typetest.json",
     "bundle-check": "node scripts/check-bundle.mjs"
   },
   "dependencies": {

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -6,8 +6,9 @@ import type { I18nTextDescriptor } from './i18n/core.js'
 import { getAtPath, setAtPathInPlace } from './i18n/core.js'
 import type { DictKeyDescriptor } from './i18n/dictionary.js'
 import { NO_I18N, type I18nStrategy } from './i18n/strategy.js'
+import { resolvePolicy } from './i18n/policy.js'
 import { encrypt, decrypt, encryptDeterministic } from './crypto.js'
-import { ConflictError, ReadOnlyError, TranslatorNotConfiguredError, TierDemoteDeniedError } from './errors.js'
+import { ConflictError, ReadOnlyError, TranslatorNotConfiguredError, TierDemoteDeniedError, LocaleNotSpecifiedError } from './errors.js'
 import { dekKey, assertTierAccess } from './team/tiers.js'
 import type { GhostRecord, TierMode, CrossTierAccessEvent } from './types.js'
 import type { UnlockedKeyring } from './team/keyring.js'
@@ -3051,17 +3052,67 @@ export class Collection<T> {
     // 2. dictKey label resolution
     if (hasDict && this.dictKeyFields && this.dictLabelResolver && locale !== 'raw') {
       const withLabels = { ...result }
+      const resolver = this.dictLabelResolver
       for (const [field, desc] of Object.entries(this.dictKeyFields)) {
-        const key = result[field]
-        if (typeof key !== 'string') continue
-        const label = await this.dictLabelResolver(
-          desc.name,
-          key,
-          locale,
-          localeOpts?.fallback,
-        )
-        if (label !== undefined) {
-          withLabels[`${field}Label`] = label
+        // dictKey default policy is 'null' (omit/null on miss) — today's
+        // behavior — unless the field declares onMissing. 'substitute'
+        // walks the declared substitute chain (passed as the resolver's
+        // fallback); 'throw' raises LocaleNotSpecifiedError.
+        const policy = desc.onMissing ? resolvePolicy(desc.onMissing, 'read') : 'null'
+        const fallback =
+          policy === 'substitute'
+            ? (localeOpts?.fallback ?? desc.substitute)
+            : localeOpts?.fallback
+        // Resolve one key → label | null, honoring the policy.
+        const resolveKey = async (key: string): Promise<string | null> => {
+          const label = await resolver(desc.name, key, locale, fallback)
+          if (label === undefined) {
+            if (policy === 'throw') {
+              throw new LocaleNotSpecifiedError(
+                field,
+                `dictKey "${field}": no label for key "${key}" in locale "${locale}".`,
+              )
+            }
+            return null
+          }
+          return label
+        }
+
+        if (field.includes('[].')) {
+          // Wildcard path `arrayKey[].leaf` (#282): add a per-element
+          // sibling `<leaf>Label`. Single level + simple leaf.
+          const parts = field.split('[].')
+          const arrayKey = parts[0]!
+          const leaf = parts[1]
+          if (!leaf || leaf.includes('.')) continue
+          const arr = (withLabels as Record<string, unknown>)[arrayKey]
+          if (!Array.isArray(arr)) continue
+          const labelKey = `${leaf}Label`
+          ;(withLabels as Record<string, unknown>)[arrayKey] = await Promise.all(
+            arr.map(async (el) => {
+              if (!el || typeof el !== 'object' || Array.isArray(el)) return el
+              const k = (el as Record<string, unknown>)[leaf]
+              if (typeof k !== 'string') return el
+              return { ...(el as Record<string, unknown>), [labelKey]: await resolveKey(k) }
+            }),
+          )
+          continue
+        }
+
+        const val = result[field]
+        if (Array.isArray(val)) {
+          // Array-of-keys → [{ key, label }] pair objects (key preserved).
+          withLabels[`${field}Label`] = await Promise.all(
+            val.map(async (k) => ({
+              key: k,
+              label: typeof k === 'string' ? await resolveKey(k) : null,
+            })),
+          )
+        } else if (typeof val === 'string') {
+          const label = await resolveKey(val)
+          // Scalar under 'null'/default omits the label key (today's
+          // behavior); 'substitute' returns a value; 'throw' threw above.
+          if (label !== null) withLabels[`${field}Label`] = label
         }
       }
       result = withLabels

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1200,6 +1200,29 @@ export class Collection<T> {
       }
     }
 
+    // i18nText script enforcement — runs AFTER auto-translate (so
+    // generated values are checked too). Throws ScriptViolationError
+    // under the default 'reject'; 'filter' strips disallowed chars in
+    // place (getAtPath returns live leaf references, so the write-back
+    // covers nested and array-wildcard paths uniformly); 'warn' leaves
+    // the value unchanged.
+    if (this.i18nFields) {
+      const obj = record as Record<string, unknown>
+      for (const [field, descriptor] of Object.entries(this.i18nFields)) {
+        if (!descriptor.options.script) continue
+        for (const leaf of getAtPath(obj, field)) {
+          if (!leaf || typeof leaf !== 'object' || Array.isArray(leaf)) continue
+          const leafMap = leaf as Record<string, unknown>
+          const { value: cleaned } = this.i18nStrategy.enforceScript(
+            leafMap,
+            field,
+            descriptor,
+          )
+          if (cleaned !== leafMap) Object.assign(leafMap, cleaned)
+        }
+      }
+    }
+
     // i18nText validation — runs AFTER schema validation so
     // the record shape is trustworthy. Throws MissingTranslationError
     // when required translations are absent.

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -1207,6 +1207,46 @@ export class LocaleNotSpecifiedError extends NoydbError {
   }
 }
 
+/**
+ * Thrown at write time when an `i18nText` slot's value contains
+ * characters outside the script set allowed for that locale, and the
+ * field's `onScriptViolation` policy is `'reject'` (the default).
+ *
+ * Distinct from {@link MissingTranslationError} (write-shape) and
+ * {@link LocaleNotSpecifiedError} (read-hole) so callers can tell a
+ * wrong-script value from a missing one.
+ */
+export class ScriptViolationError extends NoydbError {
+  /** The field whose value violated its script constraint. */
+  readonly field: string
+  /** The locale slot (e.g. `'en'`) that was checked. */
+  readonly locale: string
+  /** The Unicode scripts allowed for this slot. */
+  readonly expected: readonly string[]
+  /** A short sample of the offending characters, for diagnostics. */
+  readonly sample: string
+
+  constructor(
+    field: string,
+    locale: string,
+    expected: readonly string[],
+    sample: string,
+    message?: string,
+  ) {
+    super(
+      'SCRIPT_VIOLATION',
+      message ??
+        `Field "${field}" slot "${locale}" expects script(s) [${expected.join(', ')}] ` +
+        `but contains disallowed character(s): "${sample}".`,
+    )
+    this.name = 'ScriptViolationError'
+    this.field = field
+    this.locale = locale
+    this.expected = expected
+    this.sample = sample
+  }
+}
+
 // ─── Translator Errors ─────────────────────────────────────
 
 /**

--- a/packages/hub/src/i18n/active.ts
+++ b/packages/hub/src/i18n/active.ts
@@ -27,12 +27,14 @@
 
 import type { I18nStrategy, BuildDictionaryHandleOptions } from './strategy.js'
 import { applyI18nLocale, validateI18nTextValue } from './core.js'
+import { enforceScript } from './script.js'
 import { DictionaryHandle } from './dictionary.js'
 
 export function withI18n(): I18nStrategy {
   return {
     applyI18nLocale,
     validateI18nTextValue,
+    enforceScript,
     buildDictionaryHandle<Keys extends string = string>(
       opts: BuildDictionaryHandleOptions<Keys>,
     ): DictionaryHandle<Keys> {

--- a/packages/hub/src/i18n/core.ts
+++ b/packages/hub/src/i18n/core.ts
@@ -44,6 +44,47 @@ import { MissingTranslationError, LocaleNotSpecifiedError } from '../errors.js'
 import type { OnMissing, OnMissingPolicy, Layer } from './policy.js'
 import { resolvePolicy } from './policy.js'
 
+// ─── I18nMap type helper ───────────────────────────────────────────────
+
+/** Flatten an intersection into a single object literal for nicer hovers. */
+type Prettify<T> = { [K in keyof T]: T[K] } & {}
+
+/**
+ * The stored shape of a multilingual field, inferred from its `required`
+ * mode — so the compiler forces you to handle an absent optional locale
+ * (`string | undefined`) instead of silently yielding `undefined`.
+ *
+ * Mirrors `i18nText({ languages, required })`:
+ * - `'all'` (default) — every locale required: `{ th: string; en: string }`
+ * - `'any'`           — every locale optional: `{ th?: string; en?: string }`
+ *   (the "at least one present" guarantee is runtime-only — not expressible
+ *   in TypeScript — so each key is optional)
+ * - `readonly L[]`    — listed locales required, the rest optional:
+ *   `I18nMap<'th'|'en', ['th']>` → `{ th: string; en?: string }`
+ *
+ * @example
+ * ```ts
+ * type Lang = 'th' | 'en'
+ * interface Contact {
+ *   name: I18nMap<Lang, 'any'>      // { th?: string; en?: string }
+ *   legalName: I18nMap<Lang, ['th']> // { th: string; en?: string }
+ *   slug: I18nMap<Lang>             // { th: string; en: string }
+ * }
+ * ```
+ *
+ * @public
+ */
+export type I18nMap<
+  Langs extends string,
+  Required extends 'all' | 'any' | readonly Langs[] = 'all',
+> = Required extends 'all'
+  ? Record<Langs, string>
+  : Required extends 'any'
+    ? Partial<Record<Langs, string>>
+    : Required extends readonly (infer R extends Langs)[]
+      ? Prettify<Record<R, string> & Partial<Record<Exclude<Langs, R>, string>>>
+      : never
+
 // ─── i18nText descriptor ───────────────────────────────────────────────
 
 /**

--- a/packages/hub/src/i18n/core.ts
+++ b/packages/hub/src/i18n/core.ts
@@ -41,6 +41,7 @@
  */
 
 import { MissingTranslationError, LocaleNotSpecifiedError } from '../errors.js'
+import type { OnMissing, OnMissingPolicy } from './policy.js'
 
 // ─── i18nText descriptor ───────────────────────────────────────────────
 
@@ -72,6 +73,31 @@ export interface I18nTextOptions {
    * before `put()` if a translator is configured. Default: `false`.
    */
   readonly autoTranslate?: boolean
+  /**
+   * What to do when this field is resolved to a locale that is absent.
+   * A single policy, or a per-layer map (read/guard/join/mv/derivation/
+   * export). Default `'throw'` — today's behavior, zero breaking change.
+   * See {@link OnMissingPolicy}.
+   */
+  readonly onMissing?: OnMissingPolicy
+  /**
+   * Ordered preferred-substitute locales used when `onMissing` resolves
+   * to `'substitute'` and the target locale is absent. `'any'` as an
+   * element means "first non-empty value". A caller-supplied `fallback`
+   * at read time takes precedence over this declared list.
+   */
+  readonly substitute?: readonly string[]
+  /**
+   * Per-locale script enforcement (write-time). `'auto'` infers the
+   * allowed Unicode scripts per locale (asymmetric Latin tolerance); an
+   * object overrides per slot. Absent ⇒ no check. See `./script.ts`.
+   */
+  readonly script?: 'auto' | Partial<Record<string, readonly string[]>>
+  /**
+   * What to do when a slot's value contains characters outside its
+   * allowed script set. Default `'reject'`.
+   */
+  readonly onScriptViolation?: 'reject' | 'filter' | 'warn'
 }
 
 /**
@@ -210,12 +236,58 @@ export function validateI18nTextValue(
  * @param field    Field name used in `LocaleNotSpecifiedError` messages.
  * @returns The resolved string, OR the original map when `locale === 'raw'`.
  */
+/** Options for the policy-aware form of {@link resolveI18nText}. */
+export interface ResolveI18nOptions {
+  /** Effective policy for the resolution layer. Default `'throw'`. */
+  readonly policy?: OnMissing
+  /** Declared substitute chain; applied only under policy `'substitute'`. */
+  readonly substitute?: readonly string[]
+}
+
+/** Normalize a single-or-list fallback into an array. */
+function toChain(fallback: string | readonly string[] | undefined): readonly string[] {
+  return Array.isArray(fallback) ? fallback : fallback ? [fallback as string] : []
+}
+
+/** Walk a chain, returning the first non-empty value (or `'any'` match). */
+function pickFromChain(
+  value: Record<string, string>,
+  chain: readonly string[],
+): string | undefined {
+  for (const fb of chain) {
+    if (fb === 'any') {
+      const any = Object.values(value).find((v) => v !== '')
+      if (any !== undefined) return any
+    } else if (value[fb] !== undefined && value[fb] !== '') {
+      return value[fb]
+    }
+  }
+  return undefined
+}
+
+// Legacy 4-arg form: can only throw or return — never null. Keeps every
+// existing call site's type unchanged (default policy is 'throw').
 export function resolveI18nText(
   value: Record<string, string>,
   locale: string,
   fallback?: string | readonly string[],
   field?: string,
-): string | Record<string, string> {
+): string | Record<string, string>
+// Policy-aware form: may return null under 'null'/'substitute' policies.
+export function resolveI18nText(
+  value: Record<string, string>,
+  locale: string,
+  fallback: string | readonly string[] | undefined,
+  field: string | undefined,
+  opts: ResolveI18nOptions,
+): string | Record<string, string> | null
+export function resolveI18nText(
+  value: Record<string, string>,
+  locale: string,
+  fallback?: string | readonly string[],
+  field?: string,
+  opts?: ResolveI18nOptions,
+): string | Record<string, string> | null {
   if (locale === 'raw') {
     return value
   }
@@ -229,28 +301,30 @@ export function resolveI18nText(
     return value[locale]
   }
 
-  // Fallback chain
-  const chain: readonly string[] = Array.isArray(fallback)
-    ? fallback
-    : fallback
-      ? [fallback]
-      : []
+  const policy: OnMissing = opts?.policy ?? 'throw'
 
-  for (const fb of chain) {
-    if (fb === 'any') {
-      const any = Object.values(value).find((v) => v !== '')
-      if (any !== undefined) return any
-    } else if (value[fb] !== undefined && value[fb] !== '') {
-      return value[fb]
-    }
+  // Caller-supplied fallback ALWAYS applies first (backward compat +
+  // explicit read-time override), regardless of policy.
+  const callerChain = toChain(fallback)
+  const callerHit = pickFromChain(value, callerChain)
+  if (callerHit !== undefined) return callerHit
+
+  // Declared substitute applies ONLY under policy 'substitute'.
+  if (policy === 'substitute') {
+    const subHit = pickFromChain(value, toChain(opts?.substitute))
+    if (subHit !== undefined) return subHit
   }
 
-  throw new LocaleNotSpecifiedError(
-    field ?? '<unknown>',
-    `No translation available for locale "${locale}"` +
-      (chain.length > 0 ? ` or fallback chain [${chain.join(', ')}]` : '') +
-      '.',
-  )
+  // Exhausted.
+  if (policy === 'throw') {
+    throw new LocaleNotSpecifiedError(
+      field ?? '<unknown>',
+      `No translation available for locale "${locale}"` +
+        (callerChain.length > 0 ? ` or fallback chain [${callerChain.join(', ')}]` : '') +
+        '.',
+    )
+  }
+  return null
 }
 
 // ─── Path helpers (nested i18nFields like 'address.lineOne') ──────────

--- a/packages/hub/src/i18n/core.ts
+++ b/packages/hub/src/i18n/core.ts
@@ -41,7 +41,8 @@
  */
 
 import { MissingTranslationError, LocaleNotSpecifiedError } from '../errors.js'
-import type { OnMissing, OnMissingPolicy } from './policy.js'
+import type { OnMissing, OnMissingPolicy, Layer } from './policy.js'
+import { resolvePolicy } from './policy.js'
 
 // ─── i18nText descriptor ───────────────────────────────────────────────
 
@@ -391,6 +392,7 @@ function applyAtPath(
   path: string,
   locale: string,
   fallback: string | readonly string[] | undefined,
+  opts: ResolveI18nOptions,
 ): Record<string, unknown> {
   const arrayIdx = path.indexOf('[].')
   if (arrayIdx !== -1) {
@@ -402,7 +404,7 @@ function applyAtPath(
       ...obj,
       [arrayKey]: arr.map(item => {
         if (!item || typeof item !== 'object' || Array.isArray(item)) return item
-        return applyAtPath(item as Record<string, unknown>, restPath, locale, fallback)
+        return applyAtPath(item as Record<string, unknown>, restPath, locale, fallback, opts)
       }),
     }
   }
@@ -414,7 +416,7 @@ function applyAtPath(
     if (!nested || typeof nested !== 'object' || Array.isArray(nested)) return obj
     return {
       ...obj,
-      [head]: applyAtPath(nested as Record<string, unknown>, rest, locale, fallback),
+      [head]: applyAtPath(nested as Record<string, unknown>, rest, locale, fallback, opts),
     }
   }
   const raw = obj[path]
@@ -422,7 +424,7 @@ function applyAtPath(
   if (typeof raw !== 'object' || Array.isArray(raw)) return obj
   return {
     ...obj,
-    [path]: resolveI18nText(raw as Record<string, string>, locale, fallback, path),
+    [path]: resolveI18nText(raw as Record<string, string>, locale, fallback, path, opts),
   }
 }
 
@@ -440,20 +442,30 @@ function applyAtPath(
  * @param i18nFields  Map of field path → `I18nTextDescriptor`.
  * @param locale      The requested locale (or `'raw'`).
  * @param fallback    Fallback chain (optional).
+ * @param layer       Resolution layer (default `'read'`). Each field's
+ *                    `onMissing` policy is resolved for this layer, so the
+ *                    same record resolves leniently on a get but strictly
+ *                    inside an mv/derivation.
  */
 export function applyI18nLocale(
   record: Record<string, unknown>,
   i18nFields: Record<string, I18nTextDescriptor>,
   locale: string,
   fallback?: string | readonly string[],
+  layer: Layer = 'read',
 ): Record<string, unknown> {
   const fieldNames = Object.keys(i18nFields)
   if (fieldNames.length === 0) return record
 
   let result = record
 
-  for (const field of fieldNames) {
-    result = applyAtPath(result, field, locale, fallback)
+  for (const [field, descriptor] of Object.entries(i18nFields)) {
+    const { onMissing, substitute } = descriptor.options
+    const opts: ResolveI18nOptions = {
+      policy: resolvePolicy(onMissing, layer),
+      ...(substitute !== undefined ? { substitute } : {}),
+    }
+    result = applyAtPath(result, field, locale, fallback, opts)
   }
 
   return result

--- a/packages/hub/src/i18n/core.ts
+++ b/packages/hub/src/i18n/core.ts
@@ -79,6 +79,13 @@ export interface I18nTextOptions {
    * A single policy, or a per-layer map (read/guard/join/mv/derivation/
    * export). Default `'throw'` — today's behavior, zero breaking change.
    * See {@link OnMissingPolicy}.
+   *
+   * NOTE (current wiring): the `read` layer (`get`/`list`) is enforced.
+   * Guard, derivation, mv, join and export reads currently resolve
+   * through the same read path and so observe the `read`/scalar policy;
+   * dedicated per-layer enforcement for those contexts is a tracked
+   * follow-up (mv/join additionally require resolution to be injected
+   * into the query/aggregate pipeline, which today reads raw maps).
    */
   readonly onMissing?: OnMissingPolicy
   /**

--- a/packages/hub/src/i18n/dictionary.ts
+++ b/packages/hub/src/i18n/dictionary.ts
@@ -38,6 +38,7 @@ import type { UnlockedKeyring } from '../team/keyring.js'
 import { encrypt, decrypt } from '../crypto.js'
 import { ensureCollectionDEK } from '../team/keyring.js'
 import type { LedgerStore } from '../history/ledger/store.js'
+import type { OnMissingPolicy } from './policy.js'
 import { envelopePayloadHash } from '../history/ledger/hash.js'
 import {
   PermissionDeniedError,
@@ -81,6 +82,16 @@ export interface DictKeyDescriptor<Keys extends string = string> {
   readonly name: string
   /** Declared valid keys. When set, `put()` rejects keys not in this set. */
   readonly keys: readonly Keys[] | undefined
+  /**
+   * What to do when a label is missing for the resolved locale. Mirrors
+   * `i18nText`'s `onMissing`. Default behavior (when unset) preserves the
+   * legacy contract: a missing label is omitted (scalar) or `null`
+   * (array element) — i.e. `'null'`. Set `'substitute'` to walk the
+   * declared `substitute` chain, or `'throw'` to raise.
+   */
+  readonly onMissing?: OnMissingPolicy
+  /** Ordered preferred-substitute locales for label resolution. */
+  readonly substitute?: readonly string[]
 }
 
 /**
@@ -103,8 +114,15 @@ export interface DictKeyDescriptor<Keys extends string = string> {
 export function dictKey<Keys extends string>(
   name: string,
   keys?: readonly Keys[],
+  opts?: { onMissing?: OnMissingPolicy; substitute?: readonly string[] },
 ): DictKeyDescriptor<Keys> {
-  return { _noydbDictKey: true, name, keys }
+  return {
+    _noydbDictKey: true,
+    name,
+    keys,
+    ...(opts?.onMissing !== undefined ? { onMissing: opts.onMissing } : {}),
+    ...(opts?.substitute !== undefined ? { substitute: opts.substitute } : {}),
+  }
 }
 
 /** Runtime predicate for detecting a DictKeyDescriptor. */

--- a/packages/hub/src/i18n/index.ts
+++ b/packages/hub/src/i18n/index.ts
@@ -14,6 +14,12 @@
 export * from './core.js'
 export * from './dictionary.js'
 
+// ─── Resolution policy + script enforcement ────────────
+export { resolvePolicy } from './policy.js'
+export type { OnMissing, Layer, OnMissingPolicy } from './policy.js'
+export { inferScripts, enforceScript } from './script.js'
+export type { ScriptWarning } from './script.js'
+
 // ─── Strategy seam ─────────────────────────────────────
 export { withI18n } from './active.js'
 export type { I18nStrategy } from './strategy.js'
@@ -29,4 +35,5 @@ export {
   MissingTranslationError,
   LocaleNotSpecifiedError,
   TranslatorNotConfiguredError,
+  ScriptViolationError,
 } from '../errors.js'

--- a/packages/hub/src/i18n/policy.ts
+++ b/packages/hub/src/i18n/policy.ts
@@ -1,0 +1,57 @@
+/**
+ * Per-layer i18n resolution policy.
+ *
+ * `onMissing` governs what happens when a multilingual field is resolved
+ * to a target locale that is absent. It may be a single scalar policy or
+ * a per-layer map, so a field can be lenient at the app read boundary but
+ * strict inside a materialized view.
+ *
+ * Effective policy for layer `λ`:
+ *
+ * ```
+ * explicit(λ) = typeof onMissing === 'object' ? onMissing[λ] : undefined
+ * scalar      = typeof onMissing === 'string' ? onMissing : undefined
+ * policy(λ)   = explicit(λ) ?? layerDefault(λ) ?? scalar ?? 'throw'
+ * ```
+ *
+ * - `layerDefault('guard') = 'substitute'` — guards are lenient unless
+ *   EXPLICITLY overridden; they never inherit a scalar policy (a guard
+ *   reading a display value must not hard-fail on a missing locale).
+ * - every other layer has no default, so it inherits the scalar, else
+ *   falls back to `'throw'` (today's behavior — zero breaking change).
+ *
+ * @public
+ */
+export type OnMissing = 'substitute' | 'null' | 'throw'
+
+/**
+ * The contexts in which a multilingual field is resolved. Each can carry
+ * its own `onMissing` policy.
+ *
+ * - `read`       — ordinary app reads (`get`/`list`/query projection).
+ * - `guard`      — a guard callback reading a value.
+ * - `join`       — a joined record expanded onto a row.
+ * - `mv`         — materialized-view input.
+ * - `derivation` — derivation input.
+ * - `export`     — bundle/public-envelope export.
+ */
+export type Layer = 'read' | 'guard' | 'join' | 'mv' | 'derivation' | 'export'
+
+/** Field-level policy: a single scalar, or a per-layer map. */
+export type OnMissingPolicy = OnMissing | Partial<Record<Layer, OnMissing>>
+
+/**
+ * Resolve the effective `OnMissing` for a layer from a field's declared
+ * policy. See module docs for the resolution rule.
+ */
+export function resolvePolicy(
+  onMissing: OnMissingPolicy | undefined,
+  layer: Layer,
+): OnMissing {
+  const explicit =
+    onMissing && typeof onMissing === 'object' ? onMissing[layer] : undefined
+  const scalar = typeof onMissing === 'string' ? onMissing : undefined
+  const layerDefault: OnMissing | undefined =
+    layer === 'guard' ? 'substitute' : undefined
+  return explicit ?? layerDefault ?? scalar ?? 'throw'
+}

--- a/packages/hub/src/i18n/script.ts
+++ b/packages/hub/src/i18n/script.ts
@@ -1,0 +1,167 @@
+/**
+ * Per-locale script enforcement for `i18nText` fields (write-time).
+ *
+ * Each locale slot's string is validated against an allowed set of
+ * Unicode scripts. `'auto'` infers the set from the locale code with
+ * **asymmetric Latin tolerance** (#283): every non-Latin-script locale
+ * also allows `Latin`, because proper names and addresses in those
+ * locales routinely embed Latin brand/building/technical names — while
+ * Latin-script locales do NOT allow other scripts, so the common error
+ * (e.g. Thai text dumped into an `en` slot) is still caught.
+ *
+ * The always-on baseline is `Common` (digits, punctuation), `Inherited`
+ * and `Mark` (combining diacritics, joiners, harakat, tone marks), and
+ * whitespace — so Latin digits and in-script combining marks never
+ * false-reject.
+ *
+ * @public
+ */
+import { ScriptViolationError } from '../errors.js'
+import type { I18nTextDescriptor } from './core.js'
+
+/** Locales whose base language is written in the Latin script. */
+const LATIN_BASE = new Set([
+  'en', 'fr', 'de', 'es', 'it', 'pt', 'nl', 'sv', 'no', 'da', 'fi', 'is',
+  'pl', 'cs', 'sk', 'hu', 'ro', 'hr', 'sl', 'et', 'lv', 'lt', 'tr', 'vi',
+  'id', 'ms', 'tl', 'sw', 'af', 'ca', 'gl', 'eu', 'cy', 'ga',
+])
+
+/** Base-language → primary (non-Latin) scripts. Latin is appended by inferScripts. */
+const SCRIPT_TABLE: Record<string, readonly string[]> = {
+  th: ['Thai'],
+  ko: ['Hangul', 'Han'],
+  ja: ['Han', 'Hiragana', 'Katakana'],
+  zh: ['Han'],
+  ar: ['Arabic'],
+  fa: ['Arabic'],
+  ur: ['Arabic'],
+  ru: ['Cyrillic'],
+  uk: ['Cyrillic'],
+  bg: ['Cyrillic'],
+  sr: ['Cyrillic'],
+  he: ['Hebrew'],
+  el: ['Greek'],
+  hi: ['Devanagari'],
+  ta: ['Tamil'],
+  km: ['Khmer'],
+  lo: ['Lao'],
+  my: ['Myanmar'],
+}
+
+/** Map a BCP-47 script subtag (e.g. `Latn`, `Cyrl`) to allowed scripts. */
+const SUBTAG_SCRIPTS: Record<string, readonly string[]> = {
+  Latn: ['Latin'],
+  Cyrl: ['Cyrillic', 'Latin'],
+  Hans: ['Han', 'Latin'],
+  Hant: ['Han', 'Latin'],
+  Thai: ['Thai', 'Latin'],
+  Arab: ['Arabic', 'Latin'],
+}
+
+/**
+ * Infer the allowed Unicode scripts for a BCP-47 locale, with asymmetric
+ * Latin tolerance. A script subtag (`th-Latn`) wins over the base
+ * language. Unknown locales default to `['Latin']`.
+ */
+export function inferScripts(locale: string): readonly string[] {
+  const parts = locale.split('-')
+  const subtag = parts.find((t) => /^[A-Z][a-z]{3}$/.test(t))
+  if (subtag && SUBTAG_SCRIPTS[subtag]) return SUBTAG_SCRIPTS[subtag]
+
+  const base = (parts[0] ?? '').toLowerCase()
+  if (LATIN_BASE.has(base)) return ['Latin']
+  const primary = SCRIPT_TABLE[base]
+  if (primary) return [...primary, 'Latin'] // asymmetric Latin tolerance (#283)
+  return ['Latin']
+}
+
+/** Resolve the allowed scripts for a field's locale slot. */
+function allowedFor(descriptor: I18nTextDescriptor, locale: string): readonly string[] {
+  const script = descriptor.options.script
+  if (script && script !== 'auto') {
+    const explicit = script[locale]
+    if (explicit) return explicit
+  }
+  return inferScripts(locale)
+}
+
+/** Always-allowed baseline character classes (besides the named scripts). */
+const BASELINE = String.raw`\p{White_Space}\p{Script=Common}\p{Script=Inherited}\p{Mark}`
+
+/** Build a whole-string matcher for the allowed scripts. */
+function fullMatcher(scripts: readonly string[]): RegExp {
+  const cls = scripts.map((s) => `\\p{Script=${s}}`).join('')
+  return new RegExp(`^[${BASELINE}${cls}]*$`, 'u')
+}
+
+/** Build a single-character matcher (for sampling / stripping). */
+function charMatcher(scripts: readonly string[]): RegExp {
+  const cls = scripts.map((s) => `\\p{Script=${s}}`).join('')
+  return new RegExp(`[${BASELINE}${cls}]`, 'u')
+}
+
+/** Collect a short sample of characters that violate the allowed scripts. */
+function offendingSample(str: string, scripts: readonly string[]): string {
+  const ok = charMatcher(scripts)
+  const bad: string[] = []
+  for (const ch of str) {
+    if (!ok.test(ch)) bad.push(ch)
+    if (bad.length >= 8) break
+  }
+  return bad.join('')
+}
+
+/** Remove characters that violate the allowed scripts. */
+function stripDisallowed(str: string, scripts: readonly string[]): string {
+  const ok = charMatcher(scripts)
+  let out = ''
+  for (const ch of str) if (ok.test(ch)) out += ch
+  return out
+}
+
+/** A non-fatal script violation recorded under `'filter'`/`'warn'` modes. */
+export interface ScriptWarning {
+  readonly field: string
+  readonly locale: string
+  readonly expected: readonly string[]
+  readonly sample: string
+}
+
+/**
+ * Enforce a field's script constraint over an i18nText value map.
+ *
+ * - No `script` option ⇒ returns the value unchanged.
+ * - `onScriptViolation: 'reject'` (default) ⇒ throws {@link ScriptViolationError}.
+ * - `'filter'` ⇒ returns a copy with disallowed characters stripped + warnings.
+ * - `'warn'` ⇒ returns the value unchanged + warnings.
+ */
+export function enforceScript(
+  value: Record<string, unknown>,
+  field: string,
+  descriptor: I18nTextDescriptor,
+): { value: Record<string, unknown>; warnings: ScriptWarning[] } {
+  const opt = descriptor.options
+  if (!opt.script) return { value, warnings: [] }
+
+  const mode = opt.onScriptViolation ?? 'reject'
+  const warnings: ScriptWarning[] = []
+  let out = value
+
+  for (const [locale, raw] of Object.entries(value)) {
+    if (typeof raw !== 'string') continue
+    const allowed = allowedFor(descriptor, locale)
+    if (fullMatcher(allowed).test(raw)) continue
+
+    const sample = offendingSample(raw, allowed)
+    if (mode === 'reject') {
+      throw new ScriptViolationError(field, locale, allowed, sample)
+    }
+    warnings.push({ field, locale, expected: allowed, sample })
+    if (mode === 'filter') {
+      if (out === value) out = { ...value }
+      out[locale] = stripDisallowed(raw, allowed)
+    }
+  }
+
+  return { value: out, warnings }
+}

--- a/packages/hub/src/i18n/strategy.ts
+++ b/packages/hub/src/i18n/strategy.ts
@@ -31,6 +31,7 @@ import type { LedgerStore } from '../history/ledger/store.js'
 import type { UnlockedKeyring } from '../team/keyring.js'
 import type { NoydbEventEmitter } from '../events.js'
 import type { I18nTextDescriptor } from './core.js'
+import type { Layer } from './policy.js'
 import type { DictionaryHandle, DictionaryOptions } from './dictionary.js'
 
 /**
@@ -79,6 +80,7 @@ export interface I18nStrategy {
     fields: Record<string, I18nTextDescriptor>,
     locale: string,
     fallback?: string | readonly string[],
+    layer?: Layer,
   ): Record<string, unknown>
 
   /**

--- a/packages/hub/src/i18n/strategy.ts
+++ b/packages/hub/src/i18n/strategy.ts
@@ -32,6 +32,7 @@ import type { UnlockedKeyring } from '../team/keyring.js'
 import type { NoydbEventEmitter } from '../events.js'
 import type { I18nTextDescriptor } from './core.js'
 import type { Layer } from './policy.js'
+import type { ScriptWarning } from './script.js'
 import type { DictionaryHandle, DictionaryOptions } from './dictionary.js'
 
 /**
@@ -95,6 +96,18 @@ export interface I18nStrategy {
   ): void
 
   /**
+   * Enforce per-locale script constraints over an i18nText value map
+   * (write-time). Returns the (possibly filtered) value plus any
+   * non-fatal warnings. Returns the value unchanged when the field has
+   * no `script` option, or under `NO_I18N`.
+   */
+  enforceScript(
+    value: Record<string, unknown>,
+    field: string,
+    descriptor: I18nTextDescriptor,
+  ): { value: Record<string, unknown>; warnings: ScriptWarning[] }
+
+  /**
    * Construct a typed `DictionaryHandle` for the named dictionary.
    * Throws under `NO_I18N`.
    */
@@ -120,5 +133,6 @@ function notEnabled(op: string): Error {
 export const NO_I18N: I18nStrategy = {
   applyI18nLocale(record) { return record },
   validateI18nTextValue() { throw notEnabled('i18nText field validation') },
+  enforceScript(value) { return { value, warnings: [] } },
   buildDictionaryHandle() { throw notEnabled('vault.dictionary()') },
 }

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -688,7 +688,13 @@ export {
   resolveI18nText,
   applyI18nLocale,
 } from './i18n/core.js'
-export type { I18nTextOptions, I18nTextDescriptor } from './i18n/core.js'
+export type { I18nTextOptions, I18nTextDescriptor, ResolveI18nOptions } from './i18n/core.js'
+
+// i18n — resolution policy + script enforcement
+export { resolvePolicy } from './i18n/policy.js'
+export type { OnMissing, Layer, OnMissingPolicy } from './i18n/policy.js'
+export { inferScripts, enforceScript } from './i18n/script.js'
+export type { ScriptWarning } from './i18n/script.js'
 
 // i18n errors
 export {
@@ -698,6 +704,7 @@ export {
   MissingTranslationError,
   LocaleNotSpecifiedError,
   TranslatorNotConfiguredError,
+  ScriptViolationError,
 } from './errors.js'
 
 // Locale read options + translator audit log

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -688,7 +688,7 @@ export {
   resolveI18nText,
   applyI18nLocale,
 } from './i18n/core.js'
-export type { I18nTextOptions, I18nTextDescriptor, ResolveI18nOptions } from './i18n/core.js'
+export type { I18nTextOptions, I18nTextDescriptor, ResolveI18nOptions, I18nMap } from './i18n/core.js'
 
 // i18n — resolution policy + script enforcement
 export { resolvePolicy } from './i18n/policy.js'

--- a/packages/hub/tsconfig.typetest.json
+++ b/packages/hub/tsconfig.typetest.json
@@ -1,0 +1,6 @@
+{
+  "//": "Type-level tests (*.test-d.ts), validated by `pnpm typecheck`. rootDir is '.' so __tests__ can sit alongside src without a rootDir violation.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "rootDir": ".", "noEmit": true, "types": ["node"] },
+  "include": ["src", "__tests__/**/*.test-d.ts"]
+}

--- a/packages/in-pinia/__tests__/defineNoydbStore.test.ts
+++ b/packages/in-pinia/__tests__/defineNoydbStore.test.ts
@@ -3,7 +3,9 @@ import { setActivePinia, createPinia, storeToRefs } from 'pinia'
 import { effectScope } from 'vue'
 import { createNoydb, additiveOnly, i18nText, type Noydb, type NoydbStore, type EncryptedEnvelope, type VaultSnapshot, type StandardSchemaV1, ConflictError, Query } from '@noy-db/hub'
 import { withI18n } from '@noy-db/hub/i18n'
-import { defineNoydbStore, setActiveNoydb } from '../src/index.js'
+import { defineNoydbStore, setActiveNoydb, useNoydbI18n } from '../src/index.js'
+
+const tick = (ms = 0): Promise<void> => new Promise((r) => setTimeout(r, ms))
 
 /** Inline memory adapter — same pattern as @noy-db/core integration tests. */
 function memory(): NoydbStore {
@@ -533,5 +535,50 @@ describe('defineNoydbStore — i18nFields / dictKeyFields forwarding', () => {
     const col = vault.collection<Product>('products-i18n-read')
     const row = await col.get('p1', { locale: 'th' }) as { id: string; name: string }
     expect(row.name).toBe('วิดเจ็ต')
+  })
+
+  it("default i18n mode ('raw') keeps the {th,en} map (non-breaking)", async () => {
+    type P = { id: string; name: Record<string, string> | string }
+    const useP = defineNoydbStore<P>('p-raw', {
+      vault: 'rawv',
+      i18nFields: { name: i18nText({ languages: ['th', 'en'], required: 'any' }) },
+    })
+    const store = useP()
+    await store.$ready
+    await store.add('p1', { id: 'p1', name: { th: 'สมชาย', en: 'Somchai' } })
+    expect(store.items.find((x) => x.id === 'p1')?.name).toEqual({ th: 'สมชาย', en: 'Somchai' })
+  })
+
+  it("i18n:'follow' resolves to the global locale and re-reads on flip", async () => {
+    const i18n = useNoydbI18n()
+    i18n.setLocale('en')
+    type P = { id: string; name: Record<string, string> | string }
+    const useP = defineNoydbStore<P>('p-follow', {
+      vault: 'followv',
+      i18n: 'follow',
+      i18nFields: { name: i18nText({ languages: ['th', 'en'], required: 'any' }) },
+    })
+    const store = useP()
+    await store.$ready
+    await store.add('p1', { id: 'p1', name: { th: 'สมชาย', en: 'Somchai' } })
+    expect(store.items.find((x) => x.id === 'p1')?.name).toBe('Somchai')
+    i18n.setLocale('th')
+    for (let n = 0; n < 50 && store.items.find((x) => x.id === 'p1')?.name !== 'สมชาย'; n++) await tick(10)
+    expect(store.items.find((x) => x.id === 'p1')?.name).toBe('สมชาย')
+  })
+
+  it("i18n:{locale:'th'} pins regardless of the global locale", async () => {
+    const i18n = useNoydbI18n()
+    i18n.setLocale('en')
+    type P = { id: string; name: Record<string, string> | string }
+    const useP = defineNoydbStore<P>('p-pin', {
+      vault: 'pinv',
+      i18n: { locale: 'th' },
+      i18nFields: { name: i18nText({ languages: ['th', 'en'], required: 'any' }) },
+    })
+    const store = useP()
+    await store.$ready
+    await store.add('p1', { id: 'p1', name: { th: 'สมชาย', en: 'Somchai' } })
+    expect(store.items.find((x) => x.id === 'p1')?.name).toBe('สมชาย')
   })
 })

--- a/packages/in-pinia/__tests__/useDictLabel.test.ts
+++ b/packages/in-pinia/__tests__/useDictLabel.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { ref } from 'vue'
+import { setActivePinia, createPinia } from 'pinia'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '@noy-db/hub'
 import { ConflictError, createNoydb } from '@noy-db/hub'
 import { withI18n } from '@noy-db/hub/i18n'
 import type { Noydb, Vault } from '@noy-db/hub'
 import { setActiveNoydb } from '../src/context.js'
 import { useDictLabel } from '../src/useDictLabel.js'
+import { useNoydbI18n } from '../src/useNoydbI18n.js'
 
 function memory(): NoydbStore {
   const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
@@ -150,5 +152,18 @@ describe('useDictLabel', () => {
     const draft = label('draft')
     for (let i = 0; i < 50 && draft.value !== 'Draft'; i++) await tick(10)
     expect(draft.value).toBe('Draft')
+  })
+
+  it('defaults its locale to the shared useNoydbI18n and follows a global flip', async () => {
+    setActivePinia(createPinia())
+    const i18n = useNoydbI18n()
+    const { vault } = await setup()
+    const label = useDictLabel('invoiceStatus', { vault }) // no locale → follows global
+    const paid = label('paid')
+    for (let n = 0; n < 50 && paid.value !== 'Paid'; n++) await tick(10)
+    expect(paid.value).toBe('Paid') // global default 'en'
+    i18n.setLocale('th')
+    for (let n = 0; n < 50 && paid.value !== 'ชำระแล้ว'; n++) await tick(10)
+    expect(paid.value).toBe('ชำระแล้ว') // recomputed on global flip
   })
 })

--- a/packages/in-pinia/__tests__/useI18nField.test.ts
+++ b/packages/in-pinia/__tests__/useI18nField.test.ts
@@ -1,0 +1,48 @@
+/**
+ * useI18nField — reactive pickLang over an i18nText map.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { ref } from 'vue'
+import { useNoydbI18n } from '../src/useNoydbI18n.js'
+import { useI18nField } from '../src/useI18nField.js'
+
+beforeEach(() => setActivePinia(createPinia()))
+
+describe('useI18nField', () => {
+  it('resolves to the global locale and recomputes on flip', () => {
+    const i = useNoydbI18n()
+    const name = useI18nField({ th: 'สมชาย', en: 'Somchai' })
+    expect(name.value).toBe('Somchai') // default en
+    i.setLocale('th')
+    expect(name.value).toBe('สมชาย')
+  })
+
+  it('uses the default fallback chain (en,any) to fill a missing locale', () => {
+    useNoydbI18n() // en active
+    const name = useI18nField({ th: 'สมชาย' }) // no en → fallback en,any → th
+    expect(name.value).toBe('สมชาย')
+  })
+
+  it('returns null when the map is empty (policy null, never throws)', () => {
+    useNoydbI18n()
+    const name = useI18nField({})
+    expect(name.value).toBeNull()
+  })
+
+  it('per-call locale override ignores the global locale', () => {
+    const i = useNoydbI18n()
+    i.setLocale('en')
+    const th = useI18nField({ th: 'สมชาย', en: 'Somchai' }, { locale: 'th' })
+    expect(th.value).toBe('สมชาย')
+  })
+
+  it('reactive getter source recomputes', () => {
+    useNoydbI18n()
+    const src = ref<Record<string, string>>({ en: 'A' })
+    const v = useI18nField(() => src.value)
+    expect(v.value).toBe('A')
+    src.value = { en: 'B' }
+    expect(v.value).toBe('B')
+  })
+})

--- a/packages/in-pinia/__tests__/useNoydbI18n.test.ts
+++ b/packages/in-pinia/__tests__/useNoydbI18n.test.ts
@@ -1,0 +1,54 @@
+/**
+ * useNoydbI18n — reactive active-locale store.
+ *
+ * State-only by default; vault.setLocale only on explicit opt-in;
+ * bindTo follows an external ref one-way and never touches a vault.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { ref } from 'vue'
+import { useNoydbI18n } from '../src/useNoydbI18n.js'
+
+beforeEach(() => setActivePinia(createPinia()))
+
+describe('useNoydbI18n', () => {
+  it('defaults to en + [en, any]', () => {
+    const i = useNoydbI18n()
+    expect(i.locale).toBe('en')
+    expect(i.fallback).toEqual(['en', 'any'])
+  })
+
+  it('setLocale updates state (state-only, no vault touched)', () => {
+    const i = useNoydbI18n()
+    i.setLocale('th')
+    expect(i.locale).toBe('th')
+  })
+
+  it('setFallback updates the chain', () => {
+    const i = useNoydbI18n()
+    i.setFallback(['th', 'any'])
+    expect(i.fallback).toEqual(['th', 'any'])
+  })
+
+  it('setLocale with syncVault calls vault.setLocale on the given vault(s)', () => {
+    const i = useNoydbI18n()
+    const v1 = { setLocale: vi.fn() }
+    const v2 = { setLocale: vi.fn() }
+    i.setLocale('th', { syncVault: [v1, v2] })
+    expect(v1.setLocale).toHaveBeenCalledWith('th')
+    expect(v2.setLocale).toHaveBeenCalledWith('th')
+    expect(i.locale).toBe('th')
+  })
+
+  it('bindTo mirrors an external ref one-way and never syncs a vault', () => {
+    const i = useNoydbI18n()
+    const ext = ref('ja')
+    const stop = i.bindTo(ext) // immediate by default
+    expect(i.locale).toBe('ja')
+    ext.value = 'th'
+    expect(i.locale).toBe('th')
+    stop()
+    ext.value = 'en'
+    expect(i.locale).toBe('th') // stopped — no longer follows
+  })
+})

--- a/packages/in-pinia/src/defineNoydbStore.ts
+++ b/packages/in-pinia/src/defineNoydbStore.ts
@@ -21,8 +21,10 @@ import {
   computed,
   getCurrentScope,
   onScopeDispose,
+  isRef,
   ref,
   shallowRef,
+  watch,
   type Ref,
   type ShallowRef,
   type ComputedRef,
@@ -37,6 +39,18 @@ import type {
   DictKeyDescriptor,
 } from '@noy-db/hub'
 import { resolveNoydb } from './context.js'
+import { useNoydbI18n } from './useNoydbI18n.js'
+
+/**
+ * i18n resolution mode for a store's reads.
+ * - `'raw'` (default) — items keep `{ [locale]: string }` maps (today's behavior).
+ * - `'follow'` — resolve to the global `useNoydbI18n` locale; re-read on flip.
+ * - `{ locale, fallback? }` — pin to a fixed locale or own ref.
+ */
+export type NoydbStoreI18nMode =
+  | 'raw'
+  | 'follow'
+  | { locale: string | Ref<string>; fallback?: string | readonly string[] }
 
 /**
  * Reactive handle returned by `store.liveQuery(fn)`. Mirrors a hub
@@ -123,6 +137,15 @@ export interface NoydbStoreOptions<T> {
    * `Collection` so dictionary label resolution runs declaratively.
    */
   dictKeyFields?: Record<string, DictKeyDescriptor>
+  /**
+   * How the store resolves i18nText/dictKey fields on read.
+   * Default `'raw'` — items keep `{ [locale]: string }` maps (today's
+   * behavior; zero breaking change). `'follow'` resolves to the global
+   * `useNoydbI18n` locale and re-reads when it changes. `{ locale }`
+   * pins to a fixed locale or own ref. Set `'raw'` for stores whose maps
+   * feed identity/export reads or a per-cell bilingual toggle.
+   */
+  i18n?: NoydbStoreI18nMode
 }
 
 /**
@@ -170,6 +193,23 @@ export function defineNoydbStore<T>(
     const items: Ref<T[]> = shallowRef<T[]>([])
     const count = computed(() => items.value.length)
 
+    // i18n resolution mode. Default 'raw' (today's behavior): reads pass
+    // { locale: 'raw' }, items keep their maps. 'follow' resolves to the
+    // global useNoydbI18n locale and re-reads on flip; { locale } pins.
+    const i18nMode: NoydbStoreI18nMode = options.i18n ?? 'raw'
+    const i18nStore = i18nMode === 'follow' ? useNoydbI18n() : null
+    function localeOpts(): { locale: string; fallback?: string | readonly string[] } {
+      if (i18nMode === 'raw') return { locale: 'raw' }
+      if (i18nMode === 'follow') {
+        return { locale: i18nStore!.locale, fallback: i18nStore!.fallback }
+      }
+      const l = i18nMode.locale
+      return {
+        locale: typeof l === 'string' ? l : l.value,
+        ...(i18nMode.fallback !== undefined ? { fallback: i18nMode.fallback } : {}),
+      }
+    }
+
     // Lazy collection handle — created on first hydrate.
     let cachedCompartment: Vault | null = null
     let cachedCollection: Collection<T> | null = null
@@ -195,7 +235,7 @@ export function defineNoydbStore<T>(
 
     async function refresh(): Promise<void> {
       const c = await getCollection()
-      const list = await c.list()
+      const list = await c.list(localeOpts())
       items.value = list
     }
 
@@ -221,7 +261,7 @@ export function defineNoydbStore<T>(
       // Re-list to pick up the new record. Cheaper alternative would be to
       // splice into items.value directly, but list() ensures consistency
       // with the underlying cache.
-      items.value = await c.list()
+      items.value = await c.list(localeOpts())
     }
 
     async function update(id: string, record: T): Promise<void> {
@@ -232,7 +272,7 @@ export function defineNoydbStore<T>(
     async function remove(id: string): Promise<void> {
       const c = await getCollection()
       await c.delete(id)
-      items.value = await c.list()
+      items.value = await c.list(localeOpts())
     }
 
     function query(): Query<T> {
@@ -292,6 +332,18 @@ export function defineNoydbStore<T>(
     const $ready: Promise<void> = prefetch
       ? refresh()
       : Promise.resolve()
+
+    // Re-read with the new locale when it changes. 'follow' tracks the
+    // global store; a { locale: ref } pin tracks its own ref. 'raw' and
+    // a fixed-string locale never change, so no watch.
+    if (i18nMode === 'follow') {
+      watch(
+        () => [i18nStore!.locale, i18nStore!.fallback] as const,
+        () => { void refresh() },
+      )
+    } else if (typeof i18nMode === 'object' && isRef(i18nMode.locale)) {
+      watch(i18nMode.locale, () => { void refresh() })
+    }
 
     return {
       items,

--- a/packages/in-pinia/src/index.ts
+++ b/packages/in-pinia/src/index.ts
@@ -23,6 +23,8 @@ export type {
 export { setActiveNoydb, getActiveNoydb, resolveNoydb } from './context.js'
 export { useNoydbI18n } from './useNoydbI18n.js'
 export type { LocaleSyncable, SetLocaleOptions } from './useNoydbI18n.js'
+export { useI18nField } from './useI18nField.js'
+export type { UseI18nFieldOptions } from './useI18nField.js'
 export { createNoydbPiniaPlugin } from './plugin.js'
 export type { StoreNoydbOptions, NoydbPiniaPluginOptions } from './plugin.js'
 export {

--- a/packages/in-pinia/src/index.ts
+++ b/packages/in-pinia/src/index.ts
@@ -25,6 +25,8 @@ export { useNoydbI18n } from './useNoydbI18n.js'
 export type { LocaleSyncable, SetLocaleOptions } from './useNoydbI18n.js'
 export { useI18nField } from './useI18nField.js'
 export type { UseI18nFieldOptions } from './useI18nField.js'
+export { useDictLabel } from './useDictLabel.js'
+export type { UseDictLabelOptions } from './useDictLabel.js'
 export { createNoydbPiniaPlugin } from './plugin.js'
 export type { StoreNoydbOptions, NoydbPiniaPluginOptions } from './plugin.js'
 export {

--- a/packages/in-pinia/src/index.ts
+++ b/packages/in-pinia/src/index.ts
@@ -21,6 +21,8 @@ export type {
   NoydbLiveQuery,
 } from './defineNoydbStore.js'
 export { setActiveNoydb, getActiveNoydb, resolveNoydb } from './context.js'
+export { useNoydbI18n } from './useNoydbI18n.js'
+export type { LocaleSyncable, SetLocaleOptions } from './useNoydbI18n.js'
 export { createNoydbPiniaPlugin } from './plugin.js'
 export type { StoreNoydbOptions, NoydbPiniaPluginOptions } from './plugin.js'
 export {

--- a/packages/in-pinia/src/useDictLabel.ts
+++ b/packages/in-pinia/src/useDictLabel.ts
@@ -39,9 +39,10 @@
  * @module
  */
 
-import { ref, shallowRef, watch, type Ref } from 'vue'
+import { ref, shallowRef, toRef, watch, type Ref } from 'vue'
 import type { Vault } from '@noy-db/hub'
 import { resolveNoydb } from './context.js'
+import { useNoydbI18n } from './useNoydbI18n.js'
 
 export interface UseDictLabelOptions {
   /**
@@ -94,8 +95,26 @@ export function useDictLabel(
   const vault = resolveVault(options.vault)
   const handle = vault.dictionary(dictionaryName)
 
-  const localeRef = normaliseLocale(options.locale)
-  const fallback = options.fallback ?? (['en', 'any'] as const)
+  // When the caller omits locale/fallback, follow the shared useNoydbI18n
+  // store (so a global setLocale re-resolves all labels). Guarded: if no
+  // Pinia is active (e.g. standalone use), fall back to literal defaults
+  // — keeps the composable usable outside an app context.
+  let storeLocale: Ref<string> | null = null
+  let storeFallback: readonly string[] | null = null
+  if (options.locale === undefined || options.fallback === undefined) {
+    try {
+      const i18n = useNoydbI18n()
+      storeLocale = toRef(i18n, 'locale')
+      storeFallback = i18n.fallback
+    } catch {
+      /* no active Pinia — use literal defaults below */
+    }
+  }
+  const localeRef =
+    options.locale !== undefined
+      ? normaliseLocale(options.locale)
+      : (storeLocale ?? ref('en'))
+  const fallback = options.fallback ?? storeFallback ?? (['en', 'any'] as const)
   const onMissingMode = options.onMissing ?? 'key'
   const missing = (key: string): string =>
     onMissingMode === 'empty'

--- a/packages/in-pinia/src/useI18nField.ts
+++ b/packages/in-pinia/src/useI18nField.ts
@@ -38,7 +38,7 @@ export function useI18nField(
     const locale = opts.locale !== undefined ? unref(opts.locale) : i18n.locale
     const fallback = opts.fallback ?? i18n.fallback
     const out = resolveI18nText(
-      map as Record<string, string>,
+      map,
       locale,
       fallback,
       undefined,

--- a/packages/in-pinia/src/useI18nField.ts
+++ b/packages/in-pinia/src/useI18nField.ts
@@ -1,0 +1,50 @@
+/**
+ * `useI18nField` — a reactive `pickLang` for a single i18nText map.
+ *
+ * Resolves a `{ [locale]: string }` map to the active locale, recomputing
+ * when the locale (or a reactive source) changes. Uses hub's
+ * `resolveI18nText` with `policy: 'null'`, so it never throws and never
+ * yields `undefined` — `null` when no locale (and no fallback) resolves.
+ *
+ * Follows the global `useNoydbI18n` locale/fallback unless overridden.
+ * Ideal for resolving one field at the edge while siblings stay raw
+ * (e.g. a bilingual section reading raw maps).
+ *
+ * @public
+ */
+import { computed, unref, type Ref } from 'vue'
+import { resolveI18nText } from '@noy-db/hub/i18n'
+import { useNoydbI18n } from './useNoydbI18n.js'
+
+type MapSource =
+  | Record<string, string>
+  | (() => Record<string, string> | undefined | null)
+
+export interface UseI18nFieldOptions {
+  /** Override the active locale (string or ref). Defaults to the global. */
+  readonly locale?: string | Ref<string>
+  /** Override the fallback chain. Defaults to the global. */
+  readonly fallback?: string | readonly string[]
+}
+
+export function useI18nField(
+  source: MapSource,
+  opts: UseI18nFieldOptions = {},
+): Ref<string | null> {
+  const i18n = useNoydbI18n()
+  return computed<string | null>(() => {
+    const map = typeof source === 'function' ? source() : source
+    if (!map || typeof map !== 'object') return null
+    const locale = opts.locale !== undefined ? unref(opts.locale) : i18n.locale
+    const fallback = opts.fallback ?? i18n.fallback
+    const out = resolveI18nText(
+      map as Record<string, string>,
+      locale,
+      fallback,
+      undefined,
+      { policy: 'null' },
+    )
+    // With a concrete locale (never 'raw'), the result is string | null.
+    return typeof out === 'string' ? out : null
+  })
+}

--- a/packages/in-pinia/src/useNoydbI18n.ts
+++ b/packages/in-pinia/src/useNoydbI18n.ts
@@ -1,0 +1,66 @@
+/**
+ * `useNoydbI18n` — the reactive active-locale for a Pinia/Vue app.
+ *
+ * A single source of truth that drives opt-in store resolution
+ * (`defineNoydbStore({ i18n: 'follow' })`) and the reactive
+ * `useI18nField` / `useDictLabel` selectors.
+ *
+ * **State-only by default.** Every in-pinia reader passes `{ locale }`
+ * explicitly on each read, so the reactive `locale` state alone drives
+ * all in-pinia resolution — the vault's ambient locale is never needed.
+ * `setLocale(l, { syncVault })` additionally calls `vault.setLocale` on
+ * the vault(s) you pass, for apps that ALSO do imperative (non-in-pinia)
+ * hub reads and want those to follow. Locale-less-vault consumers leave
+ * `syncVault` off so the vault stays locale-less.
+ *
+ * @public
+ */
+import { defineStore } from 'pinia'
+import { ref, watch, type Ref } from 'vue'
+
+/** Minimal vault shape needed to sync an ambient locale. */
+export interface LocaleSyncable {
+  setLocale(locale: string | undefined): void
+}
+
+export interface SetLocaleOptions {
+  /**
+   * Vault(s) to ALSO update via `vault.setLocale` (opt-in). Omit to keep
+   * the operation state-only — the safe default for locale-less vaults.
+   */
+  readonly syncVault?: LocaleSyncable | readonly LocaleSyncable[]
+}
+
+export const useNoydbI18n = defineStore('noydb-i18n', () => {
+  const locale = ref<string>('en')
+  const fallback = ref<string[]>(['en', 'any'])
+
+  function setLocale(l: string, opts?: SetLocaleOptions): void {
+    locale.value = l
+    const sync = opts?.syncVault
+    if (sync) {
+      const vaults = Array.isArray(sync) ? sync : [sync as LocaleSyncable]
+      for (const v of vaults) v.setLocale(l)
+    }
+  }
+
+  function setFallback(chain: string[]): void {
+    fallback.value = chain
+  }
+
+  /**
+   * One-way, state-only follow of an external locale ref (e.g. vue-i18n's
+   * `locale`). Never touches a vault. Returns the watch stop handle.
+   */
+  function bindTo(source: Ref<string>, opts?: { immediate?: boolean }): () => void {
+    return watch(
+      source,
+      (v) => { locale.value = v },
+      // sync flush so the mirror propagates immediately (no tick lag) —
+      // a locale change should be observable synchronously by dependents.
+      { immediate: opts?.immediate ?? true, flush: 'sync' },
+    )
+  }
+
+  return { locale, fallback, setLocale, setFallback, bindTo }
+})

--- a/showcases/src/94-with-i18n-hardening.showcase.test.ts
+++ b/showcases/src/94-with-i18n-hardening.showcase.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Showcase 94 — i18n hardening (per-layer onMissing, substitute, script, dictKey parity)
+ *
+ * What you'll learn
+ * ─────────────────
+ * The multilingual-field hardening layer over `withI18n()`:
+ *   1. `onMissing` + `substitute` — a person's name stored in one
+ *      language resolves to a preferred substitute when the active
+ *      locale is absent (proper names aren't translated — a Thai name
+ *      shown to an `en` reader is acceptable).
+ *   2. `script` enforcement — a Thai address with embedded Latin
+ *      (building names) is accepted, while Thai text dumped into an
+ *      `en` slot is rejected. (#283)
+ *   3. dictKey parity — a honorific (`Mr.`/`Ms.` → `คุณ`) resolved per
+ *      element of a `contacts[]` array, with the stable key preserved
+ *      so identity survives the many-to-one label collapse. (#282)
+ *
+ * Why it matters
+ * ──────────────
+ * In a bilingual (or multi-script) interface, missing-translation
+ * policy, substitute ordering, and script validation otherwise sprawl
+ * across application code with weak enforcement. noy-db makes them
+ * field-level declarations honored on every read/write.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 09 (withI18n basics).
+ *
+ * What to read next
+ * ─────────────────
+ *   - docs/subsystems/i18n.md (§ Hardening)
+ *   - docs/superpowers/specs/2026-06-05-i18n-multilingual-field-hardening-design.md
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → i18n
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { withI18n, i18nText, dictKey, ScriptViolationError } from '@noy-db/hub/i18n'
+import { memory } from '@noy-db/to-memory'
+
+describe('Showcase 94 — i18n hardening', () => {
+  it('substitutes a proper name when the active locale is absent', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'pw-94-a', i18nStrategy: withI18n() })
+    const vault = await db.openVault('people', { locale: 'en' })
+    interface Person { id: string; firstName: Record<string, string> }
+    const people = vault.collection<Person>('people', {
+      i18nFields: {
+        firstName: i18nText({
+          languages: ['th', 'en'],
+          required: 'any',
+          substitute: ['en', 'th', 'any'],
+          onMissing: { read: 'substitute' },
+        }),
+      },
+    })
+    await people.put('p1', { id: 'p1', firstName: { th: 'สมชาย' } })
+    const p = await people.get('p1')
+    expect(p?.firstName).toBe('สมชาย') // en absent → substitute chain → th
+  })
+
+  it('accepts Thai-with-embedded-Latin but rejects Thai in an en slot (#283)', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'pw-94-b', i18nStrategy: withI18n() })
+    const vault = await db.openVault('orgs', { locale: 'th' })
+    interface Org { id: string; name: Record<string, string>; address: Record<string, string> }
+    const orgs = vault.collection<Org>('orgs', {
+      i18nFields: {
+        name: i18nText({ languages: ['th', 'en'], required: 'any', script: 'auto' }),
+        address: i18nText({ languages: ['th'], required: 'any', script: 'auto' }),
+      },
+    })
+    // Thai address with embedded Latin building name — accepted.
+    await orgs.put('o1', {
+      id: 'o1',
+      name: { th: 'บริษัท ตัวอย่าง' },
+      address: { th: '9/9 อาคาร TCM ถนนรัชดาภิเษก' },
+    })
+    // Thai text in the en slot — rejected.
+    await expect(
+      orgs.put('o2', { id: 'o2', name: { en: 'สมชาย' }, address: { th: 'x' } }),
+    ).rejects.toThrow(ScriptViolationError)
+  })
+
+  it('resolves an honorific per contact element, keeping the key (#282)', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'pw-94-c', i18nStrategy: withI18n() })
+    const vault = await db.openVault('entities', { locale: 'th' })
+    const dict = vault.dictionary('contactTitle')
+    await dict.put('mr', { en: 'Mr.', th: 'คุณ' })
+    await dict.put('ms', { en: 'Ms.', th: 'คุณ' })
+
+    interface Entity { id: string; contacts: { name: string; title: string }[] }
+    const entities = vault.collection<Entity>('entities', {
+      dictKeyFields: { 'contacts[].title': dictKey('contactTitle', ['mr', 'ms'] as const) },
+    })
+    await entities.put('e1', {
+      id: 'e1',
+      contacts: [
+        { name: 'Somchai', title: 'mr' },
+        { name: 'Jane', title: 'ms' },
+      ],
+    })
+    const e = (await entities.get('e1')) as unknown as { contacts: Record<string, unknown>[] }
+    // Labels collapse to คุณ for display…
+    expect(e.contacts[0]!.titleLabel).toBe('คุณ')
+    expect(e.contacts[1]!.titleLabel).toBe('คุณ')
+    // …but the stable keys stay distinct (identity survives).
+    expect(e.contacts[0]!.title).toBe('mr')
+    expect(e.contacts[1]!.title).toBe('ms')
+  })
+})

--- a/showcases/src/95-in-pinia-i18n.showcase.test.ts
+++ b/showcases/src/95-in-pinia-i18n.showcase.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Showcase 95 — in-pinia reactive i18n
+ *
+ * What you'll learn
+ * ─────────────────
+ * Make a Pinia/Vue app language-agnostic over noy-db's i18n:
+ *   1. `useNoydbI18n` — one reactive active-locale. `setLocale('th')`
+ *      flips the language; `'follow'` stores re-read resolved.
+ *   2. `defineNoydbStore({ i18n: 'follow' })` — store items resolve to
+ *      the global locale and re-resolve on flip. Default `'raw'` keeps
+ *      `{th,en}` maps (feeds a bilingual per-cell toggle).
+ *   3. `useI18nField` / `useDictLabel` — reactive field + dict-label
+ *      selectors that follow the same global locale.
+ *
+ * Why it matters
+ * ──────────────
+ * The store holds raw by default (lossless, non-breaking); resolution is
+ * opt-in and reactive. One switch re-renders the whole UI in another
+ * language — no per-component locale plumbing.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 38 (in-pinia), 09 (withI18n).
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → frameworks → in-pinia
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { createNoydb } from '@noy-db/hub'
+import { withI18n, i18nText } from '@noy-db/hub/i18n'
+import {
+  defineNoydbStore,
+  setActiveNoydb,
+  useNoydbI18n,
+  useI18nField,
+  useDictLabel,
+} from '@noy-db/in-pinia'
+import { memory } from '@noy-db/to-memory'
+
+const tick = (ms = 0): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
+interface Person { id: string; name: Record<string, string> | string }
+
+describe('Showcase 95 — in-pinia reactive i18n', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it("'follow' store resolves and re-resolves on a global setLocale flip", async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'sc95-a', i18nStrategy: withI18n() })
+    setActiveNoydb(db)
+    const i18n = useNoydbI18n()
+    i18n.setLocale('en')
+
+    const usePeople = defineNoydbStore<Person>('people', {
+      vault: 'v',
+      i18n: 'follow',
+      i18nFields: { name: i18nText({ languages: ['th', 'en'], required: 'any' }) },
+    })
+    const store = usePeople()
+    await store.$ready
+    await store.add('p1', { id: 'p1', name: { th: 'สมชาย', en: 'Somchai' } })
+
+    expect(store.items.find((p) => p.id === 'p1')?.name).toBe('Somchai')
+    i18n.setLocale('th')
+    for (let n = 0; n < 50 && store.items.find((p) => p.id === 'p1')?.name !== 'สมชาย'; n++) await tick(10)
+    expect(store.items.find((p) => p.id === 'p1')?.name).toBe('สมชาย')
+  })
+
+  it("default 'raw' store keeps the {th,en} map (bilingual source)", async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'sc95-b', i18nStrategy: withI18n() })
+    setActiveNoydb(db)
+    const usePeople = defineNoydbStore<Person>('people-raw', {
+      vault: 'v2',
+      i18nFields: { name: i18nText({ languages: ['th', 'en'], required: 'any' }) },
+    })
+    const store = usePeople()
+    await store.$ready
+    await store.add('p1', { id: 'p1', name: { th: 'สมชาย', en: 'Somchai' } })
+    // raw map preserved → a BilingualText component owns the per-cell toggle
+    expect(store.items.find((p) => p.id === 'p1')?.name).toEqual({ th: 'สมชาย', en: 'Somchai' })
+  })
+
+  it('useI18nField + useDictLabel follow the global locale', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'sc95-c', i18nStrategy: withI18n() })
+    setActiveNoydb(db)
+    const vault = await db.openVault('v3')
+    const dict = vault.dictionary('title')
+    await dict.put('mr', { en: 'Mr.', th: 'คุณ' })
+
+    const i18n = useNoydbI18n()
+    i18n.setLocale('en')
+
+    const name = useI18nField({ th: 'สมชาย', en: 'Somchai' })
+    const label = useDictLabel('title', { vault })
+    const mr = label('mr')
+    for (let n = 0; n < 50 && mr.value !== 'Mr.'; n++) await tick(10)
+    expect(name.value).toBe('Somchai')
+    expect(mr.value).toBe('Mr.')
+
+    i18n.setLocale('th')
+    for (let n = 0; n < 50 && mr.value !== 'คุณ'; n++) await tick(10)
+    expect(name.value).toBe('สมชาย')   // sync computed
+    expect(mr.value).toBe('คุณ')        // async dict label
+  })
+})


### PR DESCRIPTION
Implements the i18n multilingual-field hardening spec as **opt-in** additions to `i18nText`/`dictKey`. Every existing field behaves exactly as before — zero breaking change.

Spec: `docs/superpowers/specs/2026-06-05-i18n-multilingual-field-hardening-design.md`
Plan: `docs/superpowers/plans/2026-06-06-i18n-multilingual-field-hardening.md`
Milestone: #17

Closes #282
Closes #283

## What landed (all TDD, full suite green: 214 files / 2112 tests)

**Phase A — policy core**
- `OnMissing` / `Layer` types + `resolvePolicy()` (per-layer; `guard` lenient by default)
- Policy-aware `resolveI18nText()` with a backward-compat overload (legacy 4-arg never returns null)

**Phase B — read layer**
- `get`/`list` honor a field's `onMissing` + `substitute` (caller `fallback` overrides declared substitute)

**Phase C — script enforcement (#283)**
- `ScriptViolationError`; `script: 'auto' | {locale: Script[]}`, `onScriptViolation: reject|filter|warn`
- **Asymmetric Latin tolerance**: non-Latin locales also allow `Latin` (Thai address with embedded Latin passes), Latin locales reject other scripts (Thai-in-`en` still caught)
- `Common`/`Inherited`/`Mark` always-on baseline (digits + combining marks never false-reject)
- Wired into `put` via the tree-shaken i18n strategy

**Phase E — dictKey parity (#282)**
- `dictKey()` accepts `onMissing`/`substitute` (default stays legacy `'null'`)
- Array-of-keys → `[{key,label}]` pair objects (key preserved)
- **Wildcard-path `contacts[].title`** → per-element sibling `<leaf>Label` (the #282 gap)

**Phase F** — public exports, showcase `94-with-i18n-hardening`, `features.yaml` + subsystem doc.

## Deferred (tracked follow-ups under #17 — see plan §D)

Per-layer enforcement for **guard / derivation / mv / join / export**. A D0 spike found the MV/join read path (`materialized-views/executor.ts:106`, `query().toArray()`) reads **raw** `{locale}` maps — `mv:'throw'` has no resolution call site, and injecting resolution into `groupAndReduce` would destabilize every existing MV. Guard/derivation share a cached read facade reached through transaction internals. The policy *engine* is in place; only the per-layer *wiring* remains. Today **only the `read` layer is enforced** (documented in the `onMissing` JSDoc, the subsystem doc, and the `features.yaml` invariant) so there's no silent no-op.

Also deferred (in spec as v1.x/v2): `densifyOnWrite`, nearest-script smart substitution, dictKey `groupBy {by:'label'}` opt-in (default key-binding already holds), `warn`-mode diagnostic event channel.

## Verification
- `pnpm --filter @noy-db/hub test` — 214 files / 2112 tests pass
- `pnpm --filter @noy-db/hub typecheck` + `lint` — clean
- `node scripts/validate-features.mjs` — OK
- showcase 94 passes against the built package

> Per-layer/MV wiring is intentionally **not** in this PR; please review the deferral reasoning in plan §D0 and confirm the `read`-only scope is the right cut.

---
**Verification update (repo-wide):** i18n/dict/aggregate showcases all pass (incl. 09/14/94/10/85). Pre-existing, unrelated-to-this-PR reds in CI: `in-devtools-tui` typecheck (leftover pre.6 Track B devtools work — this PR touches neither in-devtools package) and Supabase real-service showcases 64/65/66 (env-gated live-network timeouts).

**Filter-mode caveat:** `onScriptViolation:'filter'` runs before the `required` check, so a slot that is entirely wrong-script strips to `''` and then trips `MissingTranslationError` rather than `ScriptViolationError`. Arguably correct (an all-wrong-script value *is* effectively missing), but it's an untested interaction — noted for reviewer awareness.

---
## Added: @noy-db/in-pinia reactive i18n (companion spec; resolves #286)

The reactive companion to the hub hardening — makes locale reactive in a Pinia/Vue app. Spec `docs/superpowers/specs/2026-06-06-in-pinia-reactive-i18n-design.md`, plan `docs/superpowers/plans/2026-06-06-in-pinia-reactive-i18n.md`. **Non-breaking** (store default `i18n:'raw'`).

- **`useNoydbI18n`** — reactive active-locale Pinia store; `setLocale`/`bindTo` **state-only** by default (vault sync opt-in) — resolves #286 Hazard 2.
- **`defineNoydbStore({ i18n })`** — `'raw'` (default, unchanged) | `'follow'` (resolve + re-read on flip) | `{locale}` pin.
- **`useI18nField`** — reactive pickLang (`resolveI18nText` policy:null → string|null).
- **`useDictLabel`** — now exported; defaults its locale/fallback to `useNoydbI18n` (guarded so standalone use still works).
- Showcase `95-in-pinia-i18n`; `features.yaml` + `MIGRATING.md` updated.

in-pinia: 6 files / 75 tests green; typecheck + lint clean; showcase 95 passes. `liveQuery` i18n deferred (documented). Closes #286.