### PR TITLE
refactor(hub): P2 foundation — storeCiphertext rename + ramCiphertext flag

### DIFF
--- a/packages/hub/__tests__/ram-ciphertext-flag.test.ts
+++ b/packages/hub/__tests__/ram-ciphertext-flag.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/index.js'
+
+describe('ramCiphertext flag', () => {
+  it('collection without ramCiphertext option works normally (default false)', async () => {
+    const db = await createNoydb({ user: 'test-user', secret: 'correct-horse-battery-staple' })
+    const vault = await db.openVault('v1')
+    const items = vault.collection<{ id: string; n: number }>('items')
+    await items.put('1', { id: '1', n: 99 })
+    expect((await items.get('1'))?.n).toBe(99)
+    expect(items._ramCiphertext).toBe(false)
+  })
+
+  it('collection with ramCiphertext: true is accepted and exposed via getter', async () => {
+    const db = await createNoydb({ user: 'test-user', secret: 'correct-horse-battery-staple' })
+    const vault = await db.openVault('v1')
+    const items = vault.collection<{ id: string; n: number }>('items', { ramCiphertext: true })
+    await items.put('1', { id: '1', n: 7 })
+    expect((await items.get('1'))?.n).toBe(7)
+    expect(items._ramCiphertext).toBe(true)
+  })
+})

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -175,6 +175,7 @@ export class Collection<T> {
   private readonly name: string
   private readonly keyring: UnlockedKeyring
   private readonly storeCiphertext: boolean
+  private readonly ramCiphertext: boolean
   private readonly emitter: NoydbEventEmitter
   private readonly writeQueue: WriteQueueTracker | undefined
   private readonly schemaUpdateGate: SchemaUpdateGate | undefined
@@ -617,6 +618,11 @@ export class Collection<T> {
     name: string
     keyring: UnlockedKeyring
     encrypted: boolean
+    /**
+     * Opt-in: keep the working set encrypted in RAM, decrypting on read (future phase).
+     * Default false — the working set is plaintext.
+     */
+    ramCiphertext?: boolean
     emitter: NoydbEventEmitter
     /**
      * Vault-level in-flight write tracker. When present,
@@ -953,6 +959,7 @@ export class Collection<T> {
     this.name = opts.name
     this.keyring = opts.keyring
     this.storeCiphertext = opts.encrypted
+    this.ramCiphertext = opts.ramCiphertext ?? false
     this.emitter = opts.emitter
     this.writeQueue = opts.writeQueue
     this.schemaUpdateGate = opts.schemaUpdateGate
@@ -1371,6 +1378,9 @@ export class Collection<T> {
   _applyMeta(meta: CollectionMeta): void {
     if (this.meta === undefined) this.meta = meta
   }
+
+  /** @internal — used only in tests; do not read in production code. */
+  get _ramCiphertext(): boolean { return this.ramCiphertext }
 
   /**
    * Get a single record by ID.

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -174,7 +174,7 @@ export class Collection<T> {
   private readonly vault: string
   private readonly name: string
   private readonly keyring: UnlockedKeyring
-  private readonly encrypted: boolean
+  private readonly storeCiphertext: boolean
   private readonly emitter: NoydbEventEmitter
   private readonly writeQueue: WriteQueueTracker | undefined
   private readonly schemaUpdateGate: SchemaUpdateGate | undefined
@@ -952,7 +952,7 @@ export class Collection<T> {
     this.vault = opts.vault
     this.name = opts.name
     this.keyring = opts.keyring
-    this.encrypted = opts.encrypted
+    this.storeCiphertext = opts.encrypted
     this.emitter = opts.emitter
     this.writeQueue = opts.writeQueue
     this.schemaUpdateGate = opts.schemaUpdateGate
@@ -1420,7 +1420,7 @@ export class Collection<T> {
         if (!envelope) return null
         // Tombstone tolerance (decision 5): a shredded record carries no
         // body / CEK. Reads return null rather than throwing TamperedError.
-        if (isTombstone(envelope, this.encrypted)) return null
+        if (isTombstone(envelope, this.storeCiphertext)) return null
         record = await this.decryptRecord(envelope, { id })
         if (record === null) return null
         this.lru.set(id, { record, version: envelope._v }, estimateRecordBytes(record))
@@ -1509,7 +1509,7 @@ export class Collection<T> {
       vault: this.vault,
       collectionName: this.name,
       userId: this.keyring.userId,
-      encrypted: this.encrypted,
+      encrypted: this.storeCiphertext,
       getDEK: this.getDEK,
     }
     if (this.syncAdapter !== undefined) presenceOpts.syncAdapter = this.syncAdapter
@@ -2173,7 +2173,7 @@ export class Collection<T> {
       if (cached) raw = cached.record
       else {
         const env = await this.adapter.get(this.vault, this.name, id)
-        if (!env || isTombstone(env, this.encrypted)) return null
+        if (!env || isTombstone(env, this.storeCiphertext)) return null
         raw = await this.decryptRecord(env, { id })
         if (raw === null) return null
         this.lru.set(id, { record: raw, version: env._v }, estimateRecordBytes(raw))
@@ -2549,7 +2549,7 @@ export class Collection<T> {
     let count = 0
     for (const id of ids) {
       const env = await this.adapter.get(this.vault, this.name, id)
-      if (!env || isTombstone(env, this.encrypted)) continue
+      if (!env || isTombstone(env, this.storeCiphertext)) continue
       const decoded = await this.decryptRecord(env, { skipValidation: true, id })
       if (decoded === null) continue // defensive: shredded between list and get
       const record = decoded as unknown as Record<string, unknown>
@@ -2829,7 +2829,7 @@ export class Collection<T> {
 
   async _writeTombstone(id: string, actor: string): Promise<{ previousVersion: number } | null> {
     const live = await this.adapter.get(this.vault, this.name, id)
-    if (!live || isTombstone(live, this.encrypted)) return null
+    if (!live || isTombstone(live, this.storeCiphertext)) return null
 
     await this.adapter.put(this.vault, this.name, id, buildTombstone(live._v, actor))
 
@@ -4030,7 +4030,7 @@ export class Collection<T> {
     const ids = await this.adapter.list(this.vault, this.name)
     for (const id of ids) {
       const envelope = await this.adapter.get(this.vault, this.name, id)
-      if (envelope && !isTombstone(envelope, this.encrypted)) {
+      if (envelope && !isTombstone(envelope, this.storeCiphertext)) {
         const record = await this.decryptRecord(envelope, { id })
         if (record === null) continue
         this.cache.set(id, { record, version: envelope._v })
@@ -4044,7 +4044,7 @@ export class Collection<T> {
   /** Hydrate from a pre-loaded snapshot (used by Vault). */
   async hydrateFromSnapshot(records: Record<string, EncryptedEnvelope>): Promise<void> {
     for (const [id, envelope] of Object.entries(records)) {
-      if (isTombstone(envelope, this.encrypted)) continue
+      if (isTombstone(envelope, this.storeCiphertext)) continue
       const record = await this.decryptRecord(envelope, { id })
       if (record === null) continue
       this.cache.set(id, { record, version: envelope._v })
@@ -4335,7 +4335,7 @@ export class Collection<T> {
       collection: this.name,
       recordId: id,
       getDEK: this.getDEK,
-      encrypted: this.encrypted,
+      encrypted: this.storeCiphertext,
       userId: this.keyring.userId,
       erasableBlobs: this.perRecordCek,
       debugPlaintext: this.keyring.debugPlaintext === true,
@@ -4883,7 +4883,7 @@ export class Collection<T> {
       ? { _source: source, _sourceTs: sourceTs ?? new Date().toISOString() }
       : {}
 
-    if (!this.encrypted) {
+    if (!this.storeCiphertext) {
       return {
         _noydb: NOYDB_FORMAT_VERSION,
         _v: version,
@@ -4936,11 +4936,11 @@ export class Collection<T> {
     // beside the envelope metadata so native store tools read them directly.
     // Internal (`_`-prefixed) collections keep the classic shape — some store
     // `_`-prefixed fields that the inline layout would collide with.
-    if (!this.encrypted && this.keyring.debugPlaintext === true && !this.name.startsWith('_')) {
+    if (!this.storeCiphertext && this.keyring.debugPlaintext === true && !this.name.startsWith('_')) {
       return this.buildDebugEnvelope(record, version, source, sourceTs)
     }
     const base = await this.encryptJsonString(JSON.stringify(record), version, cek, source, sourceTs)
-    if (!this.deterministicFields || !this.encrypted) return base
+    if (!this.deterministicFields || !this.storeCiphertext) return base
 
     // compute deterministic-ciphertext slots for every
     // declared field. Non-primitive values are JSON-stringified so
@@ -4978,7 +4978,7 @@ export class Collection<T> {
         `Collection "${this.name}": field "${field}" is not declared in deterministicFields`,
       )
     }
-    if (!this.encrypted) {
+    if (!this.storeCiphertext) {
       throw new Error(
         `Collection "${this.name}": findByDet is only meaningful on encrypted collections`,
       )
@@ -5009,7 +5009,7 @@ export class Collection<T> {
         `Collection "${this.name}": field "${field}" is not declared in deterministicFields`,
       )
     }
-    if (!this.encrypted) {
+    if (!this.storeCiphertext) {
       throw new Error(
         `Collection "${this.name}": queryByDet is only meaningful on encrypted collections`,
       )
@@ -5336,10 +5336,10 @@ export class Collection<T> {
     // `_cek`. Decrypting it would call `decrypt('', '', dek)` → AES-GCM
     // OperationError → TamperedError. Return null so every read callsite
     // treats it as "absent / skip", matching how get()/list already drop
-    // tombstones. Legacy plaintext collections (`!this.encrypted`) legitimately
+    // tombstones. Legacy plaintext collections (`!this.storeCiphertext`) legitimately
     // have empty `_iv`/`_data`, so `isTombstone` is false for them — preserved.
-    if (isTombstone(envelope, this.encrypted)) return null
-    if (!this.encrypted) {
+    if (isTombstone(envelope, this.storeCiphertext)) return null
+    if (!this.storeCiphertext) {
       // Debug-plaintext layout: record fields were inlined as top-level keys
       // (see buildDebugEnvelope). Reconstruct the record from the non-`_`
       // keys. Self-describing via `_debug`, so a classic plaintext reader

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -780,6 +780,11 @@ export class Vault {
      * derived collections. Defaults to the vault-wide `history` config. See #361.
      */
     historyConfig?: HistoryConfig
+    /**
+     * Opt-in: keep the working set encrypted in RAM, decrypting on read (future phase).
+     * Default false — the working set is plaintext.
+     */
+    ramCiphertext?: boolean
   }): Collection<T> {
     // Overlay intercept. When the requested collection name
     // matches a registered `withOverlayedView`, return the virtual
@@ -1033,6 +1038,7 @@ export class Vault {
         collOpts.perRecordKeys = true
       }
       if (options?.provenance !== undefined) collOpts.provenance = options.provenance
+      if (options?.ramCiphertext !== undefined) collOpts.ramCiphertext = options.ramCiphertext
       if (options?.tiers !== undefined) collOpts.tiers = options.tiers
       if (options?.tierMode !== undefined) collOpts.tierMode = options.tierMode
       collOpts.onCrossTierAccess = (event) => this.emitCrossTier(event)

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -504,7 +504,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 5401→5457 (#483 Task 4): CollectionConfig import + getConfig() aggregator (reads existing private fields, no new state)
   // Bumped 5457→5473 (#483 review follow-up): historyConfigExplicit private field + opts flag for presence-semantic history in getConfig()
   // Bumped 5473→5486 (#484 Task 2): toJSONSchema() thin delegator + buildJsonSchema/derivePersistedSchema imports (logic lives in json-schema.ts)
-  'packages/hub/src/collection.ts': 5486,
+  // Bumped 5486→5496 (storage-arch P2 foundation): ramCiphertext opt-in flag — field + opts + doc-comment + test getter. The documented hook for the future ciphertext-resident-working-set phase (default false, no behavior change). P2-T3 (StoreEdgeCodec extraction) moves crypto logic OUT of this file.
+  'packages/hub/src/collection.ts': 5496,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -581,7 +582,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 4621→4633 (#483 Task 1): meta option in CollectionOptions + _applyMeta reconcile in cached-collection branch + meta threading into new Collection() opts
   // Bumped 4633→4650 (#483 Task 2): vaultMeta field + getMeta() getter + constructor opts + _introspectState() wiring
   // Bumped 4650→4659 (#483 review follow-up): historyConfigExplicit threading + archive/schemaUpdate accessors in _introspectState()
-  'packages/hub/src/vault.ts': 4659,
+  // Bumped 4659→4665 (storage-arch P2 foundation): plumb ramCiphertext through vault.collection() to collOpts (TS declaration + pass-through) so the opt-in flag is reachable/testable. Minimal necessary plumbing.
+  'packages/hub/src/vault.ts': 4665,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),


### PR DESCRIPTION
First, behavior-preserving slice of the storage-architecture epic (P2). **No functional change** — sets up the store-edge codec work.

- **Rename** `Collection`'s internal `this.encrypted` → `this.storeCiphertext` (17 sites; identical logic). The public option name `encrypted` is unchanged; `Vault`'s separate `encrypted` field is untouched. Clarifies that the flag means *the store holds ciphertext*.
- **Plumb** a new `ramCiphertext` option (default **false**, **read nowhere** that changes behavior) — the documented hook for the future ciphertext-resident-working-set phase.

Behavior-preserving: zero new test failures (the 5 pre-existing `@noy-db/on-shamir` failures are unrelated, present before+after). New: 1 flag test (default-false + settable, real round-trip assertions).

Spec: `docs/superpowers/specs/2026-06-28-edge-crypto-storage-architecture.md` §3, §8. Reviewed (rename faithful & complete; flag provably inert).