### PR TITLE
feat(derivations): FK-keyed triggers — reverse-denormalization (#376 slice 1)

### DIFF
--- a/docs/subsystems/derivations.md
+++ b/docs/subsystems/derivations.md
@@ -112,6 +112,48 @@ This retires the hand-rolled "poke a sibling" pattern (writing a no-op
 back to the source to force a re-derive when a referenced record
 changed).
 
+### FK-keyed triggers — reverse-denormalization (#376)
+
+`sources[]` re-fires at the **same id**. `triggerBy` re-fires keyed by a
+**foreign key**: a write to a PARENT collection fans out to every source
+record whose FK matches the parent's id. The canonical use is keeping a
+denormalized field on the children in sync with a parent change.
+
+```ts
+withDerivation<Sale, { self: Sale }>({
+  source: 'sales',
+  deterministic: true,
+  // A write to buyers re-derives every sale where sale.buyerId === buyer.id.
+  triggerBy: [{ collection: 'buyers', on: 'buyerId' }], // `on` = the FK ON the source
+  // Self-write: patch ONLY buyerName back onto the sale (field-level provenance).
+  outputs: { self: { shape: 'record', collection: 'sales', denorm: ['buyerName'] } },
+  derive: async (sale, ctx) => {
+    const b = await ctx.vault.collection<Buyer>('buyers').get(sale.buyerId)
+    return { self: { ...sale, buyerName: b?.companyName ?? null } }
+  },
+  lifecycle: 'eager',
+})
+```
+
+- **Self-write + `denorm`.** A record output whose `collection` equals the
+  `source` is a *self-write* and MUST declare `denorm: [...]`. Only those
+  fields are merged onto the **raw stored record** — the rest of the user's
+  record (and any i18n maps) is never clobbered, and no whole-record
+  `_derivedFrom` tag is added (the record stays user-owned). The self-write
+  edge is exempt from cycle detection; a **value-equality guard** breaks the
+  recursion: when the patch changes nothing, no write is issued.
+- **Fan-out cost.** The match runs through the FK index when the source
+  declares `indexes: ['<on>']` (O(matching rows)); otherwise it scans
+  (O(N) — fine for small child sets; index the FK to scale). An optional
+  `maxFanout` on the trigger entry throws `DerivationCapExceededError`
+  before any write.
+- `triggerBy.collection` must differ from `source`; `on` is required.
+
+> **Slice 1 scope (#376).** This ships `triggerBy` reverse-denormalization.
+> The aggregate-onto-parent companion (`withRollup`) and rollup-on-delete
+> are a tracked follow-up (Slice 2). `vault.forget()` does not auto-re-derive
+> (it bypasses the put path) — recompute explicitly if needed.
+
 ### Optional outputs (#144)
 
 Declare an output as `optional: true` to let `derive` return `null` for

--- a/features.yaml
+++ b/features.yaml
@@ -756,6 +756,8 @@ features:
     showcases:
       - id: 80-with-derivation
         path: showcases/src/80-with-derivation.showcase.test.ts
+      - id: 104-reverse-denorm
+        path: showcases/src/104-reverse-denorm.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -766,6 +768,8 @@ features:
       - 'strict: true rolls back source write on output failure inside withTransactions'
       - 'cycle detection at vault open — refuses cyclic graphs'
       - 'declared sibling sources (#344): withDerivation({ source, sources: [...] }) re-fires the derivation on writes to any declared sibling, using the PRIMARY source record at the SAME id (silent no-op if no primary record exists there); siblings are indexed in _bySource, participate in cycle detection, and fold into the strategy hash; sources[] entries must be non-empty and != source'
+      - 'FK-keyed triggers (#376 slice 1): withDerivation({ triggerBy: [{ collection, on }] }) fans a PARENT write out to every source record where source[on] === parentId (re-derives each); fan-out uses the FK index when present, else scans; optional maxFanout throws DerivationCapExceededError before any write; triggerBy.collection must != source'
+      - 'self-write reverse-denorm (#376): a record output whose collection === source MUST declare denorm:[...] — only those fields are patched onto the raw stored record (i18n maps/other fields never clobbered; no whole-record _derivedFrom tag); the self-write edge is exempt from cycle detection and terminated by a value-equality guard (no write when the patch changes nothing)'
     related: [guards, transactions]
 
   - id: materialized-views

--- a/packages/hub/__tests__/derivations/cycle.test.ts
+++ b/packages/hub/__tests__/derivations/cycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { createNoydb, withDerivation, DerivationCycleError } from '../../src/index.js'
+import { createNoydb, withDerivation, DerivationCycleError, ValidationError } from '../../src/index.js'
 import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
 
 function memory(): NoydbStore {
@@ -36,21 +36,20 @@ function memory(): NoydbStore {
 }
 
 describe('Derivation cycle detection at vault open', () => {
-  it('refuses to open a vault with a self-cycle', async () => {
-    const bad = withDerivation({
-      source: 'a',
-      deterministic: true,
-      outputs: { o: { shape: 'record', collection: 'a' } },
-      derive: () => ({ o: {} }),
-      lifecycle: 'eager',
-    })
-    const db = await createNoydb({
-      store: memory(),
-      user: 'alice',
-      secret: 'derivation-cycle-self-passphrase-2026',
-      derivationStrategies: [bad],
-    })
-    await expect(db.openVault('demo')).rejects.toBeInstanceOf(DerivationCycleError)
+  it('rejects a self-write output without denorm at construction (#376 — was a self-cycle)', () => {
+    // A record output back to its own source is now a self-write
+    // reverse-denorm (#376) and MUST declare `denorm`. An undeclared
+    // self-write — the old "self-cycle" — is rejected earlier, at
+    // withDerivation() construction, rather than by vault-open DFS.
+    expect(() =>
+      withDerivation({
+        source: 'a',
+        deterministic: true,
+        outputs: { o: { shape: 'record', collection: 'a' } },
+        derive: () => ({ o: {} }),
+        lifecycle: 'eager',
+      }),
+    ).toThrow(ValidationError)
   })
 
   it('refuses A -> B -> A', async () => {

--- a/packages/hub/__tests__/derivations/registry.test.ts
+++ b/packages/hub/__tests__/derivations/registry.test.ts
@@ -31,13 +31,18 @@ describe('DerivationRegistry', () => {
 
   it('detects self-cycle at register-and-validate', async () => {
     const reg = new DerivationRegistry()
-    await reg.register(withDerivation({
+    // Build the spec directly — withDerivation() now rejects an undeclared
+    // self-write at construction (#376), so to exercise validate()'s DFS in
+    // isolation (and prove it still flags a denorm-LESS a → a self-cycle) we
+    // register a hand-built spec.
+    await reg.register({
       source: 'a',
       deterministic: true,
-      outputs: { o: { shape: 'record', collection: 'a' } }, // a → a
+      outputs: { o: { shape: 'record', collection: 'a' } }, // a → a, no denorm
       derive: () => ({ o: {} }),
       lifecycle: 'eager',
-    }).spec)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
     expect(() => reg.validate()).toThrow(DerivationCycleError)
   })
 

--- a/packages/hub/__tests__/derivations/trigger-by.test.ts
+++ b/packages/hub/__tests__/derivations/trigger-by.test.ts
@@ -1,0 +1,187 @@
+// FK-keyed derivation triggers — reverse-denormalization (#376 Slice 1).
+//
+// `triggerBy: [{ collection, on }]` fans a PARENT write out to every source
+// record whose FK matches, re-deriving each. A self-write output (collection
+// === source) declaring `denorm` patches only those fields back onto the
+// source record — field-level provenance — and the value-equality guard
+// terminates the self-write recursion.
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withDerivation, ValidationError, DerivationCapExceededError } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v && cname && id) { out[cname] = out[cname] ?? {}; out[cname]![id] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c]!)) { data.set(k(v, c, i), payload[c]![i]!) }
+      }
+    },
+  }
+}
+
+interface Buyer extends Record<string, unknown> { id: string; companyName: string }
+interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number; buyerName?: string; note?: string }
+
+function buyerNameDenorm(extra: { indexed?: boolean } = {}) {
+  return withDerivation<Sale, { self: Sale }>({
+    source: 'sales',
+    deterministic: true,
+    triggerBy: [{ collection: 'buyers', on: 'buyerId' }],
+    outputs: { self: { shape: 'record', collection: 'sales', denorm: ['buyerName'] } },
+    derive: async (sale, ctx) => {
+      const b = await ctx.vault.collection<Buyer>('buyers').get(sale.buyerId)
+      return { self: { ...sale, buyerName: b?.companyName ?? sale.buyerName ?? null } as Sale }
+    },
+    lifecycle: 'eager',
+  })
+}
+
+describe('triggerBy — factory validation (#376)', () => {
+  it('rejects triggerBy.collection equal to source', () => {
+    expect(() =>
+      withDerivation<Sale, { self: Sale }>({
+        source: 'sales',
+        deterministic: true,
+        triggerBy: [{ collection: 'sales', on: 'buyerId' }],
+        outputs: { self: { shape: 'record', collection: 'sales', denorm: ['buyerName'] } },
+        derive: (s) => ({ self: s }),
+        lifecycle: 'eager',
+      }),
+    ).toThrow(ValidationError)
+  })
+  it('rejects a triggerBy entry missing `on`', () => {
+    expect(() =>
+      withDerivation<Sale, { self: Sale }>({
+        source: 'sales',
+        deterministic: true,
+        triggerBy: [{ collection: 'buyers', on: '' }],
+        outputs: { self: { shape: 'record', collection: 'sales', denorm: ['buyerName'] } },
+        derive: (s) => ({ self: s }),
+        lifecycle: 'eager',
+      }),
+    ).toThrow(ValidationError)
+  })
+  it('rejects a self-write output without denorm', () => {
+    expect(() =>
+      withDerivation<Sale, { self: Sale }>({
+        source: 'sales',
+        deterministic: true,
+        triggerBy: [{ collection: 'buyers', on: 'buyerId' }],
+        outputs: { self: { shape: 'record', collection: 'sales' } },
+        derive: (s) => ({ self: s }),
+        lifecycle: 'eager',
+      }),
+    ).toThrow(ValidationError)
+  })
+})
+
+describe('triggerBy — reverse-denormalization fan-out (#376)', () => {
+  async function setup(indexed = false) {
+    const db = await createNoydb({
+      store: memory(), user: 'alice', secret: 'trigger-by-passphrase-2026',
+      derivationStrategies: [buyerNameDenorm()],
+    })
+    const v = await db.openVault('firm')
+    const buyers = v.collection<Buyer>('buyers')
+    const sales = indexed
+      ? v.collection<Sale>('sales', { indexes: ['buyerId'] })
+      : v.collection<Sale>('sales')
+    return { db, v, buyers, sales }
+  }
+
+  it('a parent rename fans out to every matching source record', async () => {
+    const { buyers, sales } = await setup()
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await buyers.put('b2', { id: 'b2', companyName: 'Globex' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 200 })
+    await sales.put('s3', { id: 's3', buyerId: 'b2', total: 300 })
+
+    // On insert (sale write, source path) buyerName is already stamped.
+    expect((await sales.get('s1'))?.buyerName).toBe('Acme')
+    expect((await sales.get('s3'))?.buyerName).toBe('Globex')
+
+    // Rename the parent → fan out to b1's sales only.
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme Corp' })
+    expect((await sales.get('s1'))?.buyerName).toBe('Acme Corp')
+    expect((await sales.get('s2'))?.buyerName).toBe('Acme Corp')
+    expect((await sales.get('s3'))?.buyerName).toBe('Globex') // untouched
+  })
+
+  it('works the same with an FK index on the source (index fan-out path)', async () => {
+    const { buyers, sales } = await setup(true)
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 200 })
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme Corp' })
+    expect((await sales.get('s1'))?.buyerName).toBe('Acme Corp')
+    expect((await sales.get('s2'))?.buyerName).toBe('Acme Corp')
+  })
+
+  it('only patches denorm fields — never clobbers other user fields', async () => {
+    const { buyers, sales } = await setup()
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100, note: 'keep me' })
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme Corp' })
+    const s = await sales.get('s1')
+    expect(s?.buyerName).toBe('Acme Corp')
+    expect(s?.note).toBe('keep me')   // untouched by the denorm patch
+    expect(s?.total).toBe(100)        // untouched
+  })
+
+  it('self-write terminates (no infinite loop) and is idempotent', async () => {
+    const { buyers, sales } = await setup()
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    // A redundant parent write (same name) must not loop or error.
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    expect((await sales.get('s1'))?.buyerName).toBe('Acme')
+  })
+
+  it('enforces maxFanout', async () => {
+    const db = await createNoydb({
+      store: memory(), user: 'alice', secret: 'trigger-by-cap-passphrase-2026',
+      derivationStrategies: [
+        withDerivation<Sale, { self: Sale }>({
+          source: 'sales',
+          deterministic: true,
+          triggerBy: [{ collection: 'buyers', on: 'buyerId', maxFanout: 1 }],
+          outputs: { self: { shape: 'record', collection: 'sales', denorm: ['buyerName'] } },
+          derive: async (sale, ctx) => {
+            const b = await ctx.vault.collection<Buyer>('buyers').get(sale.buyerId)
+            return { self: { ...sale, buyerName: b?.companyName ?? null } as Sale }
+          },
+          lifecycle: 'eager',
+        }),
+      ],
+    })
+    const v = await db.openVault('firm')
+    const buyers = v.collection<Buyer>('buyers')
+    const sales = v.collection<Sale>('sales')
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 200 }) // 2 matches > maxFanout 1
+    await expect(buyers.put('b1', { id: 'b1', companyName: 'Acme Corp' }))
+      .rejects.toBeInstanceOf(DerivationCapExceededError)
+  })
+})

--- a/packages/hub/__tests__/derivations/vault-wiring.test.ts
+++ b/packages/hub/__tests__/derivations/vault-wiring.test.ts
@@ -72,10 +72,20 @@ describe('Vault.derivationRegistry wiring', () => {
   })
 
   it('refuses to open vault with a cyclic derivation graph', async () => {
-    const bad = withDerivation({
+    // A → B → A cycle (an undeclared a → a self-write is now a construction
+    // error, #376, so use a genuine multi-collection cycle to exercise the
+    // vault-open DFS).
+    const a = withDerivation({
       source: 'a',
       deterministic: true,
-      outputs: { o: { shape: 'record', collection: 'a' } }, // self-cycle
+      outputs: { o: { shape: 'record', collection: 'b' } },
+      derive: () => ({ o: {} }),
+      lifecycle: 'eager',
+    })
+    const b = withDerivation({
+      source: 'b',
+      deterministic: true,
+      outputs: { o: { shape: 'record', collection: 'a' } },
       derive: () => ({ o: {} }),
       lifecycle: 'eager',
     })
@@ -83,7 +93,7 @@ describe('Vault.derivationRegistry wiring', () => {
       store: memory(),
       user: 'alice',
       secret: 'derivation-vault-wiring-cycle-passphrase-2026',
-      derivationStrategies: [bad],
+      derivationStrategies: [a, b],
     })
     await expect(db.openVault('demo')).rejects.toBeInstanceOf(DerivationCycleError)
   })

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -46,7 +46,7 @@ import type { PersistedCollectionIndex, PersistedIndexDef } from './indexing/per
 import { LazyQuery } from './indexing/lazy-builder.js'
 import type { LazyQuerySource } from './indexing/lazy-builder.js'
 import { NO_INDEXING, type IndexStrategy, type IndexState } from './indexing/strategy.js'
-import { IndexWriteFailureError } from './errors.js'
+import { IndexWriteFailureError, DerivationCapExceededError } from './errors.js'
 import { buildUniqueConstraintSet, type UniqueConstraintSet } from './indexing/unique-constraints.js'
 import type { RefDescriptor } from './refs.js'
 import { Lru, parseBytes, estimateRecordBytes, type LruStats } from './cache/index.js'
@@ -77,6 +77,22 @@ import type * as MVStaleModule from './materialized-views/stale.js'
 
 /** Callback for dirty tracking (sync engine integration). */
 export type OnDirtyCallback = (collection: string, id: string, action: 'put' | 'delete', version: number) => Promise<void>
+
+/**
+ * Value-equality for a single self-write reverse-denorm field (#376). Scalars
+ * compare by identity; objects by canonical JSON (denorm values should be
+ * deterministically shaped). Used as the cycle guard — when every denorm
+ * field already matches, no write is issued and the self-write recursion ends.
+ */
+function selfWriteFieldEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') return false
+  try {
+    return JSON.stringify(a) === JSON.stringify(b)
+  } catch {
+    return false
+  }
+}
 
 /**
  * Event delivered to a `collection.subscribe()` callback. Distinct
@@ -1676,6 +1692,64 @@ export class Collection<T> {
    * output (carries `_derivedFrom`) — defensive guard against missed
    * cycle detection.
    */
+  /**
+   * @internal #376 — the RAW stored record (canonical-money form, i18n maps
+   * intact), WITHOUT the locale resolution `get()` applies. Used as the
+   * patch base for self-write reverse-denorm so writing back never clobbers
+   * an i18n map or re-quantizes money incorrectly. Returns null for
+   * missing / tombstoned records.
+   */
+  async _getStoredRecord(id: string): Promise<T | null> {
+    let raw: T | null
+    if (this.lazy && this.lru) {
+      const cached = this.lru.get(id)
+      if (cached) raw = cached.record
+      else {
+        const env = await this.adapter.get(this.vault, this.name, id)
+        if (!env || isTombstone(env, this.encrypted)) return null
+        raw = await this.decryptRecord(env, { id })
+        if (raw === null) return null
+        this.lru.set(id, { record: raw, version: env._v }, estimateRecordBytes(raw))
+      }
+    } else {
+      await this.ensureHydrated()
+      raw = this.cache.get(id)?.record ?? null
+    }
+    if (raw === null) return null
+    return canonicalizeStoredMoney(raw, this.moneyFields) as T
+  }
+
+  /**
+   * @internal #376 — ids of records whose top-level `field` equals `value`.
+   * Uses the FK index when the field is indexed (O(matches)); otherwise a
+   * linear scan (O(N) — fine for small child sets; index the FK to scale).
+   */
+  async _findMatchingIds(field: string, value: unknown): Promise<string[]> {
+    const hit = this.getIndexes()?.lookupEqual(field, value)
+    if (hit) return [...hit]
+    const target = String(value)
+    const matches = (rec: Record<string, unknown>): boolean => {
+      const fv = rec[field]
+      // FK values are scalars; ignore object/array fields (never a valid FK).
+      return (typeof fv === 'string' || typeof fv === 'number') && String(fv) === target
+    }
+    if (!this.lazy) {
+      await this.ensureHydrated()
+      const out: string[] = []
+      for (const [rid, e] of this.cache) {
+        if (matches(e.record as Record<string, unknown>)) out.push(rid)
+      }
+      return out
+    }
+    const ids = await this.adapter.list(this.vault, this.name)
+    const out: string[] = []
+    for (const rid of ids) {
+      const raw = await this._getStoredRecord(rid)
+      if (raw !== null && matches(raw as Record<string, unknown>)) out.push(rid)
+    }
+    return out
+  }
+
   private async dispatchDerivations(id: string, record: T, version: number): Promise<void> {
     if (this.derivationSource === undefined) return
     // `record` is the stored form here (post-quantize) — decode so
@@ -1693,34 +1767,72 @@ export class Collection<T> {
     let DerivationExecutor: typeof DerivationExecutorType | null = null
     for (const { spec, strategyHash } of strategies) {
       const mode = typeof spec.lifecycle === 'string' ? spec.lifecycle : spec.lifecycle.mode
-      if (mode === 'eager') {
-        if (DerivationExecutor === null) {
-          ({ DerivationExecutor } = (await import('./derivations/executor.js')) as { DerivationExecutor: typeof DerivationExecutorType })
+
+      // Determine how `this.name` triggers this strategy, and build the list
+      // of source records to (re-)derive:
+      //   • source     — re-derive the written record itself (same-id).
+      //   • sources[]  — re-derive the PRIMARY source at the same id (#344).
+      //   • triggerBy  — FK fan-out (#376): re-derive every source record
+      //                  whose `on` field equals the written parent's id.
+      // `input` is passed to derive(); `base` is the raw stored source record
+      // used as the patch base for a self-write reverse-denorm output.
+      const isSource = spec.source === this.name
+      const isSibling = !isSource && (spec.sources?.includes(this.name) ?? false)
+      const trigger = !isSource && !isSibling
+        ? spec.triggerBy?.find(t => t.collection === this.name)
+        : undefined
+
+      const runs: Array<{
+        input: Record<string, unknown> & { id: string }
+        base: Record<string, unknown>
+        runId: string
+        version: number
+      }> = []
+
+      if (isSource) {
+        runs.push({ input: { ...incoming, id }, base: incoming, runId: id, version })
+      } else if (isSibling) {
+        const p = await this.derivationSource.getCollection(spec.source).get(id)
+        if (p !== null && p !== undefined) {
+          // Raw base for a (rare) sibling self-write; falls back to the
+          // resolved primary if the raw read misses.
+          const raw = await this.derivationSource.getCollection(spec.source)._getStoredRecord(id)
+          runs.push({ input: { ...p, id }, base: raw ?? p, runId: id, version: 0 })
         }
-        // #344: a sibling-triggered strategy (spec.source !== this.name)
-        // derives against the PRIMARY source record at the same id — not
-        // the incoming sibling record. Read it through the primary
-        // collection so its own money/crypto wiring applies; silent
-        // no-op if no primary record exists at that id (same-id rule).
-        let sourceWithId: Record<string, unknown> & { id: string }
-        let sourceVersion = version
-        if (spec.source === this.name) {
-          sourceWithId = { ...incoming, id } as Record<string, unknown> & { id: string }
-        } else {
-          const primary = await this.derivationSource.getCollection(spec.source).get(id)
-          if (primary === null || primary === undefined) continue
-          sourceWithId = { ...primary, id } as Record<string, unknown> & { id: string }
-          sourceVersion = 0
+      } else if (trigger) {
+        const srcColl = this.derivationSource.getCollection(spec.source)
+        const ids = await srcColl._findMatchingIds(trigger.on, id)
+        if (trigger.maxFanout !== undefined && ids.length > trigger.maxFanout) {
+          throw new DerivationCapExceededError(`triggerBy ${this.name}→${spec.source}`, ids.length, trigger.maxFanout)
         }
+        for (const sid of ids) {
+          const raw = await srcColl._getStoredRecord(sid)
+          if (raw === null) continue
+          runs.push({ input: { ...raw, id: sid }, base: raw, runId: sid, version: 0 })
+        }
+      }
+
+      if (runs.length === 0) continue
+
+      if (mode !== 'eager') {
+        for (const run of runs) await markStale(registry, spec, run.runId)
+        continue
+      }
+
+      if (DerivationExecutor === null) {
+        ({ DerivationExecutor } = (await import('./derivations/executor.js')) as { DerivationExecutor: typeof DerivationExecutorType })
+      }
+
+      for (const run of runs) {
         const ctx = { vault: this.derivationSource.getReadOnlyFacade() }
-        const result = await DerivationExecutor.run(spec, sourceWithId, sourceVersion, strategyHash, ctx)
+        const result = await DerivationExecutor.run(spec, run.input, run.version, strategyHash, ctx)
         for (const key of Object.keys(spec.outputs)) {
           const out = result.outputs[key]
           if (!out) continue
           if (out.kind === 'failed') {
             const err = out.error
             if (spec.strict) throw err
-            console.warn(`[derivation] output "${key}" for source "${spec.source}" id="${id}" failed:`, err)
+            console.warn(`[derivation] output "${key}" for source "${spec.source}" id="${run.runId}" failed:`, err)
             continue
           }
           const outSpec = spec.outputs[key]
@@ -1743,7 +1855,7 @@ export class Collection<T> {
               this.adapter,
               this.vault,
               spec.source,
-              id,
+              run.runId,
               key,
             )
             const prevKeys = new Set<string>(prior?.keys ?? [])
@@ -1779,7 +1891,7 @@ export class Collection<T> {
             // on failure-mode symmetry).
             await saveFanoutSidecar(this.adapter, this.vault, {
               source: spec.source,
-              sourceId: id,
+              sourceId: run.runId,
               outputKey: key,
               outputCollection: outSpec.collection,
               keys: newKeysList,
@@ -1787,7 +1899,7 @@ export class Collection<T> {
             continue
           }
 
-          // ── Record-shape branch (existing v1 behavior) ─────────
+          // ── Record-shape branch ────────────────────────────────
           if (out.skipped === true) {
             // Optional output returned null. Delete the
             // previously-emitted output at this id, if any. Routed
@@ -1797,25 +1909,55 @@ export class Collection<T> {
             // user-initiated delete. The txCtx hookup captures the
             // prior envelope inside `_internalDelete` for rollback
             // symmetry; delete-of-absent is a silent no-op.
-            await outputCollection._internalDelete(id, txCtx)
+            await outputCollection._internalDelete(run.runId, txCtx)
             continue
           }
+
+          // ── Self-write reverse-denorm (#376) ───────────────────
+          // An output back to its own source: patch ONLY the declared
+          // `denorm` fields onto the raw stored record, never the whole
+          // value (which would clobber user fields / i18n maps and carries
+          // the executor's `_derivedFrom` tag). If the patch changes
+          // nothing, skip the write — that value-equality is the cycle
+          // guard: the self-write re-fires the source-path derivation,
+          // which recomputes identical fields and terminates here.
+          if (outSpec.shape === 'record' && outSpec.denorm !== undefined && outSpec.collection === spec.source) {
+            const value = out.value
+            const patched: Record<string, unknown> = { ...run.base }
+            let changed = false
+            for (const f of outSpec.denorm) {
+              if (!selfWriteFieldEqual(run.base[f], value[f])) {
+                patched[f] = value[f]
+                changed = true
+              }
+            }
+            if (!changed) continue // cycle guard — nothing to write
+            if (txCtx !== null) {
+              const prior = await this.adapter.get(this.vault, outSpec.collection, run.runId)
+              txCtx._executed.push({
+                op: { type: 'put', vaultName: this.vault, collectionName: outSpec.collection, id: run.runId },
+                priorEnvelope: prior,
+              })
+            }
+            await outputCollection.put(run.runId, patched)
+            continue
+          }
+
+          // ── Normal record output (separate output collection) ──
           if (txCtx !== null) {
-            const prior = await this.adapter.get(this.vault, outSpec.collection, id)
+            const prior = await this.adapter.get(this.vault, outSpec.collection, run.runId)
             txCtx._executed.push({
               op: {
                 type: 'put',
                 vaultName: this.vault,
                 collectionName: outSpec.collection,
-                id,
+                id: run.runId,
               },
               priorEnvelope: prior,
             })
           }
-          await outputCollection.put(id, out.value)
+          await outputCollection.put(run.runId, out.value)
         }
-      } else {
-        await markStale(registry, spec, id)
       }
     }
   }

--- a/packages/hub/src/derivations/registry.ts
+++ b/packages/hub/src/derivations/registry.ts
@@ -39,6 +39,16 @@ export class DerivationRegistry {
       else this._bySource.set(extra, [reg])
     }
 
+    // FK triggers (#376) index the SAME `reg` under each parent collection so
+    // a parent write re-fires the derivation (fanned out to matching source
+    // records in `dispatchDerivations`). Like sources[], these keys enter
+    // `_bySource` so the cycle DFS walks the trigger→output edge.
+    for (const t of spec.triggerBy ?? []) {
+      const fromTrigger = this._bySource.get(t.collection)
+      if (fromTrigger) fromTrigger.push(reg)
+      else this._bySource.set(t.collection, [reg])
+    }
+
     for (const key of outputKeys) {
       const output = spec.outputs[key]
       if (!output) continue
@@ -97,6 +107,17 @@ export class DerivationRegistry {
           for (const key of Object.keys(s.spec.outputs)) {
             const output = s.spec.outputs[key]
             if (!output) continue
+            // Self-write reverse-denorm (#376): an output back to its own
+            // source is intentional, not an infinite cycle — the value-equality
+            // guard in dispatch terminates it. Skip this edge so it isn't
+            // flagged. (Self-write outputs are required to declare `denorm`.)
+            if (
+              output.shape === 'record' &&
+              output.collection === s.spec.source &&
+              output.denorm !== undefined
+            ) {
+              continue
+            }
             visit(output.collection)
           }
         }

--- a/packages/hub/src/derivations/types.ts
+++ b/packages/hub/src/derivations/types.ts
@@ -48,6 +48,27 @@ export interface RecordOutputSpec {
    * `DerivationOutputShapeError` — same as v1.
    */
   optional?: boolean
+  /**
+   * Field-level provenance for a **self-write** output (#376) — an output
+   * whose `collection` equals the strategy's `source`, used by
+   * reverse-denormalization (`triggerBy`) to patch a denormalized field
+   * back onto the source record.
+   *
+   * `denorm` names the ONLY top-level fields the derivation owns on that
+   * record. The engine merges just those fields from the `derive` return
+   * value onto the current stored record (`{ ...current, ...pick(out, denorm) }`)
+   * — the rest of the user's record is never clobbered by a stale snapshot.
+   * The whole-record `_derivedFrom` provenance tag is NOT applied (the
+   * record stays user-owned); the derivation only claims `denorm`.
+   *
+   * Cycle break is value-level: if the patch changes nothing, no write is
+   * issued — so the self-write that re-fires the source-path derivation
+   * terminates after one idempotent pass.
+   *
+   * REQUIRED when `collection === source` (validated at construction);
+   * ignored for outputs to a different collection.
+   */
+  denorm?: readonly string[]
 }
 
 /**
@@ -134,6 +155,33 @@ export interface DerivationStrategy<
    * (validated at `withDerivation()` construction time).
    */
   sources?: ReadonlyArray<string>
+  /**
+   * Foreign-key-keyed triggers for reverse-denormalization (#376). Unlike
+   * `sources[]` (which re-fires at the SAME id), a `triggerBy` entry fans a
+   * write to a PARENT collection OUT to every source record whose FK matches
+   * the written parent's id.
+   *
+   * `{ collection, on }`: a write to `collection` (the parent, e.g.
+   * `'buyers'`) re-fires this derivation once per source record where
+   * `source[on] === writtenParentId` (`on` is the FK field ON the source,
+   * e.g. `'buyerId'`). The matched source record — not the parent — is
+   * passed to `derive`.
+   *
+   * Typical use: keep a denormalized field on the source in sync with a
+   * parent change (a buyer rename → refresh `buyerName` on all their sales),
+   * via a self-write output (`collection === source`) declaring `denorm`.
+   *
+   * Fan-out runs through `ctx.vault.collection(source).query().where(on,'==',id)`,
+   * which uses the FK index when the source declares `withIndexing()` on
+   * `on` (O(children)) and otherwise scans (O(N) — fine for small child
+   * sets). Set `maxFanout` as a safety rail; exceeding it throws
+   * `DerivationCapExceededError` before any write. `triggerBy` collections
+   * participate in cycle detection like `source`/`sources`.
+   *
+   * Each `collection` must be non-empty and not equal `source`; `on` must
+   * be a non-empty field name (validated at construction).
+   */
+  triggerBy?: ReadonlyArray<{ collection: string; on: string; maxFanout?: number }>
   /** v1: only deterministic derivations supported. */
   deterministic: true
   /**

--- a/packages/hub/src/derivations/with-derivation.ts
+++ b/packages/hub/src/derivations/with-derivation.ts
@@ -42,9 +42,44 @@ export function withDerivation<
     }
   }
 
+  // Validate FK triggers (#376). Each `collection` must be a non-empty
+  // string differing from the primary source, and `on` a non-empty field.
+  if (spec.triggerBy !== undefined) {
+    for (const t of spec.triggerBy) {
+      if (typeof t?.collection !== 'string' || t.collection.length === 0) {
+        throw new ValidationError('withDerivation: each triggerBy entry needs a non-empty `collection`')
+      }
+      if (t.collection === spec.source) {
+        throw new ValidationError(
+          `withDerivation: triggerBy.collection must not equal the source "${spec.source}" (use sources[] for same-id triggers)`,
+        )
+      }
+      if (typeof t.on !== 'string' || t.on.length === 0) {
+        throw new ValidationError(
+          `withDerivation: triggerBy on "${t.collection}" needs a non-empty \`on\` (the FK field on the source)`,
+        )
+      }
+      if (t.maxFanout !== undefined && (!Number.isInteger(t.maxFanout) || t.maxFanout < 1)) {
+        throw new ValidationError(
+          `withDerivation: triggerBy maxFanout on "${t.collection}" must be a positive integer (got ${String(t.maxFanout)}).`,
+        )
+      }
+    }
+  }
+
   // Validate array-shape outputs.
   const lifecycleMode = typeof spec.lifecycle === 'string' ? spec.lifecycle : spec.lifecycle.mode
   for (const [outputKey, outputSpec] of Object.entries(spec.outputs)) {
+    // Self-write output (collection === source): reverse-denorm must declare
+    // `denorm` (the fields it owns) — field-level provenance, #376.
+    if (outputSpec.shape === 'record' && outputSpec.collection === spec.source) {
+      if (!outputSpec.denorm || outputSpec.denorm.length === 0) {
+        throw new ValidationError(
+          `withDerivation: self-write output "${outputKey}" (collection === source "${spec.source}") `
+          + 'must declare `denorm: [...]` naming the fields it maintains.',
+        )
+      }
+    }
     if (outputSpec.shape === 'array') {
       if (lifecycleMode !== 'eager') {
         throw new ValidationError(

--- a/showcases/src/104-reverse-denorm.showcase.test.ts
+++ b/showcases/src/104-reverse-denorm.showcase.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Showcase 104 — reverse-denormalization (FK derivation triggers)
+ *
+ * What you'll learn
+ * ─────────────────
+ * `triggerBy: [{ collection, on }]` keeps a denormalized field on many
+ * child records in sync with a parent change — keyed by a foreign key, not
+ * a shared id. A buyer rename fans out to every sale that references it.
+ *
+ *   - A self-write output (collection === source) declaring `denorm`
+ *     patches ONLY the named fields back onto the source record.
+ *   - Other fields on the sale are never clobbered.
+ *   - The value-equality guard terminates the self-write cleanly.
+ *
+ * Why it matters
+ * ──────────────
+ * "The buyer's name changed but old sales still show the old name" is a
+ * classic stale-denormalization bug. Declaring the dependency once moves
+ * the maintenance into the data layer — the snapshot can't drift.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 00 + 80 (withDerivation).
+ *
+ * What to read next
+ * ─────────────────
+ *   - showcase 80-with-derivation (the base primitive)
+ *   - docs/subsystems/derivations.md
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → derivations
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withDerivation } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+
+interface Buyer extends Record<string, unknown> { id: string; companyName: string }
+interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number; buyerName?: string; note?: string }
+
+describe('Showcase 104 — reverse-denormalization', () => {
+  it('a buyer rename refreshes buyerName on all their sales', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'reverse-denorm-showcase-2026',
+      derivationStrategies: [
+        withDerivation<Sale, { self: Sale }>({
+          source: 'sales',
+          deterministic: true,
+          // A write to buyers fans out to every sale whose buyerId matches.
+          triggerBy: [{ collection: 'buyers', on: 'buyerId' }],
+          // Self-write: patch ONLY buyerName back onto the sale (field-level).
+          outputs: { self: { shape: 'record', collection: 'sales', denorm: ['buyerName'] } },
+          derive: async (sale, ctx) => {
+            const b = await ctx.vault.collection<Buyer>('buyers').get(sale.buyerId)
+            return { self: { ...sale, buyerName: b?.companyName ?? null } as Sale }
+          },
+          lifecycle: 'eager',
+        }),
+      ],
+    })
+    const vault = await db.openVault('firm')
+    const buyers = vault.collection<Buyer>('buyers')
+    // Index the FK so the fan-out is O(matching sales), not a scan.
+    const sales = vault.collection<Sale>('sales', { indexes: ['buyerId'] })
+
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100, note: 'first order' })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 250 })
+    // buyerName is stamped on insert too (source-path derivation).
+    expect((await sales.get('s1'))?.buyerName).toBe('Acme')
+
+    // Rename the buyer → every referencing sale refreshes.
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme Corporation' })
+    expect((await sales.get('s1'))?.buyerName).toBe('Acme Corporation')
+    expect((await sales.get('s2'))?.buyerName).toBe('Acme Corporation')
+
+    // Non-denorm fields are preserved through the patch.
+    expect((await sales.get('s1'))?.note).toBe('first order')
+    expect((await sales.get('s1'))?.total).toBe(100)
+
+    db.close()
+  })
+})


### PR DESCRIPTION
Advances #376 — **Slice 1 (`triggerBy` reverse-denormalization)**. Implements the design in `docs/superpowers/specs/2026-06-14-fk-derivation-triggers-design.md` with the decisions you approved: **self-write + field-level provenance** (Decision 1a), and **warn-don't-require index** (Decision 3). `withRollup` + rollup-on-delete is Slice 2 (deferred).

## What & why

`withDerivation` re-fired only at the **same id** as the written record. Reverse-denormalization is keyed by a **foreign key**: a buyer rename must refresh a denormalized `buyerName` on *all* sales where `sale.buyerId === buyer.id`. That fell to userland (the "stale denormalized name" bug class). `triggerBy` fans a parent write out to every matching source record.

```ts
withDerivation<Sale, { self: Sale }>({
  source: 'sales',
  deterministic: true,
  triggerBy: [{ collection: 'buyers', on: 'buyerId' }],            // `on` = FK on the source
  outputs: { self: { shape: 'record', collection: 'sales', denorm: ['buyerName'] } },
  derive: async (sale, ctx) => {
    const b = await ctx.vault.collection<Buyer>('buyers').get(sale.buyerId)
    return { self: { ...sale, buyerName: b?.companyName ?? null } }
  },
  lifecycle: 'eager',
})
```

## How

- **`triggerBy: [{ collection, on, maxFanout? }]`** — a write to the parent re-derives every source record where `source[on] === parentId`. Fan-out uses the FK index when the source declares `indexes:[on]` (O(matches)), else scans (O(N) — fine for small child sets). `maxFanout` throws `DerivationCapExceededError` before any write.
- **Self-write + `denorm` (Decision 1a).** A record output whose `collection === source` MUST declare `denorm:[...]`. Only those fields are merged onto the **raw stored source record** — i18n maps and other user fields are never clobbered, and no whole-record `_derivedFrom` tag is added (the record stays user-owned). This is the field-level provenance you approved.
- **Cycle handling.** The self-write edge is exempted from the vault-open cycle DFS (it's intentional, not infinite). A **value-equality guard** terminates the recursion: the self-write re-fires the source-path derivation, which recomputes identical fields and skips the write.
- New `Collection` internals: `_getStoredRecord` (raw record, no locale resolution — the safe self-write base) and `_findMatchingIds` (index-accelerated FK lookup with scan fallback). The registry indexes `triggerBy` collections in `_bySource` so the DFS walks the trigger→output edge.

## Behavior-preserving test updates

Three existing cycle tests used a **single-collection self-cycle** (`a→a`), which is now (correctly) rejected *earlier* — at `withDerivation()` construction (a self-write needs `denorm`). They're updated to assert that construction guard, or to use a genuine 2-collection cycle that still exercises the vault-open DFS. No loss of coverage.

## Scope / deferred (Slice 2)

- **`withRollup`** (aggregate onto a parent field) + **rollup-on-delete** — next slice.
- **`forget()` does not auto-re-derive** (it bypasses the put path) — documented; recompute explicitly if needed.

## Tests

- New `packages/hub/__tests__/derivations/trigger-by.test.ts` (8): factory validation (triggerBy≠source, `on` required, self-write needs denorm), fan-out on parent rename, FK-index path, denorm-only patch (other fields preserved), cycle termination + idempotence, `maxFanout` cap.
- Showcase 104 (buyer rename → all sales). `docs/subsystems/derivations.md` + `features.yaml` updated.
- Full hub suite green (263 files / 2542 tests); lint clean.

Builds on the approved design PR #382.