### PR TITLE
fix(features): federation feature package → @klum-db/lobby

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -1540,7 +1540,7 @@ features:
     cluster: core
     spec: docs/subsystems/vault-group.md#overview
     subsystem_doc: docs/subsystems/vault-group.md
-    package: '@noy-db/hub'
+    package: '@klum-db/lobby'
     factory: null
     status: preview
     experimental: true


### PR DESCRIPTION
The `vault-group-federation` feature entry still listed `package: @noy-db/hub`, but the federation code was extracted into `@klum-db/lobby` in the Phase-3 extraction (`Noydb.openVaultGroup` now throws `FederationMovedError`; the entry point is `Lobby.openVaultGroup`). Corrects the registered package to match where the code actually lives.

Docs/registry only — no source/behavior change. `validate-features` passes (the schema already accepts the `@klum-db/*` scope).