### PR TITLE
feat(hub): S4 finish — enforce strategy-opt-in + ③ docs + ① consistency

### DIFF
--- a/docs/subsystems/README.md
+++ b/docs/subsystems/README.md
@@ -68,6 +68,32 @@ See [SUBSYSTEMS.md](../../SUBSYSTEMS.md) for the catalog overview, dependency gr
 |---|---|
 | [routing](./routing.md) | Multi-store routing, middleware, sync-policy, lazy-mode + LRU cache |
 
+## Schema-declared features (archetype ③) — no `with*()`
+
+These are **not** opt-in `with*()` subsystems and so have no factory and no
+`<name>Strategy` option. They are **declared on the collection itself** via
+`collection({ … })` — the collection is their opt-in unit. There is nothing to
+pass to `createNoydb`; a collection that doesn't declare the field simply
+doesn't get the behavior. `check-architecture`'s `strategy-opt-in` check exempts
+each of these (see `SCHEMA_DECLARED_OR_INFRA_EXEMPT`).
+
+| Feature | Declared as | What it adds |
+|---|---|---|
+| computed | `collection({ computed: { … } })` | Per-record derived fields evaluated on read |
+| money | `collection({ money: { … } })` | Fixed-point money field descriptors (quantize-on-write / decode-on-read) |
+| links | `collection({ links: { … } })` (`link()` refs) | Typed cross-collection references + backlinks |
+| introspection | always available on any typed collection | `collection.describe()` / `vault.dumpSchema()` read-only schema surface |
+| schema-update | `collection({ schemaUpdate: … })` | Per-collection migration strategies (blind / additive / locked / coordinated) |
+
+> **Follow-up (out of scope here):** unlike the `with*()` subsystems, these ③
+> impls are currently **kernel-resident — eagerly imported into the floor** as
+> inline write/read-path hooks (e.g. `with-shape/money/normalize`,
+> `with-formula/computed`, `with-shape/links`, `with-shape/schema-update`,
+> `with-shape/introspection/walk`). They are *not* lazy-imported from the schema
+> declaration today, so they are not tree-shaken out when unused. Moving the
+> heavy paths behind a schema-triggered `await import(...)` is tracked as a
+> follow-up; it does not change the schema-declared opt-in model above.
+
 ## Doc page template
 
 Every entry follows the same shape — see [_template.md](./_template.md). If you're adding a new subsystem, copy the template and fill it out top-to-bottom.

--- a/packages/hub/src/with-audit/forget/active.ts
+++ b/packages/hub/src/with-audit/forget/active.ts
@@ -1,0 +1,34 @@
+/**
+ * `withForgetCascade` — the active factory for GDPR right-to-erasure via
+ * per-record CEK crypto-shred (#304). Mirrors the canonical
+ * `strategy.ts` (type + `NO_FORGET` sentinel) / `active.ts` (factory) split
+ * used by the other subsystems.
+ *
+ * @module
+ */
+import type { SubjectDeclaration, ForgetStrategy } from './strategy.js'
+
+/**
+ * Declare GDPR crypto-shred for one or more collections.
+ *
+ * Each declared collection is forced to `perRecordKeys: true` (a shred can
+ * only guarantee erasure of a record whose body is keyed off a per-record
+ * CEK). On write, Noydb extracts `record[subjectField]` and maintains an
+ * encrypted `_subject_index` mapping `subject → [{collection, id}]`, so
+ * `vault.forget(subjectId)` can find every record for a subject and rewrite
+ * each to a tombstone (body + history permanently undecryptable) while the
+ * collection DEK and every other record stay intact.
+ *
+ * @example
+ * ```ts
+ * createNoydb({
+ *   secret, user,
+ *   forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
+ * })
+ * const result = await vault.forget('buyer-123')
+ * // → { subject, recordsShredded, historyVersionsShredded, collections, … }
+ * ```
+ */
+export function withForgetCascade(opts: SubjectDeclaration): ForgetStrategy {
+  return { subjects: { ...opts.subjects } }
+}

--- a/packages/hub/src/with-audit/forget/index.ts
+++ b/packages/hub/src/with-audit/forget/index.ts
@@ -21,10 +21,8 @@
  *
  * @module
  */
-export {
-  withForgetCascade,
-  NO_FORGET,
-} from './strategy.js'
+export { withForgetCascade } from './active.js'
+export { NO_FORGET } from './strategy.js'
 export type {
   SubjectDeclaration,
   ForgetStrategy,

--- a/packages/hub/src/with-audit/forget/strategy.ts
+++ b/packages/hub/src/with-audit/forget/strategy.ts
@@ -49,30 +49,9 @@ export interface ForgetStrategy {
  */
 export const NO_FORGET: ForgetStrategy = { subjects: {} }
 
-/**
- * Declare GDPR crypto-shred for one or more collections.
- *
- * Each declared collection is forced to `perRecordKeys: true` (a shred can
- * only guarantee erasure of a record whose body is keyed off a per-record
- * CEK). On write, Noydb extracts `record[subjectField]` and maintains an
- * encrypted `_subject_index` mapping `subject → [{collection, id}]`, so
- * `vault.forget(subjectId)` can find every record for a subject and rewrite
- * each to a tombstone (body + history permanently undecryptable) while the
- * collection DEK and every other record stay intact.
- *
- * @example
- * ```ts
- * createNoydb({
- *   secret, user,
- *   forgetStrategy: withForgetCascade({ subjects: { invoices: 'buyerId' } }),
- * })
- * const result = await vault.forget('buyer-123')
- * // → { subject, recordsShredded, historyVersionsShredded, collections, … }
- * ```
- */
-export function withForgetCascade(opts: SubjectDeclaration): ForgetStrategy {
-  return { subjects: { ...opts.subjects } }
-}
+// The `withForgetCascade` factory lives in `active.ts` (canonical
+// strategy.ts/active.ts/index.ts split); this file holds only the
+// declaration shape + disabled sentinel.
 
 /**
  * The outcome of a `vault.forget(subjectId)` call.

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -390,6 +390,108 @@ function scanFileForStrategyOptIn(file, content) {
   }
 }
 
+// ─── Check 5b: every service ships a withX() gate ──────────────────────
+//
+// The STRUCTURAL companion to the per-file scan above. That scan checks
+// that a consumer references `withX()`; this one guarantees the withX()
+// actually exists — i.e. every archetype-①/② service folder under
+// packages/hub/src/with-*/ ships an opt-in gate. Without it a service
+// could quietly go always-on (no factory at all) and the per-file scan
+// would never fire because there'd be nothing to look for.
+//
+// Rule: every `with-<dim>/<service>/` sub-folder — and every `with-<dim>`
+// dim that has NO sub-folders (the dim IS the service, e.g. with-cargo) —
+// must export a `with*()` factory, UNLESS it is on the exempt list below.
+//
+// Exemptions (verified 2026-07-02) fall in three buckets:
+//   ③ schema features — declared on `collection({ … })`, not a global
+//     strategy; the collection IS the opt-in unit, impl lazy-imported
+//     from the schema declaration (see docs/subsystems/<x>.md):
+//       with-formula/computed          computed({…}) field evaluator
+//       with-shape/introspection       describe()/dumpVaultSchema — read-only schema surface
+//       with-shape/links               link()/backlink schema refs
+//       with-shape/money               money() field descriptor
+//       with-shape/persisted-schemas   schema-persistence infra behind collection()
+//       with-shape/schema-update       per-collection migration strategies
+//   always-on infra — no discrete capability to gate:
+//       with-party/directory           user directory; defaults ON, called unconditionally in core keyring flows
+//       with-pod                       writeNoydbBundle/vault.dump — internal backup primitive used by snapshots/portability/cargo/backup
+//   sub-parts of an already-gated service (covered by another withX):
+//       with-lookup/embeddings         vector compute folded into withSearch()
+//       with-party/sync                sync impl behind team's withSync()
+//       with-party/auth-introspection  read-only describe/diagram surface (no instance to gate)
+//
+// NOTE — the ungated host-side free-function carve-outs (openSealedRecord,
+// adoptPartition, decryptExtractedPartition, liberateVault, diffVault) take
+// raw bytes / are shared import-merge infra with no live vault instance to
+// gate, so they intentionally have no withX(). They aren't their own
+// with-* service folder, so this scan never sees them — noted here for the
+// reader who wonders why they're absent from the list.
+const SCHEMA_DECLARED_OR_INFRA_EXEMPT = new Set([
+  'with-formula/computed',
+  'with-shape/introspection',
+  'with-shape/links',
+  'with-shape/money',
+  'with-shape/persisted-schemas',
+  'with-shape/schema-update',
+  'with-party/directory',
+  'with-pod',
+  'with-lookup/embeddings',
+  'with-party/sync',
+  'with-party/auth-introspection',
+])
+
+// Does any .ts file in `dir` (recursively) export a `with*()` factory —
+// as a function/const declaration or a re-export? `with[A-Z]` requires the
+// lowercase-`with` factory spelling, so it won't match a `WithXOptions`
+// type. Recursion is intentional: a service's factory may live in an
+// `active.ts` or a nested helper (e.g. with-commit/history/ledger).
+function exportsWithFactory(dir) {
+  let found = false
+  walkTsFiles(dir, (_file, content) => {
+    if (found) return
+    const code = stripComments(content)
+    if (
+      /export\s+(?:async\s+)?function\s+with[A-Z]\w*/.test(code) ||
+      /export\s+const\s+with[A-Z]\w*\s*[:=]/.test(code) ||
+      /export\s*(?:type\s*)?\{[^}]*\bwith[A-Z]\w*\b[^}]*\}/.test(code)
+    ) {
+      found = true
+    }
+  })
+  return found
+}
+
+function requireServiceGate(id, dir) {
+  if (SCHEMA_DECLARED_OR_INFRA_EXEMPT.has(id)) return
+  if (exportsWithFactory(dir)) return
+  fail(
+    'strategy-opt-in',
+    `service '${id}' exports no with*() factory. Every archetype-①/② service must ship a withX() opt-in gate (see the recipe in with-fork/snapshots). If it is genuinely a ③ schema feature or always-on infra, add it to SCHEMA_DECLARED_OR_INFRA_EXEMPT with a one-line reason.`,
+    dir,
+  )
+}
+
+function checkEveryServiceGated() {
+  const hubSrc = join(PACKAGES_DIR, 'hub', 'src')
+  const dims = readdirSync(hubSrc, { withFileTypes: true })
+    .filter(e => e.isDirectory() && e.name.startsWith('with-'))
+  for (const dim of dims) {
+    const dimPath = join(hubSrc, dim.name)
+    const subFolders = readdirSync(dimPath, { withFileTypes: true })
+      .filter(e => e.isDirectory() && e.name !== 'node_modules' && e.name !== 'dist')
+    if (subFolders.length === 0) {
+      // The dim itself is the service (e.g. with-cargo, with-pod).
+      requireServiceGate(dim.name, dimPath)
+    } else {
+      // A namespace dim — each leaf sub-folder is a service.
+      for (const sub of subFolders) {
+        requireServiceGate(`${dim.name}/${sub.name}`, join(dimPath, sub.name))
+      }
+    }
+  }
+}
+
 // ─── Check 6: kernel-surface ceiling ───────────────────────────────────
 
 // The always-on orchestration files (loaded by every `createNoydb`) must not
@@ -819,6 +921,7 @@ checkNoCryptoDeps()
 checkHubPortable()
 checkStoresCiphertextOnly()
 checkStrategyOptIns()
+checkEveryServiceGated()
 checkKernelSurface()
 checkNoDebugPlaintextInSource()
 checkNoOutboundKlumImport()


### PR DESCRIPTION
## S4 finish — enforce opt-in + document ③ + ① consistency (Tasks 11–13)

Completes the service-layer `withX()` work.

### Task 11 — `strategy-opt-in` now requires `withX()` per service
`check-architecture.mjs` recurses every `with-<dim>/<service>/` folder (and no-subfolder dims like `with-cargo`) and requires a `with*()` export, unless exempt. **Verified it fires** (dropping `directory` → violation; restored → PASS). The `SCHEMA_DECLARED_OR_INFRA_EXEMPT` list (11, each verified):
- **③ schema:** `computed`, `introspection`, `links`, `money`, `persisted-schemas`, `schema-update`
- **always-on infra:** `directory`, `with-pod`
- **sub-parts of a gated service:** `embeddings` (→ `withSearch`), `sync` (→ team's `withSync`), `auth-introspection` (read-only introspection)

Ungated host-side free-function carve-outs documented in a comment: `openSealedRecord`, `adoptPartition`, `decryptExtractedPartition`, `liberateVault`, `diffVault`.

### Task 12 — ③ documented as schema-declared
The schema features are declared on `collection({…})`, no `withX()`. **Honest caveat recorded:** they are currently **eagerly kernel-resident, not lazy-imported**, so they don't tree-shake when unused — tracked as a follow-up rather than claimed as done.

### Task 13 — ① consistency (light)
Normalized `forget` to the `strategy.ts`/`active.ts`/`index.ts` split. **Skipped** `guards`/`numbering`/`archive`/`derivations`/`materialized-views`/`overlay-views`/`team` — they use a `strategies:[…]` handle-array (no `NO_X` sentinel to house), so reshaping is churn for no gain.

### Gates
`turbo typecheck` 98/98 · `turbo lint` 95/95 · **`turbo test` 113/113 green (hub 2993)** · check-architecture ✓ · build ✓.

**This completes S4** — the service layer has one honest opt-in story (`withX()` for ①②, schema-declaration for ③) and a mechanically-enforced "every service is opt-in" invariant.
