### PR TITLE
feat(as-aws-s3): S3 ObjectProjection — presigned + public direct-serve (#412 P2)

### DIFF
--- a/packages/as-aws-s3/.npmignore
+++ b/packages/as-aws-s3/.npmignore
@@ -1,0 +1,7 @@
+__tests__/
+*.test.ts
+*.spec.ts
+vitest.config.ts
+tsup.config.ts
+tsconfig.json
+src/

--- a/packages/as-aws-s3/LICENSE
+++ b/packages/as-aws-s3/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 vLannaAi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/as-aws-s3/README.md
+++ b/packages/as-aws-s3/README.md
@@ -1,0 +1,43 @@
+# @noy-db/as-aws-s3
+
+An **`ObjectProjection`** for noy-db backed by AWS S3 — hold blob bytes as
+**native, directly-consumable S3 objects** (presigned or public) instead of
+encrypted-envelope chunks.
+
+`to-aws-s3` is the zero-knowledge **store** (ciphertext in/out). `as-aws-s3` is
+an `as-*` **projection**: raw bytes that can be served straight from S3/CDN and
+processed by AWS-native tooling. It lives **outside** the zero-knowledge
+guarantee — wiring it to a blob field is a deliberate, per-field opt-in.
+
+```ts
+import { asAwsS3 } from '@noy-db/as-aws-s3'
+
+const objects = asAwsS3({ bucket: 'acme-public-assets', region: 'eu-west-1' })
+
+await objects.putObject('logos/acme.png', bytes, { contentType: 'image/png', public: true })
+objects.publicUrl('logos/acme.png')              // stable CDN/S3 URL
+await objects.objectUrl('docs/x.pdf')            // presigned GET (time-limited)
+await objects.putUrl('videos/x.mp4', { contentType: 'video/mp4' }) // presigned PUT (direct upload)
+```
+
+## Options
+
+| Option | Default | Notes |
+|---|---|---|
+| `bucket` | — | Target bucket (required). |
+| `prefix` | `''` | Key prefix (folder). |
+| `region` | `us-east-1` | AWS region. |
+| `client` | new client | Share a pre-built `S3Client`. |
+| `baseUrl` | virtual-hosted S3 URL | CDN origin for `publicUrl()`. |
+| `defaultExpiresInSeconds` | `900` | Presigned-URL TTL. |
+
+## Security
+
+Objects written here are **not encrypted** by noy-db. Prefer presigned
+(`objectUrl`) over public for anything sensitive, scope the bucket tightly, and
+treat public objects as **not crypto-shreddable**. See the design spec
+(`docs/superpowers/specs/2026-06-15-as-aws-s3-direct-serve-blobs-design.md`).
+
+## Peer dependencies
+
+`@noy-db/hub`, `@aws-sdk/client-s3`, `@aws-sdk/s3-request-presigner`.

--- a/packages/as-aws-s3/__tests__/as-aws-s3.test.ts
+++ b/packages/as-aws-s3/__tests__/as-aws-s3.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Cloud-free tests for @noy-db/as-aws-s3.
+ *
+ * Command wiring is verified with a FAKE S3 client that captures commands (no
+ * network). Presigned-URL generation is verified with a REAL S3Client + dummy
+ * static credentials — SigV4 presigning is local crypto, so it runs offline.
+ * No AWS credentials and no live calls are used.
+ */
+import { describe, it, expect } from 'vitest'
+import { S3Client } from '@aws-sdk/client-s3'
+import { asAwsS3 } from '../src/index.js'
+
+function fakeClient(handlers: Record<string, (input: Record<string, unknown>) => unknown>) {
+  const sent: Array<{ name: string; input: Record<string, unknown> }> = []
+  const client = {
+    sent,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    send: async (cmd: any) => {
+      const name = cmd.constructor.name
+      sent.push({ name, input: cmd.input })
+      const h = handlers[name]
+      return h ? h(cmd.input) : {}
+    },
+  }
+  return client
+}
+
+describe('as-aws-s3 — command wiring (fake client)', () => {
+  it('putObject writes raw bytes with content type; public sets ACL; userMeta maps', async () => {
+    const fc = fakeClient({})
+    const obj = asAwsS3({ bucket: 'b', prefix: 'p', client: fc as unknown as S3Client })
+
+    await obj.putObject('k.png', new Uint8Array([1, 2, 3]), { contentType: 'image/png', public: true, userMeta: { backlink: 'tok' } })
+
+    const put = fc.sent.find((c) => c.name === 'PutObjectCommand')!
+    expect(put.input.Bucket).toBe('b')
+    expect(put.input.Key).toBe('p/k.png')
+    expect(put.input.ContentType).toBe('image/png')
+    expect(put.input.ACL).toBe('public-read')
+    expect(put.input.Metadata).toEqual({ backlink: 'tok' })
+  })
+
+  it('private putObject omits ACL', async () => {
+    const fc = fakeClient({})
+    const obj = asAwsS3({ bucket: 'b', client: fc as unknown as S3Client })
+    await obj.putObject('k', new Uint8Array([1]), { contentType: 'text/plain' })
+    const put = fc.sent.find((c) => c.name === 'PutObjectCommand')!
+    expect(put.input.ACL).toBeUndefined()
+    expect(put.input.Key).toBe('k')
+  })
+
+  it('getObject returns bytes; NotFound → null', async () => {
+    const bytes = new Uint8Array([7, 8, 9])
+    const ok = asAwsS3({ bucket: 'b', client: fakeClient({ GetObjectCommand: () => ({ Body: { transformToByteArray: async () => bytes } }) }) as unknown as S3Client })
+    expect(Buffer.from((await ok.getObject('k'))!).equals(Buffer.from(bytes))).toBe(true)
+
+    const missing = asAwsS3({ bucket: 'b', client: fakeClient({ GetObjectCommand: () => { throw { name: 'NoSuchKey' } } }) as unknown as S3Client })
+    expect(await missing.getObject('k')).toBeNull()
+  })
+
+  it('headObject maps S3 metadata; NotFound → null', async () => {
+    const obj = asAwsS3({ bucket: 'b', client: fakeClient({
+      HeadObjectCommand: () => ({ ContentLength: 42, ContentType: 'video/mp4', ETag: '"abc"', LastModified: new Date('2026-06-15T00:00:00Z'), Metadata: { dur: '12' } }),
+    }) as unknown as S3Client })
+    expect(await obj.headObject('k')).toEqual({ size: 42, contentType: 'video/mp4', etag: '"abc"', lastModified: '2026-06-15T00:00:00.000Z', userMeta: { dur: '12' } })
+
+    const missing = asAwsS3({ bucket: 'b', client: fakeClient({ HeadObjectCommand: () => { throw { $metadata: { httpStatusCode: 404 } } } }) as unknown as S3Client })
+    expect(await missing.headObject('k')).toBeNull()
+  })
+
+  it('deleteObject sends a delete', async () => {
+    const fc = fakeClient({})
+    await asAwsS3({ bucket: 'b', client: fc as unknown as S3Client }).deleteObject('k')
+    expect(fc.sent.some((c) => c.name === 'DeleteObjectCommand')).toBe(true)
+  })
+
+  it('publicUrl is a stable URL honoring baseUrl + prefix', () => {
+    const obj = asAwsS3({ bucket: 'b', prefix: 'assets', baseUrl: 'https://cdn.example.com', client: fakeClient({}) as unknown as S3Client })
+    expect(obj.publicUrl('logo.png')).toBe('https://cdn.example.com/assets/logo.png')
+  })
+})
+
+describe('as-aws-s3 — presigned URLs (real client, dummy creds, offline)', () => {
+  const client = new S3Client({ region: 'us-east-1', credentials: { accessKeyId: 'AKIAEXAMPLE', secretAccessKey: 'examplesecretkey' } })
+
+  it('objectUrl produces a presigned GET carrying the key + expiry', async () => {
+    const obj = asAwsS3({ bucket: 'b', prefix: 'p', region: 'us-east-1', client })
+    const url = await obj.objectUrl('k.png', { expiresInSeconds: 120 })
+    expect(url).toContain('p/k.png')
+    expect(url).toContain('X-Amz-Signature=')
+    expect(url).toContain('X-Amz-Expires=120')
+  })
+
+  it('putUrl produces a presigned PUT', async () => {
+    const obj = asAwsS3({ bucket: 'b', region: 'us-east-1', client })
+    const url = await obj.putUrl('big.mp4', { contentType: 'video/mp4', expiresInSeconds: 300 })
+    expect(url).toContain('big.mp4')
+    expect(url).toContain('X-Amz-Signature=')
+    expect(url).toContain('X-Amz-Expires=300')
+  })
+})

--- a/packages/as-aws-s3/package.json
+++ b/packages/as-aws-s3/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@noy-db/as-aws-s3",
+  "version": "0.2.0-pre.19",
+  "description": "AWS S3 object projection for noy-db — serve blob bytes directly from S3/CDN (presigned or public), outside the encrypted store",
+  "license": "MIT",
+  "author": "vLannaAi <vicio@lanna.ai>",
+  "homepage": "https://github.com/vLannaAi/noy-db/tree/main/packages/as-aws-s3#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vLannaAi/noy-db.git",
+    "directory": "packages/as-aws-s3"
+  },
+  "bugs": {
+    "url": "https://github.com/vLannaAi/noy-db/issues"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@noy-db/hub": "workspace:*",
+    "@aws-sdk/client-s3": "^3.0.0",
+    "@aws-sdk/s3-request-presigner": "^3.0.0"
+  },
+  "devDependencies": {
+    "@noy-db/hub": "workspace:*",
+    "@aws-sdk/client-s3": "^3.0.0",
+    "@aws-sdk/s3-request-presigner": "^3.0.0"
+  },
+  "keywords": [
+    "noy-db",
+    "projection",
+    "s3",
+    "aws",
+    "object-storage",
+    "presigned-url",
+    "cdn",
+    "direct-serve"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  }
+}

--- a/packages/as-aws-s3/src/index.ts
+++ b/packages/as-aws-s3/src/index.ts
@@ -1,0 +1,148 @@
+/**
+ * `@noy-db/as-aws-s3` — an {@link ObjectProjection} backed by AWS S3.
+ *
+ * Where `@noy-db/to-aws-s3` is a `to-*` store (ciphertext envelopes in/out, the
+ * zero-knowledge backend), this is an `as-*` **projection**: it holds blob bytes
+ * as **native, directly-consumable S3 objects** so they can be served straight
+ * from S3/CDN — presigned (time-limited, private) or public — and processed by
+ * AWS-native tooling. It sees **raw bytes** and lives **outside** the
+ * zero-knowledge guarantee; wiring it to a blob field is a deliberate opt-in.
+ *
+ * @example
+ * ```ts
+ * import { asAwsS3 } from '@noy-db/as-aws-s3'
+ * const objects = asAwsS3({ bucket: 'acme-public-assets', region: 'eu-west-1' })
+ * await objects.putObject('logos/acme.png', bytes, { contentType: 'image/png', public: true })
+ * const url = objects.publicUrl('logos/acme.png')          // stable CDN/S3 URL
+ * const dl  = await objects.objectUrl('logos/acme.png')    // presigned GET
+ * const up  = await objects.putUrl('videos/x.mp4', { contentType: 'video/mp4' }) // presigned PUT
+ * ```
+ */
+import type {
+  ObjectProjection,
+  ObjectMeta,
+  PutObjectOptions,
+  ObjectUrlOptions,
+  PutUrlOptions,
+} from '@noy-db/hub'
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+  DeleteObjectCommand,
+  HeadObjectCommand,
+} from '@aws-sdk/client-s3'
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
+
+export interface AsAwsS3Options {
+  /** Target bucket. */
+  bucket: string
+  /** Key prefix (folder). A trailing slash is added if missing. */
+  prefix?: string
+  /** AWS region. Default `us-east-1`. */
+  region?: string
+  /** Pre-built `S3Client` to share (overrides `region`). */
+  client?: S3Client
+  /**
+   * Base URL for `publicUrl()` — a CDN origin or the bucket's website/vhost
+   * URL. Defaults to the virtual-hosted S3 URL
+   * (`https://{bucket}.s3.{region}.amazonaws.com`).
+   */
+  baseUrl?: string
+  /** Default presigned-URL TTL (seconds). Default 900 (15 min). */
+  defaultExpiresInSeconds?: number
+}
+
+/** The projection plus an S3-specific stable-public-URL helper. */
+export type AsAwsS3Projection = ObjectProjection & {
+  /** A stable, non-expiring URL for a **public** object (CDN/vhost). */
+  publicUrl(key: string): string
+}
+
+function isNotFound(err: unknown): boolean {
+  const e = err as { name?: string; $metadata?: { httpStatusCode?: number } }
+  return e?.name === 'NotFound' || e?.name === 'NoSuchKey' || e?.$metadata?.httpStatusCode === 404
+}
+
+export function asAwsS3(options: AsAwsS3Options): AsAwsS3Projection {
+  const { bucket } = options
+  const prefix = options.prefix ? options.prefix.replace(/\/+$/, '') + '/' : ''
+  const region = options.region ?? 'us-east-1'
+  const client = options.client ?? new S3Client({ region })
+  // getSignedUrl types its client against its own @smithy/types copy; when the
+  // installed @aws-sdk/client-s3 and s3-request-presigner resolve to different
+  // minor versions, S3Client and the expected Client diverge only on a private
+  // `handlers` field. Runtime is identical — cast across the version skew.
+  const presignClient = client as unknown as Parameters<typeof getSignedUrl>[0]
+  const defaultExpiry = options.defaultExpiresInSeconds ?? 900
+  const publicBase = (options.baseUrl ?? `https://${bucket}.s3.${region}.amazonaws.com`).replace(/\/+$/, '')
+  const fullKey = (key: string): string => `${prefix}${key}`
+
+  return {
+    name: 'aws-s3',
+
+    async putObject(key: string, bytes: Uint8Array, opts: PutObjectOptions): Promise<void> {
+      await client.send(
+        new PutObjectCommand({
+          Bucket: bucket,
+          Key: fullKey(key),
+          Body: bytes,
+          ContentType: opts.contentType,
+          ...(opts.public ? { ACL: 'public-read' as const } : {}),
+          ...(opts.userMeta ? { Metadata: opts.userMeta } : {}),
+        }),
+      )
+    },
+
+    async getObject(key: string): Promise<Uint8Array | null> {
+      try {
+        const r = await client.send(new GetObjectCommand({ Bucket: bucket, Key: fullKey(key) }))
+        if (!r.Body) return null
+        return await r.Body.transformToByteArray()
+      } catch (err) {
+        if (isNotFound(err)) return null
+        throw err
+      }
+    },
+
+    async deleteObject(key: string): Promise<void> {
+      await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: fullKey(key) }))
+    },
+
+    async headObject(key: string): Promise<ObjectMeta | null> {
+      try {
+        const r = await client.send(new HeadObjectCommand({ Bucket: bucket, Key: fullKey(key) }))
+        return {
+          size: r.ContentLength ?? 0,
+          ...(r.ContentType ? { contentType: r.ContentType } : {}),
+          ...(r.ETag ? { etag: r.ETag } : {}),
+          ...(r.LastModified ? { lastModified: r.LastModified.toISOString() } : {}),
+          ...(r.Metadata && Object.keys(r.Metadata).length ? { userMeta: r.Metadata } : {}),
+        }
+      } catch (err) {
+        if (isNotFound(err)) return null
+        throw err
+      }
+    },
+
+    async objectUrl(key: string, opts?: ObjectUrlOptions): Promise<string> {
+      // Always a presigned GET — works for private and public objects alike.
+      // For a stable public URL, use `publicUrl()`.
+      return await getSignedUrl(presignClient, new GetObjectCommand({ Bucket: bucket, Key: fullKey(key) }), {
+        expiresIn: opts?.expiresInSeconds ?? defaultExpiry,
+      })
+    },
+
+    async putUrl(key: string, opts: PutUrlOptions): Promise<string> {
+      return await getSignedUrl(
+        presignClient,
+        new PutObjectCommand({ Bucket: bucket, Key: fullKey(key), ContentType: opts.contentType }),
+        { expiresIn: opts.expiresInSeconds ?? defaultExpiry },
+      )
+    },
+
+    publicUrl(key: string): string {
+      return `${publicBase}/${fullKey(key)}`
+    },
+  }
+}

--- a/packages/as-aws-s3/tsconfig.json
+++ b/packages/as-aws-s3/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/packages/as-aws-s3/tsup.config.ts
+++ b/packages/as-aws-s3/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  target: 'es2022',
+})

--- a/packages/as-aws-s3/vitest.config.ts
+++ b/packages/as-aws-s3/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'as-aws-s3',
+    include: ['__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,18 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.17)(happy-dom@18.0.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.3)(yaml@2.9.0)
 
+  packages/as-aws-s3:
+    devDependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.0.0
+        version: 3.1024.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.0.0
+        version: 3.1068.0
+      '@noy-db/hub':
+        specifier: workspace:*
+        version: link:../hub
+
   packages/as-blob:
     devDependencies:
       '@noy-db/hub':
@@ -1395,6 +1407,10 @@ packages:
     resolution: {integrity: sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.974.20':
+    resolution: {integrity: sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/crc64-nvme@3.972.5':
     resolution: {integrity: sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==}
     engines: {node: '>=20.0.0'}
@@ -1569,16 +1585,20 @@ packages:
     resolution: {integrity: sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/s3-request-presigner@3.1068.0':
+    resolution: {integrity: sha512-XTUoaBQH3pUlegqdoo7vkrOvlcRhSz/EO0/JYy9qKz4jdsOnPUlPY0p+rKTl27F91Gjgip8OXopiOFxVeN3Yvg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.15':
     resolution: {integrity: sha512-Ukw2RpqvaL96CjfH/FgfBmy/ZosHBqoHBCFsN61qGg99F33vpntIVii8aNeh65XuOja73arSduskoa4OJea9RQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/signature-v4-multi-region@3.996.28':
-    resolution: {integrity: sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/signature-v4-multi-region@3.996.30':
     resolution: {integrity: sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.34':
+    resolution: {integrity: sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1021.0':
@@ -1591,6 +1611,10 @@ packages:
 
   '@aws-sdk/token-providers@3.1056.0':
     resolution: {integrity: sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.12':
+    resolution: {integrity: sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.6':
@@ -1641,6 +1665,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.26':
     resolution: {integrity: sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.29':
+    resolution: {integrity: sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -4427,6 +4455,10 @@ packages:
     resolution: {integrity: sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.24.7':
+    resolution: {integrity: sha512-KoUi4M1f3BG6kzN1FnCwL7oyFptTbyBJKjR6yhSib+JHRdUmM1o+VwsFtJ66NZCkCzVfJMWRHJNo0R0jznp0Pg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.12':
     resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
     engines: {node: '>=18.0.0'}
@@ -4571,6 +4603,10 @@ packages:
     resolution: {integrity: sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.4.7':
+    resolution: {integrity: sha512-LwQZazFayImv+IOm0S0enoLeUJwmAlhGC5O6YCcLWezyu08dF46GOxPOq35OpBIHkgd7OvNvBStIFwVNyrvoBw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/smithy-client@4.12.8':
     resolution: {integrity: sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==}
     engines: {node: '>=18.0.0'}
@@ -4581,6 +4617,10 @@ packages:
 
   '@smithy/types@4.14.2':
     resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.4':
+    resolution: {integrity: sha512-B2S9+UGm1+/pHkcx3ZoLVX1a+pmSk8rqxRR+ZsNqZaJ5q9FWX9AFGQVM4qG5+OBeQUZVy99HY8HqW8gK/wgXzQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@4.2.12':
@@ -6997,7 +7037,6 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   light-my-request@6.6.0:
@@ -9720,6 +9759,17 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.20':
+    dependencies:
+      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/xml-builder': 3.972.29
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.7
+      '@smithy/signature-v4': 5.4.7
+      '@smithy/types': 4.14.4
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/crc64-nvme@3.972.5':
     dependencies:
       '@smithy/types': 4.13.1
@@ -9835,23 +9885,23 @@ snapshots:
 
   '@aws-sdk/credential-provider-login@3.972.28':
     dependencies:
-      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/core': 3.974.15
       '@aws-sdk/nested-clients': 3.996.18
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.9
       '@smithy/property-provider': 4.2.12
       '@smithy/protocol-http': 5.3.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
   '@aws-sdk/credential-provider-login@3.972.43':
     dependencies:
-      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/core': 3.974.15
       '@aws-sdk/nested-clients': 3.997.11
       '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -10129,18 +10179,18 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/core': 3.974.15
       '@aws-sdk/middleware-host-header': 3.972.8
       '@aws-sdk/middleware-logger': 3.972.8
       '@aws-sdk/middleware-recursion-detection': 3.972.9
       '@aws-sdk/middleware-user-agent': 3.972.28
       '@aws-sdk/region-config-resolver': 3.972.10
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.9
       '@aws-sdk/util-endpoints': 3.996.5
       '@aws-sdk/util-user-agent-browser': 3.972.8
       '@aws-sdk/util-user-agent-node': 3.973.14
       '@smithy/config-resolver': 4.4.13
-      '@smithy/core': 3.23.13
+      '@smithy/core': 3.24.5
       '@smithy/fetch-http-handler': 5.3.15
       '@smithy/hash-node': 4.2.12
       '@smithy/invalid-dependency': 4.2.12
@@ -10153,7 +10203,7 @@ snapshots:
       '@smithy/node-http-handler': 4.5.1
       '@smithy/protocol-http': 5.3.12
       '@smithy/smithy-client': 4.12.8
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.2
       '@smithy/url-parser': 4.2.12
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
@@ -10172,10 +10222,10 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/signature-v4-multi-region': 3.996.28
+      '@aws-sdk/core': 3.974.15
+      '@aws-sdk/signature-v4-multi-region': 3.996.30
       '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
+      '@smithy/core': 3.24.5
       '@smithy/fetch-http-handler': 5.4.4
       '@smithy/node-http-handler': 4.7.4
       '@smithy/types': 4.14.2
@@ -10202,6 +10252,15 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@aws-sdk/s3-request-presigner@3.1068.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/signature-v4-multi-region': 3.996.34
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.15':
     dependencies:
       '@aws-sdk/middleware-sdk-s3': 3.972.27
@@ -10211,14 +10270,6 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/signature-v4-multi-region@3.996.28':
-    dependencies:
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/signature-v4': 5.4.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
   '@aws-sdk/signature-v4-multi-region@3.996.30':
     dependencies:
       '@aws-sdk/types': 3.973.9
@@ -10226,24 +10277,31 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.34':
+    dependencies:
+      '@aws-sdk/types': 3.973.12
+      '@smithy/signature-v4': 5.4.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
   '@aws-sdk/token-providers@3.1021.0':
     dependencies:
-      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/core': 3.974.15
       '@aws-sdk/nested-clients': 3.996.18
-      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/types': 3.973.9
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.2
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
 
   '@aws-sdk/token-providers@3.1052.0':
     dependencies:
-      '@aws-sdk/core': 3.974.13
+      '@aws-sdk/core': 3.974.15
       '@aws-sdk/nested-clients': 3.997.11
       '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
+      '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
@@ -10254,6 +10312,11 @@ snapshots:
       '@aws-sdk/types': 3.973.9
       '@smithy/core': 3.24.5
       '@smithy/types': 4.14.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.12':
+    dependencies:
+      '@smithy/types': 4.14.4
       tslib: 2.8.1
 
   '@aws-sdk/types@3.973.6':
@@ -10319,6 +10382,12 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.26':
     dependencies:
       '@smithy/types': 4.14.2
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.29':
+    dependencies:
+      '@smithy/types': 4.14.4
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
 
@@ -12935,6 +13004,12 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@smithy/core@3.24.7':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.12':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
@@ -12958,7 +13033,7 @@ snapshots:
   '@smithy/eventstream-codec@4.2.12':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.13.1
+      '@smithy/types': 4.14.2
       '@smithy/util-hex-encoding': 4.2.2
       tslib: 2.8.1
 
@@ -13164,6 +13239,12 @@ snapshots:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.4.7':
+    dependencies:
+      '@smithy/core': 3.24.7
+      '@smithy/types': 4.14.4
+      tslib: 2.8.1
+
   '@smithy/smithy-client@4.12.8':
     dependencies:
       '@smithy/core': 3.23.13
@@ -13179,6 +13260,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.14.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.4':
     dependencies:
       tslib: 2.8.1
 


### PR DESCRIPTION
Second slice of #412 — the **`@noy-db/as-aws-s3`** package (the user-named adapter), implementing the #412 P1 `ObjectProjection` contract over AWS S3.

### What
`asAwsS3({ bucket, prefix, region, client, baseUrl, defaultExpiresInSeconds })` →
- `putObject` (raw bytes + ContentType; `ACL: public-read` when `public`; `Metadata` from `userMeta`)
- `getObject` / `deleteObject` / `headObject` (maps S3 → `ObjectMeta`)
- `objectUrl` (presigned GET), `putUrl` (presigned PUT — direct large-file upload), `publicUrl` (stable CDN/vhost URL)

Peer deps: `@noy-db/hub`, `@aws-sdk/client-s3`, `@aws-sdk/s3-request-presigner` (lockfile updated). A localized cast on the `getSignedUrl` client bridges the client-s3 ↔ presigner `@smithy/types` version skew (runtime-identical; documented).

### Verification — cloud-free, no credentials
- 8 tests: command wiring via a **fake** S3 client; presigned-URL generation via a **real** `S3Client` with **dummy static creds** (SigV4 presigning is local crypto, runs offline).
- typecheck / build / lint / `check-architecture` / `validate-features` all clean.

### Not in this slice
Blob-field wiring (storage classes routing the raw-object path to an `ObjectProjection`) is **#412 P3** — features.yaml registration + a showcase land with that end-to-end wiring. Real-bucket validation is for you to run with your creds (I don't use them).

Refs #412