### PR TITLE
FR-8: migrate-then-merge — upgrade incoming bundle before reconcile

### DIFF
--- a/docs/superpowers/plans/2026-06-17-fr8-migrate-then-merge.md
+++ b/docs/superpowers/plans/2026-06-17-fr8-migrate-then-merge.md
@@ -1,0 +1,389 @@
+# FR-8 — Migrate-then-Merge (upgrade incoming bundle before reconcile) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A first-class two-stage pipeline `migrateThenMerge(receiver, compartmentBytes, opts)` that upgrades an older-schema incoming compartment to the receiver's current schema version **in staging**, then runs the FR-3/FR-4 merge against a now schema-homogeneous pair — so the merge engine never branches on version.
+
+**Architecture:** Mostly **`@klum-db/lobby`** (the coordinator + a refactor of a shared decrypted-records merge core out of `mergeCompartment`). Two small **hub** touches: (1) `Collection.validateInput(record)` so migration can pre-validate staged records before any write (staging safety); (2) a `schemaVersion?` field on `CompartmentManifest` that FR-2's extract stamps from the source vault's fence, so the bundle self-describes its version.
+
+**Tech stack:** TypeScript, vitest, pnpm workspaces. Hub: `packages/hub`. Klum: `packages/lobby`.
+
+**Design decisions (resolved at the FR-8 design gate):**
+- **Upgrade mechanism → app-supplied transforms + additive fast-path.** The app supplies a per-collection migration chain (transforms keyed by target version); FR-8 applies `fromVersion → toVersion` in staging. The **additive fast-path** is realized via **pre-write validation**: a collection with NO supplied transform still passes when the old shape validates against the receiver schema (additive-only evolution); a non-additive drift without a transform fails *before any write* with an actionable error. (This is a deliberate refinement of the gate's "computeSchemaDelta over carried `_schemas`" wording — pre-write validation reuses the real validator and avoids fragile JSON-schema introspection of the receiver's `StandardSchemaV1`. `computeSchemaDelta` remains available for a richer proactive diagnostic as a follow-up.)
+- **Version source → stamped into the bundle.** FR-2's `extractCrossVaultPartition` reads the source vault's `schemaFenceState().currentSchemaVersion` and stamps `schemaVersion` into each `CompartmentManifest` entry. The caller reads it from the manifest (`readNoydbBundleManifest`) and passes `fromVersion`; an `assumeFromVersion` fallback covers older bundles that lack the field.
+- **API → separate `migrateThenMerge` coordinator**, built on a `mergeDecryptedRecords` core refactored out of `mergeCompartment`. Newer-than-receiver bundles are refused with an actionable `MinVersionError`.
+
+**Staging-safety guarantee:** all transforms are applied to in-memory decrypted records and **all** staged records are validated (`validateInput`) before `mergeDecryptedRecords` writes anything — a failed upgrade (throwing transform OR invalid output) never half-writes the receiver. (The merge write loop itself remains non-transactional per the existing FR-3 caveat.)
+
+---
+
+## File structure
+
+- **Modify** `packages/hub/src/collection.ts` — add public `validateInput(record)`. (Task 1)
+- **Modify** `packages/hub/src/bundle/multi-bundle.ts` — add `schemaVersion?: number` to `CompartmentManifest`. (Task 2)
+- **Modify** `packages/lobby/src/interchange/extract-cross-vault.ts` — stamp `schemaVersion` from `v.schemaFenceState()`. (Task 2)
+- **Modify** `packages/lobby/src/interchange/merge-compartment.ts` — extract a shared `mergeDecryptedRecords(receiver, decrypted, opts)` core; `mergeCompartment` delegates to it. (Task 3)
+- **Create** `packages/lobby/src/interchange/migrate-then-merge.ts` — the coordinator + `MigrationStep`/options/`MinVersionError`/`MigrationTransformRequiredError`/report types. (Task 4)
+- **Modify** `packages/lobby/src/index.ts` (barrel) — export the new public API. (Task 5)
+- **Modify** `features.yaml` — register `migrate-then-merge`. (Task 5)
+- **Tests:** `packages/hub/__tests__/` (Task 1 validateInput; Task 2 schemaVersion stamp — find the cross-vault extract test file), `packages/lobby/__tests__/migrate-then-merge.test.ts` (Task 4), and the additive fast-path / refusal cases (Task 4).
+
+---
+
+## Task 1 — hub: `Collection.validateInput(record)` (TDD)
+
+**Files:** Modify `packages/hub/src/collection.ts`; Test `packages/hub/__tests__/` (append to an existing schema/validation test, or create `validate-input.test.ts`).
+
+**Context:** `putInternal` validates via `validateSchemaInput(this.schema, record, ...)` (~line 1370). FR-8 needs to validate a record WITHOUT writing, to pre-check all staged records before the merge writes. Expose a thin public wrapper. `validateSchemaInput` is already imported in `collection.ts` (used by putInternal); confirm the import.
+
+- [ ] **Step 1: Failing test** — create `packages/hub/__tests__/validate-input.test.ts` (reuse a sibling test's vault-open + zod-schema helper; mirror how existing schema tests declare a `collection({ schema })`):
+```ts
+import { describe, it, expect } from 'vitest'
+// ... imports mirrored from an existing schema test (createNoydb, memory, zod or the repo's schema lib)
+
+describe('Collection.validateInput', () => {
+  it('returns the record when it matches the schema', async () => {
+    const c = /* open a collection with a schema requiring { id: string, n: number } */
+    await expect(c.validateInput({ id: 'a', n: 1 })).resolves.toEqual({ id: 'a', n: 1 })
+  })
+  it('throws when the record violates the schema (without writing)', async () => {
+    const c = /* same collection */
+    await expect(c.validateInput({ id: 'a', n: 'not-a-number' } as never)).rejects.toThrow()
+    // and nothing was written:
+    expect(await c.get('a')).toBeNull()
+  })
+  it('passes any record through when the collection has no schema', async () => {
+    const c = /* open a collection WITHOUT a schema */
+    await expect(c.validateInput({ anything: true } as never)).resolves.toEqual({ anything: true })
+  })
+})
+```
+
+- [ ] **Step 2: Run → fail.** `pnpm --filter @noy-db/hub test validate-input` → `validateInput is not a function`.
+
+- [ ] **Step 3: Implement.** Add a public method on `Collection` (place near `put`, after `putInternal` or beside the other public read methods). Confirm the schema field name (`this.schema`) and the `validateSchemaInput` import from `./schema.js`:
+```ts
+/**
+ * Validate a record against this collection's schema WITHOUT writing it.
+ * Returns the (possibly coerced) record on success; throws SchemaValidationError
+ * (direction: 'input') on violation. A no-op pass-through when no schema is declared.
+ * Used by FR-8 migrate-then-merge to pre-validate staged records before any write.
+ */
+async validateInput(record: T): Promise<T> {
+  if (this.schema === undefined) return record
+  return validateSchemaInput(this.schema, record, `validateInput(${this.name})`)
+}
+```
+
+- [ ] **Step 4: Run → pass.** `pnpm --filter @noy-db/hub test validate-input` green; full `pnpm --filter @noy-db/hub test` (no regression); `pnpm --filter @noy-db/hub typecheck && lint`; `pnpm check:architecture` (collection.ts is ~4810 against the 4810 ceiling after FR-4 — this adds ~10 lines; **bump the ceiling to 4830** in `scripts/check-architecture.mjs` and note it).
+
+- [ ] **Step 5: Commit** — `git commit -am "feat(hub): Collection.validateInput — validate a record without writing (FR-8 staging)"`
+
+---
+
+## Task 2 — hub + klum: stamp `schemaVersion` into the bundle manifest (TDD)
+
+**Files:** Modify `packages/hub/src/bundle/multi-bundle.ts` (add field); Modify `packages/lobby/src/interchange/extract-cross-vault.ts` (stamp it); Test the cross-vault extract test in `packages/lobby/__tests__/`.
+
+**Context:** `CompartmentManifest` has no schema-version stamp. FR-2's `extractCrossVaultPartition` (extract-cross-vault.ts:215) already loops per vault with the open `Vault v`; `v.schemaFenceState()` returns `{ currentSchemaVersion, fenceState }`. Stamp `currentSchemaVersion` into each manifest entry so the bundle self-describes its version. Additive + optional → old readers ignore it.
+
+- [ ] **Step 1: Failing test** — find the existing cross-vault extract test (grep `extractCrossVaultPartition` in `packages/lobby/__tests__/`). Append a test: build a source vault, run a schema cutover (or directly assert version 0 if no cutover helper is handy — match what the test harness supports), `extractCrossVaultPartition`, read the manifest via `readNoydbBundleManifest`, assert the compartment entry has `schemaVersion` equal to the source vault's `schemaFenceState().currentSchemaVersion`.
+```ts
+it('stamps each compartment schemaVersion from the source vault fence', async () => {
+  // ... build vaults + seed, extract
+  const { bundle } = await extractCrossVaultPartition(openVault, { seed, crossVaultRefs })
+  const manifest = readNoydbBundleManifest(bundle)
+  const expected = (await (await openVault('clients')).schemaFenceState()).currentSchemaVersion
+  const entry = manifest.compartments.find(c => /* match the clients compartment */)
+  expect(entry?.schemaVersion).toBe(expected)
+})
+```
+
+- [ ] **Step 2: Run → fail.** `schemaVersion` is undefined on the entry.
+
+- [ ] **Step 3: Implement.**
+  1. `multi-bundle.ts` `CompartmentManifest` (after `innerSha256`, ~line 49): add
+     ```ts
+     /** Source vault's schema fence version at extract time (FR-8). Opt-in; absent on older bundles. */
+     readonly schemaVersion?: number
+     ```
+  2. `extract-cross-vault.ts` in the per-vault loop (after building `entry`, before `inner.push`, ~line 245): read the fence and stamp:
+     ```ts
+     const fence = await v.schemaFenceState()
+     entry.schemaVersion = fence.currentSchemaVersion
+     ```
+     (The `entry` is already the mutable `-readonly` mapped type, so direct assignment is fine.)
+  3. Check `writeMultiVaultBundle` in `multi-bundle.ts` — if it also builds `CompartmentManifest` entries from live vaults, stamp `schemaVersion` there too (read each vault's `schemaFenceState()`); if it doesn't have the vault handy, leave the field absent (optional). Note which you did.
+
+- [ ] **Step 4: Run → pass.** `pnpm --filter @noy-db/hub build` (manifest type changed) then `pnpm --filter @klum-db/lobby test` (extract test + no regression); `pnpm --filter @noy-db/hub test` (multi-bundle codec round-trips the new field — verify the encode/decode/innerBytes cross-checks still pass); typecheck + lint both packages.
+
+- [ ] **Step 5: Commit** — `git commit -am "feat: stamp source schemaVersion into CompartmentManifest (FR-8 version source)"`
+
+---
+
+## Task 3 — klum: refactor a shared `mergeDecryptedRecords` core out of `mergeCompartment` (TDD-by-existing-tests)
+
+**Files:** Modify `packages/lobby/src/interchange/merge-compartment.ts`.
+
+**Context:** `mergeCompartment` (merge-compartment.ts:129) currently does `decrypt → build candidate/maps → diff → resolve → write`. FR-8 needs to run the SAME merge over records it has already decrypted + migrated. Extract everything after decryption into a reusable core; `mergeCompartment` becomes decrypt-then-core. **No behavior change** — the existing 110+ merge-compartment tests are the guard.
+
+- [ ] **Step 1: Establish green baseline.** `pnpm --filter @klum-db/lobby test merge-compartment` → all pass (this is the refactor's safety net; no new test first — the refactor must preserve behavior).
+
+- [ ] **Step 2: Refactor.** Introduce:
+```ts
+/**
+ * Merge an already-decrypted record set into the receiver. The shared core of
+ * mergeCompartment (decrypt → this) and migrateThenMerge (decrypt → migrate → this).
+ * `decrypted` is keyed by collection; each record carries id/record/ts/source/sourceTs.
+ */
+export async function mergeDecryptedRecords(
+  receiver: Vault,
+  decrypted: Record<string, readonly DecryptedRecord[]>,
+  opts: MergeCompartmentOptions,
+): Promise<MergeReport> {
+  const reason = opts.reason ?? 'merge:compartment'
+  // ... everything currently in mergeCompartment AFTER the decrypt call:
+  //     build incomingTs / incomingSource / incomingSourceTs / candidate,
+  //     diffVault, resolve (added/modified strategies incl. field-authority),
+  //     apply writes (gated by !dryRun), aggregate summary, return report.
+}
+```
+  Then `mergeCompartment` collapses to:
+```ts
+export async function mergeCompartment(
+  receiver: Vault,
+  compartmentBytes: Uint8Array,
+  opts: MergeCompartmentOptions,
+): Promise<MergeReport> {
+  const incoming = await decryptExtractedPartition(compartmentBytes, opts.transferKey)
+  return mergeDecryptedRecords(receiver, incoming, opts)
+}
+```
+  - Import `DecryptedRecord` type: `import { decryptExtractedPartition, type DecryptedRecord } from '@noy-db/hub/bundle'`.
+  - Keep `opts.transferKey` on `MergeCompartmentOptions` (mergeCompartment still needs it to decrypt); `mergeDecryptedRecords` ignores it (or accept a trimmed opts type — simplest is to reuse `MergeCompartmentOptions` and just not read `transferKey` in the core).
+  - Move the `incomingSourceTs`/`incomingSource`/`incomingTs` map-building and the whole resolve+write body verbatim into the core.
+
+- [ ] **Step 3: Run → still green.** `pnpm --filter @klum-db/lobby test merge-compartment` → all pass unchanged; `pnpm --filter @klum-db/lobby typecheck && lint`.
+
+- [ ] **Step 4: Commit** — `git commit -am "refactor(lobby): extract mergeDecryptedRecords core from mergeCompartment (FR-8 prep)"`
+
+---
+
+## Task 4 — klum: `migrateThenMerge` coordinator (TDD)
+
+**Files:** Create `packages/lobby/src/interchange/migrate-then-merge.ts`; Test `packages/lobby/__tests__/migrate-then-merge.test.ts`.
+
+**Context:** The coordinator: decrypt → resolve `fromVersion`/`toVersion` → refuse if newer → apply transforms in staging → pre-validate all staged records → `mergeDecryptedRecords`. `toVersion` defaults to `receiver.schemaFenceState().currentSchemaVersion`. Step 0: `pnpm --filter @noy-db/hub build` (Tasks 1+2 changed hub).
+
+- [ ] **Step 1: Failing tests** — create `migrate-then-merge.test.ts`. Reuse the merge-compartment test's extraction helpers. Build a source vault whose records are at an OLDER shape (e.g. `{ id, fullName }`) and a receiver whose schema is the NEW shape (e.g. `{ id, firstName, lastName }`); supply a migration that splits `fullName`. Cases:
+```ts
+// (a) older bundle migrates then merges, zero version-branching downstream
+it('migrates an older-schema compartment to the receiver version, then merges', async () => {
+  const report = await migrateThenMerge(receiver, compartmentBytes, {
+    transferKey,
+    fromVersion: 0,
+    toVersion: 1,
+    strategy: 'take-incoming',
+    migrations: { clients: [{ toVersion: 1, transform: (r) => {
+      const [firstName, ...rest] = String(r.fullName).split(' ')
+      return { id: r.id, firstName, lastName: rest.join(' ') }
+    } }] },
+  })
+  expect(report.summary.inserted + report.summary.updated).toBeGreaterThan(0)
+  const merged = await receiver.collection('clients').get('c1')
+  expect(merged).toMatchObject({ firstName: 'Jane', lastName: 'Doe' })
+})
+
+// (b) newer-than-receiver bundle refused with MinVersionError
+it('refuses a newer-than-receiver bundle with an actionable MinVersionError', async () => {
+  await expect(migrateThenMerge(receiver, compartmentBytes, {
+    transferKey, fromVersion: 5, toVersion: 1, strategy: 'take-incoming',
+  })).rejects.toThrow(MinVersionError)
+})
+
+// (c) additive fast-path: no transform needed when old shape still validates
+it('additive evolution merges with no transform supplied', async () => {
+  // receiver schema adds an OPTIONAL field vs the incoming shape
+  const report = await migrateThenMerge(receiver, compartmentBytes, {
+    transferKey, fromVersion: 0, toVersion: 1, strategy: 'take-incoming',
+  })
+  expect(report.summary.total).toBeGreaterThan(0)   // no MigrationTransformRequiredError
+})
+
+// (d) staging safety: a non-additive drift with NO transform throws BEFORE any write
+it('throws MigrationTransformRequiredError before writing when a transform is required', async () => {
+  await expect(migrateThenMerge(receiver, compartmentBytes, {
+    transferKey, fromVersion: 0, toVersion: 1, strategy: 'take-incoming',
+  })).rejects.toThrow(/transform required|MigrationTransformRequired/)
+  // receiver untouched:
+  expect(await receiver.collection('clients').get('c1')).toBeNull()
+})
+
+// (e) same-version bundle merges directly (no migration)
+it('merges directly when fromVersion === toVersion', async () => { /* ... */ })
+```
+
+- [ ] **Step 2: Run → fail.** Module not found.
+
+- [ ] **Step 3: Implement** — create `migrate-then-merge.ts`:
+```ts
+/**
+ * @klum-db/lobby interchange — migrate-then-merge (FR-8). Upgrade an incoming
+ * compartment to the receiver's schema version IN STAGING, then merge.
+ * @module
+ */
+import type { Vault } from '@noy-db/hub'
+import { decryptExtractedPartition, type DecryptedRecord } from '@noy-db/hub/bundle'
+import {
+  mergeDecryptedRecords,
+  type MergeCompartmentOptions,
+  type MergeReport,
+} from './merge-compartment.js'
+
+/** One upgrade step: transform a record up to `toVersion`. */
+export interface MigrationStep {
+  readonly toVersion: number
+  readonly transform: (record: Record<string, unknown>) => Record<string, unknown>
+}
+
+export interface MigrateThenMergeOptions extends MergeCompartmentOptions {
+  /** Incoming bundle's schema version. Read from CompartmentManifest.schemaVersion (FR-8). */
+  readonly fromVersion?: number
+  /** Fallback when the bundle manifest carries no schemaVersion. */
+  readonly assumeFromVersion?: number
+  /** Target version. Defaults to the receiver's fence currentSchemaVersion. */
+  readonly toVersion?: number
+  /** Per-collection ordered upgrade steps. */
+  readonly migrations?: Record<string, readonly MigrationStep[]>
+}
+
+export interface MigrateThenMergeReport extends MergeReport {
+  readonly migration: {
+    readonly fromVersion: number
+    readonly toVersion: number
+    /** Per-collection: how the records reached the target version. */
+    readonly byCollection: Record<string, 'transformed' | 'additive-no-transform' | 'same-version'>
+  }
+}
+
+/** Thrown when the incoming bundle is NEWER than the receiver — receiver must upgrade first. */
+export class MinVersionError extends Error {
+  constructor(public readonly fromVersion: number, public readonly toVersion: number) {
+    super(
+      `migrateThenMerge: incoming bundle is at schema version ${fromVersion} but the receiver ` +
+        `is at ${toVersion}. Upgrade the receiver to at least v${fromVersion} before merging ` +
+        `(a newer bundle cannot be down-migrated).`,
+    )
+    this.name = 'MinVersionError'
+  }
+}
+
+/** Thrown (BEFORE any write) when a collection needs a transform that wasn't supplied. */
+export class MigrationTransformRequiredError extends Error {
+  constructor(public readonly collection: string, public readonly cause?: unknown) {
+    super(
+      `migrateThenMerge: collection "${collection}" did not validate against the receiver schema ` +
+        `after migration and no transform was supplied to reach the target version. Provide a ` +
+        `migration step for "${collection}". Underlying: ${cause instanceof Error ? cause.message : String(cause)}`,
+    )
+    this.name = 'MigrationTransformRequiredError'
+  }
+}
+
+export async function migrateThenMerge(
+  receiver: Vault,
+  compartmentBytes: Uint8Array,
+  opts: MigrateThenMergeOptions,
+): Promise<MigrateThenMergeReport> {
+  const toVersion = opts.toVersion ?? (await receiver.schemaFenceState()).currentSchemaVersion
+  const fromVersion = opts.fromVersion ?? opts.assumeFromVersion
+  if (fromVersion === undefined) {
+    throw new Error(
+      'migrateThenMerge: cannot determine the incoming schema version. Pass fromVersion ' +
+        '(read from the bundle manifest CompartmentManifest.schemaVersion) or assumeFromVersion.',
+    )
+  }
+  if (fromVersion > toVersion) throw new MinVersionError(fromVersion, toVersion)
+
+  // 1. Decrypt (records only — _schemas is a separate bundle section, not surfaced).
+  const incoming = await decryptExtractedPartition(compartmentBytes, opts.transferKey)
+
+  // 2. STAGING: transform + pre-validate every record before any write.
+  const migrationByCollection: Record<string, 'transformed' | 'additive-no-transform' | 'same-version'> = {}
+  const staged: Record<string, DecryptedRecord[]> = {}
+
+  for (const [coll, recs] of Object.entries(incoming)) {
+    const steps = (opts.migrations?.[coll] ?? [])
+      .filter((s) => s.toVersion > fromVersion && s.toVersion <= toVersion)
+      .slice()
+      .sort((a, b) => a.toVersion - b.toVersion)
+
+    const out: DecryptedRecord[] = []
+    for (const r of recs) {
+      let body = r.record
+      for (const step of steps) body = step.transform(body)   // throwing transform → caught by caller, nothing written
+      out.push({ ...r, record: body })
+    }
+    staged[coll] = out
+
+    if (fromVersion === toVersion) migrationByCollection[coll] = 'same-version'
+    else if (steps.length > 0) migrationByCollection[coll] = 'transformed'
+    else migrationByCollection[coll] = 'additive-no-transform'
+
+    // pre-validate ALL staged records against the receiver schema (staging safety).
+    const rc = receiver.collection(coll)
+    for (const r of out) {
+      try {
+        await rc.validateInput(r.record as never)
+      } catch (cause) {
+        throw new MigrationTransformRequiredError(coll, cause)
+      }
+    }
+  }
+
+  // 3. Merge the (now homogeneous) staged records — engine never branches on version.
+  const report = await mergeDecryptedRecords(receiver, staged, opts)
+  return { ...report, migration: { fromVersion, toVersion, byCollection: migrationByCollection } }
+}
+```
+  - Confirm `receiver.schemaFenceState()` is on the public `Vault` type exported from `@noy-db/hub` (it is — vault.ts:1124). If the exported `Vault` type doesn't surface it, use `receiver._introspectState()`-style access or widen as needed; report if so.
+  - `validateInput` accepts `T`; pass `r.record as never` (the core merge already treats records as `Record<string, unknown>`).
+
+- [ ] **Step 4: Run → pass.** All five cases green; `pnpm --filter @klum-db/lobby test` (full, no regression); typecheck + lint.
+
+- [ ] **Step 5: Commit** — `git commit -am "feat(lobby): migrateThenMerge coordinator — staged upgrade then merge (FR-8)"`
+
+---
+
+## Task 5 — exports + features.yaml + full verification
+
+**Files:** Modify `packages/lobby/src/index.ts` (barrel), `features.yaml`.
+
+- [ ] **Step 1: Exports** — from the barrel that exports `mergeCompartment` (grep `mergeCompartment` in `packages/lobby/src/index.ts`), also export: `migrateThenMerge`, `mergeDecryptedRecords`, `MinVersionError`, `MigrationTransformRequiredError`, and types `MigrationStep`, `MigrateThenMergeOptions`, `MigrateThenMergeReport`. Verify `pnpm --filter @klum-db/lobby typecheck`.
+- [ ] **Step 2: features.yaml** — add a `migrate-then-merge` entry mirroring the sibling `merge-compartment` / `field-authority-merge` entries (study them for exact shape): artefact `packages/lobby/src/interchange/migrate-then-merge.ts`, spec `docs/superpowers/specs/2026-06-16-lobby-framework-design.md` (FR-8), package `@klum-db/lobby`, status `preview`, related `[merge-compartment, field-authority-merge, cross-vault-extraction]`. `node scripts/validate-features.mjs` must pass.
+- [ ] **Step 3: Full verification (lint-gap killer):**
+```bash
+pnpm --filter @noy-db/hub build && pnpm --filter @klum-db/lobby build
+pnpm --filter @noy-db/hub test && pnpm --filter @klum-db/lobby test
+pnpm lint && pnpm typecheck
+node scripts/validate-features.mjs
+pnpm check:architecture
+```
+All green.
+- [ ] **Step 4: Commit** — `git commit -am "feat: register migrate-then-merge feature + verify"`
+
+---
+
+## Self-Review
+
+**Spec coverage (issue #448):**
+- "an older-schema compartment is migrated to the receiver version, then merges with zero version-branching" → Task 4 case (a) + Task 3 (the merge core operates on homogeneous records; no version branch anywhere in `mergeDecryptedRecords`).
+- "a newer-than-receiver bundle is refused with an actionable `minVersion` message" → Task 4 `MinVersionError` + case (b).
+- "migration runs in staging — a failed upgrade never half-writes the target" → Task 4 (transforms applied in-memory + `validateInput` pre-check on ALL staged records before `mergeDecryptedRecords`) + case (d) asserts the receiver is untouched; Task 1 provides the validation primitive.
+- Builds on `carrySchemas` (#204, already default-on in FR-2 extract), the fence `currentSchemaVersion` (#271 schema lifecycle), FR-3 (the merge core), FR-4 (field-authority flows through the same core).
+
+**Placeholder scan:** every code step has concrete contents; verified refs (extract loop extract-cross-vault.ts:227-263, CompartmentManifest multi-bundle.ts:33-50, `schemaFenceState` vault.ts:1124, `validateSchemaInput` schema.ts:134, mergeCompartment 129-249). Test bodies are concrete except where they reuse the existing extraction harness (called out explicitly, not a placeholder).
+
+**Type consistency:** `MigrateThenMergeOptions extends MergeCompartmentOptions` (so `transferKey`/`strategy`/`fieldAuthority`/`dryRun`/`reason` flow through to the core). `mergeDecryptedRecords(receiver, Record<string, readonly DecryptedRecord[]>, MergeCompartmentOptions)` — Task 3 signature matches the Task 4 call. `MigrateThenMergeReport extends MergeReport` + `migration`. `MigrationStep.toVersion`/`transform` used verbatim in the apply loop.
+
+**Risk notes:** the additive fast-path is realized via pre-write validation (documented refinement of the gate's computeSchemaDelta wording — same outcome, robust). `schemaVersion` manifest field is additive/optional (old bundles → undefined → `assumeFromVersion` required). `validateInput` is a no-op when no schema is declared (so schemaless receivers accept any shape — the fast-path then always "passes", which is correct: no schema = no constraint). collection.ts ceiling raised first (4810→4830). The merge write loop stays non-transactional (pre-existing FR-3 caveat) — but the UPGRADE is fully staged, satisfying the acceptance criterion. `mergeDecryptedRecords` is exported (Task 3) so it's a tested, reusable seam for future coordinators (e.g. FR-6 graduate()).

--- a/features.yaml
+++ b/features.yaml
@@ -1115,6 +1115,28 @@ features:
       - 'record-level take strategies (take-incoming, lww-by-ts incoming-wins, added) preserve the incoming origin _sourceTs via the hub put() sourceTs override (FR-4 Q2) so source-newest stays correct across re-merges'
     related: [merge-compartment, record-provenance, cross-vault-extraction]
 
+  - id: migrate-then-merge
+    name: Migrate-then-merge — upgrade incoming compartment to receiver schema version before reconcile (FR-8)
+    cluster: snapshot-and-portability
+    spec: docs/superpowers/specs/2026-06-16-lobby-framework-design.md
+    subsystem_doc: docs/superpowers/specs/2026-06-16-lobby-framework-design.md
+    package: '@klum-db/lobby'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'migrateThenMerge(receiver, compartmentBytes, opts) is a two-stage pipeline: apply per-collection migration transforms in staging, pre-validate all staged records via validateInput, then delegate to mergeDecryptedRecords — the merge engine never branches on schema version'
+      - 'Staging-safety guarantee: all transforms and validateInput checks run in-memory before any write; a throwing transform or failing validation leaves the receiver completely untouched'
+      - 'MinVersionError is thrown (before any write) when the incoming bundle is at a schema version newer than the receiver — a newer bundle cannot be down-migrated; the receiver must upgrade first'
+      - 'Additive fast-path: collections with no supplied transform pass staging when the old shape validates against the receiver schema; schemaless receiver collections accept any shape (validateInput is a no-op)'
+      - 'MigrationTransformRequiredError is thrown (before any write) when a collection fails validation and no transform was supplied, naming the offending collection and carrying the underlying validation error'
+      - 'mergeDecryptedRecords is the shared core used by both mergeCompartment (decrypt → core) and migrateThenMerge (decrypt → migrate → core); exported for reuse by future coordinators'
+      - 'MigrateThenMergeReport extends MergeReport with a migration field carrying fromVersion, toVersion, and per-collection classification (transformed | additive-no-transform | same-version)'
+    related: [merge-compartment, field-authority-merge, cross-vault-extraction]
+
   - id: record-provenance
     name: Record provenance (_source / _sourceTs envelope fields)
     cluster: time-and-audit

--- a/packages/hub/__tests__/validate-input.test.ts
+++ b/packages/hub/__tests__/validate-input.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Collection.validateInput — validate a record against the collection schema
+ * WITHOUT writing it. Used by FR-8 migrate-then-merge to pre-validate staged
+ * records before any merge write.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { createNoydb } from '../src/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+
+// ─── Inline memory adapter (mirrored from schema.test.ts) ─────────────
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) {
+        for (const [name, coll] of existing) {
+          if (name.startsWith('_')) comp.set(name, coll)
+        }
+      }
+      store.set(c, comp)
+    },
+  }
+}
+
+// ─── Test schema ──────────────────────────────────────────────────────
+
+const ItemSchema = z.object({
+  id: z.string(),
+  n: z.number(),
+})
+
+type Item = z.infer<typeof ItemSchema>
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+describe('Collection.validateInput', () => {
+  it('returns the record when it matches the schema', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'test-passphrase-1234',
+    })
+    const vault = await db.openVault('test-co')
+    const c = vault.collection<Item>('items', { schema: ItemSchema })
+
+    await expect(c.validateInput({ id: 'a', n: 1 })).resolves.toEqual({ id: 'a', n: 1 })
+  })
+
+  it('throws when the record violates the schema (without writing)', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'test-passphrase-1234',
+    })
+    const vault = await db.openVault('test-co')
+    const c = vault.collection<Item>('items', { schema: ItemSchema })
+
+    await expect(c.validateInput({ id: 'a', n: 'not-a-number' } as never)).rejects.toThrow()
+    // nothing was written:
+    expect(await c.get('a')).toBeNull()
+  })
+
+  it('passes any record through when the collection has no schema', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'alice',
+      secret: 'test-passphrase-1234',
+    })
+    const vault = await db.openVault('test-co')
+    const c = vault.collection('items')
+
+    await expect(c.validateInput({ anything: true } as never)).resolves.toEqual({ anything: true })
+  })
+})

--- a/packages/hub/src/bundle/multi-bundle.ts
+++ b/packages/hub/src/bundle/multi-bundle.ts
@@ -47,6 +47,8 @@ export interface CompartmentManifest {
   readonly innerBytes: number
   /** SHA-256 (lowercase hex) of the inner v1 bundle bytes — pre-decrypt integrity. */
   readonly innerSha256: string
+  /** Source vault's schema fence version at extract time (FR-8). Opt-in; absent on older bundles. */
+  readonly schemaVersion?: number
 }
 
 /** The unencrypted manifest of a multi-compartment bundle. */
@@ -189,6 +191,9 @@ export async function writeMultiVaultBundle(
       const env = readNoydbBundlePublicEnvelope(innerBytes)
       if (env !== undefined) entry.publicEnvelope = env
     }
+    // FR-8: stamp schema fence version so the bundle self-describes its version.
+    const fence = await c.vault.schemaFenceState()
+    entry.schemaVersion = fence.currentSchemaVersion
     inner.push(innerBytes)
     entries.push(entry)
   }

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1280,6 +1280,21 @@ export class Collection<T> {
     }
   }
 
+  /**
+   * Validate a record against this collection's schema WITHOUT writing it.
+   * Returns the (possibly coerced) record on success; throws
+   * {@link SchemaValidationError} (direction: `'input'`) on violation.
+   * A no-op pass-through when no schema is declared.
+   *
+   * Used by FR-8 migrate-then-merge to pre-validate all staged records
+   * before `mergeDecryptedRecords` writes anything — so a failed upgrade
+   * never half-writes the receiver.
+   */
+  async validateInput(record: T): Promise<T> {
+    if (this.schema === undefined) return record
+    return validateSchemaInput(this.schema, record, `validateInput(${this.name})`)
+  }
+
   /** @internal — true when hooks should fire for this write (handlers exist, not re-entrant). */
   #hooksActive(): boolean {
     return this.writeHooks !== undefined && this.writeHooks.hasHandlers && !this.writeHooks.suppressed

--- a/packages/lobby/__tests__/extract-cross-vault.test.ts
+++ b/packages/lobby/__tests__/extract-cross-vault.test.ts
@@ -201,6 +201,33 @@ describe('extractCrossVaultPartition', () => {
   })
 })
 
+// ─── Task 2 (FR-8): schemaVersion stamping ───────────────────────────────────
+
+describe('extractCrossVaultPartition — schemaVersion stamp (FR-8)', () => {
+  it('stamps each compartment schemaVersion from the source vault fence', async () => {
+    const { openVault } = await buildFixture()
+
+    const res = await extractCrossVaultPartition(openVault, {
+      seed: { vault: 'client', seeds: { bills: () => true } },
+      crossVaultRefs: refs,
+      compartmentMeta: {
+        client: { roleTag: 'shard' },
+        directory: { roleTag: 'pool' },
+      },
+    })
+
+    const manifest = await readNoydbBundleManifest(res.bundle)
+
+    // check both compartments have schemaVersion stamped equal to the source vault fence
+    for (const entry of manifest) {
+      const vaultName = entry.roleTag === 'shard' ? 'client' : 'directory'
+      const v = await openVault(vaultName)
+      const fence = await v.schemaFenceState()
+      expect(entry.schemaVersion).toBe(fence.currentSchemaVersion)
+    }
+  })
+})
+
 // ─── Task 3: describeCrossVaultExtraction ─────────────────────────────────────
 
 describe('describeCrossVaultExtraction', () => {

--- a/packages/lobby/__tests__/migrate-then-merge.test.ts
+++ b/packages/lobby/__tests__/migrate-then-merge.test.ts
@@ -1,0 +1,235 @@
+/**
+ * migrateThenMerge — two-stage upgrade-then-merge pipeline (FR-8).
+ * Plan: docs/superpowers/plans/2026-06-17-fr8-migrate-then-merge.md §Task 4.
+ *
+ * Fixture overview
+ * ----------------
+ *   Case (a) + (d): source has OLD shape { id, fullName }; receiver schema
+ *     requires NEW shape { id, firstName, lastName }.
+ *   Case (b): same scenario but fromVersion > toVersion (newer bundle refusal).
+ *   Case (c): receiver schema adds an OPTIONAL field `{ id, name, note? }`;
+ *     incoming shape `{ id, name }` still validates → additive fast-path.
+ *   Case (e): source and receiver have the SAME shape (same-version direct merge).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { createNoydb } from '@noy-db/hub'
+import { extractPartition } from '@noy-db/hub/bundle'
+import { memory } from '@noy-db/to-memory'
+import {
+  migrateThenMerge,
+  MinVersionError,
+  MigrationTransformRequiredError,
+} from '../src/interchange/migrate-then-merge.js'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface OldClient { id: string; fullName: string }
+interface NewClient { id: string; firstName: string; lastName: string }
+interface SimpleClient { id: string; name: string }
+interface SimpleClientWithNote { id: string; name: string; note?: string }
+
+// ─── Helpers: case (a) + (b) + (d) — split-name scenario ────────────────────
+
+/** Source vault with OLD shape { id, fullName }. */
+async function buildOldBundle() {
+  const sourceDb = await createNoydb({ store: memory(), user: 'src-old', secret: 'src-old-secret-123' })
+  const source = await sourceDb.openVault('source-old')
+  const clients = source.collection<OldClient>('clients')
+  await clients.put('c1', { id: 'c1', fullName: 'Jane Doe' })
+  await clients.put('c2', { id: 'c2', fullName: 'John Smith' })
+
+  const { bundleBytes, transferKey } = await extractPartition(source, {
+    seeds: { clients: () => true },
+  })
+  return { bundleBytes, transferKey }
+}
+
+/**
+ * Receiver vault whose schema requires the NEW shape { id, firstName, lastName }.
+ * The collection is declared with a zod schema so validateInput actually enforces it.
+ */
+async function buildNewSchemaReceiver() {
+  const db = await createNoydb({ store: memory(), user: 'recv-new', secret: 'recv-new-secret-456' })
+  const vault = await db.openVault('receiver-new')
+  // Register the target schema — collection validation will enforce it
+  vault.collection<NewClient>('clients', {
+    schema: z.object({
+      id: z.string(),
+      firstName: z.string(),
+      lastName: z.string(),
+    }),
+  })
+  return vault
+}
+
+// ─── Helpers: case (c) — additive fast-path ──────────────────────────────────
+
+/** Source vault with { id, name } — the base shape. */
+async function buildSimpleBundle() {
+  const sourceDb = await createNoydb({ store: memory(), user: 'src-simple', secret: 'src-simple-secret-123' })
+  const source = await sourceDb.openVault('source-simple')
+  const clients = source.collection<SimpleClient>('clients')
+  await clients.put('c1', { id: 'c1', name: 'Alice' })
+  await clients.put('c2', { id: 'c2', name: 'Bob' })
+
+  const { bundleBytes, transferKey } = await extractPartition(source, {
+    seeds: { clients: () => true },
+  })
+  return { bundleBytes, transferKey }
+}
+
+/**
+ * Receiver whose schema adds an OPTIONAL field `note?` — additive evolution.
+ * Incoming records `{ id, name }` still pass this schema (extra optional field is fine).
+ */
+async function buildAdditiveReceiver() {
+  const db = await createNoydb({ store: memory(), user: 'recv-add', secret: 'recv-add-secret-456' })
+  const vault = await db.openVault('receiver-add')
+  vault.collection<SimpleClientWithNote>('clients', {
+    schema: z.object({
+      id: z.string(),
+      name: z.string(),
+      note: z.string().optional(),
+    }),
+  })
+  return vault
+}
+
+// ─── Helpers: case (e) — same-version direct merge ───────────────────────────
+
+async function buildSameVersionBundle() {
+  const sourceDb = await createNoydb({ store: memory(), user: 'src-sv', secret: 'src-sv-secret-123' })
+  const source = await sourceDb.openVault('source-sv')
+  const clients = source.collection<SimpleClient>('clients')
+  await clients.put('c1', { id: 'c1', name: 'Alice' })
+
+  const { bundleBytes, transferKey } = await extractPartition(source, {
+    seeds: { clients: () => true },
+  })
+  return { bundleBytes, transferKey }
+}
+
+async function buildSameVersionReceiver() {
+  const db = await createNoydb({ store: memory(), user: 'recv-sv', secret: 'recv-sv-secret-456' })
+  const vault = await db.openVault('receiver-sv')
+  return vault
+}
+
+// ─── Split-name transform ─────────────────────────────────────────────────────
+
+function splitFullName(r: Record<string, unknown>): Record<string, unknown> {
+  const [firstName, ...rest] = String(r['fullName'] ?? '').split(' ')
+  return { id: r['id'], firstName, lastName: rest.join(' ') }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('migrateThenMerge', () => {
+  // (a) Older-schema compartment migrates then merges
+  it('(a) migrates an older-schema compartment to the receiver version, then merges', async () => {
+    const { bundleBytes, transferKey } = await buildOldBundle()
+    const receiver = await buildNewSchemaReceiver()
+
+    const report = await migrateThenMerge(receiver, bundleBytes, {
+      transferKey,
+      fromVersion: 0,
+      toVersion: 1,
+      strategy: 'take-incoming',
+      migrations: {
+        clients: [{ toVersion: 1, transform: splitFullName }],
+      },
+    })
+
+    expect(report.summary.inserted + report.summary.updated).toBeGreaterThan(0)
+    const merged = await receiver.collection<NewClient>('clients').get('c1')
+    expect(merged).not.toBeNull()
+    expect(merged).toMatchObject({ firstName: 'Jane', lastName: 'Doe' })
+
+    // migration metadata
+    expect(report.migration.fromVersion).toBe(0)
+    expect(report.migration.toVersion).toBe(1)
+    expect(report.migration.byCollection['clients']).toBe('transformed')
+  })
+
+  // (b) Newer-than-receiver bundle refused with MinVersionError
+  it('(b) refuses a newer-than-receiver bundle with an actionable MinVersionError', async () => {
+    const { bundleBytes, transferKey } = await buildOldBundle()
+    const receiver = await buildNewSchemaReceiver()
+
+    await expect(
+      migrateThenMerge(receiver, bundleBytes, {
+        transferKey,
+        fromVersion: 5,
+        toVersion: 1,
+        strategy: 'take-incoming',
+      }),
+    ).rejects.toThrow(MinVersionError)
+  })
+
+  // (c) Additive fast-path: no transform needed when old shape still validates
+  it('(c) additive evolution merges with no transform supplied', async () => {
+    const { bundleBytes, transferKey } = await buildSimpleBundle()
+    const receiver = await buildAdditiveReceiver()
+
+    // No migration steps — old shape { id, name } validates against { id, name, note? }
+    const report = await migrateThenMerge(receiver, bundleBytes, {
+      transferKey,
+      fromVersion: 0,
+      toVersion: 1,
+      strategy: 'take-incoming',
+    })
+
+    // No MigrationTransformRequiredError was thrown; records merged
+    expect(report.summary.total).toBeGreaterThan(0)
+    expect(report.migration.byCollection['clients']).toBe('additive-no-transform')
+
+    const c1 = await receiver.collection<SimpleClientWithNote>('clients').get('c1')
+    expect(c1).not.toBeNull()
+    expect(c1!.name).toBe('Alice')
+  })
+
+  // (d) Staging safety: non-additive drift + no transform → throws BEFORE any write
+  it('(d) throws MigrationTransformRequiredError before writing when a transform is required', async () => {
+    const { bundleBytes, transferKey } = await buildOldBundle()
+    const receiver = await buildNewSchemaReceiver()
+
+    // No migration steps supplied — incoming { id, fullName } fails schema { id, firstName, lastName }
+    await expect(
+      migrateThenMerge(receiver, bundleBytes, {
+        transferKey,
+        fromVersion: 0,
+        toVersion: 1,
+        strategy: 'take-incoming',
+        // no migrations
+      }),
+    ).rejects.toThrow(MigrationTransformRequiredError)
+
+    // Staging safety: receiver must be untouched — c1 was never written
+    const c1 = await receiver.collection<NewClient>('clients').get('c1')
+    expect(c1).toBeNull()
+  })
+
+  // (e) Same-version bundle merges directly
+  it('(e) merges directly when fromVersion === toVersion (no migration)', async () => {
+    const { bundleBytes, transferKey } = await buildSameVersionBundle()
+    const receiver = await buildSameVersionReceiver()
+
+    const report = await migrateThenMerge(receiver, bundleBytes, {
+      transferKey,
+      fromVersion: 0,
+      toVersion: 0,
+      strategy: 'take-incoming',
+    })
+
+    expect(report.summary.inserted).toBe(1)
+    expect(report.migration.fromVersion).toBe(0)
+    expect(report.migration.toVersion).toBe(0)
+    expect(report.migration.byCollection['clients']).toBe('same-version')
+
+    const c1 = await receiver.collection<SimpleClient>('clients').get('c1')
+    expect(c1).not.toBeNull()
+    expect(c1!.name).toBe('Alice')
+  })
+})

--- a/packages/lobby/__tests__/migrate-then-merge.test.ts
+++ b/packages/lobby/__tests__/migrate-then-merge.test.ts
@@ -232,4 +232,64 @@ describe('migrateThenMerge', () => {
     expect(c1).not.toBeNull()
     expect(c1!.name).toBe('Alice')
   })
+
+  // (f) Multi-step chain applies in ascending order; out-of-window steps excluded
+  it('(f) applies a v0→v1→v2 chain in order and excludes steps above toVersion', async () => {
+    const { bundleBytes, transferKey } = await buildOldBundle()
+    const db = await createNoydb({ store: memory(), user: 'recv-chain', secret: 'recv-chain-secret-789' })
+    const receiver = await db.openVault('receiver-chain')
+    receiver.collection<{ id: string; firstName: string; lastName: string; display: string }>('clients', {
+      schema: z.object({
+        id: z.string(),
+        firstName: z.string(),
+        lastName: z.string(),
+        display: z.string(),
+      }),
+    })
+
+    const report = await migrateThenMerge(receiver, bundleBytes, {
+      transferKey,
+      fromVersion: 0,
+      toVersion: 2,
+      strategy: 'take-incoming',
+      migrations: {
+        clients: [
+          // step 2 depends on step 1's output (firstName/lastName) — proves ordering
+          { toVersion: 2, transform: (r) => ({ ...r, display: `${String(r['firstName'])} ${String(r['lastName'])}`.toUpperCase() }) },
+          { toVersion: 1, transform: splitFullName },
+          // out-of-window: toVersion 3 > target 2 → must be excluded (would overwrite display)
+          { toVersion: 3, transform: (r) => ({ ...r, display: 'SHOULD-NOT-APPLY' }) },
+        ],
+      },
+    })
+
+    expect(report.migration.byCollection['clients']).toBe('transformed')
+    const merged = await receiver.collection<{ id: string; firstName: string; lastName: string; display: string }>('clients').get('c1')
+    expect(merged).toMatchObject({ firstName: 'Jane', lastName: 'Doe', display: 'JANE DOE' })
+  })
+
+  // (g) A transform that drops `id` cannot silently detach a row (id re-injected in staging).
+  //     Uses a SCHEMALESS receiver — the exact path where validateInput would NOT catch it.
+  it('(g) re-injects canonical id when a transform drops it (schemaless receiver)', async () => {
+    const { bundleBytes, transferKey } = await buildSimpleBundle()
+    const db = await createNoydb({ store: memory(), user: 'recv-idrop', secret: 'recv-idrop-secret-789' })
+    const receiver = await db.openVault('receiver-idrop')
+
+    const report = await migrateThenMerge(receiver, bundleBytes, {
+      transferKey,
+      fromVersion: 0,
+      toVersion: 1,
+      strategy: 'take-incoming',
+      migrations: {
+        // transform DROPS id entirely — without re-injection the merge would skip the row
+        clients: [{ toVersion: 1, transform: (r) => ({ name: String(r['name']).toUpperCase() }) }],
+      },
+    })
+
+    expect(report.summary.inserted).toBe(2)   // both rows merged, none silently lost
+    const c1 = await receiver.collection<SimpleClient>('clients').get('c1')
+    expect(c1).not.toBeNull()
+    expect(c1!.name).toBe('ALICE')
+    expect(c1!.id).toBe('c1')                 // canonical id preserved
+  })
 })

--- a/packages/lobby/src/index.ts
+++ b/packages/lobby/src/index.ts
@@ -96,13 +96,25 @@ export type {
 } from './interchange/extract-cross-vault.js'
 
 // ─── FR-3: Merge-import / reconcile-into-existing vault ───────────────────────
-export { mergeCompartment, FieldLevelDeferredError } from './interchange/merge-compartment.js'
+export { mergeCompartment, mergeDecryptedRecords, FieldLevelDeferredError } from './interchange/merge-compartment.js'
 export type {
   MergeStrategy,
   MergeCompartmentOptions,
   MergeConflict,
   MergeReport,
 } from './interchange/merge-compartment.js'
+
+// ─── FR-8: Migrate-then-merge — upgrade incoming bundle before reconcile ──────
+export {
+  migrateThenMerge,
+  MinVersionError,
+  MigrationTransformRequiredError,
+} from './interchange/migrate-then-merge.js'
+export type {
+  MigrationStep,
+  MigrateThenMergeOptions,
+  MigrateThenMergeReport,
+} from './interchange/migrate-then-merge.js'
 
 // ─── FR-4: Field-authority conflict resolver ──────────────────────────────────
 export {

--- a/packages/lobby/src/interchange/extract-cross-vault.ts
+++ b/packages/lobby/src/interchange/extract-cross-vault.ts
@@ -256,6 +256,10 @@ export async function extractCrossVaultPartition(
       if (cl) entry.collections = [...cl].map(([name, ids]) => ({ name, count: ids.size }))
     }
 
+    // FR-8: stamp the source vault's schema fence version so the bundle self-describes its version.
+    const fence = await v.schemaFenceState()
+    entry.schemaVersion = fence.currentSchemaVersion
+
     inner.push(bundleBytes)
     compartments.push(entry)
     transferKeys[vaultName] = transferKey

--- a/packages/lobby/src/interchange/merge-compartment.ts
+++ b/packages/lobby/src/interchange/merge-compartment.ts
@@ -13,7 +13,7 @@
  */
 import type { Vault } from '@noy-db/hub'
 import { diffVault } from '@noy-db/hub'
-import { decryptExtractedPartition } from '@noy-db/hub/bundle'
+import { decryptExtractedPartition, type DecryptedRecord } from '@noy-db/hub/bundle'
 import {
   resolveRecordByFieldAuthority,
   FieldAuthorityPolicyMissingError,
@@ -118,7 +118,9 @@ function strategyFor(
 // ─── Core ─────────────────────────────────────────────────────────────────────
 
 /**
- * Reconcile an incoming extracted-partition compartment into a receiver vault.
+ * Merge an already-decrypted record set into the receiver. The shared core of
+ * `mergeCompartment` (decrypt → this) and `migrateThenMerge` (decrypt → migrate → this).
+ * `decrypted` is keyed by collection; each record carries id/record/ts/source/sourceTs.
  *
  * Semantics:
  * - **added**: in incoming, not in receiver → always insert (every strategy).
@@ -135,15 +137,12 @@ function strategyFor(
  * returned promise but leaves the receiver partially merged. Use `dryRun`
  * first to validate the plan when partial application is unacceptable.
  */
-export async function mergeCompartment(
+export async function mergeDecryptedRecords(
   receiver: Vault,
-  compartmentBytes: Uint8Array,
+  decrypted: Record<string, readonly DecryptedRecord[]>,
   opts: MergeCompartmentOptions,
 ): Promise<MergeReport> {
   const reason = opts.reason ?? 'merge:compartment'
-
-  // 1. Decrypt incoming records.
-  const incoming = await decryptExtractedPartition(compartmentBytes, opts.transferKey)
 
   // Build the candidate for diffVault: Record<collection, T[]> where each T has an `id` field.
   // Also keep incoming _ts for lww-by-ts comparison and _source/_sourceTs for provenance
@@ -152,7 +151,7 @@ export async function mergeCompartment(
   const incomingSource = new Map<string, Map<string, string>>()
   const incomingSourceTs = new Map<string, Map<string, string>>()
   const candidate: Record<string, Record<string, unknown>[]> = {}
-  for (const [coll, recs] of Object.entries(incoming)) {
+  for (const [coll, recs] of Object.entries(decrypted)) {
     const tsMap = new Map<string, string>()
     const srcMap = new Map<string, string>()
     const stsMap = new Map<string, string>()
@@ -301,4 +300,20 @@ export async function mergeCompartment(
     byCollection,
     conflicts,
   }
+}
+
+/**
+ * Reconcile an incoming extracted-partition compartment into a receiver vault.
+ * Decrypts the compartment bytes then delegates to {@link mergeDecryptedRecords}.
+ *
+ * See {@link mergeDecryptedRecords} for full semantics, dryRun behaviour, and
+ * the non-transactional write caveat.
+ */
+export async function mergeCompartment(
+  receiver: Vault,
+  compartmentBytes: Uint8Array,
+  opts: MergeCompartmentOptions,
+): Promise<MergeReport> {
+  const incoming = await decryptExtractedPartition(compartmentBytes, opts.transferKey)
+  return mergeDecryptedRecords(receiver, incoming, opts)
 }

--- a/packages/lobby/src/interchange/migrate-then-merge.ts
+++ b/packages/lobby/src/interchange/migrate-then-merge.ts
@@ -29,7 +29,13 @@ import {
 export interface MigrationStep {
   /** The target version this step brings records up to. */
   readonly toVersion: number
-  /** Pure transform: takes the old record body, returns the new record body. */
+  /**
+   * Pure transform: takes the old record body, returns the new record body.
+   * The transform need not preserve `id` — the canonical `id` from the decrypted
+   * record is re-injected after every step, so a transform that drops or renames
+   * `id` cannot silently detach a row from its identity (which would otherwise
+   * make the merge skip it, since the diff keys off `record.id`).
+   */
   readonly transform: (record: Record<string, unknown>) => Record<string, unknown>
 }
 
@@ -163,11 +169,14 @@ export async function migrateThenMerge(
       .sort((a, b) => a.toVersion - b.toVersion)
 
     // Apply transforms in-memory (throwing transform propagates immediately).
+    // Re-inject the canonical `id` after transforms: the diff keys candidate
+    // rows off `record.id`, so a transform that drops/renames `id` would
+    // otherwise silently detach the row (skipped, never merged).
     const out: DecryptedRecord[] = []
     for (const r of recs) {
       let body = r.record
       for (const step of steps) body = step.transform(body)
-      out.push({ ...r, record: body })
+      out.push({ ...r, record: { ...body, id: r.id } })
     }
     staged[coll] = out
 

--- a/packages/lobby/src/interchange/migrate-then-merge.ts
+++ b/packages/lobby/src/interchange/migrate-then-merge.ts
@@ -1,0 +1,207 @@
+/**
+ * @klum-db/lobby interchange — migrate-then-merge (FR-8). Upgrade an incoming
+ * compartment to the receiver's schema version IN STAGING, then merge.
+ *
+ * Pipeline:
+ *   1. Resolve fromVersion / toVersion.
+ *   2. Refuse if incoming bundle is newer than receiver (MinVersionError).
+ *   3. Decrypt the compartment bytes.
+ *   4. STAGING: apply per-collection migration transforms in-memory; then
+ *      pre-validate EVERY staged record via `receiver.collection(coll).validateInput()`
+ *      BEFORE any write. A throwing transform or validation failure leaves the
+ *      receiver completely untouched (staging-safety guarantee).
+ *   5. Delegate to `mergeDecryptedRecords` with the now schema-homogeneous
+ *      staged records — the merge engine never branches on schema version.
+ *
+ * @module
+ */
+import type { Vault } from '@noy-db/hub'
+import { decryptExtractedPartition, type DecryptedRecord } from '@noy-db/hub/bundle'
+import {
+  mergeDecryptedRecords,
+  type MergeCompartmentOptions,
+  type MergeReport,
+} from './merge-compartment.js'
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+/** One upgrade step: transform a record body up to `toVersion`. */
+export interface MigrationStep {
+  /** The target version this step brings records up to. */
+  readonly toVersion: number
+  /** Pure transform: takes the old record body, returns the new record body. */
+  readonly transform: (record: Record<string, unknown>) => Record<string, unknown>
+}
+
+export interface MigrateThenMergeOptions extends MergeCompartmentOptions {
+  /**
+   * Incoming bundle's schema version.
+   * Read from `CompartmentManifest.schemaVersion` (stamped by FR-2 extract, Task 2).
+   * When omitted, `assumeFromVersion` is used as a fallback.
+   */
+  readonly fromVersion?: number
+  /**
+   * Fallback version for bundles whose manifest carries no `schemaVersion` (older bundles).
+   * Ignored when `fromVersion` is present.
+   */
+  readonly assumeFromVersion?: number
+  /**
+   * Target schema version to migrate to.
+   * Defaults to `receiver.schemaFenceState().currentSchemaVersion`.
+   */
+  readonly toVersion?: number
+  /**
+   * Per-collection ordered upgrade steps, keyed by collection name.
+   * Steps are applied in ascending `toVersion` order, filtered to the
+   * `(fromVersion, toVersion]` window.
+   */
+  readonly migrations?: Record<string, readonly MigrationStep[]>
+}
+
+export interface MigrateThenMergeReport extends MergeReport {
+  readonly migration: {
+    readonly fromVersion: number
+    readonly toVersion: number
+    /** Per-collection account of how records reached the target version. */
+    readonly byCollection: Record<string, 'transformed' | 'additive-no-transform' | 'same-version'>
+  }
+}
+
+// ─── Errors ───────────────────────────────────────────────────────────────────
+
+/**
+ * Thrown when the incoming bundle's schema version is greater than the
+ * receiver's `currentSchemaVersion`. The receiver must be upgraded first —
+ * a newer bundle cannot be down-migrated.
+ */
+export class MinVersionError extends Error {
+  constructor(
+    public readonly fromVersion: number,
+    public readonly toVersion: number,
+  ) {
+    super(
+      `migrateThenMerge: incoming bundle is at schema version ${fromVersion} but the receiver ` +
+        `is at ${toVersion}. Upgrade the receiver to at least v${fromVersion} before merging ` +
+        `(a newer bundle cannot be down-migrated).`,
+    )
+    this.name = 'MinVersionError'
+  }
+}
+
+/**
+ * Thrown BEFORE any write when a collection's incoming records do not validate
+ * against the receiver schema and no migration transform was supplied to fix
+ * the shape. Provides an actionable error message identifying the collection.
+ */
+export class MigrationTransformRequiredError extends Error {
+  constructor(
+    public readonly collection: string,
+    public readonly cause?: unknown,
+  ) {
+    super(
+      `migrateThenMerge: collection "${collection}" did not validate against the receiver schema ` +
+        `after migration and no transform was supplied to reach the target version. Provide a ` +
+        `migration step for "${collection}". Underlying: ${cause instanceof Error ? cause.message : String(cause)}`,
+    )
+    this.name = 'MigrationTransformRequiredError'
+  }
+}
+
+// ─── Coordinator ─────────────────────────────────────────────────────────────
+
+/**
+ * Two-stage upgrade-then-merge pipeline (FR-8).
+ *
+ * Migrates an incoming compartment from `fromVersion` to `toVersion` in
+ * staging, validates every staged record against the receiver schema (using
+ * `Collection.validateInput`), then delegates to `mergeDecryptedRecords`.
+ *
+ * **Staging-safety guarantee:** all transforms and validations run in-memory
+ * before `mergeDecryptedRecords` writes anything. A throwing transform OR a
+ * failing validation leaves the receiver completely untouched.
+ *
+ * **Additive fast-path:** collections with no supplied transform still pass
+ * when the old shape validates against the receiver schema (additive-only
+ * evolution). When no schema is declared on the receiver collection,
+ * `validateInput` is a no-op — any shape passes.
+ */
+export async function migrateThenMerge(
+  receiver: Vault,
+  compartmentBytes: Uint8Array,
+  opts: MigrateThenMergeOptions,
+): Promise<MigrateThenMergeReport> {
+  // 1. Resolve target version.
+  const toVersion = opts.toVersion ?? (await receiver.schemaFenceState()).currentSchemaVersion
+
+  // 2. Resolve source version.
+  const fromVersion = opts.fromVersion ?? opts.assumeFromVersion
+  if (fromVersion === undefined) {
+    throw new Error(
+      'migrateThenMerge: cannot determine the incoming schema version. ' +
+        'Pass `fromVersion` (read from the bundle manifest CompartmentManifest.schemaVersion) ' +
+        'or `assumeFromVersion` as a fallback for older bundles.',
+    )
+  }
+
+  // 3. Refuse bundles that are NEWER than the receiver.
+  if (fromVersion > toVersion) throw new MinVersionError(fromVersion, toVersion)
+
+  // 4. Decrypt the compartment (records only).
+  const incoming = await decryptExtractedPartition(compartmentBytes, opts.transferKey)
+
+  // 5. STAGING: transform + pre-validate every record before any write.
+  //    A throwing transform or a validation failure bubbles out here —
+  //    `mergeDecryptedRecords` is never reached → receiver is untouched.
+  const migrationByCollection: Record<string, 'transformed' | 'additive-no-transform' | 'same-version'> = {}
+  const staged: Record<string, DecryptedRecord[]> = {}
+
+  for (const [coll, recs] of Object.entries(incoming)) {
+    // Select and order the applicable migration steps: (fromVersion, toVersion].
+    const steps = (opts.migrations?.[coll] ?? [])
+      .filter((s) => s.toVersion > fromVersion && s.toVersion <= toVersion)
+      .slice()
+      .sort((a, b) => a.toVersion - b.toVersion)
+
+    // Apply transforms in-memory (throwing transform propagates immediately).
+    const out: DecryptedRecord[] = []
+    for (const r of recs) {
+      let body = r.record
+      for (const step of steps) body = step.transform(body)
+      out.push({ ...r, record: body })
+    }
+    staged[coll] = out
+
+    // Classify this collection's migration path.
+    if (fromVersion === toVersion) {
+      migrationByCollection[coll] = 'same-version'
+    } else if (steps.length > 0) {
+      migrationByCollection[coll] = 'transformed'
+    } else {
+      migrationByCollection[coll] = 'additive-no-transform'
+    }
+
+    // Pre-validate ALL staged records against the receiver schema.
+    // `validateInput` is a no-op when the collection has no schema.
+    // A failing record throws MigrationTransformRequiredError — no writes happen.
+    const rc = receiver.collection(coll)
+    for (const r of out) {
+      try {
+        await rc.validateInput(r.record as never)
+      } catch (cause) {
+        throw new MigrationTransformRequiredError(coll, cause)
+      }
+    }
+  }
+
+  // 6. Merge the now schema-homogeneous staged records — no version branching here.
+  const report = await mergeDecryptedRecords(receiver, staged, opts)
+
+  return {
+    ...report,
+    migration: {
+      fromVersion,
+      toVersion,
+      byCollection: migrationByCollection,
+    },
+  }
+}

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -481,7 +481,10 @@ const KERNEL_SURFACE_BUDGET = {
   // through put / putInternal / encryptRecord / encryptJsonString / buildDebugEnvelope /
   // putAtTier — additive, guarded (provenance&&source!==undefined), zero cost off.
   // The 4 extra lines are param additions + one JSDoc sentence (no logic growth).
-  'packages/hub/src/collection.ts': 4810,
+  // Bumped 4810→4830 (2026-06-17, FR-8 Task 1): public validateInput() wrapper —
+  // thin 14-line method + JSDoc delegating to validateSchemaInput without writing;
+  // used by migrateThenMerge staging safety pre-check.
+  'packages/hub/src/collection.ts': 4830,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.


### PR DESCRIPTION
## FR-8 — Migrate-then-Merge (pilot-1 epic vLannaAi/klum-db#1, issue vLannaAi/klum-db#9)

A first-class **two-stage pipeline** for onboarding an incoming client bundle that's at an *older schema*: **upgrade** the compartment to the receiver's current schema version **in staging**, then **merge** (FR-3/FR-4) against a now schema-homogeneous pair — so the merge engine never branches on version. Completes the spec's onboarding sentence: *Relocate → **Migrate** → Merge by Authority using Provenance.*

### What's in it
- **klum — `migrateThenMerge(receiver, compartmentBytes, opts)`** (`interchange/migrate-then-merge.ts`): decrypt → resolve `fromVersion`/`toVersion` → refuse-if-newer → apply per-collection transform chain in staging → **pre-validate every staged record** → `mergeDecryptedRecords`. Returns `MergeReport` + `migration{fromVersion, toVersion, byCollection}`.
- **klum — `mergeDecryptedRecords` core** refactored out of `mergeCompartment` (the shared merge over already-decrypted records; `mergeCompartment` = decrypt → core). Behavior-preserving — the existing merge tests are the guard.
- **hub — `Collection.validateInput(record)`**: validate against the schema *without writing* (no-op when schemaless). The staging pre-validation primitive.
- **hub — `CompartmentManifest.schemaVersion`**: FR-2's cross-vault extract stamps the source vault's fence `currentSchemaVersion`, so the bundle self-describes its version. Additive/optional.
- **features.yaml:** `migrate-then-merge` registered (preview).

### Design decisions (FR-8 design gate)
- **Upgrade → app transforms + additive fast-path.** App supplies `migrations: {[collection]: [{toVersion, transform}]}`, applied `fromV→toV` in staging. The **additive fast-path** is realized via **pre-write validation** — a collection with no transform passes when the old shape still validates against the receiver schema; a non-additive drift without a transform throws `MigrationTransformRequiredError` *before any write*. *(Deliberate refinement of the gate's "computeSchemaDelta over carried `_schemas`" wording: pre-write validation reuses the real validator and avoids fragile JSON-schema introspection of the receiver's `StandardSchemaV1` — same outcome, robust. `computeSchemaDelta` remains available for a richer proactive diagnostic as a follow-up.)*
- **Version source → stamped into the bundle** (manifest `schemaVersion`; `assumeFromVersion` fallback for older bundles).
- **API → separate `migrateThenMerge` coordinator** over the `mergeDecryptedRecords` core. Newer-than-receiver bundles refused with an actionable `MinVersionError`.

### Staging-safety guarantee
All transforms are applied to in-memory records **and** all staged records are validated **before** `mergeDecryptedRecords` writes anything — a failed upgrade (throwing transform or invalid output) never half-writes the receiver. (The merge write loop itself stays non-transactional per the existing FR-3 caveat.)

### Verification
- hub: 2675 tests · lobby: 117 tests — all green
- `pnpm lint` (127) + `pnpm typecheck` (130) clean
- `validate-features.mjs` + `check:architecture` pass (collection.ts ~4816 under the 4830 kernel ceiling)

### Reuses / builds on
`carrySchemas` (#204, default-on in FR-2 extract), fence `currentSchemaVersion` (#271 schema lifecycle), FR-3 (#456, the merge core), FR-4 (#457/#458, field-authority flows through the same core). `mergeDecryptedRecords` is exported as a reusable seam for future coordinators (e.g. FR-6 `graduate()`).

### Follow-ups (non-blocking)
- `computeSchemaDelta`-over-carried-`_schemas` for a proactive "which fields need a transform" diagnostic (the current path validates reactively).
- Multi-compartment convenience wrapper (read the NDBM manifest → `migrateThenMerge` per compartment).
