### PR TITLE
docs(design): pilot-2 design pass — #376 / #377-B / #378

### DIFF
--- a/docs/superpowers/plans/2026-06-14-fiscal-primitives-maturity-plan.md
+++ b/docs/superpowers/plans/2026-06-14-fiscal-primitives-maturity-plan.md
@@ -1,0 +1,96 @@
+# Fiscal-critical primitives: preview → stable + crypto audit (#378)
+
+> **Status:** PLAN — readiness assessment + sequencing. Some flips are blocked
+> on in-flight API-changing PRs (see § Sequencing).
+> **Pilot:** Speedex bets Italian fiscal correctness on this set.
+
+## What #378 asks
+
+Move the primitives an e-invoicing app bets compliance on from `status: preview`
+to `status: stable` (API freeze + test hardening) in `features.yaml`, and schedule
+the independent crypto audit. All six are `preview` @ 0.2.0-pre.17 (confirmed).
+
+## Readiness assessment
+
+Test depth measured by `it`-block count + file count (2026-06-14, main):
+
+| Feature | Tests | Files | Pilot-validated? | API churn in flight | Verdict |
+|---|---|---|---|---|---|
+| `money` | ~116 | 15 | ✅ niwat-validated (milestone 19) | none | **READY now** |
+| `materialized-views` | ~75 | 12 | ✅ niwat (union-MV money) | i18n MV layer (#285 D2/D3) unwired | **READY** w/ caveat |
+| `derivations` | ~84 | 19 | ✅ niwat (sibling sources #344) | **#376 adds `triggerBy`/`withRollup`** | **BLOCKED on #376** |
+| `atomic-sequence` | ~23→33 | 1 | partial | **#375 adds `format`** | **BLOCKED on #375** |
+| `computed` | ~15 | 3 | ✅ niwat (AU+027 #343) | none known | READY (light coverage) |
+| `deferred-numbering` | ~12 | 1 | limited | #375 deferred-format follow-up | NOT YET (thin + pending shape) |
+
+Notes:
+- **money** is the strongest case — deepest coverage, conformance + encoding +
+  guard-gate-parity + end-to-end suites, and a real fiscal consumer (niwat)
+  validated it. Freeze-ready.
+- **materialized-views** core is freeze-ready; the open item is the i18n `mv`/`join`
+  resolution layer (#285 D2/D3), which is *additive* (doesn't change existing MV
+  APIs). Recommend stabilizing the MV core and noting i18n-MV as a separate
+  experimental sub-surface, OR waiting for #285 to close. Maintainer's call.
+- **computed** has thin coverage (~15) for a fiscal-critical primitive (derived
+  VAT/totals). Recommend a hardening pass (boundary/rounding/money-interaction
+  cases) before the flip even though no API change is pending.
+- **deferred-numbering** is thin (~12) and its `Assignment` shape may grow if the
+  #375 deferred-format follow-up lands. Keep `preview`.
+
+## ⚠️ Sequencing — the core risk
+
+**Do not freeze an API you are about to extend.** Two pilot-2 PRs change the
+surface of two of these features:
+
+- **#375 (PR #380)** adds `format` + `FormattedSequenceHandle` to `atomic-sequence`.
+- **#376** adds `triggerBy` / `withRollup` to `derivations`.
+
+Freezing `sequence` or `derivations` to `stable` *before* those land would
+immediately re-break a "stable" surface. Therefore:
+
+```
+Phase 0 (now):     money → stable. computed hardening pass → stable.
+                   (materialized-views → stable, or hold for #285 — decision)
+Phase 1:           land #375 (PR #380) → THEN atomic-sequence → stable
+Phase 2:           land #376 (after its design decisions) → THEN derivations → stable
+Phase 3:           deferred-numbering hardening (+ resolve #375 deferred-format) → stable
+Crypto audit:      independent track — schedule now, not blocked on any of the above
+```
+
+The flips themselves are one-line `status:` edits in `features.yaml` — trivial.
+The *work* is (a) the hardening passes (computed; deferred-numbering) and (b)
+respecting the order so freezes are durable.
+
+## API-freeze checklist (apply per feature before flipping)
+
+1. Public surface reviewed — no `@internal` leaks, no soon-to-change params.
+2. Error classes named + exported + documented (fiscal callers branch on them).
+3. Conformance/boundary tests present (money: encoding; sequence: gap-free under
+   contention + reset; computed: rounding/money interaction; mv: refresh atomicity).
+4. Subsystem doc + at least one showcase.
+5. `features.yaml` invariants block reflects the frozen contract.
+
+## Crypto audit (independent of the above)
+
+The encryption core (`crypto.ts`, keyring/DEK wrapping, per-record/per-blob CEK,
+record-scoped sealing) gates *production* fiscal adoption, not development. This
+is an **external engagement**, not a code change:
+
+- Scope to fix: AES-256-GCM envelope + AAD binding, PBKDF2→KEK→AES-KW DEK chain,
+  per-record CEK + crypto-shred (#304/#357), record-scoped sealing (#306/#360),
+  per-blob CEK (#365).
+- Deliverable: a tracked issue/milestone with scope doc + chosen auditor + target
+  window. **This is a scheduling/process action for the maintainer** — I can draft
+  the scope doc and the tracking issue body on request, but cannot engage an auditor.
+
+## Recommended immediate action
+
+1. Flip **money → stable** now (lowest-risk, highest pilot value, deepest coverage).
+2. Decide **materialized-views**: stabilize core now vs hold for #285.
+3. Queue a **computed** hardening pass, then flip.
+4. Hold **sequence** / **derivations** flips until #375 / #376 land (sequencing).
+5. Open the **crypto-audit** tracking issue (scope + auditor + window).
+
+Each flip is a tiny `features.yaml` PR; the gating work is the hardening passes
+and the ordering. None of this should block pilot *development* — `preview`
+already lets the pilot build; it only gates their *ship*.

--- a/docs/superpowers/specs/2026-06-14-fk-derivation-triggers-design.md
+++ b/docs/superpowers/specs/2026-06-14-fk-derivation-triggers-design.md
@@ -1,0 +1,184 @@
+# FK-keyed derivation triggers — rollups & reverse-denormalization (#376)
+
+> **Status:** DESIGN — awaiting maintainer decisions (see § Decisions needed).
+> **Pilot:** Speedex refoundation. Highest-impact pilot-2 request.
+> **Depends on:** nothing new ships first; builds on Dim 14 derivations + indexing + refs.
+
+## Problem
+
+`withDerivation` (Dim 14) re-fires for the **primary `source` record at the SAME
+id** as the written sibling (`derivations/types.ts` SAME-ID contract;
+`collection.ts:1700-1714`). That blocks the two most common parent/child
+maintenance patterns, both keyed by a **foreign key**, not a shared id:
+
+1. **Rollup / reverse-aggregation** — maintain `buyer.revenueByYear` /
+   `buyer.toPayAmount` from many child `sales` (keyed by `sale.buyerId`).
+2. **Reverse denormalization** — a `buyer.companyName` change must refresh a
+   denormalized `buyerName` on **all** `sales` where `sale.buyerId === buyer.id`.
+
+Both fall to userland today → the "stats computed two divergent ways" and "stale
+denormalized name" bug classes the pilot keeps hitting.
+
+## Why not the tools we already have
+
+- **`withMaterializedView` + aggregate** produces a *parallel grouped collection*
+  (`buyer-totals.get(buyerId)` → an aggregate row). It **cannot write an
+  aggregate onto a field of the parent `buyers` record**, and it **cannot fan a
+  parent change down to child records**. (Confirmed against
+  `materialized-views/types.ts`.) The rollup-onto-parent-field and the
+  reverse-denorm fan-out are genuinely outside MV scope.
+- **`sources[]` sibling triggers (#344)** re-fire at the *same id* — the exact
+  assumption #376 must relax.
+- **`refArray` (#377-A)** is M:N *integrity*, not derived-value maintenance.
+
+## Key facts the design leans on (grounded)
+
+- **No record-level reverse index exists.** `RefRegistry.getInbound(target)` is
+  schema-level only (which collections reference a target), not
+  `(targetId) → [referrer ids]`.
+- **The indexing subsystem already gives O(children) fan-out** *when the child
+  collection opts into `withIndexing()` and declares the FK field*:
+  `CollectionIndexes.lookupEqual(field, value)` (eager) /
+  `PersistedCollectionIndex` (lazy) return the exact id set.
+- **That index is already reachable from `derive()`** via the read-only facade:
+  `ctx.vault.collection('sales').query().where('buyerId','==',id).toArray()`
+  dispatches through the index (`query/lazy-builder.ts`). Without an index it is
+  an O(N) `list()` scan.
+- **Eager derivation dispatch is tx-atomic** (`dispatchDerivations` registers
+  output pre-images on `txCtx._executed`; `collection.ts:1729-1736`).
+- **`forget()` bypasses `Collection.put` → does NOT trigger derivations**, and
+  there is **no existing cleanup of derived outputs on source delete/forget**
+  (a pre-existing gap, relevant to rollup-on-delete below).
+
+## Proposed design
+
+Two complementary surfaces — one extends `withDerivation`, one is dedicated sugar.
+
+### A. `triggerBy` — FK-keyed re-fire (reverse-denormalization)
+
+Extend `DerivationStrategy` with an FK trigger that fans out to **every source
+record whose FK matches the written trigger record**:
+
+```ts
+withDerivation<Sale, { self: Sale }>({
+  source: 'sales',
+  triggerBy: [{ collection: 'buyers', on: 'buyerId' }], // on = FK field ON the source
+  outputs: { self: { shape: 'record', collection: 'sales' } }, // writes back to the source
+  derive: async (sale, ctx) => {
+    const b = await ctx.vault.collection<Buyer>('buyers').get(sale.buyerId)
+    return { self: { ...sale, buyerName: b?.companyName ?? sale.buyerName } }
+  },
+  lifecycle: 'eager',
+})
+```
+
+Semantics: a write to `buyers/X` resolves all `sales` where `sale.buyerId === X`
+(via `query().where('buyerId','==','X')`), and re-fires the derivation **once per
+matched source record** (the source record is the matched *sale*, not the buyer).
+Contrast with `sources[]`, which re-fires once at the same id.
+
+`on` is the FK field **on the source** (`sales.buyerId`). The trigger collection
+(`buyers`) is the parent. Self-output (`collection === source`) is the
+reverse-denorm "patch the source record in place" case — see Decision 1.
+
+### B. `withRollup` — aggregate onto a parent field
+
+Dedicated sugar for "fold children into one field on the parent":
+
+```ts
+withRollup<Sale, Buyer>({
+  from: 'sales',          // child collection (trigger)
+  key: 'buyerId',         // FK on the child → parent id
+  into: 'buyers',         // parent collection
+  field: 'revenueByYear', // field on the parent to write
+  compute: (sales) => groupSumByYear(sales, 'total'),
+})
+```
+
+Semantics: on any write **or delete** of a `sales` record, recompute
+`compute(allSalesWhere buyerId === sale.buyerId)` and write it to
+`buyers/<buyerId>.revenueByYear`. Desugars to a derivation whose source is the
+**parent** keyed off child writes, fanning *in* (aggregate) rather than *out*.
+
+`withRollup` is a thin builder over the same engine as `triggerBy`; it exists
+because the aggregate-onto-parent shape is common enough to deserve a 5-line
+declaration instead of a hand-written `derive`.
+
+### Fan-out & performance
+
+- Both use `ctx.vault.collection(child).query().where(key,'==',parentId)` →
+  O(children) when the child declares `withIndexing()` on the FK, O(N) scan
+  otherwise.
+- Reuse the existing `maxFanout` / `DerivationCapExceededError` budget (default
+  64; surfaced before any write so no partial fan-out persists). **`log()` /
+  warn when a fan-out runs unindexed** so silent O(N) scans are visible.
+
+### Cycle detection
+
+Extend the vault-open DFS (`registry.validate()`) to add edges:
+`triggerBy.collection → source` and `withRollup.from → into`. A reverse-denorm
+that writes back to its own source (`self`) is guarded at runtime by the existing
+`_derivedFrom` short-circuit (`collection.ts:1684`) — but a self-write that is
+*not* tagged `_derivedFrom` (reverse-denorm patches a real user record) needs the
+guard from Decision 1.
+
+### Lifecycle
+
+- **eager** — recompute inside the trigger write's tx (atomic, via the existing
+  `_executed` pre-image registration). Recommended default for rollups (stats
+  must not lag).
+- **lazy** — mark affected parents/children stale; resolve on read. Reuse
+  `markStale` / `resolveStaleOnRead`. The stale key must be the *affected target
+  id(s)*, not the trigger id — a fan-out marks N targets stale.
+
+## Decisions needed (maintainer's call)
+
+1. **In-place source write vs separate output (the crux).** Reverse-denorm
+   patches a **real user record** (`sales`), not a separate derived output
+   collection — a first for Dim 14, which has only ever written to *output*
+   collections it owns. Options:
+   - **(1a) Allow `self` output = write back to the source record**, tagging only
+     the derived fields' provenance. Pro: matches the use case directly. Con:
+     blurs "derived output" vs "user data"; the `_derivedFrom` whole-record
+     cycle guard no longer fits (the record is mostly user-owned). Needs a
+     **field-level** provenance + cycle guard instead of the record-level one.
+   - **(1b) Forbid self-output; reverse-denorm writes a sibling shadow collection**
+     (`sales-denorm`) joined at read. Pro: keeps the "derivations own their
+     outputs" invariant intact. Con: callers must join; doesn't match the
+     "stamp `buyerName` onto the sale" ask.
+   - **Recommendation: 1a**, with a field-level cycle guard (only the
+     `compute`d fields carry provenance; a re-fire that would produce identical
+     field values is a no-op, breaking the cycle). This is the higher-value, riskier path.
+
+2. **Rollup-on-delete + forget.** A rollup MUST recompute when a child is
+   **deleted** (else `revenueByYear` overcounts forever). Today derivation
+   dispatch fires on `put` but the delete path and `forget()` do **not** trigger
+   derivations. Options: hook `withRollup` into the delete path
+   (`enforceRefsOnDelete`-adjacent) and document that `forget()` does not
+   auto-recompute (a separate, tracked gap). **Recommendation: hook delete;
+   document forget as out-of-scope for v1 with a `vault.recomputeRollups()` escape hatch.**
+
+3. **Require an FK index?** Hard-require `withIndexing()` on the FK (throw at
+   registration if absent) vs allow the O(N) scan with a loud warn.
+   **Recommendation: warn, don't require** — small child sets are fine; requiring
+   indexing couples two subsystems and surprises small-data users. Re-evaluate if
+   pilots hit scans on large sets.
+
+4. **`withRollup` vs `triggerBy` only.** Ship both, or only `triggerBy` (rollup
+   as a documented recipe)? **Recommendation: ship both** — rollup is the more
+   common ask and the dedicated builder removes a sharp-edged hand-written derive.
+
+## Build plan (sketch, after decisions)
+
+1. `triggerBy` on `DerivationStrategy` + `with-derivation` validation; registry
+   dual-keys trigger collections; `dispatchDerivations` adds the FK-fan-out branch.
+2. Field-level provenance + cycle guard (Decision 1a).
+3. `withRollup` builder desugaring to the engine + delete-path hook (Decision 2).
+4. Extend `registry.validate()` cycle DFS.
+5. Tests: reverse-denorm fan-out (indexed + unindexed), rollup on insert/update/delete,
+   cycle rejection, cap, lazy fan-out, tx-atomic rollback. Showcases: buyer rename →
+   sales.buyerName; sale insert/delete → buyer.revenueByYear.
+6. `features.yaml` + `docs/subsystems/derivations.md`.
+
+Suggested slicing: **Slice 1** = `triggerBy` reverse-denorm (Decisions 1+3);
+**Slice 2** = `withRollup` + delete hook (Decision 2). Each is an independent PR.

--- a/docs/superpowers/specs/2026-06-14-managed-link-collection-design.md
+++ b/docs/superpowers/specs/2026-06-14-managed-link-collection-design.md
@@ -1,0 +1,128 @@
+# Managed bidirectional link collection — `vault.link` (#377 design B)
+
+> **Status:** DESIGN — awaiting maintainer decisions (see § Decisions needed).
+> **Pilot:** Speedex purchase-line ↔ sale-line linking.
+> **Relationship to #377-A:** `refArray` (shipped, PR #381) is the lightweight M:N.
+> This is the richer, first-class junction. They coexist; B is not a replacement.
+
+## Problem
+
+`refArray` (design A) gives an id-array field per-element integrity — good for
+"a post has tags". But it is **uni-directional** (the array lives on one side),
+not **queryable as links** (no first-class "what is X linked to" without scanning
+the owning collection), and has **no link-level metadata** (you can't annotate a
+link, e.g. `quantity` on an order↔product line). A real M:N relationship —
+purchase-line ↔ sale-line, with a suggest-links flow and bidirectional
+navigation — wants a managed junction.
+
+## Design A vs B — when to use which
+
+| | `refArray` (A, shipped) | `vault.link` (B, this spec) |
+|---|---|---|
+| Storage | id array on the owning record | dedicated junction collection |
+| Direction | uni (array on one side) | bidirectional, symmetric |
+| Query | scan owner / `checkIntegrity` | `links(name).of(id)` both directions |
+| Link metadata | none | optional per-link fields |
+| Integrity | per-element on the owner | both endpoints, managed |
+| Cost | zero new collection | one `_links_*` collection |
+
+Recommendation in docs: reach for A for simple tag-like sets; reach for B when
+links are themselves entities (queryable both ways, annotatable, suggest-flows).
+
+## Proposed API
+
+Mirrors the managed-collection pattern of `vault.dictionary()` /
+`vault.sequence()` (handle-cache field + lazy accessor; grounded in `vault.ts`).
+
+```ts
+// Declare (registers the link spec; idempotent like collection({ refs }))
+vault.link('saleLineLinks', {
+  a: ref('saleLines'),
+  b: ref('purchaseLines'),
+  onDelete: 'cascade',        // when an endpoint is deleted, drop its link rows
+})
+
+// Operate via the handle
+const links = vault.links('saleLineLinks')
+await links.connect(saleLineId, purchaseLineId, { qty: 3 }) // optional metadata
+await links.disconnect(saleLineId, purchaseLineId)
+const forSale = await links.of(saleLineId)     // → [{ a, b, ...meta }] touching saleLineId
+const exists  = await links.has(saleLineId, purchaseLineId)
+```
+
+### Storage
+
+- A reserved `_links_<name>` collection (new prefix + `isLinkCollectionName`
+  guard in `vault.collection()`, mirroring `_dict_*` / `_sequences`).
+- Row key = canonical `"${aId}\x00${bId}"` (null-byte joiner, same disjointness
+  trick as partitioned sequences). Row body = `{ aId, bId, ...meta }`, encrypted
+  under the `_links_<name>` DEK obtained via the vault's `getDEK` (memoized
+  promise, like `SequenceStore`).
+- Handle = `LinkSetHandle` modeled on `DictionaryHandle` (direct adapter access,
+  role-checked writes, emitter `change` events, ledger append when present, a
+  sync cache for snapshot).
+
+### Integrity & cascade
+
+- `connect()` validates both endpoints exist (strict) — reuses the
+  `enforceRefsOnPut`-style target lookup.
+- `onDelete: 'cascade'` — when endpoint A or B is deleted, drop every link row
+  touching it. **Implementation: a link-aware cleanup callback registered with
+  the vault and invoked from `enforceRefsOnDelete`**, alongside the existing
+  ref cascade (Path 2 in the map). Cleaner than registering phantom refs because
+  link rows use composite keys + direct adapter access, not `Collection.list()`
+  field matching. Reuse `cascadeInProgress` (cycle safety) and register dropped
+  rows on `txCtx._executed` for tx-atomic rollback (matching #346).
+- `onDelete: 'strict'` — block endpoint delete while links exist;
+  `onDelete: 'warn'` — leave orphan link rows, surfaced by `checkIntegrity()`
+  (extend it to walk link collections).
+
+### `.of(id)` and queryability
+
+- `of(id)` scans the link collection for rows where `aId === id || bId === id`.
+  O(links) — acceptable for v1. An optional secondary index on `aId`/`bId` can
+  come later if pilots need it.
+- **Joinability via the query DSL is deferred** (Decision 3). The current
+  `applyOneJoin` is single-FK equi-join (one-to-one / many-to-one) and cannot
+  attach an *array* of right-side records through a junction. `links(name).of(id)`
+  is the v1 query surface; DSL `joinThrough()` is a follow-up.
+
+## Decisions needed
+
+1. **Link metadata (annotated links).** Support optional per-link fields
+   (`connect(a, b, { qty })`) in v1, or pure connect/disconnect first?
+   **Recommendation: support metadata in v1** — it's the difference between a set
+   and a real relationship, and the pilot's line-linking wants `qty`. Cheap (the
+   row body already exists).
+2. **Symmetric vs directed.** Is `(a,b)` the same link as `(b,a)`? For
+   sale↔purchase the endpoints are *typed* (different collections), so the pair
+   is inherently ordered by slot (a=saleLines, b=purchaseLines). **Recommendation:
+   slot-typed (directed by slot), not symmetric** — `connect(saleId, purchaseId)`;
+   `of(id)` matches either slot. Same-collection self-links (a and b same target)
+   are allowed but out of v1 scope to optimize.
+3. **Query DSL `joinThrough()`.** Ship a junction-aware join primitive now, or
+   defer to a follow-up? **Recommendation: defer.** It needs a new `JoinLeg` kind
+   + `applyLinkJoin` + array-attach semantics — a meaningful query-layer change
+   that shouldn't gate the storage/handle primitive. `of(id)` covers the pilot.
+4. **Backup inclusion.** `_links_*` rides the regular `dump()` (`adapter.loadAll`
+   returns `_`-collections), like `_dict_*`. Confirm no addition to the special
+   `_internal` snapshot is needed. **Recommendation: rely on loadAll path
+   (no change), add a round-trip test.**
+
+## Build plan (sketch, after decisions)
+
+1. `_links_*` reserved prefix + guard + `vault.link()` registry + `vault.links()`
+   accessor + `LinkSetHandle` (connect/disconnect/has/of) with DEK + emitter +
+   ledger, modeled on `DictionaryHandle`.
+2. Endpoint validation on connect; `onDelete` cascade/strict/warn via the vault
+   cleanup callback in `enforceRefsOnDelete`; `checkIntegrity` extension.
+3. Optional link metadata (Decision 1).
+4. Tests: connect/disconnect/has/of, both-endpoint validation, cascade/strict/warn
+   on endpoint delete, tx-atomic cascade rollback, backup round-trip, reserved-name
+   guard. Showcase: sale-line ↔ purchase-line with a suggest-links flow + cascade.
+5. New `features.yaml` entry (`id: link-collection`) + `docs/core/` doc; position
+   vs `refArray`.
+
+This is a meaningfully larger build than #377-A (a new managed collection type +
+cascade integration + handle). Recommend it as its own milestone slice, sequenced
+after the pilot confirms `refArray` doesn't already cover their line-linking need.


### PR DESCRIPTION
Design pass for the three deferred pilot-2 items. **Docs only — no code.** Each spec is grounded in how the subsystem actually works (deep code map), gives a recommended approach, and surfaces the genuine maintainer decisions so you can approve a direction before any build.

## #376 — FK-keyed derivation triggers (`specs/2026-06-14-fk-derivation-triggers-design.md`)
Reverse-denormalization + rollups beyond Dim 14's same-id assumption.
- **`triggerBy: [{ collection, on }]`** — FK-keyed re-fire (fan out a parent change to all matching source records).
- **`withRollup({ from, key, into, field, compute })`** — aggregate children onto a parent field.
- Fan-out reuses the **existing index** via `ctx.vault.collection(child).query().where(fk,'==',id)` (O(children) when the FK is indexed) — no new reverse index needed.
- Why-not-MV section: MVs aggregate into a parallel collection; they can't write onto the parent record nor fan out to children.
- **Decisions:** (1) **in-place source write vs separate output — the crux** (rec: allow self-write with field-level provenance/cycle guard); (2) rollup-on-delete + `forget` gap; (3) require FK index? (rec: warn, don't require); (4) ship `withRollup`? (rec: yes). 2-slice build plan.

## #377-B — managed link collection (`specs/2026-06-14-managed-link-collection-design.md`)
First-class bidirectional junction, coexisting with the shipped `refArray` (A).
- `vault.link(name, { a, b, onDelete })` + `vault.links(name).connect/disconnect/has/of`, modeled on `DictionaryHandle`; reserved `_links_*` prefix; cascade via an `enforceRefsOnDelete` callback (tx-atomic).
- Includes an **A-vs-B "when to use which"** table.
- **Decisions:** (1) link metadata in v1 (rec: yes); (2) symmetric vs slot-typed (rec: slot-typed); (3) `joinThrough()` DSL (rec: defer); (4) backup path. Larger build; its own slice.

## #378 — fiscal-primitives maturity (`plans/2026-06-14-fiscal-primitives-maturity-plan.md`)
Per-primitive readiness + the **sequencing rule**:
- **money → stable now** (deepest coverage ~116 tests, niwat-validated). 
- **MV** core ready (caveat: i18n-MV #285 D2/D3 unwired).
- **computed** light (~15) — hardening pass first.
- **⚠️ Do NOT freeze `sequence`/`derivations` before #375/#376 land** — you'd re-break a stable surface.
- **deferred-numbering** stays preview (thin + pending #375 follow-up).
- Crypto audit = external scheduling track; I can draft the scope doc + tracking issue on request.

---
None of this blocks pilot *development* (`preview` already lets them build); the maturity flips only gate their *ship*. Ready to build any of these once you pick the directions on the flagged decisions.