### PR TITLE
feat(hub): per-blob CEK — unified eager shred on delete/compaction (#365 slice 4)

### DIFF
--- a/docs/superpowers/specs/2026-06-13-per-blob-cek-design.md
+++ b/docs/superpowers/specs/2026-06-13-per-blob-cek-design.md
@@ -122,13 +122,16 @@ the content CEK; else legacy direct-`_blob`-DEK decrypt. One extra AES-KW unwrap
    content CEK, else the `_blob` DEK); (3) promote `_cekPending` → `_cek` (atomic flip). Until migrated,
    an erasable collection's legacy blobs are reported as residue, not shreddable. Adopting the cascade
    on existing data also needs `vault.rebuildSubjectIndex()` so pre-adoption records are discoverable.
-4. **Compaction / GC** (`blob-compaction.ts`, `route-store.ts BlobLifecyclePolicy`) — eviction already
-   decrements refCount via `deleteSlot`. The refCount-0 path now *additionally* deletes the BlobObject
-   eagerly (crypto-shred) rather than waiting for `orphanRetentionDays`. `legalHold`/`retainUntil`
-   override shred just as they override eviction.
-5. **export-blobs / bundles** (`export-blobs.ts`, `bundle/`) — exporting a content-CEK blob must carry
-   (or re-wrap) the content CEK so the recipient can decrypt, analogous to the record-CEK
-   `reKeyClosure` rule. Needs explicit coverage.
+4. **Compaction / GC** (`blob-compaction.ts`, `route-store.ts BlobLifecyclePolicy`) — eviction
+   decrements refCount via `deleteSlot` → `BlobSet.delete()`. A single reclaim choke point
+   (`releaseRef`) backs every reference-drop path (slot delete/overwrite, published-version delete,
+   `forget()` shred): at refCount 0, **erasable** blobs (`_cek`) are crypto-shredded EAGERLY (GDPR
+   erasure must not wait on `orphanRetentionDays`), while **legacy** blobs keep deferred GC / orphan
+   retention. So compaction eviction of an erasable blob to refCount 0 crypto-shreds it automatically.
+5. **export-blobs / bundles** — `export-blobs.ts` exports **plaintext** via `BlobSet.get()`, which is
+   content-CEK-aware through `resolveChunkKey` (slice 1) → no change needed; the recipient re-imports
+   fresh. Partition **bundles** (`bundle/walk-closure.ts`, `extract-partition.ts`) do NOT include the
+   `_blob_*` storage collections, so blob chunks are out of the partition closure — nothing to re-wrap.
 
 ## Opt-in (D2 — tie to `perRecordKeys`)
 

--- a/packages/hub/__tests__/per-blob-cek.test.ts
+++ b/packages/hub/__tests__/per-blob-cek.test.ts
@@ -263,3 +263,59 @@ describe('per-blob CEK (slice 3: migration of legacy blobs)', () => {
     db2.close()
   })
 })
+
+describe('per-blob CEK (slice 4: eager shred on delete / compaction path)', () => {
+  let store: NoydbStore
+  beforeEach(() => { store = makeStore() })
+
+  it('delete() crypto-shreds an erasable blob at refCount 0 (covers compaction eviction)', async () => {
+    const db = await createNoydb({ store, user: 'a', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const docs = vault.collection<{ id: string }>('docs', { perRecordKeys: true })
+    await docs.put('d-1', { id: 'd-1' })
+    await docs.blob('d-1').put('f.bin', bytes('erasable, single ref'))
+    const eTag = (await docs.blob('d-1').blobInfo('f.bin'))!.eTag
+
+    await docs.blob('d-1').delete('f.bin')
+
+    // BlobObject + chunks gone — the wrapped content CEK is unrecoverable.
+    expect(await store.get(VAULT, BLOB_INDEX_COLLECTION, eTag)).toBeNull()
+    expect(await store.list(VAULT, BLOB_CHUNKS_COLLECTION)).toEqual([])
+    db.close()
+  })
+
+  it('delete() retains a shared erasable blob (refCount > 0) — other owner still reads it', async () => {
+    const db = await createNoydb({ store, user: 'a', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const docs = vault.collection<{ id: string }>('docs', { perRecordKeys: true })
+    await docs.put('d-1', { id: 'd-1' })
+    await docs.put('d-2', { id: 'd-2' })
+    const shared = bytes('shared erasable content')
+    await docs.blob('d-1').put('f.bin', shared)
+    await docs.blob('d-2').put('f.bin', shared)
+    const eTag = (await docs.blob('d-1').blobInfo('f.bin'))!.eTag
+
+    await docs.blob('d-1').delete('f.bin')
+
+    expect(await store.get(VAULT, BLOB_INDEX_COLLECTION, eTag)).not.toBeNull()
+    expect(new TextDecoder().decode((await docs.blob('d-2').get('f.bin'))!)).toBe('shared erasable content')
+    db.close()
+  })
+
+  it('delete() does NOT eager-delete a legacy blob — defers to GC / orphan retention', async () => {
+    const db = await createNoydb({ store, user: 'a', secret: SECRET, blobStrategy: withBlobs() })
+    const vault = await db.openVault(VAULT)
+    const docs = vault.collection<{ id: string }>('docs') // legacy: no _cek
+    await docs.put('d-1', { id: 'd-1' })
+    await docs.blob('d-1').put('f.bin', bytes('legacy attachment'))
+    const eTag = (await docs.blob('d-1').blobInfo('f.bin'))!.eTag
+
+    await docs.blob('d-1').delete('f.bin')
+
+    // refCount 0, but a legacy blob is left for deferred GC (retention preserved).
+    const idx = await store.get(VAULT, BLOB_INDEX_COLLECTION, eTag)
+    expect(idx).not.toBeNull()
+    expect(await store.list(VAULT, BLOB_CHUNKS_COLLECTION)).not.toEqual([])
+    db.close()
+  })
+})

--- a/packages/hub/src/blobs/blob-set.ts
+++ b/packages/hub/src/blobs/blob-set.ts
@@ -332,6 +332,43 @@ export class BlobSet {
   }
 
   /**
+   * Release `n` references to a blob and reclaim it at refCount 0 (#365 slice 4).
+   *
+   * The single reclaim choke point for every reference-drop path — slot
+   * delete/overwrite, published-version delete, and `forget()` shred — so the
+   * refCount-0 policy is uniform:
+   *  - **erasable blob** (`_cek` present) → delete the `BlobObject` (the SOLE
+   *    copy of the wrapped content CEK → chunks permanently undecryptable) and
+   *    reclaim the chunks. The crypto-shred is EAGER on every path: GDPR erasure
+   *    must not wait on orphan retention.
+   *  - **legacy blob** (no `_cek`) → reclaimed only when `reclaimLegacy` (the
+   *    `forget()` erasure path); otherwise left for deferred GC so the existing
+   *    `BlobLifecyclePolicy.orphanRetentionDays` semantics are preserved.
+   *
+   * @returns `'shredded'` (erasable, refCount 0, chunks dead) · `'retainedShared'`
+   *   (erasable, still referenced) · `'residue'` (legacy — not a crypto-shred).
+   */
+  private async releaseRef(
+    eTag: string,
+    n: number,
+    reclaimLegacy: boolean,
+  ): Promise<'shredded' | 'retainedShared' | 'residue'> {
+    const loaded = await this.loadBlobObject(eTag)
+    if (!loaded) return 'shredded' // already gone
+    const erasable = loaded.blob._cek !== undefined
+    const remaining = await this.casUpdateRefCount(eTag, -n)
+    if (remaining > 0) return erasable ? 'retainedShared' : 'residue'
+
+    if (erasable || reclaimLegacy) {
+      await this.store.delete(this.vault, BLOB_INDEX_COLLECTION, eTag)
+      for (let i = 0; i < loaded.blob.chunkCount; i++) {
+        await this.store.delete(this.vault, BLOB_CHUNKS_COLLECTION, `${eTag}_${i}`)
+      }
+    }
+    return erasable ? 'shredded' : 'residue'
+  }
+
+  /**
    * Crypto-shred this record's blob attachments (#365 slice 2) — called by
    * `vault.forget()`.
    *
@@ -369,21 +406,12 @@ export class BlobSet {
     }
 
     for (const [eTag, n] of holds) {
-      const loaded = await this.loadBlobObject(eTag)
-      if (!loaded) continue // already gone
-      const erasable = loaded.blob._cek !== undefined
-      const remaining = await this.casUpdateRefCount(eTag, -n)
-      if (remaining > 0) {
-        ;(erasable ? retainedShared : residue).push(eTag)
-        continue
-      }
-      // refCount hit 0 — reclaim. For erasable blobs the index delete IS the
-      // crypto-shred (the wrapped CEK is gone); chunk delete reclaims storage.
-      await this.store.delete(this.vault, BLOB_INDEX_COLLECTION, eTag)
-      for (let i = 0; i < loaded.blob.chunkCount; i++) {
-        await this.store.delete(this.vault, BLOB_CHUNKS_COLLECTION, `${eTag}_${i}`)
-      }
-      ;(erasable ? shredded : residue).push(eTag)
+      // Forget erasure reclaims legacy orphans too (the record is being erased),
+      // so reclaimLegacy = true — but only erasable blobs count as a crypto-shred.
+      const outcome = await this.releaseRef(eTag, n, true)
+      if (outcome === 'shredded') shredded.push(eTag)
+      else if (outcome === 'retainedShared') retainedShared.push(eTag)
+      else residue.push(eTag)
     }
 
     // Sever the subject's link: drop the record's slot map.
@@ -713,12 +741,13 @@ export class BlobSet {
       return slots
     })
 
-    // Decrement old eTag refCount outside the CAS loop
+    // Release the old eTag outside the CAS loop. An erasable blob dropping to
+    // refCount 0 here is crypto-shredded eagerly; a legacy one defers to GC.
     if (this._deferredRefDecrement) {
       const oldETag = this._deferredRefDecrement
       this._deferredRefDecrement = undefined
-      await this.casUpdateRefCount(oldETag, -1).catch(() => {
-        // Best-effort — blobGC will reconcile
+      await this.releaseRef(oldETag, 1, false).catch(() => {
+        // Best-effort — a missed decrement is reconciled by a later pass.
       })
     }
   }
@@ -755,18 +784,21 @@ export class BlobSet {
    * Decrements refCount on the blob. Chunks are GC'd by `vault.blobGC()`.
    */
   async delete(slotName: string): Promise<void> {
-    let eTagToDecrement: string | undefined
+    let eTagToRelease: string | undefined
 
     await this.casUpdateSlots((slots) => {
       if (!(slotName in slots)) return null
-      eTagToDecrement = slots[slotName]!.eTag
+      eTagToRelease = slots[slotName]!.eTag
       delete slots[slotName]
       return slots
     })
 
-    if (eTagToDecrement) {
-      await this.casUpdateRefCount(eTagToDecrement, -1).catch(() => {
-        // Best-effort — blobGC will reconcile
+    if (eTagToRelease) {
+      // Erasable blobs are crypto-shredded at refCount 0 (this also covers
+      // compaction eviction, which routes through delete()); legacy blobs keep
+      // deferred-GC / orphan-retention semantics.
+      await this.releaseRef(eTagToRelease, 1, false).catch(() => {
+        // Best-effort — a missed decrement is reconciled by a later pass.
       })
     }
   }
@@ -873,9 +905,10 @@ export class BlobSet {
     // Increment refCount for the new version's eTag
     await this.casUpdateRefCount(slot.eTag, +1)
 
-    // If overwriting an existing version with a different eTag, decrement the old one
+    // If overwriting an existing version with a different eTag, release the old
+    // one (crypto-shred at refCount 0 when erasable).
     if (existing && existing.eTag !== slot.eTag) {
-      await this.casUpdateRefCount(existing.eTag, -1).catch(() => {})
+      await this.releaseRef(existing.eTag, 1, false).catch(() => {})
     }
   }
 
@@ -926,7 +959,7 @@ export class BlobSet {
     if (!record) return
 
     await this.deleteVersionRecord(slotName, label)
-    await this.casUpdateRefCount(record.eTag, -1).catch(() => {})
+    await this.releaseRef(record.eTag, 1, false).catch(() => {})
   }
 
   /**


### PR DESCRIPTION
Final slice of per-blob crypto-shred (#365). Builds on slices 1–3 (#366/#367/#368, all merged). Makes the refCount-0 reclaim crypto-shred erasable blobs on **every** reference-drop path, not just `forget()`.

## `BlobSet.releaseRef(eTag, n, reclaimLegacy)`

A single reclaim choke point behind slot delete/overwrite, published-version delete, and `forget()` shred:
- **erasable blob** (`_cek`) → at refCount 0, delete the BlobObject (sole copy of the wrapped content CEK → chunks permanently undecryptable) + reclaim chunks, **eagerly on every path** — GDPR erasure must not wait on orphan retention.
- **legacy blob** (no `_cek`) → reclaimed only on the `forget()` erasure path (`reclaimLegacy=true`); otherwise left for deferred GC so existing `BlobLifecyclePolicy.orphanRetentionDays` semantics are **preserved**.

All four decrement sites now route through it: `put()`-overwrite, `delete()`, `publishVersion` overwrite, `deleteVersion`. `shredAllForRecord()` reuses it (`reclaimLegacy=true`). **Compaction** eviction calls `deleteSlot` → `BlobSet.delete()`, so it crypto-shreds erasable blobs at refCount 0 for free.

## Scope confirmations
- **export-blobs** — no change: exports *plaintext* via `BlobSet.get()`, which is content-CEK-aware through `resolveChunkKey` (slice 1). Recipient re-imports fresh.
- **bundles** — partition bundles don't include the `_blob_*` storage collections, so blob chunks are out of the closure — nothing to re-wrap.

## Verification
- ✅ Full hub suite: 262 files, **2534 tests** (no regressions; existing legacy-blob delete/compaction/retention tests confirm orphan-retention preserved)
- ✅ 3 new tests: `delete()` shreds an exclusive erasable blob; retains a shared one; **does not** eager-delete a legacy blob (deferred GC)
- ✅ architecture + `validate:features` + typecheck clean

## #365 complete
write/read (slice 1, #366) → `forget()` shred + reporting (2, #367) → migration (3, #368) → unified eager reclaim (4, this PR). The last deferred item of the per-record CEK epic (#357) is done.