### PR TITLE
refactor(hub): record-keys subsystem — extraction slice 2 (CEK orchestration)

### DIFF
--- a/packages/hub/__tests__/record-keys/lifecycle.test.ts
+++ b/packages/hub/__tests__/record-keys/lifecycle.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for the CEK write-path lifecycle helpers extracted into
+ * src/record-keys/lifecycle.ts (extraction slice 2).
+ *
+ * These pin the two contracts the kernel delegates to: the stable-CEK rule
+ * (resolveStableCek) and the same-body-key tier/bundle re-wrap
+ * (rewrapBodyToDek). End-to-end tier/seal behaviour is covered through the
+ * Collection/Vault integration tests; here we exercise the functions directly.
+ */
+import { describe, it, expect } from 'vitest'
+import { generateDEK, encrypt, decrypt } from '../../src/crypto.js'
+import {
+  resolveStableCek,
+  rewrapBodyToDek,
+  wrapCek,
+  unwrapCek,
+} from '../../src/record-keys/index.js'
+import { Lru } from '../../src/cache/index.js'
+import { NOYDB_FORMAT_VERSION, type EncryptedEnvelope } from '../../src/types.js'
+
+async function cekEnvelope(body: string, dek: CryptoKey): Promise<{ env: EncryptedEnvelope; cek: CryptoKey }> {
+  const cek = await generateDEK()
+  const { iv, data } = await encrypt(body, cek)
+  return {
+    cek,
+    env: { _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: 't', _iv: iv, _data: data, _cek: await wrapCek(cek, dek) },
+  }
+}
+
+describe('resolveStableCek', () => {
+  it('mints a fresh CEK for a genuine insert (no live envelope) and caches it', async () => {
+    const cache = new Lru<string, CryptoKey>({ maxRecords: 8 })
+    const cek = await resolveStableCek({ cache, getLive: async () => null, getDEK: generateDEK }, 'r1')
+    expect(cache.get('r1')).toBe(cek)
+  })
+
+  it('reuses an existing record CEK by unwrapping the live _cek', async () => {
+    const dek = await generateDEK()
+    const { env, cek } = await cekEnvelope('{"a":1}', dek)
+    const resolved = await resolveStableCek(
+      { cache: null, getLive: async () => env, getDEK: async () => dek },
+      'r2',
+    )
+    // Same key bytes: a body encrypted under `cek` decrypts under `resolved`.
+    const { iv, data } = await encrypt('{"a":1}', cek)
+    expect(await decrypt(iv, data, resolved)).toBe('{"a":1}')
+  })
+
+  it('prefers the cache over a live read (stable CEK across an update)', async () => {
+    const cache = new Lru<string, CryptoKey>({ maxRecords: 8 })
+    const cached = await generateDEK()
+    cache.set('r3', cached, 1)
+    let liveReads = 0
+    const got = await resolveStableCek(
+      { cache, getLive: async () => { liveReads++; return null }, getDEK: generateDEK },
+      'r3',
+    )
+    expect(got).toBe(cached)
+    expect(liveReads).toBe(0)
+  })
+})
+
+describe('rewrapBodyToDek', () => {
+  it('moves a CEK record from one DEK to another, preserving the body key', async () => {
+    const fromDek = await generateDEK()
+    const toDek = await generateDEK()
+    const { env, cek } = await cekEnvelope('{"v":42}', fromDek)
+
+    const r = await rewrapBodyToDek(env, fromDek, toDek)
+    expect(r._cek).toBeDefined()
+    expect(r.cek).not.toBeNull()
+
+    // The new _cek unwraps under the DESTINATION DEK to the SAME body key.
+    const movedCek = await unwrapCek(r._cek!, toDek)
+    expect(await decrypt(r._iv, r._data, movedCek)).toBe('{"v":42}')
+    // And the original body key still decrypts the re-encrypted body (same key).
+    expect(await decrypt(r._iv, r._data, cek)).toBe('{"v":42}')
+  })
+
+  it('re-encrypts a legacy (no _cek) body directly under the destination DEK', async () => {
+    const fromDek = await generateDEK()
+    const toDek = await generateDEK()
+    const { iv, data } = await encrypt('{"legacy":true}', fromDek)
+    const env: EncryptedEnvelope = { _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: 't', _iv: iv, _data: data }
+
+    const r = await rewrapBodyToDek(env, fromDek, toDek)
+    expect(r._cek).toBeUndefined()
+    expect(r.cek).toBeNull()
+    expect(await decrypt(r._iv, r._data, toDek)).toBe('{"legacy":true}')
+  })
+})

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -13,8 +13,15 @@ import type { ComputedFields } from './computed/index.js'
 import { evalComputedFields } from './computed/index.js'
 import { NO_I18N, type I18nStrategy } from './i18n/strategy.js'
 import { resolvePolicy } from './i18n/policy.js'
-import { encrypt, decrypt, encryptDeterministic, generateDEK } from './crypto.js'
-import { wrapCek, unwrapCek, isTombstone, buildTombstone } from './record-keys/index.js'
+import { encrypt, decrypt, encryptDeterministic } from './crypto.js'
+import {
+  wrapCek,
+  unwrapCek,
+  isTombstone,
+  buildTombstone,
+  resolveStableCek,
+  rewrapBodyToDek,
+} from './record-keys/index.js'
 import { ConflictError, ReadOnlyError, TranslatorNotConfiguredError, TierDemoteDeniedError, LocaleNotSpecifiedError } from './errors.js'
 import { dekKey, assertTierAccess } from './team/tiers.js'
 import type { GhostRecord, TierMode, CrossTierAccessEvent } from './types.js'
@@ -3762,42 +3769,19 @@ export class Collection<T> {
   }
 
   /**
-   * True when this record envelope is a shred tombstone: an encrypted
-   * record that carries no body and no wrapped CEK. Tombstone *creation*
-   * is step 2 (#304); step 1's read path only has to tolerate one — a
-   * `get()` on a tombstone returns `null` instead of throwing
-   * `TamperedError` (decision 5). A plaintext (`!this.encrypted`)
-   * collection legitimately has an empty `_iv`, so it is never a tombstone.
+   * Resolve the stable CEK for a record on the WRITE path — see
+   * {@link resolveStableCek}. Thin delegate that supplies the collection's
+   * CEK cache, live-envelope reader, and DEK resolver.
    */
-  /**
-   * Resolve the stable CEK for a record on the WRITE path.
-   *
-   * - Cache hit → reuse (updates and history snapshots share the record's
-   *   CEK so a single CEK delete kills the whole version chain).
-   * - Live envelope carries `_cek` → unwrap it under the collection DEK,
-   *   cache, reuse.
-   * - Otherwise (genuine insert, or a legacy record being migrated) → mint
-   *   a fresh CEK and cache it.
-   *
-   * `wrapDek` is the DEK the CEK should be (re-)wrappable under — the
-   * collection DEK on the normal path. The returned CEK is the AES-GCM body
-   * key; the caller wraps it for storage on `_cek`.
-   */
-  private async resolveRecordCek(id: string): Promise<CryptoKey> {
-    const cached = this.cekCache?.get(id)
-    if (cached) return cached
-
-    const live = await this.adapter.get(this.vault, this.name, id)
-    if (live?._cek !== undefined) {
-      const dek = await this.getDEK(this.name)
-      const cek = await unwrapCek(live._cek, dek)
-      this.cekCache?.set(id, cek, 1)
-      return cek
-    }
-
-    const fresh = await generateDEK()
-    this.cekCache?.set(id, fresh, 1)
-    return fresh
+  private resolveRecordCek(id: string): Promise<CryptoKey> {
+    return resolveStableCek(
+      {
+        cache: this.cekCache,
+        getLive: (rid) => this.adapter.get(this.vault, this.name, rid),
+        getDEK: () => this.getDEK(this.name),
+      },
+      id,
+    )
   }
 
   /**
@@ -4140,43 +4124,22 @@ export class Collection<T> {
     const fromDek = await this.getDEK(fromKey)
     const toDek = await this.getDEK(toKey)
 
-    // Per-record CEK composes with tiers: unwrap the CEK under the SOURCE
-    // tier DEK, re-encrypt the body under the SAME CEK, then re-wrap the
-    // CEK under the TARGET tier DEK. The body key is unchanged (history
+    // Per-record CEK composes with tiers: the body key is unchanged (history
     // chain identity preserved); only the wrapping key moves with the tier.
     // Legacy (no `_cek`) records take the direct-DEK path unchanged.
     const now = new Date().toISOString()
-    let next: EncryptedEnvelope
-    if (envelope._cek !== undefined) {
-      const cek = await unwrapCek(envelope._cek, fromDek)
-      const plaintext = await decrypt(envelope._iv, envelope._data, cek)
-      const { iv, data } = await encrypt(plaintext, cek)
-      const rewrapped = await wrapCek(cek, toDek)
-      this.cekCache?.set(id, cek, 1)
-      next = {
-        _noydb: NOYDB_FORMAT_VERSION,
-        _v: envelope._v + 1,
-        _ts: now,
-        _iv: iv,
-        _data: data,
-        _by: this.keyring.userId,
-        _tier: toTier,
-        _elevatedBy: this.keyring.userId,
-        _cek: rewrapped,
-      }
-    } else {
-      const plaintext = await decrypt(envelope._iv, envelope._data, fromDek)
-      const { iv, data } = await encrypt(plaintext, toDek)
-      next = {
-        _noydb: NOYDB_FORMAT_VERSION,
-        _v: envelope._v + 1,
-        _ts: now,
-        _iv: iv,
-        _data: data,
-        _by: this.keyring.userId,
-        _tier: toTier,
-        _elevatedBy: this.keyring.userId,
-      }
+    const body = await rewrapBodyToDek(envelope, fromDek, toDek)
+    if (body.cek) this.cekCache?.set(id, body.cek, 1)
+    const next: EncryptedEnvelope = {
+      _noydb: NOYDB_FORMAT_VERSION,
+      _v: envelope._v + 1,
+      _ts: now,
+      _iv: body._iv,
+      _data: body._data,
+      _by: this.keyring.userId,
+      _tier: toTier,
+      _elevatedBy: this.keyring.userId,
+      ...(body._cek !== undefined ? { _cek: body._cek } : {}),
     }
     await this.adapter.put(this.vault, this.name, id, next)
 
@@ -4221,35 +4184,17 @@ export class Collection<T> {
     // CEK re-wrap on demote — same body key, moved from the source tier
     // DEK to the target tier DEK. Legacy records take the direct-DEK path.
     const now = new Date().toISOString()
-    let next: EncryptedEnvelope
-    if (envelope._cek !== undefined) {
-      const cek = await unwrapCek(envelope._cek, fromDek)
-      const plaintext = await decrypt(envelope._iv, envelope._data, cek)
-      const { iv, data } = await encrypt(plaintext, cek)
-      const rewrapped = await wrapCek(cek, toDek)
-      this.cekCache?.set(id, cek, 1)
-      next = {
-        _noydb: NOYDB_FORMAT_VERSION,
-        _v: envelope._v + 1,
-        _ts: now,
-        _iv: iv,
-        _data: data,
-        _by: this.keyring.userId,
-        ...(toTier > 0 && { _tier: toTier }),
-        _cek: rewrapped,
-      }
-    } else {
-      const plaintext = await decrypt(envelope._iv, envelope._data, fromDek)
-      const { iv, data } = await encrypt(plaintext, toDek)
-      next = {
-        _noydb: NOYDB_FORMAT_VERSION,
-        _v: envelope._v + 1,
-        _ts: now,
-        _iv: iv,
-        _data: data,
-        _by: this.keyring.userId,
-        ...(toTier > 0 && { _tier: toTier }),
-      }
+    const body = await rewrapBodyToDek(envelope, fromDek, toDek)
+    if (body.cek) this.cekCache?.set(id, body.cek, 1)
+    const next: EncryptedEnvelope = {
+      _noydb: NOYDB_FORMAT_VERSION,
+      _v: envelope._v + 1,
+      _ts: now,
+      _iv: body._iv,
+      _data: body._data,
+      _by: this.keyring.userId,
+      ...(toTier > 0 && { _tier: toTier }),
+      ...(body._cek !== undefined ? { _cek: body._cek } : {}),
     }
     await this.adapter.put(this.vault, this.name, id, next)
 

--- a/packages/hub/src/record-keys/index.ts
+++ b/packages/hub/src/record-keys/index.ts
@@ -24,3 +24,10 @@
  */
 export { wrapCek, unwrapCek } from '../crypto.js'
 export { isTombstone, buildTombstone } from './tombstone.js'
+export { resolveStableCek, rewrapBodyToDek, type StableCekDeps, type RewrappedBody } from './lifecycle.js'
+export {
+  sealRecordToHost,
+  revokeSealedRecord,
+  rotateRecordCek,
+  type SealingContext,
+} from './sealing.js'

--- a/packages/hub/src/record-keys/lifecycle.ts
+++ b/packages/hub/src/record-keys/lifecycle.ts
@@ -1,0 +1,89 @@
+/**
+ * Per-record CEK lifecycle helpers for the WRITE path (#356 foundation).
+ *
+ * These are the collection-coupled CEK operations, lifted off `Collection`
+ * behind narrow deps so the kernel file delegates instead of carrying the
+ * crypto inline:
+ *
+ *   - {@link resolveStableCek} — the stable-CEK rule: an update or history
+ *     snapshot reuses the record's existing CEK so a single CEK delete kills
+ *     the whole version chain; a genuine insert (or legacy record being
+ *     migrated) mints a fresh one.
+ *   - {@link rewrapBodyToDek} — move a record body's wrapping from one DEK to
+ *     another (tier elevate/demote, bundle re-key) WITHOUT changing the body
+ *     key: unwrap the CEK under the source DEK, re-encrypt the body under the
+ *     same CEK, re-wrap the CEK under the destination DEK. History-chain
+ *     identity is preserved because the body key never changes.
+ *
+ * Both are pure functions over their deps — the `cekCache` ownership stays on
+ * the collection (its lifetime is tied to `load()`), so callers cache the
+ * returned key themselves.
+ */
+import { encrypt, decrypt, generateDEK, wrapCek, unwrapCek } from '../crypto.js'
+import type { EncryptedEnvelope } from '../types.js'
+import type { Lru } from '../cache/index.js'
+
+/** Dependencies {@link resolveStableCek} needs from its collection. */
+export interface StableCekDeps {
+  /** The collection's per-record CEK cache (`null` → no caching). */
+  readonly cache: Lru<string, CryptoKey> | null
+  /** Read the record's live envelope (to recover an existing `_cek`). */
+  getLive(id: string): Promise<EncryptedEnvelope | null>
+  /** The DEK the CEK is wrapped under (the collection DEK on the normal path). */
+  getDEK(): Promise<CryptoKey>
+}
+
+/**
+ * Resolve the stable CEK for a record on the write path. Caches the resolved
+ * key under `id` so an update + its history snapshot share one CEK.
+ */
+export async function resolveStableCek(deps: StableCekDeps, id: string): Promise<CryptoKey> {
+  const cached = deps.cache?.get(id)
+  if (cached) return cached
+
+  const live = await deps.getLive(id)
+  if (live?._cek !== undefined) {
+    const cek = await unwrapCek(live._cek, await deps.getDEK())
+    deps.cache?.set(id, cek, 1)
+    return cek
+  }
+
+  const fresh = await generateDEK()
+  deps.cache?.set(id, fresh, 1)
+  return fresh
+}
+
+/** Re-wrapped body bytes + the (optional) CEK to cache. */
+export interface RewrappedBody {
+  readonly _iv: string
+  readonly _data: string
+  /** Present iff the source envelope carried a CEK (per-record-key record). */
+  readonly _cek?: string
+  /** The body key when one exists, so the caller can cache it; `null` for a legacy record. */
+  readonly cek: CryptoKey | null
+}
+
+/**
+ * Move a record body from `fromDek` to `toDek`.
+ *
+ * - Per-record-key record (`_cek` present): unwrap the CEK under `fromDek`,
+ *   re-encrypt the body under the SAME CEK, re-wrap the CEK under `toDek`. The
+ *   body key is unchanged → history-chain identity preserved.
+ * - Legacy record (no `_cek`): decrypt under `fromDek`, re-encrypt under `toDek`
+ *   directly — byte-for-byte the pre-CEK behaviour.
+ */
+export async function rewrapBodyToDek(
+  envelope: Pick<EncryptedEnvelope, '_iv' | '_data' | '_cek'>,
+  fromDek: CryptoKey,
+  toDek: CryptoKey,
+): Promise<RewrappedBody> {
+  if (envelope._cek !== undefined) {
+    const cek = await unwrapCek(envelope._cek, fromDek)
+    const plaintext = await decrypt(envelope._iv, envelope._data, cek)
+    const { iv, data } = await encrypt(plaintext, cek)
+    return { _iv: iv, _data: data, _cek: await wrapCek(cek, toDek), cek }
+  }
+  const plaintext = await decrypt(envelope._iv, envelope._data, fromDek)
+  const { iv, data } = await encrypt(plaintext, toDek)
+  return { _iv: iv, _data: data, cek: null }
+}

--- a/packages/hub/src/record-keys/sealing.ts
+++ b/packages/hub/src/record-keys/sealing.ts
@@ -1,0 +1,169 @@
+/**
+ * Record-scoped CEK sealing — grantor side (#306 slices 2-3).
+ *
+ * The **grantor** holds the collection DEK and seals ONE record's CEK to an
+ * `at-*` host so that host — and only that host — can decrypt exactly that
+ * record, with no access to the vault DEK and no ability to read any other
+ * record. This is the counterpart to the host-side `openSealedRecord`
+ * (`@noy-db/hub/sealed-record`), which holds no DEK.
+ *
+ * These functions are the orchestration behind `vault.sealRecordToHost` /
+ * `vault.revokeSealedRecord` / `vault.rotateRecordCek`, lifted off `Vault`
+ * behind a narrow {@link SealingContext} so the kernel file delegates. They
+ * live in `record-keys/` (the vault-side CEK policy layer), NOT in
+ * `sealed-record/`, so the host-side subpath stays DEK-free — they import only
+ * the wire *types* from there.
+ */
+import { encrypt, decrypt, generateDEK, wrapCek, unwrapCek, bufferToBase64 } from '../crypto.js'
+import { NOYDB_FORMAT_VERSION, type EncryptedEnvelope, type NoydbStore } from '../types.js'
+import { RecordCekNotFoundError, ValidationError } from '../errors.js'
+import type { RecipientSealer } from '../team/managed-passphrase.js'
+import type { SealedCekBinding, SealedCekDeliveryEnvelope } from '../sealed-record/types.js'
+
+const subtle = globalThis.crypto.subtle
+
+/** The `_sealed_cek` delivery namespace (one envelope per `collection/id/pid`). */
+const SEALED_CEK_NS = '_sealed_cek'
+
+/** What the grantor functions need from their `Vault`. */
+export interface SealingContext {
+  readonly adapter: NoydbStore
+  /** Vault id (the adapter's first coordinate). */
+  readonly vault: string
+  /** Resolve the DEK a record's CEK is wrapped under. */
+  getDEK(collection: string): Promise<CryptoKey>
+  /** Actor id stamped on `_by` (empty string → omit). */
+  readonly actor: string
+  /** Evict the per-record CEK cache + decrypted-record cache after a rotation. */
+  invalidateRecordCaches(collection: string, id: string): Promise<void>
+}
+
+/**
+ * Seal a record's CEK to a host. See `vault.sealRecordToHost` for the contract.
+ * Returns `{ pid, envelopeKey }`.
+ */
+export async function sealRecordToHost(
+  ctx: SealingContext,
+  collection: string,
+  id: string,
+  hostSealer: RecipientSealer,
+  opts: { expiresAt: string },
+): Promise<{ pid: string; envelopeKey: string }> {
+  // Guard separators: the `_sealed_cek` id is `collection/id/pid`, so a `/` in
+  // any component would make the prefix-delete in rotateRecordCek() (which
+  // matches `${collection}/${id}/`) ambiguous and could over- or under-match.
+  if (collection.includes('/')) throw new ValidationError(`sealRecordToHost: collection "${collection}" must not contain "/"`)
+  if (id.includes('/')) throw new ValidationError(`sealRecordToHost: id "${id}" must not contain "/"`)
+
+  const live = await ctx.adapter.get(ctx.vault, collection, id)
+  if (!live || live._cek === undefined) {
+    throw new RecordCekNotFoundError(collection, id)
+  }
+
+  const dek = await ctx.getDEK(collection)
+  const cek = await unwrapCek(live._cek, dek)
+  const rawCek = await subtle.exportKey('raw', cek)
+  const cekB64 = bufferToBase64(rawCek)
+
+  const hint = await hostSealer.publishRecipientHint()
+  if (hint.pid.includes('/')) throw new ValidationError(`sealRecordToHost: recipient pid "${hint.pid}" must not contain "/"`)
+
+  const binding: SealedCekBinding = {
+    collection,
+    id,
+    cek: cekB64,
+    expiresAt: opts.expiresAt,
+  }
+  const sealed = await hostSealer.sealForRecipient(
+    new TextEncoder().encode(JSON.stringify(binding)),
+    hint,
+  )
+
+  const delivery: SealedCekDeliveryEnvelope = {
+    v: 1,
+    _noydb_sealed_cek: 1,
+    pid: hint.pid,
+    payload: bufferToBase64(sealed),
+    expiresAt: opts.expiresAt,
+  }
+
+  const envelopeKey = `${collection}/${id}/${hint.pid}`
+  const prior = await ctx.adapter.get(ctx.vault, SEALED_CEK_NS, envelopeKey)
+  const env: EncryptedEnvelope = {
+    _noydb: NOYDB_FORMAT_VERSION,
+    _v: (prior?._v ?? 0) + 1,
+    _ts: new Date().toISOString(),
+    // AES-GCM bypassed — the sealing layer is the security boundary, exactly
+    // like the managed-passphrase `_meta/sealed-passphrase` envelope.
+    _iv: '',
+    _data: JSON.stringify(delivery),
+    ...(ctx.actor ? { _by: ctx.actor } : {}),
+  }
+  await ctx.adapter.put(ctx.vault, SEALED_CEK_NS, envelopeKey, env)
+
+  return { pid: hint.pid, envelopeKey }
+}
+
+/**
+ * Soft-revoke one sealed-CEK delivery envelope (delete it from the store). A
+ * host that already fetched the envelope keeps whatever it cached; for a hard
+ * revocation use {@link rotateRecordCek}.
+ */
+export async function revokeSealedRecord(
+  ctx: SealingContext,
+  collection: string,
+  id: string,
+  pid: string,
+): Promise<void> {
+  await ctx.adapter.delete(ctx.vault, SEALED_CEK_NS, `${collection}/${id}/${pid}`)
+}
+
+/**
+ * HARD-rotate a record's CEK: re-encrypt the live body under a fresh CEK, evict
+ * caches, and delete EVERY sealed-CEK delivery envelope for the record. See
+ * `vault.rotateRecordCek` for why this bypasses `Collection.put` (no guards, no
+ * history bump — a key rotation must not re-encrypt prior history under the new
+ * CEK).
+ */
+export async function rotateRecordCek(
+  ctx: SealingContext,
+  collection: string,
+  id: string,
+): Promise<void> {
+  const live = await ctx.adapter.get(ctx.vault, collection, id)
+  if (!live || live._cek === undefined) {
+    throw new RecordCekNotFoundError(collection, id)
+  }
+
+  const dek = await ctx.getDEK(collection)
+  const oldCek = await unwrapCek(live._cek, dek)
+  const json = await decrypt(live._iv, live._data, oldCek)
+
+  const newCek = await generateDEK()
+  const { iv, data } = await encrypt(json, newCek)
+
+  const env: EncryptedEnvelope = {
+    _noydb: NOYDB_FORMAT_VERSION,
+    _v: live._v + 1,
+    _ts: new Date().toISOString(),
+    _iv: iv,
+    _data: data,
+    _cek: await wrapCek(newCek, dek),
+    ...(ctx.actor ? { _by: ctx.actor } : {}),
+    ...(live._tier !== undefined ? { _tier: live._tier } : {}),
+    ...(live._det !== undefined ? { _det: live._det } : {}),
+  }
+  await ctx.adapter.put(ctx.vault, collection, id, env)
+
+  // Evict BOTH caches synchronously so no read returns the stale old-CEK record.
+  await ctx.invalidateRecordCaches(collection, id)
+
+  // Delete every sealed-CEK delivery envelope for this record — all pids.
+  const prefix = `${collection}/${id}/`
+  const keys = await ctx.adapter.list(ctx.vault, SEALED_CEK_NS)
+  for (const key of keys) {
+    if (key.startsWith(prefix)) {
+      await ctx.adapter.delete(ctx.vault, SEALED_CEK_NS, key)
+    }
+  }
+}

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -108,11 +108,14 @@ import {
   type ClosePeriodOptions,
   type OpenPeriodOptions,
 } from './periods/index.js'
-import { encrypt, decrypt, generateDEK, bufferToBase64 } from './crypto.js'
-import { unwrapCek, wrapCek } from './record-keys/index.js'
-import { RecordCekNotFoundError } from './errors.js'
+import { encrypt, decrypt } from './crypto.js'
+import {
+  sealRecordToHost as sealRecordToHostImpl,
+  revokeSealedRecord as revokeSealedRecordImpl,
+  rotateRecordCek as rotateRecordCekImpl,
+  type SealingContext,
+} from './record-keys/index.js'
 import type { RecipientSealer } from './team/managed-passphrase.js'
-import type { SealedCekDeliveryEnvelope, SealedCekBinding } from './sealed-record/types.js'
 import {
   createExportBlobsHandle,
   EXPORT_AUDIT_COLLECTION,
@@ -2321,59 +2324,7 @@ export class Vault {
     hostSealer: RecipientSealer,
     opts: { expiresAt: string },
   ): Promise<{ pid: string; envelopeKey: string }> {
-    // Guard separators: the `_sealed_cek` id is `collection/id/pid`, so a `/`
-    // in any component would make the prefix-delete in rotateRecordCek() (which
-    // matches `${collection}/${id}/`) ambiguous and could over- or under-match.
-    if (collection.includes('/')) throw new ValidationError(`sealRecordToHost: collection "${collection}" must not contain "/"`)
-    if (id.includes('/')) throw new ValidationError(`sealRecordToHost: id "${id}" must not contain "/"`)
-
-    const live = await this.adapter.get(this.name, collection, id)
-    if (!live || live._cek === undefined) {
-      throw new RecordCekNotFoundError(collection, id)
-    }
-
-    const dek = await this.getDEK(collection)
-    const cek = await unwrapCek(live._cek, dek)
-    const rawCek = await crypto.subtle.exportKey('raw', cek)
-    const cekB64 = bufferToBase64(rawCek)
-
-    const hint = await hostSealer.publishRecipientHint()
-    if (hint.pid.includes('/')) throw new ValidationError(`sealRecordToHost: recipient pid "${hint.pid}" must not contain "/"`)
-
-    const binding: SealedCekBinding = {
-      collection,
-      id,
-      cek: cekB64,
-      expiresAt: opts.expiresAt,
-    }
-    const sealed = await hostSealer.sealForRecipient(
-      new TextEncoder().encode(JSON.stringify(binding)),
-      hint,
-    )
-
-    const delivery: SealedCekDeliveryEnvelope = {
-      v: 1,
-      _noydb_sealed_cek: 1,
-      pid: hint.pid,
-      payload: bufferToBase64(sealed),
-      expiresAt: opts.expiresAt,
-    }
-
-    const envelopeKey = `${collection}/${id}/${hint.pid}`
-    const prior = await this.adapter.get(this.name, '_sealed_cek', envelopeKey)
-    const env: EncryptedEnvelope = {
-      _noydb: NOYDB_FORMAT_VERSION,
-      _v: (prior?._v ?? 0) + 1,
-      _ts: new Date().toISOString(),
-      // AES-GCM bypassed — the sealing layer is the security boundary, exactly
-      // like the managed-passphrase `_meta/sealed-passphrase` envelope.
-      _iv: '',
-      _data: JSON.stringify(delivery),
-      ...(this.keyring.userId ? { _by: this.keyring.userId } : {}),
-    }
-    await this.adapter.put(this.name, '_sealed_cek', envelopeKey, env)
-
-    return { pid: hint.pid, envelopeKey }
+    return sealRecordToHostImpl(this.sealingContext(), collection, id, hostSealer, opts)
   }
 
   /**
@@ -2384,7 +2335,7 @@ export class Vault {
    * use {@link rotateRecordCek}.
    */
   async revokeSealedRecord(collection: string, id: string, pid: string): Promise<void> {
-    await this.adapter.delete(this.name, '_sealed_cek', `${collection}/${id}/${pid}`)
+    return revokeSealedRecordImpl(this.sealingContext(), collection, id, pid)
   }
 
   /**
@@ -2405,45 +2356,25 @@ export class Vault {
    * @throws {@link RecordCekNotFoundError} if the record is missing or has no `_cek`.
    */
   async rotateRecordCek(collection: string, id: string): Promise<void> {
-    const live = await this.adapter.get(this.name, collection, id)
-    if (!live || live._cek === undefined) {
-      throw new RecordCekNotFoundError(collection, id)
-    }
+    return rotateRecordCekImpl(this.sealingContext(), collection, id)
+  }
 
-    const dek = await this.getDEK(collection)
-    const oldCek = await unwrapCek(live._cek, dek)
-    const json = await decrypt(live._iv, live._data, oldCek)
-
-    const newCek = await generateDEK()
-    const { iv, data } = await encrypt(json, newCek)
-
-    const env: EncryptedEnvelope = {
-      _noydb: NOYDB_FORMAT_VERSION,
-      _v: live._v + 1,
-      _ts: new Date().toISOString(),
-      _iv: iv,
-      _data: data,
-      _cek: await wrapCek(newCek, dek),
-      ...(this.keyring.userId ? { _by: this.keyring.userId } : {}),
-      ...(live._tier !== undefined ? { _tier: live._tier } : {}),
-      ...(live._det !== undefined ? { _det: live._det } : {}),
-    }
-    await this.adapter.put(this.name, collection, id, env)
-
-    // Evict BOTH caches synchronously so no read returns the stale old-CEK
-    // record: the per-record CEK cache (would unwrap to the old CEK) and the
-    // decrypted-record cache (holds the old plaintext + version).
-    const coll = this.collection<Record<string, unknown>>(collection)
-    coll._invalidateCekCacheEntry(id)
-    await coll._invalidateCacheEntry(id)
-
-    // Delete every sealed-CEK delivery envelope for this record — all pids.
-    const prefix = `${collection}/${id}/`
-    const keys = await this.adapter.list(this.name, '_sealed_cek')
-    for (const key of keys) {
-      if (key.startsWith(prefix)) {
-        await this.adapter.delete(this.name, '_sealed_cek', key)
-      }
+  /**
+   * Build the {@link SealingContext} the record-keys grantor functions need:
+   * the vault-bound adapter, DEK resolver, actor, and the dual-cache eviction
+   * `rotateRecordCek` performs (per-record CEK cache + decrypted-record cache).
+   */
+  private sealingContext(): SealingContext {
+    return {
+      adapter: this.adapter,
+      vault: this.name,
+      getDEK: (collection) => this.getDEK(collection),
+      actor: this.keyring.userId,
+      invalidateRecordCaches: async (collection, id) => {
+        const coll = this.collection<Record<string, unknown>>(collection)
+        coll._invalidateCekCacheEntry(id)
+        await coll._invalidateCacheEntry(id)
+      },
     }
   }
 

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -445,10 +445,12 @@ const KERNEL_SURFACE_BUDGET = {
   // Lowered 4460→4445 (2026-06-13): record-keys subsystem extraction slice 1.
   // The pure tombstone predicate + envelope builder and the CEK-wrap surface
   // moved to src/record-keys/ (isTombstone now takes `encrypted` explicitly;
-  // _writeTombstone calls buildTombstone). A ratchet on the foundation slice —
-  // the coupled CEK orchestration (resolveRecordCek, tier/bundle re-wrap) moves
-  // in a later slice behind a deps interface.
-  'packages/hub/src/collection.ts': 4445,
+  // _writeTombstone calls buildTombstone).
+  // Lowered 4445→4385 (2026-06-13): record-keys extraction slice 2. The CEK
+  // write-path lifecycle moved to src/record-keys/lifecycle.ts behind a deps
+  // interface — resolveRecordCek is now a thin delegate to resolveStableCek,
+  // and the elevate/demote tier re-wrap if/else collapsed into rewrapBodyToDek.
+  'packages/hub/src/collection.ts': 4385,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -481,7 +483,12 @@ const KERNEL_SURFACE_BUDGET = {
   // cache eviction + prefix-delete of all sealed envelopes). The wire/binding
   // types + the host-side `openSealedRecord` (which holds no DEK) live in
   // src/sealed-record/ (the @noy-db/hub/sealed-record subpath).
-  'packages/hub/src/vault.ts': 4280,
+  // Lowered 4280→4195 (2026-06-13): record-keys extraction slice 2. The grantor
+  // sealing orchestration (sealRecordToHost / revokeSealedRecord /
+  // rotateRecordCek) moved to src/record-keys/sealing.ts behind a SealingContext
+  // deps interface; vault retains thin delegating methods + a sealingContext()
+  // builder. The host-side opener stays DEK-free in src/sealed-record/.
+  'packages/hub/src/vault.ts': 4195,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),


### PR DESCRIPTION
Stacked on #362 (slice 1). **Review/merge #362 first.**

## What

Lifts the collection- and vault-coupled CEK orchestration off the kernel files into `src/record-keys/` behind narrow deps interfaces, leaving thin delegating methods. This is where the real kernel-surface reduction comes from. **Behaviour-preserving** — verified by the full hub suite (no test changed; 5 new unit tests added).

## Changes

**`record-keys/lifecycle.ts` — CEK write path:**
- `resolveStableCek(deps, id)` — the stable-CEK rule (cache hit / unwrap live `_cek` / mint fresh). `Collection.resolveRecordCek` is now a thin delegate supplying the `cekCache`, live-envelope reader, and DEK resolver.
- `rewrapBodyToDek(env, fromDek, toDek)` — move a body's wrapping between DEKs preserving the body key. The `elevate`/`demote` tier re-wrap if/else (two ~20-line blocks) collapses into one call each.

**`record-keys/sealing.ts` — grantor side (#306):**
- `sealRecordToHost` / `revokeSealedRecord` / `rotateRecordCek` as free functions behind a `SealingContext` (`adapter`, `vault`, `getDEK`, `actor`, `invalidateRecordCaches`). `Vault` keeps the public methods as one-line delegates + a `sealingContext()` builder.
- Lives in `record-keys/` (vault-side, holds the DEK) — **not** `sealed-record/`, so the host-side opener subpath stays DEK-free. Imports only the wire *types* from there.

**Cleanup:** drops now-dead imports (`generateDEK` from collection.ts; `generateDEK`/`wrapCek`/`unwrapCek`/`bufferToBase64`/`RecordCekNotFoundError`/`SealedCek*` from vault.ts).

## Kernel-surface ratchet
| File | Before | After | Δ |
|---|---|---|---|
| `collection.ts` | 4445 | **4385** | −60 |
| `vault.ts` | 4280 | **4195** | −85 |

(Across slices 1+2: collection.ts 4460→4385, vault.ts 4280→4195.)

## Verification
- ✅ Full hub suite: 260 files, **2517 tests pass** (no regressions; no existing test modified)
- ✅ New `record-keys/lifecycle` unit tests: 5/5 (stable-CEK rule + DEK re-wrap, incl. legacy path)
- ✅ Architecture check + typecheck clean