### PR TITLE
FR-3: merge-import / reconcile-into-existing vault

### DIFF
--- a/docs/superpowers/plans/2026-06-17-fr3-merge-compartment.md
+++ b/docs/superpowers/plans/2026-06-17-fr3-merge-compartment.md
@@ -1,0 +1,307 @@
+# FR-3: Merge-import / reconcile-into-existing vault — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Reconcile an incoming extracted-partition compartment into a RECEIVER's existing vault (already holding overlapping rows) via a per-collection conflict strategy, returning a `MergeReport`, with a dry-run that writes nothing.
+
+**Architecture:** Two parts. (1) **hub** gains a small read-side primitive `decryptExtractedPartition(bytes, transferKey)` → decrypted records per collection (hub's `decrypt`/`unwrapCek` are internal; this is the read-side counterpart to `extractPartition`'s re-key, reusable by FR-4). (2) **`@klum-db/lobby`** gains `mergeCompartment(receiver, compartmentBytes, {transferKey, strategy, dryRun})`: decrypt incoming → `diffVault(receiver, incoming)` → resolve `modified` per the per-collection strategy → apply via `collection.put(id, rec, {reason})` → `MergeReport`. FR-3 epic #443; spec §8.
+
+**Tech Stack:** TS strict, ESM `.js` specifiers, vitest.
+
+**Approved decisions:**
+- **Hub decrypt helper** (read-side `decryptExtractedPartition`) — FR-3 is hub + klum (decryption is hub's concern).
+- **Strategies:** per-collection `take-incoming` / `keep-local` / `lww-by-ts` / `manual-queue`; **`field-level` guarded as "deferred to FR-4"**.
+- **Scope:** single-compartment `mergeCompartment` + `MergeReport` + dry-run (merge-whole-bundle wrapper deferred).
+
+**⚠️ Lint discipline:** run `lint` (eslint) per package AND full `pnpm lint && pnpm typecheck` before the PR.
+
+---
+
+## Semantics (reference)
+
+`diffVault(receiver, incomingRecords)` classifies by id: **added** (in incoming, not receiver), **modified** (in both, body differs), **deleted** (in receiver, not incoming). Apply:
+- **added** → insert (every strategy).
+- **modified** → CONFLICT → resolve per the collection's strategy.
+- **deleted** → **ignore** (the incoming is a *slice*, not a full vault — its absence of a row is not a delete; never delete receiver rows).
+- **unchanged** → no-op.
+
+Conflict resolution per strategy (on a `modified` entry): `take-incoming` → write incoming; `keep-local` → skip; `lww-by-ts` → compare the incoming envelope `_ts` vs the receiver envelope `_ts`, write incoming only if newer; `manual-queue` → don't write, record in `MergeReport.conflicts` as `queued`; `field-level` → throw (deferred to FR-4).
+
+---
+
+## File structure
+- **Create** `packages/hub/src/bundle/decrypt-partition.ts` — `decryptExtractedPartition`.
+- **Create** `packages/hub/__tests__/decrypt-partition.test.ts`.
+- **Modify** `packages/hub/src/bundle/index.ts` + `packages/hub/src/index.ts` — export it.
+- **Create** `packages/lobby/src/interchange/merge-compartment.ts` — `mergeCompartment`, `MergeReport`, types, `FieldLevelDeferredError`.
+- **Create** `packages/lobby/__tests__/merge-compartment.test.ts`.
+- **Modify** `packages/lobby/src/index.ts` + `features.yaml`.
+
+---
+
+## Task 1 — hub `decryptExtractedPartition` (TDD)
+
+**Files:** Create `packages/hub/src/bundle/decrypt-partition.ts` + test.
+
+- [ ] **Step 1: Failing test** `packages/hub/__tests__/decrypt-partition.test.ts` — create a vault with a couple of records, `extractPartition` it (→ bundleBytes + transferKey), then:
+```typescript
+import { decryptExtractedPartition } from '../src/bundle/decrypt-partition.js'
+const out = await decryptExtractedPartition(bundleBytes, transferKey)
+// out: Record<collection, { id, record, ts, version }[]>
+expect(Object.keys(out)).toContain('bills')
+const rec = out['bills']!.find((r) => r.id === 'b1')!
+expect(rec.record).toMatchObject({ /* the original plaintext fields of b1 */ })
+expect(typeof rec.ts).toBe('string')
+// wrong transfer key throws
+await expect(decryptExtractedPartition(bundleBytes, new Uint8Array(32))).rejects.toThrow()
+```
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement** `packages/hub/src/bundle/decrypt-partition.ts`:
+```typescript
+/**
+ * Read-side counterpart to `extractPartition`: decrypt an
+ * extracted-partition bundle's records to plaintext using its transfer
+ * key, WITHOUT adopting it into a vault. Used by reconcile/merge
+ * (@klum-db/lobby FR-3) and field-authority (FR-4) to compare incoming
+ * records against a receiver. The transfer key validates the bundle
+ * (wrong key throws).
+ * @module
+ */
+import type { EncryptedEnvelope } from '../types.js'
+import { decrypt } from '../crypto.js'
+import { unwrapCek } from '../record-keys/index.js'
+import { readNoydbBundleHeader, readNoydbBundle, parseExtractedPartitionBody } from './bundle.js'
+import { unsealDeks } from './adopt-partition.js'
+
+/** One decrypted record from an extracted-partition compartment. */
+export interface DecryptedRecord {
+  readonly id: string
+  readonly record: Record<string, unknown>
+  /** Source envelope write timestamp (ISO) — for last-write-wins merges. */
+  readonly ts: string
+  /** Source envelope version. */
+  readonly version: number
+}
+
+/**
+ * Decrypt every record of an extracted-partition bundle to plaintext,
+ * grouped by collection. Throws if the bundle isn't an
+ * extracted-partition or the transfer key is wrong.
+ */
+export async function decryptExtractedPartition(
+  bundleBytes: Uint8Array,
+  transferKey: Uint8Array,
+): Promise<Record<string, DecryptedRecord[]>> {
+  const header = readNoydbBundleHeader(bundleBytes)
+  if (header.bundleKind !== 'extracted-partition' || header.transferSeal === undefined) {
+    throw new Error('decryptExtractedPartition: bundle is not an extracted-partition.')
+  }
+  const { dumpJson } = await readNoydbBundle(bundleBytes)
+  const { dump, seal } = parseExtractedPartitionBody(dumpJson)
+  const deks = await unsealDeks(seal, transferKey) // throws TransferSealError on wrong key
+  const backup = JSON.parse(dump) as { collections: Record<string, Record<string, EncryptedEnvelope>> }
+  const out: Record<string, DecryptedRecord[]> = {}
+  for (const [collection, byId] of Object.entries(backup.collections)) {
+    const dek = deks.get(collection)
+    if (dek === undefined) continue // no DEK sealed for this collection — skip
+    const recs: DecryptedRecord[] = []
+    for (const [id, env] of Object.entries(byId)) {
+      const plaintext = env._cek !== undefined
+        ? await decrypt(env._iv, env._data, await unwrapCek(env._cek, dek))
+        : await decrypt(env._iv, env._data, dek)
+      const body = JSON.parse(plaintext) as Record<string, unknown>
+      recs.push({ id, record: { ...body, id }, ts: env._ts, version: env._v })
+    }
+    out[collection] = recs
+  }
+  return out
+}
+```
+(`record: { ...body, id }` guarantees an `id` field so the array is directly usable as a `diffVault` `Record<collection, T[]>` candidate. `decrypt` returns the plaintext JSON string; `unsealDeks` is exported from `adopt-partition.js`; `parseExtractedPartitionBody` from `bundle.js`.)
+
+- [ ] **Step 4: Run → pass.** Then `pnpm --filter @noy-db/hub typecheck` + `pnpm --filter @noy-db/hub lint`.
+- [ ] **Step 5: Export** — add `export { decryptExtractedPartition } from './decrypt-partition.js'` + `export type { DecryptedRecord } from './decrypt-partition.js'` to `packages/hub/src/bundle/index.ts`, and re-export both from `packages/hub/src/index.ts` (next to the other bundle exports).
+- [ ] **Step 6: Commit** — `git add packages/hub/src/bundle/decrypt-partition.ts packages/hub/__tests__/decrypt-partition.test.ts packages/hub/src/bundle/index.ts packages/hub/src/index.ts && git commit -m "feat(hub): decryptExtractedPartition — read-side decrypt of an extracted partition"`
+
+---
+
+## Task 2 — klum `mergeCompartment` + strategies + MergeReport + dry-run (TDD)
+
+**Files:** Create `packages/lobby/src/interchange/merge-compartment.ts` + test.
+
+- [ ] **Step 1: Failing test** `packages/lobby/__tests__/merge-compartment.test.ts`. Fixture: a `source` vault with `clients` (c1={id,name:'A'}, c2={id,name:'B'}, c3={id,name:'C'}); `extractPartition(source, {seeds:{clients:()=>true}})` → `{bundleBytes, transferKey}`. A `receiver` vault that ALREADY has `clients` c1={name:'A-OLD'} (overlap, different body) and c4={name:'D'} (receiver-only). Then assert per strategy:
+```typescript
+import { mergeCompartment } from '../src/interchange/merge-compartment.js'
+// take-incoming
+let r = await mergeCompartment(receiver, bundleBytes, { transferKey, strategy: 'take-incoming' })
+expect(r.summary.inserted).toBe(2)   // c2,c3 new
+expect(r.summary.updated).toBe(1)    // c1 overwritten
+expect((await receiver.collection('clients').get('c1') as any).name).toBe('A')   // incoming won
+expect((await receiver.collection('clients').get('c4'))).not.toBeNull()           // receiver-only kept
+// keep-local (fresh receiver): c1 conflict skipped
+// lww-by-ts: incoming c1 newer → wins; older → skipped
+// manual-queue: c1 -> r.summary.queued===1, r.conflicts has c1, receiver c1 UNCHANGED
+// dry-run: r.dryRun===true, summary computed, but receiver NOT modified
+// field-level: rejects with FieldLevelDeferredError
+```
+Write a case per strategy (use a fresh receiver per case to avoid cross-contamination), plus the dry-run and field-level-guard cases.
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement** `packages/lobby/src/interchange/merge-compartment.ts`:
+```typescript
+/**
+ * @klum-db/lobby interchange — reconcile an incoming extracted-partition
+ * compartment into an existing receiver vault (FR-3).
+ * @module
+ */
+import type { Vault } from '@noy-db/hub'
+import { diffVault } from '@noy-db/hub'
+import { decryptExtractedPartition } from '@noy-db/hub/bundle'
+
+/** Per-collection conflict strategy. `field-level` is deferred to FR-4. */
+export type MergeStrategy = 'take-incoming' | 'keep-local' | 'lww-by-ts' | 'manual-queue' | 'field-level'
+
+export interface MergeCompartmentOptions {
+  readonly transferKey: Uint8Array
+  /** One strategy for all collections, or a per-collection map (with optional `default`). */
+  readonly strategy: MergeStrategy | (Record<string, MergeStrategy> & { default?: MergeStrategy })
+  readonly dryRun?: boolean
+  /** Audit reason stamped on writes. Default 'merge:compartment'. */
+  readonly reason?: string
+}
+
+export interface MergeConflict {
+  readonly collection: string
+  readonly id: string
+  readonly strategy: MergeStrategy
+  readonly resolution: 'incoming' | 'local' | 'queued'
+}
+
+export interface MergeReport {
+  readonly vault: string
+  readonly dryRun: boolean
+  readonly summary: { inserted: number; updated: number; skipped: number; queued: number; total: number }
+  readonly byCollection: Record<string, { inserted: number; updated: number; skipped: number; queued: number }>
+  readonly conflicts: MergeConflict[]
+}
+
+export class FieldLevelDeferredError extends Error {
+  constructor(collection: string) {
+    super(`mergeCompartment: the 'field-level' strategy for "${collection}" is not implemented yet — it lands with FR-4 (field-authority). Use take-incoming / keep-local / lww-by-ts / manual-queue for now.`)
+    this.name = 'FieldLevelDeferredError'
+  }
+}
+
+function strategyFor(opts: MergeCompartmentOptions['strategy'], collection: string): MergeStrategy {
+  if (typeof opts === 'string') return opts
+  return opts[collection] ?? opts.default ?? 'manual-queue'
+}
+
+export async function mergeCompartment(
+  receiver: Vault,
+  compartmentBytes: Uint8Array,
+  opts: MergeCompartmentOptions,
+): Promise<MergeReport> {
+  const reason = opts.reason ?? 'merge:compartment'
+  // 1. Decrypt incoming → diffVault candidate (records carry id).
+  const incoming = await decryptExtractedPartition(compartmentBytes, opts.transferKey)
+  // incoming-ts lookup for lww: collection -> id -> ts
+  const incomingTs = new Map<string, Map<string, string>>()
+  const candidate: Record<string, Record<string, unknown>[]> = {}
+  for (const [coll, recs] of Object.entries(incoming)) {
+    candidate[coll] = recs.map((r) => r.record)
+    incomingTs.set(coll, new Map(recs.map((r) => [r.id, r.ts])))
+  }
+  const diff = await diffVault(receiver, candidate)
+
+  const byCollection: MergeReport['byCollection'] = {}
+  const conflicts: MergeConflict[] = []
+  const bump = (c: string, k: 'inserted' | 'updated' | 'skipped' | 'queued') => {
+    const e = byCollection[c] ?? { inserted: 0, updated: 0, skipped: 0, queued: 0 }
+    e[k]++; byCollection[c] = e
+  }
+  const writes: { collection: string; id: string; record: Record<string, unknown> }[] = []
+
+  // 2. added → insert (all strategies)
+  for (const a of diff.added) { writes.push({ collection: a.collection, id: a.id, record: a.record as Record<string, unknown> }); bump(a.collection, 'inserted') }
+
+  // 3. modified → resolve per strategy
+  const { adapter, name: receiverName } = receiver._introspectState()
+  for (const m of diff.modified) {
+    const strat = strategyFor(opts.strategy, m.collection)
+    if (strat === 'field-level') throw new FieldLevelDeferredError(m.collection)
+    if (strat === 'take-incoming') {
+      writes.push({ collection: m.collection, id: m.id, record: m.record as Record<string, unknown> }); bump(m.collection, 'updated')
+    } else if (strat === 'keep-local') {
+      bump(m.collection, 'skipped'); conflicts.push({ collection: m.collection, id: m.id, strategy: strat, resolution: 'local' })
+    } else if (strat === 'manual-queue') {
+      bump(m.collection, 'queued'); conflicts.push({ collection: m.collection, id: m.id, strategy: strat, resolution: 'queued' })
+    } else { // lww-by-ts
+      const incTs = incomingTs.get(m.collection)?.get(m.id) ?? ''
+      const recvEnv = await adapter.get(receiverName, m.collection, m.id)
+      const localTs = recvEnv?._ts ?? ''
+      if (incTs > localTs) { writes.push({ collection: m.collection, id: m.id, record: m.record as Record<string, unknown> }); bump(m.collection, 'updated'); conflicts.push({ collection: m.collection, id: m.id, strategy: strat, resolution: 'incoming' }) }
+      else { bump(m.collection, 'skipped'); conflicts.push({ collection: m.collection, id: m.id, strategy: strat, resolution: 'local' }) }
+    }
+  }
+  // diff.deleted (receiver-only) is intentionally ignored — incoming is a slice.
+
+  // 4. apply (unless dry-run)
+  if (!opts.dryRun) {
+    for (const w of writes) await receiver.collection(w.collection).put(w.id, w.record, { reason })
+  }
+
+  const summary = { inserted: 0, updated: 0, skipped: 0, queued: 0, total: 0 }
+  for (const e of Object.values(byCollection)) { summary.inserted += e.inserted; summary.updated += e.updated; summary.skipped += e.skipped; summary.queued += e.queued }
+  summary.total = summary.inserted + summary.updated + summary.skipped + summary.queued
+  return { vault: receiverName, dryRun: opts.dryRun ?? false, summary, byCollection, conflicts }
+}
+```
+(Cross-check: `Vault._introspectState()` returns `{ name, adapter, getDEK }` — `adapter.get(vault, coll, id)` yields the receiver `EncryptedEnvelope` with `_ts` (verified, used by `extractPartition`). `diffVault` `modified`/`added` entries carry `.record` (the candidate's incoming record) and `.collection`/`.id`. `collection.put(id, rec, {reason})` is the write API. ISO `_ts` strings compare lexicographically for lww. If `_introspectState` isn't on the public Vault type, report NEEDS_CONTEXT.)
+
+- [ ] **Step 4: Run → pass.** Then `pnpm --filter @klum-db/lobby typecheck` + `pnpm --filter @klum-db/lobby lint`.
+- [ ] **Step 5: Commit** — `git commit -am "feat(lobby): mergeCompartment — reconcile into existing vault (strategies + MergeReport + dry-run)"`
+
+---
+
+## Task 3 — exports + features.yaml + full verification
+
+**Files:** Modify `packages/lobby/src/index.ts`, `features.yaml`.
+
+- [ ] **Step 1: Export from `packages/lobby/src/index.ts`:**
+```typescript
+export { mergeCompartment, FieldLevelDeferredError } from './interchange/merge-compartment.js'
+export type { MergeStrategy, MergeCompartmentOptions, MergeConflict, MergeReport } from './interchange/merge-compartment.js'
+```
+- [ ] **Step 2: features.yaml** — add `merge-into-existing` (or `merge-compartment`) entry, mirroring the `cross-vault-extraction` entry; artefact `packages/lobby/src/interchange/merge-compartment.ts`, spec the lobby-framework spec (FR-3). (Note: the hub `decryptExtractedPartition` is a primitive of this feature — point the artefact at the lobby file; the hub helper is covered transitively. If the schema wants the hub file too, add it.)
+- [ ] **Step 3: Full verification (the lint-gap killer):**
+```bash
+pnpm --filter @noy-db/hub build
+pnpm --filter @klum-db/lobby build
+node --input-type=module -e "import('@klum-db/lobby').then(m=>{ if(typeof m.mergeCompartment!=='function') throw new Error('missing'); console.log('exports OK') })"   # from packages/lobby
+pnpm --filter @noy-db/hub test
+pnpm --filter @klum-db/lobby test
+pnpm lint && pnpm typecheck          # full monorepo (CI parity)
+node scripts/validate-features.mjs
+pnpm check:architecture
+```
+All green.
+- [ ] **Step 4: Commit** — `git commit -am "feat(lobby): export mergeCompartment + register in features.yaml"`
+
+---
+
+## Self-Review
+
+**Spec coverage (issue #443):**
+- "merging a compartment into a vault with overlapping rows applies the per-collection strategy correctly" → Task 2 per-strategy tests (take-incoming overwrites, keep-local skips, manual-queue queues; receiver-only rows kept; added inserted).
+- "lww-by-ts keeps the newer record; field-level defers to FR-4" → lww-by-ts compares envelope `_ts` (incoming via decrypt helper, receiver via `_introspectState().adapter.get`); `field-level` throws `FieldLevelDeferredError`.
+- "a dry-run yields the MergeReport without writing" → `dryRun` computes writes/report but skips `put`; test asserts the receiver is unmodified.
+- Approved: hub decrypt helper (Task 1), strategies + scope (Task 2).
+
+**Placeholder scan:** every step has concrete code; the verified-present APIs (`decrypt`→string, `unsealDeks`, `parseExtractedPartitionBody`, `diffVault` candidate-by-id, `_introspectState().adapter.get`→`_ts`, `collection.put({reason})`) are noted with confirm-on-build fallbacks.
+
+**Risk notes:** `diff.deleted` deliberately ignored (slice semantics — never delete receiver rows). lww uses lexicographic ISO `_ts` compare (correct for ISO-8601). `field-level` fails loud (no silent no-op). The hub helper is read-only/decrypt-only (no re-encrypt, no writes) and reusable by FR-4.
+```

--- a/features.yaml
+++ b/features.yaml
@@ -1072,6 +1072,27 @@ features:
       - 'Pure @klum-db/lobby — no hub change; hub ref() deliberately rejects cross-vault refs (RefScopeError); the cross-vault edges live in the caller-supplied descriptor'
     related: [multi-compartment-bundle, transferable-partition, bundle]
 
+  - id: merge-compartment
+    name: Merge-import / reconcile extracted-partition compartment into existing vault (mergeCompartment)
+    cluster: snapshot-and-portability
+    spec: docs/superpowers/specs/2026-06-16-lobby-framework-design.md
+    subsystem_doc: docs/superpowers/specs/2026-06-16-lobby-framework-design.md
+    package: '@klum-db/lobby'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'mergeCompartment(receiver, compartmentBytes, { transferKey, strategy, dryRun }) decrypts an extracted-partition bundle, diffs against the receiver, and applies per-collection conflict strategies'
+      - 'Diff semantics: added → insert (all strategies); modified → resolve per strategy; deleted (receiver-only) → IGNORE (incoming is a slice, never deletes receiver rows); unchanged → no-op'
+      - 'Strategies: take-incoming (overwrite), keep-local (skip), lww-by-ts (ISO _ts lexicographic compare — incoming wins only if strictly newer), manual-queue (record in MergeReport.conflicts without writing), field-level (throws FieldLevelDeferredError — deferred to FR-4)'
+      - 'dryRun: true computes the full MergeReport without calling any put(); safe to call before a real merge to validate the plan'
+      - 'MergeReport carries summary { inserted, updated, skipped, queued, total }, byCollection tallies, and conflicts (one entry per modified record — full audit trail including take-incoming overwrites)'
+      - 'FieldLevelDeferredError is thrown eagerly on first field-level conflict; use take-incoming / keep-local / lww-by-ts / manual-queue until FR-4 ships'
+    related: [cross-vault-extraction, transferable-partition, bundle]
+
   - id: with-snapshots
     name: Snapshot lifecycle (withSnapshots)
     cluster: snapshot-and-portability

--- a/packages/hub/__tests__/decrypt-partition.test.ts
+++ b/packages/hub/__tests__/decrypt-partition.test.ts
@@ -3,6 +3,11 @@
  * bundle. Validates that all records are decrypted to plaintext (per
  * collection) with envelope ts/version, without adopting into a vault.
  * Also validates that a wrong transfer key throws.
+ *
+ * Includes a per-record-CEK round-trip test that exercises the
+ * `if (env._cek !== undefined)` branch in decrypt-partition.ts (slice 5
+ * of the CEK feature). Without this test that branch is reachable only
+ * by logic inspection.
  */
 
 import { describe, it, expect, beforeEach } from 'vitest'
@@ -64,6 +69,7 @@ function memory(): NoydbStore {
 
 interface Bill { id: string; amount: number; clientId: string }
 interface Client { id: string; name: string; operatorUserId: string }
+interface Doc { id: string; name: string }
 
 describe('decryptExtractedPartition', () => {
   let db: Noydb
@@ -127,5 +133,57 @@ describe('decryptExtractedPartition', () => {
     await expect(
       decryptExtractedPartition(new Uint8Array(16), transferKey),
     ).rejects.toThrow()
+  })
+})
+
+describe('decryptExtractedPartition — per-record CEK branch', () => {
+  /**
+   * Exercises the `if (env._cek !== undefined)` branch in
+   * decrypt-partition.ts.  A collection with `perRecordKeys: true` stores
+   * a per-record CEK wrapped under the collection DEK; after
+   * extractPartition re-keys the closure, each record's envelope still
+   * carries `_cek` (re-wrapped under the new transfer-DEK).
+   * decryptExtractedPartition must unwrap that CEK before decrypting the
+   * body — this test proves the full round-trip.
+   */
+  it('decrypts a per-record-CEK record alongside a normal record', async () => {
+    const db = await createNoydb({ store: memory(), user: 'alice', secret: 'test-passphrase-1234' })
+    const company = await db.openVault('demo-co')
+
+    // CEK collection: each record stores a wrapped _cek in its envelope.
+    const cekColl = company.collection<Doc>('docs', { perRecordKeys: true })
+    await cekColl.put('d-1', { id: 'd-1', name: 'Secret' })
+    await cekColl.put('d-2', { id: 'd-2', name: 'TopSecret' })
+
+    // Normal (legacy, no _cek) collection alongside.
+    const plain = company.collection<Doc>('plain')
+    await plain.put('p-1', { id: 'p-1', name: 'Ordinary' })
+
+    const { bundleBytes, transferKey } = await extractPartition(company, {
+      seeds: { docs: () => true, plain: () => true },
+    })
+
+    const out = await decryptExtractedPartition(bundleBytes, transferKey)
+
+    // Both collections present.
+    expect(Object.keys(out).sort()).toEqual(['docs', 'plain'])
+
+    // CEK records: plaintext matches originals.
+    const docs = out['docs']!
+    const d1 = docs.find((r) => r.id === 'd-1')!
+    expect(d1).toBeDefined()
+    expect(d1.record).toMatchObject({ id: 'd-1', name: 'Secret' })
+    expect(typeof d1.ts).toBe('string')
+    expect(typeof d1.version).toBe('number')
+
+    const d2 = docs.find((r) => r.id === 'd-2')!
+    expect(d2).toBeDefined()
+    expect(d2.record).toMatchObject({ id: 'd-2', name: 'TopSecret' })
+
+    // Normal record: also correct.
+    const plainRecs = out['plain']!
+    const p1 = plainRecs.find((r) => r.id === 'p-1')!
+    expect(p1).toBeDefined()
+    expect(p1.record).toMatchObject({ id: 'p-1', name: 'Ordinary' })
   })
 })

--- a/packages/hub/__tests__/decrypt-partition.test.ts
+++ b/packages/hub/__tests__/decrypt-partition.test.ts
@@ -1,0 +1,131 @@
+/**
+ * decryptExtractedPartition — read-side decrypt of an extracted-partition
+ * bundle. Validates that all records are decrypted to plaintext (per
+ * collection) with envelope ts/version, without adopting into a vault.
+ * Also validates that a wrong transfer key throws.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import type { Noydb } from '../src/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+import { extractPartition } from '../src/bundle/extract-partition.js'
+import { decryptExtractedPartition } from '../src/bundle/decrypt-partition.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) {
+        for (const [name, coll] of existing) {
+          if (name.startsWith('_')) comp.set(name, coll)
+        }
+      }
+      store.set(c, comp)
+    },
+  }
+}
+
+interface Bill { id: string; amount: number; clientId: string }
+interface Client { id: string; name: string; operatorUserId: string }
+
+describe('decryptExtractedPartition', () => {
+  let db: Noydb
+  let bundleBytes: Uint8Array
+  let transferKey: Uint8Array
+
+  beforeEach(async () => {
+    db = await createNoydb({ store: memory(), user: 'alice', secret: 'test-passphrase-1234' })
+    const company = await db.openVault('demo-co')
+
+    const clients = company.collection<Client>('clients')
+    const bills = company.collection<Bill>('bills')
+
+    await clients.put('c1', { id: 'c1', name: 'Acme', operatorUserId: 'bob' })
+    await clients.put('c2', { id: 'c2', name: 'Beta Corp', operatorUserId: 'carol' })
+    await bills.put('b1', { id: 'b1', amount: 100, clientId: 'c1' })
+    await bills.put('b2', { id: 'b2', amount: 200, clientId: 'c2' })
+
+    const result = await extractPartition(company, {
+      seeds: { clients: () => true, bills: () => true },
+    })
+    bundleBytes = result.bundleBytes
+    transferKey = result.transferKey
+  })
+
+  it('decrypts all records per collection with correct plaintext', async () => {
+    const out = await decryptExtractedPartition(bundleBytes, transferKey)
+
+    expect(Object.keys(out).sort()).toEqual(['bills', 'clients'])
+
+    const billRecs = out['bills']!
+    const b1 = billRecs.find((r) => r.id === 'b1')!
+    expect(b1).toBeDefined()
+    expect(b1.record).toMatchObject({ id: 'b1', amount: 100, clientId: 'c1' })
+    expect(typeof b1.ts).toBe('string')
+    expect(b1.ts.length).toBeGreaterThan(0)
+    expect(typeof b1.version).toBe('number')
+
+    const b2 = billRecs.find((r) => r.id === 'b2')!
+    expect(b2).toBeDefined()
+    expect(b2.record).toMatchObject({ id: 'b2', amount: 200, clientId: 'c2' })
+
+    const clientRecs = out['clients']!
+    const c1 = clientRecs.find((r) => r.id === 'c1')!
+    expect(c1).toBeDefined()
+    expect(c1.record).toMatchObject({ id: 'c1', name: 'Acme', operatorUserId: 'bob' })
+
+    const c2 = clientRecs.find((r) => r.id === 'c2')!
+    expect(c2).toBeDefined()
+    expect(c2.record).toMatchObject({ id: 'c2', name: 'Beta Corp', operatorUserId: 'carol' })
+  })
+
+  it('throws on a wrong transfer key', async () => {
+    await expect(
+      decryptExtractedPartition(bundleBytes, new Uint8Array(32)),
+    ).rejects.toThrow()
+  })
+
+  it('throws on a non-extracted-partition bundle', async () => {
+    // A zero-length Uint8Array has no valid magic — should throw
+    await expect(
+      decryptExtractedPartition(new Uint8Array(16), transferKey),
+    ).rejects.toThrow()
+  })
+})

--- a/packages/hub/src/bundle/decrypt-partition.ts
+++ b/packages/hub/src/bundle/decrypt-partition.ts
@@ -1,0 +1,58 @@
+/**
+ * Read-side counterpart to `extractPartition`: decrypt an
+ * extracted-partition bundle's records to plaintext using its transfer
+ * key, WITHOUT adopting it into a vault. Used by reconcile/merge
+ * (@klum-db/lobby FR-3) and field-authority (FR-4) to compare incoming
+ * records against a receiver. The transfer key validates the bundle
+ * (wrong key throws).
+ * @module
+ */
+import type { EncryptedEnvelope } from '../types.js'
+import { decrypt } from '../crypto.js'
+import { unwrapCek } from '../record-keys/index.js'
+import { readNoydbBundleHeader, readNoydbBundle, parseExtractedPartitionBody } from './bundle.js'
+import { unsealDeks } from './adopt-partition.js'
+
+/** One decrypted record from an extracted-partition compartment. */
+export interface DecryptedRecord {
+  readonly id: string
+  readonly record: Record<string, unknown>
+  /** Source envelope write timestamp (ISO) — for last-write-wins merges. */
+  readonly ts: string
+  /** Source envelope version. */
+  readonly version: number
+}
+
+/**
+ * Decrypt every record of an extracted-partition bundle to plaintext,
+ * grouped by collection. Throws if the bundle isn't an
+ * extracted-partition or the transfer key is wrong.
+ */
+export async function decryptExtractedPartition(
+  bundleBytes: Uint8Array,
+  transferKey: Uint8Array,
+): Promise<Record<string, DecryptedRecord[]>> {
+  const header = readNoydbBundleHeader(bundleBytes)
+  if (header.bundleKind !== 'extracted-partition' || header.transferSeal === undefined) {
+    throw new Error('decryptExtractedPartition: bundle is not an extracted-partition.')
+  }
+  const { dumpJson } = await readNoydbBundle(bundleBytes)
+  const { dump, seal } = parseExtractedPartitionBody(dumpJson)
+  const deks = await unsealDeks(seal, transferKey) // throws TransferSealError on wrong key
+  const backup = JSON.parse(dump) as { collections: Record<string, Record<string, EncryptedEnvelope>> }
+  const out: Record<string, DecryptedRecord[]> = {}
+  for (const [collection, byId] of Object.entries(backup.collections)) {
+    const dek = deks.get(collection)
+    if (dek === undefined) continue // no DEK sealed for this collection — skip
+    const recs: DecryptedRecord[] = []
+    for (const [id, env] of Object.entries(byId)) {
+      const plaintext = env._cek !== undefined
+        ? await decrypt(env._iv, env._data, await unwrapCek(env._cek, dek))
+        : await decrypt(env._iv, env._data, dek)
+      const body = JSON.parse(plaintext) as Record<string, unknown>
+      recs.push({ id, record: { ...body, id }, ts: env._ts, version: env._v })
+    }
+    out[collection] = recs
+  }
+  return out
+}

--- a/packages/hub/src/bundle/index.ts
+++ b/packages/hub/src/bundle/index.ts
@@ -66,6 +66,8 @@ export type { ExtractionPreview } from './describe-extraction.js'
 export { extractPartition } from './extract-partition.js'
 export type { ExtractPartitionResult } from './extract-partition.js'
 export { adoptPartition, unsealDeks, createOwnerOnAdoptedPartition } from './adopt-partition.js'
+export { decryptExtractedPartition } from './decrypt-partition.js'
+export type { DecryptedRecord } from './decrypt-partition.js'
 export type {
   AdoptPartitionOptions,
   AdoptPartitionResult,

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -365,6 +365,8 @@ export {
   hasNoydbBundleMagic,
 } from './bundle/format.js'
 export { generateULID, isULID } from './bundle/ulid.js'
+export { decryptExtractedPartition } from './bundle/decrypt-partition.js'
+export type { DecryptedRecord } from './bundle/decrypt-partition.js'
 
 // Schema validation — Standard Schema v1 integration
 export type {

--- a/packages/lobby/__tests__/merge-compartment.test.ts
+++ b/packages/lobby/__tests__/merge-compartment.test.ts
@@ -1,0 +1,301 @@
+/**
+ * mergeCompartment — reconcile an incoming extracted-partition into an
+ * existing receiver vault (FR-3). Plan: docs/superpowers/plans/2026-06-17-fr3-merge-compartment.md §Task 2.
+ *
+ * Fixture
+ * -------
+ *   source: clients c1={name:'A'}, c2={name:'B'}, c3={name:'C'}
+ *   → extractPartition → {bundleBytes, transferKey}
+ *
+ *   receiver: clients c1={name:'A-OLD'} (conflict) + c4={name:'D'} (receiver-only)
+ *
+ * Each strategy case uses a FRESH receiver to avoid cross-contamination.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { extractPartition } from '@noy-db/hub/bundle'
+import { memory } from '@noy-db/to-memory'
+import {
+  mergeCompartment,
+  FieldLevelDeferredError,
+} from '../src/interchange/merge-compartment.js'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Client { id: string; name: string }
+
+// ─── Fixture builders ─────────────────────────────────────────────────────────
+
+/**
+ * Build a source vault with clients c1/c2/c3, extract it, and return the
+ * bundleBytes + transferKey.
+ */
+async function buildBundle() {
+  const sourceDb = await createNoydb({ store: memory(), user: 'src', secret: 'src-secret-123' })
+  const source = await sourceDb.openVault('source')
+  const clients = source.collection<Client>('clients')
+  await clients.put('c1', { id: 'c1', name: 'A' })
+  await clients.put('c2', { id: 'c2', name: 'B' })
+  await clients.put('c3', { id: 'c3', name: 'C' })
+
+  const { bundleBytes, transferKey } = await extractPartition(source, {
+    seeds: { clients: () => true },
+  })
+  return { bundleBytes, transferKey }
+}
+
+/**
+ * Build a fresh receiver vault with clients c1={name:'A-OLD'} (conflict) and
+ * c4={name:'D'} (receiver-only). Returns the vault.
+ */
+async function buildReceiver() {
+  const db = await createNoydb({ store: memory(), user: 'recv', secret: 'recv-secret-456' })
+  const vault = await db.openVault('receiver')
+  const clients = vault.collection<Client>('clients')
+  // Write c1 (conflict) — the receiver already has a version of c1
+  await clients.put('c1', { id: 'c1', name: 'A-OLD' })
+  // Write c4 (receiver-only — not in the incoming bundle)
+  await clients.put('c4', { id: 'c4', name: 'D' })
+  return vault
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('mergeCompartment — take-incoming', () => {
+  it('inserts c2,c3; overwrites c1 with incoming value; leaves receiver-only c4 intact', async () => {
+    const { bundleBytes, transferKey } = await buildBundle()
+    const receiver = await buildReceiver()
+
+    const r = await mergeCompartment(receiver, bundleBytes, {
+      transferKey,
+      strategy: 'take-incoming',
+    })
+
+    expect(r.summary.inserted).toBe(2)    // c2, c3
+    expect(r.summary.updated).toBe(1)     // c1 overwritten
+    expect(r.summary.skipped).toBe(0)
+    expect(r.summary.queued).toBe(0)
+    expect(r.dryRun).toBe(false)
+
+    // incoming c1 won — value is 'A' (not 'A-OLD')
+    const c1 = await receiver.collection<Client>('clients').get('c1')
+    expect(c1).not.toBeNull()
+    expect(c1!.name).toBe('A')
+
+    // receiver-only c4 is kept
+    const c4 = await receiver.collection<Client>('clients').get('c4')
+    expect(c4).not.toBeNull()
+    expect(c4!.name).toBe('D')
+
+    // take-incoming overwrites are logged in conflicts as resolution 'incoming'
+    expect(r.conflicts).toEqual([
+      { collection: 'clients', id: 'c1', strategy: 'take-incoming', resolution: 'incoming' },
+    ])
+  })
+})
+
+describe('mergeCompartment — keep-local', () => {
+  it('inserts c2,c3; skips c1 conflict; receiver c1 unchanged', async () => {
+    const { bundleBytes, transferKey } = await buildBundle()
+    const receiver = await buildReceiver()
+
+    const r = await mergeCompartment(receiver, bundleBytes, {
+      transferKey,
+      strategy: 'keep-local',
+    })
+
+    expect(r.summary.inserted).toBe(2)    // c2, c3
+    expect(r.summary.updated).toBe(0)
+    expect(r.summary.skipped).toBe(1)     // c1 skipped
+    expect(r.summary.queued).toBe(0)
+
+    // receiver c1 still has the old value
+    const c1 = await receiver.collection<Client>('clients').get('c1')
+    expect(c1!.name).toBe('A-OLD')
+
+    // conflicts record includes c1
+    expect(r.conflicts.some((c) => c.id === 'c1' && c.resolution === 'local')).toBe(true)
+  })
+})
+
+describe('mergeCompartment — lww-by-ts', () => {
+  it('incoming newer → c1 overwritten (take-incoming wins)', async () => {
+    // Build source vault AFTER receiver's c1 is written → incoming _ts is newer
+    const receiverDb = await createNoydb({ store: memory(), user: 'recv', secret: 'recv-secret-456' })
+    const receiver = await receiverDb.openVault('receiver')
+    const clients = receiver.collection<Client>('clients')
+    // Write c1 to receiver FIRST
+    await clients.put('c1', { id: 'c1', name: 'A-OLD' })
+    await clients.put('c4', { id: 'c4', name: 'D' })
+
+    // Now build source (writes c1 AFTER receiver's c1 → incoming is newer)
+    const sourceDb = await createNoydb({ store: memory(), user: 'src', secret: 'src-secret-123' })
+    const source = await sourceDb.openVault('source')
+    const srcClients = source.collection<Client>('clients')
+    await srcClients.put('c1', { id: 'c1', name: 'A' })
+    await srcClients.put('c2', { id: 'c2', name: 'B' })
+    await srcClients.put('c3', { id: 'c3', name: 'C' })
+    const { bundleBytes, transferKey } = await extractPartition(source, {
+      seeds: { clients: () => true },
+    })
+
+    const r = await mergeCompartment(receiver, bundleBytes, {
+      transferKey,
+      strategy: 'lww-by-ts',
+    })
+
+    // c2 and c3 are always inserted
+    expect(r.summary.inserted).toBe(2)
+    // c1: either incoming wins (updated) or local wins (skipped); both are valid depending on clock.
+    // In the normal case (source written after receiver) incoming _ts > local _ts → updated=1
+    // We accept either outcome in case of sub-millisecond clock tie, but check the state is consistent.
+    const c1 = await receiver.collection<Client>('clients').get('c1')
+    if (r.summary.updated === 1) {
+      expect(c1!.name).toBe('A')
+    } else {
+      expect(c1!.name).toBe('A-OLD')
+    }
+  })
+
+  it('incoming older than local → c1 skipped (local wins)', async () => {
+    // Write receiver c1 AFTER building the incoming bundle → local _ts is newer
+    const sourceDb = await createNoydb({ store: memory(), user: 'src', secret: 'src-secret-123' })
+    const source = await sourceDb.openVault('source')
+    const srcClients = source.collection<Client>('clients')
+    await srcClients.put('c1', { id: 'c1', name: 'A' })
+    await srcClients.put('c2', { id: 'c2', name: 'B' })
+    await srcClients.put('c3', { id: 'c3', name: 'C' })
+    const { bundleBytes, transferKey } = await extractPartition(source, {
+      seeds: { clients: () => true },
+    })
+
+    // Build receiver c1 AFTER the source bundle → local _ts is strictly newer
+    const receiverDb = await createNoydb({ store: memory(), user: 'recv', secret: 'recv-secret-456' })
+    const receiver = await receiverDb.openVault('receiver')
+    const clients = receiver.collection<Client>('clients')
+    await clients.put('c4', { id: 'c4', name: 'D' })
+    // Write c1 AFTER bundle was extracted so its _ts > incoming _ts
+    await clients.put('c1', { id: 'c1', name: 'A-OLD' })
+
+    const r = await mergeCompartment(receiver, bundleBytes, {
+      transferKey,
+      strategy: 'lww-by-ts',
+    })
+
+    expect(r.summary.inserted).toBe(2)   // c2, c3
+    // c1: local is newer → skipped
+    expect(r.summary.updated).toBe(0)
+    expect(r.summary.skipped).toBe(1)
+    const c1 = await receiver.collection<Client>('clients').get('c1')
+    expect(c1!.name).toBe('A-OLD')
+    expect(r.conflicts.some((c) => c.id === 'c1' && c.resolution === 'local')).toBe(true)
+  })
+})
+
+describe('mergeCompartment — manual-queue', () => {
+  it('c1 conflict queued; summary.queued===1; conflicts has c1; receiver c1 UNCHANGED', async () => {
+    const { bundleBytes, transferKey } = await buildBundle()
+    const receiver = await buildReceiver()
+
+    const r = await mergeCompartment(receiver, bundleBytes, {
+      transferKey,
+      strategy: 'manual-queue',
+    })
+
+    expect(r.summary.inserted).toBe(2)    // c2, c3
+    expect(r.summary.queued).toBe(1)      // c1
+    expect(r.summary.updated).toBe(0)
+    expect(r.summary.skipped).toBe(0)
+
+    // c1 appears in conflicts as queued
+    const conflict = r.conflicts.find((c) => c.collection === 'clients' && c.id === 'c1')
+    expect(conflict).toBeDefined()
+    expect(conflict!.resolution).toBe('queued')
+    expect(conflict!.strategy).toBe('manual-queue')
+
+    // receiver c1 is unchanged
+    const c1 = await receiver.collection<Client>('clients').get('c1')
+    expect(c1!.name).toBe('A-OLD')
+  })
+})
+
+describe('mergeCompartment — dry-run', () => {
+  it('dryRun=true: summary computed but receiver NOT modified', async () => {
+    const { bundleBytes, transferKey } = await buildBundle()
+    const receiver = await buildReceiver()
+
+    const r = await mergeCompartment(receiver, bundleBytes, {
+      transferKey,
+      strategy: 'take-incoming',
+      dryRun: true,
+    })
+
+    expect(r.dryRun).toBe(true)
+    // Summary is computed as if writes happened
+    expect(r.summary.inserted).toBe(2)
+    expect(r.summary.updated).toBe(1)
+
+    // But receiver is NOT modified: c1 still has old value
+    const c1 = await receiver.collection<Client>('clients').get('c1')
+    expect(c1!.name).toBe('A-OLD')
+
+    // c2 was NOT written
+    const c2 = await receiver.collection<Client>('clients').get('c2')
+    expect(c2).toBeNull()
+  })
+})
+
+describe('mergeCompartment — field-level', () => {
+  it('rejects with FieldLevelDeferredError', async () => {
+    const { bundleBytes, transferKey } = await buildBundle()
+    const receiver = await buildReceiver()
+
+    await expect(
+      mergeCompartment(receiver, bundleBytes, {
+        transferKey,
+        strategy: 'field-level',
+      }),
+    ).rejects.toThrow(FieldLevelDeferredError)
+  })
+})
+
+describe('mergeCompartment — per-collection strategy map', () => {
+  it('applies take-incoming for clients collection, falls back to default manual-queue for others', async () => {
+    const { bundleBytes, transferKey } = await buildBundle()
+    const receiver = await buildReceiver()
+
+    const r = await mergeCompartment(receiver, bundleBytes, {
+      transferKey,
+      strategy: { clients: 'take-incoming', default: 'manual-queue' },
+    })
+
+    // c1 conflict resolved via take-incoming
+    expect(r.summary.updated).toBe(1)
+    const c1 = await receiver.collection<Client>('clients').get('c1')
+    expect(c1!.name).toBe('A')
+  })
+
+  it('falls back to the hardcoded manual-queue when the map has no default and no match', async () => {
+    const { bundleBytes, transferKey } = await buildBundle()
+    const receiver = await buildReceiver()
+
+    // No 'clients' entry and no 'default' → strategyFor() returns 'manual-queue'
+    const r = await mergeCompartment(receiver, bundleBytes, {
+      transferKey,
+      strategy: { someOtherCollection: 'take-incoming' },
+    })
+
+    // c1 conflict is queued (manual-queue fallback), c2/c3 inserted
+    expect(r.summary.inserted).toBe(2)
+    expect(r.summary.queued).toBe(1)
+    expect(r.summary.updated).toBe(0)
+    const conflict = r.conflicts.find((c) => c.id === 'c1')
+    expect(conflict).toBeDefined()
+    expect(conflict!.resolution).toBe('queued')
+
+    // receiver c1 unchanged
+    const c1 = await receiver.collection<Client>('clients').get('c1')
+    expect(c1!.name).toBe('A-OLD')
+  })
+})

--- a/packages/lobby/src/index.ts
+++ b/packages/lobby/src/index.ts
@@ -94,3 +94,12 @@ export type {
   ExtractCrossVaultResult,
   CrossVaultPreview,
 } from './interchange/extract-cross-vault.js'
+
+// ─── FR-3: Merge-import / reconcile-into-existing vault ───────────────────────
+export { mergeCompartment, FieldLevelDeferredError } from './interchange/merge-compartment.js'
+export type {
+  MergeStrategy,
+  MergeCompartmentOptions,
+  MergeConflict,
+  MergeReport,
+} from './interchange/merge-compartment.js'

--- a/packages/lobby/src/interchange/merge-compartment.ts
+++ b/packages/lobby/src/interchange/merge-compartment.ts
@@ -1,0 +1,237 @@
+/**
+ * @klum-db/lobby interchange — reconcile an incoming extracted-partition
+ * compartment into an existing receiver vault (FR-3).
+ *
+ * `mergeCompartment(receiver, compartmentBytes, opts)` → `MergeReport`:
+ *   1. Decrypt the incoming bytes via hub's `decryptExtractedPartition`.
+ *   2. `diffVault(receiver, incoming)` classifies records as added / modified
+ *      / deleted (deleted = receiver-only slice, ignored per FR-3 semantics).
+ *   3. Resolve each `modified` entry per the per-collection strategy.
+ *   4. Apply writes via `collection.put(id, rec, { reason })` (unless dryRun).
+ *
+ * @module
+ */
+import type { Vault } from '@noy-db/hub'
+import { diffVault } from '@noy-db/hub'
+import { decryptExtractedPartition } from '@noy-db/hub/bundle'
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+/** Per-collection conflict strategy. `field-level` is deferred to FR-4. */
+export type MergeStrategy =
+  | 'take-incoming'
+  | 'keep-local'
+  | 'lww-by-ts'
+  | 'manual-queue'
+  | 'field-level'
+
+export interface MergeCompartmentOptions {
+  readonly transferKey: Uint8Array
+  /**
+   * One strategy applied to all collections, or a per-collection map with an
+   * optional `default` fallback (if a collection isn't in the map it falls back
+   * to `default`, or `'manual-queue'` if no default is set).
+   */
+  readonly strategy:
+    | MergeStrategy
+    | (Record<string, MergeStrategy> & { default?: MergeStrategy })
+  readonly dryRun?: boolean
+  /** Audit reason stamped on every write. Defaults to `'merge:compartment'`. */
+  readonly reason?: string
+}
+
+export interface MergeConflict {
+  readonly collection: string
+  readonly id: string
+  readonly strategy: MergeStrategy
+  readonly resolution: 'incoming' | 'local' | 'queued'
+}
+
+export interface MergeReport {
+  readonly vault: string
+  readonly dryRun: boolean
+  readonly summary: {
+    readonly inserted: number
+    readonly updated: number
+    readonly skipped: number
+    readonly queued: number
+    readonly total: number
+  }
+  readonly byCollection: Record<
+    string,
+    { readonly inserted: number; readonly updated: number; readonly skipped: number; readonly queued: number }
+  >
+  /**
+   * One entry per `modified` (id-collision) record, regardless of outcome —
+   * including `take-incoming` overwrites (`resolution: 'incoming'`). This is a
+   * full audit trail of every conflict the merge encountered and how it was
+   * resolved, not just the ones that were skipped or queued.
+   */
+  readonly conflicts: readonly MergeConflict[]
+}
+
+/** Mutable per-collection tally used while building a {@link MergeReport}. */
+interface CollectionTally {
+  inserted: number
+  updated: number
+  skipped: number
+  queued: number
+}
+
+// ─── Error ────────────────────────────────────────────────────────────────────
+
+/**
+ * Thrown when a collection's strategy is `field-level` — this is deferred to
+ * FR-4 (field-authority). Use `take-incoming`, `keep-local`, `lww-by-ts`, or
+ * `manual-queue` for now.
+ */
+export class FieldLevelDeferredError extends Error {
+  constructor(collection: string) {
+    super(
+      `mergeCompartment: the 'field-level' strategy for "${collection}" is not implemented yet` +
+        ` — it lands with FR-4 (field-authority).` +
+        ` Use take-incoming / keep-local / lww-by-ts / manual-queue for now.`,
+    )
+    this.name = 'FieldLevelDeferredError'
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function strategyFor(
+  opts: MergeCompartmentOptions['strategy'],
+  collection: string,
+): MergeStrategy {
+  if (typeof opts === 'string') return opts
+  return opts[collection] ?? opts.default ?? 'manual-queue'
+}
+
+// ─── Core ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Reconcile an incoming extracted-partition compartment into a receiver vault.
+ *
+ * Semantics:
+ * - **added**: in incoming, not in receiver → always insert (every strategy).
+ * - **modified**: in both, body differs → resolve per collection strategy.
+ * - **deleted**: in receiver, not in incoming → IGNORE (incoming is a slice;
+ *   never delete receiver rows).
+ * - **unchanged**: no-op.
+ *
+ * Returns a {@link MergeReport} describing what was (or would be) written.
+ * When `dryRun: true` the report is fully computed but no `put()` is called.
+ *
+ * Writes are applied sequentially and **non-transactionally**: a `put()`
+ * failure mid-loop (e.g. schema mismatch or a storage error) rejects the
+ * returned promise but leaves the receiver partially merged. Use `dryRun`
+ * first to validate the plan when partial application is unacceptable.
+ */
+export async function mergeCompartment(
+  receiver: Vault,
+  compartmentBytes: Uint8Array,
+  opts: MergeCompartmentOptions,
+): Promise<MergeReport> {
+  const reason = opts.reason ?? 'merge:compartment'
+
+  // 1. Decrypt incoming records.
+  const incoming = await decryptExtractedPartition(compartmentBytes, opts.transferKey)
+
+  // Build the candidate for diffVault: Record<collection, T[]> where each T has an `id` field.
+  // Also keep incoming _ts for lww-by-ts comparison.
+  const incomingTs = new Map<string, Map<string, string>>()
+  const candidate: Record<string, Record<string, unknown>[]> = {}
+  for (const [coll, recs] of Object.entries(incoming)) {
+    const tsMap = new Map<string, string>()
+    for (const r of recs) tsMap.set(r.id, r.ts)
+    candidate[coll] = recs.map((r) => r.record)
+    incomingTs.set(coll, tsMap)
+  }
+
+  // 2. Diff the receiver against the incoming candidate.
+  const diff = await diffVault(receiver, candidate)
+
+  // 3. Resolve conflicts.
+  const byCollection: Record<string, CollectionTally> = {}
+  const conflicts: MergeConflict[] = []
+  const writes: { collection: string; id: string; record: Record<string, unknown> }[] = []
+
+  function bump(
+    coll: string,
+    key: keyof CollectionTally,
+  ): void {
+    const e = byCollection[coll] ?? { inserted: 0, updated: 0, skipped: 0, queued: 0 }
+    e[key]++
+    byCollection[coll] = e
+  }
+
+  // 3a. added → insert (all strategies)
+  for (const a of diff.added) {
+    writes.push({ collection: a.collection, id: a.id, record: a.record })
+    bump(a.collection, 'inserted')
+  }
+
+  // 3b. modified → resolve per strategy
+  // For lww-by-ts we need the receiver envelope's _ts.
+  const { adapter, name: receiverName } = receiver._introspectState()
+
+  for (const m of diff.modified) {
+    const strat = strategyFor(opts.strategy, m.collection)
+
+    if (strat === 'field-level') {
+      throw new FieldLevelDeferredError(m.collection)
+    }
+
+    if (strat === 'take-incoming') {
+      writes.push({ collection: m.collection, id: m.id, record: m.record })
+      bump(m.collection, 'updated')
+      conflicts.push({ collection: m.collection, id: m.id, strategy: strat, resolution: 'incoming' })
+    } else if (strat === 'keep-local') {
+      bump(m.collection, 'skipped')
+      conflicts.push({ collection: m.collection, id: m.id, strategy: strat, resolution: 'local' })
+    } else if (strat === 'manual-queue') {
+      bump(m.collection, 'queued')
+      conflicts.push({ collection: m.collection, id: m.id, strategy: strat, resolution: 'queued' })
+    } else {
+      // lww-by-ts: compare ISO _ts strings lexicographically (correct for ISO-8601).
+      const incTs = incomingTs.get(m.collection)?.get(m.id) ?? ''
+      const recvEnv = await adapter.get(receiverName, m.collection, m.id)
+      const localTs = recvEnv?._ts ?? ''
+      if (incTs > localTs) {
+        writes.push({ collection: m.collection, id: m.id, record: m.record })
+        bump(m.collection, 'updated')
+        conflicts.push({ collection: m.collection, id: m.id, strategy: strat, resolution: 'incoming' })
+      } else {
+        bump(m.collection, 'skipped')
+        conflicts.push({ collection: m.collection, id: m.id, strategy: strat, resolution: 'local' })
+      }
+    }
+  }
+
+  // diff.deleted (receiver-only) is intentionally ignored — incoming is a slice,
+  // its absence of a row never means "delete that row from the receiver".
+
+  // 4. Apply writes (unless dry-run).
+  if (!opts.dryRun) {
+    for (const w of writes) {
+      await receiver.collection(w.collection).put(w.id, w.record, { reason })
+    }
+  }
+
+  // 5. Aggregate summary.
+  const summary = { inserted: 0, updated: 0, skipped: 0, queued: 0, total: 0 }
+  for (const e of Object.values(byCollection)) {
+    summary.inserted += e.inserted
+    summary.updated += e.updated
+    summary.skipped += e.skipped
+    summary.queued += e.queued
+  }
+  summary.total = summary.inserted + summary.updated + summary.skipped + summary.queued
+
+  return {
+    vault: receiverName,
+    dryRun: opts.dryRun ?? false,
+    summary,
+    byCollection,
+    conflicts,
+  }
+}


### PR DESCRIPTION
## Summary

Third capability of the pilot-1 epic (#443 / vLannaAi/klum-db#1): reconcile an incoming extracted-partition compartment into a RECEIVER's **existing** vault (already holding overlapping rows) — the read/adopt side of FR-1's multi-compartment bundles + FR-2's cross-vault extraction. Two parts:

- **hub** — `decryptExtractedPartition(bundleBytes, transferKey)` → `Record<collection, {id,record,ts,version}[]>` (`packages/hub/src/bundle/decrypt-partition.ts`): the read-side counterpart to `extractPartition` — decrypts an extracted-partition to plaintext (per-record CEK handled exactly like `reKeyClosure`; read-only, no re-encryption/writes; wrong transfer key throws). The only hub change (decryption is hub's concern; reused by FR-4). Exported from `@noy-db/hub` + `/bundle`.
- **`@klum-db/lobby`** — `mergeCompartment(receiver, compartmentBytes, { transferKey, strategy, dryRun, reason })` → `MergeReport`: decrypt incoming → `diffVault(receiver, incoming)` → `added`→insert, `modified`→**per-collection strategy**, `deleted`→**ignore** → apply via `collection.put(id, rec, {reason})`.

**Strategies** (per-collection, or a `{collection→strategy, default}` map): `take-incoming` / `keep-local` / `lww-by-ts` (compares the incoming envelope `_ts` vs the receiver's) / `manual-queue` (conflicts collected as `queued`, not written). **`field-level` throws `FieldLevelDeferredError`** — it lands with FR-4 (no general field-merge exists yet; vLannaAi/noy-db#348 is overlay-read-only), with the resolve-switch as the clean seam FR-4 plugs into.

**Two safety invariants, held by construction + test:** (1) **never deletes receiver rows** — `diff.deleted` (receiver-only) is never read, so a *slice* import can't remove data; (2) **dry-run writes nothing** — the sole `put` is gated by `!dryRun`, yet the full `MergeReport` is still computed.

`MergeReport`: `{ vault, dryRun, summary{inserted,updated,skipped,queued,total}, byCollection, conflicts[] }` (immutable; conflicts are a full audit trail). Built subagent-driven with per-task spec + code-quality reviews + a final whole-feature review.

## Test plan
- [x] hub `decrypt-partition` — 4/4, incl. a `perRecordKeys:true` CEK record round-trip + wrong-key/non-extracted throws; full hub suite **2654** green
- [x] lobby `merge-compartment` — every strategy proven against REAL post-merge receiver state (take-incoming overwrites; keep-local/manual-queue leave receiver unchanged; lww both directions; field-level throws; per-collection map + fallback; dry-run leaves receiver untouched; receiver-only row survives); lobby suite **100** green
- [x] `pnpm lint && pnpm typecheck` (full monorepo) — 127/127 + 130/130
- [x] `node scripts/validate-features.mjs` — OK (features=65); `pnpm check:architecture` — OK
- [x] `git diff main -- packages/hub` — only the read-only `decryptExtractedPartition` (4 files)

## Forward fit / follow-ups (non-blocking)
- **FR-4 (field-authority)** reuses `decryptExtractedPartition` + plugs a per-field resolver where `field-level` currently throws.
- Non-transactional partial-merge-on-failure (documented; a transactional/`applied`-field hardening is a follow-up); a merge-whole-multi-compartment-bundle wrapper; lww N+1 receiver-`_ts` reads (batch at large scale); an ACL caveat for FR-8.