### PR TITLE
feat(i18n): mv-layer resolution for UNION materialized views (#285 MV slice)

### DIFF
--- a/docs/subsystems/i18n.md
+++ b/docs/subsystems/i18n.md
@@ -79,13 +79,19 @@ i18nText({
 })
 ```
 
-> **Current wiring:** the `read` (`get`/`list`), `guard` and `derivation`
-> layers are enforced — guard / derivation `ctx.vault` reads resolve under
-> their own layer policy (`guard` defaults to the lenient `'substitute'`).
-> The `mv`, `join` and `export` layers are **not yet wired**: mv/join read
-> raw `{locale}` maps in the query/aggregate pipeline (no resolution call
-> site), so injecting resolution there is a tracked follow-up (#285 D2/D3,
-> milestone #18).
+> **Current wiring:** the `read` (`get`/`list`), `guard`, `derivation` and
+> `mv` layers are enforced — guard / derivation `ctx.vault` reads resolve under
+> their own layer policy (`guard` defaults to the lenient `'substitute'`). The
+> `mv` layer fires for **UNION** materialized views that declare
+> `{ i18nLocale, i18nFields }`: group-key i18n fields resolve at the `mv` layer
+> before bucketing, so buckets are stable strings (grouping a raw i18n field
+> without a locale throws `LocaleNotSpecifiedError` — group by a `dictKey`/
+> `staticDict` code instead, and resolve the label at read). i18n fields merely
+> *carried through* an MV stay raw — declare them on the **output collection**
+> and they resolve per-reader at read time. The `join` and `export` layers, and
+> query-form MV grouping, are **not yet wired** (the query pipeline carries no
+> locale channel) — tracked follow-ups (#285 §3 join/query-locale + export,
+> milestone #18). Design: `docs/superpowers/specs/2026-06-13-i18n-mv-join-layer-design.md`.
 
 **Script enforcement (`script`, `onScriptViolation`).** Write-time
 per-locale validation. `script: 'auto'` infers allowed Unicode scripts

--- a/features.yaml
+++ b/features.yaml
@@ -564,7 +564,7 @@ features:
       - 'resolveLabel(key, locale, fallback) walks the fallback chain'
       - 'No transliteration (locale-specific lossy mappings stay in userland)'
       - 'i18nField paths support dot notation (address.lineOne) and array wildcards (contacts[].title)'
-      - 'onMissing policy (substitute/null/throw) is per-layer; default throw preserves legacy behavior; read+guard+derivation layers wired (guard/derivation ctx.vault reads resolve under their own policy, guard defaults to substitute); mv/join/export still tracked follow-ups (#285 D2/D3 — query pipeline reads raw maps)'
+      - 'onMissing policy (substitute/null/throw) is per-layer; default throw preserves legacy behavior; read+guard+derivation+mv layers wired (guard/derivation ctx.vault reads resolve under their own policy, guard defaults to substitute; mv = UNION MV {i18nLocale,i18nFields} resolves group-key i18n fields at the mv layer before bucketing, grouping a raw i18n field w/o locale throws LocaleNotSpecifiedError, carried-through i18n stays raw + resolves at the output collection on read); join/export + query-form MV grouping still tracked follow-ups (#285 §3 — query pipeline carries no locale)'
       - 'substitute: declared ordered preferred-locale chain; caller fallback overrides it per read'
       - 'script enforcement is asymmetric-Latin: non-Latin locales also allow Latin (embedded brand/building names); Latin locales reject other scripts; Common/Inherited/Mark always allowed'
       - 'onScriptViolation reject (default) | filter | warn; ScriptViolationError distinct from MissingTranslationError / LocaleNotSpecifiedError'

--- a/packages/hub/__tests__/materialized-views/i18n.test.ts
+++ b/packages/hub/__tests__/materialized-views/i18n.test.ts
@@ -1,0 +1,133 @@
+/**
+ * i18n per-layer resolution for materialized views (#285 MV slice).
+ *  §1 display  — MVs preserve raw i18n maps; declare the field on the OUTPUT
+ *                collection → resolves per-reader at read time (no engine change).
+ *  §2 compute  — UNION MV `i18nLocale` + `i18nFields` resolve group-key i18n
+ *                fields at the `mv` layer BEFORE bucketing → stable buckets.
+ *  guard       — grouping by a raw i18n field without `i18nLocale` throws.
+ *  registration— i18nLocale/i18nFields are UNION-only (query-form throws).
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withMaterializedView } from '../../src/index.js'
+import { withAggregate } from '../../src/aggregate/index.js'
+import { sum } from '../../src/aggregate/reducers.js'
+import { i18nText } from '../../src/i18n/core.js'
+import { withI18n } from '../../src/i18n/index.js'
+import { LocaleNotSpecifiedError, MaterializedViewConfigError } from '../../src/errors.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none', required: false, flow: 'static' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter((key) => key.startsWith(prefix)).map((key) => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vn, cn, id] = key.split('/')
+        if (vn === v) { out[cn!] = out[cn!] ?? {}; out[cn!]![id!] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) for (const i of Object.keys(payload[c]!)) data.set(k(v, c, i), payload[c]![i]!)
+    },
+  }
+}
+
+interface Product extends Record<string, unknown> { id: string; category: Record<string, string> }
+interface CatCount extends Record<string, unknown> { category: unknown; n: number }
+const CATEGORY = i18nText({ languages: ['en', 'th'], required: 'all' })
+const SECRET = 'mv-i18n-layer-slice-passphrase-2026'
+
+describe('MV i18n — §2 compute (i18nLocale resolves group keys at the mv layer)', () => {
+  it('groups by the resolved i18n label when i18nLocale + i18nFields are declared', async () => {
+    const mv = withMaterializedView<CatCount>({
+      name: 'catCounts',
+      unionSources: [{ collection: 'products', map: (r) => ({ category: r.category, n: 1 }) }],
+      groupBy: 'category',
+      aggregate: { n: sum('n') },
+      i18nLocale: 'en',
+      i18nFields: { category: CATEGORY },
+      rowKey: (row) => String(row.category),
+      refresh: 'manual',
+    })
+    const db = await createNoydb({ store: memory(), user: 'a', secret: SECRET, materializedViewStrategies: [mv], aggregateStrategy: withAggregate(), i18nStrategy: withI18n() })
+    const vault = await db.openVault('v')
+    const products = vault.collection<Product>('products', { i18nFields: { category: CATEGORY } })
+    await products.put('p1', { id: 'p1', category: { en: 'Food', th: 'อาหาร' } })
+    await products.put('p2', { id: 'p2', category: { en: 'Food', th: 'อาหาร' } })
+    await products.put('p3', { id: 'p3', category: { en: 'Toys', th: 'ของเล่น' } })
+
+    await vault.refreshView('catCounts')
+
+    const out = vault.collection<CatCount>('catCounts')
+    expect((await out.get('Food'))?.n).toBe(2)   // bucketed by the resolved 'en' label
+    expect((await out.get('Toys'))?.n).toBe(1)
+  })
+})
+
+describe('MV i18n — guard (grouping a raw i18n field without a locale)', () => {
+  it('throws LocaleNotSpecifiedError rather than bucketing on a raw locale map', async () => {
+    const mv = withMaterializedView<CatCount>({
+      name: 'badCounts',
+      unionSources: [{ collection: 'products', map: (r) => ({ category: r.category, n: 1 }) }],
+      groupBy: 'category',
+      aggregate: { n: sum('n') },
+      rowKey: (row) => String(row.category),
+      refresh: 'manual',
+    })
+    const db = await createNoydb({ store: memory(), user: 'a', secret: SECRET, materializedViewStrategies: [mv], aggregateStrategy: withAggregate(), i18nStrategy: withI18n() })
+    const vault = await db.openVault('v')
+    const products = vault.collection<Product>('products', { i18nFields: { category: CATEGORY } })
+    await products.put('p1', { id: 'p1', category: { en: 'Food', th: 'อาหาร' } })
+
+    await expect(vault.refreshView('badCounts')).rejects.toBeInstanceOf(LocaleNotSpecifiedError)
+  })
+})
+
+describe('MV i18n — §1 display (resolve-at-output)', () => {
+  it('preserves the raw i18n map through the MV; the OUTPUT collection resolves per-reader', async () => {
+    interface Label extends Record<string, unknown> { id: string; label: Record<string, string> }
+    const mv = withMaterializedView<Label>({
+      name: 'productLabels',
+      unionSources: [{ collection: 'products', map: (r) => ({ id: r.id as string, label: r.category }) }],
+      rowKey: (row) => row.id,
+      refresh: 'manual',
+    })
+    const db = await createNoydb({ store: memory(), user: 'a', secret: SECRET, materializedViewStrategies: [mv], aggregateStrategy: withAggregate(), i18nStrategy: withI18n() })
+    const vault = await db.openVault('v')
+    const products = vault.collection<Product>('products', { i18nFields: { category: CATEGORY } })
+    // Declare the i18n field on the OUTPUT collection → read-time resolution.
+    vault.collection<Label>('productLabels', { i18nFields: { label: CATEGORY } })
+    await products.put('p1', { id: 'p1', category: { en: 'Food', th: 'อาหาร' } })
+
+    await vault.refreshView('productLabels')
+
+    const out = vault.collection<Label>('productLabels')
+    expect((await out.get('p1', { locale: 'en' }))?.label).toBe('Food')
+    expect((await out.get('p1', { locale: 'th' }))?.label).toBe('อาหาร')
+    expect((await out.get('p1'))?.label).toEqual({ en: 'Food', th: 'อาหาร' }) // locale-less → raw map preserved
+  })
+})
+
+describe('MV i18n — registration (union-only)', () => {
+  it('rejects i18nLocale on a query-form MV (#285 §3 deferred)', () => {
+    expect(() =>
+      withMaterializedView<CatCount>({
+        name: 'q',
+        query: (db) => db.collection<CatCount>('products').query() as never,
+        i18nLocale: 'en',
+        rowKey: (row) => String(row.category),
+        refresh: 'manual',
+      }),
+    ).toThrow(MaterializedViewConfigError)
+  })
+})

--- a/packages/hub/src/i18n/core.ts
+++ b/packages/hub/src/i18n/core.ts
@@ -121,14 +121,16 @@ export interface I18nTextOptions {
    * export). Default `'throw'` — today's behavior, zero breaking change.
    * See {@link OnMissingPolicy}.
    *
-   * NOTE (current wiring): the `read` (`get`/`list`), `guard` and
-   * `derivation` layers are enforced — guard / derivation `ctx.vault`
-   * reads resolve under their own layer policy (`guard` defaults to the
-   * lenient `'substitute'`). The `mv`, `join` and `export` layers are NOT
-   * yet wired: mv/join read raw `{locale}` maps in the query/aggregate
-   * pipeline (no resolution call site), so injecting resolution there is a
-   * tracked follow-up (#285 D2/D3). Until then those reads observe the raw
-   * map, not this policy.
+   * NOTE (current wiring): the `read` (`get`/`list`), `guard`, `derivation`
+   * and `mv` layers are enforced. Guard / derivation `ctx.vault` reads resolve
+   * under their own layer policy (`guard` defaults to the lenient
+   * `'substitute'`). The `mv` layer fires for UNION materialized views that
+   * declare `{ i18nLocale, i18nFields }` (group-key i18n fields resolve at the
+   * `mv` layer before bucketing; grouping a raw i18n field without a locale
+   * throws). The `join` and `export` layers — and query-form MV grouping — are
+   * NOT yet wired: those reads observe the raw `{locale}` map (query pipeline
+   * carries no locale channel), a tracked follow-up (#285 §3 join/query-locale,
+   * + export).
    */
   readonly onMissing?: OnMissingPolicy
   /**

--- a/packages/hub/src/materialized-views/executor.ts
+++ b/packages/hub/src/materialized-views/executor.ts
@@ -1,12 +1,13 @@
 import type { Collection } from '../collection.js'
 import type { TxContext } from '../tx/transaction.js'
 import type { EncryptedEnvelope } from '../types.js'
-import { MaterializedViewTooLargeError } from '../errors.js'
+import { MaterializedViewTooLargeError, LocaleNotSpecifiedError } from '../errors.js'
 import type { MaterializedFromMeta, MVQueryContext, MaterializedViewStrategy } from './types.js'
 import type { RegisteredMV } from './registry.js'
 import { wrapDbWithPredicates } from './registry.js'
 import { groupAndReduce } from '../aggregate/groupby.js'
 import { canonicalGroupKey } from '../aggregate/canonical-key.js'
+import { applyI18nLocale, type I18nTextDescriptor } from '../i18n/core.js'
 
 /**
  * Accessor shape passed in from the owning Vault. Mirrors v1's
@@ -130,6 +131,40 @@ async function materializeUnionResult<TRow extends Record<string, unknown>>(
 
   const groupFields: readonly string[] =
     typeof spec.groupBy === 'string' ? [spec.groupBy] : spec.groupBy
+
+  // #285 §2/§4 — i18n-aware group keys. An `i18nText` group field carries a raw
+  // `{ locale: string }` map, an unstable object key. When `i18nLocale` is
+  // declared (with `i18nFields` describing those fields), resolve the declared
+  // group-key i18n fields to it at the `mv` layer FIRST — the same unified-rows
+  // boundary where money is threaded — so buckets are stable strings and the
+  // `mv`-layer `onMissing` policy fires here.
+  if (spec.i18nLocale !== undefined && spec.i18nFields !== undefined) {
+    const groupI18n: Record<string, I18nTextDescriptor> = {}
+    for (const f of groupFields) {
+      const d = spec.i18nFields[f]
+      if (d !== undefined) groupI18n[f] = d
+    }
+    if (Object.keys(groupI18n).length > 0) {
+      for (let i = 0; i < unified.length; i++) {
+        unified[i] = applyI18nLocale(unified[i] as Record<string, unknown>, groupI18n, spec.i18nLocale, undefined, 'mv') as TRow
+      }
+    }
+  }
+  // Guard (always): a remaining object-valued group key — an undeclared i18n
+  // field or a locale-less MV — would bucket on a map. Refuse, don't bucket wrong.
+  for (const f of groupFields) {
+    for (const row of unified) {
+      const v = (row as Record<string, unknown>)[f]
+      if (v !== null && typeof v === 'object') {
+        throw new LocaleNotSpecifiedError(
+          f,
+          `Materialized view "${spec.name}" groups by "${f}", whose value is a raw i18n locale map — ` +
+            `an unstable object group key. Declare { i18nLocale, i18nFields } on the MV to resolve it at ` +
+            `the 'mv' layer, or group by a dictKey/staticDict code (the stable key) and resolve the label at read time.`,
+        )
+      }
+    }
+  }
 
   // groupBy without aggregate — dedupe by composite key, keep first
   // seen row per key. Useful for cross-arm uniqueness (e.g. unify two

--- a/packages/hub/src/materialized-views/types.ts
+++ b/packages/hub/src/materialized-views/types.ts
@@ -3,6 +3,7 @@ import type { Collection } from '../collection.js'
 import type { AggregateSpec } from '../aggregate/aggregation.js'
 import type { JoinStrategy } from '../query/join.js'
 import type { MoneyDescriptor } from '../money/descriptor.js'
+import type { I18nTextDescriptor } from '../i18n/core.js'
 
 /**
  * Minimal vault-shaped accessor passed to the MV `query()` callback.
@@ -209,6 +210,35 @@ export interface MaterializedViewStrategy<TRow extends Record<string, unknown>> 
    * if declared alone.
    */
   moneyFields?: Record<string, MoneyDescriptor>
+  /**
+   * Compute-time i18n resolution locale (#285, `mv` layer). UNION-mode only.
+   *
+   * An MV that **groups by** an `i18nText` field would otherwise bucket on the
+   * raw `{ locale: string }` map — an unstable object key. Set `i18nLocale`
+   * (with {@link i18nFields} describing those fields) and, before grouping, the
+   * executor resolves each declared i18n group-key field to this locale at the
+   * `mv` layer (`resolvePolicy(onMissing, 'mv')`), so buckets are stable strings.
+   *
+   * This is the **compute** path only: i18n fields *carried through* for display
+   * stay raw — declare them on the OUTPUT collection and they resolve per-reader
+   * at read time (the resolve-at-output model). Without `i18nLocale`, grouping by
+   * a raw i18n field throws `LocaleNotSpecifiedError` (steer: group by a
+   * `dictKey`/`staticDict` code — the stable key — and label at read).
+   *
+   * Query-form MVs do their own `groupBy` inside the `Query`, which carries no
+   * locale yet (the join/query-locale slice, #285 §3) — so `i18nLocale` /
+   * `i18nFields` on a query-form MV throw `MaterializedViewConfigError`.
+   */
+  i18nLocale?: string
+  /**
+   * i18n descriptors for UNION-mode compute (#285), keyed by the OUTPUT field
+   * name as it appears in the mapped row (NOT the source field). Mirrors
+   * {@link moneyFields}: the concatenated mapped stream is a plain array with no
+   * collection i18n context, so the descriptor (carrying `onMissing`/`substitute`
+   * /`fallback`) must be declared here for the `mv`-layer resolution that
+   * {@link i18nLocale} drives. Meaningless without `i18nLocale`.
+   */
+  i18nFields?: Record<string, I18nTextDescriptor>
   /**
    * Pure function from a materialized row → stable id used in the
    * output collection. Required — explicit always beats default-with-pitfalls

--- a/packages/hub/src/materialized-views/with-materialized-view.ts
+++ b/packages/hub/src/materialized-views/with-materialized-view.ts
@@ -114,6 +114,17 @@ export function withMaterializedView<TRow extends Record<string, unknown>>(
       )
     }
   }
+  // #285: i18nLocale / i18nFields drive UNION-mode compute-time i18n resolution
+  // (resolve group-key i18n fields before bucketing). The query() form does its
+  // own groupBy inside the Query, which carries no locale yet (#285 §3, deferred)
+  // — so these are UNION-only.
+  if ((spec.i18nLocale !== undefined || spec.i18nFields !== undefined) && !spec.unionSources) {
+    throw new MaterializedViewConfigError(
+      `withMaterializedView "${spec.name}": i18nLocale / i18nFields are UNION-mode only — `
+      + `the query() form groups inside its Query, which carries no locale yet (#285 §3). `
+      + `Group by a dictKey/staticDict code in the query form, or use unionSources.`,
+    )
+  }
   if (typeof spec.rowKey !== 'function') {
     throw new ValidationError('withMaterializedView: rowKey is required (no default; see spec § Type surface)')
   }


### PR DESCRIPTION
Builds the #285 **MV slice** per `2026-06-13-i18n-mv-join-layer-design.md` — §1 display + §2 compute + §4 mv-onMissing. The join/query-locale slice (§3) stays deferred.

**The problem:** a UNION MV grouping by an `i18nText` field buckets on the raw `{locale}` map (an unstable object key), and `mv:'throw'` had no call site (dead policy).

**This PR:**
- `MaterializedViewStrategy` gains `i18nLocale?` + `i18nFields?` (mirrors `moneyFields`; **UNION-only** — query-form throws `MaterializedViewConfigError`, its grouping is inside the `Query` which carries no locale yet, §3).
- Executor resolves declared **group-key** i18n fields at the `mv` layer **before `groupAndReduce`** (the same unified-rows boundary as `moneyFields`), so buckets are stable strings and `mv` `onMissing` is now live. A remaining object-valued group key → `LocaleNotSpecifiedError` (steer: group by a dictKey/staticDict code).
- **§1 display = resolve-at-output:** MVs preserve raw i18n maps; declare the field on the OUTPUT collection → per-reader read-time resolution (no engine change; conformance-tested).
- Carved the per-layer caveat down: read+guard+derivation+**mv** wired; join/export/query-form pending.

Tests: 4 new (compute / guard / display / registration); **full MV suite green (79)** — no regression to the #350/#291 money/staticDict path. `@noy-db/hub` typecheck + lint + arch + validate:features all green.