### PR TITLE
feat(federation): Insight-write isolation guard + least-privilege docs (#271)

### DIFF
--- a/docs/subsystems/vault-group.md
+++ b/docs/subsystems/vault-group.md
@@ -135,6 +135,47 @@ const { written, skippedVaults } = await firm.refreshInsights({ minVersion: 3 })
 > Treat its backend as a `tier: 'derived'` store with a formally weaker ZK
 > profile, and grant it explicitly.
 
+### Executor identity & least privilege
+
+`refreshInsights()` runs the derivation under whatever `Noydb` opened the group.
+In v1 that is typically the operator/admin, whose keyrings can decrypt **every**
+shard and write **everywhere** — a broad blast radius for a background job.
+
+For production, run the aggregation under a **dedicated service account** granted
+*only* read on each shard's `source` collection and write on the Insight Vault —
+nothing else. No hub change is needed; this is `grant()` + `createNoydb()` wiring:
+
+```ts
+// One-time provisioning by an admin holding owner on each vault:
+for (const shardId of shardIds) {
+  await admin.grant(shardId, {
+    userId: 'svc-insights', displayName: 'Insight aggregator', role: 'operator',
+    passphrase: SVC_PASSPHRASE,
+    permissions: { collections: { invoices: ['read'] } },        // read-only source
+  })
+}
+await admin.grant('firm-insights', {
+  userId: 'svc-insights', displayName: 'Insight aggregator', role: 'operator',
+  passphrase: SVC_PASSPHRASE,
+  permissions: { collections: { 'client-summary': ['read', 'write'] } },
+})
+
+// The aggregation process runs as the service account:
+const svc = await createNoydb({ store, user: 'svc-insights', secret: SVC_PASSPHRASE })
+const firm = await svc.openVaultGroup('firm-clients', { sharding })
+firm.withCrossVaultDerivation({ source: 'invoices', target, derive })
+await firm.refreshInsights()   // reads only what it's granted; writes only the summary
+```
+
+A shard the service account isn't granted → a `'no-grant'` skip (already handled);
+revoking its grant cleanly drops that shard from future refreshes. Every write is
+actor-stamped (`_by = 'svc-insights'`) for a clean audit trail.
+
+**Write isolation (enforced).** `withCrossVaultDerivation` throws a
+`ValidationError` if `target.vault` is the group itself or one of its shards
+(`<group>--<key>`) — a summary must never write back into client-shard data, which
+would breach the per-shard DEK boundary. The target must be a separate vault.
+
 ## Fleet schema migration (#271)
 
 When the template's `version` bumps (new schema + a `coordinatedCutover`

--- a/docs/superpowers/specs/2026-06-14-cross-vault-dek-grant-executor-identity-design.md
+++ b/docs/superpowers/specs/2026-06-14-cross-vault-dek-grant-executor-identity-design.md
@@ -1,6 +1,8 @@
 # Cross-vault DEK-grant executor identity — Insight Vault (#271)
 
-> **Status:** DESIGN — awaiting maintainer decision (see § Decision).
+> **Status:** ACCEPTED + BUILT (0.2.0-pre.19 cycle) — recommendation adopted:
+> documented the service-account least-privilege pattern + shipped Hardening 2
+> (Insight-write isolation guard). Hardening 1 (no) and 3 (defer) unchanged.
 > **Context:** the Insight Vault (#271 Layer 4, PR #391) shipped with the
 > derivation running under the **caller's** `Noydb`. This pins down the
 > least-privilege production identity for that executor.

--- a/packages/hub/__tests__/federation-insight-vault.test.ts
+++ b/packages/hub/__tests__/federation-insight-vault.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
-import { ConflictError } from '../src/errors.js'
+import { ConflictError, ValidationError } from '../src/errors.js'
 import { createNoydb } from '../src/noydb.js'
 import type { Noydb } from '../src/noydb.js'
 import type { Vault } from '../src/vault.js'
@@ -82,6 +82,32 @@ describe('Insight Vault — withCrossVaultDerivation / refreshInsights (#271)', 
       }),
     })
   }
+
+  it('refuses a target.vault that is the group itself or one of its shards (Insight-write isolation)', () => {
+    // The group is 'firm-clients'; its shards are 'firm-clients--<key>'.
+    expect(() =>
+      h.firm.withCrossVaultDerivation<Invoice, Summary>({
+        source: 'invoices',
+        target: { vault: 'firm-clients', collection: 'x' },
+        derive: () => ({}) as Summary,
+      }),
+    ).toThrow(ValidationError)
+    expect(() =>
+      h.firm.withCrossVaultDerivation<Invoice, Summary>({
+        source: 'invoices',
+        target: { vault: 'firm-clients--acme', collection: 'x' },
+        derive: () => ({}) as Summary,
+      }),
+    ).toThrow(ValidationError)
+    // A separate analytics vault is fine.
+    expect(() =>
+      h.firm.withCrossVaultDerivation<Invoice, Summary>({
+        source: 'invoices',
+        target: { vault: 'firm-insights', collection: 'client-summary' },
+        derive: () => ({}) as Summary,
+      }),
+    ).not.toThrow()
+  })
 
   it('writes one summary row per shard into the Insight Vault', async () => {
     const inv = h.firm.collection<Invoice>('invoices')

--- a/packages/hub/src/federation/vault-group.ts
+++ b/packages/hub/src/federation/vault-group.ts
@@ -243,10 +243,23 @@ export class VaultGroup<T> {
    *
    * v1 is explicit-refresh (no write-path push); call `refreshInsights()`
    * after a batch of writes, or on a schedule.
+   *
+   * The `target.vault` must NOT be the group itself or one of its shards —
+   * a summary writing back into client-shard data would breach the Insight
+   * Vault's separate-DEK-boundary contract. Such a target throws a
+   * `ValidationError` at registration (#271 Insight-write isolation).
    */
   withCrossVaultDerivation<R = Record<string, unknown>, S = Record<string, unknown>>(
     spec: CrossVaultDerivationSpec<R, S>,
   ): void {
+    const target = spec.target.vault
+    if (target === this.name || target.startsWith(`${this.name}${SHARD_SEPARATOR}`)) {
+      throw new ValidationError(
+        `withCrossVaultDerivation: target.vault "${target}" is the "${this.name}" group itself or one of ` +
+          `its shards — an Insight summary must target a SEPARATE analytics vault, never write back into ` +
+          `client-shard data (it would breach the per-shard DEK boundary). Use a distinct vault name.`,
+      )
+    }
     this.crossVaultDerivations.push(spec as unknown as CrossVaultDerivationSpec)
   }
 


### PR DESCRIPTION
Closes the cross-vault DEK-grant executor-identity design (#271). Adds a `ValidationError` guard so an Insight summary can never target the group itself or a shard, and documents the service-account least-privilege pattern. +1 test (insight suite 6→7).