### PR TITLE
feat(derivations): withRollup — aggregate onto a parent field (#376 slice 2)

### DIFF
--- a/docs/subsystems/derivations.md
+++ b/docs/subsystems/derivations.md
@@ -149,10 +149,44 @@ withDerivation<Sale, { self: Sale }>({
   before any write.
 - `triggerBy.collection` must differ from `source`; `on` is required.
 
-> **Slice 1 scope (#376).** This ships `triggerBy` reverse-denormalization.
-> The aggregate-onto-parent companion (`withRollup`) and rollup-on-delete
-> are a tracked follow-up (Slice 2). `vault.forget()` does not auto-re-derive
-> (it bypasses the put path) — recompute explicitly if needed.
+### Rollups — aggregate onto a parent field (#376 slice 2)
+
+`withRollup` is the inverse of a join: instead of reading children on
+demand, the parent carries a **maintained summary** folded from its
+children by foreign key. It recomputes on child insert, update, AND
+delete — gap-free.
+
+```ts
+import { withRollup } from '@noy-db/hub/derivations'
+
+withRollup<Sale, Buyer>({
+  from: 'sales',          // child collection (the trigger)
+  key: 'buyerId',         // FK on the child → parent id
+  into: 'buyers',         // parent collection
+  field: 'revenueByYear', // field on the parent to maintain
+  compute: (sales) => groupSumByYear(sales, 'total'),
+})
+```
+
+- On a `from` write/delete the parent at id `child[key]` is recomputed:
+  `compute(children where child[key] === parentId)` is patched onto
+  `parent[field]`. A parent write also recomputes its own aggregate, so a
+  **parent created after its children** still fills in.
+- Only `field` is patched onto the parent's raw record (other fields and
+  i18n maps untouched); a value-equality guard suppresses no-op writes.
+- The aggregate gathers children through the FK index when the `from`
+  collection declares `indexes:[key]` (O(children)), else a scan.
+- Eager-only in this slice. Desugars to a derivation carrying a `rollup`
+  marker; dispatch handles it without the executor.
+
+> **Why not a materialized view?** An MV aggregates children into a
+> *parallel* collection (`buyer-totals.get(id)`); it cannot write the
+> aggregate onto a field of the parent `buyers` record. `withRollup` does.
+
+> **Scope (#376).** Slice 1 = `triggerBy` reverse-denormalization; slice 2
+> = `withRollup` (this section) + rollup-on-delete. `vault.forget()` does
+> not auto-re-derive (it bypasses the put path) — recompute explicitly if a
+> forgotten record must drop out of an aggregate.
 
 ### Optional outputs (#144)
 

--- a/docs/subsystems/derivations.md
+++ b/docs/subsystems/derivations.md
@@ -112,6 +112,48 @@ This retires the hand-rolled "poke a sibling" pattern (writing a no-op
 back to the source to force a re-derive when a referenced record
 changed).
 
+### FK-keyed triggers — reverse-denormalization (#376)
+
+`sources[]` re-fires at the **same id**. `triggerBy` re-fires keyed by a
+**foreign key**: a write to a PARENT collection fans out to every source
+record whose FK matches the parent's id. The canonical use is keeping a
+denormalized field on the children in sync with a parent change.
+
+```ts
+withDerivation<Sale, { self: Sale }>({
+  source: 'sales',
+  deterministic: true,
+  // A write to buyers re-derives every sale where sale.buyerId === buyer.id.
+  triggerBy: [{ collection: 'buyers', on: 'buyerId' }], // `on` = the FK ON the source
+  // Self-write: patch ONLY buyerName back onto the sale (field-level provenance).
+  outputs: { self: { shape: 'record', collection: 'sales', denorm: ['buyerName'] } },
+  derive: async (sale, ctx) => {
+    const b = await ctx.vault.collection<Buyer>('buyers').get(sale.buyerId)
+    return { self: { ...sale, buyerName: b?.companyName ?? null } }
+  },
+  lifecycle: 'eager',
+})
+```
+
+- **Self-write + `denorm`.** A record output whose `collection` equals the
+  `source` is a *self-write* and MUST declare `denorm: [...]`. Only those
+  fields are merged onto the **raw stored record** — the rest of the user's
+  record (and any i18n maps) is never clobbered, and no whole-record
+  `_derivedFrom` tag is added (the record stays user-owned). The self-write
+  edge is exempt from cycle detection; a **value-equality guard** breaks the
+  recursion: when the patch changes nothing, no write is issued.
+- **Fan-out cost.** The match runs through the FK index when the source
+  declares `indexes: ['<on>']` (O(matching rows)); otherwise it scans
+  (O(N) — fine for small child sets; index the FK to scale). An optional
+  `maxFanout` on the trigger entry throws `DerivationCapExceededError`
+  before any write.
+- `triggerBy.collection` must differ from `source`; `on` is required.
+
+> **Slice 1 scope (#376).** This ships `triggerBy` reverse-denormalization.
+> The aggregate-onto-parent companion (`withRollup`) and rollup-on-delete
+> are a tracked follow-up (Slice 2). `vault.forget()` does not auto-re-derive
+> (it bypasses the put path) — recompute explicitly if needed.
+
 ### Optional outputs (#144)
 
 Declare an output as `optional: true` to let `derive` return `null` for

--- a/features.yaml
+++ b/features.yaml
@@ -755,6 +755,8 @@ features:
     showcases:
       - id: 80-with-derivation
         path: showcases/src/80-with-derivation.showcase.test.ts
+      - id: 104-reverse-denorm
+        path: showcases/src/104-reverse-denorm.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -765,6 +767,8 @@ features:
       - 'strict: true rolls back source write on output failure inside withTransactions'
       - 'cycle detection at vault open — refuses cyclic graphs'
       - 'declared sibling sources (#344): withDerivation({ source, sources: [...] }) re-fires the derivation on writes to any declared sibling, using the PRIMARY source record at the SAME id (silent no-op if no primary record exists there); siblings are indexed in _bySource, participate in cycle detection, and fold into the strategy hash; sources[] entries must be non-empty and != source'
+      - 'FK-keyed triggers (#376 slice 1): withDerivation({ triggerBy: [{ collection, on }] }) fans a PARENT write out to every source record where source[on] === parentId (re-derives each); fan-out uses the FK index when present, else scans; optional maxFanout throws DerivationCapExceededError before any write; triggerBy.collection must != source'
+      - 'self-write reverse-denorm (#376): a record output whose collection === source MUST declare denorm:[...] — only those fields are patched onto the raw stored record (i18n maps/other fields never clobbered; no whole-record _derivedFrom tag); the self-write edge is exempt from cycle detection and terminated by a value-equality guard (no write when the patch changes nothing)'
     related: [guards, transactions]
 
   - id: materialized-views

--- a/features.yaml
+++ b/features.yaml
@@ -757,6 +757,8 @@ features:
         path: showcases/src/80-with-derivation.showcase.test.ts
       - id: 104-reverse-denorm
         path: showcases/src/104-reverse-denorm.showcase.test.ts
+      - id: 105-rollup
+        path: showcases/src/105-rollup.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -769,6 +771,7 @@ features:
       - 'declared sibling sources (#344): withDerivation({ source, sources: [...] }) re-fires the derivation on writes to any declared sibling, using the PRIMARY source record at the SAME id (silent no-op if no primary record exists there); siblings are indexed in _bySource, participate in cycle detection, and fold into the strategy hash; sources[] entries must be non-empty and != source'
       - 'FK-keyed triggers (#376 slice 1): withDerivation({ triggerBy: [{ collection, on }] }) fans a PARENT write out to every source record where source[on] === parentId (re-derives each); fan-out uses the FK index when present, else scans; optional maxFanout throws DerivationCapExceededError before any write; triggerBy.collection must != source'
       - 'self-write reverse-denorm (#376): a record output whose collection === source MUST declare denorm:[...] — only those fields are patched onto the raw stored record (i18n maps/other fields never clobbered; no whole-record _derivedFrom tag); the self-write edge is exempt from cycle detection and terminated by a value-equality guard (no write when the patch changes nothing)'
+      - 'rollups (#376 slice 2): withRollup({ from, key, into, field, compute }) maintains an aggregate on the parent field — recomputed on child insert/update/DELETE (gap-free) and on a parent write (fills in a parent created after its children); only `field` is patched (value-equality guarded); children gathered via the FK index when from declares indexes:[key], else a scan; eager-only; forget() does not auto-recompute'
     related: [guards, transactions]
 
   - id: materialized-views

--- a/packages/hub/__tests__/derivations/cycle.test.ts
+++ b/packages/hub/__tests__/derivations/cycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { createNoydb, withDerivation, DerivationCycleError } from '../../src/index.js'
+import { createNoydb, withDerivation, DerivationCycleError, ValidationError } from '../../src/index.js'
 import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
 
 function memory(): NoydbStore {
@@ -36,21 +36,20 @@ function memory(): NoydbStore {
 }
 
 describe('Derivation cycle detection at vault open', () => {
-  it('refuses to open a vault with a self-cycle', async () => {
-    const bad = withDerivation({
-      source: 'a',
-      deterministic: true,
-      outputs: { o: { shape: 'record', collection: 'a' } },
-      derive: () => ({ o: {} }),
-      lifecycle: 'eager',
-    })
-    const db = await createNoydb({
-      store: memory(),
-      user: 'alice',
-      secret: 'derivation-cycle-self-passphrase-2026',
-      derivationStrategies: [bad],
-    })
-    await expect(db.openVault('demo')).rejects.toBeInstanceOf(DerivationCycleError)
+  it('rejects a self-write output without denorm at construction (#376 — was a self-cycle)', () => {
+    // A record output back to its own source is now a self-write
+    // reverse-denorm (#376) and MUST declare `denorm`. An undeclared
+    // self-write — the old "self-cycle" — is rejected earlier, at
+    // withDerivation() construction, rather than by vault-open DFS.
+    expect(() =>
+      withDerivation({
+        source: 'a',
+        deterministic: true,
+        outputs: { o: { shape: 'record', collection: 'a' } },
+        derive: () => ({ o: {} }),
+        lifecycle: 'eager',
+      }),
+    ).toThrow(ValidationError)
   })
 
   it('refuses A -> B -> A', async () => {

--- a/packages/hub/__tests__/derivations/registry.test.ts
+++ b/packages/hub/__tests__/derivations/registry.test.ts
@@ -31,13 +31,18 @@ describe('DerivationRegistry', () => {
 
   it('detects self-cycle at register-and-validate', async () => {
     const reg = new DerivationRegistry()
-    await reg.register(withDerivation({
+    // Build the spec directly — withDerivation() now rejects an undeclared
+    // self-write at construction (#376), so to exercise validate()'s DFS in
+    // isolation (and prove it still flags a denorm-LESS a → a self-cycle) we
+    // register a hand-built spec.
+    await reg.register({
       source: 'a',
       deterministic: true,
-      outputs: { o: { shape: 'record', collection: 'a' } }, // a → a
+      outputs: { o: { shape: 'record', collection: 'a' } }, // a → a, no denorm
       derive: () => ({ o: {} }),
       lifecycle: 'eager',
-    }).spec)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any)
     expect(() => reg.validate()).toThrow(DerivationCycleError)
   })
 

--- a/packages/hub/__tests__/derivations/rollup.test.ts
+++ b/packages/hub/__tests__/derivations/rollup.test.ts
@@ -1,0 +1,165 @@
+// Aggregate-onto-parent rollups (#376 slice 2).
+//
+// withRollup({ from, key, into, field, compute }) keeps a summary field on the
+// parent in sync with its children, on insert / update / delete, gap-free.
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withRollup, ValidationError } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v && cname && id) { out[cname] = out[cname] ?? {}; out[cname]![id] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c]!)) { data.set(k(v, c, i), payload[c]![i]!) }
+      }
+    },
+  }
+}
+
+interface Buyer extends Record<string, unknown> { id: string; companyName: string; totalSpent?: number; orderCount?: number }
+interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number }
+
+const totalSpentRollup = () =>
+  withRollup<Sale, Buyer>({
+    from: 'sales',
+    key: 'buyerId',
+    into: 'buyers',
+    field: 'totalSpent',
+    compute: (sales) => sales.reduce((t, s) => t + s.total, 0),
+  })
+
+describe('withRollup — factory validation (#376)', () => {
+  it('rejects from === into', () => {
+    expect(() => withRollup({ from: 'x', key: 'k', into: 'x', field: 'f', compute: () => 0 })).toThrow(ValidationError)
+  })
+  it('rejects a missing field', () => {
+    expect(() => withRollup({ from: 'sales', key: 'buyerId', into: 'buyers', field: '', compute: () => 0 })).toThrow(ValidationError)
+  })
+  it('rejects a non-function compute', () => {
+    // @ts-expect-error — compute must be a function
+    expect(() => withRollup({ from: 'sales', key: 'buyerId', into: 'buyers', field: 'f', compute: 5 })).toThrow(ValidationError)
+  })
+})
+
+describe('withRollup — aggregate maintenance (#376)', () => {
+  async function setup(indexed = false) {
+    const db = await createNoydb({
+      store: memory(), user: 'alice', secret: 'rollup-passphrase-2026',
+      derivationStrategies: [totalSpentRollup()],
+    })
+    const v = await db.openVault('firm')
+    const buyers = v.collection<Buyer>('buyers')
+    const sales = indexed
+      ? v.collection<Sale>('sales', { indexes: ['buyerId'] })
+      : v.collection<Sale>('sales')
+    return { db, v, buyers, sales }
+  }
+
+  it('maintains the aggregate across insert, update, and delete', async () => {
+    const { buyers, sales } = await setup()
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    expect((await buyers.get('b1'))?.totalSpent).toBe(100)
+
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 250 })
+    expect((await buyers.get('b1'))?.totalSpent).toBe(350)
+
+    // Update a child → recompute.
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 50 })
+    expect((await buyers.get('b1'))?.totalSpent).toBe(150)
+
+    // Delete a child → recompute (gap-free).
+    await sales.delete('s1')
+    expect((await buyers.get('b1'))?.totalSpent).toBe(50)
+
+    await sales.delete('s2')
+    expect((await buyers.get('b1'))?.totalSpent).toBe(0)
+  })
+
+  it('works with an FK index on the child', async () => {
+    const { buyers, sales } = await setup(true)
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 200 })
+    expect((await buyers.get('b1'))?.totalSpent).toBe(300)
+    await sales.delete('s1')
+    expect((await buyers.get('b1'))?.totalSpent).toBe(200)
+  })
+
+  it('isolates parents', async () => {
+    const { buyers, sales } = await setup()
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await buyers.put('b2', { id: 'b2', companyName: 'Globex' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    await sales.put('s2', { id: 's2', buyerId: 'b2', total: 999 })
+    await sales.put('s3', { id: 's3', buyerId: 'b1', total: 50 })
+    expect((await buyers.get('b1'))?.totalSpent).toBe(150)
+    expect((await buyers.get('b2'))?.totalSpent).toBe(999)
+  })
+
+  it('fills in a parent created AFTER its children', async () => {
+    const { buyers, sales } = await setup()
+    // Children written first — no parent record yet, so the rollup has
+    // nowhere to write (silently skipped).
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 200 })
+    // Now the parent appears → a parent write recomputes its own aggregate.
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    expect((await buyers.get('b1'))?.totalSpent).toBe(300)
+  })
+
+  it('patches only the rollup field — other parent fields preserved', async () => {
+    const { buyers, sales } = await setup()
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    const b = await buyers.get('b1')
+    expect(b?.totalSpent).toBe(100)
+    expect(b?.companyName).toBe('Acme') // untouched
+  })
+
+  it('supports an object aggregate (group-by-style) value', async () => {
+    const db = await createNoydb({
+      store: memory(), user: 'alice', secret: 'rollup-obj-passphrase-2026',
+      derivationStrategies: [
+        withRollup<Sale & { year: number }, Buyer>({
+          from: 'sales', key: 'buyerId', into: 'buyers', field: 'byYear',
+          compute: (sales) => {
+            const out: Record<string, number> = {}
+            for (const s of sales) out[String(s.year)] = (out[String(s.year)] ?? 0) + s.total
+            return out
+          },
+        }),
+      ],
+    })
+    const v = await db.openVault('firm')
+    const buyers = v.collection<Buyer & { byYear?: Record<string, number> }>('buyers')
+    const sales = v.collection<Sale & { year: number }>('sales')
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100, year: 2026 })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 50, year: 2026 })
+    await sales.put('s3', { id: 's3', buyerId: 'b1', total: 70, year: 2027 })
+    expect((await buyers.get('b1'))?.byYear).toEqual({ '2026': 150, '2027': 70 })
+    await sales.delete('s1')
+    expect((await buyers.get('b1'))?.byYear).toEqual({ '2026': 50, '2027': 70 })
+  })
+})

--- a/packages/hub/__tests__/derivations/trigger-by.test.ts
+++ b/packages/hub/__tests__/derivations/trigger-by.test.ts
@@ -1,0 +1,187 @@
+// FK-keyed derivation triggers — reverse-denormalization (#376 Slice 1).
+//
+// `triggerBy: [{ collection, on }]` fans a PARENT write out to every source
+// record whose FK matches, re-deriving each. A self-write output (collection
+// === source) declaring `denorm` patches only those fields back onto the
+// source record — field-level provenance — and the value-equality guard
+// terminates the self-write recursion.
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withDerivation, ValidationError, DerivationCapExceededError } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v && cname && id) { out[cname] = out[cname] ?? {}; out[cname]![id] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c]!)) { data.set(k(v, c, i), payload[c]![i]!) }
+      }
+    },
+  }
+}
+
+interface Buyer extends Record<string, unknown> { id: string; companyName: string }
+interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number; buyerName?: string; note?: string }
+
+function buyerNameDenorm(extra: { indexed?: boolean } = {}) {
+  return withDerivation<Sale, { self: Sale }>({
+    source: 'sales',
+    deterministic: true,
+    triggerBy: [{ collection: 'buyers', on: 'buyerId' }],
+    outputs: { self: { shape: 'record', collection: 'sales', denorm: ['buyerName'] } },
+    derive: async (sale, ctx) => {
+      const b = await ctx.vault.collection<Buyer>('buyers').get(sale.buyerId)
+      return { self: { ...sale, buyerName: b?.companyName ?? sale.buyerName ?? null } as Sale }
+    },
+    lifecycle: 'eager',
+  })
+}
+
+describe('triggerBy — factory validation (#376)', () => {
+  it('rejects triggerBy.collection equal to source', () => {
+    expect(() =>
+      withDerivation<Sale, { self: Sale }>({
+        source: 'sales',
+        deterministic: true,
+        triggerBy: [{ collection: 'sales', on: 'buyerId' }],
+        outputs: { self: { shape: 'record', collection: 'sales', denorm: ['buyerName'] } },
+        derive: (s) => ({ self: s }),
+        lifecycle: 'eager',
+      }),
+    ).toThrow(ValidationError)
+  })
+  it('rejects a triggerBy entry missing `on`', () => {
+    expect(() =>
+      withDerivation<Sale, { self: Sale }>({
+        source: 'sales',
+        deterministic: true,
+        triggerBy: [{ collection: 'buyers', on: '' }],
+        outputs: { self: { shape: 'record', collection: 'sales', denorm: ['buyerName'] } },
+        derive: (s) => ({ self: s }),
+        lifecycle: 'eager',
+      }),
+    ).toThrow(ValidationError)
+  })
+  it('rejects a self-write output without denorm', () => {
+    expect(() =>
+      withDerivation<Sale, { self: Sale }>({
+        source: 'sales',
+        deterministic: true,
+        triggerBy: [{ collection: 'buyers', on: 'buyerId' }],
+        outputs: { self: { shape: 'record', collection: 'sales' } },
+        derive: (s) => ({ self: s }),
+        lifecycle: 'eager',
+      }),
+    ).toThrow(ValidationError)
+  })
+})
+
+describe('triggerBy — reverse-denormalization fan-out (#376)', () => {
+  async function setup(indexed = false) {
+    const db = await createNoydb({
+      store: memory(), user: 'alice', secret: 'trigger-by-passphrase-2026',
+      derivationStrategies: [buyerNameDenorm()],
+    })
+    const v = await db.openVault('firm')
+    const buyers = v.collection<Buyer>('buyers')
+    const sales = indexed
+      ? v.collection<Sale>('sales', { indexes: ['buyerId'] })
+      : v.collection<Sale>('sales')
+    return { db, v, buyers, sales }
+  }
+
+  it('a parent rename fans out to every matching source record', async () => {
+    const { buyers, sales } = await setup()
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await buyers.put('b2', { id: 'b2', companyName: 'Globex' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 200 })
+    await sales.put('s3', { id: 's3', buyerId: 'b2', total: 300 })
+
+    // On insert (sale write, source path) buyerName is already stamped.
+    expect((await sales.get('s1'))?.buyerName).toBe('Acme')
+    expect((await sales.get('s3'))?.buyerName).toBe('Globex')
+
+    // Rename the parent → fan out to b1's sales only.
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme Corp' })
+    expect((await sales.get('s1'))?.buyerName).toBe('Acme Corp')
+    expect((await sales.get('s2'))?.buyerName).toBe('Acme Corp')
+    expect((await sales.get('s3'))?.buyerName).toBe('Globex') // untouched
+  })
+
+  it('works the same with an FK index on the source (index fan-out path)', async () => {
+    const { buyers, sales } = await setup(true)
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 200 })
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme Corp' })
+    expect((await sales.get('s1'))?.buyerName).toBe('Acme Corp')
+    expect((await sales.get('s2'))?.buyerName).toBe('Acme Corp')
+  })
+
+  it('only patches denorm fields — never clobbers other user fields', async () => {
+    const { buyers, sales } = await setup()
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100, note: 'keep me' })
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme Corp' })
+    const s = await sales.get('s1')
+    expect(s?.buyerName).toBe('Acme Corp')
+    expect(s?.note).toBe('keep me')   // untouched by the denorm patch
+    expect(s?.total).toBe(100)        // untouched
+  })
+
+  it('self-write terminates (no infinite loop) and is idempotent', async () => {
+    const { buyers, sales } = await setup()
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    // A redundant parent write (same name) must not loop or error.
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    expect((await sales.get('s1'))?.buyerName).toBe('Acme')
+  })
+
+  it('enforces maxFanout', async () => {
+    const db = await createNoydb({
+      store: memory(), user: 'alice', secret: 'trigger-by-cap-passphrase-2026',
+      derivationStrategies: [
+        withDerivation<Sale, { self: Sale }>({
+          source: 'sales',
+          deterministic: true,
+          triggerBy: [{ collection: 'buyers', on: 'buyerId', maxFanout: 1 }],
+          outputs: { self: { shape: 'record', collection: 'sales', denorm: ['buyerName'] } },
+          derive: async (sale, ctx) => {
+            const b = await ctx.vault.collection<Buyer>('buyers').get(sale.buyerId)
+            return { self: { ...sale, buyerName: b?.companyName ?? null } as Sale }
+          },
+          lifecycle: 'eager',
+        }),
+      ],
+    })
+    const v = await db.openVault('firm')
+    const buyers = v.collection<Buyer>('buyers')
+    const sales = v.collection<Sale>('sales')
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 200 }) // 2 matches > maxFanout 1
+    await expect(buyers.put('b1', { id: 'b1', companyName: 'Acme Corp' }))
+      .rejects.toBeInstanceOf(DerivationCapExceededError)
+  })
+})

--- a/packages/hub/__tests__/derivations/vault-wiring.test.ts
+++ b/packages/hub/__tests__/derivations/vault-wiring.test.ts
@@ -72,10 +72,20 @@ describe('Vault.derivationRegistry wiring', () => {
   })
 
   it('refuses to open vault with a cyclic derivation graph', async () => {
-    const bad = withDerivation({
+    // A → B → A cycle (an undeclared a → a self-write is now a construction
+    // error, #376, so use a genuine multi-collection cycle to exercise the
+    // vault-open DFS).
+    const a = withDerivation({
       source: 'a',
       deterministic: true,
-      outputs: { o: { shape: 'record', collection: 'a' } }, // self-cycle
+      outputs: { o: { shape: 'record', collection: 'b' } },
+      derive: () => ({ o: {} }),
+      lifecycle: 'eager',
+    })
+    const b = withDerivation({
+      source: 'b',
+      deterministic: true,
+      outputs: { o: { shape: 'record', collection: 'a' } },
       derive: () => ({ o: {} }),
       lifecycle: 'eager',
     })
@@ -83,7 +93,7 @@ describe('Vault.derivationRegistry wiring', () => {
       store: memory(),
       user: 'alice',
       secret: 'derivation-vault-wiring-cycle-passphrase-2026',
-      derivationStrategies: [bad],
+      derivationStrategies: [a, b],
     })
     await expect(db.openVault('demo')).rejects.toBeInstanceOf(DerivationCycleError)
   })

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1750,6 +1750,65 @@ export class Collection<T> {
     return out
   }
 
+  /**
+   * @internal #376 slice 2 — recompute a rollup aggregate onto the parent.
+   * Gathers every child of `parentId`, runs `compute`, and patches only the
+   * rollup `field` onto the parent's raw stored record (value-equality
+   * guarded). No-op when the parent record does not exist.
+   */
+  private async recomputeRollup(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spec: { source: string; rollup?: { from: string; key: string; field: string; compute: (children: any[]) => unknown } },
+    parentId: string,
+  ): Promise<void> {
+    if (this.derivationSource === undefined || spec.rollup === undefined) return
+    const { from, key, field, compute } = spec.rollup
+    const into = spec.source
+    const intoColl = this.derivationSource.getCollection(into)
+    const base = await intoColl._getStoredRecord(parentId)
+    if (base === null) return // no parent record to patch
+
+    const fromColl = this.derivationSource.getCollection(from)
+    const childIds = await fromColl._findMatchingIds(key, parentId)
+    const children: Array<Record<string, unknown>> = []
+    for (const cid of childIds) {
+      const c = await fromColl.get(cid)
+      if (c !== null && c !== undefined) children.push(c)
+    }
+
+    const newValue = compute(children)
+    if (selfWriteFieldEqual(base[field], newValue)) return // no change → no write
+
+    const patched = { ...base, [field]: newValue }
+    const txCtx = this.derivationSource.getActiveTxContext()
+    if (txCtx !== null) {
+      const prior = await this.adapter.get(this.vault, into, parentId)
+      txCtx._executed.push({
+        op: { type: 'put', vaultName: this.vault, collectionName: into, id: parentId },
+        priorEnvelope: prior,
+      })
+    }
+    await intoColl.put(parentId, patched)
+  }
+
+  /**
+   * @internal #376 slice 2 — fire any rollups for which THIS collection is the
+   * child `from`, recomputing the affected parent after a child delete. Called
+   * from the delete path with the just-removed record's key value. Other
+   * derivation kinds do not react to deletes (unchanged).
+   */
+  private async dispatchRollupsOnDelete(deleted: T): Promise<void> {
+    if (this.derivationSource === undefined) return
+    const registry = this.derivationSource.registry()
+    const rec = deleted as Record<string, unknown>
+    for (const { spec } of registry.strategiesForSource(this.name)) {
+      if (!spec.rollup || spec.rollup.from !== this.name) continue
+      const kv = rec[spec.rollup.key]
+      if (typeof kv !== 'string' && typeof kv !== 'number') continue
+      await this.recomputeRollup(spec, String(kv))
+    }
+  }
+
   private async dispatchDerivations(id: string, record: T, version: number): Promise<void> {
     if (this.derivationSource === undefined) return
     // `record` is the stored form here (post-quantize) — decode so
@@ -1767,6 +1826,22 @@ export class Collection<T> {
     let DerivationExecutor: typeof DerivationExecutorType | null = null
     for (const { spec, strategyHash } of strategies) {
       const mode = typeof spec.lifecycle === 'string' ? spec.lifecycle : spec.lifecycle.mode
+
+      // Rollup (#376 slice 2): a write to the child `from` recomputes the
+      // parent at id child[key]; a write to the parent (source = into)
+      // recomputes its own aggregate. Handled here (the executor is not run).
+      if (spec.rollup) {
+        if (mode !== 'eager') continue
+        let parentId: string | null
+        if (this.name === spec.rollup.from) {
+          const kv = incoming[spec.rollup.key]
+          parentId = (typeof kv === 'string' || typeof kv === 'number') ? String(kv) : null
+        } else {
+          parentId = id // a write to the parent recomputes its own aggregate
+        }
+        if (parentId !== null) await this.recomputeRollup(spec, parentId)
+        continue
+      }
 
       // Determine how `this.name` triggers this strategy, and build the list
       // of source records to (re-)derive:
@@ -2240,6 +2315,11 @@ export class Collection<T> {
     if (!internal) {
       await this.dispatchMaterializedViewsOnDelete(id)
       await this.dispatchArrayDerivationsOnDelete(id)
+      // Rollup-on-delete (#376 slice 2): recompute the parent aggregate now
+      // that this child is gone. `existing.record` carries the deleted child's
+      // FK; the recompute gathers the REMAINING children (this one already
+      // removed from the store/cache above).
+      if (existing) await this.dispatchRollupsOnDelete(existing.record)
     }
   }
 

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -46,7 +46,7 @@ import type { PersistedCollectionIndex, PersistedIndexDef } from './indexing/per
 import { LazyQuery } from './indexing/lazy-builder.js'
 import type { LazyQuerySource } from './indexing/lazy-builder.js'
 import { NO_INDEXING, type IndexStrategy, type IndexState } from './indexing/strategy.js'
-import { IndexWriteFailureError } from './errors.js'
+import { IndexWriteFailureError, DerivationCapExceededError } from './errors.js'
 import { buildUniqueConstraintSet, type UniqueConstraintSet } from './indexing/unique-constraints.js'
 import type { RefDescriptor } from './refs.js'
 import { Lru, parseBytes, estimateRecordBytes, type LruStats } from './cache/index.js'
@@ -77,6 +77,22 @@ import type * as MVStaleModule from './materialized-views/stale.js'
 
 /** Callback for dirty tracking (sync engine integration). */
 export type OnDirtyCallback = (collection: string, id: string, action: 'put' | 'delete', version: number) => Promise<void>
+
+/**
+ * Value-equality for a single self-write reverse-denorm field (#376). Scalars
+ * compare by identity; objects by canonical JSON (denorm values should be
+ * deterministically shaped). Used as the cycle guard — when every denorm
+ * field already matches, no write is issued and the self-write recursion ends.
+ */
+function selfWriteFieldEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') return false
+  try {
+    return JSON.stringify(a) === JSON.stringify(b)
+  } catch {
+    return false
+  }
+}
 
 /**
  * Event delivered to a `collection.subscribe()` callback. Distinct
@@ -1676,6 +1692,64 @@ export class Collection<T> {
    * output (carries `_derivedFrom`) — defensive guard against missed
    * cycle detection.
    */
+  /**
+   * @internal #376 — the RAW stored record (canonical-money form, i18n maps
+   * intact), WITHOUT the locale resolution `get()` applies. Used as the
+   * patch base for self-write reverse-denorm so writing back never clobbers
+   * an i18n map or re-quantizes money incorrectly. Returns null for
+   * missing / tombstoned records.
+   */
+  async _getStoredRecord(id: string): Promise<T | null> {
+    let raw: T | null
+    if (this.lazy && this.lru) {
+      const cached = this.lru.get(id)
+      if (cached) raw = cached.record
+      else {
+        const env = await this.adapter.get(this.vault, this.name, id)
+        if (!env || isTombstone(env, this.encrypted)) return null
+        raw = await this.decryptRecord(env, { id })
+        if (raw === null) return null
+        this.lru.set(id, { record: raw, version: env._v }, estimateRecordBytes(raw))
+      }
+    } else {
+      await this.ensureHydrated()
+      raw = this.cache.get(id)?.record ?? null
+    }
+    if (raw === null) return null
+    return canonicalizeStoredMoney(raw, this.moneyFields) as T
+  }
+
+  /**
+   * @internal #376 — ids of records whose top-level `field` equals `value`.
+   * Uses the FK index when the field is indexed (O(matches)); otherwise a
+   * linear scan (O(N) — fine for small child sets; index the FK to scale).
+   */
+  async _findMatchingIds(field: string, value: unknown): Promise<string[]> {
+    const hit = this.getIndexes()?.lookupEqual(field, value)
+    if (hit) return [...hit]
+    const target = String(value)
+    const matches = (rec: Record<string, unknown>): boolean => {
+      const fv = rec[field]
+      // FK values are scalars; ignore object/array fields (never a valid FK).
+      return (typeof fv === 'string' || typeof fv === 'number') && String(fv) === target
+    }
+    if (!this.lazy) {
+      await this.ensureHydrated()
+      const out: string[] = []
+      for (const [rid, e] of this.cache) {
+        if (matches(e.record as Record<string, unknown>)) out.push(rid)
+      }
+      return out
+    }
+    const ids = await this.adapter.list(this.vault, this.name)
+    const out: string[] = []
+    for (const rid of ids) {
+      const raw = await this._getStoredRecord(rid)
+      if (raw !== null && matches(raw as Record<string, unknown>)) out.push(rid)
+    }
+    return out
+  }
+
   private async dispatchDerivations(id: string, record: T, version: number): Promise<void> {
     if (this.derivationSource === undefined) return
     // `record` is the stored form here (post-quantize) — decode so
@@ -1693,34 +1767,72 @@ export class Collection<T> {
     let DerivationExecutor: typeof DerivationExecutorType | null = null
     for (const { spec, strategyHash } of strategies) {
       const mode = typeof spec.lifecycle === 'string' ? spec.lifecycle : spec.lifecycle.mode
-      if (mode === 'eager') {
-        if (DerivationExecutor === null) {
-          ({ DerivationExecutor } = (await import('./derivations/executor.js')) as { DerivationExecutor: typeof DerivationExecutorType })
+
+      // Determine how `this.name` triggers this strategy, and build the list
+      // of source records to (re-)derive:
+      //   • source     — re-derive the written record itself (same-id).
+      //   • sources[]  — re-derive the PRIMARY source at the same id (#344).
+      //   • triggerBy  — FK fan-out (#376): re-derive every source record
+      //                  whose `on` field equals the written parent's id.
+      // `input` is passed to derive(); `base` is the raw stored source record
+      // used as the patch base for a self-write reverse-denorm output.
+      const isSource = spec.source === this.name
+      const isSibling = !isSource && (spec.sources?.includes(this.name) ?? false)
+      const trigger = !isSource && !isSibling
+        ? spec.triggerBy?.find(t => t.collection === this.name)
+        : undefined
+
+      const runs: Array<{
+        input: Record<string, unknown> & { id: string }
+        base: Record<string, unknown>
+        runId: string
+        version: number
+      }> = []
+
+      if (isSource) {
+        runs.push({ input: { ...incoming, id }, base: incoming, runId: id, version })
+      } else if (isSibling) {
+        const p = await this.derivationSource.getCollection(spec.source).get(id)
+        if (p !== null && p !== undefined) {
+          // Raw base for a (rare) sibling self-write; falls back to the
+          // resolved primary if the raw read misses.
+          const raw = await this.derivationSource.getCollection(spec.source)._getStoredRecord(id)
+          runs.push({ input: { ...p, id }, base: raw ?? p, runId: id, version: 0 })
         }
-        // #344: a sibling-triggered strategy (spec.source !== this.name)
-        // derives against the PRIMARY source record at the same id — not
-        // the incoming sibling record. Read it through the primary
-        // collection so its own money/crypto wiring applies; silent
-        // no-op if no primary record exists at that id (same-id rule).
-        let sourceWithId: Record<string, unknown> & { id: string }
-        let sourceVersion = version
-        if (spec.source === this.name) {
-          sourceWithId = { ...incoming, id } as Record<string, unknown> & { id: string }
-        } else {
-          const primary = await this.derivationSource.getCollection(spec.source).get(id)
-          if (primary === null || primary === undefined) continue
-          sourceWithId = { ...primary, id } as Record<string, unknown> & { id: string }
-          sourceVersion = 0
+      } else if (trigger) {
+        const srcColl = this.derivationSource.getCollection(spec.source)
+        const ids = await srcColl._findMatchingIds(trigger.on, id)
+        if (trigger.maxFanout !== undefined && ids.length > trigger.maxFanout) {
+          throw new DerivationCapExceededError(`triggerBy ${this.name}→${spec.source}`, ids.length, trigger.maxFanout)
         }
+        for (const sid of ids) {
+          const raw = await srcColl._getStoredRecord(sid)
+          if (raw === null) continue
+          runs.push({ input: { ...raw, id: sid }, base: raw, runId: sid, version: 0 })
+        }
+      }
+
+      if (runs.length === 0) continue
+
+      if (mode !== 'eager') {
+        for (const run of runs) await markStale(registry, spec, run.runId)
+        continue
+      }
+
+      if (DerivationExecutor === null) {
+        ({ DerivationExecutor } = (await import('./derivations/executor.js')) as { DerivationExecutor: typeof DerivationExecutorType })
+      }
+
+      for (const run of runs) {
         const ctx = { vault: this.derivationSource.getReadOnlyFacade() }
-        const result = await DerivationExecutor.run(spec, sourceWithId, sourceVersion, strategyHash, ctx)
+        const result = await DerivationExecutor.run(spec, run.input, run.version, strategyHash, ctx)
         for (const key of Object.keys(spec.outputs)) {
           const out = result.outputs[key]
           if (!out) continue
           if (out.kind === 'failed') {
             const err = out.error
             if (spec.strict) throw err
-            console.warn(`[derivation] output "${key}" for source "${spec.source}" id="${id}" failed:`, err)
+            console.warn(`[derivation] output "${key}" for source "${spec.source}" id="${run.runId}" failed:`, err)
             continue
           }
           const outSpec = spec.outputs[key]
@@ -1743,7 +1855,7 @@ export class Collection<T> {
               this.adapter,
               this.vault,
               spec.source,
-              id,
+              run.runId,
               key,
             )
             const prevKeys = new Set<string>(prior?.keys ?? [])
@@ -1779,7 +1891,7 @@ export class Collection<T> {
             // on failure-mode symmetry).
             await saveFanoutSidecar(this.adapter, this.vault, {
               source: spec.source,
-              sourceId: id,
+              sourceId: run.runId,
               outputKey: key,
               outputCollection: outSpec.collection,
               keys: newKeysList,
@@ -1787,7 +1899,7 @@ export class Collection<T> {
             continue
           }
 
-          // ── Record-shape branch (existing v1 behavior) ─────────
+          // ── Record-shape branch ────────────────────────────────
           if (out.skipped === true) {
             // Optional output returned null. Delete the
             // previously-emitted output at this id, if any. Routed
@@ -1797,25 +1909,55 @@ export class Collection<T> {
             // user-initiated delete. The txCtx hookup captures the
             // prior envelope inside `_internalDelete` for rollback
             // symmetry; delete-of-absent is a silent no-op.
-            await outputCollection._internalDelete(id, txCtx)
+            await outputCollection._internalDelete(run.runId, txCtx)
             continue
           }
+
+          // ── Self-write reverse-denorm (#376) ───────────────────
+          // An output back to its own source: patch ONLY the declared
+          // `denorm` fields onto the raw stored record, never the whole
+          // value (which would clobber user fields / i18n maps and carries
+          // the executor's `_derivedFrom` tag). If the patch changes
+          // nothing, skip the write — that value-equality is the cycle
+          // guard: the self-write re-fires the source-path derivation,
+          // which recomputes identical fields and terminates here.
+          if (outSpec.shape === 'record' && outSpec.denorm !== undefined && outSpec.collection === spec.source) {
+            const value = out.value
+            const patched: Record<string, unknown> = { ...run.base }
+            let changed = false
+            for (const f of outSpec.denorm) {
+              if (!selfWriteFieldEqual(run.base[f], value[f])) {
+                patched[f] = value[f]
+                changed = true
+              }
+            }
+            if (!changed) continue // cycle guard — nothing to write
+            if (txCtx !== null) {
+              const prior = await this.adapter.get(this.vault, outSpec.collection, run.runId)
+              txCtx._executed.push({
+                op: { type: 'put', vaultName: this.vault, collectionName: outSpec.collection, id: run.runId },
+                priorEnvelope: prior,
+              })
+            }
+            await outputCollection.put(run.runId, patched)
+            continue
+          }
+
+          // ── Normal record output (separate output collection) ──
           if (txCtx !== null) {
-            const prior = await this.adapter.get(this.vault, outSpec.collection, id)
+            const prior = await this.adapter.get(this.vault, outSpec.collection, run.runId)
             txCtx._executed.push({
               op: {
                 type: 'put',
                 vaultName: this.vault,
                 collectionName: outSpec.collection,
-                id,
+                id: run.runId,
               },
               priorEnvelope: prior,
             })
           }
-          await outputCollection.put(id, out.value)
+          await outputCollection.put(run.runId, out.value)
         }
-      } else {
-        await markStale(registry, spec, id)
       }
     }
   }

--- a/packages/hub/src/derivations/index.ts
+++ b/packages/hub/src/derivations/index.ts
@@ -1,4 +1,5 @@
 export { withDerivation } from './with-derivation.js'
+export { withRollup } from './with-rollup.js'
 export { DerivationRegistry } from './registry.js'
 export { DerivationExecutor } from './executor.js'
 export type {

--- a/packages/hub/src/derivations/registry.ts
+++ b/packages/hub/src/derivations/registry.ts
@@ -39,6 +39,16 @@ export class DerivationRegistry {
       else this._bySource.set(extra, [reg])
     }
 
+    // FK triggers (#376) index the SAME `reg` under each parent collection so
+    // a parent write re-fires the derivation (fanned out to matching source
+    // records in `dispatchDerivations`). Like sources[], these keys enter
+    // `_bySource` so the cycle DFS walks the trigger→output edge.
+    for (const t of spec.triggerBy ?? []) {
+      const fromTrigger = this._bySource.get(t.collection)
+      if (fromTrigger) fromTrigger.push(reg)
+      else this._bySource.set(t.collection, [reg])
+    }
+
     for (const key of outputKeys) {
       const output = spec.outputs[key]
       if (!output) continue
@@ -97,6 +107,17 @@ export class DerivationRegistry {
           for (const key of Object.keys(s.spec.outputs)) {
             const output = s.spec.outputs[key]
             if (!output) continue
+            // Self-write reverse-denorm (#376): an output back to its own
+            // source is intentional, not an infinite cycle — the value-equality
+            // guard in dispatch terminates it. Skip this edge so it isn't
+            // flagged. (Self-write outputs are required to declare `denorm`.)
+            if (
+              output.shape === 'record' &&
+              output.collection === s.spec.source &&
+              output.denorm !== undefined
+            ) {
+              continue
+            }
             visit(output.collection)
           }
         }

--- a/packages/hub/src/derivations/registry.ts
+++ b/packages/hub/src/derivations/registry.ts
@@ -49,6 +49,18 @@ export class DerivationRegistry {
       else this._bySource.set(t.collection, [reg])
     }
 
+    // Rollup (#376 slice 2): a write to the child `from` collection recomputes
+    // the parent (= spec.source = into) at id child[key]. Index under `from`
+    // so a child write fires it; spec.source (into) is already indexed above,
+    // so a parent write also recomputes its own aggregate (covers the
+    // parent-created-after-children case). The from→into edge enters the cycle
+    // DFS automatically.
+    if (spec.rollup) {
+      const fromRollup = this._bySource.get(spec.rollup.from)
+      if (fromRollup) fromRollup.push(reg)
+      else this._bySource.set(spec.rollup.from, [reg])
+    }
+
     for (const key of outputKeys) {
       const output = spec.outputs[key]
       if (!output) continue

--- a/packages/hub/src/derivations/types.ts
+++ b/packages/hub/src/derivations/types.ts
@@ -48,6 +48,27 @@ export interface RecordOutputSpec {
    * `DerivationOutputShapeError` — same as v1.
    */
   optional?: boolean
+  /**
+   * Field-level provenance for a **self-write** output (#376) — an output
+   * whose `collection` equals the strategy's `source`, used by
+   * reverse-denormalization (`triggerBy`) to patch a denormalized field
+   * back onto the source record.
+   *
+   * `denorm` names the ONLY top-level fields the derivation owns on that
+   * record. The engine merges just those fields from the `derive` return
+   * value onto the current stored record (`{ ...current, ...pick(out, denorm) }`)
+   * — the rest of the user's record is never clobbered by a stale snapshot.
+   * The whole-record `_derivedFrom` provenance tag is NOT applied (the
+   * record stays user-owned); the derivation only claims `denorm`.
+   *
+   * Cycle break is value-level: if the patch changes nothing, no write is
+   * issued — so the self-write that re-fires the source-path derivation
+   * terminates after one idempotent pass.
+   *
+   * REQUIRED when `collection === source` (validated at construction);
+   * ignored for outputs to a different collection.
+   */
+  denorm?: readonly string[]
 }
 
 /**
@@ -134,6 +155,33 @@ export interface DerivationStrategy<
    * (validated at `withDerivation()` construction time).
    */
   sources?: ReadonlyArray<string>
+  /**
+   * Foreign-key-keyed triggers for reverse-denormalization (#376). Unlike
+   * `sources[]` (which re-fires at the SAME id), a `triggerBy` entry fans a
+   * write to a PARENT collection OUT to every source record whose FK matches
+   * the written parent's id.
+   *
+   * `{ collection, on }`: a write to `collection` (the parent, e.g.
+   * `'buyers'`) re-fires this derivation once per source record where
+   * `source[on] === writtenParentId` (`on` is the FK field ON the source,
+   * e.g. `'buyerId'`). The matched source record — not the parent — is
+   * passed to `derive`.
+   *
+   * Typical use: keep a denormalized field on the source in sync with a
+   * parent change (a buyer rename → refresh `buyerName` on all their sales),
+   * via a self-write output (`collection === source`) declaring `denorm`.
+   *
+   * Fan-out runs through `ctx.vault.collection(source).query().where(on,'==',id)`,
+   * which uses the FK index when the source declares `withIndexing()` on
+   * `on` (O(children)) and otherwise scans (O(N) — fine for small child
+   * sets). Set `maxFanout` as a safety rail; exceeding it throws
+   * `DerivationCapExceededError` before any write. `triggerBy` collections
+   * participate in cycle detection like `source`/`sources`.
+   *
+   * Each `collection` must be non-empty and not equal `source`; `on` must
+   * be a non-empty field name (validated at construction).
+   */
+  triggerBy?: ReadonlyArray<{ collection: string; on: string; maxFanout?: number }>
   /** v1: only deterministic derivations supported. */
   deterministic: true
   /**

--- a/packages/hub/src/derivations/types.ts
+++ b/packages/hub/src/derivations/types.ts
@@ -182,6 +182,22 @@ export interface DerivationStrategy<
    * be a non-empty field name (validated at construction).
    */
   triggerBy?: ReadonlyArray<{ collection: string; on: string; maxFanout?: number }>
+  /**
+   * @internal — set by `withRollup()` (#376 slice 2). Marks this strategy as
+   * an aggregate-onto-parent rollup: a write OR delete of a `from` (child)
+   * record recomputes `compute(children where child[key] === parentId)` and
+   * patches it onto `source[field]` of the parent at `parentId` (= child[key]).
+   * `source` is the parent (`into`) collection; the synthetic self-write
+   * output carries `denorm: [field]`. Dispatch handles rollup specially (it
+   * does not run the executor). Eager-only in this slice.
+   */
+  rollup?: {
+    readonly from: string
+    readonly key: string
+    readonly field: string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    readonly compute: (children: any[]) => unknown
+  }
   /** v1: only deterministic derivations supported. */
   deterministic: true
   /**

--- a/packages/hub/src/derivations/with-derivation.ts
+++ b/packages/hub/src/derivations/with-derivation.ts
@@ -42,9 +42,44 @@ export function withDerivation<
     }
   }
 
+  // Validate FK triggers (#376). Each `collection` must be a non-empty
+  // string differing from the primary source, and `on` a non-empty field.
+  if (spec.triggerBy !== undefined) {
+    for (const t of spec.triggerBy) {
+      if (typeof t?.collection !== 'string' || t.collection.length === 0) {
+        throw new ValidationError('withDerivation: each triggerBy entry needs a non-empty `collection`')
+      }
+      if (t.collection === spec.source) {
+        throw new ValidationError(
+          `withDerivation: triggerBy.collection must not equal the source "${spec.source}" (use sources[] for same-id triggers)`,
+        )
+      }
+      if (typeof t.on !== 'string' || t.on.length === 0) {
+        throw new ValidationError(
+          `withDerivation: triggerBy on "${t.collection}" needs a non-empty \`on\` (the FK field on the source)`,
+        )
+      }
+      if (t.maxFanout !== undefined && (!Number.isInteger(t.maxFanout) || t.maxFanout < 1)) {
+        throw new ValidationError(
+          `withDerivation: triggerBy maxFanout on "${t.collection}" must be a positive integer (got ${String(t.maxFanout)}).`,
+        )
+      }
+    }
+  }
+
   // Validate array-shape outputs.
   const lifecycleMode = typeof spec.lifecycle === 'string' ? spec.lifecycle : spec.lifecycle.mode
   for (const [outputKey, outputSpec] of Object.entries(spec.outputs)) {
+    // Self-write output (collection === source): reverse-denorm must declare
+    // `denorm` (the fields it owns) — field-level provenance, #376.
+    if (outputSpec.shape === 'record' && outputSpec.collection === spec.source) {
+      if (!outputSpec.denorm || outputSpec.denorm.length === 0) {
+        throw new ValidationError(
+          `withDerivation: self-write output "${outputKey}" (collection === source "${spec.source}") `
+          + 'must declare `denorm: [...]` naming the fields it maintains.',
+        )
+      }
+    }
     if (outputSpec.shape === 'array') {
       if (lifecycleMode !== 'eager') {
         throw new ValidationError(

--- a/packages/hub/src/derivations/with-rollup.ts
+++ b/packages/hub/src/derivations/with-rollup.ts
@@ -1,0 +1,73 @@
+import { ValidationError } from '../errors.js'
+import type { DerivationStrategy, DerivationStrategyHandle } from './types.js'
+
+/**
+ * `withRollup` — aggregate many child records onto a single field of their
+ * parent (#376 slice 2). The reverse of a join: instead of reading children
+ * on demand, the parent carries a maintained summary.
+ *
+ * ```ts
+ * withRollup<Sale, Buyer>({
+ *   from: 'sales',          // child collection (the trigger)
+ *   key: 'buyerId',         // FK on the child → parent id
+ *   into: 'buyers',         // parent collection
+ *   field: 'revenueByYear', // field on the parent to maintain
+ *   compute: (sales) => groupSumByYear(sales, 'total'),
+ * })
+ * ```
+ *
+ * On every write OR delete of a `from` record, the parent at id `child[key]`
+ * is recomputed: `compute(allChildren where child[key] === parentId)` is
+ * patched onto `parent[field]`. A parent write also recomputes its own
+ * aggregate (so a parent created after its children still fills in). Only the
+ * `field` is touched — the rest of the parent record is never clobbered — and
+ * a value-equality guard suppresses no-op writes. The aggregate is gap-free
+ * with respect to child inserts, updates, and deletes.
+ *
+ * Desugars to a `withDerivation` strategy carrying a `rollup` marker; dispatch
+ * handles it without invoking the executor. Eager-only in this slice.
+ */
+export function withRollup<
+  TChild extends Record<string, unknown> = Record<string, unknown>,
+  TParent extends Record<string, unknown> = Record<string, unknown>,
+>(config: {
+  from: string
+  key: keyof TChild & string
+  into: string
+  field: keyof TParent & string
+  compute: (children: TChild[]) => unknown
+}): DerivationStrategyHandle {
+  const { from, key, into, field, compute } = config
+  if (!from || from.length === 0) {
+    throw new ValidationError('withRollup: `from` (child collection) is required')
+  }
+  if (!into || into.length === 0) {
+    throw new ValidationError('withRollup: `into` (parent collection) is required')
+  }
+  if (from === into) {
+    throw new ValidationError('withRollup: `from` and `into` must be different collections')
+  }
+  if (!key || key.length === 0) {
+    throw new ValidationError('withRollup: `key` (FK field on the child) is required')
+  }
+  if (!field || field.length === 0) {
+    throw new ValidationError('withRollup: `field` (target field on the parent) is required')
+  }
+  if (typeof compute !== 'function') {
+    throw new ValidationError('withRollup: `compute` must be a function')
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const spec: DerivationStrategy<any, any> = {
+    source: into, // the parent record is what carries the rolled-up field
+    deterministic: true,
+    rollup: { from, key, field, compute: compute as (children: unknown[]) => unknown },
+    // Synthetic self-write output for registry / cycle bookkeeping. Dispatch
+    // patches `field` directly (value-equality guarded); the executor is not run.
+    outputs: { value: { shape: 'record', collection: into, denorm: [field] } },
+    derive: () => ({ value: {} }), // never invoked for a rollup strategy
+    lifecycle: 'eager',
+  }
+
+  return { __noydb_strategy: 'derivation', spec }
+}

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -661,6 +661,7 @@ export type {
 
 // Derivations (Dim 14) — see docs/superpowers/specs/2026-05-01-dim14-derivation-v1-design.md
 export { withDerivation } from './derivations/index.js'
+export { withRollup } from './derivations/index.js'
 export type {
   DerivationStrategy,
   DerivationStrategyHandle,

--- a/showcases/src/104-reverse-denorm.showcase.test.ts
+++ b/showcases/src/104-reverse-denorm.showcase.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Showcase 104 — reverse-denormalization (FK derivation triggers)
+ *
+ * What you'll learn
+ * ─────────────────
+ * `triggerBy: [{ collection, on }]` keeps a denormalized field on many
+ * child records in sync with a parent change — keyed by a foreign key, not
+ * a shared id. A buyer rename fans out to every sale that references it.
+ *
+ *   - A self-write output (collection === source) declaring `denorm`
+ *     patches ONLY the named fields back onto the source record.
+ *   - Other fields on the sale are never clobbered.
+ *   - The value-equality guard terminates the self-write cleanly.
+ *
+ * Why it matters
+ * ──────────────
+ * "The buyer's name changed but old sales still show the old name" is a
+ * classic stale-denormalization bug. Declaring the dependency once moves
+ * the maintenance into the data layer — the snapshot can't drift.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 00 + 80 (withDerivation).
+ *
+ * What to read next
+ * ─────────────────
+ *   - showcase 80-with-derivation (the base primitive)
+ *   - docs/subsystems/derivations.md
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → derivations
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withDerivation } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+
+interface Buyer extends Record<string, unknown> { id: string; companyName: string }
+interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number; buyerName?: string; note?: string }
+
+describe('Showcase 104 — reverse-denormalization', () => {
+  it('a buyer rename refreshes buyerName on all their sales', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'reverse-denorm-showcase-2026',
+      derivationStrategies: [
+        withDerivation<Sale, { self: Sale }>({
+          source: 'sales',
+          deterministic: true,
+          // A write to buyers fans out to every sale whose buyerId matches.
+          triggerBy: [{ collection: 'buyers', on: 'buyerId' }],
+          // Self-write: patch ONLY buyerName back onto the sale (field-level).
+          outputs: { self: { shape: 'record', collection: 'sales', denorm: ['buyerName'] } },
+          derive: async (sale, ctx) => {
+            const b = await ctx.vault.collection<Buyer>('buyers').get(sale.buyerId)
+            return { self: { ...sale, buyerName: b?.companyName ?? null } as Sale }
+          },
+          lifecycle: 'eager',
+        }),
+      ],
+    })
+    const vault = await db.openVault('firm')
+    const buyers = vault.collection<Buyer>('buyers')
+    // Index the FK so the fan-out is O(matching sales), not a scan.
+    const sales = vault.collection<Sale>('sales', { indexes: ['buyerId'] })
+
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100, note: 'first order' })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 250 })
+    // buyerName is stamped on insert too (source-path derivation).
+    expect((await sales.get('s1'))?.buyerName).toBe('Acme')
+
+    // Rename the buyer → every referencing sale refreshes.
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme Corporation' })
+    expect((await sales.get('s1'))?.buyerName).toBe('Acme Corporation')
+    expect((await sales.get('s2'))?.buyerName).toBe('Acme Corporation')
+
+    // Non-denorm fields are preserved through the patch.
+    expect((await sales.get('s1'))?.note).toBe('first order')
+    expect((await sales.get('s1'))?.total).toBe(100)
+
+    db.close()
+  })
+})

--- a/showcases/src/105-rollup.showcase.test.ts
+++ b/showcases/src/105-rollup.showcase.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Showcase 105 — rollups (aggregate onto a parent field)
+ *
+ * What you'll learn
+ * ─────────────────
+ * `withRollup({ from, key, into, field, compute })` keeps a maintained
+ * summary on a parent record, folded from its children by foreign key. It
+ * recomputes on child insert, update, AND delete — gap-free — so the
+ * parent's total never drifts from the children that produced it.
+ *
+ *   - sales → buyer.revenueByYear, aggregated by buyerId.
+ *   - Deleting a sale recomputes the buyer (no overcount).
+ *   - Only the rollup field is touched on the parent.
+ *
+ * Why it matters
+ * ──────────────
+ * "Stats computed two different ways that disagree" is a recurring class.
+ * One declared rollup is the single source of truth — the parent carries
+ * the answer, maintained by the data layer, queryable without a scan.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 00 + 80 (withDerivation) + 104 (reverse-denorm).
+ *
+ * What to read next
+ * ─────────────────
+ *   - docs/subsystems/derivations.md
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → derivations
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withRollup } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+
+interface Buyer extends Record<string, unknown> { id: string; companyName: string; revenueByYear?: Record<string, number> }
+interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number; year: number }
+
+describe('Showcase 105 — rollups', () => {
+  it('maintains buyer.revenueByYear across child insert / update / delete', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'rollup-showcase-2026',
+      derivationStrategies: [
+        withRollup<Sale, Buyer>({
+          from: 'sales',
+          key: 'buyerId',
+          into: 'buyers',
+          field: 'revenueByYear',
+          compute: (sales) => {
+            const byYear: Record<string, number> = {}
+            for (const s of sales) byYear[String(s.year)] = (byYear[String(s.year)] ?? 0) + s.total
+            return byYear
+          },
+        }),
+      ],
+    })
+    const vault = await db.openVault('firm')
+    const buyers = vault.collection<Buyer>('buyers')
+    const sales = vault.collection<Sale>('sales', { indexes: ['buyerId'] })
+
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100, year: 2026 })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 250, year: 2026 })
+    await sales.put('s3', { id: 's3', buyerId: 'b1', total: 70, year: 2027 })
+    expect((await buyers.get('b1'))?.revenueByYear).toEqual({ '2026': 350, '2027': 70 })
+
+    // Delete a sale → the buyer recomputes, no overcount.
+    await sales.delete('s2')
+    expect((await buyers.get('b1'))?.revenueByYear).toEqual({ '2026': 100, '2027': 70 })
+
+    // The parent's own fields are untouched by the rollup patch.
+    expect((await buyers.get('b1'))?.companyName).toBe('Acme')
+
+    db.close()
+  })
+})


### PR DESCRIPTION
Completes #376 — **Slice 2 (`withRollup`)**. **Stacked on #384 (Slice 1)** — base is the slice-1 branch, so this PR's diff shows only the rollup additions. Rebase onto main after #384 merges.

## What & why

The aggregate-onto-parent half of #376: a maintained summary field on the parent, folded from its children by FK, recomputed **gap-free** on child insert / update / **delete**. Kills the "stats computed two divergent ways" bug class.

```ts
withRollup<Sale, Buyer>({
  from: 'sales',          // child collection (the trigger)
  key: 'buyerId',         // FK on the child → parent id
  into: 'buyers',         // parent collection
  field: 'revenueByYear', // field on the parent to maintain
  compute: (sales) => groupSumByYear(sales, 'total'),
})
```

## How

- **`withRollup`** desugars to a derivation carrying a `rollup` marker (`source = into`; a synthetic self-write output with `denorm:[field]`). A **child write** recomputes the parent at id `child[key]`; a **parent write** recomputes its own aggregate (so a parent created *after* its children still fills in). Only `field` is patched onto the parent's raw record — other fields and i18n maps are untouched; a value-equality guard suppresses no-op writes.
- **Rollup-on-delete.** `_doDelete` now fires `dispatchRollupsOnDelete(existing)` on user deletes (alongside the existing MV + array-derivation delete hooks), so deleting a child recomputes its parent. This gap-free-on-delete property is exactly what the MV path can't give (MVs aggregate into a *parallel* collection, not onto the parent record).
- Registry indexes the rollup under `rollup.from` (child trigger) + `source` (`into`, parent trigger). The `from→into` edge enters the cycle DFS; the `into→into` self-write edge is exempt (Slice 1 mechanism).
- Reuses Slice 1 internals: `_getStoredRecord` (raw patch base), `_findMatchingIds` (index-accelerated child gather), `selfWriteFieldEqual`. **Eager-only** in this slice.

## Why not a materialized view?

An MV aggregates children into a parallel collection (`buyer-totals.get(id)`); it cannot write the aggregate onto a field of the parent `buyers` record, nor stay correct on child delete without re-materializing the whole group. `withRollup` patches the parent in place and recomputes per-affected-parent.

## Tests

- New `packages/hub/__tests__/derivations/rollup.test.ts` (9): insert/update/delete maintenance, parent-created-after-children, FK-index path, parent isolation, field-preservation, object (group-by) aggregate, factory validation.
- Showcase 105 (buyer.revenueByYear across insert/update/delete). `docs/subsystems/derivations.md` + `features.yaml` updated.
- Full hub suite green (264 files / 2551 tests); lint clean.

## Scope note

`vault.forget()` does not auto-recompute rollups (it bypasses the put/delete path) — documented; recompute explicitly if a forgotten record must drop out of an aggregate. With Slice 1 + Slice 2, the #376 build is complete.