### PR TITLE
feat(hub): withForgetCascade / vault.forget() — crypto-shred erasure (#304, epic step 2)

### DIFF
--- a/docs/core/02-encryption.md
+++ b/docs/core/02-encryption.md
@@ -55,6 +55,53 @@ By default one per-collection DEK encrypts every record body. Opt a collection i
 
 This is the foundation (step 1) for per-record erasure (`forget()` / shred, #304) and record-scoped sealing (#306), which build on top in their own slices. See `docs/superpowers/specs/2026-06-13-per-record-cek-foundation-design.md`.
 
+## GDPR crypto-shred — `withForgetCascade` / `vault.forget()` (#304)
+
+Built on per-record CEKs. Declare which collections carry erasable subject
+data and the field naming the data subject:
+
+```ts
+import { withForgetCascade } from '@noy-db/hub/forget'
+
+createNoydb({
+  secret, user,
+  historyStrategy: withHistory(),                       // ledger for the proof
+  forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+})
+
+const result = await db.vault('main').forget('buyer-123')
+// → { subject, recordsShredded, historyVersionsShredded, collections,
+//     unmigratedRecords, blobResidueCollections, ledgerEntry }
+```
+
+- **Shred = tombstone, not a CEK-only delete.** Each matching record's LIVE
+  envelope is rewritten to `{ _noydb, _v, _ts, _by, _iv:'', _data:'' }`
+  (dropping `_iv`/`_data`/`_cek`/`_det`) and EVERY `_history` version of the
+  record is tombstoned the same way. The body and all prior versions become
+  permanently undecryptable; the collection DEK and every other record are
+  untouched.
+- **Declared collections are forced to `perRecordKeys: true`** — a shred can
+  only guarantee erasure of a body keyed off a per-record CEK.
+- **Encrypted, portable subject index.** A reserved `_subject_index`
+  collection (own DEK) maps `sha256Hex(subjectId) → [{collection,id}]`, so the
+  store never sees which records share a subject. Maintained on write
+  (onAfterWrite for create/update, an `afterDelete` observer for delete) and
+  rebuildable from canonical records with `vault.rebuildSubjectIndex()` (the
+  recovery path for the single-writer read-modify-write race — no CAS in v1).
+- **Ledger proof without plaintext.** One `op:'forget'` entry is appended with
+  empty collection/id, version 0, and `payloadHash = sha256Hex(subjectId)`.
+  The hash-chain still `verify()`s — the ledger proves a subject existed and
+  was erased on a date without retaining the subject id or any content.
+- **Completeness gaps are surfaced, never silently claimed.** `forget()`
+  reports `unmigratedRecords` (a legacy body still under the shared collection
+  DEK — tombstoned, but pre-shred ciphertext leaked to a backup before
+  migration stays decryptable; migrate then re-forget) and
+  `blobResidueCollections` (blob attachments are keyed off the separate
+  `_blob` DEK and are out of scope for record-CEK shred). `forget()` is
+  idempotent: a second call shreds nothing.
+
+See `docs/superpowers/specs/2026-06-08-forget-cascade-design.md`.
+
 ## Plaintext mode
 
 `createNoydb({ encrypt: false })` skips the crypto path entirely. Records are stored as raw JSON in `_data`. Use only for testing / debugging — no privacy guarantees.

--- a/features.yaml
+++ b/features.yaml
@@ -63,6 +63,27 @@ features:
       - 'Tombstone tolerance: a `get()` on an envelope with no `_data`/`_cek` returns null rather than throwing TamperedError (shred tombstone creation is step 2 / #304)'
     related: [vault-and-collections, permissions]
 
+  - id: forget-cascade
+    name: GDPR crypto-shred (withForgetCascade / vault.forget)
+    cluster: subsystem
+    spec: docs/superpowers/specs/2026-06-08-forget-cascade-design.md
+    subsystem_doc: docs/core/02-encryption.md
+    package: '@noy-db/hub/forget'
+    factory: withForgetCascade
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'Per-record erasure builds on per-record CEK (#304 step 2): each declared collection is forced to `perRecordKeys: true` so a shred can erase one subject without touching the collection DEK or any other record'
+      - 'Shred = TOMBSTONE, not a CEK-only delete: `vault.forget(subjectId)` rewrites the live envelope to `{_noydb,_v,_ts,_by,_iv:"",_data:""}` (drops `_iv`/`_data`/`_cek`/`_det`) AND tombstones every `_history` envelope for the record → body + all versions permanently undecryptable; version counter preserved for audit'
+      - 'Encrypted portable subject index: a reserved `_subject_index` collection (own DEK) maps `sha256Hex(subjectId) → [{collection,id}]` so subject equivalence is never visible to the store; maintained on write via onAfterWrite (create/update) + an afterDelete observer (delete), rebuildable from canonical records via `vault.rebuildSubjectIndex()`'
+      - 'Ledger proof without plaintext: forget appends ONE `op:"forget"` entry with empty collection/id, version 0, and `payloadHash = sha256Hex(subjectId)`; the hash-chain still `verify()`s after a shred, proving "subject existed and was erased" without retaining the subject id'
+      - 'Read-path tombstone tolerance: every decrypt callsite (get, list, scan, history, CRDT reconcile/merge, findByDet, persisted-index reconcile) treats a tombstone as null/skip instead of throwing TamperedError'
+      - 'Completeness gaps surfaced, never silently claimed: `forget()` reports `unmigratedRecords` (legacy body still under the collection DEK) and `blobResidueCollections` (blob attachments keyed off the separate `_blob` DEK, out of scope for record-CEK shred); idempotent (a second forget shreds nothing)'
+    related: [encryption, history]
+
   - id: stores-contract
     name: 6-method NoydbStore contract
     cluster: core

--- a/packages/hub/__tests__/forget.test.ts
+++ b/packages/hub/__tests__/forget.test.ts
@@ -1,0 +1,348 @@
+/**
+ * withForgetCascade / vault.forget() — GDPR crypto-shred (#304, epic step 2).
+ *
+ * Spec: docs/superpowers/specs/2026-06-08-forget-cascade-design.md
+ * Foundation: docs/superpowers/specs/2026-06-13-per-record-cek-foundation-design.md
+ *
+ * Decision pins (foundation, APPROVED): shred = TOMBSTONE (rewrite the live
+ * envelope + every history version to `{_noydb,_v,_ts,_by,_iv:'',_data:''}`),
+ * NOT a CEK-only delete; read of a tombstone returns null (no TamperedError).
+ *
+ * 9 groups:
+ *  1. forget tombstones the live record + all history of matching records,
+ *     leaves OTHER subjects' records intact.
+ *  2. ledger.verify() still ok after shred + head op==='forget' +
+ *     payloadHash === sha256Hex(subject).
+ *  3. `_det` stripped → findByDet returns null (NO TamperedError) after shred.
+ *  4. un-migrated (perRecordKeys:false) record reported in unmigratedRecords
+ *     and still tombstoned.
+ *  5. blob residue reported.
+ *  6. idempotent (second forget → 0 shredded, no throw).
+ *  7. rebuildSubjectIndex recovers an empty index.
+ *  8. ForgetStrategyNotConfiguredError when no strategy.
+ *  9. CRDT-mode + a tombstone does not throw, and list() over a collection
+ *     containing a tombstone skips it.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { ConflictError, ForgetStrategyNotConfiguredError } from '../src/errors.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { withHistory } from '../src/history/index.js'
+import { withForgetCascade } from '../src/forget/index.js'
+import { withCrdt } from '../src/crdt/index.js'
+import { withSync } from '../src/sync/index.js'
+import { sha256Hex } from '../src/history/ledger/entry.js'
+
+/** In-memory store exposing raw envelopes + a list helper for reserved cols. */
+function memory(): NoydbStore & {
+  raw(c: string, col: string, id: string): EncryptedEnvelope | undefined
+  rawList(c: string, col: string): string[]
+} {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    raw(c, col, id) { return store.get(c)?.get(col)?.get(id) },
+    rawList(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) for (const [name, coll] of existing) if (name.startsWith('_')) comp.set(name, coll)
+      store.set(c, comp)
+    },
+  }
+}
+
+interface Invoice { id: string; buyerId: string; amount: number; memo?: string }
+
+const SECRET = 'forget-test-passphrase-1234'
+
+describe('forget — group 1: tombstones live + history of matching records', () => {
+  it('shreds the subject and all its history, leaves other subjects intact', async () => {
+    const store = memory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: SECRET,
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+    })
+    const vault = await db.openVault('v')
+    const invoices = vault.collection<Invoice>('invoices')
+
+    // buyer-1 has two records, one with several versions.
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1', amount: 100 })
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1', amount: 150 })
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1', amount: 200 })
+    await invoices.put('i-2', { id: 'i-2', buyerId: 'buyer-1', amount: 50 })
+    // buyer-2 is untouched by the forget.
+    await invoices.put('i-3', { id: 'i-3', buyerId: 'buyer-2', amount: 999 })
+    await invoices.put('i-3', { id: 'i-3', buyerId: 'buyer-2', amount: 1000 })
+
+    const result = await vault.forget('buyer-1')
+
+    expect(result.subject).toBe('buyer-1')
+    expect(result.recordsShredded).toBe(2)
+    expect(result.collections).toEqual(['invoices'])
+    // i-1 had 2 displaced history versions (v1, v2); i-2 had 0.
+    expect(result.historyVersionsShredded).toBe(2)
+
+    // buyer-1 records read as null (tombstone).
+    expect(await invoices.get('i-1')).toBeNull()
+    expect(await invoices.get('i-2')).toBeNull()
+
+    // The live envelopes are tombstones (no _data / _cek / _det).
+    const tomb = store.raw('v', 'invoices', 'i-1')!
+    expect(tomb._data).toBe('')
+    expect(tomb._cek).toBeUndefined()
+    expect(tomb._det).toBeUndefined()
+    expect(tomb._v).toBe(3) // version counter preserved
+
+    // History versions are tombstoned too.
+    for (const id of store.rawList('v', '_history').filter((k) => k.startsWith('invoices:i-1:'))) {
+      expect(store.raw('v', '_history', id)!._data).toBe('')
+    }
+
+    // buyer-2 is intact.
+    expect(await invoices.get('i-3')).toMatchObject({ amount: 1000 })
+    const hist = await invoices.history('i-3')
+    expect(hist.length).toBe(1)
+    expect(hist[0]!.record).toMatchObject({ amount: 999 })
+  })
+})
+
+describe('forget — group 2: ledger verify + head op + payloadHash', () => {
+  it('ledger.verify() passes after shred; head is op:forget with subject hash', async () => {
+    const store = memory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: SECRET,
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+    })
+    const vault = await db.openVault('v')
+    const invoices = vault.collection<Invoice>('invoices')
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1', amount: 100 })
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1', amount: 200 })
+
+    await vault.forget('buyer-1')
+
+    const ledger = vault.ledger()
+    const verify = await ledger.verify()
+    expect(verify.ok).toBe(true)
+
+    const entries = await ledger.entries()
+    const head = entries[entries.length - 1]!
+    expect(head.op).toBe('forget')
+    expect(head.collection).toBe('')
+    expect(head.id).toBe('')
+    expect(head.version).toBe(0)
+    expect(head.payloadHash).toBe(await sha256Hex('buyer-1'))
+  })
+})
+
+describe('forget — group 3: _det stripped, findByDet returns null (no TamperedError)', () => {
+  it('a deterministic field no longer matches a shredded record', async () => {
+    const store = memory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: SECRET,
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+    })
+    const vault = await db.openVault('v')
+    const invoices = vault.collection<Invoice>('invoices', {
+      deterministicFields: ['buyerId'],
+      acknowledgeDeterministicRisk: true,
+    })
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1', amount: 100 })
+
+    // Before shred, findByDet finds it.
+    expect(await invoices.findByDet('buyerId', 'buyer-1')).toMatchObject({ id: 'i-1' })
+
+    await vault.forget('buyer-1')
+
+    // After shred: _det stripped, so findByDet returns null and does NOT throw.
+    const tomb = store.raw('v', 'invoices', 'i-1')!
+    expect(tomb._det).toBeUndefined()
+    await expect(invoices.findByDet('buyerId', 'buyer-1')).resolves.toBeNull()
+  })
+})
+
+describe('forget — group 4: un-migrated record reported + still tombstoned', () => {
+  it('reports a perRecordKeys:false legacy record in unmigratedRecords', async () => {
+    const store = memory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: SECRET,
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { legacy_invoices: 'buyerId' } }),
+    })
+    const vault = await db.openVault('v')
+    // Force a legacy (no-CEK) body by writing through a DIFFERENT collection
+    // instance that the strategy does not force — but the strategy forces
+    // perRecordKeys for declared collections. To simulate an un-migrated
+    // record we write the raw envelope directly: a body with _data and no _cek.
+    const invoices = vault.collection<Invoice>('legacy_invoices')
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1', amount: 100 })
+
+    // Confirm the strategy forced perRecordKeys (the live env carries _cek).
+    expect(store.raw('v', 'legacy_invoices', 'i-1')!._cek).toBeDefined()
+
+    // Now overwrite the live envelope with a legacy (no-_cek) body to model an
+    // un-migrated record, keeping the subject index ref intact.
+    const live = store.raw('v', 'legacy_invoices', 'i-1')!
+    await store.put('v', 'legacy_invoices', 'i-1', { ...live, _cek: undefined } as EncryptedEnvelope)
+
+    const result = await vault.forget('buyer-1')
+    expect(result.unmigratedRecords).toContain('legacy_invoices:i-1')
+    // Still tombstoned.
+    expect(store.raw('v', 'legacy_invoices', 'i-1')!._data).toBe('')
+    expect(result.recordsShredded).toBe(1)
+  })
+})
+
+describe('forget — group 5: blob residue reported', () => {
+  it('reports a collection whose shredded record still has a blob slot', async () => {
+    const store = memory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: SECRET,
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+    })
+    const vault = await db.openVault('v')
+    const invoices = vault.collection<Invoice>('invoices')
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1', amount: 100 })
+
+    // Simulate a blob attachment slot for this record.
+    await store.put('v', '_blob_slots_invoices', 'i-1', {
+      _noydb: 1, _v: 1, _ts: new Date().toISOString(), _iv: 'x', _data: 'y',
+    } as EncryptedEnvelope)
+
+    const result = await vault.forget('buyer-1')
+    expect(result.blobResidueCollections).toContain('invoices')
+  })
+})
+
+describe('forget — group 6: idempotent', () => {
+  it('a second forget shreds nothing and does not throw', async () => {
+    const store = memory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: SECRET,
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+    })
+    const vault = await db.openVault('v')
+    const invoices = vault.collection<Invoice>('invoices')
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1', amount: 100 })
+
+    const first = await vault.forget('buyer-1')
+    expect(first.recordsShredded).toBe(1)
+
+    const second = await vault.forget('buyer-1')
+    expect(second.recordsShredded).toBe(0)
+    expect(second.historyVersionsShredded).toBe(0)
+    // The chain still verifies after two forgets.
+    expect((await vault.ledger().verify()).ok).toBe(true)
+  })
+})
+
+describe('forget — group 7: rebuildSubjectIndex recovers', () => {
+  it('rebuilds the subject index from canonical records', async () => {
+    const store = memory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: SECRET,
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+    })
+    const vault = await db.openVault('v')
+    const invoices = vault.collection<Invoice>('invoices')
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1', amount: 100 })
+    await invoices.put('i-2', { id: 'i-2', buyerId: 'buyer-1', amount: 50 })
+    await invoices.put('i-3', { id: 'i-3', buyerId: 'buyer-2', amount: 999 })
+
+    // Wipe the subject index to simulate a lost/empty index.
+    for (const k of store.rawList('v', '_subject_index')) {
+      await store.delete('v', '_subject_index', k)
+    }
+    expect(store.rawList('v', '_subject_index').length).toBe(0)
+
+    const subjects = await vault.rebuildSubjectIndex()
+    expect(subjects).toBe(2) // buyer-1, buyer-2
+
+    // forget now works again off the rebuilt index.
+    const result = await vault.forget('buyer-1')
+    expect(result.recordsShredded).toBe(2)
+  })
+})
+
+describe('forget — group 8: ForgetStrategyNotConfiguredError', () => {
+  it('throws when no forget strategy is configured', async () => {
+    const store = memory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: SECRET,
+      historyStrategy: withHistory(),
+    })
+    const vault = await db.openVault('v')
+    await expect(vault.forget('buyer-1')).rejects.toBeInstanceOf(ForgetStrategyNotConfiguredError)
+  })
+})
+
+interface CrdtDoc { id: string; buyerId: string; tags: Record<string, string> }
+
+describe('forget — group 9: CRDT-mode tombstone + list() skip do not throw', () => {
+  it('a tombstone in a CRDT collection reads as null and list() skips it', async () => {
+    const store = memory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: SECRET,
+      historyStrategy: withHistory(),
+      crdtStrategy: withCrdt(),
+      syncStrategy: withSync(),
+      forgetStrategy: withForgetCascade({ subjects: { crdt_invoices: 'buyerId' } }),
+    })
+    const vault = await db.openVault('v')
+    const invoices = vault.collection<CrdtDoc>('crdt_invoices', { crdt: 'lww-map' })
+    await invoices.put('c-1', { id: 'c-1', buyerId: 'buyer-1', tags: { a: '1' } })
+    await invoices.put('c-1', { id: 'c-1', buyerId: 'buyer-1', tags: { a: '2' } })
+    await invoices.put('c-2', { id: 'c-2', buyerId: 'buyer-2', tags: { b: '1' } })
+
+    await vault.forget('buyer-1')
+
+    // CRDT-mode get on the tombstone returns null, no throw.
+    await expect(invoices.get('c-1')).resolves.toBeNull()
+    // getRaw also tolerant of the tombstone.
+    await expect(invoices.getRaw('c-1')).resolves.toBeNull()
+
+    // list() over the collection containing a tombstone does NOT throw and
+    // skips the shredded record.
+    const all = await invoices.list()
+    expect(all.map((r) => r.id)).toEqual(['c-2'])
+  })
+})

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -76,6 +76,16 @@
         "default": "./dist/history/index.cjs"
       }
     },
+    "./forget": {
+      "import": {
+        "types": "./dist/forget/index.d.ts",
+        "default": "./dist/forget/index.js"
+      },
+      "require": {
+        "types": "./dist/forget/index.d.cts",
+        "default": "./dist/forget/index.cjs"
+      }
+    },
     "./query": {
       "import": {
         "types": "./dist/query/index.d.ts",

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -879,6 +879,10 @@ export class Collection<T> {
         }
         const localJson = await this.decryptJsonString(local, id)
         const remoteJson = await this.decryptJsonString(remote, id)
+        // Tombstone (shredded) on either side: the live envelope is the
+        // authoritative merge result — a shred must win and stay shredded.
+        if (localJson === null) return local
+        if (remoteJson === null) return remote
         const localState = JSON.parse(localJson) as CrdtState
         const remoteState = JSON.parse(remoteJson) as CrdtState
         const merged = this.crdtStrategy.mergeCrdtStates(localState, remoteState)
@@ -933,6 +937,10 @@ export class Collection<T> {
         resolver = async (id, local, remote) => {
           const localRecord = await this.decryptRecord(local, { skipValidation: true, id })
           const remoteRecord = await this.decryptRecord(remote, { skipValidation: true, id })
+          // Tombstone on either side wins — a shredded record must not be
+          // resurrected by a merge against a still-live peer.
+          if (localRecord === null) return local
+          if (remoteRecord === null) return remote
           const merged = mergeFn(localRecord, remoteRecord)
           const mergedVersion = Math.max(local._v, remote._v) + 1
           const cek = this.perRecordCek ? await this.resolveRecordCek(id) : undefined
@@ -1067,6 +1075,7 @@ export class Collection<T> {
         // body / CEK. Reads return null rather than throwing TamperedError.
         if (this.isTombstone(envelope)) return null
         record = await this.decryptRecord(envelope, { id })
+        if (record === null) return null
         this.lru.set(id, { record, version: envelope._v }, estimateRecordBytes(record))
       }
     } else {
@@ -1097,6 +1106,7 @@ export class Collection<T> {
     const envelope = await this.adapter.get(this.vault, this.name, id)
     if (!envelope) return null
     const json = await this.decryptJsonString(envelope)
+    if (json === null) return null // shredded (tombstone)
     return JSON.parse(json) as CrdtState
   }
 
@@ -1195,7 +1205,7 @@ export class Collection<T> {
       if (cached) return { record: cached.record, version: cached.version }
       const env = await this.adapter.get(this.vault, this.name, id)
       if (!env) return { record: null, version: 0 }
-      return { record: (await this.decryptRecord(env, { skipValidation: true })) as unknown, version: env._v }
+      return { record: (await this.decryptRecord(env, { skipValidation: true })) as unknown ?? null, version: env._v }
     }
     await this.ensureHydrated()
     const cached = this.cache.get(id)
@@ -1377,9 +1387,11 @@ export class Collection<T> {
         let existingState: LwwMapState | undefined
         if (existingEnvelope) {
           const prevJson = await this.decryptJsonString(existingEnvelope)
-          const prevParsed = JSON.parse(prevJson) as unknown
-          if (prevParsed !== null && typeof prevParsed === 'object' && '_crdt' in prevParsed) {
-            existingState = prevParsed as LwwMapState
+          if (prevJson !== null) {
+            const prevParsed = JSON.parse(prevJson) as unknown
+            if (prevParsed !== null && typeof prevParsed === 'object' && '_crdt' in prevParsed) {
+              existingState = prevParsed as LwwMapState
+            }
           }
         }
         crdtState = this.crdtStrategy.buildLwwMapState(record as Record<string, unknown>, existingState, now)
@@ -1387,9 +1399,11 @@ export class Collection<T> {
         let existingState: RgaState | undefined
         if (existingEnvelope) {
           const prevJson = await this.decryptJsonString(existingEnvelope)
-          const prevParsed = JSON.parse(prevJson) as unknown
-          if (prevParsed !== null && typeof prevParsed === 'object' && '_crdt' in prevParsed) {
-            existingState = prevParsed as RgaState
+          if (prevJson !== null) {
+            const prevParsed = JSON.parse(prevJson) as unknown
+            if (prevParsed !== null && typeof prevParsed === 'object' && '_crdt' in prevParsed) {
+              existingState = prevParsed as RgaState
+            }
           }
         }
         const arr = Array.isArray(record) ? record : [record]
@@ -1408,8 +1422,13 @@ export class Collection<T> {
 
       // Resolve snapshot for cache and history
       const resolvedRecord = this.crdtStrategy.resolveCrdtSnapshot(crdtState) as T
-      const existingResolved = existingEnvelope
-        ? { record: await this.decryptRecord(existingEnvelope, { skipValidation: true }), version: existingVersion }
+      // A tombstone (shredded) prior envelope yields a null record → treat as
+      // "no previous version" so we don't snapshot/diff an erased value.
+      const existingResolvedRecord = existingEnvelope
+        ? await this.decryptRecord(existingEnvelope, { skipValidation: true })
+        : null
+      const existingResolved = existingResolvedRecord !== null
+        ? { record: existingResolvedRecord, version: existingVersion }
         : undefined
 
       if (existingResolved && this.historyConfig.enabled !== false) {
@@ -1463,7 +1482,10 @@ export class Collection<T> {
         const previousEnvelope = await this.adapter.get(this.vault, this.name, id)
         if (previousEnvelope) {
           const previousRecord = await this.decryptRecord(previousEnvelope)
-          existing = { record: previousRecord, version: previousEnvelope._v }
+          // Tombstone (shredded) prior → treat as no previous version.
+          if (previousRecord !== null) {
+            existing = { record: previousRecord, version: previousEnvelope._v }
+          }
         }
       }
     } else {
@@ -1836,7 +1858,9 @@ export class Collection<T> {
     for (const id of ids) {
       const env = await this.adapter.get(this.vault, this.name, id)
       if (!env || this.isTombstone(env)) continue
-      const record = (await this.decryptRecord(env, { skipValidation: true, id })) as unknown as Record<string, unknown>
+      const decoded = await this.decryptRecord(env, { skipValidation: true, id })
+      if (decoded === null) continue // defensive: shredded between list and get
+      const record = decoded as unknown as Record<string, unknown>
       const next = transform(record)
       const nextVersion = (env._v ?? 0) + 1
       // Migration pass: on a `perRecordKeys` collection, a legacy (no-`_cek`)
@@ -1976,7 +2000,10 @@ export class Collection<T> {
         const previousEnvelope = await this.adapter.get(this.vault, this.name, id)
         if (previousEnvelope) {
           const previousRecord = await this.decryptRecord(previousEnvelope)
-          existing = { record: previousRecord, version: previousEnvelope._v }
+          // Tombstone (shredded) prior → no record to snapshot on delete.
+          if (previousRecord !== null) {
+            existing = { record: previousRecord, version: previousEnvelope._v }
+          }
         }
       }
     } else {
@@ -2064,6 +2091,65 @@ export class Collection<T> {
       await this.dispatchMaterializedViewsOnDelete(id)
       await this.dispatchArrayDerivationsOnDelete(id)
     }
+  }
+
+  /**
+   * @internal — GDPR crypto-shred a LIVE record to a tombstone (#304).
+   *
+   * Rewrites the on-disk envelope to `{ _noydb, _v, _ts, _by, _iv:'', _data:'' }`,
+   * dropping `_iv`/`_data`/`_cek`/`_det`. The wrapped per-record CEK is gone, so
+   * the body — and (via {@link tombstoneHistory}) every history version under
+   * the same CEK — is permanently undecryptable; the collection DEK and every
+   * other record are untouched. `_det` is stripped too, so `findByDet` no
+   * longer matches the shredded record (avoiding a post-shred TamperedError).
+   *
+   * Unlike `delete()`/`_internalDelete`, this:
+   *   - does NOT fire onDelete guards / MV / derivation dispatch (a shred is an
+   *     erasure, not a domain delete — re-running those would be wrong),
+   *   - does NOT append a per-record ledger entry (`vault.forget()` appends a
+   *     single `op:'forget'` summary for the whole subject),
+   *   - keeps the record KEY present (it's an overwrite, not an adapter delete)
+   *     so the version counter + "record existed" survive for audit.
+   *
+   * Idempotent: returns `null` when the record is absent or already a tombstone.
+   * Otherwise returns `{ previousVersion }`. Invalidates the eager cache, the
+   * lazy LRU, and the per-record CEK cache for this id.
+   */
+  /**
+   * @internal — decrypt an envelope to a plain record for subject-index
+   * rebuild (#304). Returns `null` for a tombstone or unreadable envelope.
+   * Skips schema validation — the rebuild only reads the subject field.
+   */
+  async _decodeEnvelope(envelope: EncryptedEnvelope, id: string): Promise<Record<string, unknown> | null> {
+    try {
+      const rec = await this.decryptRecord(envelope, { skipValidation: true, id })
+      return rec === null ? null : (rec as unknown as Record<string, unknown>)
+    } catch {
+      return null
+    }
+  }
+
+  async _writeTombstone(id: string, actor: string): Promise<{ previousVersion: number } | null> {
+    const live = await this.adapter.get(this.vault, this.name, id)
+    if (!live || this.isTombstone(live)) return null
+
+    const tombstone: EncryptedEnvelope = {
+      _noydb: NOYDB_FORMAT_VERSION,
+      _v: live._v,
+      _ts: new Date().toISOString(),
+      _iv: '',
+      _data: '',
+      ...(actor ? { _by: actor } : {}),
+    }
+    await this.adapter.put(this.vault, this.name, id, tombstone)
+
+    // Invalidate every in-memory view of this record so subsequent reads see
+    // the tombstone (→ null), not a stale decrypted value.
+    this.cache.delete(id)
+    this.lru?.remove(id)
+    this.cekCache?.remove(id)
+
+    return { previousVersion: live._v }
   }
 
   /**
@@ -2600,6 +2686,10 @@ export class Collection<T> {
     for (const env of envelopes) {
       // History reads skip schema validation — see getVersion() docs.
       const record = await this.decryptRecord(env, { skipValidation: true })
+      // Shredded (tombstoned) history version: the body is permanently gone,
+      // so there is nothing to return — skip it. The version still counted in
+      // the audit ledger; history() just can't surface its erased content.
+      if (record === null) continue
       entries.push({
         version: env._v,
         timestamp: env._ts,
@@ -2757,6 +2847,7 @@ export class Collection<T> {
       const envelope = await this.adapter.get(this.vault, this.name, id)
       if (envelope) {
         const record = await this.decryptRecord(envelope)
+        if (record === null) continue // shredded (tombstone) — skip
         items.push(record)
         // Same lazy-mode skip as the native path: don't pollute the LRU
         // with sequential scan results.
@@ -2853,6 +2944,7 @@ export class Collection<T> {
     const out: Array<{ id: string; record: T; version: number }> = []
     for (const { id, envelope } of items) {
       const record = await this.decryptRecord(envelope)
+      if (record === null) continue // shredded (tombstone) — skip the page row
       out.push({ id, record, version: envelope._v })
     }
     return out
@@ -2893,6 +2985,16 @@ export class Collection<T> {
       return
     }
     const record = await this.decryptRecord(envelope)
+    if (record === null) {
+      // The on-disk envelope is now a tombstone (shredded). Treat exactly
+      // like a deleted record: drop the cache entry and its index rows.
+      this.cache.delete(id)
+      if (previous) {
+        this.indexes?.remove(id, previous.record)
+        this.uniqueConstraints?.remove(id, previous.record)
+      }
+      return
+    }
     this.cache.set(id, { record, version: envelope._v })
     this.indexes?.upsert(id, record, previous ? previous.record : null)
     this.uniqueConstraints?.upsert(id, record, previous?.record)
@@ -2923,6 +3025,7 @@ export class Collection<T> {
       const envelope = await this.adapter.get(this.vault, this.name, id)
       if (envelope && !this.isTombstone(envelope)) {
         const record = await this.decryptRecord(envelope, { id })
+        if (record === null) continue
         this.cache.set(id, { record, version: envelope._v })
       }
     }
@@ -2936,6 +3039,7 @@ export class Collection<T> {
     for (const [id, envelope] of Object.entries(records)) {
       if (this.isTombstone(envelope)) continue
       const record = await this.decryptRecord(envelope, { id })
+      if (record === null) continue
       this.cache.set(id, { record, version: envelope._v })
     }
     this.hydrated = true
@@ -3036,6 +3140,7 @@ export class Collection<T> {
       const envelope = await this.adapter.get(this.vault, this.name, recordId)
       if (!envelope) continue
       const record = await this.decryptRecord(envelope, { skipValidation: true })
+      if (record === null) continue // shredded (tombstone) — no side-car to build
       await this.maintainPersistedIndexesOnPut(recordId, record, null, envelope._v)
     }
 
@@ -3098,8 +3203,14 @@ export class Collection<T> {
       const env = await this.adapter.get(this.vault, this.name, id)
       if (!env) continue
       try {
-        const body = JSON.parse(await this.decryptJsonString(env)) as { value: unknown }
-        sidecar.set(decoded.recordId, body.value)
+        const sidecarJson = await this.decryptJsonString(env)
+        if (sidecarJson === null) {
+          // Tombstone side-car (shredded) — treat as stale so it's rewritten.
+          sidecar.set(decoded.recordId, undefined)
+        } else {
+          const body = JSON.parse(sidecarJson) as { value: unknown }
+          sidecar.set(decoded.recordId, body.value)
+        }
       } catch {
         // Unreadable — treat as stale so it gets rewritten.
         sidecar.set(decoded.recordId, undefined)
@@ -3116,6 +3227,10 @@ export class Collection<T> {
       const env = await this.adapter.get(this.vault, this.name, id)
       if (!env) continue
       const record = await this.decryptRecord(env, { skipValidation: true })
+      // Shredded (tombstone) canonical record: treat like a vanished record —
+      // leave its `id` in `sidecarIds` so any lingering side-car is marked
+      // stale (and deleted) by the leftover loop below.
+      if (record === null) continue
       const live = readPersistedValue(record as unknown as Record<string, unknown>, field)
       const stored = sidecar.get(id)
       const hasSidecar = sidecarIds.has(id)
@@ -3510,6 +3625,7 @@ export class Collection<T> {
       if (!envelope) continue
       try {
         const json = await this.decryptJsonString(envelope)
+        if (json === null) continue // tombstone side-car — skip
         const body = JSON.parse(json) as { value: unknown; recordId: string }
         if (typeof body.recordId !== 'string') continue
         const rows = byField.get(decoded.field) ?? []
@@ -3829,7 +3945,8 @@ export class Collection<T> {
       const env = await this.adapter.get(this.vault, this.name, id)
       if (!env || !env._det) continue
       if (env._det[field] === target) {
-        matches.push(await this.decryptRecord(env))
+        const rec = await this.decryptRecord(env)
+        if (rec !== null) matches.push(rec) // skip tombstone (defensive)
       }
     }
     return matches
@@ -4172,7 +4289,14 @@ export class Collection<T> {
    * The optional `id` lets reads populate the CEK cache; it is omitted by
    * callers (history, conflict merge) that have only the envelope.
    */
-  private async decryptJsonString(envelope: EncryptedEnvelope, id?: string): Promise<string> {
+  private async decryptJsonString(envelope: EncryptedEnvelope, id?: string): Promise<string | null> {
+    // RISK #1 (forget cascade): a shred tombstone carries `_data: ''` and no
+    // `_cek`. Decrypting it would call `decrypt('', '', dek)` → AES-GCM
+    // OperationError → TamperedError. Return null so every read callsite
+    // treats it as "absent / skip", matching how get()/list already drop
+    // tombstones. Legacy plaintext collections (`!this.encrypted`) legitimately
+    // have empty `_iv`/`_data`, so `isTombstone` is false for them — preserved.
+    if (this.isTombstone(envelope)) return null
     if (!this.encrypted) return envelope._data
     const dek = await this.getDEK(this.name)
     if (envelope._cek !== undefined) {
@@ -4202,8 +4326,11 @@ export class Collection<T> {
   private async decryptRecord(
     envelope: EncryptedEnvelope,
     opts: { skipValidation?: boolean; id?: string } = {},
-  ): Promise<T> {
+  ): Promise<T | null> {
     const json = await this.decryptJsonString(envelope, opts.id)
+    // Tombstone (shredded record) → null, propagated from decryptJsonString.
+    // Callers skip null exactly as they already skip a tombstone envelope.
+    if (json === null) return null
     let parsed: unknown = JSON.parse(json)
 
     // CRDT resolution: if this collection is in CRDT mode, the

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -58,6 +58,8 @@
  *       │    └─ SnapshotNotFoundError  — snapshot key absent from snapshot store
  *       └─ Computed field errors
  *            └─ ComputedFieldError     — computed function threw during a write
+ *       └─ Erasure errors
+ *            └─ ForgetStrategyNotConfiguredError — vault.forget() with no withForgetCascade
  * ```
  *
  * ## Catching all NOYDB errors
@@ -2174,5 +2176,27 @@ export class VaultTemplateNotFoundError extends NoydbError {
     )
     this.name = 'VaultTemplateNotFoundError'
     this.templateName = templateName
+  }
+}
+
+// ─── Erasure Errors ────────────────────────────────────────────────────
+
+/**
+ * Thrown when `vault.forget(subjectId)` is called on a vault whose
+ * `createNoydb({ forgetStrategy })` declared no subject fields (the
+ * default `NO_FORGET`). GDPR crypto-shred needs a declared subject →
+ * record index to know which records belong to a data subject; without
+ * one there is nothing to erase and a silent no-op would be a dangerous
+ * false "erased" signal. Configure with
+ * `forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } })`.
+ */
+export class ForgetStrategyNotConfiguredError extends NoydbError {
+  constructor(
+    message = 'vault.forget() requires a forget strategy. Pass ' +
+      '`forgetStrategy: withForgetCascade({ subjects: { <collection>: <subjectField> } })` ' +
+      'from "@noy-db/hub/forget" to createNoydb().',
+  ) {
+    super('FORGET_NOT_CONFIGURED', message)
+    this.name = 'ForgetStrategyNotConfiguredError'
   }
 }

--- a/packages/hub/src/forget/index.ts
+++ b/packages/hub/src/forget/index.ts
@@ -1,0 +1,34 @@
+/**
+ * `@noy-db/hub/forget` — GDPR right-to-erasure via per-record CEK crypto-shred
+ * (#304). Import `withForgetCascade` and pass it to `createNoydb`:
+ *
+ * ```ts
+ * import { createNoydb } from '@noy-db/hub'
+ * import { withForgetCascade } from '@noy-db/hub/forget'
+ *
+ * const db = createNoydb({
+ *   secret, user,
+ *   historyStrategy: withHistory(),               // ledger for the erasure proof
+ *   forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+ * })
+ * const result = await db.vault('main').forget('buyer-123')
+ * ```
+ *
+ * The erasure flow (`vault.forget`), the subject-index maintenance hooks, and
+ * the tombstone rewrite live in core (`vault.ts` / `collection.ts`) because
+ * they touch the write path directly; this subpath only exposes the
+ * declaration factory + result types.
+ *
+ * @module
+ */
+export {
+  withForgetCascade,
+  NO_FORGET,
+} from './strategy.js'
+export type {
+  SubjectDeclaration,
+  ForgetStrategy,
+  ForgetResult,
+} from './strategy.js'
+export type { SubjectRef } from './subject-index.js'
+export { SUBJECT_INDEX_COLLECTION } from './subject-index.js'

--- a/packages/hub/src/forget/strategy.ts
+++ b/packages/hub/src/forget/strategy.ts
@@ -1,0 +1,108 @@
+/**
+ * `withForgetCascade` — declaration surface for GDPR right-to-erasure via
+ * per-record CEK crypto-shred (#304, step 2 of the CEK security epic).
+ *
+ * This file holds only the *declaration* shape and the disabled sentinel.
+ * The actual erasure machinery lives in:
+ *   - `subject-index.ts` — the encrypted `_subject_index` reserved collection
+ *   - `vault.ts` `forget()` — the per-record tombstone + ledger flow
+ *   - `collection.ts` `_writeTombstone` — the envelope rewrite
+ *
+ * A `ForgetStrategy` declares which collections carry erasable subject data
+ * and the (dotted-path) field on each record that names the data subject.
+ * Declaring a collection here ALSO forces `perRecordKeys: true` for it (a
+ * shred can only erase a record whose body is keyed off a per-record CEK),
+ * so adopters opt into the CEK foundation transitively.
+ *
+ * @module
+ */
+import type { LedgerEntry } from '../history/ledger/entry.js'
+
+/**
+ * User-supplied declaration passed to {@link withForgetCascade}. Maps a
+ * collection name to the record field (dotted path supported, e.g.
+ * `'billing.buyerId'`) that identifies the data subject for erasure.
+ *
+ * ```ts
+ * withForgetCascade({ subjects: { invoices: 'buyerId', contacts: 'id' } })
+ * ```
+ */
+export interface SubjectDeclaration {
+  readonly subjects: Record<string, string>
+}
+
+/**
+ * Resolved forget strategy threaded through Noydb → every Vault. Carries
+ * the same `subjects` map the user declared. `NO_FORGET` (empty map) is the
+ * off-by-default sentinel; `vault.forget()` throws
+ * `ForgetStrategyNotConfiguredError` when the map is empty.
+ */
+export interface ForgetStrategy {
+  /** Collection → subject-field (dotted path). Empty under `NO_FORGET`. */
+  readonly subjects: Readonly<Record<string, string>>
+}
+
+/**
+ * Disabled sentinel — no collections declare a subject field. `vault.forget()`
+ * refuses with `ForgetStrategyNotConfiguredError`; no write hooks register; no
+ * collection is forced into `perRecordKeys`. Non-adopters pay nothing.
+ */
+export const NO_FORGET: ForgetStrategy = { subjects: {} }
+
+/**
+ * Declare GDPR crypto-shred for one or more collections.
+ *
+ * Each declared collection is forced to `perRecordKeys: true` (a shred can
+ * only guarantee erasure of a record whose body is keyed off a per-record
+ * CEK). On write, Noydb extracts `record[subjectField]` and maintains an
+ * encrypted `_subject_index` mapping `subject → [{collection, id}]`, so
+ * `vault.forget(subjectId)` can find every record for a subject and rewrite
+ * each to a tombstone (body + history permanently undecryptable) while the
+ * collection DEK and every other record stay intact.
+ *
+ * @example
+ * ```ts
+ * createNoydb({
+ *   secret, user,
+ *   forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+ * })
+ * const result = await vault.forget('buyer-123')
+ * // → { subject, recordsShredded, historyVersionsShredded, collections, … }
+ * ```
+ */
+export function withForgetCascade(opts: SubjectDeclaration): ForgetStrategy {
+  return { subjects: { ...opts.subjects } }
+}
+
+/**
+ * The outcome of a `vault.forget(subjectId)` call.
+ *
+ * `unmigratedRecords` lists `collection:id` pairs that were tombstoned but
+ * whose body had NOT been migrated to a per-record CEK at shred time (legacy
+ * body still under the shared collection DEK). Those records are tombstoned
+ * (live envelope + history stripped) but their pre-shred ciphertext, if it
+ * leaked into a backup before migration, remains decryptable under the
+ * collection DEK — so erasure-completeness is NOT guaranteed for them. Run
+ * the per-record-CEK migration pass, then re-forget, to close the gap.
+ *
+ * `blobResidueCollections` lists collections where a shredded record still
+ * has blob attachments — blob content is keyed off a separate vault-wide
+ * `_blob` DEK and is OUT OF SCOPE for record-CEK shred (foundation decision
+ * #5). The caller must erase those blobs through a future blob-shred slice.
+ */
+export interface ForgetResult {
+  /** The subject id passed to `forget()`. Echoed for caller convenience. */
+  readonly subject: string
+  /** Count of live records rewritten to a tombstone. */
+  readonly recordsShredded: number
+  /** Count of `_history` envelopes tombstoned across all shredded records. */
+  readonly historyVersionsShredded: number
+  /** Distinct collections that had at least one record shredded. */
+  readonly collections: readonly string[]
+  /** `collection:id` pairs shredded while still un-migrated (see type docs). */
+  readonly unmigratedRecords: readonly string[]
+  /** Collections where a shredded record still has un-erased blob attachments. */
+  readonly blobResidueCollections: readonly string[]
+  /** The single `op:'forget'` ledger entry appended for this erasure. */
+  readonly ledgerEntry: LedgerEntry
+}

--- a/packages/hub/src/forget/subject-index.ts
+++ b/packages/hub/src/forget/subject-index.ts
@@ -1,0 +1,224 @@
+/**
+ * The encrypted subject index (#304).
+ *
+ * GDPR crypto-shred needs to answer "which records belong to data subject
+ * X?" portably (the index must travel with the vault/bundle) WITHOUT leaking
+ * subject-equivalence to the store. The rejected alternative — an unencrypted
+ * subject tag in envelope metadata — would let anyone with store access see
+ * which records share a subject. Instead we keep a reserved `_subject_index`
+ * collection, encrypted under its OWN DEK (`getDEK('_subject_index')`):
+ *
+ *   - record id  = `sha256Hex(subjectId)` — the raw subject id never appears
+ *     as a key, so the store can't correlate index entries to a known subject.
+ *   - record body = AES-GCM(JSON `[{ collection, id }]`) under the index DEK.
+ *
+ * ## Concurrency (RISK #3 — known v1 limitation)
+ *
+ * `addSubjectRef` / `removeSubjectRef` are read-modify-write with no CAS. The
+ * design assumes a SINGLE WRITER (the noy-db single-process write model). Two
+ * concurrent writers racing on the SAME subject can lose an entry (last-write
+ * wins on the ref list). This is documented, not fixed in v1:
+ * `rebuildSubjectIndex` performs a full scan to recover a correct index from
+ * the canonical records, so a lost ref is recoverable. A CAS-backed index is
+ * deferred to a later slice.
+ *
+ * @module
+ */
+import { encrypt, decrypt } from '../crypto.js'
+import type { NoydbStore, EncryptedEnvelope } from '../types.js'
+import { NOYDB_FORMAT_VERSION } from '../types.js'
+
+/** Reserved collection holding the encrypted subject → records index. */
+export const SUBJECT_INDEX_COLLECTION = '_subject_index'
+
+/** A single record reference held in a subject's index entry. */
+export interface SubjectRef {
+  readonly collection: string
+  readonly id: string
+}
+
+type GetDEK = (collectionName: string) => Promise<CryptoKey>
+
+/** SHA-256 hex of a UTF-8 string. The subject-index record key derivation. */
+async function sha256HexString(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input)
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes)
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/** Stable subject-index record id for a subject id. */
+export async function subjectKey(subjectId: string): Promise<string> {
+  return sha256HexString(subjectId)
+}
+
+/** Read + decrypt the ref list for a subject. Returns `[]` when absent. */
+async function readRefs(
+  adapter: NoydbStore,
+  vault: string,
+  getDEK: GetDEK,
+  encrypted: boolean,
+  key: string,
+): Promise<SubjectRef[]> {
+  const env = await adapter.get(vault, SUBJECT_INDEX_COLLECTION, key)
+  if (!env || !env._data) return []
+  if (!encrypted) return JSON.parse(env._data) as SubjectRef[]
+  const dek = await getDEK(SUBJECT_INDEX_COLLECTION)
+  const json = await decrypt(env._iv, env._data, dek)
+  return JSON.parse(json) as SubjectRef[]
+}
+
+/** Encrypt + write a ref list for a subject under its derived key. */
+async function writeRefs(
+  adapter: NoydbStore,
+  vault: string,
+  getDEK: GetDEK,
+  encrypted: boolean,
+  key: string,
+  refs: SubjectRef[],
+): Promise<void> {
+  const json = JSON.stringify(refs)
+  let env: EncryptedEnvelope
+  if (!encrypted) {
+    env = { _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: new Date().toISOString(), _iv: '', _data: json }
+  } else {
+    const dek = await getDEK(SUBJECT_INDEX_COLLECTION)
+    const { iv, data } = await encrypt(json, dek)
+    env = { _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: new Date().toISOString(), _iv: iv, _data: data }
+  }
+  await adapter.put(vault, SUBJECT_INDEX_COLLECTION, key, env)
+}
+
+/**
+ * Add a `{ collection, id }` ref to a subject's index entry (idempotent —
+ * a duplicate ref is not appended). Read-modify-write; see the concurrency
+ * note in the module docstring.
+ */
+export async function addSubjectRef(
+  adapter: NoydbStore,
+  vault: string,
+  getDEK: GetDEK,
+  encrypted: boolean,
+  subjectId: string,
+  ref: SubjectRef,
+): Promise<void> {
+  const key = await subjectKey(subjectId)
+  const refs = await readRefs(adapter, vault, getDEK, encrypted, key)
+  if (refs.some((r) => r.collection === ref.collection && r.id === ref.id)) return
+  refs.push(ref)
+  await writeRefs(adapter, vault, getDEK, encrypted, key, refs)
+}
+
+/**
+ * Remove a `{ collection, id }` ref from a subject's index entry. When the
+ * last ref is removed the (now empty) entry is deleted so the store holds no
+ * residual key for an erased subject.
+ */
+export async function removeSubjectRef(
+  adapter: NoydbStore,
+  vault: string,
+  getDEK: GetDEK,
+  encrypted: boolean,
+  subjectId: string,
+  ref: SubjectRef,
+): Promise<void> {
+  const key = await subjectKey(subjectId)
+  const refs = await readRefs(adapter, vault, getDEK, encrypted, key)
+  const next = refs.filter((r) => !(r.collection === ref.collection && r.id === ref.id))
+  if (next.length === refs.length) return
+  if (next.length === 0) {
+    await adapter.delete(vault, SUBJECT_INDEX_COLLECTION, key)
+    return
+  }
+  await writeRefs(adapter, vault, getDEK, encrypted, key, next)
+}
+
+/** Look up every record ref for a subject. Returns `[]` when none exist. */
+export async function lookupSubject(
+  adapter: NoydbStore,
+  vault: string,
+  getDEK: GetDEK,
+  encrypted: boolean,
+  subjectId: string,
+): Promise<SubjectRef[]> {
+  const key = await subjectKey(subjectId)
+  return readRefs(adapter, vault, getDEK, encrypted, key)
+}
+
+/**
+ * Rebuild the entire subject index from the canonical records (the recovery
+ * path for the documented read-modify-write race). Scans each declared
+ * collection, reads `record[subjectField]` (dotted path), and rewrites the
+ * index from scratch. Tombstoned (already-shredded) records contribute no
+ * ref — their body is gone, so they cannot be re-indexed.
+ *
+ * `decodeRecord` decrypts an envelope to a plain object (or returns null for
+ * a tombstone / unreadable record); supplied by the caller so this module
+ * stays free of Collection internals.
+ */
+export async function rebuildSubjectIndex(
+  adapter: NoydbStore,
+  vault: string,
+  getDEK: GetDEK,
+  encrypted: boolean,
+  subjects: Readonly<Record<string, string>>,
+  decodeRecord: (collection: string, id: string, env: EncryptedEnvelope) => Promise<Record<string, unknown> | null>,
+): Promise<number> {
+  // Drop every existing index entry first so removed refs don't linger.
+  const existing = await adapter.list(vault, SUBJECT_INDEX_COLLECTION)
+  for (const k of existing) {
+    await adapter.delete(vault, SUBJECT_INDEX_COLLECTION, k)
+  }
+
+  // subjectId → refs, accumulated across all declared collections.
+  const bySubject = new Map<string, SubjectRef[]>()
+  for (const [collection, field] of Object.entries(subjects)) {
+    const ids = await adapter.list(vault, collection)
+    for (const id of ids) {
+      if (id.startsWith('_')) continue
+      const env = await adapter.get(vault, collection, id)
+      if (!env || !env._data) continue // missing or tombstone
+      const record = await decodeRecord(collection, id, env)
+      if (record === null) continue
+      const subjectValue = readDottedPath(record, field)
+      if (subjectValue === undefined || subjectValue === null) continue
+      const subjectId = coerceSubjectId(subjectValue)
+      const list = bySubject.get(subjectId) ?? []
+      list.push({ collection, id })
+      bySubject.set(subjectId, list)
+    }
+  }
+
+  let entries = 0
+  for (const [subjectId, refs] of bySubject) {
+    const key = await subjectKey(subjectId)
+    await writeRefs(adapter, vault, getDEK, encrypted, key, refs)
+    entries++
+  }
+  return entries
+}
+
+/**
+ * Coerce a read subject-field value to a stable string id. Primitives use
+ * their natural string form; objects/arrays are JSON-stringified so structural
+ * subjects still get a deterministic key (avoids the `[object Object]` trap).
+ */
+export function coerceSubjectId(value: unknown): string {
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value)
+  }
+  return JSON.stringify(value)
+}
+
+/** Read a (possibly dotted) field path from a plain record. */
+export function readDottedPath(record: Record<string, unknown>, field: string): unknown {
+  if (!field.includes('.')) return record[field]
+  let cursor: unknown = record
+  for (const segment of field.split('.')) {
+    if (cursor === null || cursor === undefined) return undefined
+    cursor = (cursor as Record<string, unknown>)[segment]
+  }
+  return cursor
+}

--- a/packages/hub/src/history/active.ts
+++ b/packages/hub/src/history/active.ts
@@ -34,6 +34,7 @@ import {
   getVersionEnvelope,
   pruneHistory,
   clearHistory,
+  tombstoneHistory,
 } from './history.js'
 import { diff as computeDiff } from './diff.js'
 import { LedgerStore, envelopePayloadHash } from './ledger/store.js'
@@ -57,6 +58,7 @@ export function withHistory(): HistoryStrategy {
     getVersionEnvelope,
     pruneHistory,
     clearHistory,
+    tombstoneHistory,
     envelopePayloadHash,
     computePatch,
     diff: computeDiff,

--- a/packages/hub/src/history/history.ts
+++ b/packages/hub/src/history/history.ts
@@ -1,4 +1,5 @@
 import type { NoydbStore, EncryptedEnvelope, HistoryOptions, PruneOptions } from '../types.js'
+import { NOYDB_FORMAT_VERSION } from '../types.js'
 
 /**
  * History storage convention:
@@ -160,4 +161,50 @@ export async function clearHistory(
   }
 
   return toDelete.length
+}
+
+/**
+ * Crypto-shred every `_history` version of a record (#304). Each non-tombstone
+ * history envelope is OVERWRITTEN in place with a tombstone
+ * `{ _noydb, _v, _ts: now, _by: actor, _iv: '', _data: '' }` — dropping
+ * `_iv`/`_data`/`_cek`/`_det`, so the prior ciphertext (and the wrapped CEK
+ * that could decrypt it) is gone everywhere this store reaches. The version
+ * counter (`_v`) is preserved so the audit trail still shows "N versions
+ * existed and were erased."
+ *
+ * Overwrite — NOT delete — so the history key itself survives as proof the
+ * version existed. Already-tombstoned versions (re-run / idempotent forget)
+ * are left untouched and not counted.
+ *
+ * Returns the number of history versions newly tombstoned.
+ */
+export async function tombstoneHistory(
+  adapter: NoydbStore,
+  vault: string,
+  collection: string,
+  recordId: string,
+  actor: string,
+): Promise<number> {
+  const allIds = await adapter.list(vault, HISTORY_COLLECTION)
+  const matchingIds = allIds.filter(id => matchesPrefix(id, collection, recordId))
+
+  const now = new Date().toISOString()
+  let count = 0
+  for (const id of matchingIds) {
+    const env = await adapter.get(vault, HISTORY_COLLECTION, id)
+    if (!env) continue
+    // Already a tombstone (no body and no wrapped CEK)? Skip — idempotent.
+    if (!env._data && env._cek === undefined) continue
+    const tombstone: EncryptedEnvelope = {
+      _noydb: NOYDB_FORMAT_VERSION,
+      _v: env._v,
+      _ts: now,
+      _iv: '',
+      _data: '',
+      ...(actor ? { _by: actor } : {}),
+    }
+    await adapter.put(vault, HISTORY_COLLECTION, id, tombstone)
+    count++
+  }
+  return count
 }

--- a/packages/hub/src/history/ledger/entry.ts
+++ b/packages/hub/src/history/ledger/entry.ts
@@ -89,8 +89,18 @@ export interface LedgerEntry {
    * `amendment`, it carries no data envelope, so `verifyBackupIntegrity`
    * skips it in the data cross-check (it still participates in the
    * tamper-evident chain).
+   *
+   * `'forget'` is the single summary entry written by `vault.forget()`
+   * (#304 GDPR crypto-shred). `collection`/`id` are empty and `version`
+   * is 0 — a forget is not scoped to one record. `payloadHash` carries
+   * `sha256Hex(subjectId)` so the ledger PROVES "subject X existed and
+   * was erased on date D" without retaining the subject id or any
+   * plaintext; `reason` holds a JSON summary of the shred counts. Like
+   * `amendment`/`lifecycle` it carries no data envelope and is skipped
+   * by the reconstruct walker (it still participates in the chain, so
+   * `verify()` passes after a shred).
    */
-  readonly op: 'put' | 'delete' | 'amendment' | 'lifecycle' | 'migration'
+  readonly op: 'put' | 'delete' | 'amendment' | 'lifecycle' | 'migration' | 'forget'
 
   /** The collection the mutation targeted. */
   readonly collection: string

--- a/packages/hub/src/history/strategy.ts
+++ b/packages/hub/src/history/strategy.ts
@@ -121,6 +121,19 @@ export interface HistoryStrategy {
   ): Promise<number>
 
   /**
+   * Crypto-shred (overwrite-to-tombstone) every `_history` version of a
+   * record for GDPR erasure (#304). Returns the number of versions newly
+   * tombstoned, or `0` under `NO_HISTORY` (no history = nothing to shred).
+   */
+  tombstoneHistory(
+    adapter: NoydbStore,
+    vault: string,
+    collection: string,
+    recordId: string,
+    actor: string,
+  ): Promise<number>
+
+  /**
    * Compute the SHA-256 hash of an envelope's encrypted payload, used
    * by `LedgerStore.append` to track tamper-evidence. Returns the
    * empty string under `NO_HISTORY` (the call site is gated by
@@ -184,6 +197,7 @@ export const NO_HISTORY: HistoryStrategy = {
   async getVersionEnvelope() { throw notEnabled('collection.getVersion()') },
   async pruneHistory() { return 0 },
   async clearHistory() { return 0 },
+  async tombstoneHistory() { return 0 },
   async envelopePayloadHash() { return '' },
   computePatch() { return [] },
   diff() { throw notEnabled('collection.diff()') },

--- a/packages/hub/src/history/time-machine.ts
+++ b/packages/hub/src/history/time-machine.ts
@@ -222,7 +222,9 @@ export class CollectionInstant<T = unknown> {
       // carry no (collection, id) tuple of their own and would never match
       // the filter above. The narrow here is a type guard, not a runtime
       // skip.
-      if (e.op === 'amendment' || e.op === 'lifecycle') continue
+      // `forget` is a subject-erasure summary with empty (collection, id) —
+      // never matches the filter above; the narrow is a type guard.
+      if (e.op === 'amendment' || e.op === 'lifecycle' || e.op === 'forget') continue
       // `migration` is a record rewrite (cutover) — resolve it like a put.
       latest = { op: e.op === 'migration' ? 'put' : e.op, version: e.version }
     }

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -323,6 +323,7 @@ export type {
 export type { SchemaManifestRow, DeploymentEvent, CapturedBlueprint } from './federation/index.js'
 export { STATE_VAULT_NAME } from './federation/constants.js'
 export { UnknownShardError, ShardProvisioningError, VaultTemplateNotFoundError, ReservedVaultNameError } from './errors.js'
+export { ForgetStrategyNotConfiguredError } from './errors.js'
 
 // Bundle format — `.noydb` container
 export {

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -115,6 +115,8 @@ import type { AmendmentTxOptions } from './tx/transaction.js'
 import { TxContext } from './tx/transaction.js'
 import type { DryRunResult } from './tx/dry-run.js'
 import { NO_TX, type TxStrategy } from './tx/strategy.js'
+import { NO_FORGET, type ForgetStrategy } from './forget/strategy.js'
+import { readDottedPath, coerceSubjectId } from './forget/subject-index.js'
 import { INDEXED_STORE_POLICY } from './store/sync-policy.js'
 import type { PolicyEnforcer } from './session/session-policy.js'
 import { NO_SESSION, type SessionStrategy } from './session/strategy.js'
@@ -210,6 +212,7 @@ export class Noydb {
   private readonly policyEnforcers = new Map<string, PolicyEnforcer>()
   private readonly vaultTemplates = new Map<string, VaultTemplate>()
   private readonly txStrategy: TxStrategy
+  private readonly forgetStrategy: ForgetStrategy
   private readonly sessionStrategy: SessionStrategy
   private readonly syncStrategy: SyncStrategy
   private readonly snapshotStrategy: SnapshotStrategy
@@ -239,6 +242,7 @@ export class Noydb {
   constructor(options: NoydbOptions) {
     this.options = options
     this.txStrategy = options.txStrategy ?? NO_TX
+    this.forgetStrategy = options.forgetStrategy ?? NO_FORGET
     this.sessionStrategy = options.sessionStrategy ?? NO_SESSION
     this.syncStrategy = options.syncStrategy ?? NO_SYNC
     this.snapshotStrategy = options.snapshotStrategy ?? NO_SNAPSHOTS
@@ -252,7 +256,70 @@ export class Noydb {
     }
     this.#registerGuardGate()
     this.#registerPeriodGate()
+    this.#registerForgetHooks()
     this.resetSessionTimer()
+  }
+
+  /** @internal — resolved forget strategy (NO_FORGET when not configured). */
+  get _forgetStrategy(): ForgetStrategy {
+    return this.forgetStrategy
+  }
+
+  // #304 — GDPR subject-index maintenance. When `withForgetCascade` declares
+  // any subject fields, keep the encrypted `_subject_index` in lock-step with
+  // writes so `vault.forget(subjectId)` can find every record for a subject.
+  //
+  // Two consumers are required because they cover disjoint events:
+  //   - onAfterWrite fires on create/update (NOT delete) — add the new ref;
+  //     on an update that changed the subject value, drop the stale ref.
+  //   - the subsystemBus `afterDelete` observer fires on delete (onAfterWrite
+  //     does NOT) — drop the ref so a deleted record never lingers in the
+  //     index (RISK #2). Without it, forget() would try to shred a ghost.
+  #registerForgetHooks(): void {
+    const subjects = this.forgetStrategy.subjects
+    if (Object.keys(subjects).length === 0) return
+
+    const subjectFieldFor = (collection: string): string | undefined => subjects[collection]
+
+    this.writeHooks.onAfterWrite(async (event) => {
+      const field = subjectFieldFor(event.collection)
+      if (field === undefined) return
+      const vault = this.vaultCache.get(event.vault)
+      if (!vault) return
+      // Add the ref for the new subject value.
+      if (event.after !== null && typeof event.after === 'object') {
+        const subjectValue = readDottedPath(event.after as Record<string, unknown>, field)
+        if (subjectValue !== undefined && subjectValue !== null) {
+          await vault._addSubjectRef(coerceSubjectId(subjectValue), { collection: event.collection, id: event.docId })
+        }
+      }
+      // On update, if the subject value changed, drop the stale ref.
+      if (event.op === 'update' && event.before !== null && typeof event.before === 'object') {
+        const beforeValue = readDottedPath(event.before as Record<string, unknown>, field)
+        const afterValue =
+          event.after !== null && typeof event.after === 'object'
+            ? readDottedPath(event.after as Record<string, unknown>, field)
+            : undefined
+        const beforeId = beforeValue === undefined || beforeValue === null ? undefined : coerceSubjectId(beforeValue)
+        const afterId = afterValue === undefined || afterValue === null ? undefined : coerceSubjectId(afterValue)
+        if (beforeId !== undefined && beforeId !== afterId) {
+          await vault._removeSubjectRef(beforeId, { collection: event.collection, id: event.docId })
+        }
+      }
+    })
+
+    this.subsystemBus.register('afterDelete', async (event) => {
+      const field = subjectFieldFor(event.collection)
+      if (field === undefined) return
+      const vault = this.vaultCache.get(event.vault)
+      if (!vault) return
+      if (event.before !== null && typeof event.before === 'object') {
+        const subjectValue = readDottedPath(event.before as Record<string, unknown>, field)
+        if (subjectValue !== undefined && subjectValue !== null) {
+          await vault._removeSubjectRef(coerceSubjectId(subjectValue), { collection: event.collection, id: event.docId })
+        }
+      }
+    })
   }
 
   // Track A — guards migration. Registers record-lock / field-freeze / onDelete
@@ -511,6 +578,7 @@ export class Noydb {
       ...(this.options.syncStrategy !== undefined ? { syncStrategy: this.options.syncStrategy } : {}),
       ...(this.options.guardStrategies !== undefined ? { guardStrategies: this.options.guardStrategies } : {}),
       ...(this.options.numbering !== undefined ? { numberingConfigs: this.options.numbering } : {}),
+      forgetStrategy: this.forgetStrategy,
       locale: opts?.locale,
       // Thread the translator hook so Collection.put() can invoke it
       plaintextTranslator: this.options.plaintextTranslator
@@ -584,6 +652,7 @@ export class Noydb {
       ...(this.options.syncStrategy !== undefined ? { syncStrategy: this.options.syncStrategy } : {}),
       ...(this.options.guardStrategies !== undefined ? { guardStrategies: this.options.guardStrategies } : {}),
       ...(this.options.numbering !== undefined ? { numberingConfigs: this.options.numbering } : {}),
+      forgetStrategy: this.forgetStrategy,
       })
       this.vaultCache.set(name, comp)
       return comp

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -36,6 +36,7 @@ import type { PeriodsStrategy } from './periods/strategy.js'
 import type { ShadowStrategy } from './shadow/strategy.js'
 import type { TxStrategy } from './tx/strategy.js'
 import type { HistoryStrategy } from './history/strategy.js'
+import type { ForgetStrategy } from './forget/strategy.js'
 import type { SnapshotStrategy } from './snapshots/strategy.js'
 import type { I18nStrategy } from './i18n/strategy.js'
 import type { SessionStrategy } from './session/strategy.js'
@@ -1759,6 +1760,19 @@ export interface NoydbOptions {
    * @internal
    */
   readonly historyStrategy?: HistoryStrategy
+  /**
+   * GDPR right-to-erasure (#304). Pass `withForgetCascade({ subjects })`
+   * from `@noy-db/hub/forget` to declare which collections carry erasable
+   * subject data and the record field naming the data subject. Enables
+   * `vault.forget(subjectId)` crypto-shred (rewrite-to-tombstone of the live
+   * record + every history version → body permanently undecryptable, single
+   * `op:'forget'` ledger entry, chain still verifies). Each declared
+   * collection is forced to `perRecordKeys: true`. When omitted (the
+   * `NO_FORGET` default), `vault.forget()` throws
+   * `ForgetStrategyNotConfiguredError` and no subject-index write hooks run.
+   * Requires `historyStrategy` (the ledger) for the erasure-proof entry.
+   */
+  readonly forgetStrategy?: ForgetStrategy
   /**
    * tree-shake seam — optional i18n strategy. Pass `withI18n()`
    * from `@noy-db/hub/i18n` to enable `i18nText`/`dictKey` field

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -60,6 +60,15 @@ import { LEDGER_COLLECTION, LEDGER_DELTAS_COLLECTION } from './history/ledger/co
 import { sha256Hex } from './history/ledger/entry.js'
 import type { VaultInstant } from './history/time-machine.js'
 import { NO_HISTORY, type HistoryStrategy } from './history/strategy.js'
+import { NO_FORGET, type ForgetStrategy, type ForgetResult } from './forget/strategy.js'
+import {
+  addSubjectRef,
+  removeSubjectRef,
+  lookupSubject,
+  rebuildSubjectIndex as rebuildSubjectIndexImpl,
+  type SubjectRef,
+} from './forget/subject-index.js'
+import { ForgetStrategyNotConfiguredError } from './errors.js'
 import type { VaultFrame } from './shadow/vault-frame.js'
 import { NO_SHADOW, type ShadowStrategy } from './shadow/strategy.js'
 import type { ConsentContext, ConsentAuditEntry, ConsentAuditFilter, ConsentOp } from './consent/consent.js'
@@ -201,6 +210,7 @@ export class Vault {
   private readonly periodsStrategy: PeriodsStrategy
   private readonly shadowStrategy: ShadowStrategy
   private readonly historyStrategy: HistoryStrategy
+  private readonly forgetStrategy: ForgetStrategy
   private readonly i18nStrategy: I18nStrategy
   private readonly syncStrategy: SyncStrategy
   /**
@@ -487,6 +497,7 @@ export class Vault {
     syncStrategy?: SyncStrategy | undefined
     guardStrategies?: ReadonlyArray<GuardStrategyHandleAny> | undefined
     numberingConfigs?: ReadonlyArray<DeferredNumberingConfig> | undefined
+    forgetStrategy?: ForgetStrategy | undefined
   }) {
     this.adapter = opts.adapter
     this.name = opts.name
@@ -514,6 +525,7 @@ export class Vault {
     this.periodsStrategy = opts.periodsStrategy ?? NO_PERIODS
     this.shadowStrategy = opts.shadowStrategy ?? NO_SHADOW
     this.historyStrategy = opts.historyStrategy ?? NO_HISTORY
+    this.forgetStrategy = opts.forgetStrategy ?? NO_FORGET
     this.i18nStrategy = opts.i18nStrategy ?? NO_I18N
     this.syncStrategy = opts.syncStrategy ?? NO_SYNC
     // Guard + derivation registries are initialised lazily via
@@ -878,6 +890,20 @@ export class Vault {
       }
       if (options?.perRecordKeys !== undefined) {
         collOpts.perRecordKeys = options.perRecordKeys
+      }
+      // #304 — a collection declared in `withForgetCascade({ subjects })` MUST
+      // use per-record CEKs: crypto-shred can only guarantee erasure of a body
+      // keyed off a per-record CEK. Force it on (and warn if the caller
+      // explicitly set it false — that would silently defeat erasure).
+      if (this.forgetStrategy.subjects[collectionName] !== undefined) {
+        if (options?.perRecordKeys === false) {
+          console.warn(
+            `[noy-db] Collection "${collectionName}" is declared in withForgetCascade ` +
+            `but opened with perRecordKeys: false. Forcing perRecordKeys: true — ` +
+            `GDPR crypto-shred requires per-record CEKs.`,
+          )
+        }
+        collOpts.perRecordKeys = true
       }
       if (options?.tiers !== undefined) collOpts.tiers = options.tiers
       if (options?.tierMode !== undefined) collOpts.tierMode = options.tierMode
@@ -2106,6 +2132,155 @@ export class Vault {
       })
     }
     return this.ledgerStore
+  }
+
+  // ─── GDPR right-to-erasure (#304) ────────────────────────────────
+
+  /** @internal — add a subject→record ref to the encrypted subject index. */
+  async _addSubjectRef(subjectId: string, ref: SubjectRef): Promise<void> {
+    await addSubjectRef(this.adapter, this.name, this.getDEK, this.encrypted, subjectId, ref)
+  }
+
+  /** @internal — drop a subject→record ref from the encrypted subject index. */
+  async _removeSubjectRef(subjectId: string, ref: SubjectRef): Promise<void> {
+    await removeSubjectRef(this.adapter, this.name, this.getDEK, this.encrypted, subjectId, ref)
+  }
+
+  /**
+   * Rebuild the encrypted subject index from canonical records. The recovery
+   * path for the documented read-modify-write race (RISK #3). Returns the
+   * number of distinct subjects re-indexed.
+   */
+  async rebuildSubjectIndex(): Promise<number> {
+    if (Object.keys(this.forgetStrategy.subjects).length === 0) {
+      throw new ForgetStrategyNotConfiguredError()
+    }
+    return rebuildSubjectIndexImpl(
+      this.adapter,
+      this.name,
+      this.getDEK,
+      this.encrypted,
+      this.forgetStrategy.subjects,
+      async (collectionName, id, env) => {
+        const coll = this.collection<Record<string, unknown>>(collectionName)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (coll as any)._decodeEnvelope(env, id) as Promise<Record<string, unknown> | null>
+      },
+    )
+  }
+
+  /**
+   * GDPR crypto-shred of a data subject (#304). Consults the encrypted subject
+   * index and, per matching record:
+   *   - rewrites the LIVE envelope to a tombstone (drops `_iv`/`_data`/`_cek`/`_det`),
+   *   - tombstones every `_history` version of the record,
+   * so the body and all prior versions become permanently undecryptable while
+   * the collection DEK and every OTHER record stay intact. Then appends ONE
+   * `op:'forget'` ledger entry whose `payloadHash` is `sha256Hex(subjectId)` —
+   * the chain still `verify()`s, PROVING the subject existed and was erased
+   * without retaining any plaintext.
+   *
+   * Reports — but does not silently swallow — two completeness gaps:
+   *   - `unmigratedRecords`: a record whose body was NOT yet migrated to a
+   *     per-record CEK (legacy body still under the shared collection DEK). It
+   *     is still tombstoned, but its pre-shred ciphertext (if leaked to a
+   *     backup before migration) stays decryptable. Migrate, then re-forget.
+   *   - `blobResidueCollections`: a shredded record still has blob attachments,
+   *     which are keyed off a separate `_blob` DEK and are out of scope here.
+   *
+   * @throws ForgetStrategyNotConfiguredError when no `withForgetCascade` was set.
+   */
+  async forget(subjectId: string): Promise<ForgetResult> {
+    if (Object.keys(this.forgetStrategy.subjects).length === 0) {
+      throw new ForgetStrategyNotConfiguredError()
+    }
+
+    const refs = await lookupSubject(this.adapter, this.name, this.getDEK, this.encrypted, subjectId)
+
+    let recordsShredded = 0
+    let historyVersionsShredded = 0
+    const collections = new Set<string>()
+    const unmigratedRecords: string[] = []
+    const blobResidueCollections = new Set<string>()
+    const actor = this.keyring.userId
+
+    for (const ref of refs) {
+      const coll = this.collection<Record<string, unknown>>(ref.collection)
+      const perRecordKeys = this.forgetStrategy.subjects[ref.collection] !== undefined
+
+      // Detect an un-migrated record BEFORE shredding: a perRecordKeys
+      // collection whose live envelope still carries a body but no `_cek`
+      // means the body is keyed off the shared collection DEK (legacy /
+      // not-yet-migrated), so a shred cannot guarantee erasure of pre-shred
+      // ciphertext. We still tombstone it, but report the gap.
+      const live = await this.adapter.get(this.name, ref.collection, ref.id)
+      if (perRecordKeys && live && live._data && live._cek === undefined) {
+        unmigratedRecords.push(`${ref.collection}:${ref.id}`)
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const shred = await (coll as any)._writeTombstone(ref.id, actor) as { previousVersion: number } | null
+      if (shred !== null) {
+        recordsShredded++
+        collections.add(ref.collection)
+      }
+
+      // Tombstone every history version (idempotent — already-shredded skip).
+      historyVersionsShredded += await this.historyStrategy.tombstoneHistory(
+        this.adapter, this.name, ref.collection, ref.id, actor,
+      )
+
+      // Blob residue: a shredded record may still have blob attachments,
+      // tracked in `_blob_slots_{collection}` keyed by record id. Those are
+      // keyed off the separate `_blob` DEK and out of scope for record-CEK
+      // shred (foundation decision #5) — surface them loudly.
+      try {
+        const slotIds = await this.adapter.list(this.name, `_blob_slots_${ref.collection}`)
+        if (slotIds.includes(ref.id)) blobResidueCollections.add(ref.collection)
+      } catch {
+        // No blob-slots collection for this collection — nothing to report.
+      }
+
+      // Drop the (now-shredded) ref from the subject index.
+      await this._removeSubjectRef(subjectId, ref)
+    }
+
+    // ONE summary ledger entry for the whole subject. payloadHash =
+    // sha256Hex(subjectId) so the ledger proves erasure without the subject.
+    const subjectHash = await sha256Hex(subjectId)
+    const ledger = this.getLedgerOrNull()
+    if (!ledger) {
+      throw new Error(
+        'vault.forget() requires the history strategy for the erasure-proof ' +
+        'ledger entry. Pass `historyStrategy: withHistory()` from ' +
+        '"@noy-db/hub/history" to createNoydb().',
+      )
+    }
+    const ledgerEntry = await ledger.append({
+      op: 'forget',
+      collection: '',
+      id: '',
+      version: 0,
+      actor,
+      payloadHash: subjectHash,
+      reason: JSON.stringify({
+        recordsShredded,
+        historyVersionsShredded,
+        collections: [...collections],
+        unmigratedCount: unmigratedRecords.length,
+        blobResidueCollections: [...blobResidueCollections],
+      }),
+    })
+
+    return {
+      subject: subjectId,
+      recordsShredded,
+      historyVersionsShredded,
+      collections: [...collections],
+      unmigratedRecords,
+      blobResidueCollections: [...blobResidueCollections],
+      ledgerEntry,
+    }
   }
 
   /**

--- a/packages/hub/tsup.config.ts
+++ b/packages/hub/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup'
 /**
  * Build config — spec.
  *
- * The hub ships 17 subpath entries plus the main barrel. Every entry
+ * The hub ships 23 subpath entries plus the main barrel. Every entry
  * is its own bundle; tsup compiles them independently. With
  * `splitting: false`, shared modules (e.g. `errors.ts`) get inlined
  * into every entry, producing one class definition per entry. That
@@ -29,6 +29,7 @@ const ENTRIES = {
   'team/index': 'src/team/index.ts',
   'session/index': 'src/session/index.ts',
   'history/index': 'src/history/index.ts',
+  'forget/index': 'src/forget/index.ts',
   'query/index': 'src/query/index.ts',
   'blobs/index': 'src/blobs/index.ts',
   'indexing/index': 'src/indexing/index.ts',

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -428,7 +428,15 @@ const KERNEL_SURFACE_BUDGET = {
   // conflict resolvers, plus the tier elevate/demote/getAtTier CEK re-wrap.
   // This is the per-record-key layer the kernel owns; forget()/shred (#304)
   // and record-scoped sealing (#306) build on top in their own subsystems.
-  'packages/hub/src/collection.ts': 4320,
+  // Bumped 4320→4440 (#304, forget cascade step 2): the tombstone read-path
+  // hardening (RISK #1) touches every decrypt choke point — decryptJsonString
+  // / decryptRecord now return null on a tombstone and ~15 callsites (get,
+  // list/scan/listPage, history, CRDT reconcile + custom-merge, findByDet /
+  // queryByDet, _invalidateCacheEntry, persisted-index rebuild/reconcile,
+  // ensure/hydrate) skip null — plus the new `_writeTombstone` + `_decodeEnvelope`
+  // shred primitives. These are core read/write-path edits the kernel owns; the
+  // forget() orchestration + subject index live in vault.ts / src/forget/.
+  'packages/hub/src/collection.ts': 4440,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -446,7 +454,14 @@ const KERNEL_SURFACE_BUDGET = {
   // `perRecordKeys` collection option (doc + threading into collOpts),
   // mirroring the deterministicFields wiring. Config-time only; the CEK
   // crypto lives in collection.ts / crypto.ts.
-  'packages/hub/src/vault.ts': 3925,
+  // Bumped 3925→4100 (#304, forget cascade step 2): `vault.forget()` is a
+  // genuinely-core write-path orchestrator — it must drive `_writeTombstone` +
+  // `tombstoneHistory` per record, detect un-migrated / blob residue, and
+  // append the single `op:'forget'` ledger entry inline with the keyring/DEK.
+  // Adds forget() + rebuildSubjectIndex() + the _addSubjectRef/_removeSubjectRef
+  // hooks + the perRecordKeys-forcing in collection(); the subject-index crypto
+  // and the strategy declaration live in src/forget/ (the @noy-db/hub/forget subpath).
+  'packages/hub/src/vault.ts': 4100,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),
@@ -460,7 +475,14 @@ const KERNEL_SURFACE_BUDGET = {
   // and deferred-numbering option threading — public `db.*` API surface; the
   // VaultGroup / StateManagementVault / numbering implementations live in lazy
   // or sibling modules, only the thin entry points are here.
-  'packages/hub/src/noydb.ts': 2995,
+  // Bumped 2995→3070 (#304, forget cascade step 2): the subject-index lifecycle
+  // hooks must register at the hub instance level — `#registerForgetHooks`
+  // wires an onAfterWrite handler (create/update subject-ref maintenance) AND
+  // an `afterDelete` subsystemBus observer (RISK #2: onAfterWrite does not fire
+  // on delete, so the bus observer keeps the index from going stale), plus the
+  // forgetStrategy field + forwarding to every Vault. The index crypto + the
+  // erasure flow live in src/forget/ and vault.ts.
+  'packages/hub/src/noydb.ts': 3070,
 }
 
 function checkKernelSurface() {


### PR DESCRIPTION
**Step 2 of the CEK security epic #357** — GDPR crypto-shred erasure, built on the merged per-record CEK foundation (#356). Implements the approved forget-cascade design.

## What
- `withForgetCascade({ subjects: { invoices: 'buyerId' } })` (from `@noy-db/hub/forget`) — declares subject-id fields, **implies `perRecordKeys`** for those collections, and maintains an **encrypted `_subject_index`** at write time (`onAfterWrite` + an `afterDelete` bus observer so the index doesn't go stale on deletes).
- `vault.forget(subjectId)` → consults the index and per matching record **rewrites the live envelope to a tombstone** (`{_noydb,_v,_ts,_by}`, drops `_iv`/`_data`/`_cek`/`_det`) and tombstones every `_history` version → body + all versions permanently undecryptable; collection DEK + other records untouched. Appends **one `op:'forget'` ledger entry** (`payloadHash = sha256Hex(subject)`); the hash-chain still `verify()`s. Returns `{ subject, recordsShredded, historyVersionsShredded, collections, unmigratedRecords, blobResidueCollections, ledgerEntry }`.

## Correctness (the load-bearing part)
A tombstone (`_data:''`) reaching `decryptJsonString` would `atob('')`-throw. Fix: `decryptJsonString`/`decryptRecord` now return `null` on a tombstone and **every read callsite is null-safe (compiler-enforced)** — including the **CRDT conflict/merge resolvers, where a tombstone WINS the merge** (a shred must not be resurrected by a concurrent edit). Legacy plaintext collections are unaffected (`isTombstone` is false when `!encrypted`).

## Reported boundaries (approved decisions)
- `unmigratedRecords`: records in a `perRecordKeys` collection still lacking `_cek` (body under the shared DEK) — tombstoned, but pre-shred ciphertext isn't guaranteed erased.
- `blobResidueCollections`: blob attachments are NOT erased by record-CEK shred (blob CEK is a deferred epic slice).
- Subject-index write is read-modify-write (single-writer assumption, documented; `vault.rebuildSubjectIndex()` recovers). CAS hardening is a follow-up.

## Verification
typecheck ✅ · build ✅ (incl. `./forget` subpath) · **full hub suite 2499 ✅** (the null-safety refactor touched read/write/CRDT/history/ledger — none regressed) · lint ✅ · validate-features ✅ · check-architecture ✅ (kernel ceilings bumped w/ #304 justification). New `forget.test.ts` (9 groups: chain-verifies-after-shred, `_det`-stripped→findByDet-misses, un-migrated + blob reporting, CRDT+tombstone no-throw, idempotent, rebuild, not-configured error).

Next: **step 3 — #306** record-scoped CEK sealing (needs its own sealing spike).

Closes #304