### PR TITLE
feat(hub): structural group-encryption — per-field _sealed storage

### DIFF
--- a/packages/hub/__tests__/group-encryption.test.ts
+++ b/packages/hub/__tests__/group-encryption.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest'
+import {
+  generateDEK,
+  deriveSealedFieldKey,
+  encrypt,
+  decrypt,
+} from '../src/crypto.js'
+import { createNoydb } from '../src/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { ConflictError } from '../src/index.js'
+
+interface Person {
+  id: string
+  name: string
+  ssn?: string
+  dob?: string
+}
+
+function memoryStore(): NoydbStore & { _data: Map<string, Map<string, Map<string, EncryptedEnvelope>>> } {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    _data: data,
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll(v, snap) {
+      const vm = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [cn, recs] of Object.entries(snap)) {
+        const cm = new Map<string, EncryptedEnvelope>()
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+        vm.set(cn, cm)
+      }
+      data.set(v, vm)
+    },
+  }
+}
+
+describe('crypto — deriveSealedFieldKey', () => {
+  it('derives a usable AES-GCM key that round-trips', async () => {
+    const dek = await generateDEK()
+    const key = await deriveSealedFieldKey(dek, 'people', 'ssn')
+    const { iv, data } = await encrypt(JSON.stringify('123-45-6789'), key)
+    expect(JSON.parse(await decrypt(iv, data, key))).toBe('123-45-6789')
+  })
+
+  it('derives different keys per field (isolation)', async () => {
+    const dek = await generateDEK()
+    const keyA = await deriveSealedFieldKey(dek, 'people', 'ssn')
+    const keyB = await deriveSealedFieldKey(dek, 'people', 'dob')
+    const { iv, data } = await encrypt(JSON.stringify('secret'), keyA)
+    // ciphertext sealed under field a must NOT decrypt under field b's key
+    await expect(decrypt(iv, data, keyB)).rejects.toThrow()
+  })
+
+  it('derives different keys per collection', async () => {
+    const dek = await generateDEK()
+    const keyP = await deriveSealedFieldKey(dek, 'people', 'ssn')
+    const keyC = await deriveSealedFieldKey(dek, 'clients', 'ssn')
+    const { iv, data } = await encrypt(JSON.stringify('secret'), keyP)
+    await expect(decrypt(iv, data, keyC)).rejects.toThrow()
+  })
+})
+
+describe('collection — group-encryption (_sealed)', () => {
+  it('round-trips a record with a sensitive field', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, secret: 'pw', user: 'owner' })
+    const v = await db.openVault('v1', { passphrase: 'pw' })
+    const people = v.collection<Person>('people', { sensitive: ['ssn'] })
+
+    const original: Person = { id: 'p1', name: 'Alice', ssn: '123-45-6789' }
+    await people.put('p1', original)
+
+    const got = await people.get('p1')
+    expect(got).toEqual(original)
+  })
+
+  it('stores the sensitive field in _sealed, out of the open _data blob', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, secret: 'pw', user: 'owner' })
+    const v = await db.openVault('v1', { passphrase: 'pw' })
+    const people = v.collection<Person>('people', { sensitive: ['ssn'] })
+
+    await people.put('p1', { id: 'p1', name: 'Alice', ssn: '123-45-6789' })
+
+    const env = await store.get('v1', 'people', 'p1')
+    expect(env).not.toBeNull()
+    expect(env!._sealed).toBeDefined()
+    expect(env!._sealed!.ssn).toMatch(/^[A-Za-z0-9+/=]+:[A-Za-z0-9+/=]+$/)
+    // non-sensitive fields are NOT promoted into _sealed
+    expect(env!._sealed!.name).toBeUndefined()
+
+    // Prove ssn is NOT inside the open _data blob: strip _sealed from the
+    // stored envelope and re-read with a fresh instance (no decrypt cache).
+    // If ssn lived in _data it would survive; it must not.
+    const raw = store._data.get('v1')!.get('people')!.get('p1')!
+    const stripped: Record<string, unknown> = { ...raw }
+    delete stripped._sealed
+    store._data.get('v1')!.get('people')!.set('p1', stripped as unknown as EncryptedEnvelope)
+
+    const db2 = await createNoydb({ store, secret: 'pw', user: 'owner' })
+    const v2 = await db2.openVault('v1', { passphrase: 'pw' })
+    const people2 = v2.collection<Person>('people', { sensitive: ['ssn'] })
+    const partial = await people2.get('p1')
+    expect(partial).not.toBeNull()
+    expect(partial!.name).toBe('Alice')
+    expect(partial!.ssn).toBeUndefined()
+  })
+
+  it('seals every present sensitive field under its own key', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, secret: 'pw', user: 'owner' })
+    const v = await db.openVault('v1', { passphrase: 'pw' })
+    const people = v.collection<Person>('people', { sensitive: ['ssn', 'dob'] })
+
+    const original: Person = { id: 'p1', name: 'Alice', ssn: '111', dob: '1990-01-01' }
+    await people.put('p1', original)
+
+    const env = await store.get('v1', 'people', 'p1')
+    expect(env!._sealed!.ssn).toBeDefined()
+    expect(env!._sealed!.dob).toBeDefined()
+    // distinct ciphertext per field
+    expect(env!._sealed!.ssn).not.toBe(env!._sealed!.dob)
+
+    expect(await people.get('p1')).toEqual(original)
+  })
+
+  it('omits absent sensitive fields from _sealed', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, secret: 'pw', user: 'owner' })
+    const v = await db.openVault('v1', { passphrase: 'pw' })
+    const people = v.collection<Person>('people', { sensitive: ['ssn', 'dob'] })
+
+    const original: Person = { id: 'p1', name: 'Bob' }
+    await people.put('p1', original)
+
+    const env = await store.get('v1', 'people', 'p1')
+    // no sensitive fields present → no _sealed map at all
+    expect(env!._sealed).toBeUndefined()
+    expect(await people.get('p1')).toEqual(original)
+  })
+
+  it('default-off: no sensitive option → no _sealed key, classic envelope shape', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, secret: 'pw', user: 'owner' })
+    const v = await db.openVault('v1', { passphrase: 'pw' })
+    const people = v.collection<Person>('people')
+
+    await people.put('p1', { id: 'p1', name: 'Alice', ssn: '123-45-6789' })
+
+    const env = await store.get('v1', 'people', 'p1')
+    expect(env).not.toBeNull()
+    expect('_sealed' in env!).toBe(false)
+    // classic encrypted-envelope keys only
+    expect(Object.keys(env!).sort()).toEqual(['_by', '_data', '_iv', '_noydb', '_ts', '_v'])
+  })
+})

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -15,7 +15,7 @@ import type { ComputedFields } from './computed/index.js'
 import { evalComputedFields } from './computed/index.js'
 import { NO_I18N, type I18nStrategy } from './i18n/strategy.js'
 import { resolvePolicy } from './i18n/policy.js'
-import { encrypt, decrypt, encryptDeterministic } from './crypto.js'
+import { encrypt, decrypt, encryptDeterministic, deriveSealedFieldKey } from './crypto.js'
 import {
   wrapCek,
   unwrapCek,
@@ -436,6 +436,14 @@ export class Collection<T> {
    * is inactive for this collection; a frozen `Set` otherwise.
    */
   private readonly deterministicFields: ReadonlySet<string> | null
+
+  /**
+   * Declared structural-group-encryption fields (`sensitive`). Each is
+   * sealed into its own `_sealed[field]` slot under a per-field key and kept
+   * out of the open `_data` blob. Empty set ⇒ feature off (byte-identical
+   * output). See {@link encryptRecord} / {@link decryptRecord}. (#503)
+   */
+  private readonly sensitiveFields: ReadonlySet<string>
 
   /**
    * Per-record CEK opt-in (`perRecordKeys: true`). When set, writes mint /
@@ -870,6 +878,15 @@ export class Collection<T> {
      */
     acknowledgeDeterministicRisk?: boolean | undefined
     /**
+     * Structural group-encryption (#503). Fields listed here are
+     * encrypted into their own `_sealed[field]` envelope slot — each under
+     * an HKDF-derived per-field key — instead of sitting inside the open
+     * `_data` blob. Default-off: with no `sensitive` fields the envelope is
+     * byte-identical to today. Read merges them back inline (the
+     * `Sealed<V>`/`reveal()` access restriction is a separate follow-up).
+     */
+    sensitive?: readonly string[] | undefined
+    /**
      * Per-record content-encryption keys. When `true`, every record body
      * (and every history version of it) is encrypted under a fresh
      * per-record CEK, AES-KW-wrapped under the collection DEK and stored
@@ -1050,6 +1067,12 @@ export class Collection<T> {
     } else {
       this.deterministicFields = null
     }
+
+    // structural group-encryption wiring (#503): the set of fields sealed
+    // into `_sealed` per-field slots. Empty when the option is absent.
+    this.sensitiveFields = opts.sensitive && opts.sensitive.length > 0
+      ? Object.freeze(new Set(opts.sensitive))
+      : Object.freeze(new Set<string>())
 
     // per-record CEK wiring. The cache is bounded by record count; CEKs
     // are tiny CryptoKey handles, so a generous entry budget is cheap.
@@ -4949,24 +4972,55 @@ export class Collection<T> {
     if (!this.storeCiphertext && this.keyring.debugPlaintext === true && !this.name.startsWith('_')) {
       return this.buildDebugEnvelope(record, version, source, sourceTs)
     }
-    const base = await this.encryptJsonString(JSON.stringify(record), version, cek, source, sourceTs)
-    if (!this.deterministicFields || !this.storeCiphertext) return base
+
+    // Structural group-encryption (#503): peel declared sensitive fields out
+    // of the record BEFORE building `_data`, sealing each into its own
+    // `_sealed[field]` slot under a per-field key. Default-off — with no
+    // sensitive fields the open record is unchanged and no `_sealed` is
+    // emitted, so the envelope stays byte-identical to legacy output.
+    let openRecord = record
+    let sealed: Record<string, string> | undefined
+    if (this.storeCiphertext && this.sensitiveFields.size > 0) {
+      const src = record as unknown as Record<string, unknown>
+      const dek = await this.getDEK(this.name)
+      const open: Record<string, unknown> = { ...src }
+      const slots: Record<string, string> = {}
+      for (const field of this.sensitiveFields) {
+        if (!(field in src)) continue
+        const value = src[field]
+        if (value === undefined) continue
+        const fieldKey = await deriveSealedFieldKey(dek, this.name, field)
+        const { iv, data } = await encrypt(JSON.stringify(value), fieldKey)
+        slots[field] = `${iv}:${data}`
+        delete open[field]
+      }
+      if (Object.keys(slots).length > 0) {
+        sealed = slots
+        openRecord = open as unknown as T
+      }
+    }
+
+    const base = await this.encryptJsonString(JSON.stringify(openRecord), version, cek, source, sourceTs)
+    const withSealed = sealed ? { ...base, _sealed: sealed } : base
+    if (!this.deterministicFields || !this.storeCiphertext) return withSealed
 
     // compute deterministic-ciphertext slots for every
     // declared field. Non-primitive values are JSON-stringified so
-    // objects/arrays still dedupe on structural equality.
+    // objects/arrays still dedupe on structural equality. Sealed fields are
+    // excluded — they live only in `_sealed`, never the `_det` index.
     const dek = await this.getDEK(this.name)
     const rec = record as unknown as Record<string, unknown>
     const det: Record<string, string> = {}
     for (const field of this.deterministicFields) {
+      if (this.sensitiveFields.has(field)) continue
       const value = rec[field]
       if (value === undefined || value === null) continue
       const plaintext = typeof value === 'string' ? value : JSON.stringify(value)
       const { iv, data } = await encryptDeterministic(plaintext, dek, `${this.name}/${field}`)
       det[field] = `${iv}:${data}`
     }
-    if (Object.keys(det).length === 0) return base
-    return { ...base, _det: det }
+    if (Object.keys(det).length === 0) return withSealed
+    return { ...withSealed, _det: det }
   }
 
   /**
@@ -5405,6 +5459,22 @@ export class Collection<T> {
     }
 
     let record = parsed as T
+
+    // Structural group-encryption (#503): merge sealed fields back inline.
+    // Each `_sealed[field]` slot is decrypted under its own per-field key
+    // and JSON-parsed, restoring the complete record before schema
+    // validation. (The `Sealed<V>`/`reveal()` access gate is a follow-up.)
+    if (envelope._sealed !== undefined && this.storeCiphertext) {
+      const dek = await this.getDEK(this.name)
+      const target = record as unknown as Record<string, unknown>
+      for (const [field, blob] of Object.entries(envelope._sealed)) {
+        const sep = blob.indexOf(':')
+        const iv = blob.slice(0, sep)
+        const data = blob.slice(sep + 1)
+        const fieldKey = await deriveSealedFieldKey(dek, this.name, field)
+        target[field] = JSON.parse(await decrypt(iv, data, fieldKey))
+      }
+    }
 
     if (this.schema !== undefined && !opts.skipValidation) {
       // Context string deliberately avoids leaking the record id — the

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -884,6 +884,11 @@ export class Collection<T> {
      * `_data` blob. Default-off: with no `sensitive` fields the envelope is
      * byte-identical to today. Read merges them back inline (the
      * `Sealed<V>`/`reveal()` access restriction is a separate follow-up).
+     *
+     * **Incompatible with `perRecordKeys`/forget-cascade (#304):** sealed
+     * field keys derive off the *collection* DEK, not the per-record CEK, so
+     * crypto-shredding a record does not erase its sealed fields. Full
+     * per-record sealing is tracked in #306.
      */
     sensitive?: readonly string[] | undefined
     /**
@@ -1078,6 +1083,28 @@ export class Collection<T> {
     // are tiny CryptoKey handles, so a generous entry budget is cheap.
     this.perRecordCek = opts.perRecordKeys === true
     this.cekCache = this.perRecordCek ? new Lru<string, CryptoKey>({ maxRecords: 4096 }) : null
+
+    // Fix 1: guard the forget-cascade / per-record-CEK incompatibility with
+    // sealed sensitive fields (#304 × #503). Sealed-field keys derive off the
+    // collection DEK (getDEK), not the per-record CEK, so crypto-shredding a
+    // record erases _data but leaves _sealed[field] recoverable.
+    if (this.sensitiveFields.size > 0 && this.perRecordCek) {
+      console.warn(
+        `[noy-db] collection "${opts.name}": sealed \`sensitive\` fields derive off the ` +
+        `collection DEK and are NOT covered by per-record crypto-shred (#304) until ` +
+        `record-scoped sealing (#306) — forgetting a record leaves its sealed fields recoverable.`,
+      )
+    }
+
+    // Fix 3: warn when `sensitive` is a no-op in debug-plaintext mode. When
+    // storeCiphertext is false the sealing path is skipped entirely, so
+    // sensitive fields are written in plaintext.
+    if (this.sensitiveFields.size > 0 && !this.storeCiphertext) {
+      console.warn(
+        `[noy-db] collection "${opts.name}": \`sensitive\` fields are NOT sealed in ` +
+        `plaintext (debug) mode — they are written unencrypted.`,
+      )
+    }
 
     // per-record provenance opt-in (FR-5). Zero cost when off.
     this.provenance = opts.provenance === true

--- a/packages/hub/src/crypto.ts
+++ b/packages/hub/src/crypto.ts
@@ -452,12 +452,14 @@ export async function derivePresenceKey(dek: CryptoKey, collectionName: string):
  *
  * Domain-separated from the data DEK (and from the presence/deterministic
  * channels) by the fixed salt `'noydb-sealed'` and an `info` of
- * `` `${collectionName}/sealed/${field}` ``. The field name in the `info`
- * means each sensitive field gets a **distinct** key, so a `_sealed[a]`
- * ciphertext does not authenticate under field `b`'s key — sealed fields
- * are cryptographically isolated from one another. The collection name keeps
- * the same field name in two collections from sharing a key, mirroring how
- * `derivePresenceKey` / `encryptDeterministic` domain-separate.
+ * `JSON.stringify(['noydb-sealed', collectionName, field])`. The JSON-array
+ * encoding is injective — each element is separately quoted/escaped — so
+ * collection `a/sealed/b` + field `c` cannot collide with collection `a` +
+ * field `b/sealed/c`. Each sensitive field gets a **distinct** key, so a
+ * `_sealed[a]` ciphertext does not authenticate under field `b`'s key —
+ * sealed fields are cryptographically isolated from one another. The
+ * collection name keeps the same field name in two collections from sharing a
+ * key, mirroring how `derivePresenceKey` / `encryptDeterministic` domain-separate.
  *
  * @param dek            The collection's AES-256-GCM DEK (extractable).
  * @param collectionName Part of the HKDF `info` for domain separation.
@@ -472,7 +474,10 @@ export async function deriveSealedFieldKey(
   const rawDek = await subtle.exportKey('raw', dek)
   const hkdfKey = await subtle.importKey('raw', rawDek, 'HKDF', false, ['deriveBits'])
   const salt = new TextEncoder().encode('noydb-sealed')
-  const info = new TextEncoder().encode(`${collectionName}/sealed/${field}`)
+  // JSON-array encoding is injective: each element is separately quoted/
+  // escaped, so collection `a/sealed/b` + field `c` cannot collide with
+  // collection `a` + field `b/sealed/c`.
+  const info = new TextEncoder().encode(JSON.stringify(['noydb-sealed', collectionName, field]))
   const bits = await subtle.deriveBits(
     { name: 'HKDF', hash: 'SHA-256', salt, info },
     hkdfKey,

--- a/packages/hub/src/crypto.ts
+++ b/packages/hub/src/crypto.ts
@@ -443,6 +443,50 @@ export async function derivePresenceKey(dek: CryptoKey, collectionName: string):
   )
 }
 
+// ─── Sealed Field Key Derivation ──────────────────────────
+
+/**
+ * Derive a **per-field** AES-256-GCM key from a collection DEK using
+ * HKDF-SHA256, used to encrypt a single sensitive field into its own
+ * `_sealed[field]` envelope slot (structural group-encryption, #503).
+ *
+ * Domain-separated from the data DEK (and from the presence/deterministic
+ * channels) by the fixed salt `'noydb-sealed'` and an `info` of
+ * `` `${collectionName}/sealed/${field}` ``. The field name in the `info`
+ * means each sensitive field gets a **distinct** key, so a `_sealed[a]`
+ * ciphertext does not authenticate under field `b`'s key — sealed fields
+ * are cryptographically isolated from one another. The collection name keeps
+ * the same field name in two collections from sharing a key, mirroring how
+ * `derivePresenceKey` / `encryptDeterministic` domain-separate.
+ *
+ * @param dek            The collection's AES-256-GCM DEK (extractable).
+ * @param collectionName Part of the HKDF `info` for domain separation.
+ * @param field          Sensitive field name — the rest of the `info`.
+ * @returns A non-extractable AES-256-GCM key for that field's sealed slot.
+ */
+export async function deriveSealedFieldKey(
+  dek: CryptoKey,
+  collectionName: string,
+  field: string,
+): Promise<CryptoKey> {
+  const rawDek = await subtle.exportKey('raw', dek)
+  const hkdfKey = await subtle.importKey('raw', rawDek, 'HKDF', false, ['deriveBits'])
+  const salt = new TextEncoder().encode('noydb-sealed')
+  const info = new TextEncoder().encode(`${collectionName}/sealed/${field}`)
+  const bits = await subtle.deriveBits(
+    { name: 'HKDF', hash: 'SHA-256', salt, info },
+    hkdfKey,
+    KEY_BITS,
+  )
+  return subtle.importKey(
+    'raw',
+    bits,
+    { name: 'AES-GCM', length: KEY_BITS },
+    false,
+    ['encrypt', 'decrypt'],
+  )
+}
+
 // ─── Deterministic Encryption ────────────────────────────
 
 /**

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -160,6 +160,18 @@ export interface EncryptedEnvelope {
    */
   readonly _det?: Record<string, string>
   /**
+   * Structural group-encryption (#503). Map of sensitive field name →
+   * per-field sealed ciphertext in `iv:data` form (same shape as a `_det`
+   * slot). Present only when the collection declares `sensitive` fields and
+   * at least one is present on the record. Each field is encrypted under its
+   * own HKDF-derived per-field key (`deriveSealedFieldKey`, domain-separated
+   * by `<collection>/sealed/<field>`), and is kept OUT of the open `_data`
+   * blob — so a reader who can open `_data` still cannot see sealed fields
+   * without re-deriving each field key. With no sensitive fields declared the
+   * map is absent and `_data` is unchanged (byte-identical to legacy output).
+   */
+  readonly _sealed?: Record<string, string>
+  /**
    * Per-record content-encryption key (CEK), base64 AES-KW-wrapped under
    * the collection (or tier) DEK. Present only on records written by a
    * collection opened with `perRecordKeys: true`. When present, the body

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -722,6 +722,12 @@ export class Vault {
     /** — explicit ack that deterministic encryption leaks equality. */
     acknowledgeDeterministicRisk?: boolean
     /**
+     * — structural group-encryption (#503). Fields sealed into their own
+     * `_sealed[field]` envelope slot (per-field key), kept out of the open
+     * `_data` blob. Default-off; byte-identical output when absent.
+     */
+    sensitive?: readonly string[]
+    /**
      * — per-record content-encryption keys. When `true`, every record
      * body is encrypted under a fresh per-record CEK wrapped under the
      * collection DEK (`_cek`), stable across versions. Foundation for
@@ -1019,6 +1025,9 @@ export class Vault {
       }
       if (options?.acknowledgeDeterministicRisk !== undefined) {
         collOpts.acknowledgeDeterministicRisk = options.acknowledgeDeterministicRisk
+      }
+      if (options?.sensitive !== undefined) {
+        collOpts.sensitive = options.sensitive
       }
       if (options?.perRecordKeys !== undefined) {
         collOpts.perRecordKeys = options.perRecordKeys

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -506,7 +506,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 5473→5486 (#484 Task 2): toJSONSchema() thin delegator + buildJsonSchema/derivePersistedSchema imports (logic lives in json-schema.ts)
   // Bumped 5486→5496 (storage-arch P2 foundation): ramCiphertext opt-in flag — field + opts + doc-comment + test getter. The documented hook for the future ciphertext-resident-working-set phase (default false, no behavior change). P2-T3 (StoreEdgeCodec extraction) moves crypto logic OUT of this file.
   // Bumped 5496→5566 (#503 structural group-encryption): sensitive-field sealing is genuine crypto core — the write path peels declared `sensitive` fields out of `_data` and seals each into `_sealed[field]` under a per-field key, the read path re-merges them, plus the `sensitiveFields` set + `sensitive` opt + doc-comments. The per-field key derivation lives in crypto.ts (`deriveSealedFieldKey`); only the per-record encrypt/decrypt orchestration is here, beside the existing `_det`/`_cek` seams it mirrors.
-  'packages/hub/src/collection.ts': 5566,
+  // Bumped 5566→5593 (P3 safety fixes): three constructor guards — forget-cascade/perRecordCek incompatibility warn, debug-plaintext no-op warn, doc-comment note on #306. All are defensive one-time console.warn calls; no behavior change to default-off paths.
+  'packages/hub/src/collection.ts': 5593,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -505,7 +505,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 5457→5473 (#483 review follow-up): historyConfigExplicit private field + opts flag for presence-semantic history in getConfig()
   // Bumped 5473→5486 (#484 Task 2): toJSONSchema() thin delegator + buildJsonSchema/derivePersistedSchema imports (logic lives in json-schema.ts)
   // Bumped 5486→5496 (storage-arch P2 foundation): ramCiphertext opt-in flag — field + opts + doc-comment + test getter. The documented hook for the future ciphertext-resident-working-set phase (default false, no behavior change). P2-T3 (StoreEdgeCodec extraction) moves crypto logic OUT of this file.
-  'packages/hub/src/collection.ts': 5496,
+  // Bumped 5496→5566 (#503 structural group-encryption): sensitive-field sealing is genuine crypto core — the write path peels declared `sensitive` fields out of `_data` and seals each into `_sealed[field]` under a per-field key, the read path re-merges them, plus the `sensitiveFields` set + `sensitive` opt + doc-comments. The per-field key derivation lives in crypto.ts (`deriveSealedFieldKey`); only the per-record encrypt/decrypt orchestration is here, beside the existing `_det`/`_cek` seams it mirrors.
+  'packages/hub/src/collection.ts': 5566,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -583,7 +584,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 4633→4650 (#483 Task 2): vaultMeta field + getMeta() getter + constructor opts + _introspectState() wiring
   // Bumped 4650→4659 (#483 review follow-up): historyConfigExplicit threading + archive/schemaUpdate accessors in _introspectState()
   // Bumped 4659→4665 (storage-arch P2 foundation): plumb ramCiphertext through vault.collection() to collOpts (TS declaration + pass-through) so the opt-in flag is reachable/testable. Minimal necessary plumbing.
-  'packages/hub/src/vault.ts': 4665,
+  // Bumped 4665→4674 (#503 structural group-encryption): plumb the `sensitive` collection option through vault.collection() to collOpts (TS declaration + doc-comment + pass-through), mirroring deterministicFields. Minimal necessary plumbing; the sealing crypto lives in collection.ts/crypto.ts.
+  'packages/hub/src/vault.ts': 4674,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),


### PR DESCRIPTION
P3 (storage-architecture epic, §4.1): a collection can declare `sensitive: string[]` fields, which are encrypted **separately** into a per-field `_sealed` envelope slot (each under its own HKDF-derived key) and kept OUT of `_data` and the `_det` index. **Default-off**: no sensitive fields → no `_sealed`, output **byte-identical** to today.

## Crypto (opus-reviewed: Approved, no Critical)
- `deriveSealedFieldKey` (crypto.ts): HKDF-SHA256 off the collection DEK, salt `noydb-sealed` + **injective** info `JSON.stringify(['noydb-sealed', collection, field])` (domain separation, no key reuse). Fresh IV per encryption (no nonce reuse). Non-extractable keys.
- Sensitive fields removed from `_data` AND skipped in `_det`; history/snapshot writes seal too. Field isolation = genuine AES-GCM auth failure (tested). Round-trip merges before schema validation.

## Safety guards added (from review)
- **warn** when `sensitive` is combined with per-record CEK / forget-cascade — sealed fields derive off the collection DEK, so they're not covered by per-record crypto-shred until record-scoped sealing (#306). Documented on the option.
- **warn** when `sensitive` is set in debug-plaintext mode (fields written unencrypted).

## Scope / verification
- 2901 hub tests pass, 0 failures (5 pre-existing `on-shamir` dist-build failures unrelated, pass after building); group-encryption tests 8/8; typecheck clean; `check:architecture` ✓.
- Default-off byte-identity asserted by test.
- **Follow-ups (noted, not in this PR):** `Sealed<V>`/`reveal()` access gate; #306 record-scoped sealing (forget coverage); extract `sealRecord()`/`unsealRecord()` helpers (collection.ts grew ~97 lines — against the kernel-shrink goal).

Spec: `docs/superpowers/specs/2026-06-28-edge-crypto-storage-architecture.md` §4.1, §6.2.