### PR TITLE
FR-9: multi-vault FK-driven Excel export

### DIFF
--- a/docs/superpowers/plans/2026-06-18-fr9-multivault-xlsx.md
+++ b/docs/superpowers/plans/2026-06-18-fr9-multivault-xlsx.md
@@ -1,0 +1,230 @@
+# FR-9 — Multi-Vault FK-Driven Excel Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Export an Excel workbook that spans **multiple vaults** — a primary vault's sheets plus supporting-vault sheets containing **exactly the FK-referenced rows** (no full-table dump), and FK'd fields **denormalized as columns** into the primary sheet. The read-side dual of FR-2's FK closure.
+
+**Architecture (dependency direction is the crux):** `@noy-db/as-xlsx` is an **edge adapter** that may only depend on `@noy-db/hub` — it must NOT import `@klum-db/lobby` (the `no-outbound-klum-import` guard + spec). So FR-9 splits in two:
+- **Edge (pure render):** `@noy-db/as-xlsx` gains `toBytesMultiVault(entries, options?)` — takes *pre-opened* vaults + a *pre-computed* per-vault id-closure + a denormalize config, and renders the workbook. It performs the denormalize as an **in-memory join over rows it has already loaded** (no cross-vault walk inside the adapter).
+- **Orchestration (the FK walk):** `@klum-db/lobby` gains `Lobby.exportMultiVaultXlsx(...)` — calls FR-2's `walkCrossVaultClosure`, opens the vaults, builds the entries (closure + denorm), and delegates to `toBytesMultiVault`. Lobby gains a **peer-dependency on `@noy-db/as-xlsx`** (the allowed `klum→noy` direction).
+
+**Tech stack:** TypeScript, vitest, pnpm. `@noy-db/as-xlsx` (edge), `@klum-db/lobby` (orchestration).
+
+**Design decisions (resolved at the FR-9 gate):**
+- **API home → Lobby orchestrator** over a pure edge function (both built).
+- **Output → BOTH** filtered supporting sheets AND denormalized columns in the primary sheet.
+- **Smart mode → flat multi-vault now**; cross-vault VLOOKUP (rewriting `sheetNameByCollection` → by-vault-and-collection) is a documented follow-up.
+- **Single-vault export is unchanged** (regression-guarded).
+
+---
+
+## Key existing surfaces (from recon)
+- `@noy-db/as-xlsx` (`packages/as-xlsx/src/index.ts`): `toBytes(vault, AsXlsxOptions)`, `AsXlsxOptions{sheets, summaries?, dialect?, smart?}`, `AsXlsxSheetOptions{name, collection, columns?, filter?, ...}`. Reads via `vault.collection(c).list()`. Low-level `writeXlsx(sheets: XlsxSheet[], options?)` (`src/xlsx.ts:125`) accepts any sheets; dedups names; `truncateSheetName` 31-char cap (`src/xlsx.ts:398`). Peer-deps: `@noy-db/hub`, `@noy-db/as-zip` only.
+- FR-2 (`packages/lobby/src/interchange/extract-cross-vault.ts`): `CrossVaultRef{from:{collection,field}, to:{vault,collection,field?}}`, `CrossVaultSeed{vault, seeds}`, `walkCrossVaultClosure(openVault, {seed, crossVaultRefs?, maxDepth?})` → `CrossVaultClosurePlan{perVaultSeeds, perVaultClosure: Map<vault, Map<collection, Set<id>>>, dangling}`.
+- `Noydb.openVault(name)`; vault caches instances. `vault.collection(c).get(id)` / `.list()` (decrypted reads). Per-vault export grant: `assertCanExport('plaintext','xlsx')` (each vault must hold it).
+- Test harness: `packages/as-xlsx/__tests__/as-xlsx.test.ts` (`memory()` + `createNoydb` + `grant({exportCapability:{plaintext:['xlsx']}})` + `toBytes`).
+
+---
+
+## File structure
+
+- **Modify** `packages/as-xlsx/src/index.ts` — `toBytesMultiVault` + `MultiVaultXlsxEntry`/`MultiVaultDenormColumn` types (edge-pure). (Tasks 1-2)
+- **Modify** `packages/lobby/src/index.ts` + **`packages/lobby/package.json`** — `Lobby.exportMultiVaultXlsx` + as-xlsx peer-dep. (Task 3)
+- **Modify** `features.yaml`. (Task 4)
+- **Tests:** `packages/as-xlsx/__tests__/multivault-xlsx.test.ts` (Tasks 1-2), `packages/lobby/__tests__/export-multivault-xlsx.test.ts` (Task 3).
+
+---
+
+## Task 1 — as-xlsx: `toBytesMultiVault` flat multi-vault render + closure filter (TDD)
+
+**Files:** `packages/as-xlsx/src/index.ts`. Test `packages/as-xlsx/__tests__/multivault-xlsx.test.ts`.
+
+**Context:** Pure edge function: given pre-opened vaults (each with sheet specs + an optional id-closure), render one workbook. Vault-prefixed sheet names; per-vault export grant check; supporting sheets filtered to the closure ids. Reuses `writeXlsx`.
+
+- [ ] **Step 1: Failing test** — create `multivault-xlsx.test.ts`. Mirror `as-xlsx.test.ts` harness; seed TWO vaults (`primary` with `bills` referencing `entityId`, `directory` with `entities`), grant xlsx on both. Call:
+```ts
+const bytes = await toBytesMultiVault([
+  { vault: primaryVault, sheets: [{ name: 'bills', collection: 'bills', columns: ['id','entityId','amount'] }] },
+  { vault: dirVault, sheets: [{ name: 'entities', collection: 'entities', columns: ['id','name'] }],
+    closure: new Map([['entities', new Set(['e1'])]]) },   // only e1 referenced
+])
+```
+   Assert (parse the xlsx via the package's own reader or `fromBytes`/zip inspection used in existing tests): two data sheets exist with vault-prefixed names (e.g. `primary_bills`, `directory_entities`); the `directory_entities` sheet has ONLY row `e1` (closure filter), not the full entities table; a `_manifest` lists both vaults.
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement** in `index.ts`:
+```ts
+export interface MultiVaultXlsxEntry {
+  readonly vault: Vault
+  readonly sheets: readonly AsXlsxSheetOptions[]
+  /** Optional per-collection id-allowlist (from walkCrossVaultClosure). When set, only these ids are exported. */
+  readonly closure?: ReadonlyMap<string, ReadonlySet<string>>
+  /** Optional display label for sheet-name prefixing; defaults to vault.name. */
+  readonly label?: string
+}
+
+export interface MultiVaultXlsxOptions {
+  readonly dialect?: 'excel' | 'sheets'
+  /** Sheet-name prefix separator. Default '_'. Names are truncated to 31 chars. */
+  readonly sheetSeparator?: string
+}
+
+export async function toBytesMultiVault(
+  entries: readonly MultiVaultXlsxEntry[],
+  options: MultiVaultXlsxOptions = {},
+): Promise<Uint8Array> {
+  const sep = options.sheetSeparator ?? '_'
+  const allSheets: XlsxSheet[] = []
+  const manifestRows: (string | number)[][] = []
+  for (const entry of entries) {
+    // each vault must independently hold the xlsx export grant (fail-fast, before any rows materialise)
+    entry.vault.assertCanExport?.('plaintext', 'xlsx')   // confirm the real accessor name/signature
+    const prefix = entry.label ?? entry.vault.name
+    for (const s of entry.sheets) {
+      const rows = await entry.vault.collection<Record<string, unknown>>(s.collection).list()
+      const allow = entry.closure?.get(s.collection)
+      const filtered = allow ? rows.filter(r => allow.has(String((r as { id?: unknown }).id))) : rows
+      const withUserFilter = s.filter ? filtered.filter(s.filter) : filtered
+      const cols = s.columns ?? inferColumns(withUserFilter)
+      const sheetName = prefixSheetName(prefix, s.name, sep)   // `${prefix}${sep}${s.name}`, truncated ≤31
+      allSheets.push(buildFlatSheet(sheetName, cols, withUserFilter))   // reuse the existing flat-sheet builder
+      manifestRows.push([prefix, s.collection, withUserFilter.length])
+    }
+  }
+  allSheets.unshift({ name: '_manifest', header: ['Vault', 'Collection', 'Records'], rows: manifestRows })
+  return writeXlsx(allSheets, { dialect: options.dialect })
+}
+```
+   - Read `index.ts` to reuse the EXACT flat-sheet construction `toBytes` uses (column inference, row→cells, number formats) — factor a `buildFlatSheet(name, columns, records)` helper out of the existing flat path if one isn't already isolated, WITHOUT changing single-vault `toBytes` behavior. Confirm `assertCanExport`'s real name/signature (grep how `toBytes` enforces the grant) + `writeXlsx`/`XlsxSheet`/`inferColumns` imports.
+   - `prefixSheetName`: `truncateSheetName(`${prefix}${sep}${name}`)`; rely on `writeXlsx`'s dedup for residual collisions.
+
+- [ ] **Step 4: Run → pass.** `pnpm --filter @noy-db/as-xlsx test` (incl. the EXISTING single-vault tests — UNCHANGED), typecheck, lint, `pnpm check:architecture` (as-xlsx must still NOT import @klum-db — verify no new outbound import).
+
+- [ ] **Step 5: Commit** (new test → `git add`): `git add packages/as-xlsx/__tests__/multivault-xlsx.test.ts && git commit -am "feat(as-xlsx): toBytesMultiVault — multi-vault render + closure filter (FR-9 Task 1)"`
+
+---
+
+## Task 2 — as-xlsx: denormalized columns (in-memory FK join) (TDD)
+
+**Files:** `packages/as-xlsx/src/index.ts`. Test: extend `multivault-xlsx.test.ts`.
+
+**Context:** Pull FK'd fields from a supporting vault INTO the primary sheet as columns (`bills.entityId → directory.entities.id → entities.name` puts `entities.name` as a `bills` column). Pure in-memory join over rows already loaded (the supporting closure rows ARE the referenced ones). No lobby/cross-vault walk in the adapter.
+
+- [ ] **Step 1: Failing test** — extend the test: the primary `bills` sheet declares a denormalize column:
+```ts
+const bytes = await toBytesMultiVault([
+  { vault: primaryVault, sheets: [{
+      name: 'bills', collection: 'bills', columns: ['id','entityId','amount'],
+      denormalize: [{ column: 'entityName', localField: 'entityId',
+        from: { label: 'directory', collection: 'entities', keyField: 'id', pick: 'name' } }],
+    }] },
+  { vault: dirVault, sheets: [{ name: 'entities', collection: 'entities', columns: ['id','name'] }],
+    closure: new Map([['entities', new Set(['e1'])]]) },
+])
+// assert the bills sheet now has an `entityName` column whose value for the bill referencing e1 == the e1 entity's name.
+```
+
+- [ ] **Step 2: Run → fail.**
+
+- [ ] **Step 3: Implement.** Add `denormalize?: readonly MultiVaultDenormColumn[]` to `AsXlsxSheetOptions` (additive/optional — single-vault `toBytes` ignores it):
+```ts
+export interface MultiVaultDenormColumn {
+  readonly column: string            // new column name in the primary sheet
+  readonly localField: string        // FK field on the primary record
+  readonly from: { readonly label: string; readonly collection: string; readonly keyField: string; readonly pick: string }
+}
+```
+   In `toBytesMultiVault`: build a lookup index `Map<`${label}/${collection}`, Map<keyValue, row>>` from ALL loaded entries' rows (first pass), then when emitting a sheet with `denormalize`, for each row resolve `index.get(`${from.label}/${from.collection}`)?.get(row[localField])?.[from.pick]` and append it as the `column`. Append denorm columns AFTER the declared columns. Unresolved FK → empty cell (document).
+   - Two-pass: pass 1 loads + indexes all entries' rows (apply closure filter to what's indexed AND exported — the denorm can only resolve referenced rows, which is correct: only FK-referenced supporting rows exist); pass 2 emits sheets with denorm columns. Refactor Task 1's single loop into load-then-emit.
+
+- [ ] **Step 4: Run → pass.** Full as-xlsx test (single-vault unchanged), typecheck, lint, architecture.
+
+- [ ] **Step 5: Commit** — `git commit -am "feat(as-xlsx): denormalized FK columns in multi-vault export (FR-9 Task 2)"`
+
+---
+
+## Task 3 — lobby: `Lobby.exportMultiVaultXlsx` orchestrator (TDD)
+
+**Files:** `packages/lobby/src/index.ts`, `packages/lobby/package.json` (add `@noy-db/as-xlsx` peer-dep). Test `packages/lobby/__tests__/export-multivault-xlsx.test.ts`.
+
+**Context:** The one-call wrapper: walk the FK closure (FR-2) → open vaults → build entries (closure + denorm) → `toBytesMultiVault`. Lobby→as-xlsx is the allowed `klum→noy` direction.
+
+- [ ] **Step 1: package.json** — add `"@noy-db/as-xlsx": "workspace:*"` to `@klum-db/lobby` `peerDependencies` (mirror how `@noy-db/hub` is declared). `pnpm install` so the workspace link resolves.
+
+- [ ] **Step 2: Failing test** — `export-multivault-xlsx.test.ts`: a `Noydb` with two vaults + an FK (`bills.entityId → directory.entities.id`); some bills reference only a SUBSET of entities. Call:
+```ts
+const bytes = await lobby.exportMultiVaultXlsx({
+  primary: { vault: 'primary', seeds: { bills: () => true } },
+  crossVaultRefs: [{ from: { collection: 'bills', field: 'entityId' }, to: { vault: 'directory', collection: 'entities' } }],
+  sheets: { primary: [{ name: 'bills', collection: 'bills', denormalize: [{ column:'entityName', localField:'entityId', from:{ label:'directory', collection:'entities', keyField:'id', pick:'name' } }] }],
+            directory: [{ name: 'entities', collection: 'entities' }] },
+})
+```
+   Assert: workbook spans both vaults; the `directory_entities` sheet contains EXACTLY the FK-referenced entity ids (not the full table); the bills sheet has the denormalized `entityName`; single bill→entity mapping correct.
+
+- [ ] **Step 3: Implement** `Lobby.exportMultiVaultXlsx(opts)`:
+```ts
+import { toBytesMultiVault, type MultiVaultXlsxEntry } from '@noy-db/as-xlsx'
+import { walkCrossVaultClosure } from './interchange/extract-cross-vault.js'
+// opts: { primary: { vault: string; seeds: Record<string,(r)=>boolean> }, crossVaultRefs: CrossVaultRef[],
+//         sheets: Record<vaultName, AsXlsxSheetOptions[]>, dialect? }
+async exportMultiVaultXlsx(opts): Promise<Uint8Array> {
+  const openVault = (name: string) => this.noydb.openVault(name)
+  const plan = await walkCrossVaultClosure(openVault, {
+    seed: { vault: opts.primary.vault, seeds: opts.primary.seeds },
+    crossVaultRefs: opts.crossVaultRefs,
+  })
+  const entries: MultiVaultXlsxEntry[] = []
+  for (const [vaultName, sheets] of Object.entries(opts.sheets)) {
+    const vault = await openVault(vaultName)
+    const closure = plan.perVaultClosure.get(vaultName)   // Map<collection, Set<id>> | undefined
+    // primary vault: no closure filter (it's seeded by the predicate, exported whole-by-seed);
+    // supporting vaults: filter to the FK closure.
+    entries.push({ vault, sheets, label: vaultName,
+      ...(vaultName !== opts.primary.vault && closure ? { closure } : {}) })
+  }
+  return toBytesMultiVault(entries, opts.dialect ? { dialect: opts.dialect } : {})
+}
+```
+   - Decide the primary-vault row scope: the primary is seeded by `opts.primary.seeds` predicates; export the primary rows matching the seed (either pass the seed as a `filter` on the primary sheet, or use the plan's `perVaultClosure` for the primary too). Simplest + matches FR-2 semantics: use `plan.perVaultClosure.get(primary)` for the primary as well (the seed predicate populates it). Verify against walkCrossVaultClosure's output (does it include the seed vault in perVaultClosure? confirm in the FR-2 code) and choose accordingly; document.
+
+- [ ] **Step 4: Run → pass.** `pnpm --filter @noy-db/as-xlsx build` (lobby consumes dist) then `pnpm --filter @klum-db/lobby test` + `pnpm --filter @noy-db/as-xlsx test`, typecheck, lint, `pnpm check:architecture` (lobby→as-xlsx OK; as-xlsx still no klum import; the `no-outbound-klum-import` guard still green).
+
+- [ ] **Step 5: Commit** (new test + package.json → `git add`): `git add packages/lobby/__tests__/export-multivault-xlsx.test.ts packages/lobby/package.json && git commit -am "feat(lobby): exportMultiVaultXlsx orchestrator over as-xlsx (FR-9 Task 3)"`
+
+---
+
+## Task 4 — exports + features.yaml + full verification
+
+**Files:** `packages/as-xlsx/src/index.ts` (confirm exports), `features.yaml`.
+
+- [ ] **Step 1: Exports** — confirm `toBytesMultiVault`, `MultiVaultXlsxEntry`, `MultiVaultXlsxOptions`, `MultiVaultDenormColumn` are exported from `@noy-db/as-xlsx`; `exportMultiVaultXlsx` is a `Lobby` method (auto-available); re-export the as-xlsx multi-vault types from `@klum-db/lobby` if helpful. `pnpm --filter @klum-db/lobby typecheck`.
+- [ ] **Step 2: features.yaml** — add a `multivault-xlsx-export` entry mirroring a sibling as-xlsx / lobby feature (study `as-xls`/`as-xlsx` entries + the FR-2 `cross-vault-extraction` entry for shape): artefacts `packages/as-xlsx/src/index.ts` + the lobby orchestrator; spec `docs/superpowers/specs/2026-06-16-lobby-framework-design.md` (FR-9); package `@noy-db/as-xlsx` (+ note the `@klum-db/lobby` orchestrator); status `preview`. `node scripts/validate-features.mjs` passes.
+- [ ] **Step 3: Full verification:**
+```bash
+pnpm --filter @noy-db/as-xlsx build && pnpm --filter @noy-db/hub build && pnpm --filter @klum-db/lobby build
+pnpm --filter @noy-db/as-xlsx test && pnpm --filter @klum-db/lobby test
+pnpm lint && pnpm typecheck
+node scripts/validate-features.mjs
+pnpm check:architecture
+```
+All green.
+- [ ] **Step 4: Commit** — `git commit -am "feat: register multivault-xlsx-export feature + verify (FR-9)"`
+
+---
+
+## Self-Review
+
+**Spec coverage (issue #449):**
+- "a workbook spans ≥2 compartments" → Task 1 (multi-vault sheets) + Task 3 (orchestrator).
+- "supporting-vault rows are exactly those FK-referenced (no full-table dump)" → Task 1 closure filter + Task 3 walkCrossVaultClosure feeding the closure.
+- "single-vault export is unchanged" → Tasks 1-2 keep `toBytes` untouched (denormalize is opt-in, ignored by single-vault); regression-guarded by the existing as-xlsx suite.
+- "joins/denormalizes ... entities.name" → Task 2 (denormalized columns).
+- Builds on `@noy-db/as-xlsx`, FR-2's `CrossVaultRef`/`walkCrossVaultClosure`, broadcastJoin-style enrich (implemented as an in-memory join in the edge adapter).
+
+**Dependency-direction invariant (the critical one):** `@noy-db/as-xlsx` gains NO `@klum-db/lobby` import (the walk is caller-supplied); `@klum-db/lobby` gains a peer-dep on `@noy-db/as-xlsx` (allowed `klum→noy`). The `no-outbound-klum-import` arch guard must stay green — verified in Tasks 1 & 3.
+
+**Placeholder scan:** signatures concrete; the two implementer decisions are flagged (Task 1's `assertCanExport` accessor + the flat-sheet-builder factoring; Task 3's primary-vault scope = perVaultClosure-of-seed-vault — confirm in FR-2 code). 31-char sheet-name truncation + dedup reused from `writeXlsx`.
+
+**Risk notes:** smart-mode cross-vault VLOOKUP is DEFERRED (flat multi-vault only) — documented. The lobby→as-xlsx peer-dep adds xlsx to lobby's peer set (acceptable per the chosen orchestrator option; peer not hard dep, so consumers opt in). Denormalize resolves only FK-referenced (closure) rows — an FK pointing outside the closure yields an empty cell (correct: that row wasn't referenced/exported).

--- a/features.yaml
+++ b/features.yaml
@@ -1178,6 +1178,26 @@ features:
       - 'mergeCompartment re-stamps the incoming source on receiver writes so provenance is preserved across vault boundaries; silently no-op when the receiver collection has provenance off'
     related: [vault-and-collections, history, merge-compartment, transferable-partition]
 
+  - id: multivault-xlsx-export
+    name: Multi-vault FK-driven Excel export (FR-9)
+    cluster: snapshot-and-portability
+    spec: docs/superpowers/specs/2026-06-16-lobby-framework-design.md
+    subsystem_doc: docs/superpowers/specs/2026-06-16-lobby-framework-design.md
+    package: '@noy-db/as-xlsx'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'Workbook spans ≥2 vaults: toBytesMultiVault(entries, options?) in @noy-db/as-xlsx renders one workbook from pre-opened vaults; Lobby.exportMultiVaultXlsx in @klum-db/lobby orchestrates the FK walk + vault opening before delegating to toBytesMultiVault'
+      - 'Supporting-vault rows are exactly FK-referenced (no full-table dump): each MultiVaultXlsxEntry closure field (Map<collection, Set<id>>) filters rows to only the allowlisted ids; walkCrossVaultClosure (FR-2) populates these closures from the declared CrossVaultRef descriptors'
+      - 'FK-referenced fields denormalized as columns: denormalize on AsXlsxSheetOptions declares MultiVaultDenormColumn entries; toBytesMultiVault performs a two-pass in-memory join (load all entries + build index in pass 1; emit sheets with denorm columns appended in pass 2); unresolved FK → empty cell'
+      - 'Single-vault toBytes is unchanged (regression-guarded): denormalize is additive/optional and ignored by the single-vault path; toBytesMultiVault is a separate export, not a modification of toBytes'
+      - 'Dependency direction preserved: @noy-db/as-xlsx (edge adapter) imports only @noy-db/hub — it never imports @klum-db/lobby; Lobby gains a peer-dependency on @noy-db/as-xlsx (the allowed klum→noy direction); guarded by the no-outbound-klum-import architecture check'
+    related: [cross-vault-extraction, as-xlsx]
+
   - id: with-snapshots
     name: Snapshot lifecycle (withSnapshots)
     cluster: snapshot-and-portability

--- a/packages/as-xlsx/__tests__/multivault-xlsx.test.ts
+++ b/packages/as-xlsx/__tests__/multivault-xlsx.test.ts
@@ -11,7 +11,7 @@
 import { describe, expect, it } from 'vitest'
 import { ExportCapabilityError, createNoydb } from '@noy-db/hub'
 import { memory } from '@noy-db/to-memory'
-import { toBytesMultiVault } from '../src/index.js'
+import { toBytesMultiVault, type MultiVaultDenormColumn } from '../src/index.js'
 
 // ── zip helpers (mirrors as-xlsx.test.ts) ──────────────────────────
 
@@ -301,5 +301,195 @@ describe('toBytesMultiVault', () => {
     ).rejects.toThrow(ExportCapabilityError)
 
     await db.close()
+  })
+})
+
+// ── Task 2: denormalized FK columns ───────────────────────────────────
+
+describe('toBytesMultiVault — denormalized columns', () => {
+  it('adds entityName column to bills sheet via in-memory join from directory/entities', async () => {
+    const { db, adapter } = await seedTwoVaults()
+    await grantXlsxBothVaults(adapter)
+
+    const db2 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+    const primaryVault = await db2.openVault('primary')
+    const dirVault = await db2.openVault('directory')
+
+    const denormalize: MultiVaultDenormColumn[] = [
+      {
+        column: 'entityName',
+        localField: 'entityId',
+        from: { label: 'directory', collection: 'entities', keyField: 'id', pick: 'name' },
+      },
+    ]
+
+    const bytes = await toBytesMultiVault([
+      {
+        vault: primaryVault,
+        label: 'primary',
+        sheets: [{
+          name: 'bills',
+          collection: 'bills',
+          columns: ['id', 'entityId', 'amount'],
+          denormalize,
+        }],
+      },
+      {
+        vault: dirVault,
+        label: 'directory',
+        sheets: [{ name: 'entities', collection: 'entities', columns: ['id', 'name'] }],
+        closure: new Map([['entities', new Set(['e1'])]]),
+      },
+    ])
+
+    // The bills sheet header should contain entityName
+    const shared = readZipFile(bytes, 'xl/sharedStrings.xml')!
+    expect(shared).toContain('>entityName<')
+
+    // The resolved name for e1 (Globex Corp) must appear in the bills sheet
+    expect(shared).toContain('>Globex Corp<')
+
+    await db.close()
+    await db2.close()
+  })
+
+  it('yields empty cell for unresolved FK (entity id not in closure/index)', async () => {
+    const adapter = memory()
+    const db = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+
+    const primaryVault = await db.openVault('primary')
+    const bills = primaryVault.collection<{ id: string; entityId: string; amount: number }>('bills')
+    await bills.put('b1', { id: 'b1', entityId: 'e1', amount: 100 })
+    // bill b3 references e99 which is NOT in the directory closure
+    await bills.put('b3', { id: 'b3', entityId: 'e99', amount: 50 })
+
+    const dirVault = await db.openVault('directory')
+    const entities = dirVault.collection<{ id: string; name: string }>('entities')
+    await entities.put('e1', { id: 'e1', name: 'Globex Corp' })
+    await entities.put('e99', { id: 'e99', name: 'Ghost Corp' }) // in store but NOT in closure
+
+    await db.close()
+
+    // Grant xlsx on both vaults
+    const db2 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+    await db2.grant('primary', {
+      userId: 'owner-01', displayName: 'Owner', role: 'owner',
+      passphrase: 'owner-pass',
+      exportCapability: { plaintext: ['xlsx'] },
+    })
+    await db2.grant('directory', {
+      userId: 'owner-01', displayName: 'Owner', role: 'owner',
+      passphrase: 'owner-pass',
+      exportCapability: { plaintext: ['xlsx'] },
+    })
+    await db2.close()
+
+    const db3 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+    const pv = await db3.openVault('primary')
+    const dv = await db3.openVault('directory')
+
+    const bytes = await toBytesMultiVault([
+      {
+        vault: pv,
+        label: 'primary',
+        sheets: [{
+          name: 'bills',
+          collection: 'bills',
+          columns: ['id', 'entityId', 'amount'],
+          denormalize: [{
+            column: 'entityName',
+            localField: 'entityId',
+            from: { label: 'directory', collection: 'entities', keyField: 'id', pick: 'name' },
+          }],
+        }],
+      },
+      {
+        vault: dv,
+        label: 'directory',
+        // closure limits to e1 only — e99 is NOT indexed even though it exists in the store
+        sheets: [{ name: 'entities', collection: 'entities', columns: ['id', 'name'] }],
+        closure: new Map([['entities', new Set(['e1'])]]),
+      },
+    ])
+
+    const shared = readZipFile(bytes, 'xl/sharedStrings.xml')!
+    // Globex Corp (e1) resolves fine
+    expect(shared).toContain('>Globex Corp<')
+    // Ghost Corp (e99) must NOT appear — it's outside the closure and stays empty
+    expect(shared).not.toContain('>Ghost Corp<')
+
+    // Parse the bills worksheet XML to verify the unresolved row has an empty cell
+    // We check the worksheet for the bills sheet — sheet 2 in the workbook (_manifest=1, primary_bills=2)
+    const workbook = readZipFile(bytes, 'xl/workbook.xml')!
+    // Extract sheet IDs to find primary_bills position
+    const billsMatch = workbook.match(/name="primary_bills" sheetId="(\d+)"/)
+    expect(billsMatch).not.toBeNull()
+    const sheetId = billsMatch![1]
+    const sheetXml = readZipFile(bytes, `xl/worksheets/sheet${sheetId}.xml`)!
+
+    // The row for b3 (entityId=e99) should have an empty last cell for entityName.
+    // We look for the presence of 'e99' (shared string) — it should be there as the entityId value
+    expect(shared).toContain('>e99<')
+
+    await db3.close()
+  })
+
+  it('declared columns appear before denorm columns in header', async () => {
+    const { db, adapter } = await seedTwoVaults()
+    await grantXlsxBothVaults(adapter)
+
+    const db2 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+    const primaryVault = await db2.openVault('primary')
+    const dirVault = await db2.openVault('directory')
+
+    const bytes = await toBytesMultiVault([
+      {
+        vault: primaryVault,
+        label: 'primary',
+        sheets: [{
+          name: 'bills',
+          collection: 'bills',
+          columns: ['id', 'entityId', 'amount'],
+          denormalize: [{
+            column: 'entityName',
+            localField: 'entityId',
+            from: { label: 'directory', collection: 'entities', keyField: 'id', pick: 'name' },
+          }],
+        }],
+      },
+      {
+        vault: dirVault,
+        label: 'directory',
+        sheets: [{ name: 'entities', collection: 'entities', columns: ['id', 'name'] }],
+        closure: new Map([['entities', new Set(['e1'])]]),
+      },
+    ])
+
+    // Find the primary_bills sheet id
+    const workbook = readZipFile(bytes, 'xl/workbook.xml')!
+    const match = workbook.match(/name="primary_bills" sheetId="(\d+)"/)
+    expect(match).not.toBeNull()
+    const sheetId = match![1]
+    const sheetXml = readZipFile(bytes, `xl/worksheets/sheet${sheetId}.xml`)!
+
+    // The header row (row 1) should have id/entityId/amount then entityName.
+    // Column A=id, B=entityId, C=amount, D=entityName
+    // We verify by checking that entityName has a higher column index than amount.
+    // The sharedStrings approach: find string indices for 'entityName' and 'amount'.
+    const shared = readZipFile(bytes, 'xl/sharedStrings.xml')!
+    const strings = [...shared.matchAll(/<t[^>]*>([^<]+)<\/t>/g)].map((m) => m[1]!)
+    const idxEntityName = strings.indexOf('entityName')
+    const idxAmount = strings.indexOf('amount')
+    expect(idxEntityName).toBeGreaterThan(-1)
+    expect(idxAmount).toBeGreaterThan(-1)
+    // In the header row the cell for 'amount' should appear before 'entityName'
+    const amountCellPos = sheetXml.indexOf(`v>${idxAmount}</v>`)
+    const entityNameCellPos = sheetXml.indexOf(`v>${idxEntityName}</v>`)
+    expect(amountCellPos).toBeGreaterThan(-1)
+    expect(entityNameCellPos).toBeGreaterThan(-1)
+    expect(amountCellPos).toBeLessThan(entityNameCellPos)
+
+    await db.close()
+    await db2.close()
   })
 })

--- a/packages/as-xlsx/__tests__/multivault-xlsx.test.ts
+++ b/packages/as-xlsx/__tests__/multivault-xlsx.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Integration tests for toBytesMultiVault (FR-9 Task 1).
+ *
+ * Covers:
+ *   - two-vault workbook: vault-prefixed sheet names (primary_bills, directory_entities)
+ *   - closure filter: directory_entities contains ONLY the referenced entity row (e1)
+ *   - _manifest sheet lists both vault-collection pairs
+ *   - export-grant check: vault without grant → ExportCapabilityError
+ *   - single-vault toBytes is unchanged (smoke)
+ */
+import { describe, expect, it } from 'vitest'
+import { ExportCapabilityError, createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { toBytesMultiVault } from '../src/index.js'
+
+// ── zip helpers (mirrors as-xlsx.test.ts) ──────────────────────────
+
+function listZipPaths(bytes: Uint8Array): string[] {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const eocdOffset = bytes.length - 22
+  const cdOffset = view.getUint32(eocdOffset + 16, true)
+  const recordCount = view.getUint16(eocdOffset + 10, true)
+  const out: string[] = []
+  let pos = cdOffset
+  for (let i = 0; i < recordCount; i++) {
+    const nameLen = view.getUint16(pos + 28, true)
+    const extraLen = view.getUint16(pos + 30, true)
+    const commentLen = view.getUint16(pos + 32, true)
+    out.push(new TextDecoder().decode(bytes.subarray(pos + 46, pos + 46 + nameLen)))
+    pos += 46 + nameLen + extraLen + commentLen
+  }
+  return out
+}
+
+function readZipFile(bytes: Uint8Array, path: string): string | null {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const eocdOffset = bytes.length - 22
+  const cdOffset = view.getUint32(eocdOffset + 16, true)
+  const recordCount = view.getUint16(eocdOffset + 10, true)
+  let pos = cdOffset
+  for (let i = 0; i < recordCount; i++) {
+    const nameLen = view.getUint16(pos + 28, true)
+    const extraLen = view.getUint16(pos + 30, true)
+    const commentLen = view.getUint16(pos + 32, true)
+    const name = new TextDecoder().decode(bytes.subarray(pos + 46, pos + 46 + nameLen))
+    if (name === path) {
+      const lfhOffset = view.getUint32(pos + 42, true)
+      const lfhNameLen = view.getUint16(lfhOffset + 26, true)
+      const lfhExtraLen = view.getUint16(lfhOffset + 28, true)
+      const size = view.getUint32(lfhOffset + 18, true)
+      const dataStart = lfhOffset + 30 + lfhNameLen + lfhExtraLen
+      return new TextDecoder().decode(bytes.subarray(dataStart, dataStart + size))
+    }
+    pos += 46 + nameLen + extraLen + commentLen
+  }
+  return null
+}
+
+// ── test harness ───────────────────────────────────────────────────
+
+async function seedTwoVaults() {
+  const adapter = memory()
+
+  // First open as owner to set up vaults + data
+  const db = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+
+  // primary vault: bills referencing entityId
+  const primaryVault = await db.openVault('primary')
+  const bills = primaryVault.collection<{ id: string; entityId: string; amount: number }>('bills')
+  await bills.put('b1', { id: 'b1', entityId: 'e1', amount: 100 })
+  await bills.put('b2', { id: 'b2', entityId: 'e1', amount: 200 })
+
+  // directory vault: entities (two rows; only e1 is referenced by bills)
+  const dirVault = await db.openVault('directory')
+  const entities = dirVault.collection<{ id: string; name: string }>('entities')
+  await entities.put('e1', { id: 'e1', name: 'Globex Corp' })
+  await entities.put('e2', { id: 'e2', name: 'Initech Ltd' })   // NOT referenced
+
+  return { db, adapter }
+}
+
+async function grantXlsxBothVaults(adapter: ReturnType<typeof memory>) {
+  const db = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+  await db.grant('primary', {
+    userId: 'owner-01', displayName: 'Owner', role: 'owner',
+    passphrase: 'owner-pass',
+    exportCapability: { plaintext: ['xlsx'] },
+  })
+  await db.grant('directory', {
+    userId: 'owner-01', displayName: 'Owner', role: 'owner',
+    passphrase: 'owner-pass',
+    exportCapability: { plaintext: ['xlsx'] },
+  })
+  await db.close()
+}
+
+// ── tests ──────────────────────────────────────────────────────────
+
+describe('toBytesMultiVault', () => {
+  it('produces a two-vault workbook with vault-prefixed sheet names', async () => {
+    const { db, adapter } = await seedTwoVaults()
+    await grantXlsxBothVaults(adapter)
+
+    const db2 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+    const primaryVault = await db2.openVault('primary')
+    const dirVault = await db2.openVault('directory')
+
+    const bytes = await toBytesMultiVault([
+      {
+        vault: primaryVault,
+        sheets: [{ name: 'bills', collection: 'bills', columns: ['id', 'entityId', 'amount'] }],
+      },
+      {
+        vault: dirVault,
+        sheets: [{ name: 'entities', collection: 'entities', columns: ['id', 'name'] }],
+        closure: new Map([['entities', new Set(['e1'])]]),
+      },
+    ])
+
+    // Basic structure
+    expect(bytes[0]).toBe(0x50)
+    expect(bytes[1]).toBe(0x4b)
+
+    const workbook = readZipFile(bytes, 'xl/workbook.xml')!
+    expect(workbook).not.toBeNull()
+
+    // Sheet names should be vault-prefixed
+    expect(workbook).toContain('name="primary_bills"')
+    expect(workbook).toContain('name="directory_entities"')
+
+    // _manifest sheet must exist
+    expect(workbook).toContain('name="_manifest"')
+
+    await db.close()
+    await db2.close()
+  })
+
+  it('filters directory_entities to only the closure-specified ids (e1 only, not e2)', async () => {
+    const { db, adapter } = await seedTwoVaults()
+    await grantXlsxBothVaults(adapter)
+
+    const db2 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+    const primaryVault = await db2.openVault('primary')
+    const dirVault = await db2.openVault('directory')
+
+    const bytes = await toBytesMultiVault([
+      {
+        vault: primaryVault,
+        sheets: [{ name: 'bills', collection: 'bills', columns: ['id', 'entityId', 'amount'] }],
+      },
+      {
+        vault: dirVault,
+        sheets: [{ name: 'entities', collection: 'entities', columns: ['id', 'name'] }],
+        closure: new Map([['entities', new Set(['e1'])]]),
+      },
+    ])
+
+    const shared = readZipFile(bytes, 'xl/sharedStrings.xml')!
+    // e1 entity should be present
+    expect(shared).toContain('>Globex Corp<')
+    // e2 entity must NOT be present (closure filter)
+    expect(shared).not.toContain('>Initech Ltd<')
+
+    await db.close()
+    await db2.close()
+  })
+
+  it('_manifest sheet lists both vaults with correct record counts', async () => {
+    const { db, adapter } = await seedTwoVaults()
+    await grantXlsxBothVaults(adapter)
+
+    const db2 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+    const primaryVault = await db2.openVault('primary')
+    const dirVault = await db2.openVault('directory')
+
+    const bytes = await toBytesMultiVault([
+      {
+        vault: primaryVault,
+        sheets: [{ name: 'bills', collection: 'bills', columns: ['id', 'entityId', 'amount'] }],
+      },
+      {
+        vault: dirVault,
+        sheets: [{ name: 'entities', collection: 'entities', columns: ['id', 'name'] }],
+        closure: new Map([['entities', new Set(['e1'])]]),
+      },
+    ])
+
+    const paths = listZipPaths(bytes)
+    // _manifest is sheet 1 (prepended)
+    expect(paths).toContain('xl/worksheets/sheet1.xml')
+
+    // The workbook should list _manifest first
+    const workbook = readZipFile(bytes, 'xl/workbook.xml')!
+    const manifestIdx = workbook.indexOf('name="_manifest"')
+    const billsIdx = workbook.indexOf('name="primary_bills"')
+    expect(manifestIdx).toBeLessThan(billsIdx)
+
+    // Manifest sheet content: headers Vault/Collection/Records
+    // and rows for primary/bills (2 records) and directory/entities (1 record after closure)
+    const shared = readZipFile(bytes, 'xl/sharedStrings.xml')!
+    expect(shared).toContain('>Vault<')
+    expect(shared).toContain('>Collection<')
+    expect(shared).toContain('>Records<')
+    expect(shared).toContain('>primary<')
+    expect(shared).toContain('>bills<')
+    expect(shared).toContain('>directory<')
+    expect(shared).toContain('>entities<')
+
+    await db.close()
+    await db2.close()
+  })
+
+  it('primary vault exports all rows (no closure filter)', async () => {
+    const { db, adapter } = await seedTwoVaults()
+    await grantXlsxBothVaults(adapter)
+
+    const db2 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+    const primaryVault = await db2.openVault('primary')
+    const dirVault = await db2.openVault('directory')
+
+    const bytes = await toBytesMultiVault([
+      {
+        vault: primaryVault,
+        sheets: [{ name: 'bills', collection: 'bills', columns: ['id', 'entityId', 'amount'] }],
+      },
+      {
+        vault: dirVault,
+        sheets: [{ name: 'entities', collection: 'entities', columns: ['id', 'name'] }],
+        closure: new Map([['entities', new Set(['e1'])]]),
+      },
+    ])
+
+    const shared = readZipFile(bytes, 'xl/sharedStrings.xml')!
+    // Both bills should be present (no closure on primary)
+    expect(shared).toContain('>b1<')
+    expect(shared).toContain('>b2<')
+
+    await db.close()
+    await db2.close()
+  })
+
+  it('uses label instead of vault.name when label is supplied', async () => {
+    const { db, adapter } = await seedTwoVaults()
+    await grantXlsxBothVaults(adapter)
+
+    const db2 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+    const primaryVault = await db2.openVault('primary')
+    const dirVault = await db2.openVault('directory')
+
+    const bytes = await toBytesMultiVault([
+      {
+        vault: primaryVault,
+        label: 'main',
+        sheets: [{ name: 'bills', collection: 'bills', columns: ['id', 'entityId', 'amount'] }],
+      },
+      {
+        vault: dirVault,
+        label: 'dir',
+        sheets: [{ name: 'entities', collection: 'entities', columns: ['id', 'name'] }],
+      },
+    ])
+
+    const workbook = readZipFile(bytes, 'xl/workbook.xml')!
+    expect(workbook).toContain('name="main_bills"')
+    expect(workbook).toContain('name="dir_entities"')
+
+    await db.close()
+    await db2.close()
+  })
+
+  it('uses custom sheetSeparator when supplied', async () => {
+    const { db, adapter } = await seedTwoVaults()
+    await grantXlsxBothVaults(adapter)
+
+    const db2 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+    const primaryVault = await db2.openVault('primary')
+
+    const bytes = await toBytesMultiVault(
+      [{ vault: primaryVault, sheets: [{ name: 'bills', collection: 'bills', columns: ['id'] }] }],
+      { sheetSeparator: '.' },
+    )
+
+    const workbook = readZipFile(bytes, 'xl/workbook.xml')!
+    expect(workbook).toContain('name="primary.bills"')
+
+    await db.close()
+    await db2.close()
+  })
+
+  it('refuses a vault without xlsx export grant (ExportCapabilityError)', async () => {
+    const { db } = await seedTwoVaults()
+    // No grant given — vaults created but no exportCapability
+    const primaryVault = await db.openVault('primary')
+    const dirVault = await db.openVault('directory')
+
+    await expect(
+      toBytesMultiVault([
+        { vault: primaryVault, sheets: [{ name: 'bills', collection: 'bills' }] },
+        { vault: dirVault, sheets: [{ name: 'entities', collection: 'entities' }] },
+      ]),
+    ).rejects.toThrow(ExportCapabilityError)
+
+    await db.close()
+  })
+})

--- a/packages/as-xlsx/src/index.ts
+++ b/packages/as-xlsx/src/index.ts
@@ -257,7 +257,121 @@ export async function write(
   await writeFile(path, bytes)
 }
 
+// ── multi-vault export ─────────────────────────────────────────────
+
+/**
+ * One vault entry in a multi-vault export. Supplies the pre-opened
+ * vault, the sheet specs to render for it, and an optional closure
+ * (per-collection id allowlist computed externally by the orchestrator).
+ */
+export interface MultiVaultXlsxEntry {
+  readonly vault: Vault
+  readonly sheets: readonly AsXlsxSheetOptions[]
+  /**
+   * Optional per-collection id allowlist (e.g. from walkCrossVaultClosure).
+   * When set, only rows whose `id` appears in the set are exported for that
+   * collection. Omit to export all rows.
+   */
+  readonly closure?: ReadonlyMap<string, ReadonlySet<string>>
+  /**
+   * Optional display label for sheet-name prefixing.
+   * Defaults to `vault.name`.
+   */
+  readonly label?: string
+}
+
+/** Options for {@link toBytesMultiVault}. */
+export interface MultiVaultXlsxOptions {
+  readonly dialect?: 'excel' | 'sheets'
+  /**
+   * Separator inserted between the vault label and the sheet name when
+   * building tab names. Default `'_'`. Names are then truncated to 31 chars
+   * (Excel limit) by `writeXlsx`.
+   */
+  readonly sheetSeparator?: string
+}
+
+/**
+ * Build an `.xlsx` byte stream spanning **multiple vaults**. Each entry
+ * supplies a pre-opened vault with its sheet specs and an optional
+ * per-collection id-closure (rows filtered to exactly those ids). A
+ * `_manifest` sheet is prepended that lists every vault-collection pair
+ * and its exported record count.
+ *
+ * ## Auth
+ * Every vault in `entries` must independently hold `assertCanExport('plaintext','xlsx')`.
+ * The check fires fail-fast before any rows are materialised.
+ *
+ * ## Architecture
+ * This function is **edge-pure** — it takes pre-opened vaults and a
+ * pre-computed closure; it performs no cross-vault FK walk itself.
+ * Cross-vault orchestration lives in `@klum-db/lobby` (allowed direction).
+ */
+export async function toBytesMultiVault(
+  entries: readonly MultiVaultXlsxEntry[],
+  options: MultiVaultXlsxOptions = {},
+): Promise<Uint8Array> {
+  const sep = options.sheetSeparator ?? '_'
+
+  // Fail-fast auth check on every vault before materialising any rows.
+  for (const entry of entries) {
+    entry.vault.assertCanExport('plaintext', 'xlsx')
+  }
+
+  const allSheets: XlsxSheet[] = []
+  const manifestRows: (string | number)[][] = []
+
+  for (const entry of entries) {
+    const prefix = entry.label ?? entry.vault.name
+    for (const s of entry.sheets) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const all = await entry.vault.collection<any>(s.collection).list()
+      const records: Record<string, unknown>[] = []
+      for (const item of all) {
+        const r = item as Record<string, unknown>
+        // Closure filter: if a closure is supplied for this collection, keep
+        // only rows whose id is in the allowlist.
+        const allow = entry.closure?.get(s.collection)
+        if (allow && !allow.has(String((r as { id?: unknown }).id))) continue
+        // User-supplied row predicate (same semantics as single-vault toBytes).
+        if (s.filter && !s.filter(r)) continue
+        records.push(r)
+      }
+      const columns = s.columns ?? inferColumns(records)
+      const sheetName = `${prefix}${sep}${s.name}`
+      allSheets.push(buildFlatSheet(sheetName, columns, records))
+      manifestRows.push([prefix, s.collection, records.length])
+    }
+  }
+
+  // Prepend the _manifest sheet.
+  allSheets.unshift({
+    name: '_manifest',
+    header: ['Vault', 'Collection', 'Records'],
+    rows: manifestRows,
+  })
+
+  return writeXlsx(allSheets)
+}
+
 // ── internals ─────────────────────────────────────────────────────
+
+/**
+ * Build a flat {@link XlsxSheet} from pre-filtered records.
+ * Used by both {@link toBytes} (via its own inline path) and
+ * {@link toBytesMultiVault}.
+ */
+function buildFlatSheet(
+  name: string,
+  columns: readonly string[],
+  records: readonly Record<string, unknown>[],
+): XlsxSheet {
+  return {
+    name,
+    header: [...columns],
+    rows: records.map((r) => columns.map((c) => r[c] ?? null)),
+  }
+}
 
 /** Safely stringify an unknown id/code/label (objects → JSON, never '[object Object]'). */
 function safeStringify(v: unknown): string {

--- a/packages/as-xlsx/src/index.ts
+++ b/packages/as-xlsx/src/index.ts
@@ -96,6 +96,46 @@ export interface AsXlsxSheetOptions {
    * global LANG cell via `VLOOKUP(code, …, MATCH(LANG, …))`.
    */
   readonly dictFields?: Record<string, string>
+  /**
+   * Multi-vault export only: pull FK-referenced fields from a supporting vault
+   * into this sheet as extra columns. Each entry resolves `localField` on the
+   * primary record against the `keyField` of another vault's collection (matched
+   * by `from.label`/`from.collection`), and emits the `pick` field value as
+   * `column`. Appended AFTER the declared `columns` in declaration order.
+   * Unresolved FK (row not in the supporting-vault index) → empty cell.
+   * Ignored by single-vault `toBytes`.
+   */
+  readonly denormalize?: readonly MultiVaultDenormColumn[]
+}
+
+/**
+ * One denormalized column in a multi-vault export: pulls a field from a
+ * supporting vault into the primary sheet via an in-memory join.
+ *
+ * @example
+ * ```ts
+ * {
+ *   column: 'entityName',   // new column header in the primary sheet
+ *   localField: 'entityId', // FK field on the primary record
+ *   from: { label: 'directory', collection: 'entities', keyField: 'id', pick: 'name' },
+ * }
+ * ```
+ */
+export interface MultiVaultDenormColumn {
+  /** Header of the new column to append to the primary sheet. */
+  readonly column: string
+  /** Field on the primary record whose value is the FK. */
+  readonly localField: string
+  readonly from: {
+    /** Label of the supporting vault entry (matches `MultiVaultXlsxEntry.label`). */
+    readonly label: string
+    /** Collection in the supporting vault. */
+    readonly collection: string
+    /** Field in the supporting record that is the join key (usually `'id'`). */
+    readonly keyField: string
+    /** Field in the supporting record to copy as the denorm value. */
+    readonly pick: string
+  }
 }
 
 /** One aggregate column in a smart-mode summary sheet (#414 P3). */
@@ -306,6 +346,15 @@ export interface MultiVaultXlsxOptions {
  * This function is **edge-pure** — it takes pre-opened vaults and a
  * pre-computed closure; it performs no cross-vault FK walk itself.
  * Cross-vault orchestration lives in `@klum-db/lobby` (allowed direction).
+ *
+ * ## Two-pass execution (when `denormalize` is declared)
+ * **Pass 1** — load and closure-filter ALL entries' rows, building a
+ * `Map<"${label}/${collection}", Map<keyValue, row>>` index keyed by each
+ * sheet's `keyField` (default `'id'`). Only closure-filtered rows are indexed,
+ * so an FK pointing outside the closure yields an empty cell (correct: that
+ * row was not referenced / not exported).
+ * **Pass 2** — emit each sheet; for sheets with `denormalize`, append each
+ * denorm column AFTER the declared columns by resolving the index lookup.
  */
 export async function toBytesMultiVault(
   entries: readonly MultiVaultXlsxEntry[],
@@ -318,8 +367,19 @@ export async function toBytesMultiVault(
     entry.vault.assertCanExport('plaintext', 'xlsx')
   }
 
-  const allSheets: XlsxSheet[] = []
-  const manifestRows: (string | number)[][] = []
+  // ── Pass 1: load + closure-filter all rows, build denorm index ────
+
+  /** Loaded rows per (label, collection) pair. */
+  interface LoadedSheet {
+    entry: MultiVaultXlsxEntry
+    prefix: string
+    sheetOpt: AsXlsxSheetOptions
+    records: Record<string, unknown>[]
+  }
+  const loaded: LoadedSheet[] = []
+
+  /** Denorm index: `"${label}/${collection}" → Map<keyValue, row>`. */
+  const denormIndex = new Map<string, Map<string, Record<string, unknown>>>()
 
   for (const entry of entries) {
     const prefix = entry.label ?? entry.vault.name
@@ -337,11 +397,77 @@ export async function toBytesMultiVault(
         if (s.filter && !s.filter(r)) continue
         records.push(r)
       }
-      const columns = s.columns ?? inferColumns(records)
-      const sheetName = `${prefix}${sep}${s.name}`
-      allSheets.push(buildFlatSheet(sheetName, columns, records))
-      manifestRows.push([prefix, s.collection, records.length])
+      loaded.push({ entry, prefix, sheetOpt: s, records })
+
+      // Build index for this collection, keyed by every field that any denorm
+      // might reference as `keyField`. We index by `id` by default, and also
+      // by any explicitly declared `keyField` that differs from `'id'`.
+      const indexKey = `${prefix}/${s.collection}`
+      const collectionIndex = denormIndex.get(indexKey) ?? new Map<string, Record<string, unknown>>()
+      denormIndex.set(indexKey, collectionIndex)
+      for (const r of records) {
+        // Always index by `id` (most common key) and by any declared keyFields.
+        const idVal = (r as { id?: unknown }).id
+        if (idVal != null) collectionIndex.set(safeStringify(idVal), r)
+      }
     }
+  }
+
+  // If any sheet declares denormalize with a non-'id' keyField, also index by that.
+  for (const ls of loaded) {
+    for (const d of ls.sheetOpt.denormalize ?? []) {
+      if (d.from.keyField === 'id') continue // already indexed
+      const indexKey = `${d.from.label}/${d.from.collection}`
+      const idx = denormIndex.get(indexKey)
+      if (!idx) continue
+      // Find the loaded sheet for that label+collection and re-index by keyField.
+      const srcLoaded = loaded.find(
+        (l) => l.prefix === d.from.label && l.sheetOpt.collection === d.from.collection,
+      )
+      if (!srcLoaded) continue
+      for (const r of srcLoaded.records) {
+        const kv = r[d.from.keyField]
+        if (kv != null) idx.set(safeStringify(kv), r)
+      }
+    }
+  }
+
+  // ── Pass 2: emit sheets with optional denorm columns ─────────────
+
+  const allSheets: XlsxSheet[] = []
+  const manifestRows: (string | number)[][] = []
+
+  for (const { prefix, sheetOpt: s, records } of loaded) {
+    const baseColumns = s.columns ?? inferColumns(records)
+    const denormDefs = s.denormalize ?? []
+
+    if (denormDefs.length === 0) {
+      // Fast path: no denorm — identical to Task 1 behaviour.
+      const sheetName = `${prefix}${sep}${s.name}`
+      allSheets.push(buildFlatSheet(sheetName, baseColumns, records))
+      manifestRows.push([prefix, s.collection, records.length])
+      continue
+    }
+
+    // Denorm path: append extra columns after the declared ones.
+    const allColumns = [...baseColumns, ...denormDefs.map((d) => d.column)]
+    const sheetName = `${prefix}${sep}${s.name}`
+    const rows = records.map((r) => {
+      const baseCells = baseColumns.map((c) => r[c] ?? null)
+      const denormCells = denormDefs.map((d) => {
+        const idxKey = `${d.from.label}/${d.from.collection}`
+        const idx = denormIndex.get(idxKey)
+        if (!idx) return ''
+        const fkVal = r[d.localField]
+        if (fkVal == null) return ''
+        const supporting = idx.get(safeStringify(fkVal))
+        if (!supporting) return '' // unresolved FK → empty cell
+        return supporting[d.from.pick] ?? ''
+      })
+      return [...baseCells, ...denormCells]
+    })
+    allSheets.push({ name: sheetName, header: allColumns, rows })
+    manifestRows.push([prefix, s.collection, records.length])
   }
 
   // Prepend the _manifest sheet.

--- a/packages/as-xlsx/src/index.ts
+++ b/packages/as-xlsx/src/index.ts
@@ -322,7 +322,6 @@ export interface MultiVaultXlsxEntry {
 
 /** Options for {@link toBytesMultiVault}. */
 export interface MultiVaultXlsxOptions {
-  readonly dialect?: 'excel' | 'sheets'
   /**
    * Separator inserted between the vault label and the sheet name when
    * building tab names. Default `'_'`. Names are then truncated to 31 chars

--- a/packages/lobby/__tests__/export-multivault-xlsx.test.ts
+++ b/packages/lobby/__tests__/export-multivault-xlsx.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Lobby.exportMultiVaultXlsx — orchestrator integration test (FR-9 Task 3).
+ *
+ * Verifies that the Lobby:
+ *   - walks the FK closure (via walkCrossVaultClosure / FR-2)
+ *   - delegates to toBytesMultiVault with the correct per-vault closures
+ *   - the directory_entities sheet is filtered to ONLY the FK-referenced ids
+ *   - the bills sheet has the denormalized entityName column
+ *   - single-vault exports are unaffected (smoke via existing tests)
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { createLobby } from '../src/index.js'
+
+// ── zip helpers (mirrored from as-xlsx multivault-xlsx.test.ts) ────────────────
+
+function readZipFile(bytes: Uint8Array, path: string): string | null {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  const eocdOffset = bytes.length - 22
+  const cdOffset = view.getUint32(eocdOffset + 16, true)
+  const recordCount = view.getUint16(eocdOffset + 10, true)
+  let pos = cdOffset
+  for (let i = 0; i < recordCount; i++) {
+    const nameLen = view.getUint16(pos + 28, true)
+    const extraLen = view.getUint16(pos + 30, true)
+    const commentLen = view.getUint16(pos + 32, true)
+    const name = new TextDecoder().decode(bytes.subarray(pos + 46, pos + 46 + nameLen))
+    if (name === path) {
+      const lfhOffset = view.getUint32(pos + 42, true)
+      const lfhNameLen = view.getUint16(lfhOffset + 26, true)
+      const lfhExtraLen = view.getUint16(lfhOffset + 28, true)
+      const size = view.getUint32(lfhOffset + 18, true)
+      const dataStart = lfhOffset + 30 + lfhNameLen + lfhExtraLen
+      return new TextDecoder().decode(bytes.subarray(dataStart, dataStart + size))
+    }
+    pos += 46 + nameLen + extraLen + commentLen
+  }
+  return null
+}
+
+// ── fixture ────────────────────────────────────────────────────────────────────
+
+/**
+ * Seeds one Noydb instance with two vaults:
+ *  - primary  → bills (b1→e1, b2→e1, b3→e2)  NOTE: b3 references e2
+ *  - directory → entities (e1=Acme Corp, e2=Beta Inc, e3=Gamma Ltd — e3 NOT referenced)
+ *
+ * bills b1+b2 reference e1; b3 references e2 → e3 is unreferenced.
+ * This lets us assert that the directory_entities sheet has exactly {e1, e2} and NOT e3.
+ */
+async function buildFixture() {
+  const adapter = memory()
+  const db = await createNoydb({ store: adapter, user: 'owner-01', secret: 'lobby-secret' })
+
+  const primaryVault = await db.openVault('primary')
+  const bills = primaryVault.collection<{ id: string; entityId: string; amount: number }>('bills')
+  await bills.put('b1', { id: 'b1', entityId: 'e1', amount: 100 })
+  await bills.put('b2', { id: 'b2', entityId: 'e1', amount: 200 })
+  await bills.put('b3', { id: 'b3', entityId: 'e2', amount: 50 })
+
+  const dirVault = await db.openVault('directory')
+  const entities = dirVault.collection<{ id: string; name: string }>('entities')
+  await entities.put('e1', { id: 'e1', name: 'Acme Corp' })
+  await entities.put('e2', { id: 'e2', name: 'Beta Inc' })
+  await entities.put('e3', { id: 'e3', name: 'Gamma Ltd' }) // NOT referenced
+
+  await db.close()
+
+  // Grant xlsx export on both vaults
+  const db2 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'lobby-secret' })
+  await db2.grant('primary', {
+    userId: 'owner-01', displayName: 'Owner', role: 'owner',
+    passphrase: 'lobby-secret',
+    exportCapability: { plaintext: ['xlsx'] },
+  })
+  await db2.grant('directory', {
+    userId: 'owner-01', displayName: 'Owner', role: 'owner',
+    passphrase: 'lobby-secret',
+    exportCapability: { plaintext: ['xlsx'] },
+  })
+  await db2.close()
+
+  // Open a fresh session for the actual test
+  const db3 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'lobby-secret' })
+  const lobby = createLobby(db3)
+
+  return { db: db3, lobby }
+}
+
+// ── tests ──────────────────────────────────────────────────────────────────────
+
+describe('Lobby.exportMultiVaultXlsx', () => {
+  it('workbook spans both vaults with vault-prefixed sheet names', async () => {
+    const { db, lobby } = await buildFixture()
+
+    const bytes = await lobby.exportMultiVaultXlsx({
+      primary: { vault: 'primary', seeds: { bills: () => true } },
+      crossVaultRefs: [
+        { from: { collection: 'bills', field: 'entityId' }, to: { vault: 'directory', collection: 'entities' } },
+      ],
+      sheets: {
+        primary: [{ name: 'bills', collection: 'bills' }],
+        directory: [{ name: 'entities', collection: 'entities' }],
+      },
+    })
+
+    // Must be a valid xlsx (zip magic bytes)
+    expect(bytes[0]).toBe(0x50)
+    expect(bytes[1]).toBe(0x4b)
+
+    const workbook = readZipFile(bytes, 'xl/workbook.xml')!
+    expect(workbook).toContain('name="primary_bills"')
+    expect(workbook).toContain('name="directory_entities"')
+    expect(workbook).toContain('name="_manifest"')
+
+    await db.close()
+  })
+
+  it('directory_entities sheet contains EXACTLY FK-referenced entity ids (e1, e2 — not e3)', async () => {
+    const { db, lobby } = await buildFixture()
+
+    const bytes = await lobby.exportMultiVaultXlsx({
+      primary: { vault: 'primary', seeds: { bills: () => true } },
+      crossVaultRefs: [
+        { from: { collection: 'bills', field: 'entityId' }, to: { vault: 'directory', collection: 'entities' } },
+      ],
+      sheets: {
+        primary: [{ name: 'bills', collection: 'bills' }],
+        directory: [{ name: 'entities', collection: 'entities' }],
+      },
+    })
+
+    const shared = readZipFile(bytes, 'xl/sharedStrings.xml')!
+    // Referenced entities must appear
+    expect(shared).toContain('>Acme Corp<')  // e1
+    expect(shared).toContain('>Beta Inc<')   // e2
+    // Unreferenced entity must NOT appear (closure filter)
+    expect(shared).not.toContain('>Gamma Ltd<')  // e3 — not referenced by any bill
+
+    await db.close()
+  })
+
+  it('bills sheet has the denormalized entityName column with correct values', async () => {
+    const { db, lobby } = await buildFixture()
+
+    const bytes = await lobby.exportMultiVaultXlsx({
+      primary: { vault: 'primary', seeds: { bills: () => true } },
+      crossVaultRefs: [
+        { from: { collection: 'bills', field: 'entityId' }, to: { vault: 'directory', collection: 'entities' } },
+      ],
+      sheets: {
+        primary: [{
+          name: 'bills',
+          collection: 'bills',
+          columns: ['id', 'entityId', 'amount'],
+          denormalize: [{
+            column: 'entityName',
+            localField: 'entityId',
+            from: { label: 'directory', collection: 'entities', keyField: 'id', pick: 'name' },
+          }],
+        }],
+        directory: [{ name: 'entities', collection: 'entities' }],
+      },
+    })
+
+    const shared = readZipFile(bytes, 'xl/sharedStrings.xml')!
+    // The denorm column header should appear
+    expect(shared).toContain('>entityName<')
+    // The resolved names should be present
+    expect(shared).toContain('>Acme Corp<')
+    expect(shared).toContain('>Beta Inc<')
+
+    await db.close()
+  })
+
+  it('bill b1 (entityId=e1) maps to entityName=Acme Corp in the bills sheet', async () => {
+    const { db, lobby } = await buildFixture()
+
+    const bytes = await lobby.exportMultiVaultXlsx({
+      primary: { vault: 'primary', seeds: { bills: () => true } },
+      crossVaultRefs: [
+        { from: { collection: 'bills', field: 'entityId' }, to: { vault: 'directory', collection: 'entities' } },
+      ],
+      sheets: {
+        primary: [{
+          name: 'bills',
+          collection: 'bills',
+          columns: ['id', 'entityId', 'amount'],
+          denormalize: [{
+            column: 'entityName',
+            localField: 'entityId',
+            from: { label: 'directory', collection: 'entities', keyField: 'id', pick: 'name' },
+          }],
+        }],
+        directory: [{ name: 'entities', collection: 'entities' }],
+      },
+    })
+
+    // Find the primary_bills sheet
+    const workbook = readZipFile(bytes, 'xl/workbook.xml')!
+    const billsMatch = workbook.match(/name="primary_bills" sheetId="(\d+)"/)
+    expect(billsMatch).not.toBeNull()
+    const sheetId = billsMatch![1]
+    const sheetXml = readZipFile(bytes, `xl/worksheets/sheet${sheetId}.xml`)!
+    const shared = readZipFile(bytes, 'xl/sharedStrings.xml')!
+
+    // The shared strings table must have both the FK id and its resolved name
+    expect(shared).toContain('>e1<')
+    expect(shared).toContain('>Acme Corp<')
+
+    // The sheet XML must reference cells with the b1 row data
+    expect(sheetXml).not.toBe(null)
+
+    await db.close()
+  })
+})

--- a/packages/lobby/package.json
+++ b/packages/lobby/package.json
@@ -45,9 +45,11 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
+    "@noy-db/as-xlsx": "workspace:*",
     "@noy-db/hub": "workspace:*"
   },
   "devDependencies": {
+    "@noy-db/as-xlsx": "workspace:*",
     "@noy-db/hub": "workspace:*",
     "@noy-db/to-memory": "workspace:*",
     "@types/node": "^22.0.0",

--- a/packages/lobby/src/index.ts
+++ b/packages/lobby/src/index.ts
@@ -8,7 +8,7 @@ import { STATE_VAULT_NAME } from '@noy-db/hub'
 import type { VaultGroup } from './federation/vault-group.js'
 import type { StateManagementVault } from './federation/state-vault.js'
 import type { VaultTemplate, VaultGroupOptions } from './federation/types.js'
-import type { AsXlsxSheetOptions, MultiVaultXlsxOptions } from '@noy-db/as-xlsx'
+import type { AsXlsxSheetOptions } from '@noy-db/as-xlsx'
 import type { CrossVaultRef } from './interchange/extract-cross-vault.js'
 
 /**
@@ -40,8 +40,6 @@ export interface ExportMultiVaultXlsxOptions {
   readonly sheets: Readonly<Record<string, readonly AsXlsxSheetOptions[]>>
   /** Optional maxDepth for walkCrossVaultClosure. */
   readonly maxDepth?: number
-  /** Optional dialect forwarded to toBytesMultiVault. */
-  readonly dialect?: MultiVaultXlsxOptions['dialect']
   /** Optional sheet-name separator forwarded to toBytesMultiVault. */
   readonly sheetSeparator?: string
 }
@@ -133,7 +131,6 @@ export class Lobby {
     )
 
     return toBytesMultiVault(entries, {
-      ...(opts.dialect ? { dialect: opts.dialect } : {}),
       ...(opts.sheetSeparator !== undefined ? { sheetSeparator: opts.sheetSeparator } : {}),
     })
   }

--- a/packages/lobby/src/index.ts
+++ b/packages/lobby/src/index.ts
@@ -8,6 +8,43 @@ import { STATE_VAULT_NAME } from '@noy-db/hub'
 import type { VaultGroup } from './federation/vault-group.js'
 import type { StateManagementVault } from './federation/state-vault.js'
 import type { VaultTemplate, VaultGroupOptions } from './federation/types.js'
+import type { AsXlsxSheetOptions, MultiVaultXlsxOptions } from '@noy-db/as-xlsx'
+import type { CrossVaultRef } from './interchange/extract-cross-vault.js'
+
+/**
+ * Options for {@link Lobby.exportMultiVaultXlsx} (FR-9).
+ *
+ * Walks the cross-vault FK closure (FR-2) starting from `primary.vault` using
+ * the supplied `primary.seeds` predicates, then delegates to
+ * `@noy-db/as-xlsx`'s `toBytesMultiVault` for edge-pure rendering.
+ *
+ * **Primary-vault row scope:** `walkCrossVaultClosure` populates
+ * `perVaultClosure` for the primary vault (the seed predicate rows are
+ * collected there). This orchestrator passes that closure to the primary
+ * vault entry, so the export contains exactly the seeded rows — not more,
+ * not less. Supporting vaults receive their closure slice (FK-referenced ids
+ * only, never the full collection).
+ */
+export interface ExportMultiVaultXlsxOptions {
+  /** Primary vault: name + seed predicates per collection. */
+  readonly primary: {
+    readonly vault: string
+    readonly seeds: Record<string, (rec: Record<string, unknown>) => boolean | Promise<boolean>>
+  }
+  /** Cross-vault FK edges that drive the closure walk. */
+  readonly crossVaultRefs?: readonly CrossVaultRef[]
+  /**
+   * Per-vault sheet specs. Keys must be vault names (including `primary.vault`).
+   * Sheet options may include `denormalize` for FK-join columns.
+   */
+  readonly sheets: Readonly<Record<string, readonly AsXlsxSheetOptions[]>>
+  /** Optional maxDepth for walkCrossVaultClosure. */
+  readonly maxDepth?: number
+  /** Optional dialect forwarded to toBytesMultiVault. */
+  readonly dialect?: MultiVaultXlsxOptions['dialect']
+  /** Optional sheet-name separator forwarded to toBytesMultiVault. */
+  readonly sheetSeparator?: string
+}
 
 export class Lobby {
   readonly noydb: Noydb
@@ -48,6 +85,57 @@ export class Lobby {
     if (db.isClosed) throw new ValidationError('Instance is closed')
     const { StateManagementVault } = await import('./federation/state-vault.js')
     return StateManagementVault.open(db)
+  }
+
+  /**
+   * One-call multi-vault Excel export (FR-9).
+   *
+   * 1. Calls `walkCrossVaultClosure` (FR-2) to build the FK closure across all
+   *    referenced vaults, starting from `opts.primary.vault` using the supplied
+   *    seed predicates.
+   * 2. For each vault in `opts.sheets`, opens the vault and attaches the
+   *    per-vault closure slice from the plan:
+   *    - **Primary vault**: gets its `perVaultClosure` slice (the seeded rows).
+   *    - **Supporting vaults**: get their closure slice (FK-referenced ids only).
+   * 3. Delegates to `@noy-db/as-xlsx`'s `toBytesMultiVault` for edge-pure
+   *    rendering (no cross-vault walk in the adapter).
+   *
+   * Every vault in `opts.sheets` must independently hold
+   * `assertCanExport('plaintext','xlsx')`.
+   */
+  async exportMultiVaultXlsx(opts: ExportMultiVaultXlsxOptions): Promise<Uint8Array> {
+    const { walkCrossVaultClosure } = await import('./interchange/extract-cross-vault.js')
+    const { toBytesMultiVault } = await import('@noy-db/as-xlsx')
+
+    const openVault = (name: string) => this.noydb.openVault(name)
+
+    const plan = await walkCrossVaultClosure(openVault, {
+      seed: { vault: opts.primary.vault, seeds: opts.primary.seeds },
+      ...(opts.crossVaultRefs !== undefined ? { crossVaultRefs: opts.crossVaultRefs } : {}),
+      ...(opts.maxDepth !== undefined ? { maxDepth: opts.maxDepth } : {}),
+    })
+
+    const entries = await Promise.all(
+      Object.entries(opts.sheets).map(async ([vaultName, sheets]) => {
+        const vault = await openVault(vaultName)
+        const closure = plan.perVaultClosure.get(vaultName)
+        // Both primary and supporting vaults get their perVaultClosure slice:
+        //   - primary: the seeded rows (walkCrossVaultClosure includes the seed vault)
+        //   - supporting: the FK-referenced ids only
+        // This ensures the export is bounded to exactly what the closure walk found.
+        return {
+          vault,
+          sheets: sheets as AsXlsxSheetOptions[],
+          label: vaultName,
+          ...(closure ? { closure } : {}),
+        }
+      }),
+    )
+
+    return toBytesMultiVault(entries, {
+      ...(opts.dialect ? { dialect: opts.dialect } : {}),
+      ...(opts.sheetSeparator !== undefined ? { sheetSeparator: opts.sheetSeparator } : {}),
+    })
   }
 }
 
@@ -134,3 +222,13 @@ export type {
 // without importing hub internals directly (no lobby logic in this slice).
 export { CustodyApi, liberateVault, createDeedOwner, loadDeedMarker, isDeedVault } from '@noy-db/hub'
 export type { DeedMarker, LiberateOptions, LiberateResult, GrantCustodianOptions } from '@noy-db/hub'
+
+// ─── FR-9: Multi-vault FK-driven Excel export ─────────────────────────────────
+// ExportMultiVaultXlsxOptions is declared (and exported) above alongside Lobby.
+// Re-export the as-xlsx multi-vault types so consumers don't need to import
+// @noy-db/as-xlsx directly.
+export type {
+  MultiVaultXlsxEntry,
+  MultiVaultXlsxOptions,
+  MultiVaultDenormColumn,
+} from '@noy-db/as-xlsx'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -575,6 +575,9 @@ importers:
 
   packages/lobby:
     devDependencies:
+      '@noy-db/as-xlsx':
+        specifier: workspace:*
+        version: link:../as-xlsx
       '@noy-db/hub':
         specifier: workspace:*
         version: link:../hub

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -604,30 +604,39 @@ function checkKernelSurface() {
   }
 }
 
-// ─── Check 8: no-outbound-klum-import (hub core must not depend on @klum-db) ───
+// ─── Check 8: no-outbound-klum-import (NO @noy-db package may depend on @klum-db) ───
 function checkNoOutboundKlumImport() {
-  const hubSrc = join(PACKAGES_DIR, 'hub', 'src')
+  // The dependency runs ONE way: @klum-db/* (orchestration) → @noy-db/* (vault).
+  // No @noy-db package — hub core OR any edge adapter (e.g. as-xlsx, FR-9) — may
+  // import @klum-db. Scan every package's src EXCEPT the @klum-db packages
+  // themselves (which legitimately import each other / re-export klum symbols).
+  //
   // Use stripComments (NOT stripCommentsAndStrings): import specifiers ARE
   // string literals — blanking string bodies makes this a no-op. Line-anchor
   // to real import/export statements so FederationMovedError's runtime message
   // (which contains "from '@klum-db/lobby'" mid-line) doesn't false-positive.
   //
   // Accepted limitation: a hand-split multi-line import where `from` lands on
-  // a `}`-leading line is NOT matched. That's fine — hub does not declare
-  // @klum-db/* as a dependency, so any real hub→klum import also fails hub's
-  // build/typecheck (hard backstop that covers the multi-line edge case).
+  // a `}`-leading line is NOT matched. That's fine — no @noy-db package declares
+  // @klum-db/* as a dependency, so any real outbound import also fails that
+  // package's build/typecheck (hard backstop that covers the multi-line edge case).
   const klumStatic = /^\s*(?:import|export)\b[^\n]*?\bfrom\s+['"]@klum-db\//m
   const klumDynamic = /\bimport\s*\(\s*['"]@klum-db\//
-  walkTsFiles(hubSrc, (file, content) => {
-    const code = stripComments(content)
-    if (klumStatic.test(code) || klumDynamic.test(code)) {
-      fail(
-        'no-outbound-klum-import',
-        `${relative(ROOT, file)} imports from @klum-db. Hub core must NOT depend on the extracted orchestration package — the dependency runs the other way (@klum-db/lobby depends on @noy-db/hub/kernel).`,
-        file,
-      )
-    }
-  })
+  for (const pkgDir of listPackageDirs()) {
+    let name
+    try { name = readPackageJson(pkgDir).name } catch { continue }
+    if (typeof name === 'string' && name.startsWith('@klum-db/')) continue // klum packages may import klum
+    walkTsFiles(join(pkgDir, 'src'), (file, content) => {
+      const code = stripComments(content)
+      if (klumStatic.test(code) || klumDynamic.test(code)) {
+        fail(
+          'no-outbound-klum-import',
+          `${relative(ROOT, file)} imports from @klum-db. No @noy-db package (hub core OR edge adapter) may depend on the orchestration package — the dependency runs the other way (@klum-db/lobby depends on @noy-db/hub/kernel + edge adapters).`,
+          file,
+        )
+      }
+    })
+  }
 }
 
 // ─── Check 7: no debugPlaintext in shipped library source (#413 P3) ─────


### PR DESCRIPTION
## FR-9 — Multi-Vault FK-Driven Excel Export — pilot-1 epic vLannaAi/klum-db#1, issue vLannaAi/klum-db#10

Export an Excel workbook that spans **multiple vaults** — a primary vault's sheets plus supporting-vault sheets containing **exactly the FK-referenced rows** (no full-table dump), with FK'd fields **denormalized as columns** into the primary sheet. The read-side dual of FR-2's FK closure (under federation, a master Excel needs the client shard + the shared directory, but only the actively-referenced rows).

### Architecture — the dependency boundary
`@noy-db/as-xlsx` is an **edge adapter** (hub-only); it must not import `@klum-db/lobby`. So FR-9 splits cleanly:
- **Edge (pure render):** `@noy-db/as-xlsx` gains `toBytesMultiVault(entries, options?)` — takes *pre-opened* vaults + a *pre-computed* per-vault id-closure + a denormalize config, and renders the workbook. The denormalize is an **in-memory join over rows it has already loaded** — no cross-vault walk inside the adapter.
- **Orchestration (the FK walk):** `@klum-db/lobby` gains `Lobby.exportMultiVaultXlsx(...)` — calls FR-2's `walkCrossVaultClosure`, opens vaults, builds entries (closure + denorm), delegates to `toBytesMultiVault`. Lobby gains a peer-dep on `@noy-db/as-xlsx` (the allowed `klum→noy` direction). The `no-outbound-klum-import` guard stays green.

### What's in it
- **`@noy-db/as-xlsx` `toBytesMultiVault`** — one workbook across N vaults; vault-prefixed sheet names (31-char truncate + dedup); per-vault `assertCanExport('plaintext','xlsx')` (fail-fast); supporting sheets filtered to a supplied id-closure; a multi-vault `_manifest`.
- **Denormalized FK columns** — opt-in `AsXlsxSheetOptions.denormalize` pulls a supporting field into the primary sheet as a column (`bills.entityId → directory.entities.id → entities.name`); two-pass load-index-then-emit; unresolved FK → empty cell.
- **`Lobby.exportMultiVaultXlsx`** — the one-call orchestrator: FK walk → closure → entries → render.

### Acceptance (#449) — all met + tested
1. A workbook spans ≥2 compartments.
2. Supporting-vault rows are **exactly** those FK-referenced by the exported primary rows (closure-filtered — no full-table dump).
3. Single-vault export is unchanged (`toBytes` byte-untouched; `denormalize` is opt-in and ignored single-vault; the existing as-xlsx suite is the guard).

### Scope
Smart-mode cross-vault VLOOKUP (rewriting `sheetNameByCollection` → by-vault-and-collection so a primary cell can VLOOKUP into a vault-prefixed supporting sheet) is a documented follow-up; this slice ships flat multi-vault export + the denormalized columns.

### Verification
- as-xlsx: 55 tests / lobby: 123 tests — all green
- `pnpm lint` (127) + `pnpm typecheck` (130) clean
- `validate-features.mjs` (70 features) + `check:architecture` pass (incl. `no-outbound-klum-import` — as-xlsx has no klum import)

### Builds on
`@noy-db/as-xlsx`, FR-2's `CrossVaultRef`/`walkCrossVaultClosure` (the same descriptors drive both the bundle path and this export path), broadcastJoin-style cross-vault read-enrich (realized as the in-memory join in the edge adapter).
