### PR TITLE
fix(query): orderBy on money fields compares by scaled-int value, not lexically (#390)

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -197,6 +197,7 @@ features:
       - 'money-aware sum/min/max in BigInt — fixed → single string, multi → per-currency map, sum convertTo+fx → one exact figure; remove() supports live/MV maintenance'
       - 'ONE canonical encoding at user-facing extension points (#332/#335): guard gate ctx (both sides), filter()/wherePredicate() callbacks, MV union maps all see the decoded decimal — the scaled-int never escapes storage'
       - 'where() on a money field takes MAJOR-unit operands, compares BigInt-exact in scaled space (#336); contains/startsWith and malformed operands throw at build time; multi-mode cross-currency matches != only'
+      - 'orderBy() on a money field sorts by the BigInt scaled-int value, not lexically by the stored digit string (#390 — consistent with where/sum); non-money fields use the generic comparator; malformed/missing money values sort last (asc)'
       - 'nested-path declarations (#334): descriptor keys accept dotted / [] / * paths (lineItems[].amount, billing.fee, summary.*); syntax validated loudly at registration; quantize walk throws on shape mismatch, decode walk is lenient'
       - 'exact arithmetic helpers (#337): mulRate (one rounding step, at the end) and largest-remainder allocate (parts sum EXACTLY to the whole, zero drift by construction)'
       - 'branded MoneyString output type + asMoney/isMoneyString/moneyNumber accessors (#338) — input side stays the permissive string | number union'

--- a/packages/hub/__tests__/money/order-by.test.ts
+++ b/packages/hub/__tests__/money/order-by.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { createNoydb, money } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+// #390 — orderBy on a money field must compare by the BigInt scaled-int
+// value, not lexically by the stored scaled-int string ('9882' vs '10004'
+// → '9' > '1' was wrong). Consistent with where (#336) and sum.
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v && cname && id) { out[cname] = out[cname] ?? {}; out[cname]![id] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c]!)) { data.set(k(v, c, i), payload[c]![i]!) }
+      }
+    },
+  }
+}
+
+interface Invoice extends Record<string, unknown> { id: string; total: number | string }
+const schema = z.object({ id: z.string(), total: z.union([z.number(), z.string()]) })
+
+async function seed(values: Array<[string, number | string]>) {
+  const db = await createNoydb({ store: memory(), user: 'a', secret: 'money-orderby-2026' })
+  const vault = await db.openVault('books')
+  const col = vault.collection<Invoice>('invoices', { schema, moneyFields: { total: money({ currency: 'EUR', scale: 2 }) } })
+  for (const [id, total] of values) await col.put(id, { id, total })
+  return col
+}
+
+describe('money orderBy — scaled-int numeric comparison (#390)', () => {
+  it('sorts by value, not lexically (the 98.82 vs 100.04 repro)', async () => {
+    const col = await seed([['a', 98.82], ['b', 100.04]])
+    // desc: 100.04 must come before 98.82 (lexical would put 98.82 first)
+    expect((col.query().orderBy('total', 'desc').toArray()).map(r => r.id)).toEqual(['b', 'a'])
+    expect((col.query().orderBy('total', 'asc').toArray()).map(r => r.id)).toEqual(['a', 'b'])
+  })
+
+  it('orders a wider magnitude range correctly across digit counts', async () => {
+    const col = await seed([['a', 5], ['b', 99.5], ['c', 100], ['d', 1000000], ['e', 0.07]])
+    expect((col.query().orderBy('total', 'asc').toArray()).map(r => r.id)).toEqual(['e', 'a', 'b', 'c', 'd'])
+    expect((col.query().orderBy('total', 'desc').toArray()).map(r => r.id)).toEqual(['d', 'c', 'b', 'a', 'e'])
+  })
+
+  it('decoded output is correct and ordered (round-trips the read shape)', async () => {
+    const col = await seed([['a', 98.82], ['b', 100.04]])
+    const rows = col.query().orderBy('total', 'desc').toArray()
+    expect(rows.map(r => r.total)).toEqual(['100.04', '98.82'])
+  })
+
+  it('handles negatives and ties (stable)', async () => {
+    const col = await seed([['a', -50], ['b', 0], ['c', 100], ['d', 100]])
+    expect((col.query().orderBy('total', 'asc').toArray()).map(r => r.id)).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('still sorts non-money fields with the generic comparator', async () => {
+    const col = await seed([['a', 100], ['b', 5]])
+    expect((col.query().orderBy('id', 'asc').toArray()).map(r => r.id)).toEqual(['a', 'b'])
+  })
+})

--- a/packages/hub/src/money/normalize.ts
+++ b/packages/hub/src/money/normalize.ts
@@ -159,6 +159,31 @@ function formatCurrency(decimal: string, currency: string, scale: number, locale
 }
 
 /**
+ * The stored scaled-integer value of a money field as a `BigInt`, for
+ * exact numeric comparison (e.g. `orderBy` / sorting), or `null` when the
+ * stored value is missing/malformed. Mirrors the stored form `decodeValue`
+ * reads: a bare scaled-int (fixed mode) or `{ amount, currency }`
+ * (multi-currency). Comparison is in scaled space and is exact within a
+ * single currency/scale (the `where` / `sum` BigInt model); across
+ * currencies of different scales the raw scaled comparison is best-effort.
+ */
+export function moneyScaledValue(stored: unknown, desc: MoneyDescriptor): bigint | null {
+  let raw: unknown
+  if (desc.mode === 'fixed') {
+    raw = stored
+  } else {
+    if (!isMoneyValueObject(stored)) return null
+    raw = stored.amount
+  }
+  if (typeof raw !== 'string' && typeof raw !== 'number') return null
+  try {
+    return BigInt(String(raw))
+  } catch {
+    return null
+  }
+}
+
+/**
  * Decode ONE stored field value to its read shape, or `null` when the
  * stored value is malformed (defensive — never brick a read).
  */

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -18,7 +18,7 @@ import type { GroupedQuery, GroupedQueryN } from '../aggregate/groupby.js'
 import { NO_AGGREGATE, type AggregateStrategy } from '../aggregate/strategy.js'
 import type { MoneyDescriptor } from '../money/descriptor.js'
 import { wrapMoneyReducers } from '../money/money-reducer.js'
-import { decodeMoneyFields } from '../money/normalize.js'
+import { decodeMoneyFields, moneyScaledValue } from '../money/normalize.js'
 import { moneyFieldClause } from '../money/where.js'
 
 export interface OrderBy {
@@ -966,7 +966,7 @@ function executePlanWithSource(
   }
 
   if (plan.orderBy.length > 0) {
-    result = sortRecords(result, plan.orderBy)
+    result = sortRecords(result, plan.orderBy, source.moneyFields)
   }
   if (plan.offset > 0) {
     result = result.slice(plan.offset)
@@ -1217,17 +1217,35 @@ function applyCrossJoin(
   return expanded
 }
 
-function sortRecords(records: unknown[], orderBy: readonly OrderBy[]): unknown[] {
+function sortRecords(
+  records: unknown[],
+  orderBy: readonly OrderBy[],
+  moneyFields?: Record<string, MoneyDescriptor>,
+): unknown[] {
   // Stable sort: Array.prototype.sort is required to be stable since ES2019.
   return [...records].sort((a, b) => {
     for (const { field, direction } of orderBy) {
       const av = readField(a, field)
       const bv = readField(b, field)
-      const cmp = compareValues(av, bv)
+      // Money fields are stored as scaled-integer strings (#322); the generic
+      // string comparator would sort them lexically ('9882' > '10004'). Compare
+      // declared money fields by their BigInt scaled value instead — exact, and
+      // consistent with `where` (#336) and `sum` (#390).
+      const desc = moneyFields?.[field]
+      const cmp = desc ? compareMoney(av, bv, desc) : compareValues(av, bv)
       if (cmp !== 0) return direction === 'asc' ? cmp : -cmp
     }
     return 0
   })
+}
+
+/** Compare two stored money values by BigInt scaled-int; nullish/malformed last (asc). */
+function compareMoney(a: unknown, b: unknown, desc: MoneyDescriptor): number {
+  const av = moneyScaledValue(a, desc)
+  const bv = moneyScaledValue(b, desc)
+  if (av === null) return bv === null ? 0 : 1
+  if (bv === null) return -1
+  return av < bv ? -1 : av > bv ? 1 : 0
 }
 
 function readField(record: unknown, field: string): unknown {


### PR DESCRIPTION
Closes #390.

## Bug

`query().orderBy(<moneyField>, 'desc')` sorted by the **stored scaled-int string**, so it returned `98.82` before `100.04` (`'9882'` vs `'10004'` → `'9' > '1'`). Masked when all amounts share a digit count; wrong as soon as magnitudes differ. Found by the Speedex pilot's scale test — and it undercuts the money→stable flip (#378).

## Root cause

`query/builder.ts` `sortRecords()` compares **stored** values with the generic `compareValues` (money decode runs later). `where` (#336) and `sum/min/max` were money-aware (BigInt), but `sortRecords` was never threaded the `moneyFields` descriptors → lexical string fallthrough.

## Fix

- **`money/normalize.ts`** — new `moneyScaledValue(stored, desc): bigint | null` extracting the stored scaled-int as a BigInt (fixed-mode bare value + multi-currency `{ amount, currency }`; `null` on missing/malformed).
- **`query/builder.ts`** — `sortRecords` now takes `moneyFields`; a declared money field compares via BigInt (`compareMoney`, nullish/malformed last in asc), other fields via the existing `compareValues`. `executeQuery` threads `source.moneyFields`; the stateless `executePlan` path (no `source`) is unchanged.

Same-currency/scale ordering is exact (the `where`/`sum` BigInt model); cross-currency raw-scaled comparison is best-effort (single-currency fields order exactly) — documented in the helper.

## Tests

`packages/hub/__tests__/money/order-by.test.ts` (5): the exact `98.82`/`100.04` repro (asc + desc), wide magnitude range across digit counts, decoded read-shape output, negatives/ties, and non-money fields unaffected. Full hub suite green (263 files / 2539 tests); lint clean. `features.yaml` money-field invariant added.