### PR TITLE
feat(hub): debug-plaintext store mode — directly-inspectable records (#413 P1)

### DIFF
--- a/packages/hub/__tests__/debug-plaintext-mode.test.ts
+++ b/packages/hub/__tests__/debug-plaintext-mode.test.ts
@@ -1,0 +1,101 @@
+/**
+ * #413 — debug-plaintext store mode. When `encrypt: false` + `debugPlaintext:
+ * true`, user-collection records are written with their fields inlined beside
+ * the envelope metadata (`_debug: 1`, empty `_data`) so native store tooling
+ * reads them directly. Encryption + debug is rejected at construction.
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError, DebugPlaintextError, DebugReservedFieldError } from '../src/errors.js'
+import { createNoydb } from '../src/noydb.js'
+
+function makeStore(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function bucket(v: string, c: string) {
+    let m = store.get(v); if (!m) { m = new Map(); store.set(v, m) }
+    let b = m.get(c); if (!b) { b = new Map(); m.set(c, b) }
+    return b
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return bucket(v, c).get(id) ?? null },
+    async put(v, c, id, env, ev) { const b = bucket(v, c); const ex = b.get(id); if (ev !== undefined && (ex?._v ?? 0) !== ev) throw new ConflictError(ex?._v ?? 0); b.set(id, env) },
+    async delete(v, c, id) { bucket(v, c).delete(id) },
+    async list(v, c) { return [...bucket(v, c).keys()] },
+    async loadAll(v) { const m = store.get(v); const s: VaultSnapshot = {}; if (m) for (const [n, c] of m) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of c) r[id] = e; s[n] = r } return s },
+    async saveAll(v, data) { for (const [n, recs] of Object.entries(data)) { const b = bucket(v, n); for (const [id, e] of Object.entries(recs)) b.set(id, e) } },
+  }
+}
+
+describe('#413 — debug-plaintext store mode', () => {
+  it('rejects debugPlaintext combined with encryption (explicit)', async () => {
+    await expect(
+      createNoydb({ store: makeStore(), user: 'op', secret: 'passphrase-1234-long-enough', encrypt: true, debugPlaintext: true }),
+    ).rejects.toBeInstanceOf(DebugPlaintextError)
+  })
+
+  it('rejects debugPlaintext with default (encryption on)', async () => {
+    await expect(
+      createNoydb({ store: makeStore(), user: 'op', secret: 'passphrase-1234-long-enough', debugPlaintext: true }),
+    ).rejects.toBeInstanceOf(DebugPlaintextError)
+  })
+
+  it('inlines record fields into a directly-inspectable envelope', async () => {
+    const store = makeStore()
+    const db = await createNoydb({ store, user: 'op', encrypt: false, debugPlaintext: true })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string; name: string; n: number }>('docs')
+    await docs.put('d1', { id: 'd1', name: 'Alice', n: 7 })
+
+    // The raw stored envelope is directly readable — no _data unwrap needed.
+    const raw = (await store.get('t', 'docs', 'd1'))! as EncryptedEnvelope & Record<string, unknown>
+    expect(raw._debug).toBe(1)
+    expect(raw._data).toBe('')
+    expect(raw.name).toBe('Alice')
+    expect(raw.n).toBe(7)
+    expect(raw.id).toBe('d1')
+
+    // get() reconstructs the record from the inlined fields.
+    expect(await docs.get('d1')).toEqual({ id: 'd1', name: 'Alice', n: 7 })
+  })
+
+  it('round-trips updates in debug layout', async () => {
+    const db = await createNoydb({ store: makeStore(), user: 'op', encrypt: false, debugPlaintext: true })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string; v: number }>('docs')
+    await docs.put('d1', { id: 'd1', v: 1 })
+    await docs.put('d1', { id: 'd1', v: 2 })
+    expect(await docs.get('d1')).toEqual({ id: 'd1', v: 2 })
+  })
+
+  it('rejects a record with a reserved _-prefixed field', async () => {
+    const db = await createNoydb({ store: makeStore(), user: 'op', encrypt: false, debugPlaintext: true })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<Record<string, unknown>>('docs')
+    await expect(docs.put('d1', { id: 'd1', _secret: 1 })).rejects.toBeInstanceOf(DebugReservedFieldError)
+  })
+
+  it('classic plaintext mode (no debugPlaintext) is unchanged — _data carries the JSON', async () => {
+    const store = makeStore()
+    const db = await createNoydb({ store, user: 'op', encrypt: false })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string; name: string }>('docs')
+    await docs.put('d1', { id: 'd1', name: 'Bob' })
+    const raw = (await store.get('t', 'docs', 'd1'))! as EncryptedEnvelope & Record<string, unknown>
+    expect(raw._debug).toBeUndefined()
+    expect(JSON.parse(raw._data)).toEqual({ id: 'd1', name: 'Bob' })
+    expect(await docs.get('d1')).toEqual({ id: 'd1', name: 'Bob' })
+  })
+
+  it('a debug-written envelope is self-describing — a classic plaintext reader reconstructs it', async () => {
+    const store = makeStore()
+    const dbg = await createNoydb({ store, user: 'op', encrypt: false, debugPlaintext: true })
+    const v1 = await dbg.openVault('t')
+    await v1.collection<{ id: string; name: string }>('docs').put('d1', { id: 'd1', name: 'Carol' })
+
+    // Re-open the same store WITHOUT debug mode; the _debug marker drives reconstruction.
+    const plain = await createNoydb({ store, user: 'op', encrypt: false })
+    const v2 = await plain.openVault('t')
+    expect(await v2.collection<{ id: string; name: string }>('docs').get('d1')).toEqual({ id: 'd1', name: 'Carol' })
+  })
+})

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -47,7 +47,7 @@ import { LazyQuery } from './indexing/lazy-builder.js'
 import type { LazyQuerySource } from './indexing/lazy-builder.js'
 import { NO_INDEXING, type IndexStrategy, type IndexState } from './indexing/strategy.js'
 import { searchScan, type SearchOptions, type SearchResult } from './search/index.js'
-import { IndexWriteFailureError, DerivationCapExceededError } from './errors.js'
+import { IndexWriteFailureError, DerivationCapExceededError, DebugReservedFieldError } from './errors.js'
 import { buildUniqueConstraintSet, type UniqueConstraintSet } from './indexing/unique-constraints.js'
 import type { RefDescriptor } from './refs.js'
 import { Lru, parseBytes, estimateRecordBytes, type LruStats } from './cache/index.js'
@@ -4086,6 +4086,31 @@ export class Collection<T> {
    * path encrypts the body directly under the collection DEK — byte-identical
    * to pre-CEK behaviour, so non-adopting collections pay nothing.
    */
+  /**
+   * Build a debug-plaintext envelope: the record's own fields inlined as
+   * top-level keys beside the reserved `_`-metadata, with `_debug: 1` and an
+   * empty `_data`. Lets native store tooling read the record without
+   * unwrapping. Only reached for user collections under `debugPlaintext`
+   * (see {@link encryptRecord}). Rejects `_`-prefixed record fields, which
+   * would collide with the reserved metadata namespace.
+   */
+  private buildDebugEnvelope(record: T, version: number): EncryptedEnvelope {
+    const rec = record as unknown as Record<string, unknown>
+    for (const key of Object.keys(rec)) {
+      if (key.startsWith('_')) throw new DebugReservedFieldError(this.name, key)
+    }
+    return {
+      _noydb: NOYDB_FORMAT_VERSION,
+      _v: version,
+      _ts: new Date().toISOString(),
+      _iv: '',
+      _data: '',
+      _by: this.keyring.userId,
+      _debug: NOYDB_FORMAT_VERSION,
+      ...rec,
+    } as unknown as EncryptedEnvelope
+  }
+
   private async encryptJsonString(
     json: string,
     version: number,
@@ -4137,6 +4162,13 @@ export class Collection<T> {
     version: number,
     cek?: CryptoKey,
   ): Promise<EncryptedEnvelope> {
+    // Debug-plaintext: write user-collection records with their fields inlined
+    // beside the envelope metadata so native store tools read them directly.
+    // Internal (`_`-prefixed) collections keep the classic shape — some store
+    // `_`-prefixed fields that the inline layout would collide with.
+    if (!this.encrypted && this.keyring.debugPlaintext === true && !this.name.startsWith('_')) {
+      return this.buildDebugEnvelope(record, version)
+    }
     const base = await this.encryptJsonString(JSON.stringify(record), version, cek)
     if (!this.deterministicFields || !this.encrypted) return base
 
@@ -4536,7 +4568,20 @@ export class Collection<T> {
     // tombstones. Legacy plaintext collections (`!this.encrypted`) legitimately
     // have empty `_iv`/`_data`, so `isTombstone` is false for them — preserved.
     if (isTombstone(envelope, this.encrypted)) return null
-    if (!this.encrypted) return envelope._data
+    if (!this.encrypted) {
+      // Debug-plaintext layout: record fields were inlined as top-level keys
+      // (see buildDebugEnvelope). Reconstruct the record from the non-`_`
+      // keys. Self-describing via `_debug`, so a classic plaintext reader
+      // handles debug-written envelopes too.
+      if (envelope._debug !== undefined) {
+        const rec: Record<string, unknown> = {}
+        for (const [key, value] of Object.entries(envelope)) {
+          if (!key.startsWith('_')) rec[key] = value
+        }
+        return JSON.stringify(rec)
+      }
+      return envelope._data
+    }
     const dek = await this.getDEK(this.name)
     if (envelope._cek !== undefined) {
       const cached = id !== undefined ? this.cekCache?.get(id) : undefined

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -102,6 +102,39 @@ export class NoydbError extends Error {
   }
 }
 
+// ─── Debug-mode Errors ─────────────────────────────────────────────────
+
+/**
+ * Thrown at construction when `debugPlaintext: true` is combined with
+ * encryption (`encrypt` not `false`). Debug-plaintext writes records in
+ * cleartext laid out for native store inspection; it is meaningless and
+ * unsafe under encryption, so the coupling is rejected loudly rather than
+ * silently ignored.
+ */
+export class DebugPlaintextError extends NoydbError {
+  constructor(message = 'debugPlaintext requires encrypt: false') {
+    super('DEBUG_PLAINTEXT_REQUIRES_UNENCRYPTED', message)
+    this.name = 'DebugPlaintextError'
+  }
+}
+
+/**
+ * Thrown when a record written under `debugPlaintext` carries a top-level
+ * field whose name starts with `_`. Debug mode inlines record fields beside
+ * the reserved `_`-prefixed envelope metadata, so a `_`-prefixed record field
+ * would collide with metadata. The `_` namespace is reserved by NOYDB
+ * regardless; rename the field.
+ */
+export class DebugReservedFieldError extends NoydbError {
+  constructor(collection: string, field: string) {
+    super(
+      'DEBUG_RESERVED_FIELD',
+      `Record in "${collection}" has reserved field "${field}": the _ prefix is reserved under debugPlaintext mode`,
+    )
+    this.name = 'DebugReservedFieldError'
+  }
+}
+
 // ─── Crypto Errors ─────────────────────────────────────────────────────
 
 /**

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -21,7 +21,7 @@ import type {
   TranslatorAuditEntry,
   WriteConflict,
 } from './types.js'
-import { ValidationError, NoAccessError, InvalidKeyError, KeyringCorruptError, StoreCapabilityError, PermissionDeniedError, VaultTemplateNotFoundError, ReservedVaultNameError } from './errors.js'
+import { ValidationError, NoAccessError, InvalidKeyError, KeyringCorruptError, StoreCapabilityError, PermissionDeniedError, VaultTemplateNotFoundError, ReservedVaultNameError, DebugPlaintextError } from './errors.js'
 import { STATE_VAULT_NAME } from './federation/constants.js'
 import type { StateManagementVault } from './federation/state-vault.js'
 import {
@@ -151,7 +151,7 @@ const ROLE_RANK: Record<Role, number> = {
 }
 
 /** Dummy keyring for unencrypted mode. */
-function createPlaintextKeyring(userId: string): UnlockedKeyring {
+function createPlaintextKeyring(userId: string, debugPlaintext = false): UnlockedKeyring {
   return {
     userId,
     displayName: userId,
@@ -161,6 +161,7 @@ function createPlaintextKeyring(userId: string): UnlockedKeyring {
     kek: null,
     salt: new Uint8Array(0),
     authenticators: [],
+    ...(debugPlaintext ? { debugPlaintext: true } : {}),
   }
 }
 
@@ -241,6 +242,17 @@ export class Noydb {
 
   constructor(options: NoydbOptions) {
     this.options = options
+    // Debug-plaintext is an unencrypted-only inspection mode; combining it with
+    // encryption is meaningless and unsafe, so reject the coupling loudly.
+    if (options.debugPlaintext === true && options.encrypt !== false) {
+      throw new DebugPlaintextError()
+    }
+    if (options.debugPlaintext === true) {
+      console.warn(
+        '[noydb] debugPlaintext is ON — records are stored UNENCRYPTED and laid ' +
+          'out for native store inspection. NEVER use this for production or client data.',
+      )
+    }
     this.txStrategy = options.txStrategy ?? NO_TX
     this.forgetStrategy = options.forgetStrategy ?? NO_FORGET
     this.sessionStrategy = options.sessionStrategy ?? NO_SESSION
@@ -630,7 +642,7 @@ export class Noydb {
 
     // For backwards compat: if not opened yet, create with cached keyring or plaintext
     if (this.options.encrypt === false) {
-      const keyring = createPlaintextKeyring(this.options.user)
+      const keyring = createPlaintextKeyring(this.options.user, this.options.debugPlaintext === true)
       const comp = new Vault({
         adapter: this.options.store,
         name,
@@ -2833,7 +2845,7 @@ export class Noydb {
     opts: { create: boolean } = { create: true },
   ): Promise<UnlockedKeyring> {
     if (this.options.encrypt === false) {
-      return createPlaintextKeyring(this.options.user)
+      return createPlaintextKeyring(this.options.user, this.options.debugPlaintext === true)
     }
 
     const cached = this.keyringCache.get(vault)

--- a/packages/hub/src/team/keyring.ts
+++ b/packages/hub/src/team/keyring.ts
@@ -112,6 +112,16 @@ export interface UnlockedKeyring {
   readonly kek: CryptoKey | null
   readonly salt: Uint8Array
   /**
+   * Debug-plaintext layout flag. Set only on the plaintext keyring created
+   * in `encrypt: false` + `debugPlaintext: true` mode — it lives here
+   * because its lifecycle is identical to the plaintext keyring's (no
+   * encrypted vault ever has it, so this never widens the encrypted surface).
+   * When true, user-collection records are written with their fields inlined
+   * beside the envelope metadata (`_debug: 1`) so native store tooling can
+   * read them without unwrapping `_data`.
+   */
+  readonly debugPlaintext?: boolean
+  /**
    * `@noy-db/as-*` export capability. Absent when the
    * keyring was written before this RFC landed — role-based defaults
    * apply via `hasExportCapability`.

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -155,6 +155,16 @@ export interface EncryptedEnvelope {
    * across records.
    */
   readonly _cek?: string
+  /**
+   * Debug-plaintext marker. Present only on records written by a vault opened
+   * with `debugPlaintext: true` (which requires `encrypt: false`). When set,
+   * the record's own fields are inlined as top-level keys on this envelope
+   * (beside the reserved `_`-prefixed metadata) and `_data` is empty — so
+   * native store tooling (jq, S3 console) reads the record directly. The read
+   * path reconstructs the record from the non-`_` keys; the marker makes a
+   * debug envelope self-describing, so a classic plaintext reader handles it too.
+   */
+  readonly _debug?: typeof NOYDB_FORMAT_VERSION
 }
 
 /**
@@ -1967,6 +1977,14 @@ export interface NoydbOptions {
   readonly auth?: 'passphrase' | 'biometric'
   /** Enable encryption. Default: true. */
   readonly encrypt?: boolean
+  /**
+   * Debug-only: lay plaintext records out as directly-inspectable store
+   * objects (record fields inlined beside envelope metadata, `_debug: 1`) so
+   * native store tooling can read them without unwrapping `_data`. Requires
+   * `encrypt: false` — combining with encryption throws `DebugPlaintextError`
+   * at construction. NEVER enable for production or client data.
+   */
+  readonly debugPlaintext?: boolean
   /** Conflict resolution strategy. Default: 'version'. */
   readonly conflict?: ConflictStrategy
   /**

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -468,7 +468,11 @@ const KERNEL_SURFACE_BUDGET = {
   // querySourceForJoin exposes the right collection's i18nFields, and query()/
   // scan() thread the default locale into the JoinContext. The resolution
   // itself lives in src/query/join.ts.
-  'packages/hub/src/collection.ts': 4675,
+  // Bumped 4675→4720 (2026-06-15, #413): debug-plaintext record layout — the
+  // buildDebugEnvelope inliner plus the encryptRecord/decryptJsonString
+  // branches that emit and reconstruct the directly-inspectable envelope.
+  // This is intrinsic to the core record write/read path, so it lives here.
+  'packages/hub/src/collection.ts': 4720,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.


### PR DESCRIPTION
First slice of #413. Lets native store tooling read records directly in `encrypt:false` + `debugPlaintext:true` mode.

### What
- `debugPlaintext` option, carried on the plaintext keyring (no per-collection plumbing — its lifecycle matches the plaintext keyring's).
- **Hard error** (`DebugPlaintextError`) if combined with encryption; loud warning on open.
- `buildDebugEnvelope` inlines user-record fields beside `_`-metadata (`_debug:1`, empty `_data`); reserved `_`-prefixed record fields rejected (`DebugReservedFieldError`).
- Internal (`_`-prefixed) collections keep the classic shape.
- `decryptJsonString` reconstructs from non-`_` keys; `_debug` marker makes envelopes self-describing (a classic plaintext reader handles them too).

### Verification
- 7 new tests + full hub suite (2680) green; typecheck/lint/arch clean.
- Kernel ceiling `collection.ts` 4675→4720 (record-path layout is intrinsically core).

Foundational for the `as-*` cluster — the raw-object blob path (#413 P2) reused by #412 follows next.

Refs #413