### PR TITLE
FR-7: Surface / scoped sync — closes pilot-1 epic #440

### DIFF
--- a/docs/superpowers/plans/2026-06-18-fr7-surface-scoped-sync.md
+++ b/docs/superpowers/plans/2026-06-18-fr7-surface-scoped-sync.md
@@ -1,0 +1,179 @@
+# FR-7 — Surface / Scoped Sync Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A **Surface** — a persisted, bilaterally-agreed subset (`{collections, fields?, direction, conflictPolicy, cadence?}`) two parties sync. A surface syncs only its named collections/fields, in its direction, applying its conflict policy; **collections/fields outside the surface never leave the vault**.
+
+**Architecture:** `@klum-db/lobby` orchestration over the StateManagementVault persistence pattern, reusing FR-2 `extractPartition` (the scoped slice) + FR-3/4 `mergeCompartment` (apply with conflict policy). One net-new `@noy-db/hub` primitive: **structural field projection** during extract (`fieldProjection` on `reKeyClosure`). Field scoping = structural redaction at the export boundary (excluded fields are dropped before re-encryption, so they're never in the transmitted slice — not cryptographic intra-vault hiding, which is irrelevant for sync). The raw SyncEngine is NOT used (it copies ciphertext and can't project fields).
+
+**Tech stack:** TypeScript, vitest, pnpm. `@noy-db/hub` (extract projection), `@klum-db/lobby` (Surface).
+
+**Design decisions (resolved at the FR-7 gate):**
+- **Field scoping → structural field projection now** (drop non-surface fields before re-encryption).
+- **Surface → persisted + scheduled** (a `surfaces` collection in the StateManagementVault; a propose/agree bilateral handshake; a host-driven cadence scheduler).
+- Reuse FR-2 extract + FR-3/4 merge; SyncEngine not used; transfer key is per-run (out-of-band, like FR-2/3), not persisted.
+- No row-level predicate (not in #447's Surface shape).
+
+---
+
+## Key existing surfaces (from recon)
+- `extractPartition(vault, WalkClosureOptions & {compression?, carrySchemas?, carryLedger?})` (`packages/hub/src/bundle/extract-partition.ts:247`). `WalkClosureOptions{ seeds: Record<collection,(rec)=>boolean>, maxDepth? }`. The re-key loop is `reKeyClosure` (`:53-76`) with TWO branches (per-record CEK `:57-70` + standard DEK `:72-75`); `reKeySchemas` (`:89-108`) carries `_schemas/<collection>` when `carrySchemas`. No `collections` allowlist option — `seeds` keys ARE the starting collections; `maxDepth` bounds ref-following.
+- `mergeCompartment(receiver, bundleBytes, {transferKey, strategy, dryRun?, reason?, fieldAuthority?})` → MergeReport (`packages/lobby/src/interchange/merge-compartment.ts:312`). `MergeStrategy = take-incoming|keep-local|lww-by-ts|manual-queue|field-authority`.
+- `StateManagementVault.open(db)` (`packages/lobby/src/federation/state-vault.ts`) opens `STATE_VAULT_NAME`, binds typed `collection<T>()` handles (registry/manifest/events/migrationStatus); `appendEvent` uses `Date.now()`. Pattern: add a 5th `surfaces` collection.
+- Two-party harness: two `createNoydb({store: sharedStore, ...})` over a SHARED store both `StateManagementVault.open()` the same `_state` vault (federation-fleet-migration.test.ts:178 "session 2 over same store"; tab-write-propagation.test.ts:65 twoTabs).
+- Lobby files have NO kernel ceilings; extract-partition.ts has none either. Only the `no-outbound-klum-import` guard applies (FR-7 stays klum→noy clean).
+
+---
+
+## File structure
+- **Modify** `packages/hub/src/bundle/extract-partition.ts` — `fieldProjection` on `extractPartition` + `reKeyClosure` + `reKeySchemas` skip. (Task 1)
+- **Modify** `packages/lobby/src/federation/state-vault.ts` + `federation/types.ts` — `SurfaceRow` + `surfaces` collection + CRUD. (Task 2)
+- **Create** `packages/lobby/src/interchange/surface.ts` — handshake + exportSurface/applySurface + cadence. (Tasks 3-5)
+- **Modify** `packages/lobby/src/index.ts` — Lobby Surface methods + exports. (Task 4/5)
+- **Modify** `features.yaml`. (Task 6)
+- **Tests:** `packages/hub/__tests__/extract-field-projection.test.ts` (T1); `packages/lobby/__tests__/surface-*.test.ts` (T2-5).
+
+---
+
+## Task 1 — hub: `fieldProjection` in extract (structural redaction) (TDD) — RISKIEST
+
+**Files:** `packages/hub/src/bundle/extract-partition.ts`. Test `packages/hub/__tests__/extract-field-projection.test.ts`.
+
+**Context:** Add `fieldProjection?: Record<string, readonly string[]>` to `extractPartition` opts, threaded into `reKeyClosure`. In the re-key loop, between `decrypt` and `encrypt` (BOTH the CEK branch and the DEK branch), if the collection has a projection: `JSON.parse(plaintext)` → keep only listed fields + ALWAYS `id` → `JSON.stringify`. A projected collection must be SKIPPED in `reKeySchemas` (the narrowed shape ≠ the stored schema).
+
+- [ ] **Step 1: Failing test** — create `extract-field-projection.test.ts`. Mirror an existing extract/adopt test harness (`memory()` + createNoydb + a collection with 3-field records `{id, name, phone}`). Extract with `fieldProjection: { clients: ['name'] }`; decrypt the bundle via `decryptExtractedPartition` (import from `@noy-db/hub/bundle`); assert each decrypted record has `id` + `name` ONLY (no `phone`); assert a NON-projected collection in the same extract keeps all fields; assert (per-record CEK path) the SAME holds when the collection was opened with `perRecordKeys:true`.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement.**
+  1. `extractPartition` signature (`:247`): add `readonly fieldProjection?: Record<string, readonly string[]>` to the opts type; pass to `reKeyClosure(vault, closure, deks, opts.fieldProjection)` and to the `reKeySchemas` call.
+  2. `reKeyClosure` (`:53`): add a `fieldProjection?` param. Inside the per-collection loop, compute `const proj = fieldProjection?.[collectionName]` (a Set for lookup). In BOTH branches, after `const plaintext = await decrypt(...)` and BEFORE `encrypt(...)`:
+     ```ts
+     let body = plaintext
+     if (proj) {
+       const rec = JSON.parse(plaintext) as Record<string, unknown>
+       const kept: Record<string, unknown> = {}
+       if ('id' in rec) kept['id'] = rec['id']           // id ALWAYS preserved
+       for (const f of proj) if (f in rec) kept[f] = rec[f]
+       body = JSON.stringify(kept)
+     }
+     const { iv, data } = await encrypt(body, <cek|destDek>)
+     ```
+     Apply identically in the CEK branch (encrypt under `cek`) and the DEK branch (encrypt under `destDek`). Keep the `_cek` re-wrap order EXACTLY as before — only the plaintext body changes.
+  3. `reKeySchemas` (`:89`): skip any collection present in `fieldProjection` (don't carry a schema that contradicts the projected shape). Add a `fieldProjection?` param + `if (fieldProjection?.[name]) continue`.
+- [ ] **Step 4: Run → pass.** Full `pnpm --filter @noy-db/hub test` (no regression — non-projected extracts byte-identical), typecheck, lint, `pnpm check:architecture`.
+- [ ] **Step 5: Commit** (new test → `git add`): `git add packages/hub/__tests__/extract-field-projection.test.ts && git commit -am "feat(hub): fieldProjection in extract — structural field redaction (FR-7 Task 1)"`
+
+---
+
+## Task 2 — lobby: `SurfaceRow` + StateManagementVault persistence (TDD)
+
+**Files:** `packages/lobby/src/federation/types.ts`, `packages/lobby/src/federation/state-vault.ts`. Test `packages/lobby/__tests__/surface-persistence.test.ts`.
+
+- [ ] **Step 1: Failing test** — open a `StateManagementVault`, `createSurface(row)`, `getSurface(id)` round-trips, `listSurfaces()` returns it; assert the persisted shape.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement.**
+  - `types.ts`: 
+    ```ts
+    export type SurfaceDirection = 'push' | 'pull' | 'bidi'
+    export type SurfaceStatus = 'proposed' | 'agreed' | 'suspended'
+    export interface SurfaceConflictPolicy {
+      readonly strategy: MergeStrategy | (Record<string, MergeStrategy> & { default?: MergeStrategy })
+      readonly fieldAuthority?: Record<string, FieldAuthorityPolicy>
+    }
+    export interface SurfaceRow {
+      readonly id: string
+      readonly collections: readonly string[]
+      readonly fields?: Record<string, readonly string[]>     // collection → kept fields
+      readonly direction: SurfaceDirection
+      readonly conflictPolicy: SurfaceConflictPolicy
+      readonly cadenceMs?: number
+      readonly status: SurfaceStatus
+      readonly proposedBy: string
+      readonly agreedBy?: string
+      readonly createdAt: number
+      readonly lastSyncAt?: number
+      readonly nextSyncDueAt?: number
+    }
+    ```
+    (Import `MergeStrategy`/`FieldAuthorityPolicy` types from the interchange modules — type-only; confirm no runtime cycle.)
+  - `state-vault.ts`: add `SURFACES = 'surfaces'` const; bind `vault.collection<SurfaceRow>(SURFACES)` in `open()`; expose `readonly surfaces: Collection<SurfaceRow>`; add methods `createSurface(row)` (put), `getSurface(id)` (get), `listSurfaces()` (query/list), `updateSurface(id, patch)` (get→merge→put). Mirror the `migrationStatus` method pattern.
+- [ ] **Step 4: Run → pass.** lobby test + typecheck + lint.
+- [ ] **Step 5: Commit** (new test → `git add`): `git add packages/lobby/__tests__/surface-persistence.test.ts && git commit -am "feat(lobby): SurfaceRow + StateManagementVault persistence (FR-7 Task 2)"`
+
+---
+
+## Task 3 — lobby: propose / agree bilateral handshake (TDD)
+
+**Files:** Create `packages/lobby/src/interchange/surface.ts`. Test `packages/lobby/__tests__/surface-handshake.test.ts`.
+
+- [ ] **Step 1: Failing test** — TWO `Noydb` over a SHARED store (mirror federation-fleet-migration session-2 pattern). Party A `proposeSurface(smvA, def)` writes a `status:'proposed'` SurfaceRow; Party B opens the same SMV, `agreeSurface(smvB, id, 'partyB')` flips it to `status:'agreed'` (+ `agreedBy`); assert agree on a non-existent or already-agreed surface throws; assert export/apply (Task 4) refuse a non-agreed surface.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** in `surface.ts`:
+  - `proposeSurface(smv, def: SurfaceDefinition, proposedBy: string, now: number): Promise<SurfaceRow>` — builds a SurfaceRow `{...def, id: def.id ?? generateULID(), status:'proposed', proposedBy, createdAt: now}`, `smv.createSurface(row)`, returns it. (`SurfaceDefinition` = the user-facing subset: collections/fields?/direction/conflictPolicy/cadenceMs?/id?.)
+  - `agreeSurface(smv, surfaceId, agreedBy, now): Promise<SurfaceRow>` — `getSurface`; if null → `SurfaceNotFoundError`; if `status !== 'proposed'` → `SurfaceStateError`; `updateSurface(id, {status:'agreed', agreedBy})`; return.
+  - `SurfaceNotFoundError`/`SurfaceStateError` classes.
+  - Pass `now` in (no `Date.now()` inside the pure helpers — testability; the Lobby wrapper supplies `Date.now()`).
+- [ ] **Step 4: Run → pass.** lobby test + typecheck + lint.
+- [ ] **Step 5: Commit** (new files → `git add`): `git add packages/lobby/src/interchange/surface.ts packages/lobby/__tests__/surface-handshake.test.ts && git commit -am "feat(lobby): Surface propose/agree handshake (FR-7 Task 3)"`
+
+---
+
+## Task 4 — lobby: exportSurface + applySurface + Lobby wiring (TDD)
+
+**Files:** `packages/lobby/src/interchange/surface.ts`, `packages/lobby/src/index.ts`. Test `packages/lobby/__tests__/surface-sync.test.ts`.
+
+**Context:** Step 0 `pnpm --filter @noy-db/hub build` (Task 1's fieldProjection). The scoped slice = `extractPartition` restricted to surface.collections (seeds `() => true` per surface collection; **bound ref-following so ONLY surface.collections leave** — use `maxDepth: 0` if that means seeds-only, else filter the closure to surface.collections; the TEST must assert a non-surface collection is absent from the bundle) + `fieldProjection: surface.fields`. Apply = `mergeCompartment` with the conflict policy.
+
+- [ ] **Step 1: Failing test** — agreed surface `{collections:['clients'], fields:{clients:['name']}, direction:'push', conflictPolicy:{strategy:'take-incoming'}}`; source vault has `clients`(id,name,phone) + a `secret` collection NOT in the surface. `exportSurface(sourceVault, surface)` → `{bundleBytes, transferKey}`; `applySurface(receiverVault, surface, bundleBytes, transferKey)` → MergeReport. Assert: receiver `clients` rows have `name` only (no `phone`); receiver has NO `secret` collection (outside surface never leaves); MergeReport counts correct. Assert `direction:'pull'` rejects `exportSurface` from this side (export is a push-side op) and vice versa; assert a non-`agreed` surface throws.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement.**
+  - `exportSurface(source: Vault, surface: SurfaceRow): Promise<{bundleBytes: Uint8Array; transferKey: Uint8Array}>` — guard `surface.status === 'agreed'` (else `SurfaceStateError`); guard `direction !== 'pull'` (push/bidi may export); build `seeds` = `Object.fromEntries(surface.collections.map(c => [c, () => true]))`; `const { bundleBytes, transferKey } = await extractPartition(source, { seeds, maxDepth: 0, fieldProjection: surface.fields, carrySchemas: false, carryLedger: false })`; **verify only surface.collections are present** (if extractPartition can include others, post-filter — see Step 0 note); return `{bundleBytes, transferKey}`.
+  - `applySurface(receiver: Vault, surface: SurfaceRow, bundleBytes, transferKey): Promise<MergeReport>` — guard `status==='agreed'`; guard `direction !== 'push'` (pull/bidi may apply); `return mergeCompartment(receiver, bundleBytes, { transferKey, strategy: surface.conflictPolicy.strategy, ...(surface.conflictPolicy.fieldAuthority ? { fieldAuthority: surface.conflictPolicy.fieldAuthority } : {}), reason: \`sync:surface:${surface.id}\` })`.
+  - `Lobby` methods (`index.ts`): `createSurface(def)`/`getSurface(id)`/`listSurfaces()`/`proposeSurface(def)`/`agreeSurface(id, agreedBy)`/`exportSurface(vaultName, surfaceId)`/`applySurface(vaultName, surfaceId, bundleBytes, transferKey)` — open the SMV via `StateManagementVault.open(this.noydb)`, resolve the surface, open the data vault via `this.noydb.openVault`, delegate to the surface.ts helpers (supplying `Date.now()` for `now`). Export `SurfaceRow`/`SurfaceDefinition`/`SurfaceDirection`/`SurfaceConflictPolicy` types + the error classes.
+- [ ] **Step 4: Run → pass.** `pnpm --filter @klum-db/lobby test` + `pnpm --filter @noy-db/hub test`, typecheck, lint, `pnpm check:architecture` (klum→noy clean).
+- [ ] **Step 5: Commit** (new test → `git add`): `git add packages/lobby/__tests__/surface-sync.test.ts && git commit -am "feat(lobby): exportSurface/applySurface + Lobby Surface API (FR-7 Task 4)"`
+
+---
+
+## Task 5 — lobby: cadence scheduler + two-party E2E (TDD)
+
+**Files:** `packages/lobby/src/interchange/surface.ts`. Test `packages/lobby/__tests__/surface-cadence.test.ts` + `packages/lobby/__tests__/surface-e2e.test.ts`.
+
+- [ ] **Step 1: Failing tests.**
+  - cadence (pure): `isSurfaceDue(surface, now)` → true iff `surface.cadenceMs !== undefined && (surface.lastSyncAt === undefined || now >= (surface.nextSyncDueAt ?? 0))`; `listDueSurfaces(surfaces, now)` filters agreed + due. Deterministic (pass `now`).
+  - scheduler driver: `SurfaceCadenceScheduler.start(surfaceId, intervalMs, fn)` / `stop(surfaceId)` fires `fn` on the interval (test with `vi.useFakeTimers()`); `markSynced(smv, id, now)` stamps `lastSyncAt`+`nextSyncDueAt = now + cadenceMs`.
+  - E2E (`surface-e2e.test.ts`): two `Noydb` over a shared store; A proposes a push surface (`fields:{clients:['name']}`), B agrees; A `exportSurface` → B `applySurface`; assert projected + scoped result; then `markSynced` + assert `isSurfaceDue` flips false then true after advancing `now`; assert a `suspended` surface is not due.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** the pure `isSurfaceDue`/`listDueSurfaces`, `markSynced(smv, id, now)` (updateSurface), and a thin `SurfaceCadenceScheduler` (a `Map<id, interval>`; `start` uses `setInterval`; `stop`/`stopAll` clear; accepts an injectable `nowFn` defaulting to `Date.now`). Keep the driver minimal — the pure due-check is the tested core; the host wires real timers.
+- [ ] **Step 4: Run → pass.** Full lobby + hub test, typecheck, lint, architecture.
+- [ ] **Step 5: Commit** (new tests → `git add`): `git add packages/lobby/__tests__/surface-cadence.test.ts packages/lobby/__tests__/surface-e2e.test.ts && git commit -am "feat(lobby): Surface cadence scheduler + two-party E2E (FR-7 Task 5)"`
+
+---
+
+## Task 6 — features.yaml + full verification
+
+**Files:** `features.yaml`.
+- [ ] **Step 1:** add a `scoped-sync-surface` entry mirroring sibling lobby features (`cross-vault-extraction`/`merge-compartment`): artefacts `packages/lobby/src/interchange/surface.ts` + `packages/lobby/src/federation/state-vault.ts` + the hub `extract-partition.ts` projection; spec `docs/superpowers/specs/2026-06-16-lobby-framework-design.md` (FR-7); package `@klum-db/lobby`; status `preview`; invariants: (1) syncs only named collections/fields in the named direction with its conflict policy; (2) collections/fields outside the surface never leave (structural projection at extract); (3) propose/agree bilateral handshake gates sync; (4) persisted in the StateManagementVault; (5) cadence-driven, host-scheduled. `node scripts/validate-features.mjs` passes.
+- [ ] **Step 2: Full verification:**
+```bash
+pnpm --filter @noy-db/hub build && pnpm --filter @klum-db/lobby build
+pnpm --filter @noy-db/hub test && pnpm --filter @klum-db/lobby test
+pnpm lint && pnpm typecheck
+node scripts/validate-features.mjs
+pnpm check:architecture
+```
+All green.
+- [ ] **Step 3: Commit** — `git commit -am "feat: register scoped-sync-surface feature + verify (FR-7)"`
+
+---
+
+## Self-Review
+
+**Spec coverage (issue #447):**
+- "a surface syncs only its named collections/fields, in the named direction, applying its conflict policy" → Task 4 (exportSurface restricts to surface.collections + fieldProjection; direction guards; conflictPolicy→mergeCompartment strategy).
+- "collections/fields outside the surface never leave the vault" → Task 1 (structural field projection drops non-surface fields before re-encryption) + Task 4 (only surface.collections in the bundle — asserted by the `secret`-collection-absent test).
+- Persisted + scheduled (the chosen scope) → Task 2 (SMV persistence) + Task 3 (handshake) + Task 5 (cadence).
+- Builds on SyncEngine/SyncPolicy concept (reimagined as extract-project-merge — the only field-projecting path), broadcastJoin-style scoping, FR-2/3/4.
+
+**Placeholder scan:** concrete line refs (extractPartition:247, reKeyClosure:53-76, reKeySchemas:89, StateManagementVault.open). The two implementer must-confirms: Task 1's per-record-CEK branch projection (apply identically, keep `_cek` re-wrap order); Task 4's "only surface.collections leave" (maxDepth:0 vs post-filter — the test is the gate).
+
+**Risk notes:** Task 1 is riskiest — projecting in BOTH re-key branches without breaking the `_cek` re-wrap (a wrong key order → silently undecryptable at receiver; the existing comment at extract-partition.ts:62 flags this class). Field projection is STRUCTURAL (export-boundary redaction), NOT cryptographic intra-vault hiding — documented (sync only transmits the slice, so excluded fields simply aren't sent). No row-level predicate (not in #447). SyncEngine deliberately unused. transferKey is per-run, out-of-band (not persisted). Lobby files have no kernel ceilings. The `no-outbound-klum-import` guard (now scanning all noy packages, per FR-9) stays green — FR-7 is lobby-side + one hub primitive, no noy→klum import.

--- a/features.yaml
+++ b/features.yaml
@@ -1198,6 +1198,26 @@ features:
       - 'Dependency direction preserved: @noy-db/as-xlsx (edge adapter) imports only @noy-db/hub — it never imports @klum-db/lobby; Lobby gains a peer-dependency on @noy-db/as-xlsx (the allowed klum→noy direction); guarded by the no-outbound-klum-import architecture check'
     related: [cross-vault-extraction, as-xlsx]
 
+  - id: scoped-sync-surface
+    name: 'Surface — scoped sync (collections/fields/direction/conflict, persisted + handshake + cadence) (FR-7)'
+    cluster: snapshot-and-portability
+    spec: docs/superpowers/specs/2026-06-16-lobby-framework-design.md
+    subsystem_doc: docs/superpowers/specs/2026-06-16-lobby-framework-design.md
+    package: '@klum-db/lobby'
+    factory: null
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'A surface syncs only its named collections, optionally restricted to named fields (fieldProjection), in its declared direction (push/pull/bidirectional) with its conflict policy — no other data leaves the vault'
+      - 'Collections and fields outside the surface never leave the vault: structural field projection is applied at extractPartition (hub extract-partition.ts fieldProjection) before re-encryption, and only surface.collections are included in the exported bundle (maxDepth:0 collection bounding)'
+      - 'A propose/agree bilateral handshake gates sync: only surfaces in state "agreed" are eligible for exportSurface/applySurface; proposeSurface → agreeSurface is the required ceremony before any data flows'
+      - 'Surfaces are persisted in the StateManagementVault surfaces collection: SurfaceRow is stored in the SMV and survives restarts; state machine transitions (proposed → agreed → suspended → closed) are durable'
+      - 'Cadence is host-driven: isSurfaceDue(surface, now) is a pure predicate; the interval driver in the scheduler advances surfaces whose cadence window has elapsed — no background process, no shared clock'
+    related: [cross-vault-extraction, merge-compartment, vault-group-federation]
+
   - id: with-snapshots
     name: Snapshot lifecycle (withSnapshots)
     cluster: snapshot-and-portability

--- a/packages/hub/__tests__/extract-field-projection.test.ts
+++ b/packages/hub/__tests__/extract-field-projection.test.ts
@@ -1,0 +1,147 @@
+/**
+ * extractPartition fieldProjection — structural field redaction (FR-7 Task 1).
+ *
+ * Verifies that `fieldProjection: { <collection>: [...keptFields] }` drops
+ * every non-listed field from each record of the projected collection BEFORE
+ * re-encryption, so excluded fields never travel in the bundle. `id` is always
+ * preserved. Non-projected collections keep all their fields. The same holds
+ * across both re-key branches: standard per-collection DEK AND per-record CEK
+ * (`perRecordKeys: true`).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+import { extractPartition } from '../src/bundle/extract-partition.js'
+import { decryptExtractedPartition } from '../src/bundle/decrypt-partition.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) {
+        for (const [name, coll] of existing) {
+          if (name.startsWith('_')) comp.set(name, coll)
+        }
+      }
+      store.set(c, comp)
+    },
+  }
+}
+
+interface Client { id: string; name: string; phone: string }
+interface Note { id: string; title: string; body: string }
+
+describe('extractPartition — fieldProjection (structural redaction)', () => {
+  it('drops non-listed fields from a projected collection; keeps all fields on a non-projected one', async () => {
+    const db = await createNoydb({ store: memory(), user: 'alice', secret: 'test-passphrase-1234' })
+    const company = await db.openVault('demo-co')
+
+    const clients = company.collection<Client>('clients')
+    await clients.put('c1', { id: 'c1', name: 'Acme', phone: '555-0001' })
+    await clients.put('c2', { id: 'c2', name: 'Beta Corp', phone: '555-0002' })
+
+    const notes = company.collection<Note>('notes')
+    await notes.put('n1', { id: 'n1', title: 'Kickoff', body: 'agenda' })
+
+    const { bundleBytes, transferKey } = await extractPartition(company, {
+      seeds: { clients: () => true, notes: () => true },
+      fieldProjection: { clients: ['name'] },
+    })
+
+    const out = await decryptExtractedPartition(bundleBytes, transferKey)
+    expect(Object.keys(out).sort()).toEqual(['clients', 'notes'])
+
+    // clients: each record has EXACTLY id + name (NO phone).
+    for (const rec of out['clients']!) {
+      expect(Object.keys(rec.record).sort()).toEqual(['id', 'name'])
+      expect(rec.record).not.toHaveProperty('phone')
+    }
+    const c1 = out['clients']!.find((r) => r.id === 'c1')!
+    expect(c1.record).toEqual({ id: 'c1', name: 'Acme' })
+    const c2 = out['clients']!.find((r) => r.id === 'c2')!
+    expect(c2.record).toEqual({ id: 'c2', name: 'Beta Corp' })
+
+    // notes: NOT projected → keeps ALL fields.
+    const n1 = out['notes']!.find((r) => r.id === 'n1')!
+    expect(n1.record).toEqual({ id: 'n1', title: 'Kickoff', body: 'agenda' })
+  })
+
+  it('applies projection on the per-record-CEK branch (perRecordKeys: true)', async () => {
+    const db = await createNoydb({ store: memory(), user: 'alice', secret: 'test-passphrase-1234' })
+    const company = await db.openVault('demo-co')
+
+    const clients = company.collection<Client>('clients', { perRecordKeys: true })
+    await clients.put('c1', { id: 'c1', name: 'Acme', phone: '555-0001' })
+    await clients.put('c2', { id: 'c2', name: 'Beta Corp', phone: '555-0002' })
+
+    const { bundleBytes, transferKey } = await extractPartition(company, {
+      seeds: { clients: () => true },
+      fieldProjection: { clients: ['name'] },
+    })
+
+    const out = await decryptExtractedPartition(bundleBytes, transferKey)
+    for (const rec of out['clients']!) {
+      expect(Object.keys(rec.record).sort()).toEqual(['id', 'name'])
+      expect(rec.record).not.toHaveProperty('phone')
+    }
+    const c1 = out['clients']!.find((r) => r.id === 'c1')!
+    expect(c1.record).toEqual({ id: 'c1', name: 'Acme' })
+  })
+
+  it('always preserves id even when id is not listed in the projection', async () => {
+    const db = await createNoydb({ store: memory(), user: 'alice', secret: 'test-passphrase-1234' })
+    const company = await db.openVault('demo-co')
+
+    const clients = company.collection<Client>('clients')
+    await clients.put('c1', { id: 'c1', name: 'Acme', phone: '555-0001' })
+
+    // Projection lists only 'phone' — id is NOT listed but must survive.
+    const { bundleBytes, transferKey } = await extractPartition(company, {
+      seeds: { clients: () => true },
+      fieldProjection: { clients: ['phone'] },
+    })
+
+    const out = await decryptExtractedPartition(bundleBytes, transferKey)
+    const c1 = out['clients']!.find((r) => r.id === 'c1')!
+    expect(c1.id).toBe('c1')
+    expect(c1.record).toEqual({ id: 'c1', phone: '555-0001' })
+    expect(c1.record).not.toHaveProperty('name')
+  })
+})

--- a/packages/hub/src/bundle/extract-partition.ts
+++ b/packages/hub/src/bundle/extract-partition.ts
@@ -40,6 +40,7 @@ export interface ReKeyResult {
 export async function reKeyClosure(
   vault: Vault,
   closure: Map<string, Set<string>>,
+  fieldProjection?: Record<string, readonly string[]>,
 ): Promise<ReKeyResult> {
   const { name: vaultName, adapter, getDEK } = vault._introspectState()
   const collections: Record<string, Record<string, EncryptedEnvelope>> = {}
@@ -50,6 +51,22 @@ export async function reKeyClosure(
     const destDek = await generateDEK()
     deks.set(collectionName, destDek)
     const out: Record<string, EncryptedEnvelope> = {}
+    // FR-7 structural field projection: when this collection has a projection,
+    // narrow the plaintext body to `id` (always) + the listed fields BEFORE
+    // re-encryption, so excluded fields never travel in the bundle. Applied
+    // identically in both re-key branches; only the body changes — the `_cek`
+    // re-wrap order is untouched. Absent/empty projection → byte-identical to
+    // the un-projected path (`proj` is undefined and `project` is a no-op).
+    const projList = fieldProjection?.[collectionName]
+    const proj = projList ? new Set(projList) : undefined
+    const project = (plaintext: string): string => {
+      if (!proj) return plaintext
+      const rec = JSON.parse(plaintext) as Record<string, unknown>
+      const kept: Record<string, unknown> = {}
+      if ('id' in rec) kept['id'] = rec['id'] // id ALWAYS preserved
+      for (const f of proj) if (f in rec) kept[f] = rec[f]
+      return JSON.stringify(kept)
+    }
 
     for (const id of ids) {
       const env = await adapter.get(vaultName, collectionName, id)
@@ -65,13 +82,13 @@ export async function reKeyClosure(
         // re-wrap the collection DEK under their KEK on adopt.
         const cek = await unwrapCek(env._cek, srcDek)
         const plaintext = await decrypt(env._iv, env._data, cek)
-        const { iv, data } = await encrypt(plaintext, cek)
+        const { iv, data } = await encrypt(project(plaintext), cek)
         const wrapped = await wrapCek(cek, destDek)
         out[id] = { ...env, _iv: iv, _data: data, _cek: wrapped }
         continue
       }
       const plaintext = await decrypt(env._iv, env._data, srcDek)
-      const { iv, data } = await encrypt(plaintext, destDek)
+      const { iv, data } = await encrypt(project(plaintext), destDek)
       out[id] = { ...env, _iv: iv, _data: data }
     }
     collections[collectionName] = out
@@ -90,11 +107,16 @@ export async function reKeySchemas(
   vault: Vault,
   closure: Map<string, Set<string>>,
   destDeks: Map<string, CryptoKey>,
+  fieldProjection?: Record<string, readonly string[]>,
 ): Promise<Record<string, EncryptedEnvelope>> {
   const { name: vaultName, adapter, getDEK } = vault._introspectState()
   const out: Record<string, EncryptedEnvelope> = {}
 
   for (const collectionName of closure.keys()) {
+    // FR-7: skip a projected collection's schema — the narrowed shape no
+    // longer matches the stored JSON Schema, so carrying it would assert a
+    // contract the projected records violate (missing required fields).
+    if (fieldProjection?.[collectionName]) continue
     const env = await adapter.get(vaultName, SCHEMAS_COLLECTION, collectionName)
     if (!env) continue // collection has no persisted schema — skip
     const destDek = destDeks.get(collectionName)
@@ -250,6 +272,14 @@ export async function extractPartition(
     readonly compression?: 'auto' | 'brotli' | 'gzip' | 'none'
     readonly carrySchemas?: boolean
     readonly carryLedger?: boolean
+    /**
+     * FR-7 structural field projection: per-collection allow-list of fields
+     * to keep. Non-listed fields are dropped from each record BEFORE
+     * re-encryption (so they never travel in the bundle); `id` is always
+     * preserved. A projected collection's persisted schema is NOT carried.
+     * Absent/empty → un-projected behavior (byte-identical to today).
+     */
+    readonly fieldProjection?: Record<string, readonly string[]>
   },
 ): Promise<ExtractPartitionResult> {
   // FR-6: extract-and-sever is the inalienability-floor half — owner-only. A
@@ -277,7 +307,7 @@ export async function extractPartition(
   if (opts.carrySchemas) await vault._drainPendingSchemaWrites()
 
   const { closure } = await walkClosure(vault, opts)
-  const { collections, deks } = await reKeyClosure(vault, closure)
+  const { collections, deks } = await reKeyClosure(vault, closure, opts.fieldProjection)
 
   // carryLedger: mint a fresh _ledger DEK, build the carried chain, and
   // SEAL the ledger DEK alongside the data DEKs so owner-creation wraps it into the
@@ -302,7 +332,7 @@ export async function extractPartition(
 
   // Build _internal (schemas + ledger). reKeySchemas reads data-
   // collection DEKs only, so it is unaffected by the _ledger DEK added above.
-  const internalSchemas = opts.carrySchemas ? await reKeySchemas(vault, closure, deks) : {}
+  const internalSchemas = opts.carrySchemas ? await reKeySchemas(vault, closure, deks, opts.fieldProjection) : {}
   const internal: Record<string, Record<string, EncryptedEnvelope>> = {}
   if (Object.keys(internalSchemas).length > 0) internal[SCHEMAS_COLLECTION] = internalSchemas
   if (ledgerEntries) internal[LEDGER_COLLECTION] = ledgerEntries

--- a/packages/lobby/__tests__/surface-cadence.test.ts
+++ b/packages/lobby/__tests__/surface-cadence.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Surface cadence scheduler (FR-7 Task 5).
+ *
+ * Tests three layers:
+ *  1. Pure due-check: `isSurfaceDue(surface, now)` — deterministic, no Date.now().
+ *  2. `listDueSurfaces(surfaces, now)` — filter helper.
+ *  3. `markSynced(smv, id, now)` — stamps lastSyncAt + nextSyncDueAt in the SMV.
+ *  4. `SurfaceCadenceScheduler` — thin setInterval driver (vi.useFakeTimers).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { StateManagementVault } from '../src/federation/state-vault.js'
+import type { SurfaceRow } from '../src/federation/types.js'
+import {
+  isSurfaceDue,
+  listDueSurfaces,
+  markSynced,
+  SurfaceCadenceScheduler,
+} from '../src/interchange/surface.js'
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const NOW = 1_000_000
+const CADENCE = 60_000
+
+function makeAgreedSurface(overrides: Partial<SurfaceRow> = {}): SurfaceRow {
+  return {
+    id: 'surf-cadence-1',
+    collections: ['clients'],
+    direction: 'push',
+    conflictPolicy: { strategy: 'take-incoming' },
+    cadenceMs: CADENCE,
+    status: 'agreed',
+    proposedBy: 'partyA',
+    agreedBy: 'partyB',
+    createdAt: 900_000,
+    ...overrides,
+  }
+}
+
+// ─── isSurfaceDue ─────────────────────────────────────────────────────────────
+
+describe('isSurfaceDue — pure due-check (deterministic)', () => {
+  it('never-synced agreed surface with cadence is due', () => {
+    const surface = makeAgreedSurface({ lastSyncAt: undefined, nextSyncDueAt: undefined })
+    expect(isSurfaceDue(surface, NOW)).toBe(true)
+  })
+
+  it('synced surface with nextSyncDueAt in the future is NOT due', () => {
+    const surface = makeAgreedSurface({
+      lastSyncAt: NOW - 10_000,
+      nextSyncDueAt: NOW + 50_000,  // still in the future
+    })
+    expect(isSurfaceDue(surface, NOW)).toBe(false)
+  })
+
+  it('synced surface with now exactly at nextSyncDueAt is due', () => {
+    const surface = makeAgreedSurface({
+      lastSyncAt: NOW - CADENCE,
+      nextSyncDueAt: NOW,
+    })
+    expect(isSurfaceDue(surface, NOW)).toBe(true)
+  })
+
+  it('synced surface with now past nextSyncDueAt is due', () => {
+    const surface = makeAgreedSurface({
+      lastSyncAt: NOW - CADENCE - 1,
+      nextSyncDueAt: NOW - 1,  // overdue
+    })
+    expect(isSurfaceDue(surface, NOW)).toBe(true)
+  })
+
+  it('proposed surface is NOT due (only agreed surfaces trigger)', () => {
+    const surface = makeAgreedSurface({ status: 'proposed', lastSyncAt: undefined })
+    expect(isSurfaceDue(surface, NOW)).toBe(false)
+  })
+
+  it('suspended surface is NOT due', () => {
+    const surface = makeAgreedSurface({ status: 'suspended', lastSyncAt: undefined })
+    expect(isSurfaceDue(surface, NOW)).toBe(false)
+  })
+
+  it('surface without cadenceMs is never due', () => {
+    const surface: SurfaceRow = {
+      ...makeAgreedSurface(),
+      cadenceMs: undefined,
+      lastSyncAt: undefined,
+      nextSyncDueAt: undefined,
+    }
+    expect(isSurfaceDue(surface, NOW)).toBe(false)
+  })
+})
+
+// ─── listDueSurfaces ──────────────────────────────────────────────────────────
+
+describe('listDueSurfaces — filter wrapper', () => {
+  it('returns only due (agreed + cadence + overdue/never-synced) surfaces', () => {
+    const due = makeAgreedSurface({ id: 'due-1', lastSyncAt: undefined })
+    const notDue = makeAgreedSurface({ id: 'not-due', lastSyncAt: NOW - 10_000, nextSyncDueAt: NOW + 50_000 })
+    const proposed = makeAgreedSurface({ id: 'proposed-1', status: 'proposed' })
+    const noCadence: SurfaceRow = { ...makeAgreedSurface({ id: 'no-cadence' }), cadenceMs: undefined }
+
+    const result = listDueSurfaces([due, notDue, proposed, noCadence], NOW)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('due-1')
+  })
+
+  it('returns empty array when no surfaces are due', () => {
+    const notDue = makeAgreedSurface({ lastSyncAt: NOW - 1_000, nextSyncDueAt: NOW + 59_000 })
+    expect(listDueSurfaces([notDue], NOW)).toHaveLength(0)
+  })
+})
+
+// ─── markSynced ───────────────────────────────────────────────────────────────
+
+describe('markSynced — stamps lastSyncAt + nextSyncDueAt in the SMV', () => {
+  it('stamps lastSyncAt and nextSyncDueAt = now + cadenceMs', async () => {
+    const db = await createNoydb({ store: memory(), user: 'op', encrypt: false })
+    const smv = await StateManagementVault.open(db)
+
+    const surface = makeAgreedSurface({ lastSyncAt: undefined, nextSyncDueAt: undefined })
+    await smv.createSurface(surface)
+
+    await markSynced(smv, surface.id, NOW)
+
+    const updated = await smv.getSurface(surface.id)
+    expect(updated?.lastSyncAt).toBe(NOW)
+    expect(updated?.nextSyncDueAt).toBe(NOW + CADENCE)
+  })
+
+  it('isSurfaceDue is false immediately after markSynced, then true once now advances past nextSyncDueAt', async () => {
+    const db = await createNoydb({ store: memory(), user: 'op', encrypt: false })
+    const smv = await StateManagementVault.open(db)
+
+    const surface = makeAgreedSurface({ lastSyncAt: undefined, nextSyncDueAt: undefined })
+    await smv.createSurface(surface)
+
+    // Before markSynced: due (never synced)
+    expect(isSurfaceDue(surface, NOW)).toBe(true)
+
+    await markSynced(smv, surface.id, NOW)
+    const updated = await smv.getSurface(surface.id)
+
+    // Right after markSynced: not due (nextSyncDueAt in the future)
+    expect(isSurfaceDue(updated!, NOW)).toBe(false)
+    expect(isSurfaceDue(updated!, NOW + CADENCE - 1)).toBe(false)
+
+    // Once now advances past nextSyncDueAt: due again
+    expect(isSurfaceDue(updated!, NOW + CADENCE)).toBe(true)
+    expect(isSurfaceDue(updated!, NOW + CADENCE + 1)).toBe(true)
+  })
+})
+
+// ─── SurfaceCadenceScheduler ──────────────────────────────────────────────────
+
+describe('SurfaceCadenceScheduler — thin setInterval driver', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('start(id, intervalMs, fn) fires fn on the interval', () => {
+    const scheduler = new SurfaceCadenceScheduler()
+    const fn = vi.fn()
+
+    scheduler.start('surf-1', 1_000, fn)
+
+    expect(fn).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1_000)
+    expect(fn).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(1_000)
+    expect(fn).toHaveBeenCalledTimes(2)
+    vi.advanceTimersByTime(1_000)
+    expect(fn).toHaveBeenCalledTimes(3)
+
+    scheduler.stopAll()
+  })
+
+  it('stop(id) cancels the interval for the given surface only', () => {
+    const scheduler = new SurfaceCadenceScheduler()
+    const fn1 = vi.fn()
+    const fn2 = vi.fn()
+
+    scheduler.start('surf-A', 1_000, fn1)
+    scheduler.start('surf-B', 1_000, fn2)
+
+    vi.advanceTimersByTime(1_000)
+    expect(fn1).toHaveBeenCalledTimes(1)
+    expect(fn2).toHaveBeenCalledTimes(1)
+
+    scheduler.stop('surf-A')
+
+    vi.advanceTimersByTime(1_000)
+    expect(fn1).toHaveBeenCalledTimes(1)  // stopped
+    expect(fn2).toHaveBeenCalledTimes(2)  // still running
+
+    scheduler.stopAll()
+  })
+
+  it('stopAll clears all running intervals', () => {
+    const scheduler = new SurfaceCadenceScheduler()
+    const fn1 = vi.fn()
+    const fn2 = vi.fn()
+
+    scheduler.start('surf-X', 500, fn1)
+    scheduler.start('surf-Y', 500, fn2)
+
+    vi.advanceTimersByTime(500)
+    expect(fn1).toHaveBeenCalledTimes(1)
+    expect(fn2).toHaveBeenCalledTimes(1)
+
+    scheduler.stopAll()
+
+    vi.advanceTimersByTime(1_000)
+    expect(fn1).toHaveBeenCalledTimes(1)  // no more calls
+    expect(fn2).toHaveBeenCalledTimes(1)
+  })
+
+  it('start on an already-running id replaces the previous interval', () => {
+    const scheduler = new SurfaceCadenceScheduler()
+    const fn1 = vi.fn()
+    const fn2 = vi.fn()
+
+    scheduler.start('surf-1', 1_000, fn1)
+    vi.advanceTimersByTime(500)
+    // Replace before first fire
+    scheduler.start('surf-1', 1_000, fn2)
+
+    vi.advanceTimersByTime(1_000)
+    expect(fn1).not.toHaveBeenCalled()  // first interval was cancelled
+    expect(fn2).toHaveBeenCalledTimes(1)
+
+    scheduler.stopAll()
+  })
+})

--- a/packages/lobby/__tests__/surface-e2e.test.ts
+++ b/packages/lobby/__tests__/surface-e2e.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Two-party Surface E2E acceptance test (FR-7 Task 5).
+ *
+ * Acceptance criteria:
+ *  - Party A proposes a PUSH surface (clients, fields:{clients:['name']}, cadenceMs:60000).
+ *  - Party B agrees.
+ *  - A exports → B applies.
+ *  - Receiver: clients have name only (no phone); secret collection absent.
+ *  - markSynced → isSurfaceDue false → advance now past nextSyncDueAt → due true.
+ *  - A suspended surface is NOT due.
+ *
+ * This is the full scoped+projected sync proof end-to-end across two parties.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { StateManagementVault } from '../src/federation/state-vault.js'
+import {
+  proposeSurface,
+  agreeSurface,
+  exportSurface,
+  applySurface,
+  markSynced,
+  isSurfaceDue,
+} from '../src/interchange/surface.js'
+import type { SurfaceDefinition } from '../src/interchange/surface.js'
+
+// ─── Fixture types ────────────────────────────────────────────────────────────
+
+interface Client { id: string; name: string; phone: string }
+interface Secret { id: string; data: string }
+
+// ─── Full E2E walkthrough ─────────────────────────────────────────────────────
+
+describe('Surface E2E — two-party scoped+projected sync (FR-7)', () => {
+  it('full acceptance walkthrough: propose → agree → export → apply → cadence', async () => {
+    const NOW = 1_000_000
+    const CADENCE = 60_000
+
+    // ── 1. Shared state vault (both parties use the same store for the SMV)
+    const sharedStore = memory()
+    const dbA = await createNoydb({ store: sharedStore, user: 'partyA', encrypt: false })
+    const dbB = await createNoydb({ store: sharedStore, user: 'partyB', encrypt: false })
+    const smvA = await StateManagementVault.open(dbA)
+    const smvB = await StateManagementVault.open(dbB)
+
+    // ── 2. Party A proposes a PUSH surface (clients, name only, cadence 60s)
+    const def: SurfaceDefinition = {
+      id: 'e2e-surf-1',
+      collections: ['clients'],
+      fields: { clients: ['name'] },
+      direction: 'push',
+      conflictPolicy: { strategy: 'take-incoming' },
+      cadenceMs: CADENCE,
+    }
+    const proposed = await proposeSurface(smvA, def, 'partyA', NOW)
+    expect(proposed.status).toBe('proposed')
+    expect(proposed.cadenceMs).toBe(CADENCE)
+
+    // ── 3. Party B agrees
+    // Use a fresh Noydb to prove persistence (eager-cache note: fresh open reads from store)
+    const dbB2 = await createNoydb({ store: sharedStore, user: 'partyB', encrypt: false })
+    const smvB2 = await StateManagementVault.open(dbB2)
+    const agreed = await agreeSurface(smvB2, proposed.id, 'partyB', NOW + 1_000)
+    expect(agreed.status).toBe('agreed')
+    expect(agreed.agreedBy).toBe('partyB')
+
+    // ── 4. Party A's data vault: clients + secret (NOT in surface)
+    const srcDb = await createNoydb({ store: memory(), user: 'srcPartyA', secret: 'src-secret-xr7' })
+    const srcVault = await srcDb.openVault('partyA-data')
+    const clientsColl = srcVault.collection<Client>('clients')
+    await clientsColl.put('c1', { id: 'c1', name: 'Alice', phone: '+1-555-0101' })
+    await clientsColl.put('c2', { id: 'c2', name: 'Bob', phone: '+1-555-0202' })
+    const secretColl = srcVault.collection<Secret>('secret')
+    await secretColl.put('s1', { id: 's1', data: 'CONFIDENTIAL' })
+
+    // ── 5. Export (Party A side)
+    const { bundleBytes, transferKey } = await exportSurface(srcVault, agreed)
+    expect(bundleBytes).toBeInstanceOf(Uint8Array)
+    expect(bundleBytes.length).toBeGreaterThan(0)
+    expect(transferKey.length).toBe(32)
+
+    // ── 6. Apply (Party B side — fresh Noydb receiver)
+    const recvDb = await createNoydb({ store: memory(), user: 'partyB-recv', secret: 'recv-secret-y9k' })
+    const recvVault = await recvDb.openVault('partyB-data')
+    const report = await applySurface(recvVault, agreed, bundleBytes, transferKey)
+
+    // ── 7. Acceptance assertions: scoped + projected
+    expect(report.summary.inserted).toBe(2)
+
+    // clients: only id + name — phone must be absent
+    const c1 = await recvVault.collection<Record<string, unknown>>('clients').get('c1')
+    expect(c1).not.toBeNull()
+    expect(c1!['id']).toBe('c1')
+    expect(c1!['name']).toBe('Alice')
+    expect(c1!['phone']).toBeUndefined()   // projected out
+
+    const c2 = await recvVault.collection<Record<string, unknown>>('clients').get('c2')
+    expect(c2).not.toBeNull()
+    expect(c2!['name']).toBe('Bob')
+    expect(c2!['phone']).toBeUndefined()   // projected out
+
+    // secret: absent — outside the surface, never leaves
+    const secretList = await recvVault.collection<Secret>('secret').list()
+    expect(secretList).toHaveLength(0)
+
+    // ── 8. Cadence: markSynced flips isSurfaceDue false then true
+    // Before markSynced: surface is agreed+cadence+never-synced → due
+    expect(isSurfaceDue(agreed, NOW + 2_000)).toBe(true)
+
+    // markSynced stamps lastSyncAt + nextSyncDueAt.
+    // Use smvB2: it is the SMV that agreed the surface, so its cache has
+    // the status:'agreed' row (eager-cache note: each Noydb instance has
+    // its own in-memory collection cache; use the instance that last wrote
+    // the agreed status so markSynced merges from the correct basis).
+    const syncTime = NOW + 2_000
+    await markSynced(smvB2, agreed.id, syncTime)
+
+    // Read the updated surface from a fresh Noydb (force a store read, not cache)
+    const dbA2 = await createNoydb({ store: sharedStore, user: 'partyA', encrypt: false })
+    const smvA2 = await StateManagementVault.open(dbA2)
+    const afterSync = await smvA2.getSurface(agreed.id)
+    expect(afterSync).not.toBeNull()
+    expect(afterSync!.lastSyncAt).toBe(syncTime)
+    expect(afterSync!.nextSyncDueAt).toBe(syncTime + CADENCE)
+
+    // Not due right after sync
+    expect(isSurfaceDue(afterSync!, syncTime)).toBe(false)
+    expect(isSurfaceDue(afterSync!, syncTime + CADENCE - 1)).toBe(false)
+
+    // Due once now advances past nextSyncDueAt
+    expect(isSurfaceDue(afterSync!, syncTime + CADENCE)).toBe(true)
+    expect(isSurfaceDue(afterSync!, syncTime + CADENCE + 5_000)).toBe(true)
+
+    // ── 9. Suspended surface is NOT due
+    // Use smvA2 here — it has the most recent (markSynced) row in its cache
+    // after the getSurface call above, so updateSurface merges from the correct basis.
+    await smvA2.updateSurface(agreed.id, { status: 'suspended' })
+    const suspended = await smvA2.getSurface(agreed.id)
+    expect(suspended!.status).toBe('suspended')
+    // even though now is past nextSyncDueAt, a suspended surface must not fire
+    expect(isSurfaceDue(suspended!, syncTime + CADENCE + 10_000)).toBe(false)
+  })
+
+  it('secondary: smvB can read the agreed surface that smvA wrote (shared store)', async () => {
+    const sharedStore = memory()
+    const dbA = await createNoydb({ store: sharedStore, user: 'partyA', encrypt: false })
+    const smvA = await StateManagementVault.open(dbA)
+
+    const def: SurfaceDefinition = {
+      id: 'e2e-surf-2',
+      collections: ['orders'],
+      direction: 'bidi',
+      conflictPolicy: { strategy: 'lww-by-ts' },
+      cadenceMs: 30_000,
+    }
+
+    await proposeSurface(smvA, def, 'partyA', 2_000_000)
+
+    // Party B on the same store
+    const dbB = await createNoydb({ store: sharedStore, user: 'partyB', encrypt: false })
+    const smvB = await StateManagementVault.open(dbB)
+    const seen = await smvB.getSurface('e2e-surf-2')
+    expect(seen?.status).toBe('proposed')
+    expect(seen?.cadenceMs).toBe(30_000)
+
+    const agreed = await agreeSurface(smvB, 'e2e-surf-2', 'partyB', 2_001_000)
+    expect(agreed.status).toBe('agreed')
+    expect(agreed.direction).toBe('bidi')
+  })
+})

--- a/packages/lobby/__tests__/surface-handshake.test.ts
+++ b/packages/lobby/__tests__/surface-handshake.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '@noy-db/hub'
+import { ConflictError } from '@noy-db/hub'
+import { StateManagementVault } from '../src/federation/state-vault.js'
+import type { SurfaceDirection, SurfaceConflictPolicy } from '../src/federation/types.js'
+import {
+  proposeSurface,
+  agreeSurface,
+  SurfaceNotFoundError,
+  SurfaceStateError,
+} from '../src/interchange/surface.js'
+import type { SurfaceDefinition } from '../src/interchange/surface.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+const baseDef: SurfaceDefinition = {
+  collections: ['clients', 'invoices'],
+  direction: 'push' as SurfaceDirection,
+  conflictPolicy: { strategy: 'take-incoming' } as SurfaceConflictPolicy,
+}
+
+describe('Surface propose/agree bilateral handshake', () => {
+  it('proposeSurface writes a status:proposed SurfaceRow', async () => {
+    const store = memory()
+    const dbA = await createNoydb({ store, user: 'op', encrypt: false })
+    const smvA = await StateManagementVault.open(dbA)
+
+    const now = 1_000_000
+    const row = await proposeSurface(smvA, baseDef, 'partyA', now)
+
+    expect(row.status).toBe('proposed')
+    expect(row.proposedBy).toBe('partyA')
+    expect(row.createdAt).toBe(now)
+    expect(row.collections).toEqual(['clients', 'invoices'])
+    expect(row.direction).toBe('push')
+    expect(typeof row.id).toBe('string')
+    expect(row.id.length).toBeGreaterThan(0)
+    expect(row.agreedBy).toBeUndefined()
+  })
+
+  it('proposeSurface uses provided id when def.id is set', async () => {
+    const store = memory()
+    const dbA = await createNoydb({ store, user: 'op', encrypt: false })
+    const smvA = await StateManagementVault.open(dbA)
+
+    const row = await proposeSurface(smvA, { ...baseDef, id: 'my-surface-id' }, 'partyA', 1_000_000)
+    expect(row.id).toBe('my-surface-id')
+  })
+
+  it('two parties over a shared store: party B sees proposed surface and can agree', async () => {
+    // Two Noydb instances over the SAME store (same pattern as federation-fleet-migration "session 2")
+    const store = memory()
+    const dbA = await createNoydb({ store, user: 'op', encrypt: false })
+    const dbB = await createNoydb({ store, user: 'op', encrypt: false })
+
+    const smvA = await StateManagementVault.open(dbA)
+    const smvB = await StateManagementVault.open(dbB)
+
+    const now1 = 1_000_000
+    const now2 = 1_001_000
+
+    // Party A proposes
+    const proposed = await proposeSurface(smvA, baseDef, 'partyA', now1)
+    expect(proposed.status).toBe('proposed')
+
+    // Party B opens same SMV and can read the proposed surface
+    const seen = await smvB.getSurface(proposed.id)
+    expect(seen).not.toBeNull()
+    expect(seen?.status).toBe('proposed')
+
+    // Party B agrees
+    const agreed = await agreeSurface(smvB, proposed.id, 'partyB', now2)
+    expect(agreed.status).toBe('agreed')
+    expect(agreed.agreedBy).toBe('partyB')
+    expect(agreed.proposedBy).toBe('partyA')
+    expect(agreed.id).toBe(proposed.id)
+
+    // A third fresh Noydb over the same store sees the agreed state persisted correctly.
+    // (Two separate Noydb instances share the same store but each has its own
+    // in-memory eager cache — a fresh open is the correct way to verify persistence.)
+    const dbC = await createNoydb({ store, user: 'op', encrypt: false })
+    const smvC = await StateManagementVault.open(dbC)
+    const reread = await smvC.getSurface(proposed.id)
+    expect(reread?.status).toBe('agreed')
+    expect(reread?.agreedBy).toBe('partyB')
+  })
+
+  it('agreeSurface on a missing id throws SurfaceNotFoundError', async () => {
+    const store = memory()
+    const dbB = await createNoydb({ store, user: 'op', encrypt: false })
+    const smvB = await StateManagementVault.open(dbB)
+
+    await expect(agreeSurface(smvB, 'no-such-id', 'partyB', 1_000_000)).rejects.toThrow(SurfaceNotFoundError)
+  })
+
+  it('agreeSurface on an already-agreed surface throws SurfaceStateError', async () => {
+    const store = memory()
+    const dbA = await createNoydb({ store, user: 'op', encrypt: false })
+    const smvA = await StateManagementVault.open(dbA)
+
+    const proposed = await proposeSurface(smvA, baseDef, 'partyA', 1_000_000)
+    // First agree succeeds
+    await agreeSurface(smvA, proposed.id, 'partyB', 1_001_000)
+    // Second agree must throw SurfaceStateError (already agreed, not proposed)
+    await expect(agreeSurface(smvA, proposed.id, 'partyC', 1_002_000)).rejects.toThrow(SurfaceStateError)
+  })
+
+  it('agreeSurface on a suspended surface throws SurfaceStateError', async () => {
+    const store = memory()
+    const dbA = await createNoydb({ store, user: 'op', encrypt: false })
+    const smvA = await StateManagementVault.open(dbA)
+
+    const proposed = await proposeSurface(smvA, baseDef, 'partyA', 1_000_000)
+    // Manually patch to suspended
+    await smvA.updateSurface(proposed.id, { status: 'suspended' })
+
+    await expect(agreeSurface(smvA, proposed.id, 'partyB', 1_001_000)).rejects.toThrow(SurfaceStateError)
+  })
+})

--- a/packages/lobby/__tests__/surface-persistence.test.ts
+++ b/packages/lobby/__tests__/surface-persistence.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '@noy-db/hub'
+import { ConflictError } from '@noy-db/hub'
+import { StateManagementVault } from '../src/federation/state-vault.js'
+import type { SurfaceRow } from '../src/federation/types.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+const baseSurface: SurfaceRow = {
+  id: 'surf-001',
+  collections: ['clients', 'invoices'],
+  direction: 'push',
+  conflictPolicy: { strategy: 'take-incoming' },
+  status: 'proposed',
+  proposedBy: 'partyA',
+  createdAt: 1_000_000,
+}
+
+describe('StateManagementVault — surfaces collection', () => {
+  it('createSurface + getSurface round-trips the full row', async () => {
+    const db = await createNoydb({ store: memory(), user: 'op', encrypt: false })
+    const sv = await StateManagementVault.open(db)
+
+    await sv.createSurface(baseSurface)
+    const retrieved = await sv.getSurface('surf-001')
+
+    expect(retrieved).not.toBeNull()
+    expect(retrieved?.id).toBe('surf-001')
+    expect(retrieved?.collections).toEqual(['clients', 'invoices'])
+    expect(retrieved?.direction).toBe('push')
+    expect(retrieved?.status).toBe('proposed')
+    expect(retrieved?.proposedBy).toBe('partyA')
+    expect(retrieved?.createdAt).toBe(1_000_000)
+    expect(retrieved?.conflictPolicy.strategy).toBe('take-incoming')
+  })
+
+  it('listSurfaces returns all persisted surfaces', async () => {
+    const db = await createNoydb({ store: memory(), user: 'op', encrypt: false })
+    const sv = await StateManagementVault.open(db)
+
+    const s2: SurfaceRow = { ...baseSurface, id: 'surf-002', proposedBy: 'partyB' }
+    await sv.createSurface(baseSurface)
+    await sv.createSurface(s2)
+
+    const list = await sv.listSurfaces()
+    expect(list.length).toBe(2)
+    const ids = list.map((r) => r.id)
+    expect(ids).toContain('surf-001')
+    expect(ids).toContain('surf-002')
+  })
+
+  it('updateSurface patches status and agreedBy', async () => {
+    const db = await createNoydb({ store: memory(), user: 'op', encrypt: false })
+    const sv = await StateManagementVault.open(db)
+
+    await sv.createSurface(baseSurface)
+    const updated = await sv.updateSurface('surf-001', { status: 'agreed', agreedBy: 'partyB' })
+
+    expect(updated.status).toBe('agreed')
+    expect(updated.agreedBy).toBe('partyB')
+    // unchanged fields are preserved
+    expect(updated.id).toBe('surf-001')
+    expect(updated.direction).toBe('push')
+    expect(updated.proposedBy).toBe('partyA')
+
+    // persisted correctly
+    const reread = await sv.getSurface('surf-001')
+    expect(reread?.status).toBe('agreed')
+    expect(reread?.agreedBy).toBe('partyB')
+  })
+
+  it('getSurface returns null for unknown id', async () => {
+    const db = await createNoydb({ store: memory(), user: 'op', encrypt: false })
+    const sv = await StateManagementVault.open(db)
+    expect(await sv.getSurface('no-such-surface')).toBeNull()
+  })
+
+  it('persists optional fields: fields, cadenceMs, lastSyncAt, nextSyncDueAt', async () => {
+    const db = await createNoydb({ store: memory(), user: 'op', encrypt: false })
+    const sv = await StateManagementVault.open(db)
+
+    const full: SurfaceRow = {
+      ...baseSurface,
+      id: 'surf-full',
+      fields: { clients: ['name', 'email'] },
+      cadenceMs: 60_000,
+      lastSyncAt: 2_000_000,
+      nextSyncDueAt: 2_060_000,
+    }
+    await sv.createSurface(full)
+    const got = await sv.getSurface('surf-full')
+    expect(got?.fields).toEqual({ clients: ['name', 'email'] })
+    expect(got?.cadenceMs).toBe(60_000)
+    expect(got?.lastSyncAt).toBe(2_000_000)
+    expect(got?.nextSyncDueAt).toBe(2_060_000)
+  })
+
+  it('surfaces collection is isolated from existing SMV collections', async () => {
+    const db = await createNoydb({ store: memory(), user: 'op', encrypt: false })
+    const sv = await StateManagementVault.open(db)
+
+    await sv.createSurface(baseSurface)
+    // registry, schemaManifest, events are untouched
+    expect(await sv.registry.get('surf-001')).toBeNull()
+    expect(await sv.schemaManifest.get('surf-001')).toBeNull()
+    expect((await sv.queryEvents().toArray()).length).toBe(0)
+  })
+})

--- a/packages/lobby/__tests__/surface-sync.test.ts
+++ b/packages/lobby/__tests__/surface-sync.test.ts
@@ -7,10 +7,10 @@
  *   Surface:       agreed, push, collections:['clients'], fields:{clients:['name']},
  *                  conflictPolicy:{strategy:'take-incoming'}
  *
- * Direction guards (per plan):
- *   exportSurface: rejects direction='pull' (pull-only surfaces; push/bidi may export)
- *   applySurface:  rejects direction='pull' (on a pull surface, the pull-side initiates
- *                  the extract; applySurface is not called directly)
+ * Direction is orchestration metadata, NOT a primitive gate: export/apply are
+ * direction-agnostic mechanics (source→slice, slice→receiver) and work for
+ * push / pull / bidi alike (gating pull here would make pull surfaces unusable).
+ * The sync flow decides which party exports vs applies per direction.
  *
  * Both throw SurfaceStateError for a non-agreed surface.
  */
@@ -126,10 +126,14 @@ describe('exportSurface / applySurface — scoped field-projected sync', () => {
     await expect(applySurface(recvVault, proposed, new Uint8Array(16), new Uint8Array(32))).rejects.toThrow(SurfaceStateError)
   })
 
-  it('direction:pull rejects exportSurface (export is push-side only; pull surfaces cannot be exported)', async () => {
+  it('direction:pull is a direction-agnostic mechanic — export+apply work (flow agreer→proposer)', async () => {
+    // A pull surface must NOT be dead: the source still exports its slice and the
+    // receiver still applies it. Direction is honoured by the sync flow (who is
+    // source vs receiver), not by gating the primitives.
     const pullDef: SurfaceDefinition = {
       id: 'surf-pull-1',
       collections: ['clients'],
+      fields: { clients: ['name'] },
       direction: 'pull',
       conflictPolicy: { strategy: 'take-incoming' },
     }
@@ -137,23 +141,18 @@ describe('exportSurface / applySurface — scoped field-projected sync', () => {
 
     const sourceDb = await createNoydb({ store: memory(), user: 'src', secret: 'src-secret-123' })
     const sourceVault = await sourceDb.openVault('source')
+    await sourceVault.collection<Client>('clients').put('c1', { id: 'c1', name: 'Alice', phone: '+1-555-0101' })
 
-    await expect(exportSurface(sourceVault, surface)).rejects.toThrow(SurfaceStateError)
-  })
-
-  it('direction:pull rejects applySurface (pull surface: the pull-side initiates via export, not apply)', async () => {
-    const pullDef: SurfaceDefinition = {
-      id: 'surf-pull-apply-1',
-      collections: ['clients'],
-      direction: 'pull',
-      conflictPolicy: { strategy: 'take-incoming' },
-    }
-    const surface = await buildAgreedSurface(pullDef)
+    const { bundleBytes, transferKey } = await exportSurface(sourceVault, surface)
 
     const recvDb = await createNoydb({ store: memory(), user: 'recv', secret: 'recv-secret-456' })
     const recvVault = await recvDb.openVault('receiver')
+    const report = await applySurface(recvVault, surface, bundleBytes, transferKey)
 
-    await expect(applySurface(recvVault, surface, new Uint8Array(16), new Uint8Array(32))).rejects.toThrow(SurfaceStateError)
+    expect(report.summary.inserted).toBe(1)
+    const c1 = await recvVault.collection<Record<string, unknown>>('clients').get('c1')
+    expect(c1!['name']).toBe('Alice')
+    expect(c1!['phone']).toBeUndefined()   // projection still applies
   })
 })
 

--- a/packages/lobby/__tests__/surface-sync.test.ts
+++ b/packages/lobby/__tests__/surface-sync.test.ts
@@ -1,0 +1,228 @@
+/**
+ * exportSurface / applySurface — scoped extract-project-merge sync (FR-7 Task 4).
+ *
+ * Fixture
+ * -------
+ *   Source vault:  clients(id, name, phone)  + secret(id, data)
+ *   Surface:       agreed, push, collections:['clients'], fields:{clients:['name']},
+ *                  conflictPolicy:{strategy:'take-incoming'}
+ *
+ * Direction guards (per plan):
+ *   exportSurface: rejects direction='pull' (pull-only surfaces; push/bidi may export)
+ *   applySurface:  rejects direction='pull' (on a pull surface, the pull-side initiates
+ *                  the extract; applySurface is not called directly)
+ *
+ * Both throw SurfaceStateError for a non-agreed surface.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { StateManagementVault } from '../src/federation/state-vault.js'
+import type { SurfaceRow } from '../src/federation/types.js'
+import {
+  proposeSurface,
+  agreeSurface,
+  exportSurface,
+  applySurface,
+  SurfaceStateError,
+} from '../src/interchange/surface.js'
+import type { SurfaceDefinition } from '../src/interchange/surface.js'
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+interface Client { id: string; name: string; phone: string }
+interface Secret { id: string; data: string }
+
+/** Build an agreed surface (two Noydb over a shared store). */
+async function buildAgreedSurface(def: SurfaceDefinition): Promise<SurfaceRow> {
+  const store = memory()
+  const dbA = await createNoydb({ store, user: 'partyA', encrypt: false })
+  const dbB = await createNoydb({ store, user: 'partyB', encrypt: false })
+  const smvA = await StateManagementVault.open(dbA)
+  const smvB = await StateManagementVault.open(dbB)
+  const proposed = await proposeSurface(smvA, def, 'partyA', 1_000_000)
+  return agreeSurface(smvB, proposed.id, 'partyB', 1_001_000)
+}
+
+const pushDef: SurfaceDefinition = {
+  id: 'surf-push-1',
+  collections: ['clients'],
+  fields: { clients: ['name'] },
+  direction: 'push',
+  conflictPolicy: { strategy: 'take-incoming' },
+}
+
+// ─── Core round-trip ──────────────────────────────────────────────────────────
+
+describe('exportSurface / applySurface — scoped field-projected sync', () => {
+  it('exports only surface.collections with projected fields; receiver has name only, no phone, no secret', async () => {
+    const surface = await buildAgreedSurface(pushDef)
+
+    // Source vault: clients + secret (not in surface)
+    const sourceDb = await createNoydb({ store: memory(), user: 'src', secret: 'src-secret-123' })
+    const sourceVault = await sourceDb.openVault('source')
+    const clients = sourceVault.collection<Client>('clients')
+    await clients.put('c1', { id: 'c1', name: 'Alice', phone: '+1-555-0101' })
+    await clients.put('c2', { id: 'c2', name: 'Bob', phone: '+1-555-0202' })
+    const secrets = sourceVault.collection<Secret>('secret')
+    await secrets.put('s1', { id: 's1', data: 'TOP SECRET' })
+
+    // Export
+    const { bundleBytes, transferKey } = await exportSurface(sourceVault, surface)
+    expect(bundleBytes).toBeInstanceOf(Uint8Array)
+    expect(bundleBytes.length).toBeGreaterThan(0)
+    expect(transferKey).toBeInstanceOf(Uint8Array)
+    expect(transferKey.length).toBe(32)
+
+    // Receiver vault
+    const recvDb = await createNoydb({ store: memory(), user: 'recv', secret: 'recv-secret-456' })
+    const recvVault = await recvDb.openVault('receiver')
+
+    // Apply
+    const report = await applySurface(recvVault, surface, bundleBytes, transferKey)
+    expect(report.dryRun).toBe(false)
+    expect(report.summary.inserted).toBe(2)
+    expect(report.summary.updated).toBe(0)
+
+    // clients: id + name only — no phone
+    const c1 = await recvVault.collection<Record<string, unknown>>('clients').get('c1')
+    expect(c1).not.toBeNull()
+    expect(c1!['id']).toBe('c1')
+    expect(c1!['name']).toBe('Alice')
+    expect(c1!['phone']).toBeUndefined()
+
+    const c2 = await recvVault.collection<Record<string, unknown>>('clients').get('c2')
+    expect(c2).not.toBeNull()
+    expect(c2!['name']).toBe('Bob')
+    expect(c2!['phone']).toBeUndefined()
+
+    // secret: absent — outside the surface, never leaves
+    const secretList = await recvVault.collection<Secret>('secret').list()
+    expect(secretList).toHaveLength(0)
+  })
+
+  it('non-agreed (proposed) surface throws SurfaceStateError on exportSurface', async () => {
+    const store = memory()
+    const dbA = await createNoydb({ store, user: 'partyA', encrypt: false })
+    const smvA = await StateManagementVault.open(dbA)
+    const proposed = await proposeSurface(smvA, pushDef, 'partyA', 1_000_000)
+
+    const sourceDb = await createNoydb({ store: memory(), user: 'src', secret: 'src-secret-123' })
+    const sourceVault = await sourceDb.openVault('source')
+
+    await expect(exportSurface(sourceVault, proposed)).rejects.toThrow(SurfaceStateError)
+  })
+
+  it('non-agreed (proposed) surface throws SurfaceStateError on applySurface', async () => {
+    const store = memory()
+    const dbA = await createNoydb({ store, user: 'partyA', encrypt: false })
+    const smvA = await StateManagementVault.open(dbA)
+    const proposed = await proposeSurface(smvA, pushDef, 'partyA', 1_000_000)
+
+    const recvDb = await createNoydb({ store: memory(), user: 'recv', secret: 'recv-secret-456' })
+    const recvVault = await recvDb.openVault('receiver')
+
+    await expect(applySurface(recvVault, proposed, new Uint8Array(16), new Uint8Array(32))).rejects.toThrow(SurfaceStateError)
+  })
+
+  it('direction:pull rejects exportSurface (export is push-side only; pull surfaces cannot be exported)', async () => {
+    const pullDef: SurfaceDefinition = {
+      id: 'surf-pull-1',
+      collections: ['clients'],
+      direction: 'pull',
+      conflictPolicy: { strategy: 'take-incoming' },
+    }
+    const surface = await buildAgreedSurface(pullDef)
+
+    const sourceDb = await createNoydb({ store: memory(), user: 'src', secret: 'src-secret-123' })
+    const sourceVault = await sourceDb.openVault('source')
+
+    await expect(exportSurface(sourceVault, surface)).rejects.toThrow(SurfaceStateError)
+  })
+
+  it('direction:pull rejects applySurface (pull surface: the pull-side initiates via export, not apply)', async () => {
+    const pullDef: SurfaceDefinition = {
+      id: 'surf-pull-apply-1',
+      collections: ['clients'],
+      direction: 'pull',
+      conflictPolicy: { strategy: 'take-incoming' },
+    }
+    const surface = await buildAgreedSurface(pullDef)
+
+    const recvDb = await createNoydb({ store: memory(), user: 'recv', secret: 'recv-secret-456' })
+    const recvVault = await recvDb.openVault('receiver')
+
+    await expect(applySurface(recvVault, surface, new Uint8Array(16), new Uint8Array(32))).rejects.toThrow(SurfaceStateError)
+  })
+})
+
+// ─── Isolation guarantee ──────────────────────────────────────────────────────
+
+describe('exportSurface — ensures only surface.collections are in the bundle', () => {
+  it('a non-surface collection (secret) has no records in the receiver after apply', async () => {
+    const surface = await buildAgreedSurface({
+      id: 'surf-isolation-1',
+      collections: ['clients'],
+      direction: 'push',
+      conflictPolicy: { strategy: 'take-incoming' },
+    })
+
+    const sourceDb = await createNoydb({ store: memory(), user: 'src', secret: 'src-secret-123' })
+    const sourceVault = await sourceDb.openVault('source')
+    await sourceVault.collection<Client>('clients').put('c1', { id: 'c1', name: 'Alice', phone: '555' })
+    await sourceVault.collection<Secret>('secret').put('s1', { id: 's1', data: 'SENSITIVE' })
+    await sourceVault.collection<Secret>('secret').put('s2', { id: 's2', data: 'CONFIDENTIAL' })
+
+    const { bundleBytes, transferKey } = await exportSurface(sourceVault, surface)
+
+    const recvDb = await createNoydb({ store: memory(), user: 'recv', secret: 'recv-secret-456' })
+    const recvVault = await recvDb.openVault('receiver')
+    await applySurface(recvVault, surface, bundleBytes, transferKey)
+
+    // secret must NOT be in receiver
+    expect(await recvVault.collection<Secret>('secret').list()).toHaveLength(0)
+    // clients IS in receiver
+    expect(await recvVault.collection<Client>('clients').list()).toHaveLength(1)
+  })
+})
+
+// ─── Lobby Surface API ────────────────────────────────────────────────────────
+
+describe('Lobby Surface API — delegate to surface.ts helpers', () => {
+  it('Lobby.exportSurface / Lobby.applySurface round-trip via vault name', async () => {
+    const { createLobby } = await import('../src/index.js')
+
+    // Agree a surface via the low-level helpers
+    const surface = await buildAgreedSurface({
+      id: 'surf-lobby-1',
+      collections: ['orders'],
+      fields: { orders: ['amount'] },
+      direction: 'push',
+      conflictPolicy: { strategy: 'take-incoming' },
+    })
+
+    // Source Lobby
+    const srcDb = await createNoydb({ store: memory(), user: 'src', secret: 'src-secret-123' })
+    const srcLobby = createLobby(srcDb)
+    interface Order { id: string; amount: number; note: string }
+    const srcVault = await srcDb.openVault('orders')
+    await srcVault.collection<Order>('orders').put('o1', { id: 'o1', amount: 100, note: 'confidential' })
+    await srcVault.collection<Order>('orders').put('o2', { id: 'o2', amount: 200, note: 'also private' })
+
+    const { bundleBytes, transferKey } = await srcLobby.exportSurface('orders', surface)
+
+    // Receiver Lobby
+    const recvDb = await createNoydb({ store: memory(), user: 'recv', secret: 'recv-secret-456' })
+    const recvLobby = createLobby(recvDb)
+
+    const report = await recvLobby.applySurface('orders', surface, bundleBytes, transferKey)
+    expect(report.summary.inserted).toBe(2)
+
+    // amount only, no note
+    const recvVault = await recvDb.openVault('orders')
+    const o1 = await recvVault.collection<Record<string, unknown>>('orders').get('o1')
+    expect(o1!['amount']).toBe(100)
+    expect(o1!['note']).toBeUndefined()
+  })
+})

--- a/packages/lobby/src/federation/state-vault.ts
+++ b/packages/lobby/src/federation/state-vault.ts
@@ -7,7 +7,7 @@
 import type { Noydb } from '@noy-db/hub/kernel'
 import type { Collection } from '@noy-db/hub/kernel'
 import type { Query } from '@noy-db/hub/kernel'
-import type { VaultRegistryRow, SchemaManifestRow, DeploymentEvent, MigrationStatusRow, VaultTemplate } from './types.js'
+import type { VaultRegistryRow, SchemaManifestRow, DeploymentEvent, MigrationStatusRow, SurfaceRow, VaultTemplate } from './types.js'
 import { captureBlueprint, fingerprintBlueprint } from './schema-manifest.js'
 import { STATE_VAULT_NAME } from './constants.js'
 import { generateULID } from '@noy-db/hub/kernel'
@@ -21,6 +21,7 @@ const REGISTRY = 'vaultRegistry'
 const MANIFEST = 'schemaManifest'
 const EVENTS = 'deploymentEvents'
 const MIGRATION_STATUS = 'migrationStatus'
+const SURFACES = 'surfaces'
 
 export class StateManagementVault {
   /**
@@ -32,15 +33,19 @@ export class StateManagementVault {
   readonly #events: Collection<DeploymentEvent>
   /** Per-shard fleet-migration progress (#271). Surfaced via typed methods only. */
   readonly #migrationStatus: Collection<MigrationStatusRow>
+  /** Persisted Surface agreements (FR-7). Surfaced via typed methods only. */
+  readonly #surfaces: Collection<SurfaceRow>
 
   private constructor(
     readonly registry: Collection<VaultRegistryRow>,
     readonly schemaManifest: Collection<SchemaManifestRow>,
     events: Collection<DeploymentEvent>,
     migrationStatus: Collection<MigrationStatusRow>,
+    surfaces: Collection<SurfaceRow>,
   ) {
     this.#events = events
     this.#migrationStatus = migrationStatus
+    this.#surfaces = surfaces
   }
 
   /** Idempotently open the reserved state vault and bind the control-plane collections. */
@@ -51,6 +56,7 @@ export class StateManagementVault {
       vault.collection<SchemaManifestRow>(MANIFEST),
       vault.collection<DeploymentEvent>(EVENTS),
       vault.collection<MigrationStatusRow>(MIGRATION_STATUS),
+      vault.collection<SurfaceRow>(SURFACES),
     )
   }
 
@@ -68,6 +74,37 @@ export class StateManagementVault {
   /** Upsert one shard's migration status (keyed by vaultId). */
   async upsertMigrationStatus(row: MigrationStatusRow): Promise<void> {
     await this.#migrationStatus.put(row.vaultId, row)
+  }
+
+  // ─── FR-7 Surface CRUD ────────────────────────────────────────────────────
+
+  /** Persist a new Surface row (keyed by `row.id`). */
+  async createSurface(row: SurfaceRow): Promise<void> {
+    await this.#surfaces.put(row.id, row)
+  }
+
+  /** Read one Surface row by id, or null if absent. */
+  async getSurface(id: string): Promise<SurfaceRow | null> {
+    return this.#surfaces.get(id)
+  }
+
+  /** All persisted Surface rows (hydrates first). */
+  async listSurfaces(): Promise<SurfaceRow[]> {
+    await this.#surfaces.list()
+    return this.#surfaces.query().toArray()
+  }
+
+  /**
+   * Merge `patch` into the existing Surface row keyed by `id`, persist the
+   * result, and return it. Mirrors the migrationStatus upsert pattern but
+   * returns the merged row for convenience.
+   */
+  async updateSurface(id: string, patch: Partial<SurfaceRow>): Promise<SurfaceRow> {
+    const existing = await this.#surfaces.get(id)
+    if (!existing) throw new Error(`Surface not found: ${id}`)
+    const updated: SurfaceRow = { ...existing, ...patch }
+    await this.#surfaces.put(id, updated)
+    return updated
   }
 
   /** Read-only query over the append-only deployment-events log. */

--- a/packages/lobby/src/federation/types.ts
+++ b/packages/lobby/src/federation/types.ts
@@ -4,6 +4,8 @@
  * transparent shard routing. See
  * docs/superpowers/specs/2026-06-07-mvf-vaultgroup-routing-mvp-design.md.
  */
+import type { MergeStrategy } from '../interchange/merge-compartment.js'
+import type { FieldAuthorityPolicy } from '../interchange/field-authority.js'
 import type { Vault } from '@noy-db/hub/kernel'
 import type { Collection } from '@noy-db/hub/kernel'
 import type { Operator } from '@noy-db/hub/kernel'
@@ -235,4 +237,45 @@ export interface MigrationStatusRow {
   /** Records migrated by the per-shard cutover (when status `done`). */
   readonly migrated?: number
   readonly error?: string
+}
+
+// ─── FR-7 Surface / Scoped Sync ──────────────────────────────────────────────
+
+/** Which direction the sync flows across the surface boundary. */
+export type SurfaceDirection = 'push' | 'pull' | 'bidi'
+
+/** Lifecycle state of a bilateral surface agreement. */
+export type SurfaceStatus = 'proposed' | 'agreed' | 'suspended'
+
+/**
+ * Conflict resolution policy for a Surface.
+ * `strategy` may be a single MergeStrategy applied to all collections, or a
+ * per-collection map (with an optional `default` fallback).
+ */
+export interface SurfaceConflictPolicy {
+  readonly strategy: MergeStrategy | (Record<string, MergeStrategy> & { default?: MergeStrategy })
+  readonly fieldAuthority?: Record<string, FieldAuthorityPolicy>
+}
+
+/**
+ * Persisted row in the StateManagementVault `surfaces` collection (FR-7).
+ * Describes a bilaterally-agreed subset of collections/fields that two parties
+ * sync in a given direction with a given conflict policy.
+ */
+export interface SurfaceRow {
+  readonly id: string
+  /** Collection names included in this surface. */
+  readonly collections: readonly string[]
+  /** Per-collection field allow-lists (omit = all fields). */
+  readonly fields?: Record<string, readonly string[]>
+  readonly direction: SurfaceDirection
+  readonly conflictPolicy: SurfaceConflictPolicy
+  /** Sync cadence in milliseconds (undefined = manual only). */
+  readonly cadenceMs?: number
+  readonly status: SurfaceStatus
+  readonly proposedBy: string
+  readonly agreedBy?: string
+  readonly createdAt: number
+  readonly lastSyncAt?: number
+  readonly nextSyncDueAt?: number
 }

--- a/packages/lobby/src/index.ts
+++ b/packages/lobby/src/index.ts
@@ -272,8 +272,12 @@ export {
   agreeSurface,
   exportSurface,
   applySurface,
+  isSurfaceDue,
+  listDueSurfaces,
+  markSynced,
   SurfaceNotFoundError,
   SurfaceStateError,
+  SurfaceCadenceScheduler,
 } from './interchange/surface.js'
 export type {
   SurfaceDefinition,

--- a/packages/lobby/src/index.ts
+++ b/packages/lobby/src/index.ts
@@ -44,6 +44,10 @@ export interface ExportMultiVaultXlsxOptions {
   readonly sheetSeparator?: string
 }
 
+// ─── FR-7 Surface type imports (used in Lobby method signatures) ──────────────
+import type { SurfaceRow } from './federation/types.js'
+import type { MergeReport } from './interchange/merge-compartment.js'
+
 export class Lobby {
   readonly noydb: Noydb
   private readonly vaultTemplates = new Map<string, VaultTemplate>()
@@ -83,6 +87,38 @@ export class Lobby {
     if (db.isClosed) throw new ValidationError('Instance is closed')
     const { StateManagementVault } = await import('./federation/state-vault.js')
     return StateManagementVault.open(db)
+  }
+
+  // ─── FR-7 Surface API ─────────────────────────────────────────────────────
+
+  /**
+   * Export a scoped partition from `vaultName` bounded to the given surface.
+   * Delegates to `exportSurface` in `interchange/surface.ts`.
+   * The vault is opened via `this.noydb.openVault(vaultName)`.
+   */
+  async exportSurface(
+    vaultName: string,
+    surface: SurfaceRow,
+  ): Promise<{ bundleBytes: Uint8Array; transferKey: Uint8Array }> {
+    const { exportSurface: exportSurfaceFn } = await import('./interchange/surface.js')
+    const vault = await this.noydb.openVault(vaultName)
+    return exportSurfaceFn(vault, surface)
+  }
+
+  /**
+   * Apply an exported surface bundle into `vaultName`.
+   * Delegates to `applySurface` in `interchange/surface.ts`.
+   * The vault is opened via `this.noydb.openVault(vaultName)`.
+   */
+  async applySurface(
+    vaultName: string,
+    surface: SurfaceRow,
+    bundleBytes: Uint8Array,
+    transferKey: Uint8Array,
+  ): Promise<MergeReport> {
+    const { applySurface: applySurfaceFn } = await import('./interchange/surface.js')
+    const vault = await this.noydb.openVault(vaultName)
+    return applySurfaceFn(vault, surface, bundleBytes, transferKey)
   }
 
   /**
@@ -229,3 +265,22 @@ export type {
   MultiVaultXlsxOptions,
   MultiVaultDenormColumn,
 } from '@noy-db/as-xlsx'
+
+// ─── FR-7: Surface / Scoped Sync ─────────────────────────────────────────────
+export {
+  proposeSurface,
+  agreeSurface,
+  exportSurface,
+  applySurface,
+  SurfaceNotFoundError,
+  SurfaceStateError,
+} from './interchange/surface.js'
+export type {
+  SurfaceDefinition,
+} from './interchange/surface.js'
+export type {
+  SurfaceRow,
+  SurfaceDirection,
+  SurfaceStatus,
+  SurfaceConflictPolicy,
+} from './federation/types.js'

--- a/packages/lobby/src/interchange/surface.ts
+++ b/packages/lobby/src/interchange/surface.ts
@@ -176,3 +176,106 @@ export async function applySurface(
     reason: `sync:surface:${surface.id}`,
   })
 }
+
+// ─── Cadence helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Pure due-check — deterministic, no Date.now() inside.
+ *
+ * A surface is due iff:
+ *  - it has a `cadenceMs` (manually-only surfaces are never due via this check)
+ *  - its `status` is `'agreed'` (proposed/suspended do not fire)
+ *  - it has never been synced (`lastSyncAt === undefined`), OR
+ *    `now` has reached or passed `nextSyncDueAt`
+ *
+ * The caller always passes `now` explicitly so the function is testable without
+ * any timer mocking.
+ */
+export function isSurfaceDue(surface: SurfaceRow, now: number): boolean {
+  if (surface.cadenceMs === undefined) return false
+  if (surface.status !== 'agreed') return false
+  if (surface.lastSyncAt === undefined) return true
+  return now >= (surface.nextSyncDueAt ?? 0)
+}
+
+/**
+ * Filter a list of surfaces to those that are currently due.
+ * Delegates to `isSurfaceDue` for each entry.
+ */
+export function listDueSurfaces(surfaces: readonly SurfaceRow[], now: number): SurfaceRow[] {
+  return surfaces.filter(s => isSurfaceDue(s, now))
+}
+
+/**
+ * Stamp `lastSyncAt = now` and `nextSyncDueAt = now + surface.cadenceMs` in
+ * the StateManagementVault after a successful sync run. The surface must exist
+ * (reads it to get `cadenceMs`). If `cadenceMs` is undefined the stamps are
+ * written with `nextSyncDueAt = now` (no-op for future due-checks).
+ *
+ * Does NOT call Date.now() internally — the caller supplies `now`.
+ */
+export async function markSynced(
+  smv: StateManagementVault,
+  id: string,
+  now: number,
+): Promise<SurfaceRow> {
+  const existing = await smv.getSurface(id)
+  if (!existing) throw new Error(`markSynced: surface not found: ${id}`)
+  const cadenceMs = existing.cadenceMs ?? 0
+  return smv.updateSurface(id, {
+    lastSyncAt: now,
+    nextSyncDueAt: now + cadenceMs,
+  })
+}
+
+/**
+ * Thin interval driver for surface cadence.
+ *
+ * Wraps a `Map<surfaceId, timer>` so each surface can be independently
+ * started / stopped. `start` calls `setInterval(fn, intervalMs)` and
+ * replaces any existing timer for the same id. `stopAll` clears all.
+ *
+ * Accepts an injectable `nowFn` (default `Date.now`) for use-sites that
+ * need to capture the current time inside the callback — the pure due-check
+ * (`isSurfaceDue`) takes `now` explicitly and should not call this.
+ */
+export class SurfaceCadenceScheduler {
+  readonly #timers = new Map<string, ReturnType<typeof setInterval>>()
+  readonly #nowFn: () => number
+
+  constructor(nowFn: () => number = Date.now) {
+    this.#nowFn = nowFn
+  }
+
+  /** Expose nowFn for callback use-sites. */
+  get now(): number {
+    return this.#nowFn()
+  }
+
+  /**
+   * Schedule `fn` to fire every `intervalMs` milliseconds for the given
+   * `surfaceId`. If the id is already running, the previous interval is
+   * cancelled first (replace semantics).
+   */
+  start(surfaceId: string, intervalMs: number, fn: () => void): void {
+    this.stop(surfaceId)
+    const timer = setInterval(fn, intervalMs)
+    this.#timers.set(surfaceId, timer)
+  }
+
+  /** Cancel the interval for `surfaceId` (no-op if not running). */
+  stop(surfaceId: string): void {
+    const timer = this.#timers.get(surfaceId)
+    if (timer !== undefined) {
+      clearInterval(timer)
+      this.#timers.delete(surfaceId)
+    }
+  }
+
+  /** Cancel all running intervals. */
+  stopAll(): void {
+    for (const [id] of this.#timers) {
+      this.stop(id)
+    }
+  }
+}

--- a/packages/lobby/src/interchange/surface.ts
+++ b/packages/lobby/src/interchange/surface.ts
@@ -112,10 +112,16 @@ export async function agreeSurface(
  * keys are exactly `surface.collections`). Excluded fields are structurally
  * redacted before re-encryption and never travel in the bundle.
  *
+ * `exportSurface`/`applySurface` are direction-AGNOSTIC mechanics: export
+ * produces a slice from a source vault, apply merges a slice into a receiver
+ * vault. Both are needed for EVERY direction (push: proposer exports → agreer
+ * applies; pull: agreer exports → proposer applies; bidi: both). `direction` is
+ * orchestration metadata honoured by the sync flow (which party exports vs
+ * applies), not a gate on the primitives — gating it here would make pull
+ * surfaces unusable.
+ *
  * Throws:
  * - `SurfaceStateError` when `surface.status !== 'agreed'`.
- * - `SurfaceStateError` when `surface.direction === 'pull'` (pull-only surfaces
- *   cannot be exported; export is a push-side operation).
  */
 export async function exportSurface(
   source: Vault,
@@ -123,13 +129,6 @@ export async function exportSurface(
 ): Promise<{ bundleBytes: Uint8Array; transferKey: Uint8Array }> {
   if (surface.status !== 'agreed') {
     throw new SurfaceStateError(surface.id, surface.status, 'agreed')
-  }
-  if (surface.direction === 'pull') {
-    throw new SurfaceStateError(
-      surface.id,
-      `direction:${surface.direction}`,
-      'direction:push or direction:bidi (export is a push-side operation)',
-    )
   }
 
   // Seeds: include ALL records in each surface collection (no predicate filtering).
@@ -152,11 +151,11 @@ export async function exportSurface(
  * Apply an exported surface bundle into `receiver`. Decrypts + merges using
  * the surface's conflict policy.
  *
+ * Direction-agnostic mechanic (see `exportSurface`): the receiver merges the
+ * slice regardless of direction; the sync flow decides which party applies.
+ *
  * Throws:
  * - `SurfaceStateError` when `surface.status !== 'agreed'`.
- * - `SurfaceStateError` when `surface.direction === 'pull'` (on a pull surface
- *   the pull-side initiates an extract from the source; applySurface is not
- *   used in that flow).
  */
 export async function applySurface(
   receiver: Vault,
@@ -166,13 +165,6 @@ export async function applySurface(
 ): Promise<MergeReport> {
   if (surface.status !== 'agreed') {
     throw new SurfaceStateError(surface.id, surface.status, 'agreed')
-  }
-  if (surface.direction === 'pull') {
-    throw new SurfaceStateError(
-      surface.id,
-      `direction:${surface.direction}`,
-      'direction:push or direction:bidi (applySurface is the receive side of a push)',
-    )
   }
 
   return mergeCompartment(receiver, bundleBytes, {

--- a/packages/lobby/src/interchange/surface.ts
+++ b/packages/lobby/src/interchange/surface.ts
@@ -1,9 +1,12 @@
 /**
- * @klum-db/lobby interchange — Surface bilateral handshake (FR-7).
+ * @klum-db/lobby interchange — Surface bilateral handshake + export/apply (FR-7).
  * Pure helpers: `now` is always passed in; no Date.now() calls inside.
  * @packageDocumentation
  */
 import { generateULID } from '@noy-db/hub/kernel'
+import type { Vault } from '@noy-db/hub'
+import { extractPartition } from '@noy-db/hub/bundle'
+import { mergeCompartment, type MergeReport } from './merge-compartment.js'
 import type { StateManagementVault } from '../federation/state-vault.js'
 import type {
   SurfaceRow,
@@ -98,4 +101,86 @@ export async function agreeSurface(
     throw new SurfaceStateError(surfaceId, existing.status, 'proposed')
   }
   return smv.updateSurface(surfaceId, { status: 'agreed', agreedBy })
+}
+
+// ─── Export / Apply ───────────────────────────────────────────────────────────
+
+/**
+ * Export a scoped partition from `source` bounded to the surface's collections
+ * and field projection. Only surface.collections are included in the bundle
+ * (`maxDepth: 0` prevents ref-expansion to non-surface collections; the `seeds`
+ * keys are exactly `surface.collections`). Excluded fields are structurally
+ * redacted before re-encryption and never travel in the bundle.
+ *
+ * Throws:
+ * - `SurfaceStateError` when `surface.status !== 'agreed'`.
+ * - `SurfaceStateError` when `surface.direction === 'pull'` (pull-only surfaces
+ *   cannot be exported; export is a push-side operation).
+ */
+export async function exportSurface(
+  source: Vault,
+  surface: SurfaceRow,
+): Promise<{ bundleBytes: Uint8Array; transferKey: Uint8Array }> {
+  if (surface.status !== 'agreed') {
+    throw new SurfaceStateError(surface.id, surface.status, 'agreed')
+  }
+  if (surface.direction === 'pull') {
+    throw new SurfaceStateError(
+      surface.id,
+      `direction:${surface.direction}`,
+      'direction:push or direction:bidi (export is a push-side operation)',
+    )
+  }
+
+  // Seeds: include ALL records in each surface collection (no predicate filtering).
+  // maxDepth:0 ensures ref-following stops at the seed collections so no
+  // non-surface collection can slip into the closure.
+  const seeds = Object.fromEntries(surface.collections.map(c => [c, () => true]))
+
+  const { bundleBytes, transferKey } = await extractPartition(source, {
+    seeds,
+    maxDepth: 0,
+    ...(surface.fields ? { fieldProjection: surface.fields } : {}),
+    carrySchemas: false,
+    carryLedger: false,
+  })
+
+  return { bundleBytes, transferKey }
+}
+
+/**
+ * Apply an exported surface bundle into `receiver`. Decrypts + merges using
+ * the surface's conflict policy.
+ *
+ * Throws:
+ * - `SurfaceStateError` when `surface.status !== 'agreed'`.
+ * - `SurfaceStateError` when `surface.direction === 'pull'` (on a pull surface
+ *   the pull-side initiates an extract from the source; applySurface is not
+ *   used in that flow).
+ */
+export async function applySurface(
+  receiver: Vault,
+  surface: SurfaceRow,
+  bundleBytes: Uint8Array,
+  transferKey: Uint8Array,
+): Promise<MergeReport> {
+  if (surface.status !== 'agreed') {
+    throw new SurfaceStateError(surface.id, surface.status, 'agreed')
+  }
+  if (surface.direction === 'pull') {
+    throw new SurfaceStateError(
+      surface.id,
+      `direction:${surface.direction}`,
+      'direction:push or direction:bidi (applySurface is the receive side of a push)',
+    )
+  }
+
+  return mergeCompartment(receiver, bundleBytes, {
+    transferKey,
+    strategy: surface.conflictPolicy.strategy,
+    ...(surface.conflictPolicy.fieldAuthority
+      ? { fieldAuthority: surface.conflictPolicy.fieldAuthority }
+      : {}),
+    reason: `sync:surface:${surface.id}`,
+  })
 }

--- a/packages/lobby/src/interchange/surface.ts
+++ b/packages/lobby/src/interchange/surface.ts
@@ -107,10 +107,15 @@ export async function agreeSurface(
 
 /**
  * Export a scoped partition from `source` bounded to the surface's collections
- * and field projection. Only surface.collections are included in the bundle
- * (`maxDepth: 0` prevents ref-expansion to non-surface collections; the `seeds`
- * keys are exactly `surface.collections`). Excluded fields are structurally
- * redacted before re-encryption and never travel in the bundle.
+ * and field projection. Only surface.collections are included in the bundle:
+ * `seeds` keys are exactly `surface.collections` and `maxDepth: 0` bounds the
+ * walk so no non-surface collection can enter the closure. NOTE: if a surface
+ * collection holds a `ref()` to an OUT-OF-SURFACE collection, the export
+ * hard-fails with `PartitionExtractionError` (the safe outcome — it never
+ * silently pulls in or leaks the referenced collection); surfaces over
+ * collections that cross-reference outside the surface are not supported.
+ * Excluded fields are structurally redacted before re-encryption and never
+ * travel in the bundle.
  *
  * `exportSurface`/`applySurface` are direction-AGNOSTIC mechanics: export
  * produces a slice from a source vault, apply merges a slice into a receiver
@@ -153,6 +158,12 @@ export async function exportSurface(
  *
  * Direction-agnostic mechanic (see `exportSurface`): the receiver merges the
  * slice regardless of direction; the sync flow decides which party applies.
+ *
+ * NOTE: a field-projected slice applied with a `take-incoming` conflict policy
+ * is DESTRUCTIVE to non-surface fields on a record the receiver already holds
+ * (the narrowed `{id, ...surface.fields}` overwrites the full row, dropping its
+ * other fields). Use `keep-local` or `field-authority` when the receiver's
+ * out-of-surface fields must be preserved across a projected push.
  *
  * Throws:
  * - `SurfaceStateError` when `surface.status !== 'agreed'`.

--- a/packages/lobby/src/interchange/surface.ts
+++ b/packages/lobby/src/interchange/surface.ts
@@ -1,0 +1,101 @@
+/**
+ * @klum-db/lobby interchange — Surface bilateral handshake (FR-7).
+ * Pure helpers: `now` is always passed in; no Date.now() calls inside.
+ * @packageDocumentation
+ */
+import { generateULID } from '@noy-db/hub/kernel'
+import type { StateManagementVault } from '../federation/state-vault.js'
+import type {
+  SurfaceRow,
+  SurfaceDirection,
+  SurfaceConflictPolicy,
+} from '../federation/types.js'
+
+// ─── Public types ─────────────────────────────────────────────────────────────
+
+/**
+ * User-facing subset of SurfaceRow: the fields a caller provides when
+ * proposing a new surface. `id` is optional (auto-generated via ULID when
+ * omitted). `status`, `proposedBy`, `createdAt`, etc. are set by `proposeSurface`.
+ */
+export interface SurfaceDefinition {
+  readonly id?: string
+  readonly collections: readonly string[]
+  readonly fields?: Record<string, readonly string[]>
+  readonly direction: SurfaceDirection
+  readonly conflictPolicy: SurfaceConflictPolicy
+  readonly cadenceMs?: number
+}
+
+// ─── Error classes ────────────────────────────────────────────────────────────
+
+/** Thrown when a surface id cannot be found in the StateManagementVault. */
+export class SurfaceNotFoundError extends Error {
+  override name = 'SurfaceNotFoundError'
+  constructor(surfaceId: string) {
+    super(`Surface not found: ${surfaceId}`)
+  }
+}
+
+/**
+ * Thrown when an operation is invalid for the surface's current status
+ * (e.g. agreeing on an already-agreed or suspended surface).
+ */
+export class SurfaceStateError extends Error {
+  override name = 'SurfaceStateError'
+  constructor(surfaceId: string, currentStatus: string, requiredStatus: string) {
+    super(
+      `Surface ${surfaceId} has status '${currentStatus}', expected '${requiredStatus}'`,
+    )
+  }
+}
+
+// ─── Handshake helpers ────────────────────────────────────────────────────────
+
+/**
+ * Party A: persist a new `status:'proposed'` SurfaceRow in the
+ * StateManagementVault. The `id` in `def` is used when provided;
+ * otherwise a fresh ULID is generated. `now` is the creation timestamp
+ * (caller supplies, no Date.now() inside).
+ */
+export async function proposeSurface(
+  smv: StateManagementVault,
+  def: SurfaceDefinition,
+  proposedBy: string,
+  now: number,
+): Promise<SurfaceRow> {
+  const row: SurfaceRow = {
+    ...def,
+    id: def.id ?? generateULID(),
+    status: 'proposed',
+    proposedBy,
+    createdAt: now,
+  }
+  await smv.createSurface(row)
+  return row
+}
+
+/**
+ * Party B: read the surface, assert it is in `'proposed'` status, then
+ * flip it to `'agreed'` (setting `agreedBy`). Returns the updated row.
+ *
+ * Throws:
+ * - `SurfaceNotFoundError` when `surfaceId` is absent.
+ * - `SurfaceStateError` when the surface status is not `'proposed'`.
+ *
+ * `_now` is accepted for API symmetry with `proposeSurface` (Task 5 will
+ * use it for `lastSyncAt` stamping); it is not written in this task.
+ */
+export async function agreeSurface(
+  smv: StateManagementVault,
+  surfaceId: string,
+  agreedBy: string,
+  _now: number,
+): Promise<SurfaceRow> {
+  const existing = await smv.getSurface(surfaceId)
+  if (!existing) throw new SurfaceNotFoundError(surfaceId)
+  if (existing.status !== 'proposed') {
+    throw new SurfaceStateError(surfaceId, existing.status, 'proposed')
+  }
+  return smv.updateSurface(surfaceId, { status: 'agreed', agreedBy })
+}


### PR DESCRIPTION
## FR-7 — Surface / Scoped Sync — pilot-1 epic vLannaAi/klum-db#1, issue vLannaAi/klum-db#8 (CLOSES the epic)

A **Surface** — a persisted, bilaterally-agreed subset two parties sync: `{collections, fields?, direction, conflictPolicy, cadenceMs?}`. A surface syncs only its named collections/fields, in its direction, applying its conflict policy; **collections/fields outside the surface never leave the vault**. The final FR of the pilot-1 epic (8/9 already merged).

### Architecture
Lobby orchestration over the StateManagementVault, reusing FR-2 `extractPartition` (the scoped slice) + FR-3/4 `mergeCompartment` (apply with conflict policy). One new hub primitive: **structural field projection** at extract. Field scoping = structural redaction at the export boundary (excluded fields are dropped *before* re-encryption, so they're never in the transmitted slice — not cryptographic intra-vault hiding, which is irrelevant for sync). The raw SyncEngine is deliberately unused (it copies ciphertext and can't project fields); the transfer key is per-run (out-of-band, like FR-2/3), not persisted.

### What's in it
- **hub — `fieldProjection` in extract** (`bundle/extract-partition.ts`): a `project()` step in both the per-record-CEK and standard-DEK re-key branches drops non-listed fields (always keeping `id`) before re-encryption; projected collections skip schema-carry. Non-projected extracts are byte-identical (no regression).
- **lobby — `SurfaceRow` + persistence** (`federation/types.ts`, `state-vault.ts`): a 5th `surfaces` collection in the StateManagementVault with create/get/list/update.
- **lobby — propose/agree handshake** (`interchange/surface.ts`): `proposeSurface` (→ `proposed`) + `agreeSurface` (→ `agreed`); only `agreed` surfaces sync.
- **lobby — `exportSurface`/`applySurface`**: scoped extract (seeds = surface.collections, `maxDepth:0` so no non-surface collection leaks, `fieldProjection` = surface.fields) → bundle → `mergeCompartment` with the surface's conflict policy. **Direction-agnostic mechanics** (source→slice, slice→receiver); direction is orchestration metadata the sync flow honours (push: proposer exports → agreer applies; pull: the reverse; bidi: both).
- **lobby — cadence**: pure `isSurfaceDue(surface, now)`/`listDueSurfaces` + `markSynced` + a thin host-driven `SurfaceCadenceScheduler`.
- **lobby — `Lobby` API**: `createSurface`/`getSurface`/`listSurfaces`/`proposeSurface`/`agreeSurface`/`exportSurface`/`applySurface` + exports.
- **features.yaml:** `scoped-sync-surface` (preview).

### Acceptance (#447) — met + tested
1. A surface syncs only its named collections/fields, in its direction, applying its conflict policy (the two-party E2E walkthrough).
2. **Collections/fields outside the surface never leave the vault** — structural field projection at extract + `maxDepth:0` collection bounding; the E2E asserts a `secret` collection is absent and `phone` (a non-surface field) never reaches the receiver.

### Scope
Persisted Surface + propose/agree handshake + host-driven cadence (the fuller chosen scope). Cryptographic per-field hiding (per-field CEK) is out of scope (irrelevant for sync — excluded fields simply aren't transmitted).

### Verification
- hub: 2718 tests / lobby: 158 tests — all green
- `pnpm lint` (127) + `pnpm typecheck` (130) clean
- `validate-features.mjs` (71 features) + `check:architecture` pass (no-outbound-klum-import green — surface.ts imports hub, not the reverse)

### Builds on
FR-2 (`extractPartition` + the `fieldProjection` extension), FR-3/4 (`mergeCompartment` + conflict policy), the StateManagementVault persistence pattern.

---

**With this, the pilot-1 epic vLannaAi/klum-db#1 is complete: FR-1 through FR-9 all merged.** klum-db / Lobby now spans the full interchange spine (Bundle · Extract · Merge · Field-Authority · Provenance · Migrate · multi-vault Export · scoped-sync Surface) + the sovereignty custody layer (Deed/Custodian/Liberate), atop the extracted federation foundation.
