### PR TITLE
feat(hub): thread S through GroupedQuery; typed groupBy().aggregate() builder (closes last refusal gap)

### DIFF
--- a/packages/hub/__tests__/sealed-query-refusal.test-d.ts
+++ b/packages/hub/__tests__/sealed-query-refusal.test-d.ts
@@ -186,6 +186,18 @@ describe('scan().aggregate() builder-form sensitive refusal', () => {
   })
 })
 
+describe('groupBy().aggregate() builder-form sensitive refusal', () => {
+  it('refuses a sensitive reducer field in a grouped aggregate', async () => {
+    const vault = await typedVault()
+    const people = vault.collection<Person, 'ssn'>('people', { sensitive: ['ssn'] })
+    const g = people.query().groupBy('name')          // group field already S-refused (#512)
+    g.aggregate(b => ({ total: b.sum('age'), n: b.count() }))   // ok
+    // @ts-expect-error — sensitive reducer field refused in the grouped builder form
+    g.aggregate(b => ({ bad: b.sum('ssn') }))
+    g.aggregate({ total: sum('age') })   // bare-spec still compiles (sum already imported in this file)
+  })
+})
+
 describe('Q = indexed-only lazyQuery().where() refusal', () => {
   interface LRec { id: string; name: string; status: string }
   it('restricts lazyQuery().where() to indexed fields; orderBy stays free', async () => {

--- a/packages/hub/src/aggregate/groupby.ts
+++ b/packages/hub/src/aggregate/groupby.ts
@@ -67,6 +67,8 @@ import type {
   LiveAggregation,
 } from './aggregation.js'
 import { buildLiveAggregation } from './aggregation.js'
+import type { ReducerBuilder } from './reducers.js'
+import { reducerBuilder } from './reducers.js'
 import { canonicalGroupKey } from './canonical-key.js'
 import { GroupCardinalityError } from '../errors.js'
 import type { MoneyDescriptor } from '../money/descriptor.js'
@@ -202,16 +204,27 @@ abstract class GroupedQueryBase {
  * them post-group would be a different operation (`having` /
  * `groupOrderBy`), out of scope for.
  */
-export class GroupedQuery<T, F extends string> extends GroupedQueryBase {
+export class GroupedQuery<T, F extends string, S extends keyof T = never> extends GroupedQueryBase {
   /**
    * Build a grouped aggregation. Returns a `GroupedAggregation`
    * with `.run()`, `.runAsync()`, and `.live()` terminals — same shape
    * as the non-grouped `.aggregate()` wrapper, just with an array
    * result (one row per bucket) instead of a single reduced object.
+   *
+   * The builder overload `aggregate(b => spec)` types `b` as
+   * `ReducerBuilder<T, S>`, so field-taking reducers (`sum`, `avg`,
+   * `min`, `max`) refuse any field listed in the collection's
+   * `sensitive` option at compile time. The bare-spec overload is
+   * preserved for backward compatibility.
    */
+  aggregate<Spec extends AggregateSpec>(spec: Spec): GroupedAggregation<GroupedRow<F, AggregateResult<Spec>>>
+  aggregate<Spec extends AggregateSpec>(build: (b: ReducerBuilder<T, S>) => Spec): GroupedAggregation<GroupedRow<F, AggregateResult<Spec>>>
   aggregate<Spec extends AggregateSpec>(
-    spec: Spec,
+    specOrBuild: Spec | ((b: ReducerBuilder<T, S>) => Spec),
   ): GroupedAggregation<GroupedRow<F, AggregateResult<Spec>>> {
+    const spec: Spec = typeof specOrBuild === 'function'
+      ? (specOrBuild as (b: ReducerBuilder<T, S>) => Spec)(reducerBuilder as unknown as ReducerBuilder<T, S>)
+      : specOrBuild
     // T is phantom on the wrapper so consumers can still see the
     // source row type on hover. Reference it to keep lint quiet.
     void undefined as T | undefined
@@ -230,10 +243,15 @@ export class GroupedQuery<T, F extends string> extends GroupedQueryBase {
  * multi-arg `Query.groupBy(...fields)` overload. The runtime shape is
  * identical — only the type-level result-row narrowing differs.
  */
-export class GroupedQueryN<T, F extends readonly string[]> extends GroupedQueryBase {
+export class GroupedQueryN<T, F extends readonly string[], S extends keyof T = never> extends GroupedQueryBase {
+  aggregate<Spec extends AggregateSpec>(spec: Spec): GroupedAggregation<GroupedRowN<F, AggregateResult<Spec>>>
+  aggregate<Spec extends AggregateSpec>(build: (b: ReducerBuilder<T, S>) => Spec): GroupedAggregation<GroupedRowN<F, AggregateResult<Spec>>>
   aggregate<Spec extends AggregateSpec>(
-    spec: Spec,
+    specOrBuild: Spec | ((b: ReducerBuilder<T, S>) => Spec),
   ): GroupedAggregation<GroupedRowN<F, AggregateResult<Spec>>> {
+    const spec: Spec = typeof specOrBuild === 'function'
+      ? (specOrBuild as (b: ReducerBuilder<T, S>) => Spec)(reducerBuilder as unknown as ReducerBuilder<T, S>)
+      : specOrBuild
     void undefined as T | undefined
     return new GroupedAggregation<GroupedRowN<F, AggregateResult<Spec>>>(
       this.executeRecords,

--- a/packages/hub/src/aggregate/strategy.ts
+++ b/packages/hub/src/aggregate/strategy.ts
@@ -42,10 +42,10 @@ export interface AggregateStrategy {
   ): Aggregation<AggregateResult<Spec>>
 
   /**
-   * Build a `GroupedQuery<T, F>` for `Query.groupBy(field)`. Same
+   * Build a `GroupedQuery<T, F, S>` for `Query.groupBy(field)`. Same
    * closure / upstream inputs as `aggregate` plus the group key field.
    */
-  groupBy<T, F extends string>(
+  groupBy<T, F extends string, S extends keyof T = never>(
     executeRecords: () => readonly unknown[],
     field: F,
     upstreams: readonly AggregationUpstream[],
@@ -55,20 +55,20 @@ export interface AggregateStrategy {
       fallback?: string | readonly string[],
     ) => Promise<string | undefined>,
     moneyFields?: Record<string, MoneyDescriptor>,
-  ): GroupedQuery<T, F>
+  ): GroupedQuery<T, F, S>
 
   /**
-   * Variadic-keyed sibling — builds a `GroupedQueryN<T, F>` for
+   * Variadic-keyed sibling — builds a `GroupedQueryN<T, F, S>` for
    * `Query.groupBy(...fields)`. No dictLabelResolver — `<field>Label`
    * projection only applies to single-field groupings, which dispatch
    * through `groupBy` above.
    */
-  groupByN<T, F extends readonly string[]>(
+  groupByN<T, F extends readonly string[], S extends keyof T = never>(
     executeRecords: () => readonly unknown[],
     fields: F,
     upstreams: readonly AggregationUpstream[],
     moneyFields?: Record<string, MoneyDescriptor>,
-  ): GroupedQueryN<T, F>
+  ): GroupedQueryN<T, F, S>
 
   /**
    * Terminal streaming aggregator for `ScanBuilder.aggregate(spec)`.

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -733,10 +733,6 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
    * `sensitive` field at compile time. Use the builder form for new code that
    * aggregates over a collection with sensitive fields.
    *
-   * Follow-ups (out of scope for this change):
-   *   - `GroupedQuery.aggregate` dropped `S` and cannot be retrofitted here;
-   *     a separate builder form is needed.
-   *   - `ScanBuilder.aggregate` similarly has no `S` context.
    */
   aggregate<Spec extends AggregateSpec>(spec: Spec): Aggregation<AggregateResult<Spec>>
   aggregate<Spec extends AggregateSpec>(build: (b: ReducerBuilder<T, S>) => Spec): Aggregation<AggregateResult<Spec>>
@@ -833,11 +829,11 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
   // The `field` param is `QueryField<T, S>` so a sealed (`sensitive`) field is
   // refused — grouping BY a sensitive field leaks its value distribution as
   // group-key labels. With `S = never` this is exactly `string` (zero churn).
-  groupBy<F extends QueryField<T, S>>(field: F): GroupedQuery<T, F>
+  groupBy<F extends QueryField<T, S>>(field: F): GroupedQuery<T, F, S>
   groupBy<F extends readonly [QueryField<T, S>, QueryField<T, S>, ...QueryField<T, S>[]]>(
     ...fields: F
-  ): GroupedQueryN<T, F>
-  groupBy(...fields: readonly string[]): GroupedQuery<T, string> | GroupedQueryN<T, readonly string[]> {
+  ): GroupedQueryN<T, F, S>
+  groupBy(...fields: readonly string[]): GroupedQuery<T, string, S> | GroupedQueryN<T, readonly string[], S> {
     if (fields.length === 0) {
       throw new Error('.groupBy() requires at least one field')
     }
@@ -871,7 +867,7 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
     if (fields.length === 1) {
       const field = fields[0]!
       const dictLabelResolver = buildDictLabelResolver(this.joinContext, field)
-      return this.aggregateStrategy.groupBy<T, string>(
+      return this.aggregateStrategy.groupBy<T, string, S>(
         executeRecords,
         field,
         upstreams,
@@ -879,7 +875,7 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
         this.source.moneyFields,
       )
     }
-    return this.aggregateStrategy.groupByN<T, readonly string[]>(
+    return this.aggregateStrategy.groupByN<T, readonly string[], S>(
       executeRecords,
       fields,
       upstreams,


### PR DESCRIPTION
## What

Threads the sensitive-field generic `S` (phantom) through `GroupedQuery<T,F,S>` / `GroupedQueryN<T,F,S>` and adds a typed `aggregate(b => …)` builder overload — so `groupBy(...).aggregate()` refuses sensitive reducer fields. **This closes the last query-DSL field-refusal gap.**

```ts
const g = people.query().groupBy('name')        // group field already refused (#512)
g.aggregate(b => ({ total: b.sum('age') }))     // ✅
g.aggregate(b => ({ bad: b.sum('ssn') }))       // ❌ refused (this PR)
g.aggregate({ total: sum('age') })              // ✅ bare-spec unchanged (back-compat)
```

Mirrors the `Query.aggregate` (#514) and `ScanBuilder.aggregate` (#515) builder forms.

## How
- `GroupedQuery`/`GroupedQueryN` gain a 3rd generic `S` (phantom — appears only in the builder overload's `ReducerBuilder<T,S>` param). `GroupedAggregation<R>` is unchanged (no field params).
- `Query.groupBy` returns `GroupedQuery<T,F,S>`/`GroupedQueryN<T,F,S>`; the `AggregateStrategy` interface `groupBy`/`groupByN` carry `S`; the untyped `active.ts` impl needs **no change** (returned `GroupedQuery<…,never>` is structurally identical since `S` is phantom).
- Bare `aggregate(spec)` form preserved; impl resolves spec from the function up front (typed `const spec: Spec`, no cast).

## Verification
- Full `pnpm --filter @noy-db/hub typecheck` + `lint` green; suite **2915/330** (type-only); architecture OK.
- Type-test: `g.aggregate(b => b.sum('ssn'))` refused (adversarially verified — flipping to `'age'` makes the `@ts-expect-error` unused), bare-spec compiles.
- **opus review: Ready to merge** — phantom-S runtime-untouched, strategy-return assignability sound (method-param bivariance, refusal enforced at the call site — no leak), zero-churn confirmed.

Completes the compile-time refusal matrix: `where`/`orderBy`/`scan`/`lazy`/`groupBy`/`indexes`/`aggregate` across Query, ScanBuilder, and GroupedQuery.