### PR TITLE
test(stores): permanent S3/R2 CAS unit coverage

### DIFF
--- a/packages/to-aws-s3/__tests__/cas.test.ts
+++ b/packages/to-aws-s3/__tests__/cas.test.ts
@@ -1,0 +1,135 @@
+/**
+ * CAS (compare-and-swap) unit tests for the `casAtomic: true` capability.
+ *
+ * `to-aws-s3` (and `to-cloudflare-r2`, which inherits this `put` via
+ * `...s3(opts)`) implement atomic CAS on top of S3 conditional writes:
+ *   - create-only  → `PutObject` with `IfNoneMatch: '*'`
+ *   - update       → `GetObject` (read `_v` + ETag) then `PutObject` with
+ *                    `IfMatch: <etag>`
+ *   - a 412 PreconditionFailed on either path becomes a `ConflictError`.
+ *
+ * These tests exercise every CAS branch against a fake S3 that faithfully
+ * models `IfNoneMatch`/`IfMatch`/412 semantics — including a concurrent
+ * writer slipping in between the store's internal Get and Put (the case
+ * that proves the final `IfMatch` guard, not just the read-check, is what
+ * makes the swap atomic). The real-service equivalent ran against live
+ * S3 + R2 during the pre.14 release; this is the permanent regression net.
+ */
+import { describe, it, expect } from 'vitest'
+import type { S3Client } from '@aws-sdk/client-s3'
+import { ConflictError } from '@noy-db/hub'
+import type { EncryptedEnvelope } from '@noy-db/hub'
+import { s3 } from '../src/index.js'
+
+interface Hooks {
+  /** Fired after each GetObjectCommand is served, with the object key. Lets a
+   *  test inject a concurrent write between the store's internal Get and Put. */
+  afterGet?: (key: string) => void
+}
+
+/** Fake S3 modelling IfNoneMatch / IfMatch / 412 + string bodies. */
+function fakeS3(hooks: Hooks = {}): { client: S3Client; objects: Map<string, { body: string; etag: string }> } {
+  const objects = new Map<string, { body: string; etag: string }>()
+  let etagSeq = 0
+  const precondition = () => {
+    const e = new Error('PreconditionFailed')
+    e.name = 'PreconditionFailed'
+    ;(e as { $metadata?: unknown }).$metadata = { httpStatusCode: 412 }
+    return e
+  }
+  const client = {
+    async send(command: unknown) {
+      const name = (command as { constructor: { name: string } }).constructor.name
+      const input = (command as { input: Record<string, unknown> }).input
+      const key = input.Key as string
+      if (name === 'GetObjectCommand') {
+        const obj = objects.get(key)
+        if (!obj) { const e = new Error('NoSuchKey'); e.name = 'NoSuchKey'; throw e }
+        // Snapshot the ETag NOW — a concurrent write injected via afterGet
+        // must not retroactively change what this caller already read.
+        const snapshot = { ETag: `"${obj.etag}"`, Body: { async transformToString() { return obj.body } } }
+        hooks.afterGet?.(key)
+        return snapshot
+      }
+      if (name === 'PutObjectCommand') {
+        const current = objects.get(key)
+        const ifNoneMatch = input.IfNoneMatch as string | undefined
+        const ifMatch = input.IfMatch as string | undefined
+        if (ifNoneMatch === '*' && current) throw precondition()
+        if (ifMatch !== undefined && (!current || `"${current.etag}"` !== ifMatch)) throw precondition()
+        const etag = `e${++etagSeq}`
+        objects.set(key, { body: input.Body as string, etag })
+        return { ETag: `"${etag}"` }
+      }
+      if (name === 'DeleteObjectCommand') { objects.delete(key); return {} }
+      throw new Error(`unexpected command ${name}`)
+    },
+  } as unknown as S3Client
+  return { client, objects }
+}
+
+function env(v: number): EncryptedEnvelope {
+  return { _noydb: 1, _v: v, _ts: new Date(1700000000000 + v * 1000).toISOString(), _iv: 'aaaaaaaaaaaaaaaa', _data: `ct-${v}`, _by: 'alice' }
+}
+
+describe('to-aws-s3 CAS (casAtomic)', () => {
+  it('declares casAtomic: true', () => {
+    const { client } = fakeS3()
+    const store = s3({ bucket: 'b', client })
+    expect(store.capabilities?.casAtomic).toBe(true)
+  })
+
+  it('create-only (expectedVersion 0): first write succeeds, second throws ConflictError', async () => {
+    const { client, objects } = fakeS3()
+    const store = s3({ bucket: 'b', client })
+    await store.put('v', 'c', 'id', env(1), 0)
+    expect(objects.size).toBe(1)
+    await expect(store.put('v', 'c', 'id', env(1), 0)).rejects.toBeInstanceOf(ConflictError)
+  })
+
+  it('update: matching expectedVersion succeeds and bumps the stored version', async () => {
+    const { client } = fakeS3()
+    const store = s3({ bucket: 'b', client })
+    await store.put('v', 'c', 'id', env(1), 0)
+    await store.put('v', 'c', 'id', env(2), 1)
+    expect((await store.get('v', 'c', 'id'))?._v).toBe(2)
+  })
+
+  it('update: stale expectedVersion throws ConflictError without writing', async () => {
+    const { client } = fakeS3()
+    const store = s3({ bucket: 'b', client })
+    await store.put('v', 'c', 'id', env(1), 0)
+    await store.put('v', 'c', 'id', env(2), 1) // now at v=2
+    await expect(store.put('v', 'c', 'id', env(3), 1)).rejects.toBeInstanceOf(ConflictError)
+    expect((await store.get('v', 'c', 'id'))?._v).toBe(2) // unchanged
+  })
+
+  it('update: missing key throws ConflictError', async () => {
+    const { client } = fakeS3()
+    const store = s3({ bucket: 'b', client })
+    await expect(store.put('v', 'c', 'ghost', env(2), 1)).rejects.toBeInstanceOf(ConflictError)
+  })
+
+  it('update: a concurrent writer between Get and Put trips the IfMatch guard → ConflictError', async () => {
+    const hooks: Hooks = {}
+    const { client, objects } = fakeS3(hooks)
+    const store = s3({ bucket: 'b', client })
+    await store.put('v', 'c', 'id', env(1), 0)
+    // Inject exactly one concurrent write the next time the store reads this
+    // key: bump the stored ETag so the IfMatch the store captured is stale.
+    hooks.afterGet = (key) => {
+      const o = objects.get(key)!
+      objects.set(key, { body: o.body, etag: `${o.etag}-concurrent` })
+      hooks.afterGet = undefined
+    }
+    await expect(store.put('v', 'c', 'id', env(2), 1)).rejects.toBeInstanceOf(ConflictError)
+  })
+
+  it('unconditional put (no expectedVersion) overwrites', async () => {
+    const { client } = fakeS3()
+    const store = s3({ bucket: 'b', client })
+    await store.put('v', 'c', 'id', env(1))
+    await store.put('v', 'c', 'id', env(9))
+    expect((await store.get('v', 'c', 'id'))?._v).toBe(9)
+  })
+})

--- a/packages/to-cloudflare-r2/__tests__/to-cloudflare-r2.test.ts
+++ b/packages/to-cloudflare-r2/__tests__/to-cloudflare-r2.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { S3Client } from '@aws-sdk/client-s3'
+import { ConflictError } from '@noy-db/hub'
+import type { EncryptedEnvelope } from '@noy-db/hub'
 import { r2, r2EndpointFor } from '../src/index.js'
 
 function mockClient(handlers: Record<string, (input: unknown) => unknown>): {
@@ -67,5 +69,40 @@ describe('@noy-db/to-cloudflare-r2', () => {
     await store.get('v1', 'c1', 'r1')
     await store.delete('v1', 'c1', 'r1')
     expect(sent.map(c => c.name)).toEqual(['PutObjectCommand', 'GetObjectCommand', 'DeleteObjectCommand'])
+  })
+})
+
+// R2 inherits the CAS `put` from `s3()` via `...s3(opts)`. The full CAS
+// branch matrix is covered in @noy-db/to-aws-s3's cas.test.ts; here we
+// just prove R2 declares the capability and reaches the conditional-write
+// path (IfNoneMatch '*' → 412 → ConflictError) through `r2()`.
+describe('@noy-db/to-cloudflare-r2 CAS', () => {
+  const env = (v: number): EncryptedEnvelope => ({ _noydb: 1, _v: v, _ts: 't', _iv: 'a', _data: `d${v}` })
+
+  it('declares casAtomic: true', () => {
+    const { client } = mockClient({})
+    const store = r2({ bucket: 'b', client })
+    expect(store.capabilities?.casAtomic).toBe(true)
+  })
+
+  it('create-only conflict surfaces as ConflictError through r2()', async () => {
+    let exists = false
+    const { client } = mockClient({
+      PutObjectCommand: (input) => {
+        const ifNoneMatch = (input as { IfNoneMatch?: string }).IfNoneMatch
+        if (ifNoneMatch === '*' && exists) {
+          const e = new Error('PreconditionFailed')
+          e.name = 'PreconditionFailed'
+          ;(e as { $metadata?: unknown }).$metadata = { httpStatusCode: 412 }
+          throw e
+        }
+        exists = true
+        return { ETag: '"e1"' }
+      },
+      GetObjectCommand: () => ({ ETag: '"e1"', Body: { async transformToString() { return JSON.stringify(env(1)) } } }),
+    })
+    const store = r2({ bucket: 'b', client })
+    await store.put('v', 'c', 'id', env(1), 0)
+    await expect(store.put('v', 'c', 'id', env(1), 0)).rejects.toBeInstanceOf(ConflictError)
   })
 })


### PR DESCRIPTION
Closes the coverage gap flagged at the pre.14 release: the `casAtomic: true` flip on `to-aws-s3` / `to-cloudflare-r2` had **no unit test** — it was validated only by a one-off real-cloud gate (deleted after the release).

## What's added
- **`to-aws-s3/__tests__/cas.test.ts`** — every CAS branch against a fake S3 modelling `IfNoneMatch` / `IfMatch` / 412:
  - `casAtomic: true` declared
  - create-only (`expectedVersion: 0`): first write OK, second → `ConflictError`
  - update with matching version → OK + bump; stale version → `ConflictError` (no write); missing key → `ConflictError`
  - **concurrent writer between Get and Put** → `IfMatch` 412 → `ConflictError` (proves the conditional PUT, not just the read-check, makes the swap atomic)
  - unconditional put overwrites
- **`to-cloudflare-r2`** — R2 inherits `put()` via `...s3(opts)`; a focused test proves it declares the capability and reaches the conditional-write path (`IfNoneMatch '*'` → 412 → `ConflictError`) through `r2()`.

Test-only — **no version bump**; rides the next release.