### PR TITLE
release: 0.3.0-pre.2 — describe() group/order metadata + _history in pods

### DIFF
--- a/packages/as-aws-s3/CHANGELOG.md
+++ b/packages/as-aws-s3/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/as-aws-s3
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/as-aws-s3/package.json
+++ b/packages/as-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-aws-s3",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "AWS S3 object projection for noy-db — serve blob bytes directly from S3/CDN (presigned or public), outside the encrypted store",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-blob/CHANGELOG.md
+++ b/packages/as-blob/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/as-blob
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/as-blob/package.json
+++ b/packages/as-blob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-blob",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Single-attachment plaintext export for noy-db — extracts one blob from BlobSet as native MIME bytes. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier, document sub-family).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-csv/CHANGELOG.md
+++ b/packages/as-csv/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/as-csv
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/as-csv/package.json
+++ b/packages/as-csv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-csv",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "CSV plaintext export for noy-db — decrypts records and formats as comma-separated values. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-json/CHANGELOG.md
+++ b/packages/as-json/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/as-json
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/as-json/package.json
+++ b/packages/as-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-json",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Structured JSON plaintext export for noy-db — decrypts records and emits one JSON document per vault. Gated by RFC #249 canExportPlaintext capability; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-ndjson/CHANGELOG.md
+++ b/packages/as-ndjson/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/as-ndjson
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/as-ndjson/package.json
+++ b/packages/as-ndjson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-ndjson",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Newline-delimited JSON export for noy-db — streaming plaintext export suitable for data pipelines, warehouse ingestion, and jq pipelines. Gated by RFC #249 canExportPlaintext. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-noydb/CHANGELOG.md
+++ b/packages/as-noydb/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/as-noydb
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/as-noydb/package.json
+++ b/packages/as-noydb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-noydb",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Encrypted .noydb bundle export for noy-db — wraps writeNoydbBundle() with the RFC #249 canExportBundle authorization gate and ergonomic browser/node helpers. Sole member of the @noy-db/as-* encrypted tier — ciphertext in, ciphertext out.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-sql/CHANGELOG.md
+++ b/packages/as-sql/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/as-sql
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/as-sql/package.json
+++ b/packages/as-sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-sql",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "SQL dump export for noy-db — decrypts records and emits dialect-aware CREATE TABLE + INSERT statements for postgres / mysql / sqlite. One-way migration helper. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xlsx/CHANGELOG.md
+++ b/packages/as-xlsx/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @noy-db/as-xlsx
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+  - @noy-db/as-zip@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/as-xlsx/package.json
+++ b/packages/as-xlsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xlsx",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Excel spreadsheet plaintext export for noy-db — produces a real .xlsx (Office Open XML) from one or more collections. Multi-sheet, Unicode-safe via shared-strings table. Zero runtime deps beyond the workspace zip encoder. Gated by RFC #249 `canExportPlaintext` with format `'xlsx'`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xml/CHANGELOG.md
+++ b/packages/as-xml/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/as-xml
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/as-xml/package.json
+++ b/packages/as-xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xml",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "XML plaintext export for noy-db — decrypts records and formats as XML with RFC-compliant entity escaping. For legacy systems, banking batch imports, SOAP endpoints, and accounting software that requires XML. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-zip/CHANGELOG.md
+++ b/packages/as-zip/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/as-zip
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/as-zip/package.json
+++ b/packages/as-zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-zip",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Composite record + blob archive export for noy-db — bundles a collection's records plus every attached blob into one zip. Zero dependencies (STORE-only zip encoder). Gated by the RFC #249 `canExportPlaintext` capability bit with format `'zip'`. Part of the @noy-db/as-* portable-artefact family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-aws-kms/CHANGELOG.md
+++ b/packages/at-aws-kms/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — at-aws-kms
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/at-aws-kms/package.json
+++ b/packages/at-aws-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-aws-kms",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "AWS KMS sealing key provider for noy-db managed-passphrase mode — seal/unseal via KMS Encrypt/Decrypt, with KMS access logs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-azure-keyvault/CHANGELOG.md
+++ b/packages/at-azure-keyvault/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — at-azure-keyvault
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/at-azure-keyvault/package.json
+++ b/packages/at-azure-keyvault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-azure-keyvault",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Azure Key Vault sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-env/CHANGELOG.md
+++ b/packages/at-env/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — at-env
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/at-env/package.json
+++ b/packages/at-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-env",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Env-var sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a key from process.env. Smallest production-shape provider; pair with Kubernetes Secrets / Heroku env / AWS Secrets Manager.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-gcp-kms/CHANGELOG.md
+++ b/packages/at-gcp-kms/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — at-gcp-kms
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/at-gcp-kms/package.json
+++ b/packages/at-gcp-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-gcp-kms",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Google Cloud KMS sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-macos-keychain/CHANGELOG.md
+++ b/packages/at-macos-keychain/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — at-macos-keychain
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/at-macos-keychain/package.json
+++ b/packages/at-macos-keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-macos-keychain",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "macOS Keychain sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a 32-byte key stored in the user's login Keychain. Desktop-app provider in the at-* family; pairs with Touch ID via Keychain Access UI.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/attestation/CHANGELOG.md
+++ b/packages/attestation/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @noy-db/attestation
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/attestation/package.json
+++ b/packages/attestation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/attestation",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Pure, zero-dependency document-attestation primitive for noy-db — per-field salted commitments, Ed25519 sign/verify, QR credential codec, and revocation checks. Runs in Node and the browser; the offline verifier imports only this.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-peer/CHANGELOG.md
+++ b/packages/by-peer/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — by-peer
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/by-peer/package.json
+++ b/packages/by-peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-peer",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "WebRTC peer-to-peer transport for noy-db — direct browser-to-browser channel with signaling-agnostic handshake",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-tabs/CHANGELOG.md
+++ b/packages/by-tabs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @noy-db/by-tabs
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+  - @noy-db/by-peer@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/by-tabs/package.json
+++ b/packages/by-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-tabs",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "BroadcastChannel multi-tab transport for noy-db — sync between tabs of the same browser without round-tripping the storage backend",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @noy-db/cli
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+  - @noy-db/to-meter@0.3.0-pre.2
+  - @noy-db/to-probe@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/cli",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Command-line tool for noy-db — inspect .noydb bundles without decrypting, verify integrity, validate config objects, scaffold topology profiles, and monitor a live vault's store metrics.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/create-noy-db/CHANGELOG.md
+++ b/packages/create-noy-db/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — create-noy-db
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+  - @noy-db/to-file@0.3.0-pre.2
+  - @noy-db/to-memory@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/create-noy-db/package.json
+++ b/packages/create-noy-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-noy-db",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Wizard + CLI tool for noy-db: scaffold a fresh Nuxt 4 + Pinia encrypted store, or add collections to an existing project. Invoke via `npm create @noy-db`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/hub/CHANGELOG.md
+++ b/packages/hub/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — hub
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- describe()-driven layout metadata + history-complete pods (the Item release foundation).
+
+  - **`FieldMeta.group` / `FieldMeta.order`**: card/section grouping and ordering hints flow through `collection.describe()` onto each `DescribedField` (channel > zod `.meta()` > inferred, like every other meta key). Purely descriptive — fields keep their stable alphabetical emission; consumers (the `@noy-db/ui` item family) apply the grouping.
+  - **`_history` travels in the `.noydb` pod**: `vault.dump()` now enumerates the full-snapshot version-history collection alongside the ledger/schema/sequence/blob internals, so `collection.history()`, `getVersion()` and `diff()` work on a pod-restored vault. Load-side already restored `_internal` generically.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/attestation@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/hub/__tests__/bundle-history-roundtrip.test.ts
+++ b/packages/hub/__tests__/bundle-history-roundtrip.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Bundle-includes-history round-trip tests.
+ *
+ * Regression guard for the consumer gap where `vault.dump()` / the `.noydb`
+ * bundle excluded the `_history` collection: the ledger + deltas travelled,
+ * but the full-snapshot version history did not — so on a restored vault
+ * `collection.history()` / `getVersion()` / `diff()` saw none of the
+ * pre-bundle versions (the Item-family history panel rendered empty).
+ *
+ * The fix is dump-side only: `dump()` now enumerates `_history` alongside
+ * the ledger/schema/sequence/blob internals. `load()` already restores
+ * `backup._internal` generically.
+ *
+ * Setup mirrors bundle-blobs-roundtrip.test.ts (realistic store whose
+ * loadAll filters underscore collections) and verifiable-backup.test.ts
+ * (dump/load + history + fresh-vault restore).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { withHistory } from '../src/with-commit/history/index.js'
+import { ConflictError } from '../src/kernel/errors.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
+
+// Realistic in-memory store: `loadAll` filters out underscore-prefixed
+// (internal) collections, exactly like the real adapters — so dump()'s
+// explicit enumeration of `_history` is what makes it travel.
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) {
+        for (const [name, coll] of existing) {
+          if (name.startsWith('_')) comp.set(name, coll)
+        }
+      }
+      store.set(c, comp)
+    },
+  }
+}
+
+const SECRET = 'correct-horse-battery-staple-long-enough'
+
+interface Item { id: string; name: string; qty: number }
+
+describe('bundle includes history (dump → load round-trip)', () => {
+  it('history(), getVersion() and diff() survive dump → fresh-vault load', async () => {
+    const sourceDb = await createNoydb({
+      store: memory(), user: 'owner', secret: SECRET, historyStrategy: withHistory(),
+    })
+    const sourceVault = await sourceDb.openVault('demo-co')
+    const col = sourceVault.collection<Item>('items')
+    await col.put('i1', { id: 'i1', name: 'first', qty: 1 })
+    await col.put('i1', { id: 'i1', name: 'renamed', qty: 1 })
+    await col.put('i1', { id: 'i1', name: 'renamed', qty: 2 })
+    // history() archives PREVIOUS versions; the current (v3) lives in the collection
+    expect(await col.history('i1')).toHaveLength(2)
+
+    const backupJson = await sourceVault.dump()
+    // dump-side assertion: the _history collection travels in the bundle
+    expect(JSON.parse(backupJson)._internal?._history).toBeDefined()
+
+    const targetDb = await createNoydb({
+      store: memory(), user: 'owner', secret: SECRET, historyStrategy: withHistory(),
+    })
+    const targetVault = await targetDb.openVault('demo-co')
+    await targetVault.load(backupJson)
+    const col2 = targetVault.collection<Item>('items')
+
+    const entries = await col2.history('i1')
+    expect(entries).toHaveLength(2) // newest first: v2, v1
+    expect(entries[0]!.version).toBe(2)
+    expect(entries[0]!.record.name).toBe('renamed')
+    expect(entries[1]!.record.name).toBe('first')
+    expect((await col2.getVersion('i1', 1))!.name).toBe('first')
+    const changes = await col2.diff('i1', 1, 2)
+    expect(changes).toEqual([{ path: 'name', type: 'changed', from: 'first', to: 'renamed' }])
+    // versionB omitted → compare an archived version against the live current record
+    const vsCurrent = await col2.diff('i1', 2)
+    expect(vsCurrent).toEqual([{ path: 'qty', type: 'changed', from: 1, to: 2 }])
+  })
+})

--- a/packages/hub/__tests__/introspection/field-group-order.test.ts
+++ b/packages/hub/__tests__/introspection/field-group-order.test.ts
@@ -1,0 +1,110 @@
+/**
+ * FieldMeta group/order → DescribedField (Item Release, UI card grouping).
+ *
+ * group/order are descriptive layout hints: they surface on DescribedField
+ * (channel > zod .meta() > inferred precedence, like every other meta key)
+ * while the emitted fields array stays alphabetically sorted.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { createNoydb } from '../../src/kernel/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/kernel/types.js'
+import { ConflictError } from '../../src/kernel/errors.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c)
+      const s: VaultSnapshot = {}
+      if (comp) {
+        for (const [n, coll] of comp) {
+          if (!n.startsWith('_')) {
+            const r: Record<string, EncryptedEnvelope> = {}
+            for (const [id, e] of coll) r[id] = e
+            s[n] = r
+          }
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+describe('FieldMeta group/order flow through describe()', () => {
+  async function collectionWith(fieldMeta: Record<string, Record<string, unknown>>) {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-group-order' })
+    const v = await db.openVault('v')
+    return v.collection('invoices', {
+      schema: z.object({ id: z.string(), total: z.number(), issuedOn: z.string() }),
+      fieldMeta: fieldMeta as never,
+    })
+  }
+
+  it('channel fieldMeta group/order surface on DescribedField', async () => {
+    const col = await collectionWith({
+      total: { label: 'Total', group: 'Amounts', order: 2 },
+      issuedOn: { label: 'Issued', group: 'Dates', order: 1 },
+    })
+    const fields = col.describe().fields
+    const total = fields.find((f) => f.key === 'total')!
+    expect(total.group).toBe('Amounts')
+    expect(total.order).toBe(2)
+    const issued = fields.find((f) => f.key === 'issuedOn')!
+    expect(issued.group).toBe('Dates')
+    expect(issued.order).toBe(1)
+  })
+
+  it('fields stay alphabetically sorted in the emitted array (group/order are metadata only)', async () => {
+    const col = await collectionWith({ total: { label: 'Total', order: 1 } })
+    const keys = col.describe().fields.map((f) => f.key)
+    expect(keys).toEqual([...keys].sort())
+  })
+
+  it('zod .meta() group/order flow through the async describe path, channel wins', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-group-order' })
+    const v = await db.openVault('v2')
+    const col = v.collection('items', {
+      schema: z.object({
+        id: z.string(),
+        a: z.number().meta({ group: 'FromZod', order: 7 }),
+        b: z.number().meta({ group: 'Loser' }),
+      }),
+      fieldMeta: { b: { label: 'B', group: 'ChannelWins' } } as never,
+    })
+    const fields = (await col.describe({})).fields
+    expect(fields.find((f) => f.key === 'a')!.group).toBe('FromZod')
+    expect(fields.find((f) => f.key === 'a')!.order).toBe(7)
+    expect(fields.find((f) => f.key === 'b')!.group).toBe('ChannelWins')
+  })
+
+  it('absent group/order are absent, not undefined-valued keys', async () => {
+    const col = await collectionWith({ total: { label: 'Total' } })
+    const total = col.describe().fields.find((f) => f.key === 'total')!
+    expect('group' in total).toBe(false)
+    expect('order' in total).toBe(false)
+  })
+})

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/hub",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Zero-knowledge, offline-first, encrypted document store — core library with AES-256-GCM, PBKDF2, multi-user keyring, and sync engine",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/hub/src/with-pod/backup.ts
+++ b/packages/hub/src/with-pod/backup.ts
@@ -107,6 +107,7 @@ export async function dumpVault(ctx: BackupContext): Promise<string> {
   const internalSnapshot: VaultSnapshot = {}
   const internalNames = [
     LEDGER_COLLECTION, LEDGER_DELTAS_COLLECTION, SCHEMAS_COLLECTION, SEQUENCE_COLLECTION,
+    '_history', // full-snapshot version history — so history()/getVersion()/diff() survive the bundle
     '_blob_index', '_blob_chunks', '_blob_eviction_audit',
     ...Object.keys(snapshot).flatMap((c) => [`_blob_slots_${c}`, `_blob_versions_${c}`]),
   ]

--- a/packages/hub/src/with-shape/introspection/describe.ts
+++ b/packages/hub/src/with-shape/introspection/describe.ts
@@ -33,6 +33,10 @@ export interface DescribedField {
   readonly constraints?: Record<string, unknown>
   readonly label: string
   readonly description?: string
+  /** Card/section grouping hint for detail & form layouts. From fieldMeta/zod .meta(). */
+  readonly group?: string
+  /** Relative ordering hint within and across groups. Lower renders first. */
+  readonly order?: number
   readonly semanticType?: string
   readonly unit?: string
   readonly sensitivity?: 'public' | 'pii' | 'secret'
@@ -86,6 +90,7 @@ export interface ZodFieldSlot {
 // Unknown .meta() keys (not in this set) are ignored.
 const ZOD_META_KEYS = new Set<string>([
   'label', 'description', 'unit', 'semanticType', 'sensitivity', 'aggregate', 'aliases', 'displayFor',
+  'group', 'order',
 ])
 
 // ─── deriveZodFields ──────────────────────────────────────────────────────
@@ -373,6 +378,8 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
       optional: zod?.optional ?? false,
       label: resolved.label,
       ...(resolved.description !== undefined ? { description: resolved.description } : {}),
+      ...(resolved.group !== undefined ? { group: resolved.group } : {}),
+      ...(resolved.order !== undefined ? { order: resolved.order } : {}),
       ...(resolved.semanticType !== undefined ? { semanticType: resolved.semanticType } : {}),
       ...(resolved.unit !== undefined ? { unit: resolved.unit } : {}),
       ...(resolved.sensitivity !== undefined ? { sensitivity: resolved.sensitivity } : {}),

--- a/packages/hub/src/with-shape/introspection/field-meta.ts
+++ b/packages/hub/src/with-shape/introspection/field-meta.ts
@@ -36,6 +36,14 @@ export interface FieldMeta {
    * When absent, the widget is derived automatically by buildDescription.
    */
   widget?: string
+  /**
+   * Card/section grouping hint for detail & form layouts (e.g. 'Identity',
+   * 'Amounts'). Purely descriptive metadata — consumers group; describe()
+   * keeps emitting fields alphabetically.
+   */
+  group?: string
+  /** Relative ordering hint within (and across) groups. Lower renders first. */
+  order?: number
 }
 
 export class FieldMetaUnknownFieldError extends Error {
@@ -88,6 +96,8 @@ export function resolveFieldMeta(key: string, inputs: MergeInputs): ResolvedMeta
   const aliases = pick('aliases')
   const displayFor = pick('displayFor')
   const widget = pick('widget')
+  const group = pick('group')
+  const order = pick('order')
   return {
     label: pick('label') ?? humanizeFieldKey(key),
     ...(description !== undefined ? { description } : {}),
@@ -98,5 +108,7 @@ export function resolveFieldMeta(key: string, inputs: MergeInputs): ResolvedMeta
     ...(aliases !== undefined ? { aliases } : {}),
     ...(displayFor !== undefined ? { displayFor } : {}),
     ...(widget !== undefined ? { widget } : {}),
+    ...(group !== undefined ? { group } : {}),
+    ...(order !== undefined ? { order } : {}),
   }
 }

--- a/packages/in-ai/CHANGELOG.md
+++ b/packages/in-ai/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/in-ai
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/in-ai/package.json
+++ b/packages/in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-ai",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "LLM function-calling adapter for noy-db — expose ACL-scoped collections as tool definitions, then dispatch tool calls back to the vault. Format-agnostic (OpenAI, Anthropic, Vercel AI SDK).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-devtools-tui/CHANGELOG.md
+++ b/packages/in-devtools-tui/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @noy-db/in-devtools-tui
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+  - @noy-db/in-devtools@0.3.0-pre.2
+  - @noy-db/to-meter@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/in-devtools-tui/package.json
+++ b/packages/in-devtools-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-devtools-tui",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Interactive terminal inspector for a live noy-db (ink TUI over @noy-db/in-devtools).",
   "license": "MIT",
   "type": "module",

--- a/packages/in-devtools/CHANGELOG.md
+++ b/packages/in-devtools/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/in-devtools
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/in-devtools/package.json
+++ b/packages/in-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-devtools",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Framework-agnostic read-only inspector for a live noy-db — vaults, collections, schema, stats, records, and live writes.",
   "license": "MIT",
   "type": "module",

--- a/packages/in-nextjs/CHANGELOG.md
+++ b/packages/in-nextjs/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @noy-db/in-nextjs
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+  - @noy-db/in-react@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/in-nextjs/package.json
+++ b/packages/in-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nextjs",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Next.js App Router helpers for noy-db — server components, route handlers, client hooks, and cookie-based session. Thin bridge that composes @noy-db/in-react with Next's cookies()/headers() APIs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-nuxt/CHANGELOG.md
+++ b/packages/in-nuxt/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog — in-nuxt
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+  - @noy-db/in-devtools@0.3.0-pre.2
+  - @noy-db/in-pinia@0.3.0-pre.2
+  - @noy-db/in-rest@0.3.0-pre.2
+  - @noy-db/in-vue@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/in-nuxt/package.json
+++ b/packages/in-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nuxt",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Nuxt 4 module for noy-db — auto-imports, SSR-safe runtime plugin, and the @noy-db/in-pinia bridge",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-pinia/CHANGELOG.md
+++ b/packages/in-pinia/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — in-pinia
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/in-pinia/package.json
+++ b/packages/in-pinia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-pinia",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Pinia integration for noy-db — defineNoydbStore() and the augmentation plugin for existing stores",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-react/CHANGELOG.md
+++ b/packages/in-react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/in-react
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/in-react/package.json
+++ b/packages/in-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-react",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "React hooks for noy-db — useNoydb, useVault, useCollection, useQuery, useSync. Uses useSyncExternalStore for reactive subscriptions. Zero deps beyond React.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-rest/CHANGELOG.md
+++ b/packages/in-rest/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/in-rest
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/in-rest/package.json
+++ b/packages/in-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-rest",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Framework-neutral REST API integration for noy-db — createRestHandler with Hono, Express, Fastify, and Nitro subpath adapters.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-solid/CHANGELOG.md
+++ b/packages/in-solid/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/in-solid
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/in-solid/package.json
+++ b/packages/in-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-solid",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "SolidJS signal primitives for noy-db — createCollectionSignal, createQuerySignal, createSyncSignal backed by noy-db change events.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-svelte/CHANGELOG.md
+++ b/packages/in-svelte/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/in-svelte
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/in-svelte/package.json
+++ b/packages/in-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-svelte",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Svelte stores for noy-db — collectionStore / queryStore / syncStore backed by noy-db change events. Works with Svelte 4 store contract and Svelte 5 runes (via $store subscription interop).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-query/CHANGELOG.md
+++ b/packages/in-tanstack-query/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/in-tanstack-query
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/in-tanstack-query/package.json
+++ b/packages/in-tanstack-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-query",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "TanStack Query adapter for noy-db — queryFn + mutationFn helpers that speak the Collection API, plus automatic invalidation from noy-db change events. Framework-agnostic (React / Vue / Solid / Svelte).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-table/CHANGELOG.md
+++ b/packages/in-tanstack-table/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/in-tanstack-table
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/in-tanstack-table/package.json
+++ b/packages/in-tanstack-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-table",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "TanStack Table bridge for noy-db — map Collection query state (sort, filter, pagination) into Table state and back, so a useSmartTable pattern drives the DB's query DSL without glue code.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-vue/CHANGELOG.md
+++ b/packages/in-vue/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — in-vue
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/in-vue/package.json
+++ b/packages/in-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-vue",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Vue 3 / Nuxt composables for noy-db — reactive useNoydb, useCollection, useSync, and biometric plugin",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-yjs/CHANGELOG.md
+++ b/packages/in-yjs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — in-yjs
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/in-yjs/package.json
+++ b/packages/in-yjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-yjs",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Yjs Y.Doc interop for noy-db — collaborative rich-text fields with encrypted-at-rest Yjs state",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-zustand/CHANGELOG.md
+++ b/packages/in-zustand/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/in-zustand
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/in-zustand/package.json
+++ b/packages/in-zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-zustand",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Zustand adapter for noy-db — factory that mirrors defineNoydbStore for Zustand users, auto-syncs state from noy-db change events, and supports optimistic mutations.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-email-otp/CHANGELOG.md
+++ b/packages/on-email-otp/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/on-email-otp
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/on-email-otp/package.json
+++ b/packages/on-email-otp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-email-otp",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Email OTP second factor for noy-db — generates time-boxed one-time codes, delivers via a user-supplied transport (SMTP / SES / Postmark / any fn), and verifies in constant time. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-magic-link/CHANGELOG.md
+++ b/packages/on-magic-link/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/on-magic-link
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/on-magic-link/package.json
+++ b/packages/on-magic-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-magic-link",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Magic-link unlock for noy-db — one-time URL that opens a vault in a viewer-scoped session without a passphrase. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-oidc/CHANGELOG.md
+++ b/packages/on-oidc/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — on-oidc
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/on-oidc/package.json
+++ b/packages/on-oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-oidc",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "OAuth/OIDC bridge for noy-db — federated login (LINE, Google, Apple, Okta) with split-key key connector — server never sees plaintext",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-password/CHANGELOG.md
+++ b/packages/on-password/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/on-password
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/on-password/package.json
+++ b/packages/on-password/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-password",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Tier-2 password authenticator slot for noy-db. PBKDF2-SHA256 600K wraps the DEK set in its own keyring slot, distinct from the rarely-typed tier-1 phrase. Pair with @noy-db/on-email-otp or @noy-db/on-totp for the SaaS UX.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-pin/CHANGELOG.md
+++ b/packages/on-pin/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/on-pin
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/on-pin/package.json
+++ b/packages/on-pin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-pin",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Session-resume PIN quick-lock for noy-db — after a full passphrase unlock, a short-lived PIN (or a per-device biometric) re-unlocks the cached DEKs without re-typing the passphrase. PIN never replaces the passphrase; only resumes an already-unlocked session.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-recovery/CHANGELOG.md
+++ b/packages/on-recovery/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/on-recovery
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/on-recovery/package.json
+++ b/packages/on-recovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-recovery",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "One-time printable recovery codes for noy-db — last-resort vault unlock when the passphrase, passkey, and OIDC provider are all unavailable. Base32 + checksum codes, PBKDF2-derived wrapping keys, burn-on-use. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-shamir/CHANGELOG.md
+++ b/packages/on-shamir/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @noy-db/on-shamir
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/on-shamir/package.json
+++ b/packages/on-shamir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-shamir",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "k-of-n Shamir Secret Sharing of the vault KEK for multi-party unlock. Any K of N shares recombines the key; fewer than K leaks zero bits. Composable — each share can be protected by any other on-* method. Zero runtime dependencies.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-threat/CHANGELOG.md
+++ b/packages/on-threat/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/on-threat
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/on-threat/package.json
+++ b/packages/on-threat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-threat",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Threat-response primitives for noy-db — multi-attempt lockout, duress-passphrase data destruction, duress-passphrase honeypot decoy. Pure stateful helpers; the caller coordinates keyring + audit-ledger integration. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-totp/CHANGELOG.md
+++ b/packages/on-totp/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/on-totp
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/on-totp/package.json
+++ b/packages/on-totp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-totp",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "TOTP (RFC 6238) authenticator-app second factor for noy-db — generate secrets, otpauth:// provisioning URIs, and constant-time code verification. Zero dependencies (HMAC-SHA1 via Web Crypto). Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-webauthn/CHANGELOG.md
+++ b/packages/on-webauthn/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — on-webauthn
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/on-webauthn/package.json
+++ b/packages/on-webauthn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-webauthn",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "WebAuthn hardware-key keyrings for noy-db — Touch ID, Face ID, Windows Hello, YubiKey, FIDO2 passkeys",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-browser-idb/CHANGELOG.md
+++ b/packages/to-browser-idb/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — to-browser-idb
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/to-browser-idb/package.json
+++ b/packages/to-browser-idb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-browser-idb",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "IndexedDB adapter for noy-db with optional key obfuscation",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-file/CHANGELOG.md
+++ b/packages/to-file/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — to-file
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/to-file/package.json
+++ b/packages/to-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-file",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "JSON file adapter for noy-db — encrypted document store on local disk, USB sticks, or network drives",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-memory/CHANGELOG.md
+++ b/packages/to-memory/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog — to-memory
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/to-memory/package.json
+++ b/packages/to-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-memory",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "In-memory adapter for noy-db — ideal for testing, development, and ephemeral workloads",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-meter/CHANGELOG.md
+++ b/packages/to-meter/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/to-meter
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/to-meter/package.json
+++ b/packages/to-meter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-meter",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Pass-through meter for @noy-db/to-* stores — wraps any NoydbStore and records per-method latency percentiles, error rates, and byte counts on real traffic. Optional synthetic liveness probe emits degraded / restored events. No synthetic benchmarks (see @noy-db/to-probe for that) — this measures what your app is actually doing.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-probe/CHANGELOG.md
+++ b/packages/to-probe/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/to-probe
 
+## 0.3.0-pre.2
+
+### Minor Changes
+
+- 0.3 version line continues — lockstep with `@noy-db/hub` 0.3.0-pre.2 (describe() group/order metadata, \_history in the .noydb pod; see the hub changelog). No package-specific changes beyond the hub realignment.
+
+### Patch Changes
+
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.2
+
 ## 0.3.0-pre.1
 
 ### Minor Changes

--- a/packages/to-probe/package.json
+++ b/packages/to-probe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-probe",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "Diagnostic companion for the @noy-db/to-* store family — not itself a storage backend. Setup-time suitability test + topology check + runtime reliability monitor. Exercises the 6-method NoydbStore contract across five axes (write latency, CAS integrity, hydration cost, sync economics, network resilience) and produces a structured risk-scored report.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",


### PR DESCRIPTION
## Summary
- **FieldMeta.group / FieldMeta.order** flow through `collection.describe()` onto each `DescribedField` (channel > zod `.meta()` > inferred). Purely descriptive — alphabetical emission unchanged. Foundation for the `@noy-db/ui` item family's card layouts.
- **`_history` travels in `vault.dump()` / .noydb pods** — `history()`/`getVersion()`/`diff()` now work on a pod-restored vault (ledger + deltas already travelled; the full-snapshot collection did not).
- Lockstep `0.3.0-pre.2` bump across all 51 published packages.

## Tests
- `__tests__/introspection/field-group-order.test.ts` — channel + zod-meta flow, precedence, alphabetical invariant, absent-key hygiene.
- `__tests__/bundle-history-roundtrip.test.ts` — dump-side `_internal._history` presence + restored `history()`/`getVersion()`/`diff()` (incl. diff vs live current version).
- Full hub suite: 371 files / 3050 tests green; repo build + typecheck + lint green.