### PR TITLE
feat(federation): VaultGroup MVP + #312 key-custody-neutral (A/B) + Reducer.merge (E)

### DIFF
--- a/SUBSYSTEMS.md
+++ b/SUBSYSTEMS.md
@@ -21,7 +21,7 @@ const db = await createNoydb({
 
 When a subsystem is not opted into, its real implementation is replaced by a NO-OP stub (or a throwing stub on opt-in surfaces) and the heavy code is fully tree-shaken from the bundle.
 
-This document lists the always-on core and the 23 subsystems. It is the table of contents for the rest of the documentation.
+This document lists the always-on core and the 24 subsystems. It is the table of contents for the rest of the documentation.
 
 ---
 
@@ -43,7 +43,7 @@ Anything outside this floor is a subsystem.
 
 ---
 
-## The 23 subsystems
+## The 24 subsystems
 
 Each subsystem has its own subpath export under `@noy-db/hub/<name>`, a `with<Name>()` factory, and a doc page in `docs/subsystems/<name>.md`. The "LOC saved" column is the bundle weight a consumer avoids by **not** opting in.
 
@@ -114,8 +114,9 @@ The Dim 14 family. All three share the same encrypted-payload metadata envelope,
 | # | Subpath | Headline | LOC saved | Pairs with |
 |---|---|---|---:|---|
 | 17 | `@noy-db/hub/routing` | Multi-store routing + middleware + sync-policy + lazy-mode + LRU cache | ~1,985 | `indexing`, `bundle` |
+| 24 | *(preview)* | Multi-vault partition federation — `db.openVaultGroup()` transparent shard routing + `vault-registry` source-of-truth + `minVersion` fan-out guard (MVP, milestone 16) | — | `queryAcross`, `permissions` |
 
-**Totals:** ~16,650 LOC across all 23 subsystems are tree-shake-able. A consumer using only the core ships ~6,500 LOC. A consumer opting into all 23 ships ~31,700 LOC.
+**Totals:** ~16,650 LOC across all 24 subsystems are tree-shake-able. A consumer using only the core ships ~6,500 LOC. A consumer opting into all 24 ships ~31,700 LOC.
 
 ---
 

--- a/docs/subsystems/vault-group.md
+++ b/docs/subsystems/vault-group.md
@@ -36,6 +36,51 @@ const { results, skippedVaults } = await firm.collection('invoices')
 const acme = await firm.shard('acme')
 ```
 
+## Key-custody model
+
+VaultGroup operations run as the **calling identity**, which may hold grants to
+only a subset of the shards. The fan-out returns the **openable subset**; a shard
+the caller has no grant to is a `'no-grant'` skip — expected under scoped access,
+not a fault.
+
+### Skip reasons
+
+| reason | meaning |
+|---|---|
+| `'schema-drift'` | shard `schemaVersion` below the `minVersion` guard |
+| `'no-grant'` | caller holds no keyring envelope for this shard (`NoAccessError`) |
+| `'error'` | store fault, corruption, or wrong credential (`InvalidKeyError`, `KeyringCorruptError`, etc.) |
+
+Only `NoAccessError` maps to `'no-grant'`; all other errors map to `'error'` so
+that credential/corruption failures are never hidden as routine scoped-access
+skips.
+
+### Non-creating opens
+
+All federation opens (`openShard`, `queryAcross` fan-out) are **non-creating**
+(`create: false`). A missing grant therefore fails cleanly with `NoAccessError`
+and never self-provisions a keyring entry. The **only creating path** is
+`createShard`, which is called exclusively by the owning operator identity.
+
+### Registry vault access
+
+Opening a VaultGroup requires a grant to the **registry/StateManagement vault**
+(`state` in the typical setup). Without it the caller cannot read the
+`vault-registry` collection that drives shard discovery.
+
+### Partition key design
+
+`keyOf` must return an **opaque partition key** (e.g. an internal UUID or a
+short code). Registry rows are stored plaintext-visible to every member of the
+registry vault — do not key by sensitive identifiers such as tax IDs or full
+legal names.
+
+### Out of scope (this MVP)
+
+Per-identity roster scoping (limiting which registry rows a grantee can see) is
+deferred. The current model exposes the full registry to all registry-vault
+grantees; access control is at the shard level.
+
 ## Guarantees & limits
 
 - The operator `Noydb` instance owns its shards (`createShard` provisions them).

--- a/docs/subsystems/vault-group.md
+++ b/docs/subsystems/vault-group.md
@@ -1,0 +1,49 @@
+# Vault Group — Multi-Vault Partition Federation (MVF)
+
+> Status: **preview** (milestone 16 MVP). Spec:
+> `docs/superpowers/specs/2026-06-07-mvf-vaultgroup-routing-mvp-design.md`.
+
+## Overview
+
+`VaultGroup` routes records across many per-partition shard vaults behind a
+single entry point, while every shard stays an ordinary noy-db vault within its
+small-DB ceiling. Shard discovery is backed by a `vault-registry` collection
+that is the single source of truth (no dependency on `listAccessibleVaults`, so
+it works on every backend).
+
+## API
+
+```ts
+db.withVaultTemplate('client-template', {
+  version: 1,
+  configure(vault) { vault.collection('invoices') },
+})
+
+const state = await db.openVault('state')
+const firm = await db.openVaultGroup('firm-clients', {
+  registry: state.collection('vault-registry'),
+  sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template', autoCreate: true },
+})
+
+// Transparent write — routed (and auto-provisioned) by partition key.
+await firm.collection('invoices').put('inv-1', { clientId: 'acme', amount: 1200, status: 'open' })
+
+// Cross-shard fan-out read.
+const { results, skippedVaults } = await firm.collection('invoices')
+  .query().where('status', '==', 'overdue').toArray({ minVersion: 1 })
+
+// Drill down to one shard's full Collection API.
+const acme = await firm.shard('acme')
+```
+
+## Guarantees & limits
+
+- The operator `Noydb` instance owns its shards (`createShard` provisions them).
+- `createShard` is idempotent; a registry row pointing at a missing vault raises
+  `ShardProvisioningError` rather than recreating it.
+- The `minVersion` guard pre-filters shards by their registry-recorded
+  `schemaVersion`; behind-version shards land in `skippedVaults`, never mixed
+  into `results`.
+- **Out of scope (this MVP):** cross-shard joins, push-model cross-vault
+  derivations (Insight Vault), reactive `queryAcrossLive`, `aggregateAcross`,
+  and the fleet schema-migration runner. See the spec's deferred-items list.

--- a/docs/superpowers/plans/2026-06-07-mvf-vaultgroup-routing.md
+++ b/docs/superpowers/plans/2026-06-07-mvf-vaultgroup-routing.md
@@ -561,10 +561,10 @@ export type {
 
 - [ ] **Step 5: Wire `Noydb` (noydb.ts)**
 
-Add the import near the other internal imports at the top of `packages/hub/src/noydb.ts`:
+Add **type-only** imports near the other internal imports at the top of `packages/hub/src/noydb.ts`. The `VaultGroup` *value* is loaded lazily inside `openVaultGroup` (below) so the federation module stays out of the static core graph — this is what keeps the core bundle within the `check-bundle.mjs` ceiling. (`queryAcross` lives in core, but the federation classes are a preview opt-in and should not inflate the always-loaded path.)
 
 ```ts
-import { VaultGroup } from './federation/vault-group.js'
+import type { VaultGroup } from './federation/vault-group.js'
 import type { VaultTemplate, VaultGroupOptions } from './federation/types.js'
 import { VaultTemplateNotFoundError } from './errors.js'
 ```
@@ -596,6 +596,9 @@ Add these three methods to the `Noydb` class (place them just after `queryAcross
     if (this.closed) throw new ValidationError('Instance is closed')
     const template = this.vaultTemplates.get(opts.sharding.vaultTemplate)
     if (!template) throw new VaultTemplateNotFoundError(opts.sharding.vaultTemplate)
+    // Lazy-load so the federation module is a separate chunk, not part
+    // of the always-loaded core graph (keeps the core bundle ceiling).
+    const { VaultGroup } = await import('./federation/vault-group.js')
     return new VaultGroup<T>(this, name, opts.registry, opts.sharding, template)
   }
 
@@ -742,6 +745,54 @@ describe('VaultGroup — fan-out read', () => {
       { vaultId: 'firm-clients--acme', reason: 'schema-drift' },
     ])
   })
+
+  it('a per-shard read failure lands in skippedVaults with reason "error" (fan-out not aborted)', async () => {
+    // Write with one db, then read with a FRESH db (empty caches) so the
+    // fan-out actually re-hydrates from the store and re-hits list(). The
+    // injected failure targets only the invoices collection of one shard;
+    // keyring load (collection '_keyring') is unaffected, so the shard
+    // opens and the failure surfaces inside the fan-out callback.
+    const base = memory()
+    let failBigco = false
+    const adapter: NoydbStore = {
+      ...base,
+      async list(c, col) {
+        if (failBigco && c === 'firm-clients--bigco' && col === 'invoices') {
+          throw new Error('injected list failure')
+        }
+        return base.list(c, col)
+      },
+    }
+    const tmpl = (vault: Vault) => { vault.collection<Invoice>('invoices') }
+
+    // --- write side ---
+    const wdb = await createNoydb({ store: adapter, user: 'operator', secret: 'op-pass' })
+    wdb.withVaultTemplate('client-template', { version: 1, configure: tmpl })
+    const wState = await wdb.openVault('state')
+    const wFirm = await wdb.openVaultGroup<Invoice>('firm-clients', {
+      registry: wState.collection<VaultRegistryRow>('vault-registry'),
+      sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template' },
+    })
+    await wFirm.collection('invoices').put('a-1', { clientId: 'acme', amount: 100, status: 'overdue' })
+    await wFirm.collection('invoices').put('b-1', { clientId: 'bigco', amount: 300, status: 'overdue' })
+
+    // --- read side: fresh db, caches empty ---
+    failBigco = true
+    const rdb = await createNoydb({ store: adapter, user: 'operator', secret: 'op-pass' })
+    rdb.withVaultTemplate('client-template', { version: 1, configure: tmpl })
+    const rState = await rdb.openVault('state')
+    const rFirm = await rdb.openVaultGroup<Invoice>('firm-clients', {
+      registry: rState.collection<VaultRegistryRow>('vault-registry'),
+      sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template' },
+    })
+
+    const out = await rFirm.collection('invoices').query().where('status', '==', 'overdue').toArray()
+    expect(out.results.map((r) => r.amount)).toEqual([100]) // bigco failed, acme survived
+    expect(out.skippedVaults).toHaveLength(1)
+    expect(out.skippedVaults[0]!.vaultId).toBe('firm-clients--bigco')
+    expect(out.skippedVaults[0]!.reason).toBe('error')
+    expect(out.skippedVaults[0]!.error).toBeInstanceOf(Error)
+  })
 })
 ```
 
@@ -867,10 +918,10 @@ const acme = await firm.shard('acme')
 
 - [ ] **Step 2: Add the SUBSYSTEMS.md catalog row**
 
-In `SUBSYSTEMS.md`, change the catalog heading `## The 23 subsystems` to `## The 24 subsystems`, and add this row under the appropriate cluster table (Cluster — write/mutate or a federation cluster; place it after row 23):
+In `SUBSYSTEMS.md`, change the catalog heading `## The 23 subsystems` to `## The 24 subsystems`, and add this row at the end of the last cluster table. Mirror row 22's italic-parenthetical marker style (`*(always-core)*`); since this is a preview core API (not a `with*()` subpath), use `*(preview)*`:
 
 ```markdown
-| 24 | `@noy-db/hub` (core) | Multi-vault partition federation — `db.openVaultGroup()` transparent shard routing + `vault-registry` source-of-truth + `minVersion` fan-out guard (MVP) | — | `queryAcross`, `permissions` |
+| 24 | *(preview)* | Multi-vault partition federation — `db.openVaultGroup()` transparent shard routing + `vault-registry` source-of-truth + `minVersion` fan-out guard (MVP, milestone 16) | — | `queryAcross`, `permissions` |
 ```
 
 - [ ] **Step 3: Add the features.yaml entry**
@@ -918,15 +969,17 @@ git commit -m "docs(federation): vault-group subsystem doc + features.yaml regis
 
 ## Task 8: Final verification
 
-- [ ] **Step 1: Full hub suite + typecheck + feature validation**
+- [ ] **Step 1: Full hub suite + typecheck + feature validation + bundle ceiling**
 
 Run:
 ```bash
 pnpm --filter @noy-db/hub exec tsc --noEmit
 pnpm --filter @noy-db/hub test
 node scripts/validate-features.mjs
+pnpm --filter @noy-db/hub build
+pnpm --filter @noy-db/hub bundle-check
 ```
-Expected: all PASS.
+Expected: all PASS. `bundle-check` must stay within the 5% tolerance vs `bundle-manifest.json` — the dynamic `import()` in `openVaultGroup` (Task 3, Step 5) is what keeps the federation module out of the core entry chunk. If `bundle-check` fails with a core-chunk growth, confirm the import is `import type` at module top (value loaded only via `await import()` inside the method); do **not** simply run `BUNDLE_BASELINE_UPDATE=1` to paper over a real core-graph regression.
 
 - [ ] **Step 2: Confirm the join.ts invariant is untouched**
 
@@ -944,7 +997,7 @@ git commit -m "chore(federation): formatting/lint fixups" || echo "nothing to co
 
 ## Self-Review notes (for the implementer)
 
-- **Spec coverage:** withVaultTemplate (T3), createShard idempotency 4-case matrix (T3), VaultGroup/openVaultGroup (T3), write routing + autoCreate (T4), fan-out + skippedVaults + minVersion guard (T5), shard() drill-down (T3 helper + T4 usage), registry-as-source-of-truth (harness uses a real `vault-registry` collection), errors (T2). Deferred items are explicitly documented, not implemented.
+- **Spec coverage:** withVaultTemplate (T3), createShard idempotency 4-case matrix (T3), VaultGroup/openVaultGroup (T3), write routing + autoCreate (T4), fan-out merge + minVersion schema-drift guard + per-shard `reason:'error'` branch (T5), shard() drill-down (T3 helper + T4 usage), registry-as-source-of-truth (harness uses a real `vault-registry` collection), errors (T2), bundle ceiling held via lazy import (T3 Step 5 + T8). Deferred items are explicitly documented, not implemented.
 - **`shard()` drill-down** is exercised indirectly by the write-routing tests (`h.firm.shard('acme')`). If you want an explicit unit, add an `it('shard() throws UnknownShardError for an unknown key')` asserting `rejects.toBeInstanceOf(UnknownShardError)`.
 - **Type consistency:** `VaultRegistryRow` fields (`vaultId`, `partitionKey`, `templateName`, `schemaVersion`, `createdAt`) are identical in types.ts, the createShard writer, the test rows, and the guard reader. `ShardedCollection.query()` → `ShardedQuery` → `toArray(FanoutQueryOptions)` → `FanoutResult`.
 - **Encrypted-vault assumption:** `_shardVaultProvisioned` keys off the `_keyring` row, which only exists for encrypted vaults. The MVP assumes the DEK/grant model (encrypt !== false). Document if a plaintext path is ever needed (out of scope).

--- a/docs/superpowers/plans/2026-06-07-mvf-vaultgroup-routing.md
+++ b/docs/superpowers/plans/2026-06-07-mvf-vaultgroup-routing.md
@@ -1,0 +1,951 @@
+# MVF VaultGroup Routing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the milestone-16 MVP — `withVaultTemplate` + `VaultGroup`/`ShardedCollection` transparent shard routing with cross-shard fan-out reads, backed by a minimal `vault-registry` as the source of truth for shard discovery.
+
+**Architecture:** A new `packages/hub/src/federation/` module adds `VaultGroup<T>` (created via `db.openVaultGroup`) that routes writes to per-partition shard vaults by a `keyOf` partition key, reading shard locations from a caller-supplied `vault-registry` collection. Reads fan out via the existing `Noydb.queryAcross` engine, pre-filtered by a registry-recorded `schemaVersion` guard. Shards are ordinary noy-db vaults stamped from a registered template; the operator `Noydb` instance owns them.
+
+**Tech Stack:** TypeScript, `@noy-db/hub` internals (`Noydb`, `Vault`, `Collection`, `queryAcross`), Vitest. Package manager: pnpm 9.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-mvf-vaultgroup-routing-mvp-design.md`
+
+---
+
+## File Structure
+
+- **Create** `packages/hub/src/federation/types.ts` — `VaultTemplate`, `VaultRegistryRow`, `ShardingConfig`, `VaultGroupOptions`, `FanoutResult`, `SkippedVault`, `FanoutQueryOptions`.
+- **Create** `packages/hub/src/federation/vault-group.ts` — `VaultGroup<T>`, `ShardedCollection<T>`, `ShardedQuery<T>`.
+- **Create** `packages/hub/src/federation/index.ts` — re-export the public surface.
+- **Modify** `packages/hub/src/errors.ts` — add `UnknownShardError`, `ShardProvisioningError`, `VaultTemplateNotFoundError`.
+- **Modify** `packages/hub/src/noydb.ts` — add `vaultTemplates` map, `withVaultTemplate()`, `openVaultGroup()`, internal `_shardVaultProvisioned()`.
+- **Modify** `packages/hub/src/index.ts` — export federation types + classes + new errors.
+- **Create** `packages/hub/__tests__/federation-vault-group.test.ts` — full test suite.
+- **Create** `docs/subsystems/vault-group.md` — subsystem doc.
+- **Modify** `features.yaml` — register the feature.
+- **Modify** `SUBSYSTEMS.md` — add catalog row (#24).
+
+**Key facts the implementer must know (verified against the codebase):**
+- `Collection.put(id, record)` takes an explicit `id` first. `ShardedCollection.put(id, record)` mirrors this; the partition key is derived from the `record` via `keyOf`, not from `id`.
+- `Collection.query()` is **synchronous** and reads an in-memory cache. The cache is only populated after an async method runs. Call `await coll.list()` to force hydration before `coll.query().toArray()`.
+- `vault.collection(name, opts)` caches the instance per name (`collectionCache`). The first call's `opts` win, so the template's `configure(vault)` must run before any read so indexes/schema apply.
+- `db.openVault(name)` is open-or-create. A keyring envelope lands at `_keyring/<userId>`; `store.list(vaultId, '_keyring')` is non-empty iff the (encrypted) vault is provisioned.
+- `db.queryAcross(ids, fn, { concurrency })` returns `Array<{ vault, result } | { vault, error }>`; per-shard errors never abort the fan-out.
+- `Operator` type is exported from `packages/hub/src/query/predicate.ts`.
+- Tests use an inline `memory()` adapter (copy from `packages/hub/__tests__/cross-vault.test.ts`).
+
+**Run tests with:** `pnpm --filter @noy-db/hub exec vitest run __tests__/federation-vault-group.test.ts`
+
+---
+
+## Task 1: Types module
+
+**Files:**
+- Create: `packages/hub/src/federation/types.ts`
+
+- [ ] **Step 1: Write the types file**
+
+```ts
+/**
+ * @category capability
+ * Multi-vault partition federation (MVF) — public types for VaultGroup
+ * transparent shard routing. See
+ * docs/superpowers/specs/2026-06-07-mvf-vaultgroup-routing-mvp-design.md.
+ */
+import type { Vault } from '../vault.js'
+import type { Collection } from '../collection.js'
+import type { Operator } from '../query/predicate.js'
+
+/**
+ * A schema blueprint for a class of shard vaults. `configure` is
+ * re-applied to every shard handle so all shards are configured
+ * identically (collections, indexes, schemas). `version` is recorded
+ * into each shard's registry row and drives the fan-out
+ * `minVersion` guard.
+ */
+export interface VaultTemplate {
+  readonly version: number
+  readonly configure: (vault: Vault) => void
+}
+
+/** One row in the StateManagement `vault-registry` collection. */
+export interface VaultRegistryRow {
+  readonly vaultId: string
+  readonly partitionKey: string
+  readonly templateName: string
+  readonly schemaVersion: number
+  readonly createdAt: number
+}
+
+/** How a VaultGroup maps records to shards. */
+export interface ShardingConfig<T> {
+  /** Extract the partition key from a record. */
+  readonly keyOf: (record: T) => string
+  /** Name of the template (registered via `withVaultTemplate`) shards are stamped from. */
+  readonly vaultTemplate: string
+  /** When a write targets an unknown partition key, stamp a shard inline. Default `true`. */
+  readonly autoCreate?: boolean
+}
+
+/** Options for `Noydb.openVaultGroup`. */
+export interface VaultGroupOptions<T> {
+  /** The `vault-registry` collection (source of truth for shard discovery). */
+  readonly registry: Collection<VaultRegistryRow>
+  readonly sharding: ShardingConfig<T>
+}
+
+/** Options for a cross-shard fan-out read. */
+export interface FanoutQueryOptions {
+  /** Skip shards whose registry `schemaVersion` is below this. */
+  readonly minVersion?: number
+  /** Max shards queried in parallel (passed to queryAcross). Default 1. */
+  readonly concurrency?: number
+}
+
+/** A shard excluded from a fan-out result, with the reason. */
+export interface SkippedVault {
+  readonly vaultId: string
+  readonly reason: 'schema-drift' | 'error'
+  readonly error?: Error
+}
+
+/** The result of a cross-shard fan-out read. */
+export interface FanoutResult<R> {
+  readonly results: R[]
+  readonly skippedVaults: SkippedVault[]
+}
+
+/** A single captured where-clause, replayed inside each shard. */
+export interface WhereClause {
+  readonly field: string
+  readonly op: Operator
+  readonly value: unknown
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `pnpm --filter @noy-db/hub exec tsc --noEmit`
+Expected: PASS (no errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/hub/src/federation/types.ts
+git commit -m "feat(federation): vault-group public types"
+```
+
+---
+
+## Task 2: Error classes
+
+**Files:**
+- Modify: `packages/hub/src/errors.ts` (append after the existing query/data error classes)
+
+- [ ] **Step 1: Add the three error classes**
+
+Append to `packages/hub/src/errors.ts`:
+
+```ts
+// ─── Federation (multi-vault partition) Errors ──────────────────────────
+
+/**
+ * Thrown when a write targets a partition key that has no shard and
+ * `sharding.autoCreate` is disabled.
+ */
+export class UnknownShardError extends NoydbError {
+  readonly partitionKey: string
+
+  constructor(partitionKey: string, groupName: string) {
+    super(
+      'SHARD_UNKNOWN',
+      `No shard for partition key "${partitionKey}" in vault group "${groupName}" ` +
+        `and autoCreate is disabled. Call group.createShard(${JSON.stringify(partitionKey)}) ` +
+        `first, or enable sharding.autoCreate.`,
+    )
+    this.name = 'UnknownShardError'
+    this.partitionKey = partitionKey
+  }
+}
+
+/**
+ * Thrown by `createShard` when the registry has a row for a partition
+ * but the corresponding vault is not provisioned in the store —
+ * a registry/store divergence. Refusing to recreate avoids masking
+ * data loss.
+ */
+export class ShardProvisioningError extends NoydbError {
+  readonly vaultId: string
+
+  constructor(vaultId: string, partitionKey: string) {
+    super(
+      'SHARD_PROVISIONING',
+      `Registry has a row for partition "${partitionKey}" (vault "${vaultId}") but that ` +
+        `vault is not provisioned in the store. Refusing to recreate it — the registry and ` +
+        `store have diverged. Investigate before retrying.`,
+    )
+    this.name = 'ShardProvisioningError'
+    this.vaultId = vaultId
+  }
+}
+
+/** Thrown when a VaultGroup references a template name that was never registered. */
+export class VaultTemplateNotFoundError extends NoydbError {
+  readonly templateName: string
+
+  constructor(templateName: string) {
+    super(
+      'VAULT_TEMPLATE_NOT_FOUND',
+      `No vault template registered under "${templateName}". Register it with ` +
+        `db.withVaultTemplate(${JSON.stringify(templateName)}, { version, configure }) ` +
+        `before opening the vault group.`,
+    )
+    this.name = 'VaultTemplateNotFoundError'
+    this.templateName = templateName
+  }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `pnpm --filter @noy-db/hub exec tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/hub/src/errors.ts
+git commit -m "feat(federation): UnknownShardError / ShardProvisioningError / VaultTemplateNotFoundError"
+```
+
+---
+
+## Task 3: VaultGroup + createShard (with test harness)
+
+**Files:**
+- Create: `packages/hub/src/federation/vault-group.ts`
+- Create: `packages/hub/src/federation/index.ts`
+- Modify: `packages/hub/src/noydb.ts`
+- Test: `packages/hub/__tests__/federation-vault-group.test.ts`
+
+This task builds the `VaultGroup` skeleton, `createShard`, and wires `withVaultTemplate` / `openVaultGroup` / `_shardVaultProvisioned` onto `Noydb`. It establishes the shared test harness used by all later tasks.
+
+- [ ] **Step 1: Write the failing test (harness + createShard cases)**
+
+Create `packages/hub/__tests__/federation-vault-group.test.ts`:
+
+```ts
+/**
+ * MVF VaultGroup routing — milestone 16 MVP.
+ * Spec: docs/superpowers/specs/2026-06-07-mvf-vaultgroup-routing-mvp-design.md
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError, ShardProvisioningError, VaultTemplateNotFoundError, UnknownShardError } from '../src/errors.js'
+import { createNoydb } from '../src/noydb.js'
+import type { Noydb } from '../src/noydb.js'
+import type { Vault } from '../src/vault.js'
+import type { VaultRegistryRow } from '../src/federation/index.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+interface Invoice { clientId: string; amount: number; status: string }
+
+/** Build an operator db with the registry vault opened and a v1 client template registered. */
+async function harness(opts: { autoCreate?: boolean; templateVersion?: number } = {}) {
+  const adapter = memory()
+  const db = await createNoydb({ store: adapter, user: 'operator', secret: 'op-pass' })
+  db.withVaultTemplate('client-template', {
+    version: opts.templateVersion ?? 1,
+    configure(vault: Vault) {
+      vault.collection<Invoice>('invoices')
+    },
+  })
+  const stateVault = await db.openVault('state')
+  const registry = stateVault.collection<VaultRegistryRow>('vault-registry')
+  const firm = await db.openVaultGroup<Invoice>('firm-clients', {
+    registry,
+    sharding: {
+      keyOf: (r) => r.clientId,
+      vaultTemplate: 'client-template',
+      ...(opts.autoCreate !== undefined ? { autoCreate: opts.autoCreate } : {}),
+    },
+  })
+  return { adapter, db, registry, firm }
+}
+
+describe('VaultGroup — template + createShard', () => {
+  let h: Awaited<ReturnType<typeof harness>>
+  beforeEach(async () => { h = await harness() })
+
+  it('openVaultGroup throws when the template is unregistered', async () => {
+    const db = await createNoydb({ store: memory(), user: 'operator', secret: 'op-pass' })
+    const sv = await db.openVault('state')
+    await expect(
+      db.openVaultGroup<Invoice>('firm', {
+        registry: sv.collection<VaultRegistryRow>('vault-registry'),
+        sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'missing' },
+      }),
+    ).rejects.toBeInstanceOf(VaultTemplateNotFoundError)
+  })
+
+  it('createShard writes a registry row with the template version', async () => {
+    await h.firm.createShard('acme')
+    const row = await h.registry.get('acme')
+    expect(row).not.toBeNull()
+    expect(row!.vaultId).toBe('firm-clients--acme')
+    expect(row!.partitionKey).toBe('acme')
+    expect(row!.templateName).toBe('client-template')
+    expect(row!.schemaVersion).toBe(1)
+  })
+
+  it('createShard is idempotent — re-running returns a handle, no duplicate row', async () => {
+    await h.firm.createShard('acme')
+    await h.firm.createShard('acme') // no throw
+    const rows = await (async () => { await h.registry.list(); return h.registry.query().toArray() })()
+    expect(rows.filter((r) => r.partitionKey === 'acme')).toHaveLength(1)
+  })
+
+  it('createShard reconciles a provisioned-but-unregistered vault (row missing, vault exists)', async () => {
+    // Provision the shard vault directly, leaving the registry empty.
+    await h.db.openVault('firm-clients--acme')
+    const before = await h.registry.get('acme')
+    expect(before).toBeNull()
+    await h.firm.createShard('acme') // reconcile
+    const after = await h.registry.get('acme')
+    expect(after).not.toBeNull()
+  })
+
+  it('createShard throws ShardProvisioningError when the row exists but the vault is gone', async () => {
+    // Write a registry row pointing at a vault that was never provisioned.
+    await h.registry.put('ghost', {
+      vaultId: 'firm-clients--ghost', partitionKey: 'ghost',
+      templateName: 'client-template', schemaVersion: 1, createdAt: 1,
+    })
+    await expect(h.firm.createShard('ghost')).rejects.toBeInstanceOf(ShardProvisioningError)
+  })
+})
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `pnpm --filter @noy-db/hub exec vitest run __tests__/federation-vault-group.test.ts`
+Expected: FAIL — `db.withVaultTemplate is not a function` / `openVaultGroup` missing / cannot resolve `../src/federation/index.js`.
+
+- [ ] **Step 3: Write `vault-group.ts`**
+
+Create `packages/hub/src/federation/vault-group.ts`:
+
+```ts
+/**
+ * @category capability
+ * Multi-vault partition federation — VaultGroup transparent shard
+ * routing. Spec:
+ * docs/superpowers/specs/2026-06-07-mvf-vaultgroup-routing-mvp-design.md.
+ */
+import type { Noydb } from '../noydb.js'
+import type { Vault } from '../vault.js'
+import type { Collection } from '../collection.js'
+import { ShardProvisioningError, UnknownShardError } from '../errors.js'
+import type {
+  ShardingConfig,
+  VaultRegistryRow,
+  VaultTemplate,
+  FanoutQueryOptions,
+  FanoutResult,
+  SkippedVault,
+  WhereClause,
+} from './types.js'
+
+/** Keyring collection name — a provisioned encrypted vault has a row here. */
+const KEYRING_COLLECTION = '_keyring'
+
+export class VaultGroup<T> {
+  constructor(
+    /** @internal */ readonly db: Noydb,
+    /** @internal */ readonly name: string,
+    /** @internal */ readonly registry: Collection<VaultRegistryRow>,
+    /** @internal */ readonly sharding: ShardingConfig<T>,
+    /** @internal */ readonly template: VaultTemplate,
+  ) {}
+
+  /** Deterministic vault name for a partition key, namespaced by the group. */
+  shardVaultId(partitionKey: string): string {
+    return `${this.name}--${partitionKey}`
+  }
+
+  /** All registry rows (hydrates the registry collection first). */
+  async allRows(): Promise<VaultRegistryRow[]> {
+    await this.registry.list()
+    return this.registry.query().toArray()
+  }
+
+  /** Open an existing shard and apply the template. */
+  async openShard(partitionKey: string): Promise<Vault> {
+    const vault = await this.db.openVault(this.shardVaultId(partitionKey))
+    this.template.configure(vault)
+    return vault
+  }
+
+  /**
+   * Idempotently provision a shard for `partitionKey`. Returns the
+   * configured vault handle.
+   *
+   * - row + vault present → no-op, return handle
+   * - row present, vault gone → ShardProvisioningError
+   * - row absent (vault present or not) → open-or-create, configure, write row
+   */
+  async createShard(partitionKey: string): Promise<Vault> {
+    const vaultId = this.shardVaultId(partitionKey)
+    const row = await this.registry.get(partitionKey)
+    const provisioned = await this.db._shardVaultProvisioned(vaultId)
+
+    if (row && !provisioned) throw new ShardProvisioningError(vaultId, partitionKey)
+    if (row && provisioned) return this.openShard(partitionKey)
+
+    // Row absent → create (or reconcile a provisioned-but-unregistered vault).
+    const vault = await this.db.openVault(vaultId)
+    this.template.configure(vault)
+    await this.registry.put(partitionKey, {
+      vaultId,
+      partitionKey,
+      templateName: this.sharding.vaultTemplate,
+      schemaVersion: this.template.version,
+      createdAt: Date.now(),
+    })
+    return vault
+  }
+
+  /** Drill down to a single shard's full Collection API. Throws if the shard is unknown. */
+  async shard(partitionKey: string): Promise<Vault> {
+    const row = await this.registry.get(partitionKey)
+    if (!row) throw new UnknownShardError(partitionKey, this.name)
+    return this.openShard(partitionKey)
+  }
+
+  /** A sharded view over one logical collection across all shards. */
+  collection<R = T>(collectionName: string): ShardedCollection<T, R> {
+    return new ShardedCollection<T, R>(this, collectionName)
+  }
+}
+
+export class ShardedCollection<T, R = T> {
+  constructor(
+    private readonly group: VaultGroup<T>,
+    private readonly collectionName: string,
+  ) {}
+
+  /** Route a write to the shard owning `keyOf(record)`. */
+  async put(id: string, record: T): Promise<void> {
+    const key = this.group.sharding.keyOf(record)
+    const row = await this.group.registry.get(key)
+    let vault: Vault
+    if (!row) {
+      if (this.group.sharding.autoCreate === false) {
+        throw new UnknownShardError(key, this.group.name)
+      }
+      vault = await this.group.createShard(key)
+    } else {
+      vault = await this.group.openShard(key)
+    }
+    await vault.collection<T>(this.collectionName).put(id, record as T)
+  }
+
+  /** Begin a cross-shard fan-out query. */
+  query(): ShardedQuery<T, R> {
+    return new ShardedQuery<T, R>(this.group, this.collectionName, [])
+  }
+}
+
+export class ShardedQuery<T, R = T> {
+  constructor(
+    private readonly group: VaultGroup<T>,
+    private readonly collectionName: string,
+    private readonly clauses: readonly WhereClause[],
+  ) {}
+
+  where(field: string, op: WhereClause['op'], value: unknown): ShardedQuery<T, R> {
+    return new ShardedQuery<T, R>(this.group, this.collectionName, [
+      ...this.clauses,
+      { field, op, value },
+    ])
+  }
+
+  /** Fan out across eligible shards and merge results. */
+  async toArray(options: FanoutQueryOptions = {}): Promise<FanoutResult<R>> {
+    const rows = await this.group.allRows()
+    const skipped: SkippedVault[] = []
+    const eligible: VaultRegistryRow[] = []
+    for (const row of rows) {
+      if (options.minVersion !== undefined && row.schemaVersion < options.minVersion) {
+        skipped.push({ vaultId: row.vaultId, reason: 'schema-drift' })
+      } else {
+        eligible.push(row)
+      }
+    }
+
+    const across = await this.group.db.queryAcross<R[]>(
+      eligible.map((r) => r.vaultId),
+      async (vault) => {
+        this.group.template.configure(vault)
+        const coll = vault.collection<R>(this.collectionName)
+        await coll.list() // hydrate the in-memory cache before the sync query
+        let q = coll.query()
+        for (const c of this.clauses) q = q.where(c.field, c.op, c.value)
+        return q.toArray()
+      },
+      { concurrency: options.concurrency ?? 1 },
+    )
+
+    const results: R[] = []
+    for (const r of across) {
+      if (r.error) skipped.push({ vaultId: r.vault, reason: 'error', error: r.error })
+      else results.push(...r.result)
+    }
+    return { results, skippedVaults: skipped }
+  }
+}
+```
+
+- [ ] **Step 4: Write `federation/index.ts`**
+
+Create `packages/hub/src/federation/index.ts`:
+
+```ts
+export { VaultGroup, ShardedCollection, ShardedQuery } from './vault-group.js'
+export type {
+  VaultTemplate,
+  VaultRegistryRow,
+  ShardingConfig,
+  VaultGroupOptions,
+  FanoutQueryOptions,
+  FanoutResult,
+  SkippedVault,
+} from './types.js'
+```
+
+- [ ] **Step 5: Wire `Noydb` (noydb.ts)**
+
+Add the import near the other internal imports at the top of `packages/hub/src/noydb.ts`:
+
+```ts
+import { VaultGroup } from './federation/vault-group.js'
+import type { VaultTemplate, VaultGroupOptions } from './federation/types.js'
+import { VaultTemplateNotFoundError } from './errors.js'
+```
+(If `errors.js` is already imported, add `VaultTemplateNotFoundError` to that existing import list instead of adding a new line.)
+
+Add the field alongside the other `private readonly … = new Map()` declarations (near line 168):
+
+```ts
+  private readonly vaultTemplates = new Map<string, VaultTemplate>()
+```
+
+Add these three methods to the `Noydb` class (place them just after `queryAcross`):
+
+```ts
+  /**
+   * Register a shard schema blueprint. `createShard` / `openVaultGroup`
+   * stamp shards from the named template. See the MVF design spec.
+   */
+  withVaultTemplate(name: string, template: VaultTemplate): void {
+    this.vaultTemplates.set(name, template)
+  }
+
+  /**
+   * Open a VaultGroup — transparent routing over per-partition shard
+   * vaults, with shard discovery backed by the supplied `vault-registry`
+   * collection.
+   */
+  async openVaultGroup<T>(name: string, opts: VaultGroupOptions<T>): Promise<VaultGroup<T>> {
+    if (this.closed) throw new ValidationError('Instance is closed')
+    const template = this.vaultTemplates.get(opts.sharding.vaultTemplate)
+    if (!template) throw new VaultTemplateNotFoundError(opts.sharding.vaultTemplate)
+    return new VaultGroup<T>(this, name, opts.registry, opts.sharding, template)
+  }
+
+  /**
+   * @internal — true when an encrypted shard vault is provisioned
+   * (its keyring exists in the store).
+   */
+  async _shardVaultProvisioned(vaultId: string): Promise<boolean> {
+    return (await this.options.store.list(vaultId, '_keyring')).length > 0
+  }
+```
+(If `ValidationError` is not already imported in `noydb.ts`, add it — it is used elsewhere in the file, so it should already be present.)
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `pnpm --filter @noy-db/hub exec vitest run __tests__/federation-vault-group.test.ts`
+Expected: PASS — all five tests in the "template + createShard" describe block.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/hub/src/federation/ packages/hub/src/noydb.ts packages/hub/__tests__/federation-vault-group.test.ts
+git commit -m "feat(federation): VaultGroup + withVaultTemplate + openVaultGroup + idempotent createShard"
+```
+
+---
+
+## Task 4: Write routing (put)
+
+**Files:**
+- Test: `packages/hub/__tests__/federation-vault-group.test.ts` (append a describe block)
+- (Implementation already written in Task 3 — this task adds coverage and confirms behavior.)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/hub/__tests__/federation-vault-group.test.ts`:
+
+```ts
+describe('VaultGroup — write routing', () => {
+  it('put auto-creates the shard and routes the write (autoCreate default on)', async () => {
+    const h = await harness()
+    await h.firm.collection('invoices').put('inv-1', { clientId: 'acme', amount: 1200, status: 'open' })
+
+    // The shard exists and holds the record.
+    const acme = await h.firm.shard('acme')
+    const rec = await acme.collection<Invoice>('invoices').get('inv-1')
+    expect(rec).toEqual({ clientId: 'acme', amount: 1200, status: 'open' })
+
+    // A registry row was created.
+    expect(await h.registry.get('acme')).not.toBeNull()
+  })
+
+  it('put routes records with different partition keys to different shards', async () => {
+    const h = await harness()
+    await h.firm.collection('invoices').put('inv-a', { clientId: 'acme', amount: 100, status: 'open' })
+    await h.firm.collection('invoices').put('inv-b', { clientId: 'bigco', amount: 200, status: 'open' })
+
+    const acme = await h.firm.shard('acme')
+    const bigco = await h.firm.shard('bigco')
+    expect(await acme.collection<Invoice>('invoices').get('inv-b')).toBeNull()
+    expect(await bigco.collection<Invoice>('invoices').get('inv-a')).toBeNull()
+    expect(await bigco.collection<Invoice>('invoices').get('inv-b')).not.toBeNull()
+  })
+
+  it('put throws UnknownShardError when autoCreate is off and the shard is unknown', async () => {
+    const h = await harness({ autoCreate: false })
+    await expect(
+      h.firm.collection('invoices').put('inv-1', { clientId: 'acme', amount: 1, status: 'open' }),
+    ).rejects.toBeInstanceOf(UnknownShardError)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `pnpm --filter @noy-db/hub exec vitest run __tests__/federation-vault-group.test.ts -t "write routing"`
+Expected: PASS (the routing logic from Task 3 already implements this).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/hub/__tests__/federation-vault-group.test.ts
+git commit -m "test(federation): write-routing coverage (autoCreate, multi-shard, UnknownShardError)"
+```
+
+---
+
+## Task 5: Fan-out read + minSchemaVersion guard
+
+**Files:**
+- Test: `packages/hub/__tests__/federation-vault-group.test.ts` (append a describe block)
+- (Implementation already written in Task 3.)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/hub/__tests__/federation-vault-group.test.ts`:
+
+```ts
+describe('VaultGroup — fan-out read', () => {
+  it('merges matching records across shards', async () => {
+    const h = await harness()
+    const inv = h.firm.collection('invoices')
+    await inv.put('a-1', { clientId: 'acme', amount: 100, status: 'overdue' })
+    await inv.put('a-2', { clientId: 'acme', amount: 200, status: 'open' })
+    await inv.put('b-1', { clientId: 'bigco', amount: 300, status: 'overdue' })
+
+    const out = await h.firm.collection('invoices').query().where('status', '==', 'overdue').toArray()
+    expect(out.skippedVaults).toEqual([])
+    expect(out.results.map((r) => r.amount).sort((x, y) => x - y)).toEqual([100, 300])
+  })
+
+  it('minVersion guard moves behind-version shards into skippedVaults (not results)', async () => {
+    const adapter = memory()
+    const db = await createNoydb({ store: adapter, user: 'operator', secret: 'op-pass' })
+
+    // Register template v1, create shard A at v1.
+    db.withVaultTemplate('client-template', {
+      version: 1,
+      configure(vault: Vault) { vault.collection<Invoice>('invoices') },
+    })
+    const stateVault = await db.openVault('state')
+    const registry = stateVault.collection<VaultRegistryRow>('vault-registry')
+    let firm = await db.openVaultGroup<Invoice>('firm-clients', {
+      registry, sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template' },
+    })
+    await firm.collection('invoices').put('a-1', { clientId: 'acme', amount: 100, status: 'overdue' })
+
+    // Re-register the template at v2 and create shard B at v2.
+    db.withVaultTemplate('client-template', {
+      version: 2,
+      configure(vault: Vault) { vault.collection<Invoice>('invoices') },
+    })
+    firm = await db.openVaultGroup<Invoice>('firm-clients', {
+      registry, sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template' },
+    })
+    await firm.collection('invoices').put('b-1', { clientId: 'bigco', amount: 300, status: 'overdue' })
+
+    const out = await firm.collection('invoices').query()
+      .where('status', '==', 'overdue')
+      .toArray({ minVersion: 2 })
+
+    expect(out.results.map((r) => r.amount)).toEqual([300]) // only the v2 shard
+    expect(out.skippedVaults).toEqual([
+      { vaultId: 'firm-clients--acme', reason: 'schema-drift' },
+    ])
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `pnpm --filter @noy-db/hub exec vitest run __tests__/federation-vault-group.test.ts -t "fan-out read"`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/hub/__tests__/federation-vault-group.test.ts
+git commit -m "test(federation): cross-shard fan-out merge + minVersion schema-drift guard"
+```
+
+---
+
+## Task 6: Public exports
+
+**Files:**
+- Modify: `packages/hub/src/index.ts`
+
+- [ ] **Step 1: Add exports**
+
+Add to `packages/hub/src/index.ts` (near the other capability exports):
+
+```ts
+export { VaultGroup, ShardedCollection, ShardedQuery } from './federation/index.js'
+export type {
+  VaultTemplate,
+  VaultRegistryRow,
+  ShardingConfig,
+  VaultGroupOptions,
+  FanoutQueryOptions,
+  FanoutResult,
+  SkippedVault,
+} from './federation/index.js'
+export { UnknownShardError, ShardProvisioningError, VaultTemplateNotFoundError } from './errors.js'
+```
+(If `./errors.js` is already partially re-exported, add the three names to that existing export list rather than duplicating.)
+
+- [ ] **Step 2: Verify the package builds and types resolve**
+
+Run: `pnpm --filter @noy-db/hub exec tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 3: Run the full hub test suite to confirm no regressions**
+
+Run: `pnpm --filter @noy-db/hub test`
+Expected: PASS (existing suite green + the new federation file).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/hub/src/index.ts
+git commit -m "feat(federation): export VaultGroup public surface from @noy-db/hub"
+```
+
+---
+
+## Task 7: Subsystem doc + features.yaml registration
+
+**Files:**
+- Create: `docs/subsystems/vault-group.md`
+- Modify: `features.yaml`
+- Modify: `SUBSYSTEMS.md`
+
+- [ ] **Step 1: Write the subsystem doc**
+
+Create `docs/subsystems/vault-group.md`:
+
+```markdown
+# Vault Group — Multi-Vault Partition Federation (MVF)
+
+> Status: **preview** (milestone 16 MVP). Spec:
+> `docs/superpowers/specs/2026-06-07-mvf-vaultgroup-routing-mvp-design.md`.
+
+## Overview
+
+`VaultGroup` routes records across many per-partition shard vaults behind a
+single entry point, while every shard stays an ordinary noy-db vault within its
+small-DB ceiling. Shard discovery is backed by a `vault-registry` collection
+that is the single source of truth (no dependency on `listAccessibleVaults`, so
+it works on every backend).
+
+## API
+
+```ts
+db.withVaultTemplate('client-template', {
+  version: 1,
+  configure(vault) { vault.collection('invoices') },
+})
+
+const state = await db.openVault('state')
+const firm = await db.openVaultGroup('firm-clients', {
+  registry: state.collection('vault-registry'),
+  sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template', autoCreate: true },
+})
+
+// Transparent write — routed (and auto-provisioned) by partition key.
+await firm.collection('invoices').put('inv-1', { clientId: 'acme', amount: 1200, status: 'open' })
+
+// Cross-shard fan-out read.
+const { results, skippedVaults } = await firm.collection('invoices')
+  .query().where('status', '==', 'overdue').toArray({ minVersion: 1 })
+
+// Drill down to one shard's full Collection API.
+const acme = await firm.shard('acme')
+```
+
+## Guarantees & limits
+
+- The operator `Noydb` instance owns its shards (`createShard` provisions them).
+- `createShard` is idempotent; a registry row pointing at a missing vault raises
+  `ShardProvisioningError` rather than recreating it.
+- The `minVersion` guard pre-filters shards by their registry-recorded
+  `schemaVersion`; behind-version shards land in `skippedVaults`, never mixed
+  into `results`.
+- **Out of scope (this MVP):** cross-shard joins, push-model cross-vault
+  derivations (Insight Vault), reactive `queryAcrossLive`, `aggregateAcross`,
+  and the fleet schema-migration runner. See the spec's deferred-items list.
+```
+
+- [ ] **Step 2: Add the SUBSYSTEMS.md catalog row**
+
+In `SUBSYSTEMS.md`, change the catalog heading `## The 23 subsystems` to `## The 24 subsystems`, and add this row under the appropriate cluster table (Cluster — write/mutate or a federation cluster; place it after row 23):
+
+```markdown
+| 24 | `@noy-db/hub` (core) | Multi-vault partition federation — `db.openVaultGroup()` transparent shard routing + `vault-registry` source-of-truth + `minVersion` fan-out guard (MVP) | — | `queryAcross`, `permissions` |
+```
+
+- [ ] **Step 3: Add the features.yaml entry**
+
+Add to `features.yaml` under the `features:` list (follow the existing core-feature shape — `cluster`, `spec`, `subsystem_doc`, `factory` are required):
+
+```yaml
+  - id: vault-group-federation
+    name: Multi-vault partition federation (VaultGroup)
+    cluster: core
+    spec: docs/subsystems/vault-group.md#overview
+    subsystem_doc: docs/subsystems/vault-group.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    experimental: true
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'vault-registry is the single source of truth for shard discovery'
+      - 'createShard is idempotent; row-without-vault raises ShardProvisioningError'
+      - 'minVersion guard pre-filters shards by registry schemaVersion (no silent shape-mixing)'
+      - 'join.ts partitionScope seam is untouched (crossShardJoin deferred)'
+    related: [permissions, transferable-partition]
+```
+(Use `related` entries that exist in the registry; if `transferable-partition` is not a registered id, drop it and keep `[permissions]`. Verify ids with `grep "id:" features.yaml`.)
+
+- [ ] **Step 4: Validate the registry**
+
+Run: `node scripts/validate-features.mjs`
+Expected: PASS — `✓ features.yaml` (no schema, path, or spec-anchor failures).
+
+If it fails on `status` enum, confirm `status: preview` (allowed values: stable | preview | planned). If it fails on a missing `related` id, remove the offending id.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/subsystems/vault-group.md features.yaml SUBSYSTEMS.md
+git commit -m "docs(federation): vault-group subsystem doc + features.yaml registration + catalog row"
+```
+
+---
+
+## Task 8: Final verification
+
+- [ ] **Step 1: Full hub suite + typecheck + feature validation**
+
+Run:
+```bash
+pnpm --filter @noy-db/hub exec tsc --noEmit
+pnpm --filter @noy-db/hub test
+node scripts/validate-features.mjs
+```
+Expected: all PASS.
+
+- [ ] **Step 2: Confirm the join.ts invariant is untouched**
+
+Run: `git diff --stat main -- packages/hub/src/query/join.ts`
+Expected: no output (file unchanged) — the deferred-work boundary held.
+
+- [ ] **Step 3: Commit any remaining changes (if a formatter touched files)**
+
+```bash
+git add -A
+git commit -m "chore(federation): formatting/lint fixups" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review notes (for the implementer)
+
+- **Spec coverage:** withVaultTemplate (T3), createShard idempotency 4-case matrix (T3), VaultGroup/openVaultGroup (T3), write routing + autoCreate (T4), fan-out + skippedVaults + minVersion guard (T5), shard() drill-down (T3 helper + T4 usage), registry-as-source-of-truth (harness uses a real `vault-registry` collection), errors (T2). Deferred items are explicitly documented, not implemented.
+- **`shard()` drill-down** is exercised indirectly by the write-routing tests (`h.firm.shard('acme')`). If you want an explicit unit, add an `it('shard() throws UnknownShardError for an unknown key')` asserting `rejects.toBeInstanceOf(UnknownShardError)`.
+- **Type consistency:** `VaultRegistryRow` fields (`vaultId`, `partitionKey`, `templateName`, `schemaVersion`, `createdAt`) are identical in types.ts, the createShard writer, the test rows, and the guard reader. `ShardedCollection.query()` → `ShardedQuery` → `toArray(FanoutQueryOptions)` → `FanoutResult`.
+- **Encrypted-vault assumption:** `_shardVaultProvisioned` keys off the `_keyring` row, which only exists for encrypted vaults. The MVP assumes the DEK/grant model (encrypt !== false). Document if a plaintext path is ever needed (out of scope).
+```

--- a/docs/superpowers/specs/2026-06-07-mvf-vaultgroup-routing-mvp-design.md
+++ b/docs/superpowers/specs/2026-06-07-mvf-vaultgroup-routing-mvp-design.md
@@ -1,0 +1,220 @@
+# MVF VaultGroup Routing — Milestone 16 MVP Design
+
+- **Date:** 2026-06-07
+- **Milestone:** 16 — Multi-vault partition federation (epic #271)
+- **Status:** Design approved, pending implementation plan
+- **Scope:** First vertical slice — `withSharding`/`VaultGroup` transparent routing + minimal StateManagement `vault-registry`
+
+## Goal
+
+Deliver the headline `withSharding` primitive from the multi-vault partition
+federation epic as a single, self-contained vertical slice: stamp per-partition
+shards from a template, route writes transparently by partition key, and fan
+out reads across shards — all backed by a minimal `vault-registry` control-plane
+collection that is the authoritative source of shard discovery (closing the
+`listAccessibleVaults` backend-capability gap on S3 / DynamoDB / browser stores).
+
+Every individual shard remains an ordinary noy-db vault within its own
+small-DB ceiling; this epic adds automation and an entry point *above* them.
+
+## Scope
+
+### In scope
+
+- `withVaultTemplate(name, spec)` — register a schema blueprint carrying a `version`.
+- `createShard(partitionKey)` — idempotently stamp a shard from a template and
+  record its registry row.
+- `openVaultGroup(name, opts)` → `VaultGroup` + `ShardedCollection<T>`.
+- Transparent **write routing** by partition key, with `autoCreate` (default **on**).
+- Cross-shard **fan-out read**: `.query().where(...).toArray()` →
+  `{ results, skippedVaults }` with a `minSchemaVersion` guard.
+- `firm.shard(key)` — drill-down to a single shard's full `Collection` API.
+- Minimal StateManagement **`vault-registry`** collection as the source of truth
+  for shard discovery.
+
+### Explicitly deferred (with reason)
+
+- `crossShardJoin` — would touch the `partitionScope: 'all'` invariant in
+  `packages/hub/src/query/join.ts` (🔴 blocking conflict in the epic). **The MVP
+  does not modify that seam.**
+- `withCrossVaultDerivation` (Insight Vault push model) — the 🔴 cross-vault DEK
+  invariant conflict (dim14). Deferred wholesale.
+- `queryAcrossLive` (reactive fan-in), `aggregateAcross` (distributed reduce).
+- Fleet schema-migration runner (lazy / active / staged rollout).
+- StateManagement `schema-manifest`, `migration-status`, `deployment-events`
+  collections — only `vault-registry` is in scope.
+
+By deferring `crossShardJoin` and `withCrossVaultDerivation`, the MVP touches
+**neither** of the epic's two 🔴 blocking conflicts.
+
+## Architecture
+
+A single operator `Noydb` instance owns the `store` and holds grants for all
+shards it manages. `createShard` makes the operator the owner of each new shard.
+(The dedicated service-account / least-privilege executor identity question from
+the epic concerns the deferred cross-vault derivation executor, not routing.)
+
+```
+            operator Noydb instance (one store, many vaults)
+                              │
+          ┌───────────────────┼────────────────────────┐
+          │                   │                         │
+   StateManagement      VaultGroup 'firm-clients'   (other vaults…)
+   vault                 ├─ template: client-template@v3
+   └─ vault-registry     ├─ keyOf: r => r.clientId
+      (source of truth)  └─ ShardedCollection<T>
+          ▲                   │ routes to ▼
+          │            shard: client-acme   shard: client-bigco   …N
+          └──── discovery ────┘ (ordinary noy-db vaults)
+```
+
+### Components
+
+#### `withVaultTemplate(name, spec)`
+
+Registers a schema blueprint on the `Noydb` instance (or VaultGroup).
+
+```ts
+db.withVaultTemplate('client-template', {
+  version: 3,                 // schema generation this blueprint produces
+  configure(vault) {          // re-applied on every shard-collection open
+    vault.collection('invoices', { indexes: [...], schema: invoiceSchema })
+    vault.collection('ledger',   { schema: ledgerSchema })
+  },
+})
+```
+
+noy-db has no global per-vault schema registry — `collection()` options are
+re-declared on every call. The template captures those options as a `configure`
+function that `ShardedCollection` re-invokes so every routed handle is configured
+identically. `version` is recorded into each shard's registry row at
+`createShard` time and is the data source for the fan-out guard.
+
+#### `openVaultGroup(name, opts)` → `VaultGroup`
+
+```ts
+const firm = await db.openVaultGroup('firm-clients', {
+  registry: stateVault.collection('vault-registry'), // passed-in handle (bootstrap, below)
+  sharding: {
+    keyOf: (r) => r.clientId,
+    vaultTemplate: 'client-template',
+    autoCreate: true,
+  },
+})
+```
+
+#### `ShardedCollection<T>` — `firm.collection('invoices')`
+
+- `.put(record)` — `keyOf(record)` → registry lookup → (autoCreate if missing) →
+  route to that one shard.
+- `.query().where(...).toArray()` — fan-out via `queryAcross` →
+  `{ results, skippedVaults }`.
+- `firm.shard(key)` — returns the underlying `Vault` (full Collection API; escape
+  hatch for full-detail drill-down).
+
+#### `createShard(partitionKey)` — idempotent
+
+Vault-create and registry-write are two steps; `createShard` is re-runnable and
+defines every partial-failure case:
+
+| vault | registry row | action |
+|---|---|---|
+| missing | missing | create vault, apply template, write row |
+| exists | missing | reconcile — re-write row, do not error |
+| missing | exists | throw `ShardProvisioningError` (do not silently recreate — could mask data loss) |
+| exists | exists | no-op, return existing handle |
+
+### Data model — `vault-registry` row
+
+```ts
+interface VaultRegistryRow {
+  vaultId: string        // noy-db vault name, e.g. "client-acme"
+  partitionKey: string   // what keyOf() returns, e.g. "acme"
+  templateName: string   // "client-template"
+  schemaVersion: number  // copied from template.version at createShard
+  createdAt: number
+}
+```
+
+The registry is the single source of truth for discovery. `VaultGroup` never
+uses `listAccessibleVaults` for discovery — one consistent, backend-agnostic
+code path.
+
+### The `minSchemaVersion` guard
+
+- The registry rows give the candidate shard set for a fan-out.
+- The guard is a **plaintext pre-filter over registry rows**: any row whose
+  `schemaVersion < minVersion` is moved into `skippedVaults` *before* its vault
+  is opened — so a mismatched shard is never cracked open and never silently
+  mixes a different record shape into `results`.
+- Versions differ only when templates are versioned across `createShard` calls.
+  This is also the guard's test (see below); without it the guard ships untested
+  because all-from-one-template shards always yield `skippedVaults: []`.
+
+### Data flow
+
+**Write:** `put(rec)` → `keyOf(rec) = 'acme'` → registry lookup
+- hit → `openVault('client-acme')`, apply template, `collection('invoices').put(rec)`
+- miss + `autoCreate` → `createShard('acme')`, then route
+- miss + `!autoCreate` → `UnknownShardError`
+
+**Read:** `query().where('status','==','overdue').toArray()`
+→ read registry rows → version pre-filter → `queryAcross(eligibleVaultIds, v =>
+v.collection('invoices').query().where(...).toArray(), { concurrency })`
+→ flatten `result` slots into `results`; collect errored / version-filtered slots
+into `skippedVaults` with a `reason` (`'schema-drift'` | `'error'`).
+
+## Registry bootstrap
+
+The `vault-registry` lives in a normal noy-db vault (the StateManagement vault),
+opened by the operator instance. The **caller** opens/creates it and passes the
+collection handle into `openVaultGroup`. `VaultGroup` never self-bootstraps a
+vault — no chicken-and-egg.
+
+## Error handling
+
+- `UnknownShardError` — write to an unknown partition key with `autoCreate` off.
+- `ShardProvisioningError` — registry row exists but the vault is gone.
+- `VaultTemplateNotFoundError` — `vaultTemplate` names an unregistered template.
+- Per-shard fan-out failures become `skippedVaults` entries (mirrors
+  `queryAcross`'s swallow-into-result-slot behavior); a fan-out never throws as
+  a whole because one shard failed.
+
+## Invariants preserved
+
+- `packages/hub/src/query/join.ts` `partitionScope: 'all'` seam is **untouched**.
+  Cross-vault correlation still goes through `queryAcross`; `crossShardJoin` is
+  deferred. Any edit there would be scope creep into deferred join work.
+- Per-shard ZK / DEK boundary unchanged — no cross-vault derivation in the MVP.
+
+## Testing strategy
+
+- Template registration + `VaultTemplateNotFoundError`.
+- `createShard` idempotency — all four partial-failure rows above.
+- Write routing: hit, miss+autoCreate, miss+`UnknownShardError`.
+- Fan-out merge across ≥3 shards; `concurrency` honored; per-shard error → `skippedVaults`.
+- **Guard sequence:** register template v1 → `createShard('A')`; bump template to
+  v2 → `createShard('B')`; `query({ minVersion: 2 }).toArray()` → `B` in `results`,
+  `A` in `skippedVaults` with `reason: 'schema-drift'`.
+- `firm.shard(key)` drill-down returns a fully-configured `Vault` Collection.
+
+## Relationship to existing work
+
+| Prior work | Relationship |
+|---|---|
+| `queryAcross` (`noydb.ts:932`) | Internal engine for `ShardedCollection.query().toArray()` |
+| `openVault` (`noydb.ts:405`, open-or-create) | Underlying shard open/create primitive |
+| `grant` (`noydb.ts:623`) | Operator identity holds shard grants |
+| `partitionScope: 'all'` seam (`join.ts:95`) | Reserved for deferred `crossShardJoin`; untouched here |
+| `vault.collection()` per-call options (`vault.ts:522`) | Captured by the vault template's `configure` |
+| `extractPartition` / `adoptPartition` (milestone 10) | The "client leaves" provisioning ceremony for a shard (out of MVP scope, composes later) |
+
+## Open items deferred to follow-up slices
+
+- Insight Vault push-model derivation (`withCrossVaultDerivation`).
+- `crossShardJoin` programmatic API (extends `partitionScope` seam).
+- `queryAcrossLive`, `aggregateAcross`.
+- Fleet schema-migration runner + `schema-manifest` / `migration-status` /
+  `deployment-events`.
+- Keyed point-reads on `ShardedCollection` (`.get(key, id)`, `.delete(key, id)`).
+- Data-residency routing constraint on shard selection.

--- a/features.yaml
+++ b/features.yaml
@@ -1002,7 +1002,9 @@ features:
     factory: null
     status: preview
     experimental: true
-    showcases: []
+    showcases:
+      - id: 98-vault-group-federation
+        path: showcases/src/98-vault-group-federation.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []

--- a/features.yaml
+++ b/features.yaml
@@ -993,6 +993,26 @@ features:
       - 'opt-in via db.onWriteConflict / db.enableTabCoordination; base is null when history is unavailable (default NO_HISTORY)'
     related: [cross-tab-write-propagation, write-lifecycle-hooks]
 
+  - id: vault-group-federation
+    name: Multi-vault partition federation (VaultGroup)
+    cluster: core
+    spec: docs/subsystems/vault-group.md#overview
+    subsystem_doc: docs/subsystems/vault-group.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    experimental: true
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'vault-registry is the single source of truth for shard discovery'
+      - 'createShard is idempotent; row-without-vault raises ShardProvisioningError'
+      - 'minVersion guard pre-filters shards by registry schemaVersion (no silent shape-mixing)'
+      - 'join.ts partitionScope seam is untouched (crossShardJoin deferred)'
+    related: [permissions, transferable-partition]
+
 # ─── Storage adapters (phase 2) ──────────────────────────────────────
 
 adapters:

--- a/packages/hub/__tests__/federation-vault-group.test.ts
+++ b/packages/hub/__tests__/federation-vault-group.test.ts
@@ -306,3 +306,40 @@ describe('classifyShardSkip', () => {
     expect(classifyShardSkip(new Error('store boom'))).toBe('error')
   })
 })
+
+describe('VaultGroup — key-custody-neutral fan-out', () => {
+  it('non-granted shard → no-grant skip on fan-out; clean throw on drill-down/put; zero self-provision', async () => {
+    const adapter = memory()
+    const op = await createNoydb({ store: adapter, user: 'operator', secret: 'op-pass' })
+    op.withVaultTemplate('t', { version: 1, configure: (v: Vault) => { v.collection<Invoice>('invoices') } })
+    const opState = await op.openVault('state')
+    const opFirm = await op.openVaultGroup<Invoice>('firm', {
+      registry: opState.collection<VaultRegistryRow>('vault-registry'),
+      sharding: { keyOf: (r) => r.clientId, vaultTemplate: 't' },
+    })
+    await opFirm.collection('invoices').put('a1', { clientId: 'acme', amount: 100, status: 'overdue' })
+    await opFirm.collection('invoices').put('b1', { clientId: 'beta', amount: 200, status: 'overdue' })
+    await op.grant('firm--acme', { userId: 'advisor', displayName: 'Adv', role: 'viewer', passphrase: 'adv-pass' })
+    await op.grant('state', { userId: 'advisor', displayName: 'Adv', role: 'viewer', passphrase: 'adv-pass' })
+
+    const adv = await createNoydb({ store: adapter, user: 'advisor', secret: 'adv-pass' })
+    adv.withVaultTemplate('t', { version: 1, configure: (v: Vault) => { v.collection<Invoice>('invoices') } })
+    const advState = await adv.openVault('state')
+    const advFirm = await adv.openVaultGroup<Invoice>('firm', {
+      registry: advState.collection<VaultRegistryRow>('vault-registry'),
+      sharding: { keyOf: (r) => r.clientId, vaultTemplate: 't' },
+    })
+
+    const out = await advFirm.collection('invoices').query().where('status', '==', 'overdue').toArray()
+    expect(out.results.map((r) => r.amount)).toEqual([100])             // acme only (granted)
+    expect(out.skippedVaults.find((s) => s.vaultId === 'firm--beta')?.reason).toBe('no-grant')
+    expect(await adapter.get('firm--beta', '_keyring', 'advisor')).toBeNull()  // no self-provision
+
+    await expect(advFirm.shard('beta')).rejects.toBeInstanceOf(NoAccessError)
+    expect(await adapter.get('firm--beta', '_keyring', 'advisor')).toBeNull()
+    await expect(
+      advFirm.collection('invoices').put('x', { clientId: 'beta', amount: 9, status: 'open' }),
+    ).rejects.toBeInstanceOf(NoAccessError)
+    expect(await adapter.get('firm--beta', '_keyring', 'advisor')).toBeNull()
+  })
+})

--- a/packages/hub/__tests__/federation-vault-group.test.ts
+++ b/packages/hub/__tests__/federation-vault-group.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
-import { ConflictError, ShardProvisioningError, VaultTemplateNotFoundError, UnknownShardError } from '../src/errors.js'
+import { ConflictError, ShardProvisioningError, VaultTemplateNotFoundError, UnknownShardError, ValidationError } from '../src/errors.js'
 import { createNoydb } from '../src/noydb.js'
 import type { Noydb } from '../src/noydb.js'
 import type { Vault } from '../src/vault.js'
@@ -207,6 +207,25 @@ describe('VaultGroup — fan-out read', () => {
     ])
   })
 
+  it('a registry row whose vault is unprovisioned surfaces as skippedVaults reason "error" (no silent recreate)', async () => {
+    const h = await harness()
+    // Real provisioned shard with data.
+    await h.firm.collection('invoices').put('a-1', { clientId: 'acme', amount: 100, status: 'overdue' })
+    // Divergent registry row: points at a vault that was never provisioned.
+    await h.registry.put('ghost', {
+      vaultId: 'firm-clients--ghost', partitionKey: 'ghost',
+      templateName: 'client-template', schemaVersion: 1, createdAt: 1,
+    })
+
+    const out = await h.firm.collection('invoices').query().where('status', '==', 'overdue').toArray()
+
+    expect(out.results.map((r) => r.amount)).toEqual([100]) // acme only
+    const ghost = out.skippedVaults.find((s) => s.vaultId === 'firm-clients--ghost')
+    expect(ghost).toBeDefined()
+    expect(ghost!.reason).toBe('error')
+    expect(ghost!.error).toBeInstanceOf(ShardProvisioningError)
+  })
+
   it('a per-shard read failure lands in skippedVaults with reason "error" (fan-out not aborted)', async () => {
     // Write with one db, then read with a FRESH db (empty caches) so the
     // fan-out actually re-hydrates from the store and re-hits list(). The
@@ -253,5 +272,27 @@ describe('VaultGroup — fan-out read', () => {
     expect(out.skippedVaults[0]!.vaultId).toBe('firm-clients--bigco')
     expect(out.skippedVaults[0]!.reason).toBe('error')
     expect(out.skippedVaults[0]!.error).toBeInstanceOf(Error)
+  })
+})
+
+describe('VaultGroup — partition key validation', () => {
+  it('rejects a partitionKey containing the "--" separator', async () => {
+    const h = await harness()
+    await expect(h.firm.createShard('a--b')).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it('rejects a partitionKey with store-unsafe characters', async () => {
+    const h = await harness()
+    await expect(h.firm.createShard('a/b')).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it('rejects an empty partitionKey', async () => {
+    const h = await harness()
+    await expect(h.firm.createShard('')).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it('accepts ordinary hyphenated keys (e.g. UUID-like)', async () => {
+    const h = await harness()
+    await expect(h.firm.createShard('acme-corp-2026')).resolves.toBeDefined()
   })
 })

--- a/packages/hub/__tests__/federation-vault-group.test.ts
+++ b/packages/hub/__tests__/federation-vault-group.test.ts
@@ -1,0 +1,125 @@
+/**
+ * MVF VaultGroup routing — milestone 16 MVP.
+ * Spec: docs/superpowers/specs/2026-06-07-mvf-vaultgroup-routing-mvp-design.md
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError, ShardProvisioningError, VaultTemplateNotFoundError, UnknownShardError } from '../src/errors.js'
+import { createNoydb } from '../src/noydb.js'
+import type { Noydb } from '../src/noydb.js'
+import type { Vault } from '../src/vault.js'
+import type { VaultRegistryRow } from '../src/federation/index.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+interface Invoice { clientId: string; amount: number; status: string }
+
+/** Build an operator db with the registry vault opened and a v1 client template registered. */
+async function harness(opts: { autoCreate?: boolean; templateVersion?: number } = {}) {
+  const adapter = memory()
+  const db = await createNoydb({ store: adapter, user: 'operator', secret: 'op-pass' })
+  db.withVaultTemplate('client-template', {
+    version: opts.templateVersion ?? 1,
+    configure(vault: Vault) {
+      vault.collection<Invoice>('invoices')
+    },
+  })
+  const stateVault = await db.openVault('state')
+  const registry = stateVault.collection<VaultRegistryRow>('vault-registry')
+  const firm = await db.openVaultGroup<Invoice>('firm-clients', {
+    registry,
+    sharding: {
+      keyOf: (r) => r.clientId,
+      vaultTemplate: 'client-template',
+      ...(opts.autoCreate !== undefined ? { autoCreate: opts.autoCreate } : {}),
+    },
+  })
+  return { adapter, db, registry, firm }
+}
+
+describe('VaultGroup — template + createShard', () => {
+  let h: Awaited<ReturnType<typeof harness>>
+  beforeEach(async () => { h = await harness() })
+
+  it('openVaultGroup throws when the template is unregistered', async () => {
+    const db = await createNoydb({ store: memory(), user: 'operator', secret: 'op-pass' })
+    const sv = await db.openVault('state')
+    await expect(
+      db.openVaultGroup<Invoice>('firm', {
+        registry: sv.collection<VaultRegistryRow>('vault-registry'),
+        sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'missing' },
+      }),
+    ).rejects.toBeInstanceOf(VaultTemplateNotFoundError)
+  })
+
+  it('createShard writes a registry row with the template version', async () => {
+    await h.firm.createShard('acme')
+    const row = await h.registry.get('acme')
+    expect(row).not.toBeNull()
+    expect(row!.vaultId).toBe('firm-clients--acme')
+    expect(row!.partitionKey).toBe('acme')
+    expect(row!.templateName).toBe('client-template')
+    expect(row!.schemaVersion).toBe(1)
+  })
+
+  it('createShard is idempotent — re-running returns a handle, no duplicate row', async () => {
+    await h.firm.createShard('acme')
+    await h.firm.createShard('acme') // no throw
+    const rows = await (async () => { await h.registry.list(); return h.registry.query().toArray() })()
+    expect(rows.filter((r) => r.partitionKey === 'acme')).toHaveLength(1)
+  })
+
+  it('createShard reconciles a provisioned-but-unregistered vault (row missing, vault exists)', async () => {
+    // Provision the shard vault directly, leaving the registry empty.
+    await h.db.openVault('firm-clients--acme')
+    const before = await h.registry.get('acme')
+    expect(before).toBeNull()
+    await h.firm.createShard('acme') // reconcile
+    const after = await h.registry.get('acme')
+    expect(after).not.toBeNull()
+  })
+
+  it('createShard throws ShardProvisioningError when the row exists but the vault is gone', async () => {
+    // Write a registry row pointing at a vault that was never provisioned.
+    await h.registry.put('ghost', {
+      vaultId: 'firm-clients--ghost', partitionKey: 'ghost',
+      templateName: 'client-template', schemaVersion: 1, createdAt: 1,
+    })
+    await expect(h.firm.createShard('ghost')).rejects.toBeInstanceOf(ShardProvisioningError)
+  })
+})

--- a/packages/hub/__tests__/federation-vault-group.test.ts
+++ b/packages/hub/__tests__/federation-vault-group.test.ts
@@ -4,7 +4,8 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
-import { ConflictError, ShardProvisioningError, VaultTemplateNotFoundError, UnknownShardError, ValidationError } from '../src/errors.js'
+import { ConflictError, ShardProvisioningError, VaultTemplateNotFoundError, UnknownShardError, ValidationError, NoAccessError, InvalidKeyError, KeyringCorruptError } from '../src/errors.js'
+import { classifyShardSkip } from '../src/federation/classify-skip.js'
 import { createNoydb } from '../src/noydb.js'
 import type { Noydb } from '../src/noydb.js'
 import type { Vault } from '../src/vault.js'
@@ -294,5 +295,14 @@ describe('VaultGroup — partition key validation', () => {
   it('accepts ordinary hyphenated keys (e.g. UUID-like)', async () => {
     const h = await harness()
     await expect(h.firm.createShard('acme-corp-2026')).resolves.toBeDefined()
+  })
+})
+
+describe('classifyShardSkip', () => {
+  it('NoAccessError → no-grant; corruption/credential/other → error', () => {
+    expect(classifyShardSkip(new NoAccessError('x'))).toBe('no-grant')
+    expect(classifyShardSkip(new InvalidKeyError())).toBe('error')
+    expect(classifyShardSkip(new KeyringCorruptError({ failedCollections: ['c'], intactCount: 0 }))).toBe('error')
+    expect(classifyShardSkip(new Error('store boom'))).toBe('error')
   })
 })

--- a/packages/hub/__tests__/federation-vault-group.test.ts
+++ b/packages/hub/__tests__/federation-vault-group.test.ts
@@ -123,3 +123,37 @@ describe('VaultGroup — template + createShard', () => {
     await expect(h.firm.createShard('ghost')).rejects.toBeInstanceOf(ShardProvisioningError)
   })
 })
+
+describe('VaultGroup — write routing', () => {
+  it('put auto-creates the shard and routes the write (autoCreate default on)', async () => {
+    const h = await harness()
+    await h.firm.collection('invoices').put('inv-1', { clientId: 'acme', amount: 1200, status: 'open' })
+
+    // The shard exists and holds the record.
+    const acme = await h.firm.shard('acme')
+    const rec = await acme.collection<Invoice>('invoices').get('inv-1')
+    expect(rec).toEqual({ clientId: 'acme', amount: 1200, status: 'open' })
+
+    // A registry row was created.
+    expect(await h.registry.get('acme')).not.toBeNull()
+  })
+
+  it('put routes records with different partition keys to different shards', async () => {
+    const h = await harness()
+    await h.firm.collection('invoices').put('inv-a', { clientId: 'acme', amount: 100, status: 'open' })
+    await h.firm.collection('invoices').put('inv-b', { clientId: 'bigco', amount: 200, status: 'open' })
+
+    const acme = await h.firm.shard('acme')
+    const bigco = await h.firm.shard('bigco')
+    expect(await acme.collection<Invoice>('invoices').get('inv-b')).toBeNull()
+    expect(await bigco.collection<Invoice>('invoices').get('inv-a')).toBeNull()
+    expect(await bigco.collection<Invoice>('invoices').get('inv-b')).not.toBeNull()
+  })
+
+  it('put throws UnknownShardError when autoCreate is off and the shard is unknown', async () => {
+    const h = await harness({ autoCreate: false })
+    await expect(
+      h.firm.collection('invoices').put('inv-1', { clientId: 'acme', amount: 1, status: 'open' }),
+    ).rejects.toBeInstanceOf(UnknownShardError)
+  })
+})

--- a/packages/hub/__tests__/federation-vault-group.test.ts
+++ b/packages/hub/__tests__/federation-vault-group.test.ts
@@ -157,3 +157,101 @@ describe('VaultGroup — write routing', () => {
     ).rejects.toBeInstanceOf(UnknownShardError)
   })
 })
+
+describe('VaultGroup — fan-out read', () => {
+  it('merges matching records across shards', async () => {
+    const h = await harness()
+    const inv = h.firm.collection('invoices')
+    await inv.put('a-1', { clientId: 'acme', amount: 100, status: 'overdue' })
+    await inv.put('a-2', { clientId: 'acme', amount: 200, status: 'open' })
+    await inv.put('b-1', { clientId: 'bigco', amount: 300, status: 'overdue' })
+
+    const out = await h.firm.collection('invoices').query().where('status', '==', 'overdue').toArray()
+    expect(out.skippedVaults).toEqual([])
+    expect(out.results.map((r) => r.amount).sort((x, y) => x - y)).toEqual([100, 300])
+  })
+
+  it('minVersion guard moves behind-version shards into skippedVaults (not results)', async () => {
+    const adapter = memory()
+    const db = await createNoydb({ store: adapter, user: 'operator', secret: 'op-pass' })
+
+    // Register template v1, create shard A at v1.
+    db.withVaultTemplate('client-template', {
+      version: 1,
+      configure(vault: Vault) { vault.collection<Invoice>('invoices') },
+    })
+    const stateVault = await db.openVault('state')
+    const registry = stateVault.collection<VaultRegistryRow>('vault-registry')
+    let firm = await db.openVaultGroup<Invoice>('firm-clients', {
+      registry, sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template' },
+    })
+    await firm.collection('invoices').put('a-1', { clientId: 'acme', amount: 100, status: 'overdue' })
+
+    // Re-register the template at v2 and create shard B at v2.
+    db.withVaultTemplate('client-template', {
+      version: 2,
+      configure(vault: Vault) { vault.collection<Invoice>('invoices') },
+    })
+    firm = await db.openVaultGroup<Invoice>('firm-clients', {
+      registry, sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template' },
+    })
+    await firm.collection('invoices').put('b-1', { clientId: 'bigco', amount: 300, status: 'overdue' })
+
+    const out = await firm.collection('invoices').query()
+      .where('status', '==', 'overdue')
+      .toArray({ minVersion: 2 })
+
+    expect(out.results.map((r) => r.amount)).toEqual([300]) // only the v2 shard
+    expect(out.skippedVaults).toEqual([
+      { vaultId: 'firm-clients--acme', reason: 'schema-drift' },
+    ])
+  })
+
+  it('a per-shard read failure lands in skippedVaults with reason "error" (fan-out not aborted)', async () => {
+    // Write with one db, then read with a FRESH db (empty caches) so the
+    // fan-out actually re-hydrates from the store and re-hits list(). The
+    // injected failure targets only the invoices collection of one shard;
+    // keyring load (collection '_keyring') is unaffected, so the shard
+    // opens and the failure surfaces inside the fan-out callback.
+    const base = memory()
+    let failBigco = false
+    const adapter: NoydbStore = {
+      ...base,
+      async list(c, col) {
+        if (failBigco && c === 'firm-clients--bigco' && col === 'invoices') {
+          throw new Error('injected list failure')
+        }
+        return base.list(c, col)
+      },
+    }
+    const tmpl = (vault: Vault) => { vault.collection<Invoice>('invoices') }
+
+    // --- write side ---
+    const wdb = await createNoydb({ store: adapter, user: 'operator', secret: 'op-pass' })
+    wdb.withVaultTemplate('client-template', { version: 1, configure: tmpl })
+    const wState = await wdb.openVault('state')
+    const wFirm = await wdb.openVaultGroup<Invoice>('firm-clients', {
+      registry: wState.collection<VaultRegistryRow>('vault-registry'),
+      sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template' },
+    })
+    await wFirm.collection('invoices').put('a-1', { clientId: 'acme', amount: 100, status: 'overdue' })
+    await wFirm.collection('invoices').put('b-1', { clientId: 'bigco', amount: 300, status: 'overdue' })
+
+    // --- read side: fresh db, caches empty ---
+    failBigco = true
+    const rdb = await createNoydb({ store: adapter, user: 'operator', secret: 'op-pass' })
+    rdb.withVaultTemplate('client-template', { version: 1, configure: tmpl })
+    const rState = await rdb.openVault('state')
+    const rFirm = await rdb.openVaultGroup<Invoice>('firm-clients', {
+      registry: rState.collection<VaultRegistryRow>('vault-registry'),
+      sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template' },
+    })
+
+    const out = await rFirm.collection('invoices').query().where('status', '==', 'overdue').toArray()
+    expect(out.results.map((r) => r.amount)).toEqual([100]) // bigco failed, acme survived
+    expect(out.skippedVaults).toHaveLength(1)
+    expect(out.skippedVaults[0]!.vaultId).toBe('firm-clients--bigco')
+    expect(out.skippedVaults[0]!.reason).toBe('error')
+    expect(out.skippedVaults[0]!.error).toBeInstanceOf(Error)
+  })
+})

--- a/packages/hub/__tests__/reducer-merge.test.ts
+++ b/packages/hub/__tests__/reducer-merge.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { sum, count, avg, min, max } from '../src/aggregate/reducers.js'
+
+function stateOf(r: any, records: unknown[]) { let s = r.init(); for (const rec of records) s = r.step(s, rec); return s }
+
+describe('Reducer.merge', () => {
+  const A = [{ v: 10 }, { v: 20 }]
+  const B = [{ v: 30 }]
+  const cases: [string, () => any][] = [
+    ['sum', () => sum('v')], ['count', () => count()], ['avg', () => avg('v')], ['min', () => min('v')], ['max', () => max('v')],
+  ]
+  for (const [name, make] of cases) {
+    it(`${name}: merge is present, commutative, identity, and merge-then-finalize == reduce(A∪B)`, () => {
+      const r = make()
+      expect(typeof r.merge).toBe('function')
+      const sA = stateOf(r, A), sB = stateOf(r, B)
+      const whole = r.finalize(stateOf(r, [...A, ...B]))
+      expect(r.finalize(r.merge(sA, sB))).toEqual(whole)              // merge-then-finalize == reduce over concatenation
+      expect(r.finalize(r.merge(sB, sA))).toEqual(whole)              // commutative
+      expect(r.finalize(r.merge(r.init(), sA))).toEqual(r.finalize(sA)) // identity (init is neutral)
+    })
+  }
+  it('associativity (sum)', () => {
+    const r = sum('v')
+    const a = stateOf(r, [{v:1}]), b = stateOf(r, [{v:2}]), c = stateOf(r, [{v:3}])
+    expect(r.finalize(r.merge(r.merge(a, b), c))).toEqual(r.finalize(r.merge(a, r.merge(b, c))))
+  })
+})

--- a/packages/hub/src/aggregate/reducers.ts
+++ b/packages/hub/src/aggregate/reducers.ts
@@ -61,6 +61,13 @@ export interface Reducer<R, S = R> {
   /** Collapse the internal state into the user-visible result. */
   finalize(state: S): R
   /**
+   * Combine two independent partial states into one (then `finalize` once).
+   * Optional. MUST be associative + commutative with `init()` as identity.
+   * Never merge finalized results — only states. Enables parallel /
+   * hierarchical aggregation (e.g. cross-shard or advisor→firm rollup).
+   */
+  merge?(a: S, b: S): S
+  /**
    * Identifying operation tag stamped by each built-in factory.
    * Used by `summariseAggregateOp` in the introspection walker to
    * render human-readable aggregate descriptors in `dumpSchema()`.
@@ -113,6 +120,7 @@ export function count(opts?: ReducerOptions<number>): Reducer<number> {
     step: (state) => state + 1,
     remove: (state) => state - 1,
     finalize: (state) => state,
+    merge: (a, b) => a + b,
   }
 }
 
@@ -135,6 +143,7 @@ export function sum(
     step: (state, record) => state + readNumber(record, field),
     remove: (state, record) => state - readNumber(record, field),
     finalize: (state) => state,
+    merge: (a, b) => a + b,
   }
 }
 
@@ -171,6 +180,7 @@ export function avg(
       count: state.count - 1,
     }),
     finalize: (state) => (state.count === 0 ? null : state.sum / state.count),
+    merge: (a, b) => ({ sum: a.sum + b.sum, count: a.count + b.count }),
   }
 }
 
@@ -234,6 +244,7 @@ export function min(
       }
       return out
     },
+    merge: (a, b) => ({ values: [...a.values, ...b.values] }),
   }
 }
 
@@ -263,6 +274,7 @@ export function max(
       }
       return out
     },
+    merge: (a, b) => ({ values: [...a.values, ...b.values] }),
   }
 }
 

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -1969,3 +1969,61 @@ export class SnapshotNotFoundError extends NoydbError {
     this.version = version
   }
 }
+
+// ─── Federation (multi-vault partition) Errors ──────────────────────────
+
+/**
+ * Thrown when a write targets a partition key that has no shard and
+ * `sharding.autoCreate` is disabled.
+ */
+export class UnknownShardError extends NoydbError {
+  readonly partitionKey: string
+
+  constructor(partitionKey: string, groupName: string) {
+    super(
+      'SHARD_UNKNOWN',
+      `No shard for partition key "${partitionKey}" in vault group "${groupName}" ` +
+        `and autoCreate is disabled. Call group.createShard(${JSON.stringify(partitionKey)}) ` +
+        `first, or enable sharding.autoCreate.`,
+    )
+    this.name = 'UnknownShardError'
+    this.partitionKey = partitionKey
+  }
+}
+
+/**
+ * Thrown by `createShard` when the registry has a row for a partition
+ * but the corresponding vault is not provisioned in the store —
+ * a registry/store divergence. Refusing to recreate avoids masking
+ * data loss.
+ */
+export class ShardProvisioningError extends NoydbError {
+  readonly vaultId: string
+
+  constructor(vaultId: string, partitionKey: string) {
+    super(
+      'SHARD_PROVISIONING',
+      `Registry has a row for partition "${partitionKey}" (vault "${vaultId}") but that ` +
+        `vault is not provisioned in the store. Refusing to recreate it — the registry and ` +
+        `store have diverged. Investigate before retrying.`,
+    )
+    this.name = 'ShardProvisioningError'
+    this.vaultId = vaultId
+  }
+}
+
+/** Thrown when a VaultGroup references a template name that was never registered. */
+export class VaultTemplateNotFoundError extends NoydbError {
+  readonly templateName: string
+
+  constructor(templateName: string) {
+    super(
+      'VAULT_TEMPLATE_NOT_FOUND',
+      `No vault template registered under "${templateName}". Register it with ` +
+        `db.withVaultTemplate(${JSON.stringify(templateName)}, { version, configure }) ` +
+        `before opening the vault group.`,
+    )
+    this.name = 'VaultTemplateNotFoundError'
+    this.templateName = templateName
+  }
+}

--- a/packages/hub/src/federation/classify-skip.ts
+++ b/packages/hub/src/federation/classify-skip.ts
@@ -1,0 +1,13 @@
+import { NoAccessError } from '../errors.js'
+import type { SkippedVault } from './types.js'
+
+/**
+ * Classify a per-shard fan-out failure. `NoAccessError` (no keyring envelope for
+ * the calling identity) is the unambiguous not-granted signal → `'no-grant'`
+ * (expected under scoped access, not a fault). Everything else → `'error'` —
+ * `InvalidKeyError`/`DecryptionError`/`KeyringCorruptError` can mean "wrong KEK
+ * OR whole-file corruption" per loadKeyring, so they must not hide as no-grant.
+ */
+export function classifyShardSkip(err: Error): Exclude<SkippedVault['reason'], 'schema-drift'> {
+  return err instanceof NoAccessError ? 'no-grant' : 'error'
+}

--- a/packages/hub/src/federation/index.ts
+++ b/packages/hub/src/federation/index.ts
@@ -1,0 +1,10 @@
+export { VaultGroup, ShardedCollection, ShardedQuery } from './vault-group.js'
+export type {
+  VaultTemplate,
+  VaultRegistryRow,
+  ShardingConfig,
+  VaultGroupOptions,
+  FanoutQueryOptions,
+  FanoutResult,
+  SkippedVault,
+} from './types.js'

--- a/packages/hub/src/federation/types.ts
+++ b/packages/hub/src/federation/types.ts
@@ -1,0 +1,75 @@
+/**
+ * @category capability
+ * Multi-vault partition federation (MVF) — public types for VaultGroup
+ * transparent shard routing. See
+ * docs/superpowers/specs/2026-06-07-mvf-vaultgroup-routing-mvp-design.md.
+ */
+import type { Vault } from '../vault.js'
+import type { Collection } from '../collection.js'
+import type { Operator } from '../query/predicate.js'
+
+/**
+ * A schema blueprint for a class of shard vaults. `configure` is
+ * re-applied to every shard handle so all shards are configured
+ * identically (collections, indexes, schemas). `version` is recorded
+ * into each shard's registry row and drives the fan-out
+ * `minVersion` guard.
+ */
+export interface VaultTemplate {
+  readonly version: number
+  readonly configure: (vault: Vault) => void
+}
+
+/** One row in the StateManagement `vault-registry` collection. */
+export interface VaultRegistryRow {
+  readonly vaultId: string
+  readonly partitionKey: string
+  readonly templateName: string
+  readonly schemaVersion: number
+  readonly createdAt: number
+}
+
+/** How a VaultGroup maps records to shards. */
+export interface ShardingConfig<T> {
+  /** Extract the partition key from a record. */
+  readonly keyOf: (record: T) => string
+  /** Name of the template (registered via `withVaultTemplate`) shards are stamped from. */
+  readonly vaultTemplate: string
+  /** When a write targets an unknown partition key, stamp a shard inline. Default `true`. */
+  readonly autoCreate?: boolean
+}
+
+/** Options for `Noydb.openVaultGroup`. */
+export interface VaultGroupOptions<T> {
+  /** The `vault-registry` collection (source of truth for shard discovery). */
+  readonly registry: Collection<VaultRegistryRow>
+  readonly sharding: ShardingConfig<T>
+}
+
+/** Options for a cross-shard fan-out read. */
+export interface FanoutQueryOptions {
+  /** Skip shards whose registry `schemaVersion` is below this. */
+  readonly minVersion?: number
+  /** Max shards queried in parallel (passed to queryAcross). Default 1. */
+  readonly concurrency?: number
+}
+
+/** A shard excluded from a fan-out result, with the reason. */
+export interface SkippedVault {
+  readonly vaultId: string
+  readonly reason: 'schema-drift' | 'error'
+  readonly error?: Error
+}
+
+/** The result of a cross-shard fan-out read. */
+export interface FanoutResult<R> {
+  readonly results: R[]
+  readonly skippedVaults: SkippedVault[]
+}
+
+/** A single captured where-clause, replayed inside each shard. */
+export interface WhereClause {
+  readonly field: string
+  readonly op: Operator
+  readonly value: unknown
+}

--- a/packages/hub/src/federation/types.ts
+++ b/packages/hub/src/federation/types.ts
@@ -57,7 +57,7 @@ export interface FanoutQueryOptions {
 /** A shard excluded from a fan-out result, with the reason. */
 export interface SkippedVault {
   readonly vaultId: string
-  readonly reason: 'schema-drift' | 'error'
+  readonly reason: 'schema-drift' | 'error' | 'no-grant'
   readonly error?: Error
 }
 

--- a/packages/hub/src/federation/vault-group.ts
+++ b/packages/hub/src/federation/vault-group.ts
@@ -1,0 +1,172 @@
+/**
+ * @category capability
+ * Multi-vault partition federation — VaultGroup transparent shard
+ * routing. Spec:
+ * docs/superpowers/specs/2026-06-07-mvf-vaultgroup-routing-mvp-design.md.
+ */
+import type { Noydb } from '../noydb.js'
+import type { Vault } from '../vault.js'
+import type { Collection } from '../collection.js'
+import { ShardProvisioningError, UnknownShardError } from '../errors.js'
+import type {
+  ShardingConfig,
+  VaultRegistryRow,
+  VaultTemplate,
+  FanoutQueryOptions,
+  FanoutResult,
+  SkippedVault,
+  WhereClause,
+} from './types.js'
+
+export class VaultGroup<T> {
+  constructor(
+    /** @internal */ readonly db: Noydb,
+    /** @internal */ readonly name: string,
+    /** @internal */ readonly registry: Collection<VaultRegistryRow>,
+    /** @internal */ readonly sharding: ShardingConfig<T>,
+    /** @internal */ readonly template: VaultTemplate,
+  ) {}
+
+  /** Deterministic vault name for a partition key, namespaced by the group. */
+  shardVaultId(partitionKey: string): string {
+    return `${this.name}--${partitionKey}`
+  }
+
+  /** All registry rows (hydrates the registry collection first). */
+  async allRows(): Promise<VaultRegistryRow[]> {
+    await this.registry.list()
+    return this.registry.query().toArray()
+  }
+
+  /** Open an existing shard and apply the template. */
+  async openShard(partitionKey: string): Promise<Vault> {
+    const vault = await this.db.openVault(this.shardVaultId(partitionKey))
+    this.template.configure(vault)
+    return vault
+  }
+
+  /**
+   * Idempotently provision a shard for `partitionKey`. Returns the
+   * configured vault handle.
+   *
+   * - row + vault present → no-op, return handle
+   * - row present, vault gone → ShardProvisioningError
+   * - row absent (vault present or not) → open-or-create, configure, write row
+   */
+  async createShard(partitionKey: string): Promise<Vault> {
+    const vaultId = this.shardVaultId(partitionKey)
+    const row = await this.registry.get(partitionKey)
+    const provisioned = await this.db._shardVaultProvisioned(vaultId)
+
+    if (row && !provisioned) throw new ShardProvisioningError(vaultId, partitionKey)
+    if (row && provisioned) return this.openShard(partitionKey)
+
+    // Row absent → create (or reconcile a provisioned-but-unregistered vault).
+    const vault = await this.db.openVault(vaultId)
+    this.template.configure(vault)
+    await this.registry.put(partitionKey, {
+      vaultId,
+      partitionKey,
+      templateName: this.sharding.vaultTemplate,
+      schemaVersion: this.template.version,
+      createdAt: Date.now(),
+    })
+    return vault
+  }
+
+  /**
+   * Drill down to a single shard's full Collection API. Throws if the shard is unknown.
+   * Also throws ShardProvisioningError if the registry row exists but the vault has been deleted
+   * (registry/store divergence).
+   */
+  async shard(partitionKey: string): Promise<Vault> {
+    const vaultId = this.shardVaultId(partitionKey)
+    const row = await this.registry.get(partitionKey)
+    if (!row) throw new UnknownShardError(partitionKey, this.name)
+    const provisioned = await this.db._shardVaultProvisioned(vaultId)
+    if (!provisioned) throw new ShardProvisioningError(vaultId, partitionKey)
+    return this.openShard(partitionKey)
+  }
+
+  /** A sharded view over one logical collection across all shards. */
+  collection<R = T>(collectionName: string): ShardedCollection<T, R> {
+    return new ShardedCollection<T, R>(this, collectionName)
+  }
+}
+
+export class ShardedCollection<T, R = T> {
+  constructor(
+    private readonly group: VaultGroup<T>,
+    private readonly collectionName: string,
+  ) {}
+
+  /** Route a write to the shard owning `keyOf(record)`. */
+  async put(id: string, record: T): Promise<void> {
+    const key = this.group.sharding.keyOf(record)
+    const row = await this.group.registry.get(key)
+    let vault: Vault
+    if (!row) {
+      if (this.group.sharding.autoCreate === false) {
+        throw new UnknownShardError(key, this.group.name)
+      }
+      vault = await this.group.createShard(key)
+    } else {
+      vault = await this.group.openShard(key)
+    }
+    await vault.collection<T>(this.collectionName).put(id, record)
+  }
+
+  /** Begin a cross-shard fan-out query. */
+  query(): ShardedQuery<T, R> {
+    return new ShardedQuery<T, R>(this.group, this.collectionName, [])
+  }
+}
+
+export class ShardedQuery<T, R = T> {
+  constructor(
+    private readonly group: VaultGroup<T>,
+    private readonly collectionName: string,
+    private readonly clauses: readonly WhereClause[],
+  ) {}
+
+  where(field: string, op: WhereClause['op'], value: unknown): ShardedQuery<T, R> {
+    return new ShardedQuery<T, R>(this.group, this.collectionName, [
+      ...this.clauses,
+      { field, op, value },
+    ])
+  }
+
+  /** Fan out across eligible shards and merge results. */
+  async toArray(options: FanoutQueryOptions = {}): Promise<FanoutResult<R>> {
+    const rows = await this.group.allRows()
+    const skipped: SkippedVault[] = []
+    const eligible: VaultRegistryRow[] = []
+    for (const row of rows) {
+      if (options.minVersion !== undefined && row.schemaVersion < options.minVersion) {
+        skipped.push({ vaultId: row.vaultId, reason: 'schema-drift' })
+      } else {
+        eligible.push(row)
+      }
+    }
+
+    const across = await this.group.db.queryAcross<R[]>(
+      eligible.map((r) => r.vaultId),
+      async (vault) => {
+        this.group.template.configure(vault)
+        const coll = vault.collection<R>(this.collectionName)
+        await coll.list() // hydrate the in-memory cache before the sync query
+        let q = coll.query()
+        for (const c of this.clauses) q = q.where(c.field, c.op, c.value)
+        return q.toArray()
+      },
+      { concurrency: options.concurrency ?? 1 },
+    )
+
+    const results: R[] = []
+    for (const r of across) {
+      if (r.error) skipped.push({ vaultId: r.vault, reason: 'error', error: r.error })
+      else for (const item of r.result) results.push(item)
+    }
+    return { results, skippedVaults: skipped }
+  }
+}

--- a/packages/hub/src/federation/vault-group.ts
+++ b/packages/hub/src/federation/vault-group.ts
@@ -8,6 +8,7 @@ import type { Noydb } from '../noydb.js'
 import type { Vault } from '../vault.js'
 import type { Collection } from '../collection.js'
 import { ShardProvisioningError, UnknownShardError, ValidationError } from '../errors.js'
+import { classifyShardSkip } from './classify-skip.js'
 import type {
   ShardingConfig,
   VaultRegistryRow,
@@ -70,7 +71,7 @@ export class VaultGroup<T> {
 
   /** Open an existing shard and apply the template. */
   async openShard(partitionKey: string): Promise<Vault> {
-    const vault = await this.db.openVault(this.shardVaultId(partitionKey))
+    const vault = await this.db.openVault(this.shardVaultId(partitionKey), { create: false })
     this.template.configure(vault)
     return vault
   }
@@ -208,12 +209,12 @@ export class ShardedQuery<T, R = T> {
         for (const c of this.clauses) q = q.where(c.field, c.op, c.value)
         return q.toArray()
       },
-      { concurrency: options.concurrency ?? 1 },
+      { concurrency: options.concurrency ?? 1, create: false },
     )
 
     const results: R[] = []
     for (const r of across) {
-      if (r.error) skipped.push({ vaultId: r.vault, reason: 'error', error: r.error })
+      if (r.error) skipped.push({ vaultId: r.vault, reason: classifyShardSkip(r.error), error: r.error })
       else for (const item of r.result) results.push(item)
     }
     return { results, skippedVaults: skipped }

--- a/packages/hub/src/federation/vault-group.ts
+++ b/packages/hub/src/federation/vault-group.ts
@@ -7,7 +7,7 @@
 import type { Noydb } from '../noydb.js'
 import type { Vault } from '../vault.js'
 import type { Collection } from '../collection.js'
-import { ShardProvisioningError, UnknownShardError } from '../errors.js'
+import { ShardProvisioningError, UnknownShardError, ValidationError } from '../errors.js'
 import type {
   ShardingConfig,
   VaultRegistryRow,
@@ -18,6 +18,29 @@ import type {
   WhereClause,
 } from './types.js'
 
+/** Reserved separator between group name and partition key in a shard vault id. */
+const SHARD_SEPARATOR = '--'
+/** Store-safe partition-key charset (single hyphens OK; '--' is the reserved separator). */
+const SAFE_PARTITION_KEY = /^[A-Za-z0-9._-]+$/
+
+function assertSafePartitionKey(partitionKey: string): void {
+  if (partitionKey.length === 0) {
+    throw new ValidationError('partitionKey must be a non-empty string')
+  }
+  if (!SAFE_PARTITION_KEY.test(partitionKey)) {
+    throw new ValidationError(
+      `partitionKey "${partitionKey}" contains characters outside [A-Za-z0-9._-]. ` +
+        `Map your records to a store-safe key in sharding.keyOf.`,
+    )
+  }
+  if (partitionKey.includes(SHARD_SEPARATOR)) {
+    throw new ValidationError(
+      `partitionKey "${partitionKey}" must not contain "--" — it is reserved as the ` +
+        `shard vault-id separator and would risk shard-id collisions.`,
+    )
+  }
+}
+
 export class VaultGroup<T> {
   constructor(
     /** @internal */ readonly db: Noydb,
@@ -25,11 +48,18 @@ export class VaultGroup<T> {
     /** @internal */ readonly registry: Collection<VaultRegistryRow>,
     /** @internal */ readonly sharding: ShardingConfig<T>,
     /** @internal */ readonly template: VaultTemplate,
-  ) {}
+  ) {
+    if (name.includes(SHARD_SEPARATOR)) {
+      throw new ValidationError(
+        `VaultGroup name "${name}" must not contain "--" (reserved shard vault-id separator).`,
+      )
+    }
+  }
 
   /** Deterministic vault name for a partition key, namespaced by the group. */
   shardVaultId(partitionKey: string): string {
-    return `${this.name}--${partitionKey}`
+    assertSafePartitionKey(partitionKey)
+    return `${this.name}${SHARD_SEPARATOR}${partitionKey}`
   }
 
   /** All registry rows (hydrates the registry collection first). */
@@ -149,8 +179,27 @@ export class ShardedQuery<T, R = T> {
       }
     }
 
+    // Guard against registry/store divergence: a row whose vault is not
+    // provisioned must NOT be recreated by queryAcross's open-on-read.
+    // Surface it as an error-skip instead (mirrors shard()/createShard).
+    const provisioned = await Promise.all(
+      eligible.map((row) => this.group.db._shardVaultProvisioned(row.vaultId)),
+    )
+    const safeEligible: VaultRegistryRow[] = []
+    eligible.forEach((row, i) => {
+      if (provisioned[i]) {
+        safeEligible.push(row)
+      } else {
+        skipped.push({
+          vaultId: row.vaultId,
+          reason: 'error',
+          error: new ShardProvisioningError(row.vaultId, row.partitionKey),
+        })
+      }
+    })
+
     const across = await this.group.db.queryAcross<R[]>(
-      eligible.map((r) => r.vaultId),
+      safeEligible.map((r) => r.vaultId),
       async (vault) => {
         this.group.template.configure(vault)
         const coll = vault.collection<R>(this.collectionName)

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -275,8 +275,14 @@ export {
 export { SnapshotNotFoundError } from './errors.js'
 export type { SnapshotMeta, RetentionPolicy } from './snapshots/strategy.js'
 
-// Federation — VaultGroup / sharded collections
-export { VaultGroup, ShardedCollection, ShardedQuery } from './federation/index.js'
+// Federation — VaultGroup / sharded collections.
+// Type-only: these classes are never constructed by consumers — they are
+// returned by `db.openVaultGroup()` / `.collection()` / `.query()`. Exporting
+// them as types (not values) removes the only static runtime edge from the
+// package entry to the federation chunk, so federation stays purely behind the
+// dynamic `import()` in `openVaultGroup` — reliably excluded (ESM, CJS, and
+// non-tree-shaking consumers alike) until a group is actually opened.
+export type { VaultGroup, ShardedCollection, ShardedQuery } from './federation/index.js'
 export type {
   VaultTemplate,
   VaultRegistryRow,

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -275,6 +275,19 @@ export {
 export { SnapshotNotFoundError } from './errors.js'
 export type { SnapshotMeta, RetentionPolicy } from './snapshots/strategy.js'
 
+// Federation — VaultGroup / sharded collections
+export { VaultGroup, ShardedCollection, ShardedQuery } from './federation/index.js'
+export type {
+  VaultTemplate,
+  VaultRegistryRow,
+  ShardingConfig,
+  VaultGroupOptions,
+  FanoutQueryOptions,
+  FanoutResult,
+  SkippedVault,
+} from './federation/index.js'
+export { UnknownShardError, ShardProvisioningError, VaultTemplateNotFoundError } from './errors.js'
+
 // Bundle format — `.noydb` container
 export {
   writeNoydbBundle,

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -21,7 +21,7 @@ import type {
   TranslatorAuditEntry,
   WriteConflict,
 } from './types.js'
-import { ValidationError, NoAccessError, InvalidKeyError, KeyringCorruptError, StoreCapabilityError, PermissionDeniedError } from './errors.js'
+import { ValidationError, NoAccessError, InvalidKeyError, KeyringCorruptError, StoreCapabilityError, PermissionDeniedError, VaultTemplateNotFoundError } from './errors.js'
 import {
   readDirectoryConfig,
   persistDirectoryConfig,
@@ -127,6 +127,8 @@ import {
   type GateName,
   type VaultPolicy,
 } from './policy/index.js'
+import type { VaultGroup } from './federation/vault-group.js'
+import type { VaultTemplate, VaultGroupOptions } from './federation/types.js'
 
 /**
  * Privilege rank used by `listAccessibleVaults({ minRole })` to
@@ -204,6 +206,7 @@ export class Noydb {
   private writeRelay: CrossTabWriteRelay | undefined
   /** Per-vault policy enforcers. */
   private readonly policyEnforcers = new Map<string, PolicyEnforcer>()
+  private readonly vaultTemplates = new Map<string, VaultTemplate>()
   private readonly txStrategy: TxStrategy
   private readonly sessionStrategy: SessionStrategy
   private readonly syncStrategy: SyncStrategy
@@ -991,6 +994,37 @@ export class Noydb {
     }
 
     return results
+  }
+
+  /**
+   * Register a shard schema blueprint. `createShard` / `openVaultGroup`
+   * stamp shards from the named template. See the MVF design spec.
+   */
+  withVaultTemplate(name: string, template: VaultTemplate): void {
+    this.vaultTemplates.set(name, template)
+  }
+
+  /**
+   * Open a VaultGroup — transparent routing over per-partition shard
+   * vaults, with shard discovery backed by the supplied `vault-registry`
+   * collection.
+   */
+  async openVaultGroup<T>(name: string, opts: VaultGroupOptions<T>): Promise<VaultGroup<T>> {
+    if (this.closed) throw new ValidationError('Instance is closed')
+    const template = this.vaultTemplates.get(opts.sharding.vaultTemplate)
+    if (!template) throw new VaultTemplateNotFoundError(opts.sharding.vaultTemplate)
+    // Lazy-load so the federation module is a separate chunk, not part
+    // of the always-loaded core graph (keeps the core bundle ceiling).
+    const { VaultGroup } = await import('./federation/vault-group.js')
+    return new VaultGroup<T>(this, name, opts.registry, opts.sharding, template)
+  }
+
+  /**
+   * @internal — true when an encrypted shard vault is provisioned
+   * (its keyring exists in the store).
+   */
+  async _shardVaultProvisioned(vaultId: string): Promise<boolean> {
+    return (await this.options.store.list(vaultId, '_keyring')).length > 0
   }
 
   /**

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -397,7 +397,15 @@ function scanFileForStrategyOptIn(file, content) {
 const KERNEL_SURFACE_BUDGET = {
   'packages/hub/src/collection.ts': 3950,
   'packages/hub/src/vault.ts': 3640,
-  'packages/hub/src/noydb.ts': 2920,
+  // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
+  // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
+  // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),
+  // and the multi-vault federation entry points (`withVaultTemplate` /
+  // `openVaultGroup` / `_shardVaultProvisioned` — public `db.*` API; the
+  // VaultGroup *implementation* lives in the lazy `federation/` chunk via a
+  // dynamic import, NOT here). The extractable parts are already off this file;
+  // what remains is irreducible core API + auth surface.
+  'packages/hub/src/noydb.ts': 2960,
 }
 
 function checkKernelSurface() {

--- a/showcases/src/98-vault-group-federation.showcase.test.ts
+++ b/showcases/src/98-vault-group-federation.showcase.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Showcase 98 — Multi-vault partition federation (VaultGroup)
+ *
+ * What you'll learn
+ * ─────────────────
+ * A firm manages many independent client portfolios. Each client's data lives
+ * in its OWN vault (its own DEKs, its own store namespace) — yet the firm wants
+ * a single entry point to write and a single fan-out query to read across all
+ * of them. `db.openVaultGroup()` provides exactly that: transparent routing by
+ * partition key over per-client shard vaults, with shard discovery backed by a
+ * `vault-registry` collection that is the single source of truth.
+ *
+ * This showcase exercises the whole milestone-16 MVP surface:
+ *   1. `withVaultTemplate` — a versioned schema blueprint for shards
+ *   2. `openVaultGroup` — the group entry point, registry-backed
+ *   3. transparent write routing with `autoCreate` (shards stamped on demand)
+ *   4. cross-shard fan-out reads → `{ results, skippedVaults }`
+ *   5. `shard()` drill-down to one client's full Collection API
+ *   6. idempotent `createShard`
+ *   7. the `minVersion` schema-drift guard (mixed-version fleet)
+ *   8. `UnknownShardError` when `autoCreate` is off
+ *   9. partition-key validation (collision-safe shard ids)
+ *
+ * Why it matters
+ * ──────────────
+ * Per-client isolation is a cryptographic guarantee (one vault = one DEK
+ * boundary), but isolated vaults are awkward to operate at fleet scale.
+ * VaultGroup keeps the small-DB / one-vault-per-tenant philosophy intact while
+ * giving the firm fleet-level ergonomics — no application-level ACLs, no manual
+ * vault bookkeeping, and no silent mixing of records from shards sitting at
+ * different schema generations.
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → vault-group-federation
+ * spec → docs/superpowers/specs/2026-06-07-mvf-vaultgroup-routing-mvp-design.md
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, UnknownShardError, ValidationError } from '@noy-db/hub'
+import type { VaultRegistryRow } from '@noy-db/hub'
+import type { Vault } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+
+interface Invoice {
+  clientId: string
+  amount: number
+  status: 'open' | 'overdue' | 'paid'
+}
+
+/**
+ * Open a firm operator instance, register a client template at `version`,
+ * and open a VaultGroup whose registry lives in a dedicated `state` vault.
+ * The store is shared so a second operator instance can read what the first
+ * wrote — this models a real deployment, not just one in-memory session.
+ */
+async function openFirm(store: ReturnType<typeof memory>, version = 1) {
+  const db = await createNoydb({ store, user: 'firm-operator', secret: 'firm-secret-2026' })
+  db.withVaultTemplate('client-template', {
+    version,
+    configure(vault: Vault) {
+      // Every client shard gets an identically-shaped `invoices` collection.
+      vault.collection<Invoice>('invoices')
+    },
+  })
+  const state = await db.openVault('state')
+  const registry = state.collection<VaultRegistryRow>('vault-registry')
+  const firm = await db.openVaultGroup<Invoice>('firm-clients', {
+    registry,
+    sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template', autoCreate: true },
+  })
+  return { db, registry, firm }
+}
+
+describe('Showcase 98 — Multi-vault partition federation', () => {
+  it('routes writes to per-client shards and fans out reads across all of them', async () => {
+    const store = memory()
+    const { registry, firm } = await openFirm(store)
+
+    // Transparent writes. Each invoice is routed to its client's shard by
+    // `keyOf(record) = record.clientId`. Unknown partitions are auto-created.
+    const invoices = firm.collection('invoices')
+    await invoices.put('acme-1', { clientId: 'acme', amount: 1200, status: 'overdue' })
+    await invoices.put('acme-2', { clientId: 'acme', amount: 300, status: 'paid' })
+    await invoices.put('globex-1', { clientId: 'globex', amount: 900, status: 'overdue' })
+    await invoices.put('initech-1', { clientId: 'initech', amount: 50, status: 'open' })
+
+    // Three shards were stamped on demand and recorded in the registry.
+    await registry.list()
+    const rows = registry.query().toArray()
+    expect(rows.map((r) => r.partitionKey).sort()).toEqual(['acme', 'globex', 'initech'])
+    expect(rows.every((r) => r.schemaVersion === 1)).toBe(true)
+    expect(rows.find((r) => r.partitionKey === 'acme')!.vaultId).toBe('firm-clients--acme')
+
+    // Cross-shard fan-out read: "every overdue invoice across all clients".
+    const overdue = await firm.collection('invoices').query()
+      .where('status', '==', 'overdue')
+      .toArray()
+    expect(overdue.skippedVaults).toEqual([])
+    expect(overdue.results.map((r) => r.amount).sort((a, b) => a - b)).toEqual([900, 1200])
+
+    // Drill down to one client's full Collection API for detail work.
+    const acme = await firm.shard('acme')
+    const detail = await acme.collection<Invoice>('invoices').get('acme-2')
+    expect(detail).toEqual({ clientId: 'acme', amount: 300, status: 'paid' })
+  })
+
+  it('createShard is idempotent — re-provisioning a client is a no-op', async () => {
+    const store = memory()
+    const { registry, firm } = await openFirm(store)
+
+    await firm.createShard('acme')
+    await firm.createShard('acme') // safe to re-run (e.g. retried provisioning)
+
+    await registry.list()
+    const acmeRows = registry.query().toArray().filter((r) => r.partitionKey === 'acme')
+    expect(acmeRows).toHaveLength(1)
+  })
+
+  it('the minVersion guard skips behind-version shards instead of mixing record shapes', async () => {
+    const store = memory()
+
+    // Firm starts at template v1; client "acme" is provisioned at v1.
+    const v1 = await openFirm(store, 1)
+    await v1.firm.collection('invoices').put('acme-1', { clientId: 'acme', amount: 1200, status: 'overdue' })
+
+    // The firm rolls the template to v2 and onboards "globex" at v2. Now the
+    // fleet is mixed: acme@v1, globex@v2 (a realistic mid-rollout window).
+    const v2 = await openFirm(store, 2)
+    await v2.firm.collection('invoices').put('globex-1', { clientId: 'globex', amount: 900, status: 'overdue' })
+
+    // A v2-only report pre-filters by the registry-recorded schemaVersion:
+    // acme (v1) lands in skippedVaults; only globex (v2) contributes results.
+    const report = await v2.firm.collection('invoices').query()
+      .where('status', '==', 'overdue')
+      .toArray({ minVersion: 2 })
+
+    expect(report.results.map((r) => r.amount)).toEqual([900])
+    expect(report.skippedVaults).toEqual([
+      { vaultId: 'firm-clients--acme', reason: 'schema-drift' },
+    ])
+  })
+
+  it('rejects writes to unknown clients when autoCreate is off', async () => {
+    const store = memory()
+    const db = await createNoydb({ store, user: 'firm-operator', secret: 'firm-secret-2026' })
+    db.withVaultTemplate('client-template', {
+      version: 1,
+      configure(vault: Vault) { vault.collection<Invoice>('invoices') },
+    })
+    const state = await db.openVault('state')
+    const strictFirm = await db.openVaultGroup<Invoice>('firm-clients', {
+      registry: state.collection<VaultRegistryRow>('vault-registry'),
+      sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template', autoCreate: false },
+    })
+
+    await expect(
+      strictFirm.collection('invoices').put('x-1', { clientId: 'unbooked', amount: 1, status: 'open' }),
+    ).rejects.toBeInstanceOf(UnknownShardError)
+  })
+
+  it('validates partition keys so two clients can never collide into one shard', async () => {
+    const store = memory()
+    const { firm } = await openFirm(store)
+
+    // "--" is the reserved shard-id separator; allowing it in a key would let
+    // ("firm-clients", "a--b") and ("firm-clients--a", "b") collide.
+    await expect(firm.createShard('a--b')).rejects.toBeInstanceOf(ValidationError)
+    await expect(firm.createShard('bad/key')).rejects.toBeInstanceOf(ValidationError)
+
+    // Ordinary hyphenated identifiers (UUID-like) are fine.
+    await expect(firm.createShard('acme-corp-2026')).resolves.toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary

First vertical slice of **Multi-Vault Partition Federation** (epic vLannaAi/klum-db#12, milestone 16). Provides a single entry point that routes records across many per-partition shard vaults, while each shard stays an ordinary noy-db vault inside its own DEK boundary and small-DB ceiling.

- **`db.withVaultTemplate(name, { version, configure })`** — versioned shard schema blueprint.
- **`db.openVaultGroup(name, { registry, sharding })`** → `VaultGroup` / `ShardedCollection` / `ShardedQuery`.
- **Transparent write routing** by `keyOf(record)` partition key, with `autoCreate` (default on) provisioning shards on demand.
- **Cross-shard fan-out reads** — `query().where(...).toArray()` → `{ results, skippedVaults }` via the existing `queryAcross` engine.
- **`minVersion` schema-drift guard** — pre-filters shards by their registry-recorded `schemaVersion` so behind-version shards land in `skippedVaults` instead of silently mixing record shapes.
- **`shard(key)` drill-down** to one shard's full Collection API.
- **Idempotent `createShard`** (4-case provisioning matrix) backed by a minimal StateManagement **`vault-registry`** as the single source of truth for shard discovery (works on every backend — no `listAccessibleVaults` capability dependency).
- New errors: `UnknownShardError`, `ShardProvisioningError`, `VaultTemplateNotFoundError`.

### Scope / deferred
`crossShardJoin` and `withCrossVaultDerivation` (the epic's two 🔴 blocking conflicts) are intentionally deferred; `packages/hub/src/query/join.ts` `partitionScope` seam is **untouched**. Also deferred: `queryAcrossLive`, `aggregateAcross`, fleet migration runner. The federation module is lazy-loaded (own chunk) so it stays out of the core bundle graph.

### Design & plan
- Spec: `docs/superpowers/specs/2026-06-07-mvf-vaultgroup-routing-mvp-design.md`
- Plan: `docs/superpowers/plans/2026-06-07-mvf-vaultgroup-routing.md`
- Subsystem doc: `docs/subsystems/vault-group.md` (catalog vLannaAi/noy-db#24)

## Test Plan

- [x] `pnpm --filter @noy-db/hub exec tsc --noEmit` — clean
- [x] `pnpm --filter @noy-db/hub test` — 216 files / 2146 tests pass (incl. 16 federation unit tests)
- [x] `pnpm --filter @noy-db/showcases exec vitest run src/98-vault-group-federation.showcase.test.ts` — 5/5 pass against the built package
- [x] `node scripts/validate-features.mjs` — OK (registers `vault-group-federation` + showcase 98)
- [x] `packages/hub/src/query/join.ts` unchanged vs `main`

### Notes for reviewers
- `pnpm --filter @noy-db/hub bundle-check` currently fails on a **stale repo-wide baseline** (last reseeded at vLannaAi/noy-db#157, before snapshots/i18n/cross-join/etc.) — it is not wired into CI and federation is verified as a separate chunk with no core leak. Baseline refresh is a separate release-time task, intentionally not folded into this branch.