### PR TITLE
fix(blobs): blob().get() hangs for blobs ≥16KB — stream deadlock (#409)

### DIFF
--- a/packages/hub/__tests__/blob-large-roundtrip.test.ts
+++ b/packages/hub/__tests__/blob-large-roundtrip.test.ts
@@ -1,0 +1,71 @@
+/**
+ * #409 — blob().get() must resolve + round-trip for any size. The bug:
+ * compressBytes/decompressBytes awaited write+close before reading `readable`,
+ * deadlocking once the (decompressed) output exceeded the stream buffer (~16KB).
+ * put succeeded (small compressed output) but get() hung ≥16KB on any store.
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+import { createNoydb } from '../src/noydb.js'
+import { withBlobs } from '../src/blobs/index.js'
+
+function makeStore(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function bucket(v: string, c: string) {
+    let m = store.get(v); if (!m) { m = new Map(); store.set(v, m) }
+    let b = m.get(c); if (!b) { b = new Map(); m.set(c, b) }
+    return b
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return bucket(v, c).get(id) ?? null },
+    async put(v, c, id, env, ev) { const b = bucket(v, c); const ex = b.get(id); if (ev !== undefined && (ex?._v ?? 0) !== ev) throw new ConflictError(ex?._v ?? 0); b.set(id, env) },
+    async delete(v, c, id) { bucket(v, c).delete(id) },
+    async list(v, c) { return [...bucket(v, c).keys()] },
+    async loadAll(v) { const m = store.get(v); const s: VaultSnapshot = {}; if (m) for (const [n, c] of m) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of c) r[id] = e; s[n] = r } return s },
+    async saveAll(v, data) { for (const [n, recs] of Object.entries(data)) { const b = bucket(v, n); for (const [id, e] of Object.entries(recs)) b.set(id, e) } },
+  }
+}
+
+/** Reject (instead of hang) if a promise doesn't settle — so a regression fails. */
+function withTimeout<T>(p: Promise<T>, ms = 5000): Promise<T> {
+  return Promise.race([p, new Promise<T>((_, rej) => setTimeout(() => rej(new Error(`timed out after ${ms}ms`)), ms))])
+}
+
+/** Deterministic, low-compressibility-ish payload so round-trip equality is meaningful. */
+function payload(n: number): Uint8Array {
+  const b = new Uint8Array(n)
+  for (let i = 0; i < n; i++) b[i] = (i * 31 + 7) & 0xff
+  return b
+}
+
+describe('#409 — blob get() resolves + round-trips for any size', () => {
+  for (const kb of [8, 16, 64, 256, 1024]) {
+    it(`round-trips a ${kb} KB blob without hanging`, async () => {
+      const db = await createNoydb({ store: makeStore(), user: 'op', secret: 'passphrase-1234-long-enough', blobStrategy: withBlobs() })
+      const vault = await db.openVault('t')
+      const docs = vault.collection<{ id: string }>('docs', { blobFields: { f: {} } })
+      await docs.put('d1', { id: 'd1' })
+
+      const data = payload(kb * 1024)
+      await withTimeout(docs.blob('d1').put('f', data))
+      const got = await withTimeout(docs.blob('d1').get('f'))
+
+      expect(got).not.toBeNull()
+      expect(got!.byteLength).toBe(data.byteLength)
+      expect(Buffer.from(got!).equals(Buffer.from(data))).toBe(true)
+    })
+  }
+
+  it('round-trips a highly-compressible (all-zero) 64 KB blob', async () => {
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: 'passphrase-1234-long-enough', blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs', { blobFields: { f: {} } })
+    await docs.put('d1', { id: 'd1' })
+    const data = new Uint8Array(64 * 1024) // all zeros → tiny compressed → large decompressed output
+    await withTimeout(docs.blob('d1').put('f', data))
+    const got = await withTimeout(docs.blob('d1').get('f'))
+    expect(got?.byteLength).toBe(data.byteLength)
+  })
+})

--- a/packages/hub/src/blobs/blob-set.ts
+++ b/packages/hub/src/blobs/blob-set.ts
@@ -66,11 +66,12 @@ async function compressBytes(
   if (typeof CompressionStream === 'undefined') {
     return { bytes: data, algorithm: 'none' }
   }
-  const cs = new CompressionStream('gzip')
-  const writer = cs.writable.getWriter()
-  await writer.write(data as Uint8Array<ArrayBuffer>)
-  await writer.close()
-  const buf = await new Response(cs.readable).arrayBuffer()
+  // Pipe through the stream so `readable` is drained CONCURRENTLY with the
+  // write. The await-write-then-read form deadlocks once the output exceeds the
+  // stream's internal buffer (the writer backpressures waiting for a reader that
+  // hasn't started yet) — see #409.
+  const piped = new Response(data as Uint8Array<ArrayBuffer>).body!.pipeThrough(new CompressionStream('gzip'))
+  const buf = await new Response(piped).arrayBuffer()
   return { bytes: new Uint8Array(buf), algorithm: 'gzip' }
 }
 
@@ -80,11 +81,11 @@ async function decompressBytes(data: Uint8Array): Promise<Uint8Array> {
       '[noy-db] DecompressionStream not available — cannot decompress blob chunk',
     )
   }
-  const ds = new DecompressionStream('gzip')
-  const writer = ds.writable.getWriter()
-  await writer.write(data as Uint8Array<ArrayBuffer>)
-  await writer.close()
-  const buf = await new Response(ds.readable).arrayBuffer()
+  // Concurrent read via pipeThrough — the await-write-then-read form deadlocks
+  // when the DECOMPRESSED output exceeds the stream buffer (~16 KB), which is
+  // exactly the #409 hang (small compressed input → large output → backpressure).
+  const piped = new Response(data as Uint8Array<ArrayBuffer>).body!.pipeThrough(new DecompressionStream('gzip'))
+  const buf = await new Response(piped).arrayBuffer()
   return new Uint8Array(buf)
 }
 


### PR DESCRIPTION
Closes #409 (high-priority, pilot-3 blocker). `compressBytes`/`decompressBytes` awaited `writer.write()`+`close()` **before** reading the stream's `readable` — once the output exceeds the stream buffer (~16KB) the writer backpressures waiting for a reader that hasn't started → **deadlock**.

That's exactly the reported signature: `put()` OK (compressed output small → no backpressure), `get()` hangs ≥16KB (decompressed output is the full blob); the 8KB/16KB boundary is the writable high-water-mark.

**Fix:** pipe through concurrently — `new Response(bytes).body.pipeThrough(stream)` then read — the deadlock-free pattern already used in `bundle.ts` (`pumpThroughStream`). bundle.ts was already correct; only `blob-set.ts` had the bug.

Test: put+get round-trip at 8/16/64/256 KB + 1 MB + all-zeros 64 KB, each timeout-guarded (a regression fails, not hangs). Blob suite green (74).