### PR TITLE
feat(derivations): withRollup — aggregate onto a parent field (#376 slice 2)

### DIFF
--- a/docs/subsystems/derivations.md
+++ b/docs/subsystems/derivations.md
@@ -149,10 +149,44 @@ withDerivation<Sale, { self: Sale }>({
   before any write.
 - `triggerBy.collection` must differ from `source`; `on` is required.
 
-> **Slice 1 scope (#376).** This ships `triggerBy` reverse-denormalization.
-> The aggregate-onto-parent companion (`withRollup`) and rollup-on-delete
-> are a tracked follow-up (Slice 2). `vault.forget()` does not auto-re-derive
-> (it bypasses the put path) — recompute explicitly if needed.
+### Rollups — aggregate onto a parent field (#376 slice 2)
+
+`withRollup` is the inverse of a join: instead of reading children on
+demand, the parent carries a **maintained summary** folded from its
+children by foreign key. It recomputes on child insert, update, AND
+delete — gap-free.
+
+```ts
+import { withRollup } from '@noy-db/hub/derivations'
+
+withRollup<Sale, Buyer>({
+  from: 'sales',          // child collection (the trigger)
+  key: 'buyerId',         // FK on the child → parent id
+  into: 'buyers',         // parent collection
+  field: 'revenueByYear', // field on the parent to maintain
+  compute: (sales) => groupSumByYear(sales, 'total'),
+})
+```
+
+- On a `from` write/delete the parent at id `child[key]` is recomputed:
+  `compute(children where child[key] === parentId)` is patched onto
+  `parent[field]`. A parent write also recomputes its own aggregate, so a
+  **parent created after its children** still fills in.
+- Only `field` is patched onto the parent's raw record (other fields and
+  i18n maps untouched); a value-equality guard suppresses no-op writes.
+- The aggregate gathers children through the FK index when the `from`
+  collection declares `indexes:[key]` (O(children)), else a scan.
+- Eager-only in this slice. Desugars to a derivation carrying a `rollup`
+  marker; dispatch handles it without the executor.
+
+> **Why not a materialized view?** An MV aggregates children into a
+> *parallel* collection (`buyer-totals.get(id)`); it cannot write the
+> aggregate onto a field of the parent `buyers` record. `withRollup` does.
+
+> **Scope (#376).** Slice 1 = `triggerBy` reverse-denormalization; slice 2
+> = `withRollup` (this section) + rollup-on-delete. `vault.forget()` does
+> not auto-re-derive (it bypasses the put path) — recompute explicitly if a
+> forgotten record must drop out of an aggregate.
 
 ### Optional outputs (#144)
 

--- a/features.yaml
+++ b/features.yaml
@@ -765,6 +765,8 @@ features:
         path: showcases/src/80-with-derivation.showcase.test.ts
       - id: 104-reverse-denorm
         path: showcases/src/104-reverse-denorm.showcase.test.ts
+      - id: 105-rollup
+        path: showcases/src/105-rollup.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -777,6 +779,7 @@ features:
       - 'declared sibling sources (#344): withDerivation({ source, sources: [...] }) re-fires the derivation on writes to any declared sibling, using the PRIMARY source record at the SAME id (silent no-op if no primary record exists there); siblings are indexed in _bySource, participate in cycle detection, and fold into the strategy hash; sources[] entries must be non-empty and != source'
       - 'FK-keyed triggers (#376 slice 1): withDerivation({ triggerBy: [{ collection, on }] }) fans a PARENT write out to every source record where source[on] === parentId (re-derives each); fan-out uses the FK index when present, else scans; optional maxFanout throws DerivationCapExceededError before any write; triggerBy.collection must != source'
       - 'self-write reverse-denorm (#376): a record output whose collection === source MUST declare denorm:[...] — only those fields are patched onto the raw stored record (i18n maps/other fields never clobbered; no whole-record _derivedFrom tag); the self-write edge is exempt from cycle detection and terminated by a value-equality guard (no write when the patch changes nothing)'
+      - 'rollups (#376 slice 2): withRollup({ from, key, into, field, compute }) maintains an aggregate on the parent field — recomputed on child insert/update/DELETE (gap-free) and on a parent write (fills in a parent created after its children); only `field` is patched (value-equality guarded); children gathered via the FK index when from declares indexes:[key], else a scan; eager-only; forget() does not auto-recompute'
     related: [guards, transactions]
 
   - id: materialized-views

--- a/packages/hub/__tests__/derivations/rollup.test.ts
+++ b/packages/hub/__tests__/derivations/rollup.test.ts
@@ -1,0 +1,165 @@
+// Aggregate-onto-parent rollups (#376 slice 2).
+//
+// withRollup({ from, key, into, field, compute }) keeps a summary field on the
+// parent in sync with its children, on insert / update / delete, gap-free.
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withRollup, ValidationError } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v && cname && id) { out[cname] = out[cname] ?? {}; out[cname]![id] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c]!)) { data.set(k(v, c, i), payload[c]![i]!) }
+      }
+    },
+  }
+}
+
+interface Buyer extends Record<string, unknown> { id: string; companyName: string; totalSpent?: number; orderCount?: number }
+interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number }
+
+const totalSpentRollup = () =>
+  withRollup<Sale, Buyer>({
+    from: 'sales',
+    key: 'buyerId',
+    into: 'buyers',
+    field: 'totalSpent',
+    compute: (sales) => sales.reduce((t, s) => t + s.total, 0),
+  })
+
+describe('withRollup — factory validation (#376)', () => {
+  it('rejects from === into', () => {
+    expect(() => withRollup({ from: 'x', key: 'k', into: 'x', field: 'f', compute: () => 0 })).toThrow(ValidationError)
+  })
+  it('rejects a missing field', () => {
+    expect(() => withRollup({ from: 'sales', key: 'buyerId', into: 'buyers', field: '', compute: () => 0 })).toThrow(ValidationError)
+  })
+  it('rejects a non-function compute', () => {
+    // @ts-expect-error — compute must be a function
+    expect(() => withRollup({ from: 'sales', key: 'buyerId', into: 'buyers', field: 'f', compute: 5 })).toThrow(ValidationError)
+  })
+})
+
+describe('withRollup — aggregate maintenance (#376)', () => {
+  async function setup(indexed = false) {
+    const db = await createNoydb({
+      store: memory(), user: 'alice', secret: 'rollup-passphrase-2026',
+      derivationStrategies: [totalSpentRollup()],
+    })
+    const v = await db.openVault('firm')
+    const buyers = v.collection<Buyer>('buyers')
+    const sales = indexed
+      ? v.collection<Sale>('sales', { indexes: ['buyerId'] })
+      : v.collection<Sale>('sales')
+    return { db, v, buyers, sales }
+  }
+
+  it('maintains the aggregate across insert, update, and delete', async () => {
+    const { buyers, sales } = await setup()
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    expect((await buyers.get('b1'))?.totalSpent).toBe(100)
+
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 250 })
+    expect((await buyers.get('b1'))?.totalSpent).toBe(350)
+
+    // Update a child → recompute.
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 50 })
+    expect((await buyers.get('b1'))?.totalSpent).toBe(150)
+
+    // Delete a child → recompute (gap-free).
+    await sales.delete('s1')
+    expect((await buyers.get('b1'))?.totalSpent).toBe(50)
+
+    await sales.delete('s2')
+    expect((await buyers.get('b1'))?.totalSpent).toBe(0)
+  })
+
+  it('works with an FK index on the child', async () => {
+    const { buyers, sales } = await setup(true)
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 200 })
+    expect((await buyers.get('b1'))?.totalSpent).toBe(300)
+    await sales.delete('s1')
+    expect((await buyers.get('b1'))?.totalSpent).toBe(200)
+  })
+
+  it('isolates parents', async () => {
+    const { buyers, sales } = await setup()
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await buyers.put('b2', { id: 'b2', companyName: 'Globex' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    await sales.put('s2', { id: 's2', buyerId: 'b2', total: 999 })
+    await sales.put('s3', { id: 's3', buyerId: 'b1', total: 50 })
+    expect((await buyers.get('b1'))?.totalSpent).toBe(150)
+    expect((await buyers.get('b2'))?.totalSpent).toBe(999)
+  })
+
+  it('fills in a parent created AFTER its children', async () => {
+    const { buyers, sales } = await setup()
+    // Children written first — no parent record yet, so the rollup has
+    // nowhere to write (silently skipped).
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 200 })
+    // Now the parent appears → a parent write recomputes its own aggregate.
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    expect((await buyers.get('b1'))?.totalSpent).toBe(300)
+  })
+
+  it('patches only the rollup field — other parent fields preserved', async () => {
+    const { buyers, sales } = await setup()
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100 })
+    const b = await buyers.get('b1')
+    expect(b?.totalSpent).toBe(100)
+    expect(b?.companyName).toBe('Acme') // untouched
+  })
+
+  it('supports an object aggregate (group-by-style) value', async () => {
+    const db = await createNoydb({
+      store: memory(), user: 'alice', secret: 'rollup-obj-passphrase-2026',
+      derivationStrategies: [
+        withRollup<Sale & { year: number }, Buyer>({
+          from: 'sales', key: 'buyerId', into: 'buyers', field: 'byYear',
+          compute: (sales) => {
+            const out: Record<string, number> = {}
+            for (const s of sales) out[String(s.year)] = (out[String(s.year)] ?? 0) + s.total
+            return out
+          },
+        }),
+      ],
+    })
+    const v = await db.openVault('firm')
+    const buyers = v.collection<Buyer & { byYear?: Record<string, number> }>('buyers')
+    const sales = v.collection<Sale & { year: number }>('sales')
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100, year: 2026 })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 50, year: 2026 })
+    await sales.put('s3', { id: 's3', buyerId: 'b1', total: 70, year: 2027 })
+    expect((await buyers.get('b1'))?.byYear).toEqual({ '2026': 150, '2027': 70 })
+    await sales.delete('s1')
+    expect((await buyers.get('b1'))?.byYear).toEqual({ '2026': 50, '2027': 70 })
+  })
+})

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1750,6 +1750,65 @@ export class Collection<T> {
     return out
   }
 
+  /**
+   * @internal #376 slice 2 — recompute a rollup aggregate onto the parent.
+   * Gathers every child of `parentId`, runs `compute`, and patches only the
+   * rollup `field` onto the parent's raw stored record (value-equality
+   * guarded). No-op when the parent record does not exist.
+   */
+  private async recomputeRollup(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spec: { source: string; rollup?: { from: string; key: string; field: string; compute: (children: any[]) => unknown } },
+    parentId: string,
+  ): Promise<void> {
+    if (this.derivationSource === undefined || spec.rollup === undefined) return
+    const { from, key, field, compute } = spec.rollup
+    const into = spec.source
+    const intoColl = this.derivationSource.getCollection(into)
+    const base = await intoColl._getStoredRecord(parentId)
+    if (base === null) return // no parent record to patch
+
+    const fromColl = this.derivationSource.getCollection(from)
+    const childIds = await fromColl._findMatchingIds(key, parentId)
+    const children: Array<Record<string, unknown>> = []
+    for (const cid of childIds) {
+      const c = await fromColl.get(cid)
+      if (c !== null && c !== undefined) children.push(c)
+    }
+
+    const newValue = compute(children)
+    if (selfWriteFieldEqual(base[field], newValue)) return // no change → no write
+
+    const patched = { ...base, [field]: newValue }
+    const txCtx = this.derivationSource.getActiveTxContext()
+    if (txCtx !== null) {
+      const prior = await this.adapter.get(this.vault, into, parentId)
+      txCtx._executed.push({
+        op: { type: 'put', vaultName: this.vault, collectionName: into, id: parentId },
+        priorEnvelope: prior,
+      })
+    }
+    await intoColl.put(parentId, patched)
+  }
+
+  /**
+   * @internal #376 slice 2 — fire any rollups for which THIS collection is the
+   * child `from`, recomputing the affected parent after a child delete. Called
+   * from the delete path with the just-removed record's key value. Other
+   * derivation kinds do not react to deletes (unchanged).
+   */
+  private async dispatchRollupsOnDelete(deleted: T): Promise<void> {
+    if (this.derivationSource === undefined) return
+    const registry = this.derivationSource.registry()
+    const rec = deleted as Record<string, unknown>
+    for (const { spec } of registry.strategiesForSource(this.name)) {
+      if (!spec.rollup || spec.rollup.from !== this.name) continue
+      const kv = rec[spec.rollup.key]
+      if (typeof kv !== 'string' && typeof kv !== 'number') continue
+      await this.recomputeRollup(spec, String(kv))
+    }
+  }
+
   private async dispatchDerivations(id: string, record: T, version: number): Promise<void> {
     if (this.derivationSource === undefined) return
     // `record` is the stored form here (post-quantize) — decode so
@@ -1767,6 +1826,22 @@ export class Collection<T> {
     let DerivationExecutor: typeof DerivationExecutorType | null = null
     for (const { spec, strategyHash } of strategies) {
       const mode = typeof spec.lifecycle === 'string' ? spec.lifecycle : spec.lifecycle.mode
+
+      // Rollup (#376 slice 2): a write to the child `from` recomputes the
+      // parent at id child[key]; a write to the parent (source = into)
+      // recomputes its own aggregate. Handled here (the executor is not run).
+      if (spec.rollup) {
+        if (mode !== 'eager') continue
+        let parentId: string | null
+        if (this.name === spec.rollup.from) {
+          const kv = incoming[spec.rollup.key]
+          parentId = (typeof kv === 'string' || typeof kv === 'number') ? String(kv) : null
+        } else {
+          parentId = id // a write to the parent recomputes its own aggregate
+        }
+        if (parentId !== null) await this.recomputeRollup(spec, parentId)
+        continue
+      }
 
       // Determine how `this.name` triggers this strategy, and build the list
       // of source records to (re-)derive:
@@ -2240,6 +2315,11 @@ export class Collection<T> {
     if (!internal) {
       await this.dispatchMaterializedViewsOnDelete(id)
       await this.dispatchArrayDerivationsOnDelete(id)
+      // Rollup-on-delete (#376 slice 2): recompute the parent aggregate now
+      // that this child is gone. `existing.record` carries the deleted child's
+      // FK; the recompute gathers the REMAINING children (this one already
+      // removed from the store/cache above).
+      if (existing) await this.dispatchRollupsOnDelete(existing.record)
     }
   }
 

--- a/packages/hub/src/derivations/index.ts
+++ b/packages/hub/src/derivations/index.ts
@@ -1,4 +1,5 @@
 export { withDerivation } from './with-derivation.js'
+export { withRollup } from './with-rollup.js'
 export { DerivationRegistry } from './registry.js'
 export { DerivationExecutor } from './executor.js'
 export type {

--- a/packages/hub/src/derivations/registry.ts
+++ b/packages/hub/src/derivations/registry.ts
@@ -49,6 +49,18 @@ export class DerivationRegistry {
       else this._bySource.set(t.collection, [reg])
     }
 
+    // Rollup (#376 slice 2): a write to the child `from` collection recomputes
+    // the parent (= spec.source = into) at id child[key]. Index under `from`
+    // so a child write fires it; spec.source (into) is already indexed above,
+    // so a parent write also recomputes its own aggregate (covers the
+    // parent-created-after-children case). The from→into edge enters the cycle
+    // DFS automatically.
+    if (spec.rollup) {
+      const fromRollup = this._bySource.get(spec.rollup.from)
+      if (fromRollup) fromRollup.push(reg)
+      else this._bySource.set(spec.rollup.from, [reg])
+    }
+
     for (const key of outputKeys) {
       const output = spec.outputs[key]
       if (!output) continue

--- a/packages/hub/src/derivations/types.ts
+++ b/packages/hub/src/derivations/types.ts
@@ -182,6 +182,22 @@ export interface DerivationStrategy<
    * be a non-empty field name (validated at construction).
    */
   triggerBy?: ReadonlyArray<{ collection: string; on: string; maxFanout?: number }>
+  /**
+   * @internal — set by `withRollup()` (#376 slice 2). Marks this strategy as
+   * an aggregate-onto-parent rollup: a write OR delete of a `from` (child)
+   * record recomputes `compute(children where child[key] === parentId)` and
+   * patches it onto `source[field]` of the parent at `parentId` (= child[key]).
+   * `source` is the parent (`into`) collection; the synthetic self-write
+   * output carries `denorm: [field]`. Dispatch handles rollup specially (it
+   * does not run the executor). Eager-only in this slice.
+   */
+  rollup?: {
+    readonly from: string
+    readonly key: string
+    readonly field: string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    readonly compute: (children: any[]) => unknown
+  }
   /** v1: only deterministic derivations supported. */
   deterministic: true
   /**

--- a/packages/hub/src/derivations/with-rollup.ts
+++ b/packages/hub/src/derivations/with-rollup.ts
@@ -1,0 +1,73 @@
+import { ValidationError } from '../errors.js'
+import type { DerivationStrategy, DerivationStrategyHandle } from './types.js'
+
+/**
+ * `withRollup` — aggregate many child records onto a single field of their
+ * parent (#376 slice 2). The reverse of a join: instead of reading children
+ * on demand, the parent carries a maintained summary.
+ *
+ * ```ts
+ * withRollup<Sale, Buyer>({
+ *   from: 'sales',          // child collection (the trigger)
+ *   key: 'buyerId',         // FK on the child → parent id
+ *   into: 'buyers',         // parent collection
+ *   field: 'revenueByYear', // field on the parent to maintain
+ *   compute: (sales) => groupSumByYear(sales, 'total'),
+ * })
+ * ```
+ *
+ * On every write OR delete of a `from` record, the parent at id `child[key]`
+ * is recomputed: `compute(allChildren where child[key] === parentId)` is
+ * patched onto `parent[field]`. A parent write also recomputes its own
+ * aggregate (so a parent created after its children still fills in). Only the
+ * `field` is touched — the rest of the parent record is never clobbered — and
+ * a value-equality guard suppresses no-op writes. The aggregate is gap-free
+ * with respect to child inserts, updates, and deletes.
+ *
+ * Desugars to a `withDerivation` strategy carrying a `rollup` marker; dispatch
+ * handles it without invoking the executor. Eager-only in this slice.
+ */
+export function withRollup<
+  TChild extends Record<string, unknown> = Record<string, unknown>,
+  TParent extends Record<string, unknown> = Record<string, unknown>,
+>(config: {
+  from: string
+  key: keyof TChild & string
+  into: string
+  field: keyof TParent & string
+  compute: (children: TChild[]) => unknown
+}): DerivationStrategyHandle {
+  const { from, key, into, field, compute } = config
+  if (!from || from.length === 0) {
+    throw new ValidationError('withRollup: `from` (child collection) is required')
+  }
+  if (!into || into.length === 0) {
+    throw new ValidationError('withRollup: `into` (parent collection) is required')
+  }
+  if (from === into) {
+    throw new ValidationError('withRollup: `from` and `into` must be different collections')
+  }
+  if (!key || key.length === 0) {
+    throw new ValidationError('withRollup: `key` (FK field on the child) is required')
+  }
+  if (!field || field.length === 0) {
+    throw new ValidationError('withRollup: `field` (target field on the parent) is required')
+  }
+  if (typeof compute !== 'function') {
+    throw new ValidationError('withRollup: `compute` must be a function')
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const spec: DerivationStrategy<any, any> = {
+    source: into, // the parent record is what carries the rolled-up field
+    deterministic: true,
+    rollup: { from, key, field, compute: compute as (children: unknown[]) => unknown },
+    // Synthetic self-write output for registry / cycle bookkeeping. Dispatch
+    // patches `field` directly (value-equality guarded); the executor is not run.
+    outputs: { value: { shape: 'record', collection: into, denorm: [field] } },
+    derive: () => ({ value: {} }), // never invoked for a rollup strategy
+    lifecycle: 'eager',
+  }
+
+  return { __noydb_strategy: 'derivation', spec }
+}

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -673,6 +673,7 @@ export type {
 
 // Derivations (Dim 14) — see docs/superpowers/specs/2026-05-01-dim14-derivation-v1-design.md
 export { withDerivation } from './derivations/index.js'
+export { withRollup } from './derivations/index.js'
 export type {
   DerivationStrategy,
   DerivationStrategyHandle,

--- a/showcases/src/105-rollup.showcase.test.ts
+++ b/showcases/src/105-rollup.showcase.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Showcase 105 — rollups (aggregate onto a parent field)
+ *
+ * What you'll learn
+ * ─────────────────
+ * `withRollup({ from, key, into, field, compute })` keeps a maintained
+ * summary on a parent record, folded from its children by foreign key. It
+ * recomputes on child insert, update, AND delete — gap-free — so the
+ * parent's total never drifts from the children that produced it.
+ *
+ *   - sales → buyer.revenueByYear, aggregated by buyerId.
+ *   - Deleting a sale recomputes the buyer (no overcount).
+ *   - Only the rollup field is touched on the parent.
+ *
+ * Why it matters
+ * ──────────────
+ * "Stats computed two different ways that disagree" is a recurring class.
+ * One declared rollup is the single source of truth — the parent carries
+ * the answer, maintained by the data layer, queryable without a scan.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 00 + 80 (withDerivation) + 104 (reverse-denorm).
+ *
+ * What to read next
+ * ─────────────────
+ *   - docs/subsystems/derivations.md
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → derivations
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withRollup } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+
+interface Buyer extends Record<string, unknown> { id: string; companyName: string; revenueByYear?: Record<string, number> }
+interface Sale extends Record<string, unknown> { id: string; buyerId: string; total: number; year: number }
+
+describe('Showcase 105 — rollups', () => {
+  it('maintains buyer.revenueByYear across child insert / update / delete', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'rollup-showcase-2026',
+      derivationStrategies: [
+        withRollup<Sale, Buyer>({
+          from: 'sales',
+          key: 'buyerId',
+          into: 'buyers',
+          field: 'revenueByYear',
+          compute: (sales) => {
+            const byYear: Record<string, number> = {}
+            for (const s of sales) byYear[String(s.year)] = (byYear[String(s.year)] ?? 0) + s.total
+            return byYear
+          },
+        }),
+      ],
+    })
+    const vault = await db.openVault('firm')
+    const buyers = vault.collection<Buyer>('buyers')
+    const sales = vault.collection<Sale>('sales', { indexes: ['buyerId'] })
+
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+
+    await sales.put('s1', { id: 's1', buyerId: 'b1', total: 100, year: 2026 })
+    await sales.put('s2', { id: 's2', buyerId: 'b1', total: 250, year: 2026 })
+    await sales.put('s3', { id: 's3', buyerId: 'b1', total: 70, year: 2027 })
+    expect((await buyers.get('b1'))?.revenueByYear).toEqual({ '2026': 350, '2027': 70 })
+
+    // Delete a sale → the buyer recomputes, no overcount.
+    await sales.delete('s2')
+    expect((await buyers.get('b1'))?.revenueByYear).toEqual({ '2026': 100, '2027': 70 })
+
+    // The parent's own fields are untouched by the rollup patch.
+    expect((await buyers.get('b1'))?.companyName).toBe('Acme')
+
+    db.close()
+  })
+})


### PR DESCRIPTION
Slice 2 of #376 (FK-keyed derivations). Adds `withRollup` — maintain an aggregate (sum/count/…) on a parent record as children change, via the triggerBy reverse-index from slice 1. Recompute on write + a delete hook. Tests in derivations/rollup.test.ts (9), showcase 105.

Supersedes #385 (auto-closed when its stacked base branch was deleted on #384's merge); rebased onto main, s1 commit dropped as already-applied.