### PR TITLE
feat(i18n): v1.x tail — densifyOnWrite + i18n:script-violation event (#435)

### DIFF
--- a/docs/subsystems/i18n.md
+++ b/docs/subsystems/i18n.md
@@ -116,6 +116,91 @@ allowed. Violations `'reject'` (default, `ScriptViolationError`),
 `'filter'` (strip), or `'warn'`. Tighten a field with an explicit set:
 `script: { th: ['Thai'] }`.
 
+**`densifyOnWrite` — eager slot fill at write time (#435).** With
+`densifyOnWrite: true` on an `i18nText` field, every empty declared-language
+slot is filled from the field's substitute chain **at write time** — using
+`substitute ?? ['any']` (first non-empty value when no explicit chain is
+declared) — so the stored locale map is always dense and downstream layers
+(join, MV, derivation, export) never hit a hole.
+
+Which slots were auto-filled is recorded in an internal `_i18nFilled` marker
+that is encrypted with the record and **stripped from all reads** (`get`,
+`list`, `raw`). The only sanctioned way to inspect it is:
+
+```ts
+await collection.i18nProvenance(id)
+// → e.g. { name: ['en'] }  — or undefined when nothing was filled
+```
+
+Declaring the field:
+
+```ts
+i18nText({
+  languages: ['th', 'en'], required: 'any',
+  substitute: ['th', 'any'],
+  densifyOnWrite: true,
+})
+```
+
+**Write sequence** (for a densify-enabled field):
+
+1. Auto-translate (existing)
+2. `computeExemptFills` — reads the prior record's marker; classifies each
+   locale slot as *authored*, *exempt round-tripped fill*, or *cleared fill*
+3. Script enforcement — checks **authored slots only**; unchanged
+   round-tripped fills are exempt (so Thai text in an `en` fill slot does not
+   trigger a Latin-locale script rejection on a second write)
+4. Required-validation — authored floor only; fills do not satisfy `required`
+5. Densify — fill empty slots, record marker, refresh changed-source fills
+6. Encrypt and persist
+
+**Refresh and no-clobber.** Densify re-runs from the current authored slots
+on every write, so correcting a source value automatically refreshes its
+derived slots (e.g. fixing `th` re-densifies `en`). If a user authors a real
+value into a formerly-filled slot the marker for that locale is cleared and
+the value is treated as authored from that point on. A value byte-identical to
+the existing fill remains classified as a fill (value-equality provenance
+limitation).
+
+**Mutual exclusion.** `densifyOnWrite: true` combined with an **explicit**
+`onMissing: 'throw'` — scalar or any per-layer value — is a configuration
+error (densify fills every hole, making a throw policy unreachable). Declaring
+`densifyOnWrite` without an explicit `onMissing` is fine; the *default*
+`'throw'` simply never fires.
+
+**Limitation.** Supports single-leaf i18n fields only. Array-wildcard paths
+(`contacts[].name`) are skipped, mirroring auto-translate.
+
+Full design: `docs/superpowers/specs/2026-06-20-i18n-v1x-tail-design.md`.
+
+**`i18n:script-violation` event channel (#435).** The `'warn'` and `'filter'`
+script-enforcement modes collect `ScriptWarning[]` objects; previously those
+warnings were silently discarded. The typed event channel surfaces them:
+
+```ts
+// Payload shape (ScriptWarning = { field, locale, expected, sample })
+interface NoydbEventMap {
+  'i18n:script-violation': {
+    vault: string; collection: string; id: string
+    mode: 'warn' | 'filter'
+    warning: ScriptWarning
+  }
+}
+
+db.on('i18n:script-violation', (e) => {
+  // audit; e.mode === 'filter' means characters were dropped from e.warning.sample
+})
+```
+
+One event is emitted per warning per write. The event fires for `'warn'`
+(value stored as-is) and `'filter'` (disallowed characters stripped — the
+event is the **only** signal that stored data was mutated by script enforcement).
+`'reject'` throws `ScriptViolationError` and emits nothing (the caller sees
+the error directly). No new subscription surface — the existing
+`NoydbEventEmitter` API (`db.on`/`db.off`) is used.
+
+Full design: `docs/superpowers/specs/2026-06-20-i18n-v1x-tail-design.md`.
+
 **`I18nMap<Langs, Required>` type helper.** Types the stored locale-map
 from the `required` mode so the compiler forces you to handle an absent
 optional locale (`string | undefined`) instead of silently reading

--- a/docs/superpowers/plans/2026-06-20-i18n-v1x-tail-435.md
+++ b/docs/superpowers/plans/2026-06-20-i18n-v1x-tail-435.md
@@ -1,0 +1,1150 @@
+# i18n v1.x Tail (#435) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the two deferred i18n v1.x items — `densifyOnWrite` (eager-fill empty locale slots from the substitute chain at write time, with internal provenance) and the `i18n:script-violation` typed event channel (surface the `ScriptWarning[]` that script-enforcement already collects but currently discards).
+
+**Architecture:** Both features live behind the tree-shaken `withI18n()` strategy seam (`packages/hub/src/i18n/`); the ceiling-bound kernel files (`collection.ts`/`vault.ts`) hold only thin call sites. **F1 uses the spec's "dense map + prior-read" realization (decision A):** densify writes fill values into the locale map (physically dense), records which slots were filled in an internal `_i18nFilled` marker, and reads the prior record before `enforceScript` so a round-tripped derived copy (e.g. Thai in the `en` slot) is exempt from script enforcement and refreshes when its source changes — without the marker ever leaking to clients. **F2** declares one new channel on the existing `NoydbEventEmitter` and emits where warnings are discarded today.
+
+**Tech Stack:** TypeScript (ESM, `.js` import specifiers), vitest (`vitest run`), the existing `NoydbEventEmitter` / `I18nStrategy` / `resolveI18nText` infrastructure.
+
+**Spec:** [`docs/superpowers/specs/2026-06-20-i18n-v1x-tail-design.md`](../specs/2026-06-20-i18n-v1x-tail-design.md)
+
+---
+
+## File Structure
+
+| File | Create/Modify | Responsibility |
+|---|---|---|
+| `packages/hub/src/types.ts` | Modify | Declare the `'i18n:script-violation'` channel in `NoydbEventMap` |
+| `packages/hub/src/collection.ts` | Modify | F2 emit; F1 prior-read + exempt + densify call sites + `i18nDensifyFields` field + `resolveDensifyPrior` + `i18nProvenance` |
+| `packages/hub/src/i18n/core.ts` | Modify | `densifyOnWrite` option; mutual-exclusion config check in `i18nText()`; strip `_i18nFilled` in `applyI18nLocale()` |
+| `packages/hub/src/i18n/script.ts` | Modify | `enforceScript()` gains an `exempt?` locale set |
+| `packages/hub/src/i18n/densify.ts` | **Create** | Pure `computeExemptFills()` + `densify()` |
+| `packages/hub/src/i18n/strategy.ts` | Modify | `I18nStrategy` interface + `NO_I18N` no-ops for the new methods + `exempt` on `enforceScript` |
+| `packages/hub/src/i18n/active.ts` | Modify | Wire `computeExemptFills`/`densify` into `withI18n()` |
+| `scripts/check-architecture.mjs` | Modify | Raise the `collection.ts` line ceiling |
+| `features.yaml` | Modify | Register both capability nodes (CI "Spec coverage") |
+| `docs/subsystems/*i18n*` | Modify | Document densify write-sequence + the event channel |
+| `showcases/src/*` | Create/Modify | Bilingual showcase exercising densify + a `'filter'`-mode event |
+| `packages/hub/__tests__/i18n-script-violation-event.test.ts` | **Create** | F2 tests |
+| `packages/hub/__tests__/i18n-densify.test.ts` | **Create** | F1 tests (unit + integration) |
+
+**Shared test harness.** Several test tasks reuse the in-memory `NoydbStore` helper. It is defined verbatim in the existing file `packages/hub/__tests__/i18n-script-put.test.ts` lines 12-48 (the `memory()` function). Where a task says "paste the memory() helper", copy that exact block.
+
+---
+
+## Task 1 (F2): `i18n:script-violation` event channel
+
+**Files:**
+- Modify: `packages/hub/src/types.ts` (the `NoydbEventMap` interface, ~lines 1056-1105)
+- Modify: `packages/hub/src/collection.ts:1458-1463`
+- Test: `packages/hub/__tests__/i18n-script-violation-event.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/hub/__tests__/i18n-script-violation-event.test.ts`:
+
+```ts
+/** #435 F2 — i18n:script-violation typed event channel. */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { withI18n } from '../src/i18n/index.js'
+import { i18nText } from '../src/i18n/core.js'
+import type { Noydb } from '../src/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+
+// --- paste the memory() helper from i18n-script-put.test.ts lines 12-48 here ---
+
+interface Co { id: string; name: Record<string, string> }
+async function freshDb(): Promise<Noydb> {
+  return createNoydb({ store: memory(), user: 'a', secret: 'pw-sv-event', i18nStrategy: withI18n() })
+}
+
+describe('i18n:script-violation event', () => {
+  let db: Noydb
+  beforeEach(async () => { db = await freshDb() })
+
+  it("emits for 'warn' mode and stores the value unchanged", async () => {
+    const events: NoydbStore extends never ? never : any[] = []
+    db.on('i18n:script-violation', (e) => events.push(e))
+    const v = await db.openVault('v', { locale: 'th' })
+    const co = v.collection<Co>('co', {
+      i18nFields: { name: i18nText({ languages: ['th', 'en'], required: 'any', script: 'auto', onScriptViolation: 'warn' }) },
+    })
+    await co.put('c1', { id: 'c1', name: { en: 'สมชาย' } }) // Thai in the en slot
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ vault: 'v', collection: 'co', id: 'c1', mode: 'warn' })
+    expect(events[0].warning).toMatchObject({ field: 'name', locale: 'en' })
+    const got = await co.get('c1', { locale: 'raw' })
+    expect((got as any).name.en).toBe('สมชาย') // stored unchanged under 'warn'
+  })
+
+  it("emits for 'filter' mode and strips disallowed chars", async () => {
+    const events: any[] = []
+    db.on('i18n:script-violation', (e) => events.push(e))
+    const v = await db.openVault('v', { locale: 'en' })
+    const co = v.collection<Co>('co', {
+      i18nFields: { name: i18nText({ languages: ['en'], required: 'any', script: { en: ['Latin'] }, onScriptViolation: 'filter' }) },
+    })
+    await co.put('c1', { id: 'c1', name: { en: 'Somสมchai' } })
+    expect(events).toHaveLength(1)
+    expect(events[0].mode).toBe('filter')
+    const got = await co.get('c1', { locale: 'raw' })
+    expect((got as any).name.en).toBe('Somchai') // Thai stripped
+  })
+
+  it("does NOT emit for 'reject' mode (throws instead)", async () => {
+    const events: any[] = []
+    db.on('i18n:script-violation', (e) => events.push(e))
+    const v = await db.openVault('v', { locale: 'th' })
+    const co = v.collection<Co>('co', {
+      i18nFields: { name: i18nText({ languages: ['th', 'en'], required: 'any', script: 'auto' }) }, // default reject
+    })
+    await expect(co.put('c1', { id: 'c1', name: { en: 'สมชาย' } })).rejects.toThrow()
+    expect(events).toHaveLength(0)
+  })
+})
+```
+
+> Note: replace the awkward `NoydbStore extends never ...` type in the first test with a plain `const events: any[] = []` (the import of `ConflictError`/`NoydbStore` etc. is only needed by the pasted `memory()` helper).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `packages/hub`): `npx vitest run __tests__/i18n-script-violation-event.test.ts`
+Expected: FAIL — `db.on('i18n:script-violation', ...)` is a type error / no event fires (events length 0 in the warn/filter cases).
+
+- [ ] **Step 3: Declare the channel in `NoydbEventMap`**
+
+In `packages/hub/src/types.ts`, add the import near the top (after existing imports):
+
+```ts
+import type { ScriptWarning } from './i18n/script.js'
+```
+
+(`import type` — erased at compile, no runtime cycle; `script.ts` does not import `types.ts`.)
+
+Then inside `interface NoydbEventMap { ... }` (after the `'history:prune'` line), add:
+
+```ts
+  /**
+   * A non-fatal i18n script violation under `onScriptViolation: 'warn' | 'filter'`.
+   * 'warn' stored the value as-is; 'filter' stripped disallowed characters
+   * (the event is the only signal the stored data was mutated). 'reject'
+   * throws `ScriptViolationError` and emits nothing. (#435)
+   */
+  'i18n:script-violation': {
+    vault: string
+    collection: string
+    id: string
+    mode: 'warn' | 'filter'
+    warning: ScriptWarning
+  }
+```
+
+- [ ] **Step 4: Emit at the discard site**
+
+In `packages/hub/src/collection.ts`, replace lines 1458-1463:
+
+```ts
+          const { value: cleaned } = this.i18nStrategy.enforceScript(
+            leafMap,
+            field,
+            descriptor,
+          )
+          if (cleaned !== leafMap) Object.assign(leafMap, cleaned)
+```
+
+with:
+
+```ts
+          const { value: cleaned, warnings } = this.i18nStrategy.enforceScript(
+            leafMap,
+            field,
+            descriptor,
+          )
+          if (cleaned !== leafMap) Object.assign(leafMap, cleaned)
+          for (const w of warnings) {
+            this.emitter.emit('i18n:script-violation', {
+              vault: this.vault,
+              collection: this.name,
+              id,
+              mode: descriptor.options.onScriptViolation as 'warn' | 'filter',
+              warning: w,
+            })
+          }
+```
+
+(`warnings` is non-empty only under `'warn'`/`'filter'` — `'reject'` throws inside `enforceScript`, so the cast is sound.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run (from `packages/hub`): `npx vitest run __tests__/i18n-script-violation-event.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/types.ts packages/hub/src/collection.ts packages/hub/__tests__/i18n-script-violation-event.test.ts
+git commit -m "feat(i18n): i18n:script-violation event channel for warn/filter modes (#435)"
+```
+
+---
+
+## Task 2 (F1): `densifyOnWrite` option + mutual-exclusion config check
+
+**Files:**
+- Modify: `packages/hub/src/i18n/core.ts` (`I18nTextOptions` ~line 164; `i18nText()` ~line 195)
+- Test: `packages/hub/__tests__/i18n-densify.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/hub/__tests__/i18n-densify.test.ts` with the config-check tests first:
+
+```ts
+/** #435 F1 — densifyOnWrite. */
+import { describe, it, expect } from 'vitest'
+import { i18nText } from '../src/i18n/core.js'
+
+describe('densifyOnWrite config validation', () => {
+  it('rejects densifyOnWrite + explicit scalar throw policy', () => {
+    expect(() =>
+      i18nText({ languages: ['th', 'en'], required: 'any', densifyOnWrite: true, onMissing: 'throw' }),
+    ).toThrow(/densifyOnWrite/)
+  })
+
+  it('rejects densifyOnWrite + explicit per-layer throw policy', () => {
+    expect(() =>
+      i18nText({ languages: ['th', 'en'], required: 'any', densifyOnWrite: true, onMissing: { mv: 'throw' } }),
+    ).toThrow(/densifyOnWrite/)
+  })
+
+  it('allows densifyOnWrite with no explicit onMissing (default throw is fine)', () => {
+    expect(() =>
+      i18nText({ languages: ['th', 'en'], required: 'any', densifyOnWrite: true }),
+    ).not.toThrow()
+  })
+
+  it('allows densifyOnWrite with an explicit non-throw policy', () => {
+    expect(() =>
+      i18nText({ languages: ['th', 'en'], required: 'any', densifyOnWrite: true, onMissing: 'substitute' }),
+    ).not.toThrow()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `packages/hub`): `npx vitest run __tests__/i18n-densify.test.ts`
+Expected: FAIL — `densifyOnWrite` is not a known option (type error) and `i18nText` does not throw.
+
+- [ ] **Step 3: Add the option**
+
+In `packages/hub/src/i18n/core.ts`, inside `interface I18nTextOptions`, after the `onScriptViolation` field (~line 164):
+
+```ts
+  /**
+   * #435 v1.x — eager-fill empty locale slots from the substitute chain at
+   * write time, recording provenance in the internal `_i18nFilled` marker.
+   * Mutually exclusive with an EXPLICIT `'throw'` onMissing policy (densify
+   * fills every hole, so a throw would be unreachable). Without an explicit
+   * `substitute`, fills from `'any'` (first non-empty). Default absent.
+   */
+  readonly densifyOnWrite?: boolean
+```
+
+- [ ] **Step 4: Add the config-time check to `i18nText()`**
+
+In `packages/hub/src/i18n/core.ts`, replace the `i18nText` factory (lines 195-197):
+
+```ts
+export function i18nText(options: I18nTextOptions): I18nTextDescriptor {
+  return { _noydbI18nText: true, options }
+}
+```
+
+with:
+
+```ts
+export function i18nText(options: I18nTextOptions): I18nTextDescriptor {
+  if (options.densifyOnWrite === true && hasThrowPolicy(options.onMissing)) {
+    throw new Error(
+      `i18nText: densifyOnWrite cannot be combined with an explicit onMissing 'throw' ` +
+        `policy — densify fills every empty slot, so a 'throw' would be unreachable. ` +
+        `Remove the 'throw' policy or disable densifyOnWrite.`,
+    )
+  }
+  return { _noydbI18nText: true, options }
+}
+
+/** True when `onMissing` declares `'throw'` for any layer (scalar or per-layer). */
+function hasThrowPolicy(onMissing: OnMissingPolicy | undefined): boolean {
+  if (onMissing === undefined) return false
+  if (typeof onMissing === 'string') return onMissing === 'throw'
+  return Object.values(onMissing).includes('throw')
+}
+```
+
+(`OnMissingPolicy` is already imported in `core.ts` — it types the existing `onMissing` field.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run (from `packages/hub`): `npx vitest run __tests__/i18n-densify.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/i18n/core.ts packages/hub/__tests__/i18n-densify.test.ts
+git commit -m "feat(i18n): densifyOnWrite option + throw-policy mutual-exclusion check (#435)"
+```
+
+---
+
+## Task 3 (F1): `enforceScript()` gains an `exempt` locale set
+
+**Files:**
+- Modify: `packages/hub/src/i18n/script.ts:138-167`
+- Modify: `packages/hub/src/i18n/strategy.ts` (the `enforceScript` method in `I18nStrategy`)
+- Test: append to `packages/hub/__tests__/i18n-script.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/hub/__tests__/i18n-script.test.ts` (inside the top-level `describe`, or add a new `describe`):
+
+```ts
+import { enforceScript } from '../src/i18n/script.js'
+import { i18nText as i18nTextForExempt } from '../src/i18n/core.js'
+
+describe('enforceScript exempt set (#435)', () => {
+  const d = i18nTextForExempt({ languages: ['th', 'en'], required: 'any', script: 'auto' })
+
+  it('throws on Thai in the en slot without exempt', () => {
+    expect(() => enforceScript({ th: 'สมชาย', en: 'สมชาย' }, 'name', d)).toThrow()
+  })
+
+  it('skips an exempt locale (a known fill)', () => {
+    expect(() => enforceScript({ th: 'สมชาย', en: 'สมชาย' }, 'name', d, new Set(['en']))).not.toThrow()
+  })
+})
+```
+
+(If `i18n-script.test.ts` already imports `enforceScript`/`i18nText`, reuse those imports instead of the aliased ones.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `packages/hub`): `npx vitest run __tests__/i18n-script.test.ts`
+Expected: FAIL — `enforceScript` rejects the 4th argument (type error) / still throws with the exempt set.
+
+- [ ] **Step 3: Add the `exempt` parameter**
+
+In `packages/hub/src/i18n/script.ts`, change the `enforceScript` signature and loop (lines 138-164):
+
+```ts
+export function enforceScript(
+  value: Record<string, unknown>,
+  field: string,
+  descriptor: I18nTextDescriptor,
+  exempt?: ReadonlySet<string>,
+): { value: Record<string, unknown>; warnings: ScriptWarning[] } {
+  const opt = descriptor.options
+  if (!opt.script) return { value, warnings: [] }
+
+  const mode = opt.onScriptViolation ?? 'reject'
+  const warnings: ScriptWarning[] = []
+  let out = value
+
+  for (const [locale, raw] of Object.entries(value)) {
+    if (exempt?.has(locale)) continue
+    if (typeof raw !== 'string') continue
+    const allowed = allowedFor(descriptor, locale)
+    if (fullMatcher(allowed).test(raw)) continue
+
+    const sample = offendingSample(raw, allowed)
+    if (mode === 'reject') {
+      throw new ScriptViolationError(field, locale, allowed, sample)
+    }
+    warnings.push({ field, locale, expected: allowed, sample })
+    if (mode === 'filter') {
+      if (out === value) out = { ...value }
+      out[locale] = stripDisallowed(raw, allowed)
+    }
+  }
+
+  return { value: out, warnings }
+}
+```
+
+- [ ] **Step 4: Update the `I18nStrategy.enforceScript` signature**
+
+In `packages/hub/src/i18n/strategy.ts`, update the `enforceScript` method declaration in the `I18nStrategy` interface to include the optional param:
+
+```ts
+  enforceScript(
+    value: Record<string, unknown>,
+    field: string,
+    descriptor: I18nTextDescriptor,
+    exempt?: ReadonlySet<string>,
+  ): { value: Record<string, unknown>; warnings: ScriptWarning[] }
+```
+
+(The `NO_I18N` stub `enforceScript(value) { return { value, warnings: [] } }` already ignores extra args — leave it.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run (from `packages/hub`): `npx vitest run __tests__/i18n-script.test.ts`
+Expected: PASS (existing tests + 2 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/i18n/script.ts packages/hub/src/i18n/strategy.ts packages/hub/__tests__/i18n-script.test.ts
+git commit -m "feat(i18n): enforceScript exempt locale set for known densify fills (#435)"
+```
+
+---
+
+## Task 4 (F1): `densify.ts` module — `computeExemptFills` + `densify`
+
+**Files:**
+- Create: `packages/hub/src/i18n/densify.ts`
+- Test: append to `packages/hub/__tests__/i18n-densify.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/hub/__tests__/i18n-densify.test.ts`:
+
+```ts
+import { computeExemptFills, densify } from '../src/i18n/densify.js'
+
+describe('densify (pure)', () => {
+  const fields = {
+    name: i18nText({ languages: ['th', 'en'], required: 'any', substitute: ['en', 'th'], densifyOnWrite: true }),
+  }
+
+  it('fills empty slots and records provenance (insert)', () => {
+    const rec: any = { id: 'c1', name: { th: 'สมชาย' } }
+    densify(rec, undefined, fields)
+    expect(rec.name).toEqual({ th: 'สมชาย', en: 'สมชาย' })
+    expect(rec._i18nFilled).toEqual({ name: ['en'] })
+  })
+
+  it('refreshes an unchanged round-tripped fill when the source changed', () => {
+    const prior: any = { name: { th: 'สมชาย', en: 'สมชาย' }, _i18nFilled: { name: ['en'] } }
+    const rec: any = { id: 'c1', name: { th: 'สมชัย', en: 'สมชาย' } } // th corrected, en still old fill
+    densify(rec, prior, fields)
+    expect(rec.name.en).toBe('สมชัย')
+    expect(rec._i18nFilled).toEqual({ name: ['en'] })
+  })
+
+  it('clears the marker when a slot becomes authored (no clobber)', () => {
+    const prior: any = { name: { th: 'สมชาย', en: 'สมชาย' }, _i18nFilled: { name: ['en'] } }
+    const rec: any = { id: 'c1', name: { th: 'สมชาย', en: 'Somchai' } } // real en authored
+    densify(rec, prior, fields)
+    expect(rec.name.en).toBe('Somchai')
+    expect(rec._i18nFilled).toBeUndefined()
+  })
+
+  it('computeExemptFills exempts unchanged fills, not changed slots', () => {
+    const prior: any = { name: { th: 'สมชาย', en: 'สมชาย' }, _i18nFilled: { name: ['en'] } }
+    expect(computeExemptFills(prior, { name: { th: 'สมชัย', en: 'สมชาย' } }, fields).get('name')).toEqual(new Set(['en']))
+    expect(computeExemptFills(prior, { name: { th: 'สมชาย', en: 'Somchai' } }, fields).get('name')).toBeUndefined()
+    expect(computeExemptFills(undefined, { name: { th: 'สมชาย' } }, fields).size).toBe(0)
+  })
+
+  it('fills nothing when there is no source value', () => {
+    const rec: any = { id: 'c1' } // name absent
+    densify(rec, undefined, fields)
+    expect(rec._i18nFilled).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `packages/hub`): `npx vitest run __tests__/i18n-densify.test.ts`
+Expected: FAIL — `../src/i18n/densify.js` does not exist.
+
+- [ ] **Step 3: Create the module**
+
+Create `packages/hub/src/i18n/densify.ts`:
+
+```ts
+/**
+ * #435 v1.x densifyOnWrite — eager-fill empty i18n slots from each field's
+ * substitute chain at write time, recording provenance in the internal
+ * `_i18nFilled` marker (decision A: dense map + prior-read).
+ *
+ * Pure functions over plain records; all DB wiring lives in collection.ts.
+ * Only single-leaf i18n fields are supported (array-wildcard paths are
+ * skipped, mirroring auto-translate).
+ */
+import { getAtPath, resolveI18nText } from './core.js'
+import type { I18nTextDescriptor } from './core.js'
+
+const MARKER = '_i18nFilled'
+
+type Leaf = Record<string, string>
+
+/** Locales recorded as densify-filled on the prior record for `field`. */
+function priorFilled(prior: Record<string, unknown> | undefined, field: string): Set<string> {
+  if (!prior) return new Set()
+  const marker = prior[MARKER] as Record<string, string[]> | undefined
+  return new Set(marker?.[field] ?? [])
+}
+
+/** The single leaf map for `field`, or undefined for absent / array-wildcard / non-object. */
+function singleLeaf(record: Record<string, unknown>, field: string): Leaf | undefined {
+  const leaves = getAtPath(record, field)
+  if (leaves.length !== 1) return undefined
+  const leaf = leaves[0]
+  if (!leaf || typeof leaf !== 'object' || Array.isArray(leaf)) return undefined
+  return leaf as Leaf
+}
+
+/**
+ * Per field, the locales that are UNCHANGED round-tripped densify fills — i.e.
+ * marked filled on the prior record AND identical in the incoming record.
+ * These are exempt from write-time script enforcement (they are derived copies,
+ * not authored text). Slots the user changed are NOT exempt (validated as authored).
+ */
+export function computeExemptFills(
+  prior: Record<string, unknown> | undefined,
+  incoming: Record<string, unknown>,
+  fields: Record<string, I18nTextDescriptor>,
+): Map<string, Set<string>> {
+  const out = new Map<string, Set<string>>()
+  if (!prior) return out
+  for (const field of Object.keys(fields)) {
+    const filled = priorFilled(prior, field)
+    if (filled.size === 0) continue
+    const priorLeaf = singleLeaf(prior, field)
+    const incLeaf = singleLeaf(incoming, field)
+    if (!priorLeaf || !incLeaf) continue
+    const exempt = new Set<string>()
+    for (const loc of filled) {
+      if (incLeaf[loc] !== undefined && incLeaf[loc] !== '' && incLeaf[loc] === priorLeaf[loc]) {
+        exempt.add(loc)
+      }
+    }
+    if (exempt.size > 0) out.set(field, exempt)
+  }
+  return out
+}
+
+/**
+ * Mutate `record` in place: fill empty declared-language slots for each
+ * densify-enabled field from the field's substitute chain, recompute unchanged
+ * prior fills, clear marks for slots that became authored, and write the
+ * resulting `_i18nFilled` marker (removed when empty).
+ */
+export function densify(
+  record: Record<string, unknown>,
+  prior: Record<string, unknown> | undefined,
+  fields: Record<string, I18nTextDescriptor>,
+): void {
+  let marker = record[MARKER] as Record<string, string[]> | undefined
+
+  for (const [field, descriptor] of Object.entries(fields)) {
+    const leaf = singleLeaf(record, field)
+    if (!leaf) continue
+    const { languages, substitute, smartSubstitute } = descriptor.options
+    const filledSet = priorFilled(prior, field)
+    const priorLeaf = singleLeaf(prior ?? {}, field)
+    const isUnchangedFill = (loc: string): boolean =>
+      filledSet.has(loc) && priorLeaf?.[loc] !== undefined && leaf[loc] === priorLeaf[loc]
+
+    // Authored source = present, non-empty, NOT an unchanged prior fill.
+    const authored: Leaf = {}
+    for (const [loc, val] of Object.entries(leaf)) {
+      if (typeof val === 'string' && val !== '' && !isUnchangedFill(loc)) authored[loc] = val
+    }
+
+    const filled: string[] = []
+    for (const loc of languages) {
+      if (authored[loc] !== undefined) continue // real value present → not a fill
+      const sub = resolveI18nText(authored, loc, undefined, field, {
+        policy: 'substitute',
+        substitute: substitute ?? ['any'],
+        ...(smartSubstitute ? { smartSubstitute } : {}),
+      })
+      if (typeof sub === 'string' && sub !== '') {
+        leaf[loc] = sub
+        filled.push(loc)
+      } else if (isUnchangedFill(loc)) {
+        delete leaf[loc] // stale fill with no source left → drop it
+      }
+    }
+
+    if (filled.length > 0) {
+      marker ??= {}
+      marker[field] = filled
+    } else if (marker) {
+      delete marker[field]
+    }
+  }
+
+  if (marker && Object.keys(marker).length > 0) {
+    record[MARKER] = marker
+  } else {
+    delete record[MARKER]
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run (from `packages/hub`): `npx vitest run __tests__/i18n-densify.test.ts`
+Expected: PASS (4 config + 5 pure-densify tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/i18n/densify.ts packages/hub/__tests__/i18n-densify.test.ts
+git commit -m "feat(i18n): densify.ts — computeExemptFills + densify pure functions (#435)"
+```
+
+---
+
+## Task 5 (F1): Wire densify into the `I18nStrategy`
+
+**Files:**
+- Modify: `packages/hub/src/i18n/strategy.ts` (interface + `NO_I18N`)
+- Modify: `packages/hub/src/i18n/active.ts` (`withI18n()`)
+- Test: append to `packages/hub/__tests__/i18n-densify.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/hub/__tests__/i18n-densify.test.ts`:
+
+```ts
+import { withI18n } from '../src/i18n/index.js'
+import { NO_I18N } from '../src/i18n/strategy.js'
+
+describe('densify wired into the strategy', () => {
+  const fields = { name: i18nText({ languages: ['th', 'en'], required: 'any', substitute: ['en', 'th'], densifyOnWrite: true }) }
+
+  it('withI18n().densify fills slots', () => {
+    const rec: any = { id: 'c1', name: { th: 'สมชาย' } }
+    withI18n().densify(rec, undefined, fields)
+    expect(rec.name.en).toBe('สมชาย')
+  })
+
+  it('NO_I18N densify is a no-op and computeExemptFills is empty', () => {
+    const rec: any = { id: 'c1', name: { th: 'สมชาย' } }
+    NO_I18N.densify(rec, undefined, fields)
+    expect(rec._i18nFilled).toBeUndefined()
+    expect(NO_I18N.computeExemptFills(undefined, rec, fields).size).toBe(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `packages/hub`): `npx vitest run __tests__/i18n-densify.test.ts`
+Expected: FAIL — `densify`/`computeExemptFills` are not on the strategy.
+
+- [ ] **Step 3: Add the methods to the interface**
+
+In `packages/hub/src/i18n/strategy.ts`, inside the `I18nStrategy` interface (after `enforceScript`), add:
+
+```ts
+  /**
+   * Per-field locales that are unchanged round-tripped densify fills (exempt
+   * from write-time script enforcement). Empty under NO_I18N. (#435)
+   */
+  computeExemptFills(
+    prior: Record<string, unknown> | undefined,
+    incoming: Record<string, unknown>,
+    fields: Record<string, I18nTextDescriptor>,
+  ): Map<string, Set<string>>
+
+  /**
+   * Eager-fill empty i18n slots from each field's substitute chain and record
+   * provenance in `record['_i18nFilled']`. Mutates `record`. No-op under
+   * NO_I18N. (#435)
+   */
+  densify(
+    record: Record<string, unknown>,
+    prior: Record<string, unknown> | undefined,
+    fields: Record<string, I18nTextDescriptor>,
+  ): void
+```
+
+- [ ] **Step 4: Add `NO_I18N` no-ops**
+
+In `packages/hub/src/i18n/strategy.ts`, inside the `NO_I18N` object literal, add:
+
+```ts
+  computeExemptFills() { return new Map() },
+  densify() {},
+```
+
+- [ ] **Step 5: Wire `withI18n()`**
+
+In `packages/hub/src/i18n/active.ts`, add to the imports:
+
+```ts
+import { computeExemptFills, densify } from './densify.js'
+```
+
+and add `computeExemptFills,` and `densify,` to the object returned by `withI18n()` (next to `enforceScript,`).
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run (from `packages/hub`): `npx vitest run __tests__/i18n-densify.test.ts`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/hub/src/i18n/strategy.ts packages/hub/src/i18n/active.ts packages/hub/__tests__/i18n-densify.test.ts
+git commit -m "feat(i18n): wire densify/computeExemptFills into I18nStrategy (#435)"
+```
+
+---
+
+## Task 6 (F1): Strip `_i18nFilled` from read output in `applyI18nLocale`
+
+**Files:**
+- Modify: `packages/hub/src/i18n/core.ts:547-570`
+- Test: append to `packages/hub/__tests__/i18n-densify.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/hub/__tests__/i18n-densify.test.ts`:
+
+```ts
+import { applyI18nLocale } from '../src/i18n/core.js'
+
+describe('applyI18nLocale strips the _i18nFilled marker (#435)', () => {
+  const fields = { name: i18nText({ languages: ['th', 'en'], required: 'any' }) }
+
+  it('removes _i18nFilled from output without mutating the input', () => {
+    const rec: any = { id: 'c1', name: { th: 'A', en: 'A' }, _i18nFilled: { name: ['en'] } }
+    const out: any = applyI18nLocale(rec, fields, 'raw')
+    expect('_i18nFilled' in out).toBe(false)
+    expect(rec._i18nFilled).toEqual({ name: ['en'] }) // input untouched
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `packages/hub`): `npx vitest run __tests__/i18n-densify.test.ts`
+Expected: FAIL — `'_i18nFilled' in out` is `true`.
+
+- [ ] **Step 3: Add the strip**
+
+In `packages/hub/src/i18n/core.ts`, in `applyI18nLocale`, replace the final `return result` (line ~569) with:
+
+```ts
+  // #435 — the internal densify provenance marker never leaves the store.
+  if (Object.prototype.hasOwnProperty.call(result, '_i18nFilled')) {
+    const { _i18nFilled: _omit, ...rest } = result
+    result = rest
+  }
+
+  return result
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run (from `packages/hub`): `npx vitest run __tests__/i18n-densify.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/i18n/core.ts packages/hub/__tests__/i18n-densify.test.ts
+git commit -m "feat(i18n): strip internal _i18nFilled marker from read output (#435)"
+```
+
+---
+
+## Task 7 (F1): Collection wiring — prior-read, densify call, audit accessor
+
+**Files:**
+- Modify: `packages/hub/src/collection.ts` (field decl ~314; constructor ~881; write path ~1444/1458/1473; new private methods)
+- Test: append integration tests to `packages/hub/__tests__/i18n-densify.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/hub/__tests__/i18n-densify.test.ts` (add the imports + `memory()` helper at the top of the file if not already present — paste the `memory()` block from `i18n-script-put.test.ts` lines 12-48, plus `import { createNoydb } from '../src/noydb.js'`, `import type { Noydb } from '../src/noydb.js'`, and the store types):
+
+```ts
+interface Co { id: string; name: Record<string, string> }
+async function densDb(): Promise<Noydb> {
+  return createNoydb({ store: memory(), user: 'a', secret: 'pw-densify', i18nStrategy: withI18n() })
+}
+
+describe('densifyOnWrite (integration)', () => {
+  it('fills en from th, hides the marker, exposes it via i18nProvenance', async () => {
+    const db = await densDb()
+    const v = await db.openVault('v', { locale: 'en' })
+    const co = v.collection<Co>('co', {
+      i18nFields: { name: i18nText({ languages: ['th', 'en'], required: 'any', substitute: ['en', 'th'], densifyOnWrite: true }) },
+    })
+    await co.put('c1', { id: 'c1', name: { th: 'สมชาย' } })
+    expect((await co.get('c1') as any).name).toBe('สมชาย') // en reader sees the fill
+    const raw = await co.get('c1', { locale: 'raw' })
+    expect('_i18nFilled' in (raw as any)).toBe(false)
+    expect((raw as any).name).toEqual({ th: 'สมชาย', en: 'สมชาย' }) // dense
+    expect(await co.i18nProvenance('c1')).toEqual({ name: ['en'] })
+  })
+
+  it('refreshes on source change and does not clobber an authored value (the round-trip proof)', async () => {
+    const db = await densDb()
+    const v = await db.openVault('v', { locale: 'en' })
+    const co = v.collection<Co>('co', {
+      i18nFields: { name: i18nText({ languages: ['th', 'en'], required: 'any', substitute: ['en', 'th'], densifyOnWrite: true, script: 'auto' }) },
+    })
+    await co.put('c1', { id: 'c1', name: { th: 'สมชาย' } }) // en filled = สมชาย (Thai)
+    // round-trip a raw read (marker stripped), correct th, write back
+    const r1 = await co.get('c1', { locale: 'raw' })
+    await co.put('c1', { id: 'c1', name: { ...(r1 as any).name, th: 'สมชัย' } })
+    const r2 = await co.get('c1', { locale: 'raw' })
+    expect((r2 as any).name.en).toBe('สมชัย') // refreshed, NOT script-rejected
+    expect(await co.i18nProvenance('c1')).toEqual({ name: ['en'] })
+    // author a real English value
+    await co.put('c1', { id: 'c1', name: { th: 'สมชัย', en: 'Somchai' } })
+    const r3 = await co.get('c1', { locale: 'raw' })
+    expect((r3 as any).name.en).toBe('Somchai')
+    expect(await co.i18nProvenance('c1')).toBeUndefined() // marker cleared
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run (from `packages/hub`): `npx vitest run __tests__/i18n-densify.test.ts`
+Expected: FAIL — `co.i18nProvenance` is undefined / the dense map / refresh assertions fail.
+
+- [ ] **Step 3: Add the `i18nDensifyFields` field**
+
+In `packages/hub/src/collection.ts`, after the `i18nFields` field declaration (~line 314):
+
+```ts
+  private readonly i18nDensifyFields: Record<string, I18nTextDescriptor> | undefined
+```
+
+- [ ] **Step 4: Populate it in the constructor**
+
+In `packages/hub/src/collection.ts`, after `this.i18nFields = opts.i18nFields` (~line 881):
+
+```ts
+    // #435 — precompute the densify-enabled subset (undefined when none opt in)
+    // so the write path skips work for non-densify collections.
+    const densifyFields = opts.i18nFields
+      ? Object.fromEntries(
+          Object.entries(opts.i18nFields).filter(([, d]) => d.options.densifyOnWrite === true),
+        )
+      : {}
+    this.i18nDensifyFields =
+      Object.keys(densifyFields).length > 0 ? densifyFields : undefined
+```
+
+- [ ] **Step 5: Prior-read + exempt before `enforceScript`**
+
+In `packages/hub/src/collection.ts`, immediately before the `// i18nText script enforcement` comment (~line 1445), insert:
+
+```ts
+    // #435 densifyOnWrite (decision A): read prior fills so a round-tripped
+    // derived copy is exempt from script enforcement and can be refreshed.
+    // `densifyPrior` is read once here and reused by densify() below.
+    let densifyPrior: Record<string, unknown> | undefined
+    let exemptFills: Map<string, Set<string>> | undefined
+    if (this.i18nDensifyFields) {
+      densifyPrior = await this.resolveDensifyPrior(id)
+      exemptFills = this.i18nStrategy.computeExemptFills(
+        densifyPrior,
+        record as Record<string, unknown>,
+        this.i18nDensifyFields,
+      )
+    }
+```
+
+Then change the `enforceScript` call (from Task 1) to pass the exempt set — replace:
+
+```ts
+          const { value: cleaned, warnings } = this.i18nStrategy.enforceScript(
+            leafMap,
+            field,
+            descriptor,
+          )
+```
+
+with:
+
+```ts
+          const { value: cleaned, warnings } = this.i18nStrategy.enforceScript(
+            leafMap,
+            field,
+            descriptor,
+            exemptFills?.get(field),
+          )
+```
+
+- [ ] **Step 6: Densify after required-validation**
+
+In `packages/hub/src/collection.ts`, immediately after the `this.i18nPutValidator(record)` block (~line 1473), insert:
+
+```ts
+    // #435 — eager-fill empty slots + record provenance. Runs AFTER the
+    // authored gates (required + script) so only authored slots are validated;
+    // filled slots are recorded in the internal `_i18nFilled` marker.
+    if (this.i18nDensifyFields) {
+      this.i18nStrategy.densify(
+        record as Record<string, unknown>,
+        densifyPrior,
+        this.i18nDensifyFields,
+      )
+    }
+```
+
+- [ ] **Step 7: Add the `resolveDensifyPrior` + `i18nProvenance` methods**
+
+In `packages/hub/src/collection.ts`, add two private/public methods near the other put-related helpers (e.g. right after the `put` method body closes):
+
+```ts
+  /**
+   * #435 — resolve the prior stored record (with its `_i18nFilled` marker) for
+   * densify. Eager: in-memory cache; lazy: LRU then adapter. undefined if absent.
+   */
+  private async resolveDensifyPrior(id: string): Promise<Record<string, unknown> | undefined> {
+    if (this.lazy && this.lru) {
+      const cached = this.lru.get(id)
+      if (cached) return cached.record as Record<string, unknown>
+      const env = await this.adapter.get(this.vault, this.name, id)
+      if (!env) return undefined
+      const rec = await this.decryptRecord(env)
+      return rec === null ? undefined : (rec as Record<string, unknown>)
+    }
+    await this.ensureHydrated()
+    return this.cache.get(id)?.record as Record<string, unknown> | undefined
+  }
+
+  /**
+   * #435 — densify provenance for a record: which i18n slots were auto-filled,
+   * e.g. `{ name: ['en'] }`. undefined when nothing was filled. The marker is
+   * stripped from ordinary reads; this is the sanctioned audit accessor.
+   */
+  async i18nProvenance(id: string): Promise<Record<string, readonly string[]> | undefined> {
+    const prior = await this.resolveDensifyPrior(id)
+    const marker = prior?.['_i18nFilled'] as Record<string, string[]> | undefined
+    return marker && Object.keys(marker).length > 0 ? marker : undefined
+  }
+```
+
+> **Verify while implementing:** the non-CRDT write path's `cache.set(id, { record, ... })` stores the *post-densify* `record` (densify mutates the same object encrypted at line ~1645). If the eager cache turns out to hold a pre-densify copy, change `i18nProvenance`/`resolveDensifyPrior`'s eager branch to read+decrypt via `this.adapter.get` instead of `this.cache`. The integration test's `i18nProvenance` assertions catch this.
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run (from `packages/hub`): `npx vitest run __tests__/i18n-densify.test.ts`
+Expected: PASS (all densify tests, including the round-trip proof).
+
+- [ ] **Step 9: Run the full hub suite (regression check)**
+
+Run (from `packages/hub`): `npx vitest run`
+Expected: PASS — no existing i18n/collection test regresses (zero-breaking-change).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/hub/src/collection.ts packages/hub/__tests__/i18n-densify.test.ts
+git commit -m "feat(i18n): wire densifyOnWrite into Collection.put + i18nProvenance accessor (#435)"
+```
+
+---
+
+## Task 8: Raise the `collection.ts` line ceiling
+
+**Files:**
+- Modify: `scripts/check-architecture.mjs:487`
+
+- [ ] **Step 1: Run the architecture check to see the overflow**
+
+Run (from repo root): `node scripts/check-architecture.mjs`
+Expected: FAIL — `packages/hub/src/collection.ts` exceeds 4830.
+
+- [ ] **Step 2: Measure the new line count**
+
+Run (from repo root): `wc -l packages/hub/src/collection.ts`
+Note the number (call it `N`).
+
+- [ ] **Step 3: Raise the ceiling**
+
+In `scripts/check-architecture.mjs`, change line 487 from:
+
+```js
+  'packages/hub/src/collection.ts': 4830,
+```
+
+to `N + 10` (small headroom), e.g. if `wc -l` reports 4851, set:
+
+```js
+  'packages/hub/src/collection.ts': 4861,
+```
+
+(Leave `vault.ts: 4546` untouched — this plan does not modify `vault.ts`.)
+
+- [ ] **Step 4: Run the architecture check to verify it passes**
+
+Run (from repo root): `node scripts/check-architecture.mjs`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check-architecture.mjs
+git commit -m "chore(arch): raise collection.ts ceiling for densifyOnWrite wiring (#435)"
+```
+
+---
+
+## Task 9: Register both capabilities in `features.yaml`
+
+**Files:**
+- Modify: `features.yaml`
+
+- [ ] **Step 1: Inspect the existing i18n entries**
+
+Run (from repo root): `grep -n "i18n\|script\|spec:" features.yaml | head -40`
+Open `features.yaml` and locate an existing i18n capability node (e.g. the script-enforcement or onMissing node from #283/#285) to copy its exact schema (field names, indentation).
+
+- [ ] **Step 2: Add two nodes matching that schema**
+
+Add a node for `densifyOnWrite` and a node for `i18n:script-violation`, each with:
+- `spec: docs/superpowers/specs/2026-06-20-i18n-v1x-tail-design.md`
+- artefacts pointing at:
+  - densify: `packages/hub/src/i18n/densify.ts`, `packages/hub/src/i18n/core.ts`
+  - event: `packages/hub/src/types.ts`, `packages/hub/src/collection.ts`
+- `showcase:` → the showcase file created in Task 11
+- `doc:` → the subsystem doc updated in Task 10
+- tests: `packages/hub/__tests__/i18n-densify.test.ts`, `packages/hub/__tests__/i18n-script-violation-event.test.ts`
+
+Use the SAME keys the neighboring i18n node uses — do not invent fields.
+
+- [ ] **Step 3: Run the spec-coverage check**
+
+Run (from repo root): the spec-coverage / features check (find it: `grep -rn "Spec coverage\|features.yaml" scripts .github/workflows | head`). Run that script.
+Expected: PASS — no dangling refs.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add features.yaml
+git commit -m "chore(features): register densifyOnWrite + i18n:script-violation (#435)"
+```
+
+---
+
+## Task 10: Subsystem documentation
+
+**Files:**
+- Modify: the i18n subsystem doc under `docs/subsystems/` (find it: `grep -rln "i18nText\|onMissing" docs/subsystems`)
+
+- [ ] **Step 1: Add the densify write-sequence subsection**
+
+Append an `### densifyOnWrite` section containing the write-order list and the worked round-trip table from the spec (§ F1), and these key rules:
+- fills empty declared-language slots from the substitute chain (`substitute ?? ['any']`) at write time;
+- provenance recorded in the internal `_i18nFilled` marker, stripped from reads, read via `collection.i18nProvenance(id)`;
+- mutually exclusive with an explicit `onMissing: 'throw'` (config-time error);
+- decision A: prior-read before `enforceScript` so round-tripped fills are exempt and refresh on source change.
+
+- [ ] **Step 2: Add the event-channel subsection**
+
+Append an `### i18n:script-violation event` section: the payload shape (`{ vault, collection, id, mode, warning }`), that it fires for `'warn'` and `'filter'` (not `'reject'`), and the `db.on('i18n:script-violation', …)` subscribe example.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/subsystems
+git commit -m "docs(i18n): document densifyOnWrite + i18n:script-violation (#435)"
+```
+
+---
+
+## Task 11: Showcase
+
+**Files:**
+- Create/Modify: a showcase under `showcases/src/` (find the i18n showcase: `grep -rln "i18nText" showcases/src | head`)
+
+- [ ] **Step 1: Add a densify + event showcase**
+
+Add a showcase that:
+1. Opens a vault, declares a collection with `i18nFields: { name: i18nText({ languages:['th','en'], required:'any', substitute:['en','th'], densifyOnWrite:true, script:'auto', onScriptViolation:'filter' }) }`.
+2. Subscribes `db.on('i18n:script-violation', e => log(...))`.
+3. `put`s `{ name: { th: 'สมชาย' } }`, reads in `en` (shows the fill), prints `co.i18nProvenance(id)` (`{ name: ['en'] }`).
+4. `put`s a value with mixed-script text to trigger a `'filter'` event, and logs the emitted event.
+
+Mirror the structure/registration of the existing i18n showcase you found (each showcase is typically a numbered module exported from the showcases index).
+
+- [ ] **Step 2: Run the showcase the way the repo runs them**
+
+Find the run command (`grep -n "showcase" package.json showcases/package.json 2>/dev/null`) and run the new showcase.
+Expected: it prints the fill, the provenance `{ name: ['en'] }`, and the filter event.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add showcases
+git commit -m "docs(showcase): densifyOnWrite + i18n:script-violation walkthrough (#435)"
+```
+
+---
+
+## Task 12: Final verification
+
+- [ ] **Step 1: Full hub test suite**
+
+Run (from `packages/hub`): `npx vitest run`
+Expected: PASS (all tests, including the new F1/F2 files and all pre-existing i18n conformance).
+
+- [ ] **Step 2: Typecheck**
+
+Find and run the repo typecheck (`grep -n "typecheck\|tsc" package.json packages/hub/package.json`). Run it.
+Expected: PASS — no type errors (notably the `NoydbEventMap` channel and the new strategy methods).
+
+- [ ] **Step 3: Lint**
+
+Find and run lint (`grep -n "lint" package.json`). Run it.
+Expected: PASS.
+
+- [ ] **Step 4: Architecture check**
+
+Run (from repo root): `node scripts/check-architecture.mjs`
+Expected: PASS (ceiling raised in Task 8).
+
+- [ ] **Step 5: Tree-shaking / NO_I18N bundle**
+
+Confirm the default (no-i18n) path pays nothing: find the bundle/size check (`grep -rn "bundle\|size-limit\|NO_I18N" scripts package.json | head`). Verify the `NO_I18N` default bundle size is unchanged vs. `main` (all new logic is inside `withI18n()` / `densify.ts`, reached only when a field opts in). If there is no automated size check, confirm by inspection that `collection.ts` densify code is guarded by `this.i18nDensifyFields` (undefined unless a field sets `densifyOnWrite`).
+
+- [ ] **Step 6: Final commit (if any docs/cleanup remain)**
+
+```bash
+git add -A
+git commit -m "chore(i18n): finalize v1.x tail — densifyOnWrite + script-violation event (#435)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- F1 `densifyOnWrite` option → Task 2. ✓
+- Provenance marker `_i18nFilled` (internal, stripped) → Tasks 4 (write), 6 (strip), 7 (audit accessor). ✓
+- Write ordering (auto-translate → exempt → enforceScript → required → densify) → Task 7 steps 5/6. ✓
+- Refresh mechanism A (prior-read before enforceScript) → Task 7 step 5 + `resolveDensifyPrior` step 7. ✓
+- Script-exemption of round-tripped fills → Task 3 (`exempt`) + Task 4 (`computeExemptFills`) + Task 7. ✓
+- Mutual-exclusion config error → Task 2 step 4. ✓
+- `substitute ?? ['any']` default → Task 4 (`densify`). ✓
+- F2 channel + emit for warn/filter, not reject → Task 1. ✓
+- Tree-shaking / NO_I18N no-ops → Task 5 + Task 12 step 5. ✓
+- features.yaml, subsystem doc, showcase, conformance on memory store, ceiling → Tasks 8–12. ✓
+- Single-leaf-only limitation (array-wildcard skipped) → documented in `densify.ts` + Task 10. ✓
+
+**2. Placeholder scan:** All code steps show full code; commands have expected output. The only "find the script" steps (typecheck/lint/features-coverage/bundle/showcase-run) are because those command names are repo-conventions the executor confirms from `package.json` — each gives the exact `grep` to locate it. No `TBD`/"handle edge cases"/"write tests for the above".
+
+**3. Type consistency:** `computeExemptFills(prior, incoming, fields) → Map<string, Set<string>>` and `densify(record, prior, fields) → void` are identical across `densify.ts` (Task 4), the `I18nStrategy` interface (Task 5), and the `collection.ts` call sites (Task 7). `enforceScript`'s 4th param `exempt?: ReadonlySet<string>` matches in `script.ts` (Task 3), the interface (Task 3 step 4), and the call site (Task 7 step 5, passing `exemptFills?.get(field)` which is `Set<string> | undefined`). The marker key `'_i18nFilled'` is identical in `densify.ts`, `core.ts` strip, and `collection.ts` accessor. Event payload `{ vault, collection, id, mode, warning }` matches between `NoydbEventMap` (Task 1 step 3) and the emit (Task 1 step 4).

--- a/docs/superpowers/specs/2026-06-20-i18n-v1x-tail-design.md
+++ b/docs/superpowers/specs/2026-06-20-i18n-v1x-tail-design.md
@@ -1,0 +1,288 @@
+# i18n v1.x tail (#435) — `densifyOnWrite` + `i18n:script-violation` event — design
+
+> Closes the two genuinely-deferred items split out of the i18n hardening epic
+> (#285, whose per-layer `onMissing` wiring shipped). Both land as new *optional*
+> capabilities inside the tree-shaken `withI18n()` strategy — zero behavior change
+> for any field that does not opt in.
+>
+> **Foundation decision (unchanged from the parent epic): extend in place.** New
+> code lives behind the i18n strategy seam; the `NO_I18N` default bundle is
+> untouched. Kernel files (`collection.ts`, `vault.ts`) hold only thin call sites.
+>
+> Parent spec: [`2026-06-05-i18n-multilingual-field-hardening-design.md`](./2026-06-05-i18n-multilingual-field-hardening-design.md)
+> (densify is Slice 4 there; the script-violation event is the observability tail
+> of the script-enforcement model).
+
+## The two features
+
+| # | Feature | One line |
+|---|---|---|
+| **F1** | `densifyOnWrite` | Eager-fill empty i18n slots from the substitute chain **at write time**, recording provenance so a derived copy is never mistaken for an authored translation. |
+| **F2** | `i18n:script-violation` event | A typed event-bus channel that surfaces the `ScriptWarning[]` already collected by `'warn'`/`'filter'` script-enforcement modes (today silently discarded). |
+
+They are independent and ship as separate slices. F2 is small and lands first.
+
+## What already exists (reused, not rebuilt)
+
+| Capability | Where (`file:line`) | Reused as |
+|---|---|---|
+| Read-time substitute chain | `i18n/core.ts:318-405` — `toChain()`, `pickFromChain()`, `resolveI18nText()` | The exact resolution F1 replays **at write time** to compute a fill value |
+| Per-layer policy resolution | `i18n/policy.ts:47-57` — `resolvePolicy()` | The mutual-exclusion check (densify vs a `'throw'` policy) reads this |
+| Read-time locale application | `i18n/core.ts:547-570` — `applyI18nLocale()` | Where the `_i18nFilled` marker is **stripped** from localized read output |
+| `I18nTextOptions` field config | `i18n/core.ts:102-165` | F1 adds `densifyOnWrite?: boolean` here |
+| Write path (normalization sequence) | `collection.ts:1395-1484` — auto-translate → `enforceScript` → required-validate → FK → encrypt | F1 inserts the densify step; F2 emits at the `enforceScript` site |
+| Script enforcement | `i18n/script.ts:138-167` — `enforceScript()` returns `{ value, warnings }` | F1 gains a skip-set param; F2 consumes the returned `warnings` |
+| `ScriptWarning` type | `i18n/script.ts:123-128` — `{ field, locale, expected, sample }` | F2 event payload (no new type) |
+| Typed event emitter | `events.ts:6-40` — `NoydbEventEmitter` (`on`/`off`/`emit`) | F2 channel rides this — no new surface |
+| Event map | `types.ts:1056-1105` — `NoydbEventMap`, `domain:verb` convention (`sync:push`, `history:save`) | F2 declares `'i18n:script-violation'` here |
+
+## Architecture — where it sits
+
+```
+                          write path (collection.ts)
+  ┌──────────────────────────────────────────────────────────────────┐
+  │ auto-translate (1395)                                             │
+  │   │                                                               │
+  │   ▼  ❶ computeExemptFills(prior, incoming)  ◄── NEW pre-pass      │
+  │   │     (only when a field has densifyOnWrite:true)               │
+  │   ▼                                                               │
+  │ enforceScript (1445)  ── checks AUTHORED slots only ──────────────┼──► F2: emit
+  │   │     (exempt set = unchanged round-tripped fills)              │    i18n:script-violation
+  │   ▼                                                               │    for warn + filter
+  │ required-validate (1468)  ── authored floor, fills excluded ──────┤
+  │   ▼                                                               │
+  │   ❷ densify(prior, incoming)  ◄── NEW: fill + mark + refresh      │
+  │   ▼                                                               │
+  │ FK refs (1475) → encrypt + persist (1484)                         │
+  └──────────────────────────────────────────────────────────────────┘
+       ❶ ❷ are thin delegations into i18nStrategy (Approach A)
+       all logic lives in i18n/densify.ts, tree-shaken under withI18n()
+```
+
+**Approach A (chosen).** Densify logic lives in a new `i18n/densify.ts`, invoked
+through the existing `i18nStrategy` exactly as `enforceScript()` already is
+(`collection.ts:1445`). Net new lines in `collection.ts` are call sites only
+(~12-15) → a small, playbook-sanctioned ceiling raise. Rejected: a `SubsystemBus`
+handler (densify is a pre-encryption record transform, not cleanly a gate) and
+inline kernel code (bloats the file the architecture check keeps thin).
+
+## F1 — `densifyOnWrite`
+
+### Option
+
+```ts
+interface I18nTextOptions {
+  // … existing …
+  readonly densifyOnWrite?: boolean   // NEW — default absent ⇒ today's behavior
+}
+```
+
+Per-field, opt-in. When set, after an i18nText value passes the authored gates,
+every empty declared-language slot is filled from the field's substitute chain and
+the fill is recorded in a provenance marker.
+
+### Provenance marker
+
+A reserved record-level sibling key:
+
+```ts
+_i18nFilled: Record</* fieldPath */ string, /* locale codes */ string[]>
+// e.g.  { firstName: ['en'] }
+```
+
+- Stored **as part of the record**, therefore encrypted with it — zero-knowledge
+  is preserved (the store still sees only ciphertext).
+- **Fully internal.** Stripped from `get`/`list`/`raw` output by a filter in
+  `applyI18nLocale()` (`core.ts:547`). It is **not** part of the user schema and
+  callers never round-trip it.
+- Surfaced only to: (a) `as-*` export (so an export can annotate a slot as
+  *auto-filled*), and (b) a dedicated audit accessor (read-side, returns the
+  marker for a record). Both are additive, out of the hot read path.
+
+The marker holds **which** slots are derived, not their values — the values live
+in the (now dense) locale map itself, so existing downstream layers (join, MV,
+derivation, export) see a hole-free map with no per-layer plumbing. (This is the
+whole point of densify versus read-time substitution: the stored map is dense.)
+
+### Write algorithm (the precise sequence)
+
+Let `prior` = the existing stored record (its dense locale map **and** its
+`_i18nFilled` marker); `incoming` = the new record's locale map for a
+densify-enabled field. On **insert** `prior` is empty.
+
+**❶ `computeExemptFills(prior, incoming)` — pre-pass, before `enforceScript`.**
+For each locale `L` that `prior._i18nFilled[field]` marks as filled:
+
+| Incoming state of slot `L` | Classification | Consequence |
+|---|---|---|
+| empty | user cleared it | re-fill in ❷; nothing to script-check |
+| `incoming[L] === prior[L]` (unchanged) | still a derived fill (client round-tripped it) | **exempt** from `enforceScript`; refresh in ❷ |
+| `incoming[L] !== prior[L]` (changed) | user authored a real value into a formerly-filled slot | **not** exempt — script-checked as authored; marker for `L` cleared in ❷ |
+
+The function returns the exempt-locale set. This is the keystone that lets a
+dense map (which contains, e.g., Thai text in the `en` slot) survive a second
+write without `enforceScript` rejecting the derived copy — **without** exposing
+the marker to clients.
+
+**Step `enforceScript` (1445)** runs on `incoming` **minus the exempt set**.
+Authored slots (including a value newly authored into a formerly-filled slot) are
+validated; unchanged round-tripped fills are skipped.
+
+**Step required-validate (1468)** counts **authored** slots only (exempt fills do
+not satisfy `required`) — `required` remains the authored floor, independent of
+densify, exactly as the parent spec specified (no `store` layer).
+
+**❷ `densify(prior, incoming)` — after required-validate, before FK/encrypt.**
+For the field:
+1. `authored` = incoming slots that are non-empty and not in the exempt set.
+2. For each declared language `L` that is empty (or an exempt fill): compute a
+   substitute by replaying `resolveI18nText`/`pickFromChain` over `authored`
+   using the field's declared `substitute` (and `smartSubstitute` if set). If a
+   value is found, set `map[L] = value` and mark `L` filled.
+3. For any `L` now authored, **clear** its mark.
+4. Write `_i18nFilled[field]` = the marked locales (omit the field — and the whole
+   `_i18nFilled` key — when none remain).
+
+Because ❷ recomputes fills from the current authored slots on **every** write,
+a corrected source value propagates to its derived slots automatically — the
+"`th` corrected → `en` re-densifies" behavior — with **no** authored value ever
+clobbered (changed slots are reclassified as authored in ❶).
+
+### Refresh mechanism — decision A (chosen)
+
+Refresh reads the **prior marker from store**; the marker stays fully internal and
+never round-trips. Rejected alternative B (marker round-trips on raw reads): lower
+write cost but exposes the marker and breaks when a client drops it.
+
+> **Planning-time verification (risk).** Decision A requires `prior` (its map +
+> marker) to be available in the write path **before** `enforceScript`. The
+> versioned/CRDT update path very likely already loads the prior record
+> (`collection.ts:1484+`); confirm during planning. If prior state is **not**
+> cheaply available for plain puts, the fallback is decision B (round-trip the
+> marker) — a spec amendment, not a redesign, since ❶/❷ then read the incoming
+> marker instead of `prior`.
+
+### Mutual exclusion with `'throw'` policies
+
+`densifyOnWrite: true` fills every hole, so any `onMissing: 'throw'` (the parent
+spec's strict-MV case, and any other layer) becomes **unreachable**. Declaring
+both is a contradiction:
+
+- `densifyOnWrite: true` **+ an explicit `onMissing` containing `'throw'`** (scalar
+  or any per-layer value) → **config-time error** (thrown when the field
+  descriptor is built / collection constructed), naming the field and the
+  offending layer(s).
+- `densifyOnWrite: true` with **no explicit** `onMissing` → fine. The *default*
+  `'throw'` is allowed; densify simply makes it never fire.
+
+### Script-exemption interaction (worked)
+
+| Write | Effect |
+|---|---|
+| Insert `{ th: 'สมชาย' }`, `languages:['th','en']`, `substitute:['en','th']`, `densifyOnWrite` | `enforceScript` checks `th` (valid Thai) ✓; required `'any'` ✓; ❷ fills `en:'สมชาย'`, marker `{firstName:['en']}`. Stored map is dense; `en` holds Thai by design. |
+| Update `{ th: 'สมชัย', en: 'สมชาย' }` (client round-tripped the fill) | ❶ sees `en` marked & unchanged → exempt; `enforceScript` checks only `th` ✓; ❷ refreshes `en:'สมชัย'`, marker keeps `en`. **No script rejection, no clobber.** |
+| Update `{ th: 'สมชาย', en: 'Somchai' }` (user authored real English) | ❶ sees `en` marked but **changed** → not exempt; `enforceScript` checks `en='Somchai'` (Latin ✓); ❷ marks `en` authored → clears mark; `_i18nFilled` drops `en`. |
+| Read (active `en`) | resolver returns `'สมชัย'` (dense slot); `_i18nFilled` stripped from output. |
+| Audit accessor | returns `{ firstName: ['en'] }` — `en` is derived. |
+
+## F2 — `i18n:script-violation` event channel
+
+### Channel
+
+Declared in `NoydbEventMap` (`types.ts:1056`), `domain:verb` convention:
+
+```ts
+interface NoydbEventMap {
+  // … existing …
+  'i18n:script-violation': {
+    readonly vault: string
+    readonly collection: string
+    readonly id: string
+    readonly mode: 'warn' | 'filter'
+    readonly warning: ScriptWarning   // { field, locale, expected, sample }
+  }
+}
+```
+
+### Emit site & modes
+
+At `collection.ts:1458`, where `enforceScript()`'s `warnings` are **currently
+discarded**, emit one event per warning:
+
+```ts
+for (const w of warnings) {
+  emitter.emit('i18n:script-violation', { vault, collection, id, mode, warning: w })
+}
+```
+
+| Mode | Behavior | Event |
+|---|---|---|
+| `'reject'` (default) | throws `ScriptViolationError` | **none** — the caller already sees the thrown error; an event-before-throw would falsely imply the write succeeded |
+| `'warn'` | stores value as-is | **emits** |
+| `'filter'` | strips disallowed chars before storing | **emits** — the *only* signal that stored data was mutated |
+
+### Subscribe
+
+```ts
+noydb.on('i18n:script-violation', (e) => {
+  // audit/migration: e.mode === 'filter' means characters were dropped from e.warning.sample
+})
+```
+
+No new subscription surface — the existing `NoydbEventEmitter` API.
+
+## Error & edge cases
+
+- **Substitute exhausted on densify** (no authored slot to copy from, e.g. a
+  field absent on the record): densify fills nothing, marks nothing — a no-op.
+  The slot stays empty; read-time policy still applies. (This is the narrow state
+  in which a `'throw'` policy *could* fire, which is why the mutual-exclusion rule
+  is config-level intent, not a runtime guarantee.)
+- **`smartSubstitute`** is honored if the field declares it (densify replays the
+  same `resolveI18nText` path that read uses).
+- **CRDT mode**: `_i18nFilled` is an ordinary record field and merges last-write-
+  wins like the rest of the record; per-locale CRDT merge remains out of scope
+  (unchanged from the parent epic).
+- **`locale:'raw'` reads**: the locale map is returned dense (fills included);
+  `_i18nFilled` is still stripped (marker is internal, audit-accessor only).
+- **Non-densify fields** in the same collection are completely untouched by ❶/❷.
+
+## Build sequence (independently shippable slices)
+
+1. **F2 — event channel** *(Slice 1, small, ships first)*. Declare
+   `'i18n:script-violation'` in `NoydbEventMap`; emit at `collection.ts:1458` for
+   `warn`/`filter`. No dependency on F1. *(TDD: subscribe, write violating value
+   under each mode, assert event/throw.)*
+2. **F1 — `densifyOnWrite`** *(Slice 2, ships whole — fill, marker, exemption,
+   refresh, read-strip, and mutual-exclusion are entangled; an intermediate
+   "fill-only without exemption" state would break on round-trip)*. Add the
+   option; `i18n/densify.ts` with `computeExemptFills` + `densify`; thin call
+   sites in `collection.ts`; marker strip in `applyI18nLocale`; audit accessor;
+   config-time mutual-exclusion check. *(TDD: the four-row worked table above,
+   plus mutual-exclusion error and substitute-exhausted no-op.)*
+
+## Testing & non-code obligations
+
+- **TDD** throughout; conformance on `to-memory` **and** `to-file`.
+- **Zero-breaking-change proof:** the existing i18n conformance suite stays green;
+  add a test asserting a non-densify, non-`warn`/`filter` field is byte-identical
+  to today.
+- **Tree-shaking:** verify the `NO_I18N` default bundle size is unchanged (all new
+  logic inside `withI18n()`).
+- **`features.yaml`:** register both capability nodes (`densifyOnWrite`,
+  `i18n:script-violation`) or CI's "Spec coverage" job fails on dangling refs.
+- **Subsystem doc:** extend `docs/subsystems/` i18n section with the densify
+  write-sequence table and the event channel.
+- **Showcase:** extend the bilingual i18n showcase with (a) a densify fill +
+  audit-accessor read proving the marker, and (b) a `'filter'`-mode subscription
+  asserting an `i18n:script-violation` event fires when characters are stripped.
+- **Kernel ceiling:** raise `collection.ts` ceiling (`scripts/check-architecture.mjs`)
+  by the minimal amount the Approach-A call sites require (~15 lines); keep
+  `vault.ts` untouched.
+
+## Out of scope (restated)
+
+Nearest-script *smart* substitution beyond the existing `smartSubstitute` flag,
+lazy on-read translation, per-locale CRDT merge, native-digits-only enforcement —
+all remain deferred per the parent epic. The in-pinia reactive-locale companion is
+**already shipped** (PR #284) and is not part of this work.

--- a/features.yaml
+++ b/features.yaml
@@ -598,8 +598,8 @@ features:
     diagrams: []
     invariants:
       - 'densifyOnWrite: opt-in flag on withI18n; when true, every put/save eagerly fills empty locale slots by walking the substitute chain at write time'
-      - 'Provenance marker _i18nFilled:true is written into each slot populated by densification; slots the caller explicitly provided are never overwritten'
-      - 'Incompatible with onMissing:"throw" (the default); the two options are mutually exclusive and the constructor throws a ConfigError if combined'
+      - 'Provenance is a single top-level marker _i18nFilled: { <field>: [<locales>] } mapping each densify field to the locales it filled; slots the caller explicitly provided are never overwritten. The marker is internal — stripped from every user-facing read; read provenance via i18nProvenance(id)'
+      - 'Incompatible with an EXPLICIT onMissing:"throw" (scalar or any per-layer value): i18nText() throws a plain Error at field-construction time. The default onMissing is undefined (NOT "throw"), so the default case is allowed'
     related: [i18n]
 
   - id: i18n-script-violation-event
@@ -617,8 +617,8 @@ features:
     playground_pages: []
     diagrams: []
     invariants:
-      - 'Script-enforcement in warn or filter mode emits typed ScriptViolationEvent objects on the i18n:script-violation channel (observable via vault.on("i18n:script-violation", handler))'
-      - 'Event carries: field, locale, value, violatingChars[] + the enforcement mode that triggered it'
+      - 'Script-enforcement in warn or filter mode emits typed events on the i18n:script-violation channel (observable via vault.on("i18n:script-violation", handler))'
+      - 'Event payload: { vault, collection, id, mode: "warn"|"filter", warning } where warning: ScriptWarning = { field, locale, expected, sample } — expected is the allowed-script list, sample is a short offending-character excerpt. There is NO value or violatingChars[] field'
       - 'warn mode: the value is stored as-is and a warning event is emitted; filter mode: violating chars are stripped and an event is emitted; reject mode (default): throws ScriptViolationError synchronously (no event)'
     related: [i18n]
 

--- a/features.yaml
+++ b/features.yaml
@@ -582,6 +582,42 @@ features:
       - 'static dict names are read-only: put/rename/delete throw StaticDictReadonlyError'
     related: [vault-and-collections]
 
+  - id: i18n-densify-on-write
+    name: densifyOnWrite — eager-fill empty i18n locale slots at write time
+    cluster: data-shape
+    spec: docs/superpowers/specs/2026-06-20-i18n-v1x-tail-design.md
+    subsystem_doc: docs/subsystems/i18n.md
+    package: '@noy-db/hub/i18n'
+    factory: withI18n
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'densifyOnWrite: opt-in flag on withI18n; when true, every put/save eagerly fills empty locale slots by walking the substitute chain at write time'
+      - 'Provenance marker _i18nFilled:true is written into each slot populated by densification; slots the caller explicitly provided are never overwritten'
+      - 'Incompatible with onMissing:"throw" (the default); the two options are mutually exclusive and the constructor throws a ConfigError if combined'
+    related: [i18n]
+
+  - id: i18n-script-violation-event
+    name: i18n:script-violation typed event channel for script-enforcement warnings
+    cluster: data-shape
+    spec: docs/superpowers/specs/2026-06-20-i18n-v1x-tail-design.md
+    subsystem_doc: docs/subsystems/i18n.md
+    package: '@noy-db/hub/i18n'
+    factory: withI18n
+    status: preview
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'Script-enforcement in warn or filter mode emits typed ScriptViolationEvent objects on the i18n:script-violation channel (observable via vault.on("i18n:script-violation", handler))'
+      - 'Event carries: field, locale, value, violatingChars[] + the enforcement mode that triggered it'
+      - 'warn mode: the value is stored as-is and a warning event is emitted; filter mode: violating chars are stripped and an event is emitted; reject mode (default): throws ScriptViolationError synchronously (no event)'
+    related: [i18n]
+
   - id: aggregate
     name: Aggregate query terminals (sum/count/avg/groupBy)
     cluster: read-and-query

--- a/features.yaml
+++ b/features.yaml
@@ -590,7 +590,9 @@ features:
     package: '@noy-db/hub/i18n'
     factory: withI18n
     status: preview
-    showcases: []
+    showcases:
+      - id: 121-with-i18n-densify
+        path: showcases/src/121-with-i18n-densify.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
@@ -608,7 +610,9 @@ features:
     package: '@noy-db/hub/i18n'
     factory: withI18n
     status: preview
-    showcases: []
+    showcases:
+      - id: 121-with-i18n-densify
+        path: showcases/src/121-with-i18n-densify.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []

--- a/packages/hub/__tests__/i18n-densify.test.ts
+++ b/packages/hub/__tests__/i18n-densify.test.ts
@@ -1,6 +1,6 @@
 /** #435 F1 — densifyOnWrite. */
 import { describe, it, expect } from 'vitest'
-import { i18nText } from '../src/i18n/core.js'
+import { i18nText, applyI18nLocale } from '../src/i18n/core.js'
 import { computeExemptFills, densify } from '../src/i18n/densify.js'
 import { withI18n } from '../src/i18n/index.js'
 import { NO_I18N } from '../src/i18n/strategy.js'
@@ -131,5 +131,16 @@ describe('densify wired into the strategy', () => {
     NO_I18N.densify(rec, undefined, fields)
     expect(rec._i18nFilled).toBeUndefined()
     expect(NO_I18N.computeExemptFills(undefined, rec, fields).size).toBe(0)
+  })
+})
+
+describe('applyI18nLocale strips the _i18nFilled marker (#435)', () => {
+  const fields = { name: i18nText({ languages: ['th', 'en'], required: 'any' }) }
+
+  it('removes _i18nFilled from output without mutating the input', () => {
+    const rec: any = { id: 'c1', name: { th: 'A', en: 'A' }, _i18nFilled: { name: ['en'] } }
+    const out: any = applyI18nLocale(rec, fields, 'raw')
+    expect('_i18nFilled' in out).toBe(false)
+    expect(rec._i18nFilled).toEqual({ name: ['en'] }) // input untouched
   })
 })

--- a/packages/hub/__tests__/i18n-densify.test.ts
+++ b/packages/hub/__tests__/i18n-densify.test.ts
@@ -4,6 +4,48 @@ import { i18nText, applyI18nLocale } from '../src/i18n/core.js'
 import { computeExemptFills, densify } from '../src/i18n/densify.js'
 import { withI18n } from '../src/i18n/index.js'
 import { NO_I18N } from '../src/i18n/strategy.js'
+import { createNoydb } from '../src/noydb.js'
+import type { Noydb } from '../src/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) if (!n.startsWith('_')) {
+        const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) for (const [name, coll] of existing) if (name.startsWith('_')) comp.set(name, coll)
+      store.set(c, comp)
+    },
+  }
+}
 
 describe('densifyOnWrite config validation', () => {
   it('rejects densifyOnWrite + explicit scalar throw policy', () => {
@@ -142,5 +184,44 @@ describe('applyI18nLocale strips the _i18nFilled marker (#435)', () => {
     const out: any = applyI18nLocale(rec, fields, 'raw')
     expect('_i18nFilled' in out).toBe(false)
     expect(rec._i18nFilled).toEqual({ name: ['en'] }) // input untouched
+  })
+})
+
+interface Co { id: string; name: Record<string, string> }
+async function densDb(): Promise<Noydb> {
+  return createNoydb({ store: memory(), user: 'a', secret: 'pw-densify', i18nStrategy: withI18n() })
+}
+
+describe('densifyOnWrite (integration)', () => {
+  it('fills en from th, hides the marker, exposes it via i18nProvenance', async () => {
+    const db = await densDb()
+    const v = await db.openVault('v', { locale: 'en' })
+    const co = v.collection<Co>('co', {
+      i18nFields: { name: i18nText({ languages: ['th', 'en'], required: 'any', substitute: ['en', 'th'], densifyOnWrite: true }) },
+    })
+    await co.put('c1', { id: 'c1', name: { th: 'สมชาย' } })
+    expect((await co.get('c1') as any).name).toBe('สมชาย') // en reader sees the fill
+    const raw = await co.get('c1', { locale: 'raw' })
+    expect('_i18nFilled' in (raw as any)).toBe(false)
+    expect((raw as any).name).toEqual({ th: 'สมชาย', en: 'สมชาย' }) // dense
+    expect(await co.i18nProvenance('c1')).toEqual({ name: ['en'] })
+  })
+
+  it('refreshes on source change and does not clobber an authored value (the round-trip proof)', async () => {
+    const db = await densDb()
+    const v = await db.openVault('v', { locale: 'en' })
+    const co = v.collection<Co>('co', {
+      i18nFields: { name: i18nText({ languages: ['th', 'en'], required: 'any', substitute: ['en', 'th'], densifyOnWrite: true, script: 'auto' }) },
+    })
+    await co.put('c1', { id: 'c1', name: { th: 'สมชาย' } }) // en filled = สมชาย (Thai)
+    const r1 = await co.get('c1', { locale: 'raw' })
+    await co.put('c1', { id: 'c1', name: { ...(r1 as any).name, th: 'สมชัย' } })
+    const r2 = await co.get('c1', { locale: 'raw' })
+    expect((r2 as any).name.en).toBe('สมชัย') // refreshed, NOT script-rejected
+    expect(await co.i18nProvenance('c1')).toEqual({ name: ['en'] })
+    await co.put('c1', { id: 'c1', name: { th: 'สมชัย', en: 'Somchai' } })
+    const r3 = await co.get('c1', { locale: 'raw' })
+    expect((r3 as any).name.en).toBe('Somchai')
+    expect(await co.i18nProvenance('c1')).toBeUndefined() // marker cleared
   })
 })

--- a/packages/hub/__tests__/i18n-densify.test.ts
+++ b/packages/hub/__tests__/i18n-densify.test.ts
@@ -2,6 +2,8 @@
 import { describe, it, expect } from 'vitest'
 import { i18nText } from '../src/i18n/core.js'
 import { computeExemptFills, densify } from '../src/i18n/densify.js'
+import { withI18n } from '../src/i18n/index.js'
+import { NO_I18N } from '../src/i18n/strategy.js'
 
 describe('densifyOnWrite config validation', () => {
   it('rejects densifyOnWrite + explicit scalar throw policy', () => {
@@ -112,5 +114,22 @@ describe('densify (pure)', () => {
     densify(rec, prior, fields)
     expect(rec.name.en).toBe('สมชาย')
     expect(rec._i18nFilled).toEqual({ name: ['en'] }) // stays a fill (and stays script-exempt)
+  })
+})
+
+describe('densify wired into the strategy', () => {
+  const fields = { name: i18nText({ languages: ['th', 'en'], required: 'any', substitute: ['en', 'th'], densifyOnWrite: true }) }
+
+  it('withI18n().densify fills slots', () => {
+    const rec: any = { id: 'c1', name: { th: 'สมชาย' } }
+    withI18n().densify(rec, undefined, fields)
+    expect(rec.name.en).toBe('สมชาย')
+  })
+
+  it('NO_I18N densify is a no-op and computeExemptFills is empty', () => {
+    const rec: any = { id: 'c1', name: { th: 'สมชาย' } }
+    NO_I18N.densify(rec, undefined, fields)
+    expect(rec._i18nFilled).toBeUndefined()
+    expect(NO_I18N.computeExemptFills(undefined, rec, fields).size).toBe(0)
   })
 })

--- a/packages/hub/__tests__/i18n-densify.test.ts
+++ b/packages/hub/__tests__/i18n-densify.test.ts
@@ -1,6 +1,7 @@
 /** #435 F1 — densifyOnWrite. */
 import { describe, it, expect } from 'vitest'
 import { i18nText } from '../src/i18n/core.js'
+import { computeExemptFills, densify } from '../src/i18n/densify.js'
 
 describe('densifyOnWrite config validation', () => {
   it('rejects densifyOnWrite + explicit scalar throw policy', () => {
@@ -25,5 +26,47 @@ describe('densifyOnWrite config validation', () => {
     expect(() =>
       i18nText({ languages: ['th', 'en'], required: 'any', densifyOnWrite: true, onMissing: 'substitute' }),
     ).not.toThrow()
+  })
+})
+
+describe('densify (pure)', () => {
+  const fields = {
+    name: i18nText({ languages: ['th', 'en'], required: 'any', substitute: ['en', 'th'], densifyOnWrite: true }),
+  }
+
+  it('fills empty slots and records provenance (insert)', () => {
+    const rec: any = { id: 'c1', name: { th: 'สมชาย' } }
+    densify(rec, undefined, fields)
+    expect(rec.name).toEqual({ th: 'สมชาย', en: 'สมชาย' })
+    expect(rec._i18nFilled).toEqual({ name: ['en'] })
+  })
+
+  it('refreshes an unchanged round-tripped fill when the source changed', () => {
+    const prior: any = { name: { th: 'สมชาย', en: 'สมชาย' }, _i18nFilled: { name: ['en'] } }
+    const rec: any = { id: 'c1', name: { th: 'สมชัย', en: 'สมชาย' } } // th corrected, en still old fill
+    densify(rec, prior, fields)
+    expect(rec.name.en).toBe('สมชัย')
+    expect(rec._i18nFilled).toEqual({ name: ['en'] })
+  })
+
+  it('clears the marker when a slot becomes authored (no clobber)', () => {
+    const prior: any = { name: { th: 'สมชาย', en: 'สมชาย' }, _i18nFilled: { name: ['en'] } }
+    const rec: any = { id: 'c1', name: { th: 'สมชาย', en: 'Somchai' } } // real en authored
+    densify(rec, prior, fields)
+    expect(rec.name.en).toBe('Somchai')
+    expect(rec._i18nFilled).toBeUndefined()
+  })
+
+  it('computeExemptFills exempts unchanged fills, not changed slots', () => {
+    const prior: any = { name: { th: 'สมชาย', en: 'สมชาย' }, _i18nFilled: { name: ['en'] } }
+    expect(computeExemptFills(prior, { name: { th: 'สมชัย', en: 'สมชาย' } }, fields).get('name')).toEqual(new Set(['en']))
+    expect(computeExemptFills(prior, { name: { th: 'สมชาย', en: 'Somchai' } }, fields).get('name')).toBeUndefined()
+    expect(computeExemptFills(undefined, { name: { th: 'สมชาย' } }, fields).size).toBe(0)
+  })
+
+  it('fills nothing when there is no source value', () => {
+    const rec: any = { id: 'c1' } // name absent
+    densify(rec, undefined, fields)
+    expect(rec._i18nFilled).toBeUndefined()
   })
 })

--- a/packages/hub/__tests__/i18n-densify.test.ts
+++ b/packages/hub/__tests__/i18n-densify.test.ts
@@ -69,4 +69,48 @@ describe('densify (pure)', () => {
     densify(rec, undefined, fields)
     expect(rec._i18nFilled).toBeUndefined()
   })
+
+  it('drops a stale fill and clears the marker when its source disappears', () => {
+    const prior: any = { name: { th: 'สมชาย', en: 'สมชาย' }, _i18nFilled: { name: ['en'] } }
+    const rec: any = { id: 'c1', name: { en: 'สมชาย' } } // th removed, only the stale en fill remains
+    densify(rec, prior, fields)
+    expect(rec.name.en).toBeUndefined() // stale fill dropped — no authored source left
+    expect(rec._i18nFilled).toBeUndefined()
+  })
+
+  it('fills multiple empty locales from one authored source in one pass', () => {
+    const multi = {
+      name: i18nText({ languages: ['th', 'en', 'lo'], required: 'any', substitute: ['th'], densifyOnWrite: true }),
+    }
+    const rec: any = { id: 'c1', name: { th: 'สมชาย' } }
+    densify(rec, undefined, multi)
+    expect(rec.name).toEqual({ th: 'สมชาย', en: 'สมชาย', lo: 'สมชาย' })
+    expect(rec._i18nFilled.name).toEqual(expect.arrayContaining(['en', 'lo']))
+    expect(rec._i18nFilled.name).toHaveLength(2)
+  })
+
+  it('treats an empty-string slot as eligible to fill', () => {
+    const rec: any = { id: 'c1', name: { th: 'สมชาย', en: '' } }
+    densify(rec, undefined, fields)
+    expect(rec.name.en).toBe('สมชาย') // '' is empty, not authored → filled
+    expect(rec._i18nFilled).toEqual({ name: ['en'] })
+  })
+
+  it('does not mutate the prior record', () => {
+    const prior: any = { name: { th: 'สมชาย', en: 'สมชาย' }, _i18nFilled: { name: ['en'] } }
+    const priorSnapshot = JSON.parse(JSON.stringify(prior))
+    const rec: any = { id: 'c1', name: { th: 'สมชัย', en: 'สมชาย' } }
+    densify(rec, prior, fields)
+    expect(prior).toEqual(priorSnapshot)
+  })
+
+  it('keeps a re-authored value identical to the fill classified as a fill (value-equality limitation)', () => {
+    // 'en' was filled from 'th'; the user re-types the same string for 'en'.
+    // Value-equality provenance cannot tell this apart from the round-tripped fill.
+    const prior: any = { name: { th: 'สมชาย', en: 'สมชาย' }, _i18nFilled: { name: ['en'] } }
+    const rec: any = { id: 'c1', name: { th: 'สมชาย', en: 'สมชาย' } }
+    densify(rec, prior, fields)
+    expect(rec.name.en).toBe('สมชาย')
+    expect(rec._i18nFilled).toEqual({ name: ['en'] }) // stays a fill (and stays script-exempt)
+  })
 })

--- a/packages/hub/__tests__/i18n-densify.test.ts
+++ b/packages/hub/__tests__/i18n-densify.test.ts
@@ -225,3 +225,50 @@ describe('densifyOnWrite (integration)', () => {
     expect(await co.i18nProvenance('c1')).toBeUndefined() // marker cleared
   })
 })
+
+describe('densify never leaks _i18nFilled on locale-less reads (#435)', () => {
+  // Vault has NO default locale — exercises the read paths that bypass
+  // applyI18nLocale (get early-return, list, search).
+  async function localelessSetup() {
+    const db = await densDb()
+    const v = await db.openVault('v') // NO { locale }
+    const co = v.collection<Co>('co', {
+      i18nFields: { name: i18nText({ languages: ['th', 'en'], required: 'any', substitute: ['en', 'th'], densifyOnWrite: true }) },
+    })
+    await co.put('c1', { id: 'c1', name: { th: 'สมชาย' } })
+    return { co }
+  }
+
+  it('get() does not expose the marker (locale-less)', async () => {
+    const { co } = await localelessSetup()
+    const rec = (await co.get('c1'))!
+    expect('_i18nFilled' in rec).toBe(false)
+    // densify still works internally: the empty en slot was filled
+    expect((rec as any).name).toEqual({ th: 'สมชาย', en: 'สมชาย' })
+    // provenance still readable via the dedicated API
+    expect(await co.i18nProvenance('c1')).toEqual({ name: ['en'] })
+  })
+
+  it('list() does not expose the marker on any item (locale-less)', async () => {
+    const { co } = await localelessSetup()
+    const items = await co.list()
+    expect(items.length).toBe(1)
+    for (const item of items) expect('_i18nFilled' in (item as any)).toBe(false)
+  })
+
+  it('search() does not expose the marker on any result (locale-less)', async () => {
+    // Search runs over a plain-text field (`tag`); the densify i18n field
+    // (`name`) fills its empty 'en' slot, so the matched record still carries
+    // the top-level _i18nFilled marker that search returns verbatim.
+    const db = await densDb()
+    const v = await db.openVault('v') // NO { locale }
+    interface Sco { id: string; tag: string; name: Record<string, string> }
+    const co = v.collection<Sco>('co', {
+      i18nFields: { name: i18nText({ languages: ['th', 'en'], required: 'any', substitute: ['th', 'en'], densifyOnWrite: true }) },
+    })
+    await co.put('c1', { id: 'c1', tag: 'Consulting Services', name: { th: 'สมชาย' } })
+    const results = await co.search('tag', 'Consulting')
+    expect(results.length).toBeGreaterThan(0)
+    for (const r of results) expect('_i18nFilled' in (r.record as any)).toBe(false)
+  })
+})

--- a/packages/hub/__tests__/i18n-densify.test.ts
+++ b/packages/hub/__tests__/i18n-densify.test.ts
@@ -1,0 +1,29 @@
+/** #435 F1 — densifyOnWrite. */
+import { describe, it, expect } from 'vitest'
+import { i18nText } from '../src/i18n/core.js'
+
+describe('densifyOnWrite config validation', () => {
+  it('rejects densifyOnWrite + explicit scalar throw policy', () => {
+    expect(() =>
+      i18nText({ languages: ['th', 'en'], required: 'any', densifyOnWrite: true, onMissing: 'throw' }),
+    ).toThrow(/densifyOnWrite/)
+  })
+
+  it('rejects densifyOnWrite + explicit per-layer throw policy', () => {
+    expect(() =>
+      i18nText({ languages: ['th', 'en'], required: 'any', densifyOnWrite: true, onMissing: { mv: 'throw' } }),
+    ).toThrow(/densifyOnWrite/)
+  })
+
+  it('allows densifyOnWrite with no explicit onMissing (default throw is fine)', () => {
+    expect(() =>
+      i18nText({ languages: ['th', 'en'], required: 'any', densifyOnWrite: true }),
+    ).not.toThrow()
+  })
+
+  it('allows densifyOnWrite with an explicit non-throw policy', () => {
+    expect(() =>
+      i18nText({ languages: ['th', 'en'], required: 'any', densifyOnWrite: true, onMissing: 'substitute' }),
+    ).not.toThrow()
+  })
+})

--- a/packages/hub/__tests__/i18n-script-violation-event.test.ts
+++ b/packages/hub/__tests__/i18n-script-violation-event.test.ts
@@ -1,0 +1,97 @@
+/** #435 F2 — i18n:script-violation typed event channel. */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { withI18n } from '../src/i18n/index.js'
+import { i18nText } from '../src/i18n/core.js'
+import type { Noydb } from '../src/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) if (!n.startsWith('_')) {
+        const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) for (const [name, coll] of existing) if (name.startsWith('_')) comp.set(name, coll)
+      store.set(c, comp)
+    },
+  }
+}
+
+interface Co { id: string; name: Record<string, string> }
+async function freshDb(): Promise<Noydb> {
+  return createNoydb({ store: memory(), user: 'a', secret: 'pw-sv-event', i18nStrategy: withI18n() })
+}
+
+describe('i18n:script-violation event', () => {
+  let db: Noydb
+  beforeEach(async () => { db = await freshDb() })
+
+  it("emits for 'warn' mode and stores the value unchanged", async () => {
+    const events: any[] = []
+    db.on('i18n:script-violation', (e) => events.push(e))
+    const v = await db.openVault('v', { locale: 'th' })
+    const co = v.collection<Co>('co', {
+      i18nFields: { name: i18nText({ languages: ['th', 'en'], required: 'any', script: 'auto', onScriptViolation: 'warn' }) },
+    })
+    await co.put('c1', { id: 'c1', name: { en: 'สมชาย' } }) // Thai in the en slot
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ vault: 'v', collection: 'co', id: 'c1', mode: 'warn' })
+    expect(events[0].warning).toMatchObject({ field: 'name', locale: 'en' })
+    const got = await co.get('c1', { locale: 'raw' })
+    expect((got as any).name.en).toBe('สมชาย') // stored unchanged under 'warn'
+  })
+
+  it("emits for 'filter' mode and strips disallowed chars", async () => {
+    const events: any[] = []
+    db.on('i18n:script-violation', (e) => events.push(e))
+    const v = await db.openVault('v', { locale: 'en' })
+    const co = v.collection<Co>('co', {
+      i18nFields: { name: i18nText({ languages: ['en'], required: 'any', script: { en: ['Latin'] }, onScriptViolation: 'filter' }) },
+    })
+    await co.put('c1', { id: 'c1', name: { en: 'Somสมchai' } })
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ vault: 'v', collection: 'co', id: 'c1', mode: 'filter' })
+    expect(events[0].warning).toMatchObject({ field: 'name', locale: 'en' })
+    const got = await co.get('c1', { locale: 'raw' })
+    expect((got as any).name.en).toBe('Somchai') // Thai stripped
+  })
+
+  it("does NOT emit for 'reject' mode (throws instead)", async () => {
+    const events: any[] = []
+    db.on('i18n:script-violation', (e) => events.push(e))
+    const v = await db.openVault('v', { locale: 'th' })
+    const co = v.collection<Co>('co', {
+      i18nFields: { name: i18nText({ languages: ['th', 'en'], required: 'any', script: 'auto' }) }, // default reject
+    })
+    await expect(co.put('c1', { id: 'c1', name: { en: 'สมชาย' } })).rejects.toThrow()
+    expect(events).toHaveLength(0)
+  })
+})

--- a/packages/hub/__tests__/i18n-script.test.ts
+++ b/packages/hub/__tests__/i18n-script.test.ts
@@ -74,3 +74,15 @@ describe('enforceScript — filter / warn', () => {
     expect(warnings[0]?.locale).toBe('en')
   })
 })
+
+describe('enforceScript exempt set (#435)', () => {
+  const d = i18nText({ languages: ['th', 'en'], required: 'any', script: 'auto' })
+
+  it('throws on Thai in the en slot without exempt', () => {
+    expect(() => enforceScript({ th: 'สมชาย', en: 'สมชาย' }, 'name', d)).toThrow()
+  })
+
+  it('skips an exempt locale (a known fill)', () => {
+    expect(() => enforceScript({ th: 'สมชาย', en: 'สมชาย' }, 'name', d, new Set(['en']))).not.toThrow()
+  })
+})

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -3,7 +3,7 @@ import { NOYDB_FORMAT_VERSION } from './types.js'
 import type { CrdtMode, CrdtState, LwwMapState, RgaState } from './crdt/crdt.js'
 import { NO_CRDT, type CrdtStrategy } from './crdt/strategy.js'
 import type { I18nTextDescriptor } from './i18n/core.js'
-import { getAtPath, setAtPathInPlace } from './i18n/core.js'
+import { getAtPath, setAtPathInPlace, stripI18nFilled } from './i18n/core.js'
 import type { DictKeyDescriptor, StaticDictDescriptor } from './i18n/dictionary.js'
 import { isStaticDictDescriptor } from './i18n/dictionary.js'
 import type { MoneyDescriptor } from './money/descriptor.js'
@@ -2704,7 +2704,11 @@ export class Collection<T> {
     }
     await this.ensureHydrated()
     const entries: { id: string; record: T }[] = []
-    for (const [id, e] of this.cache) entries.push({ id, record: e.record })
+    // #435 — strip the internal densify marker from the user-facing records.
+    // Non-mutating: never touches the cached record object. The search index
+    // is built over the same (marker-free) record, which is fine — the marker
+    // is never a searchable field.
+    for (const [id, e] of this.cache) entries.push({ id, record: stripI18nFilled(e.record as Record<string, unknown>) as T })
     return searchScan(entries, field, query, opts)
   }
 
@@ -3842,7 +3846,10 @@ export class Collection<T> {
       Object.values(this.dictKeyFields).some(
         (d) => isStaticDictDescriptor(d) && d.displayLocale !== undefined,
       )
-    if (!locale && !hasStaticDisplay) return result as T
+    // #435 — strip the internal densify marker even when no locale is active
+    // (applyI18nLocale, which normally strips it, is skipped on this path).
+    // Non-mutating: never touches the cached/stored record object.
+    if (!locale && !hasStaticDisplay) return stripI18nFilled(result) as T
 
     // 1. i18nText resolution — guarded on `locale`, because the relaxed gate
     // above can now be entered with `locale === undefined` (static-display).
@@ -3940,7 +3947,10 @@ export class Collection<T> {
       result = withLabels
     }
 
-    return result as T
+    // #435 — final guard: the locale-less static-display path skips
+    // applyI18nLocale's strip, so ensure the densify marker never leaks here
+    // either. Non-mutating (no-op when absent or already stripped above).
+    return stripI18nFilled(result) as T
   }
 
   /**

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1455,12 +1455,27 @@ export class Collection<T> {
         for (const leaf of getAtPath(obj, field)) {
           if (!leaf || typeof leaf !== 'object' || Array.isArray(leaf)) continue
           const leafMap = leaf as Record<string, unknown>
-          const { value: cleaned } = this.i18nStrategy.enforceScript(
+          const { value: cleaned, warnings } = this.i18nStrategy.enforceScript(
             leafMap,
             field,
             descriptor,
           )
           if (cleaned !== leafMap) Object.assign(leafMap, cleaned)
+          // enforceScript only returns warnings under 'warn'/'filter' ('reject'
+          // throws first), so this guard never fires — it makes that invariant
+          // explicit and keeps `mode` off the optional-undefined type.
+          const mode = descriptor.options.onScriptViolation
+          if (mode === 'warn' || mode === 'filter') {
+            for (const w of warnings) {
+              this.emitter.emit('i18n:script-violation', {
+                vault: this.vault,
+                collection: this.name,
+                id,
+                mode,
+                warning: w,
+              })
+            }
+          }
         }
       }
     }

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -314,6 +314,13 @@ export class Collection<T> {
   private readonly i18nFields: Record<string, I18nTextDescriptor> | undefined
 
   /**
+   * #435 — the densify-enabled subset of {@link i18nFields} (fields whose
+   * descriptor opts in via `densifyOnWrite: true`). `undefined` when none opt
+   * in, so the write path skips all densify work for ordinary collections.
+   */
+  private readonly i18nDensifyFields: Record<string, I18nTextDescriptor> | undefined
+
+  /**
    * Map of field name → `DictKeyDescriptor` for fields declared with
    * `dictKey()`. Used by `get()`/`list()` to add `<field>Label` virtual
    * fields when a locale is requested.
@@ -879,6 +886,15 @@ export class Collection<T> {
     this.refEnforcer = opts.refEnforcer
     this.joinResolver = opts.joinResolver
     this.i18nFields = opts.i18nFields
+    // #435 — precompute the densify-enabled subset (undefined when none opt in)
+    // so the write path skips work for non-densify collections.
+    const densifyFields = opts.i18nFields
+      ? Object.fromEntries(
+          Object.entries(opts.i18nFields).filter(([, d]) => d.options.densifyOnWrite === true),
+        )
+      : {}
+    this.i18nDensifyFields =
+      Object.keys(densifyFields).length > 0 ? densifyFields : undefined
     this.dictKeyFields = opts.dictKeyFields
     if (opts.moneyFields) validateMoneyFieldPaths(opts.moneyFields)
     this.moneyFields = opts.moneyFields
@@ -1281,6 +1297,34 @@ export class Collection<T> {
   }
 
   /**
+   * #435 — resolve the prior stored record (with its `_i18nFilled` marker) for
+   * densify. Eager: in-memory cache; lazy: LRU then adapter. undefined if absent.
+   */
+  private async resolveDensifyPrior(id: string): Promise<Record<string, unknown> | undefined> {
+    if (this.lazy && this.lru) {
+      const cached = this.lru.get(id)
+      if (cached) return cached.record as Record<string, unknown>
+      const env = await this.adapter.get(this.vault, this.name, id)
+      if (!env) return undefined
+      const rec = await this.decryptRecord(env)
+      return rec === null ? undefined : (rec as Record<string, unknown>)
+    }
+    await this.ensureHydrated()
+    return this.cache.get(id)?.record as Record<string, unknown> | undefined
+  }
+
+  /**
+   * #435 — densify provenance for a record: which i18n slots were auto-filled,
+   * e.g. `{ name: ['en'] }`. undefined when nothing was filled. The marker is
+   * stripped from ordinary reads; this is the sanctioned audit accessor.
+   */
+  async i18nProvenance(id: string): Promise<Record<string, readonly string[]> | undefined> {
+    const prior = await this.resolveDensifyPrior(id)
+    const marker = prior?.['_i18nFilled'] as Record<string, string[]> | undefined
+    return marker && Object.keys(marker).length > 0 ? marker : undefined
+  }
+
+  /**
    * Validate a record against this collection's schema WITHOUT writing it.
    * Returns the (possibly coerced) record on success; throws
    * {@link SchemaValidationError} (direction: `'input'`) on violation.
@@ -1442,6 +1486,20 @@ export class Collection<T> {
       }
     }
 
+    // #435 densifyOnWrite (decision A): read prior fills so a round-tripped
+    // derived copy is exempt from script enforcement and can be refreshed.
+    // `densifyPrior` is read once here and reused by densify() below.
+    let densifyPrior: Record<string, unknown> | undefined
+    let exemptFills: Map<string, Set<string>> | undefined
+    if (this.i18nDensifyFields) {
+      densifyPrior = await this.resolveDensifyPrior(id)
+      exemptFills = this.i18nStrategy.computeExemptFills(
+        densifyPrior,
+        record as Record<string, unknown>,
+        this.i18nDensifyFields,
+      )
+    }
+
     // i18nText script enforcement — runs AFTER auto-translate (so
     // generated values are checked too). Throws ScriptViolationError
     // under the default 'reject'; 'filter' strips disallowed chars in
@@ -1459,6 +1517,7 @@ export class Collection<T> {
             leafMap,
             field,
             descriptor,
+            exemptFills?.get(field),
           )
           if (cleaned !== leafMap) Object.assign(leafMap, cleaned)
           // enforceScript only returns warnings under 'warn'/'filter' ('reject'
@@ -1485,6 +1544,17 @@ export class Collection<T> {
     // when required translations are absent.
     if (this.i18nPutValidator !== undefined) {
       this.i18nPutValidator(record)
+    }
+
+    // #435 — eager-fill empty slots + record provenance. Runs AFTER the
+    // authored gates (required + script) so only authored slots are validated;
+    // filled slots are recorded in the internal `_i18nFilled` marker.
+    if (this.i18nDensifyFields) {
+      this.i18nStrategy.densify(
+        record as Record<string, unknown>,
+        densifyPrior,
+        this.i18nDensifyFields,
+      )
     }
 
     // Foreign-key ref enforcement. Runs AFTER schema

--- a/packages/hub/src/i18n/active.ts
+++ b/packages/hub/src/i18n/active.ts
@@ -28,6 +28,7 @@
 import type { I18nStrategy, BuildDictionaryHandleOptions } from './strategy.js'
 import { applyI18nLocale, validateI18nTextValue } from './core.js'
 import { enforceScript } from './script.js'
+import { computeExemptFills, densify } from './densify.js'
 import { DictionaryHandle } from './dictionary.js'
 
 export function withI18n(): I18nStrategy {
@@ -35,6 +36,8 @@ export function withI18n(): I18nStrategy {
     applyI18nLocale,
     validateI18nTextValue,
     enforceScript,
+    computeExemptFills,
+    densify,
     buildDictionaryHandle<Keys extends string = string>(
       opts: BuildDictionaryHandleOptions<Keys>,
     ): DictionaryHandle<Keys> {

--- a/packages/hub/src/i18n/core.ts
+++ b/packages/hub/src/i18n/core.ts
@@ -588,5 +588,11 @@ export function applyI18nLocale(
     result = applyAtPath(result, field, locale, fallback, opts)
   }
 
+  // #435 — the internal densify provenance marker never leaves the store.
+  if (Object.prototype.hasOwnProperty.call(result, '_i18nFilled')) {
+    const { _i18nFilled: _omit, ...rest } = result
+    result = rest
+  }
+
   return result
 }

--- a/packages/hub/src/i18n/core.ts
+++ b/packages/hub/src/i18n/core.ts
@@ -589,10 +589,24 @@ export function applyI18nLocale(
   }
 
   // #435 — the internal densify provenance marker never leaves the store.
-  if (Object.prototype.hasOwnProperty.call(result, '_i18nFilled')) {
-    const { _i18nFilled: _omit, ...rest } = result
-    result = rest
-  }
+  result = stripI18nFilled(result)
 
   return result
+}
+
+/**
+ * Remove the internal densify provenance marker (`_i18nFilled`) from a
+ * read-facing record (#435). NON-mutating: returns the same object when the
+ * marker is absent, otherwise a shallow copy without the marker.
+ *
+ * MUST be applied on every user-facing read return — even locale-less ones,
+ * which bypass {@link applyI18nLocale}. MUST NOT be applied on the internal
+ * prior-read path (decryptRecord / resolveDensifyPrior), where densify needs
+ * the marker.
+ */
+export function stripI18nFilled<T extends Record<string, unknown>>(record: T): T {
+  if (!Object.prototype.hasOwnProperty.call(record, '_i18nFilled')) return record
+  const rest: T = { ...record }
+  delete (rest as Record<string, unknown>)._i18nFilled
+  return rest
 }

--- a/packages/hub/src/i18n/core.ts
+++ b/packages/hub/src/i18n/core.ts
@@ -162,6 +162,14 @@ export interface I18nTextOptions {
    * allowed script set. Default `'reject'`.
    */
   readonly onScriptViolation?: 'reject' | 'filter' | 'warn'
+  /**
+   * #435 v1.x — eager-fill empty locale slots from the substitute chain at
+   * write time, recording provenance in the internal `_i18nFilled` marker.
+   * Mutually exclusive with an EXPLICIT `'throw'` onMissing policy (densify
+   * fills every hole, so a throw would be unreachable). Without an explicit
+   * `substitute`, fills from `'any'` (first non-empty). Default absent.
+   */
+  readonly densifyOnWrite?: boolean
 }
 
 /**
@@ -193,7 +201,21 @@ export interface I18nTextDescriptor {
  * ```
  */
 export function i18nText(options: I18nTextOptions): I18nTextDescriptor {
+  if (options.densifyOnWrite === true && hasThrowPolicy(options.onMissing)) {
+    throw new Error(
+      `i18nText: densifyOnWrite cannot be combined with an explicit onMissing 'throw' ` +
+        `policy — densify fills every empty slot, so a 'throw' would be unreachable. ` +
+        `Remove the 'throw' policy or disable densifyOnWrite.`,
+    )
+  }
   return { _noydbI18nText: true, options }
+}
+
+/** True when `onMissing` declares `'throw'` for any layer (scalar or per-layer). */
+function hasThrowPolicy(onMissing: OnMissingPolicy | undefined): boolean {
+  if (onMissing === undefined) return false
+  if (typeof onMissing === 'string') return onMissing === 'throw'
+  return Object.values(onMissing).includes('throw')
 }
 
 /** Runtime predicate for detecting an `I18nTextDescriptor`. */

--- a/packages/hub/src/i18n/densify.ts
+++ b/packages/hub/src/i18n/densify.ts
@@ -65,6 +65,15 @@ export function computeExemptFills(
  * densify-enabled field from the field's substitute chain, recompute unchanged
  * prior fills, clear marks for slots that became authored, and write the
  * resulting `_i18nFilled` marker (removed when empty).
+ *
+ * `prior` is read-only — it is never mutated.
+ *
+ * Provenance uses value-equality (decision A): a slot counts as an unchanged
+ * fill when it was prior-marked AND its value still equals the prior value. A
+ * consequence is that re-authoring a value byte-identical to the existing fill
+ * keeps it classified as a fill (the visible value is unchanged either way; the
+ * slot stays script-exempt and will auto-refresh if its source later changes).
+ * This is inherent to value-equality provenance, not a bug.
  */
 export function densify(
   record: Record<string, unknown>,

--- a/packages/hub/src/i18n/densify.ts
+++ b/packages/hub/src/i18n/densify.ts
@@ -1,0 +1,120 @@
+/**
+ * #435 v1.x densifyOnWrite — eager-fill empty i18n slots from each field's
+ * substitute chain at write time, recording provenance in the internal
+ * `_i18nFilled` marker (decision A: dense map + prior-read).
+ *
+ * Pure functions over plain records; all DB wiring lives in collection.ts.
+ * Only single-leaf i18n fields are supported (array-wildcard paths are
+ * skipped, mirroring auto-translate).
+ */
+import { getAtPath, resolveI18nText } from './core.js'
+import type { I18nTextDescriptor } from './core.js'
+
+const MARKER = '_i18nFilled'
+
+type Leaf = Record<string, string>
+
+/** Locales recorded as densify-filled on the prior record for `field`. */
+function priorFilled(prior: Record<string, unknown> | undefined, field: string): Set<string> {
+  if (!prior) return new Set()
+  const marker = prior[MARKER] as Record<string, string[]> | undefined
+  return new Set(marker?.[field] ?? [])
+}
+
+/** The single leaf map for `field`, or undefined for absent / array-wildcard / non-object. */
+function singleLeaf(record: Record<string, unknown>, field: string): Leaf | undefined {
+  const leaves = getAtPath(record, field)
+  if (leaves.length !== 1) return undefined
+  const leaf = leaves[0]
+  if (!leaf || typeof leaf !== 'object' || Array.isArray(leaf)) return undefined
+  return leaf as Leaf
+}
+
+/**
+ * Per field, the locales that are UNCHANGED round-tripped densify fills — i.e.
+ * marked filled on the prior record AND identical in the incoming record.
+ * These are exempt from write-time script enforcement (they are derived copies,
+ * not authored text). Slots the user changed are NOT exempt (validated as authored).
+ */
+export function computeExemptFills(
+  prior: Record<string, unknown> | undefined,
+  incoming: Record<string, unknown>,
+  fields: Record<string, I18nTextDescriptor>,
+): Map<string, Set<string>> {
+  const out = new Map<string, Set<string>>()
+  if (!prior) return out
+  for (const field of Object.keys(fields)) {
+    const filled = priorFilled(prior, field)
+    if (filled.size === 0) continue
+    const priorLeaf = singleLeaf(prior, field)
+    const incLeaf = singleLeaf(incoming, field)
+    if (!priorLeaf || !incLeaf) continue
+    const exempt = new Set<string>()
+    for (const loc of filled) {
+      if (incLeaf[loc] !== undefined && incLeaf[loc] !== '' && incLeaf[loc] === priorLeaf[loc]) {
+        exempt.add(loc)
+      }
+    }
+    if (exempt.size > 0) out.set(field, exempt)
+  }
+  return out
+}
+
+/**
+ * Mutate `record` in place: fill empty declared-language slots for each
+ * densify-enabled field from the field's substitute chain, recompute unchanged
+ * prior fills, clear marks for slots that became authored, and write the
+ * resulting `_i18nFilled` marker (removed when empty).
+ */
+export function densify(
+  record: Record<string, unknown>,
+  prior: Record<string, unknown> | undefined,
+  fields: Record<string, I18nTextDescriptor>,
+): void {
+  let marker = record[MARKER] as Record<string, string[]> | undefined
+
+  for (const [field, descriptor] of Object.entries(fields)) {
+    const leaf = singleLeaf(record, field)
+    if (!leaf) continue
+    const { languages, substitute, smartSubstitute } = descriptor.options
+    const filledSet = priorFilled(prior, field)
+    const priorLeaf = singleLeaf(prior ?? {}, field)
+    const isUnchangedFill = (loc: string): boolean =>
+      filledSet.has(loc) && priorLeaf?.[loc] !== undefined && leaf[loc] === priorLeaf[loc]
+
+    // Authored source = present, non-empty, NOT an unchanged prior fill.
+    const authored: Leaf = {}
+    for (const [loc, val] of Object.entries(leaf)) {
+      if (typeof val === 'string' && val !== '' && !isUnchangedFill(loc)) authored[loc] = val
+    }
+
+    const filled: string[] = []
+    for (const loc of languages) {
+      if (authored[loc] !== undefined) continue // real value present → not a fill
+      const sub = resolveI18nText(authored, loc, undefined, field, {
+        policy: 'substitute',
+        substitute: substitute ?? ['any'],
+        ...(smartSubstitute ? { smartSubstitute } : {}),
+      })
+      if (typeof sub === 'string' && sub !== '') {
+        leaf[loc] = sub
+        filled.push(loc)
+      } else if (isUnchangedFill(loc)) {
+        delete leaf[loc] // stale fill with no source left → drop it
+      }
+    }
+
+    if (filled.length > 0) {
+      marker ??= {}
+      marker[field] = filled
+    } else if (marker) {
+      delete marker[field]
+    }
+  }
+
+  if (marker && Object.keys(marker).length > 0) {
+    record[MARKER] = marker
+  } else {
+    delete record[MARKER]
+  }
+}

--- a/packages/hub/src/i18n/script.ts
+++ b/packages/hub/src/i18n/script.ts
@@ -139,6 +139,7 @@ export function enforceScript(
   value: Record<string, unknown>,
   field: string,
   descriptor: I18nTextDescriptor,
+  exempt?: ReadonlySet<string>,
 ): { value: Record<string, unknown>; warnings: ScriptWarning[] } {
   const opt = descriptor.options
   if (!opt.script) return { value, warnings: [] }
@@ -148,6 +149,7 @@ export function enforceScript(
   let out = value
 
   for (const [locale, raw] of Object.entries(value)) {
+    if (exempt?.has(locale)) continue
     if (typeof raw !== 'string') continue
     const allowed = allowedFor(descriptor, locale)
     if (fullMatcher(allowed).test(raw)) continue

--- a/packages/hub/src/i18n/strategy.ts
+++ b/packages/hub/src/i18n/strategy.ts
@@ -109,6 +109,27 @@ export interface I18nStrategy {
   ): { value: Record<string, unknown>; warnings: ScriptWarning[] }
 
   /**
+   * Per-field locales that are unchanged round-tripped densify fills (exempt
+   * from write-time script enforcement). Empty under NO_I18N. (#435)
+   */
+  computeExemptFills(
+    prior: Record<string, unknown> | undefined,
+    incoming: Record<string, unknown>,
+    fields: Record<string, I18nTextDescriptor>,
+  ): Map<string, Set<string>>
+
+  /**
+   * Eager-fill empty i18n slots from each field's substitute chain and record
+   * provenance in `record['_i18nFilled']`. Mutates `record`. No-op under
+   * NO_I18N. (#435)
+   */
+  densify(
+    record: Record<string, unknown>,
+    prior: Record<string, unknown> | undefined,
+    fields: Record<string, I18nTextDescriptor>,
+  ): void
+
+  /**
    * Construct a typed `DictionaryHandle` for the named dictionary.
    * Throws under `NO_I18N`.
    */
@@ -135,5 +156,7 @@ export const NO_I18N: I18nStrategy = {
   applyI18nLocale(record) { return record },
   validateI18nTextValue() { throw notEnabled('i18nText field validation') },
   enforceScript(value) { return { value, warnings: [] } },
+  computeExemptFills() { return new Map<string, Set<string>>() },
+  densify() {},
   buildDictionaryHandle() { throw notEnabled('vault.dictionary()') },
 }

--- a/packages/hub/src/i18n/strategy.ts
+++ b/packages/hub/src/i18n/strategy.ts
@@ -105,6 +105,7 @@ export interface I18nStrategy {
     value: Record<string, unknown>,
     field: string,
     descriptor: I18nTextDescriptor,
+    exempt?: ReadonlySet<string>,
   ): { value: Record<string, unknown>; warnings: ScriptWarning[] }
 
   /**

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -56,6 +56,7 @@ import type { ObjectProjection } from './blobs/object-projection.js'
 // re-exports `StoreCoordinationProvider`, which imports `NoydbStore` from this
 // file, so going through it would create an import cycle.
 import type { CoordinationProvider } from './coordination/types.js'
+import type { ScriptWarning } from './i18n/script.js'
 
 /** Format version for encrypted record envelopes. */
 export const NOYDB_FORMAT_VERSION = 1 as const
@@ -1071,6 +1072,19 @@ export interface NoydbEventMap {
   'sync:backup-error': { vault: string; target: string; error: Error }
   'history:save': { vault: string; collection: string; id: string; version: number }
   'history:prune': { vault: string; collection: string; id: string; pruned: number }
+  /**
+   * A non-fatal i18n script violation under `onScriptViolation: 'warn' | 'filter'`.
+   * 'warn' stored the value as-is; 'filter' stripped disallowed characters
+   * (the event is the only signal the stored data was mutated). 'reject'
+   * throws `ScriptViolationError` and emits nothing. (#435)
+   */
+  'i18n:script-violation': {
+    vault: string
+    collection: string
+    id: string
+    mode: 'warn' | 'filter'
+    warning: ScriptWarning
+  }
   /**
    * Emitted when a persisted-index side-car put/delete fails after the
    * main record write already succeeded. The main record is durable; the

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -484,7 +484,11 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 4810→4830 (2026-06-17, FR-8 Task 1): public validateInput() wrapper —
   // thin 14-line method + JSDoc delegating to validateSchemaInput without writing;
   // used by migrateThenMerge staging safety pre-check.
-  'packages/hub/src/collection.ts': 4830,
+  // Bumped 4830→4911 (2026-06-20, #435 Task 7): densifyOnWrite wiring — i18nDensifyFields
+  // field + constructor subset, prior-read + computeExemptFills before enforceScript,
+  // densify() call after the put-validator, plus resolveDensifyPrior + i18nProvenance
+  // accessor. Densify logic lives in src/i18n/densify.ts; only thin call-sites are here.
+  'packages/hub/src/collection.ts': 4911,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -488,7 +488,9 @@ const KERNEL_SURFACE_BUDGET = {
   // field + constructor subset, prior-read + computeExemptFills before enforceScript,
   // densify() call after the put-validator, plus resolveDensifyPrior + i18nProvenance
   // accessor. Densify logic lives in src/i18n/densify.ts; only thin call-sites are here.
-  'packages/hub/src/collection.ts': 4911,
+  // Bumped 4911→4922 (2026-06-20, #435 review): stripI18nFilled at the three
+  // locale-less read returns (get/list early-return, search, static-display final).
+  'packages/hub/src/collection.ts': 4922,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.

--- a/showcases/src/121-with-i18n-densify.showcase.test.ts
+++ b/showcases/src/121-with-i18n-densify.showcase.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Showcase 121 — densifyOnWrite + i18n:script-violation event (#435)
+ *
+ * What you'll learn
+ * ─────────────────
+ * Two i18n tail features that remove friction in bilingual interfaces:
+ *
+ *   1. `densifyOnWrite` — when a record is written with only some locale
+ *      slots filled, the remaining slots are automatically filled from
+ *      the substitute chain at write time ("eager fill").  Downstream
+ *      readers never see an empty slot; no read-time fallback logic is
+ *      needed at the app layer.  `collection.i18nProvenance(id)` tells
+ *      you which slots were filled rather than authored.
+ *
+ *   2. `i18n:script-violation` event (filter mode) — script enforcement
+ *      in `'filter'` mode silently strips disallowed characters instead
+ *      of throwing.  It also emits a typed `ScriptViolationEvent` on
+ *      the `db` so the application layer can log, warn, or surface the
+ *      information to the user — without aborting the write.
+ *
+ * Why it matters
+ * ──────────────
+ * In a Thai/English product, a person's name is typically authored in
+ * one script.  Without densifyOnWrite every read-path (reports, exports,
+ * display components) must implement its own fallback.  With it, the
+ * database guarantees a dense locale map at rest.
+ *
+ * The filter-mode event answers "what happened?" without crashing; it
+ * gives you observability on dirty input (copy-paste from a mixed-script
+ * clipboard, for example) without a hard gate.
+ *
+ * Prerequisites
+ * ─────────────
+ * - Showcase 09 (withI18n basics).
+ * - Showcase 94 (i18n hardening — substitute + script enforcement).
+ *
+ * What to read next
+ * ─────────────────
+ *   - docs/subsystems/i18n.md (§ densifyOnWrite, § script enforcement)
+ *   - docs/superpowers/specs/2026-06-20-i18n-v1x-tail-design.md
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → i18n-densify-on-write
+ * features.yaml → features → i18n-script-violation-event
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { withI18n, i18nText } from '@noy-db/hub/i18n'
+import { memory } from '@noy-db/to-memory'
+
+// ─── Part 1: densifyOnWrite ───────────────────────────────────────────────────
+
+describe('Showcase 121-A — densifyOnWrite: eager locale fill + provenance', () => {
+  it('fills an absent en slot from the authored th value, hides the internal marker', async () => {
+    // Open the vault with a collection that has densifyOnWrite on its name field.
+    // The substitute chain is ['en','th'], so when en is empty the fill sources from th.
+    const db = await createNoydb({
+      store: memory(),
+      user: 'a',
+      secret: 'pw-121-densify',
+      i18nStrategy: withI18n(),
+    })
+    const vault = await db.openVault('staff', { locale: 'en' })
+
+    interface Employee { id: string; name: Record<string, string> }
+    const employees = vault.collection<Employee>('employees', {
+      i18nFields: {
+        name: i18nText({
+          languages: ['th', 'en'],
+          required: 'any',
+          substitute: ['en', 'th'],
+          densifyOnWrite: true,
+        }),
+      },
+    })
+
+    // Write a record with only the Thai name — English is intentionally absent.
+    await employees.put('e1', { id: 'e1', name: { th: 'สมชาย' } })
+
+    // An English-locale reader receives the filled value (no application-layer fallback needed).
+    const e = await employees.get('e1')
+    expect((e as any).name).toBe('สมชาย')
+
+    // The raw read exposes the full dense locale map but NOT the internal provenance marker.
+    // Applications should not depend on _i18nFilled — use i18nProvenance() instead.
+    const raw = await employees.get('e1', { locale: 'raw' })
+    expect((raw as any).name).toEqual({ th: 'สมชาย', en: 'สมชาย' })
+    expect('_i18nFilled' in (raw as any)).toBe(false)
+
+    // i18nProvenance() returns which slots were filled rather than authored.
+    // This is the correct way to ask "did the database fill this, or did the user write it?".
+    const provenance = await employees.i18nProvenance('e1')
+    expect(provenance).toEqual({ name: ['en'] })
+
+    db.close()
+  })
+
+  it('clears provenance when a previously-filled slot is overwritten by the author', async () => {
+    // Once the user provides a real English name, the fill is replaced and
+    // i18nProvenance() no longer mentions that slot — it is now authored.
+    const db = await createNoydb({
+      store: memory(),
+      user: 'a',
+      secret: 'pw-121-densify-b',
+      i18nStrategy: withI18n(),
+    })
+    const vault = await db.openVault('staff', { locale: 'en' })
+
+    interface Employee { id: string; name: Record<string, string> }
+    const employees = vault.collection<Employee>('employees', {
+      i18nFields: {
+        name: i18nText({
+          languages: ['th', 'en'],
+          required: 'any',
+          substitute: ['en', 'th'],
+          densifyOnWrite: true,
+        }),
+      },
+    })
+
+    // Initial write — en is filled from th.
+    await employees.put('e2', { id: 'e2', name: { th: 'สมหญิง' } })
+    expect(await employees.i18nProvenance('e2')).toEqual({ name: ['en'] })
+
+    // Author now provides the real English transliteration.
+    await employees.put('e2', { id: 'e2', name: { th: 'สมหญิง', en: 'Somying' } })
+
+    const raw = await employees.get('e2', { locale: 'raw' })
+    expect((raw as any).name.en).toBe('Somying')
+
+    // Provenance marker is gone — both slots are now authored.
+    expect(await employees.i18nProvenance('e2')).toBeUndefined()
+
+    db.close()
+  })
+})
+
+// ─── Part 2: i18n:script-violation event (filter mode) ───────────────────────
+
+describe('Showcase 121-B — i18n:script-violation event: filter mode strips + reports', () => {
+  it('strips disallowed-script chars, writes the cleaned value, and emits an event', async () => {
+    // The English name field only allows Latin characters.
+    // onScriptViolation: 'filter' means mixed input (e.g. a Thai character
+    // pasted from the clipboard) is silently stripped rather than rejected.
+    // The db emits a typed ScriptViolationEvent so the app layer can react.
+    const db = await createNoydb({
+      store: memory(),
+      user: 'a',
+      secret: 'pw-121-filter',
+      i18nStrategy: withI18n(),
+    })
+
+    const violations: any[] = []
+    // Subscribe BEFORE opening the vault — the event fires during the put().
+    db.on('i18n:script-violation', (e) => violations.push(e))
+
+    const vault = await db.openVault('contacts', { locale: 'en' })
+
+    interface Contact { id: string; name: Record<string, string> }
+    const contacts = vault.collection<Contact>('contacts', {
+      i18nFields: {
+        name: i18nText({
+          languages: ['en'],
+          required: 'any',
+          // Latin-only script enforcement for the en slot.
+          script: { en: ['Latin'] },
+          // 'filter' strips violating chars and emits an event instead of throwing.
+          onScriptViolation: 'filter',
+        }),
+      },
+    })
+
+    // Input contains Thai characters mixed into an otherwise-Latin name
+    // (typical when a user copy-pastes from a mixed-script source).
+    await contacts.put('c1', { id: 'c1', name: { en: 'Somสมchai' } })
+
+    // The stored value has been cleaned — only the Latin characters remain.
+    const stored = await contacts.get('c1', { locale: 'raw' })
+    expect((stored as any).name.en).toBe('Somchai')
+
+    // Exactly one violation event was emitted, describing what was stripped and why.
+    expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({
+      vault: 'contacts',
+      collection: 'contacts',
+      id: 'c1',
+      mode: 'filter',
+    })
+    // The event's warning object identifies the field and locale that triggered it.
+    expect(violations[0].warning).toMatchObject({ field: 'name', locale: 'en' })
+
+    db.close()
+  })
+})


### PR DESCRIPTION
Closes the two genuinely-deferred i18n v1.x items split out of the hardening epic (#285). Both land as opt-in capabilities behind the tree-shaken `withI18n()` strategy — **zero behavior change** for any field that does not opt in.

## Summary

**F1 — `densifyOnWrite`** (`i18nText({ ..., densifyOnWrite: true })`)
- Eager-fills empty declared-language slots from the field's substitute chain (`substitute ?? ['any']`) **at write time**, so the stored locale map is dense and downstream layers never hit a hole.
- Provenance is recorded in an internal `_i18nFilled: { <field>: [<locales>] }` marker — encrypted with the record, **stripped from all reads**, and exposed only via the new `collection.i18nProvenance(id)` audit accessor.
- **Decision A (dense map + prior-read):** densify reads the prior record before script enforcement so a round-tripped derived copy (e.g. Thai in the `en` slot) is **exempt** from script enforcement and **refreshes** when its source changes — while a value the user actually authored into a formerly-filled slot is kept and its marker cleared (no clobber).
- Mutually exclusive with an **explicit** `onMissing: 'throw'` (config-time error — densify fills every hole, so a throw is unreachable); the default is fine.

**F2 — `i18n:script-violation` event**
- New typed channel `noydb.on('i18n:script-violation', …)` on the existing emitter, payload `{ vault, collection, id, mode, warning }` (`warning: ScriptWarning = { field, locale, expected, sample }`).
- Fires for `'warn'` (stored as-is) and `'filter'` (chars stripped — the only signal data was mutated). `'reject'` throws `ScriptViolationError` and emits nothing. Surfaces the warnings `enforceScript` already collected but previously discarded.

## Design / Plan
- Spec: `docs/superpowers/specs/2026-06-20-i18n-v1x-tail-design.md`
- Plan: `docs/superpowers/plans/2026-06-20-i18n-v1x-tail-435.md`
- New logic lives in `packages/hub/src/i18n/densify.ts`; kernel files hold only thin call sites. `collection.ts` ceiling raised 4830 → 4922.
- Subsystem doc (`docs/subsystems/i18n.md`), `features.yaml` nodes, and showcase `121-with-i18n-densify` added.

## Test Plan
- [x] Full hub suite: **2750/2750** passing (295 files)
- [x] `eslint` clean, `tsc --noEmit` clean
- [x] `node scripts/check-architecture.mjs` PASS, `node scripts/validate-features.mjs` PASS
- [x] Showcase `121-with-i18n-densify` 3/3
- [x] Round-trip proof test: Thai `en` fill round-trips without script rejection, refreshes on `th` correction, yields to an authored value (marker cleared)
- [x] Regression: locale-less `get`/`list`/`search` on a densify collection do **not** leak `_i18nFilled`
- [x] Tree-shaking: all densify call sites gated by `i18nDensifyFields`; `NO_I18N` no-ops both methods

## Known non-blocking follow-ups
- **Lazy double-read:** on a densify-enabled collection in lazy mode with an LRU miss, the prior-read and the version path each `adapter.get`+decrypt the same id (correct, just duplicated I/O — bounded to densify collections). Optimizable by threading the resolved prior into the version path.
- **CRDT + densify:** densify mutates the record before the CRDT branch; no densify+CRDT combination exists or is tested. Reads still strip the marker; treat as undefined behavior until specified.