### PR TITLE
fix: Pilot-3 urgent bugs — store capabilities (#321) + money read parity (#322)

### DIFF
--- a/packages/hub/__tests__/money/read-parity.test.ts
+++ b/packages/hub/__tests__/money/read-parity.test.ts
@@ -41,12 +41,13 @@ function memory(): NoydbStore {
 
 interface Sale extends Record<string, unknown> { id: string; total: number | string }
 
-async function salesVault() {
+async function salesVault(defaultLocale?: string) {
   const db = await createNoydb({ store: memory(), user: 'op', secret: 'pilot3-money-parity-2026-exact', aggregateStrategy: withAggregate() })
   const v = await db.openVault('books')
   v.collection<Sale>('sales', {
     schema: z.object({ id: z.string(), total: z.union([z.number(), z.string()]) }),
     moneyFields: { total: money({ currency: 'EUR', scale: 2 }) },
+    ...(defaultLocale ? { defaultLocale } : {}),
   })
   return v
 }
@@ -64,10 +65,43 @@ describe('money read parity — get() vs list() vs query().toArray() (#322)', ()
     expect(viaGet!.total).toBe('122.00')
     expect(viaList!.total).toBe('122.00')   // was '12200' (raw cents) — the bug
     expect(viaQuery!.total).toBe('122.00')  // was '12200' (raw cents) — the bug
-    // all three paths return identical records (canonical decimal + the same
-    // derived virtuals), so a consumer never sees two representations.
+    // get() and list() are both collection-level reads with locale context →
+    // identical records (canonical decimal + the same derived virtuals).
     expect(viaList).toEqual(viaGet)
-    expect(viaQuery).toEqual(viaGet)
+    // query().toArray() is locale-less → it agrees on the canonical decimal
+    // VALUE but does not fabricate locale-formatted virtuals (see below).
+    expect(viaQuery!.total).toBe(viaGet!.total)
+  })
+
+  it('canonical value parity holds even with a collection defaultLocale (virtuals are not faked on the locale-less query path)', async () => {
+    const v = await salesVault('it-IT')
+    const sales = v.collection<Sale>('sales')
+    await sales.put('s1', { id: 's1', total: 122 })
+
+    const viaGet = (await sales.get('s1')) as Record<string, unknown>
+    const viaQuery = sales.query().toArray()[0] as Record<string, unknown>
+
+    // The canonical decimal agrees regardless of locale — the #322 invariant.
+    expect(viaGet.total).toBe('122.00')
+    expect(viaQuery.total).toBe('122.00')
+    // get() formats virtuals with the collection's it-IT locale; the locale-less
+    // query path deliberately omits them rather than guessing a wrong locale
+    // (which would reintroduce #322 on the virtual field).
+    expect(viaGet.totalFormatted).toBeDefined()
+    expect(viaQuery.totalFormatted).toBeUndefined()
+  })
+
+  it('scan() streams the canonical decimal, not raw cents (#322)', async () => {
+    const v = await salesVault()
+    const sales = v.collection<Sale>('sales')
+    await sales.put('s1', { id: 's1', total: 122 })
+    await sales.put('s2', { id: 's2', total: 5 })
+
+    const seen: string[] = []
+    for await (const rec of sales.scan({ pageSize: 10 })) {
+      seen.push(String(rec.total))
+    }
+    expect(seen.sort()).toEqual(['122.00', '5.00'])
   })
 
   it('aggregate sum already agreed with get() and still does', async () => {

--- a/packages/hub/__tests__/money/read-parity.test.ts
+++ b/packages/hub/__tests__/money/read-parity.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { createNoydb } from '../../src/index.js'
+import { withAggregate } from '../../src/aggregate/index.js'
+import { sum } from '../../src/aggregate/reducers.js'
+import { money } from '../../src/money/descriptor.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+// #322 — money fields read back differently via get() (decimal) vs
+// list()/query().toArray() (raw scaled-int cents). The stored scaled-int is
+// an internal representation and must never leak; all read paths must return
+// the same canonical decimal, matching get() / sum().
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none', required: false, flow: 'static' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) { out[cname] = out[cname] ?? {}; out[cname][id] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) { data.set(k(v, c, i), payload[c][i]) }
+      }
+    },
+  }
+}
+
+interface Sale extends Record<string, unknown> { id: string; total: number | string }
+
+async function salesVault() {
+  const db = await createNoydb({ store: memory(), user: 'op', secret: 'pilot3-money-parity-2026-exact', aggregateStrategy: withAggregate() })
+  const v = await db.openVault('books')
+  v.collection<Sale>('sales', {
+    schema: z.object({ id: z.string(), total: z.union([z.number(), z.string()]) }),
+    moneyFields: { total: money({ currency: 'EUR', scale: 2 }) },
+  })
+  return v
+}
+
+describe('money read parity — get() vs list() vs query().toArray() (#322)', () => {
+  it('returns the same decimal representation across all three read paths', async () => {
+    const v = await salesVault()
+    const sales = v.collection<Sale>('sales')
+    await sales.put('s1', { id: 's1', total: 122 })
+
+    const viaGet = await sales.get('s1')
+    const viaList = (await sales.list())[0]
+    const viaQuery = sales.query().toArray()[0]
+
+    expect(viaGet!.total).toBe('122.00')
+    expect(viaList!.total).toBe('122.00')   // was '12200' (raw cents) — the bug
+    expect(viaQuery!.total).toBe('122.00')  // was '12200' (raw cents) — the bug
+    // all three paths return identical records (canonical decimal + the same
+    // derived virtuals), so a consumer never sees two representations.
+    expect(viaList).toEqual(viaGet)
+    expect(viaQuery).toEqual(viaGet)
+  })
+
+  it('aggregate sum already agreed with get() and still does', async () => {
+    const v = await salesVault()
+    const sales = v.collection<Sale>('sales')
+    await sales.put('s1', { id: 's1', total: 122 })
+    await sales.put('s2', { id: 's2', total: 78 })
+    const got1 = await sales.get('s1')
+    expect(got1!.total).toBe('122.00')
+    const summed = await sales.query().aggregate({ t: sum('total') }).run() as Record<string, unknown>
+    expect(summed.t).toBe('200.00')
+  })
+})

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -2752,6 +2752,7 @@ export class Collection<T> {
       [],
       [],
       joinContext,
+      this.moneyFields,
     )
   }
 

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -2091,8 +2091,25 @@ export class Collection<T> {
     }
     await this.ensureHydrated()
     const records = [...this.cache.values()].map(e => e.record)
-    if (!locale) return records
+    // #322 — money decode (stored scaled-int → canonical decimal) must run
+    // even with no locale, so list() matches get(). applyLocaleToRecord
+    // decodes money regardless of locale and only resolves i18n/dict virtuals
+    // when a locale is active. Keep the no-transform fast path.
+    if (!this.hasReadTransforms()) return records
     return Promise.all(records.map(r => this.applyLocaleToRecord(r, locale)))
+  }
+
+  /**
+   * @internal — whether any read-side record transform is registered
+   * (money decode, i18nText resolution, dictKey labels). Gates the
+   * no-transform fast path in {@link list}.
+   */
+  private hasReadTransforms(): boolean {
+    return (
+      (this.moneyFields !== undefined && Object.keys(this.moneyFields).length > 0) ||
+      (this.i18nFields !== undefined && Object.keys(this.i18nFields).length > 0) ||
+      (this.dictKeyFields !== undefined && Object.keys(this.dictKeyFields).length > 0)
+    )
   }
 
   // ─── Bulk operations ─────────────────────────────────────

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -561,14 +561,20 @@ export class Query<T> {
 
   /**
    * Decode this source's money fields on read (stored scaled-int → canonical
-   * decimal), matching `Collection.get()`. No-op when the source declares no
-   * money fields. Locale is undefined here (the query layer carries no locale
-   * context); the canonical decimal is locale-independent.
+   * decimal), so `query().toArray()` agrees with `get()`/`sum()` on the value.
+   * No-op when the source declares no money fields.
+   *
+   * The query layer carries no locale context, so we decode with `'raw'` —
+   * canonical decimal, WITHOUT fabricating locale-formatted `<field>Formatted`
+   * / `<field>Number` virtuals. Producing a guessed-locale string here would
+   * just reintroduce #322's "two read paths disagree" failure on the virtual
+   * field (e.g. it-IT via `get()` vs en-US here). Consumers who need formatted
+   * money read through `get()`/`list()` with a locale.
    */
   private decodeMoney(records: readonly unknown[]): unknown[] {
     const moneyFields = this.source.moneyFields
     if (!moneyFields || Object.keys(moneyFields).length === 0) return records as unknown[]
-    return records.map(r => decodeMoneyFields(r as Record<string, unknown>, moneyFields, undefined))
+    return records.map(r => decodeMoneyFields(r as Record<string, unknown>, moneyFields, 'raw'))
   }
 
   /** Return the first matching record, or null. Joins are applied. */

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -18,6 +18,7 @@ import type { GroupedQuery, GroupedQueryN } from '../aggregate/groupby.js'
 import { NO_AGGREGATE, type AggregateStrategy } from '../aggregate/strategy.js'
 import type { MoneyDescriptor } from '../money/descriptor.js'
 import { wrapMoneyReducers } from '../money/money-reducer.js'
+import { decodeMoneyFields } from '../money/normalize.js'
 
 export interface OrderBy {
   readonly field: string
@@ -539,7 +540,11 @@ export class Query<T> {
    * for the ordering rationale.
    */
   toArray(): T[] {
-    const base = executePlanWithSource(this.source, this.plan, this.joinContext)
+    // #322 — decode money fields (stored scaled-int → canonical decimal) so
+    // query().toArray() matches get()/sum(), which already return decimal.
+    // Decode the left/base records before joins (right-side aliased fields
+    // belong to other collections and are out of this source's money scope).
+    const base = this.decodeMoney(executePlanWithSource(this.source, this.plan, this.joinContext))
     if (this.plan.joins.length === 0) return base as T[]
     if (!this.joinContext) {
       // Unreachable in practice — .join() throws if joinContext is
@@ -552,6 +557,18 @@ export class Query<T> {
       )
     }
     return applyJoins(base, this.plan.joins, this.joinContext) as T[]
+  }
+
+  /**
+   * Decode this source's money fields on read (stored scaled-int → canonical
+   * decimal), matching `Collection.get()`. No-op when the source declares no
+   * money fields. Locale is undefined here (the query layer carries no locale
+   * context); the canonical decimal is locale-independent.
+   */
+  private decodeMoney(records: readonly unknown[]): unknown[] {
+    const moneyFields = this.source.moneyFields
+    if (!moneyFields || Object.keys(moneyFields).length === 0) return records as unknown[]
+    return records.map(r => decodeMoneyFields(r as Record<string, unknown>, moneyFields, undefined))
   }
 
   /** Return the first matching record, or null. Joins are applied. */

--- a/packages/hub/src/query/scan-builder.ts
+++ b/packages/hub/src/query/scan-builder.ts
@@ -66,6 +66,8 @@ import type {
 } from '../aggregate/aggregation.js'
 import type { JoinContext, JoinLeg, JoinableSource } from './join.js'
 import { DanglingReferenceError } from '../errors.js'
+import type { MoneyDescriptor } from '../money/descriptor.js'
+import { decodeMoneyFields } from '../money/normalize.js'
 
 /**
  * Page provider — the Collection-shaped hook the builder calls to
@@ -117,6 +119,14 @@ export class ScanBuilder<T> implements AsyncIterable<T> {
    * context throws with an actionable error.
    */
   private readonly joinContext: JoinContext | undefined
+  /**
+   * Money field descriptors for the backing collection. When present, yielded
+   * records are decoded (stored scaled-int → canonical decimal) so `scan()`
+   * agrees with `get()`/`list()`/`query().toArray()` — #322. Decoded with
+   * `'raw'` (canonical decimal, no locale-formatted virtuals) since the scan
+   * stream carries no locale context, mirroring `Query.toArray()`.
+   */
+  private readonly moneyFields: Record<string, MoneyDescriptor> | undefined
 
   constructor(
     pageProvider: ScanPageProvider<T>,
@@ -124,12 +134,23 @@ export class ScanBuilder<T> implements AsyncIterable<T> {
     clauses: readonly Clause[] = [],
     joins: readonly JoinLeg[] = [],
     joinContext?: JoinContext,
+    moneyFields?: Record<string, MoneyDescriptor>,
   ) {
     this.pageProvider = pageProvider
     this.pageSize = pageSize
     this.clauses = clauses
     this.joins = joins
     this.joinContext = joinContext
+    this.moneyFields = moneyFields
+  }
+
+  /**
+   * Decode this scan's money fields on a record (stored scaled-int → canonical
+   * decimal). No-op when no money fields are declared. See {@link moneyFields}.
+   */
+  private decodeMoney(record: T): T {
+    if (!this.moneyFields || Object.keys(this.moneyFields).length === 0) return record
+    return decodeMoneyFields(record as Record<string, unknown>, this.moneyFields, 'raw') as T
   }
 
   /**
@@ -153,6 +174,7 @@ export class ScanBuilder<T> implements AsyncIterable<T> {
       [...this.clauses, clause],
       this.joins,
       this.joinContext,
+      this.moneyFields,
     )
   }
 
@@ -173,6 +195,7 @@ export class ScanBuilder<T> implements AsyncIterable<T> {
       [...this.clauses, clause],
       this.joins,
       this.joinContext,
+      this.moneyFields,
     )
   }
 
@@ -295,6 +318,7 @@ export class ScanBuilder<T> implements AsyncIterable<T> {
       this.clauses,
       [...this.joins, leg],
       this.joinContext,
+      this.moneyFields,
     )
   }
 
@@ -322,15 +346,19 @@ export class ScanBuilder<T> implements AsyncIterable<T> {
     let page = await this.pageProvider.listPage({ limit: this.pageSize })
     while (true) {
       for (const record of page.items) {
+        // Filter on the raw stored record (same order as Query.toArray:
+        // clauses first), then decode money to the canonical decimal before
+        // yielding so scan() never leaks the internal scaled-int — #322.
         if (!this.recordMatches(record)) continue
+        const decoded = this.decodeMoney(record)
         if (joinResolvers === null) {
-          yield record
+          yield decoded
         } else {
           // Apply every join leg in declaration order. Each
           // leg attaches a field — the result of one leg becomes
           // the input to the next. Multi-FK chaining is
           // supported by construction.
-          let attached: unknown = record
+          let attached: unknown = decoded
           for (const resolver of joinResolvers) {
             attached = this.applyOneJoinStreaming(attached, resolver)
           }

--- a/packages/to-aws-dynamo/__tests__/capabilities.test.ts
+++ b/packages/to-aws-dynamo/__tests__/capabilities.test.ts
@@ -8,11 +8,10 @@ import { dynamo } from '../src/index.js'
 // fiscal numbering. Construction is offline (the client is lazy), so this
 // needs no real AWS access.
 describe('dynamo() capabilities (#321)', () => {
-  it('advertises casAtomic:true and the DynamoDB blob-chunk limit', () => {
+  it('advertises casAtomic:true (ConditionExpression CAS) with an iam auth descriptor', () => {
     const caps = dynamo({ table: 't', region: 'eu-west-1' }).capabilities
     expect(caps).toBeDefined()
     expect(caps?.casAtomic).toBe(true)
     expect(caps?.auth.kind).toBe('iam')
-    expect(caps?.maxBlobBytes).toBe(256 * 1024)
   })
 })

--- a/packages/to-aws-dynamo/__tests__/capabilities.test.ts
+++ b/packages/to-aws-dynamo/__tests__/capabilities.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { dynamo } from '../src/index.js'
+
+// Regression for #321 — `dynamo()` documented `casAtomic: true` (it does
+// atomic CAS via a ConditionExpression on `_v`) but never populated
+// `capabilities`, so `vault.sequence().next()` threw SequenceOfflineError
+// against DynamoDB — the recommended production backend for gap-free
+// fiscal numbering. Construction is offline (the client is lazy), so this
+// needs no real AWS access.
+describe('dynamo() capabilities (#321)', () => {
+  it('advertises casAtomic:true and the DynamoDB blob-chunk limit', () => {
+    const caps = dynamo({ table: 't', region: 'eu-west-1' }).capabilities
+    expect(caps).toBeDefined()
+    expect(caps?.casAtomic).toBe(true)
+    expect(caps?.auth.kind).toBe('iam')
+    expect(caps?.maxBlobBytes).toBe(256 * 1024)
+  })
+})

--- a/packages/to-aws-dynamo/src/index.ts
+++ b/packages/to-aws-dynamo/src/index.ts
@@ -144,6 +144,16 @@ export function dynamo(options: DynamoOptions): NoydbStore {
   return {
     name: 'dynamo',
 
+    // #321 — DynamoDB's conditional PutItem (`ConditionExpression` on `_v`)
+    // is an atomic compare-and-swap, so it can back `vault.sequence()`.
+    // `maxBlobBytes` reflects the 400 KB item limit (minus envelope
+    // overhead) so blobs chunk instead of overflowing a single item.
+    capabilities: {
+      casAtomic: true,
+      auth: { kind: 'iam', required: true, flow: 'static' },
+      maxBlobBytes: 256 * 1024,
+    },
+
     async get(vault, collection, id) {
       const client = await getClient()
       const { GetCommand } = await import('@aws-sdk/lib-dynamodb') as { GetCommand: new (input: GetCommandInput) => unknown }

--- a/packages/to-aws-dynamo/src/index.ts
+++ b/packages/to-aws-dynamo/src/index.ts
@@ -146,12 +146,12 @@ export function dynamo(options: DynamoOptions): NoydbStore {
 
     // #321 — DynamoDB's conditional PutItem (`ConditionExpression` on `_v`)
     // is an atomic compare-and-swap, so it can back `vault.sequence()`.
-    // `maxBlobBytes` reflects the 400 KB item limit (minus envelope
-    // overhead) so blobs chunk instead of overflowing a single item.
+    // (`maxBlobBytes` — the 400 KB item-limit chunking hint — is intentionally
+    // left for the broader capabilities audit, where blob behavior can be
+    // verified against real DynamoDB; it would change chunking, not sequencing.)
     capabilities: {
       casAtomic: true,
       auth: { kind: 'iam', required: true, flow: 'static' },
-      maxBlobBytes: 256 * 1024,
     },
 
     async get(vault, collection, id) {

--- a/packages/to-memory/__tests__/capabilities.test.ts
+++ b/packages/to-memory/__tests__/capabilities.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '../src/index.js'
+
+// Regression for #321 — the factory documented `casAtomic: true` in its
+// JSDoc but never populated `capabilities` on the returned store, so
+// `vault.sequence().next()` (which gates on `capabilities.casAtomic`) threw
+// SequenceOfflineError even though memory is synchronously atomic.
+describe('memory() capabilities (#321)', () => {
+  it('advertises casAtomic:true with a valid auth descriptor', () => {
+    const caps = memory().capabilities
+    expect(caps).toBeDefined()
+    expect(caps?.casAtomic).toBe(true)
+    expect(caps?.auth.kind).toBe('none')
+    expect(caps?.auth.required).toBe(false)
+  })
+
+  it('vault.sequence().next() works end-to-end against the real adapter (no SequenceOfflineError)', async () => {
+    const db = await createNoydb({ store: memory(), user: 'op', encrypt: false })
+    const v = await db.openVault('v')
+    const seq = v.sequence('invoice-2026')
+    expect(await seq.next()).toBe(1)
+    expect(await seq.next()).toBe(2)
+  })
+})

--- a/packages/to-memory/src/index.ts
+++ b/packages/to-memory/src/index.ts
@@ -56,6 +56,15 @@ export function memory(): NoydbStore {
   return {
     name: 'memory',
 
+    // #321 — memory's synchronous Map ops make the expectedVersion check +
+    // write atomic, so it can back `vault.sequence()`. Without this the
+    // JSDoc's `casAtomic: true` promise was undefined at runtime and
+    // `sequence().next()` threw SequenceOfflineError.
+    capabilities: {
+      casAtomic: true,
+      auth: { kind: 'none', required: false, flow: 'static' },
+    },
+
     async get(vault, collection, id) {
       return store.get(vault)?.get(collection)?.get(id) ?? null
     },

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -401,8 +401,15 @@ const KERNEL_SURFACE_BUDGET = {
   // the same kernel-resident placement as the i18nText/dictKey hooks — they
   // cannot move onto the SubsystemBus. The heavy logic lives in src/money/ and
   // src/computed/; only the thin call-sites are here.
-  'packages/hub/src/collection.ts': 4010,
-  'packages/hub/src/vault.ts': 3640,
+  // Bumped 4010→4030 (2026-06-08): #322 read-path money parity — list()'s
+  // no-locale decode + the `hasReadTransforms` gate are thin decode-on-read
+  // call-sites in the get/list hot path (heavy logic in src/money/), same
+  // kernel-resident class as the money()/computed() hooks above.
+  'packages/hub/src/collection.ts': 4030,
+  // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
+  // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
+  // engine itself lives in src/numbering/; only the thin vault call-sites are here.
+  'packages/hub/src/vault.ts': 3700,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),
@@ -411,7 +418,12 @@ const KERNEL_SURFACE_BUDGET = {
   // VaultGroup *implementation* lives in the lazy `federation/` chunk via a
   // dynamic import, NOT here). The extractable parts are already off this file;
   // what remains is irreducible core API + auth surface.
-  'packages/hub/src/noydb.ts': 2960,
+  // Bumped 2960→2995 (2026-06-08): federation control-plane entry points
+  // (`openVaultGroup` auto-wire + `openStateManagementVault` factory, #271 L3)
+  // and deferred-numbering option threading — public `db.*` API surface; the
+  // VaultGroup / StateManagementVault / numbering implementations live in lazy
+  // or sibling modules, only the thin entry points are here.
+  'packages/hub/src/noydb.ts': 2995,
 }
 
 function checkKernelSurface() {


### PR DESCRIPTION
Two urgent Pilot-3 correctness bugs found during the migration build.

## #321 — `vault.sequence()` unusable (store `capabilities` undefined)
`to-memory` and `to-aws-dynamo` documented `casAtomic: true` but returned **no `capabilities` object at runtime**, so `sequence().next()` (which gates on `capabilities.casAtomic`) threw `SequenceOfflineError` — even on DynamoDB, whose conditional `PutItem` is genuine atomic CAS. Gap-free fiscal numbering was impossible on the production backend.

- `memory`: `casAtomic: true` + `none` auth (synchronous Map ops are atomic)
- `dynamo`: `casAtomic: true` + `iam` auth (ConditionExpression on `_v`)
- Verified end-to-end: `sequence().next()` → 1, 2 against the real `memory()` adapter.

**Scope note:** only the two named (pilot-critical) adapters are fixed here. The other 18 `to-*` adapters also lack `capabilities` and need a careful per-store atomicity audit (a wrong `casAtomic:true` would mask gapped/duplicate numbers) — tracked as a follow-up, not rushed into this fix.

## #322 — money fields read back as raw cents via `list()`/`toArray()`/`scan()`
`get()`/`sum()` returned the canonical decimal (`'122.00'`), but `list()` (no locale), `query().toArray()`, and `scan()` leaked the internal scaled-int (`'12200'`) — a silent 100× foot-gun.

- `list()` no longer short-circuits before the money decode.
- `query().toArray()` and `scan()` decode money to **canonical decimal** with `'raw'` (no fabricated locale-formatted virtuals) — these layers carry no locale context, so guessing a locale would just move the mismatch to `<field>Formatted` (verified by a `defaultLocale` divergence test).
- `scan()` threads `moneyFields` through `ScanBuilder` and decodes each yielded record.

## Test plan
- [x] New regression tests per adapter (`capabilities`) + per read path (money parity, defaultLocale divergence, scan).
- [x] Full hub suite green (2310/2310), tsc clean.

Closes #321
Closes #322