### PR TITLE
feat: redact option for as-json/ndjson/sql/xml + classified deferred minors

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -17,7 +17,8 @@
         "src/kernel/util/index.ts",
         "src/with-fork/snapshots/index.ts",
         "src/with-party/session/index.ts",
-        "src/with-party/team/index.ts"
+        "src/with-party/team/index.ts",
+        "src/with-shape/classified/index.ts"
       ]
     }
   }

--- a/packages/as-csv/src/index.ts
+++ b/packages/as-csv/src/index.ts
@@ -59,6 +59,9 @@ export interface AsCSVOptions {
    * layer redaction; it never affects what's on disk. Sealed handles
    * are unaffected either way — they always serialize as `'[sealed]'`,
    * so ciphertext never leaks regardless of this option.
+   *
+   * Rider companion fields (e.g. `pan_last4`) remain visible as their own
+   * columns — they are safe write-time projections.
    */
   readonly redact?: boolean | { readonly sensitivity: 'omit' | 'mask' }
 }

--- a/packages/as-json/__tests__/redact.test.ts
+++ b/packages/as-json/__tests__/redact.test.ts
@@ -1,0 +1,95 @@
+/**
+ * as-json `redact` option (#489) — classified/sensitivity-aware export via
+ * `applyListProjection`.
+ *
+ * Follows the same in-memory NoydbStore + owner-grant pattern as
+ * `as-json.test.ts`, wrapped in a local `makeVault()` helper since the
+ * neighboring tests each build the vault inline per-suite.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '@noy-db/hub'
+import { ConflictError, createNoydb, classified } from '@noy-db/hub'
+import { toObject as jsonToObject } from '../src/index.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const gc = (c: string, col: string) => {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+/**
+ * Builds a fresh vault whose owner already holds the `plaintext: ['json']`
+ * export grant (mirrors `as-json.test.ts`'s `seed()` + grant dance:
+ * the grant must be persisted and the vault reopened before the new
+ * capability is visible on the session).
+ */
+async function makeVault() {
+  const adapter = memory()
+  const db = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+  await db.openVault('acme')
+  await db.grant('acme', {
+    userId: 'owner-01', displayName: 'Owner', role: 'owner',
+    passphrase: 'owner-pass',
+    exportCapability: { plaintext: ['json'] },
+  })
+  await db.close()
+
+  const db2 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+  return db2.openVault('acme')
+}
+
+describe('as-json redact (#489)', () => {
+  it('redact: true masks classified fields and keeps riders', async () => {
+    const v = await makeVault()
+    const c = v.collection('cards', {
+      classifiedFields: { card: classified.creditCard({ pan: 'pan' }) },
+    })
+    await c.put('r1', { pan: '4242424242424242', total: 9 })
+    const doc = await jsonToObject(v, { redact: true })
+    const json = JSON.stringify(doc)
+    expect(json).toContain('•••• 4242')
+    expect(json).not.toContain('4242424242424242')
+  })
+
+  it('redact: { sensitivity: "omit" } drops plain pii-tagged columns', async () => {
+    const v = await makeVault()
+    const c = v.collection('people', { fieldMeta: { note: { label: 'N', sensitivity: 'pii' } } })
+    await c.put('p1', { name: 'x', note: 'private' })
+    const doc = await jsonToObject(v, { redact: { sensitivity: 'omit' } })
+    const json = JSON.stringify(doc)
+    expect(json).not.toContain('private')
+    expect(json).toContain('x')
+  })
+})

--- a/packages/as-json/src/index.ts
+++ b/packages/as-json/src/index.ts
@@ -17,7 +17,7 @@
  * @packageDocumentation
  */
 
-import type { Vault } from '@noy-db/hub'
+import { applyListProjection, type Vault, type CollectionDescription } from '@noy-db/hub'
 
 export interface AsJSONOptions {
   /**
@@ -40,6 +40,25 @@ export interface AsJSONOptions {
    * of the raw records the consumer originally put.
    */
   readonly includeMeta?: boolean
+
+  /**
+   * Apply the hub's `applyListProjection` read-projection before
+   * serialising records. `true` redacts only `classifiedFields` (mask /
+   * omit / rider, per the field's preset). The object form additionally
+   * redacts fields carrying a plain `fieldMeta` `sensitivity: 'pii' |
+   * 'secret'` tag, per `sensitivity: 'omit' | 'mask'`.
+   *
+   * Caveat: `describe()` reflects the declarations of *this session's*
+   * collection instance — redaction only takes effect when the
+   * collection was opened (this call or earlier in the session) with
+   * its `classifiedFields` / `fieldMeta` options. This is presentation-
+   * layer redaction; it never affects what's on disk. Sealed handles
+   * are unaffected either way — they always serialize as `'[sealed]'`,
+   * so ciphertext never leaks regardless of this option. Rider companion
+   * fields (e.g. `pan_last4`) remain visible as their own columns — they
+   * are safe write-time projections.
+   */
+  readonly redact?: boolean | { readonly sensitivity: 'omit' | 'mask' }
 }
 
 export interface AsJSONDownloadOptions extends AsJSONOptions {
@@ -84,11 +103,18 @@ export async function toObject(vault: Vault, options: AsJSONOptions = {}): Promi
   for await (const chunk of vault.exportStream({ granularity: 'collection' })) {
     if (allowlist && !allowlist.has(chunk.collection)) continue
     const bucket = doc[chunk.collection] ?? (doc[chunk.collection] = [])
+    const shouldRedact = options.redact !== undefined && options.redact !== false
+    const projectionOpts = shouldRedact && options.redact !== true ? { sensitivity: options.redact.sensitivity } : undefined
+    const desc: CollectionDescription | undefined = shouldRedact ? vault.collection(chunk.collection).describe() : undefined
     for (const record of chunk.records) {
+      let r = record as Record<string, unknown>
+      if (shouldRedact && desc) {
+        r = applyListProjection(desc, r, projectionOpts)
+      }
       if (options.includeMeta) {
-        bucket.push(record as Record<string, unknown>)
+        bucket.push(r)
       } else {
-        bucket.push(stripMeta(record as Record<string, unknown>))
+        bucket.push(stripMeta(r))
       }
     }
   }

--- a/packages/as-json/src/index.ts
+++ b/packages/as-json/src/index.ts
@@ -55,7 +55,7 @@ export interface AsJSONOptions {
    * layer redaction; it never affects what's on disk. Sealed handles
    * are unaffected either way — they always serialize as `'[sealed]'`,
    * so ciphertext never leaks regardless of this option. Rider companion
-   * fields (e.g. `pan_last4`) remain visible as their own columns — they
+   * fields (e.g. `pan_last4`) remain visible as their own keys — they
    * are safe write-time projections.
    */
   readonly redact?: boolean | { readonly sensitivity: 'omit' | 'mask' }

--- a/packages/as-ndjson/__tests__/redact.test.ts
+++ b/packages/as-ndjson/__tests__/redact.test.ts
@@ -1,0 +1,94 @@
+/**
+ * as-ndjson `redact` option (#489) — classified/sensitivity-aware export via
+ * `applyListProjection`.
+ *
+ * Follows the same in-memory NoydbStore + owner-grant pattern as
+ * `as-ndjson.test.ts`, wrapped in a local `makeVault()` helper since the
+ * neighboring tests each build the vault inline per-suite.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '@noy-db/hub'
+import { ConflictError, createNoydb, classified } from '@noy-db/hub'
+import { toString as ndjsonToString } from '../src/index.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const gc = (c: string, col: string) => {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+/**
+ * Builds a fresh vault whose owner already holds the `plaintext: ['ndjson']`
+ * export grant (mirrors the grant dance: the grant must be persisted and
+ * the vault reopened before the new capability is visible on the session).
+ */
+async function makeVault() {
+  const adapter = memory()
+  const db = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+  await db.openVault('acme')
+  await db.grant('acme', {
+    userId: 'owner-01', displayName: 'Owner', role: 'owner',
+    passphrase: 'owner-pass',
+    exportCapability: { plaintext: ['ndjson'] },
+  })
+  await db.close()
+
+  const db2 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+  return db2.openVault('acme')
+}
+
+describe('as-ndjson redact (#489)', () => {
+  it('redact: true masks classified fields and keeps riders', async () => {
+    const v = await makeVault()
+    const c = v.collection('cards', {
+      classifiedFields: { card: classified.creditCard({ pan: 'pan' }) },
+    })
+    await c.put('r1', { pan: '4242424242424242', total: 9 })
+    const ndjson = await ndjsonToString(v, { redact: true })
+    const line = ndjson.trim()
+    const obj = JSON.parse(line) as Record<string, unknown>
+    expect(obj.pan).toBe('•••• 4242')
+    expect(ndjson).not.toContain('4242424242424242')
+  })
+
+  it('redact: { sensitivity: "omit" } drops plain pii-tagged columns', async () => {
+    const v = await makeVault()
+    const c = v.collection('people', { fieldMeta: { note: { label: 'N', sensitivity: 'pii' } } })
+    await c.put('p1', { name: 'x', note: 'private' })
+    const ndjson = await ndjsonToString(v, { redact: { sensitivity: 'omit' } })
+    expect(ndjson).not.toContain('private')
+    expect(ndjson).toContain('x')
+  })
+})

--- a/packages/as-ndjson/src/index.ts
+++ b/packages/as-ndjson/src/index.ts
@@ -19,7 +19,8 @@
  * @packageDocumentation
  */
 
-import type { Vault } from '@noy-db/hub'
+import type { Vault, CollectionDescription } from '@noy-db/hub'
+import { applyListProjection } from '@noy-db/hub'
 
 export interface AsNDJSONOptions {
   /** Collection allowlist. Omit for every collection the caller can read. */
@@ -28,6 +29,26 @@ export interface AsNDJSONOptions {
   readonly includeMeta?: boolean
   /** Name of the routing field. Default `'_schema'`. */
   readonly schemaField?: string
+
+  /**
+   * Apply the hub's `applyListProjection` read-projection before
+   * serialising each record. `true` redacts only `classifiedFields` (mask /
+   * omit / rider, per the field's preset). The object form additionally
+   * redacts fields carrying a plain `fieldMeta` `sensitivity: 'pii' |
+   * 'secret'` tag, per `sensitivity: 'omit' | 'mask'`.
+   *
+   * Caveat: `describe()` reflects the declarations of *this session's*
+   * collection instance — redaction only takes effect when the
+   * collection was opened (this call or earlier in the session) with
+   * its `classifiedFields` / `fieldMeta` options. This is presentation-
+   * layer redaction; it never affects what's on disk. Sealed handles
+   * are unaffected either way — they always serialize as `'[sealed]'`,
+   * so ciphertext never leaks regardless of this option.
+   *
+   * Rider companion fields (e.g. `pan_last4`) remain visible as their own
+   * keys — they are safe write-time projections.
+   */
+  readonly redact?: boolean | { readonly sensitivity: 'omit' | 'mask' }
 }
 
 export interface AsNDJSONDownloadOptions extends AsNDJSONOptions {
@@ -50,12 +71,37 @@ export async function* stream(vault: Vault, options: AsNDJSONOptions = {}): Asyn
   const allowlist = options.collections ? new Set(options.collections) : null
   const schemaField = options.schemaField ?? '_schema'
 
+  // Cache collection descriptions for redaction
+  const descCache = new Map<string, CollectionDescription>()
+
   for await (const chunk of vault.exportStream({ granularity: 'record' })) {
     if (allowlist && !allowlist.has(chunk.collection)) continue
+
+    // Compute description once per collection if redaction is enabled
+    let desc: CollectionDescription | undefined
+    if (options.redact !== undefined && options.redact !== false) {
+      if (!descCache.has(chunk.collection)) {
+        descCache.set(chunk.collection, vault.collection(chunk.collection).describe())
+      }
+      desc = descCache.get(chunk.collection)
+    }
+
     for (const record of chunk.records) {
-      const base = options.includeMeta
-        ? (record as Record<string, unknown>)
-        : stripMeta(record as Record<string, unknown>)
+      let base: Record<string, unknown>
+      if (options.includeMeta) {
+        base = record as Record<string, unknown>
+      } else {
+        base = stripMeta(record as Record<string, unknown>)
+      }
+
+      // Apply redaction if enabled
+      if (desc !== undefined) {
+        const projectionOpts = typeof options.redact === 'object'
+          ? { sensitivity: options.redact.sensitivity }
+          : undefined
+        base = applyListProjection(desc, base, projectionOpts)
+      }
+
       const out: Record<string, unknown> = { [schemaField]: chunk.collection, ...base }
       yield JSON.stringify(out)
     }

--- a/packages/as-sql/__tests__/redact.test.ts
+++ b/packages/as-sql/__tests__/redact.test.ts
@@ -1,0 +1,97 @@
+/**
+ * as-sql `redact` option — classified/sensitivity-aware export via
+ * `applyListProjection`.
+ *
+ * Follows the same in-memory NoydbStore + owner-grant pattern as
+ * `as-sql.test.ts`, wrapped in a local `makeVault()` helper since the
+ * neighboring tests each build the vault inline per-suite.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '@noy-db/hub'
+import { ConflictError, createNoydb, classified } from '@noy-db/hub'
+import { toString as sqlToString } from '../src/index.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const gc = (c: string, col: string) => {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+/**
+ * Builds a fresh vault whose owner already holds the `plaintext: ['sql']`
+ * export grant (mirrors `as-sql.test.ts`'s `seed()` + grant dance:
+ * the grant must be persisted and the vault reopened before the new
+ * capability is visible on the session).
+ */
+async function makeVault() {
+  const adapter = memory()
+  const db = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+  await db.openVault('acme')
+  await db.grant('acme', {
+    userId: 'owner-01', displayName: 'Owner', role: 'owner',
+    passphrase: 'owner-pass',
+    exportCapability: { plaintext: ['sql'] },
+  })
+  await db.close()
+
+  const db2 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+  return db2.openVault('acme')
+}
+
+describe('as-sql redact', () => {
+  it('redact: true masks classified fields and keeps riders', async () => {
+    const v = await makeVault()
+    const c = v.collection('cards', {
+      classifiedFields: { card: classified.creditCard({ pan: 'pan' }) },
+    })
+    await c.put('r1', { pan: '4242424242424242', total: 9 })
+    const sql = await sqlToString(v, { redact: true })
+    expect(sql).toContain('•••• 4242')
+    expect(sql).not.toContain('4242424242424242')
+  })
+
+  it('redact: { sensitivity: "omit" } drops plain pii-tagged columns from CREATE/INSERT', async () => {
+    const v = await makeVault()
+    const c = v.collection('people', { fieldMeta: { note: { label: 'N', sensitivity: 'pii' } } })
+    await c.put('p1', { name: 'x', note: 'private' })
+    const sql = await sqlToString(v, { redact: { sensitivity: 'omit' } })
+    // The pii-tagged column should not appear in CREATE TABLE column list
+    expect(sql).not.toMatch(/"note"/i)
+    // The pii data should not appear in the INSERT
+    expect(sql).not.toContain('private')
+    // But the non-sensitive column should be there
+    expect(sql).toContain('x')
+  })
+})

--- a/packages/as-sql/src/index.ts
+++ b/packages/as-sql/src/index.ts
@@ -18,7 +18,7 @@
  * @packageDocumentation
  */
 
-import type { Vault } from '@noy-db/hub'
+import { applyListProjection, type Vault, type CollectionDescription } from '@noy-db/hub'
 
 export type SqlDialect = 'postgres' | 'mysql' | 'sqlite'
 export type SqlMode = 'schema-only' | 'data-only' | 'schema+data'
@@ -34,6 +34,26 @@ export interface AsSQLOptions {
   readonly tableNames?: (collection: string) => string
   /** Include `_noydb_version` / `_noydb_ts` metadata columns. Default `false`. */
   readonly metadataColumns?: boolean
+
+  /**
+   * Apply the hub's `applyListProjection` read-projection before
+   * serialising rows. `true` redacts only `classifiedFields` (mask /
+   * omit / rider, per the field's preset). The object form additionally
+   * redacts fields carrying a plain `fieldMeta` `sensitivity: 'pii' |
+   * 'secret'` tag, per `sensitivity: 'omit' | 'mask'`.
+   *
+   * Caveat: `describe()` reflects the declarations of *this session's*
+   * collection instance — redaction only takes effect when the
+   * collection was opened (this call or earlier in the session) with
+   * its `classifiedFields` / `fieldMeta` options. This is presentation-
+   * layer redaction; it never affects what's on disk. Sealed handles
+   * are unaffected either way — they always serialize as `'[sealed]'`,
+   * so ciphertext never leaks regardless of this option.
+   *
+   * Rider companion fields (e.g. `pan_last4`) remain visible as their
+   * own columns — they are safe write-time projections.
+   */
+  readonly redact?: boolean | { readonly sensitivity: 'omit' | 'mask' }
 }
 
 export interface AsSQLDownloadOptions extends AsSQLOptions {
@@ -59,8 +79,18 @@ export async function toString(vault: Vault, options: AsSQLOptions = {}): Promis
   const buckets = new Map<string, Record<string, unknown>[]>()
   for await (const chunk of vault.exportStream({ granularity: 'collection' })) {
     if (!includeAll && allowlist && !allowlist.has(chunk.collection)) continue
+    let records = chunk.records.map(r => stripMeta(r as Record<string, unknown>))
+
+    // Apply redaction projection if specified.
+    if (options.redact !== undefined && options.redact !== false) {
+      const desc: CollectionDescription = vault.collection(chunk.collection).describe()
+      const projectionOpts = options.redact === true ? undefined
+        : { sensitivity: options.redact.sensitivity }
+      records = records.map((r) => applyListProjection(desc, r, projectionOpts))
+    }
+
     const bucket = buckets.get(chunk.collection) ?? []
-    for (const r of chunk.records) bucket.push(stripMeta(r as Record<string, unknown>))
+    bucket.push(...records)
     buckets.set(chunk.collection, bucket)
   }
 

--- a/packages/as-xlsx/__tests__/redact.test.ts
+++ b/packages/as-xlsx/__tests__/redact.test.ts
@@ -9,7 +9,7 @@
 import { describe, expect, it } from 'vitest'
 import { createNoydb, classified } from '@noy-db/hub'
 import { memory } from '@noy-db/to-memory'
-import { toBytes, readXlsx } from '../src/index.js'
+import { toBytes, toBytesMultiVault, readXlsx } from '../src/index.js'
 
 /**
  * Builds a fresh vault whose owner already holds the `plaintext: ['xlsx']`
@@ -91,5 +91,48 @@ describe('as-xlsx redact (#489)', () => {
     const row = sheet.rows.slice(1).find((r) => r[h['id']!] === 'r1')!
     expect(row[h['pan']!]).toBe('•••• 4242')
     expect(Object.values(row)).not.toContain('4242424242424242')
+  })
+
+  it('multi-vault: entry-level redact only masks the sheet whose entry opted in', async () => {
+    const vRedacted = await makeVault()
+    const cRedacted = vRedacted.collection('cards', {
+      classifiedFields: { card: classified.creditCard({ pan: 'pan' }) },
+    })
+    await cRedacted.put('r1', { pan: '4242424242424242', total: 9 })
+
+    const vPlain = await makeVault()
+    const cPlain = vPlain.collection('cards', {
+      classifiedFields: { card: classified.creditCard({ pan: 'pan' }) },
+    })
+    await cPlain.put('r1', { pan: '4111111111111111', total: 5 })
+
+    const bytes = await toBytesMultiVault([
+      {
+        vault: vRedacted, label: 'redacted',
+        sheets: [{ name: 'cards', collection: 'cards' }],
+        redact: true,
+      },
+      {
+        vault: vPlain, label: 'plain',
+        sheets: [{ name: 'cards', collection: 'cards' }],
+      },
+    ])
+
+    const wb = await readXlsx(bytes)
+    const redactedSheet = wb.sheets.find((s) => s.name === 'redacted_cards')!
+    const hR = headerMap(redactedSheet)
+    const rowR = redactedSheet.rows.slice(1).find((r) => r[hR['total']!] === 9)!
+    expect(rowR[hR['pan']!]).toBe('•••• 4242')
+    expect(Object.values(rowR)).not.toContain('4242424242424242')
+
+    // The non-redacted entry is untouched: `pan` is a classified 'recoverable'
+    // field, so unprojected it stays a SealedHandle — never the raw PAN, and
+    // never masked either. It serializes via its non-leaking `toJSON()`.
+    const plainSheet = wb.sheets.find((s) => s.name === 'plain_cards')!
+    const hP = headerMap(plainSheet)
+    const rowP = plainSheet.rows.slice(1).find((r) => r[hP['total']!] === 5)!
+    expect(rowP[hP['pan']!]).toBe('"[sealed]"')
+    expect(Object.values(rowP)).not.toContain('4111111111111111')
+    expect(Object.values(rowP)).not.toContain('•••• 1111')
   })
 })

--- a/packages/as-xlsx/src/index.ts
+++ b/packages/as-xlsx/src/index.ts
@@ -205,6 +205,9 @@ export interface AsXlsxOptions {
    * redaction; it never affects what's on disk. Sealed handles are
    * unaffected either way — they always serialize as `'[sealed]'`, so
    * ciphertext never leaks regardless of this option.
+   *
+   * Rider companion fields (e.g. `pan_last4`) remain visible as their own
+   * columns — they are safe write-time projections.
    */
   readonly redact?: boolean | { readonly sensitivity: 'omit' | 'mask' }
 }

--- a/packages/as-xml/__tests__/redact.test.ts
+++ b/packages/as-xml/__tests__/redact.test.ts
@@ -1,0 +1,93 @@
+/**
+ * as-xml `redact` option — classified/sensitivity-aware export via
+ * `applyListProjection`.
+ *
+ * Follows the same in-memory NoydbStore + owner-grant pattern as
+ * `as-xml.test.ts`, wrapped in a local `makeVault()` helper since the
+ * neighboring tests each build the vault inline per-suite.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '@noy-db/hub'
+import { ConflictError, createNoydb, classified } from '@noy-db/hub'
+import { toString as xmlToString } from '../src/index.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const gc = (c: string, col: string) => {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+/**
+ * Builds a fresh vault whose owner already holds the `plaintext: ['xml']`
+ * export grant (mirrors `as-xml.test.ts`'s `seed()` + grant dance:
+ * the grant must be persisted and the vault reopened before the new
+ * capability is visible on the session).
+ */
+async function makeVault() {
+  const adapter = memory()
+  const db = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+  await db.openVault('acme')
+  await db.grant('acme', {
+    userId: 'owner-01', displayName: 'Owner', role: 'owner',
+    passphrase: 'owner-pass',
+    exportCapability: { plaintext: ['xml'] },
+  })
+  await db.close()
+
+  const db2 = await createNoydb({ store: adapter, user: 'owner-01', secret: 'owner-pass' })
+  return db2.openVault('acme')
+}
+
+describe('as-xml redact', () => {
+  it('redact: true masks classified fields and keeps riders', async () => {
+    const v = await makeVault()
+    const c = v.collection('cards', {
+      classifiedFields: { card: classified.creditCard({ pan: 'pan' }) },
+    })
+    await c.put('r1', { pan: '4242424242424242', total: 9 })
+    const xml = await xmlToString(v, { collection: 'cards', redact: true })
+    expect(xml).toContain('•••• 4242')
+    expect(xml).not.toContain('4242424242424242')
+  })
+
+  it('redact: { sensitivity: "omit" } drops plain pii-tagged columns', async () => {
+    const v = await makeVault()
+    const c = v.collection('people', { fieldMeta: { note: { label: 'N', sensitivity: 'pii' } } })
+    await c.put('p1', { name: 'x', note: 'private' })
+    const xml = await xmlToString(v, { collection: 'people', redact: { sensitivity: 'omit' } })
+    expect(xml).not.toContain('private')
+    expect(xml).toContain('x')
+  })
+})

--- a/packages/as-xml/src/index.ts
+++ b/packages/as-xml/src/index.ts
@@ -20,7 +20,8 @@
  * @packageDocumentation
  */
 
-import type { Vault } from '@noy-db/hub'
+import type { Vault, CollectionDescription } from '@noy-db/hub'
+import { applyListProjection } from '@noy-db/hub'
 
 export interface AsXMLOptions {
   /** Collection to export. */
@@ -39,6 +40,24 @@ export interface AsXMLOptions {
   readonly namespace?: string
   /** Optional namespace prefix. Used together with `namespace`. */
   readonly namespacePrefix?: string
+  /**
+   * Apply the hub's `applyListProjection` read-projection before
+   * serialising records. `true` redacts only `classifiedFields` (mask /
+   * omit / rider, per the field's preset). The object form additionally
+   * redacts fields carrying a plain `fieldMeta` `sensitivity: 'pii' |
+   * 'secret'` tag, per `sensitivity: 'omit' | 'mask'`.
+   *
+   * Caveat: `describe()` reflects the declarations of *this session's*
+   * collection instance — redaction only takes effect when the
+   * collection was opened (this call or earlier in the session) with
+   * its `classifiedFields` / `fieldMeta` options. This is presentation-
+   * layer redaction; it never affects what's on disk. Sealed handles
+   * are unaffected either way — they always serialize as `'[sealed]'`,
+   * so ciphertext never leaks regardless of this option. Rider companion
+   * fields (e.g. `pan_last4`) remain visible as their own elements —
+   * they are safe write-time projections.
+   */
+  readonly redact?: boolean | { readonly sensitivity: 'omit' | 'mask' }
 }
 
 export interface AsXMLDownloadOptions extends AsXMLOptions {
@@ -60,6 +79,13 @@ export async function toString(vault: Vault, options: AsXMLOptions): Promise<str
       records.push(...chunk.records)
       break
     }
+  }
+
+  if (options.redact !== undefined && options.redact !== false) {
+    const desc: CollectionDescription = vault.collection(options.collection).describe()
+    const projectionOpts = options.redact === true ? undefined
+      : { sensitivity: options.redact.sensitivity }
+    records.splice(0, records.length, ...records.map((r) => applyListProjection(desc, r as Record<string, unknown>, projectionOpts)))
   }
 
   const rootName = options.rootElement ?? 'Records'

--- a/packages/hub/__tests__/classified/describe-emission.test.ts
+++ b/packages/hub/__tests__/classified/describe-emission.test.ts
@@ -78,4 +78,17 @@ describe('classified in describe()/toJSONSchema()', () => {
     })
     expect(js.properties.dob!['x-sensitivity']).toBe('pii')
   })
+
+  it('channel fieldMeta sensitivity overrides the classified preset sensitivity', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'a', secret: 'pw-de-3' })
+    const v = await db.openVault('v3')
+    const c = v.collection('contacts', {
+      classifiedFields: { mail: classified.email() },
+      fieldMeta: { mail: { label: 'Mail', sensitivity: 'secret' } },
+    })
+    const desc = c.describe()
+    const mail = desc.fields.find((f) => f.key === 'mail')!
+    expect(mail.sensitivity).toBe('secret')
+    expect(mail.classified?.preset).toBe('email')
+  })
 })


### PR DESCRIPTION
## What

Completes #571 — the remaining record exporters adopt the `redact` option via the stage-1 seam (`describe()` + `applyListProjection`, zero bespoke redaction logic), mirroring the merged as-csv recipe:

- **as-json / as-ndjson / as-sql / as-xml**: `redact?: boolean | { sensitivity: 'omit' | 'mask' }`, projection before column/element derivation (omitted fields vanish structurally — verified down to as-sql's CREATE TABLE + INSERT lists), doc comments with the session-declaration and '[sealed]' caveats + rider-columns note, mask-PAN/omit-pii TDD pair each.
- **Deferred minors from the stage-1 final review**: hub regression test proving channel `fieldMeta` overrides classified-preset sensitivity; as-xlsx multi-vault `redact` test (asserts the non-opted entry stays sealed); rider-column doc notes in as-csv/as-xlsx; classified barrel added to knip entries (7 false positives gone, nothing new).

Closes #571.

## How it was built

Four exporter implementations ran as parallel agents against disjoint packages, plus a minors agent; integrated sequentially with a cross-package consistency review (option types, guard conditions, describe() amortization verified textually parallel across all six exporters).

## Verification

Full `turbo test --concurrency=1`: **110/110**; architecture invariants green; per-package lint+typecheck clean; knip delta verified (classified false positives eliminated, exit-1 backlog unchanged).