### PR TITLE
feat(hub/i18n): layer-tagged read facades — guard/derivation onMissing (#285 D1)

### DIFF
--- a/docs/subsystems/i18n.md
+++ b/docs/subsystems/i18n.md
@@ -79,11 +79,13 @@ i18nText({
 })
 ```
 
-> **Current wiring:** only the `read` layer (`get`/`list`) is enforced.
-> Guard/derivation/join/export reads resolve through the same read path
-> (so they observe the `read`/scalar policy); `mv`/`join` additionally
-> read raw maps in the query pipeline. Dedicated per-layer enforcement
-> is a tracked follow-up under milestone #17.
+> **Current wiring:** the `read` (`get`/`list`), `guard` and `derivation`
+> layers are enforced — guard / derivation `ctx.vault` reads resolve under
+> their own layer policy (`guard` defaults to the lenient `'substitute'`).
+> The `mv`, `join` and `export` layers are **not yet wired**: mv/join read
+> raw `{locale}` maps in the query/aggregate pipeline (no resolution call
+> site), so injecting resolution there is a tracked follow-up (#285 D2/D3,
+> milestone #18).
 
 **Script enforcement (`script`, `onScriptViolation`).** Write-time
 per-locale validation. `script: 'auto'` infers allowed Unicode scripts

--- a/docs/superpowers/plans/2026-06-06-i18n-multilingual-field-hardening.md
+++ b/docs/superpowers/plans/2026-06-06-i18n-multilingual-field-hardening.md
@@ -206,15 +206,15 @@ expect(() => validateI18nScript({ th:'อาคาร TCM' }, 'f', strict)).toTh
 - [x] **D0 spike — DONE (2026-06-06). VERDICT: MV/join read RAW, no resolution call site.** `materialized-views/executor.ts:106` reads source rows via `coll.query().toArray()` with **no locale**, so i18n fields are raw `{locale:string}` maps in the MV pipeline — `mv:'throw'` has nothing to fire from, and `groupAndReduce` would bucket on the raw map. Tagging a facade `layer:'mv'` would be inert.
   - **Decision:** D1 (guard/derivation, real call sites) is IN. **D2 (mv/export) and D3 (join) are DEFERRED** as follow-ups under milestone #17 — they require a deliberate design to inject i18n resolution into the query/aggregate pipeline (touches `groupAndReduce`, every MV's `query().toArray()`), which is not safe to do unattended. Documented in the PR + handoff.
 
-### Task D1: layer-tagged `ReadOnlyVaultFacade`
+### Task D1: layer-tagged `ReadOnlyVaultFacade` — ✅ DONE (2026-06-14)
 
-**Files:** Modify `src/guards/read-only-facade.ts`, `src/guards/types.ts`, `src/vault.ts`; Test `__tests__/i18n-layers.test.ts`
+**Files:** Modified `src/guards/read-only-facade.ts`, `src/vault.ts`, `src/types.ts` (`LocaleReadOptions._layer`), `src/collection.ts` (`applyLocaleToRecord` threads layer into `applyI18nLocale` + dictKey `resolvePolicy`); Test `__tests__/i18n-layers.test.ts`.
 
-- [ ] **Step 1: Failing tests:** a field `onMissing:{read:'substitute', mv:'throw', derivation:'null', guard:'substitute'}`, stored `{th:..}` only; a derivation reading `firstName` (en active) sees `null`; an MV bucketing on the en value throws on refresh; a guard reading it substitutes.
-- [ ] **Step 2:** FAIL.
-- [ ] **Step 3: Implement.** Give `ReadOnlyVaultFacade` a `readonly layer: Layer` ctor arg (default `'read'`). Its `collection().get/list/query` inject `layer` into the resolution path (extend `LocaleReadOptions` with optional `_layer`, OR have the facade pass a layer-bearing option that `applyLocaleToRecord` reads). In `vault.ts`, construct distinct facades: guard-seeding → `layer:'guard'`, derivation-seeding → `layer:'derivation'`. (Keep the cached default-`read` facade for general use.)
-- [ ] **Step 4:** PASS.
-- [ ] **Step 5: Commit** `feat(hub/i18n): layer-tagged read facades (guard/derivation)`
+- [x] **Step 1: Failing tests:** field `onMissing:{read:'throw', guard:'substitute', derivation:'null'}`, stored `{th:..}` only, `en` active; guard read substitutes, derivation read sees `null`, ordinary `get()` throws, guard layerDefault applies when no guard key declared.
+- [x] **Step 2:** FAIL.
+- [x] **Step 3: Implement.** `ReadOnlyVaultFacade` gained a `layer: Layer` ctor arg (default `'read'`); `collection().get/list` inject `{ _layer }` into `LocaleReadOptions`; `applyLocaleToRecord` reads `_layer` and threads it into `applyI18nLocale` (5th arg) + dictKey `resolvePolicy`. `vault.ts` constructs distinct facades — `_initGuards` → `'guard'`, `_initDerivations` → `'derivation'`; `_getReadOnlyFacade()` returns the guard facade (guard gate + tx amendment + dry-run), `_ensureReadOnlyFacade()` returns the derivation facade. `query()` left untagged (raw-map pipeline; see D2/D3).
+- [x] **Step 4:** PASS (4 tests).
+- [x] **Step 5: Commit** `feat(hub/i18n): layer-tagged read facades (guard/derivation)`
 
 ### Task D2: MV refresh + export layers
 

--- a/features.yaml
+++ b/features.yaml
@@ -512,7 +512,7 @@ features:
       - 'resolveLabel(key, locale, fallback) walks the fallback chain'
       - 'No transliteration (locale-specific lossy mappings stay in userland)'
       - 'i18nField paths support dot notation (address.lineOne) and array wildcards (contacts[].title)'
-      - 'onMissing policy (substitute/null/throw) is per-layer; default throw preserves legacy behavior; only the read layer is wired (guard/mv/derivation/join/export are tracked follow-ups)'
+      - 'onMissing policy (substitute/null/throw) is per-layer; default throw preserves legacy behavior; read+guard+derivation layers wired (guard/derivation ctx.vault reads resolve under their own policy, guard defaults to substitute); mv/join/export still tracked follow-ups (#285 D2/D3 — query pipeline reads raw maps)'
       - 'substitute: declared ordered preferred-locale chain; caller fallback overrides it per read'
       - 'script enforcement is asymmetric-Latin: non-Latin locales also allow Latin (embedded brand/building names); Latin locales reject other scripts; Common/Inherited/Mark always allowed'
       - 'onScriptViolation reject (default) | filter | warn; ScriptViolationError distinct from MissingTranslationError / LocaleNotSpecifiedError'

--- a/packages/hub/__tests__/i18n-layers.test.ts
+++ b/packages/hub/__tests__/i18n-layers.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Per-layer onMissing wiring — guard & derivation layers (#285 D1).
+ *
+ * A field can be lenient at the app read boundary but strict (or null)
+ * elsewhere. The SAME `firstName`, stored in `th` only and read under an
+ * active `en` locale, resolves differently per layer:
+ *
+ *   onMissing: { read:'throw', guard:'substitute', derivation:'null' }
+ *
+ *   - ordinary get()             → throws        (read layer)
+ *   - a guard reading via ctx    → 'สมชาย'        (guard layer, substitute)
+ *   - a derivation reading via ctx → null         (derivation layer)
+ *
+ * mv/join/export layers read raw maps in the query pipeline and are tracked
+ * separately (#285 D2/D3) — not covered here.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withGuard, withDerivation } from '../src/index.js'
+import { withI18n } from '../src/i18n/index.js'
+import { i18nText } from '../src/i18n/core.js'
+import type { NoydbStore, EncryptedEnvelope } from '../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname] = out[cname] ?? {}
+          out[cname][id] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c])) {
+          data.set(k(v, c, i), payload[c][i])
+        }
+      }
+    },
+  }
+}
+
+interface Person extends Record<string, unknown> { id: string; firstName: unknown }
+interface Order extends Record<string, unknown> { id: string; personId: string }
+
+const PERSON_I18N = {
+  firstName: i18nText({
+    languages: ['th', 'en'],
+    required: 'any',
+    substitute: ['en', 'th', 'any'],
+    onMissing: { read: 'throw', guard: 'substitute', derivation: 'null' },
+  }),
+}
+
+describe('per-layer onMissing — guard layer (#285)', () => {
+  it("a guard reading a sibling via ctx.vault resolves at layer 'guard' (substitute)", async () => {
+    let observed: unknown = '__unset__'
+    const orderGuard = withGuard<Order>({
+      collection: 'orders',
+      check: async (incoming, ctx) => {
+        const person = await ctx.vault.collection<Person>('people').get(incoming.personId)
+        observed = person?.firstName
+      },
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'i18n-layers-guard-passphrase-2026',
+      i18nStrategy: withI18n(),
+      guardStrategies: [orderGuard],
+    })
+    const v = await db.openVault('demo', { locale: 'en' })
+    v.collection<Person>('people', { i18nFields: PERSON_I18N })
+
+    await v.collection<Person>('people').put('p1', { id: 'p1', firstName: { th: 'สมชาย' } })
+    // Triggers the guard, which reads p1 through ctx.vault at layer 'guard'.
+    await v.collection<Order>('orders').put('o1', { id: 'o1', personId: 'p1' })
+
+    // Guard layer substitutes the missing 'en' from the chain → Thai value.
+    expect(observed).toBe('สมชาย')
+  })
+
+  it("the same field still throws on an ordinary get() (read layer)", async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'i18n-layers-read-passphrase-2026',
+      i18nStrategy: withI18n(),
+    })
+    const v = await db.openVault('demo', { locale: 'en' })
+    const people = v.collection<Person>('people', { i18nFields: PERSON_I18N })
+    await people.put('p1', { id: 'p1', firstName: { th: 'สมชาย' } })
+    await expect(people.get('p1')).rejects.toThrow(/locale/i)
+  })
+
+  it("guard layer defaults to 'substitute' even when only a read policy is declared", async () => {
+    // onMissing has NO guard key — the guard layerDefault ('substitute')
+    // applies, so the guard read does not hard-fail.
+    let observed: unknown = '__unset__'
+    const orderGuard = withGuard<Order>({
+      collection: 'orders',
+      check: async (incoming, ctx) => {
+        observed = (await ctx.vault.collection<Person>('people').get(incoming.personId))?.firstName
+      },
+    })
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'i18n-layers-guard-default-passphrase-2026',
+      i18nStrategy: withI18n(),
+      guardStrategies: [orderGuard],
+    })
+    const v = await db.openVault('demo', { locale: 'en' })
+    v.collection<Person>('people', {
+      i18nFields: {
+        firstName: i18nText({
+          languages: ['th', 'en'],
+          required: 'any',
+          substitute: ['en', 'th', 'any'],
+          onMissing: { read: 'throw' }, // no guard key
+        }),
+      },
+    })
+    await v.collection<Person>('people').put('p1', { id: 'p1', firstName: { th: 'สมชาย' } })
+    await v.collection<Order>('orders').put('o1', { id: 'o1', personId: 'p1' })
+    expect(observed).toBe('สมชาย')
+  })
+})
+
+describe('per-layer onMissing — derivation layer (#285)', () => {
+  it("a derivation reading a sibling via ctx.vault resolves at layer 'derivation' (null)", async () => {
+    interface Summary extends Record<string, unknown> { id: string; personFound: boolean; resolvedName: unknown }
+    const summarize = withDerivation<Order, { summary: Summary }>({
+      source: 'orders',
+      deterministic: true,
+      outputs: { summary: { shape: 'record', collection: 'summaries' } },
+      derive: async (order, ctx) => {
+        const person = await ctx.vault.collection<Person>('people').get(order.personId)
+        // derivation layer → the person IS found, but its missing-'en'
+        // firstName resolves to null (the derive fn branches explicitly).
+        return { summary: { id: order.id, personFound: person !== null, resolvedName: person ? person.firstName : 'NO_PERSON' } }
+      },
+      lifecycle: 'eager',
+    })
+
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'i18n-layers-derivation-passphrase-2026',
+      i18nStrategy: withI18n(),
+      derivationStrategies: [summarize],
+    })
+    const v = await db.openVault('demo', { locale: 'en' })
+    v.collection<Person>('people', { i18nFields: PERSON_I18N })
+
+    await v.collection<Person>('people').put('p1', { id: 'p1', firstName: { th: 'สมชาย' } })
+    await v.collection<Order>('orders').put('o1', { id: 'o1', personId: 'p1' })
+
+    const summary = await v.collection<Summary>('summaries').get('o1')
+    expect(summary?.personFound).toBe(true)        // sibling read succeeded
+    expect(summary?.resolvedName).toBeNull()        // firstName null at derivation layer
+  })
+})

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -3412,8 +3412,12 @@ export class Collection<T> {
 
     // 1. i18nText resolution — guarded on `locale`, because the relaxed gate
     // above can now be entered with `locale === undefined` (static-display).
+    // The layer (`'read'` by default; `'guard'`/`'derivation'` when read
+    // through a layer-tagged facade, #285) selects the field's per-layer
+    // `onMissing` policy inside applyI18nLocale.
+    const layer = localeOpts?._layer ?? 'read'
     if (locale && hasI18n && this.i18nFields) {
-      result = this.i18nStrategy.applyI18nLocale(result, this.i18nFields, locale, localeOpts?.fallback)
+      result = this.i18nStrategy.applyI18nLocale(result, this.i18nFields, locale, localeOpts?.fallback, layer)
     }
 
     // 2. dictKey / staticDict label resolution
@@ -3425,7 +3429,7 @@ export class Collection<T> {
         // behavior — unless the field declares onMissing. 'substitute'
         // walks the declared substitute chain (passed as the resolver's
         // fallback); 'throw' raises LocaleNotSpecifiedError.
-        const policy = desc.onMissing ? resolvePolicy(desc.onMissing, 'read') : 'null'
+        const policy = desc.onMissing ? resolvePolicy(desc.onMissing, layer) : 'null'
         const fallback =
           policy === 'substitute'
             ? (localeOpts?.fallback ?? desc.substitute)

--- a/packages/hub/src/guards/read-only-facade.ts
+++ b/packages/hub/src/guards/read-only-facade.ts
@@ -1,17 +1,32 @@
 import type { Vault } from '../vault.js'
 import type { Query } from '../query/builder.js'
+import type { Layer } from '../i18n/policy.js'
 import type { ReadOnlyVaultFacade as ReadOnlyVaultFacadeContract } from './types.js'
 
 /**
  * Minimal read-only wrapper over a `Vault`. Used as `ctx.vault` inside
- * guard callbacks so they can fetch related records without acquiring
- * any write capability.
+ * guard / derivation callbacks so they can fetch related records without
+ * acquiring any write capability.
+ *
+ * The `layer` tags every `get`/`list` read with the resolution layer it
+ * belongs to (#285). A guard-seeded facade reads at `'guard'`, a
+ * derivation-seeded one at `'derivation'`, so i18nText / dictKey fields
+ * resolve under that layer's `onMissing` policy instead of the `'read'`
+ * policy — e.g. a guard read can `substitute` a missing locale (lenient
+ * default) while the same field `throw`s on an ordinary app read.
+ *
+ * `query()` is left untagged: the query/aggregate pipeline reads raw
+ * `{locale}` maps (no resolution call site), so a layer tag there would be
+ * inert. Routing `mv`/`join` resolution through the pipeline is tracked
+ * separately (#285 D2/D3).
  */
 export class ReadOnlyVaultFacade implements ReadOnlyVaultFacadeContract {
   private readonly _vault: Vault
+  private readonly _layer: Layer
 
-  constructor(vault: Vault) {
+  constructor(vault: Vault, layer: Layer = 'read') {
     this._vault = vault
+    this._layer = layer
   }
 
   collection<T = unknown>(name: string): {
@@ -20,9 +35,10 @@ export class ReadOnlyVaultFacade implements ReadOnlyVaultFacadeContract {
     query(): Query<T>
   } {
     const c = this._vault.collection<T>(name)
+    const layer = this._layer
     return {
-      get: (id: string) => c.get(id),
-      list: () => c.list(),
+      get: (id: string) => c.get(id, { _layer: layer }),
+      list: () => c.list({ _layer: layer }),
       query: () => c.query(),
     }
   }

--- a/packages/hub/src/i18n/core.ts
+++ b/packages/hub/src/i18n/core.ts
@@ -121,12 +121,14 @@ export interface I18nTextOptions {
    * export). Default `'throw'` — today's behavior, zero breaking change.
    * See {@link OnMissingPolicy}.
    *
-   * NOTE (current wiring): the `read` layer (`get`/`list`) is enforced.
-   * Guard, derivation, mv, join and export reads currently resolve
-   * through the same read path and so observe the `read`/scalar policy;
-   * dedicated per-layer enforcement for those contexts is a tracked
-   * follow-up (mv/join additionally require resolution to be injected
-   * into the query/aggregate pipeline, which today reads raw maps).
+   * NOTE (current wiring): the `read` (`get`/`list`), `guard` and
+   * `derivation` layers are enforced — guard / derivation `ctx.vault`
+   * reads resolve under their own layer policy (`guard` defaults to the
+   * lenient `'substitute'`). The `mv`, `join` and `export` layers are NOT
+   * yet wired: mv/join read raw `{locale}` maps in the query/aggregate
+   * pipeline (no resolution call site), so injecting resolution there is a
+   * tracked follow-up (#285 D2/D3). Until then those reads observe the raw
+   * map, not this policy.
    */
   readonly onMissing?: OnMissingPolicy
   /**

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -38,6 +38,7 @@ import type { TxStrategy } from './tx/strategy.js'
 import type { HistoryStrategy } from './history/strategy.js'
 import type { ForgetStrategy } from './forget/strategy.js'
 import type { SnapshotStrategy } from './snapshots/strategy.js'
+import type { Layer } from './i18n/policy.js'
 import type { I18nStrategy } from './i18n/strategy.js'
 import type { SessionStrategy } from './session/strategy.js'
 import type { SyncStrategy } from './team/sync-strategy.js'
@@ -1353,6 +1354,15 @@ export interface LocaleReadOptions {
    * element to fall back to any present translation.
    */
   readonly fallback?: string | readonly string[]
+  /**
+   * @internal — the resolution layer this read belongs to (`'read'` by
+   * default). Threaded by layer-tagged read facades (guard / derivation)
+   * so `applyI18nLocale` and dictKey `resolvePolicy` select that layer's
+   * `onMissing` policy instead of the `'read'` policy. Not part of the
+   * public read API — callers select policy via the field's `onMissing`
+   * map, not by setting this. See #285.
+   */
+  readonly _layer?: Layer
 }
 
 // ─── plaintextTranslator hook ──────────────────────────────

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -247,13 +247,17 @@ export class Vault {
    */
   private overlayedViewRegistry: OverlayedViewRegistry | null = null
   /**
-   * Cached read-only facade handed to guard callbacks via `ctx.vault`,
-   * and to derivation callbacks via `derive(source, ctx)`. Allocated
-   * eagerly inside `_initGuards()` and/or `_initDerivations()` so read
+   * Cached read-only facades handed to guard callbacks via `ctx.vault`
+   * and to derivation callbacks via `derive(source, ctx)`. Split by
+   * resolution layer (#285): the guard facade reads at `layer:'guard'`,
+   * the derivation facade at `layer:'derivation'`, so i18nText / dictKey
+   * fields resolve under that layer's `onMissing` policy. Allocated
+   * eagerly inside `_initGuards()` / `_initDerivations()` so read
    * accessors stay synchronous (callers in `tx/transaction.ts` rely on
-   * that). Stays `null` for vaults with neither subsystem configured.
+   * that). Each stays `null` for vaults without that subsystem.
    */
-  private readOnlyFacade: ReadOnlyVaultFacade | null = null
+  private guardFacade: ReadOnlyVaultFacade | null = null
+  private derivationFacade: ReadOnlyVaultFacade | null = null
   private getDEK: (collectionName: string) => Promise<CryptoKey>
 
   /**
@@ -2415,7 +2419,7 @@ export class Vault {
     const registry = new GuardRegistry()
     for (const h of handles) registry.register(h.spec)
     this.guardRegistry = registry
-    this.readOnlyFacade = new ReadOnlyVaultFacade(this)
+    this.guardFacade = new ReadOnlyVaultFacade(this, 'guard')
   }
 
   /**
@@ -2448,11 +2452,12 @@ export class Vault {
     }
     registry.validate()
     this.derivationRegistry = registry
-    // Share the facade with guards: if `_initGuards` ran first the slot
-    // is already populated. Otherwise allocate so `derive(source, ctx)`
-    // has a vault accessor without re-importing the class per call.
-    if (this.readOnlyFacade === null) {
-      this.readOnlyFacade = new ReadOnlyVaultFacade(this)
+    // Derivation reads resolve at `layer:'derivation'` (#285) — a distinct
+    // facade from the guard one, so `derive(source, ctx)` gets the
+    // derivation `onMissing` policy (e.g. `'null'` → branch explicitly)
+    // rather than the lenient guard default.
+    if (this.derivationFacade === null) {
+      this.derivationFacade = new ReadOnlyVaultFacade(this, 'derivation')
     }
   }
 
@@ -2603,11 +2608,11 @@ export class Vault {
 
     const sourceColl = this.collection<Record<string, unknown>>(sourceCollection)
     const records = await sourceColl.list()
-    // `_initDerivations` populates `readOnlyFacade` — assert non-null
-    // for the closure-captured ctx. Falls back to a fresh facade on the
-    // sync-fallback path (Noydb.vault() without await) for the same
-    // defensive reason `_ensureReadOnlyFacade` exists.
-    const ctx = { vault: this.readOnlyFacade ?? new (await import('./guards/read-only-facade.js')).ReadOnlyVaultFacade(this) }
+    // `_initDerivations` populates `derivationFacade` — assert non-null
+    // for the closure-captured ctx. Falls back to a fresh `derivation`-layer
+    // facade on the sync-fallback path (Noydb.vault() without await) for the
+    // same defensive reason `_ensureReadOnlyFacade` exists.
+    const ctx = { vault: this.derivationFacade ?? new (await import('./guards/read-only-facade.js')).ReadOnlyVaultFacade(this, 'derivation') }
     let derived = 0
     let failed = 0
     for (const record of records) {
@@ -2679,24 +2684,25 @@ export class Vault {
    * never see null).
    */
   _getReadOnlyFacade(): ReadOnlyVaultFacade | null {
-    return this.readOnlyFacade
+    return this.guardFacade
   }
 
   /**
-   * Internal lazy-allocator for the read-only facade. Used as a
-   * defensive fallback; in practice `_initGuards()` eagerly
-   * instantiates this, so the lazy path is a no-op.
+   * Internal lazy-allocator for the derivation read-only facade
+   * (`layer:'derivation'`). Used as a defensive fallback; in practice
+   * `_initDerivations()` eagerly instantiates this, so the lazy path is
+   * a no-op.
    */
   private _ensureReadOnlyFacade(): ReadOnlyVaultFacade {
-    if (this.readOnlyFacade !== null) return this.readOnlyFacade
+    if (this.derivationFacade !== null) return this.derivationFacade
     // Synchronous fall-back: dynamic import isn't available here,
-    // but `_initGuards` always sets the facade before any
-    // guard-hook can fire. Reaching this branch means a Vault was
-    // constructed without `_initGuards` being awaited — e.g. via
+    // but `_initDerivations` always sets the facade before any
+    // derivation can fire. Reaching this branch means a Vault was
+    // constructed without `_initDerivations` being awaited — e.g. via
     // the sync `Noydb.vault()` fallback path. Throw with a
     // pointer rather than silently building an invalid context.
     throw new Error(
-      'Vault: guard hook fired before _initGuards() completed. ' +
+      'Vault: derivation hook fired before _initDerivations() completed. ' +
       'This typically means the vault was opened via the sync ' +
       'fallback path (Noydb.vault(name)) without first calling ' +
       'await db.openVault(name). See issue #132.',


### PR DESCRIPTION
Advances #285 (D1). **Leaves #285 open** — mv/join/export layers and the v1.x items remain (see "Deferred" below).

## What & why

PR #284 landed the i18n hardening engine but wired the per-layer `onMissing` policy for the **`read` layer only**. Guard and derivation reads observed the `read`/scalar policy. This wires those two layers so a field can be strict at the app read boundary but lenient (or null) when read inside a guard or derivation:

```ts
onMissing: { read: 'throw', guard: 'substitute', derivation: 'null' }
//   ordinary get()            → throws       (read)
//   guard ctx.vault read      → substitutes  (guard — lenient default)
//   derivation ctx.vault read → null         (derivation)
```

## How

- **`LocaleReadOptions`** gains an internal `_layer`. **`applyLocaleToRecord`** threads it into `applyI18nLocale` (the 5th `layer` arg, which already existed) and into the dictKey `resolvePolicy` call — so the field's per-layer policy is selected instead of always `'read'`.
- **`ReadOnlyVaultFacade`** gains a `layer` ctor arg (default `'read'`) and injects `{ _layer }` into `get`/`list`. `query()` is left **untagged** — the query/aggregate pipeline reads raw `{locale}` maps with no resolution call site (that's the deferred mv/join work).
- **`vault.ts`** constructs distinct facades: `_initGuards` → `'guard'`, `_initDerivations` → `'derivation'`. `_getReadOnlyFacade()` (guard gate, tx amendment runner, dry-run) returns the guard facade; `_ensureReadOnlyFacade()` (derivation source) returns the derivation facade. Previously a single shared facade served both.

## Deferred (intentionally, per the plan's D0 verdict)

The plan (`docs/superpowers/plans/2026-06-06-i18n-multilingual-field-hardening.md`, D0 verdict) marks **mv/join as "not safe to do unattended"**, and I'm respecting that:

- **mv/join (D2/D3)** — `materialized-views/executor.ts` reads source rows via `coll.query().toArray()` with **no locale**; `groupAndReduce` buckets on the raw `{locale}` map. There's no resolution call site for `mv:'throw'` to fire from. Injecting resolution is a behavior change: an unset `mv` policy resolves to `'throw'`, so existing MVs over i18n fields would start **throwing on refresh** — violating the spec's "no behavior change for fields not setting a new option" invariant. Needs a deliberate design (a `_layer` option on `Collection.query()` threading into `snapshot()`, or a post-`toArray()` resolve pass), out of scope for an unattended change.
- **export** — `pickLocale` only resolves public-envelope *metadata* (name/description), not record i18n fields; there's no record-level export resolution call site yet.
- **v1.x items** (`densifyOnWrite`, smart script substitution, dictKey `{ by:'label' }`, `onScriptViolation:'warn'` event) and the `@noy-db/in-pinia` companion — separate slices.

Caveats updated to reflect the new state (read+guard+derivation wired; mv/join/export tracked): `onMissing` JSDoc in `i18n/core.ts`, `docs/subsystems/i18n.md`, `features.yaml` invariant.

## Tests

- New `packages/hub/__tests__/i18n-layers.test.ts` (4): guard-layer substitute, read-layer throw on the same field, guard layerDefault applies without an explicit guard key, derivation-layer null (with a `personFound` signal proving the sibling read itself succeeded).
- Full hub suite green (263 files / 2538 tests); i18n/guard/derivation showcases (09, 79, 80, 94, 95) green.