### PR TITLE
release: 0.2.0-pre.26 — in-devtools InspectableContainer contract (WS-3 part A)

### DIFF
--- a/docs/superpowers/plans/2026-06-20-ws3-tooling-federation-awareness.md
+++ b/docs/superpowers/plans/2026-06-20-ws3-tooling-federation-awareness.md
@@ -1,0 +1,591 @@
+# WS-3 Tooling Federation-Awareness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `@noy-db`'s dev-tools, meter, and CLI operate on a federation `VaultGroup` by extracting a tiny type-only input contract in noy-db and building a group adapter + meter + CLI in klum-db — with no `@noy-db` package importing `@klum-db`.
+
+**Architecture:** Two additive PRs across the published-package seam. PR-1 (noy-db) extracts `InspectableContainer` in `@noy-db/in-devtools` and narrows `createInspector` to it (a real `Noydb` still satisfies it). PR-2 (klum) adds a `groupInspector` adapter, a `meterGroup` fan-out, and a `klum` CLI bin — all conforming to the noy-owned contract, none importing klum into noy.
+
+**Tech Stack:** TypeScript, pnpm workspaces + turbo (noy-db), single-package tsup + vitest (klum-db). Tests: vitest. In-memory store: `@noy-db/to-memory`.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-ws3-tooling-federation-awareness-design.md`
+
+**Publish discipline:** the two "cut release" steps publish to npm and MUST NOT run without explicit user confirmation. Current versions: `@noy-db` `0.2.0-pre.25` → PR-1 lockstep bump to `pre.26`; `@klum-db/lobby` `0.2.0-pre.27` → PR-2 bump to `pre.28`.
+
+---
+
+## File Structure
+
+**PR-1 — noy-db (`@noy-db/in-devtools`):**
+- Modify: `packages/in-devtools/src/types.ts` — add `InspectableContainer` interface; repoint `InspectorNoydb` alias; adjust imports.
+- Modify: `packages/in-devtools/src/index.ts` — narrow `createInspector` param; export `InspectableContainer`.
+- Create: `packages/in-devtools/__tests__/inspectable-container.test.ts` — contract test.
+- (Unchanged: `snapshot.ts`, `events.ts`, `records.ts`, `meter.ts` — they consume `InspectorNoydb`, which now resolves to the interface.)
+
+**PR-2 — klum-db (`@klum-db/lobby`):**
+- Modify: `package.json` — add `@noy-db/in-devtools` + `@noy-db/to-meter` peer+dev deps; add `bin`.
+- Create: `src/federation/group-inspector.ts` — `groupInspector(group)` adapter.
+- Create: `src/federation/meter-group.ts` — `meterGroup(group)` fan-out + report types.
+- Create: `src/bin/klum.ts` — CLI (`inspect-group`, `meter-group`).
+- Modify: `tsup.config.ts` — add the bin entry.
+- Modify: `src/index.ts` — export the new group-tooling surface.
+- Create: `__tests__/group-inspector.test.ts`, `__tests__/meter-group.test.ts`, `__tests__/cli.test.ts`, `__tests__/fixtures/group-config.ts`.
+
+---
+
+## PHASE 1 — noy-db PR-1: the `InspectableContainer` contract
+
+Branch: `feat/in-devtools-inspectable-container` (off `main`).
+
+### Task 1: Extract `InspectableContainer` and narrow `createInspector`
+
+**Files:**
+- Create: `packages/in-devtools/__tests__/inspectable-container.test.ts`
+- Modify: `packages/in-devtools/src/types.ts`
+- Modify: `packages/in-devtools/src/index.ts`
+
+- [ ] **Step 1: Write the failing contract test**
+
+`packages/in-devtools/__tests__/inspectable-container.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { createInspector, type InspectableContainer } from '../src/index.js'
+import type { Noydb } from '@noy-db/hub'
+
+describe('InspectableContainer contract', () => {
+  it('a real Noydb is assignable to InspectableContainer (compile-time proof)', () => {
+    const asContainer = (n: Noydb): InspectableContainer => n
+    expect(typeof asContainer).toBe('function')
+  })
+
+  it('createInspector accepts any structural InspectableContainer', () => {
+    const container: InspectableContainer = {
+      async listAccessibleVaults() {
+        return []
+      },
+      async openVault() {
+        throw new Error('not exercised by this test')
+      },
+      onAfterWrite() {
+        return () => {}
+      },
+      onWriteConflict() {
+        return () => {}
+      },
+      get writeQueue() {
+        return { pending: false, depth: 0, onChange: () => () => {}, onFlush: async () => {} }
+      },
+    }
+    const inspector = createInspector(container)
+    expect(typeof inspector.listVaults).toBe('function')
+    expect(inspector.pendingWrites()).toEqual({ pending: false, depth: 0 })
+  })
+})
+```
+
+- [ ] **Step 2: Run the test, verify it fails**
+
+Run: `pnpm --filter @noy-db/in-devtools test inspectable-container`
+Expected: FAIL — `InspectableContainer` is not exported from `../src/index.js`.
+
+- [ ] **Step 3: Add the interface in `types.ts`**
+
+In `packages/in-devtools/src/types.ts`, change the top import block to add `WriteHook`, `Unsubscribe`, `WriteQueue` and drop the now-unused `Noydb`:
+```ts
+import type {
+  Vault,
+  WriteEvent,
+  WriteConflict,
+  WriteHook,
+  Unsubscribe,
+  WriteQueue,
+  AccessibleVault,
+  CollectionDescriptor,
+  CollectionStats,
+} from '@noy-db/hub'
+```
+Replace the final `InspectorNoydb` alias (currently `export type InspectorNoydb = Noydb`) with:
+```ts
+/**
+ * The container of vaults the inspector reads from. A `Noydb` satisfies this
+ * verbatim; a klum `VaultGroup` adapter conforms structurally — so the inspector
+ * works on a single instance OR a federation without importing either.
+ */
+export interface InspectableContainer {
+  listAccessibleVaults(): Promise<readonly AccessibleVault[]>
+  openVault(name: string): Promise<Vault>
+  onAfterWrite(handler: WriteHook): Unsubscribe
+  onWriteConflict(handler: (c: WriteConflict) => void): Unsubscribe
+  readonly writeQueue: WriteQueue
+}
+
+/** @deprecated renamed to {@link InspectableContainer}. */
+export type InspectorNoydb = InspectableContainer
+```
+
+- [ ] **Step 4: Narrow `createInspector` and export the interface in `index.ts`**
+
+In `packages/in-devtools/src/index.ts`, change the import on line 2 to pull `InspectableContainer` and update the signature + delegate var name:
+```ts
+import type { Inspector, InspectableContainer, InspectorMeter } from './types.js'
+// ...
+export function createInspector(container: InspectableContainer, opts?: { meter?: InspectorMeter }): Inspector {
+  return {
+    listVaults: () => listVaults(container),
+    snapshot: (vault: Vault) => snapshot(vault),
+    records: (vault, collection, opts) => records(vault, collection, opts),
+    subscribe: (handler) => subscribe(container, handler),
+    subscribeConflicts: (handler) => subscribeConflicts(container, handler),
+    pendingWrites: () => pendingWrites(container),
+    meterSnapshot: () => meterSnapshot(opts?.meter),
+  }
+}
+```
+Add `InspectableContainer` to the `export type { … } from './types.js'` block (keep `InspectorNoydb` out of the public list — it stays an internal deprecated alias).
+(No change to `snapshot.ts`/`events.ts`: they take `noydb: InspectorNoydb`, which now resolves to the interface; every method they call — `listAccessibleVaults`, `onAfterWrite`, `onWriteConflict`, `writeQueue` — is on it.)
+
+- [ ] **Step 5: Run the contract test, verify it passes**
+
+Run: `pnpm --filter @noy-db/in-devtools test inspectable-container`
+Expected: PASS (both cases).
+
+- [ ] **Step 6: Prove backward-compat — run the full in-devtools + TUI suites**
+
+Run: `pnpm --filter @noy-db/in-devtools --filter @noy-db/in-devtools-tui test`
+Expected: PASS, unchanged counts plus the 2 new cases. (The TUI passes a real `Noydb` to `createInspector` — it still type-checks.)
+
+- [ ] **Step 7: Typecheck, lint, architecture guard**
+
+Run: `pnpm --filter @noy-db/in-devtools typecheck && pnpm --filter @noy-db/in-devtools lint && pnpm check:architecture`
+Expected: all green (guard confirms no `@klum-db` import crept in).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/in-devtools/src/types.ts packages/in-devtools/src/index.ts packages/in-devtools/__tests__/inspectable-container.test.ts
+git commit -m "feat(in-devtools): InspectableContainer contract — createInspector accepts any container of vaults"
+```
+
+### Task 2: Lockstep version bump + release PR (publish gated on user confirmation)
+
+**Files:** every `packages/*/package.json` currently at `0.2.0-pre.25` (version field only).
+
+- [ ] **Step 1:** Bump all `@noy-db/*` packages + `create-noy-db` from `0.2.0-pre.25` → `0.2.0-pre.26` (version field only; skip private packages not on the pre.N line). Reuse the established bump script pattern.
+- [ ] **Step 2:** Commit `chore(release): 0.2.0-pre.26 — in-devtools InspectableContainer (WS-3 part A)`, push branch, open PR to `main`.
+- [ ] **Step 3:** After CI green and **explicit user confirmation**, merge and cut the GitHub prerelease (`--target <full-sha>`, prerelease → `@next`). `release.yml` verifies + publishes `@noy-db/*` + `create-noy-db`.
+- [ ] **Step 4:** Verify on npm: `npm view @noy-db/in-devtools@0.2.0-pre.26 version` resolves; the package's types include `InspectableContainer`.
+
+---
+
+## PHASE 2 — klum-db PR-2: adapter + meter + CLI
+
+Branch: `feat/federation-tooling` (off klum-db `main`). All paths below are in `/Users/vicio/_github/klum-db`. Build against the **published** `@noy-db@0.2.0-pre.26` from Phase 1.
+
+### Task 3: Add dependencies
+
+**Files:** `package.json`
+
+- [ ] **Step 1:** Add to `peerDependencies`: `"@noy-db/in-devtools": "^0.2.0-pre.26"`, `"@noy-db/to-meter": "^0.2.0-pre.26"`. Add the same two to `devDependencies` pinned at `0.2.0-pre.26`.
+- [ ] **Step 2:** `pnpm install` (or the repo's install command). Expected: resolves, no peer warnings for these two.
+- [ ] **Step 3:** Commit `chore(deps): add @noy-db/in-devtools + @noy-db/to-meter for federation tooling`.
+
+### Task 4: `groupInspector` adapter
+
+**Files:**
+- Create: `src/federation/group-inspector.ts`
+- Test: `__tests__/group-inspector.test.ts`
+- Modify: `src/index.ts` (barrel export)
+
+- [ ] **Step 1: Write the failing test**
+
+`__tests__/group-inspector.test.ts` — build a 2-shard group (mirror the setup in `__tests__/federation-vault-group.test.ts`: a `to-memory` store, a Lobby with a registered vault template, `openVaultGroup` with a `keyOf` sharding config), write a record to two partitions (auto-creating two shards), then:
+```ts
+import { describe, it, expect } from 'vitest'
+import { createInspector } from '@noy-db/in-devtools'
+import { groupInspector } from '../src/federation/group-inspector.js'
+// + the existing federation test's group-setup helper
+
+describe('groupInspector', () => {
+  it('drives createInspector over a federation: lists shards, snapshots one, scopes write events', async () => {
+    const { group, db } = await makeTwoShardGroup() // helper mirroring federation-vault-group.test.ts
+    const inspector = createInspector(groupInspector(group))
+
+    const vaults = await inspector.listVaults()
+    expect(vaults.length).toBe(2)
+    expect(vaults.every((v) => v.role === 'owner')).toBe(true)
+
+    const shard = await group.shard('alice') // a real Vault
+    const snap = await inspector.snapshot(shard)
+    expect(snap.collections.map((c) => c.name)).toContain('orders')
+
+    // write-event scoping: a write to a NON-group vault must NOT fire
+    const seen: string[] = []
+    const unsub = inspector.subscribe((e) => seen.push(e.vault))
+    const outsider = await db.openVault('not-in-group', { create: true })
+    await outsider.collection('x').put('1', { id: '1' })
+    const shardVault = await group.shard('bob')
+    await shardVault.collection('orders').put('o9', { id: 'o9' })
+    await new Promise((r) => setTimeout(r, 10))
+    unsub()
+    expect(seen).toContain(shardVault === shard ? 'alice' : (await group.allRows()).find((r) => r.partitionKey === 'bob')!.vaultId)
+    expect(seen).not.toContain('not-in-group')
+  })
+})
+```
+(The implementer adapts `makeTwoShardGroup` from the existing federation test; the exact collection name `orders` follows that fixture's template.)
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `pnpm test group-inspector` — FAIL (`groupInspector` not found).
+
+- [ ] **Step 3: Implement the adapter**
+
+`src/federation/group-inspector.ts`:
+```ts
+import type { InspectableContainer } from '@noy-db/in-devtools'
+import type { AccessibleVault, Vault, WriteHook, WriteConflict, WriteQueue, Unsubscribe } from '@noy-db/hub'
+import type { VaultGroup } from './vault-group.js'
+
+/**
+ * Adapt a federation VaultGroup to the dev-tools InspectableContainer contract.
+ * Built entirely on VaultGroup's public surface (`allRows`, `db`, `template`) —
+ * no VaultGroup changes, and no @klum import lands in any @noy-db package.
+ */
+export function groupInspector(group: VaultGroup<unknown>): InspectableContainer {
+  // Group-scoped shard ids for write-event filtering; refreshed on every list.
+  let shardIds = new Set<string>()
+  const refresh = async () => {
+    const rows = await group.allRows()
+    shardIds = new Set(rows.map((r) => r.vaultId))
+    return rows
+  }
+  return {
+    async listAccessibleVaults(): Promise<readonly AccessibleVault[]> {
+      const rows = await refresh()
+      return rows.map((r): AccessibleVault => ({ id: r.vaultId, role: 'owner' }))
+    },
+    async openVault(name: string): Promise<Vault> {
+      const vault = await group.db.openVault(name)
+      group.template.configure(vault)
+      return vault
+    },
+    onAfterWrite(handler: WriteHook): Unsubscribe {
+      return group.db.onAfterWrite((event) => {
+        if (shardIds.has(event.vault)) return handler(event)
+      })
+    },
+    onWriteConflict(handler: (c: WriteConflict) => void): Unsubscribe {
+      return group.db.onWriteConflict((c) => {
+        if (shardIds.has(c.vault)) handler(c)
+      })
+    },
+    get writeQueue(): WriteQueue {
+      return group.db.writeQueue
+    },
+  }
+}
+```
+Note: callers should `await listAccessibleVaults()` before relying on write-event scoping (it primes `shardIds`); the inspector's normal flow calls `listVaults()` first. Document this on the function.
+
+- [ ] **Step 4: Export from the barrel**
+
+In `src/index.ts`, add to the appropriate section:
+```ts
+export { groupInspector } from './federation/group-inspector.js'
+```
+
+- [ ] **Step 5: Run the test, verify it passes**
+
+Run: `pnpm test group-inspector` — PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/federation/group-inspector.ts src/index.ts __tests__/group-inspector.test.ts
+git commit -m "feat(federation): groupInspector — drive @noy-db/in-devtools over a VaultGroup"
+```
+
+### Task 5: `meterGroup` fan-out
+
+**Files:**
+- Create: `src/federation/meter-group.ts`
+- Test: `__tests__/meter-group.test.ts`
+- Modify: `src/index.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+`__tests__/meter-group.test.ts` — build a 2-shard group, put N records across two partitions, assert:
+```ts
+import { describe, it, expect } from 'vitest'
+import { meterGroup } from '../src/federation/meter-group.js'
+
+describe('meterGroup', () => {
+  it('sums shape-metrics across eligible shards and surfaces skipped', async () => {
+    const { group } = await makeTwoShardGroup() // same helper as Task 4
+    // put 2 orders under 'alice', 1 under 'bob' (auto-creates both shards)
+    await group.collection('orders').put('a1', { id: 'a1', customer: 'alice' })
+    await group.collection('orders').put('a2', { id: 'a2', customer: 'alice' })
+    await group.collection('orders').put('b1', { id: 'b1', customer: 'bob' })
+
+    const report = await meterGroup(group)
+    expect(report.vaults).toBe(2)
+    expect(report.records).toBe(3)
+    expect(report.perShard.reduce((n, s) => n + s.records, 0)).toBe(3)
+    expect(report.skipped).toEqual([])
+  })
+})
+```
+
+- [ ] **Step 2: Run, verify it fails** — `pnpm test meter-group` → FAIL.
+
+- [ ] **Step 3: Implement**
+
+`src/federation/meter-group.ts`:
+```ts
+import type { VaultGroup } from './vault-group.js'
+import type { SkippedVault } from './types.js'
+
+export interface GroupShardMetrics {
+  readonly vaultId: string
+  readonly partitionKey: string
+  readonly schemaVersion: number
+  readonly collections: number
+  readonly records: number
+}
+
+export interface GroupMeterReport {
+  readonly vaults: number
+  readonly collections: number // distinct collection names across the group
+  readonly records: number // summed across shards
+  readonly perShard: ReadonlyArray<GroupShardMetrics>
+  readonly skipped: ReadonlyArray<SkippedVault>
+}
+
+/**
+ * Fan shape-metrics (collections + record counts) across the group's ELIGIBLE
+ * shards. Drifted / provisioning-failed shards are surfaced in `skipped`, never
+ * counted or silently dropped. Reuses the per-vault pattern from multi-bundle.ts.
+ */
+export async function meterGroup(
+  group: VaultGroup<unknown>,
+  opts: { minVersion?: number } = {},
+): Promise<GroupMeterReport> {
+  const { eligible, skipped } = await group.resolveEligible({ minVersion: opts.minVersion })
+  const perShard: GroupShardMetrics[] = []
+  const names = new Set<string>()
+  let records = 0
+  for (const row of eligible) {
+    const vault = await group.shard(row.partitionKey)
+    const collNames = await vault.collections()
+    let shardRecords = 0
+    for (const n of collNames) {
+      names.add(n)
+      shardRecords += await vault.collection(n).count()
+    }
+    records += shardRecords
+    perShard.push({
+      vaultId: row.vaultId,
+      partitionKey: row.partitionKey,
+      schemaVersion: row.schemaVersion,
+      collections: collNames.length,
+      records: shardRecords,
+    })
+  }
+  return { vaults: eligible.length, collections: names.size, records, perShard, skipped }
+}
+```
+
+- [ ] **Step 4: Export** — in `src/index.ts`:
+```ts
+export { meterGroup } from './federation/meter-group.js'
+export type { GroupMeterReport, GroupShardMetrics } from './federation/meter-group.js'
+```
+
+- [ ] **Step 5: Run, verify it passes** — `pnpm test meter-group` → PASS.
+
+- [ ] **Step 6: Commit**
+```bash
+git add src/federation/meter-group.ts src/index.ts __tests__/meter-group.test.ts
+git commit -m "feat(federation): meterGroup — group-wide shape metrics across eligible shards"
+```
+
+### Task 6: `klum` CLI bin
+
+**Files:**
+- Create: `src/bin/klum.ts`
+- Create: `__tests__/fixtures/group-config.ts`
+- Test: `__tests__/cli.test.ts`
+- Modify: `tsup.config.ts`, `package.json`
+
+- [ ] **Step 1: Write the failing test**
+
+`__tests__/fixtures/group-config.ts` — a config module default-exporting a factory that builds an in-memory 2-shard group and returns it:
+```ts
+import type { VaultGroup } from '../../src/federation/vault-group.js'
+export default async function openGroup(_groupName?: string): Promise<VaultGroup<unknown>> {
+  const { group } = await makeTwoShardGroup() // inline the federation-test setup here
+  await group.collection('orders').put('a1', { id: 'a1', customer: 'alice' })
+  return group
+}
+```
+`__tests__/cli.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { parseArgs, main } from '../src/bin/klum.js'
+
+describe('klum CLI', () => {
+  it('parseArgs reads command, config, --group, --vault, --meter', () => {
+    expect(parseArgs(['inspect-group', './c.js', '--group=g', '--vault=v1', '--meter'])).toEqual({
+      command: 'inspect-group',
+      configPath: './c.js',
+      group: 'g',
+      vault: 'v1',
+      meter: true,
+    })
+  })
+
+  it('inspect-group lists the group shards', async () => {
+    const lines: string[] = []
+    const code = await main(
+      ['inspect-group', new URL('./fixtures/group-config.js', import.meta.url).pathname, '--group=g'],
+      (s) => lines.push(s),
+    )
+    expect(code).toBe(0)
+    expect(lines.join('\n')).toMatch(/1 shard|alice/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run, verify it fails** — `pnpm test cli` → FAIL (`../src/bin/klum.js` missing).
+
+- [ ] **Step 3: Implement the CLI**
+
+`src/bin/klum.ts`:
+```ts
+import { createInspector } from '@noy-db/in-devtools'
+import { groupInspector } from '../federation/group-inspector.js'
+import { meterGroup } from '../federation/meter-group.js'
+import type { VaultGroup } from '../federation/vault-group.js'
+
+type GroupFactory = (groupName?: string) => Promise<VaultGroup<unknown>>
+type Log = (s: string) => void
+
+export interface ParsedArgs {
+  command: string
+  configPath?: string
+  group?: string
+  vault?: string
+  meter: boolean
+}
+
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  const out: ParsedArgs = { command: argv[0] ?? '', meter: false }
+  for (const a of argv.slice(1)) {
+    if (a.startsWith('--group=')) out.group = a.slice(8)
+    else if (a.startsWith('--vault=')) out.vault = a.slice(8)
+    else if (a === '--meter') out.meter = true
+    else if (!a.startsWith('--')) out.configPath = a
+  }
+  return out
+}
+
+async function loadGroup(args: ParsedArgs): Promise<VaultGroup<unknown>> {
+  const mod = (await import(args.configPath!)) as { default: GroupFactory }
+  return mod.default(args.group)
+}
+
+export async function runInspectGroup(args: ParsedArgs, log: Log): Promise<number> {
+  if (!args.configPath) {
+    log('usage: klum inspect-group <config> --group=<name> [--vault=<id>]')
+    return 2
+  }
+  const group = await loadGroup(args)
+  const inspector = createInspector(groupInspector(group))
+  const vaults = await inspector.listVaults()
+  log(`group "${args.group ?? ''}" — ${vaults.length} shard(s):`)
+  for (const v of vaults) log(`  ${v.id} [${v.role}]`)
+  if (args.vault) {
+    const vault = await group.db.openVault(args.vault)
+    group.template.configure(vault)
+    const snap = await inspector.snapshot(vault)
+    log(`  collections in ${args.vault}: ${snap.collections.map((c) => c.name).join(', ')}`)
+  }
+  return 0
+}
+
+export async function runMeterGroup(args: ParsedArgs, log: Log): Promise<number> {
+  if (!args.configPath) {
+    log('usage: klum meter-group <config> --group=<name>')
+    return 2
+  }
+  const group = await loadGroup(args)
+  const r = await meterGroup(group)
+  log(`group "${args.group ?? ''}" — ${r.vaults} vault(s), ${r.collections} collection(s), ${r.records} record(s)`)
+  for (const s of r.perShard) log(`  ${s.vaultId} (${s.partitionKey}) v${s.schemaVersion}: ${s.collections} coll, ${s.records} rec`)
+  if (r.skipped.length) log(`  skipped: ${r.skipped.length} shard(s)`)
+  return 0
+}
+
+export async function main(argv: readonly string[], log: Log = console.log): Promise<number> {
+  const args = parseArgs(argv)
+  switch (args.command) {
+    case 'inspect-group':
+      return runInspectGroup(args, log)
+    case 'meter-group':
+      return runMeterGroup(args, log)
+    default:
+      log('klum <inspect-group|meter-group> <config> --group=<name> [--vault=<id>]')
+      return args.command ? 1 : 0
+  }
+}
+
+// bin entrypoint
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2))
+    .then((code) => {
+      process.exitCode = code
+    })
+    .catch((e) => {
+      console.error(e)
+      process.exitCode = 1
+    })
+}
+```
+(Scoping note: the `--meter` flag is parsed but operational-store wrapping via `toMeter` is **deferred** — the CLI receives an already-built group, so operational metering is a config-factory opt-in. `meter-group` covers shape metrics. Record this as a follow-up; do not build `--meter` wrapping in this task.)
+
+- [ ] **Step 4: Wire the bin into the build**
+
+In `tsup.config.ts`, add `'src/bin/klum.ts'` to the `entry` array. In `package.json`, add:
+```json
+"bin": { "klum": "dist/bin/klum.js" }
+```
+
+- [ ] **Step 5: Run the test, verify it passes** — `pnpm test cli` → PASS.
+
+- [ ] **Step 6: Build + full suite + typecheck + lint**
+
+Run: `pnpm build && pnpm test && pnpm typecheck && pnpm lint`
+Expected: all green; `dist/bin/klum.js` emitted.
+
+- [ ] **Step 7: Commit**
+```bash
+git add src/bin/klum.ts __tests__/cli.test.ts __tests__/fixtures/group-config.ts tsup.config.ts package.json
+git commit -m "feat(cli): klum bin — inspect-group + meter-group over a federation"
+```
+
+### Task 7: Version bump + release PR (publish gated on user confirmation)
+
+- [ ] **Step 1:** Bump `@klum-db/lobby` `0.2.0-pre.27` → `0.2.0-pre.28`.
+- [ ] **Step 2:** Commit `chore(release): 0.2.0-pre.28 — federation tooling (WS-3)`, push, open PR.
+- [ ] **Step 3:** After CI green + **explicit user confirmation**, merge + cut the klum prerelease (`@next`). Confirm provenance publish from the klum repo.
+- [ ] **Step 4:** Verify on npm: `npm view @klum-db/lobby@0.2.0-pre.28 version`; `groupInspector` / `meterGroup` in the published types; the `klum` bin present.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Part A (contract) → Task 1. Part B (adapter) → Task 4. Part C (meter) → Task 5 (+ operational-meter documented as already group-wide; the CLI surfaces shape metrics). Part D (CLI) → Task 6. Publish sequencing (noy PR-1 → klum PR-2) → Tasks 2 & 7. Deferred group-TUI → not in plan (matches spec). `--meter` operational wrapping → explicitly deferred in Task 6 note (a scoped simplification of the spec's optional sugar).
+
+**Type consistency:** `InspectableContainer` members match the verbatim public hub types (`AccessibleVault`, `Vault`, `WriteHook`, `Unsubscribe`, `WriteConflict`, `WriteQueue`); the klum adapter implements exactly those; `meterGroup` uses `resolveEligible`→`{eligible,skipped}` and `shard(pk)`→`Vault`→`collections()`/`collection(n).count()` (verified public). `WriteEvent.vault` / `WriteConflict.vault` exist (verified) so the scoping filter compiles.
+
+**Placeholder scan:** the test helper `makeTwoShardGroup` is referenced, not inlined — it is an adaptation of the existing `__tests__/federation-vault-group.test.ts` setup; the implementer copies that fixture. This is the one intentional "adapt existing fixture" reference; every novel module ships complete code above.

--- a/docs/superpowers/specs/2026-06-20-ws3-tooling-federation-awareness-design.md
+++ b/docs/superpowers/specs/2026-06-20-ws3-tooling-federation-awareness-design.md
@@ -1,0 +1,117 @@
+# WS-3 tooling federation-awareness — design
+
+**Status:** design (approved 2026-06-20) — ready for implementation plan
+**Type:** cross-repo feature across the published-package seam. Workstream #3 (final) of the "orchestration → klum-db" boundary epic.
+**Repos:** `vLannaAi/noy-db` (`@noy-db/in-devtools` — one type-only change) and `vLannaAi/klum-db` (`@klum-db/lobby` — all net-new tooling).
+**Scope:** Core + group commands — make the **dev-tools, meter, and CLI** operate on a federation vault GROUP, not just a single vault.
+
+## Goal
+
+A federation operator can inspect and meter a whole `VaultGroup` — and drive it from a CLI — reusing the existing single-vault dev-tools, **without any `@noy-db` package importing `@klum-db`**. The `no-outbound-klum-import` guard stays green; group tooling lives in klum where it belongs.
+
+## The boundary principle (why this is additive, not a relocation)
+
+A federation's "atoms" are ordinary vaults: `VaultGroup.openShard(pk)` returns a real `@noy-db/hub` `Vault`. So the *vault-level* tools are already correct — only the **aggregating container** differs. We don't teach the tools "federation"; we make them accept any **container of vaults**, and a `VaultGroup` is one (via a klum-side adapter). Single-vault primitives stay in hub; group orchestration is klum's.
+
+## Investigation findings (verified 2026-06-20)
+
+- **`@noy-db/to-meter` is already federation-ready.** It wraps a `NoydbStore` (6-method interface, no vault binding). A group's shards are vaults opened from the same underlying store (`VaultGroup` holds `db: Noydb`, opens shards via `db.openVault(shardVaultId)`), so metering that store already captures all shard traffic. **No change.**
+- **`@noy-db/in-devtools` is the one bottleneck, and the coupling is already structural.** `createInspector(noydb: InspectorNoydb, …)` where `InspectorNoydb = Noydb` (a *type alias*, all imports type-only). The inspector binds only these container members: `listAccessibleVaults()`, `onAfterWrite()`, `onWriteConflict()`, `writeQueue` (`pendingWrites` reads `.pending`/`.depth`). The driver (TUI bin) additionally calls `openVault(name)`. Per-vault methods (`snapshot(vault: Vault)`, `records(vault: Vault, …)`) take a **real `Vault`** — a group's member shard satisfies them natively, so no `VaultLike` is needed.
+- **All container types are already public from `@noy-db/hub`:** `AccessibleVault` (`{ id: string; role: Role }`), `Vault`, `WriteHook` (`(e: WriteEvent) => void | Promise<void>`), `Unsubscribe` (`() => void`), `WriteConflict`, `WriteQueue` (interface with `pending`/`depth`). **PR-1 needs zero new hub exports.**
+- **`VaultGroup` is a fan-out router**, not a singleton vault proxy. Public surface (all on its current API): `allRows(): Promise<VaultRegistryRow[]>`, `shard/openShard(pk): Promise<Vault>`, `resolveEligible({minVersion?})`, `collection(name): ShardedCollection`, and `readonly db: Noydb`. `VaultRegistryRow = { vaultId; partitionKey; templateName; schemaVersion; createdAt; group }`. It opens member vaults on demand (`db.openVault(shardVaultId)` + `template.configure(vault)`); it holds no live-vault pool.
+- **klum has no group tooling yet** (no meter/inspect/cli/devtools). Its CLAUDE.md: *"Keep all cross-vault orchestration here… group-level tooling belongs in @klum-db/lobby."*
+- **No `@noy-db` package imports `@klum-db`** today.
+
+## Design
+
+### Part A — noy-db: the `InspectableContainer` contract *(dev-tools)*
+
+In `@noy-db/in-devtools`, define the input contract the inspector actually requires and narrow `createInspector` to it:
+
+```ts
+// packages/in-devtools/src/types.ts — reuses already-public hub types verbatim
+import type { AccessibleVault, Vault, WriteHook, Unsubscribe, WriteConflict, WriteQueue } from '@noy-db/hub'
+
+/** Any container of vaults the inspector can read — a Noydb or a federation adapter. */
+export interface InspectableContainer {
+  listAccessibleVaults(): Promise<readonly AccessibleVault[]>
+  openVault(name: string): Promise<Vault>
+  onAfterWrite(handler: WriteHook): Unsubscribe
+  onWriteConflict(handler: (c: WriteConflict) => void): Unsubscribe
+  readonly writeQueue: WriteQueue
+}
+```
+
+- Replace `InspectorNoydb = Noydb` usage: `createInspector(container: InspectableContainer, opts?)`. Keep the `InspectorNoydb` alias as a deprecated re-export of `InspectableContainer` for one cycle (no breaking import churn), or drop it — TBD in plan; default keep.
+- **Backward-compatible:** a real `Noydb` satisfies `InspectableContainer` verbatim (all five signatures match the public hub types). Existing callers, the TUI, and all current tests pass unchanged.
+- Export `InspectableContainer` from the in-devtools barrel so klum can type its adapter against it.
+- **Why in-devtools (not hub):** dependency inversion — the tool declares the abstraction it consumes; both `Noydb` and the klum `VaultGroup` adapter conform. Hub stays free of a devtools-specific type. (klum adds `@noy-db/in-devtools` as a peer dep for the type — see Part B.)
+
+Publish a new `@noy-db` prerelease (manual lockstep bump).
+
+### Part B — klum: `groupInspector` adapter *(dev-tools on a federation)*
+
+In `@klum-db/lobby`, a `groupInspector(group: VaultGroup): InspectableContainer` built entirely on `VaultGroup`'s **current public API** + `group.db` — **no `VaultGroup` changes**:
+
+| `InspectableContainer` member | Implementation | Notes |
+|---|---|---|
+| `listAccessibleVaults()` | `(await group.allRows()).map(r => ({ id: r.vaultId, role: 'owner' as Role }))` | group-scoped (registry rows are already filtered to this group); operator opens shards as owner |
+| `openVault(name)` | `const v = await group.db.openVault(name); group.template.configure(v); return v` | apply the template like `openShard` does, so the inspected shard has its collections/indexes |
+| `onAfterWrite(h)` | delegate to `group.db.onAfterWrite(h)`, filtered to this group's shard vaultIds | filter via the `allRows()` id set; ignores writes to vaults outside the group |
+| `onWriteConflict(h)` | delegate to `group.db.onWriteConflict(h)`, same shard filter | |
+| `writeQueue` | `group.db.writeQueue` | group shares the Noydb write queue |
+
+Then `createInspector(groupInspector(group), { meter? })` and the existing TUI/CLI inspection flow run on a federation. Exported from klum's barrel as part of the group-tooling surface. **No `@klum` import lands in any `@noy-db` package** — the adapter lives in klum and merely *conforms to* a noy-owned interface.
+
+### Part C — klum: group meter *(meter on a federation)*
+
+- **Operational metering is already group-wide** — document it: `toMeter(store)` on the Noydb's store covers all shards (they share it). The CLI surfaces it via the existing `meter.snapshot()`.
+- **New `meterGroup(group, opts?)`** — shape metrics fanned across **eligible** shards (`group.resolveEligible({minVersion?})`), reusing the per-vault pattern proven in `multi-bundle.ts` (`vault.collections()` then `collection(n).count()`):
+  ```ts
+  interface GroupMeterReport {
+    readonly vaults: number
+    readonly collections: number          // distinct collection names across the group
+    readonly records: number              // summed across shards
+    readonly perShard: ReadonlyArray<{ vaultId: string; partitionKey: string; schemaVersion: number; collections: number; records: number }>
+    readonly skipped: ReadonlyArray<SkippedVault>   // drift / provisioning-failed shards, surfaced not hidden
+  }
+  ```
+  Fan-out concurrency-bounded (reuse the federation runner's batch pattern); `skipped` is reported, never silently dropped.
+
+### Part D — klum: CLI *(cli on a federation)*
+
+Add a `klum` **bin to `@klum-db/lobby`** (`"bin": { "klum": "dist/bin/klum.js" }`, built by tsup) with two subcommands, mirroring `@noy-db/cli`'s thin arg-parser style (no new heavyweight CLI dep):
+
+- `klum inspect-group <config.{js,mjs}> --group=<name> [--vault=<id>] [--meter]` — load options from config → `createLobby(await createNoydb(options))` → `openVaultGroup(name, …)` → `groupInspector(group)` → `createInspector(...)`; print vault list + per-vault snapshot (and a chosen shard's records when `--vault` given). `--meter` wraps the store via `toMeter` first.
+- `klum meter-group <config> --group=<name>` — run `meterGroup(group)` and print the `GroupMeterReport` (totals + per-shard table + skipped).
+
+Config shape mirrors the noy CLI's: a module default-exporting `NoydbOptions` (`{ store, user?, secret? }`) plus the vault-template registration the group needs. The CLI obtains the group purely through the published `@noy-db` + klum's own `Lobby`.
+
+### Out of committed scope (decide at planning if wanted)
+- **Group TUI mode** — wiring `groupInspector` into the Ink app (`@noy-db/in-devtools-tui`) so the TUI browses a federation. Feasible (the TUI already takes an `Inspector` + a `Vault`), but it's the only piece with real UI work; the CLI already delivers "operators can drive a fleet." Left out; foldable later.
+
+## The publish-seam sequence (2-PR, additive)
+
+Unlike WS-1 this is not a relocation — the capability is **new on both sides**, so there is no "missing from both" window. Order is by dependency only:
+
+1. **noy-db PR-1** *(type-only)*: add `InspectableContainer` to `@noy-db/in-devtools`, narrow `createInspector`, export it. Tests/TUI unaffected (a `Noydb` still satisfies it). Merge → publish `@noy-db` next prerelease.
+2. **klum PR-2** *(net-new)*: add `@noy-db/in-devtools` peer dep; add `groupInspector`, `meterGroup`, the `klum` CLI bin; export the group-tooling surface from the barrel; tests against the just-published `@noy-db`. Merge → publish `@klum-db/lobby` next prerelease.
+
+## Testing & verification
+
+- **noy-db PR-1:** existing in-devtools + TUI suites pass unchanged (proves backward-compat); add a type-level test that a `Noydb` is assignable to `InspectableContainer`; `pnpm check:architecture` (guard) + build/typecheck/lint green.
+- **klum PR-2:** new suites — (a) `groupInspector` drives `createInspector` over a 2–3 shard group: `listAccessibleVaults` returns the shards, `snapshot`/`records` work on a materialized shard, write events fire on shard writes and are filtered to the group; (b) `meterGroup` totals match the sum of per-shard counts and surfaces a drifted/skipped shard; (c) CLI smoke test for `inspect-group`/`meter-group` against an in-memory store. All against the published `@noy-db`. Guard: confirm no `@noy-db` package imports `@klum-db` (unchanged — the adapter is klum-side).
+
+## Design decisions (recorded)
+1. **Contract home = `@noy-db/in-devtools`** (DIP), not hub. klum takes `@noy-db/in-devtools` as a peer dep for the type. Alternative (hub) rejected to keep hub free of a tool-specific interface.
+2. **CLI = a `bin` in `@klum-db/lobby`**, not a separate `@klum-db/cli` package. klum is single-package today; splitting is premature (YAGNI).
+3. **Per-vault role mapping** in the adapter = `'owner'` (the federation operator owns its shards via the Lobby's `db`). Revisit only if a non-owner inspection mode is needed.
+
+## Risks / edge cases
+- **Write-event scoping:** `group.db` may host vaults outside the group; the adapter MUST filter `onAfterWrite`/`onWriteConflict` to the group's shard vaultIds (from `allRows()`), refreshing the id set as shards are auto-created. Without the filter the inspector would surface cross-group writes.
+- **`openVault` vs `openShard` parity:** the adapter applies `group.template.configure(vault)` so an inspected shard matches what `openShard` produces (collections/indexes present for `dumpSchema`/stats).
+- **Eligible-only metering:** `meterGroup` walks `resolveEligible()` and reports `skipped` (schema-drift / provisioning-failed) rather than counting or hiding them — no silent truncation.
+- **Backward-compat guarantee:** if any current caller relied on passing a `Noydb` *subtype with extra required params* the narrowing could bite — verified not the case (all internal callers pass a plain `Noydb`).
+
+## Consequences
+Closes the boundary epic. The pattern established — *extract the tool's true input contract as an interface in the tool's own package; let both the single-vault concrete type and a klum adapter conform; never let the tool import klum* — is the reusable recipe for making any future single-vault tool federation-capable.

--- a/packages/as-aws-s3/package.json
+++ b/packages/as-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-aws-s3",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "AWS S3 object projection for noy-db — serve blob bytes directly from S3/CDN (presigned or public), outside the encrypted store",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-blob/package.json
+++ b/packages/as-blob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-blob",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Single-attachment plaintext export for noy-db — extracts one blob from BlobSet as native MIME bytes. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier, document sub-family).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-csv/package.json
+++ b/packages/as-csv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-csv",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "CSV plaintext export for noy-db — decrypts records and formats as comma-separated values. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-json/package.json
+++ b/packages/as-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-json",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Structured JSON plaintext export for noy-db — decrypts records and emits one JSON document per vault. Gated by RFC #249 canExportPlaintext capability; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-ndjson/package.json
+++ b/packages/as-ndjson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-ndjson",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Newline-delimited JSON export for noy-db — streaming plaintext export suitable for data pipelines, warehouse ingestion, and jq pipelines. Gated by RFC #249 canExportPlaintext. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-noydb/package.json
+++ b/packages/as-noydb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-noydb",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Encrypted .noydb bundle export for noy-db — wraps writeNoydbBundle() with the RFC #249 canExportBundle authorization gate and ergonomic browser/node helpers. Sole member of the @noy-db/as-* encrypted tier — ciphertext in, ciphertext out.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-sql/package.json
+++ b/packages/as-sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-sql",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "SQL dump export for noy-db — decrypts records and emits dialect-aware CREATE TABLE + INSERT statements for postgres / mysql / sqlite. One-way migration helper. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xlsx/package.json
+++ b/packages/as-xlsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xlsx",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Excel spreadsheet plaintext export for noy-db — produces a real .xlsx (Office Open XML) from one or more collections. Multi-sheet, Unicode-safe via shared-strings table. Zero runtime deps beyond the workspace zip encoder. Gated by RFC #249 `canExportPlaintext` with format `'xlsx'`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xml/package.json
+++ b/packages/as-xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xml",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "XML plaintext export for noy-db — decrypts records and formats as XML with RFC-compliant entity escaping. For legacy systems, banking batch imports, SOAP endpoints, and accounting software that requires XML. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-zip/package.json
+++ b/packages/as-zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-zip",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Composite record + blob archive export for noy-db — bundles a collection's records plus every attached blob into one zip. Zero dependencies (STORE-only zip encoder). Gated by the RFC #249 `canExportPlaintext` capability bit with format `'zip'`. Part of the @noy-db/as-* portable-artefact family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-aws-kms/package.json
+++ b/packages/at-aws-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-aws-kms",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "AWS KMS sealing key provider for noy-db managed-passphrase mode — seal/unseal via KMS Encrypt/Decrypt, with KMS access logs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-azure-keyvault/package.json
+++ b/packages/at-azure-keyvault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-azure-keyvault",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Azure Key Vault sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-env/package.json
+++ b/packages/at-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-env",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Env-var sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a key from process.env. Smallest production-shape provider; pair with Kubernetes Secrets / Heroku env / AWS Secrets Manager.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-gcp-kms/package.json
+++ b/packages/at-gcp-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-gcp-kms",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Google Cloud KMS sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-macos-keychain/package.json
+++ b/packages/at-macos-keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-macos-keychain",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "macOS Keychain sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a 32-byte key stored in the user's login Keychain. Desktop-app provider in the at-* family; pairs with Touch ID via Keychain Access UI.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/attestation/package.json
+++ b/packages/attestation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/attestation",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Pure, zero-dependency document-attestation primitive for noy-db — per-field salted commitments, Ed25519 sign/verify, QR credential codec, and revocation checks. Runs in Node and the browser; the offline verifier imports only this.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-peer/package.json
+++ b/packages/by-peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-peer",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "WebRTC peer-to-peer transport for noy-db — direct browser-to-browser channel with signaling-agnostic handshake",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-tabs/package.json
+++ b/packages/by-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-tabs",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "BroadcastChannel multi-tab transport for noy-db — sync between tabs of the same browser without round-tripping the storage backend",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/cli",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Command-line tool for noy-db — inspect .noydb bundles without decrypting, verify integrity, validate config objects, scaffold topology profiles, and monitor a live vault's store metrics.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/create-noy-db/package.json
+++ b/packages/create-noy-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-noy-db",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Wizard + CLI tool for noy-db: scaffold a fresh Nuxt 4 + Pinia encrypted store, or add collections to an existing project. Invoke via `npm create @noy-db`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/hub",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Zero-knowledge, offline-first, encrypted document store — core library with AES-256-GCM, PBKDF2, multi-user keyring, and sync engine",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-ai/package.json
+++ b/packages/in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-ai",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "LLM function-calling adapter for noy-db — expose ACL-scoped collections as tool definitions, then dispatch tool calls back to the vault. Format-agnostic (OpenAI, Anthropic, Vercel AI SDK).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-devtools-tui/package.json
+++ b/packages/in-devtools-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-devtools-tui",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Interactive terminal inspector for a live noy-db (ink TUI over @noy-db/in-devtools).",
   "license": "MIT",
   "type": "module",

--- a/packages/in-devtools/__tests__/inspectable-container.test.ts
+++ b/packages/in-devtools/__tests__/inspectable-container.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { createInspector, type InspectableContainer } from '../src/index.js'
+import type { Noydb } from '@noy-db/hub'
+
+describe('InspectableContainer contract', () => {
+  it('a real Noydb is assignable to InspectableContainer (compile-time proof)', () => {
+    const asContainer = (n: Noydb): InspectableContainer => n
+    expect(typeof asContainer).toBe('function')
+  })
+
+  it('createInspector accepts any structural InspectableContainer', () => {
+    const container: InspectableContainer = {
+      async listAccessibleVaults() {
+        return []
+      },
+      async openVault() {
+        throw new Error('not exercised by this test')
+      },
+      onAfterWrite() {
+        return () => {}
+      },
+      onWriteConflict() {
+        return () => {}
+      },
+      get writeQueue() {
+        return { pending: false, depth: 0, onChange: () => () => {}, onFlush: async () => {} }
+      },
+    }
+    const inspector = createInspector(container)
+    expect(typeof inspector.listVaults).toBe('function')
+    expect(inspector.pendingWrites()).toEqual({ pending: false, depth: 0 })
+  })
+})

--- a/packages/in-devtools/package.json
+++ b/packages/in-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-devtools",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Framework-agnostic read-only inspector for a live noy-db — vaults, collections, schema, stats, records, and live writes.",
   "license": "MIT",
   "type": "module",

--- a/packages/in-devtools/src/events.ts
+++ b/packages/in-devtools/src/events.ts
@@ -1,17 +1,17 @@
-import type { InspectorWriteEvent, InspectorWriteConflict, PendingWrites, InspectorNoydb } from './types.js'
+import type { InspectorWriteEvent, InspectorWriteConflict, PendingWrites, InspectableContainer } from './types.js'
 
 export function subscribe(
-  noydb: InspectorNoydb,
+  noydb: InspectableContainer,
   handler: (event: InspectorWriteEvent) => void,
 ): () => void {
   return noydb.onAfterWrite(handler)
 }
 
-export function pendingWrites(noydb: InspectorNoydb): PendingWrites {
+export function pendingWrites(noydb: InspectableContainer): PendingWrites {
   const q = noydb.writeQueue
   return { pending: q.pending, depth: q.depth }
 }
 
-export function subscribeConflicts(noydb: InspectorNoydb, handler: (c: InspectorWriteConflict) => void): () => void {
+export function subscribeConflicts(noydb: InspectableContainer, handler: (c: InspectorWriteConflict) => void): () => void {
   return noydb.onWriteConflict(handler)
 }

--- a/packages/in-devtools/src/index.ts
+++ b/packages/in-devtools/src/index.ts
@@ -1,24 +1,25 @@
 import type { Vault } from '@noy-db/hub'
-import type { Inspector, InspectorNoydb, InspectorMeter } from './types.js'
+import type { Inspector, InspectableContainer, InspectorMeter } from './types.js'
 import { listVaults, snapshot } from './snapshot.js'
 import { records } from './records.js'
 import { subscribe, subscribeConflicts, pendingWrites } from './events.js'
 import { meterSnapshot } from './meter.js'
 
-export function createInspector(noydb: InspectorNoydb, opts?: { meter?: InspectorMeter }): Inspector {
+export function createInspector(container: InspectableContainer, opts?: { meter?: InspectorMeter }): Inspector {
   return {
-    listVaults: () => listVaults(noydb),
+    listVaults: () => listVaults(container),
     snapshot: (vault: Vault) => snapshot(vault),
     records: (vault, collection, opts) => records(vault, collection, opts),
-    subscribe: (handler) => subscribe(noydb, handler),
-    subscribeConflicts: (handler) => subscribeConflicts(noydb, handler),
-    pendingWrites: () => pendingWrites(noydb),
+    subscribe: (handler) => subscribe(container, handler),
+    subscribeConflicts: (handler) => subscribeConflicts(container, handler),
+    pendingWrites: () => pendingWrites(container),
     meterSnapshot: () => meterSnapshot(opts?.meter),
   }
 }
 
 export type {
   Inspector,
+  InspectableContainer,
   VaultInfo,
   InspectorSnapshot,
   InspectorCollection,

--- a/packages/in-devtools/src/snapshot.ts
+++ b/packages/in-devtools/src/snapshot.ts
@@ -1,7 +1,7 @@
 import type { Vault } from '@noy-db/hub'
-import type { InspectorSnapshot, InspectorCollection, VaultInfo, InspectorNoydb } from './types.js'
+import type { InspectorSnapshot, InspectorCollection, VaultInfo, InspectableContainer } from './types.js'
 
-export async function listVaults(noydb: InspectorNoydb): Promise<ReadonlyArray<VaultInfo>> {
+export async function listVaults(noydb: InspectableContainer): Promise<ReadonlyArray<VaultInfo>> {
   return noydb.listAccessibleVaults()
 }
 

--- a/packages/in-devtools/src/types.ts
+++ b/packages/in-devtools/src/types.ts
@@ -1,8 +1,10 @@
 import type {
-  Noydb,
   Vault,
   WriteEvent,
   WriteConflict,
+  WriteHook,
+  Unsubscribe,
+  WriteQueue,
   AccessibleVault,
   CollectionDescriptor,
   CollectionStats,
@@ -68,5 +70,15 @@ export interface Inspector {
   meterSnapshot(): MeterSnapshot | null
 }
 
-/** @internal — the hub handle the inspector reads from. */
-export type InspectorNoydb = Noydb
+/**
+ * The container of vaults the inspector reads from. A `Noydb` satisfies this
+ * verbatim; a klum `VaultGroup` adapter conforms structurally — so the inspector
+ * works on a single instance OR a federation without importing either.
+ */
+export interface InspectableContainer {
+  listAccessibleVaults(): Promise<readonly AccessibleVault[]>
+  openVault(name: string): Promise<Vault>
+  onAfterWrite(handler: WriteHook): Unsubscribe
+  onWriteConflict(handler: (c: WriteConflict) => void): Unsubscribe
+  readonly writeQueue: WriteQueue
+}

--- a/packages/in-nextjs/package.json
+++ b/packages/in-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nextjs",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Next.js App Router helpers for noy-db — server components, route handlers, client hooks, and cookie-based session. Thin bridge that composes @noy-db/in-react with Next's cookies()/headers() APIs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-nuxt/package.json
+++ b/packages/in-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nuxt",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Nuxt 4 module for noy-db — auto-imports, SSR-safe runtime plugin, and the @noy-db/in-pinia bridge",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-pinia/package.json
+++ b/packages/in-pinia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-pinia",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Pinia integration for noy-db — defineNoydbStore() and the augmentation plugin for existing stores",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-react/package.json
+++ b/packages/in-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-react",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "React hooks for noy-db — useNoydb, useVault, useCollection, useQuery, useSync. Uses useSyncExternalStore for reactive subscriptions. Zero deps beyond React.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-rest/package.json
+++ b/packages/in-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-rest",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Framework-neutral REST API integration for noy-db — createRestHandler with Hono, Express, Fastify, and Nitro subpath adapters.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-solid/package.json
+++ b/packages/in-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-solid",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "SolidJS signal primitives for noy-db — createCollectionSignal, createQuerySignal, createSyncSignal backed by noy-db change events.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-svelte/package.json
+++ b/packages/in-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-svelte",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Svelte stores for noy-db — collectionStore / queryStore / syncStore backed by noy-db change events. Works with Svelte 4 store contract and Svelte 5 runes (via $store subscription interop).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-query/package.json
+++ b/packages/in-tanstack-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-query",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "TanStack Query adapter for noy-db — queryFn + mutationFn helpers that speak the Collection API, plus automatic invalidation from noy-db change events. Framework-agnostic (React / Vue / Solid / Svelte).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-table/package.json
+++ b/packages/in-tanstack-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-table",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "TanStack Table bridge for noy-db — map Collection query state (sort, filter, pagination) into Table state and back, so a useSmartTable pattern drives the DB's query DSL without glue code.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-vue/package.json
+++ b/packages/in-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-vue",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Vue 3 / Nuxt composables for noy-db — reactive useNoydb, useCollection, useSync, and biometric plugin",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-yjs/package.json
+++ b/packages/in-yjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-yjs",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Yjs Y.Doc interop for noy-db — collaborative rich-text fields with encrypted-at-rest Yjs state",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-zustand/package.json
+++ b/packages/in-zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-zustand",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Zustand adapter for noy-db — factory that mirrors defineNoydbStore for Zustand users, auto-syncs state from noy-db change events, and supports optimistic mutations.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-email-otp/package.json
+++ b/packages/on-email-otp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-email-otp",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Email OTP second factor for noy-db — generates time-boxed one-time codes, delivers via a user-supplied transport (SMTP / SES / Postmark / any fn), and verifies in constant time. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-magic-link/package.json
+++ b/packages/on-magic-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-magic-link",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Magic-link unlock for noy-db — one-time URL that opens a vault in a viewer-scoped session without a passphrase. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-oidc/package.json
+++ b/packages/on-oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-oidc",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "OAuth/OIDC bridge for noy-db — federated login (LINE, Google, Apple, Okta) with split-key key connector — server never sees plaintext",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-password/package.json
+++ b/packages/on-password/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-password",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Tier-2 password authenticator slot for noy-db. PBKDF2-SHA256 600K wraps the DEK set in its own keyring slot, distinct from the rarely-typed tier-1 phrase. Pair with @noy-db/on-email-otp or @noy-db/on-totp for the SaaS UX.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-pin/package.json
+++ b/packages/on-pin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-pin",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Session-resume PIN quick-lock for noy-db — after a full passphrase unlock, a short-lived PIN (or a per-device biometric) re-unlocks the cached DEKs without re-typing the passphrase. PIN never replaces the passphrase; only resumes an already-unlocked session.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-recovery/package.json
+++ b/packages/on-recovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-recovery",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "One-time printable recovery codes for noy-db — last-resort vault unlock when the passphrase, passkey, and OIDC provider are all unavailable. Base32 + checksum codes, PBKDF2-derived wrapping keys, burn-on-use. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-shamir/package.json
+++ b/packages/on-shamir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-shamir",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "k-of-n Shamir Secret Sharing of the vault KEK for multi-party unlock. Any K of N shares recombines the key; fewer than K leaks zero bits. Composable — each share can be protected by any other on-* method. Zero runtime dependencies.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-threat/package.json
+++ b/packages/on-threat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-threat",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Threat-response primitives for noy-db — multi-attempt lockout, duress-passphrase data destruction, duress-passphrase honeypot decoy. Pure stateful helpers; the caller coordinates keyring + audit-ledger integration. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-totp/package.json
+++ b/packages/on-totp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-totp",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "TOTP (RFC 6238) authenticator-app second factor for noy-db — generate secrets, otpauth:// provisioning URIs, and constant-time code verification. Zero dependencies (HMAC-SHA1 via Web Crypto). Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-webauthn/package.json
+++ b/packages/on-webauthn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-webauthn",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "WebAuthn hardware-key keyrings for noy-db — Touch ID, Face ID, Windows Hello, YubiKey, FIDO2 passkeys",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-aws-dynamo/package.json
+++ b/packages/to-aws-dynamo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-aws-dynamo",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "AWS DynamoDB adapter for noy-db — single-table design, zero-knowledge cloud sync",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-aws-s3/package.json
+++ b/packages/to-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-aws-s3",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "AWS S3 adapter for noy-db — encrypted object storage with zero-knowledge cloud sync",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-browser-idb/package.json
+++ b/packages/to-browser-idb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-browser-idb",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "IndexedDB adapter for noy-db with optional key obfuscation",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-browser-local/package.json
+++ b/packages/to-browser-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-browser-local",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "localStorage adapter for noy-db with optional key obfuscation",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-cloudflare-d1/package.json
+++ b/packages/to-cloudflare-d1/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-cloudflare-d1",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Cloudflare D1 adapter for noy-db — SQLite at the edge, running inside Cloudflare Workers. Accepts a D1Database binding and speaks the noy-db store contract via D1's prepare/bind API.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-cloudflare-r2/package.json
+++ b/packages/to-cloudflare-r2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-cloudflare-r2",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Cloudflare R2 adapter for noy-db — S3-compatible object storage with zero egress fees. Thin wrapper around @noy-db/to-aws-s3 configured for the R2 endpoint. casAtomic: true, serverWriteTime: true.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-drive/package.json
+++ b/packages/to-drive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-drive",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Google Drive bundle store for noy-db. Stores the whole vault as a single .noydb file in Drive's hidden appDataFolder; opaque ULID filenames never leak compartment names. Driver-agnostic — bring your own OAuth token.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-file/package.json
+++ b/packages/to-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-file",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "JSON file adapter for noy-db — encrypted document store on local disk, USB sticks, or network drives",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-icloud/package.json
+++ b/packages/to-icloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-icloud",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "iCloud Drive bundle store for noy-db — macOS-aware persistence that detects eviction stubs (.icloud) and conflict files automatically. Treats each vault as a single .noydb bundle, safe for the Apple ecosystem.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-memory/package.json
+++ b/packages/to-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-memory",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "In-memory adapter for noy-db — ideal for testing, development, and ephemeral workloads",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-meter/package.json
+++ b/packages/to-meter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-meter",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Pass-through meter for @noy-db/to-* stores — wraps any NoydbStore and records per-method latency percentiles, error rates, and byte counts on real traffic. Optional synthetic liveness probe emits degraded / restored events. No synthetic benchmarks (see @noy-db/to-probe for that) — this measures what your app is actually doing.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-mysql/package.json
+++ b/packages/to-mysql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-mysql",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "MySQL / MariaDB adapter for noy-db — encrypted-envelope KV with JSON column. Works with any duck-typed mysql2-style pool/connection. casAtomic: true via UPDATE … WHERE v = ?.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-nfs/package.json
+++ b/packages/to-nfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-nfs",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "NFS network-file store for noy-db. Same indexed layout as @noy-db/to-file, with pre-flight checks for nolock / noac mount options that silently break versioning guarantees on stock NFS mounts.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-postgres/package.json
+++ b/packages/to-postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-postgres",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "PostgreSQL adapter for noy-db — encrypted-envelope KV with jsonb column. Works with any duck-typed pg-style Client (node-postgres, postgres.js, pg-native, Supabase, Neon serverless). casAtomic: true via UPDATE … WHERE _v = ?.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-probe/package.json
+++ b/packages/to-probe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-probe",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Diagnostic companion for the @noy-db/to-* store family — not itself a storage backend. Setup-time suitability test + topology check + runtime reliability monitor. Exercises the 6-method NoydbStore contract across five axes (write latency, CAS integrity, hydration cost, sync economics, network resilience) and produces a structured risk-scored report.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-smb/package.json
+++ b/packages/to-smb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-smb",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "SMB/CIFS network file store for noy-db. Works against Windows file servers, NAS devices (Synology/QNAP/Netgear), and corporate shared drives via NTLM or Kerberos auth — no OS mount required.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-sqlite/package.json
+++ b/packages/to-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-sqlite",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "SQLite adapter for noy-db — single-file local encrypted document store. Works with better-sqlite3, node:sqlite (Node 22+), or bun:sqlite via a duck-typed Database interface. casAtomic: true (BEGIN IMMEDIATE + UPDATE WHERE _v=?).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-ssh/package.json
+++ b/packages/to-ssh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-ssh",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "SSH/SFTP store for noy-db — remote encrypted document storage over SSH using public-key auth. Any Linux/macOS server with sshd running becomes a noy-db backend; leverages existing ~/.ssh keys or ssh-agent. Key-only auth (no passwords).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-supabase/package.json
+++ b/packages/to-supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-supabase",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Supabase adapter for noy-db — Postgres + Storage combo. Routes records to @noy-db/to-postgres via the Supabase Postgres pool and optional blob routing via Supabase Storage.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-turso/package.json
+++ b/packages/to-turso/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-turso",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "Turso / libSQL adapter for noy-db — edge SQLite with built-in replication. Wraps @libsql/client through a small async shim that speaks the same noy-db store contract as @noy-db/to-sqlite.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-webdav/package.json
+++ b/packages/to-webdav/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-webdav",
-  "version": "0.2.0-pre.25",
+  "version": "0.2.0-pre.26",
   "description": "WebDAV adapter for noy-db — encrypted object storage over the WebDAV protocol. Works with Nextcloud, ownCloud, Apache mod_dav, and any RFC 4918 server. Pure fetch()-based, zero dependencies.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",


### PR DESCRIPTION
## WS-3 Part A — the dev-tools input contract

First of two additive PRs that make `@noy-db`'s dev-tools / meter / CLI federation-capable (boundary epic, workstream 3). This side is **type-only and backward-compatible**.

### What changed
- `@noy-db/in-devtools` now exposes an `InspectableContainer` interface — the inspector's true input contract (`listAccessibleVaults`, `openVault`, `onAfterWrite`, `onWriteConflict`, `writeQueue`), built from already-public hub types.
- `createInspector(container: InspectableContainer, …)` is narrowed to it (was the concrete `Noydb` alias). A real `Noydb` satisfies it **verbatim** — proven by the unchanged `@noy-db/in-devtools-tui` typecheck, which passes a live `Noydb`.
- Internal callers repointed off the now-dead `@internal InspectorNoydb` alias (removed).

### Why
So a klum `VaultGroup` adapter can conform to this contract **structurally**, letting the inspector run on a federation **without any `@noy-db` package importing `@klum-db`** (the `no-outbound-klum-import` guard stays the wall). Part B (the adapter + group meter + `klum` CLI) lands in `@klum-db/lobby` against the published `@noy-db@0.2.0-pre.26`.

### Verification
- `@noy-db/in-devtools`: 13/13 tests (incl. 2 new contract cases), typecheck, lint ✓
- `@noy-db/in-devtools-tui`: typecheck (backward-compat) + 10/10 tests ✓
- `pnpm check:architecture` ✓ (no outbound `@klum-db` import)

### Release
Lockstep bump `0.2.0-pre.25 → 0.2.0-pre.26` (67 packages, version field only). Also includes the WS-3 spec + implementation plan docs.