### PR TITLE
feat(guards): transitionGuard — declarative state-machine guard (#374)

### DIFF
--- a/docs/subsystems/guards.md
+++ b/docs/subsystems/guards.md
@@ -148,6 +148,38 @@ immutableGuard<Receipt>({
 
 Omitting `amendmentInvariant` leaves the empty-allow override in place.
 
+### `transitionGuard` (state-machine sugar, #374)
+
+`transitionGuard` generalizes `immutableGuard` from "any state → locked"
+to an arbitrary state graph. Declare the allowed arcs once; every write
+that moves the lifecycle field along an undeclared edge throws
+`IllegalTransitionError`. It's sugar over `withGuard` (no new write-path
+code) and inherits the same ledgered amendment override.
+
+```ts
+transitionGuard<Sale>({
+  collection: 'sales', field: 'status',
+  transitions: {                          // absence of an arc = forbidden
+    draft: ['to_verify', 'cancelled'],
+    to_verify: ['proforma', 'draft', 'cancelled'],
+    proforma: ['invoiced', 'cancelled'],
+    invoiced: ['paid'], paid: [], cancelled: [],
+  },
+  initial: ['draft', 'to_verify'],        // allowed status on insert (default: any)
+  allowIdempotent: true,                  // same→same write allowed (default true)
+})
+```
+
+- **Insert** (`existing === null`): `incoming[field]` must be in `initial`
+  (any value when `initial` is omitted); a violation reports `from: '(none)'`.
+- **Update**: the arc `(existing[field] → incoming[field])` must be a
+  declared edge, else `IllegalTransitionError(collection, id, from, to)`.
+  A state absent from the map (or mapped to `[]`) is terminal.
+- **Idempotent**: a same-state write passes when `allowIdempotent` (default
+  `true`), so a put that changes other fields without moving state is fine.
+- **Override**: an `amendment` tx by an authorized role skips the check and
+  is ledgered — `immutableGuard` is the WORM special case (every state → `[]`).
+
 ### Amendment flow
 
 ```

--- a/features.yaml
+++ b/features.yaml
@@ -872,6 +872,28 @@ features:
       - 'amendmentInvariant (#349): optional; when supplied, wires a real constraining invariant (matching GuardStrategy.amendment.invariant) into the amendment path so a constraint stays inviolable even under amendment; default omitted = empty-allow override (backward compatible)'
     related: [guards, transactions]
 
+  - id: transition-guard
+    name: transitionGuard — declarative state-machine guard
+    cluster: time-and-audit
+    spec: docs/subsystems/guards.md#guards
+    subsystem_doc: docs/subsystems/guards.md
+    package: '@noy-db/hub/guards'
+    factory: null
+    status: preview
+    showcases:
+      - id: 101-transition-guard
+        path: showcases/src/101-transition-guard.showcase.test.ts
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'transitionGuard({ collection, field, transitions, initial? }) generates a withGuard spec — no new write-path code; generalizes immutableGuard (WORM = every state maps to [])'
+      - 'insert (existing === null): incoming[field] must be in `initial`; when `initial` is omitted any value is allowed on insert'
+      - 'update: the arc (existing[field] → incoming[field]) must be a declared edge in transitions[from], else IllegalTransitionError(collection,id,from,to); a state absent from the map is terminal'
+      - 'same-state write (from === to) allowed when allowIdempotent (default true), so puts that change other fields without moving state pass'
+      - 'amendment override (admin|owner) skips the check and is ledgered, via the standard guard amendment path; out-of-initial inserts report from: "(none)"'
+    related: [guards, transactions, immutable-guard]
+
   - id: bundle
     name: '.noydb container format'
     cluster: snapshot-and-portability

--- a/packages/hub/__tests__/guards/transition-guard.test.ts
+++ b/packages/hub/__tests__/guards/transition-guard.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb, IllegalTransitionError, ValidationError } from '../../src/index.js'
+import { transitionGuard } from '../../src/guards/transition-guard.js'
+import { withTransactions } from '../../src/tx/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v && cname && id) { out[cname] = out[cname] ?? {}; out[cname]![id] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c]!)) { data.set(k(v, c, i), payload[c]![i]!) }
+      }
+    },
+  }
+}
+
+interface Sale extends Record<string, unknown> { id: string; status: string; total: number }
+
+const SALE_TRANSITIONS = {
+  draft: ['to_verify', 'cancelled'],
+  to_verify: ['proforma', 'draft', 'cancelled'],
+  proforma: ['invoiced', 'cancelled'],
+  invoiced: ['paid'],
+  paid: [],
+  cancelled: [],
+} as const
+
+function saleGuard(extra: Partial<Parameters<typeof transitionGuard<Sale>>[0]> = {}) {
+  return transitionGuard<Sale>({
+    collection: 'sales',
+    field: 'status',
+    transitions: SALE_TRANSITIONS,
+    initial: ['draft', 'to_verify'],
+    ...extra,
+  })
+}
+
+describe('transitionGuard — factory validation', () => {
+  it('rejects a missing field', () => {
+    expect(() =>
+      transitionGuard<Sale>({ collection: 'sales', field: '' as 'status', transitions: SALE_TRANSITIONS }),
+    ).toThrow(ValidationError)
+  })
+  it('rejects a missing transitions map', () => {
+    expect(() =>
+      transitionGuard<Sale>({ collection: 'sales', field: 'status', transitions: undefined as never }),
+    ).toThrow(ValidationError)
+  })
+  it('produces a guard handle for the named collection with default amendment roles', () => {
+    const h = saleGuard()
+    expect(h.spec.collection).toBe('sales')
+    expect(h.spec.amendment?.roles).toEqual(['admin', 'owner'])
+  })
+})
+
+async function vaultWith(...guards: ReturnType<typeof transitionGuard>[]) {
+  const db = await createNoydb({
+    store: memory(), user: 'alice', secret: 'transition-guard-passphrase-2026-pilot2',
+    guardStrategies: guards, txStrategy: withTransactions(),
+  })
+  const vault = await db.openVault('books')
+  return { db, vault }
+}
+
+describe('transitionGuard — inserts (initial set)', () => {
+  it('allows an insert whose status is in `initial`', async () => {
+    const { vault } = await vaultWith(saleGuard())
+    const sales = vault.collection<Sale>('sales')
+    await sales.put('s1', { id: 's1', status: 'draft', total: 100 })
+    expect((await sales.get('s1'))?.status).toBe('draft')
+  })
+
+  it('rejects an insert whose status is not in `initial` (from: "(none)")', async () => {
+    const { vault } = await vaultWith(saleGuard())
+    const sales = vault.collection<Sale>('sales')
+    await expect(sales.put('s1', { id: 's1', status: 'paid', total: 100 }))
+      .rejects.toBeInstanceOf(IllegalTransitionError)
+    expect(await sales.get('s1')).toBeNull()
+  })
+
+  it('allows any insert status when `initial` is omitted', async () => {
+    const { vault } = await vaultWith(
+      transitionGuard<Sale>({ collection: 'sales', field: 'status', transitions: SALE_TRANSITIONS }),
+    )
+    const sales = vault.collection<Sale>('sales')
+    await sales.put('s1', { id: 's1', status: 'invoiced', total: 100 })
+    expect((await sales.get('s1'))?.status).toBe('invoiced')
+  })
+})
+
+describe('transitionGuard — updates (declared arcs)', () => {
+  it('allows a declared transition', async () => {
+    const { vault } = await vaultWith(saleGuard())
+    const sales = vault.collection<Sale>('sales')
+    await sales.put('s1', { id: 's1', status: 'draft', total: 100 })
+    await sales.put('s1', { id: 's1', status: 'to_verify', total: 100 })
+    await sales.put('s1', { id: 's1', status: 'proforma', total: 100 })
+    expect((await sales.get('s1'))?.status).toBe('proforma')
+  })
+
+  it('rejects an undeclared transition and leaves the record unchanged', async () => {
+    const { vault } = await vaultWith(saleGuard())
+    const sales = vault.collection<Sale>('sales')
+    await sales.put('s1', { id: 's1', status: 'draft', total: 100 })
+    // draft → paid is not a declared arc
+    await expect(sales.put('s1', { id: 's1', status: 'paid', total: 100 }))
+      .rejects.toBeInstanceOf(IllegalTransitionError)
+    expect((await sales.get('s1'))?.status).toBe('draft')
+  })
+
+  it('rejects any outgoing transition from a terminal state', async () => {
+    const { vault } = await vaultWith(saleGuard())
+    const sales = vault.collection<Sale>('sales')
+    // Walk to the terminal state via the legal path.
+    await sales.put('s2', { id: 's2', status: 'draft', total: 100 })
+    await sales.put('s2', { id: 's2', status: 'to_verify', total: 100 })
+    await sales.put('s2', { id: 's2', status: 'proforma', total: 100 })
+    await sales.put('s2', { id: 's2', status: 'invoiced', total: 100 })
+    await sales.put('s2', { id: 's2', status: 'paid', total: 100 })
+    // paid is terminal (paid: [])
+    await expect(sales.put('s2', { id: 's2', status: 'draft', total: 100 }))
+      .rejects.toBeInstanceOf(IllegalTransitionError)
+    expect((await sales.get('s2'))?.status).toBe('paid')
+  })
+
+  it('the IllegalTransitionError carries from/to', async () => {
+    const { vault } = await vaultWith(saleGuard())
+    const sales = vault.collection<Sale>('sales')
+    await sales.put('s1', { id: 's1', status: 'draft', total: 100 })
+    try {
+      await sales.put('s1', { id: 's1', status: 'invoiced', total: 100 })
+      throw new Error('should have thrown')
+    } catch (e) {
+      expect(e).toBeInstanceOf(IllegalTransitionError)
+      const err = e as IllegalTransitionError
+      expect(err.from).toBe('draft')
+      expect(err.to).toBe('invoiced')
+      expect(err.collection).toBe('sales')
+      expect(err.id).toBe('s1')
+    }
+  })
+})
+
+describe('transitionGuard — idempotent writes', () => {
+  it('allows a same-state write by default (other fields may change)', async () => {
+    const { vault } = await vaultWith(saleGuard())
+    const sales = vault.collection<Sale>('sales')
+    await sales.put('s1', { id: 's1', status: 'draft', total: 100 })
+    await sales.put('s1', { id: 's1', status: 'draft', total: 250 }) // same status, new total
+    expect((await sales.get('s1'))?.total).toBe(250)
+  })
+
+  it('rejects a same-state write when allowIdempotent: false', async () => {
+    const { vault } = await vaultWith(saleGuard({ allowIdempotent: false }))
+    const sales = vault.collection<Sale>('sales')
+    await sales.put('s1', { id: 's1', status: 'draft', total: 100 })
+    await expect(sales.put('s1', { id: 's1', status: 'draft', total: 250 }))
+      .rejects.toBeInstanceOf(IllegalTransitionError)
+  })
+})
+
+describe('transitionGuard — amendment override', () => {
+  it('an admin/owner amendment transaction overrides an illegal transition and is committed', async () => {
+    const { db, vault } = await vaultWith(saleGuard())
+    const sales = vault.collection<Sale>('sales')
+    await sales.put('s1', { id: 's1', status: 'draft', total: 100 })
+
+    // draft → paid blocked normally
+    await expect(sales.put('s1', { id: 's1', status: 'paid', total: 100 }))
+      .rejects.toBeInstanceOf(IllegalTransitionError)
+
+    // amendment overrides
+    await db.transaction({ amendment: true, reason: 'manual correction' }, async (tx) => {
+      tx.vault('books').collection<Sale>('sales').put('s1', { id: 's1', status: 'paid', total: 100 })
+    })
+    expect((await sales.get('s1'))?.status).toBe('paid')
+  })
+})

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -558,6 +558,34 @@ export class FieldFrozenError extends NoydbError {
 }
 
 /**
+ * Thrown by a `transitionGuard` when a write moves a state field along an
+ * arc that the declared transition graph does not allow — either an
+ * update `from → to` that is not a listed edge, or an insert whose
+ * initial state is not in the allowed `initial` set (reported with
+ * `from: '(none)'`). Override via an amendment transaction by an
+ * authorized role, like any guard.
+ */
+export class IllegalTransitionError extends NoydbError {
+  readonly collection: string
+  readonly id: string
+  readonly from: string
+  readonly to: string
+
+  constructor(collection: string, id: string, from: string, to: string) {
+    super(
+      'ILLEGAL_TRANSITION',
+      `Cannot transition ${collection}/${id} from "${from}" to "${to}" — not a declared arc. ` +
+        `Use withTransactions({ amendment: true, reason }) with admin/owner role to override.`,
+    )
+    this.name = 'IllegalTransitionError'
+    this.collection = collection
+    this.id = id
+    this.from = from
+    this.to = to
+  }
+}
+
+/**
  * Thrown by an amendment invariant when the proposed change-set violates
  * the declared business rule (e.g. disbursement total not preserved).
  * Triggers a full transaction rollback via the existing revert pass.

--- a/packages/hub/src/guards/index.ts
+++ b/packages/hub/src/guards/index.ts
@@ -1,6 +1,8 @@
 export { withGuard } from './with-guard.js'
 export { immutableGuard } from './immutable-guard.js'
 export type { ImmutableGuardConfig } from './immutable-guard.js'
+export { transitionGuard } from './transition-guard.js'
+export type { TransitionGuardConfig } from './transition-guard.js'
 export { GuardRegistry } from './registry.js'
 export { GuardExecutor } from './executor.js'
 export { ReadOnlyVaultFacade } from './read-only-facade.js'
@@ -17,6 +19,7 @@ export type {
 export {
   RecordLockedError,
   FieldFrozenError,
+  IllegalTransitionError,
   InvariantError,
   AmendmentForbiddenError,
 } from '../errors.js'

--- a/packages/hub/src/guards/transition-guard.ts
+++ b/packages/hub/src/guards/transition-guard.ts
@@ -1,0 +1,152 @@
+/**
+ * `transitionGuard` — declarative state-machine sugar over the guard
+ * subsystem.
+ *
+ * Any record with a lifecycle field (invoice `status`, order state,
+ * ticket workflow, subscription phase) needs transition validation: a
+ * write may only move the field along a declared arc. That is expressible
+ * with a hand-rolled `withGuard({ check })`, but every consumer
+ * re-implements the same graph lookup + error. `transitionGuard`
+ * generates exactly that guard from a state graph, reusing the guard
+ * machinery wholesale — `check` rejection, the ledgered `amendment`
+ * override, and composition with `periods`/`history`.
+ *
+ * It generalizes {@link immutableGuard}: WORM is the special case "every
+ * state has no outgoing arcs", i.e. `transitions` mapping each state to `[]`.
+ *
+ * ```ts
+ * createNoydb({ guardStrategies: [
+ *   transitionGuard<Sale>({
+ *     collection: 'sales', field: 'status',
+ *     transitions: {                          // absence of an arc = forbidden
+ *       draft: ['to_verify', 'cancelled'],
+ *       to_verify: ['proforma', 'draft', 'cancelled'],
+ *       proforma: ['invoiced', 'cancelled'],
+ *       invoiced: ['paid'], paid: [], cancelled: [],
+ *     },
+ *     initial: ['draft', 'to_verify'],        // allowed status on insert
+ *   }),
+ * ] })
+ * ```
+ *
+ * Semantics:
+ * - **Insert** (`ctx.existing === null`): `incoming[field]` must be in
+ *   `initial`. When `initial` is omitted, any value is allowed on insert.
+ * - **Update**: the arc `(existing[field] → incoming[field])` must be
+ *   listed in `transitions[from]`, else `IllegalTransitionError`. A
+ *   same-value write (`from === to`) is allowed when `allowIdempotent`
+ *   (default `true`) — so writes that touch other fields without moving
+ *   state pass.
+ * - **Override**: inside an `amendment` transaction by an authorized role
+ *   the check is skipped and the change is ledgered (mirrors every guard).
+ *
+ * The status graph is caller-supplied data — no UI, no domain logic.
+ */
+
+import { withGuard } from './with-guard.js'
+import type { GuardStrategy, GuardStrategyHandle, GuardContext, GuardChange } from './types.js'
+import { IllegalTransitionError, ValidationError } from '../errors.js'
+
+export interface TransitionGuardConfig<T extends Record<string, unknown>> {
+  /** The collection whose state field is governed. */
+  collection: string
+  /** The state field on the record (e.g. `'status'`). */
+  field: keyof T & string
+  /**
+   * The transition graph: each state maps to the states it may move to.
+   * A state absent from the map (or mapped to `[]`) is terminal — no
+   * outgoing arc, so any non-idempotent write from it is rejected.
+   */
+  transitions: Readonly<Record<string, readonly string[]>>
+  /**
+   * States allowed as the initial value on insert (`existing === null`).
+   * Omit to allow any value on insert.
+   */
+  initial?: readonly string[]
+  /**
+   * Allow a same-value write (`from === to`) on update. Default `true` —
+   * lets a put that changes other fields, but not the state, through.
+   */
+  allowIdempotent?: boolean
+  /** Roles permitted to override via an amendment transaction. Default `['admin', 'owner']`. */
+  amendmentRoles?: ReadonlyArray<'admin' | 'owner'>
+  /**
+   * Optional set-level invariant run over the amendment change-set after
+   * the writes execute. Signature matches `GuardStrategy.amendment.invariant`
+   * exactly. When omitted the amendment is unconditionally allowed (the
+   * amendment itself is the sanctioned, ledgered override) — the
+   * backward-compatible default. Mirrors {@link immutableGuard}.
+   */
+  amendmentInvariant?: (
+    changes: ReadonlyArray<GuardChange<T>>,
+    ctx: GuardContext<T>,
+  ) => Promise<void> | void
+}
+
+function recordId(record: Record<string, unknown> | null): string {
+  const id = record?.id
+  return typeof id === 'string' ? id : ''
+}
+
+function stateOf(record: Record<string, unknown>, field: string): string {
+  const v = record[field]
+  return typeof v === 'string' ? v : String(v)
+}
+
+/**
+ * Build a state-machine transition guard. Pass the returned handle to
+ * `createNoydb({ guardStrategies: [...] })`.
+ */
+export function transitionGuard<T extends Record<string, unknown>>(
+  config: TransitionGuardConfig<T>,
+): GuardStrategyHandle<T> {
+  const { collection, field, transitions, initial, amendmentRoles, amendmentInvariant } = config
+  const allowIdempotent = config.allowIdempotent ?? true
+
+  if (!field) {
+    throw new ValidationError('transitionGuard: `field` is required')
+  }
+  if (transitions === undefined || typeof transitions !== 'object') {
+    throw new ValidationError('transitionGuard: `transitions` must be a state→states map')
+  }
+
+  const spec: GuardStrategy<T> = {
+    collection,
+    check: (incoming: T, ctx: GuardContext<T>) => {
+      const rec = incoming as Record<string, unknown>
+      const to = stateOf(rec, field)
+
+      // Insert — gate on the allowed initial set (any value if unset).
+      if (ctx.existing === null) {
+        if (initial !== undefined && !initial.includes(to)) {
+          throw new IllegalTransitionError(collection, recordId(rec), '(none)', to)
+        }
+        return
+      }
+
+      // Update — the arc (from → to) must be a declared edge.
+      const from = stateOf(ctx.existing as Record<string, unknown>, field)
+      if (from === to) {
+        if (allowIdempotent) return
+        throw new IllegalTransitionError(collection, recordId(rec), from, to)
+      }
+      const allowed = transitions[from] ?? []
+      if (!allowed.includes(to)) {
+        throw new IllegalTransitionError(collection, recordId(rec), from, to)
+      }
+    },
+    // The authorized override: inside an amendment transaction the check
+    // is skipped and the change is ledgered. By default no extra invariant
+    // — the amendment itself is the sanctioned exception. Callers may
+    // supply `amendmentInvariant` to keep a constraint inviolable even
+    // under amendment; a throw reverts the amendment as `InvariantError`.
+    amendment: {
+      roles: amendmentRoles ?? ['admin', 'owner'],
+      invariant: amendmentInvariant ?? (() => {
+        /* allow — the amendment is the override, and is ledgered */
+      }),
+    },
+  }
+
+  return withGuard<T>(spec)
+}

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -262,6 +262,7 @@ export {
   ReadOnlyFrameError,
   RecordLockedError,
   FieldFrozenError,
+  IllegalTransitionError,
   InvariantError,
   AmendmentForbiddenError,
   AttestationError,
@@ -652,6 +653,8 @@ export type { TransactionStrategyOptions } from './tx/active.js'
 export { withGuard } from './guards/index.js'
 export { immutableGuard } from './guards/index.js'
 export type { ImmutableGuardConfig } from './guards/index.js'
+export { transitionGuard } from './guards/index.js'
+export type { TransitionGuardConfig } from './guards/index.js'
 export type {
   GuardStrategy,
   GuardStrategyHandle,

--- a/showcases/src/101-transition-guard.showcase.test.ts
+++ b/showcases/src/101-transition-guard.showcase.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Showcase 101 — transitionGuard (state-machine lifecycle)
+ *
+ * What you'll learn
+ * ─────────────────
+ * `transitionGuard` turns a lifecycle field into a declarative state
+ * machine. You give it the allowed arcs; it rejects every write that
+ * moves the field along an edge you didn't declare — no hand-rolled
+ * `check` boilerplate. It's sugar over `withGuard`, so it inherits the
+ * ledgered `amendment` override for sanctioned exceptions.
+ *
+ *   - A `sales` record walks draft → to_verify → proforma → invoiced → paid.
+ *   - An illegal jump (draft → paid) is rejected with IllegalTransitionError.
+ *   - An admin/owner amendment transaction can override an illegal arc
+ *     (and the override is recorded on the audit ledger).
+ *
+ * Why it matters
+ * ──────────────
+ * Lifecycle bugs ("an invoice went back to draft after being paid") are
+ * a recurring class. Declaring the graph once, at the data layer, makes
+ * the illegal transition structurally impossible for normal writes while
+ * still allowing an auditable manual correction.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 00 + 79 (withGuard) + 20 (transactions).
+ *
+ * What to read next
+ * ─────────────────
+ *   - showcase 79-with-guard (the underlying primitive)
+ *   - docs/subsystems/guards.md
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → transition-guard
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, transitionGuard, IllegalTransitionError } from '@noy-db/hub'
+import { withTransactions } from '@noy-db/hub/tx'
+import { withHistory } from '@noy-db/hub/history'
+import { memory } from '@noy-db/to-memory'
+
+interface Sale extends Record<string, unknown> { id: string; status: string; total: number }
+
+async function open() {
+  const db = await createNoydb({
+    store: memory(),
+    user: 'alice',
+    secret: 'transition-guard-showcase-2026',
+    historyStrategy: withHistory(),
+    txStrategy: withTransactions(),
+    guardStrategies: [
+      transitionGuard<Sale>({
+        collection: 'sales',
+        field: 'status',
+        transitions: {
+          draft: ['to_verify', 'cancelled'],
+          to_verify: ['proforma', 'draft', 'cancelled'],
+          proforma: ['invoiced', 'cancelled'],
+          invoiced: ['paid'],
+          paid: [],
+          cancelled: [],
+        },
+        initial: ['draft'],
+      }),
+    ],
+  })
+  const vault = await db.openVault('firm')
+  return { db, vault, sales: vault.collection<Sale>('sales') }
+}
+
+describe('Showcase 101 — transitionGuard', () => {
+  it('walks the declared lifecycle and rejects an illegal jump', async () => {
+    const { db, sales } = await open()
+
+    await sales.put('s1', { id: 's1', status: 'draft', total: 100 })
+    await sales.put('s1', { id: 's1', status: 'to_verify', total: 100 })
+    await sales.put('s1', { id: 's1', status: 'proforma', total: 100 })
+    await sales.put('s1', { id: 's1', status: 'invoiced', total: 100 })
+    await sales.put('s1', { id: 's1', status: 'paid', total: 100 })
+    expect((await sales.get('s1'))?.status).toBe('paid')
+
+    // A fresh sale cannot jump straight to paid.
+    await sales.put('s2', { id: 's2', status: 'draft', total: 50 })
+    await expect(sales.put('s2', { id: 's2', status: 'paid', total: 50 }))
+      .rejects.toBeInstanceOf(IllegalTransitionError)
+    expect((await sales.get('s2'))?.status).toBe('draft') // unchanged
+
+    db.close()
+  })
+
+  it('an admin/owner amendment overrides an illegal arc and is ledgered', async () => {
+    const { db, vault, sales } = await open()
+    await sales.put('s1', { id: 's1', status: 'draft', total: 100 })
+
+    // Manual correction: jump draft → paid via an amendment.
+    await db.transaction({ amendment: true, reason: 'reconciliation: legacy import' }, async (tx) => {
+      tx.vault('firm').collection<Sale>('sales').put('s1', { id: 's1', status: 'paid', total: 100 })
+    })
+    expect((await sales.get('s1'))?.status).toBe('paid')
+
+    // The override is on the audit ledger.
+    const entries = await vault.ledger().entries()
+    expect(entries.some((e) => e.op === 'amendment')).toBe(true)
+
+    db.close()
+  })
+})


### PR DESCRIPTION
Closes #374.

## What & why

`immutableGuard` was the only declarative guard sugar. Any app with a lifecycle field (invoice `status`, order state, ticket workflow) hand-rolls transition validation in a custom `withGuard({ check })` — repetitive and easy to get subtly wrong. `transitionGuard` generalizes `immutableGuard` (which is just "any state → locked") to an arbitrary state graph.

```ts
createNoydb({ guardStrategies: [
  transitionGuard<Sale>({
    collection: 'sales', field: 'status',
    transitions: {                          // absence of an arc = forbidden
      draft: ['to_verify', 'cancelled'],
      to_verify: ['proforma', 'draft', 'cancelled'],
      proforma: ['invoiced', 'cancelled'],
      invoiced: ['paid'], paid: [], cancelled: [],
    },
    initial: ['draft', 'to_verify'],        // allowed status on insert (default: any)
  }),
] })
```

## Semantics

- **Insert** (`existing === null`): `incoming[field]` must be in `initial` (any value when omitted); a violation reports `from: '(none)'`.
- **Update**: the arc `(existing[field] → incoming[field])` must be a declared edge in `transitions[from]`, else `IllegalTransitionError(collection, id, from, to)`. A state absent from the map (or mapped to `[]`) is terminal.
- **Idempotent**: a same-state write (`from === to`) passes when `allowIdempotent` (default `true`), so a put that changes other fields without moving state is fine.
- **Override**: an `amendment` tx by an authorized role skips the check and is ledgered — mirrors every guard. `immutableGuard` is the WORM special case (every state → `[]`).

## How

Pure sugar over `withGuard` — no new write-path code (same approach as `immutableGuard`, which was the template). New `IllegalTransitionError` (code `ILLEGAL_TRANSITION`), exported from `@noy-db/hub` and `@noy-db/hub/guards`. Optional `amendmentInvariant` mirrors `immutableGuard` for keeping a constraint inviolable even under amendment.

## Tests

- New `packages/hub/__tests__/guards/transition-guard.test.ts` (13): factory validation, initial-set inserts (in/out/omitted), declared/undeclared arcs, terminal states, error `from`/`to` payload, idempotent on/off, amendment override.
- Showcase 101 (invoice lifecycle draft→…→paid + one rejected illegal jump + one ledgered amendment override).
- `docs/subsystems/guards.md` + `features.yaml` (new `transition-guard` entry).
- Full hub suite green (263 files / 2547 tests).

Part of the pilot-2 fast-lane batch (#374/#375/#377-A). #376 (FK derivations), #377-B (`vault.link`), and #378 (maturity) are deferred to a design pass.