### PR TITLE
test(hub): finish test-typecheck burn-down — backlog 13 → 1 (wave 3)

### DIFF
--- a/packages/hub/__tests__/coordinated-cutover-integration.test.ts
+++ b/packages/hub/__tests__/coordinated-cutover-integration.test.ts
@@ -72,7 +72,7 @@ describe('coordinatedCutover E2E (#232 3a)', () => {
     await v._drainPendingSchemaWrites()
 
     v = await open(store)
-    const logs = v.collection<{ id: string; level?: string }>('logs', {
+    const logs = v.collection<{ id: string; level?: string | undefined }>('logs', {
       schema: z.object({ id: z.string(), level: z.string().optional() }), // additive
       persistJsonSchema: true, schemaUpdate: [coordinatedCutover({ transform: (d) => d }), additiveOnly()],
     })

--- a/packages/hub/__tests__/managed-mode-adoption.test.ts
+++ b/packages/hub/__tests__/managed-mode-adoption.test.ts
@@ -109,7 +109,7 @@ describe('managed-mode adoption', () => {
         userId: 'belle',
         passphraseMode: 'managed',
         sealingKey: new MemorySealingKeyProvider({ id: 'belle-keychain' }),
-        recovery: [{ profile: 'paper', count: 6 }], // paper alone is not strong
+        recovery: [{ profile: 'paper', entries: [] }], // paper alone is not strong
         shamirRecovery: shamirRecoveryProvider(),
         transferKey,
       }),

--- a/packages/hub/__tests__/managed-passphrase.test.ts
+++ b/packages/hub/__tests__/managed-passphrase.test.ts
@@ -280,7 +280,8 @@ describe('MemoryRecipientSealer', () => {
 
     // Flip a byte in the ciphertext region (after the version + wrapped CEK + IV header).
     const tampered = new Uint8Array(sealed)
-    tampered[1 + 256 + 12 + 1] ^= 0x01
+    const tamperedIdx = 1 + 256 + 12 + 1
+    tampered[tamperedIdx] = tampered[tamperedIdx]! ^ 0x01
 
     await expect(recipient.unseal(tampered)).rejects.toThrow()
   })

--- a/packages/hub/__tests__/schema-introspection.test.ts
+++ b/packages/hub/__tests__/schema-introspection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { z } from 'zod'
-import { createNoydb, type NoydbStore } from '../src/noydb.js'
+import { createNoydb } from '../src/noydb.js'
+import type { NoydbStore } from '../src/types.js'
 import { memory } from '../../to-memory/src/index.js'
 import { withGuard } from '../src/guards/with-guard.js'
 import { additiveOnly, coordinatedCutover } from '../src/schema-update/index.js'

--- a/packages/hub/__tests__/schema-update-integration.test.ts
+++ b/packages/hub/__tests__/schema-update-integration.test.ts
@@ -11,7 +11,7 @@ import { additiveOnly, lockSchema } from '../src/schema-update/index.js'
 import { NonAdditiveSchemaChangeError, SchemaLockedError } from '../src/errors.js'
 import type { NoydbStore } from '../src/types.js'
 
-interface Invoice extends Record<string, unknown> { id: string; amount?: number }
+interface Invoice extends Record<string, unknown> { id: string; amount?: number | undefined }
 
 async function reopen(store: NoydbStore) {
   const db = await createNoydb({ store, user: 'alice', secret: 'schema-update-test-pass-1234' })

--- a/packages/hub/__tests__/schema-update/apply-cutover.test.ts
+++ b/packages/hub/__tests__/schema-update/apply-cutover.test.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { createNoydb } from '../../src/noydb.js'
 import { memory } from '../../../to-memory/src/index.js'
 
-interface Inv extends Record<string, unknown> { id: string; total?: number; amount?: { gross: number } }
+interface Inv extends Record<string, unknown> { id: string; total?: number | undefined; amount?: { gross: number } | undefined }
 
 describe('Collection._applyCutoverTransform', () => {
   it('rewrites every record through the transform, bumping _v', async () => {
@@ -16,7 +16,6 @@ describe('Collection._applyCutoverTransform', () => {
     await invoices.put('i1', { id: 'i1', total: 100 })
     await invoices.put('i2', { id: 'i2', total: 200 })
 
-    // @ts-expect-error internal method
     const count = await invoices._applyCutoverTransform((d) => ({ id: d['id'], amount: { gross: d['total'] } }))
     expect(count).toBe(2)
     expect((await invoices.get('i1'))?.amount?.gross).toBe(100)

--- a/packages/hub/__tests__/snapshots.test.ts
+++ b/packages/hub/__tests__/snapshots.test.ts
@@ -185,8 +185,8 @@ describe('SnapshotEngine.listSnapshots()', () => {
 
     const list = await engine.listSnapshots('v1')
     expect(list).toHaveLength(2)
-    expect(list[0].version).toBe(m2.version) // newest first
-    expect(list[1].version).toBe(m1.version)
+    expect(list[0]!.version).toBe(m2.version) // newest first
+    expect(list[1]!.version).toBe(m1.version)
   })
 })
 
@@ -210,8 +210,8 @@ describe('SnapshotEngine retention', () => {
 
     const list = await engine.listSnapshots('v1')
     expect(list).toHaveLength(2)
-    expect(list[0].version).toBe(m3.version)
-    expect(list[1].version).toBe(m2.version)
+    expect(list[0]!.version).toBe(m3.version)
+    expect(list[1]!.version).toBe(m2.version)
   })
 
   it('prune:false — never deletes even when keepLast exceeded', async () => {
@@ -247,8 +247,8 @@ describe('SnapshotEngine retention', () => {
 
     expect(toDelete).toEqual(['v1__snap_000001'])
     expect(index.snapshots).toHaveLength(2)
-    expect(index.snapshots[0].version).toBe('v1__snap_000002')
-    expect(index.snapshots[1].version).toBe('v1__snap_000003')
+    expect(index.snapshots[0]!.version).toBe('v1__snap_000002')
+    expect(index.snapshots[1]!.version).toBe('v1__snap_000003')
   })
 
   it('applyRetention directly — prune:false returns empty even with excess', () => {

--- a/packages/hub/__tests__/transaction.test.ts
+++ b/packages/hub/__tests__/transaction.test.ts
@@ -18,7 +18,6 @@ import { ConflictError, createNoydb, SyncTransaction } from '../src/index.js'
 import { withSync } from '../src/sync/index.js'
 import { withTransactions } from '../src/tx/index.js'
 import type { Noydb } from '../src/index.js'
-import { withSync } from '../src/sync/index.js'
 
 interface Invoice { amount: number; status: string }
 interface Payment { invoiceId: string; amount: number; paidAt: string }

--- a/packages/hub/__tests__/write-hooks-integration.test.ts
+++ b/packages/hub/__tests__/write-hooks-integration.test.ts
@@ -1,6 +1,7 @@
 /** E2E for hub write lifecycle hooks (#230). */
 import { describe, expect, it } from 'vitest'
-import { createNoydb, type Noydb, type WriteEvent } from '../src/noydb.js'
+import { createNoydb, type Noydb } from '../src/noydb.js'
+import type { WriteEvent } from '../src/index.js'
 import { withTransactions } from '../src/tx/index.js'
 import { memory } from '../../to-memory/src/index.js'
 

--- a/packages/hub/tsconfig.tests.json
+++ b/packages/hub/tsconfig.tests.json
@@ -14,18 +14,6 @@
     "__tests__/**/*.test.ts"
   ],
   "exclude": [
-    "__tests__/coordinated-cutover-integration.test.ts",
-    "__tests__/managed-mode-adoption.test.ts",
-    "__tests__/managed-mode-strong-recovery.test.ts",
-    "__tests__/managed-passphrase.test.ts",
-    "__tests__/money/mv-and-live.test.ts",
-    "__tests__/no-self-provision.test.ts",
-    "__tests__/schema-introspection.test.ts",
-    "__tests__/schema-update-integration.test.ts",
-    "__tests__/schema-update/apply-cutover.test.ts",
-    "__tests__/shamir-recovery.test.ts",
-    "__tests__/snapshots.test.ts",
-    "__tests__/transaction.test.ts",
-    "__tests__/write-hooks-integration.test.ts"
+    "__tests__/money/mv-and-live.test.ts"
   ]
 }


### PR DESCRIPTION
## What

Final wave of the test-typecheck burn-down: fixes the last 12 sibling-importing test files (16 type errors) and un-gates them. **Backlog 13 → 1** — only `mv-and-live.test.ts` remains (pending the deferred money sum-type project).

## No infra change needed

The earlier concern that these needed sibling `devDependencies` was wrong: the only `@noy-db/*` package-name import is `on-shamir`, which is **already a hub dependency** (built in CI via `^build`); the rest resolve via relative source paths. So the gated set stays **CI-robust** with no manifest change. 3 of the 12 (`shamir-recovery`, `managed-mode-strong-recovery`, `no-self-provision`) had **zero** type errors — they were excluded only by the old sibling-robustness rule and are now simply un-gated.

## Real drift surfaced
- `WriteEvent` / `NoydbStore` imported from the wrong module (not exported from where the tests reached for them).
- `managed-mode-adoption` used `{ profile: 'paper', count: 6 }` where `PaperRecovery` wants `entries`.
- Zod 4's `ZodOptional<T>` produces `T | undefined` (distinct from `?: T` under `exactOptionalPropertyTypes`), so several test interfaces widened to match what Zod actually validates.

## Verification
- `pnpm --filter @noy-db/hub typecheck` green (src + type-tests + the ratchet now gating all but 1 file).
- Full suite **2909/328** — behavior preserved (type-only).

## The backlog is now a single, well-understood entry
`mv-and-live.test.ts` stays excluded until the money sum-type-threading project (the type-system work to make `sum()` on money fields return `string` instead of the current `number` lie — a deliberate, separate effort).
