### PR TITLE
ci: split fast dev CI from full pre-publish gate (2-CI for velocity)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: CI
 
-# Standard CI — runs on every PR and push to main.
-# Jobs: architecture → spec-coverage → lint/typecheck → build → test (matrix).
+# Dev CI — fast feedback on every PR and push to main.
+# Jobs: architecture → spec-coverage → lint/typecheck → build → test (node 24).
+# Single flake-free runtime for speed; the full node 22+24 test matrix and
+# the cross-OS interop run pre-publish as a hard gate in release.yml.
 
 on:
   push:
@@ -143,20 +145,19 @@ jobs:
       - name: Build
         run: pnpm turbo build
 
-  # ── Test matrix (runtime-supported Node versions) ────────────────────
+  # ── Test (dev CI) ────────────────────────────────────────────────────
+  # Single flake-free runtime (node 24) for fast PR feedback. The full
+  # node 22 + 24 matrix AND the cross-OS interop run pre-publish in
+  # release.yml — the hard gate before anything reaches npm.
   test:
-    name: Test (node ${{ matrix.node }})
+    name: Test (node 24)
     needs: [quality, build]
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node: ['22', '24']
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: ${{ matrix.node }}
+          node-version: '24'
           package-manager-cache: false
       - name: Enable corepack (pnpm)
         run: corepack enable
@@ -167,8 +168,8 @@ jobs:
       - uses: actions/cache@v5
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-node${{ matrix.node }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-node${{ matrix.node }}-pnpm-
+          key: ${{ runner.os }}-node24-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-node24-pnpm-
       - name: Install
         run: pnpm install --frozen-lockfile
       # Restores the build job's .turbo cache (same commit sha) so this
@@ -191,59 +192,8 @@ jobs:
       - name: Test
         run: pnpm turbo test --concurrency=1 --filter '!@noy-db/showcases'
 
-  # ── WinZip-AES-256 cross-tool interop ────────────────────────────────
-  # Shells out to 7z and unar on 3 OS runners to validate that our
-  # WinZip-AES-256 writer/reader is compatible with real archive tools.
-  # continue-on-error: true until the matrix is green for the first time.
-  #
-  # Runs on push-to-main only (`github.event_name == 'push'`), NOT on PRs:
-  # the macOS/Windows runners + brew/choco tool installs are the slowest
-  # leg by far, and since it's advisory (continue-on-error) it should not
-  # sit on the PR-merge critical path. Post-merge on main still exercises it.
-  interop:
-    name: Interop (${{ matrix.os }})
-    needs: [quality, build]
-    if: github.event_name == 'push'
-    runs-on: ${{ matrix.os }}
-    continue-on-error: true
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
-        with:
-          node-version: '22'
-          package-manager-cache: false
-      - name: Enable corepack (pnpm)
-        run: corepack enable
-      - name: Get pnpm store path
-        id: pnpm-store
-        shell: bash
-        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v5
-        with:
-          path: ${{ steps.pnpm-store.outputs.path }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-pnpm-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      # Ubuntu's apt `unar` package is too old to read modern WinZip-AES-256;
-      # skip unar on Linux. Tests auto-skip via hasTool('unar') check.
-      - name: Install 7-Zip (Ubuntu)
-        if: runner.os == 'Linux'
-        run: sudo apt-get install -y p7zip-full
-
-      - name: Install 7-Zip + unar (macOS)
-        if: runner.os == 'macOS'
-        run: brew install sevenzip unar
-
-      - name: Install 7-Zip (Windows)
-        if: runner.os == 'Windows'
-        run: choco install 7zip -y
-
-      - name: Run interop tests
-        working-directory: packages/as-zip
-        run: pnpm vitest run __tests__/interop.test.ts --reporter=verbose
+  # ── Interop moved to the pre-publish gate ────────────────────────────
+  # The cross-OS WinZip-AES-256 interop matrix (ubuntu/macOS/windows +
+  # 7z/unar/choco installs) is the slowest, advisory leg, so it no longer
+  # runs on PRs or main. It now runs in release.yml as part of the full
+  # pre-publish gate, alongside the node 22 + 24 test matrix.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,9 +90,15 @@ env:
 jobs:
   # ── Gate 1: strict verification ──────────────────────────────────────
   verify:
-    name: Verify (strict)
+    name: Verify (strict, node ${{ matrix.node }})
     runs-on: ubuntu-latest
     if: github.event_name == 'release' || github.event.inputs.confirm == 'PUBLISH' || github.event_name == 'push'
+    # Full runtime matrix — the node 22 + 24 coverage that dev CI (ci.yml)
+    # trades away for PR speed runs here, as a hard gate before publish.
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['22', '24']
     steps:
       - uses: actions/checkout@v5
         with:
@@ -100,7 +106,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: ${{ matrix.node }}
           package-manager-cache: false
           registry-url: 'https://registry.npmjs.org'
 
@@ -132,9 +138,10 @@ jobs:
 
       # @noy-db/showcases topology tests need real-cloud credentials
       # (private workspace; runnable locally with .env populated).
+      # HARD GATE: unlike dev CI, a failing test here BLOCKS the publish
+      # (this is the last line of defence before npm), on both node 22 + 24.
       - name: Test
         run: pnpm turbo test --concurrency=1 --filter '!@noy-db/showcases'
-        continue-on-error: true
 
       - name: Verify package.json versions match release tag
         if: github.event_name == 'release'
@@ -147,6 +154,55 @@ jobs:
             exit 1
           fi
           echo "✅ @noy-db/hub@$HUB_VERSION matches release tag v$VERSION"
+
+  # ── Gate 1b: cross-OS interop (advisory) ─────────────────────────────
+  # WinZip-AES-256 interop across ubuntu/macOS/windows (7z/unar/choco).
+  # Moved here from dev CI: it's the slowest leg, so it runs only at
+  # release time. Advisory (continue-on-error) — it does NOT gate publish
+  # (never been first-green); it surfaces cross-tool regressions to the
+  # maintainer at release without blocking. Flip to a hard gate once green.
+  interop:
+    name: Interop (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    if: github.event_name == 'release' || github.event.inputs.confirm == 'PUBLISH'
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          package-manager-cache: false
+      - name: Enable corepack (pnpm)
+        run: corepack enable
+      - name: Get pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-pnpm-
+      - name: Install (frozen lockfile)
+        run: pnpm install --frozen-lockfile
+      - name: Install 7-Zip (Ubuntu)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y p7zip-full
+      - name: Install 7-Zip + unar (macOS)
+        if: runner.os == 'macOS'
+        run: brew install sevenzip unar
+      - name: Install 7-Zip (Windows)
+        if: runner.os == 'Windows'
+        run: choco install 7zip -y
+      - name: Run interop tests
+        working-directory: packages/as-zip
+        run: pnpm vitest run __tests__/interop.test.ts --reporter=verbose
 
   # ── Gate 2: publish with provenance ──────────────────────────────────
   #


### PR DESCRIPTION
As discussed — two CIs so frequent PRs merge fast while releases stay fully covered.

## Dev CI (`ci.yml`) — every PR + push, FAST
- `test` → **ubuntu + node 24 only** (was the 22+24 matrix). node 24 is flake-free, so the node-22 unhandled-rejection flake leaves the PR path entirely.
- **interop removed** (moved to the pre-publish gate).
- Required checks unchanged (Architecture · Spec · Lint+typecheck · Build) — verified these are the *only* required contexts, so dropping node-22/interop can't block merges.
- Keeps the turbo cache from #546.

## Full gate (`release.yml`) — before publish, HARD
- `verify` → **node 22 + 24 matrix**; the test step's `continue-on-error: true` **removed** → a failing test now **blocks the publish** (it didn't before).
- **interop** (ubuntu/macOS/windows) moved here, advisory (`continue-on-error`) until first-green.
- `publish needs: verify` → nothing reaches npm unless the full matrix passes.

Net: fast merges day-to-day; the exhaustive matrix + node-22 + interop all run as the last line of defence before npm.