### PR TITLE
feat(hub): Insight Vault — push-model cross-vault derivation (#271 Layer 4)

### DIFF
--- a/docs/subsystems/vault-group.md
+++ b/docs/subsystems/vault-group.md
@@ -89,9 +89,50 @@ grantees; access control is at the shard level.
 - The `minVersion` guard pre-filters shards by their registry-recorded
   `schemaVersion`; behind-version shards land in `skippedVaults`, never mixed
   into `results`.
-- **Out of scope (this MVP):** cross-shard joins, push-model cross-vault
-  derivations (Insight Vault), reactive `queryAcrossLive`, `aggregateAcross`,
-  and the fleet schema-migration runner. See the spec's deferred-items list.
+- **Out of scope (still):** the fleet schema-migration runner (lazy/active/
+  staged orchestration). cross-shard joins, reactive `queryAcrossLive`,
+  `aggregateAcross`, and the Insight Vault (below) have since shipped.
+
+## Insight Vault — cross-vault derivation (push model, #271 Layer 4)
+
+A fleet dashboard shouldn't decrypt N client vaults on every read. The
+**Insight Vault** is a separate analytics vault holding one small summary row
+per shard, derived from each shard and pushed in.
+
+```ts
+firm.withCrossVaultDerivation<Invoice, ClientSummary>({
+  source: 'invoices',                                       // read from each shard
+  target: { vault: 'firm-insights', collection: 'client-summary' },
+  derive: (records, ctx) => ({                              // runs per shard
+    clientId: ctx.partitionKey,
+    totalRevenue: records.reduce((s, r) => s + r.amount, 0),
+    overdueCount: records.filter((r) => r.status === 'overdue').length,
+    schemaVersion: ctx.schemaVersion,
+  }),
+})
+
+const { written, skippedVaults } = await firm.refreshInsights({ minVersion: 3 })
+// analyst then reads firm-insights directly — no per-client decryption
+```
+
+- **Push model.** `refreshInsights()` reads each eligible shard's `source`
+  records in-process (under the group's `Noydb`, which holds both keyrings),
+  runs `derive(records, ctx)` per shard, and writes the returned row into the
+  Insight Vault keyed by partition key — **re-encrypted under the Insight
+  Vault's own DEK**. A shard's ciphertext never crosses a DEK boundary.
+- **`ctx`** = `{ vaultId, partitionKey, schemaVersion }` (from the registry row).
+- Respects the `minVersion` drift guard; a shard whose read fails lands in
+  `skippedVaults` and its summary is **not** overwritten with a stale value.
+- **v1 is explicit-refresh** — call `refreshInsights()` after a batch of writes
+  or on a schedule. Auto-push-on-write is a deferred follow-up.
+
+> **⚠️ Zero-knowledge profile (weaker — read before adopting).** The Insight
+> Vault backend sees *aggregated structure* (totals, counts, timestamps) drawn
+> from many shards. That is a **weaker** guarantee than the per-shard vaults,
+> each of which is its own DEK boundary. The Insight Vault is **opt-in** and
+> should hold **aggregate scalars only** — no raw records, no embeddings.
+> Treat its backend as a `tier: 'derived'` store with a formally weaker ZK
+> profile, and grant it explicitly.
 
 ## Control plane — StateManagement Vault
 

--- a/features.yaml
+++ b/features.yaml
@@ -1234,6 +1234,8 @@ features:
         path: showcases/src/99-vault-group-live-aggregate.showcase.test.ts
       - id: 100-state-management-vault
         path: showcases/src/100-state-management-vault.showcase.test.ts
+      - id: 108-insight-vault
+        path: showcases/src/108-insight-vault.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -1242,7 +1244,8 @@ features:
       - 'createShard is idempotent; row-without-vault raises ShardProvisioningError'
       - 'minVersion guard pre-filters shards by registry schemaVersion (no silent shape-mixing)'
       - 'crossShardJoin is co-partitioned fan-out + central broadcast enrichment; join.ts and its partitionScope seam stay untouched'
-    related: [permissions, transferable-partition]
+      - 'Insight Vault (#271 Layer 4, push model): withCrossVaultDerivation({ source, target, derive }) + refreshInsights() reads each eligible shard, runs derive(records, ctx{vaultId,partitionKey,schemaVersion}) per shard, writes one summary row per shard into the target analytics vault keyed by partitionKey — re-encrypted under the Insight Vault DEK, shard ciphertext never crosses a DEK boundary; respects the minVersion drift guard; failed shard reads → skippedVaults (no stale row); v1 is explicit-refresh (no write-path push). ZK note: Insight Vault backend sees aggregated cross-shard structure — weaker profile than per-shard vaults; opt-in, aggregate scalars only'
+    related: [permissions, transferable-partition, derivations]
 
 # ─── Storage adapters (phase 2) ──────────────────────────────────────
 

--- a/packages/hub/__tests__/federation-insight-vault.test.ts
+++ b/packages/hub/__tests__/federation-insight-vault.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Insight Vault — push-model cross-vault derivation (#271 Layer 4).
+ * withCrossVaultDerivation() + refreshInsights().
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+import { createNoydb } from '../src/noydb.js'
+import type { Noydb } from '../src/noydb.js'
+import type { Vault } from '../src/vault.js'
+import type { VaultRegistryRow } from '../src/federation/index.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+interface Invoice extends Record<string, unknown> { id: string; clientId: string; amount: number; status: string }
+interface Summary extends Record<string, unknown> { clientId: string; totalRevenue: number; overdueCount: number; schemaVersion: number }
+
+async function harness(templateVersion = 1) {
+  const adapter = memory()
+  const db = await createNoydb({ store: adapter, user: 'operator', secret: 'op-pass' })
+  db.withVaultTemplate('client-template', {
+    version: templateVersion,
+    configure(vault: Vault) { vault.collection<Invoice>('invoices') },
+  })
+  const stateVault = await db.openVault('state')
+  const registry = stateVault.collection<VaultRegistryRow>('vault-registry')
+  const firm = await db.openVaultGroup<Invoice>('firm-clients', {
+    registry,
+    sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template', autoCreate: true },
+  })
+  return { adapter, db, registry, firm }
+}
+
+describe('Insight Vault — withCrossVaultDerivation / refreshInsights (#271)', () => {
+  let h: Awaited<ReturnType<typeof harness>>
+  beforeEach(async () => { h = await harness() })
+
+  function registerSummary() {
+    h.firm.withCrossVaultDerivation<Invoice, Summary>({
+      source: 'invoices',
+      target: { vault: 'firm-insights', collection: 'client-summary' },
+      derive: (records, ctx) => ({
+        clientId: ctx.partitionKey,
+        totalRevenue: records.reduce((s, r) => s + r.amount, 0),
+        overdueCount: records.filter((r) => r.status === 'overdue').length,
+        schemaVersion: ctx.schemaVersion,
+      }),
+    })
+  }
+
+  it('writes one summary row per shard into the Insight Vault', async () => {
+    const inv = h.firm.collection<Invoice>('invoices')
+    await inv.put('a1', { id: 'a1', clientId: 'acme', amount: 100, status: 'paid' })
+    await inv.put('a2', { id: 'a2', clientId: 'acme', amount: 250, status: 'overdue' })
+    await inv.put('b1', { id: 'b1', clientId: 'globex', amount: 70, status: 'overdue' })
+
+    registerSummary()
+    const res = await h.firm.refreshInsights()
+    expect(res.written).toBe(2)
+    expect(res.skippedVaults).toEqual([])
+
+    const insights = await h.db.openVault('firm-insights')
+    const summaries = insights.collection<Summary>('client-summary')
+    expect(await summaries.get('acme')).toMatchObject({ clientId: 'acme', totalRevenue: 350, overdueCount: 1, schemaVersion: 1 })
+    expect(await summaries.get('globex')).toMatchObject({ clientId: 'globex', totalRevenue: 70, overdueCount: 1 })
+  })
+
+  it('is idempotent and reflects new writes on re-refresh', async () => {
+    const inv = h.firm.collection<Invoice>('invoices')
+    await inv.put('a1', { id: 'a1', clientId: 'acme', amount: 100, status: 'paid' })
+    registerSummary()
+    await h.firm.refreshInsights()
+
+    const summaries = (await h.db.openVault('firm-insights')).collection<Summary>('client-summary')
+    expect((await summaries.get('acme'))?.totalRevenue).toBe(100)
+
+    await inv.put('a2', { id: 'a2', clientId: 'acme', amount: 400, status: 'paid' })
+    await h.firm.refreshInsights()
+    expect((await summaries.get('acme'))?.totalRevenue).toBe(500)
+    // still exactly one row for acme
+    expect(await summaries.query().toArray()).toHaveLength(1)
+  })
+
+  it('no registered derivation → refreshInsights is a no-op', async () => {
+    const res = await h.firm.refreshInsights()
+    expect(res).toEqual({ written: 0, skippedVaults: [] })
+  })
+
+  it('skips shards behind minVersion (schema drift) and does not write their summary', async () => {
+    // acme created at v1
+    await h.firm.collection<Invoice>('invoices').put('a1', { id: 'a1', clientId: 'acme', amount: 100, status: 'paid' })
+    registerSummary()
+    const res = await h.firm.refreshInsights({ minVersion: 2 }) // acme is v1 < 2
+    expect(res.written).toBe(0)
+    expect(res.skippedVaults).toEqual([{ vaultId: 'firm-clients--acme', reason: 'schema-drift' }])
+    const summaries = (await h.db.openVault('firm-insights')).collection<Summary>('client-summary')
+    expect(await summaries.get('acme')).toBeNull()
+  })
+
+  it('the shard ciphertext stays in its own vault — the Insight Vault holds only the summary', async () => {
+    const inv = h.firm.collection<Invoice>('invoices')
+    await inv.put('a1', { id: 'a1', clientId: 'acme', amount: 100, status: 'paid' })
+    registerSummary()
+    await h.firm.refreshInsights()
+    // The Insight Vault has the summary collection, NOT the source 'invoices' collection.
+    const insights = await h.db.openVault('firm-insights')
+    expect(await insights.collection<Summary>('client-summary').query().toArray()).toHaveLength(1)
+    expect(await insights.collection<Invoice>('invoices').query().toArray()).toEqual([])
+  })
+
+  it('supports multiple registered derivations', async () => {
+    const inv = h.firm.collection<Invoice>('invoices')
+    await inv.put('a1', { id: 'a1', clientId: 'acme', amount: 100, status: 'overdue' })
+    registerSummary()
+    h.firm.withCrossVaultDerivation<Invoice, { clientId: string; count: number }>({
+      source: 'invoices',
+      target: { vault: 'firm-insights', collection: 'client-count' },
+      derive: (records, ctx) => ({ clientId: ctx.partitionKey, count: records.length }),
+    })
+    const res = await h.firm.refreshInsights()
+    expect(res.written).toBe(2) // 1 shard × 2 derivations
+    const insights = await h.db.openVault('firm-insights')
+    expect((await insights.collection<Summary>('client-summary').get('acme'))?.overdueCount).toBe(1)
+    expect((await insights.collection<{ clientId: string; count: number }>('client-count').get('acme'))?.count).toBe(1)
+  })
+})

--- a/packages/hub/src/federation/index.ts
+++ b/packages/hub/src/federation/index.ts
@@ -22,4 +22,7 @@ export type {
   SchemaManifestRow,
   DeploymentEvent,
   CapturedBlueprint,
+  CrossVaultDerivationSpec,
+  CrossVaultDerivationContext,
+  RefreshInsightsResult,
 } from './types.js'

--- a/packages/hub/src/federation/types.ts
+++ b/packages/hub/src/federation/types.ts
@@ -105,6 +105,48 @@ export interface CrossVaultLiveAggregation<R> extends LiveAggregation<R> {
   readonly ready: Promise<void>
 }
 
+/**
+ * Context passed to a cross-vault `derive` callback (#271 Insight Vault).
+ * One call per shard; identifies which shard the records came from.
+ */
+export interface CrossVaultDerivationContext {
+  /** The shard's vault id (e.g. `firm-clients--acme`). */
+  readonly vaultId: string
+  /** The shard's partition key (e.g. `acme`). */
+  readonly partitionKey: string
+  /** The shard's schema/template version, from its registry row. */
+  readonly schemaVersion: number
+}
+
+/**
+ * A push-model cross-vault derivation (#271, Insight Vault — Layer 4).
+ *
+ * For each eligible shard, `refreshInsights()` reads the shard's `source`
+ * collection, runs `derive` on that shard's records, and writes the returned
+ * summary row into a separate analytics ("Insight") vault — keyed by partition
+ * key, one row per shard. The summary is re-encrypted under the Insight Vault's
+ * own DEK; the shard's ciphertext never leaves its DEK boundary (the push model
+ * that resolves the cross-vault DEK conflict). See the ZK note in the spec —
+ * the Insight Vault backend sees aggregated structure across shards, a weaker
+ * profile than per-shard vaults; opt-in.
+ */
+export interface CrossVaultDerivationSpec<R = Record<string, unknown>, S = Record<string, unknown>> {
+  /** Collection read from each shard. */
+  readonly source: string
+  /** Destination Insight Vault + collection for the per-shard summary rows. */
+  readonly target: { readonly vault: string; readonly collection: string }
+  /** Per-shard reducer: that shard's source records + context → one summary row. */
+  readonly derive: (records: R[], ctx: CrossVaultDerivationContext) => S
+}
+
+/** The result of `refreshInsights()`. */
+export interface RefreshInsightsResult {
+  /** Number of summary rows written (one per eligible shard × registered derivation). */
+  readonly written: number
+  /** Shards excluded (schema-drift, unprovisioned, or read error). */
+  readonly skippedVaults: SkippedVault[]
+}
+
 /** A serializable blueprint captured from a VaultTemplate.configure run. */
 export interface CapturedBlueprint {
   /** Sorted collection names declared by the template. */

--- a/packages/hub/src/federation/vault-group.ts
+++ b/packages/hub/src/federation/vault-group.ts
@@ -27,6 +27,9 @@ import type {
   WhereClause,
   LiveQueryOptions,
   CrossVaultLiveQuery,
+  CrossVaultDerivationSpec,
+  CrossVaultDerivationContext,
+  RefreshInsightsResult,
 } from './types.js'
 
 /** Reserved separator between group name and partition key in a shard vault id. */
@@ -197,6 +200,80 @@ export class VaultGroup<T> {
       else skipped.push({ vaultId: row.vaultId, reason: 'error', error: new ShardProvisioningError(row.vaultId, row.partitionKey) })
     })
     return { eligible, skipped }
+  }
+
+  /** @internal — registered push-model cross-vault derivations (#271 Insight Vault). */
+  private readonly crossVaultDerivations: CrossVaultDerivationSpec[] = []
+
+  /**
+   * Register a push-model cross-vault derivation — the Insight Vault pattern
+   * (#271, Layer 4). Drive it with {@link refreshInsights}.
+   *
+   * For each shard, `derive(records, ctx)` runs on that shard's `source`
+   * records and its return value is written into the analytics
+   * (`target.vault` / `target.collection`) vault, keyed by partition key —
+   * one summary row per shard. The derivation runs in-process under THIS
+   * group's `Noydb` (which already holds both the shard and Insight Vault
+   * keyrings); the shard's decrypted records are reduced to a summary that is
+   * re-encrypted under the Insight Vault's own DEK, so no shard ciphertext
+   * crosses a DEK boundary.
+   *
+   * **Zero-knowledge note:** the Insight Vault backend sees aggregated
+   * structure (totals, counts, timestamps) drawn from many shards — a weaker
+   * ZK profile than the per-shard vaults. Opt-in; keep summaries to aggregate
+   * scalars (no embeddings / no raw records).
+   *
+   * v1 is explicit-refresh (no write-path push); call `refreshInsights()`
+   * after a batch of writes, or on a schedule.
+   */
+  withCrossVaultDerivation<R = Record<string, unknown>, S = Record<string, unknown>>(
+    spec: CrossVaultDerivationSpec<R, S>,
+  ): void {
+    this.crossVaultDerivations.push(spec as unknown as CrossVaultDerivationSpec)
+  }
+
+  /**
+   * Run every registered {@link withCrossVaultDerivation}: read each eligible
+   * shard's source records, derive a per-shard summary, and write it into the
+   * Insight Vault keyed by partition key. Shards behind `minVersion`,
+   * unprovisioned, or whose read errors are reported in `skippedVaults` and
+   * are not written (a stale summary is never left behind for a failed shard).
+   */
+  async refreshInsights(options: { minVersion?: number; concurrency?: number } = {}): Promise<RefreshInsightsResult> {
+    if (this.crossVaultDerivations.length === 0) return { written: 0, skippedVaults: [] }
+    const { eligible, skipped } = await this.resolveEligible(
+      options.minVersion !== undefined ? { minVersion: options.minVersion } : {},
+    )
+    let written = 0
+    for (const spec of this.crossVaultDerivations) {
+      const results = await this.db.queryAcross<Record<string, unknown>[]>(
+        eligible.map((r) => r.vaultId),
+        async (vault) => {
+          this.template.configure(vault)
+          return vault.collection<Record<string, unknown>>(spec.source).list()
+        },
+        { create: false, ...(options.concurrency !== undefined ? { concurrency: options.concurrency } : {}) },
+      )
+      const insight = await this.db.openVault(spec.target.vault)
+      const out = insight.collection<Record<string, unknown>>(spec.target.collection)
+      for (let i = 0; i < eligible.length; i++) {
+        const row = eligible[i]!
+        const res = results[i]
+        if (!res || res.result === undefined) {
+          skipped.push({ vaultId: row.vaultId, reason: 'error', ...(res?.error ? { error: res.error } : {}) })
+          continue
+        }
+        const ctx: CrossVaultDerivationContext = {
+          vaultId: row.vaultId,
+          partitionKey: row.partitionKey,
+          schemaVersion: row.schemaVersion,
+        }
+        const summary = spec.derive(res.result, ctx)
+        await out.put(row.partitionKey, summary)
+        written++
+      }
+    }
+    return { written, skippedVaults: skipped }
   }
 }
 

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -321,6 +321,11 @@ export type {
   GroupedRow as CrossVaultGroupedRow,
 } from './federation/index.js'
 export type { SchemaManifestRow, DeploymentEvent, CapturedBlueprint } from './federation/index.js'
+export type {
+  CrossVaultDerivationSpec,
+  CrossVaultDerivationContext,
+  RefreshInsightsResult,
+} from './federation/index.js'
 export { STATE_VAULT_NAME } from './federation/constants.js'
 export { UnknownShardError, ShardProvisioningError, VaultTemplateNotFoundError, ReservedVaultNameError } from './errors.js'
 export { ForgetStrategyNotConfiguredError } from './errors.js'

--- a/showcases/src/108-insight-vault.showcase.test.ts
+++ b/showcases/src/108-insight-vault.showcase.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Showcase 108 — Insight Vault (cross-vault derivation, push model)
+ *
+ * What you'll learn
+ * ─────────────────
+ * A firm shards each client into its own vault (own DEK boundary). The firm
+ * also wants a fast, fleet-wide dashboard — overdue counts, revenue per
+ * client — WITHOUT opening and decrypting every client vault on each read.
+ * `firm.withCrossVaultDerivation()` registers a push-model aggregation:
+ * `refreshInsights()` reads each shard, derives a per-shard summary, and
+ * writes it into a separate analytics "Insight Vault" keyed by client.
+ *
+ *   1. `withCrossVaultDerivation({ source, target, derive })` — declare.
+ *   2. `refreshInsights()` — drive it (explicit-refresh in v1).
+ *   3. Read the Insight Vault directly — one tiny row per client, fast.
+ *   4. Shard ciphertext never leaves its vault; only the summary is written.
+ *
+ * Why it matters
+ * ──────────────
+ * Per-client isolation is a cryptographic guarantee, but a fleet dashboard
+ * shouldn't require N per-client decryptions on every page load. The push
+ * model keeps each shard's DEK boundary intact while giving analysts a
+ * single small vault to query.
+ *
+ * Zero-knowledge note
+ * ───────────────────
+ * The Insight Vault backend sees AGGREGATED structure across clients (totals,
+ * counts) — a weaker ZK profile than the per-client vaults. Opt-in; keep
+ * summaries to aggregate scalars.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 98 (VaultGroup federation).
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → vault-group-federation
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import type { VaultRegistryRow, Vault } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+
+interface Invoice { clientId: string; amount: number; status: 'open' | 'overdue' | 'paid' }
+interface ClientSummary { clientId: string; totalRevenue: number; overdueCount: number; schemaVersion: number }
+
+describe('Showcase 108 — Insight Vault', () => {
+  it('derives one fast summary row per client into a separate analytics vault', async () => {
+    const db = await createNoydb({ store: memory(), user: 'firm-operator', secret: 'firm-secret-2026' })
+    db.withVaultTemplate('client-template', {
+      version: 1,
+      configure(vault: Vault) { vault.collection<Invoice>('invoices') },
+    })
+    const state = await db.openVault('state')
+    const firm = await db.openVaultGroup<Invoice>('firm-clients', {
+      registry: state.collection<VaultRegistryRow>('vault-registry'),
+      sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template', autoCreate: true },
+    })
+
+    // Each invoice routes to its client's own shard vault.
+    const invoices = firm.collection('invoices')
+    await invoices.put('acme-1', { clientId: 'acme', amount: 1200, status: 'overdue' })
+    await invoices.put('acme-2', { clientId: 'acme', amount: 300, status: 'paid' })
+    await invoices.put('globex-1', { clientId: 'globex', amount: 900, status: 'overdue' })
+
+    // Declare the cross-vault derivation (Insight Vault), then drive it.
+    firm.withCrossVaultDerivation<Invoice, ClientSummary>({
+      source: 'invoices',
+      target: { vault: 'firm-insights', collection: 'client-summary' },
+      derive: (records, ctx) => ({
+        clientId: ctx.partitionKey,
+        totalRevenue: records.reduce((s, r) => s + r.amount, 0),
+        overdueCount: records.filter((r) => r.status === 'overdue').length,
+        schemaVersion: ctx.schemaVersion,
+      }),
+    })
+    const { written, skippedVaults } = await firm.refreshInsights()
+    expect(written).toBe(2)
+    expect(skippedVaults).toEqual([])
+
+    // The analyst reads ONE small vault — no per-client decryption.
+    const insights = await db.openVault('firm-insights')
+    const summary = insights.collection<ClientSummary>('client-summary')
+    expect(await summary.get('acme')).toMatchObject({ totalRevenue: 1500, overdueCount: 1 })
+    expect(await summary.get('globex')).toMatchObject({ totalRevenue: 900, overdueCount: 1 })
+
+    // The summary is the ONLY thing in the Insight Vault — no raw invoices crossed over.
+    expect(await insights.collection<Invoice>('invoices').query().toArray()).toEqual([])
+
+    // Re-refresh after a new write keeps exactly one row per client, updated.
+    await invoices.put('acme-3', { clientId: 'acme', amount: 500, status: 'overdue' })
+    await firm.refreshInsights()
+    expect(await summary.get('acme')).toMatchObject({ totalRevenue: 2000, overdueCount: 2 })
+    expect(await summary.query().toArray()).toHaveLength(2)
+
+    db.close()
+  })
+})


### PR DESCRIPTION
Advances vLannaAi/klum-db#12 (the multi-vault partition federation epic) — builds **Layer 4, the Insight Vault**, the last unbuilt layer. (`crossShardJoin` + StateManagement Vault already shipped; the issue's checklist was stale — I verified against the code.)

## What & why

A fleet dashboard shouldn't decrypt N client vaults on every read. The Insight Vault is a separate analytics vault holding **one small summary row per shard**, derived from each shard and pushed in.

```ts
firm.withCrossVaultDerivation<Invoice, ClientSummary>({
  source: 'invoices',
  target: { vault: 'firm-insights', collection: 'client-summary' },
  derive: (records, ctx) => ({
    clientId: ctx.partitionKey,
    totalRevenue: records.reduce((s, r) => s + r.amount, 0),
    overdueCount: records.filter((r) => r.status === 'overdue').length,
    schemaVersion: ctx.schemaVersion,
  }),
})
const { written, skippedVaults } = await firm.refreshInsights({ minVersion: 3 })
// analyst reads firm-insights directly — no per-client decryption
```

## How (resolves the locked design conflict)

The issue's blocking conflict was cross-vault derivation vs. the single-vault DEK invariant. **Push model**, exactly as the issue locks it: `refreshInsights()` reads each eligible shard's `source` in-process (under the group's `Noydb`, which holds both keyrings), runs `derive(records, ctx)` per shard, and writes the returned row into the Insight Vault **re-encrypted under the Insight Vault's own DEK**. A shard's ciphertext never crosses a DEK boundary. Built on the existing `resolveEligible()` + `queryAcross()` primitives.

- `ctx` = `{ vaultId, partitionKey, schemaVersion }` (from the registry row).
- Respects the `minVersion` drift guard; a failed shard read → `skippedVaults` (no stale summary left behind).
- Multiple registered derivations supported.

## Decisions (v1 — documented)

- **Executor identity:** runs under the caller's `Noydb` (holds both keyrings). The least-privilege service-account model is a hardening follow-up.
- **Consistency:** explicit-refresh (`refreshInsights()`) — the issue lists this as a valid option; avoids invasive write-path hooks + eventual-consistency edge cases. Auto-push-on-write deferred.
- **Shape:** per-shard summary, one row per shard keyed by partition key.

## ⚠️ Zero-knowledge profile (weaker — documented prominently)

The Insight Vault backend sees **aggregated structure** (totals, counts) across shards — weaker than the per-shard DEK boundaries. Opt-in; **aggregate scalars only** (no raw records, no embeddings). Spelled out in `docs/subsystems/vault-group.md` and the spec.

## Tests

- `packages/hub/__tests__/federation-insight-vault.test.ts` (6): per-shard summary, idempotent re-refresh reflecting new writes, no-op when unregistered, `minVersion` drift skip (no row written), ciphertext-isolation (Insight Vault holds only summaries), multiple derivations.
- Showcase 108. `docs/subsystems/vault-group.md` (new Insight Vault + ZK section; removed it from the out-of-scope list) + `features.yaml`. Full hub suite green (263 files / 2540 tests).

## Remaining on vLannaAi/klum-db#12 (not this PR)

The **fleet schema-migration runner** (lazy/active/staged orchestration + writing `migration-status`) and the design docs (cross-vault DEK grant model, data-residency routing) are still open. This PR closes the Insight Vault item.