### PR TITLE
Land #306 record-scoped sealing milestone + money-M parity + anonymized migration doc

### DIFF
--- a/docs/migration/2026-06-16-federation-to-klum-db.md
+++ b/docs/migration/2026-06-16-federation-to-klum-db.md
@@ -1,0 +1,167 @@
+# Consumer migration: federation → `@klum-db/lobby`
+
+**Date:** 2026-06-16
+**Applies to:** anyone consuming `@noy-db/hub` federation (VaultGroup / sharding / state-vault / insight / fleet-migration / cross-shard-join).
+**Status of the change:** merged to `main` (#450 + #452), **not yet published** to npm.
+
+> Keyed by **consumer** below (app names omitted — these are private pilot consumers). The two consumers in scope:
+> - **Consumer A** (a multi-party app; the federation-driving recipe) → **migrates to `@klum-db/lobby`.**
+> - **Consumer B** (refounded on hub-core features; transitionGuard / formatted-sequences / refArray / FK-derivations) → **almost certainly does NOT need klum-db** (see Part B).
+
+---
+
+## 1. What changed
+
+Federation was extracted out of `@noy-db/hub` into a new package **`@klum-db/lobby`** (the outward "orchestrate many vaults" framework). Concretely:
+
+- **`db.openVaultGroup()` / `db.openStateManagementVault()` / `db.withVaultTemplate()` now throw `FederationMovedError`.** The entry point is the **`Lobby`** class: `createLobby(db).openVaultGroup(...)`.
+- **Federation *types*** (`VaultGroup`, `VaultTemplate`, `VaultGroupOptions`, `VaultRegistryRow`, `CrossVaultDerivationSpec`, `MigrationStatusRow`, …) are **no longer exported from `@noy-db/hub`** — import them from `@klum-db/lobby`.
+- **Federation *error classes*** (`CrossShardJoinError`, `UnknownShardError`, `ShardProvisioningError`, `VaultTemplateNotFoundError`, `ReservedVaultNameError`, `DataResidencyError`) and **`STATE_VAULT_NAME`** remain public on `@noy-db/hub` **and** are re-exported from `@klum-db/lobby`. Catch them from whichever you depend on.
+- `@klum-db/lobby` binds to a new **`@noy-db/hub/kernel`** subpath (only present in the new, unpublished hub).
+
+The methods on a returned group/state object are **unchanged** — `firm.collection()`, `firm.query()`, `firm.withCrossVaultDerivation()`, `firm.refreshInsights()`, `firm.migrateFleet()`, `state.registry`, etc. Only *how you obtain* the group/state moves from `db` to `lobby`.
+
+---
+
+## 2. Do you even need klum-db? (the grep test)
+
+Run this in your consumer repo:
+
+```bash
+grep -rnE "openVaultGroup|openStateManagementVault|withVaultTemplate|VaultGroup|VaultRegistryRow|VaultTemplate|StateManagementVault|withCrossVaultDerivation|refreshInsights|migrateFleet|crossShardJoin|broadcastJoin|CrossVaultDerivationSpec" src/
+```
+
+- **Zero hits → you do NOT need `@klum-db/lobby`.** The federation removal is a no-op for you; the new `@noy-db/hub` is backward-compatible. Just bump hub when it publishes. *(Expected for Consumer B.)*
+- **Any hits → migrate** those call-sites to the Lobby API (Part A). *(Consumer A.)*
+
+---
+
+## Part A — Consumer A (federation user)
+
+### A1. Consume the unpublished hub + lobby locally
+
+Consumer A is a separate repo, so `workspace:*` doesn't reach it, and **lobby needs the *new* hub** (with `/kernel`) which isn't on npm. Provide **both** from your local noy-db build. Pick one:
+
+**yalc (day-to-day loop):**
+```bash
+# in noy-db
+pnpm build
+(cd packages/hub  && npx yalc publish)
+(cd packages/lobby && npx yalc publish)
+# in the consumer repo
+npx yalc add @noy-db/hub @klum-db/lobby
+pnpm install
+# after each noy-db change:
+#   (in noy-db) pnpm build && (cd packages/hub && npx yalc push) && (cd packages/lobby && npx yalc push)
+```
+
+**Tarballs (milestone / CI validation — closest to the real artifact):**
+```bash
+# in noy-db
+pnpm build
+(cd packages/hub  && pnpm pack)   # noy-db-hub-0.2.0-pre.23.tgz
+(cd packages/lobby && pnpm pack)  # klum-db-lobby-0.2.0-pre.23.tgz
+```
+```jsonc
+// consumer package.json
+"@noy-db/hub":    "file:../noy-db/packages/hub/noy-db-hub-0.2.0-pre.23.tgz",
+"@klum-db/lobby": "file:../noy-db/packages/lobby/klum-db-lobby-0.2.0-pre.23.tgz"
+```
+
+> ⚠️ Do **not** mix the npm-published `@noy-db/hub` (old, still has federation, no `/kernel`) with a local lobby — lobby's `@noy-db/hub/kernel` imports won't resolve. Use the local hub.
+> ⚠️ Do **not** `link:`/`file:` the `packages/lobby` *directory* — its `@noy-db/hub: workspace:*` peer is unresolvable outside the monorepo. yalc/pack rewrite it, which is why they work.
+
+### A2. Add ONE adapter module (contains all klum-db churn)
+
+Create `src/lib/klum.ts` in the consumer repo. Every klum-db touchpoint goes through here, so the FR work that follows lands in one file, not scattered across the app.
+
+```ts
+// src/lib/klum.ts — the consumer's single point of contact with @klum-db/lobby
+import type { Noydb } from '@noy-db/hub'
+import { createLobby, type Lobby } from '@klum-db/lobby'
+
+// One Lobby per Noydb runtime, memoized. CRITICAL: withVaultTemplate(...) and the
+// subsequent openVaultGroup(...) MUST run on the SAME Lobby instance — the Lobby
+// holds the vault-template registry (it used to live on the Noydb). The WeakMap
+// guarantees same-db → same-lobby, preserving that ordering invariant.
+const lobbies = new WeakMap<Noydb, Lobby>()
+
+export function lobbyFor(db: Noydb): Lobby {
+  let l = lobbies.get(db)
+  if (!l) {
+    l = createLobby(db)
+    lobbies.set(db, l)
+  }
+  return l
+}
+
+// Re-export the federation surface the consumer uses from its new home, so app
+// code imports from './lib/klum' (stable) rather than '@klum-db/lobby' directly.
+// Add the names you actually use.
+export type {
+  VaultGroup,
+  VaultTemplate,
+  VaultGroupOptions,
+  VaultRegistryRow,
+  CrossVaultDerivationSpec,
+  RefreshInsightsResult,
+  MigrationStatusRow,
+  FleetMigrationResult,
+} from '@klum-db/lobby'
+
+export {
+  CrossShardJoinError,
+  UnknownShardError,
+  ShardProvisioningError,
+  VaultTemplateNotFoundError,
+  ReservedVaultNameError,
+  DataResidencyError,
+} from '@klum-db/lobby'
+```
+
+### A3. Rewrite the call-sites
+
+| Before (`@noy-db/hub`) | After |
+|---|---|
+| `db.withVaultTemplate(name, tmpl)` | `lobbyFor(db).withVaultTemplate(name, tmpl)` |
+| `await db.openVaultGroup(name, opts)` | `await lobbyFor(db).openVaultGroup(name, opts)` |
+| `await db.openStateManagementVault()` | `await lobbyFor(db).openStateManagementVault()` |
+| `import type { VaultRegistryRow, … } from '@noy-db/hub'` | `import type { VaultRegistryRow, … } from './lib/klum'` |
+| `import { CrossShardJoinError } from '@noy-db/hub'`* | `import { CrossShardJoinError } from './lib/klum'` |
+
+\* federation error classes still resolve from `@noy-db/hub` too, but routing them through `./lib/klum` keeps one source of truth. **Unchanged:** every method on the returned `firm`/`state` object (`firm.query`, `firm.withCrossVaultDerivation`, `firm.refreshInsights`, `firm.migrateFleet`, `state.registry`, …) and all plain vault access (`db.openVault(...)`, `db.collection(...)`).
+
+### A4. Verify
+
+```bash
+# after wiring local hub+lobby
+pnpm typecheck && pnpm test
+# nothing should still call the removed methods on db:
+grep -rnE "\bdb[A-Za-z0-9]*\.(openVaultGroup|openStateManagementVault|withVaultTemplate)\b" src/   # expect: no hits
+```
+A leftover `db.openVaultGroup(...)` won't fail typecheck (the shim still has the name) — it throws `FederationMovedError` at runtime. The grep is the real check.
+
+### A5. Going forward — adopt FRs incrementally
+
+As the #440 lobby epic FRs land in `@klum-db/lobby` (Bundle/Manifest, Relocate, Merge, Authority, Provenance, Deed/Custodian/Liberate, Surface, Migrate), pull each via the same local setup and surface it through `./lib/klum`. Validate each against real Consumer A onboarding/withdrawal flows as it ships — don't wait for the whole epic.
+
+---
+
+## Part B — Consumer B: likely **no** klum-db
+
+Consumer B was refounded on hub-core features — `transitionGuard`, formatted sequences, `refArray`, FK derivations — **none of which are federation**. So:
+
+1. **Run the grep test (§2).** Expected: **zero** federation hits.
+2. **If zero hits → do nothing klum-db.** The federation removal does not affect you. When the new `@noy-db/hub` publishes, bump it like any normal release; your code is unchanged.
+3. **If (unexpectedly) some hits →** migrate only those specific call-sites per Part A (add `src/lib/klum.ts`, route just those through it). Everything else stays on `@noy-db/hub`.
+4. **Do NOT add `@klum-db/lobby` "to be safe."** It pulls in the outward orchestration layer Consumer B doesn't use. The whole point of the inward/outward split is that single-vault apps stay on the lean `@noy-db/hub`.
+
+**Net:** Consumer B's "migration" is expected to be a no-op + a grep confirmation. If that holds, record it (in its repo notes) and move on.
+
+---
+
+## 3. Don'ts (both apps)
+
+- Don't publish `@klum-db/*` to npm during co-development — consume locally (yalc/tarball) until the API stabilizes across a few FRs.
+- Don't scatter `@klum-db/lobby` imports through the app — keep them behind the one adapter module.
+- Don't pair local lobby with npm hub (version says `pre.23` but it's the old federation-bearing hub without `/kernel`).

--- a/docs/superpowers/specs/2026-06-29-306-record-scoped-sealing.md
+++ b/docs/superpowers/specs/2026-06-29-306-record-scoped-sealing.md
@@ -1,6 +1,6 @@
 # #306 — Record-scoped sealing (design + spec)
 
-> Status: **design/spec for review** (2026-06-29). Slice A (a data-loss bug fix) is safe to land now; Slice B (the core feature) is a runtime-crypto change spec'd here for a supervised go-ahead; Slice C is a deferred ledger-format epic. Derived from a verified code investigation — every `file:line` below was confirmed against the tree.
+> Status: **SHIPPED** (2026-06-30) — all three slices merged to `main`. Slice A `f97c64b4` (rotateRecordCek `_sealed` data-loss fix); Slice B `03929256` (CEK-derived sealing + dual-read so `forget()` crypto-shreds sealed fields); Slice C `56d747ce` (ledger `payloadHash` binds `_sealed` — back-compat, `_cek` excluded). Each was TDD'd and adversarially reviewed; the dual-read legacy-record data-loss guard is pinned by `__tests__/sealed-fields-cek-derived.test.ts`. Release note: `.changeset/record-scoped-sealing.md`. The text below is the original design (2026-06-29), kept for the rationale; one in-flight decision changed during implementation — Slice C covers `_data + _sealed` only, NOT `_cek` (a tampered `_cek` self-detects, and `rotateRecordCek` rewrites it with no ledger entry).
 
 ## Problem
 

--- a/packages/hub/CHANGELOG.md
+++ b/packages/hub/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog — hub
 
+## Unreleased
+
+Record-scoped sealing (epic [#306](https://github.com/vLannaAi/noy-db/issues/306)) — sealed `sensitive` fields now participate in crypto-shred and tamper-evidence end to end — plus money-typing parity across the aggregate builders.
+
+### Feature: record-scoped sealing — `forget()` erases sealed fields + the ledger attests them ([#306](https://github.com/vLannaAi/noy-db/issues/306))
+
+- **Erasure.** When a collection sets both `sensitive` and `perRecordKeys`, each sealed field's key now derives from the record's per-record CEK (`deriveSealedFieldKeyFromCek`) instead of the collection DEK. `vault.forget()` drops the record's wrapped `_cek`, which now makes `_sealed` cryptographically unrecoverable — the same erasure guarantee `_data` already had. `ForgetResult` gains a **`sealedFieldsShredded`** count.
+- **No-migration dual-read.** Reads try the CEK-derived key first and fall back to the collection-DEK key, so records sealed before this change stay readable with no migration step; they upgrade to CEK-derivation on their next `put()`. `rotateRecordCek` re-encrypts `_sealed` under the new CEK rather than carrying it forward.
+- **Ledger integrity.** The history ledger's `payloadHash` now binds `_sealed`, so `vault.verifyBackupIntegrity()` detects tampering or erasure of a sealed value. Backward-compatible: a record with no sealed fields hashes exactly as before (`sha256(_data)`), so existing ledgers and non-sealed backups verify byte-identically. `_cek` is intentionally **not** bound (a tampered wrapped-CEK self-detects, and `rotateRecordCek` rewrites it with no ledger entry).
+- **Boundary.** A backup captured *before* `forget()` that retained both `_sealed` and `_cek` remains recoverable by a collection-DEK holder — the same caveat `_data` carries.
+
+### Feature: money-field typing across all aggregate builders ([#306](https://github.com/vLannaAi/noy-db/issues/306))
+
+- `scan().aggregate(b => …)` and `query().groupBy(...).aggregate(b => …)` now auto-type `b.sum`/`min`/`max` over a declared `moneyFields` member as **`MoneyString`**, matching `Query.aggregate` — completing the opt-in money-field (`M`) type matrix across `Query`, `ScanBuilder`, and `GroupedQuery`/`GroupedQueryN`. Type-only (phantom generic defaulting to `never`), so collections that don't opt in stay `number`.
+
 ## 0.2.0-pre.31
 
 ### Patch Changes

--- a/packages/hub/__tests__/ledger-hash-sealed.test.ts
+++ b/packages/hub/__tests__/ledger-hash-sealed.test.ts
@@ -1,0 +1,187 @@
+/**
+ * #306 Slice C — ledger `payloadHash` attests to sealed fields (`_sealed`).
+ *
+ * Before this slice, `envelopePayloadHash` hashed only `envelope._data`, so a
+ * tampered or erased sealed-field slot (`_sealed[field]`) was INVISIBLE to
+ * `vault.verifyBackupIntegrity()`. Slice C widens the hash to also bind
+ * `_sealed` — backward-compatibly: a record with NO `_sealed` hashes exactly
+ * as before (`sha256Hex(_data)`), so every existing ledger / non-sealed backup
+ * verifies byte-identically.
+ *
+ * The end-to-end tamper/erasure detection tests (3 + 4) are the point of the
+ * slice — that behavior did NOT exist before.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { ConflictError } from '../src/errors.js'
+import { withHistory } from '../src/history/index.js'
+import { NOYDB_FORMAT_VERSION } from '../src/types.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { envelopePayloadHash } from '../src/history/ledger/hash.js'
+import { sha256Hex } from '../src/history/ledger/entry.js'
+
+interface Person {
+  id: string
+  name: string
+  ssn?: string
+}
+
+/** In-memory store exposing the raw envelope map (`_data`) for white-box tampering. */
+function memoryStore(): NoydbStore & { _data: Map<string, Map<string, Map<string, EncryptedEnvelope>>> } {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    _data: data,
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        if (cn.startsWith('_')) continue
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll(v, snap) {
+      const vm = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [cn, recs] of Object.entries(snap)) {
+        const cm = new Map<string, EncryptedEnvelope>()
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+        vm.set(cn, cm)
+      }
+      const existing = data.get(v)
+      if (existing) for (const [cn, cm] of existing) if (cn.startsWith('_')) vm.set(cn, cm)
+      data.set(v, vm)
+    },
+  }
+}
+
+function envelope(fields: Partial<EncryptedEnvelope>): EncryptedEnvelope {
+  return {
+    _noydb: NOYDB_FORMAT_VERSION,
+    _v: 1,
+    _ts: '2026-01-01T00:00:00.000Z',
+    _iv: 'iv',
+    _data: 'abc',
+    ...fields,
+  } as EncryptedEnvelope
+}
+
+describe('#306 Slice C — envelopePayloadHash binds _sealed', () => {
+  it('1. back-compat: no _sealed hashes exactly as sha256Hex(_data); null → ""', async () => {
+    const env = envelope({ _data: 'abc' })
+    expect(await envelopePayloadHash(env)).toBe(await sha256Hex('abc'))
+    expect(await envelopePayloadHash(null)).toBe('')
+  })
+
+  it('2. _sealed is bound, order-independent, and widens the hash', async () => {
+    const base = { _data: 'abc' }
+    const a = envelope({ ...base, _sealed: { ssn: 'AAA' } })
+    const b = envelope({ ...base, _sealed: { ssn: 'BBB' } })
+    // Same _data, different _sealed → different hash.
+    expect(await envelopePayloadHash(a)).not.toBe(await envelopePayloadHash(b))
+
+    // Same _data + same _sealed entries in DIFFERENT key order → same hash.
+    const order1 = envelope({ ...base, _sealed: { ssn: 'AAA', dob: 'CCC' } })
+    const order2 = envelope({ ...base, _sealed: { dob: 'CCC', ssn: 'AAA' } })
+    expect(await envelopePayloadHash(order1)).toBe(await envelopePayloadHash(order2))
+
+    // A sealed envelope's hash differs from the bare sha256Hex(_data) — proves
+    // the widening actually happened (it's not silently the legacy hash).
+    expect(await envelopePayloadHash(a)).not.toBe(await sha256Hex('abc'))
+  })
+
+  it('3. end-to-end: tampering a stored _sealed slot trips verifyBackupIntegrity (kind:data)', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store,
+      user: 'alice',
+      secret: 'test-passphrase-1234',
+      historyStrategy: withHistory(),
+    })
+    const vault = await db.openVault('firm')
+    const people = vault.collection<Person, 'ssn'>('people', { perRecordKeys: true, sensitive: ['ssn'] })
+    await people.put('p1', { id: 'p1', name: 'Ann', ssn: '123-45-6789' })
+
+    expect((await vault.verifyBackupIntegrity()).ok).toBe(true)
+
+    // Tamper directly in the adapter: reverse the sealed ssn ciphertext.
+    const raw = store._data.get('firm')!.get('people')!.get('p1')!
+    const sealedSsn = raw._sealed?.ssn
+    expect(sealedSsn).toBeDefined()
+    const tampered = { ...raw, _sealed: { ...raw._sealed, ssn: sealedSsn!.split('').reverse().join('') } }
+    store._data.get('firm')!.get('people')!.set('p1', tampered as EncryptedEnvelope)
+
+    const result = await vault.verifyBackupIntegrity()
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.kind).toBe('data')
+      if (result.kind === 'data') {
+        expect(result.collection).toBe('people')
+        expect(result.id).toBe('p1')
+      }
+    }
+  })
+
+  it('4. end-to-end: erasing the stored _sealed slot trips verifyBackupIntegrity (kind:data)', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store,
+      user: 'alice',
+      secret: 'test-passphrase-1234',
+      historyStrategy: withHistory(),
+    })
+    const vault = await db.openVault('firm')
+    const people = vault.collection<Person, 'ssn'>('people', { perRecordKeys: true, sensitive: ['ssn'] })
+    await people.put('p1', { id: 'p1', name: 'Ann', ssn: '123-45-6789' })
+
+    expect((await vault.verifyBackupIntegrity()).ok).toBe(true)
+
+    // Erase the sealed map entirely, leaving _data intact.
+    const raw = store._data.get('firm')!.get('people')!.get('p1')!
+    const { _sealed, ...withoutSealed } = raw
+    void _sealed
+    store._data.get('firm')!.get('people')!.set('p1', withoutSealed as EncryptedEnvelope)
+
+    const result = await vault.verifyBackupIntegrity()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.kind).toBe('data')
+  })
+
+  it('5. regression: a non-sealed perRecordKeys record still verifies and still trips on _data tamper', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store,
+      user: 'alice',
+      secret: 'test-passphrase-1234',
+      historyStrategy: withHistory(),
+    })
+    const vault = await db.openVault('firm')
+    const people = vault.collection<Person>('people', { perRecordKeys: true })
+    await people.put('p1', { id: 'p1', name: 'Ann' })
+
+    expect((await vault.verifyBackupIntegrity()).ok).toBe(true)
+
+    const raw = store._data.get('firm')!.get('people')!.get('p1')!
+    expect(raw._sealed).toBeUndefined()
+    const tampered = { ...raw, _data: raw._data.split('').reverse().join('') }
+    store._data.get('firm')!.get('people')!.set('p1', tampered as EncryptedEnvelope)
+
+    const result = await vault.verifyBackupIntegrity()
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.kind).toBe('data')
+  })
+})

--- a/packages/hub/__tests__/sealed-fields-cek-derived.test.ts
+++ b/packages/hub/__tests__/sealed-fields-cek-derived.test.ts
@@ -1,0 +1,254 @@
+/**
+ * #306 Slice B — sealed (`sensitive`) fields keyed off the per-record CEK.
+ *
+ * Before Slice B, `_sealed[field]` slots derived their key from the collection
+ * DEK (`deriveSealedFieldKey`), identical for every record forever — so
+ * `vault.forget()` (which drops `_cek`/`_sealed` but keeps the DEK) could NOT
+ * crypto-shred them. Slice B derives the sealed-field key from the record's
+ * per-record CEK (`deriveSealedFieldKeyFromCek`) on `perRecordKeys + sensitive`
+ * collections, so dropping `_cek` makes `_sealed` irrecoverable — matching the
+ * erasure guarantee `_data` already has.
+ *
+ * THE LINCHPIN is the dual-read fallback (Test 3): records sealed by the
+ * pre-#306 code (CEK-encrypted body, DEK-derived `_sealed`) MUST still read.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { ConflictError } from '../src/errors.js'
+import {
+  generateDEK,
+  wrapCek,
+  unwrapCek,
+  encrypt,
+  deriveSealedFieldKey,
+  deriveSealedFieldKeyFromCek,
+  decrypt,
+} from '../src/crypto.js'
+import { NOYDB_FORMAT_VERSION } from '../src/types.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { withHistory } from '../src/history/index.js'
+import { withForgetCascade } from '../src/forget/index.js'
+
+interface Person {
+  id: string
+  name: string
+  ssn: string
+}
+
+/** In-memory store exposing the raw envelope map (`_data`) for white-box reads. */
+function memoryStore(): NoydbStore & { _data: Map<string, Map<string, Map<string, EncryptedEnvelope>>> } {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    _data: data,
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        if (cn.startsWith('_')) continue
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll(v, snap) {
+      const existing = data.get(v)
+      const vm = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [cn, recs] of Object.entries(snap)) {
+        const cm = new Map<string, EncryptedEnvelope>()
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+        vm.set(cn, cm)
+      }
+      if (existing) for (const [cn, cm] of existing) if (cn.startsWith('_')) vm.set(cn, cm)
+      data.set(v, vm)
+    },
+  }
+}
+
+const SECRET = 'sealed-cek-derived-passphrase-2026-pilot'
+
+describe('#306 Slice B — sealed fields keyed off the per-record CEK', () => {
+  it('Test 1 — round-trips a sealed field; non-sealed field stays plain', async () => {
+    const db = await createNoydb({ store: memoryStore(), user: 'alice', secret: SECRET })
+    const vault = await db.openVault('v')
+    const people = vault.collection<Person, 'ssn'>('people', { perRecordKeys: true, sensitive: ['ssn'] })
+    await people.put('p1', { id: 'p1', name: 'Ada', ssn: '123-45-6789' })
+
+    const rec = await people.get('p1')
+    expect(rec).not.toBeNull()
+    expect(rec!.name).toBe('Ada')                       // non-sealed field is plain
+    expect(await rec!.ssn.reveal()).toBe('123-45-6789') // sealed field reveals
+  })
+
+  it('Test 2 — `_sealed` decrypts under the CEK-derived key, NOT the DEK-derived key', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, user: 'alice', secret: SECRET })
+    const vault = await db.openVault('v')
+    const people = vault.collection<Person, 'ssn'>('people', { perRecordKeys: true, sensitive: ['ssn'] })
+    await people.put('p1', { id: 'p1', name: 'Ada', ssn: '123-45-6789' })
+
+    const env = store._data.get('v')!.get('people')!.get('p1')!
+    expect(env._cek).toBeDefined()
+    const slot = env._sealed!.ssn!
+    const sep = slot.indexOf(':')
+    const iv = slot.slice(0, sep)
+    const data = slot.slice(sep + 1)
+
+    // White-box: reach the collection DEK and unwrap the record CEK.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dek = await (people as any).getDEK('people') as CryptoKey
+    const cek = await unwrapCek(env._cek!, dek)
+
+    // The CEK-derived key decrypts the slot; the DEK-derived key does not.
+    const cekKey = await deriveSealedFieldKeyFromCek(cek, 'people', 'ssn')
+    expect(JSON.parse(await decrypt(iv, data, cekKey))).toBe('123-45-6789')
+
+    const dekKey = await deriveSealedFieldKey(dek, 'people', 'ssn')
+    await expect(decrypt(iv, data, dekKey)).rejects.toThrow()
+  })
+
+  it('Test 3 — DUAL-READ: a legacy (DEK-sealed, CEK-bodied) record still reveals', async () => {
+    // R1 data-loss guard. Forge the EXACT shape the pre-#306 published code
+    // wrote on a `perRecordKeys + sensitive` collection: body CEK-encrypted
+    // (`_cek` present) but `_sealed[field]` derived off the collection DEK.
+    const store = memoryStore()
+    const db = await createNoydb({ store, user: 'alice', secret: SECRET })
+    const vault = await db.openVault('v')
+    const people = vault.collection<Person, 'ssn'>('people', { perRecordKeys: true, sensitive: ['ssn'] })
+
+    // Reach the REAL collection DEK white-box.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dek = await (people as any).getDEK('people') as CryptoKey
+
+    // Forge the legacy DEK-derived sealed slot.
+    const dekKey = await deriveSealedFieldKey(dek, 'people', 'ssn')
+    const sealedEnc = await encrypt(JSON.stringify('123-45-6789'), dekKey)
+    const slot = `${sealedEnc.iv}:${sealedEnc.data}`
+
+    // Forge a CEK-encrypted body (the legacy code DID use per-record CEKs for the body).
+    const cek = await generateDEK()
+    const body = await encrypt(JSON.stringify({ id: 'p1', name: 'Ada' }), cek)
+    const wrapped = await wrapCek(cek, dek)
+
+    const env: EncryptedEnvelope = {
+      _noydb: NOYDB_FORMAT_VERSION,
+      _v: 1,
+      _ts: new Date().toISOString(),
+      _iv: body.iv,
+      _data: body.data,
+      _cek: wrapped,
+      _sealed: { ssn: slot },
+    }
+    await store.put('v', 'people', 'p1', env)
+
+    // Fresh db/vault/collection on the SAME store to defeat any decrypt cache.
+    const db2 = await createNoydb({ store, user: 'alice', secret: SECRET })
+    const vault2 = await db2.openVault('v')
+    const people2 = vault2.collection<Person, 'ssn'>('people', { perRecordKeys: true, sensitive: ['ssn'] })
+    const rec = await people2.get('p1')
+    expect(rec).not.toBeNull()
+    expect(rec!.name).toBe('Ada')
+    // The CEK-derived key is tried first (fails AES-GCM auth), then the DEK
+    // fallback fires and decrypts the legacy slot — no data loss.
+    expect(await rec!.ssn.reveal()).toBe('123-45-6789')
+  })
+
+  it('Test 4 — forget() crypto-shreds sealed fields (erasure proof)', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store, user: 'alice', secret: SECRET,
+      historyStrategy: withHistory(),
+      forgetStrategy: withForgetCascade({ subjects: { people: 'subjectId' } }),
+    })
+    const vault = await db.openVault('v')
+    interface Subj { id: string; subjectId: string; name: string; ssn: string }
+    const people = vault.collection<Subj, 'ssn'>('people', { perRecordKeys: true, sensitive: ['ssn'] })
+    await people.put('p1', { id: 'p1', subjectId: 'data-subject-1', name: 'Ada', ssn: '123-45-6789' })
+
+    // Capture the live sealed blob BEFORE forget.
+    const before = store._data.get('v')!.get('people')!.get('p1')!
+    const oldSlot = before._sealed!.ssn!
+    const sep = oldSlot.indexOf(':')
+    const oldIv = oldSlot.slice(0, sep)
+    const oldData = oldSlot.slice(sep + 1)
+
+    const result = await vault.forget('data-subject-1')
+    expect(result.sealedFieldsShredded).toBe(1)
+
+    // The live envelope is now a tombstone with no `_cek` and no `_sealed`.
+    const tomb = store._data.get('v')!.get('people')!.get('p1')!
+    expect(tomb._cek).toBeUndefined()
+    expect(tomb._sealed).toBeUndefined()
+    expect(tomb._data).toBe('')
+
+    // The captured old slot is unrecoverable from the surviving collection DEK:
+    // it was CEK-derived and the CEK is gone, so the DEK-derived key fails too.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dek = await (people as any).getDEK('people') as CryptoKey
+    const dekKey = await deriveSealedFieldKey(dek, 'people', 'ssn')
+    await expect(decrypt(oldIv, oldData, dekKey)).rejects.toThrow()
+  })
+
+  it('Test 5 — rotateRecordCek re-encrypts `_sealed` under the new CEK', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, user: 'alice', secret: SECRET })
+    const vault = await db.openVault('v')
+    const people = vault.collection<Person, 'ssn'>('people', { perRecordKeys: true, sensitive: ['ssn'] })
+    await people.put('p1', { id: 'p1', name: 'Ada', ssn: '123-45-6789' })
+
+    const before = store._data.get('v')!.get('people')!.get('p1')!
+    const oldSlot = before._sealed!.ssn!
+    const oldCek = before._cek!
+
+    await vault.rotateRecordCek('people', 'p1')
+
+    // (a) reveal still works after rotation.
+    const after = await people.get('p1')
+    expect(await after!.ssn.reveal()).toBe('123-45-6789')
+
+    // (b) the new sealed blob differs (re-encrypted, not carried forward).
+    const env = store._data.get('v')!.get('people')!.get('p1')!
+    const newSlot = env._sealed!.ssn!
+    expect(newSlot).not.toBe(oldSlot)
+    expect(env._cek).not.toBe(oldCek)
+
+    // (c) the OLD CEK can no longer decrypt the NEW slot.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dek = await (people as any).getDEK('people') as CryptoKey
+    const oldCekKey = await unwrapCek(oldCek, dek)
+    const sep = newSlot.indexOf(':')
+    const nIv = newSlot.slice(0, sep)
+    const nData = newSlot.slice(sep + 1)
+    const oldDerived = await deriveSealedFieldKeyFromCek(oldCekKey, 'people', 'ssn')
+    await expect(decrypt(nIv, nData, oldDerived)).rejects.toThrow()
+  })
+
+  it('Test 6 — the #306 construction warning no longer fires', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const db = await createNoydb({ store: memoryStore(), user: 'alice', secret: SECRET })
+      const vault = await db.openVault('v')
+      vault.collection<Person, 'ssn'>('people', { perRecordKeys: true, sensitive: ['ssn'] })
+      const fired = warn.mock.calls.some((call) =>
+        call.some((arg) => typeof arg === 'string' &&
+          (arg.includes('record-scoped sealing (#306)') || arg.includes('leaves its sealed fields recoverable'))),
+      )
+      expect(fired).toBe(false)
+    } finally {
+      warn.mockRestore()
+    }
+  })
+})

--- a/packages/hub/__tests__/sealed-query-refusal.test-d.ts
+++ b/packages/hub/__tests__/sealed-query-refusal.test-d.ts
@@ -243,3 +243,44 @@ describe('money-field generic M — aggregate builder auto-types money fields', 
     expectTypeOf<Result['paid']>().toEqualTypeOf<number>()
   })
 })
+
+describe('money-field generic M — scan() & groupBy() aggregate builders auto-type money fields', () => {
+  interface Sale { id: string; amount: number; tax: number; qty: number }
+
+  it('scan().aggregate(b => …): money field → MoneyString, non-money → number', async () => {
+    const vault = await typedVault()
+    const sales = vault.collection<Sale, never, never, 'amount' | 'tax'>('sales-scan', {
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }), tax: money({ currency: 'EUR', scale: 2 }) },
+    })
+    // ScanBuilder.aggregate is async → Promise<AggregateResult<Spec>>; Awaited unwraps it.
+    const moneyAgg = sales.scan().aggregate(b => ({ paid: b.sum('amount') }))
+    const nonMoneyAgg = sales.scan().aggregate(b => ({ qty: b.sum('qty') }))
+    expectTypeOf<Awaited<typeof moneyAgg>['paid']>().toMatchTypeOf<string>()   // MoneyString (branded string)
+    expectTypeOf<Awaited<typeof nonMoneyAgg>['qty']>().toEqualTypeOf<number>()
+  })
+
+  it('groupBy().aggregate(b => …): money field → MoneyString, non-money → number', async () => {
+    const vault = await typedVault()
+    const sales = vault.collection<Sale, never, never, 'amount' | 'tax'>('sales-grp', {
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }), tax: money({ currency: 'EUR', scale: 2 }) },
+    })
+    // groupBy by a non-money key; the aggregate fields are intersected onto each
+    // GroupedRow, so run()[number]['paid'] exposes the narrowed money type. Avoid
+    // naming an aggregate field after the group key (it would intersect to never).
+    const moneyAgg = sales.query().groupBy('qty').aggregate(b => ({ paid: b.sum('amount') }))
+    const nonMoneyAgg = sales.query().groupBy('amount').aggregate(b => ({ tot: b.sum('qty') }))
+    expectTypeOf<ReturnType<typeof moneyAgg.run>[number]['paid']>().toMatchTypeOf<string>()
+    expectTypeOf<ReturnType<typeof nonMoneyAgg.run>[number]['tot']>().toEqualTypeOf<number>()
+  })
+
+  it('no M (default) keeps scan()/groupBy() b.sum as number (zero churn)', async () => {
+    const vault = await typedVault()
+    const sales = vault.collection<Sale>('sales-default', {
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+    })
+    const scanAgg = sales.scan().aggregate(b => ({ paid: b.sum('amount') }))
+    const grpAgg = sales.query().groupBy('qty').aggregate(b => ({ paid: b.sum('amount') }))
+    expectTypeOf<Awaited<typeof scanAgg>['paid']>().toEqualTypeOf<number>()
+    expectTypeOf<ReturnType<typeof grpAgg.run>[number]['paid']>().toEqualTypeOf<number>()
+  })
+})

--- a/packages/hub/src/aggregate/groupby.ts
+++ b/packages/hub/src/aggregate/groupby.ts
@@ -204,7 +204,7 @@ abstract class GroupedQueryBase {
  * them post-group would be a different operation (`having` /
  * `groupOrderBy`), out of scope for.
  */
-export class GroupedQuery<T, F extends string, S extends keyof T = never> extends GroupedQueryBase {
+export class GroupedQuery<T, F extends string, S extends keyof T = never, M extends keyof T & string = never> extends GroupedQueryBase {
   /**
    * Build a grouped aggregation. Returns a `GroupedAggregation`
    * with `.run()`, `.runAsync()`, and `.live()` terminals — same shape
@@ -212,18 +212,19 @@ export class GroupedQuery<T, F extends string, S extends keyof T = never> extend
    * result (one row per bucket) instead of a single reduced object.
    *
    * The builder overload `aggregate(b => spec)` types `b` as
-   * `ReducerBuilder<T, S>`, so field-taking reducers (`sum`, `avg`,
+   * `ReducerBuilder<T, S, M>`, so field-taking reducers (`sum`, `avg`,
    * `min`, `max`) refuse any field listed in the collection's
-   * `sensitive` option at compile time. The bare-spec overload is
-   * preserved for backward compatibility.
+   * `sensitive` option at compile time, and `sum`/`min`/`max` over a
+   * declared `moneyFields` (`M`) member return a `MoneyString`. The
+   * bare-spec overload is preserved for backward compatibility.
    */
   aggregate<Spec extends AggregateSpec>(spec: Spec): GroupedAggregation<GroupedRow<F, AggregateResult<Spec>>>
-  aggregate<Spec extends AggregateSpec>(build: (b: ReducerBuilder<T, S>) => Spec): GroupedAggregation<GroupedRow<F, AggregateResult<Spec>>>
+  aggregate<Spec extends AggregateSpec>(build: (b: ReducerBuilder<T, S, M>) => Spec): GroupedAggregation<GroupedRow<F, AggregateResult<Spec>>>
   aggregate<Spec extends AggregateSpec>(
-    specOrBuild: Spec | ((b: ReducerBuilder<T, S>) => Spec),
+    specOrBuild: Spec | ((b: ReducerBuilder<T, S, M>) => Spec),
   ): GroupedAggregation<GroupedRow<F, AggregateResult<Spec>>> {
     const spec: Spec = typeof specOrBuild === 'function'
-      ? (specOrBuild as (b: ReducerBuilder<T, S>) => Spec)(reducerBuilder as unknown as ReducerBuilder<T, S>)
+      ? (specOrBuild as (b: ReducerBuilder<T, S, M>) => Spec)(reducerBuilder as unknown as ReducerBuilder<T, S, M>)
       : specOrBuild
     // T is phantom on the wrapper so consumers can still see the
     // source row type on hover. Reference it to keep lint quiet.
@@ -243,14 +244,14 @@ export class GroupedQuery<T, F extends string, S extends keyof T = never> extend
  * multi-arg `Query.groupBy(...fields)` overload. The runtime shape is
  * identical — only the type-level result-row narrowing differs.
  */
-export class GroupedQueryN<T, F extends readonly string[], S extends keyof T = never> extends GroupedQueryBase {
+export class GroupedQueryN<T, F extends readonly string[], S extends keyof T = never, M extends keyof T & string = never> extends GroupedQueryBase {
   aggregate<Spec extends AggregateSpec>(spec: Spec): GroupedAggregation<GroupedRowN<F, AggregateResult<Spec>>>
-  aggregate<Spec extends AggregateSpec>(build: (b: ReducerBuilder<T, S>) => Spec): GroupedAggregation<GroupedRowN<F, AggregateResult<Spec>>>
+  aggregate<Spec extends AggregateSpec>(build: (b: ReducerBuilder<T, S, M>) => Spec): GroupedAggregation<GroupedRowN<F, AggregateResult<Spec>>>
   aggregate<Spec extends AggregateSpec>(
-    specOrBuild: Spec | ((b: ReducerBuilder<T, S>) => Spec),
+    specOrBuild: Spec | ((b: ReducerBuilder<T, S, M>) => Spec),
   ): GroupedAggregation<GroupedRowN<F, AggregateResult<Spec>>> {
     const spec: Spec = typeof specOrBuild === 'function'
-      ? (specOrBuild as (b: ReducerBuilder<T, S>) => Spec)(reducerBuilder as unknown as ReducerBuilder<T, S>)
+      ? (specOrBuild as (b: ReducerBuilder<T, S, M>) => Spec)(reducerBuilder as unknown as ReducerBuilder<T, S, M>)
       : specOrBuild
     void undefined as T | undefined
     return new GroupedAggregation<GroupedRowN<F, AggregateResult<Spec>>>(

--- a/packages/hub/src/aggregate/strategy.ts
+++ b/packages/hub/src/aggregate/strategy.ts
@@ -45,7 +45,7 @@ export interface AggregateStrategy {
    * Build a `GroupedQuery<T, F, S>` for `Query.groupBy(field)`. Same
    * closure / upstream inputs as `aggregate` plus the group key field.
    */
-  groupBy<T, F extends string, S extends keyof T = never>(
+  groupBy<T, F extends string, S extends keyof T = never, M extends keyof T & string = never>(
     executeRecords: () => readonly unknown[],
     field: F,
     upstreams: readonly AggregationUpstream[],
@@ -55,7 +55,7 @@ export interface AggregateStrategy {
       fallback?: string | readonly string[],
     ) => Promise<string | undefined>,
     moneyFields?: Record<string, MoneyDescriptor>,
-  ): GroupedQuery<T, F, S>
+  ): GroupedQuery<T, F, S, M>
 
   /**
    * Variadic-keyed sibling — builds a `GroupedQueryN<T, F, S>` for
@@ -63,12 +63,12 @@ export interface AggregateStrategy {
    * projection only applies to single-field groupings, which dispatch
    * through `groupBy` above.
    */
-  groupByN<T, F extends readonly string[], S extends keyof T = never>(
+  groupByN<T, F extends readonly string[], S extends keyof T = never, M extends keyof T & string = never>(
     executeRecords: () => readonly unknown[],
     fields: F,
     upstreams: readonly AggregationUpstream[],
     moneyFields?: Record<string, MoneyDescriptor>,
-  ): GroupedQueryN<T, F, S>
+  ): GroupedQueryN<T, F, S, M>
 
   /**
    * Terminal streaming aggregator for `ScanBuilder.aggregate(spec)`.

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -4011,7 +4011,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    * to the synthetic pagination path with the same one-time
    * warning (`listPage()` routes through that fallback internally).
    */
-  scan(opts: { pageSize?: number } = {}): ScanBuilder<T, S> {
+  scan(opts: { pageSize?: number } = {}): ScanBuilder<T, S, M> {
     const pageSize = opts.pageSize ?? 100
     // Build a JoinContext if the vault passed a join resolver
     // — same machinery as `query()`. Without one, `.join()`
@@ -4039,7 +4039,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     // coupling. Rebinding through the arrow keeps the unbound-
     // method lint rule happy — matches the pattern used in
     // builder.ts's candidateRecords helper.
-    return new ScanBuilder<T, S>(
+    return new ScanBuilder<T, S, M>(
       {
         listPage: (listOpts) => this.listPage(listOpts),
       },

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -16,7 +16,7 @@ import type { ComputedFields } from './computed/index.js'
 import { evalComputedFields } from './computed/index.js'
 import { NO_I18N, type I18nStrategy } from './i18n/strategy.js'
 import { resolvePolicy } from './i18n/policy.js'
-import { encrypt, decrypt, encryptDeterministic, deriveSealedFieldKey } from './crypto.js'
+import { encrypt, decrypt, encryptDeterministic, deriveSealedFieldKey, deriveSealedFieldKeyFromCek } from './crypto.js'
 import {
   wrapCek,
   unwrapCek,
@@ -1084,18 +1084,6 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     // are tiny CryptoKey handles, so a generous entry budget is cheap.
     this.perRecordCek = opts.perRecordKeys === true
     this.cekCache = this.perRecordCek ? new Lru<string, CryptoKey>({ maxRecords: 4096 }) : null
-
-    // Fix 1: guard the forget-cascade / per-record-CEK incompatibility with
-    // sealed sensitive fields (#304 × #503). Sealed-field keys derive off the
-    // collection DEK (getDEK), not the per-record CEK, so crypto-shredding a
-    // record erases _data but leaves _sealed[field] recoverable.
-    if (this.sensitiveFields.size > 0 && this.perRecordCek) {
-      console.warn(
-        `[noy-db] collection "${opts.name}": sealed \`sensitive\` fields derive off the ` +
-        `collection DEK and are NOT covered by per-record crypto-shred (#304) until ` +
-        `record-scoped sealing (#306) — forgetting a record leaves its sealed fields recoverable.`,
-      )
-    }
 
     // Fix 3: warn when `sensitive` is a no-op in debug-plaintext mode. When
     // storeCiphertext is false the sealing path is skipped entirely, so
@@ -2172,13 +2160,13 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     if (this.lazy && this.lru) {
       // Cache the handle-form (sealed fields → Sealed handles) so plaintext
       // for sensitive fields is never resident in the working set.
-      this.lru.set(id, { record: this.toCacheRecord(record, envelope), version }, estimateRecordBytes(record))
+      this.lru.set(id, { record: await this.toCacheRecord(record, envelope, id), version }, estimateRecordBytes(record))
       // Maintain persisted-index side-cars. Lazy mode is the
       // only place `persistedIndexes` is populated; eager mode uses the
       // in-memory `CollectionIndexes` above.
       await this.maintainPersistedIndexesOnPut(id, record, existing ? existing.record : null, version)
     } else {
-      this.cache.set(id, { record: this.toCacheRecord(record, envelope), version })
+      this.cache.set(id, { record: await this.toCacheRecord(record, envelope, id), version })
       // Update secondary indexes incrementally — no-op if no indexes are
       // declared. Pass the previous record (if any) so old buckets are
       // cleaned up before the new value is added.
@@ -2295,7 +2283,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
         raw = await this.decryptRecord(env, { id })
         if (raw === null) return null
         if (!cached) {
-          this.lru.set(id, { record: this.toCacheRecord(raw, env), version: env._v }, estimateRecordBytes(raw))
+          this.lru.set(id, { record: await this.toCacheRecord(raw, env, id), version: env._v }, estimateRecordBytes(raw))
         }
       } else {
         const cached = this.lru.get(id)
@@ -5092,7 +5080,9 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
         if (!(field in src)) continue
         const value = src[field]
         if (value === undefined) continue
-        const fieldKey = await deriveSealedFieldKey(dek, this.name, field)
+        const fieldKey = cek !== undefined
+          ? await deriveSealedFieldKeyFromCek(cek, this.name, field)
+          : await deriveSealedFieldKey(dek, this.name, field)
         const { iv, data } = await encrypt(JSON.stringify(value), fieldKey)
         slots[field] = `${iv}:${data}`
         delete open[field]
@@ -5485,6 +5475,24 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   }
 
   /**
+   * Resolve the per-record CEK for a stored envelope, or `undefined` for a
+   * legacy (`_cek`-absent) envelope. Unwraps `_cek` under the collection DEK and
+   * memoises it in the CEK cache under `id` (when supplied) so repeated reads of
+   * the same record skip the unwrap. Shared by the body-decrypt path
+   * ({@link decryptJsonString}) and the sealed-field path ({@link decryptRecord}
+   * / {@link toCacheRecord}) so both agree on the record's key.
+   */
+  private async resolveEnvelopeCek(envelope: EncryptedEnvelope, id?: string): Promise<CryptoKey | undefined> {
+    if (envelope._cek === undefined) return undefined
+    const cached = id !== undefined ? this.cekCache?.get(id) : undefined
+    if (cached !== undefined) return cached
+    const dek = await this.getDEK(this.name)
+    const cek = await unwrapCek(envelope._cek, dek)
+    if (id !== undefined) this.cekCache?.set(id, cek, 1)
+    return cek
+  }
+
+  /**
    * Low-level: decrypt an envelope and return the raw JSON string.
    *
    * `_cek` presence is the format discriminant (NOT `this.perRecordCek`),
@@ -5520,13 +5528,9 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       }
       return envelope._data
     }
+    const cek = await this.resolveEnvelopeCek(envelope, id)
+    if (cek !== undefined) return decrypt(envelope._iv, envelope._data, cek)
     const dek = await this.getDEK(this.name)
-    if (envelope._cek !== undefined) {
-      const cached = id !== undefined ? this.cekCache?.get(id) : undefined
-      const cek = cached ?? (await unwrapCek(envelope._cek, dek))
-      if (cached === undefined && id !== undefined) this.cekCache?.set(id, cek, 1)
-      return decrypt(envelope._iv, envelope._data, cek)
-    }
     return decrypt(envelope._iv, envelope._data, dek)
   }
 
@@ -5552,11 +5556,24 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    * {@link Sealed} handle's `reveal()` — so the on-demand reveal and the eager
    * materialisation always agree byte-for-byte.
    */
-  private async unsealField(field: string, blob: string): Promise<unknown> {
-    const dek = await this.getDEK(this.name)
+  private async unsealField(field: string, blob: string, cek?: CryptoKey): Promise<unknown> {
     const sep = blob.indexOf(':')
     const iv = blob.slice(0, sep)
     const data = blob.slice(sep + 1)
+    // #306 dual-read. Current writes seal under a key derived from the record's
+    // per-record CEK; records sealed BEFORE #306 (even ones whose body is
+    // CEK-encrypted) are sealed under the collection-DEK key. Try the CEK key
+    // first; on its AES-GCM auth failure, fall back to the DEK key. Without this
+    // fallback every pre-#306 `_sealed` record would throw TamperedError (data loss).
+    if (cek !== undefined) {
+      try {
+        const fieldKey = await deriveSealedFieldKeyFromCek(cek, this.name, field)
+        return JSON.parse(await decrypt(iv, data, fieldKey))
+      } catch {
+        // fall through to the legacy collection-DEK derivation
+      }
+    }
+    const dek = await this.getDEK(this.name)
     const fieldKey = await deriveSealedFieldKey(dek, this.name, field)
     return JSON.parse(await decrypt(iv, data, fieldKey))
   }
@@ -5568,8 +5585,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    * may sit in the working-set cache (or be logged/serialised) without
    * exposing the value, which decrypts only on `reveal()`.
    */
-  private makeSealedHandle(field: string, blob: string): SealedHandle<unknown> {
-    return new SealedHandle(() => this.unsealField(field, blob))
+  private makeSealedHandle(field: string, blob: string, cek?: CryptoKey): SealedHandle<unknown> {
+    return new SealedHandle(() => this.unsealField(field, blob, cek))
   }
 
   /**
@@ -5579,14 +5596,15 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    * write path without ever materialising sealed plaintext into it. Returns
    * `record` untouched when the collection seals nothing.
    */
-  private toCacheRecord(record: T, envelope: EncryptedEnvelope): T {
+  private async toCacheRecord(record: T, envelope: EncryptedEnvelope, id?: string): Promise<T> {
     const sealed = envelope._sealed
     if (sealed === undefined || !this.storeCiphertext || this.sensitiveFields.size === 0) {
       return record
     }
+    const cek = await this.resolveEnvelopeCek(envelope, id)
     const clone = { ...(record as unknown as Record<string, unknown>) }
     for (const [field, blob] of Object.entries(sealed)) {
-      clone[field] = this.makeSealedHandle(field, blob)
+      clone[field] = this.makeSealedHandle(field, blob, cek)
     }
     return clone as unknown as T
   }
@@ -5616,11 +5634,12 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     // public / cache path) yields an opaque {@link Sealed} handle so the
     // plaintext is never materialised into the working-set cache.
     if (envelope._sealed !== undefined && this.storeCiphertext) {
+      const sealedCek = await this.resolveEnvelopeCek(envelope, opts.id)
       const target = record as unknown as Record<string, unknown>
       for (const [field, blob] of Object.entries(envelope._sealed)) {
         target[field] = opts.sealedAsHandles
-          ? this.makeSealedHandle(field, blob)
-          : await this.unsealField(field, blob)
+          ? this.makeSealedHandle(field, blob, sealedCek)
+          : await this.unsealField(field, blob, sealedCek)
       }
     }
 

--- a/packages/hub/src/crypto.ts
+++ b/packages/hub/src/crypto.ts
@@ -492,6 +492,47 @@ export async function deriveSealedFieldKey(
   )
 }
 
+/**
+ * Derive a per-record sealed-field key from the record's **per-record CEK**
+ * (#306) rather than the collection DEK. Same HKDF construction as
+ * {@link deriveSealedFieldKey} but with salt `'noydb-sealed-cek'` (distinct
+ * from `'noydb-sealed'`), so a CEK-derived key can never collide with a
+ * DEK-derived one for the same `{collection, field}`.
+ *
+ * The point: the sealed ciphertext's only key now flows from the record's CEK.
+ * Dropping the record's wrapped `_cek` (crypto-shred / `forget`) makes the key
+ * — and thus `_sealed[field]` — unrecoverable, giving sealed fields the same
+ * erasure guarantee `_data` already has. The CEK must be extractable (it is —
+ * `unwrapCek`/`generateDEK` mint extractable keys).
+ *
+ * @param cek            The record's AES-256-GCM CEK (extractable).
+ * @param collectionName Part of the HKDF `info` for domain separation.
+ * @param field          Sensitive field name — the rest of the `info`.
+ * @returns A non-extractable AES-256-GCM key for that field's sealed slot.
+ */
+export async function deriveSealedFieldKeyFromCek(
+  cek: CryptoKey,
+  collectionName: string,
+  field: string,
+): Promise<CryptoKey> {
+  const rawCek = await subtle.exportKey('raw', cek)
+  const hkdfKey = await subtle.importKey('raw', rawCek, 'HKDF', false, ['deriveBits'])
+  const salt = new TextEncoder().encode('noydb-sealed-cek')
+  const info = new TextEncoder().encode(JSON.stringify(['noydb-sealed-cek', collectionName, field]))
+  const bits = await subtle.deriveBits(
+    { name: 'HKDF', hash: 'SHA-256', salt, info },
+    hkdfKey,
+    KEY_BITS,
+  )
+  return subtle.importKey(
+    'raw',
+    bits,
+    { name: 'AES-GCM', length: KEY_BITS },
+    false,
+    ['encrypt', 'decrypt'],
+  )
+}
+
 // ─── Deterministic Encryption ────────────────────────────
 
 /**

--- a/packages/hub/src/forget/strategy.ts
+++ b/packages/hub/src/forget/strategy.ts
@@ -126,6 +126,17 @@ export interface ForgetResult {
    * purge the side-car out of band.
    */
   readonly indexResidue: readonly string[]
+  /**
+   * Count of `_sealed[field]` slots dropped from the live store across the
+   * shredded records (#306). For slots written under `sensitive` +
+   * `perRecordKeys` (the current path), the key derives off the per-record CEK,
+   * so tombstoning the record — which drops `_cek` and `_sealed` — also
+   * crypto-shreds the value. A slot left over from a pre-#306 write keys off the
+   * collection DEK instead, so dropping it removes it from the live store but a
+   * pre-forget backup remains recoverable by a DEK holder (same caveat `_data`
+   * carries); migrate by re-`put`ting before forgetting for full crypto-shred.
+   */
+  readonly sealedFieldsShredded: number
   /** The single `op:'forget'` ledger entry appended for this erasure. */
   readonly ledgerEntry: LedgerEntry
 }

--- a/packages/hub/src/history/ledger/entry.ts
+++ b/packages/hub/src/history/ledger/entry.ts
@@ -122,12 +122,15 @@ export interface LedgerEntry {
   readonly actor: string
 
   /**
-   * Hex-encoded sha256 of the encrypted envelope's `_data` field.
-   * For `put`, this is the hash of the new ciphertext. For `delete`,
-   * it's the hash of the last visible ciphertext at deletion time,
-   * or the empty string if nothing was there to delete. Hashing the
-   * ciphertext (not the plaintext) preserves zero-knowledge — see
-   * the file docstring.
+   * Hex-encoded sha256 over the encrypted envelope's `_data` field, plus its
+   * sealed-field ciphertext map (`_sealed`) when the record carries one (#306
+   * Slice C) — so the ledger attests to both the open body and every sealed
+   * value. A record with no `_sealed` hashes `_data` alone, byte-identically to
+   * before. For `put`, this is the hash of the new ciphertext. For `delete`,
+   * it's the hash of the last visible ciphertext at deletion time, or the empty
+   * string if nothing was there to delete. Hashing the ciphertext (not the
+   * plaintext) preserves zero-knowledge — see the file docstring. The exact
+   * recipe lives in `envelopePayloadHash` (`hash.ts`).
    */
   readonly payloadHash: string
 

--- a/packages/hub/src/history/ledger/hash.ts
+++ b/packages/hub/src/history/ledger/hash.ts
@@ -9,13 +9,17 @@
  */
 
 import type { EncryptedEnvelope } from '../../types.js'
-import { sha256Hex } from './entry.js'
+import { sha256Hex, canonicalJson } from './entry.js'
 
 /**
  * Compute the `payloadHash` value for an encrypted envelope. Used by
  * `LedgerStore.append` for both put (hash the new envelope) and
  * delete (hash the previous envelope) paths, and by
  * `DictionaryHandle` so its ledger entries match the same contract.
+ *
+ * Hashes the open `_data` ciphertext, plus the sealed-field ciphertext
+ * map (`_sealed`) when a record carries one — so the ledger attests to
+ * both the open body AND every sealed value.
  *
  * Returns the empty string when there is no envelope (delete of a
  * never-existed record). The empty string tolerated by the ledger
@@ -25,10 +29,32 @@ export async function envelopePayloadHash(
   envelope: EncryptedEnvelope | null,
 ): Promise<string> {
   if (!envelope) return ''
-  // `_data` is a base64 string for encrypted envelopes and the raw
-  // JSON for plaintext ones. Both are strings, so a single sha256Hex
-  // call works for both modes — the hash value differs between
-  // encrypted/plaintext compartments because the bytes on disk
-  // differ.
-  return sha256Hex(envelope._data)
+  // Back-compat (#306 Slice C): a record with NO sealed fields hashes exactly
+  // as before — sha256 of `_data` alone — so every pre-existing ledger entry
+  // and every non-sealed backup verifies byte-identically. A record WITH
+  // `_sealed` widens the hash to also bind the sealed-field ciphertext, so the
+  // ledger attests to sealed-value tamper/erasure (a dropped or swapped
+  // `_sealed[field]` now diverges `verifyBackupIntegrity`'s data cross-check).
+  //
+  // `_cek` is deliberately NOT bound: a tampered wrapped-CEK already self-
+  // detects (it fails to unwrap), and `rotateRecordCek` rewrites `_cek` with no
+  // ledger entry — binding it would make every legitimate rotation fail verify.
+  //
+  // `canonicalJson` sorts keys, so the hash is independent of `_sealed`'s
+  // field-insertion / store-serialization order.
+  //
+  // RESIDUAL: a backup containing sealed records created BEFORE this change
+  // stored `payloadHash` over `_data` only, so it will fail the data cross-check
+  // and must be re-anchored (re-`put`/re-baseline). Sealed fields are new, so
+  // this is expected to affect ~no real vault.
+  //
+  // The two branches are NOT domain-separated — D1 pins the no-`_sealed` branch
+  // to exactly `sha256(_data)`, so it cannot carry a discriminator tag. An actor
+  // with raw-store write access could therefore set a non-sealed record's `_data`
+  // equal to the canonical-JSON string below and collide a sealed record's hash —
+  // but doing so overwrites `_data` itself, which then no longer GCM-decrypts, so
+  // it only suppresses the verify signal on an already-destroyed record; it cannot
+  // silently erase one sealed field while leaving the record readable.
+  if (envelope._sealed === undefined) return sha256Hex(envelope._data)
+  return sha256Hex(canonicalJson({ _data: envelope._data, _sealed: envelope._sealed }))
 }

--- a/packages/hub/src/query/builder.ts
+++ b/packages/hub/src/query/builder.ts
@@ -829,11 +829,11 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
   // The `field` param is `QueryField<T, S>` so a sealed (`sensitive`) field is
   // refused — grouping BY a sensitive field leaks its value distribution as
   // group-key labels. With `S = never` this is exactly `string` (zero churn).
-  groupBy<F extends QueryField<T, S>>(field: F): GroupedQuery<T, F, S>
+  groupBy<F extends QueryField<T, S>>(field: F): GroupedQuery<T, F, S, M>
   groupBy<F extends readonly [QueryField<T, S>, QueryField<T, S>, ...QueryField<T, S>[]]>(
     ...fields: F
-  ): GroupedQueryN<T, F, S>
-  groupBy(...fields: readonly string[]): GroupedQuery<T, string, S> | GroupedQueryN<T, readonly string[], S> {
+  ): GroupedQueryN<T, F, S, M>
+  groupBy(...fields: readonly string[]): GroupedQuery<T, string, S, M> | GroupedQueryN<T, readonly string[], S, M> {
     if (fields.length === 0) {
       throw new Error('.groupBy() requires at least one field')
     }
@@ -867,7 +867,7 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
     if (fields.length === 1) {
       const field = fields[0]!
       const dictLabelResolver = buildDictLabelResolver(this.joinContext, field)
-      return this.aggregateStrategy.groupBy<T, string, S>(
+      return this.aggregateStrategy.groupBy<T, string, S, M>(
         executeRecords,
         field,
         upstreams,
@@ -875,7 +875,7 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
         this.source.moneyFields,
       )
     }
-    return this.aggregateStrategy.groupByN<T, readonly string[], S>(
+    return this.aggregateStrategy.groupByN<T, readonly string[], S, M>(
       executeRecords,
       fields,
       upstreams,

--- a/packages/hub/src/query/scan-builder.ts
+++ b/packages/hub/src/query/scan-builder.ts
@@ -99,7 +99,7 @@ const DEFAULT_SCAN_PAGE_SIZE = 100
  * page size. The original builder is never mutated, so it's safe
  * to reuse across multiple parallel consumers.
  */
-export class ScanBuilder<T, S extends keyof T = never> implements AsyncIterable<T> {
+export class ScanBuilder<T, S extends keyof T = never, M extends keyof T & string = never> implements AsyncIterable<T> {
   private readonly pageProvider: ScanPageProvider<T>
   private readonly pageSize: number
   private readonly clauses: readonly Clause[]
@@ -170,14 +170,14 @@ export class ScanBuilder<T, S extends keyof T = never> implements AsyncIterable<
    * are a future optimization — the current implementation
    * evaluates clauses per record in O(1) per clause.
    */
-  where(field: QueryField<T, S>, op: Operator, value: unknown): ScanBuilder<T, S> {
+  where(field: QueryField<T, S>, op: Operator, value: unknown): ScanBuilder<T, S, M> {
     // Money fields compare in major units, BigInt-exact in scaled space —
     // same build-time operand rewrite as Query.where() (#336).
     const desc = this.moneyFields?.[field as string]
     const clause: FieldClause = desc
       ? moneyFieldClause(field as string, op, value, desc)
       : { type: 'field', field: field as string, op, value }
-    return new ScanBuilder<T, S>(
+    return new ScanBuilder<T, S, M>(
       this.pageProvider,
       this.pageSize,
       [...this.clauses, clause],
@@ -193,12 +193,12 @@ export class ScanBuilder<T, S extends keyof T = never> implements AsyncIterable<
    * don't round-trip through `toPlan()`. Prefer `.where()` when
    * possible.
    */
-  filter(fn: (record: T) => boolean): ScanBuilder<T, S> {
+  filter(fn: (record: T) => boolean): ScanBuilder<T, S, M> {
     const clause: Clause = {
       type: 'filter',
       fn: fn as (record: unknown) => boolean,
     }
-    return new ScanBuilder<T, S>(
+    return new ScanBuilder<T, S, M>(
       this.pageProvider,
       this.pageSize,
       [...this.clauses, clause],
@@ -289,7 +289,7 @@ export class ScanBuilder<T, S extends keyof T = never> implements AsyncIterable<
   join<As extends string, R = unknown>(
     field: QueryField<T, S>,
     opts: { as: As },
-  ): ScanBuilder<T & Record<As, R | null>, S> {
+  ): ScanBuilder<T & Record<As, R | null>, S, M> {
     if (!this.joinContext) {
       throw new Error(
         `ScanBuilder.join() requires a join context. Use ` +
@@ -321,7 +321,7 @@ export class ScanBuilder<T, S extends keyof T = never> implements AsyncIterable<
       // changing the planner shape.
       partitionScope: 'all',
     }
-    return new ScanBuilder<T & Record<As, R | null>, S>(
+    return new ScanBuilder<T & Record<As, R | null>, S, M>(
       this.pageProvider as unknown as ScanPageProvider<T & Record<As, R | null>>,
       this.pageSize,
       this.clauses,
@@ -582,15 +582,16 @@ export class ScanBuilder<T, S extends keyof T = never> implements AsyncIterable<
    * limit and use `query().aggregate().live()` instead.
    */
   async aggregate<Spec extends AggregateSpec>(spec: Spec): Promise<AggregateResult<Spec>>
-  async aggregate<Spec extends AggregateSpec>(build: (b: ReducerBuilder<T, S>) => Spec): Promise<AggregateResult<Spec>>
+  async aggregate<Spec extends AggregateSpec>(build: (b: ReducerBuilder<T, S, M>) => Spec): Promise<AggregateResult<Spec>>
   async aggregate<Spec extends AggregateSpec>(
-    specOrBuild: Spec | ((b: ReducerBuilder<T, S>) => Spec),
+    specOrBuild: Spec | ((b: ReducerBuilder<T, S, M>) => Spec),
   ): Promise<AggregateResult<Spec>> {
     // Opt-in builder form `aggregate(b => spec)`: `b`'s field args are
     // `QueryField<T, S>`, refusing sensitive fields (the standalone-spec form
-    // stays unrefused for back-compat). Mirrors `Query.aggregate`.
+    // stays unrefused for back-compat), and `sum`/`min`/`max` over a declared
+    // `moneyFields` (`M`) member return a `MoneyString`. Mirrors `Query.aggregate`.
     const spec: Spec = typeof specOrBuild === 'function'
-      ? (specOrBuild as (b: ReducerBuilder<T, S>) => Spec)(reducerBuilder as unknown as ReducerBuilder<T, S>)
+      ? (specOrBuild as (b: ReducerBuilder<T, S, M>) => Spec)(reducerBuilder as unknown as ReducerBuilder<T, S, M>)
       : specOrBuild
     const keys = Object.keys(spec)
     // Per-reducer state. Exactly |keys| entries, never grows with

--- a/packages/hub/src/record-keys/sealing.ts
+++ b/packages/hub/src/record-keys/sealing.ts
@@ -14,7 +14,7 @@
  * `sealed-record/`, so the host-side subpath stays DEK-free — they import only
  * the wire *types* from there.
  */
-import { encrypt, decrypt, generateDEK, wrapCek, unwrapCek, bufferToBase64 } from '../crypto.js'
+import { encrypt, decrypt, generateDEK, wrapCek, unwrapCek, bufferToBase64, deriveSealedFieldKey, deriveSealedFieldKeyFromCek } from '../crypto.js'
 import { NOYDB_FORMAT_VERSION, type EncryptedEnvelope, type NoydbStore } from '../types.js'
 import { RecordCekNotFoundError, ValidationError } from '../errors.js'
 import type { RecipientSealer } from '../team/managed-passphrase.js'
@@ -142,6 +142,30 @@ export async function rotateRecordCek(
   const newCek = await generateDEK()
   const { iv, data } = await encrypt(json, newCek)
 
+  // #306: sealed fields are now keyed off the per-record CEK, so a rotation
+  // must RE-ENCRYPT each `_sealed[field]` under the new CEK (Slice A's
+  // carry-forward would orphan them — the old CEK is gone after this rotate).
+  // Dual-read the old slot: try the old-CEK-derived key (#306 records), fall
+  // back to the collection-DEK key (legacy / pre-#306), then re-seal under newCek.
+  let sealedOut: Record<string, string> | undefined
+  if (live._sealed !== undefined) {
+    const out: Record<string, string> = {}
+    for (const [field, slot] of Object.entries(live._sealed)) {
+      const sep = slot.indexOf(':')
+      const sIv = slot.slice(0, sep)
+      const sData = slot.slice(sep + 1)
+      let plaintext: string
+      try {
+        plaintext = await decrypt(sIv, sData, await deriveSealedFieldKeyFromCek(oldCek, collection, field))
+      } catch {
+        plaintext = await decrypt(sIv, sData, await deriveSealedFieldKey(dek, collection, field))
+      }
+      const resealed = await encrypt(plaintext, await deriveSealedFieldKeyFromCek(newCek, collection, field))
+      out[field] = `${resealed.iv}:${resealed.data}`
+    }
+    sealedOut = out
+  }
+
   const env: EncryptedEnvelope = {
     _noydb: NOYDB_FORMAT_VERSION,
     _v: live._v + 1,
@@ -152,12 +176,12 @@ export async function rotateRecordCek(
     ...(ctx.actor ? { _by: ctx.actor } : {}),
     ...(live._tier !== undefined ? { _tier: live._tier } : {}),
     ...(live._det !== undefined ? { _det: live._det } : {}),
-    // Carry sealed (`sensitive`) fields forward verbatim. They are keyed off the
-    // collection DEK (`deriveSealedFieldKey`), NOT the per-record CEK, so a CEK
-    // rotation does not invalidate them — dropping them here silently lost the
-    // sealed values (data-loss bug). When record-scoped sealing (#306) lands and
-    // sealed keys derive off the CEK, this must instead re-encrypt under the new CEK.
-    ...(live._sealed !== undefined ? { _sealed: live._sealed } : {}),
+    // Re-encrypt sealed (`sensitive`) fields under the new CEK (#306). Sealed
+    // keys now derive off the per-record CEK, so the rotated record's old CEK is
+    // destroyed here — carrying the old `_sealed` slots forward verbatim would
+    // orphan them (unreadable under the new CEK). `sealedOut` holds the slots
+    // dual-read from the old CEK (or the legacy DEK) and re-sealed under newCek.
+    ...(sealedOut !== undefined ? { _sealed: sealedOut } : {}),
   }
   await ctx.adapter.put(ctx.vault, collection, id, env)
 

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -2615,6 +2615,7 @@ export class Vault {
     let blobsShredded = 0
     let blobsRetainedShared = 0
     let indexPostingsPurged = 0
+    let sealedFieldsShredded = 0
     const indexResidue: string[] = []
     const blobsEnabled = this.blobStrategy !== undefined
     const actor = this.keyring.userId
@@ -2632,6 +2633,7 @@ export class Vault {
       if (perRecordKeys && live && live._data && live._cek === undefined) {
         unmigratedRecords.push(`${ref.collection}:${ref.id}`)
       }
+      if (live?._sealed !== undefined) sealedFieldsShredded += Object.keys(live._sealed).length
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const shred = await (coll as any)._writeTombstone(ref.id, actor) as { previousVersion: number } | null
@@ -2728,6 +2730,7 @@ export class Vault {
         blobResidueCollections: [...blobResidueCollections],
         indexPostingsPurged,
         indexResidueCount: indexResidue.length,
+        sealedFieldsShredded,
       }),
     })
 
@@ -2742,6 +2745,7 @@ export class Vault {
       blobResidueCollections: [...blobResidueCollections],
       indexPostingsPurged,
       indexResidue,
+      sealedFieldsShredded,
       ledgerEntry,
     }
   }

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -4246,7 +4246,7 @@ export class Vault {
             `but the adapter has no envelope for it.`,
         }
       }
-      const actualHash = await sha256Hex(envelope._data)
+      const actualHash = await this.historyStrategy.envelopePayloadHash(envelope)
       if (actualHash !== expectedHash) {
         return {
           ok: false,

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -514,7 +514,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 5566→5593 (P3 safety fixes): three constructor guards — forget-cascade/perRecordCek incompatibility warn, debug-plaintext no-op warn, doc-comment note on #306. All are defensive one-time console.warn calls; no behavior change to default-off paths.
   // Bumped 5593→5680 (P3 Sealed<V> access gate): the sealed-field handle layer is genuine crypto/cache core. Adds `unsealField` (shared by inline-decrypt + handle reveal()), `makeSealedHandle`/`toCacheRecord` (build non-leaking handles for the working-set cache so sealed plaintext is never resident), `resolvePriorValues` (eager write/delete paths re-decrypt real values rather than re-encrypt cache handles), and `sealedAsHandles` routing through decryptRecord + the cache/public read paths. Sits directly on the existing `_sealed` seam; the per-field key derivation still lives in crypto.ts.
   // Bumped 5680→5721 (P3 lazy-mode Sealed-field corruption/leak fix): mirrors the eager `resolvePriorValues` for the lazy `_getStoredRecord` patch base — on a sealed collection it re-decrypts the stored envelope to REAL values (never re-encrypting a cache handle into the marker `'[sealed]'`) and populates the LRU in handle form via `toCacheRecord` (never sealed plaintext). Plus a one-time constructor `console.warn` when a `sensitive` field also appears in `indexes` (plaintext index defeats non-residency). Both are core crypto/cache correctness on the existing `_sealed`/LRU seams.
-  'packages/hub/src/collection.ts': 5721,
+  // Bumped 5721→5740 (#306 Slice B record-scoped sealing): sealed-field keys now derive off the per-record CEK so `forget()` crypto-shreds them. Adds the shared `resolveEnvelopeCek` helper (one unwrap+cache path for both body and sealed decryption), the dual-read fallback in `unsealField` (CEK-derived key first, collection-DEK key on auth failure — the data-loss guard for pre-#306 records), and threads the CEK through `makeSealedHandle`/`decryptRecord`/`toCacheRecord`. Net of removing the now-obsolete forget-cascade `console.warn`. Core crypto on the existing `_sealed`/`_cek` seams.
+  'packages/hub/src/collection.ts': 5740,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -593,7 +594,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 4650→4659 (#483 review follow-up): historyConfigExplicit threading + archive/schemaUpdate accessors in _introspectState()
   // Bumped 4659→4665 (storage-arch P2 foundation): plumb ramCiphertext through vault.collection() to collOpts (TS declaration + pass-through) so the opt-in flag is reachable/testable. Minimal necessary plumbing.
   // Bumped 4665→4674 (#503 structural group-encryption): plumb the `sensitive` collection option through vault.collection() to collOpts (TS declaration + doc-comment + pass-through), mirroring deterministicFields. Minimal necessary plumbing; the sealing crypto lives in collection.ts/crypto.ts.
-  'packages/hub/src/vault.ts': 4674,
+  // Bumped 4674→4677 (#306 Slice B record-scoped sealing): forget() counts and reports `sealedFieldsShredded` (read each shredded record's live `_sealed` slot count before tombstoning) on the existing forget orchestration. +3 lines; the sealing crypto lives in collection.ts/crypto.ts.
+  'packages/hub/src/vault.ts': 4677,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),


### PR DESCRIPTION
Lands the accumulated, already-reviewed `main` work that was staged locally. Five commits; CI-green at each step locally (typecheck/lint/test/arch).

## #306 — record-scoped sealing (Slices B + C)
- **Slice B** — sealed `sensitive` field keys derive from the per-record CEK (`deriveSealedFieldKeyFromCek`) when `perRecordKeys` is set, so `vault.forget()` crypto-shreds them. Dual-read fallback keeps pre-existing records readable (no migration); `rotateRecordCek` re-encrypts `_sealed`; `ForgetResult.sealedFieldsShredded` added.
- **Slice C** — the ledger `payloadHash` now binds `_sealed`, so `verifyBackupIntegrity()` detects sealed-field tamper/erasure. Backward-compatible (no-`_sealed` records hash byte-identically); `_cek` intentionally excluded.

(Slice A shipped previously; the design spec is `docs/superpowers/specs/2026-06-29-306-record-scoped-sealing.md`, now marked SHIPPED.)

## money-field generic M (parity)
- `scan().aggregate(b => …)` and `query().groupBy(...).aggregate(b => …)` auto-type `b.sum`/`min`/`max` over a declared `moneyFields` member as `MoneyString`, matching `Query.aggregate`. Type-only; phantom generic defaulting to `never`.

## Docs
- CHANGELOG `## Unreleased` milestone note.
- Anonymized rewrite of the federation→klum-db consumer migration guide (supersedes the closed #453, which named the private pilot consumers — here they are Consumer A / Consumer B only).

Each feature was implemented TDD-first and adversarially reviewed before landing locally.