### PR TITLE
fix(security): reserved secret-collections unreadable by granted principals

### DIFF
--- a/packages/hub/__tests__/reserved-secret-collection-leak.test.ts
+++ b/packages/hub/__tests__/reserved-secret-collection-leak.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Security regression — secret-bearing reserved collections must be
+ * unreadable by granted (sub-admin) principals.
+ *
+ * Before the fix, two independent seams combined into a plaintext leak of the
+ * vault's sync transport credentials:
+ *
+ *   1. `vault.collection('_sync_credentials')` returned a working handle — the
+ *      generic public read path had no guard for secret-bearing reserved names
+ *      (only `_dict_*`, `_sequences`, `_links_*` were rejected), so it decrypted
+ *      with whatever DEK the caller's keyring held, bypassing the owner/admin
+ *      gate on the dedicated `getCredential` API.
+ *
+ *   2. `grant()` propagated EVERY `_`-prefixed DEK to EVERY new keyring
+ *      regardless of role, so a freshly-granted operator/client received the
+ *      `_sync_credentials` DEK.
+ *
+ * Combined: a granted operator could read the firm's plaintext OAuth tokens.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope } from '../src/kernel/types.js'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { ReservedCollectionNameError } from '../src/kernel/errors.js'
+import { withTeam } from '../src/with-party/team/index.js'
+import {
+  createOwnerKeyring,
+  grant,
+  loadKeyring,
+  ensureCollectionDEK,
+} from '../src/with-party/team/keyring.js'
+import { putCredential, getCredential } from '../src/with-party/team/sync-credentials.js'
+import {
+  SYNC_CREDENTIALS_COLLECTION,
+  BROKER_COLLECTION,
+} from '../src/with-party/team/reserved-secret-collections.js'
+import { LEDGER_COLLECTION } from '../src/with-commit/history/ledger/constants.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'inline-memory',
+    async get(c, col, id) { return gc(c, col).get(id) ?? null },
+    async put(c, col, id, env) { gc(c, col).set(id, env) },
+    async delete(c, col, id) { gc(c, col).delete(id) },
+    async list(c, col) { return [...gc(c, col).keys()] },
+    async loadAll() { return {} },
+    async saveAll() {},
+    capabilities: { casAtomic: true, auth: { kind: 'none' } },
+  } as unknown as NoydbStore
+}
+
+const COMP = 'acme'
+const OWNER_SECRET = 'owner passphrase long enough to be safe'
+const OP_SECRET = 'operator passphrase long enough to be safe'
+const ADMIN_SECRET = 'admin passphrase long enough to be safe'
+
+const GDRIVE = {
+  adapterId: 'google-drive',
+  tokenType: 'Bearer',
+  accessToken: 'ya29.SUPER-SECRET-access-token',
+  refreshToken: 'refresh-token-XYZ',
+  expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+  scopes: 'https://www.googleapis.com/auth/drive.file',
+}
+
+describe('reserved secret-collections — Layer 1: vault.collection() guard', () => {
+  it('rejects vault.collection("_sync_credentials") — even for the owner', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'owner', secret: OWNER_SECRET })
+    const vault = await db.openVault(COMP)
+    expect(() => vault.collection(SYNC_CREDENTIALS_COLLECTION)).toThrow(ReservedCollectionNameError)
+  })
+
+  it('reserves vault.collection("_broker") ahead of the broker (#479)', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'owner', secret: OWNER_SECRET })
+    const vault = await db.openVault(COMP)
+    expect(() => vault.collection(BROKER_COLLECTION)).toThrow(ReservedCollectionNameError)
+  })
+
+  it('still allows ordinary data collections', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({ teamStrategy: withTeam(), store, user: 'owner', secret: OWNER_SECRET })
+    const vault = await db.openVault(COMP)
+    expect(() => vault.collection('invoices')).not.toThrow()
+  })
+})
+
+describe('reserved secret-collections — Layer 2: grant DEK propagation', () => {
+  it('does NOT propagate the _sync_credentials DEK to a granted operator', async () => {
+    const store = inlineMemory()
+    const owner = await createOwnerKeyring(store, COMP, 'owner', OWNER_SECRET)
+    // Owner creates a credential → owner keyring now holds the _sync_credentials DEK.
+    await putCredential(store, COMP, owner, GDRIVE)
+    expect(owner.deks.has(SYNC_CREDENTIALS_COLLECTION)).toBe(true)
+
+    await grant(store, COMP, owner, {
+      userId: 'op1',
+      displayName: 'Operator',
+      role: 'operator',
+      passphrase: OP_SECRET,
+      permissions: { invoices: 'rw' },
+    })
+    const op = await loadKeyring(store, COMP, 'op1', OP_SECRET)
+    expect(op.deks.has(SYNC_CREDENTIALS_COLLECTION)).toBe(false)
+  })
+
+  it('does NOT propagate a secret-bearing DEK to a granted client/viewer either', async () => {
+    const store = inlineMemory()
+    const owner = await createOwnerKeyring(store, COMP, 'owner', OWNER_SECRET)
+    await putCredential(store, COMP, owner, GDRIVE)
+
+    await grant(store, COMP, owner, {
+      userId: 'v1', displayName: 'Viewer', role: 'viewer', passphrase: OP_SECRET,
+    })
+    const viewer = await loadKeyring(store, COMP, 'v1', OP_SECRET)
+    expect(viewer.deks.has(SYNC_CREDENTIALS_COLLECTION)).toBe(false)
+  })
+
+  it('does NOT leak the DEK even when the grantor names it explicitly in permissions', async () => {
+    const store = inlineMemory()
+    const owner = await createOwnerKeyring(store, COMP, 'owner', OWNER_SECRET)
+    await putCredential(store, COMP, owner, GDRIVE)
+
+    await grant(store, COMP, owner, {
+      userId: 'op1', displayName: 'Operator', role: 'operator', passphrase: OP_SECRET,
+      // Deliberate escalation attempt: name the reserved secret collection.
+      permissions: { invoices: 'rw', [SYNC_CREDENTIALS_COLLECTION]: 'rw' },
+    })
+    const op = await loadKeyring(store, COMP, 'op1', OP_SECRET)
+    expect(op.deks.has(SYNC_CREDENTIALS_COLLECTION)).toBe(false)
+  })
+
+  it('KEEPS propagating operational reserved DEKs (_ledger) to a granted operator', async () => {
+    const store = inlineMemory()
+    const owner = await createOwnerKeyring(store, COMP, 'owner', OWNER_SECRET)
+    // Materialise an operational reserved DEK on the owner keyring.
+    const getDek = await ensureCollectionDEK(store, COMP, owner)
+    await getDek(LEDGER_COLLECTION)
+    expect(owner.deks.has(LEDGER_COLLECTION)).toBe(true)
+
+    await grant(store, COMP, owner, {
+      userId: 'op1', displayName: 'Operator', role: 'operator', passphrase: OP_SECRET,
+      permissions: { invoices: 'rw' },
+    })
+    const op = await loadKeyring(store, COMP, 'op1', OP_SECRET)
+    expect(op.deks.has(LEDGER_COLLECTION)).toBe(true)
+  })
+
+  it('STILL propagates the _sync_credentials DEK to a granted ADMIN (legit flow preserved)', async () => {
+    const store = inlineMemory()
+    const owner = await createOwnerKeyring(store, COMP, 'owner', OWNER_SECRET)
+    await putCredential(store, COMP, owner, GDRIVE)
+
+    await grant(store, COMP, owner, {
+      userId: 'admin1', displayName: 'Admin', role: 'admin', passphrase: ADMIN_SECRET,
+    })
+    const admin = await loadKeyring(store, COMP, 'admin1', ADMIN_SECRET)
+    expect(admin.deks.has(SYNC_CREDENTIALS_COLLECTION)).toBe(true)
+    // And the admin can read the owner's existing credential through the gated API.
+    const got = await getCredential(store, COMP, admin, 'google-drive')
+    expect(got?.accessToken).toBe(GDRIVE.accessToken)
+  })
+})
+
+describe('reserved secret-collections — end-to-end exploit is closed', () => {
+  it('a granted operator can neither open the handle nor hold the DEK', async () => {
+    const store = inlineMemory()
+
+    // Owner enrols a credential.
+    const ownerDb = await createNoydb({ teamStrategy: withTeam(), store, user: 'owner', secret: OWNER_SECRET })
+    await ownerDb.openVault(COMP)
+    const ownerKeyring = await ownerDb.getKeyring(COMP)
+    await putCredential(store, COMP, ownerKeyring, GDRIVE)
+
+    // Re-open owner so the live keyring reloads the persisted _sync_credentials DEK,
+    // then grant an operator (this is where propagation would have leaked the DEK).
+    const ownerDb2 = await createNoydb({ teamStrategy: withTeam(), store, user: 'owner', secret: OWNER_SECRET })
+    await ownerDb2.openVault(COMP)
+    await ownerDb2.grant(COMP, {
+      userId: 'op1', displayName: 'Operator', role: 'operator', passphrase: OP_SECRET,
+      permissions: { invoices: 'rw' },
+    })
+
+    // Operator connects and tries the exploit.
+    const opDb = await createNoydb({ teamStrategy: withTeam(), store, user: 'op1', secret: OP_SECRET })
+    const opVault = await opDb.openVault(COMP)
+
+    // Layer 1: public handle path is blocked.
+    expect(() => opVault.collection(SYNC_CREDENTIALS_COLLECTION)).toThrow(ReservedCollectionNameError)
+
+    // Layer 2: the DEK never reached the operator's keyring.
+    const opKeyring = await opDb.getKeyring(COMP)
+    expect(opKeyring.deks.has(SYNC_CREDENTIALS_COLLECTION)).toBe(false)
+  })
+})

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -28,6 +28,7 @@ import { OverlayedCollection } from '../with-formula/overlay-views/virtual-colle
 import type { PublicEnvelope } from '../with-party/directory/public-envelope/types.js'
 import { buildRecipientKeyringFile } from '../with-party/team/keyring.js'
 import { ensureCollectionDEK, hasAccess } from '../with-party/team/keyring.js'
+import { isSecretBearingReservedCollection } from '../with-party/team/reserved-secret-collections.js'
 import {
   assertCanExport as assertCanExportCapability,
   assertCanImport as assertCanImportCapability,
@@ -863,6 +864,15 @@ export class Vault {
     }
     // Guard: reject reserved _links_* names — use vault.link()/vault.links() instead.
     if (isLinkCollectionName(collectionName)) {
+      throw new ReservedCollectionNameError(collectionName)
+    }
+    // Guard: reject secret-bearing reserved names (`_sync_credentials`,
+    // `_broker`). Their record CONTENTS are directly-usable secrets, so they
+    // must never be reachable through the generic public collection handle —
+    // they are served only by their dedicated, owner/admin-gated API. Serving
+    // them here would decrypt with whatever DEK the caller's keyring holds,
+    // bypassing that gate. See reserved-secret-collections.ts.
+    if (isSecretBearingReservedCollection(collectionName)) {
       throw new ReservedCollectionNameError(collectionName)
     }
 

--- a/packages/hub/src/with-party/team/keyring.ts
+++ b/packages/hub/src/with-party/team/keyring.ts
@@ -22,6 +22,7 @@ import {
   loadUserEnvelope as loadUserEnvelopeFn,
   deleteUserEnvelope,
 } from '../directory/user-envelope/index.js'
+import { isSecretBearingReservedCollection } from './reserved-secret-collections.js'
 
 // ─── Roles that can grant/revoke ───────────────────────────────────────
 
@@ -440,9 +441,23 @@ export async function grant(
   const newSalt = generateSalt()
   const newKek = await deriveKey(options.passphrase, newSalt)
 
+  // Only owner and admin may ever hold a secret-bearing reserved DEK
+  // (`_sync_credentials`, `_broker`) — they are the roles the dedicated
+  // credential API admits. Every other grantee (custodian, viewer, operator,
+  // client) is excluded, even from the "wrap ALL" branches below: a custodian
+  // operates the DATA but must never read the firm's transport secrets (see
+  // `requireAdminAccess` in sync-credentials.ts), and handing any sub-admin
+  // one of these DEKs is a plaintext leak, not a metadata leak.
+  const granteeMayHoldSecrets =
+    options.role === 'owner' || options.role === 'admin'
+
   // Wrap the appropriate DEKs with the new user's KEK
   const wrappedDeks: Record<string, string> = {}
   for (const collName of Object.keys(permissions)) {
+    // Never hand a secret-bearing reserved DEK to a sub-admin, even if the
+    // grantor explicitly names it in `permissions` — that path is served
+    // only by the owner/admin-gated credential API, not per-collection grants.
+    if (isSecretBearingReservedCollection(collName) && !granteeMayHoldSecrets) continue
     const dek = callerKeyring.deks.get(collName)
     if (dek) {
       wrappedDeks[collName] = await wrapKey(dek, newKek)
@@ -460,9 +475,9 @@ export async function grant(
     options.role === 'viewer'
   ) {
     for (const [collName, dek] of callerKeyring.deks) {
-      if (!(collName in wrappedDeks)) {
-        wrappedDeks[collName] = await wrapKey(dek, newKek)
-      }
+      if (collName in wrappedDeks) continue
+      if (isSecretBearingReservedCollection(collName) && !granteeMayHoldSecrets) continue
+      wrappedDeks[collName] = await wrapKey(dek, newKek)
     }
   }
 
@@ -480,10 +495,19 @@ export async function grant(
   // plaintext leak — the ledger entries record collection names,
   // record ids, and ciphertext hashes, but never plaintext records.
   // Per-collection ledger DEKs are tracked as a follow-up.
+  //
+  // EXCEPTION — secret-bearing reserved collections (`_sync_credentials`,
+  // `_broker`) whose record CONTENTS are directly-usable secrets are NOT
+  // propagated to sub-admin grantees. Unlike the operational collections
+  // above, handing an operator/viewer/client/custodian one of these DEKs
+  // IS a plaintext leak (the firm's transport OAuth tokens). Only owner and
+  // admin — the roles the dedicated `getCredential`/`putCredential` API
+  // admits — receive them, so the legit admin-reads-existing-credential
+  // flow (which needs the DEK to decrypt, not regenerate) still works.
   for (const [collName, dek] of callerKeyring.deks) {
-    if (collName.startsWith('_') && !(collName in wrappedDeks)) {
-      wrappedDeks[collName] = await wrapKey(dek, newKek)
-    }
+    if (!collName.startsWith('_') || collName in wrappedDeks) continue
+    if (isSecretBearingReservedCollection(collName) && !granteeMayHoldSecrets) continue
+    wrappedDeks[collName] = await wrapKey(dek, newKek)
   }
 
   // Anti-privilege-escalation check. Every DEK we just

--- a/packages/hub/src/with-party/team/reserved-secret-collections.ts
+++ b/packages/hub/src/with-party/team/reserved-secret-collections.ts
@@ -1,0 +1,50 @@
+/**
+ * Secret-bearing reserved collections — the `_`-prefixed reserved collections
+ * whose record CONTENTS are directly-usable secrets (transport OAuth tokens,
+ * connection strings, API keys), as opposed to the *operational* reserved
+ * collections (`_ledger`, `_history`, `_sync`, …) whose contents are metadata
+ * (collection names, record ids, ciphertext hashes).
+ *
+ * This distinction matters at two trust-boundary seams:
+ *
+ *  1. `vault.collection()` — a secret-bearing reserved name must never be
+ *     reachable through the generic public collection handle. It is served
+ *     ONLY by its dedicated, role-gated API (e.g. `_sync_credentials` →
+ *     `getCredential`/`putCredential`, which enforce owner/admin access).
+ *
+ *  2. `grant()` DEK propagation — a sub-admin grantee (operator, viewer,
+ *     client, custodian) must NOT receive a secret-bearing collection's DEK.
+ *     Operational reserved DEKs still propagate to every role (grantees must
+ *     write ledger/history entries on every mutation), but handing a
+ *     sub-admin the `_sync_credentials` DEK would let them decrypt the firm's
+ *     transport secrets — a plaintext leak, not a metadata leak.
+ *
+ * Kept dependency-free so both the kernel (`vault.ts`) and the team layer
+ * (`keyring.ts`) can import it without an import cycle.
+ */
+
+/** Reserved collection holding per-adapter sync transport secrets. */
+export const SYNC_CREDENTIALS_COLLECTION = '_sync_credentials'
+
+/**
+ * Reserved (pre-allocated) name for the future credential broker (#479).
+ * Not yet implemented — reserved now so that neither the public collection
+ * handle nor grant propagation can ever expose it before its dedicated,
+ * role-gated API lands.
+ */
+export const BROKER_COLLECTION = '_broker'
+
+/**
+ * The set of reserved collection names whose record contents are
+ * directly-usable secrets. Membership here means: never served via
+ * `vault.collection()`, never propagated to sub-admin grantees.
+ */
+export const SECRET_BEARING_RESERVED_COLLECTIONS: ReadonlySet<string> = new Set([
+  SYNC_CREDENTIALS_COLLECTION,
+  BROKER_COLLECTION,
+])
+
+/** True when `name` is a secret-bearing reserved collection. */
+export function isSecretBearingReservedCollection(name: string): boolean {
+  return SECRET_BEARING_RESERVED_COLLECTIONS.has(name)
+}

--- a/packages/hub/src/with-party/team/sync-credentials.ts
+++ b/packages/hub/src/with-party/team/sync-credentials.ts
@@ -44,8 +44,14 @@ import { encrypt, openEnvelopeJson } from '../../kernel/enclave/index.js'
 import { ensureCollectionDEK } from './keyring.js'
 import { PermissionDeniedError } from '../../kernel/errors.js'
 
-/** The reserved collection name. Never collides with user collections. */
-export const SYNC_CREDENTIALS_COLLECTION = '_sync_credentials'
+/**
+ * The reserved collection name. Never collides with user collections.
+ * Canonical definition lives in `reserved-secret-collections.ts` (shared with
+ * the `vault.collection()` guard and grant DEK-propagation); re-exported here
+ * for existing consumers.
+ */
+export { SYNC_CREDENTIALS_COLLECTION } from './reserved-secret-collections.js'
+import { SYNC_CREDENTIALS_COLLECTION } from './reserved-secret-collections.js'
 
 // ─── Token types ──────────────────────────────────────────────────────
 

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -839,7 +839,11 @@ const KERNEL_SURFACE_BUDGET = {
   // Merge 2026-07-05 (#582 ∪ #267/#580): reconciled to the TRUE post-merge line
   // count — vault.ts now carries #267's lazyStrategy plumbing AND this branch's
   // acknowledgeEquatableRisk door together. Not loosened past the real count.
-  'packages/hub/src/kernel/vault.ts': 3888,
+  // Bumped 3888 → 3898 (2026-07-05): the secret-bearing reserved-collection
+  // guard at the collection() door — a genuinely-core trust-boundary check
+  // (closes a granted-principal read path to `_sync_credentials`) that sits
+  // alongside the existing _dict_/_links_ reserved-name guards.
+  'packages/hub/src/kernel/vault.ts': 3898,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),
@@ -1280,6 +1284,10 @@ const PRE_EXISTING_SPINE_SERVICE_IMPORTS = new Map([
     '../with-party/directory/public-envelope/types.js',
     '../with-party/team/delegation.js',
     '../with-party/team/keyring.js',
+    // reserved-secret-collection guard (security fix) — the collection() door
+    // rejects secret-bearing reserved names; sibling of the grandfathered
+    // reserved-name predicates i18n/dictionary.js and links/names.js below.
+    '../with-party/team/reserved-secret-collections.js',
     '../with-party/team/magic-link-grant.js',
     '../with-party/team/managed-passphrase.js',
     '../with-party/team/sync-strategy.js',


### PR DESCRIPTION
## Summary

Fixes a **confirmed shipped** trust-boundary bug: secret-bearing reserved collections were readable by granted (sub-admin) principals, exposing the vault's plaintext sync transport credentials. **DO NOT MERGE without security review.**

## Investigation — exploit reproduced

An owner enrolled a `_sync_credentials` record, granted an `operator`, and that operator read the plaintext token via the generic collection path. Concrete repro output (scratch, pre-fix):

```
LEAKED-PLAINTEXT >>> {"adapterId":"google-drive","tokenType":"Bearer","accessToken":"ya29.SUPER-SECRET"}
```

Two independent seams combined:

1. **`vault.collection()` had no guard for secret-bearing reserved names.** It rejected only `_dict_*`, `_sequences`, `_links_*`. `vault.collection('_sync_credentials').get(id)` returned a working handle that decrypted with whatever DEK the caller's keyring held — bypassing the `requireAdminAccess` gate on the dedicated `getCredential` API.
2. **`grant()` propagated every `_`-prefixed DEK to every new keyring regardless of role.** The all-roles propagation loop (and the separate owner/admin/custodian/viewer "wrap ALL" loop) handed sub-admins the `_sync_credentials` DEK. The code comment justified this as "a metadata leak, not a plaintext leak" — true for operational collections, **false for `_sync_credentials`**, whose contents are the secret itself.

The regression suite (`reserved-secret-collection-leak.test.ts`) was written failing-first: 5 of 8 assertions failed pre-fix (both the handle path and the DEK propagation), all 8 pass post-fix.

## Reserved-collection classification

| Collection | Class | Contents | Propagate to sub-admins? |
|---|---|---|---|
| `_sync_credentials` | **SECRET-BEARING** | OAuth tokens / connection strings / API keys — directly usable | **No** |
| `_broker` (future, #479) | **SECRET-BEARING** (pre-reserved) | broker credentials | **No** |
| `_ledger` / `_ledger_deltas` / `_history` / `_sync*` | OPERATIONAL | collection names, record ids, ciphertext hashes — metadata | Yes (unchanged) |
| `_users`, `_schemas`, `_meta`, `_sequences`, `_delegations`, `_magic_link_grants`, `_periods`, … | OPERATIONAL / lower-severity | metadata, or wrapped keys usable only with a KEK the grantee lacks | Yes (unchanged) |
| `_keyring` | **Lower severity — not exploitable via this path** | Stored with `_iv: ''` and **no collection DEK** (each keyring file is wrapped under the user's own KEK). No `_keyring` DEK exists in any `deks` map, so grant never propagates one and the generic read path cannot decrypt it. Left as-is. |

## Fix — two complementary layers

New dependency-free `packages/hub/src/with-party/team/reserved-secret-collections.ts` is the single source of truth for both seams (kept import-free to avoid a kernel↔service cycle).

**Layer 1 — `vault.collection()` guard** (`kernel/vault.ts`): rejects secret-bearing reserved names with `ReservedCollectionNameError`, mirroring the existing `isDictCollectionName`/`isLinkCollectionName` guards. Blocks the public-API handle path for every caller (including the owner — the dedicated API is the only door). `_broker` reserved now to future-proof the credential broker (#479).

**Layer 2 — grant DEK-propagation exclusion** (`with-party/team/keyring.ts`): secret-bearing reserved DEKs are no longer wrapped into sub-admin grantees' keyrings. All three propagation paths are guarded — the explicit-`permissions` loop, the owner/admin/custodian/viewer "wrap ALL" loop, and the all-roles `_`-prefix loop — so neither a role default nor an explicit per-collection grant can hand a sub-admin the DEK. The anti-privilege-escalation check (`keyring.ts:498`) is untouched.

### Layer 2 blast radius (assessed — Layer 2 shipped)

Excluding the DEK for **all** roles would have broken a legitimate flow: a newly-granted **admin** who reads an *existing* credential needs the propagated DEK to *decrypt* it (without it, `ensureCollectionDEK` would generate a fresh DEK and fail with `TamperedError`). So the exclusion is scoped: **owner and admin still receive** secret-bearing DEKs (they are exactly the roles `requireAdminAccess` admits); **operator, viewer, client, and custodian do not**. Custodian is intentionally excluded per the existing `requireAdminAccess` contract ("a custodian operates the DATA but must never read transport credentials"). A regression test asserts the admin-reads-existing-credential flow still works.

## Verification

- `pnpm --filter @noy-db/hub build / test / typecheck / lint` — green (3261 tests).
- `pnpm check:architecture` — green (added the new module to vault.ts's grandfathered port-layering allowlist alongside the existing `_dict`/`_links` reserved-name predicates; bumped the kernel-surface ceiling 3888 → 3898 with justification for the core trust-boundary guard).
- Full `pnpm test` — all pass except one pre-existing **load-sensitive constant-time timing flake** (`classified/verify-engine.test.ts`, unrelated to this change), which passes in isolation.

Also lays the `_broker` guard for #479.
