### PR TITLE
feat(hub): client unilateral withdrawal — delete + freeze (#199 P2)

### DIFF
--- a/docs/subsystems/client-portability.md
+++ b/docs/subsystems/client-portability.md
@@ -1,0 +1,59 @@
+# Client-initiated portability & withdrawal
+
+`vault.user.*` lets a **non-owner** principal act on **their own** accessible
+data: take a portable copy, or withdraw (export-and-dispose). Own-only by
+construction — the API never reaches another principal's scope.
+
+Design spec: `docs/superpowers/specs/2026-06-16-client-initiated-portability-withdrawal-design.md`.
+
+## The three operations
+
+| Method | Destructive? | Gate | Notes |
+| --- | --- | --- | --- |
+| `exportMyAccessibleData(opts)` | no | none (audited) | re-keyed copy of the caller's scope; source untouched |
+| `unilateralWithdrawal(opts)` | yes | `client-unilateral-withdraw` (fail-closed) | export **then** dispose of the source |
+| `requestWithdrawal` / `approveWithdrawal` (P3) | yes | two-party | for read-only roles that can't self-serve |
+
+### Scope
+
+The caller's **DEK access set**: collections where `hasAccess(keyring, collection)`
+(owner/admin/viewer → all; operator/client → `keyring.permissions`), optionally
+narrowed by `scope.collections`. A record outside the caller's DEKs is
+undecryptable, so it can never enter the bundle — the boundary is cryptographic,
+not a runtime allowlist. Re-keying runs before any where-filter, so the export
+uses the **allowlist** of accessible collections (not just a predicate).
+
+### Authority (kernel reality)
+
+`hasWritePermission` makes `client`/`viewer` **read-only by construction** — they
+can never delete, regardless of an `rw` entry. So self-service *destructive*
+withdrawal is the **`operator`** path (per-collection `rw`); owner/admin hold
+blanket authority and use `extractPartition`. A read-only role calling
+`unilateralWithdrawal` is rejected with `ReadOnlyError` pointing at the two-party
+`requestWithdrawal`.
+
+## Source dispositions
+
+- **`delete`** (default) — *delete-closure*: records leave the vault entirely
+  (GDPR Art. 17 erasure). The re-keyed bundle is produced **first**, so a crash
+  before deletion leaves the source intact; a partial deletion is resumable.
+- **`freeze`** — the firm retains a cryptographically-frozen, **write-once**,
+  hash-pinned snapshot of the original ciphertext envelopes (already under the
+  firm's DEKs — no re-key needed) at `_frozen_snapshots/<withdrawalId>`, then
+  delete-closures the live records. `FrozenSnapshotRef = { withdrawalId, sha256,
+  recordCount, frozenAt }`; the sha256 is pinned in the tamper-evident ledger.
+
+## The gate
+
+`client-unilateral-withdraw` is a **built-in** gate (built-ins fail closed when
+undefined; `app:*` gates default to *allow*, which is wrong for a destructive op).
+Default `{ enabled: false }` in both presets; STRICT additionally pins a
+two-factor proof + shared-device block for the opt-in case. The firm enables it
+per jurisdiction/contract.
+
+## Audit
+
+Every op appends a tamper-evident `op:'lifecycle'` ledger entry with a structured
+`reason` (`user-export` / `user-unilateral-withdrawal:<userId>:<disposition>:<legalBasis>`
+/ `withdrawal-frozen-snapshot:<id>:<sha256>`). Entries participate in the hash
+chain but carry no data payload.

--- a/docs/superpowers/specs/2026-06-16-client-initiated-portability-withdrawal-design.md
+++ b/docs/superpowers/specs/2026-06-16-client-initiated-portability-withdrawal-design.md
@@ -68,11 +68,21 @@ await db.rejectWithdrawal(vaultName, requestId, reason?): Promise<void>
 ## 6. Operation 3 — `unilateralWithdrawal` (gated)
 
 ```ts
-await vault.user.unilateralWithdrawal({ legalBasis, reKey }): Promise<Uint8Array>
+await vault.user.unilateralWithdrawal({
+  legalBasis, reKey,
+  disposition?: 'delete' | 'freeze',   // default 'delete'
+}): Promise<{ bundle: Uint8Array; snapshot?: FrozenSnapshotRef }>
 ```
 
 - Gate `client-unilateral-withdraw` — **default `{ enabled: false }`** (fail-closed). Disabled → `PolicyDeniedError` pointing the caller at `requestWithdrawal`. The firm enables it at vault creation (`policy.gates`) for jurisdictions/contracts that require it (e.g. GDPR Art. 17).
-- When enabled: export the caller's accessible closure (re-keyed) → **delete-closure** → audit (`user-unilateral-withdrawal`, `reason` carries `legalBasis`).
+- When enabled: produce the caller's re-keyed export bundle → apply the **source disposition** (§9) → audit (`user-unilateral-withdrawal`, `reason` carries `legalBasis` + disposition).
+
+### Source disposition (what happens to the source records)
+
+- **`delete`** (default) — *delete-closure*: the records leave the source vault entirely. Maximum data-minimization (GDPR Art. 17 erasure).
+- **`freeze`** — the firm retains a **cryptographically-frozen, read-only last snapshot** while the **live** records are removed. For regulated retention: the client departs with their portable copy; the firm keeps an immutable, provably-unaltered record. See §9b.
+
+`exportMyAccessibleData` (P1) is the third, non-withdrawal disposition (`leave-in-place`).
 
 ## 7. Gates (added to presets)
 
@@ -82,6 +92,8 @@ await vault.user.unilateralWithdrawal({ legalBasis, reKey }): Promise<Uint8Array
 'approve-user-withdrawal':   { minTier: 2, enabled: true },
 'client-unilateral-withdraw':{ minTier: 1, enabled: false },  // fail-closed; firm opts in
 ```
+`client-unilateral-withdraw` is a **built-in** gate (added to `BuiltInGateName`), not an `app:*` gate — built-ins fail closed when undefined, whereas `app:*` gates default to *allow* (informational). A destructive op must default-deny, so it must be built-in. Shipped in P2 (PERSONAL + STRICT presets, both `enabled:false`); STRICT additionally pins a two-factor proof + shared-device block for the opt-in case. The `user-request-withdrawal` / `approve-user-withdrawal` gates land with the P3 two-party ceremony.
+
 `exportMyAccessibleData` has **no** gate (§11.11 always-allowed) — audited only.
 
 ## 8. Audit
@@ -89,20 +101,36 @@ await vault.user.unilateralWithdrawal({ legalBasis, reKey }): Promise<Uint8Array
 All ops append a tamper-evident ledger entry reusing `op:'lifecycle'` (no op-union change) with a structured `reason`:
 `user-export` / `user-withdrawal-request` / `user-withdrawal-approved` / `user-withdrawal-rejected` / `user-unilateral-withdrawal`, each carrying `{ userId, scope, recordCount?, legalBasis?, ts }`. Entries participate in the hash chain (tamper-evident) but carry no data payload (`payloadHash:''`), matching the existing `partition-handed-over` lifecycle audit.
 
-## 9. delete-closure (the new primitive)
+## 9. delete-closure (the new destructive primitive)
 
-Single-vault deletion of the closure records after the bundle is sealed:
-1. Produce + seal the bundle (so the data is safely exported BEFORE anything is destroyed).
-2. Delete each closure record (`collection.delete` / tombstone). Run inside `withTransactions` when available for an all-or-nothing batch; otherwise best-effort + idempotent (re-deleting an absent record is a no-op).
-3. Audit AFTER deletion completes.
-Ordering guarantees no data loss on crash: a crash before step 2 leaves the source intact; a partial step 2 is resumable (the bundle already exists; re-running deletes the remainder).
+Single-vault deletion of the closure records, ALWAYS after the export (and the
+freeze snapshot, if any) is durably produced:
+1. Produce + seal the export bundle (data is safely out BEFORE anything is destroyed).
+2. (freeze only) write the frozen snapshot (§9b).
+3. Delete each closure record (`collection.delete` → tombstone). Best-effort + idempotent (re-deleting an absent record is a no-op); transaction-wrapped all-or-nothing is a future hardening (the ordering below already gives crash safety, so it is not required for correctness).
+4. Audit AFTER deletion completes.
+Crash safety by ordering: a crash before step 3 leaves the source intact; a partial step 3 is resumable (the bundle + snapshot already exist; re-running with the same `withdrawalId` deletes the remainder — the write-once snapshot put is a no-op on the second pass).
+
+**Scope:** the caller's accessible **collections** (∩ `scope.collections`). Row-level (per-entity/subject) withdrawal in a *shared* collection is deferred (needs the entity/subject model) — so withdrawal is collection-scoped, matching the per-client-vault model (#271) where a client's vault *is* their data.
+
+**Authority (kernel reality):** `hasWritePermission` (keyring.ts) makes `client` and `viewer` roles **read-only by construction** — they can never delete, regardless of any `rw` entry. So the self-service destructive path is the **`operator`** role (per-collection `rw`); owner/admin hold blanket authority and use `extractPartition` instead. A `client`/`viewer` calling `unilateralWithdrawal` is rejected with `ReadOnlyError` pointing at the two-party `requestWithdrawal`, where owner authority executes the delete. Confirmed in implementation (`withdraw-accessible.ts`).
+
+## 9b. freeze — cryptographically-frozen read-only snapshot
+
+The firm's retained copy for `disposition:'freeze'`. The caller is an **operator without the firm KEK**, so the snapshot cannot be a *re-keyed* `.noydb` bundle (the operator can't seal to the firm). Instead it **copies the existing ciphertext envelopes verbatim** — they are already under the vault's firm-owned DEKs, so the firm reopens them with the keys it already holds:
+1. For each closure record, read its stored `EncryptedEnvelope` and collect `{ collection: { id: envelope } }`.
+2. Serialize `{ withdrawalId, frozenAt, by, collections }` to JSON and store it immutably at `_frozen_snapshots/<withdrawalId>` (a reserved, write-once namespace — the put uses `expectedVersion: 0` so re-writing an existing id is rejected).
+3. **Hash-pin** it: `sha256` over the serialized body, appended to the ledger as `reason:'withdrawal-frozen-snapshot:<withdrawalId>:<sha256>'`. The hash-chained ledger makes the snapshot tamper-evident — any later alteration diverges the recorded sha256.
+4. Then delete-closure the live records (§9). Net: live data gone; the firm holds a sealed, read-only, provably-unaltered point-in-time snapshot of the original envelopes; the client holds their portable re-keyed copy.
+
+`FrozenSnapshotRef = { withdrawalId, sha256, recordCount, frozenAt }`. Reading it back = parse the stored record's `_data` JSON and decrypt each envelope with the firm's DEKs; verifying frozenness = recompute sha256 over `_data` and compare to the ledger entry.
 
 ## 10. Phasing
 
-- **P1 (slice 1):** `exportMyAccessibleData` — conservative, non-destructive, always-allowed, audited. Reuses `writeNoydbBundle` + `where` + re-key. **No new destructive code.** ← build first.
-- **P2:** the gate additions + `unilateralWithdrawal` + the `delete-closure` primitive (the destructive core, behind the default-off gate).
-- **P3:** `requestWithdrawal` / `approveWithdrawal` / `rejectWithdrawal` two-party ceremony (durable request collection).
-- **Deferred:** `scope.entity` / `scope.subject` sub-scoping (needs entity-tag model / #304 subject-index access).
+- **P1 (slice 1):** `exportMyAccessibleData` — conservative, non-destructive, always-allowed, audited. ✅ shipped.
+- **P2:** gate additions + `unilateralWithdrawal` with **both** dispositions — the `delete-closure` primitive (§9) AND the `freeze` snapshot (§9b) — behind the default-off gate.
+- **P3:** `requestWithdrawal` / `approveWithdrawal` / `rejectWithdrawal` two-party ceremony (durable request collection); approve supports the same `disposition`.
+- **Deferred:** `scope.entity` / `scope.subject` row-level sub-scoping (needs entity-tag model / #304 subject-index access); managed-mode/multi-recipient re-key.
 
 ## 11. Open questions
 

--- a/features.yaml
+++ b/features.yaml
@@ -1006,6 +1006,29 @@ features:
       - 'extractPartition appends a partition-handed-over:<sealId> lifecycle entry to the source ledger (audit signal; no-op without history)'
     related: [bundle, persisted-json-schema, history, team]
 
+  - id: client-portability
+    name: Client-initiated portability & withdrawal (vault.user.*)
+    cluster: snapshot-and-portability
+    spec: docs/superpowers/specs/2026-06-16-client-initiated-portability-withdrawal-design.md
+    subsystem_doc: docs/subsystems/client-portability.md
+    package: '@noy-db/hub/bundle'
+    factory: null
+    status: preview
+    showcases:
+      - id: 120-client-portability-withdrawal
+        path: showcases/src/120-client-portability-withdrawal.showcase.test.ts
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'own-only by construction: vault.user.* acts on the caller scope only — the DEK access set (hasAccess), optionally narrowed by scope.collections; out-of-scope records are undecryptable so never enter the bundle'
+      - 'exportMyAccessibleData is non-destructive, always-allowed (no gate), re-keyed to the caller passphrase, and audited (reason: user-export)'
+      - 'unilateralWithdrawal produces the re-keyed bundle FIRST, then disposes of the source — crash before deletion leaves the source intact; partial deletion is resumable (write-once snapshot put is idempotent on re-run)'
+      - 'destructive withdrawal is gated by the built-in client-unilateral-withdraw gate (fail-closed: undefined/disabled → PolicyDeniedError); built-in not app:* because app:* gates default to allow'
+      - 'authority: client/viewer are read-only by construction (hasWritePermission) → ReadOnlyError pointing at requestWithdrawal; operator (rw) is the self-service destructive path; owner/admin use extractPartition'
+      - 'disposition delete = delete-closure (records leave the vault); disposition freeze = write-once hash-pinned snapshot of the original envelopes at _frozen_snapshots/<id> + ledger sha256 pin, then delete-closure'
+    related: [transferable-partition, bundle, team, session-tiers]
+
   - id: with-snapshots
     name: Snapshot lifecycle (withSnapshots)
     cluster: snapshot-and-portability

--- a/packages/hub/__tests__/withdraw-accessible.test.ts
+++ b/packages/hub/__tests__/withdraw-accessible.test.ts
@@ -1,0 +1,91 @@
+/**
+ * #199 P2 — vault.user.unilateralWithdrawal(): a non-owner extracts their scope
+ * AND disposes of the source (delete | freeze). Gated by the default-off
+ * fail-closed built-in `client-unilateral-withdraw` policy.
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+import { PolicyDeniedError } from '../src/policy/errors.js'
+import { createNoydb } from '../src/noydb.js'
+import { readNoydbBundle } from '../src/bundle/bundle.js'
+
+function makeStore(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function bucket(v: string, c: string) {
+    let m = store.get(v); if (!m) { m = new Map(); store.set(v, m) }
+    let b = m.get(c); if (!b) { b = new Map(); m.set(c, b) }
+    return b
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return bucket(v, c).get(id) ?? null },
+    async put(v, c, id, env, ev) { const b = bucket(v, c); const ex = b.get(id); if (ev !== undefined && (ex?._v ?? 0) !== ev) throw new ConflictError(ex?._v ?? 0); b.set(id, env) },
+    async delete(v, c, id) { bucket(v, c).delete(id) },
+    async list(v, c) { return [...bucket(v, c).keys()] },
+    async loadAll(v) { const m = store.get(v); const s: VaultSnapshot = {}; if (m) for (const [n, c] of m) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of c) r[id] = e; s[n] = r } return s },
+    async saveAll(v, data) { for (const [n, recs] of Object.entries(data)) { const b = bucket(v, n); for (const [id, e] of Object.entries(recs)) b.set(id, e) } },
+  }
+}
+
+const GATE_ON = { gates: { 'client-unilateral-withdraw': { enabled: true, minTier: 1 } } }
+
+/** Owner-provisioned vault with one member granted `mode` on `invoices`. */
+async function setup(store: NoydbStore, role: 'operator' | 'client', mode: 'rw' | 'ro', policy?: unknown) {
+  const owner = await createNoydb({ store, user: 'firm', secret: 'owner-pw-long-enough', ...(policy ? { policy } : {}) })
+  const ov = await owner.openVault('acme')
+  await ov.collection<{ id: string; total: number }>('invoices').put('i1', { id: 'i1', total: 100 })
+  await ov.collection<{ id: string; total: number }>('invoices').put('i2', { id: 'i2', total: 50 })
+  await owner.grant('acme', {
+    userId: 'member1', displayName: 'Member', role, passphrase: 'member-pw-long-enough',
+    permissions: { invoices: mode },
+  })
+  owner.close()
+  const member = await createNoydb({ store, user: 'member1', secret: 'member-pw-long-enough' })
+  const cv = await member.openVault('acme')
+  return { cv }
+}
+
+describe('#199 P2 — unilateralWithdrawal', () => {
+  it('fails closed when the gate is disabled (default)', async () => {
+    const { cv } = await setup(makeStore(), 'operator', 'rw') // no policy → gate fail-closed
+    await expect(
+      cv.user.unilateralWithdrawal({ legalBasis: 'gdpr-art-17', reKey: { passphrase: 'new-pw' } }),
+    ).rejects.toBeInstanceOf(PolicyDeniedError)
+  })
+
+  it('read-only role cannot self-serve a withdrawal (use requestWithdrawal)', async () => {
+    const { cv } = await setup(makeStore(), 'client', 'ro', GATE_ON)
+    await expect(
+      cv.user.unilateralWithdrawal({ legalBasis: 'gdpr-art-17', reKey: { passphrase: 'new-pw' } }),
+    ).rejects.toThrow(/read-only|requestWithdrawal/)
+  })
+
+  it('delete disposition: exports the re-keyed copy + removes the live records', async () => {
+    const { cv } = await setup(makeStore(), 'operator', 'rw', GATE_ON)
+    const res = await cv.user.unilateralWithdrawal({ disposition: 'delete', legalBasis: 'gdpr-art-17', reKey: { passphrase: 'new-pw' } })
+    expect(res.snapshot).toBeUndefined()
+    // portable copy contains invoices
+    const dump = JSON.parse((await readNoydbBundle(res.bundle)).dumpJson) as { collections?: Record<string, unknown> }
+    expect(Object.keys(dump.collections ?? {})).toContain('invoices')
+    // live records gone
+    expect(await cv.collection<{ id: string }>('invoices').get('i1')).toBeNull()
+    expect(await cv.collection<{ id: string }>('invoices').get('i2')).toBeNull()
+  })
+
+  it('freeze disposition: retains a hash-pinned read-only snapshot + removes live records', async () => {
+    const store = makeStore()
+    const { cv } = await setup(store, 'operator', 'rw', GATE_ON)
+    const res = await cv.user.unilateralWithdrawal({ disposition: 'freeze', legalBasis: 'retention', reKey: { passphrase: 'new-pw' } })
+    expect(res.snapshot).toBeTruthy()
+    expect(res.snapshot!.recordCount).toBe(2)
+    expect(res.snapshot!.sha256).toMatch(/^[0-9a-f]{64}$/)
+    // the frozen snapshot record exists and holds the original envelopes
+    const snapEnv = await store.get('acme', '_frozen_snapshots', res.snapshot!.withdrawalId)
+    expect(snapEnv).not.toBeNull()
+    const snap = JSON.parse(snapEnv!._data) as { collections: { invoices?: Record<string, unknown> } }
+    expect(Object.keys(snap.collections.invoices ?? {})).toEqual(expect.arrayContaining(['i1', 'i2']))
+    // live records gone
+    expect(await cv.collection<{ id: string }>('invoices').get('i1')).toBeNull()
+  })
+})

--- a/packages/hub/src/bundle/export-accessible.ts
+++ b/packages/hub/src/bundle/export-accessible.ts
@@ -10,7 +10,46 @@
  * new owner reuses `writeNoydbBundle`'s `exportPassphrase` shorthand.
  */
 import type { Vault } from '../vault.js'
+import type { UnlockedKeyring } from '../team/keyring.js'
 import { writeNoydbBundle } from './bundle.js'
+
+/**
+ * Resolve the collections a caller may export/withdraw: operator/client are
+ * scoped to their granted collections; owner/admin/viewer see everything
+ * (`undefined` = no allowlist). A `scope.collections` sub-scope intersects the
+ * granted set. `writableOnly` keeps only `rw` grants (for destructive ops).
+ */
+export function resolveAccessibleCollections(
+  keyring: UnlockedKeyring,
+  scope: { collections?: readonly string[] } | undefined,
+  writableOnly = false,
+): string[] | undefined {
+  let collections: string[] | undefined
+  if (keyring.role === 'operator' || keyring.role === 'client') {
+    collections = Object.entries(keyring.permissions)
+      .filter(([, mode]) => !writableOnly || mode === 'rw')
+      .map(([c]) => c)
+  }
+  if (scope?.collections) {
+    const allow = new Set(scope.collections)
+    collections = (collections ?? [...scope.collections]).filter((c) => allow.has(c))
+  }
+  return collections
+}
+
+/** Produce a (optionally re-keyed, scoped) `.noydb` bundle — no audit. */
+export async function buildAccessibleBundle(
+  vault: Vault,
+  collections: string[] | undefined,
+  reKey: { passphrase: string } | undefined,
+  compression: 'auto' | 'brotli' | 'gzip' | 'none' = 'auto',
+): Promise<Uint8Array> {
+  return writeNoydbBundle(vault, {
+    compression,
+    ...(collections !== undefined ? { collections } : {}),
+    ...(reKey ? { exportPassphrase: reKey.passphrase } : {}),
+  })
+}
 
 export interface ExportAccessibleOptions {
   /**
@@ -33,24 +72,8 @@ export async function exportAccessibleData(
   opts: ExportAccessibleOptions = {},
 ): Promise<Uint8Array> {
   const { keyring } = vault._introspectState()
-
-  // Access boundary: operator/client are scoped to their granted collections;
-  // owner/admin/viewer see everything (allowlist left undefined). A sub-scope
-  // intersects the granted set.
-  let collections: string[] | undefined
-  if (keyring.role === 'operator' || keyring.role === 'client') {
-    collections = Object.keys(keyring.permissions)
-  }
-  if (opts.scope?.collections) {
-    const allow = new Set(opts.scope.collections)
-    collections = (collections ?? [...opts.scope.collections]).filter((c) => allow.has(c))
-  }
-
-  const bytes = await writeNoydbBundle(vault, {
-    compression: opts.compression ?? 'auto',
-    ...(collections !== undefined ? { collections } : {}),
-    ...(opts.reKey ? { exportPassphrase: opts.reKey.passphrase } : {}),
-  })
+  const collections = resolveAccessibleCollections(keyring, opts.scope)
+  const bytes = await buildAccessibleBundle(vault, collections, opts.reKey, opts.compression ?? 'auto')
 
   // §11.11 audit — non-destructive, always-allowed export. No-op when the vault
   // has no history/ledger strategy (avoids minting a phantom _ledger DEK).

--- a/packages/hub/src/bundle/withdraw-accessible.ts
+++ b/packages/hub/src/bundle/withdraw-accessible.ts
@@ -1,0 +1,133 @@
+/**
+ * #199 P2 — `unilateralWithdrawal`: a non-owner extracts their accessible scope
+ * AND disposes of the source copy. Destructive; gated by the default-off
+ * fail-closed built-in `client-unilateral-withdraw` policy (checked in the
+ * UserApi wrapper).
+ *
+ * Two source dispositions (see the #199 design spec §9/§9b):
+ *  - 'delete'  — delete-closure: the records leave the source vault entirely.
+ *  - 'freeze'  — the firm retains a cryptographically-frozen, read-only, write-once
+ *                snapshot (hash-pinned in the tamper-evident ledger) while the live
+ *                records are removed.
+ *
+ * Ordering guarantees no data loss: the client's re-keyed export bundle (and the
+ * freeze snapshot) are produced BEFORE anything is deleted.
+ */
+import type { Vault } from '../vault.js'
+import { sha256Hex } from '../crypto.js'
+import { ReadOnlyError } from '../errors.js'
+import { NOYDB_FORMAT_VERSION } from '../types.js'
+import { resolveAccessibleCollections, buildAccessibleBundle } from './export-accessible.js'
+
+const FROZEN_SNAPSHOTS_COLLECTION = '_frozen_snapshots'
+const ENC = new TextEncoder()
+
+function randomId(): string {
+  const b = globalThis.crypto.getRandomValues(new Uint8Array(12))
+  return Array.from(b, (x) => x.toString(16).padStart(2, '0')).join('')
+}
+
+export interface FrozenSnapshotRef {
+  readonly withdrawalId: string
+  readonly sha256: string
+  readonly recordCount: number
+  readonly frozenAt: string
+}
+
+export interface WithdrawAccessibleOptions {
+  /** Legal/contractual basis recorded in the audit (e.g. 'gdpr-art-17'). */
+  readonly legalBasis: string
+  /** Re-key the exported bundle to a new owner passphrase. */
+  readonly reKey?: { readonly passphrase: string }
+  /** Source disposition. Default 'delete'. */
+  readonly disposition?: 'delete' | 'freeze'
+  readonly scope?: { readonly collections?: readonly string[] }
+  /** Stable id for idempotent resume (default random). */
+  readonly withdrawalId?: string
+}
+
+export interface WithdrawResult {
+  readonly bundle: Uint8Array
+  readonly snapshot?: FrozenSnapshotRef
+}
+
+export async function withdrawAccessibleData(
+  vault: Vault,
+  opts: WithdrawAccessibleOptions,
+): Promise<WithdrawResult> {
+  const { name: vaultName, adapter, keyring } = vault._introspectState()
+  const disposition = opts.disposition ?? 'delete'
+
+  // Owner-class roles hold blanket authority — they use extractPartition.
+  if (keyring.role === 'owner' || keyring.role === 'admin') {
+    throw new ReadOnlyError(
+      'unilateralWithdrawal is the scoped self-service path; an owner/admin should use extractPartition',
+    )
+  }
+  // client/viewer are read-only by construction (see hasWritePermission): a
+  // destructive withdrawal they cannot self-serve — they use the two-party
+  // requestWithdrawal flow where firm authority executes the delete-closure.
+  if (keyring.role === 'client' || keyring.role === 'viewer') {
+    throw new ReadOnlyError(
+      'read-only role cannot self-serve a destructive withdrawal — use requestWithdrawal (two-party)',
+    )
+  }
+  // Operator path: destructive ops need rw on the whole scope.
+  const collections = resolveAccessibleCollections(keyring, opts.scope, true)
+  if (!collections || collections.length === 0) {
+    throw new ReadOnlyError(
+      'unilateralWithdrawal requires rw access on the withdrawn collections — use requestWithdrawal for read-only scope',
+    )
+  }
+
+  // 1. Produce the client's re-keyed portable copy FIRST (nothing destroyed yet).
+  const bundle = await buildAccessibleBundle(vault, collections, opts.reKey)
+
+  // Enumerate the closure (record ids per writable collection).
+  const closure: Array<{ collection: string; id: string }> = []
+  for (const c of collections) {
+    for (const id of await adapter.list(vaultName, c)) closure.push({ collection: c, id })
+  }
+
+  // 2. freeze: copy current envelopes into a write-once, hash-pinned snapshot
+  //    (under the vault's own firm-owned DEKs — no re-key needed).
+  let snapshot: FrozenSnapshotRef | undefined
+  if (disposition === 'freeze') {
+    const withdrawalId = opts.withdrawalId ?? `wd-${randomId()}`
+    const snap: Record<string, Record<string, unknown>> = {}
+    for (const { collection, id } of closure) {
+      const env = await adapter.get(vaultName, collection, id)
+      if (env) (snap[collection] ??= {})[id] = env
+    }
+    const frozenAt = new Date().toISOString()
+    const body = JSON.stringify({ withdrawalId, frozenAt, by: keyring.userId, collections: snap })
+    const sha = await sha256Hex(ENC.encode(body))
+    // Write-once: expectedVersion 0 rejects an overwrite (idempotent resume).
+    await adapter.put(
+      vaultName,
+      FROZEN_SNAPSHOTS_COLLECTION,
+      withdrawalId,
+      { _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: frozenAt, _iv: '', _data: body, _by: keyring.userId },
+      0,
+    )
+    // Hash-pin into the tamper-evident ledger — makes the snapshot provably unaltered.
+    await vault._getLedgerOrNull()?.append({
+      op: 'lifecycle', collection: '', id: '', version: 0, actor: keyring.userId, payloadHash: '',
+      reason: `withdrawal-frozen-snapshot:${withdrawalId}:${sha}`,
+    })
+    snapshot = { withdrawalId, sha256: sha, recordCount: closure.length, frozenAt }
+  }
+
+  // 3. delete-closure — only after the bundle + snapshot are durable.
+  for (const { collection, id } of closure) {
+    await vault.collection(collection).delete(id)
+  }
+
+  // 4. audit
+  await vault._getLedgerOrNull()?.append({
+    op: 'lifecycle', collection: '', id: '', version: 0, actor: keyring.userId, payloadHash: '',
+    reason: `user-unilateral-withdrawal:${keyring.userId}:${disposition}:${opts.legalBasis}`,
+  })
+
+  return snapshot ? { bundle, snapshot } : { bundle }
+}

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -360,6 +360,8 @@ export {
 } from './bundle/bundle.js'
 export { exportAccessibleData } from './bundle/export-accessible.js'
 export type { ExportAccessibleOptions } from './bundle/export-accessible.js'
+export { withdrawAccessibleData } from './bundle/withdraw-accessible.js'
+export type { WithdrawAccessibleOptions, WithdrawResult, FrozenSnapshotRef } from './bundle/withdraw-accessible.js'
 export type {
   NoydbBundleHeader,
   CompressionAlgo,

--- a/packages/hub/src/meta/user-envelope/api.ts
+++ b/packages/hub/src/meta/user-envelope/api.ts
@@ -30,6 +30,7 @@ import {
 } from '../../directory/visibility.js'
 import type { UserVisibility } from '../../directory/types.js'
 import type { ExportAccessibleOptions } from '../../bundle/export-accessible.js'
+import type { WithdrawAccessibleOptions, WithdrawResult } from '../../bundle/withdraw-accessible.js'
 
 /**
  * Recursive partial. Used for `updateMe(patch)` so callers can hand in
@@ -80,7 +81,7 @@ export interface UserEnvelopePresented {
  * no-op stub is fine.
  */
 export type UserEnvelopeCheckGate = (
-  gate: 'edit-own-profile' | 'view-team-profiles',
+  gate: 'edit-own-profile' | 'view-team-profiles' | 'client-unilateral-withdraw',
   presented?: UserEnvelopePresented,
 ) => Promise<void>
 
@@ -127,7 +128,27 @@ export class UserApi {
      * (which holds the keyring + bundle machinery). Omitted in low-level tests.
      */
     private readonly exportAccessible?: (opts: ExportAccessibleOptions) => Promise<Uint8Array>,
+    /**
+     * Noydb-backed `unilateralWithdrawal` (#199 P2), injected by the Vault.
+     * Destructive — extract + dispose (delete | freeze). Omitted in low-level tests.
+     */
+    private readonly unilateralWithdraw?: (opts: WithdrawAccessibleOptions) => Promise<WithdrawResult>,
   ) {}
+
+  /**
+   * #199 P2 — single-party withdrawal: export the caller's accessible scope
+   * (re-keyed) and dispose of the source (`delete` or `freeze`). Gated by the
+   * fail-closed built-in `client-unilateral-withdraw` policy — undefined or
+   * disabled → throws (use `requestWithdrawal`). The firm enables it at vault
+   * creation.
+   */
+  async unilateralWithdrawal(opts: WithdrawAccessibleOptions): Promise<WithdrawResult> {
+    if (this.checkGate) await this.checkGate('client-unilateral-withdraw')
+    if (!this.unilateralWithdraw) {
+      throw new Error('unilateralWithdrawal requires a Noydb-backed vault (not a bare UserApi)')
+    }
+    return this.unilateralWithdraw(opts)
+  }
 
   /**
    * #199 — export the calling user's accessible scope as a portable, re-keyed

--- a/packages/hub/src/policy/presets.ts
+++ b/packages/hub/src/policy/presets.ts
@@ -85,6 +85,12 @@ export const PERSONAL_POLICY: VaultPolicy = Object.freeze({
     //   self (privacy-strict opt-out).
     'edit-own-profile': { minTier: 3 },
     'view-team-profiles': { minTier: 2 },
+    // client-unilateral-withdraw: a non-owner's self-service DESTRUCTIVE
+    // withdrawal (export-and-delete/freeze, #199). Fail-closed by default —
+    // the firm opts in per jurisdiction/contract (e.g. GDPR Art. 17).
+    // Listed explicitly (not just relying on the built-in default) so it is
+    // discoverable in describeGate / policy dumps.
+    'client-unilateral-withdraw': { minTier: 1, enabled: false },
   },
 }) as VaultPolicy
 
@@ -192,6 +198,15 @@ export const STRICT_POLICY: VaultPolicy = Object.freeze({
       factors: [{ anyOf: ['totp', 'email-otp'] }],
     },
     'view-team-profiles': { minTier: 2 },
+    // STRICT: still fail-closed, but if a regulated firm flips enabled:true
+    // they inherit a two-factor proof + shared-device block for the
+    // destructive withdrawal (mirrors export-plaintext's hardening).
+    'client-unilateral-withdraw': {
+      minTier: 1,
+      enabled: false,
+      factors: [{ anyOf: ['totp', 'email-otp'], count: 2 }],
+      warn: { sharedDevice: 'block' },
+    },
   },
 }) as VaultPolicy
 

--- a/packages/hub/src/policy/types.ts
+++ b/packages/hub/src/policy/types.ts
@@ -143,6 +143,15 @@ export type BuiltInGateName =
    * regardless of this gate's settings.
    */
   | 'update-user'
+  /**
+   * Authorize a non-owner's self-service **destructive** withdrawal —
+   * `vault.user.unilateralWithdrawal` (#199). The actor exports their
+   * own re-keyed copy and then removes (delete-closure) or freezes the
+   * source records. Because it both egresses data AND destroys the
+   * firm's live copy, it MUST fail closed: undefined in a policy = denied.
+   * Hosts opt in explicitly (and typically pin `minTier`/factor proofs).
+   */
+  | 'client-unilateral-withdraw'
 
 /** Either a built-in gate name or an `app:*` custom gate. */
 export type GateName = BuiltInGateName | `app:${string}`

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -21,6 +21,7 @@ import type { JoinableSource } from './query/index.js'
 import type { OnDirtyCallback } from './collection.js'
 import type { UnlockedKeyring, BundleRecipient } from './team/keyring.js'
 import { exportAccessibleData } from './bundle/export-accessible.js'
+import { withdrawAccessibleData } from './bundle/withdraw-accessible.js'
 import type { MaterializedViewRegistry } from './materialized-views/registry.js'
 import type { MaterializedViewStrategyHandle, MVQueryContext } from './materialized-views/types.js'
 import type { OverlayedViewRegistry } from './overlay-views/registry.js'
@@ -585,6 +586,7 @@ export class Vault {
       () => this.getDEK(USER_ENVELOPE_COLLECTION),
       (gate, presented) => this.noydb.checkGate(this.name, gate, presented),
       (opts) => exportAccessibleData(this, opts),
+      (opts) => withdrawAccessibleData(this, opts),
     )
   }
 

--- a/showcases/src/120-client-portability-withdrawal.showcase.test.ts
+++ b/showcases/src/120-client-portability-withdrawal.showcase.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Showcase 120 — Client-initiated portability + withdrawal (#199)
+ *
+ * What you'll learn
+ * ─────────────────
+ * A non-owner principal (an `operator` with `rw` scope) can act on THEIR OWN
+ * accessible data, three ways, all via `vault.user.*`:
+ *
+ *   1. `exportMyAccessibleData()` — conservative, non-destructive, always
+ *      allowed. Walks the caller's accessible collections, re-keys the bundle
+ *      to a passphrase they choose, and audits the egress. Nothing is removed.
+ *   2. `unilateralWithdrawal({ disposition: 'delete' })` — export-and-erase
+ *      (GDPR Art. 17). The re-keyed copy is produced FIRST, then the live
+ *      records leave the vault entirely (delete-closure).
+ *   3. `unilateralWithdrawal({ disposition: 'freeze' })` — export, then the
+ *      firm KEEPS a cryptographically-frozen, write-once, hash-pinned snapshot
+ *      of the original ciphertext while the live records are removed. For
+ *      regulated retention: the client departs with their copy; the firm holds
+ *      an immutable, provably-unaltered point-in-time record.
+ *
+ * Why it matters
+ * ──────────────
+ * The cryptographic invariant: the caller holds the DEKs for their scope, so
+ * *export* is a capability, not a permission — the firm can audit and gate, but
+ * cannot prevent it. *Withdrawal* is destructive, so it is fail-closed behind
+ * the built-in `client-unilateral-withdraw` gate (disabled by default); the
+ * firm opts in per jurisdiction/contract. Read-only roles (`client`/`viewer`)
+ * cannot self-serve a deletion — they route to the two-party `requestWithdrawal`.
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → client-portability
+ * docs/superpowers/specs/2026-06-16-client-initiated-portability-withdrawal-design.md
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { readNoydbBundle } from '@noy-db/hub/bundle'
+import { memory } from '@noy-db/to-memory'
+
+interface Invoice extends Record<string, unknown> { id: string; total: number }
+
+/**
+ * Firm vault owned by the director, with operator "belle" granted rw on
+ * `invoices`. `enableWithdraw` flips the otherwise default-off destructive gate.
+ */
+async function firmVault(store: ReturnType<typeof memory>, enableWithdraw: boolean) {
+  const policy = enableWithdraw
+    ? ({ gates: { 'client-unilateral-withdraw': { enabled: true, minTier: 1 } } } as const)
+    : undefined
+  const director = await createNoydb({ store, user: 'alice', secret: 'alice-director-2026', ...(policy ? { policy } : {}) })
+  const ov = await director.openVault('firm')
+  await ov.collection<Invoice>('invoices').put('i1', { id: 'i1', total: 1000 })
+  await ov.collection<Invoice>('invoices').put('i2', { id: 'i2', total: 500 })
+  await director.grant('firm', {
+    userId: 'belle', displayName: 'Belle', role: 'operator', passphrase: 'belle-operator-2026',
+    permissions: { invoices: 'rw' },
+  })
+  director.close()
+  const op = await createNoydb({ store, user: 'belle', secret: 'belle-operator-2026' })
+  return op.openVault('firm')
+}
+
+describe('Showcase 120 — client portability + withdrawal', () => {
+  it('exportMyAccessibleData re-keys the caller scope and leaves the source intact', async () => {
+    const vault = await firmVault(memory(), false)
+
+    const bytes = await vault.user.exportMyAccessibleData({ reKey: { passphrase: 'belle-takeaway-pass' } })
+    const dump = JSON.parse((await readNoydbBundle(bytes)).dumpJson) as { collections?: Record<string, unknown> }
+    expect(Object.keys(dump.collections ?? {})).toContain('invoices')
+
+    // Non-destructive: the records are still live in the firm vault.
+    expect(await vault.collection<Invoice>('invoices').get('i1')).not.toBeNull()
+  })
+
+  it('the destructive withdrawal is fail-closed unless the firm opts in', async () => {
+    const vault = await firmVault(memory(), false) // gate disabled (default)
+    await expect(
+      vault.user.unilateralWithdrawal({ legalBasis: 'gdpr-art-17', reKey: { passphrase: 'x-pass' } }),
+    ).rejects.toThrow() // PolicyDeniedError — points the caller at requestWithdrawal
+  })
+
+  it('disposition:delete exports then erases the live records (GDPR Art. 17)', async () => {
+    const vault = await firmVault(memory(), true)
+
+    const { bundle, snapshot } = await vault.user.unilateralWithdrawal({
+      disposition: 'delete', legalBasis: 'gdpr-art-17', reKey: { passphrase: 'belle-takeaway-pass' },
+    })
+    expect(snapshot).toBeUndefined()
+    const dump = JSON.parse((await readNoydbBundle(bundle)).dumpJson) as { collections?: Record<string, unknown> }
+    expect(Object.keys(dump.collections ?? {})).toContain('invoices')
+
+    // Live records are gone.
+    expect(await vault.collection<Invoice>('invoices').get('i1')).toBeNull()
+    expect(await vault.collection<Invoice>('invoices').get('i2')).toBeNull()
+  })
+
+  it('disposition:freeze keeps a hash-pinned write-once snapshot, removes the live records', async () => {
+    const store = memory()
+    const vault = await firmVault(store, true)
+
+    const { snapshot } = await vault.user.unilateralWithdrawal({
+      disposition: 'freeze', legalBasis: 'regulated-retention', reKey: { passphrase: 'belle-takeaway-pass' },
+    })
+    expect(snapshot).toBeTruthy()
+    expect(snapshot!.recordCount).toBe(2)
+    expect(snapshot!.sha256).toMatch(/^[0-9a-f]{64}$/) // tamper-evident hash pinned in the ledger
+
+    // The frozen snapshot lives in the reserved write-once namespace; the firm
+    // can reopen it with the keys it already holds.
+    const frozen = await store.get('firm', '_frozen_snapshots', snapshot!.withdrawalId)
+    expect(frozen).not.toBeNull()
+
+    // Live records removed.
+    expect(await vault.collection<Invoice>('invoices').get('i1')).toBeNull()
+  })
+})


### PR DESCRIPTION
## #199 P2 — `vault.user.unilateralWithdrawal`

Builds on P1 (#436, `exportMyAccessibleData`). Adds the **destructive** self-service path with two source dispositions, per the design refinement (export + dispose):

| Disposition | Effect |
| --- | --- |
| `delete` (default) | **delete-closure** — records leave the vault entirely (GDPR Art. 17 erasure) |
| `freeze` | the firm retains a **write-once, hash-pinned** snapshot of the original ciphertext at `_frozen_snapshots/<withdrawalId>` (reopenable with the firm's existing keys — no re-key), then delete-closures the live records |

Ordering guarantees no data loss: the caller's re-keyed bundle (and the freeze snapshot) are produced **before** anything is deleted; a partial deletion is resumable (write-once snapshot put is idempotent).

### Gating & authority
- **New built-in gate `client-unilateral-withdraw`**, fail-closed (undefined/disabled → `PolicyDeniedError`). Built-in, *not* `app:*` — `app:*` gates default to *allow*, which is wrong for a destructive op. Added to PERSONAL + STRICT presets (both `enabled:false`; STRICT pins 2FA + shared-device block for the opt-in case).
- `operator` (rw) is the self-service path. `client`/`viewer` are **read-only by construction** (`hasWritePermission`) → `ReadOnlyError` pointing at the two-party `requestWithdrawal` (P3). `owner`/`admin` use `extractPartition`.

### Also
- Refactors `export-accessible.ts` to share `resolveAccessibleCollections` / `buildAccessibleBundle`.
- Registers the whole #199 feature in `features.yaml` (+ `docs/subsystems/client-portability.md` + showcase **120**) — P1 had shipped without a registry entry.
- Spec §6–§9b reconciled with the shipped envelope-copy freeze and best-effort idempotent delete.

### Tests
- `packages/hub/__tests__/withdraw-accessible.test.ts` — gate fail-closed by default, ro role → `ReadOnlyError`, `delete` erases live records, `freeze` hash-pins a write-once snapshot + erases live records.
- Showcase 120 (4 scenarios). Full hub suite green (2704); features.yaml validates; arch invariants OK.

### Follow-up
- **P3** — two-party `requestWithdrawal` / `approveWithdrawal` / `rejectWithdrawal` (durable request collection; owner authority executes the delete for read-only roles).