### PR TITLE
feat(hub): money-field generic M — b.sum(moneyField) auto-types MoneyString in aggregate builder

### DIFF
--- a/packages/hub/__tests__/sealed-query-refusal.test-d.ts
+++ b/packages/hub/__tests__/sealed-query-refusal.test-d.ts
@@ -3,7 +3,7 @@
  * Validated by `pnpm --filter @noy-db/hub typecheck:types` (tsc only; never executed).
  */
 import { describe, it, expectTypeOf } from 'vitest'
-import { createNoydb, sum } from '../src/index.js'
+import { createNoydb, sum, money } from '../src/index.js'
 import { memoryStore } from '../src/store/memory-store.js'
 
 interface Person { id: string; name: string; ssn: string; age: number }
@@ -213,5 +213,33 @@ describe('Q = indexed-only lazyQuery().where() refusal', () => {
     const vault = await typedVault()
     const c = vault.collection<LRec>('lc2', { indexes: ['status'], prefetch: false })
     c.lazyQuery().where('anything', '==', 'x')   // Q = never -> string
+  })
+})
+
+describe('money-field generic M — aggregate builder auto-types money fields', () => {
+  interface Sale { id: string; amount: number; tax: number; qty: number }
+  it('b.sum on a money field is MoneyString; non-money is number; opt-in via 4th generic', async () => {
+    const vault = await typedVault()
+    const sales = vault.collection<Sale, never, never, 'amount' | 'tax'>('sales', {
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }), tax: money({ currency: 'EUR', scale: 2 }) },
+    })
+    const q = sales.query()
+    // AggregateResult maps Reducer<R> → R, so run() exposes the narrowed types.
+    const moneyAgg = q.aggregate(b => ({ paid: b.sum('amount') }))
+    const nonMoneyAgg = q.aggregate(b => ({ qty: b.sum('qty') }))
+    type MoneyResult = ReturnType<typeof moneyAgg.run>
+    type NumberResult = ReturnType<typeof nonMoneyAgg.run>
+    // b.sum on a declared money field returns Reducer<MoneyString>;
+    // MoneyString is a branded string, so it satisfies string.
+    expectTypeOf<MoneyResult['paid']>().toMatchTypeOf<string>()
+    // Non-money field stays number.
+    expectTypeOf<NumberResult['qty']>().toEqualTypeOf<number>()
+  })
+  it('no M (default) keeps b.sum as number (zero churn)', async () => {
+    const vault = await typedVault()
+    const sales = vault.collection<Sale>('s2', { moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) } })
+    const r = sales.query().aggregate(b => ({ paid: b.sum('amount') }))
+    type Result = ReturnType<typeof r.run>
+    expectTypeOf<Result['paid']>().toEqualTypeOf<number>()
   })
 })

--- a/packages/hub/src/aggregate/reducers.ts
+++ b/packages/hub/src/aggregate/reducers.ts
@@ -374,12 +374,12 @@ export function moneyMax(field: string, opts?: ReducerOptions<number>): Reducer<
  * combinations — the field narrowing is type-only; the methods delegate
  * directly to the standalone factories.
  */
-export interface ReducerBuilder<T, S extends keyof T = never> {
+export interface ReducerBuilder<T, S extends keyof T = never, M extends keyof T & string = never> {
   count(opts?: ReducerOptions<number>): Reducer<number>
-  sum(field: QueryField<T, S>, opts?: ReducerOptions<number>): Reducer<number>
+  sum<F extends QueryField<T, S>>(field: F, opts?: ReducerOptions<number>): [F] extends [M] ? Reducer<MoneyString> : Reducer<number>
   avg(field: QueryField<T, S>, opts?: ReducerOptions<{ sum: number; count: number }>): ReturnType<typeof avg>
-  min(field: QueryField<T, S>, opts?: ReducerOptions<number>): ReturnType<typeof min>
-  max(field: QueryField<T, S>, opts?: ReducerOptions<number>): ReturnType<typeof max>
+  min<F extends QueryField<T, S>>(field: F, opts?: ReducerOptions<number>): [F] extends [M] ? Reducer<MoneyString | null> : ReturnType<typeof min>
+  max<F extends QueryField<T, S>>(field: F, opts?: ReducerOptions<number>): [F] extends [M] ? Reducer<MoneyString | null> : ReturnType<typeof max>
   moneySum(field: QueryField<T, S>, opts?: ReducerOptions<number>): Reducer<MoneyString>
   moneyMin(field: QueryField<T, S>, opts?: ReducerOptions<number>): Reducer<MoneyString | null>
   moneyMax(field: QueryField<T, S>, opts?: ReducerOptions<number>): Reducer<MoneyString | null>
@@ -394,7 +394,17 @@ export interface ReducerBuilder<T, S extends keyof T = never> {
  * parameter-contravariance, so this single instance works for all `T`/`S`.
  */
 export const reducerBuilder: ReducerBuilder<Record<string, unknown>> = {
-  count, sum, avg, min, max, moneySum, moneyMin, moneyMax,
+  count,
+  // The generic F parameter on sum/min/max in the interface is type-only; the
+  // standalone factories are plain `(field: string)` functions. With M=never the
+  // conditional return collapses to the numeric branch, matching the factories'
+  // return type, but TypeScript cannot verify that collapse for a generic method
+  // signature — so each factory is cast directly to the method's type.
+  sum: sum as ReducerBuilder<Record<string, unknown>>['sum'],
+  avg,
+  min: min as ReducerBuilder<Record<string, unknown>>['min'],
+  max: max as ReducerBuilder<Record<string, unknown>>['max'],
+  moneySum, moneyMin, moneyMax,
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -170,7 +170,7 @@ function warnOnceFallback(adapterName: string): void {
 }
 
 /** A typed collection of records within a vault. */
-export class Collection<T, S extends keyof T = never, Q extends keyof T & string = never> {
+export class Collection<T, S extends keyof T = never, Q extends keyof T & string = never, M extends keyof T & string = never> {
   private readonly adapter: NoydbStore
   private readonly vault: string
   private readonly name: string
@@ -3613,9 +3613,9 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    * const drafts = invoices.query(i => i.status === 'draft');
    * ```
    */
-  query(): Query<T, S, Q>
+  query(): Query<T, S, Q, M>
   query(predicate: (record: T) => boolean): T[]
-  query(predicate?: (record: T) => boolean): Query<T, S, Q> | T[] {
+  query(predicate?: (record: T) => boolean): Query<T, S, Q, M> | T[] {
     if (this.lazy) {
       throw new Error(
         `Collection "${this.name}": query() is not available in lazy mode (prefetch: false). ` +
@@ -3667,7 +3667,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
             : {}),
         }
       : undefined
-    return new Query<T, S, Q>(source, undefined, joinContext, this.aggregateStrategy)
+    return new Query<T, S, Q, M>(source, undefined, joinContext, this.aggregateStrategy)
   }
 
   /**

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -138,7 +138,7 @@ export interface DeclaredPredicate {
   fn: (record: unknown, ctx?: unknown) => boolean
 }
 
-export class Query<T, S extends keyof T = never, Q extends keyof T & string = never> {
+export class Query<T, S extends keyof T = never, Q extends keyof T & string = never, M extends keyof T & string = never> {
   private readonly source: InternalSource
   private readonly plan: QueryPlan
   private readonly joinContext: JoinContext | undefined
@@ -183,8 +183,8 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
    * `.wherePredicate(name, ctx?)` for the MV's query callback.
    * Consumers don't call this directly.
    */
-  _withPredicates(predicates: ReadonlyMap<string, DeclaredPredicate>): Query<T, S, Q> {
-    return new Query<T, S, Q>(
+  _withPredicates(predicates: ReadonlyMap<string, DeclaredPredicate>): Query<T, S, Q, M> {
+    return new Query<T, S, Q, M>(
       this.source as QuerySource<T>,
       this.plan,
       this.joinContext,
@@ -238,7 +238,7 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
    * canonical-JSON hash of `ctx` fold into the MV's `queryHash`, so
    * either changing forces refresh on next visit.
    */
-  wherePredicate(name: string, ctx?: unknown): Query<T, S, Q> {
+  wherePredicate(name: string, ctx?: unknown): Query<T, S, Q, M> {
     if (!this.predicates) {
       throw new Error(
         `.wherePredicate("${name}"): no predicates registered on this Query. ` +
@@ -262,7 +262,7 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
       ctxHash: canonicalCtxHash(ctx),
       fn: decl.fn,
     }
-    return new Query<T, S, Q>(
+    return new Query<T, S, Q, M>(
       this.source as QuerySource<T>,
       { ...this.plan, clauses: [...this.plan.clauses, clause] },
       this.joinContext,
@@ -280,12 +280,12 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
    * BigInt-exact per record. A malformed operand or a string operator
    * (`contains`/`startsWith`) throws here, at the call site.
    */
-  where(field: QueryField<T, S, Q>, op: Operator, value: unknown): Query<T, S, Q> {
+  where(field: QueryField<T, S, Q>, op: Operator, value: unknown): Query<T, S, Q, M> {
     const desc = this.source.moneyFields?.[field]
     const clause: FieldClause = desc
       ? moneyFieldClause(field, op, value, desc)
       : { type: 'field', field, op, value }
-    return new Query<T, S, Q>(
+    return new Query<T, S, Q, M>(
       this.source as QuerySource<T>,
       { ...this.plan, clauses: [...this.plan.clauses, clause] },
       this.joinContext,
@@ -299,16 +299,16 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
    * Each clause inside the callback is OR-combined; the group itself
    * joins the parent plan with AND.
    */
-  or(builder: (q: Query<T, S, Q>) => Query<T, S, Q>): Query<T, S, Q> {
+  or(builder: (q: Query<T, S, Q, M>) => Query<T, S, Q, M>): Query<T, S, Q, M> {
     const sub = builder(
-      new Query<T, S, Q>(this.source as QuerySource<T>, EMPTY_PLAN, this.joinContext, this.aggregateStrategy, this.predicates),
+      new Query<T, S, Q, M>(this.source as QuerySource<T>, EMPTY_PLAN, this.joinContext, this.aggregateStrategy, this.predicates),
     )
     const group: GroupClause = {
       type: 'group',
       op: 'or',
       clauses: sub.plan.clauses,
     }
-    return new Query<T, S, Q>(
+    return new Query<T, S, Q, M>(
       this.source as QuerySource<T>,
       { ...this.plan, clauses: [...this.plan.clauses, group] },
       this.joinContext,
@@ -321,16 +321,16 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
    * Logical AND group. Same shape as `or()` but every clause inside the group
    * must match. Useful for explicit grouping inside a larger OR.
    */
-  and(builder: (q: Query<T, S, Q>) => Query<T, S, Q>): Query<T, S, Q> {
+  and(builder: (q: Query<T, S, Q, M>) => Query<T, S, Q, M>): Query<T, S, Q, M> {
     const sub = builder(
-      new Query<T, S, Q>(this.source as QuerySource<T>, EMPTY_PLAN, this.joinContext, this.aggregateStrategy, this.predicates),
+      new Query<T, S, Q, M>(this.source as QuerySource<T>, EMPTY_PLAN, this.joinContext, this.aggregateStrategy, this.predicates),
     )
     const group: GroupClause = {
       type: 'group',
       op: 'and',
       clauses: sub.plan.clauses,
     }
-    return new Query<T, S, Q>(
+    return new Query<T, S, Q, M>(
       this.source as QuerySource<T>,
       { ...this.plan, clauses: [...this.plan.clauses, group] },
       this.joinContext,
@@ -340,12 +340,12 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
   }
 
   /** Escape hatch: add an arbitrary predicate function. Not serializable. */
-  filter(fn: (record: T) => boolean): Query<T, S, Q> {
+  filter(fn: (record: T) => boolean): Query<T, S, Q, M> {
     const clause: FilterClause = {
       type: 'filter',
       fn: fn as (record: unknown) => boolean,
     }
-    return new Query<T, S, Q>(
+    return new Query<T, S, Q, M>(
       this.source as QuerySource<T>,
       { ...this.plan, clauses: [...this.plan.clauses, clause] },
       this.joinContext,
@@ -359,9 +359,9 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
    * `{ by: 'label' }` to sort a `dictKey`/`staticDict` field by its resolved
    * label at the query locale instead of the stored code (#285).
    */
-  orderBy(field: QueryField<T, S>, direction: 'asc' | 'desc' = 'asc', opts?: { by?: 'value' | 'label' }): Query<T, S, Q> {
+  orderBy(field: QueryField<T, S>, direction: 'asc' | 'desc' = 'asc', opts?: { by?: 'value' | 'label' }): Query<T, S, Q, M> {
     const entry: OrderBy = opts?.by === 'label' ? { field, direction, by: 'label' } : { field, direction }
-    return new Query<T, S, Q>(
+    return new Query<T, S, Q, M>(
       this.source as QuerySource<T>,
       { ...this.plan, orderBy: [...this.plan.orderBy, entry] },
       this.joinContext,
@@ -371,8 +371,8 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
   }
 
   /** Cap the result size. */
-  limit(n: number): Query<T, S, Q> {
-    return new Query<T, S, Q>(
+  limit(n: number): Query<T, S, Q, M> {
+    return new Query<T, S, Q, M>(
       this.source as QuerySource<T>,
       { ...this.plan, limit: n },
       this.joinContext,
@@ -382,8 +382,8 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
   }
 
   /** Skip the first N matching records (after ordering). */
-  offset(n: number): Query<T, S, Q> {
-    return new Query<T, S, Q>(
+  offset(n: number): Query<T, S, Q, M> {
+    return new Query<T, S, Q, M>(
       this.source as QuerySource<T>,
       { ...this.plan, offset: n },
       this.joinContext,
@@ -453,7 +453,7 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
   join<As extends string, R = unknown>(
     field: QueryField<T, S>,
     opts: { as: As; strategy?: JoinStrategy; maxRows?: number },
-  ): Query<T & Record<As, R | null>, S, Q> {
+  ): Query<T & Record<As, R | null>, S, Q, M> {
     if (!this.joinContext) {
       throw new Error(
         `Query.join() requires a join context. Use collection.query() ` +
@@ -495,7 +495,7 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
           partitionScope: 'all',
           isDictJoin: true,
         }
-    return new Query<T & Record<As, R | null>, S, Q>(
+    return new Query<T & Record<As, R | null>, S, Q, M>(
       this.source as unknown as QuerySource<T & Record<As, R | null>>,
       { ...this.plan, joins: [...this.plan.joins, leg] },
       this.joinContext,
@@ -534,7 +534,7 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
         | { readonly predicate: string }
       maxRows?: number
     },
-  ): Query<T & { [K in As]: TTarget }, S, Q> {
+  ): Query<T & { [K in As]: TTarget }, S, Q, M> {
     if (!this.joinContext) {
       throw new Error(
         `Query.crossJoin("${target}"): requires a join context. ` +
@@ -591,7 +591,7 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
       ...(opts.maxRows !== undefined && { maxRows: opts.maxRows }),
     }
 
-    return new Query<T & { [K in As]: TTarget }, S, Q>(
+    return new Query<T & { [K in As]: TTarget }, S, Q, M>(
       this.source as unknown as QuerySource<T & { [K in As]: TTarget }>,
       { ...this.plan, clauses: [...this.plan.clauses, clause] },
       this.joinContext,
@@ -735,12 +735,12 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
    *
    */
   aggregate<Spec extends AggregateSpec>(spec: Spec): Aggregation<AggregateResult<Spec>>
-  aggregate<Spec extends AggregateSpec>(build: (b: ReducerBuilder<T, S>) => Spec): Aggregation<AggregateResult<Spec>>
+  aggregate<Spec extends AggregateSpec>(build: (b: ReducerBuilder<T, S, M>) => Spec): Aggregation<AggregateResult<Spec>>
   aggregate<Spec extends AggregateSpec>(
-    specOrBuild: Spec | ((b: ReducerBuilder<T, S>) => Spec),
+    specOrBuild: Spec | ((b: ReducerBuilder<T, S, M>) => Spec),
   ): Aggregation<AggregateResult<Spec>> {
     let spec = typeof specOrBuild === 'function'
-      ? (specOrBuild as (b: ReducerBuilder<T, S>) => Spec)((reducerBuilder as unknown) as ReducerBuilder<T, S>)
+      ? (specOrBuild as (b: ReducerBuilder<T, S, M>) => Spec)((reducerBuilder as unknown) as ReducerBuilder<T, S, M>)
       : specOrBuild
     // Rewrite sum/min/max over money fields into exact BigInt reducers
     // before the strategy runs (covers static run() and live/MV paths).

--- a/packages/hub/src/types.ts
+++ b/packages/hub/src/types.ts
@@ -57,6 +57,7 @@ import type { ObjectProjection } from './blobs/object-projection.js'
 // file, so going through it would create an import cycle.
 import type { CoordinationProvider } from './coordination/types.js'
 import type { ScriptWarning } from './i18n/script.js'
+import type { MoneyDescriptor } from './money/descriptor.js'
 
 /** Format version for encrypted record envelopes. */
 export const NOYDB_FORMAT_VERSION = 1 as const
@@ -307,6 +308,17 @@ export type IndexDefFor<F extends string> =
 export type SensitiveOpt<T, S extends keyof T> = [S] extends [never]
   ? readonly (keyof T & string)[]
   : readonly S[]
+
+/**
+ * The type of the `moneyFields` collection option, conditional on whether the
+ * caller opted into compile-time money-field typing via the 4th generic `M`.
+ * With no `M` (`M = never`) it accepts any `Record<string, MoneyDescriptor>` —
+ * runtime money only, no compile-level narrowing, non-breaking. With `M` given,
+ * it is `Record<M, MoneyDescriptor>`, tying the runtime map to the declared
+ * money-field union so the two cannot drift.
+ */
+export type MoneyFieldsOpt<T, M extends keyof T & string = never> =
+  [M] extends [never] ? Record<string, MoneyDescriptor> : Record<M, MoneyDescriptor>
 
 /**
  * Concrete {@link Sealed} handle. Holds the reveal closure (which captures the

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -31,7 +31,7 @@ import { OverlayedCollection } from './overlay-views/virtual-collection.js'
 import type { PublicEnvelope } from './meta/public-envelope/types.js'
 import { buildRecipientKeyringFile } from './team/keyring.js'
 import { ensureCollectionDEK, hasAccess, hasExportCapability, hasImportCapability } from './team/keyring.js'
-import type { ExportFormat, KeyringFile, SensitiveOpt, IndexFieldName, IndexDefFor } from './types.js'
+import type { ExportFormat, KeyringFile, SensitiveOpt, IndexFieldName, IndexDefFor, MoneyFieldsOpt } from './types.js'
 import {
   ExportCapabilityError,
   ImportCapabilityError,
@@ -91,7 +91,6 @@ import { LinkSet, isLinkCollectionName, linkCollectionName, linkRowKey, LinkInte
 import type { EmbeddingDescriptor } from './embeddings/index.js'
 import type { I18nTextDescriptor } from './i18n/core.js'
 import { getAtPath } from './i18n/core.js'
-import type { MoneyDescriptor } from './money/descriptor.js'
 import type { ComputedFields } from './computed/index.js'
 import { NO_I18N, type I18nStrategy } from './i18n/strategy.js'
 import { NO_SYNC, type SyncStrategy } from './team/sync-strategy.js'
@@ -681,7 +680,7 @@ export class Vault {
    * Lazy mode + indexes is rejected at construction time — see the
    * Collection constructor for the rationale.
    */
-  collection<T, S extends keyof T & string = never, Q extends keyof T & string = never>(collectionName: string, options?: {
+  collection<T, S extends keyof T & string = never, Q extends keyof T & string = never, M extends keyof T & string = never>(collectionName: string, options?: {
     indexes?: readonly IndexDefFor<IndexFieldName<T, S, Q>>[]
     /** — auto-reconcile policy for persisted-index drift. */
     reconcileOnOpen?: 'off' | 'dry-run' | 'auto'
@@ -706,7 +705,7 @@ export class Vault {
     /** The collection's own descriptive metadata (label/description/icon). See collection.describe(). */
     meta?: CollectionMeta
     /** — declare money() fields for currency-safe decimal storage/formatting. */
-    moneyFields?: Record<string, MoneyDescriptor>
+    moneyFields?: MoneyFieldsOpt<T, M>
     /** — declare computed scalar fields, evaluated on write (schema-owned). */
     computed?: ComputedFields<T>
     /** — per-collection conflict resolution policy. */
@@ -791,7 +790,7 @@ export class Vault {
      * Default false — the working set is plaintext.
      */
     ramCiphertext?: boolean
-  }): Collection<T, S, Q> {
+  }): Collection<T, S, Q, M> {
     // Overlay intercept. When the requested collection name
     // matches a registered `withOverlayedView`, return the virtual
     // proxy that merges base + overlay on read and routes writes to
@@ -809,7 +808,7 @@ export class Vault {
         const overlay = this.collection<T>(spec.overlay)
         const baseRowKey = overlayRegistry.resolveBaseRowKey(collectionName, this.materializedViewRegistry)
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return new OverlayedCollection<any>(spec, base, overlay, baseRowKey) as unknown as Collection<T, S, Q>
+        return new OverlayedCollection<any>(spec, base, overlay, baseRowKey) as unknown as Collection<T, S, Q, M>
       }
     }
     // Guard: reject reserved _dict_* names
@@ -1153,7 +1152,7 @@ export class Vault {
         this._pendingSchemaWrites.push(work)
       }
     }
-    return coll as unknown as Collection<T, S, Q>
+    return coll as unknown as Collection<T, S, Q, M>
   }
 
   /**


### PR DESCRIPTION
## What

Adds an **opt-in 4th generic `M`** (declared money fields) to `vault.collection<T, S, Q, M>` → `Collection<T,S,Q,M>` → `Query<T,S,Q,M>`, so the `aggregate(b => …)` builder's `b.sum`/`b.min`/`b.max` return `MoneyString` for a money field automatically — the "ideal" the explicit `b.moneySum` (from #510) stood in for.

```ts
const sales = vault.collection<Sale, never, never, 'amount' | 'tax'>('sales', {
  moneyFields: { amount: money({ currency: 'EUR', scale: 2 }), tax: money({ currency: 'EUR', scale: 2 }) },
})
sales.query().aggregate(b => ({
  paid: b.sum('amount'),   // MoneyString (money field)
  t:    b.sum('tax'),      // MoneyString
  qty:  b.sum('qty'),      // number (non-money)
}))
```

## How
- `ReducerBuilder<T, S, M>`: `sum`/`min`/`max` are generic on the field literal `F` with a conditional return `[F] extends [M] ? Reducer<MoneyString> : Reducer<number>`. `count`/`avg`/`moneySum`/`moneyMin`/`moneyMax` unchanged.
- `M extends keyof T & string = never` threaded through `Collection`/`Query`/`vault.collection` (phantom except the `aggregate` builder param) — **zero churn** when `M=never` (`sum` → `number`, today's behavior).
- `moneyFields` option tied to `M` via `MoneyFieldsOpt<T,M>` (permissive when no `M`, `Record<M, MoneyDescriptor>` when given — catches drift).
- Runtime UNCHANGED: `b.sum('amount')` is still the numeric `sum` factory; `wrapMoneyReducers` rewrites it to a money reducer at `aggregate()` time. `M` + the conditional return is the type-level assertion of that contract (same model as `moneySum`).

## Scope / follow-ups
- `Query.aggregate` only. `ScanBuilder.aggregate`/`GroupedQuery.aggregate` keep `M=never` (→ `number`; explicit `b.moneySum` still works) — documented follow-ups.

## Verification
- Full `pnpm --filter @noy-db/hub typecheck` + `lint` green; suite **2915/330** (type-only). Architecture OK.
- **opus review: Ready to merge** — conditional type sound across all regimes (incl. union/never edges), singleton cast honest (not `as any`), zero-churn confirmed, runtime untouched; safety scan clean (6 files, no stray edits).