### PR TITLE
feat(hub): typed aggregate() builder form on ScanBuilder (mirrors #514)

### DIFF
--- a/packages/hub/__tests__/sealed-query-refusal.test-d.ts
+++ b/packages/hub/__tests__/sealed-query-refusal.test-d.ts
@@ -173,3 +173,15 @@ describe('aggregate() builder-form sensitive refusal', () => {
     q.aggregate({ total: sum('age') })
   })
 })
+
+describe('scan().aggregate() builder-form sensitive refusal', () => {
+  it('refuses a sensitive field in the scan builder form; bare-spec unchanged', async () => {
+    const vault = await typedVault()
+    const people = vault.collection<Person, 'ssn'>('people', { sensitive: ['ssn'] })
+    const s = people.scan()
+    s.aggregate(b => ({ total: b.sum('age'), n: b.count() }))   // ok
+    // @ts-expect-error — sensitive field refused in the typed scan builder form
+    s.aggregate(b => ({ bad: b.sum('ssn') }))
+    s.aggregate({ total: sum('age') })   // bare-spec still compiles
+  })
+})

--- a/packages/hub/src/query/scan-builder.ts
+++ b/packages/hub/src/query/scan-builder.ts
@@ -59,6 +59,8 @@
  */
 
 import type { QueryField } from '../types.js'
+import type { ReducerBuilder } from '../aggregate/reducers.js'
+import { reducerBuilder } from '../aggregate/reducers.js'
 import type { Clause, FieldClause, Operator } from './predicate.js'
 import { evaluateClause, hasFnClause, readPath } from './predicate.js'
 import type {
@@ -579,9 +581,17 @@ export class ScanBuilder<T, S extends keyof T = never> implements AsyncIterable<
    * narrow with `.where()` enough to fit in the 50k `query()`
    * limit and use `query().aggregate().live()` instead.
    */
+  async aggregate<Spec extends AggregateSpec>(spec: Spec): Promise<AggregateResult<Spec>>
+  async aggregate<Spec extends AggregateSpec>(build: (b: ReducerBuilder<T, S>) => Spec): Promise<AggregateResult<Spec>>
   async aggregate<Spec extends AggregateSpec>(
-    spec: Spec,
+    specOrBuild: Spec | ((b: ReducerBuilder<T, S>) => Spec),
   ): Promise<AggregateResult<Spec>> {
+    // Opt-in builder form `aggregate(b => spec)`: `b`'s field args are
+    // `QueryField<T, S>`, refusing sensitive fields (the standalone-spec form
+    // stays unrefused for back-compat). Mirrors `Query.aggregate`.
+    const spec: Spec = typeof specOrBuild === 'function'
+      ? (specOrBuild as (b: ReducerBuilder<T, S>) => Spec)(reducerBuilder as unknown as ReducerBuilder<T, S>)
+      : specOrBuild
     const keys = Object.keys(spec)
     // Per-reducer state. Exactly |keys| entries, never grows with
     // the record count — that's the O(reducers) memory guarantee.


### PR DESCRIPTION
Extends the opt-in typed `aggregate(b => spec)` builder (from #514) to `scan().aggregate()`. ScanBuilder carries `S`, so `s.aggregate(b => ({ x: b.sum('ssn') }))` is refused; bare-spec `s.aggregate({...})` unchanged (back-compat). Same shared `reducerBuilder` singleton + contravariance cast as Query.aggregate — runtime identical, type-only except resolving spec from the function.

**Verification:** full typecheck green (src + type-tests + ratchet); suite 2915/330; architecture OK. Type-test: `s.aggregate(b => b.sum('ssn'))` refused, bare-spec compiles.

Follow-up: `GroupedQuery.aggregate` lacks an `S` param (needs re-threading first).