### PR TITLE
feat(as-xlsx): smart workbook — groupBy summary sheets via SUMIFS (#414 P3)

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -2286,6 +2286,8 @@ exports:
         path: showcases/src/114-as-xlsx-smart.showcase.test.ts
       - id: 115-as-xlsx-lang-cell
         path: showcases/src/115-as-xlsx-lang-cell.showcase.test.ts
+      - id: 116-as-xlsx-summary
+        path: showcases/src/116-as-xlsx-summary.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -2294,6 +2296,7 @@ exports:
       - 'Multi-sheet — preserves relational shape across collections'
       - 'Smart mode (toBytes({ smart: true }), #414 P1): id-first sheets; FK fields (auto-detected via dumpSchema) get a <field>__label VLOOKUP column with a cached resolved label (live + immediate); a _manifest index sheet. Formula cells via formula(f, cachedValue) emit <f> + cached <v>. Number formats via styled(v, code) → styles.xml; data-validation dropdowns (enum/ref auto, explicit override)'
       - 'Smart mode #414 P2: i18nFields → per-locale columns + a display column switched live by a global LANG named range on a _settings sheet (IF(LANG=…) chain); dictFields → a _Lookups_<dict> sheet + a <field>__label VLOOKUP(code, …, MATCH(LANG, header)) display; changing LANG re-renders every i18n + dict label. definedNames support in the writer'
+      - 'Smart mode #414 P3: summaries spec → a groupBy sheet of live SUMIFS/COUNTIFS/AVERAGEIFS over a data sheet (one row per distinct group), values cached at export; source value columns must be numeric (numberFormats) for the live math'
       - 'fromBytes reads sharedStrings + workbook + sheet<N>.xml; opt-in date coercion via fieldTypes'
       - 'fast-xml-parser dep (^5.0.0); strict mode via XMLValidator pre-pass'
       - 'Import gated by importCapability.plaintext.xlsx; apply() inside vault.transaction'

--- a/packages/as-xlsx/__tests__/as-xlsx-smart.test.ts
+++ b/packages/as-xlsx/__tests__/as-xlsx-smart.test.ts
@@ -169,6 +169,46 @@ describe('#414 P1 — smart export', () => {
     expect(lk.rows.slice(1).find((r) => r[lh['Code']!] === 'paid')![lh['en']!]).toBe('Paid')
   })
 
+  it('P3: groupBy summary sheet with live SUMIFS/COUNTIFS + cached values', async () => {
+    const adapter = memory()
+    const init = await createNoydb({ store: adapter, user: 'alice', secret: 'pw-sum' })
+    await init.openVault('firm')
+    await init.grant('firm', {
+      userId: 'alice', displayName: 'Alice', role: 'owner', passphrase: 'pw-sum',
+      exportCapability: { plaintext: ['xlsx'] },
+    })
+    init.close()
+    const db = await createNoydb({ store: adapter, user: 'alice', secret: 'pw-sum' })
+    const vault = await db.openVault('firm')
+    await vault.collection<Client>('clients').put('c1', { id: 'c1', name: 'Acme' })
+    const invoices = vault.collection<Invoice>('invoices', { refs: { clientId: ref('clients', 'strict') } })
+    await invoices.put('i1', { id: 'i1', clientId: 'c1', amount: 100 })
+    await invoices.put('i2', { id: 'i2', clientId: 'c1', amount: 50 })
+
+    const bytes = await toBytes(vault, {
+      smart: true,
+      sheets: [{ name: 'clients', collection: 'clients' }, { name: 'invoices', collection: 'invoices' }],
+      summaries: [
+        {
+          name: 'byClient',
+          from: 'invoices',
+          groupBy: 'clientId',
+          aggregates: [{ label: 'total', op: 'sum', field: 'amount' }, { label: 'n', op: 'count' }],
+        },
+      ],
+    })
+    const wb = await readXlsx(bytes)
+    const sum = wb.sheets.find((s) => s.name === 'byClient')!
+    expect(sum).toBeTruthy()
+    const h = headerMap(sum)
+    const row = sum.rows.slice(1).find((r) => r[h['clientId']!] === 'c1')!
+    expect(row[h['total']!]).toBe(150) // cached SUMIFS
+    expect(row[h['n']!]).toBe(2) // cached COUNTIFS
+
+    const xmls = (await readZip(bytes)).filter((p) => /sheet\d+\.xml/.test(p.path)).map((p) => DEC.decode(p.bytes))
+    expect(xmls.some((x) => x.includes('SUMIFS('))).toBe(true)
+  })
+
   it('formula() emits a live <f> with a cached value (round-trips via readXlsx)', async () => {
     const { writeXlsx } = await import('../src/index.js')
     const bytes = await writeXlsx([{ name: 's', header: ['x'], rows: [[formula('1+2', 3)]] }])

--- a/packages/as-xlsx/src/index.ts
+++ b/packages/as-xlsx/src/index.ts
@@ -97,10 +97,37 @@ export interface AsXlsxSheetOptions {
   readonly dictFields?: Record<string, string>
 }
 
+/** One aggregate column in a smart-mode summary sheet (#414 P3). */
+export interface AsXlsxSummaryAggregate {
+  /** Column header for this aggregate. */
+  readonly label: string
+  readonly op: 'sum' | 'count' | 'avg'
+  /** Field to aggregate — required for `sum`/`avg`, ignored for `count`. */
+  readonly field?: string
+}
+
+/**
+ * A groupBy summary sheet (#414 P3): groups the source collection's sheet by
+ * `groupBy` and emits live SUMIFS/COUNTIFS/AVERAGEIFS columns (values cached at
+ * export). The source value columns must be numeric for the live formulas to
+ * compute (apply `numberFormats` to money fields).
+ */
+export interface AsXlsxSummarySpec {
+  /** Summary sheet name. */
+  readonly name: string
+  /** Source collection (must be exported as a sheet). */
+  readonly from: string
+  /** Field to group by. */
+  readonly groupBy: string
+  readonly aggregates: readonly AsXlsxSummaryAggregate[]
+}
+
 /** Single-collection convenience — passed where a sheet-list is accepted. */
 export interface AsXlsxOptions {
   /** One or more sheets. At least one required. */
   readonly sheets: readonly AsXlsxSheetOptions[]
+  /** Smart mode only: groupBy summary sheets (live SUMIFS/COUNTIFS/AVERAGEIFS). */
+  readonly summaries?: readonly AsXlsxSummarySpec[]
   /**
    * Smart-workbook mode (#414). Emits a relational workbook instead of a flat
    * dump:
@@ -316,6 +343,9 @@ async function buildSmartSheets(
     return expr
   }
 
+  // Per-collection sheet metadata so summaries can reference data-sheet columns.
+  const sheetMeta = new Map<string, { name: string; colIndex: Map<string, number> }>()
+
   const dataSheets: XlsxSheet[] = mats.map((m) => {
     const refs = snapshot.collections[m.opt.collection]?.refs ?? {}
     const fields = snapshot.collections[m.opt.collection]?.fields ?? {}
@@ -332,6 +362,7 @@ async function buildSmartSheets(
     ]
     const colIndex = new Map<string, number>()
     header.forEach((h, i) => colIndex.set(h, i + 1))
+    sheetMeta.set(m.opt.collection, { name: m.opt.name, colIndex })
 
     // Data-validation dropdowns on base columns: explicit > ref-range > enum.
     const lastRow = Math.max(m.records.length + 1, 2)
@@ -413,6 +444,53 @@ async function buildSmartSheets(
 
   // Global LANG control — a Settings sheet + named range every i18n/dict label
   // references via IF(LANG=…). Only emitted when there are i18n fields.
+  // GroupBy summary sheets (#414 P3): live SUMIFS/COUNTIFS/AVERAGEIFS over a
+  // data sheet, values cached at export.
+  const summarySheets: XlsxSheet[] = []
+  for (const spec of options.summaries ?? []) {
+    const src = sheetMeta.get(spec.from)
+    const srcMat = matByCollection.get(spec.from)
+    const gCol = src?.colIndex.get(spec.groupBy)
+    if (!src || !srcMat || gCol === undefined) continue
+    const gLetter = colLetter(gCol)
+    const seen = new Set<string>()
+    const groups: unknown[] = []
+    for (const r of srcMat.records) {
+      const k = safeStringify(r[spec.groupBy])
+      if (!seen.has(k)) {
+        seen.add(k)
+        groups.push(r[spec.groupBy])
+      }
+    }
+    const header = [spec.groupBy, ...spec.aggregates.map((a) => a.label)]
+    const rows = groups.map((g, i) => {
+      const rowNum = i + 2
+      const groupRecs = srcMat.records.filter((r) => safeStringify(r[spec.groupBy]) === safeStringify(g))
+      const cells: unknown[] = [g]
+      for (const a of spec.aggregates) {
+        if (a.op === 'count') {
+          cells.push(formula(`COUNTIFS('${src.name}'!$${gLetter}:$${gLetter},$A${rowNum})`, groupRecs.length))
+          continue
+        }
+        const vIdx = a.field ? src.colIndex.get(a.field) : undefined
+        if (vIdx === undefined) {
+          cells.push(null)
+          continue
+        }
+        const vLetter = colLetter(vIdx)
+        const nums = groupRecs.map((r) => Number(r[a.field!])).filter((n) => Number.isFinite(n))
+        const sum = nums.reduce((s, n) => s + n, 0)
+        const cached = a.op === 'sum' ? sum : nums.length ? sum / nums.length : 0
+        const fn = a.op === 'sum' ? 'SUMIFS' : 'AVERAGEIFS'
+        cells.push(
+          formula(`${fn}('${src.name}'!$${vLetter}:$${vLetter},'${src.name}'!$${gLetter}:$${gLetter},$A${rowNum})`, cached),
+        )
+      }
+      return cells
+    })
+    summarySheets.push({ name: spec.name, header, rows })
+  }
+
   // Hidden lookup sheets: one per declared dictionary (code + per-locale labels).
   const lookupSheets: XlsxSheet[] = [...dictEntries.entries()].map(([dn, entries]) => ({
     name: `_Lookups_${dn}`,
@@ -432,7 +510,10 @@ async function buildSmartSheets(
     definedNames.push({ name: 'LANG', ref: `'_settings'!$B$2` })
   }
 
-  return { sheets: [...settingsSheets, ...lookupSheets, manifest, ...dataSheets], definedNames }
+  return {
+    sheets: [...settingsSheets, ...lookupSheets, manifest, ...summarySheets, ...dataSheets],
+    definedNames,
+  }
 }
 
 function inferColumns(records: readonly Record<string, unknown>[]): string[] {

--- a/showcases/src/116-as-xlsx-summary.showcase.test.ts
+++ b/showcases/src/116-as-xlsx-summary.showcase.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Showcase 116 — as-xlsx groupBy summary sheets (#414 P3)
+ *
+ * What you'll learn
+ * ─────────────────
+ * The analytical layer: declare a `summaries` spec and `toBytes({ smart: true })`
+ * emits a summary sheet whose cells are **live** `SUMIFS`/`COUNTIFS`/`AVERAGEIFS`
+ * formulas over a data sheet (one row per distinct group), with the value cached
+ * at export. Edit the source rows and the totals recompute in Excel/Sheets.
+ *
+ * Why it matters
+ * ──────────────
+ * A flat export makes the analyst rebuild pivots by hand. Here the workbook
+ * ships with the group-by analysis already wired and live — built on the same
+ * formula engine as the FK lookups and the LANG cell. (Source value columns must
+ * be numeric for the live math — apply `numberFormats` to money fields.)
+ *
+ * Spec mapping
+ * ────────────
+ *   #414 — as-xls smart workbook (P3: computed groupBy → SUMIFS)
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, ref } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { toBytes, readXlsx } from '@noy-db/as-xlsx'
+
+describe('showcase 116 — as-xlsx groupBy summary', () => {
+  it('emits a live SUMIFS/COUNTIFS summary sheet grouped by a field', async () => {
+    const store = memory()
+    const init = await createNoydb({ store, user: 'alice', secret: 'pw-116' })
+    await init.openVault('firm')
+    await init.grant('firm', {
+      userId: 'alice', displayName: 'Alice', role: 'owner', passphrase: 'pw-116',
+      exportCapability: { plaintext: ['xlsx'] },
+    })
+    init.close()
+
+    const db = await createNoydb({ store, user: 'alice', secret: 'pw-116' })
+    const vault = await db.openVault('firm')
+    await vault.collection<{ id: string; name: string }>('clients').put('c1', { id: 'c1', name: 'Acme' })
+    const invoices = vault.collection<{ id: string; clientId: string; amount: number }>('invoices', {
+      refs: { clientId: ref('clients', 'strict') },
+    })
+    await invoices.put('i1', { id: 'i1', clientId: 'c1', amount: 100 })
+    await invoices.put('i2', { id: 'i2', clientId: 'c1', amount: 50 })
+
+    const wb = await readXlsx(await toBytes(vault, {
+      smart: true,
+      sheets: [{ name: 'clients', collection: 'clients' }, { name: 'invoices', collection: 'invoices' }],
+      summaries: [{
+        name: 'byClient',
+        from: 'invoices',
+        groupBy: 'clientId',
+        aggregates: [{ label: 'total', op: 'sum', field: 'amount' }, { label: 'invoices', op: 'count' }],
+      }],
+    }))
+
+    const sum = wb.sheets.find((s) => s.name === 'byClient')!
+    const h: Record<string, string> = {}
+    for (const [letter, name] of Object.entries(sum.rows[0] ?? {})) h[String(name)] = letter
+    const row = sum.rows.slice(1).find((r) => r[h['clientId']!] === 'c1')!
+    expect(row[h['total']!]).toBe(150) // live SUMIFS, cached
+    expect(row[h['invoices']!]).toBe(2) // live COUNTIFS, cached
+  })
+})


### PR DESCRIPTION
The **analytical layer** (#414 P3). A `summaries` spec emits a groupBy sheet whose cells are **live** `SUMIFS`/`COUNTIFS`/`AVERAGEIFS` over a data sheet (one row per distinct group), values cached at export.

### What
`summaries: [{ name, from, groupBy, aggregates: [{ label, op, field? }] }]` →
- a sheet `[groupBy, …labels]`; `sum`/`avg` → `SUMIFS`/`AVERAGEIFS('From'!val,'From'!grp,groupCell)`; `count` → `COUNTIFS`. Cached = computed from records.
- **No writer change** — pure `formula(f, cached)` over the P1 engine. Source value columns must be numeric (`numberFormats`) for the live math.

### Verification
- +1 as-xlsx test (cached SUMIFS/COUNTIFS + live `SUMIFS` in the XML) + showcase 116; as-xlsx suite (42) + showcase green; typecheck/lint/arch/validate-features/showcases-typecheck clean.

**#414 P3 shipped.** Remaining: P4 (smart import), P5 (Sheets-native QUERY).

Refs #414