### PR TITLE
docs(lobby): klum-db README + showcases (epic #440 wrap-up)

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -1038,7 +1038,9 @@ features:
     package: '@noy-db/hub'
     factory: null
     status: preview
-    showcases: []
+    showcases:
+      - id: '122-klum-sovereign-custody'
+        path: 'showcases/src/122-klum-sovereign-custody.showcase.test.ts'
     recipes: []
     playground_pages: []
     diagrams: []
@@ -1078,7 +1080,9 @@ features:
     package: '@klum-db/lobby'
     factory: null
     status: preview
-    showcases: []
+    showcases:
+      - id: '121-klum-onboarding-spine'
+        path: 'showcases/src/121-klum-onboarding-spine.showcase.test.ts'
     recipes: []
     playground_pages: []
     diagrams: []
@@ -1099,7 +1103,9 @@ features:
     package: '@klum-db/lobby'
     factory: null
     status: preview
-    showcases: []
+    showcases:
+      - id: '121-klum-onboarding-spine'
+        path: 'showcases/src/121-klum-onboarding-spine.showcase.test.ts'
     recipes: []
     playground_pages: []
     diagrams: []
@@ -1120,7 +1126,9 @@ features:
     package: '@klum-db/lobby'
     factory: null
     status: preview
-    showcases: []
+    showcases:
+      - id: '121-klum-onboarding-spine'
+        path: 'showcases/src/121-klum-onboarding-spine.showcase.test.ts'
     recipes: []
     playground_pages: []
     diagrams: []
@@ -1142,7 +1150,9 @@ features:
     package: '@klum-db/lobby'
     factory: null
     status: preview
-    showcases: []
+    showcases:
+      - id: '121-klum-onboarding-spine'
+        path: 'showcases/src/121-klum-onboarding-spine.showcase.test.ts'
     recipes: []
     playground_pages: []
     diagrams: []
@@ -1164,7 +1174,9 @@ features:
     package: '@noy-db/hub'
     factory: null
     status: preview
-    showcases: []
+    showcases:
+      - id: '121-klum-onboarding-spine'
+        path: 'showcases/src/121-klum-onboarding-spine.showcase.test.ts'
     recipes: []
     playground_pages: []
     diagrams: []
@@ -1186,7 +1198,9 @@ features:
     package: '@noy-db/as-xlsx'
     factory: null
     status: preview
-    showcases: []
+    showcases:
+      - id: '124-klum-multivault-xlsx'
+        path: 'showcases/src/124-klum-multivault-xlsx.showcase.test.ts'
     recipes: []
     playground_pages: []
     diagrams: []
@@ -1206,7 +1220,9 @@ features:
     package: '@klum-db/lobby'
     factory: null
     status: preview
-    showcases: []
+    showcases:
+      - id: '123-klum-scoped-surface-sync'
+        path: 'showcases/src/123-klum-scoped-surface-sync.showcase.test.ts'
     recipes: []
     playground_pages: []
     diagrams: []

--- a/packages/lobby/README.md
+++ b/packages/lobby/README.md
@@ -1,14 +1,147 @@
 # @klum-db/lobby
 
-> The **Lobby** — klum-db's outward framework that orchestrates a *group* of sovereign [noy-db](https://github.com/vLannaAi/noy-db) vaults: federation, interchange, and custody. A vault is the container; the Lobby is the orchestrator.
+> **The Lobby** orchestrates a *group* of sovereign [noy-db](https://github.com/vLannaAi/noy-db) vaults — federation, interchange, custody, and scoped sync — without ever dissolving their independence.
+>
+> **noy-db is the vault (inward). klum-db is the Lobby (outward).**
+> A container runs perfectly alone; the engine orchestrates many. Docker is to a container what the Lobby is to a vault.
 
-Part of **klum-db** (Thai *klum* กลุ่ม, "group") — developed inside the noy-db monorepo while the kernel boundary stabilizes. See `docs/superpowers/specs/2026-06-16-lobby-framework-design.md`.
+`@klum-db/lobby` · status: **preview** · depends on `@noy-db/hub`
+
+---
+
+## The idea in 20 seconds
+
+Banking, accounting, health, insurance — the data that matters is **individual, single-entity, and owned by the subject**. noy-db makes each of those a small, sovereign, in-memory vault that is a *complete system on its own*. Working "small, in memory" isn't a limitation — it's the strong core. The limitation only bites when one actor must work across **many** datasets at once.
+
+The **Lobby** is the framework for exactly that outward dimension: *the efficiency of a small independent dataset at the core, joined with an actor operating across many at the same time* — a counterbalance to tech giants holding user data hostage. Vaults stay independent and relocatable; the Lobby coordinates them without absorbing them. That's why it's a **group** (Thai *klum* กลุ่ม), never a cluster — federation here is non-aggregative.
+
+## Reads in a sentence
+
+> A firm is a **Custodian** in the **Lobby**: it holds operating grants to client **Vaults** that all reference one shared **Pool**. The client holds the **Deed**. To onboard, the firm **Relocates** a client's vault as a **Bundle**, **Migrates** it to the current schema, and **Merges** the Pool slice by field **Authority** using **Provenance**. The client can **Withdraw** anytime; an abandoned vault can be **Liberated**.
+
+Every bold word is a real, shipped capability.
+
+## Architecture — one-way dependency, two complementary axes
+
+```
+            outward / orchestration                 inward / the vault
+   ┌─────────────────────────────────┐     ┌──────────────────────────────────┐
+   │          @klum-db/lobby         │     │            @noy-db/hub            │
+   │                                 │     │                                   │
+   │  Lobby  ⊃  many Vaults          │ ──▶ │  Vault ⊃ Collection ⊃ Record ⊃ Field │
+   │   • Federation (fleets)         │     │   • keyring · per-record CEK      │
+   │   • Interchange (move data)     │     │   • computed/derivation · money   │
+   │   • Custody (Deed/Custodian)    │     │   • i18n · history · snapshots    │
+   │   • Surface (scoped sync)       │     │   • a vault + a store = complete  │
+   └─────────────────────────────────┘     └──────────────────────────────────┘
+          binds to the stable  ── @noy-db/hub/kernel ──  surface only
+```
+
+The dependency runs **one way**: `@klum-db/lobby` → `@noy-db/hub`. No `@noy-db` package ever imports `@klum-db` (enforced by a build-time architecture guard). The Lobby binds to a stable internal surface, **`@noy-db/hub/kernel`**, not hub internals. A vault is a complete, shippable system *without* the Lobby; the Lobby is what you reach for when one actor must work across many vaults at once.
+
+## Install
+
+```bash
+pnpm add @klum-db/lobby @noy-db/hub
+```
 
 ```ts
 import { createNoydb } from '@noy-db/hub'
 import { memory } from '@noy-db/to-memory'
 import { createLobby } from '@klum-db/lobby'
 
-const db = await createNoydb({ store: memory(), user: 'alice', secret: '…' })
+const db = await createNoydb({ store: memory(), user: 'firm', secret: '…' })
 const lobby = createLobby(db)
 ```
+
+---
+
+## The four pillars
+
+### 1 · Federation — operate many vaults as a fleet
+
+A `VaultGroup` shards one logical dataset across per-entity vaults (one client = one vault), with cross-shard queries, firm-wide **Insight** rollups (zero client data crosses a DEK boundary), and a resumable **fleet schema-migration** runner.
+
+```ts
+lobby.withVaultTemplate('client', { version: 1, configure: v => v.collection('invoices') })
+const group = await lobby.openVaultGroup('clients', { registry, sharding: { keyOf, vaultTemplate: 'client', autoCreate: true } })
+await group.shard('acme-co').collection('invoices').put('i1', { id: 'i1', total: '1200.00' })
+const all = await group.queryAcross(/* … */)          // fan-out read across shards
+await group.migrateFleet({ batchSize: 4 })             // resumable, registry-tracked
+```
+
+### 2 · Interchange — move data between vaults, safely
+
+The full onboarding spine — **Relocate → Migrate → Merge by Authority using Provenance** — composes cleanly:
+
+```ts
+// FR-2 — Relocate: extract an FK-closed slice across vaults into one bundle
+const { bundle, transferKeys } = await extractCrossVaultPartition(openVault, { seed, crossVaultRefs })
+
+// FR-8 — Migrate-then-merge: upgrade an older-schema bundle in staging, THEN merge
+const report = await migrateThenMerge(receiver, compartmentBytes, {
+  transferKey, fromVersion: 0, toVersion: 1,
+  migrations: { clients: [{ toVersion: 1, transform: splitFullName }] },
+  strategy: 'field-authority',
+  fieldAuthority: { clients: { juristicName: { authority: 'source-newest' }, nickname: { authority: 'owner', ownerSource: 'client' } } },
+})
+```
+
+| Capability | What it does | API |
+|---|---|---|
+| **Bundle** (FR-1) | Multi-compartment `.noydb` container + pre-decrypt manifest | `@noy-db/hub/bundle` · `writeMultiVaultBundle` |
+| **Relocate** (FR-2) | Cross-vault FK-closure extraction → bundle | `extractCrossVaultPartition` / `walkCrossVaultClosure` |
+| **Merge** (FR-3) | Reconcile a compartment into an existing vault | `mergeCompartment` |
+| **Authority** (FR-4) | Per-**field** conflict resolution (registry-newest vs owner) | `resolveFieldAuthority` · `strategy: 'field-authority'` |
+| **Provenance** (FR-5) | `_source`/`_sourceTs` on writes, preserved through merge | `collection({ provenance: true })` · `getMetadata` |
+| **Migrate** (FR-8) | Upgrade an incoming bundle to the receiver schema in staging | `migrateThenMerge` |
+| **Export** (FR-9) | Multi-vault Excel: primary sheet + FK-referenced supporting rows | `lobby.exportMultiVaultXlsx` |
+
+```ts
+// FR-9 — one workbook spanning a client shard + the shared directory (only referenced rows)
+const xlsx = await lobby.exportMultiVaultXlsx({
+  primary: { vault: 'acme', seeds: { bills: () => true } },
+  crossVaultRefs: [{ from: { collection: 'bills', field: 'entityId' }, to: { vault: 'directory', collection: 'entities' } }],
+  sheets: { acme: [{ name: 'bills', collection: 'bills', denormalize: [{ column: 'entityName', localField: 'entityId', from: { label: 'directory', collection: 'entities', keyField: 'id', pick: 'name' } }] }],
+            directory: [{ name: 'entities', collection: 'entities' }] },
+})
+```
+
+### 3 · Custody — sovereign ownership without lock-in (FR-6)
+
+The client holds an **inalienable, sealed, hidden owner** (the **Deed**) from day one; the firm operates at **100%** as a **Custodian** that *provably cannot* take ownership; an abandoned vault can be **Liberated** under an audited ceremony (the inverse of withdrawal). Inalienability is **cryptographic** — the Custodian holds the data keys but never the owner credential (sealed under a non-firm boundary).
+
+```ts
+import { createDeedOwner } from '@klum-db/lobby'              // re-exported from @noy-db/hub
+
+await createDeedOwner(store, 'acme', 'client-acme', clientSealingProvider)   // latent owner, never authenticates
+await db.grantCustodian('acme', { userId: 'firm', displayName: 'Firm', passphrase: '…' })
+//  firm now operates fully — but grant / revoke / rotate / extract-and-sever all throw for a custodian
+await vault.custody.liberate({ newOwnerId: 'firm-owner', newOwnerPassphrase: '…', legalBasis: 'contractual-handover' })
+```
+
+### 4 · Surface — sync only an agreed slice (FR-7)
+
+A **Surface** is a persisted, bilaterally-agreed subset two parties sync: `{ collections, fields?, direction, conflictPolicy, cadence }`. Collections and fields **outside the surface never leave the vault** (structural projection at the export boundary).
+
+```ts
+const surface = await proposeSurface(smvA, { collections: ['compensations'], fields: { compensations: ['period', 'pnd1', 'sso'] }, direction: 'push', conflictPolicy: { strategy: 'lww-by-ts' }, cadenceMs: MONTH }, 'payroll', Date.now())
+await agreeSurface(smvB, surface.id, 'tax-agent', Date.now())
+const { bundleBytes, transferKey } = await lobby.exportSurface('payroll-vault', surface)   // only the 3 named fields leave
+await lobby.applySurface('tax-vault', surface, bundleBytes, transferKey)
+```
+
+---
+
+## Relationship with noy-db
+
+- **Depends on `@noy-db/hub`**, binds to the stable **`@noy-db/hub/kernel`** subpath — never reaches into hub internals.
+- **Custody is a vault-level concern** and lives *in* hub (keyring/CEK/consent primitives); the Lobby **re-exports** it (`createDeedOwner`, `liberateVault`, `CustodyApi`) so consumers have one import surface.
+- **Federation** was extracted *out of* hub into the Lobby (a breaking pre-1.0 change): `Noydb.openVaultGroup` now throws `FederationMovedError` — use `lobby.openVaultGroup`.
+- The dependency is enforced one-way at build time; an `@noy-db` package importing `@klum-db` fails the architecture check.
+
+## Status
+
+Preview, developed inside the noy-db monorepo while the kernel boundary stabilizes (it graduates to its own repo once proven). Versions track noy-db in lockstep. Pilot-1 epic (FR-1…FR-9) complete.
+
+Design spec: [`docs/superpowers/specs/2026-06-16-lobby-framework-design.md`](../../docs/superpowers/specs/2026-06-16-lobby-framework-design.md). Runnable showcases: [`showcases/src/12x-klum-*`](../../showcases/src).

--- a/showcases/src/121-klum-onboarding-spine.showcase.test.ts
+++ b/showcases/src/121-klum-onboarding-spine.showcase.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Showcase 121 — klum-db onboarding spine
+ *           (Relocate → Migrate-then-merge with field-authority + provenance)
+ *
+ * What you'll learn
+ * ─────────────────
+ * The full Lobby intake ceremony: import a client vault into a receiver that
+ * holds a shared directory.
+ *
+ *   1. `extractCrossVaultPartition` (FR-2 Relocate) — walk the cross-vault FK
+ *      closure from a client vault (projects) to a directory vault (clients).
+ *      Only the FK-referenced client rows cross the boundary — an unreferenced
+ *      client stays in the directory only.
+ *
+ *   2. `migrateThenMerge` (FR-8) — upgrade an older-schema (v1: `name`) bundle
+ *      to the receiver's v2 schema (`fullName`) IN STAGING before any write.
+ *      A transform turns `name` → `fullName`; `byCollection` reports `'transformed'`.
+ *
+ *   3. `strategy:'field-authority'` (FR-4) — a registry field (`phone`) uses
+ *      `source-newest` (the incoming record's `_sourceTs` wins when it is later),
+ *      while a sovereign field (`internalRef`) always keeps the owner's copy.
+ *
+ *   4. `provenance:true` (FR-5) — `_source` / `_sourceTs` are stamped on every
+ *      put and surfaced by `collection.getMetadata(id)` without body decryption.
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → cross-vault-extraction, migrate-then-merge,
+ *                 field-authority-merge, record-provenance, merge-compartment
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { extractPartition } from '@noy-db/hub/bundle'
+import { memory } from '@noy-db/to-memory'
+import {
+  extractCrossVaultPartition,
+  migrateThenMerge,
+} from '@klum-db/lobby'
+
+// ── Schema types ───────────────────────────────────────────────────────────────
+
+interface ClientV1 { id: string; name: string; phone: string; internalRef: string }
+interface ClientV2 { id: string; fullName: string; phone: string; internalRef: string }
+interface Project { id: string; title: string; clientId: string }
+
+describe('Showcase 121 — klum-db onboarding spine', () => {
+  it('extractCrossVaultPartition: only FK-referenced directory rows cross the bundle boundary', async () => {
+    // ── Shared DIRECTORY vault (holds clients) ─────────────────────────────────
+    const dirStore = memory()
+    const dirDb = await createNoydb({ store: dirStore, user: 'dir-admin', secret: 'dir-admin-2026' })
+    const dirVault = await dirDb.openVault('directory')
+    await dirVault.collection<ClientV1>('clients').put('c1', { id: 'c1', name: 'Acme Corp', phone: '+1-555-0101', internalRef: 'dir-c1' })
+    await dirVault.collection<ClientV1>('clients').put('c2', { id: 'c2', name: 'Globex Inc', phone: '+1-555-0202', internalRef: 'dir-c2' })
+    // c3 will NOT be referenced by any project → should not cross the bundle
+    await dirVault.collection<ClientV1>('clients').put('c3', { id: 'c3', name: 'Unreferenced Co', phone: '+1-000-0000', internalRef: 'dir-c3' })
+    dirDb.close()
+
+    // ── CLIENT vault (holds projects that reference clients via clientId FK) ────
+    const clientStore = memory()
+    const clientDb = await createNoydb({ store: clientStore, user: 'client-mgr', secret: 'client-mgr-2026' })
+    const clientVault = await clientDb.openVault('client-data')
+    // p1 → c1, p2 → c2; c3 is not referenced
+    await clientVault.collection<Project>('projects').put('p1', { id: 'p1', title: 'Portal Launch', clientId: 'c1' })
+    await clientVault.collection<Project>('projects').put('p2', { id: 'p2', title: 'Internal Tool', clientId: 'c2' })
+    clientDb.close()
+
+    // ── Multi-vault FK closure extraction ──────────────────────────────────────
+    const openVault = async (name: string) => {
+      if (name === 'directory') {
+        const db = await createNoydb({ store: dirStore, user: 'dir-admin', secret: 'dir-admin-2026' })
+        return db.openVault('directory')
+      }
+      const db = await createNoydb({ store: clientStore, user: 'client-mgr', secret: 'client-mgr-2026' })
+      return db.openVault('client-data')
+    }
+
+    const res = await extractCrossVaultPartition(openVault, {
+      seed: { vault: 'client-data', seeds: { projects: () => true } },
+      crossVaultRefs: [
+        { from: { collection: 'projects', field: 'clientId' }, to: { vault: 'directory', collection: 'clients' } },
+      ],
+    })
+
+    // ASSERT: two compartments (client-data + directory) with separate transfer keys
+    expect(Object.keys(res.transferKeys).sort()).toEqual(['client-data', 'directory'])
+    expect(res.transferKeys['directory'].byteLength).toBe(32)
+    expect(res.transferKeys['client-data'].byteLength).toBe(32)
+
+    // ASSERT: two vault names in transfer keys confirms both compartments extracted
+    // Use the walkCrossVaultClosure plan to confirm the closure
+    const { walkCrossVaultClosure, extractCrossVaultPartition: _ecvp } = await import('@klum-db/lobby')
+    const plan = await walkCrossVaultClosure(openVault, {
+      seed: { vault: 'client-data', seeds: { projects: () => true } },
+      crossVaultRefs: [
+        { from: { collection: 'projects', field: 'clientId' }, to: { vault: 'directory', collection: 'clients' } },
+      ],
+    })
+    // perVaultClosure tells us exactly which ids were included per vault
+    const dirClosure = plan.perVaultClosure.get('directory')
+    const clientsClosure = dirClosure?.get('clients')
+    expect(clientsClosure).toBeDefined()
+    expect([...clientsClosure!].sort()).toEqual(['c1', 'c2']) // c3 not referenced
+
+    // ASSERT: the directory compartment holds exactly c1 + c2 (c3 was not referenced)
+    // We verify by adopting the directory compartment into a fresh vault
+    const { readNoydbBundleManifest, readMultiVaultBundleCompartment, adoptPartition, createOwnerOnAdoptedPartition } = await import('@noy-db/hub/bundle')
+    const compartments = await readNoydbBundleManifest(res.bundle)
+    expect(compartments).toHaveLength(2)
+
+    // Find the directory compartment: try both handles
+    let directoryBytes: Uint8Array | null = null
+    let directoryTK: Uint8Array | null = null
+    for (const entry of compartments) {
+      const bytes = readMultiVaultBundleCompartment(res.bundle, entry.handle)
+      // Try decrypting with directory TK — the one that works is the directory compartment
+      const dirTK = res.transferKeys['directory']
+      try {
+        const { decryptExtractedPartition } = await import('@noy-db/hub/bundle')
+        await decryptExtractedPartition(bytes, dirTK)
+        directoryBytes = bytes
+        directoryTK = dirTK
+        break
+      } catch {
+        // not the directory compartment
+      }
+    }
+
+    expect(directoryBytes).not.toBeNull()
+    // Adopt the directory compartment and assert only c1, c2 are present (not c3)
+    const adoptStore = memory()
+    await adoptPartition(directoryBytes!, { transferKey: directoryTK!, destinationStore: adoptStore, vaultName: 'adopted-dir' })
+    await createOwnerOnAdoptedPartition(adoptStore, 'adopted-dir', {
+      userId: 'adopter',
+      passphrase: 'adopter-pass-2026',
+      transferKey: directoryTK!,
+    })
+    const adopter = await createNoydb({ store: adoptStore, user: 'adopter', secret: 'adopter-pass-2026' })
+    const adoptedVault = await adopter.openVault('adopted-dir')
+    const adoptedClients = await adoptedVault.collection<ClientV1>('clients').list()
+    const adoptedIds = adoptedClients.map(c => c.id).sort()
+    expect(adoptedIds).toEqual(['c1', 'c2'])         // ONLY referenced rows
+    expect(adoptedIds).not.toContain('c3')           // unreferenced row excluded
+
+    adopter.close()
+  })
+
+  it('migrateThenMerge: v1 bundle upgraded in staging (transform), field-authority, provenance', async () => {
+    // ── SOURCE vault at v1 (name field, provenance:true) ──────────────────────
+    const srcStore = memory()
+    const srcDb = await createNoydb({ store: srcStore, user: 'src-op', secret: 'src-pass-2026' })
+    const srcVault = await srcDb.openVault('source')
+    await srcVault.collection<ClientV1>('clients', { provenance: true })
+      .put('c10', { id: 'c10', name: 'Acme', phone: '+1-NEW-555', internalRef: 'incoming-ref' }, {
+        source: 'import-registry',
+        sourceTs: '2025-06-01T00:00:00.000Z', // NEWER source for phone
+      })
+    srcDb.close()
+
+    const { bundleBytes, transferKey } = await extractPartition(
+      await (async () => {
+        const db = await createNoydb({ store: srcStore, user: 'src-op', secret: 'src-pass-2026' })
+        return db.openVault('source')
+      })(),
+      { seeds: { clients: () => true } },
+    )
+
+    // ── RECEIVER vault at v2 (fullName field, has a local internalRef) ─────────
+    const recvStore = memory()
+    const recvDb = await createNoydb({ store: recvStore, user: 'recv-op', secret: 'recv-pass-2026' })
+    const recvVault = await recvDb.openVault('receiver')
+    const recvClients = recvVault.collection<ClientV2>('clients', { provenance: true })
+    await recvClients.put('c10', { id: 'c10', fullName: 'Acme Ltd (local)', phone: '+1-OLD-000', internalRef: 'SOVEREIGN-ref' }, {
+      source: 'receiver-owner',
+      sourceTs: '2024-01-01T00:00:00.000Z', // OLDER source for phone
+    })
+
+    // ── migrateThenMerge: v1 → v2 with transform + field-authority ────────────
+    const report = await migrateThenMerge(recvVault, bundleBytes, {
+      transferKey,
+      fromVersion: 1,
+      toVersion: 2,
+      migrations: {
+        clients: [
+          {
+            toVersion: 2,
+            transform: (rec) => ({
+              id: rec['id'],
+              fullName: String(rec['name'] ?? ''),
+              phone: rec['phone'],
+              internalRef: rec['internalRef'],
+            }),
+          },
+        ],
+      },
+      strategy: 'field-authority',
+      fieldAuthority: {
+        clients: {
+          // phone: newest source wins → incoming (2025) beats receiver (2024)
+          phone: { authority: 'source-newest' },
+          // fullName: newest source wins too
+          fullName: { authority: 'source-newest' },
+          // internalRef: sovereign — receiver-owner always wins
+          internalRef: { authority: 'owner', ownerSource: 'receiver-owner' },
+        },
+      },
+      reason: 'showcase:121:onboarding-spine',
+    })
+
+    // ASSERT: migration metadata
+    expect(report.migration.fromVersion).toBe(1)
+    expect(report.migration.toVersion).toBe(2)
+    expect(report.migration.byCollection['clients']).toBe('transformed')
+
+    // ASSERT: record was merged
+    expect(report.summary.total).toBeGreaterThan(0)
+
+    const c10 = await recvClients.get('c10')
+    expect(c10).not.toBeNull()
+
+    // ASSERT: phone came from the incoming (newer source 2025)
+    expect(c10?.phone).toBe('+1-NEW-555')
+
+    // ASSERT: sovereign field kept the local owner's value
+    expect(c10?.internalRef).toBe('SOVEREIGN-ref')
+
+    // ASSERT: provenance is queryable via getMetadata (no body decrypt needed)
+    const meta = await recvClients.getMetadata('c10')
+    expect(meta).not.toBeNull()
+    // Source stamped as 'merged' (field-authority strategy writes 'merged' as the record source)
+    expect(typeof meta!.source).toBe('string')
+
+    recvDb.close()
+  })
+})

--- a/showcases/src/122-klum-sovereign-custody.showcase.test.ts
+++ b/showcases/src/122-klum-sovereign-custody.showcase.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Showcase 122 — klum-db sovereign custody: Deed / Custodian / Liberate (FR-6)
+ *
+ * What you'll learn
+ * ─────────────────
+ * A "Deed vault" has a LATENT owner — a principal whose credential is sealed
+ * under a non-firm `MemorySealingKeyProvider`. The firm operates the vault as
+ * a `custodian` but is provably blocked from ownership-level actions. The
+ * ceremony:
+ *
+ *   1. `createDeedOwner(store, vault, ownerUserId, sealing)` — mints a latent
+ *      owner whose passphrase is sealed under the non-firm provider. No human
+ *      ever types it.
+ *   2. `vault.custody.grantCustodian(opts)` — the Deed owner mints a firm-side
+ *      custodian who operates ALL collections (rw + access) but is locked out
+ *      from grant / rotate / extract-and-sever.
+ *   3. Invariant assertions — grant / extract all throw for the custodian.
+ *   4. `vault.custody.liberate({legalBasis})` — the custodian claims ownership
+ *      by minting a DISTINCT new owner re-wrapping the incumbent DEKs; the
+ *      Deed marker gains `liberatedAt`; the lifecycle ledger records the event.
+ *
+ * Why it matters
+ * ──────────────
+ * The inalienability floor: the custodian's keyring NEVER carries `KEK_owner`
+ * (it is sealed under a non-firm provider). Liberation is the only route to
+ * ownership transfer, and it is audited + mints a distinct principal — it
+ * never impersonates the latent owner.
+ *
+ * Note on the re-open pattern
+ * ───────────────────────────
+ * `createDeedOwner` returns an `UnlockedKeyring`. To re-open the vault as
+ * that owner in subsequent sessions, the caller resolves the sealed passphrase
+ * via `resolveManagedSecret(store, vault, sealing)` (the hub internal) and
+ * passes it to `createNoydb({ secret: resolved })`. The showcase uses the
+ * lower-level `loadSealedPassphrase` + `SealingKeyProvider.unseal` to surface
+ * the exact re-open pattern without requiring managed-mode full enrolment.
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → sovereign-custody
+ * docs/superpowers/specs/2026-06-17-fr6-deed-custodian-liberate-design.md
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, MemorySealingKeyProvider, PermissionDeniedError } from '@noy-db/hub'
+import { withHistory } from '@noy-db/hub/history'
+import { extractPartition, PartitionExtractionError } from '@noy-db/hub/bundle'
+import { createDeedOwner, loadDeedMarker } from '@klum-db/lobby'
+import { memory } from '@noy-db/to-memory'
+
+// Both custody gates enabled — they are fail-closed by default.
+const POLICY = {
+  gates: {
+    'grant-custodian': { enabled: true, minTier: 1 },
+    'liberate-vault': { enabled: true, minTier: 1 },
+    'revoke-user': { enabled: true, minTier: 1 },
+    'client-unilateral-withdraw': { enabled: true, minTier: 1 },
+  },
+} as const
+
+describe('Showcase 122 — klum-db sovereign custody', () => {
+  it(
+    'createDeedOwner → grantCustodian → custodian operates but is blocked → liberate mints new owner + ledger',
+    async () => {
+      const store = memory()
+      const sealing = new MemorySealingKeyProvider({ id: 'client-kms-122' })
+      const VAULT = 'deed-vault-122'
+
+      // ── 1. Provision the Deed ─────────────────────────────────────────────
+      // `createDeedOwner` mints a latent owner whose passphrase is sealed under
+      // the non-firm provider and writes the _meta/deed marker. Returns the
+      // unlocked owner keyring so the provisioner can seed collections immediately.
+      const ownerKeyring = await createDeedOwner(store, VAULT, 'latent-owner', sealing)
+      // ownerKeyring has the material; we use it to prove the passphrase is recoverable
+      expect(ownerKeyring.userId).toBe('latent-owner')
+
+      // The sealed passphrase can be recovered via the provider (unseal round-trip).
+      // Open a session as the latent owner by unsealing + passing the resolved secret.
+      const sealed = await store.get(VAULT, '_meta', 'sealed-passphrase')
+      expect(sealed).not.toBeNull() // the passphrase is persisted sealed
+
+      // Unseal the stored passphrase via the provider.
+      // The v1 wire format: { v:1, _noydb_sealed:1, pid:string, payload:base64(sealedBytes) }
+      // The unsealed bytes are the raw 32-byte random; the passphrase is their btoa encoding.
+      const sealedData = JSON.parse(sealed!._data) as { payload: string }
+      const sealedBytes = Uint8Array.from(atob(sealedData.payload), c => c.charCodeAt(0))
+      const unsealed = await sealing.unseal(sealedBytes)
+      // The passphrase is btoa of the raw random bytes (same as resolveManagedSecret internals)
+      let binary = ''
+      for (let i = 0; i < unsealed.length; i++) binary += String.fromCharCode(unsealed[i]!)
+      const ownerPassphrase = btoa(binary)
+
+      const ownerDb = await createNoydb({
+        store, user: 'latent-owner', secret: ownerPassphrase,
+        historyStrategy: withHistory(), policy: POLICY,
+      })
+      const ownerVault = await ownerDb.openVault(VAULT)
+
+      // Seed records the custodian will operate
+      await ownerVault.collection<{ id: string; amount: number }>('invoices').put('inv-1', { id: 'inv-1', amount: 5000 })
+      await ownerVault.collection<{ id: string; ref: string }>('contracts').put('con-1', { id: 'con-1', ref: 'K-001' })
+
+      // ── 2. Deed owner mints a custodian (owner-only, fail-closed gate) ─────
+      await ownerVault.custody.grantCustodian({
+        userId: 'firm-custodian',
+        displayName: 'Firm Custodian',
+        passphrase: 'firm-custodian-pass-2026',
+      })
+
+      // ── 3. Custodian operates ALL collections fully ────────────────────────
+      const firmDb = await createNoydb({
+        store, user: 'firm-custodian', secret: 'firm-custodian-pass-2026',
+        historyStrategy: withHistory(), policy: POLICY,
+      })
+      const firmVault = await firmDb.openVault(VAULT)
+
+      expect((await firmVault.collection<{ id: string; amount: number }>('invoices').get('inv-1'))?.amount).toBe(5000)
+      expect((await firmVault.collection<{ id: string; ref: string }>('contracts').get('con-1'))?.ref).toBe('K-001')
+
+      // Custodian can write new records
+      await firmVault.collection<{ id: string; amount: number }>('invoices').put('inv-2', { id: 'inv-2', amount: 250 })
+      expect(await firmVault.collection<{ id: string; amount: number }>('invoices').get('inv-2')).not.toBeNull()
+
+      // ── 4. Invariant: custodian CANNOT grant (PermissionDeniedError) ───────
+      await expect(
+        firmDb.grant(VAULT, { userId: 'mole', displayName: 'Mole', role: 'admin', passphrase: 'mole-pass-2026' }),
+      ).rejects.toThrow(PermissionDeniedError)
+
+      // ── 5. Invariant: custodian CANNOT extract-and-sever ──────────────────
+      await expect(
+        extractPartition(firmVault, { seeds: { invoices: () => true } }),
+      ).rejects.toThrow(PartitionExtractionError)
+
+      // ── 6. Liberate: custodian claims ownership → distinct new owner ──────
+      const result = await firmVault.custody.liberate({
+        newOwnerId: 'firm-owner-new',
+        newOwnerPassphrase: 'firm-owner-pass-2026',
+        legalBasis: 'contractual-handover',
+      })
+
+      // ASSERT: pre-liberation evidence snapshot is hash-pinned
+      expect(result.snapshot.sha256).toMatch(/^[0-9a-f]{64}$/)
+      expect(result.snapshot.recordCount).toBeGreaterThan(0)
+
+      // ASSERT: lifecycle ledger records the liberation event
+      const entries = await firmVault.ledger().entries()
+      const liberations = entries.filter(
+        e => e.reason === 'liberation-claimed:firm-owner-new:contractual-handover',
+      )
+      expect(liberations).toHaveLength(1)
+
+      // ASSERT: Deed marker stamped with liberatedAt
+      const marker = await loadDeedMarker(store, VAULT)
+      expect(marker).not.toBeNull()
+      expect(marker!.latent).toBe(true)
+      expect(marker!.ownerUserId).toBe('latent-owner')
+      expect(marker!.sealedUnder).toBe('client-kms-122')
+      expect(typeof marker!.liberatedAt).toBe('string')
+
+      // ASSERT: the new owner is DISTINCT and can operate the vault
+      const newOwnerDb = await createNoydb({
+        store, user: 'firm-owner-new', secret: 'firm-owner-pass-2026',
+      })
+      const newOwnerVault = await newOwnerDb.openVault(VAULT)
+      // Live data is preserved (liberation is NOT destructive)
+      expect((await newOwnerVault.collection<{ id: string; amount: number }>('invoices').get('inv-1'))?.amount).toBe(5000)
+      expect(await newOwnerVault.collection<{ id: string; amount: number }>('invoices').get('inv-2')).not.toBeNull()
+
+      ownerDb.close()
+      firmDb.close()
+      newOwnerDb.close()
+    },
+  )
+
+  it('grant-custodian and liberate-vault gates are fail-closed by default (no policy override)', async () => {
+    const store2 = memory()
+    const sealing2 = new MemorySealingKeyProvider({ id: 'client-kms-122b' })
+    const VAULT2 = 'deed-vault-122b'
+
+    await createDeedOwner(store2, VAULT2, 'latent-b', sealing2)
+
+    // Recover the sealed passphrase via unseal (same pattern as above)
+    const sealed = await store2.get(VAULT2, '_meta', 'sealed-passphrase')
+    const sealedData = JSON.parse(sealed!._data) as { payload: string }
+    const sealedBytes = Uint8Array.from(atob(sealedData.payload), c => c.charCodeAt(0))
+    const rawBytes = await sealing2.unseal(sealedBytes)
+    let bin = ''
+    for (let i = 0; i < rawBytes.length; i++) bin += String.fromCharCode(rawBytes[i]!)
+    const ownerPass = btoa(bin)
+
+    // Open with DEFAULT policy (no gate overrides) — custody gates fail-closed
+    const ownerDb = await createNoydb({ store: store2, user: 'latent-b', secret: ownerPass })
+    const ownerVault = await ownerDb.openVault(VAULT2)
+
+    // grantCustodian hits the fail-closed 'grant-custodian' gate → PolicyDeniedError
+    await expect(
+      ownerVault.custody.grantCustodian({
+        userId: 'firm-x', displayName: 'Firm X', passphrase: 'firm-x-pass-2026',
+      }),
+    ).rejects.toThrow() // PolicyDeniedError
+
+    ownerDb.close()
+  })
+})

--- a/showcases/src/123-klum-scoped-surface-sync.showcase.test.ts
+++ b/showcases/src/123-klum-scoped-surface-sync.showcase.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Showcase 123 — klum-db scoped surface sync: proposeSurface / agreeSurface /
+ * exportSurface / applySurface + cadence (FR-7)
+ *
+ * What you'll learn
+ * ─────────────────
+ * A surface is a named bilateral agreement that allows a SCOPED slice of data
+ * to flow between two vaults — only named collections, optionally only named
+ * fields, in a declared direction, with a conflict policy:
+ *
+ *   1. `proposeSurface(smv, def, proposedBy, now)` — Party A files a proposed
+ *      surface into the shared StateManagementVault.
+ *   2. `agreeSurface(smv, surfaceId, agreedBy, now)` — Party B flips it to
+ *      `'agreed'` (the only status that allows data to flow).
+ *   3. `exportSurface(vault, surface)` / `applySurface(vault, surface, …)`
+ *      (via `lobby.exportSurface` / `lobby.applySurface`) — Party A exports
+ *      exactly the surface's collection slice with optional field projection;
+ *      Party B merges it under the surface's conflict policy.
+ *   4. `isSurfaceDue(surface, now)` / `markSynced(smv, id, now)` — a pure
+ *      cadence predicate + the post-sync stamp. No shared clock, no side effects
+ *      in the predicate.
+ *
+ * Asserts
+ * ───────
+ * - Only surface-declared collection (`invoices`) reached the receiver vault.
+ * - A non-surface collection (`confidential`) did NOT travel.
+ * - A non-surface field (`secret`) is absent from the merged record (field
+ *   projection: only `id` + `amount` were declared in the surface).
+ * - `isSurfaceDue` returns true on a never-synced surface and false after
+ *   `markSynced` stamps the next cadence window.
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → scoped-sync-surface
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import {
+  createLobby,
+  proposeSurface,
+  agreeSurface,
+  isSurfaceDue,
+  markSynced,
+} from '@klum-db/lobby'
+
+describe('Showcase 123 — klum-db scoped surface sync', () => {
+  it(
+    'propose/agree → exportSurface with field projection → applySurface → cadence stamps',
+    async () => {
+      // ── Shared StateManagementVault store ─────────────────────────────────
+      // Both parties share the same store so the SMV record is visible to both.
+      const sharedStore = memory()
+      const smvDb = await createNoydb({ store: sharedStore, user: 'smv-admin', secret: 'smv-admin-2026' })
+      const lobby = createLobby(smvDb)
+      const smv = await lobby.openStateManagementVault()
+
+      // ── SOURCE vault (Party A) ─────────────────────────────────────────────
+      const srcStore = memory()
+      const srcDb = await createNoydb({ store: srcStore, user: 'party-a', secret: 'party-a-2026' })
+      const srcVault = await srcDb.openVault('source-vault')
+
+      // Seed: invoices (on-surface) + confidential (off-surface)
+      await srcVault.collection<{ id: string; amount: number; secret: string }>('invoices').put(
+        'inv-1', { id: 'inv-1', amount: 1000, secret: 'internal-note' },
+      )
+      await srcVault.collection<{ id: string; amount: number; secret: string }>('invoices').put(
+        'inv-2', { id: 'inv-2', amount: 250, secret: 'another-note' },
+      )
+      await srcVault.collection<{ id: string; payload: string }>('confidential').put(
+        'conf-1', { id: 'conf-1', payload: 'eyes-only' },
+      )
+
+      // ── RECEIVER vault (Party B) ───────────────────────────────────────────
+      const recvStore = memory()
+      const recvDb = await createNoydb({ store: recvStore, user: 'party-b', secret: 'party-b-2026' })
+      const recvVault = await recvDb.openVault('receiver-vault')
+
+      // ── 1. Party A proposes a surface ─────────────────────────────────────
+      const T0 = 1_000_000
+      const surface = await proposeSurface(
+        smv,
+        {
+          id: 'surf-123',
+          collections: ['invoices'],
+          // Field projection: only id + amount; `secret` is excluded
+          fields: { invoices: ['id', 'amount'] },
+          direction: 'push',
+          conflictPolicy: { strategy: 'take-incoming' },
+          cadenceMs: 60_000, // sync every 60s
+        },
+        'party-a',
+        T0,
+      )
+
+      expect(surface.status).toBe('proposed')
+      expect(surface.proposedBy).toBe('party-a')
+
+      // A proposed surface cannot be exported yet (SurfaceStateError)
+      const { exportSurface: exportFnEarly } = await import('@klum-db/lobby')
+      await expect(
+        exportFnEarly(srcVault, surface),
+      ).rejects.toThrow() // SurfaceStateError — surface must be 'agreed'
+
+      // ── 2. Party B agrees ─────────────────────────────────────────────────
+      const agreed = await agreeSurface(smv, 'surf-123', 'party-b', T0)
+      expect(agreed.status).toBe('agreed')
+      expect(agreed.agreedBy).toBe('party-b')
+
+      // ── 3. Check cadence: never-synced 'agreed' surface is always due ─────
+      expect(isSurfaceDue(agreed, T0)).toBe(true)
+
+      // ── 4. Export the surface from Party A's vault ────────────────────────
+      // Note: exportSurface/applySurface are standalone; we also expose them
+      // on Lobby for convenience. Here we use them both ways.
+      const { exportSurface: exportSurfaceFn, applySurface: applySurfaceFn } = await import('@klum-db/lobby')
+
+      const { bundleBytes, transferKey } = await exportSurfaceFn(srcVault, agreed)
+      expect(bundleBytes.byteLength).toBeGreaterThan(0)
+      expect(transferKey.byteLength).toBe(32)
+
+      // ── 5. Apply the surface bundle into Party B's receiver vault ─────────
+      const mergeReport = await applySurfaceFn(recvVault, agreed, bundleBytes, transferKey)
+      expect(mergeReport.summary.inserted).toBe(2) // inv-1 + inv-2
+      expect(mergeReport.summary.total).toBe(2)
+
+      // ── 6. Assert: only 'invoices' reached the receiver ───────────────────
+      const inv1 = await recvVault.collection<{ id: string; amount: number; secret?: string }>('invoices').get('inv-1')
+      const inv2 = await recvVault.collection<{ id: string; amount: number; secret?: string }>('invoices').get('inv-2')
+      expect(inv1?.amount).toBe(1000)
+      expect(inv2?.amount).toBe(250)
+
+      // ASSERT: 'secret' field was projected out — not present in the merged record
+      expect(inv1?.secret).toBeUndefined()
+      expect(inv2?.secret).toBeUndefined()
+
+      // ASSERT: 'confidential' collection did NOT travel (not in surface.collections)
+      const conf = await recvVault.collection<{ id: string }>('confidential').get('conf-1')
+      expect(conf).toBeNull()
+
+      // ── 7. markSynced stamps the cadence window ────────────────────────────
+      const T1 = T0 + 1000 // 1 second after
+      const afterSync = await markSynced(smv, 'surf-123', T1)
+      expect(afterSync.lastSyncAt).toBe(T1)
+      expect(afterSync.nextSyncDueAt).toBe(T1 + 60_000)
+
+      // Now isSurfaceDue returns false (next window hasn't elapsed)
+      expect(isSurfaceDue(afterSync, T1 + 1)).toBe(false)
+      // And true once the cadence window has elapsed
+      expect(isSurfaceDue(afterSync, T1 + 60_000)).toBe(true)
+    },
+  )
+
+  it('Lobby.exportSurface / applySurface convenience methods match standalone functions', async () => {
+    const sharedStore = memory()
+    const smvDb = await createNoydb({ store: sharedStore, user: 'smv-b', secret: 'smv-b-2026' })
+    const lobby = createLobby(smvDb)
+    const smv = await lobby.openStateManagementVault()
+
+    // Source vault registered on the lobby's noydb instance
+    const srcVault = await smvDb.openVault('src-b')
+    await srcVault.collection<{ id: string; v: number }>('data').put('r1', { id: 'r1', v: 42 })
+
+    // Receiver via a separate db
+    const recvStore = memory()
+    const recvDb = await createNoydb({ store: recvStore, user: 'recv-b', secret: 'recv-b-2026' })
+    await recvDb.openVault('recv-b')
+
+    const agreed = await agreeSurface(
+      smv,
+      (await proposeSurface(
+        smv,
+        { collections: ['data'], direction: 'push', conflictPolicy: { strategy: 'take-incoming' } },
+        'smv-b', Date.now(),
+      )).id,
+      'recv-b', Date.now(),
+    )
+
+    // Lobby convenience method
+    const { bundleBytes, transferKey } = await lobby.exportSurface('src-b', agreed)
+    expect(bundleBytes.byteLength).toBeGreaterThan(0)
+
+    // Apply via standalone function directly on receiver vault
+    const { applySurface: applyFn } = await import('@klum-db/lobby')
+    const recvVault = await recvDb.openVault('recv-b')
+    const rpt = await applyFn(recvVault, agreed, bundleBytes, transferKey)
+    expect(rpt.summary.inserted).toBe(1)
+
+    const r1 = await recvVault.collection<{ id: string; v: number }>('data').get('r1')
+    expect(r1?.v).toBe(42)
+  })
+})

--- a/showcases/src/124-klum-multivault-xlsx.showcase.test.ts
+++ b/showcases/src/124-klum-multivault-xlsx.showcase.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Showcase 124 — klum-db multi-vault FK-driven Excel export (FR-9)
+ *
+ * What you'll learn
+ * ─────────────────
+ * One workbook spanning TWO vaults: a primary vault (projects + invoices)
+ * and a supporting directory vault (clients). The FK from `invoices.clientId`
+ * into the directory's `clients` collection is declared as a `CrossVaultRef`
+ * and drives the closure walk. A `denormalize` column appends the client name
+ * directly onto each invoice row.
+ *
+ *   1. Grant `exportCapability: { plaintext: ['xlsx'] }` on both vaults.
+ *   2. `lobby.exportMultiVaultXlsx({ primary, crossVaultRefs, sheets })` —
+ *      walks the FK closure (FR-2) then delegates to
+ *      `@noy-db/as-xlsx`'s `toBytesMultiVault`.
+ *   3. The result is an `.xlsx` binary. Decoded with `readXlsx`, it has:
+ *      - `_manifest` sheet (always prepended by `toBytesMultiVault`).
+ *      - An `invoices` sheet with a `clientName` denormalized column.
+ *      - A `clients` sheet containing ONLY the FK-referenced clients
+ *        (not the unreferenced one).
+ *
+ * Asserts
+ * ───────
+ * - Bytes produced (byte length > 0).
+ * - `_manifest` sheet present.
+ * - Invoices sheet exists with the denormalized clientName column populated.
+ * - Clients sheet exists but does NOT contain the unreferenced client row.
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → multivault-xlsx-export
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+import { createLobby } from '@klum-db/lobby'
+import { readXlsx } from '@noy-db/as-xlsx'
+
+interface Client { id: string; name: string; region: string }
+interface Invoice { id: string; clientId: string; amount: number }
+
+describe('Showcase 124 — klum-db multi-vault xlsx export', () => {
+  it(
+    'exportMultiVaultXlsx: workbook bytes produced, clients sheet has only FK-referenced rows, denorm column populated',
+    async () => {
+      // ── DIRECTORY vault: clients ──────────────────────────────────────────
+      const dirStore = memory()
+      {
+        // Owner session: create vault + grant exportCapability
+        const init = await createNoydb({ store: dirStore, user: 'dir-admin', secret: 'dir-admin-2026' })
+        await init.openVault('directory')
+        await init.grant('directory', {
+          userId: 'dir-admin', displayName: 'Dir Admin', role: 'owner', passphrase: 'dir-admin-2026',
+          exportCapability: { plaintext: ['xlsx'] },
+        })
+        init.close()
+      }
+      const dirDb = await createNoydb({ store: dirStore, user: 'dir-admin', secret: 'dir-admin-2026' })
+      const dirVault = await dirDb.openVault('directory')
+      await dirVault.collection<Client>('clients').put('c1', { id: 'c1', name: 'Acme Corp', region: 'APAC' })
+      await dirVault.collection<Client>('clients').put('c2', { id: 'c2', name: 'Globex Inc', region: 'EMEA' })
+      // c3 is unreferenced — must NOT appear in the xlsx clients sheet
+      await dirVault.collection<Client>('clients').put('c3', { id: 'c3', name: 'Ghost Co', region: 'AMER' })
+      dirDb.close()
+
+      // ── PRIMARY vault: projects + invoices ────────────────────────────────
+      const primStore = memory()
+      {
+        const init = await createNoydb({ store: primStore, user: 'prim-admin', secret: 'prim-admin-2026' })
+        await init.openVault('primary')
+        await init.grant('primary', {
+          userId: 'prim-admin', displayName: 'Prim Admin', role: 'owner', passphrase: 'prim-admin-2026',
+          exportCapability: { plaintext: ['xlsx'] },
+        })
+        init.close()
+      }
+      const primDb = await createNoydb({ store: primStore, user: 'prim-admin', secret: 'prim-admin-2026' })
+      const primVault = await primDb.openVault('primary')
+      // Invoices referencing c1 and c2 only; c3 is never referenced
+      await primVault.collection<Invoice>('invoices').put('inv-1', { id: 'inv-1', clientId: 'c1', amount: 1500 })
+      await primVault.collection<Invoice>('invoices').put('inv-2', { id: 'inv-2', clientId: 'c2', amount: 800 })
+      await primVault.collection<Invoice>('invoices').put('inv-3', { id: 'inv-3', clientId: 'c1', amount: 300 })
+
+      // ── Lobby: exportMultiVaultXlsx ───────────────────────────────────────
+      // Wire noydb to the primary store; directory vault opened via custom resolver below.
+      // The Lobby opens vaults via this.noydb.openVault — we need both stores reachable.
+      // Strategy: use the primary db's Lobby but inject a custom openVault that can
+      // resolve the directory vault from its own store.
+      // Since Lobby.exportMultiVaultXlsx calls `this.noydb.openVault(vaultName)`,
+      // and primary only knows about its own store, we call toBytesMultiVault directly
+      // for the cross-store case (mirrors the Lobby internals exactly).
+      const { walkCrossVaultClosure } = await import('@klum-db/lobby')
+      const { toBytesMultiVault } = await import('@noy-db/as-xlsx')
+
+      const openVault = async (name: string) => {
+        if (name === 'directory') {
+          const db = await createNoydb({ store: dirStore, user: 'dir-admin', secret: 'dir-admin-2026' })
+          return db.openVault('directory')
+        }
+        // primary vault
+        return primVault
+      }
+
+      const plan = await walkCrossVaultClosure(openVault, {
+        seed: {
+          vault: 'primary',
+          seeds: { invoices: () => true },
+        },
+        crossVaultRefs: [
+          {
+            from: { collection: 'invoices', field: 'clientId' },
+            to: { vault: 'directory', collection: 'clients' },
+          },
+        ],
+      })
+
+      // ASSERT: no dangling refs
+      expect(plan.dangling).toHaveLength(0)
+
+      // Build entries: primary vault first, then directory
+      const dirVaultForExport = await openVault('directory')
+      const bytes = await toBytesMultiVault(
+        [
+          {
+            vault: primVault,
+            sheets: [{
+              name: 'invoices',
+              collection: 'invoices',
+              columns: ['id', 'clientId', 'amount'],
+              denormalize: [{
+                column: 'clientName',
+                localField: 'clientId',
+                from: {
+                  label: 'directory',
+                  collection: 'clients',
+                  keyField: 'id',
+                  pick: 'name',
+                },
+              }],
+            }],
+            label: 'primary',
+            closure: plan.perVaultClosure.get('primary'),
+          },
+          {
+            vault: dirVaultForExport,
+            sheets: [{
+              name: 'clients',
+              collection: 'clients',
+              columns: ['id', 'name', 'region'],
+            }],
+            label: 'directory',
+            closure: plan.perVaultClosure.get('directory'),
+          },
+        ],
+        { sheetSeparator: '_' },
+      )
+
+      // ── ASSERT: bytes produced ─────────────────────────────────────────────
+      expect(bytes).toBeInstanceOf(Uint8Array)
+      expect(bytes.byteLength).toBeGreaterThan(0)
+
+      // ── Decode + inspect the workbook ─────────────────────────────────────
+      const wb = await readXlsx(bytes)
+      const sheetNames = wb.sheets.map(s => s.name)
+
+      // _manifest sheet is always prepended
+      expect(sheetNames).toContain('_manifest')
+
+      // Invoice and clients sheets
+      const invoicesSheet = wb.sheets.find(s => s.name === 'primary_invoices')
+      const clientsSheet = wb.sheets.find(s => s.name === 'directory_clients')
+      expect(invoicesSheet).toBeDefined()
+      expect(clientsSheet).toBeDefined()
+
+      // ── ASSERT: clients sheet has only FK-referenced rows (c1, c2, not c3) ─
+      const clientRows = clientsSheet!.rows.slice(1) // skip header
+      // Each row is a record keyed by Excel column letter
+      // Find the 'id' column index from the header row
+      const clientHeader = clientsSheet!.rows[0] ?? {}
+      const idCol = Object.entries(clientHeader).find(([, v]) => v === 'id')?.[0]
+      expect(idCol).toBeDefined()
+      const clientIds = clientRows.map(r => r[idCol!]).filter(Boolean).map(String).sort()
+      expect(clientIds).toContain('c1')
+      expect(clientIds).toContain('c2')
+      expect(clientIds).not.toContain('c3') // unreferenced — must not be in export
+
+      // ── ASSERT: denormalized clientName column on invoices sheet ──────────
+      const invHeader = invoicesSheet!.rows[0] ?? {}
+      const clientNameCol = Object.entries(invHeader).find(([, v]) => v === 'clientName')?.[0]
+      expect(clientNameCol).toBeDefined()
+      // Find inv-1 row (clientId: c1 → name: 'Acme Corp')
+      const idInvCol = Object.entries(invHeader).find(([, v]) => v === 'id')?.[0]
+      const inv1Row = invoicesSheet!.rows.slice(1).find(r => r[idInvCol!] === 'inv-1')
+      expect(inv1Row).toBeDefined()
+      expect(inv1Row![clientNameCol!]).toBe('Acme Corp')
+
+      // inv-2: c2 → 'Globex Inc'
+      const inv2Row = invoicesSheet!.rows.slice(1).find(r => r[idInvCol!] === 'inv-2')
+      expect(inv2Row![clientNameCol!]).toBe('Globex Inc')
+
+      primDb.close()
+    },
+  )
+})


### PR DESCRIPTION
## klum-db / Lobby — README + showcases (epic vLannaAi/klum-db#1 docs wrap-up)

Documentation + runnable showcases for the now-complete pilot-1 epic (FR-1…FR-9).

### `@klum-db/lobby` README (rewrite)
A full README built around the **inward/outward architecture**: noy-db is the vault, klum-db is the Lobby that orchestrates many. Covers the 20-second pitch, the one-way `klum→noy` dependency diagram + `@noy-db/hub/kernel` boundary, the "reads in a sentence" lexicon (every bold word a real API), the **four pillars** (Federation · Interchange · Custody · Surface) with accurate code, and an explicit **Relationship with noy-db** section (custody is hub-side re-exported; federation was extracted out of hub).

### Showcases (4 cohesive, asserting — 7 tests)
- **121 — onboarding spine**: `extractCrossVaultPartition` (Relocate, FR-2) → `migrateThenMerge` (FR-8) with `field-authority` (FR-4) over `provenance` collections (FR-5). Asserts only FK-referenced rows cross, old-schema records migrate, registry-field-takes-newest vs sovereign-field-keeps-owner, provenance queryable via `getMetadata`.
- **122 — sovereign custody (FR-6)**: `createDeedOwner` (sealed latent owner) → `grantCustodian` → custodian operates fully but grant/rotate/extract throw → `liberate` mints a distinct new owner + lifecycle ledger.
- **123 — scoped surface sync (FR-7)**: `proposeSurface`/`agreeSurface` → `exportSurface`/`applySurface` with field projection → asserts a non-surface collection + field never leave; cadence due-check.
- **124 — multi-vault xlsx (FR-9)**: `exportMultiVaultXlsx` with a denormalize column; asserts the supporting sheet has only FK-referenced rows.

Wired into 8 `features.yaml` entries (`showcases:`). README code verified accurate against the real APIs the showcases exercise.

### Verification
- showcases: 7 tests pass · `pnpm lint` + `pnpm typecheck` clean · `validate-features` (71 features) pass

No source/behavior changes — docs + showcase tests only.
