### PR TITLE
feat(hub): Q = indexed-only where() restriction (opt-in 3rd generic)

### DIFF
--- a/packages/hub/__tests__/sealed-query-refusal.test-d.ts
+++ b/packages/hub/__tests__/sealed-query-refusal.test-d.ts
@@ -131,3 +131,32 @@ describe('groupBy sensitive-field refusal', () => {
     plain.query().groupBy('name', 'age')
   })
 })
+
+describe('Q = indexed-only where() refusal (opt-in 3rd generic)', () => {
+  interface Rec { id: string; name: string; ssn: string; status: string }
+  it('restricts where() to indexed fields; orderBy stays free', async () => {
+    const vault = await typedVault()
+    const c = vault.collection<Rec, never, 'status'>('c', { indexes: ['status'] })
+    c.query().where('status', '==', 'x')          // ok — indexed
+    // @ts-expect-error — 'name' is not indexed; use .scan()
+    c.query().where('name', '==', 'x')
+    c.query().orderBy('name')                      // ok — orderBy NOT Q-restricted
+  })
+  it('single-generic / no-Q stays permissive (zero churn)', async () => {
+    const vault = await typedVault()
+    const c = vault.collection<Rec>('c2', { indexes: ['status'] })
+    c.query().where('anything', '==', 'x')         // Q = never -> string
+  })
+  it('Q composes with S: where = indexed minus sensitive', async () => {
+    const vault = await typedVault()
+    const c = vault.collection<Rec, 'ssn', 'status' | 'ssn'>('c3', { sensitive: ['ssn'], indexes: ['status'] })
+    c.query().where('status', '==', 'x')           // ok
+    // @ts-expect-error — ssn is indexed-declared but sensitive -> still refused
+    c.query().where('ssn', '==', 'x')
+  })
+  it('ties the indexes array to Q (no drift)', async () => {
+    const vault = await typedVault()
+    // @ts-expect-error — 'region' not in declared Q 'status'
+    vault.collection<Rec, never, 'status'>('c4', { indexes: ['region'] })
+  })
+})

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -170,7 +170,7 @@ function warnOnceFallback(adapterName: string): void {
 }
 
 /** A typed collection of records within a vault. */
-export class Collection<T, S extends keyof T = never> {
+export class Collection<T, S extends keyof T = never, Q extends keyof T & string = never> {
   private readonly adapter: NoydbStore
   private readonly vault: string
   private readonly name: string
@@ -3613,9 +3613,9 @@ export class Collection<T, S extends keyof T = never> {
    * const drafts = invoices.query(i => i.status === 'draft');
    * ```
    */
-  query(): Query<T, S>
+  query(): Query<T, S, Q>
   query(predicate: (record: T) => boolean): T[]
-  query(predicate?: (record: T) => boolean): Query<T, S> | T[] {
+  query(predicate?: (record: T) => boolean): Query<T, S, Q> | T[] {
     if (this.lazy) {
       throw new Error(
         `Collection "${this.name}": query() is not available in lazy mode (prefetch: false). ` +
@@ -3667,7 +3667,7 @@ export class Collection<T, S extends keyof T = never> {
             : {}),
         }
       : undefined
-    return new Query<T, S>(source, undefined, joinContext, this.aggregateStrategy)
+    return new Query<T, S, Q>(source, undefined, joinContext, this.aggregateStrategy)
   }
 
   /**

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -136,7 +136,7 @@ export interface DeclaredPredicate {
   fn: (record: unknown, ctx?: unknown) => boolean
 }
 
-export class Query<T, S extends keyof T = never> {
+export class Query<T, S extends keyof T = never, Q extends keyof T & string = never> {
   private readonly source: InternalSource
   private readonly plan: QueryPlan
   private readonly joinContext: JoinContext | undefined
@@ -181,8 +181,8 @@ export class Query<T, S extends keyof T = never> {
    * `.wherePredicate(name, ctx?)` for the MV's query callback.
    * Consumers don't call this directly.
    */
-  _withPredicates(predicates: ReadonlyMap<string, DeclaredPredicate>): Query<T, S> {
-    return new Query<T, S>(
+  _withPredicates(predicates: ReadonlyMap<string, DeclaredPredicate>): Query<T, S, Q> {
+    return new Query<T, S, Q>(
       this.source as QuerySource<T>,
       this.plan,
       this.joinContext,
@@ -236,7 +236,7 @@ export class Query<T, S extends keyof T = never> {
    * canonical-JSON hash of `ctx` fold into the MV's `queryHash`, so
    * either changing forces refresh on next visit.
    */
-  wherePredicate(name: string, ctx?: unknown): Query<T, S> {
+  wherePredicate(name: string, ctx?: unknown): Query<T, S, Q> {
     if (!this.predicates) {
       throw new Error(
         `.wherePredicate("${name}"): no predicates registered on this Query. ` +
@@ -260,7 +260,7 @@ export class Query<T, S extends keyof T = never> {
       ctxHash: canonicalCtxHash(ctx),
       fn: decl.fn,
     }
-    return new Query<T, S>(
+    return new Query<T, S, Q>(
       this.source as QuerySource<T>,
       { ...this.plan, clauses: [...this.plan.clauses, clause] },
       this.joinContext,
@@ -278,12 +278,12 @@ export class Query<T, S extends keyof T = never> {
    * BigInt-exact per record. A malformed operand or a string operator
    * (`contains`/`startsWith`) throws here, at the call site.
    */
-  where(field: QueryField<T, S>, op: Operator, value: unknown): Query<T, S> {
+  where(field: QueryField<T, S, Q>, op: Operator, value: unknown): Query<T, S, Q> {
     const desc = this.source.moneyFields?.[field]
     const clause: FieldClause = desc
       ? moneyFieldClause(field, op, value, desc)
       : { type: 'field', field, op, value }
-    return new Query<T, S>(
+    return new Query<T, S, Q>(
       this.source as QuerySource<T>,
       { ...this.plan, clauses: [...this.plan.clauses, clause] },
       this.joinContext,
@@ -297,16 +297,16 @@ export class Query<T, S extends keyof T = never> {
    * Each clause inside the callback is OR-combined; the group itself
    * joins the parent plan with AND.
    */
-  or(builder: (q: Query<T, S>) => Query<T, S>): Query<T, S> {
+  or(builder: (q: Query<T, S, Q>) => Query<T, S, Q>): Query<T, S, Q> {
     const sub = builder(
-      new Query<T, S>(this.source as QuerySource<T>, EMPTY_PLAN, this.joinContext, this.aggregateStrategy, this.predicates),
+      new Query<T, S, Q>(this.source as QuerySource<T>, EMPTY_PLAN, this.joinContext, this.aggregateStrategy, this.predicates),
     )
     const group: GroupClause = {
       type: 'group',
       op: 'or',
       clauses: sub.plan.clauses,
     }
-    return new Query<T, S>(
+    return new Query<T, S, Q>(
       this.source as QuerySource<T>,
       { ...this.plan, clauses: [...this.plan.clauses, group] },
       this.joinContext,
@@ -319,16 +319,16 @@ export class Query<T, S extends keyof T = never> {
    * Logical AND group. Same shape as `or()` but every clause inside the group
    * must match. Useful for explicit grouping inside a larger OR.
    */
-  and(builder: (q: Query<T, S>) => Query<T, S>): Query<T, S> {
+  and(builder: (q: Query<T, S, Q>) => Query<T, S, Q>): Query<T, S, Q> {
     const sub = builder(
-      new Query<T, S>(this.source as QuerySource<T>, EMPTY_PLAN, this.joinContext, this.aggregateStrategy, this.predicates),
+      new Query<T, S, Q>(this.source as QuerySource<T>, EMPTY_PLAN, this.joinContext, this.aggregateStrategy, this.predicates),
     )
     const group: GroupClause = {
       type: 'group',
       op: 'and',
       clauses: sub.plan.clauses,
     }
-    return new Query<T, S>(
+    return new Query<T, S, Q>(
       this.source as QuerySource<T>,
       { ...this.plan, clauses: [...this.plan.clauses, group] },
       this.joinContext,
@@ -338,12 +338,12 @@ export class Query<T, S extends keyof T = never> {
   }
 
   /** Escape hatch: add an arbitrary predicate function. Not serializable. */
-  filter(fn: (record: T) => boolean): Query<T, S> {
+  filter(fn: (record: T) => boolean): Query<T, S, Q> {
     const clause: FilterClause = {
       type: 'filter',
       fn: fn as (record: unknown) => boolean,
     }
-    return new Query<T, S>(
+    return new Query<T, S, Q>(
       this.source as QuerySource<T>,
       { ...this.plan, clauses: [...this.plan.clauses, clause] },
       this.joinContext,
@@ -357,9 +357,9 @@ export class Query<T, S extends keyof T = never> {
    * `{ by: 'label' }` to sort a `dictKey`/`staticDict` field by its resolved
    * label at the query locale instead of the stored code (#285).
    */
-  orderBy(field: QueryField<T, S>, direction: 'asc' | 'desc' = 'asc', opts?: { by?: 'value' | 'label' }): Query<T, S> {
+  orderBy(field: QueryField<T, S>, direction: 'asc' | 'desc' = 'asc', opts?: { by?: 'value' | 'label' }): Query<T, S, Q> {
     const entry: OrderBy = opts?.by === 'label' ? { field, direction, by: 'label' } : { field, direction }
-    return new Query<T, S>(
+    return new Query<T, S, Q>(
       this.source as QuerySource<T>,
       { ...this.plan, orderBy: [...this.plan.orderBy, entry] },
       this.joinContext,
@@ -369,8 +369,8 @@ export class Query<T, S extends keyof T = never> {
   }
 
   /** Cap the result size. */
-  limit(n: number): Query<T, S> {
-    return new Query<T, S>(
+  limit(n: number): Query<T, S, Q> {
+    return new Query<T, S, Q>(
       this.source as QuerySource<T>,
       { ...this.plan, limit: n },
       this.joinContext,
@@ -380,8 +380,8 @@ export class Query<T, S extends keyof T = never> {
   }
 
   /** Skip the first N matching records (after ordering). */
-  offset(n: number): Query<T, S> {
-    return new Query<T, S>(
+  offset(n: number): Query<T, S, Q> {
+    return new Query<T, S, Q>(
       this.source as QuerySource<T>,
       { ...this.plan, offset: n },
       this.joinContext,
@@ -451,7 +451,7 @@ export class Query<T, S extends keyof T = never> {
   join<As extends string, R = unknown>(
     field: QueryField<T, S>,
     opts: { as: As; strategy?: JoinStrategy; maxRows?: number },
-  ): Query<T & Record<As, R | null>, S> {
+  ): Query<T & Record<As, R | null>, S, Q> {
     if (!this.joinContext) {
       throw new Error(
         `Query.join() requires a join context. Use collection.query() ` +
@@ -493,7 +493,7 @@ export class Query<T, S extends keyof T = never> {
           partitionScope: 'all',
           isDictJoin: true,
         }
-    return new Query<T & Record<As, R | null>, S>(
+    return new Query<T & Record<As, R | null>, S, Q>(
       this.source as unknown as QuerySource<T & Record<As, R | null>>,
       { ...this.plan, joins: [...this.plan.joins, leg] },
       this.joinContext,
@@ -532,7 +532,7 @@ export class Query<T, S extends keyof T = never> {
         | { readonly predicate: string }
       maxRows?: number
     },
-  ): Query<T & { [K in As]: TTarget }, S> {
+  ): Query<T & { [K in As]: TTarget }, S, Q> {
     if (!this.joinContext) {
       throw new Error(
         `Query.crossJoin("${target}"): requires a join context. ` +
@@ -589,7 +589,7 @@ export class Query<T, S extends keyof T = never> {
       ...(opts.maxRows !== undefined && { maxRows: opts.maxRows }),
     }
 
-    return new Query<T & { [K in As]: TTarget }, S>(
+    return new Query<T & { [K in As]: TTarget }, S, Q>(
       this.source as unknown as QuerySource<T & { [K in As]: TTarget }>,
       { ...this.plan, clauses: [...this.plan.clauses, clause] },
       this.joinContext,

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -249,10 +249,16 @@ export type SealedView<T, S extends keyof T> = [S] extends [never]
  * literal from `string`, so refusing a sensitive name necessarily means
  * narrowing to the known field-name union — this is intentional and only
  * affects collections that opted in.
+ *
+ * When `Q` (the indexed-field set) is given, `where()` is additionally
+ * restricted to `Q` minus any sensitive fields — the escape hatch for
+ * non-indexed filters is `scan()`. `Q = never` (the default) preserves the
+ * existing 2-param behaviour exactly (zero churn).
  */
-export type QueryField<T, S extends keyof T = never> = [S] extends [never]
-  ? string
-  : Exclude<keyof T & string, S>
+export type QueryField<T, S extends keyof T = never, Q extends keyof T & string = never> =
+  [Q] extends [never]
+    ? ([S] extends [never] ? string : Exclude<keyof T & string, S>)
+    : Exclude<Q, S>
 
 /**
  * The type of a field-name reference in a collection's index-declaration
@@ -262,10 +268,16 @@ export type QueryField<T, S extends keyof T = never> = [S] extends [never]
  * secondary index over a sealed field defeats non-residency — previously only
  * a runtime `console.warn`). Kept distinct from `QueryField` so the two DSL
  * surfaces can diverge later without coupling.
+ *
+ * When `Q` (the indexed-field set) is given, the `indexes` option is
+ * additionally restricted to `Q` minus any sensitive fields — declaring `Q`
+ * but listing a different field in `indexes` becomes a compile error.
+ * `Q = never` (the default) preserves the existing 2-param behaviour.
  */
-export type IndexFieldName<T, S extends keyof T = never> = [S] extends [never]
-  ? string
-  : Exclude<keyof T & string, S>
+export type IndexFieldName<T, S extends keyof T = never, Q extends keyof T & string = never> =
+  [Q] extends [never]
+    ? ([S] extends [never] ? string : Exclude<keyof T & string, S>)
+    : Exclude<Q, S>
 
 /**
  * Generic form of the runtime `IndexDef` (see `indexing/eager-indexes.ts`)

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -681,8 +681,8 @@ export class Vault {
    * Lazy mode + indexes is rejected at construction time — see the
    * Collection constructor for the rationale.
    */
-  collection<T, S extends keyof T & string = never>(collectionName: string, options?: {
-    indexes?: readonly IndexDefFor<IndexFieldName<T, S>>[]
+  collection<T, S extends keyof T & string = never, Q extends keyof T & string = never>(collectionName: string, options?: {
+    indexes?: readonly IndexDefFor<IndexFieldName<T, S, Q>>[]
     /** — auto-reconcile policy for persisted-index drift. */
     reconcileOnOpen?: 'off' | 'dry-run' | 'auto'
     prefetch?: boolean
@@ -791,7 +791,7 @@ export class Vault {
      * Default false — the working set is plaintext.
      */
     ramCiphertext?: boolean
-  }): Collection<T, S> {
+  }): Collection<T, S, Q> {
     // Overlay intercept. When the requested collection name
     // matches a registered `withOverlayedView`, return the virtual
     // proxy that merges base + overlay on read and routes writes to
@@ -809,7 +809,7 @@ export class Vault {
         const overlay = this.collection<T>(spec.overlay)
         const baseRowKey = overlayRegistry.resolveBaseRowKey(collectionName, this.materializedViewRegistry)
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return new OverlayedCollection<any>(spec, base, overlay, baseRowKey) as unknown as Collection<T, S>
+        return new OverlayedCollection<any>(spec, base, overlay, baseRowKey) as unknown as Collection<T, S, Q>
       }
     }
     // Guard: reject reserved _dict_* names
@@ -1153,7 +1153,7 @@ export class Vault {
         this._pendingSchemaWrites.push(work)
       }
     }
-    return coll as unknown as Collection<T, S>
+    return coll as unknown as Collection<T, S, Q>
   }
 
   /**


### PR DESCRIPTION
## What

Adds an **opt-in** compile-time restriction so `Query.where()` only accepts **indexed** fields — declared via a 3rd generic `Q` on `vault.collection<T, S, Q>`. Mirrors the sensitive-field `S` (2nd generic) from #505. **`where()`-only** by design.

```ts
const c = vault.collection<Person, never, 'status'>('p', { indexes: ['status'] })
c.query().where('status', '==', x)   // ✅ indexed
c.query().where('name', '==', x)     // ❌ not indexed → use .scan()
c.query().orderBy('createdAt')       // ✅ orderBy NOT restricted (in-memory sort)
```

## Why where()-only

An index only accelerates `where()` with `==`/`in`. `orderBy`/`groupBy` are always in-memory passes — correct on *any* field — so restricting them would refuse valid queries. "Indexed-only" is technically honest only for `where()`; non-indexed filters go through the `.scan()` escape hatch (which carries `S` but not `Q`). This matches the spec's P4-T4 intent ("un-indexed `where` → compile error → use `scan()`").

## How

`QueryField` / `IndexFieldName` become 3-param (`<T, S, Q>`), guarded so `Q=never` is **byte-identical to today** (zero churn):
```ts
QueryField<T, S = never, Q extends keyof T & string = never> =
  [Q] extends [never]
    ? ([S] extends [never] ? string : Exclude<keyof T & string, S>)
    : Exclude<Q, S>            // indexed minus sensitive
```
`Q` (phantom, default `never`) threads through `Query<T,S,Q>` → `Collection<T,S,Q>` → `vault.collection<T,S,Q>`. Only `where`'s field param is narrowed to `QueryField<T,S,Q>`; `orderBy`/`groupBy` stay `QueryField<T,S>`. The `indexes` option becomes `IndexDefFor<IndexFieldName<T,S,Q>>`, which **ties the runtime `indexes` array to `Q`** (declaring `Q='status'` but `indexes:['region']` is a compile error). `scan()`/`lazyQuery()` correctly shed `Q`.

## Verification
- Type-only: the only runtime edits are `new Query<T,S>(` → `new Query<T,S,Q>(`. Suite **2912/329**, behavior unchanged.
- Full `pnpm --filter @noy-db/hub typecheck` green (src + type-tests + the `.test.ts` ratchet at zero exclusions). 4 new `@ts-expect-error` type-tests: indexed-only `where`, `orderBy`-stays-free, zero-churn permissive, `Q∩¬S` composition, `indexes`-tied-to-`Q`.
- **opus review: Ready to merge** — conditional type correct across all regimes (incl. union-Q, degenerate Q⊆S), no mid-chain Q drop, zero-churn confirmed.

## Merge note
Touches `builder.ts`, which #512 (groupBy refusal) also touches — whichever merges second may need a trivial conflict resolution on adjacent lines (the changes are semantically independent: #512 narrows `groupBy`, this adds the `Q` class generic). I'll handle it.
