### PR TITLE
release: 0.2.0-pre.14 — store capabilities audit + crossShardJoin (#271)

### DIFF
--- a/docs/subsystems/storage-capability-matrix.md
+++ b/docs/subsystems/storage-capability-matrix.md
@@ -14,11 +14,11 @@ vault-only stores (concurrency there is per-bundle OCC, not per-record CAS).
 | Adapter | record | vault | casAtomic | Use case | Status |
 |---|:--:|:--:|:--:|---|---|
 | `to-aws-dynamo` | ✅ | ❌ | ✅ | cloud-serverless | stable |
-| `to-aws-s3` | ✅ | ✅ | ❌ | cloud-blob-storage | stable |
+| `to-aws-s3` | ✅ | ✅ | ✅ | cloud-blob-storage | stable |
 | `to-browser-idb` | ✅ | ❌ | ✅ | pwa-offline-first | stable |
-| `to-browser-local` | ✅ | ❌ | ✅ | simple-pwa-cache | stable |
+| `to-browser-local` | ✅ | ❌ | ❌ | simple-pwa-cache | stable |
 | `to-cloudflare-d1` | ✅ | ❌ | ✅ | edge-serverless | stable |
-| `to-cloudflare-r2` | ✅ | ❌ | ❌ | edge-blob-storage | stable |
+| `to-cloudflare-r2` | ✅ | ❌ | ✅ | edge-blob-storage | stable |
 | `to-drive` | ❌ | ✅ | n/a | cloud-bundle-storage | stable |
 | `to-file` | ✅ | ❌ | ❌ | usb-or-local-disk | stable |
 | `to-icloud` | ❌ | ✅ | n/a | apple-ecosystem-sync | stable |

--- a/docs/superpowers/plans/2026-06-09-cross-shard-join.md
+++ b/docs/superpowers/plans/2026-06-09-cross-shard-join.md
@@ -1,0 +1,903 @@
+# crossShardJoin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `crossShardJoin` (co-partitioned, per-shard intra-vault join + union) and `broadcastJoin` (single shared dimension table, central enrichment) to `ShardedQuery`, closing one of the remaining #271 federation primitives.
+
+**Architecture:** Co-partitioned join threads a `JoinLeg` into the *existing, unchanged* intra-vault `.join()` inside each shard's fan-out closure (same vault, same DEK). Broadcast join is a separate central map-attach applied post-merge, bypassing the join planner. All code lives in `federation/` (a lazy chunk under no kernel-surface ceiling). `join.ts` is not touched.
+
+**Tech Stack:** TypeScript ESM, vitest, pnpm workspace (`@noy-db/hub`). Spec: `docs/superpowers/specs/2026-06-09-cross-shard-join-design.md`.
+
+**Run tests from the hub package:** `cd packages/hub && pnpm vitest run __tests__/federation-cross-shard-join.test.ts`. Lint: `pnpm lint`. Architecture: `node scripts/check-architecture.mjs` (run from repo root). **All three must pass before the branch is done — the previous cycle went red in CI because lint/architecture were skipped locally.**
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `packages/hub/src/errors.ts` | Add `CrossShardJoinError` (code `CROSS_SHARD_JOIN`). |
+| `packages/hub/src/federation/cross-shard-join.ts` | **New.** Leg types (`CoPartitionedLeg`, `BroadcastLeg`), public option types (`CrossShardJoinOptions`, `BroadcastJoinOptions`), `BroadcastSource` interface, `applyBroadcastLegs()` central executor + local `coerceKey` + warn-dedup. |
+| `packages/hub/src/federation/vault-group.ts` | `ShardedQuery` gains `coPartitionedLegs` / `broadcastLegs` constructor params + fields, `crossShardJoin()` / `broadcastJoin()` builders; `fanoutRecords` threads co-partitioned legs (with right-side hydration); `toArray` applies broadcast legs; `live` / `aggregate` / `groupBy` guards. Update the 2 existing `new ShardedQuery(...)` call sites. |
+| `packages/hub/src/federation/index.ts` | Re-export the public option types. |
+| `packages/hub/__tests__/federation-cross-shard-join.test.ts` | **New.** Behavior + failure-mode coverage. |
+| `features.yaml` | Update the `vault-group-federation` invariant line about crossShardJoin. |
+
+---
+
+## Task 1: `CrossShardJoinError`
+
+**Files:**
+- Modify: `packages/hub/src/errors.ts`
+- Test: `packages/hub/__tests__/federation-cross-shard-join.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/hub/__tests__/federation-cross-shard-join.test.ts` with:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { CrossShardJoinError, NoydbError } from '../src/errors.js'
+
+describe('CrossShardJoinError', () => {
+  it('is a NoydbError with the CROSS_SHARD_JOIN code', () => {
+    const e = new CrossShardJoinError('nope')
+    expect(e).toBeInstanceOf(NoydbError)
+    expect(e.code).toBe('CROSS_SHARD_JOIN')
+    expect(e.message).toBe('nope')
+  })
+})
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/federation-cross-shard-join.test.ts`
+Expected: FAIL — `CrossShardJoinError` is not exported from `errors.js`.
+
+- [ ] **Step 3: Implement the error**
+
+In `packages/hub/src/errors.ts`, after an existing federation error (e.g. near `UnknownShardError` / `ShardProvisioningError`), add:
+
+```ts
+/**
+ * Thrown by `ShardedQuery.crossShardJoin` / `broadcastJoin` for
+ * deterministic, query-shaping errors: an undeclared join ref (which
+ * would fail identically on every shard), or calling a deferred
+ * reactive/aggregate surface on a query that already carries join legs.
+ */
+export class CrossShardJoinError extends NoydbError {
+  constructor(message: string) {
+    super('CROSS_SHARD_JOIN', message)
+    this.name = 'CrossShardJoinError'
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/federation-cross-shard-join.test.ts`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/errors.ts packages/hub/__tests__/federation-cross-shard-join.test.ts
+git commit -m "feat(hub): CrossShardJoinError"
+```
+
+---
+
+## Task 2: Broadcast leg types + `applyBroadcastLegs` central executor
+
+This is pure (no VaultGroup), so it's tested in isolation with plain rows and a fake source.
+
+**Files:**
+- Create: `packages/hub/src/federation/cross-shard-join.ts`
+- Test: `packages/hub/__tests__/federation-cross-shard-join.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the test file:
+
+```ts
+import { applyBroadcastLegs, type BroadcastLeg, type BroadcastSource } from '../src/federation/cross-shard-join.js'
+
+function fakeSource(rows: Record<string, unknown>[]): BroadcastSource & { snapCalls: number } {
+  let snapCalls = 0
+  return {
+    get snapCalls() { return snapCalls },
+    snapshot() { snapCalls++; return rows },
+  } as BroadcastSource & { snapCalls: number }
+}
+
+describe('applyBroadcastLegs', () => {
+  it('attaches the matching dimension record by default on:id', async () => {
+    const src = fakeSource([{ id: 'usd', symbol: '$' }, { id: 'eur', symbol: '€' }])
+    const leg: BroadcastLeg = { field: 'currencyCode', as: 'fx', from: src, on: 'id', mode: 'warn' }
+    const out = await applyBroadcastLegs(
+      [{ id: 'i1', currencyCode: 'usd' }, { id: 'i2', currencyCode: 'eur' }],
+      [leg],
+    )
+    expect((out[0] as Record<string, unknown>).fx).toEqual({ id: 'usd', symbol: '$' })
+    expect((out[1] as Record<string, unknown>).fx).toEqual({ id: 'eur', symbol: '€' })
+  })
+
+  it('matches on a custom key', async () => {
+    const src = fakeSource([{ code: 'usd', symbol: '$' }])
+    const leg: BroadcastLeg = { field: 'currencyCode', as: 'fx', from: src, on: 'code', mode: 'warn' }
+    const out = await applyBroadcastLegs([{ id: 'i1', currencyCode: 'usd' }], [leg])
+    expect((out[0] as Record<string, unknown>).fx).toEqual({ code: 'usd', symbol: '$' })
+  })
+
+  it('attaches null on a miss', async () => {
+    const src = fakeSource([{ id: 'usd' }])
+    const leg: BroadcastLeg = { field: 'currencyCode', as: 'fx', from: src, on: 'id', mode: 'cascade' }
+    const out = await applyBroadcastLegs([{ id: 'i1', currencyCode: 'gbp' }], [leg])
+    expect((out[0] as Record<string, unknown>).fx).toBeNull()
+  })
+
+  it('loads the source snapshot exactly once regardless of row count', async () => {
+    const src = fakeSource([{ id: 'usd' }])
+    const leg: BroadcastLeg = { field: 'currencyCode', as: 'fx', from: src, on: 'id', mode: 'cascade' }
+    await applyBroadcastLegs(
+      Array.from({ length: 50 }, (_, i) => ({ id: `i${i}`, currencyCode: 'usd' })),
+      [leg],
+    )
+    expect(src.snapCalls).toBe(1)
+  })
+
+  it('applies multiple legs independently', async () => {
+    const fx = fakeSource([{ id: 'usd', symbol: '$' }])
+    const adv = fakeSource([{ id: 'a1', name: 'Dana' }])
+    const out = await applyBroadcastLegs(
+      [{ id: 'i1', currencyCode: 'usd', advisorId: 'a1' }],
+      [
+        { field: 'currencyCode', as: 'fx', from: fx, on: 'id', mode: 'cascade' },
+        { field: 'advisorId', as: 'advisor', from: adv, on: 'id', mode: 'cascade' },
+      ],
+    )
+    expect((out[0] as Record<string, unknown>).fx).toEqual({ id: 'usd', symbol: '$' })
+    expect((out[0] as Record<string, unknown>).advisor).toEqual({ id: 'a1', name: 'Dana' })
+  })
+
+  it('returns rows unchanged when there are no legs', async () => {
+    const rows = [{ id: 'i1' }]
+    const out = await applyBroadcastLegs(rows, [])
+    expect(out).toEqual(rows)
+  })
+})
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/federation-cross-shard-join.test.ts`
+Expected: FAIL — `cross-shard-join.js` does not exist.
+
+- [ ] **Step 3: Implement `cross-shard-join.ts`**
+
+Create `packages/hub/src/federation/cross-shard-join.ts`:
+
+```ts
+/**
+ * @category capability
+ * crossShardJoin — co-partitioned + broadcast dimension join for
+ * ShardedQuery. Spec:
+ * docs/superpowers/specs/2026-06-09-cross-shard-join-design.md.
+ *
+ * This module owns the BROADCAST half (central, post-merge map-attach)
+ * and the leg type definitions. The CO-PARTITIONED half is threaded
+ * into the existing intra-vault `.join()` from vault-group.ts — see
+ * ShardedQuery.fanoutRecords. join.ts is deliberately untouched.
+ */
+import { readPath } from '../query/predicate.js'
+import type { JoinStrategy } from '../query/join.js'
+
+/** Public options for `ShardedQuery.crossShardJoin`. */
+export interface CrossShardJoinOptions {
+  /** Alias key under which the joined same-shard record attaches. */
+  readonly as: string
+  /** Per-shard row ceiling override (default DEFAULT_JOIN_MAX_ROWS). */
+  readonly maxRows?: number
+  /** Planner strategy override, passed through to intra-vault `.join()`. */
+  readonly strategy?: JoinStrategy
+}
+
+/**
+ * Minimal structural shape of a broadcast dimension source. A
+ * `Collection` satisfies this: `snapshot()` reads its in-memory cache,
+ * `list()` hydrates it. `list` is optional so plain test sources work.
+ */
+export interface BroadcastSource {
+  snapshot(): readonly unknown[]
+  list?(): Promise<unknown>
+}
+
+/** Public options for `ShardedQuery.broadcastJoin`. */
+export interface BroadcastJoinOptions {
+  /** Alias key under which the dimension record attaches. */
+  readonly as: string
+  /** The shared dimension collection (an opened handle in another vault). */
+  readonly from: BroadcastSource
+  /** Right-side key to match `field` against. Default 'id'. */
+  readonly on?: string
+  /** Miss behavior. 'warn' (default) attaches null + one-shot warning; 'cascade' is silent. */
+  readonly mode?: 'warn' | 'cascade'
+}
+
+/** Internal co-partitioned leg carried on ShardedQuery. */
+export interface CoPartitionedLeg {
+  readonly field: string
+  readonly as: string
+  readonly maxRows: number | undefined
+  readonly strategy: JoinStrategy | undefined
+}
+
+/** Internal broadcast leg carried on ShardedQuery. */
+export interface BroadcastLeg {
+  readonly field: string
+  readonly as: string
+  readonly from: BroadcastSource
+  readonly on: string
+  readonly mode: 'warn' | 'cascade'
+}
+
+/**
+ * Coerce an unknown key value into a lookup string. Mirrors join.ts's
+ * private `coerceRefKey` (string → string; number/bigint → String;
+ * else null) — re-implemented locally to keep join.ts literally
+ * untouched.
+ */
+function coerceKey(value: unknown): string | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'bigint') return String(value)
+  return null
+}
+
+/** One-shot warn dedup for broadcast misses, keyed by `field→as`. */
+const warnedBroadcastKeys = new Set<string>()
+function warnOnceBroadcastMiss(field: string, as: string, key: string): void {
+  const dedup = `${field}→${as}:${key}`
+  if (warnedBroadcastKeys.has(dedup)) return
+  warnedBroadcastKeys.add(dedup)
+  console.warn(
+    `[noy-db] broadcastJoin: no "${as}" dimension row for ${field}="${key}". ` +
+      `Attaching null. Use mode: 'cascade' to silence.`,
+  )
+}
+
+/** Test-only reset for the broadcast warn dedup set. */
+export function resetBroadcastWarnings(): void {
+  warnedBroadcastKeys.clear()
+}
+
+/**
+ * Apply every broadcast leg to a merged row set, centrally. Each leg's
+ * source is snapshotted ONCE, indexed by its `on` key, then every row
+ * gets `{ [as]: match ?? null }`. Returns fresh top-level objects.
+ */
+export async function applyBroadcastLegs(
+  rows: readonly unknown[],
+  legs: readonly BroadcastLeg[],
+): Promise<unknown[]> {
+  if (legs.length === 0) return [...rows]
+
+  // Build one index per leg (snapshot once).
+  const indexes: { leg: BroadcastLeg; map: Map<string, unknown> }[] = []
+  for (const leg of legs) {
+    if (leg.from.list) await leg.from.list()
+    const map = new Map<string, unknown>()
+    for (const rec of leg.from.snapshot()) {
+      const k = coerceKey(readPath(rec, leg.on))
+      if (k !== null && !map.has(k)) map.set(k, rec)
+    }
+    indexes.push({ leg, map })
+  }
+
+  return rows.map((row) => {
+    const out = { ...(row as Record<string, unknown>) }
+    for (const { leg, map } of indexes) {
+      const key = coerceKey(readPath(row, leg.field))
+      const match = key === null ? null : map.get(key) ?? null
+      if (match === null && leg.mode === 'warn') {
+        warnOnceBroadcastMiss(leg.field, leg.as, key ?? '<null>')
+      }
+      out[leg.as] = match
+    }
+    return out
+  })
+}
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/federation-cross-shard-join.test.ts`
+Expected: PASS (Task 1 + Task 2 tests; 7 total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/federation/cross-shard-join.ts packages/hub/__tests__/federation-cross-shard-join.test.ts
+git commit -m "feat(hub): applyBroadcastLegs — central broadcast dimension executor"
+```
+
+---
+
+## Task 3: `crossShardJoin()` builder + co-partitioned fan-out
+
+Wire the co-partitioned leg into `ShardedQuery` and thread it through `fanoutRecords`.
+
+**Files:**
+- Modify: `packages/hub/src/federation/vault-group.ts`
+- Test: `packages/hub/__tests__/federation-cross-shard-join.test.ts`
+
+- [ ] **Step 1: Add the shared harness to the test file**
+
+At the TOP of the test file (after the existing imports), add the in-memory adapter + harness copied from `packages/hub/__tests__/federation-query-aggregate.test.ts`. Add these imports and helpers:
+
+```ts
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+import { createNoydb } from '../src/noydb.js'
+import type { Vault } from '../src/vault.js'
+import type { VaultRegistryRow } from '../src/federation/index.js'
+import { ref } from '../src/refs.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+interface Invoice { id: string; clientId: string; customerId: string; amount: number; status: string; currencyCode?: string }
+interface Customer { id: string; name: string }
+
+/** Operator db + a client template that registers customers + invoices(ref customers). */
+async function harness() {
+  const adapter = memory()
+  const db = await createNoydb({ store: adapter, user: 'operator', secret: 'op-pass' })
+  db.withVaultTemplate('client-template', {
+    version: 1,
+    configure(vault: Vault) {
+      vault.collection<Customer>('customers')
+      vault.collection<Invoice>('invoices', { refs: { customerId: ref('customers') } })
+    },
+  })
+  const stateVault = await db.openVault('state')
+  const registry = stateVault.collection<VaultRegistryRow>('vault-registry')
+  const firm = await db.openVaultGroup<Invoice>('firm-clients', {
+    registry,
+    sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template' },
+  })
+  return { adapter, db, registry, firm }
+}
+```
+
+- [ ] **Step 2: Write the failing co-partitioned test**
+
+Append:
+
+```ts
+describe('crossShardJoin (co-partitioned)', () => {
+  it('joins each shard against its same-vault right collection and unions', async () => {
+    const { firm } = await harness()
+    // Two shards (acme, globex). Each has its own customers + invoices.
+    const acme = await firm.shard('acme')
+    await acme.collection<Customer>('customers').put('c-acme', { id: 'c-acme', name: 'Acme Co' })
+    await firm.collection('invoices').put('i1', { id: 'i1', clientId: 'acme', customerId: 'c-acme', amount: 100, status: 'overdue' })
+    const globex = await firm.shard('globex')
+    await globex.collection<Customer>('customers').put('c-glx', { id: 'c-glx', name: 'Globex' })
+    await firm.collection('invoices').put('i2', { id: 'i2', clientId: 'globex', customerId: 'c-glx', amount: 200, status: 'overdue' })
+
+    const res = await firm.collection('invoices').query()
+      .where('status', '==', 'overdue')
+      .crossShardJoin('customerId', { as: 'customer' })
+      .toArray()
+
+    expect(res.skippedVaults).toEqual([])
+    const byId = Object.fromEntries(res.results.map((r) => [(r as Invoice).id, r])) as Record<string, Record<string, unknown>>
+    expect((byId['i1'].customer as Customer).name).toBe('Acme Co')
+    expect((byId['i2'].customer as Customer).name).toBe('Globex')
+  })
+})
+```
+
+Note: confirm `firm.shard(key)` is the drill-down accessor (it is — `VaultGroup.shard`). If a shard must exist before `firm.shard()`, write the invoice first (auto-creates the shard) then open it to add customers; reorder the puts if needed.
+
+- [ ] **Step 3: Run it to confirm it fails**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/federation-cross-shard-join.test.ts -t 'co-partitioned'`
+Expected: FAIL — `crossShardJoin` is not a function on `ShardedQuery`.
+
+- [ ] **Step 4: Implement the co-partitioned leg in `vault-group.ts`**
+
+In `packages/hub/src/federation/vault-group.ts`:
+
+(a) Add imports near the other federation imports:
+
+```ts
+import { applyBroadcastLegs } from './cross-shard-join.js'
+import type { CoPartitionedLeg, BroadcastLeg, CrossShardJoinOptions, BroadcastJoinOptions } from './cross-shard-join.js'
+import { CrossShardJoinError } from '../errors.js'
+```
+
+(Add `CrossShardJoinError` to the existing `from '../errors.js'` import line instead of a second import if cleaner.)
+
+(b) Change `ShardedQuery`'s constructor to carry the two leg arrays. Replace the current constructor + the `where()` method:
+
+```ts
+export class ShardedQuery<T, R = T> {
+  constructor(
+    private readonly group: VaultGroup<T>,
+    private readonly collectionName: string,
+    private readonly clauses: readonly WhereClause[],
+    private readonly coPartitionedLegs: readonly CoPartitionedLeg[] = [],
+    private readonly broadcastLegs: readonly BroadcastLeg[] = [],
+  ) {}
+
+  where(field: string, op: WhereClause['op'], value: unknown): ShardedQuery<T, R> {
+    return new ShardedQuery<T, R>(
+      this.group, this.collectionName,
+      [...this.clauses, { field, op, value }],
+      this.coPartitionedLegs, this.broadcastLegs,
+    )
+  }
+
+  /** Co-partitioned join: each shard joins its own same-vault right collection (resolved via ref()), then union. */
+  crossShardJoin(field: string, opts: CrossShardJoinOptions): ShardedQuery<T, R> {
+    const leg: CoPartitionedLeg = { field, as: opts.as, maxRows: opts.maxRows, strategy: opts.strategy }
+    return new ShardedQuery<T, R>(
+      this.group, this.collectionName, this.clauses,
+      [...this.coPartitionedLegs, leg], this.broadcastLegs,
+    )
+  }
+```
+
+(c) In `fanoutRecords`, replace the per-shard closure body so it hydrates each join target and threads the legs. Current closure ends with `return q.toArray()`; replace the closure with:
+
+```ts
+      async (vault) => {
+        this.group.template.configure(vault)
+        const coll = vault.collection<R>(this.collectionName)
+        await coll.list() // hydrate the left side
+        // Hydrate each co-partitioned join target — resolveSource reads
+        // the in-memory cache, so an unopened right collection would join
+        // to an empty snapshot (every row → null).
+        for (const leg of this.coPartitionedLegs) {
+          const desc = vault.resolveRef(this.collectionName, leg.field)
+          if (desc) await vault.collection(desc.target).list()
+        }
+        let q = coll.query()
+        for (const c of this.clauses) q = q.where(c.field, c.op, c.value)
+        for (const leg of this.coPartitionedLegs) {
+          q = q.join(leg.field, {
+            as: leg.as,
+            ...(leg.maxRows !== undefined ? { maxRows: leg.maxRows } : {}),
+            ...(leg.strategy ? { strategy: leg.strategy } : {}),
+          })
+        }
+        return q.toArray() as R[]
+      },
+```
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/federation-cross-shard-join.test.ts -t 'co-partitioned'`
+Expected: PASS. If `firm.shard('acme')` throws "unknown shard" before the invoice write, reorder so the invoice (auto-create) lands first, then `firm.shard('acme')` to add the customer, then re-query.
+
+- [ ] **Step 6: Run the full file + typecheck**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/federation-cross-shard-join.test.ts && pnpm tsc --noEmit`
+Expected: PASS, no type errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/hub/src/federation/vault-group.ts packages/hub/__tests__/federation-cross-shard-join.test.ts
+git commit -m "feat(hub): crossShardJoin — co-partitioned per-shard join + union"
+```
+
+---
+
+## Task 4: `broadcastJoin()` builder + `toArray` applies broadcast legs
+
+**Files:**
+- Modify: `packages/hub/src/federation/vault-group.ts`
+- Test: `packages/hub/__tests__/federation-cross-shard-join.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append:
+
+```ts
+import { resetBroadcastWarnings } from '../src/federation/cross-shard-join.js'
+
+describe('broadcastJoin (dimension)', () => {
+  it('enriches every merged row from a single shared dimension collection', async () => {
+    resetBroadcastWarnings()
+    const { db, firm } = await harness()
+    // Shared dimension vault, separate from any shard.
+    const dims = await db.openVault('dimensions')
+    const currencies = dims.collection<{ id: string; symbol: string }>('currencies')
+    await currencies.put('usd', { id: 'usd', symbol: '$' })
+    await currencies.put('eur', { id: 'eur', symbol: '€' })
+
+    await firm.collection('invoices').put('i1', { id: 'i1', clientId: 'acme', customerId: 'c1', amount: 100, status: 'paid', currencyCode: 'usd' })
+    await firm.collection('invoices').put('i2', { id: 'i2', clientId: 'globex', customerId: 'c2', amount: 200, status: 'paid', currencyCode: 'eur' })
+
+    const res = await firm.collection('invoices').query()
+      .broadcastJoin('currencyCode', { as: 'fx', from: currencies })
+      .toArray()
+
+    const byId = Object.fromEntries(res.results.map((r) => [(r as Invoice).id, r])) as Record<string, Record<string, unknown>>
+    expect((byId['i1'].fx as { symbol: string }).symbol).toBe('$')
+    expect((byId['i2'].fx as { symbol: string }).symbol).toBe('€')
+  })
+
+  it('combines a co-partitioned join and a broadcast join', async () => {
+    resetBroadcastWarnings()
+    const { db, firm } = await harness()
+    const dims = await db.openVault('dimensions')
+    const currencies = dims.collection<{ id: string; symbol: string }>('currencies')
+    await currencies.put('usd', { id: 'usd', symbol: '$' })
+
+    await firm.collection('invoices').put('i1', { id: 'i1', clientId: 'acme', customerId: 'c-acme', amount: 100, status: 'overdue', currencyCode: 'usd' })
+    const acme = await firm.shard('acme')
+    await acme.collection<Customer>('customers').put('c-acme', { id: 'c-acme', name: 'Acme Co' })
+
+    const res = await firm.collection('invoices').query()
+      .crossShardJoin('customerId', { as: 'customer' })
+      .broadcastJoin('currencyCode', { as: 'fx', from: currencies })
+      .toArray()
+
+    const row = res.results[0] as Record<string, unknown>
+    expect((row.customer as Customer).name).toBe('Acme Co')
+    expect((row.fx as { symbol: string }).symbol).toBe('$')
+  })
+})
+```
+
+- [ ] **Step 2: Run it to confirm it fails**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/federation-cross-shard-join.test.ts -t 'broadcastJoin'`
+Expected: FAIL — `broadcastJoin` is not a function.
+
+- [ ] **Step 3: Implement `broadcastJoin()` + `toArray` change in `vault-group.ts`**
+
+Add the builder method to `ShardedQuery` (after `crossShardJoin`):
+
+```ts
+  /** Broadcast dimension join: enrich every merged row from a single shared collection. */
+  broadcastJoin(field: string, opts: BroadcastJoinOptions): ShardedQuery<T, R> {
+    const leg: BroadcastLeg = {
+      field,
+      as: opts.as,
+      from: opts.from,
+      on: opts.on ?? 'id',
+      mode: opts.mode ?? 'warn',
+    }
+    return new ShardedQuery<T, R>(
+      this.group, this.collectionName, this.clauses,
+      this.coPartitionedLegs, [...this.broadcastLegs, leg],
+    )
+  }
+```
+
+Change `toArray` to apply broadcast legs after the fan-out merge:
+
+```ts
+  async toArray(options: FanoutQueryOptions = {}): Promise<FanoutResult<R>> {
+    const { records, skippedVaults } = await this.fanoutRecords(options)
+    const results = (await applyBroadcastLegs(records, this.broadcastLegs)) as R[]
+    return { results, skippedVaults }
+  }
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/federation-cross-shard-join.test.ts`
+Expected: PASS (all tests so far).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/federation/vault-group.ts packages/hub/__tests__/federation-cross-shard-join.test.ts
+git commit -m "feat(hub): broadcastJoin — central dimension enrichment on ShardedQuery"
+```
+
+---
+
+## Task 5: Failure semantics
+
+Undeclared ref → single `CrossShardJoinError`; dangling ref → per-shard `RefMode` (strict skips the shard, warn attaches null); broadcast miss → null + one-shot warn.
+
+**Files:**
+- Modify: `packages/hub/src/federation/vault-group.ts`
+- Test: `packages/hub/__tests__/federation-cross-shard-join.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append:
+
+```ts
+describe('crossShardJoin failure semantics', () => {
+  it('throws a single CrossShardJoinError when the join field has no ref()', async () => {
+    const { firm } = await harness()
+    await firm.collection('invoices').put('i1', { id: 'i1', clientId: 'acme', customerId: 'c1', amount: 1, status: 'open' })
+    await expect(
+      firm.collection('invoices').query().crossShardJoin('amount', { as: 'x' }).toArray(),
+    ).rejects.toBeInstanceOf(CrossShardJoinError)
+  })
+
+  it('attaches null for a dangling ref in warn mode (per-shard RefMode)', async () => {
+    // warn-mode template: ref('customers', 'warn')
+    const adapter = memory()
+    const db = await createNoydb({ store: adapter, user: 'operator', secret: 'op-pass' })
+    db.withVaultTemplate('warn-template', {
+      version: 1,
+      configure(vault: Vault) {
+        vault.collection<Customer>('customers')
+        vault.collection<Invoice>('invoices', { refs: { customerId: ref('customers', 'warn') } })
+      },
+    })
+    const sv = await db.openVault('state')
+    const registry = sv.collection<VaultRegistryRow>('vault-registry')
+    const firm = await db.openVaultGroup<Invoice>('warn-firm', {
+      registry,
+      sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'warn-template' },
+    })
+    await firm.collection('invoices').put('i1', { id: 'i1', clientId: 'acme', customerId: 'ghost', amount: 1, status: 'open' })
+
+    const res = await firm.collection('invoices').query()
+      .crossShardJoin('customerId', { as: 'customer' })
+      .toArray()
+    expect(res.results).toHaveLength(1)
+    expect((res.results[0] as Record<string, unknown>).customer).toBeNull()
+  })
+})
+
+describe('broadcastJoin miss', () => {
+  it('attaches null on a miss without throwing', async () => {
+    resetBroadcastWarnings()
+    const { db, firm } = await harness()
+    const dims = await db.openVault('dimensions')
+    const currencies = dims.collection<{ id: string }>('currencies')
+    await currencies.put('usd', { id: 'usd' })
+    await firm.collection('invoices').put('i1', { id: 'i1', clientId: 'acme', customerId: 'c1', amount: 1, status: 'paid', currencyCode: 'gbp' })
+
+    const res = await firm.collection('invoices').query()
+      .broadcastJoin('currencyCode', { as: 'fx', from: currencies, mode: 'cascade' })
+      .toArray()
+    expect((res.results[0] as Record<string, unknown>).fx).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run them to confirm they fail**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/federation-cross-shard-join.test.ts -t 'failure semantics'`
+Expected: FAIL on the undeclared-ref test — without the guard, the per-shard `.join()` throws a generic `Error` swallowed into `skippedVaults`, so `.toArray()` resolves instead of rejecting. (The warn-mode and broadcast-miss tests may already pass — that's fine; they lock the behavior.)
+
+- [ ] **Step 3: Implement the undeclared-ref pre-check**
+
+In `fanoutRecords` (or a small private helper called at the top of `fanoutRecords`), before the `queryAcross` fan-out, validate each co-partitioned leg against the template once. The template's ref registry isn't directly inspectable without a vault, so resolve against the FIRST eligible shard's vault and treat a missing ref as a deterministic error:
+
+Add, right after `const { eligible, skipped } = await this.group.resolveEligible(options)` and before the `queryAcross` call:
+
+```ts
+    // Deterministic pre-check: an undeclared join ref fails identically
+    // on every shard, so surface it as ONE CrossShardJoinError rather
+    // than N identical skips. Validate against the first eligible shard.
+    if (this.coPartitionedLegs.length > 0 && eligible.length > 0) {
+      // resolveEligible returns VaultRegistryRow[]; each row carries
+      // `partitionKey` directly (see vault-group.ts:195). Open the first
+      // eligible shard as the probe.
+      const probe = await this.group.openShard(eligible[0].partitionKey)
+      this.group.template.configure(probe)
+      for (const leg of this.coPartitionedLegs) {
+        if (!probe.resolveRef(this.collectionName, leg.field)) {
+          throw new CrossShardJoinError(
+            `crossShardJoin("${leg.field}"): no ref() declared for "${leg.field}" on ` +
+              `collection "${this.collectionName}" in template "${this.group.sharding.vaultTemplate}". ` +
+              `Add refs: { ${leg.field}: ref('<target>') } to the template's collection options.`,
+          )
+        }
+      }
+    }
+```
+
+`VaultRegistryRow.partitionKey` and `VaultGroup.openShard(partitionKey)` are both confirmed to exist. `this.group.sharding.vaultTemplate` is the template name (used only in the error string). No `SHARD_SEPARATOR` split needed.
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/federation-cross-shard-join.test.ts`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/federation/vault-group.ts packages/hub/__tests__/federation-cross-shard-join.test.ts
+git commit -m "feat(hub): crossShardJoin failure semantics — undeclared-ref pre-check"
+```
+
+---
+
+## Task 6: Deferred-surface guards (`live` / `aggregate` / `groupBy` throw with legs)
+
+**Files:**
+- Modify: `packages/hub/src/federation/vault-group.ts`
+- Test: `packages/hub/__tests__/federation-cross-shard-join.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append:
+
+```ts
+describe('deferred surfaces throw when join legs are present', () => {
+  it('live() throws CrossShardJoinError with a co-partitioned leg', async () => {
+    const { firm } = await harness()
+    expect(() =>
+      firm.collection('invoices').query().crossShardJoin('customerId', { as: 'c' }).live(),
+    ).toThrow(CrossShardJoinError)
+  })
+
+  it('aggregate() throws CrossShardJoinError with a broadcast leg', async () => {
+    const { db, firm } = await harness()
+    const dims = await db.openVault('dimensions')
+    const cur = dims.collection<{ id: string }>('currencies')
+    expect(() =>
+      firm.collection('invoices').query().broadcastJoin('currencyCode', { as: 'fx', from: cur }).aggregate({ total: 'count' } as never),
+    ).toThrow(CrossShardJoinError)
+  })
+
+  it('groupBy() throws CrossShardJoinError with a join leg', async () => {
+    const { firm } = await harness()
+    expect(() =>
+      firm.collection('invoices').query().crossShardJoin('customerId', { as: 'c' }).groupBy('status'),
+    ).toThrow(CrossShardJoinError)
+  })
+})
+```
+
+- [ ] **Step 2: Run them to confirm they fail**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/federation-cross-shard-join.test.ts -t 'deferred surfaces'`
+Expected: FAIL — these methods currently ignore the legs.
+
+- [ ] **Step 3: Add the guards**
+
+Add a private helper to `ShardedQuery` and call it at the top of `live`, `aggregate`, and `groupBy`:
+
+```ts
+  /** @internal — joined queries don't support reactive/aggregate surfaces in v1. */
+  private assertNoJoinLegs(surface: string): void {
+    if (this.coPartitionedLegs.length || this.broadcastLegs.length) {
+      throw new CrossShardJoinError(
+        `${surface}() is not supported on a ShardedQuery with crossShardJoin/broadcastJoin ` +
+          `legs in v1. Use toArray() for joined cross-shard queries.`,
+      )
+    }
+  }
+```
+
+Then, as the FIRST line inside each method:
+- `live(options = {}) { this.assertNoJoinLegs('live'); /* ...existing... */ }`
+- `aggregate(spec) { this.assertNoJoinLegs('aggregate'); /* ...existing... */ }`
+- `groupBy(field) { this.assertNoJoinLegs('groupBy'); /* ...existing... */ }`
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+Run: `cd packages/hub && pnpm vitest run __tests__/federation-cross-shard-join.test.ts`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/federation/vault-group.ts packages/hub/__tests__/federation-cross-shard-join.test.ts
+git commit -m "feat(hub): guard live/aggregate/groupBy against join legs in v1"
+```
+
+---
+
+## Task 7: Exports, features.yaml, and full verification
+
+**Files:**
+- Modify: `packages/hub/src/federation/index.ts`
+- Modify: `features.yaml`
+
+- [ ] **Step 1: Re-export the public option types**
+
+In `packages/hub/src/federation/index.ts`, add to the existing `export type { ... } from './types.js'` block a NEW export line for the cross-shard-join module:
+
+```ts
+export { resetBroadcastWarnings } from './cross-shard-join.js'
+export type {
+  CrossShardJoinOptions,
+  BroadcastJoinOptions,
+  BroadcastSource,
+} from './cross-shard-join.js'
+```
+
+- [ ] **Step 2: Verify the types are reachable from the package entry**
+
+Run: `cd packages/hub && pnpm tsc --noEmit`
+Expected: PASS, no errors.
+
+- [ ] **Step 3: Update the features.yaml invariant**
+
+In `features.yaml`, under the `vault-group-federation` feature's `invariants:` list, replace:
+
+```yaml
+      - 'join.ts partitionScope seam is untouched (crossShardJoin deferred)'
+```
+
+with:
+
+```yaml
+      - 'crossShardJoin is co-partitioned fan-out + central broadcast enrichment; join.ts and its partitionScope seam stay untouched'
+```
+
+- [ ] **Step 4: Validate features.yaml**
+
+Run (from repo root): `pnpm validate:features` (alias for `node scripts/validate-features.mjs`).
+Expected: PASS — no dangling-ref / schema failure. This is the same job CI's "Spec coverage" runs.
+
+- [ ] **Step 5: Run the FULL gate — tests + lint + architecture**
+
+Run from repo root:
+
+```bash
+cd packages/hub && pnpm vitest run __tests__/federation-cross-shard-join.test.ts && pnpm vitest run __tests__/federation-vault-group.test.ts __tests__/federation-query-aggregate.test.ts && cd ../.. && pnpm lint && node scripts/check-architecture.mjs
+```
+
+Expected: ALL pass. The architecture check must report OK (federation code is under no ceiling, but run it anyway — the previous cycle went red because lint/architecture were skipped). Fix any lint error (no inline `import()` type annotations; no unused imports) before committing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/federation/index.ts features.yaml
+git commit -m "feat(hub): export crossShardJoin option types + features.yaml invariant"
+```
+
+- [ ] **Step 7: Finish the branch**
+
+Use **superpowers:finishing-a-development-branch** to verify the full hub test suite, then push and open a PR titled `feat(hub): crossShardJoin — co-partitioned + broadcast dimension join (#271)`. The PR body should note: closes one milestone-16 primitive; `join.ts` untouched; `.live()`/`.aggregate()` deferred for joined queries. Do NOT add Claude attribution. Do NOT publish a release.
+
+---
+
+## Self-Review Notes (for the implementer)
+
+- **Type widening:** `toArray` keeps returning `FanoutResult<R>` for simplicity (the `as`-keyed fields are present at runtime; consumers cast per-leg, exactly as the intra-vault `.join()` test does with `as JoinedRow`). Do not over-engineer the generic widening — the spec accepts the cast pattern.
+- **`firm.shard(key)` vs auto-create:** writing through `firm.collection('invoices').put(...)` auto-creates the shard; `firm.shard(key)` opens an existing one. In tests that need to seed the right-side collection, write one invoice first (auto-create) OR call `firm.createShard(key)` before `firm.shard(key)`. Verify against `VaultGroup`'s actual method names (`shard` / `openShard` / `createShard`) before finalizing.
+- **The Task 5 probe line** (recovering a partition key from a vault id) is the one spot needing verification against `resolveEligible`'s real return shape — check whether eligible rows carry the partition key directly before splitting on `SHARD_SEPARATOR`.

--- a/docs/superpowers/specs/2026-06-09-cross-shard-join-design.md
+++ b/docs/superpowers/specs/2026-06-09-cross-shard-join-design.md
@@ -39,14 +39,13 @@ A consequence worth stating: because all code lives in `federation/` (already a 
 ```ts
 .crossShardJoin(field: string, opts: {
   as: string                 // alias key under which the joined record attaches
-  mode?: RefMode             // dangling-ref behavior; defaults to the ref()'s declared mode
   maxRows?: number           // per-shard row ceiling override (default DEFAULT_JOIN_MAX_ROWS)
   strategy?: JoinStrategy     // 'hash' | 'nested' planner override (passthrough)
 }): ShardedQuery<T, R>
 ```
 
 - `field` MUST be a `ref()`-declared field on the left collection in the shared template schema. If not declared, the per-shard `.join()` throws its existing actionable error; we surface that as the shard's skip reason (see Failure semantics) — except for a declaration error, which is deterministic across all shards and is therefore re-raised as a single `CrossShardJoinError` rather than N identical skips (see below).
-- Right collection name is resolved from the `ref()` descriptor — never passed explicitly (it lives in the same shard).
+- Right collection name and the dangling-ref `RefMode` are both resolved from the `ref()` descriptor — never passed explicitly. `Query.join()`'s option bag is `{ as, strategy?, maxRows? }` (no `mode` override), so `crossShardJoin` deliberately omits `mode` too; the declared ref mode governs dangling refs per shard. This keeps the intra-vault executor unchanged.
 - Returns a new `ShardedQuery` carrying an appended co-partitioned leg (immutable builder, like `.where()`).
 
 ### Broadcast dimension join
@@ -84,12 +83,19 @@ async (vault) => {
   this.group.template.configure(vault)
   const coll = vault.collection<R>(this.collectionName)
   await coll.list()
+  // Hydrate each co-partitioned join target — resolveSource reads the
+  // in-memory cache, so an unopened right collection would join to an
+  // empty snapshot (every row → null). This is the one subtlety vs the
+  // intra-vault path, where the caller has usually already opened both.
+  for (const leg of this.coPartitionedLegs) {
+    const desc = vault.resolveRef(this.collectionName, leg.field)
+    if (desc) await vault.collection(desc.target).list()
+  }
   let q = coll.query()
   for (const c of this.clauses) q = q.where(c.field, c.op, c.value)
   for (const leg of this.coPartitionedLegs) {
     q = q.join(leg.field, {
       as: leg.as,
-      ...(leg.mode ? { mode: leg.mode } : {}),
       ...(leg.maxRows !== undefined ? { maxRows: leg.maxRows } : {}),
       ...(leg.strategy ? { strategy: leg.strategy } : {}),
     })
@@ -98,7 +104,7 @@ async (vault) => {
 }
 ```
 
-Order matters and is already correct: the existing executor applies `where` → `orderBy` → `limit` → joins. We add `where` then `join`, matching that order.
+Order matters and is already correct: the existing executor applies `where` → `orderBy` → `limit` → joins. We add `where` then `join`, matching that order. The right-side hydration (`vault.resolveRef` → `vault.collection(target).list()`) must run *before* the join, since `Vault.resolveSource` reads the in-memory cache only.
 
 `toArray()` (existing) changes by applying broadcast legs centrally **after** the fan-out union:
 
@@ -112,7 +118,7 @@ async toArray(options = {}): Promise<FanoutResult<Enriched>> {
 
 `applyBroadcastLegs(rows, legs)` (new, in `cross-shard-join.ts`):
 
-- For each leg: `await leg.from.list?.()` (hydrate if hydratable), `const snap = leg.from.snapshot()`, build `Map<string, unknown>` keyed by `readPath(record, leg.on ?? 'id')` coerced via the same `coerceRefKey` narrowing `join.ts` uses (string/number → string; else skip).
+- For each leg: `await leg.from.list?.()` (hydrate if hydratable), `const snap = leg.from.snapshot()`, build `Map<string, unknown>` keyed by `readPath(record, leg.on ?? 'id')` coerced via a local `coerceKey` helper. `coerceKey` mirrors `join.ts`'s private `coerceRefKey` (string → string; number/bigint → `String(v)`; else `null`) — re-implemented locally rather than exported from `join.ts`, to keep `join.ts` literally untouched. `readPath` IS imported from `query/predicate.js` (already exported).
 - For each row: `key = coerceRefKey(readPath(row, leg.field))`; `match = key === null ? null : (map.get(key) ?? null)`; attach `{ ...row, [leg.as]: match }`. On `null` match with `mode: 'warn'` (default), emit a one-shot warning keyed by `field→as` (dedup `Set`, mirroring `warnOnceDangling`).
 - Builds each leg's map once; broadcasts to all rows. Loads the `from` snapshot exactly once per `toArray()`.
 
@@ -159,8 +165,8 @@ New `CrossShardJoinError extends NoydbError` in `packages/hub/src/errors.ts`, tw
 | `packages/hub/src/federation/vault-group.ts` | `ShardedQuery` gains `coPartitionedLegs` / `broadcastLegs` fields + constructor params, `crossShardJoin()` / `broadcastJoin()` methods; `fanoutRecords` threads co-partitioned legs into the closure; `toArray` applies broadcast legs; `live` / `aggregate` / `groupBy` guards. |
 | `packages/hub/src/errors.ts` | New `CrossShardJoinError`. |
 | `packages/hub/src/federation/index.ts` | Export the public option types (`CrossShardJoinOptions`, `BroadcastJoinOptions`, `BroadcastSource`) — they appear in the `ShardedQuery` method signatures, so they are public surface. |
-| `packages/hub/__tests__/federation/cross-shard-join.test.ts` | **New.** Behavior + failure-mode coverage. |
-| `features.yaml` | Add `cross-shard-join` entry under the federation feature; showcase optional. |
+| `packages/hub/__tests__/federation-cross-shard-join.test.ts` | **New.** Behavior + failure-mode coverage. |
+| `features.yaml` | The `vault-group-federation` feature already exists. **Update** its invariants: replace the line `'join.ts partitionScope seam is untouched (crossShardJoin deferred)'` with one stating crossShardJoin shipped *and still leaves join.ts untouched*. No new feature entry; showcase optional (the feature already carries showcases 98–100). |
 
 `join.ts` is **not** in this table — intentionally.
 

--- a/docs/superpowers/specs/2026-06-09-cross-shard-join-design.md
+++ b/docs/superpowers/specs/2026-06-09-cross-shard-join-design.md
@@ -1,0 +1,180 @@
+# crossShardJoin — co-partitioned + broadcast dimension join
+
+**Status:** Design approved 2026-06-09
+**Epic:** #271 multi-vault partition federation (milestone 16)
+**Scope:** One of the remaining federation primitives. Self-contained "quick win" — no crypto design, no `join.ts` changes.
+
+## Goal
+
+Give `ShardedQuery` two correlation primitives so a `VaultGroup` fan-out can attach related records to its rows:
+
+1. **`crossShardJoin(field, opts)`** — *co-partitioned* join: each shard joins its left collection against the **same shard's** right collection (resolved via a declared `ref()`), then results union. Reuses the existing intra-vault `.join()` executor per shard.
+2. **`broadcastJoin(field, opts)`** — *broadcast dimension* join: every merged row is enriched from a **single shared collection** (a dimension/reference table living in one vault), loaded once and attached centrally.
+
+Both are programmatic-only (never surface in the `in-sql` grammar) and return the existing `FanoutResult<R>` shape `{ results, skippedVaults }`.
+
+## Non-goals
+
+- **Arbitrary cross-partition correlation** (shard A left ⋈ shard B right). Excluded by the `join.ts` architectural invariant: "cross-vault correlation goes through `queryAcross`; this is an architectural invariant, not a limitation we plan to lift." Co-partitioned join does not breach it — every join *is* intra-vault; only the fan-out is cross-shard. Broadcast does not breach it either — it bypasses the join executor entirely (central map-attach, not correlation through the planner).
+- **Reactive joined queries.** `.live()` on a joined `ShardedQuery` is deferred (cross-shard right-side change propagation is out of scope). It throws in v1.
+- **Aggregation over joined rows.** `.aggregate()` / `.groupBy()` on a joined `ShardedQuery` is deferred. It throws in v1.
+- **SQL surface.** The `in-sql` `JOIN` keyword stays same-vault. No grammar change.
+- **`join.ts` changes.** None. See "Why `join.ts` is untouched" below.
+
+## Why `join.ts` is untouched (and the `partitionScope` seam is not used)
+
+The epic prose said crossShardJoin "extends `JoinLeg.partitionScope`." That was a pre-`VaultGroup` guess at the mechanism, written when the seam was reserved for *shard-pruning a join from a `where()` on the partition key*. The federation work that landed afterward (#292/#319) moved shard selection into `VaultGroup.resolveEligible` at the fan-out layer. The `partitionScope` field is therefore **vestigial relative to the shipped federation design** — populating it cosmetically would add an unread field-write for documentation's sake. We do not touch it.
+
+The deliverable is `crossShardJoin` (the API). It is delivered entirely from `federation/`:
+
+- Co-partitioned join calls the *existing, unchanged* intra-vault `.join()` inside each shard's closure. Same `JoinLeg`, same `applyJoins`, same DEK.
+- Broadcast is a separate central enrichment, not a join-planner construct.
+
+A consequence worth stating: because all code lives in `federation/` (already a lazy import chunk), it sits under **no** kernel-surface line ceiling (`collection.ts` / `vault.ts` / `noydb.ts`) and trips **no** architecture invariant.
+
+## API
+
+### Co-partitioned join
+
+```ts
+.crossShardJoin(field: string, opts: {
+  as: string                 // alias key under which the joined record attaches
+  mode?: RefMode             // dangling-ref behavior; defaults to the ref()'s declared mode
+  maxRows?: number           // per-shard row ceiling override (default DEFAULT_JOIN_MAX_ROWS)
+  strategy?: JoinStrategy     // 'hash' | 'nested' planner override (passthrough)
+}): ShardedQuery<T, R>
+```
+
+- `field` MUST be a `ref()`-declared field on the left collection in the shared template schema. If not declared, the per-shard `.join()` throws its existing actionable error; we surface that as the shard's skip reason (see Failure semantics) — except for a declaration error, which is deterministic across all shards and is therefore re-raised as a single `CrossShardJoinError` rather than N identical skips (see below).
+- Right collection name is resolved from the `ref()` descriptor — never passed explicitly (it lives in the same shard).
+- Returns a new `ShardedQuery` carrying an appended co-partitioned leg (immutable builder, like `.where()`).
+
+### Broadcast dimension join
+
+```ts
+.broadcastJoin(field: string, opts: {
+  as: string                 // alias key under which the dimension record attaches
+  from: BroadcastSource      // an opened Collection (or structural snapshot source) in another vault
+  on?: string                // key on the right record to match field against; default 'id'
+  mode?: 'warn' | 'cascade'   // miss behavior; default 'warn' (attach null + one-shot warning)
+}): ShardedQuery<T, R>
+```
+
+- `from` is an explicit handle because a `ref()` cannot point cross-vault. The API asymmetry (declared ref vs explicit `from`/`on`) is deliberate — two mechanisms.
+- The caller holds `from`'s keyring by possessing the opened handle → "permission-checked" by construction. No new ACL layer.
+- `BroadcastSource` is the minimal structural shape `{ snapshot(): readonly unknown[]; list?(): Promise<unknown> }` — `snapshot()` is required, `list()` optional. A `Collection` satisfies it structurally; the executor calls `await from.list()` first when present to hydrate the in-memory cache, then reads `from.snapshot()`.
+- Multiple independent `broadcastJoin` legs may be stacked (each enriches a different `as`). No join *on* a broadcast's output (no chaining a co-partitioned join against a broadcast alias).
+
+### Result
+
+```ts
+.toArray(options?: FanoutQueryOptions): Promise<FanoutResult<Enriched>>
+//   Enriched = R & { [as]: <joined record> | null }   (one widening per leg)
+//   FanoutResult = { results: Enriched[], skippedVaults: SkippedVault[] }
+```
+
+## Execution model
+
+`ShardedQuery` gains two private leg arrays: `coPartitionedLegs: CoPartitionedLeg[]` and `broadcastLegs: BroadcastLeg[]`. `crossShardJoin()` / `broadcastJoin()` return a new `ShardedQuery` with the leg appended (preserving `clauses` and the other leg array).
+
+`fanoutRecords(options)` (existing) changes in exactly one place — the per-shard closure:
+
+```ts
+async (vault) => {
+  this.group.template.configure(vault)
+  const coll = vault.collection<R>(this.collectionName)
+  await coll.list()
+  let q = coll.query()
+  for (const c of this.clauses) q = q.where(c.field, c.op, c.value)
+  for (const leg of this.coPartitionedLegs) {
+    q = q.join(leg.field, {
+      as: leg.as,
+      ...(leg.mode ? { mode: leg.mode } : {}),
+      ...(leg.maxRows !== undefined ? { maxRows: leg.maxRows } : {}),
+      ...(leg.strategy ? { strategy: leg.strategy } : {}),
+    })
+  }
+  return q.toArray()
+}
+```
+
+Order matters and is already correct: the existing executor applies `where` → `orderBy` → `limit` → joins. We add `where` then `join`, matching that order.
+
+`toArray()` (existing) changes by applying broadcast legs centrally **after** the fan-out union:
+
+```ts
+async toArray(options = {}): Promise<FanoutResult<Enriched>> {
+  const { records, skippedVaults } = await this.fanoutRecords(options)
+  const enriched = applyBroadcastLegs(records, this.broadcastLegs)  // new, in cross-shard-join.ts
+  return { results: enriched, skippedVaults }
+}
+```
+
+`applyBroadcastLegs(rows, legs)` (new, in `cross-shard-join.ts`):
+
+- For each leg: `await leg.from.list?.()` (hydrate if hydratable), `const snap = leg.from.snapshot()`, build `Map<string, unknown>` keyed by `readPath(record, leg.on ?? 'id')` coerced via the same `coerceRefKey` narrowing `join.ts` uses (string/number → string; else skip).
+- For each row: `key = coerceRefKey(readPath(row, leg.field))`; `match = key === null ? null : (map.get(key) ?? null)`; attach `{ ...row, [leg.as]: match }`. On `null` match with `mode: 'warn'` (default), emit a one-shot warning keyed by `field→as` (dedup `Set`, mirroring `warnOnceDangling`).
+- Builds each leg's map once; broadcasts to all rows. Loads the `from` snapshot exactly once per `toArray()`.
+
+## Failure semantics
+
+- **Shard throws during its join** → caught by the existing `fanoutRecords` loop and recorded as `skippedVault` with `reason: classifyShardSkip(error)`. Consistent with current fan-out behavior.
+- **Dangling ref within a shard** → the existing per-shard `RefMode`: `strict` → the shard's closure throws `DanglingReferenceError` → that shard becomes a `skippedVault`; `warn` / `cascade` → `null` attached for that row, shard succeeds.
+- **`ref()` not declared for `field`** → deterministic across all shards (shared schema). Rather than returning N identical "no ref declared" skips, detect this once up front: resolve the ref against the template schema before fan-out and throw `CrossShardJoinError` naming the field and collection. (If the template cannot be cheaply inspected, fall back to: if *every* eligible shard skips with the same ref-declaration reason, re-raise as `CrossShardJoinError`.)
+- **Broadcast miss** → `null` attached; `mode: 'warn'` (default) emits a one-shot warning; `mode: 'cascade'` is silent.
+- **Empty eligible set** (all shards drift-skipped) → `{ results: [], skippedVaults: [...] }`, broadcast legs applied to the empty set (no-op). No throw.
+
+## Guards on deferred surfaces
+
+`ShardedQuery.live()` and `ShardedQuery.aggregate()` / `.groupBy()` must throw when any leg array is non-empty:
+
+```ts
+live(options = {}): CrossVaultLiveQuery<R> {
+  if (this.coPartitionedLegs.length || this.broadcastLegs.length) {
+    throw new CrossShardJoinError(
+      'live() is not supported on a ShardedQuery with crossShardJoin/broadcastJoin legs in v1. ' +
+      'Use toArray() for joined cross-shard queries.',
+    )
+  }
+  /* ...existing... */
+}
+```
+
+Same guard at the top of `aggregate()` and `groupBy()`. This prevents silently dropping the join legs (the failure mode the design explicitly guards against).
+
+## Errors
+
+New `CrossShardJoinError extends NoydbError` in `packages/hub/src/errors.ts`, two-arg `super('CROSS_SHARD_JOIN', message)` (matching the existing error convention, e.g. `NumberingUncertaintyError`). Used for: undeclared-ref-across-all-shards, and the deferred-surface guards.
+
+## Zero-knowledge note
+
+- **Co-partitioned join**: right side is in the same shard, decrypted under the same DEK the caller already holds for that shard. No change to the per-shard ZK profile.
+- **Broadcast join**: the merged result set co-mingles plaintext from the sharded vaults *and* the dimension vault, in the caller's process. The caller already holds both keyrings (they passed the `from` handle). No ciphertext crosses a DEK boundary; no backend sees cross-vault plaintext. Document that the enriched result is plaintext from two authorized vaults — expected and caller-initiated.
+
+## Files
+
+| File | Change |
+|---|---|
+| `packages/hub/src/federation/cross-shard-join.ts` | **New.** `CoPartitionedLeg` / `BroadcastLeg` types, `BroadcastSource` interface, `applyBroadcastLegs(rows, legs)` executor, broadcast warn-dedup. |
+| `packages/hub/src/federation/vault-group.ts` | `ShardedQuery` gains `coPartitionedLegs` / `broadcastLegs` fields + constructor params, `crossShardJoin()` / `broadcastJoin()` methods; `fanoutRecords` threads co-partitioned legs into the closure; `toArray` applies broadcast legs; `live` / `aggregate` / `groupBy` guards. |
+| `packages/hub/src/errors.ts` | New `CrossShardJoinError`. |
+| `packages/hub/src/federation/index.ts` | Export the public option types (`CrossShardJoinOptions`, `BroadcastJoinOptions`, `BroadcastSource`) — they appear in the `ShardedQuery` method signatures, so they are public surface. |
+| `packages/hub/__tests__/federation/cross-shard-join.test.ts` | **New.** Behavior + failure-mode coverage. |
+| `features.yaml` | Add `cross-shard-join` entry under the federation feature; showcase optional. |
+
+`join.ts` is **not** in this table — intentionally.
+
+## Test plan (behaviors to cover)
+
+1. Co-partitioned join attaches each shard's same-vault right record; results union across shards.
+2. Co-partitioned join with a `where()` filter narrows the left set before joining (order correctness).
+3. Per-shard `maxRows` ceiling: a shard exceeding it is skipped (not the whole query).
+4. Dangling ref `strict` → shard skipped with reason; `warn`/`cascade` → `null` attached.
+5. Undeclared ref field → single `CrossShardJoinError`, not N skips.
+6. Broadcast join attaches the dimension record by `on` key; default `on: 'id'`.
+7. Broadcast miss → `null` + one-shot warn (`warn`); silent (`cascade`).
+8. Broadcast snapshot loaded exactly once regardless of row count (spy on `from.snapshot`).
+9. Stacked legs: one co-partitioned + two broadcast legs all attach independently.
+10. `.live()` / `.aggregate()` / `.groupBy()` on a joined query throw `CrossShardJoinError`.
+11. Drift-skipped shards still surface in `skippedVaults`; broadcast applied to the surviving union.
+12. Empty eligible set → `{ results: [], skippedVaults }`, no throw.

--- a/features.yaml
+++ b/features.yaml
@@ -1178,6 +1178,7 @@ adapters:
     diagrams: []
     invariants:
       - 'casAtomic: false (no atomic compare-and-swap at the FS layer)'
+      - 'serverWriteTime: true (local filesystem clock; solo-writer only; ε = 0 ms default)'
       - 'File layout: {dir}/{vault}/{collection}/{id}.json'
       - 'Each file is one EncryptedEnvelope, optionally pretty-printed'
     related: [stores-contract]
@@ -1227,7 +1228,7 @@ adapters:
   - id: to-aws-s3
     name: S3 object store
     package: '@noy-db/to-aws-s3'
-    cas_atomic: false
+    cas_atomic: true
     use_case: cloud-blob-storage
     capabilities:
       record: true
@@ -1240,16 +1241,16 @@ adapters:
     playground_pages: []
     diagrams: []
     invariants:
-      - 'casAtomic: false (no native CAS; advisory locks via If-Match)'
+      - 'casAtomic: true (IfNoneMatch: * for creates; IfMatch: etag for updates — atomic at S3 write layer)'
+      - 'serverWriteTime: true (object LastModified via sentinel; store-authoritative; ε default 5 000 ms)'
       - 'Each envelope stored as one object keyed by full path'
-      - 'Best paired with a casAtomic primary (Dynamo) via routeStore for record metadata'
       - 'Bodies are AES-GCM ciphertext — bucket reads do NOT leak plaintext (keyspace structure is visible by design)'
     related: [stores-contract, to-aws-dynamo]
 
   - id: to-browser-local
     name: localStorage store (browser)
     package: '@noy-db/to-browser-local'
-    cas_atomic: true
+    cas_atomic: false
     use_case: simple-pwa-cache
     capabilities:
       record: true
@@ -1262,7 +1263,8 @@ adapters:
     playground_pages: []
     diagrams: []
     invariants:
-      - 'casAtomic: true (synchronous localStorage transactions)'
+      - 'casAtomic: false (single-tab: synchronous and atomic; cross-tab: no serialization)'
+      - 'serverWriteTime: true (browser clock; same-tab only; ε = 0 ms default)'
       - 'Capacity-limited (5-10 MB); use to-browser-idb for larger vaults'
       - 'obfuscate mode hides vault / collection / id from the keyspace (not encryption — _data stays AES-GCM)'
     related: [stores-contract, to-browser-idb]
@@ -1270,7 +1272,7 @@ adapters:
   - id: to-cloudflare-r2
     name: Cloudflare R2 object store
     package: '@noy-db/to-cloudflare-r2'
-    cas_atomic: false
+    cas_atomic: true
     use_case: edge-blob-storage
     capabilities:
       record: true
@@ -1284,7 +1286,8 @@ adapters:
     diagrams: []
     invariants:
       - 'S3-compatible API; zero egress fees'
-      - 'casAtomic: false (no native CAS; advisory locks via If-Match)'
+      - 'casAtomic: true (inherits to-aws-s3 IfMatch/IfNoneMatch conditional CAS — R2 supports both)'
+      - 'serverWriteTime: true (object LastModified via to-aws-s3 sentinel; ε default 5 000 ms)'
       - 'Delegates to to-aws-s3 internally — endpoint = https://<accountId>.r2.cloudflarestorage.com, region = "auto"'
       - 'Bodies are AES-GCM ciphertext — Cloudflare staff with full bucket access cannot read plaintext'
     related: [stores-contract, to-cloudflare-d1, to-aws-s3]
@@ -1412,7 +1415,8 @@ adapters:
     playground_pages: []
     diagrams: []
     invariants:
-      - 'casAtomic: true (libSQL transactions)'
+      - 'casAtomic: true (atomic UPDATE … WHERE v=? RETURNING — serialized at libSQL writer; no read-check-write race)'
+      - 'serverWriteTime: true (SELECT unixepoch("now","subsec") — server-authoritative; ε default 1 000 ms)'
       - 'Replicated SQLite across regions; ideal for edge runtimes'
       - 'Duck-typed against @libsql/client — same client surface works in Workers, Node, and Bun'
       - 'Even a Turso DB administrator sees only AES-GCM ciphertext in the envelope column'

--- a/features.yaml
+++ b/features.yaml
@@ -1135,7 +1135,7 @@ features:
       - 'vault-registry is the single source of truth for shard discovery'
       - 'createShard is idempotent; row-without-vault raises ShardProvisioningError'
       - 'minVersion guard pre-filters shards by registry schemaVersion (no silent shape-mixing)'
-      - 'join.ts partitionScope seam is untouched (crossShardJoin deferred)'
+      - 'crossShardJoin is co-partitioned fan-out + central broadcast enrichment; join.ts and its partitionScope seam stay untouched'
     related: [permissions, transferable-partition]
 
 # ─── Storage adapters (phase 2) ──────────────────────────────────────

--- a/packages/as-blob/package.json
+++ b/packages/as-blob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-blob",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Single-attachment plaintext export for noy-db — extracts one blob from BlobSet as native MIME bytes. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier, document sub-family).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-csv/package.json
+++ b/packages/as-csv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-csv",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "CSV plaintext export for noy-db — decrypts records and formats as comma-separated values. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-json/package.json
+++ b/packages/as-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-json",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Structured JSON plaintext export for noy-db — decrypts records and emits one JSON document per vault. Gated by RFC #249 canExportPlaintext capability; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-ndjson/package.json
+++ b/packages/as-ndjson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-ndjson",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Newline-delimited JSON export for noy-db — streaming plaintext export suitable for data pipelines, warehouse ingestion, and jq pipelines. Gated by RFC #249 canExportPlaintext. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-noydb/package.json
+++ b/packages/as-noydb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-noydb",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Encrypted .noydb bundle export for noy-db — wraps writeNoydbBundle() with the RFC #249 canExportBundle authorization gate and ergonomic browser/node helpers. Sole member of the @noy-db/as-* encrypted tier — ciphertext in, ciphertext out.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-sql/package.json
+++ b/packages/as-sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-sql",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "SQL dump export for noy-db — decrypts records and emits dialect-aware CREATE TABLE + INSERT statements for postgres / mysql / sqlite. One-way migration helper. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xlsx/package.json
+++ b/packages/as-xlsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xlsx",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Excel spreadsheet plaintext export for noy-db — produces a real .xlsx (Office Open XML) from one or more collections. Multi-sheet, Unicode-safe via shared-strings table. Zero runtime deps beyond the workspace zip encoder. Gated by RFC #249 `canExportPlaintext` with format `'xlsx'`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xml/package.json
+++ b/packages/as-xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xml",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "XML plaintext export for noy-db — decrypts records and formats as XML with RFC-compliant entity escaping. For legacy systems, banking batch imports, SOAP endpoints, and accounting software that requires XML. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-zip/package.json
+++ b/packages/as-zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-zip",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Composite record + blob archive export for noy-db — bundles a collection's records plus every attached blob into one zip. Zero dependencies (STORE-only zip encoder). Gated by the RFC #249 `canExportPlaintext` capability bit with format `'zip'`. Part of the @noy-db/as-* portable-artefact family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-aws-kms/package.json
+++ b/packages/at-aws-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-aws-kms",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "AWS KMS sealing key provider for noy-db managed-passphrase mode — seal/unseal via KMS Encrypt/Decrypt, with KMS access logs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-azure-keyvault/package.json
+++ b/packages/at-azure-keyvault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-azure-keyvault",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Azure Key Vault sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-env/package.json
+++ b/packages/at-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-env",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Env-var sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a key from process.env. Smallest production-shape provider; pair with Kubernetes Secrets / Heroku env / AWS Secrets Manager.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-gcp-kms/package.json
+++ b/packages/at-gcp-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-gcp-kms",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Google Cloud KMS sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-macos-keychain/package.json
+++ b/packages/at-macos-keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-macos-keychain",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "macOS Keychain sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a 32-byte key stored in the user's login Keychain. Desktop-app provider in the at-* family; pairs with Touch ID via Keychain Access UI.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/attestation/package.json
+++ b/packages/attestation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/attestation",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Pure, zero-dependency document-attestation primitive for noy-db — per-field salted commitments, Ed25519 sign/verify, QR credential codec, and revocation checks. Runs in Node and the browser; the offline verifier imports only this.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-peer/package.json
+++ b/packages/by-peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-peer",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "WebRTC peer-to-peer transport for noy-db — direct browser-to-browser channel with signaling-agnostic handshake",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-tabs/package.json
+++ b/packages/by-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-tabs",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "BroadcastChannel multi-tab transport for noy-db — sync between tabs of the same browser without round-tripping the storage backend",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/cli",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Command-line tool for noy-db — inspect .noydb bundles without decrypting, verify integrity, validate config objects, scaffold topology profiles, and monitor a live vault's store metrics.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/create-noy-db/package.json
+++ b/packages/create-noy-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-noy-db",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Wizard + CLI tool for noy-db: scaffold a fresh Nuxt 4 + Pinia encrypted store, or add collections to an existing project. Invoke via `npm create @noy-db`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/hub/__tests__/federation-cross-shard-join.test.ts
+++ b/packages/hub/__tests__/federation-cross-shard-join.test.ts
@@ -4,13 +4,80 @@
  * Plan: docs/superpowers/plans/2026-06-09-cross-shard-join.md
  */
 import { describe, it, expect } from 'vitest'
-import { CrossShardJoinError, NoydbError } from '../src/errors.js'
+import { CrossShardJoinError, NoydbError, ConflictError } from '../src/errors.js'
 import {
   applyBroadcastLegs,
   resetBroadcastWarnings,
   type BroadcastLeg,
   type BroadcastSource,
 } from '../src/federation/cross-shard-join.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { createNoydb } from '../src/noydb.js'
+import type { Vault } from '../src/vault.js'
+import type { VaultRegistryRow } from '../src/federation/index.js'
+import { ref } from '../src/refs.js'
+
+// ─── In-memory adapter + harness (mirrors federation-query-aggregate.test.ts) ───
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+interface Invoice { id: string; clientId: string; customerId: string; amount: number; status: string; currencyCode?: string }
+interface Customer { id: string; name: string }
+
+/** Operator db + a client template that registers customers + invoices(ref customers). */
+async function harness() {
+  const adapter = memory()
+  const db = await createNoydb({ store: adapter, user: 'operator', secret: 'op-pass' })
+  db.withVaultTemplate('client-template', {
+    version: 1,
+    configure(vault: Vault) {
+      vault.collection<Customer>('customers')
+      vault.collection<Invoice>('invoices', { refs: { customerId: ref('customers') } })
+    },
+  })
+  const stateVault = await db.openVault('state')
+  const registry = stateVault.collection<VaultRegistryRow>('vault-registry')
+  const firm = await db.openVaultGroup<Invoice>('firm-clients', {
+    registry,
+    sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template' },
+  })
+  return { adapter, db, registry, firm }
+}
 
 describe('CrossShardJoinError', () => {
   it('is a NoydbError with the CROSS_SHARD_JOIN code', () => {
@@ -21,12 +88,12 @@ describe('CrossShardJoinError', () => {
   })
 })
 
-function fakeSource(rows: Record<string, unknown>[]): BroadcastSource & { snapCalls: number } {
-  let snapCalls = 0
+function fakeSource(rows: Record<string, unknown>[]): BroadcastSource & { listCalls: number } {
+  let listCalls = 0
   return {
-    get snapCalls() { return snapCalls },
-    snapshot() { snapCalls++; return rows },
-  } as BroadcastSource & { snapCalls: number }
+    get listCalls() { return listCalls },
+    async list() { listCalls++; return rows },
+  } as BroadcastSource & { listCalls: number }
 }
 
 describe('applyBroadcastLegs', () => {
@@ -55,14 +122,14 @@ describe('applyBroadcastLegs', () => {
     expect((out[0] as Record<string, unknown>).fx).toBeNull()
   })
 
-  it('loads the source snapshot exactly once regardless of row count', async () => {
+  it('loads the source exactly once regardless of row count', async () => {
     const src = fakeSource([{ id: 'usd' }])
     const leg: BroadcastLeg = { field: 'currencyCode', as: 'fx', from: src, on: 'id', mode: 'cascade' }
     await applyBroadcastLegs(
       Array.from({ length: 50 }, (_, i) => ({ id: `i${i}`, currencyCode: 'usd' })),
       [leg],
     )
-    expect(src.snapCalls).toBe(1)
+    expect(src.listCalls).toBe(1)
   })
 
   it('applies multiple legs independently', async () => {
@@ -84,5 +151,78 @@ describe('applyBroadcastLegs', () => {
     const rows = [{ id: 'i1' }]
     const out = await applyBroadcastLegs(rows, [])
     expect(out).toEqual(rows)
+  })
+})
+
+describe('crossShardJoin (co-partitioned)', () => {
+  it('joins each shard against its same-vault right collection and unions', async () => {
+    const { firm } = await harness()
+    // strict refs enforce integrity at write time → seed the customer (in its
+    // shard) BEFORE the invoice that references it.
+    const acme = await firm.createShard('acme')
+    await acme.collection<Customer>('customers').put('c-acme', { id: 'c-acme', name: 'Acme Co' })
+    await firm.collection('invoices').put('i1', { id: 'i1', clientId: 'acme', customerId: 'c-acme', amount: 100, status: 'overdue' })
+
+    const globex = await firm.createShard('globex')
+    await globex.collection<Customer>('customers').put('c-glx', { id: 'c-glx', name: 'Globex' })
+    await firm.collection('invoices').put('i2', { id: 'i2', clientId: 'globex', customerId: 'c-glx', amount: 200, status: 'overdue' })
+
+    const res = await firm.collection('invoices').query()
+      .where('status', '==', 'overdue')
+      .crossShardJoin('customerId', { as: 'customer' })
+      .toArray()
+
+    expect(res.skippedVaults).toEqual([])
+    const byId = Object.fromEntries(res.results.map((r) => [(r as Invoice).id, r])) as Record<string, Record<string, unknown>>
+    expect((byId['i1'].customer as Customer).name).toBe('Acme Co')
+    expect((byId['i2'].customer as Customer).name).toBe('Globex')
+  })
+})
+
+describe('broadcastJoin (dimension)', () => {
+  it('enriches every merged row from a single shared dimension collection', async () => {
+    resetBroadcastWarnings()
+    const { db, firm } = await harness()
+    const dims = await db.openVault('dimensions')
+    const currencies = dims.collection<{ id: string; symbol: string }>('currencies')
+    await currencies.put('usd', { id: 'usd', symbol: '$' })
+    await currencies.put('eur', { id: 'eur', symbol: '€' })
+
+    // No customer ref here — invoices use a warn-free standalone shard write.
+    const acme = await firm.createShard('acme')
+    await acme.collection<Customer>('customers').put('c1', { id: 'c1', name: 'A' })
+    await firm.collection('invoices').put('i1', { id: 'i1', clientId: 'acme', customerId: 'c1', amount: 100, status: 'paid', currencyCode: 'usd' })
+    const glx = await firm.createShard('globex')
+    await glx.collection<Customer>('customers').put('c2', { id: 'c2', name: 'G' })
+    await firm.collection('invoices').put('i2', { id: 'i2', clientId: 'globex', customerId: 'c2', amount: 200, status: 'paid', currencyCode: 'eur' })
+
+    const res = await firm.collection('invoices').query()
+      .broadcastJoin('currencyCode', { as: 'fx', from: currencies })
+      .toArray()
+
+    const byId = Object.fromEntries(res.results.map((r) => [(r as Invoice).id, r])) as Record<string, Record<string, unknown>>
+    expect((byId['i1'].fx as { symbol: string }).symbol).toBe('$')
+    expect((byId['i2'].fx as { symbol: string }).symbol).toBe('€')
+  })
+
+  it('combines a co-partitioned join and a broadcast join', async () => {
+    resetBroadcastWarnings()
+    const { db, firm } = await harness()
+    const dims = await db.openVault('dimensions')
+    const currencies = dims.collection<{ id: string; symbol: string }>('currencies')
+    await currencies.put('usd', { id: 'usd', symbol: '$' })
+
+    const acme = await firm.createShard('acme')
+    await acme.collection<Customer>('customers').put('c-acme', { id: 'c-acme', name: 'Acme Co' })
+    await firm.collection('invoices').put('i1', { id: 'i1', clientId: 'acme', customerId: 'c-acme', amount: 100, status: 'overdue', currencyCode: 'usd' })
+
+    const res = await firm.collection('invoices').query()
+      .crossShardJoin('customerId', { as: 'customer' })
+      .broadcastJoin('currencyCode', { as: 'fx', from: currencies })
+      .toArray()
+
+    const row = res.results[0] as Record<string, unknown>
+    expect((row.customer as Customer).name).toBe('Acme Co')
+    expect((row.fx as { symbol: string }).symbol).toBe('$')
   })
 })

--- a/packages/hub/__tests__/federation-cross-shard-join.test.ts
+++ b/packages/hub/__tests__/federation-cross-shard-join.test.ts
@@ -281,3 +281,28 @@ describe('broadcastJoin miss', () => {
     expect((res.results[0] as Record<string, unknown>).fx).toBeNull()
   })
 })
+
+describe('deferred surfaces throw when join legs are present', () => {
+  it('live() throws CrossShardJoinError with a co-partitioned leg', async () => {
+    const { firm } = await harness()
+    expect(() =>
+      firm.collection('invoices').query().crossShardJoin('customerId', { as: 'c' }).live(),
+    ).toThrow(CrossShardJoinError)
+  })
+
+  it('aggregate() throws CrossShardJoinError with a broadcast leg', async () => {
+    const { db, firm } = await harness()
+    const dims = await db.openVault('dimensions')
+    const cur = dims.collection<{ id: string }>('currencies')
+    expect(() =>
+      firm.collection('invoices').query().broadcastJoin('currencyCode', { as: 'fx', from: cur }).aggregate({ total: 'count' } as never),
+    ).toThrow(CrossShardJoinError)
+  })
+
+  it('groupBy() throws CrossShardJoinError with a join leg', async () => {
+    const { firm } = await harness()
+    expect(() =>
+      firm.collection('invoices').query().crossShardJoin('customerId', { as: 'c' }).groupBy('status'),
+    ).toThrow(CrossShardJoinError)
+  })
+})

--- a/packages/hub/__tests__/federation-cross-shard-join.test.ts
+++ b/packages/hub/__tests__/federation-cross-shard-join.test.ts
@@ -226,3 +226,58 @@ describe('broadcastJoin (dimension)', () => {
     expect((row.fx as { symbol: string }).symbol).toBe('$')
   })
 })
+
+describe('crossShardJoin failure semantics', () => {
+  it('throws a single CrossShardJoinError when the join field has no ref()', async () => {
+    const { firm } = await harness()
+    const acme = await firm.createShard('acme')
+    await acme.collection<Customer>('customers').put('c1', { id: 'c1', name: 'A' })
+    await firm.collection('invoices').put('i1', { id: 'i1', clientId: 'acme', customerId: 'c1', amount: 1, status: 'open' })
+    await expect(
+      firm.collection('invoices').query().crossShardJoin('amount', { as: 'x' }).toArray(),
+    ).rejects.toBeInstanceOf(CrossShardJoinError)
+  })
+
+  it('attaches null for a dangling ref in warn mode (per-shard RefMode)', async () => {
+    const adapter = memory()
+    const db = await createNoydb({ store: adapter, user: 'operator', secret: 'op-pass' })
+    db.withVaultTemplate('warn-template', {
+      version: 1,
+      configure(vault: Vault) {
+        vault.collection<Customer>('customers')
+        vault.collection<Invoice>('invoices', { refs: { customerId: ref('customers', 'warn') } })
+      },
+    })
+    const sv = await db.openVault('state')
+    const registry = sv.collection<VaultRegistryRow>('vault-registry')
+    const firm = await db.openVaultGroup<Invoice>('warn-firm', {
+      registry,
+      sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'warn-template' },
+    })
+    await firm.collection('invoices').put('i1', { id: 'i1', clientId: 'acme', customerId: 'ghost', amount: 1, status: 'open' })
+
+    const res = await firm.collection('invoices').query()
+      .crossShardJoin('customerId', { as: 'customer' })
+      .toArray()
+    expect(res.results).toHaveLength(1)
+    expect((res.results[0] as Record<string, unknown>).customer).toBeNull()
+  })
+})
+
+describe('broadcastJoin miss', () => {
+  it('attaches null on a miss without throwing', async () => {
+    resetBroadcastWarnings()
+    const { db, firm } = await harness()
+    const dims = await db.openVault('dimensions')
+    const currencies = dims.collection<{ id: string }>('currencies')
+    await currencies.put('usd', { id: 'usd' })
+    const acme = await firm.createShard('acme')
+    await acme.collection<Customer>('customers').put('c1', { id: 'c1', name: 'A' })
+    await firm.collection('invoices').put('i1', { id: 'i1', clientId: 'acme', customerId: 'c1', amount: 1, status: 'paid', currencyCode: 'gbp' })
+
+    const res = await firm.collection('invoices').query()
+      .broadcastJoin('currencyCode', { as: 'fx', from: currencies, mode: 'cascade' })
+      .toArray()
+    expect((res.results[0] as Record<string, unknown>).fx).toBeNull()
+  })
+})

--- a/packages/hub/__tests__/federation-cross-shard-join.test.ts
+++ b/packages/hub/__tests__/federation-cross-shard-join.test.ts
@@ -1,0 +1,16 @@
+/**
+ * crossShardJoin — co-partitioned + broadcast dimension join.
+ * Spec: docs/superpowers/specs/2026-06-09-cross-shard-join-design.md
+ * Plan: docs/superpowers/plans/2026-06-09-cross-shard-join.md
+ */
+import { describe, it, expect } from 'vitest'
+import { CrossShardJoinError, NoydbError } from '../src/errors.js'
+
+describe('CrossShardJoinError', () => {
+  it('is a NoydbError with the CROSS_SHARD_JOIN code', () => {
+    const e = new CrossShardJoinError('nope')
+    expect(e).toBeInstanceOf(NoydbError)
+    expect(e.code).toBe('CROSS_SHARD_JOIN')
+    expect(e.message).toBe('nope')
+  })
+})

--- a/packages/hub/__tests__/federation-cross-shard-join.test.ts
+++ b/packages/hub/__tests__/federation-cross-shard-join.test.ts
@@ -5,6 +5,12 @@
  */
 import { describe, it, expect } from 'vitest'
 import { CrossShardJoinError, NoydbError } from '../src/errors.js'
+import {
+  applyBroadcastLegs,
+  resetBroadcastWarnings,
+  type BroadcastLeg,
+  type BroadcastSource,
+} from '../src/federation/cross-shard-join.js'
 
 describe('CrossShardJoinError', () => {
   it('is a NoydbError with the CROSS_SHARD_JOIN code', () => {
@@ -12,5 +18,71 @@ describe('CrossShardJoinError', () => {
     expect(e).toBeInstanceOf(NoydbError)
     expect(e.code).toBe('CROSS_SHARD_JOIN')
     expect(e.message).toBe('nope')
+  })
+})
+
+function fakeSource(rows: Record<string, unknown>[]): BroadcastSource & { snapCalls: number } {
+  let snapCalls = 0
+  return {
+    get snapCalls() { return snapCalls },
+    snapshot() { snapCalls++; return rows },
+  } as BroadcastSource & { snapCalls: number }
+}
+
+describe('applyBroadcastLegs', () => {
+  it('attaches the matching dimension record by default on:id', async () => {
+    const src = fakeSource([{ id: 'usd', symbol: '$' }, { id: 'eur', symbol: '€' }])
+    const leg: BroadcastLeg = { field: 'currencyCode', as: 'fx', from: src, on: 'id', mode: 'warn' }
+    const out = await applyBroadcastLegs(
+      [{ id: 'i1', currencyCode: 'usd' }, { id: 'i2', currencyCode: 'eur' }],
+      [leg],
+    )
+    expect((out[0] as Record<string, unknown>).fx).toEqual({ id: 'usd', symbol: '$' })
+    expect((out[1] as Record<string, unknown>).fx).toEqual({ id: 'eur', symbol: '€' })
+  })
+
+  it('matches on a custom key', async () => {
+    const src = fakeSource([{ code: 'usd', symbol: '$' }])
+    const leg: BroadcastLeg = { field: 'currencyCode', as: 'fx', from: src, on: 'code', mode: 'warn' }
+    const out = await applyBroadcastLegs([{ id: 'i1', currencyCode: 'usd' }], [leg])
+    expect((out[0] as Record<string, unknown>).fx).toEqual({ code: 'usd', symbol: '$' })
+  })
+
+  it('attaches null on a miss', async () => {
+    const src = fakeSource([{ id: 'usd' }])
+    const leg: BroadcastLeg = { field: 'currencyCode', as: 'fx', from: src, on: 'id', mode: 'cascade' }
+    const out = await applyBroadcastLegs([{ id: 'i1', currencyCode: 'gbp' }], [leg])
+    expect((out[0] as Record<string, unknown>).fx).toBeNull()
+  })
+
+  it('loads the source snapshot exactly once regardless of row count', async () => {
+    const src = fakeSource([{ id: 'usd' }])
+    const leg: BroadcastLeg = { field: 'currencyCode', as: 'fx', from: src, on: 'id', mode: 'cascade' }
+    await applyBroadcastLegs(
+      Array.from({ length: 50 }, (_, i) => ({ id: `i${i}`, currencyCode: 'usd' })),
+      [leg],
+    )
+    expect(src.snapCalls).toBe(1)
+  })
+
+  it('applies multiple legs independently', async () => {
+    const fx = fakeSource([{ id: 'usd', symbol: '$' }])
+    const adv = fakeSource([{ id: 'a1', name: 'Dana' }])
+    const out = await applyBroadcastLegs(
+      [{ id: 'i1', currencyCode: 'usd', advisorId: 'a1' }],
+      [
+        { field: 'currencyCode', as: 'fx', from: fx, on: 'id', mode: 'cascade' },
+        { field: 'advisorId', as: 'advisor', from: adv, on: 'id', mode: 'cascade' },
+      ],
+    )
+    expect((out[0] as Record<string, unknown>).fx).toEqual({ id: 'usd', symbol: '$' })
+    expect((out[0] as Record<string, unknown>).advisor).toEqual({ id: 'a1', name: 'Dana' })
+  })
+
+  it('returns rows unchanged when there are no legs', async () => {
+    resetBroadcastWarnings()
+    const rows = [{ id: 'i1' }]
+    const out = await applyBroadcastLegs(rows, [])
+    expect(out).toEqual(rows)
   })
 })

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/hub",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Zero-knowledge, offline-first, encrypted document store — core library with AES-256-GCM, PBKDF2, multi-user keyring, and sync engine",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -2087,6 +2087,19 @@ export class ShardProvisioningError extends NoydbError {
   }
 }
 
+/**
+ * Thrown by `ShardedQuery.crossShardJoin` / `broadcastJoin` for
+ * deterministic, query-shaping errors: an undeclared join ref (which
+ * would fail identically on every shard), or calling a deferred
+ * reactive/aggregate surface on a query that already carries join legs.
+ */
+export class CrossShardJoinError extends NoydbError {
+  constructor(message: string) {
+    super('CROSS_SHARD_JOIN', message)
+    this.name = 'CrossShardJoinError'
+  }
+}
+
 /** Thrown when a VaultGroup references a template name that was never registered. */
 export class VaultTemplateNotFoundError extends NoydbError {
   readonly templateName: string

--- a/packages/hub/src/federation/cross-shard-join.ts
+++ b/packages/hub/src/federation/cross-shard-join.ts
@@ -1,0 +1,129 @@
+/**
+ * @category capability
+ * crossShardJoin — co-partitioned + broadcast dimension join for
+ * ShardedQuery. Spec:
+ * docs/superpowers/specs/2026-06-09-cross-shard-join-design.md.
+ *
+ * This module owns the BROADCAST half (central, post-merge map-attach)
+ * and the leg type definitions. The CO-PARTITIONED half is threaded
+ * into the existing intra-vault `.join()` from vault-group.ts — see
+ * ShardedQuery.fanoutRecords. join.ts is deliberately untouched.
+ */
+import { readPath } from '../query/predicate.js'
+import type { JoinStrategy } from '../query/join.js'
+
+/** Public options for `ShardedQuery.crossShardJoin`. */
+export interface CrossShardJoinOptions {
+  /** Alias key under which the joined same-shard record attaches. */
+  readonly as: string
+  /** Per-shard row ceiling override (default DEFAULT_JOIN_MAX_ROWS). */
+  readonly maxRows?: number
+  /** Planner strategy override, passed through to intra-vault `.join()`. */
+  readonly strategy?: JoinStrategy
+}
+
+/**
+ * Minimal structural shape of a broadcast dimension source. A
+ * `Collection` satisfies this: `snapshot()` reads its in-memory cache,
+ * `list()` hydrates it. `list` is optional so plain test sources work.
+ */
+export interface BroadcastSource {
+  snapshot(): readonly unknown[]
+  list?(): Promise<unknown>
+}
+
+/** Public options for `ShardedQuery.broadcastJoin`. */
+export interface BroadcastJoinOptions {
+  /** Alias key under which the dimension record attaches. */
+  readonly as: string
+  /** The shared dimension collection (an opened handle in another vault). */
+  readonly from: BroadcastSource
+  /** Right-side key to match `field` against. Default 'id'. */
+  readonly on?: string
+  /** Miss behavior. 'warn' (default) attaches null + one-shot warning; 'cascade' is silent. */
+  readonly mode?: 'warn' | 'cascade'
+}
+
+/** Internal co-partitioned leg carried on ShardedQuery. */
+export interface CoPartitionedLeg {
+  readonly field: string
+  readonly as: string
+  readonly maxRows: number | undefined
+  readonly strategy: JoinStrategy | undefined
+}
+
+/** Internal broadcast leg carried on ShardedQuery. */
+export interface BroadcastLeg {
+  readonly field: string
+  readonly as: string
+  readonly from: BroadcastSource
+  readonly on: string
+  readonly mode: 'warn' | 'cascade'
+}
+
+/**
+ * Coerce an unknown key value into a lookup string. Mirrors join.ts's
+ * private `coerceRefKey` (string → string; number/bigint → String;
+ * else null) — re-implemented locally to keep join.ts literally
+ * untouched.
+ */
+function coerceKey(value: unknown): string | null {
+  if (value === null || value === undefined) return null
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'bigint') return String(value)
+  return null
+}
+
+/** One-shot warn dedup for broadcast misses, keyed by `field→as`. */
+const warnedBroadcastKeys = new Set<string>()
+function warnOnceBroadcastMiss(field: string, as: string, key: string): void {
+  const dedup = `${field}→${as}:${key}`
+  if (warnedBroadcastKeys.has(dedup)) return
+  warnedBroadcastKeys.add(dedup)
+  console.warn(
+    `[noy-db] broadcastJoin: no "${as}" dimension row for ${field}="${key}". ` +
+      `Attaching null. Use mode: 'cascade' to silence.`,
+  )
+}
+
+/** Test-only reset for the broadcast warn dedup set. */
+export function resetBroadcastWarnings(): void {
+  warnedBroadcastKeys.clear()
+}
+
+/**
+ * Apply every broadcast leg to a merged row set, centrally. Each leg's
+ * source is snapshotted ONCE, indexed by its `on` key, then every row
+ * gets `{ [as]: match ?? null }`. Returns fresh top-level objects.
+ */
+export async function applyBroadcastLegs(
+  rows: readonly unknown[],
+  legs: readonly BroadcastLeg[],
+): Promise<unknown[]> {
+  if (legs.length === 0) return [...rows]
+
+  // Build one index per leg (snapshot once).
+  const indexes: { leg: BroadcastLeg; map: Map<string, unknown> }[] = []
+  for (const leg of legs) {
+    if (leg.from.list) await leg.from.list()
+    const map = new Map<string, unknown>()
+    for (const rec of leg.from.snapshot()) {
+      const k = coerceKey(readPath(rec, leg.on))
+      if (k !== null && !map.has(k)) map.set(k, rec)
+    }
+    indexes.push({ leg, map })
+  }
+
+  return rows.map((row) => {
+    const out = { ...(row as Record<string, unknown>) }
+    for (const { leg, map } of indexes) {
+      const key = coerceKey(readPath(row, leg.field))
+      const match = key === null ? null : map.get(key) ?? null
+      if (match === null && leg.mode === 'warn') {
+        warnOnceBroadcastMiss(leg.field, leg.as, key ?? '<null>')
+      }
+      out[leg.as] = match
+    }
+    return out
+  })
+}

--- a/packages/hub/src/federation/cross-shard-join.ts
+++ b/packages/hub/src/federation/cross-shard-join.ts
@@ -24,12 +24,12 @@ export interface CrossShardJoinOptions {
 
 /**
  * Minimal structural shape of a broadcast dimension source. A
- * `Collection` satisfies this: `snapshot()` reads its in-memory cache,
- * `list()` hydrates it. `list` is optional so plain test sources work.
+ * `Collection` satisfies this natively: `list()` hydrates and returns
+ * the decoded records. Kept as a one-method interface so plain test
+ * sources are trivial to construct.
  */
 export interface BroadcastSource {
-  snapshot(): readonly unknown[]
-  list?(): Promise<unknown>
+  list(): Promise<readonly unknown[]>
 }
 
 /** Public options for `ShardedQuery.broadcastJoin`. */
@@ -102,12 +102,11 @@ export async function applyBroadcastLegs(
 ): Promise<unknown[]> {
   if (legs.length === 0) return [...rows]
 
-  // Build one index per leg (snapshot once).
+  // Build one index per leg (list() once per source).
   const indexes: { leg: BroadcastLeg; map: Map<string, unknown> }[] = []
   for (const leg of legs) {
-    if (leg.from.list) await leg.from.list()
     const map = new Map<string, unknown>()
-    for (const rec of leg.from.snapshot()) {
+    for (const rec of await leg.from.list()) {
       const k = coerceKey(readPath(rec, leg.on))
       if (k !== null && !map.has(k)) map.set(k, rec)
     }

--- a/packages/hub/src/federation/index.ts
+++ b/packages/hub/src/federation/index.ts
@@ -1,6 +1,12 @@
 export { VaultGroup, ShardedCollection, ShardedQuery, ShardedGroupedQuery } from './vault-group.js'
 export { CrossVaultAggregation, CrossVaultGroupedAggregation } from './aggregate-across.js'
 export { StateManagementVault } from './state-vault.js'
+export { resetBroadcastWarnings } from './cross-shard-join.js'
+export type {
+  CrossShardJoinOptions,
+  BroadcastJoinOptions,
+  BroadcastSource,
+} from './cross-shard-join.js'
 export type {
   VaultTemplate,
   VaultRegistryRow,

--- a/packages/hub/src/federation/vault-group.ts
+++ b/packages/hub/src/federation/vault-group.ts
@@ -8,9 +8,11 @@ import type { Noydb } from '../noydb.js'
 import type { Vault } from '../vault.js'
 import type { Collection } from '../collection.js'
 import type { StateManagementVault } from './state-vault.js'
-import { ReservedVaultNameError, ShardProvisioningError, UnknownShardError, ValidationError } from '../errors.js'
+import { CrossShardJoinError, ReservedVaultNameError, ShardProvisioningError, UnknownShardError, ValidationError } from '../errors.js'
 import { STATE_VAULT_NAME } from './constants.js'
 import { classifyShardSkip } from './classify-skip.js'
+import { applyBroadcastLegs } from './cross-shard-join.js'
+import type { CoPartitionedLeg, BroadcastLeg, CrossShardJoinOptions, BroadcastJoinOptions } from './cross-shard-join.js'
 import { CrossVaultLive } from './cross-vault-live.js'
 import { CrossVaultAggregation, CrossVaultGroupedAggregation } from './aggregate-across.js'
 import type { FanoutRecordSource, LiveBinding } from './aggregate-across.js'
@@ -231,27 +233,93 @@ export class ShardedQuery<T, R = T> {
     private readonly group: VaultGroup<T>,
     private readonly collectionName: string,
     private readonly clauses: readonly WhereClause[],
+    private readonly coPartitionedLegs: readonly CoPartitionedLeg[] = [],
+    private readonly broadcastLegs: readonly BroadcastLeg[] = [],
   ) {}
 
   where(field: string, op: WhereClause['op'], value: unknown): ShardedQuery<T, R> {
-    return new ShardedQuery<T, R>(this.group, this.collectionName, [
-      ...this.clauses,
-      { field, op, value },
-    ])
+    return new ShardedQuery<T, R>(
+      this.group,
+      this.collectionName,
+      [...this.clauses, { field, op, value }],
+      this.coPartitionedLegs,
+      this.broadcastLegs,
+    )
+  }
+
+  /** Co-partitioned join: each shard joins its own same-vault right collection (resolved via ref()), then union. */
+  crossShardJoin(field: string, opts: CrossShardJoinOptions): ShardedQuery<T, R> {
+    const leg: CoPartitionedLeg = { field, as: opts.as, maxRows: opts.maxRows, strategy: opts.strategy }
+    return new ShardedQuery<T, R>(
+      this.group,
+      this.collectionName,
+      this.clauses,
+      [...this.coPartitionedLegs, leg],
+      this.broadcastLegs,
+    )
+  }
+
+  /** Broadcast dimension join: enrich every merged row from a single shared collection. */
+  broadcastJoin(field: string, opts: BroadcastJoinOptions): ShardedQuery<T, R> {
+    const leg: BroadcastLeg = {
+      field,
+      as: opts.as,
+      from: opts.from,
+      on: opts.on ?? 'id',
+      mode: opts.mode ?? 'warn',
+    }
+    return new ShardedQuery<T, R>(
+      this.group,
+      this.collectionName,
+      this.clauses,
+      this.coPartitionedLegs,
+      [...this.broadcastLegs, leg],
+    )
   }
 
   /** @internal — fan out the where-filtered records across eligible shards. */
   async fanoutRecords(options: FanoutQueryOptions = {}): Promise<{ records: R[]; skippedVaults: SkippedVault[] }> {
     const { eligible, skipped } = await this.group.resolveEligible(options)
+    // Deterministic pre-check: an undeclared co-partitioned join ref fails
+    // identically on every shard, so surface it as ONE CrossShardJoinError
+    // rather than N identical skips. Probe the first eligible shard.
+    const probeRow = eligible[0]
+    if (this.coPartitionedLegs.length > 0 && probeRow) {
+      const probe = await this.group.openShard(probeRow.partitionKey)
+      this.group.template.configure(probe)
+      for (const leg of this.coPartitionedLegs) {
+        if (!probe.resolveRef(this.collectionName, leg.field)) {
+          throw new CrossShardJoinError(
+            `crossShardJoin("${leg.field}"): no ref() declared for "${leg.field}" on ` +
+              `collection "${this.collectionName}" in template "${this.group.sharding.vaultTemplate}". ` +
+              `Add refs: { ${leg.field}: ref('<target>') } to the template's collection options.`,
+          )
+        }
+      }
+    }
     const across = await this.group.db.queryAcross<R[]>(
       eligible.map((r) => r.vaultId),
       async (vault) => {
         this.group.template.configure(vault)
         const coll = vault.collection<R>(this.collectionName)
         await coll.list() // hydrate the in-memory cache before the sync query
+        // Hydrate each co-partitioned join target — resolveSource reads the
+        // in-memory cache, so an unopened right collection would join to an
+        // empty snapshot (every row → null).
+        for (const leg of this.coPartitionedLegs) {
+          const desc = vault.resolveRef(this.collectionName, leg.field)
+          if (desc) await vault.collection(desc.target).list()
+        }
         let q = coll.query()
         for (const c of this.clauses) q = q.where(c.field, c.op, c.value)
-        return q.toArray()
+        for (const leg of this.coPartitionedLegs) {
+          q = q.join(leg.field, {
+            as: leg.as,
+            ...(leg.maxRows !== undefined ? { maxRows: leg.maxRows } : {}),
+            ...(leg.strategy ? { strategy: leg.strategy } : {}),
+          })
+        }
+        return q.toArray() as R[]
       },
       { concurrency: options.concurrency ?? 1, create: false },
     )
@@ -263,10 +331,11 @@ export class ShardedQuery<T, R = T> {
     return { records: results, skippedVaults: skipped }
   }
 
-  /** Fan out across eligible shards and merge results. */
+  /** Fan out across eligible shards, merge, then apply any broadcast dimension legs. */
   async toArray(options: FanoutQueryOptions = {}): Promise<FanoutResult<R>> {
     const { records, skippedVaults } = await this.fanoutRecords(options)
-    return { results: records, skippedVaults }
+    const results = (await applyBroadcastLegs(records, this.broadcastLegs)) as R[]
+    return { results, skippedVaults }
   }
 
   /** @internal — build the change-subscription + relevance binding for this query's group+collection. */

--- a/packages/hub/src/federation/vault-group.ts
+++ b/packages/hub/src/federation/vault-group.ts
@@ -319,7 +319,7 @@ export class ShardedQuery<T, R = T> {
             ...(leg.strategy ? { strategy: leg.strategy } : {}),
           })
         }
-        return q.toArray() as R[]
+        return q.toArray()
       },
       { concurrency: options.concurrency ?? 1, create: false },
     )

--- a/packages/hub/src/federation/vault-group.ts
+++ b/packages/hub/src/federation/vault-group.ts
@@ -348,8 +348,19 @@ export class ShardedQuery<T, R = T> {
     }
   }
 
+  /** @internal — joined queries don't support reactive/aggregate surfaces in v1. */
+  private assertNoJoinLegs(surface: string): void {
+    if (this.coPartitionedLegs.length || this.broadcastLegs.length) {
+      throw new CrossShardJoinError(
+        `${surface}() is not supported on a ShardedQuery with crossShardJoin/broadcastJoin ` +
+          `legs in v1. Use toArray() for joined cross-shard queries.`,
+      )
+    }
+  }
+
   /** Returns a reactive cross-shard live query — a facade over CrossVaultLive. */
   live(options: LiveQueryOptions = {}): CrossVaultLiveQuery<R> {
+    this.assertNoJoinLegs('live')
     const bind = this.liveBinding()
     const core = new CrossVaultLive<{ records: R[]; skipped: SkippedVault[] }>({
       ...bind,
@@ -372,11 +383,13 @@ export class ShardedQuery<T, R = T> {
 
   /** One-shot distributed aggregate — central reduce over all shard records. */
   aggregate<Spec extends AggregateSpec>(spec: Spec): CrossVaultAggregation<R, Spec> {
+    this.assertNoJoinLegs('aggregate')
     return new CrossVaultAggregation<R, Spec>(this, spec, this.liveBinding())
   }
 
   /** Begin a grouped cross-shard aggregate. */
   groupBy<F extends string>(field: F): ShardedGroupedQuery<T, R, F> {
+    this.assertNoJoinLegs('groupBy')
     return new ShardedGroupedQuery<T, R, F>(this, field)
   }
 }

--- a/packages/in-ai/package.json
+++ b/packages/in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-ai",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "LLM function-calling adapter for noy-db — expose ACL-scoped collections as tool definitions, then dispatch tool calls back to the vault. Format-agnostic (OpenAI, Anthropic, Vercel AI SDK).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-devtools-tui/package.json
+++ b/packages/in-devtools-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-devtools-tui",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Interactive terminal inspector for a live noy-db (ink TUI over @noy-db/in-devtools).",
   "license": "MIT",
   "type": "module",

--- a/packages/in-devtools/package.json
+++ b/packages/in-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-devtools",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Framework-agnostic read-only inspector for a live noy-db — vaults, collections, schema, stats, records, and live writes.",
   "license": "MIT",
   "type": "module",

--- a/packages/in-nextjs/package.json
+++ b/packages/in-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nextjs",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Next.js App Router helpers for noy-db — server components, route handlers, client hooks, and cookie-based session. Thin bridge that composes @noy-db/in-react with Next's cookies()/headers() APIs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-nuxt/package.json
+++ b/packages/in-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nuxt",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Nuxt 4 module for noy-db — auto-imports, SSR-safe runtime plugin, and the @noy-db/in-pinia bridge",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-pinia/package.json
+++ b/packages/in-pinia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-pinia",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Pinia integration for noy-db — defineNoydbStore() and the augmentation plugin for existing stores",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-react/package.json
+++ b/packages/in-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-react",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "React hooks for noy-db — useNoydb, useVault, useCollection, useQuery, useSync. Uses useSyncExternalStore for reactive subscriptions. Zero deps beyond React.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-rest/package.json
+++ b/packages/in-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-rest",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Framework-neutral REST API integration for noy-db — createRestHandler with Hono, Express, Fastify, and Nitro subpath adapters.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-solid/package.json
+++ b/packages/in-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-solid",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "SolidJS signal primitives for noy-db — createCollectionSignal, createQuerySignal, createSyncSignal backed by noy-db change events.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-svelte/package.json
+++ b/packages/in-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-svelte",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Svelte stores for noy-db — collectionStore / queryStore / syncStore backed by noy-db change events. Works with Svelte 4 store contract and Svelte 5 runes (via $store subscription interop).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-query/package.json
+++ b/packages/in-tanstack-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-query",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "TanStack Query adapter for noy-db — queryFn + mutationFn helpers that speak the Collection API, plus automatic invalidation from noy-db change events. Framework-agnostic (React / Vue / Solid / Svelte).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-table/package.json
+++ b/packages/in-tanstack-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-table",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "TanStack Table bridge for noy-db — map Collection query state (sort, filter, pagination) into Table state and back, so a useSmartTable pattern drives the DB's query DSL without glue code.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-vue/package.json
+++ b/packages/in-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-vue",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Vue 3 / Nuxt composables for noy-db — reactive useNoydb, useCollection, useSync, and biometric plugin",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-yjs/package.json
+++ b/packages/in-yjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-yjs",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Yjs Y.Doc interop for noy-db — collaborative rich-text fields with encrypted-at-rest Yjs state",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-zustand/package.json
+++ b/packages/in-zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-zustand",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Zustand adapter for noy-db — factory that mirrors defineNoydbStore for Zustand users, auto-syncs state from noy-db change events, and supports optimistic mutations.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-email-otp/package.json
+++ b/packages/on-email-otp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-email-otp",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Email OTP second factor for noy-db — generates time-boxed one-time codes, delivers via a user-supplied transport (SMTP / SES / Postmark / any fn), and verifies in constant time. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-magic-link/package.json
+++ b/packages/on-magic-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-magic-link",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Magic-link unlock for noy-db — one-time URL that opens a vault in a viewer-scoped session without a passphrase. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-oidc/package.json
+++ b/packages/on-oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-oidc",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "OAuth/OIDC bridge for noy-db — federated login (LINE, Google, Apple, Okta) with split-key key connector — server never sees plaintext",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-password/package.json
+++ b/packages/on-password/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-password",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Tier-2 password authenticator slot for noy-db. PBKDF2-SHA256 600K wraps the DEK set in its own keyring slot, distinct from the rarely-typed tier-1 phrase. Pair with @noy-db/on-email-otp or @noy-db/on-totp for the SaaS UX.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-pin/package.json
+++ b/packages/on-pin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-pin",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Session-resume PIN quick-lock for noy-db — after a full passphrase unlock, a short-lived PIN (or a per-device biometric) re-unlocks the cached DEKs without re-typing the passphrase. PIN never replaces the passphrase; only resumes an already-unlocked session.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-recovery/package.json
+++ b/packages/on-recovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-recovery",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "One-time printable recovery codes for noy-db — last-resort vault unlock when the passphrase, passkey, and OIDC provider are all unavailable. Base32 + checksum codes, PBKDF2-derived wrapping keys, burn-on-use. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-shamir/package.json
+++ b/packages/on-shamir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-shamir",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "k-of-n Shamir Secret Sharing of the vault KEK for multi-party unlock. Any K of N shares recombines the key; fewer than K leaks zero bits. Composable — each share can be protected by any other on-* method. Zero runtime dependencies.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-threat/package.json
+++ b/packages/on-threat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-threat",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Threat-response primitives for noy-db — multi-attempt lockout, duress-passphrase data destruction, duress-passphrase honeypot decoy. Pure stateful helpers; the caller coordinates keyring + audit-ledger integration. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-totp/package.json
+++ b/packages/on-totp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-totp",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "TOTP (RFC 6238) authenticator-app second factor for noy-db — generate secrets, otpauth:// provisioning URIs, and constant-time code verification. Zero dependencies (HMAC-SHA1 via Web Crypto). Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-webauthn/package.json
+++ b/packages/on-webauthn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-webauthn",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "WebAuthn hardware-key keyrings for noy-db — Touch ID, Face ID, Windows Hello, YubiKey, FIDO2 passkeys",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-aws-dynamo/package.json
+++ b/packages/to-aws-dynamo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-aws-dynamo",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "AWS DynamoDB adapter for noy-db — single-table design, zero-knowledge cloud sync",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-aws-s3/package.json
+++ b/packages/to-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-aws-s3",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "AWS S3 adapter for noy-db — encrypted object storage with zero-knowledge cloud sync",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-aws-s3/src/index.ts
+++ b/packages/to-aws-s3/src/index.ts
@@ -16,9 +16,6 @@
  *
  * ## Limitations
  *
- * - **`casAtomic: false`** — S3 has no server-side conditional write on
- *   arbitrary metadata. Concurrent puts may result in last-write-wins.
- *   Use DynamoDB for records that need conflict-safe writes.
  * - **`loadAll()` is O(N) requests** — listing + fetching every object in a
  *   vault. Suitable for vaults up to ~10K records; beyond that, prefer
  *   DynamoDB for indexed stores and S3 only for append-heavy blob storage.
@@ -39,6 +36,7 @@ import {
   S3Client,
   GetObjectCommand,
   PutObjectCommand,
+  HeadObjectCommand,
   DeleteObjectCommand,
   ListObjectsV2Command,
   HeadBucketCommand,
@@ -53,8 +51,10 @@ import {
  * vaults, use DynamoDB or pair with `routeStore` age-tiering so S3 only
  * holds archived records.
  *
- * Note: S3 does not support atomic CAS (`casAtomic: false`). Last-write-wins
- * on concurrent puts.
+ * S3 supports conditional writes (`IfMatch` / `IfNoneMatch` on `PutObject`),
+ * enabling atomic CAS (`casAtomic: true`). Server clock is read via a sentinel
+ * object's `LastModified` timestamp — store-authoritative, not client wall clock.
+ * ε defaults to 5 000 ms (S3 is NTP-synced; observed skew bound).
  */
 export interface S3Options {
   /** S3 bucket name. */
@@ -69,14 +69,24 @@ export interface S3Options {
    * to share a client across adapters or supply custom middleware.
    */
   client?: S3Client
+  /** Clock uncertainty bound for serverWriteTime (ms). Default: 5000. */
+  clockUncertaintyMs?: number
 }
 
 /**
  * Create an S3 adapter.
  * Key scheme: `{prefix}/{vault}/{collection}/{id}.json`
  */
+function isPreconditionFailed(err: unknown): boolean {
+  if (!(err instanceof Error)) return false
+  if (err.name === 'PreconditionFailed') return true
+  const meta = (err as { $metadata?: { httpStatusCode?: number } }).$metadata
+  return meta?.httpStatusCode === 412
+}
+
 export function s3(options: S3Options): NoydbStore {
   const { bucket, prefix = '' } = options
+  const clockUncertaintyMs = options.clockUncertaintyMs ?? 5_000
 
   const client = options.client ?? new S3Client({
     ...(options.region ? { region: options.region } : {}),
@@ -96,8 +106,32 @@ export function s3(options: S3Options): NoydbStore {
     return prefix ? `${prefix}/${vault}/` : `${vault}/`
   }
 
+  // Sentinel key used solely to sample the store's server clock.
+  const clockKey = prefix ? `${prefix}/_noydb-clock` : '_noydb-clock'
+
   return {
     name: 's3',
+    capabilities: {
+      casAtomic: true,
+      serverWriteTime: true,
+      auth: { kind: 'iam', required: true, flow: 'static' },
+    },
+
+    async getStoreTime() {
+      // Write a sentinel object so S3 assigns a server-authoritative LastModified.
+      await client.send(new PutObjectCommand({
+        Bucket: bucket,
+        Key: clockKey,
+        Body: '',
+        ContentType: 'text/plain',
+      }))
+      const head = await client.send(new HeadObjectCommand({
+        Bucket: bucket,
+        Key: clockKey,
+      }))
+      const serverMs = head.LastModified!.getTime()
+      return { earliest: serverMs - clockUncertaintyMs, latest: serverMs + clockUncertaintyMs }
+    },
 
     async get(vault, collection, id) {
       try {
@@ -118,16 +152,84 @@ export function s3(options: S3Options): NoydbStore {
     },
 
     async put(vault, collection, id, envelope, expectedVersion) {
+      const key = objectKey(vault, collection, id)
+
       if (expectedVersion !== undefined) {
-        const existing = await this.get(vault, collection, id)
-        if (existing && existing._v !== expectedVersion) {
-          throw new ConflictError(existing._v, `Version conflict: expected ${expectedVersion}, found ${existing._v}`)
+        if (expectedVersion === 0) {
+          // Create-only — IfNoneMatch: '*' is atomic at S3's write layer.
+          try {
+            await client.send(new PutObjectCommand({
+              Bucket: bucket,
+              Key: key,
+              Body: JSON.stringify(envelope),
+              ContentType: 'application/json',
+              IfNoneMatch: '*',
+            }))
+          } catch (err: unknown) {
+            if (isPreconditionFailed(err)) {
+              try {
+                const r = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }))
+                const b = await r.Body!.transformToString()
+                const cur = JSON.parse(b) as EncryptedEnvelope
+                throw new ConflictError(cur._v, 'Concurrent create: object already exists')
+              } catch (inner: unknown) {
+                if (inner instanceof ConflictError) throw inner
+              }
+              throw new ConflictError(0, 'Concurrent create: object already exists')
+            }
+            throw err
+          }
+          return
         }
+
+        // Update — GetObject captures ETag + verifies _v, then PutObject with
+        // IfMatch: etag ensures no concurrent writer slipped in between.
+        let currentETag: string
+        try {
+          const result = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }))
+          const body = await result.Body!.transformToString()
+          const current = JSON.parse(body) as EncryptedEnvelope
+          if (current._v !== expectedVersion) {
+            throw new ConflictError(current._v, `Version conflict: expected ${expectedVersion}, found ${current._v}`)
+          }
+          currentETag = result.ETag ?? ''
+        } catch (err: unknown) {
+          if (err instanceof ConflictError) throw err
+          if (err instanceof Error && (err.name === 'NoSuchKey' || err.name === 'NotFound')) {
+            throw new ConflictError(0, `Object not found, expected version ${expectedVersion}`)
+          }
+          throw err
+        }
+
+        try {
+          await client.send(new PutObjectCommand({
+            Bucket: bucket,
+            Key: key,
+            Body: JSON.stringify(envelope),
+            ContentType: 'application/json',
+            IfMatch: currentETag,
+          }))
+        } catch (err: unknown) {
+          if (isPreconditionFailed(err)) {
+            try {
+              const r = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }))
+              const b = await r.Body!.transformToString()
+              const latest = JSON.parse(b) as EncryptedEnvelope
+              throw new ConflictError(latest._v, 'Concurrent write detected')
+            } catch (inner: unknown) {
+              if (inner instanceof ConflictError) throw inner
+            }
+            throw new ConflictError(0, 'Concurrent write detected')
+          }
+          throw err
+        }
+        return
       }
 
+      // Unconditional PUT.
       await client.send(new PutObjectCommand({
         Bucket: bucket,
-        Key: objectKey(vault, collection, id),
+        Key: key,
         Body: JSON.stringify(envelope),
         ContentType: 'application/json',
       }))

--- a/packages/to-browser-idb/package.json
+++ b/packages/to-browser-idb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-browser-idb",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "IndexedDB adapter for noy-db with optional key obfuscation",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-browser-idb/src/index.ts
+++ b/packages/to-browser-idb/src/index.ts
@@ -179,6 +179,11 @@ function createIndexedDBAdapter(prefix: string, obfuscate: boolean, obfKey: stri
   return {
     name: 'browser:indexedDB',
 
+    capabilities: {
+      casAtomic: true,
+      auth: { kind: 'browser-origin' as const, required: false, flow: 'implicit' as const },
+    },
+
     async get(vault, collection, id) {
       const { store } = await tx('readonly')
       const raw = await idbRequest(store.get(key(vault, collection, id)))

--- a/packages/to-browser-local/package.json
+++ b/packages/to-browser-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-browser-local",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "localStorage adapter for noy-db with optional key obfuscation",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-browser-local/src/index.ts
+++ b/packages/to-browser-local/src/index.ts
@@ -24,7 +24,8 @@
  *
  * | Capability | Value |
  * |---|---|
- * | `casAtomic` | `true` — synchronous single-threaded JS |
+ * | `casAtomic` | `false` — single-tab only; cross-tab writes share storage with no serialization |
+ * | `serverWriteTime` | `true` — browser clock; same-tab only |
  * | `listPage` | ✓ — cursor-based pagination |
  * | `ping` | ✓ — round-trips a sentinel key |
  *
@@ -47,6 +48,8 @@ export interface BrowserLocalOptions {
   prefix?: string
   /** Obfuscate storage keys so collection/record names are not readable. Default: false. */
   obfuscate?: boolean
+  /** Clock uncertainty bound (ms). Default: 0. */
+  clockUncertaintyMs?: number
 }
 
 /**
@@ -56,15 +59,16 @@ export interface BrowserLocalOptions {
  * Key scheme (obfuscated): `{prefix}:{hash}:{hash}:{hash}`
  *
  * StoreCapabilities:
- *   casAtomic: true  — localStorage ops are synchronous and inherently atomic
+ *   casAtomic: false — single-tab: synchronous and inherently atomic; cross-tab: no serialization
  *   auth: { kind: 'browser-origin', flow: 'implicit', required: false }
  */
 export function browserLocalStore(options: BrowserLocalOptions = {}): NoydbStore {
   const prefix = options.prefix ?? 'noydb'
   const obfuscate = options.obfuscate ?? false
   const obfKey = obfuscate ? makeObfKey(prefix) : ''
+  const clockEpsilon = options.clockUncertaintyMs ?? 0
 
-  return createLocalStorageAdapter(prefix, obfuscate, obfKey)
+  return createLocalStorageAdapter(prefix, obfuscate, obfKey, clockEpsilon)
 }
 
 // ─── Key Obfuscation ───────────────────────────────────────────────────
@@ -176,7 +180,7 @@ function unwrapValue(raw: string, obfuscate: boolean, obfKey: string): { envelop
 
 // ─── localStorage Backend ──────────────────────────────────────────────
 
-function createLocalStorageAdapter(prefix: string, obfuscate: boolean, obfKey: string): NoydbStore {
+function createLocalStorageAdapter(prefix: string, obfuscate: boolean, obfKey: string, clockEpsilon: number): NoydbStore {
   function key(vault: string, collection: string, id: string): string {
     return `${prefix}:${hashComponent(vault, obfuscate)}:${hashComponent(collection, obfuscate)}:${hashComponent(id, obfuscate)}`
   }
@@ -191,6 +195,16 @@ function createLocalStorageAdapter(prefix: string, obfuscate: boolean, obfKey: s
 
   return {
     name: 'browser:localStorage',
+    capabilities: {
+      casAtomic: false,
+      serverWriteTime: true,
+      auth: { kind: 'browser-origin', required: false, flow: 'implicit' },
+    },
+
+    async getStoreTime() {
+      const now = Date.now()
+      return { earliest: now - clockEpsilon, latest: now + clockEpsilon }
+    },
 
     async get(vault, collection, id) {
       const data = localStorage.getItem(key(vault, collection, id))

--- a/packages/to-cloudflare-d1/package.json
+++ b/packages/to-cloudflare-d1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-cloudflare-d1",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Cloudflare D1 adapter for noy-db — SQLite at the edge, running inside Cloudflare Workers. Accepts a D1Database binding and speaks the noy-db store contract via D1's prepare/bind API.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-cloudflare-d1/src/index.ts
+++ b/packages/to-cloudflare-d1/src/index.ts
@@ -155,6 +155,11 @@ export function d1(options: D1StoreOptions): NoydbStore {
 
   const store: NoydbStore = {
     name: 'cloudflare-d1',
+    capabilities: {
+      casAtomic: true,
+      txAtomic: true,
+      auth: { kind: 'api-key', required: true, flow: 'static' },
+    },
 
     async get(vault, collection, id) {
       await ensureSchema()

--- a/packages/to-cloudflare-r2/__tests__/to-cloudflare-r2.test.ts
+++ b/packages/to-cloudflare-r2/__tests__/to-cloudflare-r2.test.ts
@@ -35,13 +35,13 @@ describe('@noy-db/to-cloudflare-r2', () => {
     expect(() => r2({ accountId: 'acc', bucket: 'b' })).toThrow(/accessKeyId.*secretAccessKey/)
   })
 
-  it('accepts a pre-built client and exposes store.name = "s3"', () => {
+  it('accepts a pre-built client and exposes store.name = "cloudflare-r2"', () => {
     const { client } = mockClient({})
     const store = r2({ bucket: 'b', client })
-    // When client is injected, the returned store is the raw s3() factory
-    // output — keeps the "s3" name so routeStore diagnostics stay
-    // unchanged.
-    expect(store.name).toBe('s3')
+    // Both construction paths (pre-built client and credentials) now wrap
+    // s3() with r2's own identity + capabilities block, so the store always
+    // reports name "cloudflare-r2" — no longer leaking the underlying "s3".
+    expect(store.name).toBe('cloudflare-r2')
   })
 
   it('name is "cloudflare-r2" when constructed with credentials', () => {

--- a/packages/to-cloudflare-r2/package.json
+++ b/packages/to-cloudflare-r2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-cloudflare-r2",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Cloudflare R2 adapter for noy-db — S3-compatible object storage with zero egress fees. Thin wrapper around @noy-db/to-aws-s3 configured for the R2 endpoint. casAtomic: true, serverWriteTime: true.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-cloudflare-r2/package.json
+++ b/packages/to-cloudflare-r2/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@noy-db/to-cloudflare-r2",
   "version": "0.2.0-pre.13",
-  "description": "Cloudflare R2 adapter for noy-db — S3-compatible object storage with zero egress fees. Thin wrapper around @noy-db/to-aws-s3 configured for the R2 endpoint. casAtomic: false (same caveat as S3).",
+  "description": "Cloudflare R2 adapter for noy-db — S3-compatible object storage with zero egress fees. Thin wrapper around @noy-db/to-aws-s3 configured for the R2 endpoint. casAtomic: true, serverWriteTime: true.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",
   "homepage": "https://github.com/vLannaAi/noy-db/tree/main/packages/to-cloudflare-r2#readme",

--- a/packages/to-cloudflare-r2/src/index.ts
+++ b/packages/to-cloudflare-r2/src/index.ts
@@ -3,8 +3,9 @@
  *
  * R2 is S3-API-compatible, so this package is a thin factory that
  * configures `@noy-db/to-aws-s3` to point at the R2 endpoint and
- * pass the R2-specific access key signature. Every capability,
- * behavior, and pagination detail of `s3()` applies verbatim.
+ * pass the R2-specific access key signature. Inherits all capabilities
+ * from `s3()` — `casAtomic: true`, `serverWriteTime: true`, server-clock
+ * sampling via `LastModified`, and `IfMatch`/`IfNoneMatch` conditional CAS.
  *
  * ## Why R2 for noy-db?
  *
@@ -64,6 +65,8 @@ export interface R2Options {
   readonly client?: S3Client
   /** Override the endpoint. Default derived from `accountId`. */
   readonly endpoint?: string
+  /** Clock uncertainty bound for serverWriteTime (ms). Forwarded to s3(). Default: 5000. */
+  clockUncertaintyMs?: number
 }
 
 const R2_REGION = 'auto'
@@ -88,8 +91,17 @@ export function r2(options: R2Options): NoydbStore {
       bucket: options.bucket,
       ...(options.prefix !== undefined && { prefix: options.prefix }),
       client: options.client,
+      ...(options.clockUncertaintyMs !== undefined && { clockUncertaintyMs: options.clockUncertaintyMs }),
     }
-    return s3(opts)
+    return {
+      ...s3(opts),
+      name: 'cloudflare-r2',
+      capabilities: {
+        casAtomic: true,
+        serverWriteTime: true,
+        auth: { kind: 'api-key', required: true, flow: 'static' },
+      },
+    }
   }
 
   if (!options.accountId) {
@@ -114,6 +126,15 @@ export function r2(options: R2Options): NoydbStore {
     bucket: options.bucket,
     ...(options.prefix !== undefined && { prefix: options.prefix }),
     client: built,
+    ...(options.clockUncertaintyMs !== undefined && { clockUncertaintyMs: options.clockUncertaintyMs }),
   }
-  return { ...s3(opts), name: 'cloudflare-r2' }
+  return {
+    ...s3(opts),
+    name: 'cloudflare-r2',
+    capabilities: {
+      casAtomic: true,
+      serverWriteTime: true,
+      auth: { kind: 'api-key', required: true, flow: 'static' },
+    },
+  }
 }

--- a/packages/to-drive/package.json
+++ b/packages/to-drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-drive",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Google Drive bundle store for noy-db. Stores the whole vault as a single .noydb file in Drive's hidden appDataFolder; opaque ULID filenames never leak compartment names. Driver-agnostic — bring your own OAuth token.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-file/package.json
+++ b/packages/to-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-file",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "JSON file adapter for noy-db — encrypted document store on local disk, USB sticks, or network drives",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-file/src/index.ts
+++ b/packages/to-file/src/index.ts
@@ -28,6 +28,7 @@
  * | Capability | Value |
  * |---|---|
  * | `casAtomic` | `false` — no atomic compare-and-swap at the FS layer |
+ * | `serverWriteTime` | `true` — local filesystem clock; solo-writer only |
  * | `listVaults` | ✓ — enumerates subdirectories |
  * | `listPage` | ✓ — cursor-based pagination over sorted filenames |
  * | `ping` | ✓ — `stat(dir)` |
@@ -69,6 +70,8 @@ export interface JsonFileOptions {
   dir: string
   /** Pretty-print JSON files. Default: true. */
   pretty?: boolean
+  /** Clock uncertainty bound (ms). Default: 0. */
+  clockUncertaintyMs?: number
 }
 
 /**
@@ -110,6 +113,17 @@ export function jsonFile(options: JsonFileOptions): NoydbStore {
 
   return {
     name: 'file',
+    capabilities: {
+      casAtomic: false,
+      serverWriteTime: true,
+      auth: { kind: 'filesystem', required: false, flow: 'static' },
+    },
+
+    async getStoreTime() {
+      const now = Date.now()
+      const ε = options.clockUncertaintyMs ?? 0
+      return { earliest: now - ε, latest: now + ε }
+    },
 
     async get(vault, collection, id) {
       const path = recordPath(vault, collection, id)

--- a/packages/to-icloud/package.json
+++ b/packages/to-icloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-icloud",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "iCloud Drive bundle store for noy-db — macOS-aware persistence that detects eviction stubs (.icloud) and conflict files automatically. Treats each vault as a single .noydb bundle, safe for the Apple ecosystem.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-memory/package.json
+++ b/packages/to-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-memory",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "In-memory adapter for noy-db — ideal for testing, development, and ephemeral workloads",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-meter/package.json
+++ b/packages/to-meter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-meter",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Pass-through meter for @noy-db/to-* stores — wraps any NoydbStore and records per-method latency percentiles, error rates, and byte counts on real traffic. Optional synthetic liveness probe emits degraded / restored events. No synthetic benchmarks (see @noy-db/to-probe for that) — this measures what your app is actually doing.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-mysql/package.json
+++ b/packages/to-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-mysql",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "MySQL / MariaDB adapter for noy-db — encrypted-envelope KV with JSON column. Works with any duck-typed mysql2-style pool/connection. casAtomic: true via UPDATE … WHERE v = ?.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-mysql/src/index.ts
+++ b/packages/to-mysql/src/index.ts
@@ -103,6 +103,11 @@ export function mysql(options: MysqlStoreOptions): NoydbStore {
 
   const store: NoydbStore = {
     name: 'mysql',
+    capabilities: {
+      casAtomic: true,
+      txAtomic: true,
+      auth: { kind: 'api-key', required: true, flow: 'static' },
+    },
 
     async get(vault, collection, id) {
       await ensureSchema()

--- a/packages/to-nfs/package.json
+++ b/packages/to-nfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-nfs",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "NFS network-file store for noy-db. Same indexed layout as @noy-db/to-file, with pre-flight checks for nolock / noac mount options that silently break versioning guarantees on stock NFS mounts.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-nfs/src/index.ts
+++ b/packages/to-nfs/src/index.ts
@@ -162,6 +162,10 @@ export function nfs(options: NfsStoreOptions): NoydbStore & { diagnostics(): Pro
 
   return {
     name: 'nfs',
+    capabilities: {
+      casAtomic: false,
+      auth: { kind: 'filesystem', required: false, flow: 'static' },
+    },
     async get(vault, collection, id) {
       return withDiagnostics(() => base.get(vault, collection, id))
     },

--- a/packages/to-postgres/package.json
+++ b/packages/to-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-postgres",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "PostgreSQL adapter for noy-db — encrypted-envelope KV with jsonb column. Works with any duck-typed pg-style Client (node-postgres, postgres.js, pg-native, Supabase, Neon serverless). casAtomic: true via UPDATE … WHERE _v = ?.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-postgres/src/index.ts
+++ b/packages/to-postgres/src/index.ts
@@ -108,6 +108,11 @@ export function postgres(options: PostgresStoreOptions): NoydbStore {
 
   const store: NoydbStore = {
     name: 'postgres',
+    capabilities: {
+      casAtomic: true,
+      txAtomic: true,
+      auth: { kind: 'api-key', required: true, flow: 'static' },
+    },
 
     async get(vault, collection, id) {
       await ensureSchema()

--- a/packages/to-probe/package.json
+++ b/packages/to-probe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-probe",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Diagnostic companion for the @noy-db/to-* store family — not itself a storage backend. Setup-time suitability test + topology check + runtime reliability monitor. Exercises the 6-method NoydbStore contract across five axes (write latency, CAS integrity, hydration cost, sync economics, network resilience) and produces a structured risk-scored report.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-smb/package.json
+++ b/packages/to-smb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-smb",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "SMB/CIFS network file store for noy-db. Works against Windows file servers, NAS devices (Synology/QNAP/Netgear), and corporate shared drives via NTLM or Kerberos auth — no OS mount required.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-smb/src/index.ts
+++ b/packages/to-smb/src/index.ts
@@ -108,6 +108,10 @@ export function smb(options: SmbStoreOptions): NoydbStore {
 
   const store: NoydbStore = {
     name,
+    capabilities: {
+      casAtomic: false,
+      auth: { kind: 'api-key', required: false, flow: 'static' },
+    },
 
     async get(vault, collection, id) {
       const bytes = await client.readFile(recordPath(vault, collection, id))

--- a/packages/to-sqlite/package.json
+++ b/packages/to-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-sqlite",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "SQLite adapter for noy-db — single-file local encrypted document store. Works with better-sqlite3, node:sqlite (Node 22+), or bun:sqlite via a duck-typed Database interface. casAtomic: true (BEGIN IMMEDIATE + UPDATE WHERE _v=?).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-sqlite/src/index.ts
+++ b/packages/to-sqlite/src/index.ts
@@ -151,6 +151,11 @@ export function sqlite(options: SqliteStoreOptions): NoydbStore {
 
   const store: NoydbStore = {
     name: 'sqlite',
+    capabilities: {
+      casAtomic: true,
+      txAtomic: true,
+      auth: { kind: 'none', required: false, flow: 'static' },
+    },
 
     async get(vault, collection, id) {
       const row = db

--- a/packages/to-ssh/package.json
+++ b/packages/to-ssh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-ssh",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "SSH/SFTP store for noy-db — remote encrypted document storage over SSH using public-key auth. Any Linux/macOS server with sshd running becomes a noy-db backend; leverages existing ~/.ssh keys or ssh-agent. Key-only auth (no passwords).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-ssh/src/index.ts
+++ b/packages/to-ssh/src/index.ts
@@ -120,6 +120,10 @@ export function ssh(options: SshStoreOptions): NoydbStore {
 
   const store: NoydbStore = {
     name,
+    capabilities: {
+      casAtomic: false,
+      auth: { kind: 'api-key', required: true, flow: 'static' },
+    },
 
     async get(vault, collection, id) {
       const bytes = await sftp.readFile(recordPath(vault, collection, id))

--- a/packages/to-supabase/package.json
+++ b/packages/to-supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-supabase",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Supabase adapter for noy-db — Postgres + Storage combo. Routes records to @noy-db/to-postgres via the Supabase Postgres pool and optional blob routing via Supabase Storage.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-supabase/src/index.ts
+++ b/packages/to-supabase/src/index.ts
@@ -60,5 +60,13 @@ export interface SupabaseStoreOptions extends Omit<PostgresStoreOptions, 'client
  */
 export function supabase(options: SupabaseStoreOptions): NoydbStore {
   const base = postgres(options)
-  return { ...base, name: 'supabase' }
+  return {
+    ...base,
+    name: 'supabase',
+    capabilities: {
+      casAtomic: true,
+      txAtomic: true,
+      auth: { kind: 'api-key', required: true, flow: 'static' },
+    },
+  }
 }

--- a/packages/to-turso/__tests__/to-turso.test.ts
+++ b/packages/to-turso/__tests__/to-turso.test.ts
@@ -15,6 +15,31 @@ function mockLibsql(): LibsqlClient & { rowMap: Map<string, Row> } {
     const normalized = sql.replace(/\s+/g, ' ').trim().toUpperCase()
     if (normalized.startsWith('CREATE TABLE') || normalized.startsWith('CREATE INDEX')) return { rows: [] }
     if (normalized === 'SELECT 1') return { rows: [{ '1': 1 }] }
+    if (normalized.startsWith('INSERT OR IGNORE INTO')) {
+      // Create-only CAS path (expectedVersion === 0). RETURNING id is empty
+      // when the row already exists (the INSERT is ignored).
+      const [vault, collection, id, v, ts, iv, data, by, tier, elevated_by, det] = args as [
+        string, string, string, number, string, string, string, string | null, number | null, string | null, string | null,
+      ]
+      const k = key(vault, collection, id)
+      if (rowMap.has(k)) return { rows: [] }
+      rowMap.set(k, { vault, collection, id, v, ts, iv, data, by, tier, elevated_by, det })
+      return { rows: [{ id }] }
+    }
+    if (normalized.startsWith('UPDATE')) {
+      // Update-only CAS path. args = [v, ts, iv, data, by, tier, elevated_by,
+      // det, vault, collection, id, expectedVersion]. RETURNING id is empty
+      // when no row matches (missing, or v !== expectedVersion).
+      const [v, ts, iv, data, by, tier, elevated_by, det, vault, collection, id, expectedV] = args as [
+        number, string, string, string, string | null, number | null, string | null, string | null,
+        string, string, string, number,
+      ]
+      const k = key(vault, collection, id)
+      const existing = rowMap.get(k)
+      if (!existing || existing.v !== expectedV) return { rows: [] }
+      rowMap.set(k, { vault, collection, id, v, ts, iv, data, by, tier, elevated_by, det })
+      return { rows: [{ id }] }
+    }
     if (normalized.startsWith('INSERT INTO')) {
       const [vault, collection, id, v, ts, iv, data, by, tier, elevated_by, det] = args as [
         string, string, string, number, string, string, string, string | null, number | null, string | null, string | null,

--- a/packages/to-turso/package.json
+++ b/packages/to-turso/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-turso",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "Turso / libSQL adapter for noy-db — edge SQLite with built-in replication. Wraps @libsql/client through a small async shim that speaks the same noy-db store contract as @noy-db/to-sqlite.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-turso/src/index.ts
+++ b/packages/to-turso/src/index.ts
@@ -42,10 +42,13 @@ export interface TursoStoreOptions {
   readonly client: LibsqlClient
   readonly tableName?: string
   readonly autoMigrate?: boolean
+  /** Clock uncertainty bound for serverWriteTime (ms). Default: 1000. */
+  readonly clockUncertaintyMs?: number
 }
 
 export function turso(options: TursoStoreOptions): NoydbStore {
   const { client, tableName = 'noydb_envelopes', autoMigrate = true } = options
+  const clockUncertaintyMs = options.clockUncertaintyMs ?? 1_000
   let schemaReady: Promise<void> | null = null
 
   async function ensureSchema(): Promise<void> {
@@ -103,16 +106,64 @@ export function turso(options: TursoStoreOptions): NoydbStore {
     expectedVersion?: number,
   ): Promise<void> {
     await ensureSchema()
+
+    const envelopeArgs = [
+      vault, collection, id,
+      envelope._v, envelope._ts, envelope._iv, envelope._data,
+      envelope._by ?? null,
+      envelope._tier ?? null,
+      envelope._elevatedBy ?? null,
+      envelope._det ? JSON.stringify(envelope._det) : null,
+    ] as const
+
     if (expectedVersion !== undefined) {
-      const result = await client.execute({
-        sql: `SELECT v FROM ${tableName} WHERE vault = ? AND collection = ? AND id = ?`,
-        args: [vault, collection, id],
-      })
-      const existing = result.rows[0] as { v: number } | undefined
-      if (existing && existing.v !== expectedVersion) {
-        throw new ConflictError(existing.v, `Version conflict: expected ${expectedVersion}, found ${existing.v}`)
+      if (expectedVersion === 0) {
+        // Create-only: INSERT OR IGNORE — atomic at SQLite's serialized write layer.
+        // RETURNING is empty if the row already existed → ConflictError.
+        const result = await client.execute({
+          sql: `INSERT OR IGNORE INTO ${tableName}
+                  (vault, collection, id, v, ts, iv, data, by, tier, elevated_by, det)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id`,
+          args: envelopeArgs,
+        })
+        if (result.rows.length === 0) {
+          const check = await client.execute({
+            sql: `SELECT v FROM ${tableName} WHERE vault = ? AND collection = ? AND id = ?`,
+            args: [vault, collection, id],
+          })
+          const currentV = (check.rows[0] as { v: number } | undefined)?.v ?? 0
+          throw new ConflictError(currentV, 'Concurrent create: record already exists')
+        }
+        return
       }
+      // Update-only: single atomic UPDATE WHERE v=? — second concurrent writer
+      // sees 0 RETURNING rows after the first writer commits.
+      const result = await client.execute({
+        sql: `UPDATE ${tableName}
+              SET v = ?, ts = ?, iv = ?, data = ?, by = ?, tier = ?, elevated_by = ?, det = ?
+              WHERE vault = ? AND collection = ? AND id = ? AND v = ?
+              RETURNING id`,
+        args: [
+          envelope._v, envelope._ts, envelope._iv, envelope._data,
+          envelope._by ?? null,
+          envelope._tier ?? null,
+          envelope._elevatedBy ?? null,
+          envelope._det ? JSON.stringify(envelope._det) : null,
+          vault, collection, id, expectedVersion,
+        ],
+      })
+      if (result.rows.length === 0) {
+        const check = await client.execute({
+          sql: `SELECT v FROM ${tableName} WHERE vault = ? AND collection = ? AND id = ?`,
+          args: [vault, collection, id],
+        })
+        const currentV = (check.rows[0] as { v: number } | undefined)?.v ?? 0
+        throw new ConflictError(currentV, `Version conflict: expected ${expectedVersion}`)
+      }
+      return
     }
+
+    // Unconditional upsert — no version guard.
     await client.execute({
       sql:
         `INSERT INTO ${tableName} (vault, collection, id, v, ts, iv, data, by, tier, elevated_by, det)
@@ -120,19 +171,24 @@ export function turso(options: TursoStoreOptions): NoydbStore {
          ON CONFLICT(vault, collection, id) DO UPDATE SET
            v = excluded.v, ts = excluded.ts, iv = excluded.iv, data = excluded.data,
            by = excluded.by, tier = excluded.tier, elevated_by = excluded.elevated_by, det = excluded.det`,
-      args: [
-        vault, collection, id,
-        envelope._v, envelope._ts, envelope._iv, envelope._data,
-        envelope._by ?? null,
-        envelope._tier ?? null,
-        envelope._elevatedBy ?? null,
-        envelope._det ? JSON.stringify(envelope._det) : null,
-      ],
+      args: envelopeArgs,
     })
   }
 
   const store: NoydbStore = {
     name: 'turso',
+    capabilities: {
+      casAtomic: true,
+      serverWriteTime: true,
+      auth: { kind: 'api-key', required: true, flow: 'static' },
+    },
+
+    async getStoreTime() {
+      const result = await client.execute("SELECT unixepoch('now','subsec') AS t")
+      const seconds = parseFloat(result.rows[0]!.t as string)
+      const ms = Math.round(seconds * 1_000)
+      return { earliest: ms - clockUncertaintyMs, latest: ms + clockUncertaintyMs }
+    },
 
     async get(vault, collection, id) {
       await ensureSchema()

--- a/packages/to-webdav/package.json
+++ b/packages/to-webdav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-webdav",
-  "version": "0.2.0-pre.13",
+  "version": "0.2.0-pre.14",
   "description": "WebDAV adapter for noy-db — encrypted object storage over the WebDAV protocol. Works with Nextcloud, ownCloud, Apache mod_dav, and any RFC 4918 server. Pure fetch()-based, zero dependencies.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-webdav/src/index.ts
+++ b/packages/to-webdav/src/index.ts
@@ -150,6 +150,10 @@ export function webdav(options: WebDAVStoreOptions): NoydbStore {
 
   const store: NoydbStore = {
     name: 'webdav',
+    capabilities: {
+      casAtomic: false,
+      auth: { kind: 'api-key', required: false, flow: 'static' },
+    },
 
     async get(vault, collection, id) {
       const res = await fetchImpl(urlFor(vault, collection, id), {


### PR DESCRIPTION
Unified **0.2.0-pre.14** lockstep release (all 66 publishable packages).

## What's in it

### 1. Store capabilities audit — `serverWriteTime` + true CAS (#271)
Wires `serverWriteTime` / `getStoreTime()` and corrects the `casAtomic` capability across the non-CAS store adapters (15 `to-*` packages). This is the adapter-side foundation for `withDeferredNumbering` (shipped in pre.13) to select the right numbering engine per backend.

### 2. crossShardJoin — co-partitioned + broadcast dimension join (#271, milestone 16)
A new federation primitive on `ShardedQuery`, closing one of the remaining multi-vault partition federation items:

- **`crossShardJoin(field, { as })`** — *co-partitioned* join: each shard joins its left collection against the **same shard's** right collection (resolved via a declared `ref()`), then results union. Reuses the existing intra-vault `.join()` executor per shard — same vault, same DEK.
- **`broadcastJoin(field, { as, from, on?, mode? })`** — *broadcast dimension* join: enriches every merged row from a **single shared collection** (a dimension table in another vault), loaded once and attached centrally.

**Design boundaries (deliberate):**
- `join.ts` and its `partitionScope` seam are **untouched** — `resolveEligible` already does shard selection at the fan-out layer; the seam was superseded.
- Stays a programmatic API — the `in-sql` `JOIN` keyword remains same-vault.
- `.live()` / `.aggregate()` / `.groupBy()` on a joined query **throw** in v1 (reactive cross-shard joins deferred) rather than silently dropping legs.
- Failure semantics: shard throw → `skippedVault`; dangling ref → per-shard `RefMode`; undeclared ref → single `CrossShardJoinError`; broadcast miss → null + one-shot warn.

Spec: `docs/superpowers/specs/2026-06-09-cross-shard-join-design.md`
Plan: `docs/superpowers/plans/2026-06-09-cross-shard-join.md`

## Verification (local)
- Repo-wide `typecheck` ✓ (127 tasks) · `lint` ✓ (124 tasks) · `check:architecture` ✓ · `validate:features` ✓
- Full hub suite ✓ (245 files, 2357 tests) — incl. 16 new cross-shard-join tests