### PR TITLE
feat(hub): two-party withdrawal ceremony — request/approve/reject (#199 P3)

### DIFF
--- a/docs/subsystems/client-portability.md
+++ b/docs/subsystems/client-portability.md
@@ -11,8 +11,17 @@ Design spec: `docs/superpowers/specs/2026-06-16-client-initiated-portability-wit
 | Method | Destructive? | Gate | Notes |
 | --- | --- | --- | --- |
 | `exportMyAccessibleData(opts)` | no | none (audited) | re-keyed copy of the caller's scope; source untouched |
-| `unilateralWithdrawal(opts)` | yes | `client-unilateral-withdraw` (fail-closed) | export **then** dispose of the source |
-| `requestWithdrawal` / `approveWithdrawal` (P3) | yes | two-party | for read-only roles that can't self-serve |
+| `unilateralWithdrawal(opts)` | yes | `client-unilateral-withdraw` (fail-closed) | operator self-serve: export **then** dispose of the source |
+| `requestWithdrawal(opts)` | no | `user-request-withdrawal` (enabled, t1) | requester (incl. read-only client/viewer) files a durable request |
+| `listWithdrawalRequests({status?})` | no | owner/admin | review the queue |
+| `approveWithdrawal(id, {reKey?})` | yes | `approve-user-withdrawal` (t2) + owner/admin | extract-and-dispose under firm authority; returns the bundle |
+| `rejectWithdrawal(id, {reason?})` | no | `approve-user-withdrawal` + owner/admin | decline; no data touched |
+
+`approveWithdrawal` reuses the SAME `freezeAndDeleteClosure` primitive as
+`unilateralWithdrawal`, so the `disposition` (`delete`/`freeze`) the requester
+chose flows through end-to-end. The request body is plaintext metadata and
+carries **no passphrase** (supplied by the approver at approval time,
+out-of-band) — nothing secret is stored at rest.
 
 ### Scope
 

--- a/docs/superpowers/specs/2026-06-16-client-initiated-portability-withdrawal-design.md
+++ b/docs/superpowers/specs/2026-06-16-client-initiated-portability-withdrawal-design.md
@@ -54,16 +54,20 @@ await vault.user.exportMyAccessibleData({
 ## 5. Operation 2 — `requestWithdrawal` (two-party)
 
 ```ts
-await vault.user.requestWithdrawal({ scope?, expiresIn? }): Promise<{ requestId, expiresAt }>
-// owner side (Noydb / db, owner authority):
-await db.approveWithdrawal(vaultName, requestId, factors?): Promise<{ bundleBytes }>
-await db.rejectWithdrawal(vaultName, requestId, reason?): Promise<void>
+// requester side (any non-owner with access; the path for read-only client/viewer):
+await vault.user.requestWithdrawal({ scope?, disposition?, legalBasis?, expiresInMs? }): Promise<{ requestId, status, expiresAt? }>
+// owner side (vault.user.*, owner/admin authority):
+await vault.user.listWithdrawalRequests({ status? }): Promise<WithdrawalRequest[]>
+await vault.user.approveWithdrawal(requestId, { reKey? }): Promise<{ bundle, snapshot? }>
+await vault.user.rejectWithdrawal(requestId, { reason? }): Promise<WithdrawalRequest>
 ```
 
-- Spans calendar time → **durable request record** in `_user_withdrawal_requests` (encrypted), NOT a transaction.
-- `requestWithdrawal`: gate `user-request-withdrawal` (default enabled, tier 1); writes the request + audit (`reason:'user-withdrawal-request:<id>'`).
-- `approveWithdrawal` (owner): gate `approve-user-withdrawal` (tier 2); extract the requester's closure (owner authority) → seal bundle → **delete-closure** → audit (`user-withdrawal-approved`). Returns the bundle to hand back.
-- `rejectWithdrawal`: marks the request rejected + audit.
+- Spans calendar time → **durable request record** in `_user_withdrawal_requests`, NOT a transaction. Body is plaintext metadata (collection names + disposition + legal basis — none secret in this trust model; the owner sees the data anyway) and carries **NO passphrase**: the re-key passphrase is supplied by the approver at approval time and conveyed out-of-band, so no secret is stored at rest.
+- The requester's **accessible** collections (read access defines "theirs") are resolved + recorded at request time, so the request is self-contained; the owner — who can delete anything — executes the disposition on approval.
+- `requestWithdrawal`: gate `user-request-withdrawal` (default enabled, tier 1); writes the request + audit (`reason:'user-withdrawal-request:<id>:<requester>'`).
+- `approveWithdrawal`: gate `approve-user-withdrawal` (tier-2 default) **+ owner/admin role** (enforced in code); validates the request is pending + not expired; build re-keyed bundle (owner authority) → dispose of source (`freezeAndDeleteClosure`, shared with P2) → mark approved (OCC) → audit (`user-withdrawal-approved`). Returns the bundle (+ snapshot on freeze) to hand back.
+- `rejectWithdrawal`: owner/admin; marks the request rejected (+ reason) + audit (`user-withdrawal-rejected`). No data touched.
+- The two-party `approveWithdrawal` reuses the SAME `freezeAndDeleteClosure` primitive as `unilateralWithdrawal` (delete or freeze), so the disposition the requester chose flows through end-to-end.
 
 ## 6. Operation 3 — `unilateralWithdrawal` (gated)
 
@@ -127,13 +131,13 @@ The firm's retained copy for `disposition:'freeze'`. The caller is an **operator
 
 ## 10. Phasing
 
-- **P1 (slice 1):** `exportMyAccessibleData` — conservative, non-destructive, always-allowed, audited. ✅ shipped.
-- **P2:** gate additions + `unilateralWithdrawal` with **both** dispositions — the `delete-closure` primitive (§9) AND the `freeze` snapshot (§9b) — behind the default-off gate.
-- **P3:** `requestWithdrawal` / `approveWithdrawal` / `rejectWithdrawal` two-party ceremony (durable request collection); approve supports the same `disposition`.
-- **Deferred:** `scope.entity` / `scope.subject` row-level sub-scoping (needs entity-tag model / #304 subject-index access); managed-mode/multi-recipient re-key.
+- **P1 (slice 1):** `exportMyAccessibleData` — conservative, non-destructive, always-allowed, audited. ✅ shipped (PR #436).
+- **P2:** built-in `client-unilateral-withdraw` gate + `unilateralWithdrawal` with **both** dispositions — the `delete-closure` primitive (§9) AND the `freeze` snapshot (§9b) — behind the default-off gate. ✅ shipped (PR #437).
+- **P3:** `requestWithdrawal` / `listWithdrawalRequests` / `approveWithdrawal` / `rejectWithdrawal` two-party ceremony (durable `_user_withdrawal_requests` collection); approve reuses the same `freezeAndDeleteClosure` so the requester's `disposition` flows through. Gates `user-request-withdrawal` (enabled, t1) + `approve-user-withdrawal` (t2 + owner/admin role). ✅ shipped.
+- **Deferred:** `scope.entity` / `scope.subject` row-level sub-scoping (needs entity-tag model / #304 subject-index access); managed-mode/multi-recipient re-key; in-band bundle delivery (a `_user_withdrawal_bundles` drop — v1 returns the bundle to the owner to hand off out-of-band); transaction-wrapped delete-closure.
 
-## 11. Open questions
+## 11. Resolved questions (decided during implementation)
 
-1. `reKey` shape — single `exportPassphrase` vs full `recipients` (multi-slot, managed-mode sealing per #197)? v1: single new-owner; managed/multi later.
-2. Should `approveWithdrawal` deliver the bundle to the requester in-band (a `_user_withdrawal_bundles` drop) or return it to the owner to hand off out-of-band? v1: return to owner.
-3. delete-closure when the caller is a non-owner: do they have delete rights on their accessible collections? (operator/client `rw` vs `ro` — unilateral withdrawal of `ro` scope must still delete; confirm the delete authority model.)
+1. `reKey` shape — **single `{ passphrase }`** for v1 (single new-owner). Full `recipients` multi-slot / managed-mode sealing (per #197) deferred.
+2. Bundle delivery — `approveWithdrawal` **returns the bundle to the owner** to hand off out-of-band (v1). In-band drop (`_user_withdrawal_bundles`) deferred.
+3. delete authority — **resolved by the kernel**: `hasWritePermission` makes `client`/`viewer` read-only by construction, so only an `operator` (rw) can self-serve `unilateralWithdrawal`; read-only roles use the two-party `requestWithdrawal` where the owner (blanket authority) executes the delete-closure. There is no "delete `ro` scope unilaterally" case — it routes to P3 by design.

--- a/features.yaml
+++ b/features.yaml
@@ -1027,6 +1027,7 @@ features:
       - 'destructive withdrawal is gated by the built-in client-unilateral-withdraw gate (fail-closed: undefined/disabled → PolicyDeniedError); built-in not app:* because app:* gates default to allow'
       - 'authority: client/viewer are read-only by construction (hasWritePermission) → ReadOnlyError pointing at requestWithdrawal; operator (rw) is the self-service destructive path; owner/admin use extractPartition'
       - 'disposition delete = delete-closure (records leave the vault); disposition freeze = write-once hash-pinned snapshot of the original envelopes at _frozen_snapshots/<id> + ledger sha256 pin, then delete-closure'
+      - 'two-party ceremony (P3) for read-only roles: requestWithdrawal files a durable plaintext-metadata request in _user_withdrawal_requests (no passphrase at rest); owner/admin approveWithdrawal (gate approve-user-withdrawal t2 + role) extracts under firm authority and reuses freezeAndDeleteClosure so the requester disposition flows through; rejectWithdrawal touches no data; approve/reject are OCC + idempotent (pending-only, expiry-checked)'
     related: [transferable-partition, bundle, team, session-tiers]
 
   - id: with-snapshots

--- a/packages/hub/__tests__/request-withdrawal.test.ts
+++ b/packages/hub/__tests__/request-withdrawal.test.ts
@@ -1,0 +1,116 @@
+/**
+ * #199 P3 — two-party withdrawal ceremony. A read-only client (who cannot
+ * self-serve a destructive `unilateralWithdrawal`) files a request; an owner
+ * reviews and approves (extract-and-dispose under firm authority) or rejects.
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+import { createNoydb } from '../src/noydb.js'
+import { readNoydbBundle } from '../src/bundle/bundle.js'
+import { WithdrawalRequestError } from '../src/bundle/request-withdrawal.js'
+
+function makeStore(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function bucket(v: string, c: string) {
+    let m = store.get(v); if (!m) { m = new Map(); store.set(v, m) }
+    let b = m.get(c); if (!b) { b = new Map(); m.set(c, b) }
+    return b
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return bucket(v, c).get(id) ?? null },
+    async put(v, c, id, env, ev) { const b = bucket(v, c); const ex = b.get(id); if (ev !== undefined && (ex?._v ?? 0) !== ev) throw new ConflictError(ex?._v ?? 0); b.set(id, env) },
+    async delete(v, c, id) { bucket(v, c).delete(id) },
+    async list(v, c) { return [...bucket(v, c).keys()] },
+    async loadAll(v) { const m = store.get(v); const s: VaultSnapshot = {}; if (m) for (const [n, c] of m) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of c) r[id] = e; s[n] = r } return s },
+    async saveAll(v, data) { for (const [n, recs] of Object.entries(data)) { const b = bucket(v, n); for (const [id, e] of Object.entries(recs)) b.set(id, e) } },
+  }
+}
+
+/** Owner vault + a read-only client both open on the same store/vault. */
+async function setup(store: NoydbStore, clientMode: 'rw' | 'ro' = 'ro') {
+  const owner = await createNoydb({ store, user: 'firm', secret: 'owner-pw-long-enough' })
+  const ov = await owner.openVault('acme')
+  await ov.collection<{ id: string; total: number }>('invoices').put('i1', { id: 'i1', total: 100 })
+  await ov.collection<{ id: string; total: number }>('invoices').put('i2', { id: 'i2', total: 50 })
+  await owner.grant('acme', {
+    userId: 'client1', displayName: 'Client', role: 'client', passphrase: 'client-pw-long-enough',
+    permissions: { invoices: clientMode },
+  })
+  const client = await createNoydb({ store, user: 'client1', secret: 'client-pw-long-enough' })
+  const cv = await client.openVault('acme')
+  return { ov, cv }
+}
+
+describe('#199 P3 — two-party withdrawal', () => {
+  it('a read-only client files a request, the owner approves and the records are deleted under firm authority', async () => {
+    const { ov, cv } = await setup(makeStore())
+
+    const { requestId, status } = await cv.user.requestWithdrawal({ legalBasis: 'gdpr-art-17' })
+    expect(status).toBe('pending')
+
+    // Owner sees the pending request.
+    const pending = await ov.user.listWithdrawalRequests({ status: 'pending' })
+    expect(pending.map((r) => r.requestId)).toContain(requestId)
+    expect(pending[0]!.requester).toBe('client1')
+    expect(pending[0]!.collections).toEqual(['invoices'])
+
+    // Owner approves → bundle handed back + records deleted under owner authority.
+    const { bundle, snapshot } = await ov.user.approveWithdrawal(requestId, { reKey: { passphrase: 'client-takeaway' } })
+    expect(snapshot).toBeUndefined()
+    const dump = JSON.parse((await readNoydbBundle(bundle)).dumpJson) as { collections?: Record<string, unknown> }
+    expect(Object.keys(dump.collections ?? {})).toContain('invoices')
+    expect(await ov.collection<{ id: string }>('invoices').get('i1')).toBeNull()
+    expect(await ov.collection<{ id: string }>('invoices').get('i2')).toBeNull()
+
+    // Request is now approved.
+    const approved = await ov.user.listWithdrawalRequests({ status: 'approved' })
+    expect(approved.map((r) => r.requestId)).toContain(requestId)
+  })
+
+  it('freeze disposition flows end-to-end through the request', async () => {
+    const { ov, cv } = await setup(makeStore())
+    const { requestId } = await cv.user.requestWithdrawal({ disposition: 'freeze', legalBasis: 'retention' })
+    const { snapshot } = await ov.user.approveWithdrawal(requestId, { reKey: { passphrase: 'p' } })
+    expect(snapshot).toBeTruthy()
+    expect(snapshot!.recordCount).toBe(2)
+    expect(snapshot!.sha256).toMatch(/^[0-9a-f]{64}$/)
+    expect(await ov.collection<{ id: string }>('invoices').get('i1')).toBeNull()
+  })
+
+  it('only an owner/admin can approve or reject', async () => {
+    const { cv } = await setup(makeStore())
+    const { requestId } = await cv.user.requestWithdrawal({ legalBasis: 'gdpr-art-17' })
+    // The client cannot approve its own request.
+    await expect(cv.user.approveWithdrawal(requestId)).rejects.toBeInstanceOf(WithdrawalRequestError)
+    await expect(cv.user.rejectWithdrawal(requestId)).rejects.toBeInstanceOf(WithdrawalRequestError)
+  })
+
+  it('reject leaves the data untouched and marks the request rejected', async () => {
+    const { ov, cv } = await setup(makeStore())
+    const { requestId } = await cv.user.requestWithdrawal({ legalBasis: 'gdpr-art-17' })
+    const rejected = await ov.user.rejectWithdrawal(requestId, { reason: 'incomplete-id-check' })
+    expect(rejected.status).toBe('rejected')
+    expect(rejected.rejectReason).toBe('incomplete-id-check')
+    // Data still present.
+    expect(await ov.collection<{ id: string }>('invoices').get('i1')).not.toBeNull()
+    // A decided request cannot be approved.
+    await expect(ov.user.approveWithdrawal(requestId)).rejects.toBeInstanceOf(WithdrawalRequestError)
+  })
+
+  it('a request cannot be approved twice', async () => {
+    const { ov, cv } = await setup(makeStore())
+    const { requestId } = await cv.user.requestWithdrawal({ legalBasis: 'gdpr-art-17' })
+    await ov.user.approveWithdrawal(requestId, { reKey: { passphrase: 'p' } })
+    await expect(ov.user.approveWithdrawal(requestId, { reKey: { passphrase: 'p' } }))
+      .rejects.toBeInstanceOf(WithdrawalRequestError)
+  })
+
+  it('an expired request cannot be approved', async () => {
+    const { ov, cv } = await setup(makeStore())
+    const { requestId, expiresAt } = await cv.user.requestWithdrawal({ legalBasis: 'gdpr-art-17', expiresInMs: -1 })
+    expect(expiresAt).toBeTruthy() // already in the past
+    await expect(ov.user.approveWithdrawal(requestId)).rejects.toThrow(/expired/)
+  })
+})

--- a/packages/hub/src/bundle/request-withdrawal.ts
+++ b/packages/hub/src/bundle/request-withdrawal.ts
@@ -1,0 +1,221 @@
+/**
+ * #199 P3 — two-party withdrawal ceremony.
+ *
+ * The conservative counterpart to `unilateralWithdrawal` (P2): a non-owner —
+ * including a read-only `client`/`viewer` who cannot self-serve a deletion —
+ * files a durable REQUEST; an owner/admin reviews it and either APPROVES
+ * (extract-and-dispose under firm authority) or REJECTS it. Every step is
+ * audited in the tamper-evident ledger.
+ *
+ *   requester:  vault.user.requestWithdrawal({ scope, disposition?, legalBasis? })
+ *   owner:      vault.user.listWithdrawalRequests()
+ *               vault.user.approveWithdrawal(requestId, { reKey })  → { bundle, snapshot? }
+ *               vault.user.rejectWithdrawal(requestId, { reason })
+ *
+ * Requests live in the reserved `_user_withdrawal_requests` namespace. The
+ * record body is plaintext metadata (collection names + disposition + legal
+ * basis — none secret in this trust model; the owner sees the data anyway) and
+ * carries NO passphrase: the re-key passphrase is supplied by the approver at
+ * approval time and conveyed to the requester out-of-band, so no secret is
+ * stored at rest.
+ */
+import type { Vault } from '../vault.js'
+import type { EncryptedEnvelope } from '../types.js'
+import { NOYDB_FORMAT_VERSION } from '../types.js'
+import { NoydbError } from '../errors.js'
+import { resolveAccessibleCollections, buildAccessibleBundle } from './export-accessible.js'
+import { freezeAndDeleteClosure, randomId, type FrozenSnapshotRef, type WithdrawResult } from './withdraw-accessible.js'
+
+export const WITHDRAWAL_REQUESTS_COLLECTION = '_user_withdrawal_requests'
+
+/** Raised when a request is missing, already decided, or expired. */
+export class WithdrawalRequestError extends NoydbError {
+  constructor(message: string) {
+    super('WITHDRAWAL_REQUEST', message)
+    this.name = 'WithdrawalRequestError'
+  }
+}
+
+export type WithdrawalRequestStatus = 'pending' | 'approved' | 'rejected'
+
+export interface WithdrawalRequest {
+  readonly requestId: string
+  readonly requester: string
+  readonly collections: readonly string[]
+  readonly disposition: 'delete' | 'freeze'
+  readonly legalBasis?: string
+  readonly status: WithdrawalRequestStatus
+  readonly requestedAt: string
+  readonly expiresAt?: string
+  readonly decidedAt?: string
+  readonly decidedBy?: string
+  readonly rejectReason?: string
+  readonly snapshotSha256?: string
+}
+
+export interface RequestWithdrawalOptions {
+  readonly scope?: { readonly collections?: readonly string[] }
+  readonly disposition?: 'delete' | 'freeze'
+  readonly legalBasis?: string
+  /** Time-to-live in ms; after this the request can no longer be approved. */
+  readonly expiresInMs?: number
+}
+
+export interface RequestWithdrawalResult {
+  readonly requestId: string
+  readonly status: WithdrawalRequestStatus
+  readonly expiresAt?: string
+}
+
+function writeRequest(vault: Vault, req: WithdrawalRequest, expectedVersion: number): Promise<void> {
+  const { name: vaultName, adapter } = vault._introspectState()
+  const body = JSON.stringify(req)
+  const env: EncryptedEnvelope = {
+    _noydb: NOYDB_FORMAT_VERSION, _v: expectedVersion + 1, _ts: req.decidedAt ?? req.requestedAt,
+    _iv: '', _data: body, _by: req.decidedBy ?? req.requester,
+  }
+  return adapter.put(vaultName, WITHDRAWAL_REQUESTS_COLLECTION, req.requestId, env, expectedVersion)
+}
+
+async function readRequest(vault: Vault, requestId: string): Promise<{ req: WithdrawalRequest; version: number }> {
+  const { name: vaultName, adapter } = vault._introspectState()
+  const env = await adapter.get(vaultName, WITHDRAWAL_REQUESTS_COLLECTION, requestId)
+  if (!env) throw new WithdrawalRequestError(`withdrawal request "${requestId}" not found`)
+  return { req: JSON.parse(env._data) as WithdrawalRequest, version: env._v }
+}
+
+/**
+ * Requester side. Files a durable request for the caller's accessible scope.
+ * Gated by `user-request-withdrawal` (checked in the UserApi wrapper).
+ */
+export async function requestWithdrawal(
+  vault: Vault,
+  opts: RequestWithdrawalOptions = {},
+): Promise<RequestWithdrawalResult> {
+  const { keyring } = vault._introspectState()
+  // Resolve the requester's accessible collections (read access defines "theirs";
+  // the owner — who can delete anything — executes the disposition on approval).
+  const collections = resolveAccessibleCollections(keyring, opts.scope, false)
+  if (!collections || collections.length === 0) {
+    throw new WithdrawalRequestError(
+      'requestWithdrawal needs a concrete scope.collections (the caller has all-collection access — name the collections to withdraw)',
+    )
+  }
+  const requestId = `wr-${randomId()}`
+  const requestedAt = new Date().toISOString()
+  const req: WithdrawalRequest = {
+    requestId, requester: keyring.userId, collections, disposition: opts.disposition ?? 'delete',
+    status: 'pending', requestedAt,
+    ...(opts.legalBasis ? { legalBasis: opts.legalBasis } : {}),
+    ...(opts.expiresInMs ? { expiresAt: new Date(Date.parse(requestedAt) + opts.expiresInMs).toISOString() } : {}),
+  }
+  await writeRequest(vault, req, 0) // create-only
+  await vault._getLedgerOrNull()?.append({
+    op: 'lifecycle', collection: '', id: '', version: 0, actor: keyring.userId, payloadHash: '',
+    reason: `user-withdrawal-request:${requestId}:${keyring.userId}`,
+  })
+  return { requestId, status: 'pending', ...(req.expiresAt ? { expiresAt: req.expiresAt } : {}) }
+}
+
+/** Owner side. List filed requests (optionally by status). */
+export async function listWithdrawalRequests(
+  vault: Vault,
+  opts: { status?: WithdrawalRequestStatus } = {},
+): Promise<WithdrawalRequest[]> {
+  const { name: vaultName, adapter } = vault._introspectState()
+  const ids = await adapter.list(vaultName, WITHDRAWAL_REQUESTS_COLLECTION)
+  const out: WithdrawalRequest[] = []
+  for (const id of ids) {
+    const env = await adapter.get(vaultName, WITHDRAWAL_REQUESTS_COLLECTION, id)
+    if (!env) continue
+    const req = JSON.parse(env._data) as WithdrawalRequest
+    if (!opts.status || req.status === opts.status) out.push(req)
+  }
+  return out
+}
+
+function assertApprover(vault: Vault): string {
+  const { keyring } = vault._introspectState()
+  if (keyring.role !== 'owner' && keyring.role !== 'admin') {
+    throw new WithdrawalRequestError('approveWithdrawal / rejectWithdrawal require an owner or admin')
+  }
+  return keyring.userId
+}
+
+function assertPending(req: WithdrawalRequest): void {
+  if (req.status !== 'pending') {
+    throw new WithdrawalRequestError(`withdrawal request "${req.requestId}" is already ${req.status}`)
+  }
+  if (req.expiresAt && Date.now() > Date.parse(req.expiresAt)) {
+    throw new WithdrawalRequestError(`withdrawal request "${req.requestId}" expired at ${req.expiresAt}`)
+  }
+}
+
+export interface ApproveWithdrawalOptions {
+  /** Re-key the handed-back bundle to a passphrase the requester will use. */
+  readonly reKey?: { readonly passphrase: string }
+}
+
+/**
+ * Owner side. Extract the requester's recorded scope under firm authority,
+ * dispose of the source per the request's disposition, mark the request
+ * approved, and return the re-keyed bundle to hand back. Gated by
+ * `approve-user-withdrawal` (checked in the UserApi wrapper) + owner/admin role.
+ */
+export async function approveWithdrawal(
+  vault: Vault,
+  requestId: string,
+  opts: ApproveWithdrawalOptions = {},
+): Promise<WithdrawResult> {
+  const approver = assertApprover(vault)
+  const { req, version } = await readRequest(vault, requestId)
+  assertPending(req)
+
+  // 1. Produce the requester's re-keyed portable copy FIRST (owner authority
+  //    holds every DEK, so the recorded collections are all readable).
+  const bundle = await buildAccessibleBundle(vault, [...req.collections], opts.reKey)
+
+  // 2. + 3. dispose of the source (freeze snapshot, optional → delete-closure).
+  const snapshot: FrozenSnapshotRef | undefined = await freezeAndDeleteClosure(vault, req.collections, {
+    disposition: req.disposition, actorUserId: approver, withdrawalId: `wd-${requestId}`,
+  })
+
+  // 4. mark approved + audit (OCC against the version we read).
+  const decidedAt = new Date().toISOString()
+  await writeRequest(vault, {
+    ...req, status: 'approved', decidedAt, decidedBy: approver,
+    ...(snapshot ? { snapshotSha256: snapshot.sha256 } : {}),
+  }, version)
+  await vault._getLedgerOrNull()?.append({
+    op: 'lifecycle', collection: '', id: '', version: 0, actor: approver, payloadHash: '',
+    reason: `user-withdrawal-approved:${requestId}:${req.requester}:${req.disposition}`,
+  })
+
+  return snapshot ? { bundle, snapshot } : { bundle }
+}
+
+export interface RejectWithdrawalOptions {
+  readonly reason?: string
+}
+
+/** Owner side. Decline a pending request (no data is touched). */
+export async function rejectWithdrawal(
+  vault: Vault,
+  requestId: string,
+  opts: RejectWithdrawalOptions = {},
+): Promise<WithdrawalRequest> {
+  const approver = assertApprover(vault)
+  const { req, version } = await readRequest(vault, requestId)
+  assertPending(req)
+  const decidedAt = new Date().toISOString()
+  const updated: WithdrawalRequest = {
+    ...req, status: 'rejected', decidedAt, decidedBy: approver,
+    ...(opts.reason ? { rejectReason: opts.reason } : {}),
+  }
+  await writeRequest(vault, updated, version)
+  await vault._getLedgerOrNull()?.append({
+    op: 'lifecycle', collection: '', id: '', version: 0, actor: approver, payloadHash: '',
+    reason: `user-withdrawal-rejected:${requestId}:${req.requester}`,
+  })
+  return updated
+}

--- a/packages/hub/src/bundle/withdraw-accessible.ts
+++ b/packages/hub/src/bundle/withdraw-accessible.ts
@@ -12,6 +12,9 @@
  *
  * Ordering guarantees no data loss: the client's re-keyed export bundle (and the
  * freeze snapshot) are produced BEFORE anything is deleted.
+ *
+ * The `freezeAndDeleteClosure` core is shared with the two-party approval path
+ * (#199 P3, `bundle/request-withdrawal.ts`).
  */
 import type { Vault } from '../vault.js'
 import { sha256Hex } from '../crypto.js'
@@ -19,10 +22,11 @@ import { ReadOnlyError } from '../errors.js'
 import { NOYDB_FORMAT_VERSION } from '../types.js'
 import { resolveAccessibleCollections, buildAccessibleBundle } from './export-accessible.js'
 
-const FROZEN_SNAPSHOTS_COLLECTION = '_frozen_snapshots'
+export const FROZEN_SNAPSHOTS_COLLECTION = '_frozen_snapshots'
 const ENC = new TextEncoder()
 
-function randomId(): string {
+/** 24-hex-char random id (used for withdrawal ids + request ids). */
+export function randomId(): string {
   const b = globalThis.crypto.getRandomValues(new Uint8Array(12))
   return Array.from(b, (x) => x.toString(16).padStart(2, '0')).join('')
 }
@@ -51,11 +55,71 @@ export interface WithdrawResult {
   readonly snapshot?: FrozenSnapshotRef
 }
 
+/**
+ * Dispose of the source records for `collections`: optionally freeze a
+ * write-once hash-pinned snapshot of the original ciphertext, then
+ * delete-closure the live records. Returns the snapshot ref on freeze.
+ *
+ * Caller MUST have produced the portable bundle FIRST — this is destructive.
+ * The delete is best-effort + idempotent (re-deleting an absent record is a
+ * no-op) and the snapshot put is write-once (CAS expectedVersion 0), so a
+ * crashed run re-run with the same `withdrawalId` is safe.
+ */
+export async function freezeAndDeleteClosure(
+  vault: Vault,
+  collections: readonly string[],
+  opts: { disposition: 'delete' | 'freeze'; actorUserId: string; withdrawalId?: string },
+): Promise<FrozenSnapshotRef | undefined> {
+  const { name: vaultName, adapter } = vault._introspectState()
+
+  // Enumerate the closure (record ids per collection).
+  const closure: Array<{ collection: string; id: string }> = []
+  for (const c of collections) {
+    for (const id of await adapter.list(vaultName, c)) closure.push({ collection: c, id })
+  }
+
+  // freeze: copy current envelopes into a write-once, hash-pinned snapshot
+  // (under the vault's own firm-owned DEKs — no re-key needed).
+  let snapshot: FrozenSnapshotRef | undefined
+  if (opts.disposition === 'freeze') {
+    const withdrawalId = opts.withdrawalId ?? `wd-${randomId()}`
+    const snap: Record<string, Record<string, unknown>> = {}
+    for (const { collection, id } of closure) {
+      const env = await adapter.get(vaultName, collection, id)
+      if (env) (snap[collection] ??= {})[id] = env
+    }
+    const frozenAt = new Date().toISOString()
+    const body = JSON.stringify({ withdrawalId, frozenAt, by: opts.actorUserId, collections: snap })
+    const sha = await sha256Hex(ENC.encode(body))
+    // Write-once: expectedVersion 0 rejects an overwrite (idempotent resume).
+    await adapter.put(
+      vaultName,
+      FROZEN_SNAPSHOTS_COLLECTION,
+      withdrawalId,
+      { _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: frozenAt, _iv: '', _data: body, _by: opts.actorUserId },
+      0,
+    )
+    // Hash-pin into the tamper-evident ledger — makes the snapshot provably unaltered.
+    await vault._getLedgerOrNull()?.append({
+      op: 'lifecycle', collection: '', id: '', version: 0, actor: opts.actorUserId, payloadHash: '',
+      reason: `withdrawal-frozen-snapshot:${withdrawalId}:${sha}`,
+    })
+    snapshot = { withdrawalId, sha256: sha, recordCount: closure.length, frozenAt }
+  }
+
+  // delete-closure — only after the snapshot is durable.
+  for (const { collection, id } of closure) {
+    await vault.collection(collection).delete(id)
+  }
+
+  return snapshot
+}
+
 export async function withdrawAccessibleData(
   vault: Vault,
   opts: WithdrawAccessibleOptions,
 ): Promise<WithdrawResult> {
-  const { name: vaultName, adapter, keyring } = vault._introspectState()
+  const { keyring } = vault._introspectState()
   const disposition = opts.disposition ?? 'delete'
 
   // Owner-class roles hold blanket authority — they use extractPartition.
@@ -83,45 +147,10 @@ export async function withdrawAccessibleData(
   // 1. Produce the client's re-keyed portable copy FIRST (nothing destroyed yet).
   const bundle = await buildAccessibleBundle(vault, collections, opts.reKey)
 
-  // Enumerate the closure (record ids per writable collection).
-  const closure: Array<{ collection: string; id: string }> = []
-  for (const c of collections) {
-    for (const id of await adapter.list(vaultName, c)) closure.push({ collection: c, id })
-  }
-
-  // 2. freeze: copy current envelopes into a write-once, hash-pinned snapshot
-  //    (under the vault's own firm-owned DEKs — no re-key needed).
-  let snapshot: FrozenSnapshotRef | undefined
-  if (disposition === 'freeze') {
-    const withdrawalId = opts.withdrawalId ?? `wd-${randomId()}`
-    const snap: Record<string, Record<string, unknown>> = {}
-    for (const { collection, id } of closure) {
-      const env = await adapter.get(vaultName, collection, id)
-      if (env) (snap[collection] ??= {})[id] = env
-    }
-    const frozenAt = new Date().toISOString()
-    const body = JSON.stringify({ withdrawalId, frozenAt, by: keyring.userId, collections: snap })
-    const sha = await sha256Hex(ENC.encode(body))
-    // Write-once: expectedVersion 0 rejects an overwrite (idempotent resume).
-    await adapter.put(
-      vaultName,
-      FROZEN_SNAPSHOTS_COLLECTION,
-      withdrawalId,
-      { _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: frozenAt, _iv: '', _data: body, _by: keyring.userId },
-      0,
-    )
-    // Hash-pin into the tamper-evident ledger — makes the snapshot provably unaltered.
-    await vault._getLedgerOrNull()?.append({
-      op: 'lifecycle', collection: '', id: '', version: 0, actor: keyring.userId, payloadHash: '',
-      reason: `withdrawal-frozen-snapshot:${withdrawalId}:${sha}`,
-    })
-    snapshot = { withdrawalId, sha256: sha, recordCount: closure.length, frozenAt }
-  }
-
-  // 3. delete-closure — only after the bundle + snapshot are durable.
-  for (const { collection, id } of closure) {
-    await vault.collection(collection).delete(id)
-  }
+  // 2. + 3. freeze (optional) then delete-closure.
+  const snapshot = await freezeAndDeleteClosure(vault, collections, {
+    disposition, actorUserId: keyring.userId, ...(opts.withdrawalId ? { withdrawalId: opts.withdrawalId } : {}),
+  })
 
   // 4. audit
   await vault._getLedgerOrNull()?.append({

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -362,6 +362,21 @@ export { exportAccessibleData } from './bundle/export-accessible.js'
 export type { ExportAccessibleOptions } from './bundle/export-accessible.js'
 export { withdrawAccessibleData } from './bundle/withdraw-accessible.js'
 export type { WithdrawAccessibleOptions, WithdrawResult, FrozenSnapshotRef } from './bundle/withdraw-accessible.js'
+export {
+  requestWithdrawal,
+  listWithdrawalRequests,
+  approveWithdrawal,
+  rejectWithdrawal,
+  WithdrawalRequestError,
+} from './bundle/request-withdrawal.js'
+export type {
+  RequestWithdrawalOptions,
+  RequestWithdrawalResult,
+  WithdrawalRequest,
+  WithdrawalRequestStatus,
+  ApproveWithdrawalOptions,
+  RejectWithdrawalOptions,
+} from './bundle/request-withdrawal.js'
 export type {
   NoydbBundleHeader,
   CompressionAlgo,

--- a/packages/hub/src/meta/user-envelope/api.ts
+++ b/packages/hub/src/meta/user-envelope/api.ts
@@ -31,6 +31,14 @@ import {
 import type { UserVisibility } from '../../directory/types.js'
 import type { ExportAccessibleOptions } from '../../bundle/export-accessible.js'
 import type { WithdrawAccessibleOptions, WithdrawResult } from '../../bundle/withdraw-accessible.js'
+import type {
+  RequestWithdrawalOptions,
+  RequestWithdrawalResult,
+  WithdrawalRequest,
+  WithdrawalRequestStatus,
+  ApproveWithdrawalOptions,
+  RejectWithdrawalOptions,
+} from '../../bundle/request-withdrawal.js'
 
 /**
  * Recursive partial. Used for `updateMe(patch)` so callers can hand in
@@ -81,7 +89,12 @@ export interface UserEnvelopePresented {
  * no-op stub is fine.
  */
 export type UserEnvelopeCheckGate = (
-  gate: 'edit-own-profile' | 'view-team-profiles' | 'client-unilateral-withdraw',
+  gate:
+    | 'edit-own-profile'
+    | 'view-team-profiles'
+    | 'client-unilateral-withdraw'
+    | 'user-request-withdrawal'
+    | 'approve-user-withdrawal',
   presented?: UserEnvelopePresented,
 ) => Promise<void>
 
@@ -133,7 +146,61 @@ export class UserApi {
      * Destructive — extract + dispose (delete | freeze). Omitted in low-level tests.
      */
     private readonly unilateralWithdraw?: (opts: WithdrawAccessibleOptions) => Promise<WithdrawResult>,
+    /**
+     * Noydb-backed two-party withdrawal ceremony (#199 P3), injected by the
+     * Vault. requestWithdraw = requester side; the rest = owner side.
+     */
+    private readonly requestWithdraw?: (opts: RequestWithdrawalOptions) => Promise<RequestWithdrawalResult>,
+    private readonly listWithdrawals?: (opts: { status?: WithdrawalRequestStatus }) => Promise<WithdrawalRequest[]>,
+    private readonly approveWithdraw?: (requestId: string, opts: ApproveWithdrawalOptions) => Promise<WithdrawResult>,
+    private readonly rejectWithdraw?: (requestId: string, opts: RejectWithdrawalOptions) => Promise<WithdrawalRequest>,
   ) {}
+
+  /**
+   * #199 P3 — file a two-party withdrawal request for the caller's accessible
+   * scope. Non-destructive (writes a pending request); an owner later approves
+   * or rejects. This is the path for read-only roles (`client`/`viewer`) that
+   * cannot self-serve a destructive `unilateralWithdrawal`. Gated by
+   * `user-request-withdrawal` (enabled by default).
+   */
+  async requestWithdrawal(opts: RequestWithdrawalOptions = {}): Promise<RequestWithdrawalResult> {
+    if (this.checkGate) await this.checkGate('user-request-withdrawal')
+    if (!this.requestWithdraw) {
+      throw new Error('requestWithdrawal requires a Noydb-backed vault (not a bare UserApi)')
+    }
+    return this.requestWithdraw(opts)
+  }
+
+  /** #199 P3 — owner side: list filed withdrawal requests (optionally by status). */
+  async listWithdrawalRequests(opts: { status?: WithdrawalRequestStatus } = {}): Promise<WithdrawalRequest[]> {
+    if (!this.listWithdrawals) {
+      throw new Error('listWithdrawalRequests requires a Noydb-backed vault (not a bare UserApi)')
+    }
+    return this.listWithdrawals(opts)
+  }
+
+  /**
+   * #199 P3 — owner side: approve a pending request. Extracts the requester's
+   * recorded scope under firm authority, disposes of the source per the
+   * request's disposition, and returns the re-keyed bundle to hand back. Gated
+   * by `approve-user-withdrawal` (tier-2 default) + owner/admin role.
+   */
+  async approveWithdrawal(requestId: string, opts: ApproveWithdrawalOptions = {}): Promise<WithdrawResult> {
+    if (this.checkGate) await this.checkGate('approve-user-withdrawal')
+    if (!this.approveWithdraw) {
+      throw new Error('approveWithdrawal requires a Noydb-backed vault (not a bare UserApi)')
+    }
+    return this.approveWithdraw(requestId, opts)
+  }
+
+  /** #199 P3 — owner side: reject a pending request (no data is touched). */
+  async rejectWithdrawal(requestId: string, opts: RejectWithdrawalOptions = {}): Promise<WithdrawalRequest> {
+    if (this.checkGate) await this.checkGate('approve-user-withdrawal')
+    if (!this.rejectWithdraw) {
+      throw new Error('rejectWithdrawal requires a Noydb-backed vault (not a bare UserApi)')
+    }
+    return this.rejectWithdraw(requestId, opts)
+  }
 
   /**
    * #199 P2 — single-party withdrawal: export the caller's accessible scope

--- a/packages/hub/src/policy/presets.ts
+++ b/packages/hub/src/policy/presets.ts
@@ -91,6 +91,11 @@ export const PERSONAL_POLICY: VaultPolicy = Object.freeze({
     // Listed explicitly (not just relying on the built-in default) so it is
     // discoverable in describeGate / policy dumps.
     'client-unilateral-withdraw': { minTier: 1, enabled: false },
+    // Two-party withdrawal (#199 P3): filing a request is non-destructive
+    // (tier-1, enabled so a read-only client can ask); deciding it is the
+    // destructive step (tier-2 floor + owner/admin role, enforced in code).
+    'user-request-withdrawal': { minTier: 1 },
+    'approve-user-withdrawal': { minTier: 2 },
   },
 }) as VaultPolicy
 
@@ -205,6 +210,14 @@ export const STRICT_POLICY: VaultPolicy = Object.freeze({
       minTier: 1,
       enabled: false,
       factors: [{ anyOf: ['totp', 'email-otp'], count: 2 }],
+      warn: { sharedDevice: 'block' },
+    },
+    // STRICT: filing stays tier-1; the destructive APPROVE demands an
+    // off-device factor + shared-device block (mirrors export-bundle).
+    'user-request-withdrawal': { minTier: 1 },
+    'approve-user-withdrawal': {
+      minTier: 2,
+      factors: [{ anyOf: ['totp', 'email-otp'] }],
       warn: { sharedDevice: 'block' },
     },
   },

--- a/packages/hub/src/policy/types.ts
+++ b/packages/hub/src/policy/types.ts
@@ -152,6 +152,19 @@ export type BuiltInGateName =
    * Hosts opt in explicitly (and typically pin `minTier`/factor proofs).
    */
   | 'client-unilateral-withdraw'
+  /**
+   * Authorize FILING a two-party withdrawal request —
+   * `vault.user.requestWithdrawal` (#199 P3). Non-destructive (writes a
+   * pending request only); enabled by default so a read-only client can ask.
+   */
+  | 'user-request-withdrawal'
+  /**
+   * Authorize DECIDING a two-party withdrawal request (approve/reject) —
+   * `vault.user.approveWithdrawal` / `rejectWithdrawal` (#199 P3). The approve
+   * path is destructive (extract-and-dispose under firm authority), so it
+   * defaults to a tier-2 floor; owner/admin role is enforced structurally.
+   */
+  | 'approve-user-withdrawal'
 
 /** Either a built-in gate name or an `app:*` custom gate. */
 export type GateName = BuiltInGateName | `app:${string}`

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -22,6 +22,7 @@ import type { OnDirtyCallback } from './collection.js'
 import type { UnlockedKeyring, BundleRecipient } from './team/keyring.js'
 import { exportAccessibleData } from './bundle/export-accessible.js'
 import { withdrawAccessibleData } from './bundle/withdraw-accessible.js'
+import { requestWithdrawal, listWithdrawalRequests, approveWithdrawal, rejectWithdrawal } from './bundle/request-withdrawal.js'
 import type { MaterializedViewRegistry } from './materialized-views/registry.js'
 import type { MaterializedViewStrategyHandle, MVQueryContext } from './materialized-views/types.js'
 import type { OverlayedViewRegistry } from './overlay-views/registry.js'
@@ -587,6 +588,10 @@ export class Vault {
       (gate, presented) => this.noydb.checkGate(this.name, gate, presented),
       (opts) => exportAccessibleData(this, opts),
       (opts) => withdrawAccessibleData(this, opts),
+      (opts) => requestWithdrawal(this, opts),
+      (opts) => listWithdrawalRequests(this, opts),
+      (requestId, opts) => approveWithdrawal(this, requestId, opts),
+      (requestId, opts) => rejectWithdrawal(this, requestId, opts),
     )
   }
 

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -534,7 +534,10 @@ const KERNEL_SURFACE_BUDGET = {
   // dict-label resolution) + skips the now-redundant dictionary snapshot.
   // Bumped 4495→4505 (2026-06-15, #412 P3): objectStore field + constructor
   // opt + thread into every Collection (mirrors blobStrategy).
-  'packages/hub/src/vault.ts': 4505,
+  // Bumped 4505→4510 (2026-06-16, #199 P3): four thin UserApi closures wiring
+  // the two-party withdrawal ceremony to the bundle subsystem (logic lives in
+  // bundle/request-withdrawal.ts; vault.ts only injects the closures).
+  'packages/hub/src/vault.ts': 4510,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),

--- a/showcases/src/120-client-portability-withdrawal.showcase.test.ts
+++ b/showcases/src/120-client-portability-withdrawal.showcase.test.ts
@@ -18,6 +18,11 @@
  *      regulated retention: the client departs with their copy; the firm holds
  *      an immutable, provably-unaltered point-in-time record.
  *
+ * And the two-party ceremony (P3) for read-only roles that CAN'T self-serve a
+ * deletion: `requestWithdrawal()` files a durable request; the owner reviews via
+ * `listWithdrawalRequests()` then `approveWithdrawal()` (extract-and-dispose
+ * under firm authority) or `rejectWithdrawal()`.
+ *
  * Why it matters
  * ──────────────
  * The cryptographic invariant: the caller holds the DEKs for their scope, so
@@ -112,5 +117,35 @@ describe('Showcase 120 — client portability + withdrawal', () => {
 
     // Live records removed.
     expect(await vault.collection<Invoice>('invoices').get('i1')).toBeNull()
+  })
+
+  it('two-party ceremony: a read-only client requests, the owner approves and erases under firm authority', async () => {
+    const store = memory()
+    // Owner seeds data and grants a READ-ONLY client.
+    const director = await createNoydb({ store, user: 'alice', secret: 'alice-director-2026' })
+    const ov = await director.openVault('firm')
+    await ov.collection<Invoice>('invoices').put('i1', { id: 'i1', total: 1000 })
+    await ov.collection<Invoice>('invoices').put('i2', { id: 'i2', total: 500 })
+    await director.grant('firm', {
+      userId: 'carla', displayName: 'Carla', role: 'client', passphrase: 'carla-client-2026',
+      permissions: { invoices: 'ro' }, // read-only — cannot self-serve a deletion
+    })
+    const client = await createNoydb({ store, user: 'carla', secret: 'carla-client-2026' })
+    const cv = await client.openVault('firm')
+
+    // 1. Read-only client FILES a request (non-destructive; enabled by default).
+    const { requestId, status } = await cv.user.requestWithdrawal({ legalBasis: 'gdpr-art-17' })
+    expect(status).toBe('pending')
+
+    // 2. Owner reviews the queue.
+    const pending = await ov.user.listWithdrawalRequests({ status: 'pending' })
+    expect(pending.map((r) => r.requestId)).toContain(requestId)
+
+    // 3. Owner APPROVES → bundle handed back, records erased under firm authority
+    //    (the client could not have deleted them itself).
+    const { bundle } = await ov.user.approveWithdrawal(requestId, { reKey: { passphrase: 'carla-takeaway' } })
+    const dump = JSON.parse((await readNoydbBundle(bundle)).dumpJson) as { collections?: Record<string, unknown> }
+    expect(Object.keys(dump.collections ?? {})).toContain('invoices')
+    expect(await ov.collection<Invoice>('invoices').get('i1')).toBeNull()
   })
 })


### PR DESCRIPTION
## #199 P3 — two-party withdrawal ceremony

Completes the #199 portability family (P1 #436 export, P2 #437 unilateral). This is the **conservative counterpart** for read-only `client`/`viewer` roles that *cannot* self-serve a destructive withdrawal: they file a request, an owner decides.

### API (all `vault.user.*`)
| Method | Side | Authority |
|---|---|---|
| `requestWithdrawal({scope?,disposition?,legalBasis?,expiresInMs?})` | requester | `user-request-withdrawal` (enabled, t1) |
| `listWithdrawalRequests({status?})` | owner | owner/admin |
| `approveWithdrawal(id,{reKey?})` → `{bundle, snapshot?}` | owner | `approve-user-withdrawal` (t2) **+ owner/admin** |
| `rejectWithdrawal(id,{reason?})` | owner | `approve-user-withdrawal` + owner/admin |

### Design points
- **Durable request** in `_user_withdrawal_requests`. Body is plaintext metadata (collection names + disposition + legal basis — none secret in this trust model; the owner sees the data anyway) and carries **no passphrase** — the re-key is supplied by the approver at approval time, out-of-band. Nothing secret stored at rest.
- The requester's **accessible** collections are resolved + recorded at request time, so the request is self-contained; the owner (blanket authority) executes the disposition on approval — the delete a read-only role couldn't do itself.
- `approveWithdrawal` **reuses the same `freezeAndDeleteClosure` primitive as P2** (extracted out of `withdraw-accessible.ts`), so the `delete`/`freeze` disposition the requester chose flows through end-to-end.
- approve/reject are **OCC + idempotent**: pending-only, expiry-checked, no double-decision.

### New built-in gates
`user-request-withdrawal` (enabled, t1) + `approve-user-withdrawal` (t2; STRICT adds an off-device factor + shared-device block). Added to both presets.

### Housekeeping
- `vault.ts` kernel ceiling 4505→4510 (four thin UserApi closures; logic lives in `bundle/request-withdrawal.ts`).
- Spec §5/§10 + resolved-questions §11 + subsystem doc + features.yaml `client-portability` invariants updated. Showcase 120 gains a two-party scenario.

### Tests
`packages/hub/__tests__/request-withdrawal.test.ts` (6): request→approve deletes under firm authority; freeze flows through; only owner/admin can decide; reject is non-destructive; no double-approve; expiry enforced. Full hub suite green (2710); features.yaml validates; arch OK.

**#199 epic complete** (P1 #436 / P2 #437 / P3 here).