### PR TITLE
feat(hub): fleet schema-migration runner for VaultGroup (#271)

### DIFF
--- a/docs/subsystems/vault-group.md
+++ b/docs/subsystems/vault-group.md
@@ -89,9 +89,10 @@ grantees; access control is at the shard level.
 - The `minVersion` guard pre-filters shards by their registry-recorded
   `schemaVersion`; behind-version shards land in `skippedVaults`, never mixed
   into `results`.
-- **Out of scope (still):** the fleet schema-migration runner (lazy/active/
-  staged orchestration). cross-shard joins, reactive `queryAcrossLive`,
-  `aggregateAcross`, and the Insight Vault (below) have since shipped.
+- **Out of scope (still):** cross-shard joins, push-model cross-vault
+  derivations (Insight Vault), reactive `queryAcrossLive`, `aggregateAcross`
+  have since shipped; remaining open items are the design questions (DEK-grant
+  executor identity, data-residency routing). See the spec's deferred list.
 
 ## Insight Vault — cross-vault derivation (push model, #271 Layer 4)
 
@@ -133,6 +134,46 @@ const { written, skippedVaults } = await firm.refreshInsights({ minVersion: 3 })
 > should hold **aggregate scalars only** — no raw records, no embeddings.
 > Treat its backend as a `tier: 'derived'` store with a formally weaker ZK
 > profile, and grant it explicitly.
+
+## Fleet schema migration (#271)
+
+When the template's `version` bumps (new schema + a `coordinatedCutover`
+transform), each shard must run its per-vault M12 cutover. The fleet runner
+orchestrates that across the group and records per-shard status in the
+StateManagement Vault — **each shard still uses M12's single-vault protocol
+internally** (`vault.runSchemaCutover()`); this adds the fleet-level ordering,
+status, and resumability.
+
+```ts
+// Active batch runner — migrate every behind shard to the template version.
+const { target, migrated, failed } = await firm.migrateFleet({ batchSize: 8 })
+
+// Staged / canary — migrate a cohort first, verify, then the rest.
+await firm.migrateFleet({ cohort: ['acme'] })
+await firm.migrateFleet()
+
+// Lazy — migrate a shard on first access (opt-in at openVaultGroup).
+const firm = await db.openVaultGroup('firm', { sharding, migrateOnOpen: true })
+
+// One shard.
+await firm.migrateShard('acme')
+```
+
+- **Per-shard step (`migrateShard`)**: open the shard (applies the template →
+  arms the cutover) → `_drainPendingSchemaWrites()` → `runSchemaCutover()` →
+  advance the registry row's `schemaVersion` → write `migration-status`. A shard
+  already at the target is a no-op. A failed cutover is caught, recorded as
+  `status: 'failed'`, and does **not** abort the fleet run.
+- **Resumable / crash-safe**: the registry `schemaVersion` is the source of
+  truth; a re-run skips shards already at the target and retries failed ones.
+- **`migration-status`** rows (`{ vaultId, currentVersion, targetVersion,
+  status, migrated?, error? }`) + `migration-started/completed/failed`
+  deployment events live in the StateManagement Vault.
+- **Mixed-version reads stay safe**: the `minVersion` fan-out guard skips
+  behind-version shards (`skippedVaults`) rather than mixing record shapes —
+  so reads work throughout the rollout window.
+- **Co-location assumption**: the runner drives co-located shards in-process.
+  Per-process/distributed shards are a `by-server` concern, out of scope.
 
 ## Control plane — StateManagement Vault
 

--- a/features.yaml
+++ b/features.yaml
@@ -1259,6 +1259,8 @@ features:
         path: showcases/src/100-state-management-vault.showcase.test.ts
       - id: 108-insight-vault
         path: showcases/src/108-insight-vault.showcase.test.ts
+      - id: 109-fleet-migration
+        path: showcases/src/109-fleet-migration.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -1268,7 +1270,8 @@ features:
       - 'minVersion guard pre-filters shards by registry schemaVersion (no silent shape-mixing)'
       - 'crossShardJoin is co-partitioned fan-out + central broadcast enrichment; join.ts and its partitionScope seam stay untouched'
       - 'Insight Vault (#271 Layer 4, push model): withCrossVaultDerivation({ source, target, derive }) + refreshInsights() reads each eligible shard, runs derive(records, ctx{vaultId,partitionKey,schemaVersion}) per shard, writes one summary row per shard into the target analytics vault keyed by partitionKey — re-encrypted under the Insight Vault DEK, shard ciphertext never crosses a DEK boundary; respects the minVersion drift guard; failed shard reads → skippedVaults (no stale row); v1 is explicit-refresh (no write-path push). ZK note: Insight Vault backend sees aggregated cross-shard structure — weaker profile than per-shard vaults; opt-in, aggregate scalars only'
-    related: [permissions, transferable-partition, derivations]
+      - 'fleet schema migration (#271): migrateFleet({cohort?,batchSize?}) + migrateShard(key) drive each shard through M12 vault.runSchemaCutover() (single-vault protocol internally), then advance the registry schemaVersion and write migration-status to the StateManagement Vault; cohort = staged/canary, batchSize = back-pressure; migrateOnOpen lazily migrates a behind shard on access; resumable/crash-safe (registry version is source of truth — re-run skips current, retries failed); a failed shard cutover is recorded, not fatal'
+    related: [permissions, transferable-partition, derivations, schema-and-refs]
 
 # ─── Storage adapters (phase 2) ──────────────────────────────────────
 

--- a/packages/hub/__tests__/federation-fleet-migration.test.ts
+++ b/packages/hub/__tests__/federation-fleet-migration.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Fleet schema-migration runner (#271): VaultGroup.migrateShard / migrateFleet
+ * + migrate-on-open, with per-shard migration-status in the StateManagement Vault.
+ */
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+import { createNoydb } from '../src/noydb.js'
+import type { Noydb } from '../src/noydb.js'
+import type { Vault } from '../src/vault.js'
+import { StateManagementVault } from '../src/federation/state-vault.js'
+import { coordinatedCutover } from '../src/schema-update/index.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+interface Invoice extends Record<string, unknown> { id: string; clientId: string; amount: number }
+
+// A managed group at `version` with a trivial template (no schema change) —
+// exercises the runner's ORCHESTRATION (version bump, status, cohort, resume).
+async function firmAt(db: Noydb, version: number, migrateOnOpen = false) {
+  db.withVaultTemplate('client-template', {
+    version,
+    configure: (v: Vault) => { v.collection<Invoice>('invoices') },
+  })
+  return db.openVaultGroup<Invoice>('firm-clients', {
+    sharding: { keyOf: (r) => r.clientId, vaultTemplate: 'client-template', autoCreate: true },
+    migrateOnOpen,
+  })
+}
+
+async function statusOf(db: Noydb, partitionKey: string) {
+  const sv = await StateManagementVault.open(db)
+  return sv.getMigrationStatus(`firm-clients--${partitionKey}`)
+}
+
+describe('fleet migration — orchestration (#271)', () => {
+  it('migrateFleet advances behind shards to the template version + records status', async () => {
+    const db = await createNoydb({ store: memory(), user: 'op', secret: 'p' })
+    const firm1 = await firmAt(db, 1)
+    await firm1.collection('invoices').put('a1', { id: 'a1', clientId: 'acme', amount: 1 })
+    await firm1.collection('invoices').put('b1', { id: 'b1', clientId: 'globex', amount: 2 })
+
+    const firm2 = await firmAt(db, 2)
+    const res = await firm2.migrateFleet()
+    expect(res.target).toBe(2)
+    expect(res.migrated.sort()).toEqual(['firm-clients--acme', 'firm-clients--globex'])
+    expect(res.failed).toEqual([])
+
+    // registry versions advanced
+    const rows = await firm2.allRows()
+    expect(rows.every((r) => r.schemaVersion === 2)).toBe(true)
+    // migration-status recorded
+    expect(await statusOf(db, 'acme')).toMatchObject({ status: 'done', targetVersion: 2 })
+  })
+
+  it('is resumable — a re-run migrates nothing once shards are current', async () => {
+    const db = await createNoydb({ store: memory(), user: 'op', secret: 'p' })
+    const firm1 = await firmAt(db, 1)
+    await firm1.collection('invoices').put('a1', { id: 'a1', clientId: 'acme', amount: 1 })
+    const firm2 = await firmAt(db, 2)
+    expect((await firm2.migrateFleet()).migrated).toEqual(['firm-clients--acme'])
+    expect((await firm2.migrateFleet()).migrated).toEqual([]) // nothing left
+  })
+
+  it('cohort restricts the run (staged / canary rollout)', async () => {
+    const db = await createNoydb({ store: memory(), user: 'op', secret: 'p' })
+    const firm1 = await firmAt(db, 1)
+    await firm1.collection('invoices').put('a1', { id: 'a1', clientId: 'acme', amount: 1 })
+    await firm1.collection('invoices').put('b1', { id: 'b1', clientId: 'globex', amount: 2 })
+    const firm2 = await firmAt(db, 2)
+
+    const canary = await firm2.migrateFleet({ cohort: ['acme'] })
+    expect(canary.migrated).toEqual(['firm-clients--acme'])
+    const rows = await firm2.allRows()
+    expect(rows.find((r) => r.partitionKey === 'acme')?.schemaVersion).toBe(2)
+    expect(rows.find((r) => r.partitionKey === 'globex')?.schemaVersion).toBe(1) // not in cohort
+
+    // then the rest
+    expect((await firm2.migrateFleet()).migrated).toEqual(['firm-clients--globex'])
+  })
+
+  it('migrateShard migrates a single shard; a current shard is a no-op', async () => {
+    const db = await createNoydb({ store: memory(), user: 'op', secret: 'p' })
+    const firm1 = await firmAt(db, 1)
+    await firm1.collection('invoices').put('a1', { id: 'a1', clientId: 'acme', amount: 1 })
+    const firm2 = await firmAt(db, 2)
+    const r1 = await firm2.migrateShard('acme')
+    expect(r1).toMatchObject({ status: 'done', targetVersion: 2 })
+    const r2 = await firm2.migrateShard('acme') // already current
+    expect(r2).toMatchObject({ status: 'done', migrated: 0 })
+  })
+
+  it('migrateOnOpen lazily migrates a behind shard on access', async () => {
+    const db = await createNoydb({ store: memory(), user: 'op', secret: 'p' })
+    const firm1 = await firmAt(db, 1)
+    await firm1.collection('invoices').put('a1', { id: 'a1', clientId: 'acme', amount: 1 })
+
+    const firm2 = await firmAt(db, 2, /* migrateOnOpen */ true)
+    expect((await firm2.allRows()).find((r) => r.partitionKey === 'acme')?.schemaVersion).toBe(1)
+    await firm2.shard('acme') // drilling in triggers the lazy migration
+    expect((await firm2.allRows()).find((r) => r.partitionKey === 'acme')?.schemaVersion).toBe(2)
+  })
+
+  it('the minVersion fan-out guard reflects migration state', async () => {
+    const db = await createNoydb({ store: memory(), user: 'op', secret: 'p' })
+    const firm1 = await firmAt(db, 1)
+    await firm1.collection('invoices').put('a1', { id: 'a1', clientId: 'acme', amount: 9 })
+    const firm2 = await firmAt(db, 2)
+    // before migration: minVersion:2 skips the v1 shard
+    const before = await firm2.collection('invoices').query().toArray({ minVersion: 2 })
+    expect(before.results).toEqual([])
+    expect(before.skippedVaults).toEqual([{ vaultId: 'firm-clients--acme', reason: 'schema-drift' }])
+    // after migration: included
+    await firm2.migrateFleet()
+    const after = await firm2.collection('invoices').query().toArray({ minVersion: 2 })
+    expect(after.results.map((r) => r.id)).toEqual(['a1'])
+    expect(after.skippedVaults).toEqual([])
+  })
+})
+
+describe('fleet migration — real coordinatedCutover across shards (#271)', () => {
+  const oldSchema = z.object({ id: z.string(), clientId: z.string(), total: z.number() })
+  const newSchema = z.object({ id: z.string(), clientId: z.string(), amount: z.object({ gross: z.number() }) })
+  const transform = (d: Record<string, unknown>) => ({ id: d['id'], clientId: d['clientId'], amount: { gross: d['total'] } })
+
+  it('migrateFleet runs each shard cutover and transforms records in place', async () => {
+    const store = memory()
+    const sharding = { keyOf: (r: { clientId: string }) => r.clientId, vaultTemplate: 'ct', autoCreate: true }
+
+    // Session 1 (v1): seed old-shape data + persist the schema baseline per shard.
+    const db1 = await createNoydb({ store, user: 'op', secret: 'p' })
+    db1.withVaultTemplate('ct', { version: 1, configure: (v: Vault) => { v.collection('invoices', { schema: oldSchema, persistJsonSchema: true }) } })
+    const firm1 = await db1.openVaultGroup('firm-clients', { sharding })
+    await firm1.collection('invoices').put('a1', { id: 'a1', clientId: 'acme', total: 100 })
+    await firm1.collection('invoices').put('b1', { id: 'b1', clientId: 'globex', total: 250 })
+    await (await firm1.shard('acme'))._drainPendingSchemaWrites()
+    await (await firm1.shard('globex'))._drainPendingSchemaWrites()
+
+    // Session 2 (v2 — fresh Noydb over the same store, like an operator restart):
+    // shards are re-opened fresh so the new schema is detected vs the v1 baseline.
+    const db2 = await createNoydb({ store, user: 'op', secret: 'p' })
+    db2.withVaultTemplate('ct', {
+      version: 2,
+      configure: (v: Vault) => { v.collection('invoices', { schema: newSchema, persistJsonSchema: true, schemaUpdate: [coordinatedCutover({ transform })] }) },
+    })
+    const firm2 = await db2.openVaultGroup('firm-clients', { sharding })
+
+    const res = await firm2.migrateFleet()
+    expect(res.migrated.sort()).toEqual(['firm-clients--acme', 'firm-clients--globex'])
+    expect(res.failed).toEqual([])
+
+    // records transformed in place on each shard
+    const acme = await firm2.shard('acme')
+    expect((await acme.collection<{ id: string; amount: { gross: number } }>('invoices').get('a1'))?.amount.gross).toBe(100)
+    const globex = await firm2.shard('globex')
+    expect((await globex.collection<{ id: string; amount: { gross: number } }>('invoices').get('b1'))?.amount.gross).toBe(250)
+
+    // status reflects a real migration (migrated >= 1)
+    const sv = await StateManagementVault.open(db2)
+    const st = await sv.getMigrationStatus('firm-clients--acme')
+    expect(st?.status).toBe('done')
+    expect(st?.migrated).toBe(1)
+  })
+})

--- a/packages/hub/src/federation/index.ts
+++ b/packages/hub/src/federation/index.ts
@@ -25,4 +25,6 @@ export type {
   CrossVaultDerivationSpec,
   CrossVaultDerivationContext,
   RefreshInsightsResult,
+  MigrationStatusRow,
+  FleetMigrationResult,
 } from './types.js'

--- a/packages/hub/src/federation/state-vault.ts
+++ b/packages/hub/src/federation/state-vault.ts
@@ -7,7 +7,7 @@
 import type { Noydb } from '../noydb.js'
 import type { Collection } from '../collection.js'
 import type { Query } from '../query/builder.js'
-import type { VaultRegistryRow, SchemaManifestRow, DeploymentEvent, VaultTemplate } from './types.js'
+import type { VaultRegistryRow, SchemaManifestRow, DeploymentEvent, MigrationStatusRow, VaultTemplate } from './types.js'
 import { captureBlueprint, fingerprintBlueprint } from './schema-manifest.js'
 import { STATE_VAULT_NAME } from './constants.js'
 import { generateULID } from '../bundle/ulid.js'
@@ -20,6 +20,7 @@ export { STATE_VAULT_NAME } from './constants.js'
 const REGISTRY = 'vaultRegistry'
 const MANIFEST = 'schemaManifest'
 const EVENTS = 'deploymentEvents'
+const MIGRATION_STATUS = 'migrationStatus'
 
 export class StateManagementVault {
   /**
@@ -29,23 +30,44 @@ export class StateManagementVault {
    * `schemaManifest` are deliberately public: consumers read and write them.)
    */
   readonly #events: Collection<DeploymentEvent>
+  /** Per-shard fleet-migration progress (#271). Surfaced via typed methods only. */
+  readonly #migrationStatus: Collection<MigrationStatusRow>
 
   private constructor(
     readonly registry: Collection<VaultRegistryRow>,
     readonly schemaManifest: Collection<SchemaManifestRow>,
     events: Collection<DeploymentEvent>,
+    migrationStatus: Collection<MigrationStatusRow>,
   ) {
     this.#events = events
+    this.#migrationStatus = migrationStatus
   }
 
-  /** Idempotently open the reserved state vault and bind the three control-plane collections. */
+  /** Idempotently open the reserved state vault and bind the control-plane collections. */
   static async open(db: Noydb): Promise<StateManagementVault> {
     const vault = await db.openVault(STATE_VAULT_NAME)
     return new StateManagementVault(
       vault.collection<VaultRegistryRow>(REGISTRY),
       vault.collection<SchemaManifestRow>(MANIFEST),
       vault.collection<DeploymentEvent>(EVENTS),
+      vault.collection<MigrationStatusRow>(MIGRATION_STATUS),
     )
+  }
+
+  /** Read one shard's migration status (or null). */
+  async getMigrationStatus(vaultId: string): Promise<MigrationStatusRow | null> {
+    return this.#migrationStatus.get(vaultId)
+  }
+
+  /** All migration-status rows (hydrates first). */
+  async listMigrationStatus(): Promise<MigrationStatusRow[]> {
+    await this.#migrationStatus.list()
+    return this.#migrationStatus.query().toArray()
+  }
+
+  /** Upsert one shard's migration status (keyed by vaultId). */
+  async upsertMigrationStatus(row: MigrationStatusRow): Promise<void> {
+    await this.#migrationStatus.put(row.vaultId, row)
   }
 
   /** Read-only query over the append-only deployment-events log. */

--- a/packages/hub/src/federation/types.ts
+++ b/packages/hub/src/federation/types.ts
@@ -53,6 +53,23 @@ export interface VaultGroupOptions<T> {
    */
   readonly registry?: Collection<VaultRegistryRow>
   readonly sharding: ShardingConfig<T>
+  /**
+   * Lazy migrate-on-open (#271 fleet migration). When `true`, opening a shard
+   * whose registry `schemaVersion` is behind the template's version runs that
+   * shard's cutover inline (via `migrateShard`) before surfacing the handle.
+   * Zero cost for shards never opened. Default `false` (use `migrateFleet`).
+   */
+  readonly migrateOnOpen?: boolean
+}
+
+/** Result of `VaultGroup.migrateFleet` (#271 active batch runner). */
+export interface FleetMigrationResult {
+  /** The version migrated toward (the template's current version). */
+  readonly target: number
+  /** vaultIds successfully migrated (or already current). */
+  readonly migrated: string[]
+  /** vaultIds whose cutover failed, with the error message. */
+  readonly failed: { readonly vaultId: string; readonly error: string }[]
 }
 
 /** Options for a cross-shard fan-out read. */
@@ -173,10 +190,39 @@ export interface SchemaManifestRow {
 export interface DeploymentEvent {
   readonly id: string
   readonly ts: number
-  readonly type: 'shard-created' | 'manifest-recorded' | 'group-opened'
+  readonly type:
+    | 'shard-created'
+    | 'manifest-recorded'
+    | 'group-opened'
+    | 'migration-started'
+    | 'migration-completed'
+    | 'migration-failed'
   readonly group: string
   readonly vaultId?: string
   readonly templateName?: string
   readonly version?: number
   readonly actor?: string
+  /** Free-form detail (e.g. migration error message). */
+  readonly detail?: string
+}
+
+/**
+ * One row in the StateManagement `migration-status` collection (#271 fleet
+ * schema-migration runner), keyed by `vaultId`. Tracks each shard's progress
+ * toward the template's current version so the active batch runner is
+ * resumable and the staged rollout can verify a cohort before proceeding.
+ */
+export interface MigrationStatusRow {
+  readonly vaultId: string
+  readonly group: string
+  /** The shard's registry schemaVersion at the time of this status. */
+  readonly currentVersion: number
+  /** The version the runner is moving this shard to (the template's version). */
+  readonly targetVersion: number
+  readonly status: 'pending' | 'running' | 'done' | 'failed'
+  readonly startedAt?: number
+  readonly finishedAt?: number
+  /** Records migrated by the per-shard cutover (when status `done`). */
+  readonly migrated?: number
+  readonly error?: string
 }

--- a/packages/hub/src/federation/vault-group.ts
+++ b/packages/hub/src/federation/vault-group.ts
@@ -7,7 +7,7 @@
 import type { Noydb } from '../noydb.js'
 import type { Vault } from '../vault.js'
 import type { Collection } from '../collection.js'
-import type { StateManagementVault } from './state-vault.js'
+import { StateManagementVault } from './state-vault.js'
 import { CrossShardJoinError, ReservedVaultNameError, ShardProvisioningError, UnknownShardError, ValidationError } from '../errors.js'
 import { STATE_VAULT_NAME } from './constants.js'
 import { classifyShardSkip } from './classify-skip.js'
@@ -30,6 +30,8 @@ import type {
   CrossVaultDerivationSpec,
   CrossVaultDerivationContext,
   RefreshInsightsResult,
+  MigrationStatusRow,
+  FleetMigrationResult,
 } from './types.js'
 
 /** Reserved separator between group name and partition key in a shard vault id. */
@@ -65,6 +67,7 @@ export class VaultGroup<T> {
     /** @internal */ readonly registry: Collection<VaultRegistryRow>,
     /** @internal */ readonly sharding: ShardingConfig<T>,
     /** @internal */ readonly template: VaultTemplate,
+    /** @internal — lazy migrate-on-open (#271). */ readonly migrateOnOpen: boolean = false,
   ) {
     if (name.includes(SHARD_SEPARATOR)) {
       throw new ValidationError(
@@ -111,8 +114,23 @@ export class VaultGroup<T> {
     return rows.filter((r) => r.group === this.name)
   }
 
-  /** Open an existing shard and apply the template. */
+  /**
+   * Open an existing shard and apply the template. When `migrateOnOpen` is set
+   * (#271) and the shard's registry version is behind the template, its cutover
+   * runs inline first — so a behind shard never surfaces a stale handle.
+   */
   async openShard(partitionKey: string): Promise<Vault> {
+    if (this.migrateOnOpen) {
+      const row = await this.registry.get(this.registryId(partitionKey))
+      if (row && row.schemaVersion < this.template.version) {
+        await this.migrateShard(partitionKey)
+      }
+    }
+    return this._openShardRaw(partitionKey)
+  }
+
+  /** @internal — open + configure with no migrate-on-open hook (used by the migration path itself to avoid recursion). */
+  private async _openShardRaw(partitionKey: string): Promise<Vault> {
     const vault = await this.db.openVault(this.shardVaultId(partitionKey), { create: false })
     this.template.configure(vault)
     return vault
@@ -274,6 +292,90 @@ export class VaultGroup<T> {
       }
     }
     return { written, skippedVaults: skipped }
+  }
+
+  /** @internal — the control-plane vault for migration status; lazily opened. */
+  private async ensureStateVault(): Promise<StateManagementVault> {
+    if (!this.stateVault) this.stateVault = await StateManagementVault.open(this.db)
+    return this.stateVault
+  }
+
+  /**
+   * Migrate ONE shard to the template's current version (#271 fleet runner,
+   * per-shard step). Opens the shard (applying the template, which arms the
+   * M12 cutover), drains schema-write detection, runs `vault.runSchemaCutover()`
+   * (the per-vault drain-barrier-transform protocol), then advances the
+   * registry row's `schemaVersion` and records `migration-status`. A shard
+   * already at the template version is a no-op (`status: 'done'`, migrated 0).
+   * Never throws on a cutover failure — it records `status: 'failed'` and
+   * returns the row, so a fleet run continues past a bad shard.
+   */
+  async migrateShard(partitionKey: string): Promise<MigrationStatusRow> {
+    const vaultId = this.shardVaultId(partitionKey)
+    const row = await this.registry.get(this.registryId(partitionKey))
+    if (!row) throw new UnknownShardError(partitionKey, this.name)
+    const target = this.template.version
+    const sv = await this.ensureStateVault()
+    const base = { vaultId, group: this.name, currentVersion: row.schemaVersion, targetVersion: target }
+
+    if (row.schemaVersion >= target) {
+      const done: MigrationStatusRow = { ...base, status: 'done', migrated: 0, finishedAt: Date.now() }
+      await sv.upsertMigrationStatus(done)
+      return done
+    }
+
+    await sv.upsertMigrationStatus({ ...base, status: 'running', startedAt: Date.now() })
+    try { await sv.appendEvent({ type: 'migration-started', group: this.name, vaultId, version: target }) } catch { /* best-effort */ }
+
+    try {
+      const vault = await this._openShardRaw(partitionKey)
+      await vault._drainPendingSchemaWrites()
+      const { migrated } = await vault.runSchemaCutover()
+      // Advance the authoritative registry version (no built-in update path).
+      await this.registry.put(this.registryId(partitionKey), { ...row, schemaVersion: target })
+      const done: MigrationStatusRow = { ...base, currentVersion: target, status: 'done', migrated, finishedAt: Date.now() }
+      await sv.upsertMigrationStatus(done)
+      try { await sv.appendEvent({ type: 'migration-completed', group: this.name, vaultId, version: target }) } catch { /* best-effort */ }
+      return done
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err)
+      const failed: MigrationStatusRow = { ...base, status: 'failed', error, finishedAt: Date.now() }
+      await sv.upsertMigrationStatus(failed)
+      try { await sv.appendEvent({ type: 'migration-failed', group: this.name, vaultId, version: target, detail: error }) } catch { /* best-effort */ }
+      return failed
+    }
+  }
+
+  /**
+   * Active batch runner (#271): migrate every shard behind the template version
+   * to it, in controlled batches. **Resumable + crash-safe** — shards already at
+   * the target are skipped (the registry version is the source of truth), so a
+   * re-run after a crash only picks up the unfinished + previously-failed shards.
+   *
+   * - `cohort` — restrict to these partition keys (the staged / canary rollout:
+   *   migrate a small cohort, verify the Insight Vault, then run the rest).
+   * - `batchSize` — max shards migrated concurrently per batch (back-pressure).
+   *   Default 4. Batches run sequentially; shards within a batch run in parallel.
+   */
+  async migrateFleet(options: { cohort?: readonly string[]; batchSize?: number } = {}): Promise<FleetMigrationResult> {
+    const target = this.template.version
+    const rows = await this.allRows()
+    const cohort = options.cohort
+    const todo = rows.filter(
+      (r) => r.schemaVersion < target && (cohort === undefined || cohort.includes(r.partitionKey)),
+    )
+    const batchSize = Math.max(1, options.batchSize ?? 4)
+    const migrated: string[] = []
+    const failed: { vaultId: string; error: string }[] = []
+    for (let i = 0; i < todo.length; i += batchSize) {
+      const batch = todo.slice(i, i + batchSize)
+      const settled = await Promise.all(batch.map((r) => this.migrateShard(r.partitionKey)))
+      for (const res of settled) {
+        if (res.status === 'done') migrated.push(res.vaultId)
+        else failed.push({ vaultId: res.vaultId, error: res.error ?? 'unknown' })
+      }
+    }
+    return { target, migrated, failed }
   }
 }
 

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -326,6 +326,8 @@ export type {
   CrossVaultDerivationSpec,
   CrossVaultDerivationContext,
   RefreshInsightsResult,
+  MigrationStatusRow,
+  FleetMigrationResult,
 } from './federation/index.js'
 export { STATE_VAULT_NAME } from './federation/constants.js'
 export { UnknownShardError, ShardProvisioningError, VaultTemplateNotFoundError, ReservedVaultNameError } from './errors.js'

--- a/packages/hub/src/introspection/fields.ts
+++ b/packages/hub/src/introspection/fields.ts
@@ -128,7 +128,6 @@ function mergeUnionMembers(
 
     // Use first-seen descriptor as the base (presentIn is always non-empty here since
     // we iterate names that appeared in at least one member's fields)
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const base = presentIn[0]!.fields[name]!
 
     // For discriminator-like fields: collect const/enum values across all members

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -1099,7 +1099,7 @@ export class Noydb {
     // Managed control plane when no explicit registry is supplied.
     const stateVault = opts.registry ? undefined : await StateManagementVault.open(this)
     const registry = opts.registry ?? stateVault!.registry
-    const group = new VaultGroup<T>(this, name, registry, opts.sharding, template)
+    const group = new VaultGroup<T>(this, name, registry, opts.sharding, template, opts.migrateOnOpen ?? false)
     if (stateVault) {
       group._attachStateVault(stateVault)
       // recordManifest persists control-plane state → hard-fail on error.

--- a/showcases/src/109-fleet-migration.showcase.test.ts
+++ b/showcases/src/109-fleet-migration.showcase.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Showcase 109 — Fleet schema migration (VaultGroup.migrateFleet)
+ *
+ * What you'll learn
+ * ─────────────────
+ * When a sharded schema evolves (the `invoices` schema gains a richer
+ * `amount` shape), every per-client shard vault must migrate — safely, at
+ * its own pace, without blocking reads across a mixed-version fleet. The
+ * fleet runner orchestrates M12's per-vault cutover across all shards and
+ * records each shard's progress in the StateManagement Vault.
+ *
+ *   1. `migrateFleet({ cohort? })` — active batch runner; staged via `cohort`.
+ *   2. `migrateShard(key)` — one shard; `migrateOnOpen` — lazy on access.
+ *   3. The `minVersion` fan-out guard skips behind-version shards until migrated.
+ *   4. Resumable: a re-run only touches shards not yet at the target.
+ *
+ * Why it matters
+ * ──────────────
+ * Migrating thousands of independent vaults is the operational hard part of
+ * per-tenant isolation. Each vault still uses M12's single-vault cutover
+ * internally; the fleet runner adds the orchestration + crash-safe status,
+ * and the `minVersion` guard means reads never silently mix record shapes
+ * from shards sitting at different schema generations.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 98 (VaultGroup), 96/coordinatedCutover (M12 per-vault cutover).
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → vault-group-federation
+ */
+
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { createNoydb, coordinatedCutover } from '@noy-db/hub'
+import type { Vault } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+
+const oldSchema = z.object({ id: z.string(), clientId: z.string(), total: z.number() })
+const newSchema = z.object({ id: z.string(), clientId: z.string(), amount: z.object({ gross: z.number() }) })
+const transform = (d: Record<string, unknown>) => ({ id: d['id'], clientId: d['clientId'], amount: { gross: d['total'] } })
+const sharding = { keyOf: (r: { clientId: string }) => r.clientId, vaultTemplate: 'client', autoCreate: true }
+
+describe('Showcase 109 — Fleet schema migration', () => {
+  it('migrates a sharded fleet from v1 to v2, staged then complete', async () => {
+    const store = memory()
+
+    // ── v1: a firm with three client shards on the old schema ──
+    const db1 = await createNoydb({ store, user: 'firm-op', secret: 'firm-2026' })
+    db1.withVaultTemplate('client', { version: 1, configure: (v: Vault) => { v.collection('invoices', { schema: oldSchema, persistJsonSchema: true }) } })
+    const firmV1 = await db1.openVaultGroup('firm', { sharding })
+    for (const [client, total] of [['acme', 100], ['globex', 250], ['initech', 70]] as const) {
+      await firmV1.collection('invoices').put(`${client}-1`, { id: `${client}-1`, clientId: client, total })
+      await (await firmV1.shard(client))._drainPendingSchemaWrites() // persist the v1 baseline
+    }
+
+    // ── v2: publish the new schema + cutover transform (operator restart) ──
+    const db2 = await createNoydb({ store, user: 'firm-op', secret: 'firm-2026' })
+    db2.withVaultTemplate('client', {
+      version: 2,
+      configure: (v: Vault) => { v.collection('invoices', { schema: newSchema, persistJsonSchema: true, schemaUpdate: [coordinatedCutover({ transform })] }) },
+    })
+    const firm = await db2.openVaultGroup('firm', { sharding })
+
+    // A mixed-version read is safe: minVersion:2 skips the not-yet-migrated shards.
+    const beforeMigration = await firm.collection('invoices').query().toArray({ minVersion: 2 })
+    expect(beforeMigration.results).toEqual([])
+    expect(beforeMigration.skippedVaults).toHaveLength(3) // all still v1
+
+    // ── Staged rollout: canary one client, verify, then the rest ──
+    const canary = await firm.migrateFleet({ cohort: ['acme'] })
+    expect(canary.migrated).toEqual(['firm--acme'])
+    const acme = await firm.shard('acme')
+    expect((await acme.collection<{ amount: { gross: number } }>('invoices').get('acme-1'))?.amount.gross).toBe(100)
+
+    // Roll out the rest; failed shards (none here) would be in `failed`.
+    const rest = await firm.migrateFleet()
+    expect(rest.migrated.sort()).toEqual(['firm--globex', 'firm--initech'])
+
+    // The whole fleet now answers the v2 fan-out.
+    const afterMigration = await firm.collection('invoices').query().toArray({ minVersion: 2 })
+    expect(afterMigration.results).toHaveLength(3)
+    expect(afterMigration.skippedVaults).toEqual([])
+
+    // Resumable: another run is a no-op now that all shards are current.
+    expect((await firm.migrateFleet()).migrated).toEqual([])
+
+    db1.close()
+    db2.close()
+  })
+})

--- a/showcases/src/109-fleet-migration.showcase.test.ts
+++ b/showcases/src/109-fleet-migration.showcase.test.ts
@@ -40,7 +40,8 @@ import { memory } from '@noy-db/to-memory'
 const oldSchema = z.object({ id: z.string(), clientId: z.string(), total: z.number() })
 const newSchema = z.object({ id: z.string(), clientId: z.string(), amount: z.object({ gross: z.number() }) })
 const transform = (d: Record<string, unknown>) => ({ id: d['id'], clientId: d['clientId'], amount: { gross: d['total'] } })
-const sharding = { keyOf: (r: { clientId: string }) => r.clientId, vaultTemplate: 'client', autoCreate: true }
+type InvoiceV1 = { id: string; clientId: string; total: number }
+const sharding = { keyOf: (r: InvoiceV1) => r.clientId, vaultTemplate: 'client', autoCreate: true }
 
 describe('Showcase 109 — Fleet schema migration', () => {
   it('migrates a sharded fleet from v1 to v2, staged then complete', async () => {


### PR DESCRIPTION
Advances vLannaAi/klum-db#12 — builds the **fleet schema-migration runner**, the last operational piece of the federation epic (only design items remain after this).

## What & why

When a sharded schema evolves, every per-client shard vault must migrate — safely, at its own pace, without blocking reads across a mixed-version fleet. M12's `coordinatedCutover` is the per-*vault* engine; this adds the fleet-level orchestration. As the issue specifies, **each vault still uses M12's single-vault protocol internally** (`vault.runSchemaCutover()`); this layer adds ordering, status, and resumability.

```ts
// Active batch runner — migrate every behind shard to the template version.
const { target, migrated, failed } = await firm.migrateFleet({ batchSize: 8 })
// Staged / canary.
await firm.migrateFleet({ cohort: ['acme'] }); await firm.migrateFleet()
// Lazy migrate-on-open.
const firm = await db.openVaultGroup('firm', { sharding, migrateOnOpen: true })
// One shard.
await firm.migrateShard('acme')
```

## How

- **`migrateShard(key)`** — the per-shard step: open the shard (template arms the cutover) → `_drainPendingSchemaWrites()` → `vault.runSchemaCutover()` → advance the registry row's `schemaVersion` → write `migration-status`. Already-current = no-op; a failed cutover is caught + recorded `'failed'`, never aborting the run.
- **`migrateFleet({ cohort?, batchSize? })`** — active batch runner. `cohort` = staged/canary; `batchSize` = back-pressure (sequential batches, parallel within, default 4). **Resumable / crash-safe** — the registry `schemaVersion` is the source of truth, so a re-run skips current shards and retries failed ones.
- **`migrateOnOpen`** (`VaultGroupOptions`) — lazy: `openShard` migrates a behind shard inline (via a raw opener to avoid recursion).
- **StateManagement Vault** — new `migrationStatus` collection + `MigrationStatusRow` `{ vaultId, group, currentVersion, targetVersion, status, migrated?, error? }` with typed accessors; + `migration-started/completed/failed` deployment events.
- **Mixed-version reads** stay safe throughout the rollout via the existing `minVersion` fan-out guard (behind shards → `skippedVaults`, never mixed shapes).
- **Co-location assumption**: drives co-located shards in-process; distributed/per-process is a `by-server` concern (documented out of scope).

## Tests

- `packages/hub/__tests__/federation-fleet-migration.test.ts` (7): orchestration (version bump + status, resumable re-run, cohort, `migrateShard` single + no-op, `migrateOnOpen` lazy, the `minVersion` guard before/after) **plus a real `coordinatedCutover`** transforming records across two shards (fresh v2 session over the same store — the realistic operator-restart path).
- Showcase 109 (v1→v2 fleet, staged then complete). `docs/subsystems/vault-group.md` (fleet-migration section) + `features.yaml`.
- Full hub suite green. (Whole-monorepo run had 3 transient `at-*` failures from a concurrent `dist/` rebuild — verified passing in isolation, unrelated to this change.)

## Remaining on vLannaAi/klum-db#12 (design only)

- cross-vault DEK-grant **executor identity** (least-privilege service account) for the Insight Vault.
- VaultGroup **data-residency** routing constraint.

## Merge note

Independent of the Insight Vault PR (#391); both add methods to `vault-group.ts` (+ federation exports), so expect a trivial conflict — resolvable by keeping both method sets.