### PR TITLE
feat(hub): client data portability — exportMyAccessibleData (#199 P1) + design spec

### DIFF
--- a/docs/superpowers/specs/2026-06-16-client-initiated-portability-withdrawal-design.md
+++ b/docs/superpowers/specs/2026-06-16-client-initiated-portability-withdrawal-design.md
@@ -1,0 +1,111 @@
+# Client-initiated data portability + withdrawal (#199)
+
+- **Date:** 2026-06-16
+- **Status:** Design / in progress
+- **Sibling of:** #198 (owner-initiated `extractPartition`/`adoptPartition`)
+- **Surfaces:** the "data sovereignty by construction" property of [[sealing-at-dimension-foundation]] §11.11 as first-class API.
+
+## 1. Goal
+
+Three operations a **non-owner** user can perform over the scope they can decrypt,
+on `vault.user.*` (own-only by construction — the existing `UserApi`):
+
+1. **`exportMyAccessibleData(opts)`** — non-destructive, re-keyed `.noydb` bundle of the caller's accessible scope. **Always allowed** (§11.11 — the firm cannot deny it) but **audited**.
+2. **`requestWithdrawal(opts)`** — durable request → owner reviews → owner approves → atomic extract-and-delete. Conservative.
+3. **`unilateralWithdrawal(opts)`** — single-party extract-and-delete of the caller's scope, **gated** by `client-unilateral-withdraw` (default **disabled**; firm opts in). Aggressive variant.
+
+The cryptographic invariant: the caller holds the DEKs for their scope, so export is a *capability*, not a *permission*. The firm can audit and (for unilateral) gate, but cannot prevent (1).
+
+## 2. What already exists (reused, not rebuilt)
+
+| Need | Existing machinery | File |
+|---|---|---|
+| `.noydb` bundle producer | `writeNoydbBundle(vault, { where, recipients/exportPassphrase, collections })` | `bundle/bundle.ts` |
+| Scoped export (skip inaccessible) | `where` plaintext predicate + `hasAccess(keyring, collection)` | `team/keyring.ts` |
+| Re-key to a new owner | `exportPassphrase` / `recipients` → `applyRecipientRewrap` (DEKs re-wrapped, ciphertext unchanged) | `bundle/bundle.ts` |
+| FK-closure walk + re-key + seal | `walkClosure` / `reKeyClosure` / `sealDeks` | `bundle/{walk-closure,extract-partition}.ts` |
+| Owner extract ceremony | `extractPartition` (owner-only, **non-destructive**) | `bundle/extract-partition.ts` |
+| Policy gates | `GatePolicy {minTier,factors,enabled}`, `checkGate`, presets | `policy/{types,presets,engine}.ts` |
+| Tamper-evident audit | ledger `append({ op, collection, id, version, actor, payloadHash, reason })` | `history/ledger/store.ts` |
+| Own-only user API | `UserApi` (writerKeyringId frozen; no `keyringId` param) | `meta/user-envelope/api.ts` |
+
+**The one genuinely new primitive:** *delete-closure* — deleting the caller's extracted records after the bundle is sealed (the withdrawal "delete" side). `extractPartition` is deliberately non-destructive; deletion is single-vault (same vault we read from), so it does NOT need the cross-vault atomicity #198 ruled out — but it must be ordered (seal first, then delete) and crash-safe (idempotent).
+
+## 3. Scope boundary
+
+Scope = **the caller's DEK access set**: collections where `hasAccess(keyring, collection)` (owner/admin/viewer → all; operator/client → `keyring.permissions`). A record outside the caller's DEKs is undecryptable, so it can never be in the bundle — the boundary is cryptographic, not a runtime allowlist.
+
+Optional narrowing (v1): `scope.collections?: string[]` (sub-allowlist of the accessible set). **Deferred:** `scope.entity` / `scope.subject` (needs the #304 `_subject_index` DEK + an entity-tag model) — documented as future, not built in v1.
+
+## 4. Operation 1 — `exportMyAccessibleData` (slice 1, conservative)
+
+```ts
+await vault.user.exportMyAccessibleData({
+  reKey: { newOwner: { userId, passphrase } },  // bundle is independently openable by the new owner
+  scope?: { collections?: string[] },
+}): Promise<Uint8Array>   // a .noydb bundle
+```
+
+- Builds a `where` predicate = `hasAccess(keyring, collection)` (∩ `scope.collections` if given).
+- Calls `writeNoydbBundle(vault, { where, exportPassphrase|recipients: newOwner, compression:'auto' })` → re-keyed, access-scoped bundle. **Non-destructive** (source untouched).
+- **No gate** — always allowed (§11.11). **Audited:** one ledger entry `op:'lifecycle'`, `reason: 'user-export:<userId>'` (+ scope/recordCount in reason JSON).
+- Zero-knowledge preserved: the `where` filter decrypts inside the unlocked vault; survivors keep their original ciphertext; only the keyring wrapping is re-done.
+
+## 5. Operation 2 — `requestWithdrawal` (two-party)
+
+```ts
+await vault.user.requestWithdrawal({ scope?, expiresIn? }): Promise<{ requestId, expiresAt }>
+// owner side (Noydb / db, owner authority):
+await db.approveWithdrawal(vaultName, requestId, factors?): Promise<{ bundleBytes }>
+await db.rejectWithdrawal(vaultName, requestId, reason?): Promise<void>
+```
+
+- Spans calendar time → **durable request record** in `_user_withdrawal_requests` (encrypted), NOT a transaction.
+- `requestWithdrawal`: gate `user-request-withdrawal` (default enabled, tier 1); writes the request + audit (`reason:'user-withdrawal-request:<id>'`).
+- `approveWithdrawal` (owner): gate `approve-user-withdrawal` (tier 2); extract the requester's closure (owner authority) → seal bundle → **delete-closure** → audit (`user-withdrawal-approved`). Returns the bundle to hand back.
+- `rejectWithdrawal`: marks the request rejected + audit.
+
+## 6. Operation 3 — `unilateralWithdrawal` (gated)
+
+```ts
+await vault.user.unilateralWithdrawal({ legalBasis, reKey }): Promise<Uint8Array>
+```
+
+- Gate `client-unilateral-withdraw` — **default `{ enabled: false }`** (fail-closed). Disabled → `PolicyDeniedError` pointing the caller at `requestWithdrawal`. The firm enables it at vault creation (`policy.gates`) for jurisdictions/contracts that require it (e.g. GDPR Art. 17).
+- When enabled: export the caller's accessible closure (re-keyed) → **delete-closure** → audit (`user-unilateral-withdrawal`, `reason` carries `legalBasis`).
+
+## 7. Gates (added to presets)
+
+```ts
+// policy/presets.ts (all presets)
+'user-request-withdrawal':   { minTier: 1, enabled: true },
+'approve-user-withdrawal':   { minTier: 2, enabled: true },
+'client-unilateral-withdraw':{ minTier: 1, enabled: false },  // fail-closed; firm opts in
+```
+`exportMyAccessibleData` has **no** gate (§11.11 always-allowed) — audited only.
+
+## 8. Audit
+
+All ops append a tamper-evident ledger entry reusing `op:'lifecycle'` (no op-union change) with a structured `reason`:
+`user-export` / `user-withdrawal-request` / `user-withdrawal-approved` / `user-withdrawal-rejected` / `user-unilateral-withdrawal`, each carrying `{ userId, scope, recordCount?, legalBasis?, ts }`. Entries participate in the hash chain (tamper-evident) but carry no data payload (`payloadHash:''`), matching the existing `partition-handed-over` lifecycle audit.
+
+## 9. delete-closure (the new primitive)
+
+Single-vault deletion of the closure records after the bundle is sealed:
+1. Produce + seal the bundle (so the data is safely exported BEFORE anything is destroyed).
+2. Delete each closure record (`collection.delete` / tombstone). Run inside `withTransactions` when available for an all-or-nothing batch; otherwise best-effort + idempotent (re-deleting an absent record is a no-op).
+3. Audit AFTER deletion completes.
+Ordering guarantees no data loss on crash: a crash before step 2 leaves the source intact; a partial step 2 is resumable (the bundle already exists; re-running deletes the remainder).
+
+## 10. Phasing
+
+- **P1 (slice 1):** `exportMyAccessibleData` — conservative, non-destructive, always-allowed, audited. Reuses `writeNoydbBundle` + `where` + re-key. **No new destructive code.** ← build first.
+- **P2:** the gate additions + `unilateralWithdrawal` + the `delete-closure` primitive (the destructive core, behind the default-off gate).
+- **P3:** `requestWithdrawal` / `approveWithdrawal` / `rejectWithdrawal` two-party ceremony (durable request collection).
+- **Deferred:** `scope.entity` / `scope.subject` sub-scoping (needs entity-tag model / #304 subject-index access).
+
+## 11. Open questions
+
+1. `reKey` shape — single `exportPassphrase` vs full `recipients` (multi-slot, managed-mode sealing per #197)? v1: single new-owner; managed/multi later.
+2. Should `approveWithdrawal` deliver the bundle to the requester in-band (a `_user_withdrawal_bundles` drop) or return it to the owner to hand off out-of-band? v1: return to owner.
+3. delete-closure when the caller is a non-owner: do they have delete rights on their accessible collections? (operator/client `rw` vs `ro` — unilateral withdrawal of `ro` scope must still delete; confirm the delete authority model.)

--- a/packages/hub/__tests__/export-accessible.test.ts
+++ b/packages/hub/__tests__/export-accessible.test.ts
@@ -1,0 +1,76 @@
+/**
+ * #199 P1 — vault.user.exportMyAccessibleData(): a non-owner exports the scope
+ * they can decrypt as a re-keyed, non-destructive `.noydb` bundle. A client
+ * granted only `invoices` must NOT be able to export `secrets`.
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+import { createNoydb } from '../src/noydb.js'
+import { readNoydbBundle } from '../src/bundle/bundle.js'
+
+function makeStore(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function bucket(v: string, c: string) {
+    let m = store.get(v); if (!m) { m = new Map(); store.set(v, m) }
+    let b = m.get(c); if (!b) { b = new Map(); m.set(c, b) }
+    return b
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return bucket(v, c).get(id) ?? null },
+    async put(v, c, id, env, ev) { const b = bucket(v, c); const ex = b.get(id); if (ev !== undefined && (ex?._v ?? 0) !== ev) throw new ConflictError(ex?._v ?? 0); b.set(id, env) },
+    async delete(v, c, id) { bucket(v, c).delete(id) },
+    async list(v, c) { return [...bucket(v, c).keys()] },
+    async loadAll(v) { const m = store.get(v); const s: VaultSnapshot = {}; if (m) for (const [n, c] of m) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of c) r[id] = e; s[n] = r } return s },
+    async saveAll(v, data) { for (const [n, recs] of Object.entries(data)) { const b = bucket(v, n); for (const [id, e] of Object.entries(recs)) b.set(id, e) } },
+  }
+}
+
+function bundleCollections(dumpJson: string): string[] {
+  const dump = JSON.parse(dumpJson) as { collections?: Record<string, unknown> }
+  return Object.keys(dump.collections ?? {})
+}
+
+describe('#199 P1 — exportMyAccessibleData', () => {
+  it('a client exports only their accessible collections, re-keyed', async () => {
+    const store = makeStore()
+    // Owner sets up two collections + grants a client RO on invoices only.
+    const owner = await createNoydb({ store, user: 'firm', secret: 'owner-pw-long-enough' })
+    const ov = await owner.openVault('acme')
+    await ov.collection<{ id: string; total: number }>('invoices').put('i1', { id: 'i1', total: 100 })
+    await ov.collection<{ id: string; note: string }>('secrets').put('s1', { id: 's1', note: 'internal' })
+    await owner.grant('acme', {
+      userId: 'client1', displayName: 'Client', role: 'client', passphrase: 'client-pw-long-enough',
+      permissions: { invoices: 'ro' },
+    })
+    owner.close()
+
+    // Client opens + exports their accessible scope, re-keyed to a new passphrase.
+    const client = await createNoydb({ store, user: 'client1', secret: 'client-pw-long-enough' })
+    const cv = await client.openVault('acme')
+    const bytes = await cv.user.exportMyAccessibleData({ reKey: { passphrase: 'new-owner-pw' } })
+
+    const { dumpJson } = await readNoydbBundle(bytes)
+    const cols = bundleCollections(dumpJson)
+    expect(cols).toContain('invoices')
+    expect(cols).not.toContain('secrets') // not granted → not exportable
+  })
+
+  it('owner export includes everything; scope.collections narrows it', async () => {
+    const store = makeStore()
+    const owner = await createNoydb({ store, user: 'firm', secret: 'owner-pw-long-enough' })
+    const ov = await owner.openVault('acme')
+    await ov.collection<{ id: string }>('invoices').put('i1', { id: 'i1' })
+    await ov.collection<{ id: string }>('secrets').put('s1', { id: 's1' })
+
+    const all = bundleCollections((await readNoydbBundle(await ov.user.exportMyAccessibleData())).dumpJson)
+    expect(all).toEqual(expect.arrayContaining(['invoices', 'secrets']))
+
+    const narrowed = bundleCollections(
+      (await readNoydbBundle(await ov.user.exportMyAccessibleData({ scope: { collections: ['invoices'] } }))).dumpJson,
+    )
+    expect(narrowed).toContain('invoices')
+    expect(narrowed).not.toContain('secrets')
+  })
+})

--- a/packages/hub/src/bundle/export-accessible.ts
+++ b/packages/hub/src/bundle/export-accessible.ts
@@ -1,0 +1,68 @@
+/**
+ * #199 P1 — `exportMyAccessibleData`: a non-owner user exports the scope they
+ * can decrypt as a portable, re-keyed `.noydb` bundle. Non-destructive and
+ * **always allowed** (the "data sovereignty by construction" property of
+ * sealing-at-dimension §11.11 — the firm cannot deny it) but **audited**.
+ *
+ * Reuses the existing bundle machinery: the access boundary is the caller's DEK
+ * set (operator/client → `keyring.permissions`; owner/admin/viewer → all), so a
+ * record outside the caller's keys can never enter the bundle. Re-keying to a
+ * new owner reuses `writeNoydbBundle`'s `exportPassphrase` shorthand.
+ */
+import type { Vault } from '../vault.js'
+import { writeNoydbBundle } from './bundle.js'
+
+export interface ExportAccessibleOptions {
+  /**
+   * Re-key the bundle so it is independently openable by a new owner with this
+   * passphrase (the receiving firm / the client themselves). Omit to inherit
+   * the source keyring (personal backup).
+   */
+  readonly reKey?: { readonly passphrase: string }
+  /** Narrow the export to a subset of the caller's accessible collections. */
+  readonly scope?: { readonly collections?: readonly string[] }
+  readonly compression?: 'auto' | 'brotli' | 'gzip' | 'none'
+}
+
+/**
+ * Produce a re-keyed, access-scoped `.noydb` bundle of the caller's accessible
+ * data. Appends a tamper-evident audit entry (`reason: 'user-export:<userId>'`).
+ */
+export async function exportAccessibleData(
+  vault: Vault,
+  opts: ExportAccessibleOptions = {},
+): Promise<Uint8Array> {
+  const { keyring } = vault._introspectState()
+
+  // Access boundary: operator/client are scoped to their granted collections;
+  // owner/admin/viewer see everything (allowlist left undefined). A sub-scope
+  // intersects the granted set.
+  let collections: string[] | undefined
+  if (keyring.role === 'operator' || keyring.role === 'client') {
+    collections = Object.keys(keyring.permissions)
+  }
+  if (opts.scope?.collections) {
+    const allow = new Set(opts.scope.collections)
+    collections = (collections ?? [...opts.scope.collections]).filter((c) => allow.has(c))
+  }
+
+  const bytes = await writeNoydbBundle(vault, {
+    compression: opts.compression ?? 'auto',
+    ...(collections !== undefined ? { collections } : {}),
+    ...(opts.reKey ? { exportPassphrase: opts.reKey.passphrase } : {}),
+  })
+
+  // §11.11 audit — non-destructive, always-allowed export. No-op when the vault
+  // has no history/ledger strategy (avoids minting a phantom _ledger DEK).
+  await vault._getLedgerOrNull()?.append({
+    op: 'lifecycle',
+    collection: '',
+    id: '',
+    version: 0,
+    actor: keyring.userId,
+    payloadHash: '',
+    reason: `user-export:${keyring.userId}`,
+  })
+
+  return bytes
+}

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -358,6 +358,8 @@ export {
   readNoydbBundleHeader,
   resetBrotliSupportCache,
 } from './bundle/bundle.js'
+export { exportAccessibleData } from './bundle/export-accessible.js'
+export type { ExportAccessibleOptions } from './bundle/export-accessible.js'
 export type {
   NoydbBundleHeader,
   CompressionAlgo,

--- a/packages/hub/src/introspection/walk.ts
+++ b/packages/hub/src/introspection/walk.ts
@@ -21,6 +21,7 @@ import type {
 } from './types.js'
 import type { Collection } from '../collection.js'
 import type { NoydbStore } from '../types.js'
+import type { UnlockedKeyring } from '../team/keyring.js'
 import type { RefRegistry } from '../refs.js'
 
 /**
@@ -36,6 +37,8 @@ export interface VaultIntrospectState {
   readonly collectionCache: Map<string, Collection<unknown>>
   readonly refRegistry: RefRegistry
   readonly getDEK: (collectionName: string) => Promise<CryptoKey>
+  /** The active unlocked keyring — role/permissions/userId for access-scoped ops. */
+  readonly keyring: UnlockedKeyring
   readonly subsystems: Record<string, boolean>
   // Typed loosely on purpose — these are private subsystem registries
   // accessed only for "is anything registered" enumeration.

--- a/packages/hub/src/meta/user-envelope/api.ts
+++ b/packages/hub/src/meta/user-envelope/api.ts
@@ -29,6 +29,7 @@ import {
   readUserVisibility,
 } from '../../directory/visibility.js'
 import type { UserVisibility } from '../../directory/types.js'
+import type { ExportAccessibleOptions } from '../../bundle/export-accessible.js'
 
 /**
  * Recursive partial. Used for `updateMe(patch)` so callers can hand in
@@ -121,7 +122,24 @@ export class UserApi {
      * Production paths always wire the Noydb-backed implementation.
      */
     private readonly checkGate?: UserEnvelopeCheckGate,
+    /**
+     * Noydb-backed `exportMyAccessibleData` (#199), injected by the Vault
+     * (which holds the keyring + bundle machinery). Omitted in low-level tests.
+     */
+    private readonly exportAccessible?: (opts: ExportAccessibleOptions) => Promise<Uint8Array>,
   ) {}
+
+  /**
+   * #199 — export the calling user's accessible scope as a portable, re-keyed
+   * `.noydb` bundle. Non-destructive and **always allowed** (data sovereignty
+   * by construction, §11.11) but audited. Scope = the caller's DEK access set.
+   */
+  async exportMyAccessibleData(opts: ExportAccessibleOptions = {}): Promise<Uint8Array> {
+    if (!this.exportAccessible) {
+      throw new Error('exportMyAccessibleData requires a Noydb-backed vault (not a bare UserApi)')
+    }
+    return this.exportAccessible(opts)
+  }
 
   // ─── Write-self ──────────────────────────────────────────────────────
 

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -20,6 +20,7 @@ import type { IndexDef } from './indexing/eager-indexes.js'
 import type { JoinableSource } from './query/index.js'
 import type { OnDirtyCallback } from './collection.js'
 import type { UnlockedKeyring, BundleRecipient } from './team/keyring.js'
+import { exportAccessibleData } from './bundle/export-accessible.js'
 import type { MaterializedViewRegistry } from './materialized-views/registry.js'
 import type { MaterializedViewStrategyHandle, MVQueryContext } from './materialized-views/types.js'
 import type { OverlayedViewRegistry } from './overlay-views/registry.js'
@@ -583,6 +584,7 @@ export class Vault {
       this.keyring.userId,
       () => this.getDEK(USER_ENVELOPE_COLLECTION),
       (gate, presented) => this.noydb.checkGate(this.name, gate, presented),
+      (opts) => exportAccessibleData(this, opts),
     )
   }
 
@@ -3662,6 +3664,7 @@ export class Vault {
       collectionCache: this.collectionCache as Map<string, any>,
       refRegistry: this.refRegistry,
       getDEK: this.getDEK,
+      keyring: this.keyring,
       subsystems: {
         guards: this.guardRegistry !== null,
         derivations: this.derivationRegistry !== null,


### PR DESCRIPTION
Starts **#199** (client-initiated data portability + withdrawal). Includes the **design spec** (all three ops) + the conservative first slice.

### Design spec
`docs/superpowers/specs/2026-06-16-client-initiated-portability-withdrawal-design.md` — maps the three `vault.user.*` ops onto existing machinery (#198 walk/re-key/seal, policy gates, ledger audit). The only genuinely new primitive is **delete-closure** (the withdrawal delete side). Phasing P1→P3, deletion behind a **default-off** `client-unilateral-withdraw` gate.

### P1 — `exportMyAccessibleData` (conservative)
- `vault.user.exportMyAccessibleData({ reKey?, scope? })` → a re-keyed `.noydb` bundle of the caller's accessible scope. **Non-destructive + always allowed** (§11.11 data-sovereignty) + **audited**.
- Scope = the caller's **DEK access set** (operator/client → `keyring.permissions`; owner/admin/viewer → all) — a record outside the caller's keys can never enter the bundle. `scope.collections` narrows.
- Reuses `writeNoydbBundle` (`collections` allowlist + `exportPassphrase` re-key) — **no new crypto**. Audit via ledger `op:'lifecycle'`, `reason:'user-export:<userId>'`. Wired onto `UserApi` via a Vault-injected closure (UserApi stays own-only by construction).

### Verification
- +2 tests (client exports only granted collections, re-keyed; owner=all, `scope` narrows). Full hub suite (**2700**) green; typecheck/lint/arch clean.

### Deferred (P2/P3)
`unilateralWithdrawal` + the `delete-closure` primitive (gated, default off); two-party `requestWithdrawal`/`approve`/`reject`; `scope.entity`/`subject` sub-scoping.

Refs #199