### PR TITLE
release: 0.2.0-pre.10 — unique indexes + dumpSchema completeness + MV map-drop + union narrowing (#293–#297)

### DIFF
--- a/docs/core/06-query-basics.md
+++ b/docs/core/06-query-basics.md
@@ -64,6 +64,57 @@ Reactive queries are documented under [docs/subsystems/live.md](../subsystems/li
 - **No SQL**: the store never sees plaintext, so the store can't run your query. Filtering happens in core after decryption.
 - **Cross-collection**: use `query().join(...)` (see [joins](../subsystems/joins.md)) or `db.queryAcross()` for federated cases.
 
+## Discriminated-union collections
+
+When `T` is a discriminated union — e.g. `Collection<Receipt>` where
+`Receipt = IV | RE | DP | RD` — hub threads `T` correctly through `get` /
+`query` / `scan`. The narrowing step is the application's responsibility.
+
+**In plain `.ts` files** a comparison is enough:
+
+```ts
+const receipts = await vault.collection<Receipt>('receipts').query().toArray()
+
+for (const r of receipts) {
+  if (r.kind === 'IV') {
+    // r: IV — invoiceNo, amount accessible, no cast needed
+    console.log(r.invoiceNo)
+  }
+}
+```
+
+**In vue-tsc / template contexts** the inline comparison is sometimes not
+sufficient. Use the exported `isDiscriminant` helper, which is a proper
+type-guard function and works reliably everywhere:
+
+```ts
+import { isDiscriminant } from '@noy-db/hub'
+
+const receipts = await vault.collection<Receipt>('receipts').query().toArray()
+
+// Filter — result type is IV[], member-specific fields accessible without cast:
+const ivs = receipts.filter(r => isDiscriminant(r, 'kind', 'IV'))
+console.log(ivs[0].invoiceNo)   // string — no cast
+
+// Branch:
+for (const r of receipts) {
+  if (isDiscriminant(r, 'kind', 'IV')) {
+    console.log(r.invoiceNo)    // r: IV here
+  }
+}
+```
+
+The discriminant key is a parameter — use any field name (`'kind'`, `'type'`,
+`'tag'`, etc.):
+
+```ts
+const aOnly = docs.filter(d => isDiscriminant(d, 'type', 'A'))
+```
+
+> **Note on type aliases.** For best results, define the union as a type alias:
+> `type Receipt = IV | RE | DP | RD`. Using a plain `interface` may limit
+> TypeScript's ability to distribute the `Extract` predicate correctly.
+
 ## See also
 
 - [docs/subsystems/indexing.md](../subsystems/indexing.md) — fast-path equality / orderBy

--- a/docs/superpowers/specs/2026-06-07-i18n-static-dictionary-design.md
+++ b/docs/superpowers/specs/2026-06-07-i18n-static-dictionary-design.md
@@ -1,0 +1,248 @@
+# i18n static / code-provided dictionary (hub core / i18n) — design
+
+> Adds a **code-provided dictionary** primitive — `staticDict(name, table, opts?)` — for *closed, defined-in-code, identical-across-vaults* enums (honorific, civil-status, gender, religion, ContactTitle, status…). Labels are supplied **at registration in code** and resolved through the *same* label machinery as `dictKey`, but with **no `_dict_*` per-vault encrypted copy** and **no `rename()`**. The record stores only the **code**, so an app migrates onto it from a userland workaround with **zero record change**.
+>
+> **Foundation decision: a sibling descriptor that reuses the resolver seam, not a new subsystem.** `staticDict` produces a descriptor accepted in the existing `dictKeyFields` config slot. Label resolution flows through the same choke points as `dictKey` (`collection.ts` read path + the query label seam) — only the *source* of labels changes (an in-memory table instead of a `_dict_*`-backed handle). No new storage, no new query operators.
+>
+> **Resolution contract: hybrid (locale-aware **and** locale-less-resolvable).** Unlike `dictKey`, a static dict is pure code with no vault-locale dependency, so it can — and must, to be useful to a locale-less consumer — emit a label even when no locale is active, via a configured `displayLocale`. When a locale *is* active it behaves exactly like `dictKey` (inherits `onMissing`/`substitute`, `groupBy by:'key'`, `orderBy {by:'label'}`). This is the only contract that resolves the #291 contradiction (see § The contradiction this resolves).
+
+Issue: [#291](https://github.com/vLannaAi/noy-db/issues/291). Consumer driver: `vLannaAi/niwat#174` (i18n native-adoption umbrella). Family: i18n hardening, **milestone #17** (sibling primitive to the #282/#283 parity work shipped in #284).
+
+## Motivation — the practical issue
+
+`dictKey` stores labels in a **per-vault encrypted `_dict_*`** collection (`i18n/dictionary.ts:48-59`) and rewrites pointers with an **O(records) `rename()`** (`dictionary.ts:450-522` → `vault.ts:1013-1040`, which lists every record in every registered collection). That is the right design for **user-editable, per-vault** enums.
+
+But a large class of enums are the opposite: **closed, defined in code, identical across every vault, never renamed per-vault** — honorifics, civil status, gender, religion, ContactTitle, status enums. For these, `dictKey` is the wrong layer:
+
+- it forces a **per-vault encrypted copy** of values that are really code constants;
+- it needs an **O(records) `rename()`** for a change that is really a code deploy;
+- under a **locale-less vault** (opened with no locale → bare reads return the raw map), a `dictKey` field's `<field>Label` does **not** auto-resolve on a bare read — the read path early-returns at `collection.ts:3042-3043` (`const locale = perCall ?? this.defaultLocale; if (!locale) return record`; locked by `dictionary.test.ts:350-367`). So every site needs a per-call resolver, and the call-site-reduction value of `dictKey` is undercut.
+
+Confirmed in practice in the consumer (`niwat#174`): the app is **locale-less by a deliberate, locking-tested invariant** and *never consumes read-time `{locale}` resolution*. The `dictKey` seeded for honorifics sat **dormant** — every site used a sync code-level label helper instead — and the dormant dict was deleted. The app now ships a userland `defineStaticDict(name, { code: {th,en} })`. It works, but the resolving lives in user land rather than the engine — hence this request to embed it.
+
+## The contradiction this resolves
+
+The naïve reading of #291 — "embed the sync userland helper **and** route it through the existing `resolveLabel` locale path for parity" — cannot hold:
+
+- the userland `defineStaticDict` is **synchronous and locale-less** — it resolves *because* it is pure code with no vault-locale dependency;
+- the existing `resolveLabel` read path is **async and locale-gated** — its first act is `if (!locale) return record` (`collection.ts:3042-3043`).
+
+Routing the workaround through that path would produce a primitive that resolves to **nothing** under a locale-less read — exactly the dormant-`dictKey` failure mode the issue complains about, and one the only known consumer (locale-less by invariant) **could not use at all**.
+
+Yet the *only* thing that justifies engine-embedding over the working userland helper is **query integration** — `orderBy`/`groupBy {by:'label'}` and `onMissing`/`substitute` parity — which a pure sync helper cannot provide, and which inherently needs *a* locale at query time.
+
+**Hybrid (this spec) is the resolution:** resolve through the locale path when a locale is active (full query integration + policy parity), and fall back to a configured `displayLocale` when no locale is active (preserves the locale-less consumer's ergonomics). It serves both the locale-aware future and the locale-less present without forking the descriptor.
+
+## What already exists (and is reused, not rebuilt)
+
+| Capability | Where | Reused as |
+|---|---|---|
+| `DictKeyDescriptor` shape + `dictKey()` factory | `i18n/dictionary.ts:79-126` | template for `StaticDictDescriptor` + `staticDict()` (distinct brand) |
+| `dictKeyFields` config slot on `collection()` | `vault.ts:522-578`, wired at `752-758` | **same slot** accepts static descriptors — drop-in at config sites |
+| Read-path label resolution (`<field>Label`, array-of-keys, wildcard `[].`) | `collection.ts:3053-3119` | the one read choke point; extended only at the locale **gate** (3042-3043) |
+| `dictLabelResolver` closure | `vault.ts:752-758` | static variant closes over the **in-memory table**, not `dictionary(name).resolveLabel` |
+| `onMissing` / `substitute` policy engine | `i18n/policy.ts` (`resolvePolicy`), applied `collection.ts:3056-3079` | unchanged; static descriptor carries the same fields |
+| Query label seam | `query/builder.ts:739,1271` (`buildDictLabelResolver` → `joinCtx.resolveDictSource(field)` → `dictSource.snapshot()` → `Map`) | gets a **code-table-backed `dictSource`** whose `snapshot()` materialises the in-memory table |
+| `groupBy`/`orderBy` key-vs-label binding | `aggregate/groupby.ts:347-381` (threaded resolver) | unchanged; binds to **key** by default, `{ by: 'label' }` opt-in |
+| `i18nPutValidator` / `enforceI18nOnPut` | `vault.ts:761-765` | extended to validate the stored code against the static table's known keys |
+| Tree-shake seam | `i18n/strategy.ts` (`NO_I18N`) / `i18n/active.ts` (`withI18n()`) | all new code lives here; non-i18n bundles pay nothing |
+
+## What is deliberately NOT reused
+
+| `dictKey` machinery | Why a static dict skips it |
+|---|---|
+| `_dict_*` encrypted collection (`dictCollectionName`, `i18n/dictionary.ts:48-59`) | labels are code constants — no per-vault storage |
+| `dictKeyFieldRegistry` + `findAndUpdateReferences` (`vault.ts:1013-1040`) | no per-vault pointer rewrite; codes never change per-vault |
+| `rename()` (`dictionary.ts:450-522`) | a label change is a code deploy, not an O(records) migration |
+| `vault.dictionary(name)` handle `put`/`rename` API | a static dict exposes **no mutation surface**; attempting `put`/`rename` on a static name throws `StaticDictReadonlyError` (see registry note below) |
+
+> **Static-name registry (small, new).** A static dict skips `dictKeyFieldRegistry` (no rename), but the `StaticDictReadonlyError` guard requires the vault to *know* a name is static so `vault.dictionary(staticName)` can refuse mutation. Maintain a `Set<string>` of static dict names, populated at `collection()` config time when a `StaticDictDescriptor` is seen in `dictKeyFields`. The guard and the Seam-1 resolver both read from it.
+
+## Success criteria (acceptance)
+
+- `staticDict(name, table, opts?)` produces a descriptor usable in the existing `dictKeyFields` slot; a record storing the bare **code** gains a resolved `<field>Label` on read.
+- **Locale-less read with `displayLocale`:** `entities.get(id)` on a vault opened with **no** locale returns `civilStatusLabel` resolved via `displayLocale` (e.g. `'นาย'`). This is the property a locale-less consumer needs and `dictKey` cannot provide.
+- **Locale-active read:** `get(id, { locale: 'en' })` returns `civilStatusLabel: 'Mr'`, honoring `onMissing`/`substitute` exactly as `dictKey` does.
+- **No `_dict_*` collection** is created for a static dict; the adapter shows no `_dict_<name>` keys.
+- **No `rename()`** path exists; `vault.dictionary(staticName)` mutation calls throw `StaticDictReadonlyError`.
+- **Query parity:** `groupBy(field)` buckets by the stable **code**; `orderBy(field, { by: 'label' })` sorts by resolved label under the active (or `displayLocale`) locale.
+- **Zero record change** to migrate from the userland workaround: the record already stores the code; only the field descriptor changes.
+- **No behavior change** for any existing `dictKey` / `i18nText` field. The locale gate still early-returns for a locale-less read **unless** a static field declares `displayLocale`. Existing conformance tests (incl. `dictionary.test.ts:350-367`) stay green, **and a new locking test asserts an `i18nText`-only collection still returns the raw `{th,en}` map on a locale-less read** (the gate edit's regression guard — not covered by the dictKey test).
+- New code lives entirely inside the tree-shaken `withI18n()` strategy.
+
+## Descriptor API
+
+```ts
+// i18n/dictionary.ts (sibling to dictKey)
+export interface StaticDictDescriptor<Keys extends string = string> {
+  readonly _noydbStaticDict: true
+  readonly name: string
+  readonly table: Readonly<Record<Keys, Readonly<Record<string, string>>>> // key -> { locale -> label }
+  readonly keys: readonly Keys[]                 // derived: Object.keys(table)
+  readonly displayLocale?: string                // label emitted under a locale-less read (the hybrid hinge)
+  readonly onMissing?: OnMissingPolicy           // same policy engine as dictKey
+  readonly substitute?: readonly string[]        // declared preferred-locale chain
+}
+
+export function staticDict<const T extends Record<string, Record<string, string>>>(
+  name: string,
+  table: T,
+  opts?: { displayLocale?: string; onMissing?: OnMissingPolicy; substitute?: readonly string[] },
+): StaticDictDescriptor<Extract<keyof T, string>>
+
+export function isStaticDictDescriptor(x: unknown): x is StaticDictDescriptor
+```
+
+Config site — drop-in alongside `dictKey`:
+
+```ts
+const workers = vault.collection<Worker>('workers', {
+  dictKeyFields: {
+    // per-vault, user-editable → dictKey (unchanged)
+    department: dictKey('department', ['ops', 'fin'] as const),
+    // closed, code-defined, identical across vaults → staticDict
+    civilStatus: staticDict('civilStatus', {
+      adultMale:   { th: 'นาย',  en: 'Mr'  },
+      adultFemale: { th: 'นาง',  en: 'Mrs' },
+      youngFemale: { th: 'นางสาว', en: 'Ms' },
+    }, { displayLocale: 'th' }),
+  },
+})
+
+// record stores only the code:
+await workers.put({ id: 'w1', civilStatus: 'adultMale' })
+
+await workers.get('w1')                  // locale-less vault → civilStatusLabel: 'นาย'  (displayLocale)
+await workers.get('w1', { locale:'en' }) // → civilStatusLabel: 'Mr'
+```
+
+## v1 SCOPE — what's in
+
+| Feature | In v1 | Notes |
+|---|:---:|---|
+| `staticDict(name, table, opts?)` + `StaticDictDescriptor` + `isStaticDictDescriptor` | ✓ | distinct `_noydbStaticDict` brand; lives in `i18n/dictionary.ts` |
+| Accept static descriptors in the existing `dictKeyFields` slot | ✓ | `vault.ts:752-758` branches on descriptor brand |
+| **Locale gate extension** (`collection.ts:3042-3043`) | ✓ | early-return suppressed only when a static field declares `displayLocale`; effective locale = `perCall ?? defaultLocale ?? desc.displayLocale` for static fields |
+| Static resolver closure over the in-memory table | ✓ | `vault.ts` builds `dictLabelResolver` from `desc.table` for static names; no `dictionary()` lookup |
+| `onMissing` / `substitute` parity via the existing policy engine | ✓ | `collection.ts:3056-3079` unchanged; default `'null'` (today's dictKey behavior) |
+| Scalar, array-of-keys (`[{key,label}]`), and wildcard (`contacts[].title`) resolution | ✓ | reuses the same `collection.ts:3081-3116` branches |
+| **No `_dict_*`, no registry, no `rename`** for static names | ✓ | static names skip `dictKeyFieldRegistry`; `vault.dictionary(staticName)` mutation → `StaticDictReadonlyError` |
+| Query seam: code-table-backed `dictSource` for `resolveDictSource(field)` | ✓ | `query/builder.ts:1271` `buildDictLabelResolver` works unchanged; `snapshot()` materialises `table` → `[{key,labels}]` |
+| `groupBy by:'key'` (default) / `orderBy { by:'label' }` (active or `displayLocale`) | ✓ | `aggregate/groupby.ts:347-381` unchanged |
+| Put-time code validation against `desc.keys` | ✓ | `enforceI18nOnPut` (`vault.ts:761-765`) rejects an unknown code with `UnknownDictCodeError` (opt-out-able) |
+| `StaticDictReadonlyError` distinct from existing dict errors | ✓ | thrown on any mutation attempt against a static name |
+| Subsystem-doc update + showcase + `features.yaml` invariants | ✓ | reader-facing; honorific/civil-status end-to-end, incl. a **locale-less** read assertion |
+
+## v1 SCOPE — what's deferred / out
+
+| Feature | Status | Why |
+|---|---|---|
+| Large *external* reference datasets (TSIC, DOPA address tree, ISO country list) | **out** | domain data, not closed app enums — stay app-side reference tables (explicit non-goal in #291) |
+| Per-vault **override** of a static label | deferred | breaks "identical across vaults by construction"; would reintroduce `_dict_*`. Separate slice if ever needed. |
+| `displayLocale` as a per-read default rather than per-descriptor | deferred | descriptor-level is simplest and matches the consumer; a read-option default can layer on later |
+| Hot-reloading the table at runtime | out | a label change is a code deploy by definition |
+| Per-layer `onMissing` (guard/mv/derivation/join/export) for static dicts | follows #285 | the broader per-layer wiring is already deferred for `dictKey`; static inherits whatever lands there |
+
+## Wiring — the two seams (concrete)
+
+Embedding touches **two** label-resolution mechanisms; they are separate and both must be wired.
+
+### Seam 1 — read path (live resolver)
+
+`vault.ts:752-758` currently builds one closure for all dict fields. Branch on descriptor brand:
+
+```ts
+collOpts.dictLabelResolver = async (dictName, key, locale, fallback) => {
+  const stat = staticByName.get(dictName)          // descriptors with _noydbStaticDict
+  if (stat) {
+    const labels = stat.table[key]
+    return labels ? resolveFromMap(labels, locale, fallback) : undefined
+  }
+  return this.dictionary(dictName).resolveLabel(key, locale, fallback) // unchanged dictKey path
+}
+```
+
+The hybrid hinge is the **gate** at `collection.ts:3038-3043`. Today there are **two** sequential early-returns:
+
+```ts
+const hasI18n = this.i18nFields && Object.keys(this.i18nFields).length > 0
+const hasDict = this.dictKeyFields && Object.keys(this.dictKeyFields).length > 0
+if (!hasI18n && !hasDict) return record   // 3040 — nothing to resolve
+const locale = localeOpts?.locale ?? this.defaultLocale
+if (!locale) return record                // 3043 — locale-less ⇒ raw record (today's invariant)
+```
+
+Only the **second** return relaxes; the first (`3040`) stays verbatim. ⚠️ Do **not** fold `hasI18n` into the second return — that would let an i18nText-only collection fall through to `applyI18nLocale(..., undefined)` on a locale-less read, breaking the consumer's bare-`{th,en}`-map invariant (the very property this feature must preserve). Correct shape:
+
+```ts
+if (!hasI18n && !hasDict) return record               // 3040 — UNCHANGED
+const locale = localeOpts?.locale ?? this.defaultLocale
+const hasStaticDisplay = /* any static descriptor in this.dictKeyFields with displayLocale */
+if (!locale && !hasStaticDisplay) return record       // only static-display proceeds locale-less
+
+// The i18n sub-block (3048) MUST now be locale-guarded, because the relaxed gate
+// can be passed with locale === undefined when hasStaticDisplay:
+if (locale && hasI18n && this.i18nFields) { /* applyI18nLocale — unchanged */ }
+
+// dictKey/static sub-block (3053): per-field effLocale = locale ?? desc.displayLocale.
+//  - static field w/ displayLocale → resolves locale-lessly
+//  - plain dictKey field (no displayLocale) → effLocale undefined → resolver returns
+//    undefined → onMissing 'null' (default) omits the label, exactly as today.
+```
+
+Locking tests to keep / add:
+- `dictionary.test.ts:350-367` (plain `dictKey`, no `displayLocale`) — still returns the raw record locale-less. ✓ unchanged.
+- **NEW**: an `i18nText`-only collection on a locale-less vault still returns the raw `{th,en}` map — a direct regression guard for this gate edit. The existing dictKey test does **not** cover the i18n path, so this guard is mandatory.
+- **NEW**: a `staticDict` with `displayLocale` resolves `<field>Label` locale-less; the same descriptor without `displayLocale` does not.
+
+### Seam 2 — query path (snapshot resolver)
+
+`query/builder.ts:1271` `buildDictLabelResolver` reads `joinCtx.resolveDictSource(field)` → `dictSource.snapshot()` (today: a snapshot of the `_dict_*` collection). A static dict has no `_dict_*`. So `resolveDictSource` returns a **code-table-backed source** whose `snapshot()` yields `[{ key, labels }]` materialised from `desc.table`. `buildDictLabelResolver` then works **unchanged**. For a locale-less `{ by: 'label' }` query, the query locale defaults to the field's `displayLocale`.
+
+## Errors
+
+| Error | When | Distinct from |
+|---|---|---|
+| `StaticDictReadonlyError` | `put`/`rename`/`delete` against a static dict name | a static dict has no mutation surface |
+| `UnknownDictCodeError` | put-time: record stores a code not in `desc.keys` (opt-out-able) | `LocaleNotSpecifiedError` (read-hole) — this is a write-shape error |
+
+`LocaleNotSpecifiedError` is still raised by `onMissing:'throw'` when a code resolves to no label in the effective locale (unchanged policy).
+
+## Behavior matrix
+
+| Read | plain `dictKey` (today) | `staticDict` w/ `displayLocale:'th'` |
+|---|---|---|
+| locale-less vault, bare `get` | raw code, **no** `…Label` | code **+** `…Label` (via `displayLocale`) |
+| `get({ locale:'en' })` | `…Label` from `_dict_*` | `…Label` from code table |
+| `get({ locale:'raw' })` | raw (block skipped, `collection.ts:3053`) | raw (same) |
+| `groupBy(field)` | by code | by code |
+| `orderBy(field,{by:'label'})` | by `_dict_*` label @ locale | by code-table label @ locale ?? `displayLocale` |
+
+## Tree-shake / registry / showcase
+
+- All new code inside `withI18n()` / `i18n/*`; `NO_I18N` stub path unaffected; bundle gate unchanged.
+- **`features.yaml`** (the `i18n` entry, lines 318-344) MUST gain invariants, or the "Spec coverage" CI job fails on dangling refs. Proposed:
+  - `staticDict(name, table, {displayLocale}) resolves labels from an in-code table — no _dict_* collection, no rename()`
+  - `static dicts resolve under a locale-less read via displayLocale; plain dictKey does not (locale gate preserved)`
+  - `static dict names are read-only: put/rename/delete throw StaticDictReadonlyError`
+- New showcase (e.g. `96-with-static-dict.showcase.test.ts`) asserting: locale-less resolution via `displayLocale`, locale-active resolution, `groupBy by:'key'`, absence of any `_dict_*` adapter key, and `StaticDictReadonlyError` on mutation.
+
+## Worked trace (acceptance)
+
+1. `vault = openVault('co1')` — **no** locale.
+2. `collection('workers', { dictKeyFields: { civilStatus: staticDict('civilStatus', TABLE, { displayLocale:'th' }) } })`.
+3. `put({ id:'w1', civilStatus:'adultMale' })` — record stores only the code; no `_dict_civilStatus` key created.
+4. `get('w1')` → `{ id:'w1', civilStatus:'adultMale', civilStatusLabel:'นาย' }` (gate not early-returned; static branch uses `displayLocale`).
+5. `get('w1', { locale:'en' })` → `civilStatusLabel:'Mr'`.
+6. `query().orderBy('civilStatus', { by:'label' })` → sorts by label at the active locale, else `displayLocale`.
+7. `vault.dictionary('civilStatus').put(...)` → throws `StaticDictReadonlyError`.
+
+## Open decisions (for the plan)
+
+- **Validation default:** is `UnknownDictCodeError` on at write by default, or opt-in? Lean **on** (codes are closed by construction; a typo is a bug). Provide `validateCodes: false` escape hatch.
+- **`displayLocale` required?** If omitted, a static dict behaves like `dictKey` under a locale-less read (no label). Lean **optional** — omit ⇒ pure parity; set ⇒ hybrid. Document that a locale-less consumer almost always wants it set.
+- **Naming:** `staticDict` vs `codeDict`. `staticDict` matches the userland workaround and the issue title.
+
+## Milestone
+
+Attach #291 to **milestone #17** (i18n hardening). Sequence after the shipped #282/#283 parity (#284); independent of the deferred per-layer enforcement (#285). Estimated as one slice: descriptor + dual-seam wiring + readonly guard + showcase + `features.yaml` + subsystem-doc.

--- a/packages/as-blob/package.json
+++ b/packages/as-blob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-blob",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Single-attachment plaintext export for noy-db — extracts one blob from BlobSet as native MIME bytes. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier, document sub-family).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-csv/package.json
+++ b/packages/as-csv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-csv",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "CSV plaintext export for noy-db — decrypts records and formats as comma-separated values. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-json/package.json
+++ b/packages/as-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-json",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Structured JSON plaintext export for noy-db — decrypts records and emits one JSON document per vault. Gated by RFC #249 canExportPlaintext capability; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-ndjson/package.json
+++ b/packages/as-ndjson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-ndjson",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Newline-delimited JSON export for noy-db — streaming plaintext export suitable for data pipelines, warehouse ingestion, and jq pipelines. Gated by RFC #249 canExportPlaintext. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-noydb/package.json
+++ b/packages/as-noydb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-noydb",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Encrypted .noydb bundle export for noy-db — wraps writeNoydbBundle() with the RFC #249 canExportBundle authorization gate and ergonomic browser/node helpers. Sole member of the @noy-db/as-* encrypted tier — ciphertext in, ciphertext out.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-sql/package.json
+++ b/packages/as-sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-sql",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "SQL dump export for noy-db — decrypts records and emits dialect-aware CREATE TABLE + INSERT statements for postgres / mysql / sqlite. One-way migration helper. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xlsx/package.json
+++ b/packages/as-xlsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xlsx",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Excel spreadsheet plaintext export for noy-db — produces a real .xlsx (Office Open XML) from one or more collections. Multi-sheet, Unicode-safe via shared-strings table. Zero runtime deps beyond the workspace zip encoder. Gated by RFC #249 `canExportPlaintext` with format `'xlsx'`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xml/package.json
+++ b/packages/as-xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xml",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "XML plaintext export for noy-db — decrypts records and formats as XML with RFC-compliant entity escaping. For legacy systems, banking batch imports, SOAP endpoints, and accounting software that requires XML. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-zip/package.json
+++ b/packages/as-zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-zip",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Composite record + blob archive export for noy-db — bundles a collection's records plus every attached blob into one zip. Zero dependencies (STORE-only zip encoder). Gated by the RFC #249 `canExportPlaintext` capability bit with format `'zip'`. Part of the @noy-db/as-* portable-artefact family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-aws-kms/package.json
+++ b/packages/at-aws-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-aws-kms",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "AWS KMS sealing key provider for noy-db managed-passphrase mode — seal/unseal via KMS Encrypt/Decrypt, with KMS access logs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-azure-keyvault/package.json
+++ b/packages/at-azure-keyvault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-azure-keyvault",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Azure Key Vault sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-env/package.json
+++ b/packages/at-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-env",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Env-var sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a key from process.env. Smallest production-shape provider; pair with Kubernetes Secrets / Heroku env / AWS Secrets Manager.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-gcp-kms/package.json
+++ b/packages/at-gcp-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-gcp-kms",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Google Cloud KMS sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-macos-keychain/package.json
+++ b/packages/at-macos-keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-macos-keychain",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "macOS Keychain sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a 32-byte key stored in the user's login Keychain. Desktop-app provider in the at-* family; pairs with Touch ID via Keychain Access UI.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/attestation/package.json
+++ b/packages/attestation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/attestation",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Pure, zero-dependency document-attestation primitive for noy-db — per-field salted commitments, Ed25519 sign/verify, QR credential codec, and revocation checks. Runs in Node and the browser; the offline verifier imports only this.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-peer/package.json
+++ b/packages/by-peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-peer",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "WebRTC peer-to-peer transport for noy-db — direct browser-to-browser channel with signaling-agnostic handshake",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-tabs/package.json
+++ b/packages/by-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-tabs",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "BroadcastChannel multi-tab transport for noy-db — sync between tabs of the same browser without round-tripping the storage backend",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/cli",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Command-line tool for noy-db — inspect .noydb bundles without decrypting, verify integrity, validate config objects, scaffold topology profiles, and monitor a live vault's store metrics.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/create-noy-db/package.json
+++ b/packages/create-noy-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-noy-db",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Wizard + CLI tool for noy-db: scaffold a fresh Nuxt 4 + Pinia encrypted store, or add collections to an existing project. Invoke via `npm create @noy-db`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/hub/CHANGELOG.md
+++ b/packages/hub/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog — hub
 
+## 0.2.0-pre.10
+
+Adopter-reported correctness + introspection batch.
+
+### Fix: unique indexes are now enforced ([#293](https://github.com/vLannaAi/noy-db/issues/293))
+
+- `{ fields: [...], unique: true }` on a collection index is **enforced at write time** — single-field **and** composite. A duplicate of an existing non-null value is rejected with the new **`UniqueConstraintError`** (carrying `collection` / `recordId` / `fields` / `conflictingId`). Previously `unique: true` was silently dropped — the input `IndexDef` didn't even carry the flag — a data-integrity footgun.
+- **Null-tolerant** (SQL NULL-distinct): the constraint applies only when every constrained field is non-null; duplicate `null`/`undefined` values coexist.
+- Enforcement covers `put` / `putMany` / `delete`, the atomic-rollback path, and the hydration rebuild (uniqueness holds against records written in a prior session).
+- **Eager mode only.** Declaring `unique` on a lazy (`prefetch:false`), CRDT, or tiered collection now **fails loud** at registration with the new **`UnsupportedIndexOptionError`** (those write paths bypass the check, so silent acceptance is refused).
+
+### Fix: `dumpSchema()` completeness ([#294](https://github.com/vLannaAi/noy-db/issues/294), [#295](https://github.com/vLannaAi/noy-db/issues/295))
+
+- Surfaces fields for **`z.discriminatedUnion`** schemas — the union of member fields (required only when required in *all* members), with the discriminator's literal set. Previously returned `fields: {}`. ([#294](https://github.com/vLannaAi/noy-db/issues/294))
+- Populates the **`derivations`** and **`overlayViews`** maps (both registries gained an `all()`); derivations are keyed by **output collection**, so multiple derivations sharing one source no longer collide. ([#295](https://github.com/vLannaAi/noy-db/issues/295))
+- Materialized-view `aggregate` ops now render as **`sum(field)`** / **`count`** instead of `"[object Object]"` (reducers carry `op`/`field` metadata). ([#295](https://github.com/vLannaAi/noy-db/issues/295))
+
+### Feature: omit rows from a materialized view ([#297](https://github.com/vLannaAi/noy-db/issues/297))
+
+- A `unionSources` `map` callback may return **`null`/`undefined`** to omit a source record from the view — no more sentinel rows. (Derivation `derive` omission was already supported at runtime via `optional` outputs.)
+
+### Feature: discriminated-union narrowing helper ([#296](https://github.com/vLannaAi/noy-db/issues/296))
+
+- New **`isDiscriminant(record, key, value)`** type-guard narrows a `Collection<Union>` read by its discriminant without `as unknown as` casts. See `docs/core/06-query-basics.md`.
+
 ## 0.2.0-pre.9
 
 ### Feature: automatic snapshot cadence ([#272](https://github.com/vLannaAi/noy-db/issues/272))

--- a/packages/hub/__tests__/discriminant.test-d.ts
+++ b/packages/hub/__tests__/discriminant.test-d.ts
@@ -1,0 +1,111 @@
+/**
+ * Type-level tests for isDiscriminant() — validated by
+ * `pnpm --filter @noy-db/hub run typecheck` (tsc -p tsconfig.typetest.json).
+ *
+ * These assertions prove that the type-guard actually narrows the union member
+ * type so that member-specific fields are accessible without any cast.
+ */
+import { describe, it, expectTypeOf } from 'vitest'
+import { isDiscriminant } from '../src/util/discriminant.js'
+
+// ─── Fixture ─────────────────────────────────────────────────────────────────
+
+type IV = { kind: 'IV'; invoiceNo: string; amount: number }
+type RE = { kind: 'RE'; receiptNo: string; paidAt: string }
+type DP = { kind: 'DP'; depositRef: string }
+type RD = { kind: 'RD'; refundOf: string }
+type Receipt = IV | RE | DP | RD
+
+const receipts: Receipt[] = [
+  { kind: 'IV', invoiceNo: 'INV-001', amount: 1200 },
+  { kind: 'RE', receiptNo: 'RCP-001', paidAt: '2026-01-01' },
+  { kind: 'DP', depositRef: 'DEP-001' },
+  { kind: 'RD', refundOf: 'INV-001' },
+]
+
+describe('isDiscriminant() — type narrowing', () => {
+  it('filter result is narrowed to the matched member type (IV[])', () => {
+    const ivs = receipts.filter(r => isDiscriminant(r, 'kind', 'IV'))
+    expectTypeOf(ivs).toEqualTypeOf<IV[]>()
+  })
+
+  it('element type of filtered array is exactly IV', () => {
+    const ivs = receipts.filter(r => isDiscriminant(r, 'kind', 'IV'))
+    type Elem = (typeof ivs)[number]
+    expectTypeOf<Elem>().toEqualTypeOf<IV>()
+  })
+
+  it('narrowed element gives access to member-specific fields without cast', () => {
+    const ivs = receipts.filter(r => isDiscriminant(r, 'kind', 'IV'))
+    // noUncheckedIndexedAccess: use the known-present element via non-null assertion
+    const first = ivs[0]!
+    // Direct field assignment: if this compiled without `as`, narrowing works
+    const no: string = first.invoiceNo
+    const amt: number = first.amount
+    void no
+    void amt
+  })
+
+  it('accessing a field from a *different* member on the narrowed type is a type error', () => {
+    const ivs = receipts.filter(r => isDiscriminant(r, 'kind', 'IV'))
+    const first = ivs[0]!
+    // receiptNo only exists on RE, not IV — this must be a compile error
+    // @ts-expect-error Property 'receiptNo' does not exist on type 'IV'
+    void first.receiptNo
+  })
+
+  it('if-branch narrows to IV and member fields are accessible', () => {
+    const r = receipts[0]!
+    if (isDiscriminant(r, 'kind', 'IV')) {
+      // r must be IV here — direct field access without cast
+      const no: string = r.invoiceNo
+      const amt: number = r.amount
+      void no; void amt
+      // @ts-expect-error Property 'receiptNo' does not exist on type 'IV'
+      void r.receiptNo
+    }
+  })
+
+  it('if-branch for RE narrows to RE', () => {
+    const r = receipts[0]!
+    if (isDiscriminant(r, 'kind', 'RE')) {
+      const paid: string = r.paidAt
+      void paid
+      // @ts-expect-error Property 'invoiceNo' does not exist on type 'RE'
+      void r.invoiceNo
+    }
+  })
+
+  it('works with non-"kind" discriminant key', () => {
+    type DocA = { type: 'A'; aField: string }
+    type DocB = { type: 'B'; bField: number }
+    type Doc = DocA | DocB
+
+    const docs: Doc[] = [
+      { type: 'A', aField: 'hello' },
+      { type: 'B', bField: 42 },
+    ]
+
+    const aOnly = docs.filter(d => isDiscriminant(d, 'type', 'A'))
+    expectTypeOf(aOnly).toEqualTypeOf<DocA[]>()
+    const first = aOnly[0]!
+    const val: string = first.aField
+    void val
+    // @ts-expect-error bField does not exist on DocA
+    void first.bField
+  })
+
+  it('if-branch with non-"kind" key narrows correctly', () => {
+    type DocA = { type: 'A'; aField: string }
+    type DocB = { type: 'B'; bField: number }
+    type Doc = DocA | DocB
+
+    const d: Doc = { type: 'A', aField: 'hello' }
+    if (isDiscriminant(d, 'type', 'A')) {
+      const val: string = d.aField
+      void val
+      // @ts-expect-error bField does not exist on DocA
+      void d.bField
+    }
+  })
+})

--- a/packages/hub/__tests__/discriminant.test.ts
+++ b/packages/hub/__tests__/discriminant.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Runtime tests for isDiscriminant() — type-guard helper for discriminated-union
+ * Collection<T> results.
+ *
+ * These are pure runtime assertions (boolean returns, field values).
+ * Type-level narrowing assertions live in discriminant.test-d.ts
+ * (validated by `pnpm --filter @noy-db/hub run typecheck`).
+ */
+import { describe, it, expect } from 'vitest'
+import { isDiscriminant } from '../src/util/discriminant.js'
+
+// ─── Fixture ─────────────────────────────────────────────────────────────────
+
+type IV = { kind: 'IV'; invoiceNo: string; amount: number }
+type RE = { kind: 'RE'; receiptNo: string; paidAt: string }
+type DP = { kind: 'DP'; depositRef: string }
+type RD = { kind: 'RD'; refundOf: string }
+type Receipt = IV | RE | DP | RD
+
+const receipts: Receipt[] = [
+  { kind: 'IV', invoiceNo: 'INV-001', amount: 1200 },
+  { kind: 'RE', receiptNo: 'RCP-001', paidAt: '2026-01-01' },
+  { kind: 'IV', invoiceNo: 'INV-002', amount: 800 },
+  { kind: 'DP', depositRef: 'DEP-001' },
+  { kind: 'RD', refundOf: 'INV-001' },
+]
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('isDiscriminant()', () => {
+  it('returns true when the record matches the discriminant value', () => {
+    expect(isDiscriminant(receipts[0], 'kind', 'IV')).toBe(true)
+    expect(isDiscriminant(receipts[1], 'kind', 'RE')).toBe(true)
+    expect(isDiscriminant(receipts[3], 'kind', 'DP')).toBe(true)
+    expect(isDiscriminant(receipts[4], 'kind', 'RD')).toBe(true)
+  })
+
+  it('returns false when the record does not match the discriminant value', () => {
+    expect(isDiscriminant(receipts[0], 'kind', 'RE')).toBe(false)
+    expect(isDiscriminant(receipts[1], 'kind', 'IV')).toBe(false)
+    expect(isDiscriminant(receipts[3], 'kind', 'IV')).toBe(false)
+  })
+
+  it('filters a union array to a single member type and field is accessible', () => {
+    const ivs = receipts.filter(r => isDiscriminant(r, 'kind', 'IV'))
+    expect(ivs).toHaveLength(2)
+    // Runtime field-value assertion (type-level assertion is in .test-d.ts)
+    expect(ivs[0].invoiceNo).toBe('INV-001')
+    expect(ivs[1].invoiceNo).toBe('INV-002')
+    expect(ivs[0].amount).toBe(1200)
+  })
+
+  it('returns empty array when no records match', () => {
+    const result = receipts.filter(r => isDiscriminant(r, 'kind', 'IV' as never))
+    // This checks runtime — all receipts do have 'kind', so we filter a non-existent value
+    const noMatch = receipts.filter(r => isDiscriminant(r, 'kind', 'XX' as Receipt['kind']))
+    expect(noMatch).toHaveLength(0)
+  })
+
+  it('works with a non-"kind" discriminant key', () => {
+    type DocA = { type: 'A'; aField: string }
+    type DocB = { type: 'B'; bField: number }
+    type Doc = DocA | DocB
+
+    const docs: Doc[] = [
+      { type: 'A', aField: 'hello' },
+      { type: 'B', bField: 42 },
+      { type: 'A', aField: 'world' },
+    ]
+
+    const aOnly = docs.filter(d => isDiscriminant(d, 'type', 'A'))
+    expect(aOnly).toHaveLength(2)
+    expect(aOnly[0].aField).toBe('hello')
+    expect(aOnly[1].aField).toBe('world')
+  })
+
+  it('works as a standalone if-branch (not just filter)', () => {
+    const r = receipts[0]
+    if (isDiscriminant(r, 'kind', 'IV')) {
+      expect(r.invoiceNo).toBe('INV-001')
+    } else {
+      throw new Error('should have matched IV')
+    }
+  })
+})

--- a/packages/hub/__tests__/dumpschema-strategies.test.ts
+++ b/packages/hub/__tests__/dumpschema-strategies.test.ts
@@ -141,6 +141,67 @@ describe('dumpSchema() — overlay views (Gap 2)', () => {
   })
 })
 
+// ─── Regression: co-sourced derivations (two derivations, same source) ──────
+
+interface Bill extends Record<string, unknown> {
+  id: string
+  amount: number
+  status: string
+}
+
+interface BillSummary extends Record<string, unknown> {
+  id: string
+  total: number
+}
+
+interface BillDerivedStatus extends Record<string, unknown> {
+  id: string
+  derived: string
+}
+
+describe('dumpSchema() — co-sourced derivations (#295 regression)', () => {
+  it('two derivations sharing the same source both appear in snap.derivations', async () => {
+    const summaryHandle = withDerivation({
+      source: 'bills',
+      deterministic: true,
+      outputs: { summary: { shape: 'record', collection: 'billSummary' } },
+      derive: (s: Bill) => ({ summary: { id: s.id, total: s.amount } }),
+      lifecycle: 'eager',
+    })
+
+    const statusHandle = withDerivation({
+      source: 'bills',
+      deterministic: true,
+      outputs: { derivedStatus: { shape: 'record', collection: 'billDerivedStatus' } },
+      derive: (s: Bill) => ({ derivedStatus: { id: s.id, derived: `${s.status}-derived` } }),
+      lifecycle: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'dumpschema-cosourced-passphrase-2026',
+      derivationStrategies: [summaryHandle, statusHandle],
+    })
+    const vault = await db.openVault('acme')
+
+    // Fire a write so both derivations run (confirms no engine rejection at runtime)
+    await vault.collection<Bill>('bills').put('b1', { id: 'b1', amount: 500, status: 'open' })
+
+    const snap = await vault.dumpSchema()
+
+    // Both derivations must appear — they must NOT collide on the 'bills' key
+    expect(Object.keys(snap.derivations)).toHaveLength(2)
+    // Each entry should be findable by its output collection name
+    expect(snap.derivations['billSummary']).toBeDefined()
+    expect(snap.derivations['billSummary']!.source).toBe('bills')
+    expect(snap.derivations['billSummary']!.outputs).toContain('billSummary')
+    expect(snap.derivations['billDerivedStatus']).toBeDefined()
+    expect(snap.derivations['billDerivedStatus']!.source).toBe('bills')
+    expect(snap.derivations['billDerivedStatus']!.outputs).toContain('billDerivedStatus')
+  })
+})
+
 // ─── Gap 3: MV aggregate rendering ──────────────────────────────────────────
 
 describe('dumpSchema() — MV aggregate ops (Gap 3)', () => {

--- a/packages/hub/__tests__/dumpschema-strategies.test.ts
+++ b/packages/hub/__tests__/dumpschema-strategies.test.ts
@@ -1,0 +1,233 @@
+/**
+ * dumpSchema() — derivations, overlay views, and MV aggregate rendering.
+ *
+ * Covers the three introspection gaps from issue #295:
+ *   1. derivations map comes back empty (DerivationRegistry lacks all())
+ *   2. overlayViews map comes back empty (OverlayedViewRegistry lacks all())
+ *   3. MV aggregate renders as "[object Object]" (reducers lack op/field metadata)
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope } from '../src/types.js'
+import {
+  createNoydb,
+  withDerivation,
+  withMaterializedView,
+  withOverlayedView,
+  sum,
+  count,
+} from '../src/index.js'
+import { withAggregate } from '../src/aggregate/index.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const parts = key.split('/')
+        const vname = parts[0], cname = parts[1], id = parts[2]
+        if (vname === v && cname && id) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface Invoice extends Record<string, unknown> {
+  id: string
+  amount: number
+  status: string
+}
+
+interface InvoiceMeta extends Record<string, unknown> {
+  id: string
+  len: number
+}
+
+// ─── Gap 1: derivations ──────────────────────────────────────────────────────
+
+describe('dumpSchema() — derivations (Gap 1)', () => {
+  it('derivations map is non-empty after registering a derivation strategy', async () => {
+    const handle = withDerivation({
+      source: 'invoices',
+      deterministic: true,
+      outputs: { meta: { shape: 'record', collection: 'invoice-meta' } },
+      derive: (s: Invoice) => ({ meta: { id: s.id, len: String(s.id).length } }),
+      lifecycle: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'dumpschema-derivations-passphrase-2026',
+      derivationStrategies: [handle],
+    })
+    const vault = await db.openVault('acme')
+
+    // Write a record so the derivation fires (confirms end-to-end wiring)
+    await vault.collection<Invoice>('invoices').put('i1', { id: 'i1', amount: 100, status: 'draft' })
+
+    const snap = await vault.dumpSchema()
+
+    // Gap 1 check: derivations must not be empty
+    expect(Object.keys(snap.derivations)).not.toHaveLength(0)
+
+    // The descriptor for the invoices derivation should have correct fields
+    const entry = Object.values(snap.derivations)[0]
+    expect(entry).toBeDefined()
+    expect(entry!.source).toBe('invoices')
+    expect(entry!.outputs).toContain('invoice-meta')
+  })
+})
+
+// ─── Gap 2: overlay views ────────────────────────────────────────────────────
+
+describe('dumpSchema() — overlay views (Gap 2)', () => {
+  it('overlayViews map is non-empty after registering an overlay', async () => {
+    const baseMV = withMaterializedView<Invoice>({
+      name: 'invoices-base',
+      sources: ['invoices'],
+      query: (db) => db.collection<Invoice>('invoices').query(),
+      rowKey: (r) => r.id,
+      refresh: 'eager',
+    })
+
+    const overlay = withOverlayedView({
+      name: 'invoices-view',
+      base: 'invoices-base',
+      overlay: 'invoices-overrides',
+      shadowField: 'status',
+      shadowValue: 'override',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'dumpschema-overlay-passphrase-2026',
+      materializedViewStrategies: [baseMV],
+      overlayedViewStrategies: [overlay],
+    })
+    const vault = await db.openVault('acme')
+
+    const snap = await vault.dumpSchema()
+
+    // Gap 2 check: overlayViews must not be empty
+    expect(Object.keys(snap.overlayViews)).not.toHaveLength(0)
+
+    const entry = snap.overlayViews['invoices-view']
+    expect(entry).toBeDefined()
+    expect(entry!.base).toBe('invoices-base')
+    expect(entry!.overlay).toBe('invoices-overrides')
+  })
+})
+
+// ─── Gap 3: MV aggregate rendering ──────────────────────────────────────────
+
+describe('dumpSchema() — MV aggregate ops (Gap 3)', () => {
+  it('sum reducer renders as "sum(field)" not "[object Object]"', async () => {
+    // Use UNION-form MV so that spec.aggregate is populated (the introspection
+    // path reads spec.aggregate directly — query-form groupBy().aggregate()
+    // embeds the spec in the query, not in the strategy).
+    const mv = withMaterializedView<{ client_id: string; total: number }>({
+      name: 'invoice-totals',
+      unionSources: [
+        {
+          collection: 'invoices',
+          map: (r: Record<string, unknown>) => ({
+            client_id: r.client_id as string,
+            total: r.amount as number,
+          }),
+        },
+        {
+          collection: 'credit-notes',
+          map: (r: Record<string, unknown>) => ({
+            client_id: r.client_id as string,
+            total: -(r.amount as number),
+          }),
+        },
+      ],
+      groupBy: 'client_id',
+      aggregate: { total: sum('total') },
+      rowKey: (r) => r.client_id,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'dumpschema-aggregate-passphrase-2026',
+      aggregateStrategy: withAggregate(),
+      materializedViewStrategies: [mv],
+    })
+    const vault = await db.openVault('acme')
+
+    const snap = await vault.dumpSchema()
+    const desc = snap.materializedViews['invoice-totals']
+    expect(desc).toBeDefined()
+    expect(desc!.aggregate).toBeDefined()
+    // Gap 3 check: must be 'sum(total)', NOT '[object Object]'
+    expect(desc!.aggregate!.total).toBe('sum(total)')
+  })
+
+  it('count reducer renders as "count"', async () => {
+    const mv = withMaterializedView<{ client_id: string; n: number }>({
+      name: 'invoice-counts',
+      unionSources: [
+        {
+          collection: 'invoices',
+          map: (r: Record<string, unknown>) => ({
+            client_id: r.client_id as string,
+            n: 1,
+          }),
+        },
+        {
+          collection: 'extras',
+          map: (r: Record<string, unknown>) => ({
+            client_id: r.client_id as string,
+            n: 1,
+          }),
+        },
+      ],
+      groupBy: 'client_id',
+      aggregate: { n: count() },
+      rowKey: (r) => r.client_id,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'dumpschema-count-passphrase-2026',
+      aggregateStrategy: withAggregate(),
+      materializedViewStrategies: [mv],
+    })
+    const vault = await db.openVault('acme')
+
+    const snap = await vault.dumpSchema()
+    const desc = snap.materializedViews['invoice-counts']
+    expect(desc).toBeDefined()
+    expect(desc!.aggregate).toBeDefined()
+    // Gap 3 check: must be 'count', NOT '[object Object]'
+    expect(desc!.aggregate!.n).toBe('count')
+  })
+})

--- a/packages/hub/__tests__/dumpschema-union.test.ts
+++ b/packages/hub/__tests__/dumpschema-union.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Regression test for issue #294:
+ * `vault.dumpSchema()` returns `fields: {}` for collections whose schema is a
+ * `z.discriminatedUnion(...)`.
+ *
+ * Root cause: `jsonSchemaToFields()` bailed early when the top-level JSON
+ * Schema had `anyOf` instead of `properties` (which is what zod-to-json-schema
+ * emits for a discriminated union).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { z } from 'zod'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+import { createNoydb } from '../src/noydb.js'
+import type { Noydb } from '../src/noydb.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+const Iv = z.object({ kind: z.literal('IV'), billId: z.string(), paidTotal: z.number() })
+const Re = z.object({ kind: z.literal('RE'), billId: z.string(), amount: z.number() })
+const ReceiptUnion = z.discriminatedUnion('kind', [Iv, Re])
+const ReceiptUnionWithRefine = z.discriminatedUnion('kind', [Iv, Re]).superRefine(() => {})
+
+describe('vault.dumpSchema() — discriminated union fields (#294)', () => {
+  const COMP = 'firm'
+  let db: Noydb
+
+  beforeEach(async () => {
+    db = await createNoydb({ store: memory(), user: 'owner-01', secret: 'pass' })
+  })
+
+  it('surfaces fields for a bare discriminated union (persistJsonSchema)', async () => {
+    const vault = await db.openVault(COMP)
+    vault.collection('receipts', { schema: ReceiptUnion, persistJsonSchema: true })
+    await vault._drainPendingSchemaWrites()
+
+    const snap = await vault.dumpSchema()
+    const fields = snap.collections['receipts']?.fields
+
+    // 1. fields must NOT be empty
+    expect(fields).toBeDefined()
+    expect(Object.keys(fields!)).not.toHaveLength(0)
+
+    // 2. common field billId is present
+    expect(fields).toHaveProperty('billId')
+
+    // 3. member-specific fields present (union of all member fields)
+    expect(fields).toHaveProperty('paidTotal')
+    expect(fields).toHaveProperty('amount')
+
+    // 4. discriminator field kind is present and surfaces its literal set
+    expect(fields).toHaveProperty('kind')
+    const kindField = fields!['kind']
+    expect(kindField?.type).toBe('enum')
+    expect(kindField?.constraints?.values).toEqual(expect.arrayContaining(['IV', 'RE']))
+  })
+
+  it('member-specific fields are marked optional; common field billId is required', async () => {
+    const vault = await db.openVault(COMP)
+    vault.collection('receipts', { schema: ReceiptUnion, persistJsonSchema: true })
+    await vault._drainPendingSchemaWrites()
+
+    const snap = await vault.dumpSchema()
+    const fields = snap.collections['receipts']?.fields!
+
+    // billId is required in both members → not optional
+    expect(fields['billId']?.optional).toBeFalsy()
+
+    // paidTotal only in Iv member → optional
+    expect(fields['paidTotal']?.optional).toBe(true)
+
+    // amount only in Re member → optional
+    expect(fields['amount']?.optional).toBe(true)
+  })
+
+  it('surfaces fields for a discriminated union wrapped in .superRefine() (ZodEffects)', async () => {
+    const vault = await db.openVault(COMP)
+    vault.collection('receipts', { schema: ReceiptUnionWithRefine, persistJsonSchema: true })
+    await vault._drainPendingSchemaWrites()
+
+    const snap = await vault.dumpSchema()
+    const fields = snap.collections['receipts']?.fields
+
+    // superRefine wrapping should NOT cause empty fields
+    expect(fields).toBeDefined()
+    expect(Object.keys(fields!)).not.toHaveLength(0)
+    expect(fields).toHaveProperty('billId')
+    expect(fields).toHaveProperty('kind')
+  })
+
+  it('live-validator path also surfaces fields for discriminated union (no persistJsonSchema)', async () => {
+    const vault = await db.openVault(COMP)
+    vault.collection('receipts', { schema: ReceiptUnion })
+
+    const snap = await vault.dumpSchema()
+    const fields = snap.collections['receipts']?.fields
+
+    expect(fields).toBeDefined()
+    expect(Object.keys(fields!)).not.toHaveLength(0)
+    expect(fields).toHaveProperty('billId')
+    expect(fields).toHaveProperty('kind')
+    expect(fields).toHaveProperty('paidTotal')
+    expect(fields).toHaveProperty('amount')
+  })
+})

--- a/packages/hub/__tests__/mv-map-drop-row.test.ts
+++ b/packages/hub/__tests__/mv-map-drop-row.test.ts
@@ -1,0 +1,189 @@
+/**
+ * #297 — UNION MV `map` returning null/undefined should drop the source
+ * row from the output instead of pushing a null value downstream.
+ *
+ * Before the fix, `arm.map(r)` was pushed unconditionally into `unified`,
+ * so a null return ended up in the groupBy/aggregate pipeline and either
+ * threw (canonicalGroupKey reading fields off null) or produced a bad row.
+ *
+ * After the fix: `if (mapped == null) continue` — the row is silently
+ * omitted and only genuinely mapped rows flow into the aggregate.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withMaterializedView, sum } from '../src/index.js'
+import { withAggregate } from '../src/aggregate/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface InvoiceRow extends Record<string, unknown> {
+  id: string
+  clientId: string
+  period: string
+  amount: number
+  /** 'posted' rows should be included; 'draft' rows should be dropped */
+  status: 'posted' | 'draft'
+}
+
+interface MvRow extends Record<string, unknown> {
+  clientId: string
+  period: string
+  total: number
+}
+
+describe('UNION MV map drop-row (#297)', () => {
+  it('map returning null drops the source row — only posted rows appear in the output', async () => {
+    const invoiceTotals = withMaterializedView<MvRow>({
+      name: 'invoiceTotals',
+      unionSources: [
+        {
+          collection: 'invoices',
+          // Return null for drafts — they should be omitted from the MV.
+          // This is the core type widening: (sourceRow) => MvRow | null
+          map: (r): MvRow | null => {
+            const inv = r as unknown as InvoiceRow
+            if (inv.status === 'draft') return null
+            return { clientId: inv.clientId, period: inv.period, total: inv.amount }
+          },
+        },
+        {
+          collection: 'adjustments',
+          map: (r): MvRow | null => {
+            const inv = r as unknown as InvoiceRow
+            if (inv.status === 'draft') return null
+            return { clientId: inv.clientId, period: inv.period, total: inv.amount }
+          },
+        },
+      ],
+      groupBy: ['clientId', 'period'],
+      aggregate: { total: sum('total') },
+      rowKey: row => `${row.clientId}|${row.period}`,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-map-drop-row-passphrase-2026',
+      materializedViewStrategies: [invoiceTotals],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('demo')
+
+    const invoices = vault.collection<InvoiceRow>('invoices')
+    const adjustments = vault.collection<InvoiceRow>('adjustments')
+
+    // Posted — should appear in MV
+    await invoices.put('inv-1', { id: 'inv-1', clientId: 'c1', period: '2026-05', amount: 100, status: 'posted' })
+    await invoices.put('inv-2', { id: 'inv-2', clientId: 'c1', period: '2026-05', amount: 50,  status: 'posted' })
+    // Draft — map returns null → must NOT appear in any output bucket
+    await invoices.put('inv-3', { id: 'inv-3', clientId: 'c1', period: '2026-05', amount: 999, status: 'draft' })
+    await invoices.put('inv-4', { id: 'inv-4', clientId: 'c2', period: '2026-05', amount: 888, status: 'draft' })
+    // Posted in second arm — should appear
+    await adjustments.put('adj-1', { id: 'adj-1', clientId: 'c1', period: '2026-05', amount: 20, status: 'posted' })
+    // Draft in second arm — map returns null → must NOT appear
+    await adjustments.put('adj-2', { id: 'adj-2', clientId: 'c2', period: '2026-05', amount: 777, status: 'draft' })
+
+    const out = vault.collection<MvRow & { _materializedFrom?: unknown }>('invoiceTotals')
+    const rows = await out.list()
+
+    // Only c1|2026-05 should exist — c2 had only drafts in both arms,
+    // so no posted rows means no bucket for c2.
+    expect(rows).toHaveLength(1)
+
+    const c1Row = await out.get('c1|2026-05')
+    expect(c1Row).not.toBeNull()
+    expect(c1Row?.clientId).toBe('c1')
+    expect(c1Row?.period).toBe('2026-05')
+    // 100 + 50 + 20 = 170; 999 and 888 and 777 (all draft) must not be included
+    expect(c1Row?.total).toBe(170)
+
+    // c2 had only drafts — no row should exist
+    const c2Row = await out.get('c2|2026-05')
+    expect(c2Row).toBeNull()
+  })
+
+  it('map returning undefined also drops the source row', async () => {
+    const totals = withMaterializedView<MvRow>({
+      name: 'totals',
+      unionSources: [
+        {
+          collection: 'invoices',
+          map: (r): MvRow | undefined => {
+            const inv = r as unknown as InvoiceRow
+            if (inv.status === 'draft') return undefined
+            return { clientId: inv.clientId, period: inv.period, total: inv.amount }
+          },
+        },
+        {
+          collection: 'adjustments',
+          map: (r): MvRow | undefined => {
+            const inv = r as unknown as InvoiceRow
+            if (inv.status === 'draft') return undefined
+            return { clientId: inv.clientId, period: inv.period, total: inv.amount }
+          },
+        },
+      ],
+      groupBy: ['clientId', 'period'],
+      aggregate: { total: sum('total') },
+      rowKey: row => `${row.clientId}|${row.period}`,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-map-drop-row-undef-passphrase-2026',
+      materializedViewStrategies: [totals],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('demo')
+
+    const invoices = vault.collection<InvoiceRow>('invoices')
+    const adjustments = vault.collection<InvoiceRow>('adjustments')
+
+    await invoices.put('inv-1', { id: 'inv-1', clientId: 'c1', period: '2026-05', amount: 200, status: 'posted' })
+    await invoices.put('inv-2', { id: 'inv-2', clientId: 'c1', period: '2026-05', amount: 100, status: 'draft' })
+    await adjustments.put('adj-1', { id: 'adj-1', clientId: 'c1', period: '2026-05', amount: 50, status: 'draft' })
+
+    const out = vault.collection<MvRow & { _materializedFrom?: unknown }>('totals')
+    const rows = await out.list()
+    expect(rows).toHaveLength(1)
+
+    const c1Row = await out.get('c1|2026-05')
+    expect(c1Row).not.toBeNull()
+    // Only the one posted invoice (200); the two drafts are dropped
+    expect(c1Row?.total).toBe(200)
+  })
+})

--- a/packages/hub/__tests__/unique-index.test.ts
+++ b/packages/hub/__tests__/unique-index.test.ts
@@ -19,7 +19,7 @@ import { createNoydb } from '../src/noydb.js'
 import { withIndexing } from '../src/indexing/index.js'
 import type { Noydb } from '../src/noydb.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
-import { ConflictError, UniqueConstraintError } from '../src/errors.js'
+import { ConflictError, UniqueConstraintError, UnsupportedIndexOptionError } from '../src/errors.js'
 
 // ── inline memory adapter ────────────────────────────────────────────────────
 function memory(): NoydbStore {
@@ -236,7 +236,7 @@ describe('putMany intra-batch duplicate', () => {
 
 // ── 8. Lazy fail-loud ────────────────────────────────────────────────────────
 describe('lazy mode fail-loud', () => {
-  it('throws at collection registration when unique index declared with prefetch:false', async () => {
+  it('throws UnsupportedIndexOptionError at collection registration when unique index declared with prefetch:false', async () => {
     const vault = await openVault()
     expect(() =>
       vault.collection<{ k: string }>('lazy-unique', {
@@ -244,7 +244,7 @@ describe('lazy mode fail-loud', () => {
         cache: { maxRecords: 100 },
         indexes: [{ fields: ['k'], unique: true }],
       }),
-    ).toThrow(/unique indexes.*lazy mode|lazy mode.*unique/i)
+    ).toThrow(UnsupportedIndexOptionError)
   })
 })
 
@@ -285,5 +285,53 @@ describe('unique index queryable', () => {
     const results = await col.query().where('taxId', '==', 'TX-001').toArray()
     expect(results).toHaveLength(1)
     expect(results[0]).toMatchObject({ taxId: 'TX-001', name: 'Alice' })
+  })
+})
+
+// ── 11. Hydration/rebuild regression — two-session path ──────────────────────
+describe('hydration rebuild (two-session path)', () => {
+  it('enforces unique constraint against records written in a prior session', async () => {
+    // One shared store so both instances see the same persisted data.
+    const sharedStore = memory()
+
+    // Session 1: write a record.
+    const db1 = await createNoydb({
+      store: sharedStore,
+      indexStrategy: withIndexing(),
+      secret: 'unique-index-test-pass',
+    })
+    const vault1 = await db1.openVault('shared-v')
+    const col1 = vault1.collection<{ taxId: string }>('employees', {
+      indexes: [{ fields: ['taxId'], unique: true }],
+    })
+    await col1.put('a', { taxId: 'TX-001' })
+
+    // Session 2: open the same vault + same collection on the same store.
+    // The unique-constraint map must be rebuilt from the hydrated cache so
+    // that 'b' with the same taxId is rejected.
+    const db2 = await createNoydb({
+      store: sharedStore,
+      indexStrategy: withIndexing(),
+      secret: 'unique-index-test-pass',
+    })
+    const vault2 = await db2.openVault('shared-v')
+    const col2 = vault2.collection<{ taxId: string }>('employees', {
+      indexes: [{ fields: ['taxId'], unique: true }],
+    })
+
+    await expect(col2.put('b', { taxId: 'TX-001' })).rejects.toThrow(UniqueConstraintError)
+  })
+})
+
+// ── 12. CRDT + unique guard ───────────────────────────────────────────────────
+describe('CRDT mode fail-loud', () => {
+  it('throws UnsupportedIndexOptionError at registration when unique index declared on a CRDT collection', async () => {
+    const vault = await openVault()
+    expect(() =>
+      vault.collection<{ taxId: string }>('crdt-unique', {
+        crdt: 'lww-map',
+        indexes: [{ fields: ['taxId'], unique: true }],
+      }),
+    ).toThrow(UnsupportedIndexOptionError)
   })
 })

--- a/packages/hub/__tests__/unique-index.test.ts
+++ b/packages/hub/__tests__/unique-index.test.ts
@@ -248,7 +248,30 @@ describe('lazy mode fail-loud', () => {
   })
 })
 
-// ── 9. Unique index still queryable ─────────────────────────────────────────
+// ── 9. putManyAtomic rollback: no ghost entries ──────────────────────────────
+describe('putManyAtomic rollback ghost-record regression', () => {
+  it('allows a fresh insert of a value after an atomic batch rolled it back', async () => {
+    const vault = await openVault()
+    const col = vault.collection<{ taxId: string }>('employees', {
+      indexes: [{ fields: ['taxId'], unique: true }],
+    })
+
+    // Phase 1: atomic batch — entry 'b' collides with 'a' → whole batch fails
+    // but 'a' was already written to store (putManyAtomic writes then reverts)
+    await expect(
+      col.putMany([
+        ['a', { taxId: 'TX-001' }],
+        ['b', { taxId: 'TX-001' }],
+      ], { atomic: true }),
+    ).rejects.toThrow(UniqueConstraintError)
+
+    // After rollback both 'a' and 'b' should be absent.
+    // TX-001 must be claimable again — no ghost entry in the unique map.
+    await expect(col.put('c', { taxId: 'TX-001' })).resolves.toBeUndefined()
+  })
+})
+
+// ── 10. Unique index still queryable ─────────────────────────────────────────
 describe('unique index queryable', () => {
   it('a unique index serves where == queries', async () => {
     const vault = await openVault()

--- a/packages/hub/__tests__/unique-index.test.ts
+++ b/packages/hub/__tests__/unique-index.test.ts
@@ -151,6 +151,8 @@ describe('update no-false-positive', () => {
 
     await col.put('a', { taxId: 'TX-001' })
     await expect(col.put('a', { taxId: 'TX-002' })).resolves.toBeUndefined()
+    // the freed old value must be claimable by a different record
+    await expect(col.put('b', { taxId: 'TX-001' })).resolves.toBeUndefined()
   })
 })
 
@@ -330,6 +332,19 @@ describe('CRDT mode fail-loud', () => {
     expect(() =>
       vault.collection<{ taxId: string }>('crdt-unique', {
         crdt: 'lww-map',
+        indexes: [{ fields: ['taxId'], unique: true }],
+      }),
+    ).toThrow(UnsupportedIndexOptionError)
+  })
+})
+
+// ── 13. Tiered collection + unique guard (C1) ─────────────────────────────────
+describe('tiered collection fail-loud', () => {
+  it('throws UnsupportedIndexOptionError at registration when unique index declared on a tiered collection', async () => {
+    const vault = await openVault()
+    expect(() =>
+      vault.collection<{ taxId: string }>('tiered-unique', {
+        tiers: [0, 1],
         indexes: [{ fields: ['taxId'], unique: true }],
       }),
     ).toThrow(UnsupportedIndexOptionError)

--- a/packages/hub/__tests__/unique-index.test.ts
+++ b/packages/hub/__tests__/unique-index.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Unique-index enforcement — #293
+ *
+ * Coverage:
+ *  1. Eager single-field: duplicate value → UniqueConstraintError with correct fields + conflictingId.
+ *  2. Null tolerance (single): two records with null taxId → both succeed.
+ *  3. Update no-false-positive: same id same value OK; update to new value OK.
+ *  4. Update-to-collide: put a (X), put b (Y), update b to X → rejects.
+ *  5. Delete frees value: put a (X), delete a, put b (X) → OK.
+ *  6. Eager composite: duplicate pair rejects; same workerId + different employerEntityId → OK;
+ *     partial null → duplicates allowed.
+ *  7. putMany intra-batch dup: two entries sharing unique value → second rejects.
+ *  8. Lazy fail-loud: prefetch:false + unique index → throws at registration.
+ *  9. Unique index still queryable: declared unique index serves where('==') queries.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { withIndexing } from '../src/indexing/index.js'
+import type { Noydb } from '../src/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError, UniqueConstraintError } from '../src/errors.js'
+
+// ── inline memory adapter ────────────────────────────────────────────────────
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string): Map<string, EncryptedEnvelope> {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+// ── shared vault setup ───────────────────────────────────────────────────────
+let db: Noydb
+
+beforeEach(async () => {
+  db = await createNoydb({ store: memory(), indexStrategy: withIndexing(), secret: 'unique-index-test-pass' })
+})
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+async function openVault(vaultName = 'v1') {
+  return db.openVault(vaultName)
+}
+
+// ── 1. Eager single-field unique — duplicate value → UniqueConstraintError ──
+describe('unique single-field index', () => {
+  it('rejects a duplicate value on a different id', async () => {
+    const vault = await openVault()
+    const col = vault.collection<{ taxId: string | null }>('employees', {
+      indexes: [{ fields: ['taxId'], unique: true }],
+    })
+
+    await col.put('a', { taxId: 'TX-001' })
+    await expect(col.put('b', { taxId: 'TX-001' })).rejects.toThrow(UniqueConstraintError)
+  })
+
+  it('error carries fields and conflictingId', async () => {
+    const vault = await openVault()
+    const col = vault.collection<{ taxId: string | null }>('employees', {
+      indexes: [{ fields: ['taxId'], unique: true }],
+    })
+
+    await col.put('a', { taxId: 'TX-001' })
+    let caught: UniqueConstraintError | undefined
+    try {
+      await col.put('b', { taxId: 'TX-001' })
+    } catch (e) {
+      caught = e as UniqueConstraintError
+    }
+
+    expect(caught).toBeInstanceOf(UniqueConstraintError)
+    expect(caught!.fields).toEqual(['taxId'])
+    expect(caught!.conflictingId).toBe('a')
+    expect(caught!.recordId).toBe('b')
+    expect(caught!.collection).toBe('employees')
+    expect(caught!.code).toBe('UNIQUE_CONSTRAINT')
+  })
+})
+
+// ── 2. Null tolerance ────────────────────────────────────────────────────────
+describe('null tolerance', () => {
+  it('allows multiple records with null for the constrained field', async () => {
+    const vault = await openVault()
+    const col = vault.collection<{ taxId: string | null }>('employees', {
+      indexes: [{ fields: ['taxId'], unique: true }],
+    })
+
+    await col.put('a', { taxId: null })
+    await expect(col.put('b', { taxId: null })).resolves.toBeUndefined()
+  })
+
+  it('allows multiple records with undefined for the constrained field', async () => {
+    const vault = await openVault()
+    const col = vault.collection<{ taxId?: string }>('employees', {
+      indexes: [{ fields: ['taxId'], unique: true }],
+    })
+
+    await col.put('a', {})
+    await expect(col.put('b', {})).resolves.toBeUndefined()
+  })
+})
+
+// ── 3. Update no-false-positive ──────────────────────────────────────────────
+describe('update no-false-positive', () => {
+  it('allows re-putting the same id with the same value', async () => {
+    const vault = await openVault()
+    const col = vault.collection<{ taxId: string }>('employees', {
+      indexes: [{ fields: ['taxId'], unique: true }],
+    })
+
+    await col.put('a', { taxId: 'TX-001' })
+    await expect(col.put('a', { taxId: 'TX-001' })).resolves.toBeUndefined()
+  })
+
+  it('allows updating a record to a new unique value', async () => {
+    const vault = await openVault()
+    const col = vault.collection<{ taxId: string }>('employees', {
+      indexes: [{ fields: ['taxId'], unique: true }],
+    })
+
+    await col.put('a', { taxId: 'TX-001' })
+    await expect(col.put('a', { taxId: 'TX-002' })).resolves.toBeUndefined()
+  })
+})
+
+// ── 4. Update-to-collide ─────────────────────────────────────────────────────
+describe('update-to-collide', () => {
+  it('rejects updating a record to a value already held by another id', async () => {
+    const vault = await openVault()
+    const col = vault.collection<{ taxId: string }>('employees', {
+      indexes: [{ fields: ['taxId'], unique: true }],
+    })
+
+    await col.put('a', { taxId: 'TX-001' })
+    await col.put('b', { taxId: 'TX-002' })
+    await expect(col.put('b', { taxId: 'TX-001' })).rejects.toThrow(UniqueConstraintError)
+  })
+})
+
+// ── 5. Delete frees value ────────────────────────────────────────────────────
+describe('delete frees value', () => {
+  it('allows a different id to claim the value after the original holder is deleted', async () => {
+    const vault = await openVault()
+    const col = vault.collection<{ taxId: string }>('employees', {
+      indexes: [{ fields: ['taxId'], unique: true }],
+    })
+
+    await col.put('a', { taxId: 'TX-001' })
+    await col.delete('a')
+    await expect(col.put('b', { taxId: 'TX-001' })).resolves.toBeUndefined()
+  })
+})
+
+// ── 6. Eager composite ───────────────────────────────────────────────────────
+describe('composite unique index', () => {
+  it('rejects a duplicate (workerId, employerEntityId) pair', async () => {
+    const vault = await openVault()
+    const col = vault.collection<{ workerId: string; employerEntityId: string }>('assignments', {
+      indexes: [{ fields: ['workerId', 'employerEntityId'], unique: true }],
+    })
+
+    await col.put('x1', { workerId: 'W1', employerEntityId: 'E1' })
+    await expect(col.put('x2', { workerId: 'W1', employerEntityId: 'E1' })).rejects.toThrow(UniqueConstraintError)
+  })
+
+  it('allows same workerId with a different employerEntityId', async () => {
+    const vault = await openVault()
+    const col = vault.collection<{ workerId: string; employerEntityId: string }>('assignments', {
+      indexes: [{ fields: ['workerId', 'employerEntityId'], unique: true }],
+    })
+
+    await col.put('x1', { workerId: 'W1', employerEntityId: 'E1' })
+    await expect(col.put('x2', { workerId: 'W1', employerEntityId: 'E2' })).resolves.toBeUndefined()
+  })
+
+  it('allows partial null: one field null → both records exempt', async () => {
+    const vault = await openVault()
+    const col = vault.collection<{ workerId: string | null; employerEntityId: string | null }>('assignments', {
+      indexes: [{ fields: ['workerId', 'employerEntityId'], unique: true }],
+    })
+
+    await col.put('x1', { workerId: 'W1', employerEntityId: null })
+    // Same workerId but one field is null → exempt
+    await expect(col.put('x2', { workerId: 'W1', employerEntityId: null })).resolves.toBeUndefined()
+  })
+})
+
+// ── 7. putMany intra-batch dup ───────────────────────────────────────────────
+describe('putMany intra-batch duplicate', () => {
+  it('rejects the second entry when two entries share the unique value', async () => {
+    const vault = await openVault()
+    const col = vault.collection<{ taxId: string }>('employees', {
+      indexes: [{ fields: ['taxId'], unique: true }],
+    })
+
+    const result = await col.putMany([
+      ['a', { taxId: 'TX-001' }],
+      ['b', { taxId: 'TX-001' }],
+    ])
+    expect(result.ok).toBe(false)
+    expect(result.success).toContain('a')
+    expect(result.failures.some(f => f.id === 'b' && f.error instanceof UniqueConstraintError)).toBe(true)
+  })
+})
+
+// ── 8. Lazy fail-loud ────────────────────────────────────────────────────────
+describe('lazy mode fail-loud', () => {
+  it('throws at collection registration when unique index declared with prefetch:false', async () => {
+    const vault = await openVault()
+    expect(() =>
+      vault.collection<{ k: string }>('lazy-unique', {
+        prefetch: false,
+        cache: { maxRecords: 100 },
+        indexes: [{ fields: ['k'], unique: true }],
+      }),
+    ).toThrow(/unique indexes.*lazy mode|lazy mode.*unique/i)
+  })
+})
+
+// ── 9. Unique index still queryable ─────────────────────────────────────────
+describe('unique index queryable', () => {
+  it('a unique index serves where == queries', async () => {
+    const vault = await openVault()
+    const col = vault.collection<{ taxId: string; name: string }>('employees', {
+      indexes: [{ fields: ['taxId'], unique: true }],
+    })
+
+    await col.put('a', { taxId: 'TX-001', name: 'Alice' })
+    await col.put('b', { taxId: 'TX-002', name: 'Bob' })
+
+    const results = await col.query().where('taxId', '==', 'TX-001').toArray()
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatchObject({ taxId: 'TX-001', name: 'Alice' })
+  })
+})

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/hub",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Zero-knowledge, offline-first, encrypted document store — core library with AES-256-GCM, PBKDF2, multi-user keyring, and sync engine",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/hub/src/aggregate/reducers.ts
+++ b/packages/hub/src/aggregate/reducers.ts
@@ -60,6 +60,18 @@ export interface Reducer<R, S = R> {
   remove?(state: S, record: unknown): S
   /** Collapse the internal state into the user-visible result. */
   finalize(state: S): R
+  /**
+   * Identifying operation tag stamped by each built-in factory.
+   * Used by `summariseAggregateOp` in the introspection walker to
+   * render human-readable aggregate descriptors in `dumpSchema()`.
+   * Optional so third-party custom reducers are unaffected.
+   */
+  readonly op?: 'count' | 'sum' | 'avg' | 'min' | 'max'
+  /**
+   * Field name for field-based reducers (`sum`, `avg`, `min`, `max`).
+   * Absent on `count` which aggregates over record count, not a field.
+   */
+  readonly field?: string
 }
 
 /**
@@ -96,6 +108,7 @@ export function count(opts?: ReducerOptions<number>): Reducer<number> {
   const _seed = opts?.seed
   void _seed
   return {
+    op: 'count',
     init: () => 0,
     step: (state) => state + 1,
     remove: (state) => state - 1,
@@ -116,6 +129,8 @@ export function sum(
   const _seed = opts?.seed
   void _seed
   return {
+    op: 'sum',
+    field,
     init: () => 0,
     step: (state, record) => state + readNumber(record, field),
     remove: (state, record) => state - readNumber(record, field),
@@ -144,6 +159,8 @@ export function avg(
   const _seed = opts?.seed
   void _seed
   return {
+    op: 'avg',
+    field,
     init: () => ({ sum: 0, count: 0 }),
     step: (state, record) => ({
       sum: state.sum + readNumber(record, field),
@@ -203,6 +220,8 @@ export function min(
   const _seed = opts?.seed
   void _seed
   return {
+    op: 'min',
+    field,
     init: () => ({ values: [] }),
     step: (state, record) => pushValue(state, readNumber(record, field)),
     remove: (state, record) => removeValue(state, readNumber(record, field)),
@@ -230,6 +249,8 @@ export function max(
   const _seed = opts?.seed
   void _seed
   return {
+    op: 'max',
+    field,
     init: () => ({ values: [] }),
     step: (state, record) => pushValue(state, readNumber(record, field)),
     remove: (state, record) => removeValue(state, readNumber(record, field)),

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -32,8 +32,8 @@ import type { PersistedCollectionIndex, PersistedIndexDef } from './indexing/per
 import { LazyQuery } from './indexing/lazy-builder.js'
 import type { LazyQuerySource } from './indexing/lazy-builder.js'
 import { NO_INDEXING, type IndexStrategy, type IndexState } from './indexing/strategy.js'
-import { IndexWriteFailureError, UnsupportedIndexOptionError } from './errors.js'
-import { UniqueConstraintSet } from './indexing/unique-constraints.js'
+import { IndexWriteFailureError } from './errors.js'
+import { buildUniqueConstraintSet, type UniqueConstraintSet } from './indexing/unique-constraints.js'
 import type { RefDescriptor } from './refs.js'
 import { Lru, parseBytes, estimateRecordBytes, type LruStats } from './cache/index.js'
 import { generateULID } from './bundle/ulid.js'
@@ -913,49 +913,14 @@ export class Collection<T> {
       lazy: this.lazy,
     })
 
-    // Unique-constraint enforcement — independent of the indexing strategy.
-    // Collect all IndexDef entries that carry `unique: true` (object form only;
-    // plain strings and readonly-string-array shorthands do not have unique).
-    const uniqueDefs: (readonly string[])[] = []
-    for (const def of opts.indexes ?? []) {
-      if (
-        def !== null &&
-        typeof def === 'object' &&
-        !Array.isArray(def) &&
-        (def as { unique?: boolean }).unique === true
-      ) {
-        const fields = (def as { fields: readonly string[] }).fields
-        if (this.lazy) {
-          // Lazy mode: unique indexes are not yet supported — fail loud at
-          // registration rather than silently ignoring.
-          throw new UnsupportedIndexOptionError(
-            'unique',
-            `unique indexes are not yet supported in lazy mode (prefetch:false) — use the default eager mode. Collection "${this.name}".`,
-          )
-        }
-        uniqueDefs.push(fields)
-      }
-    }
-    // CRDT mode: unique indexes are incompatible — the CRDT put() path
-    // short-circuits the uniqueness check, so enforcement would silently
-    // never fire. Fail loud at registration.
-    if (this.crdtMode && uniqueDefs.length > 0) {
-      throw new UnsupportedIndexOptionError(
-        'unique',
-        `unique indexes are not supported on CRDT collections (crdt mode is incompatible with eager unique enforcement). Collection "${this.name}".`,
-      )
-    }
-    // Tiered collections: unique indexes are incompatible — tier writes
-    // (putAtTier, elevate, demote) call adapter.put directly and bypass
-    // uniqueConstraints.check()/upsert() entirely, so enforcement would
-    // silently never fire on those paths. Fail loud at registration.
-    if (this.tiers && uniqueDefs.length > 0) {
-      throw new UnsupportedIndexOptionError(
-        'unique',
-        `unique indexes are not supported on tiered collections (tier writes use a separate path that bypasses unique enforcement). Collection "${this.name}".`,
-      )
-    }
-    this.uniqueConstraints = uniqueDefs.length > 0 ? new UniqueConstraintSet(this.name, uniqueDefs) : null
+    // Unique-constraint enforcement (eager mode only). Declaring `unique` on
+    // a lazy/CRDT/tiered collection throws UnsupportedIndexOptionError here —
+    // see buildUniqueConstraintSet (kept out of this kernel file).
+    this.uniqueConstraints = buildUniqueConstraintSet(this.name, opts.indexes, {
+      lazy: this.lazy,
+      crdt: this.crdtMode != null,
+      tiered: this.tiers != null,
+    })
   }
 
   /**

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -33,6 +33,7 @@ import { LazyQuery } from './indexing/lazy-builder.js'
 import type { LazyQuerySource } from './indexing/lazy-builder.js'
 import { NO_INDEXING, type IndexStrategy, type IndexState } from './indexing/strategy.js'
 import { IndexWriteFailureError } from './errors.js'
+import { UniqueConstraintSet } from './indexing/unique-constraints.js'
 import type { RefDescriptor } from './refs.js'
 import { Lru, parseBytes, estimateRecordBytes, type LruStats } from './cache/index.js'
 import { generateULID } from './bundle/ulid.js'
@@ -189,6 +190,13 @@ export class Collection<T> {
    * caller site.
    */
   private readonly indexState: IndexState
+
+  /**
+   * In-memory unique-constraint enforcement for eager mode.
+   * `null` when no `unique:true` indexes are declared on this collection,
+   * or when the collection is in lazy mode (which throws at registration).
+   */
+  private readonly uniqueConstraints: UniqueConstraintSet | null
 
   /**
    * True once `_idx/*` side-cars have been bulk-loaded into
@@ -904,6 +912,31 @@ export class Collection<T> {
       defs: opts.indexes ?? [],
       lazy: this.lazy,
     })
+
+    // Unique-constraint enforcement — independent of the indexing strategy.
+    // Collect all IndexDef entries that carry `unique: true` (object form only;
+    // plain strings and readonly-string-array shorthands do not have unique).
+    const uniqueDefs: (readonly string[])[] = []
+    for (const def of opts.indexes ?? []) {
+      if (
+        def !== null &&
+        typeof def === 'object' &&
+        !Array.isArray(def) &&
+        (def as { unique?: boolean }).unique === true
+      ) {
+        const fields = (def as { fields: readonly string[] }).fields
+        if (this.lazy) {
+          // Lazy mode: unique indexes are not yet supported — fail loud at
+          // registration rather than silently ignoring.
+          throw new Error(
+            `Collection "${this.name}": unique indexes are not yet supported in lazy mode (prefetch: false). ` +
+              `Use the default eager mode (prefetch: true, the default) for unique-index enforcement.`,
+          )
+        }
+        uniqueDefs.push(fields)
+      }
+    }
+    this.uniqueConstraints = uniqueDefs.length > 0 ? new UniqueConstraintSet(this.name, uniqueDefs) : null
   }
 
   /**
@@ -1368,6 +1401,12 @@ export class Collection<T> {
       }
     }
 
+    // Unique-constraint pre-flight — BEFORE the store write so a
+    // violation never reaches the adapter. Throws UniqueConstraintError
+    // if a different record already holds the same constrained value.
+    // No-op when no unique indexes are declared.
+    this.uniqueConstraints?.check(id, record)
+
     const envelope = await this.encryptRecord(record, version)
     await this.adapter.put(this.vault, this.name, id, envelope)
 
@@ -1421,6 +1460,8 @@ export class Collection<T> {
       // declared. Pass the previous record (if any) so old buckets are
       // cleaned up before the new value is added.
       this.indexes?.upsert(id, record, existing ? existing.record : null)
+      // Update unique-constraint maps to reflect the successful write.
+      this.uniqueConstraints?.upsert(id, record, existing?.record)
     }
 
     await this.onDirty?.(this.name, id, 'put', version)
@@ -1861,6 +1902,8 @@ export class Collection<T> {
       // or the record wasn't previously indexed.
       if (existing) {
         this.indexes?.remove(id, existing.record)
+        // Remove from unique-constraint maps so the deleted value is freed.
+        this.uniqueConstraints?.remove(id, existing.record)
       }
     }
 
@@ -2733,6 +2776,7 @@ export class Collection<T> {
     }
     this.hydrated = true
     this.rebuildEagerIndexesFromCache()
+    this.rebuildUniqueConstraintsFromCache()
   }
 
   /** Hydrate from a pre-loaded snapshot (used by Vault). */
@@ -2743,6 +2787,7 @@ export class Collection<T> {
     }
     this.hydrated = true
     this.rebuildEagerIndexesFromCache()
+    this.rebuildUniqueConstraintsFromCache()
   }
 
   /**
@@ -2763,6 +2808,19 @@ export class Collection<T> {
       snapshot.push({ id, record: entry.record })
     }
     eager.build(snapshot)
+  }
+
+  /**
+   * Rebuild unique-constraint maps from the current in-memory cache.
+   * Called after any bulk hydration alongside `rebuildEagerIndexesFromCache`.
+   */
+  private rebuildUniqueConstraintsFromCache(): void {
+    if (!this.uniqueConstraints) return
+    this.uniqueConstraints.build(
+      (function* (cache: Map<string, { record: T }>) {
+        for (const [id, entry] of cache) yield [id, entry.record] as const
+      })(this.cache),
+    )
   }
 
   /**

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -32,7 +32,7 @@ import type { PersistedCollectionIndex, PersistedIndexDef } from './indexing/per
 import { LazyQuery } from './indexing/lazy-builder.js'
 import type { LazyQuerySource } from './indexing/lazy-builder.js'
 import { NO_INDEXING, type IndexStrategy, type IndexState } from './indexing/strategy.js'
-import { IndexWriteFailureError } from './errors.js'
+import { IndexWriteFailureError, UnsupportedIndexOptionError } from './errors.js'
 import { UniqueConstraintSet } from './indexing/unique-constraints.js'
 import type { RefDescriptor } from './refs.js'
 import { Lru, parseBytes, estimateRecordBytes, type LruStats } from './cache/index.js'
@@ -928,13 +928,22 @@ export class Collection<T> {
         if (this.lazy) {
           // Lazy mode: unique indexes are not yet supported — fail loud at
           // registration rather than silently ignoring.
-          throw new Error(
-            `Collection "${this.name}": unique indexes are not yet supported in lazy mode (prefetch: false). ` +
-              `Use the default eager mode (prefetch: true, the default) for unique-index enforcement.`,
+          throw new UnsupportedIndexOptionError(
+            'unique',
+            `unique indexes are not yet supported in lazy mode (prefetch:false) — use the default eager mode. Collection "${this.name}".`,
           )
         }
         uniqueDefs.push(fields)
       }
+    }
+    // CRDT mode: unique indexes are incompatible — the CRDT put() path
+    // short-circuits the uniqueness check, so enforcement would silently
+    // never fire. Fail loud at registration.
+    if (this.crdtMode && uniqueDefs.length > 0) {
+      throw new UnsupportedIndexOptionError(
+        'unique',
+        `unique indexes are not supported on CRDT collections (crdt mode is incompatible with eager unique enforcement). Collection "${this.name}".`,
+      )
     }
     this.uniqueConstraints = uniqueDefs.length > 0 ? new UniqueConstraintSet(this.name, uniqueDefs) : null
   }

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -945,6 +945,16 @@ export class Collection<T> {
         `unique indexes are not supported on CRDT collections (crdt mode is incompatible with eager unique enforcement). Collection "${this.name}".`,
       )
     }
+    // Tiered collections: unique indexes are incompatible — tier writes
+    // (putAtTier, elevate, demote) call adapter.put directly and bypass
+    // uniqueConstraints.check()/upsert() entirely, so enforcement would
+    // silently never fire on those paths. Fail loud at registration.
+    if (this.tiers && uniqueDefs.length > 0) {
+      throw new UnsupportedIndexOptionError(
+        'unique',
+        `unique indexes are not supported on tiered collections (tier writes use a separate path that bypasses unique enforcement). Collection "${this.name}".`,
+      )
+    }
     this.uniqueConstraints = uniqueDefs.length > 0 ? new UniqueConstraintSet(this.name, uniqueDefs) : null
   }
 
@@ -1390,6 +1400,13 @@ export class Collection<T> {
 
     const version = existing ? existing.version + 1 : 1
 
+    // Unique-constraint pre-flight — BEFORE history-save so a violation
+    // never writes a history snapshot or fires 'history:save'. Runs after
+    // ensureHydrated() (eager path above) so the constraint map already
+    // reflects records from prior sessions. No-op when no unique indexes
+    // are declared.
+    this.uniqueConstraints?.check(id, record)
+
     // Save history snapshot of the PREVIOUS version before overwriting
     if (existing && this.historyConfig.enabled !== false) {
       const historyEnvelope = await this.encryptRecord(existing.record, existing.version)
@@ -1409,12 +1426,6 @@ export class Collection<T> {
         })
       }
     }
-
-    // Unique-constraint pre-flight — BEFORE the store write so a
-    // violation never reaches the adapter. Throws UniqueConstraintError
-    // if a different record already holds the same constrained value.
-    // No-op when no unique indexes are declared.
-    this.uniqueConstraints?.check(id, record)
 
     const envelope = await this.encryptRecord(record, version)
     await this.adapter.put(this.vault, this.name, id, envelope)

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -2738,12 +2738,16 @@ export class Collection<T> {
     const envelope = await this.adapter.get(this.vault, this.name, id)
     if (!envelope) {
       this.cache.delete(id)
-      if (previous) this.indexes?.remove(id, previous.record)
+      if (previous) {
+        this.indexes?.remove(id, previous.record)
+        this.uniqueConstraints?.remove(id, previous.record)
+      }
       return
     }
     const record = await this.decryptRecord(envelope)
     this.cache.set(id, { record, version: envelope._v })
     this.indexes?.upsert(id, record, previous ? previous.record : null)
+    this.uniqueConstraints?.upsert(id, record, previous?.record)
   }
 
   /**

--- a/packages/hub/src/derivations/registry.ts
+++ b/packages/hub/src/derivations/registry.ts
@@ -48,6 +48,24 @@ export class DerivationRegistry {
   }
 
   /**
+   * All registered strategies as a flat, deduplicated array.
+   * Each strategy is indexed once per source (not once per output key),
+   * so iterating `_bySource.values()` naturally yields each strategy
+   * exactly once per source — deduplication is handled by flattening
+   * the per-source arrays and collecting into a Set by identity.
+   *
+   * Used by `dumpSchema()` / `describeDerivations()` in the introspection
+   * walker to populate the derivations map.
+   */
+  all(): ReadonlyArray<RegisteredStrategy> {
+    const seen = new Set<RegisteredStrategy>()
+    for (const strategies of this._bySource.values()) {
+      for (const s of strategies) seen.add(s)
+    }
+    return [...seen]
+  }
+
+  /**
    * Cycle detection over the source → output → … graph. Call after all
    * `register()` calls complete (i.e. at vault open). Throws
    * `DerivationCycleError` on the first cycle found.

--- a/packages/hub/src/derivations/types.ts
+++ b/packages/hub/src/derivations/types.ts
@@ -124,6 +124,17 @@ export interface DerivationStrategy<
    * sibling records via `ctx.vault.collection<T>(name).get(id)` /
    * `.list()` / `.query()`. The vault accessor is read-only; there is
    * no path to a writer from `ctx`.
+   *
+   * **Per-output omission (runtime-supported):** returning `null` or
+   * `undefined` for an individual output key is handled at runtime via
+   * the `optional: true` flag on the output's `RecordOutputSpec` —
+   * the executor deletes any previously-emitted output at that id, or
+   * silently no-ops if none exists. For `shape: 'array'` outputs, null
+   * / undefined is treated as an empty array (clears all prior rows for
+   * that source). The *top-level* return must always be a `TOutputs`
+   * object; returning `null` for the whole result is not supported.
+   * (#297 — MV `unionSources` map drop-row is the analogous feature for
+   * materialized views.)
    */
   derive: (source: TSource, ctx: DerivationContext) => Promise<TOutputs> | TOutputs
   /**

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -958,6 +958,41 @@ export class IndexRequiredError extends NoydbError {
 }
 
 /**
+ * Thrown by `Collection.put()` when writing a record would violate a
+ * unique-index constraint — the same field value (or composite field
+ * tuple) is already held by a *different* record id in the collection.
+ *
+ * Properties:
+ * - `collection` — name of the collection the write was targeting
+ * - `recordId` — the id of the record being written (the would-be violator)
+ * - `fields` — the constrained field(s), e.g. `['taxId']` or `['workerId','employerEntityId']`
+ * - `conflictingId` — the id of the record already holding the value
+ *
+ * Null-distinct semantics: if any constrained field is `null`/`undefined`,
+ * the row is exempt (the constraint does not fire). This matches standard
+ * SQL NULL-distinct behavior.
+ */
+export class UniqueConstraintError extends NoydbError {
+  readonly collection: string
+  readonly recordId: string
+  readonly fields: readonly string[]
+  readonly conflictingId: string
+
+  constructor(collection: string, recordId: string, fields: readonly string[], conflictingId: string) {
+    super(
+      'UNIQUE_CONSTRAINT',
+      `Unique constraint on ${collection}.[${fields.join(', ')}] violated: ` +
+        `record "${recordId}" duplicates a value already held by "${conflictingId}".`,
+    )
+    this.name = 'UniqueConstraintError'
+    this.collection = collection
+    this.recordId = recordId
+    this.fields = fields
+    this.conflictingId = conflictingId
+  }
+}
+
+/**
  * Thrown (or surfaced via the `index:write-partial` event) when one or more
  * per-indexed-field side-car writes fail after the main record write has
  * already succeeded.

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -26,13 +26,15 @@
  *       │    ├─ ValidationError        — application-level guard failed
  *       │    └─ SchemaValidationError  — Standard Schema v1 rejection
  *       ├─ Query errors
- *       │    ├─ JoinTooLargeError           — join row ceiling exceeded
- *       │    ├─ CrossJoinTooLargeError      — cross-join row ceiling exceeded
- *       │    ├─ CrossJoinSourceUnknownError — target collection not in vault
- *       │    ├─ DanglingReferenceError — strict ref() points at nothing
- *       │    ├─ GroupCardinalityError  — groupBy bucket cap exceeded
- *       │    ├─ IndexRequiredError      — lazy-mode query touches unindexed field
- *       │    └─ IndexWriteFailureError       — index side-car put/delete failed post-main
+ *       │    ├─ JoinTooLargeError                — join row ceiling exceeded
+ *       │    ├─ CrossJoinTooLargeError            — cross-join row ceiling exceeded
+ *       │    ├─ CrossJoinSourceUnknownError       — target collection not in vault
+ *       │    ├─ DanglingReferenceError            — strict ref() points at nothing
+ *       │    ├─ GroupCardinalityError             — groupBy bucket cap exceeded
+ *       │    ├─ IndexRequiredError                — lazy-mode query touches unindexed field
+ *       │    ├─ IndexWriteFailureError            — index side-car put/delete failed post-main
+ *       │    ├─ UniqueConstraintError             — duplicate value on unique index
+ *       │    └─ UnsupportedIndexOptionError       — unique+lazy or unique+crdt at registration
  *       ├─ i18n / Dictionary errors
  *       │    ├─ ReservedCollectionNameError
  *       │    ├─ DictKeyMissingError
@@ -989,6 +991,34 @@ export class UniqueConstraintError extends NoydbError {
     this.recordId = recordId
     this.fields = fields
     this.conflictingId = conflictingId
+  }
+}
+
+/**
+ * Thrown at collection registration when an index option is declared that
+ * is incompatible with the collection's operating mode.
+ *
+ * Currently covers two cases:
+ * - `unique: true` on a lazy-mode (`prefetch: false`) collection — lazy mode
+ *   does not pre-load all records, so an in-memory uniqueness map cannot be
+ *   maintained reliably.
+ * - `unique: true` on a CRDT collection (`crdt: 'lww-map' | 'rga' | 'yjs'`) —
+ *   CRDT put() short-circuits the unique-constraint check, so enforcement would
+ *   silently not fire.
+ *
+ * Both cases are caught eagerly at `vault.collection()` time so the developer
+ * sees the incompatibility immediately rather than shipping silently-ignored
+ * constraints.
+ *
+ * The `option` field names the incompatible option (`'unique'`) so catch blocks
+ * can pattern-match without inspecting the error message.
+ */
+export class UnsupportedIndexOptionError extends NoydbError {
+  readonly option: string
+  constructor(option: string, message: string) {
+    super('UNSUPPORTED_INDEX_OPTION', message)
+    this.name = 'UnsupportedIndexOptionError'
+    this.option = option
   }
 }
 

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -763,6 +763,8 @@ export { TierNotGrantedError, TierDemoteDeniedError, DelegationTargetMissingErro
 
 // lazy-mode index errors
 export { IndexRequiredError, IndexWriteFailureError } from './errors.js'
+// unique-index enforcement error
+export { UniqueConstraintError } from './errors.js'
 export { dekKey, effectiveClearance, assertTierAccess } from './team/tiers.js'
 export type { DelegationToken, IssueDelegationOptions } from './team/delegation.js'
 export { DELEGATIONS_COLLECTION, issueDelegation, loadActiveDelegations, revokeDelegation } from './team/delegation.js'

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -764,7 +764,7 @@ export { TierNotGrantedError, TierDemoteDeniedError, DelegationTargetMissingErro
 // lazy-mode index errors
 export { IndexRequiredError, IndexWriteFailureError } from './errors.js'
 // unique-index enforcement error
-export { UniqueConstraintError } from './errors.js'
+export { UniqueConstraintError, UnsupportedIndexOptionError } from './errors.js'
 export { dekKey, effectiveClearance, assertTierAccess } from './team/tiers.js'
 export type { DelegationToken, IssueDelegationOptions } from './team/delegation.js'
 export { DELEGATIONS_COLLECTION, issueDelegation, loadActiveDelegations, revokeDelegation } from './team/delegation.js'

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -753,6 +753,9 @@ export {
 } from './session/dev-unlock.js'
 export type { DevUnlockOptions } from './session/dev-unlock.js'
 
+// Discriminated-union narrowing helper
+export { isDiscriminant } from './util/discriminant.js'
+
 // Crypto utilities (buffer encoding helpers + binary encrypt/hash)
 export { bufferToBase64, base64ToBuffer, encryptBytes, decryptBytes } from './crypto.js'
 export { encryptDeterministic, decryptDeterministic } from './crypto.js'

--- a/packages/hub/src/indexing/eager-indexes.ts
+++ b/packages/hub/src/indexing/eager-indexes.ts
@@ -31,7 +31,10 @@ import { readPath } from '../query/predicate.js'
  * Additive variants (unique constraints, partial indexes) will land as
  * further union members without breaking existing declarations.
  */
-export type IndexDef = string | { readonly fields: readonly string[] } | readonly string[]
+export type IndexDef =
+  | string
+  | { readonly fields: readonly string[]; readonly unique?: boolean }
+  | readonly string[]
 
 /**
  * Internal representation of a built hash index.

--- a/packages/hub/src/indexing/unique-constraints.ts
+++ b/packages/hub/src/indexing/unique-constraints.ts
@@ -17,7 +17,8 @@
 
 import { readPath } from '../query/predicate.js'
 import { canonicalGroupKey } from '../aggregate/canonical-key.js'
-import { UniqueConstraintError } from '../errors.js'
+import { UniqueConstraintError, UnsupportedIndexOptionError } from '../errors.js'
+import type { IndexDef } from './eager-indexes.js'
 
 interface Constraint {
   readonly fields: readonly string[]
@@ -111,4 +112,54 @@ export class UniqueConstraintSet {
       this.upsert(id, record)
     }
   }
+}
+
+/**
+ * Build the `UniqueConstraintSet` for a collection from its `IndexDef[]`,
+ * or return `null` when no `unique: true` index is declared.
+ *
+ * Unique enforcement is **eager-mode only**. If any `unique` index is
+ * declared on a lazy (`prefetch:false`), CRDT, or tiered collection, this
+ * throws `UnsupportedIndexOptionError` at registration rather than letting
+ * those write paths (which bypass `check()`/`upsert()`) silently skip
+ * enforcement. Kept out of the Collection constructor to keep that
+ * always-on kernel file lean (kernel-surface invariant).
+ */
+export function buildUniqueConstraintSet(
+  collectionName: string,
+  indexes: readonly IndexDef[] | undefined,
+  mode: { readonly lazy: boolean; readonly crdt: boolean; readonly tiered: boolean },
+): UniqueConstraintSet | null {
+  const uniqueDefs: (readonly string[])[] = []
+  for (const def of indexes ?? []) {
+    if (
+      def !== null &&
+      typeof def === 'object' &&
+      !Array.isArray(def) &&
+      (def as { unique?: boolean }).unique === true
+    ) {
+      uniqueDefs.push((def as { fields: readonly string[] }).fields)
+    }
+  }
+  if (uniqueDefs.length === 0) return null
+
+  if (mode.lazy) {
+    throw new UnsupportedIndexOptionError(
+      'unique',
+      `unique indexes are not yet supported in lazy mode (prefetch:false) — use the default eager mode. Collection "${collectionName}".`,
+    )
+  }
+  if (mode.crdt) {
+    throw new UnsupportedIndexOptionError(
+      'unique',
+      `unique indexes are not supported on CRDT collections (crdt mode is incompatible with eager unique enforcement). Collection "${collectionName}".`,
+    )
+  }
+  if (mode.tiered) {
+    throw new UnsupportedIndexOptionError(
+      'unique',
+      `unique indexes are not supported on tiered collections (tier writes use a separate path that bypasses unique enforcement). Collection "${collectionName}".`,
+    )
+  }
+  return new UniqueConstraintSet(collectionName, uniqueDefs)
 }

--- a/packages/hub/src/indexing/unique-constraints.ts
+++ b/packages/hub/src/indexing/unique-constraints.ts
@@ -1,0 +1,106 @@
+/**
+ * In-memory unique-constraint enforcement for eager-mode collections.
+ *
+ * Each `UniqueConstraintSet` holds one or more constraints, each covering
+ * an ordered tuple of field names. On every `put()` the caller invokes
+ * `check()` BEFORE the store write; on success it calls `upsert()` to
+ * update the maps. `remove()` is called on `delete()`.
+ *
+ * Null-distinct semantics: if ANY constrained field is `null` or
+ * `undefined` in the record, that record is exempt from the constraint —
+ * `keyFor` returns `null` and the record is silently skipped.
+ * This matches standard SQL NULL-distinct behavior.
+ *
+ * Only used in eager mode (`prefetch !== false`). Lazy-mode collections
+ * throw at registration instead (see Collection constructor).
+ */
+
+import { readPath } from '../query/predicate.js'
+import { canonicalGroupKey } from '../aggregate/canonical-key.js'
+import { UniqueConstraintError } from '../errors.js'
+
+interface Constraint {
+  readonly fields: readonly string[]
+  /** canonicalKey → id of the record holding that key */
+  readonly map: Map<string, string>
+}
+
+export class UniqueConstraintSet {
+  private readonly constraints: Constraint[]
+
+  constructor(
+    private readonly collectionName: string,
+    uniqueDefs: readonly (readonly string[])[],
+  ) {
+    this.constraints = uniqueDefs.map(fields => ({ fields, map: new Map() }))
+  }
+
+  get size(): number {
+    return this.constraints.length
+  }
+
+  /**
+   * Compute the canonical key for a record under a given constraint.
+   * Returns `null` if any constrained field is `null` or `undefined`
+   * (the record is exempt — no constraint is checked).
+   */
+  private keyFor(fields: readonly string[], record: unknown): string | null {
+    const row: Record<string, unknown> = {}
+    for (const f of fields) {
+      const v = readPath(record, f)
+      if (v === null || v === undefined) return null
+      row[f] = v
+    }
+    return canonicalGroupKey(fields, row)
+  }
+
+  /**
+   * Throw `UniqueConstraintError` if writing `id` with `record` would
+   * collide with a DIFFERENT existing record. Call BEFORE the store write.
+   */
+  check(id: string, record: unknown): void {
+    for (const c of this.constraints) {
+      const key = this.keyFor(c.fields, record)
+      if (key === null) continue
+      const holder = c.map.get(key)
+      if (holder !== undefined && holder !== id) {
+        throw new UniqueConstraintError(this.collectionName, id, c.fields, holder)
+      }
+    }
+  }
+
+  /**
+   * Update the constraint maps after a successful write.
+   * Pass `previous` when updating an existing record (so the old key
+   * is removed first). Pass `null` or `undefined` for a fresh insert.
+   */
+  upsert(id: string, record: unknown, previous?: unknown): void {
+    if (previous != null) this.remove(id, previous)
+    for (const c of this.constraints) {
+      const key = this.keyFor(c.fields, record)
+      if (key !== null) c.map.set(key, id)
+    }
+  }
+
+  /**
+   * Remove a record from all constraint maps.
+   * Called by `Collection.delete()`.
+   */
+  remove(id: string, record: unknown): void {
+    for (const c of this.constraints) {
+      const key = this.keyFor(c.fields, record)
+      if (key !== null && c.map.get(key) === id) c.map.delete(key)
+    }
+  }
+
+  /**
+   * Rebuild all constraint maps from a full snapshot.
+   * Called after hydration (ensureHydrated / hydrateFromSnapshot).
+   */
+  build(entries: Iterable<readonly [string, unknown]>): void {
+    for (const c of this.constraints) c.map.clear()
+    for (const [id, record] of entries) {
+      this.upsert(id, record)
+    }
+  }
+}

--- a/packages/hub/src/indexing/unique-constraints.ts
+++ b/packages/hub/src/indexing/unique-constraints.ts
@@ -96,6 +96,14 @@ export class UniqueConstraintSet {
   /**
    * Rebuild all constraint maps from a full snapshot.
    * Called after hydration (ensureHydrated / hydrateFromSnapshot).
+   *
+   * **Last-writer-wins**: this method does NOT validate pre-existing data
+   * for duplicates. If the store already contains two records sharing a
+   * constrained value (written before the unique index was declared), the
+   * last one processed wins the map slot and the duplicate is silently
+   * displaced — no error is thrown, and the earlier holder is evicted from
+   * the map. Callers retrofitting a unique index onto populated data should
+   * run a one-time uniqueness scan before relying on enforcement.
    */
   build(entries: Iterable<readonly [string, unknown]>): void {
     for (const c of this.constraints) c.map.clear()

--- a/packages/hub/src/introspection/fields.ts
+++ b/packages/hub/src/introspection/fields.ts
@@ -15,6 +15,7 @@ interface JsonSchemaShape {
   properties?: Record<string, JsonSchemaShape>
   required?: string[]
   enum?: unknown[]
+  const?: unknown
   minLength?: number
   maxLength?: number
   pattern?: string
@@ -24,6 +25,8 @@ interface JsonSchemaShape {
   exclusiveMaximum?: number
   format?: string
   items?: JsonSchemaShape
+  oneOf?: JsonSchemaShape[]
+  anyOf?: JsonSchemaShape[]
 }
 
 function jsonSchemaType(node: JsonSchemaShape): string {
@@ -32,6 +35,8 @@ function jsonSchemaType(node: JsonSchemaShape): string {
     return non[0] ?? 'opaque'
   }
   if (node.enum && Array.isArray(node.enum)) return 'enum'
+  // JSON Schema `const` is used by zod-to-json-schema for z.literal(...)
+  if (node.const !== undefined) return 'enum'
   if (typeof node.type === 'string') return node.type
   return 'opaque'
 }
@@ -39,6 +44,8 @@ function jsonSchemaType(node: JsonSchemaShape): string {
 function constraintsFor(node: JsonSchemaShape): Record<string, unknown> | undefined {
   const out: Record<string, unknown> = {}
   if (node.enum) out.values = node.enum
+  // JSON Schema `const` (used by zod-to-json-schema for z.literal) — treat like a single-value enum
+  if (node.const !== undefined) out.values = [node.const]
   if (node.minLength !== undefined) out.minLength = node.minLength
   if (node.maxLength !== undefined) out.maxLength = node.maxLength
   if (node.pattern !== undefined) out.pattern = node.pattern
@@ -50,19 +57,20 @@ function constraintsFor(node: JsonSchemaShape): Record<string, unknown> | undefi
   return Object.keys(out).length === 0 ? undefined : out
 }
 
-export function jsonSchemaToFields(
-  jsonSchema: unknown,
+/**
+ * Extract fields from a single JSON Schema object node (must have `properties`).
+ * Used by both the plain-object path and the per-member extraction in the union path.
+ */
+function extractObjectFields(
+  obj: JsonSchemaShape,
   source: FieldSource,
   refs?: Record<string, { target: string; mode: string }>,
-): Record<string, FieldDescriptor> {
-  if (!jsonSchema || typeof jsonSchema !== 'object') return {}
-  const root = jsonSchema as JsonSchemaShape
-  if (!root.properties || typeof root.properties !== 'object') return {}
+): { fields: Record<string, FieldDescriptor>; required: Set<string> } {
+  const required = new Set(Array.isArray(obj.required) ? obj.required : [])
+  const fields: Record<string, FieldDescriptor> = {}
+  if (!obj.properties || typeof obj.properties !== 'object') return { fields, required }
 
-  const required = new Set(Array.isArray(root.required) ? root.required : [])
-  const out: Record<string, FieldDescriptor> = {}
-
-  for (const [name, node] of Object.entries(root.properties)) {
+  for (const [name, node] of Object.entries(obj.properties)) {
     const descriptor: FieldDescriptor = {
       type: jsonSchemaType(node),
       source,
@@ -71,8 +79,106 @@ export function jsonSchemaToFields(
     }
     const constraints = constraintsFor(node)
     if (constraints) (descriptor as { constraints?: Record<string, unknown> }).constraints = constraints
+    fields[name] = descriptor
+  }
+
+  return { fields, required }
+}
+
+/**
+ * Merge field descriptors from multiple union members.
+ *
+ * Merge rules:
+ * - Emit the UNION of all field names so no member's fields are hidden.
+ * - A field is required (optional=false/absent) only when it is required in
+ *   EVERY member; otherwise it is marked optional=true.
+ * - For the discriminator field (appears in every member with a `const` value),
+ *   collect the const values from all members and surface them as constraints.values
+ *   so the caller can see the full literal set.
+ * - For conflicting types across members, first-seen wins.
+ */
+function mergeUnionMembers(
+  members: JsonSchemaShape[],
+  source: FieldSource,
+  refs?: Record<string, { target: string; mode: string }>,
+): Record<string, FieldDescriptor> {
+  if (members.length === 0) return {}
+
+  // Extract per-member fields + required sets
+  const extracted = members
+    .filter((m) => m.properties && typeof m.properties === 'object')
+    .map((m) => extractObjectFields(m, source, refs))
+
+  if (extracted.length === 0) return {}
+
+  // Collect all field names across all members
+  const allNames = new Set<string>()
+  for (const { fields } of extracted) {
+    for (const name of Object.keys(fields)) allNames.add(name)
+  }
+
+  const memberCount = extracted.length
+  const out: Record<string, FieldDescriptor> = {}
+
+  for (const name of allNames) {
+    // Which members contain this field?
+    const presentIn = extracted.filter(({ fields }) => name in fields)
+    const requiredInAll = presentIn.length === memberCount
+      && presentIn.every(({ required }) => required.has(name))
+
+    // Use first-seen descriptor as the base (presentIn is always non-empty here since
+    // we iterate names that appeared in at least one member's fields)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const base = presentIn[0]!.fields[name]!
+
+    // For discriminator-like fields: collect const/enum values across all members
+    // to surface the full literal set in constraints.values
+    const allValues: unknown[] = []
+    for (const { fields } of presentIn) {
+      const fd = fields[name]
+      if (fd?.constraints?.values && Array.isArray(fd.constraints.values)) {
+        for (const v of fd.constraints.values) {
+          if (!allValues.includes(v)) allValues.push(v)
+        }
+      }
+    }
+
+    const mergedConstraints: Record<string, unknown> | undefined =
+      allValues.length > 0
+        ? { ...(base.constraints ?? {}), values: allValues }
+        : base.constraints
+
+    const descriptor: FieldDescriptor = {
+      type: base.type,
+      source,
+      ...(requiredInAll ? {} : { optional: true }),
+      ...(base.references ? { references: base.references } : {}),
+    }
+    if (mergedConstraints) {
+      (descriptor as { constraints?: Record<string, unknown> }).constraints = mergedConstraints
+    }
     out[name] = descriptor
   }
 
   return out
+}
+
+export function jsonSchemaToFields(
+  jsonSchema: unknown,
+  source: FieldSource,
+  refs?: Record<string, { target: string; mode: string }>,
+): Record<string, FieldDescriptor> {
+  if (!jsonSchema || typeof jsonSchema !== 'object') return {}
+  const root = jsonSchema as JsonSchemaShape
+
+  // Handle discriminated unions: zod-to-json-schema emits anyOf/oneOf for z.discriminatedUnion
+  const unionMembers = root.anyOf ?? root.oneOf
+  if (Array.isArray(unionMembers) && unionMembers.length > 0) {
+    return mergeUnionMembers(unionMembers, source, refs)
+  }
+
+  if (!root.properties || typeof root.properties !== 'object') return {}
+
+  const { fields } = extractObjectFields(root, source, refs)
+  return fields
 }

--- a/packages/hub/src/introspection/walk.ts
+++ b/packages/hub/src/introspection/walk.ts
@@ -272,9 +272,14 @@ function describeDerivations(registry: unknown): Record<string, DerivationDescri
     const outputCollections = s.outputs
       ? Object.values(s.outputs).map((o) => (o as { collection: string }).collection)
       : []
-    // Key by source — stable, human-readable identifier. If multiple
-    // strategies share the same source, the last one wins (known limitation).
-    out[s.source] = {
+    // Key by sorted output-collection names so co-sourced derivations don't
+    // collide. A single-output derivation keys as just that collection name
+    // (e.g. 'billSummary'); multi-output keys as sorted join (e.g. 'a+b').
+    // Falls back to source when no outputs are declared (defensive).
+    const key = outputCollections.length > 0
+      ? [...outputCollections].sort().join('+')
+      : s.source
+    out[key] = {
       source: s.source,
       outputs: outputCollections,
     }

--- a/packages/hub/src/introspection/walk.ts
+++ b/packages/hub/src/introspection/walk.ts
@@ -260,14 +260,23 @@ function describeOverlays(registry: unknown): Record<string, OverlayViewDescript
 
 function describeDerivations(registry: unknown): Record<string, DerivationDescriptor> {
   if (!registry || typeof registry !== 'object') return {}
-  const specs = listFromRegistry(registry as Record<string, unknown>)
+  const items = listFromRegistry(registry as Record<string, unknown>)
   const out: Record<string, DerivationDescriptor> = {}
-  for (const spec of specs) {
-    const s = spec as { name?: string; source?: string; outputs?: ReadonlyArray<string> }
-    if (!s.name) continue
-    out[s.name] = {
-      source: s.source ?? '',
-      outputs: s.outputs ?? [],
+  for (const item of items) {
+    // `all()` on DerivationRegistry returns RegisteredStrategy objects:
+    // { spec: DerivationStrategy, strategyHash }. Read `spec` and fall
+    // back to the item itself for forward-compat with other registries.
+    const reg = item as { spec?: { source?: string; outputs?: Record<string, { collection: string }> }; source?: string; outputs?: Record<string, { collection: string }> }
+    const s = reg.spec ?? reg
+    if (!s.source) continue
+    const outputCollections = s.outputs
+      ? Object.values(s.outputs).map((o) => (o as { collection: string }).collection)
+      : []
+    // Key by source — stable, human-readable identifier. If multiple
+    // strategies share the same source, the last one wins (known limitation).
+    out[s.source] = {
+      source: s.source,
+      outputs: outputCollections,
     }
   }
   return out

--- a/packages/hub/src/materialized-views/executor.ts
+++ b/packages/hub/src/materialized-views/executor.ts
@@ -105,7 +105,11 @@ async function materializeUnionResult<TRow extends Record<string, unknown>>(
     const coll = db.collection<Record<string, unknown>>(arm.collection)
     const sourceRows = coll.query().toArray()
     for (const r of sourceRows) {
-      unified.push(arm.map(r))
+      const mapped = arm.map(r)
+      // null / undefined means "omit this source row" — skip without
+      // pushing so groupBy/aggregate never see a null entry (#297).
+      if (mapped == null) continue
+      unified.push(mapped)
     }
   }
 

--- a/packages/hub/src/materialized-views/types.ts
+++ b/packages/hub/src/materialized-views/types.ts
@@ -76,8 +76,14 @@ export interface UnionSource<TRow extends Record<string, unknown>> {
    * Called once per source row at materialization time. Each arm's
    * mapped output is concatenated into a single stream before
    * `groupBy` + `aggregate` run.
+   *
+   * Returning `null` or `undefined` **omits** the source row from the
+   * materialized output entirely — the row is not pushed into the
+   * unified stream and never reaches `groupBy` / `aggregate`. This
+   * removes the need for sentinel rows (e.g. `{ amount: 0 }`) whose
+   * sole purpose is to be aggregated away (#297).
    */
-  readonly map: (sourceRow: Record<string, unknown>) => TRow
+  readonly map: (sourceRow: Record<string, unknown>) => TRow | null | undefined
 }
 
 /**

--- a/packages/hub/src/overlay-views/registry.ts
+++ b/packages/hub/src/overlay-views/registry.ts
@@ -76,6 +76,17 @@ export class OverlayedViewRegistry {
   }
 
   /**
+   * All registered overlay strategies as a flat array.
+   * Each strategy carries `name`, `base`, and `overlay` fields that
+   * `describeOverlays()` in the introspection walker reads directly.
+   *
+   * Used by `dumpSchema()` to populate the `overlayViews` map.
+   */
+  all(): ReadonlyArray<OverlayedViewStrategy> {
+    return [...this._byName.values()]
+  }
+
+  /**
    * Resolve the `rowKey` function for an overlay's base MV. Returns
    * `undefined` if the base isn't an MV (raw source collection) or
    * if the MV registry isn't supplied. Used by the virtual-collection

--- a/packages/hub/src/util/discriminant.ts
+++ b/packages/hub/src/util/discriminant.ts
@@ -1,0 +1,65 @@
+/**
+ * Type-guard helper for narrowing discriminated-union records.
+ *
+ * `Collection<T>` correctly threads `T` through `get` / `query` / `scan`, but
+ * accessing member-specific fields after reading from a `Collection<Union>`
+ * still requires a narrowing step in application code. In regular `.ts` files
+ * a simple `if (r.kind === 'IV')` block narrows correctly; in vue-tsc /
+ * template contexts the inline comparison is sometimes not enough, and the
+ * helper below makes the guard portable and avoids `as unknown as …` casts.
+ *
+ * **Usage with Collection<T>**
+ *
+ * ```ts
+ * import { isDiscriminant } from '@noy-db/hub'
+ *
+ * type IV = { kind: 'IV'; invoiceNo: string; amount: number }
+ * type RE = { kind: 'RE'; receiptNo: string; paidAt: string }
+ * type Receipt = IV | RE | ...
+ *
+ * const receipts = await vault.collection<Receipt>('receipts').query().toArray()
+ *
+ * // Filter approach — result is IV[], invoiceNo accessible without cast:
+ * const ivs = receipts.filter(r => isDiscriminant(r, 'kind', 'IV'))
+ * console.log(ivs[0].invoiceNo)
+ *
+ * // Branch approach:
+ * for (const r of receipts) {
+ *   if (isDiscriminant(r, 'kind', 'IV')) {
+ *     console.log(r.invoiceNo)  // r: IV here
+ *   }
+ * }
+ * ```
+ *
+ * @module
+ */
+
+/**
+ * Type-guard for narrowing a discriminated-union record by its discriminant.
+ *
+ * Returns `true` when `record[key] === value`, and narrows `record` to
+ * `Extract<T, Record<K, V>>` — the exact union member(s) that carry that
+ * discriminant value.
+ *
+ * The discriminant key is a parameter (not hardcoded to `'kind'`), so this
+ * works with any field name: `'kind'`, `'type'`, `'tag'`, etc.
+ *
+ * @example
+ *   const ivs = receipts.filter(r => isDiscriminant(r, 'kind', 'IV'))
+ *   // ivs: IV[]  — invoiceNo accessible, no cast needed
+ *
+ * @typeParam T - The union type of the record (e.g. `Receipt`). Both type-alias
+ *   unions and interface-extended unions work; use a `type` alias (`type Receipt = IV | RE`) for best
+ *   results.
+ * @typeParam K - The discriminant key (must be a key of `T`).
+ * @typeParam V - The discriminant value to match. The `const` modifier ensures
+ *   TypeScript infers the string literal (e.g. `'IV'`), not the full union
+ *   `T[K]`, so the predicate resolves to the exact member type.
+ */
+export function isDiscriminant<
+  T,
+  K extends keyof T,
+  const V extends T[K],
+>(record: T, key: K, value: V): record is Extract<T, Record<K, V>> {
+  return (record as Record<PropertyKey, unknown>)[key as PropertyKey] === value
+}

--- a/packages/hub/src/util/index.ts
+++ b/packages/hub/src/util/index.ts
@@ -15,3 +15,4 @@ export type {
   FilenameProfile,
   SanitizeFilenameOptions,
 } from './sanitize-filename.js'
+export { isDiscriminant } from './discriminant.js'

--- a/packages/in-ai/package.json
+++ b/packages/in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-ai",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "LLM function-calling adapter for noy-db — expose ACL-scoped collections as tool definitions, then dispatch tool calls back to the vault. Format-agnostic (OpenAI, Anthropic, Vercel AI SDK).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-devtools-tui/package.json
+++ b/packages/in-devtools-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-devtools-tui",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Interactive terminal inspector for a live noy-db (ink TUI over @noy-db/in-devtools).",
   "license": "MIT",
   "type": "module",

--- a/packages/in-devtools/package.json
+++ b/packages/in-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-devtools",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Framework-agnostic read-only inspector for a live noy-db — vaults, collections, schema, stats, records, and live writes.",
   "license": "MIT",
   "type": "module",

--- a/packages/in-nextjs/package.json
+++ b/packages/in-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nextjs",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Next.js App Router helpers for noy-db — server components, route handlers, client hooks, and cookie-based session. Thin bridge that composes @noy-db/in-react with Next's cookies()/headers() APIs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-nuxt/package.json
+++ b/packages/in-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nuxt",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Nuxt 4 module for noy-db — auto-imports, SSR-safe runtime plugin, and the @noy-db/in-pinia bridge",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-pinia/package.json
+++ b/packages/in-pinia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-pinia",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Pinia integration for noy-db — defineNoydbStore() and the augmentation plugin for existing stores",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-react/package.json
+++ b/packages/in-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-react",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "React hooks for noy-db — useNoydb, useVault, useCollection, useQuery, useSync. Uses useSyncExternalStore for reactive subscriptions. Zero deps beyond React.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-rest/package.json
+++ b/packages/in-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-rest",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Framework-neutral REST API integration for noy-db — createRestHandler with Hono, Express, Fastify, and Nitro subpath adapters.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-solid/package.json
+++ b/packages/in-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-solid",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "SolidJS signal primitives for noy-db — createCollectionSignal, createQuerySignal, createSyncSignal backed by noy-db change events.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-svelte/package.json
+++ b/packages/in-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-svelte",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Svelte stores for noy-db — collectionStore / queryStore / syncStore backed by noy-db change events. Works with Svelte 4 store contract and Svelte 5 runes (via $store subscription interop).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-query/package.json
+++ b/packages/in-tanstack-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-query",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "TanStack Query adapter for noy-db — queryFn + mutationFn helpers that speak the Collection API, plus automatic invalidation from noy-db change events. Framework-agnostic (React / Vue / Solid / Svelte).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-table/package.json
+++ b/packages/in-tanstack-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-table",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "TanStack Table bridge for noy-db — map Collection query state (sort, filter, pagination) into Table state and back, so a useSmartTable pattern drives the DB's query DSL without glue code.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-vue/package.json
+++ b/packages/in-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-vue",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Vue 3 / Nuxt composables for noy-db — reactive useNoydb, useCollection, useSync, and biometric plugin",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-yjs/package.json
+++ b/packages/in-yjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-yjs",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Yjs Y.Doc interop for noy-db — collaborative rich-text fields with encrypted-at-rest Yjs state",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-zustand/package.json
+++ b/packages/in-zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-zustand",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Zustand adapter for noy-db — factory that mirrors defineNoydbStore for Zustand users, auto-syncs state from noy-db change events, and supports optimistic mutations.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-email-otp/package.json
+++ b/packages/on-email-otp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-email-otp",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Email OTP second factor for noy-db — generates time-boxed one-time codes, delivers via a user-supplied transport (SMTP / SES / Postmark / any fn), and verifies in constant time. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-magic-link/package.json
+++ b/packages/on-magic-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-magic-link",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Magic-link unlock for noy-db — one-time URL that opens a vault in a viewer-scoped session without a passphrase. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-oidc/package.json
+++ b/packages/on-oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-oidc",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "OAuth/OIDC bridge for noy-db — federated login (LINE, Google, Apple, Okta) with split-key key connector — server never sees plaintext",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-password/package.json
+++ b/packages/on-password/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-password",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Tier-2 password authenticator slot for noy-db. PBKDF2-SHA256 600K wraps the DEK set in its own keyring slot, distinct from the rarely-typed tier-1 phrase. Pair with @noy-db/on-email-otp or @noy-db/on-totp for the SaaS UX.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-pin/package.json
+++ b/packages/on-pin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-pin",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Session-resume PIN quick-lock for noy-db — after a full passphrase unlock, a short-lived PIN (or a per-device biometric) re-unlocks the cached DEKs without re-typing the passphrase. PIN never replaces the passphrase; only resumes an already-unlocked session.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-recovery/package.json
+++ b/packages/on-recovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-recovery",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "One-time printable recovery codes for noy-db — last-resort vault unlock when the passphrase, passkey, and OIDC provider are all unavailable. Base32 + checksum codes, PBKDF2-derived wrapping keys, burn-on-use. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-shamir/package.json
+++ b/packages/on-shamir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-shamir",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "k-of-n Shamir Secret Sharing of the vault KEK for multi-party unlock. Any K of N shares recombines the key; fewer than K leaks zero bits. Composable — each share can be protected by any other on-* method. Zero runtime dependencies.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-threat/package.json
+++ b/packages/on-threat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-threat",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Threat-response primitives for noy-db — multi-attempt lockout, duress-passphrase data destruction, duress-passphrase honeypot decoy. Pure stateful helpers; the caller coordinates keyring + audit-ledger integration. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-totp/package.json
+++ b/packages/on-totp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-totp",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "TOTP (RFC 6238) authenticator-app second factor for noy-db — generate secrets, otpauth:// provisioning URIs, and constant-time code verification. Zero dependencies (HMAC-SHA1 via Web Crypto). Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-webauthn/package.json
+++ b/packages/on-webauthn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-webauthn",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "WebAuthn hardware-key keyrings for noy-db — Touch ID, Face ID, Windows Hello, YubiKey, FIDO2 passkeys",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-aws-dynamo/package.json
+++ b/packages/to-aws-dynamo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-aws-dynamo",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "AWS DynamoDB adapter for noy-db — single-table design, zero-knowledge cloud sync",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-aws-s3/package.json
+++ b/packages/to-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-aws-s3",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "AWS S3 adapter for noy-db — encrypted object storage with zero-knowledge cloud sync",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-browser-idb/package.json
+++ b/packages/to-browser-idb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-browser-idb",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "IndexedDB adapter for noy-db with optional key obfuscation",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-browser-local/package.json
+++ b/packages/to-browser-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-browser-local",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "localStorage adapter for noy-db with optional key obfuscation",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-cloudflare-d1/package.json
+++ b/packages/to-cloudflare-d1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-cloudflare-d1",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Cloudflare D1 adapter for noy-db — SQLite at the edge, running inside Cloudflare Workers. Accepts a D1Database binding and speaks the noy-db store contract via D1's prepare/bind API.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-cloudflare-r2/package.json
+++ b/packages/to-cloudflare-r2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-cloudflare-r2",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Cloudflare R2 adapter for noy-db — S3-compatible object storage with zero egress fees. Thin wrapper around @noy-db/to-aws-s3 configured for the R2 endpoint. casAtomic: false (same caveat as S3).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-drive/package.json
+++ b/packages/to-drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-drive",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Google Drive bundle store for noy-db. Stores the whole vault as a single .noydb file in Drive's hidden appDataFolder; opaque ULID filenames never leak compartment names. Driver-agnostic — bring your own OAuth token.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-file/package.json
+++ b/packages/to-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-file",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "JSON file adapter for noy-db — encrypted document store on local disk, USB sticks, or network drives",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-icloud/package.json
+++ b/packages/to-icloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-icloud",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "iCloud Drive bundle store for noy-db — macOS-aware persistence that detects eviction stubs (.icloud) and conflict files automatically. Treats each vault as a single .noydb bundle, safe for the Apple ecosystem.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-memory/package.json
+++ b/packages/to-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-memory",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "In-memory adapter for noy-db — ideal for testing, development, and ephemeral workloads",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-meter/package.json
+++ b/packages/to-meter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-meter",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Pass-through meter for @noy-db/to-* stores — wraps any NoydbStore and records per-method latency percentiles, error rates, and byte counts on real traffic. Optional synthetic liveness probe emits degraded / restored events. No synthetic benchmarks (see @noy-db/to-probe for that) — this measures what your app is actually doing.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-mysql/package.json
+++ b/packages/to-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-mysql",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "MySQL / MariaDB adapter for noy-db — encrypted-envelope KV with JSON column. Works with any duck-typed mysql2-style pool/connection. casAtomic: true via UPDATE … WHERE v = ?.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-nfs/package.json
+++ b/packages/to-nfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-nfs",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "NFS network-file store for noy-db. Same indexed layout as @noy-db/to-file, with pre-flight checks for nolock / noac mount options that silently break versioning guarantees on stock NFS mounts.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-postgres/package.json
+++ b/packages/to-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-postgres",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "PostgreSQL adapter for noy-db — encrypted-envelope KV with jsonb column. Works with any duck-typed pg-style Client (node-postgres, postgres.js, pg-native, Supabase, Neon serverless). casAtomic: true via UPDATE … WHERE _v = ?.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-probe/package.json
+++ b/packages/to-probe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-probe",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Diagnostic companion for the @noy-db/to-* store family — not itself a storage backend. Setup-time suitability test + topology check + runtime reliability monitor. Exercises the 6-method NoydbStore contract across five axes (write latency, CAS integrity, hydration cost, sync economics, network resilience) and produces a structured risk-scored report.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-smb/package.json
+++ b/packages/to-smb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-smb",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "SMB/CIFS network file store for noy-db. Works against Windows file servers, NAS devices (Synology/QNAP/Netgear), and corporate shared drives via NTLM or Kerberos auth — no OS mount required.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-sqlite/package.json
+++ b/packages/to-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-sqlite",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "SQLite adapter for noy-db — single-file local encrypted document store. Works with better-sqlite3, node:sqlite (Node 22+), or bun:sqlite via a duck-typed Database interface. casAtomic: true (BEGIN IMMEDIATE + UPDATE WHERE _v=?).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-ssh/package.json
+++ b/packages/to-ssh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-ssh",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "SSH/SFTP store for noy-db — remote encrypted document storage over SSH using public-key auth. Any Linux/macOS server with sshd running becomes a noy-db backend; leverages existing ~/.ssh keys or ssh-agent. Key-only auth (no passwords).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-supabase/package.json
+++ b/packages/to-supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-supabase",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Supabase adapter for noy-db — Postgres + Storage combo. Routes records to @noy-db/to-postgres via the Supabase Postgres pool and optional blob routing via Supabase Storage.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-turso/package.json
+++ b/packages/to-turso/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-turso",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "Turso / libSQL adapter for noy-db — edge SQLite with built-in replication. Wraps @libsql/client through a small async shim that speaks the same noy-db store contract as @noy-db/to-sqlite.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-webdav/package.json
+++ b/packages/to-webdav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-webdav",
-  "version": "0.2.0-pre.9",
+  "version": "0.2.0-pre.10",
   "description": "WebDAV adapter for noy-db — encrypted object storage over the WebDAV protocol. Works with Nextcloud, ownCloud, Apache mod_dav, and any RFC 4918 server. Pure fetch()-based, zero dependencies.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",


### PR DESCRIPTION
Adopter-reported correctness + introspection batch, released as **0.2.0-pre.10** (lockstep bump, all 66 packages). All changes are in `@noy-db/hub`.

## Fixes

**#293 — unique indexes are now enforced** (was a silent data-integrity footgun)
- `{ fields: [...], unique: true }` enforced at write time, **single + composite**; duplicate non-null values rejected with new `UniqueConstraintError`. Null-tolerant (SQL NULL-distinct).
- Covers `put`/`putMany`/`delete`, atomic-rollback, and hydration rebuild (enforces against prior-session data).
- Eager-mode only; `unique` on lazy/CRDT/tiered collections **fails loud** at registration (`UnsupportedIndexOptionError`) — never silently ignored.

**#294 — `dumpSchema()` 0 fields for discriminated unions** → now surfaces the union of member fields (required iff required in all members) + discriminator literals.

**#295 — `dumpSchema()` introspection gaps** → `derivations`/`overlayViews` maps populate (registries gained `all()`; derivations keyed by output collection so co-sourced ones don't collide); MV `aggregate` renders `sum(field)`/`count` instead of `"[object Object]"`.

**#297 — MV row omission** → a `unionSources` `map` may return `null`/`undefined` to drop a record (no sentinel rows).

**#296 — discriminated-union DX** → ships `isDiscriminant(record, key, value)` type-guard to narrow `Collection<Union>` reads without `as unknown as` casts + a recipe in `docs/core/06-query-basics.md`.

Closes #293, #294, #295, #296, #297.

## Verification
- [x] `pnpm --filter @noy-db/hub run typecheck` (main + typetest) — clean
- [x] `pnpm --filter @noy-db/hub test` — 220 files / 2165 tests pass (incl. ~35 new tests across the 5 fixes)
- [x] `node scripts/validate-features.mjs` — OK
- [x] Lockstep bump verified: 66 package.json on `0.2.0-pre.10`, root untouched

Each fix was TDD'd; #293 (hot write-path change) went through spec + code-quality review — that pass caught and fixed the CRDT/tiered bypass, the history-write-before-check ordering, and the rollback ghost-holder edge case.

## Notes
- This is the **bug-fix batch off `main`**, independent of the milestone-16 federation work (PR #292 + the stacked cross-vault-live branch), which will rebase onto the new `main` after this lands.
- Publish happens via the GitHub Release (`release.yml`), not this PR — not triggered here.