### PR TITLE
feat(hub): Q = indexed-only lazyQuery().where() (mirrors #513)

### DIFF
--- a/packages/hub/__tests__/sealed-query-refusal.test-d.ts
+++ b/packages/hub/__tests__/sealed-query-refusal.test-d.ts
@@ -185,3 +185,21 @@ describe('scan().aggregate() builder-form sensitive refusal', () => {
     s.aggregate({ total: sum('age') })   // bare-spec still compiles
   })
 })
+
+describe('Q = indexed-only lazyQuery().where() refusal', () => {
+  interface LRec { id: string; name: string; status: string }
+  it('restricts lazyQuery().where() to indexed fields; orderBy stays free', async () => {
+    const vault = await typedVault()
+    const c = vault.collection<LRec, never, 'status'>('lc', { indexes: ['status'], prefetch: false })
+    const lq = c.lazyQuery()
+    lq.where('status', '==', 'x')           // ok — indexed
+    // @ts-expect-error — 'name' not indexed; lazy where requires an index
+    lq.where('name', '==', 'x')
+    lq.orderBy('name')                      // ok — orderBy NOT Q-restricted
+  })
+  it('no-Q lazyQuery stays permissive', async () => {
+    const vault = await typedVault()
+    const c = vault.collection<LRec>('lc2', { indexes: ['status'], prefetch: false })
+    c.lazyQuery().where('anything', '==', 'x')   // Q = never -> string
+  })
+})

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -4925,7 +4925,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    * `query()` there. Throws if no index is declared, because a lazy
    * query with no index would need to enumerate the whole collection.
    */
-  lazyQuery(): LazyQuery<T, S> {
+  lazyQuery(): LazyQuery<T, S, Q> {
     if (!this.lazy) {
       throw new Error(
         `Collection "${this.name}": lazyQuery() is only available in lazy mode ` +
@@ -4953,7 +4953,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       ensurePersistedIndexesLoaded: () => this.ensurePersistedIndexesLoaded(),
       getRecord: (id: string) => this.get(id) as unknown as Promise<T | null>,
     }
-    return new LazyQuery<T, S>(source)
+    return new LazyQuery<T, S, Q>(source)
   }
 
   /**

--- a/packages/hub/src/indexing/lazy-builder.ts
+++ b/packages/hub/src/indexing/lazy-builder.ts
@@ -61,7 +61,7 @@ const EMPTY_PLAN: LazyPlan = {
   offset: 0,
 }
 
-export class LazyQuery<T, S extends keyof T = never> {
+export class LazyQuery<T, S extends keyof T = never, Q extends keyof T & string = never> {
   private readonly source: LazyQuerySource<T>
   private readonly plan: LazyPlan
 
@@ -70,27 +70,27 @@ export class LazyQuery<T, S extends keyof T = never> {
     this.plan = plan
   }
 
-  where<V>(field: QueryField<T, S>, op: Operator, value: V): LazyQuery<T, S> {
+  where<V>(field: QueryField<T, S, Q>, op: Operator, value: V): LazyQuery<T, S, Q> {
     const clause: FieldClause = { type: 'field', field, op, value }
-    return new LazyQuery<T, S>(this.source, {
+    return new LazyQuery<T, S, Q>(this.source, {
       ...this.plan,
       clauses: [...this.plan.clauses, clause],
     })
   }
 
-  orderBy(field: QueryField<T, S>, direction: 'asc' | 'desc' = 'asc'): LazyQuery<T, S> {
-    return new LazyQuery<T, S>(this.source, {
+  orderBy(field: QueryField<T, S>, direction: 'asc' | 'desc' = 'asc'): LazyQuery<T, S, Q> {
+    return new LazyQuery<T, S, Q>(this.source, {
       ...this.plan,
       orderBy: [...this.plan.orderBy, { field, direction }],
     })
   }
 
-  limit(n: number): LazyQuery<T, S> {
-    return new LazyQuery<T, S>(this.source, { ...this.plan, limit: n })
+  limit(n: number): LazyQuery<T, S, Q> {
+    return new LazyQuery<T, S, Q>(this.source, { ...this.plan, limit: n })
   }
 
-  offset(n: number): LazyQuery<T, S> {
-    return new LazyQuery<T, S>(this.source, { ...this.plan, offset: n })
+  offset(n: number): LazyQuery<T, S, Q> {
+    return new LazyQuery<T, S, Q>(this.source, { ...this.plan, offset: n })
   }
 
   async toArray(): Promise<T[]> {


### PR DESCRIPTION
Extends the opt-in indexed-only `where()` restriction (#513) to lazy mode. `LazyQuery<T,S,Q>` — `lazyQuery().where()` field is `QueryField<T,S,Q>` (indexed ∩ non-sensitive); `orderBy` stays `QueryField<T,S>`. Especially apt for lazy mode, which **requires** an index at runtime (throws otherwise) — the type now matches that. `collection.lazyQuery()` returns `LazyQuery<T,S,Q>`. Zero churn when `Q=never`; type-only.

**Verification:** typecheck + lint + suite (2915/330) + architecture all green. Type-test: `lazyQuery().where('name')` refused on an indexed-`status` collection; permissive without Q.