### PR TITLE
feat(hub): fast-lane the niwat AU series + union-MV money bug (#342–#350)

### DIFF
--- a/docs/superpowers/specs/2026-06-08-immutable-guard-design.md
+++ b/docs/superpowers/specs/2026-06-08-immutable-guard-design.md
@@ -36,6 +36,28 @@ Generates a `withGuard` spec:
 
 `appendOnly: true` ⇒ `isImmutable = () => true`: a record is immutable from creation, so any post-insert update or delete is blocked.
 
+## `amendmentInvariant` — keep a constraint inviolable under amendment (#349)
+
+By default the generated `amendment.invariant` is an empty allow — the amendment IS the sanctioned, ledgered override. Some collections need a constraint that holds *even under amendment* (e.g. an issued document may be corrected but never deleted, or a cross-record sum must stay balanced through a repair). Rather than dropping back to a hand-rolled `withGuard`, `immutableGuard` now accepts an optional `amendmentInvariant`:
+
+```ts
+immutableGuard<Invoice>({
+  collection: 'invoices',
+  after: (r) => r.status === 'issued',
+  amendmentInvariant: (changes, ctx) => {
+    for (const c of changes) {
+      if (c.before !== null && c.after === null) {
+        throw new InvariantError('issued invoices cannot be deleted, even by amendment')
+      }
+    }
+  },
+})
+```
+
+- **Signature** matches `GuardStrategy.amendment.invariant` exactly: `(changes: ReadonlyArray<GuardChange<T>>, ctx: GuardContext<T>) => Promise<void> | void`.
+- **Wiring** — `invariant: amendmentInvariant ?? (() => { /* allow */ })`. **Omitting it preserves the prior empty-allow behavior** (backward-compatible, additive).
+- **Errors** — a throw is wrapped by the guard executor into `InvariantError` and reverts the whole amendment (the standard amendment-invariant rollback path); no other call site changes.
+
 ## Composition
 
 - **periods / history:** unchanged — `immutableGuard` is an ordinary guard, so it composes with the period-close gate and history exactly as a hand-written guard would.

--- a/docs/superpowers/specs/2026-06-13-tx-commit-invariants-design.md
+++ b/docs/superpowers/specs/2026-06-13-tx-commit-invariants-design.md
@@ -1,0 +1,100 @@
+# Commit-time changeset invariants for ordinary transactions
+
+**Issue:** #342 (AU+026) · **Layer:** Transactions · **Cluster:** au-series-pre16.
+
+## Problem
+
+The hub has exactly one set-level invariant hook today: `amendment.invariant`. It fires only inside `db.transaction({ amendment: true, reason }, …)`, requires an admin/owner role, and requires a registered guard. That is the correct shape for the WORM-override path — but ordinary application transactions also need cross-record invariants that must hold on *every* commit. niwat's `assertR1` ("every payment is 100% receipted") is the motivating case: it is a normal-write constraint, not an amendment override, and there is no hook for it.
+
+## Goal
+
+`withTransactions({ invariants: [{ scope, check }] })` — commit-time, set-level invariants that fire for **normal** `db.transaction(fn)` calls (and amendments), with no role gate and no guard requirement. Each invariant names a collection `scope` and a `check(changes, ctx)` callback that receives the commit's change-set for that scope; a throw reverts the whole transaction.
+
+## API
+
+```ts
+// tx/invariants.ts
+export interface TransactionInvariant {
+  readonly scope: string  // collection name
+  check: (
+    changes: ReadonlyArray<GuardChange<unknown>>,
+    ctx: GuardContext<unknown>,
+  ) => Promise<void> | void
+}
+
+// tx/active.ts
+export interface TransactionStrategyOptions {
+  invariants?: ReadonlyArray<TransactionInvariant>
+}
+export function withTransactions(opts?: TransactionStrategyOptions): TxStrategy
+
+// usage
+createNoydb({ txStrategy: withTransactions({
+  invariants: [{
+    scope: 'payments',
+    check(changes) {
+      for (const { after } of changes) {
+        const p = after as Payment | null
+        if (p && p.receiptAmount !== p.amount) throw new InvariantError('R1')
+      }
+    },
+  }],
+}) })
+```
+
+`TransactionInvariant` reuses the existing `GuardChange<T>` / `GuardContext<T>` shapes (erased to `unknown`) so an invariant author sees the same `{ before, after }` / `{ existing, vault, userId, role }` surface a guard amendment invariant sees.
+
+## Behavior
+
+**Changeset assembly.** From `ctx._ops`, dedup to the **last write per `(vault, coll, id)`** while preserving first-seen (write) order. For each deduped op in a watched scope build `GuardChange{ before, after }`: `before` is the plaintext prior record (null on insert), `after` is the written record (`op.record`), or `null` on delete. Group by `scope` (collection name).
+
+**Scope.** An invariant fires only when its `scope` has at least one change in the commit. `watchedScopes = new Set(invariants.map(i => i.scope))` keeps Phase-1 capture and grouping cheap.
+
+**Phase-1 before-capture.** `priorEnvelopes` holds *encrypted* envelopes; invariants need *plaintext* `before`. So in Phase 1, for any op whose collection is a watched scope, we additionally read the decrypted prior via `db.vault(v).collection(c).get(id)` into a `plainBefore` map **before** Phase 2 overwrites it. Snapshots only the initial committed state per key, matching the envelope snapshot.
+
+**Ordering vs the amendment phase.** The invariant phase runs **after** the amendment commit phase, so it applies to ordinary AND amendment transactions — an amendment is still a commit and is still subject to these set-level constraints. (Independent of `ctx._amendment`; gated only on `invariants.length > 0`.)
+
+**Context.** Per invariant, the watched scope's vault provides the ctx: `vault: v._getReadOnlyFacade() ?? <minimal read-only stub>`, `userId: v.userId`, `role: v.role`, `existing: null` (a per-record concept that doesn't apply to a set-level check — invariants get the full change-set in their first parameter).
+
+## Errors + rollback
+
+A throw from any `check` mirrors the amendment-phase failure mode exactly:
+
+```ts
+catch (err) {
+  await revertExecuted(ctx._executed, store, db)
+  throw err instanceof InvariantError ? err : new InvariantError(
+    err instanceof Error ? err.message : `invariant violated: ${String(err)}`,
+  )
+}
+```
+
+`revertExecuted` unwinds every executed op (main staged ops + nested derivation side-effects) in reverse via the raw store, then rethrows. An `InvariantError` thrown by the check passes through unwrapped; any other throw is wrapped.
+
+## Composition
+
+- **Amendment.** Additive and orthogonal. A guard `amendment.invariant` may allow a change that a tx invariant then rejects (and vice versa) — both must pass for an amendment to commit. The tx-invariant phase runs strictly after the amendment phase.
+- **Guards / periods / history / derivations.** Unchanged. Tx invariants are a commit-phase concern layered on top of Phase 2; per-op side effects (history snapshots, ledger entries, change events, eager derivations) have already fired by the time invariants run, and roll back together with the source ops on a throw.
+- **Dry-run.** `runDryRun` does not execute Phase 2 and so does not run tx invariants.
+
+## Errors + boundaries
+
+- No kernel-surface change: `index.ts`, `vault.ts`, `collection.ts` are untouched. All code lives under `tx/` (a lazy subpath chunk) + the `GuardChange`/`GuardContext` types it reuses.
+- The extra Phase-1 plaintext read is incurred **only** for ops in a watched scope — zero overhead when `invariants` is empty (the common path).
+
+## Testing
+
+- Passing invariant → tx commits.
+- Throwing invariant → `InvariantError` + ALL writes rolled back (bad record absent; a prior valid record unchanged).
+- `before`/`after` correctness: insert → `before` null; update → `before` is the prior record.
+- An invariant whose scope wasn't touched is not called.
+- Additive with amendment: an amendment tx still runs the invariant (and a violating amendment is reverted even when the guard amendment invariant would allow it).
+
+## Build sequence
+
+1. `tx/invariants.ts` — `TransactionInvariant`.
+2. `tx/active.ts` — `TransactionStrategyOptions` + `withTransactions(opts)` capturing/forwarding `invariants`.
+3. `tx/strategy.ts` — 4th `txInvariants?` param on `TxStrategy.runTransaction` (+ `NO_TX` stub).
+4. `tx/transaction.ts` — 4th param; Phase-1 `plainBefore` capture; post-amendment invariant phase.
+5. `tx/index.ts` + main barrel — export `TransactionInvariant` / `TransactionStrategyOptions`.
+6. Tests + features.yaml entry.

--- a/features.yaml
+++ b/features.yaml
@@ -108,6 +108,7 @@ features:
     invariants:
       - 'Standard Schema v1 — Zod, Valibot, ArkType, Effect Schema compatible'
       - 'Validation runs before encryption (write) and after decryption (read)'
+      - 'cascade-delete (ref mode "cascade") is transaction-atomic (#346): cascaded child deletes register on the active TxContext (_executed) and roll back with the parent on mid-batch failure; outside a tx, children + parent delete in place as before'
     related: [vault-and-collections]
 
   - id: money-field
@@ -252,6 +253,8 @@ features:
       - 'independent per-name sequences; peek() reads without allocating'
       - 'online-only: next() throws SequenceOfflineError unless store capabilities.casAtomic'
       - 'jittered backoff; SequenceContentionError after the retry budget so callers can retry/queue'
+      - 'partitioned counters (#345): vault.sequence(series, { partition: [...] }) keys an independent counter per partition; storage key = series + null-byte separator + URI-encoded "/"-joined parts, provably disjoint from plain series keys (null byte rejected in a series name)'
+      - 'seedTo(n) (#345): set-if-greater on the handle — advances to at least n, never rewinds; idempotent + CAS-safe under concurrent next()/seedTo(); fixes bundle/CSV-import counter restart-at-0; online-only (SequenceOfflineError on non-CAS; ValidationError on a deferred series)'
     related: [stores-contract, query-basics]
 
   - id: deferred-numbering
@@ -665,6 +668,9 @@ features:
     invariants:
       - 'runTransaction(db, fn) buffers writes; rollback on throw'
       - 'casAtomic stores: genuine atomicity. casAtomic:false: ordered-with-rollback'
+      - 'commit-time changeset invariants (#342): withTransactions({ invariants: [{ scope, check(changes, ctx) }] }) — set-level invariants fire at commit for ordinary db.transaction() (and amendments), no role gate; generalizes amendment.invariant'
+      - 'invariant changes = ReadonlyArray<GuardChange> for the scope (collection): before = plaintext prior (null on insert), after = written record (null on delete); plaintext before captured in Phase 1 before Phase 2 overwrites'
+      - 'a throw in check() reverts the whole tx via revertExecuted and surfaces as InvariantError; an untouched scope is skipped'
     related: [vault-and-collections]
 
   - id: derivations
@@ -687,6 +693,7 @@ features:
       - '_derivedFrom lives in encrypted payload, not unencrypted envelope'
       - 'strict: true rolls back source write on output failure inside withTransactions'
       - 'cycle detection at vault open — refuses cyclic graphs'
+      - 'declared sibling sources (#344): withDerivation({ source, sources: [...] }) re-fires the derivation on writes to any declared sibling, using the PRIMARY source record at the SAME id (silent no-op if no primary record exists there); siblings are indexed in _bySource, participate in cycle detection, and fold into the strategy hash; sources[] entries must be non-empty and != source'
     related: [guards, transactions]
 
   - id: materialized-views
@@ -725,6 +732,8 @@ features:
       - 'query callback may use multi-key groupBy(...fields); rowKey composites the grouped fields into a stable id'
       - 'UNION mode (unionSources): reads from ≥1 sibling collection; per-source map projects to MV row shape; groupBy + aggregate run on concatenated stream'
       - 'single-arm union (#331): map→group→aggregate over ONE collection with a COMPUTED bucket key (e.g. month sliced from a date) — the query form groupBy takes stored field names only; empty unionSources still throws'
+      - 'UNION money aggregation (#350): spec.moneyFields (keyed by the mapped/aggregated field) rewrites sum/min/max over those fields into exact BigInt reducers, matching the query-form path; arm map() emits DECODED canonical decimal strings, and the money reducer now parses both stored-int and decimal forms; moneyFields without aggregate throws MaterializedViewConfigError; folded into queryHash'
+      - 'UNION arm join (#347): each UnionSource may declare join[] (field/as) to attach right-side records under an alias before map() runs (same ref()-driven resolution as query-form .join()); right-side collections must be listed in sources[] for refresh tracking, else MaterializedViewConfigError; join legs fold into queryHash'
     related: [derivations, overlay-views, transactions, guards]
 
   - id: overlay-views
@@ -742,7 +751,8 @@ features:
     playground_pages: []
     diagrams: []
     invariants:
-      - 'reads merge base + overlay via single-field shadow predicate; no callback / field-level merge'
+      - 'reads merge base + overlay via single-field shadow predicate; overlay wins entirely iff overlay[shadowField] === shadowValue (binary default — unchanged when mergeMode absent)'
+      - 'field-level merge (#348, mergeMode.kind === "field-merge"): rules evaluated in declaration order, first matching whenStatus wins; the matched rule pulls its overlayFields (those present on the overlay row) over the base row, all other fields from base; the binary shadowValue check is always the implicit highest-priority rule applied first; an overlay-only row matching neither shadowValue nor any rule with no base is not surfaced'
       - 'writes through virtual collection route to overlay collection (base untouched)'
       - 'base must be concrete (real source or MV output); not another overlay'
       - 'overlay collection must be vault-known and not an MV output'
@@ -788,6 +798,7 @@ features:
       - 'after(record) is evaluated on the EXISTING record: inserts + the transition write are allowed; subsequent updates/deletes throw RecordLockedError'
       - 'appendOnly: true == after: () => true (immutable from creation)'
       - 'amendment override (admin|owner) skips check/onDelete and is ledgered, via the standard guard amendment path'
+      - 'amendmentInvariant (#349): optional; when supplied, wires a real constraining invariant (matching GuardStrategy.amendment.invariant) into the amendment path so a constraint stays inviolable even under amendment; default omitted = empty-allow override (backward compatible)'
     related: [guards, transactions]
 
   - id: bundle

--- a/packages/hub/__tests__/derivations/sibling-sources.test.ts
+++ b/packages/hub/__tests__/derivations/sibling-sources.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withDerivation, DerivationCycleError } from '../../src/index.js'
+import { ValidationError } from '../../src/errors.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+// The accounting same-id shape (#344): an `invoice` row and its `fx`
+// rate row share an id. The derivation's primary source is `invoice`,
+// but it reads the sibling `fx` rate to compute a converted total.
+// Declaring `sources: ['fx']` makes an fx write at the same id re-fire
+// the derivation against the primary invoice record.
+interface Invoice extends Record<string, unknown> { id: string; amount: number }
+interface Fx extends Record<string, unknown> { id: string; rate: number }
+interface Converted extends Record<string, unknown> { id: string; total: number; _derivedFrom?: unknown }
+
+describe('Derivation — declared sibling sources[] (#344)', () => {
+  it('(1) a write to a declared sibling re-fires derive against the primary source', async () => {
+    const strategy = withDerivation<Invoice, { converted: Converted }>({
+      source: 'invoices',
+      sources: ['fx'],
+      deterministic: true,
+      outputs: { converted: { shape: 'record', collection: 'converted' } },
+      derive: async (invoice, ctx) => {
+        const fx = await ctx.vault.collection<Fx>('fx').get(invoice.id)
+        return { converted: { id: invoice.id, total: invoice.amount * (fx?.rate ?? 1) } }
+      },
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-sibling-rerun-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+
+    await v.collection<Invoice>('invoices').put('i1', { id: 'i1', amount: 100 })
+    // First derive ran with no fx → rate defaults to 1.
+    expect((await v.collection<Converted>('converted').get('i1'))?.total).toBe(100)
+
+    // A write to the sibling `fx` at the SAME id must re-fire the
+    // derivation; the output reflects the new sibling state.
+    await v.collection<Fx>('fx').put('i1', { id: 'i1', rate: 1.25 })
+    expect((await v.collection<Converted>('converted').get('i1'))?.total).toBe(125)
+  })
+
+  it('(2) a write to the primary source still re-fires', async () => {
+    const strategy = withDerivation<Invoice, { converted: Converted }>({
+      source: 'invoices',
+      sources: ['fx'],
+      deterministic: true,
+      outputs: { converted: { shape: 'record', collection: 'converted' } },
+      derive: async (invoice, ctx) => {
+        const fx = await ctx.vault.collection<Fx>('fx').get(invoice.id)
+        return { converted: { id: invoice.id, total: invoice.amount * (fx?.rate ?? 1) } }
+      },
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-sibling-primary-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+
+    await v.collection<Fx>('fx').put('i1', { id: 'i1', rate: 2 })
+    await v.collection<Invoice>('invoices').put('i1', { id: 'i1', amount: 50 })
+    expect((await v.collection<Converted>('converted').get('i1'))?.total).toBe(100)
+
+    await v.collection<Invoice>('invoices').put('i1', { id: 'i1', amount: 70 })
+    expect((await v.collection<Converted>('converted').get('i1'))?.total).toBe(140)
+  })
+
+  it('(3) sibling write with no primary record at that id is a silent no-op', async () => {
+    const strategy = withDerivation<Invoice, { converted: Converted }>({
+      source: 'invoices',
+      sources: ['fx'],
+      deterministic: true,
+      outputs: { converted: { shape: 'record', collection: 'converted' } },
+      derive: async (invoice, ctx) => {
+        const fx = await ctx.vault.collection<Fx>('fx').get(invoice.id)
+        return { converted: { id: invoice.id, total: invoice.amount * (fx?.rate ?? 1) } }
+      },
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-sibling-noprimary-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+
+    // No invoice at 'orphan' — the sibling write must not throw, and
+    // must not synthesise any output.
+    await expect(
+      v.collection<Fx>('fx').put('orphan', { id: 'orphan', rate: 3 }),
+    ).resolves.not.toThrow()
+    expect(await v.collection<Converted>('converted').get('orphan')).toBeNull()
+  })
+
+  it('(4) lazy lifecycle: a sibling write marks stale, resolve-on-read re-derives', async () => {
+    const strategy = withDerivation<Invoice, { converted: Converted }>({
+      source: 'invoices',
+      sources: ['fx'],
+      deterministic: true,
+      outputs: { converted: { shape: 'record', collection: 'converted' } },
+      derive: async (invoice, ctx) => {
+        const fx = await ctx.vault.collection<Fx>('fx').get(invoice.id)
+        return { converted: { id: invoice.id, total: invoice.amount * (fx?.rate ?? 1) } }
+      },
+      lifecycle: 'lazy',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-sibling-lazy-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+
+    await v.collection<Invoice>('invoices').put('i1', { id: 'i1', amount: 100 })
+    expect((await v.collection<Converted>('converted').get('i1'))?.total).toBe(100)
+
+    // Sibling write marks the output stale; the next read re-derives
+    // against the primary invoice and reflects the new rate.
+    await v.collection<Fx>('fx').put('i1', { id: 'i1', rate: 1.5 })
+    expect((await v.collection<Converted>('converted').get('i1'))?.total).toBe(150)
+  })
+
+  it('(5) multiple declared siblings — a write to any one triggers', async () => {
+    interface Tax extends Record<string, unknown> { id: string; pct: number }
+    interface Total extends Record<string, unknown> { id: string; total: number }
+    const strategy = withDerivation<Invoice, { total: Total }>({
+      source: 'invoices',
+      sources: ['fx', 'tax'],
+      deterministic: true,
+      outputs: { total: { shape: 'record', collection: 'totals' } },
+      derive: async (invoice, ctx) => {
+        const fx = await ctx.vault.collection<Fx>('fx').get(invoice.id)
+        const tax = await ctx.vault.collection<Tax>('tax').get(invoice.id)
+        const base = invoice.amount * (fx?.rate ?? 1)
+        return { total: { id: invoice.id, total: base * (1 + (tax?.pct ?? 0)) } }
+      },
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-sibling-multi-passphrase-2026',
+      derivationStrategies: [strategy],
+    })
+    const v = await db.openVault('demo')
+
+    await v.collection<Invoice>('invoices').put('i1', { id: 'i1', amount: 100 })
+    expect((await v.collection<Total>('totals').get('i1'))?.total).toBe(100)
+
+    await v.collection<Fx>('fx').put('i1', { id: 'i1', rate: 2 })
+    expect((await v.collection<Total>('totals').get('i1'))?.total).toBe(200)
+
+    await v.collection<Tax>('tax').put('i1', { id: 'i1', pct: 0.1 })
+    expect((await v.collection<Total>('totals').get('i1'))?.total).toBeCloseTo(220)
+  })
+
+  it('(6) sources[] containing the primary source throws ValidationError at factory time', () => {
+    expect(() => withDerivation<Invoice, { converted: Converted }>({
+      source: 'invoices',
+      sources: ['fx', 'invoices'],
+      deterministic: true,
+      outputs: { converted: { shape: 'record', collection: 'converted' } },
+      derive: (invoice) => ({ converted: { id: invoice.id, total: invoice.amount } }),
+      lifecycle: 'eager',
+    })).toThrow(ValidationError)
+  })
+
+  it('(6b) empty / non-string sources[] entry throws ValidationError', () => {
+    expect(() => withDerivation<Invoice, { converted: Converted }>({
+      source: 'invoices',
+      sources: [''],
+      deterministic: true,
+      outputs: { converted: { shape: 'record', collection: 'converted' } },
+      derive: (invoice) => ({ converted: { id: invoice.id, total: invoice.amount } }),
+      lifecycle: 'eager',
+    })).toThrow(ValidationError)
+  })
+
+  it('(7) a declared sibling that is also an output forms a detectable cycle at vault open', async () => {
+    // source 'A' triggers off sibling 'B', and also writes to 'B' →
+    // A's _bySource keys are {A, B}; walking B's strategy outputs back
+    // to B closes the cycle.
+    const cyclic = withDerivation({
+      source: 'A',
+      sources: ['B'],
+      deterministic: true,
+      outputs: { o: { shape: 'record', collection: 'B' } },
+      derive: () => ({ o: {} }),
+      lifecycle: 'eager',
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'derivation-sibling-cycle-passphrase-2026',
+      derivationStrategies: [cyclic],
+    })
+    await expect(db.openVault('demo')).rejects.toBeInstanceOf(DerivationCycleError)
+  })
+})

--- a/packages/hub/__tests__/derivations/strategy-hash.test.ts
+++ b/packages/hub/__tests__/derivations/strategy-hash.test.ts
@@ -29,6 +29,29 @@ describe('computeStrategyHash', () => {
     expect(a).not.toBe(b)
   })
 
+  it('changes when declared sibling sources change (#344)', async () => {
+    const fn = (s: { x: number }) => ({ out: { y: s.x } })
+    const none = await computeStrategyHash('src', ['out'], fn)
+    const withOne = await computeStrategyHash('src', ['out'], fn, ['sib'])
+    const withTwo = await computeStrategyHash('src', ['out'], fn, ['sib', 'sib2'])
+    expect(withOne).not.toBe(none)
+    expect(withTwo).not.toBe(withOne)
+  })
+
+  it('is order-insensitive over declared sibling sources (#344)', async () => {
+    const fn = (s: { x: number }) => ({ out: { y: s.x } })
+    const a = await computeStrategyHash('src', ['out'], fn, ['a', 'b'])
+    const b = await computeStrategyHash('src', ['out'], fn, ['b', 'a'])
+    expect(a).toBe(b)
+  })
+
+  it('empty sources array is identical to omitting sources (#344)', async () => {
+    const fn = (s: { x: number }) => ({ out: { y: s.x } })
+    const omitted = await computeStrategyHash('src', ['out'], fn)
+    const empty = await computeStrategyHash('src', ['out'], fn, [])
+    expect(empty).toBe(omitted)
+  })
+
   it('returns a hex string', async () => {
     const h = await computeStrategyHash('s', ['o'], () => ({ o: {} } as any))
     expect(h).toMatch(/^[0-9a-f]+$/)

--- a/packages/hub/__tests__/guards/immutable-guard.test.ts
+++ b/packages/hub/__tests__/guards/immutable-guard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { createNoydb, RecordLockedError, ValidationError } from '../../src/index.js'
+import { createNoydb, RecordLockedError, ValidationError, InvariantError } from '../../src/index.js'
 import { immutableGuard } from '../../src/guards/immutable-guard.js'
 import { withTransactions } from '../../src/tx/index.js'
 import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
@@ -86,6 +86,49 @@ describe('immutableGuard — after: predicate (WORM-after-issue)', () => {
     await inv.put('a', { id: 'a', status: 'issued', total: 50 })
 
     // normal update blocked, amendment allowed
+    await db.transaction({ amendment: true, reason: 'correct issued total' }, async (tx) => {
+      tx.vault('books').collection<Invoice>('invoices').put('a', { id: 'a', status: 'issued', total: 55 })
+    })
+    expect((await inv.get('a'))?.total).toBe(55)
+  })
+})
+
+describe('immutableGuard — amendmentInvariant', () => {
+  it('a supplied invariant that throws on a frozen-field change rejects + rolls back the amendment', async () => {
+    // Keep `total` inviolable even under amendment: re-throw whenever an
+    // existing record's total changes. (`before !== null` skips the seed.)
+    const { db, vault } = await vaultWith(
+      immutableGuard<Invoice>({
+        collection: 'invoices',
+        after: (r) => r.status === 'issued',
+        amendmentInvariant: (changes) => {
+          for (const c of changes) {
+            if (c.before !== null && c.after !== null && c.before.total !== c.after.total) {
+              throw new InvariantError('total is frozen even under amendment')
+            }
+          }
+        },
+      }),
+    )
+    const inv = vault.collection<Invoice>('invoices')
+    await inv.put('a', { id: 'a', status: 'issued', total: 50 })
+
+    // Amendment attempting to change the frozen total is reverted.
+    await expect(
+      db.transaction({ amendment: true, reason: 'tamper total' }, async (tx) => {
+        tx.vault('books').collection<Invoice>('invoices').put('a', { id: 'a', status: 'issued', total: 55 })
+      }),
+    ).rejects.toBeInstanceOf(InvariantError)
+    expect((await inv.get('a'))?.total).toBe(50) // reverted
+  })
+
+  it('default (no amendmentInvariant) still allows any amendment — backward compat', async () => {
+    const { db, vault } = await vaultWith(
+      immutableGuard<Invoice>({ collection: 'invoices', after: (r) => r.status === 'issued' }),
+    )
+    const inv = vault.collection<Invoice>('invoices')
+    await inv.put('a', { id: 'a', status: 'issued', total: 50 })
+
     await db.transaction({ amendment: true, reason: 'correct issued total' }, async (tx) => {
       tx.vault('books').collection<Invoice>('invoices').put('a', { id: 'a', status: 'issued', total: 55 })
     })

--- a/packages/hub/__tests__/materialized-views/union-arm-join.test.ts
+++ b/packages/hub/__tests__/materialized-views/union-arm-join.test.ts
@@ -1,0 +1,292 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withMaterializedView, ref } from '../../src/index.js'
+import { sum } from '../../src/aggregate/reducers.js'
+import { withAggregate } from '../../src/aggregate/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) { out[cname] = out[cname] ?? {}; out[cname][id] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) { data.set(k(v, c, i), payload[c][i]) }
+      }
+    },
+  }
+}
+
+interface Client extends Record<string, unknown> { id: string; region: string }
+interface Bill extends Record<string, unknown> { id: string; clientId: string; n: number }
+interface RegionRow extends Record<string, unknown> { region: string; n: number }
+
+describe('UNION MV — per-arm join (#347 / AU+031)', () => {
+  it('resolves an arm FK to a parent and reads it via sourceRow[as] in map', async () => {
+    const byRegion = withMaterializedView<RegionRow>({
+      name: 'byRegion',
+      sources: ['clients'], // right-side of the join, for dependency tracking
+      unionSources: [
+        {
+          collection: 'bills',
+          join: [{ field: 'clientId', as: 'client' }],
+          map: r => {
+            const client = r.client as Client | null
+            if (!client) return null
+            return { region: client.region, n: r.n as number }
+          },
+        },
+      ],
+      groupBy: 'region',
+      aggregate: { n: sum('n') },
+      rowKey: row => row.region,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-union-armjoin-basic-passphrase-2026',
+      materializedViewStrategies: [byRegion],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('books')
+    vault.collection<Client>('clients')
+    vault.collection<Bill>('bills', { refs: { clientId: ref('clients') } })
+
+    const clients = vault.collection<Client>('clients')
+    const bills = vault.collection<Bill>('bills')
+
+    await clients.put('c1', { id: 'c1', region: 'north' })
+    await clients.put('c2', { id: 'c2', region: 'south' })
+    await bills.put('b1', { id: 'b1', clientId: 'c1', n: 10 })
+    await bills.put('b2', { id: 'b2', clientId: 'c1', n: 5 })
+    await bills.put('b3', { id: 'b3', clientId: 'c2', n: 7 })
+
+    const out = vault.collection<RegionRow>('byRegion')
+    expect((await out.get('north'))?.n).toBe(15)
+    expect((await out.get('south'))?.n).toBe(7)
+  })
+
+  it('refreshes when a right-side (join target) collection is written', async () => {
+    const byRegion = withMaterializedView<RegionRow>({
+      name: 'byRegion',
+      sources: ['clients'],
+      unionSources: [
+        {
+          collection: 'bills',
+          join: [{ field: 'clientId', as: 'client' }],
+          map: r => {
+            const client = r.client as Client | null
+            if (!client) return null
+            return { region: client.region, n: r.n as number }
+          },
+        },
+      ],
+      groupBy: 'region',
+      aggregate: { n: sum('n') },
+      rowKey: row => row.region,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-union-armjoin-rhs-refresh-passphrase-2026',
+      materializedViewStrategies: [byRegion],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('books')
+    vault.collection<Client>('clients')
+    vault.collection<Bill>('bills', { refs: { clientId: ref('clients', 'warn') } })
+
+    const clients = vault.collection<Client>('clients')
+    const bills = vault.collection<Bill>('bills')
+
+    // Bill written first; client not yet present → dangling, omitted by map.
+    await clients.put('c1', { id: 'c1', region: 'north' })
+    await bills.put('b1', { id: 'b1', clientId: 'c1', n: 10 })
+    expect((await vault.collection<RegionRow>('byRegion').get('north'))?.n).toBe(10)
+
+    // Reassign the client's region — a write to the RIGHT side. The MV
+    // must refresh because `sources: ['clients']` registers the dependency.
+    await clients.put('c1', { id: 'c1', region: 'west' })
+    const out = vault.collection<RegionRow>('byRegion')
+    expect(await out.get('north')).toBeNull()
+    expect((await out.get('west'))?.n).toBe(10)
+  })
+
+  it('dangling ref (no matching parent, warn mode) → row omitted', async () => {
+    const byRegion = withMaterializedView<RegionRow>({
+      name: 'byRegion',
+      sources: ['clients'],
+      unionSources: [
+        {
+          collection: 'bills',
+          join: [{ field: 'clientId', as: 'client' }],
+          map: r => {
+            const client = r.client as Client | null
+            if (!client) return null
+            return { region: client.region, n: r.n as number }
+          },
+        },
+      ],
+      groupBy: 'region',
+      aggregate: { n: sum('n') },
+      rowKey: row => row.region,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-union-armjoin-dangling-passphrase-2026',
+      materializedViewStrategies: [byRegion],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('books')
+    vault.collection<Client>('clients')
+    // warn mode so the dangling ref attaches null instead of throwing.
+    vault.collection<Bill>('bills', { refs: { clientId: ref('clients', 'warn') } })
+
+    const clients = vault.collection<Client>('clients')
+    const bills = vault.collection<Bill>('bills')
+
+    await clients.put('c1', { id: 'c1', region: 'north' })
+    await bills.put('b1', { id: 'b1', clientId: 'c1', n: 10 })
+    await bills.put('b2', { id: 'b2', clientId: 'ghost', n: 99 }) // dangling
+
+    const out = vault.collection<RegionRow>('byRegion')
+    // ghost bill is omitted by map (client === null) → only north counts.
+    expect((await out.get('north'))?.n).toBe(10)
+    expect(await out.list()).toHaveLength(1)
+  })
+
+  it('arm join WITHOUT sources throws a config error', () => {
+    expect(() =>
+      withMaterializedView<RegionRow>({
+        name: 'no-sources',
+        // sources omitted
+        unionSources: [
+          {
+            collection: 'bills',
+            join: [{ field: 'clientId', as: 'client' }],
+            map: r => {
+              const client = r.client as Client | null
+              return client ? { region: client.region, n: r.n as number } : null
+            },
+          },
+        ],
+        groupBy: 'region',
+        aggregate: { n: sum('n') },
+        rowKey: row => row.region,
+        refresh: 'eager',
+      }),
+    ).toThrow(/sources/)
+  })
+
+  it('multi-arm union with one joined arm and one plain arm', async () => {
+    interface Direct extends Record<string, unknown> { id: string; region: string; n: number }
+    const byRegion = withMaterializedView<RegionRow>({
+      name: 'byRegionMixed',
+      sources: ['clients'],
+      unionSources: [
+        {
+          collection: 'bills',
+          join: [{ field: 'clientId', as: 'client' }],
+          map: r => {
+            const client = r.client as Client | null
+            return client ? { region: client.region, n: r.n as number } : null
+          },
+        },
+        {
+          collection: 'directs',
+          // no join — region is already on the row
+          map: r => ({ region: r.region as string, n: r.n as number }),
+        },
+      ],
+      groupBy: 'region',
+      aggregate: { n: sum('n') },
+      rowKey: row => row.region,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-union-armjoin-mixed-passphrase-2026',
+      materializedViewStrategies: [byRegion],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('books')
+    vault.collection<Client>('clients')
+    vault.collection<Bill>('bills', { refs: { clientId: ref('clients') } })
+    vault.collection<Direct>('directs')
+
+    const clients = vault.collection<Client>('clients')
+    const bills = vault.collection<Bill>('bills')
+    const directs = vault.collection<Direct>('directs')
+
+    await clients.put('c1', { id: 'c1', region: 'north' })
+    await bills.put('b1', { id: 'b1', clientId: 'c1', n: 10 })
+    await directs.put('d1', { id: 'd1', region: 'north', n: 3 })
+    await directs.put('d2', { id: 'd2', region: 'south', n: 8 })
+
+    const out = vault.collection<RegionRow>('byRegionMixed')
+    expect((await out.get('north'))?.n).toBe(13) // joined 10 + direct 3
+    expect((await out.get('south'))?.n).toBe(8)
+  })
+
+  it('adding a join leg changes summarizeUnionPlan (queryHash sensitivity)', async () => {
+    const noJoin = withMaterializedView<RegionRow>({
+      name: 'h',
+      sources: ['clients'],
+      unionSources: [
+        { collection: 'bills', map: (r: Record<string, unknown>) => ({ region: r.region as string, n: r.n as number }) },
+      ],
+      groupBy: 'region',
+      aggregate: { n: sum('n') },
+      rowKey: row => row.region,
+      refresh: 'eager',
+    })
+    const withJoin = withMaterializedView<RegionRow>({
+      name: 'h',
+      sources: ['clients'],
+      unionSources: [
+        {
+          collection: 'bills',
+          join: [{ field: 'clientId', as: 'client' }],
+          map: (r: Record<string, unknown>) => {
+            const client = r.client as Client | null
+            return client ? { region: client.region, n: r.n as number } : null
+          },
+        },
+      ],
+      groupBy: 'region',
+      aggregate: { n: sum('n') },
+      rowKey: row => row.region,
+      refresh: 'eager',
+    })
+
+    const { summarizeUnionPlan } = await import('../../src/materialized-views/dependency-analyzer.js')
+    const planNoJoin = summarizeUnionPlan(noJoin.spec)
+    const planWithJoin = summarizeUnionPlan(withJoin.spec)
+    expect(planNoJoin).not.toBe(planWithJoin)
+    expect(planWithJoin).toContain('clientId→client')
+  })
+})

--- a/packages/hub/__tests__/materialized-views/union-money.test.ts
+++ b/packages/hub/__tests__/materialized-views/union-money.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { createNoydb, withMaterializedView } from '../../src/index.js'
+import { withAggregate } from '../../src/aggregate/index.js'
+import { sum, min, max } from '../../src/aggregate/reducers.js'
+import { money } from '../../src/money/descriptor.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) { out[cname] = out[cname] ?? {}; out[cname][id] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) { data.set(k(v, c, i), payload[c][i]) }
+      }
+    },
+  }
+}
+
+interface MoneyLine extends Record<string, unknown> {
+  id: string
+  period: string
+  amount: number | string
+}
+
+interface MoneyRollupRow extends Record<string, unknown> {
+  period: string
+  total: number | string
+}
+
+describe('UNION MV — money-aware aggregation (#350)', () => {
+  it('fixed-mode sum via union MV with string-passthrough map yields the exact decimal (not 0)', async () => {
+    const rollup = withMaterializedView<MoneyRollupRow>({
+      name: 'periodTotals',
+      unionSources: [
+        {
+          collection: 'receipts',
+          // Pass the decoded canonical decimal string THROUGH unchanged —
+          // this is the shape that previously crashed BigInt('10000.00').
+          map: r => ({ period: r.period as string, total: r.amount as string }),
+        },
+        {
+          collection: 'notes',
+          map: r => ({ period: r.period as string, total: r.amount as string }),
+        },
+      ],
+      groupBy: 'period',
+      aggregate: { total: sum('total') },
+      moneyFields: { total: money({ currency: 'EUR', scale: 2 }) },
+      rowKey: row => row.period,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-union-money-fixed-passthrough-passphrase-2026',
+      materializedViewStrategies: [rollup],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('books')
+    vault.collection<MoneyLine>('receipts', {
+      schema: z.object({ id: z.string(), period: z.string(), amount: z.union([z.number(), z.string()]) }),
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+    })
+    vault.collection<MoneyLine>('notes', {
+      schema: z.object({ id: z.string(), period: z.string(), amount: z.union([z.number(), z.string()]) }),
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+    })
+    const receipts = vault.collection<MoneyLine>('receipts')
+    const notes = vault.collection<MoneyLine>('notes')
+
+    await receipts.put('r1', { id: 'r1', period: '2026-05', amount: '10000.00' })
+    await receipts.put('r2', { id: 'r2', period: '2026-05', amount: '2500.50' })
+    await notes.put('n1', { id: 'n1', period: '2026-05', amount: '500.25' })
+
+    const out = vault.collection<MoneyRollupRow & { _materializedFrom?: unknown }>('periodTotals')
+    const row = await out.get('2026-05')
+    expect(row).not.toBeNull()
+    expect(row?.total).toBe('13000.75') // 10000.00 + 2500.50 + 500.25
+  })
+
+  it('float-drift case: Number() in map + 0.10/0.20/0.30 sums to exact 0.60', async () => {
+    const rollup = withMaterializedView<MoneyRollupRow>({
+      name: 'driftTotals',
+      unionSources: [
+        {
+          collection: 'lines',
+          // Deliberately route through Number() — a money descriptor must
+          // re-quantize this to the exact scaled integer, not float-drift.
+          map: r => ({ period: r.period as string, total: Number(r.amount) }),
+        },
+      ],
+      groupBy: 'period',
+      aggregate: { total: sum('total') },
+      moneyFields: { total: money({ currency: 'EUR', scale: 2 }) },
+      rowKey: row => row.period,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-union-money-drift-passphrase-2026',
+      materializedViewStrategies: [rollup],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('books')
+    vault.collection<MoneyLine>('lines', {
+      schema: z.object({ id: z.string(), period: z.string(), amount: z.union([z.number(), z.string()]) }),
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+    })
+    const lines = vault.collection<MoneyLine>('lines')
+
+    await lines.put('a', { id: 'a', period: 'p', amount: '0.10' })
+    await lines.put('b', { id: 'b', period: 'p', amount: '0.20' })
+    await lines.put('c', { id: 'c', period: 'p', amount: '0.30' })
+
+    const out = vault.collection<MoneyRollupRow>('driftTotals')
+    const row = await out.get('p')
+    expect(row?.total).toBe('0.60') // exact, not 0.6000000000000001
+  })
+
+  it('money min / max over a union arm return exact decimals', async () => {
+    interface MinMaxRow extends Record<string, unknown> {
+      period: string
+      lo: number | string
+      hi: number | string
+    }
+    const mv = withMaterializedView<MinMaxRow>({
+      name: 'minmax',
+      unionSources: [
+        {
+          collection: 'lines',
+          map: r => ({ period: r.period as string, lo: r.amount as string, hi: r.amount as string }),
+        },
+      ],
+      groupBy: 'period',
+      aggregate: { lo: min('lo'), hi: max('hi') },
+      moneyFields: {
+        lo: money({ currency: 'EUR', scale: 2 }),
+        hi: money({ currency: 'EUR', scale: 2 }),
+      },
+      rowKey: row => row.period,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-union-money-minmax-passphrase-2026',
+      materializedViewStrategies: [mv],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('books')
+    vault.collection<MoneyLine>('lines', {
+      schema: z.object({ id: z.string(), period: z.string(), amount: z.union([z.number(), z.string()]) }),
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+    })
+    const lines = vault.collection<MoneyLine>('lines')
+
+    await lines.put('a', { id: 'a', period: 'p', amount: '12.34' })
+    await lines.put('b', { id: 'b', period: 'p', amount: '99.99' })
+    await lines.put('c', { id: 'c', period: 'p', amount: '5.00' })
+
+    const out = vault.collection<MinMaxRow>('minmax')
+    const row = await out.get('p')
+    expect(row?.lo).toBe('5.00')
+    expect(row?.hi).toBe('99.99')
+  })
+
+  it('multi-currency sum returns an exact per-currency map', async () => {
+    interface MultiLine extends Record<string, unknown> {
+      id: string
+      period: string
+      amount: { amount: number | string; currency: string }
+    }
+    interface MultiRow extends Record<string, unknown> {
+      period: string
+      total: { amount: number | string; currency: string }
+    }
+    const mv = withMaterializedView<MultiRow>({
+      name: 'multiTotals',
+      unionSources: [
+        {
+          collection: 'lines',
+          map: r => ({
+            period: r.period as string,
+            total: r.amount as { amount: number | string; currency: string },
+          }),
+        },
+      ],
+      groupBy: 'period',
+      aggregate: { total: sum('total') },
+      moneyFields: { total: money({ currencies: ['EUR', 'USD'] }) },
+      rowKey: row => row.period,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-union-money-multi-passphrase-2026',
+      materializedViewStrategies: [mv],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('books')
+    vault.collection<MultiLine>('lines', {
+      schema: z.object({
+        id: z.string(),
+        period: z.string(),
+        amount: z.object({ amount: z.union([z.number(), z.string()]), currency: z.string() }),
+      }),
+      moneyFields: { amount: money({ currencies: ['EUR', 'USD'] }) },
+    })
+    const lines = vault.collection<MultiLine>('lines')
+
+    await lines.put('a', { id: 'a', period: 'p', amount: { amount: '10.00', currency: 'EUR' } })
+    await lines.put('b', { id: 'b', period: 'p', amount: { amount: '5.50', currency: 'EUR' } })
+    await lines.put('c', { id: 'c', period: 'p', amount: { amount: '3.00', currency: 'USD' } })
+
+    const out = vault.collection<MultiRow & { _materializedFrom?: unknown }>('multiTotals')
+    const row = await out.get('p')
+    expect(row?.total).toEqual({ EUR: '15.50', USD: '3.00' })
+  })
+
+  it('single-arm union with money sums exactly (#331 computed-key shape)', async () => {
+    interface DatedLine extends Record<string, unknown> {
+      id: string
+      issuedAt: string
+      amount: number | string
+    }
+    const mv = withMaterializedView<MoneyRollupRow>({
+      name: 'monthlyMoney',
+      unionSources: [
+        {
+          collection: 'invoices',
+          // Computed bucket key — month sliced from a date field.
+          map: r => ({
+            period: (r.issuedAt as string).slice(0, 7),
+            total: r.amount as string,
+          }),
+        },
+      ],
+      groupBy: 'period',
+      aggregate: { total: sum('total') },
+      moneyFields: { total: money({ currency: 'EUR', scale: 2 }) },
+      rowKey: row => row.period,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-union-money-single-arm-passphrase-2026',
+      materializedViewStrategies: [mv],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('books')
+    vault.collection<DatedLine>('invoices', {
+      schema: z.object({ id: z.string(), issuedAt: z.string(), amount: z.union([z.number(), z.string()]) }),
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+    })
+    const inv = vault.collection<DatedLine>('invoices')
+
+    await inv.put('i1', { id: 'i1', issuedAt: '2026-05-01', amount: '100.00' })
+    await inv.put('i2', { id: 'i2', issuedAt: '2026-05-20', amount: '50.25' })
+    await inv.put('i3', { id: 'i3', issuedAt: '2026-06-01', amount: '7.10' })
+
+    const out = vault.collection<MoneyRollupRow>('monthlyMoney')
+    expect((await out.get('2026-05'))?.total).toBe('150.25')
+    expect((await out.get('2026-06'))?.total).toBe('7.10')
+  })
+
+  it('regression: a union MV WITHOUT moneyFields still sums plain numbers', async () => {
+    const mv = withMaterializedView<MoneyRollupRow>({
+      name: 'plainTotals',
+      unionSources: [
+        { collection: 'a', map: r => ({ period: r.period as string, total: r.n as number }) },
+        { collection: 'b', map: r => ({ period: r.period as string, total: r.n as number }) },
+      ],
+      groupBy: 'period',
+      aggregate: { total: sum('total') },
+      rowKey: row => row.period,
+      refresh: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'mv-union-plain-numeric-passphrase-2026',
+      materializedViewStrategies: [mv],
+      aggregateStrategy: withAggregate(),
+    })
+    const vault = await db.openVault('books')
+    const a = vault.collection<{ id: string; period: string; n: number }>('a')
+    const b = vault.collection<{ id: string; period: string; n: number }>('b')
+
+    await a.put('a1', { id: 'a1', period: 'p', n: 3 })
+    await b.put('b1', { id: 'b1', period: 'p', n: 4 })
+
+    const out = vault.collection<MoneyRollupRow>('plainTotals')
+    expect((await out.get('p'))?.total).toBe(7)
+  })
+
+  it('moneyFields declared without aggregate throws a config error', () => {
+    expect(() =>
+      withMaterializedView<MoneyRollupRow>({
+        name: 'bad-money',
+        unionSources: [
+          { collection: 'a', map: r => ({ period: r.period as string, total: r.amount as string }) },
+        ],
+        groupBy: 'period',
+        // no aggregate
+        moneyFields: { total: money({ currency: 'EUR', scale: 2 }) },
+        rowKey: row => row.period,
+        refresh: 'eager',
+      }),
+    ).toThrow(/moneyFields requires aggregate/)
+  })
+})
+
+describe('UNION MV — queryHash sensitivity to moneyFields (#350)', () => {
+  it('declaring moneyFields changes summarizeUnionPlan vs the same spec without it', async () => {
+    const base = {
+      name: 'hash-money',
+      unionSources: [
+        { collection: 'a', map: (r: Record<string, unknown>) => ({ period: r.period as string, total: r.amount as string }) },
+      ],
+      groupBy: 'period',
+      aggregate: { total: sum('total') },
+      rowKey: (row: { period: string }) => row.period,
+      refresh: 'eager' as const,
+    }
+    const withMoney = withMaterializedView<{ period: string; total: string }>({
+      ...base,
+      moneyFields: { total: money({ currency: 'EUR', scale: 2 }) },
+    })
+    const withoutMoney = withMaterializedView<{ period: string; total: string }>({ ...base })
+
+    const { summarizeUnionPlan } = await import('../../src/materialized-views/dependency-analyzer.js')
+    const planWith = summarizeUnionPlan(withMoney.spec)
+    const planWithout = summarizeUnionPlan(withoutMoney.spec)
+    expect(planWith).not.toBe(planWithout)
+    expect(planWith).toContain('money(total)')
+    expect(planWithout).toContain('money()')
+  })
+})

--- a/packages/hub/__tests__/overlay-views/overlay.test.ts
+++ b/packages/hub/__tests__/overlay-views/overlay.test.ts
@@ -385,4 +385,222 @@ describe('withOverlayedView read-shadow primitive (#154)', () => {
       })()).rejects.toBeInstanceOf(OverlayCollectionUnavailableError)
     })
   })
+
+  describe('field-level merge mode (mergeMode)', () => {
+    interface MergeRow extends Record<string, unknown> {
+      clientId: string
+      amount: number
+      note?: string
+      reviewer?: string
+      dataStatus?: 'acquired' | 'approved' | 'flagged' | 'override'
+    }
+
+    // Base MV + overlay with a field-merge mergeMode. `approved` pulls
+    // amount + note (plus the shadowField) from the overlay; `flagged`
+    // pulls only the reviewer + shadowField. `override` keeps the binary
+    // full-win path. Anything else falls through to base.
+    async function setupMerge() {
+      const baseMV = withMaterializedView<MergeRow>({
+        name: 'pnd1-aggregate',
+        query: (db) => db.collection<MergeRow>('compensations').query(),
+        rowKey: (r) => r.clientId,
+        refresh: 'eager',
+      })
+      const overlay = withOverlayedView({
+        name: 'pnd1',
+        base: 'pnd1-aggregate',
+        overlay: 'pnd1-overlay',
+        shadowField: 'dataStatus',
+        shadowValue: 'override',
+        mergeMode: {
+          kind: 'field-merge',
+          rules: [
+            { whenStatus: 'approved', overlayFields: ['dataStatus', 'amount', 'note'] },
+            { whenStatus: 'flagged', overlayFields: ['dataStatus', 'reviewer'] },
+          ],
+        },
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'overlay-field-merge-passphrase-2026',
+        materializedViewStrategies: [baseMV],
+        overlayedViewStrategies: [overlay],
+      })
+      const vault = await db.openVault('demo')
+      return { vault }
+    }
+
+    it('whenStatus=approved → overlayFields come from overlay, rest from base', async () => {
+      const { vault } = await setupMerge()
+      await vault.collection<MergeRow>('compensations').put('acme', {
+        clientId: 'acme', amount: 100, note: 'base-note', reviewer: 'base-rev',
+      })
+      await vault.collection<MergeRow>('pnd1-overlay').put('acme', {
+        clientId: 'acme', amount: 250, note: 'overlay-note', reviewer: 'overlay-rev', dataStatus: 'approved',
+      })
+
+      const row = await vault.collection<MergeRow>('pnd1').get('acme')
+      // approved pulls amount + note + dataStatus from overlay…
+      expect(row?.amount).toBe(250)
+      expect(row?.note).toBe('overlay-note')
+      expect(row?.dataStatus).toBe('approved')
+      // …but reviewer is NOT in the rule → stays the base value.
+      expect(row?.reviewer).toBe('base-rev')
+    })
+
+    it('overlay status with no matching rule → base wins entirely', async () => {
+      const { vault } = await setupMerge()
+      await vault.collection<MergeRow>('compensations').put('acme', {
+        clientId: 'acme', amount: 100, note: 'base-note',
+      })
+      await vault.collection<MergeRow>('pnd1-overlay').put('acme', {
+        clientId: 'acme', amount: 999, note: 'overlay-note', dataStatus: 'acquired',
+      })
+
+      const row = await vault.collection<MergeRow>('pnd1').get('acme')
+      expect(row?.amount).toBe(100)
+      expect(row?.note).toBe('base-note')
+      // No rule matched 'acquired' and it isn't the shadowValue → base.
+      expect(row?.dataStatus).toBeUndefined()
+    })
+
+    it('shadowField===shadowValue (override) → overlay wins entirely (binary path, mergeMode ignored)', async () => {
+      const { vault } = await setupMerge()
+      await vault.collection<MergeRow>('compensations').put('acme', {
+        clientId: 'acme', amount: 100, note: 'base-note', reviewer: 'base-rev',
+      })
+      await vault.collection<MergeRow>('pnd1-overlay').put('acme', {
+        clientId: 'acme', amount: 777, note: 'overlay-note', reviewer: 'overlay-rev', dataStatus: 'override',
+      })
+
+      const row = await vault.collection<MergeRow>('pnd1').get('acme')
+      // Full overlay win — every field from overlay, even reviewer.
+      expect(row?.amount).toBe(777)
+      expect(row?.note).toBe('overlay-note')
+      expect(row?.reviewer).toBe('overlay-rev')
+      expect(row?.dataStatus).toBe('override')
+    })
+
+    it('overlay-only + matching rule (no base) → overlay row returned as-is', async () => {
+      const { vault } = await setupMerge()
+      await vault.collection<MergeRow>('pnd1-overlay').put('acme', {
+        clientId: 'acme', amount: 250, note: 'overlay-note', dataStatus: 'approved',
+      })
+
+      const row = await vault.collection<MergeRow>('pnd1').get('acme')
+      expect(row?.amount).toBe(250)
+      expect(row?.note).toBe('overlay-note')
+      expect(row?.dataStatus).toBe('approved')
+    })
+
+    it('list() applies field-merge per row', async () => {
+      const { vault } = await setupMerge()
+      await vault.collection<MergeRow>('compensations').put('acme', {
+        clientId: 'acme', amount: 100, note: 'base-acme', reviewer: 'base-rev',
+      })
+      await vault.collection<MergeRow>('compensations').put('beta', {
+        clientId: 'beta', amount: 200, note: 'base-beta',
+      })
+      // acme: approved → field-merge amount+note. beta: untouched → base.
+      await vault.collection<MergeRow>('pnd1-overlay').put('acme', {
+        clientId: 'acme', amount: 250, note: 'overlay-acme', reviewer: 'overlay-rev', dataStatus: 'approved',
+      })
+
+      const rows = await vault.collection<MergeRow>('pnd1').list()
+      expect(rows).toHaveLength(2)
+      const acme = rows.find((r) => r.clientId === 'acme')
+      const beta = rows.find((r) => r.clientId === 'beta')
+      expect(acme?.amount).toBe(250)       // overlay (rule)
+      expect(acme?.note).toBe('overlay-acme')
+      expect(acme?.reviewer).toBe('base-rev') // not in rule → base
+      expect(beta?.amount).toBe(200)       // base only
+      expect(beta?.note).toBe('base-beta')
+    })
+
+    it('rules evaluated in declaration order — first matching whenStatus wins', async () => {
+      // Two rules match the same status; the first declared one must win.
+      const baseMV = withMaterializedView<MergeRow>({
+        name: 'mv1',
+        query: (db) => db.collection<MergeRow>('src').query(),
+        rowKey: (r) => r.clientId,
+        refresh: 'eager',
+      })
+      const overlay = withOverlayedView({
+        name: 'v',
+        base: 'mv1',
+        overlay: 'ov',
+        shadowField: 'dataStatus',
+        shadowValue: 'override',
+        mergeMode: {
+          kind: 'field-merge',
+          rules: [
+            // First rule for 'flagged' pulls only reviewer.
+            { whenStatus: 'flagged', overlayFields: ['dataStatus', 'reviewer'] },
+            // Shadowed second rule for 'flagged' would also pull amount —
+            // must be ignored because the first match wins.
+            { whenStatus: 'flagged', overlayFields: ['dataStatus', 'reviewer', 'amount'] },
+          ],
+        },
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'overlay-rule-order-passphrase-2026',
+        materializedViewStrategies: [baseMV],
+        overlayedViewStrategies: [overlay],
+      })
+      const vault = await db.openVault('demo')
+      await vault.collection<MergeRow>('src').put('acme', {
+        clientId: 'acme', amount: 100, reviewer: 'base-rev',
+      })
+      await vault.collection<MergeRow>('ov').put('acme', {
+        clientId: 'acme', amount: 999, reviewer: 'overlay-rev', dataStatus: 'flagged',
+      })
+
+      const row = await vault.collection<MergeRow>('v').get('acme')
+      expect(row?.reviewer).toBe('overlay-rev') // first rule pulled reviewer
+      expect(row?.amount).toBe(100)             // first rule did NOT pull amount → base
+      expect(row?.dataStatus).toBe('flagged')
+    })
+
+    it('backward-compat: a strategy with NO mergeMode behaves exactly as the binary primitive', async () => {
+      const baseMV = withMaterializedView<MergeRow>({
+        name: 'mv1',
+        query: (db) => db.collection<MergeRow>('src').query(),
+        rowKey: (r) => r.clientId,
+        refresh: 'eager',
+      })
+      const overlay = withOverlayedView({
+        name: 'v',
+        base: 'mv1',
+        overlay: 'ov',
+        shadowField: 'dataStatus',
+        shadowValue: 'override',
+        // no mergeMode
+      })
+      const db = await createNoydb({
+        store: memory(),
+        user: 'alice',
+        secret: 'overlay-no-mergemode-passphrase-2026',
+        materializedViewStrategies: [baseMV],
+        overlayedViewStrategies: [overlay],
+      })
+      const vault = await db.openVault('demo')
+      await vault.collection<MergeRow>('src').put('acme', { clientId: 'acme', amount: 100, note: 'base' })
+      // Non-override status → overlay shadowed out entirely, base wins.
+      await vault.collection<MergeRow>('ov').put('acme', {
+        clientId: 'acme', amount: 999, note: 'overlay', dataStatus: 'approved',
+      })
+      expect((await vault.collection<MergeRow>('v').get('acme'))?.amount).toBe(100)
+      expect((await vault.collection<MergeRow>('v').get('acme'))?.note).toBe('base')
+
+      // override status → full overlay win, exactly as before.
+      await vault.collection<MergeRow>('ov').put('acme', {
+        clientId: 'acme', amount: 999, note: 'overlay', dataStatus: 'override',
+      })
+      expect((await vault.collection<MergeRow>('v').get('acme'))?.amount).toBe(999)
+      expect((await vault.collection<MergeRow>('v').get('acme'))?.note).toBe('overlay')
+    })
+  })
 })

--- a/packages/hub/__tests__/refs.test.ts
+++ b/packages/hub/__tests__/refs.test.ts
@@ -24,6 +24,7 @@ import type { Noydb } from '../src/noydb.js'
 import { withHistory } from '../src/history/index.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
 import { ConflictError } from '../src/errors.js'
+import { withTransactions } from '../src/tx/index.js'
 import {
   ref,
   RefIntegrityError,
@@ -405,6 +406,120 @@ describe('cascade mode.', () => {
 
     expect(await a.get('a-1')).toBeNull()
     expect(await b.get('b-1')).toBeNull()
+  })
+
+  // ─── cascade atomicity inside db.transaction() (AU+030 / #346) ──────
+  //
+  // Cascaded child deletes must register on the active TxContext so a
+  // later mid-commit failure rolls the children back alongside the
+  // parent. We force a mid-Phase-2 failure (AFTER the parent delete +
+  // cascade has executed) by staging a strict-ref put to a missing
+  // target as a *later* op — `Collection.put` throws RefIntegrityError
+  // during execute, triggering the transaction's best-effort revert.
+
+  it('rolls back cascaded children when a tx fails after the parent delete', async () => {
+    const txDb = await createNoydb({
+      store: memory(),
+      user: 'alice', historyStrategy: withHistory(),
+      secret: 'test-passphrase-1234',
+      txStrategy: withTransactions(),
+    })
+    const company = await txDb.openVault('demo-co')
+    const clients = company.collection<Client>('clients')
+    const invoices = company.collection<Invoice>('invoices', {
+      refs: { clientId: ref('clients', 'cascade') },
+    })
+    // A strict-ref collection we use to poison the transaction: a put
+    // with a missing target throws RefIntegrityError during execute.
+    interface Receipt { id: string; clientId: string | null }
+    company.collection<Receipt>('receipts', {
+      refs: { clientId: ref('clients', 'strict') },
+    })
+
+    await clients.put('c-1', { id: 'c-1', name: 'Acme' })
+    await invoices.put('inv-1', { id: 'inv-1', client: 'Acme', clientId: 'c-1', amount: 100 })
+    await invoices.put('inv-2', { id: 'inv-2', client: 'Acme', clientId: 'c-1', amount: 200 })
+
+    await expect(
+      txDb.transaction(async (tx) => {
+        // Stage the parent delete FIRST — cascades inv-1 + inv-2 during execute.
+        tx.vault('demo-co').collection<Client>('clients').delete('c-1')
+        // Then stage a poison op that fails mid-commit (strict ref to a
+        // now-deleted client) — after the cascade already happened.
+        tx.vault('demo-co').collection<Receipt>('receipts').put('r-1', { id: 'r-1', clientId: 'c-1' })
+      }),
+    ).rejects.toThrow(RefIntegrityError)
+
+    // Parent restored…
+    expect(await clients.get('c-1')).toBeTruthy()
+    // …and every cascaded child restored too.
+    expect(await invoices.get('inv-1')).toBeTruthy()
+    expect(await invoices.get('inv-2')).toBeTruthy()
+    // …and the poison put left no trace.
+    expect(await company.collection<Receipt>('receipts').get('r-1')).toBeNull()
+  })
+
+  it('rolls back a multi-level cascade (grandparent→parent→child) on tx abort', async () => {
+    const txDb = await createNoydb({
+      store: memory(),
+      user: 'alice', historyStrategy: withHistory(),
+      secret: 'test-passphrase-1234',
+      txStrategy: withTransactions(),
+    })
+    const company = await txDb.openVault('demo-co')
+    // grandparent ← parent ← child, all cascade.
+    interface GP { id: string; name: string }
+    interface P { id: string; gpId: string | null }
+    interface C { id: string; pId: string | null }
+    const gps = company.collection<GP>('gps')
+    const parents = company.collection<P>('parents', { refs: { gpId: ref('gps', 'cascade') } })
+    const children = company.collection<C>('children', { refs: { pId: ref('parents', 'cascade') } })
+    // Poison collection to force a mid-commit failure post-cascade.
+    interface Receipt { id: string; gpId: string | null }
+    company.collection<Receipt>('receipts', { refs: { gpId: ref('gps', 'strict') } })
+
+    await gps.put('gp-1', { id: 'gp-1', name: 'Root' })
+    await parents.put('p-1', { id: 'p-1', gpId: 'gp-1' })
+    await parents.put('p-2', { id: 'p-2', gpId: 'gp-1' })
+    await children.put('ch-1', { id: 'ch-1', pId: 'p-1' })
+    await children.put('ch-2', { id: 'ch-2', pId: 'p-2' })
+
+    await expect(
+      txDb.transaction(async (tx) => {
+        // Deleting the grandparent cascades through parents to children.
+        tx.vault('demo-co').collection<GP>('gps').delete('gp-1')
+        // Poison op fails after the whole cascade tree has executed.
+        tx.vault('demo-co').collection<Receipt>('receipts').put('r-1', { id: 'r-1', gpId: 'gp-1' })
+      }),
+    ).rejects.toThrow(RefIntegrityError)
+
+    // Every level of the cascade tree restored.
+    expect(await gps.get('gp-1')).toBeTruthy()
+    expect(await parents.get('p-1')).toBeTruthy()
+    expect(await parents.get('p-2')).toBeTruthy()
+    expect(await children.get('ch-1')).toBeTruthy()
+    expect(await children.get('ch-2')).toBeTruthy()
+  })
+
+  it('regression: cascade OUTSIDE a transaction still deletes children + parent', async () => {
+    // No txStrategy — the plain cascade path must be unchanged.
+    const company = await db.openVault('demo-co')
+    const clients = company.collection<Client>('clients')
+    const invoices = company.collection<Invoice>('invoices', {
+      refs: { clientId: ref('clients', 'cascade') },
+    })
+
+    await clients.put('c-1', { id: 'c-1', name: 'Acme' })
+    await invoices.put('inv-1', { id: 'inv-1', client: 'Acme', clientId: 'c-1', amount: 100 })
+    await invoices.put('inv-2', { id: 'inv-2', client: 'Acme', clientId: 'c-1', amount: 200 })
+    await invoices.put('inv-3', { id: 'inv-3', client: 'Other', clientId: 'other', amount: 50 })
+
+    await clients.delete('c-1')
+
+    expect(await clients.get('c-1')).toBeNull()
+    expect(await invoices.get('inv-1')).toBeNull()
+    expect(await invoices.get('inv-2')).toBeNull()
+    expect(await invoices.get('inv-3')).toBeTruthy()
   })
 })
 

--- a/packages/hub/__tests__/sequence.test.ts
+++ b/packages/hub/__tests__/sequence.test.ts
@@ -2,7 +2,7 @@
  * #303 — atomic, gap-free sequence primitive.
  */
 import { describe, it, expect } from 'vitest'
-import { createNoydb, ConflictError, SequenceOfflineError, SequenceContentionError, ReservedCollectionNameError } from '../src/index.js'
+import { createNoydb, ConflictError, SequenceOfflineError, SequenceContentionError, ReservedCollectionNameError, ValidationError } from '../src/index.js'
 import { withHistory } from '../src/history/index.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
 
@@ -189,5 +189,140 @@ describe('#303 vault.sequence', () => {
   it('collection("_sequences") throws ReservedCollectionNameError', async () => {
     const v = await vault(memory())
     expect(() => v.collection('_sequences')).toThrow(ReservedCollectionNameError)
+  })
+})
+
+describe('#345 vault.sequence — partition + seedTo', () => {
+  // ── Partitioning ──────────────────────────────────────────────────────────────
+  it('a partitioned sequence is independent from the unpartitioned series', async () => {
+    const v = await vault(memory())
+    expect(await v.sequence('invoice').next()).toBe(1)
+    expect(await v.sequence('invoice').next()).toBe(2)
+    // Partitioned counter starts fresh — disjoint key.
+    expect(await v.sequence('invoice', { partition: [2026] }).next()).toBe(1)
+    expect(await v.sequence('invoice', { partition: [2026] }).next()).toBe(2)
+    // Unpartitioned counter is untouched by the partitioned allocations.
+    expect(await v.sequence('invoice').next()).toBe(3)
+  })
+
+  it('two partition values are independent of each other', async () => {
+    const v = await vault(memory())
+    expect(await v.sequence('invoice', { partition: ['EU'] }).next()).toBe(1)
+    expect(await v.sequence('invoice', { partition: ['US'] }).next()).toBe(1)
+    expect(await v.sequence('invoice', { partition: ['EU'] }).next()).toBe(2)
+    expect(await v.sequence('invoice', { partition: ['US'] }).next()).toBe(2)
+    expect(await v.sequence('invoice', { partition: ['EU'] }).next()).toBe(3)
+  })
+
+  it('two partition components compose into one independent counter', async () => {
+    const v = await vault(memory())
+    const eu2026 = () => v.sequence('invoice', { partition: [2026, 'EU'] })
+    const us2026 = () => v.sequence('invoice', { partition: [2026, 'US'] })
+    expect(await eu2026().next()).toBe(1)
+    expect(await eu2026().next()).toBe(2)
+    expect(await us2026().next()).toBe(1)
+    // Distinct second component ⇒ distinct counter.
+    expect(await eu2026().next()).toBe(3)
+  })
+
+  it('a numeric partition component coerces to the same key as its string form', async () => {
+    const v = await vault(memory())
+    expect(await v.sequence('invoice', { partition: [2026] }).next()).toBe(1)
+    // String '2026' must resolve to the SAME counter as numeric 2026.
+    expect(await v.sequence('invoice', { partition: ['2026'] }).next()).toBe(2)
+    expect(await v.sequence('invoice', { partition: [2026] }).next()).toBe(3)
+  })
+
+  it("a '/'-containing value is URI-encoded distinct from a 2-element partition", async () => {
+    const v = await vault(memory())
+    // Single component 'a/b' encodes to 'a%2Fb'; a 2-element ['a','b'] joins to 'a/b'.
+    // The two keys must NOT collide.
+    expect(await v.sequence('s', { partition: ['a/b'] }).next()).toBe(1)
+    expect(await v.sequence('s', { partition: ['a', 'b'] }).next()).toBe(1)
+    expect(await v.sequence('s', { partition: ['a/b'] }).next()).toBe(2)
+    expect(await v.sequence('s', { partition: ['a', 'b'] }).next()).toBe(2)
+  })
+
+  it('a series name containing a null byte throws ValidationError', async () => {
+    // NOTE: enforced in vault.sequence() (integration); this case may not pass
+    // until the vault.ts guard lands. Written here for completeness.
+    const v = await vault(memory())
+    expect(() => v.sequence('bad\x00series')).toThrow(ValidationError)
+  })
+
+  it('peek works on a partitioned sequence', async () => {
+    const v = await vault(memory())
+    const seq = () => v.sequence('invoice', { partition: [2026, 'EU'] })
+    expect(await seq().peek()).toBe(0)
+    await seq().next()
+    await seq().next()
+    expect(await seq().peek()).toBe(2)
+    // The unpartitioned series remains at 0.
+    expect(await v.sequence('invoice').peek()).toBe(0)
+  })
+
+  // ── seedTo (set-if-greater) ───────────────────────────────────────────────────
+  it('seedTo advances the counter so next() continues above n', async () => {
+    const v = await vault(memory())
+    const seq = v.sequence('invoice')
+    await seq.seedTo(50)
+    expect(await seq.peek()).toBe(50)
+    expect(await seq.next()).toBe(51)
+    expect(await seq.next()).toBe(52)
+  })
+
+  it('seedTo is a no-op when the counter is already higher (set-if-greater)', async () => {
+    const v = await vault(memory())
+    const seq = v.sequence('invoice')
+    await seq.next() // 1
+    await seq.next() // 2
+    await seq.next() // 3
+    await seq.seedTo(2) // below current — must not rewind
+    expect(await seq.peek()).toBe(3)
+    expect(await seq.next()).toBe(4)
+  })
+
+  it('seedTo(0) is a no-op', async () => {
+    const v = await vault(memory())
+    const seq = v.sequence('invoice')
+    await seq.seedTo(0)
+    expect(await seq.peek()).toBe(0)
+    expect(await seq.next()).toBe(1)
+  })
+
+  it('seedTo is idempotent', async () => {
+    const v = await vault(memory())
+    const seq = v.sequence('invoice')
+    await seq.seedTo(50)
+    await seq.seedTo(50)
+    await seq.seedTo(50)
+    expect(await seq.peek()).toBe(50)
+    expect(await seq.next()).toBe(51)
+  })
+
+  it('seedTo works on a partitioned sequence', async () => {
+    const v = await vault(memory())
+    const seq = v.sequence('invoice', { partition: [2026, 'EU'] })
+    await seq.seedTo(100)
+    expect(await seq.peek()).toBe(100)
+    expect(await seq.next()).toBe(101)
+    // A different partition is unaffected.
+    expect(await v.sequence('invoice', { partition: [2026, 'US'] }).peek()).toBe(0)
+  })
+
+  it('seedTo on a non-CAS store throws SequenceOfflineError', async () => {
+    const v = await vault(memory(false))
+    await expect(v.sequence('x').seedTo(50)).rejects.toBeInstanceOf(SequenceOfflineError)
+  })
+
+  // ── Regression: bundle import must not restart serials at 0 ───────────────────
+  it('bundle-import "restart at 0" regression: seedTo(50) then next()==51', async () => {
+    const v = await vault(memory())
+    const seq = v.sequence('invoice')
+    // Fresh sequence after an import — counter is at 0 but records up to 50 exist.
+    expect(await seq.peek()).toBe(0)
+    await seq.seedTo(50)
+    // next() must skip past the imported serials, not collide with serial 1.
+    expect(await seq.next()).toBe(51)
   })
 })

--- a/packages/hub/__tests__/tx/tx-invariants.test.ts
+++ b/packages/hub/__tests__/tx/tx-invariants.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Commit-time changeset invariants for ordinary transactions (#342 / AU+026).
+ *
+ * `withTransactions({ invariants: [{ scope, check }] })` registers set-level
+ * constraints that fire at commit for NORMAL `db.transaction(fn)` calls (no
+ * amendment, no role gate). The scenarios below pin the contract:
+ *
+ *   1. Passing invariant → tx commits.
+ *   2. Throwing invariant → InvariantError + ALL writes rolled back.
+ *   3. before/after correctness (insert → before null; update → before prior).
+ *   4. An invariant whose scope wasn't touched is not called.
+ *   5. Invariants are additive with amendment — an amendment tx runs them too.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, InvariantError, withGuard } from '../../src/index.js'
+import { withTransactions } from '../../src/tx/index.js'
+import type { TransactionInvariant } from '../../src/tx/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v && cname && id) {
+          out[cname] = out[cname] ?? {}
+          out[cname]![id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c]!)) {
+          data.set(k(v, c, i), payload[c]![i]!)
+        }
+      }
+    },
+  }
+}
+
+interface Payment extends Record<string, unknown> {
+  id: string
+  amount: number
+  receiptAmount: number
+}
+
+// assertR1: every payment must be 100% receipted (receiptAmount === amount).
+const assertR1: TransactionInvariant = {
+  scope: 'payments',
+  check: (changes) => {
+    for (const { after } of changes) {
+      const p = after as Payment | null
+      if (p !== null && p.receiptAmount !== p.amount) {
+        throw new InvariantError(`R1: payment ${p.id} not fully receipted`)
+      }
+    }
+  },
+}
+
+describe('withTransactions({ invariants }) — commit-time changeset invariants', () => {
+  it('commits when the invariant passes', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'owner',
+      secret: 'tx-invariants-pass-passphrase-2026',
+      txStrategy: withTransactions({ invariants: [assertR1] }),
+    })
+    const v = await db.openVault('acme')
+
+    await db.transaction(async (tx) => {
+      tx.vault('acme').collection<Payment>('payments').put('p1', { id: 'p1', amount: 100, receiptAmount: 100 })
+    })
+
+    expect(await v.collection<Payment>('payments').get('p1')).toEqual({ id: 'p1', amount: 100, receiptAmount: 100 })
+  })
+
+  it('throws InvariantError and rolls back ALL writes when the invariant fails', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'owner',
+      secret: 'tx-invariants-fail-passphrase-2026',
+      txStrategy: withTransactions({ invariants: [assertR1] }),
+    })
+    const v = await db.openVault('acme')
+
+    // Seed a prior valid payment OUTSIDE the failing tx.
+    await v.collection<Payment>('payments').put('good', { id: 'good', amount: 50, receiptAmount: 50 })
+
+    await expect(
+      db.transaction(async (tx) => {
+        const pay = tx.vault('acme').collection<Payment>('payments')
+        // Both writes are in one tx; the bad one trips R1.
+        pay.put('good', { id: 'good', amount: 50, receiptAmount: 50 }) // still valid, but in the batch
+        pay.put('bad', { id: 'bad', amount: 100, receiptAmount: 40 })  // under-receipted → R1 fails
+      }),
+    ).rejects.toBeInstanceOf(InvariantError)
+
+    // The bad record must be absent and the prior valid one unchanged.
+    expect(await v.collection<Payment>('payments').get('bad')).toBeNull()
+    expect(await v.collection<Payment>('payments').get('good')).toEqual({ id: 'good', amount: 50, receiptAmount: 50 })
+  })
+
+  it('before is null on insert and the prior record on update', async () => {
+    const seen: Array<{ before: Payment | null; after: Payment | null }> = []
+    const captureInv: TransactionInvariant = {
+      scope: 'payments',
+      check: (changes) => {
+        for (const c of changes) {
+          seen.push({ before: c.before as Payment | null, after: c.after as Payment | null })
+        }
+      },
+    }
+    const db = await createNoydb({
+      store: memory(),
+      user: 'owner',
+      secret: 'tx-invariants-beforeafter-passphrase-2026',
+      txStrategy: withTransactions({ invariants: [captureInv] }),
+    })
+    await db.openVault('acme')
+
+    // Insert: before === null.
+    await db.transaction(async (tx) => {
+      tx.vault('acme').collection<Payment>('payments').put('p1', { id: 'p1', amount: 100, receiptAmount: 100 })
+    })
+    expect(seen).toHaveLength(1)
+    expect(seen[0]!.before).toBeNull()
+    expect(seen[0]!.after).toEqual({ id: 'p1', amount: 100, receiptAmount: 100 })
+
+    // Update: before === prior committed record.
+    seen.length = 0
+    await db.transaction(async (tx) => {
+      tx.vault('acme').collection<Payment>('payments').put('p1', { id: 'p1', amount: 100, receiptAmount: 100 })
+    })
+    expect(seen).toHaveLength(1)
+    expect(seen[0]!.before).toEqual({ id: 'p1', amount: 100, receiptAmount: 100 })
+  })
+
+  it('does not call an invariant whose scope was not touched', async () => {
+    let called = false
+    const unrelated: TransactionInvariant = {
+      scope: 'receipts',
+      check: () => { called = true },
+    }
+    const db = await createNoydb({
+      store: memory(),
+      user: 'owner',
+      secret: 'tx-invariants-unrelated-passphrase-2026',
+      txStrategy: withTransactions({ invariants: [assertR1, unrelated] }),
+    })
+    await db.openVault('acme')
+
+    await db.transaction(async (tx) => {
+      tx.vault('acme').collection<Payment>('payments').put('p1', { id: 'p1', amount: 10, receiptAmount: 10 })
+    })
+
+    expect(called).toBe(false)
+  })
+
+  it('is additive with amendment — an amendment tx still runs the invariant', async () => {
+    // A WORM guard so the collection is amendment-gated; the commit-time
+    // invariant must ALSO fire on the amendment commit.
+    const guard = withGuard<Payment>({
+      collection: 'payments',
+      check: async () => { throw new Error('locked — normal write blocked') },
+      amendment: {
+        roles: ['admin', 'owner'],
+        invariant: () => { /* amendment override allowed */ },
+      },
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'owner',
+      secret: 'tx-invariants-amendment-passphrase-2026',
+      guardStrategies: [guard],
+      txStrategy: withTransactions({ invariants: [assertR1] }),
+    })
+    const v = await db.openVault('acme')
+
+    // Valid amendment commits (passes R1).
+    await db.transaction({ amendment: true, reason: 'seed receipted payment' }, async (tx) => {
+      tx.vault('acme').collection<Payment>('payments').put('p1', { id: 'p1', amount: 100, receiptAmount: 100 })
+    })
+    expect((await v.collection<Payment>('payments').get('p1'))?.receiptAmount).toBe(100)
+
+    // R1-violating amendment is rejected + rolled back even though the
+    // guard amendment.invariant would have allowed it.
+    await expect(
+      db.transaction({ amendment: true, reason: 'under-receipt' }, async (tx) => {
+        tx.vault('acme').collection<Payment>('payments').put('p1', { id: 'p1', amount: 100, receiptAmount: 40 })
+      }),
+    ).rejects.toBeInstanceOf(InvariantError)
+    // Unchanged — reverted to the valid prior.
+    expect((await v.collection<Payment>('payments').get('p1'))?.receiptAmount).toBe(100)
+  })
+})

--- a/packages/hub/src/aggregate/groupby.ts
+++ b/packages/hub/src/aggregate/groupby.ts
@@ -259,11 +259,23 @@ export function groupAndReduce<R>(
   records: readonly unknown[],
   fieldOrFields: string | readonly string[],
   spec: AggregateSpec,
+  moneyFields?: Record<string, MoneyDescriptor>,
 ): R[] {
   const fields: readonly string[] =
     typeof fieldOrFields === 'string' ? [fieldOrFields] : fieldOrFields
   if (fields.length === 0) {
     throw new Error('.groupBy() requires at least one field')
+  }
+
+  // Money-aware aggregation: when the caller declares money descriptors
+  // for output/intermediate fields, rewrite any `sum`/`min`/`max` over
+  // them into exact BigInt reducers before bucketing. Omitted → spec
+  // passes through unchanged (backward compatible). The chainable
+  // `GroupedQuery` path already wraps upstream via `wrapSpec`; this
+  // covers direct `groupAndReduce` callers (UNION-form MVs) that have
+  // no Query wrapper to do it.
+  if (moneyFields) {
+    spec = wrapMoneyReducers(spec, moneyFields)
   }
 
   // Bucket value is { keyValues, records } so the output row can stamp

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1615,9 +1615,23 @@ export class Collection<T> {
         if (DerivationExecutor === null) {
           ({ DerivationExecutor } = (await import('./derivations/executor.js')) as { DerivationExecutor: typeof DerivationExecutorType })
         }
-        const sourceWithId = { ...incoming, id } as Record<string, unknown> & { id: string }
+        // #344: a sibling-triggered strategy (spec.source !== this.name)
+        // derives against the PRIMARY source record at the same id — not
+        // the incoming sibling record. Read it through the primary
+        // collection so its own money/crypto wiring applies; silent
+        // no-op if no primary record exists at that id (same-id rule).
+        let sourceWithId: Record<string, unknown> & { id: string }
+        let sourceVersion = version
+        if (spec.source === this.name) {
+          sourceWithId = { ...incoming, id } as Record<string, unknown> & { id: string }
+        } else {
+          const primary = await this.derivationSource.getCollection(spec.source).get(id)
+          if (primary === null || primary === undefined) continue
+          sourceWithId = { ...primary, id } as Record<string, unknown> & { id: string }
+          sourceVersion = 0
+        }
         const ctx = { vault: this.derivationSource.getReadOnlyFacade() }
-        const result = await DerivationExecutor.run(spec, sourceWithId, version, strategyHash, ctx)
+        const result = await DerivationExecutor.run(spec, sourceWithId, sourceVersion, strategyHash, ctx)
         for (const key of Object.keys(spec.outputs)) {
           const out = result.outputs[key]
           if (!out) continue

--- a/packages/hub/src/derivations/registry.ts
+++ b/packages/hub/src/derivations/registry.ts
@@ -22,12 +22,22 @@ export class DerivationRegistry {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async register(spec: DerivationStrategy<any, any>): Promise<void> {
     const outputKeys = Object.keys(spec.outputs)
-    const strategyHash = await computeStrategyHash(spec.source, outputKeys, spec.derive)
+    const strategyHash = await computeStrategyHash(spec.source, outputKeys, spec.derive, spec.sources)
     const reg: RegisteredStrategy = { spec, strategyHash }
 
     const fromSource = this._bySource.get(spec.source)
     if (fromSource) fromSource.push(reg)
     else this._bySource.set(spec.source, [reg])
+
+    // Declared sibling sources (#344) index the SAME `reg` under each
+    // extra collection so `strategiesForSource(extra)` returns it and a
+    // sibling write re-fires the derivation. Sibling keys also enter
+    // `_bySource`, so `validate()`'s cycle DFS walks them automatically.
+    for (const extra of spec.sources ?? []) {
+      const fromExtra = this._bySource.get(extra)
+      if (fromExtra) fromExtra.push(reg)
+      else this._bySource.set(extra, [reg])
+    }
 
     for (const key of outputKeys) {
       const output = spec.outputs[key]

--- a/packages/hub/src/derivations/strategy-hash.ts
+++ b/packages/hub/src/derivations/strategy-hash.ts
@@ -1,6 +1,7 @@
 /**
  * Deterministic hash of a derivation strategy's "shape": source
- * collection, output keys, derive function source. Used to detect
+ * collection, declared sibling sources, output keys, derive function
+ * source. Used to detect
  * strategy drift: a record whose `_derivedFrom.strategyHash` doesn't
  * match the current strategy is considered stale.
  *
@@ -11,11 +12,16 @@ export async function computeStrategyHash(
   outputKeys: readonly string[],
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   derive: (...args: any[]) => any,
+  sources?: ReadonlyArray<string>,
 ): Promise<string> {
   const canonical = JSON.stringify({
     source,
     outputs: [...outputKeys].sort(),
     derive: derive.toString(),
+    // Declared sibling sources (#344) — adding/removing a trigger
+    // collection invalidates cached derived records. Omitted when empty
+    // so strategies without siblings keep their existing hash.
+    ...(sources?.length ? { sources: [...sources].sort() } : {}),
   })
   const bytes = new TextEncoder().encode(canonical)
   const digest = await crypto.subtle.digest('SHA-256', bytes)

--- a/packages/hub/src/derivations/types.ts
+++ b/packages/hub/src/derivations/types.ts
@@ -108,6 +108,32 @@ export interface DerivationStrategy<
 > {
   /** Source collection name. */
   source: string
+  /**
+   * Additional collections whose writes ALSO re-fire this derivation
+   * (issue #344). By default only writes to the single declared
+   * `source` re-trigger a derivation; a `derive` that reads sibling
+   * collections via `ctx.vault` therefore goes stale when those
+   * siblings change. Declare those sibling collections here to wire
+   * them as extra triggers.
+   *
+   * **SAME-ID assumption (load-bearing):** when a write lands on one of
+   * these declared collections, the derivation re-fires with the
+   * PRIMARY `source` record read at the SAME id as the written record
+   * — NOT the written sibling record itself. If no primary `source`
+   * record exists at that id, the re-fire is a silent no-op (no throw,
+   * no output mutation). Model your collections so the sibling and the
+   * primary share an id (the common money/accounting case: an
+   * `allocations` row and its `payments`/`bills` keyed by the same id),
+   * or trigger off a collection you control the id-space of.
+   *
+   * Declared collections participate in cycle detection and are indexed
+   * in the registry's `_bySource` exactly like `source`, so a sibling
+   * that is also a derivation output forms a detectable cycle.
+   *
+   * Each entry must be a non-empty string and must not equal `source`
+   * (validated at `withDerivation()` construction time).
+   */
+  sources?: ReadonlyArray<string>
   /** v1: only deterministic derivations supported. */
   deterministic: true
   /**

--- a/packages/hub/src/derivations/with-derivation.ts
+++ b/packages/hub/src/derivations/with-derivation.ts
@@ -26,6 +26,22 @@ export function withDerivation<
     throw new ValidationError('withDerivation: derive must be a function')
   }
 
+  // Validate declared sibling sources (#344). Each must be a non-empty
+  // string and must differ from the primary source — a self-reference
+  // would double-register the strategy under the same `_bySource` key.
+  if (spec.sources !== undefined) {
+    for (const extra of spec.sources) {
+      if (typeof extra !== 'string' || extra.length === 0) {
+        throw new ValidationError('withDerivation: each entry in sources[] must be a non-empty string')
+      }
+      if (extra === spec.source) {
+        throw new ValidationError(
+          `withDerivation: sources[] must not contain the primary source "${spec.source}"`,
+        )
+      }
+    }
+  }
+
   // Validate array-shape outputs.
   const lifecycleMode = typeof spec.lifecycle === 'string' ? spec.lifecycle : spec.lifecycle.mode
   for (const [outputKey, outputSpec] of Object.entries(spec.outputs)) {

--- a/packages/hub/src/guards/immutable-guard.ts
+++ b/packages/hub/src/guards/immutable-guard.ts
@@ -27,7 +27,7 @@
  */
 
 import { withGuard } from './with-guard.js'
-import type { GuardStrategy, GuardStrategyHandle, GuardContext } from './types.js'
+import type { GuardStrategy, GuardStrategyHandle, GuardContext, GuardChange } from './types.js'
 import { RecordLockedError, ValidationError } from '../errors.js'
 
 export interface ImmutableGuardConfig<T extends Record<string, unknown>> {
@@ -44,6 +44,24 @@ export interface ImmutableGuardConfig<T extends Record<string, unknown>> {
   appendOnly?: boolean
   /** Roles permitted to override via an amendment transaction. Default `['admin', 'owner']`. */
   amendmentRoles?: ReadonlyArray<'admin' | 'owner'>
+  /**
+   * Optional set-level invariant run over the amendment change-set after
+   * the writes execute. Signature matches `GuardStrategy.amendment.invariant`
+   * exactly: it receives every {before, after} pair touching this
+   * collection in the amendment plus the guard context; throwing reverts
+   * the whole amendment and surfaces as `InvariantError`.
+   *
+   * Use this to keep a constraint inviolable EVEN under amendment — e.g.
+   * forbid deleting an issued document by re-throwing on any
+   * `before !== null && after === null` change, or assert a cross-record
+   * sum is preserved. When omitted the amendment is unconditionally
+   * allowed (the amendment itself is the sanctioned, ledgered override) —
+   * this is the backward-compatible default.
+   */
+  amendmentInvariant?: (
+    changes: ReadonlyArray<GuardChange<T>>,
+    ctx: GuardContext<T>,
+  ) => Promise<void> | void
 }
 
 function recordId(record: Record<string, unknown> | null): string {
@@ -58,7 +76,7 @@ function recordId(record: Record<string, unknown> | null): string {
 export function immutableGuard<T extends Record<string, unknown>>(
   config: ImmutableGuardConfig<T>,
 ): GuardStrategyHandle<T> {
-  const { collection, after, appendOnly, amendmentRoles } = config
+  const { collection, after, appendOnly, amendmentRoles, amendmentInvariant } = config
   if (appendOnly && after !== undefined) {
     throw new ValidationError('immutableGuard: `after` and `appendOnly` are mutually exclusive')
   }
@@ -86,13 +104,17 @@ export function immutableGuard<T extends Record<string, unknown>>(
       }
     },
     // The authorized override: inside an amendment transaction the
-    // check/onDelete are skipped and the change is ledgered. No extra
-    // invariant — the amendment itself is the sanctioned exception.
+    // check/onDelete are skipped and the change is ledgered. By default
+    // there is no extra invariant — the amendment itself is the
+    // sanctioned exception. Callers may supply `amendmentInvariant` to
+    // keep a constraint inviolable even under amendment (e.g. forbid
+    // deletes, or preserve a cross-record sum); a throw reverts the
+    // amendment and surfaces as `InvariantError`.
     amendment: {
       roles: amendmentRoles ?? ['admin', 'owner'],
-      invariant: () => {
+      invariant: amendmentInvariant ?? (() => {
         /* allow — the amendment is the override, and is ledgered */
-      },
+      }),
     },
   }
 

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -288,8 +288,8 @@ export type {
 } from './archive/index.js'
 
 // ─── Atomic sequence (#303) ─────────────────────────────────────────────────────
-export { SequenceStore } from './sequence/index.js'
-export type { SequenceHandle, NextOptions } from './sequence/index.js'
+export { SequenceStore, resolveSequenceKey } from './sequence/index.js'
+export type { SequenceHandle, NextOptions, SequenceOptions } from './sequence/index.js'
 
 // Deferred numbering — store-clock-ordered serials for non-CAS stores.
 export { withDeferredNumbering } from './numbering/descriptor.js'
@@ -640,6 +640,8 @@ export { SyncTransaction } from './team/sync-transaction.js'
 // Multi-record transactions
 export { TxContext, TxVault, TxCollection, runTransaction } from './tx/transaction.js'
 export type { TxOp } from './types.js'
+export type { TransactionInvariant } from './tx/invariants.js'
+export type { TransactionStrategyOptions } from './tx/active.js'
 
 // Guards (record lock + field freeze + amendment invariant) — see docs/superpowers/specs/2026-05-18-guards-design.md
 export { withGuard } from './guards/index.js'
@@ -678,6 +680,7 @@ export type {
   MaterializedViewOutput,
   MaterializedFromMeta,
   UnionSource,
+  UnionArmJoin,
 } from './materialized-views/index.js'
 export {
   MaterializedViewCycleError,
@@ -691,6 +694,8 @@ export { withOverlayedView } from './overlay-views/index.js'
 export type {
   OverlayedViewStrategy,
   OverlayedViewStrategyHandle,
+  OverlayFieldMergeRule,
+  OverlayFieldMergeMode,
 } from './overlay-views/index.js'
 export {
   OverlayBaseIsVirtualError,

--- a/packages/hub/src/materialized-views/dependency-analyzer.ts
+++ b/packages/hub/src/materialized-views/dependency-analyzer.ts
@@ -135,7 +135,16 @@ export function summarizeUnionPlan<T extends Record<string, unknown>>(
   spec: MaterializedViewStrategy<T>,
 ): string {
   const arms = (spec.unionSources ?? [])
-    .map(s => s.collection)
+    .map(s => {
+      // Fold each arm's join legs into the summary so adding or
+      // reordering joins (which changes the materialized rows) bumps
+      // queryHash. Leg order is declaration-significant (legs chain), so
+      // it is NOT sorted — same rationale as arm declaration order.
+      const joins = s.join?.length
+        ? `[${s.join.map(j => `${j.field}→${j.as}`).join(';')}]`
+        : ''
+      return `${s.collection}${joins}`
+    })
     .join(',')
   const groupBy: string = Array.isArray(spec.groupBy)
     ? [...spec.groupBy].sort().join(',')
@@ -143,5 +152,10 @@ export function summarizeUnionPlan<T extends Record<string, unknown>>(
       ? spec.groupBy
       : ''
   const aggKeys = spec.aggregate ? Object.keys(spec.aggregate).sort().join(',') : ''
-  return `union(${arms})|groupBy(${groupBy})|aggregate(${aggKeys})`
+  // `moneyFields` changes reducer semantics (float → exact BigInt), so
+  // declaring / removing / re-keying it must bump queryHash. Keys are
+  // sorted — they're independent of each other (one descriptor per
+  // output field), same rationale as aggregate keys.
+  const moneyKeys = spec.moneyFields ? Object.keys(spec.moneyFields).sort().join(',') : ''
+  return `union(${arms})|groupBy(${groupBy})|aggregate(${aggKeys})|money(${moneyKeys})`
 }

--- a/packages/hub/src/materialized-views/executor.ts
+++ b/packages/hub/src/materialized-views/executor.ts
@@ -103,7 +103,20 @@ async function materializeUnionResult<TRow extends Record<string, unknown>>(
   const unified: TRow[] = []
   for (const arm of spec.unionSources!) {
     const coll = db.collection<Record<string, unknown>>(arm.collection)
-    const sourceRows = coll.query().toArray()
+    // Optional per-arm FK joins: chain `.join(field, { as, ... })` for
+    // each declared leg before terminating. The aliased right-side
+    // record lands at `sourceRow[leg.as]`, where the arm's `map` reads
+    // it. Cast to `any` because the chained join widens the row type but
+    // the executor treats every row as `Record<string, unknown>` — same
+    // pattern the query-form join path uses.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let q: any = coll.query()
+    if (arm.join?.length) {
+      for (const leg of arm.join) {
+        q = q.join(leg.field, { as: leg.as, maxRows: leg.maxRows, strategy: leg.strategy })
+      }
+    }
+    const sourceRows = q.toArray() as ReadonlyArray<Record<string, unknown>>
     for (const r of sourceRows) {
       const mapped = arm.map(r)
       // null / undefined means "omit this source row" — skip without
@@ -133,7 +146,7 @@ async function materializeUnionResult<TRow extends Record<string, unknown>>(
   // groupBy + aggregate — delegate to the shared pipeline used by
   // `Query.groupBy().aggregate()`. Result rows carry each grouped
   // field in declaration order followed by the spec's reducer outputs.
-  return groupAndReduce<Record<string, unknown>>(unified, groupFields, spec.aggregate)
+  return groupAndReduce<Record<string, unknown>>(unified, groupFields, spec.aggregate, spec.moneyFields)
 }
 
 /**

--- a/packages/hub/src/materialized-views/index.ts
+++ b/packages/hub/src/materialized-views/index.ts
@@ -11,6 +11,7 @@ export type {
   MaterializedViewOutput,
   MaterializedFromMeta,
   UnionSource,
+  UnionArmJoin,
 } from './types.js'
 export type { RegisteredMV } from './registry.js'
 export type { MVExecutorAccessor, RefreshResult } from './executor.js'

--- a/packages/hub/src/materialized-views/registry.ts
+++ b/packages/hub/src/materialized-views/registry.ts
@@ -81,6 +81,11 @@ export class MaterializedViewRegistry {
     let isQuery = false
     if (spec.unionSources) {
       dependencies = new Set(spec.unionSources.map(s => s.collection))
+      // Per-arm joins resolve right-side collections that aren't among
+      // the arm `collection`s. The consumer lists those in `sources`;
+      // fold them into the dependency set so a write to a join-target
+      // collection triggers MV refresh (and contributes a cycle edge).
+      if (spec.sources) for (const s of spec.sources) dependencies.add(s)
       queryPlanSummary = summarizeUnionPlan(spec)
     } else {
       const q = spec.query!(dbForQuery)

--- a/packages/hub/src/materialized-views/types.ts
+++ b/packages/hub/src/materialized-views/types.ts
@@ -1,6 +1,8 @@
 import type { Query } from '../query/builder.js'
 import type { Collection } from '../collection.js'
 import type { AggregateSpec } from '../aggregate/aggregation.js'
+import type { JoinStrategy } from '../query/join.js'
+import type { MoneyDescriptor } from '../money/descriptor.js'
 
 /**
  * Minimal vault-shaped accessor passed to the MV `query()` callback.
@@ -82,8 +84,40 @@ export interface UnionSource<TRow extends Record<string, unknown>> {
    * unified stream and never reaches `groupBy` / `aggregate`. This
    * removes the need for sentinel rows (e.g. `{ amount: 0 }`) whose
    * sole purpose is to be aggregated away (#297).
+   *
+   * When this arm declares {@link join}, the aliased right-side
+   * record(s) are attached to the source row under each leg's `as`
+   * BEFORE `map` runs, so `map` can read `sourceRow[leg.as]`.
    */
   readonly map: (sourceRow: Record<string, unknown>) => TRow | null | undefined
+  /**
+   * Optional FK joins to apply to this arm's rows before {@link map}.
+   * Each leg resolves a `ref()`-declared foreign key on the arm's
+   * source collection into an attached right-side record under
+   * `as` — the same machinery as the query-form `Query.join()`.
+   *
+   * The right-side collections must be listed in the strategy's
+   * {@link MaterializedViewStrategy.sources} so writes to them trigger
+   * MV refresh — registration throws `MaterializedViewConfigError`
+   * otherwise (the union dependency set comes from arm `collection`s
+   * alone, which would not include join targets).
+   */
+  readonly join?: ReadonlyArray<UnionArmJoin>
+}
+
+/**
+ * One FK join leg on a UNION arm. Mirrors the option shape of the
+ * query-form `Query.join(field, { as, maxRows?, strategy? })`.
+ */
+export interface UnionArmJoin {
+  /** FK field on the arm's source collection (must have a `ref()` declared). */
+  readonly field: string
+  /** Alias under which the resolved right-side record attaches on the source row. */
+  readonly as: string
+  /** Per-side row ceiling override. `undefined` → the join default. */
+  readonly maxRows?: number
+  /** Planner strategy override. `undefined` → auto-select. */
+  readonly strategy?: JoinStrategy
 }
 
 /**
@@ -156,6 +190,25 @@ export interface MaterializedViewStrategy<TRow extends Record<string, unknown>> 
    * UNION-mode only. Ignored if {@link query} is set.
    */
   aggregate?: AggregateSpec
+  /**
+   * Money descriptors for the UNION-mode aggregate, keyed by the
+   * OUTPUT/intermediate field name as it appears in the mapped row and
+   * in {@link aggregate} (NOT the source collection's field name). When
+   * declared, any `sum` / `min` / `max` over a keyed field is rewritten
+   * into an exact per-currency BigInt reducer — without this, money
+   * aggregation in UNION mode silently runs in float (since the
+   * concatenated mapped stream is a plain array with no collection
+   * money context to inherit).
+   *
+   * UNION-mode only — the query form inherits its money descriptors
+   * from the source collection automatically. The descriptor's
+   * currency/scale must match what the arms' `map()` emits for that
+   * field (each arm maps into the same unified shape, so one descriptor
+   * per output field covers all arms). Meaningless without
+   * {@link aggregate}; registration throws `MaterializedViewConfigError`
+   * if declared alone.
+   */
+  moneyFields?: Record<string, MoneyDescriptor>
   /**
    * Pure function from a materialized row → stable id used in the
    * output collection. Required — explicit always beats default-with-pitfalls

--- a/packages/hub/src/materialized-views/with-materialized-view.ts
+++ b/packages/hub/src/materialized-views/with-materialized-view.ts
@@ -85,6 +85,27 @@ export function withMaterializedView<TRow extends Record<string, unknown>>(
         + `use groupBy to declare the bucketing keys, or remove aggregate for a pure dedup MV`,
       )
     }
+    // `moneyFields` only has meaning when there's an aggregate to
+    // money-rewrite — it keys reducer outputs, so declaring it without
+    // `aggregate` is a no-op config mistake.
+    if (spec.moneyFields && !spec.aggregate) {
+      throw new MaterializedViewConfigError(
+        `withMaterializedView "${spec.name}": moneyFields requires aggregate — `
+        + `moneyFields rewrites sum/min/max reducers over money output fields, `
+        + `so it is meaningless without an aggregate spec`,
+      )
+    }
+    // Per-arm joins resolve right-side collections that the union
+    // dependency set (built from arm `collection`s alone) does NOT
+    // include. The consumer must list those right-side collections in
+    // `sources` so writes to them trigger MV refresh.
+    if (spec.unionSources.some(s => s.join && s.join.length > 0) && (!spec.sources || spec.sources.length === 0)) {
+      throw new MaterializedViewConfigError(
+        `withMaterializedView "${spec.name}": a unionSources arm declares join(s) but `
+        + `no \`sources\` are listed — declare sources: [...] with the right-side `
+        + `(join-target) collection names so writes to them trigger MV refresh`,
+      )
+    }
     if (spec.predicates) {
       throw new MaterializedViewConfigError(
         `withMaterializedView "${spec.name}": predicates are not supported on UNION strategies — `

--- a/packages/hub/src/money/money-reducer.ts
+++ b/packages/hub/src/money/money-reducer.ts
@@ -23,7 +23,7 @@
  */
 
 import { readPath } from '../query/predicate.js'
-import { formatScaledInt } from './fixed-point.js'
+import { formatScaledInt, parseToScaledInt } from './fixed-point.js'
 import { scaleForCurrency } from './iso4217.js'
 import { MoneyUnsupportedError } from './descriptor.js'
 import type { MoneyDescriptor } from './descriptor.js'
@@ -37,13 +37,39 @@ interface ReadMoney {
   value: bigint
 }
 
-function toScaledInt(v: unknown): bigint | null {
-  if (typeof v === 'string' || typeof v === 'number' || typeof v === 'bigint') {
-    try {
-      return BigInt(v)
-    } catch {
-      return null
+/**
+ * Coerce an arbitrary money-field value into its scaled `BigInt` at the
+ * given `scale`. Handles the two shapes a money field can arrive in by
+ * the time it reaches a reducer:
+ *
+ *   - **stored form** — a bare scaled-integer string (`'12345'`) or a
+ *     `bigint`. No decimal point, so `BigInt(v)` is the fast path.
+ *   - **decoded form** — a canonical decimal string (`'123.45'`), which
+ *     is what `query().toArray()` / `decodeMoneyFields` produce (UNION
+ *     arms map over decoded rows). `BigInt('123.45')` throws, so these
+ *     route through `parseToScaledInt(v, scale)`.
+ *
+ * A `number` is treated as a decimal magnitude (parsed at `scale`).
+ * Anything unparseable → `null`.
+ */
+function toScaledIntFromAny(v: unknown, scale: number): bigint | null {
+  if (typeof v === 'bigint') return v
+  if (typeof v === 'number') {
+    const r = parseToScaledInt(v, scale)
+    return r.ok ? r.value : null
+  }
+  if (typeof v === 'string') {
+    if (!v.includes('.')) {
+      // Stored scaled-integer form (e.g. '12345') — no decimal point.
+      try {
+        return BigInt(v)
+      } catch {
+        return null
+      }
     }
+    // Decoded canonical-decimal form (e.g. '123.45').
+    const r = parseToScaledInt(v, scale)
+    return r.ok ? r.value : null
   }
   return null
 }
@@ -53,14 +79,16 @@ function readMoney(record: unknown, field: string, desc: MoneyDescriptor): ReadM
   const raw = readPath(record, field)
   if (raw === null || raw === undefined) return null
   if (desc.mode === 'fixed') {
-    const value = toScaledInt(raw)
-    return value === null ? null : { currency: desc.fixedCurrency!, value }
+    const cur = desc.fixedCurrency!
+    const value = toScaledIntFromAny(raw, desc.scaleFor(cur))
+    return value === null ? null : { currency: cur, value }
   }
   // multi mode: stored as { amount, currency }
   if (typeof raw !== 'object') return null
   const o = raw as { amount?: unknown; currency?: unknown }
   if (typeof o.currency !== 'string') return null
-  const value = toScaledInt(o.amount)
+  const scale = desc.allows(o.currency) ? desc.scaleFor(o.currency) : 0
+  const value = toScaledIntFromAny(o.amount, scale)
   return value === null ? null : { currency: o.currency, value }
 }
 

--- a/packages/hub/src/overlay-views/index.ts
+++ b/packages/hub/src/overlay-views/index.ts
@@ -4,6 +4,8 @@ export { OverlayedCollection } from './virtual-collection.js'
 export type {
   OverlayedViewStrategy,
   OverlayedViewStrategyHandle,
+  OverlayFieldMergeRule,
+  OverlayFieldMergeMode,
 } from './types.js'
 
 // Re-export errors for the subpath barrel.

--- a/packages/hub/src/overlay-views/types.ts
+++ b/packages/hub/src/overlay-views/types.ts
@@ -46,6 +46,52 @@ export interface OverlayedViewStrategy {
    */
   shadowField: string
   shadowValue: unknown
+  /**
+   * Optional field-level merge mode (AU+032 / #348). When present, a
+   * row whose `shadowField` does NOT equal `shadowValue` is no longer
+   * forced all-base: the rules below let an intermediate status pull a
+   * declared subset of fields from the overlay while every other field
+   * still comes from the base row.
+   *
+   * Absent `mergeMode` preserves the original binary behaviour
+   * exactly — overlay wins entirely iff `shadowField === shadowValue`,
+   * otherwise base wins.
+   */
+  mergeMode?: OverlayFieldMergeMode
+}
+
+/**
+ * One field-level merge rule. When the overlay row's `shadowField`
+ * equals `whenStatus`, the merged row takes `overlayFields` from the
+ * overlay and every other field from the base row.
+ *
+ * Always include `shadowField` in `overlayFields` so the status value
+ * itself propagates to the merged read (otherwise the merged row would
+ * carry the base's status, which is usually `undefined`).
+ */
+export interface OverlayFieldMergeRule {
+  /** The `overlay[shadowField]` value this rule matches. */
+  readonly whenStatus: unknown
+  /**
+   * Field names pulled from the overlay row when this rule matches.
+   * Fields absent on the overlay row are skipped (base value kept).
+   */
+  readonly overlayFields: readonly string[]
+}
+
+/**
+ * Field-level merge configuration. `rules` are evaluated in
+ * declaration order and the FIRST rule whose `whenStatus` matches the
+ * overlay's `shadowField` wins; later rules are not consulted.
+ *
+ * The binary shadow check (`shadowField === shadowValue` → overlay
+ * wins entirely) is always the implicit, highest-priority rule applied
+ * BEFORE any `rules` entry, so adding `mergeMode` never changes the
+ * full-override path.
+ */
+export interface OverlayFieldMergeMode {
+  readonly kind: 'field-merge'
+  readonly rules: readonly OverlayFieldMergeRule[]
 }
 
 /** Returned by `withOverlayedView()` and consumed by `createNoydb`. */

--- a/packages/hub/src/overlay-views/virtual-collection.ts
+++ b/packages/hub/src/overlay-views/virtual-collection.ts
@@ -8,7 +8,9 @@ import type { OverlayedViewStrategy } from './types.js'
  *
  * Implements the core `Collection<T>`-shaped read/write surface with
  * merge-on-read semantics:
- *   - `get(id)`: overlay row wins iff `overlay[shadowField] === shadowValue`
+ *   - `get(id)`: overlay row wins iff `overlay[shadowField] === shadowValue`;
+ *     when `spec.mergeMode` is set, an intermediate status may instead pull
+ *     a declared subset of fields from the overlay over the base (#348)
  *   - `list()` / `.query()`: union of ids, per-id merge applied
  *   - `put(record)` / `put(id, record)`: routes to overlay; id derived
  *     via the base MV's `rowKey` (validated on the two-arg form)
@@ -48,25 +50,14 @@ export class OverlayedCollection<T extends Record<string, unknown> = any> {
   /** Get the merged row by id. */
   async get(id: string): Promise<T | null> {
     const overlayRow = await this.overlayCollection.get(id)
-    if (overlayRow !== null && this.shadowPredicateApplies(overlayRow)) {
-      return overlayRow
-    }
     const baseRow = await this.baseCollection.get(id)
-    if (baseRow !== null) return baseRow
-    // No base row — but if an overlay row exists with the shadow
-    // predicate true, we returned it above. If overlay exists but
-    // predicate is false, return null (overlay exists but doesn't
-    // qualify, and there's no base to fall back to) — per spec
-    // operations table row "overlay exists, predicate false, no base".
-    return null
+    return this.mergeRows(overlayRow, baseRow)
   }
 
   /** List union of base + overlay ids, applying the merge per row. */
   async list(): Promise<T[]> {
     const baseRows = await this.baseCollection.list()
     const overlayRows = await this.overlayCollection.list()
-    // Build id → merged row, base-first then overlay applies shadow rule.
-    const merged = new Map<string, T>()
     const idOf = (row: T): string => {
       // Best-effort: use baseRowKey if available, else assume the row
       // has a `.id` field (common pattern). The spec requires every
@@ -76,24 +67,25 @@ export class OverlayedCollection<T extends Record<string, unknown> = any> {
       const idField = (row as Record<string, unknown>).id
       return typeof idField === 'string' ? idField : ''
     }
+    // Key base + overlay rows by id, then union the id sets and run the
+    // same per-id merge `get()` uses. Nulls (overlay-only rows that
+    // don't qualify and have no base) are filtered out.
+    const baseById = new Map<string, T>()
+    const overlayById = new Map<string, T>()
     for (const row of baseRows) {
       const id = idOf(row)
-      if (id) merged.set(id, row)
+      if (id) baseById.set(id, row)
     }
     for (const row of overlayRows) {
       const id = idOf(row)
-      if (!id) continue
-      if (this.shadowPredicateApplies(row)) {
-        merged.set(id, row) // overlay shadow wins
-      } else if (!merged.has(id)) {
-        // Overlay-only + predicate false + no base → don't surface
-        // (matches spec operations table)
-        continue
-      }
-      // else: overlay exists but predicate is false and base is
-      // present → keep the base row already in `merged`
+      if (id) overlayById.set(id, row)
     }
-    return [...merged.values()]
+    const out: T[] = []
+    for (const id of new Set([...baseById.keys(), ...overlayById.keys()])) {
+      const merged = this.mergeRows(overlayById.get(id) ?? null, baseById.get(id) ?? null)
+      if (merged !== null) out.push(merged)
+    }
+    return out
   }
 
   /**
@@ -139,9 +131,45 @@ export class OverlayedCollection<T extends Record<string, unknown> = any> {
     await this.overlayCollection.delete(id)
   }
 
-  /** True when `overlay[shadowField] === shadowValue`. */
-  private shadowPredicateApplies(row: T): boolean {
-    return (row as Record<string, unknown>)[this.spec.shadowField] === this.spec.shadowValue
+  /**
+   * Merge a single id's overlay + base rows into the visible row.
+   *
+   * Priority (first match wins):
+   *  1. Binary shadow win — overlay present AND
+   *     `overlay[shadowField] === shadowValue` → return the overlay row
+   *     entirely. This stays FIRST so the original binary behaviour is
+   *     unchanged whether or not `mergeMode` is configured.
+   *  2. Field-level merge — overlay present, `mergeMode` configured,
+   *     and a rule whose `whenStatus` equals `overlay[shadowField]`.
+   *     The matched rule pulls its `overlayFields` (those present on
+   *     the overlay row) on top of the base row. With no base row, the
+   *     overlay row is returned as-is.
+   *  3. Fallback — return the base row (possibly `null`). An
+   *     overlay-only row that qualifies under neither (1) nor (2) and
+   *     has no base is therefore NOT surfaced.
+   */
+  private mergeRows(overlayRow: T | null, baseRow: T | null): T | null {
+    const shadowField = this.spec.shadowField
+    if (
+      overlayRow !== null &&
+      (overlayRow as Record<string, unknown>)[shadowField] === this.spec.shadowValue
+    ) {
+      return overlayRow
+    }
+    if (overlayRow !== null && this.spec.mergeMode) {
+      const status = (overlayRow as Record<string, unknown>)[shadowField]
+      const rule = this.spec.mergeMode.rules.find((r) => r.whenStatus === status)
+      if (rule) {
+        if (baseRow === null) return overlayRow
+        const overlaySrc = overlayRow as Record<string, unknown>
+        const picked: Record<string, unknown> = {}
+        for (const field of rule.overlayFields) {
+          if (field in overlaySrc) picked[field] = overlaySrc[field]
+        }
+        return { ...(baseRow as Record<string, unknown>), ...picked } as T
+      }
+    }
+    return baseRow
   }
 
   // ─── Throw-stubs for the unimplemented Collection<T> surface ───────

--- a/packages/hub/src/sequence/index.ts
+++ b/packages/hub/src/sequence/index.ts
@@ -22,7 +22,7 @@
 import type { NoydbStore, EncryptedEnvelope } from '../types.js'
 import { NOYDB_FORMAT_VERSION } from '../types.js'
 import { encrypt, decrypt } from '../crypto.js'
-import { ConflictError, SequenceContentionError, SequenceOfflineError } from '../errors.js'
+import { ConflictError, SequenceContentionError, SequenceOfflineError, ValidationError } from '../errors.js'
 
 export const SEQUENCE_COLLECTION = '_sequences'
 // A sequence is a single hot CAS row — higher contention than a ledger
@@ -43,11 +43,69 @@ export interface NextOptions {
   readonly timeoutMs?: number
 }
 
+/**
+ * Partitioning for a CAS sequence (#345). A partitioned sequence is an
+ * independent counter scoped to one tuple of values — e.g.
+ * `sequence('invoice', { partition: [2026, 'EU'] })` numbers EU-2026 invoices
+ * separately from `[2026, 'US']` and from the bare `invoice` series.
+ *
+ * Partition components are URI-encoded (so `/`, null bytes and other
+ * separators in a value can never collide with the structural separators) and
+ * `'/'`-joined, then appended to the series with a null-byte (`\x00`)
+ * separator. The null byte is illegal in a plain series name, which guarantees
+ * a partitioned key is always disjoint from any unpartitioned series.
+ */
+export interface SequenceOptions {
+  /** Partition tuple. Each component is URI-encoded and `'/'`-joined. */
+  readonly partition?: readonly (string | number)[]
+}
+
+/**
+ * Resolve the CAS storage key for a (series, partition) pair.
+ *
+ * With no partition the key is `series` verbatim. With a partition the key is
+ * `${series}\x00${parts}` where `parts` is each component passed through
+ * `encodeURIComponent(String(part))` and `'/'`-joined. The null-byte separator
+ * is illegal in a plain series name, so partitioned keys never collide with
+ * unpartitioned ones; URI-encoding keeps any component containing `/` distinct
+ * from a multi-component partition.
+ *
+ * @throws {ValidationError} if any partition component is empty after `String()`
+ *   or is a non-finite number (`NaN`, `±Infinity`).
+ */
+export function resolveSequenceKey(series: string, opts?: SequenceOptions): string {
+  const partition = opts?.partition
+  if (!partition || partition.length === 0) return series
+  const parts = partition.map((p) => {
+    if (typeof p === 'number' && !Number.isFinite(p)) {
+      throw new ValidationError(`sequence partition component must be a finite number, got ${p}`)
+    }
+    const s = String(p)
+    if (s === '') {
+      throw new ValidationError('sequence partition component must not be empty')
+    }
+    return encodeURIComponent(s)
+  })
+  return `${series}\x00${parts.join('/')}`
+}
+
 export interface SequenceHandle {
   /** Atomically allocate and return the next value (1, 2, 3, …). Deferred series resolve at the next pass. */
   next(opts?: NextOptions): Promise<number>
   /** Read the current value without allocating. Returns 0 if never used. */
   peek(): Promise<number>
+  /**
+   * Set-if-greater: advance the counter to at least `n`. A no-op if the
+   * current value is already `>= n` (so it never rewinds), and `seedTo(0)` is
+   * a no-op. Idempotent and CAS-safe under concurrent `next()` / `seedTo()`.
+   *
+   * Use after a bundle / CSV import to fast-forward the counter past the
+   * highest imported serial, so subsequent `next()` calls cannot re-use a
+   * number that is already on a record.
+   *
+   * Online-only: throws {@link SequenceOfflineError} on a non-CAS store.
+   */
+  seedTo(n: number): Promise<void>
 }
 
 async function sleepBackoff(attempt: number): Promise<void> {
@@ -92,6 +150,7 @@ export class SequenceStore {
     return {
       next: () => this.next(name),
       peek: () => this.peek(name),
+      seedTo: (n) => this.seedTo(name, n),
     }
   }
 
@@ -138,6 +197,31 @@ export class SequenceStore {
       try {
         await this.adapter.put(this.vault, SEQUENCE_COLLECTION, name, envelope, expectedVersion)
         return nextValue
+      } catch (err) {
+        if (err instanceof ConflictError) {
+          lastConflict = err
+          if (attempt < MAX_NEXT_ATTEMPTS - 1) await sleepBackoff(attempt)
+          continue
+        }
+        throw err
+      }
+    }
+    void lastConflict
+    throw new SequenceContentionError(name, MAX_NEXT_ATTEMPTS)
+  }
+
+  async seedTo(name: string, n: number): Promise<void> {
+    this.assertOnline()
+    if (n <= 0) return // set-if-greater: 0 (and any non-positive seed) is a no-op
+    let lastConflict: ConflictError | undefined
+    for (let attempt = 0; attempt < MAX_NEXT_ATTEMPTS; attempt++) {
+      const { env, value } = await this.read(name)
+      if (value >= n) return // already at or past the floor — no write, idempotent
+      const expectedVersion = env?._v ?? 0 // 0 ≡ "must not yet exist" (create)
+      const envelope = await this.encryptState({ value: n }, expectedVersion + 1)
+      try {
+        await this.adapter.put(this.vault, SEQUENCE_COLLECTION, name, envelope, expectedVersion)
+        return
       } catch (err) {
         if (err instanceof ConflictError) {
           lastConflict = err

--- a/packages/hub/src/tx/active.ts
+++ b/packages/hub/src/tx/active.ts
@@ -5,12 +5,34 @@
 import { runTransaction } from './transaction.js'
 import { runDryRun } from './dry-run.js'
 import type { TxStrategy } from './strategy.js'
+import type { TransactionInvariant } from './invariants.js'
+
+/**
+ * Options for {@link withTransactions}. Currently only commit-time
+ * changeset `invariants` (see {@link TransactionInvariant}).
+ */
+export interface TransactionStrategyOptions {
+  /**
+   * Commit-time set-level invariants run over the changeset on every
+   * commit (ordinary AND amendment). See {@link TransactionInvariant}.
+   */
+  invariants?: ReadonlyArray<TransactionInvariant>
+}
 
 /**
  * Build the default transactions strategy. Pass into
  * `createNoydb({ txStrategy: withTransactions() })` to enable
  * `db.transaction(fn)` (and `db.transaction({ dryRun: true }, fn)`).
+ *
+ * Supply `{ invariants }` to register commit-time changeset invariants —
+ * set-level constraints that fire after the writes commit and revert the
+ * transaction on a throw. Unlike `amendment.invariant`, these run for
+ * ordinary `db.transaction(fn)` calls (and amendments) with no role gate.
  */
-export function withTransactions(): TxStrategy {
-  return { runTransaction, runDryRun }
+export function withTransactions(opts?: TransactionStrategyOptions): TxStrategy {
+  const invariants = opts?.invariants ?? []
+  return {
+    runTransaction: (db, fn, options) => runTransaction(db, fn, options, invariants),
+    runDryRun,
+  }
 }

--- a/packages/hub/src/tx/index.ts
+++ b/packages/hub/src/tx/index.ts
@@ -6,7 +6,9 @@
  * code.
  */
 export { withTransactions } from './active.js'
+export type { TransactionStrategyOptions } from './active.js'
 export type { TxStrategy } from './strategy.js'
+export type { TransactionInvariant } from './invariants.js'
 
 export { TxContext, TxVault, TxCollection, runTransaction } from './transaction.js'
 export type { AmendmentTxOptions } from './transaction.js'

--- a/packages/hub/src/tx/invariants.ts
+++ b/packages/hub/src/tx/invariants.ts
@@ -1,0 +1,73 @@
+/**
+ * Commit-time changeset invariants for ordinary transactions.
+ *
+ * Today the only set-level invariant hook is `amendment.invariant`, which
+ * fires solely inside `db.transaction({ amendment: true }, …)` and requires
+ * an admin/owner role plus a registered guard. That is the right shape for
+ * the WORM-override path, but normal application transactions also need
+ * cross-record invariants that hold on every commit — e.g. niwat's
+ * `assertR1` ("every payment is 100% receipted").
+ *
+ * `withTransactions({ invariants: [...] })` registers such invariants. Each
+ * one names a `scope` (a collection) and a `check(changes, ctx)` callback
+ * that receives the commit's change-set for that collection.
+ *
+ * ## Semantics
+ *
+ * - **`scope`** is a collection name. An invariant fires only when the
+ *   committed transaction wrote at least one record in that collection.
+ * - **When** — at commit, AFTER Phase 2 has executed all staged ops (so
+ *   `after` reflects the written record), and after the amendment commit
+ *   phase. It runs for BOTH ordinary and amendment transactions — an
+ *   amendment is still a commit and is still subject to these invariants.
+ * - **`changes`** — one `{ before, after }` pair per touched id (deduped to
+ *   the last write per id, preserving write order). `before` is the
+ *   plaintext prior record (captured in Phase 1 before the overwrite),
+ *   `null` for an insert. `after` is the written record, `null` for a
+ *   delete.
+ * - **Throw → revert.** A throw reverts every executed op (via the shared
+ *   `revertExecuted` unwind) and is surfaced as `InvariantError` (an
+ *   `InvariantError` thrown by the check passes through unwrapped).
+ *
+ * ```ts
+ * createNoydb({ txStrategy: withTransactions({
+ *   invariants: [{
+ *     scope: 'payments',
+ *     check(changes) {
+ *       for (const { after } of changes) {
+ *         const p = after as Payment | null
+ *         if (p && p.receiptAmount !== p.amount) {
+ *           throw new InvariantError('R1: payment not fully receipted')
+ *         }
+ *       }
+ *     },
+ *   }],
+ * }) })
+ * ```
+ */
+
+import type { GuardChange, GuardContext } from '../guards/types.js'
+
+/**
+ * A commit-time set-level invariant for ordinary (and amendment)
+ * transactions. See module docs for full semantics.
+ */
+export interface TransactionInvariant {
+  /**
+   * The collection this invariant watches. The `check` fires only when the
+   * committed transaction wrote at least one record in this collection.
+   */
+  readonly scope: string
+  /**
+   * Validate the change-set for {@link scope}. `changes` carries one
+   * `{ before, after }` pair per touched id (deduped to last-write,
+   * write-order preserved); `before` is the plaintext prior record (null
+   * on insert), `after` is the written record (null on delete). Throw to
+   * revert the whole transaction — the throw is surfaced as
+   * `InvariantError`.
+   */
+  check: (
+    changes: ReadonlyArray<GuardChange<unknown>>,
+    ctx: GuardContext<unknown>,
+  ) => Promise<void> | void
+}

--- a/packages/hub/src/tx/strategy.ts
+++ b/packages/hub/src/tx/strategy.ts
@@ -10,6 +10,7 @@
 import type { Noydb } from '../noydb.js'
 import type { TxContext, AmendmentTxOptions } from './transaction.js'
 import type { DryRunResult } from './dry-run.js'
+import type { TransactionInvariant } from './invariants.js'
 
 /**
  * @internal
@@ -19,6 +20,7 @@ export interface TxStrategy {
     db: Noydb,
     fn: (tx: TxContext) => Promise<T> | T,
     options?: AmendmentTxOptions,
+    txInvariants?: ReadonlyArray<TransactionInvariant>,
   ): Promise<T>
   runDryRun(db: Noydb, fn: (tx: TxContext) => unknown): Promise<DryRunResult>
 }
@@ -33,6 +35,11 @@ const NOT_ENABLED = new Error(
  * @internal
  */
 export const NO_TX: TxStrategy = {
-  async runTransaction() { throw NOT_ENABLED },
+  async runTransaction(
+    _db: Noydb,
+    _fn: unknown,
+    _options?: AmendmentTxOptions,
+    _txInvariants?: ReadonlyArray<TransactionInvariant>,
+  ): Promise<never> { throw NOT_ENABLED },
   async runDryRun() { throw NOT_ENABLED },
 }

--- a/packages/hub/src/tx/transaction.ts
+++ b/packages/hub/src/tx/transaction.ts
@@ -70,6 +70,8 @@ import {
 import { generateULID } from '../bundle/ulid.js'
 import type { GuardExecutor as GuardExecutorModule } from '../guards/executor.js'
 import type { LedgerEntry } from '../history/ledger/entry.js'
+import type { TransactionInvariant } from './invariants.js'
+import type { GuardChange, GuardContext, ReadOnlyVaultFacade } from '../guards/types.js'
 
 /** One op buffered inside a running `TxContext`. @internal */
 export interface StagedOp {
@@ -288,6 +290,7 @@ export async function runTransaction<T>(
   db: Noydb,
   fn: (tx: TxContext) => Promise<T> | T,
   options?: AmendmentTxOptions,
+  txInvariants?: ReadonlyArray<TransactionInvariant>,
 ): Promise<T> {
   // ─── Amendment-mode pre-flight ───────────────────────────────
   // `reason` is the only thing we can validate before the body runs;
@@ -333,11 +336,28 @@ export async function runTransaction<T>(
   // state; the in-order replay in Phase 2 takes care of successor ops.
   const priorEnvelopes = new Map<string, EncryptedEnvelope | null>()
   const store = db._store
+
+  // Commit-time changeset invariants (#342) need PLAINTEXT prior records
+  // for `before`, but `priorEnvelopes` holds ENCRYPTED envelopes. So for
+  // ops in a watched scope we additionally decrypt the prior record here,
+  // in Phase 1, BEFORE Phase 2 overwrites it. Snapshots only the initial
+  // committed state per (vault, coll, id), matching the envelope snapshot.
+  const invariants = txInvariants ?? []
+  const watchedScopes = new Set(invariants.map(i => i.scope))
+  const plainBefore = new Map<string, unknown>()
+
   for (const op of ctx._ops) {
     const key = keyOf(op)
     if (!priorEnvelopes.has(key)) {
       const env = await store.get(op.vaultName, op.collectionName, op.id)
       priorEnvelopes.set(key, env)
+    }
+    if (watchedScopes.has(op.collectionName) && !plainBefore.has(key)) {
+      const prior = await db
+        .vault(op.vaultName)
+        .collection(op.collectionName)
+        .get(op.id)
+      plainBefore.set(key, prior ?? null)
     }
     if (op.expectedVersion !== undefined) {
       const env = priorEnvelopes.get(key) ?? null
@@ -476,6 +496,86 @@ export async function runTransaction<T>(
           })
         }
         void vaultName
+      }
+    } catch (err) {
+      await revertExecuted(ctx._executed, store, db)
+      throw err instanceof InvariantError ? err : new InvariantError(
+        err instanceof Error ? err.message : `invariant violated: ${String(err)}`,
+      )
+    }
+  }
+
+  // ─── Commit-time changeset invariant phase (#342) ───────────
+  // Runs for BOTH ordinary and amendment transactions (placed after the
+  // amendment phase so an amendment commit is still subject to these
+  // set-level constraints). Assemble the changeset from the executed
+  // staged ops, deduped to the LAST write per (vault, coll, id) while
+  // preserving write order, then group `GuardChange` by collection
+  // (scope) and run each matching invariant. A throw mirrors the
+  // amendment-phase failure mode exactly: revert every executed op and
+  // re-throw as `InvariantError`.
+  if (invariants.length > 0) {
+    // Dedup ctx._ops to the last write per key, preserving first-seen
+    // (write) order so the changeset is stable and order-meaningful.
+    const lastOp = new Map<string, StagedOp>()
+    const order: string[] = []
+    for (const op of ctx._ops) {
+      const key = keyOf(op)
+      if (!lastOp.has(key)) order.push(key)
+      lastOp.set(key, op)
+    }
+
+    // Group {before, after} pairs by collection name (the invariant
+    // scope). `before` is the plaintext prior captured in Phase 1 (null
+    // for inserts / unwatched — only watched scopes were captured, and
+    // every grouped key belongs to a watched scope). `after` is the
+    // written record, null for a delete.
+    const changesByScope = new Map<string, GuardChange<unknown>[]>()
+    // Parallel map: scope → the vault name of its (last-seen) op, used to
+    // build the per-invariant read-only ctx (facade + userId + role).
+    const scopeVault = new Map<string, string>()
+    for (const key of order) {
+      const op = lastOp.get(key)!
+      if (!watchedScopes.has(op.collectionName)) continue
+      const before = plainBefore.get(key) ?? null
+      const after = op.type === 'delete' ? null : (op.record ?? null)
+      const change = { before, after } as GuardChange<unknown>
+      const arr = changesByScope.get(op.collectionName)
+      if (arr) arr.push(change)
+      else changesByScope.set(op.collectionName, [change])
+
+      // Stash the vault name alongside so we can build a per-vault ctx.
+      // (All ops in a scope group could span vaults; we resolve the
+      // vault per change below via a parallel map keyed the same way.)
+      scopeVault.set(op.collectionName, op.vaultName)
+    }
+
+    try {
+      for (const inv of invariants) {
+        const changes = changesByScope.get(inv.scope)
+        if (changes === undefined || changes.length === 0) continue
+        const vaultName = scopeVault.get(inv.scope)!
+        const v = db.vault(vaultName)
+        // Prefer the real read-only facade so the invariant can read
+        // sibling collections; fall back to a minimal read-only stub.
+        const facade: ReadOnlyVaultFacade =
+          v._getReadOnlyFacade() ?? {
+            collection<R = unknown>(name: string) {
+              const c = v.collection<R>(name)
+              return {
+                get: (id: string) => c.get(id),
+                list: () => c.list(),
+                query: () => c.query(),
+              }
+            },
+          }
+        const ctxForInv: GuardContext<unknown> = {
+          existing: null,
+          vault: facade,
+          userId: v.userId,
+          role: v.role,
+        }
+        await inv.check(changes, ctxForInv)
       }
     } catch (err) {
       await revertExecuted(ctx._executed, store, db)

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -45,7 +45,7 @@ import type { BlobStrategy } from './blobs/strategy.js'
 import type { ArchiveStrategy } from './archive/index.js'
 import type { ArchivePolicy, ArchiveContext, ArchiveResult, ArchiveRunOptions } from './archive/index.js'
 import { runArchive, runRestore, runListArchived } from './archive/index.js'
-import { SequenceStore, type SequenceHandle, SEQUENCE_COLLECTION } from './sequence/index.js'
+import { SequenceStore, type SequenceHandle, type SequenceOptions, resolveSequenceKey, SEQUENCE_COLLECTION } from './sequence/index.js'
 import { DeferredNumberingStore, type Assignment } from './numbering/index.js'
 import type { DeferredNumberingConfig } from './numbering/descriptor.js'
 import type { IndexStrategy } from './indexing/strategy.js'
@@ -1341,19 +1341,30 @@ export class Vault {
    * const cur = await vault.sequence('invoice-2026').peek()  // current value, no allocation
    * ```
    */
-  sequence(name: string): SequenceHandle {
+  sequence(series: string, opts?: SequenceOptions): SequenceHandle {
+    // A null byte is the structural partition separator in
+    // resolveSequenceKey; a series name carrying one could forge a
+    // partitioned key, so reject it (#345).
+    if (series.includes('\x00')) {
+      throw new ValidationError(`sequence("${series}"): series name must not contain a null byte (\\x00).`)
+    }
     // Deferred-numbering series route to the pass-based engine; `next({ for })`
-    // resolves at `runNumberingPass`. All other names use the CAS counter.
-    if (this.numberingConfigs.has(name)) {
+    // resolves at `runNumberingPass`. They are keyed by series only and have
+    // no CAS counter, so seedTo (CAS-only) is unavailable. All other names
+    // use the CAS counter.
+    if (this.numberingConfigs.has(series)) {
       const eng = this.deferred()
       return {
-        next: async (opts) => {
-          if (!opts?.for) {
-            throw new ValidationError(`sequence("${name}") is a deferred-numbering series; call next({ for: recordId }).`)
+        next: async (nextOpts) => {
+          if (!nextOpts?.for) {
+            throw new ValidationError(`sequence("${series}") is a deferred-numbering series; call next({ for: recordId }).`)
           }
-          return (await eng.enqueue(name, opts.for)).assigned
+          return (await eng.enqueue(series, nextOpts.for)).assigned
         },
-        peek: () => eng.peek(name),
+        peek: () => eng.peek(series),
+        seedTo: () => {
+          throw new ValidationError(`sequence("${series}") is a deferred-numbering series; seedTo is CAS-only.`)
+        },
       }
     }
     if (!this.sequenceStore) {
@@ -1365,7 +1376,7 @@ export class Vault {
         actor: this.keyring.userId,
       })
     }
-    return this.sequenceStore.handle(name)
+    return this.sequenceStore.handle(resolveSequenceKey(series, opts))
   }
 
   /** @internal — lazily build the deferred-numbering engine with a cache-coherent stamp. */
@@ -1724,9 +1735,29 @@ export class Vault {
           })
         }
         if (rule.mode === 'cascade') {
+          // Atomicity (#346): if a transaction is active, register each
+          // child's prior envelope on it BEFORE the delete so a later
+          // mid-batch failure rolls the cascade back alongside the
+          // parent. Mirrors how derivation outputs self-register on the
+          // active ctx. Outside a tx the context is null and we skip it.
+          const txCtx = this.noydb._activeTxContextOrNull
           for (const match of matches) {
             const matchId = (match['id'] as string | undefined) ?? null
             if (matchId === null) continue
+            if (txCtx !== null) {
+              const prior = await this.adapter.get(this.name, rule.collection, matchId)
+              if (prior !== null) {
+                txCtx._executed.push({
+                  op: {
+                    type: 'delete',
+                    vaultName: this.name,
+                    collectionName: rule.collection,
+                    id: matchId,
+                  },
+                  priorEnvelope: prior,
+                })
+              }
+            }
             // Recursive delete — the cycle breaker above catches
             // infinite loops.
             await fromCollection.delete(matchId)

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -410,11 +410,19 @@ const KERNEL_SURFACE_BUDGET = {
   // schema all see the get() shape) + canonicalizeStoredMoney at the gate
   // and derivation dispatch boundaries. Thin call-sites in the write hot
   // path; the canonicalization logic lives in src/money/normalize.ts.
-  'packages/hub/src/collection.ts': 4040,
+  // Bumped 4040→4060 (2026-06-13): #344 sibling-source derivations —
+  // dispatchDerivations re-reads the PRIMARY source record at the same id
+  // when a write arrives via a declared sibling (spec.source !== this.name).
+  // Thin branch in the write hot path; the registry/index logic lives in
+  // src/derivations/.
+  'packages/hub/src/collection.ts': 4060,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
-  'packages/hub/src/vault.ts': 3700,
+  // Bumped 3700→3735 (2026-06-13): #345 sequence partition/seedTo routing in
+  // `sequence()` (engine in src/sequence/) + #346 cascade-delete atomicity —
+  // child deletes register on the active TxContext inside enforceRefsOnDelete.
+  'packages/hub/src/vault.ts': 3735,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),


### PR DESCRIPTION
Fast-lanes the open niwat integration-audit work for the next release (pre.16): the urgent union-MV money bug plus the AU+026…AU+033 feature requests. All in one branch per request, as five reviewable commits.

## Scope

| Issue | What | Where |
|---|---|---|
| **#350** (urgent bug) | Union-form MVs summed money in **float** | `money-reducer`, `aggregate/groupby`, `materialized-views/*` |
| #342 (AU+026) | Commit-time changeset invariants for ordinary transactions | `tx/invariants` (new), `tx/transaction`, `tx/active` |
| #344 (AU+028) | `withDerivation` declared sibling `sources[]` | `derivations/*`, `collection.ts` |
| #345 (AU+029) | Partitioned + seedable `vault.sequence` | `sequence/index`, `vault.ts` |
| #346 (AU+030) | Cascade-delete **atomicity** | `vault.ts` |
| #347 (AU+031) | MV-side join leg in `unionSources` | `materialized-views/*` |
| #348 (AU+032) | Field-level-merge overlay (`mergeMode`) | `overlay-views/*` |
| #349 (AU+033) | `immutableGuard` `amendmentInvariant` knob | `guards/immutable-guard` |

### Notable findings during review
- **#350 was bigger than the issue stated.** Threading `moneyFields` is necessary but not sufficient: union `map()` emits *decoded canonical* decimal strings (`'10000.00'`), and the money reducer's `readMoney` did `BigInt(raw)`, which throws on those. The fix also teaches `readMoney` to parse both stored-int and canonical-decimal forms via `parseToScaledInt`. This is the last open slice of the **first-class-money milestone (#333)** and unblocks the `mvMoney` retirement for `billPaidByBill` / `receiptsByMonth` / `pnd53nAuto`.
- **#343 (AU+027) is already shipped** — the `computed/` subsystem (`vault.collection(name, { computed: { … } })`) already recomputes fields onto the source record at write time (`collection.ts`, with tests + a `features.yaml` entry). No code here; see the issue for the adoption recipe. The proposed `withComputedFields`/`onto:'self'` API is just a different spelling of what exists.
- **#346's cascade-delete already existed** via `ref(target, 'cascade')`; the real gap was atomicity. Cascaded child deletes now register their prior envelope on the active `TxContext` (mirroring how derivation outputs self-register), so a mid-batch failure rolls the whole cascade back with the parent. Behaviour outside a transaction is unchanged.
- **#349** is additive: the empty `amendment.invariant` was deliberate ("the amendment is the ledgered override"), so the default is preserved; `amendmentInvariant` is an opt-in to keep a constraint inviolable even under amendment.

## Backward compatibility
Every change is additive. New optional fields (`MaterializedViewStrategy.moneyFields`, `UnionSource.join`, `DerivationStrategy.sources`, `OverlayedViewStrategy.mergeMode`, `ImmutableGuardConfig.amendmentInvariant`, `withTransactions({ invariants })`, `vault.sequence(series, { partition })` + `seedTo`) all default to prior behaviour when omitted.

## Verification
- `typecheck` ✅ (tsc + typetest)
- `test` ✅ **256 files / 2472 tests** (incl. new suites: union-money 8, union-arm-join 6, tx-invariants 5, sibling-sources 8, strategy-hash 8, immutable-guard amendmentInvariant, sequence partition/seedTo 14, overlay field-merge, refs cascade atomicity)
- `lint` ✅ 0 errors (1 pre-existing warning in untouched `introspection/fields.ts`)
- `validate:features` ✅

## Docs / registry
- New spec `docs/superpowers/specs/2026-06-13-tx-commit-invariants-design.md`; `immutable-guard` spec extended.
- `features.yaml` invariants updated across schema-and-refs, atomic-sequence, transactions, derivations, materialized-views, overlay-views, immutable-guard.

## Notes for the release / downstream
- Epic **#341** and umbrella **#333** can close once this ships in pre.16 and niwat validates the retirements (`mvMoney`, the cert-void cascade, `recalcLines` via `computed`, `touchAffected()`, `seedSequenceFromMax`, the freeze-guarantee).
- No version bump / changeset here — that's the separate manual lockstep release PR.

Closes #342
Closes #344
Closes #345
Closes #346
Closes #347
Closes #348
Closes #349
Closes #350