### PR TITLE
fix: #554 small follow-ups — dedicated _det key (L-1) + loadFanoutSidecar error-swallow

### DIFF
--- a/packages/hub/__tests__/derivations/fanout-sidecar-encryption.test.ts
+++ b/packages/hub/__tests__/derivations/fanout-sidecar-encryption.test.ts
@@ -148,4 +148,40 @@ describe('M-3 — fanout sidecar encryption', () => {
     const loaded = await loadFanoutSidecar(store, 'v', 'docs', 'd1', 'tagRows', getDEK, true)
     expect(loaded?.keys).toEqual(['x', 'y'])
   })
+
+  // #554: a genuinely absent sidecar must still resolve to `undefined`
+  // (orphan cleanup correctly no-ops), but a PRESENT-and-corrupt one must
+  // NOT be conflated with absence — it must surface, not silently skip
+  // orphan-row deletion.
+  it('unit: absent sidecar (no envelope at all) resolves to undefined, no throw', async () => {
+    const { store } = memoryWithData()
+    const dek = await generateDEK()
+    const getDEK = async () => dek
+    const loaded = await loadFanoutSidecar(store, 'v', 'docs', 'nonexistent', 'tagRows', getDEK, true)
+    expect(loaded).toBeUndefined()
+  })
+
+  it('unit: a present but undecryptable sidecar (wrong DEK) throws instead of silently returning undefined', async () => {
+    const { store } = memoryWithData()
+    const dek = await generateDEK()
+    const wrongDek = await generateDEK()
+    await saveFanoutSidecar(store, 'v', { source: 'docs', sourceId: 'd1', outputKey: 'tagRows', outputCollection: 'docTags', keys: ['a', 'b'] }, async () => dek, true)
+    await expect(
+      loadFanoutSidecar(store, 'v', 'docs', 'd1', 'tagRows', async () => wrongDek, true),
+    ).rejects.toThrow()
+  })
+
+  it('unit: a present but unparseable ciphertext-body sidecar (corrupt JSON post-decrypt) throws', async () => {
+    const { store } = memoryWithData()
+    const dek = await generateDEK()
+    const getDEK = async () => dek
+    // A plaintext (`_iv === ''`) envelope skips decryption entirely, so
+    // corrupting `_data` directly exercises the JSON.parse failure path.
+    await store.put('v', '_meta', 'derivations-fanout/docs/d1/tagRows', {
+      _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: new Date().toISOString(), _iv: '', _data: 'not valid json{{{',
+    } as EncryptedEnvelope)
+    await expect(
+      loadFanoutSidecar(store, 'v', 'docs', 'd1', 'tagRows', getDEK, true),
+    ).rejects.toThrow()
+  })
 })

--- a/packages/hub/__tests__/det-dedicated-key.test.ts
+++ b/packages/hub/__tests__/det-dedicated-key.test.ts
@@ -1,0 +1,191 @@
+/**
+ * L-1 (#554): the deterministic `_det` index must NOT encrypt under the raw
+ * collection DEK — that puts two IV regimes (randomized `_data`, deterministic
+ * `_det`) on one key. `_det` now encrypts under a dedicated HKDF-derived key
+ * (`deriveDeterministicKey`, salt `noydb-det`), still DEK-derived so the index
+ * stays collection-level and rotation-stable (CEK rotation carries `_det`
+ * verbatim). Back-compat: `findByDet`/`queryByDet` dual-query the new AND the
+ * legacy raw-DEK target so pre-migration envelopes remain findable; they
+ * self-heal to the new key on their next write.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  encryptDeterministic,
+  deriveDeterministicKey,
+  type EnclaveKey,
+} from '../src/kernel/enclave/index.js'
+import { createNoydb } from '../src/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
+import { ConflictError } from '../src/index.js'
+
+interface User {
+  id: string
+  name: string
+  email: string
+}
+
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll(v, snap) {
+      const vm = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [cn, recs] of Object.entries(snap)) {
+        const cm = new Map<string, EncryptedEnvelope>()
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+        vm.set(cn, cm)
+      }
+      data.set(v, vm)
+    },
+  }
+}
+
+/** Reach the collection's private DEK resolver (test-only, runtime field). */
+function collectionDek(coll: unknown, name: string): Promise<EnclaveKey> {
+  const c = coll as { getDEK(collectionName: string): Promise<EnclaveKey> }
+  return c.getDEK(name)
+}
+
+async function setup() {
+  const store = memoryStore()
+  const db = await createNoydb({ store, secret: 'pw', user: 'owner' })
+  const v = await db.openVault('v1')
+  const users = v.collection<User>('users', {
+    deterministicFields: ['email'],
+    acknowledgeDeterministicRisk: true,
+  })
+  return { store, users }
+}
+
+describe('L-1 — _det encrypts under a dedicated HKDF key, not the raw DEK', () => {
+  it('preserves determinism: same value → same _det slot across two writes', async () => {
+    const { store, users } = await setup()
+    await users.put('u1', { id: 'u1', name: 'Alice', email: 'alice@example.com' })
+    await users.put('u2', { id: 'u2', name: 'Alt', email: 'alice@example.com' })
+    await users.put('u3', { id: 'u3', name: 'Bob', email: 'bob@example.com' })
+
+    const a1 = (await store.get('v1', 'users', 'u1'))!._det!.email
+    const a2 = (await store.get('v1', 'users', 'u2'))!._det!.email
+    const b = (await store.get('v1', 'users', 'u3'))!._det!.email
+    expect(a1).toBe(a2)
+    expect(a1).not.toBe(b)
+  })
+
+  it('finds freshly-written records via findByDet and queryByDet', async () => {
+    const { users } = await setup()
+    await users.put('u1', { id: 'u1', name: 'Alice', email: 'alice@example.com' })
+    await users.put('u2', { id: 'u2', name: 'Bob', email: 'bob@example.com' })
+
+    expect(await users.findByDet('email', 'bob@example.com')).toMatchObject({ id: 'u2' })
+    expect(await users.findByDet('email', 'nobody@example.com')).toBeNull()
+    const hits = await users.queryByDet('email', 'alice@example.com')
+    expect(hits.map((u) => u.id)).toEqual(['u1'])
+  })
+
+  it('domain separation: _det is NOT the raw-DEK deterministic ciphertext (and IS the derived-key one)', async () => {
+    const { store, users } = await setup()
+    await users.put('u1', { id: 'u1', name: 'Alice', email: 'alice@example.com' })
+
+    const dek = await collectionDek(users, 'users')
+    const stored = (await store.get('v1', 'users', 'u1'))!._det!.email
+
+    // What the pre-fix raw-DEK regime would have stamped:
+    const legacy = await encryptDeterministic('alice@example.com', dek, 'users/email')
+    expect(stored).not.toBe(`${legacy.iv}:${legacy.data}`)
+
+    // What the dedicated derived key stamps — proves the write side switched keys:
+    const detKey = await deriveDeterministicKey(dek)
+    const fresh = await encryptDeterministic('alice@example.com', detKey, 'users/email')
+    expect(stored).toBe(`${fresh.iv}:${fresh.data}`)
+  })
+
+  it('deriveDeterministicKey is deterministic per DEK', async () => {
+    const { users } = await setup()
+    const dek = await collectionDek(users, 'users')
+    const k1 = await deriveDeterministicKey(dek)
+    const k2 = await deriveDeterministicKey(dek)
+    const a = await encryptDeterministic('x', k1, 'users/email')
+    const b = await encryptDeterministic('x', k2, 'users/email')
+    expect(a.iv).toBe(b.iv)
+    expect(a.data).toBe(b.data)
+  })
+
+  it('BACK-COMPAT: a legacy raw-DEK _det slot is still findable via dual-query', async () => {
+    const { store, users } = await setup()
+    await users.put('u1', { id: 'u1', name: 'Alice', email: 'alice@example.com' })
+
+    // Rewrite u1's _det slot to the PRE-MIGRATION form: deterministic
+    // encryption under the raw collection DEK (what the old write path stamped).
+    const dek = await collectionDek(users, 'users')
+    const legacy = await encryptDeterministic('alice@example.com', dek, 'users/email')
+    const env = (await store.get('v1', 'users', 'u1'))!
+    await store.put('v1', 'users', 'u1', {
+      ...env,
+      _det: { ...env._det, email: `${legacy.iv}:${legacy.data}` },
+    })
+
+    expect(await users.findByDet('email', 'alice@example.com')).toMatchObject({ id: 'u1' })
+    const hits = await users.queryByDet('email', 'alice@example.com')
+    expect(hits.map((u) => u.id)).toEqual(['u1'])
+  })
+
+  it('BACK-COMPAT: queryByDet returns legacy and new envelopes together for one value', async () => {
+    const { store, users } = await setup()
+    await users.put('u1', { id: 'u1', name: 'Alice', email: 'shared@example.com' })
+    await users.put('u2', { id: 'u2', name: 'Alt', email: 'shared@example.com' })
+
+    // Downgrade only u1 to the legacy raw-DEK stamp; u2 keeps the new-key stamp.
+    const dek = await collectionDek(users, 'users')
+    const legacy = await encryptDeterministic('shared@example.com', dek, 'users/email')
+    const env = (await store.get('v1', 'users', 'u1'))!
+    await store.put('v1', 'users', 'u1', {
+      ...env,
+      _det: { ...env._det, email: `${legacy.iv}:${legacy.data}` },
+    })
+
+    const hits = await users.queryByDet('email', 'shared@example.com')
+    expect(hits.map((u) => u.id).sort()).toEqual(['u1', 'u2'])
+  })
+
+  it('legacy envelope self-heals to the new key on its next write', async () => {
+    const { store, users } = await setup()
+    await users.put('u1', { id: 'u1', name: 'Alice', email: 'alice@example.com' })
+
+    const dek = await collectionDek(users, 'users')
+    const legacy = await encryptDeterministic('alice@example.com', dek, 'users/email')
+    const env = (await store.get('v1', 'users', 'u1'))!
+    await store.put('v1', 'users', 'u1', {
+      ...env,
+      _det: { ...env._det, email: `${legacy.iv}:${legacy.data}` },
+    })
+
+    // Next write restamps _det under the dedicated key.
+    await users.put('u1', { id: 'u1', name: 'Alice v2', email: 'alice@example.com' })
+    const detKey = await deriveDeterministicKey(dek)
+    const fresh = await encryptDeterministic('alice@example.com', detKey, 'users/email')
+    const healed = (await store.get('v1', 'users', 'u1'))!._det!.email
+    expect(healed).toBe(`${fresh.iv}:${fresh.data}`)
+  })
+})

--- a/packages/hub/__tests__/enclave-surface.golden.json
+++ b/packages/hub/__tests__/enclave-surface.golden.json
@@ -12,6 +12,7 @@
     "decryptBytes",
     "decryptBytesWithAAD",
     "decryptDeterministic",
+    "deriveDeterministicKey",
     "deriveKey",
     "derivePassphraseKey",
     "derivePresenceKey",

--- a/packages/hub/src/kernel/enclave/crypto.ts
+++ b/packages/hub/src/kernel/enclave/crypto.ts
@@ -613,6 +613,52 @@ export async function deriveSealedFieldKeyFromCek(
 // ─── Deterministic Encryption ────────────────────────────
 
 /**
+ * Derive the collection's **dedicated deterministic-index key** from its DEK
+ * via HKDF-SHA256 (L-1, #554).
+ *
+ * `_det` slots previously encrypted under the raw collection DEK — the same
+ * key `_data` uses with a *randomized*-IV regime while `_det` uses a
+ * *deterministic*-IV regime. Two IV regimes on one key is avoidable hygiene
+ * debt (~2^-96 theoretical collision), so the deterministic index now gets its
+ * own HKDF-separated key: salt `'noydb-det'`, info
+ * `JSON.stringify(['noydb-det'])` (the injective JSON-array domain tag, same
+ * convention as {@link deriveSealedFieldKey}). Per-field separation still
+ * comes from the `'<collection>/<field>'` context inside
+ * {@link encryptDeterministic}, exactly as before.
+ *
+ * The derived key stays **DEK-derived (collection-level)** on purpose: `_det`
+ * is carried verbatim through per-record CEK rotation (see
+ * `record-keys/sealing.ts`), so its key must not depend on the CEK. It rotates
+ * with the collection DEK, like the presence key.
+ *
+ * The key is minted **extractable** — {@link encryptDeterministic} derives its
+ * per-value IV via HKDF over the raw key bytes (an `exportKey` under the
+ * hood), which a non-extractable key would forbid. Same in-memory posture as
+ * the DEK itself (`generateDEK` mints extractable keys).
+ *
+ * @param dek The collection's AES-256-GCM DEK (extractable).
+ * @returns A dedicated AES-256-GCM key for the `_det` deterministic index.
+ */
+export async function deriveDeterministicKey(dek: CryptoKey): Promise<CryptoKey> {
+  const rawDek = await subtle.exportKey('raw', dek)
+  const hkdfKey = await subtle.importKey('raw', rawDek, 'HKDF', false, ['deriveBits'])
+  const salt = new TextEncoder().encode('noydb-det')
+  const info = new TextEncoder().encode(JSON.stringify(['noydb-det']))
+  const bits = await subtle.deriveBits(
+    { name: 'HKDF', hash: 'SHA-256', salt, info },
+    hkdfKey,
+    KEY_BITS,
+  )
+  return subtle.importKey(
+    'raw',
+    bits,
+    { name: 'AES-GCM', length: KEY_BITS },
+    true,
+    ['encrypt', 'decrypt'],
+  )
+}
+
+/**
  * Derive a deterministic 12-byte IV from `{ DEK, context, plaintext }`
  * via HKDF-SHA256. Given the same three inputs, the IV is identical, so
  * `encryptDeterministic` produces the same ciphertext on every call —

--- a/packages/hub/src/kernel/enclave/index.ts
+++ b/packages/hub/src/kernel/enclave/index.ts
@@ -79,6 +79,7 @@ export {
   bufferToBase64,
   base64ToBuffer,
   derivePresenceKey,
+  deriveDeterministicKey,
   deriveSealedFieldKey,
   deriveSealedFieldKeyFromCek,
   wrapCek,

--- a/packages/hub/src/kernel/enclave/record-keys/deterministic.ts
+++ b/packages/hub/src/kernel/enclave/record-keys/deterministic.ts
@@ -15,7 +15,7 @@
  *
  * Internal service — not exported as a `@noy-db/hub/*` subpath.
  */
-import { encryptDeterministic, type EnclaveKey } from '../crypto.js'
+import { encryptDeterministic, deriveDeterministicKey, type EnclaveKey } from '../crypto.js'
 import type { NoydbStore } from '../../types.js'
 import type { RecordCodec } from './record-codec.js'
 
@@ -37,12 +37,25 @@ export interface DeterministicContext<T> {
   readonly codec: RecordCodec<T>
 }
 
-/** Recompute the deterministic ciphertext target for a query value. */
-async function detTarget<T>(ctx: DeterministicContext<T>, field: string, value: unknown): Promise<string> {
+/**
+ * Recompute the deterministic ciphertext targets for a query value.
+ *
+ * L-1: _det migrated to a dedicated HKDF key (salt noydb-det); dual-query
+ * keeps pre-migration envelopes findable — they self-heal to the new key on
+ * their next write. Index 0 is the current (derived-key) target, index 1 the
+ * legacy raw-DEK target. Both are derived once per query call, not per
+ * envelope, so the extra derivation is a fixed cost.
+ */
+async function detTargets<T>(ctx: DeterministicContext<T>, field: string, value: unknown): Promise<[string, string]> {
   const dek = await ctx.getDEK()
+  const detKey = await deriveDeterministicKey(dek)
   const plaintext = typeof value === 'string' ? value : JSON.stringify(value)
-  const { iv, data } = await encryptDeterministic(plaintext, dek, `${ctx.name}/${field}`)
-  return `${iv}:${data}`
+  const context = `${ctx.name}/${field}`
+  const [current, legacy] = await Promise.all([
+    encryptDeterministic(plaintext, detKey, context),
+    encryptDeterministic(plaintext, dek, context),
+  ])
+  return [`${current.iv}:${current.data}`, `${legacy.iv}:${legacy.data}`]
 }
 
 function assertDetField<T>(ctx: DeterministicContext<T>, field: string, method: string): void {
@@ -71,13 +84,13 @@ function assertDetField<T>(ctx: DeterministicContext<T>, field: string, method: 
  */
 export async function findByDet<T>(ctx: DeterministicContext<T>, field: string, value: unknown): Promise<T | null> {
   assertDetField(ctx, field, 'findByDet')
-  const target = await detTarget(ctx, field, value)
+  const [target, legacyTarget] = await detTargets(ctx, field, value)
 
   const ids = await ctx.adapter.list(ctx.vault, ctx.name)
   for (const id of ids) {
     const env = await ctx.adapter.get(ctx.vault, ctx.name, id)
     if (!env || !env._det) continue
-    if (env._det[field] === target) {
+    if (env._det[field] === target || env._det[field] === legacyTarget) {
       return ctx.codec.decryptRecord(env)
     }
   }
@@ -90,14 +103,14 @@ export async function findByDet<T>(ctx: DeterministicContext<T>, field: string, 
  */
 export async function queryByDet<T>(ctx: DeterministicContext<T>, field: string, value: unknown): Promise<T[]> {
   assertDetField(ctx, field, 'queryByDet')
-  const target = await detTarget(ctx, field, value)
+  const [target, legacyTarget] = await detTargets(ctx, field, value)
 
   const ids = await ctx.adapter.list(ctx.vault, ctx.name)
   const matches: T[] = []
   for (const id of ids) {
     const env = await ctx.adapter.get(ctx.vault, ctx.name, id)
     if (!env || !env._det) continue
-    if (env._det[field] === target) {
+    if (env._det[field] === target || env._det[field] === legacyTarget) {
       const rec = await ctx.codec.decryptRecord(env)
       if (rec !== null) matches.push(rec) // skip tombstone (defensive)
     }

--- a/packages/hub/src/kernel/enclave/record-keys/record-codec.ts
+++ b/packages/hub/src/kernel/enclave/record-keys/record-codec.ts
@@ -16,7 +16,7 @@
  *
  * Internal service — not exported as a `@noy-db/hub/*` subpath.
  */
-import { encrypt, decrypt, encryptDeterministic, wrapCek, unwrapCek, deriveSealedFieldKey, deriveSealedFieldKeyFromCek, type EnclaveKey } from '../crypto.js'
+import { encrypt, decrypt, encryptDeterministic, deriveDeterministicKey, wrapCek, unwrapCek, deriveSealedFieldKey, deriveSealedFieldKeyFromCek, type EnclaveKey } from '../crypto.js'
 import { NOYDB_FORMAT_VERSION, SealedHandle, type EncryptedEnvelope, type CrdtMode, type CrdtState, type CrdtStrategy, type VdigFieldPolicy } from '../../types.js'
 import { isTombstone } from './tombstone.js'
 import { parseSealedSlot, dualReadSealedSlot } from './sealed-slot.js'
@@ -292,7 +292,11 @@ export class RecordCodec<T> {
     // declared field. Non-primitive values are JSON-stringified so
     // objects/arrays still dedupe on structural equality. Sealed fields are
     // excluded — they live only in `_sealed`, never the `_det` index.
+    // L-1: `_det` encrypts under a dedicated HKDF-derived key (salt
+    // `noydb-det`), never the raw DEK — the DEK's randomized-IV `_data`
+    // regime and `_det`'s deterministic-IV regime must not share a key.
     const dek = await this.ctx.getDEK()
+    const detKey = await deriveDeterministicKey(dek)
     const rec = record as unknown as Record<string, unknown>
     const det: Record<string, string> = {}
     for (const field of this.ctx.deterministicFields) {
@@ -301,7 +305,7 @@ export class RecordCodec<T> {
       const value = rec[field]
       if (value === undefined || value === null) continue
       const plaintext = typeof value === 'string' ? value : JSON.stringify(value)
-      const { iv, data } = await encryptDeterministic(plaintext, dek, `${this.ctx.name}/${field}`)
+      const { iv, data } = await encryptDeterministic(plaintext, detKey, `${this.ctx.name}/${field}`)
       det[field] = `${iv}:${data}`
     }
     if (Object.keys(det).length === 0) return withVdig

--- a/packages/hub/src/with-formula/derivations/fanout-sidecar.ts
+++ b/packages/hub/src/with-formula/derivations/fanout-sidecar.ts
@@ -64,7 +64,18 @@ function recordId(source: string, sourceId: string, outputKey: string): string {
 }
 
 /**
- * Read the sidecar; returns empty if absent.
+ * Read the sidecar; returns `undefined` only when it's legitimately absent
+ * (no envelope at that id) — the correct signal for callers to skip
+ * orphan-row reconciliation because there's nothing to reconcile against.
+ *
+ * A PRESENT envelope that fails to decrypt or parse is a data-integrity
+ * problem, not an absence, and is deliberately NOT caught here: swallowing
+ * it to `undefined` would look identical to "no sidecar" and make callers
+ * (the array-derivation dispatch in `vault.ts`/`collection.ts`) silently
+ * skip deleting stale derived rows on a shrink. Let `openEnvelopeJson`'s
+ * `DecryptionError`/`TamperedError` and `JSON.parse` failures propagate,
+ * matching the no-catch convention of sibling decrypt call-sites (e.g.
+ * `with-audit/consent/consent.ts`'s `decryptEntry`).
  *
  * Dual-reads for back-compat: an envelope with `_iv === ''` is a legacy
  * plaintext sidecar (parse `_data` directly); otherwise the body was
@@ -81,18 +92,14 @@ export async function loadFanoutSidecar(
 ): Promise<FanoutSidecar | undefined> {
   const envelope = await store.get(vault, '_meta', recordId(source, sourceId, outputKey))
   if (!envelope) return undefined
-  try {
-    // Legacy plaintext (`_iv === ''`) reads directly; encrypted bodies decrypt.
-    const json = (!encrypted || envelope._iv === '')
-      ? envelope._data
-      : await openEnvelopeJson(envelope, await getDEK(FANOUT_DEK_COLLECTION))
-    const parsed = JSON.parse(json) as FanoutSidecar
-    if (parsed._noydb_fanout !== 1) return undefined
-    if (!Array.isArray(parsed.keys)) return undefined
-    return parsed
-  } catch {
-    return undefined
-  }
+  // Legacy plaintext (`_iv === ''`) reads directly; encrypted bodies decrypt.
+  const json = (!encrypted || envelope._iv === '')
+    ? envelope._data
+    : await openEnvelopeJson(envelope, await getDEK(FANOUT_DEK_COLLECTION))
+  const parsed = JSON.parse(json) as FanoutSidecar
+  if (parsed._noydb_fanout !== 1) return undefined
+  if (!Array.isArray(parsed.keys)) return undefined
+  return parsed
 }
 
 /**


### PR DESCRIPTION
Two small correctness/hardening items from #554, sized to ride the next release.

## L-1 (security hygiene) — `_det` gets a dedicated HKDF key
The deterministic `_det` index encrypted under the **raw collection DEK** — the same key `_data` uses with a randomized-IV regime, while `_det` uses a deterministic-IV regime (two IV regimes on one key; ~2⁻⁹⁶ theoretical, avoidable). Now `_det` derives a dedicated key via HKDF-SHA256 (salt `noydb-det`), disjoint from the DEK and every sibling derivation.

- **Back-compat (dual-query):** `findByDet`/`queryByDet` match against both the new-key target and the legacy raw-DEK target, so pre-migration envelopes stay findable; they self-heal to the new key on their next write. Derived once per query call, not per envelope.
- **Rotation-stable:** the det key is DEK-derived (collection-level), so `_det` carried verbatim through `rotateRecordCek` stays valid — unchanged from before.
- Reviewed by an adversarial crypto pass: domain separation clean, no dual-query false-positive path (independent HKDF keys + GCM), extractable-key posture matches the DEK it derives from (required because `encryptDeterministic` exports raw key bytes for its IV), additive enclave-barrel/golden. One info note: salt `noydb-det` is a string *prefix* of the IV salt `noydb-deterministic-v1` — confirmed harmless (independent HMAC keys), flagged so it isn't "cleaned up" into a real collision later.

## loadFanoutSidecar — stop swallowing corrupt-sidecar errors
`loadFanoutSidecar` caught decrypt/parse errors and returned `undefined`, conflating a **corrupt** sidecar with an **absent** one — so an undecryptable sidecar silently skipped orphan-row cleanup on an array-derivation shrink, leaking stale derived rows. Now: absent → `undefined` (unchanged); present-but-undecryptable/unparseable → the error propagates (matching the no-catch convention of sibling decrypt sites). All three callers verified to treat `undefined` as "nothing to reconcile"; an empty sidecar still parses cleanly.

## Verification
128/128 across the deterministic + derivations suites (7 new det tests incl. determinism, findability, domain separation, dual-query back-compat, self-heal; 3 new fanout tests incl. absent→undefined, wrong-DEK→throws, corrupt-JSON→throws); typecheck, lint, check:architecture green.

Partially addresses #554 (the A12 putInternal item stays parked as recommended).