### PR TITLE
fix(hub): correct 4 public type-soundness gaps (MV query, derivation arrays, frame overload, money sum doc)

### DIFF
--- a/packages/hub/__tests__/derivations/array-shape.test.ts
+++ b/packages/hub/__tests__/derivations/array-shape.test.ts
@@ -31,8 +31,8 @@ function memory(): NoydbStore {
       for (const [key, env] of data) {
         const [vname, cname, id] = key.split('/')
         if (vname === v) {
-          out[cname] = out[cname] ?? {}
-          out[cname][id] = env
+          out[cname!] = out[cname!] ?? {}
+          out[cname!]![id!] = env
         }
       }
       return out
@@ -79,7 +79,7 @@ function monthsCovered(periods: ReadonlyArray<{ from: string; to: string }>): st
 }
 
 async function buildDb() {
-  const strategy = withDerivation<Worker, { activeInPeriod: ActivePeriod }>({
+  const strategy = withDerivation<Worker, { activeInPeriod: ActivePeriod[] }>({
     source: 'workers',
     deterministic: true,
     outputs: {
@@ -215,7 +215,7 @@ describe('shape: array — basic fanout (#200)', () => {
 
 describe('shape: array — validation', () => {
   it('rejects lifecycle "lazy" + shape "array"', () => {
-    expect(() => withDerivation<Worker, { activeInPeriod: ActivePeriod }>({
+    expect(() => withDerivation<Worker, { activeInPeriod: ActivePeriod[] }>({
       source: 'workers',
       deterministic: true,
       outputs: {
@@ -231,7 +231,7 @@ describe('shape: array — validation', () => {
   })
 
   it('rejects array output without a key extractor', () => {
-    expect(() => withDerivation<Worker, { activeInPeriod: ActivePeriod }>({
+    expect(() => withDerivation<Worker, { activeInPeriod: ActivePeriod[] }>({
       source: 'workers',
       deterministic: true,
       outputs: {
@@ -244,7 +244,7 @@ describe('shape: array — validation', () => {
   })
 
   it('rejects negative or zero maxFanout', () => {
-    expect(() => withDerivation<Worker, { activeInPeriod: ActivePeriod }>({
+    expect(() => withDerivation<Worker, { activeInPeriod: ActivePeriod[] }>({
       source: 'workers',
       deterministic: true,
       outputs: {
@@ -263,7 +263,7 @@ describe('shape: array — validation', () => {
 
 describe('shape: array — runtime errors', () => {
   it('throws DerivationCapExceededError when array exceeds maxFanout', async () => {
-    const strategy = withDerivation<Worker, { activeInPeriod: ActivePeriod }>({
+    const strategy = withDerivation<Worker, { activeInPeriod: ActivePeriod[] }>({
       source: 'workers',
       deterministic: true,
       outputs: {
@@ -305,7 +305,7 @@ describe('shape: array — runtime errors', () => {
   })
 
   it('throws DerivationOutputShapeError on duplicate keys', async () => {
-    const strategy = withDerivation<Worker, { dup: { id: string; v: number } }>({
+    const strategy = withDerivation<Worker, { dup: { id: string; v: number }[] }>({
       source: 'workers',
       deterministic: true,
       outputs: {

--- a/packages/hub/__tests__/introspection/dump-schema-views.test.ts
+++ b/packages/hub/__tests__/introspection/dump-schema-views.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/types.js'
 import { ConflictError } from '../../src/errors.js'
-import { createNoydb, withMaterializedView, sum } from '../../src/index.js'
+import { createNoydb, withMaterializedView, sum, GroupedAggregation } from '../../src/index.js'
 import { withAggregate } from '../../src/aggregate/index.js'
 
 function inlineMemory(): NoydbStore {
@@ -47,7 +47,7 @@ describe('vault.dumpSchema() — materialized views', () => {
       name: 'invoice-totals',
       sources: ['invoices'],
       query: (db) => db.collection<Invoice>('invoices').query()
-        .groupBy('client_id').aggregate({ total: sum('amount') }),
+        .groupBy('client_id').aggregate({ total: sum('amount') }) as GroupedAggregation<{ client_id: string; total: number }>,
       rowKey: (r) => r.client_id,
       refresh: 'eager',
     })

--- a/packages/hub/__tests__/introspection/json-schema.test.ts
+++ b/packages/hub/__tests__/introspection/json-schema.test.ts
@@ -68,8 +68,8 @@ interface Order {
 
 // ─── Shared fixtures ──────────────────────────────────────────────────────────
 
-let orders: ReturnType<ReturnType<Awaited<ReturnType<typeof createNoydb>>['openVault']>['collection']>
-let stubColl: ReturnType<ReturnType<Awaited<ReturnType<typeof createNoydb>>['openVault']>['collection']>
+let orders: ReturnType<Awaited<ReturnType<Awaited<ReturnType<typeof createNoydb>>['openVault']>>['collection']>
+let stubColl: ReturnType<Awaited<ReturnType<Awaited<ReturnType<typeof createNoydb>>['openVault']>>['collection']>
 
 describe('collection.toJSONSchema()', async () => {
   const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-json-schema-1' })
@@ -85,12 +85,12 @@ describe('collection.toJSONSchema()', async () => {
   })
 
   orders = v.collection<Order>('orders_js', {
-    schema: ordersSchema as unknown as import('../../src/schema.js').StandardSchemaV1,
+    schema: ordersSchema as import('../../src/schema.js').StandardSchemaV1<unknown, Order>,
     moneyFields: { total: money({ currency: 'EUR' }) },
     refs: { buyerId: ref('buyers') },
     dictKeyFields: { status: dictKey('saleStatus', { draft: 'Draft', to_verify: 'To Verify' }) },
     fieldMeta: {
-      buyerVat: { sensitivity: 'pii' },
+      buyerVat: { sensitivity: 'pii', label: 'Buyer VAT' },
     },
   })
 
@@ -109,15 +109,15 @@ describe('collection.toJSONSchema()', async () => {
 
   it('emits JSON Schema with x- metadata extensions', async () => {
     const js = await orders.toJSONSchema() as { properties: Record<string, Record<string, unknown>> }
-    expect(js.properties.total['x-semanticType']).toBe('currency')
-    expect(js.properties.total['x-money']).toMatchObject({ currency: 'EUR' })
-    expect(js.properties.status['x-enumLabels']).toMatchObject({ to_verify: 'To Verify' })
-    expect(js.properties.buyerVat['x-sensitivity']).toBe('pii')
+    expect(js.properties.total!['x-semanticType']).toBe('currency')
+    expect(js.properties.total!['x-money']).toMatchObject({ currency: 'EUR' })
+    expect(js.properties.status!['x-enumLabels']).toMatchObject({ to_verify: 'To Verify' })
+    expect(js.properties.buyerVat!['x-sensitivity']).toBe('pii')
   })
 
   it('non-zod validator → minimal schema from field types, no throw', async () => {
     const js = await stubColl.toJSONSchema() as { type: string; properties: Record<string, Record<string, unknown>> }
     expect(js.type).toBe('object')
-    expect(js.properties.total['x-semanticType']).toBe('currency')
+    expect(js.properties.total!['x-semanticType']).toBe('currency')
   })
 })

--- a/packages/hub/__tests__/materialized-views/correctness.test.ts
+++ b/packages/hub/__tests__/materialized-views/correctness.test.ts
@@ -6,6 +6,7 @@ import {
   MaterializedViewTooLargeError,
   withGuard,
   RecordLockedError,
+  GroupedAggregation,
 } from '../../src/index.js'
 import { withAggregate } from '../../src/aggregate/index.js'
 import { sum, count } from '../../src/aggregate/reducers.js'
@@ -16,7 +17,7 @@ function memory(): NoydbStore {
   const data = new Map<string, EncryptedEnvelope>()
   const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
   return {
-    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    capabilities: { casAtomic: true, auth: { kind: 'none', required: false, flow: 'static' } },
     async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
     async put(v, c, i, env) { data.set(k(v, c, i), env) },
     async delete(v, c, i) { data.delete(k(v, c, i)) },
@@ -29,16 +30,16 @@ function memory(): NoydbStore {
       for (const [key, env] of data) {
         const [vname, cname, id] = key.split('/')
         if (vname === v) {
-          out[cname] = out[cname] ?? {}
-          out[cname][id] = env
+          out[cname!] = out[cname!] ?? {}
+          out[cname!]![id!] = env
         }
       }
       return out
     },
     async saveAll(v, payload) {
       for (const c of Object.keys(payload)) {
-        for (const i of Object.keys(payload[c])) {
-          data.set(k(v, c, i), payload[c][i])
+        for (const i of Object.keys(payload[c]!)) {
+          data.set(k(v, c, i), payload[c]![i]!)
         }
       }
     },
@@ -365,7 +366,7 @@ describe('MV correctness (#152)', () => {
         query: (db) => db.collection<Compensation>('compensations')
           .query()
           .groupBy('clientId')
-          .aggregate({ taxTotal: sum<Compensation>('taxAmount') }),
+          .aggregate({ taxTotal: sum('taxAmount') }) as GroupedAggregation<ClientTotalRow>,
         rowKey: (r) => r.clientId,
         refresh: 'eager',
       })
@@ -397,7 +398,7 @@ describe('MV correctness (#152)', () => {
         sources: ['items'],
         query: (db) => db.collection<Item>('items')
           .query()
-          .aggregate({ totalAmount: sum<Item>('n'), n: count<Item>() }),
+          .aggregate({ totalAmount: sum('n'), n: count() }),
         rowKey: () => 'grand-total',
         refresh: 'eager',
       })

--- a/packages/hub/__tests__/materialized-views/multikey.test.ts
+++ b/packages/hub/__tests__/materialized-views/multikey.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { createNoydb, withMaterializedView, sum } from '../../src/index.js'
+import { createNoydb, withMaterializedView, sum, GroupedAggregation } from '../../src/index.js'
 import { withAggregate } from '../../src/aggregate/index.js'
 import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
 
@@ -7,7 +7,7 @@ function memory(): NoydbStore {
   const data = new Map<string, EncryptedEnvelope>()
   const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
   return {
-    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    capabilities: { casAtomic: true, auth: { kind: 'none', required: false, flow: 'static' } },
     async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
     async put(v, c, i, env) { data.set(k(v, c, i), env) },
     async delete(v, c, i) { data.delete(k(v, c, i)) },
@@ -20,16 +20,16 @@ function memory(): NoydbStore {
       for (const [key, env] of data) {
         const [vname, cname, id] = key.split('/')
         if (vname === v) {
-          out[cname] = out[cname] ?? {}
-          out[cname][id] = env
+          out[cname!] = out[cname!] ?? {}
+          out[cname!]![id!] = env
         }
       }
       return out
     },
     async saveAll(v, payload) {
       for (const c of Object.keys(payload)) {
-        for (const i of Object.keys(payload[c])) {
-          data.set(k(v, c, i), payload[c][i])
+        for (const i of Object.keys(payload[c]!)) {
+          data.set(k(v, c, i), payload[c]![i]!)
         }
       }
     },
@@ -61,7 +61,7 @@ describe('withMaterializedView — multi-key groupBy inside query() (#166)', () 
         db.collection<Compensation>('compensations')
           .query()
           .groupBy('clientId', 'period')
-          .aggregate({ total: sum('taxAmount') }),
+          .aggregate({ total: sum('taxAmount') }) as GroupedAggregation<Pnd1Row>,
       sources: ['compensations'],
       rowKey: row => `${row.clientId}|${row.period}`,
       refresh: 'eager',

--- a/packages/hub/src/aggregate/reducers.ts
+++ b/packages/hub/src/aggregate/reducers.ts
@@ -146,6 +146,14 @@ export function count(opts?: ReducerOptions<number>): Reducer<number> {
  * at the field path are coerced to 0 — consumers who want a different
  * behavior (throw, skip, treat as NaN) should filter upstream via
  * `.where()` or write a custom reducer.
+ *
+ * KNOWN LIMITATION (type imprecision): the declared result type is `number`,
+ * but when `field` is a **money** field the runtime returns a decimal *string*
+ * (e.g. `'0.30'`, or `{ EUR: '0.30' }` in multi-currency mode) — money sums are
+ * BigInt-exact in scaled space and never collapse to a float. The `number` type
+ * is therefore a lie for money fields; narrow the result yourself at the call
+ * site. A precise fix requires threading money-field declarations into the type
+ * system (tracked separately).
  */
 export function sum(
   field: string,

--- a/packages/hub/src/derivations/executor.ts
+++ b/packages/hub/src/derivations/executor.ts
@@ -64,7 +64,7 @@ export const DerivationExecutor = {
    */
   async run<
     TSource extends Record<string, unknown>,
-    TOutputs extends Record<string, Record<string, unknown>>,
+    TOutputs extends Record<string, Record<string, unknown> | ReadonlyArray<Record<string, unknown>>>,
   >(
     strategy: DerivationStrategy<TSource, TOutputs>,
     source: TSource & { id: string },

--- a/packages/hub/src/derivations/types.ts
+++ b/packages/hub/src/derivations/types.ts
@@ -121,11 +121,13 @@ export type OutputSpec = RecordOutputSpec | ArrayOutputSpec
  * Registration shape passed to `withDerivation()`.
  *
  * @typeParam TSource - the source record type
- * @typeParam TOutputs - map of output-key → output record type
+ * @typeParam TOutputs - map of output-key → output record type. An output
+ *   value may be a single record, or — for `shape: 'array'` outputs — an
+ *   array of records (the fanout sidecar upserts/deletes each row).
  */
 export interface DerivationStrategy<
   TSource extends Record<string, unknown>,
-  TOutputs extends Record<string, Record<string, unknown>>,
+  TOutputs extends Record<string, Record<string, unknown> | ReadonlyArray<Record<string, unknown>>>,
 > {
   /** Source collection name. */
   source: string

--- a/packages/hub/src/derivations/with-derivation.ts
+++ b/packages/hub/src/derivations/with-derivation.ts
@@ -11,7 +11,7 @@ import type { DerivationStrategy, DerivationStrategyHandle } from './types.js'
  */
 export function withDerivation<
   TSource extends Record<string, unknown>,
-  TOutputs extends Record<string, Record<string, unknown>>,
+  TOutputs extends Record<string, Record<string, unknown> | ReadonlyArray<Record<string, unknown>>>,
 >(spec: DerivationStrategy<TSource, TOutputs>): DerivationStrategyHandle {
   if (!spec.source || spec.source.length === 0) {
     throw new ValidationError('withDerivation: source collection name is required')

--- a/packages/hub/src/materialized-views/registry.ts
+++ b/packages/hub/src/materialized-views/registry.ts
@@ -93,8 +93,11 @@ export class MaterializedViewRegistry {
       qAny = q as any
       isQuery = typeof qAny._plan === 'function'
       if (isQuery) {
-        dependencies = analyzeDependencies(q)
-        queryPlanSummary = summarizeQueryPlan(q)
+        // `q` is the `Query` arm of the union here (runtime-confirmed via
+        // `qAny._plan` above); reuse the already-`any` `qAny` the block uses
+        // for `_plan()` rather than re-narrowing.
+        dependencies = analyzeDependencies(qAny)
+        queryPlanSummary = summarizeQueryPlan(qAny)
         // Fold `.wherePredicate(name, ctx)` references into the plan
         // summary so predicate function or ctx changes (signalled by
         // bumping `hash` or supplying a different ctx) propagate into

--- a/packages/hub/src/materialized-views/types.ts
+++ b/packages/hub/src/materialized-views/types.ts
@@ -1,6 +1,7 @@
 import type { Query } from '../query/builder.js'
 import type { Collection } from '../collection.js'
-import type { AggregateSpec } from '../aggregate/aggregation.js'
+import type { AggregateSpec, Aggregation } from '../aggregate/aggregation.js'
+import type { GroupedAggregation } from '../aggregate/groupby.js'
 import type { JoinStrategy } from '../query/join.js'
 import type { MoneyDescriptor } from '../money/descriptor.js'
 import type { I18nTextDescriptor } from '../i18n/core.js'
@@ -148,7 +149,7 @@ export interface MaterializedViewStrategy<TRow extends Record<string, unknown>> 
    * (multi-source UNION). Registration throws
    * `MaterializedViewConfigError` if both are set or neither is set.
    */
-  query?: (db: MVQueryContext) => Query<TRow>
+  query?: (db: MVQueryContext) => Query<TRow> | Aggregation<TRow> | GroupedAggregation<TRow>
   /**
    * UNION-form sources: an explicit list of sibling collections
    * that contribute rows to a single MV. Each arm's `map` projects a

--- a/packages/hub/src/shadow/vault-frame.ts
+++ b/packages/hub/src/shadow/vault-frame.ts
@@ -38,6 +38,7 @@
  * @module
  */
 import type { Collection } from '../collection.js'
+import type { Query } from '../query/builder.js'
 import type { Vault } from '../vault.js'
 import type { LocaleReadOptions } from '../types.js'
 import { ReadOnlyFrameError } from '../errors.js'
@@ -93,8 +94,13 @@ export class CollectionFrame<T = unknown> {
    * `.first()`, `.count()`, `.aggregate()` all work; the builder has
    * no write surface of its own, so exposing it directly is safe.
    */
-  query(...args: Parameters<Collection<T>['query']>): ReturnType<Collection<T>['query']> {
-    return this.inner.query(...args)
+  query(): Query<T>
+  query(predicate: (record: T) => boolean): T[]
+  query(predicate?: (record: T) => boolean): Query<T> | T[] {
+    // Explicit overloads mirror Collection.query's two signatures. A
+    // `Parameters<>`/`ReturnType<>` forward collapses to the *last* overload
+    // only (`(predicate) => T[]`), losing the no-arg `() => Query<T>` form.
+    return predicate !== undefined ? this.inner.query(predicate) : this.inner.query()
   }
 
   /** History reads — allowed (history is read-only by nature). */

--- a/packages/hub/tsconfig.tests.json
+++ b/packages/hub/tsconfig.tests.json
@@ -15,14 +15,9 @@
   ],
   "exclude": [
     "__tests__/coordinated-cutover-integration.test.ts",
-    "__tests__/derivations/array-shape.test.ts",
-    "__tests__/introspection/dump-schema-views.test.ts",
-    "__tests__/introspection/json-schema.test.ts",
     "__tests__/managed-mode-adoption.test.ts",
     "__tests__/managed-mode-strong-recovery.test.ts",
     "__tests__/managed-passphrase.test.ts",
-    "__tests__/materialized-views/correctness.test.ts",
-    "__tests__/materialized-views/multikey.test.ts",
     "__tests__/money/mv-and-live.test.ts",
     "__tests__/no-self-provision.test.ts",
     "__tests__/schema-introspection.test.ts",
@@ -31,7 +26,6 @@
     "__tests__/shamir-recovery.test.ts",
     "__tests__/snapshots.test.ts",
     "__tests__/transaction.test.ts",
-    "__tests__/vault-frame.test.ts",
     "__tests__/write-hooks-integration.test.ts"
   ]
 }


### PR DESCRIPTION
## What

Fixes 4 public type-soundness gaps in `@noy-db/hub` where the **type contradicted the runtime** — surfaced by the test-typecheck ratchet (#506/#507). All backward-compatible (additive widenings + a faithful overload reconstruction). Un-gates 6 test files from the burn-down backlog (exclude **19 → 13**).

## The fixes

1. **`MaterializedViewStrategy.query`** — was `(db) => Query<TRow>`, but the MV executor already branches on `.toArray`/`.run` and accepts `Aggregation`/`GroupedAggregation` (the `sources` field's own JSDoc documents this). Widened to the 3-way union. Pure return-type widening — no caller returning `Query<TRow>` breaks; the aggregate-arm runtime guard (registry throws if an aggregate has no explicit `sources`) is untouched.

2. **`withDerivation` / `DerivationStrategy` `TOutputs`** — was `Record<string, Record<string,unknown>>`, which rejects `shape:'array'` outputs the fanout sidecar handles. Relaxed to allow `ReadonlyArray` output values (interface + function constraint + the internal `DerivationExecutor.run`). Strict superset — Record-only callers unaffected; the `outputs` map (`{ [K in keyof TOutputs]: OutputSpec }`) uses only `keyof`.

3. **`CollectionFrame.query`** — was `(...args: Parameters<Collection['query']>)`, which collapses the *overloaded* `query` to its last signature (`(predicate)=>T[]`), losing the no-arg `()=>Query` form (so `frame.query().where(...)` didn't typecheck). Replaced with explicit overloads mirroring `Collection.query`. Runtime dispatch is equivalent.

4. **`sum()` doc** — documented the known type imprecision: money fields return a decimal *string* at runtime (`'0.30'`), not the declared `number`. A precise fix needs money-field type-threading (deferred).

## Verification
- `pnpm --filter @noy-db/hub typecheck` green (src + type-tests + the ratchet incl. the 6 newly-gated files).
- Full suite **2909/328** — behavior preserved (the changes are type-only or runtime-equivalent).
- **opus review: Ready to merge** — each fix verified correct/backward-compatible against the runtime; no Critical/Important; the only review minor (an inconsistent internal constraint) is fixed in this PR.

## Notes
- The MV query callbacks keep a **single-level** `as GroupedAggregation<TRow>` (the developer asserting the aggregate yields the declared MV row type) — honest narrowing, NOT `as unknown as`. A cast-free fix would require threading group-field types through `groupBy()` (deferred, same class as the money sum-type limitation).
- `mv-and-live.test.ts` stays excluded pending the deferred money sum-type decision.

Backlog after this: **136 → 13** (12 sibling-importers needing devDeps + `mv-and-live`).
