### PR TITLE
S4: service-layer withX() — design + plan + withAttestation exemplar

### DIFF
--- a/docs/superpowers/plans/2026-07-01-service-layer-withx.md
+++ b/docs/superpowers/plans/2026-07-01-service-layer-withx.md
@@ -37,6 +37,12 @@ READ `with-fork/snapshots/strategy.ts` + `noydb-facade.ts` first; each ② servi
 
 Each `withX()` is exported from the service's `index.ts` and the `@noy-db/hub/<x>` subpath.
 
+**VALIDATED by the Task-1 exemplar — apply to every ② service:**
+- **Facade is ALWAYS built; the STRATEGY is swapped** (`NO_X` ↔ `withX()`) — do NOT gate by "construct the facade only when opted in." Per-vault facades hold state (e.g. attestation's field-schema registry) that must survive even when the capability isn't opted in.
+- **Schema/registration methods stay UNGATED** (e.g. attestation's `register()` from `collection({attestation})`); only the **capability methods** (the ones you invoke) delegate through the strategy and hit `NO_X`'s throw.
+- **Strategy methods are stateless and take the per-call context** the facade assembles (mirrors `SnapshotStrategy` taking `vault` per call); `withX()` itself takes only real opts (often none).
+- Expect a **+1 kernel-surface ratchet bump** on `vault.ts` and/or `noydb.ts` per service (the one irreducible wiring line); bump with justification, keep it to one line.
+
 ---
 
 ### Task 1: Gate exemplar — `withAttestation` (establishes the pattern)

--- a/docs/superpowers/plans/2026-07-01-service-layer-withx.md
+++ b/docs/superpowers/plans/2026-07-01-service-layer-withx.md
@@ -1,0 +1,134 @@
+# Service-layer withX() Implementation Plan (S4)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give every archetype-② on-demand service a tree-shakeable `withX()` capability gate, and make "every service is opt-in" a mechanically-enforced invariant.
+
+**Architecture:** Each ② service is gated exactly like the existing `with-fork/snapshots` ① strategy — a `NO_X` no-op stub that throws when its methods are called without opting in, a `withX()` active factory whose engine is dynamically imported, a `xStrategy` field on `createNoydb` options, and the service's public methods routed through the strategy. Archetype ③ (schema features) stays schema-declared and is exempted from the check. Spec: `docs/superpowers/specs/2026-07-01-service-layer-withx-design.md`.
+
+**Tech Stack:** TypeScript, tsup (subpath entries), vitest, pnpm/turbo. Live reference exemplar: `packages/hub/src/with-fork/snapshots/{strategy.ts,active.ts,noydb-facade.ts,index.ts}`.
+
+## Global Constraints
+
+- **Behavior for ① and ③ services is unchanged.** Only ② services change (become opt-in).
+- **② hard opt-in (pre-1.0 breaking):** calling a ② method without its `withX()` throws a per-service `…NotEnabledError extends NoydbError` whose message names the exact factory to add (mirror `ForgetStrategyNotConfiguredError`, `DirectoryDisabledError`, and the `NO_SNAPSHOTS` message at `with-fork/snapshots/strategy.ts:49`).
+- **Tree-shaking:** the `NO_X` stub is tiny and stays in the floor bundle; the real engine lives in `active.ts` and is reached only via `withX()` (dynamic import), so it's tree-shaken when not opted in.
+- **Public surface:** each service keeps its `@noy-db/hub/<x>` subpath; `withX()` is exported from it. No symbol removed from the root barrel without a deprecation.
+- **Suite stays green** (current baseline — run `pnpm --filter @noy-db/hub test` to confirm the number before starting); each ② task adds a gate test.
+- **check-architecture** `strategy-opt-in` must pass and, by the end, require a `withX()` for every ①/② service and exempt the ③ list.
+- No Claude attribution in commits; grep each diff for pilot-client names (none).
+
+---
+
+## The gate recipe (every ② task follows this — the `snapshots` exemplar in code)
+
+READ `with-fork/snapshots/strategy.ts` + `noydb-facade.ts` first; each ② service reproduces this five-part shape:
+
+1. **`with-<dim>/<svc>/strategy.ts`** — export the `XStrategy` interface (the methods the engine implements) and a `NO_X: XStrategy` stub whose every method throws `new XNotEnabledError()`:
+   ```ts
+   export const NO_X: XStrategy = {
+     someMethod() { throw new XNotEnabledError() },   // one per gated method
+   }
+   ```
+2. **`with-<dim>/<svc>/active.ts`** — `export function withX(opts: WithXOptions): XStrategy { … }` returning the real engine (the existing impl, wrapped). Heavy deps imported here (so `withX()` is the only path that pulls them).
+3. **`kernel/errors.ts`** — `export class XNotEnabledError extends NoydbError` (`code: 'X_NOT_ENABLED'`), message: `` `<methods> require `xStrategy: withX()` in createNoydb.` `` (copy the `NO_SNAPSHOTS` wording).
+4. **`kernel/types.ts`** — add `readonly xStrategy?: XStrategy` to the `createNoydb` options type (next to `snapshotStrategy`).
+5. **`kernel/noydb.ts`** (or `kernel/vault.ts` for vault-level services) — wire `strategy: options.xStrategy ?? NO_X` into the facade, and route the service's public delegator methods through `this.<strategy>` so they hit `NO_X`'s throw when not opted in.
+
+Each `withX()` is exported from the service's `index.ts` and the `@noy-db/hub/<x>` subpath.
+
+---
+
+### Task 1: Gate exemplar — `withAttestation` (establishes the pattern)
+
+**Files:**
+- Modify: `packages/hub/src/with-audit/attestation/{strategy.ts (create),active.ts (create),index.ts}`, `kernel/errors.ts`, `kernel/types.ts`, `kernel/vault.ts` (the `VaultAttestation` facade built at `vault.ts` ~610 is only constructed when opted in; else `NO_ATTESTATION`)
+- Test: `packages/hub/__tests__/attestation-optin.test.ts`
+
+**Interfaces:**
+- Produces: `withAttestation()`, `AttestationStrategy`, `NO_ATTESTATION`, `AttestationNotEnabledError`, options field `attestationStrategy`.
+
+**Methods to gate:** `issueAttestation`, `getDocumentSigningPublicKey`, `revokeAttestation`, `unrevokeAttestation`, `getRevokedDocIds`, `publishRevocationList`.
+
+- [ ] **Step 1: Failing test** — `attestation-optin.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/noydb.js'
+import { withAttestation } from '../src/with-audit/attestation/index.js'
+import { AttestationNotEnabledError } from '../src/errors.js'
+// helper: reuse the memory() store + Invoice setup from attestation-vault.test.ts
+it('throws AttestationNotEnabledError when not opted in', async () => {
+  const db = await createNoydb({ store: memory(), user: 'firm', secret: 'pw-123456' })
+  const v = await db.openVault('books')
+  await v.collection('invoices', { attestation }).put('x', { id:'x', invoiceNo:'A', total:1, issueDate:'2026-05-29' })
+  await expect(v.issueAttestation('invoices','x')).rejects.toThrow(AttestationNotEnabledError)
+})
+it('works when opted in via withAttestation()', async () => {
+  const db = await createNoydb({ store: memory(), user: 'firm', secret: 'pw-123456', attestationStrategy: withAttestation() })
+  const v = await db.openVault('books')
+  await v.collection('invoices', { attestation }).put('x', { id:'x', invoiceNo:'A', total:1, issueDate:'2026-05-29' })
+  const r = await v.issueAttestation('invoices','x')
+  expect(r.docId).toHaveLength(26)
+})
+```
+- [ ] **Step 2: Run → FAIL** (`withAttestation`/`AttestationNotEnabledError` undefined). `pnpm vitest run packages/hub/__tests__/attestation-optin.test.ts`
+- [ ] **Step 3: Implement the 5-part gate** per the recipe (create `strategy.ts` with `NO_ATTESTATION` throwing `AttestationNotEnabledError` for each of the 6 methods; `active.ts` `withAttestation()` returning the real `VaultAttestation` engine; error class; `attestationStrategy` option; wire `vault.ts` to build `VaultAttestation` only when `attestationStrategy` is present, else `NO_ATTESTATION`).
+- [ ] **Step 4: Run → PASS** (both tests). Then `pnpm --filter @noy-db/hub test` — the existing `attestation-*.test.ts` suites now must pass `attestationStrategy: withAttestation()` in their `createNoydb`; **update those setups** (they're the canonical consumers). Confirm green.
+- [ ] **Step 5: Commit** — `feat(hub): gate attestation behind withAttestation() (S4)`
+
+---
+
+### Tasks 2–10: Roll the gate out to each remaining ② service
+
+Each task = one service, following the Task-1 recipe exactly (5-part gate + an `…-optin.test.ts` asserting the `…NotEnabledError` without opt-in and success with it, + updating that service's existing test setups to pass the new strategy). Per-service specifics:
+
+| # | Service | dir | field / factory / error | methods to gate | wiring level |
+|---|---|---|---|---|---|
+| 2 | tiers | `with-audit/tiers` | `tiersStrategy` / `withTiers` / `TiersNotEnabledError` | `putAtTier` `getAtTier` `listAtTier` `elevate` `demote` | collection (`with-audit/tiers` facade) |
+| 3 | sealed-record | `with-audit/sealed-record` | `sealedRecordStrategy` / `withSealedRecord` / `SealedRecordNotEnabledError` | `sealRecordToHost` `openSealedRecord` `revokeSealedRecord` (+ `{hard}` rotate) | vault |
+| 4 | portability | `with-audit/portability` | `portabilityStrategy` / `withPortability` / `PortabilityNotEnabledError` | `exportAccessibleData` `withdrawAccessibleData` `requestWithdrawal` `approveWithdrawal` `rejectWithdrawal` `listWithdrawalRequests` | vault (via `UserApi`) |
+| 5 | custody | `with-party/custody` | `custodyStrategy` / `withCustody` / `CustodyNotEnabledError` | `grantCustodian` `revokeCustodian` `liberateVault` | noydb/vault |
+| 6 | directory | `with-party/directory` | `directoryStrategy` / `withDirectory` / reuse **`DirectoryDisabledError`** (exists) | directory config + user-visibility read/write | noydb |
+| 7 | search | `with-lookup/search` (+ `embeddings`) | `searchStrategy` / `withSearch` / `SearchNotEnabledError` | `retrieve` `similarTo` `search` `warmIndex` `flushIndex` | collection. **Resolve embeddings↔search pairing here** (spec open item): embeddings is the ①-write-hook feeding search; decide one `withSearch()` that also enables embedding compute, or a `withEmbeddings()` pair. Recommend a single `withSearch({ embeddings })`. |
+| 8 | sequence | `with-commit/sequence` | `sequenceStrategy` / `withSequence` / `SequenceNotEnabledError` | `vault.sequence()` | vault |
+| 9 | cargo | `with-cargo` | `cargoStrategy` / `withCargo` / `CargoNotEnabledError` | `extractPartition` `adoptPartition` `decryptExtractedPartition` `diffVault` | noydb/vault |
+| 10 | pod | `with-pod` | `podStrategy` / `withPod` / `PodNotEnabledError` | `writePod` `readPod` (`vault.dump`/`.load` if pod-routed) | vault |
+
+Each: one commit `feat(hub): gate <svc> behind with<Svc>() (S4)`. If a service's methods turn out to be genuinely always-on infrastructure (not a discrete capability) — STOP and report rather than force a gate.
+
+---
+
+### Task 11: Enforce "every service is opt-in" in check-architecture
+
+**Files:** Modify `scripts/check-architecture.mjs` (the `strategy-opt-in` check), `packages/hub/__tests__/` (a coverage assertion if one exists)
+
+- [ ] **Step 1:** Extend `strategy-opt-in` so that every `with-*/<svc>/` folder must export a `withX()` (archetypes ①+②) UNLESS it's in an explicit `SCHEMA_DECLARED_EXEMPT` list (archetype ③: `computed`, `money`, `links`, `introspection`, `persisted-schemas`, `schema-update`; plus non-service helpers). List each exempt folder with a one-line reason.
+- [ ] **Step 2: Run** `node scripts/check-architecture.mjs` → PASS (all ①/② have `withX`, ③ exempt).
+- [ ] **Step 3: Commit** — `build(hub): strategy-opt-in requires withX() for every service (③ exempt)`
+
+---
+
+### Task 12: Document archetype ③ as schema-declared
+
+**Files:** Create/modify `docs/subsystems/` pages for `computed`/`money`/`links`/`introspection`/`schema-update`; a short `docs/architecture` note pointing at the two seams.
+
+- [ ] **Step 1:** For each ③ feature, add/confirm a doc line: "schema-declared on `collection({ … })`; no `withX()` — the collection is its opt-in unit; impl lazy-imports from the schema declaration." Verify the lazy-import is real (grep the ③ engines for `await import(`); if a ③ impl is eagerly imported into the floor, note it as a follow-up (out of scope here).
+- [ ] **Step 2: Commit** — `docs(hub): archetype-③ schema features are schema-declared (no withX)`
+
+---
+
+### Task 13: ① consistency pass (light)
+
+**Files:** the ① service folders lacking the exact three-file shape (e.g. `forget`, `guards` had `strategy.ts` but no `active.ts`).
+
+- [ ] **Step 1:** For each ① service missing the canonical split, move the `withX()` factory into `active.ts` and keep the `NO_X` stub + type in `strategy.ts` — behavior-preserving (suite green). Do NOT change any ① public API. Skip services already conforming.
+- [ ] **Step 2: Run** full suite + check-architecture → green.
+- [ ] **Step 3: Commit** — `refactor(hub): normalize ① services to strategy/active/index shape (S4)`
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Seam A (①+② `withX`) → Tasks 1–10; the ② hard-opt-in + `NotEnabledError` → recipe + every ② task; Seam B (③ schema-declared, exempt) → Tasks 11–12; canonical 3-file shape → recipe + Task 13; `strategy-opt-in` enforcement → Task 11; success criteria (tree-shaking, floor drop, gate tests) → per-task tests + Task 11. ✓
+- **Placeholders:** the two spec "open items" (embeddings↔search pairing; named-fields-vs-array) are resolved in-plan — pairing decided in Task 7 (single `withSearch({embeddings})`), and the plan keeps named `…Strategy` fields (no array migration). ✓
+- **Type consistency:** every ② service uses the uniform quintuple `XStrategy` / `NO_X` / `withX` / `XNotEnabledError` / `xStrategy` field; names in the Task-2–10 table match this scheme. `directory` reuses the existing `DirectoryDisabledError` (noted). ✓

--- a/docs/superpowers/specs/2026-07-01-service-layer-withx-design.md
+++ b/docs/superpowers/specs/2026-07-01-service-layer-withx-design.md
@@ -1,0 +1,95 @@
+# Service-layer `withX()` design (S4)
+
+> **Status:** design (2026-07-01). The final step of the microkernel reorg: give the
+> service layer a **uniform, tree-shakeable opt-in surface**. Follows the canonical
+> lexicon (`2026-07-01-noydb-architecture-lexicon.md`) — the `with-*` folders are the
+> **service layer**; this spec defines how each service is opted into and tree-shaken.
+> The topology reorg (S1–S3, PRs #539–#545) is done; this is S4.
+
+## Problem
+
+The `with-*` services are meant to be **opt-in and tree-shakeable via a `withX()`**, but an
+audit shows only ~half have one. The gap isn't laziness — the services fall into **three
+archetypes**, and the current `withX()` pattern only fits one:
+
+| Archetype | Nature | Has `withX()` | Examples |
+|---|---|---|---|
+| **① pipeline strategy** | hooks the write/read pipeline | ✓ | history · crdt · guards · derivations · blobs · snapshots · periods · consent · tx · numbering · materialized-views · overlay-views · aggregate · indexing · shadow · archive · forget · session |
+| **② on-demand capability** | methods you *invoke* | ✗ mostly | attestation · tiers · sealed-record · portability · custody · directory · search · sequence · **cargo** · **pod** |
+| **③ schema feature** | declared per collection/field | ✗ | computed · money · links · introspection · schema-update |
+
+## Decision — pattern-honest, uniform *feel*, two seams
+
+Do **not** force one shape onto all three. Instead: two opt-in seams, matched to the
+archetypes, with one consistent developer-facing story.
+
+### Seam A — `withX()` capability → `createNoydb({ …Strategy: withX() })` (archetypes ① + ②)
+
+① and ② share the **same call shape** — a `withX()` passed to `createNoydb` under a named
+`…Strategy` field — while the injected payload differs internally:
+
+- **① pipeline:** `withX()` returns a strategy that hooks the pipeline (unchanged — already the pattern).
+- **② on-demand:** `withX()` returns a **capability gate**. Passing it (a) makes the module's
+  methods exist on the instance (`vault.issueAttestation()`, `vault.exportPod()`, …) and (b)
+  pulls the real impl via dynamic import. Omit it → the methods throw
+  `SubsystemNotEnabledError` ("enable it with `withAttestation()` in `createNoydb`") and the
+  impl tree-shakes out.
+
+Both use the same `NO_X` no-op stub default and the **existing `strategy-opt-in` architecture
+check** (which already requires a `with*()` reference to use a subsystem — ② simply joins that
+rule). To a developer, everything instance-level is a `withX()`.
+
+**Consequence (accepted):** archetype-② capabilities that are **always-on today become opt-in**
+— calling them without the `withX()` throws. This is a **pre-1.0 breaking change**, chosen for
+consistency with the ①-`strategy-opt-in` rule already enforced, and because it's what makes them
+genuinely tree-shakeable (out of the floor bundle unless opted in). The error message names the
+exact `withX()` to add.
+
+### Seam B — collection-schema declaration (archetype ③)
+
+`computed` · `money` · `links` · `introspection` · `schema-update` are field/collection features,
+declared where they live: `db.collection('x', { schema, computed: {…}, money: [...] })`. Their
+impl tree-shakes via a **dynamic import triggered by the schema declaration**. They get **no
+top-level `withX()`** — the collection *is* their opt-in unit; a global `withX()` would be a fake
+abstraction. They are documented as schema-declared features and **exempted from the `withX`
+audit** (the `strategy-opt-in` check learns this exemption list).
+
+## Canonical service shape (standardize ① + ②)
+
+Every ①/② service folder converges on the same three files:
+
+- **`strategy.ts`** — the `XStrategy` / `XCapability` type + the `NO_X` no-op stub (stays in the floor bundle; tiny).
+- **`active.ts`** — the real `withX(opts)` factory + engine, **dynamically imported** so it's tree-shaken until opted in.
+- **`index.ts`** — the barrel + the `@noy-db/hub/<x>` subpath export.
+
+## Scope
+
+- **Fill the ② gaps** — new capability-gate `withX()` for: `withAttestation` · `withTiers` ·
+  `withSealedRecord` · `withPortability` · `withCustody` · `withDirectory` · `withSearch` ·
+  `withSequence` · `withCargo` · `withPod`. (`embeddings` is the ① write-hook that *feeds*
+  `search`'s ② retrieval — they share one `withSearch()`/`withEmbeddings()` pair; resolve during
+  planning.)
+- **① services** — already conform; a light consistency pass (ensure the three-file shape + a
+  `NO_X` stub) only.
+- **③ services** — document as schema-declared; verify lazy-import tree-shaking; add their names
+  to the `strategy-opt-in` exemption list. No `withX`.
+- **Update `strategy-opt-in`** in `scripts/check-architecture.mjs` to (a) require a `withX()` for
+  every ①/② service and (b) exempt the ③ list — turning "every service is opt-in" into a
+  mechanically enforced invariant.
+
+## Success criteria
+
+- Every ① and ② service has a `withX()` and is tree-shaken from the floor bundle when not opted in.
+- The `strategy-opt-in` check passes and now covers the whole service layer (① + ② required, ③ exempt).
+- A developer opts into instance capabilities uniformly (`createNoydb({ …: withX() })`) and into
+  schema features on the collection (`collection({ computed, money, … })`).
+- Bundle-size floor drops (② capabilities leave the always-on core).
+- All existing tests pass; new tests assert the `SubsystemNotEnabledError` gate for each ② service.
+
+## Out of scope / open (resolve in the plan)
+
+- Whether `createNoydb` keeps named `…Strategy` fields or moves to a single `capabilities: [...]`
+  array (a bigger API change — **default: keep named fields**; only revisit if the ② additions
+  make it unwieldy).
+- The `embeddings`↔`search` pairing (one `withX()` or two).
+- Per-service migration ordering + the deprecation message wording.

--- a/packages/hub/__tests__/attestation-optin.test.ts
+++ b/packages/hub/__tests__/attestation-optin.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { withAttestation } from '../src/with-audit/attestation/index.js'
+import { AttestationNotEnabledError } from '../src/kernel/errors.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
+import { ConflictError } from '../src/kernel/errors.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const gc = (v: string, c: string) => { let comp = store.get(v); if (!comp) { comp = new Map(); store.set(v, comp) } let coll = comp.get(c); if (!coll) { coll = new Map(); comp.set(c, coll) } return coll }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return store.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) { const coll = gc(v, c); const ex = coll.get(id); if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v); coll.set(id, env) },
+    async delete(v, c, id) { store.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { const coll = store.get(v)?.get(c); return coll ? [...coll.keys()] : [] },
+    async loadAll(v) { const comp = store.get(v); const s: VaultSnapshot = {}; if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } } return s },
+    async saveAll(v, data) { const comp = new Map<string, Map<string, EncryptedEnvelope>>(); for (const [n, recs] of Object.entries(data)) { const coll = new Map<string, EncryptedEnvelope>(); for (const [id, e] of Object.entries(recs)) coll.set(id, e); comp.set(n, coll) } const ex = store.get(v); if (ex) for (const [n, coll] of ex) if (n.startsWith('_')) comp.set(n, coll); store.set(v, comp) },
+  }
+}
+
+interface Invoice { id: string; invoiceNo: string; total: number; issueDate: string }
+const attestation = { fields: [
+  { path: 'invoiceNo', normalize: 'alnum-upper' as const },
+  { path: 'total', normalize: 'cents' as const },
+  { path: 'issueDate', normalize: 'iso-date' as const },
+] }
+
+describe('attestation capability gate (withAttestation)', () => {
+  it('throws AttestationNotEnabledError when not opted in', async () => {
+    const db = await createNoydb({ store: memory(), user: 'firm', secret: 'pw-123456' })
+    const v = await db.openVault('books')
+    await v.collection<Invoice>('invoices', { attestation }).put('x', { id: 'x', invoiceNo: 'A', total: 1, issueDate: '2026-05-29' })
+    await expect(v.issueAttestation('invoices', 'x')).rejects.toThrow(AttestationNotEnabledError)
+  })
+
+  it('gates all six capability methods when not opted in', async () => {
+    const db = await createNoydb({ store: memory(), user: 'firm', secret: 'pw-123456' })
+    const v = await db.openVault('books')
+    await v.collection<Invoice>('invoices', { attestation }).put('x', { id: 'x', invoiceNo: 'A', total: 1, issueDate: '2026-05-29' })
+    await expect(v.issueAttestation('invoices', 'x')).rejects.toThrow(AttestationNotEnabledError)
+    await expect(v.getDocumentSigningPublicKey()).rejects.toThrow(AttestationNotEnabledError)
+    await expect(v.revokeAttestation('01JNEVERISSUED0000000000XX')).rejects.toThrow(AttestationNotEnabledError)
+    await expect(v.unrevokeAttestation('01JNEVERISSUED0000000000XX')).rejects.toThrow(AttestationNotEnabledError)
+    await expect(v.getRevokedDocIds()).rejects.toThrow(AttestationNotEnabledError)
+    await expect(v.publishRevocationList()).rejects.toThrow(AttestationNotEnabledError)
+  })
+
+  it('works when opted in via withAttestation()', async () => {
+    const db = await createNoydb({ store: memory(), user: 'firm', secret: 'pw-123456', attestationStrategy: withAttestation() })
+    const v = await db.openVault('books')
+    await v.collection<Invoice>('invoices', { attestation }).put('x', { id: 'x', invoiceNo: 'A', total: 1, issueDate: '2026-05-29' })
+    const r = await v.issueAttestation('invoices', 'x')
+    expect(r.docId).toHaveLength(26)
+  })
+})

--- a/packages/hub/__tests__/attestation-revoke-vault.test.ts
+++ b/packages/hub/__tests__/attestation-revoke-vault.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { createNoydb } from '../src/kernel/noydb.js'
 import { verifyRevocationList, isRevoked, type AttestationFieldSchema } from '@noy-db/attestation'
+import { withAttestation } from '../src/with-audit/attestation/index.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
 import { ConflictError } from '../src/kernel/errors.js'
 
@@ -28,7 +29,7 @@ const attestation: AttestationFieldSchema = {
 }
 
 async function ownerVault() {
-  const db = await createNoydb({ store: memory(), user: 'firm', secret: 'firm-passphrase-2026' })
+  const db = await createNoydb({ store: memory(), user: 'firm', secret: 'firm-passphrase-2026', attestationStrategy: withAttestation() })
   const vault = await db.openVault('books')
   await vault.collection<Invoice>('invoices', { attestation }).put('inv-1', { id: 'inv-1', invoiceNo: 'INV-1', total: 1234.5, issueDate: '2026-05-29' })
   return vault

--- a/packages/hub/__tests__/attestation-vault.test.ts
+++ b/packages/hub/__tests__/attestation-vault.test.ts
@@ -3,6 +3,7 @@ import { createNoydb } from '../src/kernel/noydb.js'
 import { verifyAttestation } from '@noy-db/attestation'
 import { withI18n } from '../src/with-shape/i18n/index.js'
 import { withHistory } from '../src/with-commit/history/index.js'
+import { withAttestation } from '../src/with-audit/attestation/index.js'
 import { i18nText } from '../src/with-shape/i18n/core.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
 import { ConflictError, AttestationError } from '../src/kernel/errors.js'
@@ -29,7 +30,7 @@ const attestation = { fields: [
 ] }
 
 async function ownerVault() {
-  const db = await createNoydb({ store: memory(), user: 'firm', secret: 'firm-passphrase-2026' })
+  const db = await createNoydb({ store: memory(), user: 'firm', secret: 'firm-passphrase-2026', attestationStrategy: withAttestation() })
   const vault = await db.openVault('books')
   const invoices = vault.collection<Invoice>('invoices', { attestation })
   await invoices.put('inv-1', { id: 'inv-1', invoiceNo: 'INV-1', total: 1234.5, issueDate: '2026-05-29' })
@@ -61,7 +62,7 @@ describe('vault.issueAttestation (integration)', () => {
   })
 
   it('throws AttestationError when the collection has no attestation schema declared', async () => {
-    const db = await createNoydb({ store: memory(), user: 'firm', secret: 'pw-123456' })
+    const db = await createNoydb({ store: memory(), user: 'firm', secret: 'pw-123456', attestationStrategy: withAttestation() })
     const vault = await db.openVault('books')
     await vault.collection<Invoice>('plain').put('x', { id: 'x', invoiceNo: 'A', total: 1, issueDate: '2026-05-29' })
     await expect(vault.issueAttestation('plain', 'x')).rejects.toThrow(AttestationError)
@@ -83,7 +84,7 @@ describe('vault.issueAttestation (integration)', () => {
       { path: 'issueDate', normalize: 'iso-date' as const },
       { path: 'vendorName', normalize: 'trim' as const },
     ] }
-    const db = await createNoydb({ store: memory(), user: 'firm', secret: 'firm-passphrase-2026', i18nStrategy: withI18n() })
+    const db = await createNoydb({ store: memory(), user: 'firm', secret: 'firm-passphrase-2026', i18nStrategy: withI18n(), attestationStrategy: withAttestation() })
     // Default locale 'en' would collapse vendorName to 'ACME Co' on a plain get().
     const vault = await db.openVault('books', { locale: 'en' })
     const invoices = vault.collection<I18nInvoice>('invoices', {
@@ -110,7 +111,7 @@ describe('vault.issueAttestation (integration)', () => {
 
 describe('vault.getDocumentSigningPublicKey (mint-on-read role gate)', () => {
   it('owner: mints the signing key on first read and returns it', async () => {
-    const db = await createNoydb({ store: memory(), user: 'firm', secret: 'firm-passphrase-2026' })
+    const db = await createNoydb({ store: memory(), user: 'firm', secret: 'firm-passphrase-2026', attestationStrategy: withAttestation() })
     const vault = await db.openVault('books')
 
     const { keyId, publicKeyB64 } = await vault.getDocumentSigningPublicKey()
@@ -124,11 +125,11 @@ describe('vault.getDocumentSigningPublicKey (mint-on-read role gate)', () => {
 
   it('non-owner on a fresh vault: refuses to mint and throws AttestationError (no signer written)', async () => {
     const adapter = memory()
-    const ownerDb = await createNoydb({ store: adapter, user: 'firm', secret: 'firm-passphrase-2026' })
+    const ownerDb = await createNoydb({ store: adapter, user: 'firm', secret: 'firm-passphrase-2026', attestationStrategy: withAttestation() })
     await ownerDb.openVault('books')
     await ownerDb.grant('books', { userId: 'viewer-01', displayName: 'Viewer', role: 'viewer', passphrase: 'viewer-pass' })
 
-    const viewerDb = await createNoydb({ store: adapter, user: 'viewer-01', secret: 'viewer-pass' })
+    const viewerDb = await createNoydb({ store: adapter, user: 'viewer-01', secret: 'viewer-pass', attestationStrategy: withAttestation() })
     const viewerVault = await viewerDb.openVault('books')
 
     await expect(viewerVault.getDocumentSigningPublicKey()).rejects.toThrow(AttestationError)
@@ -138,12 +139,12 @@ describe('vault.getDocumentSigningPublicKey (mint-on-read role gate)', () => {
 
   it('non-owner after the owner has minted: the read does NOT mint (gate only guards minting)', async () => {
     const adapter = memory()
-    const ownerDb = await createNoydb({ store: adapter, user: 'firm', secret: 'firm-passphrase-2026' })
+    const ownerDb = await createNoydb({ store: adapter, user: 'firm', secret: 'firm-passphrase-2026', attestationStrategy: withAttestation() })
     const ownerVault = await ownerDb.openVault('books')
     const minted = await ownerVault.getDocumentSigningPublicKey() // owner mints
     await ownerDb.grant('books', { userId: 'viewer-01', displayName: 'Viewer', role: 'viewer', passphrase: 'viewer-pass' })
 
-    const viewerDb = await createNoydb({ store: adapter, user: 'viewer-01', secret: 'viewer-pass' })
+    const viewerDb = await createNoydb({ store: adapter, user: 'viewer-01', secret: 'viewer-pass', attestationStrategy: withAttestation() })
     const viewerVault = await viewerDb.openVault('books')
 
     // The signer already exists, so loadSigner short-circuits before the gate —
@@ -164,7 +165,7 @@ describe('vault.getDocumentSigningPublicKey (mint-on-read role gate)', () => {
   // attestation issuance/verification keeps working across a backup round-trip.
   it('issues + verifies attestations across a dump/load round-trip', async () => {
     const adapter = memory()
-    const db = await createNoydb({ store: adapter, user: 'firm', secret: 'firm-passphrase-2026', historyStrategy: withHistory() })
+    const db = await createNoydb({ store: adapter, user: 'firm', secret: 'firm-passphrase-2026', historyStrategy: withHistory(), attestationStrategy: withAttestation() })
     const vault = await db.openVault('books')
     const invoices = vault.collection<Invoice>('invoices', { attestation })
     await invoices.put('inv-1', { id: 'inv-1', invoiceNo: 'INV-1', total: 1234.5, issueDate: '2026-05-29' })

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -288,6 +288,7 @@ export {
   InvariantError,
   AmendmentForbiddenError,
   AttestationError,
+  AttestationNotEnabledError,
   SchemaUpdateError,
   NonAdditiveSchemaChangeError,
   SchemaLockedError,

--- a/packages/hub/src/kernel/errors.ts
+++ b/packages/hub/src/kernel/errors.ts
@@ -1637,6 +1637,26 @@ export class AttestationError extends NoydbError {
   }
 }
 
+/**
+ * Thrown when an attestation capability method (`issueAttestation`,
+ * `getDocumentSigningPublicKey`, `revokeAttestation`, `unrevokeAttestation`,
+ * `getRevokedDocIds`, `publishRevocationList`) is called without opting into
+ * the attestation capability (the default `NO_ATTESTATION` stub). Attestation
+ * is an opt-in, tree-shakeable capability: enable it with
+ * `attestationStrategy: withAttestation()` from "@noy-db/hub/attestation" in
+ * createNoydb().
+ */
+export class AttestationNotEnabledError extends NoydbError {
+  constructor(
+    message = 'Attestation requires the attestation capability. Pass ' +
+      '`attestationStrategy: withAttestation()` from "@noy-db/hub/attestation" ' +
+      'to createNoydb().',
+  ) {
+    super('ATTESTATION_NOT_ENABLED', message)
+    this.name = 'AttestationNotEnabledError'
+  }
+}
+
 // ─── Session Errors ───────────────────────────────────────
 
 /**

--- a/packages/hub/src/kernel/noydb.ts
+++ b/packages/hub/src/kernel/noydb.ts
@@ -595,6 +595,7 @@ export class Noydb {
       ...(this.options.guardStrategies !== undefined ? { guardStrategies: this.options.guardStrategies } : {}),
       ...(this.options.numbering !== undefined ? { numberingConfigs: this.options.numbering } : {}),
       forgetStrategy: this.forgetStrategy,
+      ...(this.options.attestationStrategy !== undefined ? { attestationStrategy: this.options.attestationStrategy } : {}),
       locale: opts?.locale,
       ...(opts?.meta !== undefined ? { meta: opts.meta } : {}),
       // Thread the translator hook so Collection.put() can invoke it
@@ -671,6 +672,7 @@ export class Noydb {
       ...(this.options.guardStrategies !== undefined ? { guardStrategies: this.options.guardStrategies } : {}),
       ...(this.options.numbering !== undefined ? { numberingConfigs: this.options.numbering } : {}),
       forgetStrategy: this.forgetStrategy,
+      ...(this.options.attestationStrategy !== undefined ? { attestationStrategy: this.options.attestationStrategy } : {}),
       })
       this.vaultCache.set(name, comp)
       return comp

--- a/packages/hub/src/kernel/types.ts
+++ b/packages/hub/src/kernel/types.ts
@@ -38,6 +38,7 @@ import type { TxStrategy } from '../with-commit/tx/strategy.js'
 import type { HistoryStrategy } from '../with-commit/history/strategy.js'
 import type { ForgetStrategy } from '../with-audit/forget/strategy.js'
 import type { SnapshotStrategy } from '../with-fork/snapshots/strategy.js'
+import type { AttestationStrategy } from '../with-audit/attestation/strategy.js'
 import type { Layer } from '../with-shape/i18n/policy.js'
 import type { I18nStrategy } from '../with-shape/i18n/strategy.js'
 import type { SessionStrategy } from '../with-party/session/strategy.js'
@@ -2086,6 +2087,16 @@ export interface NoydbOptions {
    * When omitted, all three methods throw with a pointer at the subpath.
    */
   readonly snapshotStrategy?: SnapshotStrategy
+  /**
+   * Tree-shake seam — optional attestation capability. Pass
+   * `withAttestation()` from `@noy-db/hub/attestation` to enable
+   * `vault.issueAttestation()`, `vault.getDocumentSigningPublicKey()`,
+   * `vault.revokeAttestation()`, `vault.unrevokeAttestation()`,
+   * `vault.getRevokedDocIds()`, and `vault.publishRevocationList()`. When
+   * omitted, all six throw `AttestationNotEnabledError` and the issue/revoke/
+   * signer engines are tree-shaken out.
+   */
+  readonly attestationStrategy?: AttestationStrategy
   /**
    * Optional guard strategies — collection-level write guards. Each
    * handle is the output of `withGuard()` from `@noy-db/hub/guards`.

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -152,7 +152,7 @@ import { FenceWatcher } from '../with-shape/schema-update/fence-watcher.js'
 import { loadFence, type FenceDoc } from '../with-shape/schema-update/fence.js'
 import type { SchemaUpdateStrategy, UpdateDecision, TransformFn } from '../with-shape/schema-update/types.js'
 import type { AttestationFieldSchema, RevocationList } from '@noy-db/attestation'
-import { VaultAttestation } from '../with-audit/attestation/vault-facade.js'
+import { VaultAttestation, NO_ATTESTATION, type AttestationStrategy } from '../with-audit/attestation/vault-facade.js'
 import type { DumpSchemaOptions, VaultSchemaSnapshot, SchemaIntrospection } from '../with-shape/introspection/types.js'
 import { dumpVaultSchema, type VaultIntrospectState } from '../with-shape/introspection/walk.js'
 import type { FieldMeta } from '../with-shape/introspection/field-meta.js'
@@ -529,6 +529,7 @@ export class Vault {
     guardStrategies?: ReadonlyArray<GuardStrategyHandleAny> | undefined
     numberingConfigs?: ReadonlyArray<DeferredNumberingConfig> | undefined
     forgetStrategy?: ForgetStrategy | undefined
+    attestationStrategy?: AttestationStrategy | undefined
     /** Vault-level descriptive metadata — set once at construction (first-wins). */
     meta?: VaultMeta | undefined
   }) {
@@ -605,8 +606,9 @@ export class Vault {
     // wrapped DEKs.
     this.getDEK = this.makeGetDEK()
 
-    // Attestation facade — holds the per-collection field-schema registry and
-    // the issue/revoke entry points; built once getDEK is wired.
+    // Attestation facade — always built (holds the per-collection field-schema
+    // registry); the capability itself is gated by the injected strategy
+    // (NO_ATTESTATION default throws until `attestationStrategy: withAttestation()`).
     this.attestation = new VaultAttestation({
       adapter: this.adapter,
       vault: this.name,
@@ -614,7 +616,7 @@ export class Vault {
       role: () => this.keyring.role,
       getRawRecord: async (collection, recId) =>
         (await this.collection(collection).get(recId, { locale: 'raw' })) as Record<string, unknown> | null,
-    })
+    }, opts.attestationStrategy ?? NO_ATTESTATION)
 
     // User envelope API — frozen writerKeyringId, dynamic DEK resolver
     // (so a post-load() keyring refresh transparently rotates the DEK

--- a/packages/hub/src/with-audit/attestation/active.ts
+++ b/packages/hub/src/with-audit/attestation/active.ts
@@ -1,0 +1,49 @@
+import { AttestationError } from '../../kernel/errors.js'
+import type { AttestationStrategy } from './strategy.js'
+
+/**
+ * Enable the attestation capability.
+ * Pass to `createNoydb({ attestationStrategy: withAttestation() })` to make the
+ * vault's `issueAttestation` / `getDocumentSigningPublicKey` / `revokeAttestation`
+ * / `unrevokeAttestation` / `getRevokedDocIds` / `publishRevocationList` methods
+ * live. The issue/revoke/signer engines are dynamically imported here, so they
+ * stay out of the floor bundle until opted in.
+ */
+export function withAttestation(): AttestationStrategy {
+  return {
+    async issueAttestation(ctx, args) {
+      const { issueAttestationCore } = await import('./issue.js')
+      return issueAttestationCore(ctx, args)
+    },
+    async getDocumentSigningPublicKey(deps) {
+      const { loadSigner, loadOrCreateSigner } = await import('./signer.js')
+      // Reading an existing public key is open to any role that holds the
+      // _attestations DEK — the public key is not secret. But MINTING the
+      // signer is the firm's identity operation (same rule as issueAttestation):
+      // a non-owner read must not silently create it.
+      const existing = await loadSigner(deps.adapter, deps.vault, deps.getDEK)
+      if (existing) return { keyId: existing.keyId, publicKeyB64: existing.publicKeyB64 }
+      if (deps.role !== 'owner') {
+        throw new AttestationError(`getDocumentSigningPublicKey: no document-signing key exists yet; only the 'owner' may mint it. Caller is '${deps.role}'. Have the owner issue an attestation (or call this) first.`)
+      }
+      const signer = await loadOrCreateSigner(deps.adapter, deps.vault, deps.getDEK)
+      return { keyId: signer.keyId, publicKeyB64: signer.publicKeyB64 }
+    },
+    async revokeAttestation(ctx, docId) {
+      const { revokeDocCore } = await import('./revoke.js')
+      return revokeDocCore(ctx, docId)
+    },
+    async unrevokeAttestation(ctx, docId) {
+      const { unrevokeDocCore } = await import('./revoke.js')
+      return unrevokeDocCore(ctx, docId)
+    },
+    async getRevokedDocIds(ctx) {
+      const { getRevokedDocIdsCore } = await import('./revoke.js')
+      return getRevokedDocIdsCore(ctx)
+    },
+    async publishRevocationList(ctx) {
+      const { publishRevocationListCore } = await import('./revoke.js')
+      return publishRevocationListCore(ctx)
+    },
+  }
+}

--- a/packages/hub/src/with-audit/attestation/index.ts
+++ b/packages/hub/src/with-audit/attestation/index.ts
@@ -4,6 +4,9 @@
  * for a record and emit a QR credential verifiable offline via
  * `@noy-db/attestation`. See docs/superpowers/specs/2026-05-29-attestation-core-and-issue-design.md.
  */
+export { withAttestation } from './active.js'
+export { NO_ATTESTATION, type AttestationStrategy } from './strategy.js'
+export { AttestationNotEnabledError } from '../../kernel/errors.js'
 export { issueAttestationCore } from './issue.js'
 export type { IssueContext, IssueArgs, IssueResult } from './issue.js'
 export { ATTESTATIONS_COLLECTION } from './signer.js'

--- a/packages/hub/src/with-audit/attestation/strategy.ts
+++ b/packages/hub/src/with-audit/attestation/strategy.ts
@@ -1,0 +1,51 @@
+import type { NoydbStore } from '../../kernel/types.js'
+import type { RevocationList } from '@noy-db/attestation'
+import type { IssueContext, IssueArgs, IssueResult } from './issue.js'
+import type { RevokeContext } from './revoke.js'
+import { AttestationNotEnabledError } from '../../kernel/errors.js'
+
+/**
+ * Deps the signing-public-key lookup needs. Unlike issue/revoke there is no
+ * per-call context object for it, so the vault facade assembles this at call
+ * time (reading `role` fresh).
+ */
+export interface SignerLookupDeps {
+  readonly adapter: NoydbStore
+  readonly vault: string
+  /** The invoking keyring's role, read fresh by the caller per call. */
+  readonly role: string
+  /** Per-collection DEK resolver (bound `vault.getDEK`). */
+  readonly getDEK: (collection: string) => Promise<CryptoKey>
+}
+
+/**
+ * Attestation capability strategy — the six on-demand methods the vault's
+ * attestation delegators route through. The active engine ({@link withAttestation})
+ * dynamically imports the issue/revoke/signer cores (keeping them out of the floor
+ * bundle); {@link NO_ATTESTATION} throws. The vault-side {@link VaultAttestation}
+ * facade holds the per-collection field-schema registry and builds the per-call
+ * contexts, then delegates here.
+ * @internal
+ */
+export interface AttestationStrategy {
+  issueAttestation(ctx: IssueContext, args: IssueArgs): Promise<IssueResult>
+  getDocumentSigningPublicKey(deps: SignerLookupDeps): Promise<{ keyId: string; publicKeyB64: string }>
+  revokeAttestation(ctx: RevokeContext, docId: string): Promise<void>
+  unrevokeAttestation(ctx: RevokeContext, docId: string): Promise<void>
+  getRevokedDocIds(ctx: RevokeContext): Promise<string[]>
+  publishRevocationList(ctx: RevokeContext): Promise<RevocationList>
+}
+
+/**
+ * No-op stub — the floor default. Every capability method throws
+ * {@link AttestationNotEnabledError}; opt in with
+ * `attestationStrategy: withAttestation()` in createNoydb. @internal
+ */
+export const NO_ATTESTATION: AttestationStrategy = {
+  async issueAttestation() { throw new AttestationNotEnabledError() },
+  async getDocumentSigningPublicKey() { throw new AttestationNotEnabledError() },
+  async revokeAttestation() { throw new AttestationNotEnabledError() },
+  async unrevokeAttestation() { throw new AttestationNotEnabledError() },
+  async getRevokedDocIds() { throw new AttestationNotEnabledError() },
+  async publishRevocationList() { throw new AttestationNotEnabledError() },
+}

--- a/packages/hub/src/with-audit/attestation/vault-facade.ts
+++ b/packages/hub/src/with-audit/attestation/vault-facade.ts
@@ -18,6 +18,8 @@ import type { NoydbStore } from '../../kernel/types.js'
 import type { AttestationFieldSchema, RevocationList } from '@noy-db/attestation'
 import type { IssueContext } from './issue.js'
 import type { RevokeContext } from './revoke.js'
+import type { AttestationStrategy } from './strategy.js'
+export { NO_ATTESTATION, type AttestationStrategy } from './strategy.js'
 
 /** Everything the moving attestation methods touched on the vault's `this.*`. */
 export interface VaultAttestationDeps {
@@ -41,7 +43,17 @@ export class VaultAttestation {
    */
   private readonly registry = new Map<string, AttestationFieldSchema>()
 
-  constructor(private readonly deps: VaultAttestationDeps) {}
+  constructor(
+    private readonly deps: VaultAttestationDeps,
+    /**
+     * Opt-in capability gate. `NO_ATTESTATION` when
+     * `createNoydb({ attestationStrategy })` was omitted — every issue/revoke/
+     * signer call then throws `AttestationNotEnabledError`. The facade always
+     * exists (it holds the per-collection field-schema registry populated at
+     * `collection()` time); only the capability methods are gated.
+     */
+    private readonly strategy: AttestationStrategy,
+  ) {}
 
   /** Register a collection's attestation field-schema (from `vault.collection`). */
   register(collection: string, schema: AttestationFieldSchema): void {
@@ -53,24 +65,17 @@ export class VaultAttestation {
     if (!fieldSchema) {
       throw new AttestationError(`issueAttestation: collection '${collectionName}' has no attestation field-schema. Declare it via vault.collection('${collectionName}', { attestation: { fields: [...] } }).`)
     }
-    const { issueAttestationCore } = await import('./issue.js')
-    const out = await issueAttestationCore(this.makeIssueContext(), { collection: collectionName, id, fieldSchema })
+    const out = await this.strategy.issueAttestation(this.makeIssueContext(), { collection: collectionName, id, fieldSchema })
     return { docId: out.docId, qr: out.qr, keyId: out.keyId, publicKeyB64: out.publicKeyB64 }
   }
 
   async getDocumentSigningPublicKey(): Promise<{ keyId: string; publicKeyB64: string }> {
-    const { loadSigner, loadOrCreateSigner } = await import('./signer.js')
-    // Reading an existing public key is open to any role that holds the
-    // _attestations DEK — the public key is not secret. But MINTING the
-    // signer is the firm's identity operation (same rule as issueAttestation):
-    // a non-owner read must not silently create it.
-    const existing = await loadSigner(this.deps.adapter, this.deps.vault, this.deps.getDEK)
-    if (existing) return { keyId: existing.keyId, publicKeyB64: existing.publicKeyB64 }
-    if (this.deps.role() !== 'owner') {
-      throw new AttestationError(`getDocumentSigningPublicKey: no document-signing key exists yet; only the 'owner' may mint it. Caller is '${this.deps.role()}'. Have the owner issue an attestation (or call this) first.`)
-    }
-    const signer = await loadOrCreateSigner(this.deps.adapter, this.deps.vault, this.deps.getDEK)
-    return { keyId: signer.keyId, publicKeyB64: signer.publicKeyB64 }
+    return this.strategy.getDocumentSigningPublicKey({
+      adapter: this.deps.adapter,
+      vault: this.deps.vault,
+      role: this.deps.role(),
+      getDEK: this.deps.getDEK,
+    })
   }
 
   private makeIssueContext(): IssueContext {
@@ -91,23 +96,19 @@ export class VaultAttestation {
   }
 
   async revoke(docId: string): Promise<void> {
-    const { revokeDocCore } = await import('./revoke.js')
-    await revokeDocCore(this.makeRevokeContext(), docId)
+    await this.strategy.revokeAttestation(this.makeRevokeContext(), docId)
   }
 
   async unrevoke(docId: string): Promise<void> {
-    const { unrevokeDocCore } = await import('./revoke.js')
-    await unrevokeDocCore(this.makeRevokeContext(), docId)
+    await this.strategy.unrevokeAttestation(this.makeRevokeContext(), docId)
   }
 
   async getRevokedDocIds(): Promise<string[]> {
-    const { getRevokedDocIdsCore } = await import('./revoke.js')
-    return getRevokedDocIdsCore(this.makeRevokeContext())
+    return this.strategy.getRevokedDocIds(this.makeRevokeContext())
   }
 
   async publishRevocationList(): Promise<RevocationList> {
-    const { publishRevocationListCore } = await import('./revoke.js')
-    return publishRevocationListCore(this.makeRevokeContext())
+    return this.strategy.publishRevocationList(this.makeRevokeContext())
   }
 
   private makeRevokeContext(): RevokeContext {

--- a/packages/in-pinia/__tests__/defineNoydbStore.test.ts
+++ b/packages/in-pinia/__tests__/defineNoydbStore.test.ts
@@ -3,6 +3,7 @@ import { setActivePinia, createPinia, storeToRefs } from 'pinia'
 import { effectScope, ref } from 'vue'
 import { createNoydb, additiveOnly, i18nText, type Noydb, type NoydbStore, type EncryptedEnvelope, type VaultSnapshot, type StandardSchemaV1, ConflictError, Query } from '@noy-db/hub'
 import { withI18n } from '@noy-db/hub/i18n'
+import { withAttestation } from '@noy-db/hub/attestation'
 import { defineNoydbStore, setActiveNoydb, useNoydbI18n } from '../src/index.js'
 
 const tick = (ms = 0): Promise<void> => new Promise((r) => setTimeout(r, ms))
@@ -69,6 +70,7 @@ async function makeNoydb(): Promise<Noydb> {
     store: memory(),
     user: 'owner',
     secret: 'pinia-test-passphrase-2026',
+    attestationStrategy: withAttestation(),
   })
 }
 

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -610,7 +610,13 @@ const KERNEL_SURFACE_BUDGET = {
   // Lowered 4559→4410 (Phase 5 A3: periods extraction): the close/open/list/get methods + `_assertTsWritable` guard + `_loadPeriodsCache`/`_writePeriodRecord`/`_decryptPeriodRecord` helpers + the `periodCache` field moved to `with-audit/periods/vault-facade.ts` (`VaultPeriods`); vault.ts holds a facade instance + thin delegators (`_assertTsWritable` still the gate-bus entry point).
   // Lowered 4410→4135 (Phase 5 A4: backup extraction): `dump`/`load`/`verifyBackupIntegrity`/`exportJSON` (incl. the blob-collection enumeration in dump() and the branchy chain+data-envelope integrity walk) moved to `vault-backup.ts`; vault.ts holds thin delegators + a `backupContext()` builder exposing the read paths and the post-load mutation seams (reloadKeyring/cache-clear/ledger-reset).
   // Lowered 4135→3824 (Phase 5 A5: refs/links enforcement extraction): `enforceRefsOnPut`/`enforceRefsOnDelete`/`enforceLinksOnDelete`/`resolveRef`/`resolveSource`/`checkIntegrity` bodies + the `cascadeInProgress` cycle-breaker set moved to `with-shape/links/vault-facade.ts` (`VaultLinks`); vault.ts holds a facade instance + thin delegators (the `refEnforcer`/`joinResolver` ctor seam is unchanged — Collection still passes `this`). The ref/link registries stay vault-resident (populated by collection()/link(), read by the backup path) and arrive by reference.
-  'packages/hub/src/kernel/vault.ts': 3825,
+  // Bumped 3824→3825 then 3825→3826 (S4 Task 1: gate attestation behind withAttestation()):
+  // vault.ts threads the opt-in `attestationStrategy` — a single option-type field on the
+  // Vault ctor + a `?? NO_ATTESTATION` fallback into the always-built VaultAttestation facade
+  // (imported off the existing vault-facade re-export, so no new import line). The issue/revoke/
+  // signer engines stay in the lazy `with-audit/attestation/active.ts` chunk; only the strategy
+  // seam is here.
+  'packages/hub/src/kernel/vault.ts': 3827,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),
@@ -656,7 +662,11 @@ const KERNEL_SURFACE_BUDGET = {
   // path (`getKeyringInternal`), policy gate (`checkGate`), managed-recovery enrolment check
   // (`assertRecoveryEnrolled`), `openVault`, and the one-shot managed-recovery skip flag stay
   // kernel-resident and arrive as callbacks.
-  'packages/hub/src/kernel/noydb.ts': 2275,
+  // Bumped 2275→2276 (S4 Task 1: gate attestation behind withAttestation()): thread the opt-in
+  // `attestationStrategy` from createNoydb options into the two Vault-construction option spreads
+  // (async openVault + sync vault()). Public opt-in API surface; the engine lives in the lazy
+  // `with-audit/attestation/active.ts` chunk.
+  'packages/hub/src/kernel/noydb.ts': 2277,
 }
 
 function checkKernelSurface() {


### PR DESCRIPTION
## S4 — service-layer withX(): design + plan + the withAttestation exemplar

Landing the **design, plan, and first gate** together so the capability-gate pattern can be reviewed before it's replicated across 9 more services.

### Design (`specs/…-service-layer-withx-design.md`)
Services fall into 3 archetypes; two opt-in seams matched to them:
- **Seam A** — `withX()` → `createNoydb({ …Strategy: withX() })` for ① pipeline strategies (unchanged) **and ② on-demand capabilities** (as gates: `withX()` enables the methods + dynamic-imports the impl; omit → `XNotEnabledError` + tree-shaken).
- **Seam B** — ③ schema features stay schema-declared, no `withX()`, exempt from the audit.
- **② hard opt-in** is a pre-1.0 breaking change (accepted, for tree-shakeability + consistency with the `strategy-opt-in` rule ① already follows).

### Plan (`plans/…-service-layer-withx.md`)
13 tasks: the gate recipe + this exemplar, the 9-service rollout (table), `strategy-opt-in` enforcement, ③ docs, ① consistency.

### Exemplar — `withAttestation()` (Task 1)
The 5-part gate: `strategy.ts` (`NO_ATTESTATION` throws `AttestationNotEnabledError` for the 6 capability methods) · `active.ts` (`withAttestation()`, engine via `await import`) · the error class · the `attestationStrategy` option · vault wiring.

**Validated pattern** (baked into the recipe): the facade is *always* built and the **strategy is swapped** (not "facade only when opted in") — because per-vault facades hold state (attestation's field-schema registry) that must survive un-opted-in `collection({attestation})`. `register()` stays ungated; only the invoked capability methods gate.

- `issueAttestation()` etc. **without** `withAttestation()` → throws `AttestationNotEnabledError` (names the factory to add).
- **with** `attestationStrategy: withAttestation()` → works. Existing attestation test setups (+ one in-pinia sibling) updated to opt in.

### Gates
typecheck · lint · check-architecture ✓ · build ✓ · **test 2977** (2974 + 3 new gate tests). Kernel-surface ratchet +1 each on vault.ts/noydb.ts (one wiring line, justified).

Next PRs: Tasks 2–10 (the 9 remaining ② gates), then enforcement + ③ docs + ① pass.
