### PR TITLE
feat(sequence): formatted + reset-aware sequences (#375)

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -311,7 +311,9 @@ features:
     package: '@noy-db/hub'
     factory: null
     status: preview
-    showcases: []
+    showcases:
+      - id: 102-formatted-sequence
+        path: showcases/src/102-formatted-sequence.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -322,6 +324,7 @@ features:
       - 'jittered backoff; SequenceContentionError after the retry budget so callers can retry/queue'
       - 'partitioned counters (#345): vault.sequence(series, { partition: [...] }) keys an independent counter per partition; storage key = series + null-byte separator + URI-encoded "/"-joined parts, provably disjoint from plain series keys (null byte rejected in a series name)'
       - 'seedTo(n) (#345): set-if-greater on the handle — advances to at least n, never rewinds; idempotent + CAS-safe under concurrent next()/seedTo(); fixes bundle/CSV-import counter restart-at-0; online-only (SequenceOfflineError on non-CAS; ValidationError on a deferred series)'
+      - 'formatted serials (#375): vault.sequence(series, { format }) returns a FormattedSequenceHandle whose next() resolves to { serial, formatted }; tokens {seq}/{seq:0N}/{partition.i}; unknown token or out-of-range partition index throws ValidationError at construction; per-partition reset is inherent; unformatted next() still returns a bare number (back-compat); format is CAS-only (ValidationError on a deferred series — deferred-numbering render is a follow-up)'
     related: [stores-contract, query-basics]
 
   - id: deferred-numbering

--- a/packages/hub/__tests__/sequence.test.ts
+++ b/packages/hub/__tests__/sequence.test.ts
@@ -326,3 +326,75 @@ describe('#345 vault.sequence — partition + seedTo', () => {
     expect(await seq.next()).toBe(51)
   })
 })
+
+describe('#375 vault.sequence — format', () => {
+  it('next() returns { serial, formatted } when format is set', async () => {
+    const v = await vault(memory())
+    const seq = v.sequence('fatture', { partition: [2026], format: '{partition.0}/{seq:04}' })
+    expect(await seq.next()).toEqual({ serial: 1, formatted: '2026/0001' })
+    expect(await seq.next()).toEqual({ serial: 2, formatted: '2026/0002' })
+  })
+
+  it('per-partition reset is inherent — a new partition starts at 0001', async () => {
+    const v = await vault(memory())
+    const y2026 = v.sequence('fatture', { partition: [2026], format: '{partition.0}/{seq:04}' })
+    const y2027 = v.sequence('fatture', { partition: [2027], format: '{partition.0}/{seq:04}' })
+    expect((await y2026.next()).formatted).toBe('2026/0001')
+    expect((await y2026.next()).formatted).toBe('2026/0002')
+    expect((await y2027.next()).formatted).toBe('2027/0001') // independent counter
+    expect((await y2026.next()).formatted).toBe('2026/0003')
+  })
+
+  it('renders {seq} unpadded and {seq:0N} zero-padded', async () => {
+    const v = await vault(memory())
+    const bare = v.sequence('a', { format: 'INV-{seq}' })
+    expect((await bare.next()).formatted).toBe('INV-1')
+    const padded = v.sequence('b', { format: 'INV-{seq:03}' })
+    expect((await padded.next()).formatted).toBe('INV-001')
+  })
+
+  it('renders multiple partition components', async () => {
+    const v = await vault(memory())
+    const seq = v.sequence('inv', { partition: [2026, 'EU'], format: '{partition.1}-{partition.0}-{seq:05}' })
+    expect((await seq.next()).formatted).toBe('EU-2026-00001')
+  })
+
+  it('peek() and seedTo() still operate on the underlying integer', async () => {
+    const v = await vault(memory())
+    const seq = v.sequence('fatture', { partition: [2026], format: '{partition.0}/{seq:04}' })
+    expect(await seq.peek()).toBe(0)
+    await seq.seedTo(41)
+    expect(await seq.peek()).toBe(41)
+    expect(await seq.next()).toEqual({ serial: 42, formatted: '2026/0042' })
+  })
+
+  it('throws ValidationError at construction on an unknown token', () => {
+    return vault(memory()).then((v) => {
+      expect(() => v.sequence('x', { format: '{year}/{seq}' })).toThrow(ValidationError)
+    })
+  })
+
+  it('throws ValidationError at construction when {partition.i} exceeds the partition', () => {
+    return vault(memory()).then((v) => {
+      expect(() => v.sequence('x', { partition: [2026], format: '{partition.2}/{seq}' })).toThrow(ValidationError)
+    })
+  })
+
+  it('unformatted sequences still return a bare number (back-compat)', async () => {
+    const v = await vault(memory())
+    const seq = v.sequence('plain')
+    const n = await seq.next()
+    expect(typeof n).toBe('number')
+    expect(n).toBe(1)
+  })
+
+  it('rejects format on a deferred-numbering series', async () => {
+    const { withDeferredNumbering } = await import('../src/numbering/descriptor.js')
+    const db = await createNoydb({
+      store: memory(), user: 'owner', secret: 'pw',
+      numbering: [withDeferredNumbering({ series: 'def', collection: 'docs', field: 'serial' })],
+    })
+    const v = await db.openVault('books')
+    expect(() => v.sequence('def', { format: '{seq:04}' })).toThrow(ValidationError)
+  })
+})

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -289,8 +289,8 @@ export type {
 } from './archive/index.js'
 
 // ─── Atomic sequence (#303) ─────────────────────────────────────────────────────
-export { SequenceStore, resolveSequenceKey } from './sequence/index.js'
-export type { SequenceHandle, NextOptions, SequenceOptions } from './sequence/index.js'
+export { SequenceStore, resolveSequenceKey, compileSequenceFormat } from './sequence/index.js'
+export type { SequenceHandle, FormattedSequenceHandle, NextOptions, SequenceOptions } from './sequence/index.js'
 
 // Deferred numbering — store-clock-ordered serials for non-CAS stores.
 export { withDeferredNumbering } from './numbering/descriptor.js'

--- a/packages/hub/src/sequence/index.ts
+++ b/packages/hub/src/sequence/index.ts
@@ -58,6 +58,81 @@ export interface NextOptions {
 export interface SequenceOptions {
   /** Partition tuple. Each component is URI-encoded and `'/'`-joined. */
   readonly partition?: readonly (string | number)[]
+  /**
+   * Render template for the serial string (#375). When set, `vault.sequence`
+   * returns a {@link FormattedSequenceHandle} whose `next()` resolves to
+   * `{ serial, formatted }`. Tokens:
+   * - `{seq}` — the allocated integer
+   * - `{seq:0N}` — zero-padded to width N (e.g. `{seq:04}` → `0001`)
+   * - `{partition.i}` — the i-th `partition` component (original value)
+   *
+   * Any other token, or a `{partition.i}` index beyond the supplied
+   * `partition`, throws `ValidationError` at `vault.sequence()` construction.
+   * Per-partition reset is inherent: a new partition tuple starts at 1.
+   */
+  readonly format?: string
+}
+
+/**
+ * A formatted sequence handle (#375). Identical to {@link SequenceHandle}
+ * except `next()` also returns the rendered `formatted` string. `peek()` /
+ * `seedTo()` operate on the underlying integer counter, unchanged.
+ */
+export interface FormattedSequenceHandle {
+  /** Allocate the next value and return it with its rendered serial string. */
+  next(opts?: NextOptions): Promise<{ serial: number; formatted: string }>
+  /** Read the current integer value without allocating. Returns 0 if never used. */
+  peek(): Promise<number>
+  /** Set-if-greater on the underlying integer counter. See {@link SequenceHandle.seedTo}. */
+  seedTo(n: number): Promise<void>
+}
+
+// Matches a single `{...}` token with no nested braces.
+const SEQ_FORMAT_TOKEN = /\{([^{}]*)\}/g
+const SEQ_PAD_TOKEN = /^seq:0(\d+)$/
+const SEQ_PARTITION_TOKEN = /^partition\.(\d+)$/
+
+/**
+ * Validate a sequence `format` against the supplied partition and return a
+ * pure `(serial) => string` renderer. Eager validation: every token is
+ * checked now, so a bad pattern throws `ValidationError` at construction —
+ * never at `next()` time.
+ */
+export function compileSequenceFormat(
+  format: string,
+  series: string,
+  partition: readonly (string | number)[] | undefined,
+): (serial: number) => string {
+  const parts = partition ?? []
+  for (const m of format.matchAll(SEQ_FORMAT_TOKEN)) {
+    const token = m[1] ?? ''
+    if (token === 'seq') continue
+    if (SEQ_PAD_TOKEN.test(token)) continue
+    const partMatch = SEQ_PARTITION_TOKEN.exec(token)
+    if (partMatch) {
+      const idx = Number(partMatch[1])
+      if (idx >= parts.length) {
+        throw new ValidationError(
+          `sequence("${series}"): format token "{${token}}" references partition index ${idx}, ` +
+            `but only ${parts.length} partition component(s) were supplied.`,
+        )
+      }
+      continue
+    }
+    throw new ValidationError(
+      `sequence("${series}"): format contains unknown token "{${token}}". ` +
+        `Accepted tokens: {seq}, {seq:0N}, {partition.i}.`,
+    )
+  }
+  return (serial: number): string =>
+    format.replace(SEQ_FORMAT_TOKEN, (full, token: string) => {
+      if (token === 'seq') return String(serial)
+      const padMatch = SEQ_PAD_TOKEN.exec(token)
+      if (padMatch) return String(serial).padStart(Number(padMatch[1]), '0')
+      const partMatch = SEQ_PARTITION_TOKEN.exec(token)
+      if (partMatch) return String(parts[Number(partMatch[1])])
+      return full // unreachable — validated above
+    })
 }
 
 /**

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -45,7 +45,7 @@ import type { BlobStrategy } from './blobs/strategy.js'
 import type { ArchiveStrategy } from './archive/index.js'
 import type { ArchivePolicy, ArchiveContext, ArchiveResult, ArchiveRunOptions } from './archive/index.js'
 import { runArchive, runRestore, runListArchived } from './archive/index.js'
-import { SequenceStore, type SequenceHandle, type SequenceOptions, resolveSequenceKey, SEQUENCE_COLLECTION } from './sequence/index.js'
+import { SequenceStore, type SequenceHandle, type FormattedSequenceHandle, type SequenceOptions, resolveSequenceKey, compileSequenceFormat, SEQUENCE_COLLECTION } from './sequence/index.js'
 import { DeferredNumberingStore, type Assignment } from './numbering/index.js'
 import type { DeferredNumberingConfig } from './numbering/descriptor.js'
 import type { IndexStrategy } from './indexing/strategy.js'
@@ -1564,8 +1564,19 @@ export class Vault {
    * const n = await vault.sequence('invoice-2026').next()   // 1, then 2, …
    * const cur = await vault.sequence('invoice-2026').peek()  // current value, no allocation
    * ```
+   *
+   * Pass a `format` (#375) to emit a serial string instead of a bare
+   * integer — `next()` then returns `{ serial, formatted }`. Per-partition
+   * reset is inherent (a new partition tuple starts at 1):
+   *
+   * ```ts
+   * const seq = vault.sequence('fatture', { partition: [2026], format: '{partition.0}/{seq:04}' })
+   * await seq.next()   // { serial: 1, formatted: '2026/0001' }
+   * ```
    */
-  sequence(series: string, opts?: SequenceOptions): SequenceHandle {
+  sequence(series: string, opts: SequenceOptions & { format: string }): FormattedSequenceHandle
+  sequence(series: string, opts?: SequenceOptions): SequenceHandle
+  sequence(series: string, opts?: SequenceOptions): SequenceHandle | FormattedSequenceHandle {
     // A null byte is the structural partition separator in
     // resolveSequenceKey; a series name carrying one could forge a
     // partitioned key, so reject it (#345).
@@ -1577,6 +1588,14 @@ export class Vault {
     // no CAS counter, so seedTo (CAS-only) is unavailable. All other names
     // use the CAS counter.
     if (this.numberingConfigs.has(series)) {
+      if (opts?.format !== undefined) {
+        // Deferred numbering stamps an auto-assigned serial onto a record
+        // field at seal time; a render template there is a separate change
+        // (it would alter the stamped field's type). Not in this slice (#375).
+        throw new ValidationError(
+          `sequence("${series}") is a deferred-numbering series; the format option applies to CAS sequences only.`,
+        )
+      }
       const eng = this.deferred()
       return {
         next: async (nextOpts) => {
@@ -1600,7 +1619,20 @@ export class Vault {
         actor: this.keyring.userId,
       })
     }
-    return this.sequenceStore.handle(resolveSequenceKey(series, opts))
+    const handle = this.sequenceStore.handle(resolveSequenceKey(series, opts))
+    if (opts?.format === undefined) return handle
+    // Formatted variant (#375): validate the template now (throws on a bad
+    // token), then wrap next() to also return the rendered serial string.
+    // peek/seedTo operate on the underlying integer counter, unchanged.
+    const render = compileSequenceFormat(opts.format, series, opts.partition)
+    return {
+      next: async (nextOpts) => {
+        const serial = await handle.next(nextOpts)
+        return { serial, formatted: render(serial) }
+      },
+      peek: () => handle.peek(),
+      seedTo: (n) => handle.seedTo(n),
+    }
   }
 
   /** @internal — lazily build the deferred-numbering engine with a cache-coherent stamp. */

--- a/showcases/src/102-formatted-sequence.showcase.test.ts
+++ b/showcases/src/102-formatted-sequence.showcase.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Showcase 102 — formatted sequences (fiscal numbering)
+ *
+ * What you'll learn
+ * ─────────────────
+ * `vault.sequence(series, { partition, format })` emits a human/fiscal
+ * serial STRING (`2026/0001`), not a bare integer. The counter stays
+ * gap-free and atomic; the `format` template just renders it. Per-year
+ * reset is inherent: partition the counter by year and a new year starts
+ * back at `0001`.
+ *
+ *   - `next()` returns `{ serial, formatted }` when a format is set.
+ *   - `{seq:04}` zero-pads; `{partition.i}` injects a partition component.
+ *   - partition: [2026] and partition: [2027] are independent counters.
+ *
+ * Why it matters
+ * ──────────────
+ * Legal invoice/DDT numbering (e.g. Italian fatture: `2026/0001`,
+ * per-year reset) is otherwise hand-formatted in userland — the place
+ * where off-by-one and reset bugs hide. Declaring the pattern at the
+ * counter keeps the serial gap-free AND correctly shaped in one call.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 00.
+ *
+ * What to read next
+ * ─────────────────
+ *   - docs/subsystems/ (atomic-sequence) — the underlying counter
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → atomic-sequence
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+
+describe('Showcase 102 — formatted sequences', () => {
+  it('numbers per-year invoices 2026/0001… and resets at 2027/0001', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'formatted-sequence-showcase-2026',
+    })
+    const vault = await db.openVault('firm')
+
+    const fatture2026 = vault.sequence('fatture', {
+      partition: [2026],
+      format: '{partition.0}/{seq:04}',
+    })
+
+    const a = await fatture2026.next()
+    const b = await fatture2026.next()
+    expect(a).toEqual({ serial: 1, formatted: '2026/0001' })
+    expect(b).toEqual({ serial: 2, formatted: '2026/0002' })
+
+    // New fiscal year — an independent counter, reset to 0001.
+    const fatture2027 = vault.sequence('fatture', {
+      partition: [2027],
+      format: '{partition.0}/{seq:04}',
+    })
+    expect((await fatture2027.next()).formatted).toBe('2027/0001')
+
+    // 2026 continues unaffected.
+    expect((await fatture2026.next()).formatted).toBe('2026/0003')
+
+    db.close()
+  })
+
+  it('peek reads the underlying integer; the serial stays gap-free', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'formatted-sequence-showcase-2026',
+    })
+    const vault = await db.openVault('firm')
+    const seq = vault.sequence('ddt', { format: 'DDT-{seq:05}' })
+
+    expect(await seq.peek()).toBe(0)
+    expect((await seq.next()).formatted).toBe('DDT-00001')
+    expect((await seq.next()).formatted).toBe('DDT-00002')
+    expect(await seq.peek()).toBe(2)
+
+    db.close()
+  })
+})


### PR DESCRIPTION
Closes #375 (CAS path; deferred-numbering render noted as a follow-up below).

## What & why

`vault.sequence(series).next()` returned a bare integer. Apps needing human/fiscal serials (`2026/0001`, `INV-2026-00042`, per-year reset) formatted + managed reset in userland — exactly where off-by-one and reset bugs hide. Partitions already isolate counters (so per-year reset works); the **format string** was the missing piece.

```ts
const seq = vault.sequence('fatture', {
  partition: [2026],                  // per-year counter (reset boundary)
  format: '{partition.0}/{seq:04}',   // → "2026/0001"
})
await seq.next()   // { serial: 1, formatted: '2026/0001' }
await seq.peek()   // current integer (unchanged)
```

## How

- `SequenceOptions.format` with tokens `{seq}`, `{seq:0N}` (zero-pad to width N), `{partition.i}` (i-th partition component).
- When `format` is set, `vault.sequence()` returns a **`FormattedSequenceHandle`** whose `next()` resolves to `{ serial, formatted }`. `peek()` / `seedTo()` operate on the underlying integer counter, unchanged.
- **Back-compat:** unformatted `next()` still returns a bare `number` — the method is overloaded, so no existing caller is affected (there were zero in-repo callers relying on a non-number).
- **Per-partition reset is inherent:** `{ partition: [2026] }` and `{ partition: [2027] }` are independent counters, each starting at 1.
- `compileSequenceFormat` validates every token **eagerly at construction**: an unknown token or out-of-range `{partition.i}` throws `ValidationError` before the handle is returned — never at `next()` time.
- `SequenceStore` internals are untouched — formatting wraps the handle in `vault.ts`.

## Scope note — deferred numbering

`format` is **CAS-only**; passing it on a `withDeferredNumbering` series throws `ValidationError`. Rendering at `runNumberingPass()` seal time would change the auto-stamped field's *type* (number → string) and needs its own design + tests, so it's a tracked follow-up. The acceptance criteria (formatted serials, padding, partition tokens, per-partition reset, showcase) are all on the CAS path and are met here.

## Tests

- `packages/hub/__tests__/sequence.test.ts` new `#375` block (10): `{serial,formatted}` shape, per-partition reset (2026 vs 2027 independent), `{seq}`/`{seq:0N}` padding, multi-component partition, peek/seedTo on the integer, unknown-token + out-of-range-partition `ValidationError` at construction, bare-number back-compat, deferred-series rejection.
- Showcase 102 (per-year fatture `2026/0001…` resetting at `2027/0001`).
- `features.yaml` atomic-sequence updated. Full hub suite green (262 files / 2543 tests).

Part of the pilot-2 fast-lane batch (#374/#375/#377-A).