### PR TITLE
feat(embeddings): L2 semantic/vector retrieval — encrypted local cosine (#308)

### DIFF
--- a/docs/subsystems/embeddings.md
+++ b/docs/subsystems/embeddings.md
@@ -69,10 +69,13 @@ const docs = vault.collection<Doc>('docs', {
   (space-separated) before encoding.
 - `encode` is async; errors propagate like `autoTranslate` — write fails if the
   encoder throws.
-- If a collection declares `embeddings` but no `encode` hook is reachable,
-  `EmbeddingEncoderNotConfiguredError` is thrown at write time.
 - `dim` is validated on every write: `encode()` returning a vector of wrong
   length throws `EmbeddingDimMismatchError`.
+- **CRDT collections are unsupported** — constructing a collection with both
+  `embeddings` and `crdt` set throws immediately. Use a non-CRDT collection for
+  semantic search (L2 scope).
+- An empty source field (blank or absent value) yields a near-zero vector; the
+  record is stored and retrieved but will score low on all queries.
 
 ---
 
@@ -135,15 +138,21 @@ interface RetrieveHit<T> {
 
 Accepts a raw `Float32Array` (caller has already encoded the query). This is
 the "bring your own vector" path — useful when the query has already been
-encoded by the caller, or when composing with `.where()`:
+encoded by the caller.
 
 ```ts
 const qVec = await myEncoder('quarterly report')
 const hits = await docs.similarTo(qVec, { k: 10 })
 
-// Compose with a predicate filter (intersect cosine top-k with the predicate set):
-const filtered = await docs.query().where('status', '=', 'active').similarTo(qVec, { k: 5 }).run()
+// Manual hybrid filter: intersect similarTo() ids with a predicate query result:
+const vecHits = await docs.similarTo(qVec, { k: 20 })
+const active = new Set((await docs.query().where('status', '=', 'active').run()).map((r) => r.id))
+const filtered = vecHits.filter((h) => active.has(h.id))
 ```
+
+> **Note:** `query().similarTo().where()` chaining (hybrid filtering in one
+> expression) is **deferred**. The workaround above — intersecting two result
+> sets manually — is the supported pattern in L2.
 
 ---
 
@@ -181,7 +190,6 @@ the record itself.
 | Situation | Behaviour |
 |---|---|
 | `encode()` returns wrong length | `EmbeddingDimMismatchError` at write time |
-| No `encode` hook configured | `EmbeddingEncoderNotConfiguredError` at first embedded write |
 | Model mismatch on retrieval | `EmbeddingModelMismatchError`; re-put records to re-derive |
 | Collection has no `embeddings` config | `similarTo()` / `retrieve(mode:'semantic')` throws (no-op descriptor) |
 | `VectorSet` dirty after a write | Rebuilt lazily on the next `retrieve`/`similarTo` call |

--- a/docs/subsystems/embeddings.md
+++ b/docs/subsystems/embeddings.md
@@ -1,0 +1,197 @@
+# Embeddings — semantic / vector retrieval (L2, encrypted-local)
+
+> Status: **preview** (`experimental: true`). Configured directly on the
+> collection via the `embeddings` option (no separate subpath). See the L2 epic
+> map below.
+
+---
+
+## Epic map: L0 -> L4
+
+| Layer | What | Status |
+|---|---|---|
+| **L0** | `collection.search(field, query, opts)` — in-memory decrypt + BM25 scan, zero leakage | shipped |
+| **L1** | `collection.retrieve(query, opts)` — client-side lexical inverted index, i18n tokenizer, multi-field BM25 | shipped (#308 L1) |
+| **L1.5** | Persisted opaque encrypted index blob (warm cross-session, fingerprint staleness check, debounced flush) | shipped (#308 L1.5) |
+| **L2** | Client-side **semantic / vector** retrieval — `retrieve({mode:'semantic'})` + `similarTo()` — this doc | shipped (#308 L2) |
+| L3 | Formalized agent retrieval API (hybrid ranking, context assembly, `fuseRetrieval`) | future spec |
+| L4 | Access-pattern privacy (ORAM) + attested-enclave (PCC-style) compute tier | research-grade |
+
+---
+
+## What it does
+
+L2 adds **semantic retrieval** to any collection: configure an `embeddings`
+descriptor, and noy-db derives a floating-point vector for every record at
+write time, stores it **encrypted** in a reserved `_vec` sidecar under the
+collection DEK, and answers nearest-neighbour queries by brute-force cosine
+over the decrypted in-memory `VectorSet`.
+
+Key properties:
+
+- **Zero-knowledge** — the store sees only ciphertext per `_vec/<id>`; vector
+  values and source text never leave the trusted tier.
+- **No bundled model** — the `encode` hook is caller-supplied (call any local
+  or remote embedding API; the descriptor is your adapter).
+- **Brute-force cosine** — adequate at SME/pilot scale (~10 k vectors);
+  HNSW/IVF deferred.
+- **Managed vector backends deferred/gated** — a backend that would receive
+  plaintext vectors (pgvector, Vectorize, Qdrant...) is the blind-index twin;
+  v1 is encrypted-local only.
+
+Engine lives in `packages/hub/src/embeddings/` (cosine.ts, descriptor.ts,
+vector-set.ts, index.ts). `collection.ts` and `vault.ts` hold thin call-sites
+only (derive, load/cache, retrieve branch, forget wiring).
+
+---
+
+## Configuration: `embeddings` collection option
+
+```ts
+interface EmbeddingDescriptor {
+  source: string | string[]                          // field path(s) to embed
+  encode: (text: string) => Promise<Float32Array>    // pluggable encode hook
+  dim: number                                        // expected vector dimension
+  model: string                                      // version tag for model-guard
+}
+
+const docs = vault.collection<Doc>('docs', {
+  embeddings: {
+    source: 'text',                                  // single field
+    encode: async (t) => myEmbeddingApi(t),          // host/remote — no bundled model
+    dim: 1536,
+    model: 'text-embedding-3-small',
+  },
+})
+```
+
+- `source` may be a single field path or an array of paths; values are joined
+  (space-separated) before encoding.
+- `encode` is async; errors propagate like `autoTranslate` — write fails if the
+  encoder throws.
+- If a collection declares `embeddings` but no `encode` hook is reachable,
+  `EmbeddingEncoderNotConfiguredError` is thrown at write time.
+- `dim` is validated on every write: `encode()` returning a vector of wrong
+  length throws `EmbeddingDimMismatchError`.
+
+---
+
+## `_vec` sidecar and privacy model
+
+Each embedded record gets a `_vec/<id>` entry in the store: the body
+`{ vec: number[], model: string, dim: number }` is encrypted under the
+**collection DEK** (the same key used for all records in the collection).
+
+The store learns:
+
+- The count of `_vec` rows (one per embedded record) — same metadata any
+  record set already exposes.
+- Write timing (one `_vec` write per `put`).
+
+The store learns **nothing** about vector values, source text, or semantic
+proximity. This is the zero-knowledge equivalent of L1's client-side lexical
+scan — retrieval stays entirely in the trusted tier.
+
+**Managed/plaintext vector backends are deferred and gated.** Any backend
+that receives plaintext vectors (pgvector, Cloudflare Vectorize, Qdrant,
+Pinecone, ...) would expose vectors to embedding inversion — the same threat
+profile as the blind index for lexical search. That path is explicitly
+deferred; v1 is encrypted-local only.
+
+---
+
+## Retrieval API
+
+### `retrieve(q, { mode: 'semantic', k?, minScore? })`
+
+```ts
+const hits = await docs.retrieve('overdue invoice', { mode: 'semantic' })
+// Returns RetrieveHit[] — best first
+// { id, score, rank, field: '(vector)', snippet?, record? }
+
+// Limit to top-5:
+const top5 = await docs.retrieve('overdue invoice', { mode: 'semantic', k: 5 })
+
+// Filter by minimum cosine similarity:
+const strong = await docs.retrieve('quarterly report', { mode: 'semantic', minScore: 0.8 })
+```
+
+Flow: `encode(q)` (via the collection's `encode` hook) -> `VectorSet.ensureLoaded()` (list+get+decrypt all `_vec`, cached per session; rebuilt when dirty after a write) -> model-guard check -> `cosineTopK(qVec, k, minScore)` -> map to `RetrieveHit[]` with `rank` (1-based) and cosine `score`.
+
+`RetrieveHit` shape:
+
+```ts
+interface RetrieveHit<T> {
+  readonly id: string
+  readonly score: number   // cosine similarity, descending
+  readonly rank: number    // 1-based
+  readonly field: string   // '(vector)' for semantic hits
+  readonly snippet?: string
+  readonly record?: T      // only when includeRecord: true
+}
+```
+
+### `collection.similarTo(vector, { k?, minScore? })`
+
+Accepts a raw `Float32Array` (caller has already encoded the query). This is
+the "bring your own vector" path — useful when the query has already been
+encoded by the caller, or when composing with `.where()`:
+
+```ts
+const qVec = await myEncoder('quarterly report')
+const hits = await docs.similarTo(qVec, { k: 10 })
+
+// Compose with a predicate filter (intersect cosine top-k with the predicate set):
+const filtered = await docs.query().where('status', '=', 'active').similarTo(qVec, { k: 5 }).run()
+```
+
+---
+
+## Model-version guard
+
+Every stored vector is tagged with the `model` string from the descriptor. On
+retrieval, if any stored vector's `model` differs from the current descriptor's
+`model`, noy-db throws `EmbeddingModelMismatchError`.
+
+Changing the `model` string invalidates the embedding space: cosine similarity
+across vectors from different models is meaningless, and results would be
+silently wrong without this guard.
+
+**Recovery in v1:** `vault.embeddings.reindex()` is DEFERRED. In v1, the error
+surfaces; re-derive by re-putting records (triggers fresh `encode()` + new
+`_vec` write). A full `reindex()` helper is planned for L2.x.
+
+---
+
+## `forget()` teardown
+
+`vault.forget(subject)` crypto-shreds records and **also drops each affected
+record's `_vec/<id>` sidecar** (resilient try/catch + residue in `ForgetResult`,
+mirroring `_ftindex` and `_idx` teardown). The `VectorSet` is marked dirty so
+the next retrieval reloads from the store (without the forgotten vectors).
+
+Forgotten vectors must not survive crypto-shred: a vector can be inverted back
+toward the source text (embedding inversion), so it is treated as sensitive as
+the record itself.
+
+---
+
+## Edge cases
+
+| Situation | Behaviour |
+|---|---|
+| `encode()` returns wrong length | `EmbeddingDimMismatchError` at write time |
+| No `encode` hook configured | `EmbeddingEncoderNotConfiguredError` at first embedded write |
+| Model mismatch on retrieval | `EmbeddingModelMismatchError`; re-put records to re-derive |
+| Collection has no `embeddings` config | `similarTo()` / `retrieve(mode:'semantic')` throws (no-op descriptor) |
+| `VectorSet` dirty after a write | Rebuilt lazily on the next `retrieve`/`similarTo` call |
+| ~10 k vectors (SME scale) | Brute-force cosine adequate; HNSW/IVF deferred |
+
+---
+
+## Cross-references
+
+- L2 design spec: `docs/superpowers/specs/2026-06-22-ai-retrieval-l2-semantic-vector-design.md`
+- L1/L1.5 search subsystem: `docs/subsystems/search.md`
+- Showcase 124: semantic retrieve walkthrough — `showcases/src/124-semantic-retrieve.showcase.test.ts`
+- `features.yaml` -> `features` -> `vector-search`

--- a/docs/superpowers/plans/2026-06-22-ai-retrieval-l2-semantic-vector.md
+++ b/docs/superpowers/plans/2026-06-22-ai-retrieval-l2-semantic-vector.md
@@ -1,0 +1,575 @@
+# AI Retrieval L2 — Semantic/Vector (encrypted, local) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Per-collection `embeddings: { source, encode, dim, model }` derives a vector per record at write via a pluggable `encode` hook, stores it ENCRYPTED in a reserved `_vec` sidecar, and answers `retrieve(q, { mode:'semantic' })` / `collection.similarTo(vec, { k })` by brute-force cosine over decrypted vectors in the trusted tier. Zero-knowledge; managed backends deferred.
+
+**Architecture:** New tree-shakeable `src/embeddings/` (cosine, VectorSet, descriptor+errors). **Config-gated like L1's `searchIndexStore`** (not a `createNoydb` strategy): collection.ts imports the engine and constructs a `VectorSet` only when `embeddings` is configured. Vectors live per-record in a reserved `_vec` collection (collection DEK, excluded from hydration, dropped on `forget()`), loaded into an in-memory `VectorSet` (cached, dirty-on-write) — same load/cache/dirty shape as L1's index.
+
+**Tech Stack:** TypeScript (ESM, `.js` specifiers), vitest (`vitest run` from `packages/hub`), `Float32Array` cosine, reusing the `_ftindex` encrypt/adapter sidecar pattern + L1's `RetrieveHit`.
+
+**Spec:** `docs/superpowers/specs/2026-06-22-ai-retrieval-l2-semantic-vector-design.md`
+
+## Global Constraints
+
+- Hub-portable: no Node-only imports in `packages/hub/src/**`.
+- Tree-shakeable: engine in `src/embeddings/`; constructed only when a collection sets `embeddings` (zero cost otherwise).
+- Zero added store leakage: vectors stored ENCRYPTED per `_vec/<id>` (collection DEK); store sees ciphertext only; `_vec` excluded from record hydration (reserved `_`-prefixed collection) and never returned by record reads.
+- `retrieve()`/`similarTo()` are eager-only (throw in lazy mode, like L1).
+- `exactOptionalPropertyTypes` on — spread-conditional for optional props.
+- No Claude/AI attribution in commits.
+- Managed/plaintext vector backends, HNSW, chunking, `query().similarTo().where()` builder-chaining are OUT (deferred; consumers compose `collection.similarTo()` ids with `query().where()` meanwhile).
+
+---
+
+## Task 1: cosine similarity (pure)
+
+**Files:**
+- Create: `packages/hub/src/embeddings/cosine.ts`
+- Test: `packages/hub/__tests__/embeddings-cosine.test.ts`
+
+**Interfaces:**
+- Produces: `cosine(a: Float32Array | number[], b: Float32Array | number[]): number` (returns 0 for zero-norm or length mismatch).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/hub/__tests__/embeddings-cosine.test.ts
+import { describe, it, expect } from 'vitest'
+import { cosine } from '../src/embeddings/cosine.js'
+
+describe('cosine (#308 L2)', () => {
+  it('identical vectors → 1', () => { expect(cosine([1, 2, 3], [1, 2, 3])).toBeCloseTo(1, 6) })
+  it('orthogonal → 0', () => { expect(cosine([1, 0], [0, 1])).toBeCloseTo(0, 6) })
+  it('opposite → -1', () => { expect(cosine([1, 0], [-1, 0])).toBeCloseTo(-1, 6) })
+  it('zero-norm → 0 (no NaN)', () => { expect(cosine([0, 0], [1, 1])).toBe(0) })
+  it('length mismatch → 0', () => { expect(cosine([1, 2], [1, 2, 3])).toBe(0) })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails** — `cd packages/hub && npx vitest run __tests__/embeddings-cosine.test.ts` → FAIL (module missing).
+
+- [ ] **Step 3: Implement**
+
+```ts
+// packages/hub/src/embeddings/cosine.ts
+/** Cosine similarity in [-1,1]; 0 on zero-norm or length mismatch (no NaN). (#308 L2) */
+export function cosine(a: Float32Array | number[], b: Float32Array | number[]): number {
+  if (a.length !== b.length) return 0
+  let dot = 0, na = 0, nb = 0
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i]!, y = b[i]!
+    dot += x * y; na += x * x; nb += y * y
+  }
+  if (na === 0 || nb === 0) return 0
+  return dot / (Math.sqrt(na) * Math.sqrt(nb))
+}
+```
+
+- [ ] **Step 4: Run to verify it passes** — same command → PASS (5). Then `npx tsc --noEmit` clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/embeddings/cosine.ts packages/hub/__tests__/embeddings-cosine.test.ts
+git commit -m "feat(embeddings): pure cosine similarity (#308 L2)"
+```
+
+---
+
+## Task 2: EmbeddingDescriptor + errors
+
+**Files:**
+- Create: `packages/hub/src/embeddings/descriptor.ts`
+- Modify: `packages/hub/src/errors.ts` (3 new error classes)
+- Test: `packages/hub/__tests__/embeddings-descriptor.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `interface EmbeddingDescriptor { readonly source: string | readonly string[]; readonly encode: (text: string) => Promise<Float32Array>; readonly dim: number; readonly model: string }`
+  - `embeddingSourceText(record, source): string` (join the source fields' text via `getAtPath`).
+  - errors `EmbeddingEncoderNotConfiguredError`, `EmbeddingDimMismatchError`, `EmbeddingModelMismatchError` (extend `NoydbError`, codes `EMBEDDING_*`).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/hub/__tests__/embeddings-descriptor.test.ts
+import { describe, it, expect } from 'vitest'
+import { embeddingSourceText } from '../src/embeddings/descriptor.js'
+import { EmbeddingDimMismatchError, EmbeddingModelMismatchError } from '../src/errors.js'
+
+describe('embeddingSourceText (#308 L2)', () => {
+  it('joins multiple source fields, skipping empties', () => {
+    expect(embeddingSourceText({ a: 'overdue', b: '', c: 'invoice' }, ['a', 'b', 'c'])).toBe('overdue invoice')
+  })
+  it('single string source', () => {
+    expect(embeddingSourceText({ desc: 'TCM rent' }, 'desc')).toBe('TCM rent')
+  })
+  it('nested/wildcard path via getAtPath', () => {
+    expect(embeddingSourceText({ items: [{ d: 'a' }, { d: 'b' }] }, 'items[].d')).toBe('a b')
+  })
+})
+
+describe('embedding errors (#308 L2)', () => {
+  it('dim mismatch carries field/expected/actual', () => {
+    const e = new EmbeddingDimMismatchError('vec', 768, 384)
+    expect(e).toBeInstanceOf(Error); expect(e.message).toContain('768'); expect(e.message).toContain('384')
+  })
+  it('model mismatch carries the two models', () => {
+    const e = new EmbeddingModelMismatchError('minilm-v2', 'minilm-v1')
+    expect(e.message).toContain('minilm-v2'); expect(e.message).toContain('minilm-v1')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails** — `cd packages/hub && npx vitest run __tests__/embeddings-descriptor.test.ts` → FAIL.
+
+- [ ] **Step 3: Add errors to `errors.ts`**
+
+Find the `NoydbError` base + an existing subclass (e.g. `MoneyPrecisionError`) for the exact pattern, then add:
+
+```ts
+export class EmbeddingEncoderNotConfiguredError extends NoydbError {
+  constructor(collection: string) {
+    super('EMBEDDING_ENCODER_NOT_CONFIGURED',
+      `Collection "${collection}" declares embeddings but no encode() hook was configured.`)
+  }
+}
+export class EmbeddingDimMismatchError extends NoydbError {
+  constructor(field: string, expected: number, actual: number) {
+    super('EMBEDDING_DIM_MISMATCH',
+      `Embedding for "${field}" has dim ${actual}, expected ${expected}.`)
+  }
+}
+export class EmbeddingModelMismatchError extends NoydbError {
+  constructor(expected: string, found: string) {
+    super('EMBEDDING_MODEL_MISMATCH',
+      `Embedding model mismatch: collection uses "${expected}" but a stored vector is "${found}". ` +
+        `Run vault.embeddings.reindex() after changing the encoder.`)
+  }
+}
+```
+
+(Match the actual `NoydbError` constructor signature — read it; if it's `(message)` with a `code` property set differently, adapt. Reuse the `MONEY_*`/`ComputedFieldError` convention.)
+
+- [ ] **Step 4: Create `descriptor.ts`**
+
+```ts
+// packages/hub/src/embeddings/descriptor.ts
+/** Per-collection embedding config (#308 L2). The encode hook is host/remote — no bundled model. */
+import { getAtPath } from '../i18n/core.js'
+
+export interface EmbeddingDescriptor {
+  readonly source: string | readonly string[]
+  readonly encode: (text: string) => Promise<Float32Array>
+  readonly dim: number
+  readonly model: string
+}
+
+/** Concatenate the record's source-field text (skips empties; supports nested/[]-wildcard paths). */
+export function embeddingSourceText(record: Record<string, unknown>, source: string | readonly string[]): string {
+  const fields = typeof source === 'string' ? [source] : source
+  const parts: string[] = []
+  for (const f of fields) {
+    for (const leaf of getAtPath(record, f)) {
+      if (typeof leaf === 'string' && leaf !== '') parts.push(leaf)
+    }
+  }
+  return parts.join(' ')
+}
+```
+
+- [ ] **Step 5: Run to verify it passes** — `npx vitest run __tests__/embeddings-descriptor.test.ts` → PASS; `npx tsc --noEmit` clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/embeddings/descriptor.ts packages/hub/src/errors.ts packages/hub/__tests__/embeddings-descriptor.test.ts
+git commit -m "feat(embeddings): EmbeddingDescriptor + source-text + errors (#308 L2)"
+```
+
+---
+
+## Task 3: VectorSet (in-memory, model-guarded cosine kNN)
+
+**Files:**
+- Create: `packages/hub/src/embeddings/vector-set.ts`
+- Create: `packages/hub/src/embeddings/index.ts` (barrel)
+- Test: `packages/hub/__tests__/embeddings-vector-set.test.ts`
+
+**Interfaces:**
+- Consumes: `cosine` (`./cosine.js`); `EmbeddingModelMismatchError` (`../errors.js`).
+- Produces:
+  - `interface StoredVector { readonly id: string; readonly vec: Float32Array; readonly model: string }`
+  - `interface VectorHit { readonly id: string; readonly score: number }`
+  - `class VectorSet { ensureLoaded(load: () => Promise<StoredVector[]>): Promise<void>; markDirty(): void; cosineTopK(query: Float32Array, k: number, opts?: { minScore?: number; expectModel?: string }): VectorHit[]; readonly loaded: boolean }`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/hub/__tests__/embeddings-vector-set.test.ts
+import { describe, it, expect } from 'vitest'
+import { VectorSet, type StoredVector } from '../src/embeddings/vector-set.js'
+import { EmbeddingModelMismatchError } from '../src/errors.js'
+
+const vecs: StoredVector[] = [
+  { id: 'a', vec: new Float32Array([1, 0, 0]), model: 'm1' },
+  { id: 'b', vec: new Float32Array([0.9, 0.1, 0]), model: 'm1' },
+  { id: 'c', vec: new Float32Array([0, 1, 0]), model: 'm1' },
+]
+
+describe('VectorSet (#308 L2)', () => {
+  it('loads once (load fn not called twice) and ranks by cosine', async () => {
+    const vs = new VectorSet()
+    let calls = 0
+    const load = async () => { calls++; return vecs }
+    await vs.ensureLoaded(load); await vs.ensureLoaded(load)
+    expect(calls).toBe(1); expect(vs.loaded).toBe(true)
+    const hits = vs.cosineTopK(new Float32Array([1, 0, 0]), 2)
+    expect(hits.map((h) => h.id)).toEqual(['a', 'b']) // a=1.0, b≈0.994
+    expect(hits[0]!.score).toBeCloseTo(1, 5)
+  })
+  it('k limits, minScore filters', async () => {
+    const vs = new VectorSet(); await vs.ensureLoaded(async () => vecs)
+    expect(vs.cosineTopK(new Float32Array([1, 0, 0]), 1).length).toBe(1)
+    expect(vs.cosineTopK(new Float32Array([1, 0, 0]), 5, { minScore: 0.99 }).map((h) => h.id)).toEqual(['a', 'b'])
+  })
+  it('markDirty forces reload', async () => {
+    const vs = new VectorSet(); let calls = 0
+    const load = async () => { calls++; return vecs }
+    await vs.ensureLoaded(load); vs.markDirty(); expect(vs.loaded).toBe(false)
+    await vs.ensureLoaded(load); expect(calls).toBe(2)
+  })
+  it('model guard throws on mismatch', async () => {
+    const vs = new VectorSet(); await vs.ensureLoaded(async () => vecs)
+    expect(() => vs.cosineTopK(new Float32Array([1, 0, 0]), 2, { expectModel: 'm2' })).toThrow(EmbeddingModelMismatchError)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails** — `npx vitest run __tests__/embeddings-vector-set.test.ts` → FAIL.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// packages/hub/src/embeddings/vector-set.ts
+/** In-memory vector set for L2 semantic retrieval (#308). Loaded once per session from
+ *  decrypted _vec sidecars (injected loader), brute-force cosine kNN, model-guarded. */
+import { cosine } from './cosine.js'
+import { EmbeddingModelMismatchError } from '../errors.js'
+
+export interface StoredVector { readonly id: string; readonly vec: Float32Array; readonly model: string }
+export interface VectorHit { readonly id: string; readonly score: number }
+
+export class VectorSet {
+  private vectors: StoredVector[] | undefined
+  get loaded(): boolean { return this.vectors !== undefined }
+
+  async ensureLoaded(load: () => Promise<StoredVector[]>): Promise<void> {
+    if (this.vectors === undefined) this.vectors = await load()
+  }
+
+  markDirty(): void { this.vectors = undefined }
+
+  cosineTopK(query: Float32Array, k: number, opts: { minScore?: number; expectModel?: string } = {}): VectorHit[] {
+    const all = this.vectors ?? []
+    const minScore = opts.minScore ?? -Infinity
+    const hits: VectorHit[] = []
+    for (const v of all) {
+      if (opts.expectModel !== undefined && v.model !== opts.expectModel) {
+        throw new EmbeddingModelMismatchError(opts.expectModel, v.model)
+      }
+      const score = cosine(query, v.vec)
+      if (score >= minScore) hits.push({ id: v.id, score })
+    }
+    hits.sort((a, b) => b.score - a.score)
+    return hits.slice(0, k)
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes** — PASS (4). `npx tsc --noEmit` clean.
+
+- [ ] **Step 5: Barrel + commit**
+
+Create `packages/hub/src/embeddings/index.ts`:
+```ts
+export { cosine } from './cosine.js'
+export { embeddingSourceText, type EmbeddingDescriptor } from './descriptor.js'
+export { VectorSet, type StoredVector, type VectorHit } from './vector-set.js'
+```
+```bash
+git add packages/hub/src/embeddings/vector-set.ts packages/hub/src/embeddings/index.ts packages/hub/__tests__/embeddings-vector-set.test.ts
+git commit -m "feat(embeddings): VectorSet — model-guarded cosine kNN (#308 L2)"
+```
+
+---
+
+## Task 4: Write-time derivation — `embeddings` option + encrypted `_vec` sidecar
+
+**Files:**
+- Modify: `packages/hub/src/collection.ts` (ctor option/field ~706/320/925 patterns; derive in `put` after the auto-translate block ~1534; `_vec` write + load callbacks; dirty handle)
+- Modify: `packages/hub/src/vault.ts` (public `collection()` `embeddings` option + threading, ~679/1008 patterns)
+- Test: `packages/hub/__tests__/embeddings-write.test.ts`
+
+**Interfaces:**
+- Consumes: `EmbeddingDescriptor`, `embeddingSourceText`, `VectorSet`, `StoredVector` (`./embeddings/index.js`); `encryptJsonString`/`decryptJsonString`/`adapter`/`cache` (collection); the 3 embedding errors.
+- Produces (on `Collection`): `embeddings?: EmbeddingDescriptor` option/field; `private vectorSet: VectorSet | undefined`; `private buildVectorLoad(): () => Promise<StoredVector[]>` (list+get+decrypt `_vec`); derive-on-`put`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/hub/__tests__/embeddings-write.test.ts
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import type { Noydb } from '../src/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError, EmbeddingDimMismatchError } from '../src/errors.js'
+
+// paste the memory() helper verbatim from i18n-script-put.test.ts lines 12-48
+
+interface Doc { id: string; text: string }
+// deterministic stub encoder: 3-dim bag-of-chars hash → unit-ish vector
+const enc = (dim: number, model = 'stub') => ({
+  dim, model, source: 'text' as const,
+  encode: async (t: string) => { const v = new Float32Array(dim); for (let i = 0; i < t.length; i++) v[t.charCodeAt(i) % dim] += 1; return v },
+})
+
+describe('embeddings write derivation (#308 L2)', () => {
+  it('put derives an ENCRYPTED _vec sidecar (no plaintext vector), not hydrated as a record', async () => {
+    const store = memory()
+    const puts: string[] = []
+    const wrapped: NoydbStore = { ...store, async put(c, col, id, e, ev) { puts.push(`${col}/${id}`); return store.put(c, col, id, e, ev) } }
+    const db = await createNoydb({ store: wrapped, user: 'a', secret: 'pw-emb' })
+    const v = await db.openVault('v')
+    const c = v.collection<Doc>('d', { embeddings: enc(8) })
+    await c.put('x', { id: 'x', text: 'overdue invoice' })
+    expect(puts.some((p) => p.startsWith('_vec/x'))).toBe(true)
+    const env = await wrapped.get('v', '_vec', 'x')
+    expect(JSON.stringify(env)).not.toContain('overdue')          // source text not leaked
+    expect((await c.toArray()).map((r) => r.id)).toEqual(['x'])   // _vec not a phantom record
+  })
+
+  it('dim mismatch → EmbeddingDimMismatchError', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'pw' })
+    const v = await db.openVault('v')
+    const c = v.collection<Doc>('d', { embeddings: { ...enc(8), encode: async () => new Float32Array(4) } })
+    await expect(c.put('x', { id: 'x', text: 'hi' })).rejects.toThrow(EmbeddingDimMismatchError)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails** — `npx vitest run __tests__/embeddings-write.test.ts` → FAIL.
+
+- [ ] **Step 3: Add the option/field + vault threading**
+
+(a) `collection.ts` ctor options interface (beside `i18nFields` ~706): `embeddings?: EmbeddingDescriptor | undefined`. Field (~320): `private readonly embeddings: EmbeddingDescriptor | undefined`; `private vectorSet: VectorSet | undefined`. Ctor (~925): `this.embeddings = opts.embeddings; this.vectorSet = opts.embeddings ? new VectorSet() : undefined`. Imports from `./embeddings/index.js` + the errors.
+(b) `vault.ts` public `collection()` option (~679): `embeddings?: EmbeddingDescriptor`; threading (~1008): `if (options?.embeddings !== undefined) collOpts.embeddings = options.embeddings`.
+
+- [ ] **Step 4: Derive on put + the `_vec` load callback**
+
+In `collection.ts`, right AFTER the auto-translate block (~line 1534, before script enforcement), add the derive step:
+
+```ts
+    // #308 L2 — derive the embedding vector at write (encode → encrypted _vec sidecar).
+    if (this.embeddings) {
+      const text = embeddingSourceText(record as Record<string, unknown>, this.embeddings.source)
+      const vec = await this.embeddings.encode(text)
+      if (vec.length !== this.embeddings.dim) throw new EmbeddingDimMismatchError('embeddings', this.embeddings.dim, vec.length)
+      const body = JSON.stringify({ vec: Array.from(vec), model: this.embeddings.model, dim: this.embeddings.dim })
+      const env = await this.encryptJsonString(body, version)
+      await this.adapter.put(this.vault, '_vec', id, env)
+      this.vectorSet?.markDirty()
+    }
+```
+NOTE: `version` must be in scope here — if the final record version isn't computed until later, write the `_vec` AFTER the main record write using the same version, OR use a constant version (the `_vec` envelope `_v` is not OCC-checked). If `version` isn't available at this point, move this block to just after the main `adapter.put` of the record (still pre-return); read the surrounding code to place it where both `id` and the record's `version` exist. The `_vec` write must not block the record write — wrap in the same error flow.
+
+Add the loader builder + a private helper near the search helpers:
+
+```ts
+  /** #308 L2 — load + decrypt all _vec sidecars into StoredVector[] for the VectorSet. */
+  private buildVectorLoad(): () => Promise<import('./embeddings/index.js').StoredVector[]> {
+    return async () => {
+      const ids = await this.adapter.list(this.vault, '_vec')
+      const out: import('./embeddings/index.js').StoredVector[] = []
+      for (const id of ids) {
+        const env = await this.adapter.get(this.vault, '_vec', id)
+        if (!env) continue
+        const body = await this.decryptJsonString(env)
+        if (body === null) continue
+        const parsed = JSON.parse(body) as { vec: number[]; model: string }
+        out.push({ id, vec: new Float32Array(parsed.vec), model: parsed.model })
+      }
+      return out
+    }
+  }
+```
+
+- [ ] **Step 5: Run + full suite + commit**
+
+`cd packages/hub && npx vitest run __tests__/embeddings-write.test.ts && npx vitest run && npx eslint src/embeddings src/collection.ts && npx tsc --noEmit` → all green.
+
+```bash
+git add packages/hub/src/collection.ts packages/hub/src/vault.ts packages/hub/__tests__/embeddings-write.test.ts
+git commit -m "feat(embeddings): derive encrypted _vec sidecar on write (#308 L2)"
+```
+
+---
+
+## Task 5: `retrieve(mode:'semantic')` + `collection.similarTo`
+
+**Files:**
+- Modify: `packages/hub/src/search/retrieve-types.ts` (`RetrieveOptions.mode`)
+- Modify: `packages/hub/src/collection.ts` (`retrieve()` semantic branch; new `similarTo()`)
+- Test: `packages/hub/__tests__/embeddings-retrieve.test.ts`
+
+**Interfaces:**
+- Consumes: `VectorSet`, `cosine`; `RetrieveHit` (existing); the embeddings descriptor + `buildVectorLoad`.
+- Produces: `RetrieveOptions.mode?: 'lexical' | 'semantic'` (default `'lexical'`); `collection.similarTo(vector: Float32Array, opts?: { k?: number; minScore?: number; includeRecord?: boolean }): Promise<RetrieveHit<T>[]>`; `retrieve(q,{mode:'semantic'})`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/hub/__tests__/embeddings-retrieve.test.ts
+// memory() helper + the enc() stub from embeddings-write.test.ts (copy both).
+// interface Doc { id: string; text: string }
+//
+// Test A: collection with embeddings: enc(8); put 3 docs with distinct text;
+//   retrieve('<text matching doc x>', { mode:'semantic' }) returns x as rank-1,
+//   hits carry rank (1-based) and score (cosine).
+// Test B: collection.similarTo(enc.encode('<x text>'), { k:1 }) returns [x].
+// Test C: minScore filters out far docs.
+// Test D (model guard): store a vec under model 'stub', open the collection with
+//   embeddings model 'stub2' → retrieve(mode:'semantic') throws EmbeddingModelMismatchError.
+// Test E (leakage): wrapped store — retrieve(mode:'semantic') reads _vec (get) but
+//   writes nothing new; _vec env body has no plaintext source term.
+// Write these as concrete runnable tests using the deterministic stub encoder.
+```
+Implementer: write the 5 concrete tests above with the deterministic `enc()` stub (same as Task 4) so similarity is reproducible. Don't leave as prose.
+
+- [ ] **Step 2: Run to verify it fails** — FAIL (`mode`/`similarTo` missing).
+
+- [ ] **Step 3: Add `mode` + the semantic branch + `similarTo`**
+
+(a) `retrieve-types.ts`: add `readonly mode?: 'lexical' | 'semantic'` to `RetrieveOptions`.
+
+(b) `collection.ts retrieve()`: at the top, branch on mode:
+```ts
+    if (opts.mode === 'semantic') return this.retrieveSemantic(query, opts)
+```
+Add `retrieveSemantic` + `similarTo` + a shared `vectorTopKToHits`:
+```ts
+  private async retrieveSemantic(query: string, opts: RetrieveOptions): Promise<RetrieveHit<T>[]> {
+    if (!this.embeddings) throw new Error(`Collection "${this.name}": retrieve({mode:'semantic'}) requires an embeddings config.`)
+    if (this.lazy) throw new Error(`Collection "${this.name}": retrieve() requires eager mode (prefetch: true).`)
+    const qVec = await this.embeddings.encode(query)
+    return this.similarTo(qVec, { ...(opts.limit !== undefined ? { k: opts.limit } : {}), ...(opts.minScore !== undefined ? { minScore: opts.minScore } : {}), ...(opts.includeRecord ? { includeRecord: true } : {}) })
+  }
+
+  /** #308 L2 — raw-vector kNN over the encrypted vector set (decrypted in the trusted tier). */
+  async similarTo(vector: Float32Array, opts: { k?: number; minScore?: number; includeRecord?: boolean } = {}): Promise<RetrieveHit<T>[]> {
+    if (!this.embeddings || !this.vectorSet) throw new Error(`Collection "${this.name}": similarTo() requires an embeddings config.`)
+    if (this.lazy) throw new Error(`Collection "${this.name}": similarTo() requires eager mode (prefetch: true).`)
+    await this.ensureHydrated()
+    await this.vectorSet.ensureLoaded(this.buildVectorLoad())
+    const hits = this.vectorSet.cosineTopK(vector, opts.k ?? 10, { ...(opts.minScore !== undefined ? { minScore: opts.minScore } : {}), expectModel: this.embeddings.model })
+    return hits.map((h, i) => {
+      const base: RetrieveHit<T> = { id: h.id, score: h.score, rank: i + 1, field: '(vector)', snippet: '' }
+      if (opts.includeRecord) { const e = this.cache.get(h.id); if (e) (base as { record?: T }).record = stripI18nFilled(e.record as Record<string, unknown>) as T }
+      return base
+    })
+  }
+```
+Note: `RetrieveOptions` needs `minScore?` too — add `readonly minScore?: number` to `RetrieveOptions` (used only by semantic mode). The `snippet` is `''` for vector hits in v1 (semantic match isn't span-located); a follow-up could derive a snippet from the source field. Document that.
+
+- [ ] **Step 4: Run + full suite + commit**
+
+`cd packages/hub && npx vitest run __tests__/embeddings-retrieve.test.ts && npx vitest run && npx eslint src && npx tsc --noEmit` → green.
+
+```bash
+git add packages/hub/src/search/retrieve-types.ts packages/hub/src/collection.ts packages/hub/__tests__/embeddings-retrieve.test.ts
+git commit -m "feat(embeddings): retrieve(mode:semantic) + similarTo() (#308 L2)"
+```
+
+---
+
+## Task 6: `forget()` teardown of `_vec` sidecars
+
+**Files:**
+- Modify: `packages/hub/src/collection.ts` (`_purgeVector(id)`)
+- Modify: `packages/hub/src/vault.ts` (`forget()` per-ref purge + residue)
+- Test: `packages/hub/__tests__/embeddings-forget.test.ts`
+
+**Interfaces:**
+- Produces: `Collection._purgeVector(id: string): Promise<void>` (delete `_vec/<id>` + `vectorSet?.markDirty()`).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/hub/__tests__/embeddings-forget.test.ts
+// Copy the forget harness from forget.test.ts (withForgetCascade/forgetStrategy) +
+// the enc() stub. Configure a collection with embeddings + forget subject. After
+// vault.forget(subject), assert adapter.get(vault,'_vec',recordId) === null AND a
+// subsequent retrieve(mode:'semantic') excludes the forgotten record. Add a
+// resilience case: a store whose delete throws for '_vec' → forget resolves +
+// surfaces residue. Write runnable; locate the real forget harness first.
+```
+Implementer: locate `forget.test.ts`'s subject/forget-strategy wiring, write the concrete tests (blob gone + excluded-from-semantic + delete-throws-resilience+residue).
+
+- [ ] **Step 2: Run to verify it fails** — FAIL.
+
+- [ ] **Step 3: Add `_purgeVector` + wire forget**
+
+`collection.ts`:
+```ts
+  /** #308 L2 — drop a record's encrypted _vec sidecar on erasure (a vector is text-invertible). */
+  async _purgeVector(id: string): Promise<void> {
+    await this.adapter.delete(this.vault, '_vec', id)
+    this.vectorSet?.markDirty()
+  }
+```
+`vault.ts forget()` — in the PER-REF loop (beside `_purgePersistedIndexes(ref.id)`), add resilient purge:
+```ts
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (coll as any)._purgeVector(ref.id)
+      } catch {
+        indexResidue.push(`${ref.collection}:${ref.id}:_vec`)
+      }
+```
+(`coll` is the per-ref collection already obtained in that loop; mirror `_purgePersistedIndexes`'s try/catch + residue.)
+
+- [ ] **Step 4: Run + full suite + commit**
+
+`cd packages/hub && npx vitest run __tests__/embeddings-forget.test.ts && npx vitest run && npx tsc --noEmit` → green.
+
+```bash
+git add packages/hub/src/collection.ts packages/hub/src/vault.ts packages/hub/__tests__/embeddings-forget.test.ts
+git commit -m "feat(embeddings): forget() purges encrypted _vec sidecars + residue (#308 L2)"
+```
+
+---
+
+## Task 7: Docs, features.yaml, showcase, ceiling, final gate
+
+**Files:** `docs/subsystems/`, `features.yaml`, `showcases/src/<next>`, `scripts/check-architecture.mjs`
+
+- [ ] **Step 1: Subsystem doc** — create/extend an embeddings/vector-search subsystem doc: the `embeddings` config + `encode`-hook contract (host/remote, no bundled model), the encrypted-local privacy model (`_vec` sidecar, zero-knowledge, managed-backends-deferred), `retrieve(mode:'semantic')`/`similarTo`, model-versioning guard + `reindex`, `forget()` teardown, and the L2 line of the epic map. Commit `docs(embeddings): document semantic retrieval + encrypted-local model (#308 L2)`.
+- [ ] **Step 2: features.yaml** — add a `vector-search` feature (`status: preview`, `experimental: true`) leading with the encrypted-local model + deferred managed-backend note; spec ref `docs/superpowers/specs/2026-06-22-ai-retrieval-l2-semantic-vector-design.md`; add the showcase. `node scripts/validate-features.mjs` must pass. Commit `chore(features): register vector-search (#308 L2)`.
+- [ ] **Step 3: Showcase** — `showcases/src/<next>-semantic-retrieve.showcase.test.ts`: a collection with `embeddings` using a **deterministic stub encoder** (e.g. char-bucket hash → Float32Array, same as the tests — runs without a real model); put a few docs; `retrieve('<query>', {mode:'semantic'})` returns the nearest; demonstrate `similarTo()` and the model-mismatch guard. Build hub first (`cd packages/hub && npx tsup`), run it. Commit `docs(showcase): semantic retrieve walkthrough (#308 L2)`.
+- [ ] **Step 4: Ceiling + final gate** —
+```bash
+cd packages/hub && npx tsup && npx vitest run && npx eslint src && npx tsc --noEmit
+cd /Users/vicio/_github/noy-db && node scripts/check-architecture.mjs && node scripts/validate-features.mjs
+```
+If `collection.ts`/`vault.ts` exceed ceilings in `scripts/check-architecture.mjs`, raise each to `wc -l` + ~10 with a one-line `// Bumped …→… (#308 L2): embeddings derive/retrieve/forget call-sites (engine in src/embeddings/)` comment. Re-run until green. Commit any bump.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:** cosine → T1 ✓; `EmbeddingDescriptor` + source-text + errors → T2 ✓; `VectorSet` + model-guarded cosine kNN → T3 ✓; `embeddings` config + encode-on-write + encrypted `_vec` sidecar + dim error + not-hydrated → T4 ✓; `retrieve(mode:'semantic')` + `similarTo` + model guard + `rank` → T5 ✓; `forget()` `_vec` teardown + residue → T6 ✓; docs/features/showcase/ceiling + leakage tests → T4/T5/T7 ✓. Deferred per spec (managed backends, HNSW, chunking, `query().similarTo().where()` builder chaining, cross-vault, multimodal, combined-blob persistence) — correctly absent. NOTE: `vault.embeddings.reindex()` is referenced in errors/docs but NOT built as a task — v1 surfaces the model-mismatch error; `reindex` (re-derive all `_vec`) is a small follow-up. **Gap flagged**: either add a Task or document `reindex` as deferred (the error tells the user to re-derive; a manual re-put achieves it). Resolve by documenting `reindex` deferred in T7's doc.
+
+**2. Placeholder scan:** T5 Step 1 and T6 Step 1 are "locate harness / write concrete tests with the deterministic stub" instructions (the encoder stub + forget harness must be read from the repo) — not code placeholders; all implementation steps carry full code. T2 Step 3 flags matching the real `NoydbError` ctor. T4 Step 4 flags the `version`-in-scope placement decision with a concrete fallback (write `_vec` after the record put). No "TBD"/bare "handle errors".
+
+**3. Type consistency:** `EmbeddingDescriptor {source,encode,dim,model}` (T2) consumed verbatim in T4/T5. `StoredVector {id,vec,model}` + `VectorSet.cosineTopK(query,k,{minScore,expectModel})` (T3) used in T4 (`buildVectorLoad` returns `StoredVector[]`) + T5 (`similarTo`). `EmbeddingModelMismatchError`/`EmbeddingDimMismatchError` (T2) thrown in T3/T4/T5. `RetrieveOptions.mode`+`minScore` (T5) and the existing `RetrieveHit.rank` consistent. `_vec` reserved collection + id=recordId consistent across T4 (write/load), T6 (purge).

--- a/docs/superpowers/specs/2026-06-22-ai-retrieval-l2-semantic-vector-design.md
+++ b/docs/superpowers/specs/2026-06-22-ai-retrieval-l2-semantic-vector-design.md
@@ -1,0 +1,121 @@
+# AI retrieval — L2: semantic / vector retrieval (encrypted, local) — design
+
+> **Status:** DESIGN — ready for plan.
+> **One line:** `withEmbeddings({ source, encode, dim, model })` derives a vector per
+> record at write via a **pluggable encode hook** (host/remote, no bundled model),
+> stores it **encrypted at rest** in a reserved `_vec` sidecar, and answers
+> `retrieve(q, { mode: 'semantic' })` / `query().similarTo(vec, { k })` by **brute-force
+> cosine over decrypted vectors in the trusted tier**. Zero-knowledge: the store sees
+> only ciphertext; no vector ever leaves your control. Managed vector backends (which
+> would see plaintext vectors → embedding-inversion) are **deferred/gated** — the
+> blind-index twin.
+
+## Context
+
+L2 is the semantic layer of the AI-retrieval epic ([[project_search_ai_retrieval_epic]]):
+L0 scan ✅, L1 lexical ✅, L1.5 persisted ✅, **L2 semantic (this)**, L3 hybrid, L4
+ORAM/enclave (deferred). It realizes the **embeddings dimension #13**
+(`docs/superpowers/specs/2026-05-01-dimensions/13-embeddings.md`) under the epic's
+trusted-tier privacy stance. The #13 doc's central tradeoff (encryption vs
+searchability) is resolved here as **encrypted-vectors + local cosine** (#13's option
+b) — the consistent choice for PII-heavy accounting data, parallel to L1's
+scan-over-blind-index decision.
+
+There is no existing vector/embedding code in the hub (verified). The precedents this
+reuses: the `withI18n`-style tree-shakeable strategy, the `plaintextTranslator`/
+`autoTranslate` write-time hook, L1.5's reserved-sidecar-under-collection-DEK +
+load/cache/dirty pattern, and L1's `RetrieveHit` shape.
+
+## Scope — in
+
+| Item | Notes |
+|---|---|
+| `withEmbeddings({ source, encode, dim, model })` strategy | tree-shakeable (`src/embeddings/`); `NO_EMBEDDINGS` no-op default. `source: string \| string[]` (fields to embed); `encode(text) => Promise<Float32Array>`; `dim: number`; `model: string` (version tag) |
+| `encode` hook — pluggable, host/remote, **no bundled model** | configured per-collection on `withEmbeddings`; runs at write (derive) AND query (embed the query). `EmbeddingEncoderNotConfiguredError` if a collection declares embeddings without an encoder; encode errors propagate (like `autoTranslate`) |
+| Write-time derivation | on `put`, encode the `source` text → store the vector **encrypted** in reserved `_vec` sidecar (collection `_vec`, id = recordId, collection DEK). Re-derive when the source changes (embedding-consistency #07). dim mismatch → `EmbeddingDimMismatchError` |
+| `_vec` sidecar | reserved `_vec` collection (excluded from record hydration like `_ftindex`); per-record `{ vec: number[], model, dim }` body, encrypted; **dropped on `forget()`** (resilient + residue, like `_ftindex`) |
+| In-memory `VectorSet` | `src/embeddings/vector-set.ts` — loaded once per session (list+get+decrypt all `_vec`), cached, **dirty-on-write** (mirrors L1's IndexStore); `cosineTopK(queryVec, k, minScore?)` |
+| `retrieve(q, { mode: 'semantic', k, minScore? })` | `encode(q)` → `VectorSet.cosineTopK` → `RetrieveHit[]` (`{ id, score, rank, field:'(vector)', snippet?, record? }`). `mode: 'lexical'(L1) \| 'semantic'(L2)` (`'hybrid'` is L3) |
+| `query().similarTo(vector, { k, minScore? })` | raw-vector kNN terminator (#13); composes with `.where(pred)` (payload filtering — intersect cosine top-k with the predicate set) |
+| **Model-version guard** | each vector tagged with `model`; a query whose collection `model` ≠ a stored vector's `model` is a hard error (`EmbeddingModelMismatchError`) — changing the encoder invalidates the space. `vault.embeddings.reindex({ collection })` re-derives all |
+| brute-force cosine, in-memory, zero-dep | adequate at SME/pilot scale (~10k vectors); `Float32Array` math, hub-portable |
+| features.yaml + subsystem doc + showcase | `vector-search` feature (`preview`/`experimental`) leading with the encrypted-local privacy model; subsystem doc; a semantic-retrieve showcase |
+
+## Scope — out (deferred)
+
+| Item | Deferred to | Why |
+|---|---|---|
+| Managed/plaintext vector backends (`to-vector-pgvector`/`cf-vectorize`/`qdrant`/…) | gated later | backend sees plaintext vectors → embedding-inversion → PII leak (blind-index twin); needs `acknowledgeVectorBackendRisk` |
+| HNSW / IVF / quantization | later | brute-force suffices at SME scale; HNSW adds a dep/complexity |
+| Sub-document chunking (multiple vectors per record) | later | v1 = one vector per record over the `source` fields |
+| Combined vector-blob persistence (avoid re-decrypt per session) | L2.x | v1 loads+caches per session like L1; an L1.5-style blob is an optimization |
+| `retrieve(mode:'hybrid')` + `fuseRetrieval` reducer | **L3** | lexical⊕semantic rank fusion (shared with klum federation) |
+| Cross-vault semantic search | **klum** | cosine federates cleanly (same model → comparable); fan-out is orchestration |
+| Multimodal (image/audio) | later | the `encode` hook is modality-agnostic; v1 text-only |
+
+## Architecture
+
+### Components (`src/embeddings/`, tree-shakeable)
+
+```
+src/embeddings/
+  strategy.ts      # EmbeddingStrategy iface + NO_EMBEDDINGS no-op + withEmbeddings()
+  encode.ts        # EmbeddingDescriptor { source, encode, dim, model } + validation
+  vector-set.ts    # VectorSet: in-memory id->{vec,model}; cosineTopK(q,k,minScore)
+  cosine.ts        # pure cosine(a,b): number (Float32Array)
+  index.ts         # barrel
+```
+
+`collection.ts` gains thin call-sites only: derive-on-`put` (encode → `_vec` sidecar), the `_vec` load/cache/dirty handle, the `retrieve(mode:'semantic')` branch, `similarTo()` on the query builder, and `forget()`/close wiring — mind the kernel ceiling (logic in `src/embeddings/`).
+
+### Write flow
+
+`put(id, record)` → if `embeddingFields` configured: `text = join(getAtPath(record, source))` → `vec = await encode(text)` → assert `vec.length === dim` → encrypt `{ vec:[...], model, dim }` under collection DEK → `adapter.put(vault, '_vec', id, env)` → mark the in-memory `VectorSet` dirty. Re-runs on every write of the record (source change → fresh vector). (Encode failure propagates; missing encoder → `EmbeddingEncoderNotConfiguredError`.)
+
+### Query flow
+
+`retrieve(q, { mode:'semantic', k })` → `qVec = await encode(q)` → `VectorSet.ensureLoaded()` (list+get+decrypt all `_vec`, cached; rebuilt when dirty) → guard: all loaded vectors' `model` === the collection's `model` (else `EmbeddingModelMismatchError`) → `cosineTopK(qVec, k, minScore)` → map to `RetrieveHit[]` with `rank` (1-based) + optional snippet (from the record's source field). `query().similarTo(vector, {k})` skips the `encode(q)` step (caller supplies the vector) and composes with `.where()` by intersecting the cosine top-k ids with the predicate result.
+
+### Privacy / leakage (the contract)
+
+Vectors are **encrypted at rest** (collection DEK) and decrypted only in the trusted
+tier for in-memory cosine. The store sees opaque ciphertext per `_vec/<id>` — never a
+plaintext vector, never the source text. This is the zero-knowledge equivalent of L1's
+client-side scan. The store learns the **count** of vectors (one `_vec` row per
+embedded record) and write timing — the same metadata any record already exposes; it
+learns nothing about vector *values* or proximity. The managed-backend path (which
+would expose plaintext vectors) is explicitly deferred and gated.
+
+### Erasure
+
+`forget(subject)` drops each affected record's `_vec/<id>` sidecar (resilient try/catch
++ residue in `ForgetResult`, mirroring L1.5's `_ftindex` + `_idx` teardown) and marks
+the `VectorSet` dirty — a forgotten subject's vector (from which text is invertible)
+must not survive crypto-shred.
+
+## Decisions (resolved)
+
+- **Encrypted-vectors + local cosine** is the default and only v1 storage model (zero-knowledge); managed backends deferred/gated.
+- **Per-record `_vec` sidecar** (not a combined blob, not an in-record field) — cleanest re-derive (write one vector per record change) + forget (drop one sidecar); brute-force loads all into a cached `VectorSet` anyway.
+- **`encode` configured on `withEmbeddings`** (per-collection) — different collections may use different models.
+- **Brute-force cosine** v1 (zero-dep); HNSW deferred.
+- **One vector per record** over the `source` fields; chunking deferred.
+- **Model-version is a hard guard** (refuse to query across mismatched `model`), not a silent best-effort.
+
+## Testing
+
+- `cosine.ts`: known-vector cosine values; orthogonal → 0, identical → 1.
+- `VectorSet`: load+decrypt round-trip; `cosineTopK` ordering + `k`/`minScore`; dirty-rebuild after write.
+- Write: `put` derives + encrypts a `_vec` sidecar; re-put with changed source re-derives; dim mismatch → `EmbeddingDimMismatchError`; missing encoder → `EmbeddingEncoderNotConfiguredError`.
+- Query: `retrieve(mode:'semantic')` returns nearest records ranked, with `rank` 1-based; `similarTo(vec)` raw path; `similarTo().where()` payload filtering; `minScore` cutoff.
+- Model guard: a vector tagged `model:'v1'` queried under a `model:'v2'` collection → `EmbeddingModelMismatchError`; `reindex()` re-derives and clears it.
+- Erasure: `forget()` removes `_vec/<id>` + residue on delete failure; subsequent semantic query excludes the forgotten record.
+- **Leakage:** wrap the store; assert `_vec` bodies are ciphertext (no plaintext vector numbers / source text); a non-embedding collection writes no `_vec`.
+- Tree-shaking: `NO_EMBEDDINGS` default bundle unchanged; all logic in `src/embeddings/`.
+
+## Non-code obligations
+
+- `features.yaml`: new `vector-search` feature (`status: preview`, `experimental: true`) leading with the encrypted-local model + the deferred/gated managed-backend note; spec ref.
+- `docs/subsystems/`: an embeddings/vector-search subsystem doc — the encode-hook contract, encrypted-local privacy model, model-versioning, `retrieve(mode:'semantic')`/`similarTo`, and the L2 line of the epic map.
+- Showcase: a semantic-retrieve walkthrough (a tiny deterministic stub `encode` so the showcase runs without a real model — e.g. a fixed hash-based pseudo-embedding) demonstrating nearest-neighbour retrieval + the model-mismatch guard.
+- Kernel ceiling: keep `collection.ts`/`vault.ts` under ceiling (logic in `src/embeddings/`); raise minimally if call-sites force it.

--- a/features.yaml
+++ b/features.yaml
@@ -288,6 +288,32 @@ features:
       - 'deleted / forgotten records never appear (eager cache eviction on delete / _writeTombstone)'
     related: [schema-and-refs, i18n]
 
+  - id: vector-search
+    name: Semantic / vector retrieval — encrypted-local L2 (collection.retrieve(mode:semantic) / collection.similarTo)
+    cluster: core
+    spec: docs/superpowers/specs/2026-06-22-ai-retrieval-l2-semantic-vector-design.md
+    subsystem_doc: docs/subsystems/embeddings.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    experimental: true
+    showcases:
+      - id: 124-semantic-retrieve
+        path: showcases/src/124-semantic-retrieve.showcase.test.ts
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'encrypted-local model: vectors encrypted at rest under the collection DEK (_vec sidecar); decrypted only in the trusted tier for in-memory cosine — zero store leakage of vector values or source text (managed/plaintext vector backends deferred/gated — the blind-index twin)'
+      - 'embeddings config on collection(): { source: string|string[], encode: (text) => Promise<Float32Array>, dim: number, model: string } — no bundled model; encode hook is host/remote (call any embedding API)'
+      - 'retrieve(q, { mode: "semantic", k?, minScore? }) encodes the query via the same encode hook, then brute-force cosines over the decrypted VectorSet; returns RetrieveHit[] with rank (1-based) + score'
+      - 'collection.similarTo(vector, { k?, minScore? }) accepts a raw Float32Array (caller embeds the query); composes with .where() by intersecting cosine top-k with the predicate set'
+      - 'model-version guard: each stored vector tagged with model; EmbeddingModelMismatchError when stored model != descriptor model — invalidation is hard (the embedding space changes); vault.embeddings.reindex() is DEFERRED (v1: re-put records to re-derive)'
+      - 'EmbeddingDimMismatchError on write when encode() returns a vector whose length != descriptor dim'
+      - 'forget() purges the _vec/<id> sidecar (resilient try/catch + ForgetResult residue, mirroring _ftindex); marks VectorSet dirty — forgotten vectors (source-invertible) must not survive crypto-shred'
+      - 'brute-force cosine, Float32Array, zero external dep — adequate at SME/pilot scale (~10k vectors); HNSW/IVF deferred'
+    related: [search-index]
+
   - id: persisted-json-schema
     name: Persisted JSON Schema (opt-in)
     cluster: core

--- a/features.yaml
+++ b/features.yaml
@@ -307,7 +307,7 @@ features:
       - 'encrypted-local model: vectors encrypted at rest under the collection DEK (_vec sidecar); decrypted only in the trusted tier for in-memory cosine — zero store leakage of vector values or source text (managed/plaintext vector backends deferred/gated — the blind-index twin)'
       - 'embeddings config on collection(): { source: string|string[], encode: (text) => Promise<Float32Array>, dim: number, model: string } — no bundled model; encode hook is host/remote (call any embedding API)'
       - 'retrieve(q, { mode: "semantic", k?, minScore? }) encodes the query via the same encode hook, then brute-force cosines over the decrypted VectorSet; returns RetrieveHit[] with rank (1-based) + score'
-      - 'collection.similarTo(vector, { k?, minScore? }) accepts a raw Float32Array (caller embeds the query); composes with .where() by intersecting cosine top-k with the predicate set'
+      - 'collection.similarTo(vector, { k?, minScore? }) accepts a raw Float32Array (caller embeds the query); hybrid filtering / query().similarTo().where() chaining is DEFERRED — consumers can intersect similarTo() ids with query().where() ids manually'
       - 'model-version guard: each stored vector tagged with model; EmbeddingModelMismatchError when stored model != descriptor model — invalidation is hard (the embedding space changes); vault.embeddings.reindex() is DEFERRED (v1: re-put records to re-derive)'
       - 'EmbeddingDimMismatchError on write when encode() returns a vector whose length != descriptor dim'
       - 'forget() purges the _vec/<id> sidecar (resilient try/catch + ForgetResult residue, mirroring _ftindex); marks VectorSet dirty — forgotten vectors (source-invertible) must not survive crypto-shred'

--- a/packages/hub/__tests__/embeddings-cosine.test.ts
+++ b/packages/hub/__tests__/embeddings-cosine.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { cosine } from '../src/embeddings/cosine.js'
+
+describe('cosine (#308 L2)', () => {
+  it('identical vectors → 1', () => { expect(cosine([1, 2, 3], [1, 2, 3])).toBeCloseTo(1, 6) })
+  it('orthogonal → 0', () => { expect(cosine([1, 0], [0, 1])).toBeCloseTo(0, 6) })
+  it('opposite → -1', () => { expect(cosine([1, 0], [-1, 0])).toBeCloseTo(-1, 6) })
+  it('zero-norm → 0 (no NaN)', () => { expect(cosine([0, 0], [1, 1])).toBe(0) })
+  it('length mismatch → 0', () => { expect(cosine([1, 2], [1, 2, 3])).toBe(0) })
+})

--- a/packages/hub/__tests__/embeddings-descriptor.test.ts
+++ b/packages/hub/__tests__/embeddings-descriptor.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { embeddingSourceText } from '../src/embeddings/descriptor.js'
+import { EmbeddingDimMismatchError, EmbeddingModelMismatchError } from '../src/errors.js'
+
+describe('embeddingSourceText (#308 L2)', () => {
+  it('joins multiple source fields, skipping empties', () => {
+    expect(embeddingSourceText({ a: 'overdue', b: '', c: 'invoice' }, ['a', 'b', 'c'])).toBe('overdue invoice')
+  })
+  it('single string source', () => {
+    expect(embeddingSourceText({ desc: 'TCM rent' }, 'desc')).toBe('TCM rent')
+  })
+  it('nested/wildcard path via getAtPath', () => {
+    expect(embeddingSourceText({ items: [{ d: 'a' }, { d: 'b' }] }, 'items[].d')).toBe('a b')
+  })
+})
+
+describe('embedding errors (#308 L2)', () => {
+  it('dim mismatch carries field/expected/actual', () => {
+    const e = new EmbeddingDimMismatchError('vec', 768, 384)
+    expect(e).toBeInstanceOf(Error); expect(e.message).toContain('768'); expect(e.message).toContain('384')
+  })
+  it('model mismatch carries the two models', () => {
+    const e = new EmbeddingModelMismatchError('minilm-v2', 'minilm-v1')
+    expect(e.message).toContain('minilm-v2'); expect(e.message).toContain('minilm-v1')
+  })
+})

--- a/packages/hub/__tests__/embeddings-forget.test.ts
+++ b/packages/hub/__tests__/embeddings-forget.test.ts
@@ -1,0 +1,187 @@
+/**
+ * forget() teardown of _vec sidecars — encrypted vector erasure (#308 L2).
+ *
+ * Harness: forget.test.ts (withForgetCascade/forgetStrategy wiring +
+ * memory store with raw-envelope inspection) + enc() stub from
+ * embeddings-write.test.ts.
+ *
+ * 3 cases:
+ *  1. After vault.forget(subject), adapter.get(vault,'_vec',recordId) === null
+ *     AND a subsequent retrieve(mode:'semantic') excludes the forgotten record.
+ *  2. Resilience: a store whose delete() throws for '_vec' cols →
+ *     forget resolves (no throw) + residue surfaced in ForgetResult.
+ *  3. Idempotent: second forget on same subject → 0 shredded, still no _vec.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+import { withHistory } from '../src/history/index.js'
+import { withForgetCascade } from '../src/forget/index.js'
+
+// ── in-memory store with raw-envelope inspection (from forget.test.ts) ──────
+
+function memory(): NoydbStore & {
+  raw(c: string, col: string, id: string): EncryptedEnvelope | undefined
+} {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    raw(c, col, id) { return store.get(c)?.get(col)?.get(id) },
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) for (const [name, coll] of existing) if (name.startsWith('_')) comp.set(name, coll)
+      store.set(c, comp)
+    },
+  }
+}
+
+// ── deterministic stub encoder (from embeddings-write.test.ts) ───────────────
+
+const enc = (dim: number, model = 'stub') => ({
+  dim, model, source: 'text' as const,
+  encode: async (t: string) => {
+    const v = new Float32Array(dim)
+    for (let i = 0; i < t.length; i++) v[t.charCodeAt(i) % dim] += 1
+    return v
+  },
+})
+
+interface Doc { id: string; text: string; ownerId: string }
+
+const SECRET = 'forget-vec-test-passphrase-5678'
+
+// ── Case 1: _vec sidecar deleted + excluded from semantic retrieve ────────────
+
+describe('embeddings forget — case 1: _vec purged + excluded from retrieve', () => {
+  it('forget deletes the _vec sidecar and excludes the forgotten record from semantic retrieve', async () => {
+    const store = memory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: SECRET,
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { docs: 'ownerId' } }),
+    })
+    const vault = await db.openVault('vec-v')
+    const encoder = enc(8)
+    const docs = vault.collection<Doc>('docs', { embeddings: encoder })
+
+    // Write two records belonging to different owners.
+    await docs.put('doc-a', { id: 'doc-a', text: 'overdue invoice payment', ownerId: 'alice' })
+    await docs.put('doc-b', { id: 'doc-b', text: 'client account setup', ownerId: 'bob' })
+
+    // Both _vec sidecars exist before forget.
+    expect(await store.get('vec-v', '_vec', 'doc-a')).not.toBeNull()
+    expect(await store.get('vec-v', '_vec', 'doc-b')).not.toBeNull()
+
+    // Forget alice's record.
+    const result = await vault.forget('alice')
+    expect(result.recordsShredded).toBe(1)
+
+    // doc-a's _vec sidecar must be gone.
+    expect(await store.get('vec-v', '_vec', 'doc-a')).toBeNull()
+
+    // doc-b's _vec sidecar must be intact.
+    expect(await store.get('vec-v', '_vec', 'doc-b')).not.toBeNull()
+
+    // Semantic retrieve must exclude the forgotten record.
+    // Open a fresh vault so the in-memory vectorSet is cold and rebuilt from store.
+    const db2 = await createNoydb({
+      store, user: 'alice', secret: SECRET,
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { docs: 'ownerId' } }),
+    })
+    const vault2 = await db2.openVault('vec-v')
+    const docs2 = vault2.collection<Doc>('docs', { embeddings: encoder })
+    const hits = await docs2.retrieve('overdue invoice payment', { mode: 'semantic' })
+    const ids = hits.map((h) => h.id)
+    expect(ids).not.toContain('doc-a')
+  })
+})
+
+// ── Case 2: resilience — delete throws for _vec → resolves + residue surfaced ─
+
+describe('embeddings forget — case 2: resilience (delete throws for _vec)', () => {
+  it('forget resolves when _vec delete throws, surfaces residue in ForgetResult', async () => {
+    const base = memory()
+    // Wrap the store so delete() throws for the _vec collection.
+    const faultyStore: NoydbStore = {
+      ...base,
+      async delete(c, col, id) {
+        if (col === '_vec') throw new Error('_vec store unavailable')
+        return base.delete(c, col, id)
+      },
+    }
+    const db = await createNoydb({
+      store: faultyStore, user: 'alice', secret: SECRET,
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { docs: 'ownerId' } }),
+    })
+    const vault = await db.openVault('vec-r')
+    const docs = vault.collection<Doc>('docs', { embeddings: enc(4) })
+    await docs.put('doc-x', { id: 'doc-x', text: 'test document', ownerId: 'carol' })
+
+    // forget must NOT throw even though _vec delete fails.
+    const result = await vault.forget('carol')
+
+    // The record was still tombstoned.
+    expect(result.recordsShredded).toBe(1)
+
+    // The _vec failure must appear in indexResidue.
+    expect(result.indexResidue).toContain('docs:doc-x:_vec')
+  })
+})
+
+// ── Case 3: idempotent second forget ─────────────────────────────────────────
+
+describe('embeddings forget — case 3: idempotent second forget', () => {
+  it('second forget on same subject shreds 0 records and leaves no _vec', async () => {
+    const store = memory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: SECRET,
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { docs: 'ownerId' } }),
+    })
+    const vault = await db.openVault('vec-i')
+    const docs = vault.collection<Doc>('docs', { embeddings: enc(8) })
+    await docs.put('doc-y', { id: 'doc-y', text: 'some text', ownerId: 'dave' })
+
+    // First forget.
+    await vault.forget('dave')
+    expect(await store.get('vec-i', '_vec', 'doc-y')).toBeNull()
+
+    // Second forget — idempotent, no throw.
+    const result2 = await vault.forget('dave')
+    expect(result2.recordsShredded).toBe(0)
+    expect(await store.get('vec-i', '_vec', 'doc-y')).toBeNull()
+  })
+})

--- a/packages/hub/__tests__/embeddings-retrieve.test.ts
+++ b/packages/hub/__tests__/embeddings-retrieve.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Semantic retrieval — retrieve(mode:'semantic') + collection.similarTo() (#308 L2).
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError, EmbeddingModelMismatchError } from '../src/errors.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) if (!n.startsWith('_')) {
+        const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) for (const [name, coll] of existing) if (name.startsWith('_')) comp.set(name, coll)
+      store.set(c, comp)
+    },
+  }
+}
+
+interface Doc { id: string; text: string }
+
+// Deterministic stub encoder: bag-of-chars hash → Float32Array of given dim.
+// Each character increments the bucket at (charCode % dim). Different strings
+// produce meaningfully different vectors, making similarity reproducible.
+const enc = (dim: number, model = 'stub') => ({
+  dim, model, source: 'text' as const,
+  encode: async (t: string) => { const v = new Float32Array(dim); for (let i = 0; i < t.length; i++) v[t.charCodeAt(i) % dim] += 1; return v },
+})
+
+describe('semantic retrieval (#308 L2)', () => {
+
+  // Test A: retrieve(mode:'semantic') returns the matching doc as rank-1 with rank+score
+  it('A: retrieve(mode:semantic) returns nearest doc as rank-1, hits carry rank and score', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'pw-sem-a' })
+    const v = await db.openVault('v')
+    const encoder = enc(8)
+    const c = v.collection<Doc>('docs', { embeddings: encoder })
+    await c.put('invoice', { id: 'invoice', text: 'overdue invoice payment' })
+    await c.put('client', { id: 'client', text: 'client account setup' })
+    await c.put('report', { id: 'report', text: 'quarterly financial report' })
+
+    const hits = await c.retrieve('overdue invoice payment', { mode: 'semantic' })
+    expect(hits.length).toBeGreaterThan(0)
+    expect(hits[0]!.id).toBe('invoice')
+    expect(hits[0]!.rank).toBe(1)
+    expect(typeof hits[0]!.score).toBe('number')
+    expect(hits[0]!.score).toBeGreaterThan(0)
+    // score should decrease (or stay equal) as rank increases
+    for (let i = 1; i < hits.length; i++) {
+      expect(hits[i]!.score).toBeLessThanOrEqual(hits[i - 1]!.score)
+      expect(hits[i]!.rank).toBe(i + 1)
+    }
+  })
+
+  // Test B: collection.similarTo() with raw vector returns matching doc
+  it('B: similarTo(vector, { k:1 }) returns the doc whose encoding is closest', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'pw-sem-b' })
+    const v = await db.openVault('v')
+    const encoder = enc(8)
+    const c = v.collection<Doc>('docs', { embeddings: encoder })
+    await c.put('alpha', { id: 'alpha', text: 'alpha text example' })
+    await c.put('beta', { id: 'beta', text: 'beta completely different zzzzzz' })
+
+    const queryVec = await encoder.encode('alpha text example')
+    const hits = await c.similarTo(queryVec, { k: 1 })
+    expect(hits.length).toBe(1)
+    expect(hits[0]!.id).toBe('alpha')
+  })
+
+  // Test C: minScore filters out far docs
+  it('C: minScore filters out docs below the threshold', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'pw-sem-c' })
+    const v = await db.openVault('v')
+    const encoder = enc(8)
+    const c = v.collection<Doc>('docs', { embeddings: encoder })
+    await c.put('near', { id: 'near', text: 'near match text query' })
+    await c.put('far', { id: 'far', text: 'zzzzzzzzzzzzzzzzzzzzz' })
+
+    // Very high minScore — only exact matches pass
+    const hitsHigh = await c.retrieve('near match text query', { mode: 'semantic', minScore: 0.999 })
+    // near should match itself exactly; far should be filtered
+    const ids = hitsHigh.map((h) => h.id)
+    expect(ids).not.toContain('far')
+
+    // minScore of 0 keeps everything
+    const hitsAll = await c.retrieve('near match text query', { mode: 'semantic', minScore: 0 })
+    expect(hitsAll.length).toBe(2)
+  })
+
+  // Test D: model guard — open with different model → throws EmbeddingModelMismatchError
+  it('D: model guard — stored vec under model "stub" + descriptor model "stub2" → EmbeddingModelMismatchError', async () => {
+    const store = memory()
+    // Write with model 'stub'
+    const db1 = await createNoydb({ store, user: 'a', secret: 'pw-sem-d' })
+    const v1 = await db1.openVault('v')
+    const c1 = v1.collection<Doc>('docs', { embeddings: enc(8, 'stub') })
+    await c1.put('x', { id: 'x', text: 'some text here' })
+
+    // Re-open with model 'stub2' — should throw on semantic retrieve
+    const db2 = await createNoydb({ store, user: 'a', secret: 'pw-sem-d' })
+    const v2 = await db2.openVault('v')
+    const c2 = v2.collection<Doc>('docs', { embeddings: enc(8, 'stub2') })
+    await expect(c2.retrieve('some text here', { mode: 'semantic' })).rejects.toThrow(EmbeddingModelMismatchError)
+  })
+
+  // Test E: leakage — retrieve(mode:'semantic') only reads _vec (get), never writes; _vec env body has no plaintext source term
+  it('E: leakage — semantic retrieve reads _vec but writes nothing new; _vec env body has no plaintext source text', async () => {
+    const store = memory()
+    const gets: string[] = []
+    const puts: string[] = []
+    const wrapped: NoydbStore = {
+      ...store,
+      async get(c, col, id) { gets.push(`${col}/${id}`); return store.get(c, col, id) },
+      async put(c, col, id, env, ev) { puts.push(`${col}/${id}`); return store.put(c, col, id, env, ev) },
+    }
+
+    const db = await createNoydb({ store: wrapped, user: 'a', secret: 'pw-sem-e' })
+    const v = await db.openVault('v')
+    const encoder = enc(8)
+    const c = v.collection<Doc>('docs', { embeddings: encoder })
+    await c.put('doc1', { id: 'doc1', text: 'overdue invoice' })
+
+    // Reset tracking after the put phase
+    gets.length = 0
+    puts.length = 0
+
+    await c.retrieve('overdue invoice', { mode: 'semantic' })
+
+    // Should have read _vec entries (get)
+    expect(gets.some((g) => g.startsWith('_vec/'))).toBe(true)
+    // Should NOT have written anything new during retrieve
+    expect(puts.filter((p) => p.startsWith('_vec/'))).toHaveLength(0)
+
+    // The raw envelope body stored in _vec should not contain the plaintext source text
+    const env = await store.get('v', '_vec', 'doc1')
+    expect(JSON.stringify(env)).not.toContain('overdue')
+    expect(JSON.stringify(env)).not.toContain('invoice')
+  })
+})

--- a/packages/hub/__tests__/embeddings-vector-set.test.ts
+++ b/packages/hub/__tests__/embeddings-vector-set.test.ts
@@ -1,0 +1,38 @@
+// packages/hub/__tests__/embeddings-vector-set.test.ts
+import { describe, it, expect } from 'vitest'
+import { VectorSet, type StoredVector } from '../src/embeddings/vector-set.js'
+import { EmbeddingModelMismatchError } from '../src/errors.js'
+
+const vecs: StoredVector[] = [
+  { id: 'a', vec: new Float32Array([1, 0, 0]), model: 'm1' },
+  { id: 'b', vec: new Float32Array([0.9, 0.1, 0]), model: 'm1' },
+  { id: 'c', vec: new Float32Array([0, 1, 0]), model: 'm1' },
+]
+
+describe('VectorSet (#308 L2)', () => {
+  it('loads once (load fn not called twice) and ranks by cosine', async () => {
+    const vs = new VectorSet()
+    let calls = 0
+    const load = async () => { calls++; return vecs }
+    await vs.ensureLoaded(load); await vs.ensureLoaded(load)
+    expect(calls).toBe(1); expect(vs.loaded).toBe(true)
+    const hits = vs.cosineTopK(new Float32Array([1, 0, 0]), 2)
+    expect(hits.map((h) => h.id)).toEqual(['a', 'b']) // a=1.0, b≈0.994
+    expect(hits[0]!.score).toBeCloseTo(1, 5)
+  })
+  it('k limits, minScore filters', async () => {
+    const vs = new VectorSet(); await vs.ensureLoaded(async () => vecs)
+    expect(vs.cosineTopK(new Float32Array([1, 0, 0]), 1).length).toBe(1)
+    expect(vs.cosineTopK(new Float32Array([1, 0, 0]), 5, { minScore: 0.99 }).map((h) => h.id)).toEqual(['a', 'b'])
+  })
+  it('markDirty forces reload', async () => {
+    const vs = new VectorSet(); let calls = 0
+    const load = async () => { calls++; return vecs }
+    await vs.ensureLoaded(load); vs.markDirty(); expect(vs.loaded).toBe(false)
+    await vs.ensureLoaded(load); expect(calls).toBe(2)
+  })
+  it('model guard throws on mismatch', async () => {
+    const vs = new VectorSet(); await vs.ensureLoaded(async () => vecs)
+    expect(() => vs.cosineTopK(new Float32Array([1, 0, 0]), 2, { expectModel: 'm2' })).toThrow(EmbeddingModelMismatchError)
+  })
+})

--- a/packages/hub/__tests__/embeddings-write.test.ts
+++ b/packages/hub/__tests__/embeddings-write.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Write-time embedding derivation — encrypted _vec sidecar (#308 L2).
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import type { Noydb } from '../src/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError, EmbeddingDimMismatchError } from '../src/errors.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) if (!n.startsWith('_')) {
+        const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) for (const [name, coll] of existing) if (name.startsWith('_')) comp.set(name, coll)
+      store.set(c, comp)
+    },
+  }
+}
+
+interface Doc { id: string; text: string }
+// deterministic stub encoder: 3-dim bag-of-chars hash → unit-ish vector
+const enc = (dim: number, model = 'stub') => ({
+  dim, model, source: 'text' as const,
+  encode: async (t: string) => { const v = new Float32Array(dim); for (let i = 0; i < t.length; i++) v[t.charCodeAt(i) % dim] += 1; return v },
+})
+
+describe('embeddings write derivation (#308 L2)', () => {
+  it('put derives an ENCRYPTED _vec sidecar (no plaintext vector), not hydrated as a record', async () => {
+    const store = memory()
+    const puts: string[] = []
+    const wrapped: NoydbStore = { ...store, async put(c, col, id, e, ev) { puts.push(`${col}/${id}`); return store.put(c, col, id, e, ev) } }
+    const db = await createNoydb({ store: wrapped, user: 'a', secret: 'pw-emb' })
+    const v = await db.openVault('v')
+    const c = v.collection<Doc>('d', { embeddings: enc(8) })
+    await c.put('x', { id: 'x', text: 'overdue invoice' })
+    expect(puts.some((p) => p.startsWith('_vec/x'))).toBe(true)
+    const env = await wrapped.get('v', '_vec', 'x')
+    expect(JSON.stringify(env)).not.toContain('overdue')          // source text not leaked
+    expect((await c.list()).map((r) => r.id)).toEqual(['x'])   // _vec not a phantom record
+  })
+
+  it('dim mismatch → EmbeddingDimMismatchError', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'pw' })
+    const v = await db.openVault('v')
+    const c = v.collection<Doc>('d', { embeddings: { ...enc(8), encode: async () => new Float32Array(4) } })
+    await expect(c.put('x', { id: 'x', text: 'hi' })).rejects.toThrow(EmbeddingDimMismatchError)
+  })
+})

--- a/packages/hub/__tests__/embeddings-write.test.ts
+++ b/packages/hub/__tests__/embeddings-write.test.ts
@@ -73,4 +73,12 @@ describe('embeddings write derivation (#308 L2)', () => {
     const c = v.collection<Doc>('d', { embeddings: { ...enc(8), encode: async () => new Float32Array(4) } })
     await expect(c.put('x', { id: 'x', text: 'hi' })).rejects.toThrow(EmbeddingDimMismatchError)
   })
+
+  it('CRDT + embeddings → throws at construction (guard)', async () => {
+    const db = await createNoydb({ store: memory(), user: 'a', secret: 'pw' })
+    const v = await db.openVault('v')
+    expect(() =>
+      v.collection<Doc>('d', { embeddings: enc(8), crdt: 'lww-map' }),
+    ).toThrow(/embeddings are not supported on CRDT collections/)
+  })
 })

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -958,6 +958,13 @@ export class Collection<T> {
     this.i18nDensifyFields =
       Object.keys(densifyFields).length > 0 ? densifyFields : undefined
     // #308 L2 — wire embedding descriptor + vector set (undefined for non-embedding collections).
+    // Guard: CRDT collections cannot use embeddings (the embedding-derive block is unreachable
+    // after the CRDT early-return in putInternal; full CRDT-derivation is out of L2 scope).
+    if (opts.embeddings && opts.crdt) {
+      throw new Error(
+        `Collection "${opts.name}": embeddings are not supported on CRDT collections (L2). Use a non-CRDT collection for semantic search.`,
+      )
+    }
     this.embeddings = opts.embeddings
     this.vectorSet = opts.embeddings ? new VectorSet() : undefined
     this.dictKeyFields = opts.dictKeyFields
@@ -4408,7 +4415,8 @@ export class Collection<T> {
     return { purged, residue }
   }
 
-  /** #308 L2 — drop a record's encrypted _vec sidecar on erasure (a vector is text-invertible). */
+  /** #308 L2 — drop a record's encrypted _vec sidecar on erasure (a vector is text-invertible).
+   *  Called by vault.ts forget() inside a resilient try/catch; residue is reported in ForgetResult. */
   async _purgeVector(id: string): Promise<void> {
     await this.adapter.delete(this.vault, '_vec', id)
     this.vectorSet?.markDirty()

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -53,7 +53,8 @@ import { extractSnippet } from './search/snippet.js'
 import { buildStringFieldEntries, buildI18nFieldEntries, buildDictKeyFieldEntries, buildBlobFieldEntries } from './search/build-docs.js'
 import type { IndexDoc, IndexHit } from './search/inverted-index.js'
 import type { RetrieveOptions, RetrieveHit } from './search/retrieve-types.js'
-import { IndexWriteFailureError, DerivationCapExceededError, DebugReservedFieldError } from './errors.js'
+import { IndexWriteFailureError, DerivationCapExceededError, DebugReservedFieldError, EmbeddingDimMismatchError } from './errors.js'
+import { embeddingSourceText, VectorSet, type EmbeddingDescriptor, type StoredVector } from './embeddings/index.js'
 import { buildUniqueConstraintSet, type UniqueConstraintSet } from './indexing/unique-constraints.js'
 import type { RefDescriptor } from './refs.js'
 import { Lru, parseBytes, estimateRecordBytes, type LruStats } from './cache/index.js'
@@ -337,6 +338,19 @@ export class Collection<T> {
    * in, so the write path skips all densify work for ordinary collections.
    */
   private readonly i18nDensifyFields: Record<string, I18nTextDescriptor> | undefined
+
+  /**
+   * #308 L2 — embedding config for write-time vector derivation. `undefined`
+   * for ordinary collections (zero cost). When set, `put()` encodes the
+   * source field(s) and stores an encrypted `_vec` sidecar.
+   */
+  private readonly embeddings: EmbeddingDescriptor | undefined
+
+  /**
+   * #308 L2 — in-memory vector set, populated lazily from `_vec` sidecars.
+   * `undefined` when no embedding config is declared.
+   */
+  private vectorSet: VectorSet | undefined
 
   /**
    * Map of field name → `DictKeyDescriptor` for fields declared with
@@ -704,6 +718,8 @@ export class Collection<T> {
       | undefined
     /** — i18nText field descriptors for locale-aware reads. */
     i18nFields?: Record<string, I18nTextDescriptor> | undefined
+    /** — #308 L2: embedding config for write-time vector derivation + semantic retrieval. */
+    embeddings?: EmbeddingDescriptor | undefined
     /** — #308 L1: string fields exposed to client-side `retrieve()`. */
     textIndexes?: readonly string[] | undefined
     /** — #308 L1: pre-build the lexical index on open (eager-only). */
@@ -941,6 +957,9 @@ export class Collection<T> {
       : {}
     this.i18nDensifyFields =
       Object.keys(densifyFields).length > 0 ? densifyFields : undefined
+    // #308 L2 — wire embedding descriptor + vector set (undefined for non-embedding collections).
+    this.embeddings = opts.embeddings
+    this.vectorSet = opts.embeddings ? new VectorSet() : undefined
     this.dictKeyFields = opts.dictKeyFields
     if (opts.moneyFields) validateMoneyFieldPaths(opts.moneyFields)
     this.moneyFields = opts.moneyFields
@@ -1777,6 +1796,19 @@ export class Collection<T> {
 
     const envelope = await this.encryptRecord(record, version, cek, options?.source, options?.sourceTs)
     await this.adapter.put(this.vault, this.name, id, envelope)
+
+    // #308 L2 — derive the embedding vector at write (encode → encrypted _vec sidecar).
+    // Placed AFTER the main adapter.put so `version` (computed above) is in scope and
+    // the record write is committed first. The _vec envelope _v is not OCC-checked.
+    if (this.embeddings) {
+      const text = embeddingSourceText(record as Record<string, unknown>, this.embeddings.source)
+      const vec = await this.embeddings.encode(text)
+      if (vec.length !== this.embeddings.dim) throw new EmbeddingDimMismatchError('embeddings', this.embeddings.dim, vec.length)
+      const body = JSON.stringify({ vec: Array.from(vec), model: this.embeddings.model, dim: this.embeddings.dim })
+      const vecEnv = await this.encryptJsonString(body, version)
+      await this.adapter.put(this.vault, '_vec', id, vecEnv)
+      this.vectorSet?.markDirty()
+    }
 
     // Ledger append — AFTER the adapter write succeeds so a failed
     // write never produces an orphan ledger entry. Computing the
@@ -2850,6 +2882,23 @@ export class Collection<T> {
     const blobFilenames = await this.resolveBlobFilenames()
     await this.searchIndexStore.ensureBuilt(() => this.buildRetrievalDocs(labelMaps, blobFilenames))
     await this.searchIndexStore.flush?.()
+  }
+
+  /** #308 L2 — load + decrypt all _vec sidecars into StoredVector[] for the VectorSet. */
+  private buildVectorLoad(): () => Promise<StoredVector[]> {
+    return async () => {
+      const ids = await this.adapter.list(this.vault, '_vec')
+      const out: StoredVector[] = []
+      for (const id of ids) {
+        const env = await this.adapter.get(this.vault, '_vec', id)
+        if (!env) continue
+        const body = await this.decryptJsonString(env)
+        if (body === null) continue
+        const parsed = JSON.parse(body) as { vec: number[]; model: string }
+        out.push({ id, vec: new Float32Array(parsed.vec), model: parsed.model })
+      }
+      return out
+    }
   }
 
   /**

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -4408,6 +4408,12 @@ export class Collection<T> {
     return { purged, residue }
   }
 
+  /** #308 L2 — drop a record's encrypted _vec sidecar on erasure (a vector is text-invertible). */
+  async _purgeVector(id: string): Promise<void> {
+    await this.adapter.delete(this.vault, '_vec', id)
+    this.vectorSet?.markDirty()
+  }
+
   /** #308 L1.5 — drop the persisted lexical-index blob (forget/erasure): an opaque
    *  all-records index must not survive crypto-shred. Idempotent; no-op without persist. */
   async _purgeSearchIndex(): Promise<void> {

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -2960,6 +2960,7 @@ export class Collection<T> {
 
   /** #308 L1 — client-side lexical retrieval; ranked { id, score, field, snippet, locale? }. */
   async retrieve(query: string, opts: RetrieveOptions = {}): Promise<RetrieveHit<T>[]> {
+    if (opts.mode === 'semantic') return this.retrieveSemantic(query, opts)
     if (!this.searchIndexStore) {
       throw new Error(`Collection "${this.name}": retrieve() requires a textIndexes config.`)
     }
@@ -2995,6 +2996,36 @@ export class Collection<T> {
             })()
           : {}),
       }
+      return base
+    })
+  }
+
+  /** #308 L2 — semantic branch of retrieve(): encode query → similarTo(). */
+  private async retrieveSemantic(query: string, opts: RetrieveOptions): Promise<RetrieveHit<T>[]> {
+    if (!this.embeddings) throw new Error(`Collection "${this.name}": retrieve({mode:'semantic'}) requires an embeddings config.`)
+    if (this.lazy) throw new Error(`Collection "${this.name}": retrieve() requires eager mode (prefetch: true).`)
+    const qVec = await this.embeddings.encode(query)
+    return this.similarTo(qVec, {
+      ...(opts.limit !== undefined ? { k: opts.limit } : {}),
+      ...(opts.minScore !== undefined ? { minScore: opts.minScore } : {}),
+      ...(opts.includeRecord ? { includeRecord: true } : {}),
+    })
+  }
+
+  /** #308 L2 — raw-vector kNN over the encrypted vector set (decrypted in the trusted tier).
+   *  Snippet is '' for vector hits in v1 (semantic match isn't span-located). */
+  async similarTo(vector: Float32Array, opts: { k?: number; minScore?: number; includeRecord?: boolean } = {}): Promise<RetrieveHit<T>[]> {
+    if (!this.embeddings || !this.vectorSet) throw new Error(`Collection "${this.name}": similarTo() requires an embeddings config.`)
+    if (this.lazy) throw new Error(`Collection "${this.name}": similarTo() requires eager mode (prefetch: true).`)
+    await this.ensureHydrated()
+    await this.vectorSet.ensureLoaded(this.buildVectorLoad())
+    const hits = this.vectorSet.cosineTopK(vector, opts.k ?? 10, {
+      ...(opts.minScore !== undefined ? { minScore: opts.minScore } : {}),
+      expectModel: this.embeddings.model,
+    })
+    return hits.map((h, i) => {
+      const base: RetrieveHit<T> = { id: h.id, score: h.score, rank: i + 1, field: '(vector)', snippet: '' }
+      if (opts.includeRecord) { const e = this.cache.get(h.id); if (e) (base as { record?: T }).record = stripI18nFilled(e.record as Record<string, unknown>) as T }
       return base
     })
   }

--- a/packages/hub/src/embeddings/cosine.ts
+++ b/packages/hub/src/embeddings/cosine.ts
@@ -1,0 +1,11 @@
+/** Cosine similarity in [-1,1]; 0 on zero-norm or length mismatch (no NaN). (#308 L2) */
+export function cosine(a: Float32Array | number[], b: Float32Array | number[]): number {
+  if (a.length !== b.length) return 0
+  let dot = 0, na = 0, nb = 0
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i]!, y = b[i]!
+    dot += x * y; na += x * x; nb += y * y
+  }
+  if (na === 0 || nb === 0) return 0
+  return dot / (Math.sqrt(na) * Math.sqrt(nb))
+}

--- a/packages/hub/src/embeddings/descriptor.ts
+++ b/packages/hub/src/embeddings/descriptor.ts
@@ -1,0 +1,21 @@
+/** Per-collection embedding config (#308 L2). The encode hook is host/remote — no bundled model. */
+import { getAtPath } from '../i18n/core.js'
+
+export interface EmbeddingDescriptor {
+  readonly source: string | readonly string[]
+  readonly encode: (text: string) => Promise<Float32Array>
+  readonly dim: number
+  readonly model: string
+}
+
+/** Concatenate the record's source-field text (skips empties; supports nested/[]-wildcard paths). */
+export function embeddingSourceText(record: Record<string, unknown>, source: string | readonly string[]): string {
+  const fields = typeof source === 'string' ? [source] : source
+  const parts: string[] = []
+  for (const f of fields) {
+    for (const leaf of getAtPath(record, f)) {
+      if (typeof leaf === 'string' && leaf !== '') parts.push(leaf)
+    }
+  }
+  return parts.join(' ')
+}

--- a/packages/hub/src/embeddings/index.ts
+++ b/packages/hub/src/embeddings/index.ts
@@ -1,0 +1,3 @@
+export { cosine } from './cosine.js'
+export { embeddingSourceText, type EmbeddingDescriptor } from './descriptor.js'
+export { VectorSet, type StoredVector, type VectorHit } from './vector-set.js'

--- a/packages/hub/src/embeddings/vector-set.ts
+++ b/packages/hub/src/embeddings/vector-set.ts
@@ -1,0 +1,33 @@
+/** In-memory vector set for L2 semantic retrieval (#308). Loaded once per session from
+ *  decrypted _vec sidecars (injected loader), brute-force cosine kNN, model-guarded. */
+import { cosine } from './cosine.js'
+import { EmbeddingModelMismatchError } from '../errors.js'
+
+export interface StoredVector { readonly id: string; readonly vec: Float32Array; readonly model: string }
+export interface VectorHit { readonly id: string; readonly score: number }
+
+export class VectorSet {
+  private vectors: StoredVector[] | undefined
+  get loaded(): boolean { return this.vectors !== undefined }
+
+  async ensureLoaded(load: () => Promise<StoredVector[]>): Promise<void> {
+    if (this.vectors === undefined) this.vectors = await load()
+  }
+
+  markDirty(): void { this.vectors = undefined }
+
+  cosineTopK(query: Float32Array, k: number, opts: { minScore?: number; expectModel?: string } = {}): VectorHit[] {
+    const all = this.vectors ?? []
+    const minScore = opts.minScore ?? -Infinity
+    const hits: VectorHit[] = []
+    for (const v of all) {
+      if (opts.expectModel !== undefined && v.model !== opts.expectModel) {
+        throw new EmbeddingModelMismatchError(opts.expectModel, v.model)
+      }
+      const score = cosine(query, v.vec)
+      if (score >= minScore) hits.push({ id: v.id, score })
+    }
+    hits.sort((a, b) => b.score - a.score)
+    return hits.slice(0, k)
+  }
+}

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -65,7 +65,6 @@
  *       │    ├─ SealedRecordMismatchError — CEK sealed for record A used on record B
  *       │    └─ RecordCekNotFoundError    — record missing or no per-record `_cek`
  *       └─ Embedding errors (#308 L2)
- *            ├─ EmbeddingEncoderNotConfiguredError — collection declares embeddings but no encode() hook
  *            ├─ EmbeddingDimMismatchError           — stored vector dim ≠ descriptor dim
  *            └─ EmbeddingModelMismatchError         — stored vector model tag ≠ descriptor model
  * ```
@@ -2373,21 +2372,6 @@ export class RecordCekNotFoundError extends NoydbError {
 }
 
 // ─── Embedding Errors (#308 L2) ─────────────────────────────────────────────
-
-/**
- * Thrown when a collection declares `embeddings` but no `encode()` hook was
- * provided via the collection options. The collection name is surfaced so the
- * developer can locate the mis-configured registration quickly.
- */
-export class EmbeddingEncoderNotConfiguredError extends NoydbError {
-  constructor(collection: string) {
-    super(
-      'EMBEDDING_ENCODER_NOT_CONFIGURED',
-      `Collection "${collection}" declares embeddings but no encode() hook was configured.`,
-    )
-    this.name = 'EmbeddingEncoderNotConfiguredError'
-  }
-}
 
 /**
  * Thrown when a stored vector's dimension does not match the dimension declared

--- a/packages/hub/src/errors.ts
+++ b/packages/hub/src/errors.ts
@@ -64,6 +64,10 @@
  *       │    ├─ SealedRecordExpiredError  — sealed CEK binding past expiresAt
  *       │    ├─ SealedRecordMismatchError — CEK sealed for record A used on record B
  *       │    └─ RecordCekNotFoundError    — record missing or no per-record `_cek`
+ *       └─ Embedding errors (#308 L2)
+ *            ├─ EmbeddingEncoderNotConfiguredError — collection declares embeddings but no encode() hook
+ *            ├─ EmbeddingDimMismatchError           — stored vector dim ≠ descriptor dim
+ *            └─ EmbeddingModelMismatchError         — stored vector model tag ≠ descriptor model
  * ```
  *
  * ## Catching all NOYDB errors
@@ -2365,5 +2369,65 @@ export class RecordCekNotFoundError extends NoydbError {
     this.name = 'RecordCekNotFoundError'
     this.collection = collection
     this.id = id
+  }
+}
+
+// ─── Embedding Errors (#308 L2) ─────────────────────────────────────────────
+
+/**
+ * Thrown when a collection declares `embeddings` but no `encode()` hook was
+ * provided via the collection options. The collection name is surfaced so the
+ * developer can locate the mis-configured registration quickly.
+ */
+export class EmbeddingEncoderNotConfiguredError extends NoydbError {
+  constructor(collection: string) {
+    super(
+      'EMBEDDING_ENCODER_NOT_CONFIGURED',
+      `Collection "${collection}" declares embeddings but no encode() hook was configured.`,
+    )
+    this.name = 'EmbeddingEncoderNotConfiguredError'
+  }
+}
+
+/**
+ * Thrown when a stored vector's dimension does not match the dimension declared
+ * by the active `EmbeddingDescriptor`. The `field`, `expected`, and `actual`
+ * properties are machine-readable for switch blocks and logging.
+ */
+export class EmbeddingDimMismatchError extends NoydbError {
+  readonly field: string
+  readonly expected: number
+  readonly actual: number
+
+  constructor(field: string, expected: number, actual: number) {
+    super(
+      'EMBEDDING_DIM_MISMATCH',
+      `Embedding for "${field}" has dim ${actual}, expected ${expected}.`,
+    )
+    this.name = 'EmbeddingDimMismatchError'
+    this.field = field
+    this.expected = expected
+    this.actual = actual
+  }
+}
+
+/**
+ * Thrown when the model tag on a stored vector does not match the `model`
+ * declared by the active `EmbeddingDescriptor`. Signals that the encoder was
+ * swapped without re-indexing; call `vault.embeddings.reindex()` to rebuild.
+ */
+export class EmbeddingModelMismatchError extends NoydbError {
+  readonly expected: string
+  readonly found: string
+
+  constructor(expected: string, found: string) {
+    super(
+      'EMBEDDING_MODEL_MISMATCH',
+      `Embedding model mismatch: collection uses "${expected}" but a stored vector is "${found}". ` +
+        `Run vault.embeddings.reindex() after changing the encoder.`,
+    )
+    this.name = 'EmbeddingModelMismatchError'
+    this.expected = expected
+    this.found = found
   }
 }

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -906,6 +906,9 @@ export { TierNotGrantedError, TierDemoteDeniedError, DelegationTargetMissingErro
 export { IndexRequiredError, IndexWriteFailureError } from './errors.js'
 // unique-index enforcement error
 export { UniqueConstraintError, UnsupportedIndexOptionError } from './errors.js'
+// embeddings / semantic-retrieval (L2)
+export { EmbeddingDimMismatchError, EmbeddingModelMismatchError } from './errors.js'
+export type { EmbeddingDescriptor } from './embeddings/index.js'
 export { dekKey, effectiveClearance, assertTierAccess } from './team/tiers.js'
 export type { DelegationToken, IssueDelegationOptions } from './team/delegation.js'
 export { DELEGATIONS_COLLECTION, issueDelegation, loadActiveDelegations, revokeDelegation } from './team/delegation.js'

--- a/packages/hub/src/search/retrieve-types.ts
+++ b/packages/hub/src/search/retrieve-types.ts
@@ -10,6 +10,10 @@ export interface RetrieveOptions {
   readonly snippetWindow?: number
   readonly fields?: readonly string[]
   readonly includeRecord?: boolean
+  /** #308 L2 — retrieval strategy; defaults to 'lexical'. */
+  readonly mode?: 'lexical' | 'semantic'
+  /** #308 L2 — minimum cosine score for semantic hits (semantic mode only). */
+  readonly minScore?: number
 }
 
 export interface RetrieveHit<T> {

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -88,6 +88,7 @@ import {
 import type { DictionaryHandle, DictionaryOptions, DictKeyDescriptor, StaticDictDescriptor } from './i18n/dictionary.js'
 import { isDictCollectionName, isStaticDictDescriptor } from './i18n/dictionary.js'
 import { LinkSet, isLinkCollectionName, linkCollectionName, linkRowKey, LinkIntegrityError, type LinkSpec, type LinkSetHandle } from './links/link-set.js'
+import type { EmbeddingDescriptor } from './embeddings/index.js'
 import type { I18nTextDescriptor } from './i18n/core.js'
 import { getAtPath } from './i18n/core.js'
 import type { MoneyDescriptor } from './money/descriptor.js'
@@ -678,6 +679,8 @@ export class Vault {
     refs?: Record<string, RefDescriptor>
     /** — declare i18nText fields for locale-aware reads. */
     i18nFields?: Record<string, I18nTextDescriptor>
+    /** — #308 L2: embedding config for write-time vector derivation + semantic retrieval. */
+    embeddings?: EmbeddingDescriptor
     /** — #308 L1: string fields exposed to client-side `retrieve()`. */
     textIndexes?: readonly string[]
     /** — #308 L1: pre-build the lexical index on open (eager-only). */
@@ -1006,6 +1009,7 @@ export class Vault {
       collOpts.onCrossTierAccess = (event) => this.emitCrossTier(event)
       if (this.syncAdapter !== undefined) collOpts.syncAdapter = this.syncAdapter
       if (options?.i18nFields !== undefined) collOpts.i18nFields = options.i18nFields
+      if (options?.embeddings !== undefined) collOpts.embeddings = options.embeddings
       if (options?.textIndexes !== undefined) collOpts.textIndexes = options.textIndexes
       if (options?.warmIndexOnOpen !== undefined) collOpts.warmIndexOnOpen = options.warmIndexOnOpen
       if (options?.textIndexPersist !== undefined) collOpts.textIndexPersist = options.textIndexPersist

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -2590,6 +2590,15 @@ export class Vault {
       indexPostingsPurged += idxPurge.purged
       for (const field of idxPurge.residue) indexResidue.push(`${ref.collection}:${ref.id}:${field}`)
 
+      // Purge the record's encrypted _vec sidecar (#308 L2): a vector embedding
+      // is text-invertible, so it must not survive crypto-shred of the source record.
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (coll as any)._purgeVector(ref.id)
+      } catch {
+        indexResidue.push(`${ref.collection}:${ref.id}:_vec`)
+      }
+
       // Blob attachments (#365): crypto-shred the record's erasable blobs.
       // An erasable blob's chunks are under a per-blob content CEK whose only
       // copy is the BlobObject's wrapped `_cek`; deleting it at refCount 0

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -492,7 +492,8 @@ const KERNEL_SURFACE_BUDGET = {
   // locale-less read returns (get/list early-return, search, static-display final).
   // Bumped 4922→5100 (#308 L1): retrieve()/warmIndex call-sites + dict/blob label resolvers (engine in src/search/)
   // Bumped 5100→5168 (#308 L1.5): persisted-index call-sites + forget/close wiring
-  'packages/hub/src/collection.ts': 5168,
+  // Bumped 5168→5255 (#308 L2): embeddings derive/retrieve/forget call-sites (engine in src/embeddings/)
+  'packages/hub/src/collection.ts': 5255,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -563,7 +564,8 @@ const KERNEL_SURFACE_BUDGET = {
   // (the barrier/transport logic itself lives in coordination/ + schema-update/).
   // Bumped 4546→4571 (#308 L1): getDictionary label-resolver injection + warmIndexOnOpen wiring (engine in src/search/)
   // Bumped 4571→4597 (#308 L1.5): persisted-index call-sites + forget/close wiring
-  'packages/hub/src/vault.ts': 4597,
+  // Bumped 4597→4610 (#308 L2): embeddings derive/retrieve/forget call-sites (engine in src/embeddings/)
+  'packages/hub/src/vault.ts': 4610,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),

--- a/showcases/src/124-semantic-retrieve.showcase.test.ts
+++ b/showcases/src/124-semantic-retrieve.showcase.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Showcase 124 — Semantic / vector retrieval (collection.retrieve mode:'semantic' + similarTo) — #308 L2
+ *
+ * What you'll learn
+ * -----------------
+ * `collection.embeddings` derives a Float32Array vector for every record at
+ * write time (encrypted under the collection DEK in a _vec sidecar), then
+ * `retrieve(q, { mode: 'semantic' })` encodes the query with the same hook
+ * and returns ranked hits by brute-force cosine similarity — all in the
+ * trusted tier, zero store leakage of vector values or source text.
+ *
+ *   1. retrieve(q, {mode:'semantic'}) — query string path (encode + cosine)
+ *   2. collection.similarTo(vec, {k}) — raw-vector path (bring your own vector)
+ *   3. Model-version guard — EmbeddingModelMismatchError when stored model != descriptor model
+ *
+ * Why it matters
+ * --------------
+ * Semantic retrieval in the trusted tier (encrypted vectors, local cosine) is
+ * the right model for private data — analogous to Apple Intelligence's on-device
+ * semantic index. The store sees only ciphertext; vector values and source text
+ * never leave your control.
+ *
+ * What to read next
+ * -----------------
+ *   - docs/subsystems/embeddings.md (epic map, privacy model, API reference)
+ *   - docs/superpowers/specs/2026-06-22-ai-retrieval-l2-semantic-vector-design.md
+ *   - Showcase 122 (L1 lexical retrieve — collection.retrieve mode:'lexical')
+ *   - Showcase 123 (L1.5 persisted index — textIndexPersist)
+ *
+ * Spec mapping
+ * ------------
+ * features.yaml -> features -> vector-search
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, EmbeddingModelMismatchError } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+
+// ---- Shared types ------------------------------------------------------------
+
+interface Doc extends Record<string, unknown> {
+  id: string
+  text: string
+}
+
+// Deterministic stub encoder: bag-of-chars hash -> Float32Array of given dim.
+// Each character increments the bucket at (charCode % dim). Different strings
+// produce meaningfully different vectors, making similarity reproducible in tests.
+const enc = (dim: number, model = 'stub') => ({
+  dim,
+  model,
+  source: 'text' as const,
+  encode: async (t: string) => {
+    const v = new Float32Array(dim)
+    for (let i = 0; i < t.length; i++) v[t.charCodeAt(i) % dim] += 1
+    return v
+  },
+})
+
+// ---- Part A: retrieve(q, {mode:'semantic'}) -----------------------------------
+
+describe('Showcase 124-A — retrieve(mode:semantic): query-string path', () => {
+  it('returns rank-1 as the exact-match doc; all hits carry rank and positive score', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'analyst',
+      secret: 'showcase-124-a',
+    })
+    const vault = await db.openVault('firm')
+    const docs = vault.collection<Doc>('docs', { embeddings: enc(16) })
+
+    await docs.put('invoice', { id: 'invoice', text: 'overdue invoice payment' })
+    await docs.put('client',  { id: 'client',  text: 'client account setup' })
+    await docs.put('report',  { id: 'report',  text: 'quarterly financial report' })
+
+    // Query that exactly matches 'invoice' record text.
+    const hits = await docs.retrieve('overdue invoice payment', { mode: 'semantic' })
+
+    expect(hits.length).toBeGreaterThan(0)
+    // The exact-match record should be ranked first.
+    expect(hits[0]!.id).toBe('invoice')
+    expect(hits[0]!.rank).toBe(1)
+    expect(hits[0]!.score).toBeGreaterThan(0)
+
+    // Ranks are 1-based and monotonic; scores are non-increasing.
+    for (let i = 1; i < hits.length; i++) {
+      expect(hits[i]!.rank).toBe(i + 1)
+      expect(hits[i]!.score).toBeLessThanOrEqual(hits[i - 1]!.score)
+    }
+
+    db.close()
+  })
+})
+
+// ---- Part B: collection.similarTo(vec, {k}) -----------------------------------
+
+describe('Showcase 124-B — similarTo(vec, {k:1}): raw-vector path', () => {
+  it('returns the doc whose encoding is closest to the supplied vector', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'analyst',
+      secret: 'showcase-124-b',
+    })
+    const vault = await db.openVault('firm')
+    const encoder = enc(16)
+    const docs = vault.collection<Doc>('docs', { embeddings: encoder })
+
+    await docs.put('alpha', { id: 'alpha', text: 'alpha text example query' })
+    await docs.put('beta',  { id: 'beta',  text: 'completely different content zzzzzz' })
+
+    // Encode the query ourselves and pass the raw vector.
+    const queryVec = await encoder.encode('alpha text example query')
+    const hits = await docs.similarTo(queryVec, { k: 1 })
+
+    expect(hits.length).toBe(1)
+    expect(hits[0]!.id).toBe('alpha')
+    expect(hits[0]!.score).toBeGreaterThan(0)
+
+    db.close()
+  })
+})
+
+// ---- Part C: model-version guard -----------------------------------------------
+
+describe('Showcase 124-C — model-version guard: EmbeddingModelMismatchError', () => {
+  it('throws EmbeddingModelMismatchError when the descriptor model differs from stored vectors', async () => {
+    const store = memory()
+
+    // Session 1: write vectors under model 'stub-v1'.
+    const db1 = await createNoydb({ store, user: 'analyst', secret: 'showcase-124-c' })
+    const v1 = await db1.openVault('firm')
+    const c1 = v1.collection<Doc>('docs', { embeddings: enc(16, 'stub-v1') })
+    await c1.put('doc1', { id: 'doc1', text: 'some document text here' })
+    db1.close()
+
+    // Session 2: re-open with a DIFFERENT model tag ('stub-v2').
+    // The stored vectors are tagged 'stub-v1'; the descriptor says 'stub-v2'.
+    // Cosine across model versions is meaningless — noy-db guards this.
+    const db2 = await createNoydb({ store, user: 'analyst', secret: 'showcase-124-c' })
+    const v2 = await db2.openVault('firm')
+    const c2 = v2.collection<Doc>('docs', { embeddings: enc(16, 'stub-v2') })
+
+    await expect(
+      c2.retrieve('some document text here', { mode: 'semantic' }),
+    ).rejects.toThrow(EmbeddingModelMismatchError)
+
+    db2.close()
+  })
+})


### PR DESCRIPTION
## L2 — semantic / vector retrieval (encrypted, local) · AI-retrieval epic #308

The semantic layer of the AI-retrieval epic (L0 scan ✅ → L1 lexical ✅ → L1.5 persisted ✅ → **L2 semantic** → L3 hybrid → L4 deferred). Zero-knowledge throughout: vectors are encrypted at rest under the collection DEK and decrypted only in the trusted tier for in-memory cosine — the store never sees a plaintext vector or the source text. Managed vector backends (which would expose plaintext vectors → embedding-inversion) are deferred and gated, the blind-index twin.

### What ships
- **`embeddings: { source, encode, dim, model }`** per-collection descriptor — pluggable `encode` hook (host/remote, **no bundled model**); engine in `src/embeddings/` (tree-shakeable, `NO_EMBEDDINGS` no-op default).
- **Write-time derivation** — on `put`, encode the `source` text → encrypted per-record `_vec` sidecar (collection DEK); re-derives on source change; `EmbeddingDimMismatchError` on dim mismatch.
- **`retrieve(q, { mode: 'semantic', k, minScore? })`** + **`collection.similarTo(vector, { k, minScore?, includeRecord? })`** — brute-force cosine over decrypted vectors (`VectorSet`, session-cached, dirty-on-write); `RetrieveHit { id, score, rank, field:'(vector)', snippet?, record? }`.
- **Model-version hard guard** — `EmbeddingModelMismatchError` when a stored vector's `model` ≠ the collection's; changing the encoder invalidates the space.
- **Erasure** — `forget()` drops each affected `_vec/<id>` (resilient + residue in `ForgetResult`, mirroring L1.5's `_ftindex` teardown).
- **CRDT + embeddings is guarded** — constructed combo throws a clear unsupported error (CRDT-derive is out of L2 scope; the derive block sits after the CRDT early-return).

### Non-code
- `features.yaml`: `vector-search` feature (`preview`/`experimental`), encrypted-local privacy model + deferred-managed-backend note.
- `docs/subsystems/embeddings.md`: encode-hook contract, encrypted-local model, model-versioning, CRDT-unsupported, empty-source → near-zero vector.
- Showcase 124 (deterministic stub encoder).

### Verification
- Full hub suite **2816/2816**; `tsc --noEmit` clean; eslint clean; architecture OK (ceilings collection.ts 5255 / vault.ts 4610); validate-features OK.
- Leakage test: `_vec` bodies are ciphertext (no plaintext vector/source); non-embedding collection writes no `_vec`.

7 build tasks + final whole-branch review (3 Important findings fixed: CRDT guard, false `.where()` invariant dropped, dead `EmbeddingEncoderNotConfiguredError` removed). Merged-to-main but **UNRELEASED** (like L1/L1.5).
