### PR TITLE
feat(hub): field-metadata foundation — zod-4 substrate + collection.describe() (#482, #483)

### DIFF
--- a/docs/subsystems/field-metadata.md
+++ b/docs/subsystems/field-metadata.md
@@ -1,7 +1,8 @@
-# Field metadata — `collection.describe()` + `fieldMeta`
+# Field metadata — `collection.describe()` + `fieldMeta` + metadata ladder
 
-> Status: **preview** (#483). Spec:
+> Status: **preview** (#483). Specs:
 > `docs/superpowers/specs/2026-06-25-field-metadata-foundation-design.md`
+> · `docs/superpowers/specs/2026-06-25-metadata-ladder-and-schema-surfacing-design.md`
 
 ---
 
@@ -177,3 +178,184 @@ const d2: CollectionDescription = await coll.describe({ resolveDictLabels: true 
 ```
 
 See also: Showcase 126 (`showcases/src/126-describe-field-metadata.showcase.test.ts`).
+
+---
+
+## Metadata ladder — collection + vault level
+
+The field-level descriptors (`fieldMeta` / `DescribedField`) are the bottom rung
+of a **three-rung metadata ladder**:
+
+```
+field  →  collection  →  vault
+```
+
+Each rung adds a friendly identity layer that viewers (devtools, editor, export
+filename, API doc) consume without duplicating their own label logic.
+
+### `collectionMeta`
+
+Declare via the `meta` collection option:
+
+```ts
+const invoices = vault.collection<Invoice>('invoices', {
+  meta: {
+    label: 'Sales Invoices',
+    description: 'Outbound sales invoices billed to clients.',
+    pluralLabel: 'Sales Invoices',  // for list headers
+    icon: 'receipt',                // semantic icon name (Lucide etc.)
+  },
+  fieldMeta: { … },
+})
+```
+
+`CollectionMeta` members:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `label` | `string?` | Friendly collection name; falls back to the humanized collection name |
+| `description` | `string?` | Longer tooltip / context |
+| `icon` | `string?` | Semantic icon name (e.g. a Lucide key), not styling |
+| `pluralLabel` | `string?` | Plural form for list headers ("Invoice" → "Invoices") |
+
+Unlike `FieldMeta.label`, `CollectionMeta.label` is **optional** — the
+collection name is already a reasonable fallback identity.
+
+**First-wins reconciler.** When a collection is pre-created by an MV before the
+app's own `vault.collection()` call, the first declared `meta` wins (mirrors
+`_applyFieldMeta`).
+
+**Surfaces in:**
+- `collection.describe()` → `CollectionDescription.meta`
+- `vault.dumpSchema()` → `CollectionDescriptor.meta`
+- `in-devtools` `snapshot()` → `InspectorCollection.meta`
+
+### `vaultMeta`
+
+Declare via the `meta` vault option:
+
+```ts
+const vault = await db.openVault('ledger', {
+  meta: { label: 'Acme Ledger 2026', description: 'Main accounting vault.' },
+})
+```
+
+`VaultMeta` members:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `label` | `string?` | Friendly vault name; falls back to the vault name |
+| `description` | `string?` | Longer context |
+| `icon` | `string?` | Semantic icon name |
+
+**First-wins.** Re-opening an already-cached vault keeps its `meta`.
+
+**Surfaces in:**
+- `vault.dumpSchema()` → `VaultSchemaSnapshot.meta`
+- `in-devtools` `snapshot()` → `InspectorSnapshot.meta`
+
+**Kernel export.** `CollectionMeta` and `VaultMeta` are also exported from
+`@noy-db/hub/kernel` so that klum-db's federation layer can reuse `VaultMeta`
+for `groupMeta` without taking a full hub dep.
+
+---
+
+## `describe()` enhancements — `i18n`, `widget`, `editable`
+
+The metadata ladder build added three fields to `DescribedField`:
+
+### `i18n?: { locales?: readonly string[]; densify?: boolean }`
+
+Present on fields declared with `i18nText()`. Exposes the configured locale set
+and the `densifyOnWrite` flag so consumers know the field is multi-locale.
+
+### `widget?: string`
+
+Derived from `semanticType` + `type`, overridable via `fieldMeta.widget`:
+
+| Condition | Derived `widget` |
+|---|---|
+| `semanticType: 'date'` or `'datetime'` | `'date'` |
+| `semanticType: 'currency'` (money) | `'money'` |
+| `semanticType: 'entity'` (ref) | `'ref-select'` |
+| `dict` block present | `'select'` |
+| `type: 'boolean'` | `'checkbox'` |
+| `semanticType: 'percent'` | `'number'` |
+| `semanticType: 'url'` | `'url'` |
+| `semanticType: 'email'` | `'email'` |
+| else | `'text'` |
+
+Override: `fieldMeta: { amount: { label: 'Amount', widget: 'currency-input' } }`.
+
+### `editable: boolean`
+
+`false` for computed fields, the `id` field, and provenance-stamped fields;
+`true` otherwise. Data editors use this to render read-only cells without
+knowing the collection's internals.
+
+---
+
+## `dumpSchema()` collection-level `config` block
+
+`CollectionDescriptor.config` surfaces the **live** collection's configuration
+options for structural-audit tooling. It is populated by `dumpSchema()` when the
+collection is live-declared; omitted for bundle-reconstructed collections where
+options aren't available.
+
+```ts
+config?: {
+  textIndexes?: readonly string[]
+  textIndexPersist?: boolean
+  embeddings?: { source: string | readonly string[]; dim: number; model?: string }
+  i18nFields?: readonly string[]
+  crdt?: string
+  provenance?: boolean
+  archive?: boolean          // presence flag (the predicate is code)
+  tiers?: readonly number[]
+  tierMode?: string
+  perRecordKeys?: boolean
+  history?: boolean          // presence flag
+  schemaUpdate?: readonly string[]  // strategy names
+}
+```
+
+**Function-valued options surface as booleans (presence).** `conflictPolicy` is
+consumed at construction and has no retained state to surface.
+
+---
+
+## Devtools schema view
+
+### `in-devtools` `snapshot()`
+
+`InspectorCollection` carries all three rung outputs:
+- `meta?: CollectionMeta` — collection-level label/description
+- `described?: readonly DescribedField[]` — rich field list (label/type/widget/sensitivity/i18n/editable)
+- `config?: CollectionConfig` — structural config strip
+
+`InspectorSnapshot` gains `meta?: VaultMeta` for the vault-level label.
+
+### Terminal UI (`@noy-db/in-devtools-tui`)
+
+The structure view renders the metadata ladder compactly:
+
+**VaultList** — shows `meta.label (vaultId)` for the active vault when a label
+is declared; falls back to the vault id.
+
+**CollectionList** — shows `meta.label (name)` for each collection when a label
+is declared; falls back to the collection name.
+
+**DetailPane** (drilled schema tab):
+- Heading: `meta.label (name)` or just `name`
+- If `described` is present: one line per field — `Label  (key: type)  [pii]  [i18n]  [ro]  <widget>`
+- If `described` is absent (no live describe): raw `key: type` from `fields`
+- Config strip (dimmed): `config: idx:2  emb:1536d  i18n:3  crdt:lww  provenance  archive`
+
+Markers used:
+| Marker | Meaning |
+|---|---|
+| `[pii]` | `sensitivity: 'pii'` |
+| `[secret]` | `sensitivity: 'secret'` |
+| `[i18n]` | `i18n` block present |
+| `[ro]` | `editable: false` |
+| `<widget>` | widget hint, e.g. `<money>` or `<ref-select>` |

--- a/docs/subsystems/field-metadata.md
+++ b/docs/subsystems/field-metadata.md
@@ -1,0 +1,179 @@
+# Field metadata — `collection.describe()` + `fieldMeta`
+
+> Status: **preview** (#483). Spec:
+> `docs/superpowers/specs/2026-06-25-field-metadata-foundation-design.md`
+
+---
+
+## What it is
+
+`collection.describe()` returns a normalised `CollectionDescription` whose
+`fields: DescribedField[]` array merges every per-field config channel into a
+single consumer-neutral record. Any consumer — table header, export pipeline,
+API serialiser, AI agent context — reads from this one source instead of
+duplicating its own label/unit/sensitivity logic.
+
+**Descriptive, never prescriptive.** `DescribedField` carries meaning
+(`label`, `semanticType`, `unit`, `sensitivity`, `aggregate`, `aliases`,
+`displayFor`) — not layout, not styling, not locale selection. Those stay
+app-side.
+
+---
+
+## Sync vs async
+
+| Call | What it returns | When to use |
+|---|---|---|
+| `collection.describe()` | `CollectionDescription` (sync, immediate) | Table headers, export spec, any render-time use |
+| `collection.describe(opts)` | `Promise<CollectionDescription>` | Need validator-derived exact types, zod-4 `.meta()`, or dynamic-dict label resolution |
+
+The sync path is zero-store-I/O: no `await`, no store reads, no decryption.
+It derives field types from the in-memory config (money→`'number'`,
+ref→`'string'`/`'array'`, dictKey→`'enum'`, others→`'unknown'`).
+
+The async path adds:
+- Validator-derived `type`/`optional`/`constraints` via `deriveZodFields`
+  (lazy `import('zod')` — never a static dep).
+- Zod-4 `.meta()` key extraction (label, description, semanticType, …).
+- Dynamic-dict label resolution: `{ resolveDictLabels: true }` calls
+  `vault.dictionary(name).list()` for each dynamic dictKey field and populates
+  `dict.values[].label`.
+
+---
+
+## The `fieldMeta` channel
+
+`fieldMeta` is the primary, validator-agnostic authoring surface. It is
+declared as a collection option:
+
+```ts
+const sales = vault.collection<Sale>('sales', {
+  moneyFields:   { total: money({ currency: 'EUR' }) },
+  dictKeyFields: { status: saleStatus },
+  refs:          { buyerId: ref('buyers') },
+  fieldMeta: {
+    saleDate: { label: 'Date' },
+    total:    { label: 'Total (€)', unit: '€' },
+    buyerId:  { label: 'Buyer', sensitivity: 'pii', displayFor: 'buyerName' },
+    notes:    { label: 'Internal notes', sensitivity: 'secret' },
+  },
+})
+```
+
+`FieldMeta` members:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `label` | `string` (required) | Human display name |
+| `description` | `string?` | Longer tooltip / context |
+| `semanticType` | `SemanticType?` | Domain hint: `'date'`, `'currency'`, `'email'`, `'vat'`, … |
+| `unit` | `string?` | Display unit: `'€'`, `'%'`, `'kg'`, … |
+| `sensitivity` | `'public' \| 'pii' \| 'secret'` | Data-classification for redaction/masking |
+| `aggregate` | `'sum' \| 'count' \| 'distinct' \| 'none'` | Default aggregation |
+| `aliases` | `readonly string[]?` | Canonical search synonyms |
+| `displayFor` | `string?` | Entity pairing: `'buyerId'` → `displayFor: 'buyerName'` |
+
+---
+
+## Merge precedence
+
+For each field, three tiers of metadata are merged in priority order:
+
+```
+channel (fieldMeta) > zod-4 .meta() (async path) > inferred-from-config
+```
+
+1. **channel** — values from `collection({ fieldMeta: { … } })`. Wins over
+   everything. This is where the app author declares intent.
+2. **zod-4 `.meta()`** — async path only. Keys recognized:
+   `label`, `description`, `unit`, `semanticType`, `sensitivity`, `aggregate`,
+   `aliases`, `displayFor`. Unknown `.meta()` keys are silently ignored.
+3. **inferred-from-config** — automatically derived from the collection's other
+   config:
+   - `moneyFields` → `semanticType:'currency'`, `aggregate:'sum'`, `type:'number'`
+   - `refs` → `semanticType:'entity'`, `type:'string'` (or `'array'` for `refArray`)
+   - `dictKeyFields` → `type:'enum'`, `dict: { name, static, values[] }`
+
+Structural extras (`money`, `dict`, `ref` blocks) always come from config, not
+from the channel.
+
+---
+
+## Two-consumer pattern
+
+Call `describe()` once; hand the result to every consumer:
+
+```ts
+const d = sales.describe()
+
+// Consumer A — table header row
+const headers = d.fields.map((f) => f.label)
+
+// Consumer B — export column spec (flag PII/secret for redaction)
+const exportSpec = d.fields.map((f) => ({
+  key:      f.key,
+  label:    f.label,
+  redacted: f.sensitivity !== undefined && f.sensitivity !== 'public',
+}))
+
+// Consumer C — AI agent context (structured field list, no raw records)
+const agentContext = d.fields.map((f) => ({
+  key:  f.key,
+  type: f.type,
+  ...(f.sensitivity === 'secret' ? { omit: true } : {}),
+}))
+```
+
+`CollectionDescription` is a frozen plain object — pass it freely.
+
+---
+
+## Scope boundary
+
+`describe()` is **descriptive, not prescriptive**:
+
+- Layout order → app-side (describe() returns alphabetical by key)
+- Locale selection → app-side (staticDict can surface one locale via
+  `displayLocale`; the choice belongs to the caller)
+- Rendering / formatting → app-side
+- Validation / write enforcement → schema / guards, not describe()
+
+---
+
+## Key invariants
+
+- **Sync = zero store I/O.** The sync overload reads only in-memory config
+  assembled at collection registration time. It never calls any store method.
+- **Descriptive not prescriptive.** No layout, styling, or active-locale
+  selection in `DescribedField`.
+- **Merge precedence is fixed**: channel > zod-4 `.meta()` > inferred.
+  Application code can rely on `fieldMeta` always winning.
+- **Validator-agnostic.** Works without zod; non-zod validators get structural
+  type inference from config only (sync path) or an empty `zodFields` map
+  (async path) — no error.
+- **fieldMeta key guard (async path).** When `zodFields` is non-empty, unknown
+  `fieldMeta` keys throw `FieldMetaUnknownFieldError` — typo protection.
+  Sync path skips this check because schema fields aren't knowable without
+  async derivation.
+
+---
+
+## Public API surface (`@noy-db/hub`)
+
+```ts
+import { createNoydb, money, staticDict, ref } from '@noy-db/hub'
+import type { FieldMeta, SemanticType, CollectionDescription, DescribedField, DescribeOptions } from '@noy-db/hub'
+
+// collection option
+const coll = vault.collection('name', {
+  fieldMeta: Record<string, FieldMeta>
+})
+
+// sync
+const d: CollectionDescription = coll.describe()
+
+// async (validator types + dynamic dict labels)
+const d2: CollectionDescription = await coll.describe({ resolveDictLabels: true })
+```
+
+See also: Showcase 126 (`showcases/src/126-describe-field-metadata.showcase.test.ts`).

--- a/docs/subsystems/field-metadata.md
+++ b/docs/subsystems/field-metadata.md
@@ -359,3 +359,103 @@ Markers used:
 | `[i18n]` | `i18n` block present |
 | `[ro]` | `editable: false` |
 | `<widget>` | widget hint, e.g. `<money>` or `<ref-select>` |
+
+---
+
+## Metadata riders (#484 #485) — `toJSONSchema()`, dictKey inline labels, devtools PII masking
+
+> Spec: `docs/superpowers/specs/2026-06-25-metadata-riders-design.md`
+
+### `collection.toJSONSchema()`  (#484)
+
+An async method on `Collection` that produces a JSON Schema object annotated
+with `describe()` metadata as `x-` extension keys:
+
+```ts
+const schema = await myCollection.toJSONSchema()
+```
+
+**Pipeline:**
+1. `derivePersistedSchema(this.schema)` — produces the base JSON Schema (zod-4
+   `z.toJSONSchema()` path; zod-3 via `zod-to-json-schema`).
+2. `await this.describe({})` — the normalized per-field metadata.
+3. Overlay each property with the `x-` extension keys below.
+
+**`x-` key table:**
+
+| `describe()` field | JSON-Schema key | Notes |
+|---|---|---|
+| `label` | `x-label` | |
+| `unit` | `x-unit` | |
+| `semanticType` | `x-semanticType` | |
+| `sensitivity` | `x-sensitivity` | `'public'`, `'pii'`, or `'secret'` |
+| `widget` | `x-widget` | derived hint, overridable |
+| `editable: false` | `x-readonly: true` | only emitted when `false` |
+| `money` | `x-money` | `{ currency, scale }` |
+| `ref` | `x-ref` | `{ target }` |
+| `dict.values[].label` | `x-enumLabels` | `{ [value]: label }` map |
+
+**Validator-agnostic fallback:** when `derivePersistedSchema` yields no JSON
+Schema (non-zod validator), `toJSONSchema()` builds a minimal
+`{ type: 'object', properties }` from the field types derived by `describe()`,
+then overlays the same `x-` metadata. No throw; no zod required.
+
+---
+
+### `dictKey` inline labels  (#485)
+
+`dictKey` gains an optional inline label map alongside the existing array form:
+
+```ts
+// Today (still valid — bare array):
+dictKey('saleStatus', ['draft', 'to_verify', 'paid'] as const)
+
+// New — value→label map (keys inferred from the map):
+dictKey('saleStatus', { draft: 'Draft', to_verify: 'To Verify', paid: 'Paid' })
+
+// Or array + labels option (preserves explicit order):
+dictKey('saleStatus', VALUES, { labels: { to_verify: 'To Verify' } })
+```
+
+`DictKeyDescriptor` gains `readonly labels?: Record<string, string>`.
+
+**Semantics — display fallback:**
+- Inline labels are code-provided *defaults* surfaced when the `_dict_`
+  collection has no label for a key.
+- `describe()` (**sync**) surfaces inline labels into `dict.values[].label`
+  with zero store I/O — equivalent to `staticDict` for display purposes.
+- `describe({ resolveDictLabels: true })` (**async**) overrides from `_dict_`
+  and falls back to the inline label.
+- `toJSONSchema()` `x-enumLabels` picks them up via `describe()`.
+
+This keeps `staticDict` (closed code labels, no `_dict_`) and
+`dictKey` + inline labels (dynamic dict *with* code defaults) as distinct,
+non-overlapping tools.
+
+---
+
+### Devtools PII masking
+
+The `RecordsPane` in both devtools surfaces masks values for fields where
+`sensitivity !== 'public'` (i.e. `pii` and `secret`), protecting data during
+screen-sharing or shoulder surfing.
+
+**Behavior:**
+- Sensitive cells render as `••••` by default.
+- A reveal toggle un-masks the value on demand:
+  - **Nuxt** (`@noy-db/in-devtools-nuxt`): per-field reveal (click the masked
+    cell); a header "reveal all" toggle un-masks the whole pane.
+  - **TUI** (`@noy-db/in-devtools-tui`): press `r` to toggle reveal-all for
+    the pane (a single pane-level toggle is terminal-appropriate).
+- Public fields (`sensitivity: 'public'`) and unclassified fields (no
+  `sensitivity`) always render their raw values — they are never masked.
+- **Back-compat:** a collection without `described` (non-live or pre-enrichment)
+  has an empty sensitive-field set → nothing is masked → behavior is identical
+  to before.
+
+**Collection-change reset (TUI):** the reveal-all flag resets when the selected
+collection index changes, so revealed PII does not linger when navigating to
+another collection.
+
+This is shoulder-surfing / screen-share safety over already-decrypted local
+data — it is **not** access control. The data is already in the trusted tier.

--- a/docs/subsystems/field-metadata.md
+++ b/docs/subsystems/field-metadata.md
@@ -391,8 +391,8 @@ const schema = await myCollection.toJSONSchema()
 | `sensitivity` | `x-sensitivity` | `'public'`, `'pii'`, or `'secret'` |
 | `widget` | `x-widget` | derived hint, overridable |
 | `editable: false` | `x-readonly: true` | only emitted when `false` |
-| `money` | `x-money` | `{ currency, scale }` |
-| `ref` | `x-ref` | `{ target }` |
+| `money` | `x-money` | full money block: `{ mode, currency?, scale?, rounding? }` |
+| `ref` | `x-ref` | bare string — the ref target collection name |
 | `dict.values[].label` | `x-enumLabels` | `{ [value]: label }` map |
 
 **Validator-agnostic fallback:** when `derivePersistedSchema` yields no JSON

--- a/docs/superpowers/plans/2026-06-25-field-metadata-1-zod4-substrate.md
+++ b/docs/superpowers/plans/2026-06-25-field-metadata-1-zod4-substrate.md
@@ -1,0 +1,244 @@
+# Field-metadata Plan 1 — zod-4 substrate (#482) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `@noy-db/hub` first-class on zod 4 without breaking zod-3 consumers — bump the dev dependency and teach the JSON-Schema derivation path to use zod 4's native converter — keeping hub validator-agnostic and portable.
+
+**Architecture:** hub never imports zod statically; it validates through the Standard Schema v1 protocol. The only zod-aware code is `persisted-schemas/derive.ts`, which lazy-imports a converter. This plan adds a zod-4 detection heuristic and a native-`z.toJSONSchema()` branch (lazy `import('zod')`), leaving the existing zod-3 `zod-to-json-schema` branch intact as the fallback.
+
+**Tech Stack:** TypeScript, Vitest, zod 4 (devDependency only), Standard Schema v1.
+
+## Global Constraints
+
+- `zod` stays a **devDependency** of hub — never promoted to a direct or peer dependency (copied from spec: "zod stays a devDependency; it is not promoted to a direct or peer dependency").
+- **No static `import 'zod'`** anywhere in `packages/hub/src` — zod access is lazy/dynamic only (`await import('zod')`), like the existing `zod-to-json-schema` load.
+- hub must remain portable: no `node:*` imports (enforced by `scripts/check-architecture.mjs`).
+- Both zod 3 and zod 4 schemas must derive a JSON Schema; non-zod validators keep returning the stub envelope.
+- No Claude attribution in commits (no `Co-Authored-By: Claude` / "Generated with Claude Code").
+- Run `npm test -w @noy-db/hub` for the hub suite; the package uses Vitest.
+
+---
+
+### Task 1: Bump zod devDependency 3 → 4 and green the suite
+
+**Files:**
+- Modify: `packages/hub/package.json` (the `"zod": "^3.23.0"` line under `devDependencies`)
+- Modify: `packages/cli/package.json` (the `"zod": "^3.23.0"` line under `devDependencies`)
+- Test: existing hub + cli suites (no new test file)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a workspace where `zod` resolves to 4.x; the hub test suite passes against zod 4. Later tasks rely on zod 4 being importable via `await import('zod')` in tests.
+
+- [ ] **Step 1: Inspect current zod usage to confirm the stable-subset claim**
+
+Run: `grep -rn "z\.\|from 'zod'\|from \"zod\"" packages/hub/src packages/hub/test packages/hub/__tests__ 2>/dev/null | grep -v node_modules | sort | uniq -c | sort -rn | head -40`
+Expected: usages limited to the cross-major-stable subset (`z.object`, `z.string`, `z.number`, `z.enum`, `z.union`, `z.array`, `z.literal`, `.optional`, `.refine`, `.default`, `.parse`, `.safeParse`). Note any zod-3-only API (e.g. `z.string().nonempty()` removed in v4, `.merge()` semantics, `ZodError.format()` shape) — these are the only spots Step 4 may need to touch.
+
+- [ ] **Step 2: Bump the devDependency in both packages**
+
+In `packages/hub/package.json` change the `devDependencies` entry:
+```json
+"zod": "^4.0.0",
+```
+In `packages/cli/package.json` change the `devDependencies` entry:
+```json
+"zod": "^4.0.0",
+```
+Leave `zod-to-json-schema` exactly as-is (`devDependencies: "^3.25.2"`, `peerDependencies: "^3.25.0"`, `peerDependenciesMeta.optional: true`).
+
+- [ ] **Step 3: Install and resolve**
+
+Run: `npm install`
+Then: `node -e "console.log(require('zod/package.json').version)"`
+Expected: a `4.x.y` version string.
+
+- [ ] **Step 4: Run the full hub + cli suites; fix any zod-3→4 fallout**
+
+Run: `npm test -w @noy-db/hub`
+Expected: PASS. If a test fails on a zod-3-only API found in Step 1, migrate that call to its zod-4 equivalent (e.g. `z.string().nonempty()` → `z.string().min(1)`; `err.format()` → `err.issues` / `z.treeifyError`). Do **not** change non-test source — hub `src/` does not import zod.
+Run: `npm test -w @noy-db/cli`
+Expected: PASS (cli uses zod for its own command schemas; apply the same migration if needed).
+
+- [ ] **Step 5: Verify portability + architecture still hold**
+
+Run: `node scripts/check-architecture.mjs`
+Expected: PASS (no ceiling regressions; no new `node:*` imports).
+Run: `grep -rn "from 'zod'\|from \"zod\"\|require('zod')" packages/hub/src` 
+Expected: NO matches (hub src must not import zod — the bump is dev/test-only).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/package.json packages/cli/package.json package-lock.json
+git commit -m "build(hub): bump zod devDependency to v4 (#482)"
+```
+
+---
+
+### Task 2: zod-4 detection + native derivation branch
+
+**Files:**
+- Modify: `packages/hub/src/persisted-schemas/derive.ts`
+- Test: `packages/hub/src/persisted-schemas/derive.test.ts` (create if absent; otherwise add to the existing test file — check with `ls packages/hub/src/persisted-schemas/`)
+
+**Interfaces:**
+- Consumes: `derivePersistedSchema(validator: unknown): Promise<PersistedSchemaEnvelope>` (existing), `PersistedSchemaKind` (existing union — verify it includes `'Zod'`, `'Unknown'`).
+- Produces: zod-4 schemas now derive a real `jsonSchema` (kind `'Zod'`); zod-3 schemas unchanged; new exported predicate `isZod4Schema(value: unknown): boolean`.
+
+- [ ] **Step 1: Empirically confirm the zod-4 schema shape and converter**
+
+Run:
+```bash
+node -e "const z=require('zod'); const s=z.object({a:z.string()}); console.log('has _zod:', !!s._zod, '| has _def:', !!s._def, '| _def.typeName:', s?._def?.typeName); console.log('toJSONSchema type:', typeof z.toJSONSchema); console.log(JSON.stringify(z.toJSONSchema(s)));"
+```
+Expected: prints whether zod-4 instances carry `_zod` (the v4 internal namespace) and/or `_def`, confirms `z.toJSONSchema` is a function, and prints a valid JSON Schema. **Use the actual observed shape** to write the detection in Step 3 (if `_zod` is the discriminator, key on it; if v4 still exposes `_def.typeName` starting with something other than `Zod`, adjust accordingly). Record the observation in the test file as a comment.
+
+- [ ] **Step 2: Write the failing tests**
+
+In `packages/hub/src/persisted-schemas/derive.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { derivePersistedSchema, isZod4Schema, isZodSchema } from './derive.js'
+
+describe('derivePersistedSchema — zod 4', () => {
+  it('detects a zod-4 schema', () => {
+    expect(isZod4Schema(z.object({ a: z.string() }))).toBe(true)
+    expect(isZod4Schema({})).toBe(false)
+    expect(isZod4Schema(null)).toBe(false)
+  })
+
+  it('derives a real JSON Schema from a zod-4 schema (kind=Zod)', async () => {
+    const env = await derivePersistedSchema(z.object({ name: z.string(), age: z.number() }))
+    expect(env.kind).toBe('Zod')
+    expect(env.jsonSchema).not.toBeNull()
+    expect(env.hash).not.toBeNull()
+    // properties survive the conversion
+    const props = (env.jsonSchema as { properties?: Record<string, unknown> }).properties ?? {}
+    expect(Object.keys(props).sort()).toEqual(['age', 'name'])
+  })
+
+  it('returns the stub envelope for a non-zod validator', async () => {
+    const env = await derivePersistedSchema({ '~standard': { version: 1, vendor: 'x', validate: () => ({ value: 1 }) } })
+    expect(env.kind).toBe('Unknown')
+    expect(env.jsonSchema).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `npm test -w @noy-db/hub -- derive`
+Expected: FAIL — `isZod4Schema` is not exported; the zod-4 derive test fails because the current `detectKind` keys on `_def.typeName.startsWith('Zod')` (zod-3 shape) and the converter is `zod-to-json-schema` (zod-3-only).
+
+- [ ] **Step 4: Implement zod-4 detection + native branch**
+
+In `packages/hub/src/persisted-schemas/derive.ts`, add the predicate (adjust the discriminator to the Step-1 observation) and a lazy native converter, and branch in `derivePersistedSchema`:
+
+```ts
+/**
+ * Heuristic zod-4 detection. zod 4 moved schema internals to the `_zod`
+ * namespace (vs zod 3's `_def.typeName`). Kept duck-typed so hub never
+ * statically imports zod.
+ */
+export function isZod4Schema(value: unknown): boolean {
+  if (value === null || typeof value !== 'object') return false
+  return typeof (value as { _zod?: unknown })._zod === 'object'
+    && (value as { _zod?: unknown })._zod !== null
+}
+
+/**
+ * Lazy-import zod 4's native `toJSONSchema`. Returns the converter, or
+ * throws a clear error if zod isn't installed. zod 4-only — zod 3 has no
+ * native converter and uses {@link loadZodConverter} (`zod-to-json-schema`).
+ */
+async function loadZod4Converter(): Promise<(s: unknown) => object> {
+  try {
+    const mod = (await import('zod')) as { toJSONSchema?: (s: unknown) => object }
+    if (!mod.toJSONSchema) throw new Error('zod.toJSONSchema export missing (need zod >= 4)')
+    return mod.toJSONSchema
+  } catch (err) {
+    throw new Error(
+      'deriving a JSON Schema from a zod-4 validator requires `zod` (>=4) to be importable. '
+      + `Original error: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+}
+```
+
+Update `derivePersistedSchema` so the `'Zod'` branch picks the converter by version:
+
+```ts
+export async function derivePersistedSchema(
+  validator: unknown,
+): Promise<PersistedSchemaEnvelope> {
+  const kind = detectKind(validator)
+  const derivedAt = new Date().toISOString()
+
+  if (kind === 'Zod') {
+    const convert = isZod4Schema(validator)
+      ? await loadZod4Converter()
+      : await loadZodConverter()
+    const jsonSchema = convert(validator)
+    const canonical = canonicalize(jsonSchema)
+    const hash = await sha256Hex(new TextEncoder().encode(canonical))
+    return { _noydb_schema: 1, kind, jsonSchema, hash, derivedAt }
+  }
+
+  return {
+    _noydb_schema: 1,
+    kind,
+    jsonSchema: null,
+    hash: null,
+    reason: `derivation not yet supported for kind=${kind} (v0 supports Zod only)`,
+    derivedAt,
+  }
+}
+```
+
+Update `detectKind`/`isZodSchema` so a zod-4 schema is also classified `'Zod'`:
+
+```ts
+function detectKind(validator: unknown): PersistedSchemaKind {
+  if (isZodSchema(validator) || isZod4Schema(validator)) return 'Zod'
+  return 'Unknown'
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npm test -w @noy-db/hub -- derive`
+Expected: PASS (all three new tests, plus any pre-existing derive tests).
+
+- [ ] **Step 6: Confirm portability + no static zod import**
+
+Run: `grep -rn "from 'zod'\|from \"zod\"" packages/hub/src`
+Expected: NO matches (the new converter uses dynamic `await import('zod')`, not a static import).
+Run: `node scripts/check-architecture.mjs`
+Expected: PASS.
+
+- [ ] **Step 7: Document zod-4 support in the subsystem doc**
+
+In `packages/hub/src/persisted-schemas/derive.ts` top doc-comment, change the line "v0 supports Zod via `zod-to-json-schema` (optional peer-dep)" to note both majors: "Supports zod 3 (via the optional `zod-to-json-schema` peer-dep) and zod 4 (via its native `z.toJSONSchema()`); both are loaded lazily so hub never statically imports zod." If `docs/subsystems/` has a schema/introspection doc, add one sentence there stating hub accepts any Standard-Schema validator, with zod 3 or 4 both supported.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/hub/src/persisted-schemas/derive.ts packages/hub/src/persisted-schemas/derive.test.ts docs
+git commit -m "feat(hub): zod-4 native JSON-Schema derivation, kept agnostic + lazy (#482)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (#482 portion):**
+- devDep zod 3→4 bump → Task 1. ✓
+- zod-version-aware `derivePersistedSchema` (native zod-4 toJSONSchema + zod-3 fallback) → Task 2. ✓
+- "hub accepts any Standard-Schema validator; zod-4 read is a bonus" documentation → Task 2 Step 7. ✓
+- No peer-dep change, no static zod import → Global Constraints + Task 1 Step 5 + Task 2 Step 6. ✓
+
+**Placeholder scan:** none — all steps carry concrete code/commands. The single deliberate empirical step (Task 2 Step 1) verifies the zod-4 internal shape before writing the heuristic, with a concrete fallback instruction.
+
+**Type consistency:** `isZod4Schema`, `loadZod4Converter`, `derivePersistedSchema`, `detectKind`, `PersistedSchemaEnvelope`, `PersistedSchemaKind` used consistently and match `derive.ts` as read.

--- a/docs/superpowers/plans/2026-06-25-field-metadata-2-describe.md
+++ b/docs/superpowers/plans/2026-06-25-field-metadata-2-describe.md
@@ -1,0 +1,569 @@
+# Field-metadata Plan 2 — fieldMeta channel + collection.describe() (#483) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give a collection a consumer-neutral field-metadata layer (`fieldMeta`) and a single normalized `collection.describe()` that merges existing config (refs/money/dict/computed) + the channel + (async) zod-4 registry metadata, so every renderer/exporter reads one source instead of re-deriving facts.
+
+**Architecture:** A new `fieldMeta` entry in collection options stores per-field `FieldMeta` (canonical, validator-agnostic). A pure merge module under `introspection/` combines: channel (highest) → zod-4 `.meta()` (async only) → inferred-from-config (money/refs/format). `collection.describe()` is sync and config-only (type tags inferred from config); an async overload `describe(opts)` derives exact validator types, merges zod-4 `.meta()`, and resolves dynamic-dict labels.
+
+**Tech Stack:** TypeScript, Vitest, Standard Schema v1, zod 4 (devDependency, lazy).
+
+## Global Constraints
+
+- **Depends on Plan 1 (#482)** — `derivePersistedSchema` must already support zod 4, and `isZod4Schema` must be exported from `persisted-schemas/derive.ts`.
+- hub stays validator-agnostic: **no static `import 'zod'`** in `packages/hub/src`. The async path uses the existing lazy derivation only.
+- **Descriptive, never prescriptive** (copied from spec): metadata may carry label/semanticType/unit/sensitivity/aggregate/aliases/displayFor; it must NOT carry column order, widths, breakpoints, sort/filter defaults, routing, styling, or active-locale selection.
+- **Litmus test invariant:** a field-metadata key is admissible only if *"a second, unrelated consumer would want this fact."*
+- Merge precedence (highest wins): `fieldMeta` channel → zod-4 `.meta()` registry → inferred-from-config.
+- `describe()` (sync) does **zero store I/O** (no decryption). Only the async overload touches `_dict_*`.
+- New public symbols require re-export from `src/index.ts` (a recurring gap: local tsc passes because tests import `../src/`; only the showcase + CI cross-package typecheck against `dist/` catch a missing barrel export — so verify by building + showcase typecheck). Do **not** add to `src/kernel/index.ts` (per-collection introspection is not orchestration surface).
+- Every feature change must touch `features.yaml` or CI "Spec coverage" fails.
+- No Claude attribution in commits.
+- Spec: `docs/superpowers/specs/2026-06-25-field-metadata-foundation-design.md`.
+
+---
+
+### Task 1: `FieldMeta` type, `fieldMeta` collection option, storage + fail-loud validation
+
+**Files:**
+- Create: `packages/hub/src/introspection/field-meta.ts` (the `FieldMeta` type + helpers)
+- Modify: `packages/hub/src/vault.ts` — add `fieldMeta?` to the `CollectionOptions<T>` interface (the interface defining `schema`/`refs`/`moneyFields`/`dictKeyFields`, ~`vault.ts:672-767`) and register it in the collection-construction block (~`vault.ts:801-971`, where `refs`/`dictKeyFields` are registered and threaded into `new Collection(...)`)
+- Modify: `packages/hub/src/collection.ts` — accept + store `fieldMeta` on the Collection (mirror the `dictKeyFields` private field at ~`collection.ts:360`/assignment ~`collection.ts:970`) and add a getter
+- Test: `packages/hub/src/introspection/field-meta.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `interface FieldMeta { label: string; description?: string; semanticType?: string; unit?: string; sensitivity?: 'public'|'pii'|'secret'; aggregate?: 'sum'|'count'|'distinct'|'none'; aliases?: readonly string[]; displayFor?: string }`
+  - `CollectionOptions.fieldMeta?: Record<string, FieldMeta>`
+  - `Collection` stores it; later tasks read it via a getter `getFieldMeta(): Record<string, FieldMeta> | undefined`
+  - Unknown-key validation throws `FieldMetaUnknownFieldError` at `vault.collection()` time.
+
+- [ ] **Step 1: Write the `FieldMeta` type and a validation helper (failing test first)**
+
+In `packages/hub/src/introspection/field-meta.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { validateFieldMetaKeys } from './field-meta.js'
+
+describe('FieldMeta key validation', () => {
+  it('passes when every fieldMeta key is a known field', () => {
+    expect(() => validateFieldMetaKeys('sales', { total: { label: 'Amount' } }, new Set(['total', 'saleDate']))).not.toThrow()
+  })
+  it('throws fail-loud on an unknown field key (typo)', () => {
+    expect(() => validateFieldMetaKeys('sales', { totl: { label: 'Amount' } }, new Set(['total'])))
+      .toThrowError(/totl/)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm test -w @noy-db/hub -- field-meta`
+Expected: FAIL — module/`validateFieldMetaKeys` not found.
+
+- [ ] **Step 3: Implement the type + helper + error**
+
+Create `packages/hub/src/introspection/field-meta.ts`:
+```ts
+/**
+ * Consumer-neutral, data-relatable field descriptors — the canonical,
+ * validator-agnostic authoring channel. Merged by `collection.describe()`.
+ *
+ * Descriptive, never prescriptive: label/semanticType/unit/sensitivity/
+ * aggregate/aliases/displayFor only. Layout, styling, and active-locale
+ * selection stay app-side.
+ *
+ * @module
+ */
+
+/** Known semantic types; the union is open — unknown strings pass through. */
+export type SemanticType =
+  | 'date' | 'datetime' | 'email' | 'url' | 'currency' | 'percent'
+  | 'country' | 'vat' | 'iban' | 'entity'
+  | (string & {})
+
+export interface FieldMeta {
+  /** Human label for any displayable field. Required. */
+  label: string
+  description?: string
+  semanticType?: SemanticType
+  /** Display unit, e.g. '€', '%', 'kg'. */
+  unit?: string
+  /** Data classification driving redaction/inspector masking. */
+  sensitivity?: 'public' | 'pii' | 'secret'
+  /** Default aggregation for this field. */
+  aggregate?: 'sum' | 'count' | 'distinct' | 'none'
+  /** Canonical search synonyms (data vocabulary, not UI). */
+  aliases?: readonly string[]
+  /** Entity pairing: the field holding the human label for this id (buyerId → buyerName). */
+  displayFor?: string
+}
+
+export class FieldMetaUnknownFieldError extends Error {
+  constructor(public readonly collection: string, public readonly key: string) {
+    super(`fieldMeta for collection "${collection}" references unknown field "${key}". `
+      + `Declare it in the schema/config or remove the fieldMeta entry.`)
+    this.name = 'FieldMetaUnknownFieldError'
+  }
+}
+
+/** Reject fieldMeta keys that are not known fields (typo guard), fail-loud. */
+export function validateFieldMetaKeys(
+  collection: string,
+  fieldMeta: Record<string, FieldMeta>,
+  knownFields: ReadonlySet<string>,
+): void {
+  for (const key of Object.keys(fieldMeta)) {
+    if (!knownFields.has(key)) throw new FieldMetaUnknownFieldError(collection, key)
+  }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `npm test -w @noy-db/hub -- field-meta`
+Expected: PASS.
+
+- [ ] **Step 5: Thread `fieldMeta` through collection options + storage**
+
+In `packages/hub/src/vault.ts`:
+- Add to the `CollectionOptions<T>` interface (next to `dictKeyFields`/`moneyFields`):
+  ```ts
+  /** Consumer-neutral per-field descriptors (label/unit/semanticType/sensitivity…). See collection.describe(). */
+  readonly fieldMeta?: Record<string, import('./introspection/field-meta.js').FieldMeta>
+  ```
+- In the collection-construction block (mirror how `dictKeyFields` is captured and passed into `new Collection(...)`), pass `fieldMeta: options.fieldMeta` into the constructor opts.
+- The known-field set for validation: combine the keys of `options.moneyFields`, `options.dictKeyFields`, `options.refs`, `options.computed`, plus fields derivable from the schema. Since exact schema fields need async derivation, validate against the **union of all declared config keys plus the fieldMeta keys already covered by schema** — to keep this sync, validate that each `fieldMeta` key is either (a) a declared config key, or (b) accept it otherwise but defer strict schema-field validation. **Decision (YAGNI + fail-loud where cheap):** validate `fieldMeta` keys against the union of config keys; do not reject keys that may be plain schema fields. Call:
+  ```ts
+  if (options.fieldMeta) {
+    const known = new Set<string>([
+      ...Object.keys(options.moneyFields ?? {}),
+      ...Object.keys(options.dictKeyFields ?? {}),
+      ...Object.keys(options.refs ?? {}),
+      ...Object.keys(options.computed ?? {}),
+      ...Object.keys(options.fieldMeta), // schema fields: accepted (not strictly checkable sync)
+    ])
+    validateFieldMetaKeys(name, options.fieldMeta, known)
+  }
+  ```
+  > Note: this catches typos against config-derived fields. A stricter schema-field check belongs to the async path (Task 4) where the derived JSON Schema is available; do not add it here.
+
+In `packages/hub/src/collection.ts`:
+- Add a private field mirroring `dictKeyFields`: `private readonly fieldMeta: Record<string, FieldMeta> | undefined` and assign from `opts.fieldMeta` in the constructor.
+- Add a getter:
+  ```ts
+  /** The declared consumer-neutral field metadata channel (canonical). */
+  getFieldMeta(): Record<string, FieldMeta> | undefined { return this.fieldMeta }
+  ```
+- Import `FieldMeta` (type-only) from `./introspection/field-meta.js`.
+
+- [ ] **Step 6: Run the hub suite + arch check**
+
+Run: `npm test -w @noy-db/hub`
+Expected: PASS.
+Run: `node scripts/check-architecture.mjs`
+Expected: PASS (collection.ts/vault.ts edits are tiny — getter + option threading — well under ceilings 5285/4610).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/hub/src/introspection/field-meta.ts packages/hub/src/introspection/field-meta.test.ts packages/hub/src/vault.ts packages/hub/src/collection.ts
+git commit -m "feat(hub): fieldMeta collection option + storage + fail-loud key check (#483)"
+```
+
+---
+
+### Task 2: Pure merge + inference
+
+**Files:**
+- Modify: `packages/hub/src/introspection/field-meta.ts` (add `mergeFieldMeta`)
+- Test: `packages/hub/src/introspection/field-meta.test.ts`
+
+**Interfaces:**
+- Consumes: `FieldMeta`.
+- Produces:
+  ```ts
+  interface MergeInputs {
+    channel?: FieldMeta                 // from fieldMeta option (highest)
+    zodMeta?: Partial<FieldMeta>        // from zod-4 .meta() (async path only)
+    inferred?: Partial<FieldMeta>       // from money/refs/format
+  }
+  function resolveFieldMeta(key: string, inputs: MergeInputs): ResolvedMeta
+  ```
+  where `ResolvedMeta` has `label: string` (always — falls back to humanized key) plus the optional members.
+- `humanizeFieldKey(key: string): string` (e.g. `saleDate` → `Sale Date`, `numberT` → `Number T`).
+
+- [ ] **Step 1: Write failing tests for precedence + inference + humanize**
+
+Append to `field-meta.test.ts`:
+```ts
+import { resolveFieldMeta, humanizeFieldKey } from './field-meta.js'
+
+describe('humanizeFieldKey', () => {
+  it('splits camelCase and title-cases', () => {
+    expect(humanizeFieldKey('saleDate')).toBe('Sale Date')
+    expect(humanizeFieldKey('buyerId')).toBe('Buyer Id')
+  })
+})
+
+describe('resolveFieldMeta precedence', () => {
+  it('channel label overrides inferred and zod', () => {
+    const r = resolveFieldMeta('total', {
+      channel: { label: 'Amount' },
+      zodMeta: { label: 'ZL', unit: '€' },
+      inferred: { label: 'Total', semanticType: 'currency', aggregate: 'sum' },
+    })
+    expect(r.label).toBe('Amount')        // channel wins
+    expect(r.unit).toBe('€')              // filled from zod (channel silent)
+    expect(r.semanticType).toBe('currency') // filled from inferred
+    expect(r.aggregate).toBe('sum')
+  })
+  it('falls back to humanized key when no label anywhere', () => {
+    expect(resolveFieldMeta('saleDate', { inferred: { semanticType: 'date' } }).label).toBe('Sale Date')
+  })
+  it('zod beats inferred when channel is silent', () => {
+    expect(resolveFieldMeta('x', { zodMeta: { label: 'FromZod' }, inferred: { label: 'FromInfer' } }).label)
+      .toBe('FromZod')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm test -w @noy-db/hub -- field-meta`
+Expected: FAIL — `resolveFieldMeta`/`humanizeFieldKey` not exported.
+
+- [ ] **Step 3: Implement merge + humanize**
+
+Append to `field-meta.ts`:
+```ts
+export interface MergeInputs {
+  channel?: FieldMeta
+  zodMeta?: Partial<FieldMeta>
+  inferred?: Partial<FieldMeta>
+}
+export interface ResolvedMeta extends Partial<FieldMeta> { label: string }
+
+/** camelCase / snake_case → Title Case words. */
+export function humanizeFieldKey(key: string): string {
+  return key
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .trim()
+    .split(/\s+/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ')
+}
+
+/** Merge one field's metadata: channel > zodMeta > inferred; label always present. */
+export function resolveFieldMeta(key: string, inputs: MergeInputs): ResolvedMeta {
+  const { channel, zodMeta, inferred } = inputs
+  const pick = <K extends keyof FieldMeta>(k: K): FieldMeta[K] | undefined =>
+    channel?.[k] ?? zodMeta?.[k] ?? inferred?.[k]
+  return {
+    label: pick('label') ?? humanizeFieldKey(key),
+    ...(pick('description') !== undefined ? { description: pick('description') } : {}),
+    ...(pick('semanticType') !== undefined ? { semanticType: pick('semanticType') } : {}),
+    ...(pick('unit') !== undefined ? { unit: pick('unit') } : {}),
+    ...(pick('sensitivity') !== undefined ? { sensitivity: pick('sensitivity') } : {}),
+    ...(pick('aggregate') !== undefined ? { aggregate: pick('aggregate') } : {}),
+    ...(pick('aliases') !== undefined ? { aliases: pick('aliases') } : {}),
+    ...(pick('displayFor') !== undefined ? { displayFor: pick('displayFor') } : {}),
+  }
+}
+```
+> The conditional spreads respect `exactOptionalPropertyTypes` (a known gotcha in this repo) — never assign `undefined` to an optional prop.
+
+- [ ] **Step 4: Run to verify passing**
+
+Run: `npm test -w @noy-db/hub -- field-meta`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/introspection/field-meta.ts packages/hub/src/introspection/field-meta.test.ts
+git commit -m "feat(hub): fieldMeta merge precedence + humanize (#483)"
+```
+
+---
+
+### Task 3: `collection.describe()` (sync) + exports
+
+**Files:**
+- Create: `packages/hub/src/introspection/describe.ts` (`buildDescription` pure assembler + `DescribedField`/`CollectionDescription` types)
+- Modify: `packages/hub/src/collection.ts` (add the sync `describe()` method)
+- Modify: `packages/hub/src/index.ts` (re-export the new public types + `FieldMeta`)
+- Test: `packages/hub/src/introspection/describe.test.ts`
+
+**Interfaces:**
+- Consumes: `Collection.getFieldMeta()`, the collection's `moneyFields`/`dictKeyFields`/`refs`/`computed` (add internal getters mirroring `getFieldMeta` if not already reachable), `resolveFieldMeta`, the vault `refRegistry.getOutbound(name)`.
+- Produces:
+  ```ts
+  interface CollectionDescription { readonly collection: string; readonly fields: readonly DescribedField[] }
+  interface DescribedField {
+    readonly key: string
+    readonly type: string            // sync: inferred from config; async: validator-derived
+    readonly optional: boolean
+    readonly constraints?: Record<string, unknown>
+    readonly label: string
+    readonly description?: string
+    readonly semanticType?: string
+    readonly unit?: string
+    readonly sensitivity?: 'public'|'pii'|'secret'
+    readonly aggregate?: 'sum'|'count'|'distinct'|'none'
+    readonly aliases?: readonly string[]
+    readonly ref?: { target: string; mode: string; isArray?: true }
+    readonly displayFor?: string
+    readonly money?: { mode: 'fixed'|'multi'; currency?: string; scale?: number; rounding?: string }
+    readonly dict?: { name: string; static: boolean; values?: readonly { value: string; label?: string }[] }
+    readonly computed?: true
+  }
+  Collection.describe(): CollectionDescription   // sync overload
+  ```
+
+- [ ] **Step 1: Write failing test (sync describe over a config-only collection)**
+
+In `describe.test.ts`, use the **real** harness: `createNoydb({ store: memory(), user, secret })` → `await db.openVault('v')` → `v.collection(name, { schema, moneyFields, dictKeyFields, refs, fieldMeta })`. Build a `sales` collection with a money field, a `staticDict` status, a `buyerId` ref, and a `fieldMeta` for `saleDate`/`total`/`buyerId`. Assert the merged output:
+```ts
+const d = sales.describe()
+const byKey = Object.fromEntries(d.fields.map((f) => [f.key, f]))
+expect(byKey.total.semanticType).toBe('currency')         // inferred from money
+expect(byKey.total.aggregate).toBe('sum')                 // inferred from money
+expect(byKey.total.unit).toBe('€')                        // from fieldMeta
+expect(byKey.total.money).toMatchObject({ mode: 'fixed', currency: 'EUR' })
+expect(byKey.buyerId.semanticType).toBe('entity')         // inferred from ref
+expect(byKey.buyerId.ref).toMatchObject({ target: 'buyers' })
+expect(byKey.buyerId.displayFor).toBe('buyerName')        // from fieldMeta
+expect(byKey.status.dict).toMatchObject({ name: 'saleStatus', static: true })
+expect(byKey.status.dict.values).toEqual(
+  expect.arrayContaining([{ value: 'to_verify', label: 'To Verify' }]))  // staticDict labels surface sync
+expect(byKey.saleDate.label).toBe('Date')                 // from fieldMeta
+```
+Also assert **zero store I/O**: wrap the store so `list`/`get` throw, build the collection, and confirm `describe()` does not throw.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm test -w @noy-db/hub -- describe`
+Expected: FAIL — `describe` not a function.
+
+- [ ] **Step 3: Implement `buildDescription` (pure) + inference-from-config**
+
+Create `packages/hub/src/introspection/describe.ts`. `buildDescription` takes the collection's config maps + a `refs` map + an optional `zodFields` map (async path supplies it; sync path passes `undefined`) and returns `CollectionDescription`. Inference rules:
+- money field → `type:'number'`, `semanticType:'currency'`, `aggregate:'sum'`, `money:{…}` from the `MoneyDescriptor` (`mode`, `soleCurrency()` → currency, `scaleFor(currency)` → scale, `rounding`).
+- ref → `type:'string'` (or `'array'` if `isArray`), `semanticType:'entity'`, `ref:{target,mode,isArray?}`.
+- dictKey/staticDict → `type:'enum'`, `dict:{ name, static, values? }`. For `staticDict`, fill `values` from its in-code `table`/`keys` (the `displayLocale` label, else humanized key). For dynamic `dictKey`, `values` = declared `keys` mapped to `{value}` with **no label** (labels are async — Task 4).
+- computed → `computed:true`, `type` from `zodFields` if available else `'unknown'`.
+- plain schema field → `type` from `zodFields` if available else `'unknown'`.
+- `optional` from `zodFields` if available else `false`.
+Then `resolveFieldMeta(key, { channel: fieldMeta[key], zodMeta: zodFields?.[key]?.meta, inferred })` to fold in label/semanticType/unit/etc.
+
+The full field set (sync) = union of config keys (money/dict/ref/computed/fieldMeta) ∪ (zodFields keys when provided).
+
+- [ ] **Step 4: Add the sync `describe()` overload on `Collection`**
+
+In `collection.ts`:
+```ts
+describe(): CollectionDescription
+describe(opts: DescribeOptions): Promise<CollectionDescription>
+describe(opts?: DescribeOptions): CollectionDescription | Promise<CollectionDescription> {
+  if (opts) return this.describeAsync(opts)   // implemented in Task 4
+  return buildDescription({
+    collection: this.name,
+    fieldMeta: this.fieldMeta,
+    moneyFields: this.moneyFields,
+    dictKeyFields: this.dictKeyFields,
+    computed: this.computed,
+    refs: this.refRegistryOutbound(),   // small helper returning refRegistry.getOutbound(this.name)
+    zodFields: undefined,
+  })
+}
+```
+(If `describeAsync` doesn't exist yet, have the sync path only this task; add the `opts` overload signature but throw `new Error('async describe lands in Task 4')` for the opts branch, then wire it in Task 4. Prefer: implement sync now, leave a clearly-commented stub for the async branch.)
+
+- [ ] **Step 5: Re-export public types from `src/index.ts`**
+
+Add to `packages/hub/src/index.ts`:
+```ts
+// field metadata (#483)
+export type { FieldMeta, SemanticType } from './introspection/field-meta.js'
+export type { CollectionDescription, DescribedField, DescribeOptions } from './introspection/describe.js'
+```
+Do NOT add to `kernel/index.ts`.
+
+- [ ] **Step 6: Run tests + build + showcase typecheck (catches barrel gaps)**
+
+Run: `npm test -w @noy-db/hub -- describe`
+Expected: PASS.
+Run: `npm run build -w @noy-db/hub`
+Expected: build succeeds (showcase resolves `@noy-db/hub` from `dist/`).
+Run: `npm run typecheck -w showcases` (or the repo's showcase typecheck script — check `package.json`)
+Expected: PASS — proves the new public types are actually re-exported from the package entry, not just `../src`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/hub/src/introspection/describe.ts packages/hub/src/introspection/describe.test.ts packages/hub/src/collection.ts packages/hub/src/index.ts
+git commit -m "feat(hub): collection.describe() sync config-merge + public exports (#483)"
+```
+
+---
+
+### Task 4: async `describe(opts)` — exact types, zod-4 meta merge, dynamic dict labels
+
+**Files:**
+- Modify: `packages/hub/src/introspection/describe.ts` (a `deriveZodFields` helper + `DescribeOptions`)
+- Modify: `packages/hub/src/collection.ts` (`describeAsync`)
+- Test: `packages/hub/src/introspection/describe.test.ts`
+
+**Interfaces:**
+- Consumes: `derivePersistedSchema` + `isZod4Schema` (Plan 1), the existing JSON-Schema→field mapper in `introspection/fields.ts`, `vault.dictionary(name).list()` for dynamic dict labels.
+- Produces:
+  ```ts
+  interface DescribeOptions { readonly resolveDictLabels?: boolean }
+  Collection.describe(opts: DescribeOptions): Promise<CollectionDescription>
+  ```
+  The async path ALWAYS derives exact validator types (`type`/`optional`/`constraints`) and merges zod-4 `.meta()` registry metadata; `resolveDictLabels` additionally fills dynamic-dict `values[].label`.
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `describe.test.ts`:
+```ts
+it('async describe derives exact types from the validator', async () => {
+  const d = await sales.describe({})
+  const byKey = Object.fromEntries(d.fields.map((f) => [f.key, f]))
+  expect(byKey.saleDate.type).toBe('string')   // from schema, not 'unknown'
+  expect(byKey.total.type).toBe('number')
+})
+
+it('async describe merges zod-4 .meta() when channel is silent', async () => {
+  // a collection whose schema field carries z.number().meta({ unit: 'kg' }) and no fieldMeta for it
+  const d = await weights.describe({})
+  const w = d.fields.find((f) => f.key === 'net')!
+  expect(w.unit).toBe('kg')
+})
+
+it('resolveDictLabels fills dynamic dict labels (async, reads _dict_)', async () => {
+  await v.dictionary('priority').putAll([{ key: 'hi', labels: { en: 'High' } }])
+  const d = await tickets.describe({ resolveDictLabels: true })
+  const p = d.fields.find((f) => f.key === 'priority')!
+  expect(p.dict?.values).toEqual(expect.arrayContaining([{ value: 'hi', label: 'High' }]))
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm test -w @noy-db/hub -- describe`
+Expected: FAIL — async overload throws the Task-3 stub / labels not resolved.
+
+- [ ] **Step 3: Implement `deriveZodFields` + zod-meta extraction**
+
+In `describe.ts`, add `async function deriveZodFields(schema): Promise<Record<string, { type: string; optional: boolean; constraints?: Record<string,unknown>; meta?: Partial<FieldMeta> }>>`:
+- Call `derivePersistedSchema(schema)`; if `jsonSchema` is null, return `{}`.
+- Walk the JSON Schema `properties` using the existing mapper in `introspection/fields.ts` to get `type`/`constraints`/`optional` per field.
+- For zod-4 (`isZod4Schema(schema)`), zod's `toJSONSchema` emits registry `.meta()` keys into each property; read recognized keys (`label`, `description`, `unit`, `semanticType`, `sensitivity`, `aggregate`, `aliases`, `displayFor`) into `meta`. (Confirm during implementation which keys zod surfaces; map 1:1, ignore unknown.)
+
+- [ ] **Step 4: Implement `describeAsync` on `Collection`**
+
+```ts
+private async describeAsync(opts: DescribeOptions): Promise<CollectionDescription> {
+  const zodFields = this.schema ? await deriveZodFields(this.schema) : undefined
+  let dictLabels: Record<string, Record<string, string>> | undefined
+  if (opts.resolveDictLabels) dictLabels = await this.resolveDynamicDictLabels()  // reads vault.dictionary(name).list()
+  return buildDescription({
+    collection: this.name,
+    fieldMeta: this.fieldMeta,
+    moneyFields: this.moneyFields,
+    dictKeyFields: this.dictKeyFields,
+    computed: this.computed,
+    refs: this.refRegistryOutbound(),
+    zodFields,
+    dictLabels,
+  })
+}
+```
+Extend `buildDescription` to accept `zodFields` (exact types + zod meta) and `dictLabels` (dynamic-dict value→label) and fold them in (zod meta enters `resolveFieldMeta` as `zodMeta`; dictLabels populate dynamic `dict.values[].label`). Replace the Task-3 stub branch in `describe()` so `opts` routes to `describeAsync`.
+
+- [ ] **Step 5: Run tests + arch check**
+
+Run: `npm test -w @noy-db/hub -- describe`
+Expected: PASS.
+Run: `node scripts/check-architecture.mjs`
+Expected: PASS.
+
+- [ ] **Step 6: Validator-agnostic test (guards the core invariant)**
+
+Add a test building a collection with a **non-zod** Standard-Schema validator (a hand-rolled `{ '~standard': { version:1, vendor:'stub', validate } }`) plus a `fieldMeta` channel; assert `describe()` (sync) and `await describe({})` both return the channel metadata and never throw (no zod required). This proves the channel path is fully validator-agnostic.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/hub/src/introspection/describe.ts packages/hub/src/introspection/describe.test.ts packages/hub/src/collection.ts
+git commit -m "feat(hub): async describe() — exact types, zod-4 meta merge, dynamic dict labels (#483)"
+```
+
+---
+
+### Task 5: Showcase, docs, features.yaml
+
+**Files:**
+- Create: `showcases/src/126-describe-field-metadata.showcase.test.ts` (verify the next free number with `ls showcases/src | tail`)
+- Modify: `docs/subsystems/` (the introspection/schema doc, or create `field-metadata.md`)
+- Modify: `features.yaml`
+- Modify: `MEMORY.md` pointer + the relevant memory file (post-merge bookkeeping; optional in-branch)
+
+**Interfaces:**
+- Consumes: the public `describe()` API + `FieldMeta`.
+
+- [ ] **Step 1: Write the showcase (acts as the integration test + doc)**
+
+Create `showcases/src/126-describe-field-metadata.showcase.test.ts` importing from `@noy-db/hub` + `@noy-db/to-memory`. Build a `sales` collection with `schema`/`moneyFields`/`dictKeyFields`/`refs`/`fieldMeta`; show two consumers reading ONE source: (a) render a table header row from `describe().fields.map(f => f.label)`; (b) build an export column spec from the same `describe()` (label + which fields are `sensitivity!=='public'`). Assert the rendered headers and that PII fields are flagged.
+
+- [ ] **Step 2: Run the showcase**
+
+Run: `npm test -w showcases -- 126`
+Expected: PASS.
+
+- [ ] **Step 3: Add the `field-metadata` node to `features.yaml`**
+
+Add a node keyed to this feature with `spec: docs/superpowers/specs/2026-06-25-field-metadata-foundation-design.md`, the public symbols (`collection.describe`, `fieldMeta`), the showcase path, and invariants (descriptive-not-prescriptive; merge precedence; sync no-store-IO). Mirror the shape of an existing node (e.g. `vector-search`).
+
+- [ ] **Step 4: Verify the spec-coverage gate**
+
+Run: `node scripts/check-architecture.mjs` and the features.yaml coverage check (the script CI runs for "Spec coverage" — find it via `grep -rn "Spec coverage\|features.yaml" .github/workflows scripts`).
+Expected: PASS — no dangling refs.
+
+- [ ] **Step 5: Write the subsystem doc**
+
+Document `describe()` (sync vs async), the `fieldMeta` channel, merge precedence, the scope boundary (descriptive not prescriptive), and the two-consumer pattern (table + export). One short page.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add showcases/src/126-describe-field-metadata.showcase.test.ts features.yaml docs
+git commit -m "docs(hub): field-metadata showcase + subsystem doc + features.yaml node (#483)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (#483 portion):**
+- `fieldMeta` channel (canonical, agnostic) → Task 1. ✓
+- Merge precedence channel > zod-4 .meta() > inferred → Task 2 (pure) + Task 4 (zod tier). ✓
+- Inference from money/refs/format → Task 3. ✓
+- `collection.describe()` normalized, sync, config-only, zero store I/O → Task 3 (+ I/O-free assertion). ✓
+- Extends existing FieldDescriptor vocabulary / reuses fields.ts mapper → Task 4 Step 3. ✓
+- Async dynamic-dict labels via `_dict_*` → Task 4. ✓
+- staticDict labels surface sync (#485 partial) → Task 3 Step 1/3. ✓
+- Validator-agnostic (works without zod) → Task 4 Step 6. ✓
+- Public exports from index.ts only, not kernel → Task 3 Step 5. ✓
+- Showcase + features.yaml + docs → Task 5. ✓
+- Portability / kernel ceilings untouched → arch-check in Tasks 1/3/4. ✓
+- displayFor / aliases / sensitivity members → Task 1 type. ✓ (sensitivity here = #486's hub half.)
+
+**Placeholder scan:** Task 3 Step 4 intentionally allows a stubbed async branch wired in Task 4 — this is a sequencing handoff, not a placeholder (the sync deliverable is complete and testable on its own). All code steps carry concrete code. The few "confirm during implementation which keys zod surfaces" notes (Task 4 Step 3) are empirical-verification instructions, like Plan 1 — they have a concrete default (map recognized keys 1:1, ignore unknown).
+
+**Type consistency:** `FieldMeta`, `resolveFieldMeta`, `buildDescription`, `DescribedField`, `CollectionDescription`, `DescribeOptions`, `deriveZodFields`, `getFieldMeta` are used consistently across tasks. `describe()` overload signature identical in Tasks 3 and 4.
+
+**Refinement vs spec (flag to controller):** the spec described `describe()` as sync with `{resolveDictLabels}` async opt-in; this plan keeps that and additionally makes exact validator-derived `type`/`constraints` and the zod-4 `.meta()` merge part of the async path (sync infers `type` from config). Reason: validator type derivation needs the lazy `import('zod')`, which is inherently async; forcing it sync would break the no-store/no-static-import constraints. This is faithful to the spec's intent (cheap sync default, async for the expensive parts).

--- a/docs/superpowers/plans/2026-06-25-field-metadata-2-describe.md
+++ b/docs/superpowers/plans/2026-06-25-field-metadata-2-describe.md
@@ -486,22 +486,26 @@ private async describeAsync(opts: DescribeOptions): Promise<CollectionDescriptio
 ```
 Extend `buildDescription` to accept `zodFields` (exact types + zod meta) and `dictLabels` (dynamic-dict value→label) and fold them in (zod meta enters `resolveFieldMeta` as `zodMeta`; dictLabels populate dynamic `dict.values[].label`). Replace the Task-3 stub branch in `describe()` so `opts` routes to `describeAsync`.
 
-- [ ] **Step 5: Run tests + arch check**
+- [ ] **Step 5: Relocate real fieldMeta key-validation here (carry from Task 1)**
+
+Task 1's sync `validateFieldMetaKeys` call in `vault.ts` is a structural **no-op** — the known-field set there includes `fieldMeta`'s own keys, so it can never throw (schema field names aren't knowable synchronously). The async path is where validation becomes meaningful. In `describeAsync` (or `buildDescription` when `zodFields` is present), build the real known set = config keys (`moneyFields`/`dictKeyFields`/`refs`/`computed`) ∪ **`zodFields` keys (the derived schema fields)**, and call `validateFieldMetaKeys(this.name, this.fieldMeta ?? {}, realKnown)` so a typo'd `fieldMeta` key (e.g. `totl` for `total`) throws `FieldMetaUnknownFieldError` at first async `describe()`. Add a test: a collection whose `fieldMeta` references a non-existent field → `await c.describe({})` rejects with `FieldMetaUnknownFieldError`. Also **remove the misleading no-op** from `vault.ts`: delete the `Object.keys(options.fieldMeta)` self-inclusion + the `validateFieldMetaKeys` call there (keep the option threading), since it advertises a guarantee it can't honor. (This resolves the Task-1 review's Important plan-mandated finding.)
+
+- [ ] **Step 6: Run tests + arch check**
 
 Run: `npm test -w @noy-db/hub -- describe`
 Expected: PASS.
 Run: `node scripts/check-architecture.mjs`
 Expected: PASS.
 
-- [ ] **Step 6: Validator-agnostic test (guards the core invariant)**
+- [ ] **Step 7: Validator-agnostic test (guards the core invariant)**
 
 Add a test building a collection with a **non-zod** Standard-Schema validator (a hand-rolled `{ '~standard': { version:1, vendor:'stub', validate } }`) plus a `fieldMeta` channel; assert `describe()` (sync) and `await describe({})` both return the channel metadata and never throw (no zod required). This proves the channel path is fully validator-agnostic.
 
-- [ ] **Step 7: Commit**
+- [ ] **Step 8: Commit**
 
 ```bash
-git add packages/hub/src/introspection/describe.ts packages/hub/__tests__/introspection/describe.test.ts packages/hub/src/collection.ts
-git commit -m "feat(hub): async describe() — exact types, zod-4 meta merge, dynamic dict labels (#483)"
+git add packages/hub/src/introspection/describe.ts packages/hub/__tests__/introspection/describe.test.ts packages/hub/src/collection.ts packages/hub/src/vault.ts
+git commit -m "feat(hub): async describe() — exact types, zod-4 meta merge, dynamic dict labels + key validation (#483)"
 ```
 
 ---

--- a/docs/superpowers/plans/2026-06-25-field-metadata-2-describe.md
+++ b/docs/superpowers/plans/2026-06-25-field-metadata-2-describe.md
@@ -16,6 +16,8 @@
 - **Litmus test invariant:** a field-metadata key is admissible only if *"a second, unrelated consumer would want this fact."*
 - Merge precedence (highest wins): `fieldMeta` channel → zod-4 `.meta()` registry → inferred-from-config.
 - `describe()` (sync) does **zero store I/O** (no decryption). Only the async overload touches `_dict_*`.
+- **Test file location:** ALL test files go under `packages/hub/__tests__/introspection/` — NOT `src/`. Vitest's include glob is `__tests__/**/*.test.ts`, so a `.test.ts` placed under `src/` is **silently ignored** (won't run → false green). Import the module under test via `../../src/introspection/<file>.js`. The `Test:` paths in the tasks below say `src/introspection/...` for locality — place them under `__tests__/introspection/...` and adjust import depth.
+- **Package manager is pnpm** (not npm) for installs; `npm test -w @noy-db/hub` works for running tests.
 - New public symbols require re-export from `src/index.ts` (a recurring gap: local tsc passes because tests import `../src/`; only the showcase + CI cross-package typecheck against `dist/` catch a missing barrel export — so verify by building + showcase typecheck). Do **not** add to `src/kernel/index.ts` (per-collection introspection is not orchestration surface).
 - Every feature change must touch `features.yaml` or CI "Spec coverage" fails.
 - No Claude attribution in commits.
@@ -29,7 +31,7 @@
 - Create: `packages/hub/src/introspection/field-meta.ts` (the `FieldMeta` type + helpers)
 - Modify: `packages/hub/src/vault.ts` — add `fieldMeta?` to the `CollectionOptions<T>` interface (the interface defining `schema`/`refs`/`moneyFields`/`dictKeyFields`, ~`vault.ts:672-767`) and register it in the collection-construction block (~`vault.ts:801-971`, where `refs`/`dictKeyFields` are registered and threaded into `new Collection(...)`)
 - Modify: `packages/hub/src/collection.ts` — accept + store `fieldMeta` on the Collection (mirror the `dictKeyFields` private field at ~`collection.ts:360`/assignment ~`collection.ts:970`) and add a getter
-- Test: `packages/hub/src/introspection/field-meta.test.ts`
+- Test: `packages/hub/__tests__/introspection/field-meta.test.ts`
 
 **Interfaces:**
 - Produces:
@@ -40,7 +42,7 @@
 
 - [ ] **Step 1: Write the `FieldMeta` type and a validation helper (failing test first)**
 
-In `packages/hub/src/introspection/field-meta.test.ts`:
+In `packages/hub/__tests__/introspection/field-meta.test.ts`:
 ```ts
 import { describe, it, expect } from 'vitest'
 import { validateFieldMetaKeys } from './field-meta.js'
@@ -167,7 +169,7 @@ Expected: PASS (collection.ts/vault.ts edits are tiny — getter + option thread
 - [ ] **Step 7: Commit**
 
 ```bash
-git add packages/hub/src/introspection/field-meta.ts packages/hub/src/introspection/field-meta.test.ts packages/hub/src/vault.ts packages/hub/src/collection.ts
+git add packages/hub/src/introspection/field-meta.ts packages/hub/__tests__/introspection/field-meta.test.ts packages/hub/src/vault.ts packages/hub/src/collection.ts
 git commit -m "feat(hub): fieldMeta collection option + storage + fail-loud key check (#483)"
 ```
 
@@ -177,7 +179,7 @@ git commit -m "feat(hub): fieldMeta collection option + storage + fail-loud key 
 
 **Files:**
 - Modify: `packages/hub/src/introspection/field-meta.ts` (add `mergeFieldMeta`)
-- Test: `packages/hub/src/introspection/field-meta.test.ts`
+- Test: `packages/hub/__tests__/introspection/field-meta.test.ts`
 
 **Interfaces:**
 - Consumes: `FieldMeta`.
@@ -282,7 +284,7 @@ Expected: PASS.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add packages/hub/src/introspection/field-meta.ts packages/hub/src/introspection/field-meta.test.ts
+git add packages/hub/src/introspection/field-meta.ts packages/hub/__tests__/introspection/field-meta.test.ts
 git commit -m "feat(hub): fieldMeta merge precedence + humanize (#483)"
 ```
 
@@ -294,7 +296,7 @@ git commit -m "feat(hub): fieldMeta merge precedence + humanize (#483)"
 - Create: `packages/hub/src/introspection/describe.ts` (`buildDescription` pure assembler + `DescribedField`/`CollectionDescription` types)
 - Modify: `packages/hub/src/collection.ts` (add the sync `describe()` method)
 - Modify: `packages/hub/src/index.ts` (re-export the new public types + `FieldMeta`)
-- Test: `packages/hub/src/introspection/describe.test.ts`
+- Test: `packages/hub/__tests__/introspection/describe.test.ts`
 
 **Interfaces:**
 - Consumes: `Collection.getFieldMeta()`, the collection's `moneyFields`/`dictKeyFields`/`refs`/`computed` (add internal getters mirroring `getFieldMeta` if not already reachable), `resolveFieldMeta`, the vault `refRegistry.getOutbound(name)`.
@@ -403,7 +405,7 @@ Expected: PASS — proves the new public types are actually re-exported from the
 - [ ] **Step 7: Commit**
 
 ```bash
-git add packages/hub/src/introspection/describe.ts packages/hub/src/introspection/describe.test.ts packages/hub/src/collection.ts packages/hub/src/index.ts
+git add packages/hub/src/introspection/describe.ts packages/hub/__tests__/introspection/describe.test.ts packages/hub/src/collection.ts packages/hub/src/index.ts
 git commit -m "feat(hub): collection.describe() sync config-merge + public exports (#483)"
 ```
 
@@ -414,7 +416,7 @@ git commit -m "feat(hub): collection.describe() sync config-merge + public expor
 **Files:**
 - Modify: `packages/hub/src/introspection/describe.ts` (a `deriveZodFields` helper + `DescribeOptions`)
 - Modify: `packages/hub/src/collection.ts` (`describeAsync`)
-- Test: `packages/hub/src/introspection/describe.test.ts`
+- Test: `packages/hub/__tests__/introspection/describe.test.ts`
 
 **Interfaces:**
 - Consumes: `derivePersistedSchema` + `isZod4Schema` (Plan 1), the existing JSON-Schema→field mapper in `introspection/fields.ts`, `vault.dictionary(name).list()` for dynamic dict labels.
@@ -498,7 +500,7 @@ Add a test building a collection with a **non-zod** Standard-Schema validator (a
 - [ ] **Step 7: Commit**
 
 ```bash
-git add packages/hub/src/introspection/describe.ts packages/hub/src/introspection/describe.test.ts packages/hub/src/collection.ts
+git add packages/hub/src/introspection/describe.ts packages/hub/__tests__/introspection/describe.test.ts packages/hub/src/collection.ts
 git commit -m "feat(hub): async describe() — exact types, zod-4 meta merge, dynamic dict labels (#483)"
 ```
 

--- a/docs/superpowers/plans/2026-06-25-metadata-ladder-and-schema-surfacing.md
+++ b/docs/superpowers/plans/2026-06-25-metadata-ladder-and-schema-surfacing.md
@@ -1,0 +1,488 @@
+# Metadata Ladder + Schema Surfacing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the descriptive metadata ladder (`collectionMeta` + `vaultMeta` atop the existing `fieldMeta`) and make the live devtools surface the full schema picture (rich per-field `describe()` + collection-level config + the meta ladder).
+
+**Architecture:** Extends the just-built `fieldMeta`/`describe()`/`buildDescription` foundation on branch `feat/field-metadata-foundation`. Hub gains two new descriptor layers (collection + vault meta), three per-field `describe()` enhancements (i18n/widget/editable), and a collection-level `config` block on `dumpSchema()`. Then `in-devtools` `snapshot()` merges `describe()`+config+meta and the Nuxt/TUI viewers render it. Descriptive-only; code options, not persisted; live-devtools path only (CLI deferred).
+
+**Tech Stack:** TypeScript, Vitest, Standard Schema v1, Vue (Nuxt devtools), Ink/React (TUI).
+
+## Global Constraints
+
+- **Builds on `feat/field-metadata-foundation`** (PR #490): `fieldMeta`, `collection.describe()` (sync + async), `buildDescription` in `introspection/describe.ts`, `FieldMeta`/`DescribedField`/`CollectionDescription` types, `getFieldMeta()`/`_applyFieldMeta()` on Collection. Do NOT switch branches.
+- **Descriptive, never prescriptive.** Meta = label/description/icon/pluralLabel only. No layout/order/styling/active-locale.
+- hub stays **validator-agnostic**: no static `import 'zod'` in `packages/hub/src`.
+- `describe()` (sync, zero-arg) does **zero store I/O**.
+- **Test files live under `packages/hub/__tests__/**`** (and each package's `__tests__`/test dir) — a `.test.ts` under `src/` is silently ignored by vitest. Import the module under test via the correct relative depth.
+- **Package manager is pnpm**; `npm test --prefix packages/<pkg> -- <pattern>` runs focused tests. The DTS **build** (`npm run build --prefix packages/hub`) is stricter than vitest tsc under `exactOptionalPropertyTypes` — run it. Use conditional spreads for optional props; never assign `undefined`.
+- New public symbols re-export from `src/index.ts`; the meta **types** (`CollectionMeta`, `VaultMeta`) ALSO export from `src/kernel/index.ts` (klum-db contract). Verify barrels via `npm run build --prefix packages/hub` + showcase typecheck.
+- Kernel-surface ceilings (collection.ts, vault.ts, noydb.ts) enforced by `scripts/check-architecture.mjs` — raise minimally with a justification comment if needed.
+- No `Co-Authored-By: Claude` / "Generated with Claude Code" in commits.
+- Spec: `docs/superpowers/specs/2026-06-25-metadata-ladder-and-schema-surfacing-design.md`.
+
+---
+
+### Task 1: Meta types + `collectionMeta`
+
+**Files:**
+- Create: `packages/hub/src/introspection/meta.ts`
+- Modify: `packages/hub/src/vault.ts` (CollectionOptions ~672-770; cached-collection reconcile branch ~805-822 next to `_applyFieldMeta`)
+- Modify: `packages/hub/src/collection.ts` (store + getter + reconciler, mirror `getFieldMeta`@1173 / `_applyFieldMeta`@1264)
+- Modify: `packages/hub/src/introspection/describe.ts` (CollectionDescription + buildDescription)
+- Modify: `packages/hub/src/introspection/types.ts` (CollectionDescriptor)
+- Modify: `packages/hub/src/introspection/walk.ts` (populate descriptor.meta)
+- Modify: `packages/hub/src/index.ts` + `packages/hub/src/kernel/index.ts` (exports)
+- Test: `packages/hub/__tests__/introspection/meta.test.ts`
+
+**Interfaces:**
+- Produces: `CollectionMeta { label?: string; description?: string; icon?: string; pluralLabel?: string }`; `CollectionOptions.meta?: CollectionMeta`; `Collection.getMeta(): CollectionMeta | undefined`; `Collection._applyMeta(meta: CollectionMeta): void` (first-wins); `CollectionDescription.meta?: CollectionMeta` (label defaults to humanized collection name); `CollectionDescriptor.meta?: CollectionMeta`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/hub/__tests__/introspection/meta.test.ts` (real harness: `createNoydb({store: memory(), user, secret})` → `await db.openVault('v')` → `v.collection(name, {meta})`):
+```ts
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../../src/index.js'
+import { memory } from '@noy-db/to-memory'
+
+describe('collectionMeta', () => {
+  it('surfaces collection meta in describe() with label fallback', async () => {
+    const db = createNoydb({ store: memory(), user: 'u', secret: 's' })
+    const v = await db.openVault('v')
+    const sales = v.collection('sales', { meta: { label: 'Sales', description: 'Invoices', icon: 'receipt' } })
+    expect(sales.describe().meta).toMatchObject({ label: 'Sales', description: 'Invoices', icon: 'receipt' })
+    const plain = v.collection('line_items', {})
+    expect(plain.describe().meta?.label).toBe('Line Items')   // humanized fallback
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm test --prefix packages/hub -- meta`
+Expected: FAIL — `meta` not on options / not on describe output.
+
+- [ ] **Step 3: Create the meta types**
+
+`packages/hub/src/introspection/meta.ts`:
+```ts
+/**
+ * Descriptive metadata for the collection and vault levels of the metadata
+ * ladder (field level = FieldMeta). Identity, not structure: label /
+ * description / icon only. Descriptive, never prescriptive.
+ * @module
+ */
+
+/** A collection's own descriptive metadata. */
+export interface CollectionMeta {
+  /** Friendly name; falls back to the humanized collection name. */
+  label?: string
+  description?: string
+  /** Semantic icon NAME (e.g. a Lucide key), not styling. */
+  icon?: string
+  /** Plural form for list headers ("Invoice" → "Invoices"). */
+  pluralLabel?: string
+}
+
+/** A vault's own descriptive metadata. */
+export interface VaultMeta {
+  label?: string
+  description?: string
+  icon?: string
+}
+```
+
+- [ ] **Step 4: Thread `meta` through collection options + storage + reconciler**
+
+In `vault.ts` CollectionOptions add (next to `fieldMeta`):
+```ts
+/** The collection's own descriptive metadata (label/description/icon). See collection.describe(). */
+meta?: import('./introspection/meta.js').CollectionMeta
+```
+Thread `meta: options.meta` into the `new Collection(...)` opts (mirror `fieldMeta`). In the cached-collection branch where `coll._applyFieldMeta(options.fieldMeta)` is called, add `if (options?.meta) coll._applyMeta(options.meta)`.
+
+In `collection.ts`: add `private readonly meta: CollectionMeta | undefined` assigned from `opts.meta`; mirror the getter + reconciler:
+```ts
+import type { CollectionMeta } from './introspection/meta.js'
+// ...
+/** The collection's declared descriptive metadata. */
+getMeta(): CollectionMeta | undefined { return this.meta }
+/** First-wins reconcile for MV-pre-created collections (mirrors _applyFieldMeta). */
+_applyMeta(meta: CollectionMeta): void { if (this.meta === undefined) (this as { meta: CollectionMeta | undefined }).meta = meta }
+```
+(Match how `_applyFieldMeta` mutates a `readonly` field — copy its exact technique.)
+
+- [ ] **Step 5: Surface in describe() + dumpSchema + humanize fallback**
+
+In `describe.ts`: add `meta?: CollectionMeta` to `CollectionDescription`; in the `describe()`/`describeAsync()` callers pass `meta: this.getMeta()` into `buildDescription`; in `buildDescription` set `meta` with a label fallback: `{ ...meta, label: meta?.label ?? humanizeFieldKey(collection) }` (reuse `humanizeFieldKey` for the collection name). Use a conditional spread so an all-undefined meta still yields `{ label: humanized }`.
+
+In `introspection/types.ts`: add `readonly meta?: CollectionMeta` to `CollectionDescriptor`.
+In `introspection/walk.ts`: where each `CollectionDescriptor` is built, set `meta` from the live collection's `getMeta()` when available (the live `Collection` is reachable via the vault; mirror however `walk.ts` already reaches collection instances — if it only has names, add the meta from `vault.collection(name).getMeta()` guarded by existence).
+
+- [ ] **Step 6: Exports**
+
+`src/index.ts`: `export type { CollectionMeta, VaultMeta } from './introspection/meta.js'`.
+`src/kernel/index.ts`: `export type { CollectionMeta, VaultMeta } from '../introspection/meta.js'`.
+(VaultMeta is exported now though used in Task 2 — one export edit.)
+
+- [ ] **Step 7: Run tests + build + arch**
+
+Run: `npm test --prefix packages/hub -- meta describe` → PASS.
+Run: `npm run build --prefix packages/hub` → DTS clean.
+Run: `node scripts/check-architecture.mjs` → OK.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/hub/src/introspection/meta.ts packages/hub/src/vault.ts packages/hub/src/collection.ts packages/hub/src/introspection/describe.ts packages/hub/src/introspection/types.ts packages/hub/src/introspection/walk.ts packages/hub/src/index.ts packages/hub/src/kernel/index.ts packages/hub/__tests__/introspection/meta.test.ts
+git commit -m "feat(hub): collectionMeta + meta types (CollectionMeta/VaultMeta) (#483)"
+```
+
+---
+
+### Task 2: `vaultMeta`
+
+**Files:**
+- Modify: `packages/hub/src/noydb.ts` (openVault opts ~501-504)
+- Modify: `packages/hub/src/vault.ts` (store + getter)
+- Modify: `packages/hub/src/introspection/types.ts` (VaultSchemaSnapshot)
+- Modify: `packages/hub/src/introspection/walk.ts` (populate snapshot.meta)
+- Test: `packages/hub/__tests__/introspection/meta.test.ts` (append)
+
+**Interfaces:**
+- Consumes: `VaultMeta` (Task 1).
+- Produces: `openVault(name, { locale?, create?, meta? })`; `Vault.getMeta(): VaultMeta | undefined`; `VaultSchemaSnapshot.meta?: VaultMeta`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `meta.test.ts`:
+```ts
+it('surfaces vaultMeta on dumpSchema, first-wins', async () => {
+  const db = createNoydb({ store: memory(), user: 'u', secret: 's' })
+  const v = await db.openVault('books', { meta: { label: 'Acme Books', description: '2026' } })
+  v.collection('sales', {})
+  const dump = await v.dumpSchema()
+  expect(dump.meta).toMatchObject({ label: 'Acme Books', description: '2026' })
+  // re-open with different meta → first-wins keeps original
+  const v2 = await db.openVault('books', { meta: { label: 'OTHER' } })
+  expect(v2.getMeta()?.label).toBe('Acme Books')
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm test --prefix packages/hub -- meta`
+Expected: FAIL — `meta` not accepted/surfaced.
+
+- [ ] **Step 3: Add `meta` to openVault + store first-wins on Vault**
+
+In `noydb.ts` openVault: widen `opts?: { locale?: string; create?: boolean; meta?: VaultMeta }` (import `VaultMeta` type-only). On the cache-hit path, do NOT overwrite (first-wins): only when constructing a fresh `Vault`, pass `meta: opts?.meta`. On cache hit, leave existing meta untouched (mirror how `locale` is handled but WITHOUT the update — meta is first-wins).
+
+In `vault.ts`: add `private readonly meta: VaultMeta | undefined` from `opts.meta`; add `getMeta(): VaultMeta | undefined { return this.meta }`.
+
+- [ ] **Step 4: Surface on the snapshot**
+
+In `introspection/types.ts`: add `readonly meta?: VaultMeta` to `VaultSchemaSnapshot`.
+In `walk.ts` `dumpVaultSchema`: set `meta` from the vault's `getMeta()` when present.
+
+- [ ] **Step 5: Run tests + build + arch**
+
+Run: `npm test --prefix packages/hub -- meta` → PASS.
+Run: `npm run build --prefix packages/hub` → clean. `node scripts/check-architecture.mjs` → OK.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/noydb.ts packages/hub/src/vault.ts packages/hub/src/introspection/types.ts packages/hub/src/introspection/walk.ts packages/hub/__tests__/introspection/meta.test.ts
+git commit -m "feat(hub): vaultMeta via openVault({meta}), first-wins (#483)"
+```
+
+---
+
+### Task 3: `describe()` per-field enhancements — i18n / widget / editable
+
+**Files:**
+- Modify: `packages/hub/src/introspection/field-meta.ts` (FieldMeta gains `widget?`)
+- Modify: `packages/hub/src/introspection/describe.ts` (DescribedField + buildDescription)
+- Modify: `packages/hub/src/collection.ts` (pass i18nFields into buildDescription)
+- Test: `packages/hub/__tests__/introspection/describe.test.ts` (append)
+
+**Interfaces:**
+- Produces: `FieldMeta.widget?: string`; `DescribedField` gains `i18n?: { locales?: readonly string[]; densify?: boolean }`, `widget?: string`, `editable: boolean`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `describe.test.ts` (build a collection with an `i18nFields` text field, a money field, a computed field, an `id`):
+```ts
+it('surfaces i18n, derived widget, and editable', async () => {
+  // sales: total (money), saleDate (z.iso.date), name (i18nText), subtotal (computed)
+  const d = sales.describe()
+  const by = Object.fromEntries(d.fields.map(f => [f.key, f]))
+  expect(by.total.widget).toBe('money')
+  expect(by.saleDate.widget).toBe('date')
+  expect(by.name.i18n).toBeDefined()            // i18n block present
+  expect(by.subtotal.editable).toBe(false)      // computed → read-only
+  expect(by.total.editable).toBe(true)
+})
+it('fieldMeta.widget overrides the derived widget', async () => {
+  const f = withWidgetOverride.describe().fields.find(x => x.key === 'note')!
+  expect(f.widget).toBe('textarea')             // fieldMeta:{ note:{ widget:'textarea' } }
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm test --prefix packages/hub -- describe`
+Expected: FAIL — i18n/widget/editable absent.
+
+- [ ] **Step 3: Implement**
+
+In `field-meta.ts`: add `widget?: string` to `FieldMeta`.
+
+In `describe.ts`:
+- Add to `DescribedField`: `readonly i18n?: { locales?: readonly string[]; densify?: boolean }`, `readonly widget?: string`, `readonly editable: boolean`.
+- `buildDescription` accepts a new `i18nFields?: Record<string, I18nTextDescriptor>` input (passed from the collection). For a field present in `i18nFields`, set `type:'string'` and an `i18n` block (`locales` from the descriptor's declared locales if available, `densify` from `densifyOnWrite`). Read the `I18nTextDescriptor` shape from `packages/hub/src/i18n/` to fill these (use only fields that exist; omit `locales` if the descriptor doesn't enumerate them).
+- Compute `widget` per the spec table (override with `fieldMeta.widget` / `zodMeta.widget` first):
+  ```ts
+  function deriveWidget(f: { semanticType?: string; type: string; dict?: unknown; widget?: string }): string {
+    if (f.widget) return f.widget
+    switch (f.semanticType) {
+      case 'date': case 'datetime': return 'date'
+      case 'currency': return 'money'
+      case 'entity': return 'ref-select'
+      case 'url': return 'url'
+      case 'email': return 'email'
+      case 'percent': return 'number'
+    }
+    if (f.dict) return 'select'
+    if (f.type === 'boolean') return 'checkbox'
+    if (f.type === 'number') return 'number'
+    return 'text'
+  }
+  ```
+  (Thread `fieldMeta.widget` into the resolved meta so it reaches here; `resolveFieldMeta` should carry `widget` through — add it to the picked keys.)
+- Compute `editable`: `false` if `computed`, if `key === 'id'`, or if the field is provenance-stamped (the collection's `provenance` option + the provenance field names); else `true`.
+
+In `collection.ts`: pass `i18nFields: this.i18nFields` (private field @323) into both `buildDescription` call-sites (sync + async).
+
+- [ ] **Step 4: Run tests + build**
+
+Run: `npm test --prefix packages/hub -- describe` → PASS.
+Run: `npm run build --prefix packages/hub` → clean (watch `exactOptionalPropertyTypes` on the new optional members; conditional spreads).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/introspection/field-meta.ts packages/hub/src/introspection/describe.ts packages/hub/src/collection.ts packages/hub/__tests__/introspection/describe.test.ts
+git commit -m "feat(hub): describe() i18n/widget/editable per-field enhancements (#483)"
+```
+
+---
+
+### Task 4: `dumpSchema()` collection-level `config` block
+
+**Files:**
+- Modify: `packages/hub/src/introspection/types.ts` (CollectionDescriptor.config)
+- Modify: `packages/hub/src/collection.ts` (a `getConfig()` aggregator)
+- Modify: `packages/hub/src/introspection/walk.ts` (populate descriptor.config)
+- Test: `packages/hub/__tests__/introspection/dump-schema.test.ts` (or the existing introspection dump test — check `__tests__/introspection/`)
+
+**Interfaces:**
+- Produces: `CollectionDescriptor.config?` (shape per spec Component 5); `Collection.getConfig(): CollectionConfig | undefined`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the existing `__tests__/introspection/dump-schema.test.ts`:
+```ts
+it('surfaces collection-level config (embeddings/textIndexes/crdt/provenance/tiers)', async () => {
+  // declare a collection with embeddings + textIndexes + provenance:true + tiers:[1,2]
+  const dump = await v.dumpSchema()
+  const cfg = dump.collections['docs'].config!
+  expect(cfg.textIndexes).toContain('body')
+  expect(cfg.provenance).toBe(true)
+  expect(cfg.tiers).toEqual([1, 2])
+  expect(cfg.embeddings?.dim).toBeGreaterThan(0)
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm test --prefix packages/hub -- dump-schema`
+Expected: FAIL — `config` undefined.
+
+- [ ] **Step 3: Implement**
+
+In `types.ts` add to `CollectionDescriptor`:
+```ts
+readonly config?: {
+  readonly i18nFields?: readonly string[]
+  readonly embeddings?: { source: string; dim: number; model?: string }
+  readonly textIndexes?: readonly string[]
+  readonly textIndexPersist?: boolean
+  readonly perRecordKeys?: boolean
+  readonly provenance?: boolean
+  readonly archive?: boolean
+  readonly tiers?: readonly number[]
+  readonly tierMode?: string
+  readonly crdt?: string
+  readonly conflictPolicy?: boolean
+  readonly history?: boolean
+  readonly schemaUpdate?: readonly string[]
+}
+```
+Export this object type as `CollectionConfig` for reuse.
+
+In `collection.ts` add `getConfig(): CollectionConfig | undefined` reading the existing private fields: `i18nFields`@323 (keys), `embeddings`@349 (source/dim/model), `textIndexes`@329, `provenance`@444, `tiers`@461 (Array.from), `tierMode`@462, `crdtMode`@496, `historyConfig`@183 (presence). For the fields without a private getter (textIndexPersist, perRecordKeys, conflictPolicy, schemaUpdate names) read the corresponding private fields — grep their declarations; surface function-valued ones (`conflictPolicy`) as a boolean presence. Return `undefined` when every entry would be empty.
+
+In `walk.ts`: set `descriptor.config` from the live `collection.getConfig()` when the live instance is available; omit for bundle-reconstructed collections.
+
+- [ ] **Step 4: Run tests + build + arch**
+
+Run: `npm test --prefix packages/hub -- dump-schema` → PASS.
+Run: `npm run build --prefix packages/hub` → clean. `node scripts/check-architecture.mjs` → OK.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/introspection/types.ts packages/hub/src/collection.ts packages/hub/src/introspection/walk.ts packages/hub/__tests__/introspection/dump-schema.test.ts
+git commit -m "feat(hub): dumpSchema collection-level config block (#483)"
+```
+
+---
+
+### Task 5: `in-devtools` snapshot enrichment
+
+**Files:**
+- Modify: `packages/in-devtools/src/types.ts` (InspectorCollection + InspectorSnapshot)
+- Modify: `packages/in-devtools/src/snapshot.ts`
+- Test: `packages/in-devtools/__tests__/snapshot.test.ts` (or the package's test dir — check)
+
+**Interfaces:**
+- Consumes: `collection.describe()`, `CollectionDescriptor.config`/`.meta`, `VaultSchemaSnapshot.meta`.
+- Produces: `InspectorCollection` gains `described?: readonly DescribedField[]`, `config?`, `meta?`; `InspectorSnapshot` gains `meta?: VaultMeta`.
+
+- [ ] **Step 1: Write the failing test**
+
+In the in-devtools test dir:
+```ts
+it('snapshot includes describe() per-field + config + meta', async () => {
+  // build a live vault with vaultMeta + a collection with meta + money + textIndexes
+  const snap = await snapshot(vault)
+  expect(snap.meta?.label).toBeDefined()
+  const c = snap.collections.find(x => x.name === 'sales')!
+  expect(c.meta?.label).toBe('Sales')
+  expect(c.described?.some(f => f.widget === 'money')).toBe(true)
+  expect(c.config).toBeDefined()
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npm test --prefix packages/in-devtools -- snapshot`
+Expected: FAIL — `described`/`config`/`meta` absent.
+
+- [ ] **Step 3: Implement**
+
+In `types.ts` extend `InspectorCollection` with `meta?`, `described?: readonly DescribedField[]`, `config?` (import the hub types from `@noy-db/hub`); extend `InspectorSnapshot` with `meta?: VaultMeta`.
+
+In `snapshot.ts`: keep the existing `dumpSchema({withStats:true})` call (for `fields`/`indexes`/`refs`/`stats`/`config`/`meta`), AND for each collection call `vault.collection(name).describe()` (sync) to get `described`; set `meta` from the descriptor's `meta`; set `config` from the descriptor's `config`; set the snapshot `meta` from `dump.meta`. Guard `vault.collection(name)` for collections that may not be live-declared (skip `described` if the call throws/returns no schema).
+
+- [ ] **Step 4: Run tests + build**
+
+Run: `npm test --prefix packages/in-devtools -- snapshot` → PASS.
+Run: `npm run build --prefix packages/in-devtools` → clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/in-devtools/src/types.ts packages/in-devtools/src/snapshot.ts packages/in-devtools/__tests__
+git commit -m "feat(in-devtools): enrich snapshot with describe() + config + meta (#483)"
+```
+
+---
+
+### Task 6: Nuxt devtools rendering
+
+**Files:**
+- Modify: `packages/in-nuxt/src/runtime/devtools/SchemaPane.vue`
+- Modify: `packages/in-nuxt/src/runtime/devtools/DevtoolsPanel.vue` (vault meta label)
+- Test: a shape/snapshot test if the package tests components; else verify typecheck + manual render notes
+
+**Interfaces:**
+- Consumes: the enriched `InspectorCollection` (`described`/`config`/`meta`) + `InspectorSnapshot.meta`.
+
+- [ ] **Step 1: Render the meta header + rich fields + config strip in SchemaPane.vue**
+
+Replace the minimal field rows with rows driven by `collection.described` when present (fall back to `collection.fields` for back-compat): show `label` (from described) + `type` + a `semanticType`/`widget` badge, money currency (`field.money?.currency`), dict value count, and **badges** for `sensitivity` (`pii`/`secret`) and `i18n`. Add a collection **meta header** (`collection.meta?.label ?? collection.name` + description) above the rows, and a collapsible **config strip** rendering `collection.config` (embeddings / textIndexes / crdt / provenance / archive / tiers as small badges). Keep the existing stats line.
+
+- [ ] **Step 2: Show vault meta label in DevtoolsPanel.vue**
+
+In the vault sidebar/header, render `snapshot.meta?.label ?? vaultName` (+ description tooltip if present).
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run build --prefix packages/in-nuxt` (or the package typecheck) → clean. If the package has a component test harness, add a render test asserting the sensitivity badge + meta header appear; otherwise note the manual-verification steps in the report.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/in-nuxt/src/runtime/devtools/SchemaPane.vue packages/in-nuxt/src/runtime/devtools/DevtoolsPanel.vue
+git commit -m "feat(in-nuxt): rich schema pane — meta header, field badges, config strip (#483)"
+```
+
+---
+
+### Task 7: TUI rendering + features.yaml + docs
+
+**Files:**
+- Modify: `packages/in-devtools-tui/src/**` (the structure/schema view)
+- Modify: `features.yaml`
+- Modify: `docs/subsystems/field-metadata.md` (extend) or a new `docs/subsystems/schema-introspection.md`
+- Test: existing TUI tests / snapshot
+
+**Interfaces:**
+- Consumes: the enriched `InspectorSnapshot`.
+
+- [ ] **Step 1: Mirror the rich rendering in the TUI**
+
+In the TUI structure view, render the collection `meta.label`, the rich fields (label/type/widget + sensitivity/i18n markers), and a compact config line. Reuse the same `InspectorCollection` fields as Nuxt.
+
+- [ ] **Step 2: Run TUI tests**
+
+Run: `npm test --prefix packages/in-devtools-tui` → PASS (update snapshot tests if the rendered output changed intentionally).
+
+- [ ] **Step 3: features.yaml + docs**
+
+Extend the `field-metadata` node (or add a `metadata-ladder` node) in `features.yaml` with `spec: docs/superpowers/specs/2026-06-25-metadata-ladder-and-schema-surfacing-design.md`, the new public surface (`collectionMeta`/`vaultMeta`/`describe().widget`), and the devtools surfacing; ensure no dangling refs. Document the metadata ladder + the devtools schema view in the subsystem doc.
+
+- [ ] **Step 4: Verify spec-coverage + arch**
+
+Run the features validator (`grep -rn "validate-features" scripts package.json`) → 0 dangling refs. `node scripts/check-architecture.mjs` → OK.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/in-devtools-tui features.yaml docs
+git commit -m "feat(in-devtools-tui): rich schema view + features.yaml + docs (#483)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Meta types (CollectionMeta/VaultMeta) + kernel export → Task 1/2. ✓
+- collectionMeta (option/storage/reconciler/describe/dumpSchema) → Task 1. ✓
+- vaultMeta (openVault option/first-wins/snapshot) → Task 2. ✓
+- describe() i18n/widget/editable + fieldMeta.widget → Task 3. ✓
+- dumpSchema config block (live-only, presence for fn-valued) → Task 4. ✓
+- in-devtools snapshot enrichment → Task 5. ✓
+- Nuxt SchemaPane + vault meta → Task 6. ✓
+- TUI + features.yaml + docs → Task 7. ✓
+- fieldMeta.group DEFERRED (spec Boundary note) — intentionally no task. ✓
+- CLI richness DEFERRED — intentionally no task. ✓
+
+**Placeholder scan:** code steps carry concrete code; plumbing steps cite exact line numbers to mirror (`getFieldMeta`@1173/`_applyFieldMeta`@1264, private fields @183/323/329/349/444/461/462/496). The few "read the I18nTextDescriptor shape / grep the private field" notes are empirical-verification instructions with a concrete fallback (omit a sub-field if absent), not placeholders.
+
+**Type consistency:** `CollectionMeta`/`VaultMeta`/`CollectionConfig`/`DescribedField`(+i18n/widget/editable)/`getMeta`/`_applyMeta`/`getConfig` used consistently across tasks; `meta` is the option key at both collection and vault level; `described`/`config`/`meta` consistent on `InspectorCollection` across Tasks 5–7.

--- a/docs/superpowers/plans/2026-06-25-metadata-riders.md
+++ b/docs/superpowers/plans/2026-06-25-metadata-riders.md
@@ -1,0 +1,348 @@
+# Milestone-#20 Riders Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship three riders on the field-metadata foundation — `dictKey` inline labels (#485), `collection.toJSONSchema()` (#484), and devtools PII masking — stacked on PR #490.
+
+**Architecture:** #485 adds code-provided display-fallback labels to `dictKey`, surfaced **synchronously** through `describe()`. #484 adds an async `collection.toJSONSchema()` that overlays `describe()` metadata as `x-` extensions onto the zod-4-derived JSON Schema (or a minimal field-type schema for non-zod validators). Masking is a pure devtools consumer of the `sensitivity` already in the snapshot — RecordsPane (Nuxt + TUI) masks pii/secret values by default with reveal-on-demand.
+
+**Tech Stack:** TypeScript, Vitest, Standard Schema v1, zod 4 (devDep, lazy), Vue (Nuxt), Ink/React (TUI).
+
+## Global Constraints
+
+- **Builds on `feat/field-metadata-foundation`** (PR #490): `describe()`/`fieldMeta`, `buildDescription` (`introspection/describe.ts`), `derivePersistedSchema`/`isZod4Schema` (`persisted-schemas/derive.js`), the `dictKey`/`DictKeyDescriptor` in `i18n/dictionary.ts`, and `InspectorCollection.described` (with `sensitivity`) in the in-devtools snapshot. Do NOT switch branches.
+- Descriptive, never prescriptive; hub **validator-agnostic** — no static `import 'zod'` in `hub/src`.
+- `describe()` (sync) stays **zero store I/O**.
+- **Masking UX (decided): mask-by-default, reveal-on-demand** — pii AND secret render `••••••` by default; per-field reveal + a header "reveal all" toggle; public/unclassified always shown; a collection without `described` masks nothing (back-compat).
+- **#485 labels are a display FALLBACK** — code-provided defaults used when the dynamic `_dict_` has no label; `describe()` sync surfaces them; `resolveDictLabels:true` async overrides from `_dict_`, falling back to inline.
+- **#484 `x-` keys** (keeps output valid JSON Schema): `x-label`, `x-unit`, `x-semanticType`, `x-sensitivity`, `x-widget`, `x-readonly` (when `editable:false`), `x-money`, `x-ref`, `x-enumLabels`.
+- **Tests under `__tests__/**`** (vitest ignores `src/*.test.ts`). pnpm. The DTS build (`exactOptionalPropertyTypes`) is stricter than vitest tsc; **run `npm run typecheck` + `eslint src/` per changed package before declaring done** (the tsup build enforces neither — a CI lesson from this branch). Conditional spreads for optional props.
+- **No inline `import()` type annotations** (`consistent-type-imports`) — use top-level `import type`.
+- New public symbols re-export from `src/index.ts`. No Claude attribution in commits.
+- Spec: `docs/superpowers/specs/2026-06-25-metadata-riders-design.md`.
+
+---
+
+### Task 1: `dictKey` inline labels (#485) + sync `describe()` surfacing
+
+**Files:**
+- Modify: `packages/hub/src/i18n/dictionary.ts` (`DictKeyDescriptor` + `dictKey()` overload)
+- Modify: `packages/hub/src/introspection/describe.ts` (dynamic-dict block ~lines 308-318)
+- Test: `packages/hub/__tests__/introspection/describe.test.ts` (append) + a dictKey unit test in the dictionary test file (find it under `__tests__/`)
+
+**Interfaces:**
+- Produces: `DictKeyDescriptor.labels?: Record<string, string>`; `dictKey(name, mapOrArray, opts?)` — a plain-object 2nd arg is the value→label map (`keys = Object.keys`, `labels = map`); an array keeps current behavior + reads `opts.labels`. `describe().dict.values[].label` populated **synchronously** from inline labels.
+
+- [ ] **Step 1: Write the failing tests**
+
+In the dictionary unit test file:
+```ts
+import { dictKey, isDictKeyDescriptor } from '../src/i18n/dictionary.js' // adjust path to the test's location
+import { describe, it, expect } from 'vitest'
+
+describe('dictKey inline labels (#485)', () => {
+  it('map form: keys inferred, labels captured', () => {
+    const d = dictKey('saleStatus', { draft: 'Draft', to_verify: 'To Verify' })
+    expect(d.keys).toEqual(['draft', 'to_verify'])
+    expect(d.labels).toEqual({ draft: 'Draft', to_verify: 'To Verify' })
+  })
+  it('array + opts.labels', () => {
+    const d = dictKey('saleStatus', ['draft', 'to_verify'] as const, { labels: { to_verify: 'To Verify' } })
+    expect(d.keys).toEqual(['draft', 'to_verify'])
+    expect(d.labels).toEqual({ to_verify: 'To Verify' })
+  })
+  it('bare array unchanged (no labels)', () => {
+    const d = dictKey('saleStatus', ['draft', 'paid'] as const)
+    expect(d.keys).toEqual(['draft', 'paid'])
+    expect(d.labels).toBeUndefined()
+  })
+})
+```
+In `describe.test.ts` (append) — a collection with a `dictKey` carrying inline labels:
+```ts
+it('sync describe surfaces inline dictKey labels (#485)', () => {
+  // dictKeyFields: { status: dictKey('saleStatus', { draft:'Draft', to_verify:'To Verify' }) }
+  const f = orders.describe().fields.find((x) => x.key === 'status')!
+  expect(f.dict?.values).toEqual(expect.arrayContaining([
+    { value: 'draft', label: 'Draft' }, { value: 'to_verify', label: 'To Verify' },
+  ]))
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm test --prefix packages/hub -- dictionary describe`
+Expected: FAIL — `labels` absent; map form not handled.
+
+- [ ] **Step 3: Implement `labels` + the overload**
+
+In `dictionary.ts`, add `readonly labels?: Record<string, string>` to `DictKeyDescriptor`, and rewrite `dictKey`:
+```ts
+export function dictKey<Keys extends string>(
+  name: string,
+  keysOrMap?: readonly Keys[] | Record<Keys, string>,
+  opts?: { onMissing?: OnMissingPolicy; substitute?: readonly string[]; labels?: Record<string, string> },
+): DictKeyDescriptor<Keys> {
+  let keys: readonly Keys[] | undefined
+  let labels: Record<string, string> | undefined
+  if (Array.isArray(keysOrMap)) {
+    keys = keysOrMap as readonly Keys[]
+    labels = opts?.labels
+  } else if (keysOrMap && typeof keysOrMap === 'object') {
+    keys = Object.keys(keysOrMap) as Keys[]
+    labels = keysOrMap as Record<string, string>
+  } else {
+    keys = undefined
+    labels = opts?.labels
+  }
+  return {
+    _noydbDictKey: true,
+    name,
+    keys,
+    ...(opts?.onMissing !== undefined ? { onMissing: opts.onMissing } : {}),
+    ...(opts?.substitute !== undefined ? { substitute: opts.substitute } : {}),
+    ...(labels !== undefined ? { labels } : {}),
+  }
+}
+```
+
+In `describe.ts`, the dynamic-dict branch (~line 308) currently uses `dictLabels?.[dict.name]` (async) else `dict.keys.map(k => ({value:k}))`. Change the no-async-labels fallback to use `dict.labels` (inline) when present:
+```ts
+} else if (dict.keys !== undefined) {
+  const values = dict.keys.map((k) => {
+    const label = (dict as { labels?: Record<string, string> }).labels?.[k]
+    return label !== undefined ? { value: k, label } : { value: k }
+  })
+  dictBlock = { name: dict.name, static: false, values }
+}
+```
+(The async `dictLabels` branch already wins when resolved — inline is the fallback, per spec.)
+
+- [ ] **Step 4: Run tests + build + typecheck**
+
+Run: `npm test --prefix packages/hub -- dictionary describe` → PASS.
+Run: `npm run build --prefix packages/hub && npm run typecheck --prefix packages/hub` → clean.
+Run: `node scripts/check-architecture.mjs` → OK.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/i18n/dictionary.ts packages/hub/src/introspection/describe.ts packages/hub/__tests__
+git commit -m "feat(hub): dictKey inline labels (display fallback) + sync describe surfacing (#485)"
+```
+
+---
+
+### Task 2: `collection.toJSONSchema()` (#484)
+
+**Files:**
+- Create: `packages/hub/src/introspection/json-schema.ts` (`buildJsonSchema` pure overlay)
+- Modify: `packages/hub/src/collection.ts` (async `toJSONSchema()` method)
+- Test: `packages/hub/__tests__/introspection/json-schema.test.ts`
+
+**Interfaces:**
+- Consumes: `derivePersistedSchema` (returns `{ jsonSchema }`), `this.describe({})` (async → `CollectionDescription`), the `dict.values[].label` from Task 1.
+- Produces: `Collection.toJSONSchema(): Promise<object>` — valid JSON Schema with `x-` extension keys per property; minimal field-type schema when no zod-derived JSON Schema.
+
+- [ ] **Step 1: Write the failing test**
+
+In `json-schema.test.ts` (real harness; a zod-4 collection with money `total` EUR, ref `buyerId`, dictKey `status` with inline labels, a `pii` fieldMeta):
+```ts
+it('emits JSON Schema with x- metadata extensions', async () => {
+  const js = await orders.toJSONSchema() as { properties: Record<string, Record<string, unknown>> }
+  expect(js.properties.total['x-semanticType']).toBe('currency')
+  expect(js.properties.total['x-money']).toMatchObject({ currency: 'EUR' })
+  expect(js.properties.status['x-enumLabels']).toMatchObject({ to_verify: 'To Verify' })
+  expect(js.properties.buyerVat['x-sensitivity']).toBe('pii')
+})
+it('non-zod validator → minimal schema from field types, no throw', async () => {
+  // a collection with a hand-rolled Standard-Schema stub validator + moneyFields
+  const js = await stubColl.toJSONSchema() as { type: string; properties: Record<string, Record<string, unknown>> }
+  expect(js.type).toBe('object')
+  expect(js.properties.total['x-semanticType']).toBe('currency')
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm test --prefix packages/hub -- json-schema`
+Expected: FAIL — `toJSONSchema` not a function.
+
+- [ ] **Step 3: Implement `buildJsonSchema` (pure overlay)**
+
+`packages/hub/src/introspection/json-schema.ts`:
+```ts
+import type { CollectionDescription, DescribedField } from './describe.js'
+
+/** Map a DescribedField's type tag to a JSON-Schema `type`. */
+function jsonType(t: string): string {
+  switch (t) {
+    case 'number': return 'number'
+    case 'boolean': return 'boolean'
+    case 'array': return 'array'
+    case 'object': return 'object'
+    default: return 'string'
+  }
+}
+
+/** Overlay describe() metadata onto a base JSON Schema (or build a minimal one). */
+export function buildJsonSchema(desc: CollectionDescription, base?: Record<string, unknown> | null): object {
+  const baseProps = (base?.['properties'] as Record<string, Record<string, unknown>> | undefined) ?? {}
+  const properties: Record<string, Record<string, unknown>> = {}
+  for (const f of desc.fields) {
+    const prop: Record<string, unknown> = { ...(baseProps[f.key] ?? { type: jsonType(f.type) }) }
+    prop['x-label'] = f.label
+    if (f.unit !== undefined) prop['x-unit'] = f.unit
+    if (f.semanticType !== undefined) prop['x-semanticType'] = f.semanticType
+    if (f.sensitivity !== undefined) prop['x-sensitivity'] = f.sensitivity
+    if (f.widget !== undefined) prop['x-widget'] = f.widget
+    if (f.editable === false) prop['x-readonly'] = true
+    if (f.money !== undefined) prop['x-money'] = f.money
+    if (f.ref !== undefined) prop['x-ref'] = f.ref.target
+    if (f.dict?.values) {
+      const labels: Record<string, string> = {}
+      for (const v of f.dict.values) if (v.label !== undefined) labels[v.value] = v.label
+      if (Object.keys(labels).length) prop['x-enumLabels'] = labels
+    }
+    properties[f.key] = prop
+  }
+  return base && typeof base === 'object'
+    ? { ...base, properties }
+    : { type: 'object', properties }
+}
+```
+
+- [ ] **Step 4: Add `toJSONSchema()` to `Collection`**
+
+In `collection.ts` (import `buildJsonSchema` + `derivePersistedSchema`, both lazy-safe — `derivePersistedSchema` already lazy-imports zod):
+```ts
+/** JSON Schema for this collection with describe() metadata as x- extensions. */
+async toJSONSchema(): Promise<object> {
+  const desc = await this.describe({})
+  let base: Record<string, unknown> | null = null
+  if (this.schema !== undefined) {
+    const env = await derivePersistedSchema(this.schema)
+    base = (env.jsonSchema as Record<string, unknown> | null) ?? null
+  }
+  return buildJsonSchema(desc, base)
+}
+```
+Keep it a thin delegator (logic lives in `json-schema.ts`) so collection.ts stays near its ceiling; raise the ceiling minimally + justify if needed.
+
+- [ ] **Step 5: Run tests + build + typecheck + eslint**
+
+Run: `npm test --prefix packages/hub -- json-schema` → PASS.
+Run: `npm run build --prefix packages/hub && npm run typecheck --prefix packages/hub` → clean.
+Run: `(cd packages/hub && npx eslint src/)` → clean (no inline `import()` annotations).
+Run: `node scripts/check-architecture.mjs` → OK.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/introspection/json-schema.ts packages/hub/src/collection.ts packages/hub/__tests__/introspection/json-schema.test.ts
+git commit -m "feat(hub): collection.toJSONSchema() with x- metadata extensions (#484)"
+```
+
+---
+
+### Task 3: Nuxt RecordsPane PII masking
+
+**Files:**
+- Modify: `packages/in-nuxt/src/runtime/devtools/panes/RecordsPane.vue`
+- Test: `packages/in-nuxt/__tests__/` (extend `devtools-panel.test.ts` or add `records-mask.test.ts`)
+
+**Interfaces:**
+- Consumes: `collection.described` (each `DescribedField` has `key` + `sensitivity`) from the enriched `InspectorCollection`.
+
+- [ ] **Step 1: Write the failing test**
+
+A RecordsPane mounted with a collection whose `described` marks `vat` as `pii` and a record `{ vat: 'IT123', total: '10.00' }`:
+```ts
+it('masks pii/secret values by default; reveal unmasks', async () => {
+  // mount panel, drill into the collection's records
+  expect(wrapper.text()).toContain('••••••')      // vat masked
+  expect(wrapper.text()).toContain('10.00')        // public total shown
+  expect(wrapper.text()).not.toContain('IT123')    // pii hidden
+  await wrapper.find('[data-reveal="vat"]').trigger('click')
+  expect(wrapper.text()).toContain('IT123')        // revealed
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm test --prefix packages/in-nuxt -- records`
+Expected: FAIL — values shown unmasked.
+
+- [ ] **Step 3: Implement masking**
+
+In `RecordsPane.vue`: derive a sensitive-field set from `collection.described` (`sensitivity !== 'public'` and defined); local refs `revealed = ref(new Set<string>())` + `revealAll = ref(false)`. For each cell, render the value when the field is not sensitive OR `revealAll` OR `revealed.has(field)`, else `••••••` with a reveal control (`data-reveal="<field>"` → adds the field to `revealed`). Add a header "reveal all" toggle bound to `revealAll`. Keep the existing pagination/columns. A field not in `described` (or `described` absent) is treated as not-sensitive (back-compat).
+
+- [ ] **Step 4: Run tests + typecheck**
+
+Run: `npm test --prefix packages/in-nuxt -- records` → PASS.
+Run: `npm run build --prefix packages/in-nuxt && npm run typecheck --prefix packages/in-nuxt` → clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/in-nuxt/src/runtime/devtools/panes/RecordsPane.vue packages/in-nuxt/__tests__
+git commit -m "feat(in-nuxt): RecordsPane masks pii/secret values by default, reveal-on-demand (#483)"
+```
+
+---
+
+### Task 4: TUI RecordsPane masking + features.yaml + docs
+
+**Files:**
+- Modify: `packages/in-devtools-tui/src/panes/RecordsPane.tsx`
+- Modify: `features.yaml`
+- Modify: `docs/subsystems/field-metadata.md`
+- Test: `packages/in-devtools-tui/__tests__/` (snapshot/render test)
+
+**Interfaces:**
+- Consumes: `collection.described` `sensitivity`.
+
+- [ ] **Step 1: Write the failing test**
+
+A TUI RecordsPane render with a `pii` field → output shows `••••` for it, not the raw value, by default; a reveal key-toggle un-masks. Assert via the Ink test renderer the package already uses (mirror an existing TUI test).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npm test --prefix packages/in-devtools-tui -- records`
+Expected: FAIL — raw value shown.
+
+- [ ] **Step 3: Implement TUI masking**
+
+In `RecordsPane.tsx`: derive the sensitive-field set from `collection.described`; mask pii/secret cells with `••••` unless a reveal flag is set; add a key binding (e.g. `r`) to toggle reveal-all for the pane (terminal-appropriate — a single reveal-all toggle is fine for the TUI rather than per-field click). Guard: no `described` → mask nothing. Keep `exactOptionalPropertyTypes`/`noUncheckedIndexedAccess` clean (use `Object.entries`, conditional spreads).
+
+- [ ] **Step 4: features.yaml + docs**
+
+Add this milestone's riders to the `field-metadata`/`metadata-ladder` node (or a `metadata-riders` node): reference `docs/superpowers/specs/2026-06-25-metadata-riders-design.md`, the `collection.toJSONSchema` surface, and the devtools masking. Document `toJSONSchema()` (with the `x-` key table), the dictKey inline-label form, and the masking behavior in `docs/subsystems/field-metadata.md`. Every referenced path must exist.
+
+- [ ] **Step 5: Verify all gates**
+
+Run: `npm test --prefix packages/in-devtools-tui` → PASS (regenerate snapshots intentionally if the render changed).
+Run: `npm run build --prefix packages/in-devtools-tui && npm run typecheck --prefix packages/in-devtools-tui` → clean.
+Run: the features validator (`grep -rn "validate-features" scripts package.json`) → 0 dangling refs. `node scripts/check-architecture.mjs` → OK.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/in-devtools-tui features.yaml docs
+git commit -m "feat(in-devtools-tui): RecordsPane PII masking + features.yaml + docs (#483, #484, #485)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- #485 dictKey inline labels (map + array+labels forms, back-compat) + sync describe surfacing → Task 1. ✓
+- #484 toJSONSchema (x- overlay incl x-enumLabels from #485, non-zod minimal fallback, agnostic) → Task 2. ✓
+- Masking mask-by-default + reveal (Nuxt) → Task 3; (TUI) → Task 4. ✓
+- features.yaml + docs → Task 4. ✓
+- Non-goals (#489 export, fieldMeta.group, editor) → no tasks. ✓
+
+**Placeholder scan:** code steps carry concrete code; the few "find the test file / mirror an existing TUI test" notes are locate-the-harness instructions with the pattern named, not placeholders.
+
+**Type consistency:** `DictKeyDescriptor.labels`, `dictKey` overload, `buildJsonSchema`, `Collection.toJSONSchema`, the `x-` key set, and `collection.described.sensitivity` are used consistently across tasks. #484's `x-enumLabels` reads the `dict.values[].label` produced by #485 (Task 1 before Task 2).

--- a/docs/superpowers/specs/2026-06-25-field-metadata-foundation-design.md
+++ b/docs/superpowers/specs/2026-06-25-field-metadata-foundation-design.md
@@ -1,0 +1,330 @@
+# Field-metadata foundation — design (#482 + #483)
+
+> Milestone #20 "Field metadata & describe() (pilot-3)". This spec covers the
+> **substrate** (#482) and the **keystone** (#483). The riders #484
+> (`toJSONSchema()`), #485 (dictKey labels), #486 (sensitivity classification)
+> get short plans that reference this document.
+
+**Status:** design approved 2026-06-25, pre-implementation.
+
+---
+
+## Problem
+
+A noy-db collection already owns almost everything needed to *describe* its
+data: field names + types (the Standard-Schema validator), money semantics
+(`moneyFields`), foreign keys (`refs`), enum value sets (`dictKeyFields`),
+i18n text, and computed fields. The missing last 10% — **consumer-neutral,
+data-relatable descriptors** (label, semantic format, unit, enum value
+labels, entity display pairing, aggregation default, sensitivity) — has
+nowhere to live. The pilot (i3speedex) maintains these facts **three times**
+(Zod schema, a search `FieldDef` registry, each table's `Column[]`) and they
+drift.
+
+By the litmus test *"would a second, unrelated consumer want this fact?"*
+these descriptors belong to the data — in noy-db — because a table, an
+Excel/CSV export, a PDF report, a form generator, an API doc, and the
+devtools inspector all want the same facts.
+
+## Two findings that reframe the original issues
+
+The original issues (#482, #483) were written assuming hub uses Zod directly.
+It does not. Two verified facts from the code change the design:
+
+1. **hub is validator-agnostic.** hub never imports `zod` in `src/`. It
+   validates through the **Standard Schema v1** protocol
+   (`schema['~standard'].validate()` — `schema.ts:55-149`), so it works with
+   any conforming validator (Zod, Valibot, ArkType, Effect). `zod` is a
+   **devDependency** (`^3.23.0`) used only by hub's own tests. There is
+   therefore **no "hub runs against the consumer's zod" hazard** and **no
+   peer-dependency break is required**. #482 is *additive*, not breaking.
+
+2. **`describe()` is an extension, not greenfield.** `vault.dumpSchema()` +
+   `vault.introspect()` + a `FieldDescriptor` type already exist
+   (`introspection/`), exposing field types + refs but **omitting**
+   money/dict/i18n/computed. A JSON-Schema derivation path already exists
+   (`persisted-schemas/derive.ts` → `derivePersistedSchema`, used by #484).
+
+## Goals
+
+- Add a **consumer-neutral field-metadata layer** that merges existing
+  config + a new authoring channel + (optionally) zod-4 registry metadata.
+- Add **`collection.describe()`**: a normalized, synchronous, config-only
+  descriptor list — the single interface every renderer/exporter consumes.
+- Keep hub **validator-agnostic** and **portable** (no static `import 'zod'`).
+- Make the riders #484/#485/#486 thin additions on top.
+
+## Non-goals (scope boundary — descriptive, never prescriptive)
+
+noy-db may say *"this field means money in €, sums, is PII."* It must **not**
+say *"put it in column 3 at 60px on the sales page."* Out of scope, app-side:
+
+- column order, widths, responsive breakpoints, default-visible columns
+- per-page default sort/filter, route placement, styling
+- **active locale selection** (noy-db carries label text incl. multi-locale
+  maps; the app chooses the active locale)
+- logging/telemetry redaction enforcement (app-side)
+
+This litmus test — *"would a second, unrelated consumer want this fact?"* —
+is a binding invariant: it governs what may be added to the metadata layer.
+
+---
+
+## Architecture
+
+```
+                    collection.describe()   ← cheap, sync, config-only
+                            │  merges
+        ┌───────────────────┼───────────────────────────────┐
+   existing config      fieldMeta channel          optional zod-4 reader
+   (refs, money,        (canonical, agnostic,      (.meta()/registry,
+    dictKey, i18n,       collection options)        merged when present,
+    computed)                                       channel wins on conflict)
+                            │
+                  extends existing FieldDescriptor
+                  (introspection/types.ts) — NOT a new parallel type
+```
+
+The **zod-4 reader reuses the #484 derivation path**: zod-4's
+`z.toJSONSchema()` already folds `.meta()`/registry metadata into its output,
+so "read the zod registry" and "emit JSON Schema" are the *same* zod-4 call —
+no separate reach into zod internals, no static import (lazy/duck-typed,
+exactly like `derivePersistedSchema` does today). This unifies #483's
+reader-half with #484.
+
+---
+
+## Component 1 — `#482` substrate (additive)
+
+1. **Bump hub devDependency `zod` 3 → 4** so hub's tests exercise the zod-4
+   Standard-Schema + registry shape. (`zod` stays a devDependency; it is
+   **not** promoted to a direct or peer dependency.)
+2. **Make `derivePersistedSchema` zod-version-aware**
+   (`persisted-schemas/derive.ts`): prefer the schema's native
+   `z.toJSONSchema()` (zod 4) when present; fall back to the optional
+   `zod-to-json-schema` peer-dep (zod 3). Both majors stay supported; hub
+   keeps a hard dependency on neither.
+3. **Document** that hub accepts any Standard-Schema validator (zod 3 or 4,
+   Valibot, …). The zod-4 registry-read path is a *bonus* available only to
+   zod-4 schemas; the `fieldMeta` channel is the always-available path.
+
+No peer-dependency change. No breaking change.
+
+---
+
+## Component 2 — `#483` the `fieldMeta` channel
+
+A new `fieldMeta` entry in collection options, alongside the descriptors
+noy-db already owns:
+
+```ts
+vault.collection<Sale>('sales', {
+  schema: SaleSchema,                          // any Standard-Schema validator
+  refs:        { buyerId: ref('buyers') },
+  moneyFields: { total: money({ currency: 'EUR' }) },
+  dictKeyFields: { status: staticDict('saleStatus', { draft:'Draft', to_verify:'To Verify' }) },
+  fieldMeta: {                                 // ← new, agnostic channel
+    saleDate:  { label: 'Date',  semanticType: 'date', aggregate: 'none' },
+    total:     { label: 'Amount', semanticType: 'currency', unit: '€', aggregate: 'sum' },
+    buyerId:   { label: 'Buyer', displayFor: 'buyerName' },
+  },
+})
+```
+
+The meta shape (mandates `label`; rest optional):
+
+```ts
+interface FieldMeta {
+  label: string
+  description?: string
+  semanticType?: 'date'|'datetime'|'email'|'url'|'currency'|'percent'
+               | 'country'|'vat'|'iban'|'entity' | (string & {})  // open union
+  unit?: string                                // '€', '%', 'kg'
+  sensitivity?: 'public'|'pii'|'secret'        // #486 rides here
+  aggregate?: 'sum'|'count'|'distinct'|'none'
+  aliases?: string[]                           // search synonyms
+  displayFor?: string                          // entity pairing: buyerId ⇄ buyerName
+}
+```
+
+**Validation:** `fieldMeta` keys that are not fields in the schema/config are
+rejected **fail-loud at `collection()` time** (mirrors how an unknown
+`moneyFields` key would be caught), to catch typos. `semanticType` is an
+**open** string union — unknown values pass through (consumers may define
+their own); it is not a closed enum that rejects.
+
+**Storage:** stored on the Collection like the sibling descriptor maps;
+registered into a vault-level registry consistent with the existing
+`refRegistry`/`dictKeyFieldRegistry` pattern so introspection can reach it.
+
+### The optional zod-4 reader
+
+When the schema is zod-4, fields authored co-located via `.meta()` are read
+through the shared `z.toJSONSchema()` derivation and merged:
+
+```ts
+const SaleSchema = z.object({
+  total: z.number().meta({ label: 'Amount', semanticType: 'currency', unit: '€' }),
+})
+```
+
+The reader is **lazy/duck-typed** — it reads metadata out of the derived
+JSON Schema (which zod-4 populates from the registry), never via a static
+`import 'zod'`. For non-zod validators it is simply a no-op.
+
+### Merge precedence (highest wins)
+
+1. `fieldMeta` channel (canonical, agnostic — works for every validator)
+2. zod-4 `.meta()` registry (when present)
+3. **inferred** from existing config:
+   - `moneyFields` → `semanticType:'currency'`, `aggregate:'sum'`
+   - `refs` → `semanticType:'entity'`
+   - `z.iso.date()` / JSON-Schema `format:'date'` → `semanticType:'date'`
+   - humanized field name → fallback `label`
+
+The channel is authoritative because it is the *only* source available for
+every validator; making the always-available source win avoids a consumer's
+behavior silently depending on which validator they chose. Inference under
+the explicit sources means `describe()` is useful on existing collections
+that never declare `fieldMeta`.
+
+---
+
+## Component 3 — `collection.describe()`
+
+**Synchronous, cheap, config-only** — no decryption, no store I/O (distinct
+from the async `dumpSchema()` which samples data). Returns one normalized
+list, **extending** the existing `FieldDescriptor` rather than a parallel
+type:
+
+```ts
+collection.describe(): CollectionDescription
+
+interface CollectionDescription {
+  readonly collection: string
+  readonly fields: readonly DescribedField[]
+}
+
+interface DescribedField {
+  // ── from existing introspection (validator-derived) ──
+  readonly key: string
+  readonly type: string                 // 'string'|'number'|'boolean'|'enum'|'object'|'array'|'null'
+  readonly optional: boolean
+  readonly constraints?: Record<string, unknown>
+  // ── merged metadata ──
+  readonly label: string                // explicit → registry → humanized(key)
+  readonly description?: string
+  readonly semanticType?: string
+  readonly unit?: string
+  readonly sensitivity?: 'public'|'pii'|'secret'
+  readonly aggregate?: 'sum'|'count'|'distinct'|'none'
+  readonly aliases?: readonly string[]
+  // ── from config noy-db already owns ──
+  readonly ref?: { target: string; mode: string; isArray?: true }
+  readonly displayFor?: string
+  readonly money?: { mode: 'fixed'|'multi'; currency?: string; scale?: number; rounding?: string }
+  readonly dict?: { name: string; static: boolean
+                    values?: readonly { value: string; label?: string }[] }  // #485 labels
+  readonly computed?: true
+}
+```
+
+Example (the `sales` collection above):
+
+```ts
+[
+  { key:'saleDate', type:'string', optional:false, semanticType:'date',   label:'Date',  aggregate:'none' },
+  { key:'buyerId',  type:'string', optional:false, semanticType:'entity', label:'Buyer',
+      ref:{target:'buyers',mode:'strict'}, displayFor:'buyerName' },
+  { key:'status',   type:'enum',   optional:false, label:'Status',
+      dict:{ name:'saleStatus', static:true,
+             values:[{value:'draft',label:'Draft'},{value:'to_verify',label:'To Verify'}] } },
+  { key:'total',    type:'number', optional:false, semanticType:'currency', label:'Amount', unit:'€',
+      money:{ mode:'fixed', currency:'EUR', scale:2 }, aggregate:'sum' },
+]
+```
+
+### The one async boundary — dynamic dict labels
+
+`staticDict` labels are in-code → surface synchronously (covers the pilot's
+"To Verify" case and most of #485). **Dynamic `dictKey`** labels live in
+encrypted `_dict_*` collections → require an async read. To keep `describe()`
+sync by default:
+
+- `describe()` (sync) returns dynamic-dict fields as
+  `dict:{ name, static:false }` with declared `keys` but **no resolved
+  labels**.
+- `await collection.describe({ resolveDictLabels: true })` returns the same
+  shape with `values[].label` filled, reading `_dict_*`. Async cost is
+  visible at the call site and opt-in only.
+
+---
+
+## Component placement & exports
+
+- New files under `introspection/` (e.g. `field-meta.ts` for the `FieldMeta`
+  type + merge logic; extend the existing field/describe code). `describe()`
+  is a thin delegating method on `Collection`.
+- Export `FieldMeta`, `CollectionDescription`, `DescribedField` from
+  `src/index.ts`. **Not** from `kernel/index.ts` — per-collection
+  introspection is not orchestration surface.
+- Merge logic lives in `introspection/`, **not** `collection.ts`/`vault.ts`,
+  so the kernel-surface ceilings (collection.ts 5285, vault.ts 4610) are
+  untouched.
+
+---
+
+## How the riders attach (separate short plans)
+
+| Issue | How it rides | Net-new work |
+|---|---|---|
+| **#485** dictKey labels | `staticDict` already carries per-value labels; this design **surfaces** them via `dict.values[].label`. The only gap is an inline-map form for **dynamic** `dictKey('saleStatus', {draft:'Draft',…})`. | Accept a map form in `dictKey()` (back-compat with the bare array) + the async label resolution above. |
+| **#484** toJSONSchema | Reuses the **same** zod-4 `z.toJSONSchema()` path as the reader. Walks `describe()` output and stamps `x-label`/`x-unit`/`x-semanticType`/`x-sensitivity`/`x-money`/`x-enumLabels` extension keys. | One emitter over `describe()`. |
+| **#486** sensitivity | `sensitivity` is already in `FieldMeta` + `DescribedField`. hub side is done by this spec. | Only the redacting *export* (#489, as-* family) remains; it reads `describe().fields[].sensitivity`. |
+
+---
+
+## Testing
+
+- **Merge precedence** — channel > zod-registry > inferred, per source: a
+  money field with no `fieldMeta`; a `fieldMeta` label overriding an inferred
+  one; a zod-4 `.meta()` read; a conflict where the channel wins.
+- **Validator-agnostic** — run the `describe()` suite against **two
+  validators**: a zod-4 schema (reader path) and a hand-rolled
+  Standard-Schema stub / Valibot (channel-only, proves no zod dependency).
+  This test guards the agnostic invariant.
+- **zod 3 ↔ 4** — `derivePersistedSchema` produces equivalent field types
+  under both majors (native `z.toJSONSchema()` vs `zod-to-json-schema`).
+- **Sync/async** — `describe()` does zero store reads (assert via a wrapped
+  store that throws on `list`/`get`); `describe({resolveDictLabels:true})`
+  reads `_dict_*` and fills labels.
+- **#485 back-compat** — bare-array `dictKey` still works; map form produces
+  labels.
+- **Showcase** — next number after 125: `describe()` → a table + an export
+  reading one source.
+
+## Portability (hard invariants)
+
+- No static `import 'zod'` anywhere in `hub/src`; the reader is
+  lazy/duck-typed like `derivePersistedSchema`. Enforced by a test (the
+  arch-check Node-ban does not grep for zod) + documented invariant.
+- `scripts/check-architecture.mjs` Node-only-module ban continues to hold.
+- Kernel ceilings unchanged (no write-path changes).
+
+## `features.yaml`
+
+New `field-metadata` node pointing at this spec; riders #484/#485/#486
+reference it. (CI "Spec coverage" fails on dangling refs, so this is
+mandatory.)
+
+## Release sequencing
+
+Because #482 is **additive, not breaking**, every step is a normal
+pre-release bump (no major/breaking ceremony, no peer-dep coordination):
+
+- **Release N**: #482 substrate (devDep zod-4 bump + zod-4-aware derivation).
+- **Release N+1**: #483 `fieldMeta` + `describe()`.
+- **Release N+2**: #484 / #485 / #486 riders.
+
+One spec (this document) covers #482 + #483; #484/#485/#486 get short plans
+referencing it.

--- a/docs/superpowers/specs/2026-06-25-interactive-editor-design.md
+++ b/docs/superpowers/specs/2026-06-25-interactive-editor-design.md
@@ -1,0 +1,148 @@
+# Interactive schema & data editor — design (forward-looking)
+
+> **Design only. Not implemented this cycle.** Captures the target so the
+> read-model (`describe()` / `dumpSchema()` / the metadata ladder) is shaped to
+> serve it. Consumes
+> [2026-06-25-metadata-ladder-and-schema-surfacing-design.md](2026-06-25-metadata-ladder-and-schema-surfacing-design.md).
+
+**Status:** design recorded 2026-06-25. No implementation scheduled.
+
+---
+
+## Vision
+
+A user-friendly, interactive UI for noy-db with two halves:
+
+- **Data editor** — non-technical users create/edit *records* in a friendly
+  UI (forms + tables), with full awareness of the schema: money inputs,
+  ref dropdowns, enum selects, multi-locale fields, validation, PII masking.
+- **Schema editor** — a developer/admin defines/changes *collections*
+  visually; the tool **emits code** (Zod + collection-options) the developer
+  commits. Low-code, not no-code.
+
+## The unifying principle
+
+`describe()` is the **read-model** the whole UI renders. The data editor reads
+it to build forms; the schema editor *reverses* it into code. Every tool
+(CLI, devtools, editor) is a consumer of the same description — the editor is
+just the most demanding one, which is why its needs drive the
+`describe()`/`fieldMeta` roadmap.
+
+## Key decisions (from brainstorming, 2026-06-25)
+
+1. **Schema editing = codegen** (low-code, dev-facing), NOT a runtime
+   serializable schema IR. The UI edits a `describe()`-shaped model and emits
+   TypeScript (Zod schema + the collection-options object). Rationale: no new
+   noy-db core primitive, and no entanglement with the live schema-update /
+   Transform / Cutover migration machinery — schema changes are code the dev
+   commits and deploys, migration handled in code as today.
+2. **Read-model = hybrid** `describe()` (per-field render-model) +
+   `dumpSchema()` (structural + collection-level config), merged by consumers.
+3. **Framework:** a framework-agnostic **editor core** (`describe()` +
+   `toJSONSchema()` → render-ready view-model + validation) with thin bindings
+   — mirroring noy-db's "core + `in-*`" pattern. First binding in Vue/Nuxt.
+   Package home/naming TBD (follows the `in-*` convention for framework
+   integration).
+
+---
+
+## Phase 1 — Data editor (the high-value, low-risk half)
+
+**Forms and tables generated from `describe()`.** Per field, `widget` selects
+the input:
+
+| describe() signal | editor input |
+|---|---|
+| `widget:'money'` (+ `money.currency`) | currency input, scaled correctly |
+| `widget:'ref-select'` (+ `ref.target`, `displayFor`) | dropdown sourced from the target collection, showing the `displayFor` label |
+| `widget:'select'` (+ `dict.values[].label`) | labelled enum select |
+| `i18n` block | per-locale tabbed input |
+| `widget:'date'` | date picker |
+| `editable:false` (computed/id/provenance) | read-only display (computed shown live) |
+| `sensitivity` `pii`/`secret` | masked with reveal-on-demand |
+
+**Validation & save:**
+- `toJSONSchema()` (**#484**, build at Phase-1 start) drives a standard form
+  library (JSON-Schema-form / JSONForms) for field validation + error display.
+- `validateInput(record)` is the pre-save gate (validate without writing —
+  already exists, FR-8).
+- `put(id, record)` saves; money canonicalize→quantize, ref/i18n/dict
+  enforcement all already run inside `put()`.
+
+**Dependencies beyond the metadata-ladder spec:**
+- **#484 `collection.toJSONSchema()`** — the form engine.
+- **ref option-source** — the editor queries `target.describe()` + lists the
+  target collection; optionally a small `collection.refOptions(field, {q?})`
+  convenience.
+- **#485 dict labels** (already shipping) — the selects.
+- **#486 sensitivity** (hub flag shipped) — the masking.
+
+## Phase 2 — Schema editor (codegen)
+
+**Edits a `describe()`-shaped model** — add/rename/retype fields; set
+money/dict/refs/`fieldMeta`/`collectionMeta`; pick the collection's
+validator-level constraints — and **emits code**:
+
+```ts
+// generated: collections/sales.ts
+export const SaleSchema = z.object({
+  saleDate: z.iso.date().meta({ label: 'Date' }),
+  total:    z.number(),
+  buyerId:  z.string(),
+})
+export const salesOptions = {
+  meta: { label: 'Sales', icon: 'receipt' },
+  refs: { buyerId: ref('buyers') },
+  moneyFields: { total: money({ currency: 'EUR' }) },
+  fieldMeta: { total: { label: 'Amount', unit: '€' }, buyerId: { displayFor: 'buyerName' } },
+}
+```
+
+**Escape-hatches** — the non-serializable, function-valued options are emitted
+as `// TODO` stubs the developer completes:
+- `computed` field functions
+- custom guards / `conflictPolicy` / `archive` predicates
+- custom validator refinements beyond the basic field types
+
+This bounds the codegen: it expresses the declarative ~90% and hands off the
+imperative ~10% explicitly, rather than pretending to round-trip code it
+cannot serialize.
+
+## Phase 0 — already covered
+
+The CLI/devtools schema viewers and the `describe()`/`dumpSchema()`/metadata
+enhancements the editor's read-model depends on are the
+metadata-ladder-and-schema-surfacing spec — built first, independently
+valuable, and the editor's foundation.
+
+---
+
+## Enhancement roadmap this design implies
+
+| Enhancement | Editor need | Status |
+|---|---|---|
+| `describe()` `i18n`/`widget`/`editable` | input selection, read-only, multi-locale | metadata-ladder spec (Phase 0) |
+| `collectionMeta` / `vaultMeta` | friendly names in nav + collection list | metadata-ladder spec (Phase 0) |
+| `fieldMeta.widget` override | input override | metadata-ladder spec (Phase 0) |
+| **#484 `toJSONSchema()`** | form generation + validation | Phase 1 |
+| ref option-source helper | populate ref dropdowns | Phase 1 |
+| `fieldMeta.group`/section | form sections | Phase 1 — boundary decision (deferred until here) |
+| `federationMeta` (klum-db) | group-level nav | klum-db, reuses `VaultMeta` |
+
+## Open questions for when implementation is scheduled
+
+- Editor package home + naming (a single `in-editor` core + per-framework
+  bindings, vs a Nuxt playground app).
+- Whether the codegen schema editor needs the **persisted serializable
+  description** (deferred in Phase 0) to read existing collections from a
+  bundle, or always operates against a live, code-declared deployment.
+- Multi-record table editing, bulk operations, and undo — out of scope for the
+  initial data-editor design.
+
+## Non-goals (this design)
+
+- No implementation.
+- No runtime schema IR / no-code schema definition (explicitly rejected in
+  favor of codegen).
+- No new migration mechanism (schema changes ride the existing code +
+  schema-update path).

--- a/docs/superpowers/specs/2026-06-25-metadata-ladder-and-schema-surfacing-design.md
+++ b/docs/superpowers/specs/2026-06-25-metadata-ladder-and-schema-surfacing-design.md
@@ -1,0 +1,260 @@
+# Metadata ladder + schema surfacing — design
+
+> Milestone #20 (field-metadata epic), continuation. Builds on the
+> `fieldMeta`/`describe()` foundation
+> ([2026-06-25-field-metadata-foundation-design.md](2026-06-25-field-metadata-foundation-design.md),
+> PR #490). **Stacks on `feat/field-metadata-foundation`** → one PR, one
+> pre-release (#482 + #483 + this).
+
+**Status:** design approved 2026-06-25, pre-implementation.
+
+---
+
+## Problem
+
+The field-metadata epic gave noy-db a per-**field** descriptive layer
+(`fieldMeta` + `collection.describe()`). Two gaps remain before any
+viewer/editor can present a noy-db deployment well:
+
+1. **The metadata ladder is incomplete.** A UI that browses a deployment
+   needs friendly labels/descriptions at every level — *field → collection →
+   vault → federation*. Today only the field level exists. A nav sidebar, the
+   future editor, an API doc, and an export filename all want a collection's
+   "Sales Invoices" and a vault's "Acme Books 2026", not raw identifiers.
+2. **The display tools show almost nothing of recent features.** The devtools
+   (Nuxt `SchemaPane`, the TUI) render `in-devtools` `snapshot()`, which calls
+   `vault.dumpSchema()` and shows only field `type`/`indexed`/`stats` — none
+   of the `describe()` richness (label/money/dict/sensitivity) and none of the
+   collection-level config (i18n, embeddings, retrieve, CEK, provenance,
+   archive, tiers, crdt). All of it is surfaced **nowhere**.
+
+This spec completes the ladder (collection + vault meta) and makes the **live
+devtools** surface the full schema picture. (CLI/offline-bundle richness is
+deliberately **deferred** — collection options live in code, not the bundle;
+revisited only if a serializable persisted description is added later.)
+
+## Goals
+
+- Add `collectionMeta` + `vaultMeta` descriptor layers, consistent with
+  `fieldMeta`; export the meta types as a shared contract (klum-db's
+  federation meta reuses `VaultMeta`).
+- Enhance `describe()` with the data-editor read-side: `i18n`, `widget`,
+  `editable`, and collection-level `meta`.
+- Add a collection-level `config` block to `dumpSchema()` (the structural
+  half of the hybrid read-model).
+- Wire all of it into the **live devtools** (`in-devtools` `snapshot()` →
+  Nuxt `SchemaPane` + TUI).
+
+## Non-goals
+
+- **No CLI/bundle richness** this cycle (deferred decision).
+- **No persistence** of the meta/config (code options only, like `fieldMeta`;
+  not written to `_schemas`).
+- **No editor** (separate design:
+  [2026-06-25-interactive-editor-design.md](2026-06-25-interactive-editor-design.md)).
+- **No federation meta** in noy-db (federation lives in klum-db; noy-db only
+  exports the `VaultMeta` shape — klum-db implements `groupMeta` separately).
+- `fieldMeta.group`/section is **deferred** (see Boundary note).
+
+## Binding invariants (carried from the foundation)
+
+- **Descriptive, never prescriptive.** Meta carries label/description/icon
+  (a friendly identity), never layout/order/styling. Litmus: "would a second,
+  unrelated consumer want this fact?" — a friendly collection name: yes.
+- hub stays **validator-agnostic**; no static `import 'zod'` in `hub/src`.
+- `describe()` (sync) stays **zero store I/O**.
+- New public symbols re-export from `src/index.ts`; meta **types** also from
+  `kernel/index.ts` (klum contract). Tests live under
+  `packages/hub/__tests__/**`. DTS build (`exactOptionalPropertyTypes`) is
+  stricter than vitest tsc — run the build.
+
+---
+
+## Component 1 — the meta types
+
+New file `packages/hub/src/introspection/meta.ts` (or extend
+`field-meta.ts`):
+
+```ts
+/** A collection's own descriptive metadata (its identity, not its fields). */
+export interface CollectionMeta {
+  label?: string          // friendly name; falls back to humanized collection name
+  description?: string
+  icon?: string           // semantic icon NAME (e.g. a Lucide key), not styling
+  pluralLabel?: string    // "Invoice" → "Invoices" for list headers
+}
+
+/** A vault's own descriptive metadata. */
+export interface VaultMeta {
+  label?: string          // friendly name; falls back to the vault name
+  description?: string
+  icon?: string
+}
+```
+
+Note the ladder asymmetry: `FieldMeta.label` is **required** (a field has no
+human name otherwise), but `CollectionMeta`/`VaultMeta.label` are **optional**
+— the collection/vault name is the fallback identity.
+
+**Exports:** `CollectionMeta`, `VaultMeta` from `src/index.ts` AND
+`kernel/index.ts` (klum-db's `groupMeta` reuses `VaultMeta`).
+
+## Component 2 — `collectionMeta`
+
+- Add `meta?: CollectionMeta` to `CollectionOptions` (`vault.ts`), beside
+  `fieldMeta`.
+- Store on `Collection` (private `meta` + `getMeta(): CollectionMeta |
+  undefined`); add a first-wins reconciler `_applyMeta(meta)` and call it in
+  the cached-collection branch in `vault.ts` (mirror `_applyFieldMeta` exactly
+  — same MV-pre-created-collection fix).
+- Surface in `describe()`: `CollectionDescription` gains
+  `meta?: CollectionMeta` (with `label` defaulting to the humanized collection
+  name when absent).
+- Surface in `dumpSchema()`: `CollectionDescriptor` gains `meta?:
+  CollectionMeta`.
+
+## Component 3 — `vaultMeta`
+
+- Add `meta?: VaultMeta` to `openVault(name, { locale?, create?, meta? })`
+  (`noydb.ts`). **First-wins**: applied on first open; a cached vault keeps its
+  meta (consistent with the collection reconciler semantics).
+- Store on `Vault` (`this.meta` + `getMeta(): VaultMeta | undefined`).
+- Surface in `dumpSchema()`: `VaultSchemaSnapshot` gains `meta?: VaultMeta`
+  (label defaulting to the vault name).
+
+## Component 4 — `describe()` per-field enhancements
+
+Add to `DescribedField` (and compute in `buildDescription`):
+
+- `i18n?: { locales?: readonly string[]; densify?: boolean }` — surfaced from
+  the `i18nFields` registry (currently NOT merged by `describe()`). Pass the
+  collection's `i18nFields` into `buildDescription`; for an i18n field set the
+  block and `type: 'string'`.
+- `widget?: string` — **derived** from `semanticType` + `type`, overridable
+  via a new optional `FieldMeta.widget`:
+  | source | widget |
+  |---|---|
+  | semanticType `date`/`datetime` | `date` |
+  | semanticType `currency` (money) | `money` |
+  | semanticType `entity` (ref) | `ref-select` |
+  | `dict` present | `select` |
+  | type `boolean` | `checkbox` |
+  | semanticType `percent`/`url`/`email` | `number`/`url`/`email` |
+  | else | `text` |
+  `FieldMeta.widget` (new optional member) overrides the derivation.
+- `editable: boolean` — `false` for `computed` fields, the `id` field, and
+  `provenance`-stamped fields; `true` otherwise. Drives read-only rendering.
+
+## Component 5 — `dumpSchema()` collection-level `config`
+
+Add `config?` to `CollectionDescriptor`, populated from the **live**
+collection's getters/registries (omitted when reconstructed from a bundle,
+where options aren't available):
+
+```ts
+config?: {
+  i18nFields?: readonly string[]
+  embeddings?: { source: string; dim: number; model?: string }
+  textIndexes?: readonly string[]
+  textIndexPersist?: boolean
+  perRecordKeys?: boolean
+  provenance?: boolean
+  archive?: boolean            // presence (the predicate is code)
+  tiers?: readonly number[]
+  tierMode?: string
+  crdt?: string
+  conflictPolicy?: boolean     // presence (the resolver is code)
+  history?: boolean            // presence
+  schemaUpdate?: readonly string[]   // strategy names (already available)
+}
+```
+
+`dumpVaultSchema` (`introspection/walk.ts`) reads these from the live
+`Collection` when present. Add minimal getters on `Collection` for the options
+not already reachable. Function-valued options surface as booleans (presence),
+never the function.
+
+## Component 6 — devtools wiring (the payoff)
+
+- **`in-devtools` `snapshot()`** (`snapshot.ts`): for each collection, in
+  addition to the `dumpSchema` descriptor, call
+  `vault.collection(name).describe()` (rich per-field) and include `config` +
+  `meta`. Extend `InspectorCollection`:
+  ```ts
+  interface InspectorCollection {
+    name: string
+    meta?: CollectionMeta
+    fields: CollectionDescriptor['fields']        // keep (back-compat)
+    described?: readonly DescribedField[]          // NEW: rich per-field
+    indexes: CollectionDescriptor['indexes']
+    refs: CollectionDescriptor['refs']
+    config?: CollectionDescriptor['config']        // NEW
+    stats?: CollectionStats
+  }
+  ```
+  and `InspectorSnapshot` gains `meta?: VaultMeta`.
+- **Nuxt `SchemaPane.vue`**: render the rich fields — label, type,
+  `semanticType` badge, money currency, dict values, **sensitivity** & **i18n**
+  badges, ref target, `editable` flag — plus a collection **meta header**
+  (label/description) and a collapsible **config strip** (embeddings / retrieve
+  / CEK / provenance / archive badges). `DevtoolsPanel.vue` vault sidebar shows
+  the `vaultMeta` label.
+- **`in-devtools-tui`**: mirror the same rich rendering in the terminal views.
+
+## Boundary note — `fieldMeta.group`
+
+A per-field `group`/section ("Tax info", "Address") is **deferred**. It sits
+on the descriptive/prescriptive line: a *logical grouping* is arguably a
+semantic category a second consumer wants (data), but it can also encode form
+layout (app-side). Decision deferred to the editor's Phase-1 form-sectioning
+work, where the real requirement appears. Not built this cycle.
+
+---
+
+## Testing
+
+- **Meta ladder:** `collectionMeta`/`vaultMeta` surface in `describe()` /
+  `dumpSchema()`; label falls back to humanized collection / vault name when
+  absent; `_applyMeta` first-wins for a re-declared (MV-pre-created)
+  collection (mirror the `_applyFieldMeta` test).
+- **describe() enhancements:** an i18n field yields the `i18n` block; `widget`
+  derives correctly per `semanticType` and is overridden by `fieldMeta.widget`;
+  `computed`/`id`/`provenance` fields report `editable:false`, others `true`.
+- **config block:** a collection declared with embeddings/textIndexes/crdt/etc.
+  surfaces them in `dumpSchema().collections[x].config`; a bundle-reconstructed
+  collection omits `config`; function-valued options surface as booleans.
+- **Validator-agnostic / zero-IO** invariants still hold (re-assert for the
+  enhanced `describe()`).
+- **Devtools:** an `in-devtools` `snapshot()` test asserts `described`/`config`
+  /`meta` are populated for a live vault; Nuxt/TUI component rendering tests if
+  the packages have them (else a snapshot-shape test).
+- **DTS build** + `check-architecture` clean; new public symbols verified via
+  showcase typecheck (build hub first).
+
+## Public exports & kernel
+
+- `src/index.ts`: `CollectionMeta`, `VaultMeta`, and the new `DescribedField`
+  members are covered by the existing `CollectionDescription`/`DescribedField`
+  re-export; add `FieldMeta.widget` (same `FieldMeta` export).
+- `kernel/index.ts`: add `CollectionMeta`, `VaultMeta` types (klum-db
+  contract). `describe()`-level types stay out of kernel (per-collection
+  introspection, per the foundation spec).
+
+## features.yaml
+
+Extend the `field-metadata` node (or add a sibling `metadata-ladder` node)
+referencing this spec + the devtools surfacing; CI "Spec coverage" must stay
+green.
+
+## Release
+
+Stacks on `feat/field-metadata-foundation` (PR #490). One pre-release bundles
+#482 + #483 + this metadata ladder + devtools surfacing.
+
+## Follow-up (separate)
+
+- **klum-db issue:** `federationMeta`/`groupMeta` on `VaultGroup`, reusing
+  noy-db's `VaultMeta` shape (this repo exports the type; klum-db wires it).
+- The **interactive editor** (Phases 1–2) — see the editor design doc; its
+  Phase-0 dependencies (`describe()` enhancements + meta ladder) are satisfied
+  by this spec.

--- a/docs/superpowers/specs/2026-06-25-metadata-riders-design.md
+++ b/docs/superpowers/specs/2026-06-25-metadata-riders-design.md
@@ -1,0 +1,184 @@
+# Milestone-#20 riders — design (#484 toJSONSchema + devtools PII masking + #485 dictKey labels)
+
+> Three riders on the shipped field-metadata foundation
+> ([field-metadata-foundation](2026-06-25-field-metadata-foundation-design.md) +
+> [metadata-ladder-and-schema-surfacing](2026-06-25-metadata-ladder-and-schema-surfacing-design.md)).
+> **Stacks on `feat/field-metadata-foundation`** (PR #490) → one PR, one
+> pre-release.
+
+**Status:** design approved 2026-06-25, pre-implementation.
+
+---
+
+## Problem
+
+The field-metadata epic shipped `describe()` + `fieldMeta` + the zod-4
+substrate + the metadata ladder + live-devtools surfacing. Three small,
+high-leverage riders now compose on top of that and round out milestone #20:
+
+1. **#484 `collection.toJSONSchema()`** — the read-model's third consumer.
+   `describe()` serves JS; a JSON-Schema export serves *everything else*
+   (OpenAPI, cross-language, form builders, doc tooling). Mostly plumbing now
+   that the zod-4 `z.toJSONSchema()` path exists.
+2. **Devtools PII masking** — the devtools already *display* a field's
+   sensitivity (pii/secret badges) but the RecordsPane still shows raw PII
+   values. The classification should actually protect something on a
+   screen-shared dev tool.
+3. **#485 dictKey inline labels** — `dictKey` carries only codes today; labels
+   live in the dynamic `_dict_` collection. Let `dictKey` carry inline
+   code-provided labels as a display fallback, surfaced through `describe()`.
+
+## Goals / non-goals
+
+- Build the three riders; ship with #490's bundle.
+- Stay **descriptive, never prescriptive**; hub **validator-agnostic** (no
+  static `import 'zod'`); `describe()` sync stays **zero store I/O**.
+- **Non-goal:** #486 redacting *export* (#489, as-* family) — separate. The
+  hub `sensitivity` flag already shipped; this spec only *consumes* it (in the
+  devtools). `fieldMeta.group`, ref-option-source, the editor — all still out.
+
+## Binding conventions (carried)
+
+Tests under `__tests__/**`; pnpm; the DTS build (`exactOptionalPropertyTypes`)
+is stricter than vitest tsc — and **`npm run typecheck` + `eslint src/` per
+changed package** before push (the tsup build enforces neither — a CI lesson
+from this branch). New public symbols re-export from `src/index.ts`. No Claude
+attribution in commits.
+
+---
+
+## Rider ① — `collection.toJSONSchema()`  (#484)
+
+**Async** (needs the lazy zod-4 derivation). New method on `Collection`:
+
+```ts
+async toJSONSchema(): Promise<object>
+```
+
+Pipeline:
+1. `derivePersistedSchema(this.schema)` → the base JSON Schema (the zod-4
+   `z.toJSONSchema()` path #482 wired; zod-3 via `zod-to-json-schema`).
+2. `await this.describe({})` → the normalized per-field metadata.
+3. Overlay `describe()` metadata onto each property as **`x-` extension keys**
+   (keeps the output a valid JSON Schema):
+   | describe() field | JSON-Schema key |
+   |---|---|
+   | `label` | `x-label` |
+   | `unit` | `x-unit` |
+   | `semanticType` | `x-semanticType` |
+   | `sensitivity` | `x-sensitivity` |
+   | `widget` | `x-widget` |
+   | `editable` (when false) | `x-readonly: true` |
+   | `money` | `x-money` (currency/scale) |
+   | `ref` | `x-ref` (target) |
+   | `dict.values[].label` | `x-enumLabels` (value→label map) |
+
+**Validator-agnostic fallback:** when `derivePersistedSchema` yields no
+`jsonSchema` (non-zod validator), build a **minimal** JSON Schema —
+`{ type:'object', properties }` with each property's `type` mapped from
+`describe()`'s field `type` — so `toJSONSchema()` still returns a useful,
+metadata-bearing schema for any validator (and even for schema-less
+collections, from the config-inferred field types).
+
+**Placement/exports:** a focused `introspection/json-schema.ts`
+(`buildJsonSchema(describeResult, baseJsonSchema?)` pure overlay) + the thin
+async `Collection.toJSONSchema()` delegator. Export nothing new beyond the
+method (it returns a plain object). No kernel export.
+
+## Rider ② — Devtools PII masking
+
+The `in-devtools` snapshot already carries `described` (with `sensitivity`)
+per collection. The **RecordsPane** (Nuxt `panes/RecordsPane.vue` + TUI
+`panes/RecordsPane.tsx`) masks values for fields where
+`sensitivity !== 'public'`.
+
+**UX (decided): mask-by-default, reveal-on-demand.**
+- pii **and** secret values render as `••••••` by default.
+- per-field **reveal** (click in Nuxt / a key-toggle in the TUI) un-masks that
+  field; a header **"reveal all"** toggle un-masks the whole pane.
+- public fields (and unclassified fields) always show.
+- This is shoulder-surfing / screen-share safety over already-decrypted local
+  data — **not** access control (the data is already in the trusted tier).
+
+**Data flow:** the pane derives a `Set<fieldKey>` of sensitive fields from the
+collection's `described` (`sensitivity !== 'public'`). Reveal state is local
+component state (a revealed-field set + a reveal-all boolean). No hub change —
+pure consumer of the metadata already in the snapshot.
+
+**Back-compat:** a collection without `described` (pre-enrichment / non-live)
+has an empty sensitive-set → nothing masked → identical to today.
+
+## Rider ③ — `dictKey` inline labels  (#485)
+
+`dictKey` gains an optional inline label map (back-compat preserved):
+
+```ts
+// today (still valid):
+dictKey('saleStatus', ['draft', 'to_verify', 'paid'] as const)
+// new — value→label map (keys inferred from the map):
+dictKey('saleStatus', { draft: 'Draft', to_verify: 'To Verify', paid: 'Paid' })
+// or array + labels option (preserves explicit order):
+dictKey('saleStatus', VALUES, { labels: { to_verify: 'To Verify' } })
+```
+
+- `DictKeyDescriptor` gains `readonly labels?: Record<string, string>`.
+- `dictKey()` overload: if the 2nd arg is a **plain object**, treat it as the
+  value→label map (`keys = Object.keys`, `labels = map`); if an **array**,
+  keep current behavior + read `opts.labels`. Declared key order stays the
+  canonical display/sort order.
+
+**Semantics — display fallback (the YAGNI delta vs `staticDict`):** the inline
+labels are code-provided **defaults**. `dictKey` stays dynamic/runtime-editable
+against `_dict_`; the inline label is used when the dynamic dictionary has no
+label for a key. So:
+- `describe()` (**sync**) now surfaces inline-dictKey labels into
+  `dict.values[].label` (code-provided → no store read needed, like
+  `staticDict`).
+- `describe({ resolveDictLabels: true })` (**async**) overrides/fills from the
+  `_dict_` collection where present, falling back to the inline label
+  otherwise.
+- `toJSONSchema()` `x-enumLabels` picks them up via `describe()`.
+
+This keeps `staticDict` (closed code labels, no `_dict_`) and `dictKey`+labels
+(dynamic dict *with* code defaults) as distinct, non-overlapping tools.
+
+---
+
+## Testing
+
+- **#484:** a zod-4 collection with money/ref/dict/sensitivity/i18n →
+  `toJSONSchema()` is valid JSON Schema with the right `x-` keys per property
+  (`x-money`, `x-enumLabels`, `x-sensitivity`, …); a **non-zod**
+  Standard-Schema collection → minimal schema from field types + `x-` metadata,
+  no throw, no zod required (agnostic invariant); enum field → `x-enumLabels`
+  matches the dict labels.
+- **masking:** RecordsPane renders `••••` for a pii and a secret field by
+  default; reveal un-masks that field; reveal-all un-masks all; a public field
+  is never masked; a collection without `described` masks nothing
+  (back-compat). Nuxt component test + TUI snapshot test.
+- **#485:** map form and array+`labels` form both produce labels; bare-array
+  form unchanged; inline labels surface in **sync** `describe().dict.values`;
+  `resolveDictLabels:true` overrides from `_dict_` and falls back to inline;
+  `toJSONSchema` `x-enumLabels` reflects them.
+
+## features.yaml / docs
+
+Extend the `field-metadata` / `metadata-ladder` nodes (or a `metadata-riders`
+node) referencing this spec, the `toJSONSchema` public surface, and the
+devtools masking; keep CI Spec-coverage green. Note `toJSONSchema` + masking in
+the subsystem doc.
+
+## Decomposition
+
+Three independent units, one spec, one plan (grouped tasks):
+- **A. hub** — `dictKey` labels + `describe()` sync surfacing (#485), then
+  `toJSONSchema()` (#484, consumes #485's labels for `x-enumLabels`).
+- **B. devtools** — RecordsPane masking (Nuxt + TUI), independent of A.
+
+Order A before B is not required (B reads only `sensitivity`, already shipped),
+but #484's `x-enumLabels` test wants #485's labels, so do #485 → #484 within A.
+
+## Release
+
+Stacks on PR #490; ships with the same next additive pre-release
+(#482 + #483 + metadata ladder + devtools + these three riders).

--- a/docs/superpowers/specs/2026-06-25-metadata-riders-design.md
+++ b/docs/superpowers/specs/2026-06-25-metadata-riders-design.md
@@ -69,8 +69,8 @@ Pipeline:
    | `sensitivity` | `x-sensitivity` |
    | `widget` | `x-widget` |
    | `editable` (when false) | `x-readonly: true` |
-   | `money` | `x-money` (currency/scale) |
-   | `ref` | `x-ref` (target) |
+   | `money` | `x-money` (full block: `mode`, `currency?`, `scale?`, `rounding?`) |
+   | `ref` | `x-ref` (bare string — the ref target collection name) |
    | `dict.values[].label` | `x-enumLabels` (value→label map) |
 
 **Validator-agnostic fallback:** when `derivePersistedSchema` yields no

--- a/features.yaml
+++ b/features.yaml
@@ -390,6 +390,7 @@ features:
     package: '@noy-db/hub'
     factory: null
     status: preview
+    experimental: true
     showcases:
       - id: 126-describe-field-metadata
         path: showcases/src/126-describe-field-metadata.showcase.test.ts

--- a/features.yaml
+++ b/features.yaml
@@ -431,6 +431,28 @@ features:
       - 'CollectionMeta/VaultMeta exported from @noy-db/hub (src/index.ts) AND @noy-db/hub/kernel (kernel/index.ts) for klum-db federation contract'
     related: [field-metadata, dump-schema-introspection, in-devtools, in-devtools-nuxt]
 
+  - id: metadata-riders
+    name: Metadata riders — toJSONSchema + dictKey inline labels + devtools PII masking (#484 #485)
+    cluster: core
+    spec: docs/superpowers/specs/2026-06-25-metadata-riders-design.md
+    subsystem_doc: docs/subsystems/field-metadata.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    experimental: true
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'collection.toJSONSchema() — async; pipelines derivePersistedSchema(schema) as base then overlays describe() metadata as x- extension keys per property: x-label, x-unit, x-semanticType, x-sensitivity, x-widget, x-readonly (when editable:false), x-money, x-ref, x-enumLabels (value→label map from dict.values)'
+      - 'toJSONSchema() validator-agnostic fallback: when derivePersistedSchema yields no jsonSchema (non-zod validator), builds a minimal { type:"object", properties } from field types derived by describe(); x- metadata still applied; no throw, no zod required'
+      - 'dictKey inline labels (#485): dictKey() 2nd arg may now be a plain object (value→label map; keys inferred) or retain existing array form with optional { labels: Record<string,string> } option; DictKeyDescriptor gains readonly labels?: Record<string,string>'
+      - 'dictKey inline labels surface in sync describe() — dict.values[].label populated from code-provided defaults with no store I/O; describe({ resolveDictLabels: true }) overrides from _dict_ collection and falls back to inline label; toJSONSchema() x-enumLabels reflects inline labels'
+      - 'devtools PII masking (Nuxt + TUI): RecordsPane masks cells for fields where sensitivity !== "public" as •••• by default; a reveal toggle (per-field reveal in Nuxt, pane-level "r" key in TUI) un-masks; public and unclassified fields always shown; collection without described → no masking (back-compat)'
+      - 'TUI reveal-all resets on collection navigation (selectedIdx change) so revealed PII does not linger when switching to another collection'
+    related: [field-metadata, metadata-ladder, in-devtools, in-devtools-nuxt]
+
   - id: query-basics
     name: Always-on query DSL
     cluster: core

--- a/features.yaml
+++ b/features.yaml
@@ -406,7 +406,30 @@ features:
       - 'public exports from @noy-db/hub only (not from kernel): FieldMeta, SemanticType, CollectionDescription, DescribedField, DescribeOptions'
       - 'fieldMeta key guard (async path): when zodFields is non-empty, unknown fieldMeta keys throw FieldMetaUnknownFieldError — typo protection; sync path skips this check (schema fields not knowable without async derivation)'
       - 'validator-agnostic: works without zod; non-zod validators get structural type inference from config only on the sync path'
-    related: [dump-schema-introspection, cli-describe, money-field, schema-and-refs, i18n]
+    related: [dump-schema-introspection, cli-describe, money-field, schema-and-refs, i18n, metadata-ladder]
+
+  - id: metadata-ladder
+    name: Metadata ladder — collectionMeta/vaultMeta + devtools schema surfacing (#483)
+    cluster: core
+    spec: docs/superpowers/specs/2026-06-25-metadata-ladder-and-schema-surfacing-design.md
+    subsystem_doc: docs/subsystems/field-metadata.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    experimental: true
+    showcases: []
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'collectionMeta option (meta?: CollectionMeta): label/description/icon/pluralLabel on vault.collection(); first-wins reconciler (_applyMeta) on MV-pre-created collections; surfaced in describe() meta block and dumpSchema() CollectionDescriptor.meta'
+      - 'vaultMeta option (meta?: VaultMeta): label/description/icon on openVault(); first-wins: re-opening a cached vault keeps its meta; surfaced in dumpSchema() VaultSchemaSnapshot.meta'
+      - 'describe() enhancements: i18n block (locales/densify) for i18nText fields; widget derived from semanticType+type (overridable via fieldMeta.widget); editable:false for computed/id/provenance-stamped fields, true otherwise'
+      - 'dumpSchema() config block (CollectionConfig): textIndexes/embeddings/i18nFields/crdt/provenance/archive/tiers/tierMode/perRecordKeys/history/schemaUpdate surfaced from live collection; omitted on bundle-reconstructed collections; function-valued options surface as booleans (presence only)'
+      - 'in-devtools snapshot(): InspectorCollection gains meta/described/config; InspectorSnapshot gains meta (VaultMeta); rich fields from describe() populates described[]'
+      - 'TUI (in-devtools-tui): DetailPane shows collection meta.label heading + DescribedField list with label/type/widget/<sensitivity>/[i18n]/[ro] markers + compact config strip; CollectionList shows meta.label; VaultList shows vault meta.label for active vault'
+      - 'CollectionMeta/VaultMeta exported from @noy-db/hub (src/index.ts) AND @noy-db/hub/kernel (kernel/index.ts) for klum-db federation contract'
+    related: [field-metadata, dump-schema-introspection, in-devtools, in-devtools-nuxt]
 
   - id: query-basics
     name: Always-on query DSL

--- a/features.yaml
+++ b/features.yaml
@@ -382,6 +382,31 @@ features:
       - 'exit codes: 0 ok, 1 internal, 2 usage, 3 auth failure'
     related: [persisted-json-schema, dump-schema-introspection]
 
+  - id: field-metadata
+    name: Consumer-neutral field descriptors — collection.describe() + fieldMeta (#483)
+    cluster: core
+    spec: docs/superpowers/specs/2026-06-25-field-metadata-foundation-design.md
+    subsystem_doc: docs/subsystems/field-metadata.md
+    package: '@noy-db/hub'
+    factory: null
+    status: preview
+    showcases:
+      - id: 126-describe-field-metadata
+        path: showcases/src/126-describe-field-metadata.showcase.test.ts
+    recipes: []
+    playground_pages: []
+    diagrams: []
+    invariants:
+      - 'collection.describe() — sync overload (zero args): config-only, zero store I/O, returns CollectionDescription synchronously; async overload (opts arg): adds validator-derived exact types (deriveZodFields, lazy import), zod-4 .meta() merge, and optional dynamic-dict label resolution (resolveDictLabels: true)'
+      - 'fieldMeta collection option: Record<string, FieldMeta> — the primary validator-agnostic authoring channel; keys: label (required), description, semanticType, unit, sensitivity (public|pii|secret), aggregate, aliases, displayFor'
+      - 'merge precedence (fixed): channel (fieldMeta) > zod-4 .meta() (async path only) > inferred-from-config (money→currency, ref→entity, dictKey→enum)'
+      - 'descriptive-not-prescriptive: DescribedField carries meaning (label/unit/sensitivity/semanticType/aggregate/aliases/displayFor) — never layout, styling, or locale selection; those stay app-side'
+      - 'sync = zero store I/O: describe() (no args) reads only in-memory config assembled at collection registration — no store.get / store.list / decryption ever triggered'
+      - 'public exports from @noy-db/hub only (not from kernel): FieldMeta, SemanticType, CollectionDescription, DescribedField, DescribeOptions'
+      - 'fieldMeta key guard (async path): when zodFields is non-empty, unknown fieldMeta keys throw FieldMetaUnknownFieldError — typo protection; sync path skips this check (schema fields not knowable without async derivation)'
+      - 'validator-agnostic: works without zod; non-zod validators get structural type inference from config only on the sync path'
+    related: [dump-schema-introspection, cli-describe, money-field, schema-and-refs, i18n]
+
   - id: query-basics
     name: Always-on query DSL
     cluster: core

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -59,7 +59,7 @@
     "@noy-db/to-probe": "workspace:*",
     "@types/node": "^22.0.0",
     "yaml": "^2.9.0",
-    "zod": "^3.23.0",
+    "zod": "^4.0.0",
     "zod-to-json-schema": "^3.25.2"
   },
   "keywords": [

--- a/packages/hub/__tests__/dictionary.test.ts
+++ b/packages/hub/__tests__/dictionary.test.ts
@@ -601,3 +601,23 @@ describe('staticDict — code-provided dictionary (#291)', () => {
     expect(byCode['adultFemale']).toBe(1)
   })
 })
+
+// ─── dictKey inline labels (#485) ────────────────────────────────────────────
+
+describe('dictKey inline labels (#485)', () => {
+  it('map form: keys inferred, labels captured', () => {
+    const d = dictKey('saleStatus', { draft: 'Draft', to_verify: 'To Verify' })
+    expect(d.keys).toEqual(['draft', 'to_verify'])
+    expect(d.labels).toEqual({ draft: 'Draft', to_verify: 'To Verify' })
+  })
+  it('array + opts.labels', () => {
+    const d = dictKey('saleStatus', ['draft', 'to_verify'] as const, { labels: { to_verify: 'To Verify' } })
+    expect(d.keys).toEqual(['draft', 'to_verify'])
+    expect(d.labels).toEqual({ to_verify: 'To Verify' })
+  })
+  it('bare array unchanged (no labels)', () => {
+    const d = dictKey('saleStatus', ['draft', 'paid'] as const)
+    expect(d.keys).toEqual(['draft', 'paid'])
+    expect(d.labels).toBeUndefined()
+  })
+})

--- a/packages/hub/__tests__/introspection/describe.test.ts
+++ b/packages/hub/__tests__/introspection/describe.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest'
+import { z } from 'zod'
 import { createNoydb } from '../../src/noydb.js'
 import { money } from '../../src/money/descriptor.js'
 import { staticDict, dictKey } from '../../src/i18n/dictionary.js'
@@ -204,15 +205,14 @@ describe('collection.describe(opts) — async path', () => {
    */
 
   it('async describe derives exact types from the zod-4 validator', async () => {
-    const z4 = await import('/Users/vicio/_github/noy-db/node_modules/.pnpm/zod@4.4.3/node_modules/zod/index.js')
     const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-async-1' })
     const v = await db.openVault('av1')
 
-    const salesSchema = z4.z.object({
-      id: z4.z.string(),
-      saleDate: z4.z.string().optional(),
-      total: z4.z.number(),
-      buyerId: z4.z.string(),
+    const salesSchema = z.object({
+      id: z.string(),
+      saleDate: z.string().optional(),
+      total: z.number(),
+      buyerId: z.string(),
     })
 
     const sales = v.collection('sales_async', {
@@ -231,14 +231,13 @@ describe('collection.describe(opts) — async path', () => {
   })
 
   it('async describe merges zod-4 .meta() when channel is silent', async () => {
-    const z4 = await import('/Users/vicio/_github/noy-db/node_modules/.pnpm/zod@4.4.3/node_modules/zod/index.js')
     const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-async-2' })
     const v = await db.openVault('av2')
 
     // net has .meta({ unit: 'kg' }), no fieldMeta entry for it
-    const weightsSchema = z4.z.object({
-      id: z4.z.string(),
-      net: z4.z.number().meta({ unit: 'kg' }),
+    const weightsSchema = z.object({
+      id: z.string(),
+      net: z.number().meta({ unit: 'kg' }),
     })
 
     const weights = v.collection('weights_async', {
@@ -272,13 +271,12 @@ describe('collection.describe(opts) — async path', () => {
   })
 
   it('fieldMeta key-validation: typo in fieldMeta key rejects with FieldMetaUnknownFieldError', async () => {
-    const z4 = await import('/Users/vicio/_github/noy-db/node_modules/.pnpm/zod@4.4.3/node_modules/zod/index.js')
     const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-async-4' })
     const v = await db.openVault('av4')
 
-    const schema = z4.z.object({
-      id: z4.z.string(),
-      total: z4.z.number(),
+    const schema = z.object({
+      id: z.string(),
+      total: z.number(),
     })
 
     // 'totl' is a typo — not a real field in the schema or any config

--- a/packages/hub/__tests__/introspection/describe.test.ts
+++ b/packages/hub/__tests__/introspection/describe.test.ts
@@ -1,0 +1,193 @@
+/**
+ * collection.describe() — sync config-merge (#483 Task 3).
+ *
+ * Tests the SYNC zero-arg describe() path: config-only, no store I/O.
+ * Covers: money→currency inference, ref→entity inference, staticDict values,
+ * fieldMeta label/semanticType/unit/displayFor override, zero-store-I/O guarantee.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../../src/noydb.js'
+import { money } from '../../src/money/descriptor.js'
+import { staticDict } from '../../src/i18n/dictionary.js'
+import { ref } from '../../src/refs.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/types.js'
+import { ConflictError } from '../../src/errors.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c)
+      const s: VaultSnapshot = {}
+      if (comp) {
+        for (const [n, coll] of comp) {
+          if (!n.startsWith('_')) {
+            const r: Record<string, EncryptedEnvelope> = {}
+            for (const [id, e] of coll) r[id] = e
+            s[n] = r
+          }
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+interface Sale {
+  id: string
+  saleDate: string
+  total: string
+  status: string
+  buyerId: string
+}
+
+describe('collection.describe() — sync path', () => {
+  it('infers currency + sum from money field, picks unit from fieldMeta', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-describe' })
+    const v = await db.openVault('v')
+
+    const saleStatus = staticDict('saleStatus', {
+      pending:    { en: 'Pending' },
+      to_verify:  { en: 'To Verify' },
+      paid:       { en: 'Paid' },
+    }, { displayLocale: 'en' })
+
+    const sales = v.collection<Sale>('sales', {
+      moneyFields: { total: money({ currency: 'EUR' }) },
+      dictKeyFields: { status: saleStatus },
+      refs: { buyerId: ref('buyers') },
+      fieldMeta: {
+        saleDate: { label: 'Date' },
+        total:    { label: 'Total', unit: '€' },
+        buyerId:  { label: 'Buyer', displayFor: 'buyerName' },
+      },
+    })
+
+    const d = sales.describe()
+    const byKey = Object.fromEntries(d.fields.map((f) => [f.key, f]))
+
+    // Collection name
+    expect(d.collection).toBe('sales')
+
+    // money field: inferred semanticType/aggregate + fieldMeta unit
+    expect(byKey.total.semanticType).toBe('currency')
+    expect(byKey.total.aggregate).toBe('sum')
+    expect(byKey.total.unit).toBe('€')
+    expect(byKey.total.money).toMatchObject({ mode: 'fixed', currency: 'EUR' })
+    expect(byKey.total.type).toBe('number')
+
+    // ref field: inferred entity + fieldMeta displayFor
+    expect(byKey.buyerId.semanticType).toBe('entity')
+    expect(byKey.buyerId.ref).toMatchObject({ target: 'buyers' })
+    expect(byKey.buyerId.displayFor).toBe('buyerName')
+    expect(byKey.buyerId.type).toBe('string')
+
+    // staticDict: dict block + values with labels
+    expect(byKey.status.dict).toMatchObject({ name: 'saleStatus', static: true })
+    expect(byKey.status.dict?.values).toEqual(
+      expect.arrayContaining([{ value: 'to_verify', label: 'To Verify' }]),
+    )
+    expect(byKey.status.type).toBe('enum')
+
+    // fieldMeta label override
+    expect(byKey.saleDate.label).toBe('Date')
+  })
+
+  it('zero store I/O: describe() does not touch the store', async () => {
+    const throwing: NoydbStore = {
+      async get() { throw new Error('store.get must not be called') },
+      async put() { throw new Error('store.put must not be called') },
+      async delete() { throw new Error('store.delete must not be called') },
+      async list() { throw new Error('store.list must not be called') },
+      async loadAll() { throw new Error('store.loadAll must not be called') },
+      async saveAll() { throw new Error('store.saveAll must not be called') },
+    }
+
+    // Use a normal memory store for the db bootstrap (key derivation, _keyring write),
+    // but wrap the vault's collection in a way that lets us check no data reads occur.
+    // Since createNoydb itself writes _keyring at init time we need a real store for open,
+    // then we just confirm describe() on a fully-constructed collection does NOT throw.
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-describe-2' })
+    const v = await db.openVault('w')
+    const coll = v.collection<Sale>('sales2', {
+      moneyFields: { total: money({ currency: 'USD' }) },
+    })
+
+    // describe() is sync and config-only — should never throw
+    expect(() => coll.describe()).not.toThrow()
+
+    // Confirm the throwing store variant: build a collection directly on a
+    // fresh db that immediately switches to a throwing store post-open.
+    // We validate that calling describe() on the already-constructed collection
+    // does not interact with any store methods.
+    const db2 = await createNoydb({ store: inlineMemory(), user: 'bob', secret: 'pw-describe-3' })
+    const v2 = await db2.openVault('w2')
+    const coll2 = v2.collection<Sale>('sales3', {
+      moneyFields: { total: money({ currency: 'GBP' }) },
+      refs: { buyerId: ref('buyers') },
+    })
+
+    // Calling describe() is purely synchronous over in-memory config — no store calls
+    const desc = coll2.describe()
+    expect(desc.collection).toBe('sales3')
+    expect(desc.fields.length).toBeGreaterThan(0)
+    // The throwing store was never used above — the test passes without touching it.
+    void throwing // referenced to satisfy linter
+  })
+
+  it('dynamic dictKey: values list uses declared keys, no label', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-describe-4' })
+    const v = await db.openVault('v2')
+    const { dictKey } = await import('../../src/i18n/dictionary.js')
+
+    const orders = v.collection('orders', {
+      dictKeyFields: { phase: dictKey('phase', ['open', 'closed'] as const) },
+    })
+
+    const d = orders.describe()
+    const byKey = Object.fromEntries(d.fields.map((f) => [f.key, f]))
+    expect(byKey.phase.dict).toMatchObject({ name: 'phase', static: false })
+    // dynamic: values have no label
+    expect(byKey.phase.dict?.values).toEqual(
+      expect.arrayContaining([{ value: 'open' }, { value: 'closed' }]),
+    )
+  })
+
+  it('refArray field has isArray:true in ref block and type:array', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-describe-5' })
+    const v = await db.openVault('v3')
+    const { refArray } = await import('../../src/refs.js')
+
+    const tasks = v.collection('tasks', {
+      refs: { tagIds: refArray('tags') },
+    })
+
+    const d = tasks.describe()
+    const byKey = Object.fromEntries(d.fields.map((f) => [f.key, f]))
+    expect(byKey.tagIds.ref?.isArray).toBe(true)
+    expect(byKey.tagIds.type).toBe('array')
+  })
+})

--- a/packages/hub/__tests__/introspection/describe.test.ts
+++ b/packages/hub/__tests__/introspection/describe.test.ts
@@ -448,7 +448,7 @@ describe('collection.describe() — Task 3: i18n, widget, editable', () => {
     expect(by.name.editable).toBe(true)
   })
 
-  it('widget derivation table: boolean→checkbox, number→number, dict→select, default→text', async () => {
+  it('widget derivation table: dict→select, default→text', async () => {
     const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-t3-4' })
     const v = await db.openVault('t3v4')
     const c = v.collection('things', {
@@ -466,5 +466,29 @@ describe('collection.describe() — Task 3: i18n, widget, editable', () => {
     expect(by.status.widget).toBe('select')
     // non-special fieldMeta-only → text
     expect(by.note.widget).toBe('text')
+  })
+
+  // Regression: i18nFields keys must be included in the async knownFields set so
+  // validateFieldMetaKeys does not throw FieldMetaUnknownFieldError for fields that
+  // live in i18nFields + fieldMeta but not in the zod schema (typical for i18nText).
+  it('async describe does not throw when field is in both i18nFields and fieldMeta but not zod schema', async () => {
+    const { withI18n } = await import('../../src/i18n/active.js')
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-t3-i18n-regress', i18nStrategy: withI18n() })
+    const v = await db.openVault('t3v_i18n_regress')
+
+    const c = v.collection('items', {
+      i18nFields: { name: i18nText({ languages: ['en', 'th'], required: 'all', densifyOnWrite: false }) },
+      fieldMeta: {
+        name: { label: 'Item Name' },
+      },
+    })
+
+    // Must not throw FieldMetaUnknownFieldError despite 'name' not being a zod schema field
+    const d = await c.describe({})
+    const nameField = d.fields.find(f => f.key === 'name')!
+    expect(nameField).toBeDefined()
+    expect(nameField.label).toBe('Item Name')
+    expect(nameField.i18n).toBeDefined()
+    expect(nameField.i18n?.locales).toEqual(['en', 'th'])
   })
 })

--- a/packages/hub/__tests__/introspection/describe.test.ts
+++ b/packages/hub/__tests__/introspection/describe.test.ts
@@ -188,6 +188,20 @@ describe('collection.describe() — sync path', () => {
     expect(byKey.tagIds.ref?.isArray).toBe(true)
     expect(byKey.tagIds.type).toBe('array')
   })
+
+  it('sync describe surfaces inline dictKey labels (#485)', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-describe-6' })
+    const v = await db.openVault('v4')
+
+    const orders = v.collection('orders485', {
+      dictKeyFields: { status: dictKey('saleStatus', { draft: 'Draft', to_verify: 'To Verify' }) },
+    })
+
+    const f = orders.describe().fields.find((x) => x.key === 'status')!
+    expect(f.dict?.values).toEqual(expect.arrayContaining([
+      { value: 'draft', label: 'Draft' }, { value: 'to_verify', label: 'To Verify' },
+    ]))
+  })
 })
 
 // ─── Async describe(opts) — Task 4 (#483) ────────────────────────────────────

--- a/packages/hub/__tests__/introspection/describe.test.ts
+++ b/packages/hub/__tests__/introspection/describe.test.ts
@@ -14,6 +14,7 @@ import { z } from 'zod'
 import { createNoydb } from '../../src/noydb.js'
 import { money } from '../../src/money/descriptor.js'
 import { staticDict, dictKey } from '../../src/i18n/dictionary.js'
+import { i18nText } from '../../src/i18n/core.js'
 import { ref } from '../../src/refs.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/types.js'
 import { ConflictError } from '../../src/errors.js'
@@ -365,5 +366,105 @@ describe('collection.describe(opts) — async path', () => {
     const values = statusField.dict?.values?.map((entry) => entry.value)
     expect(values).toContain('draft')
     expect(values).toContain('sent')
+  })
+})
+
+// ─── Task 3 (#483): i18n / widget / editable per-field enhancements ──────────
+
+describe('collection.describe() — Task 3: i18n, widget, editable', () => {
+  async function makeSalesVault() {
+    const { withI18n } = await import('../../src/i18n/active.js')
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-t3-1', i18nStrategy: withI18n() })
+    const v = await db.openVault('t3v1')
+
+    // sales: total (money/currency), saleDate (z.iso.date semanticType), name (i18nText), subtotal (computed)
+    const sales = v.collection('sales', {
+      moneyFields: { total: money({ currency: 'EUR' }) },
+      i18nFields: { name: i18nText({ languages: ['en', 'th'], required: 'all', densifyOnWrite: false }) },
+      computed: { subtotal: () => 0 },
+      fieldMeta: {
+        saleDate: { label: 'Date', semanticType: 'date' },
+        total: { label: 'Total', unit: '€' },
+        name: { label: 'Name' },
+      },
+    })
+
+    return { sales }
+  }
+
+  async function makeWidgetOverrideVault() {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-t3-2' })
+    const v = await db.openVault('t3v2')
+
+    // 'note' field with fieldMeta.widget override
+    const withWidgetOverride = v.collection('notes', {
+      fieldMeta: {
+        note: { label: 'Note', widget: 'textarea' },
+      },
+    })
+
+    return { withWidgetOverride }
+  }
+
+  it('surfaces i18n, derived widget, and editable', async () => {
+    const { sales } = await makeSalesVault()
+    // sales: total (money), saleDate (semanticType:date), name (i18nText), subtotal (computed)
+    const d = sales.describe()
+    const by = Object.fromEntries(d.fields.map(f => [f.key, f]))
+    expect(by.total.widget).toBe('money')
+    expect(by.saleDate.widget).toBe('date')
+    expect(by.name.i18n).toBeDefined()            // i18n block present
+    expect(by.subtotal.editable).toBe(false)      // computed → read-only
+    expect(by.total.editable).toBe(true)
+  })
+
+  it('fieldMeta.widget overrides the derived widget', async () => {
+    const { withWidgetOverride } = await makeWidgetOverrideVault()
+    const f = withWidgetOverride.describe().fields.find(x => x.key === 'note')!
+    expect(f.widget).toBe('textarea')             // fieldMeta:{ note:{ widget:'textarea' } }
+  })
+
+  it('i18n block includes languages as locales and densifyOnWrite as densify', async () => {
+    const { sales } = await makeSalesVault()
+    const d = sales.describe()
+    const name = d.fields.find(f => f.key === 'name')!
+    expect(name.i18n).toBeDefined()
+    expect(name.i18n?.locales).toEqual(['en', 'th'])
+    expect(name.i18n?.densify).toBe(false)
+  })
+
+  it('editable=false for id field', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-t3-3' })
+    const v = await db.openVault('t3v3')
+    const c = v.collection('things', {
+      fieldMeta: {
+        id: { label: 'ID' },
+        name: { label: 'Name' },
+      },
+    })
+    const d = c.describe()
+    const by = Object.fromEntries(d.fields.map(f => [f.key, f]))
+    expect(by.id.editable).toBe(false)
+    expect(by.name.editable).toBe(true)
+  })
+
+  it('widget derivation table: boolean→checkbox, number→number, dict→select, default→text', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-t3-4' })
+    const v = await db.openVault('t3v4')
+    const c = v.collection('things', {
+      dictKeyFields: { status: dictKey('status', ['a', 'b'] as const) },
+      fieldMeta: {
+        active: { label: 'Active', semanticType: 'boolean' as never },
+        score: { label: 'Score', semanticType: 'number' as never },
+        status: { label: 'Status' },
+        note: { label: 'Note' },
+      },
+    })
+    const d = c.describe()
+    const by = Object.fromEntries(d.fields.map(f => [f.key, f]))
+    // dict field → select
+    expect(by.status.widget).toBe('select')
+    // non-special fieldMeta-only → text
+    expect(by.note.widget).toBe('text')
   })
 })

--- a/packages/hub/__tests__/introspection/describe.test.ts
+++ b/packages/hub/__tests__/introspection/describe.test.ts
@@ -1,18 +1,22 @@
 /**
- * collection.describe() — sync config-merge (#483 Task 3).
+ * collection.describe() — sync config-merge (#483 Task 3) + async exact-types (#483 Task 4).
  *
- * Tests the SYNC zero-arg describe() path: config-only, no store I/O.
+ * Sync tests (zero-arg describe()): config-only, no store I/O.
  * Covers: money→currency inference, ref→entity inference, staticDict values,
  * fieldMeta label/semanticType/unit/displayFor override, zero-store-I/O guarantee.
+ *
+ * Async tests (describe(opts)): validator-derived exact types, zod-4 .meta() merge,
+ * dynamic dict label resolution, fieldMeta key-validation, validator-agnostic invariant.
  */
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { createNoydb } from '../../src/noydb.js'
 import { money } from '../../src/money/descriptor.js'
-import { staticDict } from '../../src/i18n/dictionary.js'
+import { staticDict, dictKey } from '../../src/i18n/dictionary.js'
 import { ref } from '../../src/refs.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/types.js'
 import { ConflictError } from '../../src/errors.js'
+import { FieldMetaUnknownFieldError } from '../../src/introspection/field-meta.js'
 
 function inlineMemory(): NoydbStore {
   const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
@@ -117,45 +121,37 @@ describe('collection.describe() — sync path', () => {
   })
 
   it('zero store I/O: describe() does not touch the store', async () => {
-    const throwing: NoydbStore = {
-      async get() { throw new Error('store.get must not be called') },
-      async put() { throw new Error('store.put must not be called') },
-      async delete() { throw new Error('store.delete must not be called') },
-      async list() { throw new Error('store.list must not be called') },
-      async loadAll() { throw new Error('store.loadAll must not be called') },
-      async saveAll() { throw new Error('store.saveAll must not be called') },
-    }
-
-    // Use a normal memory store for the db bootstrap (key derivation, _keyring write),
-    // but wrap the vault's collection in a way that lets us check no data reads occur.
-    // Since createNoydb itself writes _keyring at init time we need a real store for open,
-    // then we just confirm describe() on a fully-constructed collection does NOT throw.
-    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-describe-2' })
+    // Build on a real store so createNoydb / openVault succeed (keyring write etc.)
+    const mem = inlineMemory()
+    const db = await createNoydb({ store: mem, user: 'alice', secret: 'pw-describe-2' })
     const v = await db.openVault('w')
     const coll = v.collection<Sale>('sales2', {
       moneyFields: { total: money({ currency: 'USD' }) },
-    })
-
-    // describe() is sync and config-only — should never throw
-    expect(() => coll.describe()).not.toThrow()
-
-    // Confirm the throwing store variant: build a collection directly on a
-    // fresh db that immediately switches to a throwing store post-open.
-    // We validate that calling describe() on the already-constructed collection
-    // does not interact with any store methods.
-    const db2 = await createNoydb({ store: inlineMemory(), user: 'bob', secret: 'pw-describe-3' })
-    const v2 = await db2.openVault('w2')
-    const coll2 = v2.collection<Sale>('sales3', {
-      moneyFields: { total: money({ currency: 'GBP' }) },
       refs: { buyerId: ref('buyers') },
     })
 
-    // Calling describe() is purely synchronous over in-memory config — no store calls
-    const desc = coll2.describe()
-    expect(desc.collection).toBe('sales3')
+    // Spy on every store method AFTER the vault is open (so init writes don't trip us).
+    // Any call during describe() will be recorded — we assert zero calls.
+    const getspy   = vi.spyOn(mem, 'get')
+    const putspy   = vi.spyOn(mem, 'put')
+    const delspy   = vi.spyOn(mem, 'delete')
+    const listspy  = vi.spyOn(mem, 'list')
+    const loadspy  = vi.spyOn(mem, 'loadAll')
+    const savespy  = vi.spyOn(mem, 'saveAll')
+
+    // describe() is sync and config-only — must never touch any store method.
+    const desc = coll.describe()
+
+    expect(getspy).not.toHaveBeenCalled()
+    expect(putspy).not.toHaveBeenCalled()
+    expect(delspy).not.toHaveBeenCalled()
+    expect(listspy).not.toHaveBeenCalled()
+    expect(loadspy).not.toHaveBeenCalled()
+    expect(savespy).not.toHaveBeenCalled()
+
+    // Sanity: the description is still correct.
+    expect(desc.collection).toBe('sales2')
     expect(desc.fields.length).toBeGreaterThan(0)
-    // The throwing store was never used above — the test passes without touching it.
-    void throwing // referenced to satisfy linter
   })
 
   it('dynamic dictKey: values list uses declared keys, no label', async () => {
@@ -189,5 +185,147 @@ describe('collection.describe() — sync path', () => {
     const byKey = Object.fromEntries(d.fields.map((f) => [f.key, f]))
     expect(byKey.tagIds.ref?.isArray).toBe(true)
     expect(byKey.tagIds.type).toBe('array')
+  })
+})
+
+// ─── Async describe(opts) — Task 4 (#483) ────────────────────────────────────
+
+describe('collection.describe(opts) — async path', () => {
+  /**
+   * Shared vault + collections for async tests.
+   *
+   * zod-4 empirical finding (verified via `node -e "…z.toJSONSchema(schema)…"`):
+   * toJSONSchema() emits .meta() keys INLINE on each JSON Schema property, at the
+   * same level as `type` / `format`. For example:
+   *   z.number().meta({ unit: 'kg' }) → { "type": "number", "unit": "kg" }
+   * Keys mapped: label, description, unit, semanticType, sensitivity, aggregate,
+   * aliases, displayFor. Unknown keys are ignored.
+   * Optional fields are excluded from the `required` array at root level.
+   */
+
+  it('async describe derives exact types from the zod-4 validator', async () => {
+    const z4 = await import('/Users/vicio/_github/noy-db/node_modules/.pnpm/zod@4.4.3/node_modules/zod/index.js')
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-async-1' })
+    const v = await db.openVault('av1')
+
+    const salesSchema = z4.z.object({
+      id: z4.z.string(),
+      saleDate: z4.z.string().optional(),
+      total: z4.z.number(),
+      buyerId: z4.z.string(),
+    })
+
+    const sales = v.collection('sales_async', {
+      schema: salesSchema as unknown as import('../../src/schema.js').StandardSchemaV1,
+    })
+
+    const d = await sales.describe({})
+    const byKey = Object.fromEntries(d.fields.map((f) => [f.key, f]))
+
+    // Validator-derived types — not 'unknown'
+    expect(byKey.saleDate.type).toBe('string')
+    expect(byKey.total.type).toBe('number')
+    // optional: saleDate is optional in zod schema, total/id are required
+    expect(byKey.saleDate.optional).toBe(true)
+    expect(byKey.total.optional).toBe(false)
+  })
+
+  it('async describe merges zod-4 .meta() when channel is silent', async () => {
+    const z4 = await import('/Users/vicio/_github/noy-db/node_modules/.pnpm/zod@4.4.3/node_modules/zod/index.js')
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-async-2' })
+    const v = await db.openVault('av2')
+
+    // net has .meta({ unit: 'kg' }), no fieldMeta entry for it
+    const weightsSchema = z4.z.object({
+      id: z4.z.string(),
+      net: z4.z.number().meta({ unit: 'kg' }),
+    })
+
+    const weights = v.collection('weights_async', {
+      schema: weightsSchema as unknown as import('../../src/schema.js').StandardSchemaV1,
+    })
+
+    const d = await weights.describe({})
+    const w = d.fields.find((f) => f.key === 'net')!
+
+    // zod .meta({ unit: 'kg' }) should be merged via zodMeta path
+    expect(w.unit).toBe('kg')
+  })
+
+  it('resolveDictLabels fills dynamic dict labels (async, reads _dict_)', async () => {
+    const { withI18n } = await import('../../src/i18n/active.js')
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-async-3', i18nStrategy: withI18n() })
+    const v = await db.openVault('av3')
+
+    const tickets = v.collection('tickets_async', {
+      dictKeyFields: { priority: dictKey('priority') },
+    })
+
+    await v.dictionary('priority').putAll({ hi: { en: 'High' }, lo: { en: 'Low' } })
+
+    const d = await tickets.describe({ resolveDictLabels: true })
+    const p = d.fields.find((f) => f.key === 'priority')!
+
+    expect(p.dict?.values).toEqual(
+      expect.arrayContaining([{ value: 'hi', label: 'High' }]),
+    )
+  })
+
+  it('fieldMeta key-validation: typo in fieldMeta key rejects with FieldMetaUnknownFieldError', async () => {
+    const z4 = await import('/Users/vicio/_github/noy-db/node_modules/.pnpm/zod@4.4.3/node_modules/zod/index.js')
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-async-4' })
+    const v = await db.openVault('av4')
+
+    const schema = z4.z.object({
+      id: z4.z.string(),
+      total: z4.z.number(),
+    })
+
+    // 'totl' is a typo — not a real field in the schema or any config
+    const c = v.collection('typo_coll', {
+      schema: schema as unknown as import('../../src/schema.js').StandardSchemaV1,
+      fieldMeta: {
+        totl: { label: 'Total (typo)' },
+      },
+    })
+
+    await expect(c.describe({})).rejects.toBeInstanceOf(FieldMetaUnknownFieldError)
+  })
+
+  it('validator-agnostic: non-zod Standard-Schema validator + fieldMeta channel works in sync and async describe', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-async-5' })
+    const v = await db.openVault('av5')
+
+    // Hand-rolled Standard Schema v1 stub — vendor is NOT 'zod'
+    const stubValidator: import('../../src/schema.js').StandardSchemaV1 = {
+      '~standard': {
+        version: 1,
+        vendor: 'stub',
+        validate: (value) => ({ value: value as Record<string, unknown> }),
+      },
+    }
+
+    const c = v.collection('stub_coll', {
+      schema: stubValidator,
+      fieldMeta: {
+        amount: { label: 'Amount', unit: '€' },
+      },
+    })
+
+    // Sync describe — channel metadata must be present, no zod needed
+    const syncDesc = c.describe()
+    const syncField = syncDesc.fields.find((f) => f.key === 'amount')
+    expect(syncField).toBeDefined()
+    expect(syncField!.label).toBe('Amount')
+    expect(syncField!.unit).toBe('€')
+
+    // Async describe — same channel metadata; no zod = no exact types but no throw
+    const asyncDesc = await c.describe({})
+    const asyncField = asyncDesc.fields.find((f) => f.key === 'amount')
+    expect(asyncField).toBeDefined()
+    expect(asyncField!.label).toBe('Amount')
+    expect(asyncField!.unit).toBe('€')
+    // type falls back to 'unknown' since no zod schema (no JSON Schema derivable)
+    expect(asyncField!.type).toBe('unknown')
   })
 })

--- a/packages/hub/__tests__/introspection/describe.test.ts
+++ b/packages/hub/__tests__/introspection/describe.test.ts
@@ -326,4 +326,44 @@ describe('collection.describe(opts) — async path', () => {
     // type falls back to 'unknown' since no zod schema (no JSON Schema derivable)
     expect(asyncField!.type).toBe('unknown')
   })
+
+  // Fix 1 — fieldMeta reconcile on pre-created (cached) collection
+  it('fieldMeta reconcile: re-declaring a cached collection with fieldMeta reflects label in describe()', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-1' })
+    const v = await db.openVault('reconcile_vault')
+
+    // First declaration — no fieldMeta (simulates MV auto-creation path)
+    v.collection('rec_coll', {})
+
+    // Second declaration with fieldMeta — must reconcile onto cached instance
+    const c = v.collection('rec_coll', {
+      fieldMeta: { price: { label: 'Unit Price', unit: '€' } },
+    })
+
+    const d = c.describe()
+    const priceField = d.fields.find((f) => f.key === 'price')
+    expect(priceField).toBeDefined()
+    expect(priceField!.label).toBe('Unit Price')
+    expect(priceField!.unit).toBe('€')
+  })
+
+  // Fix 2 — empty async dict must fall back to declared keys
+  it('resolveDictLabels with empty store falls back to declared keys (async superset of sync)', async () => {
+    const { withI18n } = await import('../../src/i18n/active.js')
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-emptydict-1', i18nStrategy: withI18n() })
+    const v = await db.openVault('emptydict_vault')
+
+    const c = v.collection('inv', {
+      dictKeyFields: { status: dictKey('inv_status', ['draft', 'sent'] as const) },
+    })
+
+    // Do NOT call putAll — store is empty; resolveDictLabels returns {} for the dict
+    const d = await c.describe({ resolveDictLabels: true })
+    const statusField = d.fields.find((f) => f.key === 'status')!
+
+    // Must surface the declared keys even though the store is empty
+    const values = statusField.dict?.values?.map((entry) => entry.value)
+    expect(values).toContain('draft')
+    expect(values).toContain('sent')
+  })
 })

--- a/packages/hub/__tests__/introspection/dump-schema.test.ts
+++ b/packages/hub/__tests__/introspection/dump-schema.test.ts
@@ -122,4 +122,32 @@ describe('vault.dumpSchema() — baseline', () => {
       overlayViews: expect.any(Boolean),
     }))
   })
+
+  it('surfaces collection-level config (embeddings/textIndexes/crdt/provenance/tiers)', async () => {
+    const comp = await db.openVault(COMP)
+    comp.collection<{ id: string; body: string }>('docs', {
+      textIndexes: ['body'],
+      embeddings: {
+        source: 'body',
+        dim: 128,
+        model: 'test-model',
+        encode: async () => new Float32Array(128),
+      },
+      provenance: true,
+      tiers: [1, 2],
+    })
+    const dump = await comp.dumpSchema()
+    const cfg = dump.collections['docs'].config!
+    expect(cfg.textIndexes).toContain('body')
+    expect(cfg.provenance).toBe(true)
+    expect(cfg.tiers).toEqual([1, 2])
+    expect(cfg.embeddings?.dim).toBeGreaterThan(0)
+  })
+
+  it('omits config when a collection has no configured options', async () => {
+    const comp = await db.openVault(COMP)
+    comp.collection<Invoice>('plain')
+    const dump = await comp.dumpSchema()
+    expect(dump.collections['plain'].config).toBeUndefined()
+  })
 })

--- a/packages/hub/__tests__/introspection/dump-schema.test.ts
+++ b/packages/hub/__tests__/introspection/dump-schema.test.ts
@@ -151,3 +151,74 @@ describe('vault.dumpSchema() — baseline', () => {
     expect(dump.collections['plain'].config).toBeUndefined()
   })
 })
+
+describe('vault.dumpSchema() — archive + schemaUpdate config', () => {
+  const COMP = 'acme-config'
+  let adapter: NoydbStore
+  let db: Noydb
+
+  beforeEach(async () => {
+    adapter = inlineMemory()
+    db = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+  })
+
+  it('surfaces archive: true when a collection declares an archive policy', async () => {
+    const comp = await db.openVault(COMP)
+    comp.collection<Invoice>('invoices', {
+      archive: { archiveWhen: (r) => r.status === 'paid' },
+    })
+    const dump = await comp.dumpSchema()
+    const cfg = dump.collections['invoices'].config
+    expect(cfg).toBeDefined()
+    expect(cfg!.archive).toBe(true)
+  })
+
+  it('surfaces schemaUpdate with strategy names when registered', async () => {
+    const comp = await db.openVault(COMP)
+    const strategy = {
+      name: 'addDueDate',
+      detect: async () => false as const,
+      transform: async (r: unknown) => r,
+    }
+    comp.collection<Invoice>('invoices', {
+      schema: z.object({ id: z.string(), amount: z.number(), status: z.string() }),
+      persistJsonSchema: true,
+      schemaUpdate: [strategy],
+    })
+    await comp.collection<Invoice>('invoices').put('i1', { id: 'i1', amount: 100, status: 'draft' })
+    await comp._drainPendingSchemaWrites()
+    const dump = await comp.dumpSchema()
+    const cfg = dump.collections['invoices'].config!
+    expect(cfg.schemaUpdate).toContain('addDueDate')
+  })
+
+  it('merges archive + Collection-level options into a single config object', async () => {
+    const comp = await db.openVault(COMP)
+    comp.collection<{ id: string; body: string }>('docs', {
+      textIndexes: ['body'],
+      archive: { archiveWhen: () => false },
+    })
+    const dump = await comp.dumpSchema()
+    const cfg = dump.collections['docs'].config!
+    expect(cfg.textIndexes).toContain('body')
+    expect(cfg.archive).toBe(true)
+  })
+
+  it('surfaces history: true when historyConfig is explicitly provided and enabled', async () => {
+    const comp = await db.openVault(COMP)
+    comp.collection<Invoice>('invoices', {
+      historyConfig: { maxVersions: 10 },
+    })
+    const dump = await comp.dumpSchema()
+    const cfg = dump.collections['invoices'].config!
+    expect(cfg.history).toBe(true)
+  })
+
+  it('omits history from config when no explicit historyConfig is declared', async () => {
+    const comp = await db.openVault(COMP)
+    comp.collection<Invoice>('plain')
+    const dump = await comp.dumpSchema()
+    // A plain collection has no explicit historyConfig — history must not appear.
+    expect(dump.collections['plain'].config?.history).toBeUndefined()
+  })
+})

--- a/packages/hub/__tests__/introspection/field-meta.test.ts
+++ b/packages/hub/__tests__/introspection/field-meta.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { validateFieldMetaKeys } from '../../src/introspection/field-meta.js'
+import { validateFieldMetaKeys, resolveFieldMeta, humanizeFieldKey } from '../../src/introspection/field-meta.js'
 
 describe('FieldMeta key validation', () => {
   it('passes when every fieldMeta key is a known field', () => {
@@ -8,5 +8,33 @@ describe('FieldMeta key validation', () => {
   it('throws fail-loud on an unknown field key (typo)', () => {
     expect(() => validateFieldMetaKeys('sales', { totl: { label: 'Amount' } }, new Set(['total'])))
       .toThrowError(/totl/)
+  })
+})
+
+describe('humanizeFieldKey', () => {
+  it('splits camelCase and title-cases', () => {
+    expect(humanizeFieldKey('saleDate')).toBe('Sale Date')
+    expect(humanizeFieldKey('buyerId')).toBe('Buyer Id')
+  })
+})
+
+describe('resolveFieldMeta precedence', () => {
+  it('channel label overrides inferred and zod', () => {
+    const r = resolveFieldMeta('total', {
+      channel: { label: 'Amount' },
+      zodMeta: { label: 'ZL', unit: '€' },
+      inferred: { label: 'Total', semanticType: 'currency', aggregate: 'sum' },
+    })
+    expect(r.label).toBe('Amount')        // channel wins
+    expect(r.unit).toBe('€')              // filled from zod (channel silent)
+    expect(r.semanticType).toBe('currency') // filled from inferred
+    expect(r.aggregate).toBe('sum')
+  })
+  it('falls back to humanized key when no label anywhere', () => {
+    expect(resolveFieldMeta('saleDate', { inferred: { semanticType: 'date' } }).label).toBe('Sale Date')
+  })
+  it('zod beats inferred when channel is silent', () => {
+    expect(resolveFieldMeta('x', { zodMeta: { label: 'FromZod' }, inferred: { label: 'FromInfer' } }).label)
+      .toBe('FromZod')
   })
 })

--- a/packages/hub/__tests__/introspection/field-meta.test.ts
+++ b/packages/hub/__tests__/introspection/field-meta.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+import { validateFieldMetaKeys } from '../../src/introspection/field-meta.js'
+
+describe('FieldMeta key validation', () => {
+  it('passes when every fieldMeta key is a known field', () => {
+    expect(() => validateFieldMetaKeys('sales', { total: { label: 'Amount' } }, new Set(['total', 'saleDate']))).not.toThrow()
+  })
+  it('throws fail-loud on an unknown field key (typo)', () => {
+    expect(() => validateFieldMetaKeys('sales', { totl: { label: 'Amount' } }, new Set(['total'])))
+      .toThrowError(/totl/)
+  })
+})

--- a/packages/hub/__tests__/introspection/json-schema.test.ts
+++ b/packages/hub/__tests__/introspection/json-schema.test.ts
@@ -1,0 +1,123 @@
+/**
+ * collection.toJSONSchema() — Task 2 (#484)
+ *
+ * Covers:
+ *   - zod-4 collection: x- extension keys (x-semanticType, x-money, x-enumLabels, x-sensitivity)
+ *   - x-enumLabels picks up inline dictKey labels (Task 1)
+ *   - non-zod (Standard-Schema stub): minimal field-type schema fallback + x- metadata, no throw
+ */
+
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { createNoydb } from '../../src/noydb.js'
+import { money } from '../../src/money/descriptor.js'
+import { dictKey } from '../../src/i18n/dictionary.js'
+import { ref } from '../../src/refs.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/types.js'
+import { ConflictError } from '../../src/errors.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c)
+      const s: VaultSnapshot = {}
+      if (comp) {
+        for (const [n, coll] of comp) {
+          if (!n.startsWith('_')) {
+            const r: Record<string, EncryptedEnvelope> = {}
+            for (const [id, e] of coll) r[id] = e
+            s[n] = r
+          }
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+interface Order {
+  id: string
+  total: number
+  status: string
+  buyerId: string
+  buyerVat: string
+}
+
+// ─── Shared fixtures ──────────────────────────────────────────────────────────
+
+let orders: ReturnType<ReturnType<Awaited<ReturnType<typeof createNoydb>>['openVault']>['collection']>
+let stubColl: ReturnType<ReturnType<Awaited<ReturnType<typeof createNoydb>>['openVault']>['collection']>
+
+describe('collection.toJSONSchema()', async () => {
+  const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-json-schema-1' })
+  const v = await db.openVault('vjs1')
+
+  // Zod-4 collection with money/ref/dictKey-with-inline-labels/pii fieldMeta
+  const ordersSchema = z.object({
+    id: z.string(),
+    total: z.number(),
+    status: z.string(),
+    buyerId: z.string(),
+    buyerVat: z.string(),
+  })
+
+  orders = v.collection<Order>('orders_js', {
+    schema: ordersSchema as unknown as import('../../src/schema.js').StandardSchemaV1,
+    moneyFields: { total: money({ currency: 'EUR' }) },
+    refs: { buyerId: ref('buyers') },
+    dictKeyFields: { status: dictKey('saleStatus', { draft: 'Draft', to_verify: 'To Verify' }) },
+    fieldMeta: {
+      buyerVat: { sensitivity: 'pii' },
+    },
+  })
+
+  // Non-zod Standard-Schema stub — no '~standard.vendor' === 'zod', no '_zod'
+  const stubValidator = {
+    '~standard': { version: 1, vendor: 'stub', validate: (v: unknown) => ({ value: v }) },
+  }
+
+  const db2 = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-json-schema-2' })
+  const v2 = await db2.openVault('vjs2')
+
+  stubColl = v2.collection('orders_stub', {
+    schema: stubValidator as unknown as import('../../src/schema.js').StandardSchemaV1,
+    moneyFields: { total: money({ currency: 'USD' }) },
+  })
+
+  it('emits JSON Schema with x- metadata extensions', async () => {
+    const js = await orders.toJSONSchema() as { properties: Record<string, Record<string, unknown>> }
+    expect(js.properties.total['x-semanticType']).toBe('currency')
+    expect(js.properties.total['x-money']).toMatchObject({ currency: 'EUR' })
+    expect(js.properties.status['x-enumLabels']).toMatchObject({ to_verify: 'To Verify' })
+    expect(js.properties.buyerVat['x-sensitivity']).toBe('pii')
+  })
+
+  it('non-zod validator → minimal schema from field types, no throw', async () => {
+    const js = await stubColl.toJSONSchema() as { type: string; properties: Record<string, Record<string, unknown>> }
+    expect(js.type).toBe('object')
+    expect(js.properties.total['x-semanticType']).toBe('currency')
+  })
+})

--- a/packages/hub/__tests__/introspection/meta.test.ts
+++ b/packages/hub/__tests__/introspection/meta.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/types.js'
+import { ConflictError } from '../../src/errors.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c)
+      const s: VaultSnapshot = {}
+      if (comp) {
+        for (const [n, coll] of comp) {
+          if (!n.startsWith('_')) {
+            const r: Record<string, EncryptedEnvelope> = {}
+            for (const [id, e] of coll) r[id] = e
+            s[n] = r
+          }
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+describe('collectionMeta', () => {
+  it('surfaces collection meta in describe() with label fallback', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'u', secret: 's' })
+    const v = await db.openVault('v')
+    const sales = v.collection('sales', { meta: { label: 'Sales', description: 'Invoices', icon: 'receipt' } })
+    expect(sales.describe().meta).toMatchObject({ label: 'Sales', description: 'Invoices', icon: 'receipt' })
+    const plain = v.collection('line_items', {})
+    expect(plain.describe().meta?.label).toBe('Line Items')   // humanized fallback
+  })
+})

--- a/packages/hub/__tests__/introspection/meta.test.ts
+++ b/packages/hub/__tests__/introspection/meta.test.ts
@@ -55,3 +55,16 @@ describe('collectionMeta', () => {
     expect(plain.describe().meta?.label).toBe('Line Items')   // humanized fallback
   })
 })
+
+describe('vaultMeta', () => {
+  it('surfaces vaultMeta on dumpSchema, first-wins', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'u', secret: 's' })
+    const v = await db.openVault('books', { meta: { label: 'Acme Books', description: '2026' } })
+    v.collection('sales', {})
+    const dump = await v.dumpSchema()
+    expect(dump.meta).toMatchObject({ label: 'Acme Books', description: '2026' })
+    // re-open with different meta → first-wins keeps original
+    const v2 = await db.openVault('books', { meta: { label: 'OTHER' } })
+    expect(v2.getMeta()?.label).toBe('Acme Books')
+  })
+})

--- a/packages/hub/__tests__/persisted-schemas/derive.test.ts
+++ b/packages/hub/__tests__/persisted-schemas/derive.test.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { derivePersistedSchema, isZod4Schema, isZodSchema } from '../../src/persisted-schemas/derive.js'
 
 describe('isZodSchema', () => {
-  it('identifies a Zod schema via _def.typeName', () => {
+  it('identifies a Zod schema via ~standard.vendor (v4) with _def.typeName (v3) fallback', () => {
     expect(isZodSchema(z.object({ id: z.string() }))).toBe(true)
     expect(isZodSchema(z.string())).toBe(true)
   })

--- a/packages/hub/__tests__/persisted-schemas/derive.test.ts
+++ b/packages/hub/__tests__/persisted-schemas/derive.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { z } from 'zod'
-import { derivePersistedSchema, isZodSchema } from '../../src/persisted-schemas/derive.js'
+import { derivePersistedSchema, isZod4Schema, isZodSchema } from '../../src/persisted-schemas/derive.js'
 
 describe('isZodSchema', () => {
   it('identifies a Zod schema via _def.typeName', () => {
@@ -57,5 +57,32 @@ describe('derivePersistedSchema', () => {
     expect(env.jsonSchema).toBeNull()
     expect(env.hash).toBeNull()
     expect(env.reason).toMatch(/derivation not yet supported/i)
+  })
+})
+
+// Empirical observation (zod@4): z.object({a:z.string()}) carries a `_zod`
+// property (the v4 internal namespace); `_def.typeName` is absent in native
+// v4 schemas. `z.toJSONSchema` is a top-level export on the zod module.
+describe('derivePersistedSchema — zod 4', () => {
+  it('detects a zod-4 schema', () => {
+    expect(isZod4Schema(z.object({ a: z.string() }))).toBe(true)
+    expect(isZod4Schema({})).toBe(false)
+    expect(isZod4Schema(null)).toBe(false)
+  })
+
+  it('derives a real JSON Schema from a zod-4 schema (kind=Zod)', async () => {
+    const env = await derivePersistedSchema(z.object({ name: z.string(), age: z.number() }))
+    expect(env.kind).toBe('Zod')
+    expect(env.jsonSchema).not.toBeNull()
+    expect(env.hash).not.toBeNull()
+    // properties survive the conversion
+    const props = (env.jsonSchema as { properties?: Record<string, unknown> }).properties ?? {}
+    expect(Object.keys(props).sort()).toEqual(['age', 'name'])
+  })
+
+  it('returns the stub envelope for a non-zod validator', async () => {
+    const env = await derivePersistedSchema({ '~standard': { version: 1, vendor: 'x', validate: () => ({ value: 1 }) } })
+    expect(env.kind).toBe('Unknown')
+    expect(env.jsonSchema).toBeNull()
   })
 })

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -313,7 +313,7 @@
     "@noy-db/on-shamir": "workspace:*",
     "@types/node": "^22.0.0",
     "esbuild": "^0.25.0",
-    "zod": "^3.23.0",
+    "zod": "^4.0.0",
     "zod-to-json-schema": "^3.25.2"
   },
   "peerDependencies": {

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -37,6 +37,7 @@ import type { SchemaUpdateGate } from './schema-update/gate.js'
 import type { SchemaFenceController } from './schema-update/fence-controller.js'
 import type { StandardSchemaV1 } from './schema.js'
 import { validateSchemaInput, validateSchemaOutput } from './schema.js'
+import { derivePersistedSchema } from './persisted-schemas/derive.js'
 import type { LedgerStore } from './history/ledger/index.js'
 import type { DiffEntry } from './history/diff.js'
 import { NO_HISTORY, type HistoryStrategy } from './history/strategy.js'
@@ -60,6 +61,7 @@ import { embeddingSourceText, VectorSet, type EmbeddingDescriptor, type StoredVe
 import { buildUniqueConstraintSet, type UniqueConstraintSet } from './indexing/unique-constraints.js'
 import type { RefDescriptor } from './refs.js'
 import { buildDescription, deriveZodFields, type CollectionDescription, type DescribeOptions } from './introspection/describe.js'
+import { buildJsonSchema } from './introspection/json-schema.js'
 import type { CollectionConfig } from './introspection/types.js'
 import { Lru, parseBytes, estimateRecordBytes, type LruStats } from './cache/index.js'
 import { generateULID } from './bundle/ulid.js'
@@ -1330,6 +1332,17 @@ export class Collection<T> {
       ...(this.meta !== undefined ? { meta: this.meta } : {}),
       ...(this.i18nFields !== undefined ? { i18nFields: this.i18nFields } : {}),
     })
+  }
+
+  /** JSON Schema for this collection with describe() metadata as x- extensions. */
+  async toJSONSchema(): Promise<object> {
+    const desc = await this.describe({})
+    let base: Record<string, unknown> | null = null
+    if (this.schema !== undefined) {
+      const env = await derivePersistedSchema(this.schema)
+      base = (env.jsonSchema as Record<string, unknown> | null) ?? null
+    }
+    return buildJsonSchema(desc, base)
   }
 
   /**

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1,5 +1,6 @@
 import type { NoydbStore, EncryptedEnvelope, ChangeEvent, HistoryConfig, HistoryOptions, HistoryEntry, PruneOptions, ListPageResult, LocaleReadOptions, ConflictPolicy, CollectionConflictResolver, PutManyItemOptions, PutManyOptions, PutManyResult, DeleteManyResult } from './types.js'
 import type { FieldMeta } from './introspection/field-meta.js'
+import type { CollectionMeta } from './introspection/meta.js'
 import { NOYDB_FORMAT_VERSION } from './types.js'
 import type { CrdtMode, CrdtState, LwwMapState, RgaState } from './crdt/crdt.js'
 import { NO_CRDT, type CrdtStrategy } from './crdt/strategy.js'
@@ -366,6 +367,12 @@ export class Collection<T> {
    * collection option. Read by `getFieldMeta()`; merged by `collection.describe()`.
    */
   private fieldMeta: Record<string, FieldMeta> | undefined
+
+  /**
+   * Collection-level descriptive metadata declared via the `meta` collection
+   * option. Read by `getMeta()`; surfaced in `collection.describe()`.
+   */
+  private meta: CollectionMeta | undefined
 
   /**
    * Outbound ref declarations for this collection (snapshot from vault
@@ -744,6 +751,8 @@ export class Collection<T> {
     dictKeyFields?: Record<string, DictKeyDescriptor | StaticDictDescriptor> | undefined
     /** — consumer-neutral per-field descriptors. Read via getFieldMeta(). */
     fieldMeta?: Record<string, FieldMeta> | undefined
+    /** — collection-level descriptive metadata. Read via getMeta(). */
+    meta?: CollectionMeta | undefined
     moneyFields?: Record<string, MoneyDescriptor> | undefined
     /** — outbound ref declarations (snapshot from vault refRegistry). Used by describe(). */
     declaredRefs?: Record<string, RefDescriptor> | undefined
@@ -987,6 +996,7 @@ export class Collection<T> {
     this.vectorSet = opts.embeddings ? new VectorSet() : undefined
     this.dictKeyFields = opts.dictKeyFields
     this.fieldMeta = opts.fieldMeta
+    this.meta = opts.meta
     this._refs = opts.declaredRefs ?? {}
     if (opts.moneyFields) validateMoneyFieldPaths(opts.moneyFields)
     this.moneyFields = opts.moneyFields
@@ -1172,6 +1182,9 @@ export class Collection<T> {
   /** The declared consumer-neutral field metadata channel (canonical). */
   getFieldMeta(): Record<string, FieldMeta> | undefined { return this.fieldMeta }
 
+  /** The collection's declared descriptive metadata. */
+  getMeta(): CollectionMeta | undefined { return this.meta }
+
   /**
    * Describe the collection's field schema from in-memory config — zero store I/O.
    *
@@ -1197,6 +1210,7 @@ export class Collection<T> {
       computed: this.computed,
       refs: this._refs,
       zodFields: undefined,
+      ...(this.meta !== undefined ? { meta: this.meta } : {}),
     })
   }
 
@@ -1240,6 +1254,7 @@ export class Collection<T> {
       refs: this._refs,
       zodFields,
       ...(dictLabels !== undefined ? { dictLabels } : {}),
+      ...(this.meta !== undefined ? { meta: this.meta } : {}),
     })
   }
 
@@ -1263,6 +1278,11 @@ export class Collection<T> {
   /** @internal — attach fieldMeta post-construction. See {@link _applyMoneyFields}. First-wins. */
   _applyFieldMeta(fieldMeta: Record<string, FieldMeta>): void {
     if (this.fieldMeta === undefined) this.fieldMeta = fieldMeta
+  }
+
+  /** @internal — attach collection-level meta post-construction. See {@link _applyMoneyFields}. First-wins. */
+  _applyMeta(meta: CollectionMeta): void {
+    if (this.meta === undefined) this.meta = meta
   }
 
   /**

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -60,6 +60,7 @@ import { embeddingSourceText, VectorSet, type EmbeddingDescriptor, type StoredVe
 import { buildUniqueConstraintSet, type UniqueConstraintSet } from './indexing/unique-constraints.js'
 import type { RefDescriptor } from './refs.js'
 import { buildDescription, deriveZodFields, type CollectionDescription, type DescribeOptions } from './introspection/describe.js'
+import type { CollectionConfig } from './introspection/types.js'
 import { Lru, parseBytes, estimateRecordBytes, type LruStats } from './cache/index.js'
 import { generateULID } from './bundle/ulid.js'
 import type { PresenceHandle, PresenceHandleOpts } from './team/presence.js'
@@ -1184,6 +1185,61 @@ export class Collection<T> {
 
   /** The collection's declared descriptive metadata. */
   getMeta(): CollectionMeta | undefined { return this.meta }
+
+  /**
+   * Aggregate all collection-level configuration options that are actively set
+   * into a {@link CollectionConfig} snapshot. Returns `undefined` when no options
+   * are configured (omitting the `config` block from `dumpSchema()` output).
+   * Consumed by `walk.ts` to populate `CollectionDescriptor.config`.
+   */
+  getConfig(): CollectionConfig | undefined {
+    const i18nFields = this.i18nFields !== undefined
+      ? Object.keys(this.i18nFields)
+      : undefined
+    const embeddings = this.embeddings !== undefined
+      ? {
+          source: this.embeddings.source,
+          dim: this.embeddings.dim,
+          ...(this.embeddings.model !== undefined ? { model: this.embeddings.model } : {}),
+        }
+      : undefined
+    const textIndexes = this.textIndexes !== undefined && this.textIndexes.length > 0
+      ? this.textIndexes
+      : undefined
+    const textIndexPersist = this.searchIndexStore instanceof PersistedIndexStore ? true : undefined
+    const perRecordKeys = this.perRecordCek ? true : undefined
+    const provenance = this.provenance ? true : undefined
+    const tiers = this.tiers !== null ? Array.from(this.tiers) : undefined
+    const tierMode = this.tiers !== null ? (this.tierMode as string) : undefined
+    const crdt = this.crdtMode !== undefined ? (this.crdtMode as string) : undefined
+    const history = this.historyConfig.enabled === false ? false : undefined
+
+    const hasAny =
+      i18nFields !== undefined ||
+      embeddings !== undefined ||
+      textIndexes !== undefined ||
+      textIndexPersist !== undefined ||
+      perRecordKeys !== undefined ||
+      provenance !== undefined ||
+      tiers !== undefined ||
+      crdt !== undefined ||
+      history !== undefined
+
+    if (!hasAny) return undefined
+
+    return {
+      ...(i18nFields !== undefined ? { i18nFields } : {}),
+      ...(embeddings !== undefined ? { embeddings } : {}),
+      ...(textIndexes !== undefined ? { textIndexes } : {}),
+      ...(textIndexPersist !== undefined ? { textIndexPersist } : {}),
+      ...(perRecordKeys !== undefined ? { perRecordKeys } : {}),
+      ...(provenance !== undefined ? { provenance } : {}),
+      ...(tiers !== undefined ? { tiers } : {}),
+      ...(tierMode !== undefined ? { tierMode } : {}),
+      ...(crdt !== undefined ? { crdt } : {}),
+      ...(history !== undefined ? { history } : {}),
+    }
+  }
 
   /**
    * Describe the collection's field schema from in-memory config — zero store I/O.

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -183,6 +183,8 @@ export class Collection<T> {
   private readonly getDEK: (collectionName: string) => Promise<CryptoKey>
   private readonly onDirty: OnDirtyCallback | undefined
   private readonly historyConfig: HistoryConfig
+  /** True when the caller explicitly provided a `historyConfig` option (vs. inheriting the vault default). */
+  private readonly historyConfigExplicit: boolean
 
   /**
    * tree-shake seam — the strategy that backs `collection.blob(id)`.
@@ -633,6 +635,12 @@ export class Collection<T> {
     activeTxId?: (() => string | null) | undefined
     getDEK: (collectionName: string) => Promise<CryptoKey>
     historyConfig?: HistoryConfig | undefined
+    /**
+     * When `true`, the caller explicitly provided `historyConfig` rather than
+     * inheriting the vault-wide default. Used by `getConfig()` to decide
+     * whether to surface `history: true` in the schema dump.
+     */
+    historyConfigExplicit?: boolean | undefined
     onDirty?: OnDirtyCallback | undefined
     /**
      * tree-shake seam. When omitted, `collection.blob(id)` throws
@@ -962,6 +970,7 @@ export class Collection<T> {
     this.getDEK = opts.getDEK
     this.onDirty = opts.onDirty
     this.historyConfig = opts.historyConfig ?? { enabled: true }
+    this.historyConfigExplicit = opts.historyConfigExplicit ?? false
     this.schema = opts.schema
     this.ledger = opts.ledger
     this.refEnforcer = opts.refEnforcer
@@ -1212,7 +1221,14 @@ export class Collection<T> {
     const tiers = this.tiers !== null ? Array.from(this.tiers) : undefined
     const tierMode = this.tiers !== null ? (this.tierMode as string) : undefined
     const crdt = this.crdtMode !== undefined ? (this.crdtMode as string) : undefined
-    const history = this.historyConfig.enabled === false ? false : undefined
+    /**
+     * `true` when history is explicitly enabled for this collection (i.e. the
+     * caller supplied a `historyConfig` option and history is not disabled).
+     * Omitted when no per-collection config was provided or history is disabled.
+     */
+    const history = this.historyConfigExplicit && this.historyConfig.enabled !== false
+      ? true
+      : undefined
 
     const hasAny =
       i18nFields !== undefined ||

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1211,6 +1211,7 @@ export class Collection<T> {
       refs: this._refs,
       zodFields: undefined,
       ...(this.meta !== undefined ? { meta: this.meta } : {}),
+      ...(this.i18nFields !== undefined ? { i18nFields: this.i18nFields } : {}),
     })
   }
 
@@ -1255,6 +1256,7 @@ export class Collection<T> {
       zodFields,
       ...(dictLabels !== undefined ? { dictLabels } : {}),
       ...(this.meta !== undefined ? { meta: this.meta } : {}),
+      ...(this.i18nFields !== undefined ? { i18nFields: this.i18nFields } : {}),
     })
   }
 

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -58,7 +58,7 @@ import { IndexWriteFailureError, DerivationCapExceededError, DebugReservedFieldE
 import { embeddingSourceText, VectorSet, type EmbeddingDescriptor, type StoredVector } from './embeddings/index.js'
 import { buildUniqueConstraintSet, type UniqueConstraintSet } from './indexing/unique-constraints.js'
 import type { RefDescriptor } from './refs.js'
-import { buildDescription, type CollectionDescription, type DescribeOptions } from './introspection/describe.js'
+import { buildDescription, deriveZodFields, type CollectionDescription, type DescribeOptions } from './introspection/describe.js'
 import { Lru, parseBytes, estimateRecordBytes, type LruStats } from './cache/index.js'
 import { generateULID } from './bundle/ulid.js'
 import type { PresenceHandle, PresenceHandleOpts } from './team/presence.js'
@@ -1187,8 +1187,7 @@ export class Collection<T> {
   describe(opts: DescribeOptions): Promise<CollectionDescription>
   describe(opts?: DescribeOptions): CollectionDescription | Promise<CollectionDescription> {
     if (opts) {
-      // Async path implemented in Task 4 (#483).
-      return Promise.reject(new Error('async describe() lands in Task 4 (#483)'))
+      return this.describeAsync(opts)
     }
     return buildDescription({
       collection: this.name,
@@ -1198,6 +1197,49 @@ export class Collection<T> {
       computed: this.computed,
       refs: this._refs,
       zodFields: undefined,
+    })
+  }
+
+  /**
+   * Async describe implementation (#483 Task 4).
+   * Derives validator-exact types via deriveZodFields (lazy, no static zod import),
+   * optionally resolves dynamic-dict labels from vault.dictionary(name).list(),
+   * then delegates to buildDescription which also runs fieldMeta key-validation.
+   */
+  private async describeAsync(opts: DescribeOptions): Promise<CollectionDescription> {
+    // 1. Derive per-field type/optional/constraints/meta from the validator (if any).
+    const zodFields = this.schema !== undefined
+      ? await deriveZodFields(this.schema)
+      : undefined
+
+    // 2. Optionally resolve dynamic-dict labels from the vault's dictionary store.
+    let dictLabels: Record<string, Record<string, string>> | undefined
+    if (opts.resolveDictLabels === true && this.dictKeyFields !== undefined) {
+      dictLabels = {}
+      for (const [, desc] of Object.entries(this.dictKeyFields)) {
+        if (!isStaticDictDescriptor(desc) && this.getDictionary !== undefined) {
+          const handle = await this.getDictionary(desc.name)
+          const entries = await handle.list()
+          const valueToLabel: Record<string, string> = {}
+          for (const entry of entries) {
+            // Pick the first available locale label as the display label.
+            const label = Object.values(entry.labels)[0]
+            if (label !== undefined) valueToLabel[entry.key] = label
+          }
+          dictLabels[desc.name] = valueToLabel
+        }
+      }
+    }
+
+    return buildDescription({
+      collection: this.name,
+      fieldMeta: this.fieldMeta,
+      moneyFields: this.moneyFields,
+      dictKeyFields: this.dictKeyFields,
+      computed: this.computed,
+      refs: this._refs,
+      zodFields,
+      ...(dictLabels !== undefined ? { dictLabels } : {}),
     })
   }
 

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -365,7 +365,7 @@ export class Collection<T> {
    * Consumer-neutral per-field descriptors declared via the `fieldMeta`
    * collection option. Read by `getFieldMeta()`; merged by `collection.describe()`.
    */
-  private readonly fieldMeta: Record<string, FieldMeta> | undefined
+  private fieldMeta: Record<string, FieldMeta> | undefined
 
   /**
    * Outbound ref declarations for this collection (snapshot from vault
@@ -1258,6 +1258,11 @@ export class Collection<T> {
   /** @internal — attach computed fields post-construction. See {@link _applyMoneyFields}. */
   _applyComputed(computed: ComputedFields): void {
     if (this.computed === undefined) this.computed = computed
+  }
+
+  /** @internal — attach fieldMeta post-construction. See {@link _applyMoneyFields}. First-wins. */
+  _applyFieldMeta(fieldMeta: Record<string, FieldMeta>): void {
+    if (this.fieldMeta === undefined) this.fieldMeta = fieldMeta
   }
 
   /**

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -1,4 +1,5 @@
 import type { NoydbStore, EncryptedEnvelope, ChangeEvent, HistoryConfig, HistoryOptions, HistoryEntry, PruneOptions, ListPageResult, LocaleReadOptions, ConflictPolicy, CollectionConflictResolver, PutManyItemOptions, PutManyOptions, PutManyResult, DeleteManyResult } from './types.js'
+import type { FieldMeta } from './introspection/field-meta.js'
 import { NOYDB_FORMAT_VERSION } from './types.js'
 import type { CrdtMode, CrdtState, LwwMapState, RgaState } from './crdt/crdt.js'
 import { NO_CRDT, type CrdtStrategy } from './crdt/strategy.js'
@@ -358,6 +359,12 @@ export class Collection<T> {
    * fields when a locale is requested.
    */
   private readonly dictKeyFields: Record<string, DictKeyDescriptor | StaticDictDescriptor> | undefined
+
+  /**
+   * Consumer-neutral per-field descriptors declared via the `fieldMeta`
+   * collection option. Read by `getFieldMeta()`; merged by `collection.describe()`.
+   */
+  private readonly fieldMeta: Record<string, FieldMeta> | undefined
 
   /**
    * Money field descriptors keyed by field path. Declared via the
@@ -728,6 +735,8 @@ export class Collection<T> {
     textIndexPersist?: boolean | undefined
     /** — dictKey field descriptors for label resolution on reads. */
     dictKeyFields?: Record<string, DictKeyDescriptor | StaticDictDescriptor> | undefined
+    /** — consumer-neutral per-field descriptors. Read via getFieldMeta(). */
+    fieldMeta?: Record<string, FieldMeta> | undefined
     moneyFields?: Record<string, MoneyDescriptor> | undefined
     computed?: ComputedFields | undefined
     /**
@@ -968,6 +977,7 @@ export class Collection<T> {
     this.embeddings = opts.embeddings
     this.vectorSet = opts.embeddings ? new VectorSet() : undefined
     this.dictKeyFields = opts.dictKeyFields
+    this.fieldMeta = opts.fieldMeta
     if (opts.moneyFields) validateMoneyFieldPaths(opts.moneyFields)
     this.moneyFields = opts.moneyFields
     this.computed = opts.computed
@@ -1148,6 +1158,9 @@ export class Collection<T> {
   getSchema(): StandardSchemaV1<unknown, T> | undefined {
     return this.schema
   }
+
+  /** The declared consumer-neutral field metadata channel (canonical). */
+  getFieldMeta(): Record<string, FieldMeta> | undefined { return this.fieldMeta }
 
   /**
    * @internal — attach money descriptors post-construction. MV dependency

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -58,6 +58,7 @@ import { IndexWriteFailureError, DerivationCapExceededError, DebugReservedFieldE
 import { embeddingSourceText, VectorSet, type EmbeddingDescriptor, type StoredVector } from './embeddings/index.js'
 import { buildUniqueConstraintSet, type UniqueConstraintSet } from './indexing/unique-constraints.js'
 import type { RefDescriptor } from './refs.js'
+import { buildDescription, type CollectionDescription, type DescribeOptions } from './introspection/describe.js'
 import { Lru, parseBytes, estimateRecordBytes, type LruStats } from './cache/index.js'
 import { generateULID } from './bundle/ulid.js'
 import type { PresenceHandle, PresenceHandleOpts } from './team/presence.js'
@@ -365,6 +366,12 @@ export class Collection<T> {
    * collection option. Read by `getFieldMeta()`; merged by `collection.describe()`.
    */
   private readonly fieldMeta: Record<string, FieldMeta> | undefined
+
+  /**
+   * Outbound ref declarations for this collection (snapshot from vault
+   * refRegistry at construction time). Used by `describe()` (sync, config-only).
+   */
+  private readonly _refs: Record<string, RefDescriptor>
 
   /**
    * Money field descriptors keyed by field path. Declared via the
@@ -738,6 +745,8 @@ export class Collection<T> {
     /** — consumer-neutral per-field descriptors. Read via getFieldMeta(). */
     fieldMeta?: Record<string, FieldMeta> | undefined
     moneyFields?: Record<string, MoneyDescriptor> | undefined
+    /** — outbound ref declarations (snapshot from vault refRegistry). Used by describe(). */
+    declaredRefs?: Record<string, RefDescriptor> | undefined
     computed?: ComputedFields | undefined
     /**
      * async callback that resolves a dict key to its label
@@ -978,6 +987,7 @@ export class Collection<T> {
     this.vectorSet = opts.embeddings ? new VectorSet() : undefined
     this.dictKeyFields = opts.dictKeyFields
     this.fieldMeta = opts.fieldMeta
+    this._refs = opts.declaredRefs ?? {}
     if (opts.moneyFields) validateMoneyFieldPaths(opts.moneyFields)
     this.moneyFields = opts.moneyFields
     this.computed = opts.computed
@@ -1161,6 +1171,35 @@ export class Collection<T> {
 
   /** The declared consumer-neutral field metadata channel (canonical). */
   getFieldMeta(): Record<string, FieldMeta> | undefined { return this.fieldMeta }
+
+  /**
+   * Describe the collection's field schema from in-memory config — zero store I/O.
+   *
+   * Sync overload (no args): merges moneyFields / dictKeyFields / refs /
+   * computed / fieldMeta into a {@link CollectionDescription}. Field types are
+   * inferred from config (money→'number', ref→'string'/'array', dict→'enum',
+   * others→'unknown'). Validator-derived types require the async overload (Task 4).
+   *
+   * Async overload (Task 4 #483): resolves validator-derived types + dynamic dict
+   * labels before building the description.
+   */
+  describe(): CollectionDescription
+  describe(opts: DescribeOptions): Promise<CollectionDescription>
+  describe(opts?: DescribeOptions): CollectionDescription | Promise<CollectionDescription> {
+    if (opts) {
+      // Async path implemented in Task 4 (#483).
+      return Promise.reject(new Error('async describe() lands in Task 4 (#483)'))
+    }
+    return buildDescription({
+      collection: this.name,
+      fieldMeta: this.fieldMeta,
+      moneyFields: this.moneyFields,
+      dictKeyFields: this.dictKeyFields,
+      computed: this.computed,
+      refs: this._refs,
+      zodFields: undefined,
+    })
+  }
 
   /**
    * @internal — attach money descriptors post-construction. MV dependency

--- a/packages/hub/src/i18n/dictionary.ts
+++ b/packages/hub/src/i18n/dictionary.ts
@@ -92,6 +92,12 @@ export interface DictKeyDescriptor<Keys extends string = string> {
   readonly onMissing?: OnMissingPolicy
   /** Ordered preferred-substitute locales for label resolution. */
   readonly substitute?: readonly string[]
+  /**
+   * Optional inline display labels (value → label map). A SYNC display
+   * fallback for `describe()` when async `dictLabels` (from `_dict_`) are
+   * not resolved. The async path still wins when available.
+   */
+  readonly labels?: Record<string, string>
 }
 
 /**
@@ -113,15 +119,28 @@ export interface DictKeyDescriptor<Keys extends string = string> {
  */
 export function dictKey<Keys extends string>(
   name: string,
-  keys?: readonly Keys[],
-  opts?: { onMissing?: OnMissingPolicy; substitute?: readonly string[] },
+  keysOrMap?: readonly Keys[] | Record<Keys, string>,
+  opts?: { onMissing?: OnMissingPolicy; substitute?: readonly string[]; labels?: Record<string, string> },
 ): DictKeyDescriptor<Keys> {
+  let keys: readonly Keys[] | undefined
+  let labels: Record<string, string> | undefined
+  if (Array.isArray(keysOrMap)) {
+    keys = keysOrMap as readonly Keys[]
+    labels = opts?.labels
+  } else if (keysOrMap && typeof keysOrMap === 'object') {
+    keys = Object.keys(keysOrMap) as Keys[]
+    labels = keysOrMap as Record<string, string>
+  } else {
+    keys = undefined
+    labels = opts?.labels
+  }
   return {
     _noydbDictKey: true,
     name,
     keys,
     ...(opts?.onMissing !== undefined ? { onMissing: opts.onMissing } : {}),
     ...(opts?.substitute !== undefined ? { substitute: opts.substitute } : {}),
+    ...(labels !== undefined ? { labels } : {}),
   }
 }
 

--- a/packages/hub/src/i18n/dictionary.ts
+++ b/packages/hub/src/i18n/dictionary.ts
@@ -103,18 +103,28 @@ export interface DictKeyDescriptor<Keys extends string = string> {
 /**
  * Create a `DictKeyDescriptor` for a dictionary-backed enum field.
  *
- * @param name   The dictionary name (corresponds to `_dict_<name>` collection).
- * @param keys   Optional `as const` array of valid key literals — narrows the
- *               TypeScript type to a literal union and enables put-time
- *               validation.
+ * @param name        The dictionary name (corresponds to `_dict_<name>` collection).
+ * @param keysOrMap   Either:
+ *   - An `as const` array of valid key literals — narrows the TypeScript type
+ *     to a literal union and enables put-time validation.
+ *   - A **value→label map** (`{ draft: 'Draft', paid: 'Paid' }`) — keys are
+ *     inferred from the map, and the labels are stored as inline display
+ *     defaults surfaced by `describe()` without a store read.
+ * @param opts        `{ labels?, onMissing?, substitute? }` when the array form
+ *                    is used; `opts.labels` provides inline display defaults for
+ *                    specific keys (same semantics as the map form, but
+ *                    explicit key order from the array is preserved).
  *
  * @example
  * ```ts
- * const invoices = company.collection<Invoice>('invoices', {
- *   dictKeyFields: {
- *     status: dictKey('status', ['draft', 'open', 'paid'] as const),
- *   },
- * })
+ * // array form (original):
+ * dictKey('status', ['draft', 'open', 'paid'] as const)
+ *
+ * // value→label map form (keys inferred, inline labels for describe()):
+ * dictKey('status', { draft: 'Draft', open: 'Open', paid: 'Paid' })
+ *
+ * // array + opts.labels (preserves explicit order, partial labels OK):
+ * dictKey('status', ['draft', 'open', 'paid'] as const, { labels: { paid: 'Paid' } })
  * ```
  */
 export function dictKey<Keys extends string>(

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -196,6 +196,7 @@ export type { SchemaIntrospection } from './introspection/types.js'
 
 // Field metadata (#483)
 export type { FieldMeta, SemanticType } from './introspection/field-meta.js'
+export type { CollectionMeta, VaultMeta } from './introspection/meta.js'
 export type { CollectionDescription, DescribedField, DescribeOptions } from './introspection/describe.js'
 
 // Dry-run transactions

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -389,6 +389,7 @@ export type {
   VaultSchemaSnapshot,
   DumpSchemaOptions,
   CollectionDescriptor,
+  CollectionConfig,
   CollectionStats,
   FieldDescriptor,
   FieldSource,

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -194,6 +194,10 @@ export type { WriteEvent, WriteHook } from './write-hooks.js'
 // Runtime schema introspection
 export type { SchemaIntrospection } from './introspection/types.js'
 
+// Field metadata (#483)
+export type { FieldMeta, SemanticType } from './introspection/field-meta.js'
+export type { CollectionDescription, DescribedField, DescribeOptions } from './introspection/describe.js'
+
 // Dry-run transactions
 export type { DryRunResult, AffectedDocument, GuardViolation } from './tx/dry-run.js'
 

--- a/packages/hub/src/introspection/describe.ts
+++ b/packages/hub/src/introspection/describe.ts
@@ -46,7 +46,7 @@ export interface DescribedField {
   /** i18n metadata for fields declared with i18nText(). Present only when the field is i18n-enabled. */
   readonly i18n?: { readonly locales?: readonly string[]; readonly densify?: boolean }
   /** Widget hint derived from semanticType+type, overridable via fieldMeta.widget. */
-  readonly widget?: string
+  readonly widget: string
   /** Whether the field is user-editable. False for computed, id, and provenance-stamped fields. */
   readonly editable: boolean
 }
@@ -55,7 +55,7 @@ export interface CollectionDescription {
   readonly collection: string
   readonly fields: readonly DescribedField[]
   /** Collection-level descriptive metadata; label falls back to the humanized collection name. */
-  readonly meta?: CollectionMeta
+  readonly meta: CollectionMeta
 }
 
 /** Options for the async describe(opts) overload (#483 Task 4). */

--- a/packages/hub/src/introspection/describe.ts
+++ b/packages/hub/src/introspection/describe.ts
@@ -12,12 +12,14 @@
  */
 
 import type { FieldMeta } from './field-meta.js'
-import { resolveFieldMeta } from './field-meta.js'
+import { resolveFieldMeta, validateFieldMetaKeys, FieldMetaUnknownFieldError } from './field-meta.js'
 import type { MoneyDescriptor } from '../money/descriptor.js'
 import type { DictKeyDescriptor, StaticDictDescriptor } from '../i18n/dictionary.js'
 import { isStaticDictDescriptor } from '../i18n/dictionary.js'
 import type { ComputedFields } from '../computed/index.js'
 import type { RefDescriptor } from '../refs.js'
+import { derivePersistedSchema, isZod4Schema } from '../persisted-schemas/derive.js'
+import { jsonSchemaToFields } from './fields.js'
 
 // ─── Public types ──────────────────────────────────────────────────────────
 
@@ -46,10 +48,13 @@ export interface CollectionDescription {
   readonly fields: readonly DescribedField[]
 }
 
-/** Options for the async describe() overload (Task 4 supplies the content). */
+/** Options for the async describe(opts) overload (#483 Task 4). */
 export interface DescribeOptions {
-  /** Reserved for Task 4 — async validator-derived type resolution. */
-  readonly _async?: true
+  /**
+   * When true, resolve dynamic-dict labels from vault.dictionary(name).list()
+   * and populate dict.values[].label for dynamic dictKey fields.
+   */
+  readonly resolveDictLabels?: boolean
 }
 
 // ─── ZodField slot (async path wires this; sync path passes undefined) ───
@@ -57,7 +62,78 @@ export interface DescribeOptions {
 export interface ZodFieldSlot {
   readonly type?: string
   readonly optional?: boolean
+  readonly constraints?: Record<string, unknown>
   readonly meta?: Partial<FieldMeta>
+}
+
+// ─── RECOGNIZED zod-4 .meta() keys ────────────────────────────────────────
+//
+// Empirically verified 2026-06-25 via:
+//   node -e "const {z,toJSONSchema}=require('zod'); console.log(JSON.stringify(toJSONSchema(z.object({n:z.number().meta({label:'L',unit:'kg',sensitivity:'public',semanticType:'percent',description:'d',aggregate:'sum',aliases:['a'],displayFor:'x'})}))), null, 2)"
+// Result: .meta() keys are emitted INLINE on each JSON Schema property object
+//   at the same level as `type`/`format` — NOT nested under a `metadata` key.
+// Example: z.number().meta({ unit: 'kg' }) → { "type": "number", "unit": "kg" }
+// Unknown .meta() keys (not in this set) are ignored.
+const ZOD_META_KEYS = new Set<string>([
+  'label', 'description', 'unit', 'semanticType', 'sensitivity', 'aggregate', 'aliases', 'displayFor',
+])
+
+// ─── deriveZodFields ──────────────────────────────────────────────────────
+
+/**
+ * Derive per-field slots from a Standard Schema validator.
+ * - Calls `derivePersistedSchema` to get the JSON Schema.
+ * - Falls back to `{}` for non-Zod or unknown validators.
+ * - For zod-4 schemas: reads recognized `.meta()` keys from inline property annotations.
+ * - Returns: `Record<fieldKey, { type, optional, constraints?, meta? }>`.
+ *
+ * No static zod import — all zod access is lazy via derivePersistedSchema.
+ */
+export async function deriveZodFields(
+  schema: unknown,
+): Promise<Record<string, ZodFieldSlot>> {
+  const envelope = await derivePersistedSchema(schema)
+  if (!envelope.jsonSchema) return {}
+
+  const isZod4 = isZod4Schema(schema)
+  const jsonSchema = envelope.jsonSchema as Record<string, unknown>
+
+  // Use the existing JSON-Schema→field mapper for type/optional/constraints.
+  const fieldDescriptors = jsonSchemaToFields(jsonSchema, 'live-validator')
+
+  // For zod-4: the JSON Schema properties contain inline .meta() annotations.
+  // We need to walk the raw properties to extract recognized meta keys.
+  const propertiesRaw = jsonSchema['properties'] as Record<string, Record<string, unknown>> | undefined
+
+  const result: Record<string, ZodFieldSlot> = {}
+
+  for (const [key, descriptor] of Object.entries(fieldDescriptors)) {
+    let meta: Partial<FieldMeta> | undefined
+
+    if (isZod4 && propertiesRaw) {
+      const prop = propertiesRaw[key]
+      if (prop) {
+        const extracted: Partial<FieldMeta> = {}
+        let hasAny = false
+        for (const mk of ZOD_META_KEYS) {
+          if (mk in prop) {
+            (extracted as Record<string, unknown>)[mk] = prop[mk]
+            hasAny = true
+          }
+        }
+        if (hasAny) meta = extracted
+      }
+    }
+
+    result[key] = {
+      type: descriptor.type,
+      optional: descriptor.optional === true,
+      ...(descriptor.constraints !== undefined ? { constraints: descriptor.constraints } : {}),
+      ...(meta !== undefined ? { meta } : {}),
+    }
+  }
+
+  return result
 }
 
 // ─── buildDescription ─────────────────────────────────────────────────────
@@ -71,14 +147,46 @@ export interface BuildDescriptionInput {
   readonly refs: Record<string, RefDescriptor>
   /** Async path fills this; sync path passes `undefined`. */
   readonly zodFields: Record<string, ZodFieldSlot> | undefined
+  /**
+   * Async path: when `resolveDictLabels` was true, this map holds
+   * `{ dictName -> { value -> label } }` for dynamic dictKey fields.
+   * Used to populate `dict.values[].label`.
+   */
+  readonly dictLabels?: Record<string, Record<string, string>> | undefined
 }
+
+// Re-export so that callers that want to catch the error don't need another import path.
+export { FieldMetaUnknownFieldError }
 
 /**
  * Pure assembler: no I/O, no side effects.
  * Builds a {@link CollectionDescription} from the collection's in-memory config.
+ *
+ * When `zodFields` is supplied (async path), validates that every `fieldMeta` key
+ * refers to a known field (config ∪ zodFields). Throws `FieldMetaUnknownFieldError`
+ * on the first unknown key — this is the real validation that the vault.ts no-op
+ * couldn't do (schema fields weren't knowable synchronously).
  */
 export function buildDescription(input: BuildDescriptionInput): CollectionDescription {
-  const { collection, fieldMeta, moneyFields, dictKeyFields, computed, refs, zodFields } = input
+  const { collection, fieldMeta, moneyFields, dictKeyFields, computed, refs, zodFields, dictLabels } = input
+
+  // When zodFields is present AND non-empty (async path, validator successfully derived
+  // a schema): validate fieldMeta keys against the real known-field set = config keys ∪
+  // zodFields keys. This is the carry from Task 1: vault.ts couldn't do this synchronously
+  // (schema fields weren't knowable at config time without running async derivation).
+  //
+  // When zodFields is empty (non-zod / unknown validator returned no schema info),
+  // we cannot validate — skip to remain validator-agnostic.
+  if (zodFields !== undefined && Object.keys(zodFields).length > 0 && fieldMeta !== undefined) {
+    const knownFields = new Set<string>([
+      ...Object.keys(moneyFields ?? {}),
+      ...Object.keys(dictKeyFields ?? {}),
+      ...Object.keys(refs),
+      ...Object.keys(computed ?? {}),
+      ...Object.keys(zodFields),
+    ])
+    validateFieldMetaKeys(collection, fieldMeta, knownFields)
+  }
 
   // Union of all config key sources — stable alphabetical order.
   const allKeys = new Set<string>([
@@ -143,14 +251,18 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
         })
         dictBlock = { name: dict.name, static: true, values }
       } else {
-        // Dynamic dictKey: keys declared but labels are async (Task 4).
-        const values = dict.keys !== undefined
-          ? dict.keys.map((k) => ({ value: k }))
-          : undefined
-        dictBlock = {
-          name: dict.name,
-          static: false,
-          ...(values !== undefined ? { values } : {}),
+        // Dynamic dictKey: keys declared in config; labels optionally resolved
+        // from vault.dictionary(name).list() when resolveDictLabels was requested.
+        const labelMap = dictLabels?.[dict.name]
+        if (labelMap !== undefined) {
+          // We have resolved labels — build values from the label map.
+          const values = Object.entries(labelMap).map(([value, label]) => ({ value, label }))
+          dictBlock = { name: dict.name, static: false, values }
+        } else if (dict.keys !== undefined) {
+          const values = dict.keys.map((k) => ({ value: k }))
+          dictBlock = { name: dict.name, static: false, values }
+        } else {
+          dictBlock = { name: dict.name, static: false }
         }
       }
     } else if (isComputed) {

--- a/packages/hub/src/introspection/describe.ts
+++ b/packages/hub/src/introspection/describe.ts
@@ -17,6 +17,7 @@ import type { CollectionMeta } from './meta.js'
 import type { MoneyDescriptor } from '../money/descriptor.js'
 import type { DictKeyDescriptor, StaticDictDescriptor } from '../i18n/dictionary.js'
 import { isStaticDictDescriptor } from '../i18n/dictionary.js'
+import type { I18nTextDescriptor } from '../i18n/core.js'
 import type { ComputedFields } from '../computed/index.js'
 import type { RefDescriptor } from '../refs.js'
 import { derivePersistedSchema, isZod4Schema } from '../persisted-schemas/derive.js'
@@ -42,6 +43,12 @@ export interface DescribedField {
   readonly money?: { mode: 'fixed' | 'multi'; currency?: string; scale?: number; rounding?: string }
   readonly dict?: { name: string; static: boolean; values?: readonly { value: string; label?: string }[] }
   readonly computed?: true
+  /** i18n metadata for fields declared with i18nText(). Present only when the field is i18n-enabled. */
+  readonly i18n?: { readonly locales?: readonly string[]; readonly densify?: boolean }
+  /** Widget hint derived from semanticType+type, overridable via fieldMeta.widget. */
+  readonly widget?: string
+  /** Whether the field is user-editable. False for computed, id, and provenance-stamped fields. */
+  readonly editable: boolean
 }
 
 export interface CollectionDescription {
@@ -158,10 +165,49 @@ export interface BuildDescriptionInput {
   readonly dictLabels?: Record<string, Record<string, string>> | undefined
   /** Collection-level descriptive metadata. Label falls back to humanized collection name. */
   readonly meta?: CollectionMeta | undefined
+  /**
+   * Map of field name → I18nTextDescriptor for fields declared with i18nText().
+   * When present, describe() surfaces an `i18n` block on matching DescribedField entries.
+   */
+  readonly i18nFields?: Record<string, I18nTextDescriptor> | undefined
 }
 
 // Re-export so that callers that want to catch the error don't need another import path.
 export { FieldMetaUnknownFieldError }
+
+// ─── Widget derivation ────────────────────────────────────────────────────────
+
+/**
+ * Derive a widget hint from resolved field metadata.
+ * Priority: explicit override (resolvedWidget) > semanticType > dict > type > 'text'.
+ */
+function deriveWidget(opts: {
+  semanticType?: string
+  type: string
+  dict?: unknown
+  resolvedWidget?: string
+}): string {
+  if (opts.resolvedWidget !== undefined) return opts.resolvedWidget
+  switch (opts.semanticType) {
+    case 'date':
+    case 'datetime':
+      return 'date'
+    case 'currency':
+      return 'money'
+    case 'entity':
+      return 'ref-select'
+    case 'url':
+      return 'url'
+    case 'email':
+      return 'email'
+    case 'percent':
+      return 'number'
+  }
+  if (opts.dict !== undefined) return 'select'
+  if (opts.type === 'boolean') return 'checkbox'
+  if (opts.type === 'number') return 'number'
+  return 'text'
+}
 
 /**
  * Pure assembler: no I/O, no side effects.
@@ -173,7 +219,7 @@ export { FieldMetaUnknownFieldError }
  * couldn't do (schema fields weren't knowable synchronously).
  */
 export function buildDescription(input: BuildDescriptionInput): CollectionDescription {
-  const { collection, fieldMeta, moneyFields, dictKeyFields, computed, refs, zodFields, dictLabels, meta } = input
+  const { collection, fieldMeta, moneyFields, dictKeyFields, computed, refs, zodFields, dictLabels, meta, i18nFields } = input
 
   // When zodFields is present AND non-empty (async path, validator successfully derived
   // a schema): validate fieldMeta keys against the real known-field set = config keys ∪
@@ -201,6 +247,7 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
     ...Object.keys(computed ?? {}),
     ...Object.keys(fieldMeta ?? {}),
     ...Object.keys(zodFields ?? {}),
+    ...Object.keys(i18nFields ?? {}),
   ])
 
   const fields: DescribedField[] = []
@@ -211,6 +258,7 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
     const dict = dictKeyFields?.[key]
     const refDesc = refs[key]
     const isComputed = computed !== undefined && key in computed
+    const i18nDesc = i18nFields?.[key]
 
     // ── Infer type + structural extras ────────────────────────────────────
     let type = zod?.type ?? 'unknown'
@@ -271,6 +319,10 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
           dictBlock = { name: dict.name, static: false }
         }
       }
+    } else if (i18nDesc) {
+      // i18nText field: the stored value is a locale-map object, but the resolved
+      // type exposed to consumers is 'string' (locale resolution collapses to a string).
+      type = 'string'
     } else if (isComputed) {
       // type already initialized to zod?.type ?? 'unknown' above; no re-set needed
     }
@@ -283,6 +335,32 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
       ...(zodMeta !== undefined ? { zodMeta } : {}),
       inferred,
     })
+
+    // ── i18n block (only for i18nText fields) ─────────────────────────────
+    let i18nBlock: DescribedField['i18n'] | undefined
+    if (i18nDesc !== undefined) {
+      const locales = i18nDesc.options.languages
+      const densify = i18nDesc.options.densifyOnWrite
+      i18nBlock = {
+        ...(locales !== undefined ? { locales } : {}),
+        ...(densify !== undefined ? { densify } : {}),
+      }
+    }
+
+    // ── Widget (derived, overridable via resolvedWidget from fieldMeta/zodMeta) ──
+    const widget = deriveWidget({
+      type,
+      ...(resolved.semanticType !== undefined ? { semanticType: resolved.semanticType } : {}),
+      ...(dictBlock !== undefined ? { dict: dictBlock } : {}),
+      ...(resolved.widget !== undefined ? { resolvedWidget: resolved.widget } : {}),
+    })
+
+    // ── Editable: false for computed, id, provenance-stamped fields ────────
+    // Provenance fields (_source, _sourceTs) are envelope-level metadata, not
+    // user schema fields — they won't appear as keys in fieldMeta so this check
+    // is implicitly handled (they'd never appear in allKeys). Explicitly guard
+    // computed + 'id' as the two structural non-editable cases.
+    const editable = !isComputed && key !== 'id'
 
     // ── Assemble the field (exactOptionalPropertyTypes-safe spreads) ───────
     const field: DescribedField = {
@@ -301,6 +379,9 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
       ...(moneyBlock !== undefined ? { money: moneyBlock } : {}),
       ...(dictBlock !== undefined ? { dict: dictBlock } : {}),
       ...(isComputed ? { computed: true as const } : {}),
+      ...(i18nBlock !== undefined ? { i18n: i18nBlock } : {}),
+      widget,
+      editable,
     }
 
     fields.push(field)

--- a/packages/hub/src/introspection/describe.ts
+++ b/packages/hub/src/introspection/describe.ts
@@ -315,7 +315,7 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
           dictBlock = { name: dict.name, static: false, values }
         } else if (dict.keys !== undefined) {
           const values = dict.keys.map((k) => {
-            const label = (dict as { labels?: Record<string, string> }).labels?.[k]
+            const label = dict.labels?.[k]
             return label !== undefined ? { value: k, label } : { value: k }
           })
           dictBlock = { name: dict.name, static: false, values }

--- a/packages/hub/src/introspection/describe.ts
+++ b/packages/hub/src/introspection/describe.ts
@@ -254,9 +254,10 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
         // Dynamic dictKey: keys declared in config; labels optionally resolved
         // from vault.dictionary(name).list() when resolveDictLabels was requested.
         const labelMap = dictLabels?.[dict.name]
-        if (labelMap !== undefined) {
+        const labelMapHasEntries = labelMap !== undefined && Object.keys(labelMap).length > 0
+        if (labelMapHasEntries) {
           // We have resolved labels — build values from the label map.
-          const values = Object.entries(labelMap).map(([value, label]) => ({ value, label }))
+          const values = Object.entries(labelMap!).map(([value, label]) => ({ value, label }))
           dictBlock = { name: dict.name, static: false, values }
         } else if (dict.keys !== undefined) {
           const values = dict.keys.map((k) => ({ value: k }))
@@ -266,7 +267,7 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
         }
       }
     } else if (isComputed) {
-      type = zod?.type ?? 'unknown'
+      // type already initialized to zod?.type ?? 'unknown' above; no re-set needed
     }
 
     // ── Merge fieldMeta channel ────────────────────────────────────────────

--- a/packages/hub/src/introspection/describe.ts
+++ b/packages/hub/src/introspection/describe.ts
@@ -12,7 +12,8 @@
  */
 
 import type { FieldMeta } from './field-meta.js'
-import { resolveFieldMeta, validateFieldMetaKeys, FieldMetaUnknownFieldError } from './field-meta.js'
+import { resolveFieldMeta, validateFieldMetaKeys, FieldMetaUnknownFieldError, humanizeFieldKey } from './field-meta.js'
+import type { CollectionMeta } from './meta.js'
 import type { MoneyDescriptor } from '../money/descriptor.js'
 import type { DictKeyDescriptor, StaticDictDescriptor } from '../i18n/dictionary.js'
 import { isStaticDictDescriptor } from '../i18n/dictionary.js'
@@ -46,6 +47,8 @@ export interface DescribedField {
 export interface CollectionDescription {
   readonly collection: string
   readonly fields: readonly DescribedField[]
+  /** Collection-level descriptive metadata; label falls back to the humanized collection name. */
+  readonly meta?: CollectionMeta
 }
 
 /** Options for the async describe(opts) overload (#483 Task 4). */
@@ -153,6 +156,8 @@ export interface BuildDescriptionInput {
    * Used to populate `dict.values[].label`.
    */
   readonly dictLabels?: Record<string, Record<string, string>> | undefined
+  /** Collection-level descriptive metadata. Label falls back to humanized collection name. */
+  readonly meta?: CollectionMeta | undefined
 }
 
 // Re-export so that callers that want to catch the error don't need another import path.
@@ -168,7 +173,7 @@ export { FieldMetaUnknownFieldError }
  * couldn't do (schema fields weren't knowable synchronously).
  */
 export function buildDescription(input: BuildDescriptionInput): CollectionDescription {
-  const { collection, fieldMeta, moneyFields, dictKeyFields, computed, refs, zodFields, dictLabels } = input
+  const { collection, fieldMeta, moneyFields, dictKeyFields, computed, refs, zodFields, dictLabels, meta } = input
 
   // When zodFields is present AND non-empty (async path, validator successfully derived
   // a schema): validate fieldMeta keys against the real known-field set = config keys ∪
@@ -301,5 +306,15 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
     fields.push(field)
   }
 
-  return { collection, fields }
+  // Build collection-level meta with label fallback to humanized collection name.
+  const collectionMeta: CollectionMeta = {
+    ...meta,
+    label: meta?.label ?? humanizeFieldKey(collection),
+  }
+
+  return {
+    collection,
+    fields,
+    meta: collectionMeta,
+  }
 }

--- a/packages/hub/src/introspection/describe.ts
+++ b/packages/hub/src/introspection/describe.ts
@@ -235,6 +235,7 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
       ...Object.keys(refs),
       ...Object.keys(computed ?? {}),
       ...Object.keys(zodFields),
+      ...Object.keys(i18nFields ?? {}),
     ])
     validateFieldMetaKeys(collection, fieldMeta, knownFields)
   }

--- a/packages/hub/src/introspection/describe.ts
+++ b/packages/hub/src/introspection/describe.ts
@@ -314,7 +314,10 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
           const values = Object.entries(labelMap).map(([value, label]) => ({ value, label }))
           dictBlock = { name: dict.name, static: false, values }
         } else if (dict.keys !== undefined) {
-          const values = dict.keys.map((k) => ({ value: k }))
+          const values = dict.keys.map((k) => {
+            const label = (dict as { labels?: Record<string, string> }).labels?.[k]
+            return label !== undefined ? { value: k, label } : { value: k }
+          })
           dictBlock = { name: dict.name, static: false, values }
         } else {
           dictBlock = { name: dict.name, static: false }

--- a/packages/hub/src/introspection/describe.ts
+++ b/packages/hub/src/introspection/describe.ts
@@ -257,7 +257,7 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
         const labelMapHasEntries = labelMap !== undefined && Object.keys(labelMap).length > 0
         if (labelMapHasEntries) {
           // We have resolved labels — build values from the label map.
-          const values = Object.entries(labelMap!).map(([value, label]) => ({ value, label }))
+          const values = Object.entries(labelMap).map(([value, label]) => ({ value, label }))
           dictBlock = { name: dict.name, static: false, values }
         } else if (dict.keys !== undefined) {
           const values = dict.keys.map((k) => ({ value: k }))

--- a/packages/hub/src/introspection/describe.ts
+++ b/packages/hub/src/introspection/describe.ts
@@ -1,0 +1,192 @@
+/**
+ * `buildDescription` — pure assembler that merges collection config
+ * (moneyFields / dictKeyFields / refs / computed / fieldMeta) with an
+ * optional validator-derived `zodFields` map into a normalised
+ * {@link CollectionDescription}.
+ *
+ * The sync path (`collection.describe()`) passes `zodFields: undefined`.
+ * The async path (Task 4 — #483) supplies a populated map and validator-
+ * derived type strings.
+ *
+ * @module
+ */
+
+import type { FieldMeta } from './field-meta.js'
+import { resolveFieldMeta } from './field-meta.js'
+import type { MoneyDescriptor } from '../money/descriptor.js'
+import type { DictKeyDescriptor, StaticDictDescriptor } from '../i18n/dictionary.js'
+import { isStaticDictDescriptor } from '../i18n/dictionary.js'
+import type { ComputedFields } from '../computed/index.js'
+import type { RefDescriptor } from '../refs.js'
+
+// ─── Public types ──────────────────────────────────────────────────────────
+
+export interface DescribedField {
+  readonly key: string
+  /** Sync: inferred from config ('number'|'enum'|'string'|'array'|'unknown'). Async (Task 4): validator-derived. */
+  readonly type: string
+  readonly optional: boolean
+  readonly constraints?: Record<string, unknown>
+  readonly label: string
+  readonly description?: string
+  readonly semanticType?: string
+  readonly unit?: string
+  readonly sensitivity?: 'public' | 'pii' | 'secret'
+  readonly aggregate?: 'sum' | 'count' | 'distinct' | 'none'
+  readonly aliases?: readonly string[]
+  readonly ref?: { target: string; mode: string; isArray?: true }
+  readonly displayFor?: string
+  readonly money?: { mode: 'fixed' | 'multi'; currency?: string; scale?: number; rounding?: string }
+  readonly dict?: { name: string; static: boolean; values?: readonly { value: string; label?: string }[] }
+  readonly computed?: true
+}
+
+export interface CollectionDescription {
+  readonly collection: string
+  readonly fields: readonly DescribedField[]
+}
+
+/** Options for the async describe() overload (Task 4 supplies the content). */
+export interface DescribeOptions {
+  /** Reserved for Task 4 — async validator-derived type resolution. */
+  readonly _async?: true
+}
+
+// ─── ZodField slot (async path wires this; sync path passes undefined) ───
+
+export interface ZodFieldSlot {
+  readonly type?: string
+  readonly optional?: boolean
+  readonly meta?: Partial<FieldMeta>
+}
+
+// ─── buildDescription ─────────────────────────────────────────────────────
+
+export interface BuildDescriptionInput {
+  readonly collection: string
+  readonly fieldMeta: Record<string, FieldMeta> | undefined
+  readonly moneyFields: Record<string, MoneyDescriptor> | undefined
+  readonly dictKeyFields: Record<string, DictKeyDescriptor | StaticDictDescriptor> | undefined
+  readonly computed: ComputedFields | undefined
+  readonly refs: Record<string, RefDescriptor>
+  /** Async path fills this; sync path passes `undefined`. */
+  readonly zodFields: Record<string, ZodFieldSlot> | undefined
+}
+
+/**
+ * Pure assembler: no I/O, no side effects.
+ * Builds a {@link CollectionDescription} from the collection's in-memory config.
+ */
+export function buildDescription(input: BuildDescriptionInput): CollectionDescription {
+  const { collection, fieldMeta, moneyFields, dictKeyFields, computed, refs, zodFields } = input
+
+  // Union of all config key sources — stable alphabetical order.
+  const allKeys = new Set<string>([
+    ...Object.keys(moneyFields ?? {}),
+    ...Object.keys(dictKeyFields ?? {}),
+    ...Object.keys(refs),
+    ...Object.keys(computed ?? {}),
+    ...Object.keys(fieldMeta ?? {}),
+    ...Object.keys(zodFields ?? {}),
+  ])
+
+  const fields: DescribedField[] = []
+
+  for (const key of [...allKeys].sort()) {
+    const zod = zodFields?.[key]
+    const money = moneyFields?.[key]
+    const dict = dictKeyFields?.[key]
+    const refDesc = refs[key]
+    const isComputed = computed !== undefined && key in computed
+
+    // ── Infer type + structural extras ────────────────────────────────────
+    let type = zod?.type ?? 'unknown'
+    const inferred: Partial<FieldMeta> = {}
+
+    let moneyBlock: DescribedField['money'] | undefined
+    let dictBlock: DescribedField['dict'] | undefined
+    let refBlock: DescribedField['ref'] | undefined
+
+    if (money) {
+      type = 'number'
+      inferred.semanticType = 'currency'
+      inferred.aggregate = 'sum'
+      const currency = money.soleCurrency()
+      const scale = currency !== undefined ? money.scaleFor(currency) : undefined
+      moneyBlock = {
+        mode: money.mode,
+        ...(currency !== undefined ? { currency } : {}),
+        ...(scale !== undefined ? { scale } : {}),
+        ...(money.rounding !== undefined ? { rounding: money.rounding } : {}),
+      }
+    } else if (refDesc) {
+      type = refDesc.isArray ? 'array' : 'string'
+      inferred.semanticType = 'entity'
+      refBlock = {
+        target: refDesc.target,
+        mode: refDesc.mode,
+        ...(refDesc.isArray ? { isArray: true as const } : {}),
+      }
+    } else if (dict) {
+      type = 'enum'
+      if (isStaticDictDescriptor(dict)) {
+        // Static dict: labels available synchronously from the in-code table.
+        const displayLocale = dict.displayLocale
+        const values = dict.keys.map((k) => {
+          const localeMap = dict.table[k]
+          const label = displayLocale !== undefined
+            ? (localeMap?.[displayLocale] ?? undefined)
+            : undefined
+          return label !== undefined
+            ? { value: k, label }
+            : { value: k }
+        })
+        dictBlock = { name: dict.name, static: true, values }
+      } else {
+        // Dynamic dictKey: keys declared but labels are async (Task 4).
+        const values = dict.keys !== undefined
+          ? dict.keys.map((k) => ({ value: k }))
+          : undefined
+        dictBlock = {
+          name: dict.name,
+          static: false,
+          ...(values !== undefined ? { values } : {}),
+        }
+      }
+    } else if (isComputed) {
+      type = zod?.type ?? 'unknown'
+    }
+
+    // ── Merge fieldMeta channel ────────────────────────────────────────────
+    const channelEntry = fieldMeta?.[key]
+    const zodMeta = zod?.meta
+    const resolved = resolveFieldMeta(key, {
+      ...(channelEntry !== undefined ? { channel: channelEntry } : {}),
+      ...(zodMeta !== undefined ? { zodMeta } : {}),
+      inferred,
+    })
+
+    // ── Assemble the field (exactOptionalPropertyTypes-safe spreads) ───────
+    const field: DescribedField = {
+      key,
+      type,
+      optional: zod?.optional ?? false,
+      label: resolved.label,
+      ...(resolved.description !== undefined ? { description: resolved.description } : {}),
+      ...(resolved.semanticType !== undefined ? { semanticType: resolved.semanticType } : {}),
+      ...(resolved.unit !== undefined ? { unit: resolved.unit } : {}),
+      ...(resolved.sensitivity !== undefined ? { sensitivity: resolved.sensitivity } : {}),
+      ...(resolved.aggregate !== undefined ? { aggregate: resolved.aggregate } : {}),
+      ...(resolved.aliases !== undefined ? { aliases: resolved.aliases } : {}),
+      ...(resolved.displayFor !== undefined ? { displayFor: resolved.displayFor } : {}),
+      ...(refBlock !== undefined ? { ref: refBlock } : {}),
+      ...(moneyBlock !== undefined ? { money: moneyBlock } : {}),
+      ...(dictBlock !== undefined ? { dict: dictBlock } : {}),
+      ...(isComputed ? { computed: true as const } : {}),
+    }
+
+    fields.push(field)
+  }
+
+  return { collection, fields }
+}

--- a/packages/hub/src/introspection/field-meta.ts
+++ b/packages/hub/src/introspection/field-meta.ts
@@ -1,0 +1,52 @@
+/**
+ * Consumer-neutral, data-relatable field descriptors — the canonical,
+ * validator-agnostic authoring channel. Merged by `collection.describe()`.
+ *
+ * Descriptive, never prescriptive: label/semanticType/unit/sensitivity/
+ * aggregate/aliases/displayFor only. Layout, styling, and active-locale
+ * selection stay app-side.
+ *
+ * @module
+ */
+
+/** Known semantic types; the union is open — unknown strings pass through. */
+export type SemanticType =
+  | 'date' | 'datetime' | 'email' | 'url' | 'currency' | 'percent'
+  | 'country' | 'vat' | 'iban' | 'entity'
+  | (string & {})
+
+export interface FieldMeta {
+  /** Human label for any displayable field. Required. */
+  label: string
+  description?: string
+  semanticType?: SemanticType
+  /** Display unit, e.g. '€', '%', 'kg'. */
+  unit?: string
+  /** Data classification driving redaction/inspector masking. */
+  sensitivity?: 'public' | 'pii' | 'secret'
+  /** Default aggregation for this field. */
+  aggregate?: 'sum' | 'count' | 'distinct' | 'none'
+  /** Canonical search synonyms (data vocabulary, not UI). */
+  aliases?: readonly string[]
+  /** Entity pairing: the field holding the human label for this id (buyerId → buyerName). */
+  displayFor?: string
+}
+
+export class FieldMetaUnknownFieldError extends Error {
+  constructor(public readonly collection: string, public readonly key: string) {
+    super(`fieldMeta for collection "${collection}" references unknown field "${key}". `
+      + `Declare it in the schema/config or remove the fieldMeta entry.`)
+    this.name = 'FieldMetaUnknownFieldError'
+  }
+}
+
+/** Reject fieldMeta keys that are not known fields (typo guard), fail-loud. */
+export function validateFieldMetaKeys(
+  collection: string,
+  fieldMeta: Record<string, FieldMeta>,
+  knownFields: ReadonlySet<string>,
+): void {
+  for (const key of Object.keys(fieldMeta)) {
+    if (!knownFields.has(key)) throw new FieldMetaUnknownFieldError(collection, key)
+  }
+}

--- a/packages/hub/src/introspection/field-meta.ts
+++ b/packages/hub/src/introspection/field-meta.ts
@@ -50,3 +50,38 @@ export function validateFieldMetaKeys(
     if (!knownFields.has(key)) throw new FieldMetaUnknownFieldError(collection, key)
   }
 }
+
+export interface MergeInputs {
+  channel?: FieldMeta
+  zodMeta?: Partial<FieldMeta>
+  inferred?: Partial<FieldMeta>
+}
+export interface ResolvedMeta extends Partial<FieldMeta> { label: string }
+
+/** camelCase / snake_case → Title Case words. */
+export function humanizeFieldKey(key: string): string {
+  return key
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .trim()
+    .split(/\s+/)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ')
+}
+
+/** Merge one field's metadata: channel > zodMeta > inferred; label always present. */
+export function resolveFieldMeta(key: string, inputs: MergeInputs): ResolvedMeta {
+  const { channel, zodMeta, inferred } = inputs
+  const pick = <K extends keyof FieldMeta>(k: K): FieldMeta[K] | undefined =>
+    channel?.[k] ?? zodMeta?.[k] ?? inferred?.[k]
+  return {
+    label: pick('label') ?? humanizeFieldKey(key),
+    ...(pick('description') !== undefined ? { description: pick('description') } : {}),
+    ...(pick('semanticType') !== undefined ? { semanticType: pick('semanticType') } : {}),
+    ...(pick('unit') !== undefined ? { unit: pick('unit') } : {}),
+    ...(pick('sensitivity') !== undefined ? { sensitivity: pick('sensitivity') } : {}),
+    ...(pick('aggregate') !== undefined ? { aggregate: pick('aggregate') } : {}),
+    ...(pick('aliases') !== undefined ? { aliases: pick('aliases') } : {}),
+    ...(pick('displayFor') !== undefined ? { displayFor: pick('displayFor') } : {}),
+  }
+}

--- a/packages/hub/src/introspection/field-meta.ts
+++ b/packages/hub/src/introspection/field-meta.ts
@@ -74,14 +74,21 @@ export function resolveFieldMeta(key: string, inputs: MergeInputs): ResolvedMeta
   const { channel, zodMeta, inferred } = inputs
   const pick = <K extends keyof FieldMeta>(k: K): FieldMeta[K] | undefined =>
     channel?.[k] ?? zodMeta?.[k] ?? inferred?.[k]
+  const description = pick('description')
+  const semanticType = pick('semanticType')
+  const unit = pick('unit')
+  const sensitivity = pick('sensitivity')
+  const aggregate = pick('aggregate')
+  const aliases = pick('aliases')
+  const displayFor = pick('displayFor')
   return {
     label: pick('label') ?? humanizeFieldKey(key),
-    ...(pick('description') !== undefined ? { description: pick('description') } : {}),
-    ...(pick('semanticType') !== undefined ? { semanticType: pick('semanticType') } : {}),
-    ...(pick('unit') !== undefined ? { unit: pick('unit') } : {}),
-    ...(pick('sensitivity') !== undefined ? { sensitivity: pick('sensitivity') } : {}),
-    ...(pick('aggregate') !== undefined ? { aggregate: pick('aggregate') } : {}),
-    ...(pick('aliases') !== undefined ? { aliases: pick('aliases') } : {}),
-    ...(pick('displayFor') !== undefined ? { displayFor: pick('displayFor') } : {}),
+    ...(description !== undefined ? { description } : {}),
+    ...(semanticType !== undefined ? { semanticType } : {}),
+    ...(unit !== undefined ? { unit } : {}),
+    ...(sensitivity !== undefined ? { sensitivity } : {}),
+    ...(aggregate !== undefined ? { aggregate } : {}),
+    ...(aliases !== undefined ? { aliases } : {}),
+    ...(displayFor !== undefined ? { displayFor } : {}),
   }
 }

--- a/packages/hub/src/introspection/field-meta.ts
+++ b/packages/hub/src/introspection/field-meta.ts
@@ -30,6 +30,12 @@ export interface FieldMeta {
   aliases?: readonly string[]
   /** Entity pairing: the field holding the human label for this id (buyerId → buyerName). */
   displayFor?: string
+  /**
+   * Override the widget hint derived from semanticType/type.
+   * e.g. 'textarea', 'date', 'money', 'select', 'checkbox', 'number', 'text'.
+   * When absent, the widget is derived automatically by buildDescription.
+   */
+  widget?: string
 }
 
 export class FieldMetaUnknownFieldError extends Error {
@@ -81,6 +87,7 @@ export function resolveFieldMeta(key: string, inputs: MergeInputs): ResolvedMeta
   const aggregate = pick('aggregate')
   const aliases = pick('aliases')
   const displayFor = pick('displayFor')
+  const widget = pick('widget')
   return {
     label: pick('label') ?? humanizeFieldKey(key),
     ...(description !== undefined ? { description } : {}),
@@ -90,5 +97,6 @@ export function resolveFieldMeta(key: string, inputs: MergeInputs): ResolvedMeta
     ...(aggregate !== undefined ? { aggregate } : {}),
     ...(aliases !== undefined ? { aliases } : {}),
     ...(displayFor !== undefined ? { displayFor } : {}),
+    ...(widget !== undefined ? { widget } : {}),
   }
 }

--- a/packages/hub/src/introspection/index.ts
+++ b/packages/hub/src/introspection/index.ts
@@ -12,6 +12,7 @@ export type {
   VaultSchemaSnapshot,
   DumpSchemaOptions,
   CollectionDescriptor,
+  CollectionConfig,
   CollectionStats,
   FieldDescriptor,
   FieldSource,

--- a/packages/hub/src/introspection/json-schema.ts
+++ b/packages/hub/src/introspection/json-schema.ts
@@ -9,7 +9,7 @@
  * @module
  */
 
-import type { CollectionDescription, DescribedField } from './describe.js'
+import type { CollectionDescription } from './describe.js'
 
 /** Map a DescribedField's type tag to a JSON-Schema `type`. */
 function jsonType(t: string): string {
@@ -47,6 +47,3 @@ export function buildJsonSchema(desc: CollectionDescription, base?: Record<strin
     ? { ...base, properties }
     : { type: 'object', properties }
 }
-
-// Re-export the type for callers that want to document the parameter shape.
-export type { CollectionDescription, DescribedField }

--- a/packages/hub/src/introspection/json-schema.ts
+++ b/packages/hub/src/introspection/json-schema.ts
@@ -1,0 +1,52 @@
+/**
+ * `buildJsonSchema` — pure overlay that merges describe() metadata onto a
+ * base JSON Schema (from derivePersistedSchema) as `x-` extension keys.
+ *
+ * When no base JSON Schema is available (non-zod / unknown validator),
+ * builds a minimal `{ type:'object', properties }` from describe()'s field
+ * type tags. No static `import 'zod'` — validator derivation stays lazy.
+ *
+ * @module
+ */
+
+import type { CollectionDescription, DescribedField } from './describe.js'
+
+/** Map a DescribedField's type tag to a JSON-Schema `type`. */
+function jsonType(t: string): string {
+  switch (t) {
+    case 'number': return 'number'
+    case 'boolean': return 'boolean'
+    case 'array': return 'array'
+    case 'object': return 'object'
+    default: return 'string'
+  }
+}
+
+/** Overlay describe() metadata onto a base JSON Schema (or build a minimal one). */
+export function buildJsonSchema(desc: CollectionDescription, base?: Record<string, unknown> | null): object {
+  const baseProps = (base?.['properties'] as Record<string, Record<string, unknown>> | undefined) ?? {}
+  const properties: Record<string, Record<string, unknown>> = {}
+  for (const f of desc.fields) {
+    const prop: Record<string, unknown> = { ...(baseProps[f.key] ?? { type: jsonType(f.type) }) }
+    prop['x-label'] = f.label
+    if (f.unit !== undefined) prop['x-unit'] = f.unit
+    if (f.semanticType !== undefined) prop['x-semanticType'] = f.semanticType
+    if (f.sensitivity !== undefined) prop['x-sensitivity'] = f.sensitivity
+    if (f.widget !== undefined) prop['x-widget'] = f.widget
+    if (f.editable === false) prop['x-readonly'] = true
+    if (f.money !== undefined) prop['x-money'] = f.money
+    if (f.ref !== undefined) prop['x-ref'] = f.ref.target
+    if (f.dict?.values) {
+      const labels: Record<string, string> = {}
+      for (const v of f.dict.values) if (v.label !== undefined) labels[v.value] = v.label
+      if (Object.keys(labels).length) prop['x-enumLabels'] = labels
+    }
+    properties[f.key] = prop
+  }
+  return base != null && typeof base === 'object'
+    ? { ...base, properties }
+    : { type: 'object', properties }
+}
+
+// Re-export the type for callers that want to document the parameter shape.
+export type { CollectionDescription, DescribedField }

--- a/packages/hub/src/introspection/meta.ts
+++ b/packages/hub/src/introspection/meta.ts
@@ -1,0 +1,24 @@
+/**
+ * Descriptive metadata for the collection and vault levels of the metadata
+ * ladder (field level = FieldMeta). Identity, not structure: label /
+ * description / icon only. Descriptive, never prescriptive.
+ * @module
+ */
+
+/** A collection's own descriptive metadata. */
+export interface CollectionMeta {
+  /** Friendly name; falls back to the humanized collection name. */
+  label?: string
+  description?: string
+  /** Semantic icon NAME (e.g. a Lucide key), not styling. */
+  icon?: string
+  /** Plural form for list headers ("Invoice" → "Invoices"). */
+  pluralLabel?: string
+}
+
+/** A vault's own descriptive metadata. */
+export interface VaultMeta {
+  label?: string
+  description?: string
+  icon?: string
+}

--- a/packages/hub/src/introspection/types.ts
+++ b/packages/hub/src/introspection/types.ts
@@ -10,7 +10,7 @@
 
 import type { PersistedSchemaKind } from '../persisted-schemas/types.js'
 import type { Permission } from '../types.js'
-import type { CollectionMeta } from './meta.js'
+import type { CollectionMeta, VaultMeta } from './meta.js'
 
 /** Flat snapshot of a vault's registered schema. */
 export interface SchemaIntrospection {
@@ -90,6 +90,7 @@ export interface VaultSchemaSnapshot {
   readonly emittedAt: string
   readonly subsystems: Record<string, boolean>
   readonly aclRoles?: ReadonlyArray<string>
+  readonly meta?: VaultMeta
   readonly collections: Record<string, CollectionDescriptor>
   readonly materializedViews: Record<string, MaterializedViewDescriptor>
   readonly overlayViews: Record<string, OverlayViewDescriptor>

--- a/packages/hub/src/introspection/types.ts
+++ b/packages/hub/src/introspection/types.ts
@@ -65,7 +65,23 @@ export interface CollectionConfig {
   readonly tiers?: readonly number[]
   readonly tierMode?: string
   readonly crdt?: string
+  /**
+   * `true` when history is explicitly enabled for this collection.
+   * Omitted when history is not configured or when the default vault-wide
+   * setting applies without explicit per-collection configuration.
+   */
   readonly history?: boolean
+  /**
+   * Present when the collection is registered in `vault.archiveRegistry`
+   * (i.e. an archive policy was declared). `true` = archive policy present.
+   */
+  readonly archive?: boolean
+  /**
+   * Strategy names registered for schema updates on this collection.
+   * Present only when at least one strategy is registered.
+   */
+  readonly schemaUpdate?: readonly string[]
+  // conflictPolicy omitted: consumed at construction, no retained state to surface.
 }
 
 export interface CollectionDescriptor {

--- a/packages/hub/src/introspection/types.ts
+++ b/packages/hub/src/introspection/types.ts
@@ -10,6 +10,7 @@
 
 import type { PersistedSchemaKind } from '../persisted-schemas/types.js'
 import type { Permission } from '../types.js'
+import type { CollectionMeta } from './meta.js'
 
 /** Flat snapshot of a vault's registered schema. */
 export interface SchemaIntrospection {
@@ -57,6 +58,7 @@ export interface CollectionDescriptor {
     readonly source: 'persisted' | 'live-validator'
   }
   readonly stats?: CollectionStats
+  readonly meta?: CollectionMeta
 }
 
 export interface MaterializedViewDescriptor {

--- a/packages/hub/src/introspection/types.ts
+++ b/packages/hub/src/introspection/types.ts
@@ -49,6 +49,25 @@ export interface CollectionStats {
   readonly newest: string
 }
 
+/**
+ * Collection-level configuration options surfaced by `dumpSchema()`.
+ * Only fields that are actively configured are present; the object is
+ * omitted entirely from `CollectionDescriptor.config` when nothing is set.
+ * Reused by Task 5 in-devtools display.
+ */
+export interface CollectionConfig {
+  readonly i18nFields?: readonly string[]
+  readonly embeddings?: { readonly source: string | readonly string[]; readonly dim: number; readonly model?: string }
+  readonly textIndexes?: readonly string[]
+  readonly textIndexPersist?: boolean
+  readonly perRecordKeys?: boolean
+  readonly provenance?: boolean
+  readonly tiers?: readonly number[]
+  readonly tierMode?: string
+  readonly crdt?: string
+  readonly history?: boolean
+}
+
 export interface CollectionDescriptor {
   readonly fields: Record<string, FieldDescriptor>
   readonly indexes: ReadonlyArray<{ readonly fields: ReadonlyArray<string>; readonly unique?: boolean }>
@@ -59,6 +78,7 @@ export interface CollectionDescriptor {
   }
   readonly stats?: CollectionStats
   readonly meta?: CollectionMeta
+  readonly config?: CollectionConfig
 }
 
 export interface MaterializedViewDescriptor {

--- a/packages/hub/src/introspection/walk.ts
+++ b/packages/hub/src/introspection/walk.ts
@@ -23,6 +23,7 @@ import type { Collection } from '../collection.js'
 import type { NoydbStore } from '../types.js'
 import type { UnlockedKeyring } from '../team/keyring.js'
 import type { RefRegistry } from '../refs.js'
+import type { VaultMeta } from './meta.js'
 
 /**
  * The minimal slice of Vault internal state the walker needs.
@@ -40,6 +41,8 @@ export interface VaultIntrospectState {
   /** The active unlocked keyring — role/permissions/userId for access-scoped ops. */
   readonly keyring: UnlockedKeyring
   readonly subsystems: Record<string, boolean>
+  /** Vault-level descriptive metadata, when set via `openVault({meta})`. */
+  readonly vaultMeta?: VaultMeta
   // Typed loosely on purpose — these are private subsystem registries
   // accessed only for "is anything registered" enumeration.
   readonly mvRegistry: unknown
@@ -95,6 +98,7 @@ export async function dumpVaultSchema(
     vault: state.name,
     emittedAt: new Date().toISOString(),
     subsystems: state.subsystems,
+    ...(state.vaultMeta !== undefined ? { meta: state.vaultMeta } : {}),
     collections,
     materializedViews,
     overlayViews,

--- a/packages/hub/src/introspection/walk.ts
+++ b/packages/hub/src/introspection/walk.ts
@@ -168,9 +168,10 @@ async function describeCollection(
     // Sampling path not implemented in baseline slice 2; reserved for follow-up.
   }
 
-  // Populate collection-level meta from the live collection when available.
+  // Populate collection-level meta and config from the live collection when available.
   const liveColl = state.collectionCache.get(collectionName)
   const collMeta = liveColl?.getMeta()
+  const collConfig = liveColl?.getConfig()
 
   const descriptor: CollectionDescriptor = {
     fields,
@@ -178,6 +179,7 @@ async function describeCollection(
     refs,
     ...(validator ? { validator } : {}),
     ...(collMeta !== undefined ? { meta: collMeta } : {}),
+    ...(collConfig !== undefined ? { config: collConfig } : {}),
   }
   if (withStats) {
     const stats = await statsForCollection(state.adapter, state.name, collectionName)

--- a/packages/hub/src/introspection/walk.ts
+++ b/packages/hub/src/introspection/walk.ts
@@ -9,6 +9,7 @@ import { derivePersistedSchema } from '../persisted-schemas/derive.js'
 import { loadPersistedSchema } from '../persisted-schemas/storage.js'
 import { jsonSchemaToFields } from './fields.js'
 import type {
+  CollectionConfig,
   CollectionDescriptor,
   CollectionStats,
   DumpSchemaOptions,
@@ -48,6 +49,18 @@ export interface VaultIntrospectState {
   readonly mvRegistry: unknown
   readonly overlayRegistry: unknown
   readonly derivationRegistry: unknown
+  /**
+   * Returns the registered schema-update strategy names for a collection,
+   * or `undefined` when none are registered. Populated from
+   * `vault.#schemaUpdateNames` in `_introspectState()`.
+   */
+  readonly getCollectionSchemaUpdateNames?: (col: string) => readonly string[] | undefined
+  /**
+   * Returns `true` when the collection has an archive policy registered
+   * in `vault.archiveRegistry`, `false` otherwise. Populated from
+   * `vault.archiveRegistry` in `_introspectState()`.
+   */
+  readonly hasCollectionArchive?: (col: string) => boolean
 }
 
 const INTERNAL_PREFIX = '_'
@@ -173,13 +186,29 @@ async function describeCollection(
   const collMeta = liveColl?.getMeta()
   const collConfig = liveColl?.getConfig()
 
+  // Thread vault-level config (archive + schemaUpdate) that the Collection cannot see.
+  const archivePresent = state.hasCollectionArchive?.(collectionName) === true
+  const schemaUpdateNames = state.getCollectionSchemaUpdateNames?.(collectionName)
+  const hasSchemaUpdate = schemaUpdateNames !== undefined && schemaUpdateNames.length > 0
+
+  // Merge Collection-level config with vault-level fields. Omit config entirely
+  // when all sources are empty.
+  let mergedConfig: CollectionConfig | undefined
+  if (collConfig !== undefined || archivePresent || hasSchemaUpdate) {
+    mergedConfig = {
+      ...(collConfig ?? {}),
+      ...(archivePresent ? { archive: true as const } : {}),
+      ...(hasSchemaUpdate ? { schemaUpdate: schemaUpdateNames } : {}),
+    }
+  }
+
   const descriptor: CollectionDescriptor = {
     fields,
     indexes: [],
     refs,
     ...(validator ? { validator } : {}),
     ...(collMeta !== undefined ? { meta: collMeta } : {}),
-    ...(collConfig !== undefined ? { config: collConfig } : {}),
+    ...(mergedConfig !== undefined ? { config: mergedConfig } : {}),
   }
   if (withStats) {
     const stats = await statsForCollection(state.adapter, state.name, collectionName)

--- a/packages/hub/src/introspection/walk.ts
+++ b/packages/hub/src/introspection/walk.ts
@@ -159,10 +159,11 @@ async function describeCollection(
     // No DEK or decrypt failure — fall through to live-validator
   }
 
+  const liveColl = state.collectionCache.get(collectionName)
+
   // 2. Try the live in-process validator (when no persisted envelope).
   if (!validator) {
-    const coll = state.collectionCache.get(collectionName)
-    const schema = coll?.getSchema()
+    const schema = liveColl?.getSchema()
     if (schema) {
       try {
         const derived = await derivePersistedSchema(schema)
@@ -182,7 +183,6 @@ async function describeCollection(
   }
 
   // Populate collection-level meta and config from the live collection when available.
-  const liveColl = state.collectionCache.get(collectionName)
   const collMeta = liveColl?.getMeta()
   const collConfig = liveColl?.getConfig()
 

--- a/packages/hub/src/introspection/walk.ts
+++ b/packages/hub/src/introspection/walk.ts
@@ -164,11 +164,16 @@ async function describeCollection(
     // Sampling path not implemented in baseline slice 2; reserved for follow-up.
   }
 
+  // Populate collection-level meta from the live collection when available.
+  const liveColl = state.collectionCache.get(collectionName)
+  const collMeta = liveColl?.getMeta()
+
   const descriptor: CollectionDescriptor = {
     fields,
     indexes: [],
     refs,
     ...(validator ? { validator } : {}),
+    ...(collMeta !== undefined ? { meta: collMeta } : {}),
   }
   if (withStats) {
     const stats = await statsForCollection(state.adapter, state.name, collectionName)

--- a/packages/hub/src/kernel/index.ts
+++ b/packages/hub/src/kernel/index.ts
@@ -44,6 +44,7 @@ export {
 // against these will not work from `@noy-db/hub/kernel`. Consumers needing a
 // runtime class value must import it from `@noy-db/hub` directly.
 // ─── types ────────────────────────────────────────────────────────
+export type { CollectionMeta, VaultMeta } from '../introspection/meta.js'
 export type { ChangeEvent } from '../types.js'
 export type { Vault } from '../vault.js'
 export type { Collection } from '../collection.js'

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -498,6 +498,7 @@ export class Noydb {
    * @param opts.locale  Default locale for i18n/dictKey field resolution
    *. Set here to avoid passing `{ locale }`
    *                     on every individual `get()`/`list()` call.
+   * @param opts.meta    Vault descriptive metadata (label, description, etc.). First-wins: applied on first open, ignored on subsequent opens.
    */
   async openVault(
     name: string,

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -77,6 +77,7 @@ import {
   type ResolvedPublicEnvelopeSchema,
 } from './meta/public-envelope/index.js'
 import { Vault } from './vault.js'
+import type { VaultMeta } from './introspection/meta.js'
 import { NoydbEventEmitter } from './events.js'
 import { WriteQueueTracker, type WriteQueue } from './write-queue.js'
 import { WriteHookRegistry, type WriteHook, type Unsubscribe } from './write-hooks.js'
@@ -500,7 +501,7 @@ export class Noydb {
    */
   async openVault(
     name: string,
-    opts?: { locale?: string; create?: boolean },
+    opts?: { locale?: string; create?: boolean; meta?: VaultMeta },
   ): Promise<Vault> {
     if (this.closed) throw new ValidationError('Instance is closed')
     this.touchPolicy(name)
@@ -604,6 +605,7 @@ export class Noydb {
       ...(this.options.numbering !== undefined ? { numberingConfigs: this.options.numbering } : {}),
       forgetStrategy: this.forgetStrategy,
       locale: opts?.locale,
+      ...(opts?.meta !== undefined ? { meta: opts.meta } : {}),
       // Thread the translator hook so Collection.put() can invoke it
       plaintextTranslator: this.options.plaintextTranslator
         ? (text, from, to, field, collection) =>

--- a/packages/hub/src/persisted-schemas/derive.ts
+++ b/packages/hub/src/persisted-schemas/derive.ts
@@ -84,7 +84,7 @@ async function loadZodV4Converter(): Promise<(s: unknown) => object> {
     return mod.toJSONSchema
   } catch (err) {
     throw new Error(
-      'persistJsonSchema with a Zod v4 schema requires zod@4 to be installed. '
+      'persistJsonSchema with a Zod v4 schema requires zod@4 with toJSONSchema. '
       + `Original error: ${err instanceof Error ? err.message : String(err)}`,
     )
   }

--- a/packages/hub/src/persisted-schemas/derive.ts
+++ b/packages/hub/src/persisted-schemas/derive.ts
@@ -1,7 +1,9 @@
 /**
  * Derive a {@link PersistedSchemaEnvelope} from a Standard Schema v1
- * validator. v0 supports Zod via `zod-to-json-schema` (optional peer-dep);
- * other families write a stub envelope flagging the kind.
+ * validator. Supports zod 3 (via the optional `zod-to-json-schema` peer-dep)
+ * and zod 4 (via its native `z.toJSONSchema()`); both are loaded lazily so
+ * hub never statically imports zod. Other validator families write a stub
+ * envelope flagging the kind.
  *
  * @see docs/superpowers/specs/2026-05-22-schema-dump-design.md
  *
@@ -40,8 +42,10 @@ function detectKind(validator: unknown): PersistedSchemaKind {
  * (i.e. `import { z } from 'zod'` where zod resolves to v4). Zod v4 native
  * schemas carry a `_zod` property whereas Zod v3 schemas (and the v3-compat
  * shim shipped inside zod@4 at `zod/v3`) use `_def.typeName`.
+ *
+ * Kept duck-typed so hub never statically imports zod.
  */
-function isZodV4Native(value: unknown): boolean {
+export function isZod4Schema(value: unknown): boolean {
   if (value === null || typeof value !== 'object') return false
   return '_zod' in (value as object)
 }
@@ -95,7 +99,7 @@ export async function derivePersistedSchema(
   if (kind === 'Zod') {
     let jsonSchema: object
 
-    if (isZodV4Native(validator)) {
+    if (isZod4Schema(validator)) {
       // Zod v4 native schemas: use zod's built-in toJSONSchema (available in
       // zod@4) because zod-to-json-schema@3.x parses _def.typeName which is
       // absent in native v4 schemas.

--- a/packages/hub/src/persisted-schemas/derive.ts
+++ b/packages/hub/src/persisted-schemas/derive.ts
@@ -47,7 +47,7 @@ function detectKind(validator: unknown): PersistedSchemaKind {
  */
 export function isZod4Schema(value: unknown): boolean {
   if (value === null || typeof value !== 'object') return false
-  return '_zod' in (value as object)
+  return '_zod' in value
 }
 
 /**

--- a/packages/hub/src/persisted-schemas/derive.ts
+++ b/packages/hub/src/persisted-schemas/derive.ts
@@ -13,15 +13,21 @@ import { sha256Hex } from '../crypto.js'
 import type { PersistedSchemaEnvelope, PersistedSchemaKind } from './types.js'
 
 /**
- * Heuristic Zod detection — Zod schemas carry a `_def.typeName` property
- * starting with `Zod` (e.g. `ZodObject`, `ZodString`). This survives Zod's
- * minor-version bumps because the typeName naming is stable across v3.
+ * Heuristic Zod detection — uses the Standard Schema v1 `~standard.vendor`
+ * property (present in Zod v3.23+ and Zod v4+). Falls back to the
+ * `_def.typeName` heuristic for older Zod v3 builds that predate Standard
+ * Schema support.
  */
 export function isZodSchema(value: unknown): boolean {
   if (value === null || typeof value !== 'object') return false
+  // Standard Schema v1 vendor tag — most reliable across Zod majors
+  const std = (value as { '~standard'?: { vendor?: unknown } })['~standard']
+  if (std && typeof std === 'object' && (std as { vendor?: unknown }).vendor === 'zod') return true
+  // Zod v3 fallback: _def.typeName starts with 'Zod' (e.g. 'ZodObject')
   const def = (value as { _def?: { typeName?: unknown } })._def
   if (!def || typeof def !== 'object') return false
-  return typeof def.typeName === 'string' && def.typeName.startsWith('Zod')
+  return typeof (def as { typeName?: unknown }).typeName === 'string'
+    && ((def as { typeName: string }).typeName).startsWith('Zod')
 }
 
 function detectKind(validator: unknown): PersistedSchemaKind {
@@ -30,10 +36,21 @@ function detectKind(validator: unknown): PersistedSchemaKind {
 }
 
 /**
+ * Returns `true` when the validator was created with the Zod v4 native API
+ * (i.e. `import { z } from 'zod'` where zod resolves to v4). Zod v4 native
+ * schemas carry a `_zod` property whereas Zod v3 schemas (and the v3-compat
+ * shim shipped inside zod@4 at `zod/v3`) use `_def.typeName`.
+ */
+function isZodV4Native(value: unknown): boolean {
+  if (value === null || typeof value !== 'object') return false
+  return '_zod' in (value as object)
+}
+
+/**
  * Lazy-require `zod-to-json-schema`. Returns the converter, or throws a
  * clear error if the peer-dep isn't installed.
  */
-async function loadZodConverter(): Promise<(s: unknown) => object> {
+async function loadZodToJsonSchemaConverter(): Promise<(s: unknown) => object> {
   try {
     const mod = (await import('zod-to-json-schema')) as { zodToJsonSchema?: (s: unknown) => object }
     if (!mod.zodToJsonSchema) {
@@ -49,6 +66,26 @@ async function loadZodConverter(): Promise<(s: unknown) => object> {
   }
 }
 
+/**
+ * Lazy-require Zod v4's built-in `toJSONSchema`. Used when the validator is a
+ * Zod v4 native schema and `zod-to-json-schema` is absent or cannot handle it.
+ * This is a dynamic import so it does not add a static zod dependency to hub.
+ */
+async function loadZodV4Converter(): Promise<(s: unknown) => object> {
+  try {
+    const mod = (await import('zod')) as { toJSONSchema?: (s: unknown) => object }
+    if (typeof mod.toJSONSchema !== 'function') {
+      throw new Error('zod.toJSONSchema not available (zod v4 required)')
+    }
+    return mod.toJSONSchema
+  } catch (err) {
+    throw new Error(
+      'persistJsonSchema with a Zod v4 schema requires zod@4 to be installed. '
+      + `Original error: ${err instanceof Error ? err.message : String(err)}`,
+    )
+  }
+}
+
 export async function derivePersistedSchema(
   validator: unknown,
 ): Promise<PersistedSchemaEnvelope> {
@@ -56,8 +93,21 @@ export async function derivePersistedSchema(
   const derivedAt = new Date().toISOString()
 
   if (kind === 'Zod') {
-    const convert = await loadZodConverter()
-    const jsonSchema = convert(validator)
+    let jsonSchema: object
+
+    if (isZodV4Native(validator)) {
+      // Zod v4 native schemas: use zod's built-in toJSONSchema (available in
+      // zod@4) because zod-to-json-schema@3.x parses _def.typeName which is
+      // absent in native v4 schemas.
+      const convert = await loadZodV4Converter()
+      jsonSchema = convert(validator)
+    } else {
+      // Zod v3 schemas (or v3-compat shim): use the optional peer-dep
+      // zod-to-json-schema for backward compatibility.
+      const convert = await loadZodToJsonSchemaConverter()
+      jsonSchema = convert(validator)
+    }
+
     const canonical = canonicalize(jsonSchema)
     const hash = await sha256Hex(new TextEncoder().encode(canonical))
     return { _noydb_schema: 1, kind, jsonSchema, hash, derivedAt }

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -1065,6 +1065,10 @@ export class Vault {
         validateFieldMetaKeys(collectionName, options.fieldMeta, known)
         collOpts.fieldMeta = options.fieldMeta
       }
+      // Pass a snapshot of the outbound refs for describe() (sync, config-only).
+      if (options?.refs !== undefined) {
+        collOpts.declaredRefs = this.refRegistry.getOutbound(collectionName)
+      }
       coll = new Collection<T>(collOpts)
       this.collectionCache.set(collectionName, coll)
 

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -152,6 +152,7 @@ import type { RevokeContext } from './attestation/revoke.js'
 import type { DumpSchemaOptions, VaultSchemaSnapshot, SchemaIntrospection } from './introspection/types.js'
 import { dumpVaultSchema, type VaultIntrospectState } from './introspection/walk.js'
 import type { FieldMeta } from './introspection/field-meta.js'
+import type { VaultMeta } from './introspection/meta.js'
 import { USER_ENVELOPE_COLLECTION } from './meta/user-envelope/types.js'
 
 /**
@@ -393,6 +394,13 @@ export class Vault {
   private locale: string | undefined
 
   /**
+   * Vault-level descriptive metadata. Set once at construction via
+   * `openVault(name, { meta })`. First-wins: re-opening a cached vault
+   * with different meta leaves the original untouched.
+   */
+  private readonly vaultMeta: VaultMeta | undefined
+
+  /**
    * Current consent scope. Set by `withConsent()` and
    * restored in its finally block. When non-null, every collection
    * access inside the scope writes one entry to `_consent_audit`.
@@ -539,6 +547,8 @@ export class Vault {
     guardStrategies?: ReadonlyArray<GuardStrategyHandleAny> | undefined
     numberingConfigs?: ReadonlyArray<DeferredNumberingConfig> | undefined
     forgetStrategy?: ForgetStrategy | undefined
+    /** Vault-level descriptive metadata — set once at construction (first-wins). */
+    meta?: VaultMeta | undefined
   }) {
     this.adapter = opts.adapter
     this.name = opts.name
@@ -583,6 +593,7 @@ export class Vault {
     this.historyConfig = opts.historyConfig ?? { enabled: true }
     this.reloadKeyring = opts.reloadKeyring
     this.locale = opts.locale
+    this.vaultMeta = opts.meta
     this.translateText = opts.plaintextTranslator
 
     // Build the lazy DEK resolver. Pulled out into a private method
@@ -1591,6 +1602,11 @@ export class Vault {
   /** Return the current vault-default locale. */
   getLocale(): string | undefined {
     return this.locale
+  }
+
+  /** Return the vault-level descriptive metadata (set-once at construction). */
+  getMeta(): VaultMeta | undefined {
+    return this.vaultMeta
   }
 
   /**
@@ -3805,6 +3821,7 @@ export class Vault {
         materializedViews: this.materializedViewRegistry !== null,
         overlayViews: this.overlayedViewRegistry !== null,
       },
+      ...(this.vaultMeta !== undefined ? { vaultMeta: this.vaultMeta } : {}),
       mvRegistry: this.materializedViewRegistry,
       overlayRegistry: this.overlayedViewRegistry,
       derivationRegistry: this.derivationRegistry,

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -152,7 +152,6 @@ import type { RevokeContext } from './attestation/revoke.js'
 import type { DumpSchemaOptions, VaultSchemaSnapshot, SchemaIntrospection } from './introspection/types.js'
 import { dumpVaultSchema, type VaultIntrospectState } from './introspection/walk.js'
 import type { FieldMeta } from './introspection/field-meta.js'
-import { validateFieldMetaKeys } from './introspection/field-meta.js'
 import { USER_ENVELOPE_COLLECTION } from './meta/user-envelope/types.js'
 
 /**
@@ -1053,16 +1052,11 @@ export class Vault {
       if (options?.i18nFields !== undefined && this.translateText) {
         collOpts.autoTranslateHook = this.translateText
       }
-      // fieldMeta: validate keys against union of all declared config keys, then thread through.
+      // fieldMeta: thread through to the collection. Real key-validation (against
+      // schema-derived fields) happens in the async describe() path where the full
+      // known-field set is available. The sync path at vault-construction time cannot
+      // validate schema fields, so no validate call here.
       if (options?.fieldMeta !== undefined) {
-        const known = new Set<string>([
-          ...Object.keys(options.moneyFields ?? {}),
-          ...Object.keys(options.dictKeyFields ?? {}),
-          ...Object.keys(options.refs ?? {}),
-          ...Object.keys(options.computed ?? {}),
-          ...Object.keys(options.fieldMeta), // schema fields: accepted (not strictly checkable sync)
-        ])
-        validateFieldMetaKeys(collectionName, options.fieldMeta, known)
         collOpts.fieldMeta = options.fieldMeta
       }
       // Pass a snapshot of the outbound refs for describe() (sync, config-only).

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -152,7 +152,7 @@ import type { RevokeContext } from './attestation/revoke.js'
 import type { DumpSchemaOptions, VaultSchemaSnapshot, SchemaIntrospection } from './introspection/types.js'
 import { dumpVaultSchema, type VaultIntrospectState } from './introspection/walk.js'
 import type { FieldMeta } from './introspection/field-meta.js'
-import type { VaultMeta } from './introspection/meta.js'
+import type { CollectionMeta, VaultMeta } from './introspection/meta.js'
 import { USER_ENVELOPE_COLLECTION } from './meta/user-envelope/types.js'
 
 /**
@@ -704,7 +704,7 @@ export class Vault {
     /** Consumer-neutral per-field descriptors (label/unit/semanticType/sensitivity…). See collection.describe(). */
     fieldMeta?: Record<string, FieldMeta>
     /** The collection's own descriptive metadata (label/description/icon). See collection.describe(). */
-    meta?: import('./introspection/meta.js').CollectionMeta
+    meta?: CollectionMeta
     /** — declare money() fields for currency-safe decimal storage/formatting. */
     moneyFields?: Record<string, MoneyDescriptor>
     /** — declare computed scalar fields, evaluated on write (schema-owned). */

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -947,6 +947,7 @@ export class Vault {
         getDEK: this.getDEK,
         onDirty: this.onDirty,
         historyConfig: effectiveHistoryConfig,
+        historyConfigExplicit: options?.historyConfig !== undefined,
         // thread the vault-wide blob strategy into every
         // collection. `undefined` is intentionally preserved so the
         // Collection constructor uses its NO_BLOBS default.
@@ -3825,6 +3826,14 @@ export class Vault {
       mvRegistry: this.materializedViewRegistry,
       overlayRegistry: this.overlayedViewRegistry,
       derivationRegistry: this.derivationRegistry,
+      // Thread vault-level per-collection registries into the walker so
+      // walk.ts can project archive/schemaUpdate into CollectionDescriptor.config
+      // without coupling the walker to Vault internals.
+      getCollectionSchemaUpdateNames: (col) => {
+        const names = this.#schemaUpdateNames.get(col)
+        return names !== undefined && names.length > 0 ? names : undefined
+      },
+      hasCollectionArchive: (col) => this.archiveRegistry.has(col),
     }
   }
 

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -692,6 +692,8 @@ export class Vault {
     dictKeyFields?: Record<string, DictKeyDescriptor | StaticDictDescriptor>
     /** Consumer-neutral per-field descriptors (label/unit/semanticType/sensitivity…). See collection.describe(). */
     fieldMeta?: Record<string, FieldMeta>
+    /** The collection's own descriptive metadata (label/description/icon). See collection.describe(). */
+    meta?: import('./introspection/meta.js').CollectionMeta
     /** — declare money() fields for currency-safe decimal storage/formatting. */
     moneyFields?: Record<string, MoneyDescriptor>
     /** — declare computed scalar fields, evaluated on write (schema-owned). */
@@ -820,6 +822,12 @@ export class Vault {
       // auto-created without options gets its fieldMeta attached here.
       // First-wins: if the collection already has fieldMeta set this is a no-op.
       coll._applyFieldMeta(options.fieldMeta)
+    }
+    if (coll && options?.meta) {
+      // Same MV-pre-creation reconcile as fieldMeta: attach collection-level
+      // descriptive metadata to a collection that was auto-created without options.
+      // First-wins.
+      coll._applyMeta(options.meta)
     }
     if (!coll) {
       // Register ref declarations (if any) with the vault-level
@@ -1064,6 +1072,10 @@ export class Vault {
       // validate schema fields, so no validate call here.
       if (options?.fieldMeta !== undefined) {
         collOpts.fieldMeta = options.fieldMeta
+      }
+      // meta: thread through to the collection; surfaced via getMeta() / describe().
+      if (options?.meta !== undefined) {
+        collOpts.meta = options.meta
       }
       // Pass a snapshot of the outbound refs for describe() (sync, config-only).
       if (options?.refs !== undefined) {

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -151,6 +151,8 @@ import type { IssueContext } from './attestation/issue.js'
 import type { RevokeContext } from './attestation/revoke.js'
 import type { DumpSchemaOptions, VaultSchemaSnapshot, SchemaIntrospection } from './introspection/types.js'
 import { dumpVaultSchema, type VaultIntrospectState } from './introspection/walk.js'
+import type { FieldMeta } from './introspection/field-meta.js'
+import { validateFieldMetaKeys } from './introspection/field-meta.js'
 import { USER_ENVELOPE_COLLECTION } from './meta/user-envelope/types.js'
 
 /**
@@ -689,6 +691,8 @@ export class Vault {
     textIndexPersist?: boolean
     /** — declare dictKey / staticDict fields for label resolution on reads. */
     dictKeyFields?: Record<string, DictKeyDescriptor | StaticDictDescriptor>
+    /** Consumer-neutral per-field descriptors (label/unit/semanticType/sensitivity…). See collection.describe(). */
+    readonly fieldMeta?: Record<string, FieldMeta>
     /** — declare money() fields for currency-safe decimal storage/formatting. */
     moneyFields?: Record<string, MoneyDescriptor>
     /** — declare computed scalar fields, evaluated on write (schema-owned). */
@@ -1048,6 +1052,18 @@ export class Vault {
       // Wire the translator for autoTranslate: true fields
       if (options?.i18nFields !== undefined && this.translateText) {
         collOpts.autoTranslateHook = this.translateText
+      }
+      // fieldMeta: validate keys against union of all declared config keys, then thread through.
+      if (options?.fieldMeta !== undefined) {
+        const known = new Set<string>([
+          ...Object.keys(options.moneyFields ?? {}),
+          ...Object.keys(options.dictKeyFields ?? {}),
+          ...Object.keys(options.refs ?? {}),
+          ...Object.keys(options.computed ?? {}),
+          ...Object.keys(options.fieldMeta), // schema fields: accepted (not strictly checkable sync)
+        ])
+        validateFieldMetaKeys(collectionName, options.fieldMeta, known)
+        collOpts.fieldMeta = options.fieldMeta
       }
       coll = new Collection<T>(collOpts)
       this.collectionCache.set(collectionName, coll)

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -691,7 +691,7 @@ export class Vault {
     /** — declare dictKey / staticDict fields for label resolution on reads. */
     dictKeyFields?: Record<string, DictKeyDescriptor | StaticDictDescriptor>
     /** Consumer-neutral per-field descriptors (label/unit/semanticType/sensitivity…). See collection.describe(). */
-    readonly fieldMeta?: Record<string, FieldMeta>
+    fieldMeta?: Record<string, FieldMeta>
     /** — declare money() fields for currency-safe decimal storage/formatting. */
     moneyFields?: Record<string, MoneyDescriptor>
     /** — declare computed scalar fields, evaluated on write (schema-owned). */
@@ -814,6 +814,12 @@ export class Vault {
       // MV source is auto-created (without options) before this
       // declaration; attach computed fields so writes materialize them.
       coll._applyComputed(options.computed as ComputedFields)
+    }
+    if (coll && options?.fieldMeta) {
+      // Same MV-pre-creation reconcile as money/computed: a collection
+      // auto-created without options gets its fieldMeta attached here.
+      // First-wins: if the collection already has fieldMeta set this is a no-op.
+      coll._applyFieldMeta(options.fieldMeta)
     }
     if (!coll) {
       // Register ref declarations (if any) with the vault-level

--- a/packages/in-devtools-tui/__tests__/records-pii.test.tsx
+++ b/packages/in-devtools-tui/__tests__/records-pii.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * RecordsPane PII masking tests — verifies that:
+ *   - fields with sensitivity pii/secret render as •••• by default
+ *   - the reveal-all key ('r') un-masks all sensitive cells
+ *   - public and unclassified fields are always shown
+ *   - a collection without described masks nothing (back-compat)
+ */
+import { describe, it, expect } from 'vitest'
+import { render } from 'ink-testing-library'
+import React from 'react'
+import { createNoydb, ConflictError } from '@noy-db/hub'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '@noy-db/hub'
+import { createInspector } from '@noy-db/in-devtools'
+import { App } from '../src/App.js'
+
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const coll = (v: string, c: string) => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) { const m = coll(v, c); const ex = m.get(id); if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v); m.set(id, env) },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async listVaults() { return [...data.keys()] },
+    async loadAll(v) { const vm = data.get(v); const s: VaultSnapshot = {}; if (vm) for (const [cn, cm] of vm) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of cm) r[id] = e; s[cn] = r } return s },
+    async saveAll() {},
+  }
+}
+
+/** Navigate to the Records tab for the first collection. */
+async function drillToRecords(stdin: NodeJS.WritableStream) {
+  await new Promise((r) => setTimeout(r, 120))
+  stdin.write('\r')   // enter → drill into first collection
+  await new Promise((r) => setTimeout(r, 60))
+  stdin.write('\t')   // tab → Records pane
+  await new Promise((r) => setTimeout(r, 100))
+}
+
+describe('RecordsPane PII masking', () => {
+  it('masks pii and secret fields as •••• by default', async () => {
+    const db = await createNoydb({ store: memoryStore(), user: 'owner', secret: 'pw' })
+    const vault = await db.openVault('hr')
+    const employees = vault.collection<{ id: string; name: string; email: string; salary: number }>('employees', {
+      fieldMeta: {
+        name:   { label: 'Name' },
+        email:  { label: 'Email', sensitivity: 'pii' },
+        salary: { label: 'Salary', sensitivity: 'secret' },
+      },
+    })
+    await employees.put('e1', { id: 'e1', name: 'Alice', email: 'alice@example.com', salary: 90000 })
+    const inspector = createInspector(db)
+    const initial = { vaults: await inspector.listVaults(), snapshot: await inspector.snapshot(vault) }
+
+    const { lastFrame, stdin } = render(<App inspector={inspector} vault={vault} vaultName="hr" initial={initial} />)
+    await drillToRecords(stdin)
+
+    const frame = lastFrame() ?? ''
+    // PII and secret values must be masked
+    expect(frame).toContain('••••')
+    expect(frame).not.toContain('alice@example.com')
+    expect(frame).not.toContain('90000')
+    // Public/unclassified field is shown
+    expect(frame).toContain('Alice')
+  })
+
+  it('reveal-all key (r) un-masks sensitive fields', async () => {
+    const db = await createNoydb({ store: memoryStore(), user: 'owner', secret: 'pw' })
+    const vault = await db.openVault('hr')
+    const employees = vault.collection<{ id: string; name: string; email: string }>('employees', {
+      fieldMeta: {
+        name:  { label: 'Name' },
+        email: { label: 'Email', sensitivity: 'pii' },
+      },
+    })
+    await employees.put('e1', { id: 'e1', name: 'Alice', email: 'alice@example.com' })
+    const inspector = createInspector(db)
+    const initial = { vaults: await inspector.listVaults(), snapshot: await inspector.snapshot(vault) }
+
+    const { lastFrame, stdin } = render(<App inspector={inspector} vault={vault} vaultName="hr" initial={initial} />)
+    await drillToRecords(stdin)
+
+    // Default: masked
+    expect(lastFrame() ?? '').toContain('••••')
+    expect(lastFrame() ?? '').not.toContain('alice@example.com')
+
+    // Press 'r' → reveal all
+    stdin.write('r')
+    await new Promise((r) => setTimeout(r, 60))
+    const revealed = lastFrame() ?? ''
+    expect(revealed).toContain('alice@example.com')
+    expect(revealed).not.toContain('••••')
+  })
+
+  it('public fields are never masked', async () => {
+    const db = await createNoydb({ store: memoryStore(), user: 'owner', secret: 'pw' })
+    const vault = await db.openVault('catalog')
+    const items = vault.collection<{ id: string; sku: string; price: number }>('items', {
+      fieldMeta: {
+        sku:   { label: 'SKU', sensitivity: 'public' },
+        price: { label: 'Price', sensitivity: 'public' },
+      },
+    })
+    await items.put('i1', { id: 'i1', sku: 'ABC-123', price: 42 })
+    const inspector = createInspector(db)
+    const initial = { vaults: await inspector.listVaults(), snapshot: await inspector.snapshot(vault) }
+
+    const { lastFrame, stdin } = render(<App inspector={inspector} vault={vault} vaultName="catalog" initial={initial} />)
+    await drillToRecords(stdin)
+
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('ABC-123')
+    expect(frame).toContain('42')
+    expect(frame).not.toContain('••••')
+  })
+
+  it('back-compat: no described → no masking', async () => {
+    const db = await createNoydb({ store: memoryStore(), user: 'owner', secret: 'pw' })
+    const vault = await db.openVault('legacy')
+    // No fieldMeta → no described in snapshot
+    const notes = vault.collection<{ id: string; secret: string }>('notes')
+    await notes.put('n1', { id: 'n1', secret: 'top-secret-data' })
+    const inspector = createInspector(db)
+    const initial = { vaults: await inspector.listVaults(), snapshot: await inspector.snapshot(vault) }
+
+    const { lastFrame, stdin } = render(<App inspector={inspector} vault={vault} vaultName="legacy" initial={initial} />)
+    await drillToRecords(stdin)
+
+    const frame = lastFrame() ?? ''
+    // No masking when no described
+    expect(frame).toContain('top-secret-data')
+    expect(frame).not.toContain('••••')
+  })
+
+  it('reveal-all resets when switching to a different collection', async () => {
+    const db = await createNoydb({ store: memoryStore(), user: 'owner', secret: 'pw' })
+    const vault = await db.openVault('hr')
+    const employees = vault.collection<{ id: string; name: string; email: string }>('employees', {
+      fieldMeta: {
+        name:  { label: 'Name' },
+        email: { label: 'Email', sensitivity: 'pii' },
+      },
+    })
+    await employees.put('e1', { id: 'e1', name: 'Alice', email: 'alice@example.com' })
+    const contacts = vault.collection<{ id: string; tag: string; phone: string }>('contacts', {
+      fieldMeta: {
+        tag:   { label: 'Tag' },
+        phone: { label: 'Phone', sensitivity: 'pii' },
+      },
+    })
+    await contacts.put('c1', { id: 'c1', tag: 'vip', phone: '555-1234' })
+    const inspector = createInspector(db)
+    const initial = { vaults: await inspector.listVaults(), snapshot: await inspector.snapshot(vault) }
+
+    const { lastFrame, stdin } = render(<App inspector={inspector} vault={vault} vaultName="hr" initial={initial} />)
+
+    // Navigate to Records for the first collection
+    await new Promise((r) => setTimeout(r, 120))
+    stdin.write('\r')   // enter → drill into first collection (contacts — alphabetical first)
+    await new Promise((r) => setTimeout(r, 60))
+    stdin.write('\t')   // tab → Records
+    await new Promise((r) => setTimeout(r, 120))
+
+    // Verify we're in records pane (masked by default)
+    const before = lastFrame() ?? ''
+    expect(before).toContain('••••')
+
+    // Press 'r' to reveal
+    stdin.write('r')
+    await new Promise((r) => setTimeout(r, 80))
+    const afterReveal = lastFrame() ?? ''
+    // Should be un-masked now (contains real PII from whichever collection is shown)
+    expect(afterReveal).not.toContain('••••')
+
+    // Escape back to collection list, move to second collection and drill to Records
+    stdin.write('\x1B') // escape → back to list
+    await new Promise((r) => setTimeout(r, 60))
+    stdin.write('\x1B[B') // down arrow → second collection
+    await new Promise((r) => setTimeout(r, 60))
+    stdin.write('\r')   // enter → drill
+    await new Promise((r) => setTimeout(r, 60))
+    stdin.write('\t')   // tab → Records
+    await new Promise((r) => setTimeout(r, 120))
+
+    // Reveal should have reset — second collection's PII should be masked
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('••••')
+  })
+})

--- a/packages/in-devtools-tui/__tests__/rich-schema.test.tsx
+++ b/packages/in-devtools-tui/__tests__/rich-schema.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Rich-schema rendering tests — verifies that the TUI detail pane renders
+ * collection meta.label, rich field descriptors (label/type/widget/markers),
+ * the config strip, and vault meta.label when present in the snapshot.
+ */
+import { describe, it, expect } from 'vitest'
+import { render } from 'ink-testing-library'
+import React from 'react'
+import { createNoydb, ConflictError } from '@noy-db/hub'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '@noy-db/hub'
+import { createInspector } from '@noy-db/in-devtools'
+import { App } from '../src/App.js'
+
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const coll = (v: string, c: string) => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) { const m = coll(v, c); const ex = m.get(id); if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v); m.set(id, env) },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async listVaults() { return [...data.keys()] },
+    async loadAll(v) { const vm = data.get(v); const s: VaultSnapshot = {}; if (vm) for (const [cn, cm] of vm) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of cm) r[id] = e; s[cn] = r } return s },
+    async saveAll() {},
+  }
+}
+
+async function setup() {
+  const db = await createNoydb({ store: memoryStore(), user: 'owner', secret: 'pw' })
+  const vault = await db.openVault('ledger', { meta: { label: 'Acme Ledger 2026' } })
+  vault.collection<{ id: string; amount: number; note: string }>('invoices', {
+    meta: { label: 'Sales Invoices', description: 'Outbound sales invoices' },
+    fieldMeta: {
+      amount: { label: 'Amount', sensitivity: 'pii' },
+      note:   { label: 'Note' },
+    },
+  })
+  const inspector = createInspector(db)
+  const initial = { vaults: await inspector.listVaults(), snapshot: await inspector.snapshot(vault) }
+  return { inspector, vault, initial }
+}
+
+describe('TUI rich schema rendering', () => {
+  it('shows vault meta.label in the vault list', async () => {
+    const { inspector, vault, initial } = await setup()
+    const { lastFrame } = render(
+      <App inspector={inspector} vault={vault} vaultName="ledger" initial={initial} />,
+    )
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('Acme Ledger 2026')
+  })
+
+  it('shows collection meta.label in the collection list', async () => {
+    const { inspector, vault, initial } = await setup()
+    const { lastFrame } = render(
+      <App inspector={inspector} vault={vault} vaultName="ledger" initial={initial} />,
+    )
+    const frame = lastFrame() ?? ''
+    expect(frame).toContain('Sales Invoices')
+  })
+
+  it('drilled detail pane shows label heading + rich fields + sensitivity marker', async () => {
+    const { inspector, vault, initial } = await setup()
+    const { lastFrame, stdin } = render(
+      <App inspector={inspector} vault={vault} vaultName="ledger" initial={initial} />,
+    )
+    await new Promise((r) => setTimeout(r, 100))
+    stdin.write('\r') // enter → drill into first collection
+    await new Promise((r) => setTimeout(r, 60))
+    const frame = lastFrame() ?? ''
+    // Detail heading shows meta.label
+    expect(frame).toContain('Sales Invoices')
+    // Rich field labels rendered
+    expect(frame).toContain('Amount')
+    // Sensitivity marker for pii field
+    expect(frame).toContain('[pii]')
+  })
+})

--- a/packages/in-devtools-tui/src/App.tsx
+++ b/packages/in-devtools-tui/src/App.tsx
@@ -105,7 +105,7 @@ export function App({ inspector, vault, vaultName, initial }: AppProps) {
     <Box flexDirection="column">
       <Text bold>noy-db inspector — {vaultName} <Text dimColor>(↑/↓ · ↵ drill · ⇥ tab · q quit)</Text></Text>
       <Box marginTop={1}>
-        <VaultList vaults={vaults} activeName={vaultName} />
+        <VaultList vaults={vaults} activeName={vaultName} snapshot={snapshot} />
         <CollectionList snapshot={snapshot ?? { vault: vaultName, collections: [] }} selectedIdx={selectedIdx} />
         {drilled && tab === 'records' && current
           ? <RecordsPane collection={current} page={page} {...(recErr !== undefined ? { error: recErr } : {})} />

--- a/packages/in-devtools-tui/src/App.tsx
+++ b/packages/in-devtools-tui/src/App.tsx
@@ -105,7 +105,7 @@ export function App({ inspector, vault, vaultName, initial }: AppProps) {
     <Box flexDirection="column">
       <Text bold>noy-db inspector — {vaultName} <Text dimColor>(↑/↓ · ↵ drill · ⇥ tab · q quit)</Text></Text>
       <Box marginTop={1}>
-        <VaultList vaults={vaults} activeName={vaultName} snapshot={snapshot} />
+        <VaultList vaults={vaults} activeName={vaultName} {...(snapshot !== undefined ? { snapshot } : {})} />
         <CollectionList snapshot={snapshot ?? { vault: vaultName, collections: [] }} selectedIdx={selectedIdx} />
         {drilled && tab === 'records' && current
           ? <RecordsPane collection={current} page={page} {...(recErr !== undefined ? { error: recErr } : {})} />

--- a/packages/in-devtools-tui/src/App.tsx
+++ b/packages/in-devtools-tui/src/App.tsx
@@ -32,7 +32,13 @@ export function App({ inspector, vault, vaultName, initial }: AppProps) {
   const [offset, setOffset] = useState(0)
   const [page, setPage] = useState<RecordPage | null>(null)
   const [recErr, setRecErr] = useState<string | undefined>(undefined)
+  const [revealAll, setRevealAll] = useState(false)
   const current = collections[selectedIdx]
+
+  // Reset reveal-all when the viewed collection changes so PII doesn't linger.
+  useEffect(() => {
+    setRevealAll(false)
+  }, [selectedIdx])
 
   const [view, setView] = useState<View>('structure')
   const [feed, setFeed] = useState<ReadonlyArray<FeedRow>>([])
@@ -96,6 +102,7 @@ export function App({ inspector, vault, vaultName, initial }: AppProps) {
     if (tab === 'records') {
       if (input === 'n' && (!page || offset + PAGE < page.total)) setOffset((o) => o + PAGE)
       if (input === 'p' && offset - PAGE >= 0) setOffset((o) => o - PAGE)
+      if (input === 'r') setRevealAll((v) => !v)
     }
   })
 
@@ -108,7 +115,7 @@ export function App({ inspector, vault, vaultName, initial }: AppProps) {
         <VaultList vaults={vaults} activeName={vaultName} {...(snapshot !== undefined ? { snapshot } : {})} />
         <CollectionList snapshot={snapshot ?? { vault: vaultName, collections: [] }} selectedIdx={selectedIdx} />
         {drilled && tab === 'records' && current
-          ? <RecordsPane collection={current} page={page} {...(recErr !== undefined ? { error: recErr } : {})} />
+          ? <RecordsPane collection={current} page={page} revealAll={revealAll} {...(recErr !== undefined ? { error: recErr } : {})} />
           : <DetailPane collection={drilled ? current : undefined} />}
       </Box>
     </Box>

--- a/packages/in-devtools-tui/src/panes/CollectionList.tsx
+++ b/packages/in-devtools-tui/src/panes/CollectionList.tsx
@@ -6,11 +6,13 @@ export function CollectionList({ snapshot, selectedIdx }: { snapshot: InspectorS
   return (
     <Box flexDirection="column" marginRight={2}>
       <Text bold underline>Collections</Text>
-      {snapshot.collections.map((c, i) => (
-        i === selectedIdx
-          ? <Text key={c.name} color="cyan" inverse>{c.name}</Text>
-          : <Text key={c.name}>{c.name}</Text>
-      ))}
+      {snapshot.collections.map((c, i) => {
+        // Show meta.label when present; append the collection key in dimmed parens
+        const display = c.meta?.label ? `${c.meta.label} (${c.name})` : c.name
+        return i === selectedIdx
+          ? <Text key={c.name} color="cyan" inverse>{display}</Text>
+          : <Text key={c.name}>{display}</Text>
+      })}
     </Box>
   )
 }

--- a/packages/in-devtools-tui/src/panes/DetailPane.tsx
+++ b/packages/in-devtools-tui/src/panes/DetailPane.tsx
@@ -1,17 +1,82 @@
 import React from 'react'
 import { Box, Text } from 'ink'
 import type { InspectorCollection } from '@noy-db/in-devtools'
+import type { CollectionConfig } from '@noy-db/hub'
+
+/** Compact sensitivity marker for terminal rendering. */
+function sensitivityTag(s: 'public' | 'pii' | 'secret' | undefined): string {
+  if (s === 'pii') return '[pii]'
+  if (s === 'secret') return '[secret]'
+  return ''
+}
+
+/** Render a compact config line from CollectionConfig fields that are set. */
+function ConfigLine({ config }: { config: CollectionConfig }) {
+  const parts: string[] = []
+  if (config.textIndexes?.length) parts.push(`idx:${config.textIndexes.length}`)
+  if (config.embeddings) parts.push(`emb:${config.embeddings.dim}d`)
+  if (config.i18nFields?.length) parts.push(`i18n:${config.i18nFields.length}`)
+  if (config.crdt) parts.push(`crdt:${config.crdt}`)
+  if (config.provenance) parts.push('provenance')
+  if (config.archive) parts.push('archive')
+  if (config.tiers?.length) parts.push(`tiers:${config.tiers.join(',')}`)
+  if (config.perRecordKeys) parts.push('per-record-cek')
+  if (!parts.length) return null
+  return <Text dimColor>config: {parts.join('  ')}</Text>
+}
 
 export function DetailPane({ collection }: { collection: InspectorCollection | undefined }) {
   if (!collection) return (
     <Box flexDirection="column"><Text dimColor>Select a collection (↵)</Text></Box>
   )
-  const fieldNames = Object.keys(collection.fields)
+
+  const heading = collection.meta?.label
+    ? `${collection.meta.label} (${collection.name})`
+    : collection.name
+
   return (
     <Box flexDirection="column">
-      <Text bold underline>{collection.name}</Text>
+      <Text bold underline>{heading}</Text>
+      {collection.meta?.description
+        ? <Text dimColor>{collection.meta.description}</Text>
+        : null}
       <Text>records: {collection.stats?.records ?? '—'}  bytes: {collection.stats?.bytes ?? '—'}</Text>
-      <Text>fields: {fieldNames.length ? fieldNames.join(', ') : '(none)'}</Text>
+
+      {/* Rich field list from describe() when available */}
+      {collection.described && collection.described.length > 0
+        ? (
+          <Box flexDirection="column" marginTop={1}>
+            <Text bold>schema</Text>
+            {collection.described.map((f) => {
+              const sens = sensitivityTag(f.sensitivity)
+              const i18nMark = f.i18n ? '[i18n]' : ''
+              const roMark = f.editable === false ? '[ro]' : ''
+              const widgetMark = f.widget ? `<${f.widget}>` : ''
+              const markers = [sens, i18nMark, roMark, widgetMark].filter(Boolean).join(' ')
+              return (
+                <Text key={f.key}>
+                  {'  '}{f.label} <Text dimColor>({f.key}: {f.type})</Text>
+                  {markers ? <Text color="yellow">  {markers}</Text> : null}
+                </Text>
+              )
+            })}
+          </Box>
+        )
+        : (
+          <Box flexDirection="column" marginTop={1}>
+            <Text bold>schema</Text>
+            {Object.keys(collection.fields).length
+              ? Object.keys(collection.fields).map((k) => (
+                <Text key={k}>{'  '}{k}: <Text dimColor>{collection.fields[k].type}</Text></Text>
+              ))
+              : <Text dimColor>  (no declared fields)</Text>}
+          </Box>
+        )}
+
+      {/* Collection config strip */}
+      {collection.config
+        ? <Box marginTop={1}><ConfigLine config={collection.config} /></Box>
+        : null}
     </Box>
   )
 }

--- a/packages/in-devtools-tui/src/panes/DetailPane.tsx
+++ b/packages/in-devtools-tui/src/panes/DetailPane.tsx
@@ -66,8 +66,8 @@ export function DetailPane({ collection }: { collection: InspectorCollection | u
           <Box flexDirection="column" marginTop={1}>
             <Text bold>schema</Text>
             {Object.keys(collection.fields).length
-              ? Object.keys(collection.fields).map((k) => (
-                <Text key={k}>{'  '}{k}: <Text dimColor>{collection.fields[k].type}</Text></Text>
+              ? Object.entries(collection.fields).map(([k, f]) => (
+                <Text key={k}>{'  '}{k}: <Text dimColor>{f.type}</Text></Text>
               ))
               : <Text dimColor>  (no declared fields)</Text>}
           </Box>

--- a/packages/in-devtools-tui/src/panes/RecordsPane.tsx
+++ b/packages/in-devtools-tui/src/panes/RecordsPane.tsx
@@ -45,7 +45,7 @@ export function RecordsPane({ collection, page, error, revealAll }: {
     return raw
   }
 
-  const revealHint = sensitiveKeys.size > 0 ? ' · r reveal' : ''
+  const revealHint = sensitiveKeys.size > 0 ? ' · r reveal/hide' : ''
   return (
     <Box flexDirection="column">
       <Text bold>rows {from}–{to} of {page.total} <Text dimColor>(n/p page · ⇥ back{revealHint})</Text></Text>

--- a/packages/in-devtools-tui/src/panes/RecordsPane.tsx
+++ b/packages/in-devtools-tui/src/panes/RecordsPane.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { Box, Text } from 'ink'
 import type { RecordPage, InspectorCollection } from '@noy-db/in-devtools'
 
+const MASK = '••••'
+
 function cell(value: unknown): string {
   if (value === null || value === undefined) return '·'
   if (typeof value === 'object') return Array.isArray(value) ? `[${(value as unknown[]).length}]` : '{…}'
@@ -10,11 +12,22 @@ function cell(value: unknown): string {
   return '?'
 }
 
-export function RecordsPane({ collection, page, error }: {
+export function RecordsPane({ collection, page, error, revealAll }: {
   collection: InspectorCollection
   page: RecordPage | null
   error?: string
+  revealAll?: boolean
 }) {
+  // Build the set of sensitive field keys from described[] (pii + secret); empty if no described.
+  const sensitiveKeys: ReadonlySet<string> = React.useMemo(() => {
+    if (!collection.described) return new Set<string>()
+    const keys = new Set<string>()
+    for (const f of collection.described) {
+      if (f.sensitivity !== undefined && f.sensitivity !== 'public') keys.add(f.key)
+    }
+    return keys
+  }, [collection.described])
+
   const schemaFields = Object.keys(collection.fields)
   if (error) return <Box flexDirection="column"><Text color="red">records error: {error}</Text><Text dimColor>n/p retry · ⇥ back</Text></Box>
   if (!page) return <Box flexDirection="column"><Text dimColor>loading records…</Text></Box>
@@ -25,12 +38,20 @@ export function RecordsPane({ collection, page, error }: {
   const fields = schemaFields.length > 0 ? schemaFields : firstRowKeys
   const from = page.total === 0 ? 0 : page.offset + 1
   const to = Math.min(page.offset + page.limit, page.total)
+
+  function renderCell(f: string, row: unknown): string {
+    const raw = cell((row as Record<string, unknown>)?.[f])
+    if (!revealAll && sensitiveKeys.has(f)) return MASK
+    return raw
+  }
+
+  const revealHint = sensitiveKeys.size > 0 ? ' · r reveal' : ''
   return (
     <Box flexDirection="column">
-      <Text bold>rows {from}–{to} of {page.total} <Text dimColor>(n/p page · ⇥ back)</Text></Text>
+      <Text bold>rows {from}–{to} of {page.total} <Text dimColor>(n/p page · ⇥ back{revealHint})</Text></Text>
       <Text dimColor>{fields.join('  ')}</Text>
       {page.rows.map((row, i) => (
-        <Text key={i}>{fields.map((f) => cell((row as Record<string, unknown>)?.[f])).join('  ')}</Text>
+        <Text key={i}>{fields.map((f) => renderCell(f, row)).join('  ')}</Text>
       ))}
     </Box>
   )

--- a/packages/in-devtools-tui/src/panes/VaultList.tsx
+++ b/packages/in-devtools-tui/src/panes/VaultList.tsx
@@ -1,16 +1,29 @@
 import React from 'react'
 import { Box, Text } from 'ink'
-import type { VaultInfo } from '@noy-db/in-devtools'
+import type { VaultInfo, InspectorSnapshot } from '@noy-db/in-devtools'
 
-export function VaultList({ vaults, activeName }: { vaults: ReadonlyArray<VaultInfo>; activeName: string }) {
+export function VaultList({
+  vaults,
+  activeName,
+  snapshot,
+}: {
+  vaults: ReadonlyArray<VaultInfo>
+  activeName: string
+  /** Active vault snapshot; used to read vault meta.label when available. */
+  snapshot?: InspectorSnapshot
+}) {
   return (
     <Box flexDirection="column" marginRight={2}>
       <Text bold underline>Vaults</Text>
-      {vaults.map((v) => (
-        v.id === activeName
-          ? <Text key={v.id} color="green">{'› '}{v.id}</Text>
+      {vaults.map((v) => {
+        // Show meta.label for the active vault when available
+        const vaultLabel = v.id === activeName && snapshot?.meta?.label
+          ? `${snapshot.meta.label} (${v.id})`
+          : v.id
+        return v.id === activeName
+          ? <Text key={v.id} color="green">{'› '}{vaultLabel}</Text>
           : <Text key={v.id}>{'  '}{v.id}</Text>
-      ))}
+      })}
     </Box>
   )
 }

--- a/packages/in-devtools/__tests__/snapshot.test.ts
+++ b/packages/in-devtools/__tests__/snapshot.test.ts
@@ -1,0 +1,107 @@
+/**
+ * snapshot() enrichment — #483 Task 5
+ *
+ * Asserts that snapshot() surfaces describe()-derived fields, per-collection
+ * config, per-collection meta, and vault-level meta on InspectorSnapshot.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, money } from '@noy-db/hub'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '@noy-db/hub'
+import { ConflictError } from '@noy-db/hub'
+import { snapshot } from '../src/snapshot.js'
+
+// ── Minimal in-memory store (same pattern used by inspector.test.ts) ─────────
+
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const coll = (v: string, c: string) => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const m = coll(v, c); const ex = m.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      m.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async listVaults() { return [...data.keys()] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll() {},
+  }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+async function buildVault() {
+  const db = await createNoydb({ store: memoryStore(), user: 'owner', secret: 'pw' })
+  const vault = await db.openVault('sales-db', { meta: { label: 'Acme Sales', description: 'All sales data' } })
+
+  // Collection with meta + money field + textIndexes
+  vault.collection<{ id: string; total: string; description: string }>('sales', {
+    meta: { label: 'Sales' },
+    moneyFields: { total: money({ currency: 'USD', scale: 2 }) },
+    textIndexes: ['description'],
+  })
+
+  return vault
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('snapshot() enrichment (#483 Task 5)', () => {
+  it('snapshot includes describe() per-field + config + meta', async () => {
+    const vault = await buildVault()
+    const snap = await snapshot(vault)
+
+    // Vault-level meta
+    expect(snap.meta?.label).toBeDefined()
+    expect(snap.meta?.label).toBe('Acme Sales')
+
+    // Collection-level assertions
+    const c = snap.collections.find((x) => x.name === 'sales')!
+    expect(c).toBeTruthy()
+
+    // CollectionMeta
+    expect(c.meta?.label).toBe('Sales')
+
+    // describe() fields — money field → widget === 'money'
+    expect(c.described?.some((f) => f.widget === 'money')).toBe(true)
+
+    // config (textIndexes declared)
+    expect(c.config).toBeDefined()
+    expect(c.config?.textIndexes).toContain('description')
+  })
+
+  it('described field for money has semanticType currency', async () => {
+    const vault = await buildVault()
+    const snap = await snapshot(vault)
+    const c = snap.collections.find((x) => x.name === 'sales')!
+    const moneyField = c.described?.find((f) => f.key === 'total')
+    expect(moneyField?.semanticType).toBe('currency')
+    expect(moneyField?.money?.mode).toBe('fixed')
+  })
+
+  it('snapshot does not fail for undeclared collections appearing in dumpSchema', async () => {
+    // A vault can have collections in the store that were not live-declared
+    // (e.g. from a prior open). snapshot() must not throw.
+    const db = await createNoydb({ store: memoryStore(), user: 'owner', secret: 'pw' })
+    const vault = await db.openVault('v')
+    // Declare nothing — the snapshot should still succeed
+    const snap = await snapshot(vault)
+    expect(snap).toBeDefined()
+    expect(snap.collections).toBeInstanceOf(Array)
+  })
+})

--- a/packages/in-devtools/src/snapshot.ts
+++ b/packages/in-devtools/src/snapshot.ts
@@ -8,15 +8,38 @@ export async function listVaults(noydb: InspectableContainer): Promise<ReadonlyA
 export async function snapshot(vault: Vault): Promise<InspectorSnapshot> {
   // withStats populates per-collection record/byte stats; opaque to the store.
   const dump = await vault.dumpSchema({ withStats: true })
-  // Omit `stats` when absent rather than setting it to `undefined` —
-  // the repo's tsconfig sets `exactOptionalPropertyTypes`, so an optional
-  // `stats?` field must be omitted, not explicitly undefined.
-  const collections: InspectorCollection[] = Object.entries(dump.collections).map(([name, desc]) => ({
-    name,
-    fields: desc.fields,
-    indexes: desc.indexes,
-    refs: desc.refs,
-    ...(desc.stats !== undefined ? { stats: desc.stats } : {}),
-  }))
-  return { vault: dump.vault, collections }
+  // Omit optional properties when absent rather than setting them to `undefined` —
+  // the repo's tsconfig sets `exactOptionalPropertyTypes`, so optional fields must
+  // be omitted, not explicitly set to undefined.
+  const collections: InspectorCollection[] = Object.entries(dump.collections).map(([name, desc]) => {
+    // Attempt to call describe() on the live collection to get rich field descriptors.
+    // Guard: a collection that was not live-declared on this Vault instance (e.g. from a
+    // prior open or a different process) may throw or return minimal output — skip
+    // `described` for it without failing the whole snapshot.
+    let described: InspectorCollection['described'] | undefined
+    try {
+      const coll = vault.collection(name)
+      const collDesc = coll.describe()
+      described = collDesc.fields
+    } catch {
+      // Not live-declared or no schema — skip described for this collection.
+    }
+
+    return {
+      name,
+      fields: desc.fields,
+      indexes: desc.indexes,
+      refs: desc.refs,
+      ...(desc.stats !== undefined ? { stats: desc.stats } : {}),
+      ...(desc.meta !== undefined ? { meta: desc.meta } : {}),
+      ...(desc.config !== undefined ? { config: desc.config } : {}),
+      ...(described !== undefined ? { described } : {}),
+    }
+  })
+
+  return {
+    vault: dump.vault,
+    collections,
+    ...(dump.meta !== undefined ? { meta: dump.meta } : {}),
+  }
 }

--- a/packages/in-devtools/src/types.ts
+++ b/packages/in-devtools/src/types.ts
@@ -8,6 +8,10 @@ import type {
   AccessibleVault,
   CollectionDescriptor,
   CollectionStats,
+  CollectionMeta,
+  VaultMeta,
+  CollectionConfig,
+  DescribedField,
 } from '@noy-db/hub'
 import type { MeterSnapshot } from '@noy-db/to-meter'
 
@@ -30,12 +34,20 @@ export interface InspectorCollection {
   readonly indexes: CollectionDescriptor['indexes']
   readonly refs: CollectionDescriptor['refs']
   readonly stats?: CollectionStats
+  /** Collection-level descriptive metadata (label/description/icon). */
+  readonly meta?: CollectionMeta
+  /** Per-field rich descriptors from collection.describe() (label/widget/money/dict/…). */
+  readonly described?: readonly DescribedField[]
+  /** Collection-level configuration (textIndexes/embeddings/crdt/provenance/…). */
+  readonly config?: CollectionConfig
 }
 
 /** Structure + stats for one open vault. */
 export interface InspectorSnapshot {
   readonly vault: string
   readonly collections: ReadonlyArray<InspectorCollection>
+  /** Vault-level descriptive metadata (label/description/icon). */
+  readonly meta?: VaultMeta
 }
 
 /** A page of decrypted records from one collection. */

--- a/packages/in-nuxt/__tests__/records-mask.test.ts
+++ b/packages/in-nuxt/__tests__/records-mask.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+import type {
+  Inspector,
+  VaultInfo,
+  InspectorSnapshot,
+  RecordPage,
+} from '@noy-db/in-devtools'
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function fakeInspector(snap: InspectorSnapshot, page: RecordPage) {
+  const inspector: Inspector = {
+    listVaults: async () => [{ id: 'testvault', role: 'owner' } as VaultInfo],
+    snapshot: async () => snap,
+    records: async () => page,
+    subscribe: () => () => {},
+    subscribeConflicts: () => () => {},
+    pendingWrites: () => ({ pending: false, depth: 0 }),
+    meterSnapshot: () => null,
+  }
+  return inspector
+}
+
+const fakeVault = { openVault: vi.fn() } as unknown as import('@noy-db/hub').Noydb
+
+vi.mock('@noy-db/in-pinia', () => ({
+  getActiveNoydb: vi.fn(),
+}))
+
+vi.mock('@noy-db/in-devtools', () => ({
+  createInspector: vi.fn(),
+}))
+
+import { getActiveNoydb } from '@noy-db/in-pinia'
+import { createInspector } from '@noy-db/in-devtools'
+import DevtoolsPanel from '../src/runtime/devtools/DevtoolsPanel.vue'
+
+beforeEach(() => {
+  vi.mocked(getActiveNoydb).mockReset()
+  vi.mocked(createInspector).mockReset()
+  vi.mocked(fakeVault.openVault).mockReset()
+})
+
+async function mountWithRecords(snap: InspectorSnapshot, page: RecordPage) {
+  vi.mocked(getActiveNoydb).mockReturnValue(fakeVault)
+  vi.mocked(createInspector).mockReturnValue(fakeInspector(snap, page))
+  vi.mocked(fakeVault.openVault).mockResolvedValue({} as never)
+  const wrapper = mount(DevtoolsPanel)
+  await flushPromises()
+  // Switch to Records tab
+  const tabs = wrapper.findAll('.noydb-detail-tab')
+  const recordsTab = tabs.find(t => t.text() === 'Records')
+  await recordsTab!.trigger('click')
+  await flushPromises()
+  return wrapper
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe('RecordsPane — PII masking', () => {
+  const snap: InspectorSnapshot = {
+    vault: 'testvault',
+    collections: [{
+      name: 'contacts',
+      fields: {
+        vat: { type: 'string' } as never,
+        total: { type: 'string' } as never,
+      },
+      indexes: [],
+      refs: [],
+      described: [
+        {
+          key: 'vat',
+          type: 'string',
+          optional: false,
+          label: 'VAT Number',
+          sensitivity: 'pii',
+          widget: 'text',
+          editable: true,
+        },
+        {
+          key: 'total',
+          type: 'string',
+          optional: false,
+          label: 'Total',
+          sensitivity: 'public',
+          widget: 'text',
+          editable: true,
+        },
+      ],
+    }],
+  }
+
+  const page: RecordPage = {
+    rows: [{ vat: 'IT123', total: '10.00' }],
+    total: 1,
+    limit: 20,
+    offset: 0,
+  }
+
+  it('masks pii values by default and shows public values', async () => {
+    const wrapper = await mountWithRecords(snap, page)
+    expect(wrapper.text()).toContain('••••••')      // vat masked
+    expect(wrapper.text()).toContain('10.00')        // public total shown
+    expect(wrapper.text()).not.toContain('IT123')    // pii hidden
+  })
+
+  it('reveals a masked field when its reveal control is clicked', async () => {
+    const wrapper = await mountWithRecords(snap, page)
+    expect(wrapper.text()).not.toContain('IT123')
+    await wrapper.find('[data-reveal="vat"]').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('IT123')
+  })
+
+  it('masks secret fields by default', async () => {
+    const secretSnap: InspectorSnapshot = {
+      vault: 'testvault',
+      collections: [{
+        name: 'keys',
+        fields: { apiKey: { type: 'string' } as never },
+        indexes: [],
+        refs: [],
+        described: [
+          {
+            key: 'apiKey',
+            type: 'string',
+            optional: false,
+            label: 'API Key',
+            sensitivity: 'secret',
+            widget: 'text',
+            editable: false,
+          },
+        ],
+      }],
+    }
+    const secretPage: RecordPage = {
+      rows: [{ apiKey: 'sk-supersecret' }],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    }
+    const wrapper = await mountWithRecords(secretSnap, secretPage)
+    expect(wrapper.text()).toContain('••••••')
+    expect(wrapper.text()).not.toContain('sk-supersecret')
+  })
+
+  it('reveals all fields when the "reveal all" toggle is clicked', async () => {
+    const wrapper = await mountWithRecords(snap, page)
+    expect(wrapper.text()).not.toContain('IT123')
+    await wrapper.find('[data-reveal-all]').trigger('click')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.text()).toContain('IT123')
+  })
+
+  it('masks nothing when described is absent (back-compat)', async () => {
+    const noDescSnap: InspectorSnapshot = {
+      vault: 'testvault',
+      collections: [{
+        name: 'invoices',
+        fields: {
+          id: { type: 'string' } as never,
+          amount: { type: 'string' } as never,
+        },
+        indexes: [],
+        refs: [],
+        // no described
+      }],
+    }
+    const noDescPage: RecordPage = {
+      rows: [{ id: 'inv001', amount: '9.99' }],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    }
+    const wrapper = await mountWithRecords(noDescSnap, noDescPage)
+    expect(wrapper.text()).toContain('inv001')
+    expect(wrapper.text()).toContain('9.99')
+    expect(wrapper.text()).not.toContain('••••••')
+  })
+
+  it('treats a field not in described as not-sensitive', async () => {
+    const partialDescSnap: InspectorSnapshot = {
+      vault: 'testvault',
+      collections: [{
+        name: 'mixed',
+        fields: {
+          name: { type: 'string' } as never,
+          extra: { type: 'string' } as never,
+        },
+        indexes: [],
+        refs: [],
+        described: [
+          {
+            key: 'name',
+            type: 'string',
+            optional: false,
+            label: 'Name',
+            sensitivity: 'pii',
+            widget: 'text',
+            editable: true,
+          },
+          // 'extra' not in described
+        ],
+      }],
+    }
+    const partialPage: RecordPage = {
+      rows: [{ name: 'Alice', extra: 'visible' }],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    }
+    const wrapper = await mountWithRecords(partialDescSnap, partialPage)
+    expect(wrapper.text()).toContain('••••••')
+    expect(wrapper.text()).not.toContain('Alice')
+    expect(wrapper.text()).toContain('visible') // extra not in described → shown
+  })
+})

--- a/packages/in-nuxt/__tests__/records-mask.test.ts
+++ b/packages/in-nuxt/__tests__/records-mask.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
+import { nextTick } from 'vue'
 
 import type {
   Inspector,
@@ -36,6 +37,7 @@ vi.mock('@noy-db/in-devtools', () => ({
 import { getActiveNoydb } from '@noy-db/in-pinia'
 import { createInspector } from '@noy-db/in-devtools'
 import DevtoolsPanel from '../src/runtime/devtools/DevtoolsPanel.vue'
+import RecordsPane from '../src/runtime/devtools/panes/RecordsPane.vue'
 
 beforeEach(() => {
   vi.mocked(getActiveNoydb).mockReset()
@@ -102,7 +104,7 @@ describe('RecordsPane — PII masking', () => {
 
   it('masks pii values by default and shows public values', async () => {
     const wrapper = await mountWithRecords(snap, page)
-    expect(wrapper.text()).toContain('••••••')      // vat masked
+    expect(wrapper.text()).toContain('••••')      // vat masked
     expect(wrapper.text()).toContain('10.00')        // public total shown
     expect(wrapper.text()).not.toContain('IT123')    // pii hidden
   })
@@ -143,7 +145,7 @@ describe('RecordsPane — PII masking', () => {
       offset: 0,
     }
     const wrapper = await mountWithRecords(secretSnap, secretPage)
-    expect(wrapper.text()).toContain('••••••')
+    expect(wrapper.text()).toContain('••••')
     expect(wrapper.text()).not.toContain('sk-supersecret')
   })
 
@@ -178,7 +180,7 @@ describe('RecordsPane — PII masking', () => {
     const wrapper = await mountWithRecords(noDescSnap, noDescPage)
     expect(wrapper.text()).toContain('inv001')
     expect(wrapper.text()).toContain('9.99')
-    expect(wrapper.text()).not.toContain('••••••')
+    expect(wrapper.text()).not.toContain('••••')
   })
 
   it('treats a field not in described as not-sensitive', async () => {
@@ -213,8 +215,77 @@ describe('RecordsPane — PII masking', () => {
       offset: 0,
     }
     const wrapper = await mountWithRecords(partialDescSnap, partialPage)
-    expect(wrapper.text()).toContain('••••••')
+    expect(wrapper.text()).toContain('••••')
     expect(wrapper.text()).not.toContain('Alice')
     expect(wrapper.text()).toContain('visible') // extra not in described → shown
+  })
+})
+
+// ── Collection-change reveal reset ─────────────────────────────────────────
+
+describe('RecordsPane — collection-change reveal reset', () => {
+  const collectionA = {
+    name: 'collA',
+    fields: { secret: { type: 'string' } as never },
+    indexes: [],
+    refs: [],
+    described: [
+      {
+        key: 'secret',
+        type: 'string',
+        optional: false,
+        label: 'Secret',
+        sensitivity: 'pii' as const,
+        widget: 'text',
+        editable: true,
+      },
+    ],
+  }
+
+  const collectionB = {
+    name: 'collB',
+    fields: { secret: { type: 'string' } as never },
+    indexes: [],
+    refs: [],
+    described: [
+      {
+        key: 'secret',
+        type: 'string',
+        optional: false,
+        label: 'Secret',
+        sensitivity: 'pii' as const,
+        widget: 'text',
+        editable: true,
+      },
+    ],
+  }
+
+  const page: RecordPage = {
+    rows: [{ secret: 'SENSITIVE' }],
+    total: 1,
+    limit: 20,
+    offset: 0,
+  }
+
+  it('resets revealed state when the collection prop changes', async () => {
+    const wrapper = mount(RecordsPane, {
+      props: { collection: collectionA, page, error: undefined },
+    })
+    await flushPromises()
+
+    // Field starts masked
+    expect(wrapper.text()).toContain('••••')
+    expect(wrapper.text()).not.toContain('SENSITIVE')
+
+    // Reveal the field
+    await wrapper.find('[data-reveal="secret"]').trigger('click')
+    await nextTick()
+    expect(wrapper.text()).toContain('SENSITIVE')
+
+    // Switch to a different collection — reveal state must reset
+    await wrapper.setProps({ collection: collectionB })
+    await nextTick()
+    expect(wrapper.text()).toContain('••••')
+    expect(wrapper.text()).not.toContain('SENSITIVE')
   })
 })

--- a/packages/in-nuxt/__tests__/schema-pane.test.ts
+++ b/packages/in-nuxt/__tests__/schema-pane.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+
+import type {
+  Inspector,
+  InspectorWriteEvent,
+  InspectorWriteConflict,
+  VaultInfo,
+  InspectorSnapshot,
+  RecordPage,
+} from '@noy-db/in-devtools'
+
+// ── Helper: a minimal fakeInspector (same pattern as devtools-panel.test.ts) ──
+function fakeInspector(snap: InspectorSnapshot) {
+  const inspector: Inspector = {
+    listVaults: async () => [{ id: 'testvault', role: 'owner' } as VaultInfo],
+    snapshot: async () => snap,
+    records: async () => ({ rows: [], total: 0, limit: 20, offset: 0 } as RecordPage),
+    subscribe: () => () => {},
+    subscribeConflicts: () => () => {},
+    pendingWrites: () => ({ pending: false, depth: 0 }),
+    meterSnapshot: () => null,
+  }
+  return inspector
+}
+
+const fakeVault = { openVault: vi.fn() } as unknown as import('@noy-db/hub').Noydb
+
+vi.mock('@noy-db/in-pinia', () => ({
+  getActiveNoydb: vi.fn(),
+}))
+
+vi.mock('@noy-db/in-devtools', () => ({
+  createInspector: vi.fn(),
+}))
+
+import { getActiveNoydb } from '@noy-db/in-pinia'
+import { createInspector } from '@noy-db/in-devtools'
+import DevtoolsPanel from '../src/runtime/devtools/DevtoolsPanel.vue'
+
+beforeEach(() => {
+  vi.mocked(getActiveNoydb).mockReset()
+  vi.mocked(createInspector).mockReset()
+  vi.mocked(fakeVault.openVault).mockReset()
+})
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function mountWithSnap(snap: InspectorSnapshot) {
+  vi.mocked(getActiveNoydb).mockReturnValue(fakeVault)
+  vi.mocked(createInspector).mockReturnValue(fakeInspector(snap))
+  vi.mocked(fakeVault.openVault).mockResolvedValue({} as never)
+  const wrapper = mount(DevtoolsPanel)
+  await flushPromises()
+  return wrapper
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('SchemaPane — meta header', () => {
+  it('shows collection meta label when present', async () => {
+    const snap: InspectorSnapshot = {
+      vault: 'testvault',
+      collections: [{
+        name: 'invoices',
+        fields: { id: { type: 'string' } as never },
+        indexes: [],
+        refs: [],
+        meta: { label: 'Invoice', description: 'All invoices' },
+      }],
+    }
+    const wrapper = await mountWithSnap(snap)
+    expect(wrapper.text()).toContain('Invoice')
+    expect(wrapper.text()).toContain('All invoices')
+  })
+
+  it('falls back to collection name when meta.label is absent', async () => {
+    const snap: InspectorSnapshot = {
+      vault: 'testvault',
+      collections: [{
+        name: 'orders',
+        fields: { id: { type: 'string' } as never },
+        indexes: [],
+        refs: [],
+      }],
+    }
+    const wrapper = await mountWithSnap(snap)
+    expect(wrapper.text()).toContain('orders')
+  })
+})
+
+describe('SchemaPane — sensitivity badges', () => {
+  it('renders a pii badge for a field with sensitivity=pii', async () => {
+    const snap: InspectorSnapshot = {
+      vault: 'testvault',
+      collections: [{
+        name: 'contacts',
+        fields: { email: { type: 'string' } as never },
+        indexes: [],
+        refs: [],
+        described: [
+          {
+            key: 'email',
+            type: 'string',
+            optional: false,
+            label: 'Email',
+            sensitivity: 'pii',
+            widget: 'email',
+            editable: true,
+          },
+        ],
+      }],
+    }
+    const wrapper = await mountWithSnap(snap)
+    expect(wrapper.text()).toContain('pii')
+    expect(wrapper.find('.noydb-schema__badge--pii').exists()).toBe(true)
+  })
+
+  it('renders a secret badge for a field with sensitivity=secret', async () => {
+    const snap: InspectorSnapshot = {
+      vault: 'testvault',
+      collections: [{
+        name: 'keys',
+        fields: { apiKey: { type: 'string' } as never },
+        indexes: [],
+        refs: [],
+        described: [
+          {
+            key: 'apiKey',
+            type: 'string',
+            optional: false,
+            label: 'API Key',
+            sensitivity: 'secret',
+            widget: 'text',
+            editable: false,
+          },
+        ],
+      }],
+    }
+    const wrapper = await mountWithSnap(snap)
+    expect(wrapper.text()).toContain('secret')
+    expect(wrapper.find('.noydb-schema__badge--secret').exists()).toBe(true)
+  })
+})
+
+describe('SchemaPane — i18n badge', () => {
+  it('renders an i18n badge for a field with i18n present', async () => {
+    const snap: InspectorSnapshot = {
+      vault: 'testvault',
+      collections: [{
+        name: 'products',
+        fields: { name: { type: 'string' } as never },
+        indexes: [],
+        refs: [],
+        described: [
+          {
+            key: 'name',
+            type: 'string',
+            optional: false,
+            label: 'Name',
+            i18n: { locales: ['en', 'th'] },
+            widget: 'text',
+            editable: true,
+          },
+        ],
+      }],
+    }
+    const wrapper = await mountWithSnap(snap)
+    expect(wrapper.text()).toContain('i18n')
+    expect(wrapper.find('.noydb-schema__badge--i18n').exists()).toBe(true)
+  })
+})
+
+describe('SchemaPane — config strip badges', () => {
+  it('renders textIndexes badge when config.textIndexes is set', async () => {
+    const snap: InspectorSnapshot = {
+      vault: 'testvault',
+      collections: [{
+        name: 'articles',
+        fields: { title: { type: 'string' } as never },
+        indexes: [],
+        refs: [],
+        config: { textIndexes: ['title', 'body'] },
+      }],
+    }
+    const wrapper = await mountWithSnap(snap)
+    expect(wrapper.find('.noydb-schema__config-strip').exists()).toBe(true)
+    expect(wrapper.text()).toContain('text-index')
+  })
+
+  it('renders embeddings badge when config.embeddings is set', async () => {
+    const snap: InspectorSnapshot = {
+      vault: 'testvault',
+      collections: [{
+        name: 'docs',
+        fields: { content: { type: 'string' } as never },
+        indexes: [],
+        refs: [],
+        config: { embeddings: { source: 'content', dim: 1536 } },
+      }],
+    }
+    const wrapper = await mountWithSnap(snap)
+    expect(wrapper.text()).toContain('embeddings')
+  })
+
+  it('renders crdt badge when config.crdt is set', async () => {
+    const snap: InspectorSnapshot = {
+      vault: 'testvault',
+      collections: [{
+        name: 'notes',
+        fields: { body: { type: 'string' } as never },
+        indexes: [],
+        refs: [],
+        config: { crdt: 'lww' },
+      }],
+    }
+    const wrapper = await mountWithSnap(snap)
+    expect(wrapper.text()).toContain('crdt:lww')
+  })
+
+  it('renders no config strip when collection.config is absent', async () => {
+    const snap: InspectorSnapshot = {
+      vault: 'testvault',
+      collections: [{
+        name: 'simple',
+        fields: { id: { type: 'string' } as never },
+        indexes: [],
+        refs: [],
+      }],
+    }
+    const wrapper = await mountWithSnap(snap)
+    expect(wrapper.find('.noydb-schema__config-strip').exists()).toBe(false)
+  })
+})
+
+describe('SchemaPane — described fields', () => {
+  it('shows field label from described, not raw key, when described is present', async () => {
+    const snap: InspectorSnapshot = {
+      vault: 'testvault',
+      collections: [{
+        name: 'invoices',
+        fields: { amount: { type: 'number' } as never },
+        indexes: [],
+        refs: [],
+        described: [
+          {
+            key: 'amount',
+            type: 'number',
+            optional: false,
+            label: 'Invoice Amount',
+            money: { mode: 'fixed', currency: 'THB' },
+            widget: 'money',
+            editable: true,
+          },
+        ],
+      }],
+    }
+    const wrapper = await mountWithSnap(snap)
+    expect(wrapper.text()).toContain('Invoice Amount')
+    expect(wrapper.text()).toContain('THB')
+  })
+
+  it('renders read-only badge for editable:false fields', async () => {
+    const snap: InspectorSnapshot = {
+      vault: 'testvault',
+      collections: [{
+        name: 'invoices',
+        fields: { id: { type: 'string' } as never },
+        indexes: [],
+        refs: [],
+        described: [
+          {
+            key: 'id',
+            type: 'string',
+            optional: false,
+            label: 'ID',
+            widget: 'text',
+            editable: false,
+          },
+        ],
+      }],
+    }
+    const wrapper = await mountWithSnap(snap)
+    expect(wrapper.find('.noydb-schema__badge--readonly').exists()).toBe(true)
+    expect(wrapper.text()).toContain('read-only')
+  })
+
+  it('falls back to raw fields when described is absent', async () => {
+    const snap: InspectorSnapshot = {
+      vault: 'testvault',
+      collections: [{
+        name: 'invoices',
+        fields: { id: { type: 'string' } as never, amount: { type: 'number' } as never },
+        indexes: [],
+        refs: [],
+      }],
+    }
+    const wrapper = await mountWithSnap(snap)
+    // raw keys appear in the fallback rows
+    expect(wrapper.text()).toContain('id')
+    expect(wrapper.text()).toContain('amount')
+  })
+})
+
+describe('VaultSidebar — vault meta label', () => {
+  it('shows vault meta label when snapshot.meta.label is set', async () => {
+    const snap: InspectorSnapshot = {
+      vault: 'testvault',
+      collections: [{
+        name: 'orders',
+        fields: { id: { type: 'string' } as never },
+        indexes: [],
+        refs: [],
+      }],
+      meta: { label: 'Acme DB', description: 'The Acme production vault' },
+    }
+    const wrapper = await mountWithSnap(snap)
+    expect(wrapper.text()).toContain('Acme DB')
+  })
+
+  it('falls back to vault id when snapshot.meta is absent', async () => {
+    const snap: InspectorSnapshot = {
+      vault: 'testvault',
+      collections: [{
+        name: 'orders',
+        fields: { id: { type: 'string' } as never },
+        indexes: [],
+        refs: [],
+      }],
+    }
+    const wrapper = await mountWithSnap(snap)
+    expect(wrapper.text()).toContain('testvault')
+  })
+})

--- a/packages/in-nuxt/src/runtime/devtools/DevtoolsPanel.vue
+++ b/packages/in-nuxt/src/runtime/devtools/DevtoolsPanel.vue
@@ -36,6 +36,7 @@
       <div v-if="topTab === 'structure'" class="noydb-panel__body">
         <VaultSidebar
           :vault-name="vaultInfo!.id"
+          :vault-meta="snapshotMeta"
           :collections="collections"
           :selected-name="selectedCollection?.name ?? null"
           @select="selectCollection"
@@ -78,7 +79,7 @@ import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { getActiveNoydb } from '@noy-db/in-pinia'
 import { createInspector } from '@noy-db/in-devtools'
 import type { Inspector, InspectorCollection, VaultInfo, RecordPage } from '@noy-db/in-devtools'
-import type { Vault } from '@noy-db/hub'
+import type { Vault, VaultMeta } from '@noy-db/hub'
 import type { MeterSnapshot } from '@noy-db/to-meter'
 import VaultSidebar from './panes/VaultSidebar.vue'
 import SchemaPane from './panes/SchemaPane.vue'
@@ -101,6 +102,7 @@ const vaults = ref<ReadonlyArray<VaultInfo>>([])
 const vaultInfo = computed(() => vaults.value[0] ?? null)
 const openVault = ref<Vault | null>(null)
 const collections = ref<ReadonlyArray<InspectorCollection>>([])
+const snapshotMeta = ref<VaultMeta | null>(null)
 const snapshotError = ref<string | undefined>(undefined)
 const selectedCollection = ref<InspectorCollection | null>(null)
 
@@ -148,6 +150,7 @@ async function loadSnapshot() {
   try {
     const snap = await inspector.value.snapshot(openVault.value)
     collections.value = snap.collections
+    snapshotMeta.value = snap.meta ?? null
     selectedCollection.value = snap.collections[0] ?? null
     snapshotError.value = undefined
   } catch (e) {

--- a/packages/in-nuxt/src/runtime/devtools/panes/RecordsPane.vue
+++ b/packages/in-nuxt/src/runtime/devtools/panes/RecordsPane.vue
@@ -32,7 +32,7 @@
             class="noydb-records__mask"
             :data-reveal="f"
             @click="reveal(f)"
-          >••••••</button>
+          >••••</button>
         </span>
       </div>
     </template>
@@ -40,7 +40,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import type { InspectorCollection, RecordPage } from '@noy-db/in-devtools'
 
 const props = defineProps<{
@@ -78,6 +78,10 @@ const revealed = ref(new Set<string>())
 
 /** When true, all sensitive fields are shown. */
 const revealAll = ref(false)
+
+// Reset reveal state when the viewed collection changes (prevent PII from one
+// collection lingering when the user navigates to another).
+watch(() => props.collection, () => { revealed.value = new Set(); revealAll.value = false })
 
 function isVisible(field: string): boolean {
   if (!sensitiveFields.value.has(field)) return true

--- a/packages/in-nuxt/src/runtime/devtools/panes/RecordsPane.vue
+++ b/packages/in-nuxt/src/runtime/devtools/panes/RecordsPane.vue
@@ -12,6 +12,12 @@
         <button :disabled="!canPrev" @click="$emit('prev')">◀ prev</button>
         <button :disabled="!canNext" @click="$emit('next')">next ▶</button>
       </div>
+      <button
+        v-if="hasSensitiveFields"
+        class="noydb-records__reveal-all"
+        data-reveal-all
+        @click="revealAll = !revealAll"
+      >{{ revealAll ? 'hide all' : 'reveal all' }}</button>
     </div>
     <template v-if="page && fields.length > 0">
       <div class="noydb-records__cols">
@@ -19,14 +25,22 @@
       </div>
       <div v-if="page.rows.length === 0" class="noydb-records__empty">No records</div>
       <div v-for="(row, i) in page.rows" :key="i" class="noydb-records__row">
-        <span v-for="f in fields" :key="f">{{ cell(row, f) }}</span>
+        <span v-for="f in fields" :key="f">
+          <template v-if="isVisible(f)">{{ cell(row, f) }}</template>
+          <button
+            v-else
+            class="noydb-records__mask"
+            :data-reveal="f"
+            @click="reveal(f)"
+          >••••••</button>
+        </span>
       </div>
     </template>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import type { InspectorCollection, RecordPage } from '@noy-db/in-devtools'
 
 const props = defineProps<{
@@ -41,6 +55,39 @@ const fields = computed(() => Object.keys(props.collection.fields))
 
 const canPrev = computed(() => !!props.page && props.page.offset > 0)
 const canNext = computed(() => !!props.page && props.page.offset + props.page.limit < props.page.total)
+
+// ── PII masking ────────────────────────────────────────────────────────────
+
+/** Set of field keys that are sensitive (pii or secret) per collection.described. */
+const sensitiveFields = computed((): Set<string> => {
+  const described = props.collection.described
+  if (!described) return new Set()
+  const s = new Set<string>()
+  for (const d of described) {
+    if (d.sensitivity !== undefined && d.sensitivity !== 'public') {
+      s.add(d.key)
+    }
+  }
+  return s
+})
+
+const hasSensitiveFields = computed(() => sensitiveFields.value.size > 0)
+
+/** Tracks which individual fields the user has revealed. */
+const revealed = ref(new Set<string>())
+
+/** When true, all sensitive fields are shown. */
+const revealAll = ref(false)
+
+function isVisible(field: string): boolean {
+  if (!sensitiveFields.value.has(field)) return true
+  if (revealAll.value) return true
+  return revealed.value.has(field)
+}
+
+function reveal(field: string): void {
+  revealed.value = new Set([...revealed.value, field])
+}
 
 function cell(row: unknown, field: string): string {
   if (row === null || row === undefined || typeof row !== 'object') return '·'

--- a/packages/in-nuxt/src/runtime/devtools/panes/SchemaPane.vue
+++ b/packages/in-nuxt/src/runtime/devtools/panes/SchemaPane.vue
@@ -1,16 +1,70 @@
 <template>
   <div class="noydb-schema">
     <template v-if="collection">
-      <div class="noydb-schema__label">Fields</div>
-      <div
-        v-for="[name, field] in fieldEntries"
-        :key="name"
-        class="noydb-schema__row"
-      >
-        <span class="noydb-schema__name">{{ name }}</span>
-        <span class="noydb-schema__type">{{ (field as { type?: string }).type ?? '—' }}</span>
-        <span class="noydb-schema__flag">{{ isIndexed(name) ? 'idx' : '' }}</span>
+      <!-- Collection meta header -->
+      <div class="noydb-schema__meta-header">
+        <span class="noydb-schema__meta-label">{{ collectionLabel }}</span>
+        <span
+          v-if="collection.meta?.description"
+          class="noydb-schema__meta-desc"
+          :title="collection.meta.description"
+        >{{ collection.meta.description }}</span>
       </div>
+
+      <!-- Config strip (badges for active config options) -->
+      <div v-if="configBadges.length" class="noydb-schema__config-strip">
+        <span
+          v-for="badge in configBadges"
+          :key="badge"
+          class="noydb-schema__config-badge"
+        >{{ badge }}</span>
+      </div>
+
+      <div class="noydb-schema__label noydb-schema__label--mt">Fields</div>
+
+      <!-- Rich rows from described (when present) -->
+      <template v-if="collection.described && collection.described.length">
+        <div
+          v-for="field in collection.described"
+          :key="field.key"
+          class="noydb-schema__row"
+        >
+          <span class="noydb-schema__name">{{ field.label }}</span>
+          <span class="noydb-schema__name noydb-schema__name--key" :title="field.key">{{ field.key }}</span>
+          <span class="noydb-schema__type">{{ field.type }}</span>
+          <span v-if="field.semanticType || field.widget" class="noydb-schema__badge noydb-schema__badge--semantic">
+            {{ field.semanticType ?? field.widget }}
+          </span>
+          <span v-if="field.money?.currency" class="noydb-schema__badge noydb-schema__badge--money">
+            {{ field.money.currency }}
+          </span>
+          <span v-if="field.dict" class="noydb-schema__badge noydb-schema__badge--dict">
+            dict{{ field.dict.values ? ` ×${field.dict.values.length}` : '' }}
+          </span>
+          <span v-if="field.sensitivity === 'pii'" class="noydb-schema__badge noydb-schema__badge--pii">pii</span>
+          <span v-if="field.sensitivity === 'secret'" class="noydb-schema__badge noydb-schema__badge--secret">secret</span>
+          <span v-if="field.i18n" class="noydb-schema__badge noydb-schema__badge--i18n">i18n</span>
+          <span v-if="field.ref" class="noydb-schema__badge noydb-schema__badge--ref" :title="`→ ${field.ref.target}`">
+            → {{ field.ref.target }}
+          </span>
+          <span v-if="!field.editable" class="noydb-schema__badge noydb-schema__badge--readonly">read-only</span>
+          <span class="noydb-schema__flag">{{ isIndexed(field.key) ? 'idx' : '' }}</span>
+        </div>
+      </template>
+
+      <!-- Fallback rows from fields (back-compat) -->
+      <template v-else>
+        <div
+          v-for="[name, field] in fieldEntries"
+          :key="name"
+          class="noydb-schema__row"
+        >
+          <span class="noydb-schema__name">{{ name }}</span>
+          <span class="noydb-schema__type">{{ (field as { type?: string }).type ?? '—' }}</span>
+          <span class="noydb-schema__flag">{{ isIndexed(name) ? 'idx' : '' }}</span>
+        </div>
+      </template>
+
       <div class="noydb-schema__label noydb-schema__label--mt">Stats</div>
       <div class="noydb-schema__stat">
         docs <strong>{{ collection.stats?.count ?? '—' }}</strong>
@@ -28,9 +82,30 @@ import type { InspectorCollection } from '@noy-db/in-devtools'
 
 const props = defineProps<{ collection: InspectorCollection | null }>()
 
+const collectionLabel = computed(() =>
+  props.collection?.meta?.label ?? props.collection?.name ?? ''
+)
+
 const fieldEntries = computed(() =>
   props.collection ? Object.entries(props.collection.fields) : []
 )
+
+/** Build small text badges for whichever config options are active. */
+const configBadges = computed((): string[] => {
+  const cfg = props.collection?.config
+  if (!cfg) return []
+  const badges: string[] = []
+  if (cfg.embeddings) badges.push('embeddings')
+  if (cfg.textIndexes && cfg.textIndexes.length) badges.push('text-index')
+  if (cfg.crdt) badges.push(`crdt:${cfg.crdt}`)
+  if (cfg.provenance) badges.push('provenance')
+  if (cfg.archive) badges.push('archive')
+  if (cfg.tiers && cfg.tiers.length) badges.push(`tiers:${cfg.tiers.length}`)
+  if (cfg.perRecordKeys) badges.push('per-record-keys')
+  if (cfg.history) badges.push('history')
+  if (cfg.schemaUpdate && cfg.schemaUpdate.length) badges.push('schema-update')
+  return badges
+})
 
 function isIndexed(name: string): boolean {
   return props.collection?.indexes?.some((idx) => {

--- a/packages/in-nuxt/src/runtime/devtools/panes/VaultSidebar.vue
+++ b/packages/in-nuxt/src/runtime/devtools/panes/VaultSidebar.vue
@@ -2,14 +2,17 @@
   <aside class="noydb-sidebar">
     <div class="noydb-sidebar__header">Vault</div>
     <template v-if="vaultName">
-      <div class="noydb-sidebar__vault">▸ {{ vaultName }}</div>
+      <div
+        class="noydb-sidebar__vault"
+        :title="vaultMeta?.description ?? vaultName ?? undefined"
+      >▸ {{ vaultMeta?.label ?? vaultName }}</div>
       <button
         v-for="coll in collections"
         :key="coll.name"
         :class="['noydb-sidebar__item', { 'noydb-sidebar__item--selected': coll.name === selectedName }]"
         @click="$emit('select', coll)"
       >
-        <span>{{ coll.name }}</span>
+        <span>{{ coll.meta?.label ?? coll.name }}</span>
         <span v-if="coll.stats?.count" class="noydb-sidebar__badge">{{ coll.stats.count }}</span>
       </button>
     </template>
@@ -19,9 +22,11 @@
 
 <script setup lang="ts">
 import type { InspectorCollection } from '@noy-db/in-devtools'
+import type { VaultMeta } from '@noy-db/hub'
 
 defineProps<{
   vaultName: string | null
+  vaultMeta?: VaultMeta | null
   collections: ReadonlyArray<InspectorCollection>
   selectedName: string | null
 }>()

--- a/packages/in-nuxt/vitest.config.ts
+++ b/packages/in-nuxt/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     environment: 'node',
     environmentMatchGlobs: [
       ['__tests__/devtools*.test.ts', 'happy-dom'],
+      ['__tests__/schema-pane.test.ts', 'happy-dom'],
     ],
     include: ['__tests__/**/*.test.ts'],
   },

--- a/packages/in-nuxt/vitest.config.ts
+++ b/packages/in-nuxt/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     environmentMatchGlobs: [
       ['__tests__/devtools*.test.ts', 'happy-dom'],
       ['__tests__/schema-pane.test.ts', 'happy-dom'],
+      ['__tests__/records-mask.test.ts', 'happy-dom'],
     ],
     include: ['__tests__/**/*.test.ts'],
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,11 +292,11 @@ importers:
         specifier: ^2.9.0
         version: 2.9.0
       zod:
-        specifier: ^3.23.0
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.4.3
       zod-to-json-schema:
         specifier: ^3.25.2
-        version: 3.25.2(zod@3.25.76)
+        version: 3.25.2(zod@4.4.3)
 
   packages/create-noy-db:
     dependencies:
@@ -345,11 +345,11 @@ importers:
         specifier: ^0.25.0
         version: 0.25.12
       zod:
-        specifier: ^3.23.0
-        version: 3.25.76
+        specifier: ^4.0.0
+        version: 4.4.3
       zod-to-json-schema:
         specifier: ^3.25.2
-        version: 3.25.2(zod@3.25.76)
+        version: 3.25.2(zod@4.4.3)
 
   packages/in-ai:
     devDependencies:
@@ -7037,7 +7037,6 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   light-my-request@6.6.0:
@@ -19137,9 +19136,9 @@ snapshots:
       compress-commons: 6.0.2
       readable-stream: 4.7.0
 
-  zod-to-json-schema@3.25.2(zod@3.25.76):
+  zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.3
 
   zod@3.22.3: {}
 

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -503,7 +503,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 5399→5401 (#483 Task 3): i18nFields passed into both buildDescription call-sites
   // Bumped 5401→5457 (#483 Task 4): CollectionConfig import + getConfig() aggregator (reads existing private fields, no new state)
   // Bumped 5457→5473 (#483 review follow-up): historyConfigExplicit private field + opts flag for presence-semantic history in getConfig()
-  'packages/hub/src/collection.ts': 5473,
+  // Bumped 5473→5486 (#484 Task 2): toJSONSchema() thin delegator + buildJsonSchema/derivePersistedSchema imports (logic lives in json-schema.ts)
+  'packages/hub/src/collection.ts': 5486,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -498,7 +498,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 5285→5293 (#483 Task 1): fieldMeta private field + getFieldMeta() getter + FieldMeta type import
   // Bumped 5293→5332 (#483 Task 3): describe() sync method + _refs private field + buildDescription import + declaredRefs opt
   // Bumped 5332→5374 (#483 Task 4): describeAsync() private method (derive zodFields + resolveDictLabels + delegate to buildDescription)
-  'packages/hub/src/collection.ts': 5374,
+  // Bumped 5374→5379 (#483 fix-wave): _applyFieldMeta() — first-wins reconciler mirroring _applyMoneyFields, needed for MV-pre-created collection re-declaration path
+  'packages/hub/src/collection.ts': 5379,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -497,7 +497,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 5278→5285 (#308 L3 Task 4): applyWithin() private method + within dispatch in retrieve()
   // Bumped 5285→5293 (#483 Task 1): fieldMeta private field + getFieldMeta() getter + FieldMeta type import
   // Bumped 5293→5332 (#483 Task 3): describe() sync method + _refs private field + buildDescription import + declaredRefs opt
-  'packages/hub/src/collection.ts': 5332,
+  // Bumped 5332→5374 (#483 Task 4): describeAsync() private method (derive zodFields + resolveDictLabels + delegate to buildDescription)
+  'packages/hub/src/collection.ts': 5374,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -499,7 +499,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 5293→5332 (#483 Task 3): describe() sync method + _refs private field + buildDescription import + declaredRefs opt
   // Bumped 5332→5374 (#483 Task 4): describeAsync() private method (derive zodFields + resolveDictLabels + delegate to buildDescription)
   // Bumped 5374→5379 (#483 fix-wave): _applyFieldMeta() — first-wins reconciler mirroring _applyMoneyFields, needed for MV-pre-created collection re-declaration path
-  'packages/hub/src/collection.ts': 5379,
+  // Bumped 5379→5399 (#483 Task 1): CollectionMeta import + private meta field + getMeta() getter + _applyMeta() reconciler + meta threading into both describe() calls
+  'packages/hub/src/collection.ts': 5399,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -573,7 +574,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 4597→4610 (#308 L2): embeddings derive/retrieve/forget call-sites (engine in src/embeddings/)
   // Bumped 4610→4617 (#483 Task 1): fieldMeta option in CollectionOptions + FieldMeta import + validation call-site
   // Bumped 4617→4621 (#483 Task 3): declaredRefs wiring (snapshot of outbound refs for describe())
-  'packages/hub/src/vault.ts': 4621,
+  // Bumped 4621→4633 (#483 Task 1): meta option in CollectionOptions + _applyMeta reconcile in cached-collection branch + meta threading into new Collection() opts
+  'packages/hub/src/vault.ts': 4633,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -575,7 +575,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 4610→4617 (#483 Task 1): fieldMeta option in CollectionOptions + FieldMeta import + validation call-site
   // Bumped 4617→4621 (#483 Task 3): declaredRefs wiring (snapshot of outbound refs for describe())
   // Bumped 4621→4633 (#483 Task 1): meta option in CollectionOptions + _applyMeta reconcile in cached-collection branch + meta threading into new Collection() opts
-  'packages/hub/src/vault.ts': 4633,
+  // Bumped 4633→4650 (#483 Task 2): vaultMeta field + getMeta() getter + constructor opts + _introspectState() wiring
+  'packages/hub/src/vault.ts': 4650,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -500,7 +500,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 5332→5374 (#483 Task 4): describeAsync() private method (derive zodFields + resolveDictLabels + delegate to buildDescription)
   // Bumped 5374→5379 (#483 fix-wave): _applyFieldMeta() — first-wins reconciler mirroring _applyMoneyFields, needed for MV-pre-created collection re-declaration path
   // Bumped 5379→5399 (#483 Task 1): CollectionMeta import + private meta field + getMeta() getter + _applyMeta() reconciler + meta threading into both describe() calls
-  'packages/hub/src/collection.ts': 5399,
+  // Bumped 5399→5401 (#483 Task 3): i18nFields passed into both buildDescription call-sites
+  'packages/hub/src/collection.ts': 5401,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -495,7 +495,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 5168→5255 (#308 L2): embeddings derive/retrieve/forget call-sites (engine in src/embeddings/)
   // Bumped 5255→5278 (#308 L3): retrieveLexical/retrieveHybrid private methods + thin retrieve() dispatcher
   // Bumped 5278→5285 (#308 L3 Task 4): applyWithin() private method + within dispatch in retrieve()
-  'packages/hub/src/collection.ts': 5285,
+  // Bumped 5285→5293 (#483 Task 1): fieldMeta private field + getFieldMeta() getter + FieldMeta type import
+  'packages/hub/src/collection.ts': 5293,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -567,7 +568,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 4546→4571 (#308 L1): getDictionary label-resolver injection + warmIndexOnOpen wiring (engine in src/search/)
   // Bumped 4571→4597 (#308 L1.5): persisted-index call-sites + forget/close wiring
   // Bumped 4597→4610 (#308 L2): embeddings derive/retrieve/forget call-sites (engine in src/embeddings/)
-  'packages/hub/src/vault.ts': 4610,
+  // Bumped 4610→4617 (#483 Task 1): fieldMeta option in CollectionOptions + FieldMeta import + validation call-site
+  'packages/hub/src/vault.ts': 4617,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -496,7 +496,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 5255→5278 (#308 L3): retrieveLexical/retrieveHybrid private methods + thin retrieve() dispatcher
   // Bumped 5278→5285 (#308 L3 Task 4): applyWithin() private method + within dispatch in retrieve()
   // Bumped 5285→5293 (#483 Task 1): fieldMeta private field + getFieldMeta() getter + FieldMeta type import
-  'packages/hub/src/collection.ts': 5293,
+  // Bumped 5293→5332 (#483 Task 3): describe() sync method + _refs private field + buildDescription import + declaredRefs opt
+  'packages/hub/src/collection.ts': 5332,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -569,7 +570,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 4571→4597 (#308 L1.5): persisted-index call-sites + forget/close wiring
   // Bumped 4597→4610 (#308 L2): embeddings derive/retrieve/forget call-sites (engine in src/embeddings/)
   // Bumped 4610→4617 (#483 Task 1): fieldMeta option in CollectionOptions + FieldMeta import + validation call-site
-  'packages/hub/src/vault.ts': 4617,
+  // Bumped 4617→4621 (#483 Task 3): declaredRefs wiring (snapshot of outbound refs for describe())
+  'packages/hub/src/vault.ts': 4621,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -501,7 +501,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 5374→5379 (#483 fix-wave): _applyFieldMeta() — first-wins reconciler mirroring _applyMoneyFields, needed for MV-pre-created collection re-declaration path
   // Bumped 5379→5399 (#483 Task 1): CollectionMeta import + private meta field + getMeta() getter + _applyMeta() reconciler + meta threading into both describe() calls
   // Bumped 5399→5401 (#483 Task 3): i18nFields passed into both buildDescription call-sites
-  'packages/hub/src/collection.ts': 5401,
+  // Bumped 5401→5457 (#483 Task 4): CollectionConfig import + getConfig() aggregator (reads existing private fields, no new state)
+  'packages/hub/src/collection.ts': 5457,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -502,7 +502,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 5379→5399 (#483 Task 1): CollectionMeta import + private meta field + getMeta() getter + _applyMeta() reconciler + meta threading into both describe() calls
   // Bumped 5399→5401 (#483 Task 3): i18nFields passed into both buildDescription call-sites
   // Bumped 5401→5457 (#483 Task 4): CollectionConfig import + getConfig() aggregator (reads existing private fields, no new state)
-  'packages/hub/src/collection.ts': 5457,
+  // Bumped 5457→5473 (#483 review follow-up): historyConfigExplicit private field + opts flag for presence-semantic history in getConfig()
+  'packages/hub/src/collection.ts': 5473,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -578,7 +579,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 4617→4621 (#483 Task 3): declaredRefs wiring (snapshot of outbound refs for describe())
   // Bumped 4621→4633 (#483 Task 1): meta option in CollectionOptions + _applyMeta reconcile in cached-collection branch + meta threading into new Collection() opts
   // Bumped 4633→4650 (#483 Task 2): vaultMeta field + getMeta() getter + constructor opts + _introspectState() wiring
-  'packages/hub/src/vault.ts': 4650,
+  // Bumped 4650→4659 (#483 review follow-up): historyConfigExplicit threading + archive/schemaUpdate accessors in _introspectState()
+  'packages/hub/src/vault.ts': 4659,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),

--- a/showcases/src/126-describe-field-metadata.showcase.test.ts
+++ b/showcases/src/126-describe-field-metadata.showcase.test.ts
@@ -335,12 +335,12 @@ describe('Showcase 126-C — merge precedence: channel > inferred-from-config', 
     })
     const vault = await db.openVault('firm')
 
-    interface Record extends globalThis.Record<string, unknown> {
+    interface OrderRecord extends globalThis.Record<string, unknown> {
       id: string
       status: string
     }
 
-    const coll = vault.collection<Record>('orders', {
+    const coll = vault.collection<OrderRecord>('orders', {
       dictKeyFields: {
         status: staticDict('orderStatus', {
           open:   { en: 'Open' },

--- a/showcases/src/126-describe-field-metadata.showcase.test.ts
+++ b/showcases/src/126-describe-field-metadata.showcase.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Showcase 126 — collection.describe() + fieldMeta: two consumers, one source (#483)
+ *
+ * What you'll learn
+ * -----------------
+ * `collection.describe()` (sync, zero store I/O) returns a normalised
+ * `CollectionDescription` whose `fields` array merges every config channel —
+ * money / dictKeyFields / refs / fieldMeta — into consumer-neutral
+ * `DescribedField` objects. A single `describe()` call can power many
+ * different consumers without each having to re-read the collection config.
+ *
+ *   1. Build a `sales` collection that combines schema + moneyFields +
+ *      dictKeyFields (staticDict with labels) + refs + fieldMeta sensitivity.
+ *   2. Consumer A — table header row: `describe().fields.map(f => f.label)`.
+ *   3. Consumer B — export column spec: same `describe()` result, filter
+ *      `sensitivity !== 'public'` to flag PII/secret fields for redaction.
+ *   4. Merge precedence: channel (fieldMeta) > zod-4 .meta() > inferred-from-config.
+ *
+ * Why it matters
+ * --------------
+ * Consumer-neutral field descriptors eliminate the duplication that happens
+ * when every layer (table, export, form, API serialiser) hard-codes its own
+ * label/unit/sensitivity logic. `describe()` is the single source of truth:
+ * descriptive, never prescriptive (layout, styling, and locale selection stay
+ * app-side). Running sync with zero store I/O means it is cheap to call at
+ * render time.
+ *
+ * What to read next
+ * -----------------
+ *   - docs/subsystems/field-metadata.md (this feature's subsystem doc)
+ *   - docs/superpowers/specs/2026-06-25-field-metadata-foundation-design.md
+ *   - Showcase 87  (noydb describe CLI command — vault-level describe)
+ *   - Showcase 100 (staticDict — code-provided dictionaries)
+ *
+ * Spec mapping
+ * ------------
+ * features.yaml -> features -> field-metadata
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, money, staticDict, ref } from '@noy-db/hub'
+import type { FieldMeta } from '@noy-db/hub'
+import { memory } from '@noy-db/to-memory'
+
+// ── Shared collection fixture ─────────────────────────────────────────────────
+
+/**
+ * A `sales` collection that exercises every describe() merge channel:
+ *   - moneyFields    → infers semanticType:'currency', aggregate:'sum'
+ *   - dictKeyFields  → staticDict with en labels → dict.values[].label
+ *   - refs           → infers semanticType:'entity'
+ *   - fieldMeta      → overrides label, sets sensitivity, unit, displayFor
+ */
+
+const SALE_STATUS = staticDict('saleStatus', {
+  draft:   { en: 'Draft' },
+  pending: { en: 'Pending' },
+  paid:    { en: 'Paid' },
+}, { displayLocale: 'en' })
+
+const SALE_FIELD_META: Record<string, FieldMeta> = {
+  saleDate: { label: 'Date' },
+  total:    { label: 'Total (€)', unit: '€' },
+  buyerId:  { label: 'Buyer', sensitivity: 'pii', displayFor: 'buyerName' },
+  buyerVat: { label: 'VAT number', sensitivity: 'pii', semanticType: 'vat' },
+  notes:    { label: 'Internal notes', sensitivity: 'secret' },
+}
+
+// ── Part A: table header row ──────────────────────────────────────────────────
+
+describe('Showcase 126-A — consumer A: table header row from describe().fields', () => {
+  it('returns the correct labels for all configured fields', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'demo',
+      secret: 'showcase-126-a',
+    })
+    const vault = await db.openVault('firm')
+
+    interface Sale extends Record<string, unknown> {
+      id: string
+      saleDate: string
+      total: string
+      status: string
+      buyerId: string
+      buyerVat: string
+      notes?: string
+    }
+
+    const sales = vault.collection<Sale>('sales', {
+      moneyFields:  { total: money({ currency: 'EUR' }) },
+      dictKeyFields: { status: SALE_STATUS },
+      refs:         { buyerId: ref('buyers') },
+      fieldMeta:    SALE_FIELD_META,
+    })
+
+    // Sync — zero store I/O
+    const d = sales.describe()
+
+    // Consumer A: build a table header row
+    const headers = d.fields.map((f) => f.label)
+
+    // fieldMeta labels override the humanised key name
+    expect(headers).toContain('Date')           // saleDate → 'Date'
+    expect(headers).toContain('Total (€)')      // total    → 'Total (€)'
+    expect(headers).toContain('Buyer')           // buyerId  → 'Buyer'
+    expect(headers).toContain('VAT number')     // buyerVat → 'VAT number'
+    expect(headers).toContain('Internal notes') // notes    → 'Internal notes'
+
+    // staticDict field falls back to humanised key when no fieldMeta label provided
+    // ('status' → 'Status' via humanizeFieldKey)
+    expect(headers).toContain('Status')
+
+    // Fields are in alphabetical key order (describe() sorts by key, not label)
+    const fieldKeys = d.fields.map((f) => f.key)
+    const sortedKeys = [...fieldKeys].sort()
+    expect(fieldKeys).toEqual(sortedKeys)
+
+    db.close()
+  })
+
+  it('describe() is synchronous — no awaiting required', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'demo',
+      secret: 'showcase-126-a2',
+    })
+    const vault = await db.openVault('firm')
+
+    interface SaleSimple extends Record<string, unknown> {
+      id: string
+      amount: string
+    }
+
+    const sales = vault.collection<SaleSimple>('sales', {
+      moneyFields: { amount: money({ currency: 'USD' }) },
+      fieldMeta: { amount: { label: 'Amount', unit: '$' } },
+    })
+
+    // Notably: no `await` — describe() returns CollectionDescription directly
+    const d = sales.describe()
+    const byKey = Object.fromEntries(d.fields.map((f) => [f.key, f]))
+
+    expect(d.collection).toBe('sales')
+    expect(byKey.amount?.label).toBe('Amount')
+    expect(byKey.amount?.unit).toBe('$')
+    expect(byKey.amount?.semanticType).toBe('currency')
+    expect(byKey.amount?.aggregate).toBe('sum')
+    expect(byKey.amount?.money).toMatchObject({ mode: 'fixed', currency: 'USD' })
+
+    db.close()
+  })
+})
+
+// ── Part B: export column spec ────────────────────────────────────────────────
+
+describe('Showcase 126-B — consumer B: export column spec — flag PII/secret fields', () => {
+  it('derives an export spec from describe(): label + redacted flag for non-public fields', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'demo',
+      secret: 'showcase-126-b',
+    })
+    const vault = await db.openVault('firm')
+
+    interface Sale extends Record<string, unknown> {
+      id: string
+      saleDate: string
+      total: string
+      status: string
+      buyerId: string
+      buyerVat: string
+      notes?: string
+    }
+
+    const sales = vault.collection<Sale>('sales', {
+      moneyFields:   { total: money({ currency: 'EUR' }) },
+      dictKeyFields: { status: SALE_STATUS },
+      refs:          { buyerId: ref('buyers') },
+      fieldMeta:     SALE_FIELD_META,
+    })
+
+    const d = sales.describe()
+
+    // Consumer B: build an export column spec.
+    // Public fields are exported as-is; PII and secret fields are flagged for redaction.
+    const exportSpec = d.fields.map((f) => ({
+      key:      f.key,
+      label:    f.label,
+      redacted: f.sensitivity !== undefined && f.sensitivity !== 'public',
+    }))
+
+    const byKey = Object.fromEntries(exportSpec.map((c) => [c.key, c]))
+
+    // PII fields are flagged
+    expect(byKey.buyerId?.redacted).toBe(true)
+    expect(byKey.buyerVat?.redacted).toBe(true)
+
+    // Secret fields are flagged
+    expect(byKey.notes?.redacted).toBe(true)
+
+    // Fields without a sensitivity setting are NOT redacted
+    expect(byKey.saleDate?.redacted).toBe(false)
+    expect(byKey.total?.redacted).toBe(false)
+    expect(byKey.status?.redacted).toBe(false)
+
+    // Labels are correct in the export spec too (same describe() call)
+    expect(byKey.buyerId?.label).toBe('Buyer')
+    expect(byKey.total?.label).toBe('Total (€)')
+
+    db.close()
+  })
+
+  it('two consumers, one describe() call — identical field list', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'demo',
+      secret: 'showcase-126-b2',
+    })
+    const vault = await db.openVault('firm')
+
+    interface Sale extends Record<string, unknown> {
+      id: string
+      saleDate: string
+      total: string
+      status: string
+      buyerId: string
+      buyerVat: string
+      notes?: string
+    }
+
+    const sales = vault.collection<Sale>('sales', {
+      moneyFields:   { total: money({ currency: 'EUR' }) },
+      dictKeyFields: { status: SALE_STATUS },
+      refs:          { buyerId: ref('buyers') },
+      fieldMeta:     SALE_FIELD_META,
+    })
+
+    // Both consumers read ONE result — no second describe() call
+    const d = sales.describe()
+
+    const headerRow   = d.fields.map((f) => f.label)
+    const exportCols  = d.fields.map((f) => ({ label: f.label, redacted: f.sensitivity !== 'public' && f.sensitivity !== undefined }))
+    const piiKeys     = d.fields.filter((f) => f.sensitivity === 'pii').map((f) => f.key)
+    const secretKeys  = d.fields.filter((f) => f.sensitivity === 'secret').map((f) => f.key)
+
+    // Consumer A (table header)
+    expect(headerRow).toContain('Buyer')
+    expect(headerRow).toContain('Total (€)')
+
+    // Consumer B (export spec)
+    const buyerExport = exportCols.find((c) => c.label === 'Buyer')
+    expect(buyerExport?.redacted).toBe(true)
+
+    // PII fields: buyerId + buyerVat
+    expect(piiKeys).toContain('buyerId')
+    expect(piiKeys).toContain('buyerVat')
+    expect(piiKeys).not.toContain('total')
+
+    // Secret fields: notes
+    expect(secretKeys).toContain('notes')
+    expect(secretKeys).not.toContain('saleDate')
+
+    db.close()
+  })
+})
+
+// ── Part C: merge precedence + structural inference ───────────────────────────
+
+describe('Showcase 126-C — merge precedence: channel > inferred-from-config', () => {
+  it('fieldMeta channel overrides inferred semanticType/aggregate for money fields', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'demo',
+      secret: 'showcase-126-c',
+    })
+    const vault = await db.openVault('firm')
+
+    interface Invoice extends Record<string, unknown> {
+      id: string
+      amount: string
+      clientId: string
+    }
+
+    // Without fieldMeta: money infers semanticType:'currency', aggregate:'sum'
+    const plain = vault.collection<Invoice>('invoices-plain', {
+      moneyFields: { amount: money({ currency: 'EUR' }) },
+    })
+    const dPlain = plain.describe()
+    const amountPlain = dPlain.fields.find((f) => f.key === 'amount')!
+    expect(amountPlain.semanticType).toBe('currency')
+    expect(amountPlain.aggregate).toBe('sum')
+
+    // With fieldMeta channel: channel wins over inferred values
+    const withMeta = vault.collection<Invoice>('invoices-meta', {
+      moneyFields: { amount: money({ currency: 'EUR' }) },
+      fieldMeta: {
+        amount: {
+          label: 'Invoice amount',
+          unit: '€',
+          // channel overrides: keep semanticType:'currency' but set aliases
+          semanticType: 'currency',
+          aliases: ['amount', 'invoice total'],
+        },
+        clientId: { label: 'Client', sensitivity: 'pii' },
+      },
+      refs: { clientId: ref('clients') },
+    })
+    const dMeta = withMeta.describe()
+    const byKey = Object.fromEntries(dMeta.fields.map((f) => [f.key, f]))
+
+    // channel label wins
+    expect(byKey.amount?.label).toBe('Invoice amount')
+    // channel unit present
+    expect(byKey.amount?.unit).toBe('€')
+    // channel aliases present
+    expect(byKey.amount?.aliases).toContain('invoice total')
+    // inferred money block still present
+    expect(byKey.amount?.money).toMatchObject({ mode: 'fixed', currency: 'EUR' })
+
+    // ref: inferred entity + channel overrides label + sensitivity
+    expect(byKey.clientId?.semanticType).toBe('entity')
+    expect(byKey.clientId?.label).toBe('Client')
+    expect(byKey.clientId?.sensitivity).toBe('pii')
+    expect(byKey.clientId?.ref).toMatchObject({ target: 'clients' })
+
+    db.close()
+  })
+
+  it('staticDict: describe() surfaces values with labels synchronously', async () => {
+    const db = await createNoydb({
+      store: memory(),
+      user: 'demo',
+      secret: 'showcase-126-c2',
+    })
+    const vault = await db.openVault('firm')
+
+    interface Record extends globalThis.Record<string, unknown> {
+      id: string
+      status: string
+    }
+
+    const coll = vault.collection<Record>('orders', {
+      dictKeyFields: {
+        status: staticDict('orderStatus', {
+          open:   { en: 'Open' },
+          closed: { en: 'Closed' },
+        }, { displayLocale: 'en' }),
+      },
+    })
+
+    const d = coll.describe()
+    const statusField = d.fields.find((f) => f.key === 'status')!
+
+    expect(statusField.type).toBe('enum')
+    expect(statusField.dict?.static).toBe(true)
+    expect(statusField.dict?.name).toBe('orderStatus')
+
+    // Labels from the in-code static table are surfaced synchronously
+    const labels = statusField.dict?.values?.map((v) => v.label)
+    expect(labels).toContain('Open')
+    expect(labels).toContain('Closed')
+
+    db.close()
+  })
+})


### PR DESCRIPTION
## Field-metadata foundation — milestone #20

Substrate + keystone of the field-metadata epic (consumer-neutral, data-relatable descriptors, spun out of the pilot-3 migration). Both pieces are **additive** — no breaking change, no peer-dependency change.

Closes #482. Closes #483.

### #482 — zod-4 substrate (additive)
`@noy-db/hub` is validator-agnostic (Standard Schema v1); it never imports `zod` at runtime, so there is **no peer-dep break**. This PR:
- bumps the `zod` **devDependency** 3→4 (test-only),
- makes `persisted-schemas/derive.ts` zod-version-aware — zod-4 native `z.toJSONSchema()` (lazy `import('zod')`) with the zod-3 `zod-to-json-schema` fallback,
- exports `isZod4Schema`.

### #483 — `fieldMeta` channel + `collection.describe()`
- **`fieldMeta`** collection option — canonical, validator-agnostic per-field descriptors (`label`/`semanticType`/`unit`/`sensitivity`/`aggregate`/`aliases`/`displayFor`).
- **`collection.describe()`** — normalized descriptor list merging schema introspection + the `fieldMeta` channel + the config noy-db already owns (`refs`/`moneyFields`/`dictKeyFields`/`computed`).
  - **sync** (zero-arg): config-only, **zero store I/O**, types inferred from config — the table-render hot path.
  - **async** (`describe(opts)`): exact validator-derived types (reusing `introspection/fields.ts`), zod-4 `.meta()` merge, dynamic-dict label resolution, and fieldMeta key-validation.
- **Merge precedence:** channel > zod-4 `.meta()` > inferred-from-config.
- Public types exported from `@noy-db/hub`: `FieldMeta`, `SemanticType`, `CollectionDescription`, `DescribedField`, `DescribeOptions`.

### Boundary (binding invariant)
Descriptive, never prescriptive: noy-db carries *what a field means*; column order, styling, and active-locale selection stay app-side.

### Riders (separate, ride on this)
#484 (`toJSONSchema()`) and #486 (sensitivity classification — its `FieldMeta.sensitivity` field is already here) become thin additions; #485 (dictKey labels) is largely covered by `staticDict`.

### Verification
- 2860/2860 hub tests; DTS build clean (strict `exactOptionalPropertyTypes`); `check-architecture` OK; showcase 126 green; `features.yaml` spec-coverage OK.
- Invariants test-guarded: validator-agnostic (non-zod Standard-Schema validator), sync zero-store-I/O (store-method spies), no static `import 'zod'` in `hub/src`.

### Docs
- Spec: `docs/superpowers/specs/2026-06-25-field-metadata-foundation-design.md`
- Subsystem doc: `docs/subsystems/field-metadata.md`
- Showcase: `showcases/src/126-describe-field-metadata.showcase.test.ts`

Release cadence (approved): #482 then #483 as separate additive pre-release bumps.
