### PR TITLE
feat: record-scoped CEK sealing #306 (RecipientSealer + seal/rotate API + host decrypt) — epic step 3

### DIFF
--- a/docs/packages/at-hosts.md
+++ b/docs/packages/at-hosts.md
@@ -19,3 +19,13 @@
 All implement hub's `SealingKeyProvider` (`seal`/`unseal`). Pair with `createNoydb({ passphraseMode: 'managed', sealingKey, shamirRecovery })`. See each package's README for setup.
 
 > **Azure note:** Key Vault RSA decrypt is version-bound — pin a versioned key id; auto-rotation on a versionless key orphans previously-sealed vaults.
+
+### Recipient-target sealing (`at-aws-kms`)
+
+Beyond self-sealing the managed passphrase, `@noy-db/at-aws-kms` can act as a **recipient target** via `awsKmsRecipientSealer({ keyId })`, implementing hub's `RecipientSealer`. Back it with an **asymmetric RSA** KMS key (`KeyUsage: ENCRYPT_DECRYPT`, `KeySpec` one of `RSA_2048` / `RSA_3072` / `RSA_4096`):
+
+- `publishRecipientHint()` calls KMS `GetPublicKey` and returns the public key as PEM — a grantor uses this hint to seal bytes to the host.
+- `sealForRecipient(plaintext, hint)` seals **locally** (no KMS call) in the canonical RSA-OAEP-SHA256 TLV, identical to hub's `MemoryRecipientSealer` wire format.
+- `unseal(sealed)` runs KMS `Decrypt` with `EncryptionAlgorithm: RSAES_OAEP_SHA_256` to unwrap the content-encryption key — **the private key never leaves KMS**.
+
+KMS asymmetric keys don't support an encryption context, so none is used. WebCrypto `RSA-OAEP`/SHA-256 and KMS `RSAES_OAEP_SHA_256` are wire-compatible, so a blob sealed by `MemoryRecipientSealer` (or any sealer using the shared `sealRsaOaepTlv` helper) unseals through the KMS path and vice-versa. This is the cloud-verified building block for record-scoped sealing (issue #306).

--- a/docs/superpowers/specs/2026-06-13-record-scoped-cek-sealing-design.md
+++ b/docs/superpowers/specs/2026-06-13-record-scoped-cek-sealing-design.md
@@ -1,0 +1,91 @@
+# Record-scoped CEK sealing to `at-*` hosts (#306) — design spike
+
+> **Spike, not a build spec.** Step 3 of the CEK security epic [[#357]]. #306 asks for **crypto-level
+> least-privilege**: seal exactly ONE record's key to a trusted-compute `at-*` host (e.g. a PDF-render
+> Lambda), so the host can decrypt that record and is *cryptographically* denied every other record —
+> not merely policy-denied. The per-record CEK foundation (step 1, merged) makes this possible for the
+> first time. This doc resolves the architecture, picks a delivery vehicle, and — critically — is honest
+> about the **revocation limit** that's inherent to handing a key to a host.
+
+Issue: [#306](https://github.com/vLannaAi/noy-db/issues/306) · Layer: crypto / `at-*` trusted-compute · Status: design, not implemented. Builds on the merged CEK foundation (`docs/superpowers/specs/2026-06-13-per-record-cek-foundation-design.md`) and recipient-target sealing (`2026-05-28-recipient-target-bundle-sealing-design.md`).
+
+## The gap, precisely (current code)
+
+Today an `at-*` host gets a key at **collection granularity or coarser**:
+- Managed mode (`createNoydb({ passphraseMode:'managed', sealingKey: awsKmsSealingProvider(...) })`) seals the **vault passphrase** to the host (`team/managed-passphrase.ts` `resolveManagedSecret`). On unseal the host derives the KEK → unwraps **every** collection DEK → can decrypt the **whole vault**.
+- `MagicLinkGrantSpec.record?` (`on-magic-link`) exists but is **advisory metadata only** (`team/magic-link-grant.ts:81`) — `writeMagicLinkGrant` wraps the whole **collection/tier DEK**; the `record?` field plays no cryptographic role. The grantee can decrypt every record in that collection.
+
+So "scope" is operational/policy today (`docs/packages/at-hosts.md`: "the safeguard is scope"), **not cryptographic at the record level**. The pilot's PDF-render Lambda must hold `{ sales: 'ro' }` — the whole sales collection DEK — to render one sale.
+
+## What the CEK foundation unlocks
+
+A record now has its own CEK, AES-KW-wrapped under the collection DEK on `_cek` (`crypto.ts` `wrapCek`/`unwrapCek`). The raw CEK is obtainable by the **grantor** (who holds the collection DEK): `getDEK(collection)` → `unwrapCek(env._cek, dek)` → `exportKey('raw', cek)` → 32 bytes. #306 = **seal those 32 raw CEK bytes to the host**, never the collection DEK. The host then holds exactly one record's key.
+
+## Design
+
+### Core: seal the raw CEK, client-side, to a host RecipientSealer
+1. **Grantor unwraps client-side.** The granting vault (unlocked) resolves the record's raw CEK as above. The host is **never** given the collection DEK — only the sealed CEK. This is the load-bearing invariant for host-denial (see Hard Problem A).
+2. **Seal to the host's recipient identity.** Reuse the existing `RecipientSealer` machinery (`team/managed-passphrase.ts`: `RecipientHint{v,pid,alg,material}`, `sealForRecipient(plaintextBytes, hint)`). It's algorithm-agnostic over bytes — sealing a 32-byte CEK is a drop-in for the credential bytes it seals today. A 32-byte CEK fits RSA-OAEP-2048's ~190-byte limit.
+3. **Host unseals + decrypts exactly that record.** The host receives the sealed CEK, unseals it (its private key / KMS), then `decrypt(env._iv, env._data, cek)`. It holds no other key.
+
+### Prerequisite (must land first): `at-*` hosts as RecipientSealers
+`at-aws-kms` (and the GCP/Azure trio) implement `SealingKeyProvider` (symmetric seal/unseal) but **NOT `RecipientSealer`** (the recipient-target spec §12 explicitly defers this). Record-scoped sealing to a cloud host needs the host to expose a **recipient public identity** to seal against. For AWS KMS that's an **asymmetric KMS key** + `Encrypt`/`Decrypt` (`RecipientHint.alg: 'kms-encrypt'`, a new union member). **This is the first build slice** — without it, #306 only works against the in-process `MemoryRecipientSealer`, not a real cloud host.
+
+### Delivery vehicle: a new `_meta/sealed-cek/<collection>/<id>/<pid>` envelope
+The explorer confirmed **no lightweight sealed-key delivery type exists**; the options are a full bundle (heavyweight; mutually exclusive with extracted-partition), the extract-partition transferKey path (a separate flagged design), or a new thin envelope. **Recommend the thin envelope**, mirroring `_meta/sealed-passphrase`'s `SealedEnvelope{v,_noydb_sealed,pid,payload}`:
+- One store record per (collection, record, host pid): `_meta/sealed-cek/<collection>/<id>/<pid>` → `{ v:1, pid, alg, payload: base64(seal({ collection, id, cek, expiresAt })), collection, id, expiresAt }`. The sealed `payload` wraps a **bound struct** (not bare CEK bytes) — see the binding note below; the plaintext `collection`/`id`/`expiresAt` are routing/expiry metadata for the host.
+- The host reads its sealed-CEK records (it's authorized to that `_meta` path), unseals, decrypts the referenced record(s). No bundle write.
+- A new `vault.sealRecordToHost(collection, id, hostHint, { expiresAt })` grantor API + `vault.revokeSealedRecord(...)`.
+
+### Record-binding + CloudTrail / audit observability
+**Record-binding is done IN the sealed payload, not via KMS encryption context.** A true recipient-target sealer uses an **asymmetric** KMS key (the host's private key never leaves KMS), and per the AWS KMS docs **encryption context is NOT supported with asymmetric (or HMAC) KMS keys** — so the `EncryptionContext{collection,id}` AAD-binding idea does not apply here. Instead the grantor **seals a bound struct `{ collection, id, cek, expiresAt }`** (not bare CEK bytes); on unseal the host checks the embedded `collection`/`id` match the record it's about to decrypt and rejects a mismatch → **replay-proof at the host/app layer** (a sealed CEK can't be reused against a different record).
+
+**CloudTrail:** `at-aws-kms` produces a CloudTrail entry per asymmetric `kms:Decrypt` (key ARN, principal, time) — but at **key+principal granularity, not record-level** (no encryption context to carry `{collection,id}`). Record-level audit therefore relies on the **host logging the in-payload `{collection,id}`** it processed. In-process/`MemoryRecipientSealer` and non-KMS hosts get no cloud trail at all (documented boundary). *(A symmetric-KMS variant could use real `EncryptionContext` for KMS-layer record-binding + audit — but loses the per-recipient asymmetry, requires the grantor to hold Encrypt permission on the host's symmetric key, and isn't "recipient-target." Tradeoff noted as an open decision.)*
+
+## Hard problems — confronted honestly
+
+### A. The host-denial guarantee (forward-provable; one residual)
+Sealing only the raw CEK gives a **forward** guarantee: the host never receives any other record's CEK, and never the collection DEK, so it is cryptographically denied every other record. Two things must hold for this to be airtight:
+- **Never hand the host the collection DEK** — always unwrap client-side and seal raw CEK bytes. (If the host held the DEK it could unwrap any `_cek` AND query the DEK-keyed `_det` blind-equality index across all records — see CEK foundation §1. So: raw-CEK-only, no DEK.)
+- **`_det` residue:** even record-scoped, the host with one CEK can decrypt one body; it cannot use `_det` (that needs the DEK it doesn't have). ✓.
+
+### B. Revocation is the genuinely hard limit — be loud about it
+The CEK is **stable across record versions** (foundation decision). **Once a host unseals a CEK, it holds that key in memory/disk forever** — deleting the `_meta/sealed-cek` record does NOT revoke an already-unsealed CEK. This is *inherent* to handing a key to trusted compute (true of any KMS grant). Real revocation has only two mechanisms, neither free:
+1. **CEK rotation on revoke** — re-encrypt the record body under a fresh CEK (the host's old CEK no longer decrypts the new ciphertext). This is the *only* true revocation. It's a write (and interacts with history — old versions still under the old CEK). Recommend exposing `vault.rotateRecordCek(collection, id)` as the revocation primitive.
+2. **Time-bound sealed CEKs** — encode `expiresAt` in the sealed blob / KMS grant; the host enforces expiry. Bounds exposure without a rewrite, but trusts the host to honor it (acceptable for a trusted-compute host — that's the trust model).
+
+**The honest contract #306 can offer:** *forward* least-privilege (host cryptographically can't reach other records) + *time-bounded* access to the granted record + *rotation* as hard revocation. It cannot offer "un-grant a key the host already saw" without a re-encrypt — and the spec must say so plainly. This matches the `at-hosts.md` trust boundary ("an `at-*` host CAN decrypt the slice it unseals").
+
+### C. Delivery + freshness
+The thin `_meta/sealed-cek` envelope is revocable (store delete stops *future* unseals) and supports the expiry/rotation model in B. The host needs a way to discover its sealed-CEK records (poll the `_meta/sealed-cek/<...>/<pid>` prefix, or push). Keep v1 poll-based.
+
+## v1 scope
+| Item | In | Note |
+|---|---|---|
+| `at-aws-kms` (+ GCP/Azure) implement `RecipientSealer` via asymmetric KMS (`alg:'kms-encrypt'`) | ✓ (slice 1, prerequisite) | without it, only `MemoryRecipientSealer` works |
+| Grantor `vault.sealRecordToHost(collection,id,hostHint,{expiresAt})` — unwrap raw CEK client-side, seal to host | ✓ | reuses `sealForRecipient`; raw-CEK-only, never the DEK |
+| `_meta/sealed-cek/<collection>/<id>/<pid>` thin envelope + host-side unseal+decrypt path | ✓ | mirrors `_meta/sealed-passphrase` |
+| In-payload `{collection,id}` binding → host rejects replay against a different record; asymmetric KMS `Decrypt` is CloudTrail-logged (key+principal) | ✓ | encryption context unavailable on asymmetric keys; non-KMS hosts: no cloud trail |
+| `vault.revokeSealedRecord(...)` (delete sealed env) + `vault.rotateRecordCek(...)` (true revocation) | ✓ | rotation is the only hard revoke |
+| Time-bound `expiresAt` enforced by host | ✓ | bounds the already-unsealed-CEK window |
+| Query-scoped (seal all CEKs matching a predicate) | ✗ defer | v1 is single-record; query-scope = loop over matches later |
+| Compose with `MagicLinkGrantSpec.record?` (make the advisory field cryptographic) | ◑ | nice unification; can layer after v1 |
+
+## Acceptance (for the build)
+- A host with a sealed CEK for `sales/inv-1` decrypts `inv-1` and **fails** to decrypt `sales/inv-2` (no key) — the host-denial test.
+- The host never receives a collection DEK (assert the sealed payload is a 32-byte CEK, not a DEK).
+- The host rejects a sealed CEK whose embedded `{collection,id}` doesn't match the record it's decrypting (replay-proof); the asymmetric KMS `Decrypt` is CloudTrail-logged (key+principal+time).
+- `revokeSealedRecord` stops future unseals; `rotateRecordCek` makes a previously-unsealed CEK stop decrypting the (re-encrypted) record.
+- Expired sealed CEK is rejected by the host path.
+
+## Open decisions (for review)
+1. **Delivery vehicle** — thin `_meta/sealed-cek` envelope (recommended) vs extending extract-partition transferKey sealing. Thin envelope is lighter + independently revocable.
+2. **Revocation default** — document the "rotation is the only hard revoke" limit; make `expiresAt` **required** (force a bounded window) vs optional. Lean **required** for a least-privilege feature.
+3. **at-* RecipientSealer alg** — AWS KMS asymmetric `Encrypt` (`kms-encrypt`) for v1; GCP/Azure equivalents as fast-follows. Confirm KMS asymmetric key setup is acceptable for the pilot host.
+4. **Scope of slice 1** — ship the `at-aws-kms` RecipientSealer (the recipient-target spec's deferred §12 item) as its own PR first, since #306 is blocked on it.
+
+## Sizing
+- Slice 1 — `at-aws-kms` RecipientSealer (asymmetric KMS + `RecipientHint.alg:'kms-encrypt'`): **M** (prerequisite; partly specced in the recipient-target §12).
+- Slice 2 — grantor seal API + raw-CEK-unwrap + `_meta/sealed-cek` envelope + host unseal/decrypt path + in-payload `{collection,id}` binding: **M–L**.
+- Slice 3 — `revokeSealedRecord` + `rotateRecordCek` (true revocation) + expiry enforcement: **M** (rotation interacts with history).
+So #306 ≈ **M + M–L + M**, gated on slice 1 landing first.

--- a/features.yaml
+++ b/features.yaml
@@ -84,6 +84,26 @@ features:
       - 'Completeness gaps surfaced, never silently claimed: `forget()` reports `unmigratedRecords` (legacy body still under the collection DEK) and `blobResidueCollections` (blob attachments keyed off the separate `_blob` DEK, out of scope for record-CEK shred); idempotent (a second forget shreds nothing)'
     related: [encryption, history]
 
+  - id: record-scoped-cek-sealing
+    name: Record-scoped CEK sealing to an at-* host (vault.sealRecordToHost)
+    cluster: subsystem
+    spec: docs/superpowers/specs/2026-06-13-record-scoped-cek-sealing-design.md
+    subsystem_doc: docs/core/02-encryption.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'Binding-in-payload is the security boundary: `vault.sealRecordToHost(collection, id, hostSealer, { expiresAt })` seals a `SealedCekBinding {collection,id,cek,expiresAt}` for the host; the host re-verifies `{collection,id}` and `expiresAt` from INSIDE the sealed payload, so a tampered thin `_sealed_cek/<collection>/<id>/<pid>` delivery envelope cannot redirect a CEK to another record or extend a grant'
+      - 'expiresAt is REQUIRED and authoritative: the delivery envelope carries a clear-text `expiresAt` for a fast-path reject, but `openSealedRecord()` re-checks the `expiresAt` sealed in the binding (the copy that cannot be forged) → SealedRecordExpiredError; there is NO KMS encryption context, the binding carries all authenticated context'
+      - 'rotateRecordCek is the hard revocation: re-keys the live record under a fresh CEK and deletes every `_sealed_cek/<collection>/<id>/*` envelope; a host holding a PRE-rotation sealed CEK can still read PRE-rotation history versions (they keep their old `_cek`) but the POST-rotation live envelope fails the AES-GCM auth tag → TamperedError (that asymmetry IS the revocation). Both the per-record CEK cache and the decrypted-record cache are evicted synchronously so no read returns the stale old-CEK record'
+      - 'Host holds no vault DEK: `openSealedRecord(sealedEnv, recordEnv, recipientSealer, expectedCollection, expectedId)` reconstructs exactly the one bound record from the sealed CEK + the encrypted body + the host unsealer alone — no collection/tier DEK, no keyring'
+      - 'Host denial — A cannot decrypt B: a CEK sealed for record A presented against record B''s envelope is rejected with SealedRecordMismatchError before any decrypt; only a `perRecordKeys` record has a sealable `_cek` (legacy / non-perRecordKeys → RecordCekNotFoundError, its body stays under the never-exposed collection DEK)'
+    related: [encryption, forget-cascade]
+
   - id: stores-contract
     name: 6-method NoydbStore contract
     cluster: core

--- a/features.yaml
+++ b/features.yaml
@@ -2356,8 +2356,11 @@ sealers:
     status: stable
     subsystem_doc: docs/packages/at-hosts.md
     showcases: []
+    capabilities:
+      recipientSealer: true
     invariants:
       - 'Seals and unseals via AWS KMS Encrypt/Decrypt API; key material never leaves KMS; IAM policy is the sole access gate'
+      - 'awsKmsRecipientSealer (RecipientSealer): an asymmetric RSA KMS key (ENCRYPT_DECRYPT, RSA_2048/3072/4096) acts as a recipient target — publishRecipientHint returns the KMS public key as PEM (via GetPublicKey DER SPKI→PEM), grantors seal LOCALLY in the canonical RSA-OAEP-SHA256 TLV (no KMS call), and unseal runs KMS Decrypt with EncryptionAlgorithm RSAES_OAEP_SHA_256; private key never leaves KMS, no encryption context (unsupported on asymmetric keys). Wire-compatible with hub MemoryRecipientSealer via shared sealRsaOaepTlv/parseRsaOaepTlv/aesGcmOpen helpers'
     related: [auth-landscape, session-tiers]
 
   - id: at-gcp-kms

--- a/packages/at-aws-kms/__tests__/at-aws-kms.test.ts
+++ b/packages/at-aws-kms/__tests__/at-aws-kms.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { awsKmsSealingProvider } from '../src/index.js'
+import { awsKmsSealingProvider, awsKmsRecipientSealer } from '../src/index.js'
 
 function fakeKmsClient() {
   return {
@@ -98,5 +98,129 @@ describe.skipIf(!RUN_REAL)('awsKmsSealingProvider (real KMS)', () => {
     const p = awsKmsSealingProvider({ keyId: process.env.NOYDB_TEST_AWS_KMS_KEY_ID! })
     const phrase = new TextEncoder().encode('real-key-test')
     expect(await p.unseal(await p.seal(phrase))).toEqual(phrase)
+  })
+})
+
+// ─── awsKmsRecipientSealer (asymmetric RSA KMS key) ────────────────────────
+
+/**
+ * Fake KMS client backed by a real local RSA-2048 keypair. Answers
+ * `GetPublicKey` with the keypair's DER SPKI and `Decrypt` (RSAES_OAEP_SHA_256)
+ * by doing a local WebCrypto RSA-OAEP-SHA256 decrypt of the CiphertextBlob —
+ * exactly what real KMS does for an asymmetric ENCRYPT_DECRYPT key.
+ */
+async function fakeAsymmetricKmsClient(opts?: { keyUsage?: string; keySpec?: string }) {
+  const keypair = await crypto.subtle.generateKey(
+    { name: 'RSA-OAEP', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+    true, ['encrypt', 'decrypt'],
+  )
+  const spki = new Uint8Array(await crypto.subtle.exportKey('spki', keypair.publicKey))
+  const send = vi.fn(async (cmd: any) => {
+    const name = cmd.constructor.name
+    if (name === 'GetPublicKeyCommand') {
+      return {
+        KeyUsage: opts?.keyUsage ?? 'ENCRYPT_DECRYPT',
+        KeySpec: opts?.keySpec ?? 'RSA_2048',
+        PublicKey: spki,
+      }
+    }
+    if (name === 'DecryptCommand') {
+      expect(cmd.input.EncryptionAlgorithm).toBe('RSAES_OAEP_SHA_256')
+      const wrapped: Uint8Array = cmd.input.CiphertextBlob
+      const cek = new Uint8Array(await crypto.subtle.decrypt({ name: 'RSA-OAEP' }, keypair.privateKey, wrapped as BufferSource))
+      return { Plaintext: cek }
+    }
+    throw new Error('unexpected command ' + name)
+  })
+  return { client: { send }, send, keypair, spki }
+}
+
+describe('awsKmsRecipientSealer', () => {
+  it('round-trips: publishRecipientHint → sealForRecipient → unseal (seal makes NO KMS call)', async () => {
+    const { client, send } = await fakeAsymmetricKmsClient()
+    const sealer = awsKmsRecipientSealer({ keyId: 'arn:aws:kms:us-east-1:1:key/rsa', client: client as any })
+    expect(sealer.id).toBe('aws-kms-recipient:arn:aws:kms:us-east-1:1:key/rsa')
+
+    const hint = await sealer.publishRecipientHint()
+    expect(hint.v).toBe(1)
+    expect(hint.alg).toBe('rsa-oaep-sha256')
+    expect(hint.pid).toBe(sealer.id)
+    expect(hint.material['publicKeyPem']).toMatch(/^-----BEGIN PUBLIC KEY-----/)
+
+    const callsAfterPublish = send.mock.calls.length // 1 (GetPublicKey)
+    const plaintext = new TextEncoder().encode('seal-me-to-kms')
+    const sealed = await sealer.sealForRecipient(plaintext, hint)
+    // No KMS call on the seal path.
+    expect(send.mock.calls.length).toBe(callsAfterPublish)
+
+    const opened = await sealer.unseal(sealed)
+    expect(opened).toEqual(plaintext)
+    // unseal issued exactly one DecryptCommand.
+    expect(send.mock.calls.some(([c]: any[]) => c.constructor.name === 'DecryptCommand')).toBe(true)
+  })
+
+  it('cross-sealer: MemoryRecipientSealer-sealed blob (to the KMS hint key) unseals via the KMS path', async () => {
+    const { MemoryRecipientSealer } = await import('@noy-db/hub')
+    const { client } = await fakeAsymmetricKmsClient()
+    const sealer = awsKmsRecipientSealer({ keyId: 'k-rsa', client: client as any })
+    const hint = await sealer.publishRecipientHint()
+
+    const memSender = new MemoryRecipientSealer({ id: 'mem-sender' })
+    const plaintext = new TextEncoder().encode('wire-format-identity')
+    const sealed = await memSender.sealForRecipient(plaintext, hint)
+
+    expect(await sealer.unseal(sealed)).toEqual(plaintext)
+  })
+
+  it('cross-sealer: at-aws-kms-sealed blob (to a Memory recipient key) unseals via MemoryRecipientSealer', async () => {
+    const { MemoryRecipientSealer } = await import('@noy-db/hub')
+    const { client } = await fakeAsymmetricKmsClient()
+    const sealer = awsKmsRecipientSealer({ keyId: 'k-rsa', client: client as any })
+
+    const memRecipient = new MemoryRecipientSealer({ id: 'mem-recipient' })
+    const memHint = await memRecipient.publishRecipientHint()
+    const plaintext = new TextEncoder().encode('reverse-interop')
+    const sealed = await sealer.sealForRecipient(plaintext, memHint)
+
+    expect(await memRecipient.unseal(sealed)).toEqual(plaintext)
+  })
+
+  it('sealForRecipient throws on a wrong hint.alg', async () => {
+    const { client } = await fakeAsymmetricKmsClient()
+    const sealer = awsKmsRecipientSealer({ keyId: 'k', client: client as any })
+    const hint = await sealer.publishRecipientHint()
+    await expect(sealer.sealForRecipient(new Uint8Array([1]), { ...hint, alg: 'aes-gcm' as any }))
+      .rejects.toThrow(/unsupported hint.alg/)
+  })
+
+  it('sealForRecipient throws on a wrong hint.v', async () => {
+    const { client } = await fakeAsymmetricKmsClient()
+    const sealer = awsKmsRecipientSealer({ keyId: 'k', client: client as any })
+    const hint = await sealer.publishRecipientHint()
+    await expect(sealer.sealForRecipient(new Uint8Array([1]), { ...hint, v: 2 as any }))
+      .rejects.toThrow(/unsupported hint.v/)
+  })
+
+  it('publishRecipientHint throws when the key is not ENCRYPT_DECRYPT', async () => {
+    const { client } = await fakeAsymmetricKmsClient({ keyUsage: 'SIGN_VERIFY' })
+    const sealer = awsKmsRecipientSealer({ keyId: 'k-sign', client: client as any })
+    await expect(sealer.publishRecipientHint()).rejects.toThrow(/ENCRYPT_DECRYPT/)
+  })
+
+  it('publishRecipientHint throws when the key is not an RSA key spec', async () => {
+    const { client } = await fakeAsymmetricKmsClient({ keySpec: 'ECC_NIST_P256' })
+    const sealer = awsKmsRecipientSealer({ keyId: 'k-ecc', client: client as any })
+    await expect(sealer.publishRecipientHint()).rejects.toThrow(/RSA key/)
+  })
+})
+
+const RUN_REAL_RSA = !!process.env.NOYDB_TEST_KMS_RSA_KEY_ID
+describe.skipIf(!RUN_REAL_RSA)('awsKmsRecipientSealer (real KMS asymmetric RSA key)', () => {
+  it('real GetPublicKey + local seal + real Decrypt round-trip', async () => {
+    const sealer = awsKmsRecipientSealer({ keyId: process.env.NOYDB_TEST_KMS_RSA_KEY_ID! })
+    const hint = await sealer.publishRecipientHint()
+    const plaintext = new TextEncoder().encode('real-rsa-recipient-test')
+    const sealed = await sealer.sealForRecipient(plaintext, hint)
+    expect(await sealer.unseal(sealed)).toEqual(plaintext)
   })
 })

--- a/packages/at-aws-kms/src/index.ts
+++ b/packages/at-aws-kms/src/index.ts
@@ -47,13 +47,16 @@
  * @packageDocumentation
  */
 
-import type { SealingKeyProvider } from '@noy-db/hub'
+import type { SealingKeyProvider, RecipientSealer, RecipientHint } from '@noy-db/hub'
+import { sealRsaOaepTlv, parseRsaOaepTlv, aesGcmOpen } from '@noy-db/hub'
 import {
   KMSClient,
   EncryptCommand,
   DecryptCommand,
+  GetPublicKeyCommand,
   type EncryptCommandOutput,
   type DecryptCommandOutput,
+  type GetPublicKeyCommandOutput,
 } from '@aws-sdk/client-kms'
 
 /** Options for {@link awsKmsSealingProvider}. */
@@ -96,6 +99,120 @@ export function awsKmsSealingProvider(opts: AwsKmsSealingProviderOptions): Seali
       const pt = out.Plaintext
       if (!pt) throw new Error('@noy-db/at-aws-kms: KMS Decrypt returned no Plaintext')
       return pt instanceof Uint8Array ? pt : new Uint8Array(pt)
+    },
+  }
+}
+
+/** Options for {@link awsKmsRecipientSealer}. */
+export interface AwsKmsRecipientSealerOptions {
+  /**
+   * KMS key id or ARN of an **asymmetric RSA** key with `KeyUsage:
+   * ENCRYPT_DECRYPT` and `KeySpec` one of `RSA_2048` / `RSA_3072` /
+   * `RSA_4096`. The private key never leaves KMS — unseal runs `Decrypt`.
+   */
+  readonly keyId: string
+  /** Optional region passed to the default `KMSClient` when no `client` is given. */
+  readonly region?: string
+  /** Optional pre-built client (DI for tests). Default `new KMSClient({ region? })` (ambient creds). */
+  readonly client?: Pick<KMSClient, 'send'>
+}
+
+/** KMS asymmetric key specs this recipient sealer accepts (RSA-OAEP-SHA256 wrap). */
+const SUPPORTED_RSA_KEY_SPECS = new Set(['RSA_2048', 'RSA_3072', 'RSA_4096'])
+
+/** DER SPKI bytes (from KMS `GetPublicKey`) → PEM SubjectPublicKeyInfo. */
+function derSpkiToPem(der: Uint8Array): string {
+  let binary = ''
+  for (let i = 0; i < der.length; i++) binary += String.fromCharCode(der[i]!)
+  const b64 = btoa(binary)
+  return '-----BEGIN PUBLIC KEY-----\n'
+    + (b64.match(/.{1,64}/g) ?? []).join('\n')
+    + '\n-----END PUBLIC KEY-----\n'
+}
+
+/**
+ * A {@link RecipientSealer} (plus `unseal`) backed by an **asymmetric RSA**
+ * AWS KMS key. Lets an `at-aws-kms` host act as a recipient target: a grantor
+ * obtains the host's published {@link RecipientHint} (the KMS public key as
+ * PEM) and seals bytes to it *locally* — no KMS call on the seal path. The
+ * host unseals via KMS `Decrypt` with `EncryptionAlgorithm:
+ * RSAES_OAEP_SHA_256`; the private key never leaves KMS.
+ *
+ * Wire format is the canonical recipient-target TLV
+ * ({@link sealRsaOaepTlv}/{@link parseRsaOaepTlv}) shared with hub's
+ * `MemoryRecipientSealer`, so a blob sealed by either side unseals on the
+ * other. WebCrypto RSA-OAEP/SHA-256 and KMS `RSAES_OAEP_SHA_256` are
+ * wire-compatible (RSAES-OAEP, SHA-256, MGF1-SHA256, empty label). KMS
+ * asymmetric keys do not support an encryption context, so none is used.
+ *
+ * Separate from {@link awsKmsSealingProvider} (symmetric self-seal for the
+ * managed passphrase) — this factory targets an asymmetric key.
+ *
+ * @throws Error from `publishRecipientHint` when the key is not an RSA
+ * `ENCRYPT_DECRYPT` key, or `GetPublicKey` returns no public key.
+ * @throws Error from `sealForRecipient` on an unsupported `hint.v`/`hint.alg`.
+ * Any KMS API error (AccessDenied, etc.) propagates as-is.
+ */
+export function awsKmsRecipientSealer(
+  opts: AwsKmsRecipientSealerOptions,
+): RecipientSealer & { unseal(sealed: Uint8Array): Promise<Uint8Array> } {
+  const client = opts.client ?? new KMSClient(opts.region ? { region: opts.region } : {})
+  const id = `aws-kms-recipient:${opts.keyId}`
+  return {
+    id,
+
+    async publishRecipientHint(): Promise<RecipientHint> {
+      const out: GetPublicKeyCommandOutput = await client.send(
+        new GetPublicKeyCommand({ KeyId: opts.keyId }),
+      )
+      if (out.KeyUsage !== 'ENCRYPT_DECRYPT') {
+        throw new Error(
+          `@noy-db/at-aws-kms: awsKmsRecipientSealer requires an ENCRYPT_DECRYPT key, got KeyUsage='${String(out.KeyUsage)}' for ${opts.keyId}`,
+        )
+      }
+      if (!out.KeySpec || !SUPPORTED_RSA_KEY_SPECS.has(out.KeySpec)) {
+        throw new Error(
+          `@noy-db/at-aws-kms: awsKmsRecipientSealer requires an RSA key (RSA_2048/3072/4096), got KeySpec='${String(out.KeySpec)}' for ${opts.keyId}`,
+        )
+      }
+      const der = out.PublicKey
+      if (!der) throw new Error('@noy-db/at-aws-kms: KMS GetPublicKey returned no PublicKey')
+      const derBytes = der instanceof Uint8Array ? der : new Uint8Array(der)
+      const publicKeyPem = derSpkiToPem(derBytes)
+      return { v: 1, pid: id, alg: 'rsa-oaep-sha256', material: { publicKeyPem } }
+    },
+
+    async sealForRecipient(plaintext: Uint8Array, hint: RecipientHint): Promise<Uint8Array> {
+      if (hint.v !== 1) {
+        throw new Error(`@noy-db/at-aws-kms: awsKmsRecipientSealer.sealForRecipient: unsupported hint.v ${String(hint.v)} (expected 1)`)
+      }
+      if (hint.alg !== 'rsa-oaep-sha256') {
+        throw new Error(`@noy-db/at-aws-kms: awsKmsRecipientSealer.sealForRecipient: unsupported hint.alg '${String(hint.alg)}' (expected 'rsa-oaep-sha256')`)
+      }
+      const pem = hint.material['publicKeyPem']
+      if (typeof pem !== 'string') {
+        throw new Error('@noy-db/at-aws-kms: awsKmsRecipientSealer.sealForRecipient: hint.material.publicKeyPem missing or not a string')
+      }
+      // Grantor seals LOCALLY — no KMS call.
+      return sealRsaOaepTlv(plaintext, pem)
+    },
+
+    async unseal(sealed: Uint8Array): Promise<Uint8Array> {
+      const { wrapped, iv, ct } = parseRsaOaepTlv(sealed)
+      // RSA-unwrap the CEK via KMS — the private key never leaves KMS.
+      const out: DecryptCommandOutput = await client.send(
+        new DecryptCommand({
+          KeyId: opts.keyId,
+          CiphertextBlob: wrapped,
+          EncryptionAlgorithm: 'RSAES_OAEP_SHA_256',
+        }),
+      )
+      const cek = out.Plaintext
+      if (!cek) throw new Error('@noy-db/at-aws-kms: KMS Decrypt returned no Plaintext (CEK)')
+      const cekBytes = cek instanceof Uint8Array ? cek : new Uint8Array(cek)
+      const pt = await aesGcmOpen(cekBytes, iv, ct)
+      cekBytes.fill(0)
+      return pt
     },
   }
 }

--- a/packages/hub/__tests__/record-scoped-cek-sealing.test.ts
+++ b/packages/hub/__tests__/record-scoped-cek-sealing.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Record-scoped CEK sealing to an at-* host (#306 slices 2-3).
+ *
+ * Spec: docs/superpowers/specs/2026-06-13-record-scoped-cek-sealing-design.md
+ *
+ * Grantor side (`vault.sealRecordToHost` / `revokeSealedRecord` /
+ * `rotateRecordCek`) + host side (`openSealedRecord`). The host is a
+ * `MemoryRecipientSealer` — real RSA-OAEP + AES-GCM, in-process, no AWS.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { ConflictError, TamperedError } from '../src/errors.js'
+import {
+  SealedRecordExpiredError,
+  SealedRecordMismatchError,
+  RecordCekNotFoundError,
+} from '../src/errors.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { MemoryRecipientSealer } from '../src/team/managed-passphrase.js'
+import { openSealedRecord } from '../src/sealed-record/index.js'
+import type { SealedCekDeliveryEnvelope } from '../src/sealed-record/types.js'
+
+/** In-memory store exposing raw stored envelopes for assertions. */
+function memory(): NoydbStore & { raw(c: string, col: string, id: string): EncryptedEnvelope | undefined } {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    raw(c, col, id) { return store.get(c)?.get(col)?.get(id) },
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) {
+        for (const [name, coll] of existing) {
+          if (name.startsWith('_')) comp.set(name, coll)
+        }
+      }
+      store.set(c, comp)
+    },
+  }
+}
+
+interface Doc { id: string; secret: string }
+
+const SECRET = 'test-passphrase-1234'
+const HOUR = 60 * 60 * 1000
+
+function readDelivery(
+  store: ReturnType<typeof memory>,
+  vault: string,
+  collection: string,
+  id: string,
+  pid: string,
+): SealedCekDeliveryEnvelope {
+  const env = store.raw(vault, '_sealed_cek', `${collection}/${id}/${pid}`)!
+  return JSON.parse(env._data) as SealedCekDeliveryEnvelope
+}
+
+async function setup() {
+  const store = memory()
+  const db = await createNoydb({ store, user: 'alice', secret: SECRET })
+  const vault = await db.openVault('v')
+  const docs = vault.collection<Doc>('docs', { perRecordKeys: true })
+  return { store, db, vault, docs }
+}
+
+describe('record-scoped CEK sealing — happy path', () => {
+  it('seal → openSealedRecord round-trips the record body', async () => {
+    const { store, vault, docs } = await setup()
+    await docs.put('d-1', { id: 'd-1', secret: 'the eagle lands at dawn' })
+
+    const host = new MemoryRecipientSealer({ id: 'kms:host-A' })
+    const { pid, envelopeKey } = await vault.sealRecordToHost('docs', 'd-1', host, {
+      expiresAt: new Date(Date.now() + HOUR).toISOString(),
+    })
+    expect(pid).toBe('kms:host-A')
+    expect(envelopeKey).toBe('docs/d-1/kms:host-A')
+
+    const delivery = readDelivery(store, 'v', 'docs', 'd-1', pid)
+    expect(delivery._noydb_sealed_cek).toBe(1)
+    expect(delivery.v).toBe(1)
+
+    const recordEnv = store.raw('v', 'docs', 'd-1')!
+    const json = await openSealedRecord(delivery, recordEnv, host, 'docs', 'd-1')
+    expect(JSON.parse(json)).toMatchObject({ id: 'd-1', secret: 'the eagle lands at dawn' })
+  })
+})
+
+describe('record-scoped CEK sealing — host denial', () => {
+  it('a CEK sealed for record A applied to record B → SealedRecordMismatchError', async () => {
+    const { store, vault, docs } = await setup()
+    await docs.put('A', { id: 'A', secret: 'alpha' })
+    await docs.put('B', { id: 'B', secret: 'bravo' })
+
+    const host = new MemoryRecipientSealer({ id: 'kms:host-A' })
+    const { pid } = await vault.sealRecordToHost('docs', 'A', host, {
+      expiresAt: new Date(Date.now() + HOUR).toISOString(),
+    })
+
+    const deliveryForA = readDelivery(store, 'v', 'docs', 'A', pid)
+    const envelopeOfB = store.raw('v', 'docs', 'B')!
+
+    // Present A's sealed CEK against B's envelope, claiming it is B.
+    await expect(
+      openSealedRecord(deliveryForA, envelopeOfB, host, 'docs', 'B'),
+    ).rejects.toBeInstanceOf(SealedRecordMismatchError)
+  })
+})
+
+describe('record-scoped CEK sealing — expiry', () => {
+  it('past expiry → SealedRecordExpiredError on the fast-path (envelope)', async () => {
+    const { store, vault, docs } = await setup()
+    await docs.put('d-1', { id: 'd-1', secret: 's' })
+    const host = new MemoryRecipientSealer({ id: 'kms:host-A' })
+    const { pid } = await vault.sealRecordToHost('docs', 'd-1', host, {
+      expiresAt: new Date(Date.now() - HOUR).toISOString(), // already past
+    })
+    const delivery = readDelivery(store, 'v', 'docs', 'd-1', pid)
+    const recordEnv = store.raw('v', 'docs', 'd-1')!
+    await expect(
+      openSealedRecord(delivery, recordEnv, host, 'docs', 'd-1'),
+    ).rejects.toBeInstanceOf(SealedRecordExpiredError)
+  })
+
+  it('past expiry → SealedRecordExpiredError on the AUTHORITATIVE binding even if the envelope hint is forged-future', async () => {
+    const { store, vault, docs } = await setup()
+    await docs.put('d-1', { id: 'd-1', secret: 's' })
+    const host = new MemoryRecipientSealer({ id: 'kms:host-A' })
+    const { pid } = await vault.sealRecordToHost('docs', 'd-1', host, {
+      expiresAt: new Date(Date.now() - HOUR).toISOString(), // binding is past
+    })
+    const delivery = readDelivery(store, 'v', 'docs', 'd-1', pid)
+    // Forge the clear-text envelope expiry to a future time — the fast-path
+    // would pass, but the authoritative copy inside the sealed binding is past.
+    const forged: SealedCekDeliveryEnvelope = {
+      ...delivery,
+      expiresAt: new Date(Date.now() + HOUR).toISOString(),
+    }
+    const recordEnv = store.raw('v', 'docs', 'd-1')!
+    await expect(
+      openSealedRecord(forged, recordEnv, host, 'docs', 'd-1'),
+    ).rejects.toBeInstanceOf(SealedRecordExpiredError)
+  })
+})
+
+describe('record-scoped CEK sealing — revoke', () => {
+  it('revokeSealedRecord deletes the delivery envelope', async () => {
+    const { store, vault, docs } = await setup()
+    await docs.put('d-1', { id: 'd-1', secret: 's' })
+    const host = new MemoryRecipientSealer({ id: 'kms:host-A' })
+    const { pid } = await vault.sealRecordToHost('docs', 'd-1', host, {
+      expiresAt: new Date(Date.now() + HOUR).toISOString(),
+    })
+    expect(store.raw('v', 'docs', 'd-1')).toBeDefined()
+    expect(store.raw('v', '_sealed_cek', `docs/d-1/${pid}`)).toBeDefined()
+
+    await vault.revokeSealedRecord('docs', 'd-1', pid)
+    expect(store.raw('v', '_sealed_cek', `docs/d-1/${pid}`)).toBeUndefined()
+  })
+})
+
+describe('record-scoped CEK sealing — rotateRecordCek (hard revocation)', () => {
+  it('deletes stale sealed envelopes, re-keys the live record, and old grants lose the live record', async () => {
+    const { store, vault, docs } = await setup()
+    await docs.put('d-1', { id: 'd-1', secret: 'v1 content' })
+
+    const host = new MemoryRecipientSealer({ id: 'kms:host-A' })
+    const { pid } = await vault.sealRecordToHost('docs', 'd-1', host, {
+      expiresAt: new Date(Date.now() + HOUR).toISOString(),
+    })
+
+    // Capture the PRE-rotation sealed CEK + PRE-rotation record envelope.
+    const preDelivery = readDelivery(store, 'v', 'docs', 'd-1', pid)
+    const preRecordEnv = store.raw('v', 'docs', 'd-1')!
+
+    // The pre-rotation sealed CEK opens the pre-rotation envelope (sanity).
+    const preJson = await openSealedRecord(preDelivery, preRecordEnv, host, 'docs', 'd-1')
+    expect(JSON.parse(preJson)).toMatchObject({ secret: 'v1 content' })
+
+    await vault.rotateRecordCek('docs', 'd-1')
+
+    // Stale sealed envelope deleted.
+    expect(store.raw('v', '_sealed_cek', `docs/d-1/${pid}`)).toBeUndefined()
+
+    // The live envelope was re-keyed (new _cek, bumped _v).
+    const postRecordEnv = store.raw('v', 'docs', 'd-1')!
+    expect(postRecordEnv._cek).toBeDefined()
+    expect(postRecordEnv._cek).not.toBe(preRecordEnv._cek)
+    expect(postRecordEnv._v).toBe(preRecordEnv._v + 1)
+
+    // The pre-rotation sealed CEK STILL opens the pre-rotation envelope
+    // (history versions keep their old _cek).
+    const stillPre = await openSealedRecord(preDelivery, preRecordEnv, host, 'docs', 'd-1')
+    expect(JSON.parse(stillPre)).toMatchObject({ secret: 'v1 content' })
+
+    // …but applied to the POST-rotation live envelope → TamperedError
+    // (wrong-key AES-GCM auth failure, NOT a mismatch — the binding still
+    // matches {collection,id}).
+    await expect(
+      openSealedRecord(preDelivery, postRecordEnv, host, 'docs', 'd-1'),
+    ).rejects.toBeInstanceOf(TamperedError)
+
+    // The vault itself still reads the live record (caches evicted).
+    expect(await docs.get('d-1')).toMatchObject({ id: 'd-1', secret: 'v1 content' })
+  })
+
+  it('after rotate, collection.get(id) decrypts via the fresh CEK (cekCache evicted)', async () => {
+    const { vault, docs } = await setup()
+    await docs.put('d-1', { id: 'd-1', secret: 'before' })
+    // Warm the cekCache with a read.
+    expect(await docs.get('d-1')).toMatchObject({ secret: 'before' })
+
+    await vault.rotateRecordCek('docs', 'd-1')
+
+    // If the stale CEK were still cached, this decrypt would throw TamperedError.
+    expect(await docs.get('d-1')).toMatchObject({ id: 'd-1', secret: 'before' })
+
+    // A subsequent normal update still works (CEK is stable post-rotation).
+    await docs.put('d-1', { id: 'd-1', secret: 'after' })
+    expect(await docs.get('d-1')).toMatchObject({ secret: 'after' })
+  })
+})
+
+describe('record-scoped CEK sealing — multiple pids', () => {
+  it('revoke one pid leaves the other; rotate deletes all', async () => {
+    const { store, vault, docs } = await setup()
+    await docs.put('d-1', { id: 'd-1', secret: 's' })
+
+    const hostA = new MemoryRecipientSealer({ id: 'kms:host-A' })
+    const hostB = new MemoryRecipientSealer({ id: 'kms:host-B' })
+    await vault.sealRecordToHost('docs', 'd-1', hostA, { expiresAt: new Date(Date.now() + HOUR).toISOString() })
+    await vault.sealRecordToHost('docs', 'd-1', hostB, { expiresAt: new Date(Date.now() + HOUR).toISOString() })
+
+    expect(store.raw('v', '_sealed_cek', 'docs/d-1/kms:host-A')).toBeDefined()
+    expect(store.raw('v', '_sealed_cek', 'docs/d-1/kms:host-B')).toBeDefined()
+
+    // Revoke A only.
+    await vault.revokeSealedRecord('docs', 'd-1', 'kms:host-A')
+    expect(store.raw('v', '_sealed_cek', 'docs/d-1/kms:host-A')).toBeUndefined()
+    expect(store.raw('v', '_sealed_cek', 'docs/d-1/kms:host-B')).toBeDefined()
+
+    // Rotate deletes all remaining.
+    await vault.rotateRecordCek('docs', 'd-1')
+    expect(store.raw('v', '_sealed_cek', 'docs/d-1/kms:host-B')).toBeUndefined()
+  })
+})
+
+describe('record-scoped CEK sealing — cross-process reconstruction', () => {
+  it('a host function given only {sealedEnv, recordEnv, sealer} reconstructs the record with NO vault DEK', async () => {
+    const { store, vault, docs } = await setup()
+    await docs.put('d-1', { id: 'd-1', secret: 'cross-process payload' })
+
+    const host = new MemoryRecipientSealer({ id: 'kms:remote' })
+    const { pid } = await vault.sealRecordToHost('docs', 'd-1', host, {
+      expiresAt: new Date(Date.now() + HOUR).toISOString(),
+    })
+
+    // Marshal ONLY the two envelopes across the "process boundary" — no DEK,
+    // no keyring, no vault handle. The host keeps its own sealer (its KMS key).
+    const sealedEnv = readDelivery(store, 'v', 'docs', 'd-1', pid)
+    const recordEnv = { _iv: store.raw('v', 'docs', 'd-1')!._iv, _data: store.raw('v', 'docs', 'd-1')!._data }
+
+    async function hostFunction(
+      env: SealedCekDeliveryEnvelope,
+      rec: { _iv: string; _data: string },
+      sealer: MemoryRecipientSealer,
+    ): Promise<string> {
+      return openSealedRecord(env, rec, sealer, 'docs', 'd-1')
+    }
+
+    const json = await hostFunction(sealedEnv, recordEnv, host)
+    expect(JSON.parse(json)).toMatchObject({ secret: 'cross-process payload' })
+  })
+})
+
+describe('record-scoped CEK sealing — RecordCekNotFoundError', () => {
+  it('throws for a missing record', async () => {
+    const { vault } = await setup()
+    const host = new MemoryRecipientSealer({ id: 'kms:host-A' })
+    await expect(
+      vault.sealRecordToHost('docs', 'nope', host, { expiresAt: new Date(Date.now() + HOUR).toISOString() }),
+    ).rejects.toBeInstanceOf(RecordCekNotFoundError)
+    await expect(vault.rotateRecordCek('docs', 'nope')).rejects.toBeInstanceOf(RecordCekNotFoundError)
+  })
+
+  it('throws for a non-perRecordKeys (legacy) collection — its body has no sealable _cek', async () => {
+    const { vault } = await setup()
+    const legacy = vault.collection<Doc>('legacy')
+    await legacy.put('l-1', { id: 'l-1', secret: 'plain' })
+
+    const host = new MemoryRecipientSealer({ id: 'kms:host-A' })
+    await expect(
+      vault.sealRecordToHost('legacy', 'l-1', host, { expiresAt: new Date(Date.now() + HOUR).toISOString() }),
+    ).rejects.toBeInstanceOf(RecordCekNotFoundError)
+  })
+})

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -86,6 +86,16 @@
         "default": "./dist/forget/index.cjs"
       }
     },
+    "./sealed-record": {
+      "import": {
+        "types": "./dist/sealed-record/index.d.ts",
+        "default": "./dist/sealed-record/index.js"
+      },
+      "require": {
+        "types": "./dist/sealed-record/index.d.cts",
+        "default": "./dist/sealed-record/index.cjs"
+      }
+    },
     "./query": {
       "import": {
         "types": "./dist/query/index.d.ts",

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -2968,6 +2968,19 @@ export class Collection<T> {
    * the cache entry (record still present) or deletes it (record was
    * gone before the tx and the revert deleted it again).
    */
+  /**
+   * @internal — evict ONLY the per-record CEK cache entry for `id`. Used by
+   * `vault.rotateRecordCek()`: after a hard CEK rotation the cached unwrapped
+   * CEK is stale (it would decrypt the pre-rotation body and fail GCM auth on
+   * the post-rotation body). Eviction must be synchronous with the live-envelope
+   * rewrite so no concurrent read observes the old CEK. Paired with
+   * {@link _invalidateCacheEntry} (which refreshes the decrypted-record cache).
+   * No-op when the collection is not `perRecordKeys`.
+   */
+  _invalidateCekCacheEntry(id: string): void {
+    this.cekCache?.remove(id)
+  }
+
   async _invalidateCacheEntry(id: string): Promise<void> {
     if (this.lazy && this.lru) {
       this.lru.remove(id)

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -60,6 +60,10 @@
  *            └─ ComputedFieldError     — computed function threw during a write
  *       └─ Erasure errors
  *            └─ ForgetStrategyNotConfiguredError — vault.forget() with no withForgetCascade
+ *       └─ Sealed-record errors (record-scoped CEK sealing, #306)
+ *            ├─ SealedRecordExpiredError  — sealed CEK binding past expiresAt
+ *            ├─ SealedRecordMismatchError — CEK sealed for record A used on record B
+ *            └─ RecordCekNotFoundError    — record missing or no per-record `_cek`
  * ```
  *
  * ## Catching all NOYDB errors
@@ -2198,5 +2202,81 @@ export class ForgetStrategyNotConfiguredError extends NoydbError {
   ) {
     super('FORGET_NOT_CONFIGURED', message)
     this.name = 'ForgetStrategyNotConfiguredError'
+  }
+}
+
+// ─── Sealed-record (record-scoped CEK sealing, #306) Errors ─────────────
+
+/**
+ * Thrown by `openSealedRecord()` when the sealed CEK's binding has passed its
+ * `expiresAt`. Surfaced on two checks: a cheap fast-path check on the delivery
+ * envelope's clear-text `expiresAt`, and the AUTHORITATIVE check on the
+ * `expiresAt` inside the sealed binding (the latter cannot be forged by editing
+ * the delivery envelope). Distinct from {@link KeyringExpiredError} (bundle-slot
+ * expiry) so a host can tell "this single-record grant lapsed" from a keyring-
+ * level expiry.
+ */
+export class SealedRecordExpiredError extends NoydbError {
+  readonly expiresAt: string
+  constructor(expiresAt: string) {
+    super(
+      'SEALED_RECORD_EXPIRED',
+      `Sealed record CEK expired at ${expiresAt}. The grantor must re-seal the ` +
+        `record with a later expiresAt.`,
+    )
+    this.name = 'SealedRecordExpiredError'
+    this.expiresAt = expiresAt
+  }
+}
+
+/**
+ * Thrown by `openSealedRecord()` when the sealed binding's
+ * `{collection, id}` does not match the record envelope the host is trying to
+ * decrypt. This is the host-denial boundary: a CEK sealed for record A cannot
+ * be replayed against record B's envelope. (A CEK sealed for a PRE-rotation
+ * version of a record, applied to the POST-rotation live envelope, is a
+ * different failure — the binding still matches `{collection, id}` so it gets
+ * past this check, and the AES-GCM auth-tag failure surfaces as
+ * {@link TamperedError} instead.)
+ */
+export class SealedRecordMismatchError extends NoydbError {
+  readonly expected: { collection: string; id: string }
+  readonly actual: { collection: string; id: string }
+  constructor(
+    expected: { collection: string; id: string },
+    actual: { collection: string; id: string },
+  ) {
+    super(
+      'SEALED_RECORD_MISMATCH',
+      `Sealed CEK binding is for ${actual.collection}/${actual.id} but was ` +
+        `presented against ${expected.collection}/${expected.id}. A CEK sealed ` +
+        `for one record cannot decrypt another.`,
+    )
+    this.name = 'SealedRecordMismatchError'
+    this.expected = expected
+    this.actual = actual
+  }
+}
+
+/**
+ * Thrown by `vault.sealRecordToHost()` / `vault.rotateRecordCek()` when the
+ * target record has no live envelope, or its live envelope carries no `_cek`
+ * (a legacy / non-`perRecordKeys` collection has nothing record-scoped to
+ * seal — its body is keyed off the shared collection DEK, which sealing
+ * deliberately never exposes).
+ */
+export class RecordCekNotFoundError extends NoydbError {
+  readonly collection: string
+  readonly id: string
+  constructor(collection: string, id: string) {
+    super(
+      'RECORD_CEK_NOT_FOUND',
+      `No per-record CEK for ${collection}/${id}. The record is missing, or its ` +
+        `collection was not opened with { perRecordKeys: true } — only per-record-key ` +
+        `records carry a sealable CEK.`,
+    )
+    this.name = 'RecordCekNotFoundError'
+    this.collection = collection
+    this.id = id
   }
 }

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -324,6 +324,7 @@ export type { SchemaManifestRow, DeploymentEvent, CapturedBlueprint } from './fe
 export { STATE_VAULT_NAME } from './federation/constants.js'
 export { UnknownShardError, ShardProvisioningError, VaultTemplateNotFoundError, ReservedVaultNameError } from './errors.js'
 export { ForgetStrategyNotConfiguredError } from './errors.js'
+export { SealedRecordExpiredError, SealedRecordMismatchError, RecordCekNotFoundError } from './errors.js'
 
 // Bundle format — `.noydb` container
 export {

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -579,6 +579,9 @@ export type { ShamirRecoveryProvider } from './team/shamir-recovery-provider.js'
 export {
   MemorySealingKeyProvider,
   MemoryRecipientSealer,
+  sealRsaOaepTlv,
+  parseRsaOaepTlv,
+  aesGcmOpen,
   loadSealedPassphrase,
   saveSealedPassphrase,
   parseSealedEnvelope,

--- a/packages/hub/src/sealed-record/index.ts
+++ b/packages/hub/src/sealed-record/index.ts
@@ -1,0 +1,100 @@
+/**
+ * `@noy-db/hub/sealed-record` — host-side opener for record-scoped CEK
+ * sealing (#306 slices 2-3).
+ *
+ * The **grantor** side (sealing a record's CEK to a host, revoking, and hard
+ * rotation) lives on `Vault` (`vault.sealRecordToHost` /
+ * `vault.revokeSealedRecord` / `vault.rotateRecordCek`) because it needs the
+ * collection DEK. This subpath exposes the **recipient host** side:
+ * {@link openSealedRecord} reconstructs a single record's plaintext from
+ * (a) the sealed-CEK delivery envelope, (b) the record's encrypted envelope
+ * body, and (c) the host's own unsealer — and **nothing else**. The host never
+ * touches a vault DEK and can decrypt exactly the one bound record.
+ *
+ * @module
+ */
+
+import { decrypt, base64ToBuffer } from '../crypto.js'
+import {
+  SealedRecordExpiredError,
+  SealedRecordMismatchError,
+} from '../errors.js'
+import type {
+  SealedCekDeliveryEnvelope,
+  SealedCekBinding,
+} from './types.js'
+
+export type { SealedCekDeliveryEnvelope, SealedCekBinding } from './types.js'
+export { SealedRecordExpiredError, SealedRecordMismatchError } from '../errors.js'
+
+const subtle = globalThis.crypto.subtle
+
+/**
+ * Host-side: decrypt a single record whose CEK was sealed to this host by a
+ * vault grantor via `vault.sealRecordToHost()`.
+ *
+ * Verification order (security-critical — do NOT reorder past the unseal):
+ *  1. **Fast-path expiry** — reject on the delivery envelope's clear-text
+ *     `expiresAt` before doing any (potentially expensive) unseal work. This is
+ *     a hint only.
+ *  2. **Unseal** the `payload` with the host's `recipientSealer.unseal` →
+ *     parse the {@link SealedCekBinding}.
+ *  3. **Binding match** — the binding's `{collection, id}` MUST equal the
+ *     expected pair, else {@link SealedRecordMismatchError}. This is the
+ *     host-denial boundary (a CEK sealed for record A cannot open record B).
+ *  4. **Authoritative expiry** — re-check `binding.expiresAt` (the copy that
+ *     cannot be forged by editing the delivery envelope), else
+ *     {@link SealedRecordExpiredError}.
+ *  5. **Decrypt** the record body under the unsealed CEK. A CEK from a
+ *     PRE-rotation seal applied to a POST-rotation live envelope passes (1)-(4)
+ *     but fails the AES-GCM auth tag → `TamperedError` from `decrypt`.
+ *
+ * @param sealedCekEnvelope The `SealedCekDeliveryEnvelope` written by the grantor.
+ * @param recordEnvelope    The record's `{ _iv, _data }` (the encrypted body).
+ * @param recipientSealer   The host's unsealer (`{ unseal(bytes) }`) — e.g. a
+ *                          KMS-backed sealer or `MemoryRecipientSealer`.
+ * @param expectedCollection Collection the caller believes `recordEnvelope` is in.
+ * @param expectedId         Record id the caller believes `recordEnvelope` is.
+ * @returns The decrypted record body as a JSON string.
+ */
+export async function openSealedRecord(
+  sealedCekEnvelope: SealedCekDeliveryEnvelope,
+  recordEnvelope: { readonly _iv: string; readonly _data: string },
+  recipientSealer: { unseal(bytes: Uint8Array): Promise<Uint8Array> },
+  expectedCollection: string,
+  expectedId: string,
+): Promise<string> {
+  // (1) Fast-path expiry on the (unauthenticated) delivery envelope.
+  if (Date.parse(sealedCekEnvelope.expiresAt) <= Date.now()) {
+    throw new SealedRecordExpiredError(sealedCekEnvelope.expiresAt)
+  }
+
+  // (2) Unseal → parse binding.
+  const payloadBytes = base64ToBuffer(sealedCekEnvelope.payload)
+  const openedBytes = await recipientSealer.unseal(payloadBytes)
+  const binding = JSON.parse(new TextDecoder().decode(openedBytes)) as SealedCekBinding
+
+  // (3) Binding match — host-denial boundary.
+  if (binding.collection !== expectedCollection || binding.id !== expectedId) {
+    throw new SealedRecordMismatchError(
+      { collection: expectedCollection, id: expectedId },
+      { collection: binding.collection, id: binding.id },
+    )
+  }
+
+  // (4) Authoritative expiry — the copy that cannot be forged on the envelope.
+  if (Date.parse(binding.expiresAt) <= Date.now()) {
+    throw new SealedRecordExpiredError(binding.expiresAt)
+  }
+
+  // (5) Import the raw CEK + decrypt the body. Wrong-key (pre-rotation CEK vs
+  // post-rotation body) surfaces as TamperedError from decrypt's GCM tag check.
+  const cek = await subtle.importKey(
+    'raw',
+    base64ToBuffer(binding.cek) as BufferSource,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['decrypt'],
+  )
+  return decrypt(recordEnvelope._iv, recordEnvelope._data, cek)
+}

--- a/packages/hub/src/sealed-record/types.ts
+++ b/packages/hub/src/sealed-record/types.ts
@@ -1,0 +1,70 @@
+/**
+ * Wire + binding types for record-scoped CEK sealing (#306 slices 2-3).
+ *
+ * A vault owner who holds the collection DEK can **seal a single record's
+ * content-encryption key (CEK)** to an `at-*` host (e.g. a KMS-backed
+ * {@link RecipientSealer}) so that host — and only that host — can decrypt
+ * exactly that one record, with no access to the vault DEK and no ability to
+ * read any other record. This is the record-granular counterpart to the
+ * bundle-granular sealed-credential delivery (`SealedEnvelope`).
+ *
+ * Two shapes live here:
+ *
+ *  - {@link SealedCekDeliveryEnvelope} — the **thin delivery envelope** the
+ *    grantor writes to `_sealed_cek/<collection>/<id>/<pid>`. It carries only
+ *    routing metadata (`pid`, `expiresAt`) in the clear plus the opaque sealed
+ *    `payload`. The `expiresAt` here is a *fast-path* hint; the authoritative
+ *    expiry lives INSIDE the sealed payload (see below).
+ *
+ *  - {@link SealedCekBinding} — the plaintext struct that is sealed for the
+ *    host. It binds the CEK to its `{collection, id}` and an authoritative
+ *    `expiresAt`, so a host cannot take a CEK sealed for record A and apply it
+ *    to record B's envelope (mismatch is rejected), nor read past expiry. The
+ *    binding is the security boundary; the delivery envelope is just transport.
+ *
+ * @module
+ */
+
+/**
+ * Thin delivery envelope persisted at
+ * `_sealed_cek/<collection>/<id>/<pid>`. The grantor writes one per
+ * (record, recipient host) pair. `payload` is the base64 of the bytes returned
+ * by {@link RecipientSealer.sealForRecipient} over a UTF-8
+ * `JSON.stringify({@link SealedCekBinding})`.
+ *
+ * `expiresAt` is duplicated here for a cheap pre-unseal reject, but is NOT
+ * authoritative — the binding inside `payload` carries the expiry the host
+ * verifies after unsealing, so a tampered delivery envelope cannot extend a
+ * grant.
+ */
+export interface SealedCekDeliveryEnvelope {
+  /** Envelope schema version. */
+  readonly v: 1
+  /** Magic marker for forensics + format detection. */
+  readonly _noydb_sealed_cek: 1
+  /** Recipient host provider id; matches the sealer's `.id` / hint `pid`. */
+  readonly pid: string
+  /** base64 of the sealed {@link SealedCekBinding} bytes. */
+  readonly payload: string
+  /** Fast-path expiry hint (ISO 8601). Authoritative copy is inside `payload`. */
+  readonly expiresAt: string
+}
+
+/**
+ * The plaintext struct sealed for the recipient host. After the host unseals
+ * `SealedCekDeliveryEnvelope.payload` it parses this and MUST verify:
+ *  - `collection` + `id` match the record envelope it is decrypting, and
+ *  - `expiresAt` has not passed (authoritative expiry check).
+ *
+ * `cek` is the base64 of the raw 32-byte AES-256-GCM record CEK.
+ */
+export interface SealedCekBinding {
+  /** Collection the CEK belongs to. */
+  readonly collection: string
+  /** Record id the CEK belongs to. */
+  readonly id: string
+  /** base64 of the raw AES-256-GCM CEK bytes. */
+  readonly cek: string
+  /** Authoritative expiry (ISO 8601). */
+  readonly expiresAt: string
+}

--- a/packages/hub/src/team/managed-passphrase.ts
+++ b/packages/hub/src/team/managed-passphrase.ts
@@ -202,6 +202,90 @@ export interface RecipientSealer {
 }
 
 /**
+ * Shared RSA-OAEP-SHA256 + AES-GCM seal in the canonical recipient-target
+ * TLV wire format. Mints a fresh 32-byte CEK, AES-GCM-encrypts `plaintext`
+ * under it, RSA-OAEP-SHA256-wraps the CEK to `publicKeyPem`, and packs:
+ *
+ *   byte  0       : version (0x01)
+ *   bytes 1..256  : RSA-OAEP-wrapped CEK (fixed 256 bytes at RSA-2048)
+ *   bytes 257..268: AES-GCM IV (12 bytes)
+ *   bytes 269..   : AES-GCM ciphertext ‖ 16-byte tag
+ *
+ * This is the single source of truth for the wire format — both
+ * {@link MemoryRecipientSealer} and external sealers (e.g. `@noy-db/at-aws-kms`'s
+ * asymmetric-KMS recipient sealer) call it so a blob sealed by one unseals
+ * by the other. WebCrypto RSA-OAEP/SHA-256 here is wire-compatible with
+ * AWS KMS `RSAES_OAEP_SHA_256` (both RSAES-OAEP, SHA-256 hash, MGF1-SHA256,
+ * empty label).
+ *
+ * @public — re-exported from the hub barrel for external sealer packages.
+ */
+export async function sealRsaOaepTlv(plaintext: Uint8Array, publicKeyPem: string): Promise<Uint8Array> {
+  // Parse PEM → SPKI bytes.
+  const b64 = publicKeyPem.replace(/-----BEGIN PUBLIC KEY-----/, '').replace(/-----END PUBLIC KEY-----/, '').replace(/\s+/g, '')
+  const spki = base64ToBytes(b64)
+  const recipientPub = await crypto.subtle.importKey(
+    'spki', spki as BufferSource,
+    { name: 'RSA-OAEP', hash: 'SHA-256' },
+    false, ['encrypt'],
+  )
+  // Mint fresh CEK + IV, AES-GCM encrypt plaintext.
+  const cekBytes = crypto.getRandomValues(new Uint8Array(32))
+  const cek = await crypto.subtle.importKey('raw', cekBytes as BufferSource, 'AES-GCM', false, ['encrypt'])
+  const iv = crypto.getRandomValues(new Uint8Array(12))
+  const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv: iv as BufferSource }, cek, plaintext as BufferSource))
+  // RSA-OAEP-wrap the CEK bytes.
+  const wrapped = new Uint8Array(await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, recipientPub, cekBytes as BufferSource))
+  cekBytes.fill(0)
+  if (wrapped.length !== 256) {
+    throw new Error(`sealRsaOaepTlv: expected 256-byte RSA-OAEP wrap, got ${wrapped.length}`)
+  }
+  // TLV layout.
+  const out = new Uint8Array(1 + 256 + 12 + ct.length)
+  out[0] = 0x01
+  out.set(wrapped, 1)
+  out.set(iv, 1 + 256)
+  out.set(ct, 1 + 256 + 12)
+  return out
+}
+
+/**
+ * Parse a {@link sealRsaOaepTlv} blob into its three segments without
+ * decrypting. The `wrapped` CEK is RSA-OAEP-SHA256 ciphertext over a
+ * 32-byte CEK — the unwrap step is pluggable: {@link MemoryRecipientSealer}
+ * decrypts it with a local RSA private key; `@noy-db/at-aws-kms` hands it to
+ * KMS `Decrypt`. After unwrapping, pass the CEK + `iv` + `ct` to
+ * {@link aesGcmOpen}.
+ *
+ * @public — re-exported from the hub barrel for external sealer packages.
+ */
+export function parseRsaOaepTlv(bytes: Uint8Array): { wrapped: Uint8Array; iv: Uint8Array; ct: Uint8Array } {
+  if (bytes.length < 1 + 256 + 12 + 16) {
+    throw new Error('parseRsaOaepTlv: sealed input too short')
+  }
+  if (bytes[0] !== 0x01) {
+    throw new Error(`parseRsaOaepTlv: unknown TLV version ${bytes[0]}`)
+  }
+  return {
+    wrapped: bytes.subarray(1, 1 + 256),
+    iv: bytes.subarray(1 + 256, 1 + 256 + 12),
+    ct: bytes.subarray(1 + 256 + 12),
+  }
+}
+
+/**
+ * AES-GCM-decrypt the `ct` segment of a {@link parseRsaOaepTlv} result under
+ * the unwrapped 32-byte CEK and its `iv`. Throws on a bad tag (tamper) — the
+ * same authenticated-decryption guarantee the TLV relies on.
+ *
+ * @public — re-exported from the hub barrel for external sealer packages.
+ */
+export async function aesGcmOpen(cekBytes: Uint8Array, iv: Uint8Array, ct: Uint8Array): Promise<Uint8Array> {
+  const cek = await crypto.subtle.importKey('raw', cekBytes as BufferSource, 'AES-GCM', false, ['decrypt'])
+  return new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-GCM', iv: iv as BufferSource }, cek, ct as BufferSource))
+}
+
+/**
  * Reference implementation of `RecipientSealer` + `SealingKeyProvider`.
  * Uses WebCrypto RSA-OAEP-SHA256 (2048-bit) to wrap a fresh 32-byte
  * AES-GCM CEK, AES-GCM-encrypts plaintext under it, and packs the
@@ -257,32 +341,7 @@ export class MemoryRecipientSealer implements SealingKeyProvider, RecipientSeale
     if (typeof pem !== 'string') {
       throw new Error('MemoryRecipientSealer.sealForRecipient: hint.material.publicKeyPem missing or not a string')
     }
-    // Parse PEM → SPKI bytes.
-    const b64 = pem.replace(/-----BEGIN PUBLIC KEY-----/, '').replace(/-----END PUBLIC KEY-----/, '').replace(/\s+/g, '')
-    const spki = base64ToBytes(b64)
-    const recipientPub = await crypto.subtle.importKey(
-      'spki', spki as BufferSource,
-      { name: 'RSA-OAEP', hash: 'SHA-256' },
-      false, ['encrypt'],
-    )
-    // Mint fresh CEK + IV, AES-GCM encrypt plaintext.
-    const cekBytes = crypto.getRandomValues(new Uint8Array(32))
-    const cek = await crypto.subtle.importKey('raw', cekBytes as BufferSource, 'AES-GCM', false, ['encrypt'])
-    const iv = crypto.getRandomValues(new Uint8Array(12))
-    const ct = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv: iv as BufferSource }, cek, plaintext as BufferSource))
-    // RSA-OAEP-wrap the CEK bytes.
-    const wrapped = new Uint8Array(await crypto.subtle.encrypt({ name: 'RSA-OAEP' }, recipientPub, cekBytes as BufferSource))
-    cekBytes.fill(0)
-    if (wrapped.length !== 256) {
-      throw new Error(`MemoryRecipientSealer.sealForRecipient: expected 256-byte RSA-OAEP wrap, got ${wrapped.length}`)
-    }
-    // TLV layout.
-    const out = new Uint8Array(1 + 256 + 12 + ct.length)
-    out[0] = 0x01
-    out.set(wrapped, 1)
-    out.set(iv, 1 + 256)
-    out.set(ct, 1 + 256 + 12)
-    return out
+    return sealRsaOaepTlv(plaintext, pem)
   }
 
   async seal(plaintext: Uint8Array): Promise<Uint8Array> {
@@ -291,19 +350,12 @@ export class MemoryRecipientSealer implements SealingKeyProvider, RecipientSeale
   }
 
   async unseal(bytes: Uint8Array): Promise<Uint8Array> {
-    if (bytes.length < 1 + 256 + 12 + 16) {
-      throw new Error('MemoryRecipientSealer.unseal: sealed input too short')
-    }
-    if (bytes[0] !== 0x01) {
-      throw new Error(`MemoryRecipientSealer.unseal: unknown TLV version ${bytes[0]}`)
-    }
-    const wrapped = bytes.subarray(1, 1 + 256)
-    const iv = bytes.subarray(1 + 256, 1 + 256 + 12)
-    const ct = bytes.subarray(1 + 256 + 12)
+    const { wrapped, iv, ct } = parseRsaOaepTlv(bytes)
     const { privateKey } = await this.keypair
+    // Local RSA-OAEP-SHA256 unwrap of the CEK — the pluggable step external
+    // sealers replace with KMS Decrypt.
     const cekBytes = new Uint8Array(await crypto.subtle.decrypt({ name: 'RSA-OAEP' }, privateKey, wrapped as BufferSource))
-    const cek = await crypto.subtle.importKey('raw', cekBytes as BufferSource, 'AES-GCM', false, ['decrypt'])
-    const pt = new Uint8Array(await crypto.subtle.decrypt({ name: 'AES-GCM', iv: iv as BufferSource }, cek, ct as BufferSource))
+    const pt = await aesGcmOpen(cekBytes, iv, ct)
     cekBytes.fill(0)
     return pt
   }

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -108,7 +108,10 @@ import {
   type ClosePeriodOptions,
   type OpenPeriodOptions,
 } from './periods/index.js'
-import { encrypt, decrypt } from './crypto.js'
+import { encrypt, decrypt, unwrapCek, wrapCek, generateDEK, bufferToBase64 } from './crypto.js'
+import { RecordCekNotFoundError } from './errors.js'
+import type { RecipientSealer } from './team/managed-passphrase.js'
+import type { SealedCekDeliveryEnvelope, SealedCekBinding } from './sealed-record/types.js'
 import {
   createExportBlobsHandle,
   EXPORT_AUDIT_COLLECTION,
@@ -2280,6 +2283,166 @@ export class Vault {
       unmigratedRecords,
       blobResidueCollections: [...blobResidueCollections],
       ledgerEntry,
+    }
+  }
+
+  // ─── Record-scoped CEK sealing (#306 slices 2-3) ──────────────────────
+
+  /**
+   * Seal ONE record's content-encryption key (CEK) to an `at-*` host so that
+   * host — and only that host — can decrypt exactly that record, with no
+   * access to the vault DEK and no ability to read any other record.
+   *
+   * The grantor (this caller, who holds the collection DEK) reads the record's
+   * live `_cek`, unwraps it under the collection DEK, exports the raw CEK
+   * bytes, builds a {@link SealedCekBinding} `{collection, id, cek, expiresAt}`,
+   * seals that binding for the recipient host via the host's published hint,
+   * and persists a thin {@link SealedCekDeliveryEnvelope} at
+   * `_sealed_cek/<collection>/<id>/<pid>`. The binding (not the delivery
+   * envelope) is the security boundary: the host re-verifies `{collection, id}`
+   * and `expiresAt` from inside the sealed payload.
+   *
+   * Only works on a `perRecordKeys` record — a legacy record has no `_cek` to
+   * seal (its body is under the shared collection DEK, which is never exposed
+   * by sealing) → {@link RecordCekNotFoundError}.
+   *
+   * @param collection Collection holding the record.
+   * @param id         Record id.
+   * @param hostSealer The recipient host's {@link RecipientSealer}.
+   * @param opts.expiresAt REQUIRED authoritative expiry (ISO 8601), sealed into
+   *   the binding the host verifies.
+   * @returns `{ pid, envelopeKey }` — the host provider id and the
+   *   `<collection>/<id>/<pid>` key the delivery envelope was written under.
+   */
+  async sealRecordToHost(
+    collection: string,
+    id: string,
+    hostSealer: RecipientSealer,
+    opts: { expiresAt: string },
+  ): Promise<{ pid: string; envelopeKey: string }> {
+    // Guard separators: the `_sealed_cek` id is `collection/id/pid`, so a `/`
+    // in any component would make the prefix-delete in rotateRecordCek() (which
+    // matches `${collection}/${id}/`) ambiguous and could over- or under-match.
+    if (collection.includes('/')) throw new ValidationError(`sealRecordToHost: collection "${collection}" must not contain "/"`)
+    if (id.includes('/')) throw new ValidationError(`sealRecordToHost: id "${id}" must not contain "/"`)
+
+    const live = await this.adapter.get(this.name, collection, id)
+    if (!live || live._cek === undefined) {
+      throw new RecordCekNotFoundError(collection, id)
+    }
+
+    const dek = await this.getDEK(collection)
+    const cek = await unwrapCek(live._cek, dek)
+    const rawCek = await crypto.subtle.exportKey('raw', cek)
+    const cekB64 = bufferToBase64(rawCek)
+
+    const hint = await hostSealer.publishRecipientHint()
+    if (hint.pid.includes('/')) throw new ValidationError(`sealRecordToHost: recipient pid "${hint.pid}" must not contain "/"`)
+
+    const binding: SealedCekBinding = {
+      collection,
+      id,
+      cek: cekB64,
+      expiresAt: opts.expiresAt,
+    }
+    const sealed = await hostSealer.sealForRecipient(
+      new TextEncoder().encode(JSON.stringify(binding)),
+      hint,
+    )
+
+    const delivery: SealedCekDeliveryEnvelope = {
+      v: 1,
+      _noydb_sealed_cek: 1,
+      pid: hint.pid,
+      payload: bufferToBase64(sealed),
+      expiresAt: opts.expiresAt,
+    }
+
+    const envelopeKey = `${collection}/${id}/${hint.pid}`
+    const prior = await this.adapter.get(this.name, '_sealed_cek', envelopeKey)
+    const env: EncryptedEnvelope = {
+      _noydb: NOYDB_FORMAT_VERSION,
+      _v: (prior?._v ?? 0) + 1,
+      _ts: new Date().toISOString(),
+      // AES-GCM bypassed — the sealing layer is the security boundary, exactly
+      // like the managed-passphrase `_meta/sealed-passphrase` envelope.
+      _iv: '',
+      _data: JSON.stringify(delivery),
+      ...(this.keyring.userId ? { _by: this.keyring.userId } : {}),
+    }
+    await this.adapter.put(this.name, '_sealed_cek', envelopeKey, env)
+
+    return { pid: hint.pid, envelopeKey }
+  }
+
+  /**
+   * Revoke a single sealed-CEK delivery envelope by deleting it from the store.
+   * A soft revocation: it removes the host's copy of the sealed CEK, but a host
+   * that already fetched the envelope keeps whatever it cached. For a hard
+   * revocation that makes the live record undecryptable to every prior grant,
+   * use {@link rotateRecordCek}.
+   */
+  async revokeSealedRecord(collection: string, id: string, pid: string): Promise<void> {
+    await this.adapter.delete(this.name, '_sealed_cek', `${collection}/${id}/${pid}`)
+  }
+
+  /**
+   * HARD-rotate a record's CEK: decrypt the live body under the old CEK,
+   * re-encrypt it under a freshly-minted CEK, write the new live envelope, evict
+   * the in-memory caches, and delete EVERY sealed-CEK delivery envelope for the
+   * record. After this, any host holding a previously-sealed CEK can still
+   * decrypt PRE-rotation history versions (they keep their old `_cek`) but NOT
+   * the rotated live record (its body is under the new CEK → the old CEK fails
+   * the AES-GCM auth tag → `TamperedError`). That asymmetry IS the revocation:
+   * old grants lose the live record.
+   *
+   * Administrative path — bypasses `Collection.put` deliberately (no guards, no
+   * history snapshot, no materialized-view refresh): rotation is a key-rotation
+   * operation, not a business write, and must not version-bump history (which
+   * would re-encrypt the prior version under the NEW CEK and defeat the point).
+   *
+   * @throws {@link RecordCekNotFoundError} if the record is missing or has no `_cek`.
+   */
+  async rotateRecordCek(collection: string, id: string): Promise<void> {
+    const live = await this.adapter.get(this.name, collection, id)
+    if (!live || live._cek === undefined) {
+      throw new RecordCekNotFoundError(collection, id)
+    }
+
+    const dek = await this.getDEK(collection)
+    const oldCek = await unwrapCek(live._cek, dek)
+    const json = await decrypt(live._iv, live._data, oldCek)
+
+    const newCek = await generateDEK()
+    const { iv, data } = await encrypt(json, newCek)
+
+    const env: EncryptedEnvelope = {
+      _noydb: NOYDB_FORMAT_VERSION,
+      _v: live._v + 1,
+      _ts: new Date().toISOString(),
+      _iv: iv,
+      _data: data,
+      _cek: await wrapCek(newCek, dek),
+      ...(this.keyring.userId ? { _by: this.keyring.userId } : {}),
+      ...(live._tier !== undefined ? { _tier: live._tier } : {}),
+      ...(live._det !== undefined ? { _det: live._det } : {}),
+    }
+    await this.adapter.put(this.name, collection, id, env)
+
+    // Evict BOTH caches synchronously so no read returns the stale old-CEK
+    // record: the per-record CEK cache (would unwrap to the old CEK) and the
+    // decrypted-record cache (holds the old plaintext + version).
+    const coll = this.collection<Record<string, unknown>>(collection)
+    coll._invalidateCekCacheEntry(id)
+    await coll._invalidateCacheEntry(id)
+
+    // Delete every sealed-CEK delivery envelope for this record — all pids.
+    const prefix = `${collection}/${id}/`
+    const keys = await this.adapter.list(this.name, '_sealed_cek')
+    for (const key of keys) {
+      if (key.startsWith(prefix)) {
+        await this.adapter.delete(this.name, '_sealed_cek', key)
+      }
     }
   }
 

--- a/packages/hub/tsup.config.ts
+++ b/packages/hub/tsup.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'tsup'
 /**
  * Build config — spec.
  *
- * The hub ships 23 subpath entries plus the main barrel. Every entry
+ * The hub ships 25 subpath entries plus the main barrel. Every entry
  * is its own bundle; tsup compiles them independently. With
  * `splitting: false`, shared modules (e.g. `errors.ts`) get inlined
  * into every entry, producing one class definition per entry. That
@@ -30,6 +30,7 @@ const ENTRIES = {
   'session/index': 'src/session/index.ts',
   'history/index': 'src/history/index.ts',
   'forget/index': 'src/forget/index.ts',
+  'sealed-record/index': 'src/sealed-record/index.ts',
   'query/index': 'src/query/index.ts',
   'blobs/index': 'src/blobs/index.ts',
   'indexing/index': 'src/indexing/index.ts',

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -436,7 +436,13 @@ const KERNEL_SURFACE_BUDGET = {
   // ensure/hydrate) skip null — plus the new `_writeTombstone` + `_decodeEnvelope`
   // shred primitives. These are core read/write-path edits the kernel owns; the
   // forget() orchestration + subject index live in vault.ts / src/forget/.
-  'packages/hub/src/collection.ts': 4440,
+  // Bumped 4440→4460 (#306, record-scoped CEK sealing slices 2-3): the
+  // `_invalidateCekCacheEntry(id)` core hook the kernel owns — `vault.rotateRecordCek`
+  // must evict the per-record CEK cache synchronously with the live-envelope re-key
+  // so no read returns the stale old-CEK record (the cekCache lives on Collection).
+  // The seal/revoke/rotate orchestration + the host-side opener live in vault.ts /
+  // src/sealed-record/.
+  'packages/hub/src/collection.ts': 4460,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -461,7 +467,15 @@ const KERNEL_SURFACE_BUDGET = {
   // Adds forget() + rebuildSubjectIndex() + the _addSubjectRef/_removeSubjectRef
   // hooks + the perRecordKeys-forcing in collection(); the subject-index crypto
   // and the strategy declaration live in src/forget/ (the @noy-db/hub/forget subpath).
-  'packages/hub/src/vault.ts': 4100,
+  // Bumped 4100→4280 (#306, record-scoped CEK sealing slices 2-3): the grantor
+  // side is genuinely core — it needs the collection DEK to `sealRecordToHost`
+  // (unwrap `_cek`, seal a `{collection,id,cek,expiresAt}` binding to a host
+  // RecipientSealer, write the `_sealed_cek/<collection>/<id>/<pid>` delivery
+  // envelope), `revokeSealedRecord`, and `rotateRecordCek` (hard re-key + dual
+  // cache eviction + prefix-delete of all sealed envelopes). The wire/binding
+  // types + the host-side `openSealedRecord` (which holds no DEK) live in
+  // src/sealed-record/ (the @noy-db/hub/sealed-record subpath).
+  'packages/hub/src/vault.ts': 4280,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),

--- a/scripts/feature-schema.json
+++ b/scripts/feature-schema.json
@@ -194,6 +194,7 @@
             "showcases": true, "recipes": true, "playground_pages": true,
             "diagrams": true, "invariants": true, "related": true,
             "backend":       { "enum": ["env", "macos-keychain", "aws-kms", "gcp-kms", "azure-keyvault", "wincred", "libsecret", "webauthn-prf"] },
+            "capabilities":  { "type": "object", "additionalProperties": false, "properties": { "recipientSealer": { "type": "boolean" } } },
             "subsystem_doc": { "type": "string", "pattern": "^docs/.+\\.md$" }
           }
         }


### PR DESCRIPTION
**Completes #306 (epic #357 step 3) end-to-end** — record-scoped CEK sealing to an `at-*` host. Slice 1 (the `at-aws-kms` `RecipientSealer` prerequisite) + slices 2-3 (the sealing API + host decrypt) ship together, since the RecipientSealer is only useful with the sealing API that consumes it.

## Slice 1 — `at-aws-kms` RecipientSealer (asymmetric KMS)
`awsKmsRecipientSealer({ keyId })`: `publishRecipientHint` (GetPublicKey, validated RSA ENCRYPT_DECRYPT key) → PEM hint; `sealForRecipient` = shared local RSA-OAEP seal (no KMS call); `unseal` = KMS `Decrypt(RSAES_OAEP_SHA_256)` + local AES-GCM. Extracted `MemoryRecipientSealer`'s TLV into shared `sealRsaOaepTlv`/`parseRsaOaepTlv`/`aesGcmOpen` (single source of truth). Cloud-verified against AWS docs.

## Slices 2-3 — sealing API + host decrypt
- `vault.sealRecordToHost(collection, id, hostSealer, { expiresAt })` — unwraps the record CEK (vault-side), seals a bound struct `{collection,id,cek,expiresAt}` to the host's hint, persists a thin `_sealed_cek/<collection>/<id>/<pid>` envelope. `expiresAt` REQUIRED + authoritative inside the sealed payload.
- `vault.revokeSealedRecord(...)` deletes the delivery envelope. `vault.rotateRecordCek(...)` is the **hard revoke**: re-encrypt the live body under a fresh CEK (old history versions keep their old `_cek` → a host with the old sealed CEK reads pre-rotation versions but NOT the rotated live record), evict both caches, delete stale envelopes.
- `@noy-db/hub/sealed-record` `openSealedRecord(...)` — host-side standalone decrypt, **no vault DEK needed**. Binding mismatch → `SealedRecordMismatchError`; expired → `SealedRecordExpiredError`; post-rotation wrong key → `TamperedError`.

**No KMS encryption context** (asymmetric keys don't support it — verified); record-binding lives in the sealed payload.

## Verification
`@noy-db/hub`: typecheck/build/lint ✓, **full suite 259 files / 2510 tests, 0 failures**. `@noy-db/at-aws-kms`: 12 pass / 2 skipped (env-gated real-KMS). `validate:features` ✓ (57). `check-architecture` ✓ (kernel ceilings bumped w/ #306 justification). New tests: `record-scoped-cek-sealing.test.ts` (11, incl. host-denial, rotation revocation + TamperedError, cross-process no-DEK reconstruction).

This is the final implementation step of the CEK security epic (#357): step 1 foundation ✅, step 2 erasure (#304) ✅, step 3 sealing — this PR.

Closes #306