### PR TITLE
feat(hub): per-blob CEK — forget() crypto-shred + reporting split (#365 slice 2)

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -111,7 +111,7 @@ features:
     subsystem_doc: docs/core/02-encryption.md
     package: '@noy-db/hub'
     factory: null
-    status: planned
+    status: preview
     showcases: []
     recipes: []
     playground_pages: []

--- a/packages/hub/__tests__/per-blob-cek.test.ts
+++ b/packages/hub/__tests__/per-blob-cek.test.ts
@@ -14,6 +14,8 @@ import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.
 import { ConflictError } from '../src/errors.js'
 import { createNoydb } from '../src/noydb.js'
 import { withBlobs } from '../src/blobs/index.js'
+import { withHistory } from '../src/history/index.js'
+import { withForgetCascade } from '../src/forget/index.js'
 import { BLOB_INDEX_COLLECTION, BLOB_CHUNKS_COLLECTION } from '../src/blobs/blob-set.js'
 
 function makeStore(): NoydbStore {
@@ -130,6 +132,64 @@ describe('per-blob CEK (slice 1: content-CEK write/read path)', () => {
     await store.delete(VAULT, BLOB_INDEX_COLLECTION, eTag)
 
     expect(await slot.get('f.bin')).toBeNull()
+    db.close()
+  })
+})
+
+describe('per-blob CEK (slice 2: forget() crypto-shred)', () => {
+  let store: NoydbStore
+  beforeEach(() => { store = makeStore() })
+
+  type Inv = { id: string; buyerId: string }
+  const setup = () => createNoydb({
+    store, user: 'a', secret: SECRET,
+    blobStrategy: withBlobs(),
+    historyStrategy: withHistory(),
+    forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+  })
+
+  it('forget() crypto-shreds a subject-exclusive blob (refCount 0) and reports it', async () => {
+    const db = await setup()
+    const vault = await db.openVault(VAULT)
+    const invoices = vault.collection<Inv>('invoices') // forced perRecordKeys by cascade
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1' })
+    await invoices.blob('i-1').put('contract.pdf', bytes('buyer-1 personal data'))
+    const eTag = (await invoices.blob('i-1').blobInfo('contract.pdf'))!.eTag
+
+    const result = await vault.forget('buyer-1')
+
+    expect(result.blobsShredded).toBe(1)
+    expect(result.blobsRetainedShared).toBe(0)
+    expect(result.blobResidueCollections).toEqual([]) // gap closed
+    // BlobObject + chunks gone; slot map severed.
+    expect(await store.get(VAULT, BLOB_INDEX_COLLECTION, eTag)).toBeNull()
+    expect(await store.list(VAULT, BLOB_CHUNKS_COLLECTION)).toEqual([])
+    db.close()
+  })
+
+  it('forget() retains a blob still shared by another subject, shreds it when the last owner is forgotten', async () => {
+    const db = await setup()
+    const vault = await db.openVault(VAULT)
+    const invoices = vault.collection<Inv>('invoices')
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1' })
+    await invoices.put('i-2', { id: 'i-2', buyerId: 'buyer-2' })
+    const shared = bytes('identical shared attachment')
+    await invoices.blob('i-1').put('f.pdf', shared)
+    await invoices.blob('i-2').put('f.pdf', shared)
+    const eTag = (await invoices.blob('i-1').blobInfo('f.pdf'))!.eTag
+
+    // Forget buyer-1: content is still buyer-2's → retained, not shredded.
+    const r1 = await vault.forget('buyer-1')
+    expect(r1.blobsRetainedShared).toBe(1)
+    expect(r1.blobsShredded).toBe(0)
+    expect(await store.get(VAULT, BLOB_INDEX_COLLECTION, eTag)).not.toBeNull()
+    expect(new TextDecoder().decode((await invoices.blob('i-2').get('f.pdf'))!))
+      .toBe('identical shared attachment') // buyer-2 still reads it
+
+    // Forget buyer-2 (last owner) → crypto-shred.
+    const r2 = await vault.forget('buyer-2')
+    expect(r2.blobsShredded).toBe(1)
+    expect(await store.get(VAULT, BLOB_INDEX_COLLECTION, eTag)).toBeNull()
     db.close()
   })
 })

--- a/packages/hub/src/blobs/blob-set.ts
+++ b/packages/hub/src/blobs/blob-set.ts
@@ -314,7 +314,7 @@ export class BlobSet {
   /**
    * CAS retry loop for refCount changes on a BlobObject.
    */
-  private async casUpdateRefCount(eTag: string, delta: number): Promise<void> {
+  private async casUpdateRefCount(eTag: string, delta: number): Promise<number> {
     for (let attempt = 0; attempt < MAX_CAS_RETRIES; attempt++) {
       const result = await this.loadBlobObject(eTag)
       if (!result) throw new NotFoundError(`BlobObject ${eTag} not found`)
@@ -322,12 +322,73 @@ export class BlobSet {
       const updated: BlobObject = { ...blob, refCount: blob.refCount + delta }
       try {
         await this.writeBlobObject(updated, version)
-        return
+        return updated.refCount
       } catch (err) {
         if (err instanceof ConflictError && attempt < MAX_CAS_RETRIES - 1) continue
         throw err
       }
     }
+    throw new ConflictError(-1) // exhausted retries
+  }
+
+  /**
+   * Crypto-shred this record's blob attachments (#365 slice 2) — called by
+   * `vault.forget()`.
+   *
+   * For each distinct eTag the record references (a record may attach the same
+   * content under several slot names → several refCount holds): decrement the
+   * blob's refCount by that many. When it reaches 0:
+   *  - **erasable blob** (`_cek` present) → delete the `BlobObject` (the SOLE
+   *    recoverable copy of the wrapped content CEK → chunks permanently
+   *    undecryptable) and reclaim the chunk bytes. This is the crypto-shred.
+   *  - **legacy blob** (no `_cek`) → chunks are under the shared `_blob` DEK and
+   *    stay decryptable until byte-deleted; we delete the orphaned chunks +
+   *    index but report it as residue, not a cryptographic erasure.
+   * When refCount stays > 0 the content legitimately persists for its other
+   * owner — reported as `retainedShared` (or `residue` if legacy).
+   *
+   * Finally drops the record's slot map, severing the subject's link.
+   */
+  async shredAllForRecord(): Promise<{
+    shredded: string[]
+    retainedShared: string[]
+    residue: string[]
+  }> {
+    const { slots } = await this.loadSlots()
+    const slotNames = Object.keys(slots)
+    const shredded: string[] = []
+    const retainedShared: string[] = []
+    const residue: string[] = []
+    if (slotNames.length === 0) return { shredded, retainedShared, residue }
+
+    // Reference count from THIS record per eTag.
+    const holds = new Map<string, number>()
+    for (const name of slotNames) {
+      const eTag = slots[name]!.eTag
+      holds.set(eTag, (holds.get(eTag) ?? 0) + 1)
+    }
+
+    for (const [eTag, n] of holds) {
+      const loaded = await this.loadBlobObject(eTag)
+      if (!loaded) continue // already gone
+      const erasable = loaded.blob._cek !== undefined
+      const remaining = await this.casUpdateRefCount(eTag, -n)
+      if (remaining > 0) {
+        ;(erasable ? retainedShared : residue).push(eTag)
+        continue
+      }
+      // refCount hit 0 — reclaim. For erasable blobs the index delete IS the
+      // crypto-shred (the wrapped CEK is gone); chunk delete reclaims storage.
+      await this.store.delete(this.vault, BLOB_INDEX_COLLECTION, eTag)
+      for (let i = 0; i < loaded.blob.chunkCount; i++) {
+        await this.store.delete(this.vault, BLOB_CHUNKS_COLLECTION, `${eTag}_${i}`)
+      }
+      ;(erasable ? shredded : residue).push(eTag)
+    }
+
+    // Sever the subject's link: drop the record's slot map.
+    await this.store.delete(this.vault, this.slotsCollection, this.recordId)
+    return { shredded, retainedShared, residue }
   }
 
   // ─── Chunk I/O (with AAD binding) ─────────────────────────────────

--- a/packages/hub/src/forget/strategy.ts
+++ b/packages/hub/src/forget/strategy.ts
@@ -85,10 +85,15 @@ export function withForgetCascade(opts: SubjectDeclaration): ForgetStrategy {
  * collection DEK — so erasure-completeness is NOT guaranteed for them. Run
  * the per-record-CEK migration pass, then re-forget, to close the gap.
  *
- * `blobResidueCollections` lists collections where a shredded record still
- * has blob attachments — blob content is keyed off a separate vault-wide
- * `_blob` DEK and is OUT OF SCOPE for record-CEK shred (foundation decision
- * #5). The caller must erase those blobs through a future blob-shred slice.
+ * Blob attachments (#365): a shredded record's **erasable** blobs (on a
+ * `perRecordKeys` collection) are crypto-shredded inline — `blobsShredded`
+ * counts those taken to refCount 0 (BlobObject deleted → chunks permanently
+ * undecryptable), `blobsRetainedShared` counts those still referenced by
+ * another record (shared content legitimately persists for its other owner).
+ * `blobResidueCollections` now lists only collections with blobs that could
+ * NOT be crypto-shredded: **legacy** blobs (no per-blob `_cek`, chunks under
+ * the shared `_blob` DEK — migrate them), or a session without the blob
+ * subsystem loaded. An all-erasable subject yields an empty residue list.
  */
 export interface ForgetResult {
   /** The subject id passed to `forget()`. Echoed for caller convenience. */
@@ -101,7 +106,11 @@ export interface ForgetResult {
   readonly collections: readonly string[]
   /** `collection:id` pairs shredded while still un-migrated (see type docs). */
   readonly unmigratedRecords: readonly string[]
-  /** Collections where a shredded record still has un-erased blob attachments. */
+  /** Count of erasable blobs crypto-shredded (refCount → 0, BlobObject deleted). */
+  readonly blobsShredded: number
+  /** Count of erasable blobs retained because still referenced elsewhere (shared). */
+  readonly blobsRetainedShared: number
+  /** Collections with blobs that could NOT be crypto-shredded — legacy (no `_cek`) or blobs disabled (see type docs). */
   readonly blobResidueCollections: readonly string[]
   /** The single `op:'forget'` ledger entry appended for this erasure. */
   readonly ledgerEntry: LedgerEntry

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -2209,6 +2209,9 @@ export class Vault {
     const collections = new Set<string>()
     const unmigratedRecords: string[] = []
     const blobResidueCollections = new Set<string>()
+    let blobsShredded = 0
+    let blobsRetainedShared = 0
+    const blobsEnabled = this.blobStrategy !== undefined
     const actor = this.keyring.userId
 
     for (const ref of refs) {
@@ -2237,15 +2240,25 @@ export class Vault {
         this.adapter, this.name, ref.collection, ref.id, actor,
       )
 
-      // Blob residue: a shredded record may still have blob attachments,
-      // tracked in `_blob_slots_{collection}` keyed by record id. Those are
-      // keyed off the separate `_blob` DEK and out of scope for record-CEK
-      // shred (foundation decision #5) — surface them loudly.
-      try {
-        const slotIds = await this.adapter.list(this.name, `_blob_slots_${ref.collection}`)
-        if (slotIds.includes(ref.id)) blobResidueCollections.add(ref.collection)
-      } catch {
-        // No blob-slots collection for this collection — nothing to report.
+      // Blob attachments (#365): crypto-shred the record's erasable blobs.
+      // An erasable blob's chunks are under a per-blob content CEK whose only
+      // copy is the BlobObject's wrapped `_cek`; deleting it at refCount 0
+      // shreds the content. Legacy blobs (no `_cek`) or a session without the
+      // blob subsystem cannot be shredded → reported as residue.
+      if (blobsEnabled) {
+        const r = await this.collection<Record<string, unknown>>(ref.collection)
+          .blob(ref.id)
+          .shredAllForRecord()
+        blobsShredded += r.shredded.length
+        blobsRetainedShared += r.retainedShared.length
+        if (r.residue.length > 0) blobResidueCollections.add(ref.collection)
+      } else {
+        try {
+          const slotIds = await this.adapter.list(this.name, `_blob_slots_${ref.collection}`)
+          if (slotIds.includes(ref.id)) blobResidueCollections.add(ref.collection)
+        } catch {
+          // No blob-slots collection for this collection — nothing to report.
+        }
       }
 
       // Drop the (now-shredded) ref from the subject index.
@@ -2275,6 +2288,8 @@ export class Vault {
         historyVersionsShredded,
         collections: [...collections],
         unmigratedCount: unmigratedRecords.length,
+        blobsShredded,
+        blobsRetainedShared,
         blobResidueCollections: [...blobResidueCollections],
       }),
     })
@@ -2285,6 +2300,8 @@ export class Vault {
       historyVersionsShredded,
       collections: [...collections],
       unmigratedRecords,
+      blobsShredded,
+      blobsRetainedShared,
       blobResidueCollections: [...blobResidueCollections],
       ledgerEntry,
     }

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -488,7 +488,13 @@ const KERNEL_SURFACE_BUDGET = {
   // rotateRecordCek) moved to src/record-keys/sealing.ts behind a SealingContext
   // deps interface; vault retains thin delegating methods + a sealingContext()
   // builder. The host-side opener stays DEK-free in src/sealed-record/.
-  'packages/hub/src/vault.ts': 4195,
+  // Bumped 4195→4210 (2026-06-13): #365 slice 2 — forget() now crypto-shreds a
+  // shredded record's erasable blobs inline (BlobSet.shredAllForRecord per ref)
+  // and reports blobsShredded / blobsRetainedShared. This is core erasure
+  // orchestration — it must sequence with the per-record tombstone + the single
+  // op:'forget' ledger entry, so it cannot move onto the bus. The blob refCount/
+  // crypto-shred mechanics live in src/blobs/blob-set.ts.
+  'packages/hub/src/vault.ts': 4210,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),


### PR DESCRIPTION
Slice 2 of per-blob crypto-shred (#365). Builds on slice 1 (#366, merged). **This is the slice that makes `forget()` actually erase blob attachments** — closing the `blobResidueCollections` gap for erasable collections.

## Changes

**`BlobSet.shredAllForRecord()`** — per distinct eTag the record references (a record may attach the same content under several slots → several refCount holds): decrement refCount by the hold count; at **refCount 0**, delete the BlobObject (the sole copy of the wrapped content CEK → chunks permanently undecryptable — the crypto-shred) and reclaim the chunk bytes; then drop the record's slot map. Classifies each eTag:
- `shredded` — refCount 0, had `_cek` (crypto-shredded)
- `retainedShared` — still referenced by another record (shared content persists for its other owner)
- `residue` — legacy (no `_cek`), not crypto-shreddable

(`casUpdateRefCount` now returns the new count.)

**`vault.forget()`** — replaces the "surface residue loudly" block with the inline shred when the blob subsystem is enabled (`this.blobStrategy` set); falls back to the old residue detection when blobs are disabled (so a record's blobs can't be silently missed).

**`ForgetResult`** — gains `blobsShredded` + `blobsRetainedShared`; `blobResidueCollections` now means **legacy-or-disabled only**. Ledger `reason` records the new counts.

## The shared-content contract (verified)

A blob shared by two subjects is **not** per-subject erasable under dedup — `forget(buyer-1)` retains it (refCount → 1, buyer-2 still reads it), and only `forget(buyer-2)` (the last owner) crypto-shreds it. This is the correct, honest behaviour for content-addressed dedup, and exactly the contract approved in the design.

## Kernel surface

`vault.ts` 4195 → **4210** (justified): `forget()` is the erasure orchestrator — the blob shred must sequence with the per-record tombstone + the single `op:'forget'` ledger entry, so it can't move onto the bus. The refCount/crypto-shred mechanics live in `src/blobs/blob-set.ts`.

`features.yaml`: `per-blob-cek` → `preview` (core erasure now functional behind the flag).

## Out of scope (remaining slices)
3. Migration pass for legacy blobs on a newly-erasable collection (today they're reported as residue).
4. Compaction + export/bundle content-CEK plumbing.

## Verification
- ✅ Full hub suite: 262 files, **2528 tests** (no regressions; existing `forget` group-5 residue test still passes via the blobs-disabled fallback)
- ✅ 2 new e2e tests: exclusive blob shredded (`blobsShredded:1`, empty residue, BlobObject + chunks gone); shared blob retained then shredded at last owner
- ✅ `validate:features` + architecture + typecheck clean