### PR TITLE
FR-2: cross-vault FK-closure extraction → multi-compartment bundle

### DIFF
--- a/docs/superpowers/plans/2026-06-17-fr2-cross-vault-extraction.md
+++ b/docs/superpowers/plans/2026-06-17-fr2-cross-vault-extraction.md
@@ -1,0 +1,400 @@
+# FR-2: Cross-vault FK-closure extraction → multi-compartment bundle — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A `@klum-db/lobby` orchestrator that walks an FK closure spanning vault boundaries (via an app-supplied cross-vault descriptor) and emits the seed vault's partition + exactly the FK-referenced slice of each other vault as compartments of one multi-compartment bundle.
+
+**Architecture:** Pure `@klum-db/lobby` — composes hub's intra-vault primitives (`walkClosure`, `extractPartition`, `describeExtraction`) + FR-1's low-level `encodeMultiBundle` (composes *extracted-partition* bundle bytes, not snapshots). **hub is unchanged** (hub's `ref()` deliberately rejects cross-vault refs — `RefScopeError` — so the cross-vault edges live in a klum descriptor; the extraction primitives are intra-vault and reused as-is). FR-2 epic #442; design spec `docs/superpowers/specs/2026-06-16-lobby-framework-design.md` §8.
+
+**Tech Stack:** TS strict, ESM `.js` specifiers, vitest. New code in `@klum-db/lobby` (`packages/lobby/src/interchange/`). Imports from `@noy-db/hub`, `@noy-db/hub/bundle`, `@noy-db/hub/kernel`.
+
+**Approved decisions:**
+- **Per-compartment transfer keys** — each `extractPartition` mints its own; the result returns a `{ vaultName → transferKey }` map (out-of-band). Zero hub change. Unified-handoff UX deferred to FR-6.
+- **Scope = extract + describe** — `walkCrossVaultClosure` + `extractCrossVaultPartition` + `describeCrossVaultExtraction`. The adopt/merge side is FR-3.
+- **Pure klum** — no hub change.
+
+**⚠️ Lint discipline (FR-1 lesson):** run `pnpm --filter @klum-db/lobby lint` AND the FR-1 gate-gap killer `pnpm lint && pnpm typecheck` (full monorepo) before the final commit — package `typecheck` alone does not catch eslint errors.
+
+---
+
+## The cross-vault closure algorithm (Task 1 reference)
+
+Hub's `walkClosure(vault, {seeds})` returns `{ closure: Map<collection, Set<id>> }` for ONE vault, using that vault's intra-vault refs. FR-2 bridges vaults:
+
+1. Walk the **primary** vault with the caller's seed predicates → its closure.
+2. **Harvest** cross-vault FK values: for each `CrossVaultRef {from:{collection,field}, to:{vault,collection,field?='id'}}` whose `from.collection` is in the closure, read each closure record and collect `record[from.field]` (scalar or array) into a per-target id-set `targetIds[to.vault][to.collection]`.
+3. For each **target** vault, walk it with a seed predicate selecting records whose `to.field` (default `id`) ∈ the accumulated id-set → its closure. Harvest ITS cross-vault FKs (transitive).
+4. **Fixpoint:** repeat (3) for any target whose id-set grew, bounded by `maxDepth` rounds, deduping already-walked `(vault, idset-signature)` to terminate on cycles.
+5. **Dangling check:** every harvested `(targetVault, targetCollection, id)` must appear in that target's final closure; otherwise it's a dangling ref (referenced row missing/inaccessible) → collect and fail.
+
+The per-vault **seed predicates** (primary: caller's; targets: id-membership) are what feed `extractPartition` later — it re-derives the identical intra-closure from them.
+
+---
+
+## File structure
+- **Create** `packages/lobby/src/interchange/extract-cross-vault.ts` — types, `walkCrossVaultClosure`, `extractCrossVaultPartition`, `describeCrossVaultExtraction`, `CrossVaultDanglingRefError`.
+- **Create** `packages/lobby/__tests__/extract-cross-vault.test.ts`.
+- **Modify** `packages/lobby/src/index.ts` — public exports.
+- **Modify** `features.yaml` — register the capability.
+
+---
+
+## Task 1 — Cross-vault descriptor + `walkCrossVaultClosure` (TDD)
+
+**Files:** Create `packages/lobby/src/interchange/extract-cross-vault.ts` + the test.
+
+- [ ] **Step 1: Failing test.** Set up TWO in-memory vaults via `createNoydb` + `@noy-db/to-memory` `memory()` (follow `packages/lobby/__tests__/federation-*.test.ts` for the idiom): a `directory` vault with `entities` (`{id:'e1',name:'Acme'}`, `{id:'e2',name:'Beta'}`, `{id:'e3',name:'Gamma'}`) and a `client` vault with `bills` (`{id:'b1',entityId:'e1'}`, `{id:'b2',entityId:'e2'}`). Then:
+```typescript
+import { walkCrossVaultClosure, type CrossVaultRef } from '../src/interchange/extract-cross-vault.js'
+
+const refs: CrossVaultRef[] = [{ from: { collection: 'bills', field: 'entityId' }, to: { vault: 'directory', collection: 'entities' } }]
+const plan = await walkCrossVaultClosure((name) => db.openVault(name), {
+  seed: { vault: 'client', seeds: { bills: () => true } },
+  crossVaultRefs: refs,
+})
+// primary closure has both bills
+expect(plan.perVaultClosure.get('client')!.get('bills')!.size).toBe(2)
+// directory closure has EXACTLY e1,e2 (referenced) — NOT e3
+const dirEntities = plan.perVaultClosure.get('directory')!.get('entities')!
+expect([...dirEntities].sort()).toEqual(['e1', 'e2'])
+expect(plan.dangling).toEqual([])
+```
+Add a second test: a bill referencing a missing `e9` → `plan.dangling` contains `{vault:'directory',collection:'entities',id:'e9'}`.
+
+- [ ] **Step 2: Run → fail** (`pnpm --filter @klum-db/lobby test -- extract-cross-vault`).
+
+- [ ] **Step 3: Implement types + `walkCrossVaultClosure`** in `extract-cross-vault.ts`:
+```typescript
+/**
+ * @klum-db/lobby interchange — cross-vault FK-closure extraction.
+ * Composes hub's intra-vault primitives + FR-1's encodeMultiBundle.
+ * @packageDocumentation
+ */
+import type { Vault } from '@noy-db/hub'
+import { walkClosure } from '@noy-db/hub/bundle'
+
+/** A denormalized cross-vault FK edge (hub refuses these as native refs). */
+export interface CrossVaultRef {
+  readonly from: { readonly collection: string; readonly field: string }
+  readonly to: { readonly vault: string; readonly collection: string; readonly field?: string }
+}
+
+/** Seed for the primary vault (predicate per collection, like hub walkClosure). */
+export interface CrossVaultSeed {
+  readonly vault: string
+  readonly seeds: Record<string, (rec: Record<string, unknown>) => boolean | Promise<boolean>>
+}
+
+export interface CrossVaultClosurePlan {
+  /** vault → seed predicates to feed extractPartition (primary: caller's; targets: id-membership). */
+  readonly perVaultSeeds: Map<string, Record<string, (rec: Record<string, unknown>) => boolean | Promise<boolean>>>
+  /** vault → intra closure (collection → ids). */
+  readonly perVaultClosure: Map<string, Map<string, Set<string>>>
+  /** referenced rows not found in their target closure. */
+  readonly dangling: { vault: string; collection: string; id: string }[]
+}
+
+function asIdArray(v: unknown): string[] {
+  if (v === null || v === undefined) return []
+  if (Array.isArray(v)) return v.filter((x) => typeof x === 'string' || typeof x === 'number').map(String)
+  if (typeof v === 'string' || typeof v === 'number') return [String(v)]
+  return []
+}
+
+export async function walkCrossVaultClosure(
+  openVault: (name: string) => Promise<Vault>,
+  opts: { seed: CrossVaultSeed; crossVaultRefs?: readonly CrossVaultRef[]; maxDepth?: number },
+): Promise<CrossVaultClosurePlan> {
+  const refs = opts.crossVaultRefs ?? []
+  const maxDepth = opts.maxDepth ?? 16
+  const perVaultClosure = new Map<string, Map<string, Set<string>>>()
+  const perVaultSeeds: CrossVaultClosurePlan['perVaultSeeds'] = new Map()
+  // accumulated referenced ids per target vault+collection
+  const targetIds = new Map<string, Map<string, Set<string>>>()
+  const addTarget = (v: string, c: string, id: string) => {
+    let m = targetIds.get(v); if (!m) { m = new Map(); targetIds.set(v, m) }
+    let s = m.get(c); if (!s) { s = new Set(); m.set(c, s) }
+    s.add(id)
+  }
+  const mergeClosure = (v: string, cl: Map<string, Set<string>>) => {
+    let dest = perVaultClosure.get(v); if (!dest) { dest = new Map(); perVaultClosure.set(v, dest) }
+    for (const [c, ids] of cl) { let s = dest.get(c); if (!s) { s = new Set(); dest.set(c, s) } for (const id of ids) s.add(id) }
+  }
+
+  // round 0: primary
+  perVaultSeeds.set(opts.seed.vault, opts.seed.seeds)
+  const queue: string[] = [opts.seed.vault]
+  const walkedSignature = new Set<string>()
+
+  let round = 0
+  while (queue.length > 0) {
+    if (round++ > maxDepth) break
+    const batch = queue.splice(0, queue.length)
+    for (const vaultName of batch) {
+      const seeds = perVaultSeeds.get(vaultName)!
+      const v = await openVault(vaultName)
+      const { closure } = await walkClosure(v, { seeds, ...(opts.maxDepth !== undefined ? { maxDepth: opts.maxDepth } : {}) })
+      mergeClosure(vaultName, closure)
+      // harvest cross-vault FKs from this vault's closure
+      for (const ref of refs) {
+        const ids = closure.get(ref.from.collection)
+        if (!ids) continue
+        const coll = v.collection<Record<string, unknown>>(ref.from.collection)
+        for (const id of ids) {
+          const rec = await coll.get(id)
+          for (const fk of asIdArray(rec?.[ref.from.field])) addTarget(ref.to.vault, ref.to.collection, fk)
+        }
+      }
+    }
+    // enqueue targets whose id-set introduces records not yet in their closure
+    for (const [tVault, colls] of targetIds) {
+      for (const [tColl, ids] of colls) {
+        const field = refs.find((r) => r.to.vault === tVault && r.to.collection === tColl)?.to.field ?? 'id'
+        const have = perVaultClosure.get(tVault)?.get(tColl) ?? new Set<string>()
+        const sig = `${tVault} ${tColl} ${[...ids].sort().join(',')}`
+        if ([...ids].every((id) => have.has(id)) || walkedSignature.has(sig)) continue
+        walkedSignature.add(sig)
+        const wanted = new Set(ids)
+        const seed = { [tColl]: (rec: Record<string, unknown>) => wanted.has(String(rec[field])) }
+        const existing = perVaultSeeds.get(tVault)
+        perVaultSeeds.set(tVault, existing ? { ...existing, ...seed } : seed)
+        queue.push(tVault)
+      }
+    }
+  }
+
+  // dangling check
+  const dangling: CrossVaultClosurePlan['dangling'] = []
+  for (const [tVault, colls] of targetIds) {
+    for (const [tColl, ids] of colls) {
+      const have = perVaultClosure.get(tVault)?.get(tColl) ?? new Set<string>()
+      for (const id of ids) if (!have.has(id)) dangling.push({ vault: tVault, collection: tColl, id })
+    }
+  }
+  return { perVaultSeeds, perVaultClosure, dangling }
+}
+```
+(Cross-check `walkClosure`'s `WalkClosureOptions`/`ClosureResult` shape against `@noy-db/hub/bundle`; `vault.collection(name).get(id)` returns `T | null`. If `db.openVault` differs, the caller passes the resolver, so the module stays decoupled.)
+
+- [ ] **Step 4: Run → pass.** Then `pnpm --filter @klum-db/lobby typecheck`.
+- [ ] **Step 5: Commit** — `git add packages/lobby/src/interchange/extract-cross-vault.ts packages/lobby/__tests__/extract-cross-vault.test.ts && git commit -m "feat(lobby): walkCrossVaultClosure — cross-vault FK closure planner"`
+
+---
+
+## Task 2 — `extractCrossVaultPartition` (emit multi-compartment bundle) (TDD)
+
+**Files:** Modify `extract-cross-vault.ts` + the test.
+
+- [ ] **Step 1: Failing test** (reuse the Task-1 two-vault fixture):
+```typescript
+import { extractCrossVaultPartition } from '../src/interchange/extract-cross-vault.js'
+import { readNoydbBundleManifest, readMultiVaultBundleCompartment } from '@noy-db/hub/bundle'
+
+const res = await extractCrossVaultPartition((name) => db.openVault(name), {
+  seed: { vault: 'client', seeds: { bills: () => true } },
+  crossVaultRefs: refs,
+  compartmentMeta: { client: { roleTag: 'shard' }, directory: { roleTag: 'pool', disclose: { name: true } } },
+})
+const manifest = await readNoydbBundleManifest(res.bundle)
+expect(manifest.map((m) => m.roleTag).sort()).toEqual(['pool', 'shard'])
+expect(Object.keys(res.transferKeys).sort()).toEqual(['client', 'directory'])  // per-compartment keys
+// the directory compartment carries EXACTLY e1,e2 (FK-reachable), not e3 — verify by adopting it
+import { adoptPartition, createOwnerOnAdoptedPartition } from '@noy-db/hub/bundle'
+import { memory } from '@noy-db/to-memory'
+const dirEntry = manifest.find((m) => m.roleTag === 'pool')!
+const dirBytes = readMultiVaultBundleCompartment(res.bundle, dirEntry.handle)
+const destStore = memory()
+await adoptPartition(dirBytes, { transferKey: res.transferKeys['directory']!, destinationStore: destStore, vaultName: 'dir-adopted' })
+await createOwnerOnAdoptedPartition(destStore, 'dir-adopted', { userId: 'u', passphrase: 'correct-horse-battery-staple', transferKey: res.transferKeys['directory']! })
+const dest = await (await createNoydb({ store: destStore, user: 'u', secret: 'correct-horse-battery-staple' })).openVault('dir-adopted')
+const adoptedEntities = (await dest.collection('entities').list()).map((r:any)=>r.id).sort()
+expect(adoptedEntities).toEqual(['e1', 'e2'])   // exactly the referenced rows, no e3
+```
+(If the adopt ceremony's exact option shape differs, match `AdoptPartitionOptions`/`CreateOwnerStandardOptions` from `@noy-db/hub/bundle`. The essential assertion: the directory compartment contains e1,e2 and NOT e3.)
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement** — append to `extract-cross-vault.ts`:
+```typescript
+import { extractPartition, encodeMultiBundle, readNoydbBundleHeader, readNoydbBundlePublicEnvelope, NOYDB_MULTI_BUNDLE_VERSION, generateULID, type MultiBundleManifest, type CompartmentManifest } from '@noy-db/hub/bundle'
+import { sha256Hex } from '@noy-db/hub/kernel'
+
+export class CrossVaultDanglingRefError extends Error {
+  constructor(readonly dangling: { vault: string; collection: string; id: string }[]) {
+    super(`cross-vault extraction: ${dangling.length} referenced row(s) missing from their target closure: ` + dangling.map((d) => `${d.vault}/${d.collection}/${d.id}`).slice(0, 5).join(', '))
+    this.name = 'CrossVaultDanglingRefError'
+  }
+}
+
+export interface CompartmentMeta {
+  readonly roleTag?: string
+  readonly disclose?: { readonly name?: boolean | string; readonly collections?: boolean; readonly publicEnvelope?: boolean }
+}
+
+export interface ExtractCrossVaultOptions {
+  readonly seed: CrossVaultSeed
+  readonly crossVaultRefs?: readonly CrossVaultRef[]
+  readonly maxDepth?: number
+  readonly carrySchemas?: boolean
+  readonly carryLedger?: boolean
+  readonly compression?: 'auto' | 'brotli' | 'gzip' | 'none'
+  readonly compartmentMeta?: Record<string, CompartmentMeta>
+}
+
+export interface ExtractCrossVaultResult {
+  readonly bundle: Uint8Array
+  readonly transferKeys: Record<string, Uint8Array>
+  readonly sealIds: Record<string, string>
+}
+
+export async function extractCrossVaultPartition(
+  openVault: (name: string) => Promise<Vault>,
+  opts: ExtractCrossVaultOptions,
+): Promise<ExtractCrossVaultResult> {
+  const plan = await walkCrossVaultClosure(openVault, opts)
+  if (plan.dangling.length > 0) throw new CrossVaultDanglingRefError(plan.dangling)
+
+  const inner: Uint8Array[] = []
+  const compartments: CompartmentManifest[] = []
+  const transferKeys: Record<string, Uint8Array> = {}
+  const sealIds: Record<string, string> = {}
+
+  for (const [vaultName, seeds] of plan.perVaultSeeds) {
+    const v = await openVault(vaultName)
+    const { bundleBytes, transferKey, sealId } = await extractPartition(v, {
+      seeds,
+      ...(opts.maxDepth !== undefined ? { maxDepth: opts.maxDepth } : {}),
+      carrySchemas: opts.carrySchemas ?? true,
+      carryLedger: opts.carryLedger ?? false,
+      ...(opts.compression !== undefined ? { compression: opts.compression } : {}),
+    })
+    const header = readNoydbBundleHeader(bundleBytes)
+    const meta = opts.compartmentMeta?.[vaultName]
+    const entry: { -readonly [K in keyof CompartmentManifest]: CompartmentManifest[K] } = {
+      handle: header.handle,
+      exportedAt: new Date().toISOString(),
+      innerBytes: bundleBytes.length,
+      innerSha256: await sha256Hex(bundleBytes),
+    }
+    if (meta?.roleTag !== undefined) entry.roleTag = meta.roleTag
+    if (meta?.disclose?.name !== undefined && meta.disclose.name !== false) entry.name = meta.disclose.name === true ? v.name : meta.disclose.name
+    if (meta?.disclose?.collections === true) {
+      const cl = plan.perVaultClosure.get(vaultName)
+      if (cl) entry.collections = [...cl].map(([name, ids]) => ({ name, count: ids.size }))
+    }
+    if (meta?.disclose?.publicEnvelope === true) {
+      const env = readNoydbBundlePublicEnvelope(bundleBytes)
+      if (env !== undefined) entry.publicEnvelope = env
+    }
+    inner.push(bundleBytes); compartments.push(entry)
+    transferKeys[vaultName] = transferKey; sealIds[vaultName] = sealId
+  }
+
+  const manifest: MultiBundleManifest = { multiFormatVersion: NOYDB_MULTI_BUNDLE_VERSION, handle: generateULID(), compartments }
+  return { bundle: encodeMultiBundle(manifest, inner), transferKeys, sealIds }
+}
+```
+(Confirm `generateULID`/`NOYDB_MULTI_BUNDLE_VERSION`/`readNoydbBundlePublicEnvelope` are exported from `@noy-db/hub/bundle` — they are, per FR-1's `bundle/index.ts`. Note `collections` count here comes from the closure plan, not a full `vault.collections()` scan — it reflects exactly the extracted slice.)
+
+- [ ] **Step 4: Run → pass; typecheck.**
+- [ ] **Step 5: Commit** — `git commit -am "feat(lobby): extractCrossVaultPartition — emit multi-compartment bundle + per-compartment transfer keys"`
+
+---
+
+## Task 3 — `describeCrossVaultExtraction` (per-compartment preview) (TDD)
+
+**Files:** Modify `extract-cross-vault.ts` + the test.
+
+- [ ] **Step 1: Failing test:**
+```typescript
+import { describeCrossVaultExtraction } from '../src/interchange/extract-cross-vault.js'
+const preview = await describeCrossVaultExtraction((name) => db.openVault(name), { seed: { vault: 'client', seeds: { bills: () => true } }, crossVaultRefs: refs })
+expect(preview.compartments.map((c) => c.vault).sort()).toEqual(['client', 'directory'])
+const dir = preview.compartments.find((c) => c.vault === 'directory')!
+expect(dir.preview.byCollection.find((b) => b.name === 'entities')!.recordCount).toBe(2)  // e1,e2
+expect(preview.dangling).toEqual([])
+```
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement** — append:
+```typescript
+import { describeExtraction, type ExtractionPreview } from '@noy-db/hub/bundle'
+
+export interface CrossVaultPreview {
+  readonly compartments: { readonly vault: string; readonly preview: ExtractionPreview }[]
+  readonly dangling: { vault: string; collection: string; id: string }[]
+}
+
+export async function describeCrossVaultExtraction(
+  openVault: (name: string) => Promise<Vault>,
+  opts: { seed: CrossVaultSeed; crossVaultRefs?: readonly CrossVaultRef[]; maxDepth?: number },
+): Promise<CrossVaultPreview> {
+  const plan = await walkCrossVaultClosure(openVault, opts)
+  const compartments: CrossVaultPreview['compartments'] = []
+  for (const [vaultName, seeds] of plan.perVaultSeeds) {
+    const v = await openVault(vaultName)
+    const preview = await describeExtraction(v, { seeds, ...(opts.maxDepth !== undefined ? { maxDepth: opts.maxDepth } : {}) })
+    compartments.push({ vault: vaultName, preview })
+  }
+  return { compartments, dangling: plan.dangling }
+}
+```
+
+- [ ] **Step 4: Run → pass; typecheck.**
+- [ ] **Step 5: Commit** — `git commit -am "feat(lobby): describeCrossVaultExtraction — per-compartment dry-run preview"`
+
+---
+
+## Task 4 — Public exports + features.yaml + full verification
+
+**Files:** Modify `packages/lobby/src/index.ts`, `features.yaml`.
+
+- [ ] **Step 1: Export from `packages/lobby/src/index.ts`:**
+```typescript
+export {
+  walkCrossVaultClosure,
+  extractCrossVaultPartition,
+  describeCrossVaultExtraction,
+  CrossVaultDanglingRefError,
+} from './interchange/extract-cross-vault.js'
+export type {
+  CrossVaultRef, CrossVaultSeed, CrossVaultClosurePlan,
+  CompartmentMeta, ExtractCrossVaultOptions, ExtractCrossVaultResult,
+  CrossVaultPreview,
+} from './interchange/extract-cross-vault.js'
+```
+
+- [ ] **Step 2: Register in `features.yaml`** — add an entry (id e.g. `cross-vault-extraction`) mirroring the schema of the `multi-compartment-bundle` entry FR-1 added; artefact `packages/lobby/src/interchange/extract-cross-vault.ts`, spec the lobby-framework spec (FR-2). `node scripts/validate-features.mjs` must pass.
+
+- [ ] **Step 3: Full verification (incl. the FR-1 lint-gap killer):**
+```bash
+pnpm --filter @noy-db/hub build          # klum resolves hub from dist
+pnpm --filter @klum-db/lobby build
+node --input-type=module -e "import('@klum-db/lobby').then(m=>{ for (const n of ['walkCrossVaultClosure','extractCrossVaultPartition','describeCrossVaultExtraction']) if (typeof m[n]!=='function') throw new Error('missing '+n); console.log('exports OK') })"  # run from packages/lobby
+pnpm --filter @klum-db/lobby test
+pnpm --filter @klum-db/lobby lint        # eslint — DO NOT SKIP (FR-1 lesson)
+pnpm --filter @klum-db/lobby typecheck
+pnpm lint && pnpm typecheck              # full monorepo (CI parity)
+node scripts/validate-features.mjs
+pnpm check:architecture
+```
+Expected all green.
+
+- [ ] **Step 4: Commit** — `git commit -am "feat(lobby): export cross-vault extraction API + register in features.yaml"`
+
+---
+
+## Self-Review
+
+**Spec coverage (issue #442):**
+- "seed predicate on A + cross-vault FK descriptor to B → bundle contains A's partition + exactly the B rows reachable by FK (no more)" → Task 2 test adopts the directory compartment and asserts exactly `e1,e2` (not `e3`).
+- "describeExtraction reports per-compartment counts" → Task 3 `describeCrossVaultExtraction` per-compartment `ExtractionPreview`.
+- "dangling-ref check: nothing referenced is omitted" → Task 1 dangling test + `CrossVaultDanglingRefError` thrown in Task 2.
+- Approved: per-compartment transfer keys (Task 2 `transferKeys` map); pure-klum (no hub change — verify `git diff main -- packages/hub` is empty at the end).
+
+**Placeholder scan:** every step has concrete code; the "confirm the API shape" notes target verified-present exports (`walkClosure`/`extractPartition`/`encodeMultiBundle`/`generateULID`/`NOYDB_MULTI_BUNDLE_VERSION`/`sha256Hex`/`adoptPartition`).
+
+**Lint discipline:** Task 4 runs `pnpm --filter @klum-db/lobby lint` + full `pnpm lint` (the FR-1 gap). Watch for `no-unnecessary-type-assertion` on the `-readonly` builder + any `as` casts.
+
+**Risk notes:** the fixpoint loop is bounded by `maxDepth` + a walked-signature dedup (terminates on cycles); `extractPartition` re-derives each vault's intra-closure from the computed seeds (consistent with the planner); `collections` counts come from the closure plan (exact slice), not a full vault scan.

--- a/features.yaml
+++ b/features.yaml
@@ -1051,6 +1051,27 @@ features:
       - 'encodeMultiBundle / decodeMultiBundle are the low-level framing primitives; decodeMultiBundle validates magic, version, manifest JSON, and per-compartment innerBytes overrun'
     related: [bundle, transferable-partition, public-envelope]
 
+  - id: cross-vault-extraction
+    name: Cross-vault FK-closure extraction (walkCrossVaultClosure / extractCrossVaultPartition)
+    cluster: snapshot-and-portability
+    spec: docs/superpowers/specs/2026-06-16-lobby-framework-design.md
+    subsystem_doc: docs/superpowers/specs/2026-06-16-lobby-framework-design.md
+    package: '@klum-db/lobby'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'walkCrossVaultClosure walks an FK closure spanning vault boundaries via app-supplied CrossVaultRef descriptors; per-vault seed predicates are returned for downstream extractPartition calls'
+      - 'extractCrossVaultPartition composes walkCrossVaultClosure + hub extractPartition and emits a NDBM multi-compartment bundle whose compartments contain exactly the FK-reachable slice of each vault (no extra rows)'
+      - 'describeCrossVaultExtraction is a dry-run: resolves with per-compartment ExtractionPreview and surfaces dangling refs without throwing (contrast: extractCrossVaultPartition throws CrossVaultDanglingRefError on dangling)'
+      - 'CrossVaultDanglingRefError is thrown by extractCrossVaultPartition when a referenced row is absent from its target vault closure; dangling refs are always collected and never silently dropped'
+      - 'Per-compartment transfer keys: each extractPartition mints its own key; result returns a { vaultName → transferKey } map for out-of-band delivery — bundle and keys must never be co-located'
+      - 'Pure @klum-db/lobby — no hub change; hub ref() deliberately rejects cross-vault refs (RefScopeError); the cross-vault edges live in the caller-supplied descriptor'
+    related: [multi-compartment-bundle, transferable-partition, bundle]
+
   - id: with-snapshots
     name: Snapshot lifecycle (withSnapshots)
     cluster: snapshot-and-portability

--- a/packages/lobby/__tests__/extract-cross-vault.test.ts
+++ b/packages/lobby/__tests__/extract-cross-vault.test.ts
@@ -1,11 +1,22 @@
 /**
  * walkCrossVaultClosure — cross-vault FK closure planner (Task 1)
- * Plan: docs/superpowers/plans/2026-06-17-fr2-cross-vault-extraction.md §Task 1
+ * extractCrossVaultPartition — multi-compartment bundle emitter (Task 2)
+ * Plan: docs/superpowers/plans/2026-06-17-fr2-cross-vault-extraction.md §Task 1, §Task 2
  */
 import { describe, it, expect } from 'vitest'
 import { createNoydb } from '@noy-db/hub'
 import { memory } from '@noy-db/to-memory'
-import { walkCrossVaultClosure, type CrossVaultRef } from '../src/interchange/extract-cross-vault.js'
+import {
+  walkCrossVaultClosure,
+  extractCrossVaultPartition,
+  type CrossVaultRef,
+} from '../src/interchange/extract-cross-vault.js'
+import {
+  readNoydbBundleManifest,
+  readMultiVaultBundleCompartment,
+  adoptPartition,
+  createOwnerOnAdoptedPartition,
+} from '@noy-db/hub/bundle'
 import type { Noydb } from '@noy-db/hub'
 
 // ─── Fixture ──────────────────────────────────────────────────────────────────
@@ -97,5 +108,85 @@ describe('walkCrossVaultClosure', () => {
 
     expect(plan.perVaultSeeds.has('client')).toBe(true)
     expect(plan.perVaultSeeds.has('directory')).toBe(true)
+  })
+})
+
+// ─── Task 2: extractCrossVaultPartition ───────────────────────────────────────
+
+describe('extractCrossVaultPartition', () => {
+  it('emits a multi-compartment bundle with roleTag-labelled compartments and per-vault transfer keys', async () => {
+    const { openVault } = await buildFixture()
+
+    const res = await extractCrossVaultPartition(openVault, {
+      seed: { vault: 'client', seeds: { bills: () => true } },
+      crossVaultRefs: refs,
+      compartmentMeta: {
+        client: { roleTag: 'shard' },
+        directory: { roleTag: 'pool', disclose: { name: true } },
+      },
+    })
+
+    // manifest has 2 compartments with the correct roleTags
+    const manifest = await readNoydbBundleManifest(res.bundle)
+    expect(manifest.map((m) => m.roleTag).sort()).toEqual(['pool', 'shard'])
+
+    // both vault names present in transferKeys
+    expect(Object.keys(res.transferKeys).sort()).toEqual(['client', 'directory'])
+  })
+
+  it('directory compartment contains EXACTLY e1,e2 (not e3) after adopt + createOwner', async () => {
+    const { openVault } = await buildFixture()
+
+    const res = await extractCrossVaultPartition(openVault, {
+      seed: { vault: 'client', seeds: { bills: () => true } },
+      crossVaultRefs: refs,
+      compartmentMeta: {
+        client: { roleTag: 'shard' },
+        directory: { roleTag: 'pool', disclose: { name: true } },
+      },
+    })
+
+    // extract the directory compartment bytes
+    const manifest = await readNoydbBundleManifest(res.bundle)
+    const dirEntry = manifest.find((m) => m.roleTag === 'pool')!
+    expect(dirEntry).toBeDefined()
+    const dirBytes = readMultiVaultBundleCompartment(res.bundle, dirEntry.handle)
+
+    // adopt into a fresh in-memory store
+    const destStore = memory()
+    await adoptPartition(dirBytes, {
+      transferKey: res.transferKeys['directory']!,
+      destinationStore: destStore,
+      vaultName: 'dir-adopted',
+    })
+    await createOwnerOnAdoptedPartition(destStore, 'dir-adopted', {
+      userId: 'u',
+      passphrase: 'correct-horse-battery-staple',
+      transferKey: res.transferKeys['directory']!,
+    })
+
+    // open the adopted vault and verify EXACTLY e1,e2 (not e3)
+    const dest = await (
+      await createNoydb({ store: destStore, user: 'u', secret: 'correct-horse-battery-staple' })
+    ).openVault('dir-adopted')
+    const adoptedEntities = (await dest.collection('entities').list())
+      .map((r: Record<string, unknown>) => r['id'] as string)
+      .sort()
+    expect(adoptedEntities).toEqual(['e1', 'e2'])
+  })
+
+  it('throws CrossVaultDanglingRefError when a referenced entity is missing', async () => {
+    const { clientDb, openVault } = await buildFixture()
+
+    // add a bill pointing to a non-existent e9
+    const clientVault = await clientDb.openVault('client')
+    await clientVault.collection<Bill>('bills').put('b9', { id: 'b9', entityId: 'e9' })
+
+    await expect(
+      extractCrossVaultPartition(openVault, {
+        seed: { vault: 'client', seeds: { bills: () => true } },
+        crossVaultRefs: refs,
+      }),
+    ).rejects.toThrow('cross-vault extraction')
   })
 })

--- a/packages/lobby/__tests__/extract-cross-vault.test.ts
+++ b/packages/lobby/__tests__/extract-cross-vault.test.ts
@@ -110,6 +110,15 @@ describe('walkCrossVaultClosure', () => {
     expect(plan.perVaultSeeds.has('client')).toBe(true)
     expect(plan.perVaultSeeds.has('directory')).toBe(true)
   })
+
+  it('rejects a non-id cross-vault to.field (not yet supported)', async () => {
+    const { openVault } = await buildFixture()
+
+    await expect(walkCrossVaultClosure(openVault, {
+      seed: { vault: 'client', seeds: { bills: () => true } },
+      crossVaultRefs: [{ from: { collection: 'bills', field: 'entityId' }, to: { vault: 'directory', collection: 'entities', field: 'slug' } }],
+    })).rejects.toThrow(/not supported|to\.field/i)
+  })
 })
 
 // ─── Task 2: extractCrossVaultPartition ───────────────────────────────────────

--- a/packages/lobby/__tests__/extract-cross-vault.test.ts
+++ b/packages/lobby/__tests__/extract-cross-vault.test.ts
@@ -1,0 +1,101 @@
+/**
+ * walkCrossVaultClosure — cross-vault FK closure planner (Task 1)
+ * Plan: docs/superpowers/plans/2026-06-17-fr2-cross-vault-extraction.md §Task 1
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { walkCrossVaultClosure, type CrossVaultRef } from '../src/interchange/extract-cross-vault.js'
+import type { Noydb } from '@noy-db/hub'
+
+// ─── Fixture ──────────────────────────────────────────────────────────────────
+
+interface Entity { id: string; name: string }
+interface Bill { id: string; entityId: string }
+
+async function buildFixture(): Promise<{
+  dirDb: Noydb
+  clientDb: Noydb
+  openVault: (name: string) => ReturnType<Noydb['openVault']>
+}> {
+  const dirDb = await createNoydb({ store: memory(), user: 'admin', secret: 'dir-secret' })
+  const clientDb = await createNoydb({ store: memory(), user: 'admin', secret: 'client-secret' })
+
+  // --- directory vault ---
+  const dirVault = await dirDb.openVault('directory')
+  const entities = dirVault.collection<Entity>('entities')
+  await entities.put('e1', { id: 'e1', name: 'Acme' })
+  await entities.put('e2', { id: 'e2', name: 'Beta' })
+  await entities.put('e3', { id: 'e3', name: 'Gamma' })
+
+  // --- client vault ---
+  const clientVault = await clientDb.openVault('client')
+  const bills = clientVault.collection<Bill>('bills')
+  await bills.put('b1', { id: 'b1', entityId: 'e1' })
+  await bills.put('b2', { id: 'b2', entityId: 'e2' })
+
+  const openVault = (name: string) => {
+    if (name === 'directory') return dirDb.openVault('directory')
+    if (name === 'client') return clientDb.openVault('client')
+    throw new Error(`Unknown vault: ${name}`)
+  }
+
+  return { dirDb, clientDb, openVault }
+}
+
+const refs: CrossVaultRef[] = [
+  { from: { collection: 'bills', field: 'entityId' }, to: { vault: 'directory', collection: 'entities' } },
+]
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('walkCrossVaultClosure', () => {
+  it('primary closure contains all bills; directory closure contains only FK-reachable entities (e1, e2 — NOT e3)', async () => {
+    const { openVault } = await buildFixture()
+
+    const plan = await walkCrossVaultClosure(openVault, {
+      seed: { vault: 'client', seeds: { bills: () => true } },
+      crossVaultRefs: refs,
+    })
+
+    // primary vault closure has both bills
+    expect(plan.perVaultClosure.get('client')?.get('bills')?.size).toBe(2)
+
+    // directory closure has EXACTLY e1, e2 — NOT e3
+    const dirEntities = plan.perVaultClosure.get('directory')?.get('entities')
+    expect(dirEntities).toBeDefined()
+    expect([...(dirEntities ?? [])].sort()).toEqual(['e1', 'e2'])
+
+    // no dangling refs
+    expect(plan.dangling).toEqual([])
+  })
+
+  it('bill referencing a missing entity lands in dangling', async () => {
+    const { clientDb, openVault } = await buildFixture()
+
+    // add a bill pointing to a non-existent e9
+    const clientVault = await clientDb.openVault('client')
+    await clientVault.collection<Bill>('bills').put('b9', { id: 'b9', entityId: 'e9' })
+
+    const plan = await walkCrossVaultClosure(openVault, {
+      seed: { vault: 'client', seeds: { bills: () => true } },
+      crossVaultRefs: refs,
+    })
+
+    const dangling = plan.dangling
+    expect(dangling.length).toBeGreaterThan(0)
+    expect(dangling).toContainEqual({ vault: 'directory', collection: 'entities', id: 'e9' })
+  })
+
+  it('perVaultSeeds contains entries for both client and directory', async () => {
+    const { openVault } = await buildFixture()
+
+    const plan = await walkCrossVaultClosure(openVault, {
+      seed: { vault: 'client', seeds: { bills: () => true } },
+      crossVaultRefs: refs,
+    })
+
+    expect(plan.perVaultSeeds.has('client')).toBe(true)
+    expect(plan.perVaultSeeds.has('directory')).toBe(true)
+  })
+})

--- a/packages/lobby/__tests__/extract-cross-vault.test.ts
+++ b/packages/lobby/__tests__/extract-cross-vault.test.ts
@@ -9,6 +9,7 @@ import { memory } from '@noy-db/to-memory'
 import {
   walkCrossVaultClosure,
   extractCrossVaultPartition,
+  describeCrossVaultExtraction,
   type CrossVaultRef,
 } from '../src/interchange/extract-cross-vault.js'
 import {
@@ -188,5 +189,31 @@ describe('extractCrossVaultPartition', () => {
         crossVaultRefs: refs,
       }),
     ).rejects.toThrow('cross-vault extraction')
+  })
+})
+
+// ─── Task 3: describeCrossVaultExtraction ─────────────────────────────────────
+
+describe('describeCrossVaultExtraction', () => {
+  it('returns per-compartment preview for both vaults; directory entities count is 2 (e1,e2); no dangling', async () => {
+    const { openVault } = await buildFixture()
+
+    const preview = await describeCrossVaultExtraction(openVault, {
+      seed: { vault: 'client', seeds: { bills: () => true } },
+      crossVaultRefs: refs,
+    })
+
+    // both vaults appear in compartments
+    expect(preview.compartments.map((c) => c.vault).sort()).toEqual(['client', 'directory'])
+
+    // directory compartment preview shows exactly 2 entities (e1,e2 — NOT e3)
+    const dir = preview.compartments.find((c) => c.vault === 'directory')!
+    expect(dir).toBeDefined()
+    const entitiesEntry = dir.preview.byCollection.find((b) => b.name === 'entities')!
+    expect(entitiesEntry).toBeDefined()
+    expect(entitiesEntry.recordCount).toBe(2)
+
+    // no dangling refs
+    expect(preview.dangling).toEqual([])
   })
 })

--- a/packages/lobby/__tests__/extract-cross-vault.test.ts
+++ b/packages/lobby/__tests__/extract-cross-vault.test.ts
@@ -216,4 +216,26 @@ describe('describeCrossVaultExtraction', () => {
     // no dangling refs
     expect(preview.dangling).toEqual([])
   })
+
+  it('surfaces dangling refs in preview.dangling without throwing (b9→e9 missing-ref)', async () => {
+    const { clientDb, openVault } = await buildFixture()
+
+    // add a bill pointing to a non-existent e9
+    const clientVault = await clientDb.openVault('client')
+    await clientVault.collection<Bill>('bills').put('b9', { id: 'b9', entityId: 'e9' })
+
+    // describeCrossVaultExtraction MUST RESOLVE (not throw) even with dangling refs —
+    // that is its core contract: surface, don't throw (contrast: extractCrossVaultPartition throws)
+    const preview = await describeCrossVaultExtraction(openVault, {
+      seed: { vault: 'client', seeds: { bills: () => true } },
+      crossVaultRefs: refs,
+    })
+
+    // dangling is non-empty and contains the missing e9 reference
+    expect(preview.dangling.length).toBeGreaterThan(0)
+    expect(preview.dangling).toContainEqual({ vault: 'directory', collection: 'entities', id: 'e9' })
+
+    // compartments are still returned (non-empty) even with dangling refs
+    expect(preview.compartments.length).toBeGreaterThan(0)
+  })
 })

--- a/packages/lobby/src/index.ts
+++ b/packages/lobby/src/index.ts
@@ -77,3 +77,20 @@ export {
   ReservedVaultNameError,
   DataResidencyError,
 } from '@noy-db/hub/kernel'
+
+// ─── FR-2: Cross-vault FK-closure extraction ──────────────────────────────────
+export {
+  walkCrossVaultClosure,
+  extractCrossVaultPartition,
+  describeCrossVaultExtraction,
+  CrossVaultDanglingRefError,
+} from './interchange/extract-cross-vault.js'
+export type {
+  CrossVaultRef,
+  CrossVaultSeed,
+  CrossVaultClosurePlan,
+  CompartmentMeta,
+  ExtractCrossVaultOptions,
+  ExtractCrossVaultResult,
+  CrossVaultPreview,
+} from './interchange/extract-cross-vault.js'

--- a/packages/lobby/src/interchange/extract-cross-vault.ts
+++ b/packages/lobby/src/interchange/extract-cross-vault.ts
@@ -21,7 +21,16 @@ import { sha256Hex } from '@noy-db/hub/kernel'
 /** A denormalized cross-vault FK edge (hub refuses these as native refs). */
 export interface CrossVaultRef {
   readonly from: { readonly collection: string; readonly field: string }
-  readonly to: { readonly vault: string; readonly collection: string; readonly field?: string }
+  readonly to: {
+    readonly vault: string
+    readonly collection: string
+    /**
+     * Target field the FK points to. **Currently must be `'id'` (or omitted).**
+     * Non-`id` business-key target fields are not yet supported (will be added
+     * when adopt/merge lands).
+     */
+    readonly field?: string
+  }
 }
 
 /** Seed for the primary vault (predicate per collection, like hub walkClosure). */
@@ -60,6 +69,18 @@ export async function walkCrossVaultClosure(
 ): Promise<CrossVaultClosurePlan> {
   const refs = opts.crossVaultRefs ?? []
   const maxDepth = opts.maxDepth ?? 16
+
+  // Guard: non-id target fields are silently broken (dangling false-positives + fixpoint burn).
+  // Fail loud until business-key target support is added with adopt/merge.
+  for (const ref of refs) {
+    if (ref.to.field !== undefined && ref.to.field !== 'id') {
+      throw new Error(
+        `cross-vault extraction: to.field "${ref.to.field}" (on ${ref.to.vault}/${ref.to.collection}) is not supported yet — `
+        + `the cross-vault target field must be "id" (or omitted). Business-key target fields are a future enhancement.`,
+      )
+    }
+  }
+
   const perVaultClosure = new Map<string, Map<string, Set<string>>>()
   const perVaultSeeds: CrossVaultClosurePlan['perVaultSeeds'] = new Map()
   // accumulated referenced ids per target vault+collection

--- a/packages/lobby/src/interchange/extract-cross-vault.ts
+++ b/packages/lobby/src/interchange/extract-cross-vault.ts
@@ -253,7 +253,7 @@ export async function extractCrossVaultPartition(
 
 export interface CrossVaultPreview {
   readonly compartments: ReadonlyArray<{ readonly vault: string; readonly preview: ExtractionPreview }>
-  readonly dangling: { vault: string; collection: string; id: string }[]
+  readonly dangling: ReadonlyArray<{ readonly vault: string; readonly collection: string; readonly id: string }>
 }
 
 /**

--- a/packages/lobby/src/interchange/extract-cross-vault.ts
+++ b/packages/lobby/src/interchange/extract-cross-vault.ts
@@ -11,8 +11,10 @@ import {
   readNoydbBundleHeader,
   NOYDB_MULTI_BUNDLE_VERSION,
   generateULID,
+  describeExtraction,
   type MultiBundleManifest,
   type CompartmentManifest,
+  type ExtractionPreview,
 } from '@noy-db/hub/bundle'
 import { sha256Hex } from '@noy-db/hub/kernel'
 
@@ -245,4 +247,35 @@ export async function extractCrossVaultPartition(
     compartments,
   }
   return { bundle: encodeMultiBundle(manifest, inner), transferKeys, sealIds }
+}
+
+// ─── Task 3: describeCrossVaultExtraction ────────────────────────────────────
+
+export interface CrossVaultPreview {
+  readonly compartments: ReadonlyArray<{ readonly vault: string; readonly preview: ExtractionPreview }>
+  readonly dangling: { vault: string; collection: string; id: string }[]
+}
+
+/**
+ * Dry-run that walks the cross-vault FK closure and aggregates hub's per-vault
+ * `describeExtraction` into a per-compartment preview.
+ *
+ * Writes nothing. Returns the per-vault `ExtractionPreview` (record counts,
+ * byte totals) and the dangling list from the closure walk.
+ */
+export async function describeCrossVaultExtraction(
+  openVault: (name: string) => Promise<Vault>,
+  opts: { seed: CrossVaultSeed; crossVaultRefs?: readonly CrossVaultRef[]; maxDepth?: number },
+): Promise<CrossVaultPreview> {
+  const plan = await walkCrossVaultClosure(openVault, opts)
+  const compartments: Array<{ vault: string; preview: ExtractionPreview }> = []
+  for (const [vaultName, seeds] of plan.perVaultSeeds) {
+    const v = await openVault(vaultName)
+    const preview = await describeExtraction(v, {
+      seeds,
+      ...(opts.maxDepth !== undefined ? { maxDepth: opts.maxDepth } : {}),
+    })
+    compartments.push({ vault: vaultName, preview })
+  }
+  return { compartments, dangling: plan.dangling }
 }

--- a/packages/lobby/src/interchange/extract-cross-vault.ts
+++ b/packages/lobby/src/interchange/extract-cross-vault.ts
@@ -1,0 +1,137 @@
+/**
+ * @klum-db/lobby interchange — cross-vault FK-closure extraction.
+ * Composes hub's intra-vault primitives + FR-1's encodeMultiBundle.
+ * @packageDocumentation
+ */
+import type { Vault } from '@noy-db/hub'
+import { walkClosure } from '@noy-db/hub/bundle'
+
+/** A denormalized cross-vault FK edge (hub refuses these as native refs). */
+export interface CrossVaultRef {
+  readonly from: { readonly collection: string; readonly field: string }
+  readonly to: { readonly vault: string; readonly collection: string; readonly field?: string }
+}
+
+/** Seed for the primary vault (predicate per collection, like hub walkClosure). */
+export interface CrossVaultSeed {
+  readonly vault: string
+  readonly seeds: Record<string, (rec: Record<string, unknown>) => boolean | Promise<boolean>>
+}
+
+export interface CrossVaultClosurePlan {
+  /** vault → seed predicates to feed extractPartition (primary: caller's; targets: id-membership). */
+  readonly perVaultSeeds: Map<string, Record<string, (rec: Record<string, unknown>) => boolean | Promise<boolean>>>
+  /** vault → intra closure (collection → ids). */
+  readonly perVaultClosure: Map<string, Map<string, Set<string>>>
+  /** referenced rows not found in their target closure. */
+  readonly dangling: { vault: string; collection: string; id: string }[]
+}
+
+function asIdArray(v: unknown): string[] {
+  if (v === null || v === undefined) return []
+  if (Array.isArray(v)) return v.filter((x) => typeof x === 'string' || typeof x === 'number').map(String)
+  if (typeof v === 'string' || typeof v === 'number') return [String(v)]
+  return []
+}
+
+/**
+ * Walk an FK closure that spans vault boundaries via app-supplied cross-vault refs.
+ *
+ * @param openVault - resolver for a vault by name (idempotent in the hub —
+ *   repeated calls return the same cached instance, so the per-round calls are free).
+ * @param opts.maxDepth - bounds BOTH the number of inter-vault rounds (this planner's
+ *   outer fixpoint loop) AND hub's intra-vault `walkClosure` FK depth. Default 16.
+ */
+export async function walkCrossVaultClosure(
+  openVault: (name: string) => Promise<Vault>,
+  opts: { seed: CrossVaultSeed; crossVaultRefs?: readonly CrossVaultRef[]; maxDepth?: number },
+): Promise<CrossVaultClosurePlan> {
+  const refs = opts.crossVaultRefs ?? []
+  const maxDepth = opts.maxDepth ?? 16
+  const perVaultClosure = new Map<string, Map<string, Set<string>>>()
+  const perVaultSeeds: CrossVaultClosurePlan['perVaultSeeds'] = new Map()
+  // accumulated referenced ids per target vault+collection
+  const targetIds = new Map<string, Map<string, Set<string>>>()
+
+  const addTarget = (v: string, c: string, id: string) => {
+    let m = targetIds.get(v)
+    if (!m) { m = new Map(); targetIds.set(v, m) }
+    let s = m.get(c)
+    if (!s) { s = new Set(); m.set(c, s) }
+    s.add(id)
+  }
+
+  const mergeClosure = (v: string, cl: Map<string, Set<string>>) => {
+    let dest = perVaultClosure.get(v)
+    if (!dest) { dest = new Map(); perVaultClosure.set(v, dest) }
+    for (const [c, ids] of cl) {
+      let s = dest.get(c)
+      if (!s) { s = new Set(); dest.set(c, s) }
+      for (const id of ids) s.add(id)
+    }
+  }
+
+  // round 0: primary vault
+  perVaultSeeds.set(opts.seed.vault, opts.seed.seeds)
+  const queue: string[] = [opts.seed.vault]
+  const walkedSignature = new Set<string>()
+
+  let round = 0
+  while (queue.length > 0) {
+    if (round++ > maxDepth) break
+    const batch = queue.splice(0, queue.length)
+    for (const vaultName of batch) {
+      const seeds = perVaultSeeds.get(vaultName)!
+      const v = await openVault(vaultName)
+      const { closure } = await walkClosure(v, {
+        seeds,
+        ...(opts.maxDepth !== undefined ? { maxDepth: opts.maxDepth } : {}),
+      })
+      mergeClosure(vaultName, closure)
+      // harvest cross-vault FKs from this vault's closure
+      for (const ref of refs) {
+        const ids = closure.get(ref.from.collection)
+        if (!ids) continue
+        const coll = v.collection<Record<string, unknown>>(ref.from.collection)
+        for (const id of ids) {
+          const rec = await coll.get(id)
+          for (const fk of asIdArray(rec?.[ref.from.field])) {
+            addTarget(ref.to.vault, ref.to.collection, fk)
+          }
+        }
+      }
+    }
+    // enqueue targets whose id-set introduces records not yet in their closure
+    for (const [tVault, colls] of targetIds) {
+      for (const [tColl, ids] of colls) {
+        const field = refs.find((r) => r.to.vault === tVault && r.to.collection === tColl)?.to.field ?? 'id'
+        const have = perVaultClosure.get(tVault)?.get(tColl) ?? new Set<string>()
+        const sig = `${tVault}\0${tColl}\0${[...ids].sort().join(',')}`
+        if ([...ids].every((id) => have.has(id)) || walkedSignature.has(sig)) continue
+        // Stamp before enqueue; safe because harvest is sequential — no other FK
+        // accumulation can extend targetIds between this stamp and the next round.
+        walkedSignature.add(sig)
+        const wanted = new Set(ids)
+        const seed = { [tColl]: (rec: Record<string, unknown>) => wanted.has(String(rec[field])) }
+        const existing = perVaultSeeds.get(tVault)
+        // `wanted` is always the full cumulative targetIds set for this collection,
+        // so overwriting an existing predicate for tColl is safe and idempotent.
+        perVaultSeeds.set(tVault, existing ? { ...existing, ...seed } : seed)
+        queue.push(tVault)
+      }
+    }
+  }
+
+  // dangling check: every harvested target id must appear in the final closure
+  const dangling: CrossVaultClosurePlan['dangling'] = []
+  for (const [tVault, colls] of targetIds) {
+    for (const [tColl, ids] of colls) {
+      const have = perVaultClosure.get(tVault)?.get(tColl) ?? new Set<string>()
+      for (const id of ids) {
+        if (!have.has(id)) dangling.push({ vault: tVault, collection: tColl, id })
+      }
+    }
+  }
+
+  return { perVaultSeeds, perVaultClosure, dangling }
+}

--- a/packages/lobby/src/interchange/extract-cross-vault.ts
+++ b/packages/lobby/src/interchange/extract-cross-vault.ts
@@ -152,7 +152,7 @@ export class CrossVaultDanglingRefError extends Error {
   constructor(readonly dangling: { vault: string; collection: string; id: string }[]) {
     super(
       `cross-vault extraction: ${dangling.length} referenced row(s) missing from their target closure: `
-      + dangling.map((d) => `${d.vault}/${d.collection}/${d.id}`).slice(0, 5).join(', '),
+      + dangling.slice(0, 5).map((d) => `${d.vault}/${d.collection}/${d.id}`).join(', '),
     )
     this.name = 'CrossVaultDanglingRefError'
   }
@@ -163,7 +163,6 @@ export interface CompartmentMeta {
   readonly disclose?: {
     readonly name?: boolean | string
     readonly collections?: boolean
-    readonly publicEnvelope?: boolean
   }
 }
 
@@ -179,6 +178,13 @@ export interface ExtractCrossVaultOptions {
 
 export interface ExtractCrossVaultResult {
   readonly bundle: Uint8Array
+  /**
+   * Per-compartment raw 32-byte transfer keys, keyed by vault name. Each
+   * unseals that compartment's DEKs on adoption.
+   * @remarks SECRET — deliver these out-of-band, SEPARATELY from `bundle`.
+   * Anyone with both the bundle and a compartment's key can decrypt that
+   * compartment. Never store them alongside the bundle.
+   */
   readonly transferKeys: Record<string, Uint8Array>
   readonly sealIds: Record<string, string>
 }
@@ -221,10 +227,11 @@ export async function extractCrossVaultPartition(
     }
     if (meta?.disclose?.collections === true) {
       const cl = plan.perVaultClosure.get(vaultName)
+      // `ids.size` reflects the EXTRACTED CLOSURE SLICE for this vault (the subset
+      // selected by the cross-vault FK walk), NOT the full vault record count.
+      // This differs from FR-1's writeMultiVaultBundle which counts the full vault.
       if (cl) entry.collections = [...cl].map(([name, ids]) => ({ name, count: ids.size }))
     }
-    // publicEnvelope opt-in omitted: readNoydbBundlePublicEnvelope is not
-    // exported from @noy-db/hub/bundle; deferred to a future pass.
 
     inner.push(bundleBytes)
     compartments.push(entry)

--- a/packages/lobby/src/interchange/extract-cross-vault.ts
+++ b/packages/lobby/src/interchange/extract-cross-vault.ts
@@ -4,7 +4,17 @@
  * @packageDocumentation
  */
 import type { Vault } from '@noy-db/hub'
-import { walkClosure } from '@noy-db/hub/bundle'
+import {
+  walkClosure,
+  extractPartition,
+  encodeMultiBundle,
+  readNoydbBundleHeader,
+  NOYDB_MULTI_BUNDLE_VERSION,
+  generateULID,
+  type MultiBundleManifest,
+  type CompartmentManifest,
+} from '@noy-db/hub/bundle'
+import { sha256Hex } from '@noy-db/hub/kernel'
 
 /** A denormalized cross-vault FK edge (hub refuses these as native refs). */
 export interface CrossVaultRef {
@@ -134,4 +144,98 @@ export async function walkCrossVaultClosure(
   }
 
   return { perVaultSeeds, perVaultClosure, dangling }
+}
+
+// ─── Task 2: extractCrossVaultPartition ────────────────────────────────────────
+
+export class CrossVaultDanglingRefError extends Error {
+  constructor(readonly dangling: { vault: string; collection: string; id: string }[]) {
+    super(
+      `cross-vault extraction: ${dangling.length} referenced row(s) missing from their target closure: `
+      + dangling.map((d) => `${d.vault}/${d.collection}/${d.id}`).slice(0, 5).join(', '),
+    )
+    this.name = 'CrossVaultDanglingRefError'
+  }
+}
+
+export interface CompartmentMeta {
+  readonly roleTag?: string
+  readonly disclose?: {
+    readonly name?: boolean | string
+    readonly collections?: boolean
+    readonly publicEnvelope?: boolean
+  }
+}
+
+export interface ExtractCrossVaultOptions {
+  readonly seed: CrossVaultSeed
+  readonly crossVaultRefs?: readonly CrossVaultRef[]
+  readonly maxDepth?: number
+  readonly carrySchemas?: boolean
+  readonly carryLedger?: boolean
+  readonly compression?: 'auto' | 'brotli' | 'gzip' | 'none'
+  readonly compartmentMeta?: Record<string, CompartmentMeta>
+}
+
+export interface ExtractCrossVaultResult {
+  readonly bundle: Uint8Array
+  readonly transferKeys: Record<string, Uint8Array>
+  readonly sealIds: Record<string, string>
+}
+
+export async function extractCrossVaultPartition(
+  openVault: (name: string) => Promise<Vault>,
+  opts: ExtractCrossVaultOptions,
+): Promise<ExtractCrossVaultResult> {
+  const plan = await walkCrossVaultClosure(openVault, opts)
+  if (plan.dangling.length > 0) throw new CrossVaultDanglingRefError(plan.dangling)
+
+  const inner: Uint8Array[] = []
+  const compartments: CompartmentManifest[] = []
+  const transferKeys: Record<string, Uint8Array> = {}
+  const sealIds: Record<string, string> = {}
+
+  for (const [vaultName, seeds] of plan.perVaultSeeds) {
+    const v = await openVault(vaultName)
+    const { bundleBytes, transferKey, sealId } = await extractPartition(v, {
+      seeds,
+      ...(opts.maxDepth !== undefined ? { maxDepth: opts.maxDepth } : {}),
+      carrySchemas: opts.carrySchemas ?? true,
+      carryLedger: opts.carryLedger ?? false,
+      ...(opts.compression !== undefined ? { compression: opts.compression } : {}),
+    })
+
+    const header = readNoydbBundleHeader(bundleBytes)
+    const meta = opts.compartmentMeta?.[vaultName]
+
+    const entry: { -readonly [K in keyof CompartmentManifest]: CompartmentManifest[K] } = {
+      handle: header.handle,
+      exportedAt: new Date().toISOString(),
+      innerBytes: bundleBytes.length,
+      innerSha256: await sha256Hex(bundleBytes),
+    }
+
+    if (meta?.roleTag !== undefined) entry.roleTag = meta.roleTag
+    if (meta?.disclose?.name !== undefined && meta.disclose.name !== false) {
+      entry.name = meta.disclose.name === true ? v.name : meta.disclose.name
+    }
+    if (meta?.disclose?.collections === true) {
+      const cl = plan.perVaultClosure.get(vaultName)
+      if (cl) entry.collections = [...cl].map(([name, ids]) => ({ name, count: ids.size }))
+    }
+    // publicEnvelope opt-in omitted: readNoydbBundlePublicEnvelope is not
+    // exported from @noy-db/hub/bundle; deferred to a future pass.
+
+    inner.push(bundleBytes)
+    compartments.push(entry)
+    transferKeys[vaultName] = transferKey
+    sealIds[vaultName] = sealId
+  }
+
+  const manifest: MultiBundleManifest = {
+    multiFormatVersion: NOYDB_MULTI_BUNDLE_VERSION,
+    handle: generateULID(),
+    compartments,
+  }
+  return { bundle: encodeMultiBundle(manifest, inner), transferKeys, sealIds }
 }

--- a/scripts/feature-schema.json
+++ b/scripts/feature-schema.json
@@ -57,7 +57,7 @@
       "properties": {
         "id":      { "$ref": "#/$defs/id" },
         "name":    { "type": "string", "minLength": 1 },
-        "package": { "type": "string", "pattern": "^(@noy-db/[a-z][a-z0-9-]*(/[a-z][a-z0-9-]*)?|create-noy-db)$" },
+        "package": { "type": "string", "pattern": "^(@noy-db/[a-z][a-z0-9-]*(/[a-z][a-z0-9-]*)?|@klum-db/[a-z][a-z0-9-]*|create-noy-db)$" },
         "status":  { "$ref": "#/$defs/status" },
         "experimental": {
           "oneOf": [


### PR DESCRIPTION
## Summary

Second capability of the pilot-1 epic (#442 / vLannaAi/klum-db#1): a **pure `@klum-db/lobby`** orchestrator that walks an FK closure spanning vault boundaries and emits the seed vault's partition + exactly the FK-referenced slice of each other vault as compartments of one multi-compartment bundle (FR-1). The Lobby's cross-vault **Relocate/Extract** capability — what niwat onboarding needs first.

**hub is unchanged** (`git diff main -- packages/hub` is empty): hub's `ref()` deliberately rejects cross-vault refs (`RefScopeError`), and `walkClosure`/`extractPartition`/`describeExtraction` are intra-vault primitives reused as-is. FR-2 composes them + FR-1's `encodeMultiBundle`.

New in `@klum-db/lobby` (`src/interchange/extract-cross-vault.ts`):
- `walkCrossVaultClosure(openVault, {seed, crossVaultRefs, maxDepth})` — walks per-vault closures (hub `walkClosure`), harvests cross-vault FK values via an **app-supplied descriptor** `{from:{collection,field}, to:{vault,collection,field?='id'}}`, seeds targets by id-membership, fixpoints over transitive edges (bounded by `maxDepth` + a walked-signature dedup that terminates on cycles), returns per-vault seeds/closures + a dangling list.
- `extractCrossVaultPartition(...)` — `extractPartition` per vault (re-keyed + transfer-sealed) → composes the extracted-partition bundle bytes via `encodeMultiBundle` → returns `{ bundle, transferKeys, sealIds }`. **Per-compartment transfer keys** (a `{vault → key}` map, delivered out-of-band, separate from the bundle). Throws `CrossVaultDanglingRefError` if any referenced row is missing.
- `describeCrossVaultExtraction(...)` — dry-run per-compartment preview that **surfaces** dangling refs (doesn't throw).

**Scope:** extract + describe (the adopt/merge read side is FR-3). **`to.field` is currently `id`-only** — a non-`id` target field throws a clear "not yet supported" guard (the real fix lands with FR-3+).

`features.yaml` entry `cross-vault-extraction` added; `scripts/feature-schema.json` widened to allow the `@klum-db/*` package scope (first klum feature). Built subagent-driven with per-task spec + code-quality reviews + a final whole-feature review.

## Test plan
- [x] `pnpm --filter @klum-db/lobby test` — 90 green; `extract-cross-vault` 9/9, incl. the **core acceptance vLannaAi/noy-db#1** as a real round-trip: extract → `readMultiVaultBundleCompartment` → `adoptPartition` + `createOwnerOnAdoptedPartition` with the directory compartment's transfer key → live `list()` asserts exactly `['e1','e2']` (not `e3`)
- [x] acceptance vLannaAi/noy-db#2 — `describeCrossVaultExtraction` per-compartment counts + dangling-present dry-run path
- [x] acceptance vLannaAi/noy-db#3 — `CrossVaultDanglingRefError` on a missing referenced row
- [x] `pnpm lint && pnpm typecheck` (full monorepo) — 127/127 + 130/130 (the FR-1 lint-gap killer)
- [x] `node scripts/validate-features.mjs` — OK (features=64); `pnpm check:architecture` — OK
- [x] `git diff main -- packages/hub` — empty (pure-klum)

## Forward fit (FR-3)
Each compartment is a standard adoptable extracted-partition: FR-3 consumes `readNoydbBundleManifest` → per-compartment `readMultiVaultBundleCompartment` + `adoptPartition` with the matching per-compartment transfer key. Follow-ups (non-blocking): non-`id` target fields; lobby `__tests__` into lint/typecheck scope (repo-wide hygiene); read-side perf (double walk / open-in-loop).