### PR TITLE
refactor(hub): vault backup implementation to with-pod

### DIFF
--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -9,14 +9,6 @@ import type {
   TierMode,
   Role,
 } from './types.js'
-import {
-  dumpVault,
-  loadVault,
-  verifyBackupIntegrity,
-  exportVaultJSON,
-  type BackupContext,
-  type VerifyBackupResult,
-} from './vault-backup.js'
 import type { Noydb } from './noydb.js'
 import type { IssueDelegationOptions, DelegationToken } from '../with-party/team/delegation.js'
 import { NOYDB_FORMAT_VERSION } from './types.js'
@@ -3494,22 +3486,23 @@ export class Vault {
    * both modes round-trip cleanly.
    */
   async dump(): Promise<string> {
+    const { dumpVault } = await import('../with-pod/backup.js')
     return dumpVault(this.backupContext())
   }
 
   /**
-   * Build the {@link BackupContext} the extracted backup module (`vault-backup.ts`)
+   * Build the `BackupContext` the extracted backup module (`with-pod/backup.ts`)
    * binds to: the read paths + the post-load mutation seams (`reloadKeyring`,
    * collection-cache clear, ledger-store reset) that `load()` performs on this
    * Vault's private state.
    */
-  private backupContext(): BackupContext {
+  private backupContext() {
     return {
       adapter: this.adapter,
       vault: this.name,
       userId: () => this.keyring.userId,
       getLedgerOrNull: () => this.getLedgerOrNull(),
-      envelopePayloadHash: (envelope) => this.historyStrategy.envelopePayloadHash(envelope),
+      envelopePayloadHash: (envelope: EncryptedEnvelope) => this.historyStrategy.envelopePayloadHash(envelope),
       reloadKeyringAndRebuildDEK: async () => {
         if (this.reloadKeyring) {
           this.keyring = await this.reloadKeyring()
@@ -3521,7 +3514,7 @@ export class Vault {
       },
       clearCollectionCache: () => this.collectionCache.clear(),
       resetLedgerStore: () => { this.ledgerStore = null },
-      exportStream: (opts) => this.exportStream(opts),
+      exportStream: (opts: ExportStreamOptions) => this.exportStream(opts),
     }
   }
 
@@ -3548,6 +3541,7 @@ export class Vault {
    * — there's no chain to verify against.
    */
   async load(backupJson: string): Promise<void> {
+    const { loadVault } = await import('../with-pod/backup.js')
     return loadVault(this.backupContext(), backupJson)
   }
 
@@ -3579,7 +3573,8 @@ export class Vault {
    * during `load()`. A scheduled background check is the simplest
    * way to detect tampering of an in-place vault.
    */
-  async verifyBackupIntegrity(): Promise<VerifyBackupResult> {
+  async verifyBackupIntegrity() {
+    const { verifyBackupIntegrity } = await import('../with-pod/backup.js')
     return verifyBackupIntegrity(this.backupContext())
   }
 
@@ -3845,6 +3840,7 @@ export class Vault {
    * is the live validator object, not a serialization of it).
    */
   async exportJSON(opts: ExportStreamOptions = {}): Promise<string> {
+    const { exportVaultJSON } = await import('../with-pod/backup.js')
     return exportVaultJSON(this.backupContext(), opts)
   }
 }

--- a/packages/hub/src/with-pod/backup.ts
+++ b/packages/hub/src/with-pod/backup.ts
@@ -12,8 +12,8 @@
  *
  * Internal — reached through `vault.dump()` / `vault.load()` / etc.
  */
-import { NOYDB_BACKUP_VERSION } from './types.js'
-import { BackupLedgerError, BackupCorruptedError } from './errors.js'
+import { NOYDB_BACKUP_VERSION } from '../kernel/types.js'
+import { BackupLedgerError, BackupCorruptedError } from '../kernel/errors.js'
 import { LEDGER_COLLECTION, LEDGER_DELTAS_COLLECTION } from '../with-commit/history/ledger/constants.js'
 import { SCHEMAS_COLLECTION } from '../with-shape/persisted-schemas/storage.js'
 import { SEQUENCE_COLLECTION } from '../with-commit/sequence/index.js'
@@ -24,7 +24,7 @@ import type {
   VaultSnapshot,
   ExportStreamOptions,
   ExportChunk,
-} from './types.js'
+} from '../kernel/types.js'
 import type { LedgerStore } from '../with-commit/history/ledger/store.js'
 
 /** Everything the moving backup methods touched on the vault's `this.*`. */

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -1112,12 +1112,6 @@ const PRE_EXISTING_SPINE_SERVICE_IMPORTS = new Map([
     '../with-shape/money/descriptor.js',
     '../port/by/types.js',
   ]],
-  ['packages/hub/src/kernel/vault-backup.ts', [
-    '../with-commit/history/ledger/constants.js',
-    '../with-commit/history/ledger/store.js',
-    '../with-commit/sequence/index.js',
-    '../with-shape/persisted-schemas/storage.js',
-  ]],
   ['packages/hub/src/kernel/vault.ts', [
     '../with-audit/attestation/vault-facade.js',
     '../with-audit/consent/consent.js',


### PR DESCRIPTION
Rank-2 kernel extraction (from the 2026-07-02 kernel review; queue after this: user-envelope rank 3, policy rank 5).

- `kernel/vault-backup.ts` (398 LOC) → `with-pod/backup.ts` — a backup is a vault serialized and saved, i.e. pod territory. Content-identical apart from three import-specifier lines.
- The `Vault` facade methods (`dump`, `load`, `verifyBackupIntegrity`, `exportJSON`) stay in the spine and reach the implementation via dynamic `await import()` — the sanctioned spine→service mechanism; **no grandfather-allowlist addition**. The `backupContext()` private-state accessor closure stays in vault.ts.
- Not gated behind a `withX()` — backup remains exempt always-on infra (directory/pod precedent).
- Type note: the spine can't `import type` from with-pod (port-layering) and inline `import()` type queries violate the ESLint rule, so two return-type annotations were dropped in favor of structural inference; emitted DTS verified identical (`verifyBackupIntegrity(): Promise<VerifyBackupResult>` unchanged).

Review verified: no throw-before-await ordering change in any facade method, zero static kernel→with-pod imports, goldens byte-identical to main, vault.ts at 3846/3855.

Validation: build 53/53 · cross-package test 113/113 · check:architecture · typecheck 98/98 · lint 95/95; backup suites 20/20.