### PR TITLE
fix(hub): openVault no-self-provision — fail closed instead of minting into another principal's vault (#313)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-openvault-no-self-provision-313.md
+++ b/docs/superpowers/plans/2026-06-08-openvault-no-self-provision-313.md
@@ -1,0 +1,243 @@
+# `openVault` No-Self-Provision (#313) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `openVault` from silently minting an owner keyring into a vault held by other principals — create-on-open only for a genuinely-new vault (no `_keyring/*`); a missing grant on a populated vault fails closed. Add an additive `openVault({ create?: boolean })` flag.
+
+**Architecture:** A single pre-gate in `getKeyringInternal`, placed **before `resolveManagedSecret`** (which persists on first open), keyed on one `store.list(vault,'_keyring')` membership check. Additive `create` flag threaded through `openVault` and `queryAcross`. Dedicated `0.2.0-pre.11` security release.
+
+**Tech Stack:** TypeScript, `@noy-db/hub` core (`noydb.ts`, `types.ts`), Vitest. pnpm 9.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-openvault-no-self-provision-design.md`
+
+**Branch:** `fix/pre11-no-self-provision` off `main` (`e7301e2`).
+
+**Verified facts:**
+- `getKeyringInternal(vault)` (`noydb.ts:2704`): `getKeyring`-callback short-circuit → `resolveManagedSecret` (managed mode; **persists `_meta/sealed-passphrase` on first open**, `team/managed-passphrase.ts:24-25`) → `loadKeyring` → catch: `NoAccessError`→`createOwnerKeyring`; `InvalidKeyError && onInvalidKey==='reset'`→reset; else throw.
+- `loadKeyring` throws `NoAccessError` when `_keyring/<userId>` for the caller is absent (no other-principal check).
+- `queryAcross<T>(vaultIds, fn, options)` calls `this.openVault(vaultId)` internally.
+- `_shardVaultProvisioned` (`noydb.ts:1026`) already uses `(await store.list(vault,'_keyring')).length`.
+- `NoAccessError` exported from `errors.js`; `encrypt:false` returns a plaintext keyring early (no create path).
+
+Run tests: `pnpm --filter @noy-db/hub exec vitest run <file>`
+
+---
+
+### Task 0: blast-radius prototype (do this FIRST)
+
+**Files:** `packages/hub/src/noydb.ts` (throwaway prototype)
+
+- [ ] **Step 1: Prototype the gate** — in `getKeyringInternal`, immediately after the `getKeyring`-callback `if (this.options.getKeyring) {…}` block and **before** the managed-secret resolution, insert (encrypted path only):
+```ts
+    if (this.options.encrypt !== false) {
+      const keyringUsers = await this.options.store.list(vault, '_keyring')
+      if (!keyringUsers.includes(this.options.user) && keyringUsers.length > 0) {
+        throw new NoAccessError(`No keyring for user "${this.options.user}" in vault "${vault}"`)
+      }
+    }
+```
+(This is the populated-by-others case only — the minimal probe to surface breakage.)
+
+- [ ] **Step 2: Run the FULL hub suite** — `pnpm --filter @noy-db/hub test`. Record every failure. Expected: only tests that opened another principal's populated vault expecting self-provision (relying on the hole). For each, confirm it's bug-reliant (a missing `grant` before the second identity opens) — NOT a legitimate flow.
+
+- [ ] **Step 3: Revert the prototype** (`git checkout packages/hub/src/noydb.ts`). Record the failing-test list in the commit message of Task 1 so the fixes are traceable.
+
+If any *legitimate* flow breaks (a first-owner/fixture/migration on a genuinely-empty vault failing), STOP — the discriminator is wrong; re-evaluate. (Not expected: those have empty `_keyring/*`.)
+
+---
+
+### Task 1: the create flag + pre-gate
+
+**Files:**
+- Modify: `packages/hub/src/noydb.ts` (openVault opts, getKeyringInternal pre-gate + signature, queryAcross threading)
+- Modify: `packages/hub/src/types.ts` (`QueryAcrossOptions.create?`)
+- Test: `packages/hub/__tests__/no-self-provision.test.ts` (new)
+
+- [ ] **Step 1: Write the failing tests.** Create `packages/hub/__tests__/no-self-provision.test.ts`. Copy the inline `memory()` adapter from `__tests__/cross-vault.test.ts`, plus a key-snapshot helper:
+```ts
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { NoAccessError } from '../src/errors.js'
+// memory(): copy from cross-vault.test.ts
+// also expose the underlying Map so we can snapshot keys; simplest: add a helper that lists keys via the adapter's own get/list is awkward —
+// instead capture keys by wrapping put: track every (compartment, collection, id) the adapter writes.
+
+function trackingMemory() {
+  const base = memory()
+  const writes: string[] = []
+  return {
+    adapter: {
+      ...base,
+      async put(c: string, col: string, id: string, env: any, ev?: number) {
+        writes.push(`${c}/${col}/${id}`)
+        return base.put(c, col, id, env, ev)
+      },
+    },
+    writesSince(mark: number) { return writes.slice(mark) },
+    mark() { return writes.length },
+  }
+}
+
+it('default: bob opening alice\'s populated vault fails closed and writes nothing', async () => {
+  const { adapter, mark, writesSince } = trackingMemory()
+  const alice = await createNoydb({ store: adapter, user: 'alice', secret: 'alice-pass' })
+  const av = await alice.openVault('client-1')
+  await av.collection<{ n: number }>('c').put('r1', { n: 1 })
+
+  const bob = await createNoydb({ store: adapter, user: 'bob', secret: 'bob-pass' })
+  const m = mark()
+  await expect(bob.openVault('client-1')).rejects.toBeInstanceOf(NoAccessError)
+  expect(writesSince(m)).toEqual([])                                 // NOTHING written
+  expect(await adapter.get('client-1', '_keyring', 'bob')).toBeNull()
+})
+
+it('MANAGED mode: bob (managed) opening alice\'s vault fails closed and writes no _meta/sealed-passphrase', async () => {
+  const { adapter, mark, writesSince } = trackingMemory()
+  const alice = await createNoydb({ store: adapter, user: 'alice', secret: 'alice-pass' })
+  await (await alice.openVault('client-1')).collection<{ n: number }>('c').put('r1', { n: 1 })
+
+  // a trivial in-memory sealing provider
+  const provider = {
+    id: 'test-kms',
+    async seal(b: Uint8Array) { return { ct: Buffer.from(b).toString('base64') } },
+    async unseal(s: any) { return new Uint8Array(Buffer.from(s.ct, 'base64')) },
+  }
+  const bob = await createNoydb({ store: adapter, user: 'bob', passphraseMode: 'managed', sealingKey: provider as any })
+  const m = mark()
+  await expect(bob.openVault('client-1')).rejects.toBeInstanceOf(NoAccessError)
+  expect(writesSince(m)).toEqual([])                                  // no _meta/sealed-passphrase, nothing
+})
+
+it('new vault still open-or-creates (default)', async () => {
+  const { adapter } = trackingMemory()
+  const db = await createNoydb({ store: adapter, user: 'alice', secret: 'alice-pass' })
+  const v = await db.openVault('fresh')
+  await v.collection<{ n: number }>('c').put('r1', { n: 1 })
+  expect(await adapter.get('fresh', '_keyring', 'alice')).not.toBeNull()
+})
+
+it('create:false never creates, even a fresh vault', async () => {
+  const { adapter } = trackingMemory()
+  const db = await createNoydb({ store: adapter, user: 'alice', secret: 'alice-pass' })
+  await expect(db.openVault('fresh', { create: false })).rejects.toBeInstanceOf(NoAccessError)
+  expect(await adapter.get('fresh', '_keyring', 'alice')).toBeNull()
+})
+
+it('a granted member opens fine', async () => {
+  const { adapter } = trackingMemory()
+  const alice = await createNoydb({ store: adapter, user: 'alice', secret: 'alice-pass' })
+  await (await alice.openVault('client-1')).collection<{ n: number }>('c').put('r1', { n: 1 })
+  await alice.grant('client-1', { userId: 'bob', displayName: 'Bob', role: 'viewer', passphrase: 'bob-pass' })
+
+  const bob = await createNoydb({ store: adapter, user: 'bob', secret: 'bob-pass' })
+  const bv = await bob.openVault('client-1')
+  expect(await bv.collection<{ n: number }>('c').get('r1')).toEqual({ n: 1 })
+})
+```
+(Confirm `grant` options + the `sealingKey`/managed-mode option names against `cross-vault.test.ts` and an existing managed-mode test; adjust shapes. The behavioral asserts — fail closed + nothing written + new-vault create preserved — are fixed.)
+
+- [ ] **Step 2: Run — fail.** `pnpm --filter @noy-db/hub exec vitest run __tests__/no-self-provision.test.ts` → the fail-closed + create:false tests fail (today bob self-provisions).
+
+- [ ] **Step 3: Add the `create` flag + pre-gate** in `noydb.ts`.
+`openVault` signature:
+```ts
+  async openVault(name: string, opts?: { locale?: string; create?: boolean }): Promise<Vault> {
+```
+Thread into the keyring load (the `const keyring = await this.getKeyringInternal(name)` call near line 421):
+```ts
+    const keyring = await this.getKeyringInternal(name, { create: opts?.create !== false })
+```
+`getKeyringInternal` signature + the pre-gate (insert right after the `if (this.options.getKeyring) {…}` block, before the managed-secret resolution):
+```ts
+  private async getKeyringInternal(
+    vault: string,
+    opts: { create: boolean } = { create: true },
+  ): Promise<UnlockedKeyring> {
+    // … existing: encrypt:false early return, cache check, getKeyring callback …
+
+    // Pre-gate (#313): decide create-vs-fail BEFORE any vault write (resolveManagedSecret
+    // persists on first open). One capability-free store.list; membership = caller has a keyring.
+    if (this.options.encrypt !== false) {
+      const keyringUsers = await this.options.store.list(vault, '_keyring')
+      if (!keyringUsers.includes(this.options.user)) {
+        if (opts.create === false) {
+          throw new NoAccessError(`Vault "${vault}" not opened: create disabled and no keyring for "${this.options.user}".`)
+        }
+        if (keyringUsers.length > 0) {
+          throw new NoAccessError(`No keyring for user "${this.options.user}" in vault "${vault}" (held by other principals) — refusing to self-provision.`)
+        }
+        // else: genuinely-new vault (no _keyring/*) → fall through to the normal mint+create path
+      }
+    }
+    // … existing: managed-secret resolution, loadKeyring, NoAccessError→createOwnerKeyring (now only reached for the genuinely-new fall-through) …
+```
+Leave the `loadKeyring` catch's `NoAccessError → createOwnerKeyring` branch as-is (it now only fires for the genuinely-new case the pre-gate let through). Leave the `onInvalidKey:'reset'` branch as-is.
+
+Add `create` to `QueryAcrossOptions` in `types.ts`:
+```ts
+export interface QueryAcrossOptions {
+  readonly concurrency?: number
+  /** Open shards non-creatingly — a missing grant throws instead of self-provisioning. Default: creating. */
+  readonly create?: boolean
+}
+```
+Thread it in `queryAcross`'s internal open (`const comp = await this.openVault(vaultId)`):
+```ts
+        const comp = await this.openVault(vaultId, { create: options.create !== false })
+```
+
+- [ ] **Step 4: Run — pass.** The 5 tests green. Then `pnpm --filter @noy-db/hub test` (full suite) — fix any bug-reliant tests surfaced (add the missing `grant` before the second identity opens; this is the correct pattern). `pnpm --filter @noy-db/hub run typecheck` clean.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/hub/src/noydb.ts packages/hub/src/types.ts packages/hub/__tests__/no-self-provision.test.ts
+git commit -m "fix(hub): openVault no longer self-provisions into a vault held by other principals (#313)
+
+Pre-gate in getKeyringInternal (before resolveManagedSecret) fails closed when the caller has no
+keyring and the vault has other principals' keyrings; create-on-open only for a genuinely-new vault
+(no _keyring/*). Additive openVault({create?}) + queryAcross({create?}). Tests assert nothing is
+written on the fail-closed path (default + managed mode)."
+```
+(If Task 0 surfaced bug-reliant tests, list them + their grant-fixes in the body.)
+
+---
+
+### Task 2: pre.11 lockstep bump + SECURITY changelog
+
+**Files:**
+- Modify: `packages/hub/CHANGELOG.md`
+- Modify: all 66 `packages/*/package.json` (version field)
+
+- [ ] **Step 1: CHANGELOG SECURITY entry** — prepend under `# Changelog — hub`:
+```markdown
+## 0.2.0-pre.11
+
+### Security: `openVault` no longer self-provisions into another principal's vault ([#313](https://github.com/vLannaAi/noy-db/issues/313))
+
+- Opening a vault you hold **no grant** to that is **already held by other principals** now fails closed with `NoAccessError` and writes **nothing** — previously it silently minted a fresh owner keyring (new DEKs) into that vault and read zero records. Genuinely-new vaults (no `_keyring/*`) still open-or-create as before.
+- New opt-in **`openVault({ create: false })`** (and `queryAcross({ create: false })`) forces strict open-existing — a missing grant throws instead of creating.
+- The fix sits **before** managed-passphrase secret resolution, so managed mode (KMS-sealed) also writes nothing on the fail-closed path.
+```
+
+- [ ] **Step 2: Lockstep bump** all package versions `0.2.0-pre.10` → `0.2.0-pre.11`:
+```bash
+for f in packages/*/package.json; do perl -i -pe 's/"version": "0\.2\.0-pre\.10"/"version": "0.2.0-pre.11"/ if $. < 10' "$f"; done
+grep -rl '"version": "0.2.0-pre.11"' packages/*/package.json | wc -l    # expect 66
+grep -rl '"version": "0.2.0-pre.10"' packages/*/package.json || echo "all bumped"
+```
+
+- [ ] **Step 3: Verify** — `pnpm --filter @noy-db/hub run typecheck`, `pnpm --filter @noy-db/hub test`, `node scripts/validate-features.mjs`, `node scripts/check-architecture.mjs` → all green/clean.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add -A
+git commit -m "release: 0.2.0-pre.11 — security: openVault no-self-provision (#313)"
+```
+
+---
+
+## Self-review notes
+- **Spec coverage:** pre-gate before resolveManagedSecret (Task 1 Step 3); managed-mode no-write test (Task 1 Step 1 #2); create flag + queryAcross threading (Task 1); new-vault preserved + create:false + granted-member (Task 1); blast-radius step-0 (Task 0); release (Task 2).
+- **Membership check:** `keyringUsers.includes(this.options.user)` — if the caller IS a member, fall through (loadKeyring loads their keyring); the pre-gate only acts when the caller is absent. Correct: a granted member never trips it.
+- **`getKeyring` callback path / `onInvalidKey:'reset'` / plaintext:** untouched (pre-gate is after the callback short-circuit and gated on `encrypt !== false`; reset is the caller's own stale keyring).
+- **Federation interaction:** after this lands, the cross-vault A/B work consumes the `create` flag (`create:false` on the read fan-out/`openShard`) — re-confirm it's belt-and-suspenders vs load-bearing when trimming that plan's Task 2.

--- a/docs/superpowers/specs/2026-06-08-openvault-no-self-provision-design.md
+++ b/docs/superpowers/specs/2026-06-08-openvault-no-self-provision-design.md
@@ -1,0 +1,179 @@
+# `openVault` No-Self-Provision — Design (#313)
+
+- **Date:** 2026-06-08
+- **Issue:** #313 (split from #312, custodial multi-tenant federation)
+- **Status:** Design approved (pending spec review)
+- **Release:** dedicated **`0.2.0-pre.11`** — security fix, off `main`
+- **Severity:** key-custody / data-integrity hole — an un-granted identity self-provisions owner access into another principal's vault
+
+## Goal
+
+Close a hub-wide hole: opening a vault you lack a grant to **silently mints a fresh owner
+keyring (new DEKs) into that vault** instead of failing. Make `openVault` create a keyring
+**only for a genuinely-new vault** (no `_keyring/*` at all); opening a populated vault you are
+not a member of **fails closed** (`NoAccessError`, nothing written). Introduce an additive
+`openVault({ create?: boolean })` flag (also consumed by the federation slice).
+
+## Background — the hole
+
+`loadKeyring` (`team/keyring.ts`) throws `NoAccessError` whenever **this** identity's
+`_keyring/<userId>` envelope is absent — it does **not** check whether *other* principals'
+keyrings exist. `getKeyringInternal` (`noydb.ts`) catches `NoAccessError` and treats it as
+"first boot — create owner keyring":
+
+```ts
+if (err instanceof NoAccessError) {
+  // "No keyring on disk — first boot or cleared store."
+  keyring = await createOwnerKeyring(...)   // mints a fresh OWNER keyring + new DEKs, writes it into the vault
+}
+```
+
+So any identity that opens an **existing, populated** vault it lacks a grant to:
+1. self-provisions a stray owner keyring (new DEKs) into that vault, and
+2. reads **zero records** (the new DEKs can't decrypt the real owner's ciphertext) — **no error**.
+
+It never bit the single-tenant model (you only open vaults you own). It surfaces under scoped,
+multi-principal access (the #312 custodial adopter: advisors, insight executors, drill-down,
+bundle adopt, recovery — many paths `openVault` by name).
+
+## Blast radius (verified)
+
+The implicit create-on-open is **one branch** — `getKeyringInternal`'s `NoAccessError` catch.
+Everything else is already safe:
+
+- **`getKeyring` callback path** (WebAuthn / OIDC / Shamir): documented "no automatic
+  `NoAccessError` → `createOwnerKeyring` fallback — the callback owns open-vs-create." Untouched.
+- **`onInvalidKey: 'reset'` branch**: a *different* scenario — the caller's **own** keyring exists
+  but is stale (`InvalidKeyError`); reset deletes and recreates the caller's own row. Orthogonal,
+  untouched.
+- **`adoptPartition`** (the only other `createOwnerKeyring` caller): calls it **directly** (not via
+  `openVault`) and **already guards** on `store.list(vault,'_keyring')` for existing owners.
+  Untouched.
+- **Internal `openVault` callers** — `queryAcross` and `openVaultAndEnrollRecovery` (first-owner
+  enroll on a *new* vault): fine under the gate.
+- **Plaintext mode** (`encrypt:false`): returns a plaintext keyring early — no create path.
+
+So the *only* behavior that changes is create-on-open of a **populated vault by a non-member** —
+which is always the bug. Every legitimate create-on-open (first-owner, recovery enroll, fixtures,
+plaintext→encrypted migration) acts on a genuinely-empty vault and is preserved.
+
+## The fix
+
+### 1. Pre-gate — *before* any vault write (`getKeyringInternal`, `noydb.ts`)
+
+**Placement matters.** `getKeyringInternal` runs `resolveManagedSecret` *before* `loadKeyring`, and
+on first open `resolveManagedSecret` **mints + seals + persists `_meta/sealed-passphrase` into the
+vault** (`team/managed-passphrase.ts:24-25`). A gate in the `loadKeyring` catch would fire **after**
+that write — so in **managed-passphrase mode** (the custodial adopter's mode: KMS-backed server,
+shared sealing key) a non-member opening a populated vault would already have written a sealed-secret
+artifact before failing. The gate therefore sits **before `resolveManagedSecret`**, on the encrypted
+path, after the `getKeyring`-callback short-circuit:
+
+```ts
+// encrypted path, after the getKeyring-callback return, BEFORE resolveManagedSecret:
+const keyringUsers = await this.options.store.list(vault, '_keyring')
+const callerIsMember = keyringUsers.includes(this.options.user)
+if (!callerIsMember) {
+  // The caller has no keyring in this vault.
+  if (opts.create === false) throw new NoAccessError(/* strict open-existing */)
+  if (keyringUsers.length > 0) throw new NoAccessError(/* populated by other principals → fail closed, no self-provision */)
+  // else: genuinely-new vault (no _keyring/* at all) → fall through to the normal mint+create path
+}
+```
+
+- **`callerIsMember`** → fall through: `resolveManagedSecret` (if managed) + `loadKeyring` load the
+  caller's existing keyring as today.
+- **not a member, `create: false`** → throw immediately (strict open-existing; federation reads/drill-down).
+- **not a member, others exist** → throw (fail closed) — **nothing written** (we're before `resolveManagedSecret`).
+- **not a member, no keyrings at all** → genuinely-new → fall through; the existing `loadKeyring`
+  `NoAccessError` → `createOwnerKeyring` path mints the first-owner keyring as today.
+
+One `store.list(vault, '_keyring')` (capability-free; the same call `_shardVaultProvisioned`
+uses at `noydb.ts:1026`). The existing `NoAccessError` → `createOwnerKeyring` branch in the
+`loadKeyring` catch is now reached **only** for the genuinely-new case the pre-gate let through, so
+its `createOwnerKeyring` stays as-is (single decision point = the pre-gate).
+
+### 2. Additive `create` flag
+
+```ts
+async openVault(name: string, opts?: { locale?: string; create?: boolean }): Promise<Vault>
+private async getKeyringInternal(vault: string, opts: { create: boolean } = { create: true }): Promise<UnlockedKeyring>
+```
+- `create` default `true` → create **iff** the vault has no `_keyring/*` (the new safe default).
+- `create: false` → never create; a missing grant throws `NoAccessError`.
+- **No force option** — there is no way to create into a populated vault you are not a member of.
+  No current caller needs it (verified); add later only if a real need appears.
+
+`openVault` threads `opts?.create` into `getKeyringInternal({ create: opts?.create !== false })`.
+`queryAcross` gains `create?: boolean` in `QueryAcrossOptions` (`types.ts`) and threads it into its
+internal `openVault(vaultId, { create: options.create !== false })`.
+
+## Interaction with the federation slice (#312)
+
+The cross-vault-live slice's plan (Phase 1, Task 2) introduced this same flag. **#313 owns and
+lands it first** on `main`; the federation slice then only **consumes** it (`create: false` on the
+read fan-out + `openShard`). After #313 merges, trim the cross-vault plan's Task 2 to "pass
+`create: false`" and rebase the federation branches. (`createShard` keeps the default — it only
+ever creates genuinely-new shards, which the gate permits.)
+
+**Re-confirm at trim time:** once this pre-gate is on `main`, a non-granted shard open fails closed
+**regardless** of the `create` flag (populated shard → other principals exist → `NoAccessError`),
+and the provisioning guard already filters empty shards out of the fan-out. So federation's
+`create: false` likely becomes **belt-and-suspenders** (explicit intent) rather than the
+load-bearing safety property — which now comes from #313. When trimming Task 2, state it as intent,
+not as the thing that closes the hole, so the federation plan doesn't claim a safety guarantee that
+actually lives here.
+
+## Error handling
+- Populated vault, non-member → `NoAccessError` (nothing written). The fail-closed signal.
+- `create: false` on any not-yet-accessible vault → `NoAccessError`.
+- All other `loadKeyring` errors (`KeyringCorruptError`, `InvalidKeyError` without reset) → propagate
+  unchanged (`else throw err`).
+
+## Testing
+
+**Step 0 (front-load the blast radius — the release framing depends on it):** the change is ~5
+lines; prototype it and run the **full hub suite first**, before writing the rest. The owner's
+theory is "no *legitimate* create-into-populated caller exists," so any breakage is expected to be
+a test that relied on the hole — but confirm *what* breaks and *why* before committing to the
+"dedicated security release" narrative. Each genuine break is fixed by granting the second identity
+first (the correct pattern, per `cross-vault.test.ts`).
+
+`packages/hub/__tests__/no-self-provision.test.ts` (new; reuse the inline `memory()` adapter from
+`__tests__/cross-vault.test.ts`; add a `storeKeys(adapter)` helper that snapshots all `(compartment,
+collection, id)` triples):
+1. **Fail-closed, nothing written (default mode):** alice creates+populates `v`; snapshot store keys;
+   bob `openVault('v')` → rejects `NoAccessError`; assert the store-key set is **byte-for-byte
+   unchanged** (not just `_keyring/bob` absent — **no** `_meta/*` or any artifact appeared).
+2. **Fail-closed, nothing written (MANAGED mode):** same as #1 but bob's `Noydb` is
+   `passphraseMode: 'managed'` with a sealing provider → rejects `NoAccessError` and asserts **no
+   `_meta/sealed-passphrase`** (or anything) was written into `v` (this is the case the pre-gate
+   placement exists for; a gate-in-the-catch would fail this test).
+3. **New-vault create preserved:** alice `openVault('fresh')` → succeeds; `_keyring/alice` written;
+   write+read round-trips.
+4. **`create: false` never creates:** even on a fresh vault → rejects `NoAccessError`; no keyring.
+5. **Granted member opens fine:** alice grants bob on `v`; bob `openVault('v')` → succeeds, reads
+   alice's records.
+
+## Files
+- Modify `packages/hub/src/noydb.ts` — `openVault` opts, `getKeyringInternal` signature + gated
+  `NoAccessError` branch, `queryAcross` threading.
+- Modify `packages/hub/src/types.ts` — `QueryAcrossOptions.create?`.
+- Create `packages/hub/__tests__/no-self-provision.test.ts`.
+- Modify `packages/hub/CHANGELOG.md` — **SECURITY** entry; lockstep bump to `0.2.0-pre.11`.
+
+## Release
+Dedicated **`0.2.0-pre.11`** off `main`, lockstep bump (all packages), **SECURITY** CHANGELOG note:
+"`openVault` no longer self-provisions an owner keyring into a vault held by other principals —
+opening a populated vault you lack a grant to now fails closed with `NoAccessError`. New
+(genuinely-empty) vaults still open-or-create as before. New opt-in `openVault({ create: false })`
+forces strict open-existing." Behavior change is a security fix (the prior behavior was a hole);
+not a breaking API change (the signature is additive).
+
+## Relationship to existing work
+| Prior work | Relationship |
+|---|---|
+| #312 / cross-vault slice | Introduced the `create` flag for the fan-out; #313 owns it + the global semantics, lands first |
+| `adoptPartition` (`bundle/adopt-partition.ts`) | Already guards `store.list('_keyring')`; unaffected reference for the same pattern |
+| `_shardVaultProvisioned` (`noydb.ts:1026`) | Same `store.list(vault,'_keyring').length` check, reused as the genuinely-new discriminator |
+| `getKeyring` callback / `onInvalidKey:'reset'` | Out of scope — both already avoid the implicit create |

--- a/packages/as-blob/package.json
+++ b/packages/as-blob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-blob",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Single-attachment plaintext export for noy-db — extracts one blob from BlobSet as native MIME bytes. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier, document sub-family).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-csv/package.json
+++ b/packages/as-csv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-csv",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "CSV plaintext export for noy-db — decrypts records and formats as comma-separated values. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-json/package.json
+++ b/packages/as-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-json",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Structured JSON plaintext export for noy-db — decrypts records and emits one JSON document per vault. Gated by RFC #249 canExportPlaintext capability; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-ndjson/package.json
+++ b/packages/as-ndjson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-ndjson",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Newline-delimited JSON export for noy-db — streaming plaintext export suitable for data pipelines, warehouse ingestion, and jq pipelines. Gated by RFC #249 canExportPlaintext. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-noydb/package.json
+++ b/packages/as-noydb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-noydb",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Encrypted .noydb bundle export for noy-db — wraps writeNoydbBundle() with the RFC #249 canExportBundle authorization gate and ergonomic browser/node helpers. Sole member of the @noy-db/as-* encrypted tier — ciphertext in, ciphertext out.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-sql/package.json
+++ b/packages/as-sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-sql",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "SQL dump export for noy-db — decrypts records and emits dialect-aware CREATE TABLE + INSERT statements for postgres / mysql / sqlite. One-way migration helper. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xlsx/package.json
+++ b/packages/as-xlsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xlsx",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Excel spreadsheet plaintext export for noy-db — produces a real .xlsx (Office Open XML) from one or more collections. Multi-sheet, Unicode-safe via shared-strings table. Zero runtime deps beyond the workspace zip encoder. Gated by RFC #249 `canExportPlaintext` with format `'xlsx'`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xml/package.json
+++ b/packages/as-xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xml",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "XML plaintext export for noy-db — decrypts records and formats as XML with RFC-compliant entity escaping. For legacy systems, banking batch imports, SOAP endpoints, and accounting software that requires XML. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-zip/package.json
+++ b/packages/as-zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-zip",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Composite record + blob archive export for noy-db — bundles a collection's records plus every attached blob into one zip. Zero dependencies (STORE-only zip encoder). Gated by the RFC #249 `canExportPlaintext` capability bit with format `'zip'`. Part of the @noy-db/as-* portable-artefact family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-aws-kms/package.json
+++ b/packages/at-aws-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-aws-kms",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "AWS KMS sealing key provider for noy-db managed-passphrase mode — seal/unseal via KMS Encrypt/Decrypt, with KMS access logs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-azure-keyvault/package.json
+++ b/packages/at-azure-keyvault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-azure-keyvault",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Azure Key Vault sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-env/package.json
+++ b/packages/at-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-env",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Env-var sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a key from process.env. Smallest production-shape provider; pair with Kubernetes Secrets / Heroku env / AWS Secrets Manager.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-gcp-kms/package.json
+++ b/packages/at-gcp-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-gcp-kms",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Google Cloud KMS sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-macos-keychain/package.json
+++ b/packages/at-macos-keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-macos-keychain",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "macOS Keychain sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a 32-byte key stored in the user's login Keychain. Desktop-app provider in the at-* family; pairs with Touch ID via Keychain Access UI.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/attestation/package.json
+++ b/packages/attestation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/attestation",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Pure, zero-dependency document-attestation primitive for noy-db — per-field salted commitments, Ed25519 sign/verify, QR credential codec, and revocation checks. Runs in Node and the browser; the offline verifier imports only this.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-peer/package.json
+++ b/packages/by-peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-peer",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "WebRTC peer-to-peer transport for noy-db — direct browser-to-browser channel with signaling-agnostic handshake",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-tabs/package.json
+++ b/packages/by-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-tabs",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "BroadcastChannel multi-tab transport for noy-db — sync between tabs of the same browser without round-tripping the storage backend",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/cli",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Command-line tool for noy-db — inspect .noydb bundles without decrypting, verify integrity, validate config objects, scaffold topology profiles, and monitor a live vault's store metrics.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/create-noy-db/package.json
+++ b/packages/create-noy-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-noy-db",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Wizard + CLI tool for noy-db: scaffold a fresh Nuxt 4 + Pinia encrypted store, or add collections to an existing project. Invoke via `npm create @noy-db`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/hub/CHANGELOG.md
+++ b/packages/hub/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog — hub
 
+## 0.2.0-pre.11
+
+### Security: `openVault` no longer self-provisions into another principal's vault ([#313](https://github.com/vLannaAi/noy-db/issues/313))
+
+- Opening a vault you hold **no grant** to that is **already held by other principals** now fails closed with `NoAccessError` and writes **nothing** — previously it silently minted a fresh owner keyring (new DEKs) into that vault and then read zero records. Genuinely-new vaults (no `_keyring/*`) still open-or-create exactly as before.
+- New opt-in **`openVault({ create: false })`** (and `queryAcross({ create: false })`) forces strict open-existing: a missing grant throws `NoAccessError` instead of creating.
+- The gate sits **before** managed-passphrase secret resolution, so managed (KMS-sealed) mode also writes nothing on the fail-closed path. The `getKeyring` callback path and `onInvalidKey: 'reset'` are unchanged.
+
 ## 0.2.0-pre.10
 
 Adopter-reported correctness + introspection batch.

--- a/packages/hub/__tests__/no-self-provision.test.ts
+++ b/packages/hub/__tests__/no-self-provision.test.ts
@@ -74,6 +74,15 @@ function trackingMemory() {
         writes.push(`${c}/${col}/${id}`)
         return base.put(c, col, id, env, ev)
       },
+      async saveAll(c: string, data: Record<string, Record<string, EncryptedEnvelope>>) {
+        for (const [col, recs] of Object.entries(data))
+          for (const id of Object.keys(recs)) writes.push(`${c}/${col}/${id}`)
+        return base.saveAll(c, data)
+      },
+      async delete(c: string, col: string, id: string) {
+        writes.push(`${c}/${col}/${id}:delete`)
+        return base.delete(c, col, id)
+      },
     } as NoydbStore,
     writesSince(mark: number) { return writes.slice(mark) },
     mark() { return writes.length },
@@ -132,6 +141,16 @@ describe('openVault no-self-provision (#313)', () => {
     const db = await createNoydb({ store: adapter, user: 'alice', secret: 'alice-pass' })
     await expect(db.openVault('fresh', { create: false })).rejects.toBeInstanceOf(NoAccessError)
     expect(await adapter.get('fresh', '_keyring', 'alice')).toBeNull()
+  })
+
+  it('create:false on a populated vault succeeds for a granted member', async () => {
+    const { adapter } = trackingMemory()
+    const alice = await createNoydb({ store: adapter, user: 'alice', secret: 'alice-pass' })
+    await (await alice.openVault('client-1')).collection<{ n: number }>('c').put('r1', { n: 1 })
+    await alice.grant('client-1', { userId: 'bob', displayName: 'Bob', role: 'viewer', passphrase: 'bob-pass', allowWeakPassphrase: true })
+    const bob = await createNoydb({ store: adapter, user: 'bob', secret: 'bob-pass' })
+    const bv = await bob.openVault('client-1', { create: false })
+    expect(await bv.collection<{ n: number }>('c').get('r1')).toEqual({ n: 1 })
   })
 
   it('a granted member opens fine and can read records', async () => {

--- a/packages/hub/__tests__/no-self-provision.test.ts
+++ b/packages/hub/__tests__/no-self-provision.test.ts
@@ -1,0 +1,153 @@
+/**
+ * #313 — openVault no-self-provision.
+ *
+ * Verifies that opening a vault you hold no grant to that is already
+ * held by other principals fails closed (NoAccessError) and writes
+ * NOTHING into the vault — including managed-passphrase mode where
+ * resolveManagedSecret would otherwise persist _meta/sealed-passphrase
+ * before the loadKeyring check fires.
+ *
+ * The pre-gate sits in getKeyringInternal BEFORE resolveManagedSecret
+ * (not in the loadKeyring catch) specifically to prevent that write.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError, NoAccessError } from '../src/errors.js'
+import { createNoydb } from '../src/noydb.js'
+import {
+  MemorySealingKeyProvider,
+} from '../src/team/managed-passphrase.js'
+import { shamirRecoveryProvider } from '@noy-db/on-shamir'
+
+// Inline memory adapter (same shape as cross-vault.test.ts)
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+    async listVaults() { return [...store.keys()] },
+  }
+}
+
+/**
+ * Wraps a NoydbStore adapter and tracks every (compartment/collection/id)
+ * triple that is written via put(). Enables assertions like
+ * "nothing was written after mark X".
+ */
+function trackingMemory() {
+  const base = memory()
+  const writes: string[] = []
+  return {
+    adapter: {
+      ...base,
+      async put(c: string, col: string, id: string, env: EncryptedEnvelope, ev?: number) {
+        writes.push(`${c}/${col}/${id}`)
+        return base.put(c, col, id, env, ev)
+      },
+    } as NoydbStore,
+    writesSince(mark: number) { return writes.slice(mark) },
+    mark() { return writes.length },
+  }
+}
+
+describe('openVault no-self-provision (#313)', () => {
+  it('default: bob opening alice\'s populated vault fails closed and writes nothing', async () => {
+    const { adapter, mark, writesSince } = trackingMemory()
+    const alice = await createNoydb({ store: adapter, user: 'alice', secret: 'alice-pass' })
+    const av = await alice.openVault('client-1')
+    await av.collection<{ n: number }>('c').put('r1', { n: 1 })
+
+    const bob = await createNoydb({ store: adapter, user: 'bob', secret: 'bob-pass' })
+    const m = mark()
+    await expect(bob.openVault('client-1')).rejects.toBeInstanceOf(NoAccessError)
+    expect(writesSince(m)).toEqual([])          // NOTHING written after alice populated the vault
+    expect(await adapter.get('client-1', '_keyring', 'bob')).toBeNull()
+  })
+
+  it('MANAGED mode: bob (managed) opening alice\'s vault fails closed and writes no _meta/sealed-passphrase', async () => {
+    const { adapter, mark, writesSince } = trackingMemory()
+
+    // alice creates + populates with a standard secret-based vault
+    const alice = await createNoydb({ store: adapter, user: 'alice', secret: 'alice-pass' })
+    await (await alice.openVault('client-1')).collection<{ n: number }>('c').put('r1', { n: 1 })
+
+    // bob uses managed mode — resolveManagedSecret would write _meta/sealed-passphrase
+    // on first open if the pre-gate weren't there
+    const bobProvider = new MemorySealingKeyProvider({ id: 'test-kms' })
+    const bob = await createNoydb({
+      store: adapter,
+      user: 'bob',
+      passphraseMode: 'managed',
+      sealingKey: bobProvider,
+      shamirRecovery: shamirRecoveryProvider(),
+    })
+    const m = mark()
+    await expect(bob.openVault('client-1')).rejects.toBeInstanceOf(NoAccessError)
+    // The pre-gate must fire BEFORE resolveManagedSecret, so no _meta/sealed-passphrase
+    // or any other artifact is written into client-1.
+    expect(writesSince(m)).toEqual([])          // nothing written — gate is before resolveManagedSecret
+    expect(await adapter.get('client-1', '_meta', 'sealed-passphrase')).toBeNull()
+  })
+
+  it('new vault still open-or-creates (default)', async () => {
+    const { adapter } = trackingMemory()
+    const db = await createNoydb({ store: adapter, user: 'alice', secret: 'alice-pass' })
+    const v = await db.openVault('fresh')
+    await v.collection<{ n: number }>('c').put('r1', { n: 1 })
+    expect(await adapter.get('fresh', '_keyring', 'alice')).not.toBeNull()
+  })
+
+  it('create:false never creates, even a fresh vault', async () => {
+    const { adapter } = trackingMemory()
+    const db = await createNoydb({ store: adapter, user: 'alice', secret: 'alice-pass' })
+    await expect(db.openVault('fresh', { create: false })).rejects.toBeInstanceOf(NoAccessError)
+    expect(await adapter.get('fresh', '_keyring', 'alice')).toBeNull()
+  })
+
+  it('a granted member opens fine and can read records', async () => {
+    const { adapter } = trackingMemory()
+    const alice = await createNoydb({ store: adapter, user: 'alice', secret: 'alice-pass' })
+    await (await alice.openVault('client-1')).collection<{ n: number }>('c').put('r1', { n: 1 })
+    await alice.grant('client-1', {
+      userId: 'bob',
+      displayName: 'Bob',
+      role: 'viewer',
+      passphrase: 'bob-pass',
+      allowWeakPassphrase: true,
+    })
+
+    const bob = await createNoydb({ store: adapter, user: 'bob', secret: 'bob-pass' })
+    const bv = await bob.openVault('client-1')
+    expect(await bv.collection<{ n: number }>('c').get('r1')).toEqual({ n: 1 })
+  })
+})

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/hub",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Zero-knowledge, offline-first, encrypted document store — core library with AES-256-GCM, PBKDF2, multi-user keyring, and sync engine",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -85,6 +85,7 @@ import { CrossTabWriteRelay } from './tab-write-relay.js'
 import {
   loadKeyring,
   createOwnerKeyring,
+  assertKeyringOpenAllowed,
   grant as keyringGrant,
   revoke as keyringRevoke,
   rotateKeys as keyringRotate,
@@ -2687,33 +2688,12 @@ export class Noydb {
       return keyring
     }
 
-    // Pre-gate (#313): decide create-vs-fail BEFORE any vault write.
-    // resolveManagedSecret (below) persists _meta/sealed-passphrase on
-    // first open — a gate placed after it would write an artifact before
-    // failing. One capability-free store.list; membership = caller has a
-    // keyring row. Three outcomes:
-    //   - caller IS a member → fall through (existing keyring loaded normally)
-    //   - caller NOT a member, create:false → fail immediately (strict open-existing)
-    //   - caller NOT a member, other keyrings present → fail closed (no self-provision)
-    //   - caller NOT a member, no keyrings at all → genuinely-new vault → fall through
-    // Note: encrypt:false returned a plaintext keyring above, so we are always on the
-    // encrypted path here — the outer encrypt check is intentionally omitted.
-    const keyringUsers = await this.options.store.list(vault, '_keyring')
-    if (!keyringUsers.includes(this.options.user)) {
-      if (opts.create === false) {
-        throw new NoAccessError(
-          `Vault "${vault}" not opened: create disabled and no keyring for "${this.options.user}".`,
-        )
-      }
-      if (keyringUsers.length > 0) {
-        throw new NoAccessError(
-          `No keyring for user "${this.options.user}" in vault "${vault}" `
-          + `(held by other principals) — refusing to self-provision.`,
-        )
-      }
-      // else: genuinely-new vault (no _keyring/* at all) → fall through to the
-      // normal loadKeyring → NoAccessError → createOwnerKeyring path.
-    }
+    // Pre-gate (#313): refuse to self-provision into a vault held by other
+    // principals; create-on-open only for a genuinely-new vault. Runs BEFORE
+    // resolveManagedSecret (which persists on first open) so a fail-closed open
+    // writes nothing. encrypt:false returned a plaintext keyring above, so we're
+    // always on the encrypted path here. Logic lives in team/keyring.ts.
+    await assertKeyringOpenAllowed(this.options.store, vault, this.options.user, opts.create)
 
     // Managed-passphrase mode — resolve the effective secret
     // before falling into the normal load/create path. The first call

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -404,7 +404,7 @@ export class Noydb {
    */
   async openVault(
     name: string,
-    opts?: { locale?: string },
+    opts?: { locale?: string; create?: boolean },
   ): Promise<Vault> {
     if (this.closed) throw new ValidationError('Instance is closed')
     this.touchPolicy(name)
@@ -418,7 +418,7 @@ export class Noydb {
       return comp
     }
 
-    const keyring = await this.getKeyringInternal(name)
+    const keyring = await this.getKeyringInternal(name, { create: opts?.create !== false })
     // Tier-1 unlock — passphrase / getKeyring callbacks both yield the
     // most-privileged tier. Tier-2 / tier-3 unlocks install
     // a lower tier here when they land.
@@ -954,7 +954,7 @@ export class Noydb {
       const vaultId = vaultIds[idx]!
       const task = (async () => {
         try {
-          const comp = await this.openVault(vaultId)
+          const comp = await this.openVault(vaultId, { create: options.create !== false })
           const result = await fn(comp)
           results[idx] = { vault: vaultId, result }
         } catch (err) {
@@ -2667,7 +2667,10 @@ export class Noydb {
    * accesses see them. Not exposed publicly — callers outside hub
    * should use {@link getKeyring}, which returns a defensive copy.
    */
-  private async getKeyringInternal(vault: string): Promise<UnlockedKeyring> {
+  private async getKeyringInternal(
+    vault: string,
+    opts: { create: boolean } = { create: true },
+  ): Promise<UnlockedKeyring> {
     if (this.options.encrypt === false) {
       return createPlaintextKeyring(this.options.user)
     }
@@ -2682,6 +2685,34 @@ export class Noydb {
       const keyring = await this.options.getKeyring(vault)
       this.keyringCache.set(vault, keyring)
       return keyring
+    }
+
+    // Pre-gate (#313): decide create-vs-fail BEFORE any vault write.
+    // resolveManagedSecret (below) persists _meta/sealed-passphrase on
+    // first open — a gate placed after it would write an artifact before
+    // failing. One capability-free store.list; membership = caller has a
+    // keyring row. Three outcomes:
+    //   - caller IS a member → fall through (existing keyring loaded normally)
+    //   - caller NOT a member, create:false → fail immediately (strict open-existing)
+    //   - caller NOT a member, other keyrings present → fail closed (no self-provision)
+    //   - caller NOT a member, no keyrings at all → genuinely-new vault → fall through
+    // Note: encrypt:false returned a plaintext keyring above, so we are always on the
+    // encrypted path here — the outer encrypt check is intentionally omitted.
+    const keyringUsers = await this.options.store.list(vault, '_keyring')
+    if (!keyringUsers.includes(this.options.user)) {
+      if (opts.create === false) {
+        throw new NoAccessError(
+          `Vault "${vault}" not opened: create disabled and no keyring for "${this.options.user}".`,
+        )
+      }
+      if (keyringUsers.length > 0) {
+        throw new NoAccessError(
+          `No keyring for user "${this.options.user}" in vault "${vault}" `
+          + `(held by other principals) — refusing to self-provision.`,
+        )
+      }
+      // else: genuinely-new vault (no _keyring/* at all) → fall through to the
+      // normal loadKeyring → NoAccessError → createOwnerKeyring path.
     }
 
     // Managed-passphrase mode — resolve the effective secret

--- a/packages/hub/src/team/keyring.ts
+++ b/packages/hub/src/team/keyring.ts
@@ -290,6 +290,36 @@ export async function loadKeyring(
 }
 
 /**
+ * Open-policy pre-gate (#313): decide create-vs-fail-closed **before** any
+ * vault write. `openVault` must not self-provision an owner keyring into a
+ * vault held by other principals; create-on-open is allowed only for a
+ * genuinely-new vault (no `_keyring/*` at all). Capability-free — one
+ * `store.list`. Returns when the open may proceed (the caller is a member, or
+ * the vault is genuinely-new and `create` is allowed, in which case the caller
+ * falls through to the normal `createOwnerKeyring` path); throws `NoAccessError`
+ * otherwise. Placed before managed-passphrase secret resolution (which persists
+ * on first open), so a fail-closed open writes nothing.
+ */
+export async function assertKeyringOpenAllowed(
+  store: NoydbStore,
+  vault: string,
+  userId: string,
+  create: boolean,
+): Promise<void> {
+  const keyringUsers = await store.list(vault, '_keyring')
+  if (keyringUsers.includes(userId)) return // caller is a member → load existing
+  if (!create) {
+    throw new NoAccessError(`Vault "${vault}" not opened: create disabled and no keyring for "${userId}".`)
+  }
+  if (keyringUsers.length > 0) {
+    throw new NoAccessError(
+      `No keyring for user "${userId}" in vault "${vault}" (held by other principals) — refusing to self-provision.`,
+    )
+  }
+  // empty → genuinely-new vault → caller proceeds to the create path
+}
+
+/**
  * Create the initial owner keyring for a new vault.
  *
  * Pass `{ validate: true }` (or a `PassphrasePolicy`) to gate creation

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -1191,6 +1191,14 @@ export interface QueryAcrossOptions {
    * adapters where the disk I/O serializes anyway.
    */
   readonly concurrency?: number
+  /**
+   * Open shards non-creatingly — a missing grant throws instead of
+   * self-provisioning. Default: `true` (create iff the vault has no
+   * `_keyring/*`). Pass `false` for strict open-existing semantics
+   * (e.g. federation read fan-out where shards are pre-provisioned
+   * and an absent grant should fail closed).
+   */
+  readonly create?: boolean
 }
 
 /**

--- a/packages/in-ai/package.json
+++ b/packages/in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-ai",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "LLM function-calling adapter for noy-db — expose ACL-scoped collections as tool definitions, then dispatch tool calls back to the vault. Format-agnostic (OpenAI, Anthropic, Vercel AI SDK).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-devtools-tui/package.json
+++ b/packages/in-devtools-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-devtools-tui",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Interactive terminal inspector for a live noy-db (ink TUI over @noy-db/in-devtools).",
   "license": "MIT",
   "type": "module",

--- a/packages/in-devtools/package.json
+++ b/packages/in-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-devtools",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Framework-agnostic read-only inspector for a live noy-db — vaults, collections, schema, stats, records, and live writes.",
   "license": "MIT",
   "type": "module",

--- a/packages/in-nextjs/package.json
+++ b/packages/in-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nextjs",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Next.js App Router helpers for noy-db — server components, route handlers, client hooks, and cookie-based session. Thin bridge that composes @noy-db/in-react with Next's cookies()/headers() APIs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-nuxt/package.json
+++ b/packages/in-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nuxt",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Nuxt 4 module for noy-db — auto-imports, SSR-safe runtime plugin, and the @noy-db/in-pinia bridge",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-pinia/package.json
+++ b/packages/in-pinia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-pinia",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Pinia integration for noy-db — defineNoydbStore() and the augmentation plugin for existing stores",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-react/package.json
+++ b/packages/in-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-react",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "React hooks for noy-db — useNoydb, useVault, useCollection, useQuery, useSync. Uses useSyncExternalStore for reactive subscriptions. Zero deps beyond React.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-rest/package.json
+++ b/packages/in-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-rest",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Framework-neutral REST API integration for noy-db — createRestHandler with Hono, Express, Fastify, and Nitro subpath adapters.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-solid/package.json
+++ b/packages/in-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-solid",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "SolidJS signal primitives for noy-db — createCollectionSignal, createQuerySignal, createSyncSignal backed by noy-db change events.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-svelte/package.json
+++ b/packages/in-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-svelte",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Svelte stores for noy-db — collectionStore / queryStore / syncStore backed by noy-db change events. Works with Svelte 4 store contract and Svelte 5 runes (via $store subscription interop).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-query/package.json
+++ b/packages/in-tanstack-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-query",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "TanStack Query adapter for noy-db — queryFn + mutationFn helpers that speak the Collection API, plus automatic invalidation from noy-db change events. Framework-agnostic (React / Vue / Solid / Svelte).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-table/package.json
+++ b/packages/in-tanstack-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-table",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "TanStack Table bridge for noy-db — map Collection query state (sort, filter, pagination) into Table state and back, so a useSmartTable pattern drives the DB's query DSL without glue code.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-vue/package.json
+++ b/packages/in-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-vue",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Vue 3 / Nuxt composables for noy-db — reactive useNoydb, useCollection, useSync, and biometric plugin",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-yjs/package.json
+++ b/packages/in-yjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-yjs",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Yjs Y.Doc interop for noy-db — collaborative rich-text fields with encrypted-at-rest Yjs state",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-zustand/package.json
+++ b/packages/in-zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-zustand",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Zustand adapter for noy-db — factory that mirrors defineNoydbStore for Zustand users, auto-syncs state from noy-db change events, and supports optimistic mutations.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-email-otp/package.json
+++ b/packages/on-email-otp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-email-otp",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Email OTP second factor for noy-db — generates time-boxed one-time codes, delivers via a user-supplied transport (SMTP / SES / Postmark / any fn), and verifies in constant time. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-magic-link/package.json
+++ b/packages/on-magic-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-magic-link",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Magic-link unlock for noy-db — one-time URL that opens a vault in a viewer-scoped session without a passphrase. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-oidc/package.json
+++ b/packages/on-oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-oidc",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "OAuth/OIDC bridge for noy-db — federated login (LINE, Google, Apple, Okta) with split-key key connector — server never sees plaintext",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-password/package.json
+++ b/packages/on-password/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-password",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Tier-2 password authenticator slot for noy-db. PBKDF2-SHA256 600K wraps the DEK set in its own keyring slot, distinct from the rarely-typed tier-1 phrase. Pair with @noy-db/on-email-otp or @noy-db/on-totp for the SaaS UX.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-pin/package.json
+++ b/packages/on-pin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-pin",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Session-resume PIN quick-lock for noy-db — after a full passphrase unlock, a short-lived PIN (or a per-device biometric) re-unlocks the cached DEKs without re-typing the passphrase. PIN never replaces the passphrase; only resumes an already-unlocked session.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-recovery/package.json
+++ b/packages/on-recovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-recovery",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "One-time printable recovery codes for noy-db — last-resort vault unlock when the passphrase, passkey, and OIDC provider are all unavailable. Base32 + checksum codes, PBKDF2-derived wrapping keys, burn-on-use. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-shamir/package.json
+++ b/packages/on-shamir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-shamir",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "k-of-n Shamir Secret Sharing of the vault KEK for multi-party unlock. Any K of N shares recombines the key; fewer than K leaks zero bits. Composable — each share can be protected by any other on-* method. Zero runtime dependencies.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-threat/package.json
+++ b/packages/on-threat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-threat",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Threat-response primitives for noy-db — multi-attempt lockout, duress-passphrase data destruction, duress-passphrase honeypot decoy. Pure stateful helpers; the caller coordinates keyring + audit-ledger integration. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-totp/package.json
+++ b/packages/on-totp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-totp",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "TOTP (RFC 6238) authenticator-app second factor for noy-db — generate secrets, otpauth:// provisioning URIs, and constant-time code verification. Zero dependencies (HMAC-SHA1 via Web Crypto). Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-webauthn/package.json
+++ b/packages/on-webauthn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-webauthn",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "WebAuthn hardware-key keyrings for noy-db — Touch ID, Face ID, Windows Hello, YubiKey, FIDO2 passkeys",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-aws-dynamo/package.json
+++ b/packages/to-aws-dynamo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-aws-dynamo",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "AWS DynamoDB adapter for noy-db — single-table design, zero-knowledge cloud sync",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-aws-s3/package.json
+++ b/packages/to-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-aws-s3",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "AWS S3 adapter for noy-db — encrypted object storage with zero-knowledge cloud sync",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-browser-idb/package.json
+++ b/packages/to-browser-idb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-browser-idb",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "IndexedDB adapter for noy-db with optional key obfuscation",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-browser-local/package.json
+++ b/packages/to-browser-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-browser-local",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "localStorage adapter for noy-db with optional key obfuscation",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-cloudflare-d1/package.json
+++ b/packages/to-cloudflare-d1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-cloudflare-d1",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Cloudflare D1 adapter for noy-db — SQLite at the edge, running inside Cloudflare Workers. Accepts a D1Database binding and speaks the noy-db store contract via D1's prepare/bind API.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-cloudflare-r2/package.json
+++ b/packages/to-cloudflare-r2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-cloudflare-r2",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Cloudflare R2 adapter for noy-db — S3-compatible object storage with zero egress fees. Thin wrapper around @noy-db/to-aws-s3 configured for the R2 endpoint. casAtomic: false (same caveat as S3).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-drive/package.json
+++ b/packages/to-drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-drive",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Google Drive bundle store for noy-db. Stores the whole vault as a single .noydb file in Drive's hidden appDataFolder; opaque ULID filenames never leak compartment names. Driver-agnostic — bring your own OAuth token.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-file/package.json
+++ b/packages/to-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-file",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "JSON file adapter for noy-db — encrypted document store on local disk, USB sticks, or network drives",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-icloud/package.json
+++ b/packages/to-icloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-icloud",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "iCloud Drive bundle store for noy-db — macOS-aware persistence that detects eviction stubs (.icloud) and conflict files automatically. Treats each vault as a single .noydb bundle, safe for the Apple ecosystem.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-memory/package.json
+++ b/packages/to-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-memory",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "In-memory adapter for noy-db — ideal for testing, development, and ephemeral workloads",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-meter/package.json
+++ b/packages/to-meter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-meter",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Pass-through meter for @noy-db/to-* stores — wraps any NoydbStore and records per-method latency percentiles, error rates, and byte counts on real traffic. Optional synthetic liveness probe emits degraded / restored events. No synthetic benchmarks (see @noy-db/to-probe for that) — this measures what your app is actually doing.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-mysql/package.json
+++ b/packages/to-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-mysql",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "MySQL / MariaDB adapter for noy-db — encrypted-envelope KV with JSON column. Works with any duck-typed mysql2-style pool/connection. casAtomic: true via UPDATE … WHERE v = ?.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-nfs/package.json
+++ b/packages/to-nfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-nfs",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "NFS network-file store for noy-db. Same indexed layout as @noy-db/to-file, with pre-flight checks for nolock / noac mount options that silently break versioning guarantees on stock NFS mounts.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-postgres/package.json
+++ b/packages/to-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-postgres",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "PostgreSQL adapter for noy-db — encrypted-envelope KV with jsonb column. Works with any duck-typed pg-style Client (node-postgres, postgres.js, pg-native, Supabase, Neon serverless). casAtomic: true via UPDATE … WHERE _v = ?.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-probe/package.json
+++ b/packages/to-probe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-probe",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Diagnostic companion for the @noy-db/to-* store family — not itself a storage backend. Setup-time suitability test + topology check + runtime reliability monitor. Exercises the 6-method NoydbStore contract across five axes (write latency, CAS integrity, hydration cost, sync economics, network resilience) and produces a structured risk-scored report.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-smb/package.json
+++ b/packages/to-smb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-smb",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "SMB/CIFS network file store for noy-db. Works against Windows file servers, NAS devices (Synology/QNAP/Netgear), and corporate shared drives via NTLM or Kerberos auth — no OS mount required.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-sqlite/package.json
+++ b/packages/to-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-sqlite",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "SQLite adapter for noy-db — single-file local encrypted document store. Works with better-sqlite3, node:sqlite (Node 22+), or bun:sqlite via a duck-typed Database interface. casAtomic: true (BEGIN IMMEDIATE + UPDATE WHERE _v=?).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-ssh/package.json
+++ b/packages/to-ssh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-ssh",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "SSH/SFTP store for noy-db — remote encrypted document storage over SSH using public-key auth. Any Linux/macOS server with sshd running becomes a noy-db backend; leverages existing ~/.ssh keys or ssh-agent. Key-only auth (no passwords).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-supabase/package.json
+++ b/packages/to-supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-supabase",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Supabase adapter for noy-db — Postgres + Storage combo. Routes records to @noy-db/to-postgres via the Supabase Postgres pool and optional blob routing via Supabase Storage.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-turso/package.json
+++ b/packages/to-turso/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-turso",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "Turso / libSQL adapter for noy-db — edge SQLite with built-in replication. Wraps @libsql/client through a small async shim that speaks the same noy-db store contract as @noy-db/to-sqlite.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-webdav/package.json
+++ b/packages/to-webdav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-webdav",
-  "version": "0.2.0-pre.10",
+  "version": "0.2.0-pre.11",
   "description": "WebDAV adapter for noy-db — encrypted object storage over the WebDAV protocol. Works with Nextcloud, ownCloud, Apache mod_dav, and any RFC 4918 server. Pure fetch()-based, zero dependencies.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",


### PR DESCRIPTION
**Security / key-custody fix.** Dedicated `0.2.0-pre.11`.

## Problem
`openVault` on a vault you lack a grant to **silently minted a fresh owner keyring (new DEKs) into that vault** and then read zero records — no error. `loadKeyring` throws `NoAccessError` when *this* user's `_keyring/<user>` is absent without checking for other principals; `getKeyringInternal` treated that as "first boot" and called `createOwnerKeyring`. Surfaces under scoped multi-principal access.

## Fix
A pre-gate in `getKeyringInternal`, placed **before** `resolveManagedSecret` (which persists `_meta/sealed-passphrase` on first open), via one capability-free `store.list(vault,'_keyring')` membership check (extracted to `team/keyring.ts` as `assertKeyringOpenAllowed`):
- caller is a member → load existing;
- not a member, `create:false` → throw (strict open-existing);
- not a member, other keyrings present → **throw, fail closed, write nothing**;
- not a member, no keyrings at all → genuinely-new → create as before.

Additive `openVault({ create?: boolean })` + `queryAcross({ create?: boolean })` (default unchanged).

## Verification
- [x] Blast-radius sweep: **zero** bug-reliant tests (no legitimate path opens a populated vault it doesn't own).
- [x] 6 tests incl. **managed-mode no-write** (the pre-gate-placement case) — fail-closed asserts *nothing* is written.
- [x] Full suite 2171, typecheck, validate-features, architecture (noydb.ts 2910 < 2920) all green.
- [x] `getKeyring` callback path / `onInvalidKey:'reset'` / plaintext untouched.

Closes #313.