### PR TITLE
feat(as-xlsx): smart workbook — global LANG cell + i18n (#414 P2)

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -2284,13 +2284,16 @@ exports:
         path: showcases/src/51-as-readers-import.showcase.test.ts
       - id: 114-as-xlsx-smart
         path: showcases/src/114-as-xlsx-smart.showcase.test.ts
+      - id: 115-as-xlsx-lang-cell
+        path: showcases/src/115-as-xlsx-lang-cell.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
     invariants:
       - 'Real .xlsx (Office Open XML); writer emits 6 parts incl. sharedStrings'
       - 'Multi-sheet — preserves relational shape across collections'
-      - 'Smart mode (toBytes({ smart: true }), #414 P1): id-first sheets; FK fields (auto-detected via dumpSchema) get a <field>__label VLOOKUP column with a cached resolved label (live + immediate); a _manifest index sheet. Formula cells via formula(f, cachedValue) emit <f> + cached <v>'
+      - 'Smart mode (toBytes({ smart: true }), #414 P1): id-first sheets; FK fields (auto-detected via dumpSchema) get a <field>__label VLOOKUP column with a cached resolved label (live + immediate); a _manifest index sheet. Formula cells via formula(f, cachedValue) emit <f> + cached <v>. Number formats via styled(v, code) → styles.xml; data-validation dropdowns (enum/ref auto, explicit override)'
+      - 'Smart mode #414 P2: i18nFields → per-locale columns + a display column switched live by a global LANG named range on a _settings sheet (IF(LANG=…) chain); changing LANG re-renders every label. definedNames support in the writer'
       - 'fromBytes reads sharedStrings + workbook + sheet<N>.xml; opt-in date coercion via fieldTypes'
       - 'fast-xml-parser dep (^5.0.0); strict mode via XMLValidator pre-pass'
       - 'Import gated by importCapability.plaintext.xlsx; apply() inside vault.transaction'

--- a/packages/as-xlsx/__tests__/as-xlsx-smart.test.ts
+++ b/packages/as-xlsx/__tests__/as-xlsx-smart.test.ts
@@ -5,6 +5,7 @@
  */
 import { describe, expect, it } from 'vitest'
 import { createNoydb, ref } from '@noy-db/hub'
+import { withI18n, i18nText } from '@noy-db/hub/i18n'
 import { memory } from '@noy-db/to-memory'
 import { readZip } from '@noy-db/as-zip'
 import { toBytes, readXlsx, formula } from '../src/index.js'
@@ -96,6 +97,40 @@ describe('#414 P1 — smart export', () => {
       .filter((p) => /xl\/worksheets\/sheet\d+\.xml/.test(p.path))
       .map((p) => DEC.decode(p.bytes))
     expect(sheetXmls.some((x) => x.includes('<dataValidation') && x.includes("clients'!$A$2"))).toBe(true)
+  })
+
+  it('P2: global LANG cell + i18n locale columns with a live display formula', async () => {
+    const adapter = memory()
+    const init = await createNoydb({ store: adapter, user: 'alice', secret: 'pw-i18n' })
+    await init.openVault('shop')
+    await init.grant('shop', {
+      userId: 'alice', displayName: 'Alice', role: 'owner', passphrase: 'pw-i18n',
+      exportCapability: { plaintext: ['xlsx'] },
+    })
+    init.close()
+    const db = await createNoydb({ store: adapter, user: 'alice', secret: 'pw-i18n', i18nStrategy: withI18n() })
+    const vault = await db.openVault('shop') // no active locale → raw i18n maps
+    await vault.collection<{ id: string; name: Record<string, string> }>('products', {
+      i18nFields: { name: i18nText({ languages: ['en', 'th'], required: 'all' }) },
+    }).put('p1', { id: 'p1', name: { en: 'Widget', th: 'วิดเจ็ต' } })
+
+    const bytes = await toBytes(vault, {
+      smart: true,
+      sheets: [{ name: 'products', collection: 'products', i18nFields: ['name'] }],
+    })
+    const wb = await readXlsx(bytes)
+    expect(wb.sheets.map((s) => s.name)).toContain('_settings')
+
+    const prod = wb.sheets.find((s) => s.name === 'products')!
+    const h = headerMap(prod)
+    expect(h['name'] && h['name__en'] && h['name__th']).toBeTruthy()
+    const row = prod.rows.slice(1).find((r) => r[h['id']!] === 'p1')!
+    expect(row[h['name']!]).toBe('Widget') // display cached at default locale (en)
+    expect(row[h['name__th']!]).toBe('วิดเจ็ต') // raw per-locale column
+
+    // LANG named range present in the workbook
+    const wbxml = (await readZip(bytes)).find((p) => p.path === 'xl/workbook.xml')!
+    expect(DEC.decode(wbxml.bytes)).toContain('name="LANG"')
   })
 
   it('formula() emits a live <f> with a cached value (round-trips via readXlsx)', async () => {

--- a/packages/as-xlsx/src/index.ts
+++ b/packages/as-xlsx/src/index.ts
@@ -81,6 +81,13 @@ export interface AsXlsxSheetOptions {
    * auto-detected enum/ref dropdown for that field.
    */
   readonly dropdowns?: Record<string, readonly string[]>
+  /**
+   * Smart mode only: fields whose stored value is a multi-locale i18n map
+   * (`{ en: '…', th: '…' }`). Each becomes per-locale columns plus a display
+   * column resolved **live by the global LANG cell** (change LANG → every label
+   * re-renders). Read raw, so open the export vault without an active locale.
+   */
+  readonly i18nFields?: readonly string[]
 }
 
 /** Single-collection convenience — passed where a sheet-list is accepted. */
@@ -141,7 +148,8 @@ export async function toBytes(vault: Vault, options: AsXlsxOptions): Promise<Uin
   }
 
   if (options.smart) {
-    return writeXlsx(await buildSmartSheets(vault, options))
+    const { sheets, definedNames } = await buildSmartSheets(vault, options)
+    return writeXlsx(sheets, { definedNames })
   }
 
   const materialisedSheets: XlsxSheet[] = []
@@ -228,24 +236,28 @@ function asCached(v: unknown): string | number | boolean {
 }
 
 /**
- * Smart-workbook builder (#414 P1): id-first sheets, FK→VLOOKUP label columns
- * with cached resolved labels, and a `_manifest` index sheet. Refs auto-detected
- * from `vault.dumpSchema()`.
+ * Smart-workbook builder (#414 P1+P2): id-first sheets, FK→VLOOKUP label columns,
+ * a `_manifest` index, and — when i18n fields are declared — per-locale columns
+ * with a display column driven live by a global `LANG` named range on a
+ * `_settings` sheet. Refs auto-detected from `vault.dumpSchema()`.
  */
-async function buildSmartSheets(vault: Vault, options: AsXlsxOptions): Promise<XlsxSheet[]> {
+async function buildSmartSheets(
+  vault: Vault,
+  options: AsXlsxOptions,
+): Promise<{ sheets: XlsxSheet[]; definedNames: { name: string; ref: string }[] }> {
   const snapshot = await vault.dumpSchema()
   const sheetNameByCollection = new Map<string, string>()
   for (const s of options.sheets) sheetNameByCollection.set(s.collection, s.name)
 
-  // First pass — materialise records, id-first columns, and a per-collection
-  // label map (id → first non-id field) for the cross-sheet VLOOKUP cache.
   interface Mat {
     opt: AsXlsxSheetOptions
     records: Record<string, unknown>[]
     cols: string[]
     labelMap: Map<string, unknown>
+    i18nFields: string[]
   }
   const mats: Mat[] = []
+  const localeSet = new Set<string>()
   for (const sheetOpt of options.sheets) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const collection = vault.collection<any>(sheetOpt.collection)
@@ -260,30 +272,47 @@ async function buildSmartSheets(vault: Vault, options: AsXlsxOptions): Promise<X
     const cols = ['id', ...base.filter((c) => c !== 'id')]
     const labelCol = cols.find((c) => c !== 'id')
     const labelMap = new Map<string, unknown>()
-    if (labelCol) {
+    if (labelCol) for (const r of records) if (r.id != null) labelMap.set(safeStringify(r.id), r[labelCol])
+    const i18nFields = (sheetOpt.i18nFields ?? []).filter((f) => cols.includes(f))
+    for (const f of i18nFields) {
       for (const r of records) {
-        if (r.id != null) labelMap.set(safeStringify(r.id), r[labelCol])
+        const v = r[f]
+        if (v && typeof v === 'object') for (const loc of Object.keys(v as Record<string, unknown>)) localeSet.add(loc)
       }
     }
-    mats.push({ opt: sheetOpt, records, cols, labelMap })
+    mats.push({ opt: sheetOpt, records, cols, labelMap, i18nFields })
   }
   const matByCollection = new Map(mats.map((m) => [m.opt.collection, m]))
 
-  // Second pass — emit data sheets with FK label columns.
+  const locales = [...localeSet].sort()
+  const hasI18n = locales.length > 0
+  const defaultLocale = locales.includes('en') ? 'en' : (locales[0] ?? 'en')
+  // Build an IF-chain over the per-locale cells, switched by the LANG name.
+  const ifChain = (refOf: (loc: string) => string): string => {
+    if (locales.length === 0) return '""'
+    let expr = refOf(locales[0]!)
+    for (let k = locales.length - 1; k >= 0; k--) {
+      expr = `IF(LANG="${locales[k]}",${refOf(locales[k]!)},${expr})`
+    }
+    return expr
+  }
+
   const dataSheets: XlsxSheet[] = mats.map((m) => {
     const refs = snapshot.collections[m.opt.collection]?.refs ?? {}
-    const refFields = Object.keys(refs).filter(
-      (f) => m.cols.includes(f) && matByCollection.has(refs[f]!.target),
-    )
-    const header = [...m.cols, ...refFields.map((f) => `${f}__label`)]
     const fields = snapshot.collections[m.opt.collection]?.fields ?? {}
+    const i18nSet = new Set(m.i18nFields)
+    const refFields = Object.keys(refs).filter((f) => m.cols.includes(f) && matByCollection.has(refs[f]!.target))
+    const baseCols = m.cols.filter((c) => !i18nSet.has(c))
+    const i18nFlat = m.i18nFields.flatMap((f) => [f, ...locales.map((l) => `${f}__${l}`)])
+    const header = [...baseCols, ...i18nFlat, ...refFields.map((f) => `${f}__label`)]
+    const colIndex = new Map<string, number>()
+    header.forEach((h, i) => colIndex.set(h, i + 1))
 
-    // Data-validation dropdowns: explicit > ref-range > enum-inline.
+    // Data-validation dropdowns on base columns: explicit > ref-range > enum.
     const lastRow = Math.max(m.records.length + 1, 2)
     const validations: XlsxValidation[] = []
-    for (let ci = 0; ci < m.cols.length; ci++) {
-      const field = m.cols[ci]!
-      const colL = colLetter(ci + 1)
+    for (const field of baseCols) {
+      const colL = colLetter(colIndex.get(field)!)
       const sqref = `${colL}2:${colL}${lastRow}`
       const explicit = m.opt.dropdowns?.[field]
       if (explicit && explicit.length > 0) {
@@ -298,34 +327,37 @@ async function buildSmartSheets(vault: Vault, options: AsXlsxOptions): Promise<X
         continue
       }
       const enumVals = fields[field]?.constraints?.['values']
-      if (Array.isArray(enumVals) && enumVals.length > 0) {
-        validations.push({ sqref, values: enumVals.map((v) => safeStringify(v)) })
-      }
+      if (Array.isArray(enumVals) && enumVals.length > 0) validations.push({ sqref, values: enumVals.map((v) => safeStringify(v)) })
     }
 
     const rows = m.records.map((r, i) => {
       const rowNum = i + 2 // header is row 1
-      const baseCells = m.cols.map((c) => {
+      const baseCells = baseCols.map((c) => {
         const raw = c === 'id' ? (r.id ?? null) : (r[c] ?? null)
         const fmt = m.opt.numberFormats?.[c]
         if (fmt === undefined) return raw
-        // Currency/number formats only render on numeric cells — coerce a
-        // numeric string (e.g. money '100.00') to a number.
         const num = typeof raw === 'string' && raw.trim() !== '' && Number.isFinite(Number(raw)) ? Number(raw) : raw
         return styled(num as string | number | boolean | null, fmt)
+      })
+      const i18nCells = m.i18nFields.flatMap((f) => {
+        const rawMap = (r[f] && typeof r[f] === 'object' ? r[f] : {}) as Record<string, unknown>
+        const display = formula(
+          ifChain((l) => `${colLetter(colIndex.get(`${f}__${l}`)!)}${rowNum}`),
+          asCached(rawMap[defaultLocale] ?? ''),
+        )
+        return [display, ...locales.map((l) => (rawMap[l] ?? null) as unknown)]
       })
       const refCells = refFields.map((f) => {
         const target = refs[f]!.target
         const targetSheet = sheetNameByCollection.get(target)!
         const targetMat = matByCollection.get(target)!
-        const codeRef = `${colLetter(m.cols.indexOf(f) + 1)}${rowNum}`
-        // Target is id-first, so the label is column B (index 2).
+        const codeRef = `${colLetter(colIndex.get(f)!)}${rowNum}`
         const f1 = `IFERROR(VLOOKUP(${codeRef},'${targetSheet}'!$A:$ZZ,2,FALSE),"")`
         const code = r[f]
         const cached = code == null ? '' : asCached(targetMat.labelMap.get(safeStringify(code)))
         return formula(f1, cached)
       })
-      return [...baseCells, ...refCells]
+      return [...baseCells, ...i18nCells, ...refCells]
     })
     return {
       name: m.opt.name,
@@ -336,21 +368,30 @@ async function buildSmartSheets(vault: Vault, options: AsXlsxOptions): Promise<X
     }
   })
 
-  // Manifest index sheet.
-  const manifestRows = mats.map((m) => {
-    const refs = snapshot.collections[m.opt.collection]?.refs ?? {}
-    const refSummary = Object.entries(refs)
-      .map(([f, r]) => `${f}→${r.target}`)
-      .join(', ')
-    return [m.opt.name, m.records.length, refSummary]
-  })
   const manifest: XlsxSheet = {
     name: '_manifest',
     header: ['Collection', 'Records', 'Refs'],
-    rows: manifestRows,
+    rows: mats.map((m) => {
+      const refs = snapshot.collections[m.opt.collection]?.refs ?? {}
+      return [m.opt.name, m.records.length, Object.entries(refs).map(([f, r]) => `${f}→${r.target}`).join(', ')]
+    }),
   }
 
-  return [manifest, ...dataSheets]
+  // Global LANG control — a Settings sheet + named range every i18n/dict label
+  // references via IF(LANG=…). Only emitted when there are i18n fields.
+  const settingsSheets: XlsxSheet[] = []
+  const definedNames: { name: string; ref: string }[] = []
+  if (hasI18n) {
+    settingsSheets.push({
+      name: '_settings',
+      header: ['Setting', 'Value'],
+      rows: [['Language', defaultLocale]],
+      validations: [{ sqref: 'B2:B2', values: locales }],
+    })
+    definedNames.push({ name: 'LANG', ref: `'_settings'!$B$2` })
+  }
+
+  return { sheets: [...settingsSheets, manifest, ...dataSheets], definedNames }
 }
 
 function inferColumns(records: readonly Record<string, unknown>[]): string[] {

--- a/packages/as-xlsx/src/xlsx.ts
+++ b/packages/as-xlsx/src/xlsx.ts
@@ -122,7 +122,10 @@ export interface XlsxSheet {
  * Build a complete `.xlsx` byte stream from the supplied sheet data.
  * Pure — no I/O beyond the internal zip concatenation.
  */
-export async function writeXlsx(sheets: readonly XlsxSheet[]): Promise<Uint8Array> {
+export async function writeXlsx(
+  sheets: readonly XlsxSheet[],
+  options: { definedNames?: ReadonlyArray<{ readonly name: string; readonly ref: string }> } = {},
+): Promise<Uint8Array> {
   if (sheets.length === 0) {
     throw new Error('writeXlsx: at least one sheet is required')
   }
@@ -284,6 +287,15 @@ export async function writeXlsx(sheets: readonly XlsxSheet[]): Promise<Uint8Arra
       (s) => `<sheet name="${escapeXmlAttr(s.name)}" sheetId="${s.index}" r:id="${s.id}"/>`,
     ),
     '</sheets>',
+    ...(options.definedNames && options.definedNames.length > 0
+      ? [
+          '<definedNames>',
+          ...options.definedNames.map(
+            (d) => `<definedName name="${escapeXmlAttr(d.name)}">${escapeXmlText(d.ref)}</definedName>`,
+          ),
+          '</definedNames>',
+        ]
+      : []),
     '</workbook>',
   ].join('')
 

--- a/showcases/src/115-as-xlsx-lang-cell.showcase.test.ts
+++ b/showcases/src/115-as-xlsx-lang-cell.showcase.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Showcase 115 — as-xlsx global LANG cell (#414 P2)
+ *
+ * What you'll learn
+ * ─────────────────
+ * The headline of the smart workbook: a **single workbook-level language cell**.
+ * Declare a sheet's i18n fields and `toBytes({ smart: true })` emits:
+ *   1. A `_settings` sheet with a **`LANG` named range** (a dropdown of the
+ *      available locales).
+ *   2. Per-locale columns (`name__en`, `name__th`, …) holding the raw values.
+ *   3. A display column whose formula is `IF(LANG="en", …, IF(LANG="th", …))` —
+ *      so changing the one `LANG` cell **re-renders every label in the whole
+ *      workbook live**, with the default-locale value cached for immediate show.
+ *
+ * Why it matters
+ * ──────────────
+ * A localized dataset normally means one export per language. Here a single
+ * file serves every locale: the reviewer flips `LANG` and the workbook follows.
+ * This is the same mechanism dictionaries will use (P2 cont.) and it's built
+ * entirely on P1's formula + named-range + data-validation primitives.
+ *
+ * Spec mapping
+ * ────────────
+ *   #414 — as-xls smart workbook (P2: global LANG cell + i18n)
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { withI18n, i18nText } from '@noy-db/hub/i18n'
+import { memory } from '@noy-db/to-memory'
+import { toBytes, readXlsx } from '@noy-db/as-xlsx'
+
+describe('showcase 115 — as-xlsx global LANG cell', () => {
+  it('emits a _settings LANG control + per-locale columns + a live display column', async () => {
+    const store = memory()
+    const init = await createNoydb({ store, user: 'alice', secret: 'pw-115' })
+    await init.openVault('shop')
+    await init.grant('shop', {
+      userId: 'alice', displayName: 'Alice', role: 'owner', passphrase: 'pw-115',
+      exportCapability: { plaintext: ['xlsx'] },
+    })
+    init.close()
+
+    // Open WITHOUT an active locale so i18n fields stay raw {locale: value} maps.
+    const db = await createNoydb({ store, user: 'alice', secret: 'pw-115', i18nStrategy: withI18n() })
+    const vault = await db.openVault('shop')
+    await vault.collection<{ id: string; name: Record<string, string> }>('products', {
+      i18nFields: { name: i18nText({ languages: ['en', 'th'], required: 'all' }) },
+    }).put('p1', { id: 'p1', name: { en: 'Widget', th: 'วิดเจ็ต' } })
+
+    const wb = await readXlsx(await toBytes(vault, {
+      smart: true,
+      sheets: [{ name: 'products', collection: 'products', i18nFields: ['name'] }],
+    }))
+
+    expect(wb.sheets.map((s) => s.name)).toContain('_settings') // the LANG control
+    const prod = wb.sheets.find((s) => s.name === 'products')!
+    const header: Record<string, string> = {}
+    for (const [letter, name] of Object.entries(prod.rows[0] ?? {})) header[String(name)] = letter
+    const row = prod.rows.slice(1).find((r) => r[header['id']!] === 'p1')!
+    expect(row[header['name']!]).toBe('Widget') // display resolves to LANG=en by default
+    expect(row[header['name__th']!]).toBe('วิดเจ็ต') // Thai available — flip LANG to see it
+  })
+})


### PR DESCRIPTION
The **headline** of the as-xls milestone: one workbook-level language cell that re-renders every label live.

### What
- **Writer:** named-range support — `writeXlsx(sheets, { definedNames })` → `<definedNames>` in workbook.xml.
- **Smart export:** declare a sheet's `i18nFields` → per-locale columns (`<f>__<loc>`, raw values) + a display column whose formula is an `IF(LANG="…")` chain (default-locale value cached for immediate show). A **`_settings` sheet** holds the **`LANG` named range** + a locale dropdown; changing it re-renders all i18n displays. i18n read raw (open the export vault locale-less); locales auto-detected from the maps.

### Verification
- +1 as-xlsx test (LANG named range + per-locale columns + cached display) + showcase 115; as-xlsx suite (40) + showcases green; typecheck/lint/arch/validate-features/showcases-typecheck clean.

Next (P2 cont.): dict lookup sheets (VLOOKUP + MATCH(LANG)) reuse the same LANG cell.

Refs #414