### PR TITLE
fix(hub): final-review findings (attestation getDEK late-bind, joinResolver type) + milestone changelog

### DIFF
--- a/packages/hub/CHANGELOG.md
+++ b/packages/hub/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Internal: microkernel refactor — god-object decomposition (no public API change)
+
+The three always-on hub files were decomposed behind named folder seams, taking the kernel from ~13,525 LOC to ~10,400 (−23%) with the public surface byte-identical (the `/kernel` + `/adapter` golden-surface tests guard it). No behavior change; the full suite stayed green throughout.
+
+- **Optional subsystems** are now grouped into eight `with-*` dimension folders (`with-lookup`/`with-commit`/`with-formula`/`with-shape`/`with-audit`/`with-fork`/`with-share`/`with-party`); each cohesive cluster moved behind a small deps interface with the kernel keeping thin delegators. Shared caches/registries (the per-record CEK `Lru`, eager-index caches, the subsystem bus) stay kernel-resident and pass **by reference**.
+- **`collection.ts`** 5774→4300, **`vault.ts`** 4722→3824, **`noydb.ts`** 3110→2274. Examples: envelope/CEK crypto → `record-keys/record-codec.ts`; auth/recovery/enrollment → `with-party/team/`; backup/dump-load → `vault-backup.ts`; tiers/search/index-maintenance → `with-audit/tiers` + `with-lookup/{search,indexing}`; the Collection constructor → a pure `resolveCollectionConfig()` + thin wiring.
+- **Additive only at the seams:** new `@noy-db/hub/describe` subpath (the UI contract); `bundle` moved to the `with-share` dimension (subpath unchanged); `vault.dump()`/`.noydb` bundles now include the `_blob_*` collections so blob covers travel sealed inside the artifact; `extractPartition` carries a slice's blobs re-keyed under a fresh transfer DEK (no master-key leak).
+
 Record-scoped sealing (epic [#306](https://github.com/vLannaAi/noy-db/issues/306)) — sealed `sensitive` fields now participate in crypto-shred and tamper-evidence end to end — plus money-typing parity across the aggregate builders.
 
 ### Feature: record-scoped sealing — `forget()` erases sealed fields + the ledger attests them ([#306](https://github.com/vLannaAi/noy-db/issues/306))

--- a/packages/hub/__tests__/attestation-vault.test.ts
+++ b/packages/hub/__tests__/attestation-vault.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { createNoydb } from '../src/noydb.js'
 import { verifyAttestation } from '@noy-db/attestation'
 import { withI18n } from '../src/with-shape/i18n/index.js'
+import { withHistory } from '../src/with-commit/history/index.js'
 import { i18nText } from '../src/with-shape/i18n/core.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
 import { ConflictError, AttestationError } from '../src/errors.js'
@@ -154,5 +155,45 @@ describe('vault.getDocumentSigningPublicKey (mint-on-read role gate)', () => {
     expect(result.keyId).toBe(minted.keyId)
     expect(result.publicKeyB64).toBe(minted.publicKeyB64)
     expect(after).toEqual(before) // read did not mint or mutate
+  })
+
+  // Guards the late-bound `getDEK` wiring on the attestation facade
+  // (vault.ts: `getDEK: (collection) => this.getDEK(collection)`). `load()`
+  // rebuilds `this.getDEK` against the reloaded keyring; the facade reads the
+  // current field per call rather than a frozen ctor-time closure, so
+  // attestation issuance/verification keeps working across a backup round-trip.
+  it('issues + verifies attestations across a dump/load round-trip', async () => {
+    const adapter = memory()
+    const db = await createNoydb({ store: adapter, user: 'firm', secret: 'firm-passphrase-2026', historyStrategy: withHistory() })
+    const vault = await db.openVault('books')
+    const invoices = vault.collection<Invoice>('invoices', { attestation })
+    await invoices.put('inv-1', { id: 'inv-1', invoiceNo: 'INV-1', total: 1234.5, issueDate: '2026-05-29' })
+
+    // Issue BEFORE the round-trip so the attestation facade's getDEK
+    // resolver memoizes the `_attestations` DEK; load() then rebuilds
+    // `this.getDEK` underneath it.
+    const issued = await vault.issueAttestation('invoices', 'inv-1')
+    const before = await vault.getDocumentSigningPublicKey()
+
+    const backup = await vault.dump()
+    await vault.load(backup)
+
+    // After load(), reading the signer routes through the rebuilt resolver.
+    const after = await vault.getDocumentSigningPublicKey()
+    expect(after.keyId).toBe(before.keyId)
+    expect(after.publicKeyB64).toBe(before.publicKeyB64)
+
+    const r = await verifyAttestation({
+      qr: issued.qr,
+      claimedFields: { invoiceNo: 'INV-1', total: 1234.5, issueDate: '2026-05-29' },
+      fieldSchema: attestation,
+      publicKeys: { [after.keyId]: after.publicKeyB64 },
+    })
+    expect(r.valid).toBe(true)
+
+    // And a fresh issuance still works post-load (new signer read path).
+    await vault.collection<Invoice>('invoices').put('inv-2', { id: 'inv-2', invoiceNo: 'INV-2', total: 5, issueDate: '2026-05-29' })
+    const reissued = await vault.issueAttestation('invoices', 'inv-2')
+    expect(reissued.keyId).toBe(before.keyId)
   })
 })

--- a/packages/hub/src/collection-config.ts
+++ b/packages/hub/src/collection-config.ts
@@ -202,6 +202,7 @@ export interface CollectionOpts<T> {
     | {
         resolveSource(collectionName: string): JoinableSource | null
         resolveRef(leftCollection: string, field: string): RefDescriptor | null
+        resolveDictSource?: (leftCollection: string, field: string) => JoinableSource | null
       }
     | undefined
   /** — i18nText field descriptors for locale-aware reads. */

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -610,7 +610,7 @@ export class Vault {
     this.attestation = new VaultAttestation({
       adapter: this.adapter,
       vault: this.name,
-      getDEK: this.getDEK,
+      getDEK: (collection) => this.getDEK(collection),
       role: () => this.keyring.role,
       getRawRecord: async (collection, recId) =>
         (await this.collection(collection).get(recId, { locale: 'raw' })) as Record<string, unknown> | null,


### PR DESCRIPTION
## Final-review findings + milestone changelog

Closes out the microkernel refactor arc. A final whole-branch review (three parallel lenses: crypto/keyring, shared-state aliasing, structure/surface over the full `8e6a3217..c5d6a8d0` diff) returned **clean except two issues**, both fixed here.

### Fixes
- **`vault.ts` — late-bind attestation `getDEK`.** The A2 attestation extraction captured `getDEK: this.getDEK` once at constructor time, freezing the closure. `load()` rebuilds `this.getDEK` over the reloaded keyring, so the facade must read the field per call — restored to `(collection) => this.getDEK(collection)`, matching `UserApi`/`VaultPeriods` and the pre-refactor per-call semantics. **Latent** (the only reassignment path, `load()`, doesn't carry `_attestations`, and a same-vault round-trip preserves the DEK — empirically confirmed the round-trip passes with or without the fix), but the frozen form is incorrect by construction. Adds an attestation dump/load round-trip integration guard.
- **`collection-config.ts` — restore `joinResolver.resolveDictSource?`.** The A11 ctor split dropped the optional `resolveDictSource?` arm from the exported `CollectionOpts.joinResolver` type (the Collection field kept it). Runtime was unaffected (Vault passes `this`); this restores the public type.

### Reviews that came back clean
- **Crypto/keyring (Opus):** all five clusters (A8 rotate/recover variants, RecordCodec CEK shared-`Lru` ref, A13 tiers CEK re-wrap, extractPartition fresh transfer DEK, blob fix) byte-identical — verified via git-history comparison.
- **Shared-state aliasing:** every deps interface passes the live cache/registry by reference (the attestation finding above was the one exception).
- **Structure/surface:** ctor field-wiring identical, no public-export drift, with-* import rewrites correct. (The dump() "blobs now travel" change it flagged is the intentional #527 fix.)

### Milestone changelog
Adds an Unreleased "Internal: microkernel refactor" entry: kernel ~13,525 → ~10,400 LOC (−23%), public surface byte-identical.

### Gates
typecheck · lint · **test 2950 passed / 339 files** · check-architecture ✓ · build ✓
