### PR TITLE
feat(as-xlsx): smart workbook — dict lookup sheets driven by LANG (#414 P2)

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -2293,7 +2293,7 @@ exports:
       - 'Real .xlsx (Office Open XML); writer emits 6 parts incl. sharedStrings'
       - 'Multi-sheet — preserves relational shape across collections'
       - 'Smart mode (toBytes({ smart: true }), #414 P1): id-first sheets; FK fields (auto-detected via dumpSchema) get a <field>__label VLOOKUP column with a cached resolved label (live + immediate); a _manifest index sheet. Formula cells via formula(f, cachedValue) emit <f> + cached <v>. Number formats via styled(v, code) → styles.xml; data-validation dropdowns (enum/ref auto, explicit override)'
-      - 'Smart mode #414 P2: i18nFields → per-locale columns + a display column switched live by a global LANG named range on a _settings sheet (IF(LANG=…) chain); changing LANG re-renders every label. definedNames support in the writer'
+      - 'Smart mode #414 P2: i18nFields → per-locale columns + a display column switched live by a global LANG named range on a _settings sheet (IF(LANG=…) chain); dictFields → a _Lookups_<dict> sheet + a <field>__label VLOOKUP(code, …, MATCH(LANG, header)) display; changing LANG re-renders every i18n + dict label. definedNames support in the writer'
       - 'fromBytes reads sharedStrings + workbook + sheet<N>.xml; opt-in date coercion via fieldTypes'
       - 'fast-xml-parser dep (^5.0.0); strict mode via XMLValidator pre-pass'
       - 'Import gated by importCapability.plaintext.xlsx; apply() inside vault.transaction'

--- a/packages/as-xlsx/__tests__/as-xlsx-smart.test.ts
+++ b/packages/as-xlsx/__tests__/as-xlsx-smart.test.ts
@@ -5,7 +5,7 @@
  */
 import { describe, expect, it } from 'vitest'
 import { createNoydb, ref } from '@noy-db/hub'
-import { withI18n, i18nText } from '@noy-db/hub/i18n'
+import { withI18n, i18nText, dictKey } from '@noy-db/hub/i18n'
 import { memory } from '@noy-db/to-memory'
 import { readZip } from '@noy-db/as-zip'
 import { toBytes, readXlsx, formula } from '../src/index.js'
@@ -131,6 +131,42 @@ describe('#414 P1 — smart export', () => {
     // LANG named range present in the workbook
     const wbxml = (await readZip(bytes)).find((p) => p.path === 'xl/workbook.xml')!
     expect(DEC.decode(wbxml.bytes)).toContain('name="LANG"')
+  })
+
+  it('P2 dict: a _Lookups sheet + a LANG-driven VLOOKUP label column', async () => {
+    const adapter = memory()
+    const init = await createNoydb({ store: adapter, user: 'alice', secret: 'pw-dict' })
+    await init.openVault('co')
+    await init.grant('co', {
+      userId: 'alice', displayName: 'Alice', role: 'owner', passphrase: 'pw-dict',
+      exportCapability: { plaintext: ['xlsx'] },
+    })
+    init.close()
+    const db = await createNoydb({ store: adapter, user: 'alice', secret: 'pw-dict', i18nStrategy: withI18n() })
+    const vault = await db.openVault('co')
+    await vault.dictionary('status').putAll({
+      paid: { en: 'Paid', th: 'ชำระแล้ว' },
+      draft: { en: 'Draft', th: 'ฉบับร่าง' },
+    } as Record<string, Record<string, string>>)
+    await vault.collection<{ id: string; status: string }>('orders', {
+      dictKeyFields: { status: dictKey('status', ['paid', 'draft'] as const) },
+    }).put('o1', { id: 'o1', status: 'paid' })
+
+    const wb = await readXlsx(await toBytes(vault, {
+      smart: true,
+      sheets: [{ name: 'orders', collection: 'orders', dictFields: { status: 'status' } }],
+    }))
+    expect(wb.sheets.map((s) => s.name)).toEqual(expect.arrayContaining(['_settings', '_Lookups_status', 'orders']))
+
+    const orders = wb.sheets.find((s) => s.name === 'orders')!
+    const h = headerMap(orders)
+    expect(h['status__label']).toBeTruthy()
+    expect(orders.rows.slice(1).find((r) => r[h['id']!] === 'o1')![h['status__label']!]).toBe('Paid')
+
+    const lk = wb.sheets.find((s) => s.name === '_Lookups_status')!
+    const lh = headerMap(lk)
+    expect(lh['Code'] && lh['en'] && lh['th']).toBeTruthy()
+    expect(lk.rows.slice(1).find((r) => r[lh['Code']!] === 'paid')![lh['en']!]).toBe('Paid')
   })
 
   it('formula() emits a live <f> with a cached value (round-trips via readXlsx)', async () => {

--- a/packages/as-xlsx/src/index.ts
+++ b/packages/as-xlsx/src/index.ts
@@ -88,6 +88,13 @@ export interface AsXlsxSheetOptions {
    * re-renders). Read raw, so open the export vault without an active locale.
    */
   readonly i18nFields?: readonly string[]
+  /**
+   * Smart mode only: map a dict-backed (code) field to its dictionary name, e.g.
+   * `{ status: 'status' }`. Emits a hidden `_Lookups_<dict>` sheet (code +
+   * per-locale labels) and a `<field>__label` display column resolved by the
+   * global LANG cell via `VLOOKUP(code, …, MATCH(LANG, …))`.
+   */
+  readonly dictFields?: Record<string, string>
 }
 
 /** Single-collection convenience — passed where a sheet-list is accepted. */
@@ -284,8 +291,20 @@ async function buildSmartSheets(
   }
   const matByCollection = new Map(mats.map((m) => [m.opt.collection, m]))
 
+  // Load declared dictionaries once; merge their locales into the global set.
+  const dictEntries = new Map<string, DictEntry[]>()
+  for (const m of mats) {
+    for (const [field, dictName] of Object.entries(m.opt.dictFields ?? {})) {
+      if (!m.cols.includes(field) || dictEntries.has(dictName)) continue
+      dictEntries.set(dictName, await vault.dictionary(dictName).list())
+    }
+  }
+  for (const entries of dictEntries.values()) {
+    for (const e of entries) for (const loc of Object.keys(e.labels)) localeSet.add(loc)
+  }
+
   const locales = [...localeSet].sort()
-  const hasI18n = locales.length > 0
+  const hasLang = locales.length > 0
   const defaultLocale = locales.includes('en') ? 'en' : (locales[0] ?? 'en')
   // Build an IF-chain over the per-locale cells, switched by the LANG name.
   const ifChain = (refOf: (loc: string) => string): string => {
@@ -304,7 +323,13 @@ async function buildSmartSheets(
     const refFields = Object.keys(refs).filter((f) => m.cols.includes(f) && matByCollection.has(refs[f]!.target))
     const baseCols = m.cols.filter((c) => !i18nSet.has(c))
     const i18nFlat = m.i18nFields.flatMap((f) => [f, ...locales.map((l) => `${f}__${l}`)])
-    const header = [...baseCols, ...i18nFlat, ...refFields.map((f) => `${f}__label`)]
+    const dictPairs = Object.entries(m.opt.dictFields ?? {}).filter(([f]) => m.cols.includes(f))
+    const header = [
+      ...baseCols,
+      ...i18nFlat,
+      ...dictPairs.map(([f]) => `${f}__label`),
+      ...refFields.map((f) => `${f}__label`),
+    ]
     const colIndex = new Map<string, number>()
     header.forEach((h, i) => colIndex.set(h, i + 1))
 
@@ -347,6 +372,15 @@ async function buildSmartSheets(
         )
         return [display, ...locales.map((l) => (rawMap[l] ?? null) as unknown)]
       })
+      const dictCells = dictPairs.map(([f, dn]) => {
+        const codeRef = `${colLetter(colIndex.get(f)!)}${rowNum}`
+        const lk = `_Lookups_${dn}`
+        // MATCH(LANG, lookup header row) → the locale's column in the lookup sheet.
+        const f1 = `IFERROR(VLOOKUP(${codeRef},'${lk}'!$A:$ZZ,MATCH(LANG,'${lk}'!$1:$1,0),FALSE),${codeRef})`
+        const code = r[f]
+        const entry = code == null ? undefined : dictEntries.get(dn)?.find((e) => e.key === safeStringify(code))
+        return formula(f1, asCached(entry?.labels[defaultLocale] ?? (code ?? '')))
+      })
       const refCells = refFields.map((f) => {
         const target = refs[f]!.target
         const targetSheet = sheetNameByCollection.get(target)!
@@ -357,7 +391,7 @@ async function buildSmartSheets(
         const cached = code == null ? '' : asCached(targetMat.labelMap.get(safeStringify(code)))
         return formula(f1, cached)
       })
-      return [...baseCells, ...i18nCells, ...refCells]
+      return [...baseCells, ...i18nCells, ...dictCells, ...refCells]
     })
     return {
       name: m.opt.name,
@@ -379,9 +413,16 @@ async function buildSmartSheets(
 
   // Global LANG control — a Settings sheet + named range every i18n/dict label
   // references via IF(LANG=…). Only emitted when there are i18n fields.
+  // Hidden lookup sheets: one per declared dictionary (code + per-locale labels).
+  const lookupSheets: XlsxSheet[] = [...dictEntries.entries()].map(([dn, entries]) => ({
+    name: `_Lookups_${dn}`,
+    header: ['Code', ...locales],
+    rows: entries.map((e) => [e.key, ...locales.map((l) => e.labels[l] ?? '')]),
+  }))
+
   const settingsSheets: XlsxSheet[] = []
   const definedNames: { name: string; ref: string }[] = []
-  if (hasI18n) {
+  if (hasLang) {
     settingsSheets.push({
       name: '_settings',
       header: ['Setting', 'Value'],
@@ -391,7 +432,7 @@ async function buildSmartSheets(
     definedNames.push({ name: 'LANG', ref: `'_settings'!$B$2` })
   }
 
-  return { sheets: [...settingsSheets, manifest, ...dataSheets], definedNames }
+  return { sheets: [...settingsSheets, ...lookupSheets, manifest, ...dataSheets], definedNames }
 }
 
 function inferColumns(records: readonly Record<string, unknown>[]): string[] {


### PR DESCRIPTION
Completes **#414 P2** (localization) — applies the global LANG cell to dictionary fields.

### What
`dictFields: { <field>: <dictName> }` on a smart sheet →
- a hidden **`_Lookups_<dict>`** sheet (`Code` + per-locale label columns from `vault.dictionary(name).list()`)
- a **`<field>__label`** display column: `IFERROR(VLOOKUP(code, _Lookups!…, MATCH(LANG, lookupHeader, 0), FALSE), code)`, cached at the default locale.

Changing the single `LANG` cell now re-renders **i18n *and* dict** labels. Dict locales merge into the global LANG dropdown.

### Verification
- +1 as-xlsx test (lookup sheet + LANG-driven VLOOKUP label); as-xlsx suite (41) green; typecheck/lint/arch/validate-features/showcases-typecheck clean.

**#414 P2 complete.** Next: P3 (computed — groupBy/MV → SUMIFS).

Refs #414