### PR TITLE
feat(hub): per-blob CEK — content-CEK write/read path (#365 slice 1)

### DIFF
--- a/docs/superpowers/specs/2026-06-13-per-blob-cek-design.md
+++ b/docs/superpowers/specs/2026-06-13-per-blob-cek-design.md
@@ -1,0 +1,159 @@
+# Per-blob content-encryption keys (CEK) — crypto-shred of blob attachments (DESIGN, for review)
+
+> Final deferred slice of the per-record CEK epic (#357). The record **body** + history
+> are crypto-shreddable (#304); this makes a record's **blob attachments** shreddable too,
+> closing `forget()`'s `blobResidueCollections` gap. **Issue:** #365 · **Layer:** crypto / blobs.
+> **Status:** design, not implemented. Architecture refs current as of `0.2.0-pre.16` + the
+> record-keys subsystem (#362/#364).
+
+## The gap
+
+Blobs are encrypted under a **vault-wide `_blob` DEK** (`blobs/blob-set.ts:446`), independent of
+the per-record CEK hierarchy. So when `vault.forget(subject)` tombstones a record (body + history
+undecryptable), the record's blob attachments survive — `forget()` reports them as
+`blobResidueCollections` (`vault.ts:2240`, `forget/strategy.ts:93`) and explicitly does NOT erase
+them (foundation decision #5). This is the last hole in GDPR crypto-shred.
+
+Dedup makes this hard. `eTag = HMAC(_blobDEK, plaintext)` (`blob-set.ts:447`) is content-addressed:
+identical bytes across N records share one chunk set with `refCount = N` (`_blob_index/{eTag}`,
+`_blob_chunks/{eTag}/{i}`). A naive per-`(record,blob)` CEK would destroy that.
+
+## The one idea — content CEK per eTag, crypto-shred at refCount 0
+
+Introduce a **per-eTag content CEK**: a fresh AES-256-GCM key minted on a blob's first upload,
+**AES-KW-wrapped under the `_blob` DEK** and stored on the `BlobObject` (`_blob_index/{eTag}`) as
+`_cek`. The chunks are encrypted **once** under the content CEK (not the `_blob` DEK), so:
+
+- **Dedup is preserved.** `eTag` derivation is unchanged (still `HMAC(_blobDEK, plaintext)` — the
+  dedup *address*). A re-uploader of identical content finds the existing `BlobObject`, unwraps its
+  content CEK under the `_blob` DEK, `refCount += 1`, and skips chunk re-encryption — exactly
+  today's dedup flow plus one AES-KW unwrap.
+- **Crypto-shred at refCount 0.** When the last referencer is erased/deleted (`refCount → 0`),
+  delete the `BlobObject` (the **only** wrapped content CEK) *before/independent of* chunk-byte GC.
+  The chunks become permanently undecryptable the instant that ~40-byte key is gone — even if the
+  chunk bytes linger on a backend that doesn't truly delete. That key-delete IS the shred, mirroring
+  how a record tombstone shreds the body without bulk-deleting backend bytes.
+
+This delivers the approved contract (D1): **erasure is complete when the blob is exclusively the
+subject's** (the common case — `refCount` 1 → `forget()` drops it to 0 → shred), and **correct when
+shared** (`refCount > 1` → the content legitimately persists for its other owner; `forget()` reports
+*shared-content retention*, distinct from un-erasable residue).
+
+### Why NOT a per-referencing-record wrap (design finding)
+
+The intuitive "wrap the content CEK once per referencing record, delete the subject's wrap on
+`forget()`" does **not** work under dedup and is dropped:
+
+1. **Chicken-and-egg for re-uploaders.** A second uploader of identical content needs the *existing*
+   random content CEK to reuse the chunks. Recovering it requires a copy decryptable without the
+   subject's key — i.e. a shared (`_blob`-DEK-wrapped) copy. Once that shared copy exists, per-record
+   wraps add no erasure strength: the shared copy already recovers the key while `refCount > 0`.
+2. **Cryptographic limit.** Truly revoking subject A's access to bytes that subject B still shares
+   would require *re-encrypting all chunks under a new CEK on every refCount decrement* (a blob
+   `rotateRecordCek` analog) — expensive and only meaningful if A cached the key. Standard dedup
+   systems accept that shared content is not per-subject-erasable; we do too, and report it honestly.
+
+So: **one** content CEK per eTag, in the index, shredded at `refCount 0`. (A rotate-on-decrement
+mode can be added later if a deployment ever needs per-subject revocation of shared content.)
+
+## Storage format
+
+`BlobObject` (`types.ts:1492`) gains one optional field:
+
+```ts
+readonly _cek?: string   // base64 AES-KW-wrapped content CEK (wrapped under the _blob DEK)
+```
+
+`_cek` **presence is the discriminant** (same convention as the record envelope): present → chunks
+are under the content CEK (unwrap, then decrypt each chunk); absent → legacy, chunks decrypt directly
+under the `_blob` DEK. Backward-compatible by construction — legacy blobs read unchanged.
+
+`SlotRecord` (`types.ts:1528`) and the chunk AAD (`{eTag}:{i}:{count}`, `blob-set.ts:100`) are
+**unchanged** — the slot still references by `eTag`, and AAD still binds chunk position.
+
+## Write path (`put`, `blob-set.ts:444`)
+
+1. `eTag = HMAC(_blobDEK, plaintext)` — unchanged.
+2. **Dedup hit** (`loadBlobObject(eTag)` exists): unwrap its `_cek` under the `_blob` DEK → content
+   CEK; `refCount += 1`; skip chunk write. (Legacy hit with no `_cek` on a non-erasable path: today's
+   behaviour. On an erasable collection re-uploading a legacy blob: see Migration.)
+3. **Dedup miss, erasable collection:** `cek = generateDEK()`; encrypt each chunk under `cek`;
+   `writeBlobObject({ …, _cek: wrapCek(cek, _blobDEK), refCount: 1 })`.
+4. **Dedup miss, non-erasable collection:** today's path (chunks under `_blob` DEK, no `_cek`).
+
+The content-CEK mode is a property of the **eTag/BlobObject**, fixed at first upload, not of the
+collection — see Interplay (mixed collections).
+
+## Read path (`get`)
+
+`loadBlobObject(eTag)` → if `_cek` present, unwrap under the `_blob` DEK → decrypt each chunk under
+the content CEK; else legacy direct-`_blob`-DEK decrypt. One extra AES-KW unwrap per blob open
+(cache the unwrapped CEK on the in-memory `BlobObject` for the multi-chunk loop).
+
+## Erasure integration (`forget()` + slot delete)
+
+- `forget(subject)` already tombstones the record. **New:** for each shredded record it loads
+  `_blob_slots_{collection}/{id}`, and for each slot `eTag`, `refCount -= 1` (CAS). The slot envelope
+  is dropped (it lived under the collection DEK; removing it severs the link).
+- **At `refCount → 0`:** delete the `BlobObject` (`_blob_index/{eTag}`) — the wrapped content CEK is
+  now unrecoverable → chunks crypto-shredded — then delete the chunk bytes (defense in depth /
+  storage reclaim), reusing the existing GC delete path.
+- **Reporting (D3, recommended):** `ForgetResult` distinguishes
+  - `blobsShredded` — count of eTags taken to refCount 0 and shredded;
+  - `blobsRetainedShared` — eTags still `refCount > 0` (content persists for other owners);
+  - `blobResidueCollections` — now only **non-erasable** (legacy / no-`_cek`) blobs that genuinely
+    cannot be shredded. An all-erasable subject yields an empty residue list.
+
+## Interplay resolutions
+
+1. **eTag / dedup** — unchanged (address vs. encryption key are now distinct: `eTag = HMAC(_blobDEK,·)`
+   addresses; the random content CEK encrypts). Dedup hit cost: +1 AES-KW unwrap.
+2. **Mixed erasable / non-erasable collections sharing one eTag** — the BlobObject's mode is set by
+   the first uploader. A non-erasable collection referencing a content-CEK blob unwraps fine (it holds
+   the `_blob` DEK). An erasable collection referencing a pre-existing **legacy** blob cannot shred it
+   until migrated — reported in `blobResidueCollections`. Document this boundary; do not silently claim
+   erasure.
+3. **Migration** — `_cek`-absent = legacy. A `migrateBlobs` pass (built on the chunk read/write paths)
+   re-encrypts legacy chunks under a fresh content CEK and stamps `_cek`. Until migrated, an erasable
+   collection's legacy blobs are residue, not shreddable.
+4. **Compaction / GC** (`blob-compaction.ts`, `route-store.ts BlobLifecyclePolicy`) — eviction already
+   decrements refCount via `deleteSlot`. The refCount-0 path now *additionally* deletes the BlobObject
+   eagerly (crypto-shred) rather than waiting for `orphanRetentionDays`. `legalHold`/`retainUntil`
+   override shred just as they override eviction.
+5. **export-blobs / bundles** (`export-blobs.ts`, `bundle/`) — exporting a content-CEK blob must carry
+   (or re-wrap) the content CEK so the recipient can decrypt, analogous to the record-CEK
+   `reKeyClosure` rule. Needs explicit coverage.
+
+## Opt-in (D2 — tie to `perRecordKeys`)
+
+No new public knob. A collection with `perRecordKeys: true` (or declared in `withForgetCascade`) gets
+erasable blobs automatically: its `BlobSet.put` mints content CEKs on dedup-miss. Off by default —
+non-adopting collections keep the byte-identical shared-`_blob`-DEK path.
+
+## Build slices
+
+1. **`BlobObject._cek` + content-CEK write/read path + dedup-unwrap**, behind the flag, with the
+   legacy dual-read. Tests: round-trip, dedup reuses the content CEK, legacy blobs still read.
+2. **`forget()` + slot-delete refCount drive + refCount-0 crypto-shred** + the
+   `blobsShredded`/`blobsRetainedShared`/residue reporting split.
+3. **Migration pass** (`migrateBlobs`) + the un-migrated reporting surface.
+4. **Compaction + export/bundle** content-CEK plumbing.
+
+## Acceptance
+
+- A blob attached to a single erasable-collection record is **undecryptable after `forget()`**
+  (BlobObject deleted at refCount 0); the `_blob` DEK and every other blob untouched.
+- Cross-record dedup still holds (a re-uploaded identical blob shares chunks, `refCount` increments).
+- A blob shared by two subjects survives `forget()` of one (`refCount → 1`), reported as retained-shared.
+- A non-erasable collection is byte-for-byte unchanged; a mixed vault reads both.
+- `forget()` reports erasable blobs as shredded/retained, not as un-erasable residue.
+
+## Decisions
+
+1. **Dedup model = envelope-encryption (content CEK per eTag).** Dedup preserved; crypto-shred at
+   refCount 0. *(APPROVED 2026-06-13.)*
+2. **Opt-in = tie to `perRecordKeys` / `withForgetCascade`.** No separate flag. *(APPROVED 2026-06-13.)*
+3. **`forget()` reporting** splits `blobsShredded` / `blobsRetainedShared` / (legacy-only) residue.
+   *(Recommended — confirm.)*
+4. **Per-record wrap dropped** as ineffective under dedup; single content CEK in the index.
+   *(Design finding — see above.)*

--- a/features.yaml
+++ b/features.yaml
@@ -104,6 +104,24 @@ features:
       - 'Host denial — A cannot decrypt B: a CEK sealed for record A presented against record B''s envelope is rejected with SealedRecordMismatchError before any decrypt; only a `perRecordKeys` record has a sealable `_cek` (legacy / non-perRecordKeys → RecordCekNotFoundError, its body stays under the never-exposed collection DEK)'
     related: [encryption, forget-cascade]
 
+  - id: per-blob-cek
+    name: Per-blob content CEK — crypto-shred of blob attachments (forget)
+    cluster: subsystem
+    spec: docs/superpowers/specs/2026-06-13-per-blob-cek-design.md
+    subsystem_doc: docs/core/02-encryption.md
+    package: '@noy-db/hub'
+    factory: null
+    status: planned
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'Dedup-preserving envelope encryption: a blob on a `perRecordKeys` collection mints a per-eTag content CEK, AES-KW-wrapped under the `_blob` DEK and stored on the `BlobObject._cek`; the chunks are encrypted ONCE under that content CEK so cross-record dedup still holds (`eTag = HMAC(_blobDEK, plaintext)` is unchanged — the dedup address — and a re-uploader unwraps the same content CEK and increments refCount without re-encrypting)'
+      - 'Crypto-shred at refCount 0: the BlobObject is the sole recoverable copy of the wrapped content CEK, so deleting it (when the last referencer is erased) makes the chunks permanently undecryptable even if the chunk bytes linger — a key-delete shred, not a bulk-byte delete. While refCount > 1 the content legitimately persists for its other owner (shared content is not per-subject erasable under dedup)'
+      - 'Backward-compatible discriminant: `_cek` absent → legacy blob, chunks decrypt directly under the `_blob` DEK (read unchanged); off by default — non-`perRecordKeys` collections keep the byte-identical shared-`_blob`-DEK path'
+    related: [encryption, forget-cascade, record-scoped-cek-sealing]
+
   - id: stores-contract
     name: 6-method NoydbStore contract
     cluster: core

--- a/packages/hub/__tests__/per-blob-cek.test.ts
+++ b/packages/hub/__tests__/per-blob-cek.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Per-blob content-encryption key (CEK) — slice 1: the content-CEK write/read
+ * path on erasable (`perRecordKeys`) collections (#365).
+ *
+ * Pins the foundation contract before the forget()/refCount-0 shred wiring
+ * (slice 2): erasable blobs encrypt chunks under a per-blob content CEK whose
+ * only recoverable copy is the BlobObject's wrapped `_cek`; dedup is preserved;
+ * legacy (non-erasable) blobs are byte-for-byte unchanged (no `_cek`); and
+ * deleting the BlobObject (the refCount-0 shred primitive) renders the blob
+ * unrecoverable. See docs/superpowers/specs/2026-06-13-per-blob-cek-design.md.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+import { createNoydb } from '../src/noydb.js'
+import { withBlobs } from '../src/blobs/index.js'
+import { BLOB_INDEX_COLLECTION, BLOB_CHUNKS_COLLECTION } from '../src/blobs/blob-set.js'
+
+function makeStore(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function bucket(vault: string, coll: string) {
+    let v = store.get(vault)
+    if (!v) { v = new Map(); store.set(vault, v) }
+    let c = v.get(coll)
+    if (!c) { c = new Map(); v.set(coll, c) }
+    return c
+  }
+  return {
+    name: 'memory',
+    async get(vault, coll, id) { return bucket(vault, coll).get(id) ?? null },
+    async put(vault, coll, id, env, ev) {
+      const b = bucket(vault, coll)
+      const ex = b.get(id)
+      if (ev !== undefined && (ex?._v ?? 0) !== ev) throw new ConflictError(ex?._v ?? 0)
+      b.set(id, env)
+    },
+    async delete(vault, coll, id) { bucket(vault, coll).delete(id) },
+    async list(vault, coll) { return [...bucket(vault, coll).keys()] },
+    async loadAll(vault) {
+      const v = store.get(vault)
+      const snap: VaultSnapshot = {}
+      if (v) for (const [n, c] of v) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of c) r[id] = e; snap[n] = r }
+      return snap
+    },
+    async saveAll(vault, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const b = bucket(vault, n)
+        for (const [id, e] of Object.entries(recs)) b.set(id, e)
+      }
+    },
+  }
+}
+
+const VAULT = 'v'
+const SECRET = 'correct-horse-battery-staple-long-enough'
+const bytes = (s: string) => new TextEncoder().encode(s)
+
+describe('per-blob CEK (slice 1: content-CEK write/read path)', () => {
+  let store: NoydbStore
+  beforeEach(() => { store = makeStore() })
+
+  it('erasable collection: blob round-trips and the BlobObject carries a wrapped _cek', async () => {
+    const db = await createNoydb({ store, user: 'a', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const invoices = vault.collection<{ ref: string }>('invoices', { perRecordKeys: true })
+    await invoices.put('inv-1', { ref: 'A' })
+
+    const slot = invoices.blob('inv-1')
+    await slot.put('receipt.pdf', bytes('sensitive subject data'))
+
+    expect(new TextDecoder().decode((await slot.get('receipt.pdf'))!)).toBe('sensitive subject data')
+    const info = await slot.blobInfo('receipt.pdf')
+    expect(info!._cek).toBeDefined() // chunks are under the per-blob content CEK
+    db.close()
+  })
+
+  it('legacy (non-erasable) collection: blob round-trips with NO _cek (byte-for-byte unchanged)', async () => {
+    const db = await createNoydb({ store, user: 'a', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const invoices = vault.collection<{ ref: string }>('invoices')
+    await invoices.put('inv-1', { ref: 'A' })
+
+    const slot = invoices.blob('inv-1')
+    await slot.put('receipt.pdf', bytes('ordinary attachment'))
+
+    expect(new TextDecoder().decode((await slot.get('receipt.pdf'))!)).toBe('ordinary attachment')
+    const info = await slot.blobInfo('receipt.pdf')
+    expect(info!._cek).toBeUndefined()
+    db.close()
+  })
+
+  it('dedup preserved on erasable: identical content shares one chunk set + one content CEK, refCount 2', async () => {
+    const db = await createNoydb({ store, user: 'a', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const docs = vault.collection<{ ref: string }>('docs', { perRecordKeys: true })
+    await docs.put('d-1', { ref: 'A' })
+    await docs.put('d-2', { ref: 'B' })
+
+    const content = bytes('shared content across two subjects')
+    await docs.blob('d-1').put('f.bin', content)
+    await docs.blob('d-2').put('f.bin', content)
+
+    const a = await docs.blob('d-1').blobInfo('f.bin')
+    const b = await docs.blob('d-2').blobInfo('f.bin')
+    expect(a!.eTag).toBe(b!.eTag)        // same content → same dedup address
+    expect(a!._cek).toBe(b!._cek)        // same shared content CEK (one BlobObject)
+    expect(a!.refCount).toBe(2)
+    // one physical chunk set
+    const chunkIds = await store.list(VAULT, BLOB_CHUNKS_COLLECTION)
+    expect(new Set(chunkIds.map((id) => id.slice(0, 64))).size).toBe(1)
+    // both decrypt the same plaintext
+    expect(new TextDecoder().decode((await docs.blob('d-1').get('f.bin'))!)).toBe('shared content across two subjects')
+    expect(new TextDecoder().decode((await docs.blob('d-2').get('f.bin'))!)).toBe('shared content across two subjects')
+    db.close()
+  })
+
+  it('shred primitive: deleting the BlobObject renders an erasable blob unrecoverable', async () => {
+    const db = await createNoydb({ store, user: 'a', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const docs = vault.collection<{ ref: string }>('docs', { perRecordKeys: true })
+    await docs.put('d-1', { ref: 'A' })
+
+    const slot = docs.blob('d-1')
+    await slot.put('f.bin', bytes('to be shredded'))
+    const eTag = (await slot.blobInfo('f.bin'))!.eTag
+
+    // Simulate the refCount-0 crypto-shred: drop the BlobObject (sole holder of
+    // the wrapped content CEK). The chunk bytes may linger, but without the CEK
+    // they are permanently undecryptable → get() yields null.
+    await store.delete(VAULT, BLOB_INDEX_COLLECTION, eTag)
+
+    expect(await slot.get('f.bin')).toBeNull()
+    db.close()
+  })
+})

--- a/packages/hub/src/blobs/blob-set.ts
+++ b/packages/hub/src/blobs/blob-set.ts
@@ -17,7 +17,9 @@ import {
   decryptBytesWithAAD,
   bufferToBase64,
   base64ToBuffer,
+  generateDEK,
 } from '../crypto.js'
+import { wrapCek, unwrapCek } from '../record-keys/index.js'
 import { ConflictError, NotFoundError } from '../errors.js'
 import { detectMagic, isPreCompressed } from './mime-magic.js'
 
@@ -140,6 +142,7 @@ export class BlobSet {
   private readonly encrypted: boolean
   private readonly userId: string | undefined
   private readonly maxBlobBytes: number | undefined
+  private readonly erasableBlobs: boolean
 
   constructor(opts: {
     store: NoydbStore
@@ -150,6 +153,7 @@ export class BlobSet {
     encrypted: boolean
     userId?: string
     maxBlobBytes?: number
+    erasableBlobs?: boolean
   }) {
     this.store = opts.store
     this.vault = opts.vault
@@ -159,6 +163,22 @@ export class BlobSet {
     this.encrypted = opts.encrypted
     this.userId = opts.userId
     this.maxBlobBytes = opts.maxBlobBytes
+    this.erasableBlobs = opts.erasableBlobs === true
+  }
+
+  /**
+   * Resolve the key the blob's CHUNKS are encrypted under.
+   *
+   * - `_cek` present (erasable blob) → unwrap the per-blob content CEK under
+   *   the `_blob` DEK. Deleting the BlobObject (at `refCount → 0`) makes this
+   *   key unrecoverable → the chunks are crypto-shredded.
+   * - `_cek` absent (legacy) → the `_blob` DEK encrypts chunks directly.
+   * - unencrypted vault → `null` (chunks stored as plaintext base64).
+   */
+  private async resolveChunkKey(blob: Pick<BlobObject, '_cek'>): Promise<CryptoKey | null> {
+    if (!this.encrypted) return null
+    const blobDEK = await this.getDEK(BLOB_COLLECTION)
+    return blob._cek !== undefined ? await unwrapCek(blob._cek, blobDEK) : blobDEK
   }
 
   /** The internal collection that holds slot metadata for this collection's blobs. */
@@ -410,11 +430,13 @@ export class BlobSet {
   // ─── Fetch all chunks for a blob ──────────────────────────────────
 
   private async fetchAllChunks(blob: BlobObject): Promise<Uint8Array> {
-    const blobDEK = this.encrypted ? await this.getDEK(BLOB_COLLECTION) : null
+    // Chunks are keyed under the per-blob content CEK (erasable) or directly
+    // under the `_blob` DEK (legacy) — resolveChunkKey discriminates on `_cek`.
+    const chunkKey = await this.resolveChunkKey(blob)
     const chunks: Uint8Array[] = []
 
     for (let i = 0; i < blob.chunkCount; i++) {
-      const chunk = await this.readChunk(blob.eTag, i, blob.chunkCount, blobDEK)
+      const chunk = await this.readChunk(blob.eTag, i, blob.chunkCount, chunkKey)
       if (!chunk) {
         throw new NotFoundError(
           `Blob chunk ${i}/${blob.chunkCount} missing for eTag "${blob.eTag}" on record "${this.recordId}"`,
@@ -469,7 +491,9 @@ export class BlobSet {
     const existingBlob = await this.loadBlobObject(eTag)
 
     if (existingBlob) {
-      // eTag already exists — just increment refCount (CAS retry)
+      // eTag already exists — just increment refCount (CAS retry). Dedup is
+      // preserved across the content-CEK split: the chunks (and the BlobObject's
+      // `_cek`, if any) are reused as-is; a new referencer never re-encrypts.
       await this.casUpdateRefCount(eTag, +1)
     } else {
       // Step 4 — compress
@@ -480,13 +504,26 @@ export class BlobSet {
       const chunkSize = this.effectiveChunkSize(opts)
       const chunkCount = Math.max(1, Math.ceil(compressed.byteLength / chunkSize))
 
+      // Erasable collection (`perRecordKeys`): mint a fresh per-blob content
+      // CEK and encrypt the chunks under it instead of the shared `_blob` DEK,
+      // so the BlobObject's wrapped `_cek` is the sole recoverable copy → a
+      // refCount-0 delete crypto-shreds the chunks. `eTag` (the dedup address)
+      // is still keyed off the `_blob` DEK, unchanged.
+      let chunkKey = blobDEK
+      let wrappedCek: string | undefined
+      if (blobDEK && this.erasableBlobs) {
+        const contentCek = await generateDEK()
+        wrappedCek = await wrapCek(contentCek, blobDEK)
+        chunkKey = contentCek
+      }
+
       // Step 5 — write chunks FIRST with AAD binding (safe failure order)
       for (let i = 0; i < chunkCount; i++) {
         const start = i * chunkSize
         await this.writeChunk(
           eTag, i, chunkCount,
           compressed.subarray(start, start + chunkSize),
-          blobDEK,
+          chunkKey,
         )
       }
 
@@ -501,6 +538,7 @@ export class BlobSet {
         ...(mimeType !== undefined ? { mimeType } : {}),
         createdAt: new Date().toISOString(),
         refCount: 1,
+        ...(wrappedCek !== undefined ? { _cek: wrappedCek } : {}),
       })
     }
 

--- a/packages/hub/src/blobs/strategy.ts
+++ b/packages/hub/src/blobs/strategy.ts
@@ -30,6 +30,13 @@ export interface BlobStrategyOpenArgs {
   readonly getDEK: (collectionName: string) => Promise<CryptoKey>
   readonly encrypted: boolean
   readonly userId: string
+  /**
+   * Collection opts into per-record keys (`perRecordKeys`), so its blobs are
+   * erasable: new uploads mint a per-blob content CEK (crypto-shreddable at
+   * `refCount → 0`). Off → legacy shared-`_blob`-DEK chunks. See the per-blob
+   * CEK design spec.
+   */
+  readonly erasableBlobs?: boolean
 }
 
 /**

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -3343,6 +3343,7 @@ export class Collection<T> {
       getDEK: this.getDEK,
       encrypted: this.encrypted,
       userId: this.keyring.userId,
+      erasableBlobs: this.perRecordCek,
     })
   }
 

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -1509,6 +1509,16 @@ export interface BlobObject {
   /** Live reference count — slots + published versions pointing to this blob. */
   readonly refCount: number
   /**
+   * Base64 AES-KW-wrapped per-blob **content CEK** (wrapped under the `_blob`
+   * DEK). Present on erasable-collection blobs (`perRecordKeys`): the chunks
+   * are encrypted under this content CEK rather than directly under the `_blob`
+   * DEK, so deleting this BlobObject at `refCount → 0` crypto-shreds the chunks
+   * (they become permanently undecryptable). Absent → legacy blob, chunks
+   * decrypt directly under the `_blob` DEK (read unchanged). See
+   * docs/superpowers/specs/2026-06-13-per-blob-cek-design.md.
+   */
+  readonly _cek?: string
+  /**
    * Hint indicating which store holds the chunk data.
    * Used by `routeStore` size-tiered routing: `'default'` for small blobs
    * stored inline (e.g. DynamoDB), `'blobs'` for large blobs in the overflow


### PR DESCRIPTION
Foundation slice of **per-blob crypto-shred** (#365) — the last deferred slice of the per-record CEK epic (#357). Closes `forget()`'s `blobResidueCollections` gap for erasable collections.

**Design-of-record:** `docs/superpowers/specs/2026-06-13-per-blob-cek-design.md` (in this PR). Approved decisions: **dedup-preserving envelope encryption** + **opt-in tied to `perRecordKeys`/`withForgetCascade`**. Registered in `features.yaml` as `per-blob-cek` (status: `planned`).

## The idea

Blobs use a vault-wide `_blob` DEK, so a record shred can't erase its attachments. This introduces a **per-eTag content CEK**: chunks are encrypted once under a content CEK (dedup preserved), the CEK is AES-KW-wrapped under the `_blob` DEK and stored on `BlobObject._cek`. The BlobObject is the *sole* recoverable copy of that key → deleting it at `refCount → 0` (slice 2) crypto-shreds the chunks even if the bytes linger.

> **Design finding (in the spec):** a per-*record* wrap doesn't work under dedup (chicken-and-egg for re-uploaders) and adds no erasure strength while content is shared. One content CEK per eTag, shredded at refCount 0, delivers the approved contract: complete erasure when the blob is exclusively the subject's; shared content survives for its other owner.

## This slice — content-CEK write/read path (behind `perRecordKeys`)

- `BlobObject._cek` optional field; **presence is the discriminant** (legacy blobs have none → read unchanged).
- **Write (`put`):** dedup-MISS on an erasable collection mints a content CEK, encrypts chunks under it, stamps the wrapped CEK. `eTag` (HMAC under `_blob` DEK) is unchanged → dedup-HIT reuses chunks + CEK and just `refCount += 1` (no cross-record re-encryption).
- **Read:** `resolveChunkKey()` unwraps `_cek` under the `_blob` DEK when present, else legacy direct-`_blob`-DEK.
- `erasableBlobs` threaded `Collection.blob()` → `BlobStrategyOpenArgs` → `BlobSet` (= the collection's `perRecordCek` flag).

## Out of scope (next slices, per the spec)

2. `forget()` wiring + refCount-0 crypto-shred + the `blobsShredded`/`blobsRetainedShared`/residue reporting split.
3. Migration pass for legacy blobs on a newly-erasable collection.
4. Compaction + export/bundle content-CEK plumbing.

## Verification
- ✅ Full hub suite: 262 files, **2526 tests** (no regressions; existing blob/dedup tests unchanged)
- ✅ 4 new unit tests: erasable round-trip + `_cek` stamped, legacy no-`_cek`, dedup preserved (shared eTag/CEK/refCount 2), shred primitive (delete BlobObject → unrecoverable)
- ✅ `validate:features` + architecture + typecheck clean