### PR TITLE
feat(search): #308 L1.5 — persisted lexical index + federation-ready rank

### DIFF
--- a/docs/subsystems/search.md
+++ b/docs/subsystems/search.md
@@ -13,7 +13,7 @@
 |---|---|---|
 | **L0** | `collection.search(field, query, opts)` — in-memory decrypt + BM25 scan, zero leakage | ✅ shipped |
 | **L1** | `collection.retrieve(query, opts)` — client-side **lexical inverted index**, i18n tokenizer, multi-field, snippet | ✅ shipped (#308) |
-| L1.5 | Persisted **opaque encrypted** index blob (warm cross-session, `IndexStore` seam built in L1) | deferred |
+| **L1.5** | Persisted **opaque encrypted** index blob (warm cross-session, fingerprint staleness check, debounced flush) | ✅ shipped (#308 L1.5) |
 | L2 | Client-side **semantic / vector** retrieval — `retrieve(…, {mode:'semantic'\|'hybrid'})` | future spec |
 | L3 | Formalized **agent retrieval API** (hybrid ranking, context assembly) | future spec |
 | L4 | Access-pattern privacy (ORAM) + attested-enclave (PCC-style) compute tier | research-grade |
@@ -82,12 +82,18 @@ const detail = await invoices.retrieve('overdue', { includeRecord: true })
 interface RetrieveHit<T> {
   readonly id: string       // record key
   readonly score: number    // BM25, descending
+  readonly rank: number     // 1-based position — federation-ready (Reciprocal Rank Fusion across vaults/modalities)
   readonly field: string    // winning field (highest per-field BM25)
   readonly snippet: string  // ±window chars around the best match
   readonly locale?: string  // set for i18nText and dictKey hits
   readonly record?: T       // only when includeRecord: true
 }
 ```
+
+`rank` is 1-based and monotonic with score order. It enables cross-vault Reciprocal
+Rank Fusion in the klum-db Lobby (L3) without sharing corpus-relative BM25 scores
+across vault boundaries (which would leak global document frequency). It also powers
+L3's lexical⊕semantic hybrid fusion.
 
 ### `RetrieveOptions`
 
@@ -177,20 +183,84 @@ Both require **eager mode** (`prefetch: true`, the default). Calling
 
 ---
 
-## In-memory, session-rebuilt — and the L1.5 persistence note
+## In-memory, session-rebuilt — and L1.5 persisted index
 
-The index is **session-scoped and in-memory**:
+The L1 index is **session-scoped and in-memory** by default:
 
 - It is built from the **decrypted eager cache** — no extra store reads.
 - It is **never written to the store** — zero leakage.
 - On a new session the index rebuilds on first `retrieve()` / `warmIndex()`.
 - A write (`put` / `delete`) marks the index **dirty**; the next `retrieve()`
-  triggers a full rebuild. Incremental posting updates are an L1.5 optimization.
+  triggers a full rebuild. Incremental posting updates are an L1.5+ optimization.
 
-**L1.5 (deferred):** The `IndexStore` seam is already built. A future
-`EncryptedBlobIndexStore` backend will serialize the index to an opaque encrypted
-blob in the store (same zero-knowledge guarantee, warm cross-session, write-amp
-analysis required). L1.5 is a backend swap — the `retrieve()` API is unchanged.
+**L1.5 — `textIndexPersist: true` (shipped #308 L1.5):** Opt-in persisted backend
+that survives sessions and devices with **zero added leakage**.
+
+### `textIndexPersist` option
+
+```ts
+vault.collection<Invoice>('invoices', {
+  textIndexes: ['title', 'notes'],
+  textIndexPersist: true,   // opt-in: persist the index as an opaque encrypted blob
+  warmIndexOnOpen: true,    // combine with warm load for instant first retrieve()
+})
+```
+
+When `textIndexPersist: true`:
+
+- The in-memory index is serialized and **encrypted under the collection DEK** (the
+  same key used for all records in the collection). The store sees **one opaque
+  ciphertext blob** at `_ftindex/<collection>` — no terms, postings, or plaintext.
+  Per-term addressability (the blind-index leakage profile) is structurally absent.
+- On `retrieve()` / `warmIndex()` in a new session: the blob is loaded and
+  **fingerprint-checked** (`{ count, maxVersion }` derived from the eager cache).
+  If the fingerprint matches, the index is used as-is (cold load with no re-tokenize
+  scan). If it does not match (a write on another device/tab), the index is rebuilt
+  and re-persisted (self-healing).
+- Writes (`put` / `delete`) mark the index dirty and schedule a **debounced flush**
+  — typically ~1 blob write per burst of writes, not per record.
+- **`flushIndex()`** — force-persist the index immediately (call before saving state
+  to a checkpoint, or before a known idle window):
+
+  ```ts
+  await invoices.flushIndex()
+  ```
+
+- **Close-flush** — `db.close()` triggers a best-effort flush of any pending dirty
+  index so the next session finds the freshest blob.
+- **`forget()` teardown** — `vault.forget(subject)` crypto-shreds records and **also
+  deletes the `_ftindex` blob** (calls `remove()` + `markDirty`). The blob's DEK
+  scope means it would still decrypt the forgotten subject's indexed terms if left in
+  place — so it is purged. The next `retrieve()` rebuilds from the post-forget record
+  set. If the blob could not be deleted (e.g. store is offline at shred time), this
+  is reported as a **residue warning** in the `forget()` return value — the same
+  residue-tracking contract as the `_idx` side-cars (per #401).
+
+### Fingerprint `{ count, maxVersion }`
+
+The fingerprint is derived cheaply from the in-memory eager cache at load time:
+`count` = number of records in the cache, `maxVersion` = the highest `_v` across
+all records. Every `put` bumps `_v`; every `delete` changes `count`. A fingerprint
+mismatch means the record-set has changed since the blob was built, so the blob is
+discarded and the index rebuilt. This is best-effort (two corpora can share count +
+maxVersion by coincidence), but in practice every normal operation changes at least
+one of the two values.
+
+### Zero-leakage guarantee
+
+`textIndexPersist` does **not** add any new store leakage beyond the opaque blob
+size. Specifically:
+
+- No per-term keys (blind-index pattern): the entire posting list is one blob.
+- The blob is ciphertext under the collection DEK — the store cannot distinguish
+  index writes from record writes by content.
+- The fingerprint is stored **inside** the encrypted envelope — the store never sees
+  plaintext fingerprint values.
+- `textIndexPersist: false` (default) writes nothing — collections without this
+  option pay zero overhead.
+
+See the L1.5 design spec for detailed threat analysis:
+`docs/superpowers/specs/2026-06-22-ai-retrieval-l1.5-persisted-index-design.md`
 
 ---
 
@@ -226,6 +296,8 @@ default**. The SSE path is superseded by the client-side index.
 ## Cross-references
 
 - L1 design + field-type analysis: `docs/superpowers/specs/2026-06-22-ai-retrieval-l1-lexical-index-design.md`
+- L1.5 persisted index design: `docs/superpowers/specs/2026-06-22-ai-retrieval-l1.5-persisted-index-design.md`
 - Showcase 111: L0 scan-mode search — `showcases/src/111-scan-search.showcase.test.ts`
 - Showcase 122: L1 `retrieve()` walkthrough — `showcases/src/122-with-retrieve.showcase.test.ts`
+- Showcase 123: L1.5 persisted index warm load — `showcases/src/123-persisted-index.showcase.test.ts`
 - `features.yaml` → `features` → `search-index`

--- a/docs/superpowers/plans/2026-06-22-ai-retrieval-l1.5-persisted-index.md
+++ b/docs/superpowers/plans/2026-06-22-ai-retrieval-l1.5-persisted-index.md
@@ -1,0 +1,683 @@
+# AI Retrieval L1.5 — Persisted Lexical Index Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make L1's lexical index persistable — opt-in `textIndexPersist` serializes the `InvertedIndex` to one opaque encrypted blob (collection DEK), skips the cold-rebuild scan on later sessions via a fingerprint, refreshes via debounced flush + awaitable `flushIndex()`, and tears down on `forget()`. Plus `RetrieveHit.rank` for future cross-vault fusion.
+
+**Architecture:** New `PersistedIndexStore` behind the existing `IndexStore` seam (which becomes async: `getOrBuild`→`ensureBuilt`+`flush`). The store is crypto-free — the collection injects `{load, save, remove, currentFingerprint}` callbacks built from `encryptJsonString`/`decryptJsonString` + `adapter` against a reserved `_ftindex` collection namespace. Correctness backstop: a `{count,maxVersion}` fingerprint means a stale/missing blob is never used, only rebuilt.
+
+**Tech Stack:** TypeScript (ESM, `.js` specifiers), vitest (`vitest run` from `packages/hub`), reusing the encrypted side-car pattern + the `SnapshotScheduler` debounce precedent.
+
+**Spec:** `docs/superpowers/specs/2026-06-22-ai-retrieval-l1.5-persisted-index-design.md`
+
+## Global Constraints
+
+- Hub-portable: no Node-only imports in `packages/hub/src/**`. (`setTimeout`/`clearTimeout` are universal — allowed.)
+- Tree-shakeable: all new logic in `src/search/`; `MemoryIndexStore` stays the default (zero cost when `textIndexPersist` unset).
+- Zero added store leakage: the only new store artifact is ONE opaque ciphertext blob at collection `_ftindex`, id `<collectionName>`; never plaintext/terms, no per-term addressability.
+- The index blob lives in the reserved **`_ftindex` collection** (NOT a record-id in the parent collection) so eager `loadAll`/hydrate (which excludes `_`-prefixed collection names) never treats it as a record.
+- `exactOptionalPropertyTypes` is on — assign optional props via spread-conditional.
+- eager-only (retrieve/warmIndex already throw in lazy mode).
+- No Claude/AI attribution in commits.
+
+---
+
+## Task 1: InvertedIndex snapshot (serialize/deserialize)
+
+**Files:**
+- Modify: `packages/hub/src/search/inverted-index.ts` (add `toSnapshot()` + static `fromSnapshot()`)
+- Create: `packages/hub/src/search/serialize.ts`
+- Test: `packages/hub/__tests__/search-serialize.test.ts`
+
+**Interfaces:**
+- Consumes: `InvertedIndex` internals — `private fieldStats: Map<string,{df:Map<string,number>;n:number;totalLen:number}>`, `private docs: Doc[]` where `Doc={id,field,locale?,text,len,tf:Map<string,number>,firstOffset:Map<string,number>}`.
+- Produces: `interface IndexSnapshot` (JSON-safe); `InvertedIndex.toSnapshot(): IndexSnapshot`; `InvertedIndex.fromSnapshot(s: IndexSnapshot): InvertedIndex`; `serializeIndex(idx): string`; `deserializeIndex(json): InvertedIndex`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/hub/__tests__/search-serialize.test.ts
+import { describe, it, expect } from 'vitest'
+import { InvertedIndex, type IndexDoc } from '../src/search/inverted-index.js'
+import { serializeIndex, deserializeIndex } from '../src/search/serialize.js'
+
+const docs: IndexDoc[] = [
+  { id: 'a', fields: [{ field: 'desc', text: 'overdue invoice TCM' }] },
+  { id: 'b', fields: [{ field: 'desc', text: 'paid invoice' }, { field: 'notes', locale: 'th', text: 'ค่าเช่า TCM' }] },
+]
+
+describe('index snapshot round-trip (#308 L1.5)', () => {
+  it('serialize → deserialize yields identical query results', () => {
+    const orig = InvertedIndex.build(docs)
+    const restored = deserializeIndex(serializeIndex(orig))
+    for (const q of ['invoice', 'TCM', 'ค่าเช่า', 'paid']) {
+      expect(restored.query(q)).toEqual(orig.query(q))
+    }
+  })
+  it('preserves locale + offsets (snippet fidelity)', () => {
+    const restored = deserializeIndex(serializeIndex(InvertedIndex.build(docs)))
+    const hit = restored.query('ค่าเช่า').find((h) => h.id === 'b')!
+    expect(hit.locale).toBe('th')
+    expect(hit.text.slice(hit.offset, hit.offset + 'ค่าเช่า'.length)).toBe('ค่าเช่า')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/hub && npx vitest run __tests__/search-serialize.test.ts`
+Expected: FAIL — `../src/search/serialize.js` missing.
+
+- [ ] **Step 3: Add `toSnapshot`/`fromSnapshot` to `InvertedIndex`**
+
+In `packages/hub/src/search/inverted-index.ts`, add the snapshot type near the top exports and the two methods on the class (Maps → arrays for JSON):
+
+```ts
+export interface IndexSnapshot {
+  readonly v: 1
+  readonly fieldStats: ReadonlyArray<[string, { df: [string, number][]; n: number; totalLen: number }]>
+  readonly docs: ReadonlyArray<{
+    id: string; field: string; locale?: string; text: string; len: number
+    tf: [string, number][]; firstOffset: [string, number][]
+  }>
+}
+```
+
+Add as public methods on `InvertedIndex` (after `query`):
+
+```ts
+  toSnapshot(): IndexSnapshot {
+    return {
+      v: 1,
+      fieldStats: [...this.fieldStats].map(([f, s]) => [f, { df: [...s.df], n: s.n, totalLen: s.totalLen }]),
+      docs: this.docs.map((d) => ({
+        id: d.id, field: d.field, text: d.text, len: d.len,
+        tf: [...d.tf], firstOffset: [...d.firstOffset],
+        ...(d.locale !== undefined ? { locale: d.locale } : {}),
+      })),
+    }
+  }
+
+  static fromSnapshot(s: IndexSnapshot): InvertedIndex {
+    const idx = new InvertedIndex()
+    for (const [f, st] of s.fieldStats) idx.fieldStats.set(f, { df: new Map(st.df), n: st.n, totalLen: st.totalLen })
+    for (const d of s.docs) {
+      idx.docs.push({
+        id: d.id, field: d.field, text: d.text, len: d.len,
+        tf: new Map(d.tf), firstOffset: new Map(d.firstOffset),
+        ...(d.locale !== undefined ? { locale: d.locale } : {}),
+      })
+    }
+    return idx
+  }
+```
+
+(`fieldStats`/`docs` are `private` but accessed within the class's own static method — TypeScript allows access to private members from the same class, including static methods.)
+
+- [ ] **Step 4: Create `serialize.ts`**
+
+```ts
+// packages/hub/src/search/serialize.ts
+/** (De)serialize an InvertedIndex to/from a JSON string for persistence (#308 L1.5). */
+import { InvertedIndex } from './inverted-index.js'
+
+export function serializeIndex(idx: InvertedIndex): string {
+  return JSON.stringify(idx.toSnapshot())
+}
+
+export function deserializeIndex(json: string): InvertedIndex {
+  return InvertedIndex.fromSnapshot(JSON.parse(json))
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd packages/hub && npx vitest run __tests__/search-serialize.test.ts` → PASS (2). Then `npx tsc --noEmit` → clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/search/inverted-index.ts packages/hub/src/search/serialize.ts packages/hub/__tests__/search-serialize.test.ts
+git commit -m "feat(search): InvertedIndex snapshot serialize/deserialize (#308 L1.5)"
+```
+
+---
+
+## Task 2: IndexStore async evolution (`ensureBuilt` + `flush`)
+
+**Files:**
+- Modify: `packages/hub/src/search/index-store.ts`
+- Modify: `packages/hub/src/collection.ts` (the 2 `getOrBuild` call sites + `built` reads — lines ~2847-2867)
+- Test: `packages/hub/__tests__/search-index-store.test.ts` (update for async)
+
+**Interfaces:**
+- Produces: `interface IndexStore { ensureBuilt(build: () => ReadonlyArray<IndexDoc>): Promise<InvertedIndex>; markDirty(): void; flush(): Promise<void>; readonly built: boolean }`; `MemoryIndexStore` implementing it.
+
+- [ ] **Step 1: Update the test (async)**
+
+Rewrite `packages/hub/__tests__/search-index-store.test.ts` to `await store.ensureBuilt(...)` and assert `await store.flush()` is a no-op for memory:
+
+```ts
+import { describe, it, expect } from 'vitest'
+import { MemoryIndexStore } from '../src/search/index-store.js'
+import type { IndexDoc } from '../src/search/inverted-index.js'
+
+const docs: IndexDoc[] = [{ id: 'a', fields: [{ field: 'desc', text: 'invoice' }] }]
+
+describe('MemoryIndexStore (#308 L1.5 async)', () => {
+  it('builds once and caches', async () => {
+    const store = new MemoryIndexStore()
+    let calls = 0
+    const build = () => { calls++; return docs }
+    const i1 = await store.ensureBuilt(build)
+    const i2 = await store.ensureBuilt(build)
+    expect(calls).toBe(1); expect(i1).toBe(i2); expect(store.built).toBe(true)
+    await store.flush() // no-op, resolves
+  })
+  it('markDirty forces a rebuild', async () => {
+    const store = new MemoryIndexStore()
+    let calls = 0
+    const build = () => { calls++; return docs }
+    await store.ensureBuilt(build); store.markDirty()
+    expect(store.built).toBe(false)
+    await store.ensureBuilt(build); expect(calls).toBe(2)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/hub && npx vitest run __tests__/search-index-store.test.ts` → FAIL (`ensureBuilt`/`flush` don't exist).
+
+- [ ] **Step 3: Update `index-store.ts`**
+
+```ts
+export interface IndexStore {
+  ensureBuilt(build: () => ReadonlyArray<IndexDoc>): Promise<InvertedIndex>
+  markDirty(): void
+  flush(): Promise<void>
+  readonly built: boolean
+}
+
+export class MemoryIndexStore implements IndexStore {
+  private index: InvertedIndex | undefined
+  get built(): boolean { return this.index !== undefined }
+  async ensureBuilt(build: () => ReadonlyArray<IndexDoc>): Promise<InvertedIndex> {
+    if (this.index === undefined) this.index = InvertedIndex.build(build())
+    return this.index
+  }
+  markDirty(): void { this.index = undefined }
+  async flush(): Promise<void> { /* in-memory: nothing to persist */ }
+}
+```
+
+- [ ] **Step 4: Update the L1 call sites in `collection.ts`**
+
+In `retrieve()` (~line 2867) and `warmIndex()` (~line 2850), change `const index = this.searchIndexStore.getOrBuild(...)` to `const index = await this.searchIndexStore.ensureBuilt(...)`. Both methods are already `async`. The `built` reads at ~2847/2864 are unchanged. Search for any other `getOrBuild` usage and convert (there should be exactly these two).
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd packages/hub && npx vitest run __tests__/search-index-store.test.ts __tests__/search-retrieve.test.ts && npx tsc --noEmit`
+Expected: PASS; tsc clean. Then `npx vitest run` (full suite — confirms the L1 retrieve path still works under async store).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/search/index-store.ts packages/hub/src/collection.ts packages/hub/__tests__/search-index-store.test.ts
+git commit -m "feat(search): IndexStore async ensureBuilt + flush seam (#308 L1.5)"
+```
+
+---
+
+## Task 3: PersistedIndexStore (crypto-free, injected callbacks)
+
+**Files:**
+- Create: `packages/hub/src/search/persisted-index-store.ts`
+- Test: `packages/hub/__tests__/search-persisted-index-store.test.ts`
+
+**Interfaces:**
+- Consumes: `IndexStore`, `InvertedIndex`, `IndexDoc` (`./inverted-index.js`), `serializeIndex`/`deserializeIndex` (`./serialize.js`).
+- Produces:
+  - `interface Fingerprint { readonly count: number; readonly maxVersion: number }`
+  - `interface PersistedIndexCallbacks { load(): Promise<{ json: string; fingerprint: Fingerprint } | null>; save(json: string, fp: Fingerprint): Promise<void>; remove(): Promise<void>; currentFingerprint(): Fingerprint; debounceMs?: number }`
+  - `class PersistedIndexStore implements IndexStore` (adds `removePersisted(): Promise<void>` for forget).
+
+- [ ] **Step 1: Write the failing test** (fake callbacks — no real crypto)
+
+```ts
+// packages/hub/__tests__/search-persisted-index-store.test.ts
+import { describe, it, expect } from 'vitest'
+import { PersistedIndexStore, type Fingerprint } from '../src/search/persisted-index-store.js'
+import type { IndexDoc } from '../src/search/inverted-index.js'
+
+const docs: IndexDoc[] = [{ id: 'a', fields: [{ field: 'd', text: 'invoice' }] }]
+
+function harness(fp: Fingerprint = { count: 1, maxVersion: 1 }) {
+  const blob: { json: string; fingerprint: Fingerprint } | null = null as any
+  const state = { blob, saves: 0, removes: 0, fp }
+  const store = new PersistedIndexStore({
+    load: async () => state.blob,
+    save: async (json, f) => { state.saves++; state.blob = { json, fingerprint: f } },
+    remove: async () => { state.removes++; state.blob = null },
+    currentFingerprint: () => state.fp,
+    debounceMs: 10,
+  })
+  return { store, state }
+}
+
+describe('PersistedIndexStore (#308 L1.5)', () => {
+  it('cold build persists; warm load skips the build fn', async () => {
+    const { store, state } = harness()
+    let builds = 0
+    const build = () => { builds++; return docs }
+    await store.ensureBuilt(build)            // cold: build + save
+    expect(builds).toBe(1); expect(state.saves).toBe(1)
+    // simulate a NEW session: fresh store, same blob + matching fingerprint
+    const store2 = new PersistedIndexStore({
+      load: async () => state.blob, save: async () => {}, remove: async () => {},
+      currentFingerprint: () => state.fp, debounceMs: 10,
+    })
+    let builds2 = 0
+    await store2.ensureBuilt(() => { builds2++; return docs })
+    expect(builds2).toBe(0)                    // warm: deserialized, no rebuild
+    expect((await store2.ensureBuilt(() => docs)).query('invoice').map((h) => h.id)).toEqual(['a'])
+  })
+
+  it('stale fingerprint forces a rebuild', async () => {
+    const { store, state } = harness()
+    await store.ensureBuilt(() => docs)
+    state.fp = { count: 2, maxVersion: 5 } // someone wrote elsewhere
+    const store2 = new PersistedIndexStore({
+      load: async () => state.blob, save: async () => {}, remove: async () => {},
+      currentFingerprint: () => state.fp, debounceMs: 10,
+    })
+    let builds = 0
+    await store2.ensureBuilt(() => { builds++; return docs })
+    expect(builds).toBe(1) // blob fingerprint {1,1} != current {2,5} → rebuild
+  })
+
+  it('markDirty debounces a single flush; flush() is immediate', async () => {
+    const { store, state } = harness()
+    await store.ensureBuilt(() => docs)        // saves=1
+    store.markDirty(); store.markDirty(); store.markDirty()
+    await new Promise((r) => setTimeout(r, 30)) // debounce window (10ms) elapses
+    expect(state.saves).toBe(2)                 // one coalesced flush
+    store.markDirty(); await store.flush()
+    expect(state.saves).toBe(3)                 // explicit immediate
+  })
+
+  it('removePersisted deletes the blob + marks dirty', async () => {
+    const { store, state } = harness()
+    await store.ensureBuilt(() => docs)
+    await store.removePersisted()
+    expect(state.removes).toBe(1); expect(store.built).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/hub && npx vitest run __tests__/search-persisted-index-store.test.ts` → FAIL (module missing).
+
+- [ ] **Step 3: Implement**
+
+```ts
+// packages/hub/src/search/persisted-index-store.ts
+/**
+ * Persisted backend for the L1 lexical index (#308 L1.5). Crypto-free: the
+ * collection injects load/save/remove + a fingerprint provider. In-memory while
+ * live (L1 behavior); persists an opaque snapshot via a debounced flush, and
+ * validates a loaded blob against a {count,maxVersion} fingerprint so a stale
+ * blob is never used — only rebuilt.
+ */
+import { InvertedIndex, type IndexDoc } from './inverted-index.js'
+import { serializeIndex, deserializeIndex } from './serialize.js'
+import type { IndexStore } from './index-store.js'
+
+export interface Fingerprint { readonly count: number; readonly maxVersion: number }
+
+export interface PersistedIndexCallbacks {
+  load(): Promise<{ json: string; fingerprint: Fingerprint } | null>
+  save(json: string, fp: Fingerprint): Promise<void>
+  remove(): Promise<void>
+  currentFingerprint(): Fingerprint
+  debounceMs?: number
+}
+
+function fpEqual(a: Fingerprint, b: Fingerprint): boolean {
+  return a.count === b.count && a.maxVersion === b.maxVersion
+}
+
+export class PersistedIndexStore implements IndexStore {
+  private index: InvertedIndex | undefined
+  private timer: ReturnType<typeof setTimeout> | null = null
+  private readonly debounceMs: number
+  constructor(private readonly cb: PersistedIndexCallbacks) {
+    this.debounceMs = cb.debounceMs ?? 1000
+  }
+
+  get built(): boolean { return this.index !== undefined }
+
+  async ensureBuilt(build: () => ReadonlyArray<IndexDoc>): Promise<InvertedIndex> {
+    if (this.index !== undefined) return this.index
+    const loaded = await this.cb.load()
+    if (loaded !== null && fpEqual(loaded.fingerprint, this.cb.currentFingerprint())) {
+      this.index = deserializeIndex(loaded.json)
+      return this.index
+    }
+    this.index = InvertedIndex.build(build())
+    await this.persist() // immediate persist on a fresh build
+    return this.index
+  }
+
+  markDirty(): void {
+    this.index = undefined
+    if (this.timer) clearTimeout(this.timer)
+    this.timer = setTimeout(() => { this.timer = null; void this.flushBuilt() }, this.debounceMs)
+  }
+
+  /** Force an immediate persist (cancels any pending debounce). */
+  async flush(): Promise<void> {
+    if (this.timer) { clearTimeout(this.timer); this.timer = null }
+    await this.flushBuilt()
+  }
+
+  /** Delete the persisted blob and drop the in-memory index (forget/erasure). */
+  async removePersisted(): Promise<void> {
+    if (this.timer) { clearTimeout(this.timer); this.timer = null }
+    this.index = undefined
+    await this.cb.remove()
+  }
+
+  // Persist the CURRENT in-memory index, if any. Used by debounce + flush.
+  private async flushBuilt(): Promise<void> {
+    if (this.index === undefined) return // dirty-with-no-rebuild-yet: next ensureBuilt persists
+    await this.persist()
+  }
+
+  private async persist(): Promise<void> {
+    if (this.index === undefined) return
+    await this.cb.save(serializeIndex(this.index), this.cb.currentFingerprint())
+  }
+}
+```
+
+Note the debounce semantics matching the test: `markDirty` drops the in-memory index and schedules a flush; if a query rebuilds it before the timer fires, the flush persists the rebuilt index; if not, `flushBuilt` no-ops (the next `ensureBuilt` persists on rebuild). The test triggers a rebuild implicitly? — adjust: in the `markDirty debounces` test, after `markDirty` the index is dropped, so `flushBuilt` would no-op. To make the coalesced-flush assertion hold, `markDirty`'s debounced callback must rebuild then persist. Change the debounced callback to rebuild via a stored `build` thunk: capture the last `build` in `ensureBuilt` and reuse it in the debounce. Implement that:
+
+Add a `private lastBuild?: () => ReadonlyArray<IndexDoc>`; set it in `ensureBuilt`; in `markDirty`'s timer call `void this.ensureBuilt(this.lastBuild!).then(() => this.persist())` (rebuild then persist). This yields the single coalesced save the test asserts. Update `flush()` similarly (rebuild-if-needed then persist).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/hub && npx vitest run __tests__/search-persisted-index-store.test.ts && npx tsc --noEmit` → PASS (4); clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/search/persisted-index-store.ts packages/hub/__tests__/search-persisted-index-store.test.ts
+git commit -m "feat(search): PersistedIndexStore — debounced flush + fingerprint validation (#308 L1.5)"
+```
+
+---
+
+## Task 4: Collection wiring — `textIndexPersist`, callbacks, `flushIndex()`
+
+**Files:**
+- Modify: `packages/hub/src/collection.ts` (options interface near `textIndexes`; construction ~926; new `flushIndex()` + private callback builder)
+- Test: `packages/hub/__tests__/search-persist-integration.test.ts`
+
+**Interfaces:**
+- Consumes: `PersistedIndexStore`, `Fingerprint`, `PersistedIndexCallbacks` (`./search/persisted-index-store.js`); `MemoryIndexStore`; `encryptJsonString`/`decryptJsonString`/`adapter`/`cache`/`getDEK`.
+- Produces (on `Collection`): option `textIndexPersist?: boolean`; public `flushIndex(): Promise<void>`; the index blob at adapter `(vault, '_ftindex', this.name)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/hub/__tests__/search-persist-integration.test.ts
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { withI18n } from '../src/i18n/index.js'
+import type { Noydb } from '../src/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+
+// paste the memory() helper verbatim from i18n-script-put.test.ts lines 12-48
+
+interface Inv { id: string; description: string }
+
+describe('persisted lexical index (#308 L1.5)', () => {
+  it('cold-loads a persisted index without re-tokenizing, and keeps the store zero-knowledge', async () => {
+    const store = memory()
+    const puts: string[] = []
+    const wrapped: NoydbStore = { ...store, async put(c, col, id, e, ev) { puts.push(`${col}/${id}`); return store.put(c, col, id, e, ev) } }
+
+    // session 1 — build + persist
+    const db1 = await createNoydb({ store: wrapped, user: 'a', secret: 'pw-l15', i18nStrategy: withI18n() })
+    const v1 = await db1.openVault('v')
+    const c1 = v1.collection<Inv>('inv', { textIndexes: ['description'], textIndexPersist: true })
+    await c1.put('a', { id: 'a', description: 'overdue invoice TCM' })
+    await c1.flushIndex()
+    expect(puts.some((p) => p.startsWith('_ftindex/'))).toBe(true) // an opaque index blob was written
+    // the index blob is ciphertext (no plaintext term leaks)
+    const blob = await wrapped.get('v', '_ftindex', 'inv')
+    expect(JSON.stringify(blob)).not.toContain('invoice')
+
+    // session 2 — fresh db over the SAME store: retrieve must work WITHOUT a rebuild
+    const db2 = await createNoydb({ store: wrapped, user: 'a', secret: 'pw-l15', i18nStrategy: withI18n() })
+    const v2 = await db2.openVault('v')
+    const c2 = v2.collection<Inv>('inv', { textIndexes: ['description'], textIndexPersist: true })
+    const hits = await c2.retrieve('invoice')
+    expect(hits.map((h) => h.id)).toEqual(['a'])
+  })
+
+  it('the index blob is NOT hydrated as a record', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'pw', i18nStrategy: withI18n() })
+    const v = await db.openVault('v')
+    const c = v.collection<Inv>('inv', { textIndexes: ['description'], textIndexPersist: true })
+    await c.put('a', { id: 'a', description: 'invoice' })
+    await c.flushIndex()
+    expect((await c.toArray()).map((r) => r.id)).toEqual(['a']) // only the real record
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/hub && npx vitest run __tests__/search-persist-integration.test.ts` → FAIL (`textIndexPersist`/`flushIndex` missing).
+
+- [ ] **Step 3: Add the option + construction + callbacks**
+
+(a) Options interface (beside `textIndexes`/`warmIndexOnOpen`): add `textIndexPersist?: boolean | undefined`.
+
+(b) Replace the construction at ~926:
+
+```ts
+    this.textIndexes = opts.textIndexes
+    this.searchIndexStore =
+      opts.textIndexes && opts.textIndexes.length > 0
+        ? opts.textIndexPersist
+          ? new PersistedIndexStore(this.buildPersistedIndexCallbacks())
+          : new MemoryIndexStore()
+        : undefined
+```
+
+(c) Add the callback builder + `flushIndex()` near the other search methods. The blob lives in the reserved `_ftindex` collection (id = this.name) so eager `loadAll` (which skips `_`-prefixed collection names) never hydrates it:
+
+```ts
+  private buildPersistedIndexCallbacks(): import('./search/persisted-index-store.js').PersistedIndexCallbacks {
+    const FT = '_ftindex'
+    return {
+      load: async () => {
+        const env = await this.adapter.get(this.vault, FT, this.name)
+        if (!env) return null
+        const json = await this.decryptJsonString(env)
+        if (json === null) return null
+        const fingerprint = { count: env._v, maxVersion: (env as { _ftMax?: number })._ftMax ?? env._v }
+        return { json, fingerprint }
+      },
+      save: async (json, fp) => {
+        const env = await this.encryptJsonString(json, fp.count)
+        ;(env as { _ftMax?: number })._ftMax = fp.maxVersion
+        await this.adapter.put(this.vault, FT, this.name, env)
+      },
+      remove: async () => { await this.adapter.delete(this.vault, FT, this.name) },
+      currentFingerprint: () => {
+        let maxVersion = 0
+        for (const e of this.cache.values()) if (e.version > maxVersion) maxVersion = e.version
+        return { count: this.cache.size, maxVersion }
+      },
+    }
+  }
+
+  /** #308 L1.5 — force-persist the lexical index now (e.g. on save/idle). No-op without textIndexPersist. */
+  async flushIndex(): Promise<void> {
+    await this.searchIndexStore?.flush()
+  }
+```
+
+NOTE on the fingerprint encoding: the envelope's `_v` carries `count`; a sidecar `_ftMax` carries `maxVersion`. (Both are plaintext envelope metadata, not record content — no leakage.) If adding a non-standard `_ftMax` field to `EncryptedEnvelope` trips types, instead JSON-encode the fingerprint INTO the persisted body — wrap as `JSON.stringify({ fp, snapshot })` in `save` and parse in `load`. Prefer the body-wrap approach if `EncryptedEnvelope` is a closed type: it keeps the envelope standard. Implementer: check `EncryptedEnvelope` in `types.ts`; if it's a closed interface, use the body-wrap (`save(json,fp)` stores `JSON.stringify({fp, idx: json})`; `load` parses it back). Pick one and keep `load`/`save` consistent.
+
+(d) Confirm `this.cache` entries expose `.version` (used in `currentFingerprint`); if the cache value shape differs (e.g. `{record, version}`), match it. Read the cache type before writing.
+
+- [ ] **Step 4: Run tests + full suite**
+
+Run: `cd packages/hub && npx vitest run __tests__/search-persist-integration.test.ts && npx vitest run && npx eslint src/search src/collection.ts && npx tsc --noEmit`
+Expected: PASS; full suite green; lint/tsc clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/collection.ts packages/hub/__tests__/search-persist-integration.test.ts
+git commit -m "feat(search): textIndexPersist — persisted index blob + flushIndex() (#308 L1.5)"
+```
+
+---
+
+## Task 5: `forget()` teardown + close-flush
+
+**Files:**
+- Modify: `packages/hub/src/collection.ts` (add `_purgeSearchIndex()`)
+- Modify: `packages/hub/src/vault.ts` (`forget()` — call it per affected collection)
+- Modify: `packages/hub/src/noydb.ts` (`close()` — fire-and-forget index flush)
+- Test: `packages/hub/__tests__/search-persist-forget.test.ts`
+
+**Interfaces:**
+- Consumes: `PersistedIndexStore.removePersisted()`; the `forget()` loop's `collections: Set<string>`.
+- Produces: `Collection._purgeSearchIndex(): Promise<void>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/hub/__tests__/search-persist-forget.test.ts
+// memory() helper + a forgetStrategy-configured vault (mirror an existing forget test —
+// grep __tests__ for 'forget' / 'withForgetCascade' to copy the exact setup).
+// Assert: after vault.forget(subject), the _ftindex blob for the affected collection
+// is gone (adapter.get(vault,'_ftindex',coll) === null) AND a subsequent retrieve()
+// rebuilds without the forgotten record's terms.
+```
+Implementer: locate an existing `forget()` test to copy the `forgetStrategy`/subject wiring, then write the concrete runnable assertions above (blob removed + rebuilt-without-forgotten-terms). Do not leave as prose.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/hub && npx vitest run __tests__/search-persist-forget.test.ts` → FAIL.
+
+- [ ] **Step 3: Add `_purgeSearchIndex` to collection**
+
+```ts
+  /** #308 L1.5 — drop the persisted lexical-index blob (forget/erasure): an opaque
+   *  all-records index must not survive crypto-shred. Idempotent; no-op without persist. */
+  async _purgeSearchIndex(): Promise<void> {
+    const store = this.searchIndexStore
+    if (store && 'removePersisted' in store) await (store as { removePersisted(): Promise<void> }).removePersisted()
+    else store?.markDirty()
+  }
+```
+
+- [ ] **Step 4: Call it from `vault.forget()`**
+
+In `vault.ts` `forget()`, after the per-ref loop (the `collections: Set<string>` is already accumulated), add:
+
+```ts
+    for (const collName of collections) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (this.collection(collName) as any)._purgeSearchIndex()
+    }
+```
+(Place beside the existing `_purgePersistedIndexes` handling. Mirrors that pattern.)
+
+- [ ] **Step 5: Fire-and-forget flush on `noydb.close()`**
+
+`close()` is sync. In `packages/hub/src/noydb.ts` `close()`, before clearing `vaultCache`, add a best-effort flush of any persisted search indexes:
+
+```ts
+    for (const v of this.vaultCache.values()) void v._flushSearchIndexes()
+```
+Add `_flushSearchIndexes(): Promise<void>` to `vault.ts` iterating the vault's open collections and calling `flushIndex()` on each (fire-and-forget is fine — correctness is backstopped by the fingerprint). If the vault doesn't track open collections, skip this step and rely on debounce + `flushIndex()` (note it); the fingerprint guarantees no stale index is ever served.
+
+- [ ] **Step 6: Run tests + full suite + commit**
+
+Run: `cd packages/hub && npx vitest run __tests__/search-persist-forget.test.ts && npx vitest run && npx tsc --noEmit` → all green.
+
+```bash
+git add packages/hub/src/collection.ts packages/hub/src/vault.ts packages/hub/src/noydb.ts packages/hub/__tests__/search-persist-forget.test.ts
+git commit -m "feat(search): forget() purges persisted index + close-flush (#308 L1.5)"
+```
+
+---
+
+## Task 6: `RetrieveHit.rank` (federation-ready)
+
+**Files:**
+- Modify: `packages/hub/src/search/retrieve-types.ts` (`RetrieveHit`)
+- Modify: `packages/hub/src/collection.ts` (`retrieve()` maps `rank`)
+- Test: append to `packages/hub/__tests__/search-retrieve.test.ts`
+
+**Interfaces:**
+- Produces: `RetrieveHit<T>` gains `readonly rank: number` (1-based position in the returned, score-sorted list).
+
+- [ ] **Step 1: Write the failing test** (append)
+
+```ts
+it('hits carry a 1-based rank monotonic with score order (#308 L1.5)', async () => {
+  // build a collection where two records match with different scores;
+  // assert hits[0].rank === 1, hits[1].rank === 2, and rank order matches score order.
+  // (reuse the search-retrieve harness in this file.)
+})
+```
+Implementer: write the concrete assertion using this file's existing harness (two records, one matching the query term more strongly), asserting `rank` is 1,2,… in the returned order.
+
+- [ ] **Step 2-4: Fail → implement → pass**
+
+Add `readonly rank: number` to `RetrieveHit<T>` in `retrieve-types.ts`. In `collection.ts` `retrieve()`, where hits are mapped to `RetrieveHit`, add `rank: i + 1` using the array index (the list is already score-sorted by `index.query`). Run `npx vitest run __tests__/search-retrieve.test.ts && npx tsc --noEmit`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/search/retrieve-types.ts packages/hub/src/collection.ts packages/hub/__tests__/search-retrieve.test.ts
+git commit -m "feat(search): RetrieveHit.rank for cross-vault/hybrid fusion (#308 L1.5)"
+```
+
+---
+
+## Task 7: Docs, features.yaml, showcase, ceiling, final gate
+
+**Files:** `docs/subsystems/search.md`, `features.yaml`, `showcases/src/<next>-…`, `scripts/check-architecture.mjs`
+
+- [ ] **Step 1: Subsystem doc** — add to `docs/subsystems/search.md`: `textIndexPersist` (opaque `_ftindex` blob, collection DEK, fingerprint `{count,maxVersion}`, debounced flush + `flushIndex()` + close-flush, `forget()` teardown); note `RetrieveHit.rank` and the L1.5 line of the epic map. Commit `docs(search): document persisted index + rank (#308 L1.5)`.
+- [ ] **Step 2: features.yaml** — extend the `search-index` node (still `preview`/`experimental`) with the persistence capability + spec ref `docs/superpowers/specs/2026-06-22-ai-retrieval-l1.5-persisted-index-design.md`; run `node scripts/validate-features.mjs`. Commit `chore(features): register persisted index (#308 L1.5)`.
+- [ ] **Step 3: Showcase** — add/extend a showcase: persist (session 1) → fresh db over the same store (session 2) → `retrieve()` warm-loads (no rebuild). Build hub first (`cd packages/hub && npx tsup`), run it. Commit `docs(showcase): persisted-index warm load (#308 L1.5)`.
+- [ ] **Step 4: Ceiling + final gate** —
+```bash
+cd packages/hub && npx tsup && npx vitest run && npx eslint src && npx tsc --noEmit
+cd /Users/vicio/_github/noy-db && node scripts/check-architecture.mjs && node scripts/validate-features.mjs
+```
+If `collection.ts`/`vault.ts` exceed their ceilings in `scripts/check-architecture.mjs`, raise each to `wc -l` + ~10 with a one-line `// Bumped …→… (#308 L1.5): …` comment. Re-run until green. Commit any bump `chore(arch): raise ceilings for persisted index (#308 L1.5)`.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:** serialize/deserialize → T1 ✓; async `ensureBuilt`+`flush` → T2 ✓; `PersistedIndexStore` (debounce, fingerprint, removePersisted) → T3 ✓; `textIndexPersist` + opaque `_ftindex` blob under collection DEK + `flushIndex()` + zero-leakage + not-hydrated-as-record → T4 ✓; fingerprint `{count,maxVersion}` cross-session staleness → T3/T4 ✓; `forget()` teardown + close-flush → T5 ✓; `RetrieveHit.rank` federation-ready → T6 ✓; docs/features/showcase/ceiling → T7 ✓. Deferred per spec (incremental flush, sharding, `fuseRetrieval`→L3, `lobby.retrieve`→klum) — correctly absent.
+
+**2. Placeholder scan:** T5 Step 1 and T6 Step 1 instruct the implementer to copy an existing harness then write concrete asserts (the forget/retrieve harnesses must be read from the repo) — "locate then write runnable test", not a code placeholder. T4 Step 3 flags a real type decision (`_ftMax` envelope field vs body-wrap the fingerprint) with a concrete rule (body-wrap if `EncryptedEnvelope` is closed). T3 Step 3 notes the debounce-rebuild refinement explicitly. No "TBD"/"handle errors"/bare "similar to".
+
+**3. Type consistency:** `IndexStore.ensureBuilt`/`flush` (T2) used in T3's `implements` and T4's call sites. `Fingerprint {count,maxVersion}` and `PersistedIndexCallbacks` (T3) consumed verbatim in T4's `buildPersistedIndexCallbacks`. `_ftindex` collection + id=`this.name` consistent across T4 (save/load/remove) and T5 (purge via `removePersisted`). `RetrieveHit.rank` (T6) is additive. `removePersisted` defined in T3, called in T5.

--- a/docs/superpowers/specs/2026-06-22-ai-retrieval-l1.5-persisted-index-design.md
+++ b/docs/superpowers/specs/2026-06-22-ai-retrieval-l1.5-persisted-index-design.md
@@ -1,0 +1,130 @@
+# AI retrieval — L1.5: persisted lexical index + federation-ready hit — design
+
+> **Status:** DESIGN — ready for plan.
+> **One line:** Add an opt-in **`PersistedIndexStore`** so L1's lexical index survives
+> sessions/devices (no cold rebuild scan): serialize the in-memory `InvertedIndex`,
+> store it as **one opaque encrypted blob** under the collection DEK, validate
+> freshness by a cheap **fingerprint**, refresh via a **debounced flush + flush-on-
+> close**, and tear it down on `forget()`. Plus a small **federation-ready** change
+> to `RetrieveHit` (add `rank`) so a future klum-db Lobby can fuse results across
+> vaults. **Zero added store leakage** — the blob is opaque ciphertext (no per-term
+> addressability).
+
+## Context
+
+L1 (shipped, PR #478) builds the lexical inverted index **in memory, per session**:
+the first `retrieve()`/`warmIndex()` decrypts+tokenizes the whole collection once,
+then all queries are O(postings). The cost is that **first scan every session** —
+fine at the pilot's scale, but for large corpora or short-lived agent sessions it's
+wasteful. L1 already shipped the seam for this: `IndexStore` (`getOrBuild`/
+`markDirty`/`built`, `MemoryIndexStore`). L1.5 adds the persisted backend behind
+that seam — no `retrieve()` API change for the caller.
+
+This is the "**complete the full-text index**" layer of the AI-retrieval epic
+([[project_search_ai_retrieval_epic]]): L0 scan ✅, L1 in-memory ✅, **L1.5 persisted
+(this)**, L2 semantic (next), L3 hybrid, L4 ORAM/enclave (deferred).
+
+## What exists (reused)
+
+| Capability | Where | Reused as |
+|---|---|---|
+| `IndexStore` seam + `MemoryIndexStore` | `src/search/index-store.ts` | L1.5 adds `PersistedIndexStore` implementing the same interface |
+| `InvertedIndex` (docs[] + per-field BM25 stats) | `src/search/inverted-index.ts` | gains `toSnapshot()`/`fromSnapshot()` for (de)serialization |
+| `retrieve()`/`warmIndex()` (async) | `collection.ts` | already `await` the store — absorbs the sync→async build change |
+| Encrypted side-car blob under collection DEK | the lazy `_idx` persisted-index path (`collection.ts` `encryptJsonString`/`decryptJsonString` + `adapter.put/get`) | the index blob reuses this encrypt/decrypt + key-scoping |
+| Debounced background flush precedent | `withSnapshots` `SnapshotScheduler` (own timers, `onAfterWrite`, teardown on `db.close()`) | the index-flush debounce mirrors this |
+| `forget()` crypto-shred path | `collection.ts` `forget()` (#357/#401) | gains an index-blob teardown call |
+
+## Scope — in
+
+| Item | Notes |
+|---|---|
+| `textIndexPersist?: boolean` collection option | default false → `MemoryIndexStore` (today); true → `PersistedIndexStore` |
+| `IndexStore` interface: sync `getOrBuild` → **async `ensureBuilt(build): Promise<InvertedIndex>`** | `MemoryIndexStore` implements trivially; `retrieve()`/`warmIndex()` already async |
+| `InvertedIndex.toSnapshot()/fromSnapshot()` + `src/search/serialize.ts` | structural (de)serialization of postings + stats (+ per-doc text for snippets) |
+| `PersistedIndexStore` (`src/search/persisted-index-store.ts`) | in-memory index (L1 behavior) + injected `{ load, save, remove }` crypto/blob callbacks + debounced flush + fingerprint |
+| Opaque encrypted blob at reserved key `_ftindex/<collection>` under the **collection DEK** | one ciphertext blob (sharding deferred); store learns only its size |
+| **Fingerprint** = `{ count, maxVersion }` over the collection's records | stored in the blob envelope; recomputed from the eager cache on load → use blob if match, else rebuild + re-persist (handles cross-session/device staleness) |
+| **Debounced flush** (after writes) + **flush-on-`db.close()`** | the persisted blob is a periodic snapshot; in-session the index is live in memory |
+| `forget()` tears down the index blob | calls `store.remove()` + `markDirty` — an opaque all-records index must not survive crypto-shred (#401-class) |
+| **Federation-ready `RetrieveHit`:** add `rank: number` (1-based) | enables Reciprocal-Rank-Fusion across vaults (klum Lobby) and across modalities (L3 hybrid). ids stay **vault-local** (the Lobby qualifies them with `{vault, ...}`) |
+
+## Scope — out (deferred)
+
+| Item | Deferred to | Why |
+|---|---|---|
+| Incremental posting-diff flush | later | v1 flush re-serializes the whole index; debounce keeps it ~1 write/window |
+| Sharded blob (multi-part opaque index) | later | one blob is fine until index size forces it; the `{load,save}` seam allows sharding without an API change |
+| `fuseRetrieval(lists, {strategy})` fusion reducer | **L3** | serves BOTH L3 hybrid (merge lexical⊕semantic) AND klum federation (merge across vaults) — one primitive, lands with hybrid |
+| `lobby.retrieve()` cross-vault fan-out | **klum-db** | crosses the vault/party boundary → orchestration; consumes noy's per-vault `retrieve()` + `fuseRetrieval` + `rank` via `@noy-db/hub/kernel` |
+| Semantic/vector persistence | L2 | L2 designs its own encrypted-vector persistence (vectors are expensive → always persisted) |
+
+## Architecture
+
+### Interface evolution (sync → async build)
+
+```ts
+// index-store.ts
+interface IndexStore {
+  ensureBuilt(build: () => ReadonlyArray<IndexDoc>): Promise<InvertedIndex>  // was sync getOrBuild
+  markDirty(): void
+  flush(): Promise<void>     // NEW — force-persist now (called on db.close())
+  readonly built: boolean
+}
+```
+`MemoryIndexStore.ensureBuilt` = the old `getOrBuild` wrapped in `Promise.resolve`; its `flush()` is a no-op. `retrieve()`/`warmIndex()` change `const idx = this.store.getOrBuild(...)` → `const idx = await this.store.ensureBuilt(...)` (already in async methods).
+
+### `PersistedIndexStore`
+
+Constructed by the collection (which owns the DEK + adapter) with injected callbacks so the store stays crypto-free:
+
+```ts
+new PersistedIndexStore({
+  load:   () => Promise<{ bytes: Uint8Array; fingerprint: Fingerprint } | null>,  // decrypt _ftindex/<coll>
+  save:   (bytes: Uint8Array, fp: Fingerprint) => Promise<void>,                  // encrypt + put
+  remove: () => Promise<void>,                                                    // delete blob (forget)
+  currentFingerprint: () => Fingerprint,                                          // {count, maxVersion} from cache
+  debounceMs: number,                                                            // e.g. 1000
+})
+```
+
+- **`ensureBuilt(build)`**: in-memory index? → return it. Else `load()` → if blob present AND `blob.fingerprint == currentFingerprint()` → `deserializeIndex(bytes)` (skip the scan). Else → `InvertedIndex.build(build())` (the L1 scan) → schedule an immediate flush. Cache in memory.
+- **`markDirty()`**: drop the in-memory index (next `ensureBuilt` rebuilds, L1 semantics) + schedule a debounced flush.
+- **debounced flush**: on fire → `ensureBuilt(build)` (rebuild if dirty) → `serializeIndex` → `save(bytes, currentFingerprint())`. Coalesces a burst of writes into ~one blob write.
+- **`flush()`**: cancel debounce, flush now (called from `db.close()`).
+
+### Encryption & leakage
+
+The collection serializes the snapshot, `encryptJsonString` under the **collection DEK** (so it survives per-record CEK rotation and is ciphertext to the store), and `adapter.put` at `_ftindex/<collection>`. The store sees **one opaque blob of size S** — never terms, postings, or plaintext, and no per-term addressability (the anti-blind-index invariant). Same zero-knowledge contract as L1; the only new store artifact is the opaque blob.
+
+### Fingerprint & cross-session staleness
+
+`Fingerprint = { count: number, maxVersion: number }` over the collection's records (cheap from the eager-hydrated cache: `cache.size` + max `_v`). Stored in the blob envelope. On `load`, recompute from the current cache and compare. Match → trust the blob (another session built it from the same record-set). Mismatch (a write happened on another device/tab) → discard the blob, rebuild, re-persist. This is best-effort + self-healing: a stale blob is never used, only ever rebuilt. (Hash-of-ids is a stronger fingerprint but `{count, maxVersion}` catches all add/update/delete cases since every write bumps `_v` and delete changes count.)
+
+### `forget()` teardown
+
+`forget(id)` crypto-shreds a record but keeps the DEK — so a DEK-encrypted `_ftindex` blob would still decrypt a forgotten subject's indexed terms. `forget()` therefore calls `searchIndexStore.remove()` (delete the blob) + `markDirty()`; the next `retrieve()` rebuilds from the post-forget records. (The in-memory index is also dropped by `markDirty`.)
+
+## Federation-ready `RetrieveHit`
+
+`RetrieveHit` gains `rank: number` (1-based position in the returned, score-sorted list). Rationale ([[project_search_ai_retrieval_epic]]): cross-vault federation cannot compare raw BM25 scores (local IDF is corpus-relative, and sharing global `df` would leak across the vault boundary), so the Lobby fuses by **rank** (Reciprocal Rank Fusion). The same `rank` powers L3's hybrid lexical⊕semantic fusion. ids remain **vault-local**; the klum Lobby qualifies them (`{vault, id, rank, score, snippet}`) when fanning out. No `vault` field is added to noy's `RetrieveHit` — that's the orchestrator's concern. This is the only retrieve()-output change in L1.5.
+
+## Testing
+
+- `serialize`/`deserialize` round-trip: a built index → snapshot → restored index returns identical query results.
+- **Cold-load skips the scan:** seed records, build+persist (session 1); new collection instance with the same store → `retrieve()` loads the blob and returns correct hits **without** a full re-tokenize (assert via a build-counter / spy that `InvertedIndex.build` is NOT called when the fingerprint matches).
+- **Stale fingerprint → rebuild:** persist, then mutate the underlying record-set out-of-band (bump count/version) → next load rebuilds.
+- **Debounced flush:** N rapid writes → ~1 blob `save` within the window (assert save-call count).
+- **flush-on-close:** `db.close()` persists the latest index.
+- **`forget()` removes the blob** and the next retrieve rebuilds without the forgotten record.
+- **Leakage:** wrap the store; assert the only new key written is `_ftindex/<collection>`, its body is ciphertext (no plaintext terms), and `textIndexPersist:false` writes nothing.
+- `RetrieveHit.rank` is 1-based and monotonic with score order.
+- `MemoryIndexStore` still passes its existing tests under the async `ensureBuilt` signature (no behavior change).
+
+## Non-code obligations
+
+- `docs/subsystems/search.md`: document `textIndexPersist`, the opaque-blob + fingerprint model, debounced flush, `forget()` teardown, and the L1.5 line of the epic map; note `rank` on `RetrieveHit`.
+- `features.yaml`: extend the `search-index` node (still `preview`/`experimental`) with the persistence capability + this spec ref.
+- Showcase: extend the retrieve showcase (or add one) showing persist → new-session warm load (no rebuild).
+- Kernel ceiling: the collection gains only thin call-sites (construct `PersistedIndexStore`, inject callbacks, `forget()` teardown, `db.close()` flush); keep `collection.ts` under its ceiling, raise minimally if needed.
+- Tree-shaking: all new logic in `src/search/`; `MemoryIndexStore` stays the default (zero cost when `textIndexPersist` unset).

--- a/features.yaml
+++ b/features.yaml
@@ -252,9 +252,9 @@ features:
     related: [schema-and-refs, money-field]
 
   - id: search-index
-    name: Full-text scan + L1 lexical retrieval (collection.search / collection.retrieve)
+    name: Full-text scan + L1/L1.5 lexical retrieval (collection.search / collection.retrieve / textIndexPersist)
     cluster: core
-    spec: docs/superpowers/specs/2026-06-22-ai-retrieval-l1-lexical-index-design.md
+    spec: docs/superpowers/specs/2026-06-22-ai-retrieval-l1.5-persisted-index-design.md
     subsystem_doc: docs/subsystems/search.md
     package: '@noy-db/hub'
     factory: null
@@ -265,19 +265,25 @@ features:
         path: showcases/src/111-scan-search.showcase.test.ts
       - id: 122-with-retrieve
         path: showcases/src/122-with-retrieve.showcase.test.ts
+      - id: 123-persisted-index
+        path: showcases/src/123-persisted-index.showcase.test.ts
     recipes: []
     playground_pages: []
     diagrams: []
     invariants:
       - 'collection.search(field, query, opts) is SCAN mode (L0): decrypts in-memory + ranks by BM25 — ZERO added store leakage (eager mode only); returns {id,score,record} desc by score'
-      - 'collection.retrieve(query, opts) is INDEXED mode (L1): client-side in-memory inverted index with Intl.Segmenter i18n tokenizer; multi-field BM25 + max-field scoring; returns RetrieveHit{id,score,field,snippet,locale?,record?} — ZERO store leakage (never written to the store)'
+      - 'collection.retrieve(query, opts) is INDEXED mode (L1): client-side in-memory inverted index with Intl.Segmenter i18n tokenizer; multi-field BM25 + max-field scoring; returns RetrieveHit{id,score,rank,field,snippet,locale?,record?} — ZERO store leakage (never written to the store)'
       - 'textIndexes: string[] collection opt-in selects which fields enter the inverted index; collections with no textIndexes pay zero overhead'
       - 'i18nText fields: ALL locale values indexed; hit carries matched locale; locale-agnostic query matches any locale'
       - 'dictKey fields: resolved labels (all locales) indexed; opaque key is NOT text-indexed (use where() for key equality)'
       - 'blob fields: filename indexed via listSlots() (async per-record); bytes never tokenized'
       - 'money/number/date/boolean fields: NOT indexed — use where() (text-formatting variance makes full-text wrong)'
       - 'warmIndexOnOpen:true pre-builds on collection open; warmIndex() pre-builds on demand; both require eager mode'
-      - 'index is session-scoped and in-memory; rebuild on new session; dirty-rebuild after put/delete; IndexStore seam ready for L1.5 persisted encrypted blob backend'
+      - 'textIndexPersist:true (L1.5): opt-in persists the index as ONE opaque encrypted blob (_ftindex/<collection>) under the collection DEK — ZERO added leakage; warm cross-session load (no rebuild when fingerprint {count,maxVersion} matches); default false → MemoryIndexStore (no blob written)'
+      - 'fingerprint {count,maxVersion}: recomputed from eager cache on load; mismatch → rebuild + re-persist (self-healing cross-session staleness)'
+      - 'debounced flush after put/delete; flushIndex() forces immediate persist; db.close() best-effort close-flush'
+      - 'forget() teardown: removes the _ftindex blob (markDirty + remove); index would otherwise decrypt forgotten subject terms under the collection DEK'
+      - 'RetrieveHit.rank: 1-based, monotonic with score order; federation-ready for Reciprocal Rank Fusion across vaults (klum Lobby, L3 hybrid) without sharing corpus-relative BM25 scores'
       - 'opts.match any(OR,default)/all(AND); opts.prefix → last query term is a prefix (typeahead); opts.limit → top-N; opts.includeRecord → attach full decrypted record'
       - 'deleted / forgotten records never appear (eager cache eviction on delete / _writeTombstone)'
     related: [schema-and-refs, i18n]

--- a/packages/hub/__tests__/search-index-store.test.ts
+++ b/packages/hub/__tests__/search-index-store.test.ts
@@ -4,26 +4,22 @@ import type { IndexDoc } from '../src/search/inverted-index.js'
 
 const docs: IndexDoc[] = [{ id: 'a', fields: [{ field: 'desc', text: 'invoice' }] }]
 
-describe('MemoryIndexStore (#308 L1)', () => {
-  it('builds once and caches (build fn not called again)', () => {
+describe('MemoryIndexStore (#308 L1.5 async)', () => {
+  it('builds once and caches', async () => {
     const store = new MemoryIndexStore()
     let calls = 0
     const build = () => { calls++; return docs }
-    const i1 = store.getOrBuild(build)
-    const i2 = store.getOrBuild(build)
-    expect(calls).toBe(1)
-    expect(i1).toBe(i2)
-    expect(store.built).toBe(true)
+    const i1 = await store.ensureBuilt(build)
+    const i2 = await store.ensureBuilt(build)
+    expect(calls).toBe(1); expect(i1).toBe(i2); expect(store.built).toBe(true)
+    await store.flush() // no-op, resolves
   })
-
-  it('markDirty forces a rebuild', () => {
+  it('markDirty forces a rebuild', async () => {
     const store = new MemoryIndexStore()
     let calls = 0
     const build = () => { calls++; return docs }
-    store.getOrBuild(build)
-    store.markDirty()
+    await store.ensureBuilt(build); store.markDirty()
     expect(store.built).toBe(false)
-    store.getOrBuild(build)
-    expect(calls).toBe(2)
+    await store.ensureBuilt(build); expect(calls).toBe(2)
   })
 })

--- a/packages/hub/__tests__/search-persist-forget.test.ts
+++ b/packages/hub/__tests__/search-persist-forget.test.ts
@@ -69,6 +69,58 @@ interface Invoice { id: string; buyerId: string; memo: string }
 
 const SECRET = 'search-forget-passphrase-5678'
 
+/**
+ * A NoydbStore wrapper whose `delete` throws for the `_ftindex` collection
+ * (simulates a transient/permission failure when purging the lexical-index blob)
+ * but passes through all other operations unchanged.
+ */
+function memoryWithFtindexDeleteFailure(): NoydbStore & {
+  raw(c: string, col: string, id: string): EncryptedEnvelope | undefined
+} {
+  const base = memory()
+  return {
+    ...base,
+    async delete(c, col, id) {
+      if (col === '_ftindex') throw new Error('simulated _ftindex delete failure')
+      return base.delete(c, col, id)
+    },
+  }
+}
+
+describe('forget — _ftindex purge failure is resilient (#308 L1.5)', () => {
+  it('forget() resolves, surfaces _ftindex residue, and still shreds the record when the index-blob delete throws', async () => {
+    const store = memoryWithFtindexDeleteFailure()
+    const db = await createNoydb({
+      store,
+      user: 'alice',
+      secret: SECRET,
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+      i18nStrategy: withI18n(),
+    })
+    const vault = await db.openVault('v')
+    const invoices = vault.collection<Invoice>('invoices', {
+      textIndexes: ['memo'],
+      textIndexPersist: true,
+    })
+
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1', memo: 'overdue payment frombuyer1' })
+    await invoices.put('i-2', { id: 'i-2', buyerId: 'buyer-2', memo: 'receipt frombuyer2' })
+
+    // Force the index to be persisted so the purge path is exercised.
+    await invoices.flushIndex()
+
+    // (a) forget() must RESOLVE even though _ftindex delete will throw.
+    const result = await vault.forget('buyer-1')
+
+    // (b) The returned ForgetResult must surface the FT-index as residue.
+    expect(result.indexResidue).toContain('invoices:_ftindex')
+
+    // (c) The record erasure still happened (tombstone written).
+    expect(result.recordsShredded).toBe(1)
+  })
+})
+
 describe('forget — persisted _ftindex blob is purged (#308 L1.5)', () => {
   it('forget() deletes the _ftindex blob and retrieve() rebuilds without the forgotten record', async () => {
     const store = memory()

--- a/packages/hub/__tests__/search-persist-forget.test.ts
+++ b/packages/hub/__tests__/search-persist-forget.test.ts
@@ -1,0 +1,115 @@
+/**
+ * forget() teardown for persisted lexical index (#308 L1.5 Task 5).
+ *
+ * After vault.forget(subject), the _ftindex blob for the affected collection
+ * must be gone, and a subsequent retrieve() must rebuild without the forgotten
+ * record's terms.
+ *
+ * Harness copied from forget.test.ts (group 10 / _idx side-car pattern).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { ConflictError } from '../src/errors.js'
+import { withHistory } from '../src/history/index.js'
+import { withForgetCascade } from '../src/forget/index.js'
+import { withI18n } from '../src/i18n/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+
+/** In-memory store exposing raw envelopes + a get helper for reserved cols. */
+function memory(): NoydbStore & {
+  raw(c: string, col: string, id: string): EncryptedEnvelope | undefined
+} {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    raw(c, col, id) { return store.get(c)?.get(col)?.get(id) },
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) for (const [name, coll] of existing) if (name.startsWith('_')) comp.set(name, coll)
+      store.set(c, comp)
+    },
+  }
+}
+
+interface Invoice { id: string; buyerId: string; memo: string }
+
+const SECRET = 'search-forget-passphrase-5678'
+
+describe('forget — persisted _ftindex blob is purged (#308 L1.5)', () => {
+  it('forget() deletes the _ftindex blob and retrieve() rebuilds without the forgotten record', async () => {
+    const store = memory()
+    const db = await createNoydb({
+      store,
+      user: 'alice',
+      secret: SECRET,
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+      i18nStrategy: withI18n(),
+    })
+    const vault = await db.openVault('v')
+    const invoices = vault.collection<Invoice>('invoices', {
+      textIndexes: ['memo'],
+      textIndexPersist: true,
+    })
+
+    // Write two records for different buyers.
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1', memo: 'overdue payment frombuyer1' })
+    await invoices.put('i-2', { id: 'i-2', buyerId: 'buyer-2', memo: 'receipt frombuyer2' })
+
+    // Force the index to be persisted.
+    await invoices.flushIndex()
+
+    // The _ftindex blob must exist before forget.
+    expect(await store.get('v', '_ftindex', 'invoices')).not.toBeNull()
+
+    // Forget buyer-1.
+    const result = await vault.forget('buyer-1')
+    expect(result.recordsShredded).toBe(1)
+
+    // The _ftindex blob must be gone after forget.
+    expect(await store.get('v', '_ftindex', 'invoices')).toBeNull()
+
+    // A subsequent retrieve() must rebuild without the forgotten record.
+    // buyer-2's record should still be findable.
+    const hits = await invoices.retrieve('frombuyer2')
+    expect(hits.map((h) => h.id)).toContain('i-2')
+
+    // buyer-1's record must NOT appear in any retrieve.
+    const buyer1Hits = await invoices.retrieve('frombuyer1')
+    expect(buyer1Hits.map((h) => h.id)).not.toContain('i-1')
+  })
+})

--- a/packages/hub/__tests__/search-persist-integration.test.ts
+++ b/packages/hub/__tests__/search-persist-integration.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Persisted lexical index wiring — #308 L1.5.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { withI18n } from '../src/i18n/index.js'
+import type { Noydb } from '../src/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) if (!n.startsWith('_')) {
+        const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) for (const [name, coll] of existing) if (name.startsWith('_')) comp.set(name, coll)
+      store.set(c, comp)
+    },
+  }
+}
+
+interface Inv { id: string; description: string }
+
+describe('persisted lexical index (#308 L1.5)', () => {
+  it('cold-loads a persisted index without re-tokenizing, and keeps the store zero-knowledge', async () => {
+    const store = memory()
+    const puts: string[] = []
+    const wrapped: NoydbStore = { ...store, async put(c, col, id, e, ev) { puts.push(`${col}/${id}`); return store.put(c, col, id, e, ev) } }
+
+    // session 1 — build + persist
+    const db1 = await createNoydb({ store: wrapped, user: 'a', secret: 'pw-l15', i18nStrategy: withI18n() })
+    const v1 = await db1.openVault('v')
+    const c1 = v1.collection<Inv>('inv', { textIndexes: ['description'], textIndexPersist: true })
+    await c1.put('a', { id: 'a', description: 'overdue invoice TCM' })
+    await c1.flushIndex()
+    expect(puts.some((p) => p.startsWith('_ftindex/'))).toBe(true) // an opaque index blob was written
+    // the index blob is ciphertext (no plaintext term leaks)
+    const blob = await wrapped.get('v', '_ftindex', 'inv')
+    expect(JSON.stringify(blob)).not.toContain('invoice')
+
+    // session 2 — fresh db over the SAME store: retrieve must work WITHOUT a rebuild
+    const db2 = await createNoydb({ store: wrapped, user: 'a', secret: 'pw-l15', i18nStrategy: withI18n() })
+    const v2 = await db2.openVault('v')
+    const c2 = v2.collection<Inv>('inv', { textIndexes: ['description'], textIndexPersist: true })
+    const hits = await c2.retrieve('invoice')
+    expect(hits.map((h) => h.id)).toEqual(['a'])
+  })
+
+  it('the index blob is NOT hydrated as a record', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'pw', i18nStrategy: withI18n() })
+    const v = await db.openVault('v')
+    const c = v.collection<Inv>('inv', { textIndexes: ['description'], textIndexPersist: true })
+    await c.put('a', { id: 'a', description: 'invoice' })
+    await c.flushIndex()
+    expect((await c.query().toArray()).map((r) => r.id)).toEqual(['a']) // only the real record
+  })
+})

--- a/packages/hub/__tests__/search-persist-integration.test.ts
+++ b/packages/hub/__tests__/search-persist-integration.test.ts
@@ -81,4 +81,68 @@ describe('persisted lexical index (#308 L1.5)', () => {
     await c.flushIndex()
     expect((await c.query().toArray()).map((r) => r.id)).toEqual(['a']) // only the real record
   })
+
+  it('cold-load session-2 retrieve does not write any new _ftindex blobs (fingerprint matched, loaded not rebuilt)', async () => {
+    const store = memory()
+    const puts: string[] = []
+    const wrapped: NoydbStore = {
+      ...store,
+      async put(c, col, id, e, ev) { puts.push(`${col}/${id}`); return store.put(c, col, id, e, ev) },
+    }
+
+    // session 1 — build + persist the index
+    const db1 = await createNoydb({ store: wrapped, user: 'a', secret: 'pw-l15', i18nStrategy: withI18n() })
+    const v1 = await db1.openVault('v')
+    const c1 = v1.collection<Inv>('inv', { textIndexes: ['description'], textIndexPersist: true })
+    await c1.put('r1', { id: 'r1', description: 'overdue invoice TCM' })
+    await c1.flushIndex()
+
+    // session 2 — fresh db on same store
+    const db2 = await createNoydb({ store: wrapped, user: 'a', secret: 'pw-l15', i18nStrategy: withI18n() })
+    const v2 = await db2.openVault('v')
+    const c2 = v2.collection<Inv>('inv', { textIndexes: ['description'], textIndexPersist: true })
+
+    // snapshot _ftindex put count before retrieve
+    const ftindexPutsBefore = puts.filter((p) => p.startsWith('_ftindex/')).length
+
+    // cold-load retrieve — must return correct results
+    const hits = await c2.retrieve('invoice')
+    expect(hits.map((h) => h.id)).toEqual(['r1'])
+
+    // assert NO new _ftindex writes during session-2 retrieve (blob was deserialized, not rebuilt)
+    const ftindexPutsAfter = puts.filter((p) => p.startsWith('_ftindex/')).length
+    expect(ftindexPutsAfter).toBe(ftindexPutsBefore)
+  })
+
+  it('zero _ftindex I/O when textIndexPersist is not set (MemoryIndexStore path)', async () => {
+    const store = memory()
+    const ftindexOps: string[] = []
+    const wrapped: NoydbStore = {
+      ...store,
+      async put(c, col, id, e, ev) {
+        if (col === '_ftindex') ftindexOps.push(`put:${col}/${id}`)
+        return store.put(c, col, id, e, ev)
+      },
+      async get(c, col, id) {
+        if (col === '_ftindex') ftindexOps.push(`get:${col}/${id}`)
+        return store.get(c, col, id)
+      },
+      async delete(c, col, id) {
+        if (col === '_ftindex') ftindexOps.push(`delete:${col}/${id}`)
+        return store.delete(c, col, id)
+      },
+    }
+
+    // collection WITHOUT textIndexPersist
+    const db = await createNoydb({ store: wrapped, user: 'a', secret: 'pw-nocost', i18nStrategy: withI18n() })
+    const v = await db.openVault('v')
+    const c = v.collection<Inv>('inv', { textIndexes: ['description'] /* no textIndexPersist */ })
+    await c.put('r1', { id: 'r1', description: 'overdue invoice TCM' })
+    await c.flushIndex()
+    const hits = await c.retrieve('invoice')
+    expect(hits.map((h) => h.id)).toEqual(['r1'])
+
+    // the _ftindex collection must have received zero put/get/delete calls
+    expect(ftindexOps).toHaveLength(0)
+  })
 })

--- a/packages/hub/__tests__/search-persisted-index-store.test.ts
+++ b/packages/hub/__tests__/search-persisted-index-store.test.ts
@@ -1,0 +1,68 @@
+// packages/hub/__tests__/search-persisted-index-store.test.ts
+import { describe, it, expect } from 'vitest'
+import { PersistedIndexStore, type Fingerprint } from '../src/search/persisted-index-store.js'
+import type { IndexDoc } from '../src/search/inverted-index.js'
+
+const docs: IndexDoc[] = [{ id: 'a', fields: [{ field: 'd', text: 'invoice' }] }]
+
+function harness(fp: Fingerprint = { count: 1, maxVersion: 1 }) {
+  const blob: { json: string; fingerprint: Fingerprint } | null = null as any
+  const state = { blob, saves: 0, removes: 0, fp }
+  const store = new PersistedIndexStore({
+    load: async () => state.blob,
+    save: async (json, f) => { state.saves++; state.blob = { json, fingerprint: f } },
+    remove: async () => { state.removes++; state.blob = null },
+    currentFingerprint: () => state.fp,
+    debounceMs: 10,
+  })
+  return { store, state }
+}
+
+describe('PersistedIndexStore (#308 L1.5)', () => {
+  it('cold build persists; warm load skips the build fn', async () => {
+    const { store, state } = harness()
+    let builds = 0
+    const build = () => { builds++; return docs }
+    await store.ensureBuilt(build)            // cold: build + save
+    expect(builds).toBe(1); expect(state.saves).toBe(1)
+    // simulate a NEW session: fresh store, same blob + matching fingerprint
+    const store2 = new PersistedIndexStore({
+      load: async () => state.blob, save: async () => {}, remove: async () => {},
+      currentFingerprint: () => state.fp, debounceMs: 10,
+    })
+    let builds2 = 0
+    await store2.ensureBuilt(() => { builds2++; return docs })
+    expect(builds2).toBe(0)                    // warm: deserialized, no rebuild
+    expect((await store2.ensureBuilt(() => docs)).query('invoice').map((h) => h.id)).toEqual(['a'])
+  })
+
+  it('stale fingerprint forces a rebuild', async () => {
+    const { store, state } = harness()
+    await store.ensureBuilt(() => docs)
+    state.fp = { count: 2, maxVersion: 5 } // someone wrote elsewhere
+    const store2 = new PersistedIndexStore({
+      load: async () => state.blob, save: async () => {}, remove: async () => {},
+      currentFingerprint: () => state.fp, debounceMs: 10,
+    })
+    let builds = 0
+    await store2.ensureBuilt(() => { builds++; return docs })
+    expect(builds).toBe(1) // blob fingerprint {1,1} != current {2,5} → rebuild
+  })
+
+  it('markDirty debounces a single flush; flush() is immediate', async () => {
+    const { store, state } = harness()
+    await store.ensureBuilt(() => docs)        // saves=1
+    store.markDirty(); store.markDirty(); store.markDirty()
+    await new Promise((r) => setTimeout(r, 30)) // debounce window (10ms) elapses
+    expect(state.saves).toBe(2)                 // one coalesced flush
+    store.markDirty(); await store.flush()
+    expect(state.saves).toBe(3)                 // explicit immediate
+  })
+
+  it('removePersisted deletes the blob + marks dirty', async () => {
+    const { store, state } = harness()
+    await store.ensureBuilt(() => docs)
+    await store.removePersisted()
+    expect(state.removes).toBe(1); expect(store.built).toBe(false)
+  })
+})

--- a/packages/hub/__tests__/search-retrieve.test.ts
+++ b/packages/hub/__tests__/search-retrieve.test.ts
@@ -139,4 +139,22 @@ describe('collection.retrieve() — string fields (#308 L1)', () => {
     await c.retrieve('invoice', { prefix: true })
     expect(writes.length).toBe(before) // build+retrieve wrote nothing
   })
+
+  it('hits carry a 1-based rank monotonic with score order (#308 L1.5)', async () => {
+    const v = await n.openVault('v')
+    const c = v.collection<Inv>('inv', { textIndexes: ['description', 'notes'] })
+    // Record a: TCM appears in description (stronger match)
+    await c.put('a', { id: 'a', description: 'TCM TCM overdue invoice', notes: 'regular payment' })
+    // Record b: TCM appears in notes only (weaker match)
+    await c.put('b', { id: 'b', description: 'paid invoice', notes: 'TCM building rent' })
+
+    const hits = await c.retrieve('TCM')
+    expect(hits.length).toBe(2)
+    // Hits are returned in score order (highest first)
+    expect(hits[0].id).toBe('a') // description match scores higher
+    expect(hits[1].id).toBe('b') // notes match scores lower
+    // Verify rank is 1-based and monotonic
+    expect(hits[0].rank).toBe(1)
+    expect(hits[1].rank).toBe(2)
+  })
 })

--- a/packages/hub/__tests__/search-serialize.test.ts
+++ b/packages/hub/__tests__/search-serialize.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { InvertedIndex, type IndexDoc } from '../src/search/inverted-index.js'
+import { serializeIndex, deserializeIndex } from '../src/search/serialize.js'
+
+const docs: IndexDoc[] = [
+  { id: 'a', fields: [{ field: 'desc', text: 'overdue invoice TCM' }] },
+  { id: 'b', fields: [{ field: 'desc', text: 'paid invoice' }, { field: 'notes', locale: 'th', text: 'ค่าเช่า TCM' }] },
+]
+
+describe('index snapshot round-trip (#308 L1.5)', () => {
+  it('serialize → deserialize yields identical query results', () => {
+    const orig = InvertedIndex.build(docs)
+    const restored = deserializeIndex(serializeIndex(orig))
+    for (const q of ['invoice', 'TCM', 'ค่าเช่า', 'paid']) {
+      expect(restored.query(q)).toEqual(orig.query(q))
+    }
+  })
+  it('preserves locale + offsets (snippet fidelity)', () => {
+    const restored = deserializeIndex(serializeIndex(InvertedIndex.build(docs)))
+    const hit = restored.query('ค่าเช่า').find((h) => h.id === 'b')!
+    expect(hit.locale).toBe('th')
+    expect(hit.text.slice(hit.offset, hit.offset + 'ค่าเช่า'.length)).toBe('ค่าเช่า')
+  })
+})

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -2842,7 +2842,7 @@ export class Collection<T> {
     return maps
   }
 
-  /** #308 L1.5 — force-persist the lexical index now (e.g. on save/idle). No-op without textIndexPersist. */
+  /** #308 L1.5 — force-persist the lexical index now (e.g. on save/idle). Persists only when textIndexPersist is enabled; a no-op otherwise. */
   async flushIndex(): Promise<void> {
     if (!this.searchIndexStore) return
     await this.ensureHydrated()

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -2931,10 +2931,11 @@ export class Collection<T> {
       ...(opts.fields ? { fields: opts.fields } : {}),
     })
     const window = opts.snippetWindow ?? 80
-    return hits.map((h: IndexHit) => {
+    return hits.map((h: IndexHit, i: number) => {
       const base: RetrieveHit<T> = {
         id: h.id,
         score: h.score,
+        rank: i + 1,
         field: h.field,
         snippet: extractSnippet(h.text, h.offset, window),
         ...(h.locale !== undefined ? { locale: h.locale } : {}),

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -2847,7 +2847,7 @@ export class Collection<T> {
     const built = this.searchIndexStore.built
     const labelMaps = built ? new Map() : await this.resolveDictLabelMaps()
     const blobFilenames = built ? new Map() : await this.resolveBlobFilenames()
-    this.searchIndexStore.getOrBuild(() => this.buildRetrievalDocs(labelMaps, blobFilenames))
+    await this.searchIndexStore.ensureBuilt(() => this.buildRetrievalDocs(labelMaps, blobFilenames))
   }
 
   /** #308 L1 — client-side lexical retrieval; ranked { id, score, field, snippet, locale? }. */
@@ -2864,7 +2864,7 @@ export class Collection<T> {
     const built = this.searchIndexStore.built
     const labelMaps = built ? new Map() : await this.resolveDictLabelMaps()
     const blobFilenames = built ? new Map() : await this.resolveBlobFilenames()
-    const index = this.searchIndexStore.getOrBuild(() => this.buildRetrievalDocs(labelMaps, blobFilenames))
+    const index = await this.searchIndexStore.ensureBuilt(() => this.buildRetrievalDocs(labelMaps, blobFilenames))
     const hits = index.query(query, {
       ...(opts.limit !== undefined ? { limit: opts.limit } : {}),
       ...(opts.match ? { match: opts.match } : {}),

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -48,6 +48,7 @@ import type { LazyQuerySource } from './indexing/lazy-builder.js'
 import { NO_INDEXING, type IndexStrategy, type IndexState } from './indexing/strategy.js'
 import { searchScan, type SearchOptions, type SearchResult } from './search/index.js'
 import { MemoryIndexStore, type IndexStore } from './search/index-store.js'
+import { PersistedIndexStore, type PersistedIndexCallbacks } from './search/persisted-index-store.js'
 import { extractSnippet } from './search/snippet.js'
 import { buildStringFieldEntries, buildI18nFieldEntries, buildDictKeyFieldEntries, buildBlobFieldEntries } from './search/build-docs.js'
 import type { IndexDoc, IndexHit } from './search/inverted-index.js'
@@ -707,6 +708,8 @@ export class Collection<T> {
     textIndexes?: readonly string[] | undefined
     /** — #308 L1: pre-build the lexical index on open (eager-only). */
     warmIndexOnOpen?: boolean | undefined
+    /** — #308 L1.5: persist the lexical index as an opaque encrypted blob at `_ftindex/<name>`. */
+    textIndexPersist?: boolean | undefined
     /** — dictKey field descriptors for label resolution on reads. */
     dictKeyFields?: Record<string, DictKeyDescriptor | StaticDictDescriptor> | undefined
     moneyFields?: Record<string, MoneyDescriptor> | undefined
@@ -924,7 +927,11 @@ export class Collection<T> {
     // ordinary collections pay nothing (the dirty poke + retrieve see undefined).
     this.textIndexes = opts.textIndexes
     this.searchIndexStore =
-      opts.textIndexes && opts.textIndexes.length > 0 ? new MemoryIndexStore() : undefined
+      opts.textIndexes && opts.textIndexes.length > 0
+        ? opts.textIndexPersist
+          ? new PersistedIndexStore(this.buildPersistedIndexCallbacks())
+          : new MemoryIndexStore()
+        : undefined
     // #435 — precompute the densify-enabled subset (undefined when none opt in)
     // so the write path skips work for non-densify collections.
     const densifyFields = opts.i18nFields
@@ -2833,6 +2840,58 @@ export class Collection<T> {
       maps.set(field, m)
     }
     return maps
+  }
+
+  /** #308 L1.5 — force-persist the lexical index now (e.g. on save/idle). No-op without textIndexPersist. */
+  async flushIndex(): Promise<void> {
+    if (!this.searchIndexStore) return
+    await this.ensureHydrated()
+    const labelMaps = await this.resolveDictLabelMaps()
+    const blobFilenames = await this.resolveBlobFilenames()
+    await this.searchIndexStore.ensureBuilt(() => this.buildRetrievalDocs(labelMaps, blobFilenames))
+    await this.searchIndexStore.flush?.()
+  }
+
+  /**
+   * #308 L1.5 — build the PersistedIndexCallbacks bridge: crypto lives here
+   * (collection has getDEK / encryptJsonString / decryptJsonString / adapter),
+   * the index store itself is crypto-free.
+   *
+   * Fingerprint encoding: body-wrap approach — save(json, fp) stores
+   * JSON.stringify({ fp, idx: json }) as the encrypted body so the standard
+   * EncryptedEnvelope shape is never extended. load() decrypts and JSON.parses
+   * the wrapper back out.
+   *
+   * Cache shape: this.cache stores { record, version } — currentFingerprint()
+   * iterates over e.version.
+   */
+  private buildPersistedIndexCallbacks(): PersistedIndexCallbacks {
+    const FT = '_ftindex'
+    return {
+      load: async () => {
+        const env = await this.adapter.get(this.vault, FT, this.name)
+        if (!env) return null
+        const body = await this.decryptJsonString(env)
+        if (body === null) return null
+        try {
+          const wrapped = JSON.parse(body) as { fp: { count: number; maxVersion: number }; idx: string }
+          return { json: wrapped.idx, fingerprint: wrapped.fp }
+        } catch {
+          return null
+        }
+      },
+      save: async (json, fp) => {
+        const body = JSON.stringify({ fp, idx: json })
+        const env = await this.encryptJsonString(body, fp.count)
+        await this.adapter.put(this.vault, FT, this.name, env)
+      },
+      remove: async () => { await this.adapter.delete(this.vault, FT, this.name) },
+      currentFingerprint: () => {
+        let maxVersion = 0
+        for (const e of this.cache.values()) if (e.version > maxVersion) maxVersion = e.version
+        return { count: this.cache.size, maxVersion }
+      },
+    }
   }
 
   /** #308 L1 — pre-build the lexical index (e.g. on open) so the first retrieve() pays no build scan. */

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -4327,6 +4327,14 @@ export class Collection<T> {
     return { purged, residue }
   }
 
+  /** #308 L1.5 — drop the persisted lexical-index blob (forget/erasure): an opaque
+   *  all-records index must not survive crypto-shred. Idempotent; no-op without persist. */
+  async _purgeSearchIndex(): Promise<void> {
+    const store = this.searchIndexStore
+    if (store && 'removePersisted' in store) await (store as { removePersisted(): Promise<void> }).removePersisted()
+    else store?.markDirty()
+  }
+
   /**
    * Bulk-load the persisted-index mirror from `_idx/<field>/*` side-cars
    * on first lazy-mode query. Idempotent — subsequent calls short-circuit

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -1632,6 +1632,7 @@ export class Noydb {
     }
     this.syncEngines.clear()
     for (const v of this.vaultCache.values()) v._stopFenceCoordination() // stop heartbeat/watcher timers
+    for (const v of this.vaultCache.values()) void v._flushSearchIndexes() // #308 L1.5 best-effort flush
     this.disableTabCoordination() // stop tab lock/heartbeat timers
     this.keyringCache.clear()
     this.vaultCache.clear()

--- a/packages/hub/src/search/index-store.ts
+++ b/packages/hub/src/search/index-store.ts
@@ -1,13 +1,14 @@
 /**
- * The index persistence seam (#308 L1). MemoryIndexStore is session-scoped and
- * lazy; an opaque-blob backend (L1.5) implements the same interface so the
+ * The index persistence seam (#308 L1.5). MemoryIndexStore is session-scoped and
+ * lazy; an opaque-blob backend implements the same interface so the
  * collection call-site is unchanged.
  */
 import { InvertedIndex, type IndexDoc } from './inverted-index.js'
 
 export interface IndexStore {
-  getOrBuild(build: () => ReadonlyArray<IndexDoc>): InvertedIndex
+  ensureBuilt(build: () => ReadonlyArray<IndexDoc>): Promise<InvertedIndex>
   markDirty(): void
+  flush(): Promise<void>
   readonly built: boolean
 }
 
@@ -16,10 +17,12 @@ export class MemoryIndexStore implements IndexStore {
 
   get built(): boolean { return this.index !== undefined }
 
-  getOrBuild(build: () => ReadonlyArray<IndexDoc>): InvertedIndex {
+  async ensureBuilt(build: () => ReadonlyArray<IndexDoc>): Promise<InvertedIndex> {
     if (this.index === undefined) this.index = InvertedIndex.build(build())
     return this.index
   }
 
   markDirty(): void { this.index = undefined }
+
+  async flush(): Promise<void> { /* in-memory: nothing to persist */ }
 }

--- a/packages/hub/src/search/inverted-index.ts
+++ b/packages/hub/src/search/inverted-index.ts
@@ -30,6 +30,15 @@ export interface QueryOptions {
   readonly fields?: readonly string[]
 }
 
+export interface IndexSnapshot {
+  readonly v: 1
+  readonly fieldStats: ReadonlyArray<[string, { df: [string, number][]; n: number; totalLen: number }]>
+  readonly docs: ReadonlyArray<{
+    id: string; field: string; locale?: string; text: string; len: number
+    tf: [string, number][]; firstOffset: [string, number][]
+  }>
+}
+
 interface Doc {
   id: string
   field: string
@@ -135,5 +144,30 @@ export class InvertedIndex {
 
     const results = [...best.values()].sort((a, b) => b.score - a.score)
     return opts.limit !== undefined ? results.slice(0, opts.limit) : results
+  }
+
+  toSnapshot(): IndexSnapshot {
+    return {
+      v: 1,
+      fieldStats: [...this.fieldStats].map(([f, s]) => [f, { df: [...s.df], n: s.n, totalLen: s.totalLen }]),
+      docs: this.docs.map((d) => ({
+        id: d.id, field: d.field, text: d.text, len: d.len,
+        tf: [...d.tf], firstOffset: [...d.firstOffset],
+        ...(d.locale !== undefined ? { locale: d.locale } : {}),
+      })),
+    }
+  }
+
+  static fromSnapshot(s: IndexSnapshot): InvertedIndex {
+    const idx = new InvertedIndex()
+    for (const [f, st] of s.fieldStats) idx.fieldStats.set(f, { df: new Map(st.df), n: st.n, totalLen: st.totalLen })
+    for (const d of s.docs) {
+      idx.docs.push({
+        id: d.id, field: d.field, text: d.text, len: d.len,
+        tf: new Map(d.tf), firstOffset: new Map(d.firstOffset),
+        ...(d.locale !== undefined ? { locale: d.locale } : {}),
+      })
+    }
+    return idx
   }
 }

--- a/packages/hub/src/search/persisted-index-store.ts
+++ b/packages/hub/src/search/persisted-index-store.ts
@@ -53,7 +53,7 @@ export class PersistedIndexStore implements IndexStore {
     if (this.timer) clearTimeout(this.timer)
     this.timer = setTimeout(() => {
       this.timer = null
-      void this.rebuildAndPersist()
+      void this.rebuildAndPersist().catch(() => { /* best-effort flush; fingerprint backstop forces rebuild next load */ })
     }, this.debounceMs)
   }
 
@@ -73,7 +73,9 @@ export class PersistedIndexStore implements IndexStore {
   /** Rebuild using the last known build thunk, then persist. */
   private async rebuildAndPersist(): Promise<void> {
     if (this.lastBuild === undefined) return
-    await this.ensureBuilt(this.lastBuild)
+    if (this.index === undefined) {
+      this.index = InvertedIndex.build(this.lastBuild())
+    }
     await this.persist()
   }
 

--- a/packages/hub/src/search/persisted-index-store.ts
+++ b/packages/hub/src/search/persisted-index-store.ts
@@ -1,0 +1,84 @@
+/**
+ * Persisted backend for the L1 lexical index (#308 L1.5). Crypto-free: the
+ * collection injects load/save/remove + a fingerprint provider. In-memory while
+ * live (L1 behavior); persists an opaque snapshot via a debounced flush, and
+ * validates a loaded blob against a {count,maxVersion} fingerprint so a stale
+ * blob is never used — only rebuilt.
+ */
+import { InvertedIndex, type IndexDoc } from './inverted-index.js'
+import { serializeIndex, deserializeIndex } from './serialize.js'
+import type { IndexStore } from './index-store.js'
+
+export interface Fingerprint { readonly count: number; readonly maxVersion: number }
+
+export interface PersistedIndexCallbacks {
+  load(): Promise<{ json: string; fingerprint: Fingerprint } | null>
+  save(json: string, fp: Fingerprint): Promise<void>
+  remove(): Promise<void>
+  currentFingerprint(): Fingerprint
+  debounceMs?: number
+}
+
+function fpEqual(a: Fingerprint, b: Fingerprint): boolean {
+  return a.count === b.count && a.maxVersion === b.maxVersion
+}
+
+export class PersistedIndexStore implements IndexStore {
+  private index: InvertedIndex | undefined
+  private timer: ReturnType<typeof setTimeout> | null = null
+  private lastBuild: (() => ReadonlyArray<IndexDoc>) | undefined
+  private readonly debounceMs: number
+
+  constructor(private readonly cb: PersistedIndexCallbacks) {
+    this.debounceMs = cb.debounceMs ?? 1000
+  }
+
+  get built(): boolean { return this.index !== undefined }
+
+  async ensureBuilt(build: () => ReadonlyArray<IndexDoc>): Promise<InvertedIndex> {
+    this.lastBuild = build
+    if (this.index !== undefined) return this.index
+    const loaded = await this.cb.load()
+    if (loaded !== null && fpEqual(loaded.fingerprint, this.cb.currentFingerprint())) {
+      this.index = deserializeIndex(loaded.json)
+      return this.index
+    }
+    this.index = InvertedIndex.build(build())
+    await this.persist()
+    return this.index
+  }
+
+  markDirty(): void {
+    this.index = undefined
+    if (this.timer) clearTimeout(this.timer)
+    this.timer = setTimeout(() => {
+      this.timer = null
+      void this.rebuildAndPersist()
+    }, this.debounceMs)
+  }
+
+  /** Force an immediate persist (cancels any pending debounce). */
+  async flush(): Promise<void> {
+    if (this.timer) { clearTimeout(this.timer); this.timer = null }
+    await this.rebuildAndPersist()
+  }
+
+  /** Delete the persisted blob and drop the in-memory index (forget/erasure). */
+  async removePersisted(): Promise<void> {
+    if (this.timer) { clearTimeout(this.timer); this.timer = null }
+    this.index = undefined
+    await this.cb.remove()
+  }
+
+  /** Rebuild using the last known build thunk, then persist. */
+  private async rebuildAndPersist(): Promise<void> {
+    if (this.lastBuild === undefined) return
+    await this.ensureBuilt(this.lastBuild)
+    await this.persist()
+  }
+
+  private async persist(): Promise<void> {
+    if (this.index === undefined) return
+    await this.cb.save(serializeIndex(this.index), this.cb.currentFingerprint())
+  }
+}

--- a/packages/hub/src/search/retrieve-types.ts
+++ b/packages/hub/src/search/retrieve-types.ts
@@ -15,6 +15,7 @@ export interface RetrieveOptions {
 export interface RetrieveHit<T> {
   readonly id: string
   readonly score: number
+  readonly rank: number
   readonly field: string
   readonly snippet: string
   readonly locale?: string

--- a/packages/hub/src/search/serialize.ts
+++ b/packages/hub/src/search/serialize.ts
@@ -1,0 +1,10 @@
+/** (De)serialize an InvertedIndex to/from a JSON string for persistence (#308 L1.5). */
+import { InvertedIndex } from './inverted-index.js'
+
+export function serializeIndex(idx: InvertedIndex): string {
+  return JSON.stringify(idx.toSnapshot())
+}
+
+export function deserializeIndex(json: string): InvertedIndex {
+  return InvertedIndex.fromSnapshot(JSON.parse(json))
+}

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -2613,9 +2613,15 @@ export class Vault {
 
     // Purge the persisted lexical-index blob for each affected collection
     // (#308 L1.5): an opaque all-records index must not survive crypto-shred.
+    // Failures (transient/permission) must NOT abort forget — an unpurgeable
+    // blob is erasure residue surfaced in the returned ForgetResult.
     for (const collName of collections) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await (this.collection(collName) as any)._purgeSearchIndex()
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (this.collection(collName) as any)._purgeSearchIndex()
+      } catch {
+        indexResidue.push(`${collName}:_ftindex`)
+      }
     }
 
     // ONE summary ledger entry for the whole subject. payloadHash =

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -682,6 +682,8 @@ export class Vault {
     textIndexes?: readonly string[]
     /** — #308 L1: pre-build the lexical index on open (eager-only). */
     warmIndexOnOpen?: boolean
+    /** — #308 L1.5: persist the lexical index as an opaque encrypted blob at `_ftindex/<name>`. */
+    textIndexPersist?: boolean
     /** — declare dictKey / staticDict fields for label resolution on reads. */
     dictKeyFields?: Record<string, DictKeyDescriptor | StaticDictDescriptor>
     /** — declare money() fields for currency-safe decimal storage/formatting. */
@@ -1006,6 +1008,7 @@ export class Vault {
       if (options?.i18nFields !== undefined) collOpts.i18nFields = options.i18nFields
       if (options?.textIndexes !== undefined) collOpts.textIndexes = options.textIndexes
       if (options?.warmIndexOnOpen !== undefined) collOpts.warmIndexOnOpen = options.warmIndexOnOpen
+      if (options?.textIndexPersist !== undefined) collOpts.textIndexPersist = options.textIndexPersist
       if (options?.moneyFields !== undefined) collOpts.moneyFields = options.moneyFields
       if (options?.computed !== undefined) collOpts.computed = options.computed as ComputedFields
       if (options?.dictKeyFields !== undefined) {

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -1199,7 +1199,7 @@ export class Vault {
    *  next load. Only collections with textIndexPersist have a flush(); others no-op. */
   async _flushSearchIndexes(): Promise<void> {
     for (const coll of this.collectionCache.values()) {
-      await (coll as any).flushIndex().catch(() => { /* best-effort */ })
+      await coll.flushIndex().catch(() => { /* best-effort */ })
     }
   }
 

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -1193,6 +1193,16 @@ export class Vault {
     this.#fenceCoordinationStarted = false
   }
 
+  /** @internal #308 L1.5 — best-effort flush of all open collections' persisted
+   *  lexical indexes on close(). Called fire-and-forget from noydb.close().
+   *  Correctness is backstopped by the fingerprint: a missed flush → rebuild on
+   *  next load. Only collections with textIndexPersist have a flush(); others no-op. */
+  async _flushSearchIndexes(): Promise<void> {
+    for (const coll of this.collectionCache.values()) {
+      await (coll as any).flushIndex().catch(() => { /* best-effort */ })
+    }
+  }
+
   /** @internal Drive one heartbeat + watch cycle deterministically (tests). */
   async _fenceTick(): Promise<void> {
     this._ensureFenceCoordination()
@@ -2599,6 +2609,13 @@ export class Vault {
 
       // Drop the (now-shredded) ref from the subject index.
       await this._removeSubjectRef(subjectId, ref)
+    }
+
+    // Purge the persisted lexical-index blob for each affected collection
+    // (#308 L1.5): an opaque all-records index must not survive crypto-shred.
+    for (const collName of collections) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (this.collection(collName) as any)._purgeSearchIndex()
     }
 
     // ONE summary ledger entry for the whole subject. payloadHash =

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -491,7 +491,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 4911→4922 (2026-06-20, #435 review): stripI18nFilled at the three
   // locale-less read returns (get/list early-return, search, static-display final).
   // Bumped 4922→5100 (#308 L1): retrieve()/warmIndex call-sites + dict/blob label resolvers (engine in src/search/)
-  'packages/hub/src/collection.ts': 5100,
+  // Bumped 5100→5168 (#308 L1.5): persisted-index call-sites + forget/close wiring
+  'packages/hub/src/collection.ts': 5168,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -561,7 +562,8 @@ const KERNEL_SURFACE_BUDGET = {
   // injected `CoordinationProvider` into SchemaFenceController + FenceWatcher
   // (the barrier/transport logic itself lives in coordination/ + schema-update/).
   // Bumped 4546→4571 (#308 L1): getDictionary label-resolver injection + warmIndexOnOpen wiring (engine in src/search/)
-  'packages/hub/src/vault.ts': 4571,
+  // Bumped 4571→4597 (#308 L1.5): persisted-index call-sites + forget/close wiring
+  'packages/hub/src/vault.ts': 4597,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),

--- a/showcases/src/123-persisted-index.showcase.test.ts
+++ b/showcases/src/123-persisted-index.showcase.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Showcase 123 — Persisted lexical index (textIndexPersist) — #308 L1.5
+ *
+ * What you'll learn
+ * ─────────────────
+ * `textIndexPersist: true` persists the L1 inverted index as a single **opaque
+ * encrypted blob** (`_ftindex/<collection>`) under the collection DEK.  On a
+ * fresh `createNoydb` over the **same store**, `retrieve()` cold-loads the blob
+ * and returns correct results immediately — no full re-tokenize scan of the
+ * collection.
+ *
+ * The key ideas demonstrated here:
+ *
+ *   1. **Session 1 — seed + flush**: write records, call `flushIndex()` to
+ *      force-persist the index immediately (rather than waiting for the
+ *      debounced background flush), then `db.close()`.
+ *   2. **Session 2 — warm load**: a fresh `createNoydb` over the SAME store
+ *      instance opens the vault, the collection loads the blob, the fingerprint
+ *      matches, and `retrieve()` returns correct results — no rebuild needed.
+ *   3. **Rank is 1-based and monotonic**: each `RetrieveHit` carries a `rank`
+ *      field (1, 2, 3, …) that enables Reciprocal Rank Fusion across vaults in
+ *      the klum-db Lobby (L3 federation).
+ *   4. **Stale fingerprint → self-healing rebuild**: if records are added in
+ *      session 2 before the first retrieve, the fingerprint won't match and
+ *      the index rebuilds automatically.
+ *
+ * Why it matters
+ * ──────────────
+ * In large corpora or short-lived agent sessions the first-call tokenize scan
+ * of the whole collection can be expensive.  `textIndexPersist` turns that
+ * cold-start cost into a one-off: subsequent sessions load the blob (one store
+ * read) instead of scanning.  The blob is ciphertext under the collection DEK —
+ * no terms, postings, or plaintext reach the store (zero added leakage).
+ *
+ * What to read next
+ * ─────────────────
+ *   - docs/subsystems/search.md — full L1.5 documentation
+ *   - docs/superpowers/specs/2026-06-22-ai-retrieval-l1.5-persisted-index-design.md
+ *   - Showcase 122 — L1 retrieve() walkthrough
+ *   - Showcase 111 — L0 scan-mode search
+ *
+ * Spec mapping
+ * ────────────
+ * features.yaml → features → search-index
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+
+// ─── Shared type ─────────────────────────────────────────────────────────────
+
+interface Doc extends Record<string, unknown> {
+  id: string
+  title: string
+  body: string
+}
+
+// ─── Part A: warm cross-session cold load ────────────────────────────────────
+//
+// Session 1 writes records and force-flushes the index.
+// Session 2 opens a fresh db over the SAME store and retrieves immediately —
+// the fingerprint matches and results are correct.
+
+describe('Showcase 123-A — textIndexPersist: warm cross-session load', () => {
+  it('session 2 retrieve() returns correct results from the persisted blob', async () => {
+    // The shared store survives across createNoydb calls (test-fixture pattern).
+    const store = memory()
+
+    // ── Session 1: seed records + flush ───────────────────────────────────────
+    {
+      const db = await createNoydb({
+        store,
+        user: 'analyst',
+        secret: 'persist-123-a-passphrase',
+      })
+      const vault = await db.openVault('firm')
+      const docs = vault.collection<Doc>('reports', {
+        textIndexes: ['title', 'body'],
+        textIndexPersist: true,
+      })
+
+      await docs.put('r-1', {
+        id: 'r-1',
+        title: 'Q1 Financial Overview',
+        body: 'Revenue grew by twelve percent in the first quarter.',
+      })
+      await docs.put('r-2', {
+        id: 'r-2',
+        title: 'Annual Compliance Report',
+        body: 'All regulatory requirements were met without exception.',
+      })
+      await docs.put('r-3', {
+        id: 'r-3',
+        title: 'Tax Filing Summary',
+        body: 'Estimated tax liability reduced after deduction review.',
+      })
+
+      // Force-persist the index now (rather than waiting for debounce).
+      await docs.flushIndex()
+      db.close()
+    }
+
+    // ── Session 2: fresh db, warm load ────────────────────────────────────────
+    {
+      const db = await createNoydb({
+        store,
+        user: 'analyst',
+        secret: 'persist-123-a-passphrase',
+      })
+      const vault = await db.openVault('firm')
+      const docs = vault.collection<Doc>('reports', {
+        textIndexes: ['title', 'body'],
+        textIndexPersist: true,
+      })
+
+      // retrieve() loads the persisted blob; fingerprint matches → no rebuild.
+      const hits = await docs.retrieve('financial')
+      expect(hits.length).toBeGreaterThan(0)
+      const ids = hits.map((h) => h.id)
+      expect(ids).toContain('r-1')
+
+      // Compliance report matches 'regulatory' in the body.
+      const complianceHits = await docs.retrieve('regulatory')
+      expect(complianceHits.map((h) => h.id)).toContain('r-2')
+
+      // Tax filing matches 'tax'.
+      const taxHits = await docs.retrieve('tax')
+      expect(taxHits.map((h) => h.id)).toContain('r-3')
+
+      db.close()
+    }
+  })
+})
+
+// ─── Part B: RetrieveHit.rank is 1-based and monotonic ───────────────────────
+
+describe('Showcase 123-B — RetrieveHit.rank: 1-based, monotonic with score', () => {
+  it('rank is 1 for the top hit and increases by 1 per position', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'analyst',
+      secret: 'persist-123-b-passphrase',
+    })
+    const vault = await db.openVault('firm')
+    const docs = vault.collection<Doc>('memos', {
+      textIndexes: ['title', 'body'],
+    })
+
+    await docs.put('m-1', {
+      id: 'm-1',
+      title: 'Invoice payment overdue notice',
+      body: 'The invoice dated March 1 remains unpaid.',
+    })
+    await docs.put('m-2', {
+      id: 'm-2',
+      title: 'Payment reminder for invoice',
+      body: 'Please settle the outstanding invoice balance.',
+    })
+    await docs.put('m-3', {
+      id: 'm-3',
+      title: 'Staff meeting notes',
+      body: 'Quarterly review discussion points.',
+    })
+
+    const hits = await docs.retrieve('invoice')
+    // At least 2 hits (m-1 and m-2 both mention invoice).
+    expect(hits.length).toBeGreaterThanOrEqual(2)
+
+    // rank is 1-based: first hit has rank 1.
+    expect(hits[0]!.rank).toBe(1)
+
+    // rank is monotonically increasing (1, 2, 3, …).
+    for (let i = 0; i < hits.length; i++) {
+      expect(hits[i]!.rank).toBe(i + 1)
+    }
+
+    // score is non-increasing (best-first ordering).
+    for (let i = 1; i < hits.length; i++) {
+      expect(hits[i]!.score).toBeLessThanOrEqual(hits[i - 1]!.score)
+    }
+
+    db.close()
+  })
+})
+
+// ─── Part C: stale fingerprint → self-healing rebuild ────────────────────────
+//
+// After session 1 flushes the blob, session 2 adds a new record BEFORE calling
+// retrieve().  The fingerprint (count, maxVersion) no longer matches the blob,
+// so the index is rebuilt and the new record is found.
+
+describe('Showcase 123-C — stale fingerprint: self-healing rebuild', () => {
+  it('new record added before first retrieve() is always found (fingerprint mismatch → rebuild)', async () => {
+    const store = memory()
+
+    // ── Session 1: two records + flush ────────────────────────────────────────
+    {
+      const db = await createNoydb({
+        store,
+        user: 'analyst',
+        secret: 'persist-123-c-passphrase',
+      })
+      const vault = await db.openVault('firm')
+      const docs = vault.collection<Doc>('ledger', {
+        textIndexes: ['title', 'body'],
+        textIndexPersist: true,
+      })
+
+      await docs.put('l-1', { id: 'l-1', title: 'Opening balance', body: 'Assets at start of year.' })
+      await docs.put('l-2', { id: 'l-2', title: 'Closing balance', body: 'Assets at end of year.' })
+      await docs.flushIndex()
+      db.close()
+    }
+
+    // ── Session 2: add a record, then retrieve ────────────────────────────────
+    {
+      const db = await createNoydb({
+        store,
+        user: 'analyst',
+        secret: 'persist-123-c-passphrase',
+      })
+      const vault = await db.openVault('firm')
+      const docs = vault.collection<Doc>('ledger', {
+        textIndexes: ['title', 'body'],
+        textIndexPersist: true,
+      })
+
+      // Adding a record before retrieve() bumps count+maxVersion → fingerprint
+      // mismatch → index rebuilt from scratch (self-healing).
+      await docs.put('l-3', { id: 'l-3', title: 'Adjustment entry', body: 'Depreciation adjustment.' })
+
+      // The newly added record must appear in results.
+      const hits = await docs.retrieve('adjustment')
+      expect(hits.map((h) => h.id)).toContain('l-3')
+
+      // Previously persisted records are also found.
+      const balanceHits = await docs.retrieve('balance')
+      const balanceIds = balanceHits.map((h) => h.id)
+      expect(balanceIds).toContain('l-1')
+      expect(balanceIds).toContain('l-2')
+
+      db.close()
+    }
+  })
+})


### PR DESCRIPTION
**L1.5 of the AI-retrieval epic** — makes L1's lexical index persistable so it survives sessions/devices without the cold-rebuild scan, and adds the federation-ready `RetrieveHit.rank`.

## What it does
- **`textIndexPersist?: boolean`** (opt-in): serializes the in-memory `InvertedIndex` to **one opaque encrypted blob** (collection DEK) in the reserved `_ftindex` collection. Store stays zero-knowledge — ciphertext only, no per-term addressability, not hydrated as a record.
- **Fingerprint `{count, maxVersion}`** validates freshness on load: a stale/missing/corrupt blob is **never served — only rebuilt** (self-healing). Cross-session/device safe.
- **Debounced flush** + awaitable **`collection.flushIndex()`** + best-effort flush on `db.close()`. `IndexStore` seam went async (`ensureBuilt`/`flush`).
- **`forget()` tears down the blob** for every affected collection, resilient to delete failure, and **surfaces residue** in `ForgetResult` (the #401-class erasure contract).
- **`RetrieveHit.rank`** (1-based) — enables klum-db's cross-vault Reciprocal-Rank-Fusion later (and L3's hybrid fusion).

## Federation note
Per the boundary design: the cross-vault `lobby.retrieve()` fan-out is a klum-db task; noy-db provides the per-vault `retrieve()` + the fusion-ready `rank`. The `fuseRetrieval` reducer (shared by L3 hybrid + federation) lands in L3.

## Test plan
- [x] Full hub suite **2791/2791**; eslint + tsc clean; architecture + features-validator green.
- [x] serialize round-trip; **cold-load proves rebuild is skipped** (unit build-counter + end-to-end no-new-write); stale-fingerprint rebuild; debounce coalesces to one save; `forget()` removes blob + resilience/residue test; **zero-cost-off** (no `_ftindex` I/O when unset); leakage (opaque blob, no plaintext terms).
- [x] Showcase 123 (cross-session warm load, rank, self-healing rebuild).

## Notes
- Kernel ceilings raised: collection.ts 5100→5168, vault.ts 4571→4597 (thin call-sites; engine in `src/search/`).
- Accepted Minors (final review, non-blocking): concurrent-`ensureBuilt` not deduped (consistent with `MemoryIndexStore`); sequential close-flush (off the close() path).

Spec: `docs/superpowers/specs/2026-06-22-ai-retrieval-l1.5-persisted-index-design.md` · Plan: `docs/superpowers/plans/2026-06-22-ai-retrieval-l1.5-persisted-index.md`