### PR TITLE
feat(satellites): #591 satellite collections v1 — base+satellite pair, JoinedHandle, existence authority

### DIFF
--- a/docs/superpowers/specs/2026-07-05-satellite-collections-design.md
+++ b/docs/superpowers/specs/2026-07-05-satellite-collections-design.md
@@ -40,7 +40,7 @@ collection('msgs_text', {
 ```
 
 - **Shared key = the record id.** `msgs_text/x` is the satellite of `msgs/x`. The 1:1 pairing is on the id itself, which is what makes every satellite read an O(1) same-id lookup, never a scan. **v1 allows exactly one satellite per base** (Q2, decided post-audit — the pre-audit text was inconsistently 1-vs-N; N-satellites is a deferred, explicitly versioned extension, see § Deferred).
-- **Architectural home — archetype-③ (`with-shape/satellites`), decided by audit.** The kernel-surface ratchet stands at 4647/3898/2360 for collection.ts/vault.ts/noydb.ts with the files at 4646/3897/2359 — **one line of headroom each** (`scripts/check-architecture.mjs:689,846,941`). The pairing registry, fan-out, existence checks, and joined proxy therefore live in `with-shape/satellites/*`, declared on `collection({ satelliteOf, fields, joined })` with the implementation lazy-imported (the repo's archetype-③ pattern: schema features declared on `collection()`, impl in `with-shape/*`). Kernel files get only thin bus-registered call-sites; any ceiling bump must be explicitly budgeted in the plan and justified per the ratchet doctrine ("register on the bus, not grow these files").
+- **Architectural home — archetype-③ (`with-shape/satellites`), decided by audit.** The kernel-surface ratchet stands at 4647/3898/2360 for collection.ts/vault.ts/noydb.ts with the files at 4646/3897/2359 — **one line of headroom each** (`scripts/check-architecture.mjs:689,846,941`). The pairing registry, fan-out, existence checks, and joined proxy therefore live in `with-shape/satellites/*`, declared on `collection({ satelliteOf, fields, joined })` with the implementation lazy-imported (the repo's archetype-③ pattern: schema features declared on `collection()`, impl in `with-shape/*`) *(v1 ships static imports — see § Implementation amendments)*. Kernel files get only thin bus-registered call-sites; any ceiling bump must be explicitly budgeted in the plan and justified per the ratchet doctrine ("register on the bus, not grow these files").
 - **The pairing config is persisted, not session-local (audit).** `satelliteOf` / `fields` / `joined` as pure declaration options would drift across app versions (v1 declares `fields: ['body']`, v2 adds `'subject'` → the same logical record splits differently per client; a client that never declares the satellite would not fan out deletes at all). On first declaration the vault persists a **pairing marker** (base name, `fields` hash, `joined` name) into the `_schemas` reserved collection, following the classified config-drift marker pattern (hardened against the lost-update race in `f94b158e`). A re-declaration that mismatches the persisted marker is refused (R-S9); evolving `fields` is a deliberate marker-update operation, not a silent redeclare.
 - **The satellite's `fields` list IS the routing table.** A whole-record write routes each key: in `fields` → satellite, everything else → base. One explicit array per satellite (not per-field annotation, so the 70-field case stays ergonomic). *Why not "the schemas are the routing table":* a noy-db `schema` is an opaque Standard Schema v1 validator (`kernel/schema.ts`) — field enumeration exists only via `derivePersistedSchema` (`with-shape/introspection/describe.ts`), which is async, best-effort, and effectively zod-4-only. Routing correctness is a hard invariant, so it must not depend on best-effort introspection. Derivable schema fields and `fieldMeta` keys are used as **cross-checks** on `fields` at declaration (best-effort, async — R-S5), never as the routing source.
 - **The base is oblivious and standalone.** `msgs` is defined and usable entirely on its own; its schema/API says nothing about `msgs_text`. Only the vault-level pairing registry (backed by the persisted marker) knows the link, to drive delete/forget fan-out. `msgs.get(id)` returns the hot fields only — **no satellite fetch, no `body` decrypt.** This is the whole point: the cheap read is the default.
@@ -117,7 +117,7 @@ Each satellite **is a normal collection** for writes, indexing, and storage — 
 ## Shipping obligations (audit — mechanical gates that will otherwise fail merge day)
 
 - `features.yaml` entry (schema-validated — `pnpm validate:features`).
-- Bundle-size gate: satellite code must be reachable only behind the `with-shape/satellites` lazy import — the three CI invariants (floor, cross-leak, per-subsystem) must stay green with satellites unused.
+- Bundle-size gate: satellite code must be reachable only behind the `with-shape/satellites` lazy import *(v1 ships static imports — see § Implementation amendments)* — the three CI invariants (floor, cross-leak, per-subsystem) must stay green with satellites unused.
 - `check-architecture.mjs`: register the declaration options in the archetype-③ exemption set (or ship a `with*()` factory); budget any kernel ceiling bump explicitly.
 - Doc page `docs/subsystems/satellites.md`, SPEC section, subpath export + tsup entry per the SERVICES.md governance checklist.
 - Conformance vectors live in the hub package tests (spy-store based); no adapter-conformance changes (stores see only ordinary envelopes).
@@ -241,3 +241,20 @@ detail discovered while building the rule it implements.
   **base's** resolver — base-canonical, not last-write-wins — since the base is the existence
   authority for the pair (rule 1) and its conflict policy is the one already governing the pair's
   observable identity.
+
+- **The archetype-③ implementation ships as STATIC imports from the kernel call-sites, not
+  lazy-imported (Task 12 reconciliation).** § Architectural home and § Shipping obligations above
+  describe the implementation as reachable only behind a `with-shape/satellites` lazy import; v1
+  does not ship that. `kernel/vault.ts` statically imports
+  `declare`/`proxy`/`registry`/`joined`/`types`/`forget` — matching the classified/i18n/links
+  family precedent and grandfathered per-specifier in `check-architecture.mjs`'s
+  `PRE_EXISTING_SPINE_SERVICE_IMPORTS` (port-layering). Consequence: satellite engine code
+  (registry, proxies, fan-out, joined handle, ref expansion) ships in **every** consumer bundle
+  (floor +2.4% gz, within the bundle-size gate's tolerance — the gate stays green because ③
+  schema features were never floor-excluded). Only marker persistence, post-register schema
+  derivation, and persisted-schema reads are genuinely lazy (`await import` in `marker.ts`,
+  `post-register.ts`, `dead-filter.ts`). Why: the declaration path (validate → R-S7 → registry
+  registration) must run **synchronously inside `vault.collection()`** — a sync API — which
+  precludes a lazy (async-import) spine for the core machinery. True lazy-loading of the
+  proxy/fan-out engines behind the declaration seam remains a possible future optimization
+  (shared with the #553 lazy-import debt the money/computed/classified ③ siblings already carry).

--- a/docs/superpowers/specs/2026-07-05-satellite-collections-design.md
+++ b/docs/superpowers/specs/2026-07-05-satellite-collections-design.md
@@ -198,3 +198,46 @@ Refusals & config:
 
 Conflict granularity (documented behavior, asserted as such):
 - Two clients' divergent joined writes can converge to base-from-A ⊕ satellite-from-B; the vector asserts this **documented** field-group granularity and that registering a conflict resolver for one pair member registers it for both.
+
+## Implementation amendments (v1, 2026-07-07)
+
+Four execution decisions made across Tasks 5–11, folded back into the design record (Task 12
+reconciliation). None of these revise a resolved owner decision above — each is a v1 scoping
+detail discovered while building the rule it implements.
+
+- **Satellite `query()` refuses with `SatelliteConfigError` (Task 5).** Query's terminal methods
+  (`toArray`/`first`/`count`) read the in-memory cache **synchronously**, while existence authority
+  (§ Convergence & existence authority, rule 1) requires an **async**, undecrypted check against
+  live base state — the two shapes don't compose without either breaking `query()`'s synchronous
+  contract or accepting a check that can miss an out-of-band base mutation. `list()`/`get()` remain
+  existence-safe (async, checked per call); `search`/`retrieve`/`similarTo` get their own existence
+  post-filter (Task 9) since they answer from the search facade's own cache/index, not the proxy's
+  get/list overrides.
+
+- **Bundle export filter degrades leak-on-error, never drop-live-data (Task 10).** The `as-noydb`
+  bundle export excludes base-less (dead-ciphertext) satellite envelopes (§ Conformance vectors,
+  "Export filter"). If the liveness check against the base itself errors mid-export, the filter's
+  posture is to **include** the satellite envelope (leak-on-error) rather than **exclude** it
+  (drop-on-error) — an operator can always re-run `forget()`/a sweep to close a leaked dead
+  satellite, but a wrongly dropped *live* record is unrecoverable data loss. This also discloses a
+  **first-declaration marker-race window**: between a satellite's first `declareSatellite()` call
+  writing the pairing marker to `_schemas` and that write becoming durable, a concurrent export
+  reading a not-yet-marked collection treats it as a plain collection (no existence filtering
+  applied at all) rather than as a satellite — a narrow, session-scoped race, not a persistent gap.
+
+- **`pushFiltered`/`SyncTransaction` predicate paths are outside pair-unit expansion (Task 11).**
+  Pair-unit dirty-entry expansion (a base's sync push carries its satellite's pending entries too,
+  per § Conformance vectors "Partial sync") covers the ordinary `push({ collections })` allow-list
+  path. `pushFiltered`'s per-record predicate and `SyncTransaction`'s explicit entry list are
+  **not** expanded to their pair partner — a predicate or transaction that selects a base record
+  does not implicitly pull in its satellite row. Both are documented out-of-scope for v1; a caller
+  using either path against a satellite pair is responsible for including both collections itself.
+
+- **Conflict-resolver pair-coupling is base-canonical on pre-pairing ties (Task 11).** Registering a
+  conflict resolver for one pair member mirrors it to the other (§ Conformance vectors, "Conflict
+  granularity"). If a resolver is registered on the satellite *before* the pair exists (no base
+  declared yet, or declared after), retroactive mirroring at pair-registration time resolves any tie
+  between a pre-existing base-side resolver and the satellite-side one in favor of the
+  **base's** resolver — base-canonical, not last-write-wins — since the base is the existence
+  authority for the pair (rule 1) and its conflict policy is the one already governing the pair's
+  observable identity.

--- a/knip.json
+++ b/knip.json
@@ -18,7 +18,8 @@
         "src/with-fork/snapshots/index.ts",
         "src/with-party/session/index.ts",
         "src/with-party/team/index.ts",
-        "src/with-shape/classified/index.ts"
+        "src/with-shape/classified/index.ts",
+        "src/with-shape/satellites/index.ts"
       ]
     }
   }

--- a/packages/hub/__tests__/kernel-api.golden.json
+++ b/packages/hub/__tests__/kernel-api.golden.json
@@ -119,6 +119,7 @@
     "getRevokedDocIds",
     "introspect",
     "issueAttestation",
+    "joined",
     "ledger",
     "link",
     "links",

--- a/packages/hub/__tests__/satellites-bundle-filter.test.ts
+++ b/packages/hub/__tests__/satellites-bundle-filter.test.ts
@@ -122,6 +122,38 @@ describe('writeNoydbBundle — satellite existence-authority filter (#591 Task 1
     db.close()
   })
 
+  it('leak-on-error posture: a corrupted pairing marker disables filtering for that satellite (exports UNFILTERED, never throws, never drops live data)', async () => {
+    // The filter's deliberate asymmetry (see dead-filter.ts): on any
+    // marker-read failure — DEK unreachable, decrypt/parse failure,
+    // marker not yet persisted — the collection degrades to
+    // "non-satellite" and exports unfiltered. Leaking stale dead
+    // ciphertext into a backup is recoverable; silently dropping live
+    // records from a backup is not. This test pins that posture.
+    const { db, vault, rawStore } = await openPair()
+    await vault.joined<Msg>('msgs_full').put('x', { from: 'a', body: 'B' })
+    await vault.joined<Msg>('msgs_full').put('y', { from: 'b', body: 'C' })
+    await vault.collection<Invoice>('invoices').put('a', { id: 'a', amount: 100 })
+    const controlBefore = collRecords(await exportDump(vault), 'invoices')
+    await rawStore.delete('v1', 'msgs', 'x') // genuine dead satellite row
+
+    // Corrupt the persisted _schemas/msgs_text record at the raw store:
+    // garbage ciphertext fails AES-GCM decryption, loadPersistedSchema
+    // swallows internally and returns undefined → marker unreadable.
+    const markerEnv = await rawStore.get('v1', '_schemas', 'msgs_text')
+    expect(markerEnv).not.toBeNull() // precondition: the marker WAS persisted
+    await rawStore.put('v1', '_schemas', 'msgs_text', { ...markerEnv!, _data: 'Z29vZC1sdWNrLWRlY3J5cHRpbmctdGhpcw==' })
+
+    // Export succeeds without throwing, and msgs_text passes through
+    // UNFILTERED — the dead row 'x' is included (leaked, by design).
+    const dumpJson = await exportDump(vault)
+    expect(Object.keys(collRecords(dumpJson, 'msgs_text')).sort()).toEqual(['x', 'y'])
+    // The base itself naturally carries only the live row.
+    expect(Object.keys(collRecords(dumpJson, 'msgs'))).toEqual(['y'])
+    // Non-satellite control still exports identically.
+    expect(collRecords(dumpJson, 'invoices')).toEqual(controlBefore)
+    db.close()
+  })
+
   it('a satellite pair declared with zero dead rows exports with no behavior change', async () => {
     const { db, vault } = await openPair()
     await vault.joined<Msg>('msgs_full').put('x', { from: 'a', body: 'B' })

--- a/packages/hub/__tests__/satellites-bundle-filter.test.ts
+++ b/packages/hub/__tests__/satellites-bundle-filter.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Bundle export dead-satellite filter (#591 Task 10): `.noydb` bundle
+ * export excludes satellite-collection records whose base row is dead
+ * (absent or tombstoned) — the base is the sole existence authority
+ * (existence.ts rule 1), so a satellite envelope surviving past its base
+ * is dead ciphertext (plus its wrapped keys) that must never leave the
+ * vault in a backup.
+ *
+ * Fixture pattern (spy-free in-memory store, `db.openVault`, `historyStrategy`
+ * required by `writeNoydbBundle` → `vault.dump()`) copied from
+ * satellites-joined.test.ts / bundle-slice.test.ts.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { withHistory } from '../src/with-commit/history/index.js'
+import { writeNoydbBundle, readNoydbBundle } from '../src/with-pod/bundle.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
+
+const SECRET = 'satellite-bundle-filter-test-1234'
+
+interface Msg extends Record<string, unknown> {
+  from?: string
+  body?: string
+}
+
+interface Invoice extends Record<string, unknown> {
+  id: string
+  amount: number
+}
+
+function memory(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const gc = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let comp = data.get(v); if (!comp) { comp = new Map(); data.set(v, comp) }
+    let coll = comp.get(c); if (!coll) { coll = new Map(); comp.set(c, coll) }
+    return coll
+  }
+  return {
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env) { gc(v, c).set(id, env) },
+    async delete(v, c, id) { gc(v, c).delete(id) },
+    async list(v, c) { const coll = data.get(v)?.get(c); return coll ? [...coll.keys()] : [] },
+    async loadAll(v) {
+      const comp = data.get(v); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (n.startsWith('_')) continue
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of coll) r[id] = e
+        s[n] = r
+      }
+      return s
+    },
+    async saveAll(v, recs) {
+      for (const [n, byId] of Object.entries(recs)) { const coll = gc(v, n); for (const [id, e] of Object.entries(byId)) coll.set(id, e) }
+    },
+  }
+}
+
+async function openPair() {
+  const rawStore = memory()
+  const db = await createNoydb({ store: rawStore, user: 'alice', secret: SECRET, historyStrategy: withHistory() })
+  const vault = await db.openVault('v1')
+  vault.collection<Msg>('msgs')
+  vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['body'], joined: 'msgs_full' })
+  // declareSatellite's postRegister (persists the `_schemas` pairing marker
+  // this filter reads) is fire-and-forget from `vault.collection()` — let it
+  // settle before the test proceeds, mirroring satellites-fanout.test.ts's
+  // "let ... async hydration settle" pattern.
+  await new Promise((r) => setTimeout(r, 20))
+  return { db, vault, rawStore }
+}
+
+async function exportDump(vault: Awaited<ReturnType<Awaited<ReturnType<typeof createNoydb>>['openVault']>>): Promise<string> {
+  const bytes = await writeNoydbBundle(vault)
+  const { dumpJson } = await readNoydbBundle(bytes)
+  return dumpJson
+}
+
+function collRecords(dumpJson: string, collName: string): Record<string, unknown> {
+  const parsed = JSON.parse(dumpJson) as { collections?: Record<string, Record<string, unknown>> }
+  return parsed.collections?.[collName] ?? {}
+}
+
+describe('writeNoydbBundle — satellite existence-authority filter (#591 Task 10)', () => {
+  it('excludes a satellite record whose base was raw-deleted (absent); live pair exports both', async () => {
+    const { db, vault, rawStore } = await openPair()
+    await vault.joined<Msg>('msgs_full').put('x', { from: 'a', body: 'B' })
+    await vault.joined<Msg>('msgs_full').put('y', { from: 'b', body: 'C' })
+    await rawStore.delete('v1', 'msgs', 'x')
+
+    const dumpJson = await exportDump(vault)
+    expect(Object.keys(collRecords(dumpJson, 'msgs_text'))).toEqual(['y'])
+    expect(Object.keys(collRecords(dumpJson, 'msgs'))).toEqual(['y'])
+    db.close()
+  })
+
+  it('excludes a satellite record whose base is tombstoned (not merely absent)', async () => {
+    const { db, vault, rawStore } = await openPair()
+    await vault.joined<Msg>('msgs_full').put('x', { from: 'a', body: 'B' })
+    await vault.joined<Msg>('msgs_full').put('y', { from: 'b', body: 'C' })
+    // buildTombstone() shape: _iv === '' && _data === '' — written directly via the raw store.
+    await rawStore.put('v1', 'msgs', 'x', { _noydb: 1, _v: 2, _ts: 't', _iv: '', _data: '' })
+
+    const dumpJson = await exportDump(vault)
+    expect(Object.keys(collRecords(dumpJson, 'msgs_text'))).toEqual(['y'])
+    db.close()
+  })
+
+  it('control: a non-satellite collection is untouched even when the satellite filter is active', async () => {
+    const { db, vault } = await openPair()
+    await vault.collection<Invoice>('invoices').put('a', { id: 'a', amount: 100 })
+    await vault.collection<Invoice>('invoices').put('b', { id: 'b', amount: 200 })
+    const withoutSatelliteRows = await exportDump(vault)
+
+    // Now populate the declared satellite pair too, so the (always-on)
+    // satellite filter is active for this export — `invoices` must not move.
+    await vault.joined<Msg>('msgs_full').put('x', { from: 'a', body: 'B' })
+
+    const dumpJson = await exportDump(vault)
+    expect(collRecords(dumpJson, 'invoices')).toEqual(collRecords(withoutSatelliteRows, 'invoices'))
+    expect(Object.keys(collRecords(dumpJson, 'invoices')).sort()).toEqual(['a', 'b'])
+    db.close()
+  })
+
+  it('a satellite pair declared with zero dead rows exports with no behavior change', async () => {
+    const { db, vault } = await openPair()
+    await vault.joined<Msg>('msgs_full').put('x', { from: 'a', body: 'B' })
+    await vault.joined<Msg>('msgs_full').put('y', { from: 'b', body: 'C' })
+
+    const dumpJson = await exportDump(vault)
+    expect(Object.keys(collRecords(dumpJson, 'msgs_text')).sort()).toEqual(['x', 'y'])
+    expect(Object.keys(collRecords(dumpJson, 'msgs')).sort()).toEqual(['x', 'y'])
+    db.close()
+  })
+})

--- a/packages/hub/__tests__/satellites-conformance.test.ts
+++ b/packages/hub/__tests__/satellites-conformance.test.ts
@@ -1,0 +1,435 @@
+/**
+ * Cross-cutting integration conformance vectors for satellite collections
+ * (#591, Task 13). Tasks 1–12 already have unit coverage per-file; this suite
+ * is the spec's § Conformance vectors transcribed end-to-end, covering only
+ * the vectors that cut ACROSS fan-out (Task 6), JoinedHandle (Task 7), forget
+ * fan-out (Task 8), search/det existence filtering (Task 9), and sync
+ * pair-expansion (Task 11) — never duplicating a single-task unit test.
+ *
+ * Spec: docs/superpowers/specs/2026-07-05-satellite-collections-design.md
+ *
+ * Fixture patterns are copied (not reinvented) from:
+ *  - satellites-fanout.test.ts   — spy store with put ordering
+ *  - satellites-joined.test.ts / satellites-search-filter.test.ts — raw-store
+ *    injection to simulate offline-resurrection / late-arriving states
+ *  - satellites-forget.test.ts  — forget-covered pair with perRecordKeys
+ *  - satellites-sync-pair.test.ts — inline CAS-aware memory adapter, driven
+ *    same-version conflicts
+ *  - embeddings-retrieve.test.ts — deterministic stub embeddings encoder
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { withSync } from '../src/with-party/sync/index.js'
+import { withHistory } from '../src/with-commit/history/index.js'
+import { withForgetCascade } from '../src/with-audit/forget/index.js'
+import { withSearch } from '../src/with-lookup/search/index.js'
+import { memory } from '../../to-memory/src/index.js'
+import { ConflictError, SatelliteConfigError } from '../src/kernel/errors.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
+
+const SECRET = 'satellites-conformance-test-1234'
+
+interface Msg extends Record<string, unknown> {
+  from?: string
+  subject?: string
+  body?: string
+}
+
+// ---------------------------------------------------------------------------
+// Vector (a)/(b): base put shape + crash injection
+// ---------------------------------------------------------------------------
+
+/** In-memory store instrumented with put ordering (copied from satellites-fanout.test.ts). */
+function spyMemory() {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const gc = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let comp = data.get(v); if (!comp) { comp = new Map(); data.set(v, comp) }
+    let coll = comp.get(c); if (!coll) { coll = new Map(); comp.set(c, coll) }
+    return coll
+  }
+  const putOrder: Array<[string, string]> = []
+  const store: NoydbStore = {
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env) { putOrder.push([c, id]); gc(v, c).set(id, env) },
+    async delete(v, c, id) { gc(v, c).delete(id) },
+    async list(v, c) { const coll = data.get(v)?.get(c); return coll ? [...coll.keys()] : [] },
+    async loadAll(v) {
+      const comp = data.get(v); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll(v, recs) {
+      for (const [n, byId] of Object.entries(recs)) { const coll = gc(v, n); for (const [id, e] of Object.entries(byId)) coll.set(id, e) }
+    },
+  }
+  return { store, putOrder }
+}
+
+async function openCrashPair() {
+  const spy = spyMemory()
+  const db = await createNoydb({ store: spy.store, user: 'alice', secret: SECRET })
+  const vault = await db.openVault('v1')
+  vault.collection<Msg>('msgs', {})
+  vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full' })
+  const pairOnly = (): Array<[string, string]> => spy.putOrder.filter(([c]) => c === 'msgs' || c === 'msgs_text')
+  return { vault, rawStore: spy.store, putOrder: pairOnly }
+}
+
+describe('spec conformance — cross-cutting vectors (#591, Task 13)', () => {
+  it('base put touches exactly one envelope: 1 put, 0 satellite ops (store-shape)', async () => {
+    // spec: Conformance — base-handle put performs NO satellite fan-out (audit reversal: no auto-create)
+    const { vault, putOrder } = await openCrashPair()
+    await vault.collection<Msg>('msgs').put('x', { from: 'a' })
+    expect(putOrder()).toEqual([['msgs', 'x']])
+  })
+
+  describe('crash injection: only safe-direction persisted states survive a mid-fanout kill', () => {
+    // Reads happen through a FRESH db/vault bound to the same underlying
+    // store rather than the live vault that (would have) performed the
+    // fan-out: a real process kill loses the in-memory cache too, so
+    // asserting through the live vault's still-warm cache would prove
+    // nothing about the actually-PERSISTED state — only a fresh rehydration
+    // does.
+    async function reopenCrashPair(rawStore: NoydbStore) {
+      const db2 = await createNoydb({ store: rawStore, user: 'alice', secret: SECRET })
+      const vault2 = await db2.openVault('v1')
+      vault2.collection<Msg>('msgs', {})
+      vault2.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full' })
+      return vault2
+    }
+
+    it('joined put killed after the base leg: base present, satellite absent, joined reads all-null satellite fields', async () => {
+      // spec: Conformance — crash injection, joined-put kill after the first fan-out op.
+      // Simulated by writing ONLY the base leg directly (bypassing joinedPut
+      // entirely) — a genuine process kill never reaches joinedPut's own
+      // catch-and-revert path, unlike the exception-driven revert already
+      // covered in satellites-fanout.test.ts.
+      const { vault, rawStore } = await openCrashPair()
+      await vault.collection<Msg>('msgs').put('x', { from: 'a' })
+
+      expect(await rawStore.get('v1', 'msgs', 'x')).not.toBeNull()
+      expect(await rawStore.get('v1', 'msgs_text', 'x')).toBeNull() // never produced
+
+      const fresh = await reopenCrashPair(rawStore)
+      expect(await fresh.joined<Msg>('msgs_full').get('x')).toEqual({ from: 'a', subject: null, body: null })
+    })
+
+    it('pair delete killed after the satellite leg: satellite gone, base present, joined still reads safely', async () => {
+      // spec: Conformance — crash injection, pair-delete kill after the first fan-out op
+      // (satellite leg runs FIRST for delete — convergence rule 3).
+      const { vault, rawStore } = await openCrashPair()
+      await vault.joined<Msg>('msgs_full').put('y', { from: 'b', body: 'B' })
+      // Simulate the kill: remove ONLY the satellite envelope directly,
+      // bypassing pairDelete's own revert path entirely.
+      await rawStore.delete('v1', 'msgs_text', 'y')
+
+      expect(await rawStore.get('v1', 'msgs', 'y')).not.toBeNull()
+      expect(await rawStore.get('v1', 'msgs_text', 'y')).toBeNull()
+
+      const fresh = await reopenCrashPair(rawStore)
+      expect(await fresh.joined<Msg>('msgs_full').get('y')).toEqual({ from: 'b', subject: null, body: null })
+    })
+
+    it('a base-less satellite is never produced locally by a base-only write', async () => {
+      // spec: Conformance — "a fresh base-less satellite is never produced LOCALLY"
+      const { vault, rawStore } = await openCrashPair()
+      await vault.collection<Msg>('msgs').put('z', { from: 'c' }) // as if killed before any satellite leg ran
+      expect(await rawStore.list('v1', 'msgs_text')).not.toContain('z')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Vector (c): offline resurrection containment
+  // ---------------------------------------------------------------------------
+  describe('offline resurrection containment: a lingering satellite is unreachable via every surface once the base is gone', () => {
+    async function openContainmentPair() {
+      const rawStore = memory()
+      const db = await createNoydb({ store: rawStore, user: 'alice', secret: SECRET, searchStrategy: withSearch() })
+      const vault = await db.openVault('v1')
+      vault.collection<Msg>('msgs')
+      vault.collection<Msg>('msgs_text', {
+        satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full',
+        textIndexes: ['body'], textIndexPersist: true,
+      })
+      return { vault, rawStore }
+    }
+
+    it('get/list/query-refusal/search/joined all treat a raw-store-injected offline resurrection as unreachable; the envelope itself remains', async () => {
+      // spec: Conformance — offline resurrection containment (raw-store injection)
+      const { vault, rawStore } = await openContainmentPair()
+      await vault.joined<Msg>('msgs_full').put('x', { from: 'a', body: 'zebra unique' })
+      await vault.collection<Msg>('msgs_text').retrieve('zebra') // force the persisted index to build while live
+
+      const satEnvBefore = await rawStore.get('v1', 'msgs_text', 'x')
+      expect(satEnvBefore).not.toBeNull()
+
+      // Offline resurrection: the base disappears out-of-band (e.g. a peer
+      // deleted it) while the satellite envelope keeps lingering locally —
+      // simulated with a raw store injection, same as satellites-joined.test.ts.
+      await rawStore.delete('v1', 'msgs', 'x')
+
+      expect(await vault.collection<Msg>('msgs_text').get('x')).toBeNull()
+      expect(await vault.collection<Msg>('msgs_text').list()).toEqual([])
+      expect(() => vault.collection<Msg>('msgs_text').query()).toThrowError(SatelliteConfigError)
+      expect(await vault.collection<Msg>('msgs_text').retrieve('zebra')).toEqual([])
+      expect(await vault.joined<Msg>('msgs_full').get('x')).toBeNull()
+
+      // Containment is purely observational — the satellite envelope was
+      // never physically touched.
+      expect(await rawStore.get('v1', 'msgs_text', 'x')).toEqual(satEnvBefore)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Vector (d): post-forget late-arriving satellite put
+  // ---------------------------------------------------------------------------
+  describe('post-forget late-arriving satellite put stays unreachable (observational containment — resurrection PREVENTION is #590, not asserted here)', () => {
+    it('a raw-store put of a valid satellite envelope onto a tombstoned base id is unreachable through every enumerated surface', async () => {
+      // spec: Conformance — post-forget late-arriving satellite put
+      const store = memory()
+      const opts = {
+        store, user: 'alice', secret: SECRET, searchStrategy: withSearch(),
+        historyStrategy: withHistory(),
+        forgetStrategy: withForgetCascade({ subjects: { msgs: 'from' } }),
+      }
+      const db1 = await createNoydb(opts)
+      const vault1 = await db1.openVault('v1')
+      vault1.collection<Msg>('msgs', { perRecordKeys: true })
+      vault1.collection<Msg>('msgs_text', {
+        satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full', perRecordKeys: true,
+        textIndexes: ['body'], textIndexPersist: true,
+      })
+      await vault1.joined<Msg>('msgs_full').put('x', { from: 'alice@x', body: 'walrus unique' })
+      const validSatEnv = await store.get('v1', 'msgs_text', 'x') // a genuinely valid, decryptable envelope
+      expect(validSatEnv).not.toBeNull()
+
+      await vault1.forget('alice@x') // tombstones base + satellite locally
+
+      // A late-arriving write (e.g. a delayed sync pull) lands directly on
+      // the raw store for the now-forgotten id — bypassing collection.put
+      // entirely, same as a real out-of-band store write would.
+      await store.put('v1', 'msgs_text', 'x', validSatEnv!)
+
+      // Re-open fresh (same store/secret) so the collection genuinely
+      // re-hydrates from the store — otherwise forget()'s own cache eviction
+      // would trivially hide the late arrival regardless of existence
+      // filtering, which would prove nothing. On reopen the satellite
+      // envelope IS decryptable and would otherwise be visible; only the
+      // base's tombstoned state should suppress it.
+      const db2 = await createNoydb(opts)
+      const vault2 = await db2.openVault('v1')
+      vault2.collection<Msg>('msgs', { perRecordKeys: true })
+      vault2.collection<Msg>('msgs_text', {
+        satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full', perRecordKeys: true,
+        textIndexes: ['body'], textIndexPersist: true,
+      })
+
+      expect(await vault2.collection<Msg>('msgs_text').get('x')).toBeNull()
+      expect(await vault2.collection<Msg>('msgs_text').list()).toEqual([])
+      expect(() => vault2.collection<Msg>('msgs_text').query()).toThrowError(SatelliteConfigError)
+      expect(await vault2.collection<Msg>('msgs_text').retrieve('walrus')).toEqual([])
+      expect(await vault2.joined<Msg>('msgs_full').get('x')).toBeNull()
+
+      // The re-injected envelope is left exactly as written: containment
+      // does not silently re-tombstone or purge it.
+      expect(await store.get('v1', 'msgs_text', 'x')).toEqual(validSatEnv)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Vector (e): field-group conflict granularity ("tearing")
+  // ---------------------------------------------------------------------------
+  describe('field-group conflict granularity: divergent joined writes converge to a mixed record (documented behavior, not a bug)', () => {
+    function inlineMemory(): NoydbStore {
+      const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+      function gc(c: string, col: string) {
+        let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+        let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+        return coll
+      }
+      return {
+        async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+        async put(c, col, id, env, ev) {
+          const coll = gc(c, col); const ex = coll.get(id)
+          if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+          coll.set(id, env)
+        },
+        async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+        async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+        async loadAll(c) {
+          const comp = store.get(c); const s: VaultSnapshot = {}
+          if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+          return s
+        },
+        async saveAll(c, data) {
+          for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) }
+        },
+      }
+    }
+
+    it('base and satellite resolve conflicts INDEPENDENTLY, converging under vault.joined() to a torn/mixed record', async () => {
+      // spec: Conformance — field-group conflict granularity ("tearing")
+      const COMP = 'v1'
+      const local = inlineMemory()
+      const remote = inlineMemory()
+      const db = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
+      const vault = await db.openVault(COMP)
+      vault.collection<Msg>('msgs', { conflictPolicy: 'last-writer-wins' })
+      vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full' })
+
+      await vault.joined<Msg>('msgs_full').put('m', { from: 'local0', subject: 'local0', body: '' })
+      await db.push(COMP) // remote msgs + msgs_text both land at _v=1
+
+      // Someone else pushes divergent v2s out-of-band, with deliberately
+      // opposite-signed timestamps so LWW picks a DIFFERENT side per collection.
+      const future = new Date(Date.now() + 60_000).toISOString()
+      const past = new Date(Date.now() - 60_000).toISOString()
+      await remote.put(COMP, 'msgs', 'm', { _noydb: 1, _v: 2, _ts: future, _iv: '', _data: JSON.stringify({ from: 'REMOTE' }) })
+      await remote.put(COMP, 'msgs_text', 'm', { _noydb: 1, _v: 2, _ts: past, _iv: '', _data: JSON.stringify({ subject: 'REMOTE', body: 'remote-body' }) })
+
+      // Local writes its own v2 to BOTH legs in one joined call — a real
+      // "now" timestamp, strictly between `past` and `future`.
+      await vault.joined<Msg>('msgs_full').put('m', { from: 'local1', subject: 'local1', body: 'local-body' })
+
+      const result = await db.push(COMP)
+      expect(result.conflicts).toHaveLength(2) // base AND satellite each conflict independently
+
+      // Conflict resolution writes the winner straight to the raw local
+      // store (sync.ts push()), bypassing the live Collection's cache —
+      // reopen fresh (same store) so the read reflects the actually
+      // PERSISTED post-resolution state rather than the live vault's
+      // now-stale in-memory cache.
+      const db2 = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
+      const vault2 = await db2.openVault(COMP)
+      vault2.collection<Msg>('msgs', {})
+      vault2.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full' })
+
+      // Each collection's LWW resolver picks its OWN winner: msgs → remote
+      // (future ts beats "now"), msgs_text → local ("now" beats past ts).
+      // The merged joined record is genuinely torn — half remote, half
+      // local — which is the documented behavior for this design (base and
+      // satellite are separate collections resolved independently, never one
+      // atomic joined transaction), not a bug to fix here.
+      const merged = await vault2.joined<Msg>('msgs_full').get('m')
+      expect(merged).toEqual({ from: 'REMOTE', subject: 'local1', body: 'local-body' })
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Vector (f): R-S7 retro clause
+  // ---------------------------------------------------------------------------
+  describe('R-S7 retro clause: adding forget coverage over a base whose existing satellite lacks perRecordKeys is refused', () => {
+    it('reopening with newly-added forget coverage refuses to redeclare the pre-existing non-perRecordKeys satellite', async () => {
+      // spec: Conformance — R-S7 retro clause
+      const store = memory()
+      // Session 1: no forget coverage — satellite declared WITHOUT perRecordKeys.
+      const db1 = await createNoydb({ store, user: 'alice', secret: SECRET })
+      const vault1 = await db1.openVault('v1')
+      vault1.collection<Msg>('msgs', {})
+      vault1.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full' })
+      await vault1.joined<Msg>('msgs_full').put('x', { from: 'alice@x', subject: 's', body: 'b' })
+      expect(await store.get('v1', 'msgs_text', 'x')).not.toBeNull() // the pre-existing satellite really has data
+
+      // Session 2: forget coverage is added over the base. The base itself
+      // auto-forces perRecordKeys (vault.ts's existing force-on, warn-only),
+      // but the PRE-EXISTING satellite was never migrated to perRecordKeys —
+      // R-S7's retro clause must refuse the redeclare outright.
+      const db2 = await createNoydb({
+        store, user: 'alice', secret: SECRET,
+        forgetStrategy: withForgetCascade({ subjects: { msgs: 'from' } }),
+      })
+      const vault2 = await db2.openVault('v1')
+      expect(() => vault2.collection<Msg>('msgs', {})).not.toThrow() // base: perRecordKeys force-on, no refusal
+      expect(() => vault2.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full' }))
+        .toThrowError(/R-S7/)
+
+      // This is a declaration-time refusal, not data loss — the persisted
+      // satellite data is untouched. See task-13-report.md for the finding:
+      // there is no dedicated satellite-CEK migration path implemented yet
+      // to get PAST this refusal (only the generic, unwired
+      // `_applyCutoverTransform` primitive exists) — so once hit, the pair
+      // is unusable (not even readable) in that session until one is built.
+      expect(await store.get('v1', 'msgs_text', 'x')).not.toBeNull()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Vector (g): satellite history tombstoning under forget
+  // ---------------------------------------------------------------------------
+  describe('satellite history tombstoning under forget: every displaced version, not just the live envelope', () => {
+    it('tombstones all displaced satellite history versions when the subject is forgotten', async () => {
+      // spec: Conformance — satellite history tombstoning under forget
+      const rawStore = memory()
+      const db = await createNoydb({
+        store: rawStore, user: 'alice', secret: SECRET,
+        historyStrategy: withHistory(),
+        forgetStrategy: withForgetCascade({ subjects: { msgs: 'from' } }),
+      })
+      const vault = await db.openVault('v1')
+      vault.collection<Msg>('msgs', { perRecordKeys: true })
+      vault.collection<Msg>('msgs_text', {
+        satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full', perRecordKeys: true,
+      })
+
+      await vault.joined<Msg>('msgs_full').put('x', { from: 'alice@x', subject: 's0', body: 'v0' })
+      await vault.joined<Msg>('msgs_full').put('x', { from: 'alice@x', subject: 's1', body: 'v1' })
+      await vault.joined<Msg>('msgs_full').put('x', { from: 'alice@x', subject: 's2', body: 'v2' })
+
+      const satHistoryIds = async (): Promise<string[]> =>
+        (await rawStore.list('v1', '_history')).filter((k) => k.startsWith('msgs_text:x:'))
+
+      const historyIdsBefore = await satHistoryIds()
+      expect(historyIdsBefore.length).toBeGreaterThan(0) // displaced versions recorded
+
+      const result = await vault.forget('alice@x')
+      expect(result.historyVersionsShredded).toBeGreaterThan(0)
+
+      for (const id of await satHistoryIds()) {
+        expect((await rawStore.get('v1', '_history', id))?._data).toBe('')
+      }
+      // Sanity: the live satellite envelope is tombstoned by the same call.
+      expect((await rawStore.get('v1', 'msgs_text', 'x'))?._data).toBe('')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Vector (h): similarTo existence filter (mock-embeddings fixture reused
+  // from embeddings-retrieve.test.ts — a reasonable one exists in the repo)
+  // ---------------------------------------------------------------------------
+  describe('similarTo() existence-filter for a satellite (mirrors the search/retrieve vector)', () => {
+    // Deterministic stub encoder, copied from embeddings-retrieve.test.ts:
+    // bag-of-chars hash → Float32Array of given dim.
+    const enc = (dim: number, model = 'stub') => ({
+      dim, model, source: 'body',
+      encode: async (t: string) => {
+        const v = new Float32Array(dim)
+        for (let i = 0; i < t.length; i++) { const idx = t.charCodeAt(i) % dim; v[idx] = (v[idx] ?? 0) + 1 }
+        return v
+      },
+    })
+
+    it('similarTo() drops a satellite hit whose base was raw-deleted (existence post-filter)', async () => {
+      // spec: Conformance — similarTo/embeddings existence filter
+      const rawStore = memory()
+      const encoder = enc(8)
+      const db = await createNoydb({ store: rawStore, user: 'alice', secret: SECRET, searchStrategy: withSearch() })
+      const vault = await db.openVault('v1')
+      vault.collection<Msg>('msgs')
+      vault.collection<Msg>('msgs_text', {
+        satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full', embeddings: encoder,
+      })
+
+      await vault.joined<Msg>('msgs_full').put('x', { from: 'a', body: 'zebra unique text' })
+      await vault.joined<Msg>('msgs_full').put('y', { from: 'b', body: 'completely different stuff' })
+
+      const qVec = await encoder.encode('zebra unique text')
+      const before = await vault.collection<Msg>('msgs_text').similarTo(qVec, { k: 5 })
+      expect(before.map((h) => h.id)).toContain('x')
+
+      await rawStore.delete('v1', 'msgs', 'x')
+
+      const hits = await vault.collection<Msg>('msgs_text').similarTo(qVec, { k: 5 })
+      expect(hits.map((h) => h.id)).not.toContain('x')
+    })
+  })
+})

--- a/packages/hub/__tests__/satellites-conformance.test.ts
+++ b/packages/hub/__tests__/satellites-conformance.test.ts
@@ -39,7 +39,8 @@ interface Msg extends Record<string, unknown> {
 // Vector (a)/(b): base put shape + crash injection
 // ---------------------------------------------------------------------------
 
-/** In-memory store instrumented with put ordering (copied from satellites-fanout.test.ts). */
+/** In-memory store instrumented with put ordering + one-shot per-collection
+ *  put/delete failure injection (copied from satellites-fanout.test.ts). */
 function spyMemory() {
   const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
   const gc = (v: string, c: string): Map<string, EncryptedEnvelope> => {
@@ -48,10 +49,19 @@ function spyMemory() {
     return coll
   }
   const putOrder: Array<[string, string]> = []
+  let failPut: string | null = null
+  let failDelete: string | null = null
   const store: NoydbStore = {
     async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
-    async put(v, c, id, env) { putOrder.push([c, id]); gc(v, c).set(id, env) },
-    async delete(v, c, id) { gc(v, c).delete(id) },
+    async put(v, c, id, env) {
+      if (failPut === c) { failPut = null; throw new Error(`spy: forced put failure for "${c}"`) }
+      putOrder.push([c, id])
+      gc(v, c).set(id, env)
+    },
+    async delete(v, c, id) {
+      if (failDelete === c) { failDelete = null; throw new Error(`spy: forced delete failure for "${c}"`) }
+      gc(v, c).delete(id)
+    },
     async list(v, c) { const coll = data.get(v)?.get(c); return coll ? [...coll.keys()] : [] },
     async loadAll(v) {
       const comp = data.get(v); const s: VaultSnapshot = {}
@@ -62,7 +72,11 @@ function spyMemory() {
       for (const [n, byId] of Object.entries(recs)) { const coll = gc(v, n); for (const [id, e] of Object.entries(byId)) coll.set(id, e) }
     },
   }
-  return { store, putOrder }
+  return {
+    store, putOrder,
+    failNextPutFor: (c: string): void => { failPut = c },
+    failNextDeleteFor: (c: string): void => { failDelete = c },
+  }
 }
 
 async function openCrashPair() {
@@ -72,7 +86,10 @@ async function openCrashPair() {
   vault.collection<Msg>('msgs', {})
   vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full' })
   const pairOnly = (): Array<[string, string]> => spy.putOrder.filter(([c]) => c === 'msgs' || c === 'msgs_text')
-  return { vault, rawStore: spy.store, putOrder: pairOnly }
+  return {
+    vault, rawStore: spy.store, putOrder: pairOnly,
+    failNextPutFor: spy.failNextPutFor, failNextDeleteFor: spy.failNextDeleteFor,
+  }
 }
 
 describe('spec conformance — cross-cutting vectors (#591, Task 13)', () => {
@@ -98,18 +115,37 @@ describe('spec conformance — cross-cutting vectors (#591, Task 13)', () => {
       return vault2
     }
 
-    it('joined put killed after the base leg: base present, satellite absent, joined reads all-null satellite fields', async () => {
-      // spec: Conformance — crash injection, joined-put kill after the first fan-out op.
-      // Simulated by writing ONLY the base leg directly (bypassing joinedPut
-      // entirely) — a genuine process kill never reaches joinedPut's own
-      // catch-and-revert path, unlike the exception-driven revert already
-      // covered in satellites-fanout.test.ts.
-      const { vault, rawStore } = await openCrashPair()
-      await vault.collection<Msg>('msgs').put('x', { from: 'a' })
+    it('double-fault torn pair: satellite-leg failure whose best-effort revert ALSO fails leaves the torn state standing — readable safe-direction-only, live and after re-open', async () => {
+      // spec: Atomicity — crash-window torn pair (double fault: leg failure + best-effort revert failure) reads safe-direction-only
+      //
+      // Drives the REAL fan-out path (joinedPut via vault.joined().put) into
+      // its accepted crash window: the satellite leg's adapter put throws,
+      // and the subsequent best-effort revert of the already-executed base
+      // leg ALSO fails. For a fresh id the base leg's prior envelope is null,
+      // so fanout.ts's revertAndCompensate issues an adapter DELETE to undo
+      // it — that is the op armed to fail here. Revert failures are swallowed
+      // by design (surfacing one would mask the original leg error), so this
+      // double fault leaves the torn state standing: base carries the NEW hot
+      // fields, satellite absent.
+      const { vault, rawStore, failNextPutFor, failNextDeleteFor } = await openCrashPair()
+      failNextPutFor('msgs_text')  // satellite leg throws
+      failNextDeleteFor('msgs')    // ...and the base-leg revert (delete of the fresh envelope) also fails
 
+      // The ORIGINAL satellite-leg error surfaces, not the swallowed revert error.
+      await expect(vault.joined<Msg>('msgs_full').put('x', { from: 'a', subject: 's', body: 'B' }))
+        .rejects.toThrow(/msgs_text/)
+
+      // Torn persisted state: base stands with the new hot fields; satellite
+      // never produced (no base-less satellite either — folded from vector (a)).
       expect(await rawStore.get('v1', 'msgs', 'x')).not.toBeNull()
-      expect(await rawStore.get('v1', 'msgs_text', 'x')).toBeNull() // never produced
+      expect(await rawStore.get('v1', 'msgs_text', 'x')).toBeNull()
+      expect(await rawStore.list('v1', 'msgs_text')).not.toContain('x')
 
+      // Same-session reads of the torn state are safe-direction-only:
+      expect(await vault.joined<Msg>('msgs_full').get('x')).toEqual({ from: 'a', subject: null, body: null })
+      expect(await vault.collection<Msg>('msgs_text').get('x')).toBeNull()
+
+      // And the PERSISTED torn state is equally safe after a fresh re-open:
       const fresh = await reopenCrashPair(rawStore)
       expect(await fresh.joined<Msg>('msgs_full').get('x')).toEqual({ from: 'a', subject: null, body: null })
     })
@@ -128,13 +164,6 @@ describe('spec conformance — cross-cutting vectors (#591, Task 13)', () => {
 
       const fresh = await reopenCrashPair(rawStore)
       expect(await fresh.joined<Msg>('msgs_full').get('y')).toEqual({ from: 'b', subject: null, body: null })
-    })
-
-    it('a base-less satellite is never produced locally by a base-only write', async () => {
-      // spec: Conformance — "a fresh base-less satellite is never produced LOCALLY"
-      const { vault, rawStore } = await openCrashPair()
-      await vault.collection<Msg>('msgs').put('z', { from: 'c' }) // as if killed before any satellite leg ran
-      expect(await rawStore.list('v1', 'msgs_text')).not.toContain('z')
     })
   })
 
@@ -172,6 +201,7 @@ describe('spec conformance — cross-cutting vectors (#591, Task 13)', () => {
       expect(await vault.collection<Msg>('msgs_text').list()).toEqual([])
       expect(() => vault.collection<Msg>('msgs_text').query()).toThrowError(SatelliteConfigError)
       expect(await vault.collection<Msg>('msgs_text').retrieve('zebra')).toEqual([])
+      expect(await vault.collection<Msg>('msgs_text').search('body', 'zebra')).toEqual([]) // scan-mode search, same filterLiveHits path
       expect(await vault.joined<Msg>('msgs_full').get('x')).toBeNull()
 
       // Containment is purely observational — the satellite envelope was

--- a/packages/hub/__tests__/satellites-fanout.test.ts
+++ b/packages/hub/__tests__/satellites-fanout.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Fan-out writes with revert hardening (#591, Task 6): `joinedPut`/`pairDelete`
+ * split/order writes across a base↔satellite pair and best-effort revert +
+ * compensate every already-executed leg on failure.
+ *
+ * `vault.joined()` is Task 7 — not built yet. `joinedPut`/`pairDelete` are
+ * driven directly with a hand-built `FanoutDeps`, whose `base()`/`satellite()`
+ * accessors return the (possibly proxied) handles straight from
+ * `vault.collection(...)` — unwrapping happens inside `fanout.ts` itself, the
+ * same as the production base-proxy wiring (`makeBaseProxy` in `proxy.ts`),
+ * exercised here through the public API for the pair-delete tests.
+ *
+ * Fixture pattern (spy store, `db.openVault`) copied from
+ * satellites-proxy.test.ts / satellites-registration.test.ts.
+ */
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { withSync } from '../src/with-party/sync/index.js'
+import type { NoydbStore, EncryptedEnvelope, ChangeEvent, VaultSnapshot } from '../src/kernel/types.js'
+import type { StandardSchemaV1 } from '../src/kernel/schema.js'
+import { joinedPut, pairDelete } from '../src/with-shape/satellites/fanout.js'
+import type { FanoutDeps } from '../src/with-shape/satellites/fanout.js'
+
+const SECRET = 'satellite-fanout-test-1234'
+
+interface Msg extends Record<string, unknown> {
+  from?: string
+  subject?: string
+  body?: unknown
+}
+
+/** In-memory store instrumented with put/delete ordering + one-shot failure injection. */
+function spyMemory() {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const gc = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let comp = data.get(v); if (!comp) { comp = new Map(); data.set(v, comp) }
+    let coll = comp.get(c); if (!coll) { coll = new Map(); comp.set(c, coll) }
+    return coll
+  }
+  const putOrder: Array<[string, string]> = []
+  const deleteOrder: Array<[string, string]> = []
+  let failPut: string | null = null
+  let failDelete: string | null = null
+  const store: NoydbStore = {
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env) {
+      if (failPut === c) { failPut = null; throw new Error(`spy: forced put failure for "${c}"`) }
+      putOrder.push([c, id])
+      gc(v, c).set(id, env)
+    },
+    async delete(v, c, id) {
+      if (failDelete === c) { failDelete = null; throw new Error(`spy: forced delete failure for "${c}"`) }
+      deleteOrder.push([c, id])
+      gc(v, c).delete(id)
+    },
+    async list(v, c) { const coll = data.get(v)?.get(c); return coll ? [...coll.keys()] : [] },
+    async loadAll(v) {
+      const comp = data.get(v); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll(v, recs) {
+      for (const [n, byId] of Object.entries(recs)) { const coll = gc(v, n); for (const [id, e] of Object.entries(byId)) coll.set(id, e) }
+    },
+  }
+  return {
+    store, putOrder, deleteOrder,
+    failNextPutFor: (c: string): void => { failPut = c },
+    failNextDeleteFor: (c: string): void => { failDelete = c },
+    reset: (): void => { putOrder.length = 0; deleteOrder.length = 0 },
+  }
+}
+
+async function openPair(opts?: { satelliteSchema?: z.ZodTypeAny }) {
+  const local = spyMemory()
+  const remote = spyMemory().store // a real sync target so `onDirty` is wired to a real SyncEngine
+  const db = await createNoydb({ store: local.store, sync: remote, user: 'alice', secret: SECRET, syncStrategy: withSync() })
+  const vault = await db.openVault('v1')
+  vault.collection<Msg>('msgs', {})
+  vault.collection<Msg>('msgs_text', {
+    satelliteOf: 'msgs',
+    fields: ['subject', 'body'],
+    ...(opts?.satelliteSchema !== undefined ? { schema: opts.satelliteSchema as unknown as StandardSchemaV1<unknown, Msg> } : {}),
+  })
+
+  const changeLog: ChangeEvent[] = []
+  db.on('change', (e) => changeLog.push(e))
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const engine = (db as any).syncEngines.get('v1') as { dirty: Array<{ collection: string; id: string }> }
+
+  // Filter out internal bookkeeping writes (_keyring, _meta, _sync, …) —
+  // the spy exists to observe ordering on the pair's own two collections.
+  const pairOnly = (entries: Array<[string, string]>): Array<[string, string]> =>
+    entries.filter(([c]) => c === 'msgs' || c === 'msgs_text')
+  const spy = {
+    get putOrder() { return pairOnly(local.putOrder) },
+    get deleteOrder() { return pairOnly(local.deleteOrder) },
+    failNextPutFor: local.failNextPutFor,
+    failNextDeleteFor: local.failNextDeleteFor,
+    reset: local.reset,
+    raw: local.store,
+  }
+  const dirtyLog = {
+    entriesFor: (collection: string, id: string) => engine.dirty.filter(d => d.collection === collection && d.id === id),
+  }
+  const changes = {
+    last: (collection: string): ChangeEvent | null => [...changeLog].reverse().find(e => e.collection === collection) ?? null,
+  }
+  const deps = (): FanoutDeps => ({
+    spec: { base: 'msgs', satellite: 'msgs_text', fields: ['subject', 'body'] },
+    base: () => vault.collection<Msg>('msgs'),
+    satellite: () => vault.collection<Msg>('msgs_text'),
+    adapter: local.store,
+    vaultName: 'v1',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    registry: (vault as any).satelliteRegistry,
+  })
+
+  return { vault, spy, dirtyLog, changes, deps }
+}
+
+describe('joined fan-out', () => {
+  it('splits by the fields routing table and writes base leg first', async () => {
+    const { vault, spy, deps } = await openPair()
+    await joinedPut(deps(), 'x', { from: 'a', subject: 's', body: 'B' })
+    expect(spy.putOrder).toEqual([['msgs', 'x'], ['msgs_text', 'x']])
+    expect(await vault.collection<Msg>('msgs').get('x')).toEqual({ from: 'a' })
+    expect((await vault.collection<Msg>('msgs_text').get('x'))?.body).toBe('B')
+  })
+
+  it('pre-validates both legs: an invalid satellite field aborts with ZERO adapter writes', async () => {
+    const satelliteSchema = z.object({ subject: z.string().optional(), body: z.string() })
+    const { spy, deps } = await openPair({ satelliteSchema })
+    await expect(joinedPut(deps(), 'x', { from: 'a', body: 42 })).rejects.toThrow()
+    expect(spy.putOrder).toEqual([])
+  })
+
+  it('satellite-leg adapter failure: base leg reverted, compensating change emitted, no dirty entry survives', async () => {
+    const { spy, dirtyLog, changes, deps } = await openPair()
+    spy.failNextPutFor('msgs_text')
+    await expect(joinedPut(deps(), 'x', { from: 'a', body: 'B' })).rejects.toThrow()
+    expect(await spy.raw.get('v1', 'msgs', 'x')).toBeNull() // prior (absent) restored
+    expect(dirtyLog.entriesFor('msgs', 'x')).toEqual([]) // dirty entry removed
+    expect(changes.last('msgs')).toMatchObject({ id: 'x', action: 'revert' })
+  })
+
+  it('pair delete removes the satellite leg first; failure reverts', async () => {
+    const { vault, spy, deps } = await openPair()
+    await joinedPut(deps(), 'x', { from: 'a', body: 'B' })
+    spy.reset()
+    await vault.collection<Msg>('msgs').delete('x') // through the public base-proxy delete override
+    expect(spy.deleteOrder).toEqual([['msgs_text', 'x'], ['msgs', 'x']])
+
+    await joinedPut(deps(), 'y', { from: 'b', body: 'C' })
+    spy.failNextDeleteFor('msgs')
+    await expect(vault.collection<Msg>('msgs').delete('y')).rejects.toThrow()
+    expect(await spy.raw.get('v1', 'msgs_text', 'y')).not.toBeNull() // satellite leg restored
+  })
+})

--- a/packages/hub/__tests__/satellites-fanout.test.ts
+++ b/packages/hub/__tests__/satellites-fanout.test.ts
@@ -143,19 +143,29 @@ describe('joined fan-out', () => {
     await expect(joinedPut(deps(), 'x', { from: 'a', body: 'B' })).rejects.toThrow()
     expect(await spy.raw.get('v1', 'msgs', 'x')).toBeNull() // prior (absent) restored
     expect(dirtyLog.entriesFor('msgs', 'x')).toEqual([]) // dirty entry removed
-    expect(changes.last('msgs')).toMatchObject({ id: 'x', action: 'revert' })
+    // Compensation announces the RESTORED state with the public action
+    // vocabulary: prior was absent, so the event is a plain 'delete'.
+    expect(changes.last('msgs')).toMatchObject({ id: 'x', action: 'delete' })
   })
 
   it('pair delete removes the satellite leg first; failure reverts', async () => {
-    const { vault, spy, deps } = await openPair()
+    const { vault, spy, changes, deps } = await openPair()
     await joinedPut(deps(), 'x', { from: 'a', body: 'B' })
     spy.reset()
     await vault.collection<Msg>('msgs').delete('x') // through the public base-proxy delete override
     expect(spy.deleteOrder).toEqual([['msgs_text', 'x'], ['msgs', 'x']])
 
     await joinedPut(deps(), 'y', { from: 'b', body: 'C' })
+    const priorEnvelope = await spy.raw.get('v1', 'msgs_text', 'y') // envelope to be restored
+    // subscribe() must see the compensation as a hydrated 'put' with the
+    // restored record — not a misrouted 'delete' (record: null).
+    const subEvents: Array<{ type: string; id: string; record: Msg | null }> = []
+    vault.collection<Msg>('msgs_text').subscribe(e => subEvents.push(e))
     spy.failNextDeleteFor('msgs')
     await expect(vault.collection<Msg>('msgs').delete('y')).rejects.toThrow()
-    expect(await spy.raw.get('v1', 'msgs_text', 'y')).not.toBeNull() // satellite leg restored
+    expect(await spy.raw.get('v1', 'msgs_text', 'y')).toEqual(priorEnvelope) // satellite ENVELOPE restored byte-for-byte
+    expect(changes.last('msgs_text')).toMatchObject({ id: 'y', action: 'put' }) // restored → 'put'
+    await new Promise(r => setTimeout(r, 0)) // let subscribe()'s async hydration settle
+    expect(subEvents.at(-1)).toMatchObject({ type: 'put', id: 'y', record: { body: 'C' } })
   })
 })

--- a/packages/hub/__tests__/satellites-forget.test.ts
+++ b/packages/hub/__tests__/satellites-forget.test.ts
@@ -128,4 +128,25 @@ describe('forget fan-out through the full purge suite (#591, Task 8)', () => {
 
     await expect(vault.forget('alice@x')).rejects.toThrowError(/R-S4/)
   })
+
+  it('R-S4 retry: an aborted forget can be retried to completion — the base\'s subject-index anchor must survive an abort mid-satellite-ref (no retry black hole, review C1)', async () => {
+    const { vault, rawStore, spy } = await openForgetPair()
+    await vault.joined('msgs_full').put('x', { from: 'alice@x', subject: 's', body: 'SECRET' })
+
+    spy.failNextPutFor('msgs_text') // satellite tombstone write fails ONCE
+    await expect(vault.forget('alice@x')).rejects.toThrowError(/R-S4/)
+
+    // Retry (the spy already disarmed itself after firing once) must still
+    // find the subject and shred BOTH the satellite and the base — if the
+    // satellite ref ran after (instead of before) its base ref, the base's
+    // subject-index entry would already be gone and this retry would return
+    // a clean, empty result while the satellite stays un-shredded forever.
+    const result = await vault.forget('alice@x')
+
+    expect(result.recordsShredded).toBe(2) // base + satellite, both shredded on retry
+    const satEnv = await rawStore.get('v1', 'msgs_text', 'x')
+    expect(satEnv?._data).toBe('')
+    const baseEnv = await rawStore.get('v1', 'msgs', 'x')
+    expect(baseEnv?._data).toBe('')
+  })
 })

--- a/packages/hub/__tests__/satellites-forget.test.ts
+++ b/packages/hub/__tests__/satellites-forget.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Forget fan-out through satellite pairs (#591, Task 8).
+ *
+ * Spec: docs/superpowers/specs/2026-07-05-satellite-collections-design.md
+ *
+ * A satellite record is never itself present in the encrypted subject index
+ * (its writes only ever flow through `joinedPut`, which the forget
+ * subject-index write hook never observes — see `noydb.ts#registerForgetHooks`).
+ * `vault.forget()` must still shred it: `expandRefsWithSatellites`
+ * (`with-shape/satellites/forget.ts`) synthesizes a same-id ref for every
+ * base ref whose collection has a declared satellite, and that ref rides the
+ * SAME per-ref purge suite a base ref does (tombstone, history, `_idx`
+ * purge, blobs, `_sealed`/`_sealed_cek`, vectors) — not a parallel path.
+ *
+ * Test 2 (full-purge-suite traversal) uses `_idx` side-car purge rather than
+ * wiring `withSearch` onto the satellite: proving the synthesized ref is
+ * subject to `_purgePersistedIndexes` (a mid-loop stage, not the tombstone
+ * write itself, nor the last stage) is sufficient evidence the ref traverses
+ * the whole loop body, and it reuses the exact pattern already proven for
+ * base refs in `forget.test.ts` group 10.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { withHistory } from '../src/with-commit/history/index.js'
+import { withForgetCascade } from '../src/with-audit/forget/index.js'
+import { withIndexing } from '../src/with-lookup/indexing/index.js'
+import { memory } from '../../to-memory/src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../src/kernel/types.js'
+
+const SECRET = 'satellites-forget-test-1234'
+
+interface Msg extends Record<string, unknown> {
+  from?: string
+  subject?: string
+  body?: string
+}
+
+/** Wraps a real `to-memory` store with a one-shot per-collection put-failure spy. */
+function spyStore(raw: NoydbStore): { store: NoydbStore; failNextPutFor: (coll: string) => void } {
+  let failNextFor: string | null = null
+  const store: NoydbStore = {
+    ...raw,
+    async put(vault, coll, id, env, expectedVersion) {
+      if (failNextFor === coll) {
+        failNextFor = null
+        throw new Error(`spy: injected failure for put("${coll}")`)
+      }
+      return raw.put(vault, coll, id, env, expectedVersion)
+    },
+  }
+  return { store, failNextPutFor: (coll: string) => { failNextFor = coll } }
+}
+
+async function openForgetPair(opts: { indexed?: boolean } = {}) {
+  const rawStore = memory()
+  const { store, failNextPutFor } = spyStore(rawStore)
+  const db = await createNoydb({
+    store,
+    user: 'alice',
+    secret: SECRET,
+    historyStrategy: withHistory(),
+    ...(opts.indexed ? { indexStrategy: withIndexing() } : {}),
+    forgetStrategy: withForgetCascade({ subjects: { msgs: 'from' } }),
+  })
+  const vault = await db.openVault('v1')
+  // R-S7: both pair members declare perRecordKeys explicitly (the base's is
+  // also force-derived from `forgetStrategy.subjects`, but spelling it out
+  // here keeps the fixture's forget-coverage intent legible).
+  vault.collection<Msg>('msgs', { perRecordKeys: true })
+  vault.collection<Msg>('msgs_text', {
+    satelliteOf: 'msgs',
+    fields: ['subject', 'body'],
+    joined: 'msgs_full',
+    perRecordKeys: true,
+    ...(opts.indexed ? { indexes: ['subject'], prefetch: false, cache: { maxRecords: 100 } } : {}),
+  })
+  return { vault, rawStore, spy: { failNextPutFor } }
+}
+
+async function stripCek(rawStore: NoydbStore, vault: string, collection: string, id: string): Promise<void> {
+  const live = await rawStore.get(vault, collection, id)
+  if (!live) throw new Error('stripCek: no live envelope to forge')
+  await rawStore.put(vault, collection, id, { ...live, _cek: undefined } as unknown as EncryptedEnvelope)
+}
+
+describe('forget fan-out through the full purge suite (#591, Task 8)', () => {
+  it('shreds the satellite via a synthesized ref (never in the subject index)', async () => {
+    const { vault, rawStore } = await openForgetPair()
+    await vault.joined('msgs_full').put('x', { from: 'alice@x', subject: 's', body: 'SECRET' })
+
+    const result = await vault.forget('alice@x')
+
+    expect(result.recordsShredded).toBe(2) // base + satellite
+    const satEnv = await rawStore.get('v1', 'msgs_text', 'x')
+    expect(satEnv?._data).toBe('') // tombstoned, not merely deleted
+    expect(satEnv?._cek).toBeUndefined()
+    const baseEnv = await rawStore.get('v1', 'msgs', 'x')
+    expect(baseEnv?._data).toBe('')
+  })
+
+  it('purges the satellite\'s persisted _idx side-cars (same per-ref suite as base)', async () => {
+    const { vault, rawStore } = await openForgetPair({ indexed: true })
+    await vault.joined('msgs_full').put('x', { from: 'alice@x', subject: 'zebra unique', body: 'b' })
+
+    const idxIds = () => rawStore.list('v1', 'msgs_text')
+    expect((await idxIds()).some((k) => k.startsWith('_idx/') && k.endsWith('/x'))).toBe(true)
+
+    const result = await vault.forget('alice@x')
+
+    expect(result.indexResidue).toEqual([])
+    expect((await idxIds()).some((k) => k.startsWith('_idx/') && k.endsWith('/x'))).toBe(false)
+  })
+
+  it('classification inheritance: an unmigrated (no-_cek) satellite record is REPORTED in unmigratedRecords', async () => {
+    const { vault, rawStore } = await openForgetPair()
+    await vault.joined('msgs_full').put('x', { from: 'alice@x', body: 'B' })
+    await stripCek(rawStore, 'v1', 'msgs_text', 'x') // forge a legacy shared-DEK record
+
+    const result = await vault.forget('alice@x')
+
+    expect(result.unmigratedRecords).toContain('msgs_text:x')
+  })
+
+  it('R-S4: a satellite ref that cannot be processed fails the forget loudly', async () => {
+    const { vault, spy } = await openForgetPair()
+    await vault.joined('msgs_full').put('x', { from: 'alice@x', body: 'B' })
+    spy.failNextPutFor('msgs_text') // tombstone write fails
+
+    await expect(vault.forget('alice@x')).rejects.toThrowError(/R-S4/)
+  })
+})

--- a/packages/hub/__tests__/satellites-joined.test.ts
+++ b/packages/hub/__tests__/satellites-joined.test.ts
@@ -1,0 +1,137 @@
+/**
+ * JoinedHandle + vault.joined() (#591, Task 7): the full-record access point
+ * for a base↔satellite pair declared with `joined:`. Reads merge base ⊕
+ * satellite under existence authority (rule 1); writes/deletes delegate to
+ * the Task 6 fan-out (`joinedPut`/`pairDelete`). Deliberately narrow — no
+ * reactive members.
+ *
+ * Fixture pattern (spy store, `db.openVault`) copied from
+ * satellites-fanout.test.ts.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { withSync } from '../src/with-party/sync/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
+import { SatelliteConfigError } from '../src/kernel/errors.js'
+
+const SECRET = 'satellite-joined-test-1234'
+
+interface Msg extends Record<string, unknown> {
+  from?: string
+  subject?: string
+  body?: string
+}
+
+/** In-memory store instrumented with delete ordering (copied from satellites-fanout.test.ts). */
+function spyMemory() {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const gc = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let comp = data.get(v); if (!comp) { comp = new Map(); data.set(v, comp) }
+    let coll = comp.get(c); if (!coll) { coll = new Map(); comp.set(c, coll) }
+    return coll
+  }
+  const deleteOrder: Array<[string, string]> = []
+  const store: NoydbStore = {
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env) { gc(v, c).set(id, env) },
+    async delete(v, c, id) { deleteOrder.push([c, id]); gc(v, c).delete(id) },
+    async list(v, c) { const coll = data.get(v)?.get(c); return coll ? [...coll.keys()] : [] },
+    async loadAll(v) {
+      const comp = data.get(v); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll(v, recs) {
+      for (const [n, byId] of Object.entries(recs)) { const coll = gc(v, n); for (const [id, e] of Object.entries(byId)) coll.set(id, e) }
+    },
+  }
+  return { store, deleteOrder, reset: (): void => { deleteOrder.length = 0 } }
+}
+
+async function openPair() {
+  const local = spyMemory()
+  const remote = spyMemory().store // a real sync target so onDirty is wired to a real SyncEngine
+  const db = await createNoydb({ store: local.store, sync: remote, user: 'alice', secret: SECRET, syncStrategy: withSync() })
+  const vault = await db.openVault('v1')
+  vault.collection<Msg>('msgs', { fieldMeta: { from: { label: 'From' } } })
+  vault.collection<Msg>('msgs_text', {
+    satelliteOf: 'msgs',
+    fields: ['subject', 'body'],
+    joined: 'msgs_full',
+    fieldMeta: { subject: { label: 'Subject' }, body: { label: 'Body' } },
+  })
+
+  const pairOnly = (entries: Array<[string, string]>): Array<[string, string]> =>
+    entries.filter(([c]) => c === 'msgs' || c === 'msgs_text')
+  const spy = {
+    get deleteOrder() { return pairOnly(local.deleteOrder) },
+    reset: local.reset,
+  }
+  return { vault, rawStore: local.store, spy }
+}
+
+describe('JoinedHandle', () => {
+  it('get merges base ⊕ satellite; absent satellite reads all-null for declared fields', async () => {
+    const { vault } = await openPair()
+    await vault.collection<Msg>('msgs').put('x', { from: 'a' })
+    expect(await vault.joined<Msg>('msgs_full').get('x')).toEqual({ from: 'a', subject: null, body: null })
+    await vault.collection<Msg>('msgs_text').put('x', { subject: 's', body: 'B' })
+    expect(await vault.joined<Msg>('msgs_full').get('x')).toEqual({ from: 'a', subject: 's', body: 'B' })
+  })
+
+  it('get returns null when the base is absent, even if a satellite envelope exists', async () => {
+    const { vault, rawStore } = await openPair()
+    await vault.joined<Msg>('msgs_full').put('x', { from: 'a', body: 'B' })
+    await rawStore.delete('v1', 'msgs', 'x')
+    expect(await vault.joined<Msg>('msgs_full').get('x')).toBeNull()
+  })
+
+  it('get returns null when the base is tombstoned (not merely absent), even if a satellite envelope exists', async () => {
+    const { vault, rawStore } = await openPair()
+    await vault.joined<Msg>('msgs_full').put('x', { from: 'a', body: 'B' })
+    // buildTombstone() shape: _iv === '' && _data === '' — written directly via the raw store.
+    await rawStore.put('v1', 'msgs', 'x', { _noydb: 1, _v: 2, _ts: 't', _iv: '', _data: '' })
+    expect(await vault.joined<Msg>('msgs_full').get('x')).toBeNull()
+  })
+
+  it('delete removes the pair (delegates to pairDelete, satellite first)', async () => {
+    const { vault, spy } = await openPair()
+    await vault.joined<Msg>('msgs_full').put('x', { from: 'a', body: 'B' })
+    spy.reset()
+    await vault.joined<Msg>('msgs_full').delete('x')
+    expect(spy.deleteOrder).toEqual([['msgs_text', 'x'], ['msgs', 'x']])
+  })
+
+  it('list returns merged records for live-base ids only (mirror of satellite proxy list test, through joined)', async () => {
+    const { vault, rawStore } = await openPair()
+    await vault.joined<Msg>('msgs_full').put('a', { from: 'a', body: '1' })
+    await vault.joined<Msg>('msgs_full').put('b', { from: 'b', body: '2' })
+    await rawStore.delete('v1', 'msgs', 'b') // simulate offline resurrection state
+    expect(await vault.joined<Msg>('msgs_full').list()).toEqual([{ from: 'a', subject: null, body: '1' }])
+  })
+
+  it('describe() works and unions both sides fields (UI contract); no narrow member is undefined', async () => {
+    const { vault } = await openPair()
+    const handle = vault.joined<Msg>('msgs_full')
+    const d = await handle.describe()
+    const keys = d.fields.map(f => f.key)
+    expect(keys).toEqual(expect.arrayContaining(['from', 'subject', 'body']))
+    for (const m of ['get', 'put', 'delete', 'list', 'describe'] as const) {
+      expect(typeof handle[m]).toBe('function')
+    }
+  })
+
+  it('reactive API members are absent from the handle at runtime', async () => {
+    const { vault } = await openPair()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((vault.joined<Msg>('msgs_full') as any).subscribe).toBeUndefined()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((vault.joined<Msg>('msgs_full') as any).live).toBeUndefined()
+  })
+
+  it('throws SatelliteConfigError for an unregistered joined name, pointing at declaring joined:', async () => {
+    const { vault } = await openPair()
+    expect(() => vault.joined('nope')).toThrowError(SatelliteConfigError)
+    expect(() => vault.joined('nope')).toThrowError(/joined:/)
+  })
+})

--- a/packages/hub/__tests__/satellites-marker.test.ts
+++ b/packages/hub/__tests__/satellites-marker.test.ts
@@ -1,0 +1,52 @@
+/**
+ * R-S9 — persisted pairing marker for satellite collections.
+ *
+ * `ensureSatelliteMarker` persists `{ base, fieldsHash, joined }` into
+ * `_schemas/<satellite>` on first declaration and refuses (SatelliteConfigError,
+ * "R-S9") a later re-declaration whose (base, fieldsHash, joined) diverges from
+ * what's already persisted — the satellite-pair analogue of the classified
+ * config-drift marker (#583's `_schemas` read-merge-write hardening applies
+ * identically here).
+ */
+import { describe, it, expect } from 'vitest'
+import { inlineMemory } from './classified/harness.js'
+import { generateDEK } from '../src/kernel/enclave/index.js'
+import { ensureSatelliteMarker } from '../src/with-shape/satellites/marker.js'
+import { SatelliteConfigError } from '../src/kernel/errors.js'
+import type { SatelliteSpec } from '../src/with-shape/satellites/types.js'
+
+async function makeFixture() {
+  const store = inlineMemory()
+  const dek = await generateDEK()
+  return { store, dek }
+}
+
+const spec: SatelliteSpec = {
+  base: 'msgs',
+  satellite: 'msgs_text',
+  fields: ['subject', 'body'],
+  joined: 'msgs_full',
+}
+
+describe('ensureSatelliteMarker (R-S9)', () => {
+  it('persists on first declaration and accepts an identical re-declaration', async () => {
+    const { store, dek } = await makeFixture()
+    await ensureSatelliteMarker(store, 'v1', spec, dek)
+    await expect(ensureSatelliteMarker(store, 'v1', spec, dek)).resolves.toBeUndefined()
+  })
+
+  it('refuses a re-declaration with a divergent fields list', async () => {
+    const { store, dek } = await makeFixture()
+    await ensureSatelliteMarker(store, 'v1', spec, dek)
+    await expect(
+      ensureSatelliteMarker(store, 'v1', { ...spec, fields: ['body'] }, dek),
+    ).rejects.toThrowError(/R-S9/)
+  })
+
+  it('refuses a re-declaration with a divergent base or joined name', async () => {
+    const { store, dek } = await makeFixture()
+    await ensureSatelliteMarker(store, 'v1', spec, dek)
+    await expect(ensureSatelliteMarker(store, 'v1', { ...spec, base: 'mail' }, dek)).rejects.toThrowError(SatelliteConfigError)
+    await expect(ensureSatelliteMarker(store, 'v1', { ...spec, joined: 'other' }, dek)).rejects.toThrowError(/R-S9/)
+  })
+})

--- a/packages/hub/__tests__/satellites-marker.test.ts
+++ b/packages/hub/__tests__/satellites-marker.test.ts
@@ -9,9 +9,12 @@
  * identically here).
  */
 import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
 import { inlineMemory } from './classified/harness.js'
 import { generateDEK } from '../src/kernel/enclave/index.js'
 import { ensureSatelliteMarker } from '../src/with-shape/satellites/marker.js'
+import { persistSchemaIfNeeded } from '../src/with-shape/persisted-schemas/register.js'
+import { loadPersistedSchema } from '../src/with-shape/persisted-schemas/storage.js'
 import { SatelliteConfigError } from '../src/kernel/errors.js'
 import type { SatelliteSpec } from '../src/with-shape/satellites/types.js'
 
@@ -48,5 +51,33 @@ describe('ensureSatelliteMarker (R-S9)', () => {
     await ensureSatelliteMarker(store, 'v1', spec, dek)
     await expect(ensureSatelliteMarker(store, 'v1', { ...spec, base: 'mail' }, dek)).rejects.toThrowError(SatelliteConfigError)
     await expect(ensureSatelliteMarker(store, 'v1', { ...spec, joined: 'other' }, dek)).rejects.toThrowError(/R-S9/)
+  })
+
+  it('survives a JSON-Schema (re)derivation on the shared _schemas record', async () => {
+    // Same #583 bug class as the classified marker: persistSchemaIfNeeded's
+    // read-merge-write must carry the satellite marker forward, or the R-S9
+    // drift signal silently dies the first time a satellite collection with
+    // persistJsonSchema re-derives its schema.
+    const { store, dek } = await makeFixture()
+    await ensureSatelliteMarker(store, 'v1', spec, dek)
+
+    // Schema writer touches _schemas/<satellite> (first registration writes).
+    await persistSchemaIfNeeded({
+      store, vault: 'v1', collectionName: spec.satellite,
+      validator: z.object({ subject: z.string(), body: z.string() }), dek,
+    })
+
+    // Marker survived the merge — both signals coexist on the single record.
+    const stored = await loadPersistedSchema(store, 'v1', spec.satellite, dek)
+    expect(stored?.satellite).toBeDefined()
+    expect(stored?.satellite?.base).toBe('msgs')
+    expect(stored?.kind).toBe('Zod')
+
+    // And the R-S9 guard still works end-to-end: same spec resolves,
+    // divergent spec refuses.
+    await expect(ensureSatelliteMarker(store, 'v1', spec, dek)).resolves.toBeUndefined()
+    await expect(
+      ensureSatelliteMarker(store, 'v1', { ...spec, fields: ['body'] }, dek),
+    ).rejects.toThrowError(/R-S9/)
   })
 })

--- a/packages/hub/__tests__/satellites-proxy.test.ts
+++ b/packages/hub/__tests__/satellites-proxy.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Satellite read/write proxy (#591, Task 5): existence authority + R-S6.
+ *
+ * Drives everything through the public `createNoydb`/`openVault` API with
+ * `to-memory` (fixture pattern copied from satellites-registration.test.ts).
+ * The `rawStore` handle lets tests simulate offline-resurrection states
+ * (a base delete that bypasses the Collection cache) the same way the
+ * design spec's "store-shape" vectors do.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/kernel/noydb.js'
+import type { NoydbStore } from '../src/kernel/types.js'
+import { memory } from '../../to-memory/src/index.js'
+import { RAW_TARGET } from '../src/with-shape/satellites/proxy.js'
+
+const SECRET = 'satellite-proxy-test-1234'
+
+interface Msg extends Record<string, unknown> {
+  from?: string
+  body?: string
+}
+
+async function openPair() {
+  const store: NoydbStore = memory()
+  const gets: Array<[string, string]> = []
+  const rawGet = store.get.bind(store)
+  store.get = (async (v: string, c: string, id: string) => {
+    gets.push([c, id])
+    return rawGet(v, c, id)
+  }) as NoydbStore['get']
+
+  const db = await createNoydb({ store, user: 'alice', secret: SECRET })
+  const vault = await db.openVault('v1')
+  vault.collection<Msg>('msgs', {})
+  vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['body'] })
+
+  // Decrypt spy: monkeypatch each raw collection's private codec (same
+  // "private is compile-time only" access the proxy itself relies on) so
+  // tests can assert the existence check never decrypts the base.
+  const decrypts = new Map<string, number>()
+  const spyOnDecrypts = (name: string): void => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const raw = (vault as any).collectionCache.get(name)
+    const codec = raw?.codec
+    if (codec && !codec.__decryptSpied) {
+      const orig = codec.decryptRecord.bind(codec)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      codec.decryptRecord = (...args: any[]) => {
+        decrypts.set(name, (decrypts.get(name) ?? 0) + 1)
+        return orig(...args)
+      }
+      codec.__decryptSpied = true
+    }
+  }
+  spyOnDecrypts('msgs')
+  spyOnDecrypts('msgs_text')
+
+  const spy = {
+    gets,
+    reset: (): void => { gets.length = 0; decrypts.clear() },
+    decryptsFor: (name: string): number => decrypts.get(name) ?? 0,
+  }
+  return { vault, rawStore: store, spy }
+}
+
+describe('satellite proxy — existence authority + R-S6', () => {
+  it('satellite.get returns null when the base row is absent or tombstoned; dead ciphertext remains', async () => {
+    const { vault, rawStore } = await openPair()
+    await vault.collection<Msg>('msgs').put('x', { from: 'a' })
+    await vault.collection<Msg>('msgs_text').put('x', { body: 'B' })
+    await rawStore.delete('v1', 'msgs', 'x') // simulate offline resurrection state
+    expect(await vault.collection<Msg>('msgs_text').get('x')).toBeNull()
+    expect(await rawStore.get('v1', 'msgs_text', 'x')).not.toBeNull() // no sweep
+  })
+
+  it('satellite.list excludes base-less ids', async () => {
+    const { vault, rawStore } = await openPair()
+    await vault.collection<Msg>('msgs').put('a', { from: 'a' })
+    await vault.collection<Msg>('msgs_text').put('a', { body: '1' })
+    await vault.collection<Msg>('msgs').put('b', { from: 'b' })
+    await vault.collection<Msg>('msgs_text').put('b', { body: '2' })
+    await rawStore.delete('v1', 'msgs', 'b')
+    expect((await vault.collection<Msg>('msgs_text').list()).map(r => r.body)).toEqual(['1'])
+  })
+
+  it('R-S6: satellite.put with no base record refuses', async () => {
+    const { vault } = await openPair()
+    await expect(vault.collection<Msg>('msgs_text').put('ghost', { body: 'B' })).rejects.toThrowError(/R-S6/)
+  })
+
+  it('store-shape: satellite.get does one undecrypted base get, zero base decrypts (spy counts decrypts)', async () => {
+    const { vault, spy } = await openPair()
+    await vault.collection<Msg>('msgs').put('x', { from: 'a' })
+    await vault.collection<Msg>('msgs_text').put('x', { body: 'B' })
+    spy.reset()
+    await vault.collection<Msg>('msgs_text').get('x')
+    // Exactly one adapter.get on the base ("msgs") — the existence check.
+    // (Not asserting a matching call for "msgs_text": its own get() serves
+    // from the already-warm in-memory cache after the preceding put() and
+    // never round-trips through the adapter — an orthogonal cache fact, not
+    // part of the existence-authority contract under test.)
+    expect(spy.gets.filter(([c]) => c === 'msgs')).toEqual([['msgs', 'x']])
+    expect(spy.decryptsFor('msgs')).toBe(0)
+  })
+
+  it('the proxy preserves the full Collection surface (describe, count, putMany exist)', async () => {
+    const { vault } = await openPair()
+    const sat = vault.collection<Msg>('msgs_text')
+    expect(typeof sat.describe).toBe('function')
+    expect(typeof sat.putMany).toBe('function')
+  })
+
+  it('RAW_TARGET escapes the proxy: the raw target\'s put does not do the base-exists check', async () => {
+    const { vault } = await openPair()
+    const sat = vault.collection<Msg>('msgs_text') as unknown as Record<symbol, unknown>
+    const raw = sat[RAW_TARGET] as { put: (id: string, record: Msg) => Promise<void> }
+    // No base record for "ghost" exists — the proxy's put would refuse (R-S6);
+    // the raw target's put must not.
+    await expect(raw.put('ghost', { body: 'B' })).resolves.toBeUndefined()
+  })
+
+  it('satellite.query() refuses — Query terminals are sync, existence authority requires an async check; use list()', async () => {
+    const { vault } = await openPair()
+    await vault.collection<Msg>('msgs').put('x', { from: 'a' })
+    await vault.collection<Msg>('msgs_text').put('x', { body: 'B' })
+    expect(() => vault.collection<Msg>('msgs_text').query()).toThrowError(/list\(\)/)
+  })
+})

--- a/packages/hub/__tests__/satellites-proxy.test.ts
+++ b/packages/hub/__tests__/satellites-proxy.test.ts
@@ -11,7 +11,8 @@ import { describe, it, expect } from 'vitest'
 import { createNoydb } from '../src/kernel/noydb.js'
 import type { NoydbStore } from '../src/kernel/types.js'
 import { memory } from '../../to-memory/src/index.js'
-import { RAW_TARGET } from '../src/with-shape/satellites/proxy.js'
+import { RAW_TARGET, makeSatelliteProxy } from '../src/with-shape/satellites/proxy.js'
+import { SatelliteConfigError } from '../src/kernel/errors.js'
 
 const SECRET = 'satellite-proxy-test-1234'
 
@@ -119,10 +120,44 @@ describe('satellite proxy — existence authority + R-S6', () => {
     await expect(raw.put('ghost', { body: 'B' })).resolves.toBeUndefined()
   })
 
-  it('satellite.query() refuses — Query terminals are sync, existence authority requires an async check; use list()', async () => {
+  it('satellite.query() refuses with SatelliteConfigError — Query terminals are sync, existence authority requires an async check; use list()', async () => {
     const { vault } = await openPair()
     await vault.collection<Msg>('msgs').put('x', { from: 'a' })
     await vault.collection<Msg>('msgs_text').put('x', { body: 'B' })
+    expect(() => vault.collection<Msg>('msgs_text').query()).toThrowError(SatelliteConfigError)
     expect(() => vault.collection<Msg>('msgs_text').query()).toThrowError(/list\(\)/)
+  })
+
+  it('poison check runs INSIDE the pair lock: a put queued behind a poisoning section rejects', async () => {
+    // Unit-level on makeSatelliteProxy with a stub target: the vault fixture
+    // can't distinguish the orderings because the Noydb-wide onBeforeWrite
+    // poison hook (Task 4) rejects the write either way (defense-in-depth
+    // masking). Here there is no write hook — only the proxy's own check.
+    const { SatelliteRegistry } = await import('../src/with-shape/satellites/registry.js')
+    const registry = new SatelliteRegistry()
+    const spec = { base: 'msgs', satellite: 'msgs_text', fields: ['body'] as const, joined: undefined }
+    registry.register(spec)
+    const liveEnv = { _noydb: 1, _v: 1, _ts: 't', _iv: 'iv', _data: 'd' }
+    const target = {
+      adapter: { get: async () => liveEnv }, // base always live — only poison can refuse
+      vault: 'v1',
+      put: async () => undefined,
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const proxied = makeSatelliteProxy(target as any, spec, registry)
+    // Occupy the pair lock; poison the satellite inside the held section
+    // (models a concurrent fan-out's failure path poisoning under the lock).
+    let release!: () => void
+    const gate = new Promise<void>(res => { release = res })
+    const holding = registry.withPairLock('msgs', async () => {
+      await gate
+      registry.poison('msgs_text', 'R-S1: poisoned during fan-out (ordering test)')
+    })
+    // Queue the put behind the held lock. Its poison check must run AFTER
+    // acquisition — i.e. after the poisoning section completes — so it rejects.
+    const blocked = proxied.put('x', { body: 'B' })
+    release()
+    await holding
+    await expect(blocked).rejects.toThrowError(/poisoned during fan-out/)
   })
 })

--- a/packages/hub/__tests__/satellites-proxy.test.ts
+++ b/packages/hub/__tests__/satellites-proxy.test.ts
@@ -161,3 +161,65 @@ describe('satellite proxy — existence authority + R-S6', () => {
     await expect(blocked).rejects.toThrowError(/poisoned during fan-out/)
   })
 })
+
+describe('satellite proxy — bulk methods honor the same overrides as their single-item counterpart (#591 review I1)', () => {
+  it('satellite.getMany excludes dead-base ids (real getMany binds to the raw get, bypassing existence filtering)', async () => {
+    const { vault, rawStore } = await openPair()
+    await vault.collection<Msg>('msgs').put('a', { from: 'a' })
+    await vault.collection<Msg>('msgs_text').put('a', { body: '1' })
+    await vault.collection<Msg>('msgs').put('b', { from: 'b' })
+    await vault.collection<Msg>('msgs_text').put('b', { body: '2' })
+    await rawStore.delete('v1', 'msgs', 'b') // simulate offline resurrection state
+
+    const result = await vault.collection<Msg>('msgs_text').getMany(['a', 'b'])
+
+    expect(result.get('a')).toEqual({ body: '1' })
+    expect(result.get('b')).toBeNull() // dead base -> null, matching real getMany's missing-record shape
+  })
+
+  it('satellite.putMany (non-atomic) refuses an orphan id as a FAILURE entry, not a throw, and still writes live ids', async () => {
+    const { vault } = await openPair()
+    await vault.collection<Msg>('msgs').put('a', { from: 'a' })
+
+    const result = await vault.collection<Msg>('msgs_text').putMany([
+      ['a', { body: '1' }],
+      ['ghost', { body: '2' }], // no live base -> R-S6
+    ])
+
+    expect(result.ok).toBe(false)
+    expect(result.success).toEqual(['a'])
+    expect(result.failures).toHaveLength(1)
+    expect(result.failures[0]!.id).toBe('ghost')
+    expect(result.failures[0]!.error.message).toMatch(/R-S6/)
+    expect(await vault.collection<Msg>('msgs_text').get('a')).toEqual({ body: '1' })
+  })
+
+  it('satellite.putMany({ atomic: true }) refuses the WHOLE call with R-S6 when any id lacks a live base', async () => {
+    const { vault, rawStore } = await openPair()
+    await vault.collection<Msg>('msgs').put('a', { from: 'a' })
+
+    await expect(vault.collection<Msg>('msgs_text').putMany(
+      [['a', { body: '1' }], ['ghost', { body: '2' }]],
+      { atomic: true },
+    )).rejects.toThrowError(/R-S6/)
+    // Whole call refused up front — not even the live id was written.
+    expect(await rawStore.get('v1', 'msgs_text', 'a')).toBeNull()
+  })
+
+  it('base.deleteMany fans out both legs per id (real deleteMany binds to the raw delete, bypassing pairDelete)', async () => {
+    const { vault, rawStore } = await openPair()
+    await vault.collection<Msg>('msgs').put('a', { from: 'a' })
+    await vault.collection<Msg>('msgs_text').put('a', { body: '1' })
+    await vault.collection<Msg>('msgs').put('b', { from: 'b' })
+    await vault.collection<Msg>('msgs_text').put('b', { body: '2' })
+
+    const result = await vault.collection<Msg>('msgs').deleteMany(['a', 'b'])
+
+    expect(result.ok).toBe(true)
+    expect([...result.success].sort()).toEqual(['a', 'b'])
+    expect(await rawStore.get('v1', 'msgs', 'a')).toBeNull()
+    expect(await rawStore.get('v1', 'msgs_text', 'a')).toBeNull() // satellite leg fanned out
+    expect(await rawStore.get('v1', 'msgs', 'b')).toBeNull()
+    expect(await rawStore.get('v1', 'msgs_text', 'b')).toBeNull()
+  })
+})

--- a/packages/hub/__tests__/satellites-registration.test.ts
+++ b/packages/hub/__tests__/satellites-registration.test.ts
@@ -48,6 +48,16 @@ describe('satellite declaration wiring (#591)', () => {
       .toThrowError(/R-S3/)
   })
 
+  it('R-S3: refuses satelliteOf pointing at a name that is ALREADY registered as a base (order-inverted chain)', async () => {
+    const { vault } = await openTestVault()
+    // "msgs_text" is declared as a BASE first (of "deep") ...
+    vault.collection<Msg>('deep', { satelliteOf: 'msgs_text', fields: ['x'] })
+    // ... then re-declared as a SATELLITE of "msgs" — same chain, opposite
+    // declaration order; must refuse identically to the direct-order test above.
+    expect(() => vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['body'] }))
+      .toThrowError(/R-S3/)
+  })
+
   it('R-S7: refuses a satellite without perRecordKeys when the base is forget-covered', async () => {
     const { vault } = await openTestVault({ forgetStrategy: withForgetCascade({ subjects: { msgs: 'from' } }) })
     expect(() => vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['body'] }))
@@ -55,6 +65,28 @@ describe('satellite declaration wiring (#591)', () => {
     // With perRecordKeys it registers fine:
     expect(() => vault.collection<Msg>('msgs_text2', { satelliteOf: 'msgs', fields: ['body'], perRecordKeys: true }))
       .not.toThrow()
+  })
+
+  it('R-S8: refuses declaring a satellite whose base was already constructed with crdt mode', async () => {
+    const { vault } = await openTestVault()
+    vault.collection<Msg>('msgs', { crdt: 'lww-map' })
+    expect(() => vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['body'] }))
+      .toThrowError(/R-S8/)
+  })
+
+  it('R-S8: refuses constructing the base with crdt mode AFTER the pairing already exists', async () => {
+    const { vault } = await openTestVault()
+    vault.collection<Msg>('msgs', {})
+    vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['body'] })
+    expect(() => vault.collection<Msg>('msgs', { crdt: 'lww-map' }))
+      .toThrowError(/R-S8/)
+  })
+
+  it('R-S5: refuses a joined name that matches an already-declared plain collection', async () => {
+    const { vault } = await openTestVault()
+    vault.collection<Msg>('msgs_full', {})
+    expect(() => vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['body'], joined: 'msgs_full' }))
+      .toThrowError(/R-S5/)
   })
 
   it('rejects vault.collection(<joinedName>) with a pointer to vault.joined()', async () => {

--- a/packages/hub/__tests__/satellites-registration.test.ts
+++ b/packages/hub/__tests__/satellites-registration.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Vault registration wiring for satellite collections (#591, archetype-③).
+ *
+ * Drives everything through the public `createNoydb`/`openVault` API with
+ * `to-memory` (fixture pattern copied from schema-introspection.test.ts).
+ * Covers the thin kernel call-site in `vault.ts`: R-S3/R-S5/R-S7/R-S8/R-S9
+ * sync refusals, the joined-name guard, and the async R-S1 poison cross-check.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { z } from 'zod'
+import { createNoydb } from '../src/kernel/noydb.js'
+import type { NoydbStore } from '../src/kernel/types.js'
+import { memory } from '../../to-memory/src/index.js'
+import { withForgetCascade } from '../src/with-audit/forget/index.js'
+import type { ForgetStrategy } from '../src/with-audit/forget/strategy.js'
+import { SatelliteConfigError } from '../src/kernel/errors.js'
+
+const SECRET = 'satellite-registration-test-1234'
+
+interface Msg extends Record<string, unknown> {
+  from?: string
+  subject?: string
+  subject_short?: string
+  body?: string
+}
+
+async function openTestVault(opts: { forgetStrategy?: ForgetStrategy } = {}) {
+  const store: NoydbStore = memory()
+  const db = await createNoydb({ store, user: 'alice', secret: SECRET, ...opts })
+  const vault = await db.openVault('v1')
+  return { vault, store }
+}
+
+describe('satellite declaration wiring (#591)', () => {
+  it('registers the pair; base and satellite behave as plain collections for writes', async () => {
+    const { vault, store } = await openTestVault()
+    vault.collection<Msg>('msgs', {})
+    vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full' })
+    await vault.collection<Msg>('msgs').put('x', { from: 'a', subject_short: 's' })
+    // No auto-created satellite envelope (audit reversal):
+    expect(await store.get('v1', 'msgs_text', 'x')).toBeNull()
+  })
+
+  it('R-S3: refuses satelliteOf pointing at a registered satellite', async () => {
+    const { vault } = await openTestVault()
+    vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['body'] })
+    expect(() => vault.collection<Msg>('deep', { satelliteOf: 'msgs_text', fields: ['x'] }))
+      .toThrowError(/R-S3/)
+  })
+
+  it('R-S7: refuses a satellite without perRecordKeys when the base is forget-covered', async () => {
+    const { vault } = await openTestVault({ forgetStrategy: withForgetCascade({ subjects: { msgs: 'from' } }) })
+    expect(() => vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['body'] }))
+      .toThrowError(/R-S7/)
+    // With perRecordKeys it registers fine:
+    expect(() => vault.collection<Msg>('msgs_text2', { satelliteOf: 'msgs', fields: ['body'], perRecordKeys: true }))
+      .not.toThrow()
+  })
+
+  it('rejects vault.collection(<joinedName>) with a pointer to vault.joined()', async () => {
+    const { vault } = await openTestVault()
+    vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['body'], joined: 'msgs_full' })
+    expect(() => vault.collection('msgs_full')).toThrowError(/vault\.joined/)
+  })
+
+  it('poisons the satellite when the async fields-vs-schema cross-check finds overlap (R-S1)', async () => {
+    const { vault } = await openTestVault()
+    vault.collection<Msg>('msgs', { schema: z.object({ subject: z.string(), from: z.string() }) })
+    vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'] })
+    await vi.waitFor(async () => {
+      await expect(vault.collection<Msg>('msgs_text').put('x', { subject: 's' })).rejects.toThrowError(/R-S1/)
+    })
+  })
+
+  it('idempotent re-declaration: an identical redeclare of the same satellite does not throw', () => {
+    return (async () => {
+      const { vault } = await openTestVault()
+      vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full' })
+      expect(() => vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full' }))
+        .not.toThrow()
+    })()
+  })
+
+  it('R-S9: a divergent in-session redeclaration of the same satellite name is refused', async () => {
+    const { vault } = await openTestVault()
+    vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject'] })
+    expect(() => vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['body'] }))
+      .toThrowError(/R-S9/)
+  })
+})

--- a/packages/hub/__tests__/satellites-registration.test.ts
+++ b/packages/hub/__tests__/satellites-registration.test.ts
@@ -81,6 +81,17 @@ describe('satellite declaration wiring (#591)', () => {
     })()
   })
 
+  it('a refused declaration leaves no side effects: registry stays null, plain writes unaffected', async () => {
+    const { vault } = await openTestVault({ forgetStrategy: withForgetCascade({ subjects: { msgs: 'from' } }) })
+    expect(() => vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['body'] }))
+      .toThrowError(SatelliteConfigError)
+    // Internal invariant: the refused declaration created no registry (and thus no write hook).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((vault as any).satelliteRegistry).toBeNull()
+    // A plain write on an unrelated collection flows through untouched:
+    await expect(vault.collection<Msg>('notes').put('n1', { body: 'ok' })).resolves.toBeUndefined()
+  })
+
   it('R-S9: a divergent in-session redeclaration of the same satellite name is refused', async () => {
     const { vault } = await openTestVault()
     vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject'] })

--- a/packages/hub/__tests__/satellites-registry.test.ts
+++ b/packages/hub/__tests__/satellites-registry.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { SatelliteRegistry } from '../src/with-shape/satellites/registry.js'
+
+const spec = { base: 'msgs', satellite: 'msgs_text', fields: ['body'] as const, joined: 'msgs_full' }
+
+describe('SatelliteRegistry', () => {
+  it('registers a pair and resolves by base, satellite, and joined name', () => {
+    const r = new SatelliteRegistry()
+    r.register(spec)
+    expect(r.satelliteOf('msgs')?.satellite).toBe('msgs_text')
+    expect(r.bySatellite('msgs_text')?.base).toBe('msgs')
+    expect(r.byJoined('msgs_full')?.base).toBe('msgs')
+    expect(r.isPairMember('msgs')).toBe(true)
+  })
+
+  it('R-S1(v1): refuses a second satellite on the same base', () => {
+    const r = new SatelliteRegistry()
+    r.register(spec)
+    expect(() => r.register({ base: 'msgs', satellite: 'msgs_att', fields: ['att'] })).toThrowError(/R-S1/)
+  })
+
+  it('R-S5: refuses a joined name that collides with any registered collection role', () => {
+    const r = new SatelliteRegistry()
+    r.register(spec)
+    expect(() => r.register({ base: 'docs', satellite: 'docs_body', fields: ['b'], joined: 'msgs_text' }))
+      .toThrowError(/R-S5/)
+  })
+
+  it('poison → assertNotPoisoned throws with the recorded reason', () => {
+    const r = new SatelliteRegistry()
+    r.register(spec)
+    r.poison('msgs_text', 'R-S1: fields overlap base schema field "subject"')
+    expect(() => r.assertNotPoisoned('msgs_text')).toThrowError(/R-S1.*subject/)
+  })
+
+  it('withPairLock serializes concurrent sections per base', async () => {
+    const r = new SatelliteRegistry()
+    r.register(spec)
+    const order: number[] = []
+    await Promise.all([
+      r.withPairLock('msgs', async () => { order.push(1); await new Promise(res => setTimeout(res, 20)); order.push(2) }),
+      r.withPairLock('msgs', async () => { order.push(3) }),
+    ])
+    expect(order).toEqual([1, 2, 3])
+  })
+
+  it('expandNames adds satellites of named bases (and vice versa) without duplicates', () => {
+    const r = new SatelliteRegistry()
+    r.register(spec)
+    expect(r.expandNames(['msgs', 'other']).sort()).toEqual(['msgs', 'msgs_text', 'other'])
+    expect(r.expandNames(['msgs_text']).sort()).toEqual(['msgs', 'msgs_text'])
+  })
+})

--- a/packages/hub/__tests__/satellites-registry.test.ts
+++ b/packages/hub/__tests__/satellites-registry.test.ts
@@ -19,6 +19,13 @@ describe('SatelliteRegistry', () => {
     expect(() => r.register({ base: 'msgs', satellite: 'msgs_att', fields: ['att'] })).toThrowError(/R-S1/)
   })
 
+  it('R-S3: refuses registering a spec whose satellite name is already registered as a base (order-inverted chain)', () => {
+    const r = new SatelliteRegistry()
+    r.register({ base: 'msgs_text', satellite: 'deep', fields: ['x'] }) // msgs_text is a BASE here
+    expect(() => r.register({ base: 'msgs', satellite: 'msgs_text', fields: ['body'] })) // now claimed as a satellite too
+      .toThrowError(/R-S3/)
+  })
+
   it('R-S5: refuses a joined name that collides with any registered collection role', () => {
     const r = new SatelliteRegistry()
     r.register(spec)

--- a/packages/hub/__tests__/satellites-search-filter.test.ts
+++ b/packages/hub/__tests__/satellites-search-filter.test.ts
@@ -105,3 +105,69 @@ describe('satellite search/retrieve existence post-filter (#591, Task 9)', () =>
     expect(hits.map((h) => h.id).sort()).toEqual(['d1', 'd2'])
   })
 })
+
+describe('satellite deterministic-lookup existence filter (#591, Task 9 review fix)', () => {
+  async function openDetPair() {
+    const rawStore = memory()
+    const db = await createNoydb({ store: rawStore, user: 'alice', secret: SECRET })
+    const vault = await db.openVault('v1')
+    vault.collection<Msg>('msgs')
+    vault.collection<Msg>('msgs_text', {
+      satelliteOf: 'msgs',
+      fields: ['subject', 'body'],
+      joined: 'msgs_full',
+      deterministicFields: ['body'],
+      acknowledgeDeterministicRisk: true,
+    })
+    return { vault, rawStore }
+  }
+
+  it('findByDet skips a dead-base match and still finds a later live one', async () => {
+    const { vault, rawStore } = await openDetPair()
+    // Same det value on both pairs; both rows carry an identical _det slot.
+    await vault.joined('msgs_full').put('a', { from: 'x', subject: 'dead', body: 'shared-det' })
+    await vault.joined('msgs_full').put('b', { from: 'y', subject: 'live', body: 'shared-det' })
+
+    await rawStore.delete('v1', 'msgs', 'a')
+
+    const found = await vault.collection<Msg>('msgs_text').findByDet('body', 'shared-det')
+    expect(found).toMatchObject({ subject: 'live', body: 'shared-det' })
+    // And once the second base dies too, the match is fully gone.
+    await rawStore.delete('v1', 'msgs', 'b')
+    expect(await vault.collection<Msg>('msgs_text').findByDet('body', 'shared-det')).toBeNull()
+  })
+
+  it('findByDet returns null when the only match\'s base is tombstoned', async () => {
+    const { vault, rawStore } = await openDetPair()
+    await vault.joined('msgs_full').put('x', { from: 'a', body: 'lonely-det' })
+
+    await tombstone(rawStore, 'v1', 'msgs', 'x')
+
+    expect(await vault.collection<Msg>('msgs_text').findByDet('body', 'lonely-det')).toBeNull()
+  })
+
+  it('queryByDet excludes dead-base matches and keeps live ones', async () => {
+    const { vault, rawStore } = await openDetPair()
+    await vault.joined('msgs_full').put('a', { from: 'x', subject: 'keep', body: 'multi-det' })
+    await vault.joined('msgs_full').put('b', { from: 'y', subject: 'drop', body: 'multi-det' })
+
+    await rawStore.delete('v1', 'msgs', 'b')
+
+    const hits = await vault.collection<Msg>('msgs_text').queryByDet('body', 'multi-det')
+    expect(hits).toHaveLength(1)
+    expect(hits[0]).toMatchObject({ subject: 'keep', body: 'multi-det' })
+  })
+
+  it('does not affect a non-satellite collection\'s det lookups', async () => {
+    const { vault } = await openDetPair()
+    const users = vault.collection<{ email: string }>('users', {
+      deterministicFields: ['email'],
+      acknowledgeDeterministicRisk: true,
+    })
+    await users.put('u1', { email: 'a@x' })
+    await users.put('u2', { email: 'a@x' })
+
+    expect(await users.findByDet('email', 'a@x')).not.toBeNull()
+    expect(await users.queryByDet('email', 'a@x')).toHaveLength(2)
+  })
+})

--- a/packages/hub/__tests__/satellites-search-filter.test.ts
+++ b/packages/hub/__tests__/satellites-search-filter.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Search/retrieve existence post-filter for satellite collections (#591, Task 9).
+ *
+ * Spec: docs/superpowers/specs/2026-07-05-satellite-collections-design.md
+ *
+ * `vault.collection(satelliteName)` returns an existence-filtering proxy
+ * (`with-shape/satellites/proxy.ts`) for `get`/`list`/`put`, but the search
+ * facade (`with-lookup/search/collection-facade.ts`) answers `search()` /
+ * `retrieve()` / `similarTo()` straight out of its own lexical index /
+ * eager cache — neither of those read paths ever consulted the satellite's
+ * proxy, so a satellite row whose paired base was raw-deleted or tombstoned
+ * stayed findable. This suite proves the proxy now also existence-filters
+ * those three retrieval surfaces, that a non-satellite collection is
+ * byte-identically unaffected, and that the filter is a pure read-side
+ * post-filter — it never touches the persisted `_ftindex` posting.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { withSearch } from '../src/with-lookup/search/index.js'
+import { memory } from '../../to-memory/src/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../src/kernel/types.js'
+
+const SECRET = 'satellites-search-filter-test-1234'
+
+interface Msg extends Record<string, unknown> {
+  from?: string
+  subject?: string
+  body?: string
+}
+
+async function openPair() {
+  const rawStore = memory()
+  const db = await createNoydb({
+    store: rawStore,
+    user: 'alice',
+    secret: SECRET,
+    searchStrategy: withSearch(),
+  })
+  const vault = await db.openVault('v1')
+  vault.collection<Msg>('msgs')
+  vault.collection<Msg>('msgs_text', {
+    satelliteOf: 'msgs',
+    fields: ['subject', 'body'],
+    joined: 'msgs_full',
+    textIndexes: ['body'],
+    textIndexPersist: true,
+  })
+  return { vault, rawStore }
+}
+
+async function tombstone(rawStore: NoydbStore, vault: string, collection: string, id: string): Promise<void> {
+  const live = await rawStore.get(vault, collection, id)
+  if (!live) throw new Error('tombstone: no live envelope to forge')
+  await rawStore.put(vault, collection, id, { ...(live as EncryptedEnvelope), _iv: '', _data: '' })
+}
+
+describe('satellite search/retrieve existence post-filter (#591, Task 9)', () => {
+  it('retrieve() drops a satellite hit whose base was raw-deleted; the _ftindex posting physically remains', async () => {
+    const { vault, rawStore } = await openPair()
+    await vault.joined('msgs_full').put('x', { from: 'a', body: 'zebra unique' })
+
+    // Sanity + force the persisted index to build/save while the base is live.
+    const before = await vault.collection('msgs_text').retrieve('zebra')
+    expect(before.map((h) => h.id)).toEqual(['x'])
+    const ftBefore = await rawStore.get('v1', '_ftindex', 'msgs_text')
+    expect(ftBefore).not.toBeNull()
+
+    await rawStore.delete('v1', 'msgs', 'x')
+
+    const hits = await vault.collection('msgs_text').retrieve('zebra')
+    expect(hits).toEqual([])
+
+    const ftAfter = await rawStore.get('v1', '_ftindex', 'msgs_text')
+    expect(ftAfter).toEqual(ftBefore) // posting untouched — a pure read-side filter
+  })
+
+  it('retrieve() drops a satellite hit whose base is tombstoned (not merely absent)', async () => {
+    const { vault, rawStore } = await openPair()
+    await vault.joined('msgs_full').put('y', { from: 'a', body: 'walrus unique' })
+    await vault.collection('msgs_text').retrieve('walrus') // build/persist while live
+
+    await tombstone(rawStore, 'v1', 'msgs', 'y')
+
+    const hits = await vault.collection('msgs_text').retrieve('walrus')
+    expect(hits).toEqual([])
+  })
+
+  it('search() (scan mode) also drops a satellite hit whose base was raw-deleted', async () => {
+    const { vault, rawStore } = await openPair()
+    await vault.joined('msgs_full').put('z', { from: 'a', body: 'quokka unique' })
+
+    await rawStore.delete('v1', 'msgs', 'z')
+
+    const hits = await vault.collection('msgs_text').search('body', 'quokka')
+    expect(hits).toEqual([])
+  })
+
+  it('does not affect a non-satellite collection\'s retrieve() (byte-identical behavior)', async () => {
+    const { vault } = await openPair()
+    const docs = vault.collection<{ title: string }>('docs', { textIndexes: ['title'] })
+    await docs.put('d1', { title: 'penguin waddle' })
+    await docs.put('d2', { title: 'penguin march' })
+
+    const hits = await docs.retrieve('penguin')
+    expect(hits.map((h) => h.id).sort()).toEqual(['d1', 'd2'])
+  })
+})

--- a/packages/hub/__tests__/satellites-sync-pair.test.ts
+++ b/packages/hub/__tests__/satellites-sync-pair.test.ts
@@ -122,25 +122,20 @@ describe('satellite sync pair-expansion + resolver mirroring (#591 Task 11)', ()
     expect(await localB.get(COMP, 'msgs_text', 'm3')).not.toBeNull()
   })
 
-  it('a resolver registered on the base fires for a satellite conflict (rule 5b)', async () => {
-    const local = inlineMemory()
-    const remote = inlineMemory()
-    const db = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
-    const vault = await db.openVault(COMP)
-
-    // Satellite declared FIRST so the registry already knows the pair when
-    // the base's conflictPolicy registration runs below (ordering constraint
-    // — see task-11-report.md self-review).
-    vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'] })
-    vault.collection<Msg>('msgs', { conflictPolicy: 'last-writer-wins' })
-
-    await vault.collection<Msg>('msgs').put('m4', { from: 'dave' })
-    await vault.collection<Msg>('msgs_text').put('m4', { subject: 'local-1', body: '' })
+  /**
+   * Builds a same-version (_v=2 both sides) CAS push-conflict on `msgs_text`
+   * where the LOCAL side has the older timestamp: LWW resolves to remote,
+   * FWW (and the default 'version' db-level fallback) keep local — so the
+   * winning subject fully discriminates WHICH resolver actually fired.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function driveSatelliteConflict(db: any, vault: any, local: NoydbStore, remote: NoydbStore) {
+    await vault.collection('msgs').put('m4', { from: 'dave' })
+    await vault.collection('msgs_text').put('m4', { subject: 'local-1', body: '' })
     await db.push(COMP) // remote msgs_text/m4 now at _v=1
 
     // Someone else pushes a newer version to remote out-of-band, with a
-    // FUTURE timestamp (LWW should prefer it; default 'version' strategy
-    // would not, since it compares versions, not timestamps).
+    // FUTURE timestamp.
     const futureTs = new Date(Date.now() + 60_000).toISOString()
     await remote.put(COMP, 'msgs_text', 'm4', {
       _noydb: 1, _v: 2, _ts: futureTs, _iv: '', _data: JSON.stringify({ subject: 'REMOTE', body: 'remote body' }),
@@ -148,17 +143,70 @@ describe('satellite sync pair-expansion + resolver mirroring (#591 Task 11)', ()
 
     // Local writes again (now also at _v=2, but with an OLDER timestamp) —
     // pushing this creates a same-version CAS conflict against remote.
-    await vault.collection<Msg>('msgs_text').put('m4', { subject: 'local-2', body: '' })
+    await vault.collection('msgs_text').put('m4', { subject: 'local-2', body: '' })
 
     const result = await db.push(COMP, { collections: ['msgs'] })
+    const localEnv = await local.get(COMP, 'msgs_text', 'm4')
+    return { result, winner: (JSON.parse(localEnv!._data) as Msg).subject }
+  }
+
+  it('rule 5b, NORMAL order: base declared with conflictPolicy first, satellite second — resolver still fires for a satellite conflict', async () => {
+    const local = inlineMemory()
+    const remote = inlineMemory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
+    const vault = await db.openVault(COMP)
+
+    // Normal declaration order: the base's conflictPolicy is registered
+    // BEFORE the pair exists — retroactive re-mirroring at pair-registration
+    // time must copy it onto the satellite.
+    vault.collection<Msg>('msgs', { conflictPolicy: 'last-writer-wins' })
+    vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'] })
+
+    const { result, winner } = await driveSatelliteConflict(db, vault, local, remote)
 
     expect(result.conflicts).toHaveLength(1)
     expect(result.conflicts[0]!.collection).toBe('msgs_text')
-    const localEnv = await local.get(COMP, 'msgs_text', 'm4')
-    // LWW picked remote (later _ts) — proves the mirrored resolver fired
-    // instead of falling back to the default 'version' db-level strategy
-    // (which would have kept local, since both sides were at _v=2).
-    expect(JSON.parse(localEnv!._data).subject).toBe('REMOTE')
+    // LWW picked remote (later _ts) — the mirrored resolver fired instead of
+    // the default 'version' fallback (which keeps local at equal versions).
+    expect(winner).toBe('REMOTE')
+  })
+
+  it('rule 5b, satellite-first order: a resolver registered on the base after the pair exists fires for a satellite conflict', async () => {
+    const local = inlineMemory()
+    const remote = inlineMemory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
+    const vault = await db.openVault(COMP)
+
+    vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'] })
+    vault.collection<Msg>('msgs', { conflictPolicy: 'last-writer-wins' })
+
+    const { result, winner } = await driveSatelliteConflict(db, vault, local, remote)
+
+    expect(result.conflicts).toHaveLength(1)
+    expect(result.conflicts[0]!.collection).toBe('msgs_text')
+    expect(winner).toBe('REMOTE')
+  })
+
+  it('rule 5b tie-break: when BOTH members carried different resolvers before pairing, the base\'s wins', async () => {
+    const local = inlineMemory()
+    const remote = inlineMemory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
+    const vault = await db.openVault(COMP)
+
+    // Both collections carry (different) resolvers BEFORE the pair is
+    // declared: base LWW, satellite FWW. In the driven conflict LWW resolves
+    // to remote and FWW keeps local — fully discriminating.
+    vault.collection<Msg>('msgs', { conflictPolicy: 'last-writer-wins' })
+    vault.collection<Msg>('msgs_text', { conflictPolicy: 'first-writer-wins' })
+    // NOW pair them (no conflictPolicy on this redeclare) — re-mirroring
+    // must pick the BASE's resolver as canonical for both members.
+    vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'] })
+
+    const { result, winner } = await driveSatelliteConflict(db, vault, local, remote)
+
+    expect(result.conflicts).toHaveLength(1)
+    // Base's LWW (→ remote) won over the satellite's pre-pairing FWW (→ local).
+    expect(winner).toBe('REMOTE')
   })
 
   it('control: without any satellite declared, push({ collections }) behaves exactly as before', async () => {

--- a/packages/hub/__tests__/satellites-sync-pair.test.ts
+++ b/packages/hub/__tests__/satellites-sync-pair.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Sync pair-expansion + resolver mirroring (#591 Task 11).
+ *
+ * `push({ collections })` / `pull({ collections })` treat a satellite pair as
+ * one unit: filtering by the base name also carries the satellite's dirty
+ * entries (incl. DELETEs — the security-relevant case, otherwise a
+ * satellite's heavy envelope lingers on the remote indefinitely). Registering
+ * a conflict resolver on one pair member registers it for both (spec
+ * convergence rule 5b).
+ *
+ * Fixture (inline memory adapter w/ CAS conflict support, `encrypt: false`)
+ * copied from sync-partial.test.ts / sync-conflict-policy.test.ts. Satellite
+ * declaration pattern copied from satellites-fanout.test.ts.
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
+import { ConflictError } from '../src/kernel/errors.js'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { withSync } from '../src/with-party/sync/index.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) }
+    },
+  }
+}
+
+interface Msg extends Record<string, unknown> { from?: string; subject?: string; body?: string }
+
+const COMP = 'v1'
+
+describe('satellite sync pair-expansion + resolver mirroring (#591 Task 11)', () => {
+  it('push({ collections: [base] }) transmits the satellite pair partner\'s dirty entries too', async () => {
+    const local = inlineMemory()
+    const remote = inlineMemory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
+    const vault = await db.openVault(COMP)
+    vault.collection<Msg>('msgs', {})
+    vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'] })
+
+    await vault.collection<Msg>('msgs').put('m1', { from: 'alice' })
+    await vault.collection<Msg>('msgs_text').put('m1', { subject: 's', body: 'b' })
+    expect(db.syncStatus(COMP).dirty).toBe(2)
+
+    const result = await db.push(COMP, { collections: ['msgs'] })
+
+    expect(result.pushed).toBe(2)
+    expect(await remote.get(COMP, 'msgs', 'm1')).not.toBeNull()
+    expect(await remote.get(COMP, 'msgs_text', 'm1')).not.toBeNull()
+    expect(db.syncStatus(COMP).dirty).toBe(0)
+  })
+
+  it('push({ collections: [base] }) transmits the satellite\'s DELETE too (security: no lingering remote envelope)', async () => {
+    const local = inlineMemory()
+    const remote = inlineMemory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
+    const vault = await db.openVault(COMP)
+    vault.collection<Msg>('msgs', {})
+    vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'] })
+
+    await vault.collection<Msg>('msgs').put('m2', { from: 'bob' })
+    await vault.collection<Msg>('msgs_text').put('m2', { subject: 's2', body: 'b2' })
+    await db.push(COMP) // land both on remote first
+    expect(await remote.get(COMP, 'msgs', 'm2')).not.toBeNull()
+    expect(await remote.get(COMP, 'msgs_text', 'm2')).not.toBeNull()
+
+    // Base-side delete fans out to the satellite (pairDelete, Task 6).
+    await vault.collection<Msg>('msgs').delete('m2')
+    expect(db.syncStatus(COMP).dirty).toBe(2) // both deletes tracked
+
+    const result = await db.push(COMP, { collections: ['msgs'] })
+
+    expect(result.pushed).toBe(2)
+    expect(await remote.get(COMP, 'msgs', 'm2')).toBeNull()
+    expect(await remote.get(COMP, 'msgs_text', 'm2')).toBeNull() // no lingering heavy envelope
+    expect(db.syncStatus(COMP).dirty).toBe(0)
+  })
+
+  it('pull({ collections: [base] }) pulls the satellite pair partner\'s records too', async () => {
+    const localA = inlineMemory()
+    const localB = inlineMemory()
+    const remote = inlineMemory()
+
+    const dbA = await createNoydb({ store: localA, sync: remote, user: 'a', syncStrategy: withSync(), encrypt: false })
+    const vaultA = await dbA.openVault(COMP)
+    vaultA.collection<Msg>('msgs', {})
+    vaultA.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'] })
+    await vaultA.collection<Msg>('msgs').put('m3', { from: 'carol' })
+    await vaultA.collection<Msg>('msgs_text').put('m3', { subject: 's3', body: 'b3' })
+    await dbA.push(COMP)
+
+    // dbB declares the same pair on its own vault (own registry/pairExpander).
+    const dbB = await createNoydb({ store: localB, sync: remote, user: 'b', syncStrategy: withSync(), encrypt: false })
+    const vaultB = await dbB.openVault(COMP)
+    vaultB.collection<Msg>('msgs', {})
+    vaultB.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'] })
+
+    const result = await dbB.pull(COMP, { collections: ['msgs'] })
+
+    expect(result.pulled).toBe(2)
+    expect(await localB.get(COMP, 'msgs', 'm3')).not.toBeNull()
+    expect(await localB.get(COMP, 'msgs_text', 'm3')).not.toBeNull()
+  })
+
+  it('a resolver registered on the base fires for a satellite conflict (rule 5b)', async () => {
+    const local = inlineMemory()
+    const remote = inlineMemory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
+    const vault = await db.openVault(COMP)
+
+    // Satellite declared FIRST so the registry already knows the pair when
+    // the base's conflictPolicy registration runs below (ordering constraint
+    // — see task-11-report.md self-review).
+    vault.collection<Msg>('msgs_text', { satelliteOf: 'msgs', fields: ['subject', 'body'] })
+    vault.collection<Msg>('msgs', { conflictPolicy: 'last-writer-wins' })
+
+    await vault.collection<Msg>('msgs').put('m4', { from: 'dave' })
+    await vault.collection<Msg>('msgs_text').put('m4', { subject: 'local-1', body: '' })
+    await db.push(COMP) // remote msgs_text/m4 now at _v=1
+
+    // Someone else pushes a newer version to remote out-of-band, with a
+    // FUTURE timestamp (LWW should prefer it; default 'version' strategy
+    // would not, since it compares versions, not timestamps).
+    const futureTs = new Date(Date.now() + 60_000).toISOString()
+    await remote.put(COMP, 'msgs_text', 'm4', {
+      _noydb: 1, _v: 2, _ts: futureTs, _iv: '', _data: JSON.stringify({ subject: 'REMOTE', body: 'remote body' }),
+    })
+
+    // Local writes again (now also at _v=2, but with an OLDER timestamp) —
+    // pushing this creates a same-version CAS conflict against remote.
+    await vault.collection<Msg>('msgs_text').put('m4', { subject: 'local-2', body: '' })
+
+    const result = await db.push(COMP, { collections: ['msgs'] })
+
+    expect(result.conflicts).toHaveLength(1)
+    expect(result.conflicts[0]!.collection).toBe('msgs_text')
+    const localEnv = await local.get(COMP, 'msgs_text', 'm4')
+    // LWW picked remote (later _ts) — proves the mirrored resolver fired
+    // instead of falling back to the default 'version' db-level strategy
+    // (which would have kept local, since both sides were at _v=2).
+    expect(JSON.parse(localEnv!._data).subject).toBe('REMOTE')
+  })
+
+  it('control: without any satellite declared, push({ collections }) behaves exactly as before', async () => {
+    const local = inlineMemory()
+    const remote = inlineMemory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
+    const vault = await db.openVault(COMP)
+    vault.collection<Msg>('invoices', {})
+    vault.collection<Msg>('payments', {})
+
+    await vault.collection<Msg>('invoices').put('inv-1', { from: 'x' })
+    await vault.collection<Msg>('payments').put('pay-1', { from: 'y' })
+
+    const result = await db.push(COMP, { collections: ['invoices'] })
+
+    expect(result.pushed).toBe(1)
+    expect(await remote.get(COMP, 'invoices', 'inv-1')).not.toBeNull()
+    expect(await remote.get(COMP, 'payments', 'pay-1')).toBeNull()
+    expect(db.syncStatus(COMP).dirty).toBe(1) // payments still dirty
+  })
+})

--- a/packages/hub/__tests__/satellites-validate.test.ts
+++ b/packages/hub/__tests__/satellites-validate.test.ts
@@ -3,7 +3,7 @@ import { validateSatelliteDeclaration, hashFields } from '../src/with-shape/sate
 import { SatelliteConfigError } from '../src/kernel/errors.js'
 
 describe('validateSatelliteDeclaration', () => {
-  const ok = { satellite: 'msgs_text', satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full' }
+  const ok = { satellite: 'msgs_text', satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full', joinedCollidesWithCollection: false }
 
   it('accepts a well-formed declaration and returns a frozen SatelliteSpec', () => {
     const spec = validateSatelliteDeclaration({ ...ok, baseIsSatellite: false, crdtMode: false })
@@ -30,6 +30,11 @@ describe('validateSatelliteDeclaration', () => {
       .toThrowError(/R-S5/)
   })
 
+  it('R-S5: refuses a joined name that collides with an already-declared plain collection', () => {
+    expect(() => validateSatelliteDeclaration({ ...ok, baseIsSatellite: false, crdtMode: false, joinedCollidesWithCollection: true }))
+      .toThrowError(/R-S5/)
+  })
+
   it('R-S8: refuses crdtMode on the satellite member', () => {
     expect(() => validateSatelliteDeclaration({ ...ok, baseIsSatellite: false, crdtMode: true }))
       .toThrowError(/R-S8/)
@@ -38,5 +43,9 @@ describe('validateSatelliteDeclaration', () => {
   it('hashFields is order-insensitive and stable', () => {
     expect(hashFields(['b', 'a'])).toBe(hashFields(['a', 'b']))
     expect(hashFields(['a', 'b'])).not.toBe(hashFields(['a']))
+  })
+
+  it('hashFields does not collide on a joined field vs its split components (M1 delimiter fix)', () => {
+    expect(hashFields(['ab'])).not.toBe(hashFields(['a', 'b']))
   })
 })

--- a/packages/hub/__tests__/satellites-validate.test.ts
+++ b/packages/hub/__tests__/satellites-validate.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { validateSatelliteDeclaration, hashFields } from '../src/with-shape/satellites/validate.js'
+import { SatelliteConfigError } from '../src/kernel/errors.js'
+
+describe('validateSatelliteDeclaration', () => {
+  const ok = { satellite: 'msgs_text', satelliteOf: 'msgs', fields: ['subject', 'body'], joined: 'msgs_full' }
+
+  it('accepts a well-formed declaration and returns a frozen SatelliteSpec', () => {
+    const spec = validateSatelliteDeclaration({ ...ok, baseIsSatellite: false, crdtMode: false })
+    expect(spec).toEqual({ base: 'msgs', satellite: 'msgs_text', fields: ['subject', 'body'], joined: 'msgs_full' })
+    expect(Object.isFrozen(spec)).toBe(true)
+  })
+
+  it('R-S3: refuses when the base is itself a satellite (no chains)', () => {
+    expect(() => validateSatelliteDeclaration({ ...ok, baseIsSatellite: true, crdtMode: false }))
+      .toThrowError(/R-S3/)
+  })
+
+  it('R-S5: refuses omitted, empty, or id-bearing fields', () => {
+    for (const fields of [undefined, [], ['id', 'body']]) {
+      expect(() => validateSatelliteDeclaration({ ...ok, fields: fields as never, baseIsSatellite: false, crdtMode: false }))
+        .toThrowError(SatelliteConfigError)
+    }
+    expect(() => validateSatelliteDeclaration({ ...ok, fields: ['id'], baseIsSatellite: false, crdtMode: false }))
+      .toThrowError(/R-S5/)
+  })
+
+  it('R-S5: refuses a joined name equal to base or satellite name', () => {
+    expect(() => validateSatelliteDeclaration({ ...ok, joined: 'msgs', baseIsSatellite: false, crdtMode: false }))
+      .toThrowError(/R-S5/)
+  })
+
+  it('R-S8: refuses crdtMode on the satellite member', () => {
+    expect(() => validateSatelliteDeclaration({ ...ok, baseIsSatellite: false, crdtMode: true }))
+      .toThrowError(/R-S8/)
+  })
+
+  it('hashFields is order-insensitive and stable', () => {
+    expect(hashFields(['b', 'a'])).toBe(hashFields(['a', 'b']))
+    expect(hashFields(['a', 'b'])).not.toBe(hashFields(['a']))
+  })
+})

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -124,6 +124,10 @@
       "types": "./dist/classified/index.d.ts",
       "default": "./dist/classified/index.js"
     },
+    "./satellites": {
+      "types": "./dist/satellites/index.d.ts",
+      "default": "./dist/satellites/index.js"
+    },
     "./tiers": {
       "types": "./dist/tiers/index.d.ts",
       "default": "./dist/tiers/index.js"

--- a/packages/hub/src/kernel/collection-config.ts
+++ b/packages/hub/src/kernel/collection-config.ts
@@ -178,6 +178,12 @@ export interface CollectionOpts<T> {
    * `schema` field docstring for the error semantics.
    */
   schema?: StandardSchemaV1<unknown, T> | undefined
+  /** Declares this collection a satellite of `satelliteOf` (spec #591). */
+  satelliteOf?: string | undefined
+  /** Satellite routing table — the fields owned by this satellite (required with satelliteOf). */
+  fields?: readonly string[] | undefined
+  /** Registers the full-record joined handle under this name (optional; see vault.joined()). */
+  joined?: string | undefined
   /**
    * Optional reference to the compartment's hash-chained ledger.
    * When present, successful mutations append a ledger entry via

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -3868,11 +3868,14 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     this.cekCache?.remove(id)
   }
 
-  /** @internal Satellite fan-out revert cleanup: drop the sync dirty entry and re-announce the restored state (spec #591). */
+  /** @internal Satellite fan-out revert cleanup (spec #591): drop the sync dirty entry ('revert' is
+   *  onDirty-channel-only) and re-announce the RESTORED state as a plain put/delete — `subscribe()`
+   *  only understands those two actions, and the restored record may exist again. */
   async _compensateRevertedWrite(id: string): Promise<void> {
     await this._invalidateCacheEntry(id)
     await this.onDirty?.(this.name, id, 'revert', 0)
-    this.emitter.emit('change', { vault: this.vault, collection: this.name, id, action: 'revert' })
+    const restored = await this.get(id) // rare revert path — one read buys a semantically-correct event
+    this.emitter.emit('change', { vault: this.vault, collection: this.name, id, action: restored !== null ? 'put' : 'delete' })
   }
 
   async _invalidateCacheEntry(id: string): Promise<void> {

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -113,8 +113,13 @@ import type * as MVStaleModule from '../with-formula/materialized-views/stale.js
 import { resolveCollectionConfig, type CollectionOpts } from './collection-config.js'
 import { loadEvalComputedFields } from '../with-formula/computed/lazy.js'
 
-/** Callback for dirty tracking (sync engine integration). */
-export type OnDirtyCallback = (collection: string, id: string, action: 'put' | 'delete', version: number) => Promise<void>
+/**
+ * Callback for dirty tracking (sync engine integration). `action: 'revert'`
+ * (spec #591) means "un-dirty" — the fan-out wiring in `noydb.ts` routes it
+ * to `SyncEngine.removeDirty` instead of `trackChange`; `version` is unused
+ * for that action.
+ */
+export type OnDirtyCallback = (collection: string, id: string, action: 'put' | 'delete' | 'revert', version: number) => Promise<void>
 
 /**
  * Value-equality for a single self-write reverse-denorm field. Scalars
@@ -3861,6 +3866,13 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    */
   _invalidateCekCacheEntry(id: string): void {
     this.cekCache?.remove(id)
+  }
+
+  /** @internal Satellite fan-out revert cleanup: drop the sync dirty entry and re-announce the restored state (spec #591). */
+  async _compensateRevertedWrite(id: string): Promise<void> {
+    await this._invalidateCacheEntry(id)
+    await this.onDirty?.(this.name, id, 'revert', 0)
+    this.emitter.emit('change', { vault: this.vault, collection: this.name, id, action: 'revert' })
   }
 
   async _invalidateCacheEntry(id: string): Promise<void> {

--- a/packages/hub/src/kernel/errors.ts
+++ b/packages/hub/src/kernel/errors.ts
@@ -2838,3 +2838,17 @@ export class ClassifiedRotationError extends Error {
     this.name = 'ClassifiedRotationError'
   }
 }
+
+// ─── Satellite Errors ──────────────────────────────────────────────────
+
+/**
+ * A satellite-collection declaration or operation violated the refusal
+ * matrix (R-S1…R-S9) of the satellite-collections design. The message
+ * always names the R-S id.
+ */
+export class SatelliteConfigError extends NoydbError {
+  constructor(message: string) {
+    super('SATELLITE_CONFIG_ERROR', message)
+    this.name = 'SatelliteConfigError'
+  }
+}

--- a/packages/hub/src/kernel/errors.ts
+++ b/packages/hub/src/kernel/errors.ts
@@ -2847,8 +2847,9 @@ export class ClassifiedRotationError extends Error {
  * always names the R-S id.
  */
 export class SatelliteConfigError extends NoydbError {
-  constructor(message: string) {
+  constructor(message: string, options?: { readonly cause?: unknown }) {
     super('SATELLITE_CONFIG_ERROR', message)
     this.name = 'SatelliteConfigError'
+    if (options?.cause !== undefined) this.cause = options.cause
   }
 }

--- a/packages/hub/src/kernel/noydb.ts
+++ b/packages/hub/src/kernel/noydb.ts
@@ -1482,6 +1482,10 @@ export class Noydb {
     return engine
   }
 
+  _forEachSyncEngine(vault: string, fn: (engine: SyncEngine) => void): void {
+    for (const [key, engine] of this.syncEngines) if (key === vault || key.startsWith(`${vault}::`)) fn(engine)
+  }
+
   // ─── Events ────────────────────────────────────────────────────
 
   on<K extends keyof NoydbEventMap>(event: K, handler: (data: NoydbEventMap[K]) => void): void {

--- a/packages/hub/src/kernel/noydb.ts
+++ b/packages/hub/src/kernel/noydb.ts
@@ -603,10 +603,13 @@ export class Noydb {
       emitter: this.emitter,
       onDirty: targets.length > 0
         ? async (coll, id, action, version) => {
-            // Fan out dirty tracking to all sync engines for this vault
+            // Fan out dirty tracking to all sync engines for this vault.
+            // 'revert' (satellite fan-out compensation, spec #591) un-dirties
+            // instead of tracking a new change.
             for (const [key, engine] of this.syncEngines) {
               if (key === name || key.startsWith(`${name}::`)) {
-                void engine.trackChange(coll, id, action, version)
+                if (action === 'revert') void engine.removeDirty(coll, id)
+                else void engine.trackChange(coll, id, action, version)
               }
             }
           }

--- a/packages/hub/src/kernel/types.ts
+++ b/packages/hub/src/kernel/types.ts
@@ -1328,7 +1328,8 @@ export interface ChangeEvent {
   readonly vault: string
   readonly collection: string
   readonly id: string
-  readonly action: 'put' | 'delete'
+  /** `'revert'` — satellite fan-out compensation after a reverted write (spec #591). */
+  readonly action: 'put' | 'delete' | 'revert'
 }
 
 export interface NoydbEventMap {

--- a/packages/hub/src/kernel/types.ts
+++ b/packages/hub/src/kernel/types.ts
@@ -1328,8 +1328,7 @@ export interface ChangeEvent {
   readonly vault: string
   readonly collection: string
   readonly id: string
-  /** `'revert'` — satellite fan-out compensation after a reverted write (spec #591). */
-  readonly action: 'put' | 'delete' | 'revert'
+  readonly action: 'put' | 'delete'
 }
 
 export interface NoydbEventMap {

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -114,6 +114,7 @@ import type { LocaleReadOptions, ConflictPolicy } from './types.js'
 import type { CrdtMode } from '../with-commit/crdt/crdt.js'
 import { ReservedCollectionNameError, StaticDictReadonlyError, UnknownDictCodeError, SatelliteConfigError } from './errors.js'
 import { declareSatellite } from '../with-shape/satellites/declare.js'
+import { makeSatelliteProxy } from '../with-shape/satellites/proxy.js'
 import type { SatelliteRegistry } from '../with-shape/satellites/registry.js'
 import {
   type PeriodRecord,
@@ -1239,6 +1240,10 @@ export class Vault {
         })()
         this._pendingSchemaWrites.push(work)
       }
+    }
+    if (this.satelliteRegistry) { // #591: existence-authority + R-S6 read/write proxy (with-shape/satellites/proxy.ts)
+      const spec = this.satelliteRegistry.bySatellite(collectionName)
+      if (spec) return makeSatelliteProxy(coll, spec, this.satelliteRegistry) as Collection<T, S, Q, M>
     }
     return coll as unknown as Collection<T, S, Q, M>
   }

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -112,7 +112,9 @@ import type { DerivationRegistry } from '../with-formula/derivations/registry.js
 import type { DerivationStrategyHandle } from '../with-formula/derivations/types.js'
 import type { LocaleReadOptions, ConflictPolicy } from './types.js'
 import type { CrdtMode } from '../with-commit/crdt/crdt.js'
-import { ReservedCollectionNameError, StaticDictReadonlyError, UnknownDictCodeError } from './errors.js'
+import { ReservedCollectionNameError, StaticDictReadonlyError, UnknownDictCodeError, SatelliteConfigError } from './errors.js'
+import { SatelliteRegistry } from '../with-shape/satellites/registry.js'
+import { validateSatelliteDeclaration, hashFields } from '../with-shape/satellites/validate.js'
 import {
   type PeriodRecord,
   type ClosePeriodOptions,
@@ -323,6 +325,7 @@ export class Vault {
    */
   private readonly reloadKeyring: (() => Promise<UnlockedKeyring>) | undefined
   private readonly collectionCache = new Map<string, Collection<unknown>>()
+  private satelliteRegistry: SatelliteRegistry | null = null // spec #591, archetype-③
   /** Vault-level schema cutover fence/controller. */
   readonly schemaFence: SchemaFenceController
   /** Per-client heartbeat/watcher; started lazily on cutover registration. */
@@ -777,6 +780,9 @@ export class Vault {
      * default; non-adopting collections take the legacy path unchanged.
      */
     perRecordKeys?: boolean
+    satelliteOf?: string // satellite pairing (spec #591)
+    fields?: readonly string[] // satellite routing table (required with satelliteOf)
+    joined?: string // registers the joined handle (see vault.joined())
     /**
      * Per-record provenance tracking. When `true`, `put()` calls that
      * supply a `source` option stamp `_source` / `_sourceTs` onto the
@@ -874,6 +880,39 @@ export class Vault {
     // bypassing that gate. See reserved-secret-collections.ts.
     if (isSecretBearingReservedCollection(collectionName)) {
       throw new ReservedCollectionNameError(collectionName)
+    }
+
+    if (this.satelliteRegistry?.byJoined(collectionName)) { // #591: joined handle — not a directly reachable collection
+      throw new SatelliteConfigError(`"${collectionName}" is a joined handle — use vault.joined('${collectionName}'), not vault.collection().`)
+    }
+    if (options?.satelliteOf !== undefined) {
+      let reg = this.satelliteRegistry
+      if (reg === null) {
+        reg = this.satelliteRegistry = new SatelliteRegistry()
+        this.noydb._writeHooks.onBeforeWrite(e => { // gate writes against the poison map (R-S1 cross-check)
+          if (e.vault === this.name) this.satelliteRegistry?.assertNotPoisoned(e.collection)
+        })
+      }
+      const existing = reg.bySatellite(collectionName)
+      if (existing) {
+        const same = existing.base === options.satelliteOf
+          && hashFields(existing.fields) === hashFields(options.fields ?? [])
+          && (existing.joined ?? null) === (options.joined ?? null)
+        if (!same) {
+          throw new SatelliteConfigError(`R-S9: "${collectionName}" re-declared divergently within this session (base/fields/joined mismatch).`)
+        }
+      } else {
+        const spec = validateSatelliteDeclaration({
+          satellite: collectionName, satelliteOf: options.satelliteOf, fields: options.fields, joined: options.joined,
+          baseIsSatellite: reg.bySatellite(options.satelliteOf) !== null, crdtMode: options.crdt !== undefined,
+        })
+        if (this.forgetStrategy.subjects[spec.base] !== undefined && options.perRecordKeys !== true) {
+          throw new SatelliteConfigError(`R-S7: satellite "${collectionName}" of forget-covered base "${spec.base}" must declare perRecordKeys.`)
+        }
+        reg.register(spec)
+        const baseSchema = this.collectionCache.get(spec.base)?.getSchema()
+        void import('../with-shape/satellites/post-register.js').then(m => m.postRegister(this.adapter, this.name, spec, this.getDEK, baseSchema, reg))
+      }
     }
 
     let coll = this.collectionCache.get(collectionName)

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -894,7 +894,7 @@ export class Vault {
         adapter: this.adapter, vaultName: this.name, forgetSubjects: this.forgetStrategy.subjects, getDEK: this.getDEK,
         getBaseSchema: (base) => this.collectionCache.get(base)?.getSchema(),
         registerPoisonHook: (hook) => { this.noydb._writeHooks.onBeforeWrite(hook) },
-        registerPairExpander: (expander) => { this.noydb._forEachSyncEngine(this.name, e => e.setPairExpander(expander)) },
+        forEachSyncEngine: (fn) => { this.noydb._forEachSyncEngine(this.name, fn) },
       }, collectionName, { ...options, satelliteOf: options.satelliteOf }, this.satelliteRegistry)
     }
 

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -116,6 +116,8 @@ import { ReservedCollectionNameError, StaticDictReadonlyError, UnknownDictCodeEr
 import { declareSatellite } from '../with-shape/satellites/declare.js'
 import { makeSatelliteProxy, makeBaseProxy } from '../with-shape/satellites/proxy.js'
 import type { SatelliteRegistry } from '../with-shape/satellites/registry.js'
+import { makeJoinedHandle } from '../with-shape/satellites/joined.js'
+import type { JoinedHandle } from '../with-shape/satellites/types.js'
 import {
   type PeriodRecord,
   type ClosePeriodOptions,
@@ -1248,6 +1250,16 @@ export class Vault {
       if (baseSpec) return makeBaseProxy(coll, baseSpec, this.satelliteRegistry, () => this.collection(baseSpec.satellite)) as Collection<T, S, Q, M>
     }
     return coll as unknown as Collection<T, S, Q, M>
+  }
+
+  /** Full-record handle for a satellite pair registered with `joined:` (spec #591). Narrow type — not a Collection. */
+  joined<T extends Record<string, unknown>>(name: string): JoinedHandle<T> {
+    const spec = this.satelliteRegistry?.byJoined(name)
+    if (!spec) throw new SatelliteConfigError(`No joined handle "${name}" is registered — declare it via collection(satellite, { joined: '${name}' }).`)
+    return makeJoinedHandle<T>(spec, {
+      spec, base: () => this.collection(spec.base), satellite: () => this.collection(spec.satellite),
+      adapter: this.adapter, vaultName: this.name, registry: this.satelliteRegistry!,
+    })
   }
 
   /**

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -118,6 +118,7 @@ import { makeSatelliteProxy, makeBaseProxy } from '../with-shape/satellites/prox
 import type { SatelliteRegistry } from '../with-shape/satellites/registry.js'
 import { makeJoinedHandle } from '../with-shape/satellites/joined.js'
 import type { JoinedHandle } from '../with-shape/satellites/types.js'
+import { expandRefsWithSatellites } from '../with-shape/satellites/forget.js'
 import {
   type PeriodRecord,
   type ClosePeriodOptions,
@@ -2310,6 +2311,9 @@ export class Vault {
     }
 
     const refs = await lookupSubject(this.adapter, this.name, this.getDEK, this.encrypted, subjectId)
+    // Satellite fan-out (#591, with-shape/satellites/forget.ts) — a satellite
+    // is never itself in the subject index, so synthesize its ref or it survives.
+    const allRefs = expandRefsWithSatellites(refs, this.satelliteRegistry)
 
     let recordsShredded = 0
     let historyVersionsShredded = 0
@@ -2327,9 +2331,10 @@ export class Vault {
     const blobsEnabled = this.blobStrategy !== undefined
     const actor = this.keyring.userId
 
-    for (const ref of refs) {
+    for (const ref of allRefs) {
       const coll = this.collection<Record<string, unknown>>(ref.collection)
-      const perRecordKeys = this.forgetStrategy.subjects[ref.collection] !== undefined
+      const satelliteOf = (ref as { satelliteOf?: string }).satelliteOf
+      const perRecordKeys = this.forgetStrategy.subjects[satelliteOf ?? ref.collection] !== undefined // #591 classification inheritance
 
       // Detect an un-migrated record BEFORE shredding: a perRecordKeys
       // collection whose live envelope still carries a body but no `_cek`
@@ -2389,8 +2394,17 @@ export class Vault {
         sealedCekResidue.push(`${ref.collection}:${ref.id}`)
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const shred = await (coll as any)._writeTombstone(ref.id, actor) as { previousVersion: number } | null
+      let shred: { previousVersion: number } | null
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        shred = await (coll as any)._writeTombstone(ref.id, actor) as { previousVersion: number } | null
+      } catch (cause) {
+        if (satelliteOf === undefined) throw cause // base ref: pre-existing (unwrapped) fail-loud behavior
+        throw new SatelliteConfigError( // R-S4: abort the whole forget rather than leave the heavy side un-erased
+          `R-S4: forget could not fan out to satellite "${ref.collection}" — aborting rather than leaving the heavy side`,
+          { cause },
+        )
+      }
       if (shred !== null) {
         recordsShredded++
         collections.add(ref.collection)

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -894,6 +894,7 @@ export class Vault {
         adapter: this.adapter, vaultName: this.name, forgetSubjects: this.forgetStrategy.subjects, getDEK: this.getDEK,
         getBaseSchema: (base) => this.collectionCache.get(base)?.getSchema(),
         registerPoisonHook: (hook) => { this.noydb._writeHooks.onBeforeWrite(hook) },
+        registerPairExpander: (expander) => { this.noydb._forEachSyncEngine(this.name, e => e.setPairExpander(expander)) },
       }, collectionName, { ...options, satelliteOf: options.satelliteOf }, this.satelliteRegistry)
     }
 

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -889,10 +889,17 @@ export class Vault {
     if (this.satelliteRegistry?.byJoined(collectionName)) { // #591: joined handle — not a directly reachable collection
       throw new SatelliteConfigError(`"${collectionName}" is a joined handle — use vault.joined('${collectionName}'), not vault.collection().`)
     }
+    // R-S8 direction (ii): refuse constructing (fresh OR already-cached) either
+    // pair member with crdt mode AFTER the pairing already exists.
+    if (options?.crdt !== undefined && this.satelliteRegistry?.isPairMember(collectionName)) {
+      throw new SatelliteConfigError('R-S8: crdtMode is refused on either member of a satellite pair in v1 (revert cannot compensate a merge).')
+    }
     if (options?.satelliteOf !== undefined) { // #591 thin call-site (archetype-③) — wiring lives in with-shape/satellites/declare.ts
       this.satelliteRegistry = declareSatellite({
         adapter: this.adapter, vaultName: this.name, forgetSubjects: this.forgetStrategy.subjects, getDEK: this.getDEK,
         getBaseSchema: (base) => this.collectionCache.get(base)?.getSchema(),
+        getBaseCrdt: (base) => this.collectionCache.get(base)?.getConfig()?.crdt,
+        collectionExists: (name) => this.collectionCache.has(name),
         registerPoisonHook: (hook) => { this.noydb._writeHooks.onBeforeWrite(hook) },
         forEachSyncEngine: (fn) => { this.noydb._forEachSyncEngine(this.name, fn) },
       }, collectionName, { ...options, satelliteOf: options.satelliteOf }, this.satelliteRegistry)

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -886,14 +886,7 @@ export class Vault {
       throw new SatelliteConfigError(`"${collectionName}" is a joined handle — use vault.joined('${collectionName}'), not vault.collection().`)
     }
     if (options?.satelliteOf !== undefined) {
-      let reg = this.satelliteRegistry
-      if (reg === null) {
-        reg = this.satelliteRegistry = new SatelliteRegistry()
-        this.noydb._writeHooks.onBeforeWrite(e => { // gate writes against the poison map (R-S1 cross-check)
-          if (e.vault === this.name) this.satelliteRegistry?.assertNotPoisoned(e.collection)
-        })
-      }
-      const existing = reg.bySatellite(collectionName)
+      const existing = this.satelliteRegistry?.bySatellite(collectionName)
       if (existing) {
         const same = existing.base === options.satelliteOf
           && hashFields(existing.fields) === hashFields(options.fields ?? [])
@@ -902,16 +895,24 @@ export class Vault {
           throw new SatelliteConfigError(`R-S9: "${collectionName}" re-declared divergently within this session (base/fields/joined mismatch).`)
         }
       } else {
+        // Validate FIRST — a refused declaration must leave no side effect (no registry, no hook).
         const spec = validateSatelliteDeclaration({
           satellite: collectionName, satelliteOf: options.satelliteOf, fields: options.fields, joined: options.joined,
-          baseIsSatellite: reg.bySatellite(options.satelliteOf) !== null, crdtMode: options.crdt !== undefined,
+          baseIsSatellite: (this.satelliteRegistry?.bySatellite(options.satelliteOf) ?? null) !== null, crdtMode: options.crdt !== undefined,
         })
         if (this.forgetStrategy.subjects[spec.base] !== undefined && options.perRecordKeys !== true) {
           throw new SatelliteConfigError(`R-S7: satellite "${collectionName}" of forget-covered base "${spec.base}" must declare perRecordKeys.`)
         }
-        reg.register(spec)
+        if (this.satelliteRegistry === null) {
+          this.satelliteRegistry = new SatelliteRegistry()
+          this.noydb._writeHooks.onBeforeWrite(e => { // gate writes against the poison map (R-S1 cross-check)
+            if (e.vault === this.name) this.satelliteRegistry?.assertNotPoisoned(e.collection)
+          })
+        }
+        const reg = this.satelliteRegistry; reg.register(spec)
         const baseSchema = this.collectionCache.get(spec.base)?.getSchema()
-        void import('../with-shape/satellites/post-register.js').then(m => m.postRegister(this.adapter, this.name, spec, this.getDEK, baseSchema, reg))
+        void import('../with-shape/satellites/post-register.js') // .catch: never-throw-async, independent of postRegister internals
+          .then(m => m.postRegister(this.adapter, this.name, spec, this.getDEK, baseSchema, reg)).catch(() => {})
       }
     }
 

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -113,8 +113,8 @@ import type { DerivationStrategyHandle } from '../with-formula/derivations/types
 import type { LocaleReadOptions, ConflictPolicy } from './types.js'
 import type { CrdtMode } from '../with-commit/crdt/crdt.js'
 import { ReservedCollectionNameError, StaticDictReadonlyError, UnknownDictCodeError, SatelliteConfigError } from './errors.js'
-import { SatelliteRegistry } from '../with-shape/satellites/registry.js'
-import { validateSatelliteDeclaration, hashFields } from '../with-shape/satellites/validate.js'
+import { declareSatellite } from '../with-shape/satellites/declare.js'
+import type { SatelliteRegistry } from '../with-shape/satellites/registry.js'
 import {
   type PeriodRecord,
   type ClosePeriodOptions,
@@ -885,35 +885,12 @@ export class Vault {
     if (this.satelliteRegistry?.byJoined(collectionName)) { // #591: joined handle — not a directly reachable collection
       throw new SatelliteConfigError(`"${collectionName}" is a joined handle — use vault.joined('${collectionName}'), not vault.collection().`)
     }
-    if (options?.satelliteOf !== undefined) {
-      const existing = this.satelliteRegistry?.bySatellite(collectionName)
-      if (existing) {
-        const same = existing.base === options.satelliteOf
-          && hashFields(existing.fields) === hashFields(options.fields ?? [])
-          && (existing.joined ?? null) === (options.joined ?? null)
-        if (!same) {
-          throw new SatelliteConfigError(`R-S9: "${collectionName}" re-declared divergently within this session (base/fields/joined mismatch).`)
-        }
-      } else {
-        // Validate FIRST — a refused declaration must leave no side effect (no registry, no hook).
-        const spec = validateSatelliteDeclaration({
-          satellite: collectionName, satelliteOf: options.satelliteOf, fields: options.fields, joined: options.joined,
-          baseIsSatellite: (this.satelliteRegistry?.bySatellite(options.satelliteOf) ?? null) !== null, crdtMode: options.crdt !== undefined,
-        })
-        if (this.forgetStrategy.subjects[spec.base] !== undefined && options.perRecordKeys !== true) {
-          throw new SatelliteConfigError(`R-S7: satellite "${collectionName}" of forget-covered base "${spec.base}" must declare perRecordKeys.`)
-        }
-        if (this.satelliteRegistry === null) {
-          this.satelliteRegistry = new SatelliteRegistry()
-          this.noydb._writeHooks.onBeforeWrite(e => { // gate writes against the poison map (R-S1 cross-check)
-            if (e.vault === this.name) this.satelliteRegistry?.assertNotPoisoned(e.collection)
-          })
-        }
-        const reg = this.satelliteRegistry; reg.register(spec)
-        const baseSchema = this.collectionCache.get(spec.base)?.getSchema()
-        void import('../with-shape/satellites/post-register.js') // .catch: never-throw-async, independent of postRegister internals
-          .then(m => m.postRegister(this.adapter, this.name, spec, this.getDEK, baseSchema, reg)).catch(() => {})
-      }
+    if (options?.satelliteOf !== undefined) { // #591 thin call-site (archetype-③) — wiring lives in with-shape/satellites/declare.ts
+      this.satelliteRegistry = declareSatellite({
+        adapter: this.adapter, vaultName: this.name, forgetSubjects: this.forgetStrategy.subjects, getDEK: this.getDEK,
+        getBaseSchema: (base) => this.collectionCache.get(base)?.getSchema(),
+        registerPoisonHook: (hook) => { this.noydb._writeHooks.onBeforeWrite(hook) },
+      }, collectionName, { ...options, satelliteOf: options.satelliteOf }, this.satelliteRegistry)
     }
 
     let coll = this.collectionCache.get(collectionName)

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -114,7 +114,7 @@ import type { LocaleReadOptions, ConflictPolicy } from './types.js'
 import type { CrdtMode } from '../with-commit/crdt/crdt.js'
 import { ReservedCollectionNameError, StaticDictReadonlyError, UnknownDictCodeError, SatelliteConfigError } from './errors.js'
 import { declareSatellite } from '../with-shape/satellites/declare.js'
-import { makeSatelliteProxy } from '../with-shape/satellites/proxy.js'
+import { makeSatelliteProxy, makeBaseProxy } from '../with-shape/satellites/proxy.js'
 import type { SatelliteRegistry } from '../with-shape/satellites/registry.js'
 import {
   type PeriodRecord,
@@ -1244,6 +1244,8 @@ export class Vault {
     if (this.satelliteRegistry) { // #591: existence-authority + R-S6 read/write proxy (with-shape/satellites/proxy.ts)
       const spec = this.satelliteRegistry.bySatellite(collectionName)
       if (spec) return makeSatelliteProxy(coll, spec, this.satelliteRegistry) as Collection<T, S, Q, M>
+      const baseSpec = this.satelliteRegistry.satelliteOf(collectionName) // #591 Task 6: base-side delete fan-out
+      if (baseSpec) return makeBaseProxy(coll, baseSpec, this.satelliteRegistry, () => this.collection(baseSpec.satellite)) as Collection<T, S, Q, M>
     }
     return coll as unknown as Collection<T, S, Q, M>
   }

--- a/packages/hub/src/with-party/team/sync.ts
+++ b/packages/hub/src/with-party/team/sync.ts
@@ -98,8 +98,9 @@ export class SyncEngine {
    *
    * Pair-coupled (#591 rule 5b): registering for one satellite-pair member
    * registers the same resolver for both — the pair converges under one
-   * resolution policy. Uses whatever the pair-expander knows about the pair
-   * *at this call*; see the ordering-constraint note on `setPairExpander`.
+   * resolution policy. Expands with whatever the pair-expander knows *at this
+   * call*; resolvers registered before their pair existed are covered by
+   * `remirrorPairResolvers` at pair-registration time.
    */
   registerConflictResolver(collection: string, resolver: CollectionConflictResolver): void {
     for (const n of this.pairExpander?.([collection]) ?? [collection]) this.conflictResolvers.set(n, resolver)
@@ -109,12 +110,26 @@ export class SyncEngine {
    * Wire a satellite pair-expansion function (vault registration, #591 Task 11).
    * The closure re-reads the live `SatelliteRegistry` on every call, so pairs
    * declared after this is set are still picked up by `push`/`pull` filters.
-   * `registerConflictResolver`, however, expands *at the moment it's called* —
-   * a resolver registered before its satellite partner is declared will NOT
-   * be mirrored retroactively.
    */
   setPairExpander(expander: (names: readonly string[]) => readonly string[]): void {
     this.pairExpander = expander
+  }
+
+  /**
+   * Retroactively mirror per-collection conflict resolvers across a newly
+   * registered satellite pair (#591 rule 5b) — covers the NORMAL declaration
+   * order, where the base's `conflictPolicy` resolver was registered before
+   * the satellite was declared (so the call-time expansion in
+   * `registerConflictResolver` saw no pair yet). Tie-break: when BOTH members
+   * already carry (different) resolvers, the FIRST name in `names` wins —
+   * callers pass `[base, satellite]`, so the base's resolver is canonical.
+   * Idempotent; a later explicit registration on either member still
+   * overwrites both (last-wins, via the call-time expansion above).
+   */
+  remirrorPairResolvers(names: readonly string[]): void {
+    const canonical = names.map(n => this.conflictResolvers.get(n)).find(r => r !== undefined)
+    if (!canonical) return
+    for (const n of names) this.conflictResolvers.set(n, canonical)
   }
 
   /** Record a local change for later push. */

--- a/packages/hub/src/with-party/team/sync.ts
+++ b/packages/hub/src/with-party/team/sync.ts
@@ -42,6 +42,15 @@ export class SyncEngine {
   /** Per-collection conflict resolvers registered by Collection instances. */
   private readonly conflictResolvers = new Map<string, CollectionConflictResolver>()
 
+  /**
+   * Expands a collection-name filter to include its satellite pair partner(s)
+   * (spec #591 convergence rule 5b) — wired from vault satellite declaration
+   * via `setPairExpander`. `undefined` when no satellite has ever been
+   * declared for this vault: identity behavior, zero change for non-satellite
+   * users.
+   */
+  private pairExpander?: (names: readonly string[]) => readonly string[]
+
   constructor(opts: {
     local: NoydbStore
     remote: NoydbStore
@@ -86,9 +95,26 @@ export class SyncEngine {
   /**
    * Register a per-collection conflict resolver.
    * Called by Collection when `conflictPolicy` is set.
+   *
+   * Pair-coupled (#591 rule 5b): registering for one satellite-pair member
+   * registers the same resolver for both — the pair converges under one
+   * resolution policy. Uses whatever the pair-expander knows about the pair
+   * *at this call*; see the ordering-constraint note on `setPairExpander`.
    */
   registerConflictResolver(collection: string, resolver: CollectionConflictResolver): void {
-    this.conflictResolvers.set(collection, resolver)
+    for (const n of this.pairExpander?.([collection]) ?? [collection]) this.conflictResolvers.set(n, resolver)
+  }
+
+  /**
+   * Wire a satellite pair-expansion function (vault registration, #591 Task 11).
+   * The closure re-reads the live `SatelliteRegistry` on every call, so pairs
+   * declared after this is set are still picked up by `push`/`pull` filters.
+   * `registerConflictResolver`, however, expands *at the moment it's called* —
+   * a resolver registered before its satellite partner is declared will NOT
+   * be mirrored retroactively.
+   */
+  setPairExpander(expander: (names: readonly string[]) => readonly string[]): void {
+    this.pairExpander = expander
   }
 
   /** Record a local change for later push. */
@@ -134,11 +160,14 @@ export class SyncEngine {
     const errors: Error[] = []
     const completed: number[] = []
 
+    // Partial sync: expand the filter to cover satellite pair partners (#591 rule 5b)
+    const filter = options?.collections ? new Set(this.pairExpander?.(options.collections) ?? options.collections) : null
+
     for (let i = 0; i < this.dirty.length; i++) {
       const entry = this.dirty[i]!
 
       // Partial sync: skip collections not in the filter
-      if (options?.collections && !options.collections.includes(entry.collection)) {
+      if (filter && !filter.has(entry.collection)) {
         continue
       }
 
@@ -225,12 +254,15 @@ export class SyncEngine {
     const conflicts: Conflict[] = []
     const errors: Error[] = []
 
+    // Partial sync: expand the filter to cover satellite pair partners (#591 rule 5b)
+    const filter = options?.collections ? new Set(this.pairExpander?.(options.collections) ?? options.collections) : null
+
     try {
       const remoteSnapshot = await this.remote.loadAll(this.vault)
 
       for (const [collName, records] of Object.entries(remoteSnapshot)) {
         // Partial sync: skip collections not in the filter
-        if (options?.collections && !options.collections.includes(collName)) {
+        if (filter && !filter.has(collName)) {
           continue
         }
 

--- a/packages/hub/src/with-party/team/sync.ts
+++ b/packages/hub/src/with-party/team/sync.ts
@@ -118,6 +118,13 @@ export class SyncEngine {
     this.scheduler?.notifyChange()
   }
 
+  /** Remove a dirty entry (satellite fan-out revert cleanup — spec #591). */
+  async removeDirty(collection: string, id: string): Promise<void> {
+    const before = this.dirty.length
+    this.dirty = this.dirty.filter(d => !(d.collection === collection && d.id === id))
+    if (this.dirty.length !== before) await this.persistMeta()
+  }
+
   /** Push dirty records to remote adapter. Accepts optional `PushOptions` for partial sync. */
   async push(options?: PushOptions): Promise<PushResult> {
     await this.ensureLoaded()

--- a/packages/hub/src/with-pod/bundle.ts
+++ b/packages/hub/src/with-pod/bundle.ts
@@ -1096,6 +1096,62 @@ function applySliceFilters(
 }
 
 /**
+ * Unconditionally drop satellite-collection records whose base row is dead
+ * (absent or tombstoned — existence.ts rule 1) from a vault dump. Unlike
+ * `applySliceFilters` / `applyPlaintextFilters`, this isn't opt-in: a
+ * satellite envelope that outlived its base is dead ciphertext (plus its
+ * wrapped keys) that should never leave the vault in a `.noydb` backup
+ * (#591 Task 10 — closes the last enumerated existence-authority surface).
+ *
+ * Pairing info comes from the persisted `_schemas/<name>` marker rather
+ * than the in-memory `SatelliteRegistry` — that registry is private to
+ * `Vault` and the bundle-export path only has `Vault._introspectState()`
+ * (adapter + vault name + per-collection DEK accessor), so it reads the
+ * marker instead of widening the kernel's surface. See
+ * `with-shape/satellites/dead-filter.ts`.
+ *
+ * No-ops (returns `dumpJson` unchanged) when the vault has no detectable
+ * satellite collections at all, so vaults that never use satellites pay
+ * no extra parse/reserialize cost. Also no-ops when `vault` doesn't
+ * implement `_introspectState()` at all — some call sites pass a minimal
+ * duck-typed vault-like object for unit tests (e.g.
+ * `snapshots.test.ts`'s `makeMockVault`, which implements only
+ * `getBundleHandle`/`dump`/`load`/`getPublicEnvelope`); a real `Vault`
+ * always implements it.
+ *
+ * @internal
+ */
+async function applySatelliteLivenessFilter(
+  vault: Vault,
+  dumpJson: string,
+): Promise<string> {
+  const backup = JSON.parse(dumpJson) as {
+    collections?: Record<string, Record<string, unknown>>
+    [k: string]: unknown
+  }
+  if (!backup.collections || typeof backup.collections !== 'object') return dumpJson
+  if (typeof vault._introspectState !== 'function') return dumpJson
+
+  const { adapter, name, getDEK } = vault._introspectState()
+  const { liveBaseIdSetsForBundle } = await import('../with-shape/satellites/dead-filter.js')
+  const satLive = await liveBaseIdSetsForBundle(adapter, name, Object.keys(backup.collections), getDEK)
+  if (satLive.size === 0) return dumpJson
+
+  const next: Record<string, Record<string, unknown>> = {}
+  for (const [collName, records] of Object.entries(backup.collections)) {
+    const live = satLive.get(collName)
+    if (!live) { next[collName] = records; continue }
+    const kept: Record<string, unknown> = {}
+    for (const [id, env] of Object.entries(records)) {
+      if (live.has(id)) kept[id] = env
+    }
+    next[collName] = kept
+  }
+  backup.collections = next
+  return JSON.stringify(backup)
+}
+
+/**
  * Apply opt-in plaintext-tier filters
  * to a vault dump. Operates BEFORE `applySliceFilters` so the metadata
  * pass sees the trimmed record set.
@@ -1241,10 +1297,15 @@ export async function writePod(
   const handle = await vault.getBundleHandle()
   const dumpJson = await vault.dump()
 
+  // Satellite existence-authority filter (#591 Task 10) — unconditional,
+  // runs before every other filter so dead-ciphertext satellite records
+  // never reach recipient rewrap or the opt-in filters below.
+  const satelliteFiltered = await applySatelliteLivenessFilter(vault, dumpJson)
+
   // Re-keying: when caller supplied recipients (or the single-recipient
   // shorthand), substitute the bundle's `keyrings` map with freshly
   // built recipient slots before slice filters run.
-  const rekeyed = await applyRecipientRewrap(vault, dumpJson, opts)
+  const rekeyed = await applyRecipientRewrap(vault, satelliteFiltered, opts)
   // Plaintext-tier filters run BEFORE
   // the metadata-only slice — that way the metadata pass sees the
   // already-trimmed record set and the two filter chains compose

--- a/packages/hub/src/with-shape/persisted-schemas/register.ts
+++ b/packages/hub/src/with-shape/persisted-schemas/register.ts
@@ -22,6 +22,7 @@ import { ConflictError } from '../../kernel/errors.js'
 import type { SchemaUpdateStrategy, UpdateDecision } from '../schema-update/types.js'
 import type { NoydbStore, ClassifiedMarker } from '../../kernel/types.js'
 import type { PersistedSchemaEnvelope } from './types.js'
+import type { PairingMarker } from '../satellites/types.js'
 import type { EnclaveKey } from '../../kernel/enclave/index.js'
 
 /**
@@ -144,6 +145,53 @@ export async function persistClassifiedMarker(opts: {
       throw err
     }
   }
+}
+
+/**
+ * Persist (or refresh) the R-S9 satellite pairing marker into the collection's
+ * `_schemas/<collection>` record, preserving any existing derived JSON-Schema
+ * body. Idempotent — a no-op when an equivalent marker is already stored.
+ * Independent of `persistJsonSchema`: called on satellite declaration so a
+ * later divergent re-declaration can be detected cross-session.
+ */
+export async function persistSatelliteMarker(opts: {
+  readonly store: NoydbStore
+  readonly vault: string
+  readonly collectionName: string
+  readonly dek: EnclaveKey
+  readonly marker: PairingMarker
+}): Promise<void> {
+  // Shares the `_schemas/<collection>` record with the JSON-Schema writer;
+  // CAS on the loaded version so a concurrent schema (re)registration can't
+  // silently drop the marker (and vice-versa) — see #583.
+  for (let attempt = 0; ; attempt++) {
+    const { version, payload: stored } = await loadPersistedSchemaEntry(
+      opts.store, opts.vault, opts.collectionName, opts.dek,
+    )
+    if (stored?.satellite !== undefined && satelliteMarkersEqual(stored.satellite, opts.marker)) return
+    const payload: PersistedSchemaEnvelope =
+      stored !== undefined
+        ? { ...stored, satellite: opts.marker }
+        : {
+            _noydb_schema: 1,
+            kind: 'Unknown',
+            jsonSchema: null,
+            hash: null,
+            derivedAt: new Date().toISOString(),
+            satellite: opts.marker,
+          }
+    try {
+      await savePersistedSchema(opts.store, opts.vault, opts.collectionName, opts.dek, payload, version)
+      return
+    } catch (err) {
+      if (err instanceof ConflictError && attempt < MAX_SCHEMA_CAS_RETRIES) continue
+      throw err
+    }
+  }
+}
+
+function satelliteMarkersEqual(a: PairingMarker, b: PairingMarker): boolean {
+  return a.base === b.base && a.fieldsHash === b.fieldsHash && (a.joined ?? null) === (b.joined ?? null)
 }
 
 function markersEqual(a: ClassifiedMarker, b: ClassifiedMarker): boolean {

--- a/packages/hub/src/with-shape/persisted-schemas/register.ts
+++ b/packages/hub/src/with-shape/persisted-schemas/register.ts
@@ -89,11 +89,13 @@ export async function persistSchemaIfNeeded(opts: {
       return { written: false, skipped: false, envelope: stored ?? fresh, decision }
     }
 
-    // Preserve a previously-persisted classified marker (C-A / R10) — the schema
-    // derivation knows nothing about it, so a naive overwrite here would drop the
-    // config-drift guard's cross-session signal.
-    const toSave: PersistedSchemaEnvelope =
-      stored?.classified !== undefined ? { ...fresh, classified: stored.classified } : fresh
+    // Preserve a previously-persisted classified marker (C-A / R10) and
+    // satellite pairing marker (R-S9) — the schema derivation knows nothing
+    // about them, so a naive overwrite here would drop the config-drift
+    // guards' cross-session signals.
+    let toSave: PersistedSchemaEnvelope = fresh
+    if (stored?.classified !== undefined) toSave = { ...toSave, classified: stored.classified }
+    if (stored?.satellite !== undefined) toSave = { ...toSave, satellite: stored.satellite }
     try {
       await savePersistedSchema(opts.store, opts.vault, opts.collectionName, opts.dek, toSave, version)
       return { written: true, skipped: false, envelope: toSave, decision }

--- a/packages/hub/src/with-shape/persisted-schemas/types.ts
+++ b/packages/hub/src/with-shape/persisted-schemas/types.ts
@@ -11,6 +11,7 @@
  */
 
 import type { ClassifiedMarker } from '../../kernel/types.js'
+import type { PairingMarker } from '../satellites/types.js'
 
 /** Family of Standard Schema v1 validator the persisted snapshot was derived from. */
 export type PersistedSchemaKind = 'Zod' | 'Valibot' | 'ArkType' | 'Effect' | 'Unknown'
@@ -46,4 +47,11 @@ export interface PersistedSchemaEnvelope {
    * collection that never opts into schema persistence still writes this marker.
    */
   readonly classified?: ClassifiedMarker
+  /**
+   * R-S9 satellite pairing marker. Present when this collection is declared
+   * as a satellite (`satelliteOf`). A later re-declaration of the same
+   * satellite must match `(base, fieldsHash, joined)` exactly or is refused —
+   * the satellite-pair analogue of {@link classified}'s config-drift guard.
+   */
+  readonly satellite?: PairingMarker
 }

--- a/packages/hub/src/with-shape/satellites/dead-filter.ts
+++ b/packages/hub/src/with-shape/satellites/dead-filter.ts
@@ -30,15 +30,31 @@ export async function liveBaseIdSetsForBundle(
   const out = new Map<string, Set<string>>()
   for (const name of collectionNames) {
     if (name.startsWith('_')) continue
+    // SILENT-DEGRADE surface (deliberate asymmetry): on ANY marker-read
+    // failure the collection is treated as non-satellite and exported
+    // UNFILTERED. That covers, precisely:
+    //   (a) `getDEK(name)` throwing for any reason (caught below);
+    //   (b) the persisted `_schemas/<name>` record failing to decrypt or
+    //       parse — corruption, wrong DEK, transient store error —
+    //       `loadPersistedSchema` catches internally and returns
+    //       `undefined` (storage.ts), which reads here as "no marker";
+    //   (c) the marker not yet persisted — `declareSatellite`'s
+    //       `postRegister` is fire-and-forget, so an export racing a
+    //       fresh declaration can miss it.
+    // Leak-on-error is chosen over exclude-on-error because this is a
+    // BACKUP path: exporting stale dead-satellite ciphertext is
+    // recoverable; silently dropping live records from a backup is the
+    // strictly worse failure. Pinned by the "leak-on-error posture" tests
+    // in satellites-bundle-filter.test.ts.
     let dek: EnclaveKey
     try {
       dek = await getDEK(name)
     } catch {
-      continue // no DEK reachable for this collection — can't read its marker, treat as non-satellite
+      continue // (a) no DEK reachable — can't read the marker, export unfiltered
     }
     const persisted = await loadPersistedSchema(store, vaultName, name, dek)
     const marker = persisted?.satellite
-    if (!marker) continue
+    if (!marker) continue // (b)/(c) — undecryptable/absent/markerless schema record, export unfiltered
     out.set(name, await liveBaseIdSet(store, vaultName, marker.base))
   }
   return out

--- a/packages/hub/src/with-shape/satellites/dead-filter.ts
+++ b/packages/hub/src/with-shape/satellites/dead-filter.ts
@@ -1,0 +1,45 @@
+import type { NoydbStore } from '../../kernel/types.js'
+import type { EnclaveKey } from '../../kernel/enclave/index.js'
+import { liveBaseIdSet } from './existence.js'
+
+/**
+ * Build a live-base id set for every satellite collection detectable from
+ * its persisted `_schemas/<name>` pairing marker (#591 Task 10).
+ *
+ * The bundle-export path (`with-pod/bundle.ts`) has no reachable
+ * `SatelliteRegistry` — that registry is private to `Vault` and adding an
+ * accessor would grow a kernel file past its line-ceiling ratchet. The
+ * marker persisted by `ensureSatelliteMarker` (`_schemas/<satellite>`,
+ * decrypted with the satellite collection's own DEK — see
+ * `with-shape/persisted-schemas/storage.ts`) is the fallback pairing-info
+ * source that's always reachable from just a raw store + a per-collection
+ * DEK accessor, so export uses that instead of the in-memory registry.
+ *
+ * Returns a `Map` from satellite collection name to its base's live id set
+ * (existence.ts rule 1: absent or tombstoned base ⇒ not live). Only
+ * satellite collections are present as keys — callers should treat a
+ * missing key as "not a satellite, don't filter."
+ */
+export async function liveBaseIdSetsForBundle(
+  store: NoydbStore,
+  vaultName: string,
+  collectionNames: readonly string[],
+  getDEK: (collectionName: string) => Promise<EnclaveKey>,
+): Promise<Map<string, Set<string>>> {
+  const { loadPersistedSchema } = await import('../persisted-schemas/storage.js')
+  const out = new Map<string, Set<string>>()
+  for (const name of collectionNames) {
+    if (name.startsWith('_')) continue
+    let dek: EnclaveKey
+    try {
+      dek = await getDEK(name)
+    } catch {
+      continue // no DEK reachable for this collection — can't read its marker, treat as non-satellite
+    }
+    const persisted = await loadPersistedSchema(store, vaultName, name, dek)
+    const marker = persisted?.satellite
+    if (!marker) continue
+    out.set(name, await liveBaseIdSet(store, vaultName, marker.base))
+  }
+  return out
+}

--- a/packages/hub/src/with-shape/satellites/declare.ts
+++ b/packages/hub/src/with-shape/satellites/declare.ts
@@ -22,6 +22,10 @@ export interface SatelliteDeclareContext {
   readonly getDEK: (collectionName: string) => Promise<EnclaveKey>
   /** The base collection's attached Standard Schema validator, if constructed. */
   readonly getBaseSchema: (base: string) => unknown
+  /** The base collection's constructed crdt mode, if any (R-S8 direction i). */
+  readonly getBaseCrdt: (base: string) => unknown
+  /** True when `name` is an already-constructed collection (R-S5 joined-name guard). */
+  readonly collectionExists: (name: string) => boolean
   /** Registers the vault-wide poison write-gate; invoked at most once per vault. */
   readonly registerPoisonHook: (hook: (e: { readonly vault: string; readonly collection: string }) => void) => void
   /**
@@ -77,7 +81,10 @@ export function declareSatellite(
   const spec = validateSatelliteDeclaration({
     satellite: collectionName, satelliteOf: options.satelliteOf, fields: options.fields, joined: options.joined,
     baseIsSatellite: (existingRegistry?.bySatellite(options.satelliteOf) ?? null) !== null,
-    crdtMode: options.crdt !== undefined,
+    // R-S8 direction (i): refuse if EITHER this declaration sets crdt, OR the
+    // base was already constructed with crdt mode before this pairing.
+    crdtMode: options.crdt !== undefined || ctx.getBaseCrdt(options.satelliteOf) !== undefined,
+    joinedCollidesWithCollection: options.joined !== undefined && ctx.collectionExists(options.joined),
   })
   if (ctx.forgetSubjects[spec.base] !== undefined && options.perRecordKeys !== true) {
     throw new SatelliteConfigError(`R-S7: satellite "${collectionName}" of forget-covered base "${spec.base}" must declare perRecordKeys.`)

--- a/packages/hub/src/with-shape/satellites/declare.ts
+++ b/packages/hub/src/with-shape/satellites/declare.ts
@@ -25,12 +25,20 @@ export interface SatelliteDeclareContext {
   /** Registers the vault-wide poison write-gate; invoked at most once per vault. */
   readonly registerPoisonHook: (hook: (e: { readonly vault: string; readonly collection: string }) => void) => void
   /**
-   * Wires a live pair-expansion function to the vault's SyncEngine(s) —
-   * invoked at most once per vault, alongside `registerPoisonHook`, on first
-   * satellite declaration (#591 Task 11). The closure captures the registry
-   * itself (not a snapshot), so pairs declared later are still picked up.
+   * Iterates the vault's SyncEngine(s) (#591 Task 11) — used to wire the
+   * live pair-expander (once per vault, alongside `registerPoisonHook`; the
+   * closure captures the registry itself, not a snapshot, so pairs declared
+   * later are still picked up by push/pull filters) and to retroactively
+   * re-mirror conflict resolvers on every successful pair registration.
+   * No-op when sync is not configured.
    */
-  readonly registerPairExpander: (expander: (names: readonly string[]) => readonly string[]) => void
+  readonly forEachSyncEngine: (fn: (engine: PairSyncEngine) => void) => void
+}
+
+/** The narrow slice of SyncEngine that satellite declaration wiring drives (#591 Task 11). */
+export interface PairSyncEngine {
+  setPairExpander(expander: (names: readonly string[]) => readonly string[]): void
+  remirrorPairResolvers(names: readonly string[]): void
 }
 
 export interface SatelliteDeclarationOptions {
@@ -80,10 +88,13 @@ export function declareSatellite(
     ctx.registerPoisonHook((e) => { // gate writes against the poison map (R-S1 cross-check)
       if (e.vault === ctx.vaultName) created.assertNotPoisoned(e.collection)
     })
-    ctx.registerPairExpander(names => created.expandNames(names)) // #591 Task 11: sync push/pull + conflict resolvers treat a pair as a unit
+    ctx.forEachSyncEngine(e => e.setPairExpander(names => created.expandNames(names))) // #591 Task 11: sync push/pull + conflict resolvers treat a pair as a unit
     reg = created
   }
   reg.register(spec)
+  // #591 Task 11: retroactive resolver mirroring — a conflictPolicy resolver
+  // registered on either member BEFORE this pair existed is copied to both now.
+  ctx.forEachSyncEngine(e => e.remirrorPairResolvers([spec.base, spec.satellite]))
   const registry = reg // const alias — closure below must not capture the `let`
   const baseSchema = ctx.getBaseSchema(spec.base)
   void import('./post-register.js') // .catch: never-throw-async, independent of postRegister internals

--- a/packages/hub/src/with-shape/satellites/declare.ts
+++ b/packages/hub/src/with-shape/satellites/declare.ts
@@ -1,0 +1,85 @@
+/**
+ * Satellite declaration wiring (#591, archetype-③) — the full body behind
+ * `Vault.collection()`'s thin call-site: in-session reconcile (idempotent
+ * identical redeclare / R-S9 divergent refusal), sync validation
+ * (R-S3/R-S5/R-S8), the R-S7 forget-coverage gate, lazy registry + poison
+ * write-gate creation, registration, and the fire-and-forget postRegister
+ * (marker persistence + R-S1 cross-check). Kept dependency-narrow: no
+ * `Vault` import — the kernel supplies a {@link SatelliteDeclareContext}.
+ */
+import type { NoydbStore } from '../../kernel/types.js'
+import type { EnclaveKey } from '../../kernel/enclave/index.js'
+import { SatelliteConfigError } from '../../kernel/errors.js'
+import { SatelliteRegistry } from './registry.js'
+import { validateSatelliteDeclaration, hashFields } from './validate.js'
+
+/** The narrow slice of Vault that declaration wiring needs. */
+export interface SatelliteDeclareContext {
+  readonly adapter: NoydbStore
+  readonly vaultName: string
+  /** `forgetStrategy.subjects` — collection → subject field (R-S7 gate input). */
+  readonly forgetSubjects: Record<string, string>
+  readonly getDEK: (collectionName: string) => Promise<EnclaveKey>
+  /** The base collection's attached Standard Schema validator, if constructed. */
+  readonly getBaseSchema: (base: string) => unknown
+  /** Registers the vault-wide poison write-gate; invoked at most once per vault. */
+  readonly registerPoisonHook: (hook: (e: { readonly vault: string; readonly collection: string }) => void) => void
+}
+
+export interface SatelliteDeclarationOptions {
+  readonly satelliteOf: string
+  readonly fields?: readonly string[] | undefined
+  readonly joined?: string | undefined
+  readonly perRecordKeys?: boolean | undefined
+  readonly crdt?: unknown
+}
+
+/**
+ * Register `collectionName` as a satellite per `options`. Returns the
+ * (possibly newly created) registry — the caller stores it back on the vault.
+ * A refused declaration throws {@link SatelliteConfigError} and leaves NO
+ * side effect (no registry created, no hook registered).
+ */
+export function declareSatellite(
+  ctx: SatelliteDeclareContext,
+  collectionName: string,
+  options: SatelliteDeclarationOptions,
+  existingRegistry: SatelliteRegistry | null,
+): SatelliteRegistry {
+  if (existingRegistry !== null) {
+    const existing = existingRegistry.bySatellite(collectionName)
+    if (existing) { // in-session reconcile: identical redeclare is a no-op, divergent refuses (R-S9)
+      const same = existing.base === options.satelliteOf
+        && hashFields(existing.fields) === hashFields(options.fields ?? [])
+        && (existing.joined ?? null) === (options.joined ?? null)
+      if (!same) {
+        throw new SatelliteConfigError(`R-S9: "${collectionName}" re-declared divergently within this session (base/fields/joined mismatch).`)
+      }
+      return existingRegistry
+    }
+  }
+  // Validate FIRST — a refused declaration must leave no side effect (no registry, no hook).
+  const spec = validateSatelliteDeclaration({
+    satellite: collectionName, satelliteOf: options.satelliteOf, fields: options.fields, joined: options.joined,
+    baseIsSatellite: (existingRegistry?.bySatellite(options.satelliteOf) ?? null) !== null,
+    crdtMode: options.crdt !== undefined,
+  })
+  if (ctx.forgetSubjects[spec.base] !== undefined && options.perRecordKeys !== true) {
+    throw new SatelliteConfigError(`R-S7: satellite "${collectionName}" of forget-covered base "${spec.base}" must declare perRecordKeys.`)
+  }
+  let reg = existingRegistry
+  if (reg === null) {
+    const created = new SatelliteRegistry()
+    ctx.registerPoisonHook((e) => { // gate writes against the poison map (R-S1 cross-check)
+      if (e.vault === ctx.vaultName) created.assertNotPoisoned(e.collection)
+    })
+    reg = created
+  }
+  reg.register(spec)
+  const registry = reg // const alias — closure below must not capture the `let`
+  const baseSchema = ctx.getBaseSchema(spec.base)
+  void import('./post-register.js') // .catch: never-throw-async, independent of postRegister internals
+    .then((m) => m.postRegister(ctx.adapter, ctx.vaultName, spec, ctx.getDEK, baseSchema, registry))
+    .catch(() => {})
+  return reg
+}

--- a/packages/hub/src/with-shape/satellites/declare.ts
+++ b/packages/hub/src/with-shape/satellites/declare.ts
@@ -24,6 +24,13 @@ export interface SatelliteDeclareContext {
   readonly getBaseSchema: (base: string) => unknown
   /** Registers the vault-wide poison write-gate; invoked at most once per vault. */
   readonly registerPoisonHook: (hook: (e: { readonly vault: string; readonly collection: string }) => void) => void
+  /**
+   * Wires a live pair-expansion function to the vault's SyncEngine(s) —
+   * invoked at most once per vault, alongside `registerPoisonHook`, on first
+   * satellite declaration (#591 Task 11). The closure captures the registry
+   * itself (not a snapshot), so pairs declared later are still picked up.
+   */
+  readonly registerPairExpander: (expander: (names: readonly string[]) => readonly string[]) => void
 }
 
 export interface SatelliteDeclarationOptions {
@@ -73,6 +80,7 @@ export function declareSatellite(
     ctx.registerPoisonHook((e) => { // gate writes against the poison map (R-S1 cross-check)
       if (e.vault === ctx.vaultName) created.assertNotPoisoned(e.collection)
     })
+    ctx.registerPairExpander(names => created.expandNames(names)) // #591 Task 11: sync push/pull + conflict resolvers treat a pair as a unit
     reg = created
   }
   reg.register(spec)

--- a/packages/hub/src/with-shape/satellites/declare.ts
+++ b/packages/hub/src/with-shape/satellites/declare.ts
@@ -40,7 +40,7 @@ export interface SatelliteDeclareContext {
 }
 
 /** The narrow slice of SyncEngine that satellite declaration wiring drives (#591 Task 11). */
-export interface PairSyncEngine {
+interface PairSyncEngine {
   setPairExpander(expander: (names: readonly string[]) => readonly string[]): void
   remirrorPairResolvers(names: readonly string[]): void
 }

--- a/packages/hub/src/with-shape/satellites/existence.ts
+++ b/packages/hub/src/with-shape/satellites/existence.ts
@@ -6,7 +6,7 @@ import type { NoydbStore, EncryptedEnvelope } from '../../kernel/types.js'
  * tombstone shape (`_iv === '' && _data === ''`, per `buildTombstone()`) both
  * read as "not live" — undecrypted, envelope-level checks only.
  */
-export function isEnvelopeLive(env: EncryptedEnvelope | null): boolean {
+function isEnvelopeLive(env: EncryptedEnvelope | null): boolean {
   return env !== null && !(env._iv === '' && env._data === '')
 }
 

--- a/packages/hub/src/with-shape/satellites/existence.ts
+++ b/packages/hub/src/with-shape/satellites/existence.ts
@@ -1,0 +1,24 @@
+import type { NoydbStore, EncryptedEnvelope } from '../../kernel/types.js'
+
+/**
+ * Existence authority (spec § Convergence & existence authority, rule 1): the
+ * base row is the sole authority on record existence. `null` (absent) and the
+ * tombstone shape (`_iv === '' && _data === ''`, per `buildTombstone()`) both
+ * read as "not live" — undecrypted, envelope-level checks only.
+ */
+export function isEnvelopeLive(env: EncryptedEnvelope | null): boolean {
+  return env !== null && !(env._iv === '' && env._data === '')
+}
+
+/** One undecrypted adapter `get` on the base — the store-shape the spec pins (zero extra crypto). */
+export async function isBaseLive(adapter: NoydbStore, vault: string, base: string, id: string): Promise<boolean> {
+  return isEnvelopeLive(await adapter.get(vault, base, id))
+}
+
+/** The set of base ids that are currently live — used to id-filter satellite `list()` results. */
+export async function liveBaseIdSet(adapter: NoydbStore, vault: string, base: string): Promise<Set<string>> {
+  const ids = await adapter.list(vault, base)
+  const out = new Set<string>()
+  for (const id of ids) if (await isBaseLive(adapter, vault, base, id)) out.add(id)
+  return out
+}

--- a/packages/hub/src/with-shape/satellites/fanout.ts
+++ b/packages/hub/src/with-shape/satellites/fanout.ts
@@ -20,7 +20,7 @@
  * `registry.withPairLock` this module already holds) or recurse forever
  * (the base proxy's `delete` calls straight back into `pairDelete`).
  */
-import type { EncryptedEnvelope } from '../../kernel/types.js'
+import type { EncryptedEnvelope, NoydbStore } from '../../kernel/types.js'
 import type { SatelliteSpec } from './types.js'
 import type { SatelliteRegistry } from './registry.js'
 import { RAW_TARGET } from './raw-target.js'
@@ -29,7 +29,12 @@ export interface FanoutDeps {
   readonly spec: SatelliteSpec
   readonly base: () => unknown
   readonly satellite: () => unknown
-  readonly adapter: { get(vault: string, collection: string, id: string): Promise<EncryptedEnvelope | null>; put(vault: string, collection: string, id: string, envelope: EncryptedEnvelope): Promise<void>; delete(vault: string, collection: string, id: string): Promise<void> }
+  // Widened to the full `NoydbStore` (#591 review M2): every caller already
+  // hands in the full adapter (vault.ts's `this.adapter` / a proxy's own
+  // `target.adapter`) — narrowing to fan-out's own get/put/delete needs just
+  // forced `joined.ts` to re-widen it back with a double cast to reach
+  // `isBaseLive`/`liveBaseIdSet`, which also call `.list`.
+  readonly adapter: NoydbStore
   readonly vaultName: string
   readonly registry: SatelliteRegistry
 }

--- a/packages/hub/src/with-shape/satellites/fanout.ts
+++ b/packages/hub/src/with-shape/satellites/fanout.ts
@@ -1,0 +1,113 @@
+/**
+ * Fan-out writes for a base↔satellite pair (#591, Task 6): a joined `put`
+ * splits the record across both collections and writes base-then-satellite;
+ * a pair `delete` removes satellite-then-base. Either function reverts every
+ * already-executed leg (best-effort, raw adapter writes) and compensates
+ * each reverted collection's cache/dirty-tracking/change-stream on failure.
+ *
+ * Both legs are driven through `Collection.put`/`.delete` (encryption,
+ * ledger, history, cache, sync-dirty, change-emit all fire normally); only
+ * the REVERT writes go straight to the raw adapter, mirroring
+ * `revertExecuted` (`with-commit/tx/transaction.ts:610`) — re-implemented
+ * locally rather than imported, since with-commit is a gated service this
+ * always-on satellite path must not depend on.
+ *
+ * `deps.base()`/`deps.satellite()` may return either a raw `Collection` or
+ * one of this package's proxies (`makeSatelliteProxy` / `makeBaseProxy`) —
+ * every handle is unwrapped via `RAW_TARGET` before use so fan-out never
+ * re-enters a proxy's own `put`/`delete` override. Re-entering would either
+ * deadlock (the satellite proxy's `put` takes the same non-reentrant
+ * `registry.withPairLock` this module already holds) or recurse forever
+ * (the base proxy's `delete` calls straight back into `pairDelete`).
+ */
+import type { EncryptedEnvelope } from '../../kernel/types.js'
+import type { SatelliteSpec } from './types.js'
+import type { SatelliteRegistry } from './registry.js'
+import { RAW_TARGET } from './raw-target.js'
+
+export interface FanoutDeps {
+  readonly spec: SatelliteSpec
+  readonly base: () => unknown
+  readonly satellite: () => unknown
+  readonly adapter: { get(vault: string, collection: string, id: string): Promise<EncryptedEnvelope | null>; put(vault: string, collection: string, id: string, envelope: EncryptedEnvelope): Promise<void>; delete(vault: string, collection: string, id: string): Promise<void> }
+  readonly vaultName: string
+  readonly registry: SatelliteRegistry
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CollectionHandle = any
+
+/** Escape any proxy — see file header. Plain (non-proxy) handles pass through unchanged. */
+function unwrap(handle: unknown): CollectionHandle {
+  return (handle as Record<symbol, unknown>)[RAW_TARGET] ?? handle
+}
+
+interface Leg {
+  readonly coll: string
+  readonly id: string
+  readonly prior: EncryptedEnvelope | null
+  readonly handle: CollectionHandle
+}
+
+/** Best-effort revert of every executed leg, in reverse order, then per-leg compensation. */
+async function revertAndCompensate(deps: FanoutDeps, executed: readonly Leg[]): Promise<void> {
+  for (const leg of [...executed].reverse()) {
+    try {
+      if (leg.prior !== null) await deps.adapter.put(deps.vaultName, leg.coll, leg.id, leg.prior)
+      else await deps.adapter.delete(deps.vaultName, leg.coll, leg.id)
+      await leg.handle._compensateRevertedWrite(leg.id)
+    } catch {
+      // best-effort, matches `revertExecuted` semantics (with-commit/tx/transaction.ts:632) —
+      // surfacing a revert-path failure would mask the original error that triggered the rollback.
+    }
+  }
+}
+
+/** Split `record` across the pair by `spec.fields`, base leg first, satellite leg second. */
+export async function joinedPut(deps: FanoutDeps, id: string, record: Record<string, unknown>): Promise<void> {
+  deps.registry.assertNotPoisoned(deps.spec.satellite)
+  const base = unwrap(deps.base())
+  const satellite = unwrap(deps.satellite())
+  const satFields = new Set(deps.spec.fields)
+  const baseRec: Record<string, unknown> = {}
+  const satRec: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(record)) (satFields.has(k) ? satRec : baseRec)[k] = v
+  // Pre-validate BOTH legs before any adapter write — an invalid satellite
+  // field must abort with zero writes, not a half-applied base leg.
+  await base.validateInput(baseRec)
+  await satellite.validateInput(satRec)
+  return deps.registry.withPairLock(deps.spec.base, async () => {
+    const executed: Leg[] = []
+    const run = async (handle: CollectionHandle, coll: string, rec: Record<string, unknown>): Promise<void> => {
+      executed.push({ coll, id, prior: await deps.adapter.get(deps.vaultName, coll, id), handle })
+      await handle.put(id, rec)
+    }
+    try {
+      await run(base, deps.spec.base, baseRec)          // base leg FIRST (convergence rule 3)
+      await run(satellite, deps.spec.satellite, satRec)
+    } catch (err) {
+      await revertAndCompensate(deps, executed)
+      throw err
+    }
+  })
+}
+
+/** Remove both legs of the pair, satellite first, base second. */
+export async function pairDelete(deps: FanoutDeps, id: string): Promise<void> {
+  const base = unwrap(deps.base())
+  const satellite = unwrap(deps.satellite())
+  return deps.registry.withPairLock(deps.spec.base, async () => {
+    const executed: Leg[] = []
+    const run = async (handle: CollectionHandle, coll: string): Promise<void> => {
+      executed.push({ coll, id, prior: await deps.adapter.get(deps.vaultName, coll, id), handle })
+      await handle.delete(id)
+    }
+    try {
+      await run(satellite, deps.spec.satellite)         // satellite leg FIRST (convergence rule 3)
+      await run(base, deps.spec.base)
+    } catch (err) {
+      await revertAndCompensate(deps, executed)
+      throw err
+    }
+  })
+}

--- a/packages/hub/src/with-shape/satellites/forget.ts
+++ b/packages/hub/src/with-shape/satellites/forget.ts
@@ -14,10 +14,23 @@
  *   - the synthesized ref's tombstone write can be held to R-S4 fail-loud
  *     semantics distinct from a base ref's existing resilient handling.
  *
- * The synthesized ref is appended to the SAME list the caller iterates, so it
+ * The synthesized ref is INTERLEAVED into the SAME list the caller iterates —
+ * immediately BEFORE its base ref, not appended after the whole list — so it
  * traverses every purge stage below the tombstone (history, `_idx`/`_ftindex`,
  * blobs, `_sealed`/`_sealed_cek`, vectors) identically to a base ref — there
  * is no separate satellite-only code path.
+ *
+ * Ordering is load-bearing (retry black hole, #591 review C1): `vault.forget()`'s
+ * per-ref loop removes each ref's subject-index entry (the retry anchor) only
+ * at the END of that ref's own iteration. If the satellite ref instead ran
+ * AFTER its base ref (as a simple append), an R-S4 abort mid-satellite-ref (or
+ * a crash) would leave the base ref already fully processed — including its
+ * subject-index entry already removed — so a retried `forget(subjectId)` finds
+ * nothing to resolve and returns a clean, empty result while the satellite's
+ * heavy data stays un-shredded forever. Interleaving the satellite ref BEFORE
+ * its base ref means any R-S4 abort happens before the base's subject-index
+ * anchor is touched, so a retry re-discovers the same base ref (and
+ * re-synthesizes its satellite ref) until both actually shred.
  */
 import type { SubjectRef } from '../../with-audit/forget/subject-index.js'
 import type { SatelliteRegistry } from './registry.js'
@@ -38,10 +51,15 @@ export function expandRefsWithSatellites(
   registry: SatelliteRegistry | null,
 ): ReadonlyArray<SubjectRef | SatelliteSubjectRef> {
   if (registry === null) return refs
-  const satRefs: SatelliteSubjectRef[] = []
+  const out: Array<SubjectRef | SatelliteSubjectRef> = []
+  let anySat = false
   for (const ref of refs) {
     const spec = registry.satelliteOf(ref.collection)
-    if (spec) satRefs.push({ collection: spec.satellite, id: ref.id, satelliteOf: ref.collection })
+    if (spec) {
+      anySat = true
+      out.push({ collection: spec.satellite, id: ref.id, satelliteOf: ref.collection })
+    }
+    out.push(ref)
   }
-  return satRefs.length === 0 ? refs : [...refs, ...satRefs]
+  return anySat ? out : refs
 }

--- a/packages/hub/src/with-shape/satellites/forget.ts
+++ b/packages/hub/src/with-shape/satellites/forget.ts
@@ -1,0 +1,47 @@
+/**
+ * Forget fan-out (#591, Task 8): expands the base refs resolved from the
+ * encrypted subject index with a synthesized same-id ref for every base ref
+ * whose collection has a declared satellite.
+ *
+ * A satellite record is NEVER itself indexed in `_subject_index` (its writes
+ * only ever go through `joinedPut`, which never touches the subject-field
+ * write hook — see `noydb.ts#registerForgetHooks`), so `lookupSubject` alone
+ * would leave the satellite half of a pair permanently un-erasable. The
+ * synthesized ref carries `satelliteOf` (the base collection name) so:
+ *   - `vault.forget()`'s classification line can inherit `perRecordKeys`
+ *     from the BASE's forget-strategy entry (the satellite itself is never a
+ *     `subjects` key), and
+ *   - the synthesized ref's tombstone write can be held to R-S4 fail-loud
+ *     semantics distinct from a base ref's existing resilient handling.
+ *
+ * The synthesized ref is appended to the SAME list the caller iterates, so it
+ * traverses every purge stage below the tombstone (history, `_idx`/`_ftindex`,
+ * blobs, `_sealed`/`_sealed_cek`, vectors) identically to a base ref — there
+ * is no separate satellite-only code path.
+ */
+import type { SubjectRef } from '../../with-audit/forget/subject-index.js'
+import type { SatelliteRegistry } from './registry.js'
+
+/** A subject ref synthesized from a base ref via a declared satellite pairing. */
+export interface SatelliteSubjectRef extends SubjectRef {
+  readonly satelliteOf: string
+}
+
+/**
+ * Expand `refs` (as resolved by `lookupSubject`) with one synthesized ref per
+ * base ref whose collection has a registered satellite. `registry` may be
+ * `null` (no satellite ever declared in this vault) — returns `refs`
+ * unchanged, byte-identical to pre-#591 behaviour.
+ */
+export function expandRefsWithSatellites(
+  refs: readonly SubjectRef[],
+  registry: SatelliteRegistry | null,
+): ReadonlyArray<SubjectRef | SatelliteSubjectRef> {
+  if (registry === null) return refs
+  const satRefs: SatelliteSubjectRef[] = []
+  for (const ref of refs) {
+    const spec = registry.satelliteOf(ref.collection)
+    if (spec) satRefs.push({ collection: spec.satellite, id: ref.id, satelliteOf: ref.collection })
+  }
+  return satRefs.length === 0 ? refs : [...refs, ...satRefs]
+}

--- a/packages/hub/src/with-shape/satellites/index.ts
+++ b/packages/hub/src/with-shape/satellites/index.ts
@@ -1,0 +1,3 @@
+/** Satellite collections barrel — spec/schema types + config error (#591). @module */
+export type { SatelliteSpec, PairingMarker, JoinedHandle } from './types.js'
+export { SatelliteConfigError } from '../../kernel/errors.js'

--- a/packages/hub/src/with-shape/satellites/joined.ts
+++ b/packages/hub/src/with-shape/satellites/joined.ts
@@ -14,7 +14,6 @@
  * fan-out (`joinedPut`/`pairDelete`), which already holds the pair lock and
  * reverts on partial failure — this module adds no write logic of its own.
  */
-import type { NoydbStore } from '../../kernel/types.js'
 import type { JoinedHandle, SatelliteSpec } from './types.js'
 import type { FanoutDeps } from './fanout.js'
 import { joinedPut, pairDelete } from './fanout.js'
@@ -27,11 +26,7 @@ type CollectionHandle = any
 export function makeJoinedHandle<T extends Record<string, unknown>>(spec: SatelliteSpec, deps: FanoutDeps): JoinedHandle<T> {
   const base = (): CollectionHandle => deps.base()
   const satellite = (): CollectionHandle => deps.satellite()
-  // `FanoutDeps.adapter` is narrowed to fan-out's own get/put/delete needs;
-  // `isBaseLive`/`liveBaseIdSet` want the full `NoydbStore` (they also call
-  // `.list`). The object handed in (`vault.joined()`'s `this.adapter`)
-  // always IS the full adapter — widen the type back.
-  const adapter = deps.adapter as unknown as NoydbStore
+  const adapter = deps.adapter // `FanoutDeps.adapter` is the full `NoydbStore` (#591 review M2)
 
   // Every declared satellite field defaults to null — a record with no
   // satellite row yet (or a not-yet-populated field) reads as null rather

--- a/packages/hub/src/with-shape/satellites/joined.ts
+++ b/packages/hub/src/with-shape/satellites/joined.ts
@@ -1,0 +1,79 @@
+/**
+ * JoinedHandle — the full-record access point for a base↔satellite pair
+ * declared with `joined:` (#591, Task 7). Deliberately narrow (spec § The
+ * model): get/put/delete/list/describe only, never a `Collection<T>` cast —
+ * reactive members (`subscribe`, `live`, …) are simply absent from the
+ * returned object, not stubbed.
+ *
+ * Reads compose under existence authority (spec § Convergence & existence
+ * authority, rule 1): the base row alone decides whether a record exists at
+ * all — `get`/`list` check it via an undecrypted adapter read
+ * (`isBaseLive`/`liveBaseIdSet`) before merging in the satellite side, so a
+ * base-absent-or-tombstoned id reads as fully gone even if a satellite
+ * envelope still lingers. Writes/deletes delegate wholesale to the Task 6
+ * fan-out (`joinedPut`/`pairDelete`), which already holds the pair lock and
+ * reverts on partial failure — this module adds no write logic of its own.
+ */
+import type { NoydbStore } from '../../kernel/types.js'
+import type { JoinedHandle, SatelliteSpec } from './types.js'
+import type { FanoutDeps } from './fanout.js'
+import { joinedPut, pairDelete } from './fanout.js'
+import { isBaseLive, liveBaseIdSet } from './existence.js'
+import { listWithIds } from './proxy.js'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type CollectionHandle = any
+
+export function makeJoinedHandle<T extends Record<string, unknown>>(spec: SatelliteSpec, deps: FanoutDeps): JoinedHandle<T> {
+  const base = (): CollectionHandle => deps.base()
+  const satellite = (): CollectionHandle => deps.satellite()
+  // `FanoutDeps.adapter` is narrowed to fan-out's own get/put/delete needs;
+  // `isBaseLive`/`liveBaseIdSet` want the full `NoydbStore` (they also call
+  // `.list`). The object handed in (`vault.joined()`'s `this.adapter`)
+  // always IS the full adapter — widen the type back.
+  const adapter = deps.adapter as unknown as NoydbStore
+
+  // Every declared satellite field defaults to null — a record with no
+  // satellite row yet (or a not-yet-populated field) reads as null rather
+  // than simply missing.
+  const nullSat = (): Record<string, null> => Object.fromEntries(spec.fields.map(f => [f, null]))
+  // Base spread last: R-S1 guarantees satellite `fields` never overlap the
+  // base schema (postRegister's cross-check), so this is inert on satellite
+  // keys — base wins ties defensively only.
+  const merge = (b: Record<string, unknown>, s: Record<string, unknown> | null): T =>
+    ({ ...nullSat(), ...(s ?? {}), ...b }) as T
+
+  return {
+    async get(id) {
+      if (!(await isBaseLive(adapter, deps.vaultName, spec.base, id))) return null
+      const b = await base().get(id)
+      if (b === null) return null
+      const s = await satellite().get(id) // proxied handle: existence-safe, lock-free
+      return merge(b, s)
+    },
+    async put(id, record) {
+      await joinedPut(deps, id, record)
+    },
+    async delete(id) {
+      await pairDelete(deps, id)
+    },
+    async list() {
+      const live = await liveBaseIdSet(adapter, deps.vaultName, spec.base)
+      const pairs = await listWithIds(base())
+      const out: T[] = []
+      for (const [id, b] of pairs) {
+        if (!live.has(id)) continue
+        out.push(merge(b as Record<string, unknown>, await satellite().get(id)))
+      }
+      return out
+    },
+    async describe() {
+      const [b, s] = await Promise.all([base().describe({}), satellite().describe({})])
+      return {
+        collection: spec.joined ?? `${spec.base}+${spec.satellite}`,
+        fields: [...b.fields, ...s.fields],
+        meta: { label: spec.joined ?? spec.base },
+      }
+    },
+  }
+}

--- a/packages/hub/src/with-shape/satellites/marker.ts
+++ b/packages/hub/src/with-shape/satellites/marker.ts
@@ -1,0 +1,32 @@
+import type { NoydbStore } from '../../kernel/types.js'
+import type { EnclaveKey } from '../../kernel/enclave/index.js'
+import { SatelliteConfigError } from '../../kernel/errors.js'
+import { hashFields } from './validate.js'
+import type { PairingMarker, SatelliteSpec } from './types.js'
+
+/**
+ * Persist-or-reconcile the pairing marker in `_schemas/<satellite>`.
+ * First declaration writes { base, fieldsHash, joined }; later declarations
+ * must match exactly or are refused (R-S9). Lazy imports keep the satellite
+ * spine tree-shakeable (config-drift.ts pattern).
+ */
+export async function ensureSatelliteMarker(
+  store: NoydbStore, vaultName: string, spec: SatelliteSpec, dek: EnclaveKey,
+): Promise<void> {
+  const next: PairingMarker = { base: spec.base, fieldsHash: hashFields(spec.fields), joined: spec.joined }
+  const { loadPersistedSchema } = await import('../persisted-schemas/storage.js')
+  const persisted = await loadPersistedSchema(store, vaultName, spec.satellite, dek)
+  const prior = persisted?.satellite
+  if (prior) {
+    if (prior.base !== next.base || prior.fieldsHash !== next.fieldsHash || (prior.joined ?? null) !== (next.joined ?? null)) {
+      throw new SatelliteConfigError(
+        `R-S9: satellite "${spec.satellite}" re-declared divergently from its persisted pairing marker ` +
+        `(persisted base="${prior.base}" fieldsHash=${prior.fieldsHash}; declared base="${next.base}" fieldsHash=${next.fieldsHash}). ` +
+        `Evolve the marker deliberately, don't redeclare.`,
+      )
+    }
+    return
+  }
+  const { persistSatelliteMarker } = await import('../persisted-schemas/register.js')
+  await persistSatelliteMarker({ store, vault: vaultName, collectionName: spec.satellite, dek, marker: next })
+}

--- a/packages/hub/src/with-shape/satellites/post-register.ts
+++ b/packages/hub/src/with-shape/satellites/post-register.ts
@@ -1,0 +1,31 @@
+import type { NoydbStore } from '../../kernel/types.js'
+import type { EnclaveKey } from '../../kernel/enclave/index.js'
+import type { SatelliteSpec } from './types.js'
+import type { SatelliteRegistry } from './registry.js'
+import { ensureSatelliteMarker } from './marker.js'
+
+/** Async post-registration: R-S9 marker reconcile + R-S1/R-S5 derivable-schema cross-check. Failures poison, never throw. */
+export async function postRegister(
+  store: NoydbStore, vaultName: string, spec: SatelliteSpec,
+  getDEK: (collectionName: string) => Promise<EnclaveKey>,
+  baseSchema: unknown, registry: SatelliteRegistry,
+): Promise<void> {
+  try {
+    await ensureSatelliteMarker(store, vaultName, spec, await getDEK(spec.satellite))
+  } catch (err) {
+    registry.poison(spec.satellite, (err as Error).message); return
+  }
+  if (baseSchema !== undefined) {
+    try {
+      const { derivePersistedSchema } = await import('../persisted-schemas/derive.js')
+      const envelope = await derivePersistedSchema(baseSchema)
+      const properties = (envelope.jsonSchema as Record<string, unknown> | null)?.['properties'] as Record<string, unknown> | undefined
+      const baseFields: string[] = Object.keys(properties ?? {})
+      const overlap = spec.fields.filter(f => baseFields.includes(f))
+      if (overlap.length > 0) {
+        registry.poison(spec.satellite,
+          `R-S1: satellite "${spec.satellite}" fields overlap the base schema: ${overlap.join(', ')} — routing must be unambiguous.`)
+      }
+    } catch { /* non-derivable validator → cross-check unavailable, by design (spec R-S5) */ }
+  }
+}

--- a/packages/hub/src/with-shape/satellites/proxy.ts
+++ b/packages/hub/src/with-shape/satellites/proxy.ts
@@ -1,4 +1,5 @@
 import { SatelliteConfigError } from '../../kernel/errors.js'
+import { findByDet as detFindByDet, queryByDet as detQueryByDet } from '../../kernel/enclave/record-keys/deterministic.js'
 import { isBaseLive, liveBaseIdSet } from './existence.js'
 import { pairDelete } from './fanout.js'
 import { RAW_TARGET } from './raw-target.js'
@@ -119,6 +120,38 @@ export function makeSatelliteProxy(target: any, spec: SatelliteSpec, registry: S
       const hits = await target.similarTo(vector, opts)
       return filterLiveHits(hits, adapter, vaultName, spec.base)
     },
+    // #591 Task 9 review fix: findByDet/queryByDet scan envelopes straight
+    // off the adapter (kernel/enclave/record-keys/deterministic.ts) and
+    // return BARE records (no id), so a post-filter can't correlate a match
+    // back to its base row. Instead the scan itself is scoped: re-run the
+    // same det functions over the collection's own DeterministicContext
+    // (`detContext()` is private like `adapter`/`cache` above) with its
+    // `adapter.list` narrowed to live-base ids — a dead-base match is then
+    // never visited, so findByDet correctly continues to a later live match
+    // rather than short-circuiting on a ghost.
+    async findByDet(field: string, value: unknown) {
+      return detFindByDet(liveScopedDetContext(), field, value)
+    },
+    async queryByDet(field: string, value: unknown) {
+      return detQueryByDet(liveScopedDetContext(), field, value)
+    },
+  }
+
+  const liveScopedDetContext = () => {
+    const ctx = target.detContext()
+    const raw = ctx.adapter as NoydbStore
+    return {
+      ...ctx,
+      adapter: {
+        ...raw,
+        get: raw.get.bind(raw),
+        async list(v: string, c: string) {
+          const ids = await raw.list(v, c)
+          const live = await Promise.all(ids.map((id) => isBaseLive(adapter, vaultName, spec.base, id)))
+          return ids.filter((_, i) => live[i])
+        },
+      },
+    }
   }
 
   return new Proxy(target, {

--- a/packages/hub/src/with-shape/satellites/proxy.ts
+++ b/packages/hub/src/with-shape/satellites/proxy.ts
@@ -8,6 +8,31 @@ import type { SatelliteRegistry } from './registry.js'
 export { RAW_TARGET }
 
 /**
+ * Correlates a collection handle's `list()` output with the ids implied by
+ * cache-insertion order — `list()` returns bare records (no `id` field
+ * unless the caller put one), so ids are recovered positionally against the
+ * cache's own key order instead. Read AFTER `target.list()` resolves, so a
+ * not-yet-hydrated cache on the first read doesn't race a still-empty key
+ * snapshot. Invariant: `list()` must preserve cache-insertion order
+ * (collection.ts `list()` maps `[...cache.values()]`) — positional
+ * correlation depends on it. Drops any record whose position has no
+ * corresponding cache key (should not happen in practice; defensive only).
+ * Exported so `joined.ts` (#591, Task 7) can get the same [id, record]
+ * correlation for the base side without duplicating this logic.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function listWithIds(target: any): Promise<Array<[string, unknown]>> {
+  const records = await target.list()
+  const ids = [...(target.cache as Map<string, unknown>).keys()]
+  const out: Array<[string, unknown]> = []
+  for (let i = 0; i < records.length; i++) {
+    const id = ids[i]
+    if (id !== undefined) out.push([id, records[i]])
+  }
+  return out
+}
+
+/**
  * Wraps a satellite's real `Collection<T>` in a `Proxy` that enforces
  * existence authority (spec § Convergence & existence authority, rule 1)
  * and R-S6 on top of it. Every member not explicitly overridden below
@@ -40,15 +65,8 @@ export function makeSatelliteProxy(target: any, spec: SatelliteSpec, registry: S
     },
     async list() {
       const live = await liveBaseIdSet(adapter, vaultName, spec.base)
-      const records = await target.list()
-      // `list()` returns bare records (no `id` field unless the caller put
-      // one) — correlate by position against the cache's own key order
-      // instead. Read AFTER `target.list()` resolves, so a not-yet-hydrated
-      // cache on the first read doesn't race a still-empty key snapshot.
-      // Invariant: list() must preserve cache-insertion order (collection.ts
-      // list() maps [...cache.values()]) — positional key correlation depends on it.
-      const ids = [...(target.cache as Map<string, unknown>).keys()]
-      return records.filter((_: unknown, i: number) => { const id = ids[i]; return id !== undefined && live.has(id) })
+      const pairs = await listWithIds(target)
+      return pairs.filter(([id]) => live.has(id)).map(([, record]) => record)
     },
     query: queryNotExistenceFiltered,
     async put(id: string, record: unknown) {

--- a/packages/hub/src/with-shape/satellites/proxy.ts
+++ b/packages/hub/src/with-shape/satellites/proxy.ts
@@ -1,0 +1,80 @@
+import { SatelliteConfigError } from '../../kernel/errors.js'
+import { isBaseLive, liveBaseIdSet } from './existence.js'
+import type { SatelliteSpec } from './types.js'
+import type { SatelliteRegistry } from './registry.js'
+
+/**
+ * Escape hatch: `proxied[RAW_TARGET]` returns the unwrapped collection —
+ * no existence check, no pair lock. Needed by callers (e.g. a later
+ * fan-out task's joined-handle writes) that already hold the pair mutex
+ * themselves; going back through the proxy's `put` would re-enter
+ * `registry.withPairLock` on the same base and deadlock (the mutex is not
+ * reentrant — see `registry.ts:withPairLock`).
+ */
+export const RAW_TARGET: unique symbol = Symbol('noydb.satellite.rawTarget')
+
+/**
+ * Wraps a satellite's real `Collection<T>` in a `Proxy` that enforces
+ * existence authority (spec § Convergence & existence authority, rule 1)
+ * and R-S6 on top of it. Every member not explicitly overridden below
+ * falls through to the real collection unchanged — this is why the full
+ * ~50-member surface (describe, count, putMany, …) survives without
+ * hand-stubbing. Caches nothing: every call re-checks live base state.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function makeSatelliteProxy(target: any, spec: SatelliteSpec, registry: SatelliteRegistry): any {
+  // Same private internals `Collection.putManyAtomic` reaches for
+  // (collection.ts:3223) — TypeScript `private` is compile-time only.
+  const adapter = target.adapter
+  const vaultName = target.vault
+
+  const queryNotExistenceFiltered = (): never => {
+    throw new Error(
+      `satellite "${spec.satellite}": query() is not existence-filtered. Query's terminal ` +
+      `methods (toArray/first/count) read the in-memory cache synchronously, while existence ` +
+      `authority (§ Convergence & existence authority, rule 1) requires an async, undecrypted ` +
+      `check against live base state — the two shapes don't compose without either breaking ` +
+      `query()'s synchronous contract or accepting a check that misses out-of-band base ` +
+      `mutations. Use list() (or get()) for existence-safe reads on satellite collections.`,
+    )
+  }
+
+  const overrides: Record<string, unknown> = {
+    async get(id: string) {
+      if (!(await isBaseLive(adapter, vaultName, spec.base, id))) return null
+      return target.get(id)
+    },
+    async list() {
+      const live = await liveBaseIdSet(adapter, vaultName, spec.base)
+      const records = await target.list()
+      // `list()` returns bare records (no `id` field unless the caller put
+      // one) — correlate by position against the cache's own key order
+      // instead. Read AFTER `target.list()` resolves, so a not-yet-hydrated
+      // cache on the first read doesn't race a still-empty key snapshot.
+      const ids = [...(target.cache as Map<string, unknown>).keys()]
+      return records.filter((_: unknown, i: number) => { const id = ids[i]; return id !== undefined && live.has(id) })
+    },
+    query: queryNotExistenceFiltered,
+    async put(id: string, record: unknown) {
+      registry.assertNotPoisoned(spec.satellite)
+      return registry.withPairLock(spec.base, async () => {
+        if (!(await isBaseLive(adapter, vaultName, spec.base, id))) {
+          throw new SatelliteConfigError(
+            `R-S6: satellite "${spec.satellite}" put for "${id}" with no live base record in ` +
+            `"${spec.base}" — create the base first (or write through the joined handle).`,
+          )
+        }
+        return target.put(id, record)
+      })
+    },
+  }
+
+  return new Proxy(target, {
+    get(t, prop, _recv) {
+      if (prop === RAW_TARGET) return t
+      if (typeof prop === 'string' && prop in overrides) return overrides[prop]
+      const v = Reflect.get(t, prop, t)
+      return typeof v === 'function' ? v.bind(t) : v
+    },
+  })
+}

--- a/packages/hub/src/with-shape/satellites/proxy.ts
+++ b/packages/hub/src/with-shape/satellites/proxy.ts
@@ -78,32 +78,88 @@ export function makeSatelliteProxy(target: any, spec: SatelliteSpec, registry: S
     )
   }
 
+  // Pulled out of the `overrides` object literal (rather than inlined) so
+  // `getMany`/`putMany` below can loop through the SAME existence/lock/poison
+  // logic a single get/put applies — the real `Collection.getMany`/`putMany`
+  // bind their internal `this.get`/`this.put` calls to the RAW target (see
+  // `listWithIds` header + I1, #591 review), which is exactly how a bulk call
+  // through this proxy used to bypass existence filtering and R-S6/poison/lock.
+  const getOne = async (id: string): Promise<unknown> => {
+    if (!(await isBaseLive(adapter, vaultName, spec.base, id))) return null
+    return target.get(id)
+  }
+  const putOne = async (id: string, record: unknown): Promise<unknown> => {
+    return registry.withPairLock(spec.base, async () => {
+      // Poison check INSIDE the lock: a put queued behind a section that
+      // poisons the pair (e.g. a fan-out's failure path) must observe the
+      // poison after acquiring, not race past a pre-lock check.
+      registry.assertNotPoisoned(spec.satellite)
+      if (!(await isBaseLive(adapter, vaultName, spec.base, id))) {
+        throw new SatelliteConfigError(
+          `R-S6: satellite "${spec.satellite}" put for "${id}" with no live base record in ` +
+          `"${spec.base}" — create the base first (or write through the joined handle).`,
+        )
+      }
+      return target.put(id, record)
+    })
+  }
+
   const overrides: Record<string, unknown> = {
-    async get(id: string) {
-      if (!(await isBaseLive(adapter, vaultName, spec.base, id))) return null
-      return target.get(id)
-    },
+    get: getOne,
     async list() {
       const live = await liveBaseIdSet(adapter, vaultName, spec.base)
       const pairs = await listWithIds(target)
       return pairs.filter(([id]) => live.has(id)).map(([, record]) => record)
     },
     query: queryNotExistenceFiltered,
-    async put(id: string, record: unknown) {
-      return registry.withPairLock(spec.base, async () => {
-        // Poison check INSIDE the lock: a put queued behind a section that
-        // poisons the pair (e.g. a fan-out's failure path) must observe the
-        // poison after acquiring, not race past a pre-lock check.
-        registry.assertNotPoisoned(spec.satellite)
-        if (!(await isBaseLive(adapter, vaultName, spec.base, id))) {
-          throw new SatelliteConfigError(
-            `R-S6: satellite "${spec.satellite}" put for "${id}" with no live base record in ` +
-            `"${spec.base}" — create the base first (or write through the joined handle).`,
-          )
-        }
-        return target.put(id, record)
-      })
+    put: putOne,
+    // #591 review I1: the real `getMany` loops `this.get(id)` bound to the raw
+    // target, never this proxy's existence-filtered `get` — same Map<id, T|null>
+    // shape, built from the overridden single-get instead.
+    async getMany(ids: readonly string[]) {
+      const result = new Map<string, unknown>()
+      for (const id of ids) result.set(id, await getOne(id))
+      return result
     },
+    // #591 review I1: the real `putMany` (non-atomic) loops `this.put(id, record)`
+    // bound to the raw target, bypassing R-S6/pair-lock/poison per item; looping
+    // through the overridden single-put here restores that per-item enforcement
+    // while preserving the real putMany's { ok, success, failures } shape — a
+    // refused item becomes a failure entry, not a thrown error. Atomic mode is a
+    // single transaction by design (looping per-item `put` would break its
+    // all-or-nothing revert guarantee), so instead the WHOLE call is refused
+    // with R-S6 up front, under the pair lock + poison check, if any id lacks a
+    // live base — only then does it delegate to the real atomic executor.
+    async putMany(entries: ReadonlyArray<readonly [string, unknown, unknown?]>, options?: { atomic?: boolean }) {
+      if (options?.atomic) {
+        return registry.withPairLock(spec.base, async () => {
+          registry.assertNotPoisoned(spec.satellite)
+          for (const [id] of entries) {
+            if (!(await isBaseLive(adapter, vaultName, spec.base, id))) {
+              throw new SatelliteConfigError(
+                `R-S6: satellite "${spec.satellite}" putMany(atomic) refused — "${id}" has no live base record in "${spec.base}".`,
+              )
+            }
+          }
+          return target.putMany(entries, options)
+        })
+      }
+      const success: string[] = []
+      const failures: Array<{ id: string; error: Error }> = []
+      for (const [id, record] of entries) {
+        try {
+          await putOne(id, record)
+          success.push(id)
+        } catch (error) {
+          failures.push({ id, error: error as Error })
+        }
+      }
+      return { ok: failures.length === 0, success, failures }
+    },
+    // No `deleteMany` override: the real `deleteMany` loops the raw
+    // `this.delete(id)` too, but this proxy never overrides single `delete`
+    // (satellite delete is legal, unguarded — see makeBaseProxy for the leg
+    // that DOES need fan-out) — there is nothing for a bulk delete to bypass.
     // #591 Task 9: search/retrieve/similarTo answer from the search facade's
     // own cache/index (never the get/list overrides above), so they need
     // their own existence post-filter — every retrieval surface the facade
@@ -165,21 +221,41 @@ export function makeSatelliteProxy(target: any, spec: SatelliteSpec, registry: S
 }
 
 /**
- * Wraps a satellite's BASE collection in a `Proxy` whose only override is
- * `delete` — routed through `pairDelete` (this task) so removing a base
- * record also removes its satellite row, in order, with revert-on-failure.
- * `satellite()` is a thunk, not a resolved handle: at the moment a base is
- * first requested the paired satellite may not exist yet in some call
- * orders, and `fanout.ts` re-resolves + unwraps it lazily per call anyway.
+ * Wraps a satellite's BASE collection in a `Proxy` whose overrides are
+ * `delete` and `deleteMany` — both routed through `pairDelete` (this task) so
+ * removing a base record also removes its satellite row, in order, with
+ * revert-on-failure. `satellite()` is a thunk, not a resolved handle: at the
+ * moment a base is first requested the paired satellite may not exist yet in
+ * some call orders, and `fanout.ts` re-resolves + unwraps it lazily per call
+ * anyway.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function makeBaseProxy(target: any, spec: SatelliteSpec, registry: SatelliteRegistry, satellite: () => unknown): any {
   const adapter = target.adapter
   const vaultName = target.vault
 
+  // #591 review I1: the real `deleteMany` loops `this.delete(id)` bound to the
+  // raw target, bypassing this proxy's own `delete` override entirely — a
+  // base deleteMany would silently orphan every satellite row instead of
+  // fanning out. Pulled out so both `delete` and `deleteMany` share it.
+  const deleteOne = async (id: string): Promise<void> => {
+    return pairDelete({ spec, base: () => target, satellite, adapter, vaultName, registry }, id)
+  }
+
   const overrides: Record<string, unknown> = {
-    async delete(id: string) {
-      return pairDelete({ spec, base: () => target, satellite, adapter, vaultName, registry }, id)
+    delete: deleteOne,
+    async deleteMany(ids: readonly string[]) {
+      const success: string[] = []
+      const failures: Array<{ id: string; error: Error }> = []
+      for (const id of ids) {
+        try {
+          await deleteOne(id)
+          success.push(id)
+        } catch (error) {
+          failures.push({ id, error: error as Error })
+        }
+      }
+      return { ok: failures.length === 0, success, failures }
     },
   }
 

--- a/packages/hub/src/with-shape/satellites/proxy.ts
+++ b/packages/hub/src/with-shape/satellites/proxy.ts
@@ -2,6 +2,7 @@ import { SatelliteConfigError } from '../../kernel/errors.js'
 import { isBaseLive, liveBaseIdSet } from './existence.js'
 import { pairDelete } from './fanout.js'
 import { RAW_TARGET } from './raw-target.js'
+import type { NoydbStore } from '../../kernel/types.js'
 import type { SatelliteSpec } from './types.js'
 import type { SatelliteRegistry } from './registry.js'
 
@@ -30,6 +31,24 @@ export async function listWithIds(target: any): Promise<Array<[string, unknown]>
     if (id !== undefined) out.push([id, records[i]])
   }
   return out
+}
+
+/**
+ * Existence-filter a search/retrieve hit array in place, id-scoped to the
+ * hits actually returned (never a full `liveBaseIdSet` scan — #591 Task 9).
+ * `search()`/`retrieve()`/`similarTo()` answer from the facade's own eager
+ * cache / lexical index (`with-lookup/search/collection-facade.ts`), which
+ * never observes the proxy's existence check — this closes that leak as a
+ * pure post-filter: the persisted `_ftindex` posting is never touched.
+ */
+async function filterLiveHits<H extends { id: string }>(
+  hits: readonly H[],
+  adapter: NoydbStore,
+  vaultName: string,
+  base: string,
+): Promise<H[]> {
+  const live = await Promise.all(hits.map((h) => isBaseLive(adapter, vaultName, base, h.id)))
+  return hits.filter((_, i) => live[i])
 }
 
 /**
@@ -83,6 +102,22 @@ export function makeSatelliteProxy(target: any, spec: SatelliteSpec, registry: S
         }
         return target.put(id, record)
       })
+    },
+    // #591 Task 9: search/retrieve/similarTo answer from the search facade's
+    // own cache/index (never the get/list overrides above), so they need
+    // their own existence post-filter — every retrieval surface the facade
+    // exposes is covered here.
+    async search(field: string, query: string, opts?: unknown) {
+      const hits = await target.search(field, query, opts)
+      return filterLiveHits(hits, adapter, vaultName, spec.base)
+    },
+    async retrieve(query: string, opts?: unknown) {
+      const hits = await target.retrieve(query, opts)
+      return filterLiveHits(hits, adapter, vaultName, spec.base)
+    },
+    async similarTo(vector: Float32Array, opts?: unknown) {
+      const hits = await target.similarTo(vector, opts)
+      return filterLiveHits(hits, adapter, vaultName, spec.base)
     },
   }
 

--- a/packages/hub/src/with-shape/satellites/proxy.ts
+++ b/packages/hub/src/with-shape/satellites/proxy.ts
@@ -1,5 +1,5 @@
 import { SatelliteConfigError } from '../../kernel/errors.js'
-import { findByDet as detFindByDet, queryByDet as detQueryByDet } from '../../kernel/enclave/record-keys/deterministic.js'
+import { findByDet as detFindByDet, queryByDet as detQueryByDet } from '../../kernel/enclave/index.js'
 import { isBaseLive, liveBaseIdSet } from './existence.js'
 import { pairDelete } from './fanout.js'
 import { RAW_TARGET } from './raw-target.js'

--- a/packages/hub/src/with-shape/satellites/proxy.ts
+++ b/packages/hub/src/with-shape/satellites/proxy.ts
@@ -1,17 +1,11 @@
 import { SatelliteConfigError } from '../../kernel/errors.js'
 import { isBaseLive, liveBaseIdSet } from './existence.js'
+import { pairDelete } from './fanout.js'
+import { RAW_TARGET } from './raw-target.js'
 import type { SatelliteSpec } from './types.js'
 import type { SatelliteRegistry } from './registry.js'
 
-/**
- * Escape hatch: `proxied[RAW_TARGET]` returns the unwrapped collection —
- * no existence check, no pair lock. Needed by callers (e.g. a later
- * fan-out task's joined-handle writes) that already hold the pair mutex
- * themselves; going back through the proxy's `put` would re-enter
- * `registry.withPairLock` on the same base and deadlock (the mutex is not
- * reentrant — see `registry.ts:withPairLock`).
- */
-export const RAW_TARGET: unique symbol = Symbol('noydb.satellite.rawTarget')
+export { RAW_TARGET }
 
 /**
  * Wraps a satellite's real `Collection<T>` in a `Proxy` that enforces
@@ -71,6 +65,35 @@ export function makeSatelliteProxy(target: any, spec: SatelliteSpec, registry: S
         }
         return target.put(id, record)
       })
+    },
+  }
+
+  return new Proxy(target, {
+    get(t, prop, _recv) {
+      if (prop === RAW_TARGET) return t
+      if (typeof prop === 'string' && prop in overrides) return overrides[prop]
+      const v = Reflect.get(t, prop, t)
+      return typeof v === 'function' ? v.bind(t) : v
+    },
+  })
+}
+
+/**
+ * Wraps a satellite's BASE collection in a `Proxy` whose only override is
+ * `delete` — routed through `pairDelete` (this task) so removing a base
+ * record also removes its satellite row, in order, with revert-on-failure.
+ * `satellite()` is a thunk, not a resolved handle: at the moment a base is
+ * first requested the paired satellite may not exist yet in some call
+ * orders, and `fanout.ts` re-resolves + unwraps it lazily per call anyway.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function makeBaseProxy(target: any, spec: SatelliteSpec, registry: SatelliteRegistry, satellite: () => unknown): any {
+  const adapter = target.adapter
+  const vaultName = target.vault
+
+  const overrides: Record<string, unknown> = {
+    async delete(id: string) {
+      return pairDelete({ spec, base: () => target, satellite, adapter, vaultName, registry }, id)
     },
   }
 

--- a/packages/hub/src/with-shape/satellites/proxy.ts
+++ b/packages/hub/src/with-shape/satellites/proxy.ts
@@ -29,7 +29,7 @@ export function makeSatelliteProxy(target: any, spec: SatelliteSpec, registry: S
   const vaultName = target.vault
 
   const queryNotExistenceFiltered = (): never => {
-    throw new Error(
+    throw new SatelliteConfigError(
       `satellite "${spec.satellite}": query() is not existence-filtered. Query's terminal ` +
       `methods (toArray/first/count) read the in-memory cache synchronously, while existence ` +
       `authority (§ Convergence & existence authority, rule 1) requires an async, undecrypted ` +
@@ -51,13 +51,18 @@ export function makeSatelliteProxy(target: any, spec: SatelliteSpec, registry: S
       // one) — correlate by position against the cache's own key order
       // instead. Read AFTER `target.list()` resolves, so a not-yet-hydrated
       // cache on the first read doesn't race a still-empty key snapshot.
+      // Invariant: list() must preserve cache-insertion order (collection.ts
+      // list() maps [...cache.values()]) — positional key correlation depends on it.
       const ids = [...(target.cache as Map<string, unknown>).keys()]
       return records.filter((_: unknown, i: number) => { const id = ids[i]; return id !== undefined && live.has(id) })
     },
     query: queryNotExistenceFiltered,
     async put(id: string, record: unknown) {
-      registry.assertNotPoisoned(spec.satellite)
       return registry.withPairLock(spec.base, async () => {
+        // Poison check INSIDE the lock: a put queued behind a section that
+        // poisons the pair (e.g. a fan-out's failure path) must observe the
+        // poison after acquiring, not race past a pre-lock check.
+        registry.assertNotPoisoned(spec.satellite)
         if (!(await isBaseLive(adapter, vaultName, spec.base, id))) {
           throw new SatelliteConfigError(
             `R-S6: satellite "${spec.satellite}" put for "${id}" with no live base record in ` +

--- a/packages/hub/src/with-shape/satellites/raw-target.ts
+++ b/packages/hub/src/with-shape/satellites/raw-target.ts
@@ -1,0 +1,14 @@
+/**
+ * Escape hatch: `proxied[RAW_TARGET]` returns the unwrapped collection — no
+ * existence check, no pair lock, no fan-out. Needed by callers (`fanout.ts`,
+ * a proxy's own internals) that already hold the pair mutex themselves;
+ * going back through a proxy's `put`/`delete` would re-enter
+ * `registry.withPairLock` on the same base and deadlock (non-reentrant —
+ * see `registry.ts:withPairLock`) or recurse forever (the base proxy's
+ * `delete` calls `pairDelete`, which must not call back into it).
+ *
+ * Lives in its own module (not `proxy.ts`) so `fanout.ts` can import it
+ * without creating a `proxy.ts` ⇄ `fanout.ts` import cycle — `proxy.ts`
+ * imports `pairDelete` from `fanout.ts` for `makeBaseProxy`.
+ */
+export const RAW_TARGET: unique symbol = Symbol('noydb.satellite.rawTarget')

--- a/packages/hub/src/with-shape/satellites/registry.ts
+++ b/packages/hub/src/with-shape/satellites/registry.ts
@@ -1,0 +1,54 @@
+import { SatelliteConfigError } from '../../kernel/errors.js'
+import type { SatelliteSpec } from './types.js'
+
+export class SatelliteRegistry {
+  private readonly byBase = new Map<string, SatelliteSpec>()
+  private readonly bySat = new Map<string, SatelliteSpec>()
+  private readonly byJoin = new Map<string, SatelliteSpec>()
+  private readonly poisoned = new Map<string, string>()
+  private readonly locks = new Map<string, Promise<unknown>>()
+
+  register(spec: SatelliteSpec): void {
+    if (this.byBase.has(spec.base)) {
+      throw new SatelliteConfigError(`R-S1: base "${spec.base}" already has satellite "${this.byBase.get(spec.base)!.satellite}" — v1 allows exactly one satellite per base.`)
+    }
+    const taken = (n: string) => this.byBase.has(n) || this.bySat.has(n) || this.byJoin.has(n)
+    if (spec.joined !== undefined && taken(spec.joined)) {
+      throw new SatelliteConfigError(`R-S5: joined name "${spec.joined}" collides with an existing pair member or joined name.`)
+    }
+    this.byBase.set(spec.base, spec)
+    this.bySat.set(spec.satellite, spec)
+    if (spec.joined !== undefined) this.byJoin.set(spec.joined, spec)
+  }
+
+  satelliteOf(base: string): SatelliteSpec | null { return this.byBase.get(base) ?? null }
+  bySatellite(name: string): SatelliteSpec | null { return this.bySat.get(name) ?? null }
+  byJoined(name: string): SatelliteSpec | null { return this.byJoin.get(name) ?? null }
+  isPairMember(name: string): boolean { return this.byBase.has(name) || this.bySat.has(name) }
+  allSpecs(): readonly SatelliteSpec[] { return [...this.byBase.values()] }
+
+  expandNames(names: readonly string[]): string[] {
+    const out = new Set(names)
+    for (const n of names) {
+      const asBase = this.byBase.get(n); if (asBase) out.add(asBase.satellite)
+      const asSat = this.bySat.get(n); if (asSat) out.add(asSat.base)
+    }
+    return [...out]
+  }
+
+  poison(satellite: string, reason: string): void { this.poisoned.set(satellite, reason) }
+  assertNotPoisoned(satellite: string): void {
+    const reason = this.poisoned.get(satellite)
+    if (reason !== undefined) throw new SatelliteConfigError(reason)
+  }
+
+  /** Per-base async mutex: chains sections on a stored promise tail. */
+  async withPairLock<R>(base: string, fn: () => Promise<R>): Promise<R> {
+    const tail = this.locks.get(base) ?? Promise.resolve()
+    let release!: () => void
+    const gate = new Promise<void>(res => { release = res })
+    this.locks.set(base, tail.then(() => gate))
+    await tail
+    try { return await fn() } finally { release() }
+  }
+}

--- a/packages/hub/src/with-shape/satellites/registry.ts
+++ b/packages/hub/src/with-shape/satellites/registry.ts
@@ -12,6 +12,14 @@ export class SatelliteRegistry {
     if (this.byBase.has(spec.base)) {
       throw new SatelliteConfigError(`R-S1: base "${spec.base}" already has satellite "${this.byBase.get(spec.base)!.satellite}" — v1 allows exactly one satellite per base.`)
     }
+    // R-S3, order-inverted direction: `spec.satellite` was already declared as
+    // a BASE (some other satellite is satelliteOf it) — registering it as a
+    // satellite of `spec.base` too would form a satellite-of-satellite chain.
+    // The other direction (satelliteOf pointing straight at a satellite) is
+    // caught synchronously in validate.ts BEFORE register() is ever called.
+    if (this.byBase.has(spec.satellite)) {
+      throw new SatelliteConfigError(`R-S3: "${spec.satellite}" is itself registered as a base (of "${this.byBase.get(spec.satellite)!.satellite}") — no satellite-of-satellite chains.`)
+    }
     const taken = (n: string) => this.byBase.has(n) || this.bySat.has(n) || this.byJoin.has(n)
     if (spec.joined !== undefined && taken(spec.joined)) {
       throw new SatelliteConfigError(`R-S5: joined name "${spec.joined}" collides with an existing pair member or joined name.`)

--- a/packages/hub/src/with-shape/satellites/types.ts
+++ b/packages/hub/src/with-shape/satellites/types.ts
@@ -1,0 +1,29 @@
+import type { CollectionDescription } from '../introspection/describe.js'
+
+/** One base↔satellite pair. v1: exactly one satellite per base. */
+export interface SatelliteSpec {
+  readonly base: string
+  readonly satellite: string
+  readonly fields: readonly string[]
+  readonly joined?: string | undefined
+}
+
+/** Persisted into `_schemas/<satellite>` under `x-satellite` (R-S9 drift guard). */
+export interface PairingMarker {
+  readonly base: string
+  readonly fieldsHash: string
+  readonly joined?: string | undefined
+}
+
+/**
+ * The full-record handle — deliberately NARROW (spec § The model): never a
+ * `Collection<T>` cast. `describe()` works (the @noy-db/ui contract);
+ * reactive APIs are absent from the type entirely.
+ */
+export interface JoinedHandle<T extends Record<string, unknown> = Record<string, unknown>> {
+  get(id: string): Promise<T | null>
+  put(id: string, record: T): Promise<void>
+  delete(id: string): Promise<void>
+  list(): Promise<T[]>
+  describe(): Promise<CollectionDescription>
+}

--- a/packages/hub/src/with-shape/satellites/validate.ts
+++ b/packages/hub/src/with-shape/satellites/validate.ts
@@ -1,0 +1,53 @@
+import { SatelliteConfigError } from '../../kernel/errors.js'
+import type { SatelliteSpec } from './types.js'
+
+export interface SatelliteDeclarationInput {
+  readonly satellite: string
+  readonly satelliteOf: string
+  readonly fields: readonly string[] | undefined
+  readonly joined?: string | undefined
+  /** True when the named base is itself registered as a satellite (R-S3). */
+  readonly baseIsSatellite: boolean
+  /** True when the declaring collection (or its base) sets crdtMode (R-S8). */
+  readonly crdtMode: boolean
+}
+
+/** Sync declaration refusals R-S3/R-S5/R-S8. Async cross-checks live in registry.ts. */
+export function validateSatelliteDeclaration(input: SatelliteDeclarationInput): SatelliteSpec {
+  if (input.baseIsSatellite) {
+    throw new SatelliteConfigError(
+      `R-S3: "${input.satellite}" declares satelliteOf "${input.satelliteOf}", which is itself a satellite — no satellite-of-satellite chains.`,
+    )
+  }
+  if (input.crdtMode) {
+    throw new SatelliteConfigError(
+      `R-S8: crdtMode is refused on either member of a satellite pair in v1 (revert cannot compensate a merge).`,
+    )
+  }
+  if (!input.fields || input.fields.length === 0) {
+    throw new SatelliteConfigError(`R-S5: satellite "${input.satellite}" must declare a non-empty fields list.`)
+  }
+  if (input.fields.includes('id')) {
+    throw new SatelliteConfigError(`R-S5: fields must not contain the shared key "id".`)
+  }
+  if (input.joined !== undefined && (input.joined === input.satellite || input.joined === input.satelliteOf)) {
+    throw new SatelliteConfigError(`R-S5: joined name "${input.joined}" collides with a pair member.`)
+  }
+  return Object.freeze({
+    base: input.satelliteOf,
+    satellite: input.satellite,
+    fields: Object.freeze([...input.fields]),
+    joined: input.joined,
+  })
+}
+
+/** Order-insensitive stable hash of the fields list (FNV-1a over the sorted, joined names). */
+export function hashFields(fields: readonly string[]): string {
+  const s = [...fields].sort().join('')
+  let h = 0x811c9dc5
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = Math.imul(h, 0x01000193) >>> 0
+  }
+  return h.toString(16)
+}

--- a/packages/hub/src/with-shape/satellites/validate.ts
+++ b/packages/hub/src/with-shape/satellites/validate.ts
@@ -10,6 +10,8 @@ export interface SatelliteDeclarationInput {
   readonly baseIsSatellite: boolean
   /** True when the declaring collection (or its base) sets crdtMode (R-S8). */
   readonly crdtMode: boolean
+  /** True when `joined` names an already-declared plain (non-pair) collection (R-S5). */
+  readonly joinedCollidesWithCollection: boolean
 }
 
 /** Sync declaration refusals R-S3/R-S5/R-S8. Async cross-checks live in registry.ts. */
@@ -33,6 +35,9 @@ export function validateSatelliteDeclaration(input: SatelliteDeclarationInput): 
   if (input.joined !== undefined && (input.joined === input.satellite || input.joined === input.satelliteOf)) {
     throw new SatelliteConfigError(`R-S5: joined name "${input.joined}" collides with a pair member.`)
   }
+  if (input.joinedCollidesWithCollection) {
+    throw new SatelliteConfigError(`R-S5: joined name "${input.joined}" collides with an already-declared collection.`)
+  }
   return Object.freeze({
     base: input.satelliteOf,
     satellite: input.satellite,
@@ -43,7 +48,9 @@ export function validateSatelliteDeclaration(input: SatelliteDeclarationInput): 
 
 /** Order-insensitive stable hash of the fields list (FNV-1a over the sorted, joined names). */
 export function hashFields(fields: readonly string[]): string {
-  const s = [...fields].sort().join('')
+  // '\x1f' (unit separator) — NOT '' — joins the sorted names: an empty
+  // delimiter collapses ['ab'] and ['a', 'b'] onto the same hash.
+  const s = [...fields].sort().join('\x1f')
   let h = 0x811c9dc5
   for (let i = 0; i < s.length; i++) {
     h ^= s.charCodeAt(i)

--- a/packages/hub/tsup.config.ts
+++ b/packages/hub/tsup.config.ts
@@ -47,6 +47,7 @@ const ENTRIES = {
   'util/index': 'src/kernel/util/index.ts',
   'attestation/index': 'src/with-audit/attestation/index.ts',
   'classified/index': 'src/with-shape/classified/index.ts',
+  'satellites/index': 'src/with-shape/satellites/index.ts',
   'tiers/index': 'src/with-audit/tiers/index.ts',
   'portability/index': 'src/with-audit/portability/index.ts',
   'kernel/index': 'src/legacy/kernel.ts',

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -851,7 +851,15 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 3898→3949 (2026-07-07, #591 satellites archetype-③ — thin call-sites only
   // (declare/joined accessor/proxy wrap/forget ref-expansion/pair-sync hooks); heavy
   // logic in with-shape/satellites): documented actual post-implementation line count.
-  'packages/hub/src/kernel/vault.ts': 3949,
+  // Bumped 3949→3956 (2026-07-07, #591 final-review I2/R-S8 fix): two new
+  // `SatelliteDeclareContext` ctx-accessor lines (`getBaseCrdt`/`collectionExists`,
+  // thin call-sites only) + a 4-line R-S8-direction-(ii) guard near the top of
+  // `collection()` (refuses constructing — fresh OR already-cached — a satellite
+  // pair member with crdt AFTER the pair already exists; must run before the
+  // `if (!coll)` construction branch, since re-declaring an ALREADY-cached
+  // collection with a new option skips that branch entirely) — still a thin
+  // call-site; the R-S8 refusal logic itself lives in with-shape/satellites/validate.ts.
+  'packages/hub/src/kernel/vault.ts': 3956,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -446,6 +446,8 @@ const SCHEMA_DECLARED_OR_INFRA_EXEMPT = new Set([
   'with-shape/money',
   'with-shape/persisted-schemas',
   'with-shape/schema-update',
+  // #591 satellites — satelliteOf/fields/joined declaration on collection(); joined handle via vault.joined()
+  'with-shape/satellites',
   'with-party/directory',
   'with-party/policy',
   'with-pod',
@@ -686,7 +688,10 @@ const KERNEL_SURFACE_BUDGET = {
   // Merge 2026-07-05 (#582 ∪ #267/#580): reconciled to the TRUE post-merge line
   // count — collection.ts now carries #267's lazy-strategy extraction AND this
   // branch's findByDigest/scrubEquatableTags together. Not loosened past the real count.
-  'packages/hub/src/kernel/collection.ts': 4647,
+  // Bumped 4647→4662 (2026-07-07, #591 satellites archetype-③ — thin call-sites only
+  // (declare/joined accessor/proxy wrap/forget ref-expansion/pair-sync hooks); heavy
+  // logic in with-shape/satellites): documented actual post-implementation line count.
+  'packages/hub/src/kernel/collection.ts': 4662,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -843,7 +848,10 @@ const KERNEL_SURFACE_BUDGET = {
   // guard at the collection() door — a genuinely-core trust-boundary check
   // (closes a granted-principal read path to `_sync_credentials`) that sits
   // alongside the existing _dict_/_links_ reserved-name guards.
-  'packages/hub/src/kernel/vault.ts': 3898,
+  // Bumped 3898→3949 (2026-07-07, #591 satellites archetype-③ — thin call-sites only
+  // (declare/joined accessor/proxy wrap/forget ref-expansion/pair-sync hooks); heavy
+  // logic in with-shape/satellites): documented actual post-implementation line count.
+  'packages/hub/src/kernel/vault.ts': 3949,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),
@@ -938,7 +946,10 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 2357→2360 (2026-07-04, #267 lazy service): three lazyStrategy
   // pass-through spread lines (one per Vault construction site) — standard
   // strategy plumbing, no logic.
-  'packages/hub/src/kernel/noydb.ts': 2360,
+  // Bumped 2360→2367 (2026-07-07, #591 satellites archetype-③ — thin call-sites only
+  // (declare/joined accessor/proxy wrap/forget ref-expansion/pair-sync hooks); heavy
+  // logic in with-shape/satellites): documented actual post-implementation line count.
+  'packages/hub/src/kernel/noydb.ts': 2367,
 }
 
 function checkKernelSurface() {
@@ -1311,6 +1322,14 @@ const PRE_EXISTING_SPINE_SERVICE_IMPORTS = new Map([
     '../with-shape/links/lazy-handle.js',
     '../with-shape/links/names.js',
     '../with-shape/links/vault-facade.js',
+    // #591 satellites — ③ schema feature (declare/joined accessor/proxy wrap/
+    // forget ref-expansion), thin call-sites only; heavy logic in with-shape/satellites
+    '../with-shape/satellites/declare.js',
+    '../with-shape/satellites/forget.js',
+    '../with-shape/satellites/joined.js',
+    '../with-shape/satellites/proxy.js',
+    '../with-shape/satellites/registry.js',
+    '../with-shape/satellites/types.js',
     '../with-shape/schema-update/fence-controller.js',
     '../with-shape/schema-update/fence-watcher.js',
     '../with-shape/schema-update/fence.js',
@@ -1591,6 +1610,13 @@ const PRE_EXISTING_BODY_ACCESS = new Map([
   ['packages/hub/src/with-shape/introspection/walk.ts', 1],
   ['packages/hub/src/with-shape/links/link-set.ts', 5],
   ['packages/hub/src/with-shape/persisted-schemas/storage.ts', 2],
+  // #591 satellites — existence authority (spec § Convergence & existence
+  // authority, rule 1): one undecrypted envelope-shape check (`_iv === '' &&
+  // _data === ''`, mirroring the tombstone shape) on the store's raw `get()`.
+  // No `encrypted` flag is threaded to existence.ts's call sites, so
+  // isTombstone()'s two-arg contract doesn't drop in cleanly; reviewed as a
+  // deliberate, narrow exception rather than growing the barrel's contract.
+  ['packages/hub/src/with-shape/satellites/existence.ts', 2],
   ['packages/hub/src/with-shape/schema-update/client-registry.ts', 3],
   ['packages/hub/src/with-shape/schema-update/fence.ts', 3],
   ['packages/hub/src/with-store/route-store.ts', 1],


### PR DESCRIPTION
Implements satellite collections v1 per the spec + plan carried by #592 (this PR is **stacked on `docs/satellite-collections-spec`** — merge #592 first, then retarget/merge this one). Closes #591.

## What

Off-row storage for heavy fields: a base + satellite collection pair (1:1 on record id) with explicit `fields` routing, a narrow-typed `JoinedHandle` via `vault.joined()`, persisted pairing marker (R-S9), existence-authority read filtering across every handle surface (get/list/search/retrieve/similarTo/findByDet/queryByDet/getMany + bundle export), ordered fan-out writes with hardened best-effort revert, forget fan-out through the full purge suite with residue-classification inheritance, and pair-unit sync semantics (filter expansion + pair-coupled conflict resolvers).

**Archetype-③ home:** `packages/hub/src/with-shape/satellites/` (11 modules); kernel files carry only thin call-sites (ceiling bumps are exact documented actuals: collection 4662 / vault 3956 / noydb 2367, metric = wc-l+1).

## Process

29 commits, built task-by-task from the 14-task plan with a fresh implementer + task-scoped review (spec + quality) per task, fixes re-reviewed, then a final whole-branch review on the most capable model. The final review caught one Critical no task-scoped review could see — the **forget-retry black hole** (appended satellite refs vs per-ref subject-index consumption: an R-S4 abort + retry stranded un-shredded heavy data behind a clean `ForgetResult`) — fixed by interleaving each satellite ref before its base ref, with a retry conformance vector.

## Gates

Full hub suite **3355/3355** green (12 satellite test files, 89 satellite tests incl. 9 cross-cutting conformance vectors) · typecheck (3 configs) · lint · `check:architecture` OK · knip satellite-clean · build green (`dist/satellites/`) · kernel-api golden updated deliberately for `vault.joined` · zero Claude attribution across all commits.

## Honest caveats (carry-overs the reviewers pinned)

- **Docs-repo follow-up required:** `features.yaml` / `SPEC.md` / `docs/subsystems/satellites.md` / showcases live in the `noy-db-docs` sibling repo (this repo's CLAUDE.md is stale on the extraction) — cross-repo docs PR needed post-merge. Commit `aaeb2095`'s message overclaims these; that commit is guard/exemption/subpath work only.
- **Static imports, not lazy:** the archetype-③ spine ships statically (grandfathered, matching classified/i18n precedent; floor +2.4% gz, bundle gate green); only marker/post-register/dead-filter reads are lazy. Disclosed as spec amendment 5.
- **#590 dependency:** post-forget resurrection containment is observational-only until tombstone-terminal pull lands; no vector claims prevention.
- **R-S7 retro-coverage migration gap:** the refusal has no wired satellite-CEK migration path past it yet (only the generic unwired `_applyCutoverTransform`).
- **Documented races:** first-declaration marker window (export briefly sees a plain collection) and its mirror (divergent-redeclare before async poison lands).
- **Out of scope by design:** `pushFiltered`/`SyncTransaction` predicate paths (not pair-expanded), `count()`/pagination (outside the existence-filter enumeration), satellite `query()` refuses loudly (sync-cache vs async-existence, spec amendment 1).
- **Follow-up issues to file:** R-S1 label double-use (registry one-per-base vs spec fields-overlap), failed-leg revert can drop a pre-existing dirty entry (narrow sync edge), stale marker on reused collection name (systemic `_schemas` pattern), sync conflict-resolution cache staleness (pre-existing, general).

Spec: `docs/superpowers/specs/2026-07-05-satellite-collections-design.md` (DRAFT v3 + 5 implementation amendments) · Plan: `docs/superpowers/plans/2026-07-07-satellite-collections.md` · Related: #588 #589 #590