### PR TITLE
feat(hub): extractPartition carries the slice's blobs — hardened, no master-key leak

### DIFF
--- a/packages/hub/__tests__/extractpartition-blobs.test.ts
+++ b/packages/hub/__tests__/extractpartition-blobs.test.ts
@@ -1,0 +1,318 @@
+/**
+ * extractPartition carries the slice's blobs — HARDENED key handling (#519).
+ *
+ * The crux is the HARDENED isolation property: the partition mints a FRESH
+ * transfer `_blob` DEK and re-wraps ONLY the carried slice's blob content CEKs
+ * under it. The recipient therefore gets keys for ONLY their slice's blobs —
+ * the transfer DEK can decrypt the carried cover but NOT a source-vault blob
+ * outside the slice (this is what distinguishes hardened from v1, which sealed
+ * the source's shared `_blob` DEK and would leak a key to every source blob).
+ *
+ * Mirrors setup from decrypt-partition.test.ts (extract/adopt) + per-blob-cek.test.ts (blobs).
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { ref } from '../src/refs.js'
+import { ConflictError } from '../src/errors.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot, KeyringFile } from '../src/types.js'
+import { decrypt } from '../src/crypto.js'
+import { unwrapCek } from '../src/record-keys/index.js'
+import { withBlobs } from '../src/with-shape/blobs/index.js'
+import { BLOB_INDEX_COLLECTION, BLOB_CHUNKS_COLLECTION } from '../src/with-shape/blobs/blob-set.js'
+import { extractPartition } from '../src/with-share/bundle/extract-partition.js'
+import {
+  adoptPartition,
+  createOwnerOnAdoptedPartition,
+  unsealDeks,
+} from '../src/with-share/bundle/adopt-partition.js'
+import { readNoydbBundle, parseExtractedPartitionBody } from '../src/with-share/bundle/bundle.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) {
+        for (const [name, coll] of existing) {
+          if (name.startsWith('_')) comp.set(name, coll)
+        }
+      }
+      store.set(c, comp)
+    },
+  }
+}
+
+const SECRET = 'correct-horse-battery-staple-long-enough'
+const bytes = (s: string) => new TextEncoder().encode(s)
+const decode = (u: Uint8Array) => new TextDecoder().decode(u)
+
+interface Doc { id: string; title: string }
+interface Line { id: string; docId: string }
+
+/** Recover the sealed DEK map (incl. the transfer `_blob` DEK) from a bundle. */
+async function sealedDeks(bundleBytes: Uint8Array, transferKey: Uint8Array) {
+  const { seal } = parseExtractedPartitionBody((await readNoydbBundle(bundleBytes)).dumpJson)
+  return unsealDeks(seal, transferKey)
+}
+
+describe('extractPartition blob carriage — round-trip', () => {
+  for (const erasable of [true, false] as const) {
+    it(`cover survives extract → adopt → own, byte-identical (${erasable ? 'erasable' : 'legacy'})`, async () => {
+      const src = memory()
+      const db = await createNoydb({ store: src, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+      const company = await db.openVault('demo-co')
+      const docs = company.collection<Doc>('docs', erasable ? { perRecordKeys: true } : {})
+      await docs.put('d1', { id: 'd1', title: 'Report' })
+      const cover = bytes('PNG cover bytes — the original blob content')
+      await docs.blob('d1').put('cover.png', cover)
+
+      const { bundleBytes, transferKey } = await extractPartition(company, {
+        seeds: { docs: (r) => r['id'] === 'd1' },
+      })
+
+      const dest = memory()
+      await adoptPartition(bundleBytes, { transferKey, destinationStore: dest, vaultName: 'fresh' })
+      await createOwnerOnAdoptedPartition(dest, 'fresh', {
+        userId: 'belle', passphrase: 'belle-pass-phrase-2026', transferKey,
+      })
+
+      const recipientDb = await createNoydb({ store: dest, user: 'belle', secret: 'belle-pass-phrase-2026', blobStrategy: withBlobs() })
+      const vault = await recipientDb.openVault('fresh')
+      const got = await vault.collection<Doc>('docs', erasable ? { perRecordKeys: true } : {}).blob('d1').get('cover.png')
+      expect(got).not.toBeNull()
+      expect(decode(got!)).toBe('PNG cover bytes — the original blob content')
+      recipientDb.close()
+      db.close()
+    })
+  }
+})
+
+describe('extractPartition blob carriage — HARDENED isolation property', () => {
+  it('the sealed transfer `_blob` DEK decrypts ONLY the carried slice, NOT a source blob outside the slice', async () => {
+    const src = memory()
+    const db = await createNoydb({ store: src, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const company = await db.openVault('demo-co')
+    const docs = company.collection<Doc>('docs', { perRecordKeys: true })
+    await docs.put('d1', { id: 'd1', title: 'In slice' })
+    await docs.put('d2', { id: 'd2', title: 'Out of slice' })
+    await docs.blob('d1').put('cover.png', bytes('carried cover'))
+    await docs.blob('d2').put('lonely.png', bytes('source-only blob outside the slice'))
+
+    const coverETag = (await docs.blob('d1').blobInfo('cover.png'))!.eTag
+    const lonelyETag = (await docs.blob('d2').blobInfo('lonely.png'))!.eTag
+    expect(coverETag).not.toBe(lonelyETag)
+
+    const { bundleBytes, transferKey } = await extractPartition(company, {
+      seeds: { docs: (r) => r['id'] === 'd1' },
+    })
+
+    const deks = await sealedDeks(bundleBytes, transferKey)
+    const transferBlobDek = deks.get('_blob')
+    expect(transferBlobDek).toBeDefined()
+
+    const dest = memory()
+    await adoptPartition(bundleBytes, { transferKey, destinationStore: dest, vaultName: 'fresh' })
+
+    // The SOURCE vault's blob DEK — proves the out-of-slice ciphertext below is
+    // valid (decryptable by its real key), so the negative assertions are real.
+    const srcBlobDek = await company._introspectState().getDEK('_blob')
+    expect(srcBlobDek).not.toBe(transferBlobDek) // FRESH transfer DEK, not the source's
+
+    // Positive: the transfer DEK decrypts the CARRIED cover's index entry
+    // (re-keyed under the transfer DEK into the bundle / destination)...
+    const coverIdx = await dest.get('fresh', BLOB_INDEX_COLLECTION, coverETag)
+    expect(coverIdx).not.toBeNull()
+    const coverBlob = JSON.parse(await decrypt(coverIdx!._iv, coverIdx!._data, transferBlobDek!)) as { _cek?: string }
+    expect(coverBlob._cek).toBeDefined()
+    // ...and unwraps its content CEK (chunks become decryptable for the recipient).
+    await expect(unwrapCek(coverBlob._cek!, transferBlobDek!)).resolves.toBeDefined()
+
+    // The out-of-slice blob never travelled into the bundle at all.
+    expect(await dest.get('fresh', BLOB_INDEX_COLLECTION, lonelyETag)).toBeNull()
+
+    // HARDENED master-key-leak proof: even handed the SOURCE vault's out-of-slice
+    // ciphertext directly, the transfer DEK yields NOTHING. (Under v1 — which
+    // sealed the source's shared `_blob` DEK — this DEK would decrypt it.)
+    const lonelyIdx = await src.get('demo-co', BLOB_INDEX_COLLECTION, lonelyETag)
+    expect(lonelyIdx).not.toBeNull()
+    // Sanity — the source DEK CAN read it (so the ciphertext is real)...
+    const lonelyBlob = JSON.parse(await decrypt(lonelyIdx!._iv, lonelyIdx!._data, srcBlobDek)) as { _cek?: string }
+    expect(lonelyBlob._cek).toBeDefined()
+    // ...but the transfer DEK throws on the index envelope...
+    await expect(decrypt(lonelyIdx!._iv, lonelyIdx!._data, transferBlobDek!)).rejects.toThrow()
+    // ...and cannot unwrap the source blob's content CEK (the key isolation property).
+    await expect(unwrapCek(lonelyBlob._cek!, transferBlobDek!)).rejects.toThrow()
+
+    db.close()
+  })
+})
+
+describe('extractPartition blob carriage — selective carriage', () => {
+  it('fieldProjection drops a projected-out blob field (its blob does not travel)', async () => {
+    const src = memory()
+    const db = await createNoydb({ store: src, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const company = await db.openVault('demo-co')
+    const docs = company.collection<Doc>('docs', { perRecordKeys: true })
+    await docs.put('d1', { id: 'd1', title: 'Report' })
+    await docs.blob('d1').put('cover', bytes('kept cover bytes'))
+    await docs.blob('d1').put('secret', bytes('dropped secret bytes'))
+    const secretETag = (await docs.blob('d1').blobInfo('secret'))!.eTag
+
+    const { bundleBytes, transferKey } = await extractPartition(company, {
+      seeds: { docs: (r) => r['id'] === 'd1' },
+      fieldProjection: { docs: ['title', 'cover'] },
+    })
+
+    const dest = memory()
+    await adoptPartition(bundleBytes, { transferKey, destinationStore: dest, vaultName: 'fresh' })
+    await createOwnerOnAdoptedPartition(dest, 'fresh', {
+      userId: 'belle', passphrase: 'belle-pass-phrase-2026', transferKey,
+    })
+
+    const recipientDb = await createNoydb({ store: dest, user: 'belle', secret: 'belle-pass-phrase-2026', blobStrategy: withBlobs() })
+    const vault = await recipientDb.openVault('fresh')
+    const slot = vault.collection<Doc>('docs', { perRecordKeys: true }).blob('d1')
+    expect(decode((await slot.get('cover'))!)).toBe('kept cover bytes')
+    expect(await slot.get('secret')).toBeNull()
+    // The projected-out blob's index entry never travelled.
+    expect(await dest.get('fresh', BLOB_INDEX_COLLECTION, secretETag)).toBeNull()
+    recipientDb.close()
+    db.close()
+  })
+
+  it('a blob referenced only by an out-of-closure record does not travel', async () => {
+    const src = memory()
+    const db = await createNoydb({ store: src, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const company = await db.openVault('demo-co')
+    const docs = company.collection<Doc>('docs', { perRecordKeys: true })
+    await docs.put('d1', { id: 'd1', title: 'In' })
+    await docs.put('d2', { id: 'd2', title: 'Out' })
+    await docs.blob('d1').put('cover.png', bytes('in-slice cover'))
+    await docs.blob('d2').put('lonely.png', bytes('out-of-slice blob'))
+    const lonelyETag = (await docs.blob('d2').blobInfo('lonely.png'))!.eTag
+
+    const { bundleBytes, transferKey } = await extractPartition(company, {
+      seeds: { docs: (r) => r['id'] === 'd1' },
+    })
+
+    const dest = memory()
+    await adoptPartition(bundleBytes, { transferKey, destinationStore: dest, vaultName: 'fresh' })
+    await createOwnerOnAdoptedPartition(dest, 'fresh', {
+      userId: 'belle', passphrase: 'belle-pass-phrase-2026', transferKey,
+    })
+
+    const recipientDb = await createNoydb({ store: dest, user: 'belle', secret: 'belle-pass-phrase-2026', blobStrategy: withBlobs() })
+    const vault = await recipientDb.openVault('fresh')
+    const docsR = vault.collection<Doc>('docs', { perRecordKeys: true })
+    expect(decode((await docsR.blob('d1').get('cover.png'))!)).toBe('in-slice cover')
+    // d2 was never in the closure: no record, no slot, no blob.
+    expect(await docsR.get('d2')).toBeNull()
+    expect(await dest.get('fresh', BLOB_INDEX_COLLECTION, lonelyETag)).toBeNull()
+    expect((await dest.list('fresh', BLOB_CHUNKS_COLLECTION)).some((k) => k.startsWith(lonelyETag))).toBe(false)
+    recipientDb.close()
+    db.close()
+  })
+})
+
+describe('extractPartition blob carriage — refCount + no-blob', () => {
+  it('the carried BlobObject refCount reflects carried references only', async () => {
+    const src = memory()
+    const db = await createNoydb({ store: src, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const company = await db.openVault('demo-co')
+    const docs = company.collection<Doc>('docs', { perRecordKeys: true })
+    // Two records share identical bytes → source refCount 2; only d1 is carried.
+    await docs.put('d1', { id: 'd1', title: 'A' })
+    await docs.put('d2', { id: 'd2', title: 'B' })
+    const shared = bytes('shared bytes across two records')
+    await docs.blob('d1').put('f.bin', shared)
+    await docs.blob('d2').put('f.bin', shared)
+    const eTag = (await docs.blob('d1').blobInfo('f.bin'))!.eTag
+    expect((await docs.blob('d1').blobInfo('f.bin'))!.refCount).toBe(2)
+
+    const { bundleBytes, transferKey } = await extractPartition(company, {
+      seeds: { docs: (r) => r['id'] === 'd1' },
+    })
+
+    const deks = await sealedDeks(bundleBytes, transferKey)
+    const dest = memory()
+    await adoptPartition(bundleBytes, { transferKey, destinationStore: dest, vaultName: 'fresh' })
+    const carriedIdx = await dest.get('fresh', BLOB_INDEX_COLLECTION, eTag)
+    const carried = JSON.parse(await decrypt(carriedIdx!._iv, carriedIdx!._data, deks.get('_blob')!)) as { refCount: number }
+    expect(carried.refCount).toBe(1) // recomputed from the single carried reference
+    db.close()
+  })
+
+  it('a no-blob partition extracts/adopts cleanly and mints no `_blob` DEK (source keyring untouched)', async () => {
+    const src = memory()
+    const db = await createNoydb({ store: src, user: 'alice', secret: SECRET, blobStrategy: withBlobs() })
+    const company = await db.openVault('demo-co')
+    const docs = company.collection<Doc>('docs')
+    const lines = company.collection<Line>('lines', { refs: { docId: ref('docs') } })
+    await docs.put('d1', { id: 'd1', title: 'No blobs here' })
+    await lines.put('l1', { id: 'l1', docId: 'd1' })
+
+    const keyringBefore = await src.get('demo-co', '_keyring', 'alice')
+    const deksBefore = Object.keys((JSON.parse(keyringBefore!._data) as KeyringFile).deks)
+
+    const { bundleBytes, transferKey } = await extractPartition(company, {
+      seeds: { docs: () => true },
+    })
+
+    // No `_blob` DEK in the seal.
+    const deks = await sealedDeks(bundleBytes, transferKey)
+    expect(deks.has('_blob')).toBe(false)
+
+    // Source keyring did NOT gain a phantom `_blob` DEK.
+    const keyringAfter = await src.get('demo-co', '_keyring', 'alice')
+    const deksAfter = Object.keys((JSON.parse(keyringAfter!._data) as KeyringFile).deks)
+    expect(deksAfter).not.toContain('_blob')
+    expect(deksAfter.sort()).toEqual(deksBefore.sort())
+
+    // Round-trips: records adopt + own, and blob.get is simply null.
+    const dest = memory()
+    await adoptPartition(bundleBytes, { transferKey, destinationStore: dest, vaultName: 'fresh' })
+    await createOwnerOnAdoptedPartition(dest, 'fresh', {
+      userId: 'belle', passphrase: 'belle-pass-phrase-2026', transferKey,
+    })
+    const recipientDb = await createNoydb({ store: dest, user: 'belle', secret: 'belle-pass-phrase-2026', blobStrategy: withBlobs() })
+    const vault = await recipientDb.openVault('fresh')
+    expect(await vault.collection<Doc>('docs').get('d1')).toMatchObject({ id: 'd1', title: 'No blobs here' })
+    expect(await vault.collection<Doc>('docs').blob('d1').get('cover.png')).toBeNull()
+    recipientDb.close()
+    db.close()
+  })
+})

--- a/packages/hub/src/with-share/bundle/extract-partition.ts
+++ b/packages/hub/src/with-share/bundle/extract-partition.ts
@@ -7,10 +7,24 @@
  * @module
  */
 import type { Vault } from '../../vault.js'
-import type { EncryptedEnvelope } from '../../types.js'
+import type { EncryptedEnvelope, BlobObject, SlotRecord, VersionRecord } from '../../types.js'
 import { NOYDB_BACKUP_VERSION } from '../../types.js'
-import { decrypt, encrypt, generateDEK, bufferToBase64 } from '../../crypto.js'
+import {
+  decrypt,
+  encrypt,
+  generateDEK,
+  bufferToBase64,
+  encryptBytesWithAAD,
+  decryptBytesWithAAD,
+} from '../../crypto.js'
 import { unwrapCek, wrapCek } from '../../record-keys/index.js'
+import {
+  BLOB_COLLECTION,
+  BLOB_INDEX_COLLECTION,
+  BLOB_CHUNKS_COLLECTION,
+  BLOB_SLOTS_PREFIX,
+  BLOB_VERSIONS_PREFIX,
+} from '../../with-shape/blobs/blob-set.js'
 import { PartitionExtractionError } from '../../errors.js'
 import { walkClosure, type WalkClosureOptions } from './walk-closure.js'
 import { generateULID } from './ulid.js'
@@ -218,6 +232,188 @@ export async function reKeyLedger(
   }
 }
 
+/** Build the AAD binding for chunk integrity: "{eTag}:{chunkIndex}:{chunkCount}".
+ * Mirrors `chunkAAD` in blob-set.ts — the eTag is preserved verbatim across
+ * the transfer (see `reKeyBlobs`), so the same AAD that bound a chunk in the
+ * source keeps binding it in the bundle. */
+function chunkAAD(eTag: string, chunkIndex: number, chunkCount: number): Uint8Array {
+  return new TextEncoder().encode(`${eTag}:${chunkIndex}:${chunkCount}`)
+}
+
+/** Carried blob internals + the fresh transfer `_blob` DEK (present only when
+ * the closure references at least one chunk-based blob). */
+export interface ReKeyBlobsResult {
+  /** `_blob_slots_<C>` / `_blob_versions_<C>` / `_blob_index` / `_blob_chunks`
+   * envelopes for the bundle's `_internal` map. */
+  readonly internal: Record<string, Record<string, EncryptedEnvelope>>
+  /** Fresh transfer `_blob` DEK — seal it so owner-creation wraps it under the
+   * recipient KEK. Undefined when no blob travels (source keyring untouched). */
+  readonly blobDek?: CryptoKey
+}
+
+/**
+ * Carry the FK-closed slice's blobs — HARDENED key handling (no master-key leak).
+ *
+ * The source vault's shared `_blob` DEK decrypts (or unwraps the content CEK of)
+ * EVERY blob in the source. Sealing it into the transfer would hand the recipient
+ * a key to blobs far outside their slice. Instead we mint a **fresh transfer
+ * `_blob` DEK** and arrange every carried blob into per-blob-CEK mode under it:
+ *
+ *  - **erasable blob** (`_cek` present): unwrap the per-blob content CEK under the
+ *    SOURCE `_blob` DEK, re-wrap it under the FRESH transfer DEK. Chunks travel
+ *    **verbatim** (still ciphertext under that same content CEK — passthrough).
+ *  - **legacy blob** (no `_cek`, chunks under the shared `_blob` DEK): promote it
+ *    IN-BUNDLE — mint a fresh content CEK, decrypt each chunk under the source
+ *    `_blob` DEK and re-encrypt under the content CEK (same AAD, so the eTag-bound
+ *    integrity holds), then wrap the content CEK under the transfer DEK. The
+ *    SOURCE is never mutated (non-destructive), and the bundle never holds
+ *    plaintext blob bytes (zero-knowledge preserved).
+ *
+ * **eTag identity is preserved** (not re-HMAC'd). eTags are HMAC-keyed off the
+ * `_blob` DEK, but they are stored as OPAQUE keys (`_blob_index/<eTag>`,
+ * `_blob_chunks/<eTag>_<i>`) and never recomputed on read — only on a `put()`
+ * for dedup. Keeping them verbatim keeps every slot/version/index/chunk key and
+ * the chunk AAD coherent with zero chunk-key churn. The only consequence: a
+ * future `put()` of identical bytes in the adopted vault computes a different
+ * eTag (HMAC under the fresh DEK) and will NOT dedup against the carried blob —
+ * an accepted, documented trade for hardened key isolation.
+ *
+ * Slots/versions are re-keyed under their parent collection's destination DEK
+ * (honoring `fieldProjection` — projected-out blob fields' slots never travel);
+ * `BlobObject.refCount` is recomputed from carried references only.
+ *
+ * `external` slots reference an unencrypted shared-bucket object that is not in
+ * the bundle — their slot metadata travels (so the catalog entry survives) but
+ * the bytes do not (a documented v1 limitation; their eTag is `''`).
+ */
+export async function reKeyBlobs(
+  vault: Vault,
+  closure: Map<string, Set<string>>,
+  destDeks: Map<string, CryptoKey>,
+  fieldProjection?: Record<string, readonly string[]>,
+): Promise<ReKeyBlobsResult> {
+  const { name: vaultName, adapter, getDEK } = vault._introspectState()
+  const internal: Record<string, Record<string, EncryptedEnvelope>> = {}
+
+  // travel set: eTag → number of carried references (slots + versions) within
+  // the closure. Recomputed refCount, NOT the source's (which may count
+  // out-of-slice referrers, leaving the adopted blob un-GC-able).
+  const carriedRefs = new Map<string, number>()
+  const addRef = (eTag: string): void => {
+    if (!eTag) return // external slot — no chunk-based blob to carry
+    carriedRefs.set(eTag, (carriedRefs.get(eTag) ?? 0) + 1)
+  }
+
+  const place = (collection: string, id: string, env: EncryptedEnvelope): void => {
+    let bucket = internal[collection]
+    if (!bucket) { bucket = {}; internal[collection] = bucket }
+    bucket[id] = env
+  }
+
+  // ── Slots + versions (parent-collection-DEK keyed) ─────────────────
+  for (const [collectionName, ids] of closure) {
+    const destDek = destDeks.get(collectionName)
+    if (!destDek) continue
+    const srcDek = await getDEK(collectionName)
+    const projList = fieldProjection?.[collectionName]
+    const proj = projList ? new Set(projList) : undefined
+
+    // Slots: one envelope per record, a `{ slotName: SlotRecord }` map.
+    const slotsCollection = `${BLOB_SLOTS_PREFIX}${collectionName}`
+    for (const id of ids) {
+      const env = await adapter.get(vaultName, slotsCollection, id)
+      if (!env) continue
+      const slots = JSON.parse(await decrypt(env._iv, env._data, srcDek)) as Record<string, SlotRecord>
+      // FR-7: drop projected-out blob fields' slots (slot names are blob field
+      // names) — their eTags then never enter the travel set.
+      const kept: Record<string, SlotRecord> = {}
+      for (const [slotName, slot] of Object.entries(slots)) {
+        if (proj && !proj.has(slotName)) continue
+        kept[slotName] = slot
+        addRef(slot.eTag)
+      }
+      if (Object.keys(kept).length === 0) continue
+      const { iv, data } = await encrypt(JSON.stringify(kept), destDek)
+      place(slotsCollection, id, { ...env, _iv: iv, _data: data })
+    }
+
+    // Versions: key = `${recordId}::${slotName}::${label}`; each an independent
+    // refCount hold on its eTag.
+    const versionsCollection = `${BLOB_VERSIONS_PREFIX}${collectionName}`
+    const versionKeys = await adapter.list(vaultName, versionsCollection)
+    for (const key of versionKeys) {
+      const [recordId, slotName] = key.split('::')
+      if (recordId === undefined || !ids.has(recordId)) continue
+      if (proj && slotName !== undefined && !proj.has(slotName)) continue
+      const env = await adapter.get(vaultName, versionsCollection, key)
+      if (!env) continue
+      const record = JSON.parse(await decrypt(env._iv, env._data, srcDek)) as VersionRecord
+      addRef(record.eTag)
+      const { iv, data } = await encrypt(JSON.stringify(record), destDek)
+      place(versionsCollection, key, { ...env, _iv: iv, _data: data })
+    }
+  }
+
+  // No chunk-based blob in the closure → carry nothing, mint nothing. Guarded
+  // so `getDEK('_blob')` does not auto-mint + persist a phantom DEK on the
+  // source keyring (mirrors the carryLedger non-destructive guard).
+  if (carriedRefs.size === 0) return { internal }
+
+  // ── Index + chunks (re-keyed under a FRESH transfer `_blob` DEK) ────
+  const srcBlobDek = await getDEK(BLOB_COLLECTION)
+  const transferBlobDek = await generateDEK()
+
+  for (const [eTag, refCount] of carriedRefs) {
+    const idxEnv = await adapter.get(vaultName, BLOB_INDEX_COLLECTION, eTag)
+    if (!idxEnv) continue // dangling slot reference — nothing to carry
+    const blob = JSON.parse(await decrypt(idxEnv._iv, idxEnv._data, srcBlobDek)) as BlobObject
+
+    // Resolve the per-blob content CEK; passthrough vs. in-bundle promotion.
+    let contentCek: CryptoKey
+    let chunksPassthrough: boolean
+    if (blob._cek !== undefined) {
+      contentCek = await unwrapCek(blob._cek, srcBlobDek)
+      chunksPassthrough = true
+    } else {
+      // Legacy: promote to per-blob-CEK for the bundle (source untouched).
+      contentCek = await generateDEK()
+      chunksPassthrough = false
+    }
+
+    // Chunks: verbatim for an already-erasable blob; decrypt-then-re-encrypt
+    // under the fresh content CEK for a legacy blob (same eTag-bound AAD).
+    for (let i = 0; i < blob.chunkCount; i++) {
+      const chunkId = `${eTag}_${i}`
+      const chunkEnv = await adapter.get(vaultName, BLOB_CHUNKS_COLLECTION, chunkId)
+      if (!chunkEnv) {
+        throw new PartitionExtractionError(
+          `reKeyBlobs: blob chunk ${i}/${blob.chunkCount} missing for eTag "${eTag}"; `
+          + `cannot carry an incomplete blob into the partition.`,
+        )
+      }
+      if (chunksPassthrough) {
+        place(BLOB_CHUNKS_COLLECTION, chunkId, chunkEnv)
+      } else {
+        const aad = chunkAAD(eTag, i, blob.chunkCount)
+        const plain = await decryptBytesWithAAD(chunkEnv._iv, chunkEnv._data, srcBlobDek, aad)
+        const { iv, data } = await encryptBytesWithAAD(plain, contentCek, aad)
+        place(BLOB_CHUNKS_COLLECTION, chunkId, { ...chunkEnv, _iv: iv, _data: data })
+      }
+    }
+
+    // Index: per-blob-CEK mode under the transfer DEK, refCount corrected.
+    // Drop any transient `_cekPending` (never set on a settled blob — possible
+    // only if the source is mid-migration; we set a fresh settled `_cek`).
+    const { _cekPending, ...rest } = blob
+    void _cekPending
+    const carried: BlobObject = { ...rest, refCount, _cek: await wrapCek(contentCek, transferBlobDek) }
+    const { iv, data } = await encrypt(JSON.stringify(carried), transferBlobDek)
+    place(BLOB_INDEX_COLLECTION, eTag, { ...idxEnv, _iv: iv, _data: data })
+  }
+
+  return { internal, blobDek: transferBlobDek }
+}
+
 /** A minted transfer key (raw 32 bytes) + the seal carrying the DEK set. */
 export interface SealResult {
   readonly seal: TransferSealPayload
@@ -330,12 +526,20 @@ export async function extractPartition(
     }
   }
 
-  // Build _internal (schemas + ledger). reKeySchemas reads data-
+  // Carry the slice's blobs — re-keyed under a FRESH transfer `_blob` DEK
+  // (HARDENED: never carries the source's shared blob DEK). Runs BEFORE
+  // sealDeks so the fresh DEK is sealed alongside the data DEKs; non-destructive
+  // on the source (mints + reads `_blob` only when the closure has blobs).
+  const blobs = await reKeyBlobs(vault, closure, deks, opts.fieldProjection)
+  if (blobs.blobDek) deks.set(BLOB_COLLECTION, blobs.blobDek)
+
+  // Build _internal (schemas + ledger + blobs). reKeySchemas reads data-
   // collection DEKs only, so it is unaffected by the _ledger DEK added above.
   const internalSchemas = opts.carrySchemas ? await reKeySchemas(vault, closure, deks, opts.fieldProjection) : {}
   const internal: Record<string, Record<string, EncryptedEnvelope>> = {}
   if (Object.keys(internalSchemas).length > 0) internal[SCHEMAS_COLLECTION] = internalSchemas
   if (ledgerEntries) internal[LEDGER_COLLECTION] = ledgerEntries
+  for (const [collection, records] of Object.entries(blobs.internal)) internal[collection] = records
   const hasInternal = Object.keys(internal).length > 0
 
   const { seal, transferKey } = await sealDeks(deks)


### PR DESCRIPTION
`extractPartition` (the FK-closed, re-keyed, transfer-sealed partition bundle for ownership transfer) carried zero blob data — an adopted record's `blob.get()` returned null. This carries the slice's blobs so covers survive extract→adopt, with **hardened** key handling.

**Hardened isolation (the security property):** instead of sealing the source's shared `_blob` DEK (which would hand the new owner a key to ALL source blobs), it mints a **fresh transfer `_blob` DEK** and re-wraps ONLY the carried slice's blob content CEKs under it. The source DEK is used transiently to decrypt/unwrap and **never enters the seal or bundle**. The recipient gets keys for only their slice's blobs — no cryptographic path to the source master key or out-of-slice blobs. eTags preserved (opaque passthrough, no re-HMAC); legacy shared-DEK blobs promoted in-bundle (source never mutated); ZK preserved. Adopt side unchanged (the fresh DEK rides the generic sealed-DEK set).

**Tests (the isolation property is the headline):** the adopted recipient decrypts the carried cover but **throws** (AES-GCM auth failure) on real, source-decryptable out-of-slice ciphertext — would pass under v1, proving genuine isolation. Plus round-trip (cover byte-identical), fieldProjection drops, out-of-closure exclusion, no-blob-partition clean.

typecheck ✓ · lint ✓ · test ✓ (2949, +7) · check-architecture ✓ · build ✓. Opus crypto review: **hardened isolation holds**, no Critical/High.

Follow-up (out of scope): `external`/objectStore-slot blobs carry metadata but not bytes (documented).