### PR TITLE
docs: architecture north-star + reorg/edge-crypto specs, plans & overnight reviews

### DIFF
--- a/docs/superpowers/2026-06-30-REVIEW-PACKAGE.md
+++ b/docs/superpowers/2026-06-30-REVIEW-PACKAGE.md
@@ -1,0 +1,76 @@
+# Morning review package — hub reorg, edge-crypto, and a whole-codebase audit (2026-06-30)
+
+> **Read this first.** Everything from the overnight run is linked here, prioritized. Built on branch `docs/hub-reorg-and-edge-crypto-specs`. **No code was changed** — these are specs, plans, and a read-only audit. Two **security bugs** were found that warrant action before the reorg (see 🔴 below).
+
+## What happened overnight
+
+You asked for: two specs (+ plans) for the hub work, then a whole-codebase review (security / discrepancy / refactoring), packed for your review. Done. Also — **the reorg you thought was lost is not lost**: it's commit `f6127e62` ("group optional subsystems into 7 dimension folders") on `feat/family-folders`, gate-green when committed. We finalized the naming as **`with-` prefix** (mirrors the `with*()` opt-in API). The specs re-derive the move on current `main`.
+
+## Deliverables (all committed on this branch)
+
+| # | Doc | What |
+|---|---|---|
+| Spec A | [`specs/2026-06-30-hub-src-with-dimension-reorg-design.md`](specs/2026-06-30-hub-src-with-dimension-reorg-design.md) | Group 36 optional subsystems into 7 `with-*` folders; public API + `dist/` byte-identical |
+| Plan A | [`plans/2026-06-30-hub-src-with-dimension-reorg.md`](plans/2026-06-30-hub-src-with-dimension-reorg.md) | Step-by-step move (worktree, split-safe `git mv`, import codemod, tsup entries, gates) |
+| Spec B | [`specs/2026-06-30-edge-crypto-kernel-optimization-design.md`](specs/2026-06-30-edge-crypto-kernel-optimization-design.md) | Flip the invariant to a store-edge codec: plaintext working set in trusted RAM, encrypt at disk/net/export edge; `to-memory` dissolves, `cache` = buffer pool |
+| Plan B | [`plans/2026-06-30-edge-crypto-kernel-optimization.md`](plans/2026-06-30-edge-crypto-kernel-optimization.md) | Phased (P1 built-in store DONE → P2 codec seam → P3 dissolve `to-memory` → P4 buffer-pool); **security-gated** |
+| Review | [`reviews/2026-06-30-security.md`](reviews/2026-06-30-security.md) | Crypto/security spine audit — **High 1 · Med 5 · Low 11** |
+| Review | [`reviews/2026-06-30-architecture.md`](reviews/2026-06-30-architecture.md) | Invariant/catalog drift — High 4 · Med 5 · Low 3 |
+| Review | [`reviews/2026-06-30-refactoring.md`](reviews/2026-06-30-refactoring.md) | Tech-debt + reorg sequencing — 12 ranked items |
+| Review | [`reviews/2026-06-30-reorg-readiness.md`](reviews/2026-06-30-reorg-readiness.md) | Inventory — mapping exact, 0 unmapped, ~404 test-import refs |
+
+---
+
+## 🔴 URGENT — security, act before (or independent of) the reorg
+
+Two real erasure bugs in the **`forget()` / sealed-field** path (the #306 area shipped this week). Both are **standalone fixes** — not blocked by the reorg, and worth doing first because the reorg/edge-crypto will rewrite this exact code.
+
+1. **H-1 — `forget()` doesn't delete `_sealed_cek` delivery envelopes.** A record reported as erased stays fully decryptable by a granted `at-*` host from any synced/backed-up replica (the per-record CEK survives in `_sealed_cek/<coll>/<id>/<pid>`; only `rotateRecordCek`/`revokeSealedRecord` clean it, never `forget()`). **Fix:** prefix-delete `${collection}/${id}/` from `_sealed_cek` in the forget loop + report residue. *(In any sync/backup deployment this is effectively Critical.)*
+2. **M-1 — legacy DEK-sealed fields are mis-reported as crypto-shredded.** A record with a migrated body but pre-#306 DEK-derived `_sealed` slots is counted into `sealedFieldsShredded` as destroyed, while the retained collection DEK still decrypts any synced copy. `forget()` returns empty `unmigratedRecords` + positive shred count — a false "complete erasure" signal. **Fix:** detect DEK-derived slots (CEK-derive fails) and report as residue; don't count them shredded.
+
+Other security items (full detail in the report): **M-2** subject-index is unsalted `SHA-256(subjectId)` → subject-existence brute-force; **M-3** derivations fanout sidecar is written **plaintext** (user-supplied keys can be content-bearing); **M-4** sealed-record expiry **fails open** on a malformed `expiresAt` (`NaN <= now` is false → eternal grant); **M-5** `revokeSealedRecord` is soft-only. Plus 11 Low (guard gaps, `_det` shares the DEK, metadata-in-envelope, etc.).
+
+**The crypto spine itself is sound** (PBKDF2-600K / AES-256-GCM-random-IV / AES-KW, consistent injective HKDF domain separation, only ciphertext reaches the store, the LRU is verifiably RAM-only, `SealedHandle` non-residency holds, CEK crypto-shred works *except* H-1).
+
+---
+
+## 🟡 Findings that change the plan (before reorg)
+
+**1. Extract `record-codec.ts` FIRST — it's the linchpin for everything.** The refactoring review and architecture review converge here: the envelope-build + encrypt/decrypt/CEK + #306 sealed dual-read logic is **copy-pasted** across `collection.ts`, `vault.ts`, `record-keys/sealing.ts`, and ~12 subsystem files (the envelope literal alone repeats ~30×; the security-critical dual-read exists in 2–3 drifting copies). If we reorg first, those copies **scatter into 7 folders**. Extracting one `record-codec.ts` simultaneously: (a) gives the reorg a single thing to move, (b) becomes the named "encryption-in-the-hub" module the architecture review says is missing, and (c) **is** Plan B's P2 store-edge codec seam. *Do this before the move.* (It also makes the H-1/M-1 fixes land in one place.)
+
+**2. Decide test layout in the same pass.** Tests are in a **flat `__tests__/`** (not beside source, contra CLAUDE.md). The reorg moves source into 7 folders; ~404 test-import refs across 260 files need rewriting regardless (bigger than the prototype's 438/224). Decide now: mirror `__tests__/with-*/…` or co-locate. Also: **172 of 229 test files inline `createNoydb(` with zero shared helper** — extract `__tests__/helpers/` fixtures to cut churn during the move.
+
+**3. The "minimalist ~6,500 LOC core" claim is aspirational, not load-bearing.** The 3 always-on files alone are **13,525 LOC** (collection 5,739 + vault 4,676 + noydb 3,110); the `kernel-surface` ratchet has risen ~45% as an approval queue, not a cap. ~13 subsystems are still kernel-coupled via named `…Strategy` fields rather than the `subsystem-bus`. The reorg + the god-object decomposition (refactoring items #6–#11) are the structural fix; the docs (`CLAUDE.md`, `SUBSYSTEMS.md` C1) should be reconciled to real numbers.
+
+**4. Catalog drift to fix while we're in here.** `joins`(#2)/`live`(#4) are documented subsystems with subpaths + LOC-saved but **have no module and no export** (a consumer following the docs gets a resolution failure); `routing` is claimed at `@noy-db/hub/routing` (no such subpath — it's under `./store`); `transactions` is documented but exported as `./tx`; `team`/`attestation`/`sealed-record` have subpaths but no `with*()` factory. The reorg is the natural moment to reconcile catalog ↔ exports ↔ folders.
+
+**5. The cache/`to-memory` double-residency is confirmed** (the basis for Spec B). Eager-default `loadAll`+decrypt-whole-collection holds the entire collection as plaintext on top of the store's ciphertext copy. Intrinsic to the boundary, but the eager default is the cost lever — **owned by Spec B / P4**, not flipped in the reorg.
+
+---
+
+## Security constraints folded into Spec/Plan B (the edge-crypto flip)
+
+The security review's verdict on the flip: it does **not** inherently weaken at-rest/at-network confidentiality, but it relocates the invariant from one greppable chokepoint to "all egress paths," enlarges the RAM-disclosure/swap blast radius, and silently regresses sealed-field non-residency + `forget()` unless each is re-established. **Hard requirements for P2+** (now in Plan B):
+- **Type-level `StoreEdgeCodec`** that makes an un-encoded persistent/network/export egress *unrepresentable* (not a grep guard). This is the gate; if it can't be made build-time-unbypassable, P2 stops.
+- **Sealed-field non-residency must be preserved** in a plaintext working set (keep sealed fields as handles/ciphertext even in RAM) — explicit invariant + test, or the flip undoes #306.
+- **`forget()` must RAM-scrub** the working-set copy (+ plaintext derived structures), since key-destruction no longer suffices once plaintext is resident. (V8 can't zero strings — design around it.)
+- **Swap/core-dump is the sharp edge** — treat host RAM as the new TCB; `mlock`/secure-buffer where available; document it.
+- **Silver lining to bank:** if the edge codec *re-encrypts* indexes/derived structures (randomized) rather than passing them through, the persisted `_det` equality side-channel and the metadata-in-envelope leaks (L-3/L-4/L-11) can be *removed* at the store. Make it a design goal.
+
+---
+
+## Recommended sequence
+
+1. **Fix H-1 + M-1** (forget/_sealed_cek + legacy-DEK erasure honesty) — small, security-critical, standalone. *(Your go-ahead; I won't touch crypto/forget autonomously.)*
+2. **Extract `record-codec.ts`** (+ dedupe sealed dual-read + `buildEnvelope()`) — the shared prerequisite. Lands the H-1/M-1 fixes in one place; seeds Plan B P2.
+3. **Reorg** (Plan A) — now moves a consolidated codebase, not scattered copies; fold in catalog-drift fixes + test-layout decision + the god-object cluster moves (refactoring #6–#11).
+4. **Edge-crypto** (Plan B, P2→P4) — security-gated on the type-level `StoreEdgeCodec`.
+
+Independent quick wins anytime: shared test fixtures (#4), `putInternal` decomposition (#5), the other Medium security fixes (M-2…M-5).
+
+## Open decisions for you
+- **Approve the `with-` reorg structure** as specced? (mapping confirmed exact, 0 unmapped folders.)
+- **Approve the edge-crypto direction** + its security gates, or want changes before P2 is planned in detail?
+- **Want me to fix H-1 + M-1 now** (next session), or hold for your review of the security report first?
+- **Test layout:** mirror `with-*` or co-locate?
+- One spec or keep reorg + edge-crypto as the two separate specs they are? (Recommend: keep separate; sequence reorg → edge-crypto.)

--- a/docs/superpowers/plans/2026-06-30-edge-crypto-kernel-optimization.md
+++ b/docs/superpowers/plans/2026-06-30-edge-crypto-kernel-optimization.md
@@ -1,0 +1,64 @@
+# Edge-crypto kernel optimization — Implementation Plan
+
+> **For agentic workers:** execute via superpowers:subagent-driven-development. **GATED:** Phases P2+ do not start until the security review (`scratchpad/review/security.md`) confirms the edge-formulated ciphertext guard is enforceable at the same strength as today's `stores-ciphertext-only`, and the user gives explicit go-ahead. This plan flips a central invariant.
+
+**Goal:** Make encryption a **store-edge codec** (encrypt crossing out to disk/network/export, decrypt crossing in), with a plaintext working set in trusted RAM — dissolving `to-memory` and reframing `cache` as the buffer pool.
+
+**Architecture:** Move the encryption boundary from "before any store call" to "at the persistent/transport/export edge." Behavior-preserving for at-rest/in-transit/export guarantees; removes the redundant in-RAM ciphertext copy for the pure-memory case.
+
+**Tech Stack:** TypeScript, `crypto.subtle`, tsup, vitest, pnpm.
+
+## Global Constraints
+
+- **Zero-knowledge against the backend is preserved:** every persistent/transport/export store still only ever receives ciphertext. The guarantee that weakens is *uniformity* (in-memory working set is plaintext by design) — the new guard must enforce "ciphertext at the persistent edge" build-time, as mechanically as Check 4 does today.
+- **No silent behavior change:** lazy-by-default (P4) is a separable behavior change — propose, don't bundle.
+- **Atomic doc/guard update:** "encryption before any store call" appears across docs/specs/`check-architecture.mjs`. The invariant flip updates all of them in one change or none.
+- Security review findings are folded in before P2 implementation.
+- No Claude attribution in commits.
+
+---
+
+## P1 — Built-in store (DONE — landed `e1f5ba90`)
+
+`createNoydb({ store? })` optional; built-in `MemoryStore` (`src/store/memory-store.ts`) is the zero-config default. This is the enabler for P3. No work remaining; listed for completeness.
+
+---
+
+## P2 — Store-edge codec seam
+
+**Files:** `src/store/`, `src/adapter/`, `scripts/check-architecture.mjs`, `crypto.ts` (no new primitives — reuse `encrypt`/`decrypt`/envelope).
+
+**Interfaces produced:** a `StoreEdgeCodec` boundary — `encodeForEdge(record) → EncryptedEnvelope` / `decodeFromEdge(envelope) → record` — applied by the kernel write/read path at the store seam, replacing the "encrypt before every store call" inline calls with a single named edge transform.
+
+- [ ] **Step 1 (spec the seam):** Document where every store call sits today (grep `adapter.put`/`adapter.get` in `collection.ts`/`vault.ts`/subsystems) and confirm they all route through one chokepoint suitable for a codec. If not single-chokepoint, the first task is to funnel them.
+- [ ] **Step 2 (write failing guard test):** A test asserting that anything reaching a **persistent/transport/export** store is ciphertext (the edge formulation), and that an in-memory working-set read returns plaintext without a store round-trip.
+- [ ] **Step 3 (implement the codec seam):** Introduce `StoreEdgeCodec` as the single encrypt/decrypt point at the adapter edge; the built-in `MemoryStore` path can skip the codec (no boundary crossed) — *gated behind the security-review-approved formulation*.
+- [ ] **Step 4 (re-express the guard):** Update `check-architecture.mjs` Check 4 from `stores-ciphertext-only` (every store call) to `ciphertext-at-persistent-edge` (file/cloud/sync/export adapters). Must be as mechanical and unbypassable as the original.
+- [ ] **Step 5:** typecheck ✓ · test ✓ · `check:architecture` ✓ (new guard) · the full conformance suite (`test-harnesses/adapter-conformance`) — every persistent store still ciphertext-only.
+- [ ] **Step 6:** Update every doc/spec stating "encryption before any store call" to the edge formulation, same change.
+
+## P3 — Dissolve `to-memory` from the essentials
+
+**Files:** the 5-essentials list (`noy-db` core packages), `SUBSYSTEMS.md`, the family `CLAUDE.md` essentials table, migration docs.
+
+- [ ] **Step 1:** Confirm the built-in `MemoryStore` is contract-complete vs `@noy-db/to-memory` (it covers dev/test/prototyping; spot any feature `to-memory` has that the built-in lacks — e.g. `getStoreTime` monotonic clock — and port if essential).
+- [ ] **Step 2:** Demote `to-memory` from the 5 essentials to the extended `noy-db-to` family (or deprecate if fully superseded by the built-in). Decision recorded in `SUBSYSTEMS.md` + a changelog entry.
+- [ ] **Step 3:** Migration note: "replace `to-memory` with the built-in default (omit `store`) or import from `noy-db-to`." Update recipes/showcases that used `to-memory`.
+- [ ] **Step 4:** `pnpm check:architecture` + the essentials-count gate; full test suite.
+
+## P4 — `cache` → buffer-pool framing (+ lazy-default evaluation)
+
+**Files:** `src/cache/`, `collection.ts` (the `cache`/`lru` fields + eager `prefetch` path), docs.
+
+- [ ] **Step 1:** Rename/reframe `cache` as the buffer pool in docs + identifiers where it clarifies (it is the in-memory DB, not an accelerator). Low-risk doc/naming pass.
+- [ ] **Step 2 (separate proposal):** Evaluate **lazy-by-default**. Today eager `prefetch:true` decrypts the whole collection on open (the 🔴 cost + whole-DB-in-RAM exposure). Quantify the memory/security win of lazy-default vs the offline-first eager-read feature loss. This is a behavior change — present as its own decision with benchmarks; do NOT flip silently. Intersects the refactoring review's eager-cache item.
+
+## Verification (per phase)
+
+`pnpm --filter @noy-db/hub typecheck` · `build` · `test` · `node scripts/check-architecture.mjs` · `test-harnesses/adapter-conformance` (P2/P3) · bundle-size gate (the catalog invariants).
+
+## Open questions (carry into review)
+
+- Can the edge guard be made *build-time unbypassable* (the security review's call)? If not, P2 stops.
+- Does any 🟢/🔵 subsystem secretly rely on the in-RAM ciphertext copy (CRDT merge reads the raw envelope at `collection.ts:309`; history; key-rotation)? Enumerate before P3 so dissolving `to-memory` doesn't break them.
+- Lazy-by-default: feature regression vs memory/security win — needs data.

--- a/docs/superpowers/plans/2026-06-30-edge-crypto-kernel-optimization.md
+++ b/docs/superpowers/plans/2026-06-30-edge-crypto-kernel-optimization.md
@@ -16,6 +16,22 @@
 - Security review findings are folded in before P2 implementation.
 - No Claude attribution in commits.
 
+## Security gates (from the 2026-06-30 security review — HARD requirements)
+
+The review's verdict: the flip does **not** inherently weaken at-rest/at-network confidentiality, but it relocates the invariant from one greppable chokepoint to "all egress paths." These are non-negotiable for P2+:
+
+1. **Type-level `StoreEdgeCodec`.** An un-encoded persistent/network/export egress must be **unrepresentable in the type system**, not merely grep-guarded. If it can't be made build-time-unbypassable, **P2 stops**. (The existing `stores-ciphertext-only` guard is already weaker than it claims — L-5 — so it cannot be the safety net here.)
+2. **Sealed-field non-residency preserved.** A plaintext working set must keep `sensitive` fields as `SealedHandle`/ciphertext even in RAM, or the flip silently undoes #306/#503. Explicit invariant + test.
+3. **`forget()` RAM-scrubs.** Once plaintext is resident, key-destruction no longer suffices — `forget()` must scrub the working-set copy + plaintext derived structures. V8 can't zero strings; design around it (typed-array-backed buffers for sensitive material, drop+GC the rest, document the residual). **Prerequisite: H-1 + M-1 `forget()` fixes land first** (review §🔴) so the erasure path is correct before it gains RAM-scrub duties.
+4. **Swap/core-dump is the sharp edge.** Treat host RAM as the new TCB; `mlock`/secure-buffer where available; document the threat.
+5. **Bank the silver lining:** make the edge codec **re-encrypt** indexes/derived structures (randomized) rather than pass them through — this *removes* the persisted `_det` equality side-channel and metadata-in-envelope leaks (L-3/L-4/L-11) at the store. Explicit design goal, not an accident.
+
+---
+
+## P0 — `record-codec.ts` extraction (shared with the reorg prerequisite)
+
+P2's "store-edge codec seam" IS the `record-codec.ts` extraction the reorg plan also requires. Do it **once**, first: pull envelope-build + encrypt/decrypt/CEK + the deduped #306 sealed dual-read out of `Collection` into a named module. It serves the reorg (no scattered copies), the architecture honesty ("encryption-in-the-hub" is now a module), and this spec's P2 (the codec to graft the edge logic onto). See the reorg plan's Prerequisite section.
+
 ---
 
 ## P1 — Built-in store (DONE — landed `e1f5ba90`)

--- a/docs/superpowers/plans/2026-06-30-hub-src-with-dimension-reorg.md
+++ b/docs/superpowers/plans/2026-06-30-hub-src-with-dimension-reorg.md
@@ -1,0 +1,77 @@
+# Hub `src/` `with-*` reorg — Implementation Plan
+
+> **For agentic workers:** execute via superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Relocate the hub's 36 optional subsystems into 7 `with-*` dimension folders, leaving the kernel + plumbing at `src/` top level, with byte-identical public output.
+
+**Architecture:** Pure source relocation + import rewrite. No renames, no decomposition, no `exports` change. Re-derived on current `main` from the `f6127e62` mapping; the bare names become `with-` prefixed.
+
+**Tech Stack:** TypeScript (ESM `.js` specifiers), tsup multi-entry, vitest, pnpm. Repo: `/Users/vicio/lanna-db/noy-db`.
+
+## Global Constraints
+
+- **Public API frozen:** all 28 `package.json` `exports` subpath targets and the `dist/` top-level layout must be **byte-identical** after the move. Only `src/` source paths change.
+- **Kernel-surface ratchet untouched:** `collection.ts`/`vault.ts` do not move and are not edited beyond import-path rewrites.
+- **Authoritative file list:** the reorg-readiness inventory (`scratchpad/review/reorg-readiness.md`) is the source of truth for which current-`main` folders map where — including any added since `f6127e62`. Reconcile against it before Task 1; any UNMAPPED folder is a STOP-and-confirm.
+- **Commit into a worktree immediately** (durability — the prior attempt was lost as uncommitted worktree state).
+- No Claude attribution in commits.
+
+## The mapping (target)
+
+| dimension | subsystem folders moved in |
+|---|---|
+| `with-lookup/` | aggregate · embeddings · indexing · search |
+| `with-commit/` | crdt · history · numbering · sequence · tx |
+| `with-formula/` | computed · derivations · materialized-views · overlay-views |
+| `with-shape/` | blobs · i18n · introspection · links · money · persisted-schemas · schema-update |
+| `with-audit/` | attestation · consent · forget · guards · periods · sealed-record |
+| `with-fork/` | archive · bundle · shadow · snapshots |
+| `with-party/` | auth-introspection · custody · directory · session · sync · team |
+| **stays top-level** | (dirs) kernel · query · meta · record-keys · adapter · store · cache · coordination · policy · util — (files) collection · vault · noydb · crypto · schema · refs · types · errors · events · validation · subsystem-bus · write-hooks · write-queue · debug · env-check · constants · index · vault-diff · tab-coordination · tab-write-relay |
+
+---
+
+### Task 1: Worktree + reconcile mapping against current main
+
+**Files:** none moved yet.
+
+- [ ] **Step 1:** Create a worktree off current `main`: `git worktree add ../noy-db-reorg -b feat/with-dimension-reorg`. Work there.
+- [ ] **Step 2:** Inventory: `ls -1 packages/hub/src/` (dirs only). Diff against the mapping table. For every dir, assert a target. If any dir is absent from the mapping (new since `f6127e62`), STOP and report — do not guess a dimension for a subsystem with security/crypto weight (e.g. anything CEK/sealing-related likely stays kernel-side under `record-keys`).
+- [ ] **Step 3:** Commit a `REORG-MAP.md` scratch note in the worktree recording the final dir→target decision (durable record before any move).
+
+### Task 2: Scripted, split-safe folder move
+
+**Files:** all 36 subsystem dirs → `src/with-<dim>/<subsystem>/`.
+
+- [ ] **Step 1:** Write the move as an explicit, split-safe loop (bash array of `"subsystem:dimension"` pairs; `git mv "src/$sub" "src/with-$dim/$sub"`), creating each `with-<dim>/` dir first. NOT a space-split word list (R1 landmine).
+- [ ] **Step 2:** Run it. Then verify with an inventory diff: every moved subsystem is under exactly its target `with-*`, top-level kernel dirs untouched, count matches (36 moved).
+- [ ] **Step 3:** Commit: `refactor(hub): move optional subsystems into with-* dimension folders (paths only)`. (Imports still broken at this commit — that's fine, next task fixes; keep it as a reviewable move-only commit.)
+
+### Task 3: Rewrite imports across `src/` AND `__tests__/`
+
+**Files:** every `.ts` under `src/` and `__tests__/` that imports a moved subsystem.
+
+- [ ] **Step 1:** Build a codemod (ts-morph or a careful sed over relative specifiers) that rewrites `from '.../<subsystem>/...'` and `from '../src/<subsystem>/...'` to the new `with-<dim>/<subsystem>/` path, for all 36 subsystems. Handle BOTH intra-`src` relative imports and `__tests__` `../src/...` imports (R2 landmine — the prototype missed tests).
+- [ ] **Step 2:** Run over `src/` then `__tests__/`. Include cross-dimension sibling imports (R3 — e.g. `with-audit/guards` → `with-commit/history`).
+- [ ] **Step 3:** `pnpm --filter @noy-db/hub typecheck` — the `.test.ts` ratchet compile-checks every test file, so a missed import fails here. Expected: clean. Fix any stragglers, re-run.
+- [ ] **Step 4:** Commit: `refactor(hub): rewrite imports for with-* dimension folders (src + tests)`.
+
+### Task 4: tsup entries + any path-bearing tooling
+
+**Files:** `packages/hub/tsup.config.*`, `tsconfig*.json`, any glob in build/test config.
+
+- [ ] **Step 1:** Update the tsup multi-entry *source paths* (`src/indexing/index.ts` → `src/with-lookup/indexing/index.ts`) — entry **keys** unchanged (so `dist/` + `exports` stay identical). Check `tsconfig` `include`/path globs and any `vitest.config` source globs; prefix-prefixed folders are still matched by `src/**`, so most globs need no edit — verify.
+- [ ] **Step 2:** `pnpm --filter @noy-db/hub build`. Then diff `dist/` top-level entries + every `exports` target against a pre-move build — must be byte-identical layout/keys.
+- [ ] **Step 3:** Commit: `chore(hub): point tsup entries at with-* source paths (dist unchanged)`.
+
+### Task 5: Full gate verification
+
+- [ ] **Step 1:** `pnpm --filter @noy-db/hub typecheck` ✓ · `build` ✓ · `test` (same count as pre-move) ✓ · `node scripts/check-architecture.mjs` ✓ (kernel-surface ratchet still passes — collection.ts/vault.ts unmoved).
+- [ ] **Step 2:** Sanity: import a couple of subsystems in a scratch consumer (`@noy-db/hub/indexing`, `@noy-db/hub/team`) and confirm they resolve.
+- [ ] **Step 3:** Open PR to `main` (protected — needs CI). Title: `refactor(hub): group optional subsystems into 7 with-* dimension folders`. Body: link this plan + the spec; note "paths only, public API + dist byte-identical."
+
+## Self-review checklist
+- Every moved subsystem traces to its mapping row; nothing left unmapped or in the wrong dimension.
+- `exports` targets + `dist/` keys diff = empty.
+- `__tests__` imports rewritten (typecheck is the proof).
+- `collection.ts`/`vault.ts` diff = import-path lines only.

--- a/docs/superpowers/plans/2026-06-30-hub-src-with-dimension-reorg.md
+++ b/docs/superpowers/plans/2026-06-30-hub-src-with-dimension-reorg.md
@@ -16,6 +16,27 @@
 - **Commit into a worktree immediately** (durability — the prior attempt was lost as uncommitted worktree state).
 - No Claude attribution in commits.
 
+## Prerequisite — consolidate crypto BEFORE the move (from the 2026-06-30 review)
+
+The refactoring + architecture reviews found the envelope-build / encrypt-decrypt / CEK / #306 sealed dual-read logic **copy-pasted** across `collection.ts`, `vault.ts`, `record-keys/sealing.ts`, and ~12 subsystem files (the envelope literal ~30×; the security-critical dual-read in 2–3 drifting copies). **Reorging first scatters these copies into 7 folders.** So, before Task 1:
+
+- **Extract `record-codec.ts`** (envelope build + encrypt/decrypt/CEK; `collection.ts` ~4980–5160, 5485–5660) — also the named "encryption-in-the-hub" module the architecture review wants, and the seed of edge-crypto Plan B P2.
+- **Dedupe the sealed-slot `iv:data` parse + #306 dual-read** into `record-keys/sealing.ts` (`collection.ts:5559–5579` ↔ `sealing.ts:154–165`).
+- **Add `buildEnvelope()`** to kill the ~30× literal.
+- **Land the H-1 / M-1 `forget()` security fixes** (review §🔴) in the same consolidated path while it's a single copy.
+
+These are their own commits/PR, before the reorg. See `docs/superpowers/2026-06-30-REVIEW-PACKAGE.md`.
+
+> **Reorg-readiness confirmed (review):** the mapping below is **exact** against current `main` — all 46 `src/` subfolders resolve (36 moved, 10 stay), **0 unmapped**. `tsconfig` needs no change; only the 28 tsup-entry **source paths** change (keys stay = subpaths). Codemod scale: **~404 test-import refs across 260 of 333 test files** (larger than the prototype's 438/224 — budget the second pass). ~75 cross-/same-dimension sibling-import edges; depth-recompute, don't prefix-swap.
+
+## Catalog-drift fixes to fold in (architecture review)
+
+While moving, reconcile catalog ↔ exports ↔ folders: `joins`/`live` (documented, no module/export), `routing` (claimed `@noy-db/hub/routing`, actually `./store`), `transactions` (docs say `/transactions`, export is `./tx`), `team`/`attestation`/`sealed-record` (subpath but no `with*()`). Update `SUBSYSTEMS.md` + `package.json` to match reality.
+
+## Test layout decision (review)
+
+Tests are in a flat `__tests__/` (contra CLAUDE.md "beside source"). The move orphans that from the new structure. **Decide in this pass:** mirror `__tests__/with-*/…` or co-locate. Also extract `__tests__/helpers/` fixtures (172/229 files inline `createNoydb(` with no shared helper) to cut churn during the move.
+
 ## The mapping (target)
 
 | dimension | subsystem folders moved in |

--- a/docs/superpowers/reviews/2026-06-30-architecture.md
+++ b/docs/superpowers/reviews/2026-06-30-architecture.md
@@ -1,0 +1,198 @@
+# `@noy-db/hub` — Architecture / Invariant-Discrepancy Review
+
+Scope: where the code and its stated architecture have drifted apart.
+Target: `/Users/vicio/lanna-db/noy-db/packages/hub`. Read-only.
+
+## Executive summary
+
+The hub is architecturally coherent in its *invariant that matters* (crypto happens in the
+hub before any store; stores hold ciphertext) — that boundary is real and mechanically guarded.
+But the **"minimalist core" story is no longer honest**: the three always-on orchestration files
+(`collection.ts` 5,739 + `vault.ts` 4,676 + `noydb.ts` 3,110 = **13,525 LOC**) dwarf the
+documented "~6,500 LOC core" and the "~3,000 LOC" Vault/Collection-model line in `SUBSYSTEMS.md`.
+The subsystem catalog has drifted from the real export/folder layout (phantom subpaths, factories
+with no subpath, subpaths with no factory, and a dozen feature folders inlined into the kernel).
+The `kernel-surface` ratchet is the most honest guard in the repo — and it documents, bump by
+bump, exactly how the "lean kernel" eroded. The cache/to-memory double-residency claim is
+**confirmed**.
+
+Finding counts: **High 4 · Medium 5 · Low 3**.
+
+---
+
+## HIGH
+
+### H1 — "Minimalist ~6,500 LOC core" is aspirational, not load-bearing
+- **Stated:** `noy-db/CLAUDE.md`: "always-on core is only ~6,500 LOC." `SUBSYSTEMS.md:34` (C1):
+  "Vault & Collection model … ~3,000 LOC."
+- **Actual:** `collection.ts` = 5,739 LOC, `vault.ts` = 4,676, `noydb.ts` = 3,110 — **13,525 LOC
+  in the three always-on files alone**, before counting always-on `crypto.ts`, `store/`, `errors`,
+  `schema`, `refs`, `query` basics, `record-keys/`, `money/`, `computed/`, `search/`, `embeddings/`
+  (all of which are pulled in by the kernel hot path; see H3). Total `src` non-test = 65,308 LOC.
+- **Implication:** The headline figure is off by ~2x against the three files and ~4x against the
+  C1 line item. The minimalist-core claim is **aspirational**. The thing keeping the core honest
+  today is not the LOC budget — it's tree-shaking of opt-in *strategy implementations*; the
+  *orchestration* that decides whether to call them is fully resident and large.
+
+### H2 — `kernel-surface` ceiling has functioned as a permission slip, not a cap
+- **File:** `scripts/check-architecture.mjs:402-518` (`KERNEL_SURFACE_BUDGET`).
+- `collection.ts` ceiling = **5,740** vs actual **5,739** (1-line headroom). The budget comment
+  block records a continuous climb: `3950 → 3985 → 4010 → … → 5278 → 5285 → … → 5740` — roughly
+  **+45%** over the tracked window, every step a "conscious reviewed bump." `vault.ts` ceiling 4,677
+  (actual 4,676), `noydb.ts` 3,140 (actual 3,110).
+- **Stated intent (line 645 message):** "The always-on kernel must stay lean — move new capability
+  into a subsystem that registers on the SubsystemBus." **Actual:** capability keeps landing in the
+  kernel and the ceiling is raised to match. The guard prevents *silent* regression (good) but has
+  not kept the kernel lean — it has documented its growth.
+- **Implication:** This is the single best evidence for H1. The ratchet is healthy as a tripwire;
+  it is being used as an approval queue.
+
+### H3 — A dozen real feature folders are baked into the always-on kernel with no `with*()` seam and no subpath
+- **Stated:** `noy-db/CLAUDE.md`: "If you don't opt into a subsystem, its real implementation is
+  replaced by a NO-OP … and tree-shaken out." Implies feature folders sit behind a `with*()` +
+  subpath seam.
+- **Actual:** these `src/` feature folders have **neither a subpath export nor a `with*()` factory**
+  and their call-sites are inlined into `collection.ts` (per the budget comments): `money/`,
+  `computed/`, `search/`, `embeddings/`, `links/`, `sequence/`, `record-keys/`, `persisted-schemas/`,
+  `schema-update/`, `policy/`, `custody/`, `directory/`, `meta/`, `coordination/`, `introspection/`,
+  `auth-introspection/`. The kernel-surface comments explicitly say money/computed/search/embeddings/
+  densify/provenance "cannot move onto the SubsystemBus" and live as "thin call-sites" in the hot path.
+- **Implication:** These are subsystems-in-spirit that are always-on. The product-surface claim
+  ("subsystem catalog IS the product surface, each tree-shakeable behind `with*()`") does not hold
+  for this whole class. Their *engines* may be in subfolders, but their dispatch is unconditional
+  kernel weight and they cannot be opted out.
+
+### H4 — Most subsystems are kernel-coupled via named strategy fields, not the `subsystem-bus`
+- **Files:** `collection.ts:202-209` (`blobStrategy`, `aggregateStrategy`, `crdtStrategy`,
+  `historyStrategy`, `i18nStrategy`, `syncStrategy`); `vault.ts:216-231` (10 named strategy fields:
+  blob, archive, index, aggregate, crdt, consent, periods, shadow, history, forget…).
+- **Stated:** `subsystem-bus.ts` exists (192 LOC) as the decoupling seam; its own header and
+  `check-architecture.mjs:396-401` say write-gating subsystems were "moved off these files onto the
+  SubsystemBus" and the ceiling "locks that in."
+- **Actual:** the bus comment (`subsystem-bus.ts:3`) lists only "devtools inspector, audit,
+  sync-dirty notification" as registrants, and the ceiling rationale names only **periods + guards**
+  as having actually moved. The remaining ~13 strategies are still hard-wired as named `private
+  readonly …Strategy` fields the kernel branches on directly.
+- **Implication:** The bus is real but under-adopted; "subsystem awareness baked into the kernel" is
+  the norm, not the exception. Adding a subsystem still means editing `collection.ts`/`vault.ts`,
+  which is exactly what the bus + ratchet were meant to stop.
+
+---
+
+## MEDIUM
+
+### M1 — Phantom subsystems: `joins` (#2) and `live` (#4) are documented with subpaths + LOC-saved but have no module and no export
+- **Stated:** `SUBSYSTEMS.md:55,57` advertise `@noy-db/hub/joins` ("~470 LOC saved") and
+  `@noy-db/hub/live` ("~210 LOC saved") as numbered, opt-in subsystems.
+- **Actual:** no `src/joins/`, no `src/live/` directory; no `./joins` / `./live` in `package.json`
+  exports; no `withJoins` / `withLive` factory; `index.ts` re-exports neither. Join logic lives in
+  core `src/query/join.ts`; `.live()` resolves to 1 inlined call-site in `collection.ts`.
+- **Implication:** Two of the 24 catalog rows describe seams that don't exist as documented. A
+  consumer following the docs to `import … from '@noy-db/hub/joins'` gets a resolution failure.
+
+### M2 — `routing` (#17) claimed as `@noy-db/hub/routing` but there is no such subpath
+- **Stated:** `SUBSYSTEMS.md:116` — `@noy-db/hub/routing`, ~1,985 LOC (multi-store routing,
+  middleware, sync-policy, LRU cache).
+- **Actual:** no `./routing` export. The factories (`withCache`, `withMetrics`, `withRetry`,
+  `withCircuitBreaker`, `withHealthCheck`, `withLogging`) live in `src/store/store-middleware.ts`
+  and are re-exported through `./store` and top-level `src/index.ts`. `route-store.ts`,
+  `sync-policy.ts` also under `src/store/`.
+- **Implication:** The documented entry point is wrong; the capability is real but reached via
+  `@noy-db/hub/store` / the root export. Subpath/catalog drift.
+
+### M3 — `transactions` subsystem documented at the wrong subpath
+- **Stated:** `SUBSYSTEMS.md:65` — `@noy-db/hub/transactions`.
+- **Actual:** the export is `./tx` (`package.json` → `dist/tx/index.js`), factory `withTransactions`.
+  No `./transactions` alias.
+- **Implication:** Minor but real: docs name a subpath the package does not expose.
+
+### M4 — Subpath exports with no `with*()` opt-in seam: `team`, `attestation`, `sealed-record`
+- **Actual:** `./team`, `./attestation`, `./sealed-record` are exported, but there is no `withTeam`,
+  `withAttestation`, or `withSealed*` factory anywhere in `src` (grep-verified). `team` (#15,
+  "~1,000 LOC") and the sealed-record/attestation epics are reached via `vault.*` methods / direct
+  import, not strategy injection.
+- **Implication:** Inconsistent with the "every subsystem behind a `with*()` strategy factory"
+  model. Either these are always-on (then the catalog should say so) or they lack the documented
+  opt-in seam. `strategy-opt-in` guard cannot cover them because there is no factory to reference.
+
+### M5 — `strategy-opt-in` guard is materially weaker than its description
+- **Stated:** `noy-db/CLAUDE.md`: "strategy-opt-in — using a subsystem API requires referencing its
+  `with*()` factory."
+- **Actual:** `check-architecture.mjs:343-351` (`STRATEGY_GATED_APIS`) covers **5 of 12** seams
+  (self-admitted at line 338: "Coverage today: 5 of the 12 strategy seams"): only `.dump()`,
+  `.ledger()`, `.dictionary()`, `.lazyQuery()`, `.exportBlobs()`. It also only fires on files that
+  inline `createNoydb(` (line ~382). So `crdt`, `sync`, `aggregate`, `guards`, `periods`, `session`,
+  `transactions`, `shadow` etc. throw-at-runtime APIs are **unguarded**, and any consumer file that
+  receives an injected `Vault` is out of scope.
+- **Implication:** The guard's name promises a general invariant; it enforces 5 hand-picked cases.
+  Reasonable as a tripwire, but the CLAUDE.md description overstates it.
+
+---
+
+## LOW
+
+### L1 — `withArchive` and `withDeferredNumbering` are factories with no subpath and no catalog row
+- **Actual:** `withArchive` (`src/archive/`) and `withDeferredNumbering` (`src/numbering/`) are
+  exported `with*()` factories but have no `./archive` / `./numbering` subpath and don't appear as
+  numbered subsystems in `SUBSYSTEMS.md`. They're reached via the root export.
+- **Implication:** Two more catalog/export inconsistencies; low impact (they work, just undocumented
+  as seams).
+
+### L2 — `metrics` exists as a factory but is listed under "reserved/future" subsystems
+- **Actual:** `SUBSYSTEMS.md:319` lists `@noy-db/hub/metrics` as a *reserved* name ("Today partial
+  via to-meter"), yet `withMetrics` is already a shipped factory in `src/store/store-middleware.ts`.
+- **Implication:** The roadmap section describes as future a thing that partially exists. Minor doc lag.
+
+### L3 — TODO/FIXME density is low (not a finding cluster), and `lru` is eagerly imported even in eager mode
+- **Actual:** only 2 TODO/FIXME in non-test `src` (`collection.ts`, `bundle/walk-closure.ts`) — no
+  cluster. Separately, `collection.ts:225-231` notes the `Lru` class is imported even when
+  `prefetch:false` is not set (eager mode never uses it) — a self-acknowledged, un-actioned
+  tree-shaking miss. Low impact.
+- (`pnpm knip` not run — would require a build; skipped to stay read-only/fast. Recommend running
+  it for the dead-export sweep.)
+
+---
+
+## The cache / to-memory redundancy claim — **CONFIRMED**
+
+Each sub-claim verified against current code:
+
+1. **"Each record resident in RAM twice with `to-memory`."** CONFIRMED.
+   - Built-in `src/store/memory-store.ts` (and `@noy-db/to-memory`) hold **ciphertext**
+     `EncryptedEnvelope`s in nested `Map`s (`vault → collection → id → envelope`).
+   - `collection.ts:214` `private readonly cache = new Map<string, { record: T; version }>()`
+     holds the **decrypted plaintext** record. In the default eager mode both coexist for every
+     live record.
+
+2. **"`cache` is plaintext-inside-the-boundary; `to-memory` is ciphertext-outside."** CONFIRMED.
+   - `ensureHydrated()` (`collection.ts:4151-4166`) and `hydrateFromSnapshot()` (4169-4179)
+     `decryptRecord(...)` each envelope and store the cleartext in `this.cache`. The store side
+     never sees plaintext (the architectural invariant holds); the duplication is plaintext-in-hub
+     vs ciphertext-in-store.
+
+3. **"Eager-default `loadAll`+decrypt-whole-collection is the real memory cost."** CONFIRMED.
+   - `prefetch` defaults to `true`; lazy mode is strictly opt-in (`collection.ts:1204-1206`,
+     `this.lazy = opts.prefetch === false`).
+   - `ensureHydrated()` lists **all** ids and decrypts **all** non-tombstone envelopes into `cache`
+     (4154-4162). The bounded `Lru` (`src/cache/lru.ts`) only exists in lazy mode (`lru` is `null`
+     otherwise, 1218-1221). So by default the *entire* decrypted collection is held, on top of the
+     store's full ciphertext copy.
+
+**Nuance worth flagging in the morning writeup:** the duplication is intrinsic to the
+zero-knowledge boundary, not a bug — the store *must* hold ciphertext and the query DSL *must* run
+on plaintext inside the hub. The actionable part is the **eager default**: for large collections on
+`to-memory` you pay 2x RAM unless you explicitly pass `prefetch:false` + a bounded `cache`. The
+prior analysis is accurate on all three points.
+
+---
+
+## Verdict on the minimalist-core claim
+
+**Aspirational, not load-bearing today.** What actually keeps a minimal build small is
+tree-shaking of opt-in *strategy implementations* and the per-subpath split — that part works. But
+the always-on *orchestration* (collection.ts + vault.ts + noydb.ts = 13.5K LOC, plus a dozen
+inlined feature folders per H3) is far past the documented "~6,500 LOC core," and the
+`kernel-surface` ratchet has been raised ~45% to accommodate continued growth rather than holding a
+line. The documents (`CLAUDE.md` ~6,500; `SUBSYSTEMS.md` C1 ~3,000) should be reconciled to the
+real numbers, and H3/H4 (inlined features + named-strategy coupling) are the structural reasons the
+core can't currently be called minimalist.

--- a/docs/superpowers/reviews/2026-06-30-noy-db-docs-extraction.md
+++ b/docs/superpowers/reviews/2026-06-30-noy-db-docs-extraction.md
@@ -1,0 +1,219 @@
+# noy-db → noy-db-docs extraction — strategic pre-analysis (READ-ONLY)
+
+Date: 2026-06-30. Scope: map the extraction boundary for pulling docs/help/examples/non-production
+collateral out of `/Users/vicio/lanna-db/noy-db/` into the already-scaffolded
+`/Users/vicio/lanna-db/noy-db-docs/`. No changes made.
+
+## TL;DR
+
+The destination repo is **not an empty guess — it is a deliberately pre-designed landing zone** with
+a written runbook (`docs/doc-sync.md`), a 5-partition content model, a 2-channel (`latest`/`next`)
+versioning model, and an idempotent sync-state file (`docs.manifest.json`). The seam decision is
+already made (consume **published** `@noy-db/*`, publish nothing). So this is **not** a "design the
+target" exercise; it's a "resolve two inconsistencies in the existing plan, then execute the move and
+the link rewrites" exercise. The two inconsistencies: (1) the migration gate points at PR #498, but
+#498 is actually the family-folder reorg, not a doc-extraction PR; (2) the runbook's source-of-truth
+mapping says core/subsystems docs *live in noy-db* while the migration note says docs/ *moves out* —
+those can't both hold post-move.
+
+---
+
+## 1. What `noy-db-docs` is today (destination inventory)
+
+A **Nuxt 4 + Nuxt Content v3 + Nuxt UI Pro** documentation site, scaffolded but **content-empty**.
+Single commit: `cb71b18 chore: scaffold noy-db-docs — Nuxt 4 + Content v3 + UI Pro docs skeleton`.
+
+- **Stack / consumption:** pnpm workspace, ESM-only, Node ≥22. Root `package.json` is `private`,
+  `version 0.0.0`, description: *"Consumes published @noy-db/* — publishes nothing."* The site package
+  is `@noy-db-docs/site` at `apps/docs` (Nuxt 4, `@nuxt/content` v3, `@nuxt/ui-pro` v3, image/fonts/icon).
+- **Layout:** `apps/docs` (the site, real) · `apps/showcases` (planned stub, README only) ·
+  `examples/`, `recipes/`, `templates/`, `packages/` (all **README-only placeholders**) ·
+  `scripts/sync/` (a **stub** `sync.mjs` that just prints the runbook outline) · `docs/doc-sync.md`
+  (the tracked operating manual) · `docs.manifest.json` (sync state) · `CLAUDE.md` (git-ignored local
+  pointer to `docs/doc-sync.md`).
+- **Content model — 5 partitions** under `apps/docs/content/` (`1.core/ 2.adapters/ 3.ui/
+  4.subsystems/ 5.demos/`). Only `1.core/` has real pages today (`architecture`,
+  `encryption-envelope`, `query-dsl`); the rest are `index.md` placeholders.
+- **Source-of-truth mapping (per the runbook):** core ← noy-db `@noy-db/hub` README + `docs/core/*` +
+  `SPEC.md` + typedoc; adapters ← noy-db 5 essentials + noy-db-to 16 stores + `features.yaml`;
+  ui ← noy-db-ui; subsystems ← `SUBSYSTEMS.md` + `features.yaml` + `docs/subsystems/*`;
+  demos ← noy-db-docs itself (showcases/examples/recipes), *"until then noy-db/showcases, playground,
+  recipes"*.
+- **Explicit gate (in CLAUDE.md, README, runbook):** *"Content migration (moving docs/, showcases/,
+  playground/, recipes/ out of noy-db) is deferred until noy-db PR #498 lands. This repo is the
+  prepared destination + skeleton."*
+
+**Conclusion:** the destination is ~90% designed and ~10% populated. The extraction work is mostly
+*moving content in and rewriting links*, not architecting the target.
+
+---
+
+## 2. The "2 releases (latest / next)" model — already decided
+
+The runbook **rejects a multi-version archive** (no `/v1`, `/v2`) pre-1.0. Instead **two channels
+mirroring npm dist-tags**:
+
+- `latest` = curated `@latest`; the default site. `next` = in-flight `@next` pre-release.
+- Per-page frontmatter declares lineage: `sinceVersion`, `status`
+  (`stable|experimental|deprecated|planned`), `channel` (`latest|both|next`), validated by
+  `content.config.ts`. Next-only sections carry a `channel: next` badge.
+- `docs.manifest.json` records, **per channel and per partition**, the last family version each was
+  generated from → makes re-sync idempotent.
+
+**Implication for extraction:** this is **one content tree with channel metadata**, *not* a
+snapshot-per-release directory and *not* two npm-version builds. Extraction only has to **seed the
+tree once** from current source; the channel layering is applied at sync time by reading
+`npm view @noy-db/hub dist-tags` and stamping frontmatter. The sync tooling itself is still a stub —
+real automation is also gated on the same (mis-pointed) PR.
+
+---
+
+## 3. The dependency seam — consume PUBLISHED packages (decided, and correct)
+
+The repo's own description and CLAUDE.md fix this: **consume published `@noy-db/*` at peer ranges,
+publish nothing** — the same model `klum-db` (binds `@noy-db/hub/kernel`) and `noy-db-to` (binds
+`@noy-db/hub/adapter`) already use. **Recommendation: keep this; do not workspace-link.**
+
+Why it's right: docs document *releases*. Examples/showcases/recipes that run against the published
+surface prove the docs match what users actually `npm install`. The natural consequence — the docs
+repo lags noy-db `main` by a release — is **a feature, not a bug**, and is exactly what the
+`latest`/`next` channel split expresses (`@next` carries in-flight features; docs for them sit on the
+`next` channel).
+
+**What this forces during the move:** every moved runnable asset currently uses `workspace:*` and must
+convert to a **ranged peerDependency** (`^0.2.x`):
+- `showcases/` package deps are all `workspace:*` (`@noy-db/hub`, all `in-*`, `as-*`, `by-*` …).
+- `recipes/*` packages use `workspace:*` + `peerDependencies: { @noy-db/hub: workspace:* }`.
+- `playground/cli` and `playground/nuxt` (`@noy-db/playground-nuxt`) use `workspace:*`.
+
+---
+
+## 4. MOVE / STAYS / AMBIGUOUS — the boundary
+
+### MOVE — pure public docs / examples / help (→ noy-db-docs)
+
+| Source (in noy-db) | Size | Target partition / area | Notes |
+|---|---|---|---|
+| `docs/core/` (7 files) | 44K | `content/1.core` | conceptual core docs |
+| `docs/packages/` (7) | 56K | `content/2.adapters` + cross-fam | `to/in/on/as/by/at` family overviews |
+| `docs/subsystems/` (35) | 340K | `content/4.subsystems` | the public subsystem catalog pages |
+| `docs/recipes/` (9) | 60K | `content/5.demos` (or recipes) | cookbook prose |
+| `docs/glossary/`, `docs/migration/`, `docs/th/` (Thai i18n) | ~40K | core/misc | public reference + localized intro |
+| `docs/assets/` (3) | 584K | site `public/` | images/diagrams |
+| `recipes/` (runnable: `attestation-verifier`, `aws-kms-pdf-attestation`) | — | `examples/` or `recipes/` | convert `workspace:*`→peer ranges |
+| `playground/cli` (the `pnpm demo` tour) | — | `examples/` | update/retire root `pnpm demo` |
+
+### STAYS — production source / tests / config / canonical source-of-truth
+
+| Item | Why it stays |
+|---|---|
+| `packages/**` (all ~68) | production software |
+| `test-harnesses/` (adapter-conformance, benchmarks, simulation-*) | production test infra |
+| `scripts/` (release, check-architecture, validate-features, …) | build/release tooling |
+| `features.yaml` (130K) | schema-validated production catalog; `validate:features` consumes it; also a doc *source* |
+| `turbo.json`, `tsconfig*`, `vitest.config.ts`, `eslint`, `knip.json`, `typedoc.json` | build config |
+| `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `MIGRATING.md`, `LICENSE` | per-repo / GitHub conventions; npm shopfront READMEs stay with packages |
+| `SPEC.md`, `SUBSYSTEMS.md` | **canonical source-of-truth** the docs site *renders from* — stay in noy-db, surfaced (not forked) in the site (runbook: "READMEs stay in their package repos; this repo links, doesn't fork") |
+
+### AMBIGUOUS — flag with the tradeoff
+
+| Item | Size | Tradeoff / recommendation |
+|---|---|---|
+| **`docs/superpowers/`** (specs 79, plans 86, reviews; 183 files) | **4.0M** | **The single largest and most mis-handle-prone chunk.** These are *internal design working docs* (SDD specs/plans/reviews), **neither public documentation nor production software**. They map to **no** docs-site partition. The user's phrasing ("everything not production software") would sweep them up, but they don't belong on a public docs site. **Recommend: STAYS in noy-db as internal dev history (or a separate private archive) — explicitly excluded from the published docs site.** Decide deliberately; don't let them ride along by default. |
+| **`showcases/`** (`@noy-db/showcases`, 101 `*.showcase.test.ts`, +14 helpers) | — | **Double identity: e2e TEST + literate tutorial.** README calls them "living documentation." Destination README already states the intended split: *"the full literate corpus lives here [docs]; a thin smoke subset stays in noy-db as a real in-repo integration gate."* **Recommend: split, not wholesale move** — corpus → `noy-db-docs/apps/showcases` (peer ranges); keep a smoke subset in noy-db (workspace) as the CI integration gate. They are a workspace package in `pnpm-workspace.yaml` + `turbo` test graph → moving touches both. |
+| **`playground/nuxt`** (`@noy-db/playground-nuxt`) | — | Self-describes as *"integration against a real Vue/Pinia consumer"* — a demo **and** an integration test. Same split logic as showcases: demo value → docs; if it's also a real consumer-integration gate, keep a thin version in noy-db. |
+| **`ROADMAP.md`** | 28K | Public-facing reading, but also repo planning. Lean **STAYS** (repo-level planning doc); optionally surface a rendered copy in the site. |
+| `SPEC.md` / `SUBSYSTEMS.md` | — | Listed under STAYS but inherently doc-shaped; they are *sources* the site renders. The decision hinges on the open question in §6. |
+
+### Headline counts (by content bucket, not file count)
+
+- **MOVE: 8 buckets** (docs/core, docs/packages, docs/subsystems, docs/recipes, docs/{glossary,migration,th}, docs/assets, runnable recipes/, playground/cli)
+- **STAYS: 8 buckets** (packages, test-harnesses, scripts, features.yaml, build-config, repo-convention md's, SPEC.md, SUBSYSTEMS.md)
+- **AMBIGUOUS: 5 buckets** (docs/superpowers ← biggest, showcases, playground/nuxt, ROADMAP.md, SPEC/SUBSYSTEMS-as-source)
+
+---
+
+## 5. What breaks in the core repo when docs move out
+
+1. **Relative links UP and OUT of `docs/`** — the largest mechanical cost. Grep of `docs/**.md` for
+   `](../…)` shows e.g. **34× `../../SUBSYSTEMS.md`, 11× `../../SPEC.md`, ~40× `../../packages/on-*`**
+   (on-webauthn/totp/threat/shamir/recovery/pin/oidc/magic-link/email-otp …), plus intra-`docs`
+   `../subsystems/…`, `../core/…`, `../recipes/…`. Once `docs/` lives in another repo, every `../../`
+   link to a noy-db file breaks → must be rewritten to **absolute GitHub URLs** (for source that
+   stays) or to **in-site routes** (for content that moved). Intra-docs links re-map to Nuxt Content
+   routes (numeric prefixes stripped: `1.core/index.md` → `/core`).
+2. **`pnpm-workspace.yaml`** lists `showcases` (and the workspace globs cover `recipes`, `playground`).
+   Removing those packages requires editing the workspace list.
+3. **`turbo.json`** test graph — `@noy-db/showcases` participates in `turbo run test`. The
+   `pnpm --filter @noy-db/showcases test` flow and the showcase-as-integration-gate disappear unless a
+   smoke subset is retained.
+4. **Root scripts** — `pnpm demo` runs `playground/cli`; moving it breaks the script (retire or
+   repoint).
+5. **`typedoc.json`** outputs to `docs/api` and `readme: README.md`. If `docs/` moves, the generated
+   API output path needs a decision (it's a build artifact; typedoc itself STAYS as it generates from
+   `packages/*/src`). The site can consume typedoc output as the core partition's API reference.
+6. **NOT affected:** `features.yaml` stays → `validate:features` unaffected. `check-architecture`
+   scans `packages/**` → unaffected by the docs move itself (it just stops seeing the moved
+   showcase/recipe/playground packages' `workspace:*` deps).
+
+---
+
+## 6. Risks, sequencing, and the open question
+
+### Is it safe to do AFTER the with-* reorg + edge-crypto? — Yes.
+
+- **Path-disjoint from the reorg.** PR #498 (the family-folder reorg: `packages/<family>/<pkg>`) is
+  **CLOSED** and touches `packages/**`. The extraction touches `docs/`, `showcases/`, `playground/`,
+  `recipes/` — **almost entirely disjoint paths** → low merge-conflict risk. The one overlap is the
+  doc *link rewrites* that reference `../../packages/on-*` (those target paths changed under the
+  reorg), so doing extraction **after** the reorg means you rewrite each such link **once**, to its
+  final location, rather than twice.
+- **No reason to do it early**, with one caveat: the **stale gate** (`doc-sync.md` says "deferred
+  until PR #498") is now misleading and should be re-pointed regardless of when the move happens.
+
+### Recommended sequence
+
+1. **Resolve the open question (below)** — pick the post-move source-of-truth policy.
+2. **Re-point the gate** in `docs/doc-sync.md` / `noy-db-docs/CLAUDE.md` / README from the (closed,
+   mis-identified) "#498" to the real extraction PR.
+3. **Move pure public docs** (`docs/core|packages|subsystems|recipes|glossary|migration|th|assets`)
+   into `apps/docs/content/*`; rewrite links (GitHub-absolute for stays, site-route for moves).
+4. **Split showcases**: corpus → `noy-db-docs/apps/showcases` at peer ranges; retain a smoke subset
+   in noy-db as the CI integration gate. Update `pnpm-workspace.yaml` + `turbo.json`.
+5. **Move runnable recipes + `playground/cli`** → `noy-db-docs/examples` at peer ranges; retire/repoint
+   `pnpm demo`. Decide `playground/nuxt` (demo vs. kept integration gate).
+6. **Decide `docs/superpowers/` deliberately** — recommend it stays internal and is excluded from the
+   public site.
+7. **Clean & verify core repo**: workspace globs, turbo graph, root scripts; `pnpm build/test/
+   typecheck/typedoc` + `check:architecture` + `validate:features` all green with the content gone.
+8. **Seed the docs site once**, then exercise the channel/sync model (`docs.manifest.json` +
+   frontmatter) and replace the `scripts/sync/sync.mjs` stub.
+
+### Risks
+
+- **Link rot (highest-likelihood):** ~100+ relative `../../` links break silently; the site needs a
+  link-check gate (the runbook already lists "internal link check" in step 7).
+- **Losing the showcase integration gate:** if showcases move wholesale with no smoke subset, noy-db
+  loses an e2e safety net and the moved corpus can only test the *published* surface (so it can't gate
+  unreleased changes on noy-db `main`). The split mitigates this.
+- **Source-of-truth drift:** if `docs/core`/`docs/subsystems` physically leave noy-db but the runbook
+  still names them as the canonical source, future syncs have no source to read from (see open
+  question).
+- **`docs/superpowers` accidentally published:** 4MB of internal SDD specs/plans/reviews swept into a
+  public site by an over-broad "everything non-production" rule.
+
+### THE single biggest open question
+
+> **After `docs/` physically leaves noy-db, what is the canonical source-of-truth for the `core` and
+> `subsystems` partitions?** The prepared plan is internally contradictory: `doc-sync.md`'s mapping
+> table says those partitions are *generated from* noy-db's `docs/core/*`, `docs/subsystems/*`,
+> `SPEC.md`, and `SUBSYSTEMS.md` (read-only sources), **but** the migration note says `docs/` *moves
+> out of noy-db*. Both cannot hold. Resolve to one of:
+> (a) **docs/core & docs/subsystems STAY** as source in noy-db; only `showcases/playground/recipes`
+>     move (docs site renders from the staying sources — least churn, matches the runbook as written);
+>     or
+> (b) **docs/core & docs/subsystems MOVE**; the docs repo becomes their canonical home, and the only
+>     remaining in-repo sources are package READMEs + `SPEC.md`/`SUBSYSTEMS.md`/`features.yaml` (matches
+>     the user's "all docs leave" intent but requires rewriting the runbook's source mapping).
+> This choice determines the entire extraction boundary for the two biggest doc partitions and must be
+> made before any files move.

--- a/docs/superpowers/reviews/2026-06-30-refactoring.md
+++ b/docs/superpowers/reviews/2026-06-30-refactoring.md
@@ -1,0 +1,242 @@
+# `@noy-db/hub` — Refactoring / Tech-Debt Review
+
+Scope: `/Users/vicio/lanna-db/noy-db/packages/hub`. Read-only. Oriented around the upcoming
+reorg that groups optional subsystems into 7 `with-*` dimension folders. Flags which debt is
+best paid **WITH** the reorg vs **independently**.
+
+---
+
+## TL;DR
+
+The five giant files total ~18.4K LOC. The real problem isn't size per se — it's that
+`collection.ts` (5,739) and `vault.ts` (4,676) are **god-objects** mixing 8+ concerns each, and
+the crypto/envelope/sealed-field logic that *should* live in one place is **copy-pasted** across
+`collection.ts`, `vault.ts`, `record-keys/sealing.ts`, and a dozen subsystem files. The reorg
+will physically move subsystem code into `with-*` folders; if the duplication isn't consolidated
+first, the reorg just **scatters the copies further apart**, making the eventual edge-crypto
+redesign harder. Highest leverage: extract a small shared crypto/envelope/sealed-slot module
+**before** the move, then split the two god-objects along seams that already exist in the method
+layout. `errors.ts` and `types.ts` are big but cohesive — low-risk mechanical splits, best done
+**with** the reorg so error/type modules can live beside their dimension.
+
+---
+
+## 1. The giant files
+
+### 1a. `collection.ts` — 5,739 LOC, one class, ~70 methods, ~60 private fields
+
+**Yes, it is doing far too many jobs.** The single `Collection<T,S,Q,M>` class owns: envelope
+crypto (encrypt/decrypt/CEK wrap), sealed-field group-encryption, deterministic-index ciphertext,
+the working-set cache + LRU, eager & persisted index maintenance, unique constraints, full-text +
+vector search + retrieval, i18n densify/translate, money fields, computed fields, refs/joins,
+CRDT merge, history/ledger writes, materialized-view & derivation dispatch, tiers
+(elevate/demote/putAtTier), and presence. The constructor alone is **~630 lines (L624–1255)**.
+
+**Extract candidates (by line range):**
+
+| Concern | Lines (approx) | Extract to | Notes |
+|---|---|---|---|
+| **Crypto / envelope build & decrypt** | `encryptRecord` 5052–5117, `encryptJsonString` 4998–5050, `buildDebugEnvelope` 4980–4996, `decryptJsonString` 5509–5535, `decryptRecord` 5612+, `resolveEnvelopeCek` 5485–5493, `resolveRecordCek` 4952 | a `record-codec.ts` (sibling to `record-keys/`) taking `{getDEK, name, storeCiphertext, flags}` | **This is the seam the CLAUDE.md invariant cares about.** Pulling it out makes "encryption happens in the hub" a *named module* instead of 250 lines buried in a collection method. Highest-value extraction. |
+| **Sealed-field seal/unseal** | `unsealField` 5559–5579, `makeSealedHandle` 5588, `toCacheRecord` 5599–5610, seal loop inside `encryptRecord` 5074–5094 | `record-keys/sealing.ts` (already exists!) | The parse + dual-read is **already duplicated** there (see §2a). Merge. |
+| **Deterministic index** | `findByDet` 5132, `queryByDet` 5163, det loop 5104–5116 | `record-keys/deterministic.ts` | Self-contained; only needs DEK + name. |
+| **Tiers** (elevate/demote/putAtTier/getAtTier/listAtTier/cross-tier events) | 5194–5485 (~290 LOC) | a `with-tiers` mixin/helper | A whole subsystem living inside the class. Prime reorg target. |
+| **Index maintenance** (persisted/eager/unique/reconcile) | `maintainPersistedIndexesOnPut/Delete` 4660–4758, `rebuildEagerIndexes` 4191, `rebuildUniqueConstraints` 4205, `rebuildIndexes` 4233, `reconcileIndex` 4299–4415, `autoReconcile` 4849 | extend `indexing/` (already a folder) | Index logic is split between `indexing/` and the class; consolidate. |
+| **Search/retrieval** | `search` 3114, `buildRetrievalDocs` 3132, `retrieve*` 3296–3376, `similarTo` 3377, `warmIndex`/`flushIndex` 3212/3281 | extend `search/` | |
+| **`putInternal`** | 1746–2210 (**~465 LOC single method**) | decompose into a pipeline | computed → schema → money → i18n → refs → crdt → history → embeddings → ledger → cache, all inline. See §3. |
+| **Constructor field-wiring + facade closures** | 624–1255, esp. derivation/MV/ref/join facade closures 930–1000 | a `CollectionConfig` resolver + `buildFacades(vault)` | 60+ `this.x = opts.x` assignments; the inline facade closures (derivationSource, materializedViewSource, refEnforcer, joinResolver) are ~150 lines of object literals in the ctor. |
+
+Natural cut: the class keeps the **core CRUD + cache + query orchestration**; everything in the
+table moves behind the strategy handles it already holds (`blobStrategy`, `crdtStrategy`,
+`aggregateStrategy`, `historyStrategy`, `i18nStrategy`, `syncStrategy` — the pattern exists, it's
+just not applied to crypto/tiers/det/search). **Do the crypto + sealed extraction independently
+and first; do tiers/search/index consolidation WITH the reorg.**
+
+### 1b. `vault.ts` — 4,676 LOC, `Vault` class (~90 methods) + `Transaction` class (L4616+)
+
+Cohesive *clusters* are visible in the method layout and map almost 1:1 to subsystems already
+having folders. Extract candidates:
+
+- **Periods** (`closePeriod` 3559, `listPeriods`, `getPeriod`, `_assertTsWritable` 3680,
+  `_loadPeriodsCache`, `_writePeriodRecord` 3709, `_decryptPeriodRecord` 3737) → `periods/` exists.
+- **Sealing/record-keys** (`sealRecordToHost` 2781, `revokeSealedRecord`, `rotateRecordCek` 2818,
+  `sealingContext` 2827) → `record-keys/` / `sealed-record/`.
+- **Backup/dump/load** (`dump` 3960, `load` 4044, `verifyBackupIntegrity` 4159 (~370 LOC),
+  `exportJSON` 4531) → a `vault-backup.ts`.
+- **Attestation** (`issueAttestation` 1999, `revokeAttestation` 2041, `publishRevocationList`,
+  `makeIssueContext`/`makeRevokeContext`) → `attestation/` exists.
+- **Refs/links enforcement** (`enforceRefsOnPut` 2142, `enforceRefsOnDelete` 2242,
+  `enforceLinksOnDelete` 2330, `resolveRef`, `resolveSource`) → `links/`.
+- **Subsystem `_init*` registry wiring** (`_initGuards` 2852, `_initDerivations` 2882,
+  `_initMaterializedViews` 2920, `_initOverlayedViews` 2964) → a single `registerSubsystems()` —
+  these four are near-identical boilerplate (see §2c).
+- **Export/import capability gating** (`assertCanExport`/`assertCanImport`/`canExport`/`canImport`
+  overloads 1692–2141) → a `capabilities.ts`.
+- The inner **`Transaction` class (4616–4664)** is a separate type sharing the file; move to `tx/`.
+
+`Vault` should retain `collection()` (683–1162, the factory that wires every option into a
+`Collection`), keyring/role accessors, and the subsystem registry handles. Most of the rest is
+delegatable. **Almost all WITH the reorg** — these clusters *are* the dimensions being created.
+
+### 1c. `noydb.ts` — 3,110 LOC
+
+The instance-lifecycle core (`openVault` 507, `vault` 658, `transaction` overloads 1269–1340,
+event/tab-coordination accessors) is reasonable. The bloat is one cluster:
+
+- **Auth / recovery / enrollment** — `enrollAuthenticator` 1894 → `clearQuickUnlock` 2802 is
+  **~900 contiguous LOC**: authenticators, WebAuthn, passphrase rotate/recover, Shamir, managed
+  passphrase, PIN unlock. `team/` already holds `authenticators.ts`, `recovery.ts`,
+  `rotate-recover.ts`, `managed-passphrase.ts`, `shamir-*` — these `noydb` methods are thin-ish
+  wrappers that should move next to their implementations (or into an `on-*`/`team` facade).
+- **Snapshots** (`snapshot` 2971, `initSnapshotCadence` 2988, `listSnapshots`, `restoreSnapshot`
+  3039) → `snapshots/` exists.
+- **Policy/session** (`attachPolicyEnforcer` 459, `touchPolicy`, `checkPolicyOperation`,
+  `bootstrapPolicy` 1806, `getPolicy`/`updatePolicy`) → `policy/`.
+
+**WITH the reorg** (auth → `with-team`/`on-*` dimension, snapshots → its own).
+
+### 1d. `types.ts` — 2,449 LOC, 89 exported types
+
+Cohesive but monolithic. It's a **god-barrel**: `NoydbStore` (423–606, the store contract),
+`EncryptedEnvelope` (118), `NoydbOptions` (1927–2364, ~440 LOC of option surface), blob types
+(1705–1925), sync types (1048–1210), export/capability types (633–945). Splitting by dimension
+(envelope+store → `adapter`/`store` already export some; options → near the factory; blob → `blobs/`;
+sync → `sync/`) lets each `with-*` folder own its types. **Mechanical, low-risk, do WITH the reorg**
+so types co-locate with the code that moves. Watch the `index.ts` barrel (1,079 LOC) and the frozen
+`kernel` seam — keep public re-exports stable.
+
+### 1e. `errors.ts` — 2,417 LOC, **102 error classes**, all extending `NoydbError`
+
+Flat list, each class ~15–30 LOC (message builder + `code` + structured fields). Pure mechanical
+split by dimension: index/unique errors → `indexing/errors.ts`, derivation/MV/overlay errors →
+their folders, schema-update errors (already a subclass tree `SchemaUpdateError` 981–1051) →
+`schema-update/`, sealed/tier/record-cek → `record-keys/`. Keep `NoydbError` base + the truly-core
+ones (`DecryptionError`, `TamperedError`, `NoAccessError`, `ValidationError`) in a root `errors.ts`,
+re-export all from the barrel for back-compat. **Lowest-risk of the five; do WITH the reorg.**
+
+---
+
+## 2. Duplication (DRY)
+
+### 2a. Sealed-field `iv:data` parse + dual-read — **duplicated, drifting** ⚠️
+`collection.ts unsealField` (5559–5579) and `record-keys/sealing.ts` (154–165) implement the *same*
+three steps independently: `const sep = blob.indexOf(':'); iv = slice(0,sep); data = slice(sep+1)`,
+then **try `deriveSealedFieldKeyFromCek` → catch → fall back to `deriveSealedFieldKey(dek)`** (the
+#306 dual-read). Two copies of a security-critical fallback that *must* stay byte-identical.
+`history/history.ts:25` has a third colon-split. **Extract `parseSealedSlot(blob)` +
+`unsealSlot(blob, {cek, dek, collection, field})` into `record-keys/sealing.ts` and call from both.**
+High-value, low-effort, **do BEFORE the reorg** (the edge-crypto redesign will rewrite this path;
+one copy is far cheaper to redesign than three).
+
+### 2b. Envelope literal construction — repeated ~30× across the tree
+`{ _noydb: NOYDB_FORMAT_VERSION, _v, _ts: new Date().toISOString(), _iv, _data, _by, ...}` is
+hand-built **7× in `vault.ts`, 7× in `collection.ts`, 8× in `blobs/blob-set.ts`**, plus
+`record-keys/sealing.ts`, `meta/user-envelope/storage.ts`, `history/ledger/store.ts`,
+`team/recovery.ts`, `sequence`, `numbering`, `i18n/dictionary`, `forget/subject-index`. The
+"encrypt-then-wrap-in-envelope" idiom (`const {iv,data} = await encrypt(json, dek); return {_noydb,…,_iv:iv,_data:data,_by}`)
+and its plaintext counterpart (`_iv:'', _data:json`) recur verbatim. **Extract
+`buildEnvelope(json, {dek?|cek?, version, by, ts?, provenance?})` and `buildPlaintextEnvelope(...)`
+into the record-codec module.** Removes the most-copied 6-line block in the package. **BEFORE the
+reorg** — otherwise the copies scatter into 7 folders.
+
+### 2c. Subsystem triplet boilerplate — `index.ts` + `active.ts` + `strategy.ts`
+~13 subsystems follow the identical shape (`aggregate`, `blobs`, `crdt`, `consent`, `indexing`,
+`snapshots`, `tx`, `periods`, `shadow`, plus `history` etc.): a `strategy.ts` (the `with*()` factory
++ no-op stub seam), an `active.ts` (the real impl), an `index.ts` (barrel). And `vault.ts`'s four
+`_initGuards/_initDerivations/_initMaterializedViews/_initOverlayedViews` (2852–3010) are
+near-identical registry-wiring. The `with-*` reorg is the moment to **codify the triplet as a
+template** (or a tiny `defineSubsystem({ stub, active })` helper) so each dimension folder is
+uniform and the `_init*` quartet collapses to one parameterised `registerSubsystem(handle)`.
+**This IS the reorg work** — fold it in rather than relocating 13 ad-hoc triplets.
+
+### 2d. `isTombstone(env, storeCiphertext)` — called 6× in collection (1493/1737/2282/2293/2672/2953)
+Already extracted (`record-keys/tombstone.ts`) — good. No change; cited as the *model* the
+crypto/envelope extraction should follow.
+
+---
+
+## 3. Complexity hotspots
+
+- **`Collection.putInternal` (1746–2210, ~465 LOC, one method).** The write pipeline —
+  computed→schema→money→i18n densify/translate→refs→crdt(lww/rga branch)→history→cache→embeddings→ledger
+  — all inline with deep `if (this.x)` nesting (the i18n + crdt blocks alone reach 4–5 levels,
+  e.g. 1953–1999, 1882–1918). A reader cannot hold it in their head. Refactor to an explicit
+  ordered list of pipeline steps (each a private method taking a small mutable write-context), so
+  the order is legible and individually testable. High-value; **independent of reorg** but easier
+  once crypto is extracted (§1a).
+- **`Collection` constructor (624–1255).** 60+ field assignments + ~150 LOC of inline facade-closure
+  object literals. Extract `resolveCollectionConfig(opts)` and `buildFacades(vault)`.
+- **`Vault.verifyBackupIntegrity` (4159–~4530, ~370 LOC)** and **`Vault.load` (4044–4159)** — long,
+  branchy backup logic; move to `vault-backup.ts` and decompose.
+- **`noydb` auth/recovery cluster (1894–2802, ~900 LOC)** — many near-parallel rotate/recover
+  variants (`rotateRecoveryPaper` 2341 vs `rotateRecoveryShamir` 2376; `recoverPassphrase` vs
+  `recoverManagedPassphrase` vs `recoverUser`). Consolidate behind `team/recovery`.
+
+---
+
+## 4. The eager-cache default (`prefetch: true`)
+
+`vault.ts:661` documents the default: `prefetch:true` (eager) "loads everything on first access";
+`prefetch:false` (lazy) uses a bounded LRU and **requires `cache` bounds**. Eager mode means the
+**entire collection is decrypted into a `Map` (`collection.ts:214`) on first touch** and held in
+RAM as plaintext for the session.
+
+Assessment:
+- **Correctness/perf:** eager-by-default is the simpler mental model and makes `list()/query()`
+  synchronous-feeling, but it's the wrong default for (a) large collections, (b) the zero-knowledge
+  threat model (whole-collection plaintext resident in RAM longer than necessary), and (c) memory on
+  constrained edge/browser/Worker targets. The code already *supports* lazy fully (LRU, persisted
+  indexes, `ensurePersistedIndexesLoaded`, auto-reconcile) — lazy is a mature path, not a stub.
+- **Cost of flipping the default to lazy:** lazy currently **requires** explicit `cache` bounds and
+  changes the perf profile of unindexed `query()`/`list()` to a store scan + decrypt (vault.ts:2253
+  notes this). Flipping naively would break callers relying on eager warmth and force every
+  collection to declare cache bounds. A safe path: pick a **sensible default LRU bound** so lazy
+  needs no config, keep eager opt-in for small/hot collections, and let `describe()`/indexes drive
+  warmth.
+- **Overlap with the edge-crypto redesign (specced separately):** the redesign reportedly reworks how/
+  when plaintext materialises. **Do NOT flip the default as part of *this* refactor** — but the
+  crypto/envelope extraction (§1a) is a prerequisite that makes the lazy/eager boundary a clean seam.
+  Recommendation: treat "lazy-by-default + zero-config LRU bound" as a **decision owned by the
+  edge-crypto spec**, and land §1a first so that spec has a single `record-codec` to target rather
+  than crypto smeared through `Collection`. Note the overlap explicitly in the reorg plan; the
+  mechanic refactor here is just *isolating the cache from the codec*.
+
+---
+
+## 5. Test structure (~333 `*.test.ts`, 229 in flat `__tests__/`)
+
+- **Layout mismatch vs reorg + vs CLAUDE.md.** CLAUDE.md says "tests live beside source"; in fact
+  hub centralises them in a **flat `__tests__/`** (229 top-level files). The `with-*` reorg will move
+  source into 7 dimension folders, leaving a flat test dir that no longer mirrors structure. Decide
+  now: mirror `__tests__/with-*/…` or co-locate. **Address WITH the reorg** (moving tests is cheapest
+  in the same pass that moves source).
+- **No shared fixtures.** **172 of 229 files call `createNoydb(` directly and 0 import a local
+  test-helper** — every file re-inlines vault/collection setup (memory store + openVault + unlock).
+  This is the brittleness source: a constructor/option change ripples across 170+ files. **Extract a
+  `__tests__/helpers/` with `makeVault()`/`makeCollection()` fixtures.** High-value, independent of
+  reorg, reduces churn *during* the reorg.
+- **Large suites** (`bundle-auto-unlock` 782, `blob-set` 753, `refs` 724, `route-store` 637,
+  `dictionary` 622): not flagged as wrong, but candidates to split per-behaviour when their source
+  moves, so each dimension folder gets focused suites.
+
+---
+
+## Ranked actions (value/effort)
+
+| # | Item | V/E | With reorg? | Where |
+|---|---|---|---|---|
+| 1 | Extract `record-codec.ts` (envelope build + encrypt/decrypt/CEK) out of `Collection` | High / Med | **Before** | collection.ts 4980–5160, 5485–5660 |
+| 2 | Dedupe sealed-slot parse + #306 dual-read into `record-keys/sealing.ts` | High / Low | **Before** | collection.ts 5559–5579 ↔ sealing.ts 154–165 |
+| 3 | `buildEnvelope()` helper to kill the ~30× envelope literal | High / Low | **Before** | vault/collection/blobs/+10 |
+| 4 | Shared `__tests__/helpers/` fixtures (172 files inline `createNoydb`) | High / Low | Independent | `__tests__/` |
+| 5 | Decompose `putInternal` (465 LOC) into an ordered write pipeline | High / Med | Independent | collection.ts 1746–2210 |
+| 6 | Move `Vault` clusters (periods/attestation/backup/refs/`_init*`) to existing folders | Med / Med | **With** | vault.ts §1b |
+| 7 | Move `noydb` auth/recovery 900 LOC into `team/`; snapshots/policy out | Med / Med | **With** | noydb.ts 1894–2802 |
+| 8 | Lift `Collection` tiers/search/det into strategy handles | Med / Med | **With** | collection.ts 5132–5485, 3114–3420 |
+| 9 | Split `errors.ts` (102 classes) by dimension, barrel-reexport | Med / Low | **With** | errors.ts |
+| 10 | Split `types.ts` (89 types) by dimension; keep kernel/barrel stable | Med / Med | **With** | types.ts |
+| 11 | Codify subsystem triplet template + collapse `_init*` quartet | Med / Med | **With** | 13 subsystem folders, vault.ts 2852–3010 |
+| 12 | Mirror test layout to `with-*` dimensions | Low / Med | **With** | `__tests__/` |
+
+**Sequencing:** land #1–#3 (crypto/envelope/sealed consolidation) **before** the reorg so the
+edge-crypto redesign and the folder move both target one codec module, not scattered copies. #4–#5
+are independent quick wins. #6–#12 are the reorg itself — fold the debt paydown into the move.

--- a/docs/superpowers/reviews/2026-06-30-reorg-readiness.md
+++ b/docs/superpowers/reviews/2026-06-30-reorg-readiness.md
@@ -1,0 +1,155 @@
+# Hub Reorg-Readiness Inventory
+
+Target: `/Users/vicio/lanna-db/noy-db/packages/hub`
+Checked-out branch at audit time: `docs/hub-reorg-and-edge-crypto-specs` (working tree, post-#306). Read-only audit.
+Plan: re-derive prior commit `f6127e62`'s 7-dimension grouping on current main, with a `with-` prefix on each dimension folder.
+
+> NOTE on branch: the working copy is NOT `main` and NOT `f6127e62` — it is `docs/hub-reorg-and-edge-crypto-specs`. `git ls-tree f6127e62` was not reachable from this checkout, so the "new since f6127e62" diff could not be computed against that SHA. The structural inventory below reflects the current working tree, which is what the reorg will actually run against.
+
+---
+
+## 1. Folder inventory → target dimension
+
+`src/` holds **46 subdirectories** + 20 top-level `.ts` files. Every one of the 46 folders maps cleanly:
+
+**MOVED (36 folders → 7 dimensions):**
+
+| Dimension | Folders |
+|---|---|
+| `with-lookup` | aggregate, embeddings, indexing, search |
+| `with-commit` | crdt, history, numbering, sequence, tx |
+| `with-formula` | computed, derivations, materialized-views, overlay-views |
+| `with-shape` | blobs, i18n, introspection, links, money, persisted-schemas, schema-update |
+| `with-audit` | attestation, consent, forget, guards, periods, sealed-record |
+| `with-fork` | archive, bundle, shadow, snapshots |
+| `with-party` | auth-introspection, custody, directory, session, sync, team |
+
+**STAYS at `src/` top (kernel/plumbing, 10 folders):**
+query, meta, record-keys, adapter, store, cache, kernel, coordination, policy, util
+
+**Top-level `.ts` files (stay):** collection.ts, constants.ts, crypto.ts, debug.ts, env-check.ts, errors.ts, events.ts, index.ts, noydb.ts, refs.ts, schema.ts, subsystem-bus.ts, tab-coordination.ts, tab-write-relay.ts, types.ts, validation.ts, vault-diff.ts, vault.ts, write-hooks.ts, write-queue.ts
+
+### UNMAPPED folders: **NONE.**
+Programmatic check: `folders-on-disk (46) == mapped (46)`, set-difference both directions = empty. The plan's mapping is **complete and exact** against the current tree. In particular the two #306-adjacent dirs the prompt flagged as risks — `sealed-record` (→ with-audit) and `record-keys` (→ stays) — already exist and are already in the mapping. No new orphan folder to assign a target to.
+
+---
+
+## 2. Cross-subsystem internal imports (codemod must rewrite)
+
+These are sibling imports today (`../<sub>/...`, depth 1). After the move, depth changes and many cross a dimension boundary. The codemod must **recompute relative depth from each file's new location** — not just string-swap a prefix — because subsystems contain nested files (e.g. `guards/*`) whose imports are already `../../`.
+
+### A. CROSS-DIMENSION moved→moved (become `../../with-Y/...` from a top-level subsystem file):
+```
+aggregate (lookup)        -> i18n (shape)            [1]
+aggregate (lookup)        -> money (shape)           [4]
+attestation (audit)       -> bundle (fork)           [1]
+bundle (fork)             -> history (commit)        [6]
+bundle (fork)             -> persisted-schemas (shape)[1]
+bundle (fork)             -> team (party)            [8]
+consent (audit)           -> bundle (fork)           [1]
+custody (party)           -> bundle (fork)           [2]
+derivations (formula)     -> guards (audit)          [2]
+derivations (formula)     -> tx (commit)             [1]
+embeddings (lookup)       -> i18n (shape)            [1]
+forget (audit)            -> history (commit)        [1]
+guards (audit)            -> i18n (shape)            [1]
+i18n (shape)              -> history (commit)        [3]
+i18n (shape)              -> team (party)            [3]
+introspection (shape)     -> computed (formula)      [1]
+introspection (shape)     -> team (party)            [1]
+materialized-views(form.) -> aggregate (lookup)      [4]
+materialized-views(form.) -> i18n (shape)            [2]
+materialized-views(form.) -> money (shape)           [1]
+materialized-views(form.) -> tx (commit)             [2]
+money (shape)             -> aggregate (lookup)       [2]
+periods (audit)           -> history (commit)         [3]
+search (lookup)           -> i18n (shape)             [3]
+session (party)           -> bundle (fork)            [1]
+team (party)              -> bundle (fork)            [1]
+tx (commit)               -> bundle (fork)            [1]
+tx (commit)               -> guards (audit)           [4]
+```
+
+### B. SAME-DIMENSION moved→moved (stay siblings under the same `with-X/`, path unchanged for top-level files but still re-derived for nested ones):
+```
+auth-introspection -> team               (party)
+custody            -> team               (party)
+indexing           -> aggregate          (lookup)
+introspection      -> i18n               (shape)
+introspection      -> money              (shape)
+introspection      -> persisted-schemas  (shape)
+materialized-views -> derivations        (formula)
+overlay-views      -> materialized-views  (formula)
+persisted-schemas  -> schema-update      (shape)
+schema-update      -> persisted-schemas  (shape)
+session            -> team               (party)
+snapshots          -> bundle             (fork)
+sync               -> team               (party)
+team               -> directory          (party)
+tx                 -> history            (commit)
+```
+
+### C. moved→KERNEL-STAYS (become `../../<stays>/...`):
+```
+aggregate->query[2]  auth-introspection->policy[2]  blobs->record-keys[1]
+bundle->meta[3]      bundle->record-keys[2]         custody->policy[2]
+guards->query[2]     indexing->query[4]             materialized-views->query[6]
+money->query[2]      schema-update->coordination[2] search->query[1]
+shadow->query[1]     team->meta[1]  team->policy[1] team->store[3]
+```
+
+### D. KERNEL-STAYS dir → moved subsystem (become `../with-X/...`):
+```
+query  -> aggregate[14], money[8], indexing[3], i18n[1]
+kernel -> aggregate[3], search[3], bundle[1], indexing[1], introspection[1]
+record-keys -> sealed-record[1], team[1]
+coordination -> schema-update[2]
+```
+(`kernel/index.ts` is the FROZEN seam — additive only. Re-pointing its internal imports to `../with-X/` is fine since the seam is its *exports*, not its import paths; verify no export *path string* leaks.)
+
+### E. TOP-LEVEL `src/*.ts` → moved subsystem (become `./with-X/<sub>/...`):
+High-volume — these dominate the in-source codemod surface (`./<sub>/` → `./with-X/<sub>/`):
+```
+team 60, i18n 22, bundle 19, blobs 17, history 16, introspection 15,
+session 11, tx 11, search 11, guards 11, schema-update 10, indexing 10,
+derivations 10, materialized-views 9, crdt 8, money 6, overlay-views 6,
+archive 6, numbering 6, custody 6, forget 5, computed 5, persisted-schemas 5,
+consent 5, periods 5, snapshots 4, shadow 4, directory 3, embeddings 3,
+aggregate 3, sequence 3, links 3, auth-introspection 2, attestation 2
+```
+(driven mostly by `collection.ts` / `vault.ts` / `noydb.ts` call-sites — which themselves do NOT move).
+
+---
+
+## 3. Mechanics the plan must cover
+
+- **package.json `exports`: 28 entries** (`.` + 27 subpaths). Targets are `./dist/<name>/index.{js,d.ts}` — the **public subpath names DO NOT change** (`./i18n`, `./team`, `./kernel`, …). The dist layout is driven by the tsup output key, so exports can stay byte-identical **if** the tsup output keys are kept (see next). No `typesVersions`, no `files` override surprises. Of the 46 folders, only **27 have a subpath export**; the other ~19 moved folders (computed, links, money, numbering, sequence, archive, custody, directory, auth-introspection, embeddings, search, introspection, persisted-schemas, schema-update, …) are barrel-only, so moving them touches **internal imports only**, not exports.
+- **tsup `tsup.config.ts` ENTRIES: 28 entries**, each maps an output key → **source path** e.g. `'i18n/index': 'src/i18n/index.ts'`. **These source paths DO change** → must become `'src/with-shape/i18n/index.ts'`, etc. KEEP the output key (`'i18n/index'`) unchanged so `dist/i18n/index.js` and the public subpath stay stable. This is the single most important config edit: **rewrite the RHS of all 27 subsystem ENTRIES; leave the LHS keys alone.** (`index: 'src/index.ts'` is unaffected.)
+- **tsconfig.json:** trivial — `extends: ../../tsconfig.base.json`, `rootDir: src`, `include: [src]`, `outDir: dist`. No per-subsystem path mapping, no `paths` aliases. **No change needed.** Extra folder nesting depth (src → src/with-X/sub) is irrelevant to rootDir/include.
+- **architecture `kernel-surface` ratchet** (`scripts/check-architecture.mjs`): line-count ceilings keyed ONLY on `packages/hub/src/collection.ts` (5740), `packages/hub/src/vault.ts` (4677), `packages/hub/src/noydb.ts` (3140). All three are **top-level files that STAY** → ratchet keys unaffected. No other check in `check-architecture.mjs` keys on a moving folder path (verified: no `src/<subsystem>/` path logic, only comments). Safe.
+- **No other config references subsystem source paths** — no vitest.config / knip config / eslintrc references to `src/<sub>`.
+
+---
+
+## 4. Landmines
+
+1. **`git mv` under zsh word-splitting (prior failure a).** Do NOT loop `for d in $list; git mv src/$d src/with-X/$d` in zsh — zsh doesn't word-split unquoted vars by default, so a space-joined list becomes one token and the mv mis-fires. Use an explicit per-folder `git mv` list, or `print -l`/arrays, or run the loop under `bash`, not interactive zsh. Recommend: generate one `git mv` line per folder (46 lines) and execute as a script with `set -e`.
+2. **Test-import second pass (prior failure b).** In-source codemod and test-import codemod are SEPARATE passes; the prior attempt missed the test corpus on the first run. Current scale is **LARGER than the prior 438 refs / 224 files**: see §5.
+3. **Relative-depth recompute, not prefix-swap.** Subsystems have nested files whose imports are already `../../`. A naive `s|../|../../|` is wrong. The codemod must resolve each import to an absolute module then re-emit the correct relative path from the file's NEW location. Cross-dimension imports (§2A) go from `../` to `../../with-Y/`; same-dimension nested imports may stay `../../`.
+4. **`kernel/index.ts` frozen seam.** Re-pointing kernel's *internal* imports (§2D) is fine, but confirm no exported value/type path string changes shape; the seam contract is the export set, which is preserved.
+5. **Keep tsup output keys = public subpaths.** If someone "tidies" the ENTRIES keys to `with-shape/i18n/index` while editing, every published `@noy-db/hub/i18n` subpath breaks and the exports map silently points at a non-existent dist file. Edit RHS only.
+6. **`.js` extension imports.** All imports use explicit `.js` (ESM, e.g. `from '../i18n/policy.js'`). The codemod regex must include the `.js` and the nested sub-path, not just the folder.
+7. **Barrel-only folders still need import rewrites** even though they have no export entry (§2 covers them) — don't scope the codemod to only the 27 exported subsystems.
+
+---
+
+## 5. Test-import-rewrite scale (current tree)
+
+- Total test files under `__tests__/`: **333** `.test.ts` (340 `.ts` incl. helpers).
+- Test files importing a subsystem via relative `../src/<sub>/…`: **260 files**.
+- Total such import-path references: **471**.
+- Of those, references into a **MOVED** subsystem (need rewrite): **~404** (471 minus ~67 into stays-dirs: query 22, policy 20, coordination 7, store 6, meta 5, util 3, record-keys 2, cache 2).
+- Heaviest test targets: i18n 53, history 46, bundle 39, team 38, aggregate 36, schema-update 26, money 20, tx 18, blobs 18, guards 14, search 12, persisted-schemas 11, derivations 11.
+- **This exceeds the prior attempt's 438 refs / 224 files** (growth since f6127e62), so budget the test codemod pass for ~471 refs across 260 files and re-run `pnpm --filter @noy-db/hub test` + `pnpm typecheck` after.
+
+NOTE: tests that import via the PUBLISHED subpath (`@noy-db/hub/i18n`) need NO change — public subpaths are preserved. Only relative `../src/<sub>/` deep-imports are affected.

--- a/docs/superpowers/reviews/2026-06-30-security.md
+++ b/docs/superpowers/reviews/2026-06-30-security.md
@@ -1,0 +1,331 @@
+# Security Review — `@noy-db/hub` crypto/security spine
+
+Date: 2026-06-30 · Scope: `packages/hub` (crypto primitives, envelope format, key
+management, per-record CEK, sealed `sensitive` fields, `forget()` crypto-shred, ledger
+binding, architecture guards, derived-structure leak surfaces, sealed-record/`at-*`),
+plus the security implications of the proposed "plaintext-working-set-in-RAM, codec-at-edge"
+flip. Read-only audit — nothing was modified.
+
+Method: I read the crypto/collection/ledger/sealed-record spine directly and dispatched
+three focused sub-audits (leak surfaces, forget/record-keys, sealed-record/`at-*`). Every
+load-bearing finding below was independently re-verified against source.
+
+---
+
+## Findings by severity
+
+- **High: 1**
+- **Medium: 5**
+- **Low: 11**
+- Confirmed-sound observations: see final section.
+
+The single most important issue: **H-1 — `forget()` does not delete the `_sealed_cek`
+delivery envelopes, so the per-record CEK that crypto-shred is supposed to destroy survives
+in host-recoverable form.** For an offline-first / sync / backup product this is effectively
+critical: a replica holding the pre-forget body plus the still-synced sealed-CEK envelope
+lets the granted `at-*` host fully decrypt a record the system reports as erased.
+
+---
+
+## HIGH
+
+### H-1 — `forget()` leaves the record's CEK recoverable in `_sealed_cek` envelopes
+- **Severity:** High (Critical in any multi-replica / sync / backup deployment)
+- **Where:** `src/vault.ts` `forget()` loop (~2603–2751) vs `src/record-keys/sealing.ts:60-102, 191-198`
+- **Issue:** `sealRecordToHost()` exports the record's **raw CEK bytes** and seals them to an
+  `at-*` host, persisting them at `_sealed_cek/<collection>/<id>/<pid>` (`sealing.ts:63-66, 84-102`).
+  `forget()` tombstones the live body, tombstones history, drops the live `_cek`, and purges
+  `_idx`/`_vec`/`_ftindex`/blobs — but **never touches the `_sealed_cek` namespace.** Grep
+  confirms `_sealed_cek` is deleted only by `rotateRecordCek` (sealing.ts:191-198) and
+  `revokeSealedRecord` (sealing.ts:118), never by `forget()`. The asymmetry is stark:
+  `rotateRecordCek` deletes *all* `${collection}/${id}/*` sealed-CEK envelopes precisely
+  because it is destroying the old CEK; `forget()` destroys the CEK far more permanently yet
+  omits the same cleanup.
+- **Risk:** The CEK that crypto-shred exists to destroy survives in a form the granted host can
+  unseal. In the live store the body is tombstoned so the leak is latent there; but the product
+  is **offline-first and sync-capable** — replicas, peers, and backups routinely retain the
+  pre-forget `_data` envelope. A host holding the old body envelope + the still-synced
+  `_sealed_cek` envelope recovers the full plaintext of an "erased" record, and `forget()`
+  reports complete erasure with no residue for this path (silent).
+- **Fix:** In the `forget()` per-record loop, list `_sealed_cek` and delete every key with prefix
+  `${ref.collection}/${ref.id}/` (mirror sealing.ts:192-198); surface any delete failure into a
+  `ForgetResult` residue field. Scope note: only affects records that used `sealRecordToHost`.
+
+---
+
+## MEDIUM
+
+### M-1 — Legacy DEK-derived sealed fields are mis-reported as crypto-shredded
+- **Where:** `src/vault.ts:2633-2636` (un-migrated detector + `sealedFieldsShredded` count);
+  dual-read fallback at `src/collection.ts:5568-5578`
+- **Issue:** `unsealField` dual-reads sealed slots: per-record-CEK key first, then falls back to
+  the **retained collection DEK** for pre-#306 slots (collection.ts:5576-5578). The un-migrated
+  detector only checks the body (`live._data && live._cek === undefined`). A record with a
+  migrated body (`_cek` present) but **legacy DEK-derived `_sealed` slots** is therefore *not*
+  added to `unmigratedRecords`, yet every such slot is counted into `sealedFieldsShredded` as if
+  destroyed. Dropping `_sealed` in the tombstone removes the ciphertext from the *live* store, but
+  the key (collection DEK) is retained — so any retained/synced/backed-up copy stays decryptable.
+- **Risk:** `forget()` returns empty `unmigratedRecords` + positive `sealedFieldsShredded`,
+  falsely signalling complete crypto-shred while legacy sealed values remain recoverable.
+- **Fix:** Detect DEK-derived slots (CEK-derive attempt fails) and report them in a dedicated
+  residue field; do not count them as `sealedFieldsShredded`.
+
+### M-2 — Subject-index key is an unsalted `SHA-256(subjectId)` → subject-existence brute-force
+- **Where:** `src/forget/subject-index.ts:42-54` (`subjectKey`/`sha256HexString`)
+- **Issue:** The `_subject_index` collection stores entries at `id = sha256Hex(subjectId)` with no
+  salt/pepper and no keyed hash. The module claims the store "can't correlate index entries to a
+  known subject" (subject-index.ts:11-13) — true only against an attacker with no candidate list.
+  Subject ids (emails, customer/user ids) are low-entropy and enumerable; a store-side attacker
+  can dictionary the hash to confirm "subject X has records here." Additionally the AES-GCM
+  ref-list `_data` length leaks the approximate record count per subject.
+- **Risk:** Zero-knowledge defeated for the subject→existence relation; store learns *whether* a
+  guessable subject is present and roughly how many records they own.
+- **Fix:** Key the index id with a vault-DEK-keyed PRF/HMAC (HKDF over the index DEK), not a bare
+  SHA-256, so it is not offline-computable; pad ref-list plaintext to bucketed lengths; soften the
+  docstring. (Body confidentiality itself is sound — encrypted under its own DEK.)
+
+### M-3 — Derivations fanout sidecar is written in PLAINTEXT (AES-GCM bypassed)
+- **Where:** `src/derivations/fanout-sidecar.ts:90-109` (write), `:69` (read)
+- **Issue:** The sidecar envelope is emitted with `_iv: ''` and `_data = JSON.stringify(doc)` —
+  cleartext — at `_meta/derivations-fanout/<source>/<sourceId>/<outputKey>`. The body carries
+  `source`, `sourceId`, `outputCollection`, `keys[]`, `emittedAt`. The header comment asserts "no
+  user data inside," but `keys[]` are derived-row ids produced by a **user-supplied key extractor**
+  (`executor.ts` `outSpec.key(row)`) and can be content-bearing (SKU, tag, email).
+- **Risk:** A ciphertext-only store operator reads, in plaintext, the derivation relationship graph
+  (source row → derived row ids), write-time timestamps (traffic analysis), and any content baked
+  into derived keys. The "no user data" claim is not enforced.
+- **Fix:** Route the sidecar body through the collection's `encryptJsonString`/DEK like the
+  persisted-index side-cars. If a plaintext-metadata exception is truly intended, forbid
+  content-bearing keys (hash them) and document it in the threat model.
+
+### M-4 — Sealed-record open fails OPEN on a malformed/empty `expiresAt`
+- **Where:** `src/sealed-record/index.ts:68, 86`; seal-time at `src/record-keys/sealing.ts:45-105`
+  and `src/vault.ts` `sealRecordToHost`
+- **Issue:** Both expiry checks are `Date.parse(expiresAt) <= Date.now()`. `Date.parse('')` (or any
+  non-ISO string) is `NaN`, and `NaN <= Date.now()` is `false` — so **both** checks are skipped and
+  the grant is eternal. `sealRecordToHost` passes `opts.expiresAt` into the binding with no format
+  validation, and there is no test for a malformed expiry.
+- **Risk:** A grantor passing `''` or a non-ISO timestamp silently creates a never-expiring grant;
+  the expiry control degrades to permanent.
+- **Fix:** Validate at seal time (`reject Number.isNaN(Date.parse(expiresAt))`, require future /
+  bounded TTL). At open time fail closed: `const t = Date.parse(x); if (!Number.isFinite(t) || t <= Date.now()) throw`.
+
+### M-5 — `revokeSealedRecord` does not prevent future opens (soft-only); easy to over-trust
+- **Where:** `src/record-keys/sealing.ts:112-119`; `src/vault.ts` `revokeSealedRecord`
+- **Issue:** Revoke just `adapter.delete()`s the delivery envelope. A host that already fetched it
+  (or cached the unsealed CEK) keeps decrypt capability, and an untrusted store can replay a
+  not-yet-rotated envelope. This is documented ("for hard revocation use `rotateRecordCek`"), so it
+  is a threat-model-clarity issue, not a hidden bug — but the name invites operators to assume an
+  immediate cutoff.
+- **Fix:** Make the softness explicit in the API name/docs, or add `{ hard: true }` that rotates.
+
+---
+
+## LOW
+
+### L-1 — Deterministic `_det` encryption shares the raw collection DEK with randomized `_data`
+- **Where:** `src/collection.ts:5104-5113, 5145`; `encryptDeterministic` `src/crypto.ts:592-608`
+- **Issue:** `_det` slots are AES-GCM-encrypted under the *same* collection DEK used for randomized
+  `_data` bodies, with an HKDF-derived deterministic IV. Two IV-generation regimes (random 96-bit
+  vs HKDF-derived) thus share one key and one 96-bit IV space. A collision between a derived IV and
+  a random IV under the same key breaks GCM confidentiality+integrity for those two messages.
+  Probability is negligible (~2^-96 per pair), but mixing regimes on one key is avoidable.
+- **Risk:** Low (theoretical). The documented equality side-channel of deterministic encryption is
+  separately and correctly gated behind `acknowledgeDeterministicRisk`.
+- **Fix:** Derive a dedicated key for the deterministic channel (HKDF, e.g. salt `noydb-det`), as is
+  already done for presence/sealed channels.
+
+### L-2 — Random 96-bit IV under a long-lived collection DEK (legacy non-CEK path)
+- **Where:** `src/crypto.ts:188-205, 627-629`
+- **Issue:** On the legacy (no-CEK) path many records encrypt under one collection DEK with random
+  96-bit IVs. NIST caps random-IV AES-GCM at ~2^32 invocations/key before collision risk becomes
+  non-negligible. Per-record CEK collections are unaffected (one key per record).
+- **Fix:** Document the bound; prefer `perRecordKeys` for very large/high-churn collections, or
+  rotate the DEK on a write-count threshold.
+
+### L-3 — Plaintext envelope metadata leaks to the store
+- **Where:** `EncryptedEnvelope` (`src/types.ts:118-206`)
+- **Issue:** Unencrypted at the store: `_by` (writer userId per version), `_ts`, `_v`, `_source`/
+  `_sourceTs` (provenance), `_tier`, `_elevatedBy`, and the **field NAMES** of `_det` and `_sealed`.
+  Values are encrypted; names/authorship/timestamps/tiers are not.
+- **Risk:** Metadata exposure (who wrote what, when, at which tier, which fields are sensitive).
+  Mostly by-design but should be explicit in the threat model.
+- **Fix:** Document; if field-name confidentiality is in scope, HMAC the `_det`/`_sealed` keys.
+
+### L-4 — Ledger `payloadHash` does not bind `_det` (or `_cek`, by design)
+- **Where:** `src/history/ledger/hash.ts:58-59`
+- **Issue:** The payload hash binds `_data` (+`_sealed` when present) but not `_det`. A store-write
+  attacker swapping `_det` slots is not detected by the ledger; `findByDet` could be made to
+  equivocate. The record body stays GCM-authenticated, so authentic data is unaffected. (The file's
+  own analysis of the no-`_sealed` branch non-domain-separation is sound — the collision it
+  describes only suppresses verify on an already-destroyed `_data`.)
+- **Fix:** Optionally fold `_det` into the canonical-JSON hash when present (same pattern as
+  `_sealed`).
+
+### L-5 — `stores-ciphertext-only` guard is weaker than its claim
+- **Where:** `scripts/check-architecture.mjs:264-325`
+- **Issue:** It scans only for **named** imports from `@noy-db/hub` of a fixed denylist. It misses
+  (a) namespace imports (`import * as h from '@noy-db/hub'; h.encrypt(...)`), and (b) crypto
+  functions absent from the denylist — `wrapCek`/`unwrapCek`/`deriveSealedFieldKey`/
+  `deriveSealedFieldKeyFromCek`/`derivePresenceKey`/`sha256Hex`/`hmacSha256Hex` — several of which
+  *are* re-exported from the hub root (`sha256Hex` at `index.ts:446`, `derivePresenceKey` at
+  `index.ts:687`). It is defense-in-depth only; the real guarantee is that the `NoydbStore` API
+  surface carries only `EncryptedEnvelope` and never a key (verified — all `adapter.put` callsites
+  pass envelopes). Today no `to-*` store trips it, so the invariant holds in practice.
+- **Fix:** Match namespace imports, switch the denylist to an allowlist (or flag *any* import of a
+  function whose name matches `/^(encrypt|decrypt|wrap|unwrap|derive)/`), and scan all hub subpaths.
+
+### L-6 — `hub-portable` guard misses dynamic imports, `require()`, and Node globals
+- **Where:** `scripts/check-architecture.mjs:223-262`
+- **Issue:** Static-`import`-regex only. It would not catch `await import('node:fs')`,
+  `require('fs')`, or use of Node globals (`Buffer`, `process`, `globalThis.process`). A grep
+  confirms the hub uses none of these today, so portability holds now — but the guard does not
+  enforce what it claims.
+- **Fix:** Add patterns for `import(`/`require(` of Node specifiers and for bare `Buffer`/`process`
+  usage (or run a real browser/Deno build in CI).
+
+### L-7 — `no-crypto-deps` is a denylist, not an allowlist
+- **Where:** `scripts/check-architecture.mjs:168-221`
+- **Issue:** Bans a fixed set of package names + `@noble/`/`@scure/` scopes. A crypto package not on
+  the list (e.g. `hash-wasm`, `sha.js`, `md5`, `crypto-browserify`) would pass.
+- **Fix:** Prefer an allowlist of permitted deps, or expand coverage and add a periodic review.
+
+### L-8 — Sealed-record expiry is enforced against the host's own clock
+- **Where:** `src/sealed-record/index.ts:68, 86`
+- **Issue:** The entity enforcing `expiresAt` is the host, which also holds the raw CEK after
+  unseal. A malicious host backdates its clock or skips the check entirely. Inherent to the
+  deliberate non-ZK trust model; the only real control against a malicious host is
+  `rotateRecordCek`. Should be stated explicitly in the security docs.
+
+### L-9 — No grantor authenticity on the sealed grant (RSA-OAEP, unauthenticated sender)
+- **Where:** `src/team/managed-passphrase.ts:223`; `at-aws-kms/src/index.ts:185-198`
+- **Issue:** `sealForRecipient` is plain RSA-OAEP to the host's public key. Anyone knowing the
+  host's public hint can fabricate a validly-sealed `SealedCekBinding`. Confidentiality impact is
+  low (a forged binding only opens a real record if the forger already knows that record's CEK),
+  but the host has no integrity guarantee that an opened grant reflects an actual owner decision
+  (confused-deputy flavor; matters if grant provenance is ever audited).
+- **Fix:** If provenance matters, sign the binding with a grantor key the host verifies.
+
+### L-10 — Cleartext metadata in the sealed-CEK delivery envelope
+- **Where:** `src/record-keys/sealing.ts:82-102`
+- **Issue:** The `_sealed_cek/...` envelope stores `{collection, id, pid, expiresAt}` as cleartext
+  (`_iv:''`). For an otherwise-ZK store this leaks which records are granted to which hosts and
+  until when. By design (the seal is the boundary) but worth the threat model.
+
+### L-11 — Minor leak-surface metadata + hygiene items (grouped)
+- **Indexing side-car ids** (`src/indexing/persisted-indexes.ts:33`, `collection.ts:4684`): id
+  `_idx/<field>/<recordId>` leaks indexed **field names**, per-record presence, and non-null
+  cardinality (values themselves are randomized-GCM, so no equality leak). Consistent with the
+  "ids are plaintext keys" baseline; document or HMAC the `<field>` segment.
+- **Search `_ftindex` envelope `_v`** (`collection.ts:3268`): set to `fp.count`, exposing the exact
+  record count of a searchable collection in plaintext `_v`. Pass a monotonic version instead if
+  count confidentiality matters.
+- **Raw CEK not zeroized** in `openSealedRecord` (`src/sealed-record/index.ts:73-99`): unlike
+  `MemoryRecipientSealer.unseal` which `.fill(0)`s its buffers, the opener leaves the decoded raw
+  CEK resident. Minor memory hygiene (and largely moot in V8, where key bytes also live inside the
+  non-zeroable `CryptoKey`).
+
+---
+
+## CONFIRMED SOUND
+
+Crypto primitives (`src/crypto.ts`):
+- PBKDF2-SHA256 @ 600K iterations / 32-byte salt; AES-256-GCM with a fresh `getRandomValues`
+  12-byte IV per call; AES-KW DEK/CEK wrapping; SHA-256 content hashes; HMAC-SHA256 blob eTags
+  (keyed by the blob DEK, so a store attacker can't precompute eTags for known files). No npm crypto
+  deps — `crypto.subtle` only.
+- **HKDF domain separation is consistent and correct** across every derived key: CEK-wrap KW key
+  (`asKwKey`, salt `noydb-cek-wrap`), presence (`noydb-presence`), per-field sealing from DEK
+  (`noydb-sealed`) and from CEK (`noydb-sealed-cek`, distinct salt so the two can never collide for
+  the same `{collection,field}`), and the deterministic IV (`noydb-deterministic-v1`). The sealing
+  `info` is an injective `JSON.stringify([...])`, blocking concatenation-collision attacks.
+
+Central invariant — encryption before any store call:
+- Every `adapter.put` callsite in `collection.ts` receives an envelope produced by
+  `encryptRecord`/`encryptJsonString`/`buildTombstone`. Only `EncryptedEnvelope`s reach the store.
+- `ramCiphertext` is currently an inert, default-`false` plumbed flag (the documented hook for the
+  future flip); `storeCiphertext = opts.encrypted` is the single gate for all encryption.
+
+Per-record CEK + sealed fields (#306/#503):
+- CEK-era crypto-shred genuinely works: `buildTombstone` (record-keys/tombstone.ts:45-54) emits only
+  `{_noydb,_v,_ts,_iv:'',_data:''(,_by)}` — dropping `_cek`/`_data`/`_det`/`_sealed`. With the CEK
+  gone and CEK-derived sealed-field keys (`deriveSealedFieldKeyFromCek`), body + current-format
+  sealed slots are unrecoverable. History snapshots share the stable CEK and are re-tombstoned by
+  `tombstoneHistory`, so every wrapped CEK copy in the canonical store is destroyed — **except** the
+  `_sealed_cek` copy (H-1).
+- `SealedHandle` (types.ts:330-346) holds only a `#reveal` closure over ciphertext; invisible to
+  `JSON.stringify`/`util.inspect`/`Object.keys`, `toJSON()` → `'[sealed]'`. The write/read/cache
+  paths populate the working-set cache with handles via `toCacheRecord`, so sealed plaintext is
+  never resident. Non-residency invariant holds.
+- The `#306` dual-read fallback (`unsealField`, collection.ts:5568-5578) correctly prevents data
+  loss on pre-#306 records (its erasure caveat is M-1).
+- Ledger `payloadHash` correctly widens to bind `_sealed` when present (hash.ts:58-59), with a
+  sound back-compat + collision analysis.
+
+Key management:
+- DEKs are KEK-wrapped (AES-KW) and stored per-collection in the keyring; KEK derived per
+  passphrase+salt; a keyring canary (`mintKeyringCanary`/`verifyKeyringCanary`) detects wrong
+  passphrases without exposing a DEK. Rotation re-wraps all DEKs under a fresh KEK.
+
+Sealed-record / `at-*`:
+- Host opener is genuinely DEK-free; per-record unique CEK + sealed `{collection,id}` binding +
+  authoritative (sealed) `expiresAt` re-check defeat cross-record replay and envelope tampering;
+  `rotateRecordCek` is a real hard revocation that deletes all delivery envelopes. Only `at-aws-kms`
+  implements the recipient/grant path; gcp/azure/env/macos are self-only providers with no
+  `sealForRecipient` — a compromised `at-*` host cannot escalate beyond its explicit per-record
+  grants (no DEK, no other CEK).
+
+Derived-structure leak surfaces:
+- **No deterministic encryption anywhere in indexing/search/embeddings** — all use randomized
+  AES-GCM, so the classic "Tier-B" equality leak on index values does **not** exist at the store.
+  Index side-car values, `_vec` embeddings, the `_ftindex` inverted index, and MV/overlay/
+  derivation **output rows** are all ciphertext at rest. `computed`/`aggregate` are pure in-RAM.
+- The plaintext LRU **cache is verifiably RAM-only**: a bare `Map`, no adapter import, no
+  serialize-to-store, cleared on rotation, dropped on close, not exposed via any persisted path.
+
+---
+
+## Security implications of the proposed invariant flip
+"plaintext working set in trusted RAM; encryption is a store-edge codec applied only at real
+boundaries (disk/network/export)," dissolving `to-memory`.
+
+What stays the same:
+- At the *real* untrusted boundary (cloud store, file, sync peer, export) data is still
+  AES-256-GCM, and key management (DEK/CEK/wrapping/HKDF) is unchanged. Zero-knowledge at the
+  actual egress is preserved **iff** the codec is applied at every egress.
+
+What it weakens / new care needed (concrete):
+1. **The trust boundary moves from one mechanically-checkable choke point to an open set.** Today
+   the rule is "encrypt before `adapter.put`" — a single, greppable seam. The flip makes correctness
+   depend on enumerating *every* egress: disk, network, export, blobs, sync ops, snapshots, ledger
+   persistence, backups, and **OS swap/core dumps**. Miss one and plaintext lands at the store. The
+   `stores-ciphertext-only` guard is already weaker than it claims (L-5); under the flip it becomes
+   load-bearing and must be replaced by a *type-level* `StoreEdgeCodec` seam that makes an
+   un-encoded persisted/networked egress unrepresentable (the budget comments already foreshadow a
+   "P2-T3 StoreEdgeCodec extraction" — that is the right direction and should be a hard gate).
+2. **Blast radius of memory disclosure goes from a bounded hot LRU slice to the entire dataset.**
+   The plaintext cache today is opt-in and bounded; a plaintext-resident *working set* exposes
+   everything to a heap dump, core dump, or in-process read bug. **Swap is the sharp edge**: the OS
+   paging the plaintext working set to disk silently defeats encryption-at-rest. Treat host RAM as
+   the new TCB; document it, and use `mlock`/secure-buffer where available.
+3. **Sealed-field non-residency (#503/#306) regresses by default unless specially preserved.** The
+   entire point of `SealedHandle` is that sensitive plaintext is *never* resident. A plaintext
+   working set must keep sealed fields as handles/ciphertext even in RAM, or the flip silently
+   undoes #306. This needs an explicit invariant + test.
+4. **`forget()` semantics change.** Crypto-shred today = destroy the key. With plaintext resident in
+   RAM (and in plaintext indexes/derivations), `forget()` must also scrub the RAM working-set copy
+   and any plaintext derived structures — key destruction no longer suffices. JS/V8 cannot reliably
+   zero strings (immutable, GC-managed), so this is a genuine gap to design around.
+5. **A silver lining, if the codec is done right:** today the store sees `_det` equality classes and
+   `_sealed`/`_det` field names persisted. If derived structures live as plaintext in RAM and are
+   re-encrypted (randomized) by the edge codec, the persisted `_det` equality side-channel and the
+   metadata-in-envelope leaks (L-3, L-4, L-11, and the `_det` equivalence leak) can be *removed* at
+   the store — provided the codec re-encrypts indexes rather than passing them through. This should
+   be an explicit design goal of the flip, not an accident.
+
+Net: the flip does not inherently weaken at-rest/at-network confidentiality, but it relocates the
+invariant from a single enforceable seam to a property of "all egress paths," dramatically enlarges
+the RAM-disclosure and swap blast radius, and puts the sealed-field non-residency and `forget()`
+guarantees at risk unless each is explicitly re-established. Make the edge codec a type-level seam,
+re-establish non-residency and RAM-scrub-on-forget as tested invariants, and address swap before
+shipping.

--- a/docs/superpowers/specs/2026-06-30-edge-crypto-kernel-optimization-design.md
+++ b/docs/superpowers/specs/2026-06-30-edge-crypto-kernel-optimization-design.md
@@ -1,0 +1,88 @@
+# Edge-crypto kernel optimization — plaintext working set, crypto at the boundary
+
+> **Status:** design, for review (2026-06-30). Reconstructed from a verified storage-layer audit (transcript 2026-06-28/29) that walked the reorganized hub and traced the in-memory representation end to end. Pairs with the `with-*` reorg spec but is independent. **This spec proposes flipping a central noy-db invariant — it is the high-stakes one; nothing here ships without explicit go-ahead.** The security review (overnight) assesses the flip's implications; fold its findings in before implementation.
+
+## The current invariant
+
+> *Encryption (AES-256-GCM) happens inside `@noy-db/hub` before **any** store call.*
+
+Uniform and maximally paranoid: every store — even a pure in-memory one — only ever holds `EncryptedEnvelope` ciphertext, enforced at build time by `check-architecture.mjs` Check 4 (`stores-ciphertext-only`). This is the property that lets any `to-*` backend be a dumb, untrusted ciphertext blob.
+
+## The discrepancy the reorg walk surfaced
+
+Two top-level kernel neighbors, `cache/` and `to-memory`, sit on **opposite sides of the encryption boundary** — and that exposes a redundancy:
+
+- **`to-memory`** is a **store**: nested `Map`s of `EncryptedEnvelope` — **ciphertext**, *outside* the trust boundary, a pluggable satellite (verified: 0 files in `cache/` implement `NoydbStore`; it is `class Lru`, not a store).
+- **`cache`** (the hub `Lru`) caches **decrypted records** — **plaintext**, *inside* the trust boundary, hub-internal.
+
+They are separated by `crypto.subtle` and can never be interchangeable. And `collection.ts` holds the decrypted working set in **one** field (verified): eager default `private cache = new Map<id,{record,version}>()` (a full map of every decrypted record), or lazy `private lru: Lru | null` (bounded). The query DSL iterates this in-RAM **plaintext** map directly (`[...this.cache.values()].map(e => e.record)`).
+
+**The redundancy:** with `to-memory`, one record is resident in RAM **twice** — ciphertext in the store's `Map` *and* plaintext in `collection.cache`. ~2× memory. For persistent stores (`to-file`) the two copies are sensible (ciphertext on disk, plaintext in RAM); for a pure in-memory store they are the **same data, doubly resident**. And the security value of the ciphertext copy there is near-zero: encrypting *for an in-process RAM store* is "encrypting to yourself in trusted memory" — an attacker with process-memory access already reads `collection.cache` in plaintext. It buys **contract uniformity**, not secrecy — and not for free.
+
+The deeper cost is the **eager default**: opening a collection does `loadAll` + decrypts the *entire* collection into `this.cache`. The whole DB sits decrypted in RAM, and a memory dump reveals everything.
+
+## What must actually be decrypted — the four-bucket tier analysis
+
+Cutting the catalog by *how much plaintext each operation needs* (verified against `decryptRecord` call sites + the architecture invariant):
+
+| bucket | what decrypts | features |
+|---|---|---|
+| 🟢 **NONE** (ciphertext / key / envelope only) | nothing | `party/sync` (replicates envelopes) · `fork/{bundle,snapshots,archive}` (ciphertext passthrough) · `audit/forget` (key-shred) · `audit/{attestation,sealed-record}` (sign hashes/keys) · `party/{team,session,custody}` (key wrap/unwrap) · `introspection` (schema only) · the store layer |
+| 🔵 **RESULT / CURSOR** (just the records you return) | only the N matched rows | `read`/`get(id)` · **indexed** `query`/`scan` cursor · `formula/computed`·`derivations` (one source row) · `commit/history` diff/revert (two versions of one record) · `fork/shadow` · `commit/crdt` · `shape/blobs` · `shape/{i18n,money}` read transform · `search`/`embeddings` **query** |
+| 🟡 **COLUMN(S) / INDEX** (specific fields, kept resident as index metadata — *the leak surface*) | the indexed field(s) | `lookup/indexing` (`Map<value, ids>`) · `lookup/embeddings` (vectors) · core `refs` (FK id) · `audit/{periods,guards}` (period-date / frozen field) · `shape/links` · `party/user-envelope`·`directory` (profile fields) |
+| 🔴 **ALL DATA** (full scan — the enemy) | every record | **unindexed** `query`/filter · `lookup/aggregate` on an unindexed field · `search`/`embeddings` **index build** (once) · `formula/materialized-views` **full refresh** · `fork/vault-diff` whole-vault · *(today's default)* eager `loadAll` on open |
+
+**The decisive observation:** 🔴 is not a fixed list of features — it's the list of *un-indexed / first-build / full-rebuild* operations. Every 🔴 entry has a 🔵/🟡 path once an index exists or once it goes incremental. 🟢 is ~a third of the catalog (`fork` + `sync` + key/seal ops) and runs untouched on ciphertext.
+
+## The proposed model — plaintext core, crypto at the edge
+
+> *Keep the working set as **plaintext in trusted process RAM**. Make encryption a **store-edge codec** applied only when data crosses a **real** boundary — disk (`to-file`), network (`sync`), export (`bundle`). The integrity envelope (hash-chain, signatures) is part of the same codec: applied on the way out, verified on the way in.*
+
+```
+        TRUSTED (your process RAM)        │  UNTRUSTED (the edge & beyond)
+  ┌────────────────────────────────┐     │
+  │  plaintext working set          │ ──encrypt──▶  to-file (disk)
+  │  (the Collection's record map)  │ ◀─decrypt──   sync (cloud/peer)
+  │  queries/derivations/diff run   │ ──encrypt──▶  bundle (export)
+  │  here, directly, fast           │     │
+  └────────────────────────────────┘     │
+        ONE plaintext copy                   ciphertext ONLY at/past the edge
+```
+
+This is the **mainstream, proven** shape, not an exotic one: SQLCipher decrypts pages into a plaintext page cache and encrypts at the disk edge; Postgres TDE and every "encryption at rest + TLS in transit" database has the same form — **plaintext in the trusted process, ciphertext at the boundary.** (An earlier "ciphertext-resident in RAM" idea was the unusual one and was rejected: you can't usefully compute on encrypted data, and your own keyed RAM is the trusted space — encrypting against yourself is theater.)
+
+### Consequences
+
+1. **`to-memory` dissolves.** A pure in-memory DB crosses no boundary → no encryption → no ciphertext → no store object needed. The plaintext working set *is* the database. `to-memory` drops from the 5 essentials (the built-in `MemoryStore` already covers dev/test/prototyping — see "Already shipped").
+2. **`cache` stops being a "cache" — it's the buffer pool.** In lazy mode, a *bounded* plaintext buffer paging from an encrypted persistent store (decrypt-in, evict-cold). In eager mode, the whole thing. Either way it's not redundant — it's the in-memory DB.
+3. **Crypto becomes opt-in at the edges, like the subsystems.** Cross no boundary → pay no crypto. Pure in-memory + no audit ledger = **zero encryption**, plaintext only. "Control through smallness" applied to crypto itself.
+4. **Derived structures already obey this.** Indexes (`_idx/<field>/<id>`), full-text (`cb.save(serializeIndex(...))`), and MV outputs are all **encrypted at the store** (guaranteed by Check 4) and **decrypted into RAM** to be used. So records *and* their indexes *and* search *and* MVs already follow "plaintext in RAM, ciphertext at the edge" — `to-memory` was the *sole* piece that didn't fit. Removing it makes the model uniform.
+
+## The honest cost — what the flip changes
+
+This **inverts the central invariant** from "encryption before *any* store call" (uniform, maximally paranoid) to "encryption at the trust boundary (codec)". The trade:
+
+- **What weakens:** the *uniformity* guarantee. Today `stores-ciphertext-only` is absolute — a store can never receive plaintext. Under edge-crypto, the boundary moves: the in-memory working set is plaintext by design, and the codec is what guarantees ciphertext *past the edge*. The build-time guard must be re-expressed as "ciphertext at the **persistent/transport/export** edge," not "ciphertext at every store call." This needs a new, equally-mechanical guard — the security review must confirm it can be enforced as strongly.
+- **What stays exactly the same:** the at-rest (disk), in-transit (sync), and export (bundle) guarantees — those edges always encrypt. Zero-knowledge against the *backend* is unchanged (the backend still only ever sees ciphertext). The keyring/permission model is untouched.
+- **The Tier-🟡 leak is RAM-only and unchanged in size.** Indexed field values, vectors, ref-ids, profile fields are derived-plaintext metadata resident in RAM. They are resident today too (in `collection.cache` and the in-RAM index maps). Edge-crypto doesn't widen this; it just states the boundary honestly. Nothing queryable-in-plaintext ever reaches the store (the store-usable blind-index / SSE path stays gated and unbuilt).
+
+## Already shipped (the enabler)
+
+- **Built-in `MemoryStore` + optional `store`** — `createNoydb()` is zero-config, in-RAM out of the box (`packages/hub/src/store/memory-store.ts`, `createNoydb({ store? })` now optional). Landed on `main` (`e1f5ba90`). This is what makes dropping `to-memory` viable: the kernel covers dev/test; you install `to-file`/`to-postgres` only when you want persistence.
+
+## Phasing (high level — detail in the plan)
+
+- **P1 — built-in store (DONE).**
+- **P2 — store-edge codec seam.** Formalize encrypt-on-write-out / decrypt-on-read-in as a codec at the `adapter`/`store` edge (the `feat/p2-edge-codec-seam` exploration is the seed). Re-express the `stores-ciphertext-only` guard as `ciphertext-at-the-persistent-edge`.
+- **P3 — dissolve `to-memory`.** Demote from the 5 essentials; document migration (use the built-in store).
+- **P4 — `cache` → buffer pool framing.** Rename/reframe; consider lazy-by-default (large-collection memory + the whole-DB-in-RAM exposure). This intersects the refactoring review.
+
+## Risks
+
+- **The invariant flip is load-bearing and widely assumed.** Many docs/specs state "encryption before any store call." All must be updated atomically with the guard change, or the architecture story becomes inconsistent.
+- **Lazy-by-default is a behavior change** (offline-first eager reads are a feature). Evaluate separately; don't bundle silently.
+- **Security review gating.** Do not re-express the ciphertext guard until the security review confirms the edge formulation is enforceable at the same strength.
+
+## Relationship to the reorg
+
+Independent. The reorg relocates *optional* subsystems into `with-*`; this spec reshapes the *kernel/plumbing* (`store/`, `cache/`, `to-memory`). If sequenced, reorg first (clean top-level kernel surface), then edge-crypto.

--- a/docs/superpowers/specs/2026-06-30-hub-src-with-dimension-reorg-design.md
+++ b/docs/superpowers/specs/2026-06-30-hub-src-with-dimension-reorg-design.md
@@ -1,0 +1,77 @@
+# Hub `src/` reorganization — `with-*` dimension folders
+
+> **Status:** design, for review (2026-06-30). Reconstructed from the original brainstorm + the verified prototype commit `f6127e62` ("refactor(hub): group optional subsystems into 7 dimension folders", on `feat/family-folders`, gate-green when committed). That prototype used bare folder names (`lookup/`); this spec finalizes the naming as a `with-` prefix and re-derives the move on current `main`. Pairs with the edge-crypto kernel-optimization spec (`2026-06-30-edge-crypto-kernel-optimization-design.md`); the two are independent but reference the same folder layout.
+
+## Problem
+
+`packages/hub/src/` is **flat** — ~45 sibling folders + ~20 top-level files, with no structural signal separating the always-on **kernel** from the opt-in, tree-shakeable **subsystems**. `SUBSYSTEMS.md` declares "a minimalist core + 24 opt-in subsystems," but the source layout doesn't show it: `crypto.ts` (core) and `materialized-views/` (a 1,600-LOC optional subsystem) sit at the same level. A new reader can't see the trust boundary or the core/optional split by looking at the tree, and the catalog's central claim isn't reflected in the code's shape.
+
+## Goal
+
+Group the optional subsystems into **7 dimension folders**, each prefixed `with-`, leaving the kernel + plumbing at `src/` top level. Make the catalog's core/optional split **visible in the filesystem**, with **zero change to the public API** (subpath exports and `dist/` layout stay byte-identical).
+
+## Design
+
+### The 7 dimension folders
+
+Each folder is a **dimension of capability the kernel deliberately lacks** — a coherent group of subsystems a developer opts into.
+
+| folder | the power it adds | subsystems inside |
+|---|---|---|
+| `with-lookup/` | find by content, not id | aggregate · embeddings · indexing · search |
+| `with-commit/` | safe, recorded, ordered change | crdt · history · numbering · sequence · tx |
+| `with-formula/` | spreadsheet-style derived data | computed · derivations · materialized-views · overlay-views |
+| `with-shape/` | how data is typed & formed | blobs · i18n · introspection · links · money · persisted-schemas · schema-update |
+| `with-audit/` | provable history of truth | attestation · consent · forget · guards · periods · sealed-record |
+| `with-fork/` | copies that leave the timeline | archive · bundle · shadow · snapshots |
+| `with-party/` | many principals, one vault | auth-introspection · custody · directory · session · sync · team |
+
+**36 subsystems** across 7 dimensions. (The catalog headline of "24 subsystems" counts developer-facing *features*; several share a source folder or split into eager/lazy arms, so the folder count is higher. The reorg does not change the catalog count — only where the source lives.)
+
+### What stays at `src/` top level — the kernel + plumbing
+
+What a developer must read to trust the core:
+
+- **dirs:** `kernel/` · `query/` · `meta/` · `record-keys/` (kernel-side crypto/CEK) · `adapter/` · `store/` · `cache/` · `coordination/` · `policy/` · `util/`
+- **files:** `collection.ts` · `vault.ts` · `noydb.ts` · `crypto.ts` · `schema.ts` · `refs.ts` · `types.ts` · `errors.ts` · `events.ts` · `validation.ts` · `subsystem-bus.ts` · `write-hooks.ts` · `write-queue.ts` · `debug.ts` · `env-check.ts` · `constants.ts` · `index.ts` · `vault-diff.ts` · `tab-coordination.ts` · `tab-write-relay.ts` (~20)
+
+> The **reorg-readiness inventory** (overnight review) re-validates this mapping against current `main` and flags any folder added since `f6127e62` (e.g., #306 work) that needs a target. Treat the inventory's output as the authoritative file list for the plan.
+
+### Naming rationale — why `with-`
+
+1. **The prefix mirrors the opt-in API.** Every subsystem is enabled by a `with<Name>()` strategy factory passed to `createNoydb(...)`. A folder named `with-lookup/` holds exactly the things you turn on with a `with…()` call — the layout *teaches* the mental model instead of just storing files.
+2. **It extends the family's grammar inward.** The whole product is built on prefix grammar — `to-`, `in-`, `on-`, `as-`, `by-`, `at-` for the satellite packages (CLAUDE.md: "the central mental model for the whole family"). `with-*` applies the same convention to hub-internal optional subsystems — one consistent naming story, outside and inside.
+3. **Flat but grouped, minimal churn.** A prefix keeps today's directory depth (one segment, like the `f6127e62` prototype) so it does **not** deepen every import path or re-trigger the codemod over `tsconfig` `extends` depths. All `with-*` folders sort together in the tree, giving the visual grouping of a wrapper without the path cost of a nested `subsystems/` level. (Alternatives considered: nested `subsystems/` — most self-documenting but deeper paths; `ext-`/`opt-` — fine but don't connect to the API. `with-` was chosen for the API mirror.)
+
+### The invariant: invisible to consumers
+
+The reorg moves **source paths only**. It must preserve, byte-for-byte:
+
+- **All 28 `package.json` `exports` subpath targets.** `@noy-db/hub/indexing`, `@noy-db/hub/aggregate`, etc. resolve to the same built output. The export *keys* are per-subsystem, not per-dimension, so they never reference a dimension folder name.
+- **The `dist/` top-level layout stays flat** — no `dist/with-lookup/`. The `tsup` multi-entry config names entry *keys* (`indexing`, `aggregate`, …); only the entry *source paths* change (`src/indexing/index.ts` → `src/with-lookup/indexing/index.ts`).
+- **The `kernel-surface` ratchet is untouched** — `collection.ts`/`vault.ts` do not move and are not decomposed here.
+
+This is the same property `f6127e62` verified: typecheck ✓ · build ✓ · full test suite ✓ · `check:architecture` ✓, with every subpath present and `dist/` unchanged.
+
+## Non-goals (explicitly out of scope)
+
+- **No file renames** beyond the dimension-folder move. Subsystem folder names (`indexing`, `materialized-views`) are preserved *inside* their dimension.
+- **No `collection.ts`/`vault.ts` decomposition.** Kernel-surface reduction is the edge-crypto spec's concern + a separate refactor; this spec only relocates optional subsystems.
+- **No `exports`/subpath restructure.** The public surface is frozen.
+- **No behavior change.** Pure source relocation + import rewrite.
+
+## Risks & landmines (from the prototype run)
+
+- **R1 — `git mv` under zsh word-splitting.** The first prototype `git mv` loop fired once on a space/word-split list and mis-placed `auth-introspection`. The plan must use a split-safe loop (explicit array / `while read`) and verify with a post-move inventory diff.
+- **R2 — test imports need a second codemod pass.** The src-only import rewrite missed `__tests__` files importing via `../src/<subsystem>/` (438 refs across 224 files in the prototype). The plan runs the codemod over **both** `src/` and `__tests__/`, verified by typecheck (the `.test.ts` ratchet now compile-checks every test file, so a missed import fails the gate — a safety net the prototype didn't have).
+- **R3 — cross-dimension imports.** Subsystems that import siblings now in a different dimension (e.g. `materialized-views` → `derivations`, both `with-formula` — fine; but `guards` (`with-audit`) → `history` (`with-commit`) crosses dimensions) must have those imports rewritten to `../with-X/...`. The reorg-readiness inventory enumerates these.
+- **R4 — staleness.** `f6127e62` is 21 commits behind `main` and conflicts; do **not** rebase it. Re-derive the move on current `main` from the mapping. Commit into a worktree immediately so the work is durable (the prior attempt was lost as uncommitted worktree state).
+
+## Verification
+
+All gates from `/Users/vicio/lanna-db/noy-db`, after the move:
+`pnpm --filter @noy-db/hub typecheck` (src + `.test.ts` ratchet) · `pnpm --filter @noy-db/hub build` · `pnpm --filter @noy-db/hub test` (expect the same count as pre-move) · `node scripts/check-architecture.mjs` · a `dist/` + `exports`-targets diff proving byte-identical public output.
+
+## Relationship to the edge-crypto spec
+
+Independent but complementary. This spec relocates the **optional** subsystems; the edge-crypto spec reshapes the **kernel/plumbing** at top level (`store/`, `cache/`, dissolving `to-memory`). Doing the reorg **first** gives the edge-crypto work a clean top-level kernel surface to operate on. Neither blocks the other; if sequenced, reorg → edge-crypto.

--- a/docs/superpowers/specs/2026-06-30-target-architecture-north-star.md
+++ b/docs/superpowers/specs/2026-06-30-target-architecture-north-star.md
@@ -1,0 +1,54 @@
+# Target architecture — the noy-db microkernel (north star)
+
+> **Status:** north-star design (2026-06-30). The umbrella the phase specs serve. Goal, in the owner's words: *"regain human control on clear, organized partitions and domains."* This doc defines the target shape; the phase specs/plans (reorg, edge-crypto, …) and the overnight reviews are the route to it.
+
+## The thesis
+
+noy-db should be a **microkernel**: a tiny always-on core, surrounded by concentric layers that each have **one responsibility, a named seam, and the ability to be understood and changed in isolation**. Adding a capability must flow into the right layer — never swell the kernel. Today it doesn't: the architecture review found the three always-on files at **13,525 LOC** (vs a documented ~6,500 core), ~13 subsystems hard-wired into the kernel by named strategy fields, and the kernel-surface ratchet rising ~45% as an approval queue. The refactoring closes that gap.
+
+## The concentric domains
+
+From the outside in — each is a partition with a clear boundary:
+
+| Layer | What it is | Seam / how it plugs in | State today |
+|---|---|---|---|
+| **Family packages** | the `to- in- on- as- by- at-` satellites — the only code that touches the wire/edge | npm packages, prefix grammar, bind published subpaths | organized by prefix; some live in `noy-db-to` |
+| **Optional subsystems** | opt-in capability *dimensions* — lookup · commit · formula · shape · audit · fork · party | `with-*` source folders + `with<Name>()` strategy + subpath export, registered on the **subsystem-bus** | flat folders; bus under-adopted (only periods+guards migrated) — **Phase 2 + 5** |
+| **Encryption transformers** | encryption as a **pluggable codec at the boundary**, not a fixed invariant — enabling **full / partial / no** encryption per store/field | a typed `StoreEdgeCodec` seam applied at every real egress (disk/net/export) | invariant is "encrypt before any store call"; `ramCiphertext` is an inert hook — **Phase 4** |
+| **Surfaces & contracts** | the **outbound exchange seams** to the sister frameworks | `@noy-db/hub/kernel`→klum-db · `@noy-db/hub/adapter`→noy-db-to · `collection.describe()`+design-tokens→noy-db-ui · published packages→noy-db-docs | kernel+adapter exist; ui+docs implicit — **Phase 3** |
+| **Core essentials** | what noy-db *is*: vault · collection · query basics · keyring · schema/refs · envelope crypto | the always-on classes | correct but bloated (god-objects) — **Phase 1 + 5** |
+| **Kernel / microkernel** | the minimal runtime + the extension bus everything registers on | `kernel/` (frozen seam) + `subsystem-bus.ts` | real but small relative to what bypasses it — **Phase 5** |
+
+## The three north-star commitments (owner's framing, beyond the current specs)
+
+1. **Encryption is a transformer, not a law.** Generalize the edge-crypto codec from "plaintext-in-RAM / encrypt-at-edge" to a **configurable transform** that can be **full, partial (per collection/field), or none**. This makes an unencrypted or selectively-encrypted datastore a *supported configuration*, not a fork — the codec is chosen at the boundary. (Widens the edge-crypto spec.)
+2. **Every sister-framework exchange is an explicit, documented contract.** Four seams, first-class and versioned: `/kernel` (klum-db orchestration), `/adapter` (noy-db-to stores), `describe()` + `--nui-*` tokens (noy-db-ui), and the published-package surface (noy-db-docs). The "surfaces & contracts" layer is where cross-framework coupling is allowed to live — and *only* there.
+3. **The microkernel is the evolution model.** New capability = a new dimension that registers on the bus, never a kernel edit. The `with-*` dimensions + the subsystem-bus are the seed; the success test is that `collection.ts`/`vault.ts` *stop growing* when a subsystem is added.
+
+## Success criteria (how we know we're done)
+
+- A reader can open `hub/src/` and **see the partitions** (family / `with-*` subsystems / kernel + plumbing) without a guide.
+- The four cross-framework contracts are named, documented, and the *only* places coupling crosses a repo boundary.
+- Encryption is a chosen codec: a config produces a full / partial / unencrypted store with no source fork.
+- Adding a subsystem touches its own `with-*` folder + a bus registration — **not** `collection.ts`/`vault.ts`.
+- The kernel-surface numbers reconcile with the docs (the "minimalist core" claim becomes load-bearing again).
+
+## Execution roadmap (each phase = one reviewed PR, checkpointed)
+
+| Phase | What | Serves | Spec |
+|---|---|---|---|
+| **0 (done)** | H-1/M-1 forget() erasure fixes; built-in MemoryStore | correctness floor | shipped `8e6a3217`, `e1f5ba90` |
+| **1** | Extract `record-codec.ts` (envelope+crypto+CEK+sealed dual-read; `buildEnvelope()`) | de-dup before move; the encryption-transformer seed; "encryption-in-the-hub" as a module | reorg-plan Prerequisite + edge-crypto P0 |
+| **2** | `with-*` dimension reorg (+ catalog-drift fixes + test layout) | the optional-subsystem partition | `…-hub-src-with-dimension-reorg-design.md` |
+| **3** | Formalize the 4 surfaces & contracts (kernel/adapter/ui/docs) as documented seams | the exchange layer | this doc → a contracts spec |
+| **4** | Encryption transformer: `StoreEdgeCodec` seam → partial/none capability → dissolve `to-memory` | the transformer layer | `…-edge-crypto-kernel-optimization-design.md` (widened per commitment 1) |
+| **5** | Kernel-shrink: god-object decomposition + subsystem-bus adoption | the microkernel | refactoring review items #5–#11 |
+
+Independent: `noy-db-docs` extraction (orthogonal; gated on its own source-of-truth question — see `reviews/2026-06-30-noy-db-docs-extraction.md`); the remaining Medium security items (M-2…M-5).
+
+## Guardrails for the autonomous run
+
+- Each phase lands as **one reviewed PR** through protected `main`; nothing irreversible without a checkpoint.
+- **Public API + `dist/` stay byte-identical** through the reorg (subpaths frozen).
+- **Security gates are hard** (Phase 4): a type-level codec, preserved sealed non-residency, `forget()` RAM-scrub, swap care — Phase 4 does not ship until these hold.
+- TDD + adversarial review on every code phase; the security spine is re-audited after Phases 1 and 4.


### PR DESCRIPTION
Design docs for the hub refactoring arc (no code changes). Adds: the target-architecture north-star; the with-* reorg + edge-crypto specs & plans; the 5 overnight review reports (security/architecture/refactoring/reorg-readiness/noy-db-docs); the morning review package. Reference material the code phases trace to.