### PR TITLE
feat(search): scan-mode full-text search — collection.search() (#308)

### DIFF
--- a/docs/subsystems/search.md
+++ b/docs/subsystems/search.md
@@ -1,0 +1,52 @@
+# Search — full-text / typeahead (#308)
+
+> Status: **preview**. Scan mode only. The store-usable *blind index* (SSE) is a
+> separate, explicitly-gated opt-in — design + leakage analysis in
+> `docs/superpowers/specs/2026-06-14-full-text-search-index-design.md`.
+
+`collection.search(field, query, opts)` ranks records by relevance against a
+tokenized query — moving full-text / typeahead out of userland and into the DB
+**without weakening zero-knowledge**.
+
+```ts
+const hits = await docs.search('title', 'overdue invoice')         // OR, BM25-ranked
+//   → [{ id, score, record }, …]  (best first)
+
+await docs.search('title', 'overdue invoice', { match: 'all' })    // AND
+await docs.search('title', 'mee', { prefix: true })                // typeahead
+await docs.search('title', 'invoice', { limit: 10 })               // top-N
+```
+
+## Scan mode — zero added leakage
+
+Scan mode decrypts the collection in memory and scores client-side (BM25), so
+**nothing searchable is written to the store** — it adds *no* leakage beyond
+what reading the collection already does. It is the safe default, and the right
+choice for sensitive fields (names, notes). Cost is O(n) per query (eager mode
+only), which is appropriate at small/medium scale — the point is to replace a
+hand-rolled userland scan with one call, not to scale to millions of records.
+
+- `match`: `'any'` (default, OR) or `'all'` (AND of query terms).
+- `prefix: true`: the **last** query term matches as a prefix (typeahead).
+- `limit`: return the top-N by score.
+- Returns `{ id, score, record }[]`, descending by score. Deleted / forgotten
+  records never appear (the eager cache is evicted on delete / crypto-shred).
+
+## Tokenization
+
+The default tokenizer is **NFKC-normalize → lowercase → Unicode word-boundary
+split**. It does **not** segment scripts written without inter-word spaces
+(Thai, Lao, Khmer, CJK) — those collapse to one token per run. A
+dictionary/ICU segmenter (pluggable `tokenizer`) is a follow-up; for such data,
+prefer substring matching until then. See the design note.
+
+## Not in scan mode (gated / future)
+
+A **store-usable blind index** (searchable symmetric encryption) would let the
+store narrow candidates without a full scan — but it leaks per-term document
+frequency, co-occurrence, and query access-pattern (a classic SSE profile that
+enables leakage-abuse query-recovery attacks). It is therefore **not** built
+here: it is gated behind an explicit `acknowledgeSearchIndexRisk` opt-in, a
+`forget()` posting-purge (#401), an HMAC token primitive, and an i18n tokenizer
+— all detailed in the design note. Blind-index is **not** appropriate by default
+for sensitive PII.

--- a/features.yaml
+++ b/features.yaml
@@ -248,6 +248,28 @@ features:
       - 'composes with money(): a computed money field is quantized after eval and sums exactly'
     related: [schema-and-refs, money-field]
 
+  - id: search-index
+    name: Scan-mode full-text search (collection.search)
+    cluster: core
+    spec: docs/subsystems/search.md
+    subsystem_doc: docs/subsystems/search.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    experimental: true
+    showcases:
+      - id: 111-scan-search
+        path: showcases/src/111-scan-search.showcase.test.ts
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'collection.search(field, query, opts) is SCAN mode: decrypts in-memory + ranks by BM25 — ZERO added store leakage (eager mode only); returns {id,score,record} desc by score'
+      - 'opts.match any(OR,default)/all(AND); opts.prefix → last query term is a prefix (typeahead); opts.limit → top-N'
+      - 'default tokenizer = NFKC + lowercase + Unicode word-boundary split — does NOT segment Thai/CJK (no inter-word spaces); pluggable tokenizer + a store-usable blind index (SSE; leaks term-frequency/co-occurrence) are gated follow-ups per the #308 design note'
+      - 'deleted / forgotten records never appear (eager cache eviction on delete / _writeTombstone)'
+    related: [schema-and-refs]
+
   - id: persisted-json-schema
     name: Persisted JSON Schema (opt-in)
     cluster: core

--- a/packages/hub/__tests__/search-scan.test.ts
+++ b/packages/hub/__tests__/search-scan.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Scan-mode full-text search — collection.search() (#308).
+ * Zero-leakage client-side BM25 scan; eager mode only.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { ConflictError } from '../src/errors.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { tokenize, searchScan } from '../src/search/index.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) if (!n.startsWith('_')) {
+        const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r
+      }
+      return s
+    },
+    async saveAll(c, data) { for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) } },
+  }
+}
+
+interface Doc extends Record<string, unknown> { id: string; title: string }
+
+describe('tokenize (#308)', () => {
+  it('NFKC-normalizes, lowercases, and splits on word boundaries', () => {
+    expect(tokenize('Overdue  Invoice #42!')).toEqual(['overdue', 'invoice', '42'])
+    expect(tokenize('')).toEqual([])
+  })
+})
+
+describe('searchScan (pure, #308)', () => {
+  const entries = [
+    { id: 'a', record: { title: 'overdue invoice for acme' } },
+    { id: 'b', record: { title: 'paid invoice' } },
+    { id: 'c', record: { title: 'meeting notes' } },
+  ]
+  it('ranks by relevance and supports any/all + limit + prefix', () => {
+    const any = searchScan(entries, 'title', 'invoice')
+    expect(any.map((r) => r.id).sort()).toEqual(['a', 'b'])
+
+    const all = searchScan(entries, 'title', 'overdue invoice', { match: 'all' })
+    expect(all.map((r) => r.id)).toEqual(['a'])
+
+    const top = searchScan(entries, 'title', 'invoice', { limit: 1 })
+    expect(top).toHaveLength(1)
+
+    const pre = searchScan(entries, 'title', 'inv', { prefix: true })
+    expect(pre.map((r) => r.id).sort()).toEqual(['a', 'b'])
+
+    expect(searchScan(entries, 'title', 'zzz')).toEqual([])
+  })
+})
+
+describe('collection.search() (#308)', () => {
+  let coll: Awaited<ReturnType<typeof open>>
+  async function open() {
+    const db = await createNoydb({ store: memory(), user: 'u', secret: 'search-pass-123456' })
+    const vault = await db.openVault('v')
+    const c = vault.collection<Doc>('docs')
+    await c.put('a', { id: 'a', title: 'overdue invoice for acme' })
+    await c.put('b', { id: 'b', title: 'paid invoice' })
+    await c.put('c', { id: 'c', title: 'meeting notes' })
+    return { db, vault, c }
+  }
+  beforeEach(async () => { coll = await open() })
+
+  it('returns ranked {id,score,record} hits', async () => {
+    const hits = await coll.c.search('title', 'invoice')
+    expect(hits.map((h) => h.id).sort()).toEqual(['a', 'b'])
+    expect(hits[0]!.score).toBeGreaterThan(0)
+    expect(hits[0]!.record.title).toContain('invoice')
+  })
+
+  it('typeahead via prefix', async () => {
+    const hits = await coll.c.search('title', 'mee', { prefix: true })
+    expect(hits.map((h) => h.id)).toEqual(['c'])
+  })
+
+  it('does not return a deleted record (cache eviction)', async () => {
+    await coll.c.delete('b')
+    const hits = await coll.c.search('title', 'invoice')
+    expect(hits.map((h) => h.id)).toEqual(['a'])
+  })
+
+  it('throws in lazy mode (scan needs eager)', async () => {
+    const db = await createNoydb({ store: memory(), user: 'u', secret: 'search-pass-123456' })
+    const vault = await db.openVault('v2')
+    const lazy = vault.collection<Doc>('docs', { prefetch: false, cache: { maxRecords: 100 } })
+    await lazy.put('a', { id: 'a', title: 'x' })
+    await expect(lazy.search('title', 'x')).rejects.toThrow(/eager mode/)
+  })
+})

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -46,6 +46,7 @@ import type { PersistedCollectionIndex, PersistedIndexDef } from './indexing/per
 import { LazyQuery } from './indexing/lazy-builder.js'
 import type { LazyQuerySource } from './indexing/lazy-builder.js'
 import { NO_INDEXING, type IndexStrategy, type IndexState } from './indexing/strategy.js'
+import { searchScan, type SearchOptions, type SearchResult } from './search/index.js'
 import { IndexWriteFailureError, DerivationCapExceededError } from './errors.js'
 import { buildUniqueConstraintSet, type UniqueConstraintSet } from './indexing/unique-constraints.js'
 import type { RefDescriptor } from './refs.js'
@@ -2508,6 +2509,31 @@ export class Collection<T> {
       (this.i18nFields !== undefined && Object.keys(this.i18nFields).length > 0) ||
       (this.dictKeyFields !== undefined && Object.keys(this.dictKeyFields).length > 0)
     )
+  }
+
+  /**
+   * Scan-mode full-text search over a plain-text `field` (#308). Decrypts the
+   * collection in memory and ranks records by BM25 against the tokenized query.
+   * **Zero added store leakage** — pure client-side scan; nothing searchable is
+   * written to the store. (A store-usable blind index for at-scale search is a
+   * separate, gated opt-in — see the #308 design note.) Eager mode only.
+   *
+   * `opts.match` (`'any'` default | `'all'`), `opts.prefix` (last query term as
+   * a prefix → typeahead), `opts.limit` (top-N). Returns `{ id, score, record }`
+   * ranked by descending score. The default tokenizer is word-boundary based —
+   * see `src/search/tokenize.ts` for the Thai/CJK caveat.
+   */
+  async search(field: string, query: string, opts: SearchOptions = {}): Promise<SearchResult<T>[]> {
+    if (this.lazy) {
+      throw new Error(
+        `Collection "${this.name}": search() (scan mode) requires eager mode (prefetch: true). ` +
+          `A store-usable blind index for lazy / at-scale search is a separate gated opt-in (#308).`,
+      )
+    }
+    await this.ensureHydrated()
+    const entries: { id: string; record: T }[] = []
+    for (const [id, e] of this.cache) entries.push({ id, record: e.record })
+    return searchScan(entries, field, query, opts)
   }
 
   // ─── Bulk operations ─────────────────────────────────────

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -1028,3 +1028,7 @@ export type {
   GroupedRowN,
   ScanPageProvider,
 } from './query/index.js'
+
+// Scan-mode full-text search (#308)
+export { tokenize } from './search/index.js'
+export type { Tokenizer, SearchOptions, SearchResult, SearchEntry } from './search/index.js'

--- a/packages/hub/src/search/index.ts
+++ b/packages/hub/src/search/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Search subsystem (#308) — scan-mode full-text search.
+ *
+ * Tree-shakeable: only reaches the bundle when `collection.search()` is called.
+ * The store-usable blind index (SSE) is a separate, gated opt-in specified in
+ * the #308 design note and not built here.
+ */
+export { tokenize, type Tokenizer } from './tokenize.js'
+export { searchScan, type SearchOptions, type SearchResult, type SearchEntry } from './scan.js'

--- a/packages/hub/src/search/scan.ts
+++ b/packages/hub/src/search/scan.ts
@@ -1,0 +1,110 @@
+/**
+ * Scan-mode full-text search (#308) — ranks **already-decrypted** records by
+ * BM25 against a tokenized query. Pure client-side: nothing is written to the
+ * store, so this adds **zero** leakage (unlike a store-usable blind index,
+ * which is a separate, gated opt-in — see the #308 design note).
+ *
+ * O(n) over the collection; intended for small/medium collections (the pilot's
+ * scale) where moving the existing userland scan into the DB is the win.
+ */
+import { tokenize, type Tokenizer } from './tokenize.js'
+
+export interface SearchOptions {
+  /** Top-N by score (default: all matches). */
+  readonly limit?: number
+  /** `'any'` (default) = OR of query terms; `'all'` = every term must match. */
+  readonly match?: 'any' | 'all'
+  /** Treat the LAST query term as a prefix (typeahead). */
+  readonly prefix?: boolean
+}
+
+export interface SearchResult<T> {
+  readonly id: string
+  readonly score: number
+  readonly record: T
+}
+
+export interface SearchEntry<T> {
+  readonly id: string
+  readonly record: T
+}
+
+const K1 = 1.2
+const B = 0.75
+
+/** Coerce a field value to searchable text (numbers/booleans stringified). */
+function fieldText(record: unknown, field: string): string {
+  const v = (record as Record<string, unknown>)[field]
+  if (typeof v === 'string') return v
+  if (v === null || v === undefined) return ''
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v)
+  return ''
+}
+
+export function searchScan<T>(
+  entries: ReadonlyArray<SearchEntry<T>>,
+  field: string,
+  query: string,
+  opts: SearchOptions = {},
+  tokenizer: Tokenizer = tokenize,
+): SearchResult<T>[] {
+  const queryTerms = tokenizer(query)
+  if (queryTerms.length === 0) return []
+
+  const match = opts.match ?? 'any'
+  const usePrefix = opts.prefix ?? false
+  const exactTerms = usePrefix ? queryTerms.slice(0, -1) : queryTerms
+  const prefixTerm = usePrefix ? queryTerms[queryTerms.length - 1] : undefined
+
+  // One tokenize pass per doc; collect corpus stats (df, avg length).
+  const docs = entries.map((e) => ({ id: e.id, record: e.record, terms: tokenizer(fieldText(e.record, field)) }))
+  const N = docs.length || 1
+  const df = new Map<string, number>()
+  let totalLen = 0
+  for (const d of docs) {
+    totalLen += d.terms.length
+    for (const t of new Set(d.terms)) df.set(t, (df.get(t) ?? 0) + 1)
+  }
+  const avgdl = totalLen / N || 1
+
+  // Document frequency for the prefix term: docs containing ANY term with it.
+  let prefixDf = 0
+  if (prefixTerm !== undefined) {
+    for (const d of docs) {
+      if (d.terms.some((t) => t.startsWith(prefixTerm))) prefixDf++
+    }
+  }
+
+  const requiredCount = exactTerms.length + (prefixTerm !== undefined ? 1 : 0)
+  const results: SearchResult<T>[] = []
+
+  for (const d of docs) {
+    const tf = new Map<string, number>()
+    for (const t of d.terms) tf.set(t, (tf.get(t) ?? 0) + 1)
+
+    const matched: { tf: number; df: number }[] = []
+    for (const qt of exactTerms) {
+      const c = tf.get(qt) ?? 0
+      if (c > 0) matched.push({ tf: c, df: df.get(qt) ?? 0 })
+    }
+    if (prefixTerm !== undefined) {
+      let ptf = 0
+      for (const [t, c] of tf) if (t.startsWith(prefixTerm)) ptf += c
+      if (ptf > 0) matched.push({ tf: ptf, df: prefixDf })
+    }
+
+    if (matched.length === 0) continue
+    if (match === 'all' && matched.length < requiredCount) continue
+
+    let score = 0
+    for (const m of matched) {
+      const idf = Math.log(1 + (N - m.df + 0.5) / (m.df + 0.5))
+      const denom = m.tf + K1 * (1 - B + B * (d.terms.length / avgdl))
+      score += idf * ((m.tf * (K1 + 1)) / (denom || 1))
+    }
+    results.push({ id: d.id, score, record: d.record })
+  }
+
+  results.sort((a, b) => b.score - a.score)
+  return opts.limit !== undefined ? results.slice(0, opts.limit) : results
+}

--- a/packages/hub/src/search/tokenize.ts
+++ b/packages/hub/src/search/tokenize.ts
@@ -1,0 +1,18 @@
+/**
+ * Default text tokenizer for scan-mode search (#308).
+ *
+ * NFKC-normalize → lowercase → split on Unicode letter/number runs. This is a
+ * word-boundary tokenizer: it does **not** segment scripts written without
+ * inter-word spaces (Thai, Lao, Khmer, CJK) — those collapse to one token per
+ * run. For such data, a dictionary/ICU segmenter is the right `tokenizer`
+ * (the engine takes one as a parameter); substring/`contains` matching is the
+ * pragmatic fallback until then. See the #308 design note.
+ */
+export type Tokenizer = (text: string) => string[]
+
+const WORD = /[\p{L}\p{N}]+/gu
+
+export const tokenize: Tokenizer = (text: string): string[] => {
+  if (!text) return []
+  return text.normalize('NFKC').toLowerCase().match(WORD) ?? []
+}

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -461,7 +461,10 @@ const KERNEL_SURFACE_BUDGET = {
   // erasure-path teardown of a record's `_idx` side-cars that `forget()` calls
   // (they live under the retained collection DEK, so crypto-shred alone leaves
   // them readable). Must be on the collection (owns the adapter + index defs).
-  'packages/hub/src/collection.ts': 4640,
+  // Bumped 4640→4665 (2026-06-14, #308): the thin `collection.search()`
+  // scan-mode entry point (eager-cache iterate + delegate). The tokenizer +
+  // BM25 ranker engine live in the tree-shakeable src/search/ subsystem.
+  'packages/hub/src/collection.ts': 4665,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.

--- a/showcases/src/111-scan-search.showcase.test.ts
+++ b/showcases/src/111-scan-search.showcase.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Showcase 111 — Scan-mode full-text search (collection.search)
+ *
+ * What you'll learn
+ * ─────────────────
+ * Move typeahead / full-text search OUT of userland and INTO the DB — without
+ * weakening zero-knowledge. `collection.search(field, query)` decrypts the
+ * collection in memory and ranks records by BM25 relevance. Nothing searchable
+ * is written to the store, so it adds **zero** leakage.
+ *
+ *   1. ranked results (`{ id, score, record }`, best first)
+ *   2. `match: 'all'` (AND) vs the default `'any'` (OR)
+ *   3. `prefix: true` — the last query term is a prefix (typeahead)
+ *   4. `limit` — top-N
+ *
+ * Why it matters
+ * ──────────────
+ * At pilot scale this replaces a hand-rolled client-side scan with one call,
+ * and keeps the store blind: a *store-usable* blind index (which would leak
+ * term frequency + co-occurrence) is a separate, explicitly-gated opt-in — see
+ * the #308 design note. Scan mode is the safe default for sensitive data.
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → search-index
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+
+interface Doc extends Record<string, unknown> { id: string; title: string }
+
+describe('Showcase 111 — Scan-mode full-text search', () => {
+  it('ranks records by relevance, with AND/OR, prefix typeahead, and limit', async () => {
+    const db = await createNoydb({ store: memory(), user: 'analyst', secret: 'search-2026-passphrase' })
+    const vault = await db.openVault('firm')
+    const docs = vault.collection<Doc>('docs')
+
+    await docs.put('a', { id: 'a', title: 'Overdue invoice for Acme Holdings' })
+    await docs.put('b', { id: 'b', title: 'Paid invoice — Globex' })
+    await docs.put('c', { id: 'c', title: 'Quarterly meeting notes' })
+
+    // OR (default): any query term matches → ranked best-first.
+    const anyHits = await docs.search('title', 'invoice')
+    expect(anyHits.map((h) => h.id).sort()).toEqual(['a', 'b'])
+    expect(anyHits[0]!.score).toBeGreaterThan(0)
+
+    // AND: every term must be present.
+    const andHits = await docs.search('title', 'overdue invoice', { match: 'all' })
+    expect(andHits.map((h) => h.id)).toEqual(['a'])
+
+    // Typeahead: 'mee' matches 'meeting' as a prefix.
+    const typeahead = await docs.search('title', 'mee', { prefix: true })
+    expect(typeahead.map((h) => h.id)).toEqual(['c'])
+
+    // Top-N.
+    expect(await docs.search('title', 'invoice', { limit: 1 })).toHaveLength(1)
+
+    db.close()
+  })
+})


### PR DESCRIPTION
Builds the **zero-leakage** half of #308 (per the adversarial design review): `collection.search(field, query, opts)` decrypts in-memory and ranks by BM25 — moving typeahead/full-text into the DB without weakening zero-knowledge. The store-usable **blind index (SSE)** stays gated (prereqs: #401, HMAC token, i18n tokenizer) and is NOT built here.

- `src/search/` (tree-shakeable): `tokenize` (NFKC+lowercase+Unicode word-split) + `searchScan` (BM25; `match` any/all; `prefix` typeahead; `limit`).
- `collection.search()`: thin eager-mode entry; `{id,score,record}` ranked; throws in lazy mode; deleted/forgotten records never surface.
- Subsystem doc `docs/subsystems/search.md`, showcase 111, `features.yaml` `search-index` (preview/experimental). Tests: 6 + showcase.

Tokenizer caveat: default word-split doesn't segment Thai/CJK — pluggable tokenizer is a documented follow-up. Pairs with the design note (#400) and #401.