### PR TITLE
feat(as-xlsx): smart workbook — number formats + data-validation dropdowns (#414 P1)

### DIFF
--- a/packages/as-xlsx/__tests__/as-xlsx-smart.test.ts
+++ b/packages/as-xlsx/__tests__/as-xlsx-smart.test.ts
@@ -6,7 +6,10 @@
 import { describe, expect, it } from 'vitest'
 import { createNoydb, ref } from '@noy-db/hub'
 import { memory } from '@noy-db/to-memory'
+import { readZip } from '@noy-db/as-zip'
 import { toBytes, readXlsx, formula } from '../src/index.js'
+
+const DEC = new TextDecoder()
 
 interface Client { id: string; name: string }
 interface Invoice { id: string; clientId: string; amount: number }
@@ -63,6 +66,36 @@ describe('#414 P1 — smart export', () => {
     const row = inv.rows.slice(1).find((r) => r[h['id']!] === 'i1')!
     // cached value of the VLOOKUP = the client's first field ('Acme')
     expect(row[h['clientId__label']!]).toBe('Acme')
+  })
+
+  it('numberFormats: a money field becomes a numeric cell with a number-format style', async () => {
+    const { vault } = await setup()
+    const bytes = await toBytes(vault, {
+      smart: true,
+      sheets: [
+        { name: 'clients', collection: 'clients' },
+        { name: 'invoices', collection: 'invoices', numberFormats: { amount: '#,##0.00' } },
+      ],
+    })
+    const inv = (await readXlsx(bytes)).sheets.find((s) => s.name === 'invoices')!
+    const h = headerMap(inv)
+    expect(inv.rows.slice(1).find((r) => r[h['id']!] === 'i1')![h['amount']!]).toBe(100) // numeric, not '100'
+
+    const styles = (await readZip(bytes)).find((p) => p.path === 'xl/styles.xml')
+    expect(styles).toBeTruthy()
+    expect(DEC.decode(styles!.bytes)).toContain('#,##0.00')
+  })
+
+  it('dropdowns: an FK field gets a data-validation list referencing the target sheet', async () => {
+    const { vault } = await setup()
+    const bytes = await toBytes(vault, {
+      smart: true,
+      sheets: [{ name: 'clients', collection: 'clients' }, { name: 'invoices', collection: 'invoices' }],
+    })
+    const sheetXmls = (await readZip(bytes))
+      .filter((p) => /xl\/worksheets\/sheet\d+\.xml/.test(p.path))
+      .map((p) => DEC.decode(p.bytes))
+    expect(sheetXmls.some((x) => x.includes('<dataValidation') && x.includes("clients'!$A$2"))).toBe(true)
   })
 
   it('formula() emits a live <f> with a cached value (round-trips via readXlsx)', async () => {

--- a/packages/as-xlsx/src/index.ts
+++ b/packages/as-xlsx/src/index.ts
@@ -29,10 +29,10 @@
  */
 
 import type { Vault, DictEntry } from '@noy-db/hub'
-import { writeXlsx, colLetter, formula, type XlsxSheet } from './xlsx.js'
+import { writeXlsx, colLetter, formula, styled, type XlsxSheet, type XlsxValidation } from './xlsx.js'
 import { readXlsx } from './read.js'
 
-export { writeXlsx, colLetter, formula, type XlsxSheet, type XlsxRow, type XlsxFormulaCell } from './xlsx.js'
+export { writeXlsx, colLetter, formula, styled, type XlsxSheet, type XlsxRow, type XlsxFormulaCell, type XlsxStyledCell, type XlsxValidation } from './xlsx.js'
 export { readXlsx, type ReadXlsxResult, type ReadXlsxSheet, type ReadXlsxRow } from './read.js'
 
 /** Per-sheet options for the noy-db consumer API. */
@@ -69,6 +69,18 @@ export interface AsXlsxSheetOptions {
    * mirrors `XlsxSheet.widths`, which it threads through.
    */
   readonly widths?: ReadonlyArray<number | undefined>
+  /**
+   * Smart mode only: per-field Excel number-format codes (e.g.
+   * `{ amount: '#,##0.00' }` for currency). The value is coerced to a number so
+   * the format renders. Money has no introspection signal, so currency
+   * formatting is opt-in here.
+   */
+  readonly numberFormats?: Record<string, string>
+  /**
+   * Smart mode only: per-field explicit dropdown value lists. Overrides the
+   * auto-detected enum/ref dropdown for that field.
+   */
+  readonly dropdowns?: Record<string, readonly string[]>
 }
 
 /** Single-collection convenience — passed where a sheet-list is accepted. */
@@ -264,9 +276,44 @@ async function buildSmartSheets(vault: Vault, options: AsXlsxOptions): Promise<X
       (f) => m.cols.includes(f) && matByCollection.has(refs[f]!.target),
     )
     const header = [...m.cols, ...refFields.map((f) => `${f}__label`)]
+    const fields = snapshot.collections[m.opt.collection]?.fields ?? {}
+
+    // Data-validation dropdowns: explicit > ref-range > enum-inline.
+    const lastRow = Math.max(m.records.length + 1, 2)
+    const validations: XlsxValidation[] = []
+    for (let ci = 0; ci < m.cols.length; ci++) {
+      const field = m.cols[ci]!
+      const colL = colLetter(ci + 1)
+      const sqref = `${colL}2:${colL}${lastRow}`
+      const explicit = m.opt.dropdowns?.[field]
+      if (explicit && explicit.length > 0) {
+        validations.push({ sqref, values: explicit })
+        continue
+      }
+      const rf = refs[field]
+      if (rf && matByCollection.has(rf.target)) {
+        const targetSheet = sheetNameByCollection.get(rf.target)!
+        const targetRows = Math.max(matByCollection.get(rf.target)!.records.length + 1, 2)
+        validations.push({ sqref, formula1: `'${targetSheet}'!$A$2:$A$${targetRows}` })
+        continue
+      }
+      const enumVals = fields[field]?.constraints?.['values']
+      if (Array.isArray(enumVals) && enumVals.length > 0) {
+        validations.push({ sqref, values: enumVals.map((v) => safeStringify(v)) })
+      }
+    }
+
     const rows = m.records.map((r, i) => {
       const rowNum = i + 2 // header is row 1
-      const baseCells = m.cols.map((c) => (c === 'id' ? (r.id ?? null) : (r[c] ?? null)))
+      const baseCells = m.cols.map((c) => {
+        const raw = c === 'id' ? (r.id ?? null) : (r[c] ?? null)
+        const fmt = m.opt.numberFormats?.[c]
+        if (fmt === undefined) return raw
+        // Currency/number formats only render on numeric cells — coerce a
+        // numeric string (e.g. money '100.00') to a number.
+        const num = typeof raw === 'string' && raw.trim() !== '' && Number.isFinite(Number(raw)) ? Number(raw) : raw
+        return styled(num as string | number | boolean | null, fmt)
+      })
       const refCells = refFields.map((f) => {
         const target = refs[f]!.target
         const targetSheet = sheetNameByCollection.get(target)!
@@ -280,7 +327,13 @@ async function buildSmartSheets(vault: Vault, options: AsXlsxOptions): Promise<X
       })
       return [...baseCells, ...refCells]
     })
-    return { name: m.opt.name, header, rows, ...(m.opt.widths !== undefined ? { widths: m.opt.widths } : {}) }
+    return {
+      name: m.opt.name,
+      header,
+      rows,
+      ...(validations.length > 0 ? { validations } : {}),
+      ...(m.opt.widths !== undefined ? { widths: m.opt.widths } : {}),
+    }
   })
 
   // Manifest index sheet.

--- a/packages/as-xlsx/src/xlsx.ts
+++ b/packages/as-xlsx/src/xlsx.ts
@@ -63,6 +63,35 @@ function isFormulaCell(v: unknown): v is XlsxFormulaCell {
   return typeof v === 'object' && v !== null && typeof (v as { __xlsxFormula?: unknown }).__xlsxFormula === 'string'
 }
 
+/**
+ * A value cell carrying a number-format code (e.g. `'#,##0.00'` for currency,
+ * `'yyyy-mm-dd'` for dates). Build via {@link styled}. The format only renders
+ * meaningfully on numeric values.
+ */
+export interface XlsxStyledCell {
+  readonly __xlsxStyle: string
+  readonly v: string | number | boolean | null
+}
+
+/** Build a {@link XlsxStyledCell} — a value plus an Excel number-format code. */
+export function styled(value: string | number | boolean | null, numberFormat: string): XlsxStyledCell {
+  return { __xlsxStyle: numberFormat, v: value }
+}
+
+function isStyledCell(v: unknown): v is XlsxStyledCell {
+  return typeof v === 'object' && v !== null && typeof (v as { __xlsxStyle?: unknown }).__xlsxStyle === 'string'
+}
+
+/** A data-validation rule (dropdown) over a cell range. */
+export interface XlsxValidation {
+  /** Target range in A1 notation, e.g. `'B2:B100'`. */
+  readonly sqref: string
+  /** Inline allowed values → a `"a,b,c"` list. Mutually exclusive with `formula1`. */
+  readonly values?: readonly string[]
+  /** Explicit `formula1` (e.g. a range ref `Clients!$A$2:$A$999`). */
+  readonly formula1?: string
+}
+
 /** One row in a sheet. A cell is a primitive value or an {@link XlsxFormulaCell}. */
 export type XlsxRow = ReadonlyArray<unknown>
 
@@ -85,6 +114,8 @@ export interface XlsxSheet {
    * for "auto" columns and a number for explicit widths.
    */
   readonly widths?: ReadonlyArray<number | undefined>
+  /** Data-validation dropdowns applied to ranges on this sheet. */
+  readonly validations?: readonly XlsxValidation[]
 }
 
 /**
@@ -118,6 +149,19 @@ export async function writeXlsx(sheets: readonly XlsxSheet[]): Promise<Uint8Arra
     const idx = sharedStrings.length
     sharedStrings.push(s)
     stringIndex.set(s, idx)
+    return idx
+  }
+
+  // Number-format styles. cellXf 0 is the default (no format); each distinct
+  // format code gets a numFmt (id 164+) and a cellXf that applies it.
+  const numFmtCodes: string[] = []
+  const styleIndexByCode = new Map<string, number>()
+  const internStyle = (code: string): number => {
+    const existing = styleIndexByCode.get(code)
+    if (existing !== undefined) return existing
+    const idx = numFmtCodes.length + 1 // cellXf index; 0 is the default xf
+    numFmtCodes.push(code)
+    styleIndexByCode.set(code, idx)
     return idx
   }
 
@@ -157,13 +201,48 @@ export async function writeXlsx(sheets: readonly XlsxSheet[]): Promise<Uint8Arra
     for (const row of sheet.rows) {
       rowNum++
       const cells = row
-        .map((value, i) => cellXml(value, i + 1, rowNum, internString))
+        .map((value, i) => cellXml(value, i + 1, rowNum, internString, internStyle))
         .join('')
       lines.push(`<row r="${rowNum}">${cells}</row>`)
     }
-    lines.push('</sheetData>', '</worksheet>')
+    lines.push('</sheetData>')
+    if (sheet.validations && sheet.validations.length > 0) {
+      lines.push(`<dataValidations count="${sheet.validations.length}">`)
+      for (const dv of sheet.validations) {
+        const f1 = dv.formula1 ?? `"${(dv.values ?? []).join(',')}"`
+        lines.push(
+          `<dataValidation type="list" allowBlank="1" showInputMessage="1" showErrorMessage="1" sqref="${escapeXmlAttr(dv.sqref)}"><formula1>${escapeXmlText(f1)}</formula1></dataValidation>`,
+        )
+      }
+      lines.push('</dataValidations>')
+    }
+    lines.push('</worksheet>')
     return lines.join('')
   })
+
+  // ── Styles (number formats) ─────────────────────────────────────
+
+  const hasStyles = numFmtCodes.length > 0
+  const stylesXml = hasStyles
+    ? [
+        XML_HEADER,
+        '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">',
+        `<numFmts count="${numFmtCodes.length}">`,
+        ...numFmtCodes.map((code, i) => `<numFmt numFmtId="${164 + i}" formatCode="${escapeXmlAttr(code)}"/>`),
+        '</numFmts>',
+        '<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>',
+        '<fills count="1"><fill><patternFill patternType="none"/></fill></fills>',
+        '<borders count="1"><border/></borders>',
+        '<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>',
+        `<cellXfs count="${numFmtCodes.length + 1}">`,
+        '<xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>',
+        ...numFmtCodes.map(
+          (_, i) => `<xf numFmtId="${164 + i}" fontId="0" fillId="0" borderId="0" xfId="0" applyNumberFormat="1"/>`,
+        ),
+        '</cellXfs>',
+        '</styleSheet>',
+      ].join('')
+    : ''
 
   // ── Fixed parts ─────────────────────────────────────────────────
 
@@ -185,6 +264,9 @@ export async function writeXlsx(sheets: readonly XlsxSheet[]): Promise<Uint8Arra
         `<Override PartName="/${s.path}" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>`,
     ),
     '<Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>',
+    ...(hasStyles
+      ? ['<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>']
+      : []),
     '</Types>',
   ].join('')
 
@@ -213,6 +295,9 @@ export async function writeXlsx(sheets: readonly XlsxSheet[]): Promise<Uint8Arra
         `<Relationship Id="${s.id}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet${s.index}.xml"/>`,
     ),
     `<Relationship Id="rIdSharedStrings" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings" Target="sharedStrings.xml"/>`,
+    ...(hasStyles
+      ? [`<Relationship Id="rIdStyles" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>`]
+      : []),
     '</Relationships>',
   ].join('')
 
@@ -229,6 +314,7 @@ export async function writeXlsx(sheets: readonly XlsxSheet[]): Promise<Uint8Arra
     { path: 'xl/workbook.xml', bytes: ENCODER.encode(workbookXml) },
     { path: 'xl/_rels/workbook.xml.rels', bytes: ENCODER.encode(workbookRels) },
     { path: 'xl/sharedStrings.xml', bytes: ENCODER.encode(sharedStringsXml) },
+    ...(hasStyles ? [{ path: 'xl/styles.xml', bytes: ENCODER.encode(stylesXml) }] : []),
     ...sheetEntries.map((s, i) => ({ path: s.path, bytes: ENCODER.encode(sheetXmls[i] ?? '') })),
   ]
 
@@ -242,8 +328,17 @@ function cellXml(
   colIdx: number,
   rowNum: number,
   intern: (s: string) => number,
+  internStyle: (code: string) => number,
 ): string {
   const ref = `${colLetter(colIdx)}${rowNum}`
+  if (isStyledCell(value)) {
+    const s = internStyle(value.__xlsxStyle)
+    const v = value.v
+    if (v === null || v === undefined || v === '') return `<c r="${ref}" s="${s}"/>`
+    if (typeof v === 'number' && Number.isFinite(v)) return `<c r="${ref}" s="${s}"><v>${v}</v></c>`
+    if (typeof v === 'boolean') return `<c r="${ref}" s="${s}" t="b"><v>${v ? 1 : 0}</v></c>`
+    return `<c r="${ref}" s="${s}" t="s"><v>${intern(typeof v === 'string' ? v : String(v))}</v></c>`
+  }
   if (isFormulaCell(value)) {
     const f = escapeXmlText(value.__xlsxFormula)
     if (value.v === undefined) return `<c r="${ref}"><f>${f}</f></c>`


### PR DESCRIPTION
Finishes **#414 P1** (structural export) — adds the two remaining writer capabilities and wires them into smart mode.

### Writer
- `styled(value, formatCode)` cells → emits `xl/styles.xml` (numFmts/cellXfs) + a cell `s=` index (only when styled cells exist — flat exports are byte-identical).
- `XlsxSheet.validations` → `<dataValidation type="list">` (inline list or explicit `formula1` range).

### Smart export
- **Auto dropdowns:** FK fields → list referencing the target sheet's id column; enum fields (`constraints.values` from `dumpSchema`) → inline list. Override via `sheetOpt.dropdowns`.
- **Number formats:** `sheetOpt.numberFormats` (e.g. `{ amount: '#,##0.00' }`) → styled numeric cells (numeric strings coerced to numbers). Money has no introspection signal, so currency formatting is opt-in (documented).

### Verification
- +2 as-xlsx tests (money→numeric styled cell + `styles.xml` emitted; FK dropdown references target sheet) via raw-part `readZip` inspection; as-xlsx suite (39) + showcase 114 green; typecheck/lint/arch/validate-features/showcases-typecheck clean.

Next: **P2** — dict lookup sheets + the global LANG cell.

Refs #414