### PR TITLE
refactor(hub): kernel-shrink batch 2 — snapshots, periods, backup (Phase 5 A9/A3/A4)

### DIFF
--- a/packages/hub/src/noydb.ts
+++ b/packages/hub/src/noydb.ts
@@ -109,8 +109,8 @@ import type { KeyringAuthenticator } from './types.js'
 import type { SyncEngine } from './with-party/team/sync.js'
 import type { SyncTransaction } from './with-party/team/sync-transaction.js'
 import { NO_SYNC, type SyncStrategy } from './with-party/team/sync-strategy.js'
-import { NO_SNAPSHOTS, type SnapshotStrategy, type SnapshotMeta } from './with-fork/snapshots/strategy.js'
-import { SnapshotScheduler } from './with-fork/snapshots/scheduler.js'
+import { type SnapshotMeta } from './with-fork/snapshots/strategy.js'
+import { NoydbSnapshots, NO_SNAPSHOTS } from './with-fork/snapshots/noydb-facade.js'
 import type { AmendmentTxOptions } from './with-commit/tx/transaction.js'
 import { TxContext } from './with-commit/tx/transaction.js'
 import type { DryRunResult } from './with-commit/tx/dry-run.js'
@@ -227,9 +227,7 @@ export class Noydb {
   private readonly forgetStrategy: ForgetStrategy
   private readonly sessionStrategy: SessionStrategy
   private readonly syncStrategy: SyncStrategy
-  private readonly snapshotStrategy: SnapshotStrategy
-  private snapshotScheduler: SnapshotScheduler | null = null
-  private readonly dirtySnapshotVaults = new Set<string>()
+  private readonly snapshots: NoydbSnapshots
   /**
    * Currently-running multi-record transaction, set by
    * `runTransaction` at the start of Phase 2 (commit) and cleared in
@@ -273,8 +271,13 @@ export class Noydb {
     this.forgetStrategy = options.forgetStrategy ?? NO_FORGET
     this.sessionStrategy = options.sessionStrategy ?? NO_SESSION
     this.syncStrategy = options.syncStrategy ?? NO_SYNC
-    this.snapshotStrategy = options.snapshotStrategy ?? NO_SNAPSHOTS
-    this.initSnapshotCadence()
+    this.snapshots = new NoydbSnapshots({
+      strategy: options.snapshotStrategy ?? NO_SNAPSHOTS,
+      user: options.user,
+      isClosed: () => this.closed,
+      getVault: (name) => this.vaultCache.get(name),
+      onAfterWrite: (h) => this.onAfterWrite(h),
+    })
     this.publicEnvelopeSchema = resolvePublicEnvelopeSchema(options.publicEnvelope)
     // Validate sessionPolicy at construction time (developer error if invalid).
     // The strategy's stub throws with a pointer at the subpath if the
@@ -1620,8 +1623,7 @@ export class Noydb {
 
   close(): void {
     this.closed = true
-    this.snapshotScheduler?.stop()
-    this.snapshotScheduler = null
+    this.snapshots.stop()
     if (this.sessionTimer) {
       clearTimeout(this.sessionTimer)
       this.sessionTimer = null
@@ -2969,56 +2971,7 @@ export class Noydb {
    * @throws ValidationError when the vault is not open
    */
   async snapshot(vault: string, opts?: { label?: string; note?: string }): Promise<SnapshotMeta> {
-    if (this.closed) throw new ValidationError('Instance is closed')
-    const v = this.vaultCache.get(vault)
-    if (!v) {
-      throw new ValidationError(
-        `Vault "${vault}" is not open. Call openVault() first.`,
-      )
-    }
-    return this.snapshotStrategy.snapshot(v, this.options.user, opts)
-  }
-
-  /**
-   * Wire the automatic-snapshot cadence when a non-manual `snapshotPolicy` is
-   * configured. Subscribes to `onAfterWrite` to mark the written vault dirty and
-   * nudge the scheduler; the scheduler fires `autoSnapshot()` per dirty vault.
-   * No-op for `mode:'manual'` or no policy.
-   */
-  private initSnapshotCadence(): void {
-    const policy = this.snapshotStrategy.policy
-    if (!policy || !policy.mode || policy.mode === 'manual') return
-
-    const scheduler = new SnapshotScheduler(policy, {
-      fire: async () => {
-        const names = [...this.dirtySnapshotVaults]
-        this.dirtySnapshotVaults.clear()
-        for (const name of names) {
-          const v = this.vaultCache.get(name)
-          if (!v) continue
-          try {
-            await this.snapshotStrategy.autoSnapshot(v, this.options.user)
-          } catch (err) {
-            // Keep the vault pending so a later cadence tick (interval) or the
-            // next write (debounce) retries; a failed auto-snapshot is logged,
-            // never thrown (it runs inside the after-write hook contract).
-            this.dirtySnapshotVaults.add(name)
-            console.warn(
-              `[noy-db] auto-snapshot failed for vault "${name}": ` +
-              (err instanceof Error ? err.message : String(err)),
-            )
-          }
-        }
-      },
-      pendingCount: () => this.dirtySnapshotVaults.size,
-    })
-
-    this.onAfterWrite((event) => {
-      this.dirtySnapshotVaults.add(event.vault)
-      scheduler.notifyChange()
-    })
-    scheduler.start()
-    this.snapshotScheduler = scheduler
+    return this.snapshots.snapshot(vault, opts)
   }
 
   /**
@@ -3026,8 +2979,7 @@ export class Noydb {
    * Reads only the sidecar index — does not download snapshot bytes.
    */
   async listSnapshots(vault: string): Promise<SnapshotMeta[]> {
-    if (this.closed) throw new ValidationError('Instance is closed')
-    return this.snapshotStrategy.listSnapshots(vault)
+    return this.snapshots.listSnapshots(vault)
   }
 
   /**
@@ -3037,14 +2989,7 @@ export class Noydb {
    * @throws ValidationError when the vault is not open
    */
   async restoreSnapshot(vault: string, version: string): Promise<void> {
-    if (this.closed) throw new ValidationError('Instance is closed')
-    const v = this.vaultCache.get(vault)
-    if (!v) {
-      throw new ValidationError(
-        `Vault "${vault}" is not open. Call openVault() first.`,
-      )
-    }
-    return this.snapshotStrategy.restoreSnapshot(v, version)
+    return this.snapshots.restoreSnapshot(vault, version)
   }
 }
 

--- a/packages/hub/src/vault-backup.ts
+++ b/packages/hub/src/vault-backup.ts
@@ -1,0 +1,399 @@
+/**
+ * Vault backup / restore / integrity, lifted off the `Vault` god-object
+ * (Phase 5 A4 of the microkernel refactoring).
+ *
+ * Holds `dump()` (verifiable encrypted JSON backup, including the blob
+ * collections so blob "covers" travel in the bundle), `load()` (restore +
+ * post-load integrity gate), `verifyBackupIntegrity()` (chain + data-envelope
+ * cross-check), and `exportJSON()` (plaintext per-collection export, built on
+ * the vault's `exportStream`). Behaviour is byte-identical to the inline
+ * `Vault` methods these functions replaced — every dependency the moving code
+ * touched on `this.*` arrives via {@link BackupContext}. `Vault` keeps the
+ * public methods as thin delegators.
+ *
+ * Internal — reached through `vault.dump()` / `vault.load()` / etc.
+ */
+import { NOYDB_BACKUP_VERSION } from './types.js'
+import { BackupLedgerError, BackupCorruptedError } from './errors.js'
+import { LEDGER_COLLECTION, LEDGER_DELTAS_COLLECTION } from './with-commit/history/ledger/constants.js'
+import { SCHEMAS_COLLECTION } from './with-shape/persisted-schemas/storage.js'
+import { SEQUENCE_COLLECTION } from './with-commit/sequence/index.js'
+import type {
+  NoydbStore,
+  EncryptedEnvelope,
+  VaultBackup,
+  VaultSnapshot,
+  ExportStreamOptions,
+  ExportChunk,
+} from './types.js'
+import type { LedgerStore } from './with-commit/history/ledger/store.js'
+
+/** Everything the moving backup methods touched on the vault's `this.*`. */
+export interface BackupContext {
+  /** The ciphertext store. */
+  readonly adapter: NoydbStore
+  /** Vault namespace name. */
+  readonly vault: string
+  /** The invoking keyring's user id (read fresh per call). */
+  userId(): string
+  /** The vault's ledger store, or null when history is off. */
+  getLedgerOrNull(): LedgerStore | null
+  /** Recompute an envelope's `payloadHash` (bound `historyStrategy.envelopePayloadHash`). */
+  envelopePayloadHash(envelope: EncryptedEnvelope): Promise<string>
+  /**
+   * Refresh the in-memory keyring from the freshly-loaded keyring file and
+   * rebuild the DEK resolver. No-op when the vault has no `reloadKeyring`
+   * callback (plaintext vaults / test constructions).
+   */
+  reloadKeyringAndRebuildDEK(): Promise<void>
+  /** Clear the vault's collection cache (post-load). */
+  clearCollectionCache(): void
+  /** Reset the ledger store so the next `ledger()` rebuilds its head cache. */
+  resetLedgerStore(): void
+  /** The vault's decrypt+ACL export stream (used by `exportJSON`). */
+  exportStream(opts: ExportStreamOptions): AsyncIterableIterator<ExportChunk>
+}
+
+/** Result of {@link verifyBackupIntegrity}. */
+export type VerifyBackupResult =
+  | { readonly ok: true; readonly head: string; readonly length: number }
+  | {
+      readonly ok: false
+      readonly kind: 'chain'
+      readonly divergedAt: number
+      readonly message: string
+    }
+  | {
+      readonly ok: false
+      readonly kind: 'data'
+      readonly collection: string
+      readonly id: string
+      readonly message: string
+    }
+
+/**
+ * Dump vault as a verifiable encrypted JSON backup string.
+ *
+ * backups embed the current ledger head and the full `_ledger` +
+ * `_ledger_deltas` internal collections so the receiver can run
+ * `verifyBackupIntegrity()` after `load()` and detect any tampering between
+ * dump and restore. Backups produced without a ledger skip the integrity check
+ * with a warning — both modes round-trip cleanly.
+ */
+export async function dumpVault(ctx: BackupContext): Promise<string> {
+  const snapshot = await ctx.adapter.loadAll(ctx.vault)
+
+  // Load keyrings (separate path because loadAll filters them out
+  // along with all other underscore-prefixed internal collections).
+  const keyringIds = await ctx.adapter.list(ctx.vault, '_keyring')
+  const keyrings: Record<string, unknown> = {}
+  for (const keyringId of keyringIds) {
+    const envelope = await ctx.adapter.get(ctx.vault, '_keyring', keyringId)
+    if (envelope) {
+      keyrings[keyringId] = JSON.parse(envelope._data)
+    }
+  }
+
+  // Load the ledger entries + deltas so the receiver can replay
+  // the chain after restore. Without this, `load()` would have an
+  // empty ledger and `verifyBackupIntegrity()` would have nothing
+  // to compare against.
+  //
+  // Also enumerate the blob collections so blob content ("covers")
+  // travels in the bundle (the blob DEK already travels in `_keyring`).
+  // Literals are inlined (not imported from blobs/blob-set.ts) to keep
+  // the blob runtime out of this kernel hot path — they mirror
+  // BLOB_INDEX/CHUNKS/EVICTION_AUDIT_COLLECTION and SLOTS/VERSIONS_PREFIX.
+  // The collect-loop skips empty ids, so this no-ops without blobs.
+  const internalSnapshot: VaultSnapshot = {}
+  const internalNames = [
+    LEDGER_COLLECTION, LEDGER_DELTAS_COLLECTION, SCHEMAS_COLLECTION, SEQUENCE_COLLECTION,
+    '_blob_index', '_blob_chunks', '_blob_eviction_audit',
+    ...Object.keys(snapshot).flatMap((c) => [`_blob_slots_${c}`, `_blob_versions_${c}`]),
+  ]
+  for (const internalName of internalNames) {
+    const ids = await ctx.adapter.list(ctx.vault, internalName)
+    if (ids.length === 0) continue
+    const records: Record<string, EncryptedEnvelope> = {}
+    for (const id of ids) {
+      const envelope = await ctx.adapter.get(ctx.vault, internalName, id)
+      if (envelope) records[id] = envelope
+    }
+    internalSnapshot[internalName] = records
+  }
+
+  // Embed the ledger head if there's a chain. An empty ledger
+  // (fresh vault) leaves `ledgerHead` undefined, which
+  // load() treats the same as a legacy backup (no integrity
+  // check, console warning). If history is not opted in,
+  // `getLedgerOrNull` returns null and we skip embedding entirely
+  // — the backup is still valid, just without the integrity head.
+  const ledgerForHead = ctx.getLedgerOrNull()
+  const head = ledgerForHead ? await ledgerForHead.head() : null
+  const backup: VaultBackup = {
+    _noydb_backup: NOYDB_BACKUP_VERSION,
+    _compartment: ctx.vault,
+    _exported_at: new Date().toISOString(),
+    _exported_by: ctx.userId(),
+    keyrings: keyrings as VaultBackup['keyrings'],
+    collections: snapshot,
+    ...(Object.keys(internalSnapshot).length > 0
+      ? { _internal: internalSnapshot }
+      : {}),
+    ...(head
+      ? {
+          ledgerHead: {
+            hash: head.hash,
+            index: head.entry.index,
+            ts: head.entry.ts,
+          },
+        }
+      : {}),
+  }
+
+  return JSON.stringify(backup)
+}
+
+/**
+ * Restore a vault from a verifiable backup. After loading, runs
+ * `verifyBackupIntegrity()` to confirm the hash chain, the embedded head, and
+ * every data envelope's payload hash. Legacy backups (no `ledgerHead`) load
+ * with a console warning and skip the integrity check.
+ */
+export async function loadVault(ctx: BackupContext, backupJson: string): Promise<void> {
+  const backup = JSON.parse(backupJson) as VaultBackup
+
+  // 1. Restore data collections.
+  await ctx.adapter.saveAll(ctx.vault, backup.collections)
+
+  // 2. Restore keyrings.
+  for (const [userId, keyringFile] of Object.entries(backup.keyrings)) {
+    const envelope = {
+      _noydb: 1 as const,
+      _v: 1,
+      _ts: new Date().toISOString(),
+      _iv: '',
+      _data: JSON.stringify(keyringFile),
+    }
+    await ctx.adapter.put(ctx.vault, '_keyring', userId, envelope)
+  }
+
+  // 3. Restore internal collections (`_ledger`, `_ledger_deltas`).
+  //    Required so verifyBackupIntegrity has the chain to walk.
+  if (backup._internal) {
+    for (const [internalName, records] of Object.entries(backup._internal)) {
+      for (const [id, envelope] of Object.entries(records)) {
+        await ctx.adapter.put(ctx.vault, internalName, id, envelope)
+      }
+    }
+  }
+
+  // 4. Refresh the in-memory keyring from the freshly-loaded
+  //    keyring file. Without this, the Vault's getDEK
+  //    closure still holds the OLD session's DEKs, and every
+  //    decrypt of a loaded ledger entry / data envelope fails
+  //    with TamperedError because the DEK doesn't match the
+  //    ciphertext that was encrypted with the SOURCE user's DEK.
+  //    Skipped for plaintext vaults and for tests that
+  //    construct Vault without a reloadKeyring callback.
+  await ctx.reloadKeyringAndRebuildDEK()
+
+  // 5. Clear collection cache + reset the ledger store so the
+  //    next ledger() call rebuilds its head cache from the
+  //    freshly-loaded entries.
+  ctx.clearCollectionCache()
+  ctx.resetLedgerStore()
+
+  // 5. Run the verification gate. Legacy backups (no ledgerHead)
+  //    skip this with a one-line warning so existing consumers can
+  //    still read them while migrating.
+  if (!backup.ledgerHead) {
+    console.warn(
+      `[noy-db] Loaded a legacy backup with no ledgerHead — ` +
+      `verifiable-backup integrity check skipped. ` +
+      `Re-export with a ledger-aware build to get tamper detection.`,
+    )
+    return
+  }
+
+  const result = await verifyBackupIntegrity(ctx)
+  if (!result.ok) {
+    // Surface the most specific error class we can. The result
+    // shape carries enough info for callers to inspect.
+    if (result.kind === 'data') {
+      throw new BackupCorruptedError(
+        result.collection,
+        result.id,
+        result.message,
+      )
+    }
+    throw new BackupLedgerError(result.message, result.divergedAt)
+  }
+
+  // 6. Cross-check: the freshly-verified head must match the
+  //    value embedded at dump time. A mismatch means someone
+  //    truncated or extended the chain after dump.
+  if (result.head !== backup.ledgerHead.hash) {
+    throw new BackupLedgerError(
+      `Backup ledger head mismatch: embedded "${backup.ledgerHead.hash}" ` +
+      `but reconstructed "${result.head}".`,
+    )
+  }
+}
+
+/**
+ * End-to-end backup integrity check: `ledger.verify()` (hash chain) plus a data
+ * envelope cross-check (every current record's `_data` hash must match the
+ * latest `put` entry's `payloadHash`). Returns a discriminated union so callers
+ * can distinguish chain vs data failures.
+ */
+export async function verifyBackupIntegrity(ctx: BackupContext): Promise<VerifyBackupResult> {
+  // Step 1: chain verification. Without the history strategy there
+  // is no ledger; an unaudited backup verifies trivially as `ok`
+  // because there's nothing to diverge from.
+  const ledgerForVerify = ctx.getLedgerOrNull()
+  if (!ledgerForVerify) {
+    return { ok: true, head: '', length: 0 }
+  }
+  const chainResult = await ledgerForVerify.verify()
+  if (!chainResult.ok) {
+    return {
+      ok: false,
+      kind: 'chain',
+      divergedAt: chainResult.divergedAt,
+      message:
+        `Ledger chain diverged at index ${chainResult.divergedAt}: ` +
+        `expected prevHash "${chainResult.expected}" but found "${chainResult.actual}".`,
+    }
+  }
+
+  // Step 2: data envelope cross-check. Walk every entry in the
+  // ledger and, for the LATEST `put` per (collection, id), recompute
+  // the data envelope's payloadHash and compare. Earlier puts of the
+  // same id are skipped because the data collection only holds the
+  // current version — historical envelopes live in the deltas
+  // collection (which is itself protected by the chain).
+  // Reuse the ledger we already resolved in step 1.
+  const allEntries = await ledgerForVerify.loadAllEntries()
+
+  // Find the latest non-delete entry per (collection, id). Walk
+  // the entries in reverse so we hit the latest first; mark each
+  // (collection, id) as seen and skip subsequent entries.
+  const seen = new Set<string>()
+  const latest = new Map<
+    string,
+    { collection: string; id: string; expectedHash: string }
+  >()
+  for (let i = allEntries.length - 1; i >= 0; i--) {
+    const entry = allEntries[i]
+    if (!entry) continue
+    // Amendment entries are multi-record audit entries whose
+    // `collection` and `id` are empty strings — building a `"/"`
+    // key here would mark that synthetic slot as seen and falsely
+    // trip the data check on a record that never existed. Skip
+    // them BEFORE the key/seen bookkeeping so they neither
+    // tombstone real entries nor enter the latest map.
+    if (entry.op === 'amendment' || entry.op === 'lifecycle') continue
+    const key = `${entry.collection}/${entry.id}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    // For deletes the data collection should NOT have the record,
+    // so we skip — there's nothing to cross-check. Marking the key
+    // as seen above ensures any earlier `put` of the same id is
+    // also skipped (the record was subsequently deleted).
+    if (entry.op === 'delete') continue
+    latest.set(key, {
+      collection: entry.collection,
+      id: entry.id,
+      expectedHash: entry.payloadHash,
+    })
+  }
+
+  for (const { collection, id, expectedHash } of latest.values()) {
+    const envelope = await ctx.adapter.get(ctx.vault, collection, id)
+    if (!envelope) {
+      return {
+        ok: false,
+        kind: 'data',
+        collection,
+        id,
+        message:
+          `Ledger expects data record "${collection}/${id}" to exist, ` +
+          `but the adapter has no envelope for it.`,
+      }
+    }
+    const actualHash = await ctx.envelopePayloadHash(envelope)
+    if (actualHash !== expectedHash) {
+      return {
+        ok: false,
+        kind: 'data',
+        collection,
+        id,
+        message:
+          `Data envelope "${collection}/${id}" has been tampered with: ` +
+          `expected payloadHash "${expectedHash}", got "${actualHash}".`,
+      }
+    }
+  }
+
+  return {
+    ok: true,
+    head: chainResult.head,
+    length: chainResult.length,
+  }
+}
+
+/**
+ * Plaintext per-collection export, built on the vault's `exportStream`. Forces
+ * collection granularity (record-by-record output makes no sense in a single
+ * string) and merges dictionary snapshots across collections.
+ */
+export async function exportVaultJSON(ctx: BackupContext, opts: ExportStreamOptions = {}): Promise<string> {
+  // Force per-collection granularity regardless of caller setting:
+  // record-by-record output doesn't make sense in a single string.
+  const collections: Record<
+    string,
+    {
+      schema: null
+      refs: Record<string, { target: string; mode: 'strict' | 'warn' | 'cascade' }>
+      records: unknown[]
+    }
+  > = {}
+  let ledgerHead: ExportChunk['ledgerHead'] | undefined
+  // Merged dictionary snapshot across all collections.
+  // Only populated when `resolveLabels` is not set.
+  const allDictionaries: Record<
+    string, // collection name
+    Record<string, Record<string, Record<string, string>>>
+  > = {}
+
+  for await (const chunk of ctx.exportStream({
+    granularity: 'collection',
+    withLedgerHead: opts.withLedgerHead === true,
+    // #285 export layer: thread the export locale so records are read at the
+    // `export` layer (i18nText collapsed + dictKey/staticDict labels resolved).
+    ...(opts.resolveLabels !== undefined ? { resolveLabels: opts.resolveLabels } : {}),
+  })) {
+    collections[chunk.collection] = {
+      schema: null, // Standard Schema validators are not JSON-serializable
+      refs: chunk.refs,
+      records: chunk.records,
+    }
+    if (chunk.ledgerHead) ledgerHead = chunk.ledgerHead
+    // Collect dictionary snapshots unless resolveLabels is set
+    if (!opts.resolveLabels && chunk.dictionaries) {
+      allDictionaries[chunk.collection] = chunk.dictionaries
+    }
+  }
+
+  const hasDictionaries = Object.keys(allDictionaries).length > 0
+  return JSON.stringify({
+    _noydb_export: 1,
+    _compartment: ctx.vault,
+    _exported_at: new Date().toISOString(),
+    _exported_by: ctx.userId(),
+    collections,
+    ...(hasDictionaries ? { _dictionaries: allDictionaries } : {}),
+    ...(ledgerHead ? { ledgerHead } : {}),
+  })
+}

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -1,8 +1,6 @@
 import type {
   NoydbStore,
   EncryptedEnvelope,
-  VaultBackup,
-  VaultSnapshot,
   HistoryConfig,
   ExportStreamOptions,
   ExportChunk,
@@ -11,9 +9,17 @@ import type {
   TierMode,
   Role,
 } from './types.js'
+import {
+  dumpVault,
+  loadVault,
+  verifyBackupIntegrity,
+  exportVaultJSON,
+  type BackupContext,
+  type VerifyBackupResult,
+} from './vault-backup.js'
 import type { Noydb } from './noydb.js'
 import type { IssueDelegationOptions, DelegationToken } from './with-party/team/delegation.js'
-import { NOYDB_BACKUP_VERSION, NOYDB_FORMAT_VERSION } from './types.js'
+import { NOYDB_FORMAT_VERSION } from './types.js'
 import { Collection } from './collection.js'
 import type { CacheOptions } from './collection.js'
 import type { IndexDef } from './with-lookup/indexing/eager-indexes.js'
@@ -45,7 +51,6 @@ import {
 } from './errors.js'
 import { ElevatedHandle, ELEVATION_AUDIT_COLLECTION } from './with-commit/tx/elevated-handle.js'
 import type { NoydbEventEmitter } from './events.js'
-import { BackupLedgerError, BackupCorruptedError } from './errors.js'
 import type { StandardSchemaV1 } from './schema.js'
 import type { BlobStrategy } from './with-shape/blobs/strategy.js'
 import type { ObjectProjection } from './with-shape/blobs/object-projection.js'
@@ -63,7 +68,6 @@ import type { CrdtStrategy } from './with-commit/crdt/strategy.js'
 // bundle. The leaf files hold pure constants + a tiny hash helper;
 // the class lives behind the history strategy seam.
 import type { LedgerStore } from './with-commit/history/ledger/store.js'
-import { LEDGER_COLLECTION, LEDGER_DELTAS_COLLECTION } from './with-commit/history/ledger/constants.js'
 import { sha256Hex } from './with-commit/history/ledger/entry.js'
 import type { VaultInstant } from './with-commit/history/time-machine.js'
 import { NO_HISTORY, type HistoryStrategy } from './with-commit/history/strategy.js'
@@ -148,7 +152,6 @@ import { SchemaFenceController } from './with-shape/schema-update/fence-controll
 import { FenceWatcher } from './with-shape/schema-update/fence-watcher.js'
 import { loadFence, type FenceDoc } from './with-shape/schema-update/fence.js'
 import type { SchemaUpdateStrategy, UpdateDecision, TransformFn } from './with-shape/schema-update/types.js'
-import { SCHEMAS_COLLECTION } from './with-shape/persisted-schemas/storage.js'
 import type { AttestationFieldSchema, RevocationList } from '@noy-db/attestation'
 import { VaultAttestation } from './with-audit/attestation/vault-facade.js'
 import type { DumpSchemaOptions, VaultSchemaSnapshot, SchemaIntrospection } from './with-shape/introspection/types.js'
@@ -3775,77 +3778,35 @@ export class Vault {
    * both modes round-trip cleanly.
    */
   async dump(): Promise<string> {
-    const snapshot = await this.adapter.loadAll(this.name)
+    return dumpVault(this.backupContext())
+  }
 
-    // Load keyrings (separate path because loadAll filters them out
-    // along with all other underscore-prefixed internal collections).
-    const keyringIds = await this.adapter.list(this.name, '_keyring')
-    const keyrings: Record<string, unknown> = {}
-    for (const keyringId of keyringIds) {
-      const envelope = await this.adapter.get(this.name, '_keyring', keyringId)
-      if (envelope) {
-        keyrings[keyringId] = JSON.parse(envelope._data)
-      }
+  /**
+   * Build the {@link BackupContext} the extracted backup module (`vault-backup.ts`)
+   * binds to: the read paths + the post-load mutation seams (`reloadKeyring`,
+   * collection-cache clear, ledger-store reset) that `load()` performs on this
+   * Vault's private state.
+   */
+  private backupContext(): BackupContext {
+    return {
+      adapter: this.adapter,
+      vault: this.name,
+      userId: () => this.keyring.userId,
+      getLedgerOrNull: () => this.getLedgerOrNull(),
+      envelopePayloadHash: (envelope) => this.historyStrategy.envelopePayloadHash(envelope),
+      reloadKeyringAndRebuildDEK: async () => {
+        if (this.reloadKeyring) {
+          this.keyring = await this.reloadKeyring()
+          // Rebuild the DEK resolver against the refreshed keyring so
+          // the next ensureCollectionDEK call sees the loaded wrapped
+          // DEKs, not the cached pre-load ones.
+          this.getDEK = this.makeGetDEK()
+        }
+      },
+      clearCollectionCache: () => this.collectionCache.clear(),
+      resetLedgerStore: () => { this.ledgerStore = null },
+      exportStream: (opts) => this.exportStream(opts),
     }
-
-    // Load the ledger entries + deltas so the receiver can replay
-    // the chain after restore. Without this, `load()` would have an
-    // empty ledger and `verifyBackupIntegrity()` would have nothing
-    // to compare against.
-    //
-    // Also enumerate the blob collections so blob content ("covers")
-    // travels in the bundle (the blob DEK already travels in `_keyring`).
-    // Literals are inlined (not imported from blobs/blob-set.ts) to keep
-    // the blob runtime out of this kernel hot path — they mirror
-    // BLOB_INDEX/CHUNKS/EVICTION_AUDIT_COLLECTION and SLOTS/VERSIONS_PREFIX.
-    // The collect-loop skips empty ids, so this no-ops without blobs.
-    const internalSnapshot: VaultSnapshot = {}
-    const internalNames = [
-      LEDGER_COLLECTION, LEDGER_DELTAS_COLLECTION, SCHEMAS_COLLECTION, SEQUENCE_COLLECTION,
-      '_blob_index', '_blob_chunks', '_blob_eviction_audit',
-      ...Object.keys(snapshot).flatMap((c) => [`_blob_slots_${c}`, `_blob_versions_${c}`]),
-    ]
-    for (const internalName of internalNames) {
-      const ids = await this.adapter.list(this.name, internalName)
-      if (ids.length === 0) continue
-      const records: Record<string, EncryptedEnvelope> = {}
-      for (const id of ids) {
-        const envelope = await this.adapter.get(this.name, internalName, id)
-        if (envelope) records[id] = envelope
-      }
-      internalSnapshot[internalName] = records
-    }
-
-    // Embed the ledger head if there's a chain. An empty ledger
-    // (fresh vault) leaves `ledgerHead` undefined, which
-    // load() treats the same as a legacy backup (no integrity
-    // check, console warning). If history is not opted in,
-    // `getLedgerOrNull` returns null and we skip embedding entirely
-    // — the backup is still valid, just without the integrity head.
-    const ledgerForHead = this.getLedgerOrNull()
-    const head = ledgerForHead ? await ledgerForHead.head() : null
-    const backup: VaultBackup = {
-      _noydb_backup: NOYDB_BACKUP_VERSION,
-      _compartment: this.name,
-      _exported_at: new Date().toISOString(),
-      _exported_by: this.keyring.userId,
-      keyrings: keyrings as VaultBackup['keyrings'],
-      collections: snapshot,
-      ...(Object.keys(internalSnapshot).length > 0
-        ? { _internal: internalSnapshot }
-        : {}),
-      ...(head
-        ? {
-            ledgerHead: {
-              hash: head.hash,
-              index: head.entry.index,
-              ts: head.entry.ts,
-            },
-          }
-        : {}),
-    }
-
-    return JSON.stringify(backup)
   }
 
   /**
@@ -3871,90 +3832,7 @@ export class Vault {
    * — there's no chain to verify against.
    */
   async load(backupJson: string): Promise<void> {
-    const backup = JSON.parse(backupJson) as VaultBackup
-
-    // 1. Restore data collections.
-    await this.adapter.saveAll(this.name, backup.collections)
-
-    // 2. Restore keyrings.
-    for (const [userId, keyringFile] of Object.entries(backup.keyrings)) {
-      const envelope = {
-        _noydb: 1 as const,
-        _v: 1,
-        _ts: new Date().toISOString(),
-        _iv: '',
-        _data: JSON.stringify(keyringFile),
-      }
-      await this.adapter.put(this.name, '_keyring', userId, envelope)
-    }
-
-    // 3. Restore internal collections (`_ledger`, `_ledger_deltas`).
-    //    Required so verifyBackupIntegrity has the chain to walk.
-    if (backup._internal) {
-      for (const [internalName, records] of Object.entries(backup._internal)) {
-        for (const [id, envelope] of Object.entries(records)) {
-          await this.adapter.put(this.name, internalName, id, envelope)
-        }
-      }
-    }
-
-    // 4. Refresh the in-memory keyring from the freshly-loaded
-    //    keyring file. Without this, the Vault's getDEK
-    //    closure still holds the OLD session's DEKs, and every
-    //    decrypt of a loaded ledger entry / data envelope fails
-    //    with TamperedError because the DEK doesn't match the
-    //    ciphertext that was encrypted with the SOURCE user's DEK.
-    //    Skipped for plaintext vaults and for tests that
-    //    construct Vault without a reloadKeyring callback.
-    if (this.reloadKeyring) {
-      this.keyring = await this.reloadKeyring()
-      // Rebuild the DEK resolver against the refreshed keyring so
-      // the next ensureCollectionDEK call sees the loaded wrapped
-      // DEKs, not the cached pre-load ones.
-      this.getDEK = this.makeGetDEK()
-    }
-
-    // 5. Clear collection cache + reset the ledger store so the
-    //    next ledger() call rebuilds its head cache from the
-    //    freshly-loaded entries.
-    this.collectionCache.clear()
-    this.ledgerStore = null
-
-    // 5. Run the verification gate. Legacy backups (no ledgerHead)
-    //    skip this with a one-line warning so existing consumers can
-    //    still read them while migrating.
-    if (!backup.ledgerHead) {
-      console.warn(
-        `[noy-db] Loaded a legacy backup with no ledgerHead — ` +
-        `verifiable-backup integrity check skipped. ` +
-        `Re-export with a ledger-aware build to get tamper detection.`,
-      )
-      return
-    }
-
-    const result = await this.verifyBackupIntegrity()
-    if (!result.ok) {
-      // Surface the most specific error class we can. The result
-      // shape carries enough info for callers to inspect.
-      if (result.kind === 'data') {
-        throw new BackupCorruptedError(
-          result.collection,
-          result.id,
-          result.message,
-        )
-      }
-      throw new BackupLedgerError(result.message, result.divergedAt)
-    }
-
-    // 6. Cross-check: the freshly-verified head must match the
-    //    value embedded at dump time. A mismatch means someone
-    //    truncated or extended the chain after dump.
-    if (result.head !== backup.ledgerHead.hash) {
-      throw new BackupLedgerError(
-        `Backup ledger head mismatch: embedded "${backup.ledgerHead.hash}" ` +
-        `but reconstructed "${result.head}".`,
-      )
-    }
+    return loadVault(this.backupContext(), backupJson)
   }
 
   /**
@@ -3985,115 +3863,8 @@ export class Vault {
    * during `load()`. A scheduled background check is the simplest
    * way to detect tampering of an in-place vault.
    */
-  async verifyBackupIntegrity(): Promise<
-    | { readonly ok: true; readonly head: string; readonly length: number }
-    | {
-        readonly ok: false
-        readonly kind: 'chain'
-        readonly divergedAt: number
-        readonly message: string
-      }
-    | {
-        readonly ok: false
-        readonly kind: 'data'
-        readonly collection: string
-        readonly id: string
-        readonly message: string
-      }
-  > {
-    // Step 1: chain verification. Without the history strategy there
-    // is no ledger; an unaudited backup verifies trivially as `ok`
-    // because there's nothing to diverge from.
-    const ledgerForVerify = this.getLedgerOrNull()
-    if (!ledgerForVerify) {
-      return { ok: true, head: '', length: 0 }
-    }
-    const chainResult = await ledgerForVerify.verify()
-    if (!chainResult.ok) {
-      return {
-        ok: false,
-        kind: 'chain',
-        divergedAt: chainResult.divergedAt,
-        message:
-          `Ledger chain diverged at index ${chainResult.divergedAt}: ` +
-          `expected prevHash "${chainResult.expected}" but found "${chainResult.actual}".`,
-      }
-    }
-
-    // Step 2: data envelope cross-check. Walk every entry in the
-    // ledger and, for the LATEST `put` per (collection, id), recompute
-    // the data envelope's payloadHash and compare. Earlier puts of the
-    // same id are skipped because the data collection only holds the
-    // current version — historical envelopes live in the deltas
-    // collection (which is itself protected by the chain).
-    // Reuse the ledger we already resolved in step 1.
-    const allEntries = await ledgerForVerify.loadAllEntries()
-
-    // Find the latest non-delete entry per (collection, id). Walk
-    // the entries in reverse so we hit the latest first; mark each
-    // (collection, id) as seen and skip subsequent entries.
-    const seen = new Set<string>()
-    const latest = new Map<
-      string,
-      { collection: string; id: string; expectedHash: string }
-    >()
-    for (let i = allEntries.length - 1; i >= 0; i--) {
-      const entry = allEntries[i]
-      if (!entry) continue
-      // Amendment entries are multi-record audit entries whose
-      // `collection` and `id` are empty strings — building a `"/"`
-      // key here would mark that synthetic slot as seen and falsely
-      // trip the data check on a record that never existed. Skip
-      // them BEFORE the key/seen bookkeeping so they neither
-      // tombstone real entries nor enter the latest map.
-      if (entry.op === 'amendment' || entry.op === 'lifecycle') continue
-      const key = `${entry.collection}/${entry.id}`
-      if (seen.has(key)) continue
-      seen.add(key)
-      // For deletes the data collection should NOT have the record,
-      // so we skip — there's nothing to cross-check. Marking the key
-      // as seen above ensures any earlier `put` of the same id is
-      // also skipped (the record was subsequently deleted).
-      if (entry.op === 'delete') continue
-      latest.set(key, {
-        collection: entry.collection,
-        id: entry.id,
-        expectedHash: entry.payloadHash,
-      })
-    }
-
-    for (const { collection, id, expectedHash } of latest.values()) {
-      const envelope = await this.adapter.get(this.name, collection, id)
-      if (!envelope) {
-        return {
-          ok: false,
-          kind: 'data',
-          collection,
-          id,
-          message:
-            `Ledger expects data record "${collection}/${id}" to exist, ` +
-            `but the adapter has no envelope for it.`,
-        }
-      }
-      const actualHash = await this.historyStrategy.envelopePayloadHash(envelope)
-      if (actualHash !== expectedHash) {
-        return {
-          ok: false,
-          kind: 'data',
-          collection,
-          id,
-          message:
-            `Data envelope "${collection}/${id}" has been tampered with: ` +
-            `expected payloadHash "${expectedHash}", got "${actualHash}".`,
-        }
-      }
-    }
-
-    return {
-      ok: true,
-      head: chainResult.head,
-      length: chainResult.length,
-    }
+  async verifyBackupIntegrity(): Promise<VerifyBackupResult> {
+    return verifyBackupIntegrity(this.backupContext())
   }
 
   /**
@@ -4358,52 +4129,6 @@ export class Vault {
    * is the live validator object, not a serialization of it).
    */
   async exportJSON(opts: ExportStreamOptions = {}): Promise<string> {
-    // Force per-collection granularity regardless of caller setting:
-    // record-by-record output doesn't make sense in a single string.
-    const collections: Record<
-      string,
-      {
-        schema: null
-        refs: Record<string, { target: string; mode: 'strict' | 'warn' | 'cascade' }>
-        records: unknown[]
-      }
-    > = {}
-    let ledgerHead: ExportChunk['ledgerHead'] | undefined
-    // Merged dictionary snapshot across all collections.
-    // Only populated when `resolveLabels` is not set.
-    const allDictionaries: Record<
-      string, // collection name
-      Record<string, Record<string, Record<string, string>>>
-    > = {}
-
-    for await (const chunk of this.exportStream({
-      granularity: 'collection',
-      withLedgerHead: opts.withLedgerHead === true,
-      // #285 export layer: thread the export locale so records are read at the
-      // `export` layer (i18nText collapsed + dictKey/staticDict labels resolved).
-      ...(opts.resolveLabels !== undefined ? { resolveLabels: opts.resolveLabels } : {}),
-    })) {
-      collections[chunk.collection] = {
-        schema: null, // Standard Schema validators are not JSON-serializable
-        refs: chunk.refs,
-        records: chunk.records,
-      }
-      if (chunk.ledgerHead) ledgerHead = chunk.ledgerHead
-      // Collect dictionary snapshots unless resolveLabels is set
-      if (!opts.resolveLabels && chunk.dictionaries) {
-        allDictionaries[chunk.collection] = chunk.dictionaries
-      }
-    }
-
-    const hasDictionaries = Object.keys(allDictionaries).length > 0
-    return JSON.stringify({
-      _noydb_export: 1,
-      _compartment: this.name,
-      _exported_at: new Date().toISOString(),
-      _exported_by: this.keyring.userId,
-      collections,
-      ...(hasDictionaries ? { _dictionaries: allDictionaries } : {}),
-      ...(ledgerHead ? { ledgerHead } : {}),
-    })
+    return exportVaultJSON(this.backupContext(), opts)
   }
 }

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -81,6 +81,7 @@ import { NO_SHADOW, type ShadowStrategy } from './with-fork/shadow/strategy.js'
 import type { ConsentContext, ConsentAuditEntry, ConsentAuditFilter, ConsentOp } from './with-audit/consent/consent.js'
 import { NO_CONSENT, type ConsentStrategy } from './with-audit/consent/strategy.js'
 import { NO_PERIODS, type PeriodsStrategy } from './with-audit/periods/strategy.js'
+import { VaultPeriods } from './with-audit/periods/vault-facade.js'
 import {
   RefRegistry,
   RefIntegrityError,
@@ -112,7 +113,6 @@ import type { LocaleReadOptions, ConflictPolicy } from './types.js'
 import type { CrdtMode } from './with-commit/crdt/crdt.js'
 import { ReservedCollectionNameError, StaticDictReadonlyError, UnknownDictCodeError } from './errors.js'
 import {
-  PERIODS_COLLECTION,
   type PeriodRecord,
   type ClosePeriodOptions,
   type OpenPeriodOptions,
@@ -228,7 +228,7 @@ export class Vault {
   private readonly aggregateStrategy: AggregateStrategy | undefined
   private readonly crdtStrategy: CrdtStrategy | undefined
   private readonly consentStrategy: ConsentStrategy
-  private readonly periodsStrategy: PeriodsStrategy
+  private readonly periods: VaultPeriods
   private readonly shadowStrategy: ShadowStrategy
   private readonly historyStrategy: HistoryStrategy
   private readonly forgetStrategy: ForgetStrategy
@@ -412,18 +412,6 @@ export class Vault {
    */
   private consentContext: ConsentContext | null = null
 
-  /**
-   * Cache of closed/opened accounting periods.
-   * Populated on first `closePeriod` / `openPeriod` / `listPeriods` /
-   * per-collection write call. Kept in memory as an ordered list (by
-   * `closedAt`) so period checks run fast when the gate bus fires.
-   *
-   * Sentinel `null` means "not yet loaded" — the first consumer
-   * triggers a one-time `loadPeriods()` pass. Every subsequent
-   * closure/opening pushes into the cache in-place so the next write
-   * sees the updated chain without re-reading the adapter.
-   */
-  private periodCache: PeriodRecord[] | null = null
 
   /**
    * Registry of dictKey fields declared across all collections in this
@@ -576,7 +564,16 @@ export class Vault {
     this.aggregateStrategy = opts.aggregateStrategy
     this.crdtStrategy = opts.crdtStrategy
     this.consentStrategy = opts.consentStrategy ?? NO_CONSENT
-    this.periodsStrategy = opts.periodsStrategy ?? NO_PERIODS
+    this.periods = new VaultPeriods({
+      strategy: opts.periodsStrategy ?? NO_PERIODS,
+      adapter: this.adapter,
+      vault: this.name,
+      encrypted: this.encrypted,
+      userId: () => this.keyring.userId,
+      getDEK: (collection) => this.getDEK(collection),
+      getLedgerOrNull: () => this.getLedgerOrNull(),
+      collection: (name) => this.collection(name),
+    })
     this.shadowStrategy = opts.shadowStrategy ?? NO_SHADOW
     this.historyStrategy = opts.historyStrategy ?? NO_HISTORY
     this.forgetStrategy = opts.forgetStrategy ?? NO_FORGET
@@ -3523,27 +3520,7 @@ export class Vault {
    *.
    */
   async closePeriod(options: ClosePeriodOptions): Promise<PeriodRecord> {
-    const existing = await this._loadPeriodsCache()
-    this.periodsStrategy.validatePeriodName(options.name, existing)
-    if (typeof options.endDate !== 'string' || options.endDate.length === 0) {
-      throw new ValidationError('closePeriod: endDate must be a non-empty ISO string.')
-    }
-    const anchor = await this.periodsStrategy.chainAnchor(existing)
-    const record: PeriodRecord = {
-      name: options.name,
-      kind: 'closed',
-      endDate: options.endDate,
-      closedAt: new Date().toISOString(),
-      closedBy: this.keyring.userId,
-      priorPeriodHash: anchor.priorPeriodHash,
-      ...(anchor.priorPeriodName !== undefined && { priorPeriodName: anchor.priorPeriodName }),
-      ...(options.dateField !== undefined && { dateField: options.dateField }),
-    }
-    const envelope = await this._writePeriodRecord(record)
-    await this.periodsStrategy.appendPeriodLedgerEntry(this.getLedgerOrNull(), this.keyring.userId, envelope, record.name)
-    existing.push(record)
-    this.periodCache = existing
-    return record
+    return this.periods.closePeriod(options)
   }
 
   /**
@@ -3564,82 +3541,17 @@ export class Vault {
   async openPeriod<TCollections extends Record<string, Record<string, unknown>>>(
     options: OpenPeriodOptions<TCollections>,
   ): Promise<PeriodRecord> {
-    const existing = await this._loadPeriodsCache()
-    this.periodsStrategy.validatePeriodName(options.name, existing)
-    const prior = existing.find((p) => p.name === options.fromPeriod)
-    if (!prior) {
-      throw new ValidationError(
-        `openPeriod: fromPeriod "${options.fromPeriod}" does not exist in this vault.`,
-      )
-    }
-    if (prior.kind !== 'closed') {
-      throw new ValidationError(
-        `openPeriod: fromPeriod "${options.fromPeriod}" is of kind "${prior.kind}" — only closed periods can be carried forward.`,
-      )
-    }
-
-    // Build a read-only facade over CURRENT state + the prior
-    // period's endDate; after close, records dated <= endDate are
-    // frozen so current state equals closing state. The caller
-    // filters by business date via their own query against this
-    // facade.
-    const ctx = {
-      priorEndDate: prior.endDate,
-      collection: <T = unknown>(name: string) => {
-        const c = this.collection<T>(name)
-        return {
-          get: (id: string) => c.get(id),
-          list: () => c.list(),
-        }
-      },
-    }
-    const openings = await options.carryForward(ctx)
-
-    // Write opening entries via the normal Collection path so they
-    // get encryption, ledger entries, and change events. Each record
-    // is timestamped NOW (outside every closed period) — that's why
-    // the guard permits them.
-    const openingCollections: string[] = []
-    for (const [collName, records] of Object.entries(openings)) {
-      if (!records || typeof records !== 'object') continue
-      const recordEntries = Object.entries(records)
-      if (recordEntries.length === 0) continue
-      const coll = this.collection(collName)
-      for (const [id, record] of recordEntries) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        await coll.put(id, record as any)
-      }
-      openingCollections.push(collName)
-    }
-
-    const anchor = await this.periodsStrategy.chainAnchor(existing)
-    const record: PeriodRecord = {
-      name: options.name,
-      kind: 'opened',
-      startDate: options.startDate,
-      endDate: prior.endDate, // sealing boundary inherited from prior close
-      closedAt: new Date().toISOString(),
-      closedBy: this.keyring.userId,
-      priorPeriodHash: anchor.priorPeriodHash,
-      priorPeriodName: anchor.priorPeriodName ?? prior.name,
-      ...(openingCollections.length > 0 && { openingCollections }),
-    }
-    const envelope = await this._writePeriodRecord(record)
-    await this.periodsStrategy.appendPeriodLedgerEntry(this.getLedgerOrNull(), this.keyring.userId, envelope, record.name)
-    existing.push(record)
-    this.periodCache = existing
-    return record
+    return this.periods.openPeriod(options)
   }
 
   /** Return every closed / opened period in `closedAt` order. */
   async listPeriods(): Promise<readonly PeriodRecord[]> {
-    return [...(await this._loadPeriodsCache())]
+    return this.periods.listPeriods()
   }
 
   /** Look up a single period by name. Returns `null` if not found. */
   async getPeriod(name: string): Promise<PeriodRecord | null> {
-    const all = await this._loadPeriodsCache()
-    return all.find((p) => p.name === name) ?? null
+    return this.periods.getPeriod(name)
   }
 
   /** @internal — called by the gate bus before put/delete. */
@@ -3647,68 +3559,7 @@ export class Vault {
     existing: { ts: string | null; record: Record<string, unknown> | null } | null,
     incoming: Record<string, unknown> | null,
   ): Promise<void> {
-    // Fast path: nothing to check, and no periods ever touched this
-    // vault — avoid a full adapter scan for every put.
-    if (existing === null && incoming === null) return
-    if (this.periodCache === null) {
-      this.periodCache = await this.periodsStrategy.loadPeriods(
-        this.adapter,
-        this.name,
-        (env) => this._decryptPeriodRecord(env),
-      )
-    }
-    if (this.periodCache.length === 0) return
-    this.periodsStrategy.assertTsWritable(existing, incoming, this.periodCache)
-  }
-
-  private async _loadPeriodsCache(): Promise<PeriodRecord[]> {
-    if (this.periodCache !== null) return this.periodCache
-    const loaded = await this.periodsStrategy.loadPeriods(
-      this.adapter,
-      this.name,
-      (env: EncryptedEnvelope) => this._decryptPeriodRecord(env),
-    )
-    this.periodCache = loaded
-    return loaded
-  }
-
-  private async _writePeriodRecord(record: PeriodRecord): Promise<EncryptedEnvelope> {
-    const json = JSON.stringify(record)
-    let envelope: EncryptedEnvelope
-    if (this.encrypted) {
-      const dek = await this.getDEK(PERIODS_COLLECTION)
-      const { iv, data } = await encrypt(json, dek)
-      envelope = {
-        _noydb: NOYDB_FORMAT_VERSION,
-        _v: 1,
-        _ts: new Date().toISOString(),
-        _iv: iv,
-        _data: data,
-        _by: this.keyring.userId,
-      }
-    } else {
-      envelope = {
-        _noydb: NOYDB_FORMAT_VERSION,
-        _v: 1,
-        _ts: new Date().toISOString(),
-        _iv: '',
-        _data: json,
-        _by: this.keyring.userId,
-      }
-    }
-    await this.adapter.put(this.name, PERIODS_COLLECTION, record.name, envelope)
-    return envelope
-  }
-
-  private async _decryptPeriodRecord(envelope: EncryptedEnvelope): Promise<PeriodRecord> {
-    let json: string
-    if (this.encrypted) {
-      const dek = await this.getDEK(PERIODS_COLLECTION)
-      json = await decrypt(envelope._iv, envelope._data, dek)
-    } else {
-      json = envelope._data
-    }
-    return JSON.parse(json) as PeriodRecord
+    return this.periods.assertTsWritable(existing, incoming)
   }
 
   /** List all collection names in this vault. */

--- a/packages/hub/src/with-audit/periods/vault-facade.ts
+++ b/packages/hub/src/with-audit/periods/vault-facade.ts
@@ -1,0 +1,234 @@
+/**
+ * Vault-side accounting-periods facade, lifted off the `Vault` god-object
+ * (Phase 5 A3 of the microkernel refactoring).
+ *
+ * Holds the period close/open/list/get entry points, the write-time guard
+ * (`assertTsWritable`, called by the subsystem gate bus before put/delete via
+ * the thin `vault._assertTsWritable` delegator), and the period-record cache —
+ * `periodCache`, which used to live on the `Vault` instance now lives here.
+ * The encryption/decryption of a `_periods` envelope and the chain-anchor
+ * bookkeeping are unchanged; behaviour is byte-identical to the inline `Vault`
+ * methods it replaced — every dependency the moving code touched on `this.*`
+ * arrives via {@link VaultPeriodsDeps}.
+ *
+ * Internal subsystem — reached through `vault.closePeriod(...)` etc.
+ */
+import { ValidationError } from '../../errors.js'
+import { NOYDB_FORMAT_VERSION } from '../../types.js'
+import { encrypt, decrypt } from '../../crypto.js'
+import type { EncryptedEnvelope, NoydbStore } from '../../types.js'
+import type { LedgerStore } from '../../with-commit/history/ledger/store.js'
+import type { Collection } from '../../collection.js'
+import type { PeriodsStrategy } from './strategy.js'
+import {
+  PERIODS_COLLECTION,
+  type PeriodRecord,
+  type ClosePeriodOptions,
+  type OpenPeriodOptions,
+} from './periods.js'
+
+/** Everything the moving period methods touched on the vault's `this.*`. */
+export interface VaultPeriodsDeps {
+  /** Resolved periods strategy (NO_PERIODS when not configured). */
+  readonly strategy: PeriodsStrategy
+  /** The ciphertext store. */
+  readonly adapter: NoydbStore
+  /** Vault namespace name. */
+  readonly vault: string
+  /** Whether records are encrypted (vs debug-plaintext). */
+  readonly encrypted: boolean
+  /** The invoking keyring's user id (read fresh per call). */
+  userId(): string
+  /** Per-collection DEK resolver (bound `vault.getDEK`). */
+  getDEK(collection: string): Promise<CryptoKey>
+  /** The vault's ledger store, or null when history is off. */
+  getLedgerOrNull(): LedgerStore | null
+  /** Collection accessor (used by `openPeriod`'s carry-forward writes). */
+  collection<T = unknown>(name: string): Collection<T>
+}
+
+export class VaultPeriods {
+  /**
+   * Loaded period records, lazily populated on first close/open/list/get/guard
+   * and kept in sync by the write paths. `null` until first touched — the
+   * write-guard fast-path avoids a full adapter scan for vaults that never use
+   * periods.
+   */
+  private periodCache: PeriodRecord[] | null = null
+
+  constructor(private readonly deps: VaultPeriodsDeps) {}
+
+  async closePeriod(options: ClosePeriodOptions): Promise<PeriodRecord> {
+    const existing = await this.loadPeriodsCache()
+    this.deps.strategy.validatePeriodName(options.name, existing)
+    if (typeof options.endDate !== 'string' || options.endDate.length === 0) {
+      throw new ValidationError('closePeriod: endDate must be a non-empty ISO string.')
+    }
+    const anchor = await this.deps.strategy.chainAnchor(existing)
+    const record: PeriodRecord = {
+      name: options.name,
+      kind: 'closed',
+      endDate: options.endDate,
+      closedAt: new Date().toISOString(),
+      closedBy: this.deps.userId(),
+      priorPeriodHash: anchor.priorPeriodHash,
+      ...(anchor.priorPeriodName !== undefined && { priorPeriodName: anchor.priorPeriodName }),
+      ...(options.dateField !== undefined && { dateField: options.dateField }),
+    }
+    const envelope = await this.writePeriodRecord(record)
+    await this.deps.strategy.appendPeriodLedgerEntry(this.deps.getLedgerOrNull(), this.deps.userId(), envelope, record.name)
+    existing.push(record)
+    this.periodCache = existing
+    return record
+  }
+
+  async openPeriod<TCollections extends Record<string, Record<string, unknown>>>(
+    options: OpenPeriodOptions<TCollections>,
+  ): Promise<PeriodRecord> {
+    const existing = await this.loadPeriodsCache()
+    this.deps.strategy.validatePeriodName(options.name, existing)
+    const prior = existing.find((p) => p.name === options.fromPeriod)
+    if (!prior) {
+      throw new ValidationError(
+        `openPeriod: fromPeriod "${options.fromPeriod}" does not exist in this vault.`,
+      )
+    }
+    if (prior.kind !== 'closed') {
+      throw new ValidationError(
+        `openPeriod: fromPeriod "${options.fromPeriod}" is of kind "${prior.kind}" — only closed periods can be carried forward.`,
+      )
+    }
+
+    // Build a read-only facade over CURRENT state + the prior
+    // period's endDate; after close, records dated <= endDate are
+    // frozen so current state equals closing state. The caller
+    // filters by business date via their own query against this
+    // facade.
+    const ctx = {
+      priorEndDate: prior.endDate,
+      collection: <T = unknown>(name: string) => {
+        const c = this.deps.collection<T>(name)
+        return {
+          get: (id: string) => c.get(id),
+          list: () => c.list(),
+        }
+      },
+    }
+    const openings = await options.carryForward(ctx)
+
+    // Write opening entries via the normal Collection path so they
+    // get encryption, ledger entries, and change events. Each record
+    // is timestamped NOW (outside every closed period) — that's why
+    // the guard permits them.
+    const openingCollections: string[] = []
+    for (const [collName, records] of Object.entries(openings)) {
+      if (!records || typeof records !== 'object') continue
+      const recordEntries = Object.entries(records)
+      if (recordEntries.length === 0) continue
+      const coll = this.deps.collection(collName)
+      for (const [id, record] of recordEntries) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await coll.put(id, record as any)
+      }
+      openingCollections.push(collName)
+    }
+
+    const anchor = await this.deps.strategy.chainAnchor(existing)
+    const record: PeriodRecord = {
+      name: options.name,
+      kind: 'opened',
+      startDate: options.startDate,
+      endDate: prior.endDate, // sealing boundary inherited from prior close
+      closedAt: new Date().toISOString(),
+      closedBy: this.deps.userId(),
+      priorPeriodHash: anchor.priorPeriodHash,
+      priorPeriodName: anchor.priorPeriodName ?? prior.name,
+      ...(openingCollections.length > 0 && { openingCollections }),
+    }
+    const envelope = await this.writePeriodRecord(record)
+    await this.deps.strategy.appendPeriodLedgerEntry(this.deps.getLedgerOrNull(), this.deps.userId(), envelope, record.name)
+    existing.push(record)
+    this.periodCache = existing
+    return record
+  }
+
+  /** Return every closed / opened period in `closedAt` order. */
+  async listPeriods(): Promise<readonly PeriodRecord[]> {
+    return [...(await this.loadPeriodsCache())]
+  }
+
+  /** Look up a single period by name. Returns `null` if not found. */
+  async getPeriod(name: string): Promise<PeriodRecord | null> {
+    const all = await this.loadPeriodsCache()
+    return all.find((p) => p.name === name) ?? null
+  }
+
+  /** Called by the gate bus before put/delete. */
+  async assertTsWritable(
+    existing: { ts: string | null; record: Record<string, unknown> | null } | null,
+    incoming: Record<string, unknown> | null,
+  ): Promise<void> {
+    // Fast path: nothing to check, and no periods ever touched this
+    // vault — avoid a full adapter scan for every put.
+    if (existing === null && incoming === null) return
+    if (this.periodCache === null) {
+      this.periodCache = await this.deps.strategy.loadPeriods(
+        this.deps.adapter,
+        this.deps.vault,
+        (env) => this.decryptPeriodRecord(env),
+      )
+    }
+    if (this.periodCache.length === 0) return
+    this.deps.strategy.assertTsWritable(existing, incoming, this.periodCache)
+  }
+
+  private async loadPeriodsCache(): Promise<PeriodRecord[]> {
+    if (this.periodCache !== null) return this.periodCache
+    const loaded = await this.deps.strategy.loadPeriods(
+      this.deps.adapter,
+      this.deps.vault,
+      (env: EncryptedEnvelope) => this.decryptPeriodRecord(env),
+    )
+    this.periodCache = loaded
+    return loaded
+  }
+
+  private async writePeriodRecord(record: PeriodRecord): Promise<EncryptedEnvelope> {
+    const json = JSON.stringify(record)
+    let envelope: EncryptedEnvelope
+    if (this.deps.encrypted) {
+      const dek = await this.deps.getDEK(PERIODS_COLLECTION)
+      const { iv, data } = await encrypt(json, dek)
+      envelope = {
+        _noydb: NOYDB_FORMAT_VERSION,
+        _v: 1,
+        _ts: new Date().toISOString(),
+        _iv: iv,
+        _data: data,
+        _by: this.deps.userId(),
+      }
+    } else {
+      envelope = {
+        _noydb: NOYDB_FORMAT_VERSION,
+        _v: 1,
+        _ts: new Date().toISOString(),
+        _iv: '',
+        _data: json,
+        _by: this.deps.userId(),
+      }
+    }
+    await this.deps.adapter.put(this.deps.vault, PERIODS_COLLECTION, record.name, envelope)
+    return envelope
+  }
+
+  private async decryptPeriodRecord(envelope: EncryptedEnvelope): Promise<PeriodRecord> {
+    let json: string
+    if (this.deps.encrypted) {
+      const dek = await this.deps.getDEK(PERIODS_COLLECTION)
+      json = await decrypt(envelope._iv, envelope._data, dek)
+    } else {
+      json = envelope._data
+    }
+    return JSON.parse(json) as PeriodRecord
+  }
+}

--- a/packages/hub/src/with-fork/snapshots/noydb-facade.ts
+++ b/packages/hub/src/with-fork/snapshots/noydb-facade.ts
@@ -1,0 +1,135 @@
+/**
+ * Noydb-side snapshot facade, lifted off the `Noydb` god-object (Phase 5 A9 of
+ * the microkernel refactoring).
+ *
+ * Holds the on-demand checkpoint (`snapshot`), listing (`listSnapshots`),
+ * restore (`restoreSnapshot`), and the automatic-snapshot cadence wiring
+ * (`initCadence`, previously `Noydb.initSnapshotCadence`). The dirty-vault set
+ * and the cadence scheduler — both lifecycle state that used to live on the
+ * `Noydb` instance — now live here; `Noydb.close()` calls {@link stop}.
+ * Behaviour is byte-identical to the inline `Noydb` methods it replaced — every
+ * dependency the moving code touched on `this.*` arrives via
+ * {@link NoydbSnapshotsDeps}.
+ *
+ * Internal subsystem — reached through `noydb.snapshot(...)` etc.
+ */
+import { NO_SNAPSHOTS, type SnapshotStrategy, type SnapshotMeta } from './strategy.js'
+import { SnapshotScheduler } from './scheduler.js'
+import { ValidationError } from '../../errors.js'
+import type { Vault } from '../../vault.js'
+import type { WriteHook, Unsubscribe } from '../../write-hooks.js'
+
+/** Everything the moving snapshot methods touched on the Noydb instance's `this.*`. */
+export interface NoydbSnapshotsDeps {
+  /** Resolved snapshot strategy (NO_SNAPSHOTS when not configured). */
+  readonly strategy: SnapshotStrategy
+  /** Acting user id, used as the snapshot `by`. */
+  readonly user: string
+  /** Whether the owning instance has been closed. */
+  isClosed(): boolean
+  /** Resolve an open vault from the instance's vault cache. */
+  getVault(name: string): Vault | undefined
+  /** Subscribe to post-write events (cadence dirty-marking). */
+  onAfterWrite(handler: WriteHook): Unsubscribe
+}
+
+export class NoydbSnapshots {
+  private scheduler: SnapshotScheduler | null = null
+  private readonly dirtyVaults = new Set<string>()
+
+  constructor(private readonly deps: NoydbSnapshotsDeps) {
+    this.initCadence()
+  }
+
+  /**
+   * Take an on-demand checkpoint of the given vault.
+   * Requires `snapshotStrategy: withSnapshots({ store })` in `createNoydb`.
+   * @throws ValidationError when the vault is not open
+   */
+  async snapshot(vault: string, opts?: { label?: string; note?: string }): Promise<SnapshotMeta> {
+    if (this.deps.isClosed()) throw new ValidationError('Instance is closed')
+    const v = this.deps.getVault(vault)
+    if (!v) {
+      throw new ValidationError(
+        `Vault "${vault}" is not open. Call openVault() first.`,
+      )
+    }
+    return this.deps.strategy.snapshot(v, this.deps.user, opts)
+  }
+
+  /**
+   * Wire the automatic-snapshot cadence when a non-manual `snapshotPolicy` is
+   * configured. Subscribes to `onAfterWrite` to mark the written vault dirty and
+   * nudge the scheduler; the scheduler fires `autoSnapshot()` per dirty vault.
+   * No-op for `mode:'manual'` or no policy.
+   */
+  private initCadence(): void {
+    const policy = this.deps.strategy.policy
+    if (!policy || !policy.mode || policy.mode === 'manual') return
+
+    const scheduler = new SnapshotScheduler(policy, {
+      fire: async () => {
+        const names = [...this.dirtyVaults]
+        this.dirtyVaults.clear()
+        for (const name of names) {
+          const v = this.deps.getVault(name)
+          if (!v) continue
+          try {
+            await this.deps.strategy.autoSnapshot(v, this.deps.user)
+          } catch (err) {
+            // Keep the vault pending so a later cadence tick (interval) or the
+            // next write (debounce) retries; a failed auto-snapshot is logged,
+            // never thrown (it runs inside the after-write hook contract).
+            this.dirtyVaults.add(name)
+            console.warn(
+              `[noy-db] auto-snapshot failed for vault "${name}": ` +
+              (err instanceof Error ? err.message : String(err)),
+            )
+          }
+        }
+      },
+      pendingCount: () => this.dirtyVaults.size,
+    })
+
+    this.deps.onAfterWrite((event) => {
+      this.dirtyVaults.add(event.vault)
+      scheduler.notifyChange()
+    })
+    scheduler.start()
+    this.scheduler = scheduler
+  }
+
+  /**
+   * List all snapshots for the given vault, newest first.
+   * Reads only the sidecar index — does not download snapshot bytes.
+   */
+  async listSnapshots(vault: string): Promise<SnapshotMeta[]> {
+    if (this.deps.isClosed()) throw new ValidationError('Instance is closed')
+    return this.deps.strategy.listSnapshots(vault)
+  }
+
+  /**
+   * Restore the vault to a previously snapshotted state.
+   * Runs `verifyBackupIntegrity()` automatically on restore.
+   * @throws SnapshotNotFoundError when `version` doesn't exist in the store
+   * @throws ValidationError when the vault is not open
+   */
+  async restoreSnapshot(vault: string, version: string): Promise<void> {
+    if (this.deps.isClosed()) throw new ValidationError('Instance is closed')
+    const v = this.deps.getVault(vault)
+    if (!v) {
+      throw new ValidationError(
+        `Vault "${vault}" is not open. Call openVault() first.`,
+      )
+    }
+    return this.deps.strategy.restoreSnapshot(v, version)
+  }
+
+  /** Stop the cadence scheduler (called from `Noydb.close()`). */
+  stop(): void {
+    this.scheduler?.stop()
+    this.scheduler = null
+  }
+}
+
+export { NO_SNAPSHOTS }

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -603,7 +603,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Lowered 4627→4587 (Phase 5 A2: attestation extraction): the issue/revoke methods + `make*Context` closures + the field-schema registry moved to `with-audit/attestation/vault-facade.ts` (`VaultAttestation`); vault.ts holds a facade instance + thin delegators.
   // Lowered 4587→4547 (Phase 5 A7: capability gating extraction): `assertCanExport`/`assertCanImport`/`canExport`/`canImport` predicate bodies moved to `capabilities.ts` (pure keyring predicates); vault.ts keeps the typed public overloads + thin delegators.
   // Bumped 4547→4559 (bundle includes blobs): dump() now enumerates the blob collections (global _blob_index/_blob_chunks/_blob_eviction_audit + per-collection _blob_slots_*/_blob_versions_*) so blob "covers" travel in the .noydb bundle; +12 lines (inlined name literals + computed internalNames array + explanatory comment), no blob runtime pulled into the hot path.
-  'packages/hub/src/vault.ts': 4559,
+  // Lowered 4559→4410 (Phase 5 A3: periods extraction): the close/open/list/get methods + `_assertTsWritable` guard + `_loadPeriodsCache`/`_writePeriodRecord`/`_decryptPeriodRecord` helpers + the `periodCache` field moved to `with-audit/periods/vault-facade.ts` (`VaultPeriods`); vault.ts holds a facade instance + thin delegators (`_assertTsWritable` still the gate-bus entry point).
+  'packages/hub/src/vault.ts': 4410,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -604,7 +604,8 @@ const KERNEL_SURFACE_BUDGET = {
   // Lowered 4587→4547 (Phase 5 A7: capability gating extraction): `assertCanExport`/`assertCanImport`/`canExport`/`canImport` predicate bodies moved to `capabilities.ts` (pure keyring predicates); vault.ts keeps the typed public overloads + thin delegators.
   // Bumped 4547→4559 (bundle includes blobs): dump() now enumerates the blob collections (global _blob_index/_blob_chunks/_blob_eviction_audit + per-collection _blob_slots_*/_blob_versions_*) so blob "covers" travel in the .noydb bundle; +12 lines (inlined name literals + computed internalNames array + explanatory comment), no blob runtime pulled into the hot path.
   // Lowered 4559→4410 (Phase 5 A3: periods extraction): the close/open/list/get methods + `_assertTsWritable` guard + `_loadPeriodsCache`/`_writePeriodRecord`/`_decryptPeriodRecord` helpers + the `periodCache` field moved to `with-audit/periods/vault-facade.ts` (`VaultPeriods`); vault.ts holds a facade instance + thin delegators (`_assertTsWritable` still the gate-bus entry point).
-  'packages/hub/src/vault.ts': 4410,
+  // Lowered 4410→4135 (Phase 5 A4: backup extraction): `dump`/`load`/`verifyBackupIntegrity`/`exportJSON` (incl. the blob-collection enumeration in dump() and the branchy chain+data-envelope integrity walk) moved to `vault-backup.ts`; vault.ts holds thin delegators + a `backupContext()` builder exposing the read paths and the post-load mutation seams (reloadKeyring/cache-clear/ledger-reset).
+  'packages/hub/src/vault.ts': 4135,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -633,7 +633,11 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 3095→3140 (2026-06-17, FR-6 Task 4): grantCustodian/revokeCustodian —
   // the genuinely-core owner-only custody grant/revoke surface (defended in
   // depth by gate + explicit keyring.role !== 'owner' check).
-  'packages/hub/src/noydb.ts': 3140,
+  // Lowered 3140→3085 (Phase 5 A9: snapshot extraction): `snapshot`/`listSnapshots`/
+  // `restoreSnapshot`/`initSnapshotCadence` + the dirty-vault set + cadence scheduler
+  // field moved to `with-fork/snapshots/noydb-facade.ts` (`NoydbSnapshots`); noydb.ts
+  // holds a facade instance + thin delegators and `close()` calls `snapshots.stop()`.
+  'packages/hub/src/noydb.ts': 3085,
 }
 
 function checkKernelSurface() {


### PR DESCRIPTION
Phase 5 (kernel-shrink) batch 2 — three behavior-preserving method-cluster extractions, each behind a deps interface with thin delegators left on Vault/Noydb.

- **A9** snapshots → `with-fork/snapshots/noydb-facade.ts` (noydb.ts −55; the facade owns the cadence scheduler + dirty set, `close()` calls `stop()`)
- **A3** periods → `with-audit/periods/vault-facade.ts` (vault.ts −149)
- **A4** backup `dump`/`load`/`verifyBackupIntegrity`/`exportJSON` → `vault-backup.ts` (vault.ts −275; the flagged "tangled" one — `load()`'s private-field mutations lifted via 3 context callbacks `reloadKeyringAndRebuildDEK`/`clearCollectionCache`/`resetLedgerStore`; `dump()`'s `_blob_*` enumeration carried verbatim)

**−479 LOC** off the god-objects (vault.ts 4558→4134, noydb.ts 3110→3055; ceilings lowered, never bumped). Pure moves — public methods preserved as delegators, no export removed. typecheck ✓ · lint ✓ · test ✓ (2942) · check-architecture ✓ · build ✓.