### PR TITLE
feat(federation): cross-vault live queries + distributed aggregate (queryAcrossLive / aggregateAcross) — epic #271 Phase 3

### DIFF
--- a/docs/superpowers/plans/2026-06-08-cross-vault-live-aggregate-and-312.md
+++ b/docs/superpowers/plans/2026-06-08-cross-vault-live-aggregate-and-312.md
@@ -1,0 +1,1033 @@
+# Cross-Vault Live + Aggregate + #312 Forward-Compat — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the VaultGroup fan-out key-custody-neutral (#312 A+B), add the `Reducer.merge` protocol seam (#312 E), and implement the reactive `queryAcrossLive` + distributed `aggregateAcross`/`aggregateAcrossLive` surface on `ShardedQuery`.
+
+**Architecture:** Phase 1 adds a no-create open mode so a non-granted fan-out open fails cleanly (and is classified `'no-grant'`) instead of self-provisioning — these are small core touches plus federation wiring, landing on the MVP base. Phase 2 adds optional `Reducer.merge`. Phase 3 builds one reactive core (`CrossVaultLive<S>`, single-flight + debounce + `ready`) with two `LiveQuery`/`LiveAggregation`-shaped facades, plus central-reduce aggregate wrappers, all in the lazy `federation/` chunk.
+
+**Tech Stack:** TypeScript, `@noy-db/hub` internals (`Noydb`, `Vault`, `Collection`, `queryAcross`, `reduceRecords`/`groupAndReduce`, `LiveQuery`/`LiveAggregation`), Vitest. pnpm 9.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-cross-vault-live-and-aggregate-design.md` (revised for #312).
+
+**Branching/sequencing:** Phase 1 (A+B) on the MVP base (branch `feat/m16-mvf-vaultgroup-routing`, PR #292) — land before the `reason` union ossifies. Then **rebase** `feat/m16-cross-vault-live-aggregate` onto it. Phase 2 + Phase 3 on `feat/m16-cross-vault-live-aggregate`. Run tests with `pnpm --filter @noy-db/hub exec vitest run <file>`.
+
+**Verified current state (rely on these):**
+- `SkippedVault.reason` = `'schema-drift' | 'error'` (`federation/types.ts`).
+- `ShardedQuery.toArray` (`federation/vault-group.ts`) inlines: minVersion skip → `Promise.all(_shardVaultProvisioned)` guard → `queryAcross(ids, fn, {concurrency})` → fold `r.error` into `{reason:'error'}`.
+- `openVault(name, opts?: { locale?: string })` → `getKeyringInternal(vault)`; catch: `if (err instanceof NoAccessError) { keyring = await createOwnerKeyring(...) }` (noydb.ts ~2747).
+- `loadKeyring` throws `NoAccessError` when `_keyring/<userId>` is absent (no other-principal check).
+- `queryAcross<T>(vaultIds, fn, options: QueryAcrossOptions = {})` calls `this.openVault(vaultId)` internally.
+- `Reducer<R, S=R>` = `{ init(); step(); remove?(); finalize(); op?; field? }` (`aggregate/reducers.ts`; `op`/`field` added in pre.10).
+- `NoAccessError`, `InvalidKeyError` exported from `errors.js`.
+
+---
+
+## Phase 1 — #312 A+B: key-custody-neutral fan-out (on the MVP base)
+
+### Task 1: `SkippedVault.reason: 'no-grant'` + classifier
+
+**Files:**
+- Modify: `packages/hub/src/federation/types.ts`
+- Create: `packages/hub/src/federation/classify-skip.ts`
+- Test: `packages/hub/__tests__/federation-vault-group.test.ts` (append)
+
+- [ ] **Step 1: Write the failing test** — append to the existing fan-out describe block:
+
+```ts
+import { NoAccessError, InvalidKeyError, KeyringCorruptError } from '../src/errors.js'
+import { classifyShardSkip } from '../src/federation/classify-skip.js'
+
+describe('classifyShardSkip', () => {
+  it('maps NoAccessError (no grant) to no-grant; corruption/credential errors to error', () => {
+    expect(classifyShardSkip(new NoAccessError('x'))).toBe('no-grant')
+    // #312 comment §2: InvalidKeyError can mean "wrong KEK OR whole-file corruption"
+    // (per loadKeyring) — must NOT be masked as the benign no-grant.
+    expect(classifyShardSkip(new InvalidKeyError())).toBe('error')
+    expect(classifyShardSkip(new KeyringCorruptError({ failedCollections: ['c'], intactCount: 0 }))).toBe('error')
+    expect(classifyShardSkip(new Error('store boom'))).toBe('error')
+  })
+})
+```
+(Confirm the `KeyringCorruptError` / `InvalidKeyError` constructor shapes against `errors.ts`; the assertion that matters is `NoAccessError → 'no-grant'`, everything else → `'error'`.)
+
+- [ ] **Step 2: Run it — fails** (`classify-skip.js` missing).
+Run: `pnpm --filter @noy-db/hub exec vitest run __tests__/federation-vault-group.test.ts -t classifyShardSkip` → FAIL (cannot resolve module).
+
+- [ ] **Step 3: Add the `'no-grant'` union member** in `federation/types.ts`:
+
+```ts
+export interface SkippedVault {
+  readonly vaultId: string
+  readonly reason: 'schema-drift' | 'error' | 'no-grant'
+  readonly error?: Error
+}
+```
+
+- [ ] **Step 4: Create `packages/hub/src/federation/classify-skip.ts`:**
+
+```ts
+import { NoAccessError } from '../errors.js'
+import type { SkippedVault } from './types.js'
+
+/**
+ * Classify a per-shard fan-out failure. `NoAccessError` (no keyring
+ * envelope for the calling identity) is the unambiguous not-granted
+ * signal → `'no-grant'` (expected under scoped access, not a fault).
+ *
+ * Everything else → `'error'`. In particular `InvalidKeyError` /
+ * `DecryptionError` / `KeyringCorruptError` are NOT no-grant: per
+ * `loadKeyring`, a failed unlock can mean "wrong KEK OR whole-file
+ * corruption", so masking it as the benign `'no-grant'` would hide a
+ * fault. A keyring that exists but won't unlock (credential mismatch
+ * or corruption) is a real error to surface.
+ */
+export function classifyShardSkip(err: Error): Exclude<SkippedVault['reason'], 'schema-drift'> {
+  return err instanceof NoAccessError ? 'no-grant' : 'error'
+}
+```
+
+- [ ] **Step 5: Run the test — passes.** `pnpm --filter @noy-db/hub exec vitest run __tests__/federation-vault-group.test.ts -t classifyShardSkip` → PASS. Also `pnpm --filter @noy-db/hub exec tsc --noEmit`.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add packages/hub/src/federation/types.ts packages/hub/src/federation/classify-skip.ts packages/hub/__tests__/federation-vault-group.test.ts
+git commit -m "feat(federation): add SkippedVault reason 'no-grant' + classifyShardSkip (#312 A)"
+```
+
+---
+
+### Task 2: no-create open mode (`openVault({ create:false })` + `queryAcross`)
+
+**Files:**
+- Modify: `packages/hub/src/noydb.ts` (openVault opts, getKeyringInternal, queryAcross)
+- Modify: `packages/hub/src/types.ts` (`QueryAcrossOptions`)
+- Test: `packages/hub/__tests__/no-create-open.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test** (a vault owned by alice; bob opens with `create:false` → throws, and writes no keyring):
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { NoAccessError } from '../src/errors.js'
+// reuse the inline memory() adapter pattern from __tests__/cross-vault.test.ts (copy it into this file)
+
+it('openVault({create:false}) throws NoAccessError on a vault the caller lacks a grant to, and writes no keyring', async () => {
+  const adapter = memory()
+  const alice = await createNoydb({ store: adapter, user: 'alice', secret: 'alice-pass' })
+  const av = await alice.openVault('client-1')
+  await av.collection<{ n: number }>('c').put('r1', { n: 1 })
+
+  const bob = await createNoydb({ store: adapter, user: 'bob', secret: 'bob-pass' })
+  await expect(bob.openVault('client-1', { create: false })).rejects.toBeInstanceOf(NoAccessError)
+  // bob must NOT have self-provisioned a keyring into alice's vault
+  expect(await adapter.get('client-1', '_keyring', 'bob')).toBeNull()
+})
+
+it('openVault default (create:true) still bootstraps a new vault', async () => {
+  const adapter = memory()
+  const db = await createNoydb({ store: adapter, user: 'alice', secret: 'alice-pass' })
+  const v = await db.openVault('fresh')          // no throw — creates owner keyring
+  await v.collection<{ n: number }>('c').put('r1', { n: 1 })
+  expect(await adapter.get('fresh', '_keyring', 'alice')).not.toBeNull()
+})
+```
+
+- [ ] **Step 2: Run it — fails** (currently bob self-provisions, no throw).
+Run: `pnpm --filter @noy-db/hub exec vitest run __tests__/no-create-open.test.ts` → FAIL (resolves, returns a vault; keyring written).
+
+- [ ] **Step 3: Thread the `create` option.** In `packages/hub/src/noydb.ts`:
+
+`openVault` signature → add `create`:
+```ts
+  async openVault(
+    name: string,
+    opts?: { locale?: string; create?: boolean },
+  ): Promise<Vault> {
+```
+Pass it into the keyring load — change the internal call site `const keyring = await this.getKeyringInternal(name)` (in openVault, ~line 421) to:
+```ts
+    const keyring = await this.getKeyringInternal(name, { create: opts?.create !== false })
+```
+Update `getKeyringInternal` signature + the `NoAccessError` branch (~line 2704 / 2747):
+```ts
+  private async getKeyringInternal(
+    vault: string,
+    opts: { create: boolean } = { create: true },
+  ): Promise<UnlockedKeyring> {
+```
+```ts
+      if (err instanceof NoAccessError) {
+        if (!opts.create) throw err   // no-create mode: never self-provision into a vault we lack access to
+        // No keyring on disk — first boot or cleared store.
+        keyring = await createOwnerKeyring(/* …unchanged… */)
+```
+(Leave the `InvalidKeyError && onInvalidKey === 'reset'` branch as-is — `create:false` callers don't set `onInvalidKey:'reset'`; an `InvalidKeyError` there surfaces as the no-grant signal.)
+
+Add `create` to `QueryAcrossOptions` in `packages/hub/src/types.ts`:
+```ts
+export interface QueryAcrossOptions {
+  readonly concurrency?: number
+  /** Open shards non-creatingly — a missing grant throws instead of self-provisioning. Default false (creating). */
+  readonly create?: boolean
+}
+```
+In `queryAcross`, change the internal open `const comp = await this.openVault(vaultId)` to:
+```ts
+        const comp = await this.openVault(vaultId, { create: options.create !== false ? true : false })
+```
+(Equivalently `{ create: options.create !== false }`.)
+
+- [ ] **Step 4: Run the test — passes.** Both cases green. Then `pnpm --filter @noy-db/hub test` to confirm no regression (default create path unchanged) + `tsc --noEmit`.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/hub/src/noydb.ts packages/hub/src/types.ts packages/hub/__tests__/no-create-open.test.ts
+git commit -m "feat(hub): openVault/queryAcross no-create mode — never self-provision a non-granted vault (#312 A/B)"
+```
+
+---
+
+### Task 3: non-creating open on BOTH paths (fan-out + drill-down) + classify; no-grant tests
+
+**Files:**
+- Modify: `packages/hub/src/federation/vault-group.ts` (`toArray` fan-out, `openShard`)
+- Test: `packages/hub/__tests__/federation-vault-group.test.ts` (append)
+
+This covers **#312 comment §1**: the no-create primitive must apply to the *single-shard* path too. A scoped non-owner doing `shard(key)` (drill-down) or routing a `put` to an existing shard it lacks a grant to must fail cleanly, not self-provision. `openShard` means "open an **existing** shard" → it opens non-creatingly; `shard()` and `put`-routing both go through it. `createShard` stays the sole creating path.
+
+- [ ] **Step 1: Write the failing test** — a granted shard + a non-granted shard in one group:
+
+```ts
+it('a shard the fan-out identity cannot open is skipped as no-grant (not error), and no keyring is self-provisioned', async () => {
+  // Build a registry + two shards under one operator, then GRANT only one to a second identity.
+  // Operator creates both shards (owns them); a separate "advisor" db has a grant to only shard A.
+  const adapter = memory()
+  const op = await createNoydb({ store: adapter, user: 'operator', secret: 'op-pass' })
+  op.withVaultTemplate('t', { version: 1, configure: (v: Vault) => { v.collection<Invoice>('invoices') } })
+  const opState = await op.openVault('state')
+  const opFirm = await op.openVaultGroup<Invoice>('firm', {
+    registry: opState.collection<VaultRegistryRow>('vault-registry'),
+    sharding: { keyOf: (r) => r.clientId, vaultTemplate: 't' },
+  })
+  await opFirm.collection('invoices').put('a1', { clientId: 'acme', amount: 100, status: 'overdue' })
+  await opFirm.collection('invoices').put('b1', { clientId: 'beta', amount: 200, status: 'overdue' })
+  // grant advisor only to firm--acme
+  await op.grant('firm--acme', { userId: 'advisor', displayName: 'Adv', role: 'viewer', passphrase: 'adv-pass' })
+
+  // advisor opens the SAME group (same registry vault — must be granted on 'state' too)
+  await op.grant('state', { userId: 'advisor', displayName: 'Adv', role: 'viewer', passphrase: 'adv-pass' })
+  const adv = await createNoydb({ store: adapter, user: 'advisor', secret: 'adv-pass' })
+  adv.withVaultTemplate('t', { version: 1, configure: (v: Vault) => { v.collection<Invoice>('invoices') } })
+  const advState = await adv.openVault('state')
+  const advFirm = await adv.openVaultGroup<Invoice>('firm', {
+    registry: advState.collection<VaultRegistryRow>('vault-registry'),
+    sharding: { keyOf: (r) => r.clientId, vaultTemplate: 't' },
+  })
+
+  const out = await advFirm.collection('invoices').query().where('status', '==', 'overdue').toArray()
+  expect(out.results.map((r) => r.amount)).toEqual([100])               // only acme (granted)
+  const skip = out.skippedVaults.find((s) => s.vaultId === 'firm--beta')
+  expect(skip?.reason).toBe('no-grant')
+  expect(await adapter.get('firm--beta', '_keyring', 'advisor')).toBeNull() // no self-provision
+
+  // §1: the SAME hazard on the single-shard drill-down — advisor drills into a
+  // shard it lacks a grant to → clean failure, NOT a self-provisioned keyring.
+  await expect(advFirm.shard('beta')).rejects.toBeInstanceOf(NoAccessError)
+  expect(await adapter.get('firm--beta', '_keyring', 'advisor')).toBeNull()
+  // and a routed write to that non-granted shard also fails cleanly (existing row → openShard)
+  await expect(
+    advFirm.collection('invoices').put('x', { clientId: 'beta', amount: 9, status: 'open' }),
+  ).rejects.toBeInstanceOf(NoAccessError)
+  expect(await adapter.get('firm--beta', '_keyring', 'advisor')).toBeNull()
+})
+```
+(`NoAccessError` imported at top. Confirm the grant API shape against `cross-vault.test.ts`; adjust `role`/fields if needed. The behavioral contract — no-grant skip on fan-out + clean throw on drill-down/write + zero self-provision — is fixed.)
+
+- [ ] **Step 2: Run it — fails** (today the open self-provisions → advisor sees beta as empty/error, or reads it).
+
+- [ ] **Step 3a: Wire the fan-out** in `toArray` (`vault-group.ts`) — open non-creatingly and classify:
+
+Change the `queryAcross` call's options to `{ concurrency: options.concurrency ?? 1, create: false }`, and change the skip-folding tail from:
+```ts
+      if (r.error) skipped.push({ vaultId: r.vault, reason: 'error', error: r.error })
+```
+to:
+```ts
+      if (r.error) skipped.push({ vaultId: r.vault, reason: classifyShardSkip(r.error), error: r.error })
+```
+Add `import { classifyShardSkip } from './classify-skip.js'` at the top of `vault-group.ts`.
+
+- [ ] **Step 3b: Make `openShard` non-creating** (closes the §1 drill-down hazard). Change `openShard` so it opens existing shards only:
+```ts
+  async openShard(partitionKey: string): Promise<Vault> {
+    const vault = await this.db.openVault(this.shardVaultId(partitionKey), { create: false })
+    this.template.configure(vault)
+    return vault
+  }
+```
+Verify `createShard`'s **create** branch still uses `this.db.openVault(vaultId)` *without* `{ create: false }` (it legitimately provisions). Its idempotent `row && provisioned` branch calls `openShard` — fine: a granted owner still opens; a non-grant correctly throws `NoAccessError`. `shard()` and `ShardedCollection.put`'s existing-row branch already route through `openShard`, so they inherit clean-fail automatically.
+
+- [ ] **Step 4: Run tests — pass.** The two new tests + the existing 16 federation tests (`pnpm --filter @noy-db/hub exec vitest run __tests__/federation-vault-group.test.ts`) + `tsc --noEmit`. (The existing error-branch test injects a store `list` failure → still `'error'`; the MVP createShard/reconcile tests still pass because the single operator owns its shards.)
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/hub/src/federation/vault-group.ts packages/hub/__tests__/federation-vault-group.test.ts
+git commit -m "feat(federation): fan-out opens non-creatingly + classifies no-grant vs error (#312 A/B)"
+```
+
+---
+
+### Task 4: state the key-custody-neutral contract (B, docs)
+
+**Files:**
+- Modify: `docs/subsystems/vault-group.md`
+
+- [ ] **Step 1: Add a "Key-custody model" section** to `docs/subsystems/vault-group.md`:
+
+```markdown
+## Key-custody model
+
+VaultGroup operations run **as the calling `Noydb` identity** holding *some* grants — not
+necessarily every shard. The fan-out (`query().toArray()` and the live/aggregate surface)
+returns the **openable subset** for that identity: a shard the caller lacks a grant to is
+reported in `skippedVaults` with `reason: 'no-grant'` — expected under scoped access, **not a
+fault**. The all-owning operator (one identity that created and can open every shard) is one
+configuration, not the contract.
+
+Do **not** assume "fan-out results = all shards." Distinguish the three skip reasons:
+`'schema-drift'` (below `minVersion`), `'no-grant'` (caller has no keyring for the shard;
+classified from `NoAccessError` only — `InvalidKeyError`/corruption stay `'error'`), and
+`'error'` (genuine fault, incl. `ShardProvisioningError` = registry row present but vault gone).
+All federation open paths are **non-creating** (`shard()`/`put`-routing via `openShard`, and the
+fan-out), so a missing grant fails cleanly rather than self-provisioning a keyring into the vault.
+`createShard` is the only creating path.
+
+### Registry visibility (roster is not scoped)
+
+Opening a VaultGroup requires a grant to the **registry vault**; shard grants then determine the
+openable subset. But the `vault-registry` is one shared collection of **plaintext** rows — any
+member who can read it sees **every** `partitionKey`/`vaultId`, including shards it cannot open.
+Roster *existence* is not scoped (only shard *data* is). Therefore:
+
+- **`keyOf` must return an opaque partition key.** Do **not** key by a sensitive human
+  identifier (tax id, name) — these become plaintext-visible to every group member. Use an
+  opaque internal id (e.g. a ULID `clientId`) and keep sensitive identifiers *inside* the
+  shard's records.
+- **Per-identity roster scoping** (an identity seeing only its assigned rows) is **not**
+  provided by a single shared registry — it needs row-level access or per-identity views, out of
+  scope today.
+```
+
+- [ ] **Step 2: Validate docs registry.** Run `node scripts/validate-features.mjs` → OK (path already registered).
+
+- [ ] **Step 3: Commit.**
+```bash
+git add docs/subsystems/vault-group.md
+git commit -m "docs(federation): state key-custody-neutral fan-out contract (#312 B)"
+```
+
+> After Phase 1: **rebase `feat/m16-cross-vault-live-aggregate` onto the updated MVP branch** before Phase 2/3 (`git checkout feat/m16-cross-vault-live-aggregate && git rebase feat/m16-mvf-vaultgroup-routing`).
+
+---
+
+## Phase 2 — #312 E: `Reducer.merge` (on the cross-vault-live branch)
+
+### Task 5: optional `Reducer.merge` + 5 built-ins + unit tests
+
+**Files:**
+- Modify: `packages/hub/src/aggregate/reducers.ts`
+- Test: `packages/hub/__tests__/reducer-merge.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test:**
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { sum, count, avg, min, max } from '../src/aggregate/reducers.js'
+
+// merge-then-finalize must equal reduce-over-concatenation (state-level invariant)
+function reduceState(r: ReturnType<typeof sum>, records: unknown[]) {
+  let s = r.init(); for (const rec of records) s = r.step(s, rec); return s
+}
+
+describe('Reducer.merge', () => {
+  const A = [{ v: 10 }, { v: 20 }]
+  const B = [{ v: 30 }]
+  for (const [name, make] of [['sum', () => sum('v')], ['count', () => count()], ['avg', () => avg('v')], ['min', () => min('v')], ['max', () => max('v')]] as const) {
+    it(`${name}: merge(stateA,stateB) finalizes to reduce(A∪B)`, () => {
+      const r = make() as any
+      expect(typeof r.merge).toBe('function')
+      const sA = reduceState(r, A), sB = reduceState(r, B)
+      const merged = r.finalize(r.merge(sA, sB))
+      const whole = r.finalize(reduceState(r, [...A, ...B]))
+      expect(merged).toEqual(whole)
+      // commutativity + identity
+      expect(r.finalize(r.merge(sB, sA))).toEqual(whole)
+      expect(r.finalize(r.merge(r.init(), sA))).toEqual(r.finalize(sA))
+    })
+  }
+})
+```
+
+- [ ] **Step 2: Run it — fails** (`r.merge` undefined).
+
+- [ ] **Step 3: Add `merge?` to the interface** (`reducers.ts`, after `finalize`):
+```ts
+  /**
+   * Combine two independent partial states into one (then `finalize`
+   * once). Optional. Enables parallel/hierarchical aggregation
+   * (e.g. cross-shard or advisor→firm rollup). MUST be associative +
+   * commutative with `init()` as identity. Never merge finalized
+   * results — only states.
+   */
+  merge?(a: S, b: S): S
+```
+
+- [ ] **Step 4: Implement on the 5 built-ins.** Add a `merge` to each factory's returned object:
+- `count`: state is `number` → `merge: (a, b) => a + b`
+- `sum`: state is `number` → `merge: (a, b) => a + b`
+- `min`: state `{ value }` or number — match the actual state shape in the file; `merge` takes the lesser non-null. (Read the file: `min`/`max` state is likely `number | null`.) For `number|null`: `merge: (a, b) => a === null ? b : b === null ? a : Math.min(a, b)` (max → `Math.max`).
+- `avg`: state `{ sum, count }` → `merge: (a, b) => ({ sum: a.sum + b.sum, count: a.count + b.count })`.
+Match each factory's exact state type (read the impls; `avg` uses `{ sum, count }`).
+
+- [ ] **Step 5: Run the test — passes.** Then `pnpm --filter @noy-db/hub test` (additive — existing aggregate/MV tests stay green) + `tsc --noEmit` (+ typetest).
+
+- [ ] **Step 6: Commit.**
+```bash
+git add packages/hub/src/aggregate/reducers.ts packages/hub/__tests__/reducer-merge.test.ts
+git commit -m "feat(hub): optional Reducer.merge for parallel/hierarchical combine — closes #312 E"
+```
+
+---
+
+## Phase 3 — cross-vault live + aggregate slice (on the cross-vault-live branch)
+
+### Task 6: federation types for the live/aggregate surface
+
+**Files:**
+- Modify: `packages/hub/src/federation/types.ts`
+
+- [ ] **Step 1: Add the option + row + live interfaces** to `federation/types.ts`:
+
+```ts
+import type { LiveQuery } from '../query/live.js'
+import type { LiveAggregation } from '../aggregate/aggregation.js'
+import type { AggregateResult, AggregateSpec } from '../aggregate/aggregation.js'
+
+/** Options for the live/aggregate fan-out (extends the one-shot opts). */
+export interface LiveQueryOptions extends FanoutQueryOptions {
+  /** Coalesce window before recompute. Default 0 (microtask). */
+  readonly debounceMs?: number
+}
+
+/** A grouped aggregate output row: the grouped field + the reduced spec result. */
+export type GroupedRow<F extends string, Spec extends AggregateSpec> =
+  { readonly [K in F]: unknown } & AggregateResult<Spec>
+
+/** Reactive cross-shard record (or grouped-row) query — array-shaped, mirrors LiveQuery<T>. */
+export interface CrossVaultLiveQuery<T> extends LiveQuery<T> {
+  readonly skippedVaults: readonly SkippedVault[]
+  readonly ready: Promise<void>
+}
+
+/** Reactive cross-shard scalar aggregate — mirrors LiveAggregation<R>. */
+export interface CrossVaultLiveAggregation<R> extends LiveAggregation<R> {
+  readonly skippedVaults: readonly SkippedVault[]
+  readonly ready: Promise<void>
+}
+```
+(Verify the exact export names/paths of `AggregateResult`/`AggregateSpec`/`LiveAggregation` in `aggregate/aggregation.js` and `LiveQuery` in `query/live.js`; adjust imports.)
+
+- [ ] **Step 2: Typecheck.** `pnpm --filter @noy-db/hub exec tsc --noEmit` → clean.
+
+- [ ] **Step 3: Commit.**
+```bash
+git add packages/hub/src/federation/types.ts
+git commit -m "feat(federation): live/aggregate option + row + facade types"
+```
+
+---
+
+### Task 7: `CrossVaultLive<S>` reactive core
+
+**Files:**
+- Create: `packages/hub/src/federation/cross-vault-live.ts`
+- Test: `packages/hub/__tests__/cross-vault-live-core.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test** (drive the core with a fake emitter + async compute):
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { CrossVaultLive } from '../src/federation/cross-vault-live.js'
+
+function fakeEmitter() {
+  const hs = new Set<(e: any) => void>()
+  return {
+    subscribe: (h: (e: any) => void) => { hs.add(h); return () => hs.delete(h) },
+    fire: (e: any) => { for (const h of hs) h(e) },
+  }
+}
+const tick = () => new Promise<void>((r) => setTimeout(r, 0))
+
+it('computes initial snapshot, updates on relevant change, single-flights, stops', async () => {
+  const em = fakeEmitter()
+  let n = 0
+  const core = new CrossVaultLive<number>({
+    subscribeToChanges: em.subscribe,
+    isRelevant: (e) => e.relevant === true,
+    compute: async () => { await tick(); return ++n },
+    initialSnapshot: 0,
+    debounceMs: 0,
+  })
+  expect(core.snapshot).toBe(0)              // initial, before first settle
+  await core.ready                            // first compute settled
+  expect(core.snapshot).toBe(1)
+
+  let fired = 0
+  const off = core.subscribe(() => { fired++ })
+  em.fire({ relevant: false })                // ignored
+  await tick(); await tick()
+  expect(core.snapshot).toBe(1)
+  em.fire({ relevant: true })
+  await new Promise((r) => setTimeout(r, 5))
+  expect(core.snapshot).toBe(2)
+  expect(fired).toBeGreaterThanOrEqual(1)
+
+  off(); core.stop()
+  em.fire({ relevant: true })
+  await new Promise((r) => setTimeout(r, 5))
+  expect(core.snapshot).toBe(2)              // stopped → no recompute
+})
+```
+
+- [ ] **Step 2: Run it — fails** (module missing).
+
+- [ ] **Step 3: Implement `cross-vault-live.ts`:**
+
+```ts
+/**
+ * @category capability
+ * Reactive core for cross-vault live queries/aggregations. Generic over a
+ * snapshot S. Single-flight + microtask-coalesced recompute on relevant
+ * change. Mirrors the LiveQuery/LiveAggregation contracts via facades.
+ * Spec: docs/superpowers/specs/2026-06-07-cross-vault-live-and-aggregate-design.md.
+ */
+import type { ChangeEvent } from '../types.js'
+
+export interface CrossVaultLiveOptions<S> {
+  readonly subscribeToChanges: (handler: (e: ChangeEvent) => void) => () => void
+  readonly isRelevant: (e: ChangeEvent) => boolean
+  readonly compute: () => Promise<S>
+  readonly initialSnapshot: S
+  readonly debounceMs?: number
+}
+
+export class CrossVaultLive<S> {
+  snapshot: S
+  error: Error | null = null
+  readonly ready: Promise<void>
+
+  private readonly subs = new Set<() => void>()
+  private readonly unsubChange: () => void
+  private readonly opts: CrossVaultLiveOptions<S>
+  private stopped = false
+  private computing = false
+  private dirty = false
+  private scheduled = false
+  private timer: ReturnType<typeof setTimeout> | null = null
+  private resolveReady!: () => void
+  private settledOnce = false
+
+  constructor(opts: CrossVaultLiveOptions<S>) {
+    this.opts = opts
+    this.snapshot = opts.initialSnapshot
+    this.ready = new Promise<void>((res) => { this.resolveReady = res })
+    this.unsubChange = opts.subscribeToChanges((e) => {
+      if (this.stopped || !opts.isRelevant(e)) return
+      this.schedule()
+    })
+    this.schedule() // initial compute
+  }
+
+  subscribe(cb: () => void): () => void {
+    if (this.stopped) return () => {}
+    this.subs.add(cb)
+    return () => this.subs.delete(cb)
+  }
+
+  stop(): void {
+    if (this.stopped) return
+    this.stopped = true
+    this.unsubChange()
+    if (this.timer !== null) clearTimeout(this.timer)
+    this.subs.clear()
+    if (!this.settledOnce) this.resolveReady() // never leave ready dangling
+  }
+
+  private schedule(): void {
+    if (this.stopped) return
+    if (this.computing) { this.dirty = true; return }
+    if (this.scheduled) return
+    this.scheduled = true
+    const run = () => { this.scheduled = false; void this.runCompute() }
+    const ms = this.opts.debounceMs ?? 0
+    if (ms > 0) this.timer = setTimeout(run, ms)
+    else queueMicrotask(run)
+  }
+
+  private async runCompute(): Promise<void> {
+    if (this.stopped) return
+    this.computing = true
+    this.dirty = false
+    try {
+      const next = await this.opts.compute()
+      if (this.stopped) return
+      this.snapshot = next
+      this.error = null
+    } catch (err) {
+      if (this.stopped) return
+      this.error = err instanceof Error ? err : new Error(String(err))
+    } finally {
+      this.computing = false
+      if (!this.stopped) {
+        if (!this.settledOnce) { this.settledOnce = true; this.resolveReady() }
+        for (const cb of this.subs) cb()
+        if (this.dirty) this.schedule()
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the test — passes.** + `tsc --noEmit`.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/hub/src/federation/cross-vault-live.ts packages/hub/__tests__/cross-vault-live-core.test.ts
+git commit -m "feat(federation): CrossVaultLive reactive core (single-flight + debounce + ready)"
+```
+
+---
+
+### Task 8: extract `resolveEligible` / `fanoutRecords` (DRY refactor)
+
+**Files:**
+- Modify: `packages/hub/src/federation/vault-group.ts`
+- Test: `packages/hub/__tests__/federation-vault-group.test.ts` (existing — regression only)
+
+- [ ] **Step 1: Add `VaultGroup.resolveEligible`** (lift the minVersion + provisioning logic out of `toArray`):
+
+```ts
+  /** @internal — eligible (openable-candidate) rows + drift/divergence skips. */
+  async resolveEligible(options: { minVersion?: number } = {}): Promise<{
+    eligible: VaultRegistryRow[]
+    skipped: SkippedVault[]
+  }> {
+    const rows = await this.allRows()
+    const skipped: SkippedVault[] = []
+    const versionOk: VaultRegistryRow[] = []
+    for (const row of rows) {
+      if (options.minVersion !== undefined && row.schemaVersion < options.minVersion) {
+        skipped.push({ vaultId: row.vaultId, reason: 'schema-drift' })
+      } else versionOk.push(row)
+    }
+    const provisioned = await Promise.all(versionOk.map((r) => this.db._shardVaultProvisioned(r.vaultId)))
+    const eligible: VaultRegistryRow[] = []
+    versionOk.forEach((row, i) => {
+      if (provisioned[i]) eligible.push(row)
+      else skipped.push({ vaultId: row.vaultId, reason: 'error', error: new ShardProvisioningError(row.vaultId, row.partitionKey) })
+    })
+    return { eligible, skipped }
+  }
+```
+
+- [ ] **Step 2: Add `ShardedQuery.fanoutRecords`** (the shared record fan-out):
+
+```ts
+  /** @internal — fan out the where-filtered records across eligible shards. */
+  async fanoutRecords(options: FanoutQueryOptions = {}): Promise<{ records: R[]; skippedVaults: SkippedVault[] }> {
+    const { eligible, skipped } = await this.group.resolveEligible(options)
+    const across = await this.group.db.queryAcross<R[]>(
+      eligible.map((r) => r.vaultId),
+      async (vault) => {
+        this.group.template.configure(vault)
+        const coll = vault.collection<R>(this.collectionName)
+        await coll.list()
+        let q = coll.query()
+        for (const c of this.clauses) q = q.where(c.field, c.op, c.value)
+        return q.toArray()
+      },
+      { concurrency: options.concurrency ?? 1, create: false },
+    )
+    const results: R[] = []
+    for (const r of across) {
+      if (r.error) skipped.push({ vaultId: r.vault, reason: classifyShardSkip(r.error), error: r.error })
+      else for (const item of r.result) results.push(item)
+    }
+    return { records: results, skippedVaults: skipped }
+  }
+```
+
+- [ ] **Step 3: Reduce `toArray` to one line:**
+```ts
+  async toArray(options: FanoutQueryOptions = {}): Promise<FanoutResult<R>> {
+    const { records, skippedVaults } = await this.fanoutRecords(options)
+    return { results: records, skippedVaults }
+  }
+```
+
+- [ ] **Step 4: Run the full federation file — all 16 MVP tests + Task-3 no-grant test still pass** (behavior identical). `pnpm --filter @noy-db/hub exec vitest run __tests__/federation-vault-group.test.ts` + `tsc --noEmit`.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/hub/src/federation/vault-group.ts
+git commit -m "refactor(federation): extract resolveEligible/fanoutRecords (shared by toArray/live/aggregate)"
+```
+
+---
+
+### Task 9: `ShardedQuery.live()` + `CrossVaultLiveQuery` facade
+
+**Files:**
+- Modify: `packages/hub/src/federation/vault-group.ts`
+- Test: `packages/hub/__tests__/federation-query-aggregate.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test** (reuse the harness from `federation-vault-group.test.ts` — copy `memory()`/`Invoice`/`harness` into this file; add `waitFor`):
+
+```ts
+async function waitFor(pred: () => boolean, { timeout = 1000, interval = 5 } = {}) {
+  const start = Date.now()
+  while (!pred()) { if (Date.now() - start > timeout) throw new Error('waitFor timeout'); await new Promise((r) => setTimeout(r, interval)) }
+}
+
+it('live() reflects initial + reacts to writes + picks up a new shard, then stop()', async () => {
+  const h = await harness()
+  await h.firm.collection('invoices').put('a1', { clientId: 'acme', amount: 100, status: 'overdue' })
+  const lq = h.firm.collection('invoices').query().where('status', '==', 'overdue').live()
+  await lq.ready
+  expect(lq.value.map((r) => r.amount)).toEqual([100])
+  expect(lq.skippedVaults).toEqual([])
+
+  await h.firm.collection('invoices').put('b1', { clientId: 'beta', amount: 200, status: 'overdue' }) // new shard
+  await waitFor(() => lq.value.length === 2)
+  expect(lq.value.map((r) => r.amount).sort((x, y) => x - y)).toEqual([100, 200])
+
+  lq.stop()
+  await h.firm.collection('invoices').put('a2', { clientId: 'acme', amount: 300, status: 'overdue' })
+  await new Promise((r) => setTimeout(r, 30))
+  expect(lq.value.length).toBe(2) // stopped
+})
+```
+
+- [ ] **Step 2: Run it — fails** (`.live` missing).
+
+- [ ] **Step 3: Implement `ShardedQuery.live`** in `vault-group.ts` (+ the facade). Add imports for `CrossVaultLive` and the facade types, then:
+
+```ts
+  live(options: LiveQueryOptions = {}): CrossVaultLiveQuery<R> {
+    const group = this.group
+    const collectionName = this.collectionName
+    const core = new CrossVaultLive<{ records: R[]; skipped: SkippedVault[] }>({
+      subscribeToChanges: (h) => { group.db.on('change', h); return () => group.db.off('change', h) },
+      isRelevant: (e) => e.collection === collectionName && e.vault.startsWith(`${group.name}--`),
+      compute: async () => {
+        const { records, skippedVaults } = await this.fanoutRecords(options)
+        return { records, skipped: skippedVaults }
+      },
+      initialSnapshot: { records: [], skipped: [] },
+      ...(options.debounceMs !== undefined ? { debounceMs: options.debounceMs } : {}),
+    })
+    return {
+      get value() { return core.snapshot.records as readonly R[] },
+      get skippedVaults() { return core.snapshot.skipped as readonly SkippedVault[] },
+      get error() { return core.error },
+      ready: core.ready,
+      subscribe: (cb) => core.subscribe(cb),
+      stop: () => core.stop(),
+    }
+  }
+```
+(`LiveQueryOptions`, `CrossVaultLiveQuery`, `SkippedVault` imported from `./types.js`; `CrossVaultLive` from `./cross-vault-live.js`.)
+
+- [ ] **Step 4: Run the test — passes.** + `tsc --noEmit`.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/hub/src/federation/vault-group.ts packages/hub/__tests__/federation-query-aggregate.test.ts
+git commit -m "feat(federation): ShardedQuery.live() — reactive cross-shard records (queryAcrossLive)"
+```
+
+---
+
+### Task 10: `aggregate(spec)` / `groupBy().aggregate(spec)` one-shot
+
+**Files:**
+- Create: `packages/hub/src/federation/aggregate-across.ts`
+- Modify: `packages/hub/src/federation/vault-group.ts` (`aggregate`, `groupBy`, `ShardedGroupedQuery`)
+- Test: `packages/hub/__tests__/federation-query-aggregate.test.ts` (append)
+
+- [ ] **Step 1: Write the failing test** (avg correctness across shards is the key assertion):
+
+```ts
+import { sum, count, avg } from '../src/aggregate/reducers.js'
+
+it('aggregate across shards: sum/count/avg correct (avg = central reduce, not avg-of-avgs)', async () => {
+  const h = await harness()
+  const inv = h.firm.collection('invoices')
+  await inv.put('a1', { clientId: 'acme', amount: 100, status: 'open' })
+  await inv.put('a2', { clientId: 'acme', amount: 200, status: 'open' })
+  await inv.put('b1', { clientId: 'beta', amount: 300, status: 'open' })
+  const { result, skippedVaults } = await h.firm.collection('invoices').query()
+    .aggregate({ total: sum('amount'), n: count(), mean: avg('amount') }).run()
+  expect(skippedVaults).toEqual([])
+  expect(result.total).toBe(600)
+  expect(result.n).toBe(3)
+  expect(result.mean).toBe(200) // NOT (150+300)/2 = 225
+})
+
+it('groupBy(status).aggregate sums per status across shards', async () => {
+  const h = await harness()
+  const inv = h.firm.collection('invoices')
+  await inv.put('a1', { clientId: 'acme', amount: 100, status: 'overdue' })
+  await inv.put('b1', { clientId: 'beta', amount: 300, status: 'overdue' })
+  await inv.put('b2', { clientId: 'beta', amount: 50, status: 'open' })
+  const { results } = await h.firm.collection('invoices').query()
+    .groupBy('status').aggregate({ total: sum('amount') }).run()
+  const overdue = results.find((r) => r.status === 'overdue')
+  expect(overdue?.total).toBe(400)
+})
+```
+
+- [ ] **Step 2: Run it — fails** (`.aggregate`/`.groupBy` missing).
+
+- [ ] **Step 3: Create `federation/aggregate-across.ts`:**
+
+```ts
+import { reduceRecords } from '../aggregate/aggregation.js'
+import { groupAndReduce } from '../aggregate/groupby.js'
+import type { AggregateResult, AggregateSpec } from '../aggregate/aggregation.js'
+import type { FanoutQueryOptions, SkippedVault, GroupedRow, CrossVaultLiveAggregation, CrossVaultLiveQuery } from './types.js'
+
+export interface FanoutRecordSource<R> {
+  fanoutRecords(options: FanoutQueryOptions): Promise<{ records: R[]; skippedVaults: SkippedVault[] }>
+}
+
+export class CrossVaultAggregation<R, Spec extends AggregateSpec> {
+  constructor(private readonly src: FanoutRecordSource<R>, private readonly spec: Spec) {}
+  async run(options: FanoutQueryOptions = {}): Promise<{ result: AggregateResult<Spec>; skippedVaults: SkippedVault[] }> {
+    const { records, skippedVaults } = await this.src.fanoutRecords(options)
+    return { result: reduceRecords(records, this.spec), skippedVaults }
+  }
+  // live(): CrossVaultLiveAggregation<...> — added in Task 11
+}
+
+export class CrossVaultGroupedAggregation<R, F extends string, Spec extends AggregateSpec> {
+  constructor(private readonly src: FanoutRecordSource<R>, private readonly field: F, private readonly spec: Spec) {}
+  async run(options: FanoutQueryOptions = {}): Promise<{ results: GroupedRow<F, Spec>[]; skippedVaults: SkippedVault[] }> {
+    const { records, skippedVaults } = await this.src.fanoutRecords(options)
+    return { results: groupAndReduce<GroupedRow<F, Spec>>(records, this.field, this.spec), skippedVaults }
+  }
+  // live(): CrossVaultLiveQuery<...> — added in Task 11
+}
+```
+(Verify `reduceRecords`/`groupAndReduce` import paths; both confirmed in `aggregate/`.)
+
+- [ ] **Step 4: Add `aggregate`/`groupBy` to `ShardedQuery` + `ShardedGroupedQuery`** in `vault-group.ts`:
+
+```ts
+  aggregate<Spec extends AggregateSpec>(spec: Spec): CrossVaultAggregation<R, Spec> {
+    return new CrossVaultAggregation<R, Spec>(this, spec)
+  }
+  groupBy<F extends string>(field: F): ShardedGroupedQuery<T, R, F> {
+    return new ShardedGroupedQuery<T, R, F>(this, field)
+  }
+```
+```ts
+export class ShardedGroupedQuery<T, R, F extends string> {
+  constructor(private readonly query: ShardedQuery<T, R>, private readonly field: F) {}
+  aggregate<Spec extends AggregateSpec>(spec: Spec): CrossVaultGroupedAggregation<R, F, Spec> {
+    return new CrossVaultGroupedAggregation<R, F, Spec>(
+      { fanoutRecords: (o) => this.query.fanoutRecords(o) }, this.field, spec,
+    )
+  }
+}
+```
+(`ShardedQuery` already satisfies `FanoutRecordSource<R>` via `fanoutRecords`; pass `this`.)
+
+- [ ] **Step 5: Run the tests — pass.** + `tsc --noEmit`.
+
+- [ ] **Step 6: Commit.**
+```bash
+git add packages/hub/src/federation/aggregate-across.ts packages/hub/src/federation/vault-group.ts packages/hub/__tests__/federation-query-aggregate.test.ts
+git commit -m "feat(federation): aggregateAcross — one-shot distributed reduce + groupBy (central reduce)"
+```
+
+---
+
+### Task 11: `aggregate().live()` (reactive distributed reduce)
+
+**Files:**
+- Modify: `packages/hub/src/federation/aggregate-across.ts`
+- Test: `packages/hub/__tests__/federation-query-aggregate.test.ts` (append)
+
+- [ ] **Step 1: Write the failing test:**
+
+```ts
+it('aggregate().live() updates the scalar on write', async () => {
+  const h = await harness()
+  await h.firm.collection('invoices').put('a1', { clientId: 'acme', amount: 100, status: 'open' })
+  const la = h.firm.collection('invoices').query().aggregate({ total: sum('amount') }).live()
+  await la.ready
+  expect(la.value?.total).toBe(100)
+  await h.firm.collection('invoices').put('b1', { clientId: 'beta', amount: 50, status: 'open' })
+  await waitFor(() => la.value?.total === 150)
+  la.stop()
+})
+```
+
+- [ ] **Step 2: Run it — fails** (`.live` missing on the aggregation wrapper).
+
+- [ ] **Step 3: Add `live()` to both wrappers** in `aggregate-across.ts`. They need the group's emitter + relevance; thread a small `LiveBinding` from `ShardedQuery` (the group name + collection + `db`). Extend the wrappers' constructors to also accept a `bind: { subscribeToChanges, isRelevant }` (built by `ShardedQuery` the same way `live()` does), then:
+
+```ts
+  // on CrossVaultAggregation:
+  live(options: LiveQueryOptions = {}): CrossVaultLiveAggregation<AggregateResult<Spec>> {
+    const core = new CrossVaultLive<{ value: AggregateResult<Spec> | undefined; skipped: SkippedVault[] }>({
+      ...this.bind,
+      compute: async () => {
+        const { records, skippedVaults } = await this.src.fanoutRecords(options)
+        return { value: reduceRecords(records, this.spec), skipped: skippedVaults }
+      },
+      initialSnapshot: { value: undefined, skipped: [] },
+      ...(options.debounceMs !== undefined ? { debounceMs: options.debounceMs } : {}),
+    })
+    return {
+      get value() { return core.snapshot.value },
+      get skippedVaults() { return core.snapshot.skipped },
+      get error() { return core.error },
+      ready: core.ready,
+      subscribe: (cb) => core.subscribe(cb),
+      stop: () => core.stop(),
+    }
+  }
+```
+`CrossVaultGroupedAggregation.live()` is the same but snapshot `{ rows: GroupedRow[]; skipped }`, returns a `CrossVaultLiveQuery<GroupedRow<F,Spec>>` (value = rows, array-shaped), using `groupAndReduce`. Update `ShardedQuery.aggregate`/`ShardedGroupedQuery.aggregate` to pass the `bind` (factor the `subscribeToChanges`/`isRelevant` construction from Task 9 into a small `ShardedQuery.liveBinding()` helper and reuse it).
+
+- [ ] **Step 4: Run the test — passes.** + `tsc --noEmit`.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/hub/src/federation/aggregate-across.ts packages/hub/src/federation/vault-group.ts packages/hub/__tests__/federation-query-aggregate.test.ts
+git commit -m "feat(federation): aggregateAcrossLive — reactive distributed reduce (ungrouped + grouped)"
+```
+
+---
+
+### Task 12: public exports + adapter shape-compat type test
+
+**Files:**
+- Modify: `packages/hub/src/federation/index.ts`, `packages/hub/src/index.ts`
+- Test: `packages/hub/__tests__/cross-vault-live.test-d.ts` (new)
+
+- [ ] **Step 1: Write the type-compat test** (`*.test-d.ts`, checked by `tsconfig.typetest.json`):
+
+```ts
+import { expectTypeOf } from 'vitest'
+import type { CrossVaultLiveQuery, CrossVaultLiveAggregation } from '../src/federation/index.js'
+import type { LiveQuery } from '../src/query/live.js'
+import type { LiveAggregation } from '../src/aggregate/aggregation.js'
+
+expectTypeOf<CrossVaultLiveQuery<{ a: number }>>().toMatchTypeOf<LiveQuery<{ a: number }>>()
+expectTypeOf<CrossVaultLiveAggregation<{ total: number }>>().toMatchTypeOf<LiveAggregation<{ total: number }>>()
+```
+
+- [ ] **Step 2: Add exports.** In the internal barrel `federation/index.ts`, value-export the new
+classes (internal consumers may need them):
+```ts
+export { CrossVaultAggregation, CrossVaultGroupedAggregation } from './aggregate-across.js'
+export { ShardedGroupedQuery } from './vault-group.js'
+export type { CrossVaultLiveQuery, CrossVaultLiveAggregation, LiveQueryOptions, GroupedRow } from './types.js'
+```
+(`CrossVaultLive` is the internal reactive core — do **not** export it from the public entry.)
+
+From the **public entry** `packages/hub/src/index.ts`, re-export these **type-only** — matching the
+MVP convention (`export type { VaultGroup, ShardedCollection, ShardedQuery }`). These classes are
+**never constructed by consumers** — `CrossVaultAggregation`/`CrossVaultGroupedAggregation` are
+returned by `.aggregate()`, `ShardedGroupedQuery` by `.groupBy()`, the live facades by `.live()`.
+Type-only keeps the only runtime edge to federation the dynamic `import()` in `openVaultGroup`, so
+the chunk stays excluded for ESM/CJS/non-tree-shaking consumers alike:
+```ts
+export type {
+  CrossVaultAggregation, CrossVaultGroupedAggregation, ShardedGroupedQuery,
+  CrossVaultLiveQuery, CrossVaultLiveAggregation, LiveQueryOptions, GroupedRow,
+} from './federation/index.js'
+```
+(If any of these is genuinely needed as a runtime value by a consumer — none is today — promote it
+to a value export *and* re-verify the bundle-floor leak canaries stay clean.)
+
+- [ ] **Step 3: Run typecheck + typetest.** `pnpm --filter @noy-db/hub run typecheck` → clean (both configs).
+
+- [ ] **Step 4: Commit.**
+```bash
+git add packages/hub/src/federation/index.ts packages/hub/src/index.ts packages/hub/__tests__/cross-vault-live.test-d.ts
+git commit -m "feat(federation): export live/aggregate surface + LiveQuery shape-compat type test"
+```
+
+---
+
+### Task 13: showcase 99 + features.yaml
+
+**Files:**
+- Create: `showcases/src/99-vault-group-live-aggregate.showcase.test.ts`
+- Modify: `features.yaml`
+
+- [ ] **Step 1: Write the showcase** (mirror showcase 98's structure; import from `@noy-db/hub` + `@noy-db/to-memory`). Demonstrate: `.query().where().live()` (assert via `await lq.ready` + a `waitFor` after a write), `.aggregate({...}).run()` (sum/avg across shards), `.groupBy('clientId').aggregate({...}).run()`. Generic firm/clients framing, no client names.
+
+- [ ] **Step 2: Rebuild hub + run the showcase.**
+```bash
+pnpm --filter @noy-db/hub build
+pnpm --filter @noy-db/showcases exec vitest run src/99-vault-group-live-aggregate.showcase.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 3: Register in `features.yaml`** — add to the `vault-group-federation` entry's `showcases:` list:
+```yaml
+      - id: 99-vault-group-live-aggregate
+        path: showcases/src/99-vault-group-live-aggregate.showcase.test.ts
+```
+
+- [ ] **Step 4: Validate.** `node scripts/validate-features.mjs` → OK.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add showcases/src/99-vault-group-live-aggregate.showcase.test.ts features.yaml
+git commit -m "docs(federation): showcase 99 — live + distributed aggregate; register in features.yaml"
+```
+
+---
+
+### Task 14: final verification
+
+- [ ] **Step 1: Full gate.**
+```bash
+pnpm --filter @noy-db/hub run typecheck
+pnpm --filter @noy-db/hub test
+node scripts/validate-features.mjs
+pnpm --filter @noy-db/hub build
+pnpm --filter @noy-db/hub bundle-check     # federation stays a lazy chunk; note the pre-existing stale-baseline caveat — judge by leak canaries, not headline gz
+node scripts/check-architecture.mjs        # collection.ts unchanged here; openVault edit is small — confirm kernel-surface ceiling not breached
+```
+Expected: typecheck/test/validate-features/architecture pass; bundle-check leak canaries clean (federation not in core entry).
+
+- [ ] **Step 2: Confirm `join.ts` untouched.** `git diff --stat main -- packages/hub/src/query/join.ts` → empty.
+
+---
+
+## Self-review notes (for the implementer)
+
+- **Spec coverage:** A → Tasks 1–4; B → Tasks 2–4 (no-create open + contract doc); E → Task 5; reactive core → Task 7; `live()` → Task 9; `aggregate`/`groupBy` one-shot → Task 10; `aggregate().live()` → Task 11; `ready`/`stop`/`skippedVaults`/shape-compat → Tasks 7/9/11/12; central-reduce + avg correctness → Task 10; showcase → Task 13.
+- **No-grant test realism (Task 3):** uses a real second identity with a grant to only one shard — this exercises the actual `NoAccessError` path, and asserts no rogue keyring is written (the security property). If the grant/role API differs, align with `cross-vault.test.ts`; the behavioral contract (no-grant skip + no self-provision) is fixed.
+- **Type consistency:** `fanoutRecords` returns `{ records, skippedVaults }` everywhere; `CrossVaultAggregation.run` returns `{ result, skippedVaults }`; grouped returns `{ results, skippedVaults }`; live facades expose `value`/`skippedVaults`/`error`/`ready`/`subscribe`/`stop`.
+- **merge is state-level (Task 5):** the test asserts merge-then-finalize ≡ reduce-over-concatenation — never merge finalized results.
+- **Deferred (do NOT build):** distributed partial-reduce using `merge`, hierarchical rollup, multi-key groupBy, framework adapters, the four #312 out-of-scope items.
+```

--- a/docs/superpowers/specs/2026-06-07-cross-vault-live-and-aggregate-design.md
+++ b/docs/superpowers/specs/2026-06-07-cross-vault-live-and-aggregate-design.md
@@ -1,0 +1,304 @@
+# Cross-Vault Live Queries & Distributed Aggregate — Design
+
+- **Date:** 2026-06-07
+- **Milestone:** 16 — Multi-vault partition federation (epic #271)
+- **Status:** Design approved; revised to fold in the #312 forward-compat amendments (A/B/E) — pending re-review, follows the VaultGroup routing MVP (PR #292)
+- **Scope:** `queryAcrossLive` (reactive record fan-out) + `aggregateAcross` (one-shot distributed reduce, scalars + groupBy) + `aggregateAcrossLive` (reactive distributed reduce), all on the `ShardedQuery` surface — made **key-custody-neutral** per #312
+
+## #312 forward-compat amendments (folded in)
+
+This revision absorbs three forward-compat changes from #312 (custodial multi-tenant adopter, epic #271). They are cheap pre-implementation and expensive to retrofit once the surface ossifies:
+
+- **A — `SkippedVault.reason: 'no-grant'`** distinct from `'error'`. A fan-out identity that legitimately lacks a grant to a shard must be reported as access-scoping, not a fault.
+- **B — key-custody-neutral fan-out contract.** Drop "single operator owns all shards" from the *contract*: VaultGroup ops run as an identity holding *some* grants; the eligible/returned set is the **openable subset**, not necessarily all shards. All-owning-operator is one configuration.
+- **E — optional `Reducer.merge(S,S): S`** on the aggregate protocol (complements `remove`/`seed`), enabling parallel + hierarchical combine. **Central-reduce stays the default** for this slice; `merge` is the seam that unblocks distributed partial-reduce and advisor→firm rollup later.
+
+**Load-bearing finding (beyond #312 as written):** A+B require a real behavior change, not just a new union member. `loadKeyring` throws `NoAccessError` when *this* identity's `_keyring/<userId>` is absent without checking whether the vault has *other* principals; `getKeyringInternal` then treats that as "first boot" and **`createOwnerKeyring`s a fresh owner keyring with new DEKs into the vault**. So a non-granted fan-out open today would *silently self-provision* (zero-record read, stray keyring written) instead of failing — there'd be nothing for A to classify, and B's model would be actively unsafe. Resolution (chosen): a **contained no-create open mode** used only by the read fan-out (below); global `openVault` behavior is unchanged.
+
+## Goal
+
+Extend the VaultGroup read surface from the MVP (one-shot `query().where().toArray()`)
+with **reactive cross-shard queries** and **distributed aggregation**, so a firm can
+render a live "all overdue invoices across every client" list or "total revenue per
+client" dashboard without manually wiring N per-vault subscriptions or stitching N
+aggregate queries.
+
+## Scope
+
+### In scope
+- `ShardedQuery.live(opts?)` → `CrossVaultLiveQuery<R>` — reactive merged records across shards (the epic's `queryAcrossLive`).
+- `ShardedQuery.aggregate(spec)` / `ShardedQuery.groupBy(field).aggregate(spec)` → a `CrossVaultAggregation` / `CrossVaultGroupedAggregation` wrapper with:
+  - `.run(opts?)` — one-shot distributed reduce (the epic's `aggregateAcross`).
+  - `.live(opts?)` — reactive distributed reduce (`aggregateAcrossLive`).
+- Reducers: `count` / `sum` / `avg` / `min` / `max` (the existing `@noy-db/hub/aggregate` reducers) + single-field `groupBy`.
+- All live primitives expose `ready: Promise<void>` (resolves after first settle) and carry `skippedVaults`.
+- **(A)** `SkippedVault.reason` gains `'no-grant'`; the fan-out opens shards non-creatingly and classifies authz failures distinctly.
+- **(B)** Key-custody-neutral contract stated in the subsystem doc + this spec; the implementation already returns the openable subset.
+- **(E)** `Reducer.merge?(a,b): S` added to the protocol + the 5 built-ins, with unit tests. (Used as a seam; aggregate impl stays central-reduce.)
+
+### Out of scope / deferred (with reason)
+- **Framework adapter bindings** (`in-vue` / `in-react` / `in-pinia` / `in-zustand`). The cross-vault live primitives are made *structurally assignable* to the existing `LiveQuery<T>` / `LiveAggregation<R>` contracts (verified by a type test) so adapters can bind them later, but no framework package is modified in this slice.
+- **Distributed partial-reduce + hierarchical rollup.** This slice adds the `Reducer.merge` *protocol* (E) but the `aggregateAcross` *implementation* stays **central reduce** (fan out the `where`-filtered records, concatenate, reduce once on the coordinator — correct for all reducers incl. `avg`). Rewriting the aggregate into a per-shard partial-state → merge-by-bucket engine (transfers tiny states; enables advisor→firm rollup) is a follow-up that *consumes* `merge`. Adding the protocol method now is the cheap, expensive-to-retrofit part; using it pervasively is deferred.
+- **Multi-key `groupBy`.** `groupAndReduce` already accepts `string | readonly string[]`, so multi-key is nearly free at runtime; this slice exposes only single-field `groupBy(field)` to keep the typed row shape simple. Multi-key is a deliberate, low-cost follow-up.
+- **Public Noydb engine methods** `db.queryAcrossLive` / `db.aggregateAcross`. The features are delivered via the `ShardedQuery` ergonomic surface (which is what consumers use). No new method on the core `Noydb` class → zero new core-bundle weight. Naming map: epic `queryAcrossLive` → `ShardedQuery.live()`; epic `aggregateAcross` → `ShardedQuery.aggregate().run()`.
+- **`crossShardJoin`, `withCrossVaultDerivation`, fleet migration runner.** Other epic slices. `packages/hub/src/query/join.ts` remains untouched.
+
+## Architecture
+
+Most new code lives in the **federation module** (`packages/hub/src/federation/`), which is
+already lazily loaded as its own chunk (MVP). The reactive core reaches change events
+through the **already-public** `db.on('change', …)` / `db.off('change', …)`
+(`NoydbEventMap['change'] = ChangeEvent`). The live/reactive surface adds **no core
+weight**. Two small core touches are required by the #312 amendments: a no-create open
+option on `openVault`/`queryAcross` (A, below) and the additive `Reducer.merge?` on the
+aggregate protocol (E). Both are tiny and additive.
+
+### Key-custody-neutral fan-out (#312 A + B)
+
+The read fan-out must open shards **non-creatingly**, so a missing grant fails cleanly
+instead of self-provisioning:
+
+- **Core:** `openVault(name, { create?: boolean })` (default `true`, unchanged). When
+  `create: false`, `getKeyringInternal` re-throws `NoAccessError` (and does not run
+  `createOwnerKeyring`) instead of minting a keyring. `queryAcross(ids, fn, { create: false })`
+  threads it through.
+- **Both open paths are non-creating (#312 comment §1).** Self-provisioning must not be
+  re-opened on the single-shard path: a scoped non-owner can call `shard(key)` (drill-down) or
+  route a `put` to an existing shard it lacks a grant to. So **`openShard` opens non-creatingly**
+  (it means "open an *existing* shard") — `shard()` and `put`-routing-to-an-existing-row both go
+  through it and fail cleanly with `NoAccessError`. **`createShard` remains the sole creating
+  path** (its create branch uses `openVault({ create: true })` directly; its idempotent
+  `row && provisioned` branch calls the non-creating `openShard`, which still succeeds for a
+  granted owner). Read fan-out (`toArray`/`live`/`aggregate`) opens via `queryAcross({ create: false })`.
+- **Classification (A) — `NoAccessError` only (#312 comment §2).** `classifyShardSkip(err)`:
+  `err instanceof NoAccessError` → `reason: 'no-grant'`; **everything else → `reason: 'error'`**.
+  `NoAccessError` (no keyring envelope for this identity) is the *unambiguous* not-granted signal.
+  `InvalidKeyError`/`DecryptionError` are **not** classified as no-grant: per `loadKeyring`,
+  the "no DEK unwrapped + canary failed" path is *"wrong KEK **or whole-file corruption**"* — so
+  bucketing it as the benign `'no-grant'` could mask corruption. A keyring that exists but won't
+  unlock (credential mismatch) or is corrupt is a real fault to surface, not a silent skip.
+  `KeyringCorruptError` and `ShardProvisioningError` (registry row present, vault *gone* — caught
+  *before* the open by the `store.list` provisioning guard, unaffected by grants) likewise stay
+  `'error'`. A pinning test asserts a corruption scenario surfaces as `'error'`, never `'no-grant'`.
+- **Contract (B):** the eligible/returned set is the **openable subset** for the calling
+  identity, not necessarily all shards. A non-granted shard appears in `skippedVaults` with
+  `reason: 'no-grant'` — *expected* under scoped access, not a fault. All-owning-operator is
+  one configuration. Stated in the subsystem doc + this spec so consumers don't bake in
+  completeness.
+- **Registry-grant prerequisite (B).** Opening the group at all requires a grant to the
+  **StateManagement/registry vault** — the caller passes in an already-opened `vault-registry`
+  collection handle (`openVaultGroup` doesn't self-open it), so a caller who can't open that
+  vault can't construct the group. *Shard* grants then determine the openable subset *within*
+  it. (Concretely: a scoped advisor needs read access to the registry vault plus grants to
+  their ~40–50 client shards; the registry rows are plaintext metadata — `vaultId`,
+  `partitionKey`, `schemaVersion` — no per-client DEK.)
+- **Scope boundary (residual, tracked separately).** This is a *contained* fix on the
+  federation open paths. Global `openVault` is unchanged: a non-granted identity opening a
+  vault **outside** the federation surface still self-provisions today (the `getKeyringInternal`
+  → `createOwnerKeyring` fallback fires whenever the caller's keyring is absent, without
+  checking for other principals). Closing that hub-wide — `createOwnerKeyring` only on a
+  genuinely-new vault (no `_keyring/*` at all) — is broad-blast-radius and out of scope here;
+  filed as **#313** (the load-bearing fix for multi-tenant, since many non-federation paths
+  also `openVault` by name — scoped drill-down, server-side insight executor, bundle
+  import/adopt, recovery). **The `create` flag added here composes with #313's planned design**
+  (create only when the vault has no `_keyring/*` at all; explicit `create: true` as the opt-in
+  escape hatch for genuine create-into-existing) — so #313 tightens the `create: true` *default*
+  semantics without reworking this flag: federation reads/drill-down already pass `create: false`,
+  and `createShard` only ever creates genuinely-new shards.
+
+### Registry visibility — roster existence is NOT scoped (#312 comment §3)
+
+Making the registry the entry gate (B) means **registry-read exposes the whole roster.** The
+`vault-registry` is one shared collection of **plaintext** rows; a scoped identity granted
+registry-read to discover *its* shards reads **every** row — learning the `partitionKey` /
+`vaultId` of *all* participants, including shards it cannot open. **Shard-level data access is
+scoped; roster-level existence is not.** Two consequences:
+
+1. **`keyOf` must return an opaque partition key.** Because `partitionKey`/`vaultId` are
+   plaintext-visible to every group member, they must not encode anything sensitive — for the
+   custodial adopter, **not** `keyOf: r => r.taxId` or a client name, but an opaque internal id
+   (e.g. a ULID `clientId`), with sensitive identifiers living *inside* the client's vault
+   records. Then the leak is bounded to "N opaque vaults exist," normally acceptable. Stated as
+   guidance in the subsystem doc (the natural temptation is to key by a human identifier).
+2. **Per-identity roster scoping is a known boundary, not provided here.** If an adopter needs
+   an identity to see *only its assigned* registry rows (not the full roster), a single shared
+   plaintext registry can't deliver that — it needs registry-row-level access control or
+   per-identity registry views, a larger design out of scope for this slice. Named so adopters
+   don't assume the registry grant confers row-level scoping.
+
+   **Pre-filter optimization — must preserve A's signal (#312 comment §4).** A scoped identity's
+   full-roster fan-out yields many `'no-grant'` skips (one per shard it can't open). A future
+   optimization can pre-filter — intersect registry `vaultId`s with the caller's grant set
+   *before* fan-out — to avoid N failing opens (no registry change needed; the caller knows its
+   grants). **But it must NOT make non-granted shards silently absent** — that would turn A's
+   *visible* scoping back into *invisible* scoping and hide a **misconfigured** grant (an advisor
+   who *should* have shard X but doesn't would just vanish from results instead of surfacing as a
+   `'no-grant'` entry the UI can flag). So the optimization must either be **opt-in**, or still
+   **emit the pre-filtered shards as `'no-grant'` skips** (computed from registry ∖ grants, emitted
+   without opening) — keeping B's "openable subset is *explicit*, not silently truncated" property.
+
+Three units (live/aggregate surface):
+
+### 1. `CrossVaultLive<S>` — the reactive core (`federation/cross-vault-live.ts`)
+
+A generic reactive loop over a **snapshot** `S`. One implementation, two facades.
+
+```
+db.on('change') ──filter(isRelevant)──▶ scheduleRecompute ──debounce/single-flight──▶ compute(): Promise<S>
+                                                                                          │
+                                          snapshot = S ; error = null|err ; notify() ◀────┘
+```
+
+State & contract:
+- `snapshot: S` — current full result (starts at `initialSnapshot`).
+- `error: Error | null`.
+- `ready: Promise<void>` — resolves after the **first** compute settles (success or error). Serves SSR / "spinner until first result" / deterministic tests.
+- `subscribe(cb): () => void` — fires after each settle (including the first if subscribed before it); does **not** fire synchronously on subscribe. Returns an unsubscribe fn.
+- `stop(): void` — unsubscribe from the emitter, cancel any pending schedule, clear subscribers, mark stopped (later in-flight results are discarded). Idempotent.
+
+Reactivity rules:
+- **Relevance filter** (provided by the caller). For VaultGroup: `e.collection === collectionName && e.vault.startsWith(`${groupName}--`)`. The `${groupName}--` prefix is collision-safe because the MVP validates that neither group name nor partition key contains `--`. **No registry-watching needed:** an empty newly-created shard contributes nothing, and the first data write to any shard (new or existing) matches the prefix and triggers a recompute that re-reads the registry — so dynamic shard pickup falls out of data-write events for free.
+- **Single-flight + trailing recompute:** if a change arrives while a compute is in flight, set `dirty`; when it settles, if `dirty`, recompute again. Guarantees no overlapping fan-outs and that the final snapshot reflects the latest committed state.
+- **Debounce/coalesce:** schedule recompute via `queueMicrotask` by default (`debounceMs: 0`) so a synchronous burst (e.g. `putMany`) collapses into one recompute; `debounceMs > 0` uses a timer. Configurable via opts.
+- Change events fire **after** store commit, so a same-instance write is already reflected in the shard collection's in-memory cache when the recompute reads it. (Same-instance reactivity only — cross-process/tab propagation is a `by-*` transport concern, out of scope; co-location assumption per the epic.)
+
+Two thin facades over the core:
+
+```ts
+// records / grouped rows — array-shaped, mirrors LiveQuery<T>
+interface CrossVaultLiveQuery<T> extends LiveQuery<T> {       // value: readonly T[]; error: Error|null; subscribe; stop
+  readonly skippedVaults: readonly SkippedVault[]
+  readonly ready: Promise<void>
+}
+// scalar aggregate — mirrors LiveAggregation<R>
+interface CrossVaultLiveAggregation<R> extends LiveAggregation<R> {  // value: R|undefined; error: unknown; subscribe; stop
+  readonly skippedVaults: readonly SkippedVault[]
+  readonly ready: Promise<void>
+}
+```
+The facade `value` / `skippedVaults` / `error` are getters reading the core's current snapshot. `CrossVaultLiveQuery<T>` is assignable to `LiveQuery<T>` and `CrossVaultLiveAggregation<R>` to `LiveAggregation<R>` (extra members only) — the adapter-compat guarantee, asserted by a type test.
+
+**Reference semantics (intentional divergence):** `LiveQuery`'s doc promises the same array reference mutated in place; the cross-vault compute returns a **fresh** merged array each settle. New-ref-per-update is better for Vue/React change detection. Documented so it isn't "fixed" back to in-place mutation; the type-level compat test still passes.
+
+### 2. Distributed aggregate (`federation/aggregate-across.ts`)
+
+Central reduce over the concatenated, `where`-filtered record stream — the same pattern the UNION materialized-view already uses:
+
+- Ungrouped: `reduceRecords(allRecords, spec)` → `AggregateResult<Spec>`.
+- Grouped: `groupAndReduce(allRecords, field, spec)` → `Row[]` where `Row = { [field]: K } & AggregateResult<Spec>`.
+
+Wrappers (mirroring single-vault `Aggregation` / `GroupedAggregation`):
+```ts
+class CrossVaultAggregation<Spec> {
+  run(opts?): Promise<{ result: AggregateResult<Spec>; skippedVaults: SkippedVault[] }>
+  live(opts?): CrossVaultLiveAggregation<AggregateResult<Spec>>
+}
+class CrossVaultGroupedAggregation<F extends string, Spec> {
+  run(opts?): Promise<{ results: GroupedRow<F, Spec>[]; skippedVaults: SkippedVault[] }>
+  live(opts?): CrossVaultLiveQuery<GroupedRow<F, Spec>>   // grouped rows are array-shaped
+}
+```
+The grouped cardinality cap (100k buckets, enforced inside `groupAndReduce`) applies to the **merged** stream; an overflow throws on `run()` and surfaces as `error` on `.live()`. Documented.
+
+**`Reducer.merge` (#312 E) — protocol seam, added now, used later.** Add an optional `merge?(a: S, b: S): S` to the `Reducer<R,S>` interface (`aggregate/reducers.ts`), complementing `remove`/`seed`, and implement it on the 5 built-ins: `sum`/`count` → `a + b`; `min`/`max` → `Math.min`/`Math.max`; `avg` → `{ sum: a.sum + b.sum, n: a.n + b.n }`. It is **purely additive and optional** (no protocol break; central reduce ignores it). `merge` combines independent partial **states** (then `finalize` once) — never finalized results. This unblocks two follow-ups without committing to them now: distributed partial-reduce (per-shard state → merge-by-bucket → finalize, transferring tiny states instead of records) and hierarchical rollup (advisor-level partials → firm-level), the custodial adopter's exact shape.
+
+### 3. `ShardedQuery` surface additions (`federation/vault-group.ts`)
+
+Extend the MVP `ShardedQuery<T,R>` (`where`, `toArray`) with:
+- `.live(opts?): CrossVaultLiveQuery<R>`
+- `.groupBy<F extends string>(field: F): ShardedGroupedQuery<T, R, F>`
+- `.aggregate<Spec>(spec): CrossVaultAggregation<Spec>`
+
+and a new `ShardedGroupedQuery<T,R,F>` with `.aggregate<Spec>(spec): CrossVaultGroupedAggregation<F, Spec>`.
+
+**Shared internals (DRY refactor of the MVP):** extract from `toArray` two reused helpers, then make `toArray`, `live`, and the aggregate computes all route through them:
+- `VaultGroup.resolveEligible(opts): Promise<{ eligible: VaultRegistryRow[]; skipped: SkippedVault[] }>` — `allRows` → `minVersion` schema-drift skip → provisioning-divergence guard (`Promise.all(_shardVaultProvisioned)`).
+- `ShardedQuery.fanoutRecords(opts): Promise<{ records: R[]; skippedVaults: SkippedVault[] }>` — `resolveEligible` → `queryAcross(ids, fn, { create: false })` (no-create open + configure + `await list()` hydrate + `query().where(clauses).toArray()`) → merge results + fold per-shard errors into `skippedVaults` via `classifyShardSkip(err)` (`'no-grant'` for `NoAccessError` only, else `'error'`).
+
+Then:
+- `toArray(opts)` = `fanoutRecords(opts)` (behavior identical to MVP — verified by re-running the 16 MVP tests).
+- `live(opts)` = `CrossVaultLiveQuery` over compute `() => fanoutRecords(opts)`.
+- `aggregate(spec).run(opts)` = `fanoutRecords(opts)` → `reduceRecords(records, spec)`.
+- `aggregate(spec).live(opts)` = `CrossVaultLiveAggregation` over the same compose.
+- grouped variants swap `reduceRecords` for `groupAndReduce`.
+
+## Data flow (live records example)
+
+```
+firm.collection('invoices').query().where('status','==','overdue').live()
+  → new CrossVaultLiveQuery facade over CrossVaultLive<{records, skipped}>:
+      subscribeToChanges = h => { db.on('change', h); return () => db.off('change', h) }
+      isRelevant = e => e.collection === 'invoices' && e.vault.startsWith('firm-clients--')
+      compute    = () => shardedQuery.fanoutRecords(opts)
+      initial    = { records: [], skipped: [] }
+  → constructor kicks first compute (async); ready resolves after it settles
+  → on each relevant committed change: microtask-coalesced, single-flight recompute
+```
+
+## Error handling
+- **No grant (A):** the calling identity has no keyring for a shard (`NoAccessError` from the no-create open) → `skippedVaults` `{ reason: 'no-grant', error }`. Expected under scoped access, not a fault.
+- Per-shard fan-out fault — anything **not** `NoAccessError` (incl. `InvalidKeyError`/`DecryptionError`/`KeyringCorruptError` = corruption or credential mismatch) → `skippedVaults` `{ reason: 'error', error }`.
+- Schema drift (below `minVersion`) → `skippedVaults` `{ reason: 'schema-drift' }` (reused).
+- Provisioning divergence (registry row, vault gone) → `skippedVaults` `{ reason: 'error', error: ShardProvisioningError }` (caught by the provisioning guard before the open; stays `'error'`, distinct from `'no-grant'`).
+- Catastrophic compute failure (e.g. registry read throws, or grouped cardinality overflow) → live primitive sets `error`, retains last good snapshot, notifies; `run()` rejects.
+- Empty fleet / no matching records → records `[]`; `count` 0, `sum` 0, `avg` `null` (per the `avg` reducer); grouped `[]`.
+
+## Testing strategy
+
+A **polling helper is mandatory** for the reactive tests — never assert "after N ticks." (Project history: the pre.6 cross-tab flake was fixed in pre.7 by polling instead of fixed `settle()` ticks; async-debounced fan-out is strictly more timing-sensitive.)
+```ts
+async function waitFor(pred: () => boolean, { timeout = 1000, interval = 5 } = {}) { /* poll until pred() or timeout-throw */ }
+```
+Prefer awaiting `lq.ready` for the first settle; use `waitFor(() => predicate)` for subsequent updates.
+
+Cases:
+1. **queryAcrossLive:** `await lq.ready` → initial value; write to a shard → `waitFor` value updates; write to a **new** partition (autoCreate) → new shard's records appear (dynamic pickup via data-write event); delete → disappears; `stop()` → no further updates; unsubscribe removes one callback; registry-read failure → `error` set, value retained.
+2. **Single-flight / coalesce:** a burst of rapid puts → final value correct (assert eventual correctness via `waitFor`; optionally spy compute count ≤ writes).
+3. **aggregateAcross one-shot:** `sum`/`count` across ≥2 shards; **`avg` correctness across shards** — shardA `[100,200]`, shardB `[300]` → `avg === 200` (proves central reduce, not averaging finalized averages); `groupBy('status')` with the same status spanning multiple shards → one merged bucket; `skippedVaults` (drift + provisioning) excluded from totals; empty → `count 0`, `avg null`, grouped `[]`.
+4. **aggregateAcrossLive:** ungrouped + grouped value updates on change (`waitFor`); `stop()`.
+5. **Adapter shape-compat (type test):** `expectTypeOf<CrossVaultLiveQuery<R>>().toMatchTypeOf<LiveQuery<R>>()` and `CrossVaultLiveAggregation<R>` ⊑ `LiveAggregation<R>`.
+6. **MVP regression:** the 16 existing `federation-vault-group.test.ts` tests still pass after the `resolveEligible`/`fanoutRecords` extraction.
+7. **(A) no-grant classification:** a fan-out where the identity lacks a grant to one shard (real keyring scenario: shard owned by another principal, operator has no grant) → that shard appears in `skippedVaults` with `reason: 'no-grant'` (not `'error'`); other shards return; **assert no `_keyring/<operator>` was written into the non-granted vault** (proves the no-create open didn't self-provision). Plus: provisioning-divergence still `'error'`; a genuine fault (e.g. injected store error) still `'error'`.
+8. **(E) `Reducer.merge` unit tests** (`aggregate/reducers` test): for each of `sum`/`count`/`min`/`max`/`avg` — commutativity `merge(a,b) ≡ merge(b,a)`, associativity, identity `merge(init(), a) ≡ a`, and **merge-then-`finalize` equals reduce-over-concatenation** (the state-level invariant; never merge finalized results).
+
+A showcase (`99-vault-group-live-aggregate.showcase.test.ts`) and a `features.yaml` showcase entry are added in the implementation plan.
+
+## Files
+
+**#312 A+B (land on the MVP base first — see Sequencing):**
+- Modify `packages/hub/src/federation/types.ts` — `SkippedVault.reason` += `'no-grant'`.
+- Modify `packages/hub/src/noydb.ts` — `openVault(name, { create?: boolean })` (default true) + thread `{ create }` through `queryAcross`; `getKeyringInternal` re-throws `NoAccessError` instead of `createOwnerKeyring` when `create: false`. (Small, additive; default path unchanged.)
+- Modify `packages/hub/src/federation/vault-group.ts` — `classifyShardSkip(err)` helper; fan-out opens with `{ create: false }` and classifies `'no-grant'` vs `'error'`.
+- Modify `docs/subsystems/vault-group.md` — state the key-custody-neutral contract (B).
+
+**#312 E (land on the cross-vault-live branch, pre-implementation):**
+- Modify `packages/hub/src/aggregate/reducers.ts` — add optional `merge?(a,b): S` to the `Reducer` interface + the 5 built-ins.
+
+**Cross-vault live/aggregate slice:**
+- Create `packages/hub/src/federation/cross-vault-live.ts` — `CrossVaultLive<S>` core + `CrossVaultLiveQuery` / `CrossVaultLiveAggregation` facades + interfaces.
+- Create `packages/hub/src/federation/aggregate-across.ts` — central-reduce wrappers (`CrossVaultAggregation`, `CrossVaultGroupedAggregation`), reusing `reduceRecords` / `groupAndReduce`.
+- Modify `packages/hub/src/federation/vault-group.ts` — extract `resolveEligible` / `fanoutRecords`; refactor `toArray`; add `live`, `groupBy`, `aggregate`, `ShardedGroupedQuery`.
+- Modify `packages/hub/src/federation/types.ts` — option/result/row types (`LiveQueryOptions = FanoutQueryOptions & { debounceMs? }`, `GroupedRow`).
+- Modify `packages/hub/src/federation/index.ts` + `packages/hub/src/index.ts` — export new public types/classes.
+- Create `packages/hub/__tests__/federation-query-aggregate.test.ts` (live + aggregate + no-grant) and `packages/hub/__tests__/reducer-merge.test.ts` (E unit tests).
+- Create `showcases/src/99-vault-group-live-aggregate.showcase.test.ts` + register in `features.yaml`.
+
+## Sequencing
+
+Respecting the already-done rebase: **A+B on the MVP base first** (so the `SkippedVault.reason` union doesn't ossify in PR #292 before it merges — #312's whole point) → **rebase cross-vault-live** → **E** + the live/aggregate slice on the cross-vault-live branch. A+B can ride PR #292 (or a small stacked PR onto it); E + the slice are the cross-vault-live PR.
+
+## Relationship to existing work
+| Prior work | Relationship |
+|---|---|
+| VaultGroup routing MVP (PR #292) | `live`/`aggregate` extend `ShardedQuery`; reuse `resolveEligible`/provisioning guard/`queryAcross` fan-out |
+| `LiveQuery<T>` / `LiveAggregation<R>` (`query/live.ts`, `aggregate/aggregation.ts`) | Contracts the cross-vault facades mirror (adapter compat) |
+| `reduceRecords` / `groupAndReduce` (`aggregate/`) | Central-reduce engine — reused unchanged |
+| UNION materialized view | Precedent for "group + aggregate over a concatenated stream" |
+| `db.on('change')` / `ChangeEvent` (`NoydbEventMap`) | In-process fan-in source for reactivity — no new transport |
+| #312 (custodial multi-tenant adopter) | Source of amendments A (`'no-grant'`), B (key-custody-neutral contract), E (`Reducer.merge`); folded in above |
+| `loadKeyring` / `getKeyringInternal` / `createOwnerKeyring` (`team/keyring.ts`, `noydb.ts`) | A's no-create open mode hangs off these; default (create) path unchanged |
+| `join.ts` | Untouched (crossShardJoin deferred) |
+
+## Held out of scope (per #312, for separate discussion)
+The issue explicitly parks four related ideas; not pulled into this slice: (1) a docs note that custodial adopters can build cross-vault insight today via a trusted KMS-server executor + sync; (2) a cross-vault scoped-write / routing primitive on delegation tokens; (3) a guarantee that the reactive change-source is transport-pluggable (sync-fed, not only same-instance `db.on('change')`); (4) `extractPartition` carrying the key-custody handoff (re-wrap DEK to recipient, drop operator grant).
+```

--- a/features.yaml
+++ b/features.yaml
@@ -1005,6 +1005,8 @@ features:
     showcases:
       - id: 98-vault-group-federation
         path: showcases/src/98-vault-group-federation.showcase.test.ts
+      - id: 99-vault-group-live-aggregate
+        path: showcases/src/99-vault-group-live-aggregate.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []

--- a/packages/hub/__tests__/cross-vault-live-core.test.ts
+++ b/packages/hub/__tests__/cross-vault-live-core.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { CrossVaultLive } from '../src/federation/cross-vault-live.js'
+
+function fakeEmitter() {
+  const hs = new Set<(e: any) => void>()
+  return {
+    subscribe: (h: (e: any) => void) => { hs.add(h); return () => hs.delete(h) },
+    fire: (e: any) => { for (const h of hs) h(e) },
+  }
+}
+const tick = () => new Promise<void>((r) => setTimeout(r, 0))
+
+it('computes initial snapshot, updates on relevant change, single-flights, stops', async () => {
+  const em = fakeEmitter()
+  let n = 0
+  const core = new CrossVaultLive<number>({
+    subscribeToChanges: em.subscribe,
+    isRelevant: (e) => e.relevant === true,
+    compute: async () => { await tick(); return ++n },
+    initialSnapshot: 0,
+    debounceMs: 0,
+  })
+  expect(core.snapshot).toBe(0)              // initial, before first settle
+  await core.ready                            // first compute settled
+  expect(core.snapshot).toBe(1)
+
+  let fired = 0
+  const off = core.subscribe(() => { fired++ })
+  em.fire({ relevant: false })                // ignored
+  await tick(); await tick()
+  expect(core.snapshot).toBe(1)
+  em.fire({ relevant: true })
+  await new Promise((r) => setTimeout(r, 5))
+  expect(core.snapshot).toBe(2)
+  expect(fired).toBeGreaterThanOrEqual(1)
+
+  off(); core.stop()
+  em.fire({ relevant: true })
+  await new Promise((r) => setTimeout(r, 5))
+  expect(core.snapshot).toBe(2)              // stopped → no recompute
+})

--- a/packages/hub/__tests__/cross-vault-live-types.test-d.ts
+++ b/packages/hub/__tests__/cross-vault-live-types.test-d.ts
@@ -1,0 +1,12 @@
+/**
+ * Type-compat test: CrossVaultLiveQuery and CrossVaultLiveAggregation must be
+ * assignable to LiveQuery / LiveAggregation respectively (shape-compatible
+ * facades). Validated by `pnpm typecheck` (tsconfig.typetest.json).
+ */
+import { expectTypeOf } from 'vitest'
+import type { LiveQuery } from '../src/query/live.js'
+import type { LiveAggregation } from '../src/aggregate/aggregation.js'
+import type { CrossVaultLiveQuery, CrossVaultLiveAggregation } from '../src/federation/index.js'
+
+expectTypeOf<CrossVaultLiveQuery<{ amount: number }>>().toMatchTypeOf<LiveQuery<{ amount: number }>>()
+expectTypeOf<CrossVaultLiveAggregation<{ total: number }>>().toMatchTypeOf<LiveAggregation<{ total: number }>>()

--- a/packages/hub/__tests__/federation-query-aggregate.test.ts
+++ b/packages/hub/__tests__/federation-query-aggregate.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Cross-vault live query — ShardedQuery.live() reactive facade.
+ * Task 9 of cross-vault-live-aggregate plan.
+ * Spec: docs/superpowers/specs/2026-06-07-cross-vault-live-and-aggregate-design.md
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+import { createNoydb } from '../src/noydb.js'
+import type { Vault } from '../src/vault.js'
+import type { VaultRegistryRow } from '../src/federation/index.js'
+
+// ─── Shared in-memory adapter (copied from federation-vault-group.test.ts) ───
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+interface Invoice { clientId: string; amount: number; status: string }
+
+/** Build an operator db with the registry vault opened and a v1 client template registered. */
+async function harness(opts: { autoCreate?: boolean; templateVersion?: number } = {}) {
+  const adapter = memory()
+  const db = await createNoydb({ store: adapter, user: 'operator', secret: 'op-pass' })
+  db.withVaultTemplate('client-template', {
+    version: opts.templateVersion ?? 1,
+    configure(vault: Vault) {
+      vault.collection<Invoice>('invoices')
+    },
+  })
+  const stateVault = await db.openVault('state')
+  const registry = stateVault.collection<VaultRegistryRow>('vault-registry')
+  const firm = await db.openVaultGroup<Invoice>('firm-clients', {
+    registry,
+    sharding: {
+      keyOf: (r) => r.clientId,
+      vaultTemplate: 'client-template',
+      ...(opts.autoCreate !== undefined ? { autoCreate: opts.autoCreate } : {}),
+    },
+  })
+  return { adapter, db, registry, firm }
+}
+
+// ─── Polling helper (never assert on fixed ticks) ─────────────────────────
+
+async function waitFor(pred: () => boolean, { timeout = 2000, interval = 5 } = {}) {
+  const start = Date.now()
+  while (!pred()) {
+    if (Date.now() - start > timeout) throw new Error('waitFor timeout')
+    await new Promise<void>((r) => setTimeout(r, interval))
+  }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe('ShardedQuery.live()', () => {
+  it('reflects initial snapshot after ready, reacts to writes, picks up new shard, stop() halts updates', async () => {
+    const h = await harness()
+    await h.firm.collection('invoices').put('a1', { clientId: 'acme', amount: 100, status: 'overdue' })
+
+    const lq = h.firm.collection('invoices').query().where('status', '==', 'overdue').live()
+    await lq.ready
+    expect(lq.value.map((r) => r.amount)).toEqual([100])
+    expect(lq.skippedVaults).toEqual([])
+
+    // Write to an existing shard — should react
+    await h.firm.collection('invoices').put('a2', { clientId: 'acme', amount: 150, status: 'overdue' })
+    await waitFor(() => lq.value.length === 2)
+    expect(lq.value.map((r) => r.amount).sort((x, y) => x - y)).toEqual([100, 150])
+
+    // Write to a NEW shard (autoCreate) — new partition should appear
+    await h.firm.collection('invoices').put('b1', { clientId: 'beta', amount: 200, status: 'overdue' })
+    await waitFor(() => lq.value.length === 3)
+    expect(lq.value.map((r) => r.amount).sort((x, y) => x - y)).toEqual([100, 150, 200])
+
+    // stop() halts updates
+    lq.stop()
+    await h.firm.collection('invoices').put('a3', { clientId: 'acme', amount: 300, status: 'overdue' })
+    await new Promise<void>((r) => setTimeout(r, 30))
+    expect(lq.value.length).toBe(3) // no update after stop
+  })
+})

--- a/packages/hub/__tests__/federation-query-aggregate.test.ts
+++ b/packages/hub/__tests__/federation-query-aggregate.test.ts
@@ -5,7 +5,7 @@
  */
 import { describe, it, expect } from 'vitest'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
-import { ConflictError } from '../src/errors.js'
+import { ConflictError, NoAccessError } from '../src/errors.js'
 import { createNoydb } from '../src/noydb.js'
 import type { Vault } from '../src/vault.js'
 import type { VaultRegistryRow } from '../src/federation/index.js'
@@ -180,5 +180,48 @@ describe('ShardedQuery.aggregate().live()', () => {
       return row !== undefined && row.total === 300
     })
     lg.stop()
+  })
+})
+
+// ─── Review follow-up 5: no-grant assertion on the live/aggregate surface ─────
+
+describe('ShardedQuery.live() — no-grant scoped access', () => {
+  it('live() skips non-granted shard as no-grant + only shows granted shard rows after ready', async () => {
+    // Operator creates two shards (firm-clients--acme and firm-clients--beta),
+    // then grants advisor access to only one shard + the state registry vault.
+    const adapter = memory()
+    const op = await createNoydb({ store: adapter, user: 'operator', secret: 'op-pass' })
+    op.withVaultTemplate('client-template', { version: 1, configure: (v: Vault) => { v.collection<Invoice>('invoices') } })
+    const opState = await op.openVault('state')
+    const opFirm = await op.openVaultGroup<Invoice>('firm-clients', {
+      registry: opState.collection<VaultRegistryRow>('vault-registry'),
+      sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template' },
+    })
+    await opFirm.collection('invoices').put('a1', { clientId: 'acme', amount: 100, status: 'overdue' })
+    await opFirm.collection('invoices').put('b1', { clientId: 'beta', amount: 200, status: 'overdue' })
+    // Grant advisor only to firm-clients--acme and the state registry vault
+    await op.grant('firm-clients--acme', { userId: 'advisor', displayName: 'Adv', role: 'viewer', passphrase: 'adv-pass' })
+    await op.grant('state', { userId: 'advisor', displayName: 'Adv', role: 'viewer', passphrase: 'adv-pass' })
+
+    // Advisor opens the same group
+    const adv = await createNoydb({ store: adapter, user: 'advisor', secret: 'adv-pass' })
+    adv.withVaultTemplate('client-template', { version: 1, configure: (v: Vault) => { v.collection<Invoice>('invoices') } })
+    const advState = await adv.openVault('state')
+    const advFirm = await adv.openVaultGroup<Invoice>('firm-clients', {
+      registry: advState.collection<VaultRegistryRow>('vault-registry'),
+      sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template' },
+    })
+
+    const lq = advFirm.collection('invoices').query().where('status', '==', 'overdue').live()
+    await lq.ready
+
+    // Only acme (granted) rows appear; beta (non-granted) is in skippedVaults with reason 'no-grant'
+    expect(lq.value.map((r) => r.amount)).toEqual([100])
+    const skip = lq.skippedVaults.find((s) => s.vaultId === 'firm-clients--beta')
+    expect(skip?.reason).toBe('no-grant')
+    // Advisor must NOT have self-provisioned a keyring into the non-granted shard
+    expect(await adapter.get('firm-clients--beta', '_keyring', 'advisor')).toBeNull()
+
+    lq.stop()
   })
 })

--- a/packages/hub/__tests__/federation-query-aggregate.test.ts
+++ b/packages/hub/__tests__/federation-query-aggregate.test.ts
@@ -9,6 +9,7 @@ import { ConflictError } from '../src/errors.js'
 import { createNoydb } from '../src/noydb.js'
 import type { Vault } from '../src/vault.js'
 import type { VaultRegistryRow } from '../src/federation/index.js'
+import { sum, count, avg } from '../src/aggregate/reducers.js'
 
 // ─── Shared in-memory adapter (copied from federation-vault-group.test.ts) ───
 
@@ -111,5 +112,35 @@ describe('ShardedQuery.live()', () => {
     await h.firm.collection('invoices').put('a3', { clientId: 'acme', amount: 300, status: 'overdue' })
     await new Promise<void>((r) => setTimeout(r, 30))
     expect(lq.value.length).toBe(3) // no update after stop
+  })
+})
+
+// ─── Task 10: one-shot aggregate ─────────────────────────────────────────────
+
+describe('ShardedQuery.aggregate() one-shot', () => {
+  it('aggregate across shards: sum/count/avg correct (avg = central reduce, not avg-of-avgs)', async () => {
+    const h = await harness()
+    const inv = h.firm.collection('invoices')
+    await inv.put('a1', { clientId: 'acme', amount: 100, status: 'open' })
+    await inv.put('a2', { clientId: 'acme', amount: 200, status: 'open' })
+    await inv.put('b1', { clientId: 'beta', amount: 300, status: 'open' })
+    const { result, skippedVaults } = await h.firm.collection('invoices').query()
+      .aggregate({ total: sum('amount'), n: count(), mean: avg('amount') }).run()
+    expect(skippedVaults).toEqual([])
+    expect(result.total).toBe(600)
+    expect(result.n).toBe(3)
+    expect(result.mean).toBe(200) // NOT (150+300)/2 = 225 — central reduce, not avg-of-avgs
+  })
+
+  it('groupBy(status).aggregate sums per status across shards', async () => {
+    const h = await harness()
+    const inv = h.firm.collection('invoices')
+    await inv.put('a1', { clientId: 'acme', amount: 100, status: 'overdue' })
+    await inv.put('b1', { clientId: 'beta', amount: 300, status: 'overdue' })
+    await inv.put('b2', { clientId: 'beta', amount: 50, status: 'open' })
+    const { results } = await h.firm.collection('invoices').query()
+      .groupBy('status').aggregate({ total: sum('amount') }).run()
+    const overdue = results.find((r) => r.status === 'overdue')
+    expect(overdue?.total).toBe(400)
   })
 })

--- a/packages/hub/__tests__/federation-query-aggregate.test.ts
+++ b/packages/hub/__tests__/federation-query-aggregate.test.ts
@@ -144,3 +144,41 @@ describe('ShardedQuery.aggregate() one-shot', () => {
     expect(overdue?.total).toBe(400)
   })
 })
+
+// ─── Task 11: reactive aggregate (.live()) ────────────────────────────────────
+
+describe('ShardedQuery.aggregate().live()', () => {
+  it('updates the scalar aggregate on write, then stop() halts updates', async () => {
+    const h = await harness()
+    await h.firm.collection('invoices').put('a1', { clientId: 'acme', amount: 100, status: 'open' })
+    const la = h.firm.collection('invoices').query().aggregate({ total: sum('amount') }).live()
+    await la.ready
+    expect(la.value?.total).toBe(100)
+
+    await h.firm.collection('invoices').put('b1', { clientId: 'beta', amount: 50, status: 'open' })
+    await waitFor(() => la.value?.total === 150)
+    la.stop()
+
+    // After stop, writes do not update the aggregate
+    await h.firm.collection('invoices').put('b2', { clientId: 'beta', amount: 999, status: 'open' })
+    await new Promise<void>((r) => setTimeout(r, 30))
+    expect(la.value?.total).toBe(150)
+  })
+
+  it('groupBy().aggregate().live() updates grouped rows on write', async () => {
+    const h = await harness()
+    await h.firm.collection('invoices').put('a1', { clientId: 'acme', amount: 100, status: 'overdue' })
+    const lg = h.firm.collection('invoices').query()
+      .groupBy('status').aggregate({ total: sum('amount') }).live()
+    await lg.ready
+    const overdueRow = lg.value.find((r) => r.status === 'overdue')
+    expect(overdueRow?.total).toBe(100)
+
+    await h.firm.collection('invoices').put('b1', { clientId: 'beta', amount: 200, status: 'overdue' })
+    await waitFor(() => {
+      const row = lg.value.find((r) => r.status === 'overdue')
+      return row !== undefined && row.total === 300
+    })
+    lg.stop()
+  })
+})

--- a/packages/hub/src/federation/aggregate-across.ts
+++ b/packages/hub/src/federation/aggregate-across.ts
@@ -17,6 +17,7 @@ import type {
   CrossVaultLiveQuery,
 } from './types.js'
 import { CrossVaultLive } from './cross-vault-live.js'
+import type { ChangeEvent } from '../types.js'
 
 /** A source that can fan out records across shards. Satisfied by ShardedQuery. */
 export interface FanoutRecordSource<R> {
@@ -25,8 +26,8 @@ export interface FanoutRecordSource<R> {
 
 /** Live-binding hooks (change subscription + relevance) threaded from ShardedQuery. */
 export interface LiveBinding {
-  subscribeToChanges: (handler: (e: any) => void) => () => void
-  isRelevant: (e: any) => boolean
+  subscribeToChanges: (handler: (e: ChangeEvent) => void) => () => void
+  isRelevant: (e: ChangeEvent) => boolean
 }
 
 /**

--- a/packages/hub/src/federation/aggregate-across.ts
+++ b/packages/hub/src/federation/aggregate-across.ts
@@ -1,0 +1,126 @@
+/**
+ * @category capability
+ * One-shot distributed aggregate wrappers for cross-vault fan-out.
+ * Central-reduce: all shard records are concatenated and reduced in one pass
+ * so avg/mean values are computed over the full union, not as avg-of-avgs.
+ * Spec: docs/superpowers/specs/2026-06-07-cross-vault-live-and-aggregate-design.md.
+ */
+import { reduceRecords } from '../aggregate/aggregation.js'
+import { groupAndReduce } from '../aggregate/groupby.js'
+import type { AggregateResult, AggregateSpec } from '../aggregate/aggregation.js'
+import type {
+  FanoutQueryOptions,
+  SkippedVault,
+  GroupedRow,
+  LiveQueryOptions,
+  CrossVaultLiveAggregation,
+  CrossVaultLiveQuery,
+} from './types.js'
+import { CrossVaultLive } from './cross-vault-live.js'
+
+/** A source that can fan out records across shards. Satisfied by ShardedQuery. */
+export interface FanoutRecordSource<R> {
+  fanoutRecords(options: FanoutQueryOptions): Promise<{ records: R[]; skippedVaults: SkippedVault[] }>
+}
+
+/** Live-binding hooks (change subscription + relevance) threaded from ShardedQuery. */
+export interface LiveBinding {
+  subscribeToChanges: (handler: (e: any) => void) => () => void
+  isRelevant: (e: any) => boolean
+}
+
+/**
+ * One-shot cross-vault aggregate. Concatenates all shard records and runs a
+ * single central reduce, ensuring correct avg/mean values.
+ */
+export class CrossVaultAggregation<R, Spec extends AggregateSpec> {
+  constructor(
+    private readonly src: FanoutRecordSource<R>,
+    private readonly spec: Spec,
+    private readonly bind?: LiveBinding,
+  ) {}
+
+  async run(options: FanoutQueryOptions = {}): Promise<{
+    result: AggregateResult<Spec>
+    skippedVaults: SkippedVault[]
+  }> {
+    const { records, skippedVaults } = await this.src.fanoutRecords(options)
+    return { result: reduceRecords(records, this.spec), skippedVaults }
+  }
+
+  live(options: LiveQueryOptions = {}): CrossVaultLiveAggregation<AggregateResult<Spec>> {
+    if (!this.bind) throw new Error('CrossVaultAggregation: live() requires a LiveBinding — use ShardedQuery.aggregate()')
+    const spec = this.spec
+    const src = this.src
+    const core = new CrossVaultLive<{ value: AggregateResult<Spec> | undefined; skipped: SkippedVault[] }>({
+      subscribeToChanges: this.bind.subscribeToChanges,
+      isRelevant: this.bind.isRelevant,
+      compute: async () => {
+        const { records, skippedVaults } = await src.fanoutRecords(options)
+        return { value: reduceRecords(records, spec), skipped: skippedVaults }
+      },
+      initialSnapshot: { value: undefined, skipped: [] },
+      ...(options.debounceMs !== undefined ? { debounceMs: options.debounceMs } : {}),
+    })
+    return {
+      get value() { return core.snapshot.value },
+      get skippedVaults() { return core.snapshot.skipped as readonly SkippedVault[] },
+      get error() { return core.error },
+      ready: core.ready,
+      subscribe: (cb) => core.subscribe(cb),
+      stop: () => core.stop(),
+    }
+  }
+}
+
+/**
+ * One-shot cross-vault grouped aggregate. Concatenates all shard records and
+ * runs a single central group-and-reduce, emitting one row per bucket.
+ */
+export class CrossVaultGroupedAggregation<R, F extends string, Spec extends AggregateSpec> {
+  constructor(
+    private readonly src: FanoutRecordSource<R>,
+    private readonly field: F,
+    private readonly spec: Spec,
+    private readonly bind?: LiveBinding,
+  ) {}
+
+  async run(options: FanoutQueryOptions = {}): Promise<{
+    results: GroupedRow<F, Spec>[]
+    skippedVaults: SkippedVault[]
+  }> {
+    const { records, skippedVaults } = await this.src.fanoutRecords(options)
+    return {
+      results: groupAndReduce<GroupedRow<F, Spec>>(records, this.field, this.spec),
+      skippedVaults,
+    }
+  }
+
+  live(options: LiveQueryOptions = {}): CrossVaultLiveQuery<GroupedRow<F, Spec>> {
+    if (!this.bind) throw new Error('CrossVaultGroupedAggregation: live() requires a LiveBinding — use ShardedQuery.groupBy().aggregate()')
+    const field = this.field
+    const spec = this.spec
+    const src = this.src
+    const core = new CrossVaultLive<{ records: GroupedRow<F, Spec>[]; skipped: SkippedVault[] }>({
+      subscribeToChanges: this.bind.subscribeToChanges,
+      isRelevant: this.bind.isRelevant,
+      compute: async () => {
+        const { records, skippedVaults } = await src.fanoutRecords(options)
+        return {
+          records: groupAndReduce<GroupedRow<F, Spec>>(records, field, spec),
+          skipped: skippedVaults,
+        }
+      },
+      initialSnapshot: { records: [], skipped: [] },
+      ...(options.debounceMs !== undefined ? { debounceMs: options.debounceMs } : {}),
+    })
+    return {
+      get value() { return core.snapshot.records as readonly GroupedRow<F, Spec>[] },
+      get skippedVaults() { return core.snapshot.skipped as readonly SkippedVault[] },
+      get error() { return core.error },
+      ready: core.ready,
+      subscribe: (cb) => core.subscribe(cb),
+      stop: () => core.stop(),
+    }
+  }
+}

--- a/packages/hub/src/federation/cross-vault-live.ts
+++ b/packages/hub/src/federation/cross-vault-live.ts
@@ -1,0 +1,92 @@
+/**
+ * @category capability
+ * Reactive core for cross-vault live queries/aggregations. Generic over a
+ * snapshot S. Single-flight + microtask-coalesced recompute on relevant
+ * change. Mirrors the LiveQuery/LiveAggregation contracts via facades.
+ * Spec: docs/superpowers/specs/2026-06-07-cross-vault-live-and-aggregate-design.md.
+ */
+import type { ChangeEvent } from '../types.js'
+
+export interface CrossVaultLiveOptions<S> {
+  readonly subscribeToChanges: (handler: (e: ChangeEvent) => void) => () => void
+  readonly isRelevant: (e: ChangeEvent) => boolean
+  readonly compute: () => Promise<S>
+  readonly initialSnapshot: S
+  readonly debounceMs?: number
+}
+
+export class CrossVaultLive<S> {
+  snapshot: S
+  error: Error | null = null
+  readonly ready: Promise<void>
+
+  private readonly subs = new Set<() => void>()
+  private readonly unsubChange: () => void
+  private readonly opts: CrossVaultLiveOptions<S>
+  private stopped = false
+  private computing = false
+  private dirty = false
+  private scheduled = false
+  private timer: ReturnType<typeof setTimeout> | null = null
+  private resolveReady!: () => void
+  private settledOnce = false
+
+  constructor(opts: CrossVaultLiveOptions<S>) {
+    this.opts = opts
+    this.snapshot = opts.initialSnapshot
+    this.ready = new Promise<void>((res) => { this.resolveReady = res })
+    this.unsubChange = opts.subscribeToChanges((e) => {
+      if (this.stopped || !opts.isRelevant(e)) return
+      this.schedule()
+    })
+    this.schedule() // initial compute
+  }
+
+  subscribe(cb: () => void): () => void {
+    if (this.stopped) return () => {}
+    this.subs.add(cb)
+    return () => this.subs.delete(cb)
+  }
+
+  stop(): void {
+    if (this.stopped) return
+    this.stopped = true
+    this.unsubChange()
+    if (this.timer !== null) clearTimeout(this.timer)
+    this.subs.clear()
+    if (!this.settledOnce) this.resolveReady() // never leave ready dangling
+  }
+
+  private schedule(): void {
+    if (this.stopped) return
+    if (this.computing) { this.dirty = true; return }
+    if (this.scheduled) return
+    this.scheduled = true
+    const run = () => { this.scheduled = false; void this.runCompute() }
+    const ms = this.opts.debounceMs ?? 0
+    if (ms > 0) this.timer = setTimeout(run, ms)
+    else queueMicrotask(run)
+  }
+
+  private async runCompute(): Promise<void> {
+    if (this.stopped) return
+    this.computing = true
+    this.dirty = false
+    try {
+      const next = await this.opts.compute()
+      if (this.stopped) return
+      this.snapshot = next
+      this.error = null
+    } catch (err) {
+      if (this.stopped) return
+      this.error = err instanceof Error ? err : new Error(String(err))
+    } finally {
+      this.computing = false
+      if (!this.stopped) {
+        if (!this.settledOnce) { this.settledOnce = true; this.resolveReady() }
+        for (const cb of this.subs) cb()
+        if (this.dirty) this.schedule()
+      }
+    }
+  }
+}

--- a/packages/hub/src/federation/cross-vault-live.ts
+++ b/packages/hub/src/federation/cross-vault-live.ts
@@ -65,6 +65,7 @@ export class CrossVaultLive<S> {
     const run = () => { this.scheduled = false; void this.runCompute() }
     const ms = this.opts.debounceMs ?? 0
     if (ms > 0) this.timer = setTimeout(run, ms)
+    // queueMicrotask is non-cancellable; the `if (this.stopped) return` guard at the top of runCompute makes a post-stop fire a no-op.
     else queueMicrotask(run)
   }
 

--- a/packages/hub/src/federation/index.ts
+++ b/packages/hub/src/federation/index.ts
@@ -1,4 +1,5 @@
-export { VaultGroup, ShardedCollection, ShardedQuery } from './vault-group.js'
+export { VaultGroup, ShardedCollection, ShardedQuery, ShardedGroupedQuery } from './vault-group.js'
+export { CrossVaultAggregation, CrossVaultGroupedAggregation } from './aggregate-across.js'
 export type {
   VaultTemplate,
   VaultRegistryRow,
@@ -7,4 +8,8 @@ export type {
   FanoutQueryOptions,
   FanoutResult,
   SkippedVault,
+  CrossVaultLiveQuery,
+  CrossVaultLiveAggregation,
+  LiveQueryOptions,
+  GroupedRow,
 } from './types.js'

--- a/packages/hub/src/federation/types.ts
+++ b/packages/hub/src/federation/types.ts
@@ -7,6 +7,8 @@
 import type { Vault } from '../vault.js'
 import type { Collection } from '../collection.js'
 import type { Operator } from '../query/predicate.js'
+import type { LiveQuery } from '../query/live.js'
+import type { LiveAggregation, AggregateResult, AggregateSpec } from '../aggregate/aggregation.js'
 
 /**
  * A schema blueprint for a class of shard vaults. `configure` is
@@ -72,4 +74,26 @@ export interface WhereClause {
   readonly field: string
   readonly op: Operator
   readonly value: unknown
+}
+
+/** Options for the live/aggregate fan-out (extends the one-shot opts). */
+export interface LiveQueryOptions extends FanoutQueryOptions {
+  /** Coalesce window before recompute. Default 0 (microtask). */
+  readonly debounceMs?: number
+}
+
+/** A grouped aggregate output row: the grouped field + the reduced spec result. */
+export type GroupedRow<F extends string, Spec extends AggregateSpec> =
+  { readonly [K in F]: unknown } & AggregateResult<Spec>
+
+/** Reactive cross-shard record (or grouped-row) query — array-shaped, mirrors LiveQuery<T>. */
+export interface CrossVaultLiveQuery<T> extends LiveQuery<T> {
+  readonly skippedVaults: readonly SkippedVault[]
+  readonly ready: Promise<void>
+}
+
+/** Reactive cross-shard scalar aggregate — mirrors LiveAggregation<R>. */
+export interface CrossVaultLiveAggregation<R> extends LiveAggregation<R> {
+  readonly skippedVaults: readonly SkippedVault[]
+  readonly ready: Promise<void>
 }

--- a/packages/hub/src/federation/vault-group.ts
+++ b/packages/hub/src/federation/vault-group.ts
@@ -123,6 +123,28 @@ export class VaultGroup<T> {
   collection<R = T>(collectionName: string): ShardedCollection<T, R> {
     return new ShardedCollection<T, R>(this, collectionName)
   }
+
+  /** @internal — eligible (openable-candidate) rows + drift/divergence skips. */
+  async resolveEligible(options: { minVersion?: number } = {}): Promise<{
+    eligible: VaultRegistryRow[]
+    skipped: SkippedVault[]
+  }> {
+    const rows = await this.allRows()
+    const skipped: SkippedVault[] = []
+    const versionOk: VaultRegistryRow[] = []
+    for (const row of rows) {
+      if (options.minVersion !== undefined && row.schemaVersion < options.minVersion) {
+        skipped.push({ vaultId: row.vaultId, reason: 'schema-drift' })
+      } else versionOk.push(row)
+    }
+    const provisioned = await Promise.all(versionOk.map((r) => this.db._shardVaultProvisioned(r.vaultId)))
+    const eligible: VaultRegistryRow[] = []
+    versionOk.forEach((row, i) => {
+      if (provisioned[i]) eligible.push(row)
+      else skipped.push({ vaultId: row.vaultId, reason: 'error', error: new ShardProvisioningError(row.vaultId, row.partitionKey) })
+    })
+    return { eligible, skipped }
+  }
 }
 
 export class ShardedCollection<T, R = T> {
@@ -167,40 +189,11 @@ export class ShardedQuery<T, R = T> {
     ])
   }
 
-  /** Fan out across eligible shards and merge results. */
-  async toArray(options: FanoutQueryOptions = {}): Promise<FanoutResult<R>> {
-    const rows = await this.group.allRows()
-    const skipped: SkippedVault[] = []
-    const eligible: VaultRegistryRow[] = []
-    for (const row of rows) {
-      if (options.minVersion !== undefined && row.schemaVersion < options.minVersion) {
-        skipped.push({ vaultId: row.vaultId, reason: 'schema-drift' })
-      } else {
-        eligible.push(row)
-      }
-    }
-
-    // Guard against registry/store divergence: a row whose vault is not
-    // provisioned must NOT be recreated by queryAcross's open-on-read.
-    // Surface it as an error-skip instead (mirrors shard()/createShard).
-    const provisioned = await Promise.all(
-      eligible.map((row) => this.group.db._shardVaultProvisioned(row.vaultId)),
-    )
-    const safeEligible: VaultRegistryRow[] = []
-    eligible.forEach((row, i) => {
-      if (provisioned[i]) {
-        safeEligible.push(row)
-      } else {
-        skipped.push({
-          vaultId: row.vaultId,
-          reason: 'error',
-          error: new ShardProvisioningError(row.vaultId, row.partitionKey),
-        })
-      }
-    })
-
+  /** @internal — fan out the where-filtered records across eligible shards. */
+  async fanoutRecords(options: FanoutQueryOptions = {}): Promise<{ records: R[]; skippedVaults: SkippedVault[] }> {
+    const { eligible, skipped } = await this.group.resolveEligible(options)
     const across = await this.group.db.queryAcross<R[]>(
-      safeEligible.map((r) => r.vaultId),
+      eligible.map((r) => r.vaultId),
       async (vault) => {
         this.group.template.configure(vault)
         const coll = vault.collection<R>(this.collectionName)
@@ -211,12 +204,17 @@ export class ShardedQuery<T, R = T> {
       },
       { concurrency: options.concurrency ?? 1, create: false },
     )
-
     const results: R[] = []
     for (const r of across) {
       if (r.error) skipped.push({ vaultId: r.vault, reason: classifyShardSkip(r.error), error: r.error })
       else for (const item of r.result) results.push(item)
     }
-    return { results, skippedVaults: skipped }
+    return { records: results, skippedVaults: skipped }
+  }
+
+  /** Fan out across eligible shards and merge results. */
+  async toArray(options: FanoutQueryOptions = {}): Promise<FanoutResult<R>> {
+    const { records, skippedVaults } = await this.fanoutRecords(options)
+    return { results: records, skippedVaults }
   }
 }

--- a/packages/hub/src/federation/vault-group.ts
+++ b/packages/hub/src/federation/vault-group.ts
@@ -9,6 +9,7 @@ import type { Vault } from '../vault.js'
 import type { Collection } from '../collection.js'
 import { ShardProvisioningError, UnknownShardError, ValidationError } from '../errors.js'
 import { classifyShardSkip } from './classify-skip.js'
+import { CrossVaultLive } from './cross-vault-live.js'
 import type {
   ShardingConfig,
   VaultRegistryRow,
@@ -17,6 +18,8 @@ import type {
   FanoutResult,
   SkippedVault,
   WhereClause,
+  LiveQueryOptions,
+  CrossVaultLiveQuery,
 } from './types.js'
 
 /** Reserved separator between group name and partition key in a shard vault id. */
@@ -216,5 +219,29 @@ export class ShardedQuery<T, R = T> {
   async toArray(options: FanoutQueryOptions = {}): Promise<FanoutResult<R>> {
     const { records, skippedVaults } = await this.fanoutRecords(options)
     return { results: records, skippedVaults }
+  }
+
+  /** Returns a reactive cross-shard live query — a facade over CrossVaultLive. */
+  live(options: LiveQueryOptions = {}): CrossVaultLiveQuery<R> {
+    const group = this.group
+    const collectionName = this.collectionName
+    const core = new CrossVaultLive<{ records: R[]; skipped: SkippedVault[] }>({
+      subscribeToChanges: (h) => { group.db.on('change', h); return () => group.db.off('change', h) },
+      isRelevant: (e) => e.collection === collectionName && e.vault.startsWith(`${group.name}--`),
+      compute: async () => {
+        const { records, skippedVaults } = await this.fanoutRecords(options)
+        return { records, skipped: skippedVaults }
+      },
+      initialSnapshot: { records: [], skipped: [] },
+      ...(options.debounceMs !== undefined ? { debounceMs: options.debounceMs } : {}),
+    })
+    return {
+      get value() { return core.snapshot.records as readonly R[] },
+      get skippedVaults() { return core.snapshot.skipped as readonly SkippedVault[] },
+      get error() { return core.error },
+      ready: core.ready,
+      subscribe: (cb) => core.subscribe(cb),
+      stop: () => core.stop(),
+    }
   }
 }

--- a/packages/hub/src/federation/vault-group.ts
+++ b/packages/hub/src/federation/vault-group.ts
@@ -10,6 +10,9 @@ import type { Collection } from '../collection.js'
 import { ShardProvisioningError, UnknownShardError, ValidationError } from '../errors.js'
 import { classifyShardSkip } from './classify-skip.js'
 import { CrossVaultLive } from './cross-vault-live.js'
+import { CrossVaultAggregation, CrossVaultGroupedAggregation } from './aggregate-across.js'
+import type { FanoutRecordSource, LiveBinding } from './aggregate-across.js'
+import type { AggregateSpec } from '../aggregate/aggregation.js'
 import type {
   ShardingConfig,
   VaultRegistryRow,
@@ -221,13 +224,21 @@ export class ShardedQuery<T, R = T> {
     return { results: records, skippedVaults }
   }
 
-  /** Returns a reactive cross-shard live query — a facade over CrossVaultLive. */
-  live(options: LiveQueryOptions = {}): CrossVaultLiveQuery<R> {
+  /** @internal — build the change-subscription + relevance binding for this query's group+collection. */
+  liveBinding(): LiveBinding {
     const group = this.group
     const collectionName = this.collectionName
-    const core = new CrossVaultLive<{ records: R[]; skipped: SkippedVault[] }>({
+    return {
       subscribeToChanges: (h) => { group.db.on('change', h); return () => group.db.off('change', h) },
       isRelevant: (e) => e.collection === collectionName && e.vault.startsWith(`${group.name}--`),
+    }
+  }
+
+  /** Returns a reactive cross-shard live query — a facade over CrossVaultLive. */
+  live(options: LiveQueryOptions = {}): CrossVaultLiveQuery<R> {
+    const bind = this.liveBinding()
+    const core = new CrossVaultLive<{ records: R[]; skipped: SkippedVault[] }>({
+      ...bind,
       compute: async () => {
         const { records, skippedVaults } = await this.fanoutRecords(options)
         return { records, skipped: skippedVaults }
@@ -243,5 +254,32 @@ export class ShardedQuery<T, R = T> {
       subscribe: (cb) => core.subscribe(cb),
       stop: () => core.stop(),
     }
+  }
+
+  /** One-shot distributed aggregate — central reduce over all shard records. */
+  aggregate<Spec extends AggregateSpec>(spec: Spec): CrossVaultAggregation<R, Spec> {
+    return new CrossVaultAggregation<R, Spec>(this, spec, this.liveBinding())
+  }
+
+  /** Begin a grouped cross-shard aggregate. */
+  groupBy<F extends string>(field: F): ShardedGroupedQuery<T, R, F> {
+    return new ShardedGroupedQuery<T, R, F>(this, field)
+  }
+}
+
+/** Grouped cross-shard query — intermediate after `.groupBy(field)`, terminates with `.aggregate(spec)`. */
+export class ShardedGroupedQuery<T, R, F extends string> {
+  constructor(
+    private readonly query: ShardedQuery<T, R>,
+    private readonly field: F,
+  ) {}
+
+  aggregate<Spec extends AggregateSpec>(spec: Spec): CrossVaultGroupedAggregation<R, F, Spec> {
+    return new CrossVaultGroupedAggregation<R, F, Spec>(
+      { fanoutRecords: (o) => this.query.fanoutRecords(o) } satisfies FanoutRecordSource<R>,
+      this.field,
+      spec,
+      this.query.liveBinding(),
+    )
   }
 }

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -292,6 +292,11 @@ export type {
   FanoutResult,
   SkippedVault,
 } from './federation/index.js'
+export type {
+  CrossVaultAggregation, CrossVaultGroupedAggregation, ShardedGroupedQuery,
+  CrossVaultLiveQuery, CrossVaultLiveAggregation, LiveQueryOptions,
+  GroupedRow as CrossVaultGroupedRow,
+} from './federation/index.js'
 export { UnknownShardError, ShardProvisioningError, VaultTemplateNotFoundError } from './errors.js'
 
 // Bundle format — `.noydb` container

--- a/showcases/src/99-vault-group-live-aggregate.showcase.test.ts
+++ b/showcases/src/99-vault-group-live-aggregate.showcase.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Showcase 99 — VaultGroup: live cross-shard queries + distributed aggregates
+ *
+ * What you'll learn
+ * ─────────────────
+ * Building on Showcase 98 (basic VaultGroup fan-out), this showcase adds the
+ * reactive and aggregate dimensions of the cross-vault federation surface:
+ *
+ *   1. `.query().where().live()` — a reactive cross-shard query that emits an
+ *      updated `value` array whenever any shard's matching records change.
+ *      `await lq.ready` settles the initial snapshot; `waitFor` polls for
+ *      subsequent reactive updates.
+ *
+ *   2. `.aggregate({ total: sum('amount'), n: count() }).run()` — one-shot
+ *      distributed aggregate that collects all shard records into a central
+ *      reduce pass (no avg-of-avgs: mean is computed over the full union).
+ *
+ *   3. `.groupBy('clientId').aggregate({ total: sum('amount') }).run()` —
+ *      one-shot grouped aggregate; one output row per distinct `clientId`
+ *      across all shards.
+ *
+ * Why it matters
+ * ──────────────
+ * Per-shard isolation is cryptographic (one vault = one DEK boundary), yet
+ * the firm needs fleet-level visibility without merging data stores. The
+ * live and aggregate surfaces bridge the two: reactive UI bindings stay
+ * coherent as data arrives from any shard, and reporting numbers are always
+ * correct because the reduce runs over the full union — not an average of
+ * per-shard averages.
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → vault-group-federation
+ * spec → docs/superpowers/specs/2026-06-07-cross-vault-live-and-aggregate-design.md
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import type { VaultRegistryRow } from '@noy-db/hub'
+import type { Vault } from '@noy-db/hub'
+import { sum, count, avg } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+
+// ─── Domain model ───────────────────────────────────────────────────────────
+
+interface Invoice {
+  clientId: string
+  amount: number
+  status: 'open' | 'overdue' | 'paid'
+}
+
+// ─── Polling helper ──────────────────────────────────────────────────────────
+
+async function waitFor(pred: () => boolean, { timeout = 2000, interval = 5 } = {}) {
+  const start = Date.now()
+  while (!pred()) {
+    if (Date.now() - start > timeout) throw new Error('waitFor timeout')
+    await new Promise<void>((r) => setTimeout(r, interval))
+  }
+}
+
+// ─── Harness ─────────────────────────────────────────────────────────────────
+
+/**
+ * Open a firm operator with a client template (v1) and a vault-registry–backed
+ * VaultGroup. Partition key is `clientId` (opaque internal id — NOT a human
+ * identifier, per the roster-visibility contract).
+ */
+async function openFirm(store: ReturnType<typeof memory>) {
+  const db = await createNoydb({ store, user: 'firm-operator', secret: 'firm-secret-2026' })
+  db.withVaultTemplate('client-template', {
+    version: 1,
+    configure(vault: Vault) {
+      vault.collection<Invoice>('invoices')
+    },
+  })
+  const state = await db.openVault('state')
+  const registry = state.collection<VaultRegistryRow>('vault-registry')
+  const firm = await db.openVaultGroup<Invoice>('firm-clients', {
+    registry,
+    sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template', autoCreate: true },
+  })
+  return { db, firm }
+}
+
+// ─── Showcase tests ──────────────────────────────────────────────────────────
+
+describe('Showcase 99 — VaultGroup live + distributed aggregate', () => {
+  // Track live handles for cleanup
+  const liveHandles: Array<{ stop(): void }> = []
+  afterEach(() => {
+    for (const h of liveHandles) h.stop()
+    liveHandles.length = 0
+  })
+
+  it('live() reflects the initial snapshot and reacts to writes across shards', async () => {
+    const store = memory()
+    const { firm } = await openFirm(store)
+
+    // Seed an invoice on one shard before starting the live query.
+    await firm.collection('invoices').put('c1-inv1', { clientId: 'c1', amount: 500, status: 'overdue' })
+
+    // Start the live query — `await lq.ready` settles the initial snapshot.
+    const lq = firm.collection('invoices').query().where('status', '==', 'overdue').live()
+    liveHandles.push(lq)
+    await lq.ready
+
+    expect(lq.value.map((r) => r.amount)).toEqual([500])
+    expect(lq.skippedVaults).toEqual([])
+
+    // Write to the same shard — live query must update.
+    await firm.collection('invoices').put('c1-inv2', { clientId: 'c1', amount: 300, status: 'overdue' })
+    await waitFor(() => lq.value.length === 2)
+    expect(lq.value.map((r) => r.amount).sort((a, b) => a - b)).toEqual([300, 500])
+
+    // Write to a NEW shard (auto-created) — live query picks it up.
+    await firm.collection('invoices').put('c2-inv1', { clientId: 'c2', amount: 750, status: 'overdue' })
+    await waitFor(() => lq.value.length === 3)
+    expect(lq.value.map((r) => r.amount).sort((a, b) => a - b)).toEqual([300, 500, 750])
+
+    // stop() halts updates — subsequent writes do not propagate.
+    lq.stop()
+    await firm.collection('invoices').put('c1-inv3', { clientId: 'c1', amount: 999, status: 'overdue' })
+    await new Promise<void>((r) => setTimeout(r, 30))
+    expect(lq.value.length).toBe(3)
+  })
+
+  it('aggregate().run() performs a central reduce — sum/count/avg correct across shards', async () => {
+    const store = memory()
+    const { firm } = await openFirm(store)
+
+    // Two invoices on shard c1 (amounts 100 + 200) and one on shard c2 (300).
+    // avg must be (100+200+300)/3 = 200, NOT avg-of-avgs (150+300)/2 = 225.
+    await firm.collection('invoices').put('c1-inv1', { clientId: 'c1', amount: 100, status: 'open' })
+    await firm.collection('invoices').put('c1-inv2', { clientId: 'c1', amount: 200, status: 'open' })
+    await firm.collection('invoices').put('c2-inv1', { clientId: 'c2', amount: 300, status: 'open' })
+
+    const { result, skippedVaults } = await firm.collection('invoices')
+      .query()
+      .aggregate({ total: sum('amount'), n: count(), mean: avg('amount') })
+      .run()
+
+    expect(skippedVaults).toEqual([])
+    expect(result.total).toBe(600)
+    expect(result.n).toBe(3)
+    // Central reduce: mean = 600/3 = 200 (not avg-of-avgs)
+    expect(result.mean).toBe(200)
+  })
+
+  it('groupBy().aggregate().run() produces one row per distinct clientId across all shards', async () => {
+    const store = memory()
+    const { firm } = await openFirm(store)
+
+    // Invoices spread across two client shards, two statuses.
+    await firm.collection('invoices').put('c1-inv1', { clientId: 'c1', amount: 100, status: 'overdue' })
+    await firm.collection('invoices').put('c1-inv2', { clientId: 'c1', amount: 200, status: 'open' })
+    await firm.collection('invoices').put('c2-inv1', { clientId: 'c2', amount: 400, status: 'overdue' })
+    await firm.collection('invoices').put('c3-inv1', { clientId: 'c3', amount: 50, status: 'open' })
+
+    const { results, skippedVaults } = await firm.collection('invoices')
+      .query()
+      .groupBy('clientId')
+      .aggregate({ total: sum('amount') })
+      .run()
+
+    expect(skippedVaults).toEqual([])
+
+    // One row per clientId; each row has the sum of that client's invoices.
+    const byClient = Object.fromEntries(results.map((r) => [r.clientId, r.total]))
+    expect(byClient['c1']).toBe(300)  // 100 + 200
+    expect(byClient['c2']).toBe(400)
+    expect(byClient['c3']).toBe(50)
+    expect(results).toHaveLength(3)
+  })
+})


### PR DESCRIPTION
Phase 3 of the multi-vault federation epic (#271), on top of the MVP + vLannaAi/klum-db#13 A/B/E (#292) and the vLannaAi/noy-db#313 fix (#315), both now on `main`.

## Adds (all on the `ShardedQuery` surface)
- **`query().where().live()`** → `CrossVaultLiveQuery<R>` — reactive merged records across shards (the epic's `queryAcrossLive`). Subscribes once to `db.on('change')`, filtered by the `<group>--` shard prefix; **dynamic shard pickup for free** (a new shard's first write triggers a recompute that re-reads the registry).
- **`query().aggregate(spec).run()`** and **`query().groupBy(field).aggregate(spec).run()`** → one-shot distributed reduce (the epic's `aggregateAcross`) — **central reduce** (concatenate `where`-filtered records, reduce once), correct for `avg` across shards (state-level, not avg-of-avgs).
- **`.aggregate(spec).live()`** → reactive distributed reduce (ungrouped scalar + grouped rows).
- One reactive core `CrossVaultLive<S>` (single-flight + microtask-coalesce + `ready` promise + `stop`), two facades mirroring the existing `LiveQuery` / `LiveAggregation` contracts (type-test verified) so framework adapters can bind later.

## Notes
- All new code is in the lazy **`federation/` chunk**; entry exports are **type-only** (classes are method-returned, never consumer-constructed) — bundle **leak canaries clean**, federation stays out of the core graph.
- Skips carry `'no-grant'` / `'schema-drift'` / `'error'` uniformly (shared `fanoutRecords`); a live no-grant test asserts a scoped identity sees only its shards + zero self-provision.
- `Reducer.merge` (from vLannaAi/klum-db#13 E) is present as a **seam**; the aggregate impl stays central-reduce — distributed partial-reduce / hierarchical rollup is a deferred follow-up.
- `join.ts` untouched. Showcase 99 added.

## Verification
- [x] `pnpm --filter @noy-db/hub test` — 225 files / 2202 tests
- [x] typecheck (+typetest, incl. LiveQuery shape-compat) clean
- [x] validate-features, architecture, bundle leak-canaries ✓
- [x] showcase 99 green against the built package

Part of vLannaAi/klum-db#12. **Held for review — not auto-merged.**