### PR TITLE
docs(design): #271 remaining design notes — Insight Vault identity + data-residency

### DIFF
--- a/docs/superpowers/specs/2026-06-14-cross-vault-dek-grant-executor-identity-design.md
+++ b/docs/superpowers/specs/2026-06-14-cross-vault-dek-grant-executor-identity-design.md
@@ -1,0 +1,110 @@
+# Cross-vault DEK-grant executor identity — Insight Vault (#271)
+
+> **Status:** DESIGN — awaiting maintainer decision (see § Decision).
+> **Context:** the Insight Vault (#271 Layer 4, PR #391) shipped with the
+> derivation running under the **caller's** `Noydb`. This pins down the
+> least-privilege production identity for that executor.
+
+## Problem
+
+`firm.refreshInsights()` reads each shard's records, derives a summary, and
+writes it to the Insight Vault. v1 runs under whatever `Noydb` opened the
+`VaultGroup` — typically the **bank admin**, whose keyrings can decrypt *every*
+shard and write *everywhere*. That's a broad blast radius for a background
+aggregation job: a compromised refresh process can read all client data and
+mutate any vault.
+
+The open question from the epic: does the executor run under the bank admin's
+`Noydb`, or a **dedicated service account** with `role: 'operator'` grants on
+exactly the source shards (read) and the Insight Vault (write) — least privilege?
+
+## Current model (grounded)
+
+- **Grants mint per-principal keyrings.** `db.grant(vaultId, { userId, role,
+  passphrase, permissions })` writes a keyring envelope so a principal opening
+  that vault under their passphrase receives exactly the granted collection DEKs
+  (`noydb.ts:704`; `GrantOptions` at `types.ts:1072`, incl. per-collection
+  `permissions`).
+- **A `Noydb` IS an identity.** `createNoydb({ user, secret })` is "this
+  principal, this passphrase." It holds only the keyrings it can unwrap; reading
+  a shard requires a grant on it.
+- **Missing grants already degrade gracefully.** The federation fan-out
+  classifies a `NoAccessError` as a `'no-grant'` skip
+  (`classifyShardSkip` / `resolveEligible`), so an executor lacking a shard's
+  read grant simply skips that shard rather than failing.
+- **Writes are actor-stamped.** Every envelope/ledger entry records `_by` =
+  the writing principal's `userId`, so a service-account identity yields a clean
+  audit trail distinct from human admins.
+
+## Key realization
+
+**The least-privilege model needs essentially no new hub code — it is a
+deployment pattern.** "Run the derivation under a scoped service account"
+means: open the `VaultGroup` under a `Noydb` constructed for a service-account
+principal that has been `grant()`-ed:
+
+- **read** on each shard's `source` collection (decryption requires only a read
+  grant), and
+- **write** on the Insight Vault's target collection — *and nothing else*.
+
+```ts
+// One-time provisioning (by an admin who holds owner on each vault):
+for (const shardId of shardIds) {
+  await admin.grant(shardId, {
+    userId: 'svc-insights', displayName: 'Insight aggregator', role: 'operator',
+    passphrase: SVC_PASSPHRASE,
+    permissions: { collections: { invoices: ['read'] } },   // read-only on the source
+  })
+}
+await admin.grant('firm-insights', {
+  userId: 'svc-insights', displayName: 'Insight aggregator', role: 'operator',
+  passphrase: SVC_PASSPHRASE,
+  permissions: { collections: { 'client-summary': ['read', 'write'] } },
+})
+
+// The aggregation process runs as the service account:
+const svc = await createNoydb({ store, user: 'svc-insights', secret: SVC_PASSPHRASE })
+const firm = await svc.openVaultGroup('firm-clients', { sharding })
+firm.withCrossVaultDerivation({ source: 'invoices', target: { vault: 'firm-insights', collection: 'client-summary' }, derive })
+await firm.refreshInsights()    // reads only what it's granted; writes only the summary
+```
+
+A shard the service account isn't granted → `'no-grant'` skip (already handled).
+Revoking the account's grant on a shard cleanly removes it from future refreshes.
+
+## Decision
+
+**Which is the supported model?**
+
+- **(A) Caller's `Noydb` (v1, shipped).** Simplest; broad privilege. Fine for
+  single-operator / dev.
+- **(B) Dedicated service account (least privilege).** Recommended for
+  production. Read-only on shards, write on the Insight Vault, nothing else;
+  bounded blast radius; clean audit actor; graceful skip on revoked shards.
+
+**Recommendation: document (B) as the production pattern; keep (A) as the
+default. No core change required** — (B) is `grant()` + `createNoydb()` wiring.
+
+Two small, *optional* hub hardenings to make (B) safer/ergonomic (each a yes/no):
+
+1. **Read-only enforcement on the source.** Should `withCrossVaultDerivation`
+   assert the executor's grant on `source` is read-only (reject if it also holds
+   write)? *Rec: no* — least privilege is the operator's grant choice; the hub
+   shouldn't second-guess a valid grant. Document instead.
+2. **Insight-write isolation guard.** Should the engine refuse a `target.vault`
+   that is also a *shard* of the group (preventing accidental write-back into
+   client data)? *Rec: yes* — cheap invariant; a summary must never target a
+   shard vault. Add a check in `withCrossVaultDerivation` /`refreshInsights`.
+3. **A `db.grantServiceAccount(...)` convenience** that bundles the per-shard
+   read + Insight write grants? *Rec: defer* — the explicit `grant()` loop is
+   clear and flexible; sugar can come if pilots ask.
+
+## Build (if approved)
+
+- **Docs (always):** an "Insight Vault identity & least privilege" section in
+  `docs/subsystems/vault-group.md` + the ZK note cross-link, with the snippet above.
+- **Hardening 2 (if yes):** `withCrossVaultDerivation` throws if
+  `target.vault === this.name` or matches `shardVaultId(any registered partition)`
+  prefix — a `ValidationError`. ~10 lines + a test.
+- No change to the refresh engine itself; (A) and (B) are the same code path
+  under different identities.

--- a/docs/superpowers/specs/2026-06-14-vaultgroup-data-residency-routing-design.md
+++ b/docs/superpowers/specs/2026-06-14-vaultgroup-data-residency-routing-design.md
@@ -1,0 +1,103 @@
+# VaultGroup data-residency routing constraint (#271)
+
+> **Status:** DESIGN — awaiting maintainer decision (see § Decision).
+> **Context:** the epic flags data-residency (dim11's `region` idea) as an
+> undesigned dependency for regulated MVF deployments. This scopes how a
+> `VaultGroup` routes each shard to a region-appropriate backend and refuses
+> non-compliant placement.
+
+## Problem
+
+A regulated firm (GDPR, data locality) must keep a client's shard vault on a
+backend in a specific region — `acme` → EU store, `globex` → US store. Today a
+`VaultGroup` provisions and reads every shard through the **single** store on
+its `Noydb` (`this.db.options.store`). There is no per-shard backend selection
+and no way to *enforce* that a shard lands on a region-correct backend.
+
+## Current state (grounded)
+
+- **One store per `Noydb`.** All vaults (shards, state vault, Insight Vault) go
+  through `options.store` (`noydb.ts`).
+- **But the routing seam already exists.** `routeStore({ vaultRoutes: { 'EU-':
+  euStore, 'US-': usStore }, default })` multiplexes by **vault-name prefix**
+  (`store/route-store.ts:112` — "Route by vault name (prefix patterns, e.g.
+  `'EU-'`"). Since a shard's vault id is `${group}--${partitionKey}`, a
+  region-encoding partition key (`eu-acme` → `firm--eu-acme`) already routes to
+  the right regional backend via a `vaultRoutes` prefix (`firm--eu-`).
+- **No `region` capability.** `StoreCapabilities` (`types.ts:1641`) has no
+  `region` field, so a misconfigured route — a shard physically landing on the
+  wrong-region backend — cannot be *detected*. Residency today is achievable but
+  **unenforced** (operator must wire `vaultRoutes` correctly by hand).
+
+So the gap is **enforcement**, not raw capability: prevent a shard from being
+created/written on a backend whose region doesn't match the record's required region.
+
+## Decision
+
+Three layered, independently-shippable pieces; decide how far to go.
+
+### 1. `region` store capability (advisory) — recommend YES
+
+Add `readonly region?: string` to `StoreCapabilities`. Adapters/`routeStore`
+declare the region a store serves (`{ region: 'eu' }`). Purely advisory until a
+consumer enforces it; zero behavior change for stores that omit it.
+
+### 2. `VaultGroup` placement guard — recommend YES
+
+Add `sharding.regionOf?: (record: T) => string`. On `createShard` (and the
+routing `put` that auto-creates), the group resolves the candidate backend for
+the shard's vault id and compares its declared `capabilities.region` to
+`regionOf(record)`; on mismatch it throws **`DataResidencyError`** *before*
+provisioning — so a shard never lands on a non-compliant backend.
+
+Resolving "the candidate backend for a vault id": ask the (possibly routed)
+store which backend a vault id maps to. `RoutedNoydbStore` can expose a
+`resolveBackend(vaultId): NoydbStore` (it already computes this internally for
+`vaultRoutes`); a plain store resolves to itself. The guard reads
+`resolveBackend(shardVaultId).capabilities?.region`.
+
+Reads are unaffected — fan-out already hits whatever backend the route picks;
+the constraint is about *placement* (and a loud failure if naming/routing drift
+apart).
+
+### 3. Region-encoded partitioning convention — recommend DOCUMENT
+
+The cleanest way for `vaultRoutes` to route shards by region is a
+region-segment in the partition key (`eu-acme`, `us-globex` — within the
+existing `[A-Za-z0-9._-]` charset), so `firm--eu-` / `firm--us-` prefixes route.
+Document this convention; optionally let `sharding.regionOf` + a
+`sharding.shardKey(region, key)` helper compose the name so naming and routing
+can't drift. *Rec: document the convention now; the helper is optional sugar.*
+
+## Open dependencies / non-goals (v1)
+
+- **Multi-backend wiring stays the operator's job** via `routeStore`. The hub
+  adds the *capability* + the *guard*; it does not manage regional connections.
+- **Moving an existing shard between regions** (re-homing) is out of scope —
+  that's an `extractPartition` → re-`adoptPartition`-on-regional-store ceremony
+  (#198), not a routing change.
+- **Reads from the wrong region** aren't blocked by this design (the route
+  already determines the physical backend); the guard prevents wrong-region
+  *placement*, which is the compliance-relevant event.
+- **Per-region keyrings / cross-region grants** are unchanged (each shard keeps
+  its own DEK boundary regardless of region).
+
+## Recommendation summary
+
+Ship **1 + 2** (advisory `region` capability + `regionOf` placement guard +
+`DataResidencyError`) and **document 3**. This makes residency *enforceable* on
+top of the existing `routeStore` seam without the hub taking on connection
+management. If even that is more than wanted now, the minimum viable answer is
+**"residency = `routeStore({ vaultRoutes })` + a region-encoded partition key;
+enforcement is a documented follow-up"** — i.e. document-only, no code.
+
+## Build (if 1+2 approved)
+
+- `StoreCapabilities.region?: string` (`types.ts`) + thread it through
+  `routeStore` (a routed store reports the region of its `default`, or per-route).
+- `RoutedNoydbStore.resolveBackend(vaultId)` (expose existing internal mapping).
+- `ShardingConfig.regionOf?` (`federation/types.ts`); `createShard` placement
+  check + `DataResidencyError` (`errors.ts`).
+- Tests: mismatch throws on create; matching create succeeds; no `regionOf` →
+  unchanged. Showcase: EU/US split via `routeStore` + `regionOf`.
+- Docs: residency section in `docs/subsystems/vault-group.md`.


### PR DESCRIPTION
The two remaining (design-only) items on vLannaAi/klum-db#12, after the Insight Vault (#391) and fleet migration runner (#392) shipped. **Docs only.** Each gives a grounded recommendation + explicit decisions, so vLannaAi/klum-db#12 can close once you pick directions.

## 1. Cross-vault DEK-grant executor identity (`…cross-vault-dek-grant-executor-identity-design.md`)

Least-privilege identity for `refreshInsights()`. v1 runs under the caller's `Noydb` (can decrypt every shard). 

**Key finding: the least-privilege model needs essentially no hub code** — it's a deployment pattern. Run the `VaultGroup` under a **service account** `grant()`-ed *read* on each shard's source collection and *write* on the Insight Vault collection, and nothing else; missing grants already degrade to `'no-grant'` skips, and writes are actor-stamped for a clean audit trail.

- **Decision:** (A) caller's Noydb [shipped default] vs (B) service account [recommended for production]. Rec: document B as the pattern, keep A as default — no core change.
- Optional hardening (rec yes): refuse a `target.vault` that is itself a shard of the group (~10 lines).

## 2. VaultGroup data-residency routing (`…vaultgroup-data-residency-routing-design.md`)

**Key finding: residency is already achievable** via `routeStore({ vaultRoutes: { 'firm--eu-': euStore, … } })` + region-encoded partition keys (the `vaultRoutes` prefix seam already exists). The gap is **enforcement** — `StoreCapabilities` has no `region`, so a wrong-region placement can't be detected.

- **Decision — how far to go:**
  1. advisory `StoreCapabilities.region?` (rec yes),
  2. `sharding.regionOf` + placement guard throwing `DataResidencyError` on mismatch + `RoutedNoydbStore.resolveBackend()` (rec yes),
  3. document the region-encoded-partition convention (rec yes).
  - Minimum viable = document-only (routeStore + convention; enforcement deferred).
- Non-goals (v1): multi-backend wiring stays the operator's `routeStore` job; re-homing a shard across regions is an `extractPartition`→`adoptPartition` ceremony.

---

Pick a direction on each and I'll implement (item 1 is mostly docs + a tiny guard; item 2's 1+2 is a small, well-scoped build). With these resolved, vLannaAi/klum-db#12 is fully closeable.