### PR TITLE
feat(hub): zero-config createNoydb via built-in memoryStore

### DIFF
--- a/packages/hub/__tests__/memory-store.test.ts
+++ b/packages/hub/__tests__/memory-store.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { memoryStore } from '../src/store/memory-store.js'
+import type { EncryptedEnvelope } from '../src/types.js'
+import { ConflictError } from '../src/errors.js'
+
+const env = (v: number): EncryptedEnvelope =>
+  ({ _noydb: 1, _v: v, _ts: '2026-01-01T00:00:00.000Z', _iv: '', _data: `d${v}` }) as unknown as EncryptedEnvelope
+
+describe('memoryStore', () => {
+  it('put then get returns the envelope; missing returns null', async () => {
+    const s = memoryStore()
+    expect(await s.get('v', 'c', '1')).toBeNull()
+    await s.put('v', 'c', '1', env(0))
+    expect((await s.get('v', 'c', '1'))?._data).toBe('d0')
+  })
+
+  it('list returns ids; delete removes', async () => {
+    const s = memoryStore()
+    await s.put('v', 'c', 'a', env(0))
+    await s.put('v', 'c', 'b', env(0))
+    expect((await s.list('v', 'c')).sort()).toEqual(['a', 'b'])
+    await s.delete('v', 'c', 'a')
+    expect(await s.list('v', 'c')).toEqual(['b'])
+  })
+
+  it('CAS: put with stale expectedVersion throws ConflictError', async () => {
+    const s = memoryStore()
+    await s.put('v', 'c', '1', env(5))
+    await expect(s.put('v', 'c', '1', env(6), 4)).rejects.toBeInstanceOf(ConflictError)
+    await s.put('v', 'c', '1', env(6), 5) // matching version succeeds
+    expect((await s.get('v', 'c', '1'))?._v).toBe(6)
+  })
+
+  it('loadAll returns a snapshot excluding _system collections; saveAll replaces user collections', async () => {
+    const s = memoryStore()
+    await s.put('v', 'items', '1', env(0))
+    await s.put('v', '_idx', 'x', env(0)) // system collection — excluded from loadAll
+    expect(await s.loadAll('v')).toEqual({ items: { '1': env(0) } })
+
+    await s.saveAll('v', { items: { '2': env(0) } })
+    expect(await s.list('v', 'items')).toEqual(['2']) // user collection replaced
+    expect(await s.list('v', '_idx')).toEqual(['x']) // system collection preserved
+  })
+
+  it('declares casAtomic + a monotonic store clock', async () => {
+    const s = memoryStore()
+    expect(s.capabilities?.casAtomic).toBe(true)
+    const t1 = await s.getStoreTime!()
+    const t2 = await s.getStoreTime!()
+    expect(t2.earliest).toBeGreaterThan(t1.earliest)
+  })
+})

--- a/packages/hub/__tests__/zero-config-store.test.ts
+++ b/packages/hub/__tests__/zero-config-store.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/index.js'
+
+// The point of this test: NO `store` is passed.
+// Minimal non-store options copied from packages/hub/__tests__/integration.test.ts.
+describe('createNoydb without a store', () => {
+  it('defaults to the built-in memoryStore and round-trips a record', async () => {
+    const db = await createNoydb({ user: 'test-user', secret: 'correct-horse-battery-staple' })
+    const vault = await db.openVault('v1')
+    const items = vault.collection<{ id: string; n: number }>('items')
+    await items.put('1', { id: '1', n: 42 })
+    expect((await items.get('1'))?.n).toBe(42)
+  })
+})

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -226,6 +226,7 @@ export { SyncScheduler, INDEXED_STORE_POLICY, BUNDLE_STORE_POLICY } from './stor
 export type { SyncTarget, SyncTargetRole } from './types.js'
 
 // Store routing
+export { memoryStore } from './store/memory-store.js'
 export { routeStore } from './store/route-store.js'
 export type {
   RouteStoreOptions, RoutedNoydbStore, BlobStoreRoute, AgeRoute,

--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -118,6 +118,7 @@ import { NO_TX, type TxStrategy } from './tx/strategy.js'
 import { NO_FORGET, type ForgetStrategy } from './forget/strategy.js'
 import { readDottedPath, coerceSubjectId } from './forget/subject-index.js'
 import { INDEXED_STORE_POLICY } from './store/sync-policy.js'
+import { memoryStore } from './store/memory-store.js'
 import type { PolicyEnforcer } from './session/session-policy.js'
 import { NO_SESSION, type SessionStrategy } from './session/strategy.js'
 import {
@@ -169,9 +170,12 @@ function createPlaintextKeyring(userId: string, debugPlaintext = false): Unlocke
   }
 }
 
+/** NoydbOptions with the store resolved to a non-optional value (internal use only). */
+type ResolvedNoydbOptions = NoydbOptions & { readonly store: NoydbStore }
+
 /** The top-level NOYDB instance. */
 export class Noydb {
-  private readonly options: NoydbOptions
+  private readonly options: ResolvedNoydbOptions
   private readonly emitter = new NoydbEventEmitter()
   private readonly writeQueueTracker = new WriteQueueTracker()
   private readonly writeHooks = new WriteHookRegistry()
@@ -247,7 +251,7 @@ export class Noydb {
   /** Audit log for all translator invocations in this session. Cleared on `close()`. */
   private readonly _translatorAuditLog: TranslatorAuditEntry[] = []
 
-  constructor(options: NoydbOptions) {
+  constructor(options: ResolvedNoydbOptions) {
     this.options = options
     // Debug-plaintext is an unencrypted-only inspection mode; combining it with
     // encryption is meaningless and unsafe, so reject the coupling loudly.
@@ -3046,6 +3050,7 @@ export class Noydb {
 
 /** Create a new NOYDB instance. */
 export async function createNoydb(options: NoydbOptions): Promise<Noydb> {
+  if (!options.store) options = { ...options, store: memoryStore() }
   const encrypted = options.encrypt !== false
   const managed = options.passphraseMode === 'managed'
 
@@ -3082,7 +3087,7 @@ export async function createNoydb(options: NoydbOptions): Promise<Noydb> {
     throw new ValidationError('A secret (passphrase) or getKeyring callback is required when encryption is enabled')
   }
 
-  return new Noydb(options)
+  return new Noydb(options as ResolvedNoydbOptions)
 }
 
 // ─── Internal helpers ─────────────────────────────────────────────────

--- a/packages/hub/src/store/memory-store.ts
+++ b/packages/hub/src/store/memory-store.ts
@@ -1,0 +1,82 @@
+import type { NoydbStore, VaultSnapshot, EncryptedEnvelope, StoreTime } from '../types.js'
+import { ConflictError } from '../errors.js'
+
+/**
+ * Built-in in-memory store — the kernel's zero-config default.
+ *
+ * Nested `Map`s: `vault → collection → id → envelope`. Non-persistent
+ * (data is lost on process exit). A conformant 6-method {@link NoydbStore}
+ * with CAS atomicity and a monotonic store clock — the kernel version of
+ * `@noy-db/to-memory`'s core, so `createNoydb()` works with no store package.
+ *
+ * Portable: imports only `types` + `errors` (no crypto primitive) — passes
+ * the `stores-ciphertext-only` architecture guard.
+ */
+export function memoryStore(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  let clock = 0
+  const epsilon = 1
+
+  const coll = (vault: string, collection: string): Map<string, EncryptedEnvelope> => {
+    let comp = store.get(vault)
+    if (!comp) { comp = new Map(); store.set(vault, comp) }
+    let c = comp.get(collection)
+    if (!c) { c = new Map(); comp.set(collection, c) }
+    return c
+  }
+
+  return {
+    name: 'memory',
+    capabilities: { casAtomic: true, serverWriteTime: true, auth: { kind: 'none', required: false, flow: 'static' } },
+
+    async getStoreTime(): Promise<StoreTime> {
+      const now = ++clock
+      return { earliest: now - epsilon, latest: now + epsilon }
+    },
+
+    async get(vault, collection, id) {
+      return store.get(vault)?.get(collection)?.get(id) ?? null
+    },
+
+    async put(vault, collection, id, envelope, expectedVersion) {
+      const c = coll(vault, collection)
+      const existing = c.get(id)
+      if (expectedVersion !== undefined && existing && existing._v !== expectedVersion) {
+        throw new ConflictError(existing._v, `Version conflict: expected ${expectedVersion}, found ${existing._v}`)
+      }
+      c.set(id, envelope)
+    },
+
+    async delete(vault, collection, id) {
+      store.get(vault)?.get(collection)?.delete(id)
+    },
+
+    async list(vault, collection) {
+      const c = store.get(vault)?.get(collection)
+      return c ? [...c.keys()] : []
+    },
+
+    async loadAll(vault): Promise<VaultSnapshot> {
+      const comp = store.get(vault)
+      const snapshot: VaultSnapshot = {}
+      if (comp) {
+        for (const [name, c] of comp) {
+          if (name.startsWith('_')) continue // system collections hydrate lazily
+          const records: Record<string, EncryptedEnvelope> = {}
+          for (const [id, envelope] of c) records[id] = envelope
+          snapshot[name] = records
+        }
+      }
+      return snapshot
+    },
+
+    async saveAll(vault, data: VaultSnapshot) {
+      const comp = store.get(vault)
+      if (comp) for (const k of [...comp.keys()]) if (!k.startsWith('_')) comp.delete(k)
+      for (const [name, records] of Object.entries(data)) {
+        const c = coll(vault, name)
+        for (const [id, envelope] of Object.entries(records)) c.set(id, envelope)
+      }
+    },
+  }
+}

--- a/packages/hub/src/store/memory-store.ts
+++ b/packages/hub/src/store/memory-store.ts
@@ -11,11 +11,15 @@ import { ConflictError } from '../errors.js'
  *
  * Portable: imports only `types` + `errors` (no crypto primitive) — passes
  * the `stores-ciphertext-only` architecture guard.
+ *
+ * Implements the 6-method core only (no optional `listVaults`/`ping`/`tx`),
+ * so `Noydb.listAccessibleVaults()` throws its documented capability error
+ * rather than enumerating vaults under the default store.
  */
 export function memoryStore(): NoydbStore {
   const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
   let clock = 0
-  const epsilon = 1
+  const epsilon = 0 // matches @noy-db/to-memory's default clockUncertainty; non-overlapping intervals
 
   const coll = (vault: string, collection: string): Map<string, EncryptedEnvelope> => {
     let comp = store.get(vault)

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -1772,8 +1772,8 @@ export interface StoreCapabilities {
 // ─── Factory Options ───────────────────────────────────────────────────
 
 export interface NoydbOptions {
-  /** Primary store (local storage). */
-  readonly store: NoydbStore
+  /** The ciphertext store. Optional — defaults to the built-in `memoryStore()` (non-persistent). */
+  readonly store?: NoydbStore
   /**
    * tree-shake seam — optional blob strategy. Pass `withBlobs()`
    * from `@noy-db/hub/blobs` to enable `collection.blob(id)` storage.


### PR DESCRIPTION
## What

Add a built-in in-memory `NoydbStore` (`memoryStore()`) to the kernel and make `createNoydb`'s `store` option **optional**, defaulting to it.

```ts
const db = await createNoydb({ secret: '…' })  // ← no `store` needed; in-memory by default
```

## Why

Today `store` is required, so you must install and configure a store package (`@noy-db/to-memory`) just to open a vault. This makes `createNoydb()` work **zero-config** (non-persistent, in-memory) — install a real store (`to-file`, etc.) only when you need persistence. `@noy-db/to-memory` is no longer required to use the DB.

## Changes (3 commits)

- `memoryStore()` — conformant 6-method `NoydbStore` (nested `Map`s, CAS atomicity, monotonic store clock). A faithful kernel subset of `@noy-db/to-memory`'s verified core; imports only `types` + `errors` (passes `stores-ciphertext-only`).
- `NoydbOptions.store` → optional; `createNoydb` injects `memoryStore()` when absent (one injection point, one internal `ResolvedNoydbOptions` narrow). Backward-compatible — callers passing `store` are unaffected.
- Public `memoryStore` export; unit tests (5) + zero-config integration test (1).

## Verification

- `pnpm --filter @noy-db/hub typecheck` clean; P1 tests 6/6; `check:architecture` ✓ — on the vanilla `main` base.
- The ciphertext-only invariant holds: the default store sits at the same pipeline position as any other (hub encrypts before `put()`); it never receives plaintext.

## Follow-up (separate)

Demoting `@noy-db/to-memory` from the 5 essentials is the governance half this enables — a separate change.