### PR TITLE
klum-db/Lobby foundation: scaffold @klum-db/lobby + @noy-db/hub/kernel surface

### DIFF
--- a/docs/superpowers/plans/2026-06-16-klum-db-refactor-foundation.md
+++ b/docs/superpowers/plans/2026-06-16-klum-db-refactor-foundation.md
@@ -1,0 +1,564 @@
+# klum-db / Lobby Refactor Foundation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up the `@klum-db/lobby` package in the noy-db monorepo and expose a stable `@noy-db/hub/kernel` API — the foundation the federation extraction (separate plan) binds to.
+
+**Architecture:** `klum-db` is a separate brand/npm org that *orchestrates* noy-db vaults (Docker ↔ container). It is developed **inside the noy-db monorepo first** (publishing `@klum-db/*` from here) and graduates to its own repo once the boundary is proven. This plan does the two low-risk, high-leverage foundation pieces: (1) scaffold `@klum-db/lobby` with full build/test wiring under the `@klum-db` scope; (2) add a `@noy-db/hub/kernel` subpath that re-exports exactly the internal symbols federation needs (`readPath`, `reduceRecords`, `groupAndReduce`, `generateULID`, `sha256Hex`, the federation error classes, and the supporting types). The actual federation move is **out of scope** — see "Phase 3" at the end.
+
+**Tech Stack:** pnpm@9.15.4 workspaces · turbo · tsup (dual ESM-split + CJS) · vitest · TypeScript 5.7 (strict, `moduleResolution: bundler`, `.js` import specifiers).
+
+**Spec:** `docs/superpowers/specs/2026-06-16-lobby-framework-design.md` (§5 unit-tiering, §7 lexicon, §10 packaging, §11 phases).
+
+---
+
+## Scope & decomposition note
+
+This plan covers **spec §11 phases 1–2 only**. Phase 3 (extract `packages/hub/src/federation/` into `@klum-db/lobby`) is deliberately a **separate downstream plan** because its exact shape — inverting the `Noydb` private-state coupling (`vaultTemplates`, `closed`, `_shardVaultProvisioned`, `_resolveBackend`) and the dynamic `import('./federation/...')` integration — must be authored against the **kernel API that Task 3 below creates**. Authoring it now would require speculative placeholders. The "Phase 3 follow-up" section at the end specifies its scope concretely so it can become its own plan immediately after this one lands.
+
+Phases 1–2 produce working, independently-testable software: a wired, building, tested `@klum-db/lobby` package + a tested `@noy-db/hub/kernel` surface. Nothing in `hub`'s existing behaviour changes (Task 3 is purely additive).
+
+---
+
+## File structure
+
+**New package — `packages/lobby/` (`@klum-db/lobby`):**
+- `package.json` — manifest under `@klum-db` scope; peer-deps `@noy-db/hub`.
+- `tsconfig.json` — extends root base.
+- `tsup.config.ts` — dual ESM/CJS single-entry build.
+- `vitest.config.ts` — project config, name `lobby`.
+- `src/index.ts` — the `Lobby` core class + `createLobby` factory (minimal; federation entry lands in Phase 3).
+- `__tests__/lobby.test.ts` — wires `Lobby` over an in-memory `Noydb`.
+- `README.md`, `LICENSE`.
+
+**Modified — `packages/hub/` (additive only):**
+- `src/kernel/index.ts` — NEW barrel re-exporting the kernel surface.
+- `tsup.config.ts` — add `'kernel/index'` entry.
+- `package.json` — add `./kernel` subpath export.
+- `__tests__/kernel-surface.test.ts` — NEW test asserting the surface.
+
+---
+
+## PHASE 1 — Scaffold `@klum-db/lobby`
+
+### Task 1: Create the package manifest and tooling configs
+
+**Files:**
+- Create: `packages/lobby/package.json`
+- Create: `packages/lobby/tsconfig.json`
+- Create: `packages/lobby/tsup.config.ts`
+- Create: `packages/lobby/vitest.config.ts`
+- Create: `packages/lobby/README.md`
+- Create: `packages/lobby/LICENSE`
+
+- [ ] **Step 1: Create `packages/lobby/package.json`**
+
+```json
+{
+  "name": "@klum-db/lobby",
+  "version": "0.2.0-pre.23",
+  "description": "klum-db Lobby — orchestrates a group of sovereign noy-db vaults (federation, interchange, custody). The outward framework to noy-db's inward vault.",
+  "license": "MIT",
+  "author": "vLannaAi <vicio@lanna.ai>",
+  "homepage": "https://github.com/vLannaAi/noy-db/tree/main/packages/lobby#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vLannaAi/noy-db.git",
+    "directory": "packages/lobby"
+  },
+  "bugs": {
+    "url": "https://github.com/vLannaAi/noy-db/issues"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@noy-db/hub": "workspace:*"
+  },
+  "devDependencies": {
+    "@noy-db/hub": "workspace:*",
+    "@noy-db/to-memory": "workspace:*",
+    "@types/node": "^22.0.0"
+  },
+  "keywords": [
+    "klum-db",
+    "lobby",
+    "noy-db",
+    "federation",
+    "vault-orchestration",
+    "data-sovereignty",
+    "multi-vault"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  }
+}
+```
+
+- [ ] **Step 2: Create `packages/lobby/tsconfig.json`**
+
+```json
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}
+```
+
+- [ ] **Step 3: Create `packages/lobby/tsup.config.ts`**
+
+```typescript
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  target: 'es2022',
+})
+```
+
+- [ ] **Step 4: Create `packages/lobby/vitest.config.ts`**
+
+```typescript
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'lobby',
+    include: ['__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+})
+```
+
+- [ ] **Step 5: Create `packages/lobby/README.md`**
+
+```markdown
+# @klum-db/lobby
+
+> The **Lobby** — klum-db's outward framework that orchestrates a *group* of sovereign [noy-db](https://github.com/vLannaAi/noy-db) vaults: federation, interchange, and custody. A vault is the container; the Lobby is the orchestrator.
+
+Part of **klum-db** (Thai *klum* กลุ่ม, "group") — developed inside the noy-db monorepo while the kernel boundary stabilizes. See `docs/superpowers/specs/2026-06-16-lobby-framework-design.md`.
+
+```ts
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { createLobby } from '@klum-db/lobby'
+
+const db = await createNoydb({ store: memory(), user: 'alice', secret: '…' })
+const lobby = createLobby(db)
+```
+```
+
+- [ ] **Step 6: Create `packages/lobby/LICENSE`**
+
+Run: `cp packages/at-env/LICENSE packages/lobby/LICENSE`
+Expected: file copied (MIT license text, identical to other packages).
+
+- [ ] **Step 7: Install so pnpm links the new workspace package**
+
+Run: `pnpm install`
+Expected: completes without error; output mentions the new `@klum-db/lobby` workspace package. (`packages/*` is already a workspace glob, so no `pnpm-workspace.yaml` change is needed.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/lobby/package.json packages/lobby/tsconfig.json packages/lobby/tsup.config.ts packages/lobby/vitest.config.ts packages/lobby/README.md packages/lobby/LICENSE pnpm-lock.yaml
+git commit -m "feat(lobby): scaffold @klum-db/lobby package skeleton"
+```
+
+---
+
+### Task 2: Implement the `Lobby` core class (TDD)
+
+**Files:**
+- Create: `packages/lobby/__tests__/lobby.test.ts`
+- Create: `packages/lobby/src/index.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/lobby/__tests__/lobby.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { Lobby, createLobby } from '../src/index.js'
+
+describe('Lobby', () => {
+  it('wraps the Noydb instance whose vaults it orchestrates', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'correct-horse-battery-staple',
+    })
+    const lobby = createLobby(db)
+    expect(lobby).toBeInstanceOf(Lobby)
+    expect(lobby.noydb).toBe(db)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @klum-db/lobby test`
+Expected: FAIL — cannot resolve `../src/index.js` (file does not exist yet).
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `packages/lobby/src/index.ts`:
+
+```typescript
+/**
+ * **@klum-db/lobby** — the Lobby: klum-db's outward framework that
+ * orchestrates a *group* of sovereign noy-db vaults.
+ *
+ * A noy-db vault is a complete, sovereign unit (the container). The
+ * Lobby is what holds many of them side by side (the commons) and is
+ * the way in (the entrance) — federation, interchange, and custody.
+ *
+ * This is the foundation surface; federation entry points
+ * (`openVaultGroup`, `openStateManagementVault`) land when the
+ * federation subsystem is extracted from `@noy-db/hub` (Phase 3).
+ *
+ * @packageDocumentation
+ */
+
+import type { Noydb } from '@noy-db/hub'
+
+/**
+ * Orchestrates a group of sovereign noy-db vaults sharing one
+ * {@link Noydb} runtime (one store, one keyring root).
+ */
+export class Lobby {
+  /** The Noydb runtime whose vaults this Lobby orchestrates. */
+  readonly noydb: Noydb
+
+  constructor(noydb: Noydb) {
+    this.noydb = noydb
+  }
+}
+
+/** Create a {@link Lobby} over an existing {@link Noydb} runtime. */
+export function createLobby(noydb: Noydb): Lobby {
+  return new Lobby(noydb)
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @klum-db/lobby test`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Typecheck and build**
+
+Run: `pnpm --filter @klum-db/lobby typecheck && pnpm --filter @klum-db/lobby build`
+Expected: typecheck clean; build emits `packages/lobby/dist/index.js`, `index.cjs`, `index.d.ts`, `index.d.cts`.
+
+- [ ] **Step 6: Verify the monorepo architecture check accepts the new package**
+
+Run: `pnpm check:architecture`
+Expected: PASS. If it fails because `@klum-db/lobby` is an unknown package/scope, open `scripts/check-architecture.mjs`, find the package/family allowlist or layering map, and add `@klum-db/lobby` as a package that is **allowed to depend on `@noy-db/hub`** (klum → noy is the permitted direction; noy → klum must remain forbidden). Re-run until green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/lobby/src/index.ts packages/lobby/__tests__/lobby.test.ts
+# include scripts/check-architecture.mjs only if it was edited in Step 6
+git commit -m "feat(lobby): Lobby core class wrapping a Noydb runtime"
+```
+
+---
+
+## PHASE 2 — `@noy-db/hub/kernel` stable surface
+
+### Task 3: Create the kernel barrel and its test (TDD)
+
+**Files:**
+- Create: `packages/hub/__tests__/kernel-surface.test.ts`
+- Create: `packages/hub/src/kernel/index.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/hub/__tests__/kernel-surface.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import * as kernel from '../src/kernel/index.js'
+// Type-only smoke: fails to compile if any of these types stop being exported.
+import type {
+  ChangeEvent, Vault, Collection, Noydb, Operator, Query, JoinStrategy,
+  LiveQuery, AggregateResult, AggregateSpec, LiveAggregation, IndexDef,
+} from '../src/kernel/index.js'
+
+describe('@noy-db/hub/kernel surface', () => {
+  it('exposes the runtime kernel functions federation needs', () => {
+    expect(typeof kernel.readPath).toBe('function')
+    expect(typeof kernel.reduceRecords).toBe('function')
+    expect(typeof kernel.groupAndReduce).toBe('function')
+    expect(typeof kernel.generateULID).toBe('function')
+    expect(typeof kernel.sha256Hex).toBe('function')
+  })
+
+  it('exposes the federation error classes', () => {
+    const names = [
+      'CrossShardJoinError', 'DataResidencyError', 'ReservedVaultNameError',
+      'ShardProvisioningError', 'UnknownShardError', 'ValidationError',
+      'VaultTemplateNotFoundError',
+    ] as const
+    for (const n of names) {
+      expect(typeof (kernel as Record<string, unknown>)[n]).toBe('function')
+    }
+  })
+
+  it('generateULID returns a 26-char Crockford ULID', () => {
+    expect(kernel.generateULID()).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/)
+  })
+})
+
+// Compile-time assertion that the type surface is present (no runtime cost).
+type _TypeSurface = [
+  ChangeEvent, Vault, Collection, Noydb, Operator, Query, JoinStrategy,
+  LiveQuery, AggregateResult, AggregateSpec, LiveAggregation, IndexDef,
+]
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm --filter @noy-db/hub test -- kernel-surface`
+Expected: FAIL — cannot resolve `../src/kernel/index.js` (does not exist yet).
+
+- [ ] **Step 3: Create the kernel barrel**
+
+Create `packages/hub/src/kernel/index.ts`:
+
+```typescript
+/**
+ * **@noy-db/hub/kernel** — the stable internal surface that outward
+ * frameworks (klum-db / Lobby) bind to *instead of* reaching into hub
+ * internals via relative paths.
+ *
+ * This is the "kernel-surface extraction" (spec §10): the minimal set
+ * of runtime helpers, error classes, and types the federation /
+ * orchestration layer needs from the vault core. Treat it as a
+ * contract — additive changes only; removals are breaking.
+ *
+ * @packageDocumentation
+ */
+
+// ─── runtime helpers ──────────────────────────────────────────────
+export { readPath } from '../query/predicate.js'
+export { reduceRecords } from '../aggregate/aggregation.js'
+export { groupAndReduce } from '../aggregate/groupby.js'
+export { generateULID } from '../bundle/ulid.js'
+export { sha256Hex } from '../crypto.js'
+
+// ─── error classes ────────────────────────────────────────────────
+export {
+  CrossShardJoinError,
+  DataResidencyError,
+  ReservedVaultNameError,
+  ShardProvisioningError,
+  UnknownShardError,
+  ValidationError,
+  VaultTemplateNotFoundError,
+} from '../errors.js'
+
+// ─── types ────────────────────────────────────────────────────────
+export type { ChangeEvent } from '../types.js'
+export type { Vault } from '../vault.js'
+export type { Collection } from '../collection.js'
+export type { Noydb } from '../noydb.js'
+export type { Operator } from '../query/predicate.js'
+export type { Query } from '../query/builder.js'
+export type { JoinStrategy } from '../query/join.js'
+export type { LiveQuery } from '../query/live.js'
+export type {
+  AggregateResult,
+  AggregateSpec,
+  LiveAggregation,
+} from '../aggregate/aggregation.js'
+export type { IndexDef } from '../indexing/eager-indexes.js'
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm --filter @noy-db/hub test -- kernel-surface`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/kernel/index.ts packages/hub/__tests__/kernel-surface.test.ts
+git commit -m "feat(hub): add @noy-db/hub/kernel stable internal surface"
+```
+
+---
+
+### Task 4: Publish the `./kernel` subpath (build wiring)
+
+**Files:**
+- Modify: `packages/hub/tsup.config.ts:51` (add to `ENTRIES`)
+- Modify: `packages/hub/package.json:269-278` (add `./kernel` export after `./attestation`)
+
+- [ ] **Step 1: Add the tsup entry**
+
+In `packages/hub/tsup.config.ts`, inside the `ENTRIES` object, add this line immediately after `'attestation/index': 'src/attestation/index.ts',`:
+
+```typescript
+  'kernel/index': 'src/kernel/index.ts',
+```
+
+- [ ] **Step 2: Add the package export**
+
+In `packages/hub/package.json`, in the `"exports"` map, add this block immediately after the `"./attestation": { … }` block (after the closing `}` on line 278, before the `}` that closes `"exports"`):
+
+```json
+    ,"./kernel": {
+      "import": {
+        "types": "./dist/kernel/index.d.ts",
+        "default": "./dist/kernel/index.js"
+      },
+      "require": {
+        "types": "./dist/kernel/index.d.cts",
+        "default": "./dist/kernel/index.cjs"
+      }
+    }
+```
+
+(If you prefer trailing-comma-free JSON: put the comma after the `./attestation` block's closing brace instead and drop the leading comma above — the result must be valid JSON. Verify with `node -e "require('./packages/hub/package.json')"`.)
+
+- [ ] **Step 3: Build hub and verify the subpath artifacts exist**
+
+Run: `pnpm --filter @noy-db/hub build`
+Expected: build succeeds; then:
+
+Run: `ls packages/hub/dist/kernel/`
+Expected: lists `index.js`, `index.cjs`, `index.d.ts`, `index.d.cts`.
+
+- [ ] **Step 4: Verify the subpath resolves as a real package export**
+
+Run: `node --input-type=module -e "import('@noy-db/hub/kernel').then(m => { if (typeof m.generateULID !== 'function') throw new Error('kernel subpath broken'); console.log('kernel subpath OK:', m.generateULID().length) })"`
+Expected: prints `kernel subpath OK: 26`. (Resolves the built `@noy-db/hub/kernel` via the workspace symlink + the new export map.)
+
+- [ ] **Step 5: Confirm nothing else regressed**
+
+Run: `pnpm --filter @noy-db/hub test`
+Expected: PASS (full hub suite, including the new kernel-surface test). Then:
+
+Run: `pnpm --filter @noy-db/hub bundle-check`
+Expected: PASS or the pre-existing baseline drift only (per `project_bundle_baseline_stale` — judge by leak canaries, not headline gz; the new `kernel` subpath must not pull federation/orchestration code into the main bundle).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/tsup.config.ts packages/hub/package.json
+git commit -m "feat(hub): export ./kernel subpath (dual ESM/CJS)"
+```
+
+---
+
+### Task 5: Point `@klum-db/lobby` at the kernel (proves the boundary)
+
+**Files:**
+- Modify: `packages/lobby/package.json` (add `@noy-db/hub/kernel` usage is via the existing `@noy-db/hub` dep — no manifest change needed)
+- Modify: `packages/lobby/__tests__/lobby.test.ts` (add a kernel-consumption test)
+
+- [ ] **Step 1: Write a failing test that consumes the kernel from Lobby's side**
+
+Append to `packages/lobby/__tests__/lobby.test.ts`:
+
+```typescript
+import { generateULID } from '@noy-db/hub/kernel'
+
+describe('kernel boundary', () => {
+  it('Lobby can consume the @noy-db/hub/kernel surface', () => {
+    const id = generateULID()
+    expect(id).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/)
+  })
+})
+```
+
+- [ ] **Step 2: Run it to verify it passes (kernel was built in Task 4)**
+
+Run: `pnpm --filter @klum-db/lobby test`
+Expected: PASS (2 describe blocks). This proves `@klum-db/lobby` resolves and consumes the stable kernel surface across the package boundary — the exact channel Phase 3's federation code will use.
+
+- [ ] **Step 3: Full-monorepo green check**
+
+Run: `pnpm build && pnpm test`
+Expected: turbo builds all packages and the full suite passes. (Confirms the new package + subpath integrate with the existing pipeline.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/lobby/__tests__/lobby.test.ts
+git commit -m "test(lobby): consume @noy-db/hub/kernel across the package boundary"
+```
+
+---
+
+## PHASE 3 — Federation extraction (SEPARATE follow-up plan)
+
+**Not part of this plan's checklist.** Author this as its own plan (`docs/superpowers/plans/<date>-klum-db-federation-extraction.md`) once Phases 1–2 land, because its precise steps depend on the kernel API created above and on inverting `Noydb` private-state coupling. Concrete scope for that plan:
+
+1. **Extend the kernel** with the inversion hooks federation entry points need from `Noydb`: a stable way to read `closed` state and call `_shardVaultProvisioned` / `_resolveBackend`. Move the **vault-template registry** (`withVaultTemplate` / `vaultTemplates`) out of `Noydb` into the `Lobby` (templates are a federation concern).
+2. **Relocate `STATE_VAULT_NAME`** from `packages/hub/src/federation/constants.ts` to a hub-core file (`packages/hub/src/constants.ts`); update `noydb.ts:25` and `index.ts:348` imports. The reserved-name guard (`noydb.ts:1106`) stays in hub.
+3. **Move** `packages/hub/src/federation/*` (10 files: `vault-group`, `aggregate-across`, `cross-shard-join`, `cross-vault-live`, `state-vault`, `schema-manifest`, `classify-skip`, `types`, `index`, `constants`-minus-STATE_VAULT_NAME) into `packages/lobby/src/federation/`, rewriting every `../X.js` hub-internal import to `@noy-db/hub/kernel` (per the kernel map) and `Noydb`/`Vault`/`Collection` to `@noy-db/hub`.
+4. **Implement Lobby entry points** (`Lobby.withVaultTemplate`, `Lobby.openVaultGroup`, `Lobby.openStateManagementVault`) in klum-db, lifting the logic from `noydb.ts:1095–1148`, reading templates from the Lobby instead of `db.vaultTemplates`.
+5. **Deprecation shims in hub:** replace `Noydb.openVaultGroup` / `openStateManagementVault` / `withVaultTemplate` bodies with a new `FederationMovedError` (added to `errors.ts`) + one-time `console.warn`, pointing to `@klum-db/lobby`. (Pre-1.0 throwing shim — no `hub → klum` dependency, preserving the acyclic architecture.) Remove the federation type re-exports from `index.ts:318–347`; they move to `@klum-db/lobby`'s public API.
+6. **Migrate tests:** move the 7 `packages/hub/__tests__/federation-*.test.ts` to `packages/lobby/__tests__/`, rewriting them to the Lobby API.
+7. **Update showcases** 98, 99, 100, 108, 109, 110 in `showcases/src/` to import from `@klum-db/lobby`.
+8. **Verify** `pnpm check:architecture` (noy → klum must remain forbidden; klum → noy allowed), full `pnpm build && pnpm test`, and `bundle-check` (hub core shrinks; federation chunk gone).
+
+---
+
+## Self-Review
+
+**1. Spec coverage (§11 phases 1–2):**
+- §11.1 "Establish Lobby package skeleton + unit-driver contract" → Tasks 1–2 establish the package + `Lobby` class. (Unit-driver *contract* is deferred with Phase 3/§5 — the foundation only needs the package + core class; noted, not silently dropped.)
+- §11.2 "Kernel-surface extraction — stable internal vault API" → Tasks 3–4 (`@noy-db/hub/kernel`) + Task 5 proves cross-boundary consumption.
+- §11.3+ (federation move) → explicitly scoped to the Phase 3 follow-up plan.
+
+**2. Placeholder scan:** No "TBD/TODO/handle errors" in executable steps. Every code step shows complete file contents or the exact lines to insert. The Phase 3 section is labelled non-executable design, not a placeholder in the checklist.
+
+**3. Type/name consistency:** `Lobby` / `createLobby` used identically in Tasks 1, 2, 5. Kernel symbol names (`readPath`, `reduceRecords`, `groupAndReduce`, `generateULID`, `sha256Hex`, the 7 error classes, the 12 types) match the verified hub source. `@noy-db/hub/kernel` path is consistent across the barrel, the export map, the tsup entry, and both consuming tests. Package name `@klum-db/lobby` and dir `packages/lobby` consistent throughout.
+
+**4. Known environmental caveats baked in:** zsh word-splitting avoided (no unquoted list vars in commands); `bundle-check` baseline-drift expectation noted; architecture-check allowlist update flagged as a conditional step; no publish steps (publishing is gated on explicit confirmation, out of scope here).

--- a/docs/superpowers/specs/2026-06-16-lobby-framework-design.md
+++ b/docs/superpowers/specs/2026-06-16-lobby-framework-design.md
@@ -5,6 +5,7 @@
 **Author:** brainstormed with vLannaAi
 **Drives:** pilot-1 epic #440 (FR-1…FR-9, #441–449) and the re-homing of federation #271.
 **Supersedes framing of:** the milestone-organization sketch for #440 (see "Pilot-1 → Lobby map" below).
+**Decisions locked 2026-06-16:** brand = `klum-db`; npm org = `@klum-db/*` (created); core class = `Lobby`; repo split staged (monorepo-first, graduate later). GitHub issues now carry `noy` / `klum` labels.
 
 ---
 
@@ -146,11 +147,13 @@ The outward ecosystem already **exists inside `hub`** and is the **seed of Lobby
 
 So Lobby v0 is: **(re-homed federation) + (new pilot-1 interchange/custody)**, packaged as one coherent outward framework.
 
+**Migration cost:** federation already shipped *inside* `hub` (#271, `hub/src/federation/` — `vault-group.ts`, `cross-shard-join.ts`, `aggregate-across.ts`). Moving it to `@klum-db/*` is a **breaking change** for current federation users — it needs either a deprecation shim re-exporting from `hub` for one minor, or a clean major-bump migration note. The new pilot-1 FRs are net-new, so they start fresh in klum-db at zero cost.
+
 ---
 
 ## 10. Packaging & the enabler
 
-- **Lobby** ships as its own framework/scope, depending on `@noy-db/hub`. (Exact npm scope is an open question — `@noy-db/lobby*` vs a distinct brand scope — see §12.)
+- **Lobby** ships under its **own brand and npm org — `klum-db` / `@klum-db/*`** (org reserved 2026-06-16), depending on `@noy-db/hub`. The brand is **klum-db** (Thai *klum* กลุ่ม, "group" — a loose side-by-side group, deliberately *not* "cluster"); the core class is **Lobby**. Same relationship as Docker (brand) ↔ container (concept).
 - **Unit-driver family** at the Lobby layer expresses §5's tiering (noy-db vault = flagship; sqlite/duckdb = shallow on-ramp drivers).
 - **Inward subsystems are not changed by this spec.** Extracting computed/money/i18n/etc. from `hub` source is a *separate* effort gated on the **kernel-surface extraction** (a small, stable internal core API — long deferred; see CEK epic notes). That extraction is also what lets Lobby attach to a **stable vault API** instead of `hub` internals. It is the real enabler and should be sequenced first for any deep outward feature.
 
@@ -172,7 +175,7 @@ Each phase is its own spec → plan → implementation cycle. This document is t
 
 ## 12. Open questions
 
-- **npm scope/brand for Lobby** — `@noy-db/lobby` (one ecosystem, clear lineage) vs a distinct brand (stronger Docker:container separation). Leaning `@noy-db/lobby` for discoverability.
+- ~~npm scope/brand for Lobby~~ **DECIDED 2026-06-16:** separate brand **klum-db**, separate npm org **`@klum-db/*`** (created). **Repo split staged** — develop in the noy-db monorepo (publishing `@klum-db/*` from here) while the kernel-surface boundary stabilizes, then graduate to a separate repository at §11 step 7 once the boundary is proven.
 - **Deed mechanism** — sealed-owner credential as an extension of `#197` sealed-passphrase (unlock) into **ownership establishment**; exact key-topology TBD in the FR-6 spec.
 - **Pool authority defaults** — does the Pool ship a default Authority policy, or is it always app-supplied (Insight-Vault-style engine-vs-policy split)? Leaning app-supplied.
 - **Foreign-unit graduation** — is "dock sqlite → graduate to vault" a Lobby command or a one-off Relocate? Likely a Lobby `graduate()` built on Migrate + Adopt.

--- a/docs/superpowers/specs/2026-06-16-lobby-framework-design.md
+++ b/docs/superpowers/specs/2026-06-16-lobby-framework-design.md
@@ -1,0 +1,179 @@
+# Lobby — the framework for a world of vaults
+
+**Status:** Design / positioning spec (north-star). Not an implementation plan.
+**Date:** 2026-06-16
+**Author:** brainstormed with vLannaAi
+**Drives:** pilot-1 epic #440 (FR-1…FR-9, #441–449) and the re-homing of federation #271.
+**Supersedes framing of:** the milestone-organization sketch for #440 (see "Pilot-1 → Lobby map" below).
+
+---
+
+## 1. What this is (and is not)
+
+This is **not** a product re-positioning. noy-db's pitch — *your data, your device, your keys, nobody's server* — is unchanged. This is an **internal organization re-centering**: as noy-db has grown, many dimensions have accreted **inside the core** (`@noy-db/hub`), repeatedly raising the kernel ceilings (`vault.ts`, `collection.ts`). The versatility developers love is winning; **ease of use and maintainability** are paying for it.
+
+The goal: a crisp structural axis so new growth lands in the right place instead of swelling the core — while preserving both **versatility** and the **essential ease of use** that the prefix-family convention (`to-/in-/on-/as-/by-/at-*`) created.
+
+**Non-goals:** re-branding the product; turning vaults into a cluster; joining/merging vaults for aggregate value; changing the single-vault developer experience.
+
+---
+
+## 2. The organizing axis: inward vs outward
+
+The right axis is **not** `core / subsystem / adapter / family` flattened together — it is **inward vs outward**, with the existing tiers living *inside* the inward half.
+
+### Inward — the vault, = **noy-db**
+`hub/` looks **into** the vault to make it versatile and powerful. **A vault + a store is already a complete, shippable system** — and that is all most of the audience needs.
+
+Inward tiers (definitions locked during design):
+
+- **Core** — the kernel: `vault`, `collection`, keyring/roles, query DSL, envelope/crypto, the store contract.
+- **Subsystem** — a **tree-shakeable arm of the core that extends it**. Reach varies: *leaf* (computed/derivation, money — use it or tree-shake it) vs *deeper* arms. Inward subsystems today: computed/derivation, money, i18n, full-text search, snapshots, history/audit ledger. (Their clean extraction from `hub` source is gated on the **kernel-surface extraction** — see §10.)
+- **Adapter** — a concrete solution **orchestrated per recipe**.
+- **Family of adapters** — a **clear contract that solves a dimension's existential challenge**, exposing a **menu of interchangeable solutions** under one contract. You open the door (`to-`) and see alternatives with different performance / cost / durability / lifecycle (record store, vault store, CAS vs non-CAS needing serialization…), all interchangeable. The current doors are all **two-letter prepositions**: `to · in · on · as · by · at`.
+
+### The edge
+`as-*` (export — leaving the vault) and the rest of the families (`to/on/by/at/in`) are the vault talking to the outside world.
+
+### Outward — the world of vaults, = **Lobby** (new)
+Beyond the vault lies an ecosystem that **orchestrates many vaults**: federation, interchange/portability, sovereignty/custody, sealing-at-scale, revocation, migration, erasure.
+
+**Crucial finding:** these are **not** a family. A family is *horizontal* — one door, N interchangeable solutions, same focus. These are *vertical* — **one orchestration path with accreting capability**. They don't belong behind a door; they belong **outside the vault**, in their own framework.
+
+---
+
+## 3. Two frameworks: the vault and the world of vaults
+
+> **A noy-db vault is the container. Lobby is Docker.**
+> A container runs perfectly alone; the engine orchestrates many — their lifecycle, identity, custody, and exchange.
+
+- **noy-db** stays the clean, inward **vault** framework. `@noy-db/hub` + inward subsystems + edge adapter families.
+- **Lobby** is a **separate framework** that **hosts vaults**. It **depends on** noy-db, ships on its own cadence, and serves a **different audience**: the *actor* who operates many vaults (the firm, the clinic, the bank, the insurer), not the individual with one.
+
+This separation is the mechanism that **structurally protects** noy-db's inward simplicity: outward complexity cannot leak back into the core because it lives in a different framework.
+
+---
+
+## 4. What the Lobby is
+
+A **Lobby** has a **dual function**, both captured by the word:
+
+1. **The commons** — many vaults sitting **side by side**, federated. **Non-aggregative**: the value is *not* from joining them. The vaults are **independent**; putting them together creates no added value through merge — which is exactly why **federation** (clean) is the right model and **cluster** (implies merged compute/data) is the wrong one. We place vaults side by side; we do not join them.
+2. **The entrance** — the **main door** you pass through to reach a vault, **even a single one** (a single client). The Lobby is the way *in*.
+
+**Loose coupling is a first-class property.** A vault can be **relocated** to a different environment, run by a **different app**, and remain **interoperable** with noy-db vault data. Vaults are portable and sovereign; they are *guests* of a Lobby, not parts of it.
+
+---
+
+## 5. Unit tiering — what docks in the Lobby
+
+Decision: **dock anything; sovereign features for vaults** (tiered).
+
+- The Lobby can carry **any** DB unit (a sqlite file, a duckdb, …) as a **shallow on-ramp** — import, sync, adopt. *(A harbor docks any vessel.)*
+- The **deep features** — custody, sealing, **Authority** merge, crypto-shred **Forget**, revocation — **require a noy-db vault**, because they need its keyring, per-record CEK, and consent primitives. A raw sqlite file can be carried and synced but cannot be cryptographically forgotten or carry per-field authority.
+- This yields a **migration story**: *dock a legacy unit → graduate it into a vault* to unlock the sovereign tier.
+
+Implication: **"which unit you dock" is itself a family-with-a-menu — at the Lobby layer** (a *unit-driver* family; the noy-db vault is the flagship vessel). The family pattern that didn't fit the orchestration capabilities reappears, correctly, at the docking boundary.
+
+---
+
+## 6. The metaphor & why "vault" already held the surprise
+
+`vault` ← Old French *voûte* ← Vulgar Latin *volta* ← Latin **volvere**, "to roll / to turn." The **original** sense is the **arch** — the springing curve; the *strong room* came later, **because** arched ceilings made strong rooms possible; the *treasury* function came later still. The same root gives **vault = to leap** (pole-vault). So a vault both **spans** and **leaps** — fitting for data that arcs across parties.
+
+> **The shape created the room; the room created the function.**
+
+The orchestrator name **Lobby** was chosen (over *cloister*, *atrium*, *aqueduct*, maritime *wharf/quay*) because it is **instantly understood by everyone** and uniquely names **both** Lobby functions — the commons *and* the entrance — keeping the README effective in the first 20 seconds, with the vault=arch etymology held in reserve as the brand's depth.
+
+---
+
+## 7. The lexicon
+
+**Spine:** `Lobby ⊃ Vault ⊃ Collection ⊃ Record ⊃ Field`
+
+### New — Lobby layer
+| Term | Meaning |
+|---|---|
+| **Lobby** | The outward framework: entrance + federation commons. Hosts vaults. (the one big coinage) |
+| **Pool** | A shared vault of common entities (companies, people) that many vaults **reference** by FK. Shared, unowned, long-lived. *(replaces the rejected "directory")* |
+| **Relocate** | Move a whole vault to another environment/app (extract + re-key + leave). The headline portability act. |
+| **Liberate** | Claim ownership of an **abandoned sealed-owner vault** — the inverse of **Withdraw**. |
+| **Deed** | The **inalienable ownership root** (sealed/hidden-owner credential). Owning ≠ operating. |
+| **Custodian** | Holder of a **100%-operational but non-owning grant** — cannot revoke / re-key / relocate / grant. The agent/firm. |
+
+### New — merge/sync attributes (pilot-1)
+| Term | Meaning |
+|---|---|
+| **Surface** | An agreed subset (collections / fields / direction / cadence) two parties sync. (FR-7) |
+| **Authority** | Which party owns a given **field** on merge (per-field, not per-record). (FR-4) |
+| **Provenance** | `_source` / `_sourceTs` lineage — who last wrote each field. (FR-5) |
+| **ConflictStrategy** | take-incoming / keep-local / lww / field-authority / manual. (FR-3) |
+
+### Established — keep as-is
+`Bundle` · `Compartment` · `Manifest` · `Partition` · `Snapshot` · `Keyring` · `Grant` · `Role` (owner/admin/operator/viewer/client) · `Store` · `Schema/Version` · `Ledger` · `Federation` · `Shard` · `Insight` · verbs `Extract · Adopt · Merge · Migrate · Sync · Withdraw · Forget`.
+
+**Reads in a sentence:** *"A firm is a **Custodian** in the **Lobby**: it holds operating grants to client **Vaults** that all reference one shared **Pool**. The client holds the **Deed**. To onboard, the firm **Relocates** a client's vault as a **Bundle**, **Migrates** it to the current schema, and **Merges** the Pool slice by field **Authority** using **Provenance**. The client can **Withdraw** anytime; an abandoned vault can be **Liberated**."*
+
+---
+
+## 8. Pilot-1 → Lobby map (epic #440)
+
+The 9 FRs are no longer homeless "deltas to slot into milestones" — each is a Lobby capability:
+
+| FR | # | Lobby capability | Lexicon |
+|----|---|------------------|---------|
+| FR-1 | 441 | Multi-compartment **Bundle** + pre-decrypt **Manifest** | Bundle/Compartment/Manifest |
+| FR-2 | 442 | Cross-vault FK-closure **Extract** → multi-compartment Bundle | Relocate/Extract/Partition |
+| FR-3 | 443 | **Merge** into an existing vault | Merge/ConflictStrategy |
+| FR-4 | 444 | Field-**Authority** resolver | Authority |
+| FR-5 | 445 | **Provenance** (`_source`/`_sourceTs`) | Provenance |
+| FR-6 | 446 | **Deed** + **Custodian** + **Liberate** (sovereign custody) | Deed/Custodian/Liberate |
+| FR-7 | 447 | Scoped sync **Surface** | Surface |
+| FR-8 | 448 | **Migrate**-then-Merge (upgrade incoming before reconcile) | Migrate |
+| FR-9 | 449 | Multi-compartment export reading the **Pool** | (edge: `as-xlsx`) |
+
+Dependency spine (unchanged from the analysis): FR-1 → {FR-2, FR-3}; FR-5 → FR-4; FR-8 wraps FR-3/4; FR-9 reuses FR-2's FK descriptors; FR-6 is independent (custody topology). FR-9 stays at the **edge** (`as-xlsx`) — it reads across vaults but is an export, not orchestration.
+
+---
+
+## 9. Lobby is partly a re-homing, not all-new
+
+The outward ecosystem already **exists inside `hub`** and is the **seed of Lobby**:
+
+- **Federation #271** — VaultGroup, `withSharding`/routing, crossShardJoin, **Insight** Vault, StateManagement Vault — is outward by nature and a prime candidate to **migrate into Lobby**.
+- Single-vault portability/withdrawal (#198/#199/#348, SyncEngine, `diffVault`) are the **inward primitives** Lobby's interchange capabilities build on.
+- The `at-*` sealing family is the existing **second trust boundary**; Lobby's custody features compose with it, they don't replace it.
+
+So Lobby v0 is: **(re-homed federation) + (new pilot-1 interchange/custody)**, packaged as one coherent outward framework.
+
+---
+
+## 10. Packaging & the enabler
+
+- **Lobby** ships as its own framework/scope, depending on `@noy-db/hub`. (Exact npm scope is an open question — `@noy-db/lobby*` vs a distinct brand scope — see §12.)
+- **Unit-driver family** at the Lobby layer expresses §5's tiering (noy-db vault = flagship; sqlite/duckdb = shallow on-ramp drivers).
+- **Inward subsystems are not changed by this spec.** Extracting computed/money/i18n/etc. from `hub` source is a *separate* effort gated on the **kernel-surface extraction** (a small, stable internal core API — long deferred; see CEK epic notes). That extraction is also what lets Lobby attach to a **stable vault API** instead of `hub` internals. It is the real enabler and should be sequenced first for any deep outward feature.
+
+---
+
+## 11. Phased path (north-star → first steps)
+
+1. **Establish Lobby** as a package skeleton depending on `hub`; define the **unit-driver** contract (vault flagship; passthrough driver for foreign units).
+2. **Kernel-surface extraction** — the stable internal vault API Lobby binds to (enabler; also unblocks inward subsystem extraction later).
+3. **Interchange core (FR-1/2/3 + FR-8)** — Bundle/Compartment/Manifest, cross-vault Extract/Relocate, Merge, Migrate-then-Merge.
+4. **Correct merge (FR-5 → FR-4)** — Provenance, then field Authority.
+5. **Custody (FR-6)** — Deed/Custodian/Liberate (parallel; independent).
+6. **Mesh + Pool (FR-7, Pool, FR-9 edge)** — Surface sync; the Pool reference vault; multi-compartment export.
+7. **Re-home federation #271** into Lobby once the boundary is proven.
+
+Each phase is its own spec → plan → implementation cycle. This document is the shared frame they all reference.
+
+---
+
+## 12. Open questions
+
+- **npm scope/brand for Lobby** — `@noy-db/lobby` (one ecosystem, clear lineage) vs a distinct brand (stronger Docker:container separation). Leaning `@noy-db/lobby` for discoverability.
+- **Deed mechanism** — sealed-owner credential as an extension of `#197` sealed-passphrase (unlock) into **ownership establishment**; exact key-topology TBD in the FR-6 spec.
+- **Pool authority defaults** — does the Pool ship a default Authority policy, or is it always app-supplied (Insight-Vault-style engine-vs-policy split)? Leaning app-supplied.
+- **Foreign-unit graduation** — is "dock sqlite → graduate to vault" a Lobby command or a one-off Relocate? Likely a Lobby `graduate()` built on Migrate + Adopt.
+- **Kernel-surface extraction scope** — minimum stable API Lobby needs vs the full inward-subsystem extraction (do the minimum first).

--- a/packages/hub/__tests__/kernel-surface.test.ts
+++ b/packages/hub/__tests__/kernel-surface.test.ts
@@ -17,9 +17,9 @@ describe('@noy-db/hub/kernel surface', () => {
 
   it('exposes the federation error classes', () => {
     const names = [
-      'CrossShardJoinError', 'DataResidencyError', 'ReservedVaultNameError',
-      'ShardProvisioningError', 'UnknownShardError', 'ValidationError',
-      'VaultTemplateNotFoundError',
+      'CrossShardJoinError', 'DataResidencyError', 'NoAccessError',
+      'ReservedVaultNameError', 'ShardProvisioningError', 'UnknownShardError',
+      'ValidationError', 'VaultTemplateNotFoundError',
     ] as const
     for (const n of names) {
       expect(typeof (kernel as Record<string, unknown>)[n]).toBe('function')

--- a/packages/hub/__tests__/kernel-surface.test.ts
+++ b/packages/hub/__tests__/kernel-surface.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import * as kernel from '../src/kernel/index.js'
+// Type-only smoke: fails to compile if any of these types stop being exported.
+import type {
+  ChangeEvent, Vault, Collection, Noydb, Operator, Query, JoinStrategy,
+  LiveQuery, AggregateResult, AggregateSpec, LiveAggregation, IndexDef,
+} from '../src/kernel/index.js'
+
+describe('@noy-db/hub/kernel surface', () => {
+  it('exposes the runtime kernel functions federation needs', () => {
+    expect(typeof kernel.readPath).toBe('function')
+    expect(typeof kernel.reduceRecords).toBe('function')
+    expect(typeof kernel.groupAndReduce).toBe('function')
+    expect(typeof kernel.generateULID).toBe('function')
+    expect(typeof kernel.sha256Hex).toBe('function')
+  })
+
+  it('exposes the federation error classes', () => {
+    const names = [
+      'CrossShardJoinError', 'DataResidencyError', 'ReservedVaultNameError',
+      'ShardProvisioningError', 'UnknownShardError', 'ValidationError',
+      'VaultTemplateNotFoundError',
+    ] as const
+    for (const n of names) {
+      expect(typeof (kernel as Record<string, unknown>)[n]).toBe('function')
+    }
+  })
+
+  it('generateULID returns a 26-char Crockford ULID', () => {
+    expect(kernel.generateULID()).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/)
+  })
+})
+
+// Compile-time assertion that the type surface is present (no runtime cost).
+type _TypeSurface = [
+  ChangeEvent, Vault, Collection, Noydb, Operator, Query, JoinStrategy,
+  LiveQuery, AggregateResult, AggregateSpec, LiveAggregation, IndexDef,
+]

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -275,6 +275,16 @@
         "types": "./dist/attestation/index.d.cts",
         "default": "./dist/attestation/index.cjs"
       }
+    },
+    "./kernel": {
+      "import": {
+        "types": "./dist/kernel/index.d.ts",
+        "default": "./dist/kernel/index.js"
+      },
+      "require": {
+        "types": "./dist/kernel/index.d.cts",
+        "default": "./dist/kernel/index.cjs"
+      }
     }
   },
   "main": "./dist/index.cjs",

--- a/packages/hub/src/kernel/index.ts
+++ b/packages/hub/src/kernel/index.ts
@@ -29,6 +29,10 @@ export {
   VaultTemplateNotFoundError,
 } from '../errors.js'
 
+// Types only (erased at emit). NOTE: Vault / Collection / Noydb / Query are
+// runtime classes in hub, but are re-exported here as TYPES — `instanceof`
+// against these will not work from `@noy-db/hub/kernel`. Consumers needing a
+// runtime class value must import it from `@noy-db/hub` directly.
 // ─── types ────────────────────────────────────────────────────────
 export type { ChangeEvent } from '../types.js'
 export type { Vault } from '../vault.js'

--- a/packages/hub/src/kernel/index.ts
+++ b/packages/hub/src/kernel/index.ts
@@ -22,6 +22,7 @@ export { sha256Hex } from '../crypto.js'
 export {
   CrossShardJoinError,
   DataResidencyError,
+  NoAccessError,
   ReservedVaultNameError,
   ShardProvisioningError,
   UnknownShardError,

--- a/packages/hub/src/kernel/index.ts
+++ b/packages/hub/src/kernel/index.ts
@@ -1,0 +1,46 @@
+/**
+ * **@noy-db/hub/kernel** — the stable internal surface that outward
+ * frameworks (klum-db / Lobby) bind to *instead of* reaching into hub
+ * internals via relative paths.
+ *
+ * This is the "kernel-surface extraction" (spec §10): the minimal set
+ * of runtime helpers, error classes, and types the federation /
+ * orchestration layer needs from the vault core. Treat it as a
+ * contract — additive changes only; removals are breaking.
+ *
+ * @packageDocumentation
+ */
+
+// ─── runtime helpers ──────────────────────────────────────────────
+export { readPath } from '../query/predicate.js'
+export { reduceRecords } from '../aggregate/aggregation.js'
+export { groupAndReduce } from '../aggregate/groupby.js'
+export { generateULID } from '../bundle/ulid.js'
+export { sha256Hex } from '../crypto.js'
+
+// ─── error classes ────────────────────────────────────────────────
+export {
+  CrossShardJoinError,
+  DataResidencyError,
+  ReservedVaultNameError,
+  ShardProvisioningError,
+  UnknownShardError,
+  ValidationError,
+  VaultTemplateNotFoundError,
+} from '../errors.js'
+
+// ─── types ────────────────────────────────────────────────────────
+export type { ChangeEvent } from '../types.js'
+export type { Vault } from '../vault.js'
+export type { Collection } from '../collection.js'
+export type { Noydb } from '../noydb.js'
+export type { Operator } from '../query/predicate.js'
+export type { Query } from '../query/builder.js'
+export type { JoinStrategy } from '../query/join.js'
+export type { LiveQuery } from '../query/live.js'
+export type {
+  AggregateResult,
+  AggregateSpec,
+  LiveAggregation,
+} from '../aggregate/aggregation.js'
+export type { IndexDef } from '../indexing/eager-indexes.js'

--- a/packages/hub/tsup.config.ts
+++ b/packages/hub/tsup.config.ts
@@ -49,6 +49,7 @@ const ENTRIES = {
   'sync/index': 'src/sync/index.ts',
   'util/index': 'src/util/index.ts',
   'attestation/index': 'src/attestation/index.ts',
+  'kernel/index': 'src/kernel/index.ts',
 }
 
 export default defineConfig([

--- a/packages/lobby/LICENSE
+++ b/packages/lobby/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 vLannaAi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/lobby/README.md
+++ b/packages/lobby/README.md
@@ -1,0 +1,14 @@
+# @klum-db/lobby
+
+> The **Lobby** — klum-db's outward framework that orchestrates a *group* of sovereign [noy-db](https://github.com/vLannaAi/noy-db) vaults: federation, interchange, and custody. A vault is the container; the Lobby is the orchestrator.
+
+Part of **klum-db** (Thai *klum* กลุ่ม, "group") — developed inside the noy-db monorepo while the kernel boundary stabilizes. See `docs/superpowers/specs/2026-06-16-lobby-framework-design.md`.
+
+````ts
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { createLobby } from '@klum-db/lobby'
+
+const db = await createNoydb({ store: memory(), user: 'alice', secret: '…' })
+const lobby = createLobby(db)
+````

--- a/packages/lobby/README.md
+++ b/packages/lobby/README.md
@@ -4,11 +4,11 @@
 
 Part of **klum-db** (Thai *klum* กลุ่ม, "group") — developed inside the noy-db monorepo while the kernel boundary stabilizes. See `docs/superpowers/specs/2026-06-16-lobby-framework-design.md`.
 
-````ts
+```ts
 import { createNoydb } from '@noy-db/hub'
 import { memory } from '@noy-db/to-memory'
 import { createLobby } from '@klum-db/lobby'
 
 const db = await createNoydb({ store: memory(), user: 'alice', secret: '…' })
 const lobby = createLobby(db)
-````
+```

--- a/packages/lobby/__tests__/lobby.test.ts
+++ b/packages/lobby/__tests__/lobby.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { createNoydb } from '@noy-db/hub'
 import { memory } from '@noy-db/to-memory'
 import { Lobby, createLobby } from '../src/index.js'
+import { generateULID } from '@noy-db/hub/kernel'
 
 describe('Lobby', () => {
   it('wraps the Noydb instance whose vaults it orchestrates', async () => {
@@ -13,5 +14,12 @@ describe('Lobby', () => {
     const lobby = createLobby(db)
     expect(lobby).toBeInstanceOf(Lobby)
     expect(lobby.noydb).toBe(db)
+  })
+})
+
+describe('kernel boundary', () => {
+  it('Lobby can consume the @noy-db/hub/kernel surface', () => {
+    const id = generateULID()
+    expect(id).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/)
   })
 })

--- a/packages/lobby/__tests__/lobby.test.ts
+++ b/packages/lobby/__tests__/lobby.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { Lobby, createLobby } from '../src/index.js'
+
+describe('Lobby', () => {
+  it('wraps the Noydb instance whose vaults it orchestrates', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'correct-horse-battery-staple',
+    })
+    const lobby = createLobby(db)
+    expect(lobby).toBeInstanceOf(Lobby)
+    expect(lobby.noydb).toBe(db)
+  })
+})

--- a/packages/lobby/package.json
+++ b/packages/lobby/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@klum-db/lobby",
+  "version": "0.2.0-pre.23",
+  "description": "klum-db Lobby — orchestrates a group of sovereign noy-db vaults (federation, interchange, custody). The outward framework to noy-db's inward vault.",
+  "license": "MIT",
+  "author": "vLannaAi <vicio@lanna.ai>",
+  "homepage": "https://github.com/vLannaAi/noy-db/tree/main/packages/lobby#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vLannaAi/noy-db.git",
+    "directory": "packages/lobby"
+  },
+  "bugs": {
+    "url": "https://github.com/vLannaAi/noy-db/issues"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@noy-db/hub": "workspace:*"
+  },
+  "devDependencies": {
+    "@noy-db/hub": "workspace:*",
+    "@noy-db/to-memory": "workspace:*",
+    "@types/node": "^22.0.0"
+  },
+  "keywords": [
+    "klum-db",
+    "lobby",
+    "noy-db",
+    "federation",
+    "vault-orchestration",
+    "data-sovereignty",
+    "multi-vault"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  }
+}

--- a/packages/lobby/src/index.ts
+++ b/packages/lobby/src/index.ts
@@ -1,0 +1,34 @@
+/**
+ * **@klum-db/lobby** — the Lobby: klum-db's outward framework that
+ * orchestrates a *group* of sovereign noy-db vaults.
+ *
+ * A noy-db vault is a complete, sovereign unit (the container). The
+ * Lobby is what holds many of them side by side (the commons) and is
+ * the way in (the entrance) — federation, interchange, and custody.
+ *
+ * This is the foundation surface; federation entry points
+ * (`openVaultGroup`, `openStateManagementVault`) land when the
+ * federation subsystem is extracted from `@noy-db/hub` (Phase 3).
+ *
+ * @packageDocumentation
+ */
+
+import type { Noydb } from '@noy-db/hub'
+
+/**
+ * Orchestrates a group of sovereign noy-db vaults sharing one
+ * {@link Noydb} runtime (one store, one keyring root).
+ */
+export class Lobby {
+  /** The Noydb runtime whose vaults this Lobby orchestrates. */
+  readonly noydb: Noydb
+
+  constructor(noydb: Noydb) {
+    this.noydb = noydb
+  }
+}
+
+/** Create a {@link Lobby} over an existing {@link Noydb} runtime. */
+export function createLobby(noydb: Noydb): Lobby {
+  return new Lobby(noydb)
+}

--- a/packages/lobby/tsconfig.json
+++ b/packages/lobby/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/packages/lobby/tsup.config.ts
+++ b/packages/lobby/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  target: 'es2022',
+})

--- a/packages/lobby/vitest.config.ts
+++ b/packages/lobby/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'lobby',
+    include: ['__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -573,6 +573,18 @@ importers:
         specifier: ^5.0.0
         version: 5.0.12(@types/react@18.3.28)(react@18.3.1)
 
+  packages/lobby:
+    devDependencies:
+      '@noy-db/hub':
+        specifier: workspace:*
+        version: link:../hub
+      '@noy-db/to-memory':
+        specifier: workspace:*
+        version: link:../to-memory
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+
   packages/on-email-otp:
     devDependencies:
       '@noy-db/hub':

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -83,7 +83,7 @@ for (const dir of packageDirs) {
     continue
   }
 
-  if (!pkg.name || !pkg.name.startsWith('@noy-db/')) {
+  if (!pkg.name || !(pkg.name.startsWith('@noy-db/') || pkg.name.startsWith('@klum-db/'))) {
     continue
   }
 
@@ -126,7 +126,7 @@ for (const dir of packageDirs) {
   } catch {
     continue
   }
-  if (!pkg.name || !pkg.name.startsWith('@noy-db/')) continue
+  if (!pkg.name || !(pkg.name.startsWith('@noy-db/') || pkg.name.startsWith('@klum-db/'))) continue
 
   const [maj, min, pat] = (pkg.version ?? '').split('.').map(Number)
   if (maj > coreMajor || (maj === coreMajor && min > coreMinor) || (maj === coreMajor && min === coreMinor && pat > corePatch)) {


### PR DESCRIPTION
## Summary

Foundation for the **inward/outward re-organization** of noy-db: spinning out **klum-db / Lobby** — the *outward* framework that orchestrates a group of sovereign noy-db vaults — from **noy-db**, the *inward* vault. (vault ↔ container ; Lobby ↔ Docker.) This PR is **Phase 1 + Phase 2** of the foundation; it is **purely additive** and changes no existing hub behavior.

- **`@klum-db/lobby`** (new npm org `@klum-db`) — scaffolded under the monorepo with full build/test wiring (dual ESM/CJS, vitest, lockstep, architecture-check). Minimal `Lobby` class wrapping a `Noydb` runtime; federation entry points are deferred to Phase 3.
- **`@noy-db/hub/kernel`** — a new stable subpath that re-exports exactly the internal hub symbols an orchestration layer needs (runtime helpers `readPath`/`reduceRecords`/`groupAndReduce`/`generateULID`/`sha256Hex`, the federation error classes incl. `NoAccessError`, and the supporting types). This is the kernel-surface contract klum-db binds to *instead of* reaching into hub internals.
- **Boundary proven** — a test confirms `@klum-db/lobby` consumes `@noy-db/hub/kernel` across the package boundary.
- **`scripts/release.mjs`** — version-lockstep + sanity-check guards broadened so `@klum-db/*` rides the same lockstep as `@noy-db/*`.
- Includes the design spec (`docs/superpowers/specs/2026-06-16-lobby-framework-design.md`) and implementation plan (`docs/superpowers/plans/2026-06-16-klum-db-refactor-foundation.md`).

Built task-by-task with two-stage (spec + code-quality) review per task plus a final whole-implementation review.

## Out of scope (separate follow-up plan)

**Phase 3 — federation extraction:** moving `packages/hub/src/federation/` into `@klum-db/lobby` (inverting the `Noydb` private-state coupling) with a deprecation shim. Authored against the kernel surface this PR establishes. Relates to vLannaAi/klum-db#12 (federation is the seed of klum-db) and the vLannaAi/klum-db#1 epic (pilot-1 FRs map into Lobby).

## Test Plan

- [x] `pnpm --filter @klum-db/lobby test` — 2/2 (incl. cross-package kernel consumption)
- [x] `pnpm --filter @noy-db/hub test -- kernel-surface` — 3/3
- [x] `pnpm --filter @noy-db/hub test` — full hub suite green (2713 tests), no behavior change
- [x] `pnpm build && pnpm test` — full monorepo: 70/70 build tasks; suite green (two pre-existing, unrelated timeout flakes: `as-csv` round-trip, `hub` cross-vault `minRole`)
- [x] `pnpm check:architecture` — passes (klum→noy allowed; a `noy→klum` guard is a Phase-3 addition)
- [x] `node --check scripts/release.mjs` — clean