### PR TITLE
feat(federation): data-residency placement guard (#271)

### DIFF
--- a/docs/subsystems/vault-group.md
+++ b/docs/subsystems/vault-group.md
@@ -216,6 +216,46 @@ await firm.migrateShard('acme')
 - **Co-location assumption**: the runner drives co-located shards in-process.
   Per-process/distributed shards are a `by-server` concern, out of scope.
 
+## Data residency (#271)
+
+A regulated firm must keep each client's shard on a backend in a specific region
+(`acme` → EU store, `globex` → US store). Routing already supports this via
+`routeStore({ vaultRoutes })` (vault-name prefix → backend); the residency guard
+adds **enforcement** so a shard can never be *placed* on a wrong-region backend.
+
+```ts
+const eu = /* an EU-region store */, us = /* a US-region store */
+// Backends declare the region they serve:
+eu.capabilities = { ...eu.capabilities, region: 'eu' }
+us.capabilities = { ...us.capabilities, region: 'us' }
+
+const store = routeStore({ vaultRoutes: { 'firm--eu-': eu, 'firm--us-': us }, default: control })
+const firm = await db.openVaultGroup<Client>('firm', {
+  sharding: {
+    keyOf: (r) => r.placementKey,   // region-encoded → routes to the right backend
+    regionOf: (r) => r.region,      // the legally-required residency region
+    vaultTemplate: 'client', autoCreate: true,
+  },
+})
+
+await firm.collection('clients').put('c1', { region: 'eu', placementKey: 'eu-acme', ... })  // ✓ EU
+await firm.collection('clients').put('c2', { region: 'eu', placementKey: 'us-acme', ... })  // ✗ DataResidencyError
+```
+
+- **`StoreCapabilities.region`** (advisory) — a store declares the region it serves;
+  zero behavior change for stores that omit it.
+- **`sharding.regionOf(record)`** — the region a record's shard must live in. On
+  `createShard` (and the auto-creating `put`), the group resolves the candidate
+  backend (`routeStore.resolveBackend(vaultId)` — vault-prefix routing) and throws
+  **`DataResidencyError`** *before provisioning* if the backend's `region` differs.
+- **Placement-only.** Reads aren't blocked (the route already determines the
+  physical backend); the guard prevents wrong-region *placement* — the
+  compliance-relevant event — and loudly catches naming/routing drift.
+- **Convention.** Encode the region in the partition key (`eu-acme`, `us-globex`,
+  within `[A-Za-z0-9._-]`) so `firm--eu-` / `firm--us-` prefixes route. Re-homing
+  an existing shard between regions is out of scope (an `extractPartition` →
+  re-adopt ceremony, #198), not a routing change.
+
 ## Control plane — StateManagement Vault
 
 `openVaultGroup(name)` (no explicit `registry`) auto-opens the reserved

--- a/docs/superpowers/specs/2026-06-14-vaultgroup-data-residency-routing-design.md
+++ b/docs/superpowers/specs/2026-06-14-vaultgroup-data-residency-routing-design.md
@@ -1,6 +1,10 @@
 # VaultGroup data-residency routing constraint (#271)
 
-> **Status:** DESIGN — awaiting maintainer decision (see § Decision).
+> **Status:** ACCEPTED + BUILT (0.2.0-pre.19 cycle) — shipped recommendation
+> 1 + 2 (advisory `StoreCapabilities.region` + `sharding.regionOf` placement
+> guard + `DataResidencyError` + `RoutedNoydbStore.resolveBackend`) and
+> documented 3 (region-encoded partition-key convention). The `shardKey` helper
+> remains optional/deferred.
 > **Context:** the epic flags data-residency (dim11's `region` idea) as an
 > undesigned dependency for regulated MVF deployments. This scopes how a
 > `VaultGroup` routes each shard to a region-appropriate backend and refuses

--- a/features.yaml
+++ b/features.yaml
@@ -1297,6 +1297,8 @@ features:
         path: showcases/src/108-insight-vault.showcase.test.ts
       - id: 109-fleet-migration
         path: showcases/src/109-fleet-migration.showcase.test.ts
+      - id: 110-data-residency
+        path: showcases/src/110-data-residency.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -1307,6 +1309,8 @@ features:
       - 'crossShardJoin is co-partitioned fan-out + central broadcast enrichment; join.ts and its partitionScope seam stay untouched'
       - 'Insight Vault (#271 Layer 4, push model): withCrossVaultDerivation({ source, target, derive }) + refreshInsights() reads each eligible shard, runs derive(records, ctx{vaultId,partitionKey,schemaVersion}) per shard, writes one summary row per shard into the target analytics vault keyed by partitionKey — re-encrypted under the Insight Vault DEK, shard ciphertext never crosses a DEK boundary; respects the minVersion drift guard; failed shard reads → skippedVaults (no stale row); v1 is explicit-refresh (no write-path push). ZK note: Insight Vault backend sees aggregated cross-shard structure — weaker profile than per-shard vaults; opt-in, aggregate scalars only'
       - 'fleet schema migration (#271): migrateFleet({cohort?,batchSize?}) + migrateShard(key) drive each shard through M12 vault.runSchemaCutover() (single-vault protocol internally), then advance the registry schemaVersion and write migration-status to the StateManagement Vault; cohort = staged/canary, batchSize = back-pressure; migrateOnOpen lazily migrates a behind shard on access; resumable/crash-safe (registry version is source of truth — re-run skips current, retries failed); a failed shard cutover is recorded, not fatal'
+      - 'Insight-write isolation (#271): withCrossVaultDerivation throws ValidationError if target.vault is the group itself or one of its shards (<group>--<key>) — a summary must never write back into client-shard data (per-shard DEK boundary). Least-privilege executor = a service account granted read-on-shards + write-on-Insight only (grant()+createNoydb wiring, no hub change)'
+      - 'data-residency placement guard (#271): sharding.regionOf(record) + advisory StoreCapabilities.region; on createShard the group resolves the placement backend (routeStore.resolveBackend via vault-prefix routing) and throws DataResidencyError before provisioning if the backend region != regionOf — so a shard never lands on a non-compliant backend. Advisory until a region is declared; reads are unaffected (placement-only constraint); re-homing an existing shard is out of scope (extractPartition ceremony)'
     related: [permissions, transferable-partition, derivations, schema-and-refs]
 
 # ─── Storage adapters (phase 2) ──────────────────────────────────────

--- a/packages/hub/__tests__/federation-data-residency.test.ts
+++ b/packages/hub/__tests__/federation-data-residency.test.ts
@@ -1,0 +1,127 @@
+/**
+ * VaultGroup data-residency placement guard (#271).
+ * sharding.regionOf + StoreCapabilities.region + DataResidencyError, on top
+ * of routeStore vault-prefix routing.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot, StoreCapabilities } from '../src/types.js'
+import { ConflictError, DataResidencyError } from '../src/errors.js'
+import { routeStore } from '../src/store/route-store.js'
+import { createNoydb } from '../src/noydb.js'
+import type { Vault } from '../src/vault.js'
+import type { VaultRegistryRow } from '../src/federation/index.js'
+
+function memory(region?: string): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  const capabilities: StoreCapabilities = { casAtomic: false, auth: { kind: 'none', required: false, flow: 'static' }, ...(region ? { region } : {}) }
+  return {
+    name: `memory${region ? `-${region}` : ''}`,
+    capabilities,
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+// A record carries its required region; `routeKey` lets a test deliberately
+// drive a routing/region MISMATCH (key routes one way, regionOf says another).
+interface Doc extends Record<string, unknown> { id: string; region: string; routeKey?: string }
+
+async function harness() {
+  // Region-encoded shard ids: `firm--eu-*` → EU backend, `firm--us-*` → US.
+  const eu = memory('eu')
+  const us = memory('us')
+  const control = memory() // no region — the registry/state vault lives here
+  const store = routeStore({ vaultRoutes: { 'firm--eu-': eu, 'firm--us-': us }, default: control })
+  const db = await createNoydb({ store, user: 'operator', secret: 'op-pass' })
+  db.withVaultTemplate('client', { version: 1, configure: (v: Vault) => { v.collection<Doc>('docs') } })
+  const stateVault = await db.openVault('state')
+  const registry = stateVault.collection<VaultRegistryRow>('vault-registry')
+  const firm = await db.openVaultGroup<Doc>('firm', {
+    registry,
+    sharding: {
+      keyOf: (r) => r.routeKey ?? `${r.region}-${r.id}`,
+      regionOf: (r) => r.region,
+      vaultTemplate: 'client',
+      autoCreate: true,
+    },
+  })
+  return { db, firm, eu, us }
+}
+
+describe('VaultGroup data-residency placement guard (#271)', () => {
+  let h: Awaited<ReturnType<typeof harness>>
+  beforeEach(async () => { h = await harness() })
+
+  it('allows a shard whose placement backend region matches regionOf', async () => {
+    await h.firm.collection<Doc>('docs').put('a1', { id: 'acme', region: 'eu' }) // key eu-acme → firm--eu-acme → EU
+    const acme = await h.firm.shard('eu-acme')
+    expect((await acme.collection<Doc>('docs').get('a1'))?.region).toBe('eu')
+  })
+
+  it('refuses a shard landing on a wrong-region backend (DataResidencyError, before provisioning)', async () => {
+    // routeKey 'us-acme' routes to the US backend, but regionOf says 'eu' → mismatch.
+    await expect(
+      h.firm.collection<Doc>('docs').put('x1', { id: 'acme', region: 'eu', routeKey: 'us-acme' }),
+    ).rejects.toBeInstanceOf(DataResidencyError)
+    // Nothing was provisioned.
+    await expect(h.firm.shard('us-acme')).rejects.toThrow()
+  })
+
+  it('refuses when the backend declares no region at all', async () => {
+    // key 'xx-acme' matches neither prefix → default (control, no region); regionOf 'eu' → mismatch.
+    await expect(
+      h.firm.collection<Doc>('docs').put('y1', { id: 'acme', region: 'eu', routeKey: 'xx-acme' }),
+    ).rejects.toBeInstanceOf(DataResidencyError)
+  })
+
+  it('is a no-op without regionOf — placement unguarded', async () => {
+    const eu = memory('eu')
+    const store = routeStore({ vaultRoutes: { 'plain--': eu }, default: memory() })
+    const db = await createNoydb({ store, user: 'op', secret: 'op-pass' })
+    db.withVaultTemplate('client', { version: 1, configure: (v: Vault) => { v.collection<Doc>('docs') } })
+    const sv = await db.openVault('state')
+    const firm = await db.openVaultGroup<Doc>('plain', {
+      registry: sv.collection<VaultRegistryRow>('vault-registry'),
+      sharding: { keyOf: (r) => r.id, vaultTemplate: 'client', autoCreate: true }, // no regionOf
+    })
+    await firm.collection<Doc>('docs').put('z1', { id: 'acme', region: 'eu' }) // no guard → succeeds
+    expect((await (await firm.shard('acme')).collection<Doc>('docs').get('z1'))?.id).toBe('acme')
+    db.close()
+  })
+
+  it('resolveBackend maps a vault id to its region-correct backend', () => {
+    const eu = memory('eu'), us = memory('us'), def = memory()
+    const store = routeStore({ vaultRoutes: { 'firm--eu-': eu, 'firm--us-': us }, default: def })
+    expect(store.resolveBackend('firm--eu-acme').capabilities?.region).toBe('eu')
+    expect(store.resolveBackend('firm--us-globex').capabilities?.region).toBe('us')
+    expect(store.resolveBackend('firm--xx-foo').capabilities?.region).toBeUndefined()
+  })
+})

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -2183,6 +2183,33 @@ export class ShardProvisioningError extends NoydbError {
 }
 
 /**
+ * Thrown by `VaultGroup.createShard` when `sharding.regionOf` resolves a
+ * required region that doesn't match the placement backend's
+ * `capabilities.region` — the shard would land on a non-compliant backend
+ * (data-residency violation, #271). Raised BEFORE provisioning, so no
+ * vault is created.
+ */
+export class DataResidencyError extends NoydbError {
+  readonly vaultId: string
+  readonly requiredRegion: string
+  readonly backendRegion: string | undefined
+
+  constructor(vaultId: string, requiredRegion: string, backendRegion: string | undefined) {
+    super(
+      'DATA_RESIDENCY',
+      `Shard "${vaultId}" requires region "${requiredRegion}" but its placement backend ` +
+        `declares region ${backendRegion === undefined ? '(none)' : `"${backendRegion}"`}. ` +
+        `Refusing to provision — route this shard to a region-correct backend via ` +
+        `routeStore({ vaultRoutes }) (e.g. a region-encoded partition key) before retrying.`,
+    )
+    this.name = 'DataResidencyError'
+    this.vaultId = vaultId
+    this.requiredRegion = requiredRegion
+    this.backendRegion = backendRegion
+  }
+}
+
+/**
  * Thrown by `ShardedQuery.crossShardJoin` / `broadcastJoin` for
  * deterministic, query-shaping errors: an undeclared join ref (which
  * would fail identically on every shard), or calling a deferred

--- a/packages/hub/src/federation/types.ts
+++ b/packages/hub/src/federation/types.ts
@@ -42,6 +42,16 @@ export interface ShardingConfig<T> {
   readonly vaultTemplate: string
   /** When a write targets an unknown partition key, stamp a shard inline. Default `true`. */
   readonly autoCreate?: boolean
+  /**
+   * Data-residency guard (#271): the geographic region a record's shard must
+   * live in (e.g. `'eu'`). When set, `createShard` resolves the candidate
+   * backend (via `routeStore`'s vault-prefix routing) and throws
+   * `DataResidencyError` if its `capabilities.region` doesn't match — so a
+   * shard never lands on a non-compliant backend. Advisory until a region is
+   * declared on the backing store; pair with `routeStore({ vaultRoutes })`
+   * and a region-encoded partition key (e.g. `eu-acme` → `firm--eu-`).
+   */
+  readonly regionOf?: (record: T) => string
 }
 
 /** Options for `Noydb.openVaultGroup`. */

--- a/packages/hub/src/federation/vault-group.ts
+++ b/packages/hub/src/federation/vault-group.ts
@@ -8,7 +8,7 @@ import type { Noydb } from '../noydb.js'
 import type { Vault } from '../vault.js'
 import type { Collection } from '../collection.js'
 import { StateManagementVault } from './state-vault.js'
-import { CrossShardJoinError, ReservedVaultNameError, ShardProvisioningError, UnknownShardError, ValidationError } from '../errors.js'
+import { CrossShardJoinError, DataResidencyError, ReservedVaultNameError, ShardProvisioningError, UnknownShardError, ValidationError } from '../errors.js'
 import { STATE_VAULT_NAME } from './constants.js'
 import { classifyShardSkip } from './classify-skip.js'
 import { applyBroadcastLegs } from './cross-shard-join.js'
@@ -143,14 +143,25 @@ export class VaultGroup<T> {
    * - row + vault present → no-op, return handle
    * - row present, vault gone → ShardProvisioningError
    * - row absent (vault present or not) → open-or-create, configure, write row
+   *
+   * When `region` is given (the routing `put` passes `sharding.regionOf(record)`),
+   * the candidate backend's `capabilities.region` must match or this throws
+   * `DataResidencyError` BEFORE provisioning (#271 data-residency guard).
    */
-  async createShard(partitionKey: string): Promise<Vault> {
+  async createShard(partitionKey: string, region?: string): Promise<Vault> {
     const vaultId = this.shardVaultId(partitionKey)
     const row = await this.registry.get(this.registryId(partitionKey))
     const provisioned = await this.db._shardVaultProvisioned(vaultId)
 
     if (row && !provisioned) throw new ShardProvisioningError(vaultId, partitionKey)
     if (row && provisioned) return this.openShard(partitionKey)
+
+    // Data-residency placement guard: refuse a shard landing on a backend
+    // whose declared region doesn't match the record's required region.
+    if (region !== undefined) {
+      const backendRegion = this.db._resolveBackend(vaultId).capabilities?.region
+      if (backendRegion !== region) throw new DataResidencyError(vaultId, region, backendRegion)
+    }
 
     // Row absent → create (or reconcile a provisioned-but-unregistered vault).
     const vault = await this.db.openVault(vaultId)
@@ -407,7 +418,7 @@ export class ShardedCollection<T, R = T> {
       if (this.group.sharding.autoCreate === false) {
         throw new UnknownShardError(key, this.group.name)
       }
-      vault = await this.group.createShard(key)
+      vault = await this.group.createShard(key, this.group.sharding.regionOf?.(record))
     } else {
       vault = await this.group.openShard(key)
     }

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -330,7 +330,7 @@ export type {
   FleetMigrationResult,
 } from './federation/index.js'
 export { STATE_VAULT_NAME } from './federation/constants.js'
-export { UnknownShardError, ShardProvisioningError, VaultTemplateNotFoundError, ReservedVaultNameError } from './errors.js'
+export { UnknownShardError, ShardProvisioningError, VaultTemplateNotFoundError, ReservedVaultNameError, DataResidencyError } from './errors.js'
 export { ForgetStrategyNotConfiguredError } from './errors.js'
 export { SealedRecordExpiredError, SealedRecordMismatchError, RecordCekNotFoundError } from './errors.js'
 

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -1141,6 +1141,19 @@ export class Noydb {
   }
 
   /**
+   * @internal — the physical backend store a vault id maps to. A
+   * `routeStore` resolves the vault-prefix route via its `resolveBackend`;
+   * a plain store is its own backend. Used by the federation data-residency
+   * guard to read the placement backend's `capabilities.region` (#271).
+   */
+  _resolveBackend(vaultId: string): NoydbStore {
+    const store = this.options.store as NoydbStore & {
+      resolveBackend?: (vaultId: string) => NoydbStore
+    }
+    return store.resolveBackend ? store.resolveBackend(vaultId) : this.options.store
+  }
+
+  /**
    * Change the current user's passphrase for a vault.
    *
    * Validates the new passphrase against the strength rules. Pass

--- a/packages/hub/src/store/route-store.ts
+++ b/packages/hub/src/store/route-store.ts
@@ -276,6 +276,14 @@ export interface RoutedNoydbStore extends NoydbStore {
 
   /** Snapshot the current override/suspend state for diagnostics. */
   routeStatus(): RouteStatus
+
+  /**
+   * Resolve the physical backend a vault id maps to via the geographic
+   * `vaultRoutes` prefix routing (collection-independent), falling back to
+   * the `default` store. Used by the federation data-residency guard (#271)
+   * to read the placement backend's `capabilities.region`.
+   */
+  resolveBackend(vaultId: string): NoydbStore
 }
 
 // ─── Implementation ──────────────────────────────────────────────────────
@@ -671,6 +679,17 @@ export function routeStore(opts: RouteStoreOptions): RoutedNoydbStore {
       const q: Record<string, number> = {}
       for (const [k, v] of writeQueues) q[k] = v.writes.length
       return { overrides: ov, suspended: [...suspended], queued: q }
+    },
+
+    resolveBackend(vaultId: string): NoydbStore {
+      // Geographic routing is vault-prefix based + collection-independent;
+      // the region-relevant backend is the vaultRoutes match, else default.
+      if (opts.vaultRoutes) {
+        for (const [prefix, s] of Object.entries(opts.vaultRoutes)) {
+          if (vaultId.startsWith(prefix)) return s
+        }
+      }
+      return primary
     },
   }
 

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -1663,6 +1663,13 @@ export interface StoreCapabilities {
    * numbering (use CAS `sequence().next()` or per-series).
    */
   serverWriteTime?: boolean
+  /**
+   * Advisory geographic region this store serves (e.g. `'eu'`, `'us'`).
+   * Purely declarative — no behavior change for stores that omit it. The
+   * federation data-residency guard (#271) compares this against a
+   * `sharding.regionOf(record)` to refuse non-compliant shard placement.
+   */
+  region?: string
   auth: StoreAuth
   /**
    * true — the store implements {@link NoydbStore.tx} and commits

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -529,7 +529,11 @@ const KERNEL_SURFACE_BUDGET = {
   // on delete, so the bus observer keeps the index from going stale), plus the
   // forgetStrategy field + forwarding to every Vault. The index crypto + the
   // erasure flow live in src/forget/ and vault.ts.
-  'packages/hub/src/noydb.ts': 3070,
+  // Bumped 3070→3085 (2026-06-14, #271 close-out): `_resolveBackend(vaultId)` —
+  // the store-resolution seam for the data-residency placement guard. It must
+  // live on Noydb (which owns `options.store`); the routing logic itself stays
+  // in src/store/route-store.ts (RoutedNoydbStore.resolveBackend).
+  'packages/hub/src/noydb.ts': 3085,
 }
 
 function checkKernelSurface() {

--- a/showcases/src/110-data-residency.showcase.test.ts
+++ b/showcases/src/110-data-residency.showcase.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Showcase 110 — Data-residency placement guard (VaultGroup)
+ *
+ * What you'll learn
+ * ─────────────────
+ * A regulated firm must keep each client's shard vault on a backend in a
+ * specific region (GDPR / data locality): `eu-*` clients → an EU store,
+ * `us-*` clients → a US store. The federation layer enforces this at
+ * PLACEMENT time — a shard can never be provisioned on a wrong-region backend.
+ *
+ *   1. `routeStore({ vaultRoutes })` routes shard vault ids by name prefix
+ *      to a regional backend (the existing geographic-routing seam).
+ *   2. A backend declares the region it serves via `capabilities.region`.
+ *   3. `sharding.regionOf(record)` states the region a record requires.
+ *   4. On auto-create, the group compares the two and throws
+ *      `DataResidencyError` BEFORE provisioning on a mismatch.
+ *
+ * Why it matters
+ * ──────────────
+ * Residency is a placement invariant, not a runtime filter. Catching a
+ * wrong-region placement loudly — before any client data is written — is the
+ * compliance-relevant event; a region-encoded partition key keeps naming and
+ * routing from drifting silently apart.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 98 (VaultGroup routing).
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → vault-group-federation
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, routeStore, DataResidencyError } from '@noy-db/hub'
+import type { Vault, NoydbStore } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import type { VaultRegistryRow } from '@noy-db/hub'
+
+/** A real in-memory store tagged with the region it serves. */
+function regional(region?: string): NoydbStore {
+  const base = memory()
+  return {
+    ...base,
+    name: `mem${region ? `-${region}` : ''}`,
+    capabilities: { casAtomic: false, auth: { kind: 'none', required: false, flow: 'static' }, ...(region ? { region } : {}) },
+  }
+}
+
+interface Client extends Record<string, unknown> {
+  id: string
+  region: string        // the legally-required residency region
+  placementKey: string  // region-encoded partition key set upstream (can drift → guard catches it)
+  name: string
+}
+
+describe('Showcase 110 — Data-residency placement guard', () => {
+  it('routes EU/US shards to region-correct backends and refuses non-compliant placement', async () => {
+    const eu = regional('eu')
+    const us = regional('us')
+    const control = regional() // registry/state vault — region-neutral
+
+    // Geographic routing by shard-id prefix: firm--eu-* → EU, firm--us-* → US.
+    const store = routeStore({ vaultRoutes: { 'firm--eu-': eu, 'firm--us-': us }, default: control })
+    const db = await createNoydb({ store, user: 'firm-op', secret: 'firm-2026' })
+    db.withVaultTemplate('client', { version: 1, configure: (v: Vault) => { v.collection<Client>('clients') } })
+
+    const state = await db.openVault('state')
+    const firm = await db.openVaultGroup<Client>('firm', {
+      registry: state.collection<VaultRegistryRow>('vault-registry'),
+      sharding: {
+        // Routing follows the upstream-provided placement key; the residency
+        // requirement comes from `region` — the guard catches any drift.
+        keyOf: (r) => r.placementKey,
+        regionOf: (r) => r.region,
+        vaultTemplate: 'client',
+        autoCreate: true,
+      },
+    })
+
+    // ── Compliant placement: each client lands on its region's backend ──
+    await firm.collection<Client>('clients').put('c1', { id: 'acme', region: 'eu', placementKey: 'eu-acme', name: 'Acme GmbH' })
+    await firm.collection<Client>('clients').put('c2', { id: 'globex', region: 'us', placementKey: 'us-globex', name: 'Globex Inc' })
+
+    const acme = await firm.shard('eu-acme')
+    expect((await acme.collection<Client>('clients').get('c1'))?.name).toBe('Acme GmbH')
+
+    // The EU client's data physically lives on the EU backend, not the US one.
+    expect(store.resolveBackend('firm--eu-acme').capabilities?.region).toBe('eu')
+    expect(store.resolveBackend('firm--us-globex').capabilities?.region).toBe('us')
+
+    // ── Non-compliant placement is refused before provisioning ──
+    // An EU-required client whose placement key routes to the US backend
+    // (an upstream mislabel). The guard refuses it before any vault is made.
+    await expect(
+      firm.collection<Client>('clients').put('bad', { id: 'bphar', region: 'eu', placementKey: 'us-bphar', name: 'Mislabeled' }),
+    ).rejects.toBeInstanceOf(DataResidencyError)
+
+    db.close()
+  })
+})


### PR DESCRIPTION
Closes the data-residency-routing design (#271). Adds advisory `StoreCapabilities.region`, `sharding.regionOf`, `RoutedNoydbStore.resolveBackend`, and a `createShard` placement guard that throws `DataResidencyError` before provisioning a shard on a wrong-region backend. Placement-only; reads unaffected. 5 tests + showcase 110 + docs. Pairs with vLannaAi/noy-db#398 to close the vLannaAi/klum-db#12 epic's two design items.