### PR TITLE
fix(forget): purge persisted _idx side-cars on crypto-shred (#401)

### DIFF
--- a/packages/hub/__tests__/forget.test.ts
+++ b/packages/hub/__tests__/forget.test.ts
@@ -30,6 +30,7 @@ import { ConflictError, ForgetStrategyNotConfiguredError } from '../src/errors.j
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
 import { withHistory } from '../src/history/index.js'
 import { withForgetCascade } from '../src/forget/index.js'
+import { withIndexing } from '../src/indexing/index.js'
 import { withCrdt } from '../src/crdt/index.js'
 import { withSync } from '../src/sync/index.js'
 import { sha256Hex } from '../src/history/ledger/entry.js'
@@ -344,5 +345,40 @@ describe('forget — group 9: CRDT-mode tombstone + list() skip do not throw', (
     // skips the shredded record.
     const all = await invoices.list()
     expect(all.map((r) => r.id)).toEqual(['c-2'])
+  })
+})
+
+describe('forget — group 10: persisted _idx side-cars are purged (#401)', () => {
+  it('forget() deletes the _idx side-cars of shredded records, leaving no DEK-decryptable index residue', async () => {
+    const store = memory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: SECRET,
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+      indexStrategy: withIndexing(),
+    })
+    const vault = await db.openVault('v')
+    // Lazy mode (prefetch:false) → durable `_idx/<field>/<recordId>` side-cars.
+    const invoices = vault.collection<Invoice>('invoices', { indexes: ['buyerId'], prefetch: false, cache: { maxRecords: 100 } })
+
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1', amount: 100 })
+    await invoices.put('i-2', { id: 'i-2', buyerId: 'buyer-1', amount: 50 })
+    await invoices.put('i-3', { id: 'i-3', buyerId: 'buyer-2', amount: 999 })
+
+    const idxIds = () => store.rawList('v', 'invoices').filter((k) => k.startsWith('_idx/'))
+    // Side-cars exist for the soon-to-be-forgotten records.
+    expect(idxIds().some((k) => k.endsWith('/i-1'))).toBe(true)
+    expect(idxIds().some((k) => k.endsWith('/i-2'))).toBe(true)
+
+    const result = await vault.forget('buyer-1')
+    expect(result.recordsShredded).toBe(2)
+    expect(result.indexPostingsPurged).toBeGreaterThanOrEqual(2)
+    expect(result.indexResidue).toEqual([])
+
+    // The shredded records' index side-cars are GONE (no value leak under the DEK).
+    expect(idxIds().some((k) => k.endsWith('/i-1'))).toBe(false)
+    expect(idxIds().some((k) => k.endsWith('/i-2'))).toBe(false)
+    // buyer-2's side-car is intact (only the subject's index was purged).
+    expect(idxIds().some((k) => k.endsWith('/i-3'))).toBe(true)
   })
 })

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -3839,6 +3839,35 @@ export class Collection<T> {
   }
 
   /**
+   * @internal — hard-delete this record's persisted `_idx/<field>/<recordId>`
+   * side-cars for the erasure path (#401). `forget()` crypto-shreds the body but
+   * keeps the collection DEK, under which these side-cars are encrypted — so
+   * without this they leave the indexed field VALUES readable after a "forget".
+   *
+   * Content-free: the side-car id is `encodeIdxId(def.key, id)`, so it needs no
+   * body decode (the body is being shredded). Eager mode has no durable side-car
+   * → no-op. The in-memory mirror is left as-is: it is ephemeral (rebuilt from
+   * the now-deleted side-cars on reopen) and live reads skip the tombstone, so a
+   * stale mirror hit cannot surface the erased record. Returns the count deleted
+   * + the `def.key`s whose delete FAILED (residue that still leaks the value).
+   */
+  async _purgePersistedIndexes(id: string): Promise<{ purged: number; residue: string[] }> {
+    const persisted = this.persistedIndexes
+    if (!persisted) return { purged: 0, residue: [] }
+    let purged = 0
+    const residue: string[] = []
+    for (const def of persisted.definitions()) {
+      try {
+        await this.adapter.delete(this.vault, this.name, encodeIdxId(def.key, id))
+        purged++
+      } catch {
+        residue.push(def.key)
+      }
+    }
+    return { purged, residue }
+  }
+
+  /**
    * Bulk-load the persisted-index mirror from `_idx/<field>/*` side-cars
    * on first lazy-mode query. Idempotent — subsequent calls short-circuit
    * on the `persistedIndexesLoaded` flag.

--- a/packages/hub/src/forget/strategy.ts
+++ b/packages/hub/src/forget/strategy.ts
@@ -112,6 +112,20 @@ export interface ForgetResult {
   readonly blobsRetainedShared: number
   /** Collections with blobs that could NOT be crypto-shredded — legacy (no `_cek`) or blobs disabled (see type docs). */
   readonly blobResidueCollections: readonly string[]
+  /**
+   * Count of persisted `_idx/<field>/<recordId>` index side-cars hard-deleted
+   * across the shredded records (#401). These live under the retained
+   * collection DEK, so crypto-shred alone would leave the indexed field VALUES
+   * readable — `forget()` must delete them.
+   */
+  readonly indexPostingsPurged: number
+  /**
+   * `collection:id:field` entries whose persisted `_idx` side-car could NOT be
+   * deleted (#401) — index residue that still leaks the indexed value under the
+   * retained collection DEK. Non-empty means erasure is INCOMPLETE: retry, or
+   * purge the side-car out of band.
+   */
+  readonly indexResidue: readonly string[]
   /** The single `op:'forget'` ledger entry appended for this erasure. */
   readonly ledgerEntry: LedgerEntry
 }

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -2469,6 +2469,8 @@ export class Vault {
     const blobResidueCollections = new Set<string>()
     let blobsShredded = 0
     let blobsRetainedShared = 0
+    let indexPostingsPurged = 0
+    const indexResidue: string[] = []
     const blobsEnabled = this.blobStrategy !== undefined
     const actor = this.keyring.userId
 
@@ -2497,6 +2499,14 @@ export class Vault {
       historyVersionsShredded += await this.historyStrategy.tombstoneHistory(
         this.adapter, this.name, ref.collection, ref.id, actor,
       )
+
+      // Purge the record's persisted `_idx` side-cars (#401): they live under
+      // the retained collection DEK, so crypto-shred alone leaves the indexed
+      // field VALUES readable. Content-free delete; failures → indexResidue.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const idxPurge = await (coll as any)._purgePersistedIndexes(ref.id) as { purged: number; residue: string[] }
+      indexPostingsPurged += idxPurge.purged
+      for (const field of idxPurge.residue) indexResidue.push(`${ref.collection}:${ref.id}:${field}`)
 
       // Blob attachments (#365): crypto-shred the record's erasable blobs.
       // An erasable blob's chunks are under a per-blob content CEK whose only
@@ -2549,6 +2559,8 @@ export class Vault {
         blobsShredded,
         blobsRetainedShared,
         blobResidueCollections: [...blobResidueCollections],
+        indexPostingsPurged,
+        indexResidueCount: indexResidue.length,
       }),
     })
 
@@ -2561,6 +2573,8 @@ export class Vault {
       blobsShredded,
       blobsRetainedShared,
       blobResidueCollections: [...blobResidueCollections],
+      indexPostingsPurged,
+      indexResidue,
       ledgerEntry,
     }
   }

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -457,7 +457,11 @@ const KERNEL_SURFACE_BUDGET = {
   // recompute + onDelete hook are write-path orchestration that must sequence
   // with the existing derivation dispatch; the rollup/trigger registries live
   // in src/derivations/.
-  'packages/hub/src/collection.ts': 4610,
+  // Bumped 4610→4640 (2026-06-14, #401): `_purgePersistedIndexes(id)` — the
+  // erasure-path teardown of a record's `_idx` side-cars that `forget()` calls
+  // (they live under the retained collection DEK, so crypto-shred alone leaves
+  // them readable). Must be on the collection (owns the adapter + index defs).
+  'packages/hub/src/collection.ts': 4640,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -508,7 +512,10 @@ const KERNEL_SURFACE_BUDGET = {
   // #361 per-collection history-ledger scoping (historyConfig on collection()).
   // These are call-site/enforcement seams that must live on the always-on vault;
   // the engines live in src/sequence/, src/refs.ts, and src/links/.
-  'packages/hub/src/vault.ts': 4470,
+  // Bumped 4470→4485 (2026-06-14, #401): forget() now purges each shredded
+  // record's persisted `_idx` side-cars + reports residue (indexPostingsPurged /
+  // indexResidue) — core erasure orchestration alongside the tombstone/blob shred.
+  'packages/hub/src/vault.ts': 4485,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),


### PR DESCRIPTION
Closes #401. `forget()` crypto-shreds the body but kept the collection DEK — under which the persisted `_idx/<field>/<recordId>` side-cars are encrypted — and `_writeTombstone` bypassed the delete-path index teardown, so a forgotten subject's **indexed field values stayed decryptable**. Now `forget()` hard-deletes each shredded record's `_idx` side-cars and reports any residue (`ForgetResult.indexPostingsPurged`/`indexResidue`), mirroring `blobResidueCollections`. Test added; full forget suite green (10). Also a hard prerequisite for #308's blind-index.