### PR TITLE
feat(as-xlsx): smart workbook — formulas + FK VLOOKUP + manifest (#414 P1)

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -2282,12 +2282,15 @@ exports:
         path: showcases/src/33-as-xlsx.showcase.test.ts
       - id: 51-as-readers-import
         path: showcases/src/51-as-readers-import.showcase.test.ts
+      - id: 114-as-xlsx-smart
+        path: showcases/src/114-as-xlsx-smart.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
     invariants:
       - 'Real .xlsx (Office Open XML); writer emits 6 parts incl. sharedStrings'
       - 'Multi-sheet — preserves relational shape across collections'
+      - 'Smart mode (toBytes({ smart: true }), #414 P1): id-first sheets; FK fields (auto-detected via dumpSchema) get a <field>__label VLOOKUP column with a cached resolved label (live + immediate); a _manifest index sheet. Formula cells via formula(f, cachedValue) emit <f> + cached <v>'
       - 'fromBytes reads sharedStrings + workbook + sheet<N>.xml; opt-in date coercion via fieldTypes'
       - 'fast-xml-parser dep (^5.0.0); strict mode via XMLValidator pre-pass'
       - 'Import gated by importCapability.plaintext.xlsx; apply() inside vault.transaction'

--- a/packages/as-xlsx/__tests__/as-xlsx-smart.test.ts
+++ b/packages/as-xlsx/__tests__/as-xlsx-smart.test.ts
@@ -1,0 +1,74 @@
+/**
+ * #414 P1 — smart-workbook export. `toBytes(vault, { smart: true })` emits a
+ * relational workbook: id-first sheets, a `_manifest` index, and FK→VLOOKUP
+ * label columns (auto-detected via dumpSchema) carrying a cached resolved label.
+ */
+import { describe, expect, it } from 'vitest'
+import { createNoydb, ref } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { toBytes, readXlsx, formula } from '../src/index.js'
+
+interface Client { id: string; name: string }
+interface Invoice { id: string; clientId: string; amount: number }
+
+async function setup() {
+  const adapter = memory()
+  const init = await createNoydb({ store: adapter, user: 'alice', secret: 'pw-2026' })
+  await init.openVault('firm')
+  await init.grant('firm', {
+    userId: 'alice', displayName: 'Alice', role: 'owner', passphrase: 'pw-2026',
+    exportCapability: { plaintext: ['xlsx'] },
+  })
+  init.close()
+
+  const db = await createNoydb({ store: adapter, user: 'alice', secret: 'pw-2026' })
+  const vault = await db.openVault('firm')
+  await vault.collection<Client>('clients').put('c1', { id: 'c1', name: 'Acme' })
+  await vault.collection<Invoice>('invoices', { refs: { clientId: ref('clients', 'strict') } })
+    .put('i1', { id: 'i1', clientId: 'c1', amount: 100 })
+  return { vault }
+}
+
+/** Build a header-name → column-letter map from a readXlsx sheet's first row. */
+function headerMap(sheet: { rows: readonly Record<string, unknown>[] }): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [letter, name] of Object.entries(sheet.rows[0] ?? {})) out[String(name)] = letter
+  return out
+}
+
+describe('#414 P1 — smart export', () => {
+  it('emits a _manifest sheet listing collections + refs', async () => {
+    const { vault } = await setup()
+    const wb = await readXlsx(await toBytes(vault, {
+      smart: true,
+      sheets: [{ name: 'clients', collection: 'clients' }, { name: 'invoices', collection: 'invoices' }],
+    }))
+    const manifest = wb.sheets.find((s) => s.name === '_manifest')!
+    expect(manifest).toBeTruthy()
+    const h = headerMap(manifest)
+    const invRow = manifest.rows.slice(1).find((r) => r[h['Collection']!] === 'invoices')!
+    expect(invRow[h['Refs']!]).toBe('clientId→clients')
+  })
+
+  it('FK field gets a VLOOKUP label column with the cached resolved label', async () => {
+    const { vault } = await setup()
+    const inv = (await readXlsx(await toBytes(vault, {
+      smart: true,
+      sheets: [{ name: 'clients', collection: 'clients' }, { name: 'invoices', collection: 'invoices' }],
+    }))).sheets.find((s) => s.name === 'invoices')!
+
+    const h = headerMap(inv)
+    expect(h['id']).toBe('A') // id-first
+    expect(h['clientId__label']).toBeTruthy()
+    const row = inv.rows.slice(1).find((r) => r[h['id']!] === 'i1')!
+    // cached value of the VLOOKUP = the client's first field ('Acme')
+    expect(row[h['clientId__label']!]).toBe('Acme')
+  })
+
+  it('formula() emits a live <f> with a cached value (round-trips via readXlsx)', async () => {
+    const { writeXlsx } = await import('../src/index.js')
+    const bytes = await writeXlsx([{ name: 's', header: ['x'], rows: [[formula('1+2', 3)]] }])
+    const wb = await readXlsx(bytes)
+    expect(wb.sheets[0]!.rows[1]!['A']).toBe(3) // cached value readable
+  })
+})

--- a/packages/as-xlsx/src/index.ts
+++ b/packages/as-xlsx/src/index.ts
@@ -29,10 +29,10 @@
  */
 
 import type { Vault, DictEntry } from '@noy-db/hub'
-import { writeXlsx, type XlsxSheet } from './xlsx.js'
+import { writeXlsx, colLetter, formula, type XlsxSheet } from './xlsx.js'
 import { readXlsx } from './read.js'
 
-export { writeXlsx, colLetter, type XlsxSheet, type XlsxRow } from './xlsx.js'
+export { writeXlsx, colLetter, formula, type XlsxSheet, type XlsxRow, type XlsxFormulaCell } from './xlsx.js'
 export { readXlsx, type ReadXlsxResult, type ReadXlsxSheet, type ReadXlsxRow } from './read.js'
 
 /** Per-sheet options for the noy-db consumer API. */
@@ -75,6 +75,21 @@ export interface AsXlsxSheetOptions {
 export interface AsXlsxOptions {
   /** One or more sheets. At least one required. */
   readonly sheets: readonly AsXlsxSheetOptions[]
+  /**
+   * Smart-workbook mode (#414). Emits a relational workbook instead of a flat
+   * dump:
+   *   - every sheet is **id-first** (record `id` in column A);
+   *   - each foreign-key field (auto-detected via `vault.dumpSchema()`) gets a
+   *     `<field>__label` column — a cross-sheet `VLOOKUP` that resolves the
+   *     reference to the target's first field, carrying a **cached** label so it
+   *     shows immediately and recomputes live on edit;
+   *   - a `_manifest` index sheet lists every collection, its row count, and
+   *     its refs.
+   *
+   * Requires unique sheet names ≤ 31 chars (so cross-sheet refs resolve) and an
+   * `id` field on records. Defaults to the existing flat export when omitted.
+   */
+  readonly smart?: boolean
 }
 
 /** Options for `download()` — adds optional filename. */
@@ -111,6 +126,10 @@ export async function toBytes(vault: Vault, options: AsXlsxOptions): Promise<Uin
 
   if (options.sheets.length === 0) {
     throw new Error('as-xlsx: at least one sheet is required')
+  }
+
+  if (options.smart) {
+    return writeXlsx(await buildSmartSheets(vault, options))
   }
 
   const materialisedSheets: XlsxSheet[] = []
@@ -177,6 +196,109 @@ export async function write(
 }
 
 // ── internals ─────────────────────────────────────────────────────
+
+/** Safely stringify an unknown id/code/label (objects → JSON, never '[object Object]'). */
+function safeStringify(v: unknown): string {
+  if (typeof v === 'string') return v
+  if (typeof v === 'number' || typeof v === 'boolean' || typeof v === 'bigint') return String(v)
+  if (v == null) return ''
+  try {
+    return JSON.stringify(v) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+/** Coerce an arbitrary value to a formula cached-value (string/number/boolean). */
+function asCached(v: unknown): string | number | boolean {
+  if (typeof v === 'number' || typeof v === 'boolean' || typeof v === 'string') return v
+  return safeStringify(v)
+}
+
+/**
+ * Smart-workbook builder (#414 P1): id-first sheets, FK→VLOOKUP label columns
+ * with cached resolved labels, and a `_manifest` index sheet. Refs auto-detected
+ * from `vault.dumpSchema()`.
+ */
+async function buildSmartSheets(vault: Vault, options: AsXlsxOptions): Promise<XlsxSheet[]> {
+  const snapshot = await vault.dumpSchema()
+  const sheetNameByCollection = new Map<string, string>()
+  for (const s of options.sheets) sheetNameByCollection.set(s.collection, s.name)
+
+  // First pass — materialise records, id-first columns, and a per-collection
+  // label map (id → first non-id field) for the cross-sheet VLOOKUP cache.
+  interface Mat {
+    opt: AsXlsxSheetOptions
+    records: Record<string, unknown>[]
+    cols: string[]
+    labelMap: Map<string, unknown>
+  }
+  const mats: Mat[] = []
+  for (const sheetOpt of options.sheets) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const collection = vault.collection<any>(sheetOpt.collection)
+    const list = await collection.list()
+    const records: Record<string, unknown>[] = []
+    for (const item of list) {
+      const r = item as Record<string, unknown>
+      if (sheetOpt.filter && !sheetOpt.filter(r)) continue
+      records.push(r)
+    }
+    const base = sheetOpt.columns ?? inferColumns(records)
+    const cols = ['id', ...base.filter((c) => c !== 'id')]
+    const labelCol = cols.find((c) => c !== 'id')
+    const labelMap = new Map<string, unknown>()
+    if (labelCol) {
+      for (const r of records) {
+        if (r.id != null) labelMap.set(safeStringify(r.id), r[labelCol])
+      }
+    }
+    mats.push({ opt: sheetOpt, records, cols, labelMap })
+  }
+  const matByCollection = new Map(mats.map((m) => [m.opt.collection, m]))
+
+  // Second pass — emit data sheets with FK label columns.
+  const dataSheets: XlsxSheet[] = mats.map((m) => {
+    const refs = snapshot.collections[m.opt.collection]?.refs ?? {}
+    const refFields = Object.keys(refs).filter(
+      (f) => m.cols.includes(f) && matByCollection.has(refs[f]!.target),
+    )
+    const header = [...m.cols, ...refFields.map((f) => `${f}__label`)]
+    const rows = m.records.map((r, i) => {
+      const rowNum = i + 2 // header is row 1
+      const baseCells = m.cols.map((c) => (c === 'id' ? (r.id ?? null) : (r[c] ?? null)))
+      const refCells = refFields.map((f) => {
+        const target = refs[f]!.target
+        const targetSheet = sheetNameByCollection.get(target)!
+        const targetMat = matByCollection.get(target)!
+        const codeRef = `${colLetter(m.cols.indexOf(f) + 1)}${rowNum}`
+        // Target is id-first, so the label is column B (index 2).
+        const f1 = `IFERROR(VLOOKUP(${codeRef},'${targetSheet}'!$A:$ZZ,2,FALSE),"")`
+        const code = r[f]
+        const cached = code == null ? '' : asCached(targetMat.labelMap.get(safeStringify(code)))
+        return formula(f1, cached)
+      })
+      return [...baseCells, ...refCells]
+    })
+    return { name: m.opt.name, header, rows, ...(m.opt.widths !== undefined ? { widths: m.opt.widths } : {}) }
+  })
+
+  // Manifest index sheet.
+  const manifestRows = mats.map((m) => {
+    const refs = snapshot.collections[m.opt.collection]?.refs ?? {}
+    const refSummary = Object.entries(refs)
+      .map(([f, r]) => `${f}→${r.target}`)
+      .join(', ')
+    return [m.opt.name, m.records.length, refSummary]
+  })
+  const manifest: XlsxSheet = {
+    name: '_manifest',
+    header: ['Collection', 'Records', 'Refs'],
+    rows: manifestRows,
+  }
+
+  return [manifest, ...dataSheets]
+}
 
 function inferColumns(records: readonly Record<string, unknown>[]): string[] {
   const seen = new Set<string>()

--- a/packages/as-xlsx/src/xlsx.ts
+++ b/packages/as-xlsx/src/xlsx.ts
@@ -43,7 +43,27 @@ import { writeZip, type ZipEntry } from '@noy-db/as-zip'
 const XML_HEADER = '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
 const ENCODER = new TextEncoder()
 
-/** One row in a sheet. Values are coerced per type at emit time. */
+/**
+ * A formula cell. Emits `<f>` so the spreadsheet recomputes live; `v` is an
+ * optional cached result (what the formula currently evaluates to) so the value
+ * shows immediately on open and survives a round-trip read. Build via
+ * {@link formula}. The formula string must NOT include a leading `=`.
+ */
+export interface XlsxFormulaCell {
+  readonly __xlsxFormula: string
+  readonly v?: string | number | boolean
+}
+
+/** Build a {@link XlsxFormulaCell}. `f` is the formula body without a leading `=`. */
+export function formula(f: string, cachedValue?: string | number | boolean): XlsxFormulaCell {
+  return cachedValue === undefined ? { __xlsxFormula: f } : { __xlsxFormula: f, v: cachedValue }
+}
+
+function isFormulaCell(v: unknown): v is XlsxFormulaCell {
+  return typeof v === 'object' && v !== null && typeof (v as { __xlsxFormula?: unknown }).__xlsxFormula === 'string'
+}
+
+/** One row in a sheet. A cell is a primitive value or an {@link XlsxFormulaCell}. */
 export type XlsxRow = ReadonlyArray<unknown>
 
 /** One sheet in a workbook. */
@@ -224,6 +244,13 @@ function cellXml(
   intern: (s: string) => number,
 ): string {
   const ref = `${colLetter(colIdx)}${rowNum}`
+  if (isFormulaCell(value)) {
+    const f = escapeXmlText(value.__xlsxFormula)
+    if (value.v === undefined) return `<c r="${ref}"><f>${f}</f></c>`
+    if (typeof value.v === 'number' && Number.isFinite(value.v)) return `<c r="${ref}"><f>${f}</f><v>${value.v}</v></c>`
+    if (typeof value.v === 'boolean') return `<c r="${ref}" t="b"><f>${f}</f><v>${value.v ? 1 : 0}</v></c>`
+    return `<c r="${ref}" t="str"><f>${f}</f><v>${escapeXmlText(String(value.v))}</v></c>`
+  }
   if (value === null || value === undefined || value === '') return `<c r="${ref}"/>`
   if (typeof value === 'number' && Number.isFinite(value)) {
     return `<c r="${ref}"><v>${value}</v></c>`

--- a/showcases/src/114-as-xlsx-smart.showcase.test.ts
+++ b/showcases/src/114-as-xlsx-smart.showcase.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Showcase 114 — as-xlsx smart workbook (#414 P1)
+ *
+ * What you'll learn
+ * ─────────────────
+ * `toBytes(vault, { smart: true })` projects a vault as a *relational* workbook
+ * rather than a flat dump:
+ *   1. Every sheet is **id-first** (record `id` in column A).
+ *   2. Each foreign-key field (auto-detected via `vault.dumpSchema()`) gets a
+ *      `<field>__label` column — a cross-sheet **VLOOKUP** that resolves the
+ *      reference to the target's first field. It carries a **cached** label, so
+ *      the value shows immediately on open AND recomputes live if you edit the
+ *      target sheet.
+ *   3. A `_manifest` index sheet lists every collection, its row count, and its
+ *      refs.
+ *
+ * Why it matters
+ * ──────────────
+ * A flat export loses the relational shape — a `clientId` column is just an
+ * opaque code. Smart mode turns it into a live, human-readable lookup, the way
+ * an analyst would build the workbook by hand. This is P1 of the as-xls
+ * milestone (structural/relational); localization (a global language cell) and
+ * computed formulas (groupBy/MV → SUMIFS) follow.
+ *
+ * Spec mapping
+ * ────────────
+ *   #414 — as-xls smart workbook (P1: structural export)
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, ref } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { toBytes, readXlsx } from '@noy-db/as-xlsx'
+
+describe('showcase 114 — as-xlsx smart workbook', () => {
+  it('FK fields become live VLOOKUP label columns; a _manifest indexes the workbook', async () => {
+    const store = memory()
+    const init = await createNoydb({ store, user: 'alice', secret: 'pw-114' })
+    await init.openVault('firm')
+    await init.grant('firm', {
+      userId: 'alice', displayName: 'Alice', role: 'owner', passphrase: 'pw-114',
+      exportCapability: { plaintext: ['xlsx'] },
+    })
+    init.close()
+
+    const db = await createNoydb({ store, user: 'alice', secret: 'pw-114' })
+    const vault = await db.openVault('firm')
+    await vault.collection<{ id: string; name: string }>('clients').put('c1', { id: 'c1', name: 'Acme' })
+    await vault.collection<{ id: string; clientId: string; amount: number }>('invoices', {
+      refs: { clientId: ref('clients', 'strict') },
+    }).put('i1', { id: 'i1', clientId: 'c1', amount: 100 })
+
+    const wb = await readXlsx(await toBytes(vault, {
+      smart: true,
+      sheets: [{ name: 'clients', collection: 'clients' }, { name: 'invoices', collection: 'invoices' }],
+    }))
+
+    expect(wb.sheets.map((s) => s.name)).toContain('_manifest')
+
+    const inv = wb.sheets.find((s) => s.name === 'invoices')!
+    const header: Record<string, string> = {}
+    for (const [letter, name] of Object.entries(inv.rows[0] ?? {})) header[String(name)] = letter
+    const row = inv.rows.slice(1).find((r) => r[header['id']!] === 'i1')!
+    expect(row[header['clientId__label']!]).toBe('Acme') // resolved via cross-sheet VLOOKUP (cached)
+  })
+})


### PR DESCRIPTION
Starts the **as-xls smart-workbook milestone** (#414) — evolving `@noy-db/as-xlsx` from a flat dump into a relational workbook.

### What (slice 1 of P1)
- **Writer:** formula cells via `formula(f, cachedValue?)` → emits `<f>` + an optional cached `<v>` (live recompute, immediate value, round-trippable).
- **Export:** `toBytes({ smart: true })` — **id-first** sheets; each **FK field** (auto-detected via `vault.dumpSchema()`) gets a `<field>__label` **cross-sheet VLOOKUP** column resolving to the target's first field, with the label **cached** at export; a **`_manifest`** index sheet. Flat export is unchanged when `smart` is omitted.

### Verification
- +3 as-xlsx tests (manifest, FK label cached value, formula round-trip) + showcase 114; as-xlsx suite (37) green; typecheck / lint / arch / validate-features / showcases-typecheck clean. No new deps, no kernel-surface growth.

### Next slices
P1: number formats (money/date styles), data-validation dropdowns → P2: dict lookup sheets + the global LANG cell → P3: computed/groupBy/MV → SUMIFS → P4: smart import.

Refs #414