### PR TITLE
feat(hub): per-record CEK foundation (#304/#306 epic step 1)

### DIFF
--- a/docs/core/02-encryption.md
+++ b/docs/core/02-encryption.md
@@ -34,6 +34,27 @@ Passphrase
 
 `_v` and `_ts` are NOT encrypted — the sync engine needs them without keys. Everything in `_data` IS encrypted.
 
+## Per-record keys (CEK) — opt-in
+
+By default one per-collection DEK encrypts every record body. Opt a collection into per-record content-encryption keys with `vault.collection(name, { perRecordKeys: true })` and each record gets its own AES-256-GCM **CEK**, AES-KW-wrapped under the collection DEK and stored on the envelope's `_cek`:
+
+```json
+{
+  "_noydb": 1, "_v": 3, "_ts": "…",
+  "_iv": "<base64>", "_data": "<base64 ciphertext, encrypted under the CEK>",
+  "_cek": "<base64 AES-KW-wrapped CEK, wrapped under the collection/tier DEK>"
+}
+```
+
+- **Discriminant is `_cek` presence, not the flag.** A record with `_cek` is decrypted by unwrapping the CEK under the collection DEK then decrypting the body under the CEK; a record without it takes the legacy path (body directly under the collection DEK). So a collection without `perRecordKeys` is byte-identical to before, and a mixed vault — or a recipient that never set the flag — reads both kinds.
+- **Stable across versions.** Insert mints the CEK; updates and history snapshots reuse it, so every `_history` envelope for a record carries the same `_cek`. A session-scoped LRU caches the unwrapped CEK per `(collection, id)`.
+- **`_det` stays DEK-keyed.** Deterministic blind-equality slots remain keyed to the collection DEK (equal plaintext → equal ciphertext across records), explicitly excluded from CEK scope.
+- **Tiers compose.** `elevate`/`demote` re-wrap the *same* CEK from the source tier DEK to the target tier DEK; the body key is unchanged.
+- **Bundles re-wrap.** Extract/partition re-key (`reKeyClosure`) unwraps each `_cek` under the source DEK and re-wraps it under the fresh destination DEK, so adopted records stay decryptable.
+- **Tombstone-tolerant read.** A `get()` on an envelope with no `_data`/`_cek` returns `null` rather than throwing `TamperedError`.
+
+This is the foundation (step 1) for per-record erasure (`forget()` / shred, #304) and record-scoped sealing (#306), which build on top in their own slices. See `docs/superpowers/specs/2026-06-13-per-record-cek-foundation-design.md`.
+
 ## Plaintext mode
 
 `createNoydb({ encrypt: false })` skips the crypto path entirely. Records are stored as raw JSON in `_data`. Use only for testing / debugging — no privacy guarantees.
@@ -63,6 +84,7 @@ These are the bright lines. Any change to one of them is a security review.
 | **AES-KW for DEK wrapping** | Standard RFC 3394. No custom KDF. |
 | **KEK never on disk** | Only `_keyring/<user>` records persist (which carry wrapped DEKs, not the KEK). |
 | **Authenticated decryption fails closed** | A modified envelope throws `TamperedError`; no partial-decryption fallback. |
+| **Per-record CEK is stable + DEK-scoped** | Under `perRecordKeys`, a record's CEK is reused across all its versions/history and is only ever AES-KW-wrapped under the collection/tier DEK (`crypto.ts` `wrapCek`/`unwrapCek`). `_det` slots are never CEK-keyed. |
 
 ## See also
 

--- a/docs/superpowers/specs/2026-06-13-per-record-cek-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-13-per-record-cek-foundation-design.md
@@ -1,0 +1,97 @@
+# Per-record content-encryption keys (CEK) — foundation design (DESIGN ONLY, for review)
+
+> **Foundation slice of the erasure/sealing security epic.** This is **step 1** of the build order
+> the forget-cascade spec recommends (`per-record CEK → withForgetCascade #304 → record-scoped CEK
+> sealing #306`). It introduces a per-record key layer **behind a per-collection flag**, resolves the
+> interplay the [forget-cascade spec](./2026-06-08-forget-cascade-design.md) only *flagged*
+> (`_det` blind-equality, history, tiers, blobs, bundles, migration, hot-path perf), and is the gate
+> for both #304 and #306. **Security-critical core-crypto change — review before implementation.**
+
+**Issues:** foundation for #304 + #306 · **Layer:** crypto / store · **Status:** design, not implemented.
+**Architecture grounding:** all file:line refs below are current as of `0.2.0-pre.16` (`400b0583`).
+
+## The one idea
+
+Today the DEK is **per-collection** (`getDEK(collection)` — `keyring.ts:1198`): one AES-256-GCM key encrypts every record body *and* every `_history` envelope in a collection. That makes per-subject erasure and per-record sealing impossible without erasing/sealing the whole collection.
+
+Introduce a **per-record CEK**: a fresh AES-256-GCM key per record, **AES-KW-wrapped under the collection DEK** and stored on the envelope as `_cek`. The body (and every history version of that record) encrypts under the CEK. Then:
+- **Erase a record** = delete its `_cek` everywhere → body + all history versions permanently undecryptable; the collection DEK and every *other* record untouched (#304).
+- **Seal one record to an `at-*` host** = seal that record's CEK, not the collection DEK (#306).
+
+No new crypto primitives are needed — this mirrors the existing DEK-wrapped-under-KEK pattern exactly (`crypto.ts` already has `generateDEK`/`wrapKey`/`unwrapKey`).
+
+## Envelope format
+
+`EncryptedEnvelope` (`types.ts:98-135`) gains one optional field:
+
+```ts
+readonly _cek?: string   // base64 AES-KW-wrapped CEK (wrapped under the collection/tier DEK)
+```
+
+`_cek` **presence is the format discriminant** — there is no per-envelope format version today (`_noydb` is a vault-wide constant). `decryptJsonString` (`collection.ts:3928`) branches: `_cek` present → unwrap CEK under the collection DEK, decrypt body with CEK; `_cek` absent → legacy path (decrypt body directly under the collection DEK). This makes the change **backward-compatible by construction** — legacy records read unchanged.
+
+## Write path (the stable-CEK rule)
+
+The CEK must be **stable across versions of a record** — otherwise history versions don't share it and "one delete erases all versions" fails. So:
+
+- **Insert** (`encryptRecord`, `collection.ts:3569`): `cek = generateDEK()`; `encrypt(body, cek)`; `_cek = wrapKey(cek, getDEK(collection))`.
+- **Update**: read the live envelope's `_cek`, `unwrapKey` it under the collection DEK, **reuse the same CEK** to encrypt the new body, re-wrap under the (unchanged) collection DEK. Do **not** generate a new CEK on update.
+- **History save** (`collection.ts:1441` → `history/history.ts:41`): the prior version is re-encrypted before being displaced. It MUST be encrypted under the **record's CEK**, not a fresh `getDEK` call — so every `_history/{collection}:{id}:{v}` envelope for a record carries that record's same `_cek`. This is the change that makes a single CEK delete kill the whole version chain. *(Today history re-encrypts under the collection DEK — this is the one history-path edit.)*
+
+**Caching:** a session-scoped `(collection,id) → CryptoKey` LRU (reuse `cache/lru.ts`) avoids re-unwrapping on repeated reads and supplies the stable CEK on update. Keyed to session lifetime; bounded by LRU. Cleared on `load()` alongside the DEK cache.
+
+## Read path
+
+`decryptJsonString`: `getDEK(collection)` → (if `_cek`) `unwrapKey(_cek, dek)` → `decrypt(_iv, _data, cek)`. One extra AES-KW unwrap per read (cache-missed); negligible per-op, see Perf.
+
+## Interplay resolutions (the point of this spec)
+
+### 1. Deterministic `_det` fields — STAY DEK-keyed; shred strips them
+`_det` blind-equality (`crypto.ts:438` `encryptDeterministic`, written at `collection.ts:3569`, searched at `:3603`) is keyed off the **collection DEK** (HKDF IV from the raw DEK bytes), so equal plaintext → equal ciphertext *across records*. Per-record CEKs would destroy that. **Resolution: `_det` remains keyed to the collection DEK, explicitly excluded from CEK scope.** The body encrypts under the CEK; `_det` slots keep using `getDEK(collection)` unchanged.
+
+**Shred residue (critical):** after a CEK delete, the `_det` map survives on the envelope and `findByDet` would still match a record whose body is gone — then `decryptRecord` throws `TamperedError` (`collection.ts:3603-3628` doesn't catch). **Resolution: a shred is not just "delete `_cek`" — it rewrites the live envelope to a tombstone** that strips `_iv`, `_data`, `_cek`, **and `_det`**, keeping only `{ _noydb, _v, _ts, _by }` (so the version counter + "record existed" survive for ledger/audit continuity), and deletes (or tombstones) every `_history` envelope for the record. With `_det` gone, `findByDet` no longer matches a shredded record; `get()` on a tombstone returns `null`/a `shredded` marker rather than throwing. **`forget()`/shred owns three deletions per record: body-CEK, history envelopes, `_det` slots.** This is the residue fix the forget-cascade spec did not resolve.
+
+### 2. History — shares the record CEK (see Write path)
+Verified: history is a verbatim envelope pass-through today (`history.ts:41`), each version independently re-encrypted under the collection DEK at `collection.ts:1441`. Under CEK, that one site uses the record's stable CEK, so all versions share `_cek` and die together on shred. No history-storage change beyond that encrypt-key swap.
+
+### 3. Tiers — compose transparently
+Tier DEKs are extra slots in the same keyring Map (`dekKey(collection, tier)`, `team/tiers.ts:24`); `assertTierAccess` gates them. A CEK wrapped under the tier DEK composes — gating the tier DEK gates the CEK. The **one** edit: `elevate`/`demote` (`collection.ts:3832`) must `unwrapKey(_cek, fromTierDEK)` → `wrapKey(cek, toTierDEK)` (re-wrap, same CEK, new wrapping key). `assertTierAccess` is untouched.
+
+### 4. Bundles / extract-partition — re-wrap `_cek` on re-key (correctness-critical)
+`reKeyClosure` (`bundle/extract-partition.ts:39`) currently does `{ ...env, _iv, _data }` — re-encrypting bodies under a fresh destination DEK. With `_cek`, that spread would carry a **source-DEK-wrapped** CEK into a bundle re-keyed under a different DEK → **silently undecryptable for the recipient**. **Resolution:** the re-key must `unwrapKey(env._cek, srcDek)` → re-encrypt body under the same CEK (or a fresh one) → `wrapKey(cek, destDek)` → new `_cek`. `sealDeks` (collection-granularity, `:194`) is unchanged — CEKs become accessible transitively once the recipient re-wraps collection DEKs under their KEK (`adopt-partition.ts:249`). **This site needs new test coverage** (none exists — `_cek` is new). #306's record-scoped sealing layers here later: seal one record's CEK instead of the collection DEK.
+
+### 5. Blobs — DEFERRED to a later slice (documented boundary)
+Blobs share one vault-wide `_blob` DEK, and dedup keys the eTag off it (`HMAC(blobDEK, plaintext)`, `blobs/blob-set.ts:446`). Per-blob CEK would break cross-record dedup. **Resolution for this foundation: record-CEK does NOT cover blob content.** A record's blob attachments are *not* erased by a record-CEK shred in step 1 — this boundary MUST be surfaced loudly by `forget()` ("N blob attachments not shredded — blob CEK is a separate slice"). Per-blob CEK + dedup-vs-shred tradeoff is its own design (later slice).
+
+### 6. Migration — flag-gated, `_cek`-absence = legacy, surfaced erasure gap
+No per-record format version exists; `_cek` absent = legacy (body under collection DEK). New writes on a `perRecordKeys` collection emit `_cek` from the start. Existing records migrate via a re-encrypt pass built on `migrateAll`/`coordinatedCutover` (`collection.ts:1782`, `schema-update/cutover.ts`): decrypt under collection DEK → generate CEK → re-encrypt body under CEK → wrap → write `{ ...env, _cek, _iv, _data }`. **Until a record is migrated, `forget()` cannot guarantee its erasure** (body still directly under the shared collection DEK) — `forget()` MUST report un-migrated records explicitly rather than silently claim success.
+
+## Flag / opt-in
+Per-collection opt-in, mirroring `deterministicFields`: `vault.collection(name, { perRecordKeys: true })` sets `this.perRecordCek` and gates the CEK path in `encryptRecord`/`decryptJsonString`. `withForgetCascade({ subjects })` (#304) implies `perRecordKeys` for its declared collections. A vault-wide default can layer on later. Off by default — non-adopters pay nothing and read/write the legacy path unchanged.
+
+## Performance
+- **Write:** +1 `generateDEK()` (insert only; updates reuse the cached CEK) +1 `wrapKey` (AES-KW, one RFC-3394 block pass).
+- **Read:** +1 `unwrapKey` on cache miss; LRU-cached thereafter.
+- AES-KW is cheap; at typical noy-db scale (tens of records/op, ≤50K-record vaults) the overhead is negligible. Add a `to-bench` micro-benchmark (Dim 06) as a build gate; flag if >X% write regression.
+
+## Build slices (step 1 only — #304/#306 are separate)
+1. **Envelope `_cek` + crypto wrap/unwrap + read/write path + stable-CEK cache**, behind `perRecordKeys`, with the legacy dual-read. Tests: round-trip, update reuses CEK, legacy records still read.
+2. **History under record CEK** (the `collection.ts:1441` key swap) + test that all versions decrypt under the same CEK.
+3. **Migration pass** (`migrateAll`-based re-encrypt) + the "un-migrated = not shreddable" reporting surface.
+4. **Tier elevate/demote CEK re-wrap** + test.
+5. **Bundle `reKeyClosure` CEK re-wrap** + extract/adopt round-trip test with CEK records (the correctness-critical gap).
+(#304 `withForgetCascade` + `_det`/history/tombstone shred semantics, and #306 record-scoped CEK sealing, build on top — separate specs/PRs.)
+
+## Acceptance (foundation)
+- A `perRecordKeys` collection round-trips records (insert + update) with `_cek`; updates reuse the same CEK; all history versions decrypt under it.
+- A non-`perRecordKeys` collection is byte-for-byte unchanged (legacy path); a mixed vault reads both.
+- Extract-partition of CEK records → adopt → recipient decrypts every record (the re-wrap works).
+- Tier elevate/demote of a CEK record preserves decryptability at the new tier.
+- `forget()`/shred (built in #304 on this) makes body + all history undecryptable, strips `_det`, leaves a tombstone, and the ledger hash-chain still verifies — and reports un-migrated/blob residue explicitly.
+
+## Decisions (APPROVED 2026-06-13)
+1. **Shred = tombstone.** A shred rewrites the live envelope to `{_noydb,_v,_ts,_by}` — no body / `_cek` / `_det` — and tombstones every `_history` envelope for the record. Preserves the version counter + "existed and was erased" for the audit ledger. (Tombstone *creation* is step 2 / #304; step 1's read path must tolerate a tombstone — see #5.)
+2. **CEK reused on re-key.** Bundle/extract re-key keeps the same CEK per record (re-wrapped under the destination DEK), preserving history-chain identity. Fresh-CEK-on-extract is deferred.
+3. **Per-collection flag.** `vault.collection(name, { perRecordKeys: true })` — mirrors `deterministicFields`. Off by default; a vault-wide default may layer on later. Erasure-bearing collections opt in without taxing the rest.
+4. **Migration = explicit pass** (`migrateAll`-based re-encrypt) for a deterministic erasure-completeness guarantee; lazy-on-next-write may be added later as an optional accelerator. Un-migrated records are reported by `forget()`, never silently claimed erased.
+5. **Read-of-shredded = `null` + `_shredded` marker.** `get()` on a tombstone returns `null`; the tombstone carries a queryable `_shredded` metadata marker so callers distinguish "never existed" from "erased." Step 1's read path must return `null` (not throw `TamperedError`) on an envelope with no `_data`/`_cek`.

--- a/features.yaml
+++ b/features.yaml
@@ -56,6 +56,11 @@ features:
       - 'AES-KW (RFC 3394) for wrapping DEKs with KEK'
       - 'KEK never persisted (in-memory only during session)'
       - 'Zero crypto dependencies — only Web Crypto API (architecture invariant: no-crypto-deps)'
+      - 'Per-record CEK (opt-in `perRecordKeys: true`): a fresh AES-256-GCM content-encryption key per record, AES-KW-wrapped under the collection DEK and stored on the envelope `_cek`; body encrypts under the CEK while `_det` deterministic slots stay keyed to the collection DEK'
+      - 'CEK is stable across versions: insert mints it, updates and history snapshots reuse the same CEK, so every `_history` envelope for a record carries that record `_cek` (foundation for per-record erasure #304 / record-scoped sealing #306)'
+      - 'Legacy dual-read: `_cek` presence is the format discriminant, not the flag — a collection without `perRecordKeys` is byte-identical to the legacy path and a mixed vault (and recipients that never set the flag) read both kinds'
+      - 'Tiers compose: elevate/demote re-wrap the same CEK from the source tier DEK to the target tier DEK (body key unchanged); bundle/extract re-key (`reKeyClosure`) re-wraps each `_cek` under the destination DEK so adopted records stay decryptable'
+      - 'Tombstone tolerance: a `get()` on an envelope with no `_data`/`_cek` returns null rather than throwing TamperedError (shred tombstone creation is step 2 / #304)'
     related: [vault-and-collections, permissions]
 
   - id: stores-contract

--- a/packages/hub/__tests__/per-record-cek.test.ts
+++ b/packages/hub/__tests__/per-record-cek.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Per-record content-encryption keys (CEK) — foundation (step 1).
+ *
+ * Spec: docs/superpowers/specs/2026-06-13-per-record-cek-foundation-design.md
+ *
+ * Covers the 5 build slices:
+ *  1. Envelope `_cek` + wrap/unwrap on read/write + stable-CEK cache +
+ *     `perRecordKeys` flag + legacy dual-read + tombstone-tolerant read.
+ *  2. History under the record's stable CEK.
+ *  3. Migration (`_applyCutoverTransform`) legacy→CEK re-encrypt pass.
+ *  4. Tier elevate/demote CEK re-wrap.
+ *  5. Bundle `reKeyClosure` CEK re-wrap (extract → adopt round-trip).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { ConflictError } from '../src/errors.js'
+import { NOYDB_FORMAT_VERSION } from '../src/types.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { withHistory } from '../src/history/index.js'
+import { extractPartition } from '../src/bundle/extract-partition.js'
+import { adoptPartition, createOwnerOnAdoptedPartition } from '../src/bundle/adopt-partition.js'
+
+/** In-memory store that also exposes the raw stored envelopes for assertions. */
+function memory(): NoydbStore & { raw(c: string, col: string, id: string): EncryptedEnvelope | undefined } {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    raw(c, col, id) { return store.get(c)?.get(col)?.get(id) },
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) {
+        for (const [name, coll] of existing) {
+          if (name.startsWith('_')) comp.set(name, coll)
+        }
+      }
+      store.set(c, comp)
+    },
+  }
+}
+
+interface Doc { id: string; name: string; note?: string }
+
+describe('per-record CEK — slice 1: round-trip + flag + cache', () => {
+  it('round-trips a perRecordKeys record and stamps _cek on the envelope', async () => {
+    const store = memory()
+    const db = await createNoydb({ store, user: 'alice', secret: 'test-passphrase-1234' })
+    const vault = await db.openVault('v')
+    const cek = vault.collection<Doc>('cek', { perRecordKeys: true })
+
+    await cek.put('d-1', { id: 'd-1', name: 'Alpha' })
+    expect(await cek.get('d-1')).toMatchObject({ id: 'd-1', name: 'Alpha' })
+
+    const env = store.raw('v', 'cek', 'd-1')!
+    expect(env._cek).toBeDefined()
+    expect(typeof env._cek).toBe('string')
+    expect(env._data.length).toBeGreaterThan(0)
+  })
+
+  it('a CEK record body differs from a legacy record body for the same plaintext', async () => {
+    const store = memory()
+    const db = await createNoydb({ store, user: 'alice', secret: 'test-passphrase-1234' })
+    const vault = await db.openVault('v')
+    const legacy = vault.collection<Doc>('legacy')
+    const cek = vault.collection<Doc>('cek', { perRecordKeys: true })
+
+    await legacy.put('d-1', { id: 'd-1', name: 'Same' })
+    await cek.put('d-1', { id: 'd-1', name: 'Same' })
+
+    const legacyEnv = store.raw('v', 'legacy', 'd-1')!
+    const cekEnv = store.raw('v', 'cek', 'd-1')!
+    expect(legacyEnv._cek).toBeUndefined()
+    expect(cekEnv._cek).toBeDefined()
+    // Different keys + random IVs → different ciphertext.
+    expect(cekEnv._data).not.toBe(legacyEnv._data)
+  })
+})
+
+describe('per-record CEK — legacy dual-read', () => {
+  it('a non-perRecordKeys collection is byte-identical to legacy (no _cek)', async () => {
+    const store = memory()
+    const db = await createNoydb({ store, user: 'alice', secret: 'test-passphrase-1234' })
+    const vault = await db.openVault('v')
+    const legacy = vault.collection<Doc>('legacy')
+
+    await legacy.put('d-1', { id: 'd-1', name: 'Plain' })
+    const env = store.raw('v', 'legacy', 'd-1')!
+    expect(env._cek).toBeUndefined()
+    expect(await legacy.get('d-1')).toMatchObject({ id: 'd-1', name: 'Plain' })
+  })
+
+  it('a mixed vault reads both legacy and CEK records', async () => {
+    const store = memory()
+    const db = await createNoydb({ store, user: 'alice', secret: 'test-passphrase-1234' })
+    const vault = await db.openVault('v')
+    const legacy = vault.collection<Doc>('legacy')
+    const cek = vault.collection<Doc>('cek', { perRecordKeys: true })
+
+    await legacy.put('l-1', { id: 'l-1', name: 'Legacy' })
+    await cek.put('c-1', { id: 'c-1', name: 'Cek' })
+
+    expect(await legacy.get('l-1')).toMatchObject({ name: 'Legacy' })
+    expect(await cek.get('c-1')).toMatchObject({ name: 'Cek' })
+
+    // Reopen the vault (fresh collection instances, cold CEK cache).
+    const db2 = await createNoydb({ store, user: 'alice', secret: 'test-passphrase-1234' })
+    const vault2 = await db2.openVault('v')
+    expect(await vault2.collection<Doc>('legacy').get('l-1')).toMatchObject({ name: 'Legacy' })
+    expect(await vault2.collection<Doc>('cek', { perRecordKeys: true }).get('c-1')).toMatchObject({ name: 'Cek' })
+    // A collection that NEVER set the flag still reads CEK records — `_cek`
+    // presence is the format discriminant, not the flag.
+    expect(await vault2.collection<Doc>('cek').get('c-1')).toMatchObject({ name: 'Cek' })
+  })
+})
+
+describe('per-record CEK — slice 1/2: update reuses CEK + history', () => {
+  it('an update reuses the same CEK (identical wrapped _cek) and history decrypts', async () => {
+    const store = memory()
+    const db = await createNoydb({ store, user: 'alice', secret: 'test-passphrase-1234', historyStrategy: withHistory() })
+    const vault = await db.openVault('v')
+    const cek = vault.collection<Doc>('cek', { perRecordKeys: true })
+
+    await cek.put('d-1', { id: 'd-1', name: 'v1' })
+    const env1 = store.raw('v', 'cek', 'd-1')!
+    const wrapped1 = env1._cek!
+
+    await cek.put('d-1', { id: 'd-1', name: 'v2' })
+    const env2 = store.raw('v', 'cek', 'd-1')!
+    const wrapped2 = env2._cek!
+
+    // AES-KW is deterministic over (key, kek), so the same CEK wrapped under
+    // the same collection DEK produces the identical wrapped string — proof
+    // the update reused the record's stable CEK rather than minting a fresh
+    // one.
+    expect(wrapped2).toBe(wrapped1)
+
+    expect(await cek.get('d-1')).toMatchObject({ name: 'v2' })
+
+    // History version 1 carries the same _cek and decrypts under it.
+    const v1 = await cek.getVersion('d-1', 1)
+    expect(v1).toMatchObject({ name: 'v1' })
+  })
+
+  it('all history versions of a CEK record decrypt under the shared CEK', async () => {
+    const store = memory()
+    const db = await createNoydb({ store, user: 'alice', secret: 'test-passphrase-1234', historyStrategy: withHistory() })
+    const vault = await db.openVault('v')
+    const cek = vault.collection<Doc>('cek', { perRecordKeys: true })
+
+    await cek.put('d-1', { id: 'd-1', name: 'v1' })
+    await cek.put('d-1', { id: 'd-1', name: 'v2' })
+    await cek.put('d-1', { id: 'd-1', name: 'v3' })
+
+    expect(await cek.getVersion('d-1', 1)).toMatchObject({ name: 'v1' })
+    expect(await cek.getVersion('d-1', 2)).toMatchObject({ name: 'v2' })
+    expect(await cek.get('d-1')).toMatchObject({ name: 'v3' })
+
+    // Survives a cold reopen (history snapshot envelopes carry the CEK).
+    const db2 = await createNoydb({ store, user: 'alice', secret: 'test-passphrase-1234', historyStrategy: withHistory() })
+    const cek2 = (await db2.openVault('v')).collection<Doc>('cek', { perRecordKeys: true })
+    expect(await cek2.getVersion('d-1', 1)).toMatchObject({ name: 'v1' })
+    expect(await cek2.getVersion('d-1', 2)).toMatchObject({ name: 'v2' })
+  })
+})
+
+describe('per-record CEK — slice 4: tiers', () => {
+  it('elevate then demote a CEK record preserves decryptability at each tier', async () => {
+    const store = memory()
+    const db = await createNoydb({ store, user: 'alice', secret: 'test-passphrase-1234' })
+    const vault = await db.openVault('v')
+    const cek = vault.collection<Doc>('cek', { perRecordKeys: true, tiers: [1] })
+
+    await cek.put('d-1', { id: 'd-1', name: 'secret' })
+    expect((store.raw('v', 'cek', 'd-1')!)._cek).toBeDefined()
+
+    await cek.elevate('d-1', 1)
+    const elevated = store.raw('v', 'cek', 'd-1')!
+    expect(elevated._tier).toBe(1)
+    expect(elevated._cek).toBeDefined()
+    expect(await cek.getAtTier('d-1')).toMatchObject({ name: 'secret' })
+
+    await cek.demote('d-1', 0)
+    const demoted = store.raw('v', 'cek', 'd-1')!
+    expect(demoted._tier).toBeUndefined()
+    expect(demoted._cek).toBeDefined()
+    expect(await cek.getAtTier('d-1')).toMatchObject({ name: 'secret' })
+    expect(await cek.get('d-1')).toMatchObject({ name: 'secret' })
+  })
+})
+
+describe('per-record CEK — slice 5: extract/adopt round-trip', () => {
+  it('extractPartition → adopt → recipient decrypts every CEK record', async () => {
+    const srcStore = memory()
+    const db = await createNoydb({ store: srcStore, user: 'alice', secret: 'test-passphrase-1234' })
+    const company = await db.openVault('demo-co')
+    const cek = company.collection<Doc>('cek', { perRecordKeys: true })
+    await cek.put('c-1', { id: 'c-1', name: 'Hotel' })
+    await cek.put('c-2', { id: 'c-2', name: 'Cafe' })
+    // Update one record so its history chain shares the CEK before extraction.
+    await cek.put('c-1', { id: 'c-1', name: 'Hotel-Renamed' })
+
+    const { bundleBytes, transferKey } = await extractPartition(company, { seeds: { cek: () => true } })
+
+    const dest = memory()
+    await adoptPartition(bundleBytes, { transferKey, destinationStore: dest, vaultName: 'acme' })
+    await createOwnerOnAdoptedPartition(dest, 'acme', {
+      userId: 'belle', passphrase: 'belle-hotel-dept-2026', transferKey,
+    })
+
+    const recipientDb = await createNoydb({ store: dest, user: 'belle', secret: 'belle-hotel-dept-2026' })
+    const recipientVault = await recipientDb.openVault('acme')
+    const recipientCek = recipientVault.collection<Doc>('cek')
+
+    // The re-keyed envelope still carries a _cek (re-wrapped under the
+    // destination DEK), and the recipient decrypts it.
+    expect(dest.raw('acme', 'cek', 'c-1')!._cek).toBeDefined()
+    expect(await recipientCek.get('c-1')).toMatchObject({ id: 'c-1', name: 'Hotel-Renamed' })
+    expect(await recipientCek.get('c-2')).toMatchObject({ id: 'c-2', name: 'Cafe' })
+  })
+})
+
+describe('per-record CEK — slice 1: tombstone tolerance', () => {
+  it('get() on a body-less / CEK-less envelope returns null and does not throw', async () => {
+    const store = memory()
+    const db = await createNoydb({ store, user: 'alice', secret: 'test-passphrase-1234' })
+    const vault = await db.openVault('v')
+    const cek = vault.collection<Doc>('cek', { perRecordKeys: true, prefetch: false, cache: { maxRecords: 100 } })
+
+    await cek.put('d-1', { id: 'd-1', name: 'present' })
+
+    // Hand-construct a shred tombstone on a fresh id (lazy LRU never cached
+    // it, so the read goes through the adapter + tombstone guard). `_v`/`_ts`
+    // survive; no `_data`/`_cek`.
+    await store.put('v', 'cek', 'tomb', {
+      _noydb: NOYDB_FORMAT_VERSION,
+      _v: 2,
+      _ts: new Date().toISOString(),
+      _iv: '',
+      _data: '',
+      _by: 'alice',
+    } as EncryptedEnvelope)
+
+    await expect(cek.get('tomb')).resolves.toBeNull()
+    // The live record is unaffected.
+    expect(await cek.get('d-1')).toMatchObject({ name: 'present' })
+  })
+
+  it('eager-mode hydration skips tombstones rather than throwing TamperedError', async () => {
+    const store = memory()
+    const db = await createNoydb({ store, user: 'alice', secret: 'test-passphrase-1234' })
+    const vault = await db.openVault('v')
+    const cek = vault.collection<Doc>('cek', { perRecordKeys: true })
+    await cek.put('keep', { id: 'keep', name: 'keep' })
+
+    // Tombstone a separate id, then reopen so eager hydration walks it.
+    await store.put('v', 'cek', 'gone', {
+      _noydb: NOYDB_FORMAT_VERSION, _v: 5, _ts: new Date().toISOString(), _iv: '', _data: '', _by: 'alice',
+    } as EncryptedEnvelope)
+
+    const db2 = await createNoydb({ store, user: 'alice', secret: 'test-passphrase-1234' })
+    const cek2 = (await db2.openVault('v')).collection<Doc>('cek', { perRecordKeys: true })
+    await expect(cek2.get('gone')).resolves.toBeNull()
+    expect(await cek2.get('keep')).toMatchObject({ name: 'keep' })
+  })
+})

--- a/packages/hub/src/bundle/extract-partition.ts
+++ b/packages/hub/src/bundle/extract-partition.ts
@@ -9,7 +9,7 @@
 import type { Vault } from '../vault.js'
 import type { EncryptedEnvelope } from '../types.js'
 import { NOYDB_BACKUP_VERSION } from '../types.js'
-import { decrypt, encrypt, generateDEK, bufferToBase64 } from '../crypto.js'
+import { decrypt, encrypt, generateDEK, bufferToBase64, unwrapCek, wrapCek } from '../crypto.js'
 import { PartitionExtractionError } from '../errors.js'
 import { walkClosure, type WalkClosureOptions } from './walk-closure.js'
 import { generateULID } from './ulid.js'
@@ -53,6 +53,22 @@ export async function reKeyClosure(
     for (const id of ids) {
       const env = await adapter.get(vaultName, collectionName, id)
       if (!env) continue
+      if (env._cek !== undefined) {
+        // Per-record CEK: a naive `{ ...env }` spread would carry a
+        // SOURCE-DEK-wrapped CEK into a bundle re-keyed under a different
+        // destination DEK — silently undecryptable for the recipient.
+        // Re-wrap: unwrap the CEK under the source DEK, re-encrypt the body
+        // under the SAME CEK (decision 2 — CEK reused on re-key, preserving
+        // the history-chain identity), then wrap the CEK under the fresh
+        // destination DEK. The recipient gains access transitively once they
+        // re-wrap the collection DEK under their KEK on adopt.
+        const cek = await unwrapCek(env._cek, srcDek)
+        const plaintext = await decrypt(env._iv, env._data, cek)
+        const { iv, data } = await encrypt(plaintext, cek)
+        const wrapped = await wrapCek(cek, destDek)
+        out[id] = { ...env, _iv: iv, _data: data, _cek: wrapped }
+        continue
+      }
       const plaintext = await decrypt(env._iv, env._data, srcDek)
       const { iv, data } = await encrypt(plaintext, destDek)
       out[id] = { ...env, _iv: iv, _data: data }

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -13,7 +13,7 @@ import type { ComputedFields } from './computed/index.js'
 import { evalComputedFields } from './computed/index.js'
 import { NO_I18N, type I18nStrategy } from './i18n/strategy.js'
 import { resolvePolicy } from './i18n/policy.js'
-import { encrypt, decrypt, encryptDeterministic } from './crypto.js'
+import { encrypt, decrypt, encryptDeterministic, generateDEK, wrapCek, unwrapCek } from './crypto.js'
 import { ConflictError, ReadOnlyError, TranslatorNotConfiguredError, TierDemoteDeniedError, LocaleNotSpecifiedError } from './errors.js'
 import { dekKey, assertTierAccess } from './team/tiers.js'
 import type { GhostRecord, TierMode, CrossTierAccessEvent } from './types.js'
@@ -334,6 +334,27 @@ export class Collection<T> {
    * is inactive for this collection; a frozen `Set` otherwise.
    */
   private readonly deterministicFields: ReadonlySet<string> | null
+
+  /**
+   * Per-record CEK opt-in (`perRecordKeys: true`). When set, writes mint /
+   * reuse a per-record content-encryption key and stamp `_cek` on the
+   * envelope (see {@link EncryptedEnvelope._cek}). OFF by default — a
+   * non-adopting collection takes the byte-identical legacy path. The READ
+   * path does not consult this flag: `_cek` presence on the envelope is the
+   * format discriminant, so a mixed vault (and a recipient that never set the
+   * flag) still decrypts CEK records.
+   */
+  private readonly perRecordCek: boolean
+
+  /**
+   * Session-scoped `(id) → CEK` cache for this collection. Lets updates
+   * reuse a record's stable CEK and lets repeated reads skip the AES-KW
+   * unwrap. Bounded by LRU; never persisted. Dropped when the owning
+   * collection instance is discarded — `vault.load()` clears the
+   * collectionCache, so a keyring refresh drops every CEK alongside the
+   * DEK cache. `null` unless `perRecordCek` is set.
+   */
+  private readonly cekCache: Lru<string, CryptoKey> | null
 
   /**
    * declared tiers for this collection. `null` when
@@ -706,6 +727,15 @@ export class Collection<T> {
      */
     acknowledgeDeterministicRisk?: boolean | undefined
     /**
+     * Per-record content-encryption keys. When `true`, every record body
+     * (and every history version of it) is encrypted under a fresh
+     * per-record CEK, AES-KW-wrapped under the collection DEK and stored
+     * on the envelope's `_cek`. Off by default. Foundation for per-record
+     * erasure (#304) and record-scoped sealing (#306). `_det` slots stay
+     * keyed to the collection DEK regardless.
+     */
+    perRecordKeys?: boolean | undefined
+    /**
      * declared tiers this collection supports. An
      * undefined or empty list disables the hierarchical-tier surface
      * on this collection (`putAtTier`, `getAtTier`, `elevate`, `demote`
@@ -834,21 +864,27 @@ export class Collection<T> {
       this.deterministicFields = null
     }
 
+    // per-record CEK wiring. The cache is bounded by record count; CEKs
+    // are tiny CryptoKey handles, so a generous entry budget is cheap.
+    this.perRecordCek = opts.perRecordKeys === true
+    this.cekCache = this.perRecordCek ? new Lru<string, CryptoKey>({ maxRecords: 4096 }) : null
+
     // register CRDT conflict resolver with SyncEngine
     if (opts.crdt && opts.onRegisterConflictResolver) {
       const crdtMode = opts.crdt
-      const crdtResolver: CollectionConflictResolver = async (_id, local, remote) => {
+      const crdtResolver: CollectionConflictResolver = async (id, local, remote) => {
         if (crdtMode === 'yjs') {
           // Core cannot merge Yjs without the yjs package — take the higher version
           return local._v >= remote._v ? local : remote
         }
-        const localJson = await this.decryptJsonString(local)
-        const remoteJson = await this.decryptJsonString(remote)
+        const localJson = await this.decryptJsonString(local, id)
+        const remoteJson = await this.decryptJsonString(remote, id)
         const localState = JSON.parse(localJson) as CrdtState
         const remoteState = JSON.parse(remoteJson) as CrdtState
         const merged = this.crdtStrategy.mergeCrdtStates(localState, remoteState)
         const mergedVersion = Math.max(local._v, remote._v) + 1
-        return this.encryptJsonString(JSON.stringify(merged), mergedVersion)
+        const cek = this.perRecordCek ? await this.resolveRecordCek(id) : undefined
+        return this.encryptJsonString(JSON.stringify(merged), mergedVersion, cek)
       }
       opts.onRegisterConflictResolver(this.name, crdtResolver)
     }
@@ -894,12 +930,13 @@ export class Collection<T> {
       } else {
         // Custom merge fn: decrypt both → merge → re-encrypt
         const mergeFn = policy as (local: T, remote: T) => T
-        resolver = async (_id, local, remote) => {
-          const localRecord = await this.decryptRecord(local, { skipValidation: true })
-          const remoteRecord = await this.decryptRecord(remote, { skipValidation: true })
+        resolver = async (id, local, remote) => {
+          const localRecord = await this.decryptRecord(local, { skipValidation: true, id })
+          const remoteRecord = await this.decryptRecord(remote, { skipValidation: true, id })
           const merged = mergeFn(localRecord, remoteRecord)
           const mergedVersion = Math.max(local._v, remote._v) + 1
-          return this.encryptRecord(merged, mergedVersion)
+          const cek = this.perRecordCek ? await this.resolveRecordCek(id) : undefined
+          return this.encryptRecord(merged, mergedVersion, cek)
         }
       }
 
@@ -1026,7 +1063,10 @@ export class Collection<T> {
         // Cache miss: hit the adapter, decrypt, populate the LRU.
         const envelope = await this.adapter.get(this.vault, this.name, id)
         if (!envelope) return null
-        record = await this.decryptRecord(envelope)
+        // Tombstone tolerance (decision 5): a shredded record carries no
+        // body / CEK. Reads return null rather than throwing TamperedError.
+        if (this.isTombstone(envelope)) return null
+        record = await this.decryptRecord(envelope, { id })
         this.lru.set(id, { record, version: envelope._v }, estimateRecordBytes(record))
       }
     } else {
@@ -1360,7 +1400,10 @@ export class Collection<T> {
       }
 
       const version = existingVersion + 1
-      const envelope = await this.encryptJsonString(JSON.stringify(crdtState), version)
+      // Stable per-record CEK shared by the new CRDT body and its history
+      // snapshot (undefined on non-CEK collections → legacy path).
+      const cek = this.perRecordCek ? await this.resolveRecordCek(id) : undefined
+      const envelope = await this.encryptJsonString(JSON.stringify(crdtState), version, cek)
       await this.adapter.put(this.vault, this.name, id, envelope)
 
       // Resolve snapshot for cache and history
@@ -1370,7 +1413,7 @@ export class Collection<T> {
         : undefined
 
       if (existingResolved && this.historyConfig.enabled !== false) {
-        const histEnvelope = await this.encryptRecord(existingResolved.record, existingResolved.version)
+        const histEnvelope = await this.encryptRecord(existingResolved.record, existingResolved.version, cek)
         await this.historyStrategy.saveHistory(this.adapter, this.vault, this.name, id, histEnvelope)
         this.emitter.emit('history:save', { vault: this.vault, collection: this.name, id, version: existingResolved.version })
         if (this.historyConfig.maxVersions) {
@@ -1437,9 +1480,17 @@ export class Collection<T> {
     // are declared.
     this.uniqueConstraints?.check(id, record)
 
+    // Per-record CEK: resolve the record's stable CEK ONCE (insert mints,
+    // update reuses the live envelope's CEK), then encrypt BOTH the history
+    // snapshot of the prior version AND the new body under it — so every
+    // version of a record carries the same `_cek` and dies together on a
+    // future shred. `undefined` on a legacy / non-CEK collection → the
+    // byte-identical legacy write path.
+    const cek = this.perRecordCek ? await this.resolveRecordCek(id) : undefined
+
     // Save history snapshot of the PREVIOUS version before overwriting
     if (existing && this.historyConfig.enabled !== false) {
-      const historyEnvelope = await this.encryptRecord(existing.record, existing.version)
+      const historyEnvelope = await this.encryptRecord(existing.record, existing.version, cek)
       await this.historyStrategy.saveHistory(this.adapter, this.vault, this.name, id, historyEnvelope)
 
       this.emitter.emit('history:save', {
@@ -1457,7 +1508,7 @@ export class Collection<T> {
       }
     }
 
-    const envelope = await this.encryptRecord(record, version)
+    const envelope = await this.encryptRecord(record, version, cek)
     await this.adapter.put(this.vault, this.name, id, envelope)
 
     // Ledger append — AFTER the adapter write succeeds so a failed
@@ -1784,11 +1835,20 @@ export class Collection<T> {
     let count = 0
     for (const id of ids) {
       const env = await this.adapter.get(this.vault, this.name, id)
-      if (!env) continue
-      const record = (await this.decryptRecord(env, { skipValidation: true })) as unknown as Record<string, unknown>
+      if (!env || this.isTombstone(env)) continue
+      const record = (await this.decryptRecord(env, { skipValidation: true, id })) as unknown as Record<string, unknown>
       const next = transform(record)
       const nextVersion = (env._v ?? 0) + 1
-      const newEnv = await this.encryptRecord(next as unknown as T, nextVersion)
+      // Migration pass: on a `perRecordKeys` collection, a legacy (no-`_cek`)
+      // record gets a freshly minted CEK here (legacy → CEK re-encrypt), while
+      // an already-CEK record reuses its stable CEK. This is the
+      // erasure-completeness pass — once migrated, the record body is keyed
+      // off a per-record CEK and a future shred can erase it. Until then it
+      // stays directly under the collection DEK. `forget()`/shred (step 2,
+      // #304) reports un-migrated records explicitly rather than claiming
+      // erasure.
+      const cek = this.perRecordCek ? await this.resolveRecordCek(id) : undefined
+      const newEnv = await this.encryptRecord(next as unknown as T, nextVersion, cek)
       await this.adapter.put(this.vault, this.name, id, newEnv)
       await this._invalidateCacheEntry(id) // refresh in-memory cache after the raw write
       if (this.ledger) {
@@ -1923,9 +1983,12 @@ export class Collection<T> {
       existing = this.cache.get(id)
     }
 
-    // Save history snapshot before deleting
+    // Save history snapshot before deleting. On a CEK collection the
+    // snapshot reuses the record's stable CEK so the displaced version
+    // stays in the same key chain as the rest of its history.
     if (existing && this.historyConfig.enabled !== false) {
-      const historyEnvelope = await this.encryptRecord(existing.record, existing.version)
+      const cek = this.perRecordCek ? await this.resolveRecordCek(id) : undefined
+      const historyEnvelope = await this.encryptRecord(existing.record, existing.version, cek)
       await this.historyStrategy.saveHistory(this.adapter, this.vault, this.name, id, historyEnvelope)
     }
 
@@ -2858,8 +2921,8 @@ export class Collection<T> {
     const ids = await this.adapter.list(this.vault, this.name)
     for (const id of ids) {
       const envelope = await this.adapter.get(this.vault, this.name, id)
-      if (envelope) {
-        const record = await this.decryptRecord(envelope)
+      if (envelope && !this.isTombstone(envelope)) {
+        const record = await this.decryptRecord(envelope, { id })
         this.cache.set(id, { record, version: envelope._v })
       }
     }
@@ -2871,7 +2934,8 @@ export class Collection<T> {
   /** Hydrate from a pre-loaded snapshot (used by Vault). */
   async hydrateFromSnapshot(records: Record<string, EncryptedEnvelope>): Promise<void> {
     for (const [id, envelope] of Object.entries(records)) {
-      const record = await this.decryptRecord(envelope)
+      if (this.isTombstone(envelope)) continue
+      const record = await this.decryptRecord(envelope, { id })
       this.cache.set(id, { record, version: envelope._v })
     }
     this.hydrated = true
@@ -3159,7 +3223,11 @@ export class Collection<T> {
     await this.ensureHydrated()
     const result: Record<string, EncryptedEnvelope> = {}
     for (const [id, entry] of this.cache) {
-      result[id] = await this.encryptRecord(entry.record, entry.version)
+      // Reuse the record's stable CEK on a `perRecordKeys` collection so the
+      // dumped envelope matches the stored format and stays in the same key
+      // chain. `undefined` → legacy path.
+      const cek = this.perRecordCek ? await this.resolveRecordCek(id) : undefined
+      result[id] = await this.encryptRecord(entry.record, entry.version, cek)
     }
     return result
   }
@@ -3571,7 +3639,64 @@ export class Collection<T> {
     return new LazyQuery<T>(source)
   }
 
-  private async encryptJsonString(json: string, version: number): Promise<EncryptedEnvelope> {
+  /**
+   * True when this record envelope is a shred tombstone: an encrypted
+   * record that carries no body and no wrapped CEK. Tombstone *creation*
+   * is step 2 (#304); step 1's read path only has to tolerate one — a
+   * `get()` on a tombstone returns `null` instead of throwing
+   * `TamperedError` (decision 5). A plaintext (`!this.encrypted`)
+   * collection legitimately has an empty `_iv`, so it is never a tombstone.
+   */
+  private isTombstone(envelope: EncryptedEnvelope): boolean {
+    if (!this.encrypted) return false
+    return !envelope._data && envelope._cek === undefined
+  }
+
+  /**
+   * Resolve the stable CEK for a record on the WRITE path.
+   *
+   * - Cache hit → reuse (updates and history snapshots share the record's
+   *   CEK so a single CEK delete kills the whole version chain).
+   * - Live envelope carries `_cek` → unwrap it under the collection DEK,
+   *   cache, reuse.
+   * - Otherwise (genuine insert, or a legacy record being migrated) → mint
+   *   a fresh CEK and cache it.
+   *
+   * `wrapDek` is the DEK the CEK should be (re-)wrappable under — the
+   * collection DEK on the normal path. The returned CEK is the AES-GCM body
+   * key; the caller wraps it for storage on `_cek`.
+   */
+  private async resolveRecordCek(id: string): Promise<CryptoKey> {
+    const cached = this.cekCache?.get(id)
+    if (cached) return cached
+
+    const live = await this.adapter.get(this.vault, this.name, id)
+    if (live?._cek !== undefined) {
+      const dek = await this.getDEK(this.name)
+      const cek = await unwrapCek(live._cek, dek)
+      this.cekCache?.set(id, cek, 1)
+      return cek
+    }
+
+    const fresh = await generateDEK()
+    this.cekCache?.set(id, fresh, 1)
+    return fresh
+  }
+
+  /**
+   * Encrypt a JSON body into an envelope.
+   *
+   * When `cek` is supplied (per-record CEK collections), the body is
+   * encrypted under the CEK and the CEK is AES-KW-wrapped under the
+   * collection DEK and stamped on `_cek`. When `cek` is omitted, the legacy
+   * path encrypts the body directly under the collection DEK — byte-identical
+   * to pre-CEK behaviour, so non-adopting collections pay nothing.
+   */
+  private async encryptJsonString(
+    json: string,
+    version: number,
+    cek?: CryptoKey,
+  ): Promise<EncryptedEnvelope> {
     const by = this.keyring.userId
 
     if (!this.encrypted) {
@@ -3586,6 +3711,21 @@ export class Collection<T> {
     }
 
     const dek = await this.getDEK(this.name)
+
+    if (cek !== undefined) {
+      const { iv, data } = await encrypt(json, cek)
+      const wrapped = await wrapCek(cek, dek)
+      return {
+        _noydb: NOYDB_FORMAT_VERSION,
+        _v: version,
+        _ts: new Date().toISOString(),
+        _iv: iv,
+        _data: data,
+        _by: by,
+        _cek: wrapped,
+      }
+    }
+
     const { iv, data } = await encrypt(json, dek)
 
     return {
@@ -3598,8 +3738,12 @@ export class Collection<T> {
     }
   }
 
-  private async encryptRecord(record: T, version: number): Promise<EncryptedEnvelope> {
-    const base = await this.encryptJsonString(JSON.stringify(record), version)
+  private async encryptRecord(
+    record: T,
+    version: number,
+    cek?: CryptoKey,
+  ): Promise<EncryptedEnvelope> {
+    const base = await this.encryptJsonString(JSON.stringify(record), version, cek)
     if (!this.deterministicFields || !this.encrypted) return base
 
     // compute deterministic-ciphertext slots for every
@@ -3803,7 +3947,18 @@ export class Collection<T> {
     }
 
     const dek = await this.getDEK(key)
-    const plaintext = await decrypt(envelope._iv, envelope._data, dek)
+    // A tiered record may carry a per-record CEK (e.g. a CEK record
+    // elevated via `elevate()`): the CEK is wrapped under the TIER DEK, so
+    // unwrap under the tier DEK then decrypt the body under the CEK. Legacy
+    // tiered records decrypt directly under the tier DEK.
+    let plaintext: string
+    if (envelope._cek !== undefined) {
+      const cek = await unwrapCek(envelope._cek, dek)
+      this.cekCache?.set(id, cek, 1)
+      plaintext = await decrypt(envelope._iv, envelope._data, cek)
+    } else {
+      plaintext = await decrypt(envelope._iv, envelope._data, dek)
+    }
     const record = JSON.parse(plaintext) as T
 
     this.emitCrossTierEvent({
@@ -3867,18 +4022,43 @@ export class Collection<T> {
     const fromDek = await this.getDEK(fromKey)
     const toDek = await this.getDEK(toKey)
 
-    const plaintext = await decrypt(envelope._iv, envelope._data, fromDek)
-    const { iv, data } = await encrypt(plaintext, toDek)
+    // Per-record CEK composes with tiers: unwrap the CEK under the SOURCE
+    // tier DEK, re-encrypt the body under the SAME CEK, then re-wrap the
+    // CEK under the TARGET tier DEK. The body key is unchanged (history
+    // chain identity preserved); only the wrapping key moves with the tier.
+    // Legacy (no `_cek`) records take the direct-DEK path unchanged.
     const now = new Date().toISOString()
-    const next: EncryptedEnvelope = {
-      _noydb: NOYDB_FORMAT_VERSION,
-      _v: envelope._v + 1,
-      _ts: now,
-      _iv: iv,
-      _data: data,
-      _by: this.keyring.userId,
-      _tier: toTier,
-      _elevatedBy: this.keyring.userId,
+    let next: EncryptedEnvelope
+    if (envelope._cek !== undefined) {
+      const cek = await unwrapCek(envelope._cek, fromDek)
+      const plaintext = await decrypt(envelope._iv, envelope._data, cek)
+      const { iv, data } = await encrypt(plaintext, cek)
+      const rewrapped = await wrapCek(cek, toDek)
+      this.cekCache?.set(id, cek, 1)
+      next = {
+        _noydb: NOYDB_FORMAT_VERSION,
+        _v: envelope._v + 1,
+        _ts: now,
+        _iv: iv,
+        _data: data,
+        _by: this.keyring.userId,
+        _tier: toTier,
+        _elevatedBy: this.keyring.userId,
+        _cek: rewrapped,
+      }
+    } else {
+      const plaintext = await decrypt(envelope._iv, envelope._data, fromDek)
+      const { iv, data } = await encrypt(plaintext, toDek)
+      next = {
+        _noydb: NOYDB_FORMAT_VERSION,
+        _v: envelope._v + 1,
+        _ts: now,
+        _iv: iv,
+        _data: data,
+        _by: this.keyring.userId,
+        _tier: toTier,
+        _elevatedBy: this.keyring.userId,
+      }
     }
     await this.adapter.put(this.vault, this.name, id, next)
 
@@ -3920,17 +4100,38 @@ export class Collection<T> {
     const fromDek = await this.getDEK(dekKey(this.name, fromTier))
     const toDek = await this.getDEK(dekKey(this.name, toTier))
 
-    const plaintext = await decrypt(envelope._iv, envelope._data, fromDek)
-    const { iv, data } = await encrypt(plaintext, toDek)
+    // CEK re-wrap on demote — same body key, moved from the source tier
+    // DEK to the target tier DEK. Legacy records take the direct-DEK path.
     const now = new Date().toISOString()
-    const next: EncryptedEnvelope = {
-      _noydb: NOYDB_FORMAT_VERSION,
-      _v: envelope._v + 1,
-      _ts: now,
-      _iv: iv,
-      _data: data,
-      _by: this.keyring.userId,
-      ...(toTier > 0 && { _tier: toTier }),
+    let next: EncryptedEnvelope
+    if (envelope._cek !== undefined) {
+      const cek = await unwrapCek(envelope._cek, fromDek)
+      const plaintext = await decrypt(envelope._iv, envelope._data, cek)
+      const { iv, data } = await encrypt(plaintext, cek)
+      const rewrapped = await wrapCek(cek, toDek)
+      this.cekCache?.set(id, cek, 1)
+      next = {
+        _noydb: NOYDB_FORMAT_VERSION,
+        _v: envelope._v + 1,
+        _ts: now,
+        _iv: iv,
+        _data: data,
+        _by: this.keyring.userId,
+        ...(toTier > 0 && { _tier: toTier }),
+        _cek: rewrapped,
+      }
+    } else {
+      const plaintext = await decrypt(envelope._iv, envelope._data, fromDek)
+      const { iv, data } = await encrypt(plaintext, toDek)
+      next = {
+        _noydb: NOYDB_FORMAT_VERSION,
+        _v: envelope._v + 1,
+        _ts: now,
+        _iv: iv,
+        _data: data,
+        _by: this.keyring.userId,
+        ...(toTier > 0 && { _tier: toTier }),
+      }
     }
     await this.adapter.put(this.vault, this.name, id, next)
 
@@ -3957,10 +4158,29 @@ export class Collection<T> {
     }
   }
 
-  /** Low-level: decrypt an envelope and return the raw JSON string. */
-  private async decryptJsonString(envelope: EncryptedEnvelope): Promise<string> {
+  /**
+   * Low-level: decrypt an envelope and return the raw JSON string.
+   *
+   * `_cek` presence is the format discriminant (NOT `this.perRecordCek`),
+   * so a mixed vault — and a recipient that never opted into
+   * `perRecordKeys` — decrypts both legacy and CEK records:
+   *  - `_cek` present → unwrap the CEK under the collection DEK, decrypt the
+   *    body under the CEK (cache the unwrapped CEK so repeated reads skip it).
+   *  - `_cek` absent → legacy path, body decrypts directly under the
+   *    collection DEK.
+   *
+   * The optional `id` lets reads populate the CEK cache; it is omitted by
+   * callers (history, conflict merge) that have only the envelope.
+   */
+  private async decryptJsonString(envelope: EncryptedEnvelope, id?: string): Promise<string> {
     if (!this.encrypted) return envelope._data
     const dek = await this.getDEK(this.name)
+    if (envelope._cek !== undefined) {
+      const cached = id !== undefined ? this.cekCache?.get(id) : undefined
+      const cek = cached ?? (await unwrapCek(envelope._cek, dek))
+      if (cached === undefined && id !== undefined) this.cekCache?.set(id, cek, 1)
+      return decrypt(envelope._iv, envelope._data, cek)
+    }
     return decrypt(envelope._iv, envelope._data, dek)
   }
 
@@ -3981,9 +4201,9 @@ export class Collection<T> {
    */
   private async decryptRecord(
     envelope: EncryptedEnvelope,
-    opts: { skipValidation?: boolean } = {},
+    opts: { skipValidation?: boolean; id?: string } = {},
   ): Promise<T> {
-    const json = await this.decryptJsonString(envelope)
+    const json = await this.decryptJsonString(envelope, opts.id)
     let parsed: unknown = JSON.parse(json)
 
     // CRDT resolution: if this collection is in CRDT mode, the

--- a/packages/hub/src/crypto.ts
+++ b/packages/hub/src/crypto.ts
@@ -113,6 +113,70 @@ export async function unwrapKey(
   }
 }
 
+// ─── Per-record CEK wrapping ───────────────────────────────────────────
+
+/**
+ * Derive a **dedicated** AES-KW wrapping key from a collection/tier DEK via
+ * HKDF-SHA256, used to wrap/unwrap a per-record CEK.
+ *
+ * The collection/tier DEKs are AES-256-**GCM** keys (usages
+ * `encrypt`/`decrypt`) and cannot themselves act as an AES-KW KEK. We do NOT
+ * re-import the raw DEK bytes directly as an AES-KW key — that would reuse one
+ * key across two primitives (AES-GCM for `_det`/presence, AES-KW for CEK
+ * wrapping), violating key separation. Instead we HKDF-derive a domain-
+ * separated KW key (salt `noydb-cek-wrap`), exactly as `derivePresenceKey`
+ * derives a separate presence key. The derivation is deterministic, so
+ * wrapping the same CEK under the same DEK always yields identical ciphertext
+ * — which is what lets an update reuse a record's stable CEK and produce a
+ * byte-identical `_cek`. The KW key is independent of the DEK's GCM key.
+ *
+ * The DEK must be extractable (it is — `generateDEK`/`unwrapKey` mint
+ * extractable keys).
+ */
+async function asKwKey(dek: CryptoKey): Promise<CryptoKey> {
+  const rawDek = await subtle.exportKey('raw', dek)
+  const hkdfKey = await subtle.importKey('raw', rawDek, 'HKDF', false, ['deriveBits'])
+  const salt = new TextEncoder().encode('noydb-cek-wrap')
+  const info = new TextEncoder().encode('v1')
+  const bits = await subtle.deriveBits(
+    { name: 'HKDF', hash: 'SHA-256', salt, info },
+    hkdfKey,
+    KEY_BITS,
+  )
+  return subtle.importKey('raw', bits, 'AES-KW', false, ['wrapKey', 'unwrapKey'])
+}
+
+/**
+ * AES-KW-wrap a per-record CEK under a collection/tier DEK. Returns base64.
+ * Deterministic over `(cek, dek)`.
+ */
+export async function wrapCek(cek: CryptoKey, dek: CryptoKey): Promise<string> {
+  const kw = await asKwKey(dek)
+  const wrapped = await subtle.wrapKey('raw', cek, kw, 'AES-KW')
+  return bufferToBase64(wrapped)
+}
+
+/**
+ * Unwrap a per-record CEK from base64 under a collection/tier DEK. Throws
+ * `InvalidKeyError` if the wrapped bytes do not authenticate under the DEK.
+ */
+export async function unwrapCek(wrappedBase64: string, dek: CryptoKey): Promise<CryptoKey> {
+  const kw = await asKwKey(dek)
+  try {
+    return await subtle.unwrapKey(
+      'raw',
+      base64ToBuffer(wrappedBase64) as BufferSource,
+      kw,
+      'AES-KW',
+      { name: 'AES-GCM', length: KEY_BITS },
+      true,
+      ['encrypt', 'decrypt'],
+    )
+  } catch {
+    throw new InvalidKeyError()
+  }
+}
+
 // ─── Encrypt / Decrypt ─────────────────────────────────────────────────
 
 export interface EncryptResult {

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -132,6 +132,27 @@ export interface EncryptedEnvelope {
    * side channel.
    */
   readonly _det?: Record<string, string>
+  /**
+   * Per-record content-encryption key (CEK), base64 AES-KW-wrapped under
+   * the collection (or tier) DEK. Present only on records written by a
+   * collection opened with `perRecordKeys: true`. When present, the body
+   * (`_iv`/`_data`) is encrypted under the unwrapped CEK rather than the
+   * collection DEK directly.
+   *
+   * Presence is the format discriminant: `_cek` absent → legacy body
+   * keyed off the collection DEK (read unchanged); `_cek` present →
+   * unwrap under the collection DEK, then decrypt the body under the CEK.
+   *
+   * The CEK is stable across every version of a record (insert mints it;
+   * updates and history snapshots reuse it), so all `_history` envelopes
+   * for a record carry the same `_cek`. This is the foundation for
+   * per-record erasure (#304) and record-scoped sealing (#306).
+   *
+   * `_det` slots are deliberately NOT keyed off the CEK — they remain
+   * keyed to the collection DEK so blind-equality search keeps working
+   * across records.
+   */
+  readonly _cek?: string
 }
 
 /**

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -628,6 +628,14 @@ export class Vault {
     /** — explicit ack that deterministic encryption leaks equality. */
     acknowledgeDeterministicRisk?: boolean
     /**
+     * — per-record content-encryption keys. When `true`, every record
+     * body is encrypted under a fresh per-record CEK wrapped under the
+     * collection DEK (`_cek`), stable across versions. Foundation for
+     * per-record erasure (#304) / record-scoped sealing (#306). Off by
+     * default; non-adopting collections take the legacy path unchanged.
+     */
+    perRecordKeys?: boolean
+    /**
      * declarative blob retention / TTL policy per slot
      * name. Values are `{ retainDays?, evictWhen? }`. Evaluated only
      * when `vault.compact()` runs.
@@ -867,6 +875,9 @@ export class Vault {
       }
       if (options?.acknowledgeDeterministicRisk !== undefined) {
         collOpts.acknowledgeDeterministicRisk = options.acknowledgeDeterministicRisk
+      }
+      if (options?.perRecordKeys !== undefined) {
+        collOpts.perRecordKeys = options.perRecordKeys
       }
       if (options?.tiers !== undefined) collOpts.tiers = options.tiers
       if (options?.tierMode !== undefined) collOpts.tierMode = options.tierMode

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -420,7 +420,15 @@ const KERNEL_SURFACE_BUDGET = {
   // branch in applyLocaleToRecord. This is the one read choke point the
   // hybrid resolution contract must extend; the resolver/registries live in
   // the tree-shaken withI18n() strategy + vault, not here.
-  'packages/hub/src/collection.ts': 4085,
+  // Bumped 4085→4320 (2026-06-13): per-record CEK foundation (step 1 of the
+  // erasure/sealing epic — #304/#306 gate). The CEK encrypt/decrypt branch is
+  // a core write/read choke point: resolveRecordCek + isTombstone helpers, the
+  // `_cek`-aware encryptJsonString/decryptJsonString/decryptRecord, the stable
+  // CEK threaded through put/CRDT-put/delete-history/migration/dump and the two
+  // conflict resolvers, plus the tier elevate/demote/getAtTier CEK re-wrap.
+  // This is the per-record-key layer the kernel owns; forget()/shred (#304)
+  // and record-scoped sealing (#306) build on top in their own subsystems.
+  'packages/hub/src/collection.ts': 4320,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -434,7 +442,11 @@ const KERNEL_SURFACE_BUDGET = {
   // applyLocale + resolveDictSource, and the resolveLabelFromMap helper. These
   // are the config-time registry + the two label-resolution seams the hybrid
   // contract requires to live on the vault; no per-vault _dict_* storage added.
-  'packages/hub/src/vault.ts': 3905,
+  // Bumped 3905→3925 (2026-06-13): per-record CEK foundation — the
+  // `perRecordKeys` collection option (doc + threading into collOpts),
+  // mirroring the deterministicFields wiring. Config-time only; the CEK
+  // crypto lives in collection.ts / crypto.ts.
+  'packages/hub/src/vault.ts': 3925,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),


### PR DESCRIPTION
**Design-only, for review** before any core-crypto code. This is **step 1** of the erasure/sealing security epic — the shared per-record-CEK foundation that #304 (crypto-shred erasure) and #306 (record-scoped `at-*` sealing) both require.

## Why a foundation spec first
Per the forget-cascade spec's own recommendation, #304 and #306 are **one epic** on a shared primitive (the DEK is per-collection today, so neither per-subject erasure nor per-record sealing is possible without finer key granularity). This spec introduces a **per-record CEK** (AES-KW-wrapped under the collection DEK — mirrors the existing DEK-under-KEK pattern, no new crypto), **behind a per-collection `perRecordKeys` flag**, and **resolves the interplay the existing spec only flagged**:

- **`_det` blind-equality** stays DEK-keyed (excluded from CEK); **shred strips `_det` + history + body-CEK and tombstones** — fixes the `findByDet` shred-residue the prior spec left open.
- **history** shares the record's *stable* CEK (one delete kills the whole version chain).
- **tiers** compose (elevate/demote re-wraps the CEK under the dest tier DEK).
- **bundles**: `reKeyClosure` must unwrap+rewrap `_cek` under the dest DEK — **correctness-critical, needs new test coverage**.
- **blobs**: deferred (shared `_blob` DEK + eTag dedup) — boundary surfaced loudly by `forget()`.
- **migration**: `_cek`-absence = legacy dual-read; un-migrated records aren't shreddable and `forget()` reports them.

Grounded in the current crypto/envelope/DEK/`_det`/bundle/tier code with file:line refs.

## What I'm asking for
Review of the **5 open decisions** at the end (tombstone-vs-delete on shred, CEK stability on re-key, flag granularity, migration trigger, read-of-shredded semantics) before I implement step 1's 5 build slices behind the flag.

Foundation for #304 + #306. No code in this PR.