### PR TITLE
feat(hub): debug-plaintext P3 — helper, CI guard, docs + showcase (#413)

### DIFF
--- a/docs/core/02-encryption.md
+++ b/docs/core/02-encryption.md
@@ -133,6 +133,39 @@ These are the bright lines. Any change to one of them is a security review.
 | **Authenticated decryption fails closed** | A modified envelope throws `TamperedError`; no partial-decryption fallback. |
 | **Per-record CEK is stable + DEK-scoped** | Under `perRecordKeys`, a record's CEK is reused across all its versions/history and is only ever AES-KW-wrapped under the collection/tier DEK (`crypto.ts` `wrapCek`/`unwrapCek`). `_det` slots are never CEK-keyed. |
 
+## Debug-plaintext mode (dev-only)
+
+Zero-knowledge encryption is the default. During **local development**, though,
+you sometimes want to point your store's native tools straight at the data. Open
+the vault with `encrypt: false` **and** `debugPlaintext: true`:
+
+```ts
+const db = await createNoydb({ store, user: 'dev', encrypt: false, debugPlaintext: true })
+```
+
+This changes the on-store *layout* so it's directly legible:
+
+- **Records** are written with their fields inlined beside the envelope
+  metadata (`_debug: 1`, empty `_data`) instead of stuffed into `_data` as a
+  JSON string — so `jq '.total'` over a `to-file` object just works.
+- **Blobs** are written as a single un-gzipped object — the chunk's base64
+  `_data` decodes straight to the original bytes (`base64 -d`).
+
+To unwrap an envelope programmatically (the core of a `noydb cat` script),
+use `readPlaintextRecord(envelope)` — it handles both the inlined and the
+classic plaintext layouts, and throws on an encrypted envelope.
+
+Guardrails:
+
+- `debugPlaintext: true` combined with encryption throws `DebugPlaintextError`
+  at construction — it is an unencrypted-only inspection mode.
+- Opening a vault in this mode prints a loud warning.
+- A CI architecture check (`no-debug-plaintext-in-source`) forbids hardcoding
+  `debugPlaintext: true` in shipped library source.
+
+**Never use this for production or client data.** It stores everything in
+cleartext and is not crypto-shreddable.
+
 ## See also
 
 - [Core 03 — Stores](./03-stores.md) — the contract that holds these invariants in place

--- a/features.yaml
+++ b/features.yaml
@@ -46,7 +46,9 @@ features:
     package: '@noy-db/hub'
     factory: null
     status: stable
-    showcases: []
+    showcases:
+      - id: 112-debug-plaintext-mode
+        path: showcases/src/112-debug-plaintext-mode.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -61,6 +63,7 @@ features:
       - 'Legacy dual-read: `_cek` presence is the format discriminant, not the flag — a collection without `perRecordKeys` is byte-identical to the legacy path and a mixed vault (and recipients that never set the flag) read both kinds'
       - 'Tiers compose: elevate/demote re-wrap the same CEK from the source tier DEK to the target tier DEK (body key unchanged); bundle/extract re-key (`reKeyClosure`) re-wraps each `_cek` under the destination DEK so adopted records stay decryptable'
       - 'Tombstone tolerance: a `get()` on an envelope with no `_data`/`_cek` returns null rather than throwing TamperedError (shred tombstone creation is step 2 / #304)'
+      - 'Debug-plaintext mode (`debugPlaintext: true`, requires `encrypt: false`): records are written with fields inlined beside the `_`-metadata (`_debug: 1`, empty `_data`) and blobs as a single un-gzipped object, so native store tooling reads them directly; `readPlaintextRecord()` unwraps both layouts. Rejected under encryption (`DebugPlaintextError`); CI guard `no-debug-plaintext-in-source` forbids it in shipped library source. DEV-ONLY — never for production/client data.'
     related: [vault-and-collections, permissions]
 
   - id: forget-cascade

--- a/packages/hub/__tests__/debug-plaintext-mode.test.ts
+++ b/packages/hub/__tests__/debug-plaintext-mode.test.ts
@@ -9,6 +9,7 @@ import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.
 import { ConflictError, DebugPlaintextError, DebugReservedFieldError } from '../src/errors.js'
 import { createNoydb } from '../src/noydb.js'
 import { withBlobs } from '../src/blobs/index.js'
+import { readPlaintextRecord } from '../src/debug.js'
 
 function makeStore(): NoydbStore {
   const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
@@ -106,6 +107,21 @@ function payload(n: number): Uint8Array {
   for (let i = 0; i < n; i++) b[i] = (i * 7) & 0xff
   return b
 }
+
+describe('#413 P3 — readPlaintextRecord helper', () => {
+  it('unwraps a debug-inlined envelope', () => {
+    const env = { _noydb: 1, _v: 1, _ts: 't', _iv: '', _data: '', _by: 'op', _debug: 1, id: 'd1', name: 'Alice' }
+    expect(readPlaintextRecord(env as never)).toEqual({ id: 'd1', name: 'Alice' })
+  })
+  it('unwraps a classic plaintext envelope', () => {
+    const env = { _noydb: 1, _v: 1, _ts: 't', _iv: '', _data: JSON.stringify({ id: 'd1', n: 2 }) }
+    expect(readPlaintextRecord(env as never)).toEqual({ id: 'd1', n: 2 })
+  })
+  it('throws on an encrypted envelope (non-empty _iv)', () => {
+    const env = { _noydb: 1, _v: 1, _ts: 't', _iv: 'abc', _data: 'ciphertext' }
+    expect(() => readPlaintextRecord(env as never)).toThrow(/encrypted/)
+  })
+})
 
 describe('#413 P2 — debug-plaintext blobs: single un-gzipped object', () => {
   it('stores a blob as one un-gzipped, directly-decodable object', async () => {

--- a/packages/hub/src/debug.ts
+++ b/packages/hub/src/debug.ts
@@ -1,0 +1,43 @@
+/**
+ * Helpers for reading records out of a *plaintext* store (`encrypt: false`)
+ * with native tooling — the programmatic core of a `noydb cat`-style unwrap.
+ * See the plaintext/debug-store-mode design.
+ */
+import type { EncryptedEnvelope } from './types.js'
+
+/**
+ * Extract the record from a plaintext stored envelope, handling both layouts:
+ *
+ *   - **classic plaintext** (`encrypt: false`): the record is JSON in `_data`.
+ *   - **debugPlaintext**: the record's fields are inlined beside the
+ *     `_`-prefixed metadata (marked by `_debug`).
+ *
+ * Returns `null` for an empty/absent body. Throws if handed an **encrypted**
+ * envelope (non-empty `_iv`) — there is no key here; decrypt through the vault
+ * instead. Intended for record envelopes, not blob chunks.
+ *
+ * @example
+ * ```ts
+ * // node script over a to-file store, no vault needed:
+ * const env = JSON.parse(readFileSync('data/acme/invoices/inv-1.json', 'utf8'))
+ * console.log(readPlaintextRecord(env)) // → { id: 'inv-1', total: '120.00', … }
+ * ```
+ */
+export function readPlaintextRecord<T = Record<string, unknown>>(
+  envelope: EncryptedEnvelope,
+): T | null {
+  if (envelope._iv !== '') {
+    throw new Error(
+      'readPlaintextRecord: envelope is encrypted (non-empty _iv) — decrypt via the vault, not this helper',
+    )
+  }
+  if (envelope._debug !== undefined) {
+    const record: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(envelope)) {
+      if (!key.startsWith('_')) record[key] = value
+    }
+    return record as T
+  }
+  if (!envelope._data) return null
+  return JSON.parse(envelope._data) as T
+}

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -168,6 +168,7 @@ export {
 export { detectMimeType, detectMagic, isPreCompressed } from './blobs/mime-magic.js'
 export { wrapBundleStore, createBundleStore } from './store/bundle-store.js'
 export type { WrappedBundleNoydbStore, WrapBundleStoreOptions } from './store/bundle-store.js'
+export { readPlaintextRecord } from './debug.js'
 
 // Observable write-queue
 export type { WriteQueue } from './write-queue.js'
@@ -333,6 +334,7 @@ export { STATE_VAULT_NAME } from './federation/constants.js'
 export { UnknownShardError, ShardProvisioningError, VaultTemplateNotFoundError, ReservedVaultNameError, DataResidencyError } from './errors.js'
 export { ForgetStrategyNotConfiguredError } from './errors.js'
 export { SealedRecordExpiredError, SealedRecordMismatchError, RecordCekNotFoundError } from './errors.js'
+export { DebugPlaintextError, DebugReservedFieldError } from './errors.js'
 
 // Bundle format — `.noydb` container
 export {

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -161,7 +161,7 @@ function createPlaintextKeyring(userId: string, debugPlaintext = false): Unlocke
     kek: null,
     salt: new Uint8Array(0),
     authenticators: [],
-    ...(debugPlaintext ? { debugPlaintext: true } : {}),
+    ...(debugPlaintext ? { debugPlaintext } : {}),
   }
 }
 

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -578,6 +578,29 @@ function checkKernelSurface() {
   }
 }
 
+// ─── Check 7: no debugPlaintext in shipped library source (#413 P3) ─────
+
+/**
+ * `debugPlaintext: true` stores records UNENCRYPTED, laid out for native store
+ * inspection — a consumer-set, dev-only option. No shipped library source under
+ * `packages/*​/src` should hardcode it on. Tests (`__tests__`) and showcases
+ * (`showcases/`) live outside `packages/*​/src` and may set it freely.
+ */
+function checkNoDebugPlaintextInSource() {
+  const re = /debugPlaintext\s*:\s*true/
+  for (const pkgDir of listPackageDirs()) {
+    walkTsFiles(join(pkgDir, 'src'), (file, content) => {
+      if (re.test(stripComments(content))) {
+        fail(
+          'no-debug-plaintext-in-source',
+          `${relative(ROOT, file)} hardcodes "debugPlaintext: true" — it stores records UNENCRYPTED and is a dev-only consumer option; never ship it on in library source.`,
+          file,
+        )
+      }
+    })
+  }
+}
+
 // ─── Run ───────────────────────────────────────────────────────────────
 
 const startTime = Date.now()
@@ -588,6 +611,7 @@ checkHubPortable()
 checkStoresCiphertextOnly()
 checkStrategyOptIns()
 checkKernelSurface()
+checkNoDebugPlaintextInSource()
 
 const elapsed = ((Date.now() - startTime) / 1000).toFixed(2)
 

--- a/showcases/src/112-debug-plaintext-mode.showcase.test.ts
+++ b/showcases/src/112-debug-plaintext-mode.showcase.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Showcase 112 — debug-plaintext store mode (#413)
+ *
+ * What you'll learn
+ * ─────────────────
+ * `createNoydb({ encrypt: false, debugPlaintext: true })` — a DEV-ONLY mode
+ * that lays plaintext data out so native store tooling (jq, the S3 console, a
+ * DB browser) reads it DIRECTLY, without unwrapping `_data`:
+ *   1. Records are written with their fields inlined beside the envelope
+ *      metadata (`_debug: 1`, empty `_data`) — `jq '.total'` just works.
+ *   2. Blobs are written as a single un-gzipped object — the chunk's base64
+ *      `_data` decodes straight to the original bytes (`base64 -d`).
+ *   3. `readPlaintextRecord(envelope)` is the programmatic unwrap helper
+ *      (the core of a `noydb cat`), handling both the inlined and the classic
+ *      plaintext layouts.
+ *   4. It is rejected if combined with encryption — debug-plaintext is an
+ *      unencrypted-only inspection mode.
+ *
+ * Why it matters
+ * ──────────────
+ * Zero-knowledge encryption is the default and the point — but during local
+ * development you often want to point your store's native tools straight at the
+ * data. This mode makes the store legible WITHOUT a decrypt step, while a CI
+ * guard (`no-debug-plaintext-in-source`) ensures it never ships on in library
+ * code. NEVER use it for production or client data.
+ *
+ * What to read next
+ * ─────────────────
+ *   - docs/core/02-encryption.md (§ Debug-plaintext mode)
+ *   - docs/superpowers/specs/2026-06-15-plaintext-debug-store-mode-design.md
+ *
+ * Spec mapping
+ * ────────────
+ *   #413 — plaintext/debug store mode
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, readPlaintextRecord, DebugPlaintextError } from '@noy-db/hub'
+import { withBlobs } from '@noy-db/hub/blobs'
+import { memory } from '@noy-db/to-memory'
+
+describe('showcase 112 — debug-plaintext store mode', () => {
+  it('records are directly readable; blobs are a single un-gzipped object', async () => {
+    const store = memory()
+    const db = await createNoydb({ store, user: 'dev', encrypt: false, debugPlaintext: true, blobStrategy: withBlobs() })
+    const vault = await db.openVault('acme')
+    const invoices = vault.collection<{ id: string; total: string }>('invoices', { blobFields: { scan: {} } })
+
+    await invoices.put('inv-1', { id: 'inv-1', total: '120.00' })
+
+    // (1) The raw stored envelope has the record's fields at the top level.
+    const raw = (await store.get('acme', 'invoices', 'inv-1'))! as Record<string, unknown>
+    expect(raw._debug).toBe(1)
+    expect(raw.total).toBe('120.00')
+
+    // (3) readPlaintextRecord unwraps it (the `noydb cat` core).
+    expect(readPlaintextRecord(raw as never)).toEqual({ id: 'inv-1', total: '120.00' })
+
+    // (2) Blob → one un-gzipped object whose base64 decodes to the bytes.
+    const bytes = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
+    await invoices.blob('inv-1').put('scan', bytes)
+    const chunkKeys = await store.list('acme', '_blob_chunks')
+    expect(chunkKeys.length).toBe(1)
+    const chunk = (await store.get('acme', '_blob_chunks', chunkKeys[0]))!
+    expect(Buffer.from(chunk._data, 'base64').equals(Buffer.from(bytes))).toBe(true)
+    expect(Buffer.from((await invoices.blob('inv-1').get('scan'))!).equals(Buffer.from(bytes))).toBe(true)
+  })
+
+  it('(4) debugPlaintext + encryption is rejected', async () => {
+    await expect(
+      createNoydb({ store: memory(), user: 'dev', secret: 'pw-112-long-enough', debugPlaintext: true }),
+    ).rejects.toBeInstanceOf(DebugPlaintextError)
+  })
+})

--- a/showcases/src/112-debug-plaintext-mode.showcase.test.ts
+++ b/showcases/src/112-debug-plaintext-mode.showcase.test.ts
@@ -48,7 +48,7 @@ describe('showcase 112 — debug-plaintext store mode', () => {
     await invoices.put('inv-1', { id: 'inv-1', total: '120.00' })
 
     // (1) The raw stored envelope has the record's fields at the top level.
-    const raw = (await store.get('acme', 'invoices', 'inv-1'))! as Record<string, unknown>
+    const raw = (await store.get('acme', 'invoices', 'inv-1'))! as unknown as Record<string, unknown>
     expect(raw._debug).toBe(1)
     expect(raw.total).toBe('120.00')
 


### PR DESCRIPTION
Closes out **#413** (debug-plaintext store mode).

### What
- **`readPlaintextRecord(envelope)`** — pure unwrap helper (the `noydb cat` core): reconstructs a record from the debug-inlined layout (`_debug`) or classic plaintext `_data` JSON; throws on an encrypted envelope. Exported from the hub with `DebugPlaintextError`/`DebugReservedFieldError`.
- **CI guard `no-debug-plaintext-in-source`** (check-architecture.mjs) — forbids hardcoding `debugPlaintext: true` in `packages/*/src` (tests/showcases are outside src and may set it). `createPlaintextKeyring` switched to shorthand `{ debugPlaintext }` so the guard doesn't self-trip.
- **Showcase 112** (registered under the `encryption` feature) + **docs** (`02-encryption.md` § Debug-plaintext mode) + an encryption invariant.

### Verification
- +4 helper unit tests + showcase (2); full hub suite green; `check-architecture` (incl. the new guard) + `validate-features` + typecheck + lint clean.

With P1 (record inlining) + P2 (single un-gzipped blobs) + P3, **#413 is complete**. The native-bytes `ObjectProjection` raw path lands with #412.

Closes #413