### PR TITLE
feat(hub): debug-plaintext blobs — single un-gzipped object (#413 P2)

### DIFF
--- a/packages/hub/__tests__/debug-plaintext-mode.test.ts
+++ b/packages/hub/__tests__/debug-plaintext-mode.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from 'vitest'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
 import { ConflictError, DebugPlaintextError, DebugReservedFieldError } from '../src/errors.js'
 import { createNoydb } from '../src/noydb.js'
+import { withBlobs } from '../src/blobs/index.js'
 
 function makeStore(): NoydbStore {
   const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
@@ -97,5 +98,53 @@ describe('#413 — debug-plaintext store mode', () => {
     const plain = await createNoydb({ store, user: 'op', encrypt: false })
     const v2 = await plain.openVault('t')
     expect(await v2.collection<{ id: string; name: string }>('docs').get('d1')).toEqual({ id: 'd1', name: 'Carol' })
+  })
+})
+
+function payload(n: number): Uint8Array {
+  const b = new Uint8Array(n)
+  for (let i = 0; i < n; i++) b[i] = (i * 7) & 0xff
+  return b
+}
+
+describe('#413 P2 — debug-plaintext blobs: single un-gzipped object', () => {
+  it('stores a blob as one un-gzipped, directly-decodable object', async () => {
+    const store = makeStore()
+    const db = await createNoydb({ store, user: 'op', encrypt: false, debugPlaintext: true, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs', { blobFields: { f: {} } })
+    await docs.put('d1', { id: 'd1' })
+    const data = payload(2000)
+    await docs.blob('d1').put('f', data)
+
+    // Exactly one chunk object, plaintext, base64 decodes straight to the bytes.
+    const chunkKeys = await store.list('t', '_blob_chunks')
+    expect(chunkKeys.length).toBe(1)
+    const chunk = (await store.get('t', '_blob_chunks', chunkKeys[0]))!
+    expect(chunk._iv).toBe('')
+    expect(Buffer.from(chunk._data, 'base64').equals(Buffer.from(data))).toBe(true)
+
+    // Blob index records compression none + a single chunk.
+    const idxKeys = await store.list('t', '_blob_index')
+    const idx = JSON.parse((await store.get('t', '_blob_index', idxKeys[0]))!._data) as { compression: string; chunkCount: number }
+    expect(idx.compression).toBe('none')
+    expect(idx.chunkCount).toBe(1)
+
+    // Round-trips through the API.
+    const got = await docs.blob('d1').get('f')
+    expect(Buffer.from(got!).equals(Buffer.from(data))).toBe(true)
+  })
+
+  it('classic plaintext mode still gzips blobs (debug differs)', async () => {
+    const store = makeStore()
+    const db = await createNoydb({ store, user: 'op', encrypt: false, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs', { blobFields: { f: {} } })
+    await docs.put('d1', { id: 'd1' })
+    await docs.blob('d1').put('f', payload(2000))
+
+    const idxKeys = await store.list('t', '_blob_index')
+    const idx = JSON.parse((await store.get('t', '_blob_index', idxKeys[0]))!._data) as { compression: string }
+    expect(idx.compression).toBe('gzip')
   })
 })

--- a/packages/hub/src/blobs/blob-set.ts
+++ b/packages/hub/src/blobs/blob-set.ts
@@ -144,6 +144,7 @@ export class BlobSet {
   private readonly userId: string | undefined
   private readonly maxBlobBytes: number | undefined
   private readonly erasableBlobs: boolean
+  private readonly debugPlaintext: boolean
 
   constructor(opts: {
     store: NoydbStore
@@ -155,6 +156,7 @@ export class BlobSet {
     userId?: string
     maxBlobBytes?: number
     erasableBlobs?: boolean
+    debugPlaintext?: boolean
   }) {
     this.store = opts.store
     this.vault = opts.vault
@@ -165,6 +167,7 @@ export class BlobSet {
     this.userId = opts.userId
     this.maxBlobBytes = opts.maxBlobBytes
     this.erasableBlobs = opts.erasableBlobs === true
+    this.debugPlaintext = opts.debugPlaintext === true
   }
 
   /**
@@ -667,6 +670,11 @@ export class BlobSet {
     } else {
       shouldCompress = true
     }
+    // Debug-plaintext: write the blob as a single un-gzipped object so the
+    // stored chunk's base64 `_data` decodes directly to the original bytes
+    // (`base64 -d`) — no gzip layer, no multi-chunk reassembly. (encrypt:false
+    // already stores chunks unencrypted; this drops the remaining indirection.)
+    if (this.debugPlaintext) shouldCompress = false
 
     // Step 3 — deduplication check
     const existingBlob = await this.loadBlobObject(eTag)
@@ -682,7 +690,11 @@ export class BlobSet {
         ? await compressBytes(data)
         : { bytes: data, algorithm: 'none' as const }
 
-      const chunkSize = this.effectiveChunkSize(opts)
+      // Debug-plaintext stores the whole blob as one object (single chunk) so
+      // it is one directly-openable file in the store rather than N shards.
+      const chunkSize = this.debugPlaintext
+        ? Math.max(compressed.byteLength, 1)
+        : this.effectiveChunkSize(opts)
       const chunkCount = Math.max(1, Math.ceil(compressed.byteLength / chunkSize))
 
       // Erasable collection (`perRecordKeys`): mint a fresh per-blob content

--- a/packages/hub/src/blobs/strategy.ts
+++ b/packages/hub/src/blobs/strategy.ts
@@ -37,6 +37,14 @@ export interface BlobStrategyOpenArgs {
    * CEK design spec.
    */
   readonly erasableBlobs?: boolean
+  /**
+   * Vault is in debug-plaintext mode (`encrypt: false` + `debugPlaintext: true`).
+   * Blobs are then written as a single un-gzipped object (one base64 chunk) so
+   * the stored object is directly recoverable with native tools (`base64 -d`),
+   * matching the directly-inspectable record layout. Dev-only — see the
+   * plaintext/debug-store-mode design.
+   */
+  readonly debugPlaintext?: boolean
 }
 
 /**

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -3603,6 +3603,7 @@ export class Collection<T> {
       encrypted: this.encrypted,
       userId: this.keyring.userId,
       erasableBlobs: this.perRecordCek,
+      debugPlaintext: this.keyring.debugPlaintext === true,
     })
   }
 


### PR DESCRIPTION
Second slice of #413. In `debugPlaintext` mode, a blob is stored as **one un-gzipped object** so it's directly recoverable with native tools (`base64 -d`), matching the directly-inspectable record layout from P1.

### What
- `debugPlaintext` threaded into `BlobStrategyOpenArgs`/`BlobSet` via `collection.blob()`'s `openSlot` args (off the plaintext keyring — same source as the record path).
- `put()`: debug mode forces compression `'none'` + single chunk (`chunkCount === 1`). `encrypt:false` already stores chunks unencrypted, so the stored chunk's base64 `_data` now decodes straight to the original bytes.
- Non-debug paths (chunking, gzip, encryption, dedup, erasable CEK) are untouched.

### Verification
- +2 tests (single un-gzipped decodable object; classic-mode-still-gzips contrast); blob suite (50) + full hub suite green; typecheck/lint/arch clean.

This is the **shared raw-object blob layout** the `as-*` cluster builds on. The native-bytes `ObjectProjection` variant (raw file, no envelope/base64) lands with #412 where there's an S3 object store to implement + test it.

Refs #413 (P3 remaining: `noydb cat` helper, CI guard, docs/showcase)