### PR TITLE
feat(refs): refArray — array refs / M:N link integrity (#377-A)

### DIFF
--- a/docs/core/05-schema-and-refs.md
+++ b/docs/core/05-schema-and-refs.md
@@ -53,6 +53,33 @@ Three modes (passed as `ref(target, mode)` or `ref(target, { mode })`):
 | `'warn'` | Throws | Joined value is `null`; one-shot console warn |
 | `'cascade'` | Cascades the delete to all referencing children | Joined value is `null` silently |
 
+### Array refs / many-to-many (`refArray`, #377-A)
+
+`refArray(target, mode)` gives a field holding an **array of ids** the same
+integrity, for M:N relationships (order↔product, post↔tag):
+
+```ts
+import { refArray } from '@noy-db/hub'
+
+const orders = vault.collection<Order>('orders', {
+  refs: { productIds: refArray('products', 'warn') },
+})
+```
+
+Each element is validated against `target` independently, with the same
+three modes applied per element:
+
+- **strict** — `put()` rejects if **any** element's target is missing (the
+  error's `refId` is the offending element); `delete()` of a target is
+  blocked while any record's array still contains its id.
+- **warn** — both succeed; `vault.checkIntegrity()` reports **one violation
+  per dangling element**.
+- **cascade** — `delete()` of a target deletes every record whose array
+  contains its id (cycle-safe, like scalar cascade); `put()` is unchecked
+  (same as scalar cascade).
+
+An empty array or a `null`/`undefined` field is allowed (no links).
+
 Used by:
 - `query.join(field, { as })` — see [docs/subsystems/joins.md](../subsystems/joins.md)
 - `vault.checkIntegrity()` — full ref-graph audit

--- a/features.yaml
+++ b/features.yaml
@@ -167,7 +167,9 @@ features:
     package: '@noy-db/hub'
     factory: null
     status: stable
-    showcases: []
+    showcases:
+      - id: 103-ref-array
+        path: showcases/src/103-ref-array.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -175,6 +177,7 @@ features:
       - 'Standard Schema v1 — Zod, Valibot, ArkType, Effect Schema compatible'
       - 'Validation runs before encryption (write) and after decryption (read)'
       - 'cascade-delete (ref mode "cascade") is transaction-atomic (#346): cascaded child deletes register on the active TxContext (_executed) and roll back with the parent on mid-batch failure; outside a tx, children + parent delete in place as before'
+      - 'array refs / M:N (#377-A): refArray(target, mode) validates each element of an id-array field against the target; strict rejects on a missing element at put + blocks delete of a referenced target; cascade deletes every record whose array contains the deleted id (cycle-safe); warn surfaces one checkIntegrity() violation per dangling element; empty/nullish arrays allowed'
     related: [vault-and-collections]
 
   - id: money-field

--- a/packages/hub/__tests__/refs.test.ts
+++ b/packages/hub/__tests__/refs.test.ts
@@ -27,6 +27,8 @@ import { ConflictError } from '../src/errors.js'
 import { withTransactions } from '../src/tx/index.js'
 import {
   ref,
+  refArray,
+  isRefArray,
   RefIntegrityError,
   RefScopeError,
   RefRegistry,
@@ -593,5 +595,131 @@ describe('checkIntegrity.', () => {
     const result = await company.checkIntegrity()
     expect(result.violations).toHaveLength(2)
     expect(result.violations.map((v) => v.field).sort()).toEqual(['categoryId', 'clientId'])
+  })
+})
+
+// ─── refArray — many-to-many (#377-A) ────────────────────────────────
+
+interface Order {
+  id: string
+  productIds: string[] | null
+}
+
+describe('refArray() helper', () => {
+  it('produces an array-ref descriptor flagged isArray', () => {
+    const d = refArray('products', 'warn')
+    expect(d).toEqual({ target: 'products', mode: 'warn', isArray: true })
+    expect(isRefArray(d)).toBe(true)
+    expect(isRefArray(ref('products'))).toBe(false)
+  })
+  it('defaults to strict mode', () => {
+    expect(refArray('products').mode).toBe('strict')
+  })
+  it('rejects cross-vault targets', () => {
+    expect(() => refArray('other/products')).toThrow(RefScopeError)
+  })
+})
+
+describe('refArray — strict on put', () => {
+  let db: Noydb
+  beforeEach(async () => {
+    db = await createNoydb({ store: memory(), user: 'alice', historyStrategy: withHistory(), secret: 'test-passphrase-1234' })
+  })
+
+  it('allows put when every element target exists', async () => {
+    const company = await db.openVault('demo-co')
+    const products = company.collection<Client>('products')
+    const orders = company.collection<Order>('orders', { refs: { productIds: refArray('products') } })
+    await products.put('p-1', { id: 'p-1', name: 'A' })
+    await products.put('p-2', { id: 'p-2', name: 'B' })
+    await orders.put('o-1', { id: 'o-1', productIds: ['p-1', 'p-2'] })
+    expect(await orders.get('o-1')).toBeTruthy()
+  })
+
+  it('rejects put when any element target is missing (reports the bad element)', async () => {
+    const company = await db.openVault('demo-co')
+    const products = company.collection<Client>('products')
+    const orders = company.collection<Order>('orders', { refs: { productIds: refArray('products') } })
+    await products.put('p-1', { id: 'p-1', name: 'A' })
+    try {
+      await orders.put('o-1', { id: 'o-1', productIds: ['p-1', 'ghost'] })
+      throw new Error('expected throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(RefIntegrityError)
+      const e = err as RefIntegrityError
+      expect(e.field).toBe('productIds')
+      expect(e.refTo).toBe('products')
+      expect(e.refId).toBe('ghost')
+    }
+  })
+
+  it('allows an empty array and a nullish field', async () => {
+    const company = await db.openVault('demo-co')
+    company.collection<Client>('products')
+    const orders = company.collection<Order>('orders', { refs: { productIds: refArray('products') } })
+    await orders.put('o-1', { id: 'o-1', productIds: [] })
+    await orders.put('o-2', { id: 'o-2', productIds: null })
+    expect(await orders.get('o-1')).toBeTruthy()
+    expect(await orders.get('o-2')).toBeTruthy()
+  })
+
+  it('rejects a non-array value for an array-ref field', async () => {
+    const company = await db.openVault('demo-co')
+    company.collection<Client>('products')
+    const orders = company.collection<Record<string, unknown>>('orders', { refs: { productIds: refArray('products') } })
+    await expect(orders.put('o-1', { id: 'o-1', productIds: 'p-1' })).rejects.toBeInstanceOf(RefIntegrityError)
+  })
+})
+
+describe('refArray — delete (strict / cascade / warn)', () => {
+  let db: Noydb
+  beforeEach(async () => {
+    db = await createNoydb({ store: memory(), user: 'alice', historyStrategy: withHistory(), secret: 'test-passphrase-1234' })
+  })
+
+  it('strict: blocks delete of a target still referenced by any array', async () => {
+    const company = await db.openVault('demo-co')
+    const products = company.collection<Client>('products')
+    const orders = company.collection<Order>('orders', { refs: { productIds: refArray('products', 'strict') } })
+    await products.put('p-1', { id: 'p-1', name: 'A' })
+    await orders.put('o-1', { id: 'o-1', productIds: ['p-1'] })
+    await expect(products.delete('p-1')).rejects.toBeInstanceOf(RefIntegrityError)
+    expect(await products.get('p-1')).toBeTruthy()
+  })
+
+  it('cascade: deletes every record whose array contains the deleted id', async () => {
+    const company = await db.openVault('demo-co')
+    const products = company.collection<Client>('products')
+    const orders = company.collection<Order>('orders', { refs: { productIds: refArray('products', 'cascade') } })
+    await products.put('p-1', { id: 'p-1', name: 'A' })
+    await products.put('p-2', { id: 'p-2', name: 'B' })
+    await orders.put('o-1', { id: 'o-1', productIds: ['p-1', 'p-9'] })
+    await orders.put('o-2', { id: 'o-2', productIds: ['p-2'] })          // unrelated
+    await products.delete('p-1')
+    expect(await orders.get('o-1')).toBeNull()   // cascaded
+    expect(await orders.get('o-2')).toBeTruthy() // untouched
+  })
+
+  it('warn: delete leaves an orphaned element, surfaced by checkIntegrity', async () => {
+    const company = await db.openVault('demo-co')
+    const products = company.collection<Client>('products')
+    const orders = company.collection<Order>('orders', { refs: { productIds: refArray('products', 'warn') } })
+    await products.put('p-1', { id: 'p-1', name: 'A' })
+    await products.put('p-2', { id: 'p-2', name: 'B' })
+    await orders.put('o-1', { id: 'o-1', productIds: ['p-1', 'p-2'] })
+    await products.delete('p-2') // warn — allowed, leaves orphan
+    const result = await company.checkIntegrity()
+    expect(result.violations).toHaveLength(1)
+    expect(result.violations[0]).toMatchObject({ collection: 'orders', id: 'o-1', field: 'productIds', refTo: 'products', refId: 'p-2', mode: 'warn' })
+  })
+
+  it('checkIntegrity reports one violation per dangling element', async () => {
+    const company = await db.openVault('demo-co')
+    company.collection<Client>('products')
+    const orders = company.collection<Order>('orders', { refs: { productIds: refArray('products', 'warn') } })
+    await orders.put('o-1', { id: 'o-1', productIds: ['ghost-1', 'ghost-2'] })
+    const result = await company.checkIntegrity()
+    expect(result.violations).toHaveLength(2)
+    expect(result.violations.map((v) => v.refId).sort()).toEqual(['ghost-1', 'ghost-2'])
   })
 })

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -446,6 +446,8 @@ export type {
 // Foreign-key references via ref()
 export {
   ref,
+  refArray,
+  isRefArray,
   RefRegistry,
   RefIntegrityError,
   RefScopeError,

--- a/packages/hub/src/refs.ts
+++ b/packages/hub/src/refs.ts
@@ -58,6 +58,21 @@ export type RefMode = 'strict' | 'warn' | 'cascade'
 export interface RefDescriptor {
   readonly target: string
   readonly mode: RefMode
+  /**
+   * Present and `true` only for an array ref (#377-A, `refArray()`): the
+   * field holds an ARRAY of ids, each validated against `target`
+   * independently (M:N). Absent for a scalar `ref()`. The same `mode`
+   * semantics apply per element — strict rejects on a missing element at
+   * put + blocks delete of a referenced target; cascade deletes every
+   * record whose array contains the deleted id; warn surfaces orphans
+   * only via `checkIntegrity()`.
+   */
+  readonly isArray?: true
+}
+
+/** Runtime predicate: is this an array ref (`refArray()`) vs a scalar `ref()`? */
+export function isRefArray(desc: RefDescriptor): boolean {
+  return desc.isArray === true
 }
 
 /**
@@ -133,6 +148,41 @@ export function ref(target: string, mode: RefMode = 'strict'): RefDescriptor {
 }
 
 /**
+ * Array reference (#377-A) — the many-to-many soft-FK. The field holds an
+ * array of ids; each element is validated against `target` independently.
+ *
+ * ```ts
+ * const orders = company.collection<Order>('orders', {
+ *   refs: { productIds: refArray('products', 'warn') },
+ * })
+ * ```
+ *
+ * Same three `mode` semantics as `ref()`, applied per element:
+ *   - **strict** — `put()` rejects if ANY element's target is missing;
+ *     `delete()` of a target is blocked while any record's array still
+ *     contains its id.
+ *   - **warn** — both succeed; orphaned elements surface via
+ *     `vault.checkIntegrity()` (one violation per dangling element).
+ *   - **cascade** — `delete()` of a target deletes every record whose
+ *     array contains its id (cycle-safe, like scalar cascade).
+ *
+ * A `null`/`undefined` field is allowed (no links). Non-array values, or
+ * non-string/number elements, are an integrity error. Cross-vault targets
+ * are rejected exactly as in `ref()`.
+ */
+export function refArray(target: string, mode: RefMode = 'strict'): RefDescriptor {
+  if (target.includes('/')) {
+    throw new RefScopeError(target)
+  }
+  if (!target || target.startsWith('_')) {
+    throw new Error(
+      `refArray(): target collection name must be non-empty and cannot start with '_' (reserved for internal collections). Got "${target}".`,
+    )
+  }
+  return { target, mode, isArray: true }
+}
+
+/**
  * Per-vault registry of reference declarations.
  *
  * The registry is populated by `Collection` constructors (which pass
@@ -159,7 +209,7 @@ export class RefRegistry {
   private readonly outbound = new Map<string, Record<string, RefDescriptor>>()
   private readonly inbound = new Map<
     string,
-    Array<{ collection: string; field: string; mode: RefMode }>
+    Array<{ collection: string; field: string; mode: RefMode; isArray?: true }>
   >()
 
   /**
@@ -184,7 +234,7 @@ export class RefRegistry {
       for (const k of existingKeys) {
         const a = existing[k]
         const b = refs[k]
-        if (!a || !b || a.target !== b.target || a.mode !== b.mode) {
+        if (!a || !b || a.target !== b.target || a.mode !== b.mode || a.isArray !== b.isArray) {
           throw new Error(
             `RefRegistry: conflicting ref declarations for collection "${collection}" field "${k}"`,
           )
@@ -195,7 +245,7 @@ export class RefRegistry {
     this.outbound.set(collection, { ...refs })
     for (const [field, desc] of Object.entries(refs)) {
       const list = this.inbound.get(desc.target) ?? []
-      list.push({ collection, field, mode: desc.mode })
+      list.push({ collection, field, mode: desc.mode, ...(desc.isArray ? { isArray: true } : {}) })
       this.inbound.set(desc.target, list)
     }
   }
@@ -208,7 +258,7 @@ export class RefRegistry {
   /** Get the inbound refs that target a given collection (or `[]`). */
   getInbound(
     target: string,
-  ): ReadonlyArray<{ collection: string; field: string; mode: RefMode }> {
+  ): ReadonlyArray<{ collection: string; field: string; mode: RefMode; isArray?: true }> {
     return this.inbound.get(target) ?? []
   }
 

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -77,6 +77,7 @@ import { NO_PERIODS, type PeriodsStrategy } from './periods/strategy.js'
 import {
   RefRegistry,
   RefIntegrityError,
+  isRefArray,
   type RefDescriptor,
   type RefViolation,
 } from './refs.js'
@@ -1877,6 +1878,48 @@ export class Vault {
       // Users who want "always required" should express it in their
       // Standard Schema validator via a non-optional field.
       if (rawId === null || rawId === undefined) continue
+
+      // Array ref (#377-A): validate each element against the target.
+      if (isRefArray(descriptor)) {
+        if (!Array.isArray(rawId)) {
+          throw new RefIntegrityError({
+            collection: collectionName,
+            id: (obj['id'] as string | undefined) ?? '<unknown>',
+            field,
+            refTo: descriptor.target,
+            refId: null,
+            message: `Array ref field "${collectionName}.${field}" must be an array, got ${typeof rawId}.`,
+          })
+        }
+        const arrTarget = this.collection<Record<string, unknown>>(descriptor.target)
+        for (const el of rawId) {
+          if (typeof el !== 'string' && typeof el !== 'number') {
+            throw new RefIntegrityError({
+              collection: collectionName,
+              id: (obj['id'] as string | undefined) ?? '<unknown>',
+              field,
+              refTo: descriptor.target,
+              refId: null,
+              message: `Array ref "${collectionName}.${field}" elements must be strings or numbers, got ${typeof el}.`,
+            })
+          }
+          const elId = String(el)
+          if (!(await arrTarget.get(elId))) {
+            throw new RefIntegrityError({
+              collection: collectionName,
+              id: (obj['id'] as string | undefined) ?? '<unknown>',
+              field,
+              refTo: descriptor.target,
+              refId: elId,
+              message:
+                `Strict array ref "${collectionName}.${field}" → "${descriptor.target}" ` +
+                `cannot be satisfied: element id "${elId}" not found in "${descriptor.target}".`,
+            })
+          }
+        }
+        continue
+      }
+
       // Refs must be strings or numbers — anything else (object,
       // array, boolean) is a programming error and should fail
       // loudly rather than serialize as "[object Object]".
@@ -1937,7 +1980,13 @@ export class Vault {
         const allRecords = await fromCollection.list()
         const matches = allRecords.filter((rec) => {
           const raw = rec[rule.field]
-          // Same string/number-only restriction as enforceRefsOnPut.
+          // Array ref (#377-A): match when any element equals the deleted id.
+          if (rule.isArray) {
+            return Array.isArray(raw) && raw.some(
+              (el) => (typeof el === 'string' || typeof el === 'number') && String(el) === id,
+            )
+          }
+          // Scalar: same string/number-only restriction as enforceRefsOnPut.
           // Anything else can't have been a valid ref to begin with,
           // so it can't match.
           if (typeof raw !== 'string' && typeof raw !== 'number') return false
@@ -2066,6 +2115,26 @@ export class Vault {
         for (const [field, descriptor] of Object.entries(refs)) {
           const rawId = record[field]
           if (rawId === null || rawId === undefined) continue
+          const target = this.collection<Record<string, unknown>>(descriptor.target)
+
+          // Array ref (#377-A): report one violation per dangling element.
+          if (isRefArray(descriptor)) {
+            if (!Array.isArray(rawId)) {
+              violations.push({ collection: collectionName, id: recId, field, refTo: descriptor.target, refId: rawId, mode: descriptor.mode })
+              continue
+            }
+            for (const el of rawId) {
+              if (typeof el !== 'string' && typeof el !== 'number') {
+                violations.push({ collection: collectionName, id: recId, field, refTo: descriptor.target, refId: el, mode: descriptor.mode })
+                continue
+              }
+              if (!(await target.get(String(el)))) {
+                violations.push({ collection: collectionName, id: recId, field, refTo: descriptor.target, refId: el, mode: descriptor.mode })
+              }
+            }
+            continue
+          }
+
           // Non-scalar ref values are flagged as a violation rather
           // than thrown — `checkIntegrity` is a "report what's wrong"
           // tool, not a "block on first failure" tool. The thrown
@@ -2082,7 +2151,6 @@ export class Vault {
             continue
           }
           const refId = String(rawId)
-          const target = this.collection<Record<string, unknown>>(descriptor.target)
           const exists = await target.get(refId)
           if (!exists) {
             violations.push({

--- a/showcases/src/103-ref-array.showcase.test.ts
+++ b/showcases/src/103-ref-array.showcase.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Showcase 103 — refArray (many-to-many integrity)
+ *
+ * What you'll learn
+ * ─────────────────
+ * `refArray(target, mode)` gives a field that holds an ARRAY of ids
+ * referential integrity — the M:N counterpart of `ref()`. Each element is
+ * validated against the target collection independently, with the same
+ * strict / warn / cascade modes applied per element.
+ *
+ *   - strict put rejects if any linked id is missing.
+ *   - cascade delete removes every record whose array contained the id.
+ *   - checkIntegrity() reports one orphan per dangling element.
+ *
+ * Why it matters
+ * ──────────────
+ * M:N links (order↔product, post↔tag, line-item linking) otherwise store
+ * raw id arrays with zero integrity — the "stale link" and "deleted thing
+ * still referenced" bug classes. refArray makes the link set self-checking.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 00 + 12 (joins / ref).
+ *
+ * What to read next
+ * ─────────────────
+ *   - docs/core/05-schema-and-refs.md
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → schema-and-refs
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, refArray, RefIntegrityError } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+
+interface Product { id: string; name: string }
+interface Order { id: string; productIds: string[] }
+
+async function open() {
+  const db = await createNoydb({ store: memory(), user: 'alice', secret: 'ref-array-showcase-2026' })
+  const vault = await db.openVault('shop')
+  return { db, vault }
+}
+
+describe('Showcase 103 — refArray (M:N)', () => {
+  it('strict mode validates every linked product on put', async () => {
+    const { db, vault } = await open()
+    const products = vault.collection<Product>('products')
+    const orders = vault.collection<Order>('orders', {
+      refs: { productIds: refArray('products', 'strict') },
+    })
+
+    await products.put('p1', { id: 'p1', name: 'Widget' })
+    await products.put('p2', { id: 'p2', name: 'Gadget' })
+
+    // Every element must resolve, or the whole put is rejected.
+    await orders.put('o1', { id: 'o1', productIds: ['p1', 'p2'] })
+    await expect(orders.put('o2', { id: 'o2', productIds: ['p1', 'ghost'] }))
+      .rejects.toBeInstanceOf(RefIntegrityError)
+
+    db.close()
+  })
+
+  it('cascade mode removes every order whose array contained the deleted product', async () => {
+    const { db, vault } = await open()
+    const products = vault.collection<Product>('products')
+    const orders = vault.collection<Order>('orders', {
+      refs: { productIds: refArray('products', 'cascade') },
+    })
+
+    await products.put('p1', { id: 'p1', name: 'Widget' })
+    await products.put('p3', { id: 'p3', name: 'Doohickey' })
+    await orders.put('o1', { id: 'o1', productIds: ['p1', 'p9'] }) // cascade put is unchecked
+    await orders.put('o3', { id: 'o3', productIds: ['p3'] })
+
+    await products.delete('p1')
+    expect(await orders.get('o1')).toBeNull()    // contained p1 → cascaded
+    expect(await orders.get('o3')).toBeTruthy()  // only p3 → untouched
+
+    db.close()
+  })
+
+  it('warn mode surfaces dangling links via checkIntegrity()', async () => {
+    const { db, vault } = await open()
+    const products = vault.collection<Product>('products')
+    const orders = vault.collection<Order>('orders', {
+      refs: { productIds: refArray('products', 'warn') },
+    })
+    await products.put('p1', { id: 'p1', name: 'Widget' })
+    await products.put('p2', { id: 'p2', name: 'Gadget' })
+    await orders.put('o1', { id: 'o1', productIds: ['p1', 'p2'] })
+
+    await products.delete('p2') // warn — allowed, leaves an orphan link
+    const { violations } = await vault.checkIntegrity()
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({ collection: 'orders', id: 'o1', field: 'productIds', refId: 'p2' })
+
+    db.close()
+  })
+})


### PR DESCRIPTION
Implements **design A** of #377 (array refs). The richer **design B** (`vault.link` managed junction) is deferred to the design pass — see below. #377 stays open for design B.

## What & why

`ref(target, mode)` is single-target per field; there was no integrity for **many-to-many** relationships. Any M:N model (tags, order↔product, line-item linking) stored raw id arrays with zero referential integrity, cascade, or orphan detection. `refArray(target, mode)` gives an id-array field the same soft-FK integrity, applied per element.

```ts
const orders = company.collection<Order>('orders', {
  refs: { productIds: refArray('products', 'warn') },
})
```

## Semantics (per element, mirroring scalar `ref`)

- **strict** — `put()` rejects if **any** element's target is missing (the `RefIntegrityError.refId` is the offending element); `delete()` of a target is blocked while any record's array still contains its id.
- **warn** — both succeed; `vault.checkIntegrity()` reports **one violation per dangling element**.
- **cascade** — `delete()` of a target deletes every record whose array contains its id (cycle-safe via the existing `cascadeInProgress` set; tx-atomic via `_executed`); `put()` is unchecked (same as scalar cascade).
- Empty array or `null`/`undefined` field → allowed (no links). A non-array value, or a non-string/number element, is a `RefIntegrityError`.

## How

- `refArray()` returns a `RefDescriptor` with `isArray: true`; `isRefArray(desc)` predicate. Both exported from `@noy-db/hub`. The `refs` option type already accepts `RefDescriptor`, so no option-shape change.
- `isArray` is threaded onto the registry's **inbound** rule so the delete-time matcher knows to scan arrays (`raw.some(el => String(el) === id)`).
- `enforceRefsOnPut` and `checkIntegrity` branch on `isRefArray`. **The scalar `ref` path is byte-for-byte unchanged.**

## Deferred — design B (`vault.link`)

The issue's design B (a first-class bidirectional junction collection: `vault.link(name, { a, b, onDelete })` + `vault.links(name).connect/disconnect/of`) is a substantially larger new surface and a maintainer design call. It's deferred to the pilot-2 design pass alongside #376 and #378. Design A here is the interim that closes the immediate M:N integrity gap.

## Tests

- `packages/hub/__tests__/refs.test.ts` new `refArray` blocks (12): factory/predicate/defaults/cross-vault, strict put (valid / missing-element / empty / nullish / non-array), strict delete-block, cascade delete (with isolation of unrelated records), warn + `checkIntegrity` (one violation per dangling element).
- Showcase 103 (order↔product: strict put validation, cascade delete, warn + checkIntegrity).
- `docs/core/05-schema-and-refs.md` + `features.yaml` updated. Full hub suite green (262 files / 2545 tests).

Part of the pilot-2 fast-lane batch (#374 PR #379 / #375 PR #380 / #377-A here).