### PR TITLE
feat(hub): refuse sensitive fields in groupBy() (+ document aggregate gap)

### DIFF
--- a/packages/hub/__tests__/sealed-query-refusal.test-d.ts
+++ b/packages/hub/__tests__/sealed-query-refusal.test-d.ts
@@ -110,3 +110,24 @@ describe('index-declaration sensitive-field refusal', () => {
     vault.collection<Person>('e', { indexes: ['anything', { fields: ['x', 'y'] }] })
   })
 })
+
+describe('groupBy sensitive-field refusal', () => {
+  it('refuses groupBy on a sensitive field; allows non-sensitive', async () => {
+    const vault = await typedVault()
+    const people = vault.collection<Person, 'ssn'>('people', { sensitive: ['ssn'] })
+    const q = people.query()
+    // @ts-expect-error — grouping BY a sealed field leaks its values as group keys
+    q.groupBy('ssn')
+    q.groupBy('name')              // ok
+    // @ts-expect-error — multi-field groupBy also refuses a sealed field
+    q.groupBy('name', 'ssn')
+    q.groupBy('name', 'age')       // ok
+  })
+
+  it('keeps groupBy permissive without sensitive fields', async () => {
+    const vault = await typedVault()
+    const plain = vault.collection<Person>('plain')
+    plain.query().groupBy('ssn')           // S = never -> any field
+    plain.query().groupBy('name', 'age')
+  })
+})

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -718,6 +718,14 @@ export class Query<T, S extends keyof T = never> {
    * executor — that's  constraint #2. When partition-aware
    * aggregation lands, the seed will carry running state across
    * partition boundaries without an API break.
+   *
+   * KNOWN GAP (sealed fields): `where`/`orderBy`/`groupBy` refuse a
+   * `sensitive` field at compile time, but a reducer over a sensitive field
+   * (e.g. `aggregate({ x: sum('ssn') })`) is NOT refused — the reducer
+   * factories (`sum`/`min`/`max`/…) are standalone `(field: string)` functions
+   * with no collection-type context, so `aggregate(spec)` cannot see which
+   * field is inside each reducer. Closing this requires a typed spec-builder
+   * redesign (tracked separately); avoid aggregating sensitive fields.
    */
   aggregate<Spec extends AggregateSpec>(
     spec: Spec,
@@ -806,8 +814,11 @@ export class Query<T, S extends keyof T = never> {
    * The performance caveat is the same: filter clauses cost O(N)
    * per record and can't be index-accelerated.
    */
-  groupBy<F extends string>(field: F): GroupedQuery<T, F>
-  groupBy<F extends readonly [string, string, ...string[]]>(
+  // The `field` param is `QueryField<T, S>` so a sealed (`sensitive`) field is
+  // refused — grouping BY a sensitive field leaks its value distribution as
+  // group-key labels. With `S = never` this is exactly `string` (zero churn).
+  groupBy<F extends QueryField<T, S>>(field: F): GroupedQuery<T, F>
+  groupBy<F extends readonly [QueryField<T, S>, QueryField<T, S>, ...QueryField<T, S>[]]>(
     ...fields: F
   ): GroupedQueryN<T, F>
   groupBy(...fields: readonly string[]): GroupedQuery<T, string> | GroupedQueryN<T, readonly string[]> {


### PR DESCRIPTION
## What
Extends the sensitive-field compile-time refusal (from #505) to `Query.groupBy()`.

```ts
const people = vault.collection<Person, 'ssn'>('people', { sensitive: ['ssn'] })
people.query().groupBy('ssn')          // ❌ compile error (leaks values as group keys)
people.query().groupBy('name')         // ✅
people.query().groupBy('name', 'ssn')  // ❌ (multi-field overload too)
```

`groupBy`'s `field` param (both single- and multi-field overloads) is now `QueryField<T, S>` instead of bare `string`. With `S = never` it's exactly `string` — **zero churn** (242 existing call sites unaffected; the literal still infers for the group-key type).

## Scope (per design decision)
- **groupBy** → refuse sensitive ✅ (this PR).
- **orderBy** → already refused sensitive (from #505).
- **live()** → no field params; nothing to do (`S`-refusal is about predicate field *names*, not result shape).
- **aggregate** → **documented known gap**: `aggregate({ x: sum('ssn') })` is *not* refused, because `sum`/`min`/`max` are standalone `(field: string)` factories with no collection-type context. Closing it needs a typed spec-builder redesign (separate project). JSDoc note added on `aggregate()`.

## Verification
- Full hub `typecheck` green (incl. the new groupBy refusal type-tests: `.groupBy('ssn')` refused, plain collections permissive).
- Suite **2912/329** — type-only, behavior unchanged.

This is the "extend refusal to groupBy/aggregate/live" half. The `Q = indexed-only where()` restriction is a separate, larger PR.