### PR TITLE
feat(as-xlsx): smart import — reverse the smart layout onto a schema (#414 P4 Mode A)

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -2288,6 +2288,8 @@ exports:
         path: showcases/src/115-as-xlsx-lang-cell.showcase.test.ts
       - id: 116-as-xlsx-summary
         path: showcases/src/116-as-xlsx-summary.showcase.test.ts
+      - id: 117-as-xlsx-smart-import
+        path: showcases/src/117-as-xlsx-smart-import.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -2297,6 +2299,7 @@ exports:
       - 'Smart mode (toBytes({ smart: true }), #414 P1): id-first sheets; FK fields (auto-detected via dumpSchema) get a <field>__label VLOOKUP column with a cached resolved label (live + immediate); a _manifest index sheet. Formula cells via formula(f, cachedValue) emit <f> + cached <v>. Number formats via styled(v, code) → styles.xml; data-validation dropdowns (enum/ref auto, explicit override)'
       - 'Smart mode #414 P2: i18nFields → per-locale columns + a display column switched live by a global LANG named range on a _settings sheet (IF(LANG=…) chain); dictFields → a _Lookups_<dict> sheet + a <field>__label VLOOKUP(code, …, MATCH(LANG, header)) display; changing LANG re-renders every i18n + dict label. definedNames support in the writer'
       - 'Smart mode #414 P3: summaries spec → a groupBy sheet of live SUMIFS/COUNTIFS/AVERAGEIFS over a data sheet (one row per distinct group), values cached at export; source value columns must be numeric (numberFormats) for the live math'
+      - 'Smart mode #414 P4: fromBytes({ smart: true }) reverses the smart layout onto an existing schema (Mode A) — rebuilds i18n maps from <f>__<loc> columns, drops the i18n display + <f>__label derived columns, keeps code columns'
       - 'fromBytes reads sharedStrings + workbook + sheet<N>.xml; opt-in date coercion via fieldTypes'
       - 'fast-xml-parser dep (^5.0.0); strict mode via XMLValidator pre-pass'
       - 'Import gated by importCapability.plaintext.xlsx; apply() inside vault.transaction'

--- a/packages/as-xlsx/__tests__/as-xlsx-smart.test.ts
+++ b/packages/as-xlsx/__tests__/as-xlsx-smart.test.ts
@@ -6,9 +6,10 @@
 import { describe, expect, it } from 'vitest'
 import { createNoydb, ref } from '@noy-db/hub'
 import { withI18n, i18nText, dictKey } from '@noy-db/hub/i18n'
+import { withTransactions } from '@noy-db/hub/tx'
 import { memory } from '@noy-db/to-memory'
 import { readZip } from '@noy-db/as-zip'
-import { toBytes, readXlsx, formula } from '../src/index.js'
+import { toBytes, readXlsx, formula, fromBytes } from '../src/index.js'
 
 const DEC = new TextDecoder()
 
@@ -207,6 +208,32 @@ describe('#414 P1 — smart export', () => {
 
     const xmls = (await readZip(bytes)).filter((p) => /sheet\d+\.xml/.test(p.path)).map((p) => DEC.decode(p.bytes))
     expect(xmls.some((x) => x.includes('SUMIFS('))).toBe(true)
+  })
+
+  it('P4 smart import: reverses the smart layout — rebuilds i18n maps, drops derived columns', async () => {
+    const adapter = memory()
+    const init = await createNoydb({ store: adapter, user: 'alice', secret: 'pw-rt' })
+    await init.openVault('shop')
+    await init.grant('shop', {
+      userId: 'alice', displayName: 'Alice', role: 'owner', passphrase: 'pw-rt',
+      exportCapability: { plaintext: ['xlsx'] }, importCapability: { plaintext: ['xlsx'] },
+    })
+    init.close()
+    const db = await createNoydb({ store: adapter, user: 'alice', secret: 'pw-rt', i18nStrategy: withI18n(), txStrategy: withTransactions() })
+    const vault = await db.openVault('shop')
+    const products = vault.collection<{ id: string; name: Record<string, string> }>('products', {
+      i18nFields: { name: i18nText({ languages: ['en', 'th'], required: 'all' }) },
+    })
+    await products.put('p1', { id: 'p1', name: { en: 'Widget', th: 'วิดเจ็ต' } })
+
+    const bytes = await toBytes(vault, { smart: true, sheets: [{ name: 'products', collection: 'products', i18nFields: ['name'] }] })
+
+    // Drop then re-import to prove the smart reader rebuilds the record.
+    await products.delete('p1')
+    const plan = await fromBytes(vault, bytes, { collection: 'products', sheet: 'products', smart: true, policy: 'merge' })
+    await plan.apply()
+
+    expect(await products.get('p1')).toEqual({ id: 'p1', name: { en: 'Widget', th: 'วิดเจ็ต' } })
   })
 
   it('formula() emits a live <f> with a cached value (round-trips via readXlsx)', async () => {

--- a/packages/as-xlsx/src/index.ts
+++ b/packages/as-xlsx/src/index.ts
@@ -595,6 +595,14 @@ export interface AsXlsxImportOptions {
    * Unknown labels (no match in any locale) pass through as-is.
    */
   readonly dicts?: Readonly<Record<string, readonly DictEntry[]>>
+  /**
+   * Read a sheet produced by smart export (#414 P4). Reverses the smart layout:
+   * reconstructs i18n fields from their per-locale columns (`<f>__<loc>` →
+   * `{ loc: value }`), and drops derived columns — the i18n display column and
+   * every `<f>__label` (FK/dict) formula column. Code columns (the real values)
+   * pass through. Maps onto the existing collection schema (Mode A).
+   */
+  readonly smart?: boolean
 }
 
 export interface AsXlsxImportPlan {
@@ -692,6 +700,17 @@ export async function fromBytes(
     }
   }
 
+  // Smart layout: any `<base>__<suffix>` where suffix isn't 'label' marks an
+  // i18n base whose display column (`<base>`) is a formula to be dropped and
+  // whose per-locale columns rebuild the `{ loc: value }` map.
+  const i18nBases = new Set<string>()
+  if (options.smart) {
+    for (const field of colToField.values()) {
+      const m = /^(.+)__(.+)$/.exec(field)
+      if (m && m[2] !== 'label') i18nBases.add(m[1]!)
+    }
+  }
+
   const records: Record<string, unknown>[] = []
   for (let i = headerRowIdx + 1; i < allRows.length; i++) {
     const row = allRows[i]!
@@ -700,6 +719,22 @@ export async function fromBytes(
     for (const [col, value] of Object.entries(row)) {
       const field = colToField.get(col)
       if (field === undefined) continue
+      if (options.smart) {
+        if (field.endsWith('__label')) continue // derived FK/dict label
+        const lm = /^(.+)__(.+)$/.exec(field)
+        if (lm && lm[2] !== 'label' && i18nBases.has(lm[1]!)) {
+          const base = lm[1]!
+          const coerced = coerceXlsxCell(value, types[base])
+          if (coerced !== undefined && coerced !== '') {
+            const map = (record[base] as Record<string, unknown> | undefined) ?? {}
+            map[lm[2]!] = coerced
+            record[base] = map
+            hasAny = true
+          }
+          continue
+        }
+        if (i18nBases.has(field)) continue // i18n display column (formula)
+      }
       const coerced = coerceXlsxCell(value, types[field])
       if (coerced !== undefined) {
         const invMap = invertMaps.get(field)

--- a/showcases/src/117-as-xlsx-smart-import.showcase.test.ts
+++ b/showcases/src/117-as-xlsx-smart-import.showcase.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Showcase 117 — as-xlsx smart import (#414 P4)
+ *
+ * What you'll learn
+ * ─────────────────
+ * The read side of the smart workbook. `fromBytes(vault, bytes, { smart: true })`
+ * reverses what smart export wrote — onto an EXISTING schema (Mode A):
+ *   1. Rebuilds i18n fields from their per-locale columns (`name__en`,
+ *      `name__th` → `{ en, th }`).
+ *   2. Drops the derived columns — the i18n display column and every
+ *      `<field>__label` (FK/dict) formula column.
+ *   3. Keeps the code columns (the real values), then applies via diff.
+ *
+ * Why it matters
+ * ──────────────
+ * Round-trip: export a vault as a rich workbook, edit it in Excel, import it
+ * back. The smart reader strips the presentation layer (labels, displays) and
+ * reconstructs the canonical record — so a human-edited workbook flows straight
+ * back into the encrypted store.
+ *
+ * Spec mapping
+ * ────────────
+ *   #414 — as-xls smart workbook (P4: smart import, Mode A)
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { withI18n, i18nText } from '@noy-db/hub/i18n'
+import { withTransactions } from '@noy-db/hub/tx'
+import { memory } from '@noy-db/to-memory'
+import { toBytes, fromBytes } from '@noy-db/as-xlsx'
+
+describe('showcase 117 — as-xlsx smart import (round-trip)', () => {
+  it('exports a localized workbook, then imports it back onto the schema', async () => {
+    const store = memory()
+    const init = await createNoydb({ store, user: 'alice', secret: 'pw-117' })
+    await init.openVault('shop')
+    await init.grant('shop', {
+      userId: 'alice', displayName: 'Alice', role: 'owner', passphrase: 'pw-117',
+      exportCapability: { plaintext: ['xlsx'] }, importCapability: { plaintext: ['xlsx'] },
+    })
+    init.close()
+
+    const db = await createNoydb({ store, user: 'alice', secret: 'pw-117', i18nStrategy: withI18n(), txStrategy: withTransactions() })
+    const vault = await db.openVault('shop')
+    const products = vault.collection<{ id: string; name: Record<string, string> }>('products', {
+      i18nFields: { name: i18nText({ languages: ['en', 'th'], required: 'all' }) },
+    })
+    await products.put('p1', { id: 'p1', name: { en: 'Widget', th: 'วิดเจ็ต' } })
+
+    // Export → (edit in Excel) → import back.
+    const bytes = await toBytes(vault, { smart: true, sheets: [{ name: 'products', collection: 'products', i18nFields: ['name'] }] })
+    await products.delete('p1')
+    const plan = await fromBytes(vault, bytes, { collection: 'products', sheet: 'products', smart: true })
+    await plan.apply()
+
+    expect(await products.get('p1')).toEqual({ id: 'p1', name: { en: 'Widget', th: 'วิดเจ็ต' } })
+  })
+})


### PR DESCRIPTION
The **read side** of the smart workbook. `fromBytes(vault, bytes, { smart: true })` inverts what smart export wrote, onto an **existing** schema (Mode A):
- rebuilds **i18n** fields from their per-locale columns (`<f>__<loc>` → `{ loc: value }`);
- drops **derived** columns — the i18n display column and every `<f>__label` (FK/dict) formula column;
- keeps **code** columns (the real values), then applies via the existing diff/apply.

Reuses the existing dict-label inversion + `diffVault` + tx apply.

### Verification
- +1 as-xlsx test: export → delete → smart-import → apply **round-trips** an i18n map; showcase 117; as-xlsx suite (43) + showcase green; typecheck/lint/arch/validate-features/showcases-typecheck clean.

Remaining #414: **P4 Mode B** (infer a new schema from a workbook), **P5** (Google-Sheets-native QUERY).

Refs #414