### PR TITLE
fix(hub): close the four open Medium security findings (M-2…M-5)

### DIFF
--- a/packages/hub/__tests__/derivations/fanout-sidecar-encryption.test.ts
+++ b/packages/hub/__tests__/derivations/fanout-sidecar-encryption.test.ts
@@ -1,0 +1,151 @@
+/**
+ * M-3 (security): the derivations fanout sidecar must be encrypted under the
+ * collection DEK, not written as plaintext JSON. A ciphertext-only store must
+ * not be able to read the derivation graph / `keys[]` / `emittedAt`.
+ *
+ * Back-compat: legacy plaintext sidecars (`_iv === ''`) must still read.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withDerivation } from '../../src/index.js'
+import { generateDEK } from '../../src/crypto.js'
+import { NOYDB_FORMAT_VERSION } from '../../src/types.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/types.js'
+import {
+  saveFanoutSidecar,
+  loadFanoutSidecar,
+} from '../../src/with-formula/derivations/fanout-sidecar.js'
+
+function memoryWithData(): { store: NoydbStore; data: Map<string, EncryptedEnvelope> } {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  const store = {
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+    async get(v: string, c: string, i: string) { return data.get(k(v, c, i)) ?? null },
+    async put(v: string, c: string, i: string, env: EncryptedEnvelope) { data.set(k(v, c, i), env) },
+    async delete(v: string, c: string, i: string) { data.delete(k(v, c, i)) },
+    async list(v: string, c: string) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v: string) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/')
+        if (vname === v) {
+          out[cname!] = out[cname!] ?? {}
+          out[cname!]![id!] = env
+        }
+      }
+      return out
+    },
+    async saveAll(v: string, payload: Record<string, Record<string, EncryptedEnvelope>>) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c]!)) {
+          data.set(k(v, c, i), payload[c]![i]!)
+        }
+      }
+    },
+  } as unknown as NoydbStore
+  return { store, data }
+}
+
+interface Tagged extends Record<string, unknown> {
+  id: string
+  tags: string[]
+}
+
+interface TagRow extends Record<string, unknown> {
+  id: string
+  sourceId: string
+  tag: string
+}
+
+async function buildDb(store: NoydbStore) {
+  const strategy = withDerivation<Tagged, { tagRows: TagRow[] }>({
+    source: 'docs',
+    deterministic: true,
+    outputs: {
+      tagRows: {
+        shape: 'array',
+        collection: 'docTags',
+        key: (o) => `${o.sourceId as string}|${o.tag as string}`,
+        maxFanout: 36,
+      },
+    },
+    derive: (doc) => ({
+      tagRows: doc.tags.map(tag => ({ id: `${doc.id}|${tag}`, sourceId: doc.id, tag })),
+    }),
+    lifecycle: 'eager',
+  })
+  const db = await createNoydb({
+    store,
+    user: 'alice',
+    secret: 'correct horse battery staple printer toaster',
+    derivationStrategies: [strategy],
+  })
+  const vault = await db.openVault('acme')
+  return { db, vault }
+}
+
+describe('M-3 — fanout sidecar encryption', () => {
+  it('writes the sidecar as ciphertext (not plaintext JSON) in an encrypted vault', async () => {
+    const { store, data } = memoryWithData()
+    const { vault } = await buildDb(store)
+    const docs = vault.collection<Tagged>('docs')
+    await docs.put('d1', { id: 'd1', tags: ['alpha', 'beta'] })
+
+    // Locate the sidecar envelope in the raw store.
+    const sidecarKey = [...data.keys()].find(key => key.includes('/_meta/derivations-fanout/'))
+    expect(sidecarKey).toBeDefined()
+    const env = data.get(sidecarKey!)!
+    // Encrypted: a real IV, and the body is NOT plaintext JSON.
+    expect(env._iv).not.toBe('')
+    let leaked = false
+    try {
+      const parsed = JSON.parse(env._data) as { _noydb_fanout?: number }
+      leaked = parsed._noydb_fanout === 1
+    } catch { /* ciphertext is not JSON — good */ }
+    expect(leaked).toBe(false)
+  })
+
+  it('the array derivation diff still works end-to-end (shrink removes orphans)', async () => {
+    const { store } = memoryWithData()
+    const { vault } = await buildDb(store)
+    const docs = vault.collection<Tagged>('docs')
+    const tagRows = vault.collection<TagRow>('docTags')
+
+    await docs.put('d1', { id: 'd1', tags: ['alpha', 'beta'] })
+    expect(await tagRows.get('d1|alpha')).toBeDefined()
+    expect(await tagRows.get('d1|beta')).toBeDefined()
+
+    // Shrink: drop 'beta'.
+    await docs.put('d1', { id: 'd1', tags: ['alpha'] })
+    expect(await tagRows.get('d1|alpha')).toBeDefined()
+    expect(await tagRows.get('d1|beta')).toBeNull()
+  })
+
+  it('unit: encrypt round-trips through load', async () => {
+    const { store } = memoryWithData()
+    const dek = await generateDEK()
+    const getDEK = async () => dek
+    await saveFanoutSidecar(store, 'v', { source: 'docs', sourceId: 'd1', outputKey: 'tagRows', outputCollection: 'docTags', keys: ['a', 'b'] }, getDEK, true)
+    const loaded = await loadFanoutSidecar(store, 'v', 'docs', 'd1', 'tagRows', getDEK, true)
+    expect(loaded?.keys).toEqual(['a', 'b'])
+  })
+
+  it('unit: legacy plaintext sidecar (_iv==="") still reads', async () => {
+    const { store } = memoryWithData()
+    const dek = await generateDEK()
+    const getDEK = async () => dek
+    // Hand-write a legacy plaintext sidecar.
+    const legacyDoc = {
+      _noydb_fanout: 1, source: 'docs', sourceId: 'd1', outputKey: 'tagRows',
+      outputCollection: 'docTags', keys: ['x', 'y'], emittedAt: new Date().toISOString(),
+    }
+    await store.put('v', '_meta', 'derivations-fanout/docs/d1/tagRows', {
+      _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: new Date().toISOString(), _iv: '', _data: JSON.stringify(legacyDoc),
+    } as EncryptedEnvelope)
+    const loaded = await loadFanoutSidecar(store, 'v', 'docs', 'd1', 'tagRows', getDEK, true)
+    expect(loaded?.keys).toEqual(['x', 'y'])
+  })
+})

--- a/packages/hub/__tests__/sealed-record-expiry-fail-closed.test.ts
+++ b/packages/hub/__tests__/sealed-record-expiry-fail-closed.test.ts
@@ -1,0 +1,145 @@
+/**
+ * M-4 (security): sealed-record expiry must fail CLOSED.
+ *
+ * `Date.parse('')` / non-ISO → NaN, and `NaN <= Date.now()` is `false`, so the
+ * old `Date.parse(x) <= Date.now()` checks SKIPPED a malformed expiry → an
+ * eternal grant. Fix: reject a malformed/empty `expiresAt` at seal time, and
+ * fail closed (`!Number.isFinite(t) || t <= now → throw`) at open time.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { ConflictError, SealedRecordExpiredError, ValidationError } from '../src/errors.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { MemoryRecipientSealer } from '../src/with-party/team/managed-passphrase.js'
+import { openSealedRecord } from '../src/with-audit/sealed-record/index.js'
+import { bufferToBase64 } from '../src/crypto.js'
+import type { SealedCekDeliveryEnvelope, SealedCekBinding } from '../src/with-audit/sealed-record/types.js'
+
+function memory(): NoydbStore & { raw(c: string, col: string, id: string): EncryptedEnvelope | undefined } {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    raw(c, col, id) { return store.get(c)?.get(col)?.get(id) },
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) for (const [name, coll] of existing) if (name.startsWith('_')) comp.set(name, coll)
+      store.set(c, comp)
+    },
+  }
+}
+
+interface Doc { id: string; secret: string }
+const SECRET = 'test-passphrase-1234'
+const HOUR = 60 * 60 * 1000
+
+async function setup() {
+  const store = memory()
+  const db = await createNoydb({ store, user: 'alice', secret: SECRET })
+  const vault = await db.openVault('v')
+  const docs = vault.collection<Doc>('docs', { perRecordKeys: true })
+  return { store, vault, docs }
+}
+
+describe('M-4 — sealed-record expiry fails closed', () => {
+  it('seal time rejects an empty expiresAt', async () => {
+    const { vault, docs } = await setup()
+    await docs.put('d-1', { id: 'd-1', secret: 's' })
+    const host = new MemoryRecipientSealer({ id: 'kms:host-A' })
+    await expect(
+      vault.sealRecordToHost('docs', 'd-1', host, { expiresAt: '' }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it('seal time rejects a non-ISO expiresAt', async () => {
+    const { vault, docs } = await setup()
+    await docs.put('d-1', { id: 'd-1', secret: 's' })
+    const host = new MemoryRecipientSealer({ id: 'kms:host-A' })
+    await expect(
+      vault.sealRecordToHost('docs', 'd-1', host, { expiresAt: 'not-a-date' }),
+    ).rejects.toBeInstanceOf(ValidationError)
+  })
+
+  it('open time fails closed when the sealed binding carries a malformed expiresAt', async () => {
+    // Craft a delivery whose CLEAR-TEXT envelope expiry is valid (passes the
+    // fast-path), but whose authoritative sealed binding expiry is ''. The
+    // old code skipped the NaN check and opened; fail-closed must throw.
+    const host = new MemoryRecipientSealer({ id: 'kms:host-A' })
+    const hint = await host.publishRecipientHint()
+    const binding: SealedCekBinding = {
+      collection: 'docs', id: 'd-1',
+      cek: bufferToBase64(new Uint8Array(32)),
+      expiresAt: '', // malformed authoritative expiry
+    }
+    const sealed = await host.sealForRecipient(new TextEncoder().encode(JSON.stringify(binding)), hint)
+    const delivery: SealedCekDeliveryEnvelope = {
+      v: 1, _noydb_sealed_cek: 1, pid: hint.pid,
+      payload: bufferToBase64(sealed),
+      expiresAt: new Date(Date.now() + HOUR).toISOString(), // valid → passes fast-path
+    }
+    const recordEnv = { _iv: 'AAAA', _data: 'AAAA' }
+    await expect(
+      openSealedRecord(delivery, recordEnv, host, 'docs', 'd-1'),
+    ).rejects.toBeInstanceOf(SealedRecordExpiredError)
+  })
+
+  it('a valid future expiry still opens', async () => {
+    const { store, vault, docs } = await setup()
+    await docs.put('d-1', { id: 'd-1', secret: 'the eagle lands at dawn' })
+    const host = new MemoryRecipientSealer({ id: 'kms:host-A' })
+    const { pid } = await vault.sealRecordToHost('docs', 'd-1', host, {
+      expiresAt: new Date(Date.now() + HOUR).toISOString(),
+    })
+    const delivery = JSON.parse(store.raw('v', '_sealed_cek', `docs/d-1/${pid}`)!._data) as SealedCekDeliveryEnvelope
+    const recordEnv = store.raw('v', 'docs', 'd-1')!
+    const json = await openSealedRecord(delivery, recordEnv, host, 'docs', 'd-1')
+    expect(JSON.parse(json)).toMatchObject({ id: 'd-1', secret: 'the eagle lands at dawn' })
+  })
+
+  it('a valid past expiry still throws as before', async () => {
+    const { store, vault, docs } = await setup()
+    await docs.put('d-1', { id: 'd-1', secret: 's' })
+    const host = new MemoryRecipientSealer({ id: 'kms:host-A' })
+    // Past expiry is a valid timestamp → accepted at seal time, rejected at open.
+    const { pid } = await vault.sealRecordToHost('docs', 'd-1', host, {
+      expiresAt: new Date(Date.now() - HOUR).toISOString(),
+    })
+    const delivery = JSON.parse(store.raw('v', '_sealed_cek', `docs/d-1/${pid}`)!._data) as SealedCekDeliveryEnvelope
+    const recordEnv = store.raw('v', 'docs', 'd-1')!
+    await expect(
+      openSealedRecord(delivery, recordEnv, host, 'docs', 'd-1'),
+    ).rejects.toBeInstanceOf(SealedRecordExpiredError)
+  })
+})

--- a/packages/hub/__tests__/sealed-record-hard-revoke.test.ts
+++ b/packages/hub/__tests__/sealed-record-hard-revoke.test.ts
@@ -1,0 +1,110 @@
+/**
+ * M-5 (security): `revokeSealedRecord` is SOFT by default (it only deletes the
+ * delivery envelope — a host that already fetched the sealed CEK keeps decrypt
+ * capability). The opt-in `{ hard: true }` rotates the record CEK so a
+ * pre-revoke sealed CEK can no longer open the (now re-encrypted) record.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { ConflictError, TamperedError } from '../src/errors.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import { MemoryRecipientSealer } from '../src/with-party/team/managed-passphrase.js'
+import { openSealedRecord } from '../src/with-audit/sealed-record/index.js'
+import type { SealedCekDeliveryEnvelope } from '../src/with-audit/sealed-record/types.js'
+
+function memory(): NoydbStore & { raw(c: string, col: string, id: string): EncryptedEnvelope | undefined } {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    raw(c, col, id) { return store.get(c)?.get(col)?.get(id) },
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) if (!n.startsWith('_')) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of coll) r[id] = e
+        s[n] = r
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) for (const [name, coll] of existing) if (name.startsWith('_')) comp.set(name, coll)
+      store.set(c, comp)
+    },
+  }
+}
+
+interface Doc { id: string; secret: string }
+const SECRET = 'test-passphrase-1234'
+const HOUR = 60 * 60 * 1000
+
+async function setup() {
+  const store = memory()
+  const db = await createNoydb({ store, user: 'alice', secret: SECRET })
+  const vault = await db.openVault('v')
+  const docs = vault.collection<Doc>('docs', { perRecordKeys: true })
+  return { store, vault, docs }
+}
+
+describe('M-5 — sealed-record revoke softness', () => {
+  it('default revoke is SOFT: a host that already fetched the CEK can still decrypt', async () => {
+    const { store, vault, docs } = await setup()
+    await docs.put('d-1', { id: 'd-1', secret: 'the eagle lands at dawn' })
+    const host = new MemoryRecipientSealer({ id: 'kms:host-A' })
+    const { pid } = await vault.sealRecordToHost('docs', 'd-1', host, {
+      expiresAt: new Date(Date.now() + HOUR).toISOString(),
+    })
+    // Host fetches the delivery before revocation.
+    const delivery = JSON.parse(store.raw('v', '_sealed_cek', `docs/d-1/${pid}`)!._data) as SealedCekDeliveryEnvelope
+
+    await vault.revokeSealedRecord('docs', 'd-1', pid) // default = soft
+
+    // Delivery envelope gone from the store...
+    expect(store.raw('v', '_sealed_cek', `docs/d-1/${pid}`)).toBeUndefined()
+    // ...but the already-fetched copy still opens the (un-rotated) record.
+    const recordEnv = store.raw('v', 'docs', 'd-1')!
+    const json = await openSealedRecord(delivery, recordEnv, host, 'docs', 'd-1')
+    expect(JSON.parse(json)).toMatchObject({ secret: 'the eagle lands at dawn' })
+  })
+
+  it('{ hard: true } rotates: a pre-revoke sealed CEK no longer opens the record', async () => {
+    const { store, vault, docs } = await setup()
+    await docs.put('d-1', { id: 'd-1', secret: 'the eagle lands at dawn' })
+    const host = new MemoryRecipientSealer({ id: 'kms:host-A' })
+    const { pid } = await vault.sealRecordToHost('docs', 'd-1', host, {
+      expiresAt: new Date(Date.now() + HOUR).toISOString(),
+    })
+    const delivery = JSON.parse(store.raw('v', '_sealed_cek', `docs/d-1/${pid}`)!._data) as SealedCekDeliveryEnvelope
+
+    await vault.revokeSealedRecord('docs', 'd-1', pid, { hard: true })
+
+    // The live record was re-encrypted under a fresh CEK → the old sealed CEK
+    // fails the GCM auth tag.
+    const recordEnv = store.raw('v', 'docs', 'd-1')!
+    await expect(
+      openSealedRecord(delivery, recordEnv, host, 'docs', 'd-1'),
+    ).rejects.toBeInstanceOf(TamperedError)
+    // And the delivery envelope is gone too.
+    expect(store.raw('v', '_sealed_cek', `docs/d-1/${pid}`)).toBeUndefined()
+  })
+})

--- a/packages/hub/__tests__/subject-index-keyed.test.ts
+++ b/packages/hub/__tests__/subject-index-keyed.test.ts
@@ -1,0 +1,166 @@
+/**
+ * M-2 (security): the subject-index record id must be a vault-DEK-keyed PRF
+ * (HMAC over the `_subject_index` DEK), not an unsalted `sha256Hex(subjectId)`
+ * (offline brute-forceable). The encrypted ref-list is padded to bucketed
+ * lengths so its `_data` length does not leak the record count.
+ *
+ * Back-compat: forget() must still find + erase records indexed under the
+ * LEGACY sha256 key form (dual-lookup), or pre-existing subjects become
+ * un-forgettable.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { ConflictError } from '../src/errors.js'
+import { withForgetCascade } from '../src/with-audit/forget/index.js'
+import { withHistory } from '../src/with-commit/history/index.js'
+import { generateDEK } from '../src/crypto.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/types.js'
+import {
+  addSubjectRef,
+  removeSubjectRef,
+  lookupSubject,
+} from '../src/with-audit/forget/subject-index.js'
+
+async function sha256HexUtf8(input: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', new TextEncoder().encode(input))
+  return Array.from(new Uint8Array(digest)).map(b => b.toString(16).padStart(2, '0')).join('')
+}
+
+function memory(): NoydbStore & {
+  raw(c: string, col: string, id: string): EncryptedEnvelope | undefined
+  rawList(c: string, col: string): string[]
+} {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    raw(c, col, id) { return store.get(c)?.get(col)?.get(id) },
+    rawList(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) if (!n.startsWith('_')) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of coll) r[id] = e
+        s[n] = r
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) for (const [name, coll] of existing) if (name.startsWith('_')) comp.set(name, coll)
+      store.set(c, comp)
+    },
+  }
+}
+
+interface Invoice { id: string; buyerId: string; amount: number }
+const SECRET = 'subject-index-test-passphrase-1234'
+
+async function buildDb(store: NoydbStore) {
+  const db = await createNoydb({
+    store, user: 'alice', secret: SECRET,
+    historyStrategy: withHistory(),
+    forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+  })
+  const vault = await db.openVault('v')
+  return { db, vault }
+}
+
+describe('M-2 — subject index keyed id + bucketed ref list', () => {
+  it('the stored index id is NOT sha256Hex(subjectId)', async () => {
+    const store = memory()
+    const { vault } = await buildDb(store)
+    const invoices = vault.collection<Invoice>('invoices')
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1', amount: 100 })
+
+    const keys = store.rawList('v', '_subject_index')
+    expect(keys.length).toBe(1)
+    const legacy = await sha256HexUtf8('buyer-1')
+    expect(keys).not.toContain(legacy)
+  })
+
+  it('two subjects with different small ref counts produce equal-length _data (bucketed)', async () => {
+    const store = memory()
+    const { vault } = await buildDb(store)
+    const invoices = vault.collection<Invoice>('invoices')
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-A', amount: 1 })   // A: 1 ref
+    await invoices.put('i-2', { id: 'i-2', buyerId: 'buyer-B', amount: 2 })   // B: 2 refs
+    await invoices.put('i-3', { id: 'i-3', buyerId: 'buyer-B', amount: 3 })
+
+    const keys = store.rawList('v', '_subject_index')
+    expect(keys.length).toBe(2)
+    const lens = keys.map(k => store.raw('v', '_subject_index', k)!._data.length)
+    expect(lens[0]).toBe(lens[1])
+  })
+
+  it('forget() still erases a record indexed under the LEGACY sha256 key form', async () => {
+    const store = memory()
+    const { vault } = await buildDb(store)
+    const invoices = vault.collection<Invoice>('invoices')
+    await invoices.put('i-1', { id: 'i-1', buyerId: 'buyer-1', amount: 100 })
+
+    // Simulate a legacy deployment: relocate buyer-1's index entry from the
+    // new keyed id to the legacy sha256 id (body unchanged).
+    const keyedId = store.rawList('v', '_subject_index')[0]!
+    const env = store.raw('v', '_subject_index', keyedId)!
+    const legacyId = await sha256HexUtf8('buyer-1')
+    await store.put('v', '_subject_index', legacyId, env)
+    await store.delete('v', '_subject_index', keyedId)
+
+    const result = await vault.forget('buyer-1')
+    expect(result.recordsShredded).toBe(1)
+    expect(await invoices.get('i-1')).toBeNull()
+    expect(store.raw('v', 'invoices', 'i-1')!._data).toBe('')
+    // The legacy index entry was cleaned up (empty → deleted).
+    expect(store.rawList('v', '_subject_index')).not.toContain(legacyId)
+  })
+
+  it('unit: dual-lookup finds + removes a legacy bare-array entry', async () => {
+    const store = memory()
+    const dek = await generateDEK()
+    const getDEK = async () => dek
+    // Hand-write a legacy entry: sha256 key + bare-array body encrypted under DEK.
+    const legacyId = await sha256HexUtf8('buyer-L')
+    const { encrypt } = await import('../src/crypto.js')
+    const { iv, data } = await encrypt(JSON.stringify([{ collection: 'invoices', id: 'i-L' }]), dek)
+    await store.put('v', '_subject_index', legacyId, {
+      _noydb: 1, _v: 1, _ts: new Date().toISOString(), _iv: iv, _data: data,
+    } as EncryptedEnvelope)
+
+    const found = await lookupSubject(store, 'v', getDEK, true, 'buyer-L')
+    expect(found).toEqual([{ collection: 'invoices', id: 'i-L' }])
+
+    await removeSubjectRef(store, 'v', getDEK, true, 'buyer-L', { collection: 'invoices', id: 'i-L' })
+    expect(await lookupSubject(store, 'v', getDEK, true, 'buyer-L')).toEqual([])
+    expect(store.rawList('v', '_subject_index')).not.toContain(legacyId)
+  })
+
+  it('unit: a new write lands under the keyed id, not sha256', async () => {
+    const store = memory()
+    const dek = await generateDEK()
+    const getDEK = async () => dek
+    await addSubjectRef(store, 'v', getDEK, true, 'buyer-N', { collection: 'invoices', id: 'i-N' })
+    const legacyId = await sha256HexUtf8('buyer-N')
+    expect(store.rawList('v', '_subject_index')).not.toContain(legacyId)
+    expect(await lookupSubject(store, 'v', getDEK, true, 'buyer-N')).toEqual([{ collection: 'invoices', id: 'i-N' }])
+  })
+})

--- a/packages/hub/src/collection.ts
+++ b/packages/hub/src/collection.ts
@@ -2179,13 +2179,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
           if (out.kind === 'array') {
             // Load the prior key set from the fanout sidecar.
             const { loadFanoutSidecar, saveFanoutSidecar } = await import('./with-formula/derivations/fanout-sidecar.js')
-            const prior = await loadFanoutSidecar(
-              this.adapter,
-              this.vault,
-              spec.source,
-              run.runId,
-              key,
-            )
+            const prior = await loadFanoutSidecar(this.adapter, this.vault, spec.source, run.runId, key, this.getDEK, this.storeCiphertext)
             const prevKeys = new Set<string>(prior?.keys ?? [])
             const newKeysList = out.entries.map(e => e.key)
             const newKeysSet = new Set<string>(newKeysList)
@@ -2223,7 +2217,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
               outputKey: key,
               outputCollection: outSpec.collection,
               keys: newKeysList,
-            })
+            }, this.getDEK, this.storeCiphertext)
             continue
           }
 
@@ -2662,13 +2656,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
         if (helpers === null) {
           helpers = await import('./with-formula/derivations/fanout-sidecar.js')
         }
-        const sidecar = await helpers.loadFanoutSidecar(
-          this.adapter,
-          this.vault,
-          spec.source,
-          id,
-          outputKey,
-        )
+        const sidecar = await helpers.loadFanoutSidecar(this.adapter, this.vault, spec.source, id, outputKey, this.getDEK, this.storeCiphertext)
         if (!sidecar) continue
         const outputCollection = this.derivationSource.getCollection(outSpec.collection)
         for (const derivedId of sidecar.keys) {

--- a/packages/hub/src/record-keys/sealing.ts
+++ b/packages/hub/src/record-keys/sealing.ts
@@ -55,6 +55,13 @@ export async function sealRecordToHost(
   // matches `${collection}/${id}/`) ambiguous and could over- or under-match.
   if (collection.includes('/')) throw new ValidationError(`sealRecordToHost: collection "${collection}" must not contain "/"`)
   if (id.includes('/')) throw new ValidationError(`sealRecordToHost: id "${id}" must not contain "/"`)
+  // M-4: reject a malformed/empty expiry at seal time. `Date.parse('')` (and any
+  // non-ISO string) is NaN, and the open-time check `NaN <= now` is `false` — so
+  // a malformed expiry would silently mint an ETERNAL grant. A *past* (but valid)
+  // timestamp is still allowed: it seals, then fails closed at open time.
+  if (Number.isNaN(Date.parse(opts.expiresAt))) {
+    throw new ValidationError(`sealRecordToHost: expiresAt "${opts.expiresAt}" is not a valid ISO 8601 timestamp`)
+  }
 
   const live = await ctx.adapter.get(ctx.vault, collection, id)
   if (!live || live._cek === undefined) {

--- a/packages/hub/src/record-keys/sealing.ts
+++ b/packages/hub/src/record-keys/sealing.ts
@@ -113,16 +113,34 @@ export async function sealRecordToHost(
 }
 
 /**
- * Soft-revoke one sealed-CEK delivery envelope (delete it from the store). A
- * host that already fetched the envelope keeps whatever it cached; for a hard
- * revocation use {@link rotateRecordCek}.
+ * Revoke one sealed-CEK grant.
+ *
+ * **Default (`{ hard: false }`) is SOFT** — it only deletes the delivery
+ * envelope from the store. A host that already fetched (or cached the unsealed
+ * CEK from) that envelope KEEPS decrypt capability for the record; soft revoke
+ * is a "stop new fetches" control, not a cryptographic cutoff.
+ *
+ * **`{ hard: true }`** additionally rotates the record's CEK (via
+ * {@link rotateRecordCek}): the live body is re-encrypted under a fresh CEK and
+ * EVERY sealed-CEK delivery envelope for the record (all pids) is deleted, so
+ * any previously-sealed CEK fails the AES-GCM auth tag on the rotated body —
+ * future opens are cryptographically denied. (PRE-rotation history versions,
+ * which keep their old `_cek`, remain openable — same semantics as
+ * `rotateRecordCek`.)
  */
 export async function revokeSealedRecord(
   ctx: SealingContext,
   collection: string,
   id: string,
   pid: string,
+  opts?: { hard?: boolean },
 ): Promise<void> {
+  if (opts?.hard === true) {
+    // Hard revocation supersedes the single-pid soft delete: rotateRecordCek
+    // re-keys the record and drops every delivery envelope for it.
+    await rotateRecordCek(ctx, collection, id)
+    return
+  }
   await ctx.adapter.delete(ctx.vault, SEALED_CEK_NS, `${collection}/${id}/${pid}`)
 }
 

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -2730,7 +2730,7 @@ export class Vault {
           if (out.kind === 'array') {
             const { loadFanoutSidecar, saveFanoutSidecar } =
               await import('./with-formula/derivations/fanout-sidecar.js')
-            const prior = await loadFanoutSidecar(this.adapter, this.name, spec.source, id, key)
+            const prior = await loadFanoutSidecar(this.adapter, this.name, spec.source, id, key, this.getDEK, this.encrypted)
             const prevKeys = new Set<string>(prior?.keys ?? [])
             const newKeysList = out.entries.map(e => e.key)
             const newKeysSet = new Set<string>(newKeysList)
@@ -2747,7 +2747,7 @@ export class Vault {
               outputKey: key,
               outputCollection: outSpec.collection,
               keys: newKeysList,
-            })
+            }, this.getDEK, this.encrypted)
             continue
           }
 

--- a/packages/hub/src/vault.ts
+++ b/packages/hub/src/vault.ts
@@ -2444,14 +2444,14 @@ export class Vault {
   }
 
   /**
-   * Revoke a single sealed-CEK delivery envelope by deleting it from the store.
-   * A soft revocation: it removes the host's copy of the sealed CEK, but a host
-   * that already fetched the envelope keeps whatever it cached. For a hard
-   * revocation that makes the live record undecryptable to every prior grant,
-   * use {@link rotateRecordCek}.
+   * Revoke a sealed-CEK grant. **Default is SOFT**: deletes the `pid` delivery
+   * envelope, but a host that already fetched it KEEPS decrypt capability (stops
+   * new fetches, not a cryptographic cutoff). Pass **`{ hard: true }`** to rotate
+   * the record CEK ({@link rotateRecordCek}) so any prior sealed CEK can no
+   * longer open the record. See `revokeSealedRecord` in `record-keys/sealing.ts`.
    */
-  async revokeSealedRecord(collection: string, id: string, pid: string): Promise<void> {
-    return revokeSealedRecordImpl(this.sealingContext(), collection, id, pid)
+  async revokeSealedRecord(collection: string, id: string, pid: string, opts?: { hard?: boolean }): Promise<void> {
+    return revokeSealedRecordImpl(this.sealingContext(), collection, id, pid, opts)
   }
 
   /**

--- a/packages/hub/src/with-audit/forget/subject-index.ts
+++ b/packages/hub/src/with-audit/forget/subject-index.ts
@@ -8,9 +8,17 @@
  * which records share a subject. Instead we keep a reserved `_subject_index`
  * collection, encrypted under its OWN DEK (`getDEK('_subject_index')`):
  *
- *   - record id  = `sha256Hex(subjectId)` — the raw subject id never appears
- *     as a key, so the store can't correlate index entries to a known subject.
- *   - record body = AES-GCM(JSON `[{ collection, id }]`) under the index DEK.
+ *   - record id  = `HMAC-SHA256(indexDEK, subjectId)` (M-2). A bare
+ *     `sha256Hex(subjectId)` would be offline-computable: an attacker with
+ *     store access and a candidate list (emails / customer ids are low-entropy)
+ *     could dictionary the hash to confirm "subject X is present here." Keying
+ *     the id with the vault-only index DEK removes that capability — without the
+ *     DEK the id cannot be derived. (Legacy entries written before M-2 used the
+ *     bare sha256 id; the read/remove paths dual-look-up both forms.)
+ *   - record body = AES-GCM(JSON `{ r: [{ collection, id }], p }`) under the
+ *     index DEK, where `p` pads the plaintext to a bucketed length so the
+ *     ciphertext `_data` length does not leak the approximate record count.
+ *     Legacy bodies were a bare `[{ collection, id }]` array; reads accept both.
  *
  * ## Concurrency (RISK #3 — known v1 limitation)
  *
@@ -24,12 +32,19 @@
  *
  * @module
  */
-import { encrypt, decrypt } from '../../crypto.js'
+import { encrypt, decrypt, hmacSha256Hex } from '../../crypto.js'
 import type { NoydbStore, EncryptedEnvelope } from '../../types.js'
 import { NOYDB_FORMAT_VERSION } from '../../types.js'
 
 /** Reserved collection holding the encrypted subject → records index. */
 export const SUBJECT_INDEX_COLLECTION = '_subject_index'
+
+/**
+ * Bucket (bytes) the encrypted ref-list plaintext is padded up to, so the
+ * ciphertext `_data` length leaks only `count` rounded up to a bucket — not the
+ * exact record count. 256 keeps small subjects (the common case) indistinguishable.
+ */
+const REF_LIST_BUCKET = 256
 
 /** A single record reference held in a subject's index entry. */
 export interface SubjectRef {
@@ -39,7 +54,7 @@ export interface SubjectRef {
 
 type GetDEK = (collectionName: string) => Promise<CryptoKey>
 
-/** SHA-256 hex of a UTF-8 string. The subject-index record key derivation. */
+/** SHA-256 hex of a UTF-8 string. The LEGACY (pre-M-2) subject-index key. */
 async function sha256HexString(input: string): Promise<string> {
   const bytes = new TextEncoder().encode(input)
   const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes)
@@ -48,12 +63,42 @@ async function sha256HexString(input: string): Promise<string> {
     .join('')
 }
 
-/** Stable subject-index record id for a subject id. */
-export async function subjectKey(subjectId: string): Promise<string> {
-  return sha256HexString(subjectId)
+/**
+ * The subject-index record id(s) to consult for a subject, most-current first.
+ *
+ * - Encrypted vault: the PRIMARY id is `HMAC-SHA256(indexDEK, subjectId)` (M-2)
+ *   — not offline-computable. The LEGACY `sha256Hex(subjectId)` id is also
+ *   returned so reads/removes still find entries written before M-2 (dual-lookup).
+ * - Plaintext/debug vault: no DEK to key with, so the only id is the legacy
+ *   sha256 form (unchanged behaviour — plaintext mode is not zero-knowledge anyway).
+ */
+async function subjectKeys(getDEK: GetDEK, encrypted: boolean, subjectId: string): Promise<string[]> {
+  const legacy = await sha256HexString(subjectId)
+  if (!encrypted) return [legacy]
+  const dek = await getDEK(SUBJECT_INDEX_COLLECTION)
+  const keyed = await hmacSha256Hex(dek, new TextEncoder().encode(subjectId))
+  return keyed === legacy ? [keyed] : [keyed, legacy]
 }
 
-/** Read + decrypt the ref list for a subject. Returns `[]` when absent. */
+/** The id new writes land under (keyed when encrypted, else legacy sha256). */
+async function primarySubjectKey(getDEK: GetDEK, encrypted: boolean, subjectId: string): Promise<string> {
+  return (await subjectKeys(getDEK, encrypted, subjectId))[0]!
+}
+
+/** Parse a stored ref-list body: new padded `{ r, p }` wrapper OR legacy bare array. */
+function parseRefs(json: string): SubjectRef[] {
+  const parsed = JSON.parse(json) as SubjectRef[] | { r: SubjectRef[] }
+  return Array.isArray(parsed) ? parsed : parsed.r
+}
+
+/** Serialize + pad the ref list to a bucket boundary (encrypted vaults only). */
+function serializeRefs(refs: SubjectRef[]): string {
+  const base = JSON.stringify({ r: refs, p: '' })
+  const pad = Math.ceil(base.length / REF_LIST_BUCKET) * REF_LIST_BUCKET - base.length
+  return JSON.stringify({ r: refs, p: ' '.repeat(pad) })
+}
+
+/** Read + decrypt the ref list at a SINGLE index key. Returns `[]` when absent. */
 async function readRefs(
   adapter: NoydbStore,
   vault: string,
@@ -63,10 +108,10 @@ async function readRefs(
 ): Promise<SubjectRef[]> {
   const env = await adapter.get(vault, SUBJECT_INDEX_COLLECTION, key)
   if (!env || !env._data) return []
-  if (!encrypted) return JSON.parse(env._data) as SubjectRef[]
+  if (!encrypted) return parseRefs(env._data)
   const dek = await getDEK(SUBJECT_INDEX_COLLECTION)
   const json = await decrypt(env._iv, env._data, dek)
-  return JSON.parse(json) as SubjectRef[]
+  return parseRefs(json)
 }
 
 /** Encrypt + write a ref list for a subject under its derived key. */
@@ -78,13 +123,13 @@ async function writeRefs(
   key: string,
   refs: SubjectRef[],
 ): Promise<void> {
-  const json = JSON.stringify(refs)
   let env: EncryptedEnvelope
   if (!encrypted) {
-    env = { _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: new Date().toISOString(), _iv: '', _data: json }
+    // Plaintext/debug vault: keep the legacy bare-array form (no padding needed).
+    env = { _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: new Date().toISOString(), _iv: '', _data: JSON.stringify(refs) }
   } else {
     const dek = await getDEK(SUBJECT_INDEX_COLLECTION)
-    const { iv, data } = await encrypt(json, dek)
+    const { iv, data } = await encrypt(serializeRefs(refs), dek)
     env = { _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: new Date().toISOString(), _iv: iv, _data: data }
   }
   await adapter.put(vault, SUBJECT_INDEX_COLLECTION, key, env)
@@ -103,7 +148,7 @@ export async function addSubjectRef(
   subjectId: string,
   ref: SubjectRef,
 ): Promise<void> {
-  const key = await subjectKey(subjectId)
+  const key = await primarySubjectKey(getDEK, encrypted, subjectId)
   const refs = await readRefs(adapter, vault, getDEK, encrypted, key)
   if (refs.some((r) => r.collection === ref.collection && r.id === ref.id)) return
   refs.push(ref)
@@ -123,18 +168,25 @@ export async function removeSubjectRef(
   subjectId: string,
   ref: SubjectRef,
 ): Promise<void> {
-  const key = await subjectKey(subjectId)
-  const refs = await readRefs(adapter, vault, getDEK, encrypted, key)
-  const next = refs.filter((r) => !(r.collection === ref.collection && r.id === ref.id))
-  if (next.length === refs.length) return
-  if (next.length === 0) {
-    await adapter.delete(vault, SUBJECT_INDEX_COLLECTION, key)
-    return
+  // Dual-lookup: drop the ref from BOTH the keyed (M-2) and the legacy sha256
+  // entry, so a pre-M-2 subject is still fully erased.
+  for (const key of await subjectKeys(getDEK, encrypted, subjectId)) {
+    const refs = await readRefs(adapter, vault, getDEK, encrypted, key)
+    const next = refs.filter((r) => !(r.collection === ref.collection && r.id === ref.id))
+    if (next.length === refs.length) continue
+    if (next.length === 0) {
+      await adapter.delete(vault, SUBJECT_INDEX_COLLECTION, key)
+    } else {
+      await writeRefs(adapter, vault, getDEK, encrypted, key, next)
+    }
   }
-  await writeRefs(adapter, vault, getDEK, encrypted, key, next)
 }
 
-/** Look up every record ref for a subject. Returns `[]` when none exist. */
+/**
+ * Look up every record ref for a subject. Returns `[]` when none exist. Unions
+ * the keyed (M-2) and legacy sha256 entries (dual-lookup), deduplicated, so a
+ * subject indexed before M-2 is still fully found.
+ */
 export async function lookupSubject(
   adapter: NoydbStore,
   vault: string,
@@ -142,8 +194,18 @@ export async function lookupSubject(
   encrypted: boolean,
   subjectId: string,
 ): Promise<SubjectRef[]> {
-  const key = await subjectKey(subjectId)
-  return readRefs(adapter, vault, getDEK, encrypted, key)
+  const keys = await subjectKeys(getDEK, encrypted, subjectId)
+  const seen = new Set<string>()
+  const out: SubjectRef[] = []
+  for (const key of keys) {
+    for (const ref of await readRefs(adapter, vault, getDEK, encrypted, key)) {
+      const dedup = `${ref.collection} ${ref.id}`
+      if (seen.has(dedup)) continue
+      seen.add(dedup)
+      out.push(ref)
+    }
+  }
+  return out
 }
 
 /**
@@ -192,7 +254,7 @@ export async function rebuildSubjectIndex(
 
   let entries = 0
   for (const [subjectId, refs] of bySubject) {
-    const key = await subjectKey(subjectId)
+    const key = await primarySubjectKey(getDEK, encrypted, subjectId)
     await writeRefs(adapter, vault, getDEK, encrypted, key, refs)
     entries++
   }

--- a/packages/hub/src/with-audit/sealed-record/index.ts
+++ b/packages/hub/src/with-audit/sealed-record/index.ts
@@ -64,8 +64,11 @@ export async function openSealedRecord(
   expectedCollection: string,
   expectedId: string,
 ): Promise<string> {
-  // (1) Fast-path expiry on the (unauthenticated) delivery envelope.
-  if (Date.parse(sealedCekEnvelope.expiresAt) <= Date.now()) {
+  // (1) Fast-path expiry on the (unauthenticated) delivery envelope. Fail
+  // CLOSED (M-4): a malformed/empty `expiresAt` parses to NaN — treat it as
+  // expired rather than letting `NaN <= now` (which is `false`) skip the check.
+  const fastT = Date.parse(sealedCekEnvelope.expiresAt)
+  if (!Number.isFinite(fastT) || fastT <= Date.now()) {
     throw new SealedRecordExpiredError(sealedCekEnvelope.expiresAt)
   }
 
@@ -83,7 +86,9 @@ export async function openSealedRecord(
   }
 
   // (4) Authoritative expiry — the copy that cannot be forged on the envelope.
-  if (Date.parse(binding.expiresAt) <= Date.now()) {
+  // Fail CLOSED (M-4): a malformed/empty `expiresAt` → NaN → treat as expired.
+  const t = Date.parse(binding.expiresAt)
+  if (!Number.isFinite(t) || t <= Date.now()) {
     throw new SealedRecordExpiredError(binding.expiresAt)
   }
 

--- a/packages/hub/src/with-formula/derivations/fanout-sidecar.ts
+++ b/packages/hub/src/with-formula/derivations/fanout-sidecar.ts
@@ -11,15 +11,23 @@
  * read prior keys, compute `toDelete = prev \ new`, write new, persist
  * back.
  *
- * Stored as plain JSON with AES-GCM bypassed (same pattern as
- * `_meta/policy`, `_meta/recovery-paper`, `_meta/sealed-passphrase`,
- * etc.): the sidecar is system metadata, not user data, and the
- * derived outputs themselves carry their own encryption envelopes.
+ * The body is encrypted (AES-GCM under the `_meta` collection DEK) when
+ * the vault is encrypted — the `keys[]` are derived-row ids produced by a
+ * user-supplied key extractor and can be content-bearing (SKU, tag, email),
+ * so a ciphertext-only store must not read them, the derivation graph, or
+ * `emittedAt`. Back-compat: sidecars written before this fix are plaintext
+ * (`_iv === ''`); `loadFanoutSidecar` dual-reads them.
  *
  * @module
  */
 import type { NoydbStore, EncryptedEnvelope } from '../../types.js'
 import { NOYDB_FORMAT_VERSION } from '../../types.js'
+import { encrypt, decrypt } from '../../crypto.js'
+
+type GetDEK = (collectionName: string) => Promise<CryptoKey>
+
+/** The `_meta` collection name whose DEK encrypts the sidecar body. */
+const FANOUT_DEK_COLLECTION = '_meta'
 
 /** Magic-prefixed JSON payload at `_meta/<recordId>`. */
 export interface FanoutSidecar {
@@ -55,18 +63,30 @@ function recordId(source: string, sourceId: string, outputKey: string): string {
   return `derivations-fanout/${source}/${sourceId}/${outputKey}`
 }
 
-/** Read the sidecar; returns empty if absent. */
+/**
+ * Read the sidecar; returns empty if absent.
+ *
+ * Dual-reads for back-compat: an envelope with `_iv === ''` is a legacy
+ * plaintext sidecar (parse `_data` directly); otherwise the body was
+ * encrypted under the `_meta` DEK and is decrypted first.
+ */
 export async function loadFanoutSidecar(
   store: NoydbStore,
   vault: string,
   source: string,
   sourceId: string,
   outputKey: string,
+  getDEK: GetDEK,
+  encrypted: boolean,
 ): Promise<FanoutSidecar | undefined> {
   const envelope = await store.get(vault, '_meta', recordId(source, sourceId, outputKey))
   if (!envelope) return undefined
   try {
-    const parsed = JSON.parse(envelope._data) as FanoutSidecar
+    // Legacy plaintext (`_iv === ''`) reads directly; encrypted bodies decrypt.
+    const json = (!encrypted || envelope._iv === '')
+      ? envelope._data
+      : await decrypt(envelope._iv, envelope._data, await getDEK(FANOUT_DEK_COLLECTION))
+    const parsed = JSON.parse(json) as FanoutSidecar
     if (parsed._noydb_fanout !== 1) return undefined
     if (!Array.isArray(parsed.keys)) return undefined
     return parsed
@@ -75,7 +95,11 @@ export async function loadFanoutSidecar(
   }
 }
 
-/** Persist (insert/replace) the sidecar with a fresh key set. */
+/**
+ * Persist (insert/replace) the sidecar with a fresh key set. The body is
+ * encrypted under the `_meta` DEK when the vault is encrypted (the `keys[]`
+ * can be content-bearing); plaintext only in debug/unencrypted vaults.
+ */
 export async function saveFanoutSidecar(
   store: NoydbStore,
   vault: string,
@@ -86,6 +110,8 @@ export async function saveFanoutSidecar(
     readonly outputCollection: string
     readonly keys: ReadonlyArray<string>
   },
+  getDEK: GetDEK,
+  encrypted: boolean,
 ): Promise<void> {
   const doc: FanoutSidecar = {
     _noydb_fanout: 1,
@@ -98,13 +124,25 @@ export async function saveFanoutSidecar(
   }
   const id = recordId(payload.source, payload.sourceId, payload.outputKey)
   const prior = await store.get(vault, '_meta', id)
-  const envelope: EncryptedEnvelope = {
-    _noydb: NOYDB_FORMAT_VERSION,
-    _v: (prior?._v ?? 0) + 1,
-    _ts: new Date().toISOString(),
-    // AES-GCM bypassed — sidecar is system metadata, no user data inside.
-    _iv: '',
-    _data: JSON.stringify(doc),
+  const json = JSON.stringify(doc)
+  let envelope: EncryptedEnvelope
+  if (!encrypted) {
+    envelope = {
+      _noydb: NOYDB_FORMAT_VERSION,
+      _v: (prior?._v ?? 0) + 1,
+      _ts: new Date().toISOString(),
+      _iv: '',
+      _data: json,
+    }
+  } else {
+    const { iv, data } = await encrypt(json, await getDEK(FANOUT_DEK_COLLECTION))
+    envelope = {
+      _noydb: NOYDB_FORMAT_VERSION,
+      _v: (prior?._v ?? 0) + 1,
+      _ts: new Date().toISOString(),
+      _iv: iv,
+      _data: data,
+    }
   }
   await store.put(vault, '_meta', id, envelope)
 }


### PR DESCRIPTION
## Close the four open Medium security findings (M-2…M-5)

From the 2026-06-30 whole-codebase security audit. TDD per finding (failing test reproducing the vuln → fix → green), one commit each. **Adversarially reviewed (Opus): all four verified CLOSED end-to-end, no new issues.**

| # | Finding | Fix |
|---|---|---|
| **M-3** | Derivations fanout sidecar written in **plaintext** (`_iv:''`) — ZK leak of the derivation graph + content-bearing derived keys | Body now encrypted under the `_meta` per-vault DEK; plaintext form reachable only on `!encrypted` (debug) vaults. **Dual-read** legacy plaintext (`_iv===''`) for back-compat. |
| **M-4** | Sealed-record expiry **failed open** on malformed/empty `expiresAt` (`NaN <= now` is false) | Reject non-parseable expiry at seal time; **fail closed** at both open sites (`!Number.isFinite(t) \|\| t <= now`). |
| **M-2** | Subject-index id was unsalted `sha256Hex(subjectId)` — offline brute-forceable; ref-list length leaked record count | Id is now `HMAC-SHA256(indexDEK, subjectId)` (keyed off a store-unavailable per-vault DEK); ref-list padded to 256-byte buckets. **Dual-lookup** keeps legacy `sha256` entries findable so `forget()` still erases pre-existing subjects (no migration required). |
| **M-5** | `revokeSealedRecord` soft-only; name implied a hard cutoff | Docstrings now state the default is soft (delivery-envelope removal); opt-in `{ hard: true }` rotates the CEK (cryptographic cutoff). Default unchanged. |

### Back-compat
- **M-3**: `loadFanoutSidecar` dual-reads — `_iv===''` → legacy plaintext, else decrypt; new writes always encrypt.
- **M-2**: `lookupSubject`/`removeSubjectRef` union + dedup the keyed and legacy ids; `readRefs` accepts both the padded `{r,p}` body and the legacy bare array. Pre-existing subjects stay fully found + erasable. Ledger `payloadHash` left untouched.

### Gates
typecheck · lint · check-architecture ✓ · build ✓ · **test 2966 passed / 343 files** (+16 new; existing derivations/forget/sealed-record/seal-to-host suites green).

### Known follow-up (not in scope here)
`loadFanoutSidecar` swallows a decrypt/parse error and returns `undefined`, skipping orphan-row deletion on array-derivation shrink — **pre-existing** (predates this change), correctness-not-confidentiality. Noted for a separate fix.
