### PR TITLE
feat(in-pinia): dynamic vault resolver for defineNoydbStore (#383)

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -1726,6 +1726,8 @@ frameworks:
         path: showcases/src/38-in-pinia.showcase.test.ts
       - id: 95-in-pinia-i18n
         path: showcases/src/95-in-pinia-i18n.showcase.test.ts
+      - id: 106-in-pinia-dynamic-vault
+        path: showcases/src/106-in-pinia-dynamic-vault.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -1736,6 +1738,7 @@ frameworks:
       - 'useNoydbI18n is the reactive active-locale; setLocale is state-only by default (vault.setLocale opt-in via syncVault); bindTo follows an external ref state-only and never touches a vault'
       - 'defineNoydbStore i18n option defaults to raw (today behavior; non-breaking); follow re-reads c.list({locale}) on locale change; {locale} pins'
       - 'useI18nField is a reactive pickLang (resolveI18nText policy:null → string|null); useDictLabel defaults its locale/fallback to useNoydbI18n and follows a global flip'
+      - 'dynamic vault resolver (#383): vault may be a () => string evaluated at access time for federation routing; getCollection() self-heals when the resolved name changes (add/remove/refresh re-bind); a reactive resolver auto re-hydrates items on change (watch → refresh); a static string is unchanged/back-compat; an in-flight liveQuery() stays bound to its creation-time vault'
     related: [in-vue]
 
   - id: in-devtools

--- a/packages/in-pinia/__tests__/defineNoydbStore.test.ts
+++ b/packages/in-pinia/__tests__/defineNoydbStore.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { setActivePinia, createPinia, storeToRefs } from 'pinia'
-import { effectScope } from 'vue'
+import { effectScope, ref } from 'vue'
 import { createNoydb, additiveOnly, i18nText, type Noydb, type NoydbStore, type EncryptedEnvelope, type VaultSnapshot, type StandardSchemaV1, ConflictError, Query } from '@noy-db/hub'
 import { withI18n } from '@noy-db/hub/i18n'
 import { defineNoydbStore, setActiveNoydb, useNoydbI18n } from '../src/index.js'
@@ -580,5 +580,79 @@ describe('defineNoydbStore — i18nFields / dictKeyFields forwarding', () => {
     await store.$ready
     await store.add('p1', { id: 'p1', name: { th: 'สมชาย', en: 'Somchai' } })
     expect(store.items.find((x) => x.id === 'p1')?.name).toBe('สมชาย')
+  })
+})
+
+describe('defineNoydbStore — dynamic vault resolver (#383)', () => {
+  let db: Noydb
+  beforeEach(async () => {
+    setActivePinia(createPinia())
+    db = await makeNoydb()
+    setActiveNoydb(db)
+  })
+  afterEach(() => { setActiveNoydb(null) })
+
+  it('resolves the vault from a function and re-hydrates when its reactive dep changes', async () => {
+    // Seed two per-client shard vaults directly.
+    const c1 = await db.openVault('clients-C1')
+    await c1.collection<Invoice>('invoices').put('a', { id: 'a', amount: 1, status: 'open', client: 'C1' })
+    const c2 = await db.openVault('clients-C2')
+    await c2.collection<Invoice>('invoices').put('b', { id: 'b', amount: 2, status: 'open', client: 'C2' })
+
+    const code = ref('C1') // active client scope (e.g. from the URL)
+    const useInvoices = defineNoydbStore<Invoice>('invoices', { vault: () => `clients-${code.value}` })
+    const store = useInvoices()
+    await store.$ready
+    expect(store.items.map((i) => i.id)).toEqual(['a'])
+
+    // Drill into the other client → the store follows into its shard.
+    code.value = 'C2'
+    for (let n = 0; n < 50 && store.items[0]?.id !== 'b'; n++) await tick(10)
+    expect(store.items.map((i) => i.id)).toEqual(['b'])
+
+    // …and back.
+    code.value = 'C1'
+    for (let n = 0; n < 50 && store.items[0]?.id !== 'a'; n++) await tick(10)
+    expect(store.items.map((i) => i.id)).toEqual(['a'])
+  })
+
+  it('writes land in the currently-resolved vault', async () => {
+    const code = ref('C1')
+    const useInvoices = defineNoydbStore<Invoice>('invoices', { vault: () => `w-${code.value}` })
+    const store = useInvoices()
+    await store.$ready
+    await store.add('x', { id: 'x', amount: 5, status: 'open', client: 'C1' })
+
+    code.value = 'C2'
+    await tick(20) // let the re-bind watch settle
+    await store.add('y', { id: 'y', amount: 9, status: 'open', client: 'C2' })
+
+    const w1 = await db.openVault('w-C1')
+    const w2 = await db.openVault('w-C2')
+    expect((await w1.collection<Invoice>('invoices').list()).map((i) => i.id)).toEqual(['x'])
+    expect((await w2.collection<Invoice>('invoices').list()).map((i) => i.id)).toEqual(['y'])
+  })
+
+  it('a non-reactive resolver self-heals on the next refresh()/add()', async () => {
+    let current = 'C1'
+    const useInvoices = defineNoydbStore<Invoice>('invoices', { vault: () => `nr-${current}` })
+    const store = useInvoices()
+    await store.$ready
+    await store.add('a', { id: 'a', amount: 1, status: 'open', client: 'C1' })
+    expect(store.items.map((i) => i.id)).toEqual(['a'])
+
+    current = 'C2' // non-reactive change — no auto-watch fires
+    await store.refresh() // explicit re-bind
+    expect(store.items.map((i) => i.id)).toEqual([]) // nr-C2 is empty
+    await store.add('b', { id: 'b', amount: 2, status: 'open', client: 'C2' })
+    expect(store.items.map((i) => i.id)).toEqual(['b'])
+  })
+
+  it('a static string vault still works (back-compat)', async () => {
+    const useInvoices = defineNoydbStore<Invoice>('invoices', { vault: 'static-v' })
+    const store = useInvoices()
+    await store.$ready
+    await store.add('a', { id: 'a', amount: 1, status: 'open', client: 'X' })
+    expect(store.items.map((i) => i.id)).toEqual(['a'])
   })
 })

--- a/packages/in-pinia/src/defineNoydbStore.ts
+++ b/packages/in-pinia/src/defineNoydbStore.ts
@@ -74,8 +74,22 @@ export interface NoydbLiveQuery<R> {
  * for full type safety.
  */
 export interface NoydbStoreOptions<T> {
-  /** Vault (tenant) name. */
-  vault: string
+  /**
+   * Vault (tenant) name, or a **resolver** evaluated at access time for
+   * federation routing (#383). A plain `string` binds the store to one
+   * vault for its lifetime (unchanged behavior). A `() => string` resolver
+   * is re-evaluated on every read/write and whenever its reactive
+   * dependencies change — so a store can follow the app's active scope into
+   * a per-client shard vault (e.g. `() => firm.shardVaultId(clientCode.value)`).
+   *
+   * When the resolved name changes, the store re-opens the new vault and
+   * re-hydrates `items` (mirrors the `i18n: 'follow'` re-read). If the
+   * resolver reads Vue reactive state, the re-hydrate is automatic; if it
+   * reads non-reactive state, the next `refresh()`/`add()`/`remove()`
+   * re-binds. Note: an in-flight `liveQuery()` handle stays bound to the
+   * vault it was created against — recreate it after a vault change.
+   */
+  vault: string | (() => string)
   /** Collection name within the vault. Defaults to the store id. */
   collection?: string
   /**
@@ -210,14 +224,27 @@ export function defineNoydbStore<T>(
       }
     }
 
-    // Lazy collection handle — created on first hydrate.
+    // Resolve the target vault name. A `() => string` resolver (#383) is
+    // evaluated on every access so the store can follow the app's active
+    // scope into a per-client shard vault; a plain string is constant.
+    const resolveVaultName = (): string =>
+      typeof options.vault === 'function' ? options.vault() : options.vault
+
+    // Lazy collection handle — created on first hydrate, and re-created when
+    // the resolved vault name changes (federation re-bind).
     let cachedCompartment: Vault | null = null
     let cachedCollection: Collection<T> | null = null
+    let boundVaultName: string | null = null
 
     async function getCollection(): Promise<Collection<T>> {
-      if (cachedCollection) return cachedCollection
+      const vaultName = resolveVaultName()
+      // Self-heal on vault change: a cached handle is only reused while it
+      // belongs to the currently-resolved vault. When the resolver returns a
+      // new name, fall through and re-open — so add()/remove()/refresh() all
+      // bind to the right shard without any extra wiring.
+      if (cachedCollection && boundVaultName === vaultName) return cachedCollection
       const noydb = resolveNoydb(options.noydb ?? null)
-      cachedCompartment = await noydb.openVault(options.vault)
+      cachedCompartment = await noydb.openVault(vaultName)
       // Pass the schema down to the Collection so validation runs at
       // the encrypt/decrypt boundary instead of only at the store
       // layer. This catches drifted stored data on read (which the
@@ -230,6 +257,7 @@ export function defineNoydbStore<T>(
       if (options.i18nFields !== undefined) collOpts.i18nFields = options.i18nFields
       if (options.dictKeyFields !== undefined) collOpts.dictKeyFields = options.dictKeyFields
       cachedCollection = cachedCompartment.collection<T>(collectionName, collOpts)
+      boundVaultName = vaultName
       return cachedCollection
     }
 
@@ -343,6 +371,18 @@ export function defineNoydbStore<T>(
       )
     } else if (typeof i18nMode === 'object' && isRef(i18nMode.locale)) {
       watch(i18nMode.locale, () => { void refresh() })
+    }
+
+    // Federation re-bind (#383): when the vault resolver depends on reactive
+    // state, re-hydrate as its resolved name changes. `getCollection()` already
+    // self-heals to the new vault; this just drives the auto-refresh so `items`
+    // follows the active scope. Only wired for a resolver (a static string
+    // never changes). The value-equality guard means a reactive dependency
+    // change that yields the same vault name does not re-hydrate.
+    if (typeof options.vault === 'function') {
+      watch(resolveVaultName, (next, prev) => {
+        if (next !== prev) void refresh()
+      })
     }
 
     return {

--- a/showcases/src/106-in-pinia-dynamic-vault.showcase.test.ts
+++ b/showcases/src/106-in-pinia-dynamic-vault.showcase.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Showcase 106 — in-pinia dynamic vault resolver (federation routing)
+ *
+ * What you'll learn
+ * ─────────────────
+ * `defineNoydbStore({ vault })` accepts a **resolver** — `() => string` —
+ * evaluated at access time, so one logical store can follow the app's
+ * active scope into a per-client shard vault. Drill into `/clients/C2`
+ * and the same `useDisbursements` store re-binds to that client's vault
+ * and re-hydrates, with no per-shard store instances.
+ *
+ *   1. `vault: () => 'clients-' + code.value` — reactive resolver.
+ *   2. Flipping the scope ref re-opens the new vault and refreshes items.
+ *   3. Writes land in whichever vault is currently resolved.
+ *   4. A plain `vault: 'x'` string keeps working unchanged.
+ *
+ * Why it matters
+ * ──────────────
+ * Per-client vault federation shards data into one vault per client. A
+ * fixed `vault: string` can't follow the focused client; the resolver lets
+ * every existing store opt into federation routing with a one-line change.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 38 (in-pinia).
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → frameworks → in-pinia
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { ref } from 'vue'
+import { createNoydb } from '@noy-db/hub'
+import { defineNoydbStore, setActiveNoydb } from '@noy-db/in-pinia'
+import { memory } from '@noy-db/to-memory'
+
+const tick = (ms = 0): Promise<void> => new Promise((r) => setTimeout(r, ms))
+
+interface Disbursement { id: string; amount: number; client: string }
+
+describe('Showcase 106 — in-pinia dynamic vault resolver', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it('follows the active client scope into its shard vault', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'sc106' })
+    setActiveNoydb(db)
+
+    // Seed two per-client shard vaults.
+    const c1 = await db.openVault('clients-C1')
+    await c1.collection<Disbursement>('disbursements').put('d1', { id: 'd1', amount: 100, client: 'C1' })
+    const c2 = await db.openVault('clients-C2')
+    await c2.collection<Disbursement>('disbursements').put('d2', { id: 'd2', amount: 200, client: 'C2' })
+
+    // The active client (e.g. from the route) drives the resolver.
+    const clientCode = ref('C1')
+    const useDisbursements = defineNoydbStore<Disbursement>('disbursements', {
+      vault: () => `clients-${clientCode.value}`,
+    })
+
+    const store = useDisbursements()
+    await store.$ready
+    expect(store.items.map((d) => d.id)).toEqual(['d1'])
+
+    // Navigate to client C2 → the store re-binds to clients-C2 and re-hydrates.
+    clientCode.value = 'C2'
+    for (let n = 0; n < 50 && store.items[0]?.id !== 'd2'; n++) await tick(10)
+    expect(store.items.map((d) => d.id)).toEqual(['d2'])
+
+    // A new disbursement is written into the currently-focused client's vault.
+    await store.add('d3', { id: 'd3', amount: 50, client: 'C2' })
+    const stillC2 = await db.openVault('clients-C2')
+    expect((await stillC2.collection<Disbursement>('disbursements').list()).map((d) => d.id).sort())
+      .toEqual(['d2', 'd3'])
+    // C1's vault is untouched.
+    const stillC1 = await db.openVault('clients-C1')
+    expect((await stillC1.collection<Disbursement>('disbursements').list()).map((d) => d.id)).toEqual(['d1'])
+
+    db.close()
+  })
+})


### PR DESCRIPTION
Closes #383.

## What & why

`defineNoydbStore` bound each store to a **fixed `vault: string`**, resolved once. That blocks per-client **vault federation** — where one logical collection (e.g. `disbursements`) lives in many per-client shard vaults and the *active* vault depends on app scope (the focused client). This lets `vault` be a **resolver** evaluated at access time, so one store follows the active scope into its shard.

```ts
const useDisbursements = defineNoydbStore<Disbursement>('disbursements', {
  vault: () => firm.shardVaultId(clientCode.value),   // re-resolved at access time
})
```

## How

- **`NoydbStoreOptions.vault: string | (() => string)`** — backwards compatible; a plain string is unchanged.
- **`getCollection()` self-heals** — it tracks the bound vault name and re-opens when the resolver returns a new one, so `add()` / `remove()` / `refresh()` all bind to the right shard with no extra wiring.
- **Reactive auto re-hydrate** — a `watch` on the resolved name calls `refresh()` when it changes (mirrors the existing `i18n: 'follow'` re-read), with a value-equality guard so a dependency change that yields the *same* vault name is a no-op. Only wired for a function resolver (a static string never changes).
- **Non-reactive resolver** self-heals on the next `refresh()`/`add()`/`remove()`.

## Caveat (documented on the option)

An in-flight `liveQuery()` handle stays bound to the vault it was created against — recreate it after a vault change. (`items` / `count` / `refresh` / `add` / `remove` / `query` all follow the resolver.)

## Tests

- 4 new in `defineNoydbStore.test.ts`: reactive re-hydrate both directions, writes land in the currently-resolved vault, non-reactive self-heal via explicit `refresh()`, static-string back-compat. (34 in-pinia tests pass.)
- Showcase 106 (drill into client C2 → store re-binds to `clients-C2`, writes land there, C1 untouched). `features.yaml` in-pinia invariant added.

Pairs with `VaultGroup.shardVaultId(code)` (hub federation). Filed from niwat #30.

> Note from the issue: a separate low-priority finding (a vault written by a strategy-less instance then read by a full-strategy instance returns unreliable cross-instance `.query().where(...)`) is **not** addressed here — worth its own issue if it recurs.