### PR TITLE
fix(hub): include blob collections in vault.dump()/.noydb so covers travel in the bundle

### DIFF
--- a/packages/hub/__tests__/bundle-blobs-roundtrip.test.ts
+++ b/packages/hub/__tests__/bundle-blobs-roundtrip.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Bundle-includes-blobs round-trip tests.
+ *
+ * Regression guard for the consumer bug where `vault.dump()` / the
+ * `.noydb` bundle excluded the `_blob_*` collections, so blob content
+ * ("covers") never travelled inside the bundle — a restored vault had
+ * dangling blob references (the bytes were gone).
+ *
+ * The fix is dump-side only: `dump()` now enumerates the blob
+ * collections (the three global ones plus the per-user-collection
+ * slots/versions) alongside the ledger/schema/sequence internals.
+ * `load()` already restores `backup._internal` generically, and the
+ * blob DEK already travels in `_keyring`, so restored covers decrypt.
+ *
+ * Before the fix, the assertions that the `_blob_*` collections are
+ * present in the backup JSON, and that the restored cover reads back
+ * byte-identical, both FAIL.
+ *
+ * Setup mirrors blob-set.test.ts / per-blob-cek.test.ts (blob API) and
+ * verifiable-backup.test.ts (dump/load + history + fresh-vault restore).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { withBlobs } from '../src/with-shape/blobs/index.js'
+import { withHistory } from '../src/with-commit/history/index.js'
+import {
+  BLOB_INDEX_COLLECTION,
+  BLOB_CHUNKS_COLLECTION,
+  BLOB_SLOTS_PREFIX,
+} from '../src/with-shape/blobs/blob-set.js'
+import { ConflictError } from '../src/errors.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+
+// Realistic in-memory store: `loadAll` filters out underscore-prefixed
+// (internal) collections, exactly like the real adapters — so dump()'s
+// explicit enumeration of the blob collections is what makes them
+// travel. `saveAll` preserves any existing internal collections.
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) {
+        for (const [name, coll] of existing) {
+          if (name.startsWith('_')) comp.set(name, coll)
+        }
+      }
+      store.set(c, comp)
+    },
+  }
+}
+
+const SECRET = 'correct-horse-battery-staple-long-enough'
+
+function cover(n: number): Uint8Array {
+  // Deterministic few-KB "cover" image stand-in.
+  const buf = new Uint8Array(n)
+  for (let i = 0; i < n; i++) buf[i] = (i * 31 + 7) & 0xff
+  return buf
+}
+
+describe('bundle includes blobs (dump → load round-trip).', () => {
+  it('blob covers travel inside the bundle and restore byte-identical', async () => {
+    const sourceStore = memory()
+    const sourceDb = await createNoydb({
+      store: sourceStore,
+      user: 'alice',
+      secret: SECRET,
+      blobStrategy: withBlobs(),
+      historyStrategy: withHistory(),
+    })
+    const sourceVault = await sourceDb.openVault('demo-co')
+    const books = sourceVault.collection<{ title: string }>('books')
+    await books.put('book-1', { title: 'Moby Dick' })
+
+    const coverBytes = cover(4096)
+    await books.blob('book-1').put('cover.png', coverBytes, { mimeType: 'image/png' })
+
+    // Sanity: the blob collections are populated in the source store.
+    expect((await sourceStore.list('demo-co', BLOB_INDEX_COLLECTION)).length).toBeGreaterThan(0)
+    expect((await sourceStore.list('demo-co', BLOB_CHUNKS_COLLECTION)).length).toBeGreaterThan(0)
+    expect((await sourceStore.list('demo-co', `${BLOB_SLOTS_PREFIX}books`)).length).toBeGreaterThan(0)
+
+    const backupJson = await sourceVault.dump()
+    const backup = JSON.parse(backupJson)
+
+    // The fix: the blob collections are now present in the bundle's
+    // _internal section. Before the fix, _internal had only the
+    // ledger/schema/sequence collections and these were ABSENT.
+    expect(backup._internal).toBeDefined()
+    expect(backup._internal[BLOB_INDEX_COLLECTION]).toBeDefined()
+    expect(backup._internal[BLOB_CHUNKS_COLLECTION]).toBeDefined()
+    expect(backup._internal[`${BLOB_SLOTS_PREFIX}books`]).toBeDefined()
+    expect(Object.keys(backup._internal[BLOB_CHUNKS_COLLECTION]).length).toBeGreaterThan(0)
+
+    // Restore into a FRESH vault (new store + new Noydb, same secret so
+    // the dumped keyring DEKs — including the blob DEK — unwrap).
+    const targetStore = memory()
+    const targetDb = await createNoydb({
+      store: targetStore,
+      user: 'alice',
+      secret: SECRET,
+      blobStrategy: withBlobs(),
+      historyStrategy: withHistory(),
+    })
+    const targetVault = await targetDb.openVault('demo-co')
+    await targetVault.load(backupJson)
+
+    // The record itself round-trips.
+    const targetBooks = targetVault.collection<{ title: string }>('books')
+    expect(await targetBooks.get('book-1')).toEqual({ title: 'Moby Dick' })
+
+    // The cover reads back byte-identical and decrypts. Without the
+    // fix this returns null / fails — the chunks never travelled.
+    const restored = await targetBooks.blob('book-1').get('cover.png')
+    expect(restored).not.toBeNull()
+    expect(restored!.byteLength).toBe(coverBytes.byteLength)
+    expect([...restored!]).toEqual([...coverBytes])
+
+    const info = await targetBooks.blob('book-1').list()
+    expect(info).toHaveLength(1)
+    expect(info[0]!.name).toBe('cover.png')
+    expect(info[0]!.mimeType).toBe('image/png')
+
+    sourceDb.close()
+    targetDb.close()
+  })
+
+  it('a vault with no blobs still dumps and loads cleanly', async () => {
+    const sourceStore = memory()
+    const sourceDb = await createNoydb({
+      store: sourceStore,
+      user: 'alice',
+      secret: SECRET,
+      blobStrategy: withBlobs(),
+      historyStrategy: withHistory(),
+    })
+    const sourceVault = await sourceDb.openVault('demo-co')
+    const notes = sourceVault.collection<{ body: string }>('notes')
+    await notes.put('n-1', { body: 'hello' })
+
+    const backupJson = await sourceVault.dump()
+    const backup = JSON.parse(backupJson)
+
+    // No blobs were written → no _blob_* collections in the bundle
+    // (the dump loop skips empty ids).
+    expect(backup._internal[BLOB_INDEX_COLLECTION]).toBeUndefined()
+    expect(backup._internal[BLOB_CHUNKS_COLLECTION]).toBeUndefined()
+    expect(backup._internal[`${BLOB_SLOTS_PREFIX}notes`]).toBeUndefined()
+
+    const targetStore = memory()
+    const targetDb = await createNoydb({
+      store: targetStore,
+      user: 'alice',
+      secret: SECRET,
+      blobStrategy: withBlobs(),
+      historyStrategy: withHistory(),
+    })
+    const targetVault = await targetDb.openVault('demo-co')
+    await targetVault.load(backupJson)
+
+    const targetNotes = targetVault.collection<{ body: string }>('notes')
+    expect(await targetNotes.get('n-1')).toEqual({ body: 'hello' })
+
+    sourceDb.close()
+    targetDb.close()
+  })
+
+  it('dump() works when the blobs subsystem is not opted in', async () => {
+    const sourceStore = memory()
+    const sourceDb = await createNoydb({
+      store: sourceStore,
+      user: 'alice',
+      secret: SECRET,
+      historyStrategy: withHistory(),
+    })
+    const sourceVault = await sourceDb.openVault('demo-co')
+    const notes = sourceVault.collection<{ body: string }>('notes')
+    await notes.put('n-1', { body: 'no blobs here' })
+
+    // Should not throw — the blob-collection enumeration finds no ids.
+    const backupJson = await sourceVault.dump()
+    const backup = JSON.parse(backupJson)
+    expect(backup.collections.notes['n-1']).toBeDefined()
+
+    sourceDb.close()
+  })
+})

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -3941,8 +3941,20 @@ export class Vault {
     // the chain after restore. Without this, `load()` would have an
     // empty ledger and `verifyBackupIntegrity()` would have nothing
     // to compare against.
+    //
+    // Also enumerate the blob collections so blob content ("covers")
+    // travels in the bundle (the blob DEK already travels in `_keyring`).
+    // Literals are inlined (not imported from blobs/blob-set.ts) to keep
+    // the blob runtime out of this kernel hot path — they mirror
+    // BLOB_INDEX/CHUNKS/EVICTION_AUDIT_COLLECTION and SLOTS/VERSIONS_PREFIX.
+    // The collect-loop skips empty ids, so this no-ops without blobs.
     const internalSnapshot: VaultSnapshot = {}
-    for (const internalName of [LEDGER_COLLECTION, LEDGER_DELTAS_COLLECTION, SCHEMAS_COLLECTION, SEQUENCE_COLLECTION]) {
+    const internalNames = [
+      LEDGER_COLLECTION, LEDGER_DELTAS_COLLECTION, SCHEMAS_COLLECTION, SEQUENCE_COLLECTION,
+      '_blob_index', '_blob_chunks', '_blob_eviction_audit',
+      ...Object.keys(snapshot).flatMap((c) => [`_blob_slots_${c}`, `_blob_versions_${c}`]),
+    ]
+    for (const internalName of internalNames) {
       const ids = await this.adapter.list(this.name, internalName)
       if (ids.length === 0) continue
       const records: Record<string, EncryptedEnvelope> = {}

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -602,7 +602,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Lowered 4723→4627 (Phase 5 A6: ElevatedHandle extraction): the inner `ElevatedHandle` class + `ELEVATION_AUDIT_COLLECTION` const moved to `with-commit/tx/elevated-handle.ts`; vault.ts imports them (elevate() / _elevatedPut) and index.ts re-exports from the new module.
   // Lowered 4627→4587 (Phase 5 A2: attestation extraction): the issue/revoke methods + `make*Context` closures + the field-schema registry moved to `with-audit/attestation/vault-facade.ts` (`VaultAttestation`); vault.ts holds a facade instance + thin delegators.
   // Lowered 4587→4547 (Phase 5 A7: capability gating extraction): `assertCanExport`/`assertCanImport`/`canExport`/`canImport` predicate bodies moved to `capabilities.ts` (pure keyring predicates); vault.ts keeps the typed public overloads + thin delegators.
-  'packages/hub/src/vault.ts': 4547,
+  // Bumped 4547→4559 (bundle includes blobs): dump() now enumerates the blob collections (global _blob_index/_blob_chunks/_blob_eviction_audit + per-collection _blob_slots_*/_blob_versions_*) so blob "covers" travel in the .noydb bundle; +12 lines (inlined name literals + computed internalNames array + explanatory comment), no blob runtime pulled into the hot path.
+  'packages/hub/src/vault.ts': 4559,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),


### PR DESCRIPTION
Verified consumer bug: `vault.dump()` / the `.noydb` bundle excluded the `_blob_*` collections, so blob content ("covers") never travelled — a restored vault had dangling blob references. The `.noydb` is spec'd as the "whole-vault blobs" / full bundle, so this is a real gap.

**Fix (dump-side only):** the hardcoded internal-collection list `[LEDGER, LEDGER_DELTAS, SCHEMAS, SEQUENCE]` becomes a computed list that also enumerates the blob collections — the 3 global (`_blob_index`/`_blob_chunks`/`_blob_eviction_audit`) plus per-user-collection `_blob_slots_<C>`/`_blob_versions_<C>`. The existing skip-empty collect-loop is unchanged. `load()` is untouched (it restores `backup._internal` generically); the `_blob` DEK already travels in the dumped `_keyring`, so restored covers decrypt; blobs ship as ciphertext (sealed). Literals inlined (matching the blobs/ constants) to keep the blob runtime out of the kernel hot path.

**TDD-proven:** `bundle-blobs-roundtrip.test.ts` puts a 4 KB cover → `dump()` → asserts `_blob_*` in the backup → `load()` into a fresh vault → `blob.get()` returns byte-identical decrypted bytes. Verified it FAILS without the fix. Also covers a no-blob vault + dump without the blobs subsystem.

typecheck ✓ · lint ✓ · test ✓ (2942, +3) · check-architecture ✓ (vault.ts ceiling 4547→4559, justified) · build ✓.

Follow-up (separate): `extractPartition` (the partition-transfer bundle) has the same gap — design in progress.