### PR TITLE
fix(classified): harden _schemas marker against lost-update race (#583)

### DIFF
--- a/packages/hub/__tests__/classified/schemas-marker-race.test.ts
+++ b/packages/hub/__tests__/classified/schemas-marker-race.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Regression for #583 — the `_schemas/<collection>` classified-marker
+ * lost-update race.
+ *
+ * The R10 config-drift guard's persisted signal is an `x-classified` marker
+ * merged into the collection's `_schemas/<collection>` record. That record is
+ * SHARED with the JSON-Schema writer (`persistSchemaIfNeeded`). Both do a
+ * get-then-put read-modify-write. Interleave their load→save windows and the
+ * later put clobbers the earlier one — the classic lost update:
+ *
+ *   schema-writer loads (no marker) → marker-writer loads (no marker) →
+ *   marker-writer saves {…, classified} → schema-writer saves stale
+ *   {classified: undefined} → marker gone → R10 signal (b) disabled.
+ *
+ * The fix threads the loaded envelope `_v` through the save as an optimistic
+ * version guard (CAS) and retries on conflict, so the losing writer re-reads,
+ * re-merges the other's field, and re-puts. The marker survives.
+ */
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { inlineMemory, type InlineMemoryStore } from './harness.js'
+import { createNoydb } from '../../src/kernel/noydb.js'
+import { classified } from '../../src/with-shape/classified/presets.js'
+import { ClassifiedConfigError } from '../../src/kernel/errors.js'
+import type { ClassifiedFieldSpec } from '../../src/with-shape/classified/descriptor.js'
+import type { EncryptedEnvelope } from '../../src/kernel/types.js'
+import {
+  persistSchemaIfNeeded,
+  persistClassifiedMarker,
+} from '../../src/with-shape/persisted-schemas/register.js'
+import { loadPersistedSchema } from '../../src/with-shape/persisted-schemas/storage.js'
+import { generateDEK } from '../../src/kernel/enclave/index.js'
+import type { ClassifiedMarker } from '../../src/kernel/types.js'
+
+const VAULT = 'v1'
+const COLL = 'users'
+
+const passwordSpec: ClassifiedFieldSpec = {
+  _noydbClassified: true, preset: 'password', storage: 'digest-only',
+  sensitivity: 'secret', list: { kind: 'omit' }, verifyNormalize: 'password',
+}
+
+const marker: ClassifiedMarker = { digestOnly: ['password'], equatable: [] }
+
+/**
+ * Wrap a store so a one-shot async hook fires the first time
+ * `_schemas/<COLL>` is READ. The hook runs AFTER the pre-existing state is
+ * captured for that read, modelling "the other writer's put lands in the gap
+ * between this writer's load and its save". Re-entrant reads (from inside the
+ * hook itself) bypass the gate via the `fired` latch.
+ */
+function gateOnFirstSchemaRead(
+  inner: InlineMemoryStore,
+  hook: () => Promise<void>,
+): InlineMemoryStore {
+  let fired = false
+  return {
+    ...inner,
+    async get(c: string, col: string, id: string): Promise<EncryptedEnvelope | null> {
+      const res = await inner.get(c, col, id)
+      if (!fired && col === '_schemas' && id === COLL) {
+        fired = true
+        await hook() // the racing writer runs to completion in the gap
+      }
+      return res
+    },
+  }
+}
+
+describe('#583 — _schemas classified-marker lost-update race', () => {
+  it('schema-writer racing a marker-write must NOT drop the classified marker', async () => {
+    const base = inlineMemory()
+    const dek = await generateDEK()
+
+    // The schema writer's load fires the marker write to completion in its gap.
+    const store = gateOnFirstSchemaRead(base, async () => {
+      await persistClassifiedMarker({
+        store: base, vault: VAULT, collectionName: COLL, dek, marker,
+      })
+    })
+
+    // First registration of a (non-Zod) validator -> the schema writer WILL
+    // write. Under the no-CAS RMW it overwrites the just-landed marker.
+    await persistSchemaIfNeeded({
+      store, vault: VAULT, collectionName: COLL, validator: {}, dek,
+    })
+
+    const stored = await loadPersistedSchema(base, VAULT, COLL, dek)
+    expect(stored?.classified).toBeDefined()
+    expect(stored?.classified?.digestOnly).toEqual(['password'])
+  })
+
+  it('marker-writer racing a schema-write must NOT drop the derived schema body', async () => {
+    // Symmetric direction: the marker writer's load fires the schema write in
+    // its gap; CAS then forces the marker writer to re-merge onto the schema
+    // record rather than clobber it back to a bare marker envelope. A real Zod
+    // validator gives the schema a non-null body, so a clobber is observable.
+    const base = inlineMemory()
+    const dekB = await generateDEK()
+    const validator = z.object({ password: z.string(), name: z.string() })
+
+    let fired = false
+    const store: InlineMemoryStore = {
+      ...base,
+      async get(c, col, id) {
+        const res = await base.get(c, col, id)
+        if (!fired && col === '_schemas' && id === COLL) {
+          fired = true
+          await persistSchemaIfNeeded({
+            store: base, vault: VAULT, collectionName: COLL, validator, dek: dekB,
+          })
+        }
+        return res
+      },
+    }
+
+    await persistClassifiedMarker({
+      store, vault: VAULT, collectionName: COLL, dek: dekB, marker,
+    })
+
+    const stored = await loadPersistedSchema(base, VAULT, COLL, dekB)
+    // both signals coexist on the single record
+    expect(stored?.classified?.digestOnly).toEqual(['password'])
+    expect(stored?.kind).toBe('Zod')
+    expect(stored?.jsonSchema).not.toBeNull()
+    expect(stored?.hash).not.toBeNull()
+  })
+
+  it('R10 still fires end-to-end: a naive handle over a marked+schema-persisting collection throws', async () => {
+    const store = inlineMemory()
+    // Seed a classified collection that ALSO persists its JSON schema, so both
+    // writers touch `_schemas/users`. The marker must survive.
+    const db = await createNoydb({ store, user: 'a', secret: 'pw-583-e2e' })
+    const v = await db.openVault(VAULT)
+    const users = v.collection<Record<string, unknown>>(COLL, {
+      perRecordKeys: true,
+      persistJsonSchema: true,
+      classifiedFields: { password: passwordSpec },
+    })
+    await users.put('r1', { password: 'hunter2-hunter2', name: 'A' })
+
+    // A fresh session opening a naive handle must be refused by R10.
+    const db2 = await createNoydb({ store, user: 'a', secret: 'pw-583-e2e' })
+    const v2 = await db2.openVault(VAULT)
+    const naive = v2.collection<Record<string, unknown>>(COLL, { perRecordKeys: true })
+    await expect(naive.put('r1', { name: 'B' })).rejects.toBeInstanceOf(ClassifiedConfigError)
+  }, 30_000)
+
+  it('classified() preset is exercised (sanity: marker digest set matches preset)', async () => {
+    // guards against an accidentally trivial marker in the e2e vector above
+    const spec = classified.password()
+    expect(spec.storage).toBe('digest-only')
+  })
+})

--- a/packages/hub/src/with-shape/persisted-schemas/register.ts
+++ b/packages/hub/src/with-shape/persisted-schemas/register.ts
@@ -15,13 +15,23 @@
  */
 
 import { derivePersistedSchema } from './derive.js'
-import { loadPersistedSchema, savePersistedSchema } from './storage.js'
+import { loadPersistedSchemaEntry, savePersistedSchema } from './storage.js'
 import { computeSchemaDelta } from '../schema-update/delta.js'
 import { evaluateStrategies } from '../schema-update/dispatch.js'
+import { ConflictError } from '../../kernel/errors.js'
 import type { SchemaUpdateStrategy, UpdateDecision } from '../schema-update/types.js'
 import type { NoydbStore, ClassifiedMarker } from '../../kernel/types.js'
 import type { PersistedSchemaEnvelope } from './types.js'
 import type { EnclaveKey } from '../../kernel/enclave/index.js'
+
+/**
+ * Max optimistic-CAS retries for the shared `_schemas/<collection>` record
+ * (#583). Only two writers ever contend (the JSON-Schema writer and the
+ * classified-marker writer), so one retry suffices; the headroom covers a
+ * pathological re-order. Exhausting it rethrows the {@link ConflictError}
+ * rather than silently losing a write.
+ */
+const MAX_SCHEMA_CAS_RETRIES = 5
 
 export interface PersistSchemaResult {
   /** True when a fresh envelope was written to storage. */
@@ -43,40 +53,54 @@ export async function persistSchemaIfNeeded(opts: {
   readonly strategies?: readonly SchemaUpdateStrategy[]
 }): Promise<PersistSchemaResult> {
   const fresh = await derivePersistedSchema(opts.validator)
-  const stored = await loadPersistedSchema(opts.store, opts.vault, opts.collectionName, opts.dek)
 
-  if (stored && isEquivalent(stored, fresh)) {
-    return { written: false, skipped: true, envelope: stored, decision: { action: 'allow' } }
+  // The `_schemas/<collection>` record is shared with the classified-marker
+  // writer, so a plain load→save loses whichever writer put first (#583). Read
+  // the version at load time and CAS on it; on conflict re-read (picking up the
+  // other writer's field), re-evaluate, and retry.
+  for (let attempt = 0; ; attempt++) {
+    const { version, payload: stored } = await loadPersistedSchemaEntry(
+      opts.store, opts.vault, opts.collectionName, opts.dek,
+    )
+
+    if (stored && isEquivalent(stored, fresh)) {
+      return { written: false, skipped: true, envelope: stored, decision: { action: 'allow' } }
+    }
+
+    // Changed (or first registration). Run update strategies only when we
+    // have a comparable JSON-Schema baseline and strategies were registered.
+    let decision: UpdateDecision = { action: 'allow' }
+    const strategies = opts.strategies ?? []
+    if (
+      stored &&
+      strategies.length > 0 &&
+      stored.kind === fresh.kind &&
+      isPlainObject(stored.jsonSchema) &&
+      isPlainObject(fresh.jsonSchema)
+    ) {
+      const delta = computeSchemaDelta(stored.jsonSchema, fresh.jsonSchema, opts.collectionName)
+      decision = await evaluateStrategies(delta, strategies, { collection: opts.collectionName })
+    }
+
+    if (decision.action !== 'allow') {
+      // reject (or cutover): do NOT overwrite the baseline — the
+      // old schema stays the source of truth until the change is resolved.
+      return { written: false, skipped: false, envelope: stored ?? fresh, decision }
+    }
+
+    // Preserve a previously-persisted classified marker (C-A / R10) — the schema
+    // derivation knows nothing about it, so a naive overwrite here would drop the
+    // config-drift guard's cross-session signal.
+    const toSave: PersistedSchemaEnvelope =
+      stored?.classified !== undefined ? { ...fresh, classified: stored.classified } : fresh
+    try {
+      await savePersistedSchema(opts.store, opts.vault, opts.collectionName, opts.dek, toSave, version)
+      return { written: true, skipped: false, envelope: toSave, decision }
+    } catch (err) {
+      if (err instanceof ConflictError && attempt < MAX_SCHEMA_CAS_RETRIES) continue
+      throw err
+    }
   }
-
-  // Changed (or first registration). Run update strategies only when we
-  // have a comparable JSON-Schema baseline and strategies were registered.
-  let decision: UpdateDecision = { action: 'allow' }
-  const strategies = opts.strategies ?? []
-  if (
-    stored &&
-    strategies.length > 0 &&
-    stored.kind === fresh.kind &&
-    isPlainObject(stored.jsonSchema) &&
-    isPlainObject(fresh.jsonSchema)
-  ) {
-    const delta = computeSchemaDelta(stored.jsonSchema, fresh.jsonSchema, opts.collectionName)
-    decision = await evaluateStrategies(delta, strategies, { collection: opts.collectionName })
-  }
-
-  if (decision.action !== 'allow') {
-    // reject (or cutover): do NOT overwrite the baseline — the
-    // old schema stays the source of truth until the change is resolved.
-    return { written: false, skipped: false, envelope: stored ?? fresh, decision }
-  }
-
-  // Preserve a previously-persisted classified marker (C-A / R10) — the schema
-  // derivation knows nothing about it, so a naive overwrite here would drop the
-  // config-drift guard's cross-session signal.
-  const toSave: PersistedSchemaEnvelope =
-    stored?.classified !== undefined ? { ...fresh, classified: stored.classified } : fresh
-  await savePersistedSchema(opts.store, opts.vault, opts.collectionName, opts.dek, toSave)
-  return { written: true, skipped: false, envelope: toSave, decision }
 }
 
 /**
@@ -93,20 +117,33 @@ export async function persistClassifiedMarker(opts: {
   readonly dek: EnclaveKey
   readonly marker: ClassifiedMarker
 }): Promise<void> {
-  const stored = await loadPersistedSchema(opts.store, opts.vault, opts.collectionName, opts.dek)
-  if (stored?.classified !== undefined && markersEqual(stored.classified, opts.marker)) return
-  const payload: PersistedSchemaEnvelope =
-    stored !== undefined
-      ? { ...stored, classified: opts.marker }
-      : {
-          _noydb_schema: 1,
-          kind: 'Unknown',
-          jsonSchema: null,
-          hash: null,
-          derivedAt: new Date().toISOString(),
-          classified: opts.marker,
-        }
-  await savePersistedSchema(opts.store, opts.vault, opts.collectionName, opts.dek, payload)
+  // Shares the `_schemas/<collection>` record with the JSON-Schema writer;
+  // CAS on the loaded version so a concurrent schema (re)registration can't
+  // silently drop the marker (and vice-versa) — see #583.
+  for (let attempt = 0; ; attempt++) {
+    const { version, payload: stored } = await loadPersistedSchemaEntry(
+      opts.store, opts.vault, opts.collectionName, opts.dek,
+    )
+    if (stored?.classified !== undefined && markersEqual(stored.classified, opts.marker)) return
+    const payload: PersistedSchemaEnvelope =
+      stored !== undefined
+        ? { ...stored, classified: opts.marker }
+        : {
+            _noydb_schema: 1,
+            kind: 'Unknown',
+            jsonSchema: null,
+            hash: null,
+            derivedAt: new Date().toISOString(),
+            classified: opts.marker,
+          }
+    try {
+      await savePersistedSchema(opts.store, opts.vault, opts.collectionName, opts.dek, payload, version)
+      return
+    } catch (err) {
+      if (err instanceof ConflictError && attempt < MAX_SCHEMA_CAS_RETRIES) continue
+      throw err
+    }
+  }
 }
 
 function markersEqual(a: ClassifiedMarker, b: ClassifiedMarker): boolean {

--- a/packages/hub/src/with-shape/persisted-schemas/storage.ts
+++ b/packages/hub/src/with-shape/persisted-schemas/storage.ts
@@ -24,6 +24,45 @@ import type { PersistedSchemaEnvelope } from './types.js'
 export const SCHEMAS_COLLECTION = '_schemas' as const
 
 /**
+ * A decrypted persisted-schema read paired with the wrapping envelope's
+ * `_v`. The version is the optimistic-concurrency token: pass it back to
+ * {@link savePersistedSchema} as `expectedVersion` to make the write a CAS
+ * that rejects a stale put (see #583 — the `_schemas` record is shared by
+ * the JSON-Schema writer and the classified-marker writer).
+ */
+export interface PersistedSchemaEntry {
+  /** Wrapping envelope `_v` (0 when no record exists yet). */
+  readonly version: number
+  /** Decrypted payload, or `undefined` when absent/corrupt/wrong-DEK. */
+  readonly payload: PersistedSchemaEnvelope | undefined
+}
+
+/**
+ * Read the persisted-schema envelope for one collection together with its
+ * wrapping `_v`. The version reflects the raw stored envelope even when the
+ * payload cannot be decrypted/parsed (so a CAS still guards a corrupt record
+ * rather than silently clobbering it).
+ */
+export async function loadPersistedSchemaEntry(
+  store: NoydbStore,
+  vault: string,
+  collection: string,
+  dek: EnclaveKey,
+): Promise<PersistedSchemaEntry> {
+  const envelope = await store.get(vault, SCHEMAS_COLLECTION, collection)
+  if (!envelope) return { version: 0, payload: undefined }
+  const version = envelope._v
+  try {
+    const plaintext = await openEnvelopeJson(envelope, dek)
+    const parsed = JSON.parse(plaintext) as PersistedSchemaEnvelope
+    if (parsed._noydb_schema !== 1) return { version, payload: undefined }
+    return { version, payload: parsed }
+  } catch {
+    return { version, payload: undefined }
+  }
+}
+
+/**
  * Read and decrypt the persisted-schema envelope for one collection.
  * Returns `undefined` when no envelope has been written or when decryption
  * fails (e.g. wrong DEK passed). Tolerates corrupted records — JSON parse
@@ -35,22 +74,20 @@ export async function loadPersistedSchema(
   collection: string,
   dek: EnclaveKey,
 ): Promise<PersistedSchemaEnvelope | undefined> {
-  const envelope = await store.get(vault, SCHEMAS_COLLECTION, collection)
-  if (!envelope) return undefined
-  try {
-    const plaintext = await openEnvelopeJson(envelope, dek)
-    const parsed = JSON.parse(plaintext) as PersistedSchemaEnvelope
-    if (parsed._noydb_schema !== 1) return undefined
-    return parsed
-  } catch {
-    return undefined
-  }
+  return (await loadPersistedSchemaEntry(store, vault, collection, dek)).payload
 }
 
 /**
  * Encrypt and persist a schema envelope for one collection. Always
  * overwrites any prior write (callers gate on hash equality before calling
  * to avoid no-op writes).
+ *
+ * Pass `expectedVersion` — the `version` from {@link loadPersistedSchemaEntry}
+ * captured at load time — to make the write an optimistic CAS: on a store with
+ * `casAtomic`, `store.put` throws {@link ConflictError} when the record was
+ * bumped concurrently, so a lost update on the shared `_schemas` record is
+ * rejected instead of silently clobbering the other writer's field (#583).
+ * When omitted, keeps the legacy unconditional last-writer-wins behaviour.
  */
 export async function savePersistedSchema(
   store: NoydbStore,
@@ -58,16 +95,17 @@ export async function savePersistedSchema(
   collection: string,
   dek: EnclaveKey,
   payload: PersistedSchemaEnvelope,
+  expectedVersion?: number,
 ): Promise<void> {
   const json = JSON.stringify(payload)
   const { iv, data } = await encrypt(json, dek)
-  const prior = await store.get(vault, SCHEMAS_COLLECTION, collection)
+  const baseVersion = expectedVersion ?? (await store.get(vault, SCHEMAS_COLLECTION, collection))?._v ?? 0
   const env: EncryptedEnvelope = {
     _noydb: NOYDB_FORMAT_VERSION,
-    _v: (prior?._v ?? 0) + 1,
+    _v: baseVersion + 1,
     _ts: new Date().toISOString(),
     _iv: iv,
     _data: data,
   }
-  await store.put(vault, SCHEMAS_COLLECTION, collection, env)
+  await store.put(vault, SCHEMAS_COLLECTION, collection, env, expectedVersion)
 }


### PR DESCRIPTION
## Problem

The classified **R10 config-drift guard** has two trigger signals: (a) the runtime `prev._vdig/_bidx`-carries check, and (b) a persisted `x-classified` "digest-only declared" **marker** in the `_schemas/<collection>` record.

Signal (b) is written via a get-then-put RMW (`persistClassifiedMarker` → `savePersistedSchema`, `_v = (prior?._v ?? 0)+1`, **no CAS**) that **shares its `_schemas/<collection>` record with the JSON-Schema writer** (`persistSchemaIfNeeded`). Classic lost update:

```
schema-writer loads (no marker) → marker-writer loads (no marker)
→ marker-writer saves {…, classified} → schema-writer saves stale {classified: undefined}
→ marker gone → R10 signal (b) disabled for the first-write window
```

Steady state is backstopped by signal (a) once a record carries `_vdig`/`_bidx`; this closes the first-write window. Filed from the slice-2b (#578) security review as hardening.

## Repro (failing-first)

`__tests__/classified/schemas-marker-race.test.ts` drives the **real** `persistSchemaIfNeeded` / `persistClassifiedMarker` and injects the interleave with a one-shot store hook that fires the racing writer inside the victim's load→save gap. Two directions, both **red pre-fix**:

- schema-writer racing a marker-write → marker dropped (`classified` undefined)
- marker-writer racing a schema-write (real Zod validator) → schema body clobbered back to `kind: 'Unknown'`, `jsonSchema: null`

Both **green post-fix**. A third vector proves R10 still fires end-to-end (naive handle over a marked + `persistJsonSchema` collection throws `ClassifiedConfigError`).

## Fix — Option A (CAS / OCC), not Option B

Chose the **optimistic-version-guard** option over moving the marker to its own record key. Rationale (lower blast radius):

- **No persisted-format change** → no migration for markers already shipped in slice 2b (0.3.0-pre.4), and the marker keeps travelling in `extract-partition` / `backup` bundles exactly as today. Option B's separate key would orphan existing markers and would be **dropped by `extract-partition`** (it does a targeted `get(_schemas, <collectionName>)`, so a `<col>#classified` sibling never travels), plus a key-collision edge in the `_schemas` namespace (collection names aren't char-validated).
- **R10 read path untouched.** `classifiedMarkerDigestOnly()` / `readClassifiedMarkerDigestOnly` still read `loadPersistedSchema(...).classified.digestOnly` — same record, same single read, same memoization. Semantics preserved by construction.
- Strictly better than today on `casAtomic` stores; never worse on non-CAS stores.

Implementation:

- `loadPersistedSchemaEntry()` returns `{ version, payload }` (the wrapping `_v` even when the payload is corrupt/undecryptable). `loadPersistedSchema` is now a thin wrapper over it — no public-surface change.
- `savePersistedSchema(..., expectedVersion?)` computes `_v = expectedVersion + 1` and passes `expectedVersion` to the store's native `put(..., expectedVersion)` optimistic lock (throws `ConflictError` on mismatch). Omitting it keeps legacy last-writer-wins.
- Both writers wrap load→save in a bounded retry-on-`ConflictError` loop (max 5): re-read, re-merge the other writer's field, re-put. Exhaustion rethrows rather than silently losing a write.

## Verify

- `pnpm --filter @noy-db/hub build && typecheck && lint` — clean
- `pnpm check:architecture` — OK
- Full hub suite: **3266 passed / 0 failed** (415 files), incl. the known load-sensitive `verify-engine.test.ts` flake (passed this run)

A `@noy-db/hub` patch changeset is authored locally (gitignored, per repo convention).

Closes #583