### PR TITLE
feat(as-xlsx): smart workbook — Google-Sheets QUERY dialect (#414 P5)

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -2290,6 +2290,8 @@ exports:
         path: showcases/src/116-as-xlsx-summary.showcase.test.ts
       - id: 117-as-xlsx-smart-import
         path: showcases/src/117-as-xlsx-smart-import.showcase.test.ts
+      - id: 118-as-xlsx-sheets-query
+        path: showcases/src/118-as-xlsx-sheets-query.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -2300,6 +2302,7 @@ exports:
       - 'Smart mode #414 P2: i18nFields → per-locale columns + a display column switched live by a global LANG named range on a _settings sheet (IF(LANG=…) chain); dictFields → a _Lookups_<dict> sheet + a <field>__label VLOOKUP(code, …, MATCH(LANG, header)) display; changing LANG re-renders every i18n + dict label. definedNames support in the writer'
       - 'Smart mode #414 P3: summaries spec → a groupBy sheet of live SUMIFS/COUNTIFS/AVERAGEIFS over a data sheet (one row per distinct group), values cached at export; source value columns must be numeric (numberFormats) for the live math'
       - 'Smart mode #414 P4: fromBytes({ smart: true }) reverses the smart layout onto an existing schema (Mode A) — rebuilds i18n maps from <f>__<loc> columns, drops the i18n display + <f>__label derived columns, keeps code columns'
+      - 'Smart mode #414 P5: dialect:"sheets" emits each summary as a single Google-Sheets QUERY formula (Sheets-only — QUERY errors in Excel); dialect:"excel" (default) stays cross-compatible SUMIFS'
       - 'fromBytes reads sharedStrings + workbook + sheet<N>.xml; opt-in date coercion via fieldTypes'
       - 'fast-xml-parser dep (^5.0.0); strict mode via XMLValidator pre-pass'
       - 'Import gated by importCapability.plaintext.xlsx; apply() inside vault.transaction'

--- a/packages/as-xlsx/__tests__/as-xlsx-smart.test.ts
+++ b/packages/as-xlsx/__tests__/as-xlsx-smart.test.ts
@@ -236,6 +236,25 @@ describe('#414 P1 — smart export', () => {
     expect(await products.get('p1')).toEqual({ id: 'p1', name: { en: 'Widget', th: 'วิดเจ็ต' } })
   })
 
+  it('P5 sheets dialect: a summary emits a single Google-Sheets QUERY formula', async () => {
+    const { vault } = await setup()
+    const bytes = await toBytes(vault, {
+      smart: true,
+      dialect: 'sheets',
+      sheets: [{ name: 'clients', collection: 'clients' }, { name: 'invoices', collection: 'invoices' }],
+      summaries: [{
+        name: 'byClient',
+        from: 'invoices',
+        groupBy: 'clientId',
+        aggregates: [{ label: 'total', op: 'sum', field: 'amount' }, { label: 'n', op: 'count' }],
+      }],
+    })
+    const xmls = (await readZip(bytes)).filter((p) => /sheet\d+\.xml/.test(p.path)).map((p) => DEC.decode(p.bytes))
+    expect(xmls.some((x) => x.includes('QUERY(') && x.includes('SELECT') && x.includes('GROUP BY'))).toBe(true)
+    // and NOT a per-row SUMIFS (that's the excel dialect)
+    expect(xmls.some((x) => x.includes('SUMIFS('))).toBe(false)
+  })
+
   it('formula() emits a live <f> with a cached value (round-trips via readXlsx)', async () => {
     const { writeXlsx } = await import('../src/index.js')
     const bytes = await writeXlsx([{ name: 's', header: ['x'], rows: [[formula('1+2', 3)]] }])

--- a/packages/as-xlsx/src/index.ts
+++ b/packages/as-xlsx/src/index.ts
@@ -129,6 +129,13 @@ export interface AsXlsxOptions {
   /** Smart mode only: groupBy summary sheets (live SUMIFS/COUNTIFS/AVERAGEIFS). */
   readonly summaries?: readonly AsXlsxSummarySpec[]
   /**
+   * Smart mode only: summary formula dialect. `'excel'` (default) emits
+   * cross-compatible per-row SUMIFS/COUNTIFS/AVERAGEIFS. `'sheets'` emits a
+   * single Google-Sheets `QUERY` formula per summary — **Sheets-only** (QUERY
+   * errors in Excel); use when the target is Google Sheets.
+   */
+  readonly dialect?: 'excel' | 'sheets'
+  /**
    * Smart-workbook mode (#414). Emits a relational workbook instead of a flat
    * dump:
    *   - every sheet is **id-first** (record `id` in column A);
@@ -444,8 +451,10 @@ async function buildSmartSheets(
 
   // Global LANG control — a Settings sheet + named range every i18n/dict label
   // references via IF(LANG=…). Only emitted when there are i18n fields.
-  // GroupBy summary sheets (#414 P3): live SUMIFS/COUNTIFS/AVERAGEIFS over a
-  // data sheet, values cached at export.
+  // GroupBy summary sheets (#414 P3/P5). Excel dialect (default): per-row live
+  // SUMIFS/COUNTIFS/AVERAGEIFS, values cached. Sheets dialect: a single
+  // Google-Sheets QUERY formula (Sheets-only — QUERY errors in Excel).
+  const dialect = options.dialect ?? 'excel'
   const summarySheets: XlsxSheet[] = []
   for (const spec of options.summaries ?? []) {
     const src = sheetMeta.get(spec.from)
@@ -453,6 +462,29 @@ async function buildSmartSheets(
     const gCol = src?.colIndex.get(spec.groupBy)
     if (!src || !srcMat || gCol === undefined) continue
     const gLetter = colLetter(gCol)
+
+    if (dialect === 'sheets') {
+      // One live QUERY formula that spills the grouped table (#414 P5).
+      const selects: string[] = []
+      const labels: string[] = []
+      for (const a of spec.aggregates) {
+        if (a.op === 'count') {
+          selects.push(`COUNT(${gLetter})`)
+          labels.push(`COUNT(${gLetter}) '${a.label}'`)
+          continue
+        }
+        const vIdx = a.field ? src.colIndex.get(a.field) : undefined
+        if (vIdx === undefined) continue
+        const vL = colLetter(vIdx)
+        const fn = a.op === 'sum' ? 'SUM' : 'AVG'
+        selects.push(`${fn}(${vL})`)
+        labels.push(`${fn}(${vL}) '${a.label}'`)
+      }
+      const q = `QUERY('${src.name}'!A:ZZ, "SELECT ${gLetter}, ${selects.join(', ')} GROUP BY ${gLetter} LABEL ${labels.join(', ')}", 1)`
+      summarySheets.push({ name: spec.name, rows: [[formula(q)]] })
+      continue
+    }
+
     const seen = new Set<string>()
     const groups: unknown[] = []
     for (const r of srcMat.records) {

--- a/showcases/src/118-as-xlsx-sheets-query.showcase.test.ts
+++ b/showcases/src/118-as-xlsx-sheets-query.showcase.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Showcase 118 — as-xlsx Google-Sheets QUERY dialect (#414 P5)
+ *
+ * What you'll learn
+ * ─────────────────
+ * Smart export's summary sheets default to cross-compatible per-row SUMIFS
+ * (Excel + Sheets). With `dialect: 'sheets'` each summary instead becomes a
+ * single live **`QUERY`** formula — the idiomatic Google Sheets way to group
+ * and aggregate, auto-expanding as the source grows.
+ *
+ * Why it matters
+ * ──────────────
+ * `QUERY` is Sheets-only (it errors in Excel), so it can't be the default — but
+ * when the target IS Google Sheets, one QUERY cell beats N SUMIFS rows: it
+ * spills, recomputes live, and reads like SQL. Pick the dialect for your target.
+ *
+ * Spec mapping
+ * ────────────
+ *   #414 — as-xls smart workbook (P5: Sheets-native QUERY dialect)
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, ref } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { readZip } from '@noy-db/as-zip'
+import { toBytes } from '@noy-db/as-xlsx'
+
+const DEC = new TextDecoder()
+
+describe('showcase 118 — as-xlsx Sheets QUERY dialect', () => {
+  it('dialect:"sheets" emits a single QUERY formula per summary', async () => {
+    const store = memory()
+    const init = await createNoydb({ store, user: 'alice', secret: 'pw-118' })
+    await init.openVault('firm')
+    await init.grant('firm', {
+      userId: 'alice', displayName: 'Alice', role: 'owner', passphrase: 'pw-118',
+      exportCapability: { plaintext: ['xlsx'] },
+    })
+    init.close()
+
+    const db = await createNoydb({ store, user: 'alice', secret: 'pw-118' })
+    const vault = await db.openVault('firm')
+    await vault.collection<{ id: string; name: string }>('clients').put('c1', { id: 'c1', name: 'Acme' })
+    const invoices = vault.collection<{ id: string; clientId: string; amount: number }>('invoices', {
+      refs: { clientId: ref('clients', 'strict') },
+    })
+    await invoices.put('i1', { id: 'i1', clientId: 'c1', amount: 100 })
+    await invoices.put('i2', { id: 'i2', clientId: 'c1', amount: 50 })
+
+    const bytes = await toBytes(vault, {
+      smart: true,
+      dialect: 'sheets',
+      sheets: [{ name: 'clients', collection: 'clients' }, { name: 'invoices', collection: 'invoices' }],
+      summaries: [{
+        name: 'byClient',
+        from: 'invoices',
+        groupBy: 'clientId',
+        aggregates: [{ label: 'total', op: 'sum', field: 'amount' }, { label: 'invoices', op: 'count' }],
+      }],
+    })
+
+    const xmls = (await readZip(bytes))
+      .filter((p) => /xl\/worksheets\/sheet\d+\.xml/.test(p.path))
+      .map((p) => DEC.decode(p.bytes))
+    expect(xmls.some((x) => x.includes('QUERY(') && x.includes('GROUP BY'))).toBe(true)
+  })
+})


### PR DESCRIPTION
A `dialect` option for summary sheets.

- **`dialect: 'excel'`** (default) — cross-compatible per-row SUMIFS/COUNTIFS/AVERAGEIFS (Excel **and** Sheets), values cached. Unchanged.
- **`dialect: 'sheets'`** — each summary becomes a single live `QUERY` formula (`SELECT … GROUP BY … LABEL …`) over the source sheet — idiomatic Google Sheets, spills + recomputes live. **Sheets-only** (QUERY errors in Excel), so opt-in.

### Verification
- +1 as-xlsx test (sheets dialect emits `QUERY`, not `SUMIFS`) + showcase 118; as-xlsx suite (44) + showcase green; typecheck/lint/arch/validate-features/showcases-typecheck clean.

Completes the planned **#414** phases (P1 structural · P2 localization · P3 computed · P4 Mode A import · P5 Sheets dialect). Remaining optional: **P4 Mode B** (infer a new schema from a workbook).

Refs #414