### PR TITLE
feat(query): dictKey/staticDict label-sort — orderBy({ by: 'label' }) (#285)

### DIFF
--- a/docs/subsystems/i18n.md
+++ b/docs/subsystems/i18n.md
@@ -132,6 +132,13 @@ stable key is preserved through resolution, so identity operations
 (`groupBy`, dedup) bind to the key even when labels collapse across
 locales (`Mr.`/`Ms.` → `คุณ`).
 
+**Label sort (#285).** Identity binding stays on the code, but when you want
+results *ordered* by the human label, opt in per-call:
+`query().orderBy('status', 'asc', { by: 'label' })` sorts a `dictKey`/`staticDict`
+field by its resolved label at the query locale (`toArray({ locale })`, or a
+`staticDict` `displayLocale` when locale-less), falling back to the code when no
+label resolves. The default `orderBy('status')` still sorts by the stored code.
+
 ## staticDict (code-provided dictionary)
 
 `staticDict(name, table, opts?)` is a sibling to `dictKey` for **closed,

--- a/features.yaml
+++ b/features.yaml
@@ -569,6 +569,7 @@ features:
       - 'script enforcement is asymmetric-Latin: non-Latin locales also allow Latin (embedded brand/building names); Latin locales reject other scripts; Common/Inherited/Mark always allowed'
       - 'onScriptViolation reject (default) | filter | warn; ScriptViolationError distinct from MissingTranslationError / LocaleNotSpecifiedError'
       - 'dictKey array-of-keys resolves to [{key,label}] pair objects; wildcard-path contacts[].title adds per-element <leaf>Label; identity ops bind to the stable key'
+      - 'dictKey label-sort (#285): orderBy(field, dir, {by:"label"}) sorts a dictKey/staticDict field by its resolved label at the query locale (toArray({locale}) or staticDict displayLocale), falling back to the code; default orderBy still sorts by the stored code; identity binding stays on the code'
       - 'staticDict(name, table, {displayLocale}) resolves labels from an in-code table — no _dict_* collection, no rename()'
       - 'static dicts resolve under a locale-less read via displayLocale; plain dictKey does not (locale gate preserved)'
       - 'static dict names are read-only: put/rename/delete throw StaticDictReadonlyError'

--- a/packages/hub/__tests__/query-dictkey-label-sort.test.ts
+++ b/packages/hub/__tests__/query-dictkey-label-sort.test.ts
@@ -1,0 +1,85 @@
+/**
+ * #285 dictKey label-sort — orderBy(field, dir, { by: 'label' }) sorts a
+ * dictKey/staticDict field by its resolved label at the query locale (or a
+ * staticDict displayLocale), not by the stored code.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { ConflictError } from '../src/errors.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { withI18n } from '../src/i18n/index.js'
+import { staticDict } from '../src/i18n/dictionary.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) if (!n.startsWith('_')) {
+        const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r
+      }
+      return s
+    },
+    async saveAll(c, data) { for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) } },
+  }
+}
+
+// Codes 'a1'/'z1' deliberately sort OPPOSITE to their labels:
+//   by code asc → a1, z1   ;   by label(en) asc → z1(Apple), a1(Zebra)
+interface Row extends Record<string, unknown> { id: string; cat: string }
+const CAT = staticDict('cat', {
+  a1: { en: 'Zebra', th: 'ม้าลาย' },
+  z1: { en: 'Apple', th: 'แอปเปิล' },
+}, { displayLocale: 'en' })
+const SECRET = 'dictkey-label-sort-pass-2026'
+
+async function seed() {
+  const db = await createNoydb({ store: memory(), user: 'a', secret: SECRET, i18nStrategy: withI18n() })
+  const vault = await db.openVault('v')
+  const rows = vault.collection<Row>('rows', { dictKeyFields: { cat: CAT } })
+  await rows.put('r-a', { id: 'r-a', cat: 'a1' })
+  await rows.put('r-z', { id: 'r-z', cat: 'z1' })
+  return { rows }
+}
+
+describe('#285 dictKey label-sort', () => {
+  it('default orderBy sorts by the stored code', async () => {
+    const { rows } = await seed()
+    const out = rows.query().orderBy('cat', 'asc').toArray()
+    expect(out.map((r) => r.id)).toEqual(['r-a', 'r-z']) // a1 < z1
+  })
+
+  it('orderBy({ by: "label" }) sorts by the resolved label (staticDict displayLocale, locale-less)', async () => {
+    const { rows } = await seed()
+    const out = rows.query().orderBy('cat', 'asc', { by: 'label' }).toArray()
+    expect(out.map((r) => r.id)).toEqual(['r-z', 'r-a']) // Apple(z1) < Zebra(a1)
+  })
+
+  it('orderBy({ by: "label" }) honors the per-call query locale', async () => {
+    const { rows } = await seed()
+    // th labels sort by code point: ม (U+0E21, ม้าลาย/a1) < แ (U+0E41, แอปเปิล/z1)
+    // → [r-a, r-z], which DIFFERS from the en order [r-z, r-a] → the locale flows.
+    const out = rows.query().orderBy('cat', 'asc', { by: 'label' }).toArray({ locale: 'th' })
+    expect(out.map((r) => r.id)).toEqual(['r-a', 'r-z'])
+  })
+
+  it('desc label-sort reverses', async () => {
+    const { rows } = await seed()
+    const out = rows.query().orderBy('cat', 'desc', { by: 'label' }).toArray()
+    expect(out.map((r) => r.id)).toEqual(['r-a', 'r-z']) // Zebra(a1) > Apple(z1)
+  })
+})

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -24,6 +24,13 @@ import { moneyFieldClause } from '../money/where.js'
 export interface OrderBy {
   readonly field: string
   readonly direction: 'asc' | 'desc'
+  /**
+   * Sort key for a `dictKey`/`staticDict` field (#285): `'value'` (default)
+   * sorts by the stored code; `'label'` sorts by the code's resolved label at
+   * the query locale (`toArray({ locale })`, or a `staticDict` `displayLocale`).
+   * Falls back to the code when no label resolves.
+   */
+  readonly by?: 'value' | 'label'
 }
 
 /**
@@ -304,11 +311,16 @@ export class Query<T> {
     )
   }
 
-  /** Sort by a field. Subsequent calls are tie-breakers. */
-  orderBy(field: string, direction: 'asc' | 'desc' = 'asc'): Query<T> {
+  /**
+   * Sort by a field. Subsequent calls are tie-breakers. Pass
+   * `{ by: 'label' }` to sort a `dictKey`/`staticDict` field by its resolved
+   * label at the query locale instead of the stored code (#285).
+   */
+  orderBy(field: string, direction: 'asc' | 'desc' = 'asc', opts?: { by?: 'value' | 'label' }): Query<T> {
+    const entry: OrderBy = opts?.by === 'label' ? { field, direction, by: 'label' } : { field, direction }
     return new Query<T>(
       this.source as QuerySource<T>,
-      { ...this.plan, orderBy: [...this.plan.orderBy, { field, direction }] },
+      { ...this.plan, orderBy: [...this.plan.orderBy, entry] },
       this.joinContext,
       this.aggregateStrategy,
       this.predicates,
@@ -561,7 +573,7 @@ export class Query<T> {
     // query().toArray() matches get()/sum(), which already return decimal.
     // Decode the left/base records before joins (right-side aliased fields
     // belong to other collections and are out of this source's money scope).
-    const base = this.decodeMoney(executePlanWithSource(this.source, this.plan, this.joinContext))
+    const base = this.decodeMoney(executePlanWithSource(this.source, this.plan, this.joinContext, opts?.locale))
     if (this.plan.joins.length === 0) return base as T[]
     if (!this.joinContext) {
       // Unreachable in practice — .join() throws if joinContext is
@@ -947,6 +959,7 @@ function executePlanWithSource(
   source: InternalSource,
   plan: QueryPlan,
   joinContext?: JoinContext,
+  locale?: string,
 ): unknown[] {
   const hasCrossJoins = plan.clauses.some(c => c.type === 'crossJoin')
 
@@ -971,7 +984,10 @@ function executePlanWithSource(
   }
 
   if (plan.orderBy.length > 0) {
-    result = sortRecords(result, plan.orderBy, source.moneyFields)
+    // #285 dictKey label-sort: for any `orderBy(..., { by: 'label' })`, build a
+    // sync code→label map at the query locale so the sort compares labels.
+    const labelMaps = buildOrderLabelMaps(plan.orderBy, joinContext, locale)
+    result = sortRecords(result, plan.orderBy, source.moneyFields, labelMaps)
   }
   if (plan.offset > 0) {
     result = result.slice(plan.offset)
@@ -1226,12 +1242,23 @@ function sortRecords(
   records: unknown[],
   orderBy: readonly OrderBy[],
   moneyFields?: Record<string, MoneyDescriptor>,
+  labelMaps?: Map<string, Map<string, string>>,
 ): unknown[] {
   // Stable sort: Array.prototype.sort is required to be stable since ES2019.
   return [...records].sort((a, b) => {
-    for (const { field, direction } of orderBy) {
-      const av = readField(a, field)
-      const bv = readField(b, field)
+    for (const { field, direction, by } of orderBy) {
+      let av = readField(a, field)
+      let bv = readField(b, field)
+      // #285 dictKey label-sort: compare resolved labels (fallback to the code
+      // when unresolved), so e.g. honorific codes sort by their locale label.
+      const labelMap = by === 'label' ? labelMaps?.get(field) : undefined
+      if (labelMap) {
+        av = (typeof av === 'string' ? labelMap.get(av) : undefined) ?? av
+        bv = (typeof bv === 'string' ? labelMap.get(bv) : undefined) ?? bv
+        const cmp = compareValues(av, bv)
+        if (cmp !== 0) return direction === 'asc' ? cmp : -cmp
+        continue
+      }
       // Money fields are stored as scaled-integer strings (#322); the generic
       // string comparator would sort them lexically ('9882' > '10004'). Compare
       // declared money fields by their BigInt scaled value instead — exact, and
@@ -1242,6 +1269,39 @@ function sortRecords(
     }
     return 0
   })
+}
+
+/**
+ * #285 dictKey label-sort: for each `orderBy(..., { by: 'label' })` field, build
+ * a sync `code → label` map at the query `locale` (falling back to a
+ * `staticDict` `displayLocale`) from the join context's dict source. Fields
+ * with no resolvable dict source are skipped — the sort then falls back to the
+ * stored code for them.
+ */
+function buildOrderLabelMaps(
+  orderBy: readonly OrderBy[],
+  joinContext: JoinContext | undefined,
+  locale: string | undefined,
+): Map<string, Map<string, string>> | undefined {
+  if (!joinContext?.resolveDictSource) return undefined
+  const resolveDict = joinContext.resolveDictSource.bind(joinContext)
+  let maps: Map<string, Map<string, string>> | undefined
+  for (const { field, by } of orderBy) {
+    if (by !== 'label') continue
+    const dictSource = resolveDict(field)
+    if (!dictSource) continue
+    const loc = locale ?? dictSource.displayLocale
+    if (loc === undefined) continue
+    const codeToLabel = new Map<string, string>()
+    for (const entry of dictSource.snapshot()) {
+      const k = (entry as Record<string, unknown>)['key']
+      const labels = (entry as Record<string, unknown>)['labels'] as Record<string, string> | undefined
+      const label = labels?.[loc]
+      if (typeof k === 'string' && typeof label === 'string') codeToLabel.set(k, label)
+    }
+    ;(maps ??= new Map()).set(field, codeToLabel)
+  }
+  return maps
 }
 
 /** Compare two stored money values by BigInt scaled-int; nullish/malformed last (asc). */


### PR DESCRIPTION
Deferred v1.x item: `orderBy(field, dir, { by: 'label' })` sorts a dictKey/staticDict field by its resolved label at the query locale (`toArray({ locale })`, or a staticDict `displayLocale` when locale-less), falling back to the code. Default `orderBy` still sorts by the stored code; **identity binding stays on the code**.

Contained to `query/builder.ts` (OrderBy type + `orderBy()` opts + a sync code→label map threaded into `sortRecords`). Additive — no `by:'label'` → identical behavior. Tests: 4 new + query-join/cross-join/join-i18n green (56).