### PR TITLE
feat(hub): ObjectProjection contract + memory impl (#412 P1)

### DIFF
--- a/packages/hub/__tests__/object-projection.test.ts
+++ b/packages/hub/__tests__/object-projection.test.ts
@@ -1,0 +1,58 @@
+/**
+ * #412 P1 — the ObjectProjection contract + memoryObjectProjection reference
+ * impl. This is the shared seam for direct-serve blobs (#412) and the debug
+ * raw-object path (#413): write raw bytes as one native object + get a URL.
+ */
+import { describe, it, expect } from 'vitest'
+import { memoryObjectProjection } from '../src/blobs/object-projection.js'
+
+describe('#412 — ObjectProjection (memory reference impl)', () => {
+  it('round-trips raw bytes through put/get/head/delete', async () => {
+    const obj = memoryObjectProjection()
+    const bytes = new Uint8Array([1, 2, 3, 4, 5])
+    await obj.putObject('a/b.png', bytes, { contentType: 'image/png' })
+
+    const got = await obj.getObject('a/b.png')
+    expect(got).not.toBeNull()
+    expect(Buffer.from(got!).equals(Buffer.from(bytes))).toBe(true)
+
+    const meta = await obj.headObject('a/b.png')
+    expect(meta).toEqual({ size: 5, contentType: 'image/png' })
+
+    await obj.deleteObject('a/b.png')
+    expect(await obj.getObject('a/b.png')).toBeNull()
+    expect(await obj.headObject('a/b.png')).toBeNull()
+  })
+
+  it('delete is idempotent; missing reads return null', async () => {
+    const obj = memoryObjectProjection()
+    await obj.deleteObject('nope') // no throw
+    expect(await obj.getObject('nope')).toBeNull()
+  })
+
+  it('preserves user metadata (the secondary store)', async () => {
+    const obj = memoryObjectProjection()
+    await obj.putObject('k', new Uint8Array([9]), { contentType: 'application/octet-stream', userMeta: { backlink: 'tok_123' } })
+    expect((await obj.headObject('k'))?.userMeta).toEqual({ backlink: 'tok_123' })
+  })
+
+  it('objectUrl: presigned (private) carries an expiry; public is a stable URL', async () => {
+    const obj = memoryObjectProjection({ baseUrl: 'https://cdn.example.com' })
+    await obj.putObject('priv', new Uint8Array([1]), { contentType: 'text/plain' })
+    await obj.putObject('pub', new Uint8Array([1]), { contentType: 'text/plain', public: true })
+
+    const priv = await obj.objectUrl('priv', { expiresInSeconds: 60 })
+    expect(priv).toContain('expires=60')
+
+    const pub = await obj.objectUrl('pub')
+    expect(pub).toBe('https://cdn.example.com/pub')
+    expect(pub).not.toContain('expires')
+  })
+
+  it('putUrl returns a direct-upload URL carrying the content type', async () => {
+    const obj = memoryObjectProjection()
+    const url = await obj.putUrl('big.mp4', { contentType: 'video/mp4' })
+    expect(url).toContain('upload=memory')
+    expect(url).toContain(encodeURIComponent('video/mp4'))
+  })
+})

--- a/packages/hub/src/blobs/index.ts
+++ b/packages/hub/src/blobs/index.ts
@@ -18,6 +18,15 @@
 export { withBlobs } from './active.js'
 export type { BlobStrategy, BlobStrategyOpenArgs } from './strategy.js'
 
+export { memoryObjectProjection } from './object-projection.js'
+export type {
+  ObjectProjection,
+  ObjectMeta,
+  PutObjectOptions,
+  ObjectUrlOptions,
+  PutUrlOptions,
+} from './object-projection.js'
+
 export { BlobSet } from './blob-set.js'
 export {
   BLOB_COLLECTION,

--- a/packages/hub/src/blobs/object-projection.ts
+++ b/packages/hub/src/blobs/object-projection.ts
@@ -1,0 +1,107 @@
+/**
+ * `ObjectProjection` — the capability an `as-*` projection store implements to
+ * hold blob bytes as native, directly-consumable objects (e.g. servable S3
+ * objects) rather than the encrypted-envelope chunks a `NoydbStore` holds.
+ *
+ * This is the shared seam behind **direct-serve blobs** (#412) and the
+ * **debug raw-object path** (#413): "write these bytes as one real object and
+ * give me a URL to it." See the as-aws-s3 design spec.
+ *
+ * Unlike `NoydbStore` (ciphertext in / ciphertext out), an `ObjectProjection`
+ * sees **raw bytes** — it is `as-*`, not `to-*`, and lives **outside** the
+ * zero-knowledge guarantee. Wiring it up is a deliberate, per-field opt-in.
+ */
+
+/** Metadata about a stored object, without its body. */
+export interface ObjectMeta {
+  readonly size: number
+  readonly contentType?: string
+  readonly etag?: string
+  readonly lastModified?: string
+  /** S3-style user metadata (`x-amz-meta-*`). Small; see the design's
+   *  plain / encrypted / opaque-token modes. */
+  readonly userMeta?: Record<string, string>
+}
+
+export interface PutObjectOptions {
+  readonly contentType: string
+  /** World-readable object (CDN origin) vs private (presigned-only). Default false. */
+  readonly public?: boolean
+  /** User metadata mirrored onto the object (the "secondary store"). */
+  readonly userMeta?: Record<string, string>
+}
+
+export interface ObjectUrlOptions {
+  /** TTL for a presigned URL (ignored for a public object). */
+  readonly expiresInSeconds?: number
+}
+
+export interface PutUrlOptions {
+  readonly contentType: string
+  readonly expiresInSeconds?: number
+}
+
+export interface ObjectProjection {
+  /** Diagnostic name (e.g. `'aws-s3'`, `'memory'`). */
+  readonly name?: string
+  /** Write raw bytes as a single native object with a real content type. */
+  putObject(key: string, bytes: Uint8Array, opts: PutObjectOptions): Promise<void>
+  /** Read the raw bytes back; `null` if absent. */
+  getObject(key: string): Promise<Uint8Array | null>
+  /** Delete the object. Idempotent — absent is not an error. */
+  deleteObject(key: string): Promise<void>
+  /** Object metadata without the body; `null` if absent. */
+  headObject(key: string): Promise<ObjectMeta | null>
+  /** A URL to GET the object — presigned (time-limited) or stable public. */
+  objectUrl(key: string, opts?: ObjectUrlOptions): Promise<string>
+  /** A presigned URL the client PUTs bytes to directly (large-file upload,
+   *  bytes bypass the hub). */
+  putUrl(key: string, opts: PutUrlOptions): Promise<string>
+}
+
+/**
+ * In-memory {@link ObjectProjection} — a reference implementation for tests,
+ * local development, and the hub's blob-wiring conformance. Holds bytes in a
+ * `Map`; URLs are synthetic (`memory://…`). Not for production.
+ */
+export function memoryObjectProjection(opts: { baseUrl?: string } = {}): ObjectProjection {
+  const base = opts.baseUrl ?? 'memory://objects'
+  const store = new Map<
+    string,
+    { bytes: Uint8Array; contentType: string; userMeta?: Record<string, string>; public: boolean }
+  >()
+  return {
+    name: 'memory',
+    async putObject(key, bytes, o) {
+      store.set(key, {
+        bytes,
+        contentType: o.contentType,
+        public: o.public === true,
+        ...(o.userMeta ? { userMeta: o.userMeta } : {}),
+      })
+    },
+    async getObject(key) {
+      return store.get(key)?.bytes ?? null
+    },
+    async deleteObject(key) {
+      store.delete(key)
+    },
+    async headObject(key) {
+      const e = store.get(key)
+      if (!e) return null
+      return {
+        size: e.bytes.byteLength,
+        contentType: e.contentType,
+        ...(e.userMeta ? { userMeta: e.userMeta } : {}),
+      }
+    },
+    async objectUrl(key, o) {
+      const e = store.get(key)
+      if (e?.public) return `${base}/${key}`
+      return `${base}/${key}?sig=memory&expires=${o?.expiresInSeconds ?? 900}`
+    },
+    async putUrl(key, o) {
+      return `${base}/${key}?upload=memory&ct=${encodeURIComponent(o.contentType)}`
+    },
+  }
+}

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -157,6 +157,14 @@ export type {
   BlobResponseOptions,
 } from './types.js'
 export { BlobSet } from './blobs/blob-set.js'
+export { memoryObjectProjection } from './blobs/object-projection.js'
+export type {
+  ObjectProjection,
+  ObjectMeta,
+  PutObjectOptions,
+  ObjectUrlOptions,
+  PutUrlOptions,
+} from './blobs/object-projection.js'
 export {
   BLOB_COLLECTION,
   BLOB_INDEX_COLLECTION,


### PR DESCRIPTION
First slice of #412. The **shared seam** for direct-serve blobs (#412) and the debug raw-object path (#413).

### What
- **`ObjectProjection`** interface — `putObject`/`getObject`/`deleteObject`/`headObject`/`objectUrl`/`putUrl` + `ObjectMeta`/`PutObjectOptions`. Sees **raw bytes** (it's `as-*`, not `to-*`; outside the ZK guarantee). Per-field opt-in wiring is a later slice.
- **`memoryObjectProjection()`** reference impl — tests / local dev / upcoming hub conformance. Exported from `@noy-db/hub` + `/blobs`.

### Why a contract-first slice
`@noy-db/as-aws-s3` needs `@aws-sdk/s3-request-presigner` (not yet in the lockfile → frozen-install change) and the hub blob-wiring has an open decision (dedicated `objectStore` vs `routeStore({publicBlobs})`). Landing the **contract + memory impl** first de-risks both: the adapter just implements this interface (P2), and the hub raw-blob path wires to it (P3).

### Verification
- 5 tests (round-trip, idempotent delete, user-metadata, presigned-vs-public URL, put-URL); typecheck/lint/arch clean.

Refs #412 (P2: as-aws-s3 package; P3: hub storage-class wiring)