### PR TITLE
feat(hub): compile-time refusal of sensitive fields in where/orderBy/scan/index (P3-T5)

### DIFF
--- a/docs/superpowers/plans/2026-06-29-p3-t5-compile-time-sensitive-field-refusal.md
+++ b/docs/superpowers/plans/2026-06-29-p3-t5-compile-time-sensitive-field-refusal.md
@@ -1,0 +1,541 @@
+# Compile-Time Sensitive-Field Refusal (P3-T5) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `@noy-db/hub` refuse a collection's declared `sensitive` fields at **compile time** in the query/scan/index DSLs (`Query.where`/`.orderBy`, `ScanBuilder.where`, `LazyQuery.where`/`.orderBy`, and the `indexes`/`deterministicFields`/`textIndexes` collection options), turning today's silent runtime-seal into a `tsc` error.
+
+**Architecture:** Type-only change. The runtime already seals `sensitive` fields out of `_data`/`_det`, so `where('ssn', …)` already returns nothing — this plan adds the compile-time gate. We thread the existing `S` (the sensitive-field union, already on `Collection<T, S>`) through the three query builders (`Query<T, S>`, `ScanBuilder<T, S>`, `LazyQuery<T, S>`), and narrow each field-name parameter to a new `QueryField<T, S>` type. The narrowing is **guarded** — `[S] extends [never] ? string : Exclude<keyof T & string, S>` — so collections that declare **no** sensitive fields keep the permissive `field: string` signature unchanged (zero churn for existing consumers); only collections that opt into `sensitive: [...]` get strict field typing.
+
+**Tech Stack:** TypeScript 5.9 (`*.test-d.ts` type-tests enforced by `tsc --noEmit -p tsconfig.typetest.json`, run via `pnpm --filter @noy-db/hub typecheck:types`), tsup (DTS build), pnpm + turbo.
+
+> **Type-test gate (READ — the plan's verification mechanism):** Type-tests in this repo are **NOT** run by vitest `--typecheck`. They are `*.test-d.ts` files included by `packages/hub/tsconfig.typetest.json` and validated by `pnpm --filter @noy-db/hub typecheck:types` (= `tsc --noEmit -p tsconfig.typetest.json`). Under `tsc`, an **unused `@ts-expect-error` is a hard error (TS2578)** and an `expectTypeOf<…>().toEqualTypeOf<…>()` mismatch is a type error — so the red→green cycle works: a negative test goes RED with `TS2578: Unused '@ts-expect-error' directive` until the refusal is implemented, then GREEN. The full `pnpm --filter @noy-db/hub typecheck` runs BOTH `tsc --noEmit` (src) and the type-test config. Wherever a step below says to run the type-test, use `pnpm --filter @noy-db/hub typecheck:types`.
+
+## Global Constraints
+
+- **Type-only.** No runtime behavior change. Do not touch any `.where()`/`.orderBy()`/`new Query()` runtime body except to change a parameter's TYPE annotation. Runtime sealing already exists; this is purely the compile-time gate.
+- **`S` defaults to `never` everywhere.** Every builder generic is `<T, S extends keyof T = never>`. Every existing single-arg reference (`Query<T>`, `ScanBuilder<T>`, `LazyQuery<T>`, `Collection<T>`) MUST keep compiling unchanged — there are ~26 `Query<T>` references in `builder.ts` alone and ~446 consumer call sites that must be untouched.
+- **Guarded narrowing.** `QueryField<T, S> = [S] extends [never] ? string : Exclude<keyof T & string, S>`. A collection with no `sensitive` declaration (S = never) gets `string` — byte-identical DX to today. Verify this property with a type-test in every task.
+- **No new public method.** The escape hatch for a sensitive collection that genuinely needs a dynamic field string is a documented cast: `where(field as QueryField<T, S>, …)`. Do not add a `whereDynamic`/`whereUnchecked` method.
+- **Run `node scripts/check-architecture.mjs` before every commit** (kernel-surface line-count ratchet on `collection.ts`/`vault.ts`/`noydb.ts`; bump a ceiling only with a `// Bumped X→Y (reason)` comment if a genuine core line is added).
+- **Final gate runs the FULL monorepo typecheck** (`pnpm typecheck`), not just `@noy-db/hub` — a public return/param type change ripples into showcases and sibling packages (this is exactly how the prior `SealedView` regression escaped a hub-only check).
+
+---
+
+### Task 1: The `QueryField<T, S>` + `IndexFieldName<T, S>` type aliases
+
+**Files:**
+- Modify: `packages/hub/src/types.ts` (add the two aliases next to `SealedView`, ~line 233)
+- Test: `packages/hub/__tests__/query-field-type.test-d.ts` (create)
+
+**Interfaces:**
+- Produces:
+  - `export type QueryField<T, S extends keyof T = never> = [S] extends [never] ? string : Exclude<keyof T & string, S>`
+  - `export type IndexFieldName<T, S extends keyof T = never> = [S] extends [never] ? string : Exclude<keyof T & string, S>`
+  - (Both have the same definition today; they are kept as two names so the query-DSL narrowing and the index-option narrowing can evolve independently — e.g. a future `Q = indexed-only` restriction on `QueryField` without touching index declarations.)
+
+- [ ] **Step 1: Write the failing type-test**
+
+Create `packages/hub/__tests__/query-field-type.test-d.ts`:
+
+```ts
+import { describe, it, expectTypeOf } from 'vitest'
+import type { QueryField, IndexFieldName } from '../src/types.js'
+
+interface Person { id: string; name: string; ssn: string; age: number }
+
+describe('QueryField<T, S>', () => {
+  it('is permissive `string` when no sensitive fields (S = never)', () => {
+    // The zero-churn guarantee: collections without `sensitive` keep `field: string`.
+    expectTypeOf<QueryField<Person>>().toEqualTypeOf<string>()
+    expectTypeOf<QueryField<Person, never>>().toEqualTypeOf<string>()
+  })
+
+  it('narrows to non-sensitive field names when S is populated', () => {
+    expectTypeOf<QueryField<Person, 'ssn'>>().toEqualTypeOf<'id' | 'name' | 'age'>()
+  })
+
+  it('IndexFieldName mirrors QueryField', () => {
+    expectTypeOf<IndexFieldName<Person>>().toEqualTypeOf<string>()
+    expectTypeOf<IndexFieldName<Person, 'ssn'>>().toEqualTypeOf<'id' | 'name' | 'age'>()
+  })
+})
+```
+
+- [ ] **Step 2: Run the type-test to verify it fails**
+
+Run: `pnpm --filter @noy-db/hub typecheck:types`
+Expected: FAIL — `Cannot find name 'QueryField'` / module has no exported member `QueryField`.
+
+- [ ] **Step 3: Add the aliases to `types.ts`**
+
+In `packages/hub/src/types.ts`, immediately after the `SealedView` definition (the block ending around line 233), add:
+
+```ts
+/**
+ * The type of a field-name argument to the query/scan DSL (`where`, `orderBy`,
+ * …) for a collection whose sealed (`sensitive`) fields are `S`.
+ *
+ * Guarded so the common case is unchanged: with **no** sensitive fields
+ * (`S = never`) it is exactly `string` — collections that don't opt into
+ * `sensitive` keep today's permissive DSL, zero churn. Once a field is
+ * declared `sensitive`, the DSL narrows to the non-sensitive field names, so
+ * `where('ssn', …)` becomes a compile error. TypeScript cannot subtract a
+ * literal from `string`, so refusing a sensitive name necessarily means
+ * narrowing to the known field-name union — this is intentional and only
+ * affects collections that opted in.
+ */
+export type QueryField<T, S extends keyof T = never> = [S] extends [never]
+  ? string
+  : Exclude<keyof T & string, S>
+
+/**
+ * The type of a field-name reference in a collection's index-declaration
+ * options (`indexes`, `deterministicFields`, `textIndexes`). Same guarded
+ * narrowing as {@link QueryField}: permissive `string` until a field is
+ * declared `sensitive`, then the sensitive names are refused (a plaintext
+ * secondary index over a sealed field defeats non-residency — previously only
+ * a runtime `console.warn`). Kept distinct from `QueryField` so the two DSL
+ * surfaces can diverge later without coupling.
+ */
+export type IndexFieldName<T, S extends keyof T = never> = [S] extends [never]
+  ? string
+  : Exclude<keyof T & string, S>
+```
+
+- [ ] **Step 4: Run the type-test to verify it passes**
+
+Run: `pnpm --filter @noy-db/hub typecheck:types`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Architecture check + commit**
+
+```bash
+node scripts/check-architecture.mjs   # Expected: ✓ Architecture invariants OK
+git add packages/hub/src/types.ts packages/hub/__tests__/query-field-type.test-d.ts
+git commit -m "feat(hub): QueryField<T,S> / IndexFieldName<T,S> field-name types (guarded, default-permissive)"
+```
+
+---
+
+### Task 2: Thread `S` through `Query<T, S>` and narrow `where`/`orderBy`
+
+**Files:**
+- Modify: `packages/hub/src/query/builder.ts` (class header line 138; `where` line 280; `orderBy` line 359; `or` line 299; `and` line 321; `filter` line 340; `join` line 450; `crossJoin` line 525; `wherePredicate` line 238; and every internal `new Query<T>(...)` within the class)
+- Modify: `packages/hub/src/collection.ts:3616` (`query()` overload return type) and `:3670` (`new Query<T>(...)` construction)
+- Test: `packages/hub/__tests__/sealed-query-refusal.test-d.ts` (create — Query portion; ScanBuilder/LazyQuery/index portions are appended in later tasks)
+
+**Interfaces:**
+- Consumes: `QueryField<T, S>` from Task 1.
+- Produces:
+  - `export class Query<T, S extends keyof T = never>` — `S` is phantom (type-only; no constructor param, no runtime field).
+  - `where(field: QueryField<T, S>, op: Operator, value: unknown): Query<T, S>`
+  - `orderBy(field: QueryField<T, S>, direction?: 'asc' | 'desc', opts?: { by?: 'value' | 'label' }): Query<T, S>`
+  - All chaining methods return `Query<T, S>` (or `Query<T & …, S>` for joins), preserving `S` down the chain.
+  - `collection.query(): Query<T, S>` (the no-arg overload only; the predicate overload returning `T[]` is unchanged).
+
+- [ ] **Step 1: Write the failing type-test**
+
+Create `packages/hub/__tests__/sealed-query-refusal.test-d.ts`:
+
+```ts
+import { describe, it, expectTypeOf } from 'vitest'
+import { createNoydb } from '../src/index.js'
+import { memoryStore } from '../src/store/memory-store.js'
+
+interface Person { id: string; name: string; ssn: string; age: number }
+
+// A vault opened for type-level assertions only (never awaited at runtime here).
+async function typedVault() {
+  const db = createNoydb({ store: memoryStore() })
+  const vault = await db.openVault('v', { passphrase: 'x'.repeat(12) })
+  return vault
+}
+
+describe('Query sensitive-field refusal', () => {
+  it('refuses where() on a sensitive field, allows non-sensitive', async () => {
+    const vault = await typedVault()
+    const people = vault.collection<Person>('people', { sensitive: ['ssn'] })
+    const q = people.query()
+    // @ts-expect-error — 'ssn' is sealed; refused at compile time
+    q.where('ssn', '==', 'x')
+    q.where('name', '==', 'Ada')        // ok
+    q.orderBy('age', 'desc')            // ok
+    // @ts-expect-error — orderBy on a sealed field is refused
+    q.orderBy('ssn')
+  })
+
+  it('keeps where() permissive on a collection with no sensitive fields', async () => {
+    const vault = await typedVault()
+    const plain = vault.collection<Person>('plain')
+    // No `sensitive` → field stays `string`, every existing call still compiles.
+    plain.query().where('ssn', '==', 'x').orderBy('whatever-string')
+    expectTypeOf(plain.query().where).parameter(0).toEqualTypeOf<string>()
+  })
+})
+```
+
+- [ ] **Step 2: Run the type-test to verify it fails**
+
+Run: `pnpm --filter @noy-db/hub typecheck:types`
+Expected: FAIL with `TS2578: Unused '@ts-expect-error' directive` — because `where('ssn', …)` currently compiles (today's `field: string`), so the directive catches nothing. `tsc` flags every unused `@ts-expect-error` as a hard error; that is the RED phase.
+
+- [ ] **Step 3: Add `S` to the `Query` class and narrow the field params**
+
+In `packages/hub/src/query/builder.ts`:
+
+1. Change the class header (line 138):
+```ts
+export class Query<T, S extends keyof T = never> {
+```
+
+2. Add the import at the top of the file (join the existing `from '../types.js'` import if present, else add):
+```ts
+import type { QueryField } from '../types.js'
+```
+
+3. Change `where` (line 280) — only the signature line; the body is unchanged except the `new Query<T>` → `new Query<T, S>`:
+```ts
+  where(field: QueryField<T, S>, op: Operator, value: unknown): Query<T, S> {
+```
+…and inside its body change `return new Query<T>(` to `return new Query<T, S>(`.
+
+4. Change `orderBy` (line 359):
+```ts
+  orderBy(field: QueryField<T, S>, direction: 'asc' | 'desc' = 'asc', opts?: { by?: 'value' | 'label' }): Query<T, S> {
+```
+…and `new Query<T>(` → `new Query<T, S>(` in its body.
+
+5. For the remaining chaining methods, change the return annotation `Query<T>` → `Query<T, S>` and every internal `new Query<T>(` → `new Query<T, S>(`:
+   - `filter(fn: (record: T) => boolean): Query<T, S>` (line 340)
+   - `wherePredicate(name: string, ctx?: unknown): Query<T, S>` (line 238)
+   - `or(builder: (q: Query<T, S>) => Query<T, S>): Query<T, S>` (line 299) — change BOTH the callback param type and the return.
+   - `and(builder: (q: Query<T, S>) => Query<T, S>): Query<T, S>` (line 321) — same.
+   - `join<As extends string, R = unknown>(field: QueryField<T, S>, opts: {…}): Query<T & Record<As, R | null>, S>` (line 450) — narrow `field`, carry `S` into the widened record type (`S extends keyof T` still holds because `keyof T ⊆ keyof (T & …)`).
+   - `crossJoin<…>(target: string, opts: {…}): Query<T & { [K in As]: TTarget }, S>` (line 525) — `target` is an external collection name, NOT a field of `T`; leave it `string`, only change the return annotation to carry `S`.
+
+   > Note: `groupBy` (line 808) and `aggregate` (line 721) return `GroupedQuery`/`Aggregation`, which do **not** carry `S`. Leave their signatures unchanged — grouping/aggregating by a sensitive field is a separate leak vector, explicitly out of scope for this plan (record it in the progress ledger as a follow-up). `groupBy`'s `field: F extends string` stays `string`.
+
+6. Inside any other method body in the class that does `new Query<T>(`, change it to `new Query<T, S>(` (sweep the file — there are ~13). Since `S` is phantom, `new Query<T, S>(...sameArgs)` type-checks with no runtime change.
+
+In `packages/hub/src/collection.ts`:
+
+7. Change the no-arg `query()` overload (line 3616) from `query(): Query<T>` to:
+```ts
+  query(): Query<T, S>
+```
+Leave the `query(predicate): T[]` overload and the implementation signature `query(predicate?: …): Query<T> | T[]` unchanged (the impl signature is not part of the public type). At the construction site (line 3670) change `return new Query<T>(` to `return new Query<T, S>(`.
+
+- [ ] **Step 4: Run the type-test to verify it passes**
+
+Run: `pnpm --filter @noy-db/hub typecheck:types`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Verify no hub-internal regression (the zero-churn property)**
+
+Run: `pnpm --filter @noy-db/hub typecheck`
+Expected: PASS — every existing `Query<T>` reference still resolves (S defaults to never). If anything in hub fails here, it is a real regression, not a consumer issue — fix it before committing.
+
+- [ ] **Step 6: Architecture check + commit**
+
+```bash
+node scripts/check-architecture.mjs
+git add packages/hub/src/query/builder.ts packages/hub/src/collection.ts packages/hub/__tests__/sealed-query-refusal.test-d.ts
+git commit -m "feat(hub): thread S through Query<T,S>; refuse sealed fields in where/orderBy"
+```
+
+---
+
+### Task 3: Thread `S` through `ScanBuilder<T, S>` and narrow `where`
+
+**Files:**
+- Modify: `packages/hub/src/query/scan-builder.ts` (class header line 99; `where` line 170; `filter` line 193; `join` line 286; every internal `new ScanBuilder<T>(...)`)
+- Modify: `packages/hub/src/collection.ts:4026` (`scan()` return type) and its `new ScanBuilder<T>(...)` construction site(s)
+- Test: append to `packages/hub/__tests__/sealed-query-refusal.test-d.ts`
+
+**Interfaces:**
+- Consumes: `QueryField<T, S>` (Task 1).
+- Produces:
+  - `export class ScanBuilder<T, S extends keyof T = never> implements AsyncIterable<T>`
+  - `where(field: QueryField<T, S>, op: Operator, value: unknown): ScanBuilder<T, S>`
+  - `collection.scan(opts?): ScanBuilder<T, S>`
+
+- [ ] **Step 1: Add the failing type-test (append a new `describe`)**
+
+Append to `packages/hub/__tests__/sealed-query-refusal.test-d.ts`:
+
+```ts
+describe('ScanBuilder sensitive-field refusal', () => {
+  it('refuses scan().where() on a sensitive field', async () => {
+    const vault = await typedVault()
+    const people = vault.collection<Person>('people', { sensitive: ['ssn'] })
+    const s = people.scan()
+    // @ts-expect-error — sealed field refused in scan
+    s.where('ssn', '==', 'x')
+    s.where('age', '>', 18)  // ok
+  })
+
+  it('keeps scan().where() permissive without sensitive fields', async () => {
+    const vault = await typedVault()
+    const plain = vault.collection<Person>('plain')
+    plain.scan().where('any-string', '==', 1)  // still `string`
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @noy-db/hub typecheck:types`
+Expected: FAIL — the new `@ts-expect-error` is unused (scan `where('ssn')` currently compiles).
+
+- [ ] **Step 3: Add `S` to `ScanBuilder` and narrow `where`**
+
+In `packages/hub/src/query/scan-builder.ts`:
+1. Add import: `import type { QueryField } from '../types.js'`
+2. Class header (line 99): `export class ScanBuilder<T, S extends keyof T = never> implements AsyncIterable<T> {`
+3. `where` (line 170): `where(field: QueryField<T, S>, op: Operator, value: unknown): ScanBuilder<T, S> {` and `new ScanBuilder<T>(` → `new ScanBuilder<T, S>(` in the body.
+4. `filter` (line 193): return `ScanBuilder<T, S>`; `new ScanBuilder<T>(` → `new ScanBuilder<T, S>(`.
+5. `join` (line 286): `join<As extends string, R = unknown>(field: QueryField<T, S>, opts: { as: As }): ScanBuilder<T & Record<As, R | null>, S>` — narrow `field`, carry `S`; `new ScanBuilder<…>` updated accordingly.
+6. Sweep every other `new ScanBuilder<T>(` in the class → `new ScanBuilder<T, S>(`.
+7. Leave `aggregate` (line 581) and `[Symbol.asyncIterator]` (line 339) signatures unchanged (no field-name param; iterator yields `T`).
+
+In `packages/hub/src/collection.ts`:
+8. `scan(opts: { pageSize?: number } = {}): ScanBuilder<T, S> {` (line 4026), and change its `new ScanBuilder<T>(` construction site(s) to `new ScanBuilder<T, S>(`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm --filter @noy-db/hub typecheck:types`
+Expected: PASS (4 tests total now).
+
+- [ ] **Step 5: Hub typecheck + architecture check + commit**
+
+```bash
+pnpm --filter @noy-db/hub typecheck     # Expected: PASS
+node scripts/check-architecture.mjs
+git add packages/hub/src/query/scan-builder.ts packages/hub/src/collection.ts packages/hub/__tests__/sealed-query-refusal.test-d.ts
+git commit -m "feat(hub): thread S through ScanBuilder<T,S>; refuse sealed fields in scan().where"
+```
+
+---
+
+### Task 4: Thread `S` through `LazyQuery<T, S>` and narrow `where`/`orderBy`
+
+**Files:**
+- Modify: `packages/hub/src/indexing/lazy-builder.ts` (class header line 63; `where` line 72; `orderBy` line 80; every internal `new LazyQuery<T>(...)`)
+- Modify: `packages/hub/src/collection.ts:4928` (`lazyQuery()` return type) and its `new LazyQuery<T>(...)` site
+- Test: append to `packages/hub/__tests__/sealed-query-refusal.test-d.ts`
+
+**Interfaces:**
+- Consumes: `QueryField<T, S>` (Task 1).
+- Produces:
+  - `export class LazyQuery<T, S extends keyof T = never>`
+  - `where<V>(field: QueryField<T, S>, op: Operator, value: V): LazyQuery<T, S>`
+  - `orderBy(field: QueryField<T, S>, direction?: 'asc' | 'desc'): LazyQuery<T, S>`
+  - `collection.lazyQuery(): LazyQuery<T, S>`
+
+- [ ] **Step 1: Add the failing type-test (append)**
+
+Append to `packages/hub/__tests__/sealed-query-refusal.test-d.ts`:
+
+```ts
+describe('LazyQuery sensitive-field refusal', () => {
+  it('refuses lazyQuery().where()/orderBy() on a sensitive field', async () => {
+    const db = createNoydb({ store: memoryStore() })
+    const vault = await db.openVault('lz', { passphrase: 'x'.repeat(12) })
+    // lazyQuery requires lazy mode (prefetch: false)
+    const people = vault.collection<Person>('people', { sensitive: ['ssn'], prefetch: false })
+    const lq = people.lazyQuery()
+    // @ts-expect-error — sealed field refused in lazy where
+    lq.where('ssn', '==', 'x')
+    lq.where('name', '==', 'Ada')   // ok
+    // @ts-expect-error — sealed field refused in lazy orderBy
+    lq.orderBy('ssn')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @noy-db/hub typecheck:types`
+Expected: FAIL — new `@ts-expect-error` directives unused.
+
+- [ ] **Step 3: Add `S` to `LazyQuery` and narrow the field params**
+
+In `packages/hub/src/indexing/lazy-builder.ts`:
+1. Add import: `import type { QueryField } from '../types.js'` (note: `lazy-builder.ts` is one level under `src/indexing/`, so the path is `'../types.js'`; confirm the relative depth and adjust if the file resolves `types` differently).
+2. Class header (line 63): `export class LazyQuery<T, S extends keyof T = never> {`
+3. `where` (line 72): `where<V>(field: QueryField<T, S>, op: Operator, value: V): LazyQuery<T, S> {` and `new LazyQuery<T>(` → `new LazyQuery<T, S>(`.
+4. `orderBy` (line 80): `orderBy(field: QueryField<T, S>, direction: 'asc' | 'desc' = 'asc'): LazyQuery<T, S> {` and `new LazyQuery<T>(` → `new LazyQuery<T, S>(`.
+5. Sweep any remaining `new LazyQuery<T>(` in the class → `new LazyQuery<T, S>(`.
+
+In `packages/hub/src/collection.ts`:
+6. `lazyQuery(): LazyQuery<T, S> {` (line 4928) and change its `new LazyQuery<T>(` site to `new LazyQuery<T, S>(`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm --filter @noy-db/hub typecheck:types`
+Expected: PASS (5 tests total).
+
+- [ ] **Step 5: Hub typecheck + architecture check + commit**
+
+```bash
+pnpm --filter @noy-db/hub typecheck
+node scripts/check-architecture.mjs
+git add packages/hub/src/indexing/lazy-builder.ts packages/hub/src/collection.ts packages/hub/__tests__/sealed-query-refusal.test-d.ts
+git commit -m "feat(hub): thread S through LazyQuery<T,S>; refuse sealed fields in lazy where/orderBy"
+```
+
+---
+
+### Task 5: Narrow the `indexes` / `deterministicFields` / `textIndexes` collection options
+
+**Files:**
+- Modify: `packages/hub/src/vault.ts` (the `collection<T, const S …>({ … })` option object, ~lines 684–794 — specifically `indexes`, `deterministicFields`, `textIndexes`)
+- Modify: `packages/hub/src/types.ts` (add an `IndexDefFor<F>` generic mirroring the runtime `IndexDef` shape)
+- Test: append to `packages/hub/__tests__/sealed-query-refusal.test-d.ts`
+
+**Interfaces:**
+- Consumes: `IndexFieldName<T, S>` (Task 1), and the runtime `IndexDef` shape from `packages/hub/src/indexing/eager-indexes.ts:34` (`string | { fields: readonly string[]; unique?: boolean } | readonly string[]`).
+- Produces:
+  - `export type IndexDefFor<F extends string> = F | { readonly fields: readonly F[]; readonly unique?: boolean } | readonly F[]`
+  - `vault.collection`'s `indexes?: readonly IndexDefFor<IndexFieldName<T, S[number]>>[]`, `deterministicFields?: readonly IndexFieldName<T, S[number]>[]`, `textIndexes?: readonly IndexFieldName<T, S[number]>[]`.
+  - Because `S[number]` is `never` when no `sensitive` option is given, all three stay `IndexDefFor<string>` / `readonly string[]` — unchanged for non-sensitive collections.
+
+- [ ] **Step 1: Add the failing type-test (append)**
+
+Append to `packages/hub/__tests__/sealed-query-refusal.test-d.ts`:
+
+```ts
+describe('index-declaration sensitive-field refusal', () => {
+  it('refuses indexing / det-encrypting / text-indexing a sensitive field', async () => {
+    const vault = await typedVault()
+    vault.collection<Person>('a', {
+      sensitive: ['ssn'],
+      // @ts-expect-error — cannot put a sealed field in a plaintext index
+      indexes: ['ssn'],
+    })
+    vault.collection<Person>('b', {
+      sensitive: ['ssn'],
+      // @ts-expect-error — cannot put a sealed field in a composite index
+      indexes: [{ fields: ['name', 'ssn'] }],
+    })
+    vault.collection<Person>('c', {
+      sensitive: ['ssn'],
+      // @ts-expect-error — sealed field cannot be deterministically encrypted here
+      deterministicFields: ['ssn'],
+    })
+    // Non-sensitive fields index fine on the same collection:
+    vault.collection<Person>('d', { sensitive: ['ssn'], indexes: ['name', 'age'] })
+  })
+
+  it('keeps index options permissive without sensitive fields', async () => {
+    const vault = await typedVault()
+    vault.collection<Person>('e', { indexes: ['anything', { fields: ['x', 'y'] }] })
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pnpm --filter @noy-db/hub typecheck:types`
+Expected: FAIL — the four `@ts-expect-error` directives are unused (today the options are `IndexDef[]` / `readonly string[]`, which accept `'ssn'`).
+
+- [ ] **Step 3: Add `IndexDefFor` and narrow the three options**
+
+In `packages/hub/src/types.ts`, after `IndexFieldName` (Task 1), add:
+
+```ts
+/**
+ * Generic form of the runtime `IndexDef` (see `indexing/eager-indexes.ts`)
+ * parameterised by the allowed field-name set `F`. Used to refuse `sensitive`
+ * fields in the `indexes` collection option at compile time while leaving the
+ * runtime `IndexDef` (string-based) untouched.
+ */
+export type IndexDefFor<F extends string> =
+  | F
+  | { readonly fields: readonly F[]; readonly unique?: boolean }
+  | readonly F[]
+```
+
+In `packages/hub/src/vault.ts`, in the `collection<T, const S …>` option object:
+- `indexes?: readonly IndexDefFor<IndexFieldName<T, S[number]>>[]` (was `IndexDef[]`)
+- `deterministicFields?: readonly IndexFieldName<T, S[number]>[]` (was `readonly string[]`)
+- `textIndexes?: readonly IndexFieldName<T, S[number]>[]` (was `readonly string[]`)
+
+Add `IndexFieldName, IndexDefFor` to the existing `import type { … } from './types.js'` in `vault.ts`. Keep the runtime body that reads `opts.indexes` unchanged (it already handles `string | string[] | { fields }`).
+
+> If a build error appears where `vault.ts` passes `opts.indexes` into a function typed `IndexDef[]`, add a single localized cast at that internal boundary (`opts.indexes as IndexDef[]`) — the narrowing is a compile-time-only restriction on the public option; the internal index machinery still accepts the wider runtime shape.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pnpm --filter @noy-db/hub typecheck:types`
+Expected: PASS (7 tests total).
+
+- [ ] **Step 5: Hub typecheck + architecture check + commit**
+
+```bash
+pnpm --filter @noy-db/hub typecheck
+node scripts/check-architecture.mjs
+git add packages/hub/src/types.ts packages/hub/src/vault.ts packages/hub/__tests__/sealed-query-refusal.test-d.ts
+git commit -m "feat(hub): refuse sealed fields in indexes/deterministicFields/textIndexes options"
+```
+
+---
+
+### Task 6: Full-monorepo verification + consumer fixups + runtime regression check
+
+**Files:**
+- Modify (only as needed): `packages/in-rest/src/query-params.ts:64,67` and any other consumer the full typecheck flags.
+- Modify (only if a real core line was added): `scripts/check-architecture.mjs` (kernel-surface ceiling — with a justification comment).
+- Docs: `packages/hub/docs/subsystems/` is NOT in scope; add a short note to the existing sealed/sensitive doc if one exists (see Step 4).
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–5.
+
+- [ ] **Step 1: Build hub DTS (needed so sibling packages resolve the new types)**
+
+Run: `NODE_OPTIONS="--max-old-space-size=8192" pnpm --filter @noy-db/hub build`
+Expected: `hub build OK` (the DTS worker needs the larger heap locally; CI has it by default).
+
+- [ ] **Step 2: Full monorepo typecheck — surface ALL consumer breakage**
+
+Run: `NODE_OPTIONS="--max-old-space-size=8192" pnpm typecheck`
+Expected: initially FAILS in consumers that pass a raw `string` field to a query on a **sensitive** collection (most consumers are non-sensitive and unaffected). The known candidate is `packages/in-rest/src/query-params.ts` (it builds `result.where(field, op, …)` from a raw HTTP `string`). This only breaks if `apply<T>` is ever instantiated with a sensitive `S`; if `Query<T>`’s `S` defaults to `never` there, it stays permissive and does NOT break. Read each error before changing anything.
+
+- [ ] **Step 3: Fix each flagged consumer with the documented escape-hatch cast**
+
+For any consumer that legitimately passes a dynamic field string into a query whose `S` is non-`never`, cast at the call site using the exported type. Example for `in-rest` IF flagged:
+
+```ts
+// packages/in-rest/src/query-params.ts
+import type { QueryField } from '@noy-db/hub'
+// …
+result = result.where(field as QueryField<T>, op, value as T[keyof T & string])
+```
+
+Do **not** widen the builder types to fix a consumer — the consumer is the right place for the cast (it is the one erasing field-name type information from an HTTP string). If a consumer fix is more than a localized cast, stop and escalate — it means a builder signature is wrong.
+
+- [ ] **Step 4: Document the escape hatch**
+
+If a sealed/sensitive subsystem doc exists (search `packages/hub/docs` and `SUBSYSTEMS.md` for "sealed"/"sensitive"), add a short paragraph: sensitive fields are refused at compile time in `where`/`orderBy`/`scan`/index options; for a genuinely dynamic field name on a sensitive collection, cast via `field as QueryField<T, S>`. If no such doc exists, skip — do not create a new doc file (out of scope).
+
+- [ ] **Step 5: Run the FULL hub test suite — prove zero runtime change**
+
+Run: `pnpm --filter @noy-db/hub test`
+Expected: PASS at the same count as before this plan (the change is type-only; any runtime delta is a bug). Also run the type-tests explicitly: `pnpm --filter @noy-db/hub typecheck:types` → all `*.test-d.ts` clean.
+
+- [ ] **Step 6: Final architecture check + commit**
+
+```bash
+node scripts/check-architecture.mjs     # Expected: ✓ (bump a ceiling only with a justification comment if a real core line was added)
+git add -A
+git commit -m "test(hub): full-monorepo typecheck green for sensitive-field refusal; consumer casts"
+```
+
+---
+
+## Notes for the executor
+
+- **The whole change is type-only.** If you find yourself altering a `.where()`/`.orderBy()` runtime body beyond `new Query<T>` → `new Query<T, S>`, stop — you are out of scope.
+- **The zero-churn property is the most important invariant.** After every task, `pnpm --filter @noy-db/hub typecheck` must stay green. If a hub-internal `Query<T>`/`ScanBuilder<T>` reference breaks, S did not default correctly — fix the default, don't sprinkle casts.
+- **`@ts-expect-error` is the test.** A passing type-test means the directive caught a real compile error. If a directive becomes "unused," the refusal regressed.
+- **Out of scope (record as ledger follow-ups):** `groupBy`/`aggregate`/`join`-target sensitive refusal; the `Q = indexed-only` query restriction (full P3-T5); narrowing `refs`/`i18nFields`/`moneyFields`/`dictKeyFields` keys; the runtime `console.warn` at `collection.ts:1114` can stay (defense in depth) or be removed once compile-time refusal lands — leave it for now.

--- a/docs/superpowers/plans/2026-06-29-p3-t5-compile-time-sensitive-field-refusal.md
+++ b/docs/superpowers/plans/2026-06-29-p3-t5-compile-time-sensitive-field-refusal.md
@@ -484,12 +484,23 @@ git commit -m "feat(hub): refuse sealed fields in indexes/deterministicFields/te
 ### Task 6: Full-monorepo verification + consumer fixups + runtime regression check
 
 **Files:**
+- Modify: `packages/hub/src/index.ts` (add `QueryField` / `IndexFieldName` to the public barrel — see Step 0).
 - Modify (only as needed): `packages/in-rest/src/query-params.ts:64,67` and any other consumer the full typecheck flags.
 - Modify (only if a real core line was added): `scripts/check-architecture.mjs` (kernel-surface ceiling — with a justification comment).
 - Docs: `packages/hub/docs/subsystems/` is NOT in scope; add a short note to the existing sealed/sensitive doc if one exists (see Step 4).
 
 **Interfaces:**
 - Consumes: everything from Tasks 1–5.
+
+- [ ] **Step 0: Export `QueryField` / `IndexFieldName` from the public barrel**
+
+`packages/hub/src/index.ts` uses **explicit named re-exports** from `./types.js` (there is no `export *`). The new types are NOT yet on the public surface, so the consumer cast in Step 3 (`import type { QueryField } from '@noy-db/hub'`) would not resolve. Add them to an existing `export type { … } from './types.js'` block in `packages/hub/src/index.ts` (e.g. next to the other DSL/query type exports):
+
+```ts
+export type { QueryField, IndexFieldName } from './types.js'
+```
+
+(`SealedView`/`Sealed`/`SealedHandle` being absent from the barrel is a separate pre-existing gap from #504 — do NOT add those here; out of scope.)
 
 - [ ] **Step 1: Build hub DTS (needed so sibling packages resolve the new types)**
 

--- a/docs/superpowers/plans/2026-06-29-p3-t5-compile-time-sensitive-field-refusal.md
+++ b/docs/superpowers/plans/2026-06-29-p3-t5-compile-time-sensitive-field-refusal.md
@@ -4,7 +4,9 @@
 
 **Goal:** Make `@noy-db/hub` refuse a collection's declared `sensitive` fields at **compile time** in the query/scan/index DSLs (`Query.where`/`.orderBy`, `ScanBuilder.where`, `LazyQuery.where`/`.orderBy`, and the `indexes`/`deterministicFields`/`textIndexes` collection options), turning today's silent runtime-seal into a `tsc` error.
 
-**Architecture:** Type-only change. The runtime already seals `sensitive` fields out of `_data`/`_det`, so `where('ssn', …)` already returns nothing — this plan adds the compile-time gate. We thread the existing `S` (the sensitive-field union, already on `Collection<T, S>`) through the three query builders (`Query<T, S>`, `ScanBuilder<T, S>`, `LazyQuery<T, S>`), and narrow each field-name parameter to a new `QueryField<T, S>` type. The narrowing is **guarded** — `[S] extends [never] ? string : Exclude<keyof T & string, S>` — so collections that declare **no** sensitive fields keep the permissive `field: string` signature unchanged (zero churn for existing consumers); only collections that opt into `sensitive: [...]` get strict field typing.
+**Architecture:** Type-only change. The runtime already seals `sensitive` fields out of `_data`/`_det`, so `where('ssn', …)` already returns nothing — this plan adds the compile-time gate. We thread the existing `S` (the sensitive-field union, already on `Collection<T, S>`) through the three query builders (`Query<T, S>`, `ScanBuilder<T, S>`, `LazyQuery<T, S>`), and narrow each field-name parameter to a new `QueryField<T, S>` type. The narrowing is **guarded** — `[S] extends [never] ? string : Exclude<keyof T & string, S>` — so collections that declare **no** sensitive fields keep the permissive `field: string` signature unchanged (zero churn for existing consumers); only collections that opt into compile-time refusal get strict field typing.
+
+**Opt-in 2nd generic (DECIDED — read carefully).** TypeScript's all-or-nothing type-argument rule means `vault.collection<Person>('p', { sensitive: ['ssn'] })` cannot *infer* `S='ssn'` (supplying `<Person>` pins the second param `S` to its default). So compile-time refusal is **opt-in via an explicit second generic**: `vault.collection<Person, 'ssn'>('people', { sensitive: ['ssn'] })` engages refusal (`S='ssn'`), while the single-generic `vault.collection<Person>('people', { sensitive: ['ssn'] })` keeps compiling and gets **runtime sealing only** (`S=never`, no compile refusal). `vault.collection`'s second generic is therefore a **union** `S extends keyof T & string = never` (NOT a tuple), and `Collection<T, S>` is returned directly (not `Collection<T, S[number]>`). The `sensitive` option is typed `SensitiveOpt<T, S> = [S] extends [never] ? readonly (keyof T & string)[] : readonly S[]` so the single-generic form accepts any field array (runtime-only) while the 2-generic form **ties** the runtime array to `S` (writing `sensitive: ['dob']` under `<Person, 'ssn'>` is a compile error — no drift). This design is verified.
 
 **Tech Stack:** TypeScript 5.9 (`*.test-d.ts` type-tests enforced by `tsc --noEmit -p tsconfig.typetest.json`, run via `pnpm --filter @noy-db/hub typecheck:types`), tsup (DTS build), pnpm + turbo.
 
@@ -14,6 +16,7 @@
 
 - **Type-only.** No runtime behavior change. Do not touch any `.where()`/`.orderBy()`/`new Query()` runtime body except to change a parameter's TYPE annotation. Runtime sealing already exists; this is purely the compile-time gate.
 - **`S` defaults to `never` everywhere.** Every builder generic is `<T, S extends keyof T = never>`. Every existing single-arg reference (`Query<T>`, `ScanBuilder<T>`, `LazyQuery<T>`, `Collection<T>`) MUST keep compiling unchanged — there are ~26 `Query<T>` references in `builder.ts` alone and ~446 consumer call sites that must be untouched.
+- **Opt-in refusal via the 2nd generic; single-generic stays permissive.** Refusal fires only for `vault.collection<T, S>(…)` (explicit union `S`). `vault.collection<T>(…, { sensitive: [...] })` (single generic) MUST still compile and behave exactly as today (runtime sealing, `field: string`). A type-test MUST assert this non-breaking guarantee. `vault.collection`'s second generic is a union `S extends keyof T & string = never` returning `Collection<T, S>`; the `sensitive` option uses `SensitiveOpt<T, S> = [S] extends [never] ? readonly (keyof T & string)[] : readonly S[]`.
 - **Guarded narrowing.** `QueryField<T, S> = [S] extends [never] ? string : Exclude<keyof T & string, S>`. A collection with no `sensitive` declaration (S = never) gets `string` — byte-identical DX to today. Verify this property with a type-test in every task.
 - **No new public method.** The escape hatch for a sensitive collection that genuinely needs a dynamic field string is a documented cast: `where(field as QueryField<T, S>, …)`. Do not add a `whereDynamic`/`whereUnchecked` method.
 - **Run `node scripts/check-architecture.mjs` before every commit** (kernel-surface line-count ratchet on `collection.ts`/`vault.ts`/`noydb.ts`; bump a ceiling only with a `// Bumped X→Y (reason)` comment if a genuine core line is added).
@@ -154,7 +157,7 @@ async function typedVault() {
 describe('Query sensitive-field refusal', () => {
   it('refuses where() on a sensitive field, allows non-sensitive', async () => {
     const vault = await typedVault()
-    const people = vault.collection<Person>('people', { sensitive: ['ssn'] })
+    const people = vault.collection<Person, 'ssn'>('people', { sensitive: ['ssn'] })
     const q = people.query()
     // @ts-expect-error — 'ssn' is sealed; refused at compile time
     q.where('ssn', '==', 'x')
@@ -245,7 +248,119 @@ git commit -m "feat(hub): thread S through Query<T,S>; refuse sealed fields in w
 
 ---
 
-### Task 3: Thread `S` through `ScanBuilder<T, S>` and narrow `where`
+### Task 3: Reshape `vault.collection` to opt-in union-`S` and rewrite the Query type-test to the real API
+
+> **Why this task exists:** TypeScript cannot infer `S` from the `sensitive` argument when `T` is given explicitly (`vault.collection<Person>(…)`), so refusal must be opt-in via an explicit second generic. Task 2 threaded `S` through `Query` and its type-test used a workaround (`null! as Query<Person,'ssn'>` / a tuple 2nd generic) because the real `vault.collection` could not yet produce a refusing `Query`. This task makes `vault.collection<Person, 'ssn'>('people', { sensitive: ['ssn'] }).query()` produce `Query<Person, 'ssn'>` end-to-end, and rewrites the Query type-test to that real call pattern.
+
+**Files:**
+- Modify: `packages/hub/src/vault.ts` — the public `collection<T, const S …>(…)` signature (generic header ~line 684; `sensitive?:` line ~729; return type `}): Collection<T, S[number]>` ~line 794; the overlay-intercept cast `as Collection<T, S[number]>` ~lines 808–812)
+- Modify: `packages/hub/src/types.ts` — add the `SensitiveOpt<T, S>` helper next to `QueryField` (Task 1)
+- Test: rewrite `packages/hub/__tests__/sealed-query-refusal.test-d.ts` (the Query `describe` blocks from Task 2) to use the real `vault.collection<Person, 'ssn'>(…)` API, and add the non-breaking permissive-case assertion
+
+**Interfaces:**
+- Consumes: `Collection<T, S extends keyof T = never>` (unchanged), `QueryField<T, S>` / `Query<T, S>` (Tasks 1–2).
+- Produces:
+  - `export type SensitiveOpt<T, S extends keyof T> = [S] extends [never] ? readonly (keyof T & string)[] : readonly S[]` (in `types.ts`)
+  - `collection<T, S extends keyof T & string = never>(collectionName: string, options?: { …; sensitive?: SensitiveOpt<T, S>; … }): Collection<T, S>` — second generic is now a **union** (was `const S extends readonly (keyof T & string)[]`), return is `Collection<T, S>` (was `Collection<T, S[number]>`).
+
+**Design note (verified):** with this signature, `vault.collection<Person, 'ssn'>('p', { sensitive: ['ssn'] })` ⇒ `Collection<Person, 'ssn'>` (refusal engages); `vault.collection<Person>('p', { sensitive: ['ssn'] })` ⇒ `Collection<Person, never>` and the `sensitive` array is still accepted (runtime-only, no refusal); `vault.collection<Person, 'ssn'>('p', { sensitive: ['dob'] })` is a compile error (the `readonly S[]` ties the runtime list to the type).
+
+- [ ] **Step 1: Rewrite the Query type-test to the real API (RED)**
+
+Replace the two Query `describe` blocks in `packages/hub/__tests__/sealed-query-refusal.test-d.ts` (the ones Task 2 wrote with `null! as Query<…>` / tuple workarounds) with the real call pattern. The `typedVault()` helper stays. Use exactly:
+
+```ts
+describe('Query sensitive-field refusal (real vault.collection API)', () => {
+  it('refuses where()/orderBy() on a sensitive field when opted in via the 2nd generic', async () => {
+    const vault = await typedVault()
+    const people = vault.collection<Person, 'ssn'>('people', { sensitive: ['ssn'] })
+    const q = people.query()
+    // @ts-expect-error — 'ssn' is sealed; refused at compile time
+    q.where('ssn', '==', 'x')
+    q.where('name', '==', 'Ada')        // ok
+    q.orderBy('age', 'desc')            // ok
+    // @ts-expect-error — orderBy on a sealed field is refused
+    q.orderBy('ssn')
+  })
+
+  it('single-generic + sensitive still compiles (runtime-only, no refusal) — non-breaking', async () => {
+    const vault = await typedVault()
+    // No 2nd generic → S = never → field stays `string`, sensitive array still accepted.
+    const people = vault.collection<Person>('people', { sensitive: ['ssn'] })
+    people.query().where('ssn', '==', 'x').orderBy('whatever-string')
+  })
+
+  it('ties the runtime sensitive array to the 2nd generic (no drift)', async () => {
+    const vault = await typedVault()
+    // @ts-expect-error — declared sensitive 'ssn' but runtime array lists a different field
+    vault.collection<Person, 'ssn'>('people', { sensitive: ['name'] })
+  })
+
+  it('plain collection (no sensitive) keeps where() permissive', async () => {
+    const vault = await typedVault()
+    const plain = vault.collection<Person>('plain')
+    plain.query().where('anything', '==', 1).orderBy('whatever')
+    expectTypeOf(plain.query().where).parameter(0).toEqualTypeOf<string>()
+  })
+})
+```
+
+Run: `pnpm --filter @noy-db/hub typecheck:types`
+Expected: FAIL — `vault.collection<Person, 'ssn'>('people', { sensitive: ['ssn'] })` does not yet typecheck (today the 2nd generic is a tuple `const S extends readonly (keyof T & string)[]`, so `'ssn'` is not a valid 2nd argument), and the drift `@ts-expect-error` is unused. This is RED.
+
+- [ ] **Step 2: Add `SensitiveOpt<T, S>` to `types.ts`**
+
+After `IndexFieldName` (Task 1) in `packages/hub/src/types.ts`:
+
+```ts
+/**
+ * The type of the `sensitive` collection option, conditional on whether the
+ * caller opted into compile-time refusal via an explicit second generic.
+ * With no 2nd generic (`S = never`) it accepts any field array — runtime
+ * sealing only, no compile refusal, non-breaking. With `S` given, it is
+ * `readonly S[]`, which ties the runtime array to the declared sensitive
+ * union so the two cannot drift.
+ */
+export type SensitiveOpt<T, S extends keyof T> = [S] extends [never]
+  ? readonly (keyof T & string)[]
+  : readonly S[]
+```
+
+- [ ] **Step 3: Reshape the `vault.collection` signature**
+
+In `packages/hub/src/vault.ts`:
+1. Change the generic header (line ~684) from
+   `collection<T, const S extends readonly (keyof T & string)[] = readonly []>(collectionName: string, options?: {`
+   to
+   `collection<T, S extends keyof T & string = never>(collectionName: string, options?: {`
+2. Change the `sensitive?:` option (line ~729) from `sensitive?: S` to `sensitive?: SensitiveOpt<T, S>`.
+3. Change the return type (line ~794) from `}): Collection<T, S[number]> {` to `}): Collection<T, S> {`.
+4. Change the overlay-intercept return cast (lines ~808–812) from `as unknown as Collection<T, S[number]>` to `as unknown as Collection<T, S>`.
+5. Add `SensitiveOpt` to the existing `import type { … } from './types.js'` in `vault.ts`.
+
+Leave every internal `this.collection<T>(name)` call unchanged — they supply only `T`, so `S` defaults to `never` (runtime behaviour identical). The runtime body that reads `opts.sensitive` into a `Set<string>` is unchanged (it accepts any string array at runtime).
+
+- [ ] **Step 4: Run the type-test to verify it passes (GREEN)**
+
+Run: `pnpm --filter @noy-db/hub typecheck:types`
+Expected: PASS — the refusal `@ts-expect-error`s and the drift `@ts-expect-error` are all used; the permissive single-generic and plain cases compile.
+
+- [ ] **Step 5: Zero-churn proof — full hub typecheck**
+
+Run: `pnpm --filter @noy-db/hub typecheck`
+Expected: PASS. Every existing `vault.collection<T>(name, opts)` call inside hub still resolves (`S=never`). If a hub-internal call that passed `sensitive` with a tuple-expectation breaks, that is the signal — but no internal call supplies a 2nd generic, so none should break.
+
+- [ ] **Step 6: Architecture check + commit**
+
+```bash
+node scripts/check-architecture.mjs
+git add packages/hub/src/vault.ts packages/hub/src/types.ts packages/hub/__tests__/sealed-query-refusal.test-d.ts
+git commit -m "feat(hub): opt-in union-S 2nd generic on vault.collection; end-to-end where/orderBy refusal"
+```
+
+---
+
+### Task 4: Thread `S` through `ScanBuilder<T, S>` and narrow `where`
 
 **Files:**
 - Modify: `packages/hub/src/query/scan-builder.ts` (class header line 99; `where` line 170; `filter` line 193; `join` line 286; every internal `new ScanBuilder<T>(...)`)
@@ -267,7 +382,7 @@ Append to `packages/hub/__tests__/sealed-query-refusal.test-d.ts`:
 describe('ScanBuilder sensitive-field refusal', () => {
   it('refuses scan().where() on a sensitive field', async () => {
     const vault = await typedVault()
-    const people = vault.collection<Person>('people', { sensitive: ['ssn'] })
+    const people = vault.collection<Person, 'ssn'>('people', { sensitive: ['ssn'] })
     const s = people.scan()
     // @ts-expect-error — sealed field refused in scan
     s.where('ssn', '==', 'x')
@@ -317,7 +432,7 @@ git commit -m "feat(hub): thread S through ScanBuilder<T,S>; refuse sealed field
 
 ---
 
-### Task 4: Thread `S` through `LazyQuery<T, S>` and narrow `where`/`orderBy`
+### Task 5: Thread `S` through `LazyQuery<T, S>` and narrow `where`/`orderBy`
 
 **Files:**
 - Modify: `packages/hub/src/indexing/lazy-builder.ts` (class header line 63; `where` line 72; `orderBy` line 80; every internal `new LazyQuery<T>(...)`)
@@ -342,7 +457,7 @@ describe('LazyQuery sensitive-field refusal', () => {
     const db = createNoydb({ store: memoryStore() })
     const vault = await db.openVault('lz', { passphrase: 'x'.repeat(12) })
     // lazyQuery requires lazy mode (prefetch: false)
-    const people = vault.collection<Person>('people', { sensitive: ['ssn'], prefetch: false })
+    const people = vault.collection<Person, 'ssn'>('people', { sensitive: ['ssn'], prefetch: false })
     const lq = people.lazyQuery()
     // @ts-expect-error — sealed field refused in lazy where
     lq.where('ssn', '==', 'x')
@@ -386,7 +501,7 @@ git commit -m "feat(hub): thread S through LazyQuery<T,S>; refuse sealed fields 
 
 ---
 
-### Task 5: Narrow the `indexes` / `deterministicFields` / `textIndexes` collection options
+### Task 6: Narrow the `indexes` / `deterministicFields` / `textIndexes` collection options
 
 **Files:**
 - Modify: `packages/hub/src/vault.ts` (the `collection<T, const S …>({ … })` option object, ~lines 684–794 — specifically `indexes`, `deterministicFields`, `textIndexes`)
@@ -397,8 +512,8 @@ git commit -m "feat(hub): thread S through LazyQuery<T,S>; refuse sealed fields 
 - Consumes: `IndexFieldName<T, S>` (Task 1), and the runtime `IndexDef` shape from `packages/hub/src/indexing/eager-indexes.ts:34` (`string | { fields: readonly string[]; unique?: boolean } | readonly string[]`).
 - Produces:
   - `export type IndexDefFor<F extends string> = F | { readonly fields: readonly F[]; readonly unique?: boolean } | readonly F[]`
-  - `vault.collection`'s `indexes?: readonly IndexDefFor<IndexFieldName<T, S[number]>>[]`, `deterministicFields?: readonly IndexFieldName<T, S[number]>[]`, `textIndexes?: readonly IndexFieldName<T, S[number]>[]`.
-  - Because `S[number]` is `never` when no `sensitive` option is given, all three stay `IndexDefFor<string>` / `readonly string[]` — unchanged for non-sensitive collections.
+  - `vault.collection`'s `indexes?: readonly IndexDefFor<IndexFieldName<T, S>>[]`, `deterministicFields?: readonly IndexFieldName<T, S>[]`, `textIndexes?: readonly IndexFieldName<T, S>[]`.
+  - Because `S` is `never` when no `sensitive` option is given, all three stay `IndexDefFor<string>` / `readonly string[]` — unchanged for non-sensitive collections.
 
 - [ ] **Step 1: Add the failing type-test (append)**
 
@@ -408,23 +523,23 @@ Append to `packages/hub/__tests__/sealed-query-refusal.test-d.ts`:
 describe('index-declaration sensitive-field refusal', () => {
   it('refuses indexing / det-encrypting / text-indexing a sensitive field', async () => {
     const vault = await typedVault()
-    vault.collection<Person>('a', {
+    vault.collection<Person, 'ssn'>('a', {
       sensitive: ['ssn'],
       // @ts-expect-error — cannot put a sealed field in a plaintext index
       indexes: ['ssn'],
     })
-    vault.collection<Person>('b', {
+    vault.collection<Person, 'ssn'>('b', {
       sensitive: ['ssn'],
       // @ts-expect-error — cannot put a sealed field in a composite index
       indexes: [{ fields: ['name', 'ssn'] }],
     })
-    vault.collection<Person>('c', {
+    vault.collection<Person, 'ssn'>('c', {
       sensitive: ['ssn'],
       // @ts-expect-error — sealed field cannot be deterministically encrypted here
       deterministicFields: ['ssn'],
     })
     // Non-sensitive fields index fine on the same collection:
-    vault.collection<Person>('d', { sensitive: ['ssn'], indexes: ['name', 'age'] })
+    vault.collection<Person, 'ssn'>('d', { sensitive: ['ssn'], indexes: ['name', 'age'] })
   })
 
   it('keeps index options permissive without sensitive fields', async () => {
@@ -457,9 +572,9 @@ export type IndexDefFor<F extends string> =
 ```
 
 In `packages/hub/src/vault.ts`, in the `collection<T, const S …>` option object:
-- `indexes?: readonly IndexDefFor<IndexFieldName<T, S[number]>>[]` (was `IndexDef[]`)
-- `deterministicFields?: readonly IndexFieldName<T, S[number]>[]` (was `readonly string[]`)
-- `textIndexes?: readonly IndexFieldName<T, S[number]>[]` (was `readonly string[]`)
+- `indexes?: readonly IndexDefFor<IndexFieldName<T, S>>[]` (was `IndexDef[]`)
+- `deterministicFields?: readonly IndexFieldName<T, S>[]` (was `readonly string[]`)
+- `textIndexes?: readonly IndexFieldName<T, S>[]` (was `readonly string[]`)
 
 Add `IndexFieldName, IndexDefFor` to the existing `import type { … } from './types.js'` in `vault.ts`. Keep the runtime body that reads `opts.indexes` unchanged (it already handles `string | string[] | { fields }`).
 
@@ -481,7 +596,7 @@ git commit -m "feat(hub): refuse sealed fields in indexes/deterministicFields/te
 
 ---
 
-### Task 6: Full-monorepo verification + consumer fixups + runtime regression check
+### Task 7: Full-monorepo verification + consumer fixups + runtime regression check
 
 **Files:**
 - Modify: `packages/hub/src/index.ts` (add `QueryField` / `IndexFieldName` to the public barrel — see Step 0).

--- a/packages/hub/__tests__/query-field-type.test-d.ts
+++ b/packages/hub/__tests__/query-field-type.test-d.ts
@@ -1,0 +1,21 @@
+import { describe, it, expectTypeOf } from 'vitest'
+import type { QueryField, IndexFieldName } from '../src/types.js'
+
+interface Person { id: string; name: string; ssn: string; age: number }
+
+describe('QueryField<T, S>', () => {
+  it('is permissive `string` when no sensitive fields (S = never)', () => {
+    // The zero-churn guarantee: collections without `sensitive` keep `field: string`.
+    expectTypeOf<QueryField<Person>>().toEqualTypeOf<string>()
+    expectTypeOf<QueryField<Person, never>>().toEqualTypeOf<string>()
+  })
+
+  it('narrows to non-sensitive field names when S is populated', () => {
+    expectTypeOf<QueryField<Person, 'ssn'>>().toEqualTypeOf<'id' | 'name' | 'age'>()
+  })
+
+  it('IndexFieldName mirrors QueryField', () => {
+    expectTypeOf<IndexFieldName<Person>>().toEqualTypeOf<string>()
+    expectTypeOf<IndexFieldName<Person, 'ssn'>>().toEqualTypeOf<'id' | 'name' | 'age'>()
+  })
+})

--- a/packages/hub/__tests__/sealed-query-refusal.test-d.ts
+++ b/packages/hub/__tests__/sealed-query-refusal.test-d.ts
@@ -96,6 +96,11 @@ describe('index-declaration sensitive-field refusal', () => {
       // @ts-expect-error — sealed field cannot be deterministically encrypted here
       deterministicFields: ['ssn'],
     })
+    vault.collection<Person, 'ssn'>('ct', {
+      sensitive: ['ssn'],
+      // @ts-expect-error — sealed field cannot be lexically (text-)indexed here
+      textIndexes: ['ssn'],
+    })
     // Non-sensitive fields index fine on the same collection:
     vault.collection<Person, 'ssn'>('d', { sensitive: ['ssn'], indexes: ['name', 'age'] })
   })

--- a/packages/hub/__tests__/sealed-query-refusal.test-d.ts
+++ b/packages/hub/__tests__/sealed-query-refusal.test-d.ts
@@ -46,3 +46,20 @@ describe('Query sensitive-field refusal (real vault.collection API)', () => {
     expectTypeOf(plain.query().where).parameter(0).toEqualTypeOf<string>()
   })
 })
+
+describe('ScanBuilder sensitive-field refusal', () => {
+  it('refuses scan().where() on a sensitive field', async () => {
+    const vault = await typedVault()
+    const people = vault.collection<Person, 'ssn'>('people', { sensitive: ['ssn'] })
+    const s = people.scan()
+    // @ts-expect-error — sealed field refused in scan
+    s.where('ssn', '==', 'x')
+    s.where('age', '>', 18)  // ok
+  })
+
+  it('keeps scan().where() permissive without sensitive fields', async () => {
+    const vault = await typedVault()
+    const plain = vault.collection<Person>('plain')
+    plain.scan().where('any-string', '==', 1)  // still `string`
+  })
+})

--- a/packages/hub/__tests__/sealed-query-refusal.test-d.ts
+++ b/packages/hub/__tests__/sealed-query-refusal.test-d.ts
@@ -1,52 +1,48 @@
 /**
  * Type-level tests for sensitive-field refusal in the Query DSL.
  * Validated by `pnpm --filter @noy-db/hub typecheck:types` (tsc only; never executed).
- *
- * NOTE: TypeScript does not support partial type argument inference — when T is
- * explicit, S defaults to `readonly []` (not inferred from the `sensitive` array).
- * The correct form when creating a collection is to provide both T and S:
- *   vault.collection<Person, readonly ['ssn']>('people', { sensitive: ['ssn'] })
- * Or to let both be inferred from the call site. For the type-test below,
- * module-level typed constants are used to keep assertions focused.
  */
 import { describe, it, expectTypeOf } from 'vitest'
 import { createNoydb } from '../src/index.js'
 import { memoryStore } from '../src/store/memory-store.js'
-import type { Query } from '../src/query/builder.js'
 
 interface Person { id: string; name: string; ssn: string; age: number }
 
-// Typed constants — valid TypeScript module-level declarations used for type assertions.
-// `null!` is the standard "typed never-null" pattern for type-only test files.
-const qSealed = null! as Query<Person, 'ssn'>    // collection with sensitive: ['ssn']
-const qPlain = null! as Query<Person>             // collection with no sensitive fields
+async function typedVault() {
+  const db = await createNoydb({ store: memoryStore(), user: 'test', secret: 'x'.repeat(12) })
+  return db.openVault('v')
+}
 
-describe('Query sensitive-field refusal', () => {
-  it('refuses where() on a sensitive field, allows non-sensitive', () => {
-    // @ts-expect-error — 'ssn' is sealed; refused at compile time
-    qSealed.where('ssn', '==', 'x')
-    qSealed.where('name', '==', 'Ada')        // ok
-    qSealed.orderBy('age', 'desc')            // ok
-    // @ts-expect-error — orderBy on a sealed field is refused
-    qSealed.orderBy('ssn')
-  })
-
-  it('keeps where() permissive on a collection with no sensitive fields', () => {
-    // No `sensitive` → S = never → field stays `string`, every existing call still compiles.
-    qPlain.where('ssn', '==', 'x').orderBy('whatever-string')
-    expectTypeOf(qPlain.where).parameter(0).toEqualTypeOf<string>()
-  })
-
-  it('collection().query() returns Query<T, S> — integration smoke', async () => {
-    // Use both type args (required by TypeScript's partial inference rules)
-    const db = await createNoydb({ store: memoryStore(), user: 'test', secret: 'x'.repeat(12) })
-    const vault = await db.openVault('v')
-    const people = vault.collection<Person, readonly ['ssn']>('people', { sensitive: ['ssn'] })
+describe('Query sensitive-field refusal (real vault.collection API)', () => {
+  it('refuses where()/orderBy() on a sensitive field when opted in via the 2nd generic', async () => {
+    const vault = await typedVault()
+    const people = vault.collection<Person, 'ssn'>('people', { sensitive: ['ssn'] })
     const q = people.query()
-    // @ts-expect-error — where on sealed field is refused
+    // @ts-expect-error — 'ssn' is sealed; refused at compile time
     q.where('ssn', '==', 'x')
-    q.where('name', '==', 'Ada')   // ok
-    // @ts-expect-error — orderBy on sealed field is refused
+    q.where('name', '==', 'Ada')        // ok
+    q.orderBy('age', 'desc')            // ok
+    // @ts-expect-error — orderBy on a sealed field is refused
     q.orderBy('ssn')
+  })
+
+  it('single-generic + sensitive still compiles (runtime-only, no refusal) — non-breaking', async () => {
+    const vault = await typedVault()
+    // No 2nd generic → S = never → field stays `string`, sensitive array still accepted.
+    const people = vault.collection<Person>('people', { sensitive: ['ssn'] })
+    people.query().where('ssn', '==', 'x').orderBy('whatever-string')
+  })
+
+  it('ties the runtime sensitive array to the 2nd generic (no drift)', async () => {
+    const vault = await typedVault()
+    // @ts-expect-error — declared sensitive 'ssn' but runtime array lists a different field
+    vault.collection<Person, 'ssn'>('people', { sensitive: ['name'] })
+  })
+
+  it('plain collection (no sensitive) keeps where() permissive', async () => {
+    const vault = await typedVault()
+    const plain = vault.collection<Person>('plain')
+    plain.query().where('anything', '==', 1).orderBy('whatever')
+    expectTypeOf(plain.query().where).parameter(0).toEqualTypeOf<string>()
   })
 })

--- a/packages/hub/__tests__/sealed-query-refusal.test-d.ts
+++ b/packages/hub/__tests__/sealed-query-refusal.test-d.ts
@@ -1,0 +1,52 @@
+/**
+ * Type-level tests for sensitive-field refusal in the Query DSL.
+ * Validated by `pnpm --filter @noy-db/hub typecheck:types` (tsc only; never executed).
+ *
+ * NOTE: TypeScript does not support partial type argument inference — when T is
+ * explicit, S defaults to `readonly []` (not inferred from the `sensitive` array).
+ * The correct form when creating a collection is to provide both T and S:
+ *   vault.collection<Person, readonly ['ssn']>('people', { sensitive: ['ssn'] })
+ * Or to let both be inferred from the call site. For the type-test below,
+ * module-level typed constants are used to keep assertions focused.
+ */
+import { describe, it, expectTypeOf } from 'vitest'
+import { createNoydb } from '../src/index.js'
+import { memoryStore } from '../src/store/memory-store.js'
+import type { Query } from '../src/query/builder.js'
+
+interface Person { id: string; name: string; ssn: string; age: number }
+
+// Typed constants — valid TypeScript module-level declarations used for type assertions.
+// `null!` is the standard "typed never-null" pattern for type-only test files.
+const qSealed = null! as Query<Person, 'ssn'>    // collection with sensitive: ['ssn']
+const qPlain = null! as Query<Person>             // collection with no sensitive fields
+
+describe('Query sensitive-field refusal', () => {
+  it('refuses where() on a sensitive field, allows non-sensitive', () => {
+    // @ts-expect-error — 'ssn' is sealed; refused at compile time
+    qSealed.where('ssn', '==', 'x')
+    qSealed.where('name', '==', 'Ada')        // ok
+    qSealed.orderBy('age', 'desc')            // ok
+    // @ts-expect-error — orderBy on a sealed field is refused
+    qSealed.orderBy('ssn')
+  })
+
+  it('keeps where() permissive on a collection with no sensitive fields', () => {
+    // No `sensitive` → S = never → field stays `string`, every existing call still compiles.
+    qPlain.where('ssn', '==', 'x').orderBy('whatever-string')
+    expectTypeOf(qPlain.where).parameter(0).toEqualTypeOf<string>()
+  })
+
+  it('collection().query() returns Query<T, S> — integration smoke', async () => {
+    // Use both type args (required by TypeScript's partial inference rules)
+    const db = await createNoydb({ store: memoryStore(), user: 'test', secret: 'x'.repeat(12) })
+    const vault = await db.openVault('v')
+    const people = vault.collection<Person, readonly ['ssn']>('people', { sensitive: ['ssn'] })
+    const q = people.query()
+    // @ts-expect-error — where on sealed field is refused
+    q.where('ssn', '==', 'x')
+    q.where('name', '==', 'Ada')   // ok
+    // @ts-expect-error — orderBy on sealed field is refused
+    q.orderBy('ssn')
+  })
+})

--- a/packages/hub/__tests__/sealed-query-refusal.test-d.ts
+++ b/packages/hub/__tests__/sealed-query-refusal.test-d.ts
@@ -77,3 +77,31 @@ describe('LazyQuery sensitive-field refusal', () => {
     lq.orderBy('ssn')
   })
 })
+
+describe('index-declaration sensitive-field refusal', () => {
+  it('refuses indexing / det-encrypting / text-indexing a sensitive field', async () => {
+    const vault = await typedVault()
+    vault.collection<Person, 'ssn'>('a', {
+      sensitive: ['ssn'],
+      // @ts-expect-error — cannot put a sealed field in a plaintext index
+      indexes: ['ssn'],
+    })
+    vault.collection<Person, 'ssn'>('b', {
+      sensitive: ['ssn'],
+      // @ts-expect-error — cannot put a sealed field in a composite index
+      indexes: [{ fields: ['name', 'ssn'] }],
+    })
+    vault.collection<Person, 'ssn'>('c', {
+      sensitive: ['ssn'],
+      // @ts-expect-error — sealed field cannot be deterministically encrypted here
+      deterministicFields: ['ssn'],
+    })
+    // Non-sensitive fields index fine on the same collection:
+    vault.collection<Person, 'ssn'>('d', { sensitive: ['ssn'], indexes: ['name', 'age'] })
+  })
+
+  it('keeps index options permissive without sensitive fields', async () => {
+    const vault = await typedVault()
+    vault.collection<Person>('e', { indexes: ['anything', { fields: ['x', 'y'] }] })
+  })
+})

--- a/packages/hub/__tests__/sealed-query-refusal.test-d.ts
+++ b/packages/hub/__tests__/sealed-query-refusal.test-d.ts
@@ -63,3 +63,17 @@ describe('ScanBuilder sensitive-field refusal', () => {
     plain.scan().where('any-string', '==', 1)  // still `string`
   })
 })
+
+describe('LazyQuery sensitive-field refusal', () => {
+  it('refuses lazyQuery().where()/orderBy() on a sensitive field', async () => {
+    const vault = await typedVault()
+    // lazyQuery requires lazy mode (prefetch: false)
+    const people = vault.collection<Person, 'ssn'>('people', { sensitive: ['ssn'], prefetch: false })
+    const lq = people.lazyQuery()
+    // @ts-expect-error — sealed field refused in lazy where
+    lq.where('ssn', '==', 'x')
+    lq.where('name', '==', 'Ada')   // ok
+    // @ts-expect-error — sealed field refused in lazy orderBy
+    lq.orderBy('ssn')
+  })
+})

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -3613,9 +3613,9 @@ export class Collection<T, S extends keyof T = never> {
    * const drafts = invoices.query(i => i.status === 'draft');
    * ```
    */
-  query(): Query<T>
+  query(): Query<T, S>
   query(predicate: (record: T) => boolean): T[]
-  query(predicate?: (record: T) => boolean): Query<T> | T[] {
+  query(predicate?: (record: T) => boolean): Query<T, S> | T[] {
     if (this.lazy) {
       throw new Error(
         `Collection "${this.name}": query() is not available in lazy mode (prefetch: false). ` +
@@ -3667,7 +3667,7 @@ export class Collection<T, S extends keyof T = never> {
             : {}),
         }
       : undefined
-    return new Query<T>(source, undefined, joinContext, this.aggregateStrategy)
+    return new Query<T, S>(source, undefined, joinContext, this.aggregateStrategy)
   }
 
   /**

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -4925,7 +4925,7 @@ export class Collection<T, S extends keyof T = never> {
    * `query()` there. Throws if no index is declared, because a lazy
    * query with no index would need to enumerate the whole collection.
    */
-  lazyQuery(): LazyQuery<T> {
+  lazyQuery(): LazyQuery<T, S> {
     if (!this.lazy) {
       throw new Error(
         `Collection "${this.name}": lazyQuery() is only available in lazy mode ` +
@@ -4953,7 +4953,7 @@ export class Collection<T, S extends keyof T = never> {
       ensurePersistedIndexesLoaded: () => this.ensurePersistedIndexesLoaded(),
       getRecord: (id: string) => this.get(id) as unknown as Promise<T | null>,
     }
-    return new LazyQuery<T>(source)
+    return new LazyQuery<T, S>(source)
   }
 
   /**

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -4023,7 +4023,7 @@ export class Collection<T, S extends keyof T = never> {
    * to the synthetic pagination path with the same one-time
    * warning (`listPage()` routes through that fallback internally).
    */
-  scan(opts: { pageSize?: number } = {}): ScanBuilder<T> {
+  scan(opts: { pageSize?: number } = {}): ScanBuilder<T, S> {
     const pageSize = opts.pageSize ?? 100
     // Build a JoinContext if the vault passed a join resolver
     // — same machinery as `query()`. Without one, `.join()`
@@ -4051,7 +4051,7 @@ export class Collection<T, S extends keyof T = never> {
     // coupling. Rebinding through the arrow keeps the unbound-
     // method lint rule happy — matches the pattern used in
     // builder.ts's candidateRecords helper.
-    return new ScanBuilder<T>(
+    return new ScanBuilder<T, S>(
       {
         listPage: (listOpts) => this.listPage(listOpts),
       },

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -1057,6 +1057,9 @@ export type {
   ScanPageProvider,
 } from './query/index.js'
 
+// Query DSL helpers (escape-hatch types for consumers with dynamic field names)
+export type { QueryField, IndexFieldName } from './types.js'
+
 // Scan-mode full-text search (#308)
 export { tokenize } from './search/index.js'
 export type { Tokenizer, SearchOptions, SearchResult, SearchEntry } from './search/index.js'

--- a/packages/hub/src/indexing/lazy-builder.ts
+++ b/packages/hub/src/indexing/lazy-builder.ts
@@ -27,6 +27,7 @@ import type { Clause, FieldClause, Operator } from '../query/predicate.js'
 import { evaluateClause, readPath } from '../query/predicate.js'
 import type { PersistedCollectionIndex } from './persisted-indexes.js'
 import { IndexRequiredError } from '../errors.js'
+import type { QueryField } from '../types.js'
 
 export interface LazyOrderBy {
   readonly field: string
@@ -60,7 +61,7 @@ const EMPTY_PLAN: LazyPlan = {
   offset: 0,
 }
 
-export class LazyQuery<T> {
+export class LazyQuery<T, S extends keyof T = never> {
   private readonly source: LazyQuerySource<T>
   private readonly plan: LazyPlan
 
@@ -69,27 +70,27 @@ export class LazyQuery<T> {
     this.plan = plan
   }
 
-  where<V>(field: string, op: Operator, value: V): LazyQuery<T> {
+  where<V>(field: QueryField<T, S>, op: Operator, value: V): LazyQuery<T, S> {
     const clause: FieldClause = { type: 'field', field, op, value }
-    return new LazyQuery<T>(this.source, {
+    return new LazyQuery<T, S>(this.source, {
       ...this.plan,
       clauses: [...this.plan.clauses, clause],
     })
   }
 
-  orderBy(field: string, direction: 'asc' | 'desc' = 'asc'): LazyQuery<T> {
-    return new LazyQuery<T>(this.source, {
+  orderBy(field: QueryField<T, S>, direction: 'asc' | 'desc' = 'asc'): LazyQuery<T, S> {
+    return new LazyQuery<T, S>(this.source, {
       ...this.plan,
       orderBy: [...this.plan.orderBy, { field, direction }],
     })
   }
 
-  limit(n: number): LazyQuery<T> {
-    return new LazyQuery<T>(this.source, { ...this.plan, limit: n })
+  limit(n: number): LazyQuery<T, S> {
+    return new LazyQuery<T, S>(this.source, { ...this.plan, limit: n })
   }
 
-  offset(n: number): LazyQuery<T> {
-    return new LazyQuery<T>(this.source, { ...this.plan, offset: n })
+  offset(n: number): LazyQuery<T, S> {
+    return new LazyQuery<T, S>(this.source, { ...this.plan, offset: n })
   }
 
   async toArray(): Promise<T[]> {

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -5,6 +5,7 @@
  * mutated. This makes plans safe to share, cache, and serialize.
  */
 
+import type { QueryField } from '../types.js'
 import type { Clause, CrossJoinClause, FieldClause, FilterClause, GroupClause, Operator, WherePredicateClause } from './predicate.js'
 import { evaluateClause, hasFnClause } from './predicate.js'
 import type { CollectionIndexes } from '../indexing/eager-indexes.js'
@@ -135,7 +136,7 @@ export interface DeclaredPredicate {
   fn: (record: unknown, ctx?: unknown) => boolean
 }
 
-export class Query<T> {
+export class Query<T, S extends keyof T = never> {
   private readonly source: InternalSource
   private readonly plan: QueryPlan
   private readonly joinContext: JoinContext | undefined
@@ -180,8 +181,8 @@ export class Query<T> {
    * `.wherePredicate(name, ctx?)` for the MV's query callback.
    * Consumers don't call this directly.
    */
-  _withPredicates(predicates: ReadonlyMap<string, DeclaredPredicate>): Query<T> {
-    return new Query<T>(
+  _withPredicates(predicates: ReadonlyMap<string, DeclaredPredicate>): Query<T, S> {
+    return new Query<T, S>(
       this.source as QuerySource<T>,
       this.plan,
       this.joinContext,
@@ -235,7 +236,7 @@ export class Query<T> {
    * canonical-JSON hash of `ctx` fold into the MV's `queryHash`, so
    * either changing forces refresh on next visit.
    */
-  wherePredicate(name: string, ctx?: unknown): Query<T> {
+  wherePredicate(name: string, ctx?: unknown): Query<T, S> {
     if (!this.predicates) {
       throw new Error(
         `.wherePredicate("${name}"): no predicates registered on this Query. ` +
@@ -259,7 +260,7 @@ export class Query<T> {
       ctxHash: canonicalCtxHash(ctx),
       fn: decl.fn,
     }
-    return new Query<T>(
+    return new Query<T, S>(
       this.source as QuerySource<T>,
       { ...this.plan, clauses: [...this.plan.clauses, clause] },
       this.joinContext,
@@ -277,12 +278,12 @@ export class Query<T> {
    * BigInt-exact per record. A malformed operand or a string operator
    * (`contains`/`startsWith`) throws here, at the call site.
    */
-  where(field: string, op: Operator, value: unknown): Query<T> {
+  where(field: QueryField<T, S>, op: Operator, value: unknown): Query<T, S> {
     const desc = this.source.moneyFields?.[field]
     const clause: FieldClause = desc
       ? moneyFieldClause(field, op, value, desc)
       : { type: 'field', field, op, value }
-    return new Query<T>(
+    return new Query<T, S>(
       this.source as QuerySource<T>,
       { ...this.plan, clauses: [...this.plan.clauses, clause] },
       this.joinContext,
@@ -296,16 +297,16 @@ export class Query<T> {
    * Each clause inside the callback is OR-combined; the group itself
    * joins the parent plan with AND.
    */
-  or(builder: (q: Query<T>) => Query<T>): Query<T> {
+  or(builder: (q: Query<T, S>) => Query<T, S>): Query<T, S> {
     const sub = builder(
-      new Query<T>(this.source as QuerySource<T>, EMPTY_PLAN, this.joinContext, this.aggregateStrategy, this.predicates),
+      new Query<T, S>(this.source as QuerySource<T>, EMPTY_PLAN, this.joinContext, this.aggregateStrategy, this.predicates),
     )
     const group: GroupClause = {
       type: 'group',
       op: 'or',
       clauses: sub.plan.clauses,
     }
-    return new Query<T>(
+    return new Query<T, S>(
       this.source as QuerySource<T>,
       { ...this.plan, clauses: [...this.plan.clauses, group] },
       this.joinContext,
@@ -318,16 +319,16 @@ export class Query<T> {
    * Logical AND group. Same shape as `or()` but every clause inside the group
    * must match. Useful for explicit grouping inside a larger OR.
    */
-  and(builder: (q: Query<T>) => Query<T>): Query<T> {
+  and(builder: (q: Query<T, S>) => Query<T, S>): Query<T, S> {
     const sub = builder(
-      new Query<T>(this.source as QuerySource<T>, EMPTY_PLAN, this.joinContext, this.aggregateStrategy, this.predicates),
+      new Query<T, S>(this.source as QuerySource<T>, EMPTY_PLAN, this.joinContext, this.aggregateStrategy, this.predicates),
     )
     const group: GroupClause = {
       type: 'group',
       op: 'and',
       clauses: sub.plan.clauses,
     }
-    return new Query<T>(
+    return new Query<T, S>(
       this.source as QuerySource<T>,
       { ...this.plan, clauses: [...this.plan.clauses, group] },
       this.joinContext,
@@ -337,12 +338,12 @@ export class Query<T> {
   }
 
   /** Escape hatch: add an arbitrary predicate function. Not serializable. */
-  filter(fn: (record: T) => boolean): Query<T> {
+  filter(fn: (record: T) => boolean): Query<T, S> {
     const clause: FilterClause = {
       type: 'filter',
       fn: fn as (record: unknown) => boolean,
     }
-    return new Query<T>(
+    return new Query<T, S>(
       this.source as QuerySource<T>,
       { ...this.plan, clauses: [...this.plan.clauses, clause] },
       this.joinContext,
@@ -356,9 +357,9 @@ export class Query<T> {
    * `{ by: 'label' }` to sort a `dictKey`/`staticDict` field by its resolved
    * label at the query locale instead of the stored code (#285).
    */
-  orderBy(field: string, direction: 'asc' | 'desc' = 'asc', opts?: { by?: 'value' | 'label' }): Query<T> {
+  orderBy(field: QueryField<T, S>, direction: 'asc' | 'desc' = 'asc', opts?: { by?: 'value' | 'label' }): Query<T, S> {
     const entry: OrderBy = opts?.by === 'label' ? { field, direction, by: 'label' } : { field, direction }
-    return new Query<T>(
+    return new Query<T, S>(
       this.source as QuerySource<T>,
       { ...this.plan, orderBy: [...this.plan.orderBy, entry] },
       this.joinContext,
@@ -368,8 +369,8 @@ export class Query<T> {
   }
 
   /** Cap the result size. */
-  limit(n: number): Query<T> {
-    return new Query<T>(
+  limit(n: number): Query<T, S> {
+    return new Query<T, S>(
       this.source as QuerySource<T>,
       { ...this.plan, limit: n },
       this.joinContext,
@@ -379,8 +380,8 @@ export class Query<T> {
   }
 
   /** Skip the first N matching records (after ordering). */
-  offset(n: number): Query<T> {
-    return new Query<T>(
+  offset(n: number): Query<T, S> {
+    return new Query<T, S>(
       this.source as QuerySource<T>,
       { ...this.plan, offset: n },
       this.joinContext,
@@ -448,9 +449,9 @@ export class Query<T> {
    * `.join()`.
    */
   join<As extends string, R = unknown>(
-    field: string,
+    field: QueryField<T, S>,
     opts: { as: As; strategy?: JoinStrategy; maxRows?: number },
-  ): Query<T & Record<As, R | null>> {
+  ): Query<T & Record<As, R | null>, S> {
     if (!this.joinContext) {
       throw new Error(
         `Query.join() requires a join context. Use collection.query() ` +
@@ -492,7 +493,7 @@ export class Query<T> {
           partitionScope: 'all',
           isDictJoin: true,
         }
-    return new Query<T & Record<As, R | null>>(
+    return new Query<T & Record<As, R | null>, S>(
       this.source as unknown as QuerySource<T & Record<As, R | null>>,
       { ...this.plan, joins: [...this.plan.joins, leg] },
       this.joinContext,
@@ -531,7 +532,7 @@ export class Query<T> {
         | { readonly predicate: string }
       maxRows?: number
     },
-  ): Query<T & { [K in As]: TTarget }> {
+  ): Query<T & { [K in As]: TTarget }, S> {
     if (!this.joinContext) {
       throw new Error(
         `Query.crossJoin("${target}"): requires a join context. ` +
@@ -588,7 +589,7 @@ export class Query<T> {
       ...(opts.maxRows !== undefined && { maxRows: opts.maxRows }),
     }
 
-    return new Query<T & { [K in As]: TTarget }>(
+    return new Query<T & { [K in As]: TTarget }, S>(
       this.source as unknown as QuerySource<T & { [K in As]: TTarget }>,
       { ...this.plan, clauses: [...this.plan.clauses, clause] },
       this.joinContext,

--- a/packages/hub/src/query/scan-builder.ts
+++ b/packages/hub/src/query/scan-builder.ts
@@ -58,6 +58,7 @@
  *   - `scan().join(...)` — tracked under  (streaming join)
  */
 
+import type { QueryField } from '../types.js'
 import type { Clause, FieldClause, Operator } from './predicate.js'
 import { evaluateClause, hasFnClause, readPath } from './predicate.js'
 import type {
@@ -96,7 +97,7 @@ const DEFAULT_SCAN_PAGE_SIZE = 100
  * page size. The original builder is never mutated, so it's safe
  * to reuse across multiple parallel consumers.
  */
-export class ScanBuilder<T> implements AsyncIterable<T> {
+export class ScanBuilder<T, S extends keyof T = never> implements AsyncIterable<T> {
   private readonly pageProvider: ScanPageProvider<T>
   private readonly pageSize: number
   private readonly clauses: readonly Clause[]
@@ -167,14 +168,14 @@ export class ScanBuilder<T> implements AsyncIterable<T> {
    * are a future optimization — the current implementation
    * evaluates clauses per record in O(1) per clause.
    */
-  where(field: string, op: Operator, value: unknown): ScanBuilder<T> {
+  where(field: QueryField<T, S>, op: Operator, value: unknown): ScanBuilder<T, S> {
     // Money fields compare in major units, BigInt-exact in scaled space —
     // same build-time operand rewrite as Query.where() (#336).
-    const desc = this.moneyFields?.[field]
+    const desc = this.moneyFields?.[field as string]
     const clause: FieldClause = desc
-      ? moneyFieldClause(field, op, value, desc)
-      : { type: 'field', field, op, value }
-    return new ScanBuilder<T>(
+      ? moneyFieldClause(field as string, op, value, desc)
+      : { type: 'field', field: field as string, op, value }
+    return new ScanBuilder<T, S>(
       this.pageProvider,
       this.pageSize,
       [...this.clauses, clause],
@@ -190,12 +191,12 @@ export class ScanBuilder<T> implements AsyncIterable<T> {
    * don't round-trip through `toPlan()`. Prefer `.where()` when
    * possible.
    */
-  filter(fn: (record: T) => boolean): ScanBuilder<T> {
+  filter(fn: (record: T) => boolean): ScanBuilder<T, S> {
     const clause: Clause = {
       type: 'filter',
       fn: fn as (record: unknown) => boolean,
     }
-    return new ScanBuilder<T>(
+    return new ScanBuilder<T, S>(
       this.pageProvider,
       this.pageSize,
       [...this.clauses, clause],
@@ -284,9 +285,9 @@ export class ScanBuilder<T> implements AsyncIterable<T> {
    * eager join.
    */
   join<As extends string, R = unknown>(
-    field: string,
+    field: QueryField<T, S>,
     opts: { as: As },
-  ): ScanBuilder<T & Record<As, R | null>> {
+  ): ScanBuilder<T & Record<As, R | null>, S> {
     if (!this.joinContext) {
       throw new Error(
         `ScanBuilder.join() requires a join context. Use ` +
@@ -318,7 +319,7 @@ export class ScanBuilder<T> implements AsyncIterable<T> {
       // changing the planner shape.
       partitionScope: 'all',
     }
-    return new ScanBuilder<T & Record<As, R | null>>(
+    return new ScanBuilder<T & Record<As, R | null>, S>(
       this.pageProvider as unknown as ScanPageProvider<T & Record<As, R | null>>,
       this.pageSize,
       this.clauses,

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -268,6 +268,18 @@ export type IndexFieldName<T, S extends keyof T = never> = [S] extends [never]
   : Exclude<keyof T & string, S>
 
 /**
+ * The type of the `sensitive` collection option, conditional on whether the
+ * caller opted into compile-time refusal via an explicit second generic.
+ * With no 2nd generic (`S = never`) it accepts any field array — runtime
+ * sealing only, no compile refusal, non-breaking. With `S` given, it is
+ * `readonly S[]`, which ties the runtime array to the declared sensitive
+ * union so the two cannot drift.
+ */
+export type SensitiveOpt<T, S extends keyof T> = [S] extends [never]
+  ? readonly (keyof T & string)[]
+  : readonly S[]
+
+/**
  * Concrete {@link Sealed} handle. Holds the reveal closure (which captures the
  * field's ciphertext blob and the unseal routine) in a private field, so it is
  * invisible to `JSON.stringify`, `util.inspect`, and `Object.keys`. `toJSON`

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -271,7 +271,12 @@ export type IndexFieldName<T, S extends keyof T = never> = [S] extends [never]
  * Generic form of the runtime `IndexDef` (see `indexing/eager-indexes.ts`)
  * parameterised by the allowed field-name set `F`. Used to refuse `sensitive`
  * fields in the `indexes` collection option at compile time while leaving the
- * runtime `IndexDef` (string-based) untouched.
+ * runtime `IndexDef` (string-based) untouched. `IndexDefFor<string>` is
+ * structurally identical to `IndexDef`, which is why `vault.collection` can cast
+ * the narrowed public option straight to `IndexDef[]` at the runtime boundary.
+ * **Keep this in sync with `IndexDef`** — if `IndexDef` gains a new union member,
+ * add it here too, or that boundary cast will silently admit shapes the runtime
+ * machinery does not narrow.
  */
 export type IndexDefFor<F extends string> =
   | F

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -238,6 +238,36 @@ export type SealedView<T, S extends keyof T> = [S] extends [never]
     }
 
 /**
+ * The type of a field-name argument to the query/scan DSL (`where`, `orderBy`,
+ * …) for a collection whose sealed (`sensitive`) fields are `S`.
+ *
+ * Guarded so the common case is unchanged: with **no** sensitive fields
+ * (`S = never`) it is exactly `string` — collections that don't opt into
+ * `sensitive` keep today's permissive DSL, zero churn. Once a field is
+ * declared `sensitive`, the DSL narrows to the non-sensitive field names, so
+ * `where('ssn', …)` becomes a compile error. TypeScript cannot subtract a
+ * literal from `string`, so refusing a sensitive name necessarily means
+ * narrowing to the known field-name union — this is intentional and only
+ * affects collections that opted in.
+ */
+export type QueryField<T, S extends keyof T = never> = [S] extends [never]
+  ? string
+  : Exclude<keyof T & string, S>
+
+/**
+ * The type of a field-name reference in a collection's index-declaration
+ * options (`indexes`, `deterministicFields`, `textIndexes`). Same guarded
+ * narrowing as {@link QueryField}: permissive `string` until a field is
+ * declared `sensitive`, then the sensitive names are refused (a plaintext
+ * secondary index over a sealed field defeats non-residency — previously only
+ * a runtime `console.warn`). Kept distinct from `QueryField` so the two DSL
+ * surfaces can diverge later without coupling.
+ */
+export type IndexFieldName<T, S extends keyof T = never> = [S] extends [never]
+  ? string
+  : Exclude<keyof T & string, S>
+
+/**
  * Concrete {@link Sealed} handle. Holds the reveal closure (which captures the
  * field's ciphertext blob and the unseal routine) in a private field, so it is
  * invisible to `JSON.stringify`, `util.inspect`, and `Object.keys`. `toJSON`

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -273,7 +273,8 @@ export type IndexFieldName<T, S extends keyof T = never> = [S] extends [never]
  * fields in the `indexes` collection option at compile time while leaving the
  * runtime `IndexDef` (string-based) untouched. `IndexDefFor<string>` is
  * structurally identical to `IndexDef`, which is why `vault.collection` can cast
- * the narrowed public option straight to `IndexDef[]` at the runtime boundary.
+ * the narrowed public option to `IndexDef[]` at the runtime boundary (through
+ * `unknown`, solely to drop the `readonly`).
  * **Keep this in sync with `IndexDef`** — if `IndexDef` gains a new union member,
  * add it here too, or that boundary cast will silently admit shapes the runtime
  * machinery does not narrow.

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -268,6 +268,17 @@ export type IndexFieldName<T, S extends keyof T = never> = [S] extends [never]
   : Exclude<keyof T & string, S>
 
 /**
+ * Generic form of the runtime `IndexDef` (see `indexing/eager-indexes.ts`)
+ * parameterised by the allowed field-name set `F`. Used to refuse `sensitive`
+ * fields in the `indexes` collection option at compile time while leaving the
+ * runtime `IndexDef` (string-based) untouched.
+ */
+export type IndexDefFor<F extends string> =
+  | F
+  | { readonly fields: readonly F[]; readonly unique?: boolean }
+  | readonly F[]
+
+/**
  * The type of the `sensitive` collection option, conditional on whether the
  * caller opted into compile-time refusal via an explicit second generic.
  * With no 2nd generic (`S = never`) it accepts any field array — runtime

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -31,7 +31,7 @@ import { OverlayedCollection } from './overlay-views/virtual-collection.js'
 import type { PublicEnvelope } from './meta/public-envelope/types.js'
 import { buildRecipientKeyringFile } from './team/keyring.js'
 import { ensureCollectionDEK, hasAccess, hasExportCapability, hasImportCapability } from './team/keyring.js'
-import type { ExportFormat, KeyringFile } from './types.js'
+import type { ExportFormat, KeyringFile, SensitiveOpt } from './types.js'
 import {
   ExportCapabilityError,
   ImportCapabilityError,
@@ -681,7 +681,7 @@ export class Vault {
    * Lazy mode + indexes is rejected at construction time — see the
    * Collection constructor for the rationale.
    */
-  collection<T, const S extends readonly (keyof T & string)[] = readonly []>(collectionName: string, options?: {
+  collection<T, S extends keyof T & string = never>(collectionName: string, options?: {
     indexes?: IndexDef[]
     /** — auto-reconcile policy for persisted-index drift. */
     reconcileOnOpen?: 'off' | 'dry-run' | 'auto'
@@ -726,7 +726,7 @@ export class Vault {
      * `_sealed[field]` envelope slot (per-field key), kept out of the open
      * `_data` blob. Default-off; byte-identical output when absent.
      */
-    sensitive?: S
+    sensitive?: SensitiveOpt<T, S>
     /**
      * — per-record content-encryption keys. When `true`, every record
      * body is encrypted under a fresh per-record CEK wrapped under the
@@ -791,7 +791,7 @@ export class Vault {
      * Default false — the working set is plaintext.
      */
     ramCiphertext?: boolean
-  }): Collection<T, S[number]> {
+  }): Collection<T, S> {
     // Overlay intercept. When the requested collection name
     // matches a registered `withOverlayedView`, return the virtual
     // proxy that merges base + overlay on read and routes writes to
@@ -809,7 +809,7 @@ export class Vault {
         const overlay = this.collection<T>(spec.overlay)
         const baseRowKey = overlayRegistry.resolveBaseRowKey(collectionName, this.materializedViewRegistry)
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return new OverlayedCollection<any>(spec, base, overlay, baseRowKey) as unknown as Collection<T, S[number]>
+        return new OverlayedCollection<any>(spec, base, overlay, baseRowKey) as unknown as Collection<T, S>
       }
     }
     // Guard: reject reserved _dict_* names
@@ -1153,7 +1153,7 @@ export class Vault {
         this._pendingSchemaWrites.push(work)
       }
     }
-    return coll as unknown as Collection<T, S[number]>
+    return coll as unknown as Collection<T, S>
   }
 
   /**

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -31,7 +31,7 @@ import { OverlayedCollection } from './overlay-views/virtual-collection.js'
 import type { PublicEnvelope } from './meta/public-envelope/types.js'
 import { buildRecipientKeyringFile } from './team/keyring.js'
 import { ensureCollectionDEK, hasAccess, hasExportCapability, hasImportCapability } from './team/keyring.js'
-import type { ExportFormat, KeyringFile, SensitiveOpt } from './types.js'
+import type { ExportFormat, KeyringFile, SensitiveOpt, IndexFieldName, IndexDefFor } from './types.js'
 import {
   ExportCapabilityError,
   ImportCapabilityError,
@@ -682,7 +682,7 @@ export class Vault {
    * Collection constructor for the rationale.
    */
   collection<T, S extends keyof T & string = never>(collectionName: string, options?: {
-    indexes?: IndexDef[]
+    indexes?: readonly IndexDefFor<IndexFieldName<T, S>>[]
     /** — auto-reconcile policy for persisted-index drift. */
     reconcileOnOpen?: 'off' | 'dry-run' | 'auto'
     prefetch?: boolean
@@ -694,7 +694,7 @@ export class Vault {
     /** — #308 L2: embedding config for write-time vector derivation + semantic retrieval. */
     embeddings?: EmbeddingDescriptor
     /** — #308 L1: string fields exposed to client-side `retrieve()`. */
-    textIndexes?: readonly string[]
+    textIndexes?: readonly IndexFieldName<T, S>[]
     /** — #308 L1: pre-build the lexical index on open (eager-only). */
     warmIndexOnOpen?: boolean
     /** — #308 L1.5: persist the lexical index as an opaque encrypted blob at `_ftindex/<name>`. */
@@ -718,7 +718,7 @@ export class Vault {
      * equality search. See `Collection` constructor docs for the full
      * trade-off. Requires `acknowledgeDeterministicRisk: true`.
      */
-    deterministicFields?: readonly string[]
+    deterministicFields?: readonly IndexFieldName<T, S>[]
     /** — explicit ack that deterministic encryption leaks equality. */
     acknowledgeDeterministicRisk?: boolean
     /**
@@ -1013,7 +1013,7 @@ export class Vault {
             }
           : {}),
       }
-      if (options?.indexes !== undefined) collOpts.indexes = options.indexes
+      if (options?.indexes !== undefined) collOpts.indexes = options.indexes as unknown as IndexDef[]
       if (options?.reconcileOnOpen !== undefined) collOpts.reconcileOnOpen = options.reconcileOnOpen
       if (options?.prefetch !== undefined) collOpts.prefetch = options.prefetch
       if (options?.cache !== undefined) collOpts.cache = options.cache

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -353,8 +353,6 @@ const STRATEGY_GATED_APIS = [
 // but always throws regardless of indexStrategy).
 const STRATEGY_OPT_IN_EXEMPT = new Set([
   'packages/hub/__tests__/overlay-views/overlay.test.ts',
-  // Type-only test; `.lazyQuery()` is never executed — tsc-only gate.
-  'packages/hub/__tests__/sealed-query-refusal.test-d.ts',
 ])
 
 function checkStrategyOptIns() {
@@ -365,6 +363,11 @@ function checkStrategyOptIns() {
 }
 
 function scanFileForStrategyOptIn(file, content) {
+  // Type-only tests (`*.test-d.ts`) are consumed by tsc and NEVER executed, so
+  // the runtime "gated API throws without its strategy" hazard this check guards
+  // against cannot occur in them. Skip the whole class (covers any current/future
+  // type-test that references a gated API like `.lazyQuery()` for type assertions).
+  if (file.endsWith('.test-d.ts')) return
   if (STRATEGY_OPT_IN_EXEMPT.has(relative(ROOT, file))) return
   // Use the stronger strip — error-message strings legitimately mention
   // method names like ".dictionary()" inside hint text, which the

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -353,6 +353,8 @@ const STRATEGY_GATED_APIS = [
 // but always throws regardless of indexStrategy).
 const STRATEGY_OPT_IN_EXEMPT = new Set([
   'packages/hub/__tests__/overlay-views/overlay.test.ts',
+  // Type-only test; `.lazyQuery()` is never executed — tsc-only gate.
+  'packages/hub/__tests__/sealed-query-refusal.test-d.ts',
 ])
 
 function checkStrategyOptIns() {


### PR DESCRIPTION
## What

Makes `@noy-db/hub` refuse a collection's declared **`sensitive`** fields at **compile time** in the query/scan/index DSLs — turning today's silent runtime-seal into a `tsc` error. Completes the P3 epic on top of the `Sealed<V>` access gate (#504).

```ts
const people = vault.collection<Person, 'ssn'>('people', { sensitive: ['ssn'] })

people.query().where('ssn', '==', x)     // ❌ compile error
people.query().orderBy('ssn')            // ❌
people.scan().where('ssn', '==', x)      // ❌
people.lazyQuery().where('ssn', '==', x) // ❌
vault.collection<Person, 'ssn'>('p', { sensitive: ['ssn'], indexes: ['ssn'] }) // ❌ (plaintext index over a sealed field)

people.query().where('name', '==', x)    // ✅
```

## Opt-in via a 2nd generic (design decision)

TypeScript's all-or-nothing type-argument rule means `vault.collection<Person>('p', { sensitive: ['ssn'] })` **cannot infer** `S='ssn'` (supplying `<Person>` pins the second generic to its default). So compile-time refusal is **opt-in** via an explicit second generic:

- `vault.collection<Person, 'ssn'>(…)` → refusal engages.
- `vault.collection<Person>(…, { sensitive: ['ssn'] })` → still compiles, **runtime sealing only** (no compile refusal). **Non-breaking** — every existing call is unaffected.

The 2-generic form also **ties** the runtime array to the type: `vault.collection<Person, 'ssn'>('p', { sensitive: ['name'] })` is a compile error (no drift).

> Note: this also surfaced that #504's `SealedView` typing never fired for the `vault.collection<Person>(…)` pattern for the same reason — masked because hub's `.test.ts` files aren't typechecked (only `.test-d.ts` are). A candidate follow-up.

## How

Type-only. Threads the existing sensitive-field union `S` through `Query<T,S>`, `ScanBuilder<T,S>`, `LazyQuery<T,S>`, and the `vault.collection → Collection<T,S>` wiring; narrows each field-name parameter via guarded types:

- `QueryField<T,S> = [S] extends [never] ? string : Exclude<keyof T & string, S>` — **zero churn**: collections with no sensitive fields keep `field: string` exactly as today.
- `IndexFieldName<T,S>` / `IndexDefFor<F>` — same guard for `indexes`/`deterministicFields`/`textIndexes`.
- `SensitiveOpt<T,S>` — conditional `sensitive` option type (permissive single-generic, array-tied 2-generic).

`QueryField`/`IndexFieldName` are exported from the barrel for the documented escape-hatch cast (`field as QueryField<T,S>`) when a sensitive collection genuinely needs a dynamic field string.

## Verification

- **Type-only / zero runtime change:** hub test suite **2909 tests — identical count to pre-branch**.
- **Full monorepo `pnpm typecheck`: 98/98 green** (forced, uncached) — the gate the prior `SealedView` regression escaped.
- Refusal proven by `@ts-expect-error` type-tests under `tsc` (an unused directive is a hard error, so the tests genuinely fail on a regression): `where`/`orderBy`/`scan`/`lazyQuery`/`indexes`/`deterministicFields`/`textIndexes` refusal, single-generic permissive, drift-tie, and plain-collection permissive.
- Built via subagent-driven development: 7 tasks, each gated by a per-task review; opus final whole-branch review verdict **Ready to merge** (no Critical/Important).

## Scope / follow-ups (not in this PR)

- `groupBy`/`aggregate`/`live` transition to other builder types and don't carry `S` (out of scope — noted).
- The `Q = indexed-only` query restriction (full P3-T5), `Sealed`/`SealedView` barrel export + `.test.ts` typecheck gap, and tightening the drift test's `@ts-expect-error` are noted follow-ups.
