### PR TITLE
feat(hub): per-blob CEK — legacy-blob migration pass (#365 slice 3)

### DIFF
--- a/docs/superpowers/specs/2026-06-13-per-blob-cek-design.md
+++ b/docs/superpowers/specs/2026-06-13-per-blob-cek-design.md
@@ -113,9 +113,15 @@ the content CEK; else legacy direct-`_blob`-DEK decrypt. One extra AES-KW unwrap
    the `_blob` DEK). An erasable collection referencing a pre-existing **legacy** blob cannot shred it
    until migrated — reported in `blobResidueCollections`. Document this boundary; do not silently claim
    erasure.
-3. **Migration** — `_cek`-absent = legacy. A `migrateBlobs` pass (built on the chunk read/write paths)
-   re-encrypts legacy chunks under a fresh content CEK and stamps `_cek`. Until migrated, an erasable
-   collection's legacy blobs are residue, not shreddable.
+3. **Migration** — `_cek`-absent = legacy. `BlobSet.migrate()` (explicit maintenance pass, mirrors the
+   record-CEK posture) re-encrypts a record's legacy chunks **in place** under a fresh content CEK and
+   stamps `_cek`, preserving the eTag/chunkCount/chunkSize/compression. Crash-safe + idempotent via a
+   transient **`_cekPending`** field: (1) persist the wrapped content CEK in `_cekPending` (readers
+   ignore it → blob stays readable under the `_blob` DEK, and the key survives a crash → no data loss);
+   (2) re-encrypt each chunk under the content CEK (a resume reads an already-migrated chunk under the
+   content CEK, else the `_blob` DEK); (3) promote `_cekPending` → `_cek` (atomic flip). Until migrated,
+   an erasable collection's legacy blobs are reported as residue, not shreddable. Adopting the cascade
+   on existing data also needs `vault.rebuildSubjectIndex()` so pre-adoption records are discoverable.
 4. **Compaction / GC** (`blob-compaction.ts`, `route-store.ts BlobLifecyclePolicy`) — eviction already
    decrements refCount via `deleteSlot`. The refCount-0 path now *additionally* deletes the BlobObject
    eagerly (crypto-shred) rather than waiting for `orphanRetentionDays`. `legalHold`/`retainUntil`

--- a/packages/hub/__tests__/per-blob-cek.test.ts
+++ b/packages/hub/__tests__/per-blob-cek.test.ts
@@ -193,3 +193,73 @@ describe('per-blob CEK (slice 2: forget() crypto-shred)', () => {
     db.close()
   })
 })
+
+describe('per-blob CEK (slice 3: migration of legacy blobs)', () => {
+  let store: NoydbStore
+  beforeEach(() => { store = makeStore() })
+
+  it('migrate() re-keys a legacy blob to a content CEK, preserving readability', async () => {
+    const db = await createNoydb({ store, user: 'a', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const docs = vault.collection<{ id: string }>('docs') // legacy: no perRecordKeys
+    await docs.put('d-1', { id: 'd-1' })
+    await docs.blob('d-1').put('f.bin', bytes('legacy attachment bytes'))
+    expect((await docs.blob('d-1').blobInfo('f.bin'))!._cek).toBeUndefined()
+
+    const r = await docs.blob('d-1').migrate()
+    expect(r.migrated).toHaveLength(1)
+    // Now erasable, and still decrypts to the same bytes.
+    expect((await docs.blob('d-1').blobInfo('f.bin'))!._cek).toBeDefined()
+    expect(new TextDecoder().decode((await docs.blob('d-1').get('f.bin'))!)).toBe('legacy attachment bytes')
+    db.close()
+  })
+
+  it('migrate() is idempotent — a second pass reports already-erasable, no change', async () => {
+    const db = await createNoydb({ store, user: 'a', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const docs = vault.collection<{ id: string }>('docs')
+    await docs.put('d-1', { id: 'd-1' })
+    await docs.blob('d-1').put('f.bin', bytes('x'))
+
+    await docs.blob('d-1').migrate()
+    const cek1 = (await docs.blob('d-1').blobInfo('f.bin'))!._cek
+    const r2 = await docs.blob('d-1').migrate()
+    expect(r2.migrated).toEqual([])
+    expect(r2.alreadyErasable).toHaveLength(1)
+    expect((await docs.blob('d-1').blobInfo('f.bin'))!._cek).toBe(cek1) // unchanged
+    db.close()
+  })
+
+  it('a migrated legacy blob becomes crypto-shreddable by forget() (cross-session adoption)', async () => {
+    // Session 1: plain collection, legacy blob (no _cek).
+    const db1 = await createNoydb({ store, user: 'a', secret: SECRET, blobStrategy: withBlobs() })
+    const v1 = await db1.openVault(VAULT)
+    const c1 = v1.collection<{ id: string; sub: string }>('docs')
+    await c1.put('d-1', { id: 'd-1', sub: 'subj-1' })
+    await c1.blob('d-1').put('f.bin', bytes('pre-adoption data'))
+    db1.close()
+
+    // Session 2: same store, now with forget cascade (forces perRecordKeys).
+    const db2 = await createNoydb({
+      store, user: 'a', secret: SECRET, blobStrategy: withBlobs(),
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { docs: 'sub' } }),
+    })
+    const v2 = await db2.openVault(VAULT)
+    const c2 = v2.collection<{ id: string; sub: string }>('docs')
+    const eTag = (await c2.blob('d-1').blobInfo('f.bin'))!.eTag
+
+    // Adopting the cascade on existing data: rebuild the subject index so the
+    // pre-adoption record is discoverable by forget().
+    await v2.rebuildSubjectIndex()
+
+    // After migration the legacy blob is crypto-shreddable (before, it would be
+    // reported as residue).
+    await c2.blob('d-1').migrate()
+    const result = await v2.forget('subj-1')
+    expect(result.blobsShredded).toBe(1)
+    expect(result.blobResidueCollections).toEqual([])
+    expect(await store.get(VAULT, BLOB_INDEX_COLLECTION, eTag)).toBeNull()
+    db2.close()
+  })
+})

--- a/packages/hub/src/blobs/blob-set.ts
+++ b/packages/hub/src/blobs/blob-set.ts
@@ -391,6 +391,97 @@ export class BlobSet {
     return { shredded, retainedShared, residue }
   }
 
+  /** CAS retry loop for an arbitrary BlobObject mutation. */
+  private async casUpdateBlobObject(
+    eTag: string,
+    mutate: (blob: BlobObject) => BlobObject,
+  ): Promise<void> {
+    for (let attempt = 0; attempt < MAX_CAS_RETRIES; attempt++) {
+      const result = await this.loadBlobObject(eTag)
+      if (!result) throw new NotFoundError(`BlobObject ${eTag} not found`)
+      try {
+        await this.writeBlobObject(mutate(result.blob), result.version)
+        return
+      } catch (err) {
+        if (err instanceof ConflictError && attempt < MAX_CAS_RETRIES - 1) continue
+        throw err
+      }
+    }
+    throw new ConflictError(-1) // exhausted retries
+  }
+
+  /**
+   * Migrate this record's LEGACY blobs (no `_cek`, chunks under the shared
+   * `_blob` DEK) to per-blob content CEKs so they become crypto-shreddable
+   * (#365 slice 3). Returns the eTags migrated vs. already-erasable.
+   *
+   * **Explicit maintenance pass** (mirrors the record-CEK migration posture):
+   * re-encrypts the existing compressed chunks IN PLACE under a fresh content
+   * CEK — preserving the eTag, chunkCount, chunkSize, and compression — then
+   * flips the `_cek` discriminant. Crash-safe + idempotent via `_cekPending`:
+   *   1. persist the wrapped content CEK in `_cekPending` (readers ignore it →
+   *      the blob stays readable under the `_blob` DEK; the key survives a crash);
+   *   2. re-encrypt each chunk under the content CEK (a resume reads an
+   *      already-migrated chunk under the content CEK, else under the `_blob` DEK);
+   *   3. promote `_cekPending` → `_cek` (atomic flip). Reads now use the CEK.
+   * A re-run after a crash resumes from whichever phase was reached.
+   *
+   * Dedup-safe: migrating a shared blob (refCount > 1) re-keys it for every
+   * referencer at once; a non-erasable collection still reads it (it unwraps
+   * `_cek` under the `_blob` DEK it holds).
+   */
+  async migrate(): Promise<{ migrated: string[]; alreadyErasable: string[] }> {
+    const migrated: string[] = []
+    const alreadyErasable: string[] = []
+    if (!this.encrypted) return { migrated, alreadyErasable }
+
+    const blobDEK = await this.getDEK(BLOB_COLLECTION)
+    const { slots } = await this.loadSlots()
+    const eTags = new Set(Object.values(slots).map((s) => s.eTag))
+
+    for (const eTag of eTags) {
+      const loaded = await this.loadBlobObject(eTag)
+      if (!loaded) continue
+      const blob = loaded.blob
+      if (blob._cek !== undefined) { alreadyErasable.push(eTag); continue }
+
+      // Phase 1 — persist the content CEK (resume reuses an existing pending one).
+      let contentCek: CryptoKey
+      if (blob._cekPending !== undefined) {
+        contentCek = await unwrapCek(blob._cekPending, blobDEK)
+      } else {
+        contentCek = await generateDEK()
+        const wrapped = await wrapCek(contentCek, blobDEK)
+        await this.casUpdateBlobObject(eTag, (b) => ({ ...b, _cekPending: wrapped }))
+      }
+
+      // Phase 2 — re-encrypt each chunk under the content CEK, in place.
+      for (let i = 0; i < blob.chunkCount; i++) {
+        let raw: Uint8Array | null
+        try {
+          raw = await this.readChunk(eTag, i, blob.chunkCount, blobDEK)
+        } catch {
+          // Already re-encrypted under the content CEK (crash resume).
+          raw = await this.readChunk(eTag, i, blob.chunkCount, contentCek)
+        }
+        if (!raw) {
+          throw new NotFoundError(
+            `Blob chunk ${i}/${blob.chunkCount} missing for eTag "${eTag}" during migration`,
+          )
+        }
+        await this.writeChunk(eTag, i, blob.chunkCount, raw, contentCek)
+      }
+
+      // Phase 3 — promote _cekPending → _cek (atomic flip).
+      await this.casUpdateBlobObject(eTag, (b) => {
+        const { _cekPending, ...rest } = b
+        return _cekPending === undefined ? b : { ...rest, _cek: _cekPending }
+      })
+      migrated.push(eTag)
+    }
+    return { migrated, alreadyErasable }
+  }
+
   // ─── Chunk I/O (with AAD binding) ─────────────────────────────────
 
   private async writeChunk(

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -1519,6 +1519,15 @@ export interface BlobObject {
    */
   readonly _cek?: string
   /**
+   * Transient migration marker (#365 slice 3). Present only while a legacy
+   * blob is being migrated to a content CEK: it holds the wrapped content CEK
+   * BEFORE the chunks have been re-encrypted under it. Readers **ignore**
+   * `_cekPending` (they key off `_cek`), so the blob stays readable under the
+   * `_blob` DEK during migration AND the content CEK survives a crash → a
+   * re-run resumes and promotes `_cekPending` → `_cek`. Never set on a settled blob.
+   */
+  readonly _cekPending?: string
+  /**
    * Hint indicating which store holds the chunk data.
    * Used by `routeStore` size-tiered routing: `'default'` for small blobs
    * stored inline (e.g. DynamoDB), `'blobs'` for large blobs in the overflow


### PR DESCRIPTION
Slice 3 of per-blob crypto-shred (#365). Builds on slices 1 (#366) + 2 (#367), both merged. Makes **legacy blobs** (no per-blob `_cek`) crypto-shreddable — for collections that adopt `perRecordKeys` *after* accumulating blobs.

## `BlobSet.migrate()`

Explicit maintenance pass (mirrors the record-CEK migration posture). For each distinct legacy eTag the record references, re-encrypts the existing compressed chunks **in place** under a fresh content CEK — preserving the eTag, chunkCount, chunkSize, and compression — then flips the `_cek` discriminant. Returns `{ migrated, alreadyErasable }` (idempotent — an already-erasable blob is skipped).

## Crash-safe + resumable (the `_cekPending` two-phase flip)

In-place chunk re-encryption has a **data-loss hazard**: if the process dies after overwriting chunks under a new content CEK but before persisting that key, the chunks are orphaned forever. The fix is a transient `BlobObject._cekPending` field:

1. **persist** the wrapped content CEK in `_cekPending` — readers *ignore* it (they key off `_cek`), so the blob stays readable under the `_blob` DEK during migration, and the key survives a crash;
2. **re-encrypt** each chunk under the content CEK (a resume reads an already-migrated chunk under the content CEK, else the `_blob` DEK);
3. **promote** `_cekPending` → `_cek` (atomic flip) — reads now use the content CEK.

A re-run after a crash resumes from whichever phase was reached. No data loss, no read outage.

## Verification
- ✅ Full hub suite: 262 files, **2531 tests** (no regressions)
- ✅ 3 new tests: migrate re-keys + preserves readability; idempotent second pass; **cross-session adoption** (legacy blob created pre-cascade → `rebuildSubjectIndex()` + `migrate()` → `forget()` crypto-shreds it, empty residue)
- ✅ `validate:features` + architecture + typecheck clean

## Remaining (#365)
4. Compaction + export/bundle content-CEK plumbing — the last slice (export/bundle must carry/re-wrap the content CEK so a recipient can decrypt).