### PR TITLE
feat(as-xlsx): smart import Mode B — infer a schema from a workbook (#414 P4 Mode B)

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -2292,6 +2292,8 @@ exports:
         path: showcases/src/117-as-xlsx-smart-import.showcase.test.ts
       - id: 118-as-xlsx-sheets-query
         path: showcases/src/118-as-xlsx-sheets-query.showcase.test.ts
+      - id: 119-as-xlsx-infer-schema
+        path: showcases/src/119-as-xlsx-infer-schema.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -2303,6 +2305,7 @@ exports:
       - 'Smart mode #414 P3: summaries spec → a groupBy sheet of live SUMIFS/COUNTIFS/AVERAGEIFS over a data sheet (one row per distinct group), values cached at export; source value columns must be numeric (numberFormats) for the live math'
       - 'Smart mode #414 P4: fromBytes({ smart: true }) reverses the smart layout onto an existing schema (Mode A) — rebuilds i18n maps from <f>__<loc> columns, drops the i18n display + <f>__label derived columns, keeps code columns'
       - 'Smart mode #414 P5: dialect:"sheets" emits each summary as a single Google-Sheets QUERY formula (Sheets-only — QUERY errors in Excel); dialect:"excel" (default) stays cross-compatible SUMIFS'
+      - 'Smart mode #414 P4 Mode B: inferSchema(bytes) bootstraps a schema from an arbitrary workbook — types from sampled cells, id field, FKs by value-subset match; zodSourceFor() emits a Zod snippet. Heuristic (review the draft)'
       - 'fromBytes reads sharedStrings + workbook + sheet<N>.xml; opt-in date coercion via fieldTypes'
       - 'fast-xml-parser dep (^5.0.0); strict mode via XMLValidator pre-pass'
       - 'Import gated by importCapability.plaintext.xlsx; apply() inside vault.transaction'

--- a/packages/as-xlsx/__tests__/as-xlsx-smart.test.ts
+++ b/packages/as-xlsx/__tests__/as-xlsx-smart.test.ts
@@ -9,7 +9,7 @@ import { withI18n, i18nText, dictKey } from '@noy-db/hub/i18n'
 import { withTransactions } from '@noy-db/hub/tx'
 import { memory } from '@noy-db/to-memory'
 import { readZip } from '@noy-db/as-zip'
-import { toBytes, readXlsx, formula, fromBytes } from '../src/index.js'
+import { toBytes, readXlsx, formula, fromBytes, writeXlsx, inferSchema, zodSourceFor } from '../src/index.js'
 
 const DEC = new TextDecoder()
 
@@ -253,6 +253,20 @@ describe('#414 P1 — smart export', () => {
     expect(xmls.some((x) => x.includes('QUERY(') && x.includes('SELECT') && x.includes('GROUP BY'))).toBe(true)
     // and NOT a per-row SUMIFS (that's the excel dialect)
     expect(xmls.some((x) => x.includes('SUMIFS('))).toBe(false)
+  })
+
+  it('P4 Mode B: infers a schema (types + FK) from an arbitrary workbook', async () => {
+    const bytes = await writeXlsx([
+      { name: 'clients', header: ['id', 'name'], rows: [['c1', 'Acme'], ['c2', 'Beta']] },
+      { name: 'invoices', header: ['id', 'clientId', 'amount', 'paid'], rows: [['i1', 'c1', 100, true]] },
+    ])
+    const schema = await inferSchema(bytes)
+    expect(schema.collections['clients']!.idField).toBe('id')
+    expect(schema.collections['clients']!.fields['name']!.type).toBe('string')
+    expect(schema.collections['invoices']!.fields['amount']!.type).toBe('number')
+    expect(schema.collections['invoices']!.fields['paid']!.type).toBe('boolean')
+    expect(schema.collections['invoices']!.fields['clientId']!.references).toBe('clients')
+    expect(zodSourceFor(schema)).toContain('z.number()')
   })
 
   it('formula() emits a live <f> with a cached value (round-trips via readXlsx)', async () => {

--- a/packages/as-xlsx/src/index.ts
+++ b/packages/as-xlsx/src/index.ts
@@ -34,6 +34,7 @@ import { readXlsx } from './read.js'
 
 export { writeXlsx, colLetter, formula, styled, type XlsxSheet, type XlsxRow, type XlsxFormulaCell, type XlsxStyledCell, type XlsxValidation } from './xlsx.js'
 export { readXlsx, type ReadXlsxResult, type ReadXlsxSheet, type ReadXlsxRow } from './read.js'
+export { inferSchema, zodSourceFor, type InferredSchema, type InferredCollection, type InferredField, type InferredType } from './infer.js'
 
 /** Per-sheet options for the noy-db consumer API. */
 export interface AsXlsxSheetOptions {

--- a/packages/as-xlsx/src/infer.ts
+++ b/packages/as-xlsx/src/infer.ts
@@ -1,0 +1,137 @@
+/**
+ * #414 P4 Mode B — infer a noy-db schema from an arbitrary workbook.
+ *
+ * Heuristic by nature (the spec's genuinely-hard part): types come from sampling
+ * cell values, foreign keys from value-subset matching against another sheet's
+ * id column. Use it to BOOTSTRAP a schema you then review — not as ground truth.
+ * Standard Schema validators aren't JSON-serializable, so {@link zodSourceFor}
+ * emits a Zod snippet you adopt in code rather than a live validator.
+ */
+import { readXlsx } from './read.js'
+
+export type InferredType = 'string' | 'number' | 'boolean' | 'date'
+
+export interface InferredField {
+  readonly type: InferredType
+  /** Target collection (sheet) name when this field looks like a foreign key. */
+  readonly references?: string
+}
+
+export interface InferredCollection {
+  readonly idField: string
+  readonly fields: Record<string, InferredField>
+}
+
+export interface InferredSchema {
+  readonly collections: Record<string, InferredCollection>
+}
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2})?/
+
+function inferType(vals: readonly unknown[]): InferredType {
+  if (vals.length === 0) return 'string'
+  if (vals.every((v) => typeof v === 'boolean')) return 'boolean'
+  if (vals.every((v) => typeof v === 'number')) return 'number'
+  if (vals.every((v) => typeof v === 'string' && ISO_DATE.test(v))) return 'date'
+  return 'string'
+}
+
+interface SheetData {
+  name: string
+  fields: string[]
+  records: Record<string, unknown>[]
+}
+
+/**
+ * Infer a {@link InferredSchema} from an `.xlsx` byte stream. Sheets whose name
+ * starts with `_` (our smart-export meta sheets) are skipped; pass `skipSheets`
+ * to exclude more (e.g. summary sheets).
+ */
+export async function inferSchema(
+  bytes: Uint8Array,
+  options: { skipSheets?: readonly string[] } = {},
+): Promise<InferredSchema> {
+  const skip = new Set(options.skipSheets ?? [])
+  const decoded = await readXlsx(bytes)
+
+  const sheets: SheetData[] = []
+  for (const sh of decoded.sheets) {
+    if (sh.name.startsWith('_') || skip.has(sh.name)) continue
+    const headerRow = sh.rows[0] ?? {}
+    const colToField = new Map<string, string>()
+    const fields: string[] = []
+    for (const [letter, val] of Object.entries(headerRow)) {
+      const name =
+        typeof val === 'string' ? val.trim() : typeof val === 'number' || typeof val === 'boolean' ? String(val) : ''
+      if (!name) continue
+      colToField.set(letter, name)
+      fields.push(name)
+    }
+    const records = sh.rows.slice(1).map((row) => {
+      const rec: Record<string, unknown> = {}
+      for (const [letter, val] of Object.entries(row)) {
+        const f = colToField.get(letter)
+        if (f !== undefined) rec[f] = val
+      }
+      return rec
+    })
+    sheets.push({ name: sh.name, fields, records })
+  }
+
+  const valuesOf = (s: SheetData, f: string): unknown[] =>
+    s.records.map((r) => r[f]).filter((v) => v != null && v !== '')
+
+  const idFieldOf = (s: SheetData): string => {
+    if (s.fields.includes('id')) return 'id'
+    // First field whose non-null values are all unique → a natural key.
+    for (const f of s.fields) {
+      const vals = valuesOf(s, f)
+      if (vals.length > 0 && new Set(vals.map((v) => String(v))).size === vals.length) return f
+    }
+    return s.fields[0] ?? 'id'
+  }
+
+  const meta = sheets.map((s) => ({ s, idField: idFieldOf(s) }))
+  const idValuesByName = new Map<string, Set<string>>()
+  for (const { s, idField } of meta) {
+    idValuesByName.set(s.name, new Set(valuesOf(s, idField).map((v) => String(v))))
+  }
+
+  const collections: Record<string, InferredCollection> = {}
+  for (const { s, idField } of meta) {
+    const fields: Record<string, InferredField> = {}
+    for (const f of s.fields) {
+      const vals = valuesOf(s, f)
+      const type = inferType(vals)
+      let references: string | undefined
+      if (f !== idField && type === 'string' && vals.length > 0) {
+        const distinct = new Set(vals.map((v) => String(v)))
+        for (const { s: other } of meta) {
+          if (other.name === s.name) continue
+          const ids = idValuesByName.get(other.name)
+          if (ids && ids.size > 0 && [...distinct].every((v) => ids.has(v))) {
+            references = other.name
+            break
+          }
+        }
+      }
+      fields[f] = references ? { type, references } : { type }
+    }
+    collections[s.name] = { idField, fields }
+  }
+  return { collections }
+}
+
+/** Emit a Zod schema snippet (guidance) from an {@link InferredSchema}. */
+export function zodSourceFor(schema: InferredSchema): string {
+  const zType = (t: InferredType): string =>
+    t === 'number' ? 'z.number()' : t === 'boolean' ? 'z.boolean()' : t === 'date' ? 'z.string().datetime()' : 'z.string()'
+  const blocks = [`import { z } from 'zod'`]
+  for (const [name, c] of Object.entries(schema.collections)) {
+    const lines = Object.entries(c.fields).map(
+      ([f, d]) => `  ${f}: ${zType(d.type)},${d.references ? ` // → ${d.references}` : ''}`,
+    )
+    blocks.push(`export const ${name}Schema = z.object({\n${lines.join('\n')}\n})`)
+  }
+  return blocks.join('\n\n')
+}

--- a/showcases/src/119-as-xlsx-infer-schema.showcase.test.ts
+++ b/showcases/src/119-as-xlsx-infer-schema.showcase.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Showcase 119 — as-xlsx schema inference (#414 P4 Mode B)
+ *
+ * What you'll learn
+ * ─────────────────
+ * Point `inferSchema(bytes)` at an ARBITRARY workbook (not one we exported) and
+ * it bootstraps a noy-db schema: column types from sampled cells (number /
+ * boolean / date / string), the id field, and foreign keys detected by
+ * value-subset matching against another sheet's id column. `zodSourceFor()`
+ * emits a Zod snippet you adopt in code.
+ *
+ * Why it matters
+ * ──────────────
+ * Mode A round-trips OUR exports deterministically; Mode B is the harder,
+ * heuristic case — turning a spreadsheet someone hands you into a starting-point
+ * schema. Treat the result as a draft to review, not ground truth.
+ *
+ * Spec mapping
+ * ────────────
+ *   #414 — as-xls smart workbook (P4 Mode B: schema inference)
+ */
+import { describe, it, expect } from 'vitest'
+import { writeXlsx, inferSchema, zodSourceFor } from '@noy-db/as-xlsx'
+
+describe('showcase 119 — as-xlsx schema inference', () => {
+  it('infers types + foreign keys from a hand-made workbook', async () => {
+    const bytes = await writeXlsx([
+      { name: 'clients', header: ['id', 'name'], rows: [['c1', 'Acme'], ['c2', 'Beta']] },
+      { name: 'invoices', header: ['id', 'clientId', 'amount', 'paid'], rows: [['i1', 'c1', 100, true], ['i2', 'c2', 50, false]] },
+    ])
+
+    const schema = await inferSchema(bytes)
+    expect(schema.collections['invoices']!.fields['amount']!.type).toBe('number')
+    expect(schema.collections['invoices']!.fields['paid']!.type).toBe('boolean')
+    expect(schema.collections['invoices']!.fields['clientId']!.references).toBe('clients') // FK detected from the data
+
+    // Adopt the generated Zod in your code, then open the collections with it.
+    expect(zodSourceFor(schema)).toContain('export const invoicesSchema = z.object({')
+  })
+})


### PR DESCRIPTION
The optional, heuristic read mode — bootstrap a noy-db schema from an **arbitrary** workbook (completes #414).

### What
- **`inferSchema(bytes)`** — per non-meta sheet: infer column types from sampled cells (number/boolean/date/string), pick the id field (`id` or first all-unique column), detect **foreign keys** by value-subset match against another sheet's id column. Skips `_`-prefixed meta sheets.
- **`zodSourceFor(schema)`** — emits a Zod snippet (guidance); Standard Schema validators aren't JSON-serializable, so you adopt the generated code, not a live object.

New `src/infer.ts`; exported from the package.

### Verification
- +1 as-xlsx test (type + FK inference + Zod source) + showcase 119; as-xlsx suite (45) + showcase green; typecheck/lint/arch/validate-features/showcases-typecheck clean.

**Completes #414 in full** — P1 structural · P2 localization · P3 computed · P4 import (Mode A + Mode B) · P5 Sheets dialect.

Closes #414