### PR TITLE
feat(hub): money() — currency-safe decimal field descriptor (#300)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-money-decimal-field.md
+++ b/docs/superpowers/plans/2026-06-08-money-decimal-field.md
@@ -1,0 +1,257 @@
+# money() Field Descriptor — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `money()` field descriptor to `@noy-db/hub` that stores currency values as exact scaled integers (string-encoded), formats on read, supports opt-in multi-currency, and makes `sum/min/max` exact end-to-end including magnitudes past `Number.MAX_SAFE_INTEGER`.
+
+**Architecture:** A branded descriptor (`money(opts) → { _noydbMoney: true, options }`) declared per-collection via `options.moneyFields` — identical plumbing to `i18nFields`/`dictKeyFields`. A pure BigInt fixed-point core does all decimal↔integer conversion via string manipulation (never float multiplication). Write quantizes after schema validation; read exposes an exact decimal string plus `<field>Formatted`/`<field>Number` virtuals in `applyLocaleToRecord`. Exact aggregation is achieved by wrapping `sum/min/max` reducers at the `Query` layer (where `moneyFields` is in scope) with a BigInt money reducer that returns per-currency exact-string results.
+
+**Tech Stack:** TypeScript, `BigInt`, `Intl.NumberFormat`, zod (existing schema layer), vitest.
+
+---
+
+## File Structure
+
+- **Create** `packages/hub/src/money/iso4217.ts` — ISO-4217 minor-units table + `scaleForCurrency()`.
+- **Create** `packages/hub/src/money/fixed-point.ts` — pure core: `parseToScaledInt`, `formatScaledInt`, rounding modes. No I/O, no descriptor knowledge.
+- **Create** `packages/hub/src/money/descriptor.ts` — `money()`, `MoneyDescriptor`, `MoneyOptions`, `isMoneyDescriptor`, construction validation; `MoneyPrecisionError`, `MoneyCurrencyError`.
+- **Create** `packages/hub/src/money/normalize.ts` — write-side `quantizeMoneyFields(record, moneyFields)` and read-side `decodeMoneyFields(record, moneyFields, locale)`.
+- **Create** `packages/hub/src/money/money-reducer.ts` — BigInt money reducer + `wrapMoneyReducers(spec, moneyFields)` + FX conversion.
+- **Create** `packages/hub/src/money/index.ts` — barrel re-export.
+- **Modify** `packages/hub/src/vault.ts` — `CollectionOptions.moneyFields`, `moneyFieldRegistry`, populate + pass-through (mirror i18nFields at :531, :615, :751).
+- **Modify** `packages/hub/src/collection.ts` — `moneyFields` opt (~596/781), quantize in `putInternal` after `validateSchemaInput` (~1168), decode in `applyLocaleToRecord` (~3081), pass `moneyFields` into `Query` (~2303).
+- **Modify** `packages/hub/src/query.ts` — accept `moneyFields`, call `wrapMoneyReducers` before reduction; thread `convertTo`/`fx` aggregate options.
+- **Modify** `packages/hub/src/introspection/fields.ts` — emit `money` field kind.
+- **Modify** `packages/hub/src/index.ts` — export `money`, `isMoneyDescriptor`, `MoneyDescriptor`, error types.
+- **Modify** `SUBSYSTEMS.md`, `packages/hub/README.md`, `features.yaml` — docs + registry.
+- **Test dirs:** `packages/hub/__tests__/money/`.
+
+---
+
+## Task 1: ISO-4217 table + scale resolution
+
+**Files:** Create `packages/hub/src/money/iso4217.ts`; Test `packages/hub/__tests__/money/iso4217.test.ts`
+
+- [ ] **Step 1: Failing test**
+```ts
+import { describe, it, expect } from 'vitest'
+import { scaleForCurrency } from '../../src/money/iso4217.js'
+describe('scaleForCurrency', () => {
+  it('returns ISO-4217 minor units', () => {
+    expect(scaleForCurrency('EUR')).toBe(2)
+    expect(scaleForCurrency('JPY')).toBe(0)
+    expect(scaleForCurrency('BHD')).toBe(3)
+    expect(scaleForCurrency('USD')).toBe(2)
+  })
+  it('returns null for unknown currency', () => {
+    expect(scaleForCurrency('ZZZ')).toBeNull()
+  })
+})
+```
+- [ ] **Step 2:** `npx vitest run packages/hub/__tests__/money/iso4217.test.ts` → FAIL (module missing).
+- [ ] **Step 3: Implement.** A `Record<string, number>` covering the common set (EUR/USD/GBP/CHF/JPY/CNY/BHD/KWD/TND and ~40 majors; default 2 not assumed — only listed codes are known). `export function scaleForCurrency(code: string): number | null { return MINOR_UNITS[code] ?? null }`.
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5: Commit** `feat(money): ISO-4217 minor-units table`.
+
+## Task 2: Pure BigInt fixed-point core
+
+**Files:** Create `packages/hub/src/money/fixed-point.ts`; Test `packages/hub/__tests__/money/fixed-point.test.ts`
+
+Interface:
+```ts
+export type RoundingMode = 'half-up'|'half-even'|'half-down'|'up'|'down'|'ceil'|'floor'
+// Parse a decimal (number|string) to a scaled BigInt. Returns { value } or throws RangeError-like
+// signal via a discriminated result so the descriptor layer can map to MoneyPrecisionError.
+export function parseToScaledInt(input: number | string, scale: number, rounding?: RoundingMode):
+  { ok: true; value: bigint } | { ok: false; reason: 'precision' | 'nonfinite' }
+// Render a scaled BigInt back to a canonical decimal string, e.g. (12345n, 2) → '123.45'; (5n,0)→'5'
+export function formatScaledInt(value: bigint, scale: number): string
+```
+
+- [ ] **Step 1: Failing tests** (table-driven):
+```ts
+import { describe, it, expect } from 'vitest'
+import { parseToScaledInt, formatScaledInt } from '../../src/money/fixed-point.js'
+const ok = (r: ReturnType<typeof parseToScaledInt>) => { if (!r.ok) throw new Error('expected ok'); return r.value }
+describe('parseToScaledInt', () => {
+  it('exact, no rounding needed', () => {
+    expect(ok(parseToScaledInt('123.45', 2))).toBe(12345n)
+    expect(ok(parseToScaledInt(123.45, 2))).toBe(12345n)
+    expect(ok(parseToScaledInt('5', 0))).toBe(5n)
+    expect(ok(parseToScaledInt('-0.01', 2))).toBe(-1n)
+    expect(ok(parseToScaledInt('1.20', 2))).toBe(120n)
+  })
+  it('never uses float multiplication (0.1-class stays exact)', () => {
+    expect(ok(parseToScaledInt('0.1', 2))).toBe(10n)
+    expect(ok(parseToScaledInt('0.2', 2))).toBe(20n)
+  })
+  it('exact past 2^53', () => {
+    expect(ok(parseToScaledInt('90071992547409.91', 2))).toBe(9007199254740991n)
+  })
+  it('rejects excess precision without rounding', () => {
+    expect(parseToScaledInt('123.456', 2)).toEqual({ ok: false, reason: 'precision' })
+  })
+  it('rejects non-finite', () => {
+    expect(parseToScaledInt(NaN, 2)).toEqual({ ok: false, reason: 'nonfinite' })
+    expect(parseToScaledInt(Infinity, 2)).toEqual({ ok: false, reason: 'nonfinite' })
+  })
+  it('rounding modes on the tie digit', () => {
+    expect(ok(parseToScaledInt('123.455', 2, 'half-up'))).toBe(12346n)
+    expect(ok(parseToScaledInt('123.445', 2, 'half-up'))).toBe(12345n)
+    expect(ok(parseToScaledInt('123.455', 2, 'half-even'))).toBe(12346n) // 5→6 even
+    expect(ok(parseToScaledInt('123.445', 2, 'half-even'))).toBe(12344n) // 4→4 even
+    expect(ok(parseToScaledInt('123.451', 2, 'half-down'))).toBe(12345n)
+    expect(ok(parseToScaledInt('123.451', 2, 'down'))).toBe(12345n)
+    expect(ok(parseToScaledInt('123.451', 2, 'up'))).toBe(12346n)
+    expect(ok(parseToScaledInt('-123.451', 2, 'ceil'))).toBe(-12345n)
+    expect(ok(parseToScaledInt('-123.451', 2, 'floor'))).toBe(-12346n)
+  })
+})
+describe('formatScaledInt', () => {
+  it('renders canonical decimal strings', () => {
+    expect(formatScaledInt(12345n, 2)).toBe('123.45')
+    expect(formatScaledInt(-1n, 2)).toBe('-0.01')
+    expect(formatScaledInt(5n, 0)).toBe('5')
+    expect(formatScaledInt(9007199254740991n, 2)).toBe('90071992547409.91')
+  })
+})
+```
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3: Implement.** Algorithm — coerce `input` to a canonical decimal *string* (for `number`, use `String(input)`; reject if it contains `e`/`E` exponent by expanding, or reject non-finite first). Split on `.`. Take `frac`; if `frac.length > scale`: the digits beyond `scale` are the discarded part — if all zero, truncate exactly; else if `rounding` undefined → `{ok:false,reason:'precision'}`; else compute the rounding increment from the first discarded digit + remainder + sign + mode. Build the integer string `intPart + frac.padEnd(scale,'0').slice(0,scale)`, parse `BigInt`, apply increment. Sign handled on the BigInt. `formatScaledInt`: work on `abs`, left-pad to `scale+1`, insert `.` at `len-scale`, strip trailing-`.000` only when `scale===0`, re-apply sign.
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5: Commit** `feat(money): pure BigInt fixed-point core`.
+
+## Task 3: Descriptor + construction validation + errors
+
+**Files:** Create `packages/hub/src/money/descriptor.ts`; Test `packages/hub/__tests__/money/descriptor.test.ts`
+
+Types:
+```ts
+export interface MoneyOptionsFixed { currency: string; scale?: number; rounding?: RoundingMode }
+export interface MoneyOptionsMulti { currencies: 'any' | string[]; scaleOverrides?: Record<string,number>; rounding?: RoundingMode }
+export type MoneyOptions = MoneyOptionsFixed | MoneyOptionsMulti
+export interface MoneyDescriptor {
+  readonly _noydbMoney: true
+  readonly mode: 'fixed' | 'multi'
+  readonly options: MoneyOptions
+  readonly rounding?: RoundingMode
+  // resolved helpers:
+  scaleFor(currency: string): number   // throws MoneyCurrencyError if unresolvable
+  currencyOf(value: unknown): string   // fixed → options.currency; multi → value.currency
+  allows(currency: string): boolean
+}
+export class MoneyPrecisionError extends Error { constructor(public field: string, public value: unknown, public scale: number) {…} }
+export class MoneyCurrencyError extends Error { constructor(public field: string, public currency: string, public reason: 'not-allowed'|'unknown-scale') {…} }
+```
+- [ ] **Step 1: Failing test**
+```ts
+import { describe, it, expect } from 'vitest'
+import { money, isMoneyDescriptor, MoneyCurrencyError } from '../../src/money/descriptor.js'
+describe('money()', () => {
+  it('fixed mode resolves scale from ISO-4217 when omitted', () => {
+    const d = money({ currency: 'EUR' }); expect(d.mode).toBe('fixed'); expect(d.scaleFor('EUR')).toBe(2)
+  })
+  it('fixed mode honors explicit scale', () => { expect(money({ currency:'XAU', scale:4 }).scaleFor('XAU')).toBe(4) })
+  it('multi mode resolves per-currency scale', () => {
+    const d = money({ currencies: ['EUR','JPY'] }); expect(d.scaleFor('EUR')).toBe(2); expect(d.scaleFor('JPY')).toBe(0)
+  })
+  it('multi scaleOverrides win', () => { expect(money({ currencies:'any', scaleOverrides:{ FOO:5 } }).scaleFor('FOO')).toBe(5) })
+  it('multi rejects disallowed currency', () => {
+    expect(() => money({ currencies:['EUR'] }).scaleFor('USD')).toThrow(MoneyCurrencyError)
+  })
+  it('unknown currency without scale throws at construction', () => { expect(() => money({ currency:'ZZZ' })).toThrow(MoneyCurrencyError) })
+  it('currency + currencies together throws', () => {
+    // @ts-expect-error mutually exclusive
+    expect(() => money({ currency:'EUR', currencies:'any' })).toThrow()
+  })
+  it('isMoneyDescriptor predicate', () => { expect(isMoneyDescriptor(money({currency:'EUR'}))).toBe(true); expect(isMoneyDescriptor({})).toBe(false) })
+})
+```
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3: Implement** using `scaleForCurrency` from Task 1. Construction validates mutual exclusivity, and for fixed mode eagerly resolves+caches scale (throw if unknown & no `scale`). `scaleFor` for multi: `scaleOverrides[c] ?? scaleForCurrency(c)`; throw `MoneyCurrencyError` if not allowed or unresolved.
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5: Commit** `feat(money): descriptor + construction validation + typed errors`.
+
+## Task 4: Write/read normalization helpers
+
+**Files:** Create `packages/hub/src/money/normalize.ts`; Test `packages/hub/__tests__/money/normalize.test.ts`
+
+```ts
+// Write: mutate a shallow clone — money fields → canonical stored form.
+//   fixed: '12345'   |   multi: { amount:'12345', currency:'EUR' }
+export function quantizeMoneyFields<T extends Record<string,unknown>>(record: T, moneyFields: Record<string,MoneyDescriptor>): T
+// Read: stored form → exact decimal string + virtuals (<f>Formatted, <f>Number)
+export function decodeMoneyFields<T extends Record<string,unknown>>(record: T, moneyFields: Record<string,MoneyDescriptor>, locale: string | undefined): T
+```
+- [ ] **Step 1: Failing test** covering: fixed write `123.45`→`'12345'`; multi write `{amount:123.45,currency:'EUR'}`→`{amount:'12345',currency:'EUR'}`; bare-amount accepted in multi only when allow-list length 1; null passthrough; precision throw → `MoneyPrecisionError`; read fixed `'12345'`→`total:'123.45'`, `totalFormatted` (locale `'de-DE'` → contains `123,45`), `totalNumber:123.45`; read of >2^53 keeps `total` exact-string and documents `totalNumber` lossy (assert string exact, number defined).
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3: Implement.** Write uses `parseToScaledInt` + descriptor `rounding`/`scaleFor`; map `{ok:false}` to `MoneyPrecisionError`/non-finite throw. Read uses `formatScaledInt`; `<f>Formatted` via `new Intl.NumberFormat(locale ?? 'en-US', { style:'currency', currency }).format(Number(decimalString))` (format is display-only; exactness lives in the string); `<f>Number = Number(decimalString)`.
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5: Commit** `feat(money): write/read normalization helpers`.
+
+## Task 5: Wire into Vault + Collection (write + read paths)
+
+**Files:** Modify `packages/hub/src/vault.ts`, `packages/hub/src/collection.ts`; Test `packages/hub/__tests__/money/collection-roundtrip.test.ts`
+
+- [ ] **Step 1: Failing integration test** — open a vault, declare `collection('invoices', { schema, moneyFields: { total: money({currency:'EUR',scale:2}) } })`, `put('a',{ id:'a', total: 123.45 })`, then `get('a', { locale:'de-DE' })` → `total==='123.45'`, `totalFormatted` contains `123,45`, `totalNumber===123.45`. Raw read (`locale:'raw'` or no locale) → stored `'12345'` is decoded to `'123.45'` (decode always runs; raw only skips Intl formatting/virtuals — match dictKey's `locale!=='raw'` gate).
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3: Implement wiring** (mirror i18nFields exactly):
+  - `vault.ts`: add `moneyFields?: Record<string,MoneyDescriptor>` to `CollectionOptions` (~531); `moneyFieldRegistry: Map<string, Record<string,MoneyDescriptor>>` (~332); populate in `collection()` (~615); pass to `collOpts` (~751).
+  - `collection.ts`: add `moneyFields` to constructor opts type (~596) + field (~781); in `putInternal` after `validateSchemaInput` (~1168) call `record = quantizeMoneyFields(record, this.moneyFields)` when present; in `applyLocaleToRecord` (~3081) call `record = decodeMoneyFields(record, this.moneyFields, locale)` (always decode stored→decimal; gate the Intl virtuals on `locale!=='raw'` inside the helper).
+- [ ] **Step 4:** Run → PASS; also run `packages/hub/__tests__/i18n` to confirm no regression in the shared apply path.
+- [ ] **Step 5: Commit** `feat(money): wire descriptor into vault + collection write/read paths`.
+
+## Task 6: Exact money-aware aggregation
+
+**Files:** Create `packages/hub/src/money/money-reducer.ts`; Modify `packages/hub/src/collection.ts` (~2303), `packages/hub/src/query.ts`; Test `packages/hub/__tests__/money/aggregate.test.ts`
+
+Design: aggregates run over **raw** records (money = scaled-int string). `wrapMoneyReducers(spec, moneyFields)` inspects each reducer's `.op`/`.field`; when `field ∈ moneyFields` and `op ∈ {sum,min,max}`, replaces it with a money reducer whose state is per-currency `Map<string,bigint>` and whose `finalize` returns either a single exact string (fixed mode / single currency present) or a `Record<currency,string>` map (multi). `sum(field,{convertTo,fx})` converts via `fx` to one exact string.
+
+- [ ] **Step 1: Failing test**
+```ts
+// fixed-mode exact sum incl >2^53; per-currency map for multi; FX convert; min/max
+// e.g. put lines total 0.1,0.2,0.3 → sum '0.60' exact
+// multi EUR+USD → sum { EUR:'...', USD:'...' }; with {convertTo:'EUR', fx:{ 'USD->EUR':0.9 }} → single string
+```
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3: Implement.** Verify (in-test) that `Query`'s record source is raw, pre-`applyLocaleToRecord`; if not, route aggregate over raw records. Pass `moneyFields` into `Query` at collection.ts:2303 and into the aggregate execution; call `wrapMoneyReducers` before `reduceRecords`/groupby. Money reducer parses stored integer strings to BigInt, accumulates per currency, finalizes with `formatScaledInt`. FX: for each currency subtotal, look up `fx['${cur}->${convertTo}']` (throw if missing), multiply (decimal-safe via scaled-int), sum.
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5: Commit** `feat(money): exact BigInt money-aware sum/min/max with per-currency + FX`.
+
+## Task 7: Introspection field kind
+
+**Files:** Modify `packages/hub/src/introspection/fields.ts`; Test `packages/hub/__tests__/money/introspection.test.ts`
+
+- [ ] **Step 1: Failing test** — introspecting a collection with a money field yields a field entry `{ kind:'money', currency|currencies, scale }`.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3: Implement** — extend the field walker to recognize `isMoneyDescriptor` and emit the `money` kind (follow how i18nText/dictKey are surfaced).
+- [ ] **Step 4:** Run → PASS.
+- [ ] **Step 5: Commit** `feat(money): introspection money field kind`.
+
+## Task 8: Public exports + docs + registry
+
+**Files:** Modify `packages/hub/src/index.ts`, `packages/hub/src/money/index.ts`, `SUBSYSTEMS.md`, `packages/hub/README.md`, `features.yaml`
+
+- [ ] **Step 1:** Export `money`, `isMoneyDescriptor`, types `MoneyDescriptor`/`MoneyOptions`/`RoundingMode`, `MoneyPrecisionError`, `MoneyCurrencyError` from `index.ts` (alongside the i18n descriptor exports ~668-686).
+- [ ] **Step 2:** Add a `money()` row to the README descriptor table and a short section to `SUBSYSTEMS.md` (Schema layer). Register the feature in `features.yaml` (artefact → spec/plan/showcase refs) so the Spec-coverage CI job passes — **mandatory**.
+- [ ] **Step 3: Typecheck + build** `npx tsc -p packages/hub/tsconfig.json --noEmit` and the package build. Expected: clean.
+- [ ] **Step 4: Commit** `feat(money): export public surface + docs + features.yaml`.
+
+## Task 9: Full-pipeline integration + verification
+
+**Files:** Test `packages/hub/__tests__/money/end-to-end.test.ts`
+
+- [ ] **Step 1:** Write an invoice-shaped end-to-end test: lines with `unitPrice`/`taxAmount`/`total`; sum over `total` exact; a value whose scaled int > `Number.MAX_SAFE_INTEGER` round-trips and sums exactly; multi-currency breakdown; negative credit; null optional excluded from sum; rounding-mode write; `MoneyPrecisionError` on excess precision without rounding.
+- [ ] **Step 2:** `npx vitest run packages/hub/__tests__/money` → all PASS.
+- [ ] **Step 3:** Full hub suite `npx vitest run packages/hub` → green (no regressions, esp. i18n/aggregate/introspection).
+- [ ] **Step 4:** Lint + typecheck + build clean.
+- [ ] **Step 5: Commit** `test(money): full-pipeline integration incl >2^53 exactness`.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** §1 API→T3; §2 write→T2/T4/T5; §3 read→T4/T5; §4 aggregates(per-currency+FX+>2^53)→T2/T6/T9; §5 boundaries(zod-loose, i18n order, introspection)→T5/T7; §6 testing→every task + T9; ISO-4217 scale→T1/T3. No gaps.
+- **Type consistency:** `MoneyDescriptor.scaleFor/currencyOf/allows`, `parseToScaledInt`/`formatScaledInt`, `quantizeMoneyFields`/`decodeMoneyFields`, `wrapMoneyReducers` referenced consistently across T2–T6.
+- **Placeholder scan:** none — algorithms and test cases are concrete.
+- **Risk note (verify during T6):** confirm the aggregate record source is raw (pre-locale). If aggregation runs post-`applyLocaleToRecord`, the money reducer must parse the decimal-string form instead — handled by reading `scaleFor` and parsing accordingly; the test in T6 Step 3 asserts which form arrives.

--- a/docs/superpowers/plans/2026-06-08-money-decimal-field.md
+++ b/docs/superpowers/plans/2026-06-08-money-decimal-field.md
@@ -185,7 +185,7 @@ export function decodeMoneyFields<T extends Record<string,unknown>>(record: T, m
 ```
 - [ ] **Step 1: Failing test** covering: fixed write `123.45`→`'12345'`; multi write `{amount:123.45,currency:'EUR'}`→`{amount:'12345',currency:'EUR'}`; bare-amount accepted in multi only when allow-list length 1; null passthrough; precision throw → `MoneyPrecisionError`; read fixed `'12345'`→`total:'123.45'`, `totalFormatted` (locale `'de-DE'` → contains `123,45`), `totalNumber:123.45`; read of >2^53 keeps `total` exact-string and documents `totalNumber` lossy (assert string exact, number defined).
 - [ ] **Step 2:** Run → FAIL.
-- [ ] **Step 3: Implement.** Write uses `parseToScaledInt` + descriptor `rounding`/`scaleFor`; map `{ok:false}` to `MoneyPrecisionError`/non-finite throw. Read uses `formatScaledInt`; `<f>Formatted` via `new Intl.NumberFormat(locale ?? 'en-US', { style:'currency', currency }).format(Number(decimalString))` (format is display-only; exactness lives in the string); `<f>Number = Number(decimalString)`.
+- [ ] **Step 3: Implement.** Write uses `parseToScaledInt` + descriptor `rounding`/`scaleFor`; map `{ok:false}` to `MoneyPrecisionError`/non-finite throw. **Number-input precision hazard:** `String(0.1+0.2)` → `'0.30000000000000004'`; document that the **string write path is the exact one**, and add a test asserting a float artifact past `scale` precision-rejects (no rounding) rather than silently mis-storing. Read uses `formatScaledInt`; `<f>Formatted` via `new Intl.NumberFormat(locale ?? 'en-US', { style:'currency', currency, minimumFractionDigits: scale, maximumFractionDigits: scale }).format(decimalString)` — **pass the decimal STRING, never `Number(...)`** (Intl.format accepts string/BigInt at full precision; `Number()` would re-corrupt past 2^53 and is the exact bug this feature kills). `<f>Number = Number(decimalString)` (the one explicitly-lossy convenience).
 - [ ] **Step 4:** Run → PASS.
 - [ ] **Step 5: Commit** `feat(money): write/read normalization helpers`.
 
@@ -205,13 +205,21 @@ export function decodeMoneyFields<T extends Record<string,unknown>>(record: T, m
 
 **Files:** Create `packages/hub/src/money/money-reducer.ts`; Modify `packages/hub/src/collection.ts` (~2303), `packages/hub/src/query.ts`; Test `packages/hub/__tests__/money/aggregate.test.ts`
 
-Design: aggregates run over **raw** records (money = scaled-int string). `wrapMoneyReducers(spec, moneyFields)` inspects each reducer's `.op`/`.field`; when `field ∈ moneyFields` and `op ∈ {sum,min,max}`, replaces it with a money reducer whose state is per-currency `Map<string,bigint>` and whose `finalize` returns either a single exact string (fixed mode / single currency present) or a `Record<currency,string>` map (multi). `sum(field,{convertTo,fx})` converts via `fx` to one exact string.
+Design: aggregates run over **raw** records — **CONFIRMED**: `source.snapshot()` is `[...cache.values()].map(e=>e.record)` (collection.ts:2270), never `applyLocaleToRecord`'d, so money arrives as the scaled-int string. `wrapMoneyReducers(spec, moneyFields)` inspects each reducer's `.op`/`.field`; when `field ∈ moneyFields` and `op ∈ {sum,min,max}`, replaces it with a money reducer whose state is per-currency `Map<string,bigint>` and whose `finalize` returns either a single exact string (fixed mode / single currency present) or a `Record<currency,string>` map (multi). `sum(field,{convertTo,fx})` converts via `fx` to one exact string.
+
+**`remove()` is REQUIRED, not optional.** The Reducer protocol's `remove()` is what enables incremental maintenance under `buildLiveAggregation` and materialized views. The pilot's `saleRollups` is exactly money→`sum`→MV with put/delete maintenance (the #305 scenario), so a money reducer without `remove()` would break live/MV aggregation — parity with the generic `sum/min/max` (which all implement `remove`) is mandatory:
+- `sum.remove`: subtract the per-currency BigInt.
+- `min/max.remove`: per-currency multiset, mirroring the generic `pushValue`/`removeValue` (reducers.ts:226/255) but keyed by currency.
+
+**Silent-100×-error guard.** If a money field ever reaches the *generic* `sum`, `readNumber('12345')` returns `12345` — a silent 100× error, the worst failure class for an accounting DB. `wrapMoneyReducers` must be the single source of truth, and the generic field-reducers should assert/throw if handed a value that parses to a money-shaped object or a field known to be money (defensive: a dev-mode guard in `readNumber` when the raw value is an `{amount,currency}` object).
 
 - [ ] **Step 1: Failing test**
 ```ts
 // fixed-mode exact sum incl >2^53; per-currency map for multi; FX convert; min/max
 // e.g. put lines total 0.1,0.2,0.3 → sum '0.60' exact
 // multi EUR+USD → sum { EUR:'...', USD:'...' }; with {convertTo:'EUR', fx:{ 'USD->EUR':0.9 }} → single string
+// remove(): a live/MV aggregate over a money sum stays correct after a source delete
+//           (put a,b,c summing 0.60 → delete b → sum recomputes exactly; mirrors saleRollups)
 ```
 - [ ] **Step 2:** Run → FAIL.
 - [ ] **Step 3: Implement.** Verify (in-test) that `Query`'s record source is raw, pre-`applyLocaleToRecord`; if not, route aggregate over raw records. Pass `moneyFields` into `Query` at collection.ts:2303 and into the aggregate execution; call `wrapMoneyReducers` before `reduceRecords`/groupby. Money reducer parses stored integer strings to BigInt, accumulates per currency, finalizes with `formatScaledInt`. FX: for each currency subtotal, look up `fx['${cur}->${convertTo}']` (throw if missing), multiply (decimal-safe via scaled-int), sum.
@@ -254,4 +262,6 @@ Design: aggregates run over **raw** records (money = scaled-int string). `wrapMo
 - **Spec coverage:** §1 API→T3; §2 write→T2/T4/T5; §3 read→T4/T5; §4 aggregates(per-currency+FX+>2^53)→T2/T6/T9; §5 boundaries(zod-loose, i18n order, introspection)→T5/T7; §6 testing→every task + T9; ISO-4217 scale→T1/T3. No gaps.
 - **Type consistency:** `MoneyDescriptor.scaleFor/currencyOf/allows`, `parseToScaledInt`/`formatScaledInt`, `quantizeMoneyFields`/`decodeMoneyFields`, `wrapMoneyReducers` referenced consistently across T2–T6.
 - **Placeholder scan:** none — algorithms and test cases are concrete.
-- **Risk note (verify during T6):** confirm the aggregate record source is raw (pre-locale). If aggregation runs post-`applyLocaleToRecord`, the money reducer must parse the decimal-string form instead — handled by reading `scaleFor` and parsing accordingly; the test in T6 Step 3 asserts which form arrives.
+- **Risk note (RESOLVED):** aggregate source is raw — `source.snapshot()` = `[...cache.values()].map(e=>e.record)` (collection.ts:2270), never locale-applied; `applyLocaleToRecord` runs only on `get()`/`list()` returns (collection.ts:999, 2041). Money reducer parses scaled-int strings. Decode's primary-field transform (`'12345'`→`'123.45'`) therefore never touches internal storage round-trips (history/ledger/re-encrypt).
+- **`remove()` parity (T6):** money `sum/min/max` implement `remove()` for live/MV maintenance — required for the pilot's `saleRollups` money MV. See Task 6.
+- **Deferred — multi-mode equality indexing:** equality/`unique` indexes on a *multi-mode* `{amount,currency}` field need a canonical composite key; fixed-mode scaled-int strings index as-is. #293 (unique) just shipped, so a multi-mode money `unique` index could behave unexpectedly — explicitly deferred; document "index a derived scalar, not the money object" until a follow-up.

--- a/docs/superpowers/specs/2026-06-08-money-decimal-field-design.md
+++ b/docs/superpowers/specs/2026-06-08-money-decimal-field-design.md
@@ -93,14 +93,15 @@ The acceptance criterion — `aggregate(sum())` is exact.
 - **Schema:** the zod schema declares the field loosely (`z.union([z.number(), z.string()])`, or an `{amount,currency}` object in multi mode); the descriptor owns canonical form, scale, currency, and rounding. Schema validates shape first, descriptor quantizes second.
 - **i18n ordering:** `<field>Formatted` is computed in `applyLocaleToRecord` alongside `<field>Label`, using the same locale resolution; no new ordering rules.
 - **FX source:** `fx` is a caller-supplied rate map / lookup (`{ from, to } → rate`), passed per aggregate call — noy-db neither stores nor sources rates in v1 (a persisted FX-rate companion field remains a separate follow-up).
-- **Introspection / devtools:** money fields surface in the introspection walker (`introspection/fields.ts`) as a `money` field kind with `{ mode, currency|currencies, scale }`.
+- **Introspection / devtools:** *deferred.* The introspection walker is schema-derived (`vault._introspectState()`) and currently surfaces **no** field-descriptor metadata — `i18nText` and `dictKey` are not introspected either. Surfacing money alone would be asymmetric; descriptor introspection (money + i18n + dictKey, uniformly) is its own follow-up.
 
 ### Deferred (separate issues, not v1)
 
+- **Descriptor introspection** (money/i18n/dictKey surfaced in `dumpSchema`) — none are today; do them together.
 - **Persisted** FX-rate companion field / historical-rate storage (per-call `fx` is supported; storing rates is not).
 - Exact `avg()` over money.
 - Money consumed by computed fields — picked up by **#302**.
-- Index semantics beyond equality on the scaled integer.
+- Index semantics beyond equality on the scaled integer. Equality/`unique` on a *multi-mode* `{amount,currency}` value needs a canonical composite key (fixed-mode scaled-int strings index as-is); index a derived scalar until a follow-up.
 
 ## 6. Testing
 

--- a/docs/superpowers/specs/2026-06-08-money-decimal-field-design.md
+++ b/docs/superpowers/specs/2026-06-08-money-decimal-field-design.md
@@ -1,0 +1,143 @@
+# money() — currency-safe, multi-currency decimal field descriptor
+
+**Issue:** #300 (Pilot-3 / i3speedex delegation gap) · **Layer:** Schema · **Cluster:** A (schema fields) alongside #302 computed scalars, #299 cross-record validators.
+
+## Problem
+
+The pilot stores `subtotal` / `taxAmount` / `total` / `unitPrice` as JS `number`. Floating-point cannot represent most decimal money values exactly (`0.1 + 0.2 !== 0.3`), so every VAT/currency computation is a precision/rounding hazard and all of it stays in userland. The existing `sum()` aggregate accumulates in JS `number` (`state + readNumber(...)`, `aggregate/reducers.ts:135`) and therefore drifts.
+
+## Goals
+
+1. A `money({ scale, allowed?, rounding? })` field descriptor — sibling of `i18nText` / `dictKey` — owning fixed-point storage, validation, multi-currency, and locale formatting.
+2. **Maximum accuracy, end to end:** no money value is ever a float at any layer the DB stores, sums, or persists. Exact values survive arbitrarily large magnitudes (past `Number.MAX_SAFE_INTEGER`).
+3. **First-class multi-currency:** currency travels with each value; `aggregate(sum())` is exact per currency, with explicit (and only explicit) FX conversion.
+
+## Core principles
+
+- **Integers live in storage; decimals live only at the boundary.** Money is a fixed-point integer in storage and arithmetic; the decimal form materializes only on read (display) and on write input (immediately quantized).
+- **Exactness is carried as a string, not a JS number.** Stored amount and every exact output (sums, per-currency totals) are decimal/integer **strings**, so accuracy is unbounded. A JS `number` is offered only as an explicit, lossy convenience (`Number(...)`), never as the source of truth.
+- **Currency travels with the value.** Mixing currencies is never silently collapsed; conversion is always an explicit, rate-bearing, audited act.
+
+## 1. Public API
+
+```ts
+money({
+  scale: number,            // required; decimal places for stored amounts. minorUnit = 10^scale
+  allowed?: string[],       // optional ISO-4217 whitelist; writes outside it reject
+  defaultCurrency?: string, // optional; lets write input omit currency
+  rounding?: RoundingMode,  // omitted ⇒ excess input precision REJECTS (no silent mutation)
+})
+
+type RoundingMode =
+  | 'half-up' | 'half-even' | 'half-down'
+  | 'up' | 'down' | 'ceil' | 'floor'
+```
+
+Note `currency` is **no longer fixed per field** — it is per record/value. Implementation mirrors the descriptor pattern (`i18n/core.ts:180`):
+
+```ts
+interface MoneyDescriptor {
+  readonly _noydbMoney: true
+  readonly options: MoneyOptions
+}
+function money(options: MoneyOptions): MoneyDescriptor
+function isMoneyDescriptor(x: unknown): x is MoneyDescriptor
+```
+
+The collection collects declared descriptors into a per-collection
+`moneyFields: Record<fieldPath, MoneyDescriptor>` — same plumbing as
+`i18nFields` / `dictKeyFields` (`collection.ts:593-596`).
+
+## 2. Storage shape (on the wire, inside the encrypted envelope)
+
+```jsonc
+total: { amount: "12345", currency: "EUR" }   // amount = scaled-integer STRING (BigInt-safe)
+```
+
+- `amount` is the scaled integer serialized as a **string** — exact and unbounded, never a JS number.
+- `currency` is the per-value ISO-4217 code.
+- `null` permitted for nullable fields.
+
+## 3. Write path
+
+Write input accepts, per field:
+
+```ts
+{ amount: number | string, currency?: string }   // currency optional iff defaultCurrency set
+```
+
+On `put()` (after zod schema validation — mirrors `i18nText` ordering, `collection.ts:1244`):
+
+1. Resolve currency (input ∪ `defaultCurrency`); if `allowed` set and currency ∉ it ⇒ `MoneyCurrencyError`.
+2. Reject non-finite input (`NaN`, `Infinity`).
+3. Parse to a scaled integer by **decimal-string manipulation** (split on `.`, pad/truncate fraction to `scale`) — never `value * 10^scale` (float multiplication reintroduces drift).
+4. Excess fractional precision: `rounding` omitted ⇒ throw `MoneyPrecisionError`; else apply the mode via BigInt.
+5. Store `{ amount: <integer-string>, currency }`.
+
+Negatives allowed (credits/refunds).
+
+## 4. Read path
+
+On `get()` / `list()` with locale resolution (`applyLocaleToRecord`):
+
+- Field is exposed as a plain (JSON-clean, methodless) value:
+  ```ts
+  total: { amount: "123.45", currency: "EUR" }   // amount = EXACT decimal string
+  ```
+  `amount` is the exact decimal string (not a float). Consumers wanting a number opt in via `Number(total.amount)`.
+- A virtual **`<field>Formatted`** locale string is added (`'€123,45'`) via `Intl.NumberFormat(locale, { style:'currency', currency })`, mirroring `dictKey`'s `<field>Label`. Read-only; stripped before the next write.
+
+*(Review flag: amount-as-exact-string is the maximum-accuracy choice; it replaces the earlier single-currency "decimal number" read shape. Flagged for sign-off.)*
+
+## 5. Exact aggregates
+
+The acceptance criterion — `aggregate(sum())` is exact.
+
+- **`sum` / `min` / `max` group by currency.** When the reduced field is `money`, the reducer accumulates stored integers **in BigInt, partitioned by currency**, and finalizes each partition to an exact decimal string:
+  ```ts
+  sum('total') → { EUR: "12345.67", USD: "980.00" }   // exact, no FX
+  min/max('total') → { EUR: "...", USD: "..." }        // per-currency extremes
+  ```
+  Aggregates run over raw decrypted records *before* `applyLocaleToRecord`, so the reducer sees the integer string; `scale` comes from `moneyFields`.
+- **Opt-in FX conversion** collapses to one currency, explicitly:
+  ```ts
+  sum('total', { convertTo: 'EUR', rates, rounding?: RoundingMode })
+    → "13313.45"   // documented rounding; rate + mode recorded for audit
+  ```
+  Maximum-accuracy conversion order: sum **exactly per currency first**, then convert each per-currency subtotal **once** (one rounding per currency, not per row), then add. `rates` are exact decimal strings applied at high internal precision (rate scale up to 12 digits) via BigInt; the result rounds to the target currency `scale` with the given mode (default `half-even`).
+- **`avg()` — maximum accuracy, not "exact" (division can't be exact).** Per currency, avg computes `sum / count` at an **extended scale** (`scale + guardDigits`, default `guardDigits: 6`) and returns the high-precision decimal string plus the documented final rounding. No silent collapse to a lossy float.
+
+## 6. Boundaries & interplay
+
+- **Schema:** zod declares the field as an object `{ amount: z.union([z.number(), z.string()]), currency: z.string().optional() }` (a provided `moneyField()` zod helper); the descriptor owns scale/rounding/currency-whitelist.
+- **i18n ordering:** `<field>Formatted` computed in `applyLocaleToRecord` beside `<field>Label`, same locale resolution.
+- **Introspection / devtools:** money fields surface in `introspection/fields.ts` as kind `money` with `{ scale, allowed }`.
+
+### Deferred (separate issues)
+
+- A dynamic FX-rate **provider** subsystem (sourcing/caching live rates) — v1 takes caller-supplied `rates`.
+- Exact rational `avg` / carrying remainders.
+- Index semantics beyond equality on `(currency, amount)`.
+- Money consumed by computed fields — picked up by **#302**.
+
+## 7. Testing
+
+- **Quantization round-trip:** `{amount:"123.45",currency:"EUR"}` → store `"12345"` → read `"123.45"`; number and string inputs; `defaultCurrency` fill.
+- **Currency whitelist:** write outside `allowed` ⇒ `MoneyCurrencyError`.
+- **Precision/rounding:** table-driven over every `RoundingMode` incl. half-even vs half-up ties (`123.455` / `123.445`); reject-by-default throws `MoneyPrecisionError`.
+- **Exactness regression:** `0.1`-class sum exact; sum past `Number.MAX_SAFE_INTEGER` exact via integer-string accumulation.
+- **Multi-currency sum:** mixed EUR+USD rows → exact per-currency map; single-currency → single-key map.
+- **FX conversion:** known rate set → `convertTo` total matches a hand-computed reference; sum-then-convert-once beats convert-then-sum on accumulated rounding (assert the documented order).
+- **avg accuracy:** `10/3`-class avg returns extended-scale string, not a drifted float.
+- **Read formatting:** `<field>Formatted` per locale/currency; negatives.
+- **Nulls / optional:** nullable money round-trips; excluded from sums.
+- **Ordering:** descriptor validation runs after zod.
+
+## Build sequence
+
+1. Descriptor + predicate + types (`money()`, `MoneyDescriptor`, `MoneyOptions`, `MoneyPrecisionError`, `MoneyCurrencyError`) + `moneyField()` zod helper.
+2. BigInt fixed-point core: decimal-string ⇄ scaled-integer-string, all rounding modes, high-precision multiply for FX (pure, unit-tested in isolation).
+3. Write-path wiring: `moneyFields` collection, currency resolve/whitelist, quantize-on-put after schema validation.
+4. Read-path wiring: exact-string decimal exposure + `<field>Formatted` virtual in `applyLocaleToRecord`.
+5. Currency-partitioned `sum`/`min`/`max` reducers (exact per-currency map) + opt-in `convertTo`/`rates` collapse + high-accuracy `avg`.
+6. Introspection field kind; docs (SUBSYSTEMS / README descriptor table); features.yaml registration.

--- a/docs/superpowers/specs/2026-06-08-money-decimal-field-design.md
+++ b/docs/superpowers/specs/2026-06-08-money-decimal-field-design.md
@@ -1,4 +1,4 @@
-# money() — currency-safe, multi-currency decimal field descriptor
+# money() — currency-safe decimal field descriptor
 
 **Issue:** #300 (Pilot-3 / i3speedex delegation gap) · **Layer:** Schema · **Cluster:** A (schema fields) alongside #302 computed scalars, #299 cross-record validators.
 
@@ -6,26 +6,29 @@
 
 The pilot stores `subtotal` / `taxAmount` / `total` / `unitPrice` as JS `number`. Floating-point cannot represent most decimal money values exactly (`0.1 + 0.2 !== 0.3`), so every VAT/currency computation is a precision/rounding hazard and all of it stays in userland. The existing `sum()` aggregate accumulates in JS `number` (`state + readNumber(...)`, `aggregate/reducers.ts:135`) and therefore drifts.
 
-## Goals
+## Goal
 
-1. A `money({ scale, allowed?, rounding? })` field descriptor — sibling of `i18nText` / `dictKey` — owning fixed-point storage, validation, multi-currency, and locale formatting.
-2. **Maximum accuracy, end to end:** no money value is ever a float at any layer the DB stores, sums, or persists. Exact values survive arbitrarily large magnitudes (past `Number.MAX_SAFE_INTEGER`).
-3. **First-class multi-currency:** currency travels with each value; `aggregate(sum())` is exact per currency, with explicit (and only explicit) FX conversion.
+A `money({ currency | currencies, scale, rounding })` field descriptor — a sibling of `i18nText` / `dictKey` — that owns fixed-point storage, rounding, validation, multi-currency, and locale formatting, and makes `aggregate(sum())` over the field **exact end-to-end**, including magnitudes past `Number.MAX_SAFE_INTEGER`.
 
-## Core principles
+## Core principle
 
-- **Integers live in storage; decimals live only at the boundary.** Money is a fixed-point integer in storage and arithmetic; the decimal form materializes only on read (display) and on write input (immediately quantized).
-- **Exactness is carried as a string, not a JS number.** Stored amount and every exact output (sums, per-currency totals) are decimal/integer **strings**, so accuracy is unbounded. A JS `number` is offered only as an explicit, lossy convenience (`Number(...)`), never as the source of truth.
-- **Currency travels with the value.** Mixing currencies is never silently collapsed; conversion is always an explicit, rate-bearing, audited act.
+**Integers live in storage as digit strings; decimals live only at the boundary.** Money never exists as a JS `number` anywhere the DB performs arithmetic or persistence — a `number` truncates past 2^53, so the scaled integer is stored as a **string of digits**, parsed to `BigInt` for arithmetic, and rendered to a decimal string at the boundary. The convenience `number` form is offered only as a clearly-lossy read virtual. Aggregates run over the raw stored integers, before any read-time transform.
 
 ## 1. Public API
 
 ```ts
+// Fixed single currency (default):
 money({
-  scale: number,            // required; decimal places for stored amounts. minorUnit = 10^scale
-  allowed?: string[],       // optional ISO-4217 whitelist; writes outside it reject
-  defaultCurrency?: string, // optional; lets write input omit currency
-  rounding?: RoundingMode,  // omitted ⇒ excess input precision REJECTS (no silent mutation)
+  currency: string,            // ISO 4217 code
+  scale?: number,              // default: ISO-4217 minor units for `currency`
+  rounding?: RoundingMode,     // omitted ⇒ excess precision REJECTS
+})
+
+// Multi-currency (opt-in): currency travels per-record
+money({
+  currencies: 'any' | string[],   // allow-list, or 'any'
+  scaleOverrides?: Record<string, number>, // override ISO-4217 default per currency
+  rounding?: RoundingMode,
 })
 
 type RoundingMode =
@@ -33,12 +36,14 @@ type RoundingMode =
   | 'up' | 'down' | 'ceil' | 'floor'
 ```
 
-Note `currency` is **no longer fixed per field** — it is per record/value. Implementation mirrors the descriptor pattern (`i18n/core.ts:180`):
+`currency` and `currencies` are **mutually exclusive** (validated at descriptor construction). Scale is resolved per currency from a built-in **ISO-4217 minor-units table** (`EUR→2`, `JPY→0`, `BHD→3`, …); `scale` (fixed mode) or `scaleOverrides` (multi mode) override it. Unknown currency with no override ⇒ descriptor-construction error.
+
+Implementation mirrors the existing descriptor pattern (`i18n/core.ts:180`):
 
 ```ts
 interface MoneyDescriptor {
   readonly _noydbMoney: true
-  readonly options: MoneyOptions
+  readonly options: MoneyOptions   // normalized: { mode:'fixed'|'multi', ... }
 }
 function money(options: MoneyOptions): MoneyDescriptor
 function isMoneyDescriptor(x: unknown): x is MoneyDescriptor
@@ -48,96 +53,72 @@ The collection collects declared descriptors into a per-collection
 `moneyFields: Record<fieldPath, MoneyDescriptor>` — same plumbing as
 `i18nFields` / `dictKeyFields` (`collection.ts:593-596`).
 
-## 2. Storage shape (on the wire, inside the encrypted envelope)
+## 2. Write path
 
-```jsonc
-total: { amount: "12345", currency: "EUR" }   // amount = scaled-integer STRING (BigInt-safe)
-```
+Accepts `number | string` decimal input (`123.45` or `'123.45'`); multi-currency fields accept `{ amount, currency }` (or a bare amount only if a single allow-listed currency makes it unambiguous). On `put()`:
 
-- `amount` is the scaled integer serialized as a **string** — exact and unbounded, never a JS number.
-- `currency` is the per-value ISO-4217 code.
-- `null` permitted for nullable fields.
+1. Reject non-finite (`NaN`, `Infinity`).
+2. **Multi-currency:** validate `currency` ∈ allow-list (or any non-empty ISO code if `'any'`); resolve `scale` for that currency.
+3. Parse to a scaled integer by **decimal-string manipulation** (never `value * 10^scale` on a float — that reintroduces drift). Split on `.`, pad/truncate the fractional part to `scale`, concatenate, parse to `BigInt`.
+4. Excess fractional precision:
+   - `rounding` omitted ⇒ throw typed **`MoneyPrecisionError`** (field, value, scale).
+   - `rounding` set ⇒ apply the mode to the excess digits.
+5. Store the scaled integer **as a digit string** — fixed mode: `total: '12345'`; multi mode: `total: { amount: '12345', currency: 'EUR' }`.
 
-## 3. Write path
+Negative values allowed (credits / refunds). `null` allowed for nullable fields. Runs **after** zod schema validation, mirroring `i18nText` ordering (`collection.ts:1244`).
 
-Write input accepts, per field:
-
-```ts
-{ amount: number | string, currency?: string }   // currency optional iff defaultCurrency set
-```
-
-On `put()` (after zod schema validation — mirrors `i18nText` ordering, `collection.ts:1244`):
-
-1. Resolve currency (input ∪ `defaultCurrency`); if `allowed` set and currency ∉ it ⇒ `MoneyCurrencyError`.
-2. Reject non-finite input (`NaN`, `Infinity`).
-3. Parse to a scaled integer by **decimal-string manipulation** (split on `.`, pad/truncate fraction to `scale`) — never `value * 10^scale` (float multiplication reintroduces drift).
-4. Excess fractional precision: `rounding` omitted ⇒ throw `MoneyPrecisionError`; else apply the mode via BigInt.
-5. Store `{ amount: <integer-string>, currency }`.
-
-Negatives allowed (credits/refunds).
-
-## 4. Read path
+## 3. Read path
 
 On `get()` / `list()` with locale resolution (`applyLocaleToRecord`):
 
-- Field is exposed as a plain (JSON-clean, methodless) value:
-  ```ts
-  total: { amount: "123.45", currency: "EUR" }   // amount = EXACT decimal string
-  ```
-  `amount` is the exact decimal string (not a float). Consumers wanting a number opt in via `Number(total.amount)`.
-- A virtual **`<field>Formatted`** locale string is added (`'€123,45'`) via `Intl.NumberFormat(locale, { style:'currency', currency })`, mirroring `dictKey`'s `<field>Label`. Read-only; stripped before the next write.
+- The field is exposed as an **exact decimal string** — fixed: `total: '123.45'`; multi: `total: { amount: '123.45', currency: 'EUR' }`.
+- Virtual **`<field>Formatted`** — locale currency string `'€123,45'` via `Intl.NumberFormat(locale, { style:'currency', currency })`. In multi mode it uses the record's own currency. Mirrors `dictKey`'s `<field>Label`.
+- Virtual **`<field>Number`** — convenience JS `number` (`123.45`), explicitly documented as **lossy for magnitudes past `Number.MAX_SAFE_INTEGER`**; for exact math callers use the string.
+- Both virtuals are read-only and stripped before the next write (existing virtual-field lifecycle).
 
-*(Review flag: amount-as-exact-string is the maximum-accuracy choice; it replaces the earlier single-currency "decimal number" read shape. Flagged for sign-off.)*
+Locale resolution reuses the same default-locale machinery as `i18nText`.
 
-## 5. Exact aggregates
+## 4. Exact aggregates
 
 The acceptance criterion — `aggregate(sum())` is exact.
 
-- **`sum` / `min` / `max` group by currency.** When the reduced field is `money`, the reducer accumulates stored integers **in BigInt, partitioned by currency**, and finalizes each partition to an exact decimal string:
-  ```ts
-  sum('total') → { EUR: "12345.67", USD: "980.00" }   // exact, no FX
-  min/max('total') → { EUR: "...", USD: "..." }        // per-currency extremes
-  ```
-  Aggregates run over raw decrypted records *before* `applyLocaleToRecord`, so the reducer sees the integer string; `scale` comes from `moneyFields`.
-- **Opt-in FX conversion** collapses to one currency, explicitly:
-  ```ts
-  sum('total', { convertTo: 'EUR', rates, rounding?: RoundingMode })
-    → "13313.45"   // documented rounding; rate + mode recorded for audit
-  ```
-  Maximum-accuracy conversion order: sum **exactly per currency first**, then convert each per-currency subtotal **once** (one rounding per currency, not per row), then add. `rates` are exact decimal strings applied at high internal precision (rate scale up to 12 digits) via BigInt; the result rounds to the target currency `scale` with the given mode (default `half-even`).
-- **`avg()` — maximum accuracy, not "exact" (division can't be exact).** Per currency, avg computes `sum / count` at an **extended scale** (`scale + guardDigits`, default `guardDigits: 6`) and returns the high-precision decimal string plus the documented final rounding. No silent collapse to a lossy float.
+- A **money-aware reducer path** for `sum` / `min` / `max`: when the reduced field is declared `money` on the source collection, the reducer accumulates the **stored integers in `BigInt`** (parsed from the digit strings) and renders an exact decimal **string** at `finalize`. No float anywhere; exact past 2^53.
+- Aggregates run over raw decrypted records *before* `applyLocaleToRecord`, so the reducer sees the integer string, not the read-time decimal. Scale is read from `moneyFields`.
+- **Multi-currency reduction is currency-aware:** `sum`/`min`/`max` return an **exact per-currency map** by default — `{ EUR:'1234.50', USD:'990.00' }` — never silently converting across currencies. Fixed-mode fields return a single exact string.
+- **Opt-in FX conversion to one figure:** `sum('total', { convertTo:'EUR', fx })` where `fx` supplies rates; the reducer converts each currency's exact subtotal and sums to a single exact string. Missing rate ⇒ throws (never fabricates a rate). `convertTo` without `fx` ⇒ throws.
+- **`avg()` over money is explicitly NOT exactness-guaranteed in v1** (division) — documented. `sum` / `min` / `max` are exact.
 
-## 6. Boundaries & interplay
+## 5. Boundaries & interplay
 
-- **Schema:** zod declares the field as an object `{ amount: z.union([z.number(), z.string()]), currency: z.string().optional() }` (a provided `moneyField()` zod helper); the descriptor owns scale/rounding/currency-whitelist.
-- **i18n ordering:** `<field>Formatted` computed in `applyLocaleToRecord` beside `<field>Label`, same locale resolution.
-- **Introspection / devtools:** money fields surface in `introspection/fields.ts` as kind `money` with `{ scale, allowed }`.
+- **Schema:** the zod schema declares the field loosely (`z.union([z.number(), z.string()])`, or an `{amount,currency}` object in multi mode); the descriptor owns canonical form, scale, currency, and rounding. Schema validates shape first, descriptor quantizes second.
+- **i18n ordering:** `<field>Formatted` is computed in `applyLocaleToRecord` alongside `<field>Label`, using the same locale resolution; no new ordering rules.
+- **FX source:** `fx` is a caller-supplied rate map / lookup (`{ from, to } → rate`), passed per aggregate call — noy-db neither stores nor sources rates in v1 (a persisted FX-rate companion field remains a separate follow-up).
+- **Introspection / devtools:** money fields surface in the introspection walker (`introspection/fields.ts`) as a `money` field kind with `{ mode, currency|currencies, scale }`.
 
-### Deferred (separate issues)
+### Deferred (separate issues, not v1)
 
-- A dynamic FX-rate **provider** subsystem (sourcing/caching live rates) — v1 takes caller-supplied `rates`.
-- Exact rational `avg` / carrying remainders.
-- Index semantics beyond equality on `(currency, amount)`.
+- **Persisted** FX-rate companion field / historical-rate storage (per-call `fx` is supported; storing rates is not).
+- Exact `avg()` over money.
 - Money consumed by computed fields — picked up by **#302**.
+- Index semantics beyond equality on the scaled integer.
 
-## 7. Testing
+## 6. Testing
 
-- **Quantization round-trip:** `{amount:"123.45",currency:"EUR"}` → store `"12345"` → read `"123.45"`; number and string inputs; `defaultCurrency` fill.
-- **Currency whitelist:** write outside `allowed` ⇒ `MoneyCurrencyError`.
-- **Precision/rounding:** table-driven over every `RoundingMode` incl. half-even vs half-up ties (`123.455` / `123.445`); reject-by-default throws `MoneyPrecisionError`.
-- **Exactness regression:** `0.1`-class sum exact; sum past `Number.MAX_SAFE_INTEGER` exact via integer-string accumulation.
-- **Multi-currency sum:** mixed EUR+USD rows → exact per-currency map; single-currency → single-key map.
-- **FX conversion:** known rate set → `convertTo` total matches a hand-computed reference; sum-then-convert-once beats convert-then-sum on accumulated rounding (assert the documented order).
-- **avg accuracy:** `10/3`-class avg returns extended-scale string, not a drifted float.
-- **Read formatting:** `<field>Formatted` per locale/currency; negatives.
-- **Nulls / optional:** nullable money round-trips; excluded from sums.
-- **Ordering:** descriptor validation runs after zod.
+- **Quantization round-trip:** write `123.45` → store `'12345'` → read `'123.45'`; string and number inputs; fixed and multi mode.
+- **Exactness past 2^53:** store/read/sum a value whose scaled integer exceeds `Number.MAX_SAFE_INTEGER` (e.g. `90071992547409.91`) — exact through the full store→read→reduce pipeline, not just sum finalize. Assert `<field>Number` is documented-lossy here.
+- **Precision handling:** table-driven over every `RoundingMode`, incl. half-even vs half-up tie-breaking (`123.455`, `123.445`); reject-by-default throws `MoneyPrecisionError`.
+- **Multi-currency:** per-record currency stored + read; scale derived per ISO-4217 (JPY=0, EUR=2, BHD=3); write with disallowed currency rejects; `scaleOverrides` honored.
+- **Currency-aware aggregates:** `sum` over mixed currencies returns the exact per-currency map; `convertTo`+`fx` yields one exact figure; missing-rate and `convertTo`-without-`fx` both throw.
+- **Read formatting:** `<field>Formatted` per locale uses the record's currency; symbol/grouping; negatives.
+- **Nulls / optional fields:** nullable money round-trips and is excluded from sums correctly.
+- **Ordering:** descriptor validation runs after zod; a schema-invalid record never reaches quantization.
+- **Descriptor construction:** `currency`+`currencies` together throws; unknown currency without override throws.
 
 ## Build sequence
 
-1. Descriptor + predicate + types (`money()`, `MoneyDescriptor`, `MoneyOptions`, `MoneyPrecisionError`, `MoneyCurrencyError`) + `moneyField()` zod helper.
-2. BigInt fixed-point core: decimal-string ⇄ scaled-integer-string, all rounding modes, high-precision multiply for FX (pure, unit-tested in isolation).
-3. Write-path wiring: `moneyFields` collection, currency resolve/whitelist, quantize-on-put after schema validation.
-4. Read-path wiring: exact-string decimal exposure + `<field>Formatted` virtual in `applyLocaleToRecord`.
-5. Currency-partitioned `sum`/`min`/`max` reducers (exact per-currency map) + opt-in `convertTo`/`rates` collapse + high-accuracy `avg`.
+1. ISO-4217 minor-units table + scale resolution; descriptor + predicate + types (`money()`, `MoneyDescriptor`, `MoneyOptions`, `MoneyPrecisionError`), incl. fixed/multi normalization and mutual-exclusion validation.
+2. BigInt fixed-point core: decimal-string ⇄ scaled-integer (string-encoded), all rounding modes (pure, unit-tested in isolation).
+3. Write-path wiring: `moneyFields` collection, currency validation, quantize-on-put after schema validation; fixed vs `{amount,currency}` storage.
+4. Read-path wiring: exact-string exposure + `<field>Formatted` + `<field>Number` virtuals in `applyLocaleToRecord`.
+5. Money-aware `sum`/`min`/`max` reducer path: BigInt over string integers, per-currency maps, exact-string finalize, opt-in `convertTo`/`fx`.
 6. Introspection field kind; docs (SUBSYSTEMS / README descriptor table); features.yaml registration.

--- a/features.yaml
+++ b/features.yaml
@@ -110,6 +110,26 @@ features:
       - 'Validation runs before encryption (write) and after decryption (read)'
     related: [vault-and-collections]
 
+  - id: money-field
+    name: money() currency-safe decimal field descriptor
+    cluster: core
+    spec: docs/superpowers/specs/2026-06-08-money-decimal-field-design.md
+    subsystem_doc: docs/superpowers/specs/2026-06-08-money-decimal-field-design.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'scaled-integer storage as digit strings — exact past Number.MAX_SAFE_INTEGER (a JSON number truncates at 2^53)'
+      - 'reject excess precision by default; opt-in rounding modes (half-up/half-even/half-down/up/down/ceil/floor)'
+      - 'fixed single-currency, or opt-in per-record multi-currency (currencies: any | [...]) with ISO-4217 scale resolution'
+      - 'read shape: exact decimal string + <field>Formatted (Intl, full precision) + <field>Number (documented-lossy convenience)'
+      - 'money-aware sum/min/max in BigInt — fixed → single string, multi → per-currency map, sum convertTo+fx → one exact figure; remove() supports live/MV maintenance'
+    related: [schema-and-refs, query-basics]
+
   - id: persisted-json-schema
     name: Persisted JSON Schema (opt-in)
     cluster: core

--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -178,6 +178,30 @@ Core has zero `node:` imports — it runs unchanged in browsers, Node, Bun, Deno
 
 CSV, XML, xlsx, and the rest of the plaintext tier — plus encrypted `.noydb` bundles under the `as-noydb` encrypted tier — all live in the [`@noy-db/as-*`](https://www.npmjs.com/search?q=%40noy-db%2Fas-) family. Every invocation is gated by the two-tier authorization model (`canExportPlaintext` default off, `canExportBundle` default on for owner/admin) and lands in the audit ledger.
 
+## Money fields
+
+`money()` is a schema-layer field descriptor (a sibling of `i18nText()` / `dictKey()`) for currency-safe, exact decimal values. Money is stored as a scaled integer encoded as a **digit string**, so it is exact for any magnitude — past `Number.MAX_SAFE_INTEGER` included (a JSON number would silently truncate at 2^53).
+
+```ts
+vault.collection('invoices', {
+  schema: z.object({ id: z.string(), total: z.union([z.number(), z.string()]) }),
+  moneyFields: { total: money({ currency: 'EUR', scale: 2 }) }, // scale optional — ISO-4217 default
+})
+
+await invoices.put('a', { id: 'a', total: '123.45' })          // stored as '12345'
+const inv = await invoices.get('a', { locale: 'de-DE' })
+// inv.total           → '123.45'   (exact decimal string)
+// inv.totalFormatted  → '123,45 €' (Intl, full precision)
+// inv.totalNumber     → 123.45     (convenience JS number; lossy past 2^53)
+
+// Exact aggregation — sum/min/max run in BigInt, no float drift:
+invoices.query().aggregate({ total: sum('total') }).run() // → '0.60', never 0.6000000000000001
+```
+
+- **Rounding:** excess precision is **rejected** by default; opt in per field with `money({ ..., rounding: 'half-even' })` (`half-up` / `half-even` / `half-down` / `up` / `down` / `ceil` / `floor`).
+- **Multi-currency:** opt in with `money({ currencies: 'any' | ['EUR','USD'] })` — currency travels per record as `{ amount, currency }`; `sum` returns an exact per-currency map (`{ EUR: '15.50', USD: '3.00' }`), or one figure with `sum('total', { convertTo: 'EUR', fx })`.
+- Money `sum`/`min`/`max` implement incremental `remove()`, so they stay exact under live aggregation and materialized-view maintenance.
+
 ## Status
 
 **Pre-release** (`0.1.0-pre.1`). API may change before `1.0`. Install from the `next` dist-tag:

--- a/packages/hub/__tests__/money/aggregate.test.ts
+++ b/packages/hub/__tests__/money/aggregate.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest'
 import { z } from 'zod'
 import { createNoydb } from '../../src/index.js'
 import { withAggregate } from '../../src/aggregate/index.js'
-import { sum, min, max, count } from '../../src/aggregate/reducers.js'
-import { money } from '../../src/money/descriptor.js'
+import { sum, min, max, count, avg } from '../../src/aggregate/reducers.js'
+import { money, MoneyUnsupportedError } from '../../src/money/descriptor.js'
 import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
 
 function memory(): NoydbStore {
@@ -148,6 +148,16 @@ describe('money aggregation — exact', () => {
     r = await lines.query().aggregate({ total: sum('total'), n: count() }).run() as Record<string, unknown>
     expect(r.total).toBe('0.40') // exact recompute, not stale
     expect(r.n).toBe(2)
+  })
+
+  it('avg() over a money field throws MoneyUnsupportedError instead of silently returning 0', async () => {
+    const vault = await vaultWith(money({ currency: 'EUR', scale: 2 }))
+    const lines = vault.collection<Line>('lines')
+    await lines.put('a', { id: 'a', total: '10.00' })
+    await lines.put('b', { id: 'b', total: '20.00' })
+    expect(
+      () => lines.query().aggregate({ mean: avg('total') }).run(),
+    ).toThrow(MoneyUnsupportedError)
   })
 
   it('grouped sum over a money field is exact per bucket', async () => {

--- a/packages/hub/__tests__/money/aggregate.test.ts
+++ b/packages/hub/__tests__/money/aggregate.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { createNoydb } from '../../src/index.js'
+import { withAggregate } from '../../src/aggregate/index.js'
+import { sum, min, max, count } from '../../src/aggregate/reducers.js'
+import { money } from '../../src/money/descriptor.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) { out[cname] = out[cname] ?? {}; out[cname][id] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) { data.set(k(v, c, i), payload[c][i]) }
+      }
+    },
+  }
+}
+
+interface Line extends Record<string, unknown> { id: string; total: number | string }
+
+async function vaultWith(moneyField: ReturnType<typeof money>) {
+  const db = await createNoydb({
+    store: memory(),
+    user: 'alice',
+    secret: 'money-aggregate-passphrase-2026-pilot3-exact',
+    aggregateStrategy: withAggregate(),
+  })
+  const vault = await db.openVault('books')
+  // Schema is loose enough for both fixed (number|string) and multi
+  // ({amount,currency}) money input — the descriptor owns canonical form.
+  const moneyInput = z.union([
+    z.number(),
+    z.string(),
+    z.object({ amount: z.union([z.number(), z.string()]), currency: z.string() }),
+  ])
+  vault.collection<Line>('lines', {
+    schema: z.object({ id: z.string(), total: moneyInput }),
+    moneyFields: { total: moneyField },
+  })
+  return vault
+}
+
+describe('money aggregation — exact', () => {
+  it('fixed-mode sum is exact (0.1 + 0.2 + 0.3 = 0.60, no float drift)', async () => {
+    const vault = await vaultWith(money({ currency: 'EUR', scale: 2 }))
+    const lines = vault.collection<Line>('lines')
+    await lines.put('a', { id: 'a', total: '0.10' })
+    await lines.put('b', { id: 'b', total: '0.20' })
+    await lines.put('c', { id: 'c', total: '0.30' })
+
+    const r = await lines.query().aggregate({ total: sum('total') }).run() as Record<string, unknown>
+    expect(r.total).toBe('0.60') // exact string, not 0.6000000000000001
+  })
+
+  it('sum stays exact past Number.MAX_SAFE_INTEGER', async () => {
+    const vault = await vaultWith(money({ currency: 'EUR', scale: 2 }))
+    const lines = vault.collection<Line>('lines')
+    await lines.put('a', { id: 'a', total: '90071992547409.91' })
+    await lines.put('b', { id: 'b', total: '0.09' })
+
+    const r = await lines.query().aggregate({ total: sum('total') }).run() as Record<string, unknown>
+    expect(r.total).toBe('90071992547410.00')
+  })
+
+  it('an unwrapped generic sum over money would be wrong — proving the wrap ran', async () => {
+    // If wrapMoneyReducers did NOT run, readNumber('10') → 0 and the sum
+    // would be '0' / 0. The exact 0.60 above is the proof it ran.
+    const vault = await vaultWith(money({ currency: 'EUR', scale: 2 }))
+    const lines = vault.collection<Line>('lines')
+    await lines.put('a', { id: 'a', total: '12.34' })
+    const r = await lines.query().aggregate({ s: sum('total') }).run() as Record<string, unknown>
+    expect(r.s).toBe('12.34')
+  })
+
+  it('min / max are exact in fixed mode', async () => {
+    const vault = await vaultWith(money({ currency: 'EUR', scale: 2 }))
+    const lines = vault.collection<Line>('lines')
+    await lines.put('a', { id: 'a', total: '5.00' })
+    await lines.put('b', { id: 'b', total: '1.50' })
+    await lines.put('c', { id: 'c', total: '9.99' })
+    const r = await lines.query().aggregate({ lo: min('total'), hi: max('total') }).run() as Record<string, unknown>
+    expect(r.lo).toBe('1.50')
+    expect(r.hi).toBe('9.99')
+  })
+
+  it('multi-currency sum returns an exact per-currency map', async () => {
+    const vault = await vaultWith(money({ currencies: ['EUR', 'USD'] }))
+    const lines = vault.collection<Line>('lines')
+    await lines.put('a', { id: 'a', total: { amount: '10.00', currency: 'EUR' } as never })
+    await lines.put('b', { id: 'b', total: { amount: '5.50', currency: 'EUR' } as never })
+    await lines.put('c', { id: 'c', total: { amount: '3.00', currency: 'USD' } as never })
+
+    const r = await lines.query().aggregate({ total: sum('total') }).run() as Record<string, unknown>
+    expect(r.total).toEqual({ EUR: '15.50', USD: '3.00' })
+  })
+
+  it('multi-currency sum with convertTo + fx yields one exact figure', async () => {
+    const vault = await vaultWith(money({ currencies: ['EUR', 'USD'] }))
+    const lines = vault.collection<Line>('lines')
+    await lines.put('a', { id: 'a', total: { amount: '10.00', currency: 'EUR' } as never })
+    await lines.put('b', { id: 'b', total: { amount: '10.00', currency: 'USD' } as never })
+
+    const r = await lines.query()
+      .aggregate({ total: sum('total', { convertTo: 'EUR', fx: { 'USD->EUR': '0.90' } }) })
+      .run() as Record<string, unknown>
+    expect(r.total).toBe('19.00') // 10 EUR + 10 USD * 0.90 = 19.00
+  })
+
+  it('convertTo without fx throws', async () => {
+    const vault = await vaultWith(money({ currencies: ['EUR', 'USD'] }))
+    const lines = vault.collection<Line>('lines')
+    await lines.put('a', { id: 'a', total: { amount: '1.00', currency: 'USD' } as never })
+    expect(
+      () => lines.query().aggregate({ total: sum('total', { convertTo: 'EUR' }) }).run(),
+    ).toThrow(/fx/)
+  })
+
+  it('remove(): a grouped/live-style recompute stays exact after a source delete', async () => {
+    const vault = await vaultWith(money({ currency: 'EUR', scale: 2 }))
+    const lines = vault.collection<Line>('lines')
+    await lines.put('a', { id: 'a', total: '0.10' })
+    await lines.put('b', { id: 'b', total: '0.20' })
+    await lines.put('c', { id: 'c', total: '0.30' })
+
+    let r = await lines.query().aggregate({ total: sum('total'), n: count() }).run() as Record<string, unknown>
+    expect(r.total).toBe('0.60')
+    expect(r.n).toBe(3)
+
+    await lines.delete('b')
+    r = await lines.query().aggregate({ total: sum('total'), n: count() }).run() as Record<string, unknown>
+    expect(r.total).toBe('0.40') // exact recompute, not stale
+    expect(r.n).toBe(2)
+  })
+
+  it('grouped sum over a money field is exact per bucket', async () => {
+    interface Sale extends Record<string, unknown> { id: string; buyer: string; total: number | string }
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'money-grouped-passphrase-2026-pilot3',
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('books')
+    vault.collection<Sale>('sales', {
+      schema: z.object({ id: z.string(), buyer: z.string(), total: z.union([z.number(), z.string()]) }),
+      moneyFields: { total: money({ currency: 'EUR', scale: 2 }) },
+    })
+    const sales = vault.collection<Sale>('sales')
+    await sales.put('a', { id: 'a', buyer: 'acme', total: '0.10' })
+    await sales.put('b', { id: 'b', buyer: 'acme', total: '0.20' })
+    await sales.put('c', { id: 'c', buyer: 'globex', total: '1.00' })
+
+    const rows = await sales.query().groupBy('buyer').aggregate({ total: sum('total') }).run() as Array<Record<string, unknown>>
+    const byBuyer = Object.fromEntries(rows.map(r => [r.buyer, r.total]))
+    expect(byBuyer.acme).toBe('0.30')
+    expect(byBuyer.globex).toBe('1.00')
+  })
+})

--- a/packages/hub/__tests__/money/aggregate.test.ts
+++ b/packages/hub/__tests__/money/aggregate.test.ts
@@ -133,7 +133,7 @@ describe('money aggregation — exact', () => {
     ).toThrow(/fx/)
   })
 
-  it('remove(): a grouped/live-style recompute stays exact after a source delete', async () => {
+  it('batch recompute stays exact after a source delete (see mv-and-live for the MV/live paths)', async () => {
     const vault = await vaultWith(money({ currency: 'EUR', scale: 2 }))
     const lines = vault.collection<Line>('lines')
     await lines.put('a', { id: 'a', total: '0.10' })

--- a/packages/hub/__tests__/money/collection-roundtrip.test.ts
+++ b/packages/hub/__tests__/money/collection-roundtrip.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { createNoydb } from '../../src/index.js'
+import { money, MoneyPrecisionError } from '../../src/money/descriptor.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) { out[cname] = out[cname] ?? {}; out[cname][id] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) { data.set(k(v, c, i), payload[c][i]) }
+      }
+    },
+  }
+}
+
+interface Invoice extends Record<string, unknown> {
+  id: string
+  total: number | string
+}
+
+async function openVault() {
+  const db = await createNoydb({
+    store: memory(),
+    user: 'alice',
+    secret: 'money-collection-roundtrip-passphrase-2026-pilot3',
+  })
+  return db.openVault('books')
+}
+
+describe('money field — collection write/read round-trip', () => {
+  it('quantizes on put and decodes on get with locale formatting', async () => {
+    const vault = await openVault()
+    vault.collection<Invoice>('invoices', {
+      schema: z.object({ id: z.string(), total: z.union([z.number(), z.string()]) }),
+      moneyFields: { total: money({ currency: 'EUR', scale: 2 }) },
+    })
+    const col = vault.collection<Invoice>('invoices')
+    await col.put('a', { id: 'a', total: 123.45 })
+
+    const read = await col.get('a', { locale: 'de-DE' }) as Record<string, unknown>
+    expect(read.total).toBe('123.45')           // exact decimal string
+    expect(String(read.totalFormatted)).toContain('123,45')
+    expect(read.totalNumber).toBe(123.45)
+  })
+
+  it('decodes the primary even with no locale (no raw-integer leak)', async () => {
+    const vault = await openVault()
+    vault.collection<Invoice>('invoices', {
+      schema: z.object({ id: z.string(), total: z.union([z.number(), z.string()]) }),
+      moneyFields: { total: money({ currency: 'EUR', scale: 2 }) },
+    })
+    const col = vault.collection<Invoice>('invoices')
+    await col.put('a', { id: 'a', total: '99.90' })
+
+    const read = await col.get('a') as Record<string, unknown>
+    expect(read.total).toBe('99.90') // NOT '9990'
+  })
+
+  it('exact past 2^53 round-trips through encryption', async () => {
+    const vault = await openVault()
+    vault.collection<Invoice>('invoices', {
+      schema: z.object({ id: z.string(), total: z.union([z.number(), z.string()]) }),
+      moneyFields: { total: money({ currency: 'EUR', scale: 2 }) },
+    })
+    const col = vault.collection<Invoice>('invoices')
+    await col.put('big', { id: 'big', total: '90071992547409.91' })
+
+    const read = await col.get('big', { locale: 'de-DE' }) as Record<string, unknown>
+    expect(read.total).toBe('90071992547409.91')
+    expect(String(read.totalFormatted)).toContain('90.071.992.547.409,91')
+  })
+
+  it('rejects excess precision with MoneyPrecisionError on put', async () => {
+    const vault = await openVault()
+    vault.collection<Invoice>('invoices', {
+      schema: z.object({ id: z.string(), total: z.union([z.number(), z.string()]) }),
+      moneyFields: { total: money({ currency: 'EUR', scale: 2 }) },
+    })
+    const col = vault.collection<Invoice>('invoices')
+    await expect(col.put('bad', { id: 'bad', total: '1.234' })).rejects.toBeInstanceOf(MoneyPrecisionError)
+  })
+})

--- a/packages/hub/__tests__/money/descriptor.test.ts
+++ b/packages/hub/__tests__/money/descriptor.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { money, isMoneyDescriptor, MoneyCurrencyError } from '../../src/money/descriptor.js'
+
+describe('money()', () => {
+  it('fixed mode resolves scale from ISO-4217 when omitted', () => {
+    const d = money({ currency: 'EUR' })
+    expect(d.mode).toBe('fixed')
+    expect(d.fixedCurrency).toBe('EUR')
+    expect(d.scaleFor('EUR')).toBe(2)
+    expect(d.soleCurrency()).toBe('EUR')
+  })
+
+  it('fixed mode honors explicit scale (unlisted currency)', () => {
+    expect(money({ currency: 'XAU', scale: 4 }).scaleFor('XAU')).toBe(4)
+  })
+
+  it('fixed mode rejects a different currency', () => {
+    expect(() => money({ currency: 'EUR' }).scaleFor('USD')).toThrow(MoneyCurrencyError)
+  })
+
+  it('multi mode resolves per-currency scale', () => {
+    const d = money({ currencies: ['EUR', 'JPY'] })
+    expect(d.mode).toBe('multi')
+    expect(d.scaleFor('EUR')).toBe(2)
+    expect(d.scaleFor('JPY')).toBe(0)
+    expect(d.allows('EUR')).toBe(true)
+    expect(d.allows('USD')).toBe(false)
+  })
+
+  it("multi 'any' allows any code with a known scale", () => {
+    const d = money({ currencies: 'any' })
+    expect(d.allows('USD')).toBe(true)
+    expect(d.scaleFor('BHD')).toBe(3)
+    expect(d.soleCurrency()).toBeUndefined()
+  })
+
+  it('multi scaleOverrides win', () => {
+    expect(money({ currencies: 'any', scaleOverrides: { FOO: 5 } }).scaleFor('FOO')).toBe(5)
+  })
+
+  it('multi single-element allow-list has a sole currency', () => {
+    expect(money({ currencies: ['EUR'] }).soleCurrency()).toBe('EUR')
+  })
+
+  it('multi rejects a disallowed currency', () => {
+    expect(() => money({ currencies: ['EUR'] }).scaleFor('USD')).toThrow(MoneyCurrencyError)
+  })
+
+  it('unknown currency without scale throws at construction', () => {
+    expect(() => money({ currency: 'ZZZ' })).toThrow(MoneyCurrencyError)
+  })
+
+  it('multi allow-list with an unresolvable code throws at construction', () => {
+    expect(() => money({ currencies: ['EUR', 'ZZZ'] })).toThrow(MoneyCurrencyError)
+  })
+
+  it('currency + currencies together throws', () => {
+    // @ts-expect-error mutually exclusive
+    expect(() => money({ currency: 'EUR', currencies: 'any' })).toThrow()
+  })
+
+  it('isMoneyDescriptor predicate', () => {
+    expect(isMoneyDescriptor(money({ currency: 'EUR' }))).toBe(true)
+    expect(isMoneyDescriptor({})).toBe(false)
+    expect(isMoneyDescriptor(null)).toBe(false)
+  })
+})

--- a/packages/hub/__tests__/money/descriptor.test.ts
+++ b/packages/hub/__tests__/money/descriptor.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { money, isMoneyDescriptor, MoneyCurrencyError } from '../../src/money/descriptor.js'
+import {
+  money,
+  isMoneyDescriptor,
+  MoneyCurrencyError,
+  MoneyPrecisionError,
+  MoneyUnsupportedError,
+} from '../../src/money/descriptor.js'
+import { NoydbError } from '../../src/errors.js'
 
 describe('money()', () => {
   it('fixed mode resolves scale from ISO-4217 when omitted', () => {
@@ -63,5 +70,22 @@ describe('money()', () => {
     expect(isMoneyDescriptor(money({ currency: 'EUR' }))).toBe(true)
     expect(isMoneyDescriptor({})).toBe(false)
     expect(isMoneyDescriptor(null)).toBe(false)
+  })
+
+  it('money errors extend NoydbError with stable codes (catch-all convention)', () => {
+    const precision = new MoneyPrecisionError('amount', '1.999', 2)
+    const currency = new MoneyCurrencyError('USD', 'not-allowed', 'amount')
+    const unsupported = new MoneyUnsupportedError('amount')
+    for (const e of [precision, currency, unsupported]) {
+      expect(e).toBeInstanceOf(NoydbError)
+      expect(e).toBeInstanceOf(Error)
+    }
+    expect(precision.code).toBe('MONEY_PRECISION')
+    expect(currency.code).toBe('MONEY_CURRENCY')
+    expect(unsupported.code).toBe('MONEY_UNSUPPORTED')
+    // class-name and public fields preserved
+    expect(precision.name).toBe('MoneyPrecisionError')
+    expect(currency.currency).toBe('USD')
+    expect(unsupported.field).toBe('amount')
   })
 })

--- a/packages/hub/__tests__/money/end-to-end.test.ts
+++ b/packages/hub/__tests__/money/end-to-end.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { createNoydb } from '../../src/index.js'
+import { withAggregate } from '../../src/aggregate/index.js'
+import { sum, count } from '../../src/aggregate/reducers.js'
+import { money } from '../../src/money/descriptor.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) { out[cname] = out[cname] ?? {}; out[cname][id] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) { data.set(k(v, c, i), payload[c][i]) }
+      }
+    },
+  }
+}
+
+interface SaleLine extends Record<string, unknown> {
+  id: string
+  unitPrice: number | string
+  taxAmount: number | string
+  total: number | string | null
+}
+
+describe('money — invoice-shaped end-to-end', () => {
+  it('multiple money fields, negative credit, null excluded from sum, rounding write', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'money-e2e-passphrase-2026-pilot3-invoices',
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('books')
+    vault.collection<SaleLine>('lines', {
+      schema: z.object({
+        id: z.string(),
+        unitPrice: z.union([z.number(), z.string()]),
+        taxAmount: z.union([z.number(), z.string()]),
+        total: z.union([z.number(), z.string()]).nullable(),
+      }),
+      moneyFields: {
+        unitPrice: money({ currency: 'EUR', scale: 2 }),
+        taxAmount: money({ currency: 'EUR', scale: 2 }),
+        // rounding field: VAT computed upstream may carry extra precision
+        total: money({ currency: 'EUR', scale: 2, rounding: 'half-even' }),
+      },
+    })
+    const lines = vault.collection<SaleLine>('lines')
+
+    await lines.put('l1', { id: 'l1', unitPrice: '10.00', taxAmount: '2.20', total: '12.20' })
+    await lines.put('l2', { id: 'l2', unitPrice: '3.33', taxAmount: '0.73', total: '4.065' }) // rounds → 4.07 (half-even on 4.065 → 4.06? tie to even)
+    await lines.put('credit', { id: 'credit', unitPrice: '-5.00', taxAmount: '-1.10', total: '-6.10' })
+    await lines.put('draft', { id: 'draft', unitPrice: '9.99', taxAmount: '0', total: null }) // not yet totalled
+
+    // read: exact decimal strings + formatting
+    const l1 = await lines.get('l1', { locale: 'en-US' }) as Record<string, unknown>
+    expect(l1.total).toBe('12.20')
+    expect(String(l1.totalFormatted)).toContain('12.20')
+
+    // negative credit round-trips
+    const credit = await lines.get('credit') as Record<string, unknown>
+    expect(credit.total).toBe('-6.10')
+
+    // half-even rounding: 4.065 → 4.06 (round to even tie)
+    const l2 = await lines.get('l2') as Record<string, unknown>
+    expect(l2.total).toBe('4.06')
+
+    // null total stays null
+    const draft = await lines.get('draft') as Record<string, unknown>
+    expect(draft.total).toBeNull()
+
+    // exact sum over total — null excluded, credit subtracted:
+    // 12.20 + 4.06 + (-6.10) = 10.16
+    const agg = await lines.query().aggregate({ total: sum('total'), n: count() }).run() as Record<string, unknown>
+    expect(agg.total).toBe('10.16')
+    expect(agg.n).toBe(4) // count is over records, not non-null totals
+  })
+})

--- a/packages/hub/__tests__/money/fixed-point.test.ts
+++ b/packages/hub/__tests__/money/fixed-point.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { parseToScaledInt, formatScaledInt } from '../../src/money/fixed-point.js'
+
+const ok = (r: ReturnType<typeof parseToScaledInt>): bigint => {
+  if (!r.ok) throw new Error(`expected ok, got ${r.reason}`)
+  return r.value
+}
+
+describe('parseToScaledInt', () => {
+  it('exact, no rounding needed', () => {
+    expect(ok(parseToScaledInt('123.45', 2))).toBe(12345n)
+    expect(ok(parseToScaledInt(123.45, 2))).toBe(12345n)
+    expect(ok(parseToScaledInt('5', 0))).toBe(5n)
+    expect(ok(parseToScaledInt('-0.01', 2))).toBe(-1n)
+    expect(ok(parseToScaledInt('1.20', 2))).toBe(120n)
+    expect(ok(parseToScaledInt('0', 2))).toBe(0n)
+    expect(ok(parseToScaledInt('-0', 2))).toBe(0n)
+    expect(ok(parseToScaledInt('.5', 2))).toBe(50n)
+  })
+
+  it('never uses float multiplication (0.1-class stays exact)', () => {
+    expect(ok(parseToScaledInt('0.1', 2))).toBe(10n)
+    expect(ok(parseToScaledInt('0.2', 2))).toBe(20n)
+    expect(ok(parseToScaledInt('0.3', 2))).toBe(30n)
+  })
+
+  it('exact past Number.MAX_SAFE_INTEGER', () => {
+    expect(ok(parseToScaledInt('90071992547409.91', 2))).toBe(9007199254740991n)
+    expect(ok(parseToScaledInt('999999999999999999.99', 2))).toBe(99999999999999999999n)
+  })
+
+  it('handles exponent-notation number input', () => {
+    expect(ok(parseToScaledInt(1e-2, 2))).toBe(1n) // 0.01
+    expect(ok(parseToScaledInt(1.5e3, 2))).toBe(150000n) // 1500.00
+  })
+
+  it('rejects excess precision without rounding', () => {
+    expect(parseToScaledInt('123.456', 2)).toEqual({ ok: false, reason: 'precision' })
+    expect(parseToScaledInt('0.001', 2)).toEqual({ ok: false, reason: 'precision' })
+  })
+
+  it('rejects non-finite / unparseable', () => {
+    expect(parseToScaledInt(NaN, 2)).toEqual({ ok: false, reason: 'nonfinite' })
+    expect(parseToScaledInt(Infinity, 2)).toEqual({ ok: false, reason: 'nonfinite' })
+    expect(parseToScaledInt('abc', 2)).toEqual({ ok: false, reason: 'nonfinite' })
+    expect(parseToScaledInt('1.2.3', 2)).toEqual({ ok: false, reason: 'nonfinite' })
+  })
+
+  it('rounding modes on the tie digit', () => {
+    expect(ok(parseToScaledInt('123.455', 2, 'half-up'))).toBe(12346n)
+    expect(ok(parseToScaledInt('123.445', 2, 'half-up'))).toBe(12345n)
+    expect(ok(parseToScaledInt('123.455', 2, 'half-even'))).toBe(12346n) // last kept 5 odd → up
+    expect(ok(parseToScaledInt('123.445', 2, 'half-even'))).toBe(12344n) // last kept 4 even → stay
+    expect(ok(parseToScaledInt('123.465', 2, 'half-even'))).toBe(12346n) // last kept 6 even → stay
+    expect(ok(parseToScaledInt('123.451', 2, 'half-down'))).toBe(12345n)
+    expect(ok(parseToScaledInt('123.456', 2, 'half-down'))).toBe(12346n)
+    expect(ok(parseToScaledInt('123.455', 2, 'half-down'))).toBe(12345n) // exactly 5, no more → down
+    expect(ok(parseToScaledInt('123.451', 2, 'down'))).toBe(12345n)
+    expect(ok(parseToScaledInt('123.451', 2, 'up'))).toBe(12346n)
+    expect(ok(parseToScaledInt('123.451', 2, 'ceil'))).toBe(12346n)
+    expect(ok(parseToScaledInt('-123.451', 2, 'ceil'))).toBe(-12345n)
+    expect(ok(parseToScaledInt('123.451', 2, 'floor'))).toBe(12345n)
+    expect(ok(parseToScaledInt('-123.451', 2, 'floor'))).toBe(-12346n)
+  })
+
+  it('tail of trailing zeros past scale is exact, not a precision error', () => {
+    expect(ok(parseToScaledInt('123.4500', 2))).toBe(12345n)
+  })
+})
+
+describe('formatScaledInt', () => {
+  it('renders canonical decimal strings', () => {
+    expect(formatScaledInt(12345n, 2)).toBe('123.45')
+    expect(formatScaledInt(-1n, 2)).toBe('-0.01')
+    expect(formatScaledInt(5n, 0)).toBe('5')
+    expect(formatScaledInt(0n, 2)).toBe('0.00')
+    expect(formatScaledInt(7n, 2)).toBe('0.07')
+    expect(formatScaledInt(120n, 2)).toBe('1.20')
+    expect(formatScaledInt(9007199254740991n, 2)).toBe('90071992547409.91')
+  })
+
+  it('round-trips with parseToScaledInt', () => {
+    for (const s of ['123.45', '-0.01', '0.00', '1000000.99', '90071992547409.91']) {
+      expect(formatScaledInt(ok(parseToScaledInt(s, 2)), 2)).toBe(s)
+    }
+  })
+})

--- a/packages/hub/__tests__/money/iso4217.test.ts
+++ b/packages/hub/__tests__/money/iso4217.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { scaleForCurrency } from '../../src/money/iso4217.js'
+
+describe('scaleForCurrency', () => {
+  it('returns ISO-4217 minor units for known codes', () => {
+    expect(scaleForCurrency('EUR')).toBe(2)
+    expect(scaleForCurrency('USD')).toBe(2)
+    expect(scaleForCurrency('JPY')).toBe(0)
+    expect(scaleForCurrency('KRW')).toBe(0)
+    expect(scaleForCurrency('BHD')).toBe(3)
+    expect(scaleForCurrency('KWD')).toBe(3)
+  })
+
+  it('returns null for unknown currency (no silent default)', () => {
+    expect(scaleForCurrency('ZZZ')).toBeNull()
+    expect(scaleForCurrency('XAU')).toBeNull() // gold — caller must set scale
+  })
+})

--- a/packages/hub/__tests__/money/mv-and-live.test.ts
+++ b/packages/hub/__tests__/money/mv-and-live.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { createNoydb, withMaterializedView } from '../../src/index.js'
+import { withAggregate } from '../../src/aggregate/index.js'
+import { sum } from '../../src/aggregate/reducers.js'
+import { money } from '../../src/money/descriptor.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) { out[cname] = out[cname] ?? {}; out[cname][id] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) { data.set(k(v, c, i), payload[c][i]) }
+      }
+    },
+  }
+}
+
+interface Line extends Record<string, unknown> { id: string; total: number | string }
+interface Rollup extends Record<string, unknown> { total: string }
+
+describe('money in materialized views + live aggregation (the saleRollups scenario)', () => {
+  it('eager MV over a money sum: string aggregate survives MV storage + recomputes exactly on source delete', async () => {
+    // The literal saleRollups shape: money → sum → MV, refreshed on put/delete.
+    const rollup = withMaterializedView<Rollup>({
+      name: 'sale-rollups',
+      sources: ['lines'],
+      query: (db) => db.collection<Line>('lines').query().aggregate({ total: sum<Line>('total') }),
+      rowKey: () => 'grand-total',
+      refresh: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'money-mv-passphrase-2026-pilot3-rollups',
+      aggregateStrategy: withAggregate(),
+      materializedViewStrategies: [rollup],
+    })
+    const vault = await db.openVault('books')
+    vault.collection<Line>('lines', {
+      schema: z.object({ id: z.string(), total: z.union([z.number(), z.string()]) }),
+      moneyFields: { total: money({ currency: 'EUR', scale: 2 }) },
+    })
+    const lines = vault.collection<Line>('lines')
+
+    await lines.put('a', { id: 'a', total: '0.10' })
+    await lines.put('b', { id: 'b', total: '0.20' })
+    await lines.put('c', { id: 'c', total: '0.30' })
+
+    // MV row holds the exact decimal string (not a corrupted number).
+    let row = await vault.collection<Rollup>('sale-rollups').get('grand-total')
+    expect(row?.total).toBe('0.60')
+
+    // Source delete → eager MV recomputes exactly (the #305 path, now with money).
+    await lines.delete('b')
+    row = await vault.collection<Rollup>('sale-rollups').get('grand-total')
+    expect(row?.total).toBe('0.40')
+  })
+
+  it('.live() over a money sum: exact value, updates on put and delete', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'money-live-passphrase-2026-pilot3',
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('books')
+    vault.collection<Line>('lines', {
+      schema: z.object({ id: z.string(), total: z.union([z.number(), z.string()]) }),
+      moneyFields: { total: money({ currency: 'EUR', scale: 2 }) },
+    })
+    const lines = vault.collection<Line>('lines')
+    await lines.put('a', { id: 'a', total: '0.10' })
+    await lines.put('b', { id: 'b', total: '0.20' })
+
+    const live = lines.query().aggregate({ total: sum('total') }).live()
+    expect((live.value as { total: string }).total).toBe('0.30')
+
+    const seen: string[] = []
+    live.subscribe(() => {
+      const v = live.value as { total: string } | undefined
+      if (v) seen.push(v.total)
+    })
+
+    await lines.put('c', { id: 'c', total: '0.30' })
+    expect((live.value as { total: string }).total).toBe('0.60')
+
+    await lines.delete('a')
+    expect((live.value as { total: string }).total).toBe('0.50')
+
+    expect(seen).toContain('0.60')
+    expect(seen).toContain('0.50')
+  })
+})

--- a/packages/hub/__tests__/money/normalize.test.ts
+++ b/packages/hub/__tests__/money/normalize.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { quantizeMoneyFields, decodeMoneyFields } from '../../src/money/normalize.js'
+import { money, MoneyPrecisionError } from '../../src/money/descriptor.js'
+
+const fields = {
+  fixed: { total: money({ currency: 'EUR', scale: 2 }) },
+  rounded: { total: money({ currency: 'EUR', scale: 2, rounding: 'half-up' }) },
+  multi: { total: money({ currencies: ['EUR', 'USD', 'JPY'] }) },
+  multiSole: { total: money({ currencies: ['EUR'] }) },
+}
+
+describe('quantizeMoneyFields (write)', () => {
+  it('fixed: decimal → scaled-integer digit string', () => {
+    expect(quantizeMoneyFields({ total: 123.45 }, fields.fixed)).toEqual({ total: '12345' })
+    expect(quantizeMoneyFields({ total: '123.45' }, fields.fixed)).toEqual({ total: '12345' })
+    expect(quantizeMoneyFields({ total: '-0.01' }, fields.fixed)).toEqual({ total: '-1' })
+  })
+
+  it('multi: stores { amount, currency } with per-currency scale', () => {
+    expect(quantizeMoneyFields({ total: { amount: '123.45', currency: 'EUR' } }, fields.multi))
+      .toEqual({ total: { amount: '12345', currency: 'EUR' } })
+    // JPY scale 0
+    expect(quantizeMoneyFields({ total: { amount: '500', currency: 'JPY' } }, fields.multi))
+      .toEqual({ total: { amount: '500', currency: 'JPY' } })
+  })
+
+  it('multi single-currency allow-list accepts a bare amount', () => {
+    expect(quantizeMoneyFields({ total: 123.45 }, fields.multiSole))
+      .toEqual({ total: { amount: '12345', currency: 'EUR' } })
+  })
+
+  it('multi with >1 currency rejects a bare amount', () => {
+    expect(() => quantizeMoneyFields({ total: 123.45 }, fields.multi)).toThrow(/multi-currency/)
+  })
+
+  it('null / undefined pass through untouched', () => {
+    expect(quantizeMoneyFields({ total: null }, fields.fixed)).toEqual({ total: null })
+    expect(quantizeMoneyFields({ other: 1 }, fields.fixed)).toEqual({ other: 1 })
+  })
+
+  it('excess precision throws MoneyPrecisionError without rounding', () => {
+    expect(() => quantizeMoneyFields({ total: '123.456' }, fields.fixed)).toThrow(MoneyPrecisionError)
+  })
+
+  it('rounding mode quantizes excess precision', () => {
+    expect(quantizeMoneyFields({ total: '123.456' }, fields.rounded)).toEqual({ total: '12346' })
+  })
+
+  it('float artifact past scale precision-rejects (string is the exact write path)', () => {
+    // 0.1 + 0.2 === 0.30000000000000004 → 17 frac digits, scale 2, no rounding
+    expect(() => quantizeMoneyFields({ total: 0.1 + 0.2 }, fields.fixed)).toThrow(MoneyPrecisionError)
+    // the exact path:
+    expect(quantizeMoneyFields({ total: '0.30' }, fields.fixed)).toEqual({ total: '30' })
+  })
+
+  it('does not mutate the input record', () => {
+    const input = { total: 123.45 }
+    quantizeMoneyFields(input, fields.fixed)
+    expect(input).toEqual({ total: 123.45 })
+  })
+})
+
+describe('decodeMoneyFields (read)', () => {
+  it('fixed: scaled-integer string → exact decimal + virtuals', () => {
+    const out = decodeMoneyFields({ total: '12345' }, fields.fixed, 'de-DE') as Record<string, unknown>
+    expect(out.total).toBe('123.45')
+    expect(String(out.totalFormatted)).toContain('123,45')
+    expect(out.totalNumber).toBe(123.45)
+  })
+
+  it('multi: { amount, currency } decodes with the record currency', () => {
+    const out = decodeMoneyFields(
+      { total: { amount: '12345', currency: 'USD' } },
+      fields.multi,
+      'en-US',
+    ) as Record<string, unknown>
+    expect(out.total).toEqual({ amount: '123.45', currency: 'USD' })
+    expect(String(out.totalFormatted)).toContain('123.45')
+    expect(out.totalNumber).toBe(123.45)
+  })
+
+  it("locale 'raw' decodes the primary but skips Intl virtuals", () => {
+    const out = decodeMoneyFields({ total: '12345' }, fields.fixed, 'raw') as Record<string, unknown>
+    expect(out.total).toBe('123.45')
+    expect(out.totalFormatted).toBeUndefined()
+    expect(out.totalNumber).toBeUndefined()
+  })
+
+  it('exact past 2^53: primary string stays exact, Formatted full-precision, Number is the lossy convenience', () => {
+    const out = decodeMoneyFields({ total: '9007199254740991' }, fields.fixed, 'de-DE') as Record<string, unknown>
+    expect(out.total).toBe('90071992547409.91') // exact
+    expect(String(out.totalFormatted)).toContain('90.071.992.547.409,91') // exact, grouped
+    expect(typeof out.totalNumber).toBe('number') // defined, documented-lossy
+  })
+
+  it('round-trips: write then read returns the original decimal', () => {
+    const stored = quantizeMoneyFields({ total: '1000000.99' }, fields.fixed)
+    const read = decodeMoneyFields(stored, fields.fixed, 'raw') as Record<string, unknown>
+    expect(read.total).toBe('1000000.99')
+  })
+})

--- a/packages/hub/src/aggregate/active.ts
+++ b/packages/hub/src/aggregate/active.ts
@@ -40,11 +40,11 @@ export function withAggregate(): AggregateStrategy {
     aggregate(executeRecords, spec, upstreams) {
       return new Aggregation(executeRecords, spec as unknown as AggregateSpec, upstreams) as unknown as Aggregation<AggregateResult<typeof spec>>
     },
-    groupBy(executeRecords, field, upstreams, dictLabelResolver) {
-      return new GroupedQuery(executeRecords, field, upstreams, dictLabelResolver)
+    groupBy(executeRecords, field, upstreams, dictLabelResolver, moneyFields) {
+      return new GroupedQuery(executeRecords, field, upstreams, dictLabelResolver, moneyFields)
     },
-    groupByN(executeRecords, fields, upstreams) {
-      return new GroupedQueryN(executeRecords, fields, upstreams)
+    groupByN(executeRecords, fields, upstreams, moneyFields) {
+      return new GroupedQueryN(executeRecords, fields, upstreams, undefined, moneyFields)
     },
     async scanAggregate(iter, spec) {
       const collected: unknown[] = []

--- a/packages/hub/src/aggregate/groupby.ts
+++ b/packages/hub/src/aggregate/groupby.ts
@@ -69,6 +69,8 @@ import type {
 import { buildLiveAggregation } from './aggregation.js'
 import { canonicalGroupKey } from './canonical-key.js'
 import { GroupCardinalityError } from '../errors.js'
+import type { MoneyDescriptor } from '../money/descriptor.js'
+import { wrapMoneyReducers } from '../money/money-reducer.js'
 
 /**
  * Cardinality thresholds for `.groupBy()`. The warn threshold gives
@@ -172,9 +174,20 @@ abstract class GroupedQueryBase {
       locale: string,
       fallback?: string | readonly string[],
     ) => Promise<string | undefined>,
+    /**
+     * Money field descriptors for the backing collection — used to
+     * rewrite `sum`/`min`/`max` over money fields into exact BigInt
+     * reducers when `.aggregate(spec)` is terminated.
+     */
+    protected readonly moneyFields?: Record<string, MoneyDescriptor>,
   ) {
     this.fields =
       typeof fieldOrFields === 'string' ? [fieldOrFields] : [...fieldOrFields]
+  }
+
+  /** Apply money-aware reducer rewriting when money fields are declared. */
+  protected wrapSpec<Spec extends AggregateSpec>(spec: Spec): Spec {
+    return this.moneyFields ? (wrapMoneyReducers(spec, this.moneyFields) as Spec) : spec
   }
 }
 
@@ -204,7 +217,7 @@ export class GroupedQuery<T, F extends string> extends GroupedQueryBase {
     return new GroupedAggregation<GroupedRow<F, AggregateResult<Spec>>>(
       this.executeRecords,
       this.fields,
-      spec,
+      this.wrapSpec(spec),
       this.upstreams,
       this.dictLabelResolver,
     )
@@ -224,7 +237,7 @@ export class GroupedQueryN<T, F extends readonly string[]> extends GroupedQueryB
     return new GroupedAggregation<GroupedRowN<F, AggregateResult<Spec>>>(
       this.executeRecords,
       this.fields,
-      spec,
+      this.wrapSpec(spec),
       this.upstreams,
       this.dictLabelResolver,
     )

--- a/packages/hub/src/aggregate/reducers.ts
+++ b/packages/hub/src/aggregate/reducers.ts
@@ -79,6 +79,16 @@ export interface Reducer<R, S = R> {
    * Absent on `count` which aggregates over record count, not a field.
    */
   readonly field?: string
+  /**
+   * Money-only: target currency for `sum` over a multi-currency money
+   * field. Consumed by `wrapMoneyReducers` to convert per-currency
+   * subtotals to one figure. Ignored for non-money fields.
+   */
+  readonly convertTo?: string
+  /**
+   * Money-only: FX rate map (`'USD->EUR' → rate`) used with `convertTo`.
+   */
+  readonly fx?: Record<string, number | string>
 }
 
 /**
@@ -98,6 +108,13 @@ export interface Reducer<R, S = R> {
 export interface ReducerOptions<TSeed = unknown> {
   /**  constraint #2 — seed is plumbed through but unused in. */
   readonly seed?: TSeed
+  /**
+   * Money-only (honored by `sum` over a multi-currency money field):
+   * convert per-currency subtotals to this currency for a single figure.
+   */
+  readonly convertTo?: string
+  /** Money-only: FX rate map (`'USD->EUR' → rate`) used with `convertTo`. */
+  readonly fx?: Record<string, number | string>
 }
 
 // ---------------------------------------------------------------------------
@@ -139,6 +156,10 @@ export function sum(
   return {
     op: 'sum',
     field,
+    // Money-only metadata, read by `wrapMoneyReducers`. No effect on a
+    // generic numeric sum.
+    ...(opts?.convertTo !== undefined ? { convertTo: opts.convertTo } : {}),
+    ...(opts?.fx !== undefined ? { fx: opts.fx } : {}),
     init: () => 0,
     step: (state, record) => state + readNumber(record, field),
     remove: (state, record) => state - readNumber(record, field),
@@ -291,5 +312,20 @@ export function max(
  */
 function readNumber(record: unknown, field: string): number {
   const value = readPath(record, field)
+  // Defensive: a `{ amount, currency }` value means a multi-currency
+  // money field reached a generic numeric reducer instead of being
+  // rewritten by `wrapMoneyReducers` — that would silently produce a
+  // wrong total. Surface it loudly rather than coercing to 0.
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'amount' in value &&
+    'currency' in value
+  ) {
+    throw new Error(
+      `aggregate: field "${field}" holds a money value but was not money-aware — ` +
+        `declare it in the collection's moneyFields so sum/min/max stay exact`,
+    )
+  }
   return typeof value === 'number' && Number.isFinite(value) ? value : 0
 }

--- a/packages/hub/src/aggregate/strategy.ts
+++ b/packages/hub/src/aggregate/strategy.ts
@@ -20,6 +20,7 @@ import type {
   AggregationUpstream,
 } from './aggregation.js'
 import type { GroupedQuery, GroupedQueryN } from './groupby.js'
+import type { MoneyDescriptor } from '../money/descriptor.js'
 
 /**
  * Seam interface. `@internal` — will promote to public only when the
@@ -53,6 +54,7 @@ export interface AggregateStrategy {
       locale: string,
       fallback?: string | readonly string[],
     ) => Promise<string | undefined>,
+    moneyFields?: Record<string, MoneyDescriptor>,
   ): GroupedQuery<T, F>
 
   /**
@@ -65,6 +67,7 @@ export interface AggregateStrategy {
     executeRecords: () => readonly unknown[],
     fields: F,
     upstreams: readonly AggregationUpstream[],
+    moneyFields?: Record<string, MoneyDescriptor>,
   ): GroupedQueryN<T, F>
 
   /**

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -2304,6 +2304,7 @@ export class Collection<T> {
       // back to a linear scan otherwise.
       getIndexes: () => this.getIndexes(),
       lookupById: (id: string) => this.cache.get(id)?.record,
+      ...(this.moneyFields ? { moneyFields: this.moneyFields } : {}),
     }
     // Build a JoinContext if the vault passed a join resolver.
     // Without one, .join() on the resulting Query will throw with an

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -5,6 +5,8 @@ import { NO_CRDT, type CrdtStrategy } from './crdt/strategy.js'
 import type { I18nTextDescriptor } from './i18n/core.js'
 import { getAtPath, setAtPathInPlace } from './i18n/core.js'
 import type { DictKeyDescriptor } from './i18n/dictionary.js'
+import type { MoneyDescriptor } from './money/descriptor.js'
+import { quantizeMoneyFields, decodeMoneyFields } from './money/normalize.js'
 import { NO_I18N, type I18nStrategy } from './i18n/strategy.js'
 import { resolvePolicy } from './i18n/policy.js'
 import { encrypt, decrypt, encryptDeterministic } from './crypto.js'
@@ -284,6 +286,14 @@ export class Collection<T> {
    * fields when a locale is requested.
    */
   private readonly dictKeyFields: Record<string, DictKeyDescriptor> | undefined
+
+  /**
+   * Money field descriptors keyed by field path. Declared via the
+   * `moneyFields` collection option. Used by `put()` to quantize decimal
+   * input to a scaled-integer string, and by `get()`/`list()` to decode
+   * back to an exact decimal plus `<field>Formatted`/`<field>Number`.
+   */
+  private readonly moneyFields: Record<string, MoneyDescriptor> | undefined
 
   /**
    * Async callback provided by the Vault that resolves a dict key
@@ -594,6 +604,7 @@ export class Collection<T> {
     i18nFields?: Record<string, I18nTextDescriptor> | undefined
     /** — dictKey field descriptors for label resolution on reads. */
     dictKeyFields?: Record<string, DictKeyDescriptor> | undefined
+    moneyFields?: Record<string, MoneyDescriptor> | undefined
     /**
      * async callback that resolves a dict key to its label
      * for a given locale. Provided by the Vault.
@@ -779,6 +790,7 @@ export class Collection<T> {
     this.joinResolver = opts.joinResolver
     this.i18nFields = opts.i18nFields
     this.dictKeyFields = opts.dictKeyFields
+    this.moneyFields = opts.moneyFields
     this.dictLabelResolver = opts.dictLabelResolver
     this.i18nPutValidator = opts.i18nPutValidator
     this.autoTranslateHook = opts.autoTranslateHook
@@ -1166,6 +1178,15 @@ export class Collection<T> {
     // encrypt path.
     if (this.schema !== undefined) {
       record = await validateSchemaInput(this.schema, record, `put(${id})`)
+    }
+
+    // Quantize money fields to their canonical stored form (scaled-int
+    // digit string, or { amount, currency } in multi mode). Runs AFTER
+    // schema validation — the zod schema validates the loose input shape;
+    // the descriptor owns precision/scale/currency. Throws
+    // MoneyPrecisionError / MoneyCurrencyError on bad input.
+    if (this.moneyFields) {
+      record = quantizeMoneyFields(record as Record<string, unknown>, this.moneyFields) as T
     }
 
     // Auto-translate missing i18nText translations.
@@ -3084,12 +3105,27 @@ export class Collection<T> {
   ): Promise<T> {
     const hasI18n = this.i18nFields && Object.keys(this.i18nFields).length > 0
     const hasDict = this.dictKeyFields && Object.keys(this.dictKeyFields).length > 0
-    if (!hasI18n && !hasDict) return record
+    const hasMoney = this.moneyFields && Object.keys(this.moneyFields).length > 0
+    if (!hasI18n && !hasDict && !hasMoney) return record
 
     const locale = localeOpts?.locale ?? this.defaultLocale
-    if (!locale) return record
 
     let result = record as unknown as Record<string, unknown>
+
+    // Money decode runs regardless of locale: the primary field is always
+    // turned from its stored scaled-integer string into an exact decimal
+    // string. The `<field>Formatted`/`<field>Number` virtuals are added
+    // unless `locale === 'raw'` (handled inside decodeMoneyFields).
+    if (hasMoney && this.moneyFields) {
+      result = decodeMoneyFields(
+        result,
+        this.moneyFields,
+        typeof locale === 'string' ? locale : undefined,
+      )
+    }
+
+    // i18nText / dictKey resolution require an active locale.
+    if (!locale) return result as T
 
     // 1. i18nText resolution
     if (hasI18n && this.i18nFields) {

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -289,15 +289,9 @@ export class Collection<T> {
 
   /**
    * Money field descriptors keyed by field path. Declared via the
-   * `moneyFields` collection option. Used by `put()` to quantize decimal
-   * input to a scaled-integer string, and by `get()`/`list()` to decode
-   * back to an exact decimal plus `<field>Formatted`/`<field>Number`.
-   *
-   * Mutable so descriptors can be attached after construction — a
-   * collection referenced as a materialized-view source is created
-   * (without options) by MV dependency analysis during `openVault`,
-   * before the user's `collection(name, { moneyFields })` declaration.
-   * {@link _applyMoneyFields} reconciles that ordering. First-wins.
+   * `moneyFields` collection option: `put()` quantizes to a scaled-int
+   * string, `get()`/`list()` decode back. Mutable so {@link _applyMoneyFields}
+   * can attach descriptors to a collection MV-analysis pre-created.
    */
   private moneyFields: Record<string, MoneyDescriptor> | undefined
 
@@ -957,18 +951,13 @@ export class Collection<T> {
   }
 
   /**
-   * @internal — attach money field descriptors to an already-constructed
-   * collection. Needed because a collection referenced as a
-   * materialized-view source is auto-created (without options) by MV
-   * dependency analysis during `openVault`, before the user's
-   * `collection(name, { moneyFields })` declaration runs. First
-   * declaration wins; a no-op once money fields are set. Not part of the
-   * public API.
+   * @internal — attach money descriptors post-construction. MV dependency
+   * analysis auto-creates a source collection (without options) during
+   * `openVault`, before the user's `collection(name, { moneyFields })`
+   * declaration; this reconciles that ordering. First-wins. Not public.
    */
   _applyMoneyFields(moneyFields: Record<string, MoneyDescriptor>): void {
-    if (this.moneyFields === undefined) {
-      this.moneyFields = moneyFields
-    }
+    if (this.moneyFields === undefined) this.moneyFields = moneyFields
   }
 
   /**
@@ -1201,11 +1190,8 @@ export class Collection<T> {
       record = await validateSchemaInput(this.schema, record, `put(${id})`)
     }
 
-    // Quantize money fields to their canonical stored form (scaled-int
-    // digit string, or { amount, currency } in multi mode). Runs AFTER
-    // schema validation — the zod schema validates the loose input shape;
-    // the descriptor owns precision/scale/currency. Throws
-    // MoneyPrecisionError / MoneyCurrencyError on bad input.
+    // Quantize money fields to their stored form (scaled-int string).
+    // After schema validation — descriptor owns precision/scale/currency.
     if (this.moneyFields) {
       record = quantizeMoneyFields(record as Record<string, unknown>, this.moneyFields) as T
     }
@@ -3134,16 +3120,10 @@ export class Collection<T> {
 
     let result = record as unknown as Record<string, unknown>
 
-    // Money decode runs regardless of locale: the primary field is always
-    // turned from its stored scaled-integer string into an exact decimal
-    // string. The `<field>Formatted`/`<field>Number` virtuals are added
-    // unless `locale === 'raw'` (handled inside decodeMoneyFields).
+    // Money decode runs regardless of locale (stored int → decimal string);
+    // virtuals are gated on `locale !== 'raw'` inside decodeMoneyFields.
     if (hasMoney && this.moneyFields) {
-      result = decodeMoneyFields(
-        result,
-        this.moneyFields,
-        typeof locale === 'string' ? locale : undefined,
-      )
+      result = decodeMoneyFields(result, this.moneyFields, typeof locale === 'string' ? locale : undefined)
     }
 
     // i18nText / dictKey resolution require an active locale.

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -292,8 +292,14 @@ export class Collection<T> {
    * `moneyFields` collection option. Used by `put()` to quantize decimal
    * input to a scaled-integer string, and by `get()`/`list()` to decode
    * back to an exact decimal plus `<field>Formatted`/`<field>Number`.
+   *
+   * Mutable so descriptors can be attached after construction — a
+   * collection referenced as a materialized-view source is created
+   * (without options) by MV dependency analysis during `openVault`,
+   * before the user's `collection(name, { moneyFields })` declaration.
+   * {@link _applyMoneyFields} reconciles that ordering. First-wins.
    */
-  private readonly moneyFields: Record<string, MoneyDescriptor> | undefined
+  private moneyFields: Record<string, MoneyDescriptor> | undefined
 
   /**
    * Async callback provided by the Vault that resolves a dict key
@@ -948,6 +954,21 @@ export class Collection<T> {
    */
   getSchema(): StandardSchemaV1<unknown, T> | undefined {
     return this.schema
+  }
+
+  /**
+   * @internal — attach money field descriptors to an already-constructed
+   * collection. Needed because a collection referenced as a
+   * materialized-view source is auto-created (without options) by MV
+   * dependency analysis during `openVault`, before the user's
+   * `collection(name, { moneyFields })` declaration runs. First
+   * declaration wins; a no-op once money fields are set. Not part of the
+   * public API.
+   */
+  _applyMoneyFields(moneyFields: Record<string, MoneyDescriptor>): void {
+    if (this.moneyFields === undefined) {
+      this.moneyFields = moneyFields
+    }
   }
 
   /**

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -720,6 +720,7 @@ export {
   isMoneyDescriptor,
   MoneyPrecisionError,
   MoneyCurrencyError,
+  MoneyUnsupportedError,
   scaleForCurrency,
 } from './money/index.js'
 export type {

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -714,6 +714,23 @@ export {
 } from './i18n/core.js'
 export type { I18nTextOptions, I18nTextDescriptor, ResolveI18nOptions, I18nMap } from './i18n/core.js'
 
+// money — currency-safe decimal field descriptor
+export {
+  money,
+  isMoneyDescriptor,
+  MoneyPrecisionError,
+  MoneyCurrencyError,
+  scaleForCurrency,
+} from './money/index.js'
+export type {
+  MoneyDescriptor,
+  MoneyOptions,
+  MoneyOptionsFixed,
+  MoneyOptionsMulti,
+  RoundingMode,
+  FxRates,
+} from './money/index.js'
+
 // i18n — resolution policy + script enforcement
 export { resolvePolicy } from './i18n/policy.js'
 export type { OnMissing, Layer, OnMissingPolicy } from './i18n/policy.js'

--- a/packages/hub/src/money/descriptor.ts
+++ b/packages/hub/src/money/descriptor.ts
@@ -16,6 +16,7 @@
 
 import type { RoundingMode } from './fixed-point.js'
 import { scaleForCurrency } from './iso4217.js'
+import { NoydbError } from '../errors.js'
 
 export interface MoneyOptionsFixed {
   currency: string
@@ -53,13 +54,14 @@ export interface MoneyDescriptor {
 }
 
 /** Raised when a written value carries more precision than `scale` allows. */
-export class MoneyPrecisionError extends Error {
+export class MoneyPrecisionError extends NoydbError {
   constructor(
     public readonly field: string,
     public readonly value: unknown,
     public readonly scale: number,
   ) {
     super(
+      'MONEY_PRECISION',
       `money: value ${JSON.stringify(value)} for field "${field}" exceeds scale ${scale} ` +
         `and no rounding mode is configured`,
     )
@@ -68,13 +70,14 @@ export class MoneyPrecisionError extends Error {
 }
 
 /** Raised when a currency is disallowed or has no resolvable scale. */
-export class MoneyCurrencyError extends Error {
+export class MoneyCurrencyError extends NoydbError {
   constructor(
     public readonly currency: string,
     public readonly reason: 'not-allowed' | 'unknown-scale',
     public readonly field?: string,
   ) {
     super(
+      'MONEY_CURRENCY',
       reason === 'not-allowed'
         ? `money: currency "${currency}" is not allowed${field ? ` for field "${field}"` : ''}`
         : `money: no scale known for currency "${currency}"${field ? ` (field "${field}")` : ''} — ` +
@@ -85,12 +88,13 @@ export class MoneyCurrencyError extends Error {
 }
 
 /** Raised when an aggregate operation is not supported on a money field. */
-export class MoneyUnsupportedError extends Error {
+export class MoneyUnsupportedError extends NoydbError {
   constructor(
     public readonly field: string,
     message?: string,
   ) {
     super(
+      'MONEY_UNSUPPORTED',
       message ??
         `money: operation is not supported on field "${field}" — use sum() and count() and divide at the boundary`,
     )

--- a/packages/hub/src/money/descriptor.ts
+++ b/packages/hub/src/money/descriptor.ts
@@ -1,0 +1,159 @@
+/**
+ * The `money()` field descriptor — a branded schema-layer descriptor, a
+ * sibling of `i18nText()` / `dictKey()`. It owns currency, scale, and
+ * rounding policy for a field; the pure arithmetic lives in
+ * {@link ./fixed-point} and default scale resolution in
+ * {@link ./iso4217}.
+ *
+ * Two modes:
+ *   - **fixed**  `money({ currency: 'EUR' })` — one currency for the
+ *     field; the value stores a bare scaled-integer string.
+ *   - **multi**  `money({ currencies: 'any' | [...] })` — currency travels
+ *     per record; the value stores `{ amount, currency }`.
+ *
+ * `currency` and `currencies` are mutually exclusive.
+ */
+
+import type { RoundingMode } from './fixed-point.js'
+import { scaleForCurrency } from './iso4217.js'
+
+export interface MoneyOptionsFixed {
+  currency: string
+  /** Override the ISO-4217 default scale (required for unlisted codes). */
+  scale?: number
+  rounding?: RoundingMode
+}
+
+export interface MoneyOptionsMulti {
+  currencies: 'any' | readonly string[]
+  /** Per-currency scale overrides (required for unlisted codes). */
+  scaleOverrides?: Record<string, number>
+  rounding?: RoundingMode
+}
+
+export type MoneyOptions = MoneyOptionsFixed | MoneyOptionsMulti
+
+export interface MoneyDescriptor {
+  readonly _noydbMoney: true
+  readonly mode: 'fixed' | 'multi'
+  readonly options: MoneyOptions
+  readonly rounding: RoundingMode | undefined
+  /** The currency for fixed mode; `undefined` in multi mode. */
+  readonly fixedCurrency: string | undefined
+  /** Resolve the scale for a currency, throwing if not allowed / unknown. */
+  scaleFor(currency: string): number
+  /** Whether this descriptor permits the given currency. */
+  allows(currency: string): boolean
+  /**
+   * The single currency this descriptor implies, if any — fixed mode, or
+   * multi mode with exactly one allow-listed currency. Lets a multi field
+   * accept a bare amount unambiguously. `undefined` otherwise.
+   */
+  soleCurrency(): string | undefined
+}
+
+/** Raised when a written value carries more precision than `scale` allows. */
+export class MoneyPrecisionError extends Error {
+  constructor(
+    public readonly field: string,
+    public readonly value: unknown,
+    public readonly scale: number,
+  ) {
+    super(
+      `money: value ${JSON.stringify(value)} for field "${field}" exceeds scale ${scale} ` +
+        `and no rounding mode is configured`,
+    )
+    this.name = 'MoneyPrecisionError'
+  }
+}
+
+/** Raised when a currency is disallowed or has no resolvable scale. */
+export class MoneyCurrencyError extends Error {
+  constructor(
+    public readonly currency: string,
+    public readonly reason: 'not-allowed' | 'unknown-scale',
+    public readonly field?: string,
+  ) {
+    super(
+      reason === 'not-allowed'
+        ? `money: currency "${currency}" is not allowed${field ? ` for field "${field}"` : ''}`
+        : `money: no scale known for currency "${currency}"${field ? ` (field "${field}")` : ''} — ` +
+            `pass an explicit scale / scaleOverrides`,
+    )
+    this.name = 'MoneyCurrencyError'
+  }
+}
+
+function isMultiOptions(o: MoneyOptions): o is MoneyOptionsMulti {
+  return 'currencies' in o
+}
+
+/** Create a {@link MoneyDescriptor}. */
+export function money(options: MoneyOptions): MoneyDescriptor {
+  const hasFixed = 'currency' in options
+  const hasMulti = 'currencies' in options
+  if (hasFixed && hasMulti) {
+    throw new TypeError('money: `currency` and `currencies` are mutually exclusive')
+  }
+  if (!hasFixed && !hasMulti) {
+    throw new TypeError('money: one of `currency` or `currencies` is required')
+  }
+
+  const rounding = options.rounding
+
+  if (isMultiOptions(options)) {
+    const overrides = options.scaleOverrides ?? {}
+    const allowList = options.currencies
+    const allows = (c: string): boolean =>
+      allowList === 'any' ? true : allowList.includes(c)
+    const scaleFor = (c: string): number => {
+      if (!allows(c)) throw new MoneyCurrencyError(c, 'not-allowed')
+      const s = overrides[c] ?? scaleForCurrency(c)
+      if (s === null || s === undefined) throw new MoneyCurrencyError(c, 'unknown-scale')
+      return s
+    }
+    // Eagerly validate the allow-list resolves (catch typos at construction).
+    if (allowList !== 'any') for (const c of allowList) scaleFor(c)
+    const soleCurrency = (): string | undefined =>
+      allowList !== 'any' && allowList.length === 1 ? allowList[0] : undefined
+    return {
+      _noydbMoney: true,
+      mode: 'multi',
+      options,
+      rounding,
+      fixedCurrency: undefined,
+      scaleFor,
+      allows,
+      soleCurrency,
+    }
+  }
+
+  // fixed
+  const currency = options.currency
+  const resolvedScale = options.scale ?? scaleForCurrency(currency)
+  if (resolvedScale === null || resolvedScale === undefined) {
+    throw new MoneyCurrencyError(currency, 'unknown-scale')
+  }
+  return {
+    _noydbMoney: true,
+    mode: 'fixed',
+    options,
+    rounding,
+    fixedCurrency: currency,
+    scaleFor(c: string): number {
+      if (c !== currency) throw new MoneyCurrencyError(c, 'not-allowed')
+      return resolvedScale
+    },
+    allows: (c: string): boolean => c === currency,
+    soleCurrency: (): string | undefined => currency,
+  }
+}
+
+/** Runtime predicate for detecting a {@link MoneyDescriptor}. */
+export function isMoneyDescriptor(x: unknown): x is MoneyDescriptor {
+  return (
+    typeof x === 'object' &&
+    x !== null &&
+    (x as { _noydbMoney?: unknown })._noydbMoney === true
+  )
+}

--- a/packages/hub/src/money/descriptor.ts
+++ b/packages/hub/src/money/descriptor.ts
@@ -84,6 +84,20 @@ export class MoneyCurrencyError extends Error {
   }
 }
 
+/** Raised when an aggregate operation is not supported on a money field. */
+export class MoneyUnsupportedError extends Error {
+  constructor(
+    public readonly field: string,
+    message?: string,
+  ) {
+    super(
+      message ??
+        `money: operation is not supported on field "${field}" — use sum() and count() and divide at the boundary`,
+    )
+    this.name = 'MoneyUnsupportedError'
+  }
+}
+
 function isMultiOptions(o: MoneyOptions): o is MoneyOptionsMulti {
   return 'currencies' in o
 }

--- a/packages/hub/src/money/fixed-point.ts
+++ b/packages/hub/src/money/fixed-point.ts
@@ -33,9 +33,9 @@ function expandExponent(s: string): string {
   const m = /^([+-]?)(\d+)(?:\.(\d+))?[eE]([+-]?\d+)$/.exec(s)
   if (!m) return s
   const sign = m[1] === '-' ? '-' : ''
-  const intp = m[2]
+  const intp = m[2]!
   const frac = m[3] ?? ''
-  const exp = Number(m[4])
+  const exp = Number(m[4]!)
   const digits = intp + frac
   const pointPos = intp.length + exp
   let body: string

--- a/packages/hub/src/money/fixed-point.ts
+++ b/packages/hub/src/money/fixed-point.ts
@@ -1,0 +1,170 @@
+/**
+ * Pure fixed-point decimal core for the money descriptor.
+ *
+ * All conversion goes decimal-string ⇄ scaled `BigInt`. There is no
+ * floating-point arithmetic anywhere: a value like `123.45` becomes
+ * `12345n` purely by string manipulation, never by `value * 100` (which
+ * would reintroduce the very drift money() exists to eliminate). BigInt
+ * has no magnitude ceiling, so values past `Number.MAX_SAFE_INTEGER`
+ * stay exact end-to-end.
+ *
+ * This module knows nothing about currencies, descriptors, or storage —
+ * it is the isolated, exhaustively-tested arithmetic kernel.
+ */
+
+export type RoundingMode =
+  | 'half-up'
+  | 'half-even'
+  | 'half-down'
+  | 'up'
+  | 'down'
+  | 'ceil'
+  | 'floor'
+
+export type ParseResult =
+  | { ok: true; value: bigint }
+  | { ok: false; reason: 'precision' | 'nonfinite' }
+
+/**
+ * Expand exponent notation (`1e-7`, `1.5e3`) into a plain decimal
+ * string. Returns the input unchanged when it carries no exponent.
+ */
+function expandExponent(s: string): string {
+  const m = /^([+-]?)(\d+)(?:\.(\d+))?[eE]([+-]?\d+)$/.exec(s)
+  if (!m) return s
+  const sign = m[1] === '-' ? '-' : ''
+  const intp = m[2]
+  const frac = m[3] ?? ''
+  const exp = Number(m[4])
+  const digits = intp + frac
+  const pointPos = intp.length + exp
+  let body: string
+  if (pointPos <= 0) {
+    body = '0.' + '0'.repeat(-pointPos) + digits
+  } else if (pointPos >= digits.length) {
+    body = digits + '0'.repeat(pointPos - digits.length)
+  } else {
+    body = digits.slice(0, pointPos) + '.' + digits.slice(pointPos)
+  }
+  return sign + body
+}
+
+/**
+ * Normalize an input to a canonical decimal string, or `null` if it is
+ * non-finite / not a valid decimal.
+ */
+function toCanonicalDecimalString(input: number | string): string | null {
+  let s: string
+  if (typeof input === 'number') {
+    if (!Number.isFinite(input)) return null
+    s = String(input)
+  } else {
+    s = input.trim()
+  }
+  s = expandExponent(s)
+  if (s.startsWith('+')) s = s.slice(1)
+  // optional sign, then digits with at most one dot, at least one digit
+  if (!/^-?(\d+(\.\d*)?|\.\d+)$/.test(s)) return null
+  return s
+}
+
+/**
+ * Decide whether the truncated magnitude should be incremented by one
+ * minor unit, given the discarded fractional tail. Only called when the
+ * tail is known to contain a non-zero digit.
+ */
+function shouldRoundUp(
+  negative: boolean,
+  lastKeptDigit: number,
+  firstDiscarded: number,
+  hasMoreNonZeroAfterFirst: boolean,
+  mode: RoundingMode,
+): boolean {
+  switch (mode) {
+    case 'up':
+      return true
+    case 'down':
+      return false
+    case 'ceil':
+      return !negative
+    case 'floor':
+      return negative
+    case 'half-up':
+      return firstDiscarded >= 5
+    case 'half-down':
+      return firstDiscarded > 5 || (firstDiscarded === 5 && hasMoreNonZeroAfterFirst)
+    case 'half-even':
+      if (firstDiscarded > 5) return true
+      if (firstDiscarded < 5) return false
+      // exactly 5 leading the tail
+      return hasMoreNonZeroAfterFirst || lastKeptDigit % 2 === 1
+  }
+}
+
+/**
+ * Parse a decimal (`number | string`) into a scaled `BigInt` at the
+ * given scale. When the input carries more fractional precision than
+ * `scale`:
+ *   - `rounding` omitted ⇒ `{ ok: false, reason: 'precision' }`
+ *   - `rounding` set ⇒ the tail is rounded per the mode.
+ * Non-finite / unparseable input ⇒ `{ ok: false, reason: 'nonfinite' }`.
+ */
+export function parseToScaledInt(
+  input: number | string,
+  scale: number,
+  rounding?: RoundingMode,
+): ParseResult {
+  const canonical = toCanonicalDecimalString(input)
+  if (canonical === null) return { ok: false, reason: 'nonfinite' }
+
+  const negative = canonical.startsWith('-')
+  const unsigned = negative ? canonical.slice(1) : canonical
+  const dot = unsigned.indexOf('.')
+  const intPart = dot === -1 ? unsigned : unsigned.slice(0, dot)
+  const fracPart = dot === -1 ? '' : unsigned.slice(dot + 1)
+
+  const intDigits = intPart === '' ? '0' : intPart
+
+  if (fracPart.length <= scale) {
+    const keep = fracPart.padEnd(scale, '0')
+    const magnitude = BigInt(intDigits + keep)
+    return { ok: true, value: negative && magnitude !== 0n ? -magnitude : magnitude }
+  }
+
+  // More precision than scale — inspect the discarded tail.
+  const keep = fracPart.slice(0, scale)
+  const tail = fracPart.slice(scale)
+  const magnitudeDigits = intDigits + keep
+  let magnitude = BigInt(magnitudeDigits)
+
+  if (/^0+$/.test(tail)) {
+    // tail is all zeros — exact, no rounding required.
+    return { ok: true, value: negative && magnitude !== 0n ? -magnitude : magnitude }
+  }
+
+  if (rounding === undefined) return { ok: false, reason: 'precision' }
+
+  const lastKeptDigit = Number(magnitudeDigits[magnitudeDigits.length - 1])
+  const firstDiscarded = Number(tail[0])
+  const hasMoreNonZeroAfterFirst = /[1-9]/.test(tail.slice(1))
+  if (shouldRoundUp(negative, lastKeptDigit, firstDiscarded, hasMoreNonZeroAfterFirst, rounding)) {
+    magnitude += 1n
+  }
+  return { ok: true, value: negative && magnitude !== 0n ? -magnitude : magnitude }
+}
+
+/**
+ * Render a scaled `BigInt` back to its canonical decimal string at the
+ * given scale. `(12345n, 2)` → `'123.45'`; `(5n, 0)` → `'5'`;
+ * `(-1n, 2)` → `'-0.01'`. Exact for any magnitude.
+ */
+export function formatScaledInt(value: bigint, scale: number): string {
+  const negative = value < 0n
+  const abs = (negative ? -value : value).toString()
+  if (scale === 0) return (negative ? '-' : '') + abs
+  const padded = abs.padStart(scale + 1, '0')
+  const cut = padded.length - scale
+  const intPart = padded.slice(0, cut)
+  const fracPart = padded.slice(cut)
+  return (negative ? '-' : '') + intPart + '.' + fracPart
+}

--- a/packages/hub/src/money/index.ts
+++ b/packages/hub/src/money/index.ts
@@ -5,7 +5,7 @@
  * @see ./descriptor for the public `money()` factory.
  */
 
-export { money, isMoneyDescriptor, MoneyPrecisionError, MoneyCurrencyError } from './descriptor.js'
+export { money, isMoneyDescriptor, MoneyPrecisionError, MoneyCurrencyError, MoneyUnsupportedError } from './descriptor.js'
 export type {
   MoneyDescriptor,
   MoneyOptions,

--- a/packages/hub/src/money/index.ts
+++ b/packages/hub/src/money/index.ts
@@ -1,0 +1,17 @@
+/**
+ * `@noy-db/hub` money subsystem — the `money()` field descriptor for
+ * currency-safe, exact decimal storage, formatting, and aggregation.
+ *
+ * @see ./descriptor for the public `money()` factory.
+ */
+
+export { money, isMoneyDescriptor, MoneyPrecisionError, MoneyCurrencyError } from './descriptor.js'
+export type {
+  MoneyDescriptor,
+  MoneyOptions,
+  MoneyOptionsFixed,
+  MoneyOptionsMulti,
+} from './descriptor.js'
+export type { RoundingMode } from './fixed-point.js'
+export { scaleForCurrency } from './iso4217.js'
+export type { FxRates } from './money-reducer.js'

--- a/packages/hub/src/money/iso4217.ts
+++ b/packages/hub/src/money/iso4217.ts
@@ -30,7 +30,6 @@ const MINOR_UNITS: Readonly<Record<string, number>> = {
  * scale).
  */
 export function scaleForCurrency(code: string): number | null {
-  return Object.prototype.hasOwnProperty.call(MINOR_UNITS, code)
-    ? MINOR_UNITS[code]
-    : null
+  const v = MINOR_UNITS[code]
+  return v === undefined ? null : v
 }

--- a/packages/hub/src/money/iso4217.ts
+++ b/packages/hub/src/money/iso4217.ts
@@ -1,0 +1,36 @@
+/**
+ * ISO 4217 minor-unit (scale) lookup.
+ *
+ * Maps a currency code to the number of decimal places its minor unit
+ * uses — `EUR` → 2 (cents), `JPY` → 0 (no minor unit), `BHD` → 3 (fils).
+ * Only listed codes are "known"; an unlisted code returns `null` so the
+ * descriptor layer can demand an explicit `scale` / `scaleOverrides`
+ * rather than silently assuming 2. This avoids the classic bug where a
+ * 0-decimal currency (JPY) is stored as if it had cents.
+ *
+ * Coverage is the common ISO-4217 set; exotic or non-listed codes must
+ * declare scale explicitly. This table is the single source of truth for
+ * default scale resolution — see {@link scaleForCurrency}.
+ */
+const MINOR_UNITS: Readonly<Record<string, number>> = {
+  // 2-decimal majors
+  EUR: 2, USD: 2, GBP: 2, CHF: 2, CAD: 2, AUD: 2, NZD: 2, SGD: 2,
+  HKD: 2, CNY: 2, INR: 2, BRL: 2, MXN: 2, ZAR: 2, RUB: 2, TRY: 2,
+  PLN: 2, SEK: 2, NOK: 2, DKK: 2, CZK: 2, HUF: 2, RON: 2, ILS: 2,
+  THB: 2, PHP: 2, MYR: 2, IDR: 2, AED: 2, SAR: 2, QAR: 2, EGP: 2,
+  // 0-decimal
+  JPY: 0, KRW: 0, ISK: 0, CLP: 0, VND: 0, XOF: 0, XAF: 0, PYG: 0,
+  // 3-decimal
+  BHD: 3, KWD: 3, OMR: 3, TND: 3, JOD: 3, IQD: 3, LYD: 3,
+}
+
+/**
+ * Return the ISO-4217 minor-unit scale for a currency code, or `null`
+ * when the code is not in the known set (caller must supply an explicit
+ * scale).
+ */
+export function scaleForCurrency(code: string): number | null {
+  return Object.prototype.hasOwnProperty.call(MINOR_UNITS, code)
+    ? MINOR_UNITS[code]
+    : null
+}

--- a/packages/hub/src/money/money-reducer.ts
+++ b/packages/hub/src/money/money-reducer.ts
@@ -1,0 +1,237 @@
+/**
+ * Money-aware aggregation: exact `sum` / `min` / `max` over money
+ * fields.
+ *
+ * The generic reducers (`aggregate/reducers.ts`) read a field via
+ * `readNumber`, which coerces a string (the stored scaled-integer form
+ * of money, e.g. `'12345'`) to `0` — so an un-wrapped money `sum` would
+ * silently return zero. {@link wrapMoneyReducers} rewrites any `sum` /
+ * `min` / `max` over a declared money field into a reducer that
+ * accumulates per-currency `BigInt` totals of the stored integers, so
+ * the result is exact for any magnitude (past `Number.MAX_SAFE_INTEGER`
+ * included).
+ *
+ * Results are currency-aware and never silently mix currencies:
+ *   - **fixed** mode → a single exact decimal string.
+ *   - **multi** mode → an exact `Record<currency, string>` map.
+ *   - **`sum` with `convertTo` + `fx`** → a single exact string, with
+ *     each currency converted via BigInt arithmetic (no float).
+ *
+ * `remove()` is implemented for every money reducer so they participate
+ * in incremental live-aggregation and materialized-view maintenance
+ * exactly like the generic reducers they replace.
+ */
+
+import { readPath } from '../query/predicate.js'
+import { formatScaledInt } from './fixed-point.js'
+import { scaleForCurrency } from './iso4217.js'
+import type { MoneyDescriptor } from './descriptor.js'
+import type { Reducer } from '../aggregate/reducers.js'
+import type { AggregateSpec } from '../aggregate/aggregation.js'
+
+export type FxRates = Record<string, number | string>
+
+interface ReadMoney {
+  currency: string
+  value: bigint
+}
+
+/** Read the raw stored money value (scaled integer) from a record. */
+function readMoney(record: unknown, field: string, desc: MoneyDescriptor): ReadMoney | null {
+  const raw = readPath(record, field)
+  if (raw === null || raw === undefined) return null
+  try {
+    if (desc.mode === 'fixed') {
+      return { currency: desc.fixedCurrency!, value: BigInt(String(raw)) }
+    }
+    if (typeof raw !== 'object') return null // malformed multi value
+    const o = raw as { amount: unknown; currency: unknown }
+    return { currency: String(o.currency), value: BigInt(String(o.amount)) }
+  } catch {
+    return null
+  }
+}
+
+/** Resolve the scale to use for a target currency (may be outside the allow-list). */
+function targetScaleFor(desc: MoneyDescriptor, currency: string): number {
+  if (desc.allows(currency)) return desc.scaleFor(currency)
+  const s = scaleForCurrency(currency)
+  if (s === null) {
+    throw new Error(`money: cannot determine scale for conversion target "${currency}"`)
+  }
+  return s
+}
+
+/** Parse a rate (number | string) into a scaled BigInt + its scale. */
+function parseRate(rate: number | string): { int: bigint; scale: number } {
+  const s = String(rate).trim()
+  const neg = s.startsWith('-')
+  const body = neg ? s.slice(1) : s
+  const dot = body.indexOf('.')
+  const intPart = dot === -1 ? body : body.slice(0, dot)
+  const fracPart = dot === -1 ? '' : body.slice(dot + 1)
+  const int = BigInt((intPart === '' ? '0' : intPart) + fracPart)
+  return { int: neg ? -int : int, scale: fracPart.length }
+}
+
+/** BigInt division of `n / d` with half-even (banker's) rounding. */
+function divRoundHalfEven(n: bigint, d: bigint): bigint {
+  const q = n / d
+  const r = n % d
+  const twiceR = (r < 0n ? -r : r) * 2n
+  if (twiceR < d) return q
+  if (twiceR > d) return q + (n < 0n ? -1n : 1n)
+  return q % 2n === 0n ? q : q + (n < 0n ? -1n : 1n)
+}
+
+/** Convert a scaled integer from `srcScale` to `targetScale` applying `rate`. */
+function convertScaled(value: bigint, srcScale: number, rate: number | string, targetScale: number): bigint {
+  const { int: rateInt, scale: rateScale } = parseRate(rate)
+  const product = value * rateInt
+  const curScale = srcScale + rateScale
+  if (curScale === targetScale) return product
+  if (curScale < targetScale) return product * 10n ** BigInt(targetScale - curScale)
+  return divRoundHalfEven(product, 10n ** BigInt(curScale - targetScale))
+}
+
+function finalizeSum(
+  state: Map<string, bigint>,
+  desc: MoneyDescriptor,
+  convertTo: string | undefined,
+  fx: FxRates | undefined,
+): string | Record<string, string> {
+  if (convertTo !== undefined) {
+    if (fx === undefined) {
+      throw new Error(`money: sum convertTo "${convertTo}" requires an fx rate map`)
+    }
+    const targetScale = targetScaleFor(desc, convertTo)
+    let total = 0n
+    for (const [cur, v] of state) {
+      if (cur === convertTo) {
+        total += convertScaled(v, desc.scaleFor(cur), 1, targetScale)
+        continue
+      }
+      const rate = fx[`${cur}->${convertTo}`]
+      if (rate === undefined) {
+        throw new Error(`money: no fx rate for "${cur}->${convertTo}"`)
+      }
+      total += convertScaled(v, desc.scaleFor(cur), rate, targetScale)
+    }
+    return formatScaledInt(total, targetScale)
+  }
+
+  if (desc.mode === 'fixed') {
+    const cur = desc.fixedCurrency!
+    return formatScaledInt(state.get(cur) ?? 0n, desc.scaleFor(cur))
+  }
+
+  const out: Record<string, string> = {}
+  for (const [cur, v] of state) out[cur] = formatScaledInt(v, desc.scaleFor(cur))
+  return out
+}
+
+function moneySumReducer(
+  field: string,
+  desc: MoneyDescriptor,
+  convertTo: string | undefined,
+  fx: FxRates | undefined,
+): Reducer<unknown, Map<string, bigint>> {
+  return {
+    op: 'sum',
+    field,
+    init: () => new Map<string, bigint>(),
+    step: (state, record) => {
+      const m = readMoney(record, field, desc)
+      if (m) state.set(m.currency, (state.get(m.currency) ?? 0n) + m.value)
+      return state
+    },
+    remove: (state, record) => {
+      const m = readMoney(record, field, desc)
+      if (m) state.set(m.currency, (state.get(m.currency) ?? 0n) - m.value)
+      return state
+    },
+    finalize: (state) => finalizeSum(state, desc, convertTo, fx),
+  }
+}
+
+function extremum(values: readonly bigint[], op: 'min' | 'max'): bigint {
+  let out = values[0]!
+  for (let i = 1; i < values.length; i++) {
+    const v = values[i]!
+    if (op === 'min' ? v < out : v > out) out = v
+  }
+  return out
+}
+
+function moneyMinMaxReducer(
+  op: 'min' | 'max',
+  field: string,
+  desc: MoneyDescriptor,
+): Reducer<unknown, Map<string, bigint[]>> {
+  return {
+    op,
+    field,
+    init: () => new Map<string, bigint[]>(),
+    step: (state, record) => {
+      const m = readMoney(record, field, desc)
+      if (m) {
+        const arr = state.get(m.currency)
+        if (arr) arr.push(m.value)
+        else state.set(m.currency, [m.value])
+      }
+      return state
+    },
+    remove: (state, record) => {
+      const m = readMoney(record, field, desc)
+      if (m) {
+        const arr = state.get(m.currency)
+        if (arr) {
+          const idx = arr.indexOf(m.value)
+          if (idx >= 0) arr.splice(idx, 1)
+        }
+      }
+      return state
+    },
+    finalize: (state) => {
+      if (desc.mode === 'fixed') {
+        const cur = desc.fixedCurrency!
+        const arr = state.get(cur)
+        if (!arr || arr.length === 0) return null
+        return formatScaledInt(extremum(arr, op), desc.scaleFor(cur))
+      }
+      const out: Record<string, string> = {}
+      for (const [cur, arr] of state) {
+        if (arr.length > 0) out[cur] = formatScaledInt(extremum(arr, op), desc.scaleFor(cur))
+      }
+      return out
+    },
+  }
+}
+
+/**
+ * Rewrite any `sum` / `min` / `max` reducer over a declared money field
+ * into its exact BigInt money-aware equivalent. Other reducers (and
+ * reducers over non-money fields) pass through unchanged. Returns a new
+ * spec; the input is not mutated.
+ */
+export function wrapMoneyReducers(
+  spec: AggregateSpec,
+  moneyFields: Record<string, MoneyDescriptor>,
+): AggregateSpec {
+  let changed = false
+  const out: Record<string, Reducer<unknown, unknown>> = {}
+  for (const [key, reducer] of Object.entries(spec)) {
+    const field = reducer.field
+    const desc = field ? moneyFields[field] : undefined
+    if (desc && (reducer.op === 'sum' || reducer.op === 'min' || reducer.op === 'max')) {
+      changed = true
+      out[key] =
+        reducer.op === 'sum'
+          ? moneySumReducer(field!, desc, reducer.convertTo, reducer.fx as FxRates | undefined)
+          : (moneyMinMaxReducer(reducer.op, field!, desc) as Reducer<unknown, unknown>)
+    } else {
+      out[key] = reducer
+    }
+  }
+  return changed ? out : spec
+}

--- a/packages/hub/src/money/money-reducer.ts
+++ b/packages/hub/src/money/money-reducer.ts
@@ -36,20 +36,31 @@ interface ReadMoney {
   value: bigint
 }
 
+function toScaledInt(v: unknown): bigint | null {
+  if (typeof v === 'string' || typeof v === 'number' || typeof v === 'bigint') {
+    try {
+      return BigInt(v)
+    } catch {
+      return null
+    }
+  }
+  return null
+}
+
 /** Read the raw stored money value (scaled integer) from a record. */
 function readMoney(record: unknown, field: string, desc: MoneyDescriptor): ReadMoney | null {
   const raw = readPath(record, field)
   if (raw === null || raw === undefined) return null
-  try {
-    if (desc.mode === 'fixed') {
-      return { currency: desc.fixedCurrency!, value: BigInt(String(raw)) }
-    }
-    if (typeof raw !== 'object') return null // malformed multi value
-    const o = raw as { amount: unknown; currency: unknown }
-    return { currency: String(o.currency), value: BigInt(String(o.amount)) }
-  } catch {
-    return null
+  if (desc.mode === 'fixed') {
+    const value = toScaledInt(raw)
+    return value === null ? null : { currency: desc.fixedCurrency!, value }
   }
+  // multi mode: stored as { amount, currency }
+  if (typeof raw !== 'object') return null
+  const o = raw as { amount?: unknown; currency?: unknown }
+  if (typeof o.currency !== 'string') return null
+  const value = toScaledInt(o.amount)
+  return value === null ? null : { currency: o.currency, value }
 }
 
 /** Resolve the scale to use for a target currency (may be outside the allow-list). */

--- a/packages/hub/src/money/money-reducer.ts
+++ b/packages/hub/src/money/money-reducer.ts
@@ -25,6 +25,7 @@
 import { readPath } from '../query/predicate.js'
 import { formatScaledInt } from './fixed-point.js'
 import { scaleForCurrency } from './iso4217.js'
+import { MoneyUnsupportedError } from './descriptor.js'
 import type { MoneyDescriptor } from './descriptor.js'
 import type { Reducer } from '../aggregate/reducers.js'
 import type { AggregateSpec } from '../aggregate/aggregation.js'
@@ -234,6 +235,12 @@ export function wrapMoneyReducers(
   for (const [key, reducer] of Object.entries(spec)) {
     const field = reducer.field
     const desc = field ? moneyFields[field] : undefined
+    if (desc && reducer.op === 'avg') {
+      throw new MoneyUnsupportedError(
+        field!,
+        `avg() is not supported on money field "${field}" in v1 — use sum() and count() and divide at the boundary.`,
+      )
+    }
     if (desc && (reducer.op === 'sum' || reducer.op === 'min' || reducer.op === 'max')) {
       changed = true
       out[key] =

--- a/packages/hub/src/money/normalize.ts
+++ b/packages/hub/src/money/normalize.ts
@@ -23,7 +23,7 @@ interface MoneyValueObject {
 }
 
 function isMoneyValueObject(v: unknown): v is MoneyValueObject {
-  return typeof v === 'object' && v !== null && 'currency' in (v as object)
+  return typeof v === 'object' && v !== null && 'currency' in v
 }
 
 /** Parse one decimal input to a stored digit string at `scale`. */
@@ -117,12 +117,15 @@ export function decodeMoneyFields<T extends Record<string, unknown>>(
     let currency: string
     let scaledIntString: string
     if (desc.mode === 'fixed') {
+      if (typeof stored !== 'string' && typeof stored !== 'number') continue
       currency = desc.fixedCurrency!
       scaledIntString = String(stored)
     } else {
       if (!isMoneyValueObject(stored)) continue // defensive: malformed stored value
-      currency = String(stored.currency)
-      scaledIntString = String(stored.amount)
+      const amount = stored.amount
+      if (typeof stored.currency !== 'string' || (typeof amount !== 'string' && typeof amount !== 'number')) continue
+      currency = stored.currency
+      scaledIntString = String(amount)
     }
 
     const scale = desc.scaleFor(currency)

--- a/packages/hub/src/money/normalize.ts
+++ b/packages/hub/src/money/normalize.ts
@@ -1,0 +1,134 @@
+/**
+ * Write-side and read-side normalization for money fields.
+ *
+ * - **Write** ({@link quantizeMoneyFields}): user input (`number | string`,
+ *   or `{ amount, currency }` in multi mode) → the canonical *stored*
+ *   form — a scaled-integer **digit string** (`'12345'`), or
+ *   `{ amount: '12345', currency: 'EUR' }` in multi mode. A JSON number
+ *   would truncate past 2^53, so the integer is always stored as a string.
+ * - **Read** ({@link decodeMoneyFields}): stored form → an exact decimal
+ *   string (`'123.45'`) plus, when formatting is requested, the virtual
+ *   `<field>Formatted` (locale currency string) and `<field>Number`
+ *   (convenience JS number, explicitly lossy past 2^53).
+ *
+ * Both return a shallow clone; neither mutates the input record.
+ */
+
+import { parseToScaledInt, formatScaledInt } from './fixed-point.js'
+import { MoneyPrecisionError, type MoneyDescriptor } from './descriptor.js'
+
+interface MoneyValueObject {
+  amount: unknown
+  currency: unknown
+}
+
+function isMoneyValueObject(v: unknown): v is MoneyValueObject {
+  return typeof v === 'object' && v !== null && 'currency' in (v as object)
+}
+
+/** Parse one decimal input to a stored digit string at `scale`. */
+function quantizeAmount(
+  field: string,
+  input: number | string,
+  scale: number,
+  rounding: MoneyDescriptor['rounding'],
+): string {
+  const r = parseToScaledInt(input, scale, rounding)
+  if (!r.ok) {
+    if (r.reason === 'precision') throw new MoneyPrecisionError(field, input, scale)
+    throw new TypeError(`money: field "${field}" value ${JSON.stringify(input)} is not a finite decimal`)
+  }
+  return r.value.toString()
+}
+
+/**
+ * Convert money fields in `record` from user input to their canonical
+ * stored form. Returns a shallow clone.
+ */
+export function quantizeMoneyFields<T extends Record<string, unknown>>(
+  record: T,
+  moneyFields: Record<string, MoneyDescriptor>,
+): T {
+  const out: Record<string, unknown> = { ...record }
+  for (const [field, desc] of Object.entries(moneyFields)) {
+    const raw = out[field]
+    if (raw === null || raw === undefined) continue
+
+    if (desc.mode === 'fixed') {
+      const currency = desc.fixedCurrency!
+      out[field] = quantizeAmount(field, raw as number | string, desc.scaleFor(currency), desc.rounding)
+      continue
+    }
+
+    // multi mode
+    let amount: number | string
+    let currency: string
+    if (isMoneyValueObject(raw)) {
+      currency = String(raw.currency)
+      amount = raw.amount as number | string
+    } else {
+      const sole = desc.soleCurrency()
+      if (sole === undefined) {
+        throw new TypeError(
+          `money: field "${field}" is multi-currency — write { amount, currency }, not a bare amount`,
+        )
+      }
+      currency = sole
+      amount = raw as number | string
+    }
+    const scale = desc.scaleFor(currency) // throws MoneyCurrencyError if disallowed
+    out[field] = { amount: quantizeAmount(field, amount, scale, desc.rounding), currency }
+  }
+  return out as T
+}
+
+function formatCurrency(decimal: string, currency: string, scale: number, locale: string): string {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: scale,
+    maximumFractionDigits: scale,
+  }).format(decimal) // string arg → full precision, exact past 2^53
+}
+
+/**
+ * Convert money fields in `record` from stored form to the read shape:
+ * an exact decimal string, plus `<field>Formatted` / `<field>Number`
+ * virtuals when `locale !== 'raw'`. Returns a shallow clone.
+ */
+export function decodeMoneyFields<T extends Record<string, unknown>>(
+  record: T,
+  moneyFields: Record<string, MoneyDescriptor>,
+  locale: string | undefined,
+): T {
+  const out: Record<string, unknown> = { ...record }
+  const format = locale !== 'raw'
+  const fmtLocale = typeof locale === 'string' && locale !== 'raw' ? locale : 'en-US'
+
+  for (const [field, desc] of Object.entries(moneyFields)) {
+    const stored = out[field]
+    if (stored === null || stored === undefined) continue
+
+    let currency: string
+    let scaledIntString: string
+    if (desc.mode === 'fixed') {
+      currency = desc.fixedCurrency!
+      scaledIntString = String(stored)
+    } else {
+      if (!isMoneyValueObject(stored)) continue // defensive: malformed stored value
+      currency = String(stored.currency)
+      scaledIntString = String(stored.amount)
+    }
+
+    const scale = desc.scaleFor(currency)
+    const decimal = formatScaledInt(BigInt(scaledIntString), scale)
+
+    out[field] = desc.mode === 'fixed' ? decimal : { amount: decimal, currency }
+
+    if (format) {
+      out[`${field}Formatted`] = formatCurrency(decimal, currency, scale, fmtLocale)
+      out[`${field}Number`] = Number(decimal)
+    }
+  }
+  return out as T
+}

--- a/packages/hub/src/money/normalize.ts
+++ b/packages/hub/src/money/normalize.ts
@@ -83,12 +83,17 @@ export function quantizeMoneyFields<T extends Record<string, unknown>>(
 }
 
 function formatCurrency(decimal: string, currency: string, scale: number, locale: string): string {
-  return new Intl.NumberFormat(locale, {
+  const fmt = new Intl.NumberFormat(locale, {
     style: 'currency',
     currency,
     minimumFractionDigits: scale,
     maximumFractionDigits: scale,
-  }).format(decimal) // string arg → full precision, exact past 2^53
+  })
+  // V8's Intl.format accepts a decimal STRING and formats it at full
+  // precision (exact past 2^53). The TS lib types only declare
+  // number|bigint, so cast — a number arg here would re-introduce the
+  // float drift this whole feature exists to eliminate.
+  return (fmt.format as unknown as (value: string) => string)(decimal)
 }
 
 /**

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -16,6 +16,8 @@ import { buildLiveQuery } from './live.js'
 import type { AggregateSpec, AggregateResult, AggregationUpstream, Aggregation } from '../aggregate/aggregation.js'
 import type { GroupedQuery, GroupedQueryN } from '../aggregate/groupby.js'
 import { NO_AGGREGATE, type AggregateStrategy } from '../aggregate/strategy.js'
+import type { MoneyDescriptor } from '../money/descriptor.js'
+import { wrapMoneyReducers } from '../money/money-reducer.js'
 
 export interface OrderBy {
   readonly field: string
@@ -77,6 +79,11 @@ export interface QuerySource<T> {
   getIndexes?(): CollectionIndexes | null
   /** O(1) record lookup by id, used to materialize index hits. */
   lookupById?(id: string): T | undefined
+  /**
+   * Money field descriptors for the backing collection, used to rewrite
+   * `sum`/`min`/`max` over money fields into exact BigInt reducers.
+   */
+  moneyFields?: Record<string, MoneyDescriptor>
 }
 
 interface InternalSource {
@@ -84,6 +91,7 @@ interface InternalSource {
   subscribe?(cb: () => void): () => void
   getIndexes?(): CollectionIndexes | null
   lookupById?(id: string): unknown
+  moneyFields?: Record<string, MoneyDescriptor>
 }
 
 /**
@@ -621,6 +629,12 @@ export class Query<T> {
   aggregate<Spec extends AggregateSpec>(
     spec: Spec,
   ): Aggregation<AggregateResult<Spec>> {
+    // Rewrite sum/min/max over money fields into exact BigInt reducers
+    // before the strategy runs (covers static run() and live/MV paths).
+    const moneyFields = this.source.moneyFields
+    if (moneyFields) {
+      spec = wrapMoneyReducers(spec, moneyFields) as Spec
+    }
     // Closure over the current query. Produces the record set that
     // the aggregation reduces — same pipeline as `count()`, skipping
     // limit/offset because aggregation is over the full match set,
@@ -742,12 +756,14 @@ export class Query<T> {
         field,
         upstreams,
         dictLabelResolver,
+        this.source.moneyFields,
       )
     }
     return this.aggregateStrategy.groupByN<T, readonly string[]>(
       executeRecords,
       fields,
       upstreams,
+      this.source.moneyFields,
     )
   }
 

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -69,6 +69,7 @@ import type { DictionaryHandle, DictionaryOptions, DictKeyDescriptor } from './i
 import { isDictCollectionName } from './i18n/dictionary.js'
 import type { I18nTextDescriptor } from './i18n/core.js'
 import { getAtPath } from './i18n/core.js'
+import type { MoneyDescriptor } from './money/descriptor.js'
 import { NO_I18N, type I18nStrategy } from './i18n/strategy.js'
 import { NO_SYNC, type SyncStrategy } from './team/sync-strategy.js'
 // Type-only imports for the guard + derivation subsystems. The
@@ -531,6 +532,8 @@ export class Vault {
     i18nFields?: Record<string, I18nTextDescriptor>
     /** — declare dictKey fields for label resolution on reads. */
     dictKeyFields?: Record<string, DictKeyDescriptor>
+    /** — declare money() fields for currency-safe decimal storage/formatting. */
+    moneyFields?: Record<string, MoneyDescriptor>
     /** — per-collection conflict resolution policy. */
     conflictPolicy?: ConflictPolicy<T>
     /** — CRDT mode for collaborative editing without conflicts. */
@@ -749,6 +752,7 @@ export class Vault {
       collOpts.onCrossTierAccess = (event) => this.emitCrossTier(event)
       if (this.syncAdapter !== undefined) collOpts.syncAdapter = this.syncAdapter
       if (options?.i18nFields !== undefined) collOpts.i18nFields = options.i18nFields
+      if (options?.moneyFields !== undefined) collOpts.moneyFields = options.moneyFields
       if (options?.dictKeyFields !== undefined) {
         // Build the label resolver callback for this collection
         collOpts.dictLabelResolver = async (dictName, key, locale, fallback) => {

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -605,6 +605,13 @@ export class Vault {
     }
 
     let coll = this.collectionCache.get(collectionName)
+    if (coll && options?.moneyFields) {
+      // The collection may have been auto-created (without options) by
+      // materialized-view dependency analysis during openVault, before
+      // this declaration. Reconcile money descriptors onto it so writes
+      // quantize and money-aware aggregation applies. First-wins.
+      coll._applyMoneyFields(options.moneyFields)
+    }
     if (!coll) {
       // Register ref declarations (if any) with the vault-level
       // registry BEFORE constructing the Collection. This way the

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -395,7 +395,12 @@ function scanFileForStrategyOptIn(file, content) {
 // itself into the kernel shows up here as a line-count regression — the fix is
 // to register on the bus, not to grow these files.
 const KERNEL_SURFACE_BUDGET = {
-  'packages/hub/src/collection.ts': 3950,
+  // Bumped 3950→3985 for the money() write/read hooks (#300): quantize-on-put
+  // + decode-on-read are inline transforms in the put/get hot paths, the same
+  // kernel-resident placement as the i18nText/dictKey hooks — they cannot move
+  // onto the SubsystemBus. The heavy logic lives in src/money/; only the thin
+  // call-sites are here.
+  'packages/hub/src/collection.ts': 3985,
   'packages/hub/src/vault.ts': 3640,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy


### PR DESCRIPTION
Closes #300.

`money()` — a currency-safe decimal field descriptor (sibling of `i18nText()` / `dictKey()`) that owns fixed-point storage, rounding, multi-currency, locale formatting, and **exact** aggregation. From the Pilot-3 (i3speedex) migration: the pilot stored money as JS `number`, keeping all VAT/currency arithmetic in userland.

> **Draft — awaiting review, do not merge.** Built autonomously end-to-end; flagged items below are deliberate scope calls for your sign-off.

## Core principle
**Integers live in storage as digit strings; decimals live only at the boundary.** Money never exists as a JS `number` where the DB persists or computes — a `number` truncates past 2^53, so the scaled integer is stored as a string, parsed to `BigInt` for arithmetic, and rendered to a decimal string at the edge.

## What it does
- **Descriptor:** `money({ currency, scale?, rounding? })` (fixed) or `money({ currencies: 'any' | [...], scaleOverrides? })` (multi). Scale defaults from a built-in ISO-4217 table (JPY=0, EUR=2, BHD=3).
- **Write:** decimal `number | string` → scaled-integer **digit string** via string math (never float ×). Excess precision is **rejected** unless a `rounding` mode is set (7 modes, incl. banker's half-even).
- **Read:** exact decimal string + virtual `<field>Formatted` (Intl, full precision) + `<field>Number` (documented-lossy convenience).
- **Exact aggregation:** `sum`/`min`/`max` over a money field are rewritten to BigInt reducers — fixed → single string, multi → exact per-currency map (`{ EUR:'15.50', USD:'3.00' }`), `sum(..., { convertTo, fx })` → one figure (BigInt, half-even; throws on missing rate). Works on flat **and** grouped (`groupBy`) paths, and in materialized views + `.live()`.

## Verified (not just built)
- 54 money tests across 8 files; full hub suite **2219 passing**; typecheck clean; `eslint src/` clean; `features.yaml` validates.
- Exactness past `Number.MAX_SAFE_INTEGER` proven end-to-end (store → read → Intl format → sum), e.g. `90071992547409.91`.
- Rounding tie-breaks (half-even vs half-up); the `0.1 + 0.2 + 0.3 = 0.60` float-drift trap; negatives; null-excluded-from-sum.
- **A real bug found & fixed by verification:** an MV/`saleRollups`-shaped scenario (money → `sum` → MV) summed to **0**. MV dependency analysis auto-creates the source collection (without options) during `openVault`, *before* the user's `collection(name, { moneyFields })` declaration — so `moneyFields` was silently dropped and the stored money string coerced to 0 in the generic reducer. Fixed by reconciling descriptors onto the pre-created collection (`Collection._applyMoneyFields`, first-wins). New `mv-and-live` tests prove the MV recomputes exactly on source delete and `.live()` stays exact.

## Deliberate scope calls (your sign-off)
- **Read type is a string, not number.** `total` reads back as `'123.45'`. A consumer who declares the natural `total: z.number()` will have **writes succeed but reads return a string**. The README example steers to `z.union([z.number(), z.string()])`; the strict-`z.number()` failure mode is currently untested — worth a follow-up (clearer error or a doc note).
- **Introspection deferred.** The schema-walker surfaces no descriptor metadata today — `i18nText`/`dictKey` aren't introspected either. Doing money alone would be asymmetric; descriptor introspection is a uniform follow-up.
- **Also deferred:** persisted FX-rate storage (per-call `fx` is supported), exact `avg()` over money, equality/`unique` index on a *multi-mode* `{amount,currency}` value (fixed-mode indexes as-is).

## Not in this PR
Cluster A also has **#302** (computed scalars, will consume `money`) and **#299** (cross-record async validators) — not designed here; they need their own specs. Also from the triage: **#305** and **#310** were closed (already-fixed / out-of-domain).

## Docs
Spec `docs/superpowers/specs/2026-06-08-money-decimal-field-design.md`, plan `docs/superpowers/plans/2026-06-08-money-decimal-field.md`, README "Money fields" section, `features.yaml` `money-field` entry.
