### PR TITLE
feat(hub): per-collection history/ledger scoping (#361)

### DIFF
--- a/docs/subsystems/history.md
+++ b/docs/subsystems/history.md
@@ -30,11 +30,39 @@ const db = await createNoydb({
 })
 ```
 
-Per-collection retention via `historyConfig`:
+Vault-wide retention via the `history` config:
 
 ```ts
-vault.openVault('firm', { historyConfig: { maxVersions: 50 } })
+createNoydb({ ..., history: { maxVersions: 50 } })
 ```
+
+### Per-collection scoping (#361)
+
+By default `withHistory()` is all-or-nothing: every collection gets per-record
+snapshots **and** appends to the vault-wide tamper ledger. Pass a per-collection
+`historyConfig` to `vault.collection()` to override the vault-wide config for that
+collection only (wholesale, not merged):
+
+```ts
+// Filed legal records — full audit (snapshots + tamper ledger). This is the default.
+const receipts = vault.collection('receipts')
+
+// High-churn operational collection — no snapshots, no ledger entries.
+const scratch = vault.collection('scratch', {
+  historyConfig: { enabled: false, ledger: false },
+})
+```
+
+- `enabled: false` — suppress per-record snapshots for this collection.
+- `ledger: false` — exclude this collection's writes from the hash-chained
+  tamper ledger. Its puts/deletes leave **no** ledger entry; the chain stays
+  valid (`vault.ledger().verify()` still passes) — it simply never receives
+  those entries. Independent of `enabled`. No effect when `withHistory()` is
+  not active (there is no ledger).
+
+This lets you confine snapshots + tamper-evidence to the few collections where
+they carry legal weight, without paying snapshot + ledger-entry-per-write across
+operational / derived collections vault-wide.
 
 ## API
 

--- a/features.yaml
+++ b/features.yaml
@@ -446,6 +446,7 @@ features:
       - 'Hash-chained ledger; every entry prevHash = sha256 of predecessor'
       - 'Multi-writer safe on casAtomic stores via optimistic-CAS retry'
       - 'vault.at(timestamp) returns a VaultInstant for past-state reads'
+      - 'Per-collection scoping (#361): vault.collection(name, { historyConfig }) overrides the vault-wide history config wholesale for that collection — `enabled:false` suppresses snapshots, `ledger:false` excludes its writes from the tamper chain (chain still verifies; entries simply absent); no effect without withHistory()'
     related: [vault-and-collections, periods, bundle]
 
   - id: blobs

--- a/packages/hub/__tests__/per-collection-history-scoping.test.ts
+++ b/packages/hub/__tests__/per-collection-history-scoping.test.ts
@@ -1,0 +1,178 @@
+// Per-collection history / tamper-ledger scoping (#361).
+//
+// `withHistory()` enables per-record snapshots AND the hash-chained tamper
+// ledger vault-wide. These tests cover the per-collection override that lets a
+// caller confine snapshots + tamper-evidence to the collections where they
+// carry weight (e.g. RD-filed legal records) without paying snapshot +
+// ledger-entry-per-write across operational / derived collections.
+//
+//   • `historyConfig: { enabled: false }`  → no per-record snapshots
+//   • `historyConfig: { ledger: false }`   → no ledger entries (chain stays valid)
+//   • the override scopes to that collection only; siblings are unaffected
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import type { Noydb } from '../src/noydb.js'
+import { withHistory } from '../src/history/index.js'
+import { ConflictError } from '../src/errors.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [name, records] of Object.entries(data)) {
+        const coll = getCollection(c, name)
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+      }
+    },
+  }
+}
+
+interface Rec { id: string; v: number }
+
+describe('per-collection history scoping (#361)', () => {
+  let db: Noydb
+
+  beforeEach(async () => {
+    db = await createNoydb({
+      store: memory(),
+      user: 'owner-01',
+      historyStrategy: withHistory(),
+      encrypt: false,
+      history: { enabled: true },
+    })
+  })
+
+  describe('part 1 — per-collection historyConfig (snapshots)', () => {
+    it('historyConfig.enabled:false suppresses snapshots for that collection only', async () => {
+      const vault = await db.openVault('co')
+      const legal = vault.collection<Rec>('legal')
+      const ops = vault.collection<Rec>('ops', { historyConfig: { enabled: false } })
+
+      // two puts each → a default collection records one snapshot per record
+      await legal.put('a', { id: 'a', v: 1 })
+      await legal.put('a', { id: 'a', v: 2 })
+      await ops.put('b', { id: 'b', v: 1 })
+      await ops.put('b', { id: 'b', v: 2 })
+
+      expect(await legal.history('a')).toHaveLength(1)
+      expect(await ops.history('b')).toHaveLength(0)
+    })
+
+    it('a per-call historyConfig overrides the vault-wide config wholesale', async () => {
+      // vault-wide enabled:true, but this collection opts out
+      const vault = await db.openVault('co')
+      const ops = vault.collection<Rec>('ops', { historyConfig: { enabled: false } })
+      await ops.put('b', { id: 'b', v: 1 })
+      await ops.put('b', { id: 'b', v: 2 })
+      expect(await ops.history('b')).toHaveLength(0)
+    })
+  })
+
+  describe('part 2 — per-collection ledger opt-out', () => {
+    it('historyConfig.ledger:false excludes the collection from the tamper chain', async () => {
+      const vault = await db.openVault('co')
+      const legal = vault.collection<Rec>('legal')
+      const ops = vault.collection<Rec>('ops', { historyConfig: { ledger: false } })
+
+      await legal.put('a', { id: 'a', v: 1 })
+      await ops.put('b', { id: 'b', v: 1 })
+      await ops.put('b', { id: 'b', v: 2 })
+      await legal.put('a', { id: 'a', v: 2 })
+
+      const entries = await vault.ledger().entries()
+      // only legal's two writes appear; ops is absent entirely
+      expect(entries).toHaveLength(2)
+      expect(entries.every((e) => e.collection === 'legal')).toBe(true)
+      expect(entries.some((e) => e.collection === 'ops')).toBe(false)
+    })
+
+    it('the chain still verifies after a collection opts out', async () => {
+      const vault = await db.openVault('co')
+      const legal = vault.collection<Rec>('legal')
+      const ops = vault.collection<Rec>('ops', { historyConfig: { ledger: false } })
+
+      await ops.put('b', { id: 'b', v: 1 })
+      await legal.put('a', { id: 'a', v: 1 })
+      await ops.delete('b')
+      await legal.put('a', { id: 'a', v: 2 })
+
+      const result = await vault.ledger().verify()
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.length).toBe(2) // both legal writes only
+    })
+
+    it('opting one collection out leaves siblings appending normally', async () => {
+      const vault = await db.openVault('co')
+      const a = vault.collection<Rec>('a')
+      const b = vault.collection<Rec>('b', { historyConfig: { ledger: false } })
+      const c = vault.collection<Rec>('c')
+
+      await a.put('x', { id: 'x', v: 1 })
+      await b.put('y', { id: 'y', v: 1 })
+      await c.put('z', { id: 'z', v: 1 })
+
+      const cols = (await vault.ledger().entries()).map((e) => e.collection).sort()
+      expect(cols).toEqual(['a', 'c'])
+    })
+
+    it('ledger.entries() still works when an opted-out collection deletes', async () => {
+      const vault = await db.openVault('co')
+      const ops = vault.collection<Rec>('ops', { historyConfig: { ledger: false } })
+      await ops.put('b', { id: 'b', v: 1 })
+      await ops.delete('b')
+      expect(await vault.ledger().entries()).toHaveLength(0)
+    })
+  })
+
+  describe('combined — legal records auditable, operational collections quiet', () => {
+    it('legal collection gets snapshots + ledger; operational gets neither', async () => {
+      const vault = await db.openVault('firm')
+      const receipts = vault.collection<Rec>('receipts') // default: full audit
+      const scratch = vault.collection<Rec>('scratch', {
+        historyConfig: { enabled: false, ledger: false },
+      })
+
+      await receipts.put('r1', { id: 'r1', v: 1 })
+      await receipts.put('r1', { id: 'r1', v: 2 })
+      await scratch.put('s1', { id: 's1', v: 1 })
+      await scratch.put('s1', { id: 's1', v: 2 })
+
+      expect(await receipts.history('r1')).toHaveLength(1)
+      expect(await scratch.history('s1')).toHaveLength(0)
+
+      const entries = await vault.ledger().entries()
+      expect(entries.every((e) => e.collection === 'receipts')).toBe(true)
+      expect(entries).toHaveLength(2)
+    })
+  })
+})

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -2092,6 +2092,16 @@ export interface HistoryConfig {
   readonly enabled?: boolean
   /** Maximum history entries per record. Oldest pruned on overflow. Default: unlimited. */
   readonly maxVersions?: number
+  /**
+   * Participate in the vault-wide hash-chained tamper ledger. Default:
+   * `true` (every write of this collection appends a ledger entry when
+   * `withHistory()` is active). Set `false` to exclude this collection's
+   * writes from the chain — its puts/deletes leave no ledger entry,
+   * confining tamper-evidence to the collections where it carries weight.
+   * Independent of `enabled`, which gates per-record snapshots. Has no
+   * effect when `withHistory()` is not active (there is no ledger). See #361.
+   */
+  readonly ledger?: boolean
 }
 
 /** Options for querying history. */

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -692,6 +692,17 @@ export class Vault {
     schemaUpdate?: readonly SchemaUpdateStrategy[]
     /** — declare the per-field schema for document attestation (issue side). */
     attestation?: AttestationFieldSchema
+    /**
+     * Per-collection history & tamper-ledger scoping. Overrides the
+     * vault-wide `history` config for THIS collection only (wholesale, not
+     * merged). `enabled: false` suppresses per-record snapshots for this
+     * collection; `ledger: false` excludes its writes from the vault-wide
+     * hash-chained tamper ledger. Lets you confine version snapshots +
+     * tamper-evidence to the few collections where they carry legal weight,
+     * without paying snapshot + ledger-entry-per-write across operational /
+     * derived collections. Defaults to the vault-wide `history` config. See #361.
+     */
+    historyConfig?: HistoryConfig
   }): Collection<T> {
     // Overlay intercept. When the requested collection name
     // matches a registered `withOverlayedView`, return the virtual
@@ -822,6 +833,11 @@ export class Vault {
         schemaUpdateGate = new SchemaUpdateGate(work)
       }
 
+      // Per-collection history/ledger scoping (#361). A per-call
+      // `historyConfig` overrides the vault-wide config wholesale for this
+      // collection; `ledger: false` excludes it from the tamper chain.
+      const effectiveHistoryConfig = options?.historyConfig ?? this.historyConfig
+
       const collOpts: ConstructorParameters<typeof Collection<T>>[0] = {
         adapter: this.adapter,
         vault: this.name,
@@ -837,7 +853,7 @@ export class Vault {
         schemaFence: this.schemaFence,
         getDEK: this.getDEK,
         onDirty: this.onDirty,
-        historyConfig: this.historyConfig,
+        historyConfig: effectiveHistoryConfig,
         // thread the vault-wide blob strategy into every
         // collection. `undefined` is intentionally preserved so the
         // Collection constructor uses its NO_BLOBS default.
@@ -848,7 +864,11 @@ export class Vault {
         historyStrategy: this.historyStrategy,
         i18nStrategy: this.i18nStrategy,
         syncStrategy: this.syncStrategy,
-        ledger: this.getLedgerOrNull() ?? undefined,
+        // Per-collection ledger opt-out (#361): when this collection sets
+        // `historyConfig.ledger: false`, withhold the ledger reference so all
+        // four `if (this.ledger)` append sites in Collection no-op. The chain
+        // stays valid — it simply never receives this collection's entries.
+        ledger: effectiveHistoryConfig.ledger === false ? undefined : (this.getLedgerOrNull() ?? undefined),
         refEnforcer: this,
         joinResolver: this,
         defaultLocale: this.locale,

--- a/showcases/src/07-with-history.showcase.test.ts
+++ b/showcases/src/07-with-history.showcase.test.ts
@@ -74,4 +74,41 @@ describe('Showcase 07 — withHistory()', () => {
     expect(() => vault.ledger()).toThrow(/history/)
     db.close()
   })
+
+  // ── Per-collection scoping (#361) ────────────────────────────────────
+  // History is all-or-nothing vault-wide by default. When tamper-evidence
+  // only matters on a few collections (e.g. filed legal records), confine
+  // snapshots + ledger to those, and let high-churn operational collections
+  // opt out — no per-record snapshot, no ledger entry per write.
+  it('confines snapshots + tamper-ledger to the collections that need them', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'with-history-passphrase-2026',
+      historyStrategy: withHistory(),
+    })
+    const vault = await db.openVault('firm')
+
+    // Filed receipts: full audit (default — snapshots + ledger).
+    const receipts = vault.collection<Note>('receipts')
+    // Scratchpad: no snapshots, no ledger entries.
+    const scratch = vault.collection<Note>('scratch', {
+      historyConfig: { enabled: false, ledger: false },
+    })
+
+    await receipts.put('r1', { id: 'r1', text: 'v1' })
+    await receipts.put('r1', { id: 'r1', text: 'v2' })
+    await scratch.put('s1', { id: 's1', text: 'draft' })
+    await scratch.put('s1', { id: 's1', text: 'draft 2' })
+
+    // Only the receipts collection appears on the tamper chain…
+    const entries = await vault.ledger().entries()
+    expect(entries).toHaveLength(2)
+    expect(entries.every((e) => e.collection === 'receipts')).toBe(true)
+
+    // …and the chain still verifies end-to-end.
+    const result = await vault.ledger().verify()
+    expect(result.ok).toBe(true)
+    db.close()
+  })
 })


### PR DESCRIPTION
Closes #361.

## Problem

`withHistory()` was all-or-nothing vault-wide: every collection paid per-record snapshots **and** a hash-chained tamper-ledger entry per write. You couldn't get tamper-evidence on *some* collections (the documents where it has legal weight) without paying snapshot + ledger-entry-per-write across *all* of them — disproportionate for most of a vault. Filed from the niwat integration audit (AU+022).

## What changed

**Part 1 — per-collection `historyConfig` (snapshots).** Added `historyConfig?: HistoryConfig` to `Vault.collection()`'s options. It overrides the vault-wide config **wholesale** for that collection. The `Collection` constructor already honored a `historyConfig` — `vault.ts` just never threaded a per-call value (it always passed `this.historyConfig`). Now `vault.collection(name, { historyConfig: { enabled: false } })` scopes per-record snapshots off for that collection only.

**Part 2 — per-collection ledger opt-out.** Added `ledger?: boolean` to `HistoryConfig`. `ledger: false` withholds the ledger reference from that `Collection`, so all four `if (this.ledger)` append sites no-op. The hash chain stays valid — `vault.ledger().verify()` still passes — it simply never receives that collection's entries. Independent of `enabled`. No effect when `withHistory()` is not active (there is no ledger). **Default preserves existing behavior** (every collection participates).

### Usage

```ts
// Filed legal records — full audit (default): snapshots + tamper ledger.
const receipts = vault.collection('receipts')

// High-churn operational collection — neither.
const scratch = vault.collection('scratch', {
  historyConfig: { enabled: false, ledger: false },
})
```

## Design notes / scope

- The issue framed Part 2 as "opt-in"; the backward-compatible realization is an **opt-out** flag (default = participate). Flipping the *vault-wide* default off is a clean follow-up if "most of the vault should be quiet" becomes common — out of scope here.
- The ledger is a vault-wide singleton; per-collection `ledger: true` can't conjure a ledger when `withHistory()` is inactive, so the actionable override is `ledger: false`. Documented as such.
- The dictionary-handle ledger path (`vault.ts:1277`) and vault-level `forget()` / amendment paths are **unchanged** — only the per-collection `collection()` path is gated.

## Tests

- New `packages/hub/__tests__/per-collection-history-scoping.test.ts` (7 tests): snapshots-off, ledger opt-out, chain-still-verifies, sibling isolation, delete-while-opted-out, combined legal-vs-operational.
- Showcase 07 extended with a per-collection scoping scenario.
- Full hub suite green (2541 tests); `docs/subsystems/history.md` + `features.yaml` updated.