### PR TITLE
ci: re-parallelize the test job (#564)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,12 +149,21 @@ jobs:
           restore-keys: ${{ runner.os }}-turbo-
       - name: Build
         run: pnpm turbo build
-      # Concurrency=1 avoids cross-package temp-dir / port collisions
-      # that surfaced with the default parallel runner. Each package's
-      # test suite is fast on its own; serializing them adds < 1 minute
-      # to the matrix wall time.
-      - name: Test
-        run: pnpm turbo test --concurrency=1
+      # Two-phase test schedule (#564). The historical --concurrency=1
+      # guarded against cross-package collisions, but an empirical sweep
+      # found none: suites already use fs.mkdtemp-style unique dirs and no
+      # fixed ports. What DOES exist is CPU contention — hub (~400 test
+      # files, the box's dominant consumer) starving wall-clock-sensitive
+      # tests in whatever runs beside it. So: hub runs ALONE with the full
+      # runner (its vitest workers parallelize internally), then the
+      # satellites run at --concurrency=4 (matched to the 4-vCPU runner).
+      # The recurring in-pinia TamperedError flake was a real hub race
+      # (concurrent openVault() building two key-divergent Vaults) — fixed
+      # at the root by the single-flight memo in kernel/noydb.ts.
+      - name: Test (hub)
+        run: pnpm turbo test --filter=@noy-db/hub
+      - name: Test (satellites)
+        run: pnpm turbo test --filter='!@noy-db/hub' --concurrency=4
 
   # ── Interop moved to the pre-publish gate ────────────────────────────
   # The cross-OS WinZip-AES-256 interop matrix (ubuntu/macOS/windows +

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,8 +138,11 @@ jobs:
 
       # HARD GATE: unlike dev CI, a failing test here BLOCKS the publish
       # (this is the last line of defence before npm), on both node 22 + 24.
-      - name: Test
-        run: pnpm turbo test --concurrency=1
+      # Two-phase schedule matches dev CI (#564) — kept in lockstep per cbf07ea4.
+      - name: Test (hub)
+        run: pnpm turbo test --filter=@noy-db/hub
+      - name: Test (satellites)
+        run: pnpm turbo test --filter='!@noy-db/hub' --concurrency=4
 
       - name: Verify package.json versions match release tag
         if: github.event_name == 'release'

--- a/packages/at-aws-kms/__tests__/at-aws-kms.test.ts
+++ b/packages/at-aws-kms/__tests__/at-aws-kms.test.ts
@@ -89,7 +89,9 @@ describe('@noy-db/at-aws-kms — integration with @noy-db/hub managed-passphrase
     const note = await vault2.collection<{ id: string; note: string }>('notes').get('n1')
     expect(note).toEqual({ id: 'n1', note: 'managed-mode write via at-aws-kms' })
     db2.close()
-  })
+    // 30s timeout (#564): two full managed-mode opens (600K-PBKDF2 × several)
+    // sit near the 5s vitest default when parallel suites compete for CPU.
+  }, 30_000)
 })
 
 const RUN_REAL = !!process.env.NOYDB_TEST_AWS_KMS_KEY_ID

--- a/packages/at-azure-keyvault/__tests__/at-azure-keyvault.test.ts
+++ b/packages/at-azure-keyvault/__tests__/at-azure-keyvault.test.ts
@@ -99,7 +99,9 @@ describe('@noy-db/at-azure-keyvault — integration with @noy-db/hub managed-pas
     )
     expect(note).toEqual({ id: 'n1', note: 'managed-mode write via at-azure-keyvault' })
     db2.close()
-  })
+    // 30s timeout (#564): two full managed-mode opens (600K-PBKDF2 × several)
+    // sit near the 5s vitest default when parallel suites compete for CPU.
+  }, 30_000)
 })
 
 const RUN_REAL = !!process.env.NOYDB_TEST_AZURE_KEY_ID

--- a/packages/at-env/__tests__/at-env.test.ts
+++ b/packages/at-env/__tests__/at-env.test.ts
@@ -102,6 +102,9 @@ describe('@noy-db/at-env — integration with @noy-db/hub managed-passphrase mod
   beforeEach(() => { process.env[TEST_ENV] = TEST_KEY_BASE64 })
   afterEach(() => { delete process.env[TEST_ENV] })
 
+  // 30s timeout (#564): two full managed-mode opens = several 600K-PBKDF2
+  // derivations plus first-import transform of three packages — legitimately
+  // near the 5s vitest default when parallel suites compete for CPU.
   it('round-trips a managed-mode vault end-to-end (no user passphrase typed)', async () => {
     const { createNoydb } = await import('@noy-db/hub')
     const { memory } = await import('@noy-db/to-memory')
@@ -138,5 +141,5 @@ describe('@noy-db/at-env — integration with @noy-db/hub managed-passphrase mod
     const note = await vault2.collection<{ id: string; note: string }>('notes').get('n1')
     expect(note).toEqual({ id: 'n1', note: 'managed-mode write via at-env' })
     db2.close()
-  })
+  }, 30_000)
 })

--- a/packages/at-gcp-kms/__tests__/at-gcp-kms.test.ts
+++ b/packages/at-gcp-kms/__tests__/at-gcp-kms.test.ts
@@ -117,7 +117,9 @@ describe('@noy-db/at-gcp-kms — integration with @noy-db/hub managed-passphrase
     const note = await vault2.collection<{ id: string; note: string }>('notes').get('n1')
     expect(note).toEqual({ id: 'n1', note: 'managed-mode write via at-gcp-kms' })
     db2.close()
-  })
+    // 30s timeout (#564): two full managed-mode opens (600K-PBKDF2 × several)
+    // sit near the 5s vitest default when parallel suites compete for CPU.
+  }, 30_000)
 })
 
 const RUN_REAL = !!process.env.NOYDB_TEST_GCP_KMS_KEY_NAME

--- a/packages/at-macos-keychain/__tests__/integration.test.ts
+++ b/packages/at-macos-keychain/__tests__/integration.test.ts
@@ -66,7 +66,9 @@ describe('@noy-db/at-macos-keychain — integration with @noy-db/hub managed-pas
     const note = await vault2.collection<{ id: string; note: string }>('notes').get('n1')
     expect(note).toEqual({ id: 'n1', note: 'managed-mode write via at-macos-keychain' })
     db2.close()
-  })
+    // 30s timeout (#564): two full managed-mode opens (600K-PBKDF2 × several)
+    // sit near the 5s vitest default when parallel suites compete for CPU.
+  }, 30_000)
 
   it('a different (service, account) creates an isolated vault that cannot read the first', async () => {
     const store = memory()

--- a/packages/hub/__tests__/classified/ct-equal.test.ts
+++ b/packages/hub/__tests__/classified/ct-equal.test.ts
@@ -31,16 +31,32 @@ describe('blindedEqual (double-HMAC reduction)', () => {
     // HMAC cost is block-count granular (sub-µs per block); assert the 100x
     // length spread stays within a generous constant factor — a linear or
     // early-return regression blows well past it.
-    const N = 200
-    const time = async (a: Uint8Array, b: Uint8Array) => {
+    //
+    // Sampling is interleaved round-robin with per-class medians (#564): a
+    // single contiguous window per class is at the mercy of whatever CPU-
+    // contention burst lands inside it (concurrent CI suites, GC) — one such
+    // burst dilated the `short` window 13x. A spike now either hits all three
+    // classes of a round alike or is discarded by the median.
+    const ROUNDS = 10
+    const PER_ROUND = 20 // 10 × 20 = the same 200 total iterations per class
+    const timeOnce = async (a: Uint8Array, b: Uint8Array) => {
       const t0 = performance.now()
-      for (let i = 0; i < N; i++) await blindedEqual(a, b)
+      for (let i = 0; i < PER_ROUND; i++) await blindedEqual(a, b)
       return performance.now() - t0
     }
-    await time(bytes('warmup'), bytes('warmup'))
-    const short = await time(bytes('aa'), bytes('ab'))
-    const long = await time(bytes('x'.repeat(200)), bytes('y'.repeat(200)))
-    const mixed = await time(bytes('aa'), bytes('x'.repeat(200)))
+    const median = (xs: number[]) => [...xs].sort((p, q) => p - q)[Math.floor(xs.length / 2)]!
+    await timeOnce(bytes('warmup'), bytes('warmup'))
+    const shorts: number[] = []
+    const longs: number[] = []
+    const mixeds: number[] = []
+    for (let r = 0; r < ROUNDS; r++) {
+      shorts.push(await timeOnce(bytes('aa'), bytes('ab')))
+      longs.push(await timeOnce(bytes('x'.repeat(200)), bytes('y'.repeat(200))))
+      mixeds.push(await timeOnce(bytes('aa'), bytes('x'.repeat(200))))
+    }
+    const short = median(shorts)
+    const long = median(longs)
+    const mixed = median(mixeds)
     // Bidirectional: the short/long/mixed timings must stay within a
     // generous constant factor of each other, in either direction — a
     // regression that makes any of them disproportionately slow OR

--- a/packages/hub/__tests__/classified/verify-engine.test.ts
+++ b/packages/hub/__tests__/classified/verify-engine.test.ts
@@ -10,6 +10,15 @@ import { ClassifiedConfigError, ClassifiedVerifyError } from '../../src/kernel/e
 const pw: VdigFieldPolicy = { normalize: 'password', notLastN: 0 }
 const sa: VdigFieldPolicy = { normalize: 'secret-answer', notLastN: 0 }
 
+/** Wall-clock one call — used by the C4 timing-parity vectors. */
+async function timeOnce(fn: () => Promise<unknown>): Promise<number> {
+  const t0 = performance.now()
+  await fn()
+  return performance.now() - t0
+}
+/** Median — discards the contention-dilated outlier of a 3-sample class. */
+const medianOf = (xs: number[]): number => [...xs].sort((a, b) => a - b)[Math.floor(xs.length / 2)]!
+
 function ctxFor(env: EncryptedEnvelope | null, cek: CryptoKey | undefined, now = () => Date.now()): VerifyEngineCtx {
   return {
     collection: 'users',
@@ -76,12 +85,20 @@ describe('verifyDigestField', () => {
   it('C4 timing parity: missing record / missing slot cost within the wrong-candidate envelope', async () => {
     const cek = await generateDEK()
     const env = await envWith(cek, { password: { value: 'correct-horse-battery', policy: pw } })
-    const time = async (fn: () => Promise<unknown>) => {
-      const t0 = performance.now(); await fn(); return performance.now() - t0
+    // Interleaved median-of-3 per class (#564): a single sample is at the
+    // mercy of a CPU-contention burst from concurrently-running suites — one
+    // dilated sample flips a pairwise 0.4 ratio without any real regression.
+    const wrongs: number[] = []
+    const missingRecords: number[] = []
+    const missingSlots: number[] = []
+    for (let r = 0; r < 3; r++) {
+      wrongs.push(await timeOnce(() => verifyDigestField(ctxFor(env, cek), 'r1', 'password', 'wrong-password-!!', pw)))
+      missingRecords.push(await timeOnce(() => verifyDigestField(ctxFor(null, cek), 'r1', 'password', 'wrong-password-!!', pw)))
+      missingSlots.push(await timeOnce(() => verifyDigestField(ctxFor({ ...env, _vdig: {} }, cek), 'r1', 'password', 'wrong-password-!!', pw)))
     }
-    const wrong = await time(() => verifyDigestField(ctxFor(env, cek), 'r1', 'password', 'wrong-password-!!', pw))
-    const missingRecord = await time(() => verifyDigestField(ctxFor(null, cek), 'r1', 'password', 'wrong-password-!!', pw))
-    const missingSlot = await time(() => verifyDigestField(ctxFor({ ...env, _vdig: {} }, cek), 'r1', 'password', 'wrong-password-!!', pw))
+    const wrong = medianOf(wrongs)
+    const missingRecord = medianOf(missingRecords)
+    const missingSlot = medianOf(missingSlots)
     // The 600K PBKDF2 dominates (~100ms+); an unpadded miss returns in <5ms.
     expect(missingRecord).toBeGreaterThan(wrong * 0.4)
     expect(missingSlot).toBeGreaterThan(wrong * 0.4)
@@ -155,13 +172,23 @@ describe('verifyTextField', () => {
   it('C4 timing parity: present-correct / present-wrong / missing record / missing slot all pay the uniform pad', async () => {
     const cek = await generateDEK()
     const env = await sealedEnvWith(cek, 'ssn', 'sensitive-value-42')
-    const time = async (fn: () => Promise<unknown>) => {
-      const t0 = performance.now(); await fn(); return performance.now() - t0
+    // Interleaved median-of-3 per class (#564) — same rationale as the
+    // digest-path C4 vector above: one contention-dilated sample must not
+    // flip a pairwise ratio.
+    const corrects: number[] = []
+    const wrongs: number[] = []
+    const missingRecords: number[] = []
+    const missingSlots: number[] = []
+    for (let r = 0; r < 3; r++) {
+      corrects.push(await timeOnce(() => verifyTextField(ctxFor(env, cek), 'r1', 'ssn', 'sensitive-value-42', 'password')))
+      wrongs.push(await timeOnce(() => verifyTextField(ctxFor(env, cek), 'r1', 'ssn', 'wrong-value', 'password')))
+      missingRecords.push(await timeOnce(() => verifyTextField(ctxFor(null, cek), 'r1', 'ssn', 'wrong-value', 'password')))
+      missingSlots.push(await timeOnce(() => verifyTextField(ctxFor({ ...env, _sealed: {} }, cek), 'r1', 'ssn', 'wrong-value', 'password')))
     }
-    const correct = await time(() => verifyTextField(ctxFor(env, cek), 'r1', 'ssn', 'sensitive-value-42', 'password'))
-    const wrong = await time(() => verifyTextField(ctxFor(env, cek), 'r1', 'ssn', 'wrong-value', 'password'))
-    const missingRecord = await time(() => verifyTextField(ctxFor(null, cek), 'r1', 'ssn', 'wrong-value', 'password'))
-    const missingSlot = await time(() => verifyTextField(ctxFor({ ...env, _sealed: {} }, cek), 'r1', 'ssn', 'wrong-value', 'password'))
+    const correct = medianOf(corrects)
+    const wrong = medianOf(wrongs)
+    const missingRecord = medianOf(missingRecords)
+    const missingSlot = medianOf(missingSlots)
     // The unconditional 600K-PBKDF2 pad dominates (~100ms+); a path that skipped
     // it would return in <5ms. Pairwise generous bounds, same style as the
     // digest-path vector — every outcome must sit inside every other's envelope.

--- a/packages/hub/__tests__/open-vault-single-flight.test.ts
+++ b/packages/hub/__tests__/open-vault-single-flight.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Concurrent `openVault(name)` calls must converge on ONE Vault instance
+ * (#564). Before the single-flight memo, two callers racing past the
+ * `vaultCache` miss each constructed a Vault; their Collections then minted
+ * independent DEKs for the same store slice, so a record written through one
+ * failed decryption through the other with a spurious `TamperedError` — the
+ * recurring in-pinia CI flake (unhandled rejection from a background
+ * federation-re-bind `refresh()` racing an `add()`).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { inlineMemory } from './classified/harness.js'
+
+describe('openVault — single-flight per name', () => {
+  it('concurrent opens of the same name return the same Vault instance', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'u', secret: 'open-race-pw' })
+    const [v1, v2, v3] = await Promise.all([
+      db.openVault('same'),
+      db.openVault('same'),
+      db.openVault('same'),
+    ])
+    expect(v1).toBe(v2)
+    expect(v2).toBe(v3)
+  }, 60_000)
+
+  it('a write through one racing opener is readable through the other', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'u', secret: 'open-race-pw-2' })
+    const [va, vb] = await Promise.all([db.openVault('shared'), db.openVault('shared')])
+    type Row = { id: string; n: number }
+    const ca = va.collection<Row>('rows')
+    const cb = vb.collection<Row>('rows')
+    await ca.put('a', { id: 'a', n: 1 })
+    // Pre-fix this threw TamperedError: cb held a different DEK for 'rows'.
+    const listed = await cb.list()
+    expect(listed.map((r) => r.id)).toEqual(['a'])
+  }, 60_000)
+
+  it('different names still open independently', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'u', secret: 'open-race-pw-3' })
+    const [v1, v2] = await Promise.all([db.openVault('one'), db.openVault('two')])
+    expect(v1).not.toBe(v2)
+    expect(v1.name).toBe('one')
+    expect(v2.name).toBe('two')
+  }, 60_000)
+})

--- a/packages/hub/src/kernel/noydb.ts
+++ b/packages/hub/src/kernel/noydb.ts
@@ -155,6 +155,15 @@ export class Noydb {
   /** Pre-resolved `vault.user` API factory (mirrors `coordinationProvider` above). Public so `Vault` can call it. */
   readonly userApiFactory: UserApiFactory
   private readonly vaultCache = new Map<string, Vault>()
+  /**
+   * In-flight `openVault` promise per name — concurrent opens of the same
+   * vault must converge on ONE Vault instance. Without this, two callers
+   * racing past the `vaultCache` miss each construct a Vault (and later two
+   * Collections with independent DEKs for the same store slice), so a record
+   * written through one fails decryption through the other with a spurious
+   * `TamperedError` (#564).
+   */
+  private readonly vaultOpening = new Map<string, Promise<Vault>>()
   private readonly keyringCache = new Map<string, UnlockedKeyring>()
   private readonly syncEngines = new Map<string, SyncEngine>()
   /**
@@ -499,6 +508,13 @@ export class Noydb {
     this.touchPolicy(name)
 
     let comp = this.vaultCache.get(name)
+    if (!comp) {
+      // Serialize concurrent opens of the same name (#564): the loser of the
+      // race awaits the winner's construction instead of building a second,
+      // key-divergent Vault for the same store slice.
+      const pending = this.vaultOpening.get(name)
+      if (pending) comp = await pending
+    }
     if (comp) {
       // Update locale on existing cached vault if specified
       if (opts?.locale !== undefined) {
@@ -507,6 +523,20 @@ export class Noydb {
       return comp
     }
 
+    const opening = this.#openVaultFresh(name, opts)
+    this.vaultOpening.set(name, opening)
+    try {
+      return await opening
+    } finally {
+      this.vaultOpening.delete(name)
+    }
+  }
+
+  /** Uncached single-flight body of {@link openVault} — see `vaultOpening`. */
+  async #openVaultFresh(
+    name: string,
+    opts?: { locale?: string; create?: boolean; meta?: VaultMeta },
+  ): Promise<Vault> {
     const keyring = await this._getKeyringInternal(name, { create: opts?.create !== false })
     // Tier-1 unlock — passphrase / getKeyring callbacks both yield the
     // most-privileged tier. Tier-2 / tier-3 unlocks install
@@ -559,7 +589,7 @@ export class Noydb {
       }
     }
 
-    comp = new Vault({
+    const comp = new Vault({
       adapter: this.options.store,
       name,
       noydb: this,

--- a/packages/in-nuxt/__tests__/rest-runtime.test.ts
+++ b/packages/in-nuxt/__tests__/rest-runtime.test.ts
@@ -28,6 +28,9 @@ function makeEvent(opts: Partial<FakeH3Event> & { context?: Record<string, unkno
 }
 
 describe('runtime/rest handler', () => {
+  // 30s timeout (#564): the FIRST test in the file pays the whole dynamic
+  // `import('../src/runtime/rest.js')` transform cost, which can exceed the
+  // 5s vitest default when parallel package suites compete for CPU.
   it('returns 500 noydb_store_not_configured when store is absent', async () => {
     const mod = await import('../src/runtime/rest.js')
     const handler = mod.default as (event: FakeH3Event) => Promise<Response>
@@ -37,7 +40,7 @@ describe('runtime/rest handler', () => {
     expect(res.status).toBe(500)
     const body = await res.json() as { error: string }
     expect(body.error).toBe('noydb_store_not_configured')
-  })
+  }, 30_000)
 
   it('reads config from event.context.nitro.runtimeConfig (canonical Nitro path)', async () => {
     const mod = await import('../src/runtime/rest.js')

--- a/packages/on-oidc/__tests__/on-oidc.test.ts
+++ b/packages/on-oidc/__tests__/on-oidc.test.ts
@@ -280,9 +280,15 @@ describe('enrollOidc + unlockOidc round-trip', () => {
 
     const enrollment = await enrollOidc(keyring, 'company-a', TEST_CONFIG, token)
 
-    // Use a fresh token (same sub, still valid)
-    const unlockToken = makeIdToken({ sub })
-    const unlocked = await unlockOidc(enrollment, TEST_CONFIG, unlockToken)
+    // Reuse the SAME token for unlock (#564). The transport key is
+    // HKDF(raw token string) and this replay-mock returns the enroll-time
+    // ciphertext verbatim, so unlock only decrypts when the token bytes
+    // match. Minting a second token here worked only when both mints landed
+    // in the same wall-clock second (iat is second-granular) — a 1-in-N
+    // flake. A REAL key connector decrypts on PUT and re-encrypts per GET
+    // (see enrollOidc's transport-encryption comment), which is what makes
+    // fresh-token unlocks work in production.
+    const unlocked = await unlockOidc(enrollment, TEST_CONFIG, token)
 
     expect(unlocked.userId).toBe('alice')
     expect(unlocked.displayName).toBe('Alice')
@@ -300,7 +306,9 @@ describe('enrollOidc + unlockOidc round-trip', () => {
     vi.stubGlobal('fetch', mockFetch)
 
     const enrollment = await enrollOidc(keyring, 'company-a', TEST_CONFIG, token)
-    const unlocked = await unlockOidc(enrollment, TEST_CONFIG, makeIdToken({ sub }))
+    // Same token for unlock — the replay-mock requires byte-identical
+    // transport keys (see the round-trip test above, #564).
+    const unlocked = await unlockOidc(enrollment, TEST_CONFIG, token)
 
     const dek = unlocked.deks.get('invoices')!
     const iv = globalThis.crypto.getRandomValues(new Uint8Array(12))
@@ -316,8 +324,11 @@ describe('enrollOidc + unlockOidc round-trip', () => {
     const mockFetch = makeKeyConnectorMock()
     vi.stubGlobal('fetch', mockFetch)
 
-    await enrollOidc(keyring, 'company-a', TEST_CONFIG, makeIdToken({ sub }))
-    const unlocked = await unlockOidc(enrollment_placeholder(), TEST_CONFIG, makeIdToken({ sub }))
+    // One token for both — the replay-mock requires byte-identical
+    // transport keys (see the round-trip test above, #564).
+    const token = makeIdToken({ sub })
+    await enrollOidc(keyring, 'company-a', TEST_CONFIG, token)
+    const unlocked = await unlockOidc(enrollment_placeholder(), TEST_CONFIG, token)
     expect(unlocked.permissions).toEqual({ invoices: 'rw', clients: 'rw' })
 
     function enrollment_placeholder() {

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -883,7 +883,10 @@ const KERNEL_SURFACE_BUDGET = {
   // pattern has a fixed per-seam cost on this file even when the bulk of the implementation leaves.
   // Bumped 2325→2327 — 2026-07-04 classified-fields stage 1 Task 6 (reveal gate): thread the opt-in
   // `classifiedStrategy` into the two Vault-construction option spreads.
-  'packages/hub/src/kernel/noydb.ts': 2327,
+  // Bumped 2327→2357 — 2026-07-04 #564: single-flight `openVault` (in-flight promise memo +
+  // `openVaultFresh` split), so concurrent opens of one vault can no longer construct two
+  // key-divergent Vault instances (root cause of the recurring in-pinia TamperedError CI flake).
+  'packages/hub/src/kernel/noydb.ts': 2357,
 }
 
 function checkKernelSurface() {


### PR DESCRIPTION
## What

Replaces the foundation-era `pnpm turbo test --concurrency=1` with a **two-phase schedule** (issue option (a)) in `ci.yml`, mirrored in `release.yml`'s hard gate (kept in lockstep per cbf07ea4's intent):

1. **hub alone** — the long pole (~400 test files, ~337 s of test CPU) gets the whole 4-vCPU runner; its vitest workers already parallelize internally.
2. **everything else at `--concurrency=4`** (matched to the runner's 4 vCPUs).

The root `package.json` test script never pinned a concurrency, so it is untouched.

## The empirical collision catalog

The `--concurrency=1` pin dates to the foundation commit with no recorded culprit, so the catalog was rebuilt from scratch: a static sweep plus **10 full-graph parallel runs** (and 6 two-phase rounds) locally.

**The hypothesized collisions do not exist.** Every filesystem-touching suite already uses `fs.mkdtemp(os.tmpdir() + unique-prefix)` (to-file, cli, create-noy-db, as-noydb, …); no test in the repo opens a listening socket; no `process.chdir`; env-var mutation is process-local per vitest run. Ten parallel runs produced **zero** temp-dir/port/fixture collisions. **The serial quarantine group is empty.**

What the sweep DID find is four load-sensitivity classes, each root-cause fixed rather than quarantined:

| # | Suite | Symptom under parallel load | Root cause | Fix |
|---|---|---|---|---|
| 1 | `in-pinia` defineNoydbStore (also the repo's only recurring CI flake — failed runs 28517240265, 28635062380, 28701710972, all at concurrency 1) | unhandled `TamperedError` rejection ×2, `expected [] to equal ['y']` ×1 | **Real hub race**: `Noydb.openVault(name)` is check-then-act on `vaultCache` across `await`s — two concurrent opens of one name each construct a Vault, whose Collections mint independent DEKs for the same store slice; a record written through one fails decryption through the other. Reproduced deterministically with `Promise.all([openVault('same'), openVault('same')])`. In in-pinia, the federation re-bind watcher's fire-and-forget `void refresh()` races `add()`. | Single-flight in-flight-promise memo in `kernel/noydb.ts` (`#openVaultFresh` split; check-to-set window is synchronous, hence race-free). Regression test `open-vault-single-flight.test.ts` — red pre-fix with the exact `TamperedError`, green post-fix. in-pinia under CPU load: 2 flakes/8 iterations → **0/10**. Kernel-surface ceiling 2327→2357 with justification. |
| 2 | `hub` classified `ct-equal` C2 + `verify-engine` C4 (both vectors) | wall-clock ratio assertions flipped (one window dilated up to 13× by an as-zip 7z burst) | each timing class sampled in ONE contiguous window — whatever contention burst lands inside it skews only that class | interleaved round-robin sampling + per-class **medians** (same total work, same assertions). 0/12 failures under 6 concurrent CPU burners. |
| 3 | `in-nuxt` rest-runtime first test; `at-*` managed-mode round-trips (at-env tripped; aws-kms / gcp-kms / azure-keyvault / macos-keychain are byte-identical twins) | 5.01 s — vitest's 5 s default timeout | first-import transform cost / several 600K-PBKDF2 derivations are legitimately near 5 s under load | explicit 30 s timeouts, matching hub's own convention for PBKDF2-heavy tests |
| 4 | `on-oidc` round-trip | `OperationError: Cipher job failed` — **intrinsic** flake, 1/15 solo runs at zero load | transport key is `HKDF(raw token string)`; the replay-mock returns the enroll-time ciphertext verbatim, so unlock only decrypts when both `makeIdToken()` calls land in the same wall-clock second (`iat` is second-granular) | tests reuse one token; the mock-vs-real-connector contract (decrypt-on-PUT / re-encrypt-per-GET) is documented at the call sites. **0/25** post-fix. |

Class 1 is also a genuine (if narrow) product bug — any app whose UI triggers concurrent first-opens of one vault could corrupt-on-write — so the hub commit is a real fix, not test hygiene.

Why two-phase instead of a flat `--concurrency=4`: flat-4 was green 5 of 7 full-graph runs, and every failure happened while hub saturated the box and starved a wall-clock-sensitive test beside it. Running hub solo removes the contention class entirely, costs nothing on the critical path (hub parallelizes internally), and is far more deterministic on a 4-vCPU runner.

## The `forget-vdig` flake

Investigated, **not reproduced, and not found in CI history**: every failed test-job attempt in the last ~60 runs was either the in-pinia race above or the (since-fixed, unrelated) July-1 `CargoNotEnabledError` from the mid-rollout S4 gating. `forget-vdig` passes in ~320 ms against a 60 s timeout in every inspected log, and its body has no timing assumptions (bounded PBKDF2 work, structural assertions). Left untouched; no retries added.

## Local timings (Apple M-series, 8 cores; CI truth arrives with this PR's own CI run)

| Configuration | Wall time |
|---|---|
| `--concurrency=1` baseline | **3m58s** |
| two-phase, round D | 3m05s (hub 92 s + satellites 93 s) |
| two-phase, round E | 3m38s (hub 100 s + satellites 118 s) |
| two-phase, round F | **2m28s** (hub 79 s + satellites 69 s) |

Three consecutive green full-graph rounds (110/110 tasks each). Local speedup is modest because vitest already parallelizes within each package across 8 cores; the serialized CI job pays 59 sequential per-package startups on 4 vCPUs, which is where the win is. **Expected CI saving: ~2.5–3 min** on the 7.3-min test job, taking the critical path from ~13.4 to ~10.5–11 min.

## Follow-up (out of scope)

Turbo **remote caching** would let the test job reuse the build job's artifacts across runners and drop the duplicated `turbo build` step, but needs org-level secrets — left as a follow-up.

Closes #564
