### PR TITLE
feat(hub): add listPage to built-in memoryStore (scan fast-path)

### DIFF
--- a/packages/hub/__tests__/memory-store.test.ts
+++ b/packages/hub/__tests__/memory-store.test.ts
@@ -49,4 +49,31 @@ describe('memoryStore', () => {
     const t2 = await s.getStoreTime!()
     expect(t2.earliest).toBeGreaterThan(t1.earliest)
   })
+
+  it('listPage returns paginated results with stable sorting (by id) and correct cursor', async () => {
+    const s = memoryStore()
+    // Seed out of lexicographic order so the sort() guarantee is actually exercised
+    // (Map preserves insertion order; without sort, page 1 would be ['c','a']).
+    await s.put('v', 'c', 'c', env(0))
+    await s.put('v', 'c', 'a', env(0))
+    await s.put('v', 'c', 'b', env(0))
+
+    // First page: 2 items (limit 2)
+    const page1 = await s.listPage!('v', 'c', undefined, 2)
+    expect(page1.items).toHaveLength(2)
+    expect(page1.items[0]?.id).toBe('a')
+    expect(page1.items[1]?.id).toBe('b')
+    expect(page1.nextCursor).toBe('2')
+
+    // Second page: 1 item remaining
+    const page2 = await s.listPage!('v', 'c', '2', 2)
+    expect(page2.items).toHaveLength(1)
+    expect(page2.items[0]?.id).toBe('c')
+    expect(page2.nextCursor).toBeNull()
+
+    // Empty collection
+    const emptyPage = await s.listPage!('v', 'nonexistent', undefined, 10)
+    expect(emptyPage.items).toEqual([])
+    expect(emptyPage.nextCursor).toBeNull()
+  })
 })

--- a/packages/hub/src/store/memory-store.ts
+++ b/packages/hub/src/store/memory-store.ts
@@ -1,4 +1,4 @@
-import type { NoydbStore, VaultSnapshot, EncryptedEnvelope, StoreTime } from '../types.js'
+import type { NoydbStore, VaultSnapshot, EncryptedEnvelope, StoreTime, ListPageResult } from '../types.js'
 import { ConflictError } from '../errors.js'
 
 /**
@@ -81,6 +81,21 @@ export function memoryStore(): NoydbStore {
         const c = coll(vault, name)
         for (const [id, envelope] of Object.entries(records)) c.set(id, envelope)
       }
+    },
+
+    async listPage(vault, collection, cursor, limit = 100): Promise<ListPageResult> {
+      const c = store.get(vault)?.get(collection)
+      if (!c) return { items: [], nextCursor: null }
+      const ids = [...c.keys()].sort()
+      const start = cursor ? parseInt(cursor, 10) : 0
+      const end = Math.min(start + limit, ids.length)
+      const items: Array<{ id: string; envelope: EncryptedEnvelope }> = []
+      for (let i = start; i < end; i++) {
+        const id = ids[i]!
+        const envelope = c.get(id)
+        if (envelope) items.push({ id, envelope })
+      }
+      return { items, nextCursor: end < ids.length ? String(end) : null }
     },
   }
 }


### PR DESCRIPTION
Adds the optional `listPage` pagination method to the kernel's built-in `memoryStore()` (from #499), mirroring `@noy-db/to-memory`'s implementation: sorted-id numeric-offset cursor, returns `ListPageResult` (`{ items: {id, envelope}[], nextCursor }`).

This gives the built-in store the `Collection.scan()` streaming fast-path (stores without `listPage` fall back to `loadAll` + slice). Additive, no behavior change to existing paths.

- 1 new test covering pagination across a cursor boundary + empty collection; seeded **out of lexicographic order** so the sort guarantee is actually exercised. 6/6 memory-store tests pass.

No crypto, no new deps.