### PR TITLE
feat(hub): lazy-import ③ schema engines so they tree-shake when undeclared (#553)

### DIFF
--- a/packages/hub/__tests__/lazy-schema-engines.test.ts
+++ b/packages/hub/__tests__/lazy-schema-engines.test.ts
@@ -1,0 +1,178 @@
+// #553 — archetype-③ schema engines are lazy: the schema declaration is
+// the opt-in unit, and the floor never links an engine a collection
+// didn't declare.
+//
+// The bundle-level proof lives in scripts/check-bundle.mjs (the floor
+// scenario's `eagerImports` canaries); this file proves the RUNTIME
+// seams: (a) a floor collection with no declarations never installs the
+// money engine, (b) every converted engine still behaves identically
+// when its declaration is present.
+//
+// NOTE on ordering: the money engine installs into module-level state
+// when `money()` is first called, so the "not installed" assertions run
+// FIRST in this file (vitest runs a file's tests sequentially, and each
+// test file gets its own module registry).
+
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { createNoydb } from '../src/index.js'
+import { money } from '../src/with-shape/money/descriptor.js'
+import { isMoneyEngineInstalled, moneyRuntime } from '../src/kernel/money-runtime.js'
+import { withAggregate } from '../src/with-lookup/aggregate/index.js'
+import { sum } from '../src/with-lookup/aggregate/reducers.js'
+import type { NoydbStore, EncryptedEnvelope } from '../src/kernel/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none', required: false, flow: 'static' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/') as [string, string, string]
+        if (vname === v) { out[cname] = out[cname] ?? {}; out[cname][id] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c]!)) { data.set(k(v, c, i), payload[c]![i]!) }
+      }
+    },
+  }
+}
+
+async function openTestVault() {
+  const db = await createNoydb({
+    store: memory(),
+    user: 'alice',
+    secret: 'lazy-engines-553-test-passphrase',
+    aggregateStrategy: withAggregate(),
+  })
+  return db.openVault('main')
+}
+
+describe('#553 — floor collection without ③ declarations', () => {
+  it('never installs the money engine (write/read/query all work without it)', async () => {
+    // Nothing in this file has called money() yet — importing the barrel
+    // alone must not link the engine.
+    expect(isMoneyEngineInstalled()).toBe(false)
+    expect(() => moneyRuntime()).toThrowError(/money\(\)/)
+
+    const vault = await openTestVault()
+    const coll = vault.collection<Record<string, unknown>>('plain')
+    await coll.put('a', { id: 'a', n: 2 })
+    await coll.put('b', { id: 'b', n: 5 })
+    expect(await coll.get('a')).toMatchObject({ n: 2 })
+    const rows = coll.query().where('n', '>', 1).toArray()
+    expect(rows).toHaveLength(2)
+    await coll.delete('b')
+    expect(await coll.get('b')).toBeNull()
+
+    // The plain collection's whole lifecycle consulted no money engine.
+    expect(isMoneyEngineInstalled()).toBe(false)
+  })
+})
+
+describe('#553 — engines still work when declared', () => {
+  it('money: declaring via money() links the engine; quantize/where/sort/sum/decode intact', async () => {
+    const vault = await openTestVault()
+    const coll = vault.collection<Record<string, unknown>>('invoices', {
+      moneyFields: { total: money({ currency: 'EUR', scale: 2 }) },
+    })
+    expect(isMoneyEngineInstalled()).toBe(true)
+
+    await coll.put('i1', { id: 'i1', total: '10.50' })
+    await coll.put('i2', { id: 'i2', total: 3 })
+
+    // Read decodes stored scaled-int back to exact decimal.
+    expect(await coll.get('i1')).toMatchObject({ total: '10.50' })
+
+    // SYNC query DSL: build-time operand quantization + BigInt-exact compare.
+    const over5 = coll.query().where('total', '>', 5).toArray()
+    expect(over5).toHaveLength(1)
+    expect(over5[0]).toMatchObject({ id: 'i1' })
+
+    // Malformed operand still throws AT .where() — sync error timing preserved.
+    expect(() => coll.query().where('total', '>', 'not-a-number')).toThrowError()
+
+    // Money-aware ordering (BigInt scaled compare).
+    const sorted = coll.query().orderBy('total', 'asc').toArray()
+    expect(sorted.map(r => r['id'])).toEqual(['i2', 'i1'])
+
+    // Exact money sum via wrapped reducers.
+    const agg = await coll.query().aggregate({ total: sum('total') }).run()
+    expect(agg.total).toBe('13.50')
+  })
+
+  it('computed: engine loads on the first computed-declared put', async () => {
+    const vault = await openTestVault()
+    const coll = vault.collection<Record<string, unknown>>('orders', {
+      computed: { gross: (r: Record<string, unknown>) => (r['net'] as number) * 2 },
+    })
+    await coll.put('o1', { id: 'o1', net: 21 })
+    expect(await coll.get('o1')).toMatchObject({ gross: 42 })
+  })
+
+  it('links: lazy handle is cached, does I/O on demand, and cascades on delete', async () => {
+    const vault = await openTestVault()
+    const students = vault.collection<Record<string, unknown>>('students')
+    const courses = vault.collection<Record<string, unknown>>('courses')
+    await students.put('s1', { id: 's1' })
+    await courses.put('c1', { id: 'c1' })
+
+    vault.link('enrollment', { a: 'students', b: 'courses' })
+    const handle = vault.links('enrollment')
+    expect(vault.links('enrollment')).toBe(handle) // cached, same object
+
+    await handle.connect('s1', 'c1', { grade: 'A' })
+    expect(await handle.has('s1', 'c1')).toBe(true)
+    expect(await handle.of('s1')).toEqual([{ a: 's1', b: 'c1', meta: { grade: 'A' } }])
+
+    // Default onDelete: 'cascade' — deleting an endpoint removes its rows.
+    await students.delete('s1')
+    expect(await handle.list()).toEqual([])
+  })
+
+  it('schema-update: gated writes + fence state via the lazy engine', async () => {
+    const { additiveOnly } = await import('../src/with-shape/schema-update/strategies.js')
+    const vault = await openTestVault()
+    const coll = vault.collection<Record<string, unknown>>('docs', {
+      schema: z.object({ id: z.string(), title: z.string() }),
+      persistJsonSchema: true,
+      schemaUpdate: [additiveOnly()],
+    })
+    await coll.put('d1', { id: 'd1', title: 'hello' })
+    expect(await coll.get('d1')).toMatchObject({ title: 'hello' })
+    // Lazy loadFence path — a vault with no active cutover reads 'normal'.
+    const fence = await vault.schemaFenceState()
+    expect(fence.fenceState).toBe('normal')
+  })
+
+  it('introspection: dumpSchema and toJSONSchema resolve via lazy imports', async () => {
+    const vault = await openTestVault()
+    const coll = vault.collection<Record<string, unknown>>('items', {
+      schema: z.object({ id: z.string(), qty: z.number() }),
+    })
+    await coll.put('x', { id: 'x', qty: 1 })
+
+    const snapshot = await vault.dumpSchema()
+    expect(Object.keys(snapshot.collections)).toContain('items')
+
+    const js = await coll.toJSONSchema() as Record<string, unknown>
+    expect(js).toBeTruthy()
+    expect(typeof js).toBe('object')
+
+    // Sync describe() is unchanged (stays static — public sync API).
+    const desc = coll.describe()
+    expect(desc.collection).toBe('items')
+  })
+})

--- a/packages/hub/bundle-manifest.json
+++ b/packages/hub/bundle-manifest.json
@@ -1,25 +1,25 @@
 {
   "scenarios": {
     "floor": {
-      "minifiedBytes": 1186,
-      "gzippedBytes": 403
+      "minifiedBytes": 1354,
+      "gzippedBytes": 440
     },
     "history": {
-      "minifiedBytes": 5787,
-      "gzippedBytes": 2224
+      "minifiedBytes": 5955,
+      "gzippedBytes": 2278
     },
     "classified": {
-      "minifiedBytes": 2340,
-      "gzippedBytes": 870
+      "minifiedBytes": 2508,
+      "gzippedBytes": 914
     },
     "analytics": {
-      "minifiedBytes": 2059,
-      "gzippedBytes": 822
+      "minifiedBytes": 2227,
+      "gzippedBytes": 864
     },
     "all-on": {
-      "minifiedBytes": 26125,
-      "gzippedBytes": 8157
+      "minifiedBytes": 26293,
+      "gzippedBytes": 8215
     }
   },
-  "updatedAt": "2026-07-04T07:12:52.616Z"
+  "updatedAt": "2026-07-04T12:57:06.653Z"
 }

--- a/packages/hub/scripts/check-bundle.mjs
+++ b/packages/hub/scripts/check-bundle.mjs
@@ -102,6 +102,19 @@ const SCENARIOS = [
       'DerivationRegistry',
       'GuardExecutor',
       'DerivationExecutor',
+      // Archetype-3 schema engines (#553) -- declaration-gated, must never
+      // be statically reachable from the floor:
+      'quantizeMoneyFields',   // money write engine (linked by money())
+      'decodeMoneyFields',     // money read engine
+      'moneyFieldClause',      // money where() build engine
+      'evaluateMoneyClause',   // money predicate engine
+      'wrapMoneyReducers',     // money aggregation engine
+      'evalComputedFields',    // computed-fields engine (lazy at first put)
+      'LinkSet',               // link-set storage engine (lazy links() handle)
+      'persistSchemaIfNeeded', // schema-update decision engine
+      'FenceWatcher',          // cutover heartbeat/watcher
+      'dumpVaultSchema',       // introspection walker
+      'buildJsonSchema',       // JSON-Schema assembler
     ],
   },
   {
@@ -141,6 +154,14 @@ const SCENARIOS = [
       export { createNoydb, withIndexing, withAggregate }
     `,
     leakCanaries: [],
+    // The aggregate service must not drag the money engine in -- money
+    // reducer wrapping goes through the kernel's money-runtime seam and
+    // only links when a collection declares money() fields (#553).
+    eagerImports: [
+      'wrapMoneyReducers',
+      'quantizeMoneyFields',
+      'decodeMoneyFields',
+    ],
   },
   {
     name: 'all-on',

--- a/packages/hub/src/kernel/collection-config.ts
+++ b/packages/hub/src/kernel/collection-config.ts
@@ -44,7 +44,7 @@ import type { IndexDef } from '../with-lookup/indexing/eager-indexes.js'
 import type { I18nTextDescriptor } from '../with-shape/i18n/core.js'
 import type { DictKeyDescriptor, StaticDictDescriptor, DictionaryHandle } from '../with-shape/i18n/dictionary.js'
 import type { MoneyDescriptor } from '../with-shape/money/descriptor.js'
-import { validateMoneyFieldPaths } from '../with-shape/money/paths.js'
+import { moneyRuntime } from './money-runtime.js'
 import type { ComputedFields } from '../with-formula/computed/index.js'
 import { resolveClassifiedFields, ClassifiedConfigError, type ClassifiedEntry, type ResolvedClassified } from '../with-shape/classified/resolve.js'
 import { guardClassifiedCompat, type ClassifiedGuardCtx } from '../with-shape/classified/guards.js'
@@ -464,7 +464,7 @@ export function resolveCollectionConfig<T>(opts: CollectionOpts<T>) {
     )
   }
 
-  if (opts.moneyFields) validateMoneyFieldPaths(opts.moneyFields)
+  if (opts.moneyFields) moneyRuntime().validateMoneyFieldPaths(opts.moneyFields)
 
   const resolvedClassified: ResolvedClassified | undefined =
     opts.classifiedFields !== undefined

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -12,10 +12,8 @@ import { getAtPath, setAtPathInPlace, stripI18nFilled } from '../with-shape/i18n
 import type { DictKeyDescriptor, StaticDictDescriptor, DictionaryHandle } from '../with-shape/i18n/dictionary.js'
 import { isStaticDictDescriptor } from '../with-shape/i18n/dictionary.js'
 import type { MoneyDescriptor } from '../with-shape/money/descriptor.js'
-import { quantizeMoneyFields, decodeMoneyFields, canonicalizeStoredMoney, canonicalizeIncomingMoney } from '../with-shape/money/normalize.js'
-import { validateMoneyFieldPaths } from '../with-shape/money/paths.js'
+import { moneyRuntime } from './money-runtime.js'
 import type { ComputedFields } from '../with-formula/computed/index.js'
-import { evalComputedFields } from '../with-formula/computed/index.js'
 import { enforceClassifiedWrite } from '../with-shape/classified/write.js'
 import type { I18nStrategy } from '../with-shape/i18n/strategy.js'
 import { resolvePolicy } from '../with-shape/i18n/policy.js'
@@ -82,7 +80,6 @@ import type { VectorSet, EmbeddingDescriptor } from '../with-lookup/embeddings/i
 import { buildUniqueConstraintSet, type UniqueConstraintSet } from '../with-lookup/indexing/unique-constraints.js'
 import type { RefDescriptor } from './refs.js'
 import { buildDescription, deriveZodFields, type CollectionDescription, type DescribeOptions } from '../with-shape/introspection/describe.js'
-import { buildJsonSchema } from '../with-shape/introspection/json-schema.js'
 import type { CollectionConfig } from '../with-shape/introspection/types.js'
 import { Lru, parseBytes, estimateRecordBytes, type LruStats } from './cache/index.js'
 import { generateULID } from '../with-pod/ulid.js'
@@ -112,6 +109,7 @@ import type { MVQueryContext } from '../with-formula/materialized-views/types.js
 import type { MaterializedViewExecutor as MVExecutorType } from '../with-formula/materialized-views/executor.js'
 import type * as MVStaleModule from '../with-formula/materialized-views/stale.js'
 import { resolveCollectionConfig, type CollectionOpts } from './collection-config.js'
+import { loadEvalComputedFields } from '../with-formula/computed/lazy.js'
 
 /** Callback for dirty tracking (sync engine integration). */
 export type OnDirtyCallback = (collection: string, id: string, action: 'put' | 'delete', version: number) => Promise<void>
@@ -1110,6 +1108,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
 
   /** JSON Schema for this collection with describe() metadata as x- extensions. */
   async toJSONSchema(): Promise<object> {
+    // Lazy import (#553) -- only reachable through this async method.
+    const { buildJsonSchema } = await import('../with-shape/introspection/json-schema.js')
     const desc = await this.describe({})
     let base: Record<string, unknown> | null = null
     if (this.schema !== undefined) {
@@ -1189,7 +1189,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    */
   _applyMoneyFields(moneyFields: Record<string, MoneyDescriptor>): void {
     if (this.moneyFields !== undefined) return
-    validateMoneyFieldPaths(moneyFields)
+    moneyRuntime().validateMoneyFieldPaths(moneyFields)
     this.moneyFields = moneyFields
   }
 
@@ -1600,7 +1600,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     // gates, computed fields, and schema validation all see the decoded
     // `get()` shape. Best-effort — bad input passes through and the
     // quantize stage below throws the real error.
-    record = canonicalizeIncomingMoney(record, this.moneyFields) as T
+    if (this.moneyFields) record = moneyRuntime().canonicalizeIncomingMoney(record, this.moneyFields) as T
 
     // Gate bus (Track A) — write-gating services (guards: record-lock /
     // field-freeze / amendment-collect; periods: closed-period guard) run here,
@@ -1621,7 +1621,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
         op: existingEnv ? 'update' : 'create',
         vault: this.vault, collection: this.name, docId: id,
         incoming: record,
-        existing: canonicalizeStoredMoney(existingRecord, this.moneyFields),
+        existing: this.moneyFields ? moneyRuntime().canonicalizeStoredMoney(existingRecord, this.moneyFields) : existingRecord,
         existingVersion: existingEnv?._v ?? 0,
         existingTs: existingEnv?._ts,
         userId: this.keyring.userId,
@@ -1643,7 +1643,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     // them and the schema validates the computed result. Throws
     // ComputedFieldError if a function throws.
     if (this.computed !== undefined) {
-      record = evalComputedFields(record as Record<string, unknown>, this.computed, id) as T
+      record = (await loadEvalComputedFields())(record as Record<string, unknown>, this.computed, id) as T
     }
 
     // Schema validation — runs BEFORE encryption so invalid records are
@@ -1660,7 +1660,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     // Quantize money fields to their stored form (scaled-int string).
     // After schema validation — descriptor owns precision/scale/currency.
     if (this.moneyFields) {
-      record = quantizeMoneyFields(record as Record<string, unknown>, this.moneyFields) as T
+      record = moneyRuntime().quantizeMoneyFields(record as Record<string, unknown>, this.moneyFields) as T
     }
 
     // Auto-translate missing i18nText translations.
@@ -2161,7 +2161,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       raw = (await this.resolvePriorValues(id))?.record ?? null
     }
     if (raw === null) return null
-    return canonicalizeStoredMoney(raw, this.moneyFields) as T
+    return (this.moneyFields ? moneyRuntime().canonicalizeStoredMoney(raw, this.moneyFields) : raw) as T
   }
 
   /**
@@ -2258,7 +2258,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     if (this.derivationSource === undefined) return
     // `record` is the stored form here (post-quantize) — decode so
     // derive(source, ctx) sees the canonical money shape.
-    const incoming = canonicalizeStoredMoney(record, this.moneyFields) as Record<string, unknown>
+    const incoming = (this.moneyFields ? moneyRuntime().canonicalizeStoredMoney(record, this.moneyFields) : record) as Record<string, unknown>
     if (incoming && typeof incoming === 'object' && '_derivedFrom' in incoming) return
     const registry = this.derivationSource.registry()
     const strategies = registry.strategiesForSource(this.name)
@@ -2632,7 +2632,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
         }
         await this.subsystemBus.dispatchGate('beforeDelete', {
           vault: this.vault, collection: this.name, docId: id,
-          existing: canonicalizeStoredMoney(existingRecord, this.moneyFields),
+          existing: this.moneyFields ? moneyRuntime().canonicalizeStoredMoney(existingRecord, this.moneyFields) : existingRecord,
           existingVersion: existingEnv._v,
           existingTs: existingEnv._ts,
           internal,
@@ -3970,7 +3970,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     // Money decode runs regardless of locale (stored int → decimal string);
     // virtuals are gated on `locale !== 'raw'` inside decodeMoneyFields.
     if (hasMoney && this.moneyFields) {
-      result = decodeMoneyFields(result, this.moneyFields, typeof locale === 'string' ? locale : undefined)
+      result = moneyRuntime().decodeMoneyFields(result, this.moneyFields, typeof locale === 'string' ? locale : undefined)
     }
 
     // i18nText / dictKey resolution require an active locale — EXCEPT a

--- a/packages/hub/src/kernel/money-runtime.ts
+++ b/packages/hub/src/kernel/money-runtime.ts
@@ -1,0 +1,52 @@
+/**
+ * Money engine runtime seam (#553).
+ *
+ * The kernel floor consults the money engine from SYNC paths — the
+ * query DSL executes synchronously (`toArray()`/`first()`/`count()`),
+ * `where()` quantizes operands at build time, and `moneyFields` path
+ * validation throws at declaration time — so an `await import()` seam
+ * would either break those sync semantics or race a fire-and-forget
+ * preload. Instead the DECLARATION carries the engine: constructing a
+ * descriptor via `money()` statically links the implementation
+ * (`with-shape/money/engine.ts`) and installs it here, so by the time
+ * any kernel path holds a `MoneyDescriptor` the engine is guaranteed
+ * present.
+ *
+ * The kernel floor imports ONLY this holder plus the erased
+ * {@link MoneyEngine} type; the engine modules are reachable solely
+ * through the user's own `money()` import — a consumer that never
+ * declares a money field tree-shakes the whole family out.
+ */
+import { NoydbError } from './errors.js'
+import type { MoneyEngine } from '../with-shape/money/engine.js'
+
+export type { MoneyEngine }
+
+let engine: MoneyEngine | null = null
+
+/** @internal — called (idempotently) by `money()` when a descriptor is built. */
+export function installMoneyEngine(e: MoneyEngine): void {
+  engine ??= e
+}
+
+/** @internal — test-only visibility into whether the engine was linked. */
+export function isMoneyEngineInstalled(): boolean {
+  return engine !== null
+}
+
+/**
+ * @internal — resolve the installed engine. Every call site is gated on
+ * the presence of a `MoneyDescriptor`, which only `money()` constructs,
+ * so this cannot throw for supported inputs. A hand-rolled descriptor
+ * object (not produced by `money()`) is the one path that lands here.
+ */
+export function moneyRuntime(): MoneyEngine {
+  if (engine === null) {
+    throw new NoydbError(
+      'MONEY_ENGINE_NOT_LINKED',
+      'money fields require descriptors created via money() from @noy-db/hub — ' +
+        'hand-rolled descriptor objects are not supported',
+    )
+  }
+  return engine
+}

--- a/packages/hub/src/kernel/query/builder.ts
+++ b/packages/hub/src/kernel/query/builder.ts
@@ -20,9 +20,7 @@ import { reducerBuilder } from '../../with-lookup/aggregate/reducers.js'
 import type { GroupedQuery, GroupedQueryN } from '../../with-lookup/aggregate/groupby.js'
 import { NO_AGGREGATE, type AggregateStrategy } from '../../with-lookup/aggregate/strategy.js'
 import type { MoneyDescriptor } from '../../with-shape/money/descriptor.js'
-import { wrapMoneyReducers } from '../../with-shape/money/money-reducer.js'
-import { decodeMoneyFields, moneyScaledValue } from '../../with-shape/money/normalize.js'
-import { moneyFieldClause } from '../../with-shape/money/where.js'
+import { moneyRuntime } from '../money-runtime.js'
 
 export interface OrderBy {
   readonly field: string
@@ -283,7 +281,7 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
   where(field: QueryField<T, S, Q>, op: Operator, value: unknown): Query<T, S, Q, M> {
     const desc = this.source.moneyFields?.[field]
     const clause: FieldClause = desc
-      ? moneyFieldClause(field, op, value, desc)
+      ? moneyRuntime().moneyFieldClause(field, op, value, desc)
       : { type: 'field', field, op, value }
     return new Query<T, S, Q, M>(
       this.source as QuerySource<T>,
@@ -646,7 +644,7 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
   private decodeMoney(records: readonly unknown[]): unknown[] {
     const moneyFields = this.source.moneyFields
     if (!moneyFields || Object.keys(moneyFields).length === 0) return records as unknown[]
-    return records.map(r => decodeMoneyFields(r as Record<string, unknown>, moneyFields, 'raw'))
+    return records.map(r => moneyRuntime().decodeMoneyFields(r as Record<string, unknown>, moneyFields, 'raw'))
   }
 
   /** Return the first matching record, or null. Joins are applied. `opts.locale` resolves joined i18n fields. */
@@ -746,7 +744,7 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
     // before the strategy runs (covers static run() and live/MV paths).
     const moneyFields = this.source.moneyFields
     if (moneyFields) {
-      spec = wrapMoneyReducers(spec, moneyFields) as Spec
+      spec = moneyRuntime().wrapMoneyReducers(spec, moneyFields) as Spec
     }
     // Closure over the current query. Produces the record set that
     // the aggregation reduces — same pipeline as `count()`, skipping
@@ -1179,7 +1177,7 @@ export function executePlan(records: readonly unknown[], plan: QueryPlan): unkno
 function fnViewDecoder(source: InternalSource): ((r: unknown) => unknown) | undefined {
   const mf = source.moneyFields
   if (!mf || Object.keys(mf).length === 0) return undefined
-  return r => decodeMoneyFields(r as Record<string, unknown>, mf, 'raw')
+  return r => moneyRuntime().decodeMoneyFields(r as Record<string, unknown>, mf, 'raw')
 }
 
 function filterRecords(
@@ -1370,8 +1368,8 @@ function buildOrderLabelMaps(
 
 /** Compare two stored money values by BigInt scaled-int; nullish/malformed last (asc). */
 function compareMoney(a: unknown, b: unknown, desc: MoneyDescriptor): number {
-  const av = moneyScaledValue(a, desc)
-  const bv = moneyScaledValue(b, desc)
+  const av = moneyRuntime().moneyScaledValue(a, desc)
+  const bv = moneyRuntime().moneyScaledValue(b, desc)
   if (av === null) return bv === null ? 0 : 1
   if (bv === null) return -1
   return av < bv ? -1 : av > bv ? 1 : 0

--- a/packages/hub/src/kernel/query/predicate.ts
+++ b/packages/hub/src/kernel/query/predicate.ts
@@ -6,7 +6,8 @@
  * tree-shakeable through it.
  */
 
-import { evaluateMoneyClause, type MoneyWhereOperand } from '../../with-shape/money/where.js'
+import type { MoneyWhereOperand } from '../../with-shape/money/where.js'
+import { moneyRuntime } from '../money-runtime.js'
 
 /** Comparison operators supported by the where() builder. */
 export type Operator =
@@ -142,7 +143,7 @@ export function evaluateFieldClause(record: unknown, clause: FieldClause): boole
   // the stored form is a digit string, so the generic paths below would
   // either reject (string vs number is not comparable) or compare
   // lexicographically. The operand was quantized at build time.
-  if (clause.money) return evaluateMoneyClause(actual, op, clause.money)
+  if (clause.money) return moneyRuntime().evaluateMoneyClause(actual, op, clause.money)
 
   switch (op) {
     case '==':

--- a/packages/hub/src/kernel/query/scan-builder.ts
+++ b/packages/hub/src/kernel/query/scan-builder.ts
@@ -70,8 +70,7 @@ import type {
 import type { JoinContext, JoinLeg, JoinableSource } from './join.js'
 import { DanglingReferenceError } from '../errors.js'
 import type { MoneyDescriptor } from '../../with-shape/money/descriptor.js'
-import { decodeMoneyFields } from '../../with-shape/money/normalize.js'
-import { moneyFieldClause } from '../../with-shape/money/where.js'
+import { moneyRuntime } from '../money-runtime.js'
 
 /**
  * Page provider — the Collection-shaped hook the builder calls to
@@ -154,7 +153,7 @@ export class ScanBuilder<T, S extends keyof T = never, M extends keyof T & strin
    */
   private decodeMoney(record: T): T {
     if (!this.moneyFields || Object.keys(this.moneyFields).length === 0) return record
-    return decodeMoneyFields(record as Record<string, unknown>, this.moneyFields, 'raw') as T
+    return moneyRuntime().decodeMoneyFields(record as Record<string, unknown>, this.moneyFields, 'raw') as T
   }
 
   /**
@@ -175,7 +174,7 @@ export class ScanBuilder<T, S extends keyof T = never, M extends keyof T & strin
     // same build-time operand rewrite as Query.where().
     const desc = this.moneyFields?.[field as string]
     const clause: FieldClause = desc
-      ? moneyFieldClause(field as string, op, value, desc)
+      ? moneyRuntime().moneyFieldClause(field as string, op, value, desc)
       : { type: 'field', field: field as string, op, value }
     return new ScanBuilder<T, S, M>(
       this.pageProvider,

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -89,7 +89,8 @@ import {
 } from './refs.js'
 import type { DictionaryHandle, DictionaryOptions, DictKeyDescriptor, StaticDictDescriptor } from '../with-shape/i18n/dictionary.js'
 import { isDictCollectionName, isStaticDictDescriptor } from '../with-shape/i18n/dictionary.js'
-import { LinkSet, isLinkCollectionName, type LinkSpec, type LinkSetHandle } from '../with-shape/links/link-set.js'
+import { isLinkCollectionName, type LinkSpec, type LinkSetHandle } from '../with-shape/links/names.js'
+import { makeLazyLinkSetHandle, type LazyLinkSetHandle } from '../with-shape/links/lazy-handle.js'
 import type { EmbeddingDescriptor } from '../with-lookup/embeddings/index.js'
 import type { I18nTextDescriptor } from '../with-shape/i18n/core.js'
 import { getAtPath } from '../with-shape/i18n/core.js'
@@ -131,17 +132,17 @@ import {
   type MagicLinkGrantRecord,
 } from '../with-party/team/magic-link-grant.js'
 import { CustodyApi } from '../with-party/custody/index.js'
-import { persistSchemaIfNeeded } from '../with-shape/persisted-schemas/register.js'
+// #553: gate + controller + fence-doc reader stay static (a REMOTE cutover must fence this client even without local declarations, and schemaFenceState() is a thin live read that UI bindings seed from in one tick); the decision engine + watcher load lazily.
+import type { FenceWatcher } from '../with-shape/schema-update/fence-watcher.js'
 import { SchemaUpdateGate } from '../with-shape/schema-update/gate.js'
 import { SchemaFenceController } from '../with-shape/schema-update/fence-controller.js'
-import { FenceWatcher } from '../with-shape/schema-update/fence-watcher.js'
 import { loadFence, type FenceDoc } from '../with-shape/schema-update/fence.js'
 import type { SchemaUpdateStrategy, UpdateDecision, TransformFn } from '../with-shape/schema-update/types.js'
 import type { AttestationFieldSchema, RevocationList } from '@noy-db/attestation'
 import { VaultAttestation, NO_ATTESTATION, type AttestationStrategy } from '../with-audit/attestation/vault-facade.js'
 import { NO_SEALED_RECORD, type SealedRecordStrategy } from '../with-audit/sealed-record/strategy.js'
 import type { DumpSchemaOptions, VaultSchemaSnapshot, SchemaIntrospection } from '../with-shape/introspection/types.js'
-import { dumpVaultSchema, type VaultIntrospectState } from '../with-shape/introspection/walk.js'
+import type { VaultIntrospectState } from '../with-shape/introspection/walk.js'
 import type { FieldMeta } from '../with-shape/introspection/field-meta.js'
 import type { CollectionMeta, VaultMeta } from '../with-shape/introspection/meta.js'
 import type { ClassifiedEntry } from '../with-shape/classified/resolve.js'
@@ -464,8 +465,8 @@ export class Vault {
 
   /** Registered link specs, keyed by link name; set by `vault.link()`. */
   private readonly linkRegistry = new Map<string, LinkSpec>()
-  /** Cache of LinkSet handles, one per link name. */
-  private readonly linkSetCache = new Map<string, LinkSet>()
+  /** Cache of link-set handles, one per link name (lazy -- see links()). */
+  private readonly linkSetCache = new Map<string, LazyLinkSetHandle>()
 
   /** — subscribers for cross-tier access events. */
   private readonly crossTierSubs = new Set<(event: CrossTierAccessEvent) => void>()
@@ -962,13 +963,14 @@ export class Vault {
         const strategies = options.schemaUpdate ?? []
         const work = (async (): Promise<UpdateDecision> => {
           const dek = await this.getDEK(collectionName)
+          const { persistSchemaIfNeeded } = await import('../with-shape/persisted-schemas/register.js') // lazy (#553)
           const result = await persistSchemaIfNeeded({
             store: this.adapter, vault: this.name, collectionName, validator, dek, strategies,
           })
           const decision = result.decision ?? { action: 'allow' as const }
           if (decision.action === 'cutover') {
             this.schemaFence.registerPendingCutover(collectionName, decision.transform)
-            this._ensureFenceCoordination()
+            await this._ensureFenceCoordination()
           }
           return decision
         })()
@@ -1179,7 +1181,7 @@ export class Vault {
         const work = (async () => {
           try {
             const dek = await this.getDEK(collectionName)
-            await persistSchemaIfNeeded({
+            await (await import('../with-shape/persisted-schemas/register.js')).persistSchemaIfNeeded({
               store: this.adapter,
               vault: this.name,
               collectionName,
@@ -1281,10 +1283,12 @@ export class Vault {
     return loadFence(this.adapter, this.name)
   }
 
-  /** @internal Start the per-client heartbeat + fence watcher once a cutover is registered. */
-  _ensureFenceCoordination(): void {
+  /** @internal Start heartbeat + fence watcher once a cutover is registered. Async since #553: FenceWatcher dynamic-imports on demand. */
+  async _ensureFenceCoordination(): Promise<void> {
     if (this.#fenceCoordinationStarted) return
     this.#fenceCoordinationStarted = true
+    const { FenceWatcher } = await import('../with-shape/schema-update/fence-watcher.js')
+    if (!this.#fenceCoordinationStarted) return // _stop raced the load -- don't resurrect
     this.#fenceWatcher = new FenceWatcher({
       coordination: this.noydb.coordination,
       vault: this.name,
@@ -1315,7 +1319,7 @@ export class Vault {
 
   /** @internal Drive one heartbeat + watch cycle deterministically (tests). */
   async _fenceTick(): Promise<void> {
-    this._ensureFenceCoordination()
+    await this._ensureFenceCoordination()
     await this.#fenceWatcher!.beat()
     await this.#fenceWatcher!.check()
   }
@@ -1571,17 +1575,12 @@ export class Vault {
       if (!spec) {
         throw new ValidationError(`vault.links("${name}"): not declared. Call vault.link("${name}", { a, b }) first.`)
       }
-      handle = new LinkSet(
-        this.adapter,
-        this.name,
-        name,
-        spec,
-        this.encrypted,
-        this.getDEK,
-        this.keyring.userId,
-        this.emitter,
-        async (collection, id) => (await this.collection(collection).get(id)) !== null,
-      )
+      // #553: handle surface is all-async, so the LinkSet engine dynamic-imports on first link I/O.
+      handle = makeLazyLinkSetHandle({
+        adapter: this.adapter, vault: this.name, name, spec, encrypted: this.encrypted,
+        getDEK: this.getDEK, actor: this.keyring.userId, emitter: this.emitter,
+        endpointExists: async (collection, id) => (await this.collection(collection).get(id)) !== null,
+      })
       this.linkSetCache.set(name, handle)
     }
     return handle
@@ -3318,6 +3317,7 @@ export class Vault {
    * @see docs/superpowers/specs/2026-05-22-schema-dump-design.md
    */
   async dumpSchema(opts: DumpSchemaOptions = {}): Promise<VaultSchemaSnapshot> {
+    const { dumpVaultSchema } = await import('../with-shape/introspection/walk.js') // lazy (#553)
     return dumpVaultSchema(this, opts)
   }
 

--- a/packages/hub/src/with-formula/computed/lazy.ts
+++ b/packages/hub/src/with-formula/computed/lazy.ts
@@ -1,0 +1,19 @@
+/**
+ * Lazy loader for the computed-fields engine (#553).
+ *
+ * The `computed` declaration on `collection({ … })` is the opt-in unit;
+ * the engine's only kernel consultation is the (async) write pipeline,
+ * so it loads on the first computed-declared put and stays out of the
+ * floor bundle otherwise. Cached after first load — mirrors the
+ * deferred-load pattern used for guards/derivations.
+ */
+import type * as ComputedModule from './index.js'
+
+type EvalComputedFieldsFn = typeof ComputedModule.evalComputedFields
+
+let fn: EvalComputedFieldsFn | null = null
+
+export async function loadEvalComputedFields(): Promise<EvalComputedFieldsFn> {
+  fn ??= (await import('./index.js')).evalComputedFields
+  return fn
+}

--- a/packages/hub/src/with-lookup/aggregate/groupby.ts
+++ b/packages/hub/src/with-lookup/aggregate/groupby.ts
@@ -72,7 +72,7 @@ import { reducerBuilder } from './reducers.js'
 import { canonicalGroupKey } from './canonical-key.js'
 import { GroupCardinalityError } from '../../kernel/errors.js'
 import type { MoneyDescriptor } from '../../with-shape/money/descriptor.js'
-import { wrapMoneyReducers } from '../../with-shape/money/money-reducer.js'
+import { moneyRuntime } from '../../kernel/money-runtime.js'
 import { applyI18nLocale, type I18nTextDescriptor } from '../../with-shape/i18n/core.js'
 
 /**
@@ -190,7 +190,7 @@ abstract class GroupedQueryBase {
 
   /** Apply money-aware reducer rewriting when money fields are declared. */
   protected wrapSpec<Spec extends AggregateSpec>(spec: Spec): Spec {
-    return this.moneyFields ? (wrapMoneyReducers(spec, this.moneyFields) as Spec) : spec
+    return this.moneyFields ? (moneyRuntime().wrapMoneyReducers(spec, this.moneyFields) as Spec) : spec
   }
 }
 
@@ -295,7 +295,7 @@ export function groupAndReduce<R>(
   // covers direct `groupAndReduce` callers (UNION-form MVs) that have
   // no Query wrapper to do it.
   if (moneyFields) {
-    spec = wrapMoneyReducers(spec, moneyFields)
+    spec = moneyRuntime().wrapMoneyReducers(spec, moneyFields)
   }
 
   // Bucket value is { keyValues, records } so the output row can stamp

--- a/packages/hub/src/with-shape/links/lazy-handle.ts
+++ b/packages/hub/src/with-shape/links/lazy-handle.ts
@@ -1,0 +1,56 @@
+/**
+ * Lazy link-set handle factory (#553).
+ *
+ * `vault.links(name)` is a SYNC accessor, but every method on the handle
+ * it returns is async — so the handle can defer loading the `LinkSet`
+ * storage engine to the first actual link I/O. This keeps `link-set.ts`
+ * out of the floor bundle for consumers that never use links, while the
+ * handle object itself stays cached and referentially stable per name.
+ *
+ * Besides the public {@link LinkSetHandle} surface, the handle carries
+ * the two cascade internals the ref/link enforcement facade consults
+ * (`vault-facade.ts` casts the handle to `LinkSet` and duck-types them).
+ */
+import { linkCollectionName, type LinkRow, type LinkSpec, type LinkSetHandle } from './names.js'
+import type { LinkSet } from './link-set.js'
+import type { NoydbStore } from '../../kernel/types.js'
+import type { NoydbEventEmitter } from '../../kernel/events.js'
+import type { EnclaveKey } from '../../kernel/enclave/index.js'
+
+/** @internal The lazy handle: public surface + facade cascade internals. */
+export type LazyLinkSetHandle = LinkSetHandle & {
+  readonly _collectionName: string
+  _rowsTouchingEndpoint(collection: string, id: string): Promise<LinkRow[]>
+}
+
+/** @internal Constructor args for the deferred {@link LinkSet}. */
+export interface LazyLinkSetDeps {
+  readonly adapter: NoydbStore
+  readonly vault: string
+  readonly name: string
+  readonly spec: LinkSpec
+  readonly encrypted: boolean
+  readonly getDEK: (collectionName: string) => Promise<EnclaveKey>
+  readonly actor: string
+  readonly emitter: NoydbEventEmitter
+  readonly endpointExists: (collection: string, id: string) => Promise<boolean>
+}
+
+/** @internal Build the handle; the LinkSet engine dynamic-imports on first use. */
+export function makeLazyLinkSetHandle(d: LazyLinkSetDeps): LazyLinkSetHandle {
+  let engine: Promise<LinkSet> | null = null
+  const load = (): Promise<LinkSet> =>
+    (engine ??= import('./link-set.js').then(
+      ({ LinkSet }) =>
+        new LinkSet(d.adapter, d.vault, d.name, d.spec, d.encrypted, d.getDEK, d.actor, d.emitter, d.endpointExists),
+    ))
+  return {
+    _collectionName: linkCollectionName(d.name),
+    connect: async (aId, bId, meta) => (await load()).connect(aId, bId, meta),
+    disconnect: async (aId, bId) => (await load()).disconnect(aId, bId),
+    has: async (aId, bId) => (await load()).has(aId, bId),
+    of: async (id) => (await load()).of(id),
+    list: async () => (await load()).list(),
+    _rowsTouchingEndpoint: async (collection, id) => (await load())._rowsTouchingEndpoint(collection, id),
+  }
+}

--- a/packages/hub/src/with-shape/links/link-set.ts
+++ b/packages/hub/src/with-shape/links/link-set.ts
@@ -24,70 +24,25 @@ import { NOYDB_FORMAT_VERSION } from '../../kernel/types.js'
 import { encrypt, openEnvelopeJson, type EnclaveKey } from '../../kernel/enclave/index.js'
 import { NoydbError } from '../../kernel/errors.js'
 
-export const LINK_COLLECTION_PREFIX = '_links_'
-
-/** Storage collection name for a logical link set. */
-export function linkCollectionName(name: string): string {
-  return `${LINK_COLLECTION_PREFIX}${name}`
-}
-
-/** True for any reserved link-collection name. */
-export function isLinkCollectionName(name: string): boolean {
-  return name.startsWith(LINK_COLLECTION_PREFIX)
-}
-
-/** What happens to a link's rows when one of its endpoint records is deleted. */
-export type LinkOnDelete = 'cascade' | 'strict' | 'warn'
-
-/**
- * Declaration for a link set, passed to `vault.link(name, spec)`. `a` and
- * `b` are the endpoint collection names (slot-typed). `onDelete` governs
- * what happens to link rows when an endpoint record is deleted:
- * `'cascade'` (default) removes the touching link rows, `'strict'` blocks
- * the endpoint delete while links exist, `'warn'` leaves orphan rows
- * (surfaced by `vault.checkIntegrity()`).
- */
-export interface LinkSpec {
-  readonly a: string
-  readonly b: string
-  readonly onDelete?: LinkOnDelete
-}
-
-/** One link tuple as returned by `of()` / `list()`. */
-export interface LinkRow {
-  readonly a: string
-  readonly b: string
-  readonly meta?: Record<string, unknown>
-}
+// Naming helpers, declaration types, and LinkIntegrityError live in
+// `names.ts` (the always-loadable slice — #553); re-exported here so
+// existing import paths and the root barrel are unchanged.
+export {
+  LINK_COLLECTION_PREFIX,
+  linkCollectionName,
+  isLinkCollectionName,
+  linkRowKey,
+  LinkIntegrityError,
+} from './names.js'
+export type { LinkOnDelete, LinkSpec, LinkRow, LinkSetHandle } from './names.js'
+import { linkCollectionName, linkRowKey } from './names.js'
+import type { LinkSpec, LinkRow, LinkSetHandle } from './names.js'
 
 /** Stored form (also the row key derivation source). */
 interface LinkEntry {
   a: string
   b: string
   meta?: Record<string, unknown>
-}
-
-/**
- * Compose the row key for an ordered `(a, b)` pair. Each id is
- * URI-encoded and joined with `|` — encodeURIComponent escapes `|`, so the
- * key is unambiguous regardless of id contents.
- */
-export function linkRowKey(aId: string, bId: string): string {
-  return `${encodeURIComponent(aId)}|${encodeURIComponent(bId)}`
-}
-
-/** Public handle returned by `vault.links(name)`. */
-export interface LinkSetHandle {
-  /** Create (or overwrite the metadata of) the link `(aId, bId)`. Validates both endpoints exist. */
-  connect(aId: string, bId: string, meta?: Record<string, unknown>): Promise<void>
-  /** Remove the link `(aId, bId)`. Idempotent — a no-op if it doesn't exist. */
-  disconnect(aId: string, bId: string): Promise<void>
-  /** Whether the link `(aId, bId)` exists. */
-  has(aId: string, bId: string): Promise<boolean>
-  /** All links touching `id` on EITHER endpoint. */
-  of(id: string): Promise<LinkRow[]>
-  /** All links in the set. */
-  list(): Promise<LinkRow[]>
 }
 
 /**
@@ -206,24 +161,5 @@ export class LinkEndpointError extends NoydbError {
     this.link = link
     this.endpoint = endpoint
     this.missingId = missingId
-  }
-}
-
-/** Thrown when a `strict` link blocks deletion of an endpoint that still has links. */
-export class LinkIntegrityError extends NoydbError {
-  readonly link: string
-  readonly endpoint: string
-  readonly id: string
-  readonly count: number
-  constructor(link: string, endpoint: string, id: string, count: number) {
-    super(
-      'LINK_INTEGRITY',
-      `Cannot delete "${endpoint}"/"${id}": ${count} link(s) in "${link}" still reference it (onDelete: 'strict').`,
-    )
-    this.name = 'LinkIntegrityError'
-    this.link = link
-    this.endpoint = endpoint
-    this.id = id
-    this.count = count
   }
 }

--- a/packages/hub/src/with-shape/links/names.ts
+++ b/packages/hub/src/with-shape/links/names.ts
@@ -1,0 +1,91 @@
+/**
+ * Link-set naming helpers, declaration types, and errors — the tiny,
+ * always-loadable slice of the links feature (#553).
+ *
+ * Split out of `link-set.ts` so the kernel floor (reserved-name guard in
+ * `vault.collection()`, the lazy `vault.links()` handle) and the ref/link
+ * enforcement facade can bind these few lines WITHOUT statically pulling
+ * the `LinkSet` storage engine; that class now loads via dynamic import
+ * on first link I/O. `link-set.ts` re-exports everything here, so import
+ * paths and class identities are unchanged for existing consumers.
+ */
+
+import { NoydbError } from '../../kernel/errors.js'
+
+export const LINK_COLLECTION_PREFIX = '_links_'
+
+/** Storage collection name for a logical link set. */
+export function linkCollectionName(name: string): string {
+  return `${LINK_COLLECTION_PREFIX}${name}`
+}
+
+/** True for any reserved link-collection name. */
+export function isLinkCollectionName(name: string): boolean {
+  return name.startsWith(LINK_COLLECTION_PREFIX)
+}
+
+/** What happens to a link's rows when one of its endpoint records is deleted. */
+export type LinkOnDelete = 'cascade' | 'strict' | 'warn'
+
+/**
+ * Declaration for a link set, passed to `vault.link(name, spec)`. `a` and
+ * `b` are the endpoint collection names (slot-typed). `onDelete` governs
+ * what happens to link rows when an endpoint record is deleted:
+ * `'cascade'` (default) removes the touching link rows, `'strict'` blocks
+ * the endpoint delete while links exist, `'warn'` leaves orphan rows
+ * (surfaced by `vault.checkIntegrity()`).
+ */
+export interface LinkSpec {
+  readonly a: string
+  readonly b: string
+  readonly onDelete?: LinkOnDelete
+}
+
+/** One link tuple as returned by `of()` / `list()`. */
+export interface LinkRow {
+  readonly a: string
+  readonly b: string
+  readonly meta?: Record<string, unknown>
+}
+
+/**
+ * Compose the row key for an ordered `(a, b)` pair. Each id is
+ * URI-encoded and joined with `|` — encodeURIComponent escapes `|`, so the
+ * key is unambiguous regardless of id contents.
+ */
+export function linkRowKey(aId: string, bId: string): string {
+  return `${encodeURIComponent(aId)}|${encodeURIComponent(bId)}`
+}
+
+/** Public handle returned by `vault.links(name)`. */
+export interface LinkSetHandle {
+  /** Create (or overwrite the metadata of) the link `(aId, bId)`. Validates both endpoints exist. */
+  connect(aId: string, bId: string, meta?: Record<string, unknown>): Promise<void>
+  /** Remove the link `(aId, bId)`. Idempotent — a no-op if it doesn't exist. */
+  disconnect(aId: string, bId: string): Promise<void>
+  /** Whether the link `(aId, bId)` exists. */
+  has(aId: string, bId: string): Promise<boolean>
+  /** All links touching `id` on EITHER endpoint. */
+  of(id: string): Promise<LinkRow[]>
+  /** All links in the set. */
+  list(): Promise<LinkRow[]>
+}
+
+/** Thrown when a `strict` link blocks deletion of an endpoint that still has links. */
+export class LinkIntegrityError extends NoydbError {
+  readonly link: string
+  readonly endpoint: string
+  readonly id: string
+  readonly count: number
+  constructor(link: string, endpoint: string, id: string, count: number) {
+    super(
+      'LINK_INTEGRITY',
+      `Cannot delete "${endpoint}"/"${id}": ${count} link(s) in "${link}" still reference it (onDelete: 'strict').`,
+    )
+    this.name = 'LinkIntegrityError'
+    this.link = link
+    this.endpoint = endpoint
+    this.id = id
+    this.count = count
+  }
+}

--- a/packages/hub/src/with-shape/links/vault-facade.ts
+++ b/packages/hub/src/with-shape/links/vault-facade.ts
@@ -19,10 +19,12 @@ import {
   linkCollectionName,
   linkRowKey,
   LinkIntegrityError,
-  type LinkSet,
   type LinkSpec,
   type LinkSetHandle,
-} from './link-set.js'
+} from './names.js'
+// Type-only -- the LinkSet storage engine loads via dynamic import in the
+// Vault's lazy links() handle (#553); this facade only needs its shape.
+import type { LinkSet } from './link-set.js'
 import type { JoinableSource } from '../../kernel/query/index.js'
 import type { Collection } from '../../kernel/collection.js'
 import type { NoydbStore } from '../../kernel/types.js'

--- a/packages/hub/src/with-shape/money/descriptor.ts
+++ b/packages/hub/src/with-shape/money/descriptor.ts
@@ -17,6 +17,7 @@
 import type { RoundingMode } from './fixed-point.js'
 import { scaleForCurrency } from './iso4217.js'
 import { NoydbError } from '../../kernel/errors.js'
+import { linkMoneyEngine } from './engine.js'
 
 export interface MoneyOptionsFixed {
   currency: string
@@ -108,6 +109,11 @@ function isMultiOptions(o: MoneyOptions): o is MoneyOptionsMulti {
 
 /** Create a {@link MoneyDescriptor}. */
 export function money(options: MoneyOptions): MoneyDescriptor {
+  // The declaration is the engine's opt-in unit (#553): constructing a
+  // descriptor statically links normalize/paths/where/money-reducer into
+  // the kernel's runtime seam, so every later kernel consultation
+  // (including the SYNC query DSL) finds the engine already present.
+  linkMoneyEngine()
   const hasFixed = 'currency' in options
   const hasMulti = 'currencies' in options
   if (hasFixed && hasMulti) {

--- a/packages/hub/src/with-shape/money/engine.ts
+++ b/packages/hub/src/with-shape/money/engine.ts
@@ -1,0 +1,49 @@
+/**
+ * Links the money engine into the kernel's runtime seam (#553).
+ *
+ * Called by `money()` when a descriptor is constructed — the schema
+ * declaration is the opt-in unit, so declaring a money field is what
+ * pulls the engine (normalize / paths / where / money-reducer) into the
+ * consumer's bundle. The kernel floor itself only imports the tiny
+ * holder in `kernel/money-runtime.ts` (plus this module's TYPE); without
+ * a `money()` call the whole family tree-shakes out.
+ */
+import { installMoneyEngine } from '../../kernel/money-runtime.js'
+import {
+  quantizeMoneyFields,
+  decodeMoneyFields,
+  canonicalizeStoredMoney,
+  canonicalizeIncomingMoney,
+  moneyScaledValue,
+} from './normalize.js'
+import { validateMoneyFieldPaths } from './paths.js'
+import { moneyFieldClause, evaluateMoneyClause } from './where.js'
+import { wrapMoneyReducers } from './money-reducer.js'
+
+/** The engine functions the kernel floor consults on money-declared collections. */
+export interface MoneyEngine {
+  readonly quantizeMoneyFields: typeof quantizeMoneyFields
+  readonly decodeMoneyFields: typeof decodeMoneyFields
+  readonly canonicalizeStoredMoney: typeof canonicalizeStoredMoney
+  readonly canonicalizeIncomingMoney: typeof canonicalizeIncomingMoney
+  readonly moneyScaledValue: typeof moneyScaledValue
+  readonly validateMoneyFieldPaths: typeof validateMoneyFieldPaths
+  readonly moneyFieldClause: typeof moneyFieldClause
+  readonly evaluateMoneyClause: typeof evaluateMoneyClause
+  readonly wrapMoneyReducers: typeof wrapMoneyReducers
+}
+
+/** Idempotent — safe to call once per `money()` invocation. */
+export function linkMoneyEngine(): void {
+  installMoneyEngine({
+    quantizeMoneyFields,
+    decodeMoneyFields,
+    canonicalizeStoredMoney,
+    canonicalizeIncomingMoney,
+    moneyScaledValue,
+    validateMoneyFieldPaths,
+    moneyFieldClause,
+    evaluateMoneyClause,
+    wrapMoneyReducers,
+  })
+}

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -1043,7 +1043,6 @@ const PRE_EXISTING_SPINE_SERVICE_IMPORTS = new Map([
     '../with-shape/introspection/field-meta.js',
     '../with-shape/introspection/meta.js',
     '../with-shape/money/descriptor.js',
-    '../with-shape/money/paths.js',
     '../with-shape/schema-update/fence-controller.js',
     '../with-shape/schema-update/gate.js',
   ]],
@@ -1058,6 +1057,8 @@ const PRE_EXISTING_SPINE_SERVICE_IMPORTS = new Map([
     '../with-commit/history/strategy.js',
     '../with-commit/tx/transaction.js',
     '../with-formula/computed/index.js',
+    // #553 -- tiny lazy-loader seam; the computed engine itself now dynamic-imports
+    '../with-formula/computed/lazy.js',
     '../with-formula/derivations/executor.js',
     '../with-formula/derivations/fanout-sidecar.js',
     '../with-formula/derivations/registry.js',
@@ -1104,12 +1105,9 @@ const PRE_EXISTING_SPINE_SERVICE_IMPORTS = new Map([
     '../with-shape/i18n/strategy.js',
     '../with-shape/introspection/describe.js',
     '../with-shape/introspection/field-meta.js',
-    '../with-shape/introspection/json-schema.js',
     '../with-shape/introspection/meta.js',
     '../with-shape/introspection/types.js',
     '../with-shape/money/descriptor.js',
-    '../with-shape/money/normalize.js',
-    '../with-shape/money/paths.js',
     '../with-shape/persisted-schemas/derive.js',
     '../with-shape/schema-update/fence-controller.js',
     '../with-shape/schema-update/gate.js',
@@ -1252,9 +1250,11 @@ const PRE_EXISTING_SPINE_SERVICE_IMPORTS = new Map([
     '../with-shape/introspection/meta.js',
     '../with-shape/introspection/types.js',
     '../with-shape/introspection/walk.js',
-    '../with-shape/links/link-set.js',
+    // #553 -- always-loadable links slice (naming/types + the lazy handle
+    // factory); the LinkSet storage engine itself now dynamic-imports
+    '../with-shape/links/lazy-handle.js',
+    '../with-shape/links/names.js',
     '../with-shape/links/vault-facade.js',
-    '../with-shape/persisted-schemas/register.js',
     '../with-shape/schema-update/fence-controller.js',
     '../with-shape/schema-update/fence-watcher.js',
     '../with-shape/schema-update/fence.js',
@@ -1268,9 +1268,6 @@ const PRE_EXISTING_SPINE_SERVICE_IMPORTS = new Map([
     '../../with-lookup/aggregate/strategy.js',
     '../../with-lookup/indexing/eager-indexes.js',
     '../../with-shape/money/descriptor.js',
-    '../../with-shape/money/money-reducer.js',
-    '../../with-shape/money/normalize.js',
-    '../../with-shape/money/where.js',
   ]],
   ['packages/hub/src/kernel/query/index.ts', [
     '../../with-lookup/aggregate/aggregation.js',
@@ -1281,6 +1278,11 @@ const PRE_EXISTING_SPINE_SERVICE_IMPORTS = new Map([
   ['packages/hub/src/kernel/query/join.ts', [
     '../../with-shape/i18n/core.js',
   ]],
+  ['packages/hub/src/kernel/money-runtime.ts', [
+    // #553 -- TYPE-only (erased) import of the MoneyEngine interface; the
+    // engine values are linked at runtime by money() via installMoneyEngine()
+    '../with-shape/money/engine.js',
+  ]],
   ['packages/hub/src/kernel/query/predicate.ts', [
     '../../with-shape/money/where.js',
   ]],
@@ -1288,8 +1290,6 @@ const PRE_EXISTING_SPINE_SERVICE_IMPORTS = new Map([
     '../../with-lookup/aggregate/aggregation.js',
     '../../with-lookup/aggregate/reducers.js',
     '../../with-shape/money/descriptor.js',
-    '../../with-shape/money/normalize.js',
-    '../../with-shape/money/where.js',
   ]],
   ['packages/hub/src/kernel/enclave/record-keys/record-codec.ts', [
     '../../../with-commit/crdt/crdt.js',


### PR DESCRIPTION
The archetype-③ schema features (computed, money, links, introspection, schema-update) were statically imported into the kernel floor, so a collection that never declared them still shipped their engines. This moves each engine behind a seam **triggered by the schema declaration**. Context: `docs/superpowers/plans/2026-07-01-service-layer-withx.md` Task 12 (S4).

## What moved behind which seam

| Engine | Seam | Why this seam |
|---|---|---|
| **money** (`normalize` / `paths` / `where` / `money-reducer`) | **Declaration-carried linking**: `money()` statically links the engine (`with-shape/money/engine.ts`) and installs it into the new `kernel/money-runtime.ts` holder; the kernel + query DSL consult `moneyRuntime()`. | The query DSL executes **synchronously** (`toArray()`/`first()`/`count()`), `where()` quantizes operands at build time (documented "throws at the call site"), and `moneyFields` path validation throws at declaration time. An `await import()` here would either break those sync semantics or race a fire-and-forget preload. Since a money declaration requires the caller's own `money()` import, the declaration itself carries the engine — sync error timing preserved exactly, and an undeclared consumer tree-shakes the whole family. (A hand-rolled descriptor object not built by `money()` now throws `MONEY_ENGINE_NOT_LINKED` with an actionable message; no such construction exists in-repo.) |
| **computed** (`evalComputedFields`) | Dynamic import on the first computed-declared `put()` (`with-formula/computed/lazy.ts`, cached after first load). | The engine's only kernel consultation is the async write pipeline. |
| **links** (`LinkSet` storage engine) | `vault.links()` returns a cached lazy handle (`with-shape/links/lazy-handle.ts`) whose all-async surface dynamic-imports `LinkSet` on the first link I/O. Naming helpers / declaration types / `LinkIntegrityError` moved to `links/names.ts` (re-exported from `link-set.ts`, so import paths and class identities are unchanged). | `links()` is sync but every handle method is async. The ref-enforcement facade (`VaultLinks`) stays static — refs are kernel-core, and its `resolveRef`/`resolveSource` are consulted from the sync query-join path. |
| **schema-update** (`persistSchemaIfNeeded` → delta/dispatch engine, `FenceWatcher`) | Dynamic imports at their async-only call sites (the two async persistence IIFEs in `vault.collection()`, and the now-async internal `_ensureFenceCoordination()`). | `SchemaUpdateGate`, `SchemaFenceController`, **and `loadFence` deliberately stay static**: a **remote** client's coordinated cutover must fence this client's writes even when it declared no `schemaUpdate` strategies, and `schemaFenceState()` is a documented "thin live read" that UI bindings (e.g. `in-vue`'s `useMigrationState`) seed from within one tick — lazying it was tried and measurably regressed that timing (caught by the in-vue suite), so it was reverted. |
| **introspection** (`dumpVaultSchema` walker, `buildJsonSchema`) | Dynamic imports inside the async `vault.dumpSchema()` / `collection.toJSONSchema()`. | The `describe()` spine (`buildDescription`) stays static — no-args `describe()` is a **public sync** method, and the no-sync→async constraint rules out lazying it. This is the remaining static slice of introspection. |

No public API changed; no sync method became async. (`Vault._ensureFenceCoordination`, an underscore-internal with no external callers, went `void → Promise<void>`; both in-repo call sites are async.)

## Classified spine (grandfathered debt)

**Not converted — structurally different, as the issue anticipated.** The spine (`resolve.ts` / `guards.ts` / `write.ts`) is consulted from **sync declaration paths** (`vault.collection()` config resolution, the `_applyClassifiedFields` reconcile), and unlike money a `ClassifiedFieldSpec` is a **plain branded object** (`_noydbClassified: true`) with no mandatory factory call — hand-rolled specs are valid, so the declaration-carried-linking trick that works for `money()` has no sound trigger. The heavy crypto engines (`enclave/classify/*`) were already behind dynamic imports in `active.ts` and stay that way.

## Bundle evidence (entry-chunk metric)

`check-bundle.mjs` measures the **entry chunk only** (post-#130 splitting mode); the discriminating signal for this change is the **eager-import prologue scan**, which now has 11 new canaries on the floor scenario + 3 on analytics — all green, i.e. none of the ③ engines is statically imported by the floor's entry anymore:

- Floor entry chunk: 403 → **440 B gz** (+37 B of seam glue: the money holder, lazy handle trampolines). Manifest re-baselined via `BUNDLE_BASELINE_UPDATE`.
- The engines never lived in the entry chunk itself — they sat in *statically-imported shared chunks*, which the entry-only metric doesn't charge. The change shows in the floor consumer's **eagerly-loaded total** (entry + transitively statically-imported chunks, esbuild `splitting: true` against the built dist): **399,388 → 384,877 B min (−14,511); 117,110 → 111,921 B gz (−5,189)**. Engine-internal code (e.g. the money fixed-point arithmetic, `parseToScaledInt`) verifiably left the eager set.
- Residual caveat: functions that are ALSO public root-barrel exports (`persistSchemaIfNeeded`, `computeSchemaDelta`, `evalComputedFields`, `buildDescription`) remain reachable through dist chunk co-location for consumers whose bundler doesn't shake them — a public-API surface question, out of scope here.

## Guards & ratchets

- `pnpm check:architecture` green. The `port-layering` spine-import baseline **shrank by 9 grandfathered static `with-*` entries** against 4 new tiny-seam entries (each justified inline: the `computed/lazy` loader, `links/names` + `links/lazy-handle`, and a TYPE-only `money/engine` import) — net **−5**.
- `kernel-surface` ceilings untouched and still met: collection.ts 4480/4481, vault.ts 3865/3866, noydb.ts 2326/2327 — seam code moved into satellite modules instead of growing the spine.
- `root-barrel` / `kernel-api` / cargo goldens: **unchanged** — no export added or removed on any public surface.

## Test evidence

- New `packages/hub/__tests__/lazy-schema-engines.test.ts`: (a) a floor collection with no declarations completes its whole write/read/query lifecycle with the money engine **never installed** (`isMoneyEngineInstalled() === false`, `moneyRuntime()` throws with an actionable message); (b) each converted engine behaves identically when declared — money quantize / sync `where()` incl. build-time operand throw / BigInt orderBy / exact `sum()` / decode; computed materialization on first put; lazy cached links handle incl. cascade-on-delete; schema-update gated writes + `schemaFenceState()`; `dumpSchema()` / `toJSONSchema()` / sync `describe()`.
- Full hub suite: **396 files / 3,185 tests passed**. Full satellite suite: **109/109 tasks passed** (hub-alone + satellites-at-concurrency-4, the same split the repo's gate loop uses; the in-vue `useMigrationState` seed-timing test drove the `loadFence` revert and is green).
- `pnpm --filter @noy-db/hub typecheck` (3 tsconfigs) + `eslint src/` + `bundle-check` + `pnpm check:architecture` green.

Closes #553
