### PR TITLE
Store adapter seam + conformance kit, ESM-only build & Node 22 floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['20', '22']
+        node: ['22', '24']
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ concurrency:
 permissions:
   contents: read
 
+# Hub ships dts for 28 subpath entries off a very large type surface
+# (field-metadata epic); tsup's rollup-dts worker needs more than the
+# default heap or it dies with ERR_WORKER_OUT_OF_MEMORY. Applies to every
+# job that builds (build, lint+typecheck, test, interop).
+env:
+  NODE_OPTIONS: --max-old-space-size=8192
+
 jobs:
   # ── Architecture invariants ──────────────────────────────────────────
   # Enforces the design contract: peer-dep convention, zero crypto deps,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,11 @@ concurrency:
 permissions:
   contents: read
 
+# Hub's dts build (28 subpath entries, large type surface) needs more than
+# the default heap or tsup's rollup-dts worker dies with ERR_WORKER_OUT_OF_MEMORY.
+env:
+  NODE_OPTIONS: --max-old-space-size=8192
+
 jobs:
   # ── Gate 1: strict verification ──────────────────────────────────────
   verify:

--- a/docs/superpowers/plans/2026-06-27-store-seam-and-conformance-kit.md
+++ b/docs/superpowers/plans/2026-06-27-store-seam-and-conformance-kit.md
@@ -401,7 +401,10 @@ Expected: the kit emits `dist/index.{js,cjs,d.ts,d.cts}`; typecheck clean; `to-m
 ```bash
 pnpm check:architecture
 ```
-Expected: pass — the kit is skipped by rule #1; every other `@noy-db/*` package still must be `workspace:*`.
+Expected: pass — the kit is outside the `packages/` scan (it lives in `test-harnesses/`), so
+rule #1 is satisfied without the exemption firing. The exemption is pre-emptive: it becomes
+load-bearing in P1 when the scan is broadened or packages move under `packages/*/*`. Every other
+`@noy-db/*` package still must be `workspace:*`.
 
 - [ ] **Step 7: Full-graph sanity (guards + build + a representative test)**
 
@@ -427,6 +430,9 @@ git commit -m "feat(conformance): make adapter-conformance kit publishable on th
 - **D3 (the seam):** Task 1 creates `@noy-db/hub/adapter` exporting the contract types + store errors. ✓
 - **D3 (conformance kit):** Task 3 promotes `@noy-db/test-adapter-conformance` to publishable, peering hub at a range. ✓
 - **D6 (guard exemption):** Task 3 Step 4 adds the narrow rule-#1 exemption. ✓
+  Note: as of P0 the exemption is pre-emptive — `check:architecture` is green because the kit
+  lives in `test-harnesses/` and is outside the `packages/` scan, not because the exemption fired.
+  The exemption becomes active in P1.
 - **P0 "essential stores build against the subpath":** Task 2 migrates `to-memory`, `to-file`, `to-browser-idb`. ✓
 - **Naming collision (`/store` taken):** seam named `/adapter`. ✓
 - **Deferred (correctly out of P0):** the 15 moving stores migrate in P3; `noy-db-to` scaffold is P2; folder reorg is P1. Not in this plan.

--- a/docs/superpowers/plans/2026-06-27-store-seam-and-conformance-kit.md
+++ b/docs/superpowers/plans/2026-06-27-store-seam-and-conformance-kit.md
@@ -1,0 +1,446 @@
+# Store-Adapter Seam + Conformance Kit (P0) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Carve a stable published `@noy-db/hub/adapter` subpath (the ciphertext store contract) and promote the existing conformance harness to a publishable package, so a future `noy-db-to` repo can build storage adapters against a versioned seam — exactly as `klum-db` binds to `@noy-db/hub/kernel`.
+
+**Architecture:** Add one named-re-export barrel (`src/adapter/index.ts`) wired into the hub's existing multi-entry tsup build and `exports` map, mirroring the `./kernel` precedent. Migrate the three essential in-repo stores (`to-memory`, `to-file`, `to-browser-idb`) to import the contract from the new subpath. Promote `@noy-db/test-adapter-conformance` from a private/source-only/`0.0.0` workspace tool to a built, publishable package peering `@noy-db/hub` at a range, with a single narrow exemption from architecture-guard rule #1.
+
+**Tech Stack:** pnpm 9 + turbo, tsup (ESM+CJS+DTS), vitest, TypeScript strict.
+
+**Parent spec:** `docs/superpowers/specs/2026-06-27-extract-stores-to-noy-db-to-design.md` (phase P0).
+
+## Global Constraints
+
+- **No Claude/Anthropic attribution** in commits, PRs, docs, or CHANGELOGs. Commit messages end with no `Co-Authored-By: Claude` / "Generated with Claude" footer.
+- **Never reference the private pilot client by name** — grep the diff before every commit.
+- **Never publish** (or run a publish-adjacent command) without explicit user confirmation. This plan does **not** publish anything.
+- **Crypto:** zero npm crypto deps (guard #2); `crypto.subtle` only. The seam exposes no crypto primitives.
+- **Peer-dep convention (guard #1):** every `@noy-db/*` satellite keeps `peerDependencies['@noy-db/hub'] = "workspace:*"`. The **only** package exempted by this plan is `@noy-db/test-adapter-conformance` (test tooling that must peer a range).
+- **Stores import only the ciphertext surface (guard #4):** no crypto named-imports from `@noy-db/hub`.
+- **Work on a branch.** The repo's default branch is `main`; create `feat/store-adapter-seam` before Task 1 (`git checkout -b feat/store-adapter-seam`). Commit after every task.
+- **Verify before claiming done:** every "run" step must actually be run and its output observed.
+
+---
+
+### Task 1: The `@noy-db/hub/adapter` seam barrel
+
+**Files:**
+- Create: `packages/hub/src/adapter/index.ts`
+- Modify: `packages/hub/tsup.config.ts` (add one entry to the `ENTRIES` object)
+- Modify: `packages/hub/package.json` (add `./adapter` to `exports`, after the `./kernel` block)
+- Test: `packages/hub/__tests__/adapter-seam.test.ts`
+
+**Interfaces:**
+- Consumes: `NoydbStore`, `EncryptedEnvelope`, `VaultSnapshot`, `TxOp`, `StoreCapabilities`, `StoreTime`, `ListPageResult` from `packages/hub/src/types.ts`; `ConflictError`, `NetworkError`, `StoreCapabilityError` (error classes — see Step 1 grep to confirm their file).
+- Produces: a new public subpath `@noy-db/hub/adapter` re-exporting those symbols. Tasks 2 and 3 import from it.
+
+- [ ] **Step 1: Confirm the error classes' source file**
+
+The contract types are confirmed in `packages/hub/src/types.ts`. Confirm where the three error classes are *defined* (so the barrel imports from the right file):
+
+```bash
+cd /Users/vicio/lanna-db/noy-db
+grep -rn "export class ConflictError\|export class NetworkError\|export class StoreCapabilityError" packages/hub/src/
+```
+Expected: `ConflictError` and `NetworkError` in `packages/hub/src/errors.ts`. If `StoreCapabilityError` is reported in a different file (e.g. `src/store/index.ts`), use that path in Step 3's `export { StoreCapabilityError } from '...'` line instead of `../errors.js`.
+
+- [ ] **Step 2: Write the failing test**
+
+```typescript
+// packages/hub/__tests__/adapter-seam.test.ts
+import { describe, it, expect } from 'vitest'
+import { ConflictError, NetworkError, StoreCapabilityError } from '@noy-db/hub/adapter'
+import type {
+  NoydbStore,
+  EncryptedEnvelope,
+  VaultSnapshot,
+  TxOp,
+  StoreCapabilities,
+  StoreTime,
+  ListPageResult,
+} from '@noy-db/hub/adapter'
+
+describe('@noy-db/hub/adapter seam', () => {
+  it('re-exports the store-facing error classes as constructable runtime values', () => {
+    const conflict = new ConflictError(7)
+    expect(conflict).toBeInstanceOf(ConflictError)
+    expect(conflict.version).toBe(7)
+    expect(new NetworkError()).toBeInstanceOf(NetworkError)
+    expect(new StoreCapabilityError('listVaults')).toBeInstanceOf(StoreCapabilityError)
+  })
+
+  it('re-exports the store contract types (compile-time only)', () => {
+    // type-only smoke: these must resolve at typecheck; runtime is a no-op
+    const env = null as EncryptedEnvelope | null
+    const store = null as unknown as NoydbStore
+    const snap = null as unknown as VaultSnapshot
+    const ops = null as unknown as readonly TxOp[]
+    const caps = null as unknown as StoreCapabilities
+    const time = null as unknown as StoreTime
+    const page = null as unknown as ListPageResult
+    expect([env, store, snap, ops, caps, time, page].every(v => v === null)).toBe(true)
+  })
+})
+```
+
+(If `StoreCapabilityError`'s constructor signature differs from `(method: string)`, adjust the call — confirm with `grep -n "class StoreCapabilityError" -A4 packages/hub/src/*.ts`.)
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+pnpm --filter @noy-db/hub build   # build current state (no /adapter yet)
+pnpm --filter @noy-db/hub test -- adapter-seam
+```
+Expected: FAIL — `ERR_PACKAGE_PATH_NOT_EXPORTED` / "Package subpath './adapter' is not defined by 'exports'".
+
+- [ ] **Step 4: Create the seam barrel**
+
+```typescript
+// packages/hub/src/adapter/index.ts
+/**
+ * @noy-db/hub/adapter — the stable store-adapter contract.
+ *
+ * A storage backend (a `to-*` package) binds ONLY to this subpath: the
+ * ciphertext-facing slice of the hub. It carries the 6-method `NoydbStore`
+ * contract (plus its optional extension methods), the envelope / snapshot / op
+ * types a store passes through, and the store-facing error classes. Mirrors the
+ * `@noy-db/hub/kernel` seam used by klum-db and the `by-*` transports.
+ *
+ * Named re-exports only (no `export *`) so the published surface is explicit and
+ * tsup's per-entry bundling keeps class identity stable across subpaths.
+ */
+export type {
+  NoydbStore,
+  EncryptedEnvelope,
+  VaultSnapshot,
+  TxOp,
+  StoreCapabilities,
+  StoreTime,
+  ListPageResult,
+} from '../types.js'
+
+export { ConflictError, NetworkError, StoreCapabilityError } from '../errors.js'
+```
+
+(If Step 1 showed `StoreCapabilityError` lives elsewhere, split it into a second `export { StoreCapabilityError } from '<its-path>.js'` line.)
+
+- [ ] **Step 5: Wire the build entry**
+
+In `packages/hub/tsup.config.ts`, add the entry to the `ENTRIES` object, immediately after the `'kernel/index': 'src/kernel/index.ts',` line:
+
+```typescript
+  'kernel/index': 'src/kernel/index.ts',
+  'adapter/index': 'src/adapter/index.ts',
+}
+```
+
+- [ ] **Step 6: Add the `exports` entry**
+
+In `packages/hub/package.json`, the `./kernel` block is the last entry in `exports`. Add a comma after its closing brace and append `./adapter`:
+
+```json
+    "./kernel": {
+      "import": {
+        "types": "./dist/kernel/index.d.ts",
+        "default": "./dist/kernel/index.js"
+      },
+      "require": {
+        "types": "./dist/kernel/index.d.cts",
+        "default": "./dist/kernel/index.cjs"
+      }
+    },
+    "./adapter": {
+      "import": {
+        "types": "./dist/adapter/index.d.ts",
+        "default": "./dist/adapter/index.js"
+      },
+      "require": {
+        "types": "./dist/adapter/index.d.cts",
+        "default": "./dist/adapter/index.cjs"
+      }
+    }
+```
+
+- [ ] **Step 7: Rebuild and run the test to verify it passes**
+
+```bash
+pnpm --filter @noy-db/hub build
+pnpm --filter @noy-db/hub test -- adapter-seam
+pnpm --filter @noy-db/hub typecheck
+```
+Expected: build emits `dist/adapter/index.{js,cjs,d.ts,d.cts}`; the test PASSES; typecheck clean.
+
+- [ ] **Step 8: Confirm guards still pass**
+
+```bash
+pnpm check:architecture
+```
+Expected: all checks pass (the new subpath exposes no crypto; `kernel-surface` ratchet untouched).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/hub/src/adapter/index.ts packages/hub/tsup.config.ts packages/hub/package.json packages/hub/__tests__/adapter-seam.test.ts
+git commit -m "feat(hub): add @noy-db/hub/adapter store-contract subpath"
+```
+
+---
+
+### Task 2: Migrate the essential stores to the seam
+
+**Files (per store — repeat the cycle for each):**
+- Modify: `packages/to-memory/src/index.ts` (lines ~30–31)
+- Modify: `packages/to-file/src/index.ts` (the `@noy-db/hub` contract import)
+- Modify: `packages/to-browser-idb/src/index.ts` (the `@noy-db/hub` contract import)
+- Test: existing `packages/to-*/__tests__/conformance.test.ts` (no new test; these prove the seam works end-to-end)
+
+**Interfaces:**
+- Consumes: `@noy-db/hub/adapter` (from Task 1).
+- Produces: three essential stores importing the contract from the seam instead of the barrel. (The 15 stores destined for `noy-db-to` are migrated later, at relocation time, in plan P3.)
+
+- [ ] **Step 1: Inspect the current contract imports**
+
+```bash
+cd /Users/vicio/lanna-db/noy-db
+grep -n "from '@noy-db/hub'" packages/to-memory/src/index.ts packages/to-file/src/index.ts packages/to-browser-idb/src/index.ts
+```
+Expected (to-memory): `import type { NoydbStore, EncryptedEnvelope, VaultSnapshot, TxOp } from '@noy-db/hub'` and `import { ConflictError } from '@noy-db/hub'`. Note the exact symbol list per file (to-file / to-browser-idb may differ slightly).
+
+- [ ] **Step 2: Repoint `to-memory`'s contract imports to the seam**
+
+In `packages/to-memory/src/index.ts`, change the two import lines from `'@noy-db/hub'` to `'@noy-db/hub/adapter'`:
+
+```typescript
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot, TxOp } from '@noy-db/hub/adapter'
+import { ConflictError } from '@noy-db/hub/adapter'
+```
+
+Leave any non-contract imports (if present) pointing at their current subpaths. Only the contract symbols (`NoydbStore`, `EncryptedEnvelope`, `VaultSnapshot`, `TxOp`, `StoreCapabilities`, `StoreTime`, `ListPageResult`, `ConflictError`, `NetworkError`, `StoreCapabilityError`) move.
+
+- [ ] **Step 3: Build + test + typecheck `to-memory`**
+
+```bash
+pnpm --filter @noy-db/to-memory build
+pnpm --filter @noy-db/to-memory test
+pnpm --filter @noy-db/to-memory typecheck
+```
+Expected: build OK; the conformance suite (`runStoreConformanceTests('memory', …)`) PASSES against the seam; typecheck clean.
+
+- [ ] **Step 4: Repeat Steps 2–3 for `to-file`**
+
+Repoint the contract symbols in `packages/to-file/src/index.ts` to `'@noy-db/hub/adapter'` (use the exact symbol list Step 1 reported for this file), then:
+
+```bash
+pnpm --filter @noy-db/to-file build
+pnpm --filter @noy-db/to-file test
+pnpm --filter @noy-db/to-file typecheck
+```
+Expected: all pass.
+
+- [ ] **Step 5: Repeat Steps 2–3 for `to-browser-idb`**
+
+Repoint the contract symbols in `packages/to-browser-idb/src/index.ts` to `'@noy-db/hub/adapter'`, then:
+
+```bash
+pnpm --filter @noy-db/to-browser-idb build
+pnpm --filter @noy-db/to-browser-idb test
+pnpm --filter @noy-db/to-browser-idb typecheck
+```
+Expected: all pass.
+
+- [ ] **Step 6: Confirm guards still pass**
+
+```bash
+pnpm check:architecture
+```
+Expected: pass. Rule #4 (`stores-ciphertext-only`) regexes `@noy-db/hub` *and its subpaths*, so it still inspects the new `@noy-db/hub/adapter` imports — and the seam exposes no banned crypto names, so the three stores remain clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/to-memory/src/index.ts packages/to-file/src/index.ts packages/to-browser-idb/src/index.ts
+git commit -m "refactor(stores): bind essential stores to @noy-db/hub/adapter seam"
+```
+
+---
+
+### Task 3: Promote `@noy-db/test-adapter-conformance` to a publishable package
+
+**Files:**
+- Modify: `test-harnesses/adapter-conformance/package.json`
+- Create: `test-harnesses/adapter-conformance/tsup.config.ts`
+- Modify: `test-harnesses/adapter-conformance/src/index.ts` (repoint the `NoydbStore` type import)
+- Modify: `scripts/check-architecture.mjs` (one-line guard-#1 exemption)
+
+**Interfaces:**
+- Consumes: `@noy-db/hub/adapter` (from Task 1) for the `NoydbStore` type; `vitest` (peer).
+- Produces: a built, publishable `@noy-db/test-adapter-conformance` that peers `@noy-db/hub` at a range — consumable by the future `noy-db-to` repo. Public API unchanged: `runStoreConformanceTests(name, factory, cleanup?)`.
+
+- [ ] **Step 1: Repoint the contract import in the harness source**
+
+```bash
+cd /Users/vicio/lanna-db/noy-db
+grep -n "from '@noy-db/hub'" test-harnesses/adapter-conformance/src/index.ts
+```
+Change the `NoydbStore` type import in `test-harnesses/adapter-conformance/src/index.ts` from `'@noy-db/hub'` to `'@noy-db/hub/adapter'`. For example:
+
+```typescript
+import type { NoydbStore } from '@noy-db/hub/adapter'
+```
+(Keep any other imports as-is; only the contract type moves.)
+
+- [ ] **Step 2: Add the build config**
+
+```typescript
+// test-harnesses/adapter-conformance/tsup.config.ts
+import { defineConfig } from 'tsup'
+
+export default defineConfig([
+  {
+    entry: { index: 'src/index.ts' },
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+    target: 'es2022',
+  },
+  {
+    entry: { index: 'src/index.ts' },
+    format: ['cjs'],
+    dts: true,
+    clean: false,
+    sourcemap: true,
+    target: 'es2022',
+  },
+])
+```
+
+- [ ] **Step 3: Make the package.json publishable**
+
+Replace `test-harnesses/adapter-conformance/package.json` with:
+
+```json
+{
+  "name": "@noy-db/test-adapter-conformance",
+  "version": "0.2.0-pre.30",
+  "description": "Parameterized adapter contract tests for noy-db storage backends",
+  "license": "MIT",
+  "author": "vLannaAi <vicio@lanna.ai>",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "vitest run --passWithNoTests",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@noy-db/hub": "workspace:^",
+    "vitest": "^3.0.0"
+  },
+  "devDependencies": {
+    "@noy-db/hub": "workspace:*",
+    "vitest": "^3.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  }
+}
+```
+
+Notes:
+- `private: true` is **removed** — the package now joins the publish set.
+- `version` matches the current lockstep line (`0.2.0-pre.30`); the release normalizer keeps it aligned.
+- `@noy-db/hub` is a **peer** at `workspace:^` (pnpm publishes this as `^0.2.0-pre.30`, a range) and a **dev** at `workspace:*` (for local build/typecheck).
+
+- [ ] **Step 4: Exempt the kit from architecture-guard rule #1**
+
+In `scripts/check-architecture.mjs`, inside `checkPeerDeps()`, add the exemption immediately after the existing hub skip:
+
+```javascript
+    if (pj.name === '@noy-db/hub') continue
+    // Test tooling: must peer @noy-db/hub at a RANGE so external repos (noy-db-to)
+    // can consume it. Exempt from the workspace:* convention. (Not a satellite.)
+    if (pj.name === '@noy-db/test-adapter-conformance') continue
+```
+
+- [ ] **Step 5: Build the kit and verify a store's conformance run still passes against it**
+
+```bash
+pnpm install            # re-link workspace graph after manifest changes
+pnpm --filter @noy-db/test-adapter-conformance build
+pnpm --filter @noy-db/test-adapter-conformance typecheck
+pnpm --filter @noy-db/to-memory test
+```
+Expected: the kit emits `dist/index.{js,cjs,d.ts,d.cts}`; typecheck clean; `to-memory`'s conformance test (which imports `@noy-db/test-adapter-conformance`) still PASSES — now resolving the kit's built dist instead of source.
+
+- [ ] **Step 6: Confirm guards pass with the exemption**
+
+```bash
+pnpm check:architecture
+```
+Expected: pass — the kit is skipped by rule #1; every other `@noy-db/*` package still must be `workspace:*`.
+
+- [ ] **Step 7: Full-graph sanity (guards + build + a representative test)**
+
+```bash
+pnpm turbo build --filter @noy-db/hub --filter @noy-db/test-adapter-conformance --filter @noy-db/to-memory --filter @noy-db/to-file --filter @noy-db/to-browser-idb
+pnpm turbo test  --filter @noy-db/to-memory --filter @noy-db/to-file --filter @noy-db/to-browser-idb
+```
+Expected: all green.
+
+- [ ] **Step 8: Grep the diff for the client name, then commit**
+
+```bash
+git diff --staged | grep -i "<pilot-client-name>" && echo "STOP: client name present" || echo "clean"
+git add test-harnesses/adapter-conformance/package.json test-harnesses/adapter-conformance/tsup.config.ts test-harnesses/adapter-conformance/src/index.ts scripts/check-architecture.mjs
+git commit -m "feat(conformance): make adapter-conformance kit publishable on the adapter seam"
+```
+(Replace `<pilot-client-name>` with the actual name to grep for; do not write it into any committed file.)
+
+---
+
+## Self-review (performed against the spec)
+
+- **D3 (the seam):** Task 1 creates `@noy-db/hub/adapter` exporting the contract types + store errors. ✓
+- **D3 (conformance kit):** Task 3 promotes `@noy-db/test-adapter-conformance` to publishable, peering hub at a range. ✓
+- **D6 (guard exemption):** Task 3 Step 4 adds the narrow rule-#1 exemption. ✓
+- **P0 "essential stores build against the subpath":** Task 2 migrates `to-memory`, `to-file`, `to-browser-idb`. ✓
+- **Naming collision (`/store` taken):** seam named `/adapter`. ✓
+- **Deferred (correctly out of P0):** the 15 moving stores migrate in P3; `noy-db-to` scaffold is P2; folder reorg is P1. Not in this plan.
+- **Type consistency:** the symbol set (`NoydbStore`, `EncryptedEnvelope`, `VaultSnapshot`, `TxOp`, `StoreCapabilities`, `StoreTime`, `ListPageResult`, `ConflictError`, `NetworkError`, `StoreCapabilityError`) is identical in Task 1's barrel, Task 1's test, and Task 2's migration. ✓
+
+---
+
+## Plan roadmap (subsequent phases — separate plans)
+
+Each becomes its own plan once the prior one is merged (later phases bind to earlier phases' concrete output):
+
+- **P1 — Folder reorg in `noy-db`.** Move packages into `packages/<family>/<pkg>` (basename == package short name); update `pnpm-workspace.yaml` (`packages/*` → also `packages/*/*`). Names unchanged; turbo/changesets are path-agnostic. Verify: full build/test/typecheck + `check:architecture` green.
+- **P2 — Scaffold `noy-db-to`.** New repo: pnpm workspace (`to-*` at root, flat), tsup/vitest/eslint configs, sibling architecture guard (range-peer + adapter-subpath-only), CI calling the shared reusable workflow, `release.yml` (provenance + explicit-confirm), devDep on the published `@noy-db/test-adapter-conformance`, ranged peer on `@noy-db/hub`.
+- **P3 — Relocate the 15 stores in batches.** Per package: copy to `noy-db-to`, migrate contract imports to `@noy-db/hub/adapter`, convert peer to a range, run conformance against published hub; delete from `noy-db`; drop from release set, changesets, `features.yaml`, storage matrix, docs.
+- **P4 — Rebuild `to-nfs` standalone** (sever `to-file`) so `noy-db-to` has zero inbound deps to noy-db's stores.
+- **P5 — First `noy-db-to` release** (explicit user confirmation) + confirm `noy-db` no longer publishes the moved packages (klum-db split precedent).
+- **P6 — (Optional) uniform CI** reusable workflow adopted across `klum-db`, `nit-db`, `noy-db`, `noy-db-to`.

--- a/docs/superpowers/specs/2026-06-27-extract-stores-to-noy-db-to-design.md
+++ b/docs/superpowers/specs/2026-06-27-extract-stores-to-noy-db-to-design.md
@@ -1,0 +1,187 @@
+# Extract non-essential storage adapters into a `noy-db-to` repo
+
+**Date:** 2026-06-27
+**Status:** Design — pending review
+**Scope:** `noy-db` (source) + new `noy-db-to` repo. Does **not** touch `klum-db`, `nit-db`, or the UI packages.
+
+## Context
+
+`lanna-db` is a working directory, not a repo or package — it holds several independently
+git-tracked repos of the noy-db family. `noy-db` is a pnpm+turbo monorepo of **68 packages**; its
+CI runs the test job serially (`turbo test --concurrency=1`) across a Node 20/22 matrix plus a
+3-OS interop job, which is the main source of its slow CI. The `to-*` storage family alone is 21
+packages, and the cloud adapters drag cloud-credential surface into the core repo.
+
+This design splits the storage family across two repos along a single curation line, and reorganizes
+both repos around a family-folder convention — so each repo is smaller, CI is faster and uniform,
+versioning is independent, and a developer can navigate the family from its folder layout alone.
+
+### Goals
+
+1. **Level repo size** — shrink `noy-db` by relocating ~15 storage adapters.
+2. **Faster, uniform CI** — fewer packages and no cloud creds in core CI; a shared CI shape across
+   the family repos.
+3. **Focused Claude-Code context** — a single-purpose stores repo, and family-grouped folders.
+4. **Independent versioning** — the stores repo versions and releases on its own line, decoupled
+   from noy-db's churn via a published contract.
+5. **Simplified access** — the folder layout teaches the family; the repo split teaches
+   essential-vs-extended.
+
+### Non-goals
+
+- **Bundle size.** The cloud SDKs are already *optional peer-deps*; nothing ships them unless
+  imported. This split changes CI/cognitive load, not runtime weight.
+- **Splitting other families** (`in-/on-/as-/by-/at-`). They stay in `noy-db`.
+- **Cross-repo in-tree visibility** (submodules / generated catalogs). Decorative; dropped.
+- **Folding `noy-db-ui` into noy-db.** Separate decision, out of scope here.
+
+## Decisions (settled)
+
+### D1 — The split line: essential-default stays, everything else moves
+
+The classification criterion is a single question: *is this a default, essential store?* This avoids
+the multi-qualifier "networked/cloud/server" definition (which leaves mixed local/network adapters
+straddling the cut) and classifies every current and future store unambiguously.
+
+**Stay in `noy-db`** (essential defaults):
+- `to-memory` — every test target; ephemeral
+- `to-file` — canonical local persistence
+- `to-browser-idb` — the browser default (async, large quota, transactional)
+
+**Move to `noy-db-to`** (everything else, 15 packages):
+- `to-browser-local` (niche fallback), `to-aws-s3`, `to-aws-dynamo`, `to-cloudflare-d1`,
+  `to-cloudflare-r2`, `to-postgres`, `to-mysql`, `to-turso`, `to-supabase`, `to-smb`, `to-ssh`,
+  `to-webdav`, `to-nfs`, `to-drive`, `to-icloud`
+
+**Open minor (O1):** `to-probe` (diagnostic) and `to-meter` (a metering decorator) carry the `to-`
+prefix but are not real storage targets. They stay in `noy-db` for now (tightly coupled to hub
+testing). A later option is to move them out of `to/` into a `dev/` family folder; not done here.
+
+### D2 — Folder convention
+
+- **Directory basename == package short name** (`to-aws-s3`), so `pnpm --filter`, grep, and GitHub
+  search map 1:1 to a folder with no translation.
+- **A family grouping folder (`to/`, `in/`, …) is used only in a multi-family repo.**
+  - `noy-db` is multi-family → `packages/<family>/<pkg>`, e.g. `packages/to/to-memory`.
+  - `noy-db-to` is single-family → packages sit flat at the repo root, e.g. `to-aws-s3`. The repo
+    name is the grouping; no redundant `/to/` middle folder (which also isn't in the npm name).
+
+```
+noy-db/packages/                         noy-db-to/
+├── hub/                                 ├── to-browser-local/
+├── cli/  create-noy-db/  attestation/   ├── to-aws-s3/   to-aws-dynamo/
+├── to/   to-memory to-file              ├── to-cloudflare-d1/  to-cloudflare-r2/
+│         to-browser-idb                 ├── to-postgres/ to-mysql/ to-turso/ to-supabase/
+│         (to-probe to-meter — O1)       ├── to-smb/ to-ssh/ to-webdav/ to-nfs/
+├── in/   on/   as/   by/   at/          ├── to-drive/ to-icloud/
+                                         ├── pnpm-workspace.yaml  → ['to-*']
+                                         └── CLAUDE.md  .github/  release.yml
+```
+
+### D3 — The published contract (the seam)
+
+Today every `to-*` package is already constrained by architecture guard #4
+(`stores-ciphertext-only`): a store may import only the ciphertext-facing slice of the hub. That
+narrow surface becomes a **stable published subpath, `@noy-db/hub/adapter`**, exporting:
+- the `NoydbStore` interface (the 6-method contract: `get/put/delete/list/loadAll/saveAll` + the
+  optional extension methods),
+- the ciphertext envelope type (`EncryptedEnvelope`) and the snapshot/op types stores pass through
+  (`VaultSnapshot`, `TxOp`, `StoreCapabilities`, `StoreTime`, `ListPageResult`),
+- the store-facing error classes (`ConflictError`, `NetworkError`, `StoreCapabilityError`).
+
+> **Naming note:** `@noy-db/hub/store` is **already taken** — it currently exports hub-internal store
+> *routing / middleware / sync-policy* machinery, not the adapter contract. The new seam is therefore
+> named `@noy-db/hub/adapter` ("a store adapter binds to `@noy-db/hub/adapter`").
+
+This mirrors how `klum-db` binds only to `@noy-db/hub/kernel`. The existing parameterized
+adapter-conformance harness (`@noy-db/test-adapter-conformance`, today private/`0.0.0`/source-only,
+exporting `runStoreConformanceTests(name, factory, cleanup?)`) is **promoted in place to a published
+package** — keeping its current name to avoid renaming 21 store devDeps + 21 test imports — so the
+external repo runs the *same* contract tests against the *published* hub. Because a publishable kit
+must peer `@noy-db/hub` at a **range**, it takes a narrow, explicit **exemption from architecture
+guard rule #1** (it is test tooling, not a satellite).
+
+### D4 — Versioning
+
+- `noy-db` keeps **lockstep** versioning on its line (currently `0.2.0-pre.30`), minus the moved
+  packages.
+- `noy-db-to` gets its **own independent line** (e.g. `0.2.0-pre.N`) and peers `@noy-db/hub` at a
+  **range** (`^0.2.x`), never `workspace:*`. It re-publishes only when (a) a store changes, or
+  (b) the `@noy-db/hub/store` contract changes (which surfaces as a peer-range bump — the explicit
+  signal that the contract moved). Routine noy-db feature releases never force a `noy-db-to` rebuild.
+
+### D5 — `to-nfs` rebuilt fresh (no `to-file` dependency)
+
+`to-nfs` currently reuses `to-file`. NFS violates `to-file`'s implicit local-POSIX invariants
+(atomic rename, working fsync, meaningful locks): over NFS you face `ESTALE`, close-to-open
+consistency, unreliable locking, root-squash uid/gid mapping, and latency that demands
+cache/retry. A quality NFS adapter is a different implementation, not a `to-file` subclass.
+Rebuilding it standalone also removes the **only** dependency edge from `noy-db-to` back into a
+`noy-db` store — so `noy-db-to` ends with **zero inbound deps to noy-db's stores**, peering only the
+hub. (`to-supabase → to-postgres` and `to-cloudflare-r2 → to-aws-s3` are both intra-`noy-db-to`, so
+they stay normal workspace deps.)
+
+### D6 — Architecture guards split
+
+- In `noy-db`, guards #1 (`peerDependencies['@noy-db/hub'] = "workspace:*"`) and #4
+  (`stores-ciphertext-only`) still apply to the essential stores.
+- `noy-db-to` gets a sibling guard (the store-world twin of klum-db's `no-outbound-klum-import`):
+  every store peers `@noy-db/hub` at a **range** (never `workspace:*`), and imports only the
+  published `@noy-db/hub/adapter` subpath.
+
+### D7 — CI
+
+- `noy-db` CI shrinks (15 fewer packages; no cloud creds).
+- `noy-db-to` CI: build/lint/typecheck/test against the **published** hub + the conformance kit;
+  cloud adapters **mock-tested by default**, with real-cloud runs gated to a scheduled/manual
+  workflow (creds live only here, not in core).
+- **Uniform CI** via a shared **reusable GitHub workflow** that all family repos call with params
+  (test command, Node matrix). Rollout to all repos is a follow-up phase, not a blocker.
+
+### D8 — npm & release
+
+- Package **names are unchanged** (`@noy-db/to-aws-s3`, …). The `@noy-db` scope is published from
+  two repos — npm allows this; the scope is just a namespace.
+- `noy-db-to` replicates `noy-db`'s release discipline: `release.yml` triggered by GitHub Release /
+  explicit `workflow_dispatch confirm=PUBLISH`, `npm whoami` scope check, `--provenance`,
+  `@latest`/`@next` dist-tag routing. **Never publish without explicit user confirmation.**
+- **Publisher handoff:** once `noy-db-to` publishes a moved package at a higher version under the
+  same name+tag, consumers upgrade transparently via `npm i`. `noy-db` must **stop** publishing the
+  moved packages (remove them from its release set) so two publishers never race — exactly the
+  precedent set when `@klum-db/*` was removed from noy-db's `release.yml` during the klum-db split.
+
+## Migration phases (high level; detailed plan to follow)
+
+- **P0 — Seam first (additive, no moves).** Introduce `@noy-db/hub/adapter` subpath; promote/publish
+  `@noy-db/store-conformance`. Migrate the essential stores' contract imports to the subpath and
+  verify they build/test against it. CI green. *(Detailed in `plans/2026-06-27-store-seam-and-conformance-kit.md`.)*
+- **P1 — Folder reorg in noy-db.** Move packages into `packages/<family>/<pkg>`; update
+  `pnpm-workspace.yaml` glob (`packages/*` → also `packages/*/*`). Names unchanged; turbo/changesets
+  are path-agnostic. CI green.
+- **P2 — Scaffold `noy-db-to`.** pnpm workspace (`to-*`), shared tooling, CI calling the reusable
+  workflow, `release.yml`, sibling architecture guard, ranged peer on `@noy-db/hub`, consumes the
+  conformance kit.
+- **P3 — Relocate stores in batches.** Per batch: copy package into `noy-db-to`, convert peer to
+  ranged, run conformance against published hub; delete from `noy-db`; drop from noy-db's release
+  set, changesets, `features.yaml`, and docs.
+- **P4 — Rebuild `to-nfs`** standalone (sever `to-file`). *(Staged fallback: relocate as-is with a
+  temporary ranged dep on published `@noy-db/to-file`, then rewrite — only if P3 timing demands it.)*
+- **P5 — First `noy-db-to` release** + consumer/docs updates; confirm noy-db no longer publishes the
+  moved packages.
+- **P6 — (Optional) uniform CI** reusable workflow adopted across `klum-db`, `nit-db`, `noy-db`,
+  `noy-db-to`.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Version/publisher handoff race | noy-db removes moved pkgs from release set before/at first noy-db-to publish (klum-db precedent). |
+| Contract drift between repos | `@noy-db/hub/adapter` is a versioned subpath; `@noy-db/store-conformance` runs in noy-db-to CI against published hub. |
+| Guard drift | Port guards #1/#4 to a noy-db-to sibling guard; keep both in CI. |
+| Cloud creds | Real-cloud tests gated to scheduled/manual workflow in noy-db-to only. |
+| Cross-repo dep via `to-nfs`→`to-file` | Rebuild `to-nfs` standalone (D5). |
+
+## Open questions
+
+- **O1:** Final home of `to-probe` / `to-meter` (stay in `to/`, or move to a `dev/` family). Default: stay.
+- **O2:** `to-nfs` immediate rewrite (P4) vs. staged relocate-then-rewrite. Default: immediate.

--- a/docs/superpowers/specs/2026-06-27-extract-stores-to-noy-db-to-design.md
+++ b/docs/superpowers/specs/2026-06-27-extract-stores-to-noy-db-to-design.md
@@ -99,7 +99,10 @@ exporting `runStoreConformanceTests(name, factory, cleanup?)`) is **promoted in 
 package** — keeping its current name to avoid renaming 21 store devDeps + 21 test imports — so the
 external repo runs the *same* contract tests against the *published* hub. Because a publishable kit
 must peer `@noy-db/hub` at a **range**, it takes a narrow, explicit **exemption from architecture
-guard rule #1** (it is test tooling, not a satellite).
+guard rule #1** (it is test tooling, not a satellite). As of P0, `check-architecture.mjs` scans
+only `packages/`, so the kit currently satisfies rule #1 by being outside the scan — the explicit
+exemption is pre-emptive and becomes active in P1 (when packages move under `packages/*/*` or the
+scan broadens to `test-harnesses/`).
 
 ### D4 — Versioning
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "packageManager": "pnpm@9.15.4",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "turbo run build",

--- a/packages/as-aws-s3/package.json
+++ b/packages/as-aws-s3/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/as-aws-s3/tsup.config.ts
+++ b/packages/as-aws-s3/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/as-blob/package.json
+++ b/packages/as-blob/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/as-blob/tsup.config.ts
+++ b/packages/as-blob/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/as-csv/package.json
+++ b/packages/as-csv/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/as-csv/tsup.config.ts
+++ b/packages/as-csv/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/as-json/package.json
+++ b/packages/as-json/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/as-json/tsup.config.ts
+++ b/packages/as-json/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/as-ndjson/package.json
+++ b/packages/as-ndjson/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/as-ndjson/tsup.config.ts
+++ b/packages/as-ndjson/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/as-noydb/package.json
+++ b/packages/as-noydb/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/as-noydb/tsup.config.ts
+++ b/packages/as-noydb/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/as-sql/package.json
+++ b/packages/as-sql/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/as-sql/tsup.config.ts
+++ b/packages/as-sql/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/as-xlsx/package.json
+++ b/packages/as-xlsx/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/as-xlsx/tsup.config.ts
+++ b/packages/as-xlsx/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/as-xml/package.json
+++ b/packages/as-xml/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/as-xml/tsup.config.ts
+++ b/packages/as-xml/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/as-zip/package.json
+++ b/packages/as-zip/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/as-zip/tsup.config.ts
+++ b/packages/as-zip/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/at-aws-kms/package.json
+++ b/packages/at-aws-kms/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/at-aws-kms/tsup.config.ts
+++ b/packages/at-aws-kms/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/at-azure-keyvault/package.json
+++ b/packages/at-azure-keyvault/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/at-azure-keyvault/tsup.config.ts
+++ b/packages/at-azure-keyvault/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/at-env/package.json
+++ b/packages/at-env/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/at-env/tsup.config.ts
+++ b/packages/at-env/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/at-gcp-kms/package.json
+++ b/packages/at-gcp-kms/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/at-gcp-kms/tsup.config.ts
+++ b/packages/at-gcp-kms/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/at-macos-keychain/package.json
+++ b/packages/at-macos-keychain/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -39,7 +32,7 @@
     "darwin"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/at-macos-keychain/src/index.ts
+++ b/packages/at-macos-keychain/src/index.ts
@@ -79,7 +79,15 @@
  * @packageDocumentation
  */
 
+import { createRequire } from 'node:module'
+
 import type { SealingKeyProvider } from '@noy-db/hub'
+
+// ESM has no ambient `require`. Synthesize one bound to this module's URL so
+// the native `@napi-rs/keyring` addon (a CJS-only N-API binary) can still be
+// lazily loaded on darwin. This package is Node/darwin-only by definition, so
+// node:module is always available here.
+const require = createRequire(import.meta.url)
 
 /**
  * Structural shape of `@napi-rs/keyring`'s `Entry` class.

--- a/packages/at-macos-keychain/tsup.config.ts
+++ b/packages/at-macos-keychain/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/attestation/package.json
+++ b/packages/attestation/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/attestation/tsup.config.ts
+++ b/packages/attestation/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/by-peer/package.json
+++ b/packages/by-peer/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/by-peer/tsup.config.ts
+++ b/packages/by-peer/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/by-tabs/package.json
+++ b/packages/by-tabs/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/by-tabs/tsup.config.ts
+++ b/packages/by-tabs/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,17 +20,10 @@
   },
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -39,7 +32,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     index: 'src/index.ts',
     'bin/noydb': 'src/bin/noydb.ts',
   },
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: { entry: 'src/index.ts' },
   clean: true,
   splitting: false,

--- a/packages/create-noy-db/package.json
+++ b/packages/create-noy-db/package.json
@@ -33,7 +33,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup && node scripts/postbuild.mjs",

--- a/packages/create-noy-db/tsup.config.ts
+++ b/packages/create-noy-db/tsup.config.ts
@@ -19,8 +19,8 @@ export default defineConfig({
     'src/bin/create.ts',
     'src/bin/noy-db.ts',
   ],
-  // ESM-only: every other @noy-db package is ESM and Node 20+ supports it
-  // natively. CJS would just be dead code that bloats the install.
+  // ESM-only: every @noy-db package is ESM and the family targets Node 22+.
+  // CJS would just be dead code that bloats the install.
   format: ['esm'],
   dts: true,
   clean: true,

--- a/packages/hub/__tests__/adapter-seam.test.ts
+++ b/packages/hub/__tests__/adapter-seam.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { ConflictError, NetworkError, StoreCapabilityError } from '@noy-db/hub/adapter'
+import type {
+  NoydbStore,
+  EncryptedEnvelope,
+  VaultSnapshot,
+  TxOp,
+  StoreCapabilities,
+  StoreTime,
+  ListPageResult,
+} from '@noy-db/hub/adapter'
+
+describe('@noy-db/hub/adapter seam', () => {
+  it('re-exports the store-facing error classes as constructable runtime values', () => {
+    const conflict = new ConflictError(7)
+    expect(conflict).toBeInstanceOf(ConflictError)
+    expect(conflict.version).toBe(7)
+    expect(new NetworkError()).toBeInstanceOf(NetworkError)
+    expect(new StoreCapabilityError('listVaults', 'openVault')).toBeInstanceOf(StoreCapabilityError)
+  })
+
+  it('re-exports the store contract types (compile-time only)', () => {
+    // type-only smoke: these must resolve at typecheck; runtime is a no-op
+    const env = null as EncryptedEnvelope | null
+    const store = null as unknown as NoydbStore
+    const snap = null as unknown as VaultSnapshot
+    const ops = null as unknown as readonly TxOp[]
+    const caps = null as unknown as StoreCapabilities
+    const time = null as unknown as StoreTime
+    const page = null as unknown as ListPageResult
+    expect([env, store, snap, ops, caps, time, page].every(v => v === null)).toBe(true)
+  })
+})

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -17,287 +17,118 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./i18n": {
-      "import": {
-        "types": "./dist/i18n/index.d.ts",
-        "default": "./dist/i18n/index.js"
-      },
-      "require": {
-        "types": "./dist/i18n/index.d.cts",
-        "default": "./dist/i18n/index.cjs"
-      }
+      "types": "./dist/i18n/index.d.ts",
+      "default": "./dist/i18n/index.js"
     },
     "./store": {
-      "import": {
-        "types": "./dist/store/index.d.ts",
-        "default": "./dist/store/index.js"
-      },
-      "require": {
-        "types": "./dist/store/index.d.cts",
-        "default": "./dist/store/index.cjs"
-      }
+      "types": "./dist/store/index.d.ts",
+      "default": "./dist/store/index.js"
     },
     "./team": {
-      "import": {
-        "types": "./dist/team/index.d.ts",
-        "default": "./dist/team/index.js"
-      },
-      "require": {
-        "types": "./dist/team/index.d.cts",
-        "default": "./dist/team/index.cjs"
-      }
+      "types": "./dist/team/index.d.ts",
+      "default": "./dist/team/index.js"
     },
     "./session": {
-      "import": {
-        "types": "./dist/session/index.d.ts",
-        "default": "./dist/session/index.js"
-      },
-      "require": {
-        "types": "./dist/session/index.d.cts",
-        "default": "./dist/session/index.cjs"
-      }
+      "types": "./dist/session/index.d.ts",
+      "default": "./dist/session/index.js"
     },
     "./history": {
-      "import": {
-        "types": "./dist/history/index.d.ts",
-        "default": "./dist/history/index.js"
-      },
-      "require": {
-        "types": "./dist/history/index.d.cts",
-        "default": "./dist/history/index.cjs"
-      }
+      "types": "./dist/history/index.d.ts",
+      "default": "./dist/history/index.js"
     },
     "./forget": {
-      "import": {
-        "types": "./dist/forget/index.d.ts",
-        "default": "./dist/forget/index.js"
-      },
-      "require": {
-        "types": "./dist/forget/index.d.cts",
-        "default": "./dist/forget/index.cjs"
-      }
+      "types": "./dist/forget/index.d.ts",
+      "default": "./dist/forget/index.js"
     },
     "./sealed-record": {
-      "import": {
-        "types": "./dist/sealed-record/index.d.ts",
-        "default": "./dist/sealed-record/index.js"
-      },
-      "require": {
-        "types": "./dist/sealed-record/index.d.cts",
-        "default": "./dist/sealed-record/index.cjs"
-      }
+      "types": "./dist/sealed-record/index.d.ts",
+      "default": "./dist/sealed-record/index.js"
     },
     "./query": {
-      "import": {
-        "types": "./dist/query/index.d.ts",
-        "default": "./dist/query/index.js"
-      },
-      "require": {
-        "types": "./dist/query/index.d.cts",
-        "default": "./dist/query/index.cjs"
-      }
+      "types": "./dist/query/index.d.ts",
+      "default": "./dist/query/index.js"
     },
     "./blobs": {
-      "import": {
-        "types": "./dist/blobs/index.d.ts",
-        "default": "./dist/blobs/index.js"
-      },
-      "require": {
-        "types": "./dist/blobs/index.d.cts",
-        "default": "./dist/blobs/index.cjs"
-      }
+      "types": "./dist/blobs/index.d.ts",
+      "default": "./dist/blobs/index.js"
     },
     "./indexing": {
-      "import": {
-        "types": "./dist/indexing/index.d.ts",
-        "default": "./dist/indexing/index.js"
-      },
-      "require": {
-        "types": "./dist/indexing/index.d.cts",
-        "default": "./dist/indexing/index.cjs"
-      }
+      "types": "./dist/indexing/index.d.ts",
+      "default": "./dist/indexing/index.js"
     },
     "./aggregate": {
-      "import": {
-        "types": "./dist/aggregate/index.d.ts",
-        "default": "./dist/aggregate/index.js"
-      },
-      "require": {
-        "types": "./dist/aggregate/index.d.cts",
-        "default": "./dist/aggregate/index.cjs"
-      }
+      "types": "./dist/aggregate/index.d.ts",
+      "default": "./dist/aggregate/index.js"
     },
     "./crdt": {
-      "import": {
-        "types": "./dist/crdt/index.d.ts",
-        "default": "./dist/crdt/index.js"
-      },
-      "require": {
-        "types": "./dist/crdt/index.d.cts",
-        "default": "./dist/crdt/index.cjs"
-      }
+      "types": "./dist/crdt/index.d.ts",
+      "default": "./dist/crdt/index.js"
     },
     "./bundle": {
-      "import": {
-        "types": "./dist/bundle/index.d.ts",
-        "default": "./dist/bundle/index.js"
-      },
-      "require": {
-        "types": "./dist/bundle/index.d.cts",
-        "default": "./dist/bundle/index.cjs"
-      }
+      "types": "./dist/bundle/index.d.ts",
+      "default": "./dist/bundle/index.js"
     },
     "./consent": {
-      "import": {
-        "types": "./dist/consent/index.d.ts",
-        "default": "./dist/consent/index.js"
-      },
-      "require": {
-        "types": "./dist/consent/index.d.cts",
-        "default": "./dist/consent/index.cjs"
-      }
+      "types": "./dist/consent/index.d.ts",
+      "default": "./dist/consent/index.js"
     },
     "./periods": {
-      "import": {
-        "types": "./dist/periods/index.d.ts",
-        "default": "./dist/periods/index.js"
-      },
-      "require": {
-        "types": "./dist/periods/index.d.cts",
-        "default": "./dist/periods/index.cjs"
-      }
+      "types": "./dist/periods/index.d.ts",
+      "default": "./dist/periods/index.js"
     },
     "./guards": {
-      "import": {
-        "types": "./dist/guards/index.d.ts",
-        "default": "./dist/guards/index.js"
-      },
-      "require": {
-        "types": "./dist/guards/index.d.cts",
-        "default": "./dist/guards/index.cjs"
-      }
+      "types": "./dist/guards/index.d.ts",
+      "default": "./dist/guards/index.js"
     },
     "./shadow": {
-      "import": {
-        "types": "./dist/shadow/index.d.ts",
-        "default": "./dist/shadow/index.js"
-      },
-      "require": {
-        "types": "./dist/shadow/index.d.cts",
-        "default": "./dist/shadow/index.cjs"
-      }
+      "types": "./dist/shadow/index.d.ts",
+      "default": "./dist/shadow/index.js"
     },
     "./snapshots": {
-      "import": {
-        "types": "./dist/snapshots/index.d.ts",
-        "default": "./dist/snapshots/index.js"
-      },
-      "require": {
-        "types": "./dist/snapshots/index.d.cts",
-        "default": "./dist/snapshots/index.cjs"
-      }
+      "types": "./dist/snapshots/index.d.ts",
+      "default": "./dist/snapshots/index.js"
     },
     "./tx": {
-      "import": {
-        "types": "./dist/tx/index.d.ts",
-        "default": "./dist/tx/index.js"
-      },
-      "require": {
-        "types": "./dist/tx/index.d.cts",
-        "default": "./dist/tx/index.cjs"
-      }
+      "types": "./dist/tx/index.d.ts",
+      "default": "./dist/tx/index.js"
     },
     "./derivations": {
-      "import": {
-        "types": "./dist/derivations/index.d.ts",
-        "default": "./dist/derivations/index.js"
-      },
-      "require": {
-        "types": "./dist/derivations/index.d.cts",
-        "default": "./dist/derivations/index.cjs"
-      }
+      "types": "./dist/derivations/index.d.ts",
+      "default": "./dist/derivations/index.js"
     },
     "./materialized-views": {
-      "import": {
-        "types": "./dist/materialized-views/index.d.ts",
-        "default": "./dist/materialized-views/index.js"
-      },
-      "require": {
-        "types": "./dist/materialized-views/index.d.cts",
-        "default": "./dist/materialized-views/index.cjs"
-      }
+      "types": "./dist/materialized-views/index.d.ts",
+      "default": "./dist/materialized-views/index.js"
     },
     "./overlay-views": {
-      "import": {
-        "types": "./dist/overlay-views/index.d.ts",
-        "default": "./dist/overlay-views/index.js"
-      },
-      "require": {
-        "types": "./dist/overlay-views/index.d.cts",
-        "default": "./dist/overlay-views/index.cjs"
-      }
+      "types": "./dist/overlay-views/index.d.ts",
+      "default": "./dist/overlay-views/index.js"
     },
     "./sync": {
-      "import": {
-        "types": "./dist/sync/index.d.ts",
-        "default": "./dist/sync/index.js"
-      },
-      "require": {
-        "types": "./dist/sync/index.d.cts",
-        "default": "./dist/sync/index.cjs"
-      }
+      "types": "./dist/sync/index.d.ts",
+      "default": "./dist/sync/index.js"
     },
     "./util": {
-      "import": {
-        "types": "./dist/util/index.d.ts",
-        "default": "./dist/util/index.js"
-      },
-      "require": {
-        "types": "./dist/util/index.d.cts",
-        "default": "./dist/util/index.cjs"
-      }
+      "types": "./dist/util/index.d.ts",
+      "default": "./dist/util/index.js"
     },
     "./attestation": {
-      "import": {
-        "types": "./dist/attestation/index.d.ts",
-        "default": "./dist/attestation/index.js"
-      },
-      "require": {
-        "types": "./dist/attestation/index.d.cts",
-        "default": "./dist/attestation/index.cjs"
-      }
+      "types": "./dist/attestation/index.d.ts",
+      "default": "./dist/attestation/index.js"
     },
     "./kernel": {
-      "import": {
-        "types": "./dist/kernel/index.d.ts",
-        "default": "./dist/kernel/index.js"
-      },
-      "require": {
-        "types": "./dist/kernel/index.d.cts",
-        "default": "./dist/kernel/index.cjs"
-      }
+      "types": "./dist/kernel/index.d.ts",
+      "default": "./dist/kernel/index.js"
     },
     "./adapter": {
-      "import": {
-        "types": "./dist/adapter/index.d.ts",
-        "default": "./dist/adapter/index.js"
-      },
-      "require": {
-        "types": "./dist/adapter/index.d.cts",
-        "default": "./dist/adapter/index.cjs"
-      }
+      "types": "./dist/adapter/index.d.ts",
+      "default": "./dist/adapter/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -306,7 +137,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -285,6 +285,16 @@
         "types": "./dist/kernel/index.d.cts",
         "default": "./dist/kernel/index.cjs"
       }
+    },
+    "./adapter": {
+      "import": {
+        "types": "./dist/adapter/index.d.ts",
+        "default": "./dist/adapter/index.js"
+      },
+      "require": {
+        "types": "./dist/adapter/index.d.cts",
+        "default": "./dist/adapter/index.cjs"
+      }
     }
   },
   "main": "./dist/index.cjs",

--- a/packages/hub/src/adapter/index.ts
+++ b/packages/hub/src/adapter/index.ts
@@ -1,0 +1,23 @@
+/**
+ * @noy-db/hub/adapter — the stable store-adapter contract.
+ *
+ * A storage backend (a `to-*` package) binds ONLY to this subpath: the
+ * ciphertext-facing slice of the hub. It carries the 6-method `NoydbStore`
+ * contract (plus its optional extension methods), the envelope / snapshot / op
+ * types a store passes through, and the store-facing error classes. Mirrors the
+ * `@noy-db/hub/kernel` seam used by klum-db and the `by-*` transports.
+ *
+ * Named re-exports only (no `export *`) so the published surface is explicit and
+ * tsup's per-entry bundling keeps class identity stable across subpaths.
+ */
+export type {
+  NoydbStore,
+  EncryptedEnvelope,
+  VaultSnapshot,
+  TxOp,
+  StoreCapabilities,
+  StoreTime,
+  ListPageResult,
+} from '../types.js'
+
+export { ConflictError, NetworkError, StoreCapabilityError } from '../errors.js'

--- a/packages/hub/src/tab-coordination.ts
+++ b/packages/hub/src/tab-coordination.ts
@@ -201,6 +201,11 @@ function cheapRand(): string {
 
 /** Browser default lock manager (navigator.locks) or undefined. */
 export function defaultLockManager(): TabLockManager | undefined {
+  // Gate on `window` — a real browser signal. Node 21+ exposes a global
+  // `navigator`, and Node 24+ surfaces `navigator.locks` (Web Locks), so the
+  // presence of navigator.locks alone is NOT a browser signal; without this
+  // gate we'd run the role election in Node. Symmetric with defaultChannel().
+  if (typeof (globalThis as { window?: unknown }).window === 'undefined') return undefined
   const nav = (globalThis as { navigator?: { locks?: TabLockManager } }).navigator
   return nav?.locks
 }

--- a/packages/hub/tsup.config.ts
+++ b/packages/hub/tsup.config.ts
@@ -14,13 +14,9 @@ import { defineConfig } from 'tsup'
  *
  * `splitting: true` for ESM extracts shared modules into separate
  * chunk files (e.g. `dist/chunk-ABC123.js`) that every entry imports.
- * One class definition; `instanceof` works again across subpaths.
- *
- * CJS doesn't support code splitting natively. We keep CJS as the
- * single-bundle "self-contained per entry" mode. Modern consumers
- * almost universally use ESM, where instanceof works correctly.
- * CJS consumers who mix subpaths can use string-discriminator checks
- * (`err.code === '...'`) — documented in `docs/reference/api-stability.md`.
+ * One class definition; `instanceof` works again across subpaths. The
+ * package is ESM-only, so this single build is the whole story — there
+ * is no CJS single-bundle mode to reconcile against.
  */
 const ENTRIES = {
   index: 'src/index.ts',
@@ -53,29 +49,14 @@ const ENTRIES = {
   'adapter/index': 'src/adapter/index.ts',
 }
 
-export default defineConfig([
-  // ESM build with code splitting — shared chunks deduplicated so
-  // class identity holds across subpath boundaries.
-  {
-    entry: ENTRIES,
-    format: ['esm'],
-    dts: true,
-    clean: true,
-    splitting: true,
-    sourcemap: true,
-    target: 'es2022',
-  },
-  // CJS build without splitting — preserves the v0.24 single-bundle
-  // shape for legacy consumers. `clean: false` so it doesn't wipe the
-  // ESM artefacts emitted by the first config. dts emits `.d.cts` for
-  // CJS consumers under `moduleResolution: node16/nodenext`.
-  {
-    entry: ENTRIES,
-    format: ['cjs'],
-    dts: true,
-    clean: false,
-    splitting: false,
-    sourcemap: true,
-    target: 'es2022',
-  },
-])
+// ESM build with code splitting — shared chunks deduplicated so
+// class identity holds across subpath boundaries.
+export default defineConfig({
+  entry: ENTRIES,
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  splitting: true,
+  sourcemap: true,
+  target: 'es2022',
+})

--- a/packages/hub/tsup.config.ts
+++ b/packages/hub/tsup.config.ts
@@ -50,6 +50,7 @@ const ENTRIES = {
   'util/index': 'src/util/index.ts',
   'attestation/index': 'src/attestation/index.ts',
   'kernel/index': 'src/kernel/index.ts',
+  'adapter/index': 'src/adapter/index.ts',
 }
 
 export default defineConfig([

--- a/packages/in-ai/package.json
+++ b/packages/in-ai/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/in-ai/tsup.config.ts
+++ b/packages/in-ai/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/in-devtools-tui/package.json
+++ b/packages/in-devtools-tui/package.json
@@ -32,5 +32,8 @@
     "ink-testing-library": "^4.0.0",
     "@types/node": "^22.0.0",
     "@types/react": "^18.3.12"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   }
 }

--- a/packages/in-devtools/package.json
+++ b/packages/in-devtools/package.json
@@ -4,19 +4,12 @@
   "description": "Framework-agnostic read-only inspector for a live noy-db — vaults, collections, schema, stats, records, and live writes.",
   "license": "MIT",
   "type": "module",
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
   "files": [
@@ -34,5 +27,8 @@
   "devDependencies": {
     "@noy-db/hub": "workspace:*",
     "@noy-db/to-meter": "workspace:*"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   }
 }

--- a/packages/in-devtools/tsup.config.ts
+++ b/packages/in-devtools/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/in-nextjs/package.json
+++ b/packages/in-nextjs/package.json
@@ -17,27 +17,14 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./client": {
-      "import": {
-        "types": "./dist/client.d.ts",
-        "default": "./dist/client.js"
-      },
-      "require": {
-        "types": "./dist/client.d.cts",
-        "default": "./dist/client.cjs"
-      }
+      "types": "./dist/client.d.ts",
+      "default": "./dist/client.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -46,7 +33,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/in-nextjs/tsup.config.ts
+++ b/packages/in-nextjs/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: { index: 'src/index.ts', client: 'src/client.ts' },
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/in-nuxt/package.json
+++ b/packages/in-nuxt/package.json
@@ -30,7 +30,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/in-pinia/package.json
+++ b/packages/in-pinia/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/in-pinia/tsup.config.ts
+++ b/packages/in-pinia/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/in-react/package.json
+++ b/packages/in-react/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/in-react/tsup.config.ts
+++ b/packages/in-react/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/in-rest/package.json
+++ b/packages/in-rest/package.json
@@ -17,57 +17,26 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./hono": {
-      "import": {
-        "types": "./dist/adapters/hono.d.ts",
-        "default": "./dist/adapters/hono.js"
-      },
-      "require": {
-        "types": "./dist/adapters/hono.d.cts",
-        "default": "./dist/adapters/hono.cjs"
-      }
+      "types": "./dist/adapters/hono.d.ts",
+      "default": "./dist/adapters/hono.js"
     },
     "./express": {
-      "import": {
-        "types": "./dist/adapters/express.d.ts",
-        "default": "./dist/adapters/express.js"
-      },
-      "require": {
-        "types": "./dist/adapters/express.d.cts",
-        "default": "./dist/adapters/express.cjs"
-      }
+      "types": "./dist/adapters/express.d.ts",
+      "default": "./dist/adapters/express.js"
     },
     "./fastify": {
-      "import": {
-        "types": "./dist/adapters/fastify.d.ts",
-        "default": "./dist/adapters/fastify.js"
-      },
-      "require": {
-        "types": "./dist/adapters/fastify.d.cts",
-        "default": "./dist/adapters/fastify.cjs"
-      }
+      "types": "./dist/adapters/fastify.d.ts",
+      "default": "./dist/adapters/fastify.js"
     },
     "./nitro": {
-      "import": {
-        "types": "./dist/adapters/nitro.d.ts",
-        "default": "./dist/adapters/nitro.js"
-      },
-      "require": {
-        "types": "./dist/adapters/nitro.d.cts",
-        "default": "./dist/adapters/nitro.cjs"
-      }
+      "types": "./dist/adapters/nitro.d.ts",
+      "default": "./dist/adapters/nitro.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -76,7 +45,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/in-rest/tsup.config.ts
+++ b/packages/in-rest/tsup.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     'src/adapters/fastify.ts',
     'src/adapters/nitro.ts',
   ],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/in-solid/package.json
+++ b/packages/in-solid/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/in-solid/tsup.config.ts
+++ b/packages/in-solid/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/in-svelte/package.json
+++ b/packages/in-svelte/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/in-svelte/tsup.config.ts
+++ b/packages/in-svelte/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/in-tanstack-query/package.json
+++ b/packages/in-tanstack-query/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/in-tanstack-query/tsup.config.ts
+++ b/packages/in-tanstack-query/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/in-tanstack-table/package.json
+++ b/packages/in-tanstack-table/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/in-tanstack-table/tsup.config.ts
+++ b/packages/in-tanstack-table/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/in-vue/package.json
+++ b/packages/in-vue/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/in-vue/tsup.config.ts
+++ b/packages/in-vue/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/in-yjs/package.json
+++ b/packages/in-yjs/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/in-yjs/tsup.config.ts
+++ b/packages/in-yjs/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/in-zustand/package.json
+++ b/packages/in-zustand/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/in-zustand/tsup.config.ts
+++ b/packages/in-zustand/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/on-email-otp/package.json
+++ b/packages/on-email-otp/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/on-email-otp/tsup.config.ts
+++ b/packages/on-email-otp/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/on-magic-link/package.json
+++ b/packages/on-magic-link/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/on-magic-link/tsup.config.ts
+++ b/packages/on-magic-link/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/on-oidc/package.json
+++ b/packages/on-oidc/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/on-oidc/tsup.config.ts
+++ b/packages/on-oidc/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/on-password/package.json
+++ b/packages/on-password/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/on-password/tsup.config.ts
+++ b/packages/on-password/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/on-pin/package.json
+++ b/packages/on-pin/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/on-pin/tsup.config.ts
+++ b/packages/on-pin/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/on-recovery/package.json
+++ b/packages/on-recovery/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/on-recovery/tsup.config.ts
+++ b/packages/on-recovery/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/on-shamir/package.json
+++ b/packages/on-shamir/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/on-shamir/tsup.config.ts
+++ b/packages/on-shamir/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/on-threat/package.json
+++ b/packages/on-threat/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/on-threat/tsup.config.ts
+++ b/packages/on-threat/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/on-totp/package.json
+++ b/packages/on-totp/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/on-totp/tsup.config.ts
+++ b/packages/on-totp/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/on-webauthn/package.json
+++ b/packages/on-webauthn/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/on-webauthn/tsup.config.ts
+++ b/packages/on-webauthn/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-aws-dynamo/package.json
+++ b/packages/to-aws-dynamo/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-aws-dynamo/tsup.config.ts
+++ b/packages/to-aws-dynamo/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-aws-s3/package.json
+++ b/packages/to-aws-s3/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-aws-s3/tsup.config.ts
+++ b/packages/to-aws-s3/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-browser-idb/package.json
+++ b/packages/to-browser-idb/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-browser-idb/src/index.ts
+++ b/packages/to-browser-idb/src/index.ts
@@ -31,8 +31,8 @@
  * @packageDocumentation
  */
 
-import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '@noy-db/hub'
-import { ConflictError } from '@noy-db/hub'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '@noy-db/hub/adapter'
+import { ConflictError } from '@noy-db/hub/adapter'
 
 /**
  * Options for `browserIdbStore()`.

--- a/packages/to-browser-idb/tsup.config.ts
+++ b/packages/to-browser-idb/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-browser-local/package.json
+++ b/packages/to-browser-local/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-browser-local/tsup.config.ts
+++ b/packages/to-browser-local/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-cloudflare-d1/package.json
+++ b/packages/to-cloudflare-d1/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-cloudflare-d1/tsup.config.ts
+++ b/packages/to-cloudflare-d1/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-cloudflare-r2/package.json
+++ b/packages/to-cloudflare-r2/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-cloudflare-r2/tsup.config.ts
+++ b/packages/to-cloudflare-r2/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-drive/package.json
+++ b/packages/to-drive/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-drive/tsup.config.ts
+++ b/packages/to-drive/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-file/package.json
+++ b/packages/to-file/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-file/src/index.ts
+++ b/packages/to-file/src/index.ts
@@ -44,19 +44,14 @@
 
 import { readFile, writeFile, mkdir, readdir, unlink, stat } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '@noy-db/hub/adapter'
+import { ConflictError } from '@noy-db/hub/adapter'
 import type {
-  NoydbStore,
-  EncryptedEnvelope,
-  VaultSnapshot,
   Vault,
   WriteNoydbBundleOptions,
   NoydbBundleReadResult,
 } from '@noy-db/hub'
-import {
-  ConflictError,
-  writeNoydbBundle,
-  readNoydbBundle,
-} from '@noy-db/hub'
+import { writeNoydbBundle, readNoydbBundle } from '@noy-db/hub'
 
 /**
  * Options for `jsonFile()`.

--- a/packages/to-file/tsup.config.ts
+++ b/packages/to-file/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-icloud/package.json
+++ b/packages/to-icloud/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-icloud/tsup.config.ts
+++ b/packages/to-icloud/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-memory/package.json
+++ b/packages/to-memory/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-memory/src/index.ts
+++ b/packages/to-memory/src/index.ts
@@ -27,8 +27,8 @@
  * @packageDocumentation
  */
 
-import type { NoydbStore, EncryptedEnvelope, VaultSnapshot, TxOp } from '@noy-db/hub'
-import { ConflictError } from '@noy-db/hub'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot, TxOp } from '@noy-db/hub/adapter'
+import { ConflictError } from '@noy-db/hub/adapter'
 
 /**
  * Create an in-memory adapter backed by nested Maps.

--- a/packages/to-memory/tsup.config.ts
+++ b/packages/to-memory/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-meter/package.json
+++ b/packages/to-meter/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-meter/tsup.config.ts
+++ b/packages/to-meter/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-mysql/package.json
+++ b/packages/to-mysql/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-mysql/tsup.config.ts
+++ b/packages/to-mysql/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-nfs/package.json
+++ b/packages/to-nfs/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-nfs/tsup.config.ts
+++ b/packages/to-nfs/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-postgres/package.json
+++ b/packages/to-postgres/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-postgres/tsup.config.ts
+++ b/packages/to-postgres/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-probe/package.json
+++ b/packages/to-probe/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-probe/tsup.config.ts
+++ b/packages/to-probe/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'tsup'
 
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-smb/package.json
+++ b/packages/to-smb/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-smb/tsup.config.ts
+++ b/packages/to-smb/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-sqlite/package.json
+++ b/packages/to-sqlite/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-sqlite/tsup.config.ts
+++ b/packages/to-sqlite/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-ssh/package.json
+++ b/packages/to-ssh/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-ssh/tsup.config.ts
+++ b/packages/to-ssh/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-supabase/package.json
+++ b/packages/to-supabase/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-supabase/tsup.config.ts
+++ b/packages/to-supabase/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-turso/package.json
+++ b/packages/to-turso/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-turso/tsup.config.ts
+++ b/packages/to-turso/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/packages/to-webdav/package.json
+++ b/packages/to-webdav/package.json
@@ -17,17 +17,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -36,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/to-webdav/tsup.config.ts
+++ b/packages/to-webdav/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
+  format: ['esm'],
   dts: true,
   clean: true,
   splitting: false,

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -135,6 +135,11 @@ function checkPeerDeps() {
     if (pj.name === '@noy-db/hub') continue
     // Test tooling: must peer @noy-db/hub at a RANGE so external repos (noy-db-to)
     // can consume it. Exempt from the workspace:* convention. (Not a satellite.)
+    // NOTE: This exemption is PRE-EMPTIVE — inert today because this guard only
+    // scans packages/ (via listPackageDirs) and the kit lives in
+    // test-harnesses/adapter-conformance (outside the scan). It becomes
+    // load-bearing in P1 when packages move under packages/*/* or the scan is
+    // broadened to cover test-harnesses/.
     if (pj.name === '@noy-db/test-adapter-conformance') continue
 
     const dep = pj.dependencies?.['@noy-db/hub']

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -133,6 +133,9 @@ function checkPeerDeps() {
     // depend on hub.
     if (!pj.name.startsWith('@noy-db/')) continue
     if (pj.name === '@noy-db/hub') continue
+    // Test tooling: must peer @noy-db/hub at a RANGE so external repos (noy-db-to)
+    // can consume it. Exempt from the workspace:* convention. (Not a satellite.)
+    if (pj.name === '@noy-db/test-adapter-conformance') continue
 
     const dep = pj.dependencies?.['@noy-db/hub']
     const peer = pj.peerDependencies?.['@noy-db/hub']

--- a/test-harnesses/adapter-conformance/package.json
+++ b/test-harnesses/adapter-conformance/package.json
@@ -8,17 +8,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
-  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
@@ -43,5 +36,8 @@
   "publishConfig": {
     "access": "public",
     "tag": "latest"
+  },
+  "engines": {
+    "node": ">=22.0.0"
   }
 }

--- a/test-harnesses/adapter-conformance/package.json
+++ b/test-harnesses/adapter-conformance/package.json
@@ -1,17 +1,47 @@
 {
   "name": "@noy-db/test-adapter-conformance",
-  "version": "0.0.0",
-  "private": true,
-  "description": "Parameterized adapter contract tests",
+  "version": "0.2.0-pre.30",
+  "description": "Parameterized adapter contract tests for noy-db storage backends",
+  "license": "MIT",
+  "author": "vLannaAi <vicio@lanna.ai>",
   "type": "module",
+  "sideEffects": false,
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
   },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
-    "test": "vitest run --passWithNoTests"
+    "build": "tsup",
+    "test": "vitest run --passWithNoTests",
+    "lint": "eslint src/",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@noy-db/hub": "workspace:^",
+    "vitest": "^3.0.0"
   },
   "devDependencies": {
     "@noy-db/hub": "workspace:*",
     "vitest": "^3.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
   }
 }

--- a/test-harnesses/adapter-conformance/src/index.ts
+++ b/test-harnesses/adapter-conformance/src/index.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterAll } from 'vitest'
-import type { NoydbStore, EncryptedEnvelope } from '@noy-db/hub'
-import { ConflictError } from '@noy-db/hub'
+import type { NoydbStore, EncryptedEnvelope } from '@noy-db/hub/adapter'
+import { ConflictError } from '@noy-db/hub/adapter'
 
 function makeEnvelope(version: number, data = 'test-data'): EncryptedEnvelope {
   return {

--- a/test-harnesses/adapter-conformance/tsup.config.ts
+++ b/test-harnesses/adapter-conformance/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig([
+  {
+    entry: { index: 'src/index.ts' },
+    format: ['esm'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+    target: 'es2022',
+  },
+  {
+    entry: { index: 'src/index.ts' },
+    format: ['cjs'],
+    dts: true,
+    clean: false,
+    sourcemap: true,
+    target: 'es2022',
+  },
+])

--- a/test-harnesses/adapter-conformance/tsup.config.ts
+++ b/test-harnesses/adapter-conformance/tsup.config.ts
@@ -1,20 +1,10 @@
 import { defineConfig } from 'tsup'
 
-export default defineConfig([
-  {
-    entry: { index: 'src/index.ts' },
-    format: ['esm'],
-    dts: true,
-    clean: true,
-    sourcemap: true,
-    target: 'es2022',
-  },
-  {
-    entry: { index: 'src/index.ts' },
-    format: ['cjs'],
-    dts: true,
-    clean: false,
-    sourcemap: true,
-    target: 'es2022',
-  },
-])
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm'],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  target: 'es2022',
+})


### PR DESCRIPTION
Branches the `feat/store-adapter-seam` line into main. Two related threads:

## Store adapter seam + conformance kit
- New `@noy-db/hub/adapter` store-contract subpath; essential stores bind to it.
- `@noy-db/test-adapter-conformance` made publishable on the adapter seam (so external `to-*` repos can run the same contract suite); guard exemption documented as pre-emptive/inert until P1.

## ESM-only build & Node 22 floor (`56ccf097`)
- Drop CJS output across all packages — every package was already `"type": "module"` with ESM as primary; the parallel CJS build was dead weight (klum-db, nit-db, UI packages are all ESM-native).
- `exports` maps collapsed from dual import/require to a single `{ types, default }`; dangling `main` removed; no more `.cjs`/`.d.cts`.
- hub keeps `splitting: true` — the thing that makes `instanceof` hold across its 28 subpaths; dropping the CJS single-bundle mode strengthens that.
- `at-macos-keychain`: native addon loaded via `createRequire(import.meta.url)`.
- `engines.node` → `>=22.0.0` family-wide (Node 18/20 are EOL); CI matrix `['20','22']` → `['22','24']`.

## Verification
- Build 70/70 (ESM-only output confirmed), typecheck 130/130 (new exports maps resolve types for every consumer), architecture guard clean.
- Remaining test failures are pre-existing/environmental: `better-sqlite3` native ABI built for Node 20, and credentialed Supabase real-service showcases. Not introduced here.