### PR TITLE
feat(hub): export Sealed/SealedView/SealedHandle from the package barrel

### DIFF
--- a/packages/hub/__tests__/sealed-exports.test-d.ts
+++ b/packages/hub/__tests__/sealed-exports.test-d.ts
@@ -1,0 +1,34 @@
+/**
+ * Public-surface contract: the sealed-field access types (#504) are importable
+ * from the package barrel `@noy-db/hub`, so consumers can annotate sealed reads
+ * without reaching into internal modules. Validated by
+ * `pnpm --filter @noy-db/hub typecheck:types` (tsc only). A missing barrel
+ * export makes this file fail to compile.
+ */
+import { describe, it, expectTypeOf } from 'vitest'
+// Import from the package entry (the barrel), NOT from ../src/types.js — that
+// is the whole point of this test.
+import { SealedHandle } from '../src/index.js'
+import type { Sealed, SealedView } from '../src/index.js'
+
+interface Person { id: string; name: string; ssn: string }
+
+describe('sealed-field types are on the public barrel', () => {
+  it('Sealed<V> is the opaque handle contract', () => {
+    expectTypeOf<Sealed<string>['sealed']>().toEqualTypeOf<true>()
+    expectTypeOf<Sealed<string>['reveal']>().toEqualTypeOf<() => Promise<string>>()
+  })
+
+  it('SealedView<T, S> maps sealed fields to handles, keeps the rest', () => {
+    type V = SealedView<Person, 'ssn'>
+    expectTypeOf<V['ssn']>().toEqualTypeOf<Sealed<string>>()
+    expectTypeOf<V['name']>().toEqualTypeOf<string>()
+    // Identity when nothing is sealed.
+    expectTypeOf<SealedView<Person, never>>().toEqualTypeOf<Person>()
+  })
+
+  it('SealedHandle is exported as a value (for instanceof narrowing)', () => {
+    // A SealedHandle instance satisfies the Sealed<V> contract.
+    expectTypeOf<InstanceType<typeof SealedHandle<string>>>().toMatchTypeOf<Sealed<string>>()
+  })
+})

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -1063,6 +1063,14 @@ export type {
 // Query DSL helpers (escape-hatch types for consumers with dynamic field names)
 export type { QueryField, IndexFieldName } from './types.js'
 
+// Sealed-field access surface (#504): `Sealed<V>` is the opaque handle a public
+// read returns for a `sensitive` field; `SealedView<T, S>` is the record shape
+// `get()` returns (sealed fields → handles); `SealedHandle` is the concrete
+// class (exported for `instanceof` narrowing — the `Sealed.sealed` discriminant
+// also narrows structurally).
+export type { Sealed, SealedView } from './types.js'
+export { SealedHandle } from './types.js'
+
 // Scan-mode full-text search (#308)
 export { tokenize } from './search/index.js'
 export type { Tokenizer, SearchOptions, SearchResult, SearchEntry } from './search/index.js'


### PR DESCRIPTION
## What
Exports the #504 sealed-field access types — `Sealed<V>`, `SealedView<T,S>`, and the `SealedHandle` class — from the package barrel. They existed in `src/types.ts` but were never on the public surface, so consumers couldn't annotate sealed reads (`r.ssn: Sealed<string>`, the `SealedView` shape `get()` returns) without importing from internal paths.

## Surface added
```ts
import { SealedHandle } from '@noy-db/hub'          // value — for `instanceof`
import type { Sealed, SealedView } from '@noy-db/hub'
```
`SealedHandle` is the concrete class (enables `instanceof` narrowing); `Sealed`'s `sealed: true` discriminant also narrows structurally.

## Verification
- Confirmed `Sealed`/`SealedView`/`SealedHandle` are in the emitted `dist/index.d.ts` export block.
- New `sealed-exports.test-d.ts` imports all three **from the barrel** (not `../src/types.js`), so a missing export is a compile failure — and the typecheck ratchet keeps it that way.
- Full hub `typecheck` green; architecture OK.

Closes the small public-surface gap flagged during the P3 sealed-fields epic (#504/#505).