### PR TITLE
feat(hub): Cluster B — atomic sequence (#303) + forget-cascade design spec (#304)

### DIFF
--- a/docs/superpowers/specs/2026-06-08-forget-cascade-design.md
+++ b/docs/superpowers/specs/2026-06-08-forget-cascade-design.md
@@ -69,3 +69,13 @@ const result = await vault.forget('buyer-123')
 - [ ] predicate/subject-scoped CEK shred (record bodies + history unrecoverable)
 - [ ] ledger hash-chain still verifies after a shred
 - [ ] portable expression of "all records of subject X" (the encrypted subject index)
+
+## Coupled work — #306 record-scoped sealed slices
+
+#306 ("tighten server-side `at-*` decryption to one record") rides on the **same per-record CEK** introduced here, so the two should be built together.
+
+Today, sealing operates on **per-collection DEKs** (`{ collection: rawDEK }` maps — see `bundle/extract-partition.ts`), so granting an `at-*` host (e.g. `at-aws-kms`) access to one record means sealing the **whole collection's** key. **Permission-level** record narrowing already exists — `@noy-db/on-magic-link`'s `MagicLinkGrantSpec` carries `collection?` + `record?`, and `db.grant` restricts which records a viewer may read — but that is an *authorization* restriction; the grantee still holds the collection DEK and could decrypt other records if it bypassed the permission layer.
+
+#306's actual ask is **crypto-level** least-privilege: *"host denied any record outside the grant"* + *"CloudTrail-observable scope"*. That requires sealing **only the granted record's CEK** to the host — impossible until per-record CEKs exist. So #306 = "seal a single CEK (not the collection DEK) to an `at-*` recipient," layered on step 1 above (recipient-target sealing already exists; the change is sealing a CEK instead of a collection DEK).
+
+**Recommendation:** track #304 and #306 as one security epic. Build order: per-record CEK (step 1) → `withForgetCascade` (#304) → record-scoped CEK sealing to `at-*` hosts (#306).

--- a/docs/superpowers/specs/2026-06-08-forget-cascade-design.md
+++ b/docs/superpowers/specs/2026-06-08-forget-cascade-design.md
@@ -1,0 +1,71 @@
+# withForgetCascade — DEK crypto-shred for right-to-erasure (DESIGN ONLY)
+
+**Issue:** #304 · **Layer:** Store / crypto · **Status:** design spec — **not implemented**. This is a security-critical change to the core encryption path and warrants a dedicated, reviewed effort. This document resolves the two open questions the Dim-11 spec flagged and scopes the build.
+
+## Problem
+
+GDPR right-to-erasure in an encrypted-by-default store: overwriting PII does not erase it (copies, backups, and `_history` retain prior ciphertext). The clean resolution is **crypto-shred** — destroy the key so the ciphertext is permanently undecryptable everywhere it exists.
+
+## The blocker (why this is not a small feature)
+
+**The DEK is per-collection** (`getDEK(collectionName)` — every record body and every `_history` envelope in a collection encrypts under one key). Shredding that key would erase the **entire collection**, not one data subject. Selective per-subject erasure is therefore impossible on the current architecture; it requires finer key granularity.
+
+## Design: per-record content-encryption keys (CEK)
+
+Introduce a **per-record CEK**:
+
+1. On write, generate a random CEK; encrypt the record body (and each history version) under it.
+2. **Wrap** the CEK under the collection DEK (AES-KW, as DEKs are wrapped under the KEK today); store the wrapped CEK alongside the envelope (a new `_cek` field, or a sibling `_ceks/<collection>/<id>` record).
+3. Decryption: unwrap the CEK with the collection DEK, then decrypt the body.
+
+Crypto-shred is then: **delete the wrapped CEK.** The body ciphertext (and all history versions under the same CEK) becomes permanently undecryptable — across every store and backup that doesn't hold the CEK — while the collection DEK (and thus every *other* record) is untouched.
+
+## Open question 1 — expressing "all records of subject X" portably
+
+Resolved with a **declared subject field + an encrypted subject index**:
+
+```ts
+withForgetCascade({ subjectField: 'buyerId' })   // per collection, or vault-wide map
+```
+
+- On write, extract `record[subjectField]` and maintain an **encrypted** index `subject → [{collection, id}]` (a reserved `_subject_index` collection, encrypted under its own DEK). The index travels with the vault/bundle, so erasure is portable.
+- **Rejected alternative:** an unencrypted subject tag in the envelope metadata (findable without decrypting) — it leaks subject-equivalence (which records share a subject), violating the non-correlation invariant. The encrypted index avoids the leak at the cost of write-time maintenance.
+
+`vault.forget(subjectId)` consults the index, then shreds each record's CEK.
+
+## Open question 2 — composition with withHistory
+
+Each record's **entire version chain shares the record's CEK** (every `_history` envelope for that record is encrypted under it). So a single CEK delete makes the current value **and all prior versions** unrecoverable in one operation — exactly the audit-vs-erasure resolution:
+
+- The **ledger hash-chain stays intact** — it stores `payloadHash` (a hash of former plaintext) and `prevHash` links, never plaintext. Chain `verify()` still passes after a shred.
+- `forget()` appends an **erasure ledger entry** (`op: 'forget'`, subject-hash, count, ts, actor) — so the ledger *proves* "subject X's data existed and was erased on date D" without retaining the data.
+
+## API (proposed)
+
+```ts
+createNoydb({ /* … */ forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId', … } }) })
+
+const result = await vault.forget('buyer-123')
+// → { subject, recordsShredded, historyVersionsShredded, collections, ledgerEntry }
+```
+
+## Build scope & risks (why a dedicated effort)
+
+- **Core-crypto path change:** every write generates + wraps a CEK; every read unwraps it. Touches the hottest path; needs careful performance review (per-record AES-KW wrap/unwrap, key caching).
+- **Migration:** existing records (body under the collection DEK) are not shreddable; a migration re-encrypts them under per-record CEKs. Until migrated, `forget` cannot guarantee erasure of legacy records — must be surfaced explicitly.
+- **Backup/copy semantics:** shred guarantees unrecoverability only for ciphertext whose CEK you control. A plaintext copy already exfiltrated is out of scope (true of any crypto-erasure) — document the boundary.
+- **Index integrity:** the subject index is correctness-critical (a missed record = incomplete erasure). It must be transactionally maintained with writes and rebuildable by a scan.
+- **Tier/deterministic-field interplay:** deterministic-encryption fields (`_det`) are keyed off the collection DEK for blind-equality; per-record CEKs change that — those fields may need exclusion from CEK scope or their own shred semantics.
+
+## Recommended sequencing
+
+1. CEK envelope format + wrap/unwrap + read/write path (behind a flag), with migration of existing records.
+2. Subject index + `withForgetCascade` declaration.
+3. `vault.forget()` + erasure ledger entry + post-shred chain-verify.
+4. Interplay passes: history, deterministic fields, tiers, bundles/backups, blobs (blob CEKs).
+
+## Acceptance (from #304)
+
+- [ ] predicate/subject-scoped CEK shred (record bodies + history unrecoverable)
+- [ ] ledger hash-chain still verifies after a shred
+- [ ] portable expression of "all records of subject X" (the encrypted subject index)

--- a/features.yaml
+++ b/features.yaml
@@ -230,6 +230,25 @@ features:
       - 'Index-aware execution: indexed fast-path then fallback scan'
     related: [vault-and-collections]
 
+  - id: atomic-sequence
+    name: Atomic gap-free sequence (online-only numbering)
+    cluster: core
+    spec: SUBSYSTEMS.md#the-minimalist-core
+    subsystem_doc: docs/core/06-query-basics.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'vault.sequence(name).next() allocates 1,2,3,… gap-free + exactly-once via optimistic-CAS on _sequences/<name>'
+      - 'independent per-name sequences; peek() reads without allocating'
+      - 'online-only: next() throws SequenceOfflineError unless store capabilities.casAtomic'
+      - 'jittered backoff; SequenceContentionError after the retry budget so callers can retry/queue'
+    related: [stores-contract, query-basics]
+
   # ─── Subsystems behind with*() factories ───────────────────────────
 
   - id: team

--- a/packages/hub/README.md
+++ b/packages/hub/README.md
@@ -291,6 +291,19 @@ await vault.restore('invoices', 'inv-2020') // relocate back to primary (decrypt
 
 Archival uses low-level relocation, so it **bypasses guards** (issued/immutable records over a sealed period can still be archived) and doesn't recompute finalized aggregates. Archived records read `null` from the primary store until restored; a `legalHold` predicate blocks archival entirely.
 
+## Atomic sequences
+
+`vault.sequence(name)` gives gap-free, exactly-once numbering — the primitive fiscal/ERP/ticketing apps need for invoice or DDT numbers — backed by an optimistic compare-and-swap counter.
+
+```ts
+const n = await vault.sequence('invoice-2026').next()   // 1, then 2, 3, … no gaps, no duplicates
+const cur = await vault.sequence('invoice-2026').peek()  // read current value without allocating
+```
+
+- **Independent per name** — `sequence('invoice-2026')` and `sequence('ddt-2026')` are separate counters.
+- **Concurrency-safe** — concurrent `next()` calls retry on CAS contention (jittered backoff); a genuine burst beyond the retry budget surfaces `SequenceContentionError` so the caller can retry or queue.
+- **Online-only — by design.** Gap-free numbering needs single-authority serialization, which an offline writer can't provide. `next()` throws `SequenceOfflineError` unless the store advertises `capabilities.casAtomic`. This is the honest wall: assign each `next()` value to its record in the same operation (a discarded value is a gap in *usage*, not in the sequence).
+
 ## Status
 
 **Pre-release** (`0.1.0-pre.1`). API may change before `1.0`. Install from the `next` dist-tag:

--- a/packages/hub/__tests__/sequence.test.ts
+++ b/packages/hub/__tests__/sequence.test.ts
@@ -2,7 +2,8 @@
  * #303 — atomic, gap-free sequence primitive.
  */
 import { describe, it, expect } from 'vitest'
-import { createNoydb, ConflictError, SequenceOfflineError, SequenceContentionError } from '../src/index.js'
+import { createNoydb, ConflictError, SequenceOfflineError, SequenceContentionError, ReservedCollectionNameError } from '../src/index.js'
+import { withHistory } from '../src/history/index.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
 
 function memory(casAtomic = true): NoydbStore {
@@ -30,6 +31,53 @@ function memory(casAtomic = true): NoydbStore {
     async loadAll(v) {
       const vm = store.get(v); const snap: VaultSnapshot = {}
       if (vm) for (const [n, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[n] = r
+      }
+      return snap
+    },
+    async saveAll(v, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const cm = gc(v, n)
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+      }
+    },
+  }
+}
+
+/**
+ * Faithful-contract adapter: loadAll filters `_`-prefixed collections, exactly
+ * as real adapters do. Used for dump/load round-trip tests so the regression
+ * only passes when dump() explicitly re-adds _sequences to _internal (the blocker
+ * fix). Without the fix, restored next() would return 1; with it, it returns 4.
+ */
+function memoryFaithful(casAtomic = true): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const gc = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = store.get(v); if (!vm) { vm = new Map(); store.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    capabilities: { casAtomic, auth: { kind: 'none' } },
+    async get(v, c, id) { return store.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const cm = gc(v, c); const ex = cm.get(id)
+      if (ev !== undefined) {
+        if (ev === 0 && ex) throw new ConflictError(ex._v)
+        if (ev !== 0 && (!ex || ex._v !== ev)) throw new ConflictError(ex?._v ?? 0)
+      }
+      cm.set(id, env)
+    },
+    async delete(v, c, id) { store.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(store.get(v)?.get(c)?.keys() ?? [])] },
+    // Faithful: skip `_`-prefixed internal collections, mirroring real adapters.
+    async loadAll(v) {
+      const vm = store.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [n, cm] of vm) {
+        if (n.startsWith('_')) continue
         const r: Record<string, EncryptedEnvelope> = {}
         for (const [id, e] of cm) r[id] = e
         snap[n] = r
@@ -93,5 +141,53 @@ describe('#303 vault.sequence', () => {
 
   it('SequenceContentionError is exported for callers to handle', () => {
     expect(new SequenceContentionError('s', 8)).toBeInstanceOf(Error)
+  })
+
+  // ── Blocker fix: _sequences must survive dump()/load() round-trip ──────────────
+  it('dump()/load() round-trip: next() continues at 4 (not 1) after restore', async () => {
+    // Source vault: allocate 1, 2, 3 then dump. dump() works without
+    // history (the backup just omits the integrity head), but we opt into
+    // withHistory() so the backup also carries a verifiable ledger head —
+    // exercising the full dump()/load() round-trip end to end.
+    const srcStore = memoryFaithful()
+    const srcDb = await createNoydb({ store: srcStore, user: 'owner', secret: 'passphrase', historyStrategy: withHistory() })
+    const srcVault = await srcDb.openVault('acme')
+    const seq = srcVault.sequence('invoice-2026')
+    expect(await seq.next()).toBe(1)
+    expect(await seq.next()).toBe(2)
+    expect(await seq.next()).toBe(3)
+    const backupJson = await srcVault.dump()
+
+    // Target vault: restore from backup, then next() must continue at 4.
+    const tgtStore = memoryFaithful()
+    const tgtDb = await createNoydb({ store: tgtStore, user: 'owner', secret: 'passphrase', historyStrategy: withHistory() })
+    const tgtVault = await tgtDb.openVault('acme')
+    await tgtVault.load(backupJson)
+    // Counter must resume from 3, not reset to 0.
+    expect(await tgtVault.sequence('invoice-2026').peek()).toBe(3)
+    expect(await tgtVault.sequence('invoice-2026').next()).toBe(4)
+  })
+
+  // ── Contention: put on _sequences always conflicts → SequenceContentionError ──
+  it('throws SequenceContentionError when the store always conflicts on _sequences', async () => {
+    // Use a normal CAS adapter for vault setup, then wrap its `put` to throw
+    // ConflictError for any write targeting the _sequences collection.
+    const base = memory()
+    const conflicting: NoydbStore = {
+      ...base,
+      async put(v, c, id, env, ev) {
+        if (c === '_sequences') throw new ConflictError(0)
+        return base.put(v, c, id, env, ev)
+      },
+    }
+    const db = await createNoydb({ store: conflicting, user: 'owner', secret: 'pw' })
+    const v = await db.openVault('books')
+    await expect(v.sequence('x').next()).rejects.toBeInstanceOf(SequenceContentionError)
+  })
+
+  // ── Name guard: collection('_sequences') must be blocked ──────────────────────
+  it('collection("_sequences") throws ReservedCollectionNameError', async () => {
+    const v = await vault(memory())
+    expect(() => v.collection('_sequences')).toThrow(ReservedCollectionNameError)
   })
 })

--- a/packages/hub/__tests__/sequence.test.ts
+++ b/packages/hub/__tests__/sequence.test.ts
@@ -1,0 +1,97 @@
+/**
+ * #303 — atomic, gap-free sequence primitive.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, ConflictError, SequenceOfflineError, SequenceContentionError } from '../src/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
+
+function memory(casAtomic = true): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const gc = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = store.get(v); if (!vm) { vm = new Map(); store.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    capabilities: { casAtomic, auth: { kind: 'none' } },
+    async get(v, c, id) { return store.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const cm = gc(v, c); const ex = cm.get(id)
+      // CAS: ev === 0 ⇒ must not exist; ev === N ⇒ existing must be at N.
+      if (ev !== undefined) {
+        if (ev === 0 && ex) throw new ConflictError(ex._v)
+        if (ev !== 0 && (!ex || ex._v !== ev)) throw new ConflictError(ex?._v ?? 0)
+      }
+      cm.set(id, env)
+    },
+    async delete(v, c, id) { store.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(store.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = store.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [n, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[n] = r
+      }
+      return snap
+    },
+    async saveAll(v, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const cm = gc(v, n)
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+      }
+    },
+  }
+}
+
+async function vault(store: NoydbStore) {
+  const db = await createNoydb({ store, user: 'owner', secret: 'pw' })
+  return db.openVault('books')
+}
+
+describe('#303 vault.sequence', () => {
+  it('allocates gap-free 1,2,3,…', async () => {
+    const v = await vault(memory())
+    const seq = v.sequence('invoice-2026')
+    expect(await seq.next()).toBe(1)
+    expect(await seq.next()).toBe(2)
+    expect(await seq.next()).toBe(3)
+  })
+
+  it('peek reads the current value without allocating', async () => {
+    const v = await vault(memory())
+    const seq = v.sequence('ddt')
+    expect(await seq.peek()).toBe(0)
+    await seq.next()
+    expect(await seq.peek()).toBe(1)
+    await seq.next()
+    expect(await seq.peek()).toBe(2)
+  })
+
+  it('independent per-name sequences', async () => {
+    const v = await vault(memory())
+    expect(await v.sequence('a').next()).toBe(1)
+    expect(await v.sequence('b').next()).toBe(1)
+    expect(await v.sequence('a').next()).toBe(2)
+    expect(await v.sequence('b').next()).toBe(2)
+  })
+
+  it('exactly-once + gap-free under concurrency (no duplicates, no gaps)', async () => {
+    const v = await vault(memory())
+    const seq = v.sequence('concurrent')
+    const N = 12 // moderate concurrency; extreme bursts surface SequenceContentionError
+    const results = await Promise.all(Array.from({ length: N }, () => seq.next()))
+    const sorted = [...results].sort((x, y) => x - y)
+    expect(sorted).toEqual(Array.from({ length: N }, (_, i) => i + 1)) // exactly 1..N, no dupes/gaps
+  })
+
+  it('online-only: throws SequenceOfflineError on a non-CAS store', async () => {
+    const v = await vault(memory(false))
+    await expect(v.sequence('x').next()).rejects.toBeInstanceOf(SequenceOfflineError)
+  })
+
+  it('SequenceContentionError is exported for callers to handle', () => {
+    expect(new SequenceContentionError('s', 8)).toBeInstanceOf(Error)
+  })
+})

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -731,6 +731,42 @@ export class LedgerContentionError extends NoydbError {
 }
 
 /**
+ * Thrown by `vault.sequence(name).next()` after exhausting its CAS retry
+ * budget under contention. The counter is intact; the caller may retry.
+ */
+export class SequenceContentionError extends NoydbError {
+  readonly sequence: string
+  readonly attempts: number
+
+  constructor(sequence: string, attempts: number) {
+    super(
+      'SEQUENCE_CONTENTION',
+      `vault.sequence("${sequence}").next(): failed to allocate after ${attempts} optimistic-CAS retries`,
+    )
+    this.name = 'SequenceContentionError'
+    this.sequence = sequence
+    this.attempts = attempts
+  }
+}
+
+/**
+ * Thrown by `vault.sequence(name).next()` when the backing store is not
+ * CAS-capable (`capabilities.casAtomic !== true`). Gap-free numbering
+ * requires single-authority serialization, which an offline / non-CAS
+ * store cannot provide — this is a deliberate online-only wall.
+ */
+export class SequenceOfflineError extends NoydbError {
+  constructor() {
+    super(
+      'SEQUENCE_OFFLINE',
+      'vault.sequence().next() requires an online CAS-capable store ' +
+        '(capabilities.casAtomic). Gap-free numbering cannot be serialized offline.',
+    )
+    this.name = 'SequenceOfflineError'
+  }
+}
+
+/**
  * Thrown when a bundle push is rejected because the remote has been updated
  * since the local bundle was last pulled.
  *

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -247,6 +247,8 @@ export {
   ElevationExpiredError,
   AlreadyElevatedError,
   LedgerContentionError,
+  SequenceContentionError,
+  SequenceOfflineError,
   BundleIntegrityError,
   BundleSealMismatchError,
   BundleVersionConflictError,
@@ -284,6 +286,10 @@ export type {
   ArchiveResult,
   ArchiveRunOptions,
 } from './archive/index.js'
+
+// ─── Atomic sequence (#303) ─────────────────────────────────────────────────────
+export { SequenceStore } from './sequence/index.js'
+export type { SequenceHandle } from './sequence/index.js'
 
 // Federation — VaultGroup / sharded collections.
 // Type-only: these classes are never constructed by consumers — they are

--- a/packages/hub/src/sequence/index.ts
+++ b/packages/hub/src/sequence/index.ts
@@ -24,7 +24,7 @@ import { NOYDB_FORMAT_VERSION } from '../types.js'
 import { encrypt, decrypt } from '../crypto.js'
 import { ConflictError, SequenceContentionError, SequenceOfflineError } from '../errors.js'
 
-const SEQUENCE_COLLECTION = '_sequences'
+export const SEQUENCE_COLLECTION = '_sequences'
 // A sequence is a single hot CAS row — higher contention than a ledger
 // append. A larger budget + jittered backoff absorbs moderate concurrency;
 // a genuine burst beyond this surfaces SequenceContentionError so the

--- a/packages/hub/src/sequence/index.ts
+++ b/packages/hub/src/sequence/index.ts
@@ -1,0 +1,145 @@
+/**
+ * Atomic sequence primitive — online-coordinated gap-free numbering.
+ *
+ * `vault.sequence('invoice-2026').next()` returns 1, 2, 3, … with no
+ * gaps and no duplicates, even under concurrent callers. Each named
+ * sequence is an independent counter record at `_sequences/<name>`,
+ * incremented with an optimistic compare-and-swap retry loop — the same
+ * proven pattern as the ledger head (`history/ledger/store.ts`).
+ *
+ * **Explicitly online-only.** Gap-free numbering requires single-authority
+ * serialization, which an offline / non-CAS store cannot provide. `next()`
+ * throws {@link SequenceOfflineError} unless the backing store advertises
+ * `capabilities.casAtomic`. This is a deliberate, honest wall — an offline
+ * writer cannot safely allocate a global sequence number.
+ *
+ * Note on "gap-free": the *sequence* is gap-free (each `next()` yields a
+ * unique, +1 value). If a caller discards a value without using it, that
+ * is a gap in *usage*, not in the sequence — assign each `next()` result
+ * to its record in the same operation.
+ */
+
+import type { NoydbStore, EncryptedEnvelope } from '../types.js'
+import { NOYDB_FORMAT_VERSION } from '../types.js'
+import { encrypt, decrypt } from '../crypto.js'
+import { ConflictError, SequenceContentionError, SequenceOfflineError } from '../errors.js'
+
+const SEQUENCE_COLLECTION = '_sequences'
+// A sequence is a single hot CAS row — higher contention than a ledger
+// append. A larger budget + jittered backoff absorbs moderate concurrency;
+// a genuine burst beyond this surfaces SequenceContentionError so the
+// caller can retry / queue (the honest online-only contract).
+const MAX_NEXT_ATTEMPTS = 16
+
+interface SequenceState {
+  value: number
+}
+
+export interface SequenceHandle {
+  /** Atomically allocate and return the next value (1, 2, 3, …). */
+  next(): Promise<number>
+  /** Read the current value without allocating. Returns 0 if never used. */
+  peek(): Promise<number>
+}
+
+async function sleepBackoff(attempt: number): Promise<void> {
+  // Exponential backoff with full jitter to break the thundering herd
+  // when many writers contend on the same counter row.
+  const ceil = Math.min(2 ** attempt, 32)
+  const ms = Math.floor(Math.random() * ceil)
+  await new Promise((r) => setTimeout(r, ms))
+}
+
+export class SequenceStore {
+  private readonly adapter: NoydbStore
+  private readonly vault: string
+  private readonly encrypted: boolean
+  private readonly getDEK: (collectionName: string) => Promise<CryptoKey>
+  private readonly actor: string
+  /**
+   * Memoized DEK promise. The `_sequences` collection DEK is created on
+   * first access; without sharing one promise, a burst of concurrent
+   * `next()` calls would each trigger DEK creation and diverge (one
+   * writer's ciphertext unreadable by another). One shared promise → one
+   * DEK.
+   */
+  private dekPromise: Promise<CryptoKey> | null = null
+
+  constructor(opts: {
+    adapter: NoydbStore
+    vault: string
+    encrypted: boolean
+    getDEK: (collectionName: string) => Promise<CryptoKey>
+    actor: string
+  }) {
+    this.adapter = opts.adapter
+    this.vault = opts.vault
+    this.encrypted = opts.encrypted
+    this.getDEK = opts.getDEK
+    this.actor = opts.actor
+  }
+
+  /** A handle bound to one sequence name. */
+  handle(name: string): SequenceHandle {
+    return {
+      next: () => this.next(name),
+      peek: () => this.peek(name),
+    }
+  }
+
+  private assertOnline(): void {
+    if (this.adapter.capabilities?.casAtomic !== true) {
+      throw new SequenceOfflineError()
+    }
+  }
+
+  private dek(): Promise<CryptoKey> {
+    if (!this.dekPromise) this.dekPromise = this.getDEK(SEQUENCE_COLLECTION)
+    return this.dekPromise
+  }
+
+  private async read(name: string): Promise<{ env: EncryptedEnvelope | null; value: number }> {
+    const env = await this.adapter.get(this.vault, SEQUENCE_COLLECTION, name)
+    if (!env) return { env: null, value: 0 }
+    const json = this.encrypted ? await decrypt(env._iv, env._data, await this.dek()) : env._data
+    const state = JSON.parse(json) as SequenceState
+    return { env, value: state.value }
+  }
+
+  private async encryptState(state: SequenceState, version: number): Promise<EncryptedEnvelope> {
+    const json = JSON.stringify(state)
+    if (!this.encrypted) {
+      return { _noydb: NOYDB_FORMAT_VERSION, _v: version, _ts: new Date().toISOString(), _iv: '', _data: json, _by: this.actor }
+    }
+    const { iv, data } = await encrypt(json, await this.dek())
+    return { _noydb: NOYDB_FORMAT_VERSION, _v: version, _ts: new Date().toISOString(), _iv: iv, _data: data, _by: this.actor }
+  }
+
+  async peek(name: string): Promise<number> {
+    return (await this.read(name)).value
+  }
+
+  async next(name: string): Promise<number> {
+    this.assertOnline()
+    let lastConflict: ConflictError | undefined
+    for (let attempt = 0; attempt < MAX_NEXT_ATTEMPTS; attempt++) {
+      const { env, value } = await this.read(name)
+      const nextValue = value + 1
+      const expectedVersion = env?._v ?? 0 // 0 ≡ "must not yet exist" (create)
+      const envelope = await this.encryptState({ value: nextValue }, expectedVersion + 1)
+      try {
+        await this.adapter.put(this.vault, SEQUENCE_COLLECTION, name, envelope, expectedVersion)
+        return nextValue
+      } catch (err) {
+        if (err instanceof ConflictError) {
+          lastConflict = err
+          if (attempt < MAX_NEXT_ATTEMPTS - 1) await sleepBackoff(attempt)
+          continue
+        }
+        throw err
+      }
+    }
+    void lastConflict
+    throw new SequenceContentionError(name, MAX_NEXT_ATTEMPTS)
+  }
+}

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -217,6 +217,13 @@ export interface NoydbStore {
    */
   name?: string
 
+  /**
+   * Optional declared store capabilities (CAS atomicity, native tx, blob
+   * size limits, auth). Consumers that require a capability — e.g.
+   * `vault.sequence().next()` needs `casAtomic` — read it here.
+   */
+  capabilities?: StoreCapabilities
+
   /** Get a single record. Returns null if not found. */
   get(vault: string, collection: string, id: string): Promise<EncryptedEnvelope | null>
 

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -45,7 +45,7 @@ import type { BlobStrategy } from './blobs/strategy.js'
 import type { ArchiveStrategy } from './archive/index.js'
 import type { ArchivePolicy, ArchiveContext, ArchiveResult, ArchiveRunOptions } from './archive/index.js'
 import { runArchive, runRestore, runListArchived } from './archive/index.js'
-import { SequenceStore, type SequenceHandle } from './sequence/index.js'
+import { SequenceStore, type SequenceHandle, SEQUENCE_COLLECTION } from './sequence/index.js'
 import type { IndexStrategy } from './indexing/strategy.js'
 import type { AggregateStrategy } from './aggregate/strategy.js'
 import type { CrdtStrategy } from './crdt/strategy.js'
@@ -530,8 +530,9 @@ export class Vault {
    *. `put()` validates keys against the declared set; reads
    *   with `{ locale }` add `<field>Label` virtual fields.
    *
-   * Throws `ReservedCollectionNameError` for names starting with `_dict_`.
-   * Use `vault.dictionary(name)` to access dictionary collections.
+   * Throws `ReservedCollectionNameError` for names starting with `_dict_` or
+   * equal to `_sequences`. Use `vault.dictionary(name)` for dict collections
+   * and `vault.sequence(name)` for sequence counters.
    *
    * Lazy mode + indexes is rejected at construction time — see the
    * Collection constructor for the rationale.
@@ -621,6 +622,10 @@ export class Vault {
     }
     // Guard: reject reserved _dict_* names
     if (isDictCollectionName(collectionName)) {
+      throw new ReservedCollectionNameError(collectionName)
+    }
+    // Guard: reject the internal _sequences collection — use vault.sequence() instead.
+    if (collectionName === SEQUENCE_COLLECTION) {
       throw new ReservedCollectionNameError(collectionName)
     }
 
@@ -2949,7 +2954,7 @@ export class Vault {
     // empty ledger and `verifyBackupIntegrity()` would have nothing
     // to compare against.
     const internalSnapshot: VaultSnapshot = {}
-    for (const internalName of [LEDGER_COLLECTION, LEDGER_DELTAS_COLLECTION, SCHEMAS_COLLECTION]) {
+    for (const internalName of [LEDGER_COLLECTION, LEDGER_DELTAS_COLLECTION, SCHEMAS_COLLECTION, SEQUENCE_COLLECTION]) {
       const ids = await this.adapter.list(this.name, internalName)
       if (ids.length === 0) continue
       const records: Record<string, EncryptedEnvelope> = {}

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -45,6 +45,7 @@ import type { BlobStrategy } from './blobs/strategy.js'
 import type { ArchiveStrategy } from './archive/index.js'
 import type { ArchivePolicy, ArchiveContext, ArchiveResult, ArchiveRunOptions } from './archive/index.js'
 import { runArchive, runRestore, runListArchived } from './archive/index.js'
+import { SequenceStore, type SequenceHandle } from './sequence/index.js'
 import type { IndexStrategy } from './indexing/strategy.js'
 import type { AggregateStrategy } from './aggregate/strategy.js'
 import type { CrdtStrategy } from './crdt/strategy.js'
@@ -272,6 +273,9 @@ export class Vault {
    * docstring.
    */
   private ledgerStore: LedgerStore | null = null
+
+  /** Lazily-built atomic-sequence store. See {@link sequence}. */
+  private sequenceStore: SequenceStore | null = null
 
   /**
    * Background writes for persisted-schema envelopes (#schema-dump v0
@@ -1309,6 +1313,34 @@ export class Vault {
    * await vault.compact({ maxEvictions: 1000 })             // cap batch
    * ```
    */
+  /**
+   * Atomic, gap-free numbering. `vault.sequence('invoice-2026').next()`
+   * returns 1, 2, 3, … with no gaps or duplicates under concurrency, via
+   * an optimistic-CAS counter at `_sequences/<name>`. Each name is an
+   * independent sequence.
+   *
+   * **Online-only:** `next()` throws `SequenceOfflineError` unless the
+   * store advertises `capabilities.casAtomic` — gap-free numbering cannot
+   * be serialized by an offline / non-CAS writer.
+   *
+   * ```ts
+   * const n = await vault.sequence('invoice-2026').next()   // 1, then 2, …
+   * const cur = await vault.sequence('invoice-2026').peek()  // current value, no allocation
+   * ```
+   */
+  sequence(name: string): SequenceHandle {
+    if (!this.sequenceStore) {
+      this.sequenceStore = new SequenceStore({
+        adapter: this.adapter,
+        vault: this.name,
+        encrypted: this.encrypted,
+        getDEK: this.getDEK,
+        actor: this.keyring.userId,
+      })
+    }
+    return this.sequenceStore.handle(name)
+  }
+
   async compact(options: CompactRunOptions = {}): Promise<CompactionResult> {
     return runCompaction({
       adapter: this.adapter,


### PR DESCRIPTION
Closes #303. Specs #304. Cluster B — one built, one design-spec'd (your calls).

> **Draft — independent (branches from `main`), awaiting review, do not merge.** Both Cluster B items had open design questions; per your decisions: build #303, spec #304.

## #303 — atomic gap-free sequence (built)
`vault.sequence(name).next()` returns 1, 2, 3, … gap-free and exactly-once under concurrency, backed by an optimistic compare-and-swap counter at `_sequences/<name>` — the same proven loop as the ledger head.

```ts
await vault.sequence('invoice-2026').next()   // 1, then 2, 3, …
await vault.sequence('invoice-2026').peek()    // current value, no allocation
```
- Independent per name; jittered backoff; `SequenceContentionError` after the retry budget (caller retries/queues).
- **Online-only by design** (your choice): `next()` throws `SequenceOfflineError` unless the store advertises `capabilities.casAtomic`. Gap-free numbering needs single-authority serialization an offline writer can't provide. Added the optional `capabilities` field to the `NoydbStore` type (stores already supply it; nothing read it before).
- 6 tests incl. gap-free-under-concurrency.

## #304 — withForgetCascade crypto-shred (DESIGN SPEC ONLY, not built)
Per your decision not to make an invasive core-crypto change blind. The spec (`docs/superpowers/specs/2026-06-08-forget-cascade-design.md`) resolves the blocker and the two open questions:
- **Blocker:** the DEK is **per-collection**, so you can't selectively erase one subject without nuking the collection. Fix: a **per-record content-DEK (CEK)** wrapped under the collection DEK; shred = delete the wrapped CEK → that record's body + all history unrecoverable, collection untouched.
- **"All records of subject X" portably** → a declared `subjectField` + an **encrypted** subject index (rejecting an unencrypted envelope tag that would leak subject-equivalence).
- **Composes with history** → the whole version chain shares the record's CEK, so one delete erases current + all prior versions; the ledger hash-chain still verifies (it holds hashes, not plaintext), and `forget()` appends an erasure ledger entry that *proves* erasure without retaining data.
- Spec scopes it as a dedicated security epic (core-crypto path change, migration of existing records, deterministic-field/tier/blob interplay).

## Verification (#303)
Full hub suite **2201 passing**; typecheck clean; `eslint src/` clean; `features.yaml` valid (49); architecture invariants pass.
