### PR TITLE
FR-1: multi-compartment .noydb bundle + pre-decrypt manifest

### DIFF
--- a/docs/superpowers/plans/2026-06-17-fr1-multi-compartment-bundle.md
+++ b/docs/superpowers/plans/2026-06-17-fr1-multi-compartment-bundle.md
@@ -1,0 +1,502 @@
+# FR-1: Multi-compartment Bundle + pre-decrypt Manifest — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Let one `.noydb` container hold N vault compartments with a pre-decrypt manifest, by **composing** existing single-vault bundles inside a new outer container — without touching the v1 format.
+
+**Architecture:** A multi-compartment bundle is a new **`NDBM`** container: a fixed prefix, an unencrypted **manifest** (the opt-in disclosure layer), then N standard `.noydb` v1 bundles concatenated. Each compartment is produced by the existing `writeNoydbBundle` and read by the existing `readNoydbBundle` — so the v1 format/validator is **untouched**, every compartment "loads independently" for free, and the strict inner minimum-disclosure headers stay strict while the outer manifest carries owner-curated, opt-in fields. (FR-1 epic #441; design spec `docs/superpowers/specs/2026-06-16-lobby-framework-design.md` §7–8.)
+
+**Tech Stack:** TS strict, ESM `.js` specifiers, vitest. New code is self-contained in `@noy-db/hub` (`packages/hub/src/bundle/`); no `@klum-db` change (Lobby orchestration is FR-2).
+
+**Design decisions (approved):**
+- **Manifest disclosure = opt-in, layered.** Always: `handle`, `roleTag?`, `exportedAt`, `innerBytes`, `innerSha256`. Opt-in (writer chooses per compartment): `name`, `collections[{name,count}]`, `publicEnvelope`.
+- **Scope = pure hub format.** No `Lobby.exportBundle` in FR-1.
+- **Compose, don't mutate v1.** New `NDBM` outer container embeds untouched v1 `.noydb` bundles.
+
+---
+
+## Outer container layout (`NDBM`)
+
+```
+offset 0 : magic 'NDBM'            (4 bytes: 0x4e 0x44 0x42 0x4d)
+offset 4 : multiFormatVersion = 1  (1 byte)
+offset 5 : reserved = 0            (1 byte)
+offset 6 : manifestLength uint32BE (4 bytes)
+offset 10: manifest JSON (UTF-8, manifestLength bytes)
+offset 10+manifestLength: inner v1 bundles concatenated, in manifest order,
+                          each `compartments[i].innerBytes` long.
+```
+The manifest is the source of truth for framing: slice compartment `i` by summing prior `innerBytes`. Each inner slice is a complete, standard `.noydb` bundle.
+
+---
+
+## File structure
+
+- **Create** `packages/hub/src/bundle/multi-bundle.ts` — constants, types, manifest validator, encode/decode framing, `writeMultiVaultBundle`, `readNoydbBundleManifest`, `readMultiVaultBundleCompartment`.
+- **Create** `packages/hub/__tests__/multi-bundle.test.ts` — tests.
+- **Modify** `packages/hub/src/bundle/index.ts` and `packages/hub/src/index.ts` — public exports.
+- **Modify** `features.yaml` — register the capability (CI "Spec coverage" gate).
+
+---
+
+## Task 1 — Format module: constants, types, validator, framing codec (TDD)
+
+**Files:** Create `packages/hub/src/bundle/multi-bundle.ts`; Create `packages/hub/__tests__/multi-bundle.test.ts`.
+
+- [ ] **Step 1: Write the failing framing round-trip test** — `packages/hub/__tests__/multi-bundle.test.ts`:
+```typescript
+import { describe, it, expect } from 'vitest'
+import {
+  NOYDB_MULTI_BUNDLE_MAGIC,
+  encodeMultiBundle,
+  decodeMultiBundle,
+  type MultiBundleManifest,
+} from '../src/bundle/multi-bundle.js'
+
+describe('multi-bundle framing codec', () => {
+  it('round-trips a manifest + inner byte blobs', () => {
+    const inner0 = new Uint8Array([1, 2, 3, 4, 5])
+    const inner1 = new Uint8Array([9, 8, 7])
+    const manifest: MultiBundleManifest = {
+      multiFormatVersion: 1,
+      handle: '01HZZZZZZZZZZZZZZZZZZZZZZZ',
+      compartments: [
+        { handle: '01HAAAAAAAAAAAAAAAAAAAAAAA', exportedAt: '2026-06-17T00:00:00.000Z', innerBytes: 5, innerSha256: 'a'.repeat(64), roleTag: 'shard' },
+        { handle: '01HBBBBBBBBBBBBBBBBBBBBBBB', exportedAt: '2026-06-17T00:00:00.000Z', innerBytes: 3, innerSha256: 'b'.repeat(64) },
+      ],
+    }
+    const bytes = encodeMultiBundle(manifest, [inner0, inner1])
+    expect(bytes.subarray(0, 4)).toEqual(NOYDB_MULTI_BUNDLE_MAGIC)
+    const decoded = decodeMultiBundle(bytes)
+    expect(decoded.manifest).toEqual(manifest)
+    expect(decoded.inner[0]).toEqual(inner0)
+    expect(decoded.inner[1]).toEqual(inner1)
+  })
+
+  it('rejects bytes without the NDBM magic', () => {
+    expect(() => decodeMultiBundle(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))).toThrow(/magic/i)
+  })
+
+  it('rejects a manifest whose innerBytes sum exceeds the body', () => {
+    const m: MultiBundleManifest = {
+      multiFormatVersion: 1, handle: '01HZZZZZZZZZZZZZZZZZZZZZZZ',
+      compartments: [{ handle: '01HAAAAAAAAAAAAAAAAAAAAAAA', exportedAt: '2026-06-17T00:00:00.000Z', innerBytes: 999, innerSha256: 'a'.repeat(64) }],
+    }
+    const bytes = encodeMultiBundle(m, [new Uint8Array([1, 2, 3])])
+    // tamper: truncate body so the declared innerBytes overruns
+    expect(() => decodeMultiBundle(bytes.subarray(0, bytes.length - 1))).toThrow(/truncat|overrun|length/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run → fail** (`pnpm --filter @noy-db/hub test -- multi-bundle`) — module missing.
+
+- [ ] **Step 3: Implement the format module** — `packages/hub/src/bundle/multi-bundle.ts`:
+```typescript
+/**
+ * Multi-compartment `.noydb` bundle (`NDBM`). A thin outer container
+ * that embeds N standard single-vault `.noydb` bundles plus an
+ * unencrypted, owner-curated **manifest**. The v1 single-vault format
+ * is untouched; each compartment is a complete v1 bundle, produced by
+ * `writeNoydbBundle` and read by `readNoydbBundle`.
+ *
+ * Layout: magic 'NDBM'(4) · version(1) · reserved(1) · manifestLen(4 BE)
+ *         · manifest JSON · concat(inner v1 bundles, in manifest order).
+ *
+ * @packageDocumentation
+ */
+import type { Vault } from '../vault.js'
+import type { PublicEnvelope } from '../meta/public-envelope/types.js'
+import { sha256Hex } from '../crypto.js'
+import { generateULID } from './ulid.js'
+import { readUint32BE, writeUint32BE, hasNoydbBundleMagic } from './format.js'
+import {
+  writeNoydbBundle,
+  readNoydbBundleHeader,
+  readNoydbBundlePublicEnvelope,
+  type WriteNoydbBundleOptions,
+} from './bundle.js'
+
+/** Magic bytes 'NDBM' — NOYDB Multi-compartment bundle. */
+export const NOYDB_MULTI_BUNDLE_MAGIC = new Uint8Array([0x4e, 0x44, 0x42, 0x4d])
+/** Fixed prefix: magic(4) + version(1) + reserved(1) + manifestLen(4). */
+export const NOYDB_MULTI_BUNDLE_PREFIX_BYTES = 10
+/** Current multi-bundle layout version. */
+export const NOYDB_MULTI_BUNDLE_VERSION = 1
+
+/** One compartment's entry in the pre-decrypt manifest. */
+export interface CompartmentManifest {
+  /** The inner v1 bundle's stable ULID handle. */
+  readonly handle: string
+  /** Owner-curated classification (e.g. 'shard', 'pool'). Opt-in. */
+  readonly roleTag?: string
+  /** ISO export timestamp. Always set by the writer; absent for a v1 bundle read as a 1-entry manifest. */
+  readonly exportedAt?: string
+  /** Compartment (vault) name. Opt-in disclosure. */
+  readonly name?: string
+  /** Collection names + record counts. Opt-in disclosure. */
+  readonly collections?: readonly { readonly name: string; readonly count: number }[]
+  /** Inner bundle's owner-curated public envelope, surfaced. Opt-in. */
+  readonly publicEnvelope?: PublicEnvelope
+  /** Byte length of the inner v1 bundle (drives framing). */
+  readonly innerBytes: number
+  /** SHA-256 (lowercase hex) of the inner v1 bundle bytes — pre-decrypt integrity. */
+  readonly innerSha256: string
+}
+
+/** The unencrypted manifest of a multi-compartment bundle. */
+export interface MultiBundleManifest {
+  readonly multiFormatVersion: number
+  /** Opaque ULID for the outer container. */
+  readonly handle: string
+  readonly compartments: readonly CompartmentManifest[]
+}
+
+/** Assemble the `NDBM` container from a manifest + inner bundle bytes (in manifest order). */
+export function encodeMultiBundle(
+  manifest: MultiBundleManifest,
+  inner: readonly Uint8Array[],
+): Uint8Array {
+  if (manifest.compartments.length !== inner.length) {
+    throw new Error(`multi-bundle: manifest has ${manifest.compartments.length} compartments but ${inner.length} inner bundles were provided.`)
+  }
+  const manifestBytes = new TextEncoder().encode(JSON.stringify(manifest))
+  const bodyLen = inner.reduce((n, b) => n + b.length, 0)
+  const out = new Uint8Array(NOYDB_MULTI_BUNDLE_PREFIX_BYTES + manifestBytes.length + bodyLen)
+  out.set(NOYDB_MULTI_BUNDLE_MAGIC, 0)
+  out[4] = NOYDB_MULTI_BUNDLE_VERSION
+  out[5] = 0
+  writeUint32BE(out, 6, manifestBytes.length)
+  out.set(manifestBytes, NOYDB_MULTI_BUNDLE_PREFIX_BYTES)
+  let off = NOYDB_MULTI_BUNDLE_PREFIX_BYTES + manifestBytes.length
+  for (const b of inner) { out.set(b, off); off += b.length }
+  return out
+}
+
+function hasMultiMagic(bytes: Uint8Array): boolean {
+  if (bytes.length < NOYDB_MULTI_BUNDLE_MAGIC.length) return false
+  for (let i = 0; i < NOYDB_MULTI_BUNDLE_MAGIC.length; i++) if (bytes[i] !== NOYDB_MULTI_BUNDLE_MAGIC[i]) return false
+  return true
+}
+
+function validateManifest(parsed: unknown): asserts parsed is MultiBundleManifest {
+  if (parsed === null || typeof parsed !== 'object') throw new Error('multi-bundle manifest must be a JSON object.')
+  const m = parsed as Record<string, unknown>
+  if (m['multiFormatVersion'] !== NOYDB_MULTI_BUNDLE_VERSION) throw new Error(`multi-bundle manifest.multiFormatVersion must be ${NOYDB_MULTI_BUNDLE_VERSION}, got ${String(m['multiFormatVersion'])}.`)
+  if (typeof m['handle'] !== 'string') throw new Error('multi-bundle manifest.handle must be a string.')
+  if (!Array.isArray(m['compartments'])) throw new Error('multi-bundle manifest.compartments must be an array.')
+  for (const c of m['compartments'] as unknown[]) {
+    if (c === null || typeof c !== 'object') throw new Error('multi-bundle compartment must be an object.')
+    const e = c as Record<string, unknown>
+    if (typeof e['handle'] !== 'string') throw new Error('multi-bundle compartment.handle must be a string.')
+    if (typeof e['innerBytes'] !== 'number' || !Number.isInteger(e['innerBytes']) || e['innerBytes'] < 0) throw new Error('multi-bundle compartment.innerBytes must be a non-negative integer.')
+    if (typeof e['innerSha256'] !== 'string' || !/^[0-9a-f]{64}$/.test(e['innerSha256'])) throw new Error('multi-bundle compartment.innerSha256 must be 64-char lowercase hex.')
+  }
+}
+
+/** Parse the `NDBM` container into its manifest + raw inner bundle byte slices. */
+export function decodeMultiBundle(bytes: Uint8Array): { manifest: MultiBundleManifest; inner: Uint8Array[] } {
+  if (!hasMultiMagic(bytes)) throw new Error('not a NOYDB multi-bundle: missing NDBM magic.')
+  if (bytes.length < NOYDB_MULTI_BUNDLE_PREFIX_BYTES) throw new Error('multi-bundle truncated: shorter than the fixed prefix.')
+  if (bytes[4] !== NOYDB_MULTI_BUNDLE_VERSION) throw new Error(`unsupported multi-bundle version ${String(bytes[4])}.`)
+  const manifestLen = readUint32BE(bytes, 6)
+  const manifestEnd = NOYDB_MULTI_BUNDLE_PREFIX_BYTES + manifestLen
+  if (manifestEnd > bytes.length) throw new Error('multi-bundle truncated: manifest length overruns the buffer.')
+  const manifestJson = new TextDecoder('utf-8', { fatal: true }).decode(bytes.subarray(NOYDB_MULTI_BUNDLE_PREFIX_BYTES, manifestEnd))
+  let parsed: unknown
+  try { parsed = JSON.parse(manifestJson) } catch (err) { throw new Error(`multi-bundle manifest is not valid JSON: ${(err as Error).message}`) }
+  validateManifest(parsed)
+  const inner: Uint8Array[] = []
+  let off = manifestEnd
+  for (const c of parsed.compartments) {
+    const end = off + c.innerBytes
+    if (end > bytes.length) throw new Error(`multi-bundle truncated: compartment "${c.handle}" innerBytes overruns the buffer.`)
+    inner.push(bytes.subarray(off, end))
+    off = end
+  }
+  return { manifest: parsed, inner }
+}
+```
+(If `WriteNoydbBundleOptions`/`readNoydbBundlePublicEnvelope` are not exported from `./bundle.js`, they are — confirmed in `bundle/index.ts`. Keep the `validateManifest` type-narrowing so `parsed.compartments` is typed in `decodeMultiBundle`.)
+
+- [ ] **Step 4: Run → pass** (`pnpm --filter @noy-db/hub test -- multi-bundle`). Then `pnpm --filter @noy-db/hub typecheck`.
+
+- [ ] **Step 5: Commit** — `git add packages/hub/src/bundle/multi-bundle.ts packages/hub/__tests__/multi-bundle.test.ts && git commit -m "feat(hub): multi-bundle NDBM framing codec + manifest types"`
+
+---
+
+## Task 2 — `writeMultiVaultBundle` (compose v1 bundles) (TDD)
+
+**Files:** Modify `packages/hub/src/bundle/multi-bundle.ts`; Modify the test.
+
+- [ ] **Step 1: Append the failing writer test.** Follow `packages/hub/__tests__/bundle.test.ts` for the in-memory vault setup (createNoydb + store + `vault.collection(...).put(...)`). Create TWO vaults with a couple of records each, then:
+```typescript
+import { writeMultiVaultBundle, readNoydbBundleManifest } from '../src/bundle/multi-bundle.js'
+// ... in a test, with two opened vaults `a` and `b` holding data:
+const bytes = await writeMultiVaultBundle([
+  { vault: a, roleTag: 'shard', exportedAt: '2026-06-17T00:00:00.000Z', disclose: { name: true, collections: true } },
+  { vault: b, roleTag: 'pool' },
+])
+const manifest = await readNoydbBundleManifest(bytes)
+expect(manifest).toHaveLength(2)
+expect(manifest[0]!.roleTag).toBe('shard')
+expect(manifest[0]!.name).toBe(a.name)            // disclosed
+expect(manifest[0]!.collections?.length).toBeGreaterThan(0)  // disclosed
+expect(manifest[1]!.roleTag).toBe('pool')
+expect(manifest[1]!.name).toBeUndefined()         // not disclosed
+expect(manifest[1]!.collections).toBeUndefined()  // not disclosed
+expect(manifest[0]!.innerSha256).toMatch(/^[0-9a-f]{64}$/)
+```
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement `writeMultiVaultBundle`** — append to `multi-bundle.ts`:
+```typescript
+/** Per-compartment input to {@link writeMultiVaultBundle}. */
+export interface MultiVaultCompartmentInput {
+  readonly vault: Vault
+  /** Owner-curated classification surfaced in the manifest (e.g. 'shard', 'pool'). */
+  readonly roleTag?: string
+  /** ISO timestamp for the manifest; defaults to now. */
+  readonly exportedAt?: string
+  /** Opt-in pre-decrypt disclosure for this compartment. */
+  readonly disclose?: {
+    /** `true` → use `vault.name`; a string → that explicit name. */
+    readonly name?: boolean | string
+    /** `true` → include collection names + record counts. */
+    readonly collections?: boolean
+    /** `true` → surface the inner bundle's public envelope into the manifest. */
+    readonly publicEnvelope?: boolean
+  }
+  /** Options forwarded to `writeNoydbBundle` for this compartment's inner bundle. */
+  readonly bundleOptions?: WriteNoydbBundleOptions
+}
+
+/** Write N vaults into one `NDBM` multi-compartment bundle. */
+export async function writeMultiVaultBundle(
+  compartments: readonly MultiVaultCompartmentInput[],
+  opts: { readonly handle?: string } = {},
+): Promise<Uint8Array> {
+  if (compartments.length === 0) throw new Error('writeMultiVaultBundle: at least one compartment is required.')
+  const inner: Uint8Array[] = []
+  const entries: CompartmentManifest[] = []
+  for (const c of compartments) {
+    const innerBytes = await writeNoydbBundle(c.vault, c.bundleOptions ?? {})
+    const header = readNoydbBundleHeader(innerBytes)
+    const entry: {
+      -readonly [K in keyof CompartmentManifest]: CompartmentManifest[K]
+    } = {
+      handle: header.handle,
+      exportedAt: c.exportedAt ?? new Date().toISOString(),
+      innerBytes: innerBytes.length,
+      innerSha256: await sha256Hex(innerBytes),
+    }
+    if (c.roleTag !== undefined) entry.roleTag = c.roleTag
+    if (c.disclose?.name !== undefined && c.disclose.name !== false) {
+      entry.name = c.disclose.name === true ? c.vault.name : c.disclose.name
+    }
+    if (c.disclose?.collections === true) {
+      const names = await c.vault.collections()
+      entry.collections = await Promise.all(
+        names.map(async (n) => ({ name: n, count: await c.vault.collection(n).count() })),
+      )
+    }
+    if (c.disclose?.publicEnvelope === true) {
+      const env = readNoydbBundlePublicEnvelope(innerBytes)
+      if (env !== undefined) entry.publicEnvelope = env
+    }
+    inner.push(innerBytes)
+    entries.push(entry)
+  }
+  const manifest: MultiBundleManifest = {
+    multiFormatVersion: NOYDB_MULTI_BUNDLE_VERSION,
+    handle: opts.handle ?? generateULID(),
+    compartments: entries,
+  }
+  return encodeMultiBundle(manifest, inner)
+}
+```
+(Confirm `vault.collection(name)` + `.count()` and `vault.collections(): Promise<string[]>` against `vault.ts` — verified present. If `count()` needs args or differs, match the real signature.)
+
+- [ ] **Step 4: Run → pass; typecheck.**
+
+- [ ] **Step 5: Commit** — `git commit -am "feat(hub): writeMultiVaultBundle composes v1 bundles + opt-in manifest"`
+
+---
+
+## Task 3 — Readers: `readNoydbBundleManifest` + `readMultiVaultBundleCompartment` (incl. v1 back-compat) (TDD)
+
+**Files:** Modify `packages/hub/src/bundle/multi-bundle.ts`; Modify the test.
+
+- [ ] **Step 1: Append failing reader tests:**
+```typescript
+import { readMultiVaultBundleCompartment } from '../src/bundle/multi-bundle.js'
+import { readNoydbBundle, writeNoydbBundle } from '../src/bundle/bundle.js'
+
+it('each compartment loads independently via readNoydbBundle', async () => {
+  const bytes = await writeMultiVaultBundle([{ vault: a }, { vault: b }])
+  const manifest = await readNoydbBundleManifest(bytes)
+  for (const c of manifest) {
+    const innerBytes = readMultiVaultBundleCompartment(bytes, c.handle)
+    const verifySha = await import('../src/crypto.js').then(m => m.sha256Hex(innerBytes))
+    expect(verifySha).toBe(c.innerSha256)
+    const read = await readNoydbBundle(innerBytes)   // loads independently
+    expect(read.dumpJson.length).toBeGreaterThan(0)
+  }
+})
+
+it('reads a single v1 bundle as a 1-entry manifest (back-compat)', async () => {
+  const v1 = await writeNoydbBundle(a)
+  const manifest = await readNoydbBundleManifest(v1)
+  expect(manifest).toHaveLength(1)
+  expect(manifest[0]!.handle).toBe(readNoydbBundleHeader(v1).handle)
+  // the whole v1 bundle IS the only compartment:
+  expect(readMultiVaultBundleCompartment(v1, manifest[0]!.handle)).toEqual(v1)
+})
+```
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement the readers** — append to `multi-bundle.ts`:
+```typescript
+/**
+ * Read the pre-decrypt manifest of a bundle WITHOUT decrypting any
+ * compartment. Accepts a multi-compartment `NDBM` bundle (returns its
+ * N entries) OR a single v1 `NDB1` bundle (returns a 1-entry manifest,
+ * for uniform handling). Throws on anything else.
+ */
+export async function readNoydbBundleManifest(bytes: Uint8Array): Promise<CompartmentManifest[]> {
+  if (hasMultiMagic(bytes)) return [...decodeMultiBundle(bytes).manifest.compartments]
+  if (hasNoydbBundleMagic(bytes)) {
+    const header = readNoydbBundleHeader(bytes)
+    const env = readNoydbBundlePublicEnvelope(bytes)
+    const entry: { -readonly [K in keyof CompartmentManifest]: CompartmentManifest[K] } = {
+      handle: header.handle,
+      innerBytes: bytes.length,
+      innerSha256: await sha256Hex(bytes),
+    }
+    if (env !== undefined) entry.publicEnvelope = env
+    return [entry]
+  }
+  throw new Error('readNoydbBundleManifest: not a NOYDB bundle (no NDB1 or NDBM magic).')
+}
+
+/**
+ * Extract one compartment's inner v1 `.noydb` bundle bytes (verified
+ * against its manifest `innerSha256`), ready to pass to `readNoydbBundle`.
+ * `selector` is a compartment `handle` or a zero-based index. For a
+ * single v1 bundle, the bundle itself is the only compartment.
+ */
+export function readMultiVaultBundleCompartment(bytes: Uint8Array, selector: string | number): Uint8Array {
+  if (hasNoydbBundleMagic(bytes) && !hasMultiMagic(bytes)) {
+    const header = readNoydbBundleHeader(bytes)
+    if (selector === 0 || selector === header.handle) return bytes
+    throw new Error(`readMultiVaultBundleCompartment: single v1 bundle has only compartment "${header.handle}".`)
+  }
+  const { manifest, inner } = decodeMultiBundle(bytes)
+  const idx = typeof selector === 'number'
+    ? selector
+    : manifest.compartments.findIndex((c) => c.handle === selector)
+  if (idx < 0 || idx >= inner.length) throw new Error(`readMultiVaultBundleCompartment: no compartment ${typeof selector === 'number' ? `at index ${selector}` : `"${selector}"`}.`)
+  return inner[idx]!
+}
+```
+(`readNoydbBundleManifest` is async only because the v1-compat branch hashes the whole bundle; the NDBM branch is sync-fast. That's fine.)
+
+- [ ] **Step 4: Run → pass; typecheck.**
+
+- [ ] **Step 5: Commit** — `git commit -am "feat(hub): readNoydbBundleManifest + readMultiVaultBundleCompartment (v1 back-compat)"`
+
+---
+
+## Task 4 — Backward-compat + disclosure-default assertions (TDD)
+
+**Files:** Modify the test only.
+
+- [ ] **Step 1: Add assertions** proving the v1 path is untouched and the default manifest is minimal:
+```typescript
+it('single-vault writeNoydbBundle is byte-unaffected by this feature', async () => {
+  // Two writes of the same vault content produce stable handles (existing v1 guarantee).
+  const x = await writeNoydbBundle(a)
+  expect(readNoydbBundleHeader(x).formatVersion).toBe(1) // still v1; NDB1, not NDBM
+  expect(x.subarray(0, 4)).not.toEqual(NOYDB_MULTI_BUNDLE_MAGIC)
+})
+
+it('default manifest discloses only handle/roleTag/exportedAt (+ integrity), not name/collections', async () => {
+  const bytes = await writeMultiVaultBundle([{ vault: a, roleTag: 'shard' }])
+  const [c] = await readNoydbBundleManifest(bytes)
+  expect(c!.handle).toBeDefined()
+  expect(c!.exportedAt).toBeDefined()
+  expect(c!.roleTag).toBe('shard')
+  expect(c!.name).toBeUndefined()
+  expect(c!.collections).toBeUndefined()
+  expect(c!.publicEnvelope).toBeUndefined()
+})
+```
+
+- [ ] **Step 2: Run → pass** (no impl change expected; if a fails, fix the impl from Task 2/3). Then run the FULL hub suite: `pnpm --filter @noy-db/hub test` — confirm the existing bundle tests are all still green (v1 untouched).
+
+- [ ] **Step 3: Commit** — `git commit -am "test(hub): multi-bundle back-compat + default-disclosure assertions"`
+
+---
+
+## Task 5 — Public exports + features.yaml + full verification
+
+**Files:** Modify `packages/hub/src/bundle/index.ts`, `packages/hub/src/index.ts`, `features.yaml`.
+
+- [ ] **Step 1: Export from `packages/hub/src/bundle/index.ts`** — add after the existing bundle exports:
+```typescript
+export {
+  writeMultiVaultBundle,
+  readNoydbBundleManifest,
+  readMultiVaultBundleCompartment,
+  encodeMultiBundle,
+  decodeMultiBundle,
+  NOYDB_MULTI_BUNDLE_MAGIC,
+  NOYDB_MULTI_BUNDLE_PREFIX_BYTES,
+  NOYDB_MULTI_BUNDLE_VERSION,
+} from './multi-bundle.js'
+export type {
+  CompartmentManifest,
+  MultiBundleManifest,
+  MultiVaultCompartmentInput,
+} from './multi-bundle.js'
+```
+
+- [ ] **Step 2: Re-export the high-level API from `packages/hub/src/index.ts`** — next to the existing `writeNoydbBundle`/`readNoydbBundle` exports, add:
+```typescript
+export { writeMultiVaultBundle, readNoydbBundleManifest, readMultiVaultBundleCompartment } from './bundle/multi-bundle.js'
+export type { CompartmentManifest, MultiBundleManifest, MultiVaultCompartmentInput } from './bundle/multi-bundle.js'
+```
+
+- [ ] **Step 3: Register in `features.yaml`** — open `features.yaml`, find how an existing bundle feature is declared (e.g. the entry for `writeNoydbBundle`/extraction), and add a sibling entry for the multi-compartment bundle (id like `multi-compartment-bundle`), pointing at the artefact (`packages/hub/src/bundle/multi-bundle.ts`) and the spec (`docs/superpowers/specs/2026-06-16-lobby-framework-design.md`, FR-1). Match the schema of neighbouring entries exactly. (This satisfies the CI "Spec coverage" gate — `node scripts/validate-features.mjs` must pass.)
+
+- [ ] **Step 4: Full verification:**
+```bash
+pnpm --filter @noy-db/hub build
+node --input-type=module -e "import('@noy-db/hub').then(m=>{ if(typeof m.writeMultiVaultBundle!=='function'||typeof m.readNoydbBundleManifest!=='function') throw new Error('exports missing'); console.log('exports OK') })"
+pnpm --filter @noy-db/hub test
+pnpm --filter @noy-db/hub typecheck
+pnpm validate:features    # or: node scripts/validate-features.mjs
+pnpm check:architecture
+pnpm --filter @noy-db/hub bundle-check   # canaries must stay ✓; multi-bundle is a new module, not in the main entry's hot path
+```
+Expected: all green (bundle-check size may show the known stale-baseline drift — judge by canaries).
+
+- [ ] **Step 5: Commit** — `git commit -am "feat(hub): export multi-compartment bundle API + register in features.yaml"`
+
+---
+
+## Self-Review
+
+**1. Spec coverage (issue #441 acceptance):**
+- "round-trip an N-compartment bundle; each compartment loads independently" → Task 1 framing round-trip + Task 3 `readMultiVaultBundleCompartment` → `readNoydbBundle` per compartment.
+- "manifest enumerates all compartments + public envelopes pre-decrypt" → Task 2/3 `readNoydbBundleManifest` (no decryption; `publicEnvelope` opt-in surfaced).
+- "single-vault `writeNoydbBundle(vault)` stays backward-compatible" → Task 4 (v1 untouched; distinct `NDBM` magic; v1 reads as 1-entry manifest).
+- Approved decisions: opt-in layered disclosure (Task 2 `disclose`), pure hub scope (no klum change).
+
+**2. Placeholder scan:** every step has concrete code/commands. The two confirm-the-API notes (`vault.collections()`/`count()`, and `WriteNoydbBundleOptions` export) are verified-present, not guesses.
+
+**3. Type/name consistency:** `writeMultiVaultBundle` / `readNoydbBundleManifest` / `readMultiVaultBundleCompartment` / `encodeMultiBundle` / `decodeMultiBundle` / `CompartmentManifest` / `MultiBundleManifest` / `MultiVaultCompartmentInput` consistent across tasks and both export sites. `NOYDB_MULTI_BUNDLE_*` constants consistent.
+
+**4. Risk notes:** v1 format/validator deliberately untouched (compose, don't mutate); distinct `NDBM` magic makes v1 readers fail-closed; manifest integrity via per-compartment `innerSha256`; `exportedAt` is the only always-on timestamp and lives solely in the opt-in outer manifest (the strict inner v1 headers remain timestamp-free).

--- a/features.yaml
+++ b/features.yaml
@@ -1030,6 +1030,27 @@ features:
       - 'two-party ceremony (P3) for read-only roles: requestWithdrawal files a durable plaintext-metadata request in _user_withdrawal_requests (no passphrase at rest); owner/admin approveWithdrawal (gate approve-user-withdrawal t2 + role) extracts under firm authority and reuses freezeAndDeleteClosure so the requester disposition flows through; rejectWithdrawal touches no data; approve/reject are OCC + idempotent (pending-only, expiry-checked)'
     related: [transferable-partition, bundle, team, session-tiers]
 
+  - id: multi-compartment-bundle
+    name: Multi-compartment bundle (NDBM — N vaults in one .noydb container)
+    cluster: snapshot-and-portability
+    spec: docs/superpowers/specs/2026-06-16-lobby-framework-design.md
+    subsystem_doc: docs/superpowers/specs/2026-06-16-lobby-framework-design.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'NDBM outer container: magic NDBM(4) + version(1) + reserved(1) + manifestLen uint32BE(4) + manifest JSON + concat inner v1 bundles in manifest order'
+      - 'Compose, not mutate: each compartment is a complete standard v1 NDB1 bundle produced by writeNoydbBundle; the v1 format/validator is untouched'
+      - 'Pre-decrypt manifest: always-on fields handle/exportedAt/innerBytes/innerSha256; opt-in fields name/collections/publicEnvelope controlled per-compartment by writeMultiVaultBundle({ disclose })'
+      - 'readNoydbBundleManifest is format-polymorphic: NDBM returns N entries; a single v1 NDB1 bundle returns a 1-entry manifest (back-compat for uniform callers)'
+      - 'readMultiVaultBundleCompartment(bytes, handleOrIndex) extracts one compartment slice for direct pass-through to readNoydbBundle; for a v1 bundle the bundle itself is the only compartment'
+      - 'encodeMultiBundle / decodeMultiBundle are the low-level framing primitives; decodeMultiBundle validates magic, version, manifest JSON, and per-compartment innerBytes overrun'
+    related: [bundle, transferable-partition, public-envelope]
+
   - id: with-snapshots
     name: Snapshot lifecycle (withSnapshots)
     cluster: snapshot-and-portability

--- a/packages/hub/__tests__/multi-bundle.test.ts
+++ b/packages/hub/__tests__/multi-bundle.test.ts
@@ -31,12 +31,35 @@ describe('multi-bundle framing codec', () => {
   })
 
   it('rejects a manifest whose innerBytes sum exceeds the body', () => {
+    // Build a valid buffer (innerBytes matches actual length), then truncate
+    // one byte so decode sees the declared innerBytes overrunning the buffer.
+    const inner0 = new Uint8Array([1, 2, 3])
     const m: MultiBundleManifest = {
       multiFormatVersion: 1, handle: '01HZZZZZZZZZZZZZZZZZZZZZZZ',
-      compartments: [{ handle: '01HAAAAAAAAAAAAAAAAAAAAAAA', exportedAt: '2026-06-17T00:00:00.000Z', innerBytes: 999, innerSha256: 'a'.repeat(64) }],
+      compartments: [{ handle: '01HAAAAAAAAAAAAAAAAAAAAAAA', exportedAt: '2026-06-17T00:00:00.000Z', innerBytes: 3, innerSha256: 'a'.repeat(64) }],
     }
-    const bytes = encodeMultiBundle(m, [new Uint8Array([1, 2, 3])])
-    // tamper: truncate body so the declared innerBytes overruns
-    expect(() => decodeMultiBundle(bytes.subarray(0, bytes.length - 1))).toThrow(/truncat|overrun|length/i)
+    const good = encodeMultiBundle(m, [inner0])
+    // Truncate the last byte — decode now sees innerBytes=3 but only 2 bytes available.
+    expect(() => decodeMultiBundle(good.subarray(0, good.length - 1))).toThrow(/truncat|overrun|length/i)
+  })
+
+  it('encodeMultiBundle rejects an innerBytes / actual-length mismatch', () => {
+    const m: MultiBundleManifest = {
+      multiFormatVersion: 1, handle: '01HZZZZZZZZZZZZZZZZZZZZZZZ',
+      compartments: [{ handle: '01HAAAAAAAAAAAAAAAAAAAAAAA', exportedAt: '2026-06-17T00:00:00.000Z', innerBytes: 99, innerSha256: 'a'.repeat(64) }],
+    }
+    expect(() => encodeMultiBundle(m, [new Uint8Array([1, 2, 3])])).toThrow(/innerBytes|declares/i)
+  })
+
+  it('decodeMultiBundle rejects trailing bytes after the last compartment', () => {
+    const inner0 = new Uint8Array([1, 2, 3])
+    const m: MultiBundleManifest = {
+      multiFormatVersion: 1, handle: '01HZZZZZZZZZZZZZZZZZZZZZZZ',
+      compartments: [{ handle: '01HAAAAAAAAAAAAAAAAAAAAAAA', exportedAt: '2026-06-17T00:00:00.000Z', innerBytes: 3, innerSha256: 'a'.repeat(64) }],
+    }
+    const good = encodeMultiBundle(m, [inner0])
+    const withTrailer = new Uint8Array(good.length + 2)
+    withTrailer.set(good, 0)
+    expect(() => decodeMultiBundle(withTrailer)).toThrow(/trailing/i)
   })
 })

--- a/packages/hub/__tests__/multi-bundle.test.ts
+++ b/packages/hub/__tests__/multi-bundle.test.ts
@@ -141,6 +141,18 @@ describe('multi-bundle framing codec', () => {
     withTrailer.set(good, 0)
     expect(() => decodeMultiBundle(withTrailer)).toThrow(/trailing/i)
   })
+
+  it('rejects duplicate compartment handles', () => {
+    const dup = '01HAAAAAAAAAAAAAAAAAAAAAAA'
+    const m: MultiBundleManifest = {
+      multiFormatVersion: 1, handle: '01HZZZZZZZZZZZZZZZZZZZZZZZ',
+      compartments: [
+        { handle: dup, exportedAt: '2026-06-17T00:00:00.000Z', innerBytes: 1, innerSha256: 'a'.repeat(64) },
+        { handle: dup, exportedAt: '2026-06-17T00:00:00.000Z', innerBytes: 1, innerSha256: 'b'.repeat(64) },
+      ],
+    }
+    expect(() => encodeMultiBundle(m, [new Uint8Array([1]), new Uint8Array([2])])).toThrow(/duplicate/i)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/hub/__tests__/multi-bundle.test.ts
+++ b/packages/hub/__tests__/multi-bundle.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import {
+  NOYDB_MULTI_BUNDLE_MAGIC,
+  encodeMultiBundle,
+  decodeMultiBundle,
+  type MultiBundleManifest,
+} from '../src/bundle/multi-bundle.js'
+
+describe('multi-bundle framing codec', () => {
+  it('round-trips a manifest + inner byte blobs', () => {
+    const inner0 = new Uint8Array([1, 2, 3, 4, 5])
+    const inner1 = new Uint8Array([9, 8, 7])
+    const manifest: MultiBundleManifest = {
+      multiFormatVersion: 1,
+      handle: '01HZZZZZZZZZZZZZZZZZZZZZZZ',
+      compartments: [
+        { handle: '01HAAAAAAAAAAAAAAAAAAAAAAA', exportedAt: '2026-06-17T00:00:00.000Z', innerBytes: 5, innerSha256: 'a'.repeat(64), roleTag: 'shard' },
+        { handle: '01HBBBBBBBBBBBBBBBBBBBBBBB', exportedAt: '2026-06-17T00:00:00.000Z', innerBytes: 3, innerSha256: 'b'.repeat(64) },
+      ],
+    }
+    const bytes = encodeMultiBundle(manifest, [inner0, inner1])
+    expect(bytes.subarray(0, 4)).toEqual(NOYDB_MULTI_BUNDLE_MAGIC)
+    const decoded = decodeMultiBundle(bytes)
+    expect(decoded.manifest).toEqual(manifest)
+    expect(decoded.inner[0]).toEqual(inner0)
+    expect(decoded.inner[1]).toEqual(inner1)
+  })
+
+  it('rejects bytes without the NDBM magic', () => {
+    expect(() => decodeMultiBundle(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]))).toThrow(/magic/i)
+  })
+
+  it('rejects a manifest whose innerBytes sum exceeds the body', () => {
+    const m: MultiBundleManifest = {
+      multiFormatVersion: 1, handle: '01HZZZZZZZZZZZZZZZZZZZZZZZ',
+      compartments: [{ handle: '01HAAAAAAAAAAAAAAAAAAAAAAA', exportedAt: '2026-06-17T00:00:00.000Z', innerBytes: 999, innerSha256: 'a'.repeat(64) }],
+    }
+    const bytes = encodeMultiBundle(m, [new Uint8Array([1, 2, 3])])
+    // tamper: truncate body so the declared innerBytes overruns
+    expect(() => decodeMultiBundle(bytes.subarray(0, bytes.length - 1))).toThrow(/truncat|overrun|length/i)
+  })
+})

--- a/packages/hub/__tests__/multi-bundle.test.ts
+++ b/packages/hub/__tests__/multi-bundle.test.ts
@@ -1,10 +1,89 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import {
   NOYDB_MULTI_BUNDLE_MAGIC,
   encodeMultiBundle,
   decodeMultiBundle,
+  writeMultiVaultBundle,
+  readNoydbBundleManifest,
+  readMultiVaultBundleCompartment,
   type MultiBundleManifest,
 } from '../src/bundle/multi-bundle.js'
+import { writeNoydbBundle, readNoydbBundle } from '../src/bundle/bundle.js'
+import { readNoydbBundleHeader } from '../src/bundle/bundle.js'
+import { createNoydb } from '../src/noydb.js'
+import type { Noydb } from '../src/noydb.js'
+import type {
+  NoydbStore,
+  EncryptedEnvelope,
+  VaultSnapshot,
+  ListPageResult,
+} from '../src/types.js'
+import { ConflictError } from '../src/index.js'
+import type { Vault } from '../src/vault.js'
+
+/** Inline memory adapter — mirrors bundle.test.ts. */
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string): Map<string, EncryptedEnvelope> {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) {
+        for (const [name, coll] of existing) {
+          if (name.startsWith('_')) comp.set(name, coll)
+        }
+      }
+      store.set(c, comp)
+    },
+    async listPage(c, col, cursor, limit = 100): Promise<ListPageResult> {
+      const coll = store.get(c)?.get(col)
+      if (!coll) return { items: [], nextCursor: null }
+      const ids = [...coll.keys()].sort()
+      const start = cursor ? parseInt(cursor, 10) : 0
+      const end = Math.min(start + limit, ids.length)
+      const items: ListPageResult['items'] = []
+      for (let i = start; i < end; i++) {
+        const id = ids[i]!
+        const envelope = coll.get(id)
+        if (envelope) items.push({ id, envelope })
+      }
+      return { items, nextCursor: end < ids.length ? String(end) : null }
+    },
+  }
+}
 
 describe('multi-bundle framing codec', () => {
   it('round-trips a manifest + inner byte blobs', () => {
@@ -61,5 +140,141 @@ describe('multi-bundle framing codec', () => {
     const withTrailer = new Uint8Array(good.length + 2)
     withTrailer.set(good, 0)
     expect(() => decodeMultiBundle(withTrailer)).toThrow(/trailing/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Writer + reader integration (real vaults)
+// ---------------------------------------------------------------------------
+
+describe('multi-bundle > writer: writeMultiVaultBundle', () => {
+  let db: Noydb
+  let a: Vault
+  let b: Vault
+
+  beforeEach(async () => {
+    db = await createNoydb({
+      store: memory(),
+      user: 'owner',
+      secret: 'multi-bundle-test-passphrase-2026',
+    })
+    a = await db.openVault('VAULT-A')
+    const invoicesA = a.collection<{ id: string; amount: number }>('invoices')
+    await invoicesA.put('inv-1', { id: 'inv-1', amount: 100 })
+    await invoicesA.put('inv-2', { id: 'inv-2', amount: 200 })
+
+    b = await db.openVault('VAULT-B')
+    const invoicesB = b.collection<{ id: string; status: string }>('payments')
+    await invoicesB.put('pay-1', { id: 'pay-1', status: 'pending' })
+    await invoicesB.put('pay-2', { id: 'pay-2', status: 'settled' })
+  })
+
+  it('two compartments: one disclosed, one undisclosed', async () => {
+    const bytes = await writeMultiVaultBundle([
+      { vault: a, roleTag: 'shard', exportedAt: '2026-06-17T00:00:00.000Z', disclose: { name: true, collections: true } },
+      { vault: b, roleTag: 'pool' },
+    ])
+    const manifest = await readNoydbBundleManifest(bytes)
+    expect(manifest).toHaveLength(2)
+
+    // compartment [0]: roleTag and opt-in disclosures present
+    expect(manifest[0]!.roleTag).toBe('shard')
+    expect(manifest[0]!.name).toBe(a.name)                          // disclosed
+    expect(manifest[0]!.collections?.length).toBeGreaterThan(0)     // disclosed
+    expect(manifest[0]!.innerSha256).toMatch(/^[0-9a-f]{64}$/)
+
+    // compartment [1]: roleTag present but opt-in fields absent
+    expect(manifest[1]!.roleTag).toBe('pool')
+    expect(manifest[1]!.name).toBeUndefined()                       // not disclosed
+    expect(manifest[1]!.collections).toBeUndefined()                // not disclosed
+    expect(manifest[1]!.innerSha256).toMatch(/^[0-9a-f]{64}$/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Reader tests
+// ---------------------------------------------------------------------------
+
+describe('multi-bundle > readers', () => {
+  let db: Noydb
+  let a: Vault
+  let b: Vault
+
+  beforeEach(async () => {
+    db = await createNoydb({
+      store: memory(),
+      user: 'owner',
+      secret: 'multi-bundle-test-passphrase-2026',
+    })
+    a = await db.openVault('VAULT-A')
+    const invoicesA = a.collection<{ id: string; amount: number }>('invoices')
+    await invoicesA.put('inv-1', { id: 'inv-1', amount: 100 })
+    await invoicesA.put('inv-2', { id: 'inv-2', amount: 200 })
+
+    b = await db.openVault('VAULT-B')
+    const invoicesB = b.collection<{ id: string; status: string }>('payments')
+    await invoicesB.put('pay-1', { id: 'pay-1', status: 'pending' })
+    await invoicesB.put('pay-2', { id: 'pay-2', status: 'settled' })
+  })
+
+  it('each compartment loads independently via readNoydbBundle', async () => {
+    const bytes = await writeMultiVaultBundle([{ vault: a }, { vault: b }])
+    const manifest = await readNoydbBundleManifest(bytes)
+    for (const c of manifest) {
+      const innerBytes = readMultiVaultBundleCompartment(bytes, c.handle)
+      const { sha256Hex } = await import('../src/crypto.js')
+      const verifySha = await sha256Hex(innerBytes)
+      expect(verifySha).toBe(c.innerSha256)
+      const read = await readNoydbBundle(innerBytes)   // loads independently
+      expect(read.dumpJson.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('reads a single v1 bundle as a 1-entry manifest (back-compat)', async () => {
+    const v1 = await writeNoydbBundle(a)
+    const manifest = await readNoydbBundleManifest(v1)
+    expect(manifest).toHaveLength(1)
+    expect(manifest[0]!.handle).toBe(readNoydbBundleHeader(v1).handle)
+    // the whole v1 bundle IS the only compartment:
+    expect(readMultiVaultBundleCompartment(v1, manifest[0]!.handle)).toEqual(v1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Backward-compat + default disclosure assertions
+// ---------------------------------------------------------------------------
+
+describe('multi-bundle > back-compat + default disclosure', () => {
+  let db: Noydb
+  let a: Vault
+
+  beforeEach(async () => {
+    db = await createNoydb({
+      store: memory(),
+      user: 'owner',
+      secret: 'multi-bundle-test-passphrase-2026',
+    })
+    a = await db.openVault('VAULT-A')
+    const invoicesA = a.collection<{ id: string; amount: number }>('invoices')
+    await invoicesA.put('inv-1', { id: 'inv-1', amount: 100 })
+    await invoicesA.put('inv-2', { id: 'inv-2', amount: 200 })
+  })
+
+  it('single-vault writeNoydbBundle is byte-unaffected by this feature', async () => {
+    // Two writes of the same vault content produce stable handles (existing v1 guarantee).
+    const x = await writeNoydbBundle(a)
+    expect(readNoydbBundleHeader(x).formatVersion).toBe(1) // still v1; NDB1, not NDBM
+    expect(x.subarray(0, 4)).not.toEqual(NOYDB_MULTI_BUNDLE_MAGIC)
+  })
+
+  it('default manifest discloses only handle/roleTag/exportedAt (+ integrity), not name/collections', async () => {
+    const bytes = await writeMultiVaultBundle([{ vault: a, roleTag: 'shard' }])
+    const [c] = await readNoydbBundleManifest(bytes)
+    expect(c!.handle).toBeDefined()
+    expect(c!.exportedAt).toBeDefined()
+    expect(c!.roleTag).toBe('shard')
+    expect(c!.name).toBeUndefined()
+    expect(c!.collections).toBeUndefined()
+    expect(c!.publicEnvelope).toBeUndefined()
   })
 })

--- a/packages/hub/src/bundle/index.ts
+++ b/packages/hub/src/bundle/index.ts
@@ -41,6 +41,23 @@ export type {
 
 export { generateULID, isULID } from './ulid.js'
 
+// ─── Multi-compartment bundle (NDBM) ─────────────────────────────────
+export {
+  writeMultiVaultBundle,
+  readNoydbBundleManifest,
+  readMultiVaultBundleCompartment,
+  encodeMultiBundle,
+  decodeMultiBundle,
+  NOYDB_MULTI_BUNDLE_MAGIC,
+  NOYDB_MULTI_BUNDLE_PREFIX_BYTES,
+  NOYDB_MULTI_BUNDLE_VERSION,
+} from './multi-bundle.js'
+export type {
+  CompartmentManifest,
+  MultiBundleManifest,
+  MultiVaultCompartmentInput,
+} from './multi-bundle.js'
+
 // ─── Partition extraction ────────────────────────────────
 export { walkClosure } from './walk-closure.js'
 export type { WalkClosureOptions, ClosureResult } from './walk-closure.js'

--- a/packages/hub/src/bundle/multi-bundle.ts
+++ b/packages/hub/src/bundle/multi-bundle.ts
@@ -101,10 +101,10 @@ function validateManifest(parsed: unknown): asserts parsed is MultiBundleManifes
     if (c === null || typeof c !== 'object') throw new Error('multi-bundle compartment must be an object.')
     const e = c as Record<string, unknown>
     if (typeof e['handle'] !== 'string' || e['handle'].length === 0) throw new Error('multi-bundle compartment.handle must be a non-empty string.')
-    if (seenHandles.has(e['handle'] as string)) {
-      throw new Error(`multi-bundle manifest has a duplicate compartment handle "${e['handle'] as string}".`)
+    if (seenHandles.has(e['handle'])) {
+      throw new Error(`multi-bundle manifest has a duplicate compartment handle "${e['handle']}".`)
     }
-    seenHandles.add(e['handle'] as string)
+    seenHandles.add(e['handle'])
     if (typeof e['innerBytes'] !== 'number' || !Number.isInteger(e['innerBytes']) || e['innerBytes'] < 0) throw new Error('multi-bundle compartment.innerBytes must be a non-negative integer.')
     if (typeof e['innerSha256'] !== 'string' || !/^[0-9a-f]{64}$/.test(e['innerSha256'])) throw new Error('multi-bundle compartment.innerSha256 must be 64-char lowercase hex.')
   }

--- a/packages/hub/src/bundle/multi-bundle.ts
+++ b/packages/hub/src/bundle/multi-bundle.ts
@@ -1,0 +1,229 @@
+/**
+ * Multi-compartment `.noydb` bundle (`NDBM`). A thin outer container
+ * that embeds N standard single-vault `.noydb` bundles plus an
+ * unencrypted, owner-curated **manifest**. The v1 single-vault format
+ * is untouched; each compartment is a complete v1 bundle, produced by
+ * `writeNoydbBundle` and read by `readNoydbBundle`.
+ *
+ * Layout: magic 'NDBM'(4) · version(1) · reserved(1) · manifestLen(4 BE)
+ *         · manifest JSON · concat(inner v1 bundles, in manifest order).
+ *
+ * @packageDocumentation
+ */
+import type { Vault } from '../vault.js'
+import type { PublicEnvelope } from '../meta/public-envelope/types.js'
+import { sha256Hex } from '../crypto.js'
+import { generateULID } from './ulid.js'
+import { readUint32BE, writeUint32BE, hasNoydbBundleMagic } from './format.js'
+import {
+  writeNoydbBundle,
+  readNoydbBundleHeader,
+  readNoydbBundlePublicEnvelope,
+  type WriteNoydbBundleOptions,
+} from './bundle.js'
+
+/** Magic bytes 'NDBM' — NOYDB Multi-compartment bundle. */
+export const NOYDB_MULTI_BUNDLE_MAGIC = new Uint8Array([0x4e, 0x44, 0x42, 0x4d])
+/** Fixed prefix: magic(4) + version(1) + reserved(1) + manifestLen(4). */
+export const NOYDB_MULTI_BUNDLE_PREFIX_BYTES = 10
+/** Current multi-bundle layout version. */
+export const NOYDB_MULTI_BUNDLE_VERSION = 1
+
+/** One compartment's entry in the pre-decrypt manifest. */
+export interface CompartmentManifest {
+  /** The inner v1 bundle's stable ULID handle. */
+  readonly handle: string
+  /** Owner-curated classification (e.g. 'shard', 'pool'). Opt-in. */
+  readonly roleTag?: string
+  /** ISO export timestamp. Always set by the writer; absent for a v1 bundle read as a 1-entry manifest. */
+  readonly exportedAt?: string
+  /** Compartment (vault) name. Opt-in disclosure. */
+  readonly name?: string
+  /** Collection names + record counts. Opt-in disclosure. */
+  readonly collections?: readonly { readonly name: string; readonly count: number }[]
+  /** Inner bundle's owner-curated public envelope, surfaced. Opt-in. */
+  readonly publicEnvelope?: PublicEnvelope
+  /** Byte length of the inner v1 bundle (drives framing). */
+  readonly innerBytes: number
+  /** SHA-256 (lowercase hex) of the inner v1 bundle bytes — pre-decrypt integrity. */
+  readonly innerSha256: string
+}
+
+/** The unencrypted manifest of a multi-compartment bundle. */
+export interface MultiBundleManifest {
+  readonly multiFormatVersion: number
+  /** Opaque ULID for the outer container. */
+  readonly handle: string
+  readonly compartments: readonly CompartmentManifest[]
+}
+
+/** Assemble the `NDBM` container from a manifest + inner bundle bytes (in manifest order). */
+export function encodeMultiBundle(
+  manifest: MultiBundleManifest,
+  inner: readonly Uint8Array[],
+): Uint8Array {
+  if (manifest.compartments.length !== inner.length) {
+    throw new Error(`multi-bundle: manifest has ${manifest.compartments.length} compartments but ${inner.length} inner bundles were provided.`)
+  }
+  const manifestBytes = new TextEncoder().encode(JSON.stringify(manifest))
+  const bodyLen = inner.reduce((n, b) => n + b.length, 0)
+  const out = new Uint8Array(NOYDB_MULTI_BUNDLE_PREFIX_BYTES + manifestBytes.length + bodyLen)
+  out.set(NOYDB_MULTI_BUNDLE_MAGIC, 0)
+  out[4] = NOYDB_MULTI_BUNDLE_VERSION
+  out[5] = 0
+  writeUint32BE(out, 6, manifestBytes.length)
+  out.set(manifestBytes, NOYDB_MULTI_BUNDLE_PREFIX_BYTES)
+  let off = NOYDB_MULTI_BUNDLE_PREFIX_BYTES + manifestBytes.length
+  for (const b of inner) { out.set(b, off); off += b.length }
+  return out
+}
+
+function hasMultiMagic(bytes: Uint8Array): boolean {
+  if (bytes.length < NOYDB_MULTI_BUNDLE_MAGIC.length) return false
+  for (let i = 0; i < NOYDB_MULTI_BUNDLE_MAGIC.length; i++) if (bytes[i] !== NOYDB_MULTI_BUNDLE_MAGIC[i]) return false
+  return true
+}
+
+function validateManifest(parsed: unknown): asserts parsed is MultiBundleManifest {
+  if (parsed === null || typeof parsed !== 'object') throw new Error('multi-bundle manifest must be a JSON object.')
+  const m = parsed as Record<string, unknown>
+  if (m['multiFormatVersion'] !== NOYDB_MULTI_BUNDLE_VERSION) throw new Error(`multi-bundle manifest.multiFormatVersion must be ${NOYDB_MULTI_BUNDLE_VERSION}, got ${String(m['multiFormatVersion'])}.`)
+  if (typeof m['handle'] !== 'string') throw new Error('multi-bundle manifest.handle must be a string.')
+  if (!Array.isArray(m['compartments'])) throw new Error('multi-bundle manifest.compartments must be an array.')
+  for (const c of m['compartments'] as unknown[]) {
+    if (c === null || typeof c !== 'object') throw new Error('multi-bundle compartment must be an object.')
+    const e = c as Record<string, unknown>
+    if (typeof e['handle'] !== 'string') throw new Error('multi-bundle compartment.handle must be a string.')
+    if (typeof e['innerBytes'] !== 'number' || !Number.isInteger(e['innerBytes']) || e['innerBytes'] < 0) throw new Error('multi-bundle compartment.innerBytes must be a non-negative integer.')
+    if (typeof e['innerSha256'] !== 'string' || !/^[0-9a-f]{64}$/.test(e['innerSha256'])) throw new Error('multi-bundle compartment.innerSha256 must be 64-char lowercase hex.')
+  }
+}
+
+/** Parse the `NDBM` container into its manifest + raw inner bundle byte slices. */
+export function decodeMultiBundle(bytes: Uint8Array): { manifest: MultiBundleManifest; inner: Uint8Array[] } {
+  if (!hasMultiMagic(bytes)) throw new Error('not a NOYDB multi-bundle: missing NDBM magic.')
+  if (bytes.length < NOYDB_MULTI_BUNDLE_PREFIX_BYTES) throw new Error('multi-bundle truncated: shorter than the fixed prefix.')
+  if (bytes[4] !== NOYDB_MULTI_BUNDLE_VERSION) throw new Error(`unsupported multi-bundle version ${String(bytes[4])}.`)
+  const manifestLen = readUint32BE(bytes, 6)
+  const manifestEnd = NOYDB_MULTI_BUNDLE_PREFIX_BYTES + manifestLen
+  if (manifestEnd > bytes.length) throw new Error('multi-bundle truncated: manifest length overruns the buffer.')
+  const manifestJson = new TextDecoder('utf-8', { fatal: true }).decode(bytes.subarray(NOYDB_MULTI_BUNDLE_PREFIX_BYTES, manifestEnd))
+  let parsed: unknown
+  try { parsed = JSON.parse(manifestJson) } catch (err) { throw new Error(`multi-bundle manifest is not valid JSON: ${(err as Error).message}`) }
+  validateManifest(parsed)
+  const inner: Uint8Array[] = []
+  let off = manifestEnd
+  for (const c of parsed.compartments) {
+    const end = off + c.innerBytes
+    if (end > bytes.length) throw new Error(`multi-bundle truncated: compartment "${c.handle}" innerBytes overruns the buffer.`)
+    inner.push(bytes.subarray(off, end))
+    off = end
+  }
+  return { manifest: parsed, inner }
+}
+
+/** Per-compartment input to {@link writeMultiVaultBundle}. */
+export interface MultiVaultCompartmentInput {
+  readonly vault: Vault
+  /** Owner-curated classification surfaced in the manifest (e.g. 'shard', 'pool'). */
+  readonly roleTag?: string
+  /** ISO timestamp for the manifest; defaults to now. */
+  readonly exportedAt?: string
+  /** Opt-in pre-decrypt disclosure for this compartment. */
+  readonly disclose?: {
+    /** `true` → use `vault.name`; a string → that explicit name. */
+    readonly name?: boolean | string
+    /** `true` → include collection names + record counts. */
+    readonly collections?: boolean
+    /** `true` → surface the inner bundle's public envelope into the manifest. */
+    readonly publicEnvelope?: boolean
+  }
+  /** Options forwarded to `writeNoydbBundle` for this compartment's inner bundle. */
+  readonly bundleOptions?: WriteNoydbBundleOptions
+}
+
+/** Write N vaults into one `NDBM` multi-compartment bundle. */
+export async function writeMultiVaultBundle(
+  compartments: readonly MultiVaultCompartmentInput[],
+  opts: { readonly handle?: string } = {},
+): Promise<Uint8Array> {
+  if (compartments.length === 0) throw new Error('writeMultiVaultBundle: at least one compartment is required.')
+  const inner: Uint8Array[] = []
+  const entries: CompartmentManifest[] = []
+  for (const c of compartments) {
+    const innerBytes = await writeNoydbBundle(c.vault, c.bundleOptions ?? {})
+    const header = readNoydbBundleHeader(innerBytes)
+    const entry: {
+      -readonly [K in keyof CompartmentManifest]: CompartmentManifest[K]
+    } = {
+      handle: header.handle,
+      exportedAt: c.exportedAt ?? new Date().toISOString(),
+      innerBytes: innerBytes.length,
+      innerSha256: await sha256Hex(innerBytes),
+    }
+    if (c.roleTag !== undefined) entry.roleTag = c.roleTag
+    if (c.disclose?.name !== undefined && c.disclose.name !== false) {
+      entry.name = c.disclose.name === true ? c.vault.name : c.disclose.name
+    }
+    if (c.disclose?.collections === true) {
+      const names = await c.vault.collections()
+      entry.collections = await Promise.all(
+        names.map(async (n) => ({ name: n, count: await c.vault.collection(n).count() })),
+      )
+    }
+    if (c.disclose?.publicEnvelope === true) {
+      const env = readNoydbBundlePublicEnvelope(innerBytes)
+      if (env !== undefined) entry.publicEnvelope = env
+    }
+    inner.push(innerBytes)
+    entries.push(entry)
+  }
+  const manifest: MultiBundleManifest = {
+    multiFormatVersion: NOYDB_MULTI_BUNDLE_VERSION,
+    handle: opts.handle ?? generateULID(),
+    compartments: entries,
+  }
+  return encodeMultiBundle(manifest, inner)
+}
+
+/**
+ * Read the pre-decrypt manifest of a bundle WITHOUT decrypting any
+ * compartment. Accepts a multi-compartment `NDBM` bundle (returns its
+ * N entries) OR a single v1 `NDB1` bundle (returns a 1-entry manifest,
+ * for uniform handling). Throws on anything else.
+ */
+export async function readNoydbBundleManifest(bytes: Uint8Array): Promise<CompartmentManifest[]> {
+  if (hasMultiMagic(bytes)) return [...decodeMultiBundle(bytes).manifest.compartments]
+  if (hasNoydbBundleMagic(bytes)) {
+    const header = readNoydbBundleHeader(bytes)
+    const env = readNoydbBundlePublicEnvelope(bytes)
+    const entry: { -readonly [K in keyof CompartmentManifest]: CompartmentManifest[K] } = {
+      handle: header.handle,
+      innerBytes: bytes.length,
+      innerSha256: await sha256Hex(bytes),
+    }
+    if (env !== undefined) entry.publicEnvelope = env
+    return [entry]
+  }
+  throw new Error('readNoydbBundleManifest: not a NOYDB bundle (no NDB1 or NDBM magic).')
+}
+
+/**
+ * Extract one compartment's inner v1 `.noydb` bundle bytes (verified
+ * against its manifest `innerSha256`), ready to pass to `readNoydbBundle`.
+ * `selector` is a compartment `handle` or a zero-based index. For a
+ * single v1 bundle, the bundle itself is the only compartment.
+ */
+export function readMultiVaultBundleCompartment(bytes: Uint8Array, selector: string | number): Uint8Array {
+  if (hasNoydbBundleMagic(bytes) && !hasMultiMagic(bytes)) {
+    const header = readNoydbBundleHeader(bytes)
+    if (selector === 0 || selector === header.handle) return bytes
+    throw new Error(`readMultiVaultBundleCompartment: single v1 bundle has only compartment "${header.handle}".`)
+  }
+  const { manifest, inner } = decodeMultiBundle(bytes)
+  const idx = typeof selector === 'number'
+    ? selector
+    : manifest.compartments.findIndex((c) => c.handle === selector)
+  if (idx < 0 || idx >= inner.length) throw new Error(`readMultiVaultBundleCompartment: no compartment ${typeof selector === 'number' ? `at index ${selector}` : `"${selector}"`}.`)
+  return inner[idx]!
+}

--- a/packages/hub/src/bundle/multi-bundle.ts
+++ b/packages/hub/src/bundle/multi-bundle.ts
@@ -65,6 +65,11 @@ export function encodeMultiBundle(
   if (manifest.compartments.length !== inner.length) {
     throw new Error(`multi-bundle: manifest has ${manifest.compartments.length} compartments but ${inner.length} inner bundles were provided.`)
   }
+  for (let i = 0; i < inner.length; i++) {
+    if (manifest.compartments[i]!.innerBytes !== inner[i]!.length) {
+      throw new Error(`multi-bundle: compartment ${i} declares innerBytes ${manifest.compartments[i]!.innerBytes} but ${inner[i]!.length} bytes were provided.`)
+    }
+  }
   const manifestBytes = new TextEncoder().encode(JSON.stringify(manifest))
   const bodyLen = inner.reduce((n, b) => n + b.length, 0)
   const out = new Uint8Array(NOYDB_MULTI_BUNDLE_PREFIX_BYTES + manifestBytes.length + bodyLen)
@@ -88,12 +93,12 @@ function validateManifest(parsed: unknown): asserts parsed is MultiBundleManifes
   if (parsed === null || typeof parsed !== 'object') throw new Error('multi-bundle manifest must be a JSON object.')
   const m = parsed as Record<string, unknown>
   if (m['multiFormatVersion'] !== NOYDB_MULTI_BUNDLE_VERSION) throw new Error(`multi-bundle manifest.multiFormatVersion must be ${NOYDB_MULTI_BUNDLE_VERSION}, got ${String(m['multiFormatVersion'])}.`)
-  if (typeof m['handle'] !== 'string') throw new Error('multi-bundle manifest.handle must be a string.')
+  if (typeof m['handle'] !== 'string' || m['handle'].length === 0) throw new Error('multi-bundle manifest.handle must be a non-empty string.')
   if (!Array.isArray(m['compartments'])) throw new Error('multi-bundle manifest.compartments must be an array.')
   for (const c of m['compartments'] as unknown[]) {
     if (c === null || typeof c !== 'object') throw new Error('multi-bundle compartment must be an object.')
     const e = c as Record<string, unknown>
-    if (typeof e['handle'] !== 'string') throw new Error('multi-bundle compartment.handle must be a string.')
+    if (typeof e['handle'] !== 'string' || e['handle'].length === 0) throw new Error('multi-bundle compartment.handle must be a non-empty string.')
     if (typeof e['innerBytes'] !== 'number' || !Number.isInteger(e['innerBytes']) || e['innerBytes'] < 0) throw new Error('multi-bundle compartment.innerBytes must be a non-negative integer.')
     if (typeof e['innerSha256'] !== 'string' || !/^[0-9a-f]{64}$/.test(e['innerSha256'])) throw new Error('multi-bundle compartment.innerSha256 must be 64-char lowercase hex.')
   }
@@ -118,6 +123,9 @@ export function decodeMultiBundle(bytes: Uint8Array): { manifest: MultiBundleMan
     if (end > bytes.length) throw new Error(`multi-bundle truncated: compartment "${c.handle}" innerBytes overruns the buffer.`)
     inner.push(bytes.subarray(off, end))
     off = end
+  }
+  if (off !== bytes.length) {
+    throw new Error(`multi-bundle: ${bytes.length - off} trailing byte(s) after the last compartment — buffer may be corrupt.`)
   }
   return { manifest: parsed, inner }
 }
@@ -209,10 +217,16 @@ export async function readNoydbBundleManifest(bytes: Uint8Array): Promise<Compar
 }
 
 /**
- * Extract one compartment's inner v1 `.noydb` bundle bytes (verified
- * against its manifest `innerSha256`), ready to pass to `readNoydbBundle`.
- * `selector` is a compartment `handle` or a zero-based index. For a
- * single v1 bundle, the bundle itself is the only compartment.
+ * Extract one compartment's inner v1 `.noydb` bundle bytes, ready to
+ * pass to `readNoydbBundle`. `selector` is a compartment `handle` or a
+ * zero-based index. For a single v1 bundle, the bundle itself is the
+ * only compartment.
+ *
+ * Does NOT verify the manifest `innerSha256` — it returns the raw
+ * slice. Integrity is enforced downstream: `readNoydbBundle` verifies
+ * the inner bundle's own `bodySha256`. Callers wanting an early,
+ * pre-decrypt check can hash the returned bytes against the
+ * compartment's `innerSha256`.
  */
 export function readMultiVaultBundleCompartment(bytes: Uint8Array, selector: string | number): Uint8Array {
   if (hasNoydbBundleMagic(bytes) && !hasMultiMagic(bytes)) {

--- a/packages/hub/src/bundle/multi-bundle.ts
+++ b/packages/hub/src/bundle/multi-bundle.ts
@@ -62,6 +62,7 @@ export function encodeMultiBundle(
   manifest: MultiBundleManifest,
   inner: readonly Uint8Array[],
 ): Uint8Array {
+  validateManifest(manifest)
   if (manifest.compartments.length !== inner.length) {
     throw new Error(`multi-bundle: manifest has ${manifest.compartments.length} compartments but ${inner.length} inner bundles were provided.`)
   }
@@ -95,10 +96,15 @@ function validateManifest(parsed: unknown): asserts parsed is MultiBundleManifes
   if (m['multiFormatVersion'] !== NOYDB_MULTI_BUNDLE_VERSION) throw new Error(`multi-bundle manifest.multiFormatVersion must be ${NOYDB_MULTI_BUNDLE_VERSION}, got ${String(m['multiFormatVersion'])}.`)
   if (typeof m['handle'] !== 'string' || m['handle'].length === 0) throw new Error('multi-bundle manifest.handle must be a non-empty string.')
   if (!Array.isArray(m['compartments'])) throw new Error('multi-bundle manifest.compartments must be an array.')
+  const seenHandles = new Set<string>()
   for (const c of m['compartments'] as unknown[]) {
     if (c === null || typeof c !== 'object') throw new Error('multi-bundle compartment must be an object.')
     const e = c as Record<string, unknown>
     if (typeof e['handle'] !== 'string' || e['handle'].length === 0) throw new Error('multi-bundle compartment.handle must be a non-empty string.')
+    if (seenHandles.has(e['handle'] as string)) {
+      throw new Error(`multi-bundle manifest has a duplicate compartment handle "${e['handle'] as string}".`)
+    }
+    seenHandles.add(e['handle'] as string)
     if (typeof e['innerBytes'] !== 'number' || !Number.isInteger(e['innerBytes']) || e['innerBytes'] < 0) throw new Error('multi-bundle compartment.innerBytes must be a non-negative integer.')
     if (typeof e['innerSha256'] !== 'string' || !/^[0-9a-f]{64}$/.test(e['innerSha256'])) throw new Error('multi-bundle compartment.innerSha256 must be 64-char lowercase hex.')
   }
@@ -229,6 +235,9 @@ export async function readNoydbBundleManifest(bytes: Uint8Array): Promise<Compar
  * compartment's `innerSha256`.
  */
 export function readMultiVaultBundleCompartment(bytes: Uint8Array, selector: string | number): Uint8Array {
+  if (typeof selector === 'number' && !Number.isInteger(selector)) {
+    throw new Error(`readMultiVaultBundleCompartment: numeric selector must be an integer, got ${selector}.`)
+  }
   if (hasNoydbBundleMagic(bytes) && !hasMultiMagic(bytes)) {
     const header = readNoydbBundleHeader(bytes)
     if (selector === 0 || selector === header.handle) return bytes

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -533,6 +533,10 @@ export type {
 } from './meta/public-envelope/index.js'
 export { readNoydbBundlePublicEnvelope } from './bundle/bundle.js'
 
+// Multi-compartment bundle (NDBM) — writeMultiVaultBundle / readNoydbBundleManifest / readMultiVaultBundleCompartment
+export { writeMultiVaultBundle, readNoydbBundleManifest, readMultiVaultBundleCompartment } from './bundle/multi-bundle.js'
+export type { CompartmentManifest, MultiBundleManifest, MultiVaultCompartmentInput } from './bundle/multi-bundle.js'
+
 // User envelope (docs/superpowers/specs/2026-05-05-user-envelope-design.md)
 export {
   USER_ENVELOPE_COLLECTION,


### PR DESCRIPTION
## Summary

First capability of the pilot-1 epic (#441 / vLannaAi/klum-db#1): a multi-compartment `.noydb` bundle so one container can carry N vaults with a pre-decrypt **manifest** — the foundation FR-2 (cross-vault FK-closure extraction) and FR-9 (multi-vault export) build on.

**Compose, don't mutate.** A multi-compartment bundle is a **new outer container (`NDBM` magic)** that embeds N untouched standard v1 `.noydb` bundles + an opt-in, owner-curated manifest. The v1 single-vault format (`format.ts`/`bundle.ts`) is **completely untouched** — so back-compat is structural, and "each compartment loads independently" is free (each *is* a standard bundle, read by the existing `readNoydbBundle`).

New API in `@noy-db/hub` (+ `@noy-db/hub/bundle`):
- `writeMultiVaultBundle(compartments, opts)` — composes `writeNoydbBundle` per vault into one `NDBM` container.
- `readNoydbBundleManifest(bytes)` — pre-decrypt manifest; also reads a v1 bundle as a 1-entry manifest (uniform handling).
- `readMultiVaultBundleCompartment(bytes, handle|index)` — extract one compartment's inner v1 bundle bytes → `readNoydbBundle`.
- `encodeMultiBundle`/`decodeMultiBundle` (lower-level framing codec), `CompartmentManifest`/`MultiBundleManifest`/`MultiVaultCompartmentInput` types.

**Manifest disclosure = opt-in, layered** (the privacy reconciliation): always `handle`/`roleTag?`/`exportedAt`/`innerBytes`/`innerSha256`; opt-in per compartment `name`/`collections[{name,count}]`/`publicEnvelope`. The strict inner v1 headers stay minimum-disclosure; the outer manifest is the owner-curated layer (like the existing `publicEnvelope`).

**Format-safety:** `NDBM` is distinct from `NDB1` (v1 readers fail-closed); `encodeMultiBundle` cross-checks declared vs actual `innerBytes`; `decodeMultiBundle` rejects bad magic, manifest overrun, per-compartment overrun, and trailing bytes; `validateManifest` rejects malformed shapes.

Scope: **pure hub format** — no `@klum-db` change (the Lobby orchestration that *drives* multi-compartment emission is FR-2).

Built subagent-driven with per-task spec + code-quality reviews (which added the codec self-consistency guards) + a final whole-feature review.

## Test plan
- [x] `pnpm --filter @noy-db/hub test` — 2649 green; new `multi-bundle.test.ts` 10/10 (framing round-trip + hostile-framing rejections; writer w/ real 2-vault disclosure; independent per-compartment decode via `readNoydbBundle`; v1→1-entry back-compat; default-minimal disclosure)
- [x] `pnpm --filter @noy-db/hub typecheck` — clean
- [x] `node scripts/validate-features.mjs` — OK (registered `multi-compartment-bundle`)
- [x] `pnpm check:architecture` — OK
- [x] hub `bundle-check` — leak canaries ✓ (v1 main entry untouched)

## Follow-up (non-blocking)
- Add a positive test for `disclose:{publicEnvelope:true}` surfacing (needs a source vault carrying a public envelope; the wire-up reuses the separately-tested `readNoydbBundlePublicEnvelope`).