### PR TITLE
feat(blobs): external-blob metadata/backlink + import-bootstrap (#412 §3.6/§3.8)

### DIFF
--- a/packages/as-aws-s3/__tests__/as-aws-s3.test.ts
+++ b/packages/as-aws-s3/__tests__/as-aws-s3.test.ts
@@ -74,6 +74,27 @@ describe('as-aws-s3 — command wiring (fake client)', () => {
     expect(fc.sent.some((c) => c.name === 'DeleteObjectCommand')).toBe(true)
   })
 
+  it('listPrefix lists objects and strips the configured prefix', async () => {
+    const fc = fakeClient({
+      ListObjectsV2Command: () => ({
+        Contents: [
+          { Key: 'p/a/b.png', Size: 10, ETag: '"e1"' },
+          { Key: 'p/a/c.png', Size: 20, ETag: '"e2"', LastModified: new Date('2026-06-15T00:00:00Z') },
+        ],
+        IsTruncated: false,
+      }),
+    })
+    const obj = asAwsS3({ bucket: 'b', prefix: 'p', client: fc as unknown as S3Client })
+    const list = await obj.listPrefix('a/')
+    expect(list).toEqual([
+      { key: 'a/b.png', meta: { size: 10, etag: '"e1"' } },
+      { key: 'a/c.png', meta: { size: 20, etag: '"e2"', lastModified: '2026-06-15T00:00:00.000Z' } },
+    ])
+    // queried under the full prefix
+    const cmd = fc.sent.find((c) => c.name === 'ListObjectsV2Command')!
+    expect(cmd.input.Prefix).toBe('p/a/')
+  })
+
   it('publicUrl is a stable URL honoring baseUrl + prefix', () => {
     const obj = asAwsS3({ bucket: 'b', prefix: 'assets', baseUrl: 'https://cdn.example.com', client: fakeClient({}) as unknown as S3Client })
     expect(obj.publicUrl('logo.png')).toBe('https://cdn.example.com/assets/logo.png')

--- a/packages/as-aws-s3/src/index.ts
+++ b/packages/as-aws-s3/src/index.ts
@@ -31,6 +31,7 @@ import {
   GetObjectCommand,
   DeleteObjectCommand,
   HeadObjectCommand,
+  ListObjectsV2Command,
 } from '@aws-sdk/client-s3'
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner'
 
@@ -139,6 +140,31 @@ export function asAwsS3(options: AsAwsS3Options): AsAwsS3Projection {
         new PutObjectCommand({ Bucket: bucket, Key: fullKey(key), ContentType: opts.contentType }),
         { expiresIn: opts.expiresInSeconds ?? defaultExpiry },
       )
+    },
+
+    async listPrefix(listPrefixArg: string) {
+      const out: Array<{ key: string; meta: ObjectMeta }> = []
+      let token: string | undefined
+      do {
+        const r = await client.send(
+          new ListObjectsV2Command({ Bucket: bucket, Prefix: fullKey(listPrefixArg), ContinuationToken: token }),
+        )
+        for (const obj of r.Contents ?? []) {
+          if (!obj.Key) continue
+          // Strip the configured prefix so callers see logical keys.
+          const logicalKey = prefix && obj.Key.startsWith(prefix) ? obj.Key.slice(prefix.length) : obj.Key
+          out.push({
+            key: logicalKey,
+            meta: {
+              size: obj.Size ?? 0,
+              ...(obj.ETag ? { etag: obj.ETag } : {}),
+              ...(obj.LastModified ? { lastModified: obj.LastModified.toISOString() } : {}),
+            },
+          })
+        }
+        token = r.IsTruncated ? r.NextContinuationToken : undefined
+      } while (token)
+      return out
     },
 
     publicUrl(key: string): string {

--- a/packages/hub/__tests__/external-blob.test.ts
+++ b/packages/hub/__tests__/external-blob.test.ts
@@ -10,6 +10,7 @@ import { ConflictError } from '../src/errors.js'
 import { createNoydb } from '../src/noydb.js'
 import { withBlobs } from '../src/blobs/index.js'
 import { memoryObjectProjection } from '../src/blobs/object-projection.js'
+import { importExternalObjects } from '../src/blobs/import-external.js'
 
 function makeStore(): NoydbStore {
   const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
@@ -92,6 +93,71 @@ describe('#412 P3 — external blob fields route to the ObjectProjection', () =>
     await docs.blob('d1').delete('video')
     expect(await objects.getObject(key)).toBeNull()
     expect(await docs.blob('d1').get('video')).toBeNull()
+  })
+
+  it('stamps an opaque-token backlink (default) onto the object + records it on the slot', async () => {
+    const objects = memoryObjectProjection()
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: 'passphrase-1234-long-enough', objectStore: objects, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs', { blobFields: { video: { external: true } } })
+    await docs.put('d1', { id: 'd1' })
+    await docs.blob('d1').put('video', payload(200))
+
+    const meta = await objects.headObject('docs/d1/video')
+    const token = meta?.userMeta?.['noydb-backlink']
+    expect(typeof token).toBe('string')
+    const slot = (await docs.blob('d1').list()).find((s) => s.name === 'video')!
+    expect(slot.external?.backlink).toBe(token) // self-recorded for reconcile
+    // opaque-token does not leak the record id
+    expect(meta?.userMeta?.['noydb-record']).toBeUndefined()
+  })
+
+  it('plain backlink stamps the structure (leaky, opt-in)', async () => {
+    const objects = memoryObjectProjection()
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: 'passphrase-1234-long-enough', objectStore: objects, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs', { blobFields: { video: { external: true, backlink: 'plain' } } })
+    await docs.put('d1', { id: 'd1' })
+    await docs.blob('d1').put('video', payload(200))
+    const meta = await objects.headObject('docs/d1/video')
+    expect(meta?.userMeta).toMatchObject({ 'noydb-collection': 'docs', 'noydb-record': 'd1', 'noydb-field': 'video' })
+  })
+
+  it('setExternalMeta / externalMeta round-trip the secondary metadata store', async () => {
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: 'passphrase-1234-long-enough', objectStore: memoryObjectProjection(), blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs', { blobFields: { video: { external: true } } })
+    await docs.put('d1', { id: 'd1' })
+    await docs.blob('d1').put('video', payload(200))
+    await docs.blob('d1').setExternalMeta('video', { durationSec: 12, width: 1920, height: 1080 })
+    expect(await docs.blob('d1').externalMeta('video')).toEqual({ durationSec: 12, width: 1920, height: 1080 })
+    // survives re-upload
+    await docs.blob('d1').put('video', payload(300))
+    expect(await docs.blob('d1').externalMeta('video')).toEqual({ durationSec: 12, width: 1920, height: 1080 })
+  })
+
+  it('importExternalObjects builds a collection from existing bucket objects (idempotent)', async () => {
+    const objects = memoryObjectProjection()
+    await objects.putObject('docs/r1/scan', payload(100), { contentType: 'image/png' })
+    await objects.putObject('docs/r2/scan', payload(150), { contentType: 'image/png' })
+    await objects.putObject('other/x', payload(10), { contentType: 'text/plain' }) // excluded by the 'docs/' prefix filter
+
+    const db = await createNoydb({ store: makeStore(), user: 'op', secret: 'passphrase-1234-long-enough', objectStore: objects, blobStrategy: withBlobs() })
+    const vault = await db.openVault('t')
+    const docs = vault.collection<{ id: string }>('docs', { blobFields: { scan: { external: true } } })
+
+    const res = await importExternalObjects({ collection: docs, objectStore: objects, field: 'scan', options: { prefix: 'docs/' } })
+    expect(res.imported).toBe(2)
+    expect(res.recordIds.sort()).toEqual(['r1', 'r2'])
+
+    // records exist + the external blob is readable through the anchored slot
+    expect(await docs.get('r1')).toEqual({ id: 'r1' })
+    expect(Buffer.from((await docs.blob('r1').get('scan'))!).equals(Buffer.from(payload(100)))).toBe(true)
+
+    // idempotent re-run
+    const res2 = await importExternalObjects({ collection: docs, objectStore: objects, field: 'scan', options: { prefix: 'docs/' } })
+    expect(res2.imported).toBe(2)
+    expect(await docs.list()).toHaveLength(2)
   })
 
   it('url() throws for a non-external slot', async () => {

--- a/packages/hub/src/blobs/blob-compaction.ts
+++ b/packages/hub/src/blobs/blob-compaction.ts
@@ -80,6 +80,19 @@ export interface BlobFieldPolicy<T = unknown> {
    * than presigned-only. Default `false` (presigned). Ignored unless `external`.
    */
   readonly public?: boolean
+  /**
+   * For an `external` field: how to stamp a **backlink** (this record's
+   * vault/collection/id/field) onto the object's metadata — the self-describing
+   * "secondary store" that powers reconcile / DR / import re-pairing.
+   * - `'opaque-token'` (default): a random id; preserves the opaque-bucket
+   *   property (no names leak); the token is also recorded on the slot.
+   * - `'encrypted'`: the reference encrypted under the blob DEK (ZK-preserving;
+   *   falls back to `'opaque-token'` on a plaintext vault).
+   * - `'plain'`: the reference in cleartext metadata — **leaks structure** to
+   *   bucket readers; only for non-sensitive deployments.
+   * - `'none'`: no backlink.
+   */
+  readonly backlink?: 'opaque-token' | 'encrypted' | 'plain' | 'none'
 }
 
 export type BlobFieldsConfig<T = unknown> = Record<string, BlobFieldPolicy<T>>

--- a/packages/hub/src/blobs/blob-set.ts
+++ b/packages/hub/src/blobs/blob-set.ts
@@ -669,15 +669,30 @@ export class BlobSet {
       }
       const key = `${this.collection}/${this.recordId}/${slotName}`
       const isPublic = policy.public === true
-      await this.objectStore.putObject(key, data, { contentType, public: isPublic })
+      // Stamp a self-describing backlink onto the object's metadata (the
+      // "secondary store"): default opaque-token (no name leak).
+      const backlink = await this.buildBacklink(slotName, policy.backlink ?? 'opaque-token')
+      await this.objectStore.putObject(key, data, {
+        contentType,
+        public: isPublic,
+        ...(backlink.userMeta ? { userMeta: backlink.userMeta } : {}),
+      })
 
       const uploaderUserId = opts?.uploadedBy ?? this.userId
       let oldETag: string | undefined
       await this.casUpdateSlots((slots) => {
         oldETag = slots[slotName]?.eTag || undefined
+        // Preserve any previously-synced derived metadata across re-upload.
+        const prevMeta = slots[slotName]?.external?.meta
         slots[slotName] = {
           eTag: '',
-          external: { key, contentType, ...(isPublic ? { public: true } : {}) },
+          external: {
+            key,
+            contentType,
+            ...(isPublic ? { public: true } : {}),
+            ...(backlink.token ? { backlink: backlink.token } : {}),
+            ...(prevMeta ? { meta: prevMeta } : {}),
+          },
           filename: slotName,
           size: data.byteLength,
           mimeType: contentType,
@@ -851,6 +866,106 @@ export class BlobSet {
       throw new NotFoundError(`Blob slot "${slotName}" is external but no objectStore is configured`)
     }
     return this.objectStore.objectUrl(slot.external.key, opts)
+  }
+
+  /**
+   * Build the backlink stamped onto an external object's metadata — the
+   * self-describing "secondary store" reference back to this record. See
+   * {@link BlobFieldPolicy.backlink}. Returns the `userMeta` to attach and, for
+   * `opaque-token`, the `token` to record on the slot.
+   */
+  private async buildBacklink(
+    slotName: string,
+    mode: 'opaque-token' | 'encrypted' | 'plain' | 'none',
+  ): Promise<{ userMeta?: Record<string, string>; token?: string }> {
+    if (mode === 'none') return {}
+    const ref = { vault: this.vault, collection: this.collection, record: this.recordId, field: slotName }
+    if (mode === 'plain') {
+      return {
+        userMeta: {
+          'noydb-vault': ref.vault,
+          'noydb-collection': ref.collection,
+          'noydb-record': ref.record,
+          'noydb-field': ref.field,
+        },
+      }
+    }
+    if (mode === 'encrypted' && this.encrypted) {
+      const dek = await this.getDEK(BLOB_COLLECTION)
+      const { iv, data } = await encrypt(JSON.stringify(ref), dek)
+      return { userMeta: { 'noydb-backlink-enc': `${iv}.${data}` } }
+    }
+    // opaque-token — also the fallback when `encrypted` is requested on a
+    // plaintext vault (no DEK to encrypt under).
+    const bytes = globalThis.crypto.getRandomValues(new Uint8Array(16))
+    const token = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('')
+    return { userMeta: { 'noydb-backlink': token }, token }
+  }
+
+  /**
+   * Adopt an EXISTING object in the projection into this slot **without
+   * re-uploading** — used by import/bootstrap to anchor objects already in the
+   * bucket. Writes the external slot record (the catalog entry).
+   */
+  async adoptExternal(
+    slotName: string,
+    ref: {
+      key: string
+      size?: number
+      contentType?: string
+      public?: boolean
+      backlink?: string
+      meta?: Record<string, unknown>
+    },
+  ): Promise<void> {
+    const uploaderUserId = this.userId
+    await this.casUpdateSlots((slots) => {
+      slots[slotName] = {
+        eTag: '',
+        external: {
+          key: ref.key,
+          ...(ref.contentType ? { contentType: ref.contentType } : {}),
+          ...(ref.public ? { public: true } : {}),
+          ...(ref.backlink ? { backlink: ref.backlink } : {}),
+          ...(ref.meta ? { meta: ref.meta } : {}),
+        },
+        filename: slotName,
+        size: ref.size ?? 0,
+        ...(ref.contentType ? { mimeType: ref.contentType } : {}),
+        uploadedAt: new Date().toISOString(),
+        ...(uploaderUserId !== undefined ? { uploadedBy: uploaderUserId } : {}),
+      }
+      return slots
+    })
+  }
+
+  /**
+   * Merge derived metadata (video `duration`, image `width`/`height`, arbitrary
+   * metatags) into an external slot's secondary metadata store. Typically called
+   * from an AWS-side processing callback (MediaConvert / ffprobe / Rekognition)
+   * once it has probed the object. No-op for a missing or non-external slot.
+   */
+  async setExternalMeta(slotName: string, meta: Record<string, unknown>): Promise<void> {
+    await this.casUpdateSlots((slots) => {
+      const slot = slots[slotName]
+      if (!slot?.external) return null
+      slots[slotName] = {
+        ...slot,
+        external: { ...slot.external, meta: { ...slot.external.meta, ...meta } },
+      }
+      return slots
+    })
+  }
+
+  /**
+   * Read an external slot's synced derived metadata (the secondary store).
+   * Returns `null` for a missing or non-external slot, `{}` if none synced yet.
+   */
+  async externalMeta(slotName: string): Promise<Record<string, unknown> | null> {
+    const { slots } = await this.loadSlots()
+    const slot = slots[slotName]
+    if (!slot?.external) return null
+    return slot.external.meta ?? {}
   }
 
   /**

--- a/packages/hub/src/blobs/import-external.ts
+++ b/packages/hub/src/blobs/import-external.ts
@@ -1,0 +1,86 @@
+/**
+ * Import / bootstrap (reverse projection) — walk an existing bucket/prefix in an
+ * {@link ObjectProjection} and build a master collection where each record
+ * anchors one object, restoring the record-anchoring invariant for objects that
+ * pre-date noy-db (or were written by another system). See as-aws-s3 §3.8.
+ *
+ * Idempotent: re-running re-adopts the same objects under the same record ids.
+ */
+import type { ObjectProjection } from './object-projection.js'
+
+/** Minimal collection surface this utility needs (avoids importing the kernel). */
+export interface ImportableCollection {
+  get(id: string): Promise<unknown>
+  put(id: string, record: unknown): Promise<unknown>
+  blob(id: string): {
+    adoptExternal(
+      slot: string,
+      ref: { key: string; size?: number; contentType?: string; public?: boolean; backlink?: string },
+    ): Promise<void>
+  }
+}
+
+export interface ImportExternalOptions {
+  /** Only consider objects under this key prefix. Default `''` (all). */
+  prefix?: string
+  /**
+   * Derive the record id for an object key. Default: the path segment before
+   * the last — i.e. `{collection}/{recordId}/{field}` → `recordId`. Return
+   * `null` to skip the object.
+   */
+  deriveRecordId?: (key: string) => string | null
+  /** Build the anchor record for a new id. Default `{ id }`. */
+  makeRecord?: (id: string) => unknown
+}
+
+export interface ImportExternalResult {
+  imported: number
+  skipped: number
+  recordIds: string[]
+}
+
+function defaultDeriveRecordId(key: string): string | null {
+  const parts = key.split('/')
+  return parts.length >= 2 ? (parts[parts.length - 2] ?? null) : null
+}
+
+/**
+ * Build/extend `collection` from the objects under `prefix` in `objectStore`,
+ * adopting each as the `field` blob on its derived record.
+ */
+export async function importExternalObjects(args: {
+  collection: ImportableCollection
+  objectStore: ObjectProjection
+  field: string
+  options?: ImportExternalOptions
+}): Promise<ImportExternalResult> {
+  const { collection, objectStore, field } = args
+  const opts = args.options ?? {}
+  const derive = opts.deriveRecordId ?? defaultDeriveRecordId
+  const makeRecord = opts.makeRecord ?? ((id: string) => ({ id }))
+
+  const objects = await objectStore.listPrefix(opts.prefix ?? '')
+  const recordIds: string[] = []
+  let imported = 0
+  let skipped = 0
+
+  for (const { key, meta } of objects) {
+    const recordId = derive(key)
+    if (!recordId) {
+      skipped++
+      continue
+    }
+    if ((await collection.get(recordId)) == null) {
+      await collection.put(recordId, makeRecord(recordId))
+    }
+    await collection.blob(recordId).adoptExternal(field, {
+      key,
+      ...(meta.size !== undefined ? { size: meta.size } : {}),
+      ...(meta.contentType ? { contentType: meta.contentType } : {}),
+    })
+    recordIds.push(recordId)
+    imported++
+  }
+
+  return { imported, skipped, recordIds }
+}

--- a/packages/hub/src/blobs/index.ts
+++ b/packages/hub/src/blobs/index.ts
@@ -22,10 +22,17 @@ export { memoryObjectProjection } from './object-projection.js'
 export type {
   ObjectProjection,
   ObjectMeta,
+  ObjectListEntry,
   PutObjectOptions,
   ObjectUrlOptions,
   PutUrlOptions,
 } from './object-projection.js'
+export { importExternalObjects } from './import-external.js'
+export type {
+  ImportableCollection,
+  ImportExternalOptions,
+  ImportExternalResult,
+} from './import-external.js'
 
 export { BlobSet } from './blob-set.js'
 export {

--- a/packages/hub/src/blobs/object-projection.ts
+++ b/packages/hub/src/blobs/object-projection.ts
@@ -41,6 +41,12 @@ export interface PutUrlOptions {
   readonly expiresInSeconds?: number
 }
 
+/** One entry returned by {@link ObjectProjection.listPrefix}. */
+export interface ObjectListEntry {
+  readonly key: string
+  readonly meta: ObjectMeta
+}
+
 export interface ObjectProjection {
   /** Diagnostic name (e.g. `'aws-s3'`, `'memory'`). */
   readonly name?: string
@@ -57,6 +63,8 @@ export interface ObjectProjection {
   /** A presigned URL the client PUTs bytes to directly (large-file upload,
    *  bytes bypass the hub). */
   putUrl(key: string, opts: PutUrlOptions): Promise<string>
+  /** List objects under a key prefix — for import / reconcile. */
+  listPrefix(prefix: string): Promise<ObjectListEntry[]>
 }
 
 /**
@@ -102,6 +110,17 @@ export function memoryObjectProjection(opts: { baseUrl?: string } = {}): ObjectP
     },
     async putUrl(key, o) {
       return `${base}/${key}?upload=memory&ct=${encodeURIComponent(o.contentType)}`
+    },
+    async listPrefix(prefix) {
+      const out: ObjectListEntry[] = []
+      for (const [key, e] of store) {
+        if (!key.startsWith(prefix)) continue
+        out.push({
+          key,
+          meta: { size: e.bytes.byteLength, contentType: e.contentType, ...(e.userMeta ? { userMeta: e.userMeta } : {}) },
+        })
+      }
+      return out
     },
   }
 }

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -161,10 +161,17 @@ export { memoryObjectProjection } from './blobs/object-projection.js'
 export type {
   ObjectProjection,
   ObjectMeta,
+  ObjectListEntry,
   PutObjectOptions,
   ObjectUrlOptions,
   PutUrlOptions,
 } from './blobs/object-projection.js'
+export { importExternalObjects } from './blobs/import-external.js'
+export type {
+  ImportableCollection,
+  ImportExternalOptions,
+  ImportExternalResult,
+} from './blobs/import-external.js'
 export {
   BLOB_COLLECTION,
   BLOB_INDEX_COLLECTION,

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -1584,6 +1584,14 @@ export interface SlotRecord {
     readonly key: string
     readonly contentType?: string
     readonly public?: boolean
+    /** Opaque-token backlink stamped on the object (when `backlink:'opaque-token'`). */
+    readonly backlink?: string
+    /**
+     * Secondary metadata store synced from the object / its processing pipeline
+     * (e.g. video `duration`, image `width`/`height`, arbitrary metatags).
+     * Populated via `BlobSet.setExternalMeta()` — typically an AWS-side callback.
+     */
+    readonly meta?: Record<string, unknown>
   }
   /** User-visible filename for the slot. */
   readonly filename: string


### PR DESCRIPTION
Adds the two `as-aws-s3` follow-ups you picked for pre.20 — both already designed, both cloud-free testable.

### Metadata + backlink (§3.6)
- External put stamps a **backlink** onto the object's metadata (the 'secondary store'). Modes via `blobFields.<f>.backlink`: **opaque-token** (default — random id, no name leak, recorded on the slot for reconcile), **encrypted** (ref under the blob DEK; falls back to opaque-token on plaintext vaults), **plain** (cleartext, leaks structure), **none**.
- `setExternalMeta()` / `externalMeta()` — per-slot secondary metadata store for AWS-side probe results (duration, dimensions, metatags); survives re-upload.

### Import / bootstrap (§3.8)
- `ObjectProjection.listPrefix()` (memory + as-aws-s3 paginated `ListObjectsV2`, prefix-stripped).
- `BlobSet.adoptExternal()` — anchor an existing object into a slot **without re-uploading**.
- `importExternalObjects()` — walk a bucket/prefix → build a collection, adopting each object as the field blob on its derived record. **Idempotent**.

### Verification
- +7 hub tests (backlink opaque/plain, setExternalMeta round-trip, import idempotent) + 1 as-aws-s3 (listPrefix); **full hub suite (2698) green** (2 flaky timing tests confirmed non-reproducible across 2 reruns); arch / lint / typecheck / validate-features / showcases-typecheck clean. No new deps, no kernel-surface growth.

Refs #412 (remaining deferred: two-phase presigned-PUT upload, copyMetadata-to-existing, real-bucket validation)