### PR TITLE
docs: zero-config createNoydb (built-in in-memory store)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,12 @@ An encrypted, offline-first, **serverless** document store. The library lives in
 
 ## 30-second vanilla example
 
-The minimum — no framework, no cloud, nothing to install beyond two packages:
+The minimum — no framework, no cloud, nothing to install beyond `@noy-db/hub`:
 
 ```ts
 import { createNoydb } from '@noy-db/hub'
-import { memory } from '@noy-db/to-memory'
 
-const db = await createNoydb({
-  store: memory(),
+const db = await createNoydb({       // zero-config: in-memory by default (built-in store)
   user: 'alice',
   secret: 'correct-horse-battery-staple',
 })
@@ -64,6 +62,8 @@ console.log(await invoices.get('inv-001'))   // { id: 'inv-001', amount: 1200 }
 
 await db.close()                               // clears keys from memory
 ```
+
+`createNoydb()` needs no `store` — it uses a **built-in in-memory store** by default (non-persistent). For tests wanting the fuller in-memory backend (adds `listVaults`/`tx`/`listPage`), add **[`@noy-db/to-memory`](docs/packages/to-stores.md)** and pass `store: memory()`.
 
 **Swap storage with one line** — keep the rest identical:
 
@@ -199,14 +199,16 @@ loadAll(vault)
 saveAll(vault, data)
 ```
 
-> If your existing storage can implement these six methods, it can store noy-db ciphertext. That is the full contract — 5 essential `to-*` stores ship here; 16 extended stores (SQL, cloud, remote-FS, personal drives) live in [noy-db-to](https://github.com/vLannaAi/noy-db-to). A custom store is `createStore(opts => ({ name, ...methods }))`.
+> If your existing storage can implement these six methods, it can store noy-db ciphertext. That is the full contract — the kernel ships a **built-in in-memory store** (so `store` is optional for the in-memory case); 5 essential `to-*` stores ship here for persistence and the fuller in-memory backend; 16 extended stores (SQL, cloud, remote-FS, personal drives) live in [noy-db-to](https://github.com/vLannaAi/noy-db-to). A custom store is `createStore(opts => ({ name, ...methods }))`.
 
 ---
 
 ## Install for common scenarios
 
 ```bash
-# Development / testing — in-memory, no persistence
+# Development / testing — in-memory, no persistence (built-in; nothing to add)
+pnpm add @noy-db/hub
+# …or the fuller in-memory test store (adds listVaults / tx / listPage):
 pnpm add @noy-db/hub @noy-db/to-memory
 
 # Local CLI / Node service — files on disk

--- a/SUBSYSTEMS.md
+++ b/SUBSYSTEMS.md
@@ -4,7 +4,7 @@
 
 ## Why subsystems
 
-NOYDB is built as a **minimalist core + opt-in subsystems**. A consumer who calls only `createNoydb({ store, user })` gets a fully working zero-knowledge encrypted document store and pays for nothing else. Every other capability — history, blobs, sync, joins, CRDT — is a subsystem the developer opts into by passing a strategy factory:
+NOYDB is built as a **minimalist core + opt-in subsystems**. A consumer who calls only `createNoydb({ user })` — no `store`, since the kernel ships a built-in in-memory default — gets a fully working zero-knowledge encrypted document store and pays for nothing else. Every other capability — history, blobs, sync, joins, CRDT — is a subsystem the developer opts into by passing a strategy factory:
 
 ```ts
 import { createNoydb } from '@noy-db/hub'

--- a/docs/packages/to-stores.md
+++ b/docs/packages/to-stores.md
@@ -12,11 +12,11 @@ events, multi-user keyrings all work identically over every backend.
 
 ## Essentials (ship in this repo)
 
-The stores 80% of apps start with, plus the tooling pair.
+The stores 80% of apps start with, plus the tooling pair. For the in-memory case the kernel ships a **built-in default store** — `createNoydb()` needs no `store` — so `@noy-db/to-memory` below is the *fuller* in-memory backend, not a prerequisite to start.
 
 | Package | When to use |
 |---|---|
-| [`@noy-db/to-memory`](../../packages/to-memory) | Tests, REPL, ephemeral caches. `casAtomic: true`, `txAtomic: true` — a great sanity backstop. |
+| [`@noy-db/to-memory`](../../packages/to-memory) | **Fuller in-memory store** (the kernel's built-in default already covers basic in-memory). Tests, REPL, ephemeral caches; adds `listVaults` / `tx` / `listPage` over the 6-method built-in. `casAtomic: true`, `txAtomic: true` — a great sanity backstop. |
 | [`@noy-db/to-file`](../../packages/to-file) | Local disk / USB stick. JSON file per record. Also ships `saveBundle` / `loadBundle` and `exportBlobsToDirectory` (target-profile filename sanitization + Zip-Slip path containment). |
 | [`@noy-db/to-browser-idb`](../../packages/to-browser-idb) | IndexedDB in browsers / PWAs. Atomic CAS via single `readwrite` transaction. |
 | [`@noy-db/to-probe`](../../packages/to-probe) | **Diagnostic companion.** Not a backend — runs synthetic benchmarks against any store you pass in and reports on its suitability for a given role (primary, sync-peer, backup, archive). |
@@ -68,7 +68,7 @@ pnpm add @noy-db/to-postgres     # node-postgres
 - **"I have an AWS account."** → `to-aws-dynamo` primary + `to-aws-s3` blobs via `routeStore` (both in noy-db-to).
 - **"I have ssh access to a box."** → `to-ssh` (noy-db-to).
 - **"I'm in Cloudflare Workers."** → `to-cloudflare-d1` + `to-cloudflare-r2` (both in noy-db-to).
-- **"I'm just testing."** → `to-memory`.
+- **"I'm just testing."** → nothing — the built-in in-memory default is enough; reach for `to-memory` only when you need `listVaults` / `tx` / `listPage`.
 
 Don't pick one forever — a vault can sync to multiple `SyncTarget`s with
 different stores, roles, and policies. See the


### PR DESCRIPTION
Follow-up to #499. `createNoydb()` now works with **no `store`** — the kernel ships a built-in in-memory default — so the docs no longer tell you to add `@noy-db/to-memory` just to start.

**Changes (docs only):**
- **README** — 30-second quickstart drops the mandatory `@noy-db/to-memory` import (`createNoydb({ secret })` is zero-config); install section shows in-memory needs nothing extra; store-contract note mentions the built-in default.
- **docs/packages/to-stores.md** — repositions `@noy-db/to-memory` as the *fuller* in-memory backend (adds `listVaults`/`tx`/`listPage` over the 6-method built-in) and the canonical test store, not a prerequisite.
- **SUBSYSTEMS.md** — intro example notes `store` is optional.

`@noy-db/to-memory` still ships as an essential — it's depended on by ~16 packages' test suites and is feature-richer than the built-in. This change is purely the messaging catch-up for the zero-config default.