### PR TITLE
FR-6: Deed / Custodian / Liberate — sovereignty-preserving custody

### DIFF
--- a/docs/superpowers/plans/2026-06-17-fr6-deed-custodian-liberate.md
+++ b/docs/superpowers/plans/2026-06-17-fr6-deed-custodian-liberate.md
@@ -1,0 +1,237 @@
+# FR-6 — Deed / Custodian / Liberate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **This touches the security-critical keyring core — every Role comparison site must be audited (a missed branch is a privilege-escalation bug).**
+
+**Goal:** Sovereignty-preserving custody: a sealed/hidden owner (**Deed**), a 100%-operational-but-non-owning **Custodian** role, and an audited **Liberate** ceremony — per the design spec `docs/superpowers/specs/2026-06-17-fr6-deed-custodian-liberate-design.md`.
+
+**Architecture:** Pure `@noy-db/hub` (custody is a vault-level concern; the keyring/sealing/ledger primitives all live in hub). The `custodian` role is added to the `Role` union; Deed provisioning reuses managed-mode sealing; Liberate reuses `freezeAndDeleteClosure` + owner-keyring minting. Surface on a new `vault.custody.*` namespace mirroring `vault.user.*`. `@klum-db/lobby` re-exports the custody types (no lobby logic in slice 1).
+
+**Tech stack:** TypeScript, vitest, pnpm. Scope = pragmatic first cut (see spec §7): defer rotation-escrow, auto-abandonment, raw-store-bypass hardening of operational ops.
+
+**Security invariants (the acceptance):**
+1. Custodian operates fully (rw all collections) but is **provably unable** to grant / revoke / rotate / extract-and-sever.
+2. The owner (sealed credential) can revoke the custodian + `extractPartition` **without the custodian's cooperation**.
+3. Liberate claims ownership of a sealed-owner vault under an audited event; withdrawal **and** liberation both appear in the lifecycle ledger.
+4. Inalienability is **cryptographic**: the custodian can never reach `KEK_owner` (sealed under a non-firm `SealingKeyProvider`).
+
+---
+
+## File structure
+
+- **Modify** `packages/hub/src/types.ts` — widen `Role`; (gates live in policy/types).
+- **Modify** `packages/hub/src/team/keyring.ts` — permission funcs handle `custodian`; block rotate.
+- **Modify** `packages/hub/src/noydb.ts` — `ROLE_RANK`; `grantCustodian`/`revokeCustodian`.
+- **Modify** `packages/hub/src/policy/types.ts` — add gate names.
+- **Modify** `packages/hub/src/bundle/withdraw-accessible.ts`, `bundle/extract-partition.ts` — block custodian.
+- **Create** `packages/hub/src/team/deed.ts` — Deed marker + provisioning.
+- **Create** `packages/hub/src/custody/liberate.ts` + `packages/hub/src/custody/index.ts` (CustodyApi).
+- **Modify** `packages/hub/src/vault.ts` — `vault.custody` wiring.
+- **Modify** `packages/hub/src/index.ts`, `packages/lobby/src/index.ts` — exports.
+- **Modify** `features.yaml`, `scripts/check-architecture.mjs` (ceiling bumps).
+
+---
+
+## Task 1 — `custodian` role: union + capabilities + gate names (hub kernel — RISKIEST) (TDD)
+
+**Files:** `packages/hub/src/types.ts` (Role ~84), `packages/hub/src/team/keyring.ts` (50-81, 443, 558, 1244-1254), `packages/hub/src/noydb.ts` (ROLE_RANK ~141), `packages/hub/src/policy/types.ts` (BuiltInGateName ~93). Test `packages/hub/__tests__/custodian-role.test.ts`.
+
+**Capabilities:** custodian = `admin`-level **rw + access on all collections**, but **`canGrant(custodian,*) = false`** and **`canRevoke(custodian,*) = false`**, and **NOT grantable by admin** (only owner can grant a custodian).
+
+- [ ] **Step 1: Failing test** — create `custodian-role.test.ts` mirroring `access-control.test.ts` (inline-memory adapter, `createNoydb`, `grant`). Assert: (a) an owner can `grant({role:'custodian', permissions?})` and the custodian can read+write ALL collections; (b) the custodian **cannot** `grant(...)` (→ PermissionDeniedError); (c) the custodian **cannot** `revoke(...)`; (d) an **admin cannot** grant a custodian (only owner can). (Gate-name + provisioning tests come in later tasks.)
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement.**
+  1. `types.ts:84`: `export type Role = 'owner' | 'admin' | 'custodian' | 'operator' | 'viewer' | 'client'`. Update the doc-comment role matrix above it to describe custodian (rw-all, no grant/revoke/rotate/sever).
+  2. `noydb.ts:141` `ROLE_RANK`: add `custodian: 4` (operationally admin-rank; owner stays 5). This is the exhaustive `Record<Role,number>` TS will flag — must update.
+  3. `keyring.ts` `hasWritePermission` (1244): add `|| keyring.role === 'custodian'` to the all-true branch (custodian writes all).
+  4. `keyring.ts` `hasAccess` (1251): add `|| keyring.role === 'custodian'` to the all-true branch.
+  5. `keyring.ts` `canGrant` (52): custodian falls through to `return false` (already does — owner/admin are the only true branches; custodian returns false). **Verify** no change needed, but add an explicit early `if (callerRole === 'custodian') return false` for clarity + a comment.
+  6. `keyring.ts` `canRevoke` (58): same — explicit `if (callerRole === 'custodian') return false`.
+  7. `keyring.ts` `ADMIN_GRANTABLE_TARGETS` (50): do NOT add `'custodian'` (admin cannot grant custodian — only owner). Add a comment. Since `canGrant(admin, 'custodian')` → `ADMIN_GRANTABLE_TARGETS.includes('custodian')` → false. Good — verify.
+  8. `keyring.ts:443` (grant DEK propagation — the branch where `owner|admin|viewer` get ALL DEKs): add `'custodian'` so a granted custodian receives all collection DEKs (operational). **Critical** — without this the custodian can't operate.
+  9. `keyring.ts:558` (`findAdminDescendants` skip `kf.role !== 'admin'`): leave as-is (custodian is not an admin-descendant cascade root) — but add a comment confirming custodian is intentionally excluded from admin cascade.
+
+- [ ] **Step 4: Run → pass.** Then **audit every other Role comparison site** the recon flagged (`team/tiers.ts:63` assertTierAccess — custodian should pass tiers like admin; `collection.ts:4640` canAmend — custodian = admin; `team/sync-credentials.ts:79` — custodian must NOT issue sync creds: block it). For each: decide custodian's behavior, implement, and add a one-line test or assertion. Full `pnpm --filter @noy-db/hub test` (no regression), typecheck (catches ROLE_RANK), lint, `pnpm check:architecture`.
+
+- [ ] **Step 5: Commit** — `git commit -am "feat(hub): custodian role — rw-all operations, no grant/revoke (FR-6 Task 1)"`
+
+**Also in this task (gate names, self-contained):** add `'grant-custodian'` and `'liberate-vault'` to `BuiltInGateName` (`policy/types.ts:93`). Add a quick test asserting both fail-closed by default (no policy → `checkGate` throws `disabled`) and pass when `{enabled:true,minTier:1}`. (Mirror a `client-unilateral-withdraw` gate test.)
+
+---
+
+## Task 2 — Block custodian from rotate / sever / extract (hub security boundary) (TDD)
+
+**Files:** `packages/hub/src/team/keyring.ts` (top of `rotateKeys` ~756), `packages/hub/src/bundle/withdraw-accessible.ts` (role guard ~126), `packages/hub/src/bundle/extract-partition.ts` (owner check ~255). Test: extend `custodian-role.test.ts`.
+
+- [ ] **Step 1: Failing tests** — append: a custodian (a) cannot `db.rotate(...)` (→ PermissionDeniedError); (b) cannot `vault.user.unilateralWithdrawal(...)` destructive sever (→ ReadOnlyError/PermissionDeniedError, redirected to liberate); (c) cannot `extractPartition(vault, ...)` (→ PermissionDeniedError). These prove invariant #1's "re-key / extract / sever" half.
+
+- [ ] **Step 2: Run → fail** (custodian currently treated as admin in some paths).
+
+- [ ] **Step 3: Implement.**
+  - `keyring.ts` `rotateKeys` (~756, top): `if (callerKeyring.role === 'custodian') throw new PermissionDeniedError('custodian cannot rotate keys (FR-6: re-key is an owner meta-capability)')`. (Confirm the param name holding the caller keyring + the PermissionDeniedError import.)
+  - `withdraw-accessible.ts` (~126): extend the `owner|admin` rejection (or add a dedicated branch) so `role === 'custodian'` throws with a message pointing to `liberateVault` — the custodian must not destructively sever; it liberates via the audited ceremony.
+  - `extract-partition.ts` (~255): the owner-only guard — confirm custodian is rejected (it's not owner, so likely already throws; make the message explicit and add the assertion).
+
+- [ ] **Step 4: Run → pass.** Full hub test (no regression — ensure existing owner/admin/operator paths unchanged), typecheck, lint, architecture.
+
+- [ ] **Step 5: Commit** — `git commit -am "feat(hub): block custodian from rotate/sever/extract (FR-6 Task 2)"`
+
+---
+
+## Task 3 — Deed marker + provisioning (hub, managed-mode seam) (TDD)
+
+**Files:** Create `packages/hub/src/team/deed.ts`. Test `packages/hub/__tests__/deed.test.ts`.
+
+**Context:** Deed = a sealed owner under a **non-firm** `SealingKeyProvider` + a `_meta/deed` marker. Reuses `resolveManagedSecret` (managed-passphrase.ts:523) + `createOwnerKeyring`. `SealingKeyProvider` = `{ id, seal(Uint8Array)→Uint8Array, unseal(Uint8Array)→Uint8Array }` (managed-passphrase.ts:72). `MemorySealingKeyProvider` exists for tests.
+
+- [ ] **Step 1: Failing test** — `deed.test.ts`: with a `MemorySealingKeyProvider` ('client-kms'), `createDeedOwner(store, vault, 'client-01', provider)` → the vault has a latent owner sealed under that provider; `loadDeedMarker(store, vault)` returns `{ ownerUserId:'client-01', sealedUnder:'client-kms', latent:true, issuedAt }`; `isDeedVault(store, vault)` → true; a fresh vault → false. Then assert the owner can be re-opened via the SAME provider (managed unseal) — proving the latent owner needs no interactive passphrase.
+
+- [ ] **Step 2: Run → fail** (module missing).
+
+- [ ] **Step 3: Implement** `deed.ts`:
+  - `DEED_RECORD_ID = 'deed'`; `DeedMarker` interface `{ ownerUserId; sealedUnder: string; latent: true; issuedAt: string; liberatedAt?: string }`.
+  - `async createDeedOwner(store, vault, ownerUserId, sealing: SealingKeyProvider): Promise<UnlockedKeyring>` — call `resolveManagedSecret(store, vault, sealing)` to mint+seal the passphrase (writes `_meta/sealed-passphrase`), then `createOwnerKeyring(store, vault, ownerUserId, <resolved passphrase>)`, then write the `_meta/deed` marker (`store.put(vault, '_meta', DEED_RECORD_ID, env)` — mirror `saveSealedPassphrase`'s envelope shape; the marker is plaintext metadata). Return the unlocked owner keyring.
+  - `async loadDeedMarker(store, vault): Promise<DeedMarker | null>`; `async isDeedVault(store, vault): Promise<boolean>`.
+  - Read `managed-passphrase.ts` to use `resolveManagedSecret`'s real signature; if it's not exported, export it or use the public managed-mode entry the test harness uses.
+
+- [ ] **Step 4: Run → pass.** typecheck + lint + full hub test. (New file — exempt from kernel ceilings.)
+
+- [ ] **Step 5: Commit** — `git commit -am "feat(hub): Deed marker + sealed-owner provisioning (FR-6 Task 3)"`
+
+---
+
+## Task 4 — `grantCustodian` / `revokeCustodian` on Noydb (TDD)
+
+**Files:** `packages/hub/src/noydb.ts` (near `grant`/`revoke` ~714/734). Test: extend `custodian-role.test.ts` or a new `custodian-grant.test.ts`.
+
+- [ ] **Step 1: Failing test** — owner provisions a Deed vault (Task 3), then `db.grantCustodian(vault, { userId:'firm-01', displayName, passphrase })` (gate `'grant-custodian'` enabled in policy); the firm opens + operates fully; `db.revokeCustodian(vault, { userId:'firm-01' })` (as owner) removes it. Assert grantCustodian throws when the `'grant-custodian'` gate is disabled (fail-closed) and when the caller is not owner.
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement** two methods (mirror `grant`/`revoke` at 714/734):
+```ts
+async grantCustodian(vault: string, options: Omit<GrantOptions,'role'>, factors?: FactorProofBundle): Promise<void> {
+  this.checkPolicyOperation(vault, 'grant')
+  await this.checkGate(vault, 'grant-custodian', factors)
+  const keyring = await this.getKeyringInternal(vault)
+  if (keyring.role !== 'owner') throw new PermissionDeniedError('only the Deed owner can grant a custodian')
+  await keyringGrant(this.options.store, vault, keyring, { ...options, role: 'custodian' })
+}
+async revokeCustodian(vault: string, options: RevokeOptions, factors?: FactorProofBundle): Promise<void> {
+  this.checkPolicyOperation(vault, 'revoke')
+  await this.checkGate(vault, 'revoke-user', factors)
+  const keyring = await this.getKeyringInternal(vault)
+  if (keyring.role !== 'owner') throw new PermissionDeniedError('only the Deed owner can revoke a custodian')
+  await keyringRevoke(this.options.store, vault, keyring, options)
+}
+```
+  - **Ceiling:** `noydb.ts` ceiling is 3095 — bump to 3140 in `scripts/check-architecture.mjs` with justification ("FR-6 custody API: genuinely-core grant/revoke surface").
+
+- [ ] **Step 4: Run → pass.** Full hub test, typecheck, lint, architecture.
+
+- [ ] **Step 5: Commit** — `git commit -am "feat(hub): grantCustodian/revokeCustodian (FR-6 Task 4)"`
+
+---
+
+## Task 5 — `liberateVault` ceremony (TDD)
+
+**Files:** Create `packages/hub/src/custody/liberate.ts`. Test `packages/hub/__tests__/liberate.test.ts`.
+
+**Context:** Manual audited claim. The custodian (holds the DEKs) claims ownership: freeze a pre-liberation snapshot, mint a NEW owner keyring re-wrapping the incumbent DEKs under a new KEK (NOT unsealing the old owner — preserves the inalienability floor), ledger-audit. Reuses `freezeAndDeleteClosure` (withdraw-accessible.ts:68, disposition `'freeze'`) + `createOwnerKeyring` + the DEK re-wrap from `adopt-partition.ts:297-302` + `vault._getLedgerOrNull()?.append`.
+
+- [ ] **Step 1: Failing test** — `liberate.test.ts`: a Deed vault with a granted custodian; the custodian calls `liberateVault(vault, { newOwnerId:'firm-01', newOwnerPassphrase, legalBasis:'contractual-handover' })` (gate `'liberate-vault'` enabled). Assert: returns `{ snapshot: FrozenSnapshotRef }` with a 64-hex sha256; a `liberation-claimed:firm-01:contractual-handover` lifecycle ledger entry exists; the new owner can operate; the OLD sealed-owner credential is orphaned (not impersonated). Also: gate disabled → throws; caller not custodian → throws.
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement** `liberate.ts`:
+```ts
+export interface LiberateOptions {
+  readonly newOwnerId: string
+  readonly newOwnerPassphrase: string
+  readonly legalBasis: string
+  readonly factors?: FactorProofBundle
+}
+export interface LiberateResult { readonly snapshot: FrozenSnapshotRef }
+
+export async function liberateVault(vault: Vault, opts: LiberateOptions): Promise<LiberateResult> {
+  // 1. gate
+  await vault.noydb.checkGate(vault.name, 'liberate-vault', opts.factors)
+  // 2. caller must be the custodian (de-facto authority holding the DEKs)
+  const keyring = vault.keyring // confirm accessor; else vault._introspectState()
+  if (keyring.role !== 'custodian') throw new PermissionDeniedError('liberation is claimed by the custodian')
+  // 3. freeze a pre-liberation evidence snapshot of all collections
+  const collections = /* all collection names — reuse the helper withdraw uses (resolveAccessibleCollections / vault collection list) */
+  const snapshot = await freezeAndDeleteClosure(vault, collections, { disposition: 'freeze', actorUserId: keyring.userId })
+  // 4. mint a NEW owner keyring, re-wrapping the incumbent DEKs under the new owner KEK
+  //    (mirror adopt-partition.ts:297-302; source DEKs = keyring.deks)
+  const newOwner = await createOwnerKeyring(adapter, vault.name, opts.newOwnerId, opts.newOwnerPassphrase)
+  // re-wrap each DEK from keyring.deks under newOwner.kek, write _keyring/<newOwnerId>
+  // 5. ledger audit
+  await vault._getLedgerOrNull()?.append({ op:'lifecycle', collection:'', id:'', version:0,
+    actor: opts.newOwnerId, payloadHash:'', reason:`liberation-claimed:${opts.newOwnerId}:${opts.legalBasis}` })
+  // 6. update _meta/deed marker → liberatedAt
+  return { snapshot: snapshot! }
+}
+```
+  - Read `withdraw-accessible.ts` for `freezeAndDeleteClosure`'s exact signature + how it lists collections; read `adopt-partition.ts:270-302` for the precise re-wrap (`wrapKey(dek, kek)` + KeyringFile write). Confirm `vault.keyring`/`vault.adapter`/`vault.noydb.checkGate`/`vault._getLedgerOrNull` accessors (use `_introspectState()` if `keyring`/`adapter` aren't public).
+  - **Note on freeze semantics:** `freezeAndDeleteClosure` with `disposition:'freeze'` writes a hash-pinned snapshot then DELETES live records. For liberation we want the data PRESERVED for the new owner, not deleted. **Decide:** either (a) use `disposition:'freeze'` for the evidence snapshot but the new owner re-adopts from it, or (b) snapshot WITHOUT delete (a read-only hash-pin) so the live data stays for the new owner. **Prefer (b)** — liberation transfers operation continuity; add a snapshot-only helper or pass a flag. Confirm against the freeze code and pick the path that leaves live data intact for the new owner. Document the choice in the test.
+
+- [ ] **Step 4: Run → pass.** Full hub test, typecheck, lint, architecture. (New file — ceiling-exempt.)
+
+- [ ] **Step 5: Commit** — `git commit -am "feat(hub): liberateVault audited ceremony (FR-6 Task 5)"`
+
+---
+
+## Task 6 — `vault.custody.*` surface + exports (TDD)
+
+**Files:** Create `packages/hub/src/custody/index.ts` (CustodyApi); `packages/hub/src/vault.ts` (`public readonly custody` + wiring ~583); `packages/hub/src/index.ts` + `packages/lobby/src/index.ts` (exports). Test `packages/hub/__tests__/custody-api.test.ts` (the end-to-end acceptance scenarios).
+
+- [ ] **Step 1: Failing test** — `custody-api.test.ts`: the FULL acceptance walkthrough via `vault.custody.*`:
+  - provision a Deed vault; `vault.custody.grantCustodian({...})`; custodian operates fully but `vault.custody`/grant/rotate/sever all denied;
+  - owner (re-opened via the sealing provider) `revokeCustodian` + `extractPartition` with custodian offline;
+  - custodian `vault.custody.liberate({legalBasis})` mints a new owner; ledger shows a prior withdrawal AND the liberation.
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement.**
+  - `custody/index.ts`: `CustodyApi` class mirroring `UserApi` (api.ts:123) — constructor takes injected callbacks `(grantCustodian, revokeCustodian, liberate, provisionDeed?)`; methods delegate.
+  - `vault.ts`: `public readonly custody: CustodyApi` (declare ~282), wire in the constructor (~583) mirroring `this.user = new UserApi(...)` — inject closures calling `this.noydb.grantCustodian(this.name, ...)`, `revokeCustodian`, and `liberateVault(this, ...)`. **Ceiling:** bump `vault.ts` 4520→4545 in check-architecture.mjs (justified: custody surface field + wiring).
+  - `hub/src/index.ts`: export `CustodyApi`, `liberateVault`, `createDeedOwner`/`loadDeedMarker`/`isDeedVault`, `DeedMarker`, `LiberateOptions`/`LiberateResult`.
+  - `lobby/src/index.ts`: re-export the custody types (no lobby logic in slice 1).
+
+- [ ] **Step 4: Run → pass.** Full hub + lobby test, typecheck, lint, architecture.
+
+- [ ] **Step 5: Commit** — `git commit -am "feat(hub): vault.custody.* surface + exports (FR-6 Task 6)"`
+
+---
+
+## Task 7 — features.yaml + full verification
+
+**Files:** `features.yaml`.
+
+- [ ] **Step 1: features.yaml** — add a `sovereign-custody` (or `deed-custodian-liberate`) entry mirroring a sibling hub feature: artefacts `packages/hub/src/custody/`, `packages/hub/src/team/deed.ts`; spec the FR-6 design spec; package `@noy-db/hub`; status `preview`. Invariants summarizing the 4 security invariants. `node scripts/validate-features.mjs` passes.
+- [ ] **Step 2: Full verification:**
+```bash
+pnpm --filter @noy-db/hub build && pnpm --filter @klum-db/lobby build
+pnpm --filter @noy-db/hub test && pnpm --filter @klum-db/lobby test
+pnpm lint && pnpm typecheck
+node scripts/validate-features.mjs
+pnpm check:architecture
+```
+All green.
+- [ ] **Step 3: Commit** — `git commit -am "feat: register sovereign-custody feature + verify (FR-6)"`
+
+---
+
+## Self-Review
+
+**Spec coverage (issue #446 + design spec):**
+- (a) sealed/auto-owner → Task 3; custodian operates fully but cannot grant/revoke/rotate/extract/sever → Tasks 1+2 (proven by denial tests).
+- (b) owner revokes custodian + extracts without cooperation → Task 4 (revokeCustodian, owner-only) + Task 6 acceptance test (custodian offline).
+- (c) liberation claims ownership under an audited event; withdrawal + liberation both in ledger → Task 5 + Task 6 acceptance test.
+- inalienability cryptographic → Task 3 (non-firm sealing) — custodian never holds `KEK_owner`.
+
+**Placeholder scan:** every task cites exact files/lines from the recon; the two genuine implementation decisions are called out explicitly (Task 5's freeze-vs-snapshot-only for liberation continuity; Task 1's audit of all 15+ Role sites). Implementers must read the cited code to confirm accessors before writing.
+
+**Risk notes:** Task 1 is the riskiest (Role union widening → privilege-escalation if a comparison site is missed; the recon enumerated all 15+ sites — audit each). TS flags only `ROLE_RANK`; the rest are manual. Deferred (spec §7): rotation-escrow, auto-abandonment, raw-store-bypass hardening of operational ops — documented, not silently dropped. New files (deed.ts, custody/*) are ceiling-exempt; noydb.ts (3095→3140) + vault.ts (4520→4545) bumped first (raise-first playbook). The final whole-FR review must specifically probe: can a custodian reach owner via ANY path (grant-self-owner, rotate-then-strip, direct extract)?

--- a/docs/superpowers/specs/2026-06-17-fr6-deed-custodian-liberate-design.md
+++ b/docs/superpowers/specs/2026-06-17-fr6-deed-custodian-liberate-design.md
@@ -1,0 +1,122 @@
+# FR-6 — Deed / Custodian / Liberate (sovereignty-preserving custody) — Design Spec
+
+**Issue:** #446 (pilot-1 epic #440). **Status:** design — pending review.
+**Scope decision:** *pragmatic first cut* (see §7). **Lexicon:** Deed / Custodian / Liberate (spec §7 of the Lobby framework design).
+
+---
+
+## 1. Problem & thesis
+
+A tax firm is a **processor**; the **client owns** the data (PDPA/GDPR). Today the only way to give the firm full operational access is to make it `owner` or `admin` — which also hands it the meta-capabilities (revoke, re-key, extract-and-sever, grant). We want the inverse topology of `#198 reKey` (full handoff): the firm operates at 100% while the **client holds the inalienable root from day one — hidden and flattened** (the client never has to authenticate). This is the embodiment of klum-db's "counterbalance to tech giants holding data hostage."
+
+The model has three parts:
+- **(a) Deed** — an auto-generated, *sealed*, *hidden* owner credential established at provisioning. The vault is owned by a principal who never authenticates (latent owner). Owning ≠ operating.
+- **(b) Custodian** — a grant that is **100% operational** (full read/write on all collections) yet **provably cannot**: revoke the owner or other grantees, re-key (rotate), extract-and-sever, or grant new parties. The firm.
+- **(c) Liberate** — an authorized, audited claim of ownership over a sealed-owner vault (abandonment / contractual handover) — the **inverse of #199 withdrawal** (there the owner severs the host; here the host ascends to owner). Same key-topology family, opposite direction; both audited + evidence-reversible.
+
+## 2. What already exists (reused, not rebuilt)
+
+(From the FR-6 reconnaissance.)
+- **Roles** (`hub/src/types.ts:84`): `owner | admin | operator | viewer | client`. `owner` is non-revocable (`team/keyring.ts canRevoke` blocks `owner`). Permission checks: `hasWritePermission`/`hasAccess`/`canGrant`/`canRevoke`.
+- **Keyring/key-custody** (`team/keyring.ts`): passphrase → `deriveKey` → **KEK**; per-collection random **DEK** wrapped `AES-KW(DEK, KEK)` in `_keyring/<userId>`. `grant()` wraps the SAME DEKs under a grantee's KEK. `revoke()` removes a keyring. `rotateKeys()` mints fresh DEKs + **strips other users' DEK entries** (the escrow problem).
+- **Managed mode / sealed owner** (`noydb.ts`, `bundle/adopt-partition.ts`): `passphraseMode:'managed'` mints a random passphrase, sealed under a **`SealingKeyProvider`** (KMS/keychain); `_meta/sealed-passphrase`; Shamir recovery via `ShamirRecoveryProvider`; `openVaultAndEnrollRecovery` / `recoverManagedPassphrase`.
+- **#199 withdrawal** (`bundle/withdraw-accessible.ts`, `bundle/request-withdrawal.ts`): `exportAccessibleData` (non-destructive), `withdrawAccessibleData` (delete/freeze), two-party `requestWithdrawal`/`approveWithdrawal`/`rejectWithdrawal`, `freezeAndDeleteClosure` + hash-pinned `FrozenSnapshotRef`. Surfaced on `vault.user.*`.
+- **Lifecycle ledger** (`history/ledger/entry.ts`): `op:'lifecycle'` + a semantic `reason` string (e.g. `partition-handed-over:<sealId>`, `creation-of-new-owner:<userId>`, `user-withdrawal-approved:...`).
+- **Lobby** (`lobby/src/index.ts`): thin orchestrator over a `Noydb` + vault-template registry; re-exports the FR-2/3/4/8 interchange surface.
+
+`Deed`, `Custodian`, `Liberate` are **net-new symbols** (verified).
+
+## 3. The key topology (the heart of FR-6)
+
+```
+                 ┌─────────────────────────────────────────────┐
+   CLIENT  ───►  │ Deed = OWNER keyring (role 'owner')          │
+ (latent,        │   KEK_owner  ⇐ sealed passphrase             │
+  never auths)   │   sealed under  SealingKeyProvider_client    │  ◄── non-firm trust boundary
+                 │   wraps:  AES-KW(DEK_c, KEK_owner)  ∀ c      │
+                 └─────────────────────────────────────────────┘
+                                     │  (same DEKs, different wrap)
+                 ┌─────────────────────────────────────────────┐
+   FIRM    ───►  │ Custodian keyring (role 'custodian')         │
+ (operates       │   KEK_cust ⇐ firm passphrase / firm sealing  │
+  100%)          │   wraps:  AES-KW(DEK_c, KEK_cust)  ∀ c      │
+                 │   CANNOT: rotate · revoke · grant · sever    │
+                 └─────────────────────────────────────────────┘
+```
+
+**Why inalienability is cryptographic, not a soft check:**
+The Deed (owner) credential is sealed under a `SealingKeyProvider` that the **Custodian/firm does not control** (client-held KMS, or a neutral escrow named at provisioning). The Custodian holds the DEKs (so it operates fully) but can **never obtain `KEK_owner`** → can never act *as* the owner. The owner can always unseal (via the client boundary), revoke the Custodian, and `extractPartition` **without the Custodian's cooperation** (acceptance #2). The operational constraints on the Custodian (no rotate/grant/revoke/sever) are enforced **structurally in the role matrix** (acceptance #1); the *inalienability of ownership itself* is the crypto floor above.
+
+**Trust-boundary honesty (documented, not hand-waved):** in the pragmatic first cut the no-rotate/no-grant/no-revoke constraints are enforced at the API + role layer. A Custodian with **raw `NoydbStore` access** that bypasses the API is out of scope for slice 1 (same posture as today's `canRevoke`); the **ownership anchor** (custodian can't unseal `KEK_owner`) still holds against raw access because it is cryptographic. Closing the raw-access gap on the operational ops is a Phase-2 follow-up (see §7).
+
+## 4. The `custodian` role
+
+Add `'custodian'` to the `Role` union. Semantics = `admin`-level **operation** minus the meta-capabilities:
+
+| Capability | owner | admin | **custodian** | operator |
+|---|---|---|---|---|
+| rw on all collections | ✓ | ✓ | **✓** | explicit only |
+| grant roles | all | ≤admin | **✗** | ✗ |
+| revoke roles | all | ≤admin | **✗** | ✗ |
+| rotate keys | ✓ | ✓ | **✗** | ✗ |
+| extract-and-sever (withdraw destructive) | ✓ | ✓ | **✗** | self only |
+| export accessible (non-destructive copy) | ✓ | ✓ | **✓** | self scope |
+
+Enforced in: `hasWritePermission` (custodian → true, like admin), `hasAccess` (custodian → true), `canGrant(custodian, *) → false`, `canRevoke(custodian, *) → false`, and a guard in `rotateKeys` / the destructive `withdraw` path rejecting `role==='custodian'`. New policy gates back the ceremonies (§6).
+
+## 5. On-disk markers & audit
+
+- **`_meta/deed`** — records the Deed at provisioning: `{ ownerUserId, sealedUnder: <provider descriptor / 'client-kms' | 'neutral-escrow'>, issuedAt, latent: true }`. Marks the owner keyring as Deed-inalienable.
+- **Lifecycle ledger** (`op:'lifecycle'`, reused) reasons:
+  - `deed-issued:<ownerUserId>`
+  - `custodian-granted:<custodianUserId>`
+  - `custodian-revoked:<custodianUserId>`
+  - `liberation-claimed:<newOwnerUserId>:<legalBasis>` (+ a `FrozenSnapshotRef` of the pre-liberation state, mirroring withdrawal's frozen snapshot for evidence-reversibility).
+
+Every FR-6 ceremony writes a ledger entry; withdrawal **and** liberation therefore both appear in the lifecycle ledger (acceptance #3).
+
+## 6. Ceremonies / API surface
+
+Custody is **per-vault** (a Deed belongs to one client vault); the `Lobby` may later offer fleet-wide wrappers (a firm holding Custodian grants over many client shards) — not in this slice. Surface attaches on the vault (mirroring `vault.user.*`), under a new **`vault.custody.*`** namespace, with hub functions in a new `hub/src/custody/` module.
+
+1. **Provision with Deed** — extend vault creation / a `provisionWithDeed(...)`:
+   - mint the owner keyring (role `owner`) with a random passphrase **sealed under the supplied non-firm `SealingKeyProvider`** (reuse managed-mode sealing); write `_meta/deed`; ledger `deed-issued`. The client is latent (never authenticates).
+2. **`vault.custody.grantCustodian({ custodianUserId, passphrase | sealing })`** — owner-gated; mints a `custodian`-role keyring wrapping the existing DEK set under the custodian's KEK; ledger `custodian-granted`. Gate: `grant-custodian`.
+3. **`vault.custody.revokeCustodian({ custodianUserId })`** — owner-only (the owner can do this without the custodian's cooperation, via the sealed credential); removes the custodian keyring; ledger `custodian-revoked`. (Reuses `revoke()`.)
+4. **`vault.custody.liberate({ legalBasis, newOwner })`** — the manual audited claim. The de-facto authority (custodian, who holds the DEKs) claims ownership: freeze a pre-liberation snapshot (`freezeAndDeleteClosure` disposition `freeze` → `FrozenSnapshotRef`), mint a **new** owner keyring (re-wrap the DEKs under the new owner's KEK — the original sealed owner is NOT unsealed, preserving the inalienability floor; liberation MINTS a new owner, it does not impersonate the old one), ledger `liberation-claimed`. Gate: `liberate-vault` (default-off, requires `legalBasis`). Evidence-reversible via the frozen snapshot + ledger.
+
+## 7. Scope: in / deferred
+
+**In this slice (meets all of #446 acceptance):**
+- `custodian` role + the meta-capability constraints (rotate/grant/revoke/sever blocked).
+- Deed provisioning = sealed-owner under a **non-firm** `SealingKeyProvider` + `_meta/deed` + crypto-anchored inalienability.
+- `grantCustodian` / `revokeCustodian` (owner can revoke + `extractPartition` without custodian cooperation).
+- `liberate` = manual audited ceremony (freeze snapshot + mint new owner + ledger); withdrawal & liberation both in the lifecycle ledger.
+- Policy gates: `grant-custodian`, `liberate-vault`.
+
+**Deferred (documented limitations + follow-up issues):**
+- **Custodian survives key rotation (the escrow problem).** Today `rotateKeys` strips non-rotating users' DEKs. In slice 1 the **owner** is blocked from rotating away the custodian by gating, and the custodian cannot rotate at all; a *deliberate* owner rotation that re-grants the custodian afterward is the supported path. KMS-escrow (custodian DEKs always re-wrapped under a firm KMS key at rotation) is Phase 2.
+- **Auto-abandonment detection** for Liberate (time-lock / quorum staleness) — slice 1 is manual/contractual only.
+- **Raw-`NoydbStore`-bypass hardening** of the operational constraints (the ownership anchor is already crypto-enforced; the operational ops are API-enforced in slice 1).
+- **Recovery-quorum Liberate** (no-custodian, Shamir quorum reclaims) — slice 1's liberate is the custodian-ascends path; the recovery path leans on existing `recoverManagedPassphrase`.
+
+## 8. Security model summary
+
+- **Inalienability:** cryptographic — the Custodian cannot reach `KEK_owner` (sealed under a non-firm boundary). ✓
+- **Operational constraint:** structural — `custodian` role blocks grant/revoke/rotate/sever. ✓ (API-layer for slice 1; raw-access hardening deferred.)
+- **Owner autonomy:** the owner can revoke the custodian + extract without custodian cooperation (it unseals its own credential). ✓
+- **Liberation:** gated (default-off), requires `legalBasis`, freezes an evidence snapshot, mints a new owner (never impersonates the sealed owner), audited in the ledger. ✓
+- **Reversibility:** every ceremony leaves an indelible ledger entry; liberation + withdrawal both pin a frozen snapshot. ✓
+
+## 9. Testing strategy (acceptance → tests)
+
+- **Deed:** provision a vault with a sealed/auto-owner under a test `SealingKeyProvider`; assert the owner is latent (no interactive passphrase) and `_meta/deed` records the non-firm boundary.
+- **Custodian operates fully:** custodian reads/writes all collections; **provably cannot** grant / revoke / rotate / destructive-withdraw (each throws a permission/gate error).
+- **Owner autonomy:** the sealed owner (recovered via the provider) revokes the custodian + `extractPartition` succeeds with the custodian offline.
+- **Liberate:** an audited `liberate({legalBasis})` mints a new owner, freezes a snapshot, and writes `liberation-claimed`; assert both a prior withdrawal and the liberation appear in the lifecycle ledger; assert the new owner can operate and the old sealed owner credential is orphaned (not impersonated).
+
+## 10. Open questions for review
+
+1. Should `provisionWithDeed` be a new `vault.custody.*` entry, an option on the existing managed-mode vault creation, or a `Lobby` method? (Proposed: a hub `custody/` function surfaced as `vault.custody.provisionDeed`, with a `Lobby` convenience later.)
+2. Is the `custodian` role addition to the public `Role` union acceptable as a breaking-ish surface change (it widens a public union; pre-1.0 so low cost)? (Proposed: yes.)
+3. For slice-1 Liberate, is the **custodian-ascends** path (firm claims ownership, holding the DEKs) the right primary, with recovery-quorum deferred? (Proposed: yes.)

--- a/features.yaml
+++ b/features.yaml
@@ -1030,6 +1030,25 @@ features:
       - 'two-party ceremony (P3) for read-only roles: requestWithdrawal files a durable plaintext-metadata request in _user_withdrawal_requests (no passphrase at rest); owner/admin approveWithdrawal (gate approve-user-withdrawal t2 + role) extracts under firm authority and reuses freezeAndDeleteClosure so the requester disposition flows through; rejectWithdrawal touches no data; approve/reject are OCC + idempotent (pending-only, expiry-checked)'
     related: [transferable-partition, bundle, team, session-tiers]
 
+  - id: sovereign-custody
+    name: Deed / Custodian / Liberate — sovereignty-preserving custody (FR-6)
+    cluster: collaboration-and-auth
+    spec: docs/superpowers/specs/2026-06-17-fr6-deed-custodian-liberate-design.md
+    subsystem_doc: docs/superpowers/specs/2026-06-17-fr6-deed-custodian-liberate-design.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'Custodian operates fully (rw all collections) but is provably unable to grant / revoke / rotate / extract-and-sever; canGrant(custodian,*) = false, canRevoke(custodian,*) = false, rotateKeys throws PermissionDeniedError'
+      - 'Owner (sealed under a non-firm SealingKeyProvider via Deed) can revoke the custodian + extractPartition without the custodian''s cooperation; revokeCustodian is owner-only'
+      - 'Liberate claims ownership under an audited lifecycle ledger entry (liberation-claimed:<newOwnerId>:<legalBasis>); both withdrawal and liberation appear in the ledger; liberation mints a distinct new owner re-wrapping incumbent DEKs without unsealing the sealed owner credential'
+      - 'Inalienability is cryptographic: the custodian never holds KEK_owner (sealed under a non-firm SealingKeyProvider); grant-custodian and liberate-vault gates are fail-closed (disabled → PolicyDeniedError)'
+    related: [team, transferable-partition, bundle, permissions]
+
   - id: multi-compartment-bundle
     name: Multi-compartment bundle (NDBM — N vaults in one .noydb container)
     cluster: snapshot-and-portability

--- a/packages/hub/__tests__/custodian-grant.test.ts
+++ b/packages/hub/__tests__/custodian-grant.test.ts
@@ -1,0 +1,132 @@
+/**
+ * FR-6 Task 4 — `grantCustodian` / `revokeCustodian` on `Noydb`.
+ *
+ * Owner-only custody API, defended in depth: the operation is gated
+ * (`grant-custodian` / `revoke-user`, both fail-closed) AND the caller's
+ * keyring must resolve to `owner` (an explicit `keyring.role !== 'owner'`
+ * check). A custodian is granted under the `custodian` role and operates
+ * every collection; `revokeCustodian` removes it again.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError, PermissionDeniedError } from '../src/errors.js'
+import { createNoydb } from '../src/noydb.js'
+import type { Noydb } from '../src/noydb.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) }
+    },
+  }
+}
+
+interface Invoice { amount: number; status: string }
+
+describe('FR-6 Task 4 — grantCustodian / revokeCustodian (owner-only custody API)', () => {
+  const COMP = 'C400'
+  // The custody API is gated; enable `grant-custodian` so the owner can mint a
+  // custodian. `revoke-user` is enabled too so `revokeCustodian` is exercised.
+  const POLICY = {
+    gates: {
+      'grant-custodian': { enabled: true, minTier: 1 },
+      'revoke-user': { enabled: true, minTier: 1 },
+    },
+  }
+
+  let adapter: NoydbStore
+  let ownerDb: Noydb
+
+  beforeEach(async () => {
+    adapter = inlineMemory()
+    ownerDb = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass', policy: POLICY })
+    const comp = await ownerDb.openVault(COMP)
+    await comp.collection<Invoice>('invoices').put('inv-001', { amount: 5000, status: 'draft' })
+    await comp.collection<Invoice>('payments').put('pay-001', { amount: 3000, status: 'paid' })
+  })
+
+  it('owner grants a custodian who opens + reads/writes ALL collections', async () => {
+    await expect(
+      ownerDb.grantCustodian(COMP, { userId: 'firm-01', displayName: 'Firm', passphrase: 'firm-pass-long' }),
+    ).resolves.not.toThrow()
+
+    const firmDb = await createNoydb({ store: adapter, user: 'firm-01', secret: 'firm-pass-long' })
+    const comp = await firmDb.openVault(COMP)
+    // reads every collection
+    expect((await comp.collection<Invoice>('invoices').get('inv-001'))?.amount).toBe(5000)
+    expect((await comp.collection<Invoice>('payments').get('pay-001'))?.amount).toBe(3000)
+    // writes every collection
+    await expect(
+      comp.collection<Invoice>('invoices').put('inv-002', { amount: 1000, status: 'new' }),
+    ).resolves.not.toThrow()
+    await expect(
+      comp.collection<Invoice>('payments').put('pay-002', { amount: 7, status: 'x' }),
+    ).resolves.not.toThrow()
+  })
+
+  it('(a) grantCustodian FAILS when the `grant-custodian` gate is disabled (fail-closed)', async () => {
+    // Fresh vault + a NoyDB with NO policy: the `grant-custodian` built-in gate
+    // is unconfigured, so it must fail closed even for the owner. (Using a
+    // separate vault avoids reading C400's persisted gate-enabled policy.)
+    const NO_GATE_COMP = 'C400-nogate'
+    const noGateDb = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+    const comp = await noGateDb.openVault(NO_GATE_COMP)
+    await comp.collection<Invoice>('invoices').put('inv-001', { amount: 1, status: 'x' })
+    await expect(
+      noGateDb.grantCustodian(NO_GATE_COMP, { userId: 'firm-02', displayName: 'Firm', passphrase: 'firm-pass-long' }),
+    ).rejects.toThrow()
+  })
+
+  it('(b) grantCustodian FAILS when the caller is NOT the owner (admin tries)', async () => {
+    await ownerDb.grant(COMP, { userId: 'admin-01', displayName: 'Admin', role: 'admin', passphrase: 'admin-pass' })
+    const adminDb = await createNoydb({ store: adapter, user: 'admin-01', secret: 'admin-pass', policy: POLICY })
+    await adminDb.openVault(COMP)
+    await expect(
+      adminDb.grantCustodian(COMP, { userId: 'firm-03', displayName: 'Firm', passphrase: 'firm-pass-long' }),
+    ).rejects.toThrow(PermissionDeniedError)
+  })
+
+  it('(c) revokeCustodian (as owner) removes the custodian', async () => {
+    await ownerDb.grantCustodian(COMP, { userId: 'firm-01', displayName: 'Firm', passphrase: 'firm-pass-long' })
+    // sanity: the custodian can open before revocation
+    const firmDb = await createNoydb({ store: adapter, user: 'firm-01', secret: 'firm-pass-long' })
+    await expect(firmDb.openVault(COMP)).resolves.toBeTruthy()
+
+    await expect(
+      ownerDb.revokeCustodian(COMP, { userId: 'firm-01' }),
+    ).resolves.not.toThrow()
+
+    // after revocation the firm keyring is gone — a fresh open is denied
+    const firmAfter = await createNoydb({ store: adapter, user: 'firm-01', secret: 'firm-pass-long' })
+    await expect(firmAfter.openVault(COMP)).rejects.toThrow()
+  })
+
+  it('revokeCustodian FAILS when the caller is NOT the owner (admin tries)', async () => {
+    await ownerDb.grantCustodian(COMP, { userId: 'firm-01', displayName: 'Firm', passphrase: 'firm-pass-long' })
+    await ownerDb.grant(COMP, { userId: 'admin-01', displayName: 'Admin', role: 'admin', passphrase: 'admin-pass' })
+    const adminDb = await createNoydb({ store: adapter, user: 'admin-01', secret: 'admin-pass', policy: POLICY })
+    await adminDb.openVault(COMP)
+    await expect(
+      adminDb.revokeCustodian(COMP, { userId: 'firm-01' }),
+    ).rejects.toThrow(PermissionDeniedError)
+  })
+})

--- a/packages/hub/__tests__/custodian-role.test.ts
+++ b/packages/hub/__tests__/custodian-role.test.ts
@@ -1,0 +1,188 @@
+/**
+ * FR-6 Task 1 — the `custodian` role.
+ *
+ * A custodian is operationally admin-rank: rw + access on ALL collections
+ * and receives every collection DEK on grant. BUT it is provably unable to
+ * grant or revoke, and an admin cannot mint one — only the (Deed) owner can.
+ *
+ * (Task 2 will additionally block rotate / sever / extract; Task 4 adds the
+ * `grantCustodian`/`revokeCustodian` owner API. This file covers the kernel
+ * role/capability matrix + the two new built-in gate names fail-closed.)
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError, PermissionDeniedError } from '../src/errors.js'
+import { createNoydb } from '../src/noydb.js'
+import type { Noydb } from '../src/noydb.js'
+import { checkGate, PolicyDeniedError } from '../src/policy/index.js'
+import { putCredential } from '../src/team/sync-credentials.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) }
+    },
+  }
+}
+
+interface Invoice { amount: number; status: string }
+
+describe('custodian role', () => {
+  let adapter: NoydbStore
+  let ownerDb: Noydb
+  const COMP = 'C200'
+
+  beforeEach(async () => {
+    adapter = inlineMemory()
+    ownerDb = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+    const comp = await ownerDb.openVault(COMP)
+    await comp.collection<Invoice>('invoices').put('inv-001', { amount: 5000, status: 'draft' })
+    await comp.collection<Invoice>('payments').put('pay-001', { amount: 3000, status: 'paid' })
+  })
+
+  describe('(a) owner grants a custodian who operates ALL collections', () => {
+    let custodianDb: Noydb
+
+    beforeEach(async () => {
+      await ownerDb.grant(COMP, {
+        userId: 'cust-01', displayName: 'Custodian', role: 'custodian',
+        passphrase: 'cust-pass',
+      })
+      custodianDb = await createNoydb({ store: adapter, user: 'cust-01', secret: 'cust-pass' })
+    })
+
+    it('reads every collection (no explicit permissions needed)', async () => {
+      const comp = await custodianDb.openVault(COMP)
+      expect((await comp.collection<Invoice>('invoices').get('inv-001'))?.amount).toBe(5000)
+      expect((await comp.collection<Invoice>('payments').get('pay-001'))?.amount).toBe(3000)
+    })
+
+    it('writes every collection', async () => {
+      const comp = await custodianDb.openVault(COMP)
+      await expect(
+        comp.collection<Invoice>('invoices').put('inv-002', { amount: 1000, status: 'new' }),
+      ).resolves.not.toThrow()
+      await expect(
+        comp.collection<Invoice>('payments').put('pay-002', { amount: 7, status: 'x' }),
+      ).resolves.not.toThrow()
+    })
+  })
+
+  describe('(b)+(c) custodian cannot grant or revoke', () => {
+    let custodianDb: Noydb
+
+    beforeEach(async () => {
+      await ownerDb.grant(COMP, {
+        userId: 'cust-01', displayName: 'Custodian', role: 'custodian',
+        passphrase: 'cust-pass',
+      })
+      // a separate user the custodian might try to revoke
+      await ownerDb.grant(COMP, { userId: 'viewer-01', displayName: 'V', role: 'viewer', passphrase: 'p' })
+      custodianDb = await createNoydb({ store: adapter, user: 'cust-01', secret: 'cust-pass' })
+    })
+
+    it('cannot grant any role', async () => {
+      await expect(
+        custodianDb.grant(COMP, { userId: 'x', displayName: 'X', role: 'viewer', passphrase: 'p' }),
+      ).rejects.toThrow(PermissionDeniedError)
+      await expect(
+        custodianDb.grant(COMP, { userId: 'y', displayName: 'Y', role: 'operator', passphrase: 'p', permissions: { invoices: 'rw' } }),
+      ).rejects.toThrow(PermissionDeniedError)
+    })
+
+    it('cannot revoke anyone', async () => {
+      await expect(
+        custodianDb.revoke(COMP, { userId: 'viewer-01' }),
+      ).rejects.toThrow(PermissionDeniedError)
+    })
+  })
+
+  describe('(d) admin cannot grant a custodian — only the owner can', () => {
+    it('admin → custodian is denied', async () => {
+      await ownerDb.grant(COMP, { userId: 'admin-01', displayName: 'Admin', role: 'admin', passphrase: 'admin-pass' })
+      const adminDb = await createNoydb({ store: adapter, user: 'admin-01', secret: 'admin-pass' })
+      await expect(
+        adminDb.grant(COMP, { userId: 'cust-from-admin', displayName: 'C', role: 'custodian', passphrase: 'p' }),
+      ).rejects.toThrow(PermissionDeniedError)
+    })
+
+    it('owner → custodian succeeds (control)', async () => {
+      await expect(
+        ownerDb.grant(COMP, { userId: 'cust-02', displayName: 'C', role: 'custodian', passphrase: 'p' }),
+      ).resolves.not.toThrow()
+    })
+  })
+
+  describe('audit of other Role comparison sites', () => {
+    let custodianDb: Noydb
+
+    beforeEach(async () => {
+      await ownerDb.grant(COMP, {
+        userId: 'cust-01', displayName: 'Custodian', role: 'custodian',
+        passphrase: 'cust-pass',
+      })
+      custodianDb = await createNoydb({ store: adapter, user: 'cust-01', secret: 'cust-pass' })
+    })
+
+    it('sync-credentials.ts: custodian CANNOT issue sync credentials (firm infra, not operational scope)', async () => {
+      const comp = await custodianDb.openVault(COMP)
+      const { keyring } = comp._introspectState()
+      await expect(
+        putCredential(adapter, COMP, keyring, { adapterId: 'gdrive', tokenType: 'Bearer', accessToken: 'x' }),
+      ).rejects.toThrow(PermissionDeniedError)
+    })
+
+    it('tiers.ts: custodian operates non-zero tiers like admin (auto-mints the tier DEK)', async () => {
+      const comp = await custodianDb.openVault(COMP)
+      const docs = comp.collection<{ id: string; body: string }>('tiered', { tiers: [0, 1, 2] })
+      // assertTierAccess + the elevate tier-reach check both treat custodian as
+      // admin-rank, so writing at a tier whose DEK does not yet exist succeeds.
+      await expect(docs.putAtTier('d1', { id: 'd1', body: 'secret' }, 2)).resolves.not.toThrow()
+      expect((await docs.getAtTier('d1'))?.body).toBe('secret')
+    })
+  })
+})
+
+describe('FR-6 built-in gates: grant-custodian / liberate-vault', () => {
+  // Mirror the `client-unilateral-withdraw` fail-closed contract: a built-in
+  // gate with no configured policy is DENIED ('disabled'); it only passes once
+  // the host opts in with `{ enabled: true, minTier: 1 }`.
+  const EMPTY_POLICY = { gates: {} } as const
+
+  for (const gate of ['grant-custodian', 'liberate-vault'] as const) {
+    it(`${gate}: fails closed by default (no policy)`, async () => {
+      let err: unknown
+      try {
+        await checkGate(EMPTY_POLICY, gate, { activeTier: 1 })
+      } catch (e) { err = e }
+      expect(err).toBeInstanceOf(PolicyDeniedError)
+      if (err instanceof PolicyDeniedError) expect(err.reason).toBe('disabled')
+    })
+
+    it(`${gate}: passes when enabled`, async () => {
+      const policy = { gates: { [gate]: { enabled: true, minTier: 1 as const } } }
+      await expect(
+        checkGate(policy, gate, { activeTier: 1 }),
+      ).resolves.toBeUndefined()
+    })
+  }
+})

--- a/packages/hub/__tests__/custodian-role.test.ts
+++ b/packages/hub/__tests__/custodian-role.test.ts
@@ -11,11 +11,12 @@
  */
 import { describe, it, expect, beforeEach } from 'vitest'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
-import { ConflictError, PermissionDeniedError } from '../src/errors.js'
+import { ConflictError, PermissionDeniedError, ReadOnlyError } from '../src/errors.js'
 import { createNoydb } from '../src/noydb.js'
 import type { Noydb } from '../src/noydb.js'
 import { checkGate, PolicyDeniedError } from '../src/policy/index.js'
 import { putCredential } from '../src/team/sync-credentials.js'
+import { extractPartition } from '../src/bundle/extract-partition.js'
 
 function inlineMemory(): NoydbStore {
   const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
@@ -159,6 +160,82 @@ describe('custodian role', () => {
       await expect(docs.putAtTier('d1', { id: 'd1', body: 'secret' }, 2)).resolves.not.toThrow()
       expect((await docs.getAtTier('d1'))?.body).toBe('secret')
     })
+  })
+})
+
+describe('FR-6 Task 2 — custodian blocked from rotate / sever / extract', () => {
+  // The custodian operates fully but is the de-facto authority WITHOUT
+  // ownership: it must be provably unable to re-key, destructively sever, or
+  // extract-and-sever. These three meta-capabilities are owner-only.
+  const COMP = 'C201'
+  // The withdrawal path is itself gated by `client-unilateral-withdraw`; enable
+  // it so the role guard (not the gate) is what rejects the custodian.
+  const POLICY = { gates: { 'client-unilateral-withdraw': { enabled: true, minTier: 1 } } }
+
+  interface Inv { id: string; amount: number; status: string }
+  let adapter: NoydbStore
+  let ownerDb: Noydb
+  let custodianDb: Noydb
+
+  beforeEach(async () => {
+    adapter = inlineMemory()
+    ownerDb = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass', policy: POLICY })
+    const comp = await ownerDb.openVault(COMP)
+    await comp.collection<Inv>('invoices').put('inv-001', { id: 'inv-001', amount: 5000, status: 'draft' })
+    await comp.collection<Inv>('payments').put('pay-001', { id: 'pay-001', amount: 3000, status: 'paid' })
+    await ownerDb.grant(COMP, {
+      userId: 'cust-01', displayName: 'Custodian', role: 'custodian', passphrase: 'cust-pass',
+    })
+    custodianDb = await createNoydb({ store: adapter, user: 'cust-01', secret: 'cust-pass' })
+  })
+
+  it('(a) custodian cannot rotate keys', async () => {
+    await custodianDb.openVault(COMP)
+    await expect(
+      custodianDb.rotate(COMP, ['invoices']),
+    ).rejects.toThrow(PermissionDeniedError)
+  })
+
+  it('(b) custodian cannot destructively withdraw/sever — redirected to liberate (delete)', async () => {
+    const comp = await custodianDb.openVault(COMP)
+    const p = comp.user.unilateralWithdrawal({
+      disposition: 'delete', legalBasis: 'x', reKey: { passphrase: 'new-pw' },
+    })
+    await expect(p).rejects.toThrow(ReadOnlyError)
+    await expect(p).rejects.toThrow(/liberate|custody/)
+    // live records untouched (nothing severed)
+    expect((await comp.collection<Inv>('invoices').get('inv-001'))?.amount).toBe(5000)
+  })
+
+  it('(b) custodian cannot destructively withdraw/sever — redirected to liberate (freeze)', async () => {
+    const comp = await custodianDb.openVault(COMP)
+    await expect(
+      comp.user.unilateralWithdrawal({
+        disposition: 'freeze', legalBasis: 'x', reKey: { passphrase: 'new-pw' },
+      }),
+    ).rejects.toThrow(/liberate|custody/)
+  })
+
+  it('(c) custodian cannot extractPartition', async () => {
+    const comp = await custodianDb.openVault(COMP)
+    await expect(
+      extractPartition(comp, { seeds: { invoices: () => true } }),
+    ).rejects.toThrow(/owner|custodian/)
+  })
+
+  it('control: the owner CAN rotate / extract (no regression)', async () => {
+    const comp = await ownerDb.openVault(COMP)
+    await expect(ownerDb.rotate(COMP, ['invoices'])).resolves.not.toThrow()
+    await expect(
+      extractPartition(comp, { seeds: { invoices: () => true } }),
+    ).resolves.toBeTruthy()
+  })
+
+  it('control: an admin CAN rotate (no regression)', async () => {
+    await ownerDb.grant(COMP, { userId: 'admin-01', displayName: 'Admin', role: 'admin', passphrase: 'admin-pass' })
+    const adminDb = await createNoydb({ store: adapter, user: 'admin-01', secret: 'admin-pass' })
+    await adminDb.openVault(COMP)
+    await expect(adminDb.rotate(COMP, ['invoices'])).resolves.not.toThrow()
   })
 })
 

--- a/packages/hub/__tests__/custody-api.test.ts
+++ b/packages/hub/__tests__/custody-api.test.ts
@@ -1,0 +1,221 @@
+/**
+ * FR-6 Task 6 — `vault.custody.*` surface: the END-TO-END acceptance walkthrough.
+ *
+ * This exercises the whole FR-6 ceremony through the public `vault.custody.*`
+ * namespace (mirroring `vault.user.*`) rather than the low-level functions:
+ *
+ *   1. Provision a Deed vault (latent owner sealed under a non-firm
+ *      `MemorySealingKeyProvider`) with records + the `grant-custodian` /
+ *      `liberate-vault` gates enabled.
+ *   2. The Deed owner mints a custodian via `vault.custody.grantCustodian(...)`.
+ *      The firm (custodian) opens + reads/writes ALL collections, but is
+ *      provably UNABLE to grant / rotate / sever / extract (spot-checked
+ *      denials — invariant #1).
+ *   3. The owner — re-resolved through the SAME sealing provider (a latent
+ *      owner never types a passphrase) — `vault.custody.revokeCustodian(...)`
+ *      AND `extractPartition(...)` succeed with the custodian "offline" (we
+ *      simply never use the custodian keyring) — invariant #2.
+ *   4. A custodian claims ownership via `vault.custody.liberate(...)`, minting
+ *      a new owner under an audited event. The shared lifecycle ledger shows
+ *      BOTH a prior withdrawal-style entry AND the liberation entry — the two
+ *      events share the one `vault.ledger()` mechanism (invariant #3).
+ *
+ * Inalienability (#4) is cryptographic: the custodian's keyring never carries
+ * `KEK_owner` (sealed under the non-firm provider), proven structurally — the
+ * custodian cannot extract/sever, and liberation mints a DISTINCT new owner
+ * rather than impersonating the latent one.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError, PermissionDeniedError, ReadOnlyError } from '../src/errors.js'
+import { PartitionExtractionError } from '../src/bundle/extract-partition.js'
+import { extractPartition } from '../src/bundle/extract-partition.js'
+import { createNoydb } from '../src/noydb.js'
+import type { Noydb } from '../src/noydb.js'
+import { withHistory } from '../src/history/index.js'
+import { MemorySealingKeyProvider, resolveManagedSecret } from '../src/team/managed-passphrase.js'
+import { createDeedOwner, loadDeedMarker } from '../src/team/deed.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function bucket(v: string, c: string) {
+    let m = store.get(v); if (!m) { m = new Map(); store.set(v, m) }
+    let b = m.get(c); if (!b) { b = new Map(); m.set(c, b) }
+    return b
+  }
+  return {
+    async get(v, c, id) { return bucket(v, c).get(id) ?? null },
+    async put(v, c, id, env, ev) { const b = bucket(v, c); const ex = b.get(id); if (ev !== undefined && (ex?._v ?? 0) !== ev) throw new ConflictError(ex?._v ?? 0); b.set(id, env) },
+    async delete(v, c, id) { bucket(v, c).delete(id) },
+    async list(v, c) { return [...bucket(v, c).keys()] },
+    async loadAll(v) { const m = store.get(v); const s: VaultSnapshot = {}; if (m) for (const [n, c] of m) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of c) r[id] = e; s[n] = r } } return s },
+    async saveAll(v, data) { for (const [n, recs] of Object.entries(data)) { const b = bucket(v, n); for (const [id, e] of Object.entries(recs)) b.set(id, e) } },
+  }
+}
+
+interface Invoice { id: string; amount: number; status: string }
+
+const VAULT = 'C600'
+// Both custody gates enabled; `revoke-user` (used by revokeCustodian) + the
+// `client-unilateral-withdraw` gate (used to stage the prior withdrawal entry).
+const POLICY = {
+  gates: {
+    'grant-custodian': { enabled: true, minTier: 1 },
+    'liberate-vault': { enabled: true, minTier: 1 },
+    'revoke-user': { enabled: true, minTier: 1 },
+    'client-unilateral-withdraw': { enabled: true, minTier: 1 },
+  },
+}
+
+describe('FR-6 Task 6 — vault.custody.* end-to-end acceptance walkthrough', () => {
+  let adapter: NoydbStore
+  let sealing: MemorySealingKeyProvider
+
+  beforeEach(() => {
+    adapter = inlineMemory()
+    sealing = new MemorySealingKeyProvider({ id: 'client-kms' })
+  })
+
+  /**
+   * Re-resolve the latent Deed owner as a working `Noydb`. The owner credential
+   * was minted + sealed under the non-firm provider by `createDeedOwner`; here
+   * we UNSEAL it through the SAME provider (`resolveManagedSecret`) and hand the
+   * resolved passphrase to `createNoydb` as the secret. NO HUMAN ever types it —
+   * the sealing provider is the only re-entry point — which is exactly the
+   * latent-owner property. (We resolve-then-pass rather than using
+   * `passphraseMode: 'managed'` so the acceptance walkthrough stays focused on
+   * custody and isn't entangled with managed-mode's strong-recovery enrolment
+   * gate, which is a separate epic.)
+   */
+  async function openLatentOwner(): Promise<Noydb> {
+    const passphrase = await resolveManagedSecret(adapter, VAULT, sealing)
+    return createNoydb({
+      store: adapter, user: 'owner-01', secret: passphrase,
+      historyStrategy: withHistory(), policy: POLICY,
+    })
+  }
+
+  /**
+   * Provision a Deed vault: a latent owner sealed under the non-firm provider
+   * + the `_meta/deed` marker, with the history strategy live (so the lifecycle
+   * ledger records the ceremony) and three seeded collections.
+   */
+  async function provisionDeed(): Promise<Noydb> {
+    // Mint the sealed owner + marker (machine-side, no human passphrase).
+    await createDeedOwner(adapter, VAULT, 'owner-01', sealing)
+    const ownerDb = await openLatentOwner()
+    const comp = await ownerDb.openVault(VAULT)
+    await comp.collection<Invoice>('invoices').put('inv-001', { id: 'inv-001', amount: 5000, status: 'draft' })
+    await comp.collection<Invoice>('payments').put('pay-001', { id: 'pay-001', amount: 3000, status: 'paid' })
+    await comp.collection<Invoice>('archive').put('arc-001', { id: 'arc-001', amount: 99, status: 'old' })
+    return ownerDb
+  }
+
+  it('full acceptance: grant → custodian operates + is denied → owner revokes/extracts offline → liberate (ledger shows withdrawal + liberation)', async () => {
+    const ownerDb = await provisionDeed()
+    const ownerVault = await ownerDb.openVault(VAULT)
+
+    // ── 1. Owner grants a custodian through vault.custody.grantCustodian ──────
+    await expect(
+      ownerVault.custody.grantCustodian({ userId: 'firm-01', displayName: 'Firm', passphrase: 'firm-pass-long' }),
+    ).resolves.not.toThrow()
+
+    // ── 2. The custodian opens + reads/writes ALL collections ────────────────
+    const firmDb = await createNoydb({ store: adapter, user: 'firm-01', secret: 'firm-pass-long', historyStrategy: withHistory(), policy: POLICY })
+    const firmVault = await firmDb.openVault(VAULT)
+    expect((await firmVault.collection<Invoice>('invoices').get('inv-001'))?.amount).toBe(5000)
+    expect((await firmVault.collection<Invoice>('payments').get('pay-001'))?.amount).toBe(3000)
+    await expect(firmVault.collection<Invoice>('invoices').put('inv-002', { id: 'inv-002', amount: 1000, status: 'new' })).resolves.not.toThrow()
+    await expect(firmVault.collection<Invoice>('payments').put('pay-002', { id: 'pay-002', amount: 7, status: 'x' })).resolves.not.toThrow()
+
+    // ── 2b. The custodian is PROVABLY UNABLE to grant / rotate / sever / extract
+    // grant (via db.grant — the keyring boundary): denied.
+    await expect(
+      firmDb.grant(VAULT, { userId: 'mole-01', displayName: 'Mole', role: 'admin', passphrase: 'mole-pass-long' }),
+    ).rejects.toThrow(PermissionDeniedError)
+    // rotate: denied (re-key is an owner meta-capability).
+    await expect(firmDb.rotate(VAULT)).rejects.toThrow(PermissionDeniedError)
+    // destructive sever via vault.user.unilateralWithdrawal: denied (must liberate).
+    await expect(
+      firmVault.user.unilateralWithdrawal({ legalBasis: 'sneaky-sever' }),
+    ).rejects.toThrow(ReadOnlyError)
+    // extract-and-sever via extractPartition: denied (owner-only).
+    await expect(
+      extractPartition(firmVault, { seeds: { invoices: () => true } }),
+    ).rejects.toThrow(PartitionExtractionError)
+
+    // ── 3. Owner re-resolved via the sealing provider (no interactive
+    //       passphrase) revokes the custodian + extracts — custodian OFFLINE.
+    //       (We simply never touch firmDb / the custodian keyring here.)
+    const latentOwnerDb = await openLatentOwner()
+    const latentOwnerVault = await latentOwnerDb.openVault(VAULT)
+    await expect(
+      latentOwnerVault.custody.revokeCustodian({ userId: 'firm-01' }),
+    ).resolves.not.toThrow()
+    // After revocation the firm keyring is gone — a fresh custodian open is denied.
+    const firmAfter = await createNoydb({ store: adapter, user: 'firm-01', secret: 'firm-pass-long' })
+    await expect(firmAfter.openVault(VAULT)).rejects.toThrow()
+    // The latent owner can extract-and-sever WITHOUT the custodian's cooperation.
+    const extracted = await extractPartition(latentOwnerVault, { seeds: { invoices: () => true } })
+    expect(extracted.bundleBytes.byteLength).toBeGreaterThan(0)
+    expect(extracted.transferKey.byteLength).toBe(32)
+  })
+
+  it('liberation: custodian claims ownership; ledger shows BOTH a prior withdrawal-style entry AND the liberation entry (shared mechanism)', async () => {
+    const ownerDb = await provisionDeed()
+    const ownerVault = await ownerDb.openVault(VAULT)
+
+    // Stage a PRIOR withdrawal-style lifecycle entry: an operator self-serves a
+    // (non-destructive freeze) unilateral withdrawal over the `archive`
+    // collection — this writes a `user-unilateral-withdrawal:...` entry into the
+    // SAME `vault.ledger()` the liberation later appends to.
+    await ownerDb.grant(VAULT, { userId: 'op-01', displayName: 'Op', role: 'operator', passphrase: 'op-pass-long', permissions: { archive: 'rw' } })
+    const opDb = await createNoydb({ store: adapter, user: 'op-01', secret: 'op-pass-long', historyStrategy: withHistory(), policy: POLICY })
+    const opVault = await opDb.openVault(VAULT)
+    await opVault.user.unilateralWithdrawal({ legalBasis: 'partial-handover', disposition: 'freeze', scope: { collections: ['archive'] } })
+
+    // Now mint the custodian + liberate via vault.custody.liberate.
+    await ownerVault.custody.grantCustodian({ userId: 'firm-01', displayName: 'Firm', passphrase: 'firm-pass-long' })
+    const firmDb = await createNoydb({ store: adapter, user: 'firm-01', secret: 'firm-pass-long', historyStrategy: withHistory(), policy: POLICY })
+    const firmVault = await firmDb.openVault(VAULT)
+
+    const result = await firmVault.custody.liberate({
+      newOwnerId: 'firm-owner-01', newOwnerPassphrase: 'firm-owner-pass-long', legalBasis: 'contractual-handover',
+    })
+    expect(result.snapshot.sha256).toMatch(/^[0-9a-f]{64}$/)
+
+    // The ONE shared lifecycle ledger carries BOTH lifecycle events.
+    const entries = await firmVault.ledger().entries()
+    const withdrawals = entries.filter(e => typeof e.reason === 'string' && e.reason.startsWith('user-unilateral-withdrawal:'))
+    const liberations = entries.filter(e => e.reason === 'liberation-claimed:firm-owner-01:contractual-handover')
+    expect(withdrawals.length).toBeGreaterThanOrEqual(1)
+    expect(liberations).toHaveLength(1)
+
+    // The new owner is a DISTINCT principal who can operate as owner; live data preserved.
+    const newOwnerDb = await createNoydb({ store: adapter, user: 'firm-owner-01', secret: 'firm-owner-pass-long' })
+    const newOwnerVault = await newOwnerDb.openVault(VAULT)
+    expect((await newOwnerVault.collection<Invoice>('invoices').get('inv-001'))?.amount).toBe(5000)
+
+    // The Deed marker records `liberatedAt`.
+    const marker = await loadDeedMarker(adapter, VAULT)
+    expect(typeof marker?.liberatedAt).toBe('string')
+  })
+
+  it('vault.custody.grantCustodian is owner-only (an admin caller is denied)', async () => {
+    const ownerDb = await provisionDeed()
+    await ownerDb.grant(VAULT, { userId: 'admin-01', displayName: 'Admin', role: 'admin', passphrase: 'admin-pass-long' })
+    const adminDb = await createNoydb({ store: adapter, user: 'admin-01', secret: 'admin-pass-long', policy: POLICY })
+    const adminVault = await adminDb.openVault(VAULT)
+    await expect(
+      adminVault.custody.grantCustodian({ userId: 'firm-99', displayName: 'Firm', passphrase: 'firm-pass-long' }),
+    ).rejects.toThrow(PermissionDeniedError)
+  })
+
+  it('vault.custody.liberate is denied to a non-custodian (owner caller)', async () => {
+    const ownerDb = await provisionDeed()
+    const ownerVault = await ownerDb.openVault(VAULT)
+    await expect(
+      ownerVault.custody.liberate({ newOwnerId: 'x', newOwnerPassphrase: 'x-pass-long', legalBasis: 'nope' }),
+    ).rejects.toThrow(PermissionDeniedError)
+  })
+})

--- a/packages/hub/__tests__/deed.test.ts
+++ b/packages/hub/__tests__/deed.test.ts
@@ -1,0 +1,141 @@
+/**
+ * FR-6 Task 3 — Deed marker + sealed-owner provisioning.
+ *
+ * A Deed vault has a latent owner: the owner credential is minted
+ * machine-side and sealed under a NON-FIRM {@link SealingKeyProvider}
+ * (the cryptographic inalienability anchor). The owner never types a
+ * passphrase — they re-resolve it through the same provider.
+ *
+ * The `_meta/deed` marker is PLAINTEXT metadata: it records WHO the
+ * latent owner is and WHICH sealing boundary protects them, so it must
+ * be readable without unlocking the vault. The marker itself is never
+ * sealed — the owner *credential* is.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+import { MemorySealingKeyProvider } from '../src/team/managed-passphrase.js'
+import {
+  createDeedOwner,
+  loadDeedMarker,
+  isDeedVault,
+  DEED_RECORD_ID,
+  type DeedMarker,
+} from '../src/team/deed.js'
+
+function inlineMemory(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const gc = (v: string, c: string) => {
+    let comp = data.get(v); if (!comp) { comp = new Map(); data.set(v, comp) }
+    let coll = comp.get(c); if (!coll) { coll = new Map(); comp.set(c, coll) }
+    return coll
+  }
+  return {
+    async get(v, c, id) { return gc(v, c).get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = gc(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { gc(v, c).delete(id) },
+    async list(v, c) { return [...gc(v, c).keys()] },
+    async loadAll() { return {} },
+    async saveAll() {},
+  }
+}
+
+describe('FR-6 Deed — sealed/latent owner provisioning', () => {
+  let store: NoydbStore
+  let provider: MemorySealingKeyProvider
+
+  beforeEach(() => {
+    store = inlineMemory()
+    provider = new MemorySealingKeyProvider({ id: 'client-kms' })
+  })
+
+  it('createDeedOwner returns an unlocked owner keyring', async () => {
+    const keyring = await createDeedOwner(store, 'deed-vault', 'client-01', provider)
+    expect(keyring.userId).toBe('client-01')
+    expect(keyring.role).toBe('owner')
+    // Owner is unlocked (KEK present — derived from the sealed passphrase).
+    expect(keyring.kek).not.toBeNull()
+  })
+
+  it('writes a plaintext _meta/deed marker describing the latent owner + sealing boundary', async () => {
+    const before = new Date().toISOString()
+    await createDeedOwner(store, 'deed-vault', 'client-01', provider)
+    const after = new Date().toISOString()
+
+    const marker = await loadDeedMarker(store, 'deed-vault')
+    expect(marker).not.toBeNull()
+    expect(marker!.ownerUserId).toBe('client-01')
+    expect(marker!.sealedUnder).toBe('client-kms')
+    expect(marker!.latent).toBe(true)
+    expect(typeof marker!.issuedAt).toBe('string')
+    expect(marker!.issuedAt >= before).toBe(true)
+    expect(marker!.issuedAt <= after).toBe(true)
+    expect(marker!.liberatedAt).toBeUndefined()
+  })
+
+  it('the marker is readable WITHOUT unlocking (plaintext metadata, not sealed)', async () => {
+    await createDeedOwner(store, 'deed-vault', 'client-01', provider)
+    // Read the raw envelope directly off the store and parse it as plain JSON.
+    const env = await store.get('deed-vault', '_meta', DEED_RECORD_ID)
+    expect(env).not.toBeNull()
+    const payload = JSON.parse(env!._data) as Record<string, unknown>
+    expect(payload['ownerUserId']).toBe('client-01')
+    expect(payload['sealedUnder']).toBe('client-kms')
+    expect(payload['latent']).toBe(true)
+  })
+
+  it('isDeedVault → true for a provisioned Deed vault', async () => {
+    await createDeedOwner(store, 'deed-vault', 'client-01', provider)
+    expect(await isDeedVault(store, 'deed-vault')).toBe(true)
+  })
+
+  it('isDeedVault → false for a vault with no deed marker', async () => {
+    expect(await isDeedVault(store, 'plain-vault')).toBe(false)
+    expect(await loadDeedMarker(store, 'plain-vault')).toBeNull()
+  })
+
+  it('the latent owner can be re-resolved via the SAME provider with no interactive passphrase', async () => {
+    // Provision the Deed owner once.
+    const first = await createDeedOwner(store, 'deed-vault', 'client-01', provider)
+    expect(first.role).toBe('owner')
+
+    // Re-resolve the sealed passphrase through the SAME provider — no human
+    // ever typed it. This is the latent-owner proof.
+    const { resolveManagedSecret } = await import('../src/team/managed-passphrase.js')
+    const reopenProvider = new MemorySealingKeyProvider({ id: 'client-kms' })
+    const passphrase = await resolveManagedSecret(store, 'deed-vault', reopenProvider)
+    expect(typeof passphrase).toBe('string')
+    expect(passphrase.length).toBeGreaterThan(0)
+
+    // Re-derive the owner KEK from the unsealed passphrase + persisted salt
+    // and confirm it unlocks the same keyring (canary verifies).
+    const { loadKeyring } = await import('../src/team/keyring.js')
+    const reopened = await loadKeyring(store, 'deed-vault', 'client-01', passphrase)
+    expect(reopened.userId).toBe('client-01')
+    expect(reopened.role).toBe('owner')
+    expect(reopened.kek).not.toBeNull()
+  })
+
+  it('a non-firm provider is the only anchor — a different provider id cannot re-resolve', async () => {
+    await createDeedOwner(store, 'deed-vault', 'client-01', provider)
+    const firmProvider = new MemorySealingKeyProvider({ id: 'firm-kms' })
+    const { resolveManagedSecret } = await import('../src/team/managed-passphrase.js')
+    await expect(
+      resolveManagedSecret(store, 'deed-vault', firmProvider),
+    ).rejects.toThrow()
+  })
+
+  it('DeedMarker shape (type-level sanity)', async () => {
+    await createDeedOwner(store, 'deed-vault', 'client-01', provider)
+    const marker = (await loadDeedMarker(store, 'deed-vault')) as DeedMarker
+    // Exhaustive read — proves the four required fields exist.
+    const { ownerUserId, sealedUnder, latent, issuedAt } = marker
+    expect([ownerUserId, sealedUnder, latent, issuedAt]).toEqual([
+      'client-01', 'client-kms', true, marker.issuedAt,
+    ])
+  })
+})

--- a/packages/hub/__tests__/liberate.test.ts
+++ b/packages/hub/__tests__/liberate.test.ts
@@ -1,0 +1,172 @@
+/**
+ * FR-6 Task 5 — `liberateVault`: the audited claim of ownership over a
+ * sealed-owner (Deed) vault. The inverse of #199 withdrawal.
+ *
+ * The **custodian** is the de-facto authority: it holds every collection DEK
+ * and operates the vault fully, but it can never reach `KEK_owner` (sealed
+ * under a non-firm provider). Liberation is the ONLY way a custodian assumes
+ * ownership — and it does so under an audited ceremony:
+ *
+ *   1. gate `'liberate-vault'` (fail-closed)
+ *   2. caller MUST be the `custodian`
+ *   3. freeze a PRE-liberation EVIDENCE snapshot (hash-pinned) — but the live
+ *      data is PRESERVED for the new owner (liberation transfers operational
+ *      continuity; it does NOT erase)
+ *   4. mint a NEW owner keyring re-wrapping the incumbent DEKs under the new
+ *      owner's KEK (the old sealed owner is NOT unsealed — the inalienability
+ *      floor is preserved; the new owner is a DISTINCT principal and the old
+ *      sealed-owner credential is orphaned, never impersonated)
+ *   5. lifecycle ledger `liberation-claimed:<newOwnerId>:<legalBasis>`
+ *   6. stamp `_meta/deed` marker `liberatedAt`
+ *
+ * FREEZE-vs-SNAPSHOT-ONLY DECISION (see liberate.ts + the plan §"Task 5"):
+ * `freezeAndDeleteClosure` (withdraw-accessible.ts) writes the hash-pinned
+ * snapshot then DELETES the live records. That is correct for a destructive
+ * withdrawal but WRONG for liberation, which must leave the live data intact
+ * for the new owner. We factored a snapshot-only helper `freezeSnapshotOnly`
+ * out of that module (the existing freeze-AND-delete path is unchanged); the
+ * test below asserts the live records SURVIVE the ceremony.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError, PermissionDeniedError } from '../src/errors.js'
+import { PolicyDeniedError } from '../src/policy/errors.js'
+import { createNoydb } from '../src/noydb.js'
+import type { Noydb } from '../src/noydb.js'
+import { withHistory } from '../src/history/index.js'
+import { saveDeedMarker, loadDeedMarker } from '../src/team/deed.js'
+import { liberateVault } from '../src/custody/liberate.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function bucket(v: string, c: string) {
+    let m = store.get(v); if (!m) { m = new Map(); store.set(v, m) }
+    let b = m.get(c); if (!b) { b = new Map(); m.set(c, b) }
+    return b
+  }
+  return {
+    async get(v, c, id) { return bucket(v, c).get(id) ?? null },
+    async put(v, c, id, env, ev) { const b = bucket(v, c); const ex = b.get(id); if (ev !== undefined && (ex?._v ?? 0) !== ev) throw new ConflictError(ex?._v ?? 0); b.set(id, env) },
+    async delete(v, c, id) { bucket(v, c).delete(id) },
+    async list(v, c) { return [...bucket(v, c).keys()] },
+    async loadAll(v) { const m = store.get(v); const s: VaultSnapshot = {}; if (m) for (const [n, c] of m) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of c) r[id] = e; s[n] = r } } return s },
+    async saveAll(v, data) { for (const [n, recs] of Object.entries(data)) { const b = bucket(v, n); for (const [id, e] of Object.entries(recs)) b.set(id, e) } },
+  }
+}
+
+interface Invoice { amount: number; status: string }
+
+const VAULT = 'C500'
+// `liberate-vault` is the fail-closed gate that authorises the ceremony.
+// `grant-custodian` is enabled so the owner can mint the custodian first.
+const POLICY = {
+  gates: {
+    'liberate-vault': { enabled: true, minTier: 1 },
+    'grant-custodian': { enabled: true, minTier: 1 },
+  },
+}
+
+describe('FR-6 Task 5 — liberateVault (audited custodian ownership claim)', () => {
+  let adapter: NoydbStore
+  let ownerDb: Noydb
+
+  /**
+   * Provision a Deed-flavoured vault (owner + a plaintext `_meta/deed` marker)
+   * with the history strategy enabled (so the lifecycle ledger is live), seed
+   * two collections, then grant a custodian.
+   */
+  async function provisionWithCustodian(policy: unknown = POLICY): Promise<void> {
+    ownerDb = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass', historyStrategy: withHistory(), ...(policy ? { policy } : {}) })
+    const comp = await ownerDb.openVault(VAULT)
+    await comp.collection<Invoice>('invoices').put('inv-001', { amount: 5000, status: 'draft' })
+    await comp.collection<Invoice>('payments').put('pay-001', { amount: 3000, status: 'paid' })
+    // Stamp a Deed marker so liberation has a marker to update with `liberatedAt`.
+    await saveDeedMarker(adapter, VAULT, {
+      ownerUserId: 'owner-01', sealedUnder: 'client-kms', latent: true, issuedAt: new Date().toISOString(),
+    })
+    await ownerDb.grantCustodian(VAULT, { userId: 'firm-01', displayName: 'Firm', passphrase: 'firm-pass-long' })
+  }
+
+  beforeEach(() => {
+    adapter = inlineMemory()
+  })
+
+  it('custodian liberates: snapshot pinned, ledger audited, live data preserved, new owner operates', async () => {
+    await provisionWithCustodian()
+
+    // The custodian opens + claims ownership.
+    const firmDb = await createNoydb({ store: adapter, user: 'firm-01', secret: 'firm-pass-long', historyStrategy: withHistory() })
+    const custodianVault = await firmDb.openVault(VAULT)
+
+    const result = await liberateVault(custodianVault, {
+      newOwnerId: 'firm-owner-01',
+      newOwnerPassphrase: 'firm-owner-pass-long',
+      legalBasis: 'contractual-handover',
+    })
+
+    // 1. evidence snapshot returned with a 64-hex sha256.
+    expect(result.snapshot.sha256).toMatch(/^[0-9a-f]{64}$/)
+    expect(result.snapshot.recordCount).toBeGreaterThan(0)
+    expect(typeof result.snapshot.frozenAt).toBe('string')
+
+    // 2. lifecycle ledger carries the liberation-claimed entry.
+    const entries = await custodianVault.ledger().entries()
+    const claimed = entries.filter(e => e.reason === 'liberation-claimed:firm-owner-01:contractual-handover')
+    expect(claimed).toHaveLength(1)
+
+    // 3. LIVE data is PRESERVED (liberation transfers continuity; it does NOT erase).
+    expect((await custodianVault.collection<Invoice>('invoices').get('inv-001'))?.amount).toBe(5000)
+    expect((await custodianVault.collection<Invoice>('payments').get('pay-001'))?.amount).toBe(3000)
+
+    // 4. the NEW owner is a DISTINCT principal who can open + operate as owner.
+    const newOwnerDb = await createNoydb({ store: adapter, user: 'firm-owner-01', secret: 'firm-owner-pass-long' })
+    const newOwnerVault = await newOwnerDb.openVault(VAULT)
+    expect((await newOwnerVault.collection<Invoice>('invoices').get('inv-001'))?.amount).toBe(5000)
+    await expect(
+      newOwnerVault.collection<Invoice>('invoices').put('inv-002', { amount: 1, status: 'new' }),
+    ).resolves.not.toThrow()
+    // The new owner can perform an owner-only meta-capability (grant) → proves owner role.
+    await expect(
+      newOwnerDb.grant(VAULT, { userId: 'staff-01', displayName: 'Staff', role: 'viewer', passphrase: 'staff-pass-long', permissions: { invoices: 'ro' } }),
+    ).resolves.not.toThrow()
+
+    // 5. the OLD sealed-owner credential is ORPHANED, not impersonated — the new
+    //    owner keyring is a separate `_keyring/<id>` file under a fresh KEK; the
+    //    original owner-01 keyring is untouched and still present.
+    expect(await adapter.get(VAULT, '_keyring', 'owner-01')).not.toBeNull()
+    expect(await adapter.get(VAULT, '_keyring', 'firm-owner-01')).not.toBeNull()
+
+    // 6. the Deed marker now records `liberatedAt`.
+    const marker = await loadDeedMarker(adapter, VAULT)
+    expect(typeof marker?.liberatedAt).toBe('string')
+  })
+
+  it('throws when the `liberate-vault` gate is disabled (fail-closed)', async () => {
+    // No policy → the `liberate-vault` built-in gate is unconfigured → fail-closed.
+    await provisionWithCustodian({ gates: { 'grant-custodian': { enabled: true, minTier: 1 } } })
+    const firmDb = await createNoydb({ store: adapter, user: 'firm-01', secret: 'firm-pass-long', historyStrategy: withHistory() })
+    const custodianVault = await firmDb.openVault(VAULT)
+    await expect(
+      liberateVault(custodianVault, { newOwnerId: 'firm-owner-01', newOwnerPassphrase: 'firm-owner-pass-long', legalBasis: 'contractual-handover' }),
+    ).rejects.toBeInstanceOf(PolicyDeniedError)
+  })
+
+  it('throws when the caller is NOT the custodian (owner tries)', async () => {
+    await provisionWithCustodian()
+    // The owner opens the vault and tries to liberate — only the custodian may.
+    const ownerVault = await ownerDb.openVault(VAULT)
+    await expect(
+      liberateVault(ownerVault, { newOwnerId: 'firm-owner-01', newOwnerPassphrase: 'firm-owner-pass-long', legalBasis: 'contractual-handover' }),
+    ).rejects.toBeInstanceOf(PermissionDeniedError)
+  })
+
+  it('throws when the caller is an operator (not the custodian)', async () => {
+    await provisionWithCustodian()
+    await ownerDb.grant(VAULT, { userId: 'op-01', displayName: 'Op', role: 'operator', passphrase: 'op-pass-long', permissions: { invoices: 'rw' } })
+    const opDb = await createNoydb({ store: adapter, user: 'op-01', secret: 'op-pass-long', historyStrategy: withHistory() })
+    const opVault = await opDb.openVault(VAULT)
+    await expect(
+      liberateVault(opVault, { newOwnerId: 'firm-owner-01', newOwnerPassphrase: 'firm-owner-pass-long', legalBasis: 'contractual-handover' }),
+    ).rejects.toBeInstanceOf(PermissionDeniedError)
+  })
+})

--- a/packages/hub/__tests__/liberate.test.ts
+++ b/packages/hub/__tests__/liberate.test.ts
@@ -169,4 +169,20 @@ describe('FR-6 Task 5 — liberateVault (audited custodian ownership claim)', ()
       liberateVault(opVault, { newOwnerId: 'firm-owner-01', newOwnerPassphrase: 'firm-owner-pass-long', legalBasis: 'contractual-handover' }),
     ).rejects.toBeInstanceOf(PermissionDeniedError)
   })
+
+  it('refuses to clobber an existing principal: newOwnerId must be a fresh id', async () => {
+    await provisionWithCustodian()
+    const firmDb = await createNoydb({ store: adapter, user: 'firm-01', secret: 'firm-pass-long', historyStrategy: withHistory() })
+    const custodianVault = await firmDb.openVault(VAULT)
+    // capture the existing owner-01 keyring envelope before the attempt
+    const before = await adapter.get(VAULT, '_keyring', 'owner-01')
+    // newOwnerId collides with the existing sealed owner → must throw, no clobber.
+    await expect(
+      liberateVault(custodianVault, { newOwnerId: 'owner-01', newOwnerPassphrase: 'whatever-long-pass', legalBasis: 'contractual-handover' }),
+    ).rejects.toBeInstanceOf(PermissionDeniedError)
+    // the original keyring is byte-identical (not overwritten) and no liberation ledger entry was written.
+    expect(await adapter.get(VAULT, '_keyring', 'owner-01')).toEqual(before)
+    const entries = await custodianVault.ledger().entries()
+    expect(entries.filter(e => e.reason?.startsWith('liberation-claimed:'))).toHaveLength(0)
+  })
 })

--- a/packages/hub/src/bundle/extract-partition.ts
+++ b/packages/hub/src/bundle/extract-partition.ts
@@ -252,6 +252,11 @@ export async function extractPartition(
     readonly carryLedger?: boolean
   },
 ): Promise<ExtractPartitionResult> {
+  // FR-6: owner-only is exactly right for custody — a custodian is NOT owner,
+  // so it already fails here ('custodian' is reported in the message). This is
+  // the extract-and-sever half of the inalienability floor; Task 2 adds the
+  // explicit denial assertion against this branch (no code change needed —
+  // documented here so the audit shows it was considered, not missed).
   if (vault.role !== 'owner') {
     throw new PartitionExtractionError(
       `extractPartition requires the 'owner' role on the source vault; caller is '${vault.role}'. `

--- a/packages/hub/src/bundle/extract-partition.ts
+++ b/packages/hub/src/bundle/extract-partition.ts
@@ -252,11 +252,16 @@ export async function extractPartition(
     readonly carryLedger?: boolean
   },
 ): Promise<ExtractPartitionResult> {
-  // FR-6: owner-only is exactly right for custody — a custodian is NOT owner,
-  // so it already fails here ('custodian' is reported in the message). This is
-  // the extract-and-sever half of the inalienability floor; Task 2 adds the
-  // explicit denial assertion against this branch (no code change needed —
-  // documented here so the audit shows it was considered, not missed).
+  // FR-6: extract-and-sever is the inalienability-floor half — owner-only. A
+  // custodian operates fully but must NEVER produce a standalone re-keyed
+  // partition (that would let it sever a copy out from under the sealed owner).
+  // Explicit assertion so the security boundary is auditable at this site.
+  if (vault.role === 'custodian') {
+    throw new PartitionExtractionError(
+      'extractPartition is owner-only; a custodian cannot extract-and-sever '
+      + '(FR-6: producing a re-keyed standalone partition is an ownership operation; use the Deed owner).',
+    )
+  }
   if (vault.role !== 'owner') {
     throw new PartitionExtractionError(
       `extractPartition requires the 'owner' role on the source vault; caller is '${vault.role}'. `

--- a/packages/hub/src/bundle/request-withdrawal.ts
+++ b/packages/hub/src/bundle/request-withdrawal.ts
@@ -136,6 +136,10 @@ export async function listWithdrawalRequests(
 
 function assertApprover(vault: Vault): string {
   const { keyring } = vault._introspectState()
+  // FR-6: custodian is INTENTIONALLY excluded (SAFER default — review flag).
+  // Approving a two-party withdrawal is a destructive extract-and-dispose
+  // exercised under FIRM authority — a governance act adjacent to grant/revoke,
+  // which a non-owning custodian cannot do. It stays owner/admin-only.
   if (keyring.role !== 'owner' && keyring.role !== 'admin') {
     throw new WithdrawalRequestError('approveWithdrawal / rejectWithdrawal require an owner or admin')
   }

--- a/packages/hub/src/bundle/withdraw-accessible.ts
+++ b/packages/hub/src/bundle/withdraw-accessible.ts
@@ -128,6 +128,14 @@ export async function withdrawAccessibleData(
       'unilateralWithdrawal is the scoped self-service path; an owner/admin should use extractPartition',
     )
   }
+  // TODO(FR-6 Task 2): add an explicit `custodian` branch here that throws and
+  //   points the caller to `vault.custody.liberate` — a custodian must NOT
+  //   destructively SEVER the vault; it claims ownership via the audited
+  //   Liberate ceremony. Today a custodian falls through to the operator path
+  //   below and is rejected by the "requires rw access on scope" guard
+  //   (resolveAccessibleCollections returns undefined for custodian → no
+  //   collections), so it cannot self-serve a sever — but the message is
+  //   wrong. Task 2 replaces this with a dedicated, correctly-worded branch.
   // client/viewer are read-only by construction (see hasWritePermission): a
   // destructive withdrawal they cannot self-serve — they use the two-party
   // requestWithdrawal flow where firm authority executes the delete-closure.

--- a/packages/hub/src/bundle/withdraw-accessible.ts
+++ b/packages/hub/src/bundle/withdraw-accessible.ts
@@ -128,14 +128,16 @@ export async function withdrawAccessibleData(
       'unilateralWithdrawal is the scoped self-service path; an owner/admin should use extractPartition',
     )
   }
-  // TODO(FR-6 Task 2): add an explicit `custodian` branch here that throws and
-  //   points the caller to `vault.custody.liberate` — a custodian must NOT
-  //   destructively SEVER the vault; it claims ownership via the audited
-  //   Liberate ceremony. Today a custodian falls through to the operator path
-  //   below and is rejected by the "requires rw access on scope" guard
-  //   (resolveAccessibleCollections returns undefined for custodian → no
-  //   collections), so it cannot self-serve a sever — but the message is
-  //   wrong. Task 2 replaces this with a dedicated, correctly-worded branch.
+  // FR-6: a custodian must NOT destructively SEVER the vault. It holds the DEKs
+  // and operates fully, but ownership is claimed only through the audited
+  // Liberate ceremony — never by a one-sided delete/freeze withdrawal. Fires
+  // BEFORE the operator rw-scope path below (where a custodian would otherwise
+  // be rejected with the wrong "requires rw access" message).
+  if (keyring.role === 'custodian') {
+    throw new ReadOnlyError(
+      'a custodian cannot destructively withdraw/sever; use vault.custody.liberate for an audited ownership claim',
+    )
+  }
   // client/viewer are read-only by construction (see hasWritePermission): a
   // destructive withdrawal they cannot self-serve — they use the two-party
   // requestWithdrawal flow where firm authority executes the delete-closure.

--- a/packages/hub/src/bundle/withdraw-accessible.ts
+++ b/packages/hub/src/bundle/withdraw-accessible.ts
@@ -56,6 +56,59 @@ export interface WithdrawResult {
 }
 
 /**
+ * Freeze a write-once, hash-pinned snapshot of the current ciphertext for
+ * `collections` WITHOUT touching the live records. Returns the snapshot ref.
+ *
+ * This is the non-destructive core shared by two callers:
+ *  - `freezeAndDeleteClosure` (#199 withdrawal, disposition `'freeze'`) — which
+ *    pins the snapshot and THEN delete-closures the live records.
+ *  - FR-6 `liberateVault` (custody) — which pins a PRE-liberation evidence
+ *    snapshot but PRESERVES the live data for the new owner (operational
+ *    continuity; liberation transfers, it does not erase).
+ *
+ * The snapshot put is write-once (CAS expectedVersion 0) and the ledger pin is
+ * appended on success, so a crashed run re-run with the same `withdrawalId` is
+ * safe. The snapshot is taken under the vault's own firm-owned DEKs — no re-key.
+ */
+export async function freezeSnapshotOnly(
+  vault: Vault,
+  collections: readonly string[],
+  opts: { actorUserId: string; withdrawalId?: string },
+): Promise<FrozenSnapshotRef> {
+  const { name: vaultName, adapter } = vault._introspectState()
+
+  // Enumerate the closure (record ids per collection).
+  const closure: Array<{ collection: string; id: string }> = []
+  for (const c of collections) {
+    for (const id of await adapter.list(vaultName, c)) closure.push({ collection: c, id })
+  }
+
+  const withdrawalId = opts.withdrawalId ?? `wd-${randomId()}`
+  const snap: Record<string, Record<string, unknown>> = {}
+  for (const { collection, id } of closure) {
+    const env = await adapter.get(vaultName, collection, id)
+    if (env) (snap[collection] ??= {})[id] = env
+  }
+  const frozenAt = new Date().toISOString()
+  const body = JSON.stringify({ withdrawalId, frozenAt, by: opts.actorUserId, collections: snap })
+  const sha = await sha256Hex(ENC.encode(body))
+  // Write-once: expectedVersion 0 rejects an overwrite (idempotent resume).
+  await adapter.put(
+    vaultName,
+    FROZEN_SNAPSHOTS_COLLECTION,
+    withdrawalId,
+    { _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: frozenAt, _iv: '', _data: body, _by: opts.actorUserId },
+    0,
+  )
+  // Hash-pin into the tamper-evident ledger — makes the snapshot provably unaltered.
+  await vault._getLedgerOrNull()?.append({
+    op: 'lifecycle', collection: '', id: '', version: 0, actor: opts.actorUserId, payloadHash: '',
+    reason: `withdrawal-frozen-snapshot:${withdrawalId}:${sha}`,
+  })
+  return { withdrawalId, sha256: sha, recordCount: closure.length, frozenAt }
+}
+
+/**
  * Dispose of the source records for `collections`: optionally freeze a
  * write-once hash-pinned snapshot of the original ciphertext, then
  * delete-closure the live records. Returns the snapshot ref on freeze.
@@ -70,46 +123,21 @@ export async function freezeAndDeleteClosure(
   collections: readonly string[],
   opts: { disposition: 'delete' | 'freeze'; actorUserId: string; withdrawalId?: string },
 ): Promise<FrozenSnapshotRef | undefined> {
-  const { name: vaultName, adapter } = vault._introspectState()
-
-  // Enumerate the closure (record ids per collection).
-  const closure: Array<{ collection: string; id: string }> = []
-  for (const c of collections) {
-    for (const id of await adapter.list(vaultName, c)) closure.push({ collection: c, id })
-  }
-
-  // freeze: copy current envelopes into a write-once, hash-pinned snapshot
-  // (under the vault's own firm-owned DEKs — no re-key needed).
-  let snapshot: FrozenSnapshotRef | undefined
-  if (opts.disposition === 'freeze') {
-    const withdrawalId = opts.withdrawalId ?? `wd-${randomId()}`
-    const snap: Record<string, Record<string, unknown>> = {}
-    for (const { collection, id } of closure) {
-      const env = await adapter.get(vaultName, collection, id)
-      if (env) (snap[collection] ??= {})[id] = env
-    }
-    const frozenAt = new Date().toISOString()
-    const body = JSON.stringify({ withdrawalId, frozenAt, by: opts.actorUserId, collections: snap })
-    const sha = await sha256Hex(ENC.encode(body))
-    // Write-once: expectedVersion 0 rejects an overwrite (idempotent resume).
-    await adapter.put(
-      vaultName,
-      FROZEN_SNAPSHOTS_COLLECTION,
-      withdrawalId,
-      { _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: frozenAt, _iv: '', _data: body, _by: opts.actorUserId },
-      0,
-    )
-    // Hash-pin into the tamper-evident ledger — makes the snapshot provably unaltered.
-    await vault._getLedgerOrNull()?.append({
-      op: 'lifecycle', collection: '', id: '', version: 0, actor: opts.actorUserId, payloadHash: '',
-      reason: `withdrawal-frozen-snapshot:${withdrawalId}:${sha}`,
-    })
-    snapshot = { withdrawalId, sha256: sha, recordCount: closure.length, frozenAt }
-  }
+  // freeze: pin a write-once, hash-pinned snapshot BEFORE any delete. The
+  // snapshot-only core is shared with FR-6 liberation (which never deletes).
+  const snapshot = opts.disposition === 'freeze'
+    ? await freezeSnapshotOnly(vault, collections, {
+        actorUserId: opts.actorUserId,
+        ...(opts.withdrawalId ? { withdrawalId: opts.withdrawalId } : {}),
+      })
+    : undefined
 
   // delete-closure — only after the snapshot is durable.
-  for (const { collection, id } of closure) {
-    await vault.collection(collection).delete(id)
+  const { name: vaultName, adapter } = vault._introspectState()
+  for (const c of collections) {
+    for (const id of await adapter.list(vaultName, c)) {
+      await vault.collection(c).delete(id)
+    }
   }
 
   return snapshot

--- a/packages/hub/src/custody/index.ts
+++ b/packages/hub/src/custody/index.ts
@@ -1,0 +1,73 @@
+/**
+ * Public `vault.custody.*` API surface (FR-6).
+ *
+ * The custody namespace is the vault-instance face of the FR-6 sovereign-custody
+ * model — it mirrors `vault.user.*` exactly: a thin delegation shell with NO
+ * business logic. The Vault constructs one `CustodyApi` per session, injecting
+ * closures that bind the vault name / keyring into the genuinely-core
+ * implementations (`Noydb.grantCustodian` / `Noydb.revokeCustodian` and the
+ * `liberateVault` ceremony). Each method just forwards to its injected callback.
+ *
+ * Three operations:
+ *  - `grantCustodian(opts)` — owner-only: mint a `custodian` who operates the
+ *    vault fully but can never grant / rotate / sever / extract.
+ *  - `revokeCustodian(opts)` — owner-only: remove a custodian.
+ *  - `liberate(opts)` — custodian-only: audited claim of ownership over a
+ *    sealed-owner (Deed) vault (mints a DISTINCT new owner; ledger-audited).
+ *
+ * Provisioning a Deed (`createDeedOwner`) is deliberately NOT on this class: it
+ * is a store-level operation that mints the vault's first owner, so there is no
+ * vault instance (and thus no custody namespace) yet — it stays the exported
+ * `team/deed.ts` function.
+ *
+ * @see docs/superpowers/specs/2026-06-17-fr6-deed-custodian-liberate-design.md
+ * @module
+ */
+import type { GrantOptions, RevokeOptions } from '../types.js'
+import type { FactorProofBundle } from '../policy/types.js'
+import type { LiberateOptions, LiberateResult } from './liberate.js'
+
+/** Options for `vault.custody.grantCustodian` — a grant with the role fixed to `custodian`. */
+export type GrantCustodianOptions = Omit<GrantOptions, 'role'>
+
+/**
+ * Implementation behind `vault.custody`. Constructed once per Vault. Holds the
+ * injected, vault-bound implementations in closure; every method delegates with
+ * no added logic (the owner-only / custodian-only / gate checks all live in the
+ * injected implementations — `Noydb.grantCustodian` etc. and `liberateVault`).
+ */
+export class CustodyApi {
+  constructor(
+    /** Bound `Noydb.grantCustodian(this.name, ...)` — owner-only, gated. */
+    private readonly _grantCustodian: (options: GrantCustodianOptions, factors?: FactorProofBundle) => Promise<void>,
+    /** Bound `Noydb.revokeCustodian(this.name, ...)` — owner-only, gated. */
+    private readonly _revokeCustodian: (options: RevokeOptions, factors?: FactorProofBundle) => Promise<void>,
+    /** Bound `liberateVault(this, ...)` — custodian-only audited ownership claim. */
+    private readonly _liberate: (opts: LiberateOptions) => Promise<LiberateResult>,
+  ) {}
+
+  /**
+   * Owner-only: grant the FR-6 `custodian` role. The custodian operates every
+   * collection (rw + access) but is provably unable to grant / revoke / rotate /
+   * extract-and-sever. Defended in depth (gate + owner-only role check) inside
+   * the injected `Noydb.grantCustodian`.
+   */
+  async grantCustodian(options: GrantCustodianOptions, factors?: FactorProofBundle): Promise<void> {
+    return this._grantCustodian(options, factors)
+  }
+
+  /** Owner-only: revoke a custodian. */
+  async revokeCustodian(options: RevokeOptions, factors?: FactorProofBundle): Promise<void> {
+    return this._revokeCustodian(options, factors)
+  }
+
+  /**
+   * Custodian-only: the audited claim of ownership over a sealed-owner (Deed)
+   * vault. Mints a DISTINCT new owner re-wrapping the incumbent DEKs under a
+   * fresh KEK (the latent owner is never impersonated), ledger-audited. See
+   * {@link liberateVault}.
+   */
+  async liberate(opts: LiberateOptions): Promise<LiberateResult> {
+    return this._liberate(opts)
+  }
+}

--- a/packages/hub/src/custody/liberate.ts
+++ b/packages/hub/src/custody/liberate.ts
@@ -86,6 +86,16 @@ export async function liberateVault(
     )
   }
 
+  // Refuse to clobber an existing principal: the new owner must be a FRESH id.
+  // (Checked before any side effect so a colliding id never leaves a half-run
+  //  ceremony — no orphan snapshot, no partial keyring overwrite.)
+  const existing = await adapter.get(vaultName, '_keyring', opts.newOwnerId)
+  if (existing) {
+    throw new PermissionDeniedError(
+      `liberateVault: newOwnerId "${opts.newOwnerId}" already exists as a principal; choose a fresh id (liberation mints a distinct owner, it never overwrites an existing keyring)`,
+    )
+  }
+
   // 3. Pre-liberation EVIDENCE snapshot of every operational collection —
   //    snapshot-only (live data preserved for the new owner; liberation
   //    transfers operational continuity, it does not erase).

--- a/packages/hub/src/custody/liberate.ts
+++ b/packages/hub/src/custody/liberate.ts
@@ -1,0 +1,140 @@
+/**
+ * FR-6 Task 5 — `liberateVault`: the audited claim of ownership over a
+ * sealed-owner (Deed) vault. The inverse of #199 withdrawal.
+ *
+ * A **Deed** vault's owner credential is sealed under a non-firm provider, so
+ * the firm-side **custodian** (which holds every collection DEK and operates
+ * the vault fully) can never reach `KEK_owner`. Liberation is the ONLY route
+ * by which a custodian assumes ownership, and it is deliberately a manual,
+ * audited ceremony:
+ *
+ *   1. gate `'liberate-vault'` (fail-closed)
+ *   2. caller MUST be the `custodian` (the de-facto authority holding the DEKs)
+ *   3. freeze a PRE-liberation EVIDENCE snapshot (hash-pinned in the ledger) —
+ *      but PRESERVE the live data for the new owner (see the freeze decision
+ *      below)
+ *   4. mint a NEW owner keyring re-wrapping the incumbent DEKs under the new
+ *      owner's KEK
+ *   5. lifecycle ledger `liberation-claimed:<newOwnerId>:<legalBasis>`
+ *   6. stamp the `_meta/deed` marker with `liberatedAt`
+ *
+ * ## Security: the inalienability floor
+ *
+ * Liberation **mints a new owner from the custodian's DEKs** — it does NOT
+ * unseal the original sealed owner. The old sealed-owner credential is left
+ * untouched and ORPHANED (its `_keyring/<id>` file remains, its KEK is still
+ * sealed under the non-firm provider), never impersonated. The new owner is a
+ * DISTINCT principal under a fresh KEK derived from `newOwnerPassphrase`. This
+ * preserves the inalienability floor: the act of claiming ownership is itself
+ * auditable and produces a different principal, rather than silently assuming
+ * the latent owner's identity.
+ *
+ * ## Freeze decision: snapshot-only, not freeze-and-delete
+ *
+ * `freezeAndDeleteClosure` (withdraw-accessible.ts) writes a hash-pinned
+ * snapshot and THEN delete-closures the live records — correct for a
+ * destructive #199 withdrawal, WRONG for liberation. Liberation transfers
+ * operational continuity; it must leave the live data intact for the new
+ * owner. We therefore call the snapshot-only core `freezeSnapshotOnly`
+ * (factored out of that module; the freeze-AND-delete withdrawal path is
+ * unchanged) to pin the evidence snapshot while preserving the records.
+ *
+ * @module
+ */
+
+import type { Vault } from '../vault.js'
+import type { FactorProofBundle } from '../policy/types.js'
+import type { KeyringFile } from '../types.js'
+import { PermissionDeniedError } from '../errors.js'
+import { wrapKey } from '../crypto.js'
+import { createOwnerKeyring } from '../team/keyring.js'
+import type { FrozenSnapshotRef } from '../bundle/withdraw-accessible.js'
+import { freezeSnapshotOnly } from '../bundle/withdraw-accessible.js'
+import { loadDeedMarker, saveDeedMarker } from '../team/deed.js'
+
+export interface LiberateOptions {
+  /** The id of the new owner principal the custodian mints by claiming ownership. */
+  readonly newOwnerId: string
+  /** The passphrase that derives the new owner's KEK (the DEKs are re-wrapped under it). */
+  readonly newOwnerPassphrase: string
+  /** Legal/contractual basis recorded in the audit (e.g. 'contractual-handover'). */
+  readonly legalBasis: string
+  readonly factors?: FactorProofBundle
+}
+
+export interface LiberateResult {
+  /** The hash-pinned pre-liberation evidence snapshot. */
+  readonly snapshot: FrozenSnapshotRef
+}
+
+/**
+ * Audited claim of ownership over a sealed-owner vault by its custodian. See
+ * the module doc for the full ceremony + security rationale.
+ */
+export async function liberateVault(
+  vault: Vault,
+  opts: LiberateOptions,
+): Promise<LiberateResult> {
+  // 1. gate — fail-closed `liberate-vault`.
+  await vault.noydb.checkGate(vault.name, 'liberate-vault', opts.factors)
+
+  // 2. caller must be the custodian (the de-facto authority holding the DEKs).
+  const { name: vaultName, adapter, keyring } = vault._introspectState()
+  if (keyring.role !== 'custodian') {
+    throw new PermissionDeniedError(
+      'liberation is claimed only by the custodian (the de-facto authority holding the DEKs)',
+    )
+  }
+
+  // 3. Pre-liberation EVIDENCE snapshot of every operational collection —
+  //    snapshot-only (live data preserved for the new owner; liberation
+  //    transfers operational continuity, it does not erase).
+  const collections = await listOperationalCollections(vault)
+  const snapshot = await freezeSnapshotOnly(vault, collections, { actorUserId: keyring.userId })
+
+  // 4. Mint a NEW owner keyring, re-wrapping the incumbent DEKs under the new
+  //    owner's fresh KEK. The old sealed owner is NOT unsealed — a DISTINCT
+  //    principal is minted and the original owner credential is left orphaned
+  //    (inalienability floor). Mirrors adopt-partition.ts's DEK re-wrap.
+  const newOwner = await createOwnerKeyring(adapter, vaultName, opts.newOwnerId, opts.newOwnerPassphrase)
+  if (!newOwner.kek) {
+    throw new PermissionDeniedError(
+      `new owner keyring for "${opts.newOwnerId}" has no KEK to re-wrap the incumbent DEKs under`,
+    )
+  }
+  const env = await adapter.get(vaultName, '_keyring', opts.newOwnerId)
+  if (!env) {
+    throw new PermissionDeniedError(`new owner keyring for "${opts.newOwnerId}" did not persist`)
+  }
+  const keyringFile = JSON.parse(env._data) as KeyringFile
+  const mergedDeks: Record<string, string> = { ...keyringFile.deks }
+  for (const [collection, dek] of keyring.deks) {
+    mergedDeks[collection] = await wrapKey(dek, newOwner.kek)
+  }
+  const mergedFile: KeyringFile = { ...keyringFile, deks: mergedDeks }
+  await adapter.put(vaultName, '_keyring', opts.newOwnerId, { ...env, _data: JSON.stringify(mergedFile) })
+
+  // 5. Lifecycle ledger audit (no-op if the history strategy is absent).
+  await vault._getLedgerOrNull()?.append({
+    op: 'lifecycle', collection: '', id: '', version: 0, actor: opts.newOwnerId, payloadHash: '',
+    reason: `liberation-claimed:${opts.newOwnerId}:${opts.legalBasis}`,
+  })
+
+  // 6. Stamp the Deed marker with `liberatedAt` (if a marker exists).
+  const marker = await loadDeedMarker(adapter, vaultName)
+  if (marker) {
+    await saveDeedMarker(adapter, vaultName, { ...marker, liberatedAt: new Date().toISOString() })
+  }
+
+  return { snapshot }
+}
+
+/**
+ * Enumerate the vault's operational (user-facing) collections — those carried
+ * by the caller's keyring DEK map, minus the reserved internal collections
+ * (`_*`). These are the collections frozen into the evidence snapshot.
+ */
+async function listOperationalCollections(vault: Vault): Promise<readonly string[]> {
+  const { keyring } = vault._introspectState()
+  return [...keyring.deks.keys()].filter((c) => !c.startsWith('_'))
+}

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -560,6 +560,14 @@ export type {
 } from './meta/user-envelope/api.js'
 export { UserApi } from './meta/user-envelope/api.js'
 
+// FR-6 sovereign custody — Deed / Custodian / Liberate.
+export { CustodyApi } from './custody/index.js'
+export type { GrantCustodianOptions } from './custody/index.js'
+export { liberateVault } from './custody/liberate.js'
+export type { LiberateOptions, LiberateResult } from './custody/liberate.js'
+export { createDeedOwner, loadDeedMarker, isDeedVault, DEED_RECORD_ID } from './team/deed.js'
+export type { DeedMarker } from './team/deed.js'
+
 // Auth introspection
 export {
   describeAuthConfig,

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -142,6 +142,12 @@ const ROLE_RANK: Record<Role, number> = {
   client: 1,
   viewer: 2,
   operator: 3,
+  // FR-6: custodian is operationally admin-rank (rw + access on every
+  // collection) — it ranks alongside admin for "how much can this
+  // principal see/operate." It is NOT above admin, and explicitly below
+  // owner: a custodian can never grant/revoke/rotate/sever (those are
+  // owner meta-capabilities), so it must not outrank or equal the owner.
+  custodian: 4,
   admin: 4,
   owner: 5,
 }

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -749,6 +749,47 @@ export class Noydb {
   }
 
   /**
+   * Grant the FR-6 `custodian` role to a user (owner-only custody API).
+   *
+   * A custodian operates every collection (rw + access) but is provably
+   * unable to grant / revoke / rotate / extract-and-sever. Only the Deed
+   * owner may mint one. Defended in depth: the `grant-custodian` gate
+   * (fail-closed) AND an explicit `keyring.role !== 'owner'` check — the
+   * gate enforces host policy, the role check enforces the cryptographic
+   * owner-only invariant even if a host mis-configures the gate.
+   */
+  async grantCustodian(
+    vault: string,
+    options: Omit<GrantOptions, 'role'>,
+    factors?: FactorProofBundle,
+  ): Promise<void> {
+    this.checkPolicyOperation(vault, 'grant')
+    await this.checkGate(vault, 'grant-custodian', factors)
+    const keyring = await this.getKeyringInternal(vault)
+    if (keyring.role !== 'owner') throw new PermissionDeniedError('only the Deed owner can grant a custodian')
+    await keyringGrant(this.options.store, vault, keyring, { ...options, role: 'custodian' })
+  }
+
+  /**
+   * Revoke a custodian (owner-only custody API).
+   *
+   * Mirrors {@link revoke} but pins the caller to the Deed owner: defended
+   * in depth by the `revoke-user` gate AND an explicit `keyring.role !==
+   * 'owner'` check, so an admin cannot unwind a custodianship.
+   */
+  async revokeCustodian(
+    vault: string,
+    options: RevokeOptions,
+    factors?: FactorProofBundle,
+  ): Promise<void> {
+    this.checkPolicyOperation(vault, 'revoke')
+    await this.checkGate(vault, 'revoke-user', factors)
+    const keyring = await this.getKeyringInternal(vault)
+    if (keyring.role !== 'owner') throw new PermissionDeniedError('only the Deed owner can revoke a custodian')
+    await keyringRevoke(this.options.store, vault, keyring, options)
+  }
+
+  /**
    * Mutate post-grant identity fields on an existing keyring — `role`,
    * `displayName`, and/or `permissions`. Pure plaintext-header rewrite:
    * no DEK rewrap, no KEK required, no authenticator slots touched.

--- a/packages/hub/src/policy/types.ts
+++ b/packages/hub/src/policy/types.ts
@@ -165,6 +165,23 @@ export type BuiltInGateName =
    * defaults to a tier-2 floor; owner/admin role is enforced structurally.
    */
   | 'approve-user-withdrawal'
+  /**
+   * Authorize minting a **custodian** — `db.grantCustodian` (FR-6). The
+   * custodian is the de-facto operational authority on a sealed-owner (Deed)
+   * vault, so granting one is an ownership-level act: this gate MUST fail
+   * closed (undefined in a policy = denied) and owner-only role is enforced
+   * structurally. Hosts opt in explicitly, typically pinning factor proofs.
+   */
+  | 'grant-custodian'
+  /**
+   * Authorize the audited **Liberate** ceremony — `vault.custody.liberate`
+   * (FR-6). The custodian (holding the live DEKs) claims ownership of a
+   * sealed-owner vault under a recorded legal basis, minting a NEW owner
+   * keyring. Destructive-of-the-old-ownership and irreversible, so it MUST
+   * fail closed (undefined = denied); the caller-is-custodian check is
+   * enforced structurally in the ceremony.
+   */
+  | 'liberate-vault'
 
 /** Either a built-in gate name or an `app:*` custom gate. */
 export type GateName = BuiltInGateName | `app:${string}`

--- a/packages/hub/src/team/deed.ts
+++ b/packages/hub/src/team/deed.ts
@@ -1,0 +1,192 @@
+/**
+ * FR-6 — Deed: sealed / hidden-owner provisioning.
+ *
+ * A **Deed** is a vault owned by a *latent* principal who never
+ * authenticates. The owner credential (the random passphrase that
+ * derives `KEK_owner`) is minted machine-side and sealed under a
+ * **non-firm** {@link SealingKeyProvider} — that sealing boundary is
+ * the cryptographic *inalienability anchor*: whoever holds the
+ * provider (the client / their KMS) is the only party that can ever
+ * re-derive `KEK_owner`. A firm-side custodian operates the vault
+ * fully but can never reach the owner key — there is deliberately NO
+ * firm-controlled fallback.
+ *
+ * Provisioning reuses the managed-mode seam:
+ *   - {@link resolveManagedSecret} mints + seals + persists the random
+ *     passphrase at `_meta/sealed-passphrase` (and unseals it on every
+ *     subsequent open through the same provider).
+ *   - {@link createOwnerKeyring} derives `KEK_owner` from that
+ *     passphrase and writes the `_keyring/<ownerUserId>` file.
+ *
+ * On top of that, a Deed writes a `_meta/deed` **marker**. The marker
+ * is PLAINTEXT metadata — it records WHO the latent owner is and WHICH
+ * sealing boundary protects them, so it must be readable without
+ * unlocking the vault (a custodian or auditor inspecting the vault must
+ * be able to see "this is a Deed vault, owner = X, sealed under Y"
+ * without any key). The marker itself is therefore never sealed; only
+ * the owner *credential* is.
+ *
+ * @module
+ */
+
+import type { NoydbStore, EncryptedEnvelope } from '../types.js'
+import { NOYDB_FORMAT_VERSION } from '../types.js'
+import type { UnlockedKeyring } from './keyring.js'
+import { createOwnerKeyring } from './keyring.js'
+import type { SealingKeyProvider } from './managed-passphrase.js'
+import { resolveManagedSecret } from './managed-passphrase.js'
+
+/** Reserved id for the Deed marker under `_meta`. */
+export const DEED_RECORD_ID = 'deed' as const
+
+/**
+ * Plaintext metadata recording a vault's latent-owner Deed. Persisted
+ * at `_meta/deed`. Readable without unlocking the vault by design — it
+ * carries no secret material, only the identity of the latent owner
+ * and the sealing boundary that anchors inalienability.
+ */
+export interface DeedMarker {
+  /** The latent owner principal — the user id of the `_keyring/<id>` owner file. */
+  readonly ownerUserId: string
+  /**
+   * The `SealingKeyProvider.id` the owner credential is sealed under.
+   * The inalienability anchor: only the holder of this (non-firm)
+   * provider can re-derive `KEK_owner`. Audit metadata — never secret.
+   */
+  readonly sealedUnder: string
+  /** Always `true` for a Deed — the owner never authenticates interactively. */
+  readonly latent: true
+  /** ISO-8601 timestamp the Deed was issued. */
+  readonly issuedAt: string
+  /**
+   * ISO-8601 timestamp the vault was liberated (a new owner claimed it
+   * via the audited Liberate ceremony), if any. Absent until liberation.
+   */
+  readonly liberatedAt?: string
+}
+
+/**
+ * Wire-format payload stored inside the `_meta/deed` envelope. Carries
+ * a magic marker for forensics + the {@link DeedMarker} fields. JSON,
+ * AES-GCM bypassed (the marker is plaintext metadata by design).
+ */
+interface DeedEnvelopePayload extends DeedMarker {
+  readonly _noydb_deed: 1
+}
+
+/**
+ * Provision a Deed: a latent owner whose credential is sealed under
+ * `sealing` (a NON-firm provider). Mints + seals the owner passphrase
+ * via {@link resolveManagedSecret}, derives the owner keyring via
+ * {@link createOwnerKeyring}, then writes the plaintext `_meta/deed`
+ * marker. Returns the unlocked owner keyring.
+ *
+ * The returned keyring is the only in-memory window onto `KEK_owner`
+ * for this call; the persistent re-entry point is the sealing provider
+ * (re-run {@link resolveManagedSecret} with the same provider to
+ * re-resolve the passphrase, then {@link createOwnerKeyring}/load to
+ * unlock — no interactive passphrase is ever required).
+ *
+ * There is deliberately no firm-controlled fallback: the marker's
+ * `sealedUnder` is the single cryptographic anchor of ownership.
+ */
+export async function createDeedOwner(
+  store: NoydbStore,
+  vault: string,
+  ownerUserId: string,
+  sealing: SealingKeyProvider,
+): Promise<UnlockedKeyring> {
+  // 1. Mint + seal + persist the random owner passphrase under the
+  //    non-firm provider (writes _meta/sealed-passphrase).
+  const passphrase = await resolveManagedSecret(store, vault, sealing)
+
+  // 2. Derive KEK_owner from the (never-human-seen) passphrase and
+  //    write the owner keyring file.
+  const keyring = await createOwnerKeyring(store, vault, ownerUserId, passphrase)
+
+  // 3. Write the plaintext Deed marker. NOT sealed — it is audit
+  //    metadata that must be readable without unlocking.
+  await saveDeedMarker(store, vault, {
+    ownerUserId,
+    sealedUnder: sealing.id,
+    latent: true,
+    issuedAt: new Date().toISOString(),
+  })
+
+  return keyring
+}
+
+/**
+ * Read the {@link DeedMarker} from `_meta/deed`, or `null` if the vault
+ * has no Deed marker (i.e. it is not a Deed vault). Plaintext read — no
+ * unlocking required.
+ */
+export async function loadDeedMarker(
+  store: NoydbStore,
+  vault: string,
+): Promise<DeedMarker | null> {
+  const envelope = await store.get(vault, '_meta', DEED_RECORD_ID)
+  if (!envelope) return null
+  let payload: unknown
+  try {
+    payload = JSON.parse(envelope._data)
+  } catch {
+    return null
+  }
+  if (typeof payload !== 'object' || payload === null) return null
+  const r = payload as Record<string, unknown>
+  if (r._noydb_deed !== 1) return null
+  if (
+    typeof r.ownerUserId !== 'string'
+    || typeof r.sealedUnder !== 'string'
+    || r.latent !== true
+    || typeof r.issuedAt !== 'string'
+  ) {
+    return null
+  }
+  const marker: DeedMarker = {
+    ownerUserId: r.ownerUserId,
+    sealedUnder: r.sealedUnder,
+    latent: true,
+    issuedAt: r.issuedAt,
+    ...(typeof r.liberatedAt === 'string' ? { liberatedAt: r.liberatedAt } : {}),
+  }
+  return marker
+}
+
+/** Whether `vault` carries a Deed marker (a sealed/latent owner). */
+export async function isDeedVault(
+  store: NoydbStore,
+  vault: string,
+): Promise<boolean> {
+  return (await loadDeedMarker(store, vault)) !== null
+}
+
+/**
+ * Persist a {@link DeedMarker} at `_meta/deed`. Mirrors
+ * `saveSealedPassphrase`'s envelope shape: a standard
+ * {@link EncryptedEnvelope} with AES-GCM bypassed (`_iv: ''`), the
+ * payload stored as plaintext JSON in `_data`. The marker is metadata,
+ * not a secret — sealing it would defeat its purpose (auditors /
+ * custodians must read it without a key).
+ *
+ * @internal — used by `createDeedOwner` and (later) the Liberate
+ * ceremony to stamp `liberatedAt`.
+ */
+export async function saveDeedMarker(
+  store: NoydbStore,
+  vault: string,
+  marker: DeedMarker,
+): Promise<void> {
+  const persisted: DeedEnvelopePayload = { _noydb_deed: 1, ...marker }
+  const prior = await store.get(vault, '_meta', DEED_RECORD_ID)
+  const env: EncryptedEnvelope = {
+    _noydb: NOYDB_FORMAT_VERSION,
+    _v: (prior?._v ?? 0) + 1,
+    _ts: new Date().toISOString(),
+    // AES-GCM bypassed — the marker is plaintext audit metadata.
+    _iv: '',
+    _data: JSON.stringify(persisted),
+  }
+  await store.put(vault, '_meta', DEED_RECORD_ID, env)
+}

--- a/packages/hub/src/team/keyring.ts
+++ b/packages/hub/src/team/keyring.ts
@@ -47,10 +47,18 @@ import {
  *      a console warning (`cascade: 'warn'`). The walk uses the
  *      `granted_by` field on each keyring file as the parent pointer.
  */
+// FR-6: 'custodian' is deliberately ABSENT here. An admin must not be able
+// to mint (or revoke) a custodian — only the (sealed Deed) owner can, because
+// the custodian is the de-facto operational authority and granting one is an
+// ownership-level act. `canGrant(admin, 'custodian')` therefore returns false.
 const ADMIN_GRANTABLE_TARGETS: readonly Role[] = ['operator', 'viewer', 'client', 'admin']
 
 function canGrant(callerRole: Role, targetRole: Role): boolean {
   if (callerRole === 'owner') return true
+  // FR-6: a custodian can never grant — it holds the DEKs to OPERATE the
+  // vault but no authority to widen the principal set. Explicit + fail-safe
+  // (it would also fall through to `return false`, but spell it out).
+  if (callerRole === 'custodian') return false
   if (callerRole === 'admin') return ADMIN_GRANTABLE_TARGETS.includes(targetRole)
   return false
 }
@@ -58,6 +66,8 @@ function canGrant(callerRole: Role, targetRole: Role): boolean {
 function canRevoke(callerRole: Role, targetRole: Role): boolean {
   if (targetRole === 'owner') return false // owner cannot be revoked
   if (callerRole === 'owner') return true
+  // FR-6: a custodian can never revoke — same non-owning rationale as canGrant.
+  if (callerRole === 'custodian') return false
   if (callerRole === 'admin') return ADMIN_GRANTABLE_TARGETS.includes(targetRole)
   return false
 }
@@ -439,8 +449,16 @@ export async function grant(
     }
   }
 
-  // For owner/admin/viewer roles, wrap ALL known DEKs
-  if (options.role === 'owner' || options.role === 'admin' || options.role === 'viewer') {
+  // For owner/admin/custodian/viewer roles, wrap ALL known DEKs.
+  // FR-6: a custodian operates EVERY collection, so — like admin — it must
+  // receive every collection DEK on grant. Without this branch a custodian
+  // could neither read nor write and the role would be inert.
+  if (
+    options.role === 'owner' ||
+    options.role === 'admin' ||
+    options.role === 'custodian' ||
+    options.role === 'viewer'
+  ) {
     for (const [collName, dek] of callerKeyring.deks) {
       if (!(collName in wrappedDeks)) {
         wrappedDeks[collName] = await wrapKey(dek, newKek)
@@ -555,6 +573,11 @@ async function findAdminDescendants(
     const env = await adapter.get(vault, '_keyring', userId)
     if (!env) continue
     const kf = JSON.parse(env._data) as KeyringFile
+    // Only admins can grant, so only admins have a delegation subtree to
+    // cascade. FR-6: a custodian is intentionally EXCLUDED here — it cannot
+    // grant (canGrant(custodian,*) === false), so it is never a cascade root
+    // and never a descendant edge. Treating it as an admin-descendant would
+    // wrongly sweep it into an admin's revoke cascade.
     if (kf.role !== 'admin') continue // only admins can grant — leaves are uninteresting
     if (kf.user_id === rootUserId) continue // self-edges are noise
     const list = childrenByParent.get(kf.granted_by) ?? []
@@ -759,6 +782,11 @@ export async function rotateKeys(
   callerKeyring: UnlockedKeyring,
   collections: string[],
 ): Promise<void> {
+  // TODO(FR-6 Task 2): block custodian from rotating keys —
+  //   `if (callerKeyring.role === 'custodian') throw new PermissionDeniedError(...)`.
+  //   Re-keying is an owner meta-capability; a custodian must NOT be able to
+  //   rotate (it would let it strip the sealed owner's DEK access). Enforced in
+  //   Task 2; flagged here so this site is not overlooked.
   // Generate new DEKs for each affected collection
   const newDeks = new Map<string, CryptoKey>()
   for (const collName of collections) {
@@ -1035,8 +1063,10 @@ export async function buildRecipientKeyringFile(
     }
   }
 
-  // owner / admin / viewer: wrap every known DEK (matches grant).
-  if (role === 'owner' || role === 'admin' || role === 'viewer') {
+  // owner / admin / custodian / viewer: wrap every known DEK (matches grant).
+  // FR-6: a custodian recipient operates every collection, so it receives all
+  // DEKs just like admin (kept in lockstep with grant()'s all-DEKs branch).
+  if (role === 'owner' || role === 'admin' || role === 'custodian' || role === 'viewer') {
     for (const [collName, dek] of callerKeyring.deks) {
       if (!(collName in wrappedDeks)) {
         wrappedDeks[collName] = await wrapKey(dek, newKek)
@@ -1168,6 +1198,11 @@ export async function listUsersWithEnvelopes<T = unknown>(
   callerRole: Role,
   options: ListUsersOptions = {},
 ): Promise<Array<{ user: UserInfo; envelope: UserEnvelopeReader<T> | null }>> {
+  // FR-6: custodian is INTENTIONALLY treated as NON-privileged here (SAFER
+  // default — review flag). Directory-privilege is a team-MANAGEMENT capability
+  // (bypassing the visibility toggle + listing hidden principals); a custodian
+  // is non-owning and cannot grant/revoke, so it should not see the hidden
+  // team membership. It still gets the normal (non-hidden) directory view.
   const isPrivileged = callerRole === 'owner' || callerRole === 'admin'
 
   // 1. Vault-level directory toggle.
@@ -1242,14 +1277,22 @@ export async function ensureCollectionDEK(
 
 /** Check if a user has write permission for a collection. */
 export function hasWritePermission(keyring: UnlockedKeyring, collectionName: string): boolean {
-  if (keyring.role === 'owner' || keyring.role === 'admin') return true
+  // FR-6: custodian writes every collection (admin-level operational rw).
+  if (keyring.role === 'owner' || keyring.role === 'admin' || keyring.role === 'custodian') return true
   if (keyring.role === 'viewer' || keyring.role === 'client') return false
   return keyring.permissions[collectionName] === 'rw'
 }
 
 /** Check if a user has any access to a collection. */
 export function hasAccess(keyring: UnlockedKeyring, collectionName: string): boolean {
-  if (keyring.role === 'owner' || keyring.role === 'admin' || keyring.role === 'viewer') return true
+  // FR-6: custodian reads every collection (admin-level operational access).
+  if (
+    keyring.role === 'owner' ||
+    keyring.role === 'admin' ||
+    keyring.role === 'custodian' ||
+    keyring.role === 'viewer'
+  )
+    return true
   return collectionName in keyring.permissions
 }
 
@@ -1312,6 +1355,12 @@ export async function persistKeyring(
  * keyring revocation.
  */
 function defaultBundleCapability(role: Role): boolean {
+  // FR-6: custodian is INTENTIONALLY not in the default-true set (SAFER
+  // default — review flag). A bundle is an external artifact that outlives
+  // keyring revocation; the owner can still grant a custodian
+  // `exportCapability.bundle = true` explicitly when an offline backup is
+  // part of the custody contract. Defaulting it off keeps a custodian from
+  // silently minting a revocation-surviving copy of the whole vault.
   return role === 'owner' || role === 'admin'
 }
 
@@ -1454,7 +1503,11 @@ export function evaluateImportCapability(
 }
 
 function resolvePermissions(role: Role, explicit?: Permissions): Permissions {
-  if (role === 'owner' || role === 'admin' || role === 'viewer') return {}
+  // FR-6: custodian is full-access-by-role (hasAccess/hasWritePermission
+  // short-circuit on the role), so — like admin — its permissions map is
+  // empty. Returning {} also prevents a caller-supplied `permissions` from
+  // accidentally NARROWING a custodian below its role guarantee.
+  if (role === 'owner' || role === 'admin' || role === 'custodian' || role === 'viewer') return {}
   return explicit ?? {}
 }
 

--- a/packages/hub/src/team/keyring.ts
+++ b/packages/hub/src/team/keyring.ts
@@ -782,11 +782,14 @@ export async function rotateKeys(
   callerKeyring: UnlockedKeyring,
   collections: string[],
 ): Promise<void> {
-  // TODO(FR-6 Task 2): block custodian from rotating keys —
-  //   `if (callerKeyring.role === 'custodian') throw new PermissionDeniedError(...)`.
-  //   Re-keying is an owner meta-capability; a custodian must NOT be able to
-  //   rotate (it would let it strip the sealed owner's DEK access). Enforced in
-  //   Task 2; flagged here so this site is not overlooked.
+  // FR-6: re-keying is an owner-only meta-capability. A custodian operates the
+  // vault fully but must NOT rotate — rotation would let it mint fresh DEKs and
+  // strip the sealed owner's access, breaking the inalienability floor.
+  if (callerKeyring.role === 'custodian') {
+    throw new PermissionDeniedError(
+      'custodian cannot rotate keys (FR-6: re-key is an owner-only meta-capability; use the Deed owner)',
+    )
+  }
   // Generate new DEKs for each affected collection
   const newDeks = new Map<string, CryptoKey>()
   for (const collName of collections) {

--- a/packages/hub/src/team/peer-recover.ts
+++ b/packages/hub/src/team/peer-recover.ts
@@ -41,6 +41,10 @@ import { assertStrongPassphrase, type PassphrasePolicy } from '../validation.js'
 import type { UnlockedKeyring } from './keyring.js'
 import { mintKeyringCanary } from './keyring.js'
 
+// FR-6: 'custodian' is deliberately ABSENT — an admin cannot peer-recover a
+// custodian (mirrors ADMIN_GRANTABLE_TARGETS: custodians are owner-managed
+// only). The owner CAN recover one (canRecover returns true for owner). As a
+// CALLER, a custodian recovers nobody (it is neither owner nor admin → false).
 const ADMIN_RECOVERABLE_TARGETS: readonly Role[] = ['operator', 'viewer', 'client', 'admin']
 
 /**

--- a/packages/hub/src/team/sync-credentials.ts
+++ b/packages/hub/src/team/sync-credentials.ts
@@ -76,6 +76,11 @@ export interface SyncCredential {
 // ─── Access check ─────────────────────────────────────────────────────
 
 function requireAdminAccess(keyring: UnlockedKeyring): void {
+  // FR-6: custodian is INTENTIONALLY excluded. Sync credentials are the
+  // firm's hosting/infrastructure secrets (OAuth tokens, connection strings) —
+  // not the custodian's operational scope. A custodian operates the DATA but
+  // must never mint or read transport credentials that could be used to
+  // re-home or impersonate the firm's vault. Do NOT add 'custodian' here.
   if (keyring.role !== 'owner' && keyring.role !== 'admin') {
     throw new PermissionDeniedError(
       `Sync credentials require owner or admin role. Current role: "${keyring.role}"`,

--- a/packages/hub/src/team/tiers.ts
+++ b/packages/hub/src/team/tiers.ts
@@ -60,7 +60,9 @@ export function assertTierAccess(
   tier: number,
 ): void {
   if (tier <= 0) return
-  if (keyring.role === 'owner' || keyring.role === 'admin') return
+  // FR-6: custodian operates every collection at every tier (admin-level
+  // operational authority), so it may mint a tier DEK on demand like admin.
+  if (keyring.role === 'owner' || keyring.role === 'admin' || keyring.role === 'custodian') return
   if (!keyring.deks.has(dekKey(collection, tier))) {
     throw new TierNotGrantedError(collection, tier)
   }

--- a/packages/hub/src/tx/transaction.ts
+++ b/packages/hub/src/tx/transaction.ts
@@ -160,7 +160,10 @@ export class TxContext {
       // vault case the tests exercise; multi-vault amendments check
       // each touched vault as they first appear.
       const role = v.role
-      if (role !== 'admin' && role !== 'owner') {
+      // FR-6: custodian is admin-rank for operational mutations, and an
+      // amendment is an operational (data-correcting) act — not an ownership
+      // meta-capability — so custodian is allowed alongside owner/admin.
+      if (role !== 'admin' && role !== 'owner' && role !== 'custodian') {
         throw new AmendmentForbiddenError(v.userId, role)
       }
       // Amendments require an initialised guard registry — they

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -73,15 +73,25 @@ export const NOYDB_SYNC_VERSION = 1 as const
  * Roles control both the operations a user can perform and which DEKs
  * they receive in their keyring:
  *
- * | Role       | Collections      | Can grant/revoke | Can export |
- * |------------|-----------------|:----------------:|:----------:|
- * | `owner`    | all (rw)        | Yes (all roles)  | Yes        |
- * | `admin`    | all (rw)        | Yes (≤ admin)    | Yes        |
- * | `operator` | explicit (rw)   | No               | ACL-scoped |
- * | `viewer`   | all (ro)        | No               | Yes        |
- * | `client`   | explicit (ro)   | No               | ACL-scoped |
+ * | Role        | Collections      | Can grant/revoke | Can export |
+ * |-------------|-----------------|:----------------:|:----------:|
+ * | `owner`     | all (rw)        | Yes (all roles)  | Yes        |
+ * | `admin`     | all (rw)        | Yes (≤ admin)    | Yes        |
+ * | `custodian` | all (rw)        | No (see below)   | Yes        |
+ * | `operator`  | explicit (rw)   | No               | ACL-scoped |
+ * | `viewer`    | all (ro)        | No               | Yes        |
+ * | `client`    | explicit (ro)   | No               | ACL-scoped |
+ *
+ * **`custodian` (FR-6 sovereign custody).** Operationally admin-rank —
+ * rw + access on every collection, receives all collection DEKs on grant
+ * — but is *provably non-owning*: it CANNOT grant, revoke, rotate keys,
+ * or extract-and-sever a partition (the last three are enforced in Task 2,
+ * see the TODO(FR-6 Task 2) markers). Only the (sealed Deed) **owner** may
+ * mint or remove a custodian; an admin cannot. This is the inalienability
+ * floor — a custodian can run the vault day-to-day yet never escalate to
+ * the owner credential.
  */
-export type Role = 'owner' | 'admin' | 'operator' | 'viewer' | 'client'
+export type Role = 'owner' | 'admin' | 'custodian' | 'operator' | 'viewer' | 'client'
 
 /**
  * Read-write or read-only access on a collection.

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -85,8 +85,9 @@ export const NOYDB_SYNC_VERSION = 1 as const
  * **`custodian` (FR-6 sovereign custody).** Operationally admin-rank —
  * rw + access on every collection, receives all collection DEKs on grant
  * — but is *provably non-owning*: it CANNOT grant, revoke, rotate keys,
- * or extract-and-sever a partition (the last three are enforced in Task 2,
- * see the TODO(FR-6 Task 2) markers). Only the (sealed Deed) **owner** may
+ * destructively withdraw/sever, or extract-and-sever a partition (rotate is
+ * blocked in `rotateKeys`, sever in `withdrawAccessibleData`, and extract in
+ * `extractPartition`). Only the (sealed Deed) **owner** may
  * mint or remove a custodian; an admin cannot. This is the inalienability
  * floor — a custodian can run the vault day-to-day yet never escalate to
  * the owner credential.

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -136,6 +136,8 @@ import {
   type MagicLinkGrantRecord,
 } from './team/magic-link-grant.js'
 import { UserApi } from './meta/user-envelope/api.js'
+import { CustodyApi } from './custody/index.js'
+import { liberateVault } from './custody/liberate.js'
 import { persistSchemaIfNeeded } from './persisted-schemas/register.js'
 import { SchemaUpdateGate } from './schema-update/gate.js'
 import { SchemaFenceController } from './schema-update/fence-controller.js'
@@ -280,6 +282,19 @@ export class Vault {
    * @see docs/superpowers/specs/2026-05-05-user-envelope-design.md
    */
   public readonly user: UserApi
+
+  /**
+   * FR-6 custody API — the sovereign-custody surface, mirroring `vault.user.*`.
+   *
+   * - `grantCustodian(opts)` / `revokeCustodian(opts)` — owner-only: mint /
+   *   remove a `custodian` who operates the vault fully but can never grant /
+   *   rotate / sever / extract.
+   * - `liberate(opts)` — custodian-only: the audited claim of ownership over a
+   *   sealed-owner (Deed) vault (mints a DISTINCT new owner; ledger-audited).
+   *
+   * @see docs/superpowers/specs/2026-06-17-fr6-deed-custodian-liberate-design.md
+   */
+  public readonly custody: CustodyApi
 
   /**
    * Optional callback that re-derives an UnlockedKeyring from the
@@ -592,6 +607,16 @@ export class Vault {
       (opts) => listWithdrawalRequests(this, opts),
       (requestId, opts) => approveWithdrawal(this, requestId, opts),
       (requestId, opts) => rejectWithdrawal(this, requestId, opts),
+    )
+
+    // FR-6 custody API — mirrors the UserApi injection pattern: vault-bound
+    // closures over Noydb.grantCustodian/revokeCustodian (owner-only, gated)
+    // and the liberateVault ceremony (custodian-only). No logic here — the
+    // CustodyApi is a pure delegation shell (see custody/index.ts).
+    this.custody = new CustodyApi(
+      (options, factors) => this.noydb.grantCustodian(this.name, options, factors),
+      (options, factors) => this.noydb.revokeCustodian(this.name, options, factors),
+      (opts) => liberateVault(this, opts),
     )
   }
 

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -3258,8 +3258,14 @@ export class Vault {
     }
     // Construction-time tier-reach check: scan keyring for any
     // `*#${tier}` DEK. Owners and admins skip — they auto-mint at
-    // write time per the existing `assertTierAccess` rules.
-    if (this.keyring.role !== 'owner' && this.keyring.role !== 'admin') {
+    // write time per the existing `assertTierAccess` rules. FR-6:
+    // custodian is admin-rank operationally and auto-mints tier DEKs
+    // too (kept in lockstep with assertTierAccess in team/tiers.ts).
+    if (
+      this.keyring.role !== 'owner' &&
+      this.keyring.role !== 'admin' &&
+      this.keyring.role !== 'custodian'
+    ) {
       const suffix = `#${tier}`
       let found = false
       for (const k of this.keyring.deks.keys()) {

--- a/packages/lobby/src/index.ts
+++ b/packages/lobby/src/index.ts
@@ -127,3 +127,10 @@ export type {
   FieldAuthorityPolicy,
   FieldAuthorityInputs,
 } from './interchange/field-authority.js'
+
+// ─── FR-6: Sovereign custody (Deed / Custodian / Liberate) ────────────────────
+// Pure re-exports — custody is a vault-level concern in @noy-db/hub; the Lobby
+// surfaces the types/functions so fleet-level orchestration can reach them
+// without importing hub internals directly (no lobby logic in this slice).
+export { CustodyApi, liberateVault, createDeedOwner, loadDeedMarker, isDeedVault } from '@noy-db/hub'
+export type { DeedMarker, LiberateOptions, LiberateResult, GrantCustodianOptions } from '@noy-db/hub'

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -574,7 +574,10 @@ const KERNEL_SURFACE_BUDGET = {
   // in src/store/route-store.ts (RoutedNoydbStore.resolveBackend).
   // Bumped 3085→3095 (2026-06-15, #412 P3): thread createNoydb({ objectStore })
   // into the three vault-construction option spreads.
-  'packages/hub/src/noydb.ts': 3095,
+  // Bumped 3095→3140 (2026-06-17, FR-6 Task 4): grantCustodian/revokeCustodian —
+  // the genuinely-core owner-only custody grant/revoke surface (defended in
+  // depth by gate + explicit keyring.role !== 'owner' check).
+  'packages/hub/src/noydb.ts': 3140,
 }
 
 function checkKernelSurface() {

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -547,7 +547,10 @@ const KERNEL_SURFACE_BUDGET = {
   // the two-party withdrawal ceremony to the bundle subsystem (logic lives in
   // bundle/request-withdrawal.ts; vault.ts only injects the closures).
   // Bumped 4510→4520 (2026-06-17, FR-5 #445): provenance option + collOpts thread.
-  'packages/hub/src/vault.ts': 4520,
+  // Bumped 4520→4545 (2026-06-17, FR-6 Task 6): custody surface field + wiring
+  // (`public readonly custody: CustodyApi` + the three-closure injection
+  // mirroring the UserApi pattern; logic lives in custody/index.ts + liberate.ts).
+  'packages/hub/src/vault.ts': 4545,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),


### PR DESCRIPTION
## FR-6 — Deed / Custodian / Liberate (sovereignty-preserving custody) — pilot-1 epic vLannaAi/klum-db#1, issue vLannaAi/klum-db#7

**The strategic FR.** Sovereign-by-default custody: the client holds an **inalienable, sealed, hidden owner** (the **Deed**) from day one while the firm operates at **100%** as a **Custodian** that *provably cannot* take ownership — and an abandoned/handed-over vault can be **Liberated** under an audited ceremony (the inverse of vLannaAi/noy-db#199 withdrawal). klum-db's "counterbalance to tech giants holding data hostage," made cryptographic.

Design spec: `docs/superpowers/specs/2026-06-17-fr6-deed-custodian-liberate-design.md` (reviewed + approved).

### The key topology
```
CLIENT (latent, never authenticates)
  └─ Deed = OWNER keyring   KEK_owner <= passphrase sealed under SealingKeyProvider_client  <- non-firm boundary
FIRM (operates 100%)
  └─ Custodian keyring      same DEKs wrapped under KEK_cust;  CANNOT rotate / revoke / grant / sever
```
The Custodian holds the DEKs (operates fully) but **never reaches `KEK_owner`** (sealed under a boundary the firm doesn't control) -> inalienability is **cryptographic**, not a soft check.

### What's in it
- **`custodian` role** (`types.ts`/`team/keyring.ts`) — rw + access on all collections, but `canGrant`/`canRevoke` = false; not grantable by admin (owner-only). Full Role-comparison audit across the keyring core (15+ sites).
- **Negative capabilities** — custodian blocked from `rotateKeys` (`PermissionDeniedError`), destructive `withdraw`/sever (`ReadOnlyError`, points to liberate), and `extractPartition` (`PartitionExtractionError`).
- **Deed provisioning** (`team/deed.ts`) — `createDeedOwner` seals the owner passphrase under a non-firm `SealingKeyProvider` (reuses managed-mode) + a plaintext `_meta/deed` marker; `loadDeedMarker`/`isDeedVault`. Latent owner re-resolves with no interactive passphrase.
- **`grantCustodian`/`revokeCustodian`** (`noydb.ts`) — owner-only (gate + explicit role check, defense in depth).
- **`liberateVault`** (`custody/liberate.ts`) — gated (`liberate-vault`, fail-closed), custodian-only; freezes an evidence snapshot (live data **preserved** via the new `freezeSnapshotOnly` — withdrawal's freeze-AND-delete is byte-unchanged); mints a **distinct** new owner re-wrapping the incumbent DEKs (never unseals/impersonates the sealed owner); lifecycle ledger `liberation-claimed`; stamps `_meta/deed.liberatedAt`.
- **`vault.custody.*`** surface (`custody/index.ts`, mirrors `vault.user.*`) + hub/lobby exports + policy gates `grant-custodian`/`liberate-vault`.

### Acceptance (#446) — all met + tested
1. Sealed/auto-owner; custodian operates fully but **provably cannot** grant/revoke/rotate/extract/sever (denial tests).
2. The owner (sealed credential) revokes the custodian + `extractPartition` **without the custodian's cooperation** (custodian-offline test).
3. Liberation claims ownership under an audited event; **both** withdrawal and liberation appear in the lifecycle ledger (end-to-end walkthrough).
4. Inalienability is **cryptographic** (custodian never holds `KEK_owner`).

### Scope (pragmatic first cut — honest deferrals)
Deferred with documented follow-ups: Custodian-survives-key-rotation (the escrow problem), auto-abandonment detection for Liberate, and raw-`NoydbStore`-bypass hardening of the *operational* constraints (the ownership *anchor* is already crypto-enforced even against raw access).

### Verification
- hub: 2714 tests / lobby: 119 tests — all green
- `pnpm lint` (127) + `pnpm typecheck` (130) clean
- `validate-features.mjs` (69 features) + `check:architecture` pass (noydb.ts <=3140, vault.ts 4543<=4545)

### Builds on
vLannaAi/noy-db#198 reKey, vLannaAi/noy-db#199 withdrawal, managed-mode sealed-passphrase + SealingKeyProvider, the lifecycle ledger, per-record CEK. Pure `@noy-db/hub` (custody is vault-level); lobby re-exports the types.
