### PR TITLE
fix(hub): sync tombstone-terminal rule — forget() survives sync (#590) + sync-applied cache invalidation (#598)

### DIFF
--- a/docs/superpowers/plans/2026-07-09-sync-tombstone-terminal.md
+++ b/docs/superpowers/plans/2026-07-09-sync-tombstone-terminal.md
@@ -1,0 +1,863 @@
+# Sync Tombstone-Terminal Rule Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make crypto-shred tombstones terminal in sync (#590: pull/push can never resurrect a forgotten record; the shred propagates and re-asserts in both directions) and route every sync-applied local write through Collection cache invalidation (#598).
+
+**Architecture:** A shape-only tombstone predicate (`isTombstoneShape`) lets the `SyncEngine` recognize erasures without per-collection context. Terminal-rule checks run before any version comparison or conflict resolver in `pull()`, `push()`, and `pushFiltered()`. `_writeTombstone` gains an `onDirty` call so shreds ride the normal push channel. A `setCacheInvalidator` hook (same injection pattern as `setPairExpander`) is wired from `Noydb.openVault` to `Vault._invalidateSyncApplied`.
+
+**Tech Stack:** TypeScript ESM, vitest, pnpm. All work in `packages/hub`. Spec: `docs/superpowers/specs/2026-07-08-sync-tombstone-terminal-design.md`.
+
+## Global Constraints
+
+- **No Claude attribution** in any commit message, PR, or changelog (family-wide hard rule).
+- **Hub stays portable** — no Node built-ins in `packages/hub/src/**`; `crypto.subtle` only (no crypto needed here anyway).
+- **Frozen seams untouched**: do NOT export any new name from `src/legacy/kernel.ts`, `src/with-cargo/index.ts`, or `src/legacy/adapter.ts`. New types go in `src/kernel/types.ts` + the main entry `src/index.ts` only.
+- **TDD**: every behavior change lands with its failing test first.
+- All commands below run from the **repo root** (`/Users/vicio/lanna-db/noy-db`) unless noted.
+- Match existing file style: `push()`/`pushFiltered()` are intentionally parallel near-duplicates — mirror changes into both, do not refactor them together.
+- Branch: `fix/590-sync-tombstone-terminal` (already created; spec committed).
+
+## Shared test harness (used by Tasks 1, 3, 4, 5, 6)
+
+All new tests live in ONE new file: `packages/hub/__tests__/sync-tombstone-terminal.test.ts`. Task 1 creates it with this header + helpers; later tasks append `describe` blocks to it.
+
+```ts
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot, ErasureEnforcement } from '../src/kernel/types.js'
+import { ConflictError } from '../src/kernel/errors.js'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { withSync } from '../src/with-party/sync/index.js'
+import { withForgetCascade } from '../src/with-audit/forget/index.js'
+import { isTombstoneShape } from '../src/kernel/enclave/record-keys/tombstone.js'
+
+/** In-memory store (mirrors the harness in sync.test.ts). */
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) }
+    },
+  }
+}
+
+/** A crypto-shred tombstone as `buildTombstone` mints it. */
+function tombstoneEnv(v: number, ts = new Date().toISOString()): EncryptedEnvelope {
+  return { _noydb: 1, _v: v, _ts: ts, _iv: '', _data: '' }
+}
+
+interface Note { body: string; subjectId?: string }
+const V = 'V1'
+```
+
+Run file: `pnpm vitest run packages/hub/__tests__/sync-tombstone-terminal.test.ts`
+
+---
+
+### Task 1: `isTombstoneShape` predicate
+
+**Files:**
+- Modify: `packages/hub/src/kernel/enclave/record-keys/tombstone.ts`
+- Create (Test): `packages/hub/__tests__/sync-tombstone-terminal.test.ts` (harness above + this describe)
+
+**Interfaces:**
+- Produces: `isTombstoneShape(envelope: EncryptedEnvelope): boolean` exported from `src/kernel/enclave/record-keys/tombstone.js` — Tasks 3/4 import it into `sync.ts`.
+
+- [ ] **Step 1: Write the failing test** — create the test file with the shared harness, then append:
+
+```ts
+describe('isTombstoneShape', () => {
+  it('recognises the buildTombstone shape and nothing else', () => {
+    expect(isTombstoneShape(tombstoneEnv(3))).toBe(true)
+    // live encrypted envelope: non-empty _data
+    expect(isTombstoneShape({ _noydb: 1, _v: 1, _ts: 'x', _iv: 'abc', _data: 'ciphertext' })).toBe(false)
+    // unencrypted record envelope: non-empty JSON _data, empty _iv
+    expect(isTombstoneShape({ _noydb: 1, _v: 1, _ts: 'x', _iv: '', _data: '{"a":1}' })).toBe(false)
+    // _sync meta shape: empty _iv, non-empty _data
+    expect(isTombstoneShape({ _noydb: 1, _v: 1, _ts: 'x', _iv: '', _data: '{"dirty":[]}' })).toBe(false)
+    // empty _data but a wrapped CEK present → not a shred
+    expect(isTombstoneShape({ _noydb: 1, _v: 1, _ts: 'x', _iv: '', _data: '', _cek: 'wrapped' })).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run packages/hub/__tests__/sync-tombstone-terminal.test.ts`
+Expected: FAIL — `isTombstoneShape` is not exported.
+
+- [ ] **Step 3: Implement** — in `tombstone.ts`, add below `isTombstone` and make `isTombstone` delegate:
+
+```ts
+/**
+ * Shape-only tombstone recognition for layers that have no per-collection
+ * context (the sync engine, #590): a tombstone carries an empty `_data` and
+ * no wrapped CEK. No live envelope can match — record bodies never serialize
+ * to the empty string (the `_sync` meta envelope carries non-empty `_data`,
+ * and legacy migration envelopes carry non-empty `_iv`/`_data`).
+ */
+export function isTombstoneShape(envelope: EncryptedEnvelope): boolean {
+  return envelope._data === '' && envelope._cek === undefined
+}
+```
+
+and change the body of `isTombstone` to:
+
+```ts
+export function isTombstone(envelope: EncryptedEnvelope, encrypted: boolean): boolean {
+  if (!encrypted) return false
+  return isTombstoneShape(envelope)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes** — same command, expected: PASS.
+
+- [ ] **Step 5: Regression + commit**
+
+```bash
+pnpm vitest run packages/hub/src/kernel packages/hub/__tests__/forget-sealed-erasure.test.ts
+git add packages/hub/src/kernel/enclave/record-keys/tombstone.ts packages/hub/__tests__/sync-tombstone-terminal.test.ts
+git commit -m "feat(hub): shape-only tombstone predicate for context-free layers (#590)"
+```
+
+---
+
+### Task 2: Types — `ErasureEnforcement`, `erasures` on results, `'sync:erasure'` event
+
+**Files:**
+- Modify: `packages/hub/src/kernel/types.ts` (Conflict/results block ~1188–1285; `NoydbEventMap` ~1334)
+- Modify: `packages/hub/src/index.ts` (type export list, `PullResult` is at ~:101)
+
+**Interfaces:**
+- Produces (Tasks 3/4 construct these; consumers read them):
+
+```ts
+export interface ErasureEnforcement {
+  readonly vault: string
+  readonly collection: string
+  readonly id: string
+  /** The winning tombstone (as stored after enforcement). */
+  readonly tombstone: EncryptedEnvelope
+  /** The live envelope that lost: a suppressed dirty local edit, or the remote copy destroyed by re-assertion. */
+  readonly suppressed: EncryptedEnvelope
+  readonly direction: 'pull' | 'push'
+}
+```
+
+- [ ] **Step 1: Add the type** — in `kernel/types.ts`, insert the `ErasureEnforcement` interface (exact code above, with a doc comment referencing #590) directly after the `Conflict` interface.
+
+- [ ] **Step 2: Extend the results** — append to both `PushResult` and `PullResult`:
+
+```ts
+  /** #590: tombstone enforcements applied during this run (never resolver-visible). */
+  readonly erasures?: ErasureEnforcement[]
+```
+
+- [ ] **Step 3: Extend the event map** — in `NoydbEventMap` next to `'sync:pull'`:
+
+```ts
+  'sync:erasure': ErasureEnforcement
+```
+
+- [ ] **Step 4: Export from the main entry** — in `src/index.ts`, add `ErasureEnforcement,` to the type list containing `PullResult` (~:101). Do NOT touch `src/legacy/kernel.ts`, `src/with-cargo/index.ts`, or `src/legacy/adapter.ts`.
+
+- [ ] **Step 5: Verify + commit**
+
+Run: `pnpm --filter @noy-db/hub typecheck` — expected: PASS.
+Run: `pnpm vitest run packages/hub/__tests__/cargo-surface-golden.test.ts packages/hub/__tests__/kernel-surface-golden.test.ts` — expected: PASS (surfaces unchanged). If a golden test fails, you exported into a seam — undo Step 4's location, do not update the golden files.
+
+```bash
+git add packages/hub/src/kernel/types.ts packages/hub/src/index.ts
+git commit -m "feat(hub): ErasureEnforcement type, erasures on sync results, sync:erasure event (#590)"
+```
+
+---
+
+### Task 3: Pull terminal rule + engine-side invalidator plumbing
+
+**Files:**
+- Modify: `packages/hub/src/with-party/team/sync.ts` (`pull()` ~:265–343; new private members)
+- Test: `packages/hub/__tests__/sync-tombstone-terminal.test.ts` (append describe)
+
+**Interfaces:**
+- Consumes: `isTombstoneShape` (Task 1), `ErasureEnforcement` (Task 2).
+- Produces (used by Task 4 in push paths, wired by Task 6):
+  - `setCacheInvalidator(fn: (collection: string, id: string) => Promise<void>): void` (public)
+  - `private applyRemote(collection: string, id: string, envelope: EncryptedEnvelope): Promise<void>`
+  - `private reportErasure(collection: string, id: string, tombstone: EncryptedEnvelope, suppressed: EncryptedEnvelope, direction: 'pull' | 'push'): ErasureEnforcement`
+  - `private reassertTombstone(collection: string, id: string, tombstone: EncryptedEnvelope, suppressedRemote: EncryptedEnvelope): Promise<ErasureEnforcement>`
+
+- [ ] **Step 1: Write the failing tests** — append to the test file:
+
+```ts
+describe('pull tombstone-terminal rule (#590)', () => {
+  async function setup(conflict?: 'local-wins') {
+    const local = inlineMemory(); const remote = inlineMemory()
+    const db = await createNoydb({
+      store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false,
+      ...(conflict ? { conflict } : {}),
+    })
+    const vault = await db.openVault(V)
+    const notes = vault.collection<Note>('notes')
+    return { local, remote, db, notes }
+  }
+
+  it('a remote tombstone beats a newer dirty local edit — enforced, dirty dropped, reported, resolver bypassed', async () => {
+    const { local, remote, db, notes } = await setup('local-wins')
+    await notes.put('n1', { body: 'v1' })
+    await db.push(V)                                      // both sides at _v=1
+    await notes.put('n1', { body: 'offline edit' })       // dirty, _v=2
+    await remote.put(V, 'notes', 'n1', tombstoneEnv(1))   // another device shredded it
+
+    const events: ErasureEnforcement[] = []
+    db.on('sync:erasure', e => events.push(e))
+    const pull = await db.pull(V)
+
+    expect((await local.get(V, 'notes', 'n1'))!._data).toBe('')  // enforced despite local-wins + higher local _v
+    expect(pull.erasures).toHaveLength(1)
+    expect(pull.erasures![0]!.direction).toBe('pull')
+    expect(pull.erasures![0]!.suppressed._v).toBe(2)
+    expect(pull.conflicts).toHaveLength(0)                       // never a resolvable conflict
+    expect(events).toHaveLength(1)
+
+    const push = await db.push(V)
+    expect(push.pushed).toBe(0)                                  // suppressed edit is not pushed
+    db.close()
+  })
+
+  it('a remote tombstone over a non-dirty stale copy applies silently (no erasure report)', async () => {
+    const { local, remote, db, notes } = await setup()
+    await notes.put('n1', { body: 'v1' })
+    await db.push(V)                                      // clean
+    await remote.put(V, 'notes', 'n1', tombstoneEnv(1))
+    const pull = await db.pull(V)
+    expect((await local.get(V, 'notes', 'n1'))!._data).toBe('')
+    expect(pull.erasures ?? []).toHaveLength(0)
+    db.close()
+  })
+
+  it('a local tombstone is never overwritten by a higher-_v live remote — re-asserted outward with a bumped _v', async () => {
+    const { local, remote, db, notes } = await setup()
+    await notes.put('n1', { body: 'v1' })
+    await db.push(V)
+    const live = (await remote.get(V, 'notes', 'n1'))!
+    await local.put(V, 'notes', 'n1', tombstoneEnv(1))    // local shred residue
+    await remote.put(V, 'notes', 'n1', { ...live, _v: 3 }) // offline peer's later edit
+
+    const pull = await db.pull(V)
+
+    expect((await local.get(V, 'notes', 'n1'))!._data).toBe('')
+    const remoteEnv = (await remote.get(V, 'notes', 'n1'))!
+    expect(remoteEnv._data).toBe('')                       // remote re-tombstoned
+    expect(remoteEnv._v).toBe(3)                           // bumped to the suppressed _v
+    expect((await local.get(V, 'notes', 'n1'))!._v).toBe(3)
+    expect(pull.erasures).toHaveLength(1)
+    expect(pull.erasures![0]!.suppressed._v).toBe(3)
+    db.close()
+  })
+
+  it('re-assert at equal _v: remote live copy is tombstoned without a bump', async () => {
+    const { local, remote, db, notes } = await setup()
+    await notes.put('n1', { body: 'v1' })
+    await db.push(V)
+    await local.put(V, 'notes', 'n1', tombstoneEnv(1))
+    const pull = await db.pull(V)
+    const remoteEnv = (await remote.get(V, 'notes', 'n1'))!
+    expect(remoteEnv._data).toBe('')
+    expect(remoteEnv._v).toBe(1)
+    expect(pull.erasures).toHaveLength(1)
+    db.close()
+  })
+
+  it('both sides tombstoned: higher _v wins, nothing reported', async () => {
+    const { local, remote, db } = await setup()
+    await local.put(V, 'notes', 'n1', tombstoneEnv(1))
+    await remote.put(V, 'notes', 'n1', tombstoneEnv(4))
+    const pull = await db.pull(V)
+    expect((await local.get(V, 'notes', 'n1'))!._v).toBe(4)
+    expect(pull.erasures ?? []).toHaveLength(0)
+    db.close()
+  })
+
+  it('modifiedSince never skips an arriving tombstone (but still skips old live envelopes)', async () => {
+    const { local, remote, db, notes } = await setup()
+    await notes.put('n1', { body: 'v1' })
+    await notes.put('n2', { body: 'v1' })
+    await db.push(V)
+    await remote.put(V, 'notes', 'n1', tombstoneEnv(2, '2000-01-01T00:00:00.000Z'))
+    const oldLive = (await remote.get(V, 'notes', 'n2'))!
+    await remote.put(V, 'notes', 'n2', { ...oldLive, _v: 2, _ts: '2000-01-01T00:00:00.000Z' })
+
+    await db.pull(V, { modifiedSince: '2020-01-01T00:00:00.000Z' })
+
+    expect((await local.get(V, 'notes', 'n1'))!._data).toBe('')  // tombstone exempt from the filter
+    expect((await local.get(V, 'notes', 'n2'))!._v).toBe(1)      // old live envelope still filtered
+    db.close()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run packages/hub/__tests__/sync-tombstone-terminal.test.ts`
+Expected: the new describe FAILS (tombstones overwritten / no `erasures` field); Task 1's describe still passes.
+
+- [ ] **Step 3: Implement in `sync.ts`**
+
+3a. Import: add `isTombstoneShape` to the imports from a new line: `import { isTombstoneShape } from '../../kernel/enclave/record-keys/tombstone.js'`, and add `ErasureEnforcement` to the type import list from `'../../kernel/types.js'`.
+
+3b. New members on `SyncEngine` (below `pairExpander`):
+
+```ts
+  /** #598: refreshes Collection in-memory views after a sync-applied local write. Wired by the vault at open. */
+  private cacheInvalidator?: (collection: string, id: string) => Promise<void>
+
+  /** Wire the Collection-cache invalidation hook (#598). Same injection pattern as `setPairExpander`. */
+  setCacheInvalidator(fn: (collection: string, id: string) => Promise<void>): void {
+    this.cacheInvalidator = fn
+  }
+```
+
+3c. Private helpers (place near `handleConflict`):
+
+```ts
+  /** Apply an envelope to the local store and refresh in-memory views (#598). */
+  private async applyRemote(collection: string, id: string, envelope: EncryptedEnvelope): Promise<void> {
+    await this.local.put(this.vault, collection, id, envelope)
+    await this.cacheInvalidator?.(collection, id)
+  }
+
+  /** Record + emit a tombstone enforcement (#590). */
+  private reportErasure(
+    collection: string, id: string,
+    tombstone: EncryptedEnvelope, suppressed: EncryptedEnvelope,
+    direction: 'pull' | 'push',
+  ): ErasureEnforcement {
+    const enforcement: ErasureEnforcement = { vault: this.vault, collection, id, tombstone, suppressed, direction }
+    this.emitter.emit('sync:erasure', enforcement)
+    return enforcement
+  }
+
+  /**
+   * Re-assert a local tombstone over a live remote envelope (#590): the shred
+   * wins in both directions, regardless of `_v`. Bumps the tombstone to the
+   * suppressed envelope's `_v` when higher so per-key version counters stay
+   * monotonic on every store; `_by` (the shredding actor) is preserved.
+   */
+  private async reassertTombstone(
+    collection: string, id: string,
+    tombstone: EncryptedEnvelope, suppressedRemote: EncryptedEnvelope,
+  ): Promise<ErasureEnforcement> {
+    let winner = tombstone
+    if (suppressedRemote._v > tombstone._v) {
+      winner = { ...tombstone, _v: suppressedRemote._v, _ts: new Date().toISOString() }
+      await this.applyRemote(collection, id, winner)
+    }
+    await this.remote.put(this.vault, collection, id, winner)
+    return this.reportErasure(collection, id, winner, suppressedRemote, 'pull')
+  }
+```
+
+3d. Rework `pull()`'s per-record body. Add `const erasures: ErasureEnforcement[] = []` next to `conflicts`. Change the `modifiedSince` filter to:
+
+```ts
+          // Partial sync: modifiedSince filter — arriving tombstones are exempt (#590):
+          // an erasure must never be skipped by partial sync.
+          if (options?.modifiedSince && remoteEnvelope._ts <= options.modifiedSince && !isTombstoneShape(remoteEnvelope)) {
+            continue
+          }
+```
+
+Replace the body of the inner `try` (currently `const localEnvelope = …` through the `// Same version or local is newer` comment) with:
+
+```ts
+            const localEnvelope = await this.local.get(this.vault, collName, id)
+            const remoteIsTombstone = isTombstoneShape(remoteEnvelope)
+
+            if (!localEnvelope) {
+              // New record from remote (tombstones included — durable erasure evidence)
+              await this.applyRemote(collName, id, remoteEnvelope)
+              pulled++
+            } else if (isTombstoneShape(localEnvelope)) {
+              if (remoteIsTombstone) {
+                // Both shredded — keep the higher version counter
+                if (remoteEnvelope._v > localEnvelope._v) await this.applyRemote(collName, id, remoteEnvelope)
+              } else {
+                // Terminal rule (#590): a tombstone is never overwritten by a live
+                // envelope, regardless of _v. Re-assert the shred outward instead.
+                erasures.push(await this.reassertTombstone(collName, id, localEnvelope, remoteEnvelope))
+              }
+            } else if (remoteIsTombstone) {
+              // Terminal rule (#590): an arriving tombstone wins over any local live
+              // envelope — even a newer, dirty one. Resolvers are never consulted.
+              const wasDirty = this.dirty.some(d => d.collection === collName && d.id === id)
+              await this.applyRemote(collName, id, remoteEnvelope)
+              this.dirty = this.dirty.filter(d => !(d.collection === collName && d.id === id))
+              pulled++
+              if (wasDirty) erasures.push(this.reportErasure(collName, id, remoteEnvelope, localEnvelope, 'pull'))
+            } else if (remoteEnvelope._v > localEnvelope._v) {
+              // Remote is newer — check if we have a dirty entry for this
+              const isDirty = this.dirty.some(d => d.collection === collName && d.id === id)
+              if (isDirty) {
+                // Both changed — conflict
+                const { handled, conflict } = await this.handleConflict(
+                  collName,
+                  id,
+                  localEnvelope,
+                  remoteEnvelope,
+                  'pull',
+                )
+                conflicts.push(conflict)
+                if (handled === 'remote') {
+                  await this.applyRemote(collName, id, conflict.remote)
+                  this.dirty = this.dirty.filter(d => !(d.collection === collName && d.id === id))
+                  pulled++
+                } else if (handled === 'merged' && conflict.local !== localEnvelope) {
+                  const merged = conflict.local
+                  await this.applyRemote(collName, id, merged)
+                  this.dirty = this.dirty.filter(d => !(d.collection === collName && d.id === id))
+                  pulled++
+                }
+                // 'local' or 'deferred': push handles it
+              } else {
+                // Remote is newer, no local changes — update
+                await this.applyRemote(collName, id, remoteEnvelope)
+                pulled++
+              }
+            }
+            // Same version or local is newer — skip (push will handle)
+```
+
+Change the result construction to `const result: PullResult = { pulled, conflicts, errors, erasures }`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run packages/hub/__tests__/sync-tombstone-terminal.test.ts`
+Expected: PASS (all describes so far).
+
+- [ ] **Step 5: Regression + commit**
+
+```bash
+pnpm vitest run packages/hub/__tests__/sync.test.ts packages/hub/__tests__/sync-conflict-policy.test.ts packages/hub/__tests__/sync-partial.test.ts packages/hub/__tests__/sync-transaction.test.ts packages/hub/__tests__/satellites-sync-pair.test.ts packages/hub/__tests__/sync-credentials.test.ts
+git add packages/hub/src/with-party/team/sync.ts packages/hub/__tests__/sync-tombstone-terminal.test.ts
+git commit -m "fix(hub): pull() treats crypto-shred tombstones as terminal and re-asserts them (#590)"
+```
+
+Expected: all regression suites PASS.
+
+---
+
+### Task 4: Push side — unconditional tombstone push + conflict-path enforcement
+
+**Files:**
+- Modify: `packages/hub/src/with-party/team/sync.ts` (`push()` ~:170–262 and `pushFiltered()` ~:357–438 — mirror the same changes into BOTH; they are intentionally parallel)
+- Test: `packages/hub/__tests__/sync-tombstone-terminal.test.ts` (append describe)
+
+**Interfaces:**
+- Consumes: `isTombstoneShape`, `applyRemote`, `reportErasure` (Task 3), `ErasureEnforcement` (Task 2).
+
+- [ ] **Step 1: Write the failing tests** — append:
+
+```ts
+describe('push tombstone-terminal rule (#590)', () => {
+  async function setup(conflict?: 'local-wins') {
+    const local = inlineMemory(); const remote = inlineMemory()
+    const db = await createNoydb({
+      store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false,
+      ...(conflict ? { conflict } : {}),
+    })
+    const vault = await db.openVault(V)
+    const notes = vault.collection<Note>('notes')
+    return { local, remote, db, notes }
+  }
+
+  it('a dirty entry whose local envelope is a tombstone pushes unconditionally (no CAS)', async () => {
+    const { local, remote, db, notes } = await setup()
+    await notes.put('n1', { body: 'v1' })                  // dirty at _v=1
+    // remote meanwhile holds a much newer live copy — CAS would refuse
+    const liveRemote: EncryptedEnvelope = { _noydb: 1, _v: 9, _ts: new Date().toISOString(), _iv: '', _data: '{"body":"other"}' }
+    await remote.put(V, 'notes', 'n1', liveRemote)
+    await local.put(V, 'notes', 'n1', tombstoneEnv(1))     // shredded before the push ran
+
+    const push = await db.push(V)
+
+    expect(push.pushed).toBe(1)
+    expect((await remote.get(V, 'notes', 'n1'))!._data).toBe('')  // erasure won without CAS
+    const again = await db.push(V)
+    expect(again.pushed).toBe(0)                                   // entry completed
+    db.close()
+  })
+
+  it('push ConflictError against a remote tombstone: enforced locally, reported, resolver bypassed', async () => {
+    const { local, remote, db, notes } = await setup('local-wins')
+    await notes.put('n1', { body: 'v1' })
+    await db.push(V)                                       // both at _v=1
+    await notes.put('n1', { body: 'offline edit' })        // dirty, _v=2 (CAS expects remote _v=1)
+    await remote.put(V, 'notes', 'n1', tombstoneEnv(5))    // shredded elsewhere at _v=5 → CAS mismatch
+
+    const events: ErasureEnforcement[] = []
+    db.on('sync:erasure', e => events.push(e))
+    const push = await db.push(V)
+
+    expect((await local.get(V, 'notes', 'n1'))!._data).toBe('')   // enforced despite local-wins
+    expect(push.erasures).toHaveLength(1)
+    expect(push.erasures![0]!.direction).toBe('push')
+    expect(push.erasures![0]!.suppressed._v).toBe(2)
+    expect(push.conflicts).toHaveLength(0)
+    expect(events).toHaveLength(1)
+    expect((await db.push(V)).pushed).toBe(0)                     // entry completed, edit never re-pushed
+    db.close()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run packages/hub/__tests__/sync-tombstone-terminal.test.ts`
+Expected: new describe FAILS (first: `push.pushed` is 0 with the entry stuck on ConflictError; second: local-wins resurrects the remote).
+
+- [ ] **Step 3: Implement in `push()`** — two insertions:
+
+3a. After `const envelope = await this.local.get(…)` / the `if (!envelope)` block, before the inner `try { await this.remote.put(…, entry.version - 1) }`:
+
+```ts
+          if (isTombstoneShape(envelope)) {
+            // #590: a tombstone push is an erasure assertion — unconditional,
+            // no CAS, no conflict resolution. Erasure always wins.
+            await this.remote.put(this.vault, entry.collection, entry.id, envelope)
+            completed.push(i)
+            pushed++
+            continue
+          }
+```
+
+3b. In the `ConflictError` branch, inside `if (remoteEnvelope) {`, wrap the existing `handleConflict` block:
+
+```ts
+              if (remoteEnvelope) {
+                if (isTombstoneShape(remoteEnvelope)) {
+                  // #590: remote already shredded this record — enforce locally,
+                  // never resolve. Resolvers must not overrule an erasure.
+                  await this.applyRemote(entry.collection, entry.id, remoteEnvelope)
+                  erasures.push(this.reportErasure(entry.collection, entry.id, remoteEnvelope, envelope, 'push'))
+                  completed.push(i)
+                } else {
+                  const { handled, conflict } = await this.handleConflict(
+                    // … existing block unchanged, except: replace the two
+                    // `await this.local.put(this.vault, entry.collection, entry.id, X)`
+                    // applies (handled === 'remote' and handled === 'merged') with
+                    // `await this.applyRemote(entry.collection, entry.id, X)`
+                  )
+                }
+              }
+```
+
+3c. Add `const erasures: ErasureEnforcement[] = []` beside `conflicts` and include `erasures` in the `PushResult` construction.
+
+- [ ] **Step 4: Mirror the exact same three changes into `pushFiltered()`** (it has the identical structure).
+
+- [ ] **Step 5: Run tests to verify they pass** — same command, expected: PASS.
+
+- [ ] **Step 6: Regression + commit**
+
+```bash
+pnpm vitest run packages/hub/__tests__/sync.test.ts packages/hub/__tests__/sync-conflict-policy.test.ts packages/hub/__tests__/sync-partial.test.ts packages/hub/__tests__/sync-transaction.test.ts packages/hub/__tests__/satellites-sync-pair.test.ts
+git add packages/hub/src/with-party/team/sync.ts packages/hub/__tests__/sync-tombstone-terminal.test.ts
+git commit -m "fix(hub): push() asserts tombstones unconditionally and never resolves against them (#590)"
+```
+
+---
+
+### Task 5: Forget propagation — `_writeTombstone` enters the dirty log + end-to-end vectors
+
+**Files:**
+- Modify: `packages/hub/src/kernel/collection.ts` (`_writeTombstone`, ~:2957–2970 — one added line)
+- Test: `packages/hub/__tests__/sync-tombstone-terminal.test.ts` (append describe)
+
+**Interfaces:**
+- Consumes: `this.onDirty` (existing `OnDirtyCallback` field on Collection), Tasks 3/4 sync behavior.
+
+- [ ] **Step 1: Write the failing tests** — append (encrypted, REAL `vault.forget()`):
+
+```ts
+describe('end-to-end: forget() + sync (#590 exit criteria)', () => {
+  async function setup() {
+    const local = inlineMemory(); const remote = inlineMemory()
+    const db = await createNoydb({
+      store: local, sync: remote, user: 'alice', secret: 'hunter2', syncStrategy: withSync(),
+      forgetStrategy: withForgetCascade({ subjects: { notes: 'subjectId' } }),
+    })
+    const vault = await db.openVault(V)
+    const notes = vault.collection<Note>('notes', { perRecordKeys: true })
+    return { local, remote, db, vault, notes }
+  }
+
+  it('the shred rides the push channel: forget → push tombstones the remote', async () => {
+    const { remote, db, vault, notes } = await setup()
+    await notes.put('n1', { subjectId: 's1', body: 'secret' })
+    await db.push(V)
+    await vault.forget('s1')
+    await db.push(V)
+    const remoteEnv = (await remote.get(V, 'notes', 'n1'))!
+    expect(remoteEnv._data).toBe('')
+    expect(remoteEnv._cek).toBeUndefined()
+    db.close()
+  })
+
+  it('exit criteria, order pull-then-push: offline higher-_v edit cannot resurrect; tombstoned everywhere, edit reported', async () => {
+    const { local, remote, db, vault, notes } = await setup()
+    await notes.put('n1', { subjectId: 's1', body: 'secret' })
+    await db.push(V)
+    const preShred = (await remote.get(V, 'notes', 'n1'))!   // what offline peer B still holds
+    await vault.forget('s1')                                  // ledger-attested shred on A
+    await remote.put(V, 'notes', 'n1', { ...preShred, _v: preShred._v + 1 })  // B pushed its edit
+
+    const pull = await db.pull(V)
+    await db.push(V)
+
+    expect(await notes.get('n1')).toBeNull()                                  // still erased on A
+    expect((await local.get(V, 'notes', 'n1'))!._data).toBe('')
+    const remoteEnv = (await remote.get(V, 'notes', 'n1'))!
+    expect(remoteEnv._data).toBe('')                                          // remote re-tombstoned
+    expect(remoteEnv._cek).toBeUndefined()
+    expect(remoteEnv._v).toBe(preShred._v + 1)                                // monotonic counter kept
+    expect(pull.erasures).toHaveLength(1)                                     // B's edit reported, not applied
+    db.close()
+  })
+
+  it('exit criteria, order push-then-pull: same convergence', async () => {
+    const { local, remote, db, vault, notes } = await setup()
+    await notes.put('n1', { subjectId: 's1', body: 'secret' })
+    await db.push(V)
+    const preShred = (await remote.get(V, 'notes', 'n1'))!
+    await vault.forget('s1')
+    await remote.put(V, 'notes', 'n1', { ...preShred, _v: preShred._v + 1 })
+
+    await db.push(V)     // unconditional tombstone assertion overwrites B's copy
+    await db.pull(V)
+
+    expect(await notes.get('n1')).toBeNull()
+    expect((await local.get(V, 'notes', 'n1'))!._data).toBe('')
+    expect((await remote.get(V, 'notes', 'n1'))!._data).toBe('')
+    db.close()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run packages/hub/__tests__/sync-tombstone-terminal.test.ts`
+Expected: first test FAILS (remote keeps the live envelope — the tombstone never entered the dirty log). The order tests may partially pass off Task 3/4 behavior; the push-propagation test must fail.
+
+- [ ] **Step 3: Implement** — in `_writeTombstone` (`kernel/collection.ts`), after the cache-eviction lines (`this.cekCache?.remove(id)`), before `return`:
+
+```ts
+    // #590: the shred must ride the sync push channel like any other write —
+    // without this the remote keeps the pre-shred envelope (wrapped CEK
+    // intact) until a pull re-assertion happens to run.
+    await this.onDirty?.(this.name, id, 'put', live._v)
+```
+
+- [ ] **Step 4: Run tests to verify they pass** — same command, expected: PASS (whole file).
+
+- [ ] **Step 5: Regression (forget + satellites + kernel ceiling) + commit**
+
+```bash
+pnpm vitest run packages/hub/__tests__/forget-sealed-erasure.test.ts packages/hub/__tests__/satellites-forget.test.ts packages/hub/__tests__/embeddings-forget.test.ts
+pnpm check:architecture
+git add packages/hub/src/kernel/collection.ts packages/hub/__tests__/sync-tombstone-terminal.test.ts
+git commit -m "fix(hub): forget() tombstones enter the sync dirty log — the shred propagates on push (#590)"
+```
+
+Expected: forget suites PASS; `check:architecture` PASS (the kernel-surface line ratchet has headroom for one line — if it trips, STOP and surface it, do not raise the ceiling).
+
+---
+
+### Task 6: #598 — wire the cache invalidator end to end
+
+**Files:**
+- Modify: `packages/hub/src/kernel/vault.ts` (add `_invalidateSyncApplied` near the other `@internal` helpers; `collectionCache` is at :331)
+- Modify: `packages/hub/src/kernel/noydb.ts` (`openVault`, immediately after the `const comp = new Vault({ … })` construction that starts at ~:598)
+- Test: `packages/hub/__tests__/sync-tombstone-terminal.test.ts` (append describe)
+
+**Interfaces:**
+- Consumes: `SyncEngine.setCacheInvalidator` (Task 3), `Collection._invalidateCekCacheEntry` / `_invalidateCacheEntry` (existing), `Noydb._forEachSyncEngine(vault, fn)` (existing, noydb.ts:1485).
+- Produces: `Vault._invalidateSyncApplied(collection: string, id: string): Promise<void>` (@internal).
+
+- [ ] **Step 1: Write the failing tests** — append:
+
+```ts
+describe('sync-applied writes refresh the Collection cache (#598)', () => {
+  it('a pull-applied newer envelope is visible through collection.get without a re-open', async () => {
+    const local = inlineMemory(); const remote = inlineMemory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
+    const vault = await db.openVault(V)
+    const notes = vault.collection<Note>('notes')
+    await notes.put('n1', { body: 'v1' })
+    await db.push(V)
+    expect((await notes.get('n1'))!.body).toBe('v1')          // cache warm
+
+    const env = (await remote.get(V, 'notes', 'n1'))!
+    const newer = { ...env, _v: 2, _data: JSON.stringify({ ...JSON.parse(env._data), body: 'v2-from-remote' }) }
+    await remote.put(V, 'notes', 'n1', newer)
+    await db.pull(V)
+
+    expect((await notes.get('n1'))!.body).toBe('v2-from-remote')  // stale cache would still say v1
+    db.close()
+  })
+
+  it('an enforced tombstone is immediately unreadable through collection.get (no decrypted residue in memory)', async () => {
+    const local = inlineMemory(); const remote = inlineMemory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'alice', secret: 'hunter2', syncStrategy: withSync() })
+    const vault = await db.openVault(V)
+    const notes = vault.collection<Note>('notes', { perRecordKeys: true })
+    await notes.put('n1', { subjectId: 's1', body: 'secret' })
+    await db.push(V)
+    expect((await notes.get('n1'))!.body).toBe('secret')      // cache warm with decrypted record
+
+    await remote.put(V, 'notes', 'n1', tombstoneEnv(1))       // shredded on another device
+    await db.pull(V)
+
+    expect(await notes.get('n1')).toBeNull()                  // enforced AND evicted
+    db.close()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run packages/hub/__tests__/sync-tombstone-terminal.test.ts`
+Expected: both new tests FAIL on the stale-cache assertion (`v1` / `'secret'` still served).
+
+- [ ] **Step 3: Implement `Vault._invalidateSyncApplied`** — in `vault.ts`:
+
+```ts
+  /**
+   * @internal Sync-applied envelope invalidation (#598): refresh every
+   * in-memory view of a record the sync engine rewrote underneath us.
+   * No-op for collections not instantiated this session — they hydrate
+   * from the store on first use and need no eviction.
+   */
+  async _invalidateSyncApplied(collection: string, id: string): Promise<void> {
+    const coll = this.collectionCache.get(collection)
+    if (!coll) return
+    coll._invalidateCekCacheEntry(id)
+    await coll._invalidateCacheEntry(id)
+  }
+```
+
+- [ ] **Step 4: Wire it in `Noydb.openVault`** — in `noydb.ts`, directly after the `const comp = new Vault({ … })` statement's closing `})`:
+
+```ts
+    // #598: sync-applied writes (pull applies, conflict winners, tombstone
+    // enforcement) must refresh Collection in-memory views.
+    this._forEachSyncEngine(name, engine => {
+      engine.setCacheInvalidator((collection, id) => comp._invalidateSyncApplied(collection, id))
+    })
+```
+
+- [ ] **Step 5: Run tests to verify they pass** — same command, expected: PASS (entire file).
+
+- [ ] **Step 6: Regression + commit**
+
+```bash
+pnpm --filter @noy-db/hub test
+git add packages/hub/src/kernel/vault.ts packages/hub/src/kernel/noydb.ts
+git commit -m "fix(hub): sync-applied envelopes invalidate Collection caches (#598)"
+```
+
+Expected: full hub suite PASS.
+
+---
+
+### Task 7: Verification sweep + changeset
+
+**Files:**
+- Create: `.changeset/sync-tombstone-terminal.md`
+
+- [ ] **Step 1: Full verification** (memory: CI runs ESLint — lint locally, not just typecheck)
+
+```bash
+pnpm --filter @noy-db/hub test
+pnpm --filter @noy-db/hub typecheck
+pnpm --filter @noy-db/hub lint
+pnpm check:architecture
+pnpm vitest run packages/hub/__tests__/cargo-surface-golden.test.ts packages/hub/__tests__/kernel-surface-golden.test.ts
+```
+
+Expected: all PASS. Golden surfaces must be UNCHANGED (no update to any `.golden.json`).
+
+- [ ] **Step 2: Changeset**
+
+```markdown
+---
+'@noy-db/hub': patch
+---
+
+Security (#590): sync now treats crypto-shred tombstones as terminal. `pull()` never overwrites a `forget()` tombstone with a live envelope regardless of `_v` and re-asserts the shred outward; `push()` asserts tombstones unconditionally and never conflict-resolves against one (resolvers are bypassed — an erasure cannot be overruled); `forget()` tombstones now enter the sync dirty log so the shred propagates on push. Suppressed edits are reported via `PushResult.erasures` / `PullResult.erasures` and the new `sync:erasure` event (new `ErasureEnforcement` type). Also fixes #598: every sync-applied local write now refreshes the Collection in-memory caches, so same-session readers see sync results (and never a decrypted residue of a shredded record).
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .changeset/sync-tombstone-terminal.md
+git commit -m "chore: changeset for sync tombstone-terminal rule (#590, #598)"
+```
+
+---
+
+### Task 8: PR + issue hygiene
+
+- [ ] **Step 1: Push and open the PR** (no Claude attribution anywhere)
+
+```bash
+git push -u origin fix/590-sync-tombstone-terminal
+gh pr create --repo vLannaAi/noy-db --title "fix(hub): sync tombstone-terminal rule — forget() survives sync (#590) + sync-applied cache invalidation (#598)" --body "$(cat <<'EOF'
+Closes #590. Closes #598.
+
+Implements docs/superpowers/specs/2026-07-08-sync-tombstone-terminal-design.md (milestone: Sync convergence & tombstones).
+
+- `pull()` treats a crypto-shred tombstone as terminal for its record id: never overwritten by a live envelope regardless of `_v`; re-asserted outward (remote re-tombstoned, `_v` bumped to keep counters monotonic).
+- `push()` asserts local tombstones unconditionally (no CAS) and never conflict-resolves against a remote tombstone — per-collection resolvers and the db-level strategy are bypassed for erasures.
+- `_writeTombstone` enters the sync dirty log, so the shred propagates on the normal push channel.
+- Suppressed edits are reported (`erasures` on push/pull results + `sync:erasure` event, new `ErasureEnforcement` type) — never silently applied.
+- #598: all sync-applied local writes route through Collection cache invalidation (new `SyncEngine.setCacheInvalidator`, wired vault-side), so enforced tombstones leave no decrypted in-memory residue.
+- Seam impact: none — no `/kernel`, `/cargo`, or `/adapter` surface change (golden tests untouched). Resolves the milestone's `port?` to plain `api`.
+
+Known, documented window: a push-only client that edited offline can transiently resurrect the remote copy; the first sync by any tombstone-holder re-tombstones it. A dumb ciphertext store cannot enforce this server-side.
+
+Exit-criteria conformance vector (forget on A + concurrent higher-`_v` edit on offline B + bidirectional sync in both orders → tombstoned everywhere, edit reported) is in `packages/hub/__tests__/sync-tombstone-terminal.test.ts`.
+EOF
+)"
+```
+
+- [ ] **Step 2: Grep the diff for the pilot-client name** (family hard rule) before requesting review:
+
+Run: `git diff main...HEAD | grep -i "<pilot-client-name>"` — expected: no matches (the operator knows the name; any match blocks the PR).
+
+- [ ] **Step 3: Issue hygiene** — after the PR is open:
+
+```bash
+gh issue edit 590 --repo vLannaAi/noy-db --remove-label "surface: port?"
+gh issue edit 598 --repo vLannaAi/noy-db --add-label "surface: internal"
+```
+
+(#590 stays `surface: api` — the tombstone-terminal semantics + `erasures`/event are api-surface; the envelope shape did not change so `port?` is resolved-out. Milestone title `[api·port?]` gets its `?` resolved only when #589's design also lands — leave the milestone title alone for now.)

--- a/docs/superpowers/specs/2026-07-08-sync-tombstone-terminal-design.md
+++ b/docs/superpowers/specs/2026-07-08-sync-tombstone-terminal-design.md
@@ -77,10 +77,14 @@ terminal rule itself never depends on `_v`.
 so the shred rides the normal push channel immediately. The pull-side re-assert is the
 convergence backstop for peers that only ever pull.
 
-**Accepted window (documented):** a push-only client that edited offline can
-transiently resurrect the *remote* copy; the first sync by any tombstone-holder
-re-tombstones it. A dumb ciphertext store cannot enforce this server-side; convergence
-to the tombstone is guaranteed once any tombstone-holder syncs.
+**Accepted window (documented):** any client whose push precedes its pull can transiently
+resurrect the *remote* copy — including the CAS-matching case: `buildTombstone` keeps the
+displaced `_v`, so a peer that edited once from the same base passes the `expectedVersion`
+check and overwrites the remote tombstone **silently and unreported** (no ConflictError, so
+the push-side enforcement never fires), and its own next pull does not repair the remote
+(equal `_v` → skip). Convergence still holds: the first sync by any tombstone-holder
+re-tombstones the remote via pull re-assertion. `sync()` (pull-then-push) protects the
+default path; a dumb ciphertext store cannot enforce this server-side.
 
 ### 4. Reporting (api-additive)
 

--- a/docs/superpowers/specs/2026-07-08-sync-tombstone-terminal-design.md
+++ b/docs/superpowers/specs/2026-07-08-sync-tombstone-terminal-design.md
@@ -61,10 +61,11 @@ Enforced at every compare point, **before any resolver runs**:
 
 | Situation | Behavior |
 |---|---|
-| Pull: local tombstone, remote live (any `_v` — higher, equal, lower) | Never apply. **Re-assert**: put the tombstone to the remote with `_v = max(local._v, remote._v)`, fresh `_ts`, original `_by` preserved; update local to the same `_v`. Report the suppressed remote envelope. |
-| Pull: remote tombstone, local live (any `_v`, even dirty) | Apply the tombstone locally, drop the dirty entry, invalidate caches, report the suppressed local envelope. |
-| Push conflict (`handleConflict` call sites in `push`/`pushFiltered`) | If either side is a tombstone, the tombstone wins unconditionally. Per-collection resolvers and the db-level `ConflictStrategy` are **never consulted** — a resolver must not overrule a ledger-attested erasure. |
-| Pull `modifiedSince` filter | Tombstones are exempt — an erasure is never skipped by partial sync. |
+| Pull: local tombstone, remote live (any `_v` — higher, equal, lower) | Never apply. **Re-assert**: put the tombstone to the remote with `_v = max(local._v, remote._v)`, fresh `_ts` when bumped, original `_by` preserved; update local to the same `_v`. Report the suppressed remote envelope. |
+| Pull: remote tombstone, local live | Apply the tombstone locally regardless of `_v`, drop any dirty entry, invalidate caches. Report the suppressed local envelope **only when it was dirty** (an actual local edit was lost); a non-dirty stale copy is a plain apply, not a suppression. |
+| Push: the local envelope for a dirty entry is a tombstone | **Unconditional put** — no CAS `expectedVersion`, no conflict path. A tombstone push is an erasure assertion; erasure always wins. |
+| Push `ConflictError` path (`push`/`pushFiltered`): remote is a tombstone | Enforce locally, complete the entry, report the suppressed local envelope. Per-collection resolvers and the db-level `ConflictStrategy` are **never consulted** — a resolver must not overrule a ledger-attested erasure. |
+| Pull `modifiedSince` filter | **Remote tombstones are exempt** — an arriving erasure is never skipped by partial sync. (A local-tombstone re-assert can be deferred by `modifiedSince` filtering of the remote live copy; the next full pull — or the push channel — covers it.) |
 | Both sides tombstones | Keep the higher `_v`; no report. |
 
 The `_v`-bump on re-assert keeps per-key version monotonicity on each store; the
@@ -84,9 +85,16 @@ to the tombstone is guaranteed once any tombstone-holder syncs.
 ### 4. Reporting (api-additive)
 
 - New type `ErasureEnforcement { vault, collection, id, tombstone, suppressed,
-  direction: 'pull' | 'push' }` in `kernel/types.ts`.
-- New optional `erasures?: ErasureEnforcement[]` on `PullResult` and `PushResult`.
-- New `'sync:erasure'` event.
+  direction: 'pull' | 'push' }` in `kernel/types.ts`; `suppressed` is always the
+  concrete live envelope that lost (never null — unreported enforcements are
+  plain applies).
+- New optional `erasures?: ErasureEnforcement[]` on `PullResult` and `PushResult`
+  (optional so existing constructors of these types stay valid; the engine always
+  sets it).
+- New `'sync:erasure'` event in `NoydbEventMap`.
+- Exported from the main hub entry only — **not** added to the `/kernel`, `/cargo`,
+  or `/adapter` seams (verified: none of them export the sync result types today;
+  the golden surfaces stay byte-identical).
 
 Deliberately **not** a `Conflict`: conflicts carry `resolve()` semantics and resolver
 routing, which erasure enforcement must never have.

--- a/docs/superpowers/specs/2026-07-08-sync-tombstone-terminal-design.md
+++ b/docs/superpowers/specs/2026-07-08-sync-tombstone-terminal-design.md
@@ -1,0 +1,127 @@
+# Sync tombstone-terminal rule — design (#590 + #598)
+
+**Date:** 2026-07-08
+**Issues:** [#590](https://github.com/vLannaAi/noy-db/issues/590) (security: pull overwrites forget tombstones), [#598](https://github.com/vLannaAi/noy-db/issues/598) (sync-applied envelopes bypass the Collection cache)
+**Milestone:** Sync convergence & tombstones [api·port?] — this design resolves the `port?`: **no `/adapter` change**.
+
+## Problem
+
+`vault.forget()` crypto-shreds a record by rewriting its live envelope to a tombstone
+(`{_noydb, _v, _ts, _by?, _iv:'', _data:''}`, `_cek` dropped — the omission *is* the
+erasure; `kernel/enclave/record-keys/tombstone.ts`). Sync voids that promise two ways:
+
+1. **Pull is tombstone-blind** (`with-party/team/sync.ts` `pull()`): any remote envelope
+   with `_v` greater than the local one is applied verbatim. An offline peer holding a
+   live copy at a higher `_v` overwrites the tombstone with decryptable plaintext
+   (its own `_cek` intact) — after a completed, ledger-attested shred.
+2. **The shred never propagates**: `_writeTombstone` (`kernel/collection.ts:2957`)
+   writes via a raw adapter put and never enters the sync dirty log. The remote keeps
+   the pre-shred live envelope indefinitely, even with no concurrent edit; any pull
+   resurrects it locally.
+
+Additionally (#598), every sync-applied local write (`pull()` applies, conflict
+winners in `push()`/`pull()`/`pushFiltered()`) bypasses `_invalidateCacheEntry`, so an
+eager Collection cache serves stale — for tombstones, still-decrypted — records for the
+rest of the session.
+
+## Approaches considered
+
+- **A. Tombstone-terminal rule in `SyncEngine` + pull-side re-assert + forget enters
+  the dirty log** — chosen. Pure hub change; reuses the existing tombstone envelope
+  shape; converges in both directions and both sync orders.
+- **B. Sync-level erasure/delete oplog** (the #589 structural fix, generalized) —
+  rejected for now: #589's exit criteria defers it to the next sync-engine structural
+  iteration; #590 is fixable today without it.
+- **C. Pull-only enforcement, no re-assert** — rejected: the remote keeps a
+  resurrectable envelope until some other peer pulls; fails #590's exit criteria
+  ("tombstoned everywhere, both orders").
+
+## Design
+
+### 1. Recognition — `isTombstoneShape`
+
+New pure predicate beside `buildTombstone` in `kernel/enclave/record-keys/tombstone.ts`:
+
+```ts
+isTombstoneShape(env) === (env._data === '' && env._cek === undefined)
+```
+
+Collection-independent — sync has no per-collection `encrypted` flag, and doesn't need
+one: no real record serializes to empty `_data` (JSON bodies are non-empty; the
+`_sync/meta` envelope carries non-empty `_data`). The existing
+`isTombstone(env, encrypted)` read-path predicate is untouched.
+
+**Seam impact: none.** The tombstone is already an ordinary `EncryptedEnvelope` that
+round-trips through every store. No `/adapter` type or contract change; the milestone's
+`surface: port?` label resolves to plain `api`.
+
+### 2. Terminal rule in `SyncEngine`
+
+Enforced at every compare point, **before any resolver runs**:
+
+| Situation | Behavior |
+|---|---|
+| Pull: local tombstone, remote live (any `_v` — higher, equal, lower) | Never apply. **Re-assert**: put the tombstone to the remote with `_v = max(local._v, remote._v)`, fresh `_ts`, original `_by` preserved; update local to the same `_v`. Report the suppressed remote envelope. |
+| Pull: remote tombstone, local live (any `_v`, even dirty) | Apply the tombstone locally, drop the dirty entry, invalidate caches, report the suppressed local envelope. |
+| Push conflict (`handleConflict` call sites in `push`/`pushFiltered`) | If either side is a tombstone, the tombstone wins unconditionally. Per-collection resolvers and the db-level `ConflictStrategy` are **never consulted** — a resolver must not overrule a ledger-attested erasure. |
+| Pull `modifiedSince` filter | Tombstones are exempt — an erasure is never skipped by partial sync. |
+| Both sides tombstones | Keep the higher `_v`; no report. |
+
+The `_v`-bump on re-assert keeps per-key version monotonicity on each store; the
+terminal rule itself never depends on `_v`.
+
+### 3. Propagation — forget enters the dirty log
+
+`_writeTombstone` additionally calls `this.onDirty?.(this.name, id, 'put', live._v)`
+so the shred rides the normal push channel immediately. The pull-side re-assert is the
+convergence backstop for peers that only ever pull.
+
+**Accepted window (documented):** a push-only client that edited offline can
+transiently resurrect the *remote* copy; the first sync by any tombstone-holder
+re-tombstones it. A dumb ciphertext store cannot enforce this server-side; convergence
+to the tombstone is guaranteed once any tombstone-holder syncs.
+
+### 4. Reporting (api-additive)
+
+- New type `ErasureEnforcement { vault, collection, id, tombstone, suppressed,
+  direction: 'pull' | 'push' }` in `kernel/types.ts`.
+- New optional `erasures?: ErasureEnforcement[]` on `PullResult` and `PushResult`.
+- New `'sync:erasure'` event.
+
+Deliberately **not** a `Conflict`: conflicts carry `resolve()` semantics and resolver
+routing, which erasure enforcement must never have.
+
+### 5. #598 — sync-applied writes invalidate the Collection cache
+
+New `setCacheInvalidator(fn)` on `SyncEngine` (same injection pattern as
+`setPairExpander`), wired where the vault attaches the sync engine, using the existing
+recipe from `vault.ts` (`_invalidateCekCacheEntry` + `_invalidateCacheEntry`).
+No-op for collections never instantiated in this session. Every sync-applied local
+write calls it: pull applies, conflict `remote`/`merged` applies in
+`push`/`pull`/`pushFiltered`, and tombstone enforcement.
+
+### 6. Testing (TDD; tests first per repo convention)
+
+Vectors in the hub sync test suite:
+
+1. **#590 exit-criteria vector**: forget on A + higher-`_v` offline edit on B +
+   bidirectional sync in *both orders* → record tombstoned on A, B, and the remote;
+   B's edit reported via `erasures` + `'sync:erasure'`, never silently applied.
+2. **No-concurrent-edit propagation**: after forget on A, the remote is tombstoned via
+   push (dirty-log path) and, independently, via pull re-assert (backstop path).
+3. **Resolver bypass**: an LWW / custom / manual resolver that would pick the live side
+   is not invoked for tombstone pairs.
+4. **`modifiedSince` exemption**: a tombstone older than the cutoff still applies.
+5. **Equal/lower `_v` re-assert**: remote live at `_v` equal to or below the tombstone's
+   is still re-tombstoned (covers propagation-never-happened).
+6. **#598 vectors**: eager-cache `get()` after a pull-applied newer envelope returns
+   the new record; after tombstone enforcement returns `null`; CEK cache evicted for
+   `perRecordKeys` collections.
+
+## Out of scope (unchanged)
+
+- #589 delete tombstones / sync oplog.
+- History dead-ciphertext retention (history under a shredded CEK is already
+  undecryptable; physical GC stays as-is).
+- Satellite pairing interplay — the satellites kill-order rule downgraded by audit
+  finding A1 can be revisited once this lands.

--- a/packages/hub/__tests__/enclave-surface.golden.json
+++ b/packages/hub/__tests__/enclave-surface.golden.json
@@ -36,6 +36,7 @@
     "hmacSha256Hex",
     "importCek",
     "isTombstone",
+    "isTombstoneShape",
     "mintBidxTag",
     "openEnvelopeJson",
     "pbkdf2VerifyDigest",

--- a/packages/hub/__tests__/root-barrel-surface.golden.json
+++ b/packages/hub/__tests__/root-barrel-surface.golden.json
@@ -551,6 +551,7 @@
     "EnrollAuthenticatorWrappingDEKsOptions",
     "EnrollAuthenticatorWrappingKEKOptions",
     "EnrollRecoveryResult",
+    "ErasureEnforcement",
     "ExportAccessibleOptions",
     "ExportCapability",
     "ExportChunk",

--- a/packages/hub/__tests__/sync-tombstone-terminal.test.ts
+++ b/packages/hub/__tests__/sync-tombstone-terminal.test.ts
@@ -4,6 +4,7 @@ import { ConflictError } from '../src/kernel/errors.js'
 import { createNoydb } from '../src/kernel/noydb.js'
 import { withSync } from '../src/with-party/sync/index.js'
 import { withForgetCascade } from '../src/with-audit/forget/index.js'
+import { withHistory } from '../src/with-commit/history/index.js'
 import { isTombstoneShape } from '../src/kernel/enclave/record-keys/tombstone.js'
 
 /** In-memory store (mirrors the harness in sync.test.ts). */
@@ -209,6 +210,70 @@ describe('push tombstone-terminal rule (#590)', () => {
     expect(push.conflicts).toHaveLength(0)
     expect(events).toHaveLength(1)
     expect((await db.push(V)).pushed).toBe(0)                     // entry completed, edit never re-pushed
+    db.close()
+  })
+})
+
+describe('end-to-end: forget() + sync (#590 exit criteria)', () => {
+  async function setup() {
+    const local = inlineMemory(); const remote = inlineMemory()
+    const db = await createNoydb({
+      store: local, sync: remote, user: 'alice', secret: 'hunter2', syncStrategy: withSync(),
+      forgetStrategy: withForgetCascade({ subjects: { notes: 'subjectId' } }),
+      historyStrategy: withHistory(),
+    })
+    const vault = await db.openVault(V)
+    const notes = vault.collection<Note>('notes', { perRecordKeys: true })
+    return { local, remote, db, vault, notes }
+  }
+
+  it('the shred rides the push channel: forget → push tombstones the remote', async () => {
+    const { remote, db, vault, notes } = await setup()
+    await notes.put('n1', { subjectId: 's1', body: 'secret' })
+    await db.push(V)
+    await vault.forget('s1')
+    await db.push(V)
+    const remoteEnv = (await remote.get(V, 'notes', 'n1'))!
+    expect(remoteEnv._data).toBe('')
+    expect(remoteEnv._cek).toBeUndefined()
+    db.close()
+  })
+
+  it('exit criteria, order pull-then-push: offline higher-_v edit cannot resurrect; tombstoned everywhere, edit reported', async () => {
+    const { local, remote, db, vault, notes } = await setup()
+    await notes.put('n1', { subjectId: 's1', body: 'secret' })
+    await db.push(V)
+    const preShred = (await remote.get(V, 'notes', 'n1'))!   // what offline peer B still holds
+    await vault.forget('s1')                                  // ledger-attested shred on A
+    await remote.put(V, 'notes', 'n1', { ...preShred, _v: preShred._v + 1 })  // B pushed its edit
+
+    const pull = await db.pull(V)
+    await db.push(V)
+
+    expect(await notes.get('n1')).toBeNull()                                  // still erased on A
+    expect((await local.get(V, 'notes', 'n1'))!._data).toBe('')
+    const remoteEnv = (await remote.get(V, 'notes', 'n1'))!
+    expect(remoteEnv._data).toBe('')                                          // remote re-tombstoned
+    expect(remoteEnv._cek).toBeUndefined()
+    expect(remoteEnv._v).toBe(preShred._v + 1)                                // monotonic counter kept
+    expect(pull.erasures).toHaveLength(1)                                     // B's edit reported, not applied
+    db.close()
+  })
+
+  it('exit criteria, order push-then-pull: same convergence', async () => {
+    const { local, remote, db, vault, notes } = await setup()
+    await notes.put('n1', { subjectId: 's1', body: 'secret' })
+    await db.push(V)
+    const preShred = (await remote.get(V, 'notes', 'n1'))!
+    await vault.forget('s1')
+    await remote.put(V, 'notes', 'n1', { ...preShred, _v: preShred._v + 1 })
+
+    await db.push(V)     // unconditional tombstone assertion overwrites B's copy
+    await db.pull(V)
+
+    expect(await notes.get('n1')).toBeNull()
+    expect((await local.get(V, 'notes', 'n1'))!._data).toBe('')
+    expect((await remote.get(V, 'notes', 'n1'))!._data).toBe('')
     db.close()
   })
 })

--- a/packages/hub/__tests__/sync-tombstone-terminal.test.ts
+++ b/packages/hub/__tests__/sync-tombstone-terminal.test.ts
@@ -55,3 +55,109 @@ describe('isTombstoneShape', () => {
     expect(isTombstoneShape({ _noydb: 1, _v: 1, _ts: 'x', _iv: '', _data: '', _cek: 'wrapped' })).toBe(false)
   })
 })
+
+describe('pull tombstone-terminal rule (#590)', () => {
+  async function setup(conflict?: 'local-wins') {
+    const local = inlineMemory(); const remote = inlineMemory()
+    const db = await createNoydb({
+      store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false,
+      ...(conflict ? { conflict } : {}),
+    })
+    const vault = await db.openVault(V)
+    const notes = vault.collection<Note>('notes')
+    return { local, remote, db, notes }
+  }
+
+  it('a remote tombstone beats a newer dirty local edit — enforced, dirty dropped, reported, resolver bypassed', async () => {
+    const { local, remote, db, notes } = await setup('local-wins')
+    await notes.put('n1', { body: 'v1' })
+    await db.push(V)                                      // both sides at _v=1
+    await notes.put('n1', { body: 'offline edit' })       // dirty, _v=2
+    await remote.put(V, 'notes', 'n1', tombstoneEnv(1))   // another device shredded it
+
+    const events: ErasureEnforcement[] = []
+    db.on('sync:erasure', e => events.push(e))
+    const pull = await db.pull(V)
+
+    expect((await local.get(V, 'notes', 'n1'))!._data).toBe('')  // enforced despite local-wins + higher local _v
+    expect(pull.erasures).toHaveLength(1)
+    expect(pull.erasures![0]!.direction).toBe('pull')
+    expect(pull.erasures![0]!.suppressed._v).toBe(2)
+    expect(pull.conflicts).toHaveLength(0)                       // never a resolvable conflict
+    expect(events).toHaveLength(1)
+
+    const push = await db.push(V)
+    expect(push.pushed).toBe(0)                                  // suppressed edit is not pushed
+    db.close()
+  })
+
+  it('a remote tombstone over a non-dirty stale copy applies silently (no erasure report)', async () => {
+    const { local, remote, db, notes } = await setup()
+    await notes.put('n1', { body: 'v1' })
+    await db.push(V)                                      // clean
+    await remote.put(V, 'notes', 'n1', tombstoneEnv(1))
+    const pull = await db.pull(V)
+    expect((await local.get(V, 'notes', 'n1'))!._data).toBe('')
+    expect(pull.erasures ?? []).toHaveLength(0)
+    db.close()
+  })
+
+  it('a local tombstone is never overwritten by a higher-_v live remote — re-asserted outward with a bumped _v', async () => {
+    const { local, remote, db, notes } = await setup()
+    await notes.put('n1', { body: 'v1' })
+    await db.push(V)
+    const live = (await remote.get(V, 'notes', 'n1'))!
+    await local.put(V, 'notes', 'n1', tombstoneEnv(1))    // local shred residue
+    await remote.put(V, 'notes', 'n1', { ...live, _v: 3 }) // offline peer's later edit
+
+    const pull = await db.pull(V)
+
+    expect((await local.get(V, 'notes', 'n1'))!._data).toBe('')
+    const remoteEnv = (await remote.get(V, 'notes', 'n1'))!
+    expect(remoteEnv._data).toBe('')                       // remote re-tombstoned
+    expect(remoteEnv._v).toBe(3)                           // bumped to the suppressed _v
+    expect((await local.get(V, 'notes', 'n1'))!._v).toBe(3)
+    expect(pull.erasures).toHaveLength(1)
+    expect(pull.erasures![0]!.suppressed._v).toBe(3)
+    db.close()
+  })
+
+  it('re-assert at equal _v: remote live copy is tombstoned without a bump', async () => {
+    const { local, remote, db, notes } = await setup()
+    await notes.put('n1', { body: 'v1' })
+    await db.push(V)
+    await local.put(V, 'notes', 'n1', tombstoneEnv(1))
+    const pull = await db.pull(V)
+    const remoteEnv = (await remote.get(V, 'notes', 'n1'))!
+    expect(remoteEnv._data).toBe('')
+    expect(remoteEnv._v).toBe(1)
+    expect(pull.erasures).toHaveLength(1)
+    db.close()
+  })
+
+  it('both sides tombstoned: higher _v wins, nothing reported', async () => {
+    const { local, remote, db } = await setup()
+    await local.put(V, 'notes', 'n1', tombstoneEnv(1))
+    await remote.put(V, 'notes', 'n1', tombstoneEnv(4))
+    const pull = await db.pull(V)
+    expect((await local.get(V, 'notes', 'n1'))!._v).toBe(4)
+    expect(pull.erasures ?? []).toHaveLength(0)
+    db.close()
+  })
+
+  it('modifiedSince never skips an arriving tombstone (but still skips old live envelopes)', async () => {
+    const { local, remote, db, notes } = await setup()
+    await notes.put('n1', { body: 'v1' })
+    await notes.put('n2', { body: 'v1' })
+    await db.push(V)
+    await remote.put(V, 'notes', 'n1', tombstoneEnv(2, '2000-01-01T00:00:00.000Z'))
+    const oldLive = (await remote.get(V, 'notes', 'n2'))!
+    await remote.put(V, 'notes', 'n2', { ...oldLive, _v: 2, _ts: '2000-01-01T00:00:00.000Z' })
+
+    await db.pull(V, { modifiedSince: '2020-01-01T00:00:00.000Z' })
+
+    expect((await local.get(V, 'notes', 'n1'))!._data).toBe('')  // tombstone exempt from the filter
+    expect((await local.get(V, 'notes', 'n2'))!._v).toBe(1)      // old live envelope still filtered
+    db.close()
+  })
+})

--- a/packages/hub/__tests__/sync-tombstone-terminal.test.ts
+++ b/packages/hub/__tests__/sync-tombstone-terminal.test.ts
@@ -313,3 +313,28 @@ describe('sync-applied writes refresh the Collection cache (#598)', () => {
     db.close()
   })
 })
+
+describe('sync transactions vs tombstones (#590)', () => {
+  it('a staged write suppressed by tombstone enforcement is disclosed via result.erasures', async () => {
+    const local = inlineMemory(); const remote = inlineMemory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
+    const vault = await db.openVault(V)
+    const notes = vault.collection<Note>('notes')
+    await notes.put('n1', { body: 'v1' })
+    await db.push(V)                                       // both sides synced at _v=1
+
+    await remote.put(V, 'notes', 'n1', tombstoneEnv(5))    // shredded elsewhere — CAS mismatch on push
+
+    const tx = db.transaction(V)
+    tx.put('notes', 'n1', { body: 'offline edit' })
+    const result = await tx.commit()
+
+    expect(result.erasures).toHaveLength(1)
+    expect(result.erasures![0]!.direction).toBe('push')
+    expect((await local.get(V, 'notes', 'n1'))!._data).toBe('')  // local enforced to the tombstone
+    // By design, status stays 'committed' — the erasures field is the disclosure that a
+    // staged write was suppressed, not a change to the committed/conflict status logic.
+    expect(result.status).toBe('committed')
+    db.close()
+  })
+})

--- a/packages/hub/__tests__/sync-tombstone-terminal.test.ts
+++ b/packages/hub/__tests__/sync-tombstone-terminal.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot, ErasureEnforcement } from '../src/kernel/types.js'
+import { ConflictError } from '../src/kernel/errors.js'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { withSync } from '../src/with-party/sync/index.js'
+import { withForgetCascade } from '../src/with-audit/forget/index.js'
+import { isTombstoneShape } from '../src/kernel/enclave/record-keys/tombstone.js'
+
+/** In-memory store (mirrors the harness in sync.test.ts). */
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) }
+    },
+  }
+}
+
+/** A crypto-shred tombstone as `buildTombstone` mints it. */
+function tombstoneEnv(v: number, ts = new Date().toISOString()): EncryptedEnvelope {
+  return { _noydb: 1, _v: v, _ts: ts, _iv: '', _data: '' }
+}
+
+interface Note { body: string; subjectId?: string }
+const V = 'V1'
+
+describe('isTombstoneShape', () => {
+  it('recognises the buildTombstone shape and nothing else', () => {
+    expect(isTombstoneShape(tombstoneEnv(3))).toBe(true)
+    // live encrypted envelope: non-empty _data
+    expect(isTombstoneShape({ _noydb: 1, _v: 1, _ts: 'x', _iv: 'abc', _data: 'ciphertext' })).toBe(false)
+    // unencrypted record envelope: non-empty JSON _data, empty _iv
+    expect(isTombstoneShape({ _noydb: 1, _v: 1, _ts: 'x', _iv: '', _data: '{"a":1}' })).toBe(false)
+    // _sync meta shape: empty _iv, non-empty _data
+    expect(isTombstoneShape({ _noydb: 1, _v: 1, _ts: 'x', _iv: '', _data: '{"dirty":[]}' })).toBe(false)
+    // empty _data but a wrapped CEK present → not a shred
+    expect(isTombstoneShape({ _noydb: 1, _v: 1, _ts: 'x', _iv: '', _data: '', _cek: 'wrapped' })).toBe(false)
+  })
+})

--- a/packages/hub/__tests__/sync-tombstone-terminal.test.ts
+++ b/packages/hub/__tests__/sync-tombstone-terminal.test.ts
@@ -161,3 +161,54 @@ describe('pull tombstone-terminal rule (#590)', () => {
     db.close()
   })
 })
+
+describe('push tombstone-terminal rule (#590)', () => {
+  async function setup(conflict?: 'local-wins') {
+    const local = inlineMemory(); const remote = inlineMemory()
+    const db = await createNoydb({
+      store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false,
+      ...(conflict ? { conflict } : {}),
+    })
+    const vault = await db.openVault(V)
+    const notes = vault.collection<Note>('notes')
+    return { local, remote, db, notes }
+  }
+
+  it('a dirty entry whose local envelope is a tombstone pushes unconditionally (no CAS)', async () => {
+    const { local, remote, db, notes } = await setup()
+    await notes.put('n1', { body: 'v1' })                  // dirty at _v=1
+    // remote meanwhile holds a much newer live copy — CAS would refuse
+    const liveRemote: EncryptedEnvelope = { _noydb: 1, _v: 9, _ts: new Date().toISOString(), _iv: '', _data: '{"body":"other"}' }
+    await remote.put(V, 'notes', 'n1', liveRemote)
+    await local.put(V, 'notes', 'n1', tombstoneEnv(1))     // shredded before the push ran
+
+    const push = await db.push(V)
+
+    expect(push.pushed).toBe(1)
+    expect((await remote.get(V, 'notes', 'n1'))!._data).toBe('')  // erasure won without CAS
+    const again = await db.push(V)
+    expect(again.pushed).toBe(0)                                   // entry completed
+    db.close()
+  })
+
+  it('push ConflictError against a remote tombstone: enforced locally, reported, resolver bypassed', async () => {
+    const { local, remote, db, notes } = await setup('local-wins')
+    await notes.put('n1', { body: 'v1' })
+    await db.push(V)                                       // both at _v=1
+    await notes.put('n1', { body: 'offline edit' })        // dirty, _v=2 (CAS expects remote _v=1)
+    await remote.put(V, 'notes', 'n1', tombstoneEnv(5))    // shredded elsewhere at _v=5 → CAS mismatch
+
+    const events: ErasureEnforcement[] = []
+    db.on('sync:erasure', e => events.push(e))
+    const push = await db.push(V)
+
+    expect((await local.get(V, 'notes', 'n1'))!._data).toBe('')   // enforced despite local-wins
+    expect(push.erasures).toHaveLength(1)
+    expect(push.erasures![0]!.direction).toBe('push')
+    expect(push.erasures![0]!.suppressed._v).toBe(2)
+    expect(push.conflicts).toHaveLength(0)
+    expect(events).toHaveLength(1)
+    expect((await db.push(V)).pushed).toBe(0)                     // entry completed, edit never re-pushed
+    db.close()
+  })
+})

--- a/packages/hub/__tests__/sync-tombstone-terminal.test.ts
+++ b/packages/hub/__tests__/sync-tombstone-terminal.test.ts
@@ -277,3 +277,39 @@ describe('end-to-end: forget() + sync (#590 exit criteria)', () => {
     db.close()
   })
 })
+
+describe('sync-applied writes refresh the Collection cache (#598)', () => {
+  it('a pull-applied newer envelope is visible through collection.get without a re-open', async () => {
+    const local = inlineMemory(); const remote = inlineMemory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
+    const vault = await db.openVault(V)
+    const notes = vault.collection<Note>('notes')
+    await notes.put('n1', { body: 'v1' })
+    await db.push(V)
+    expect((await notes.get('n1'))!.body).toBe('v1')          // cache warm
+
+    const env = (await remote.get(V, 'notes', 'n1'))!
+    const newer = { ...env, _v: 2, _data: JSON.stringify({ ...JSON.parse(env._data), body: 'v2-from-remote' }) }
+    await remote.put(V, 'notes', 'n1', newer)
+    await db.pull(V)
+
+    expect((await notes.get('n1'))!.body).toBe('v2-from-remote')  // stale cache would still say v1
+    db.close()
+  })
+
+  it('an enforced tombstone is immediately unreadable through collection.get (no decrypted residue in memory)', async () => {
+    const local = inlineMemory(); const remote = inlineMemory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'alice', secret: 'hunter2', syncStrategy: withSync() })
+    const vault = await db.openVault(V)
+    const notes = vault.collection<Note>('notes', { perRecordKeys: true })
+    await notes.put('n1', { subjectId: 's1', body: 'secret' })
+    await db.push(V)
+    expect((await notes.get('n1'))!.body).toBe('secret')      // cache warm with decrypted record
+
+    await remote.put(V, 'notes', 'n1', tombstoneEnv(1))       // shredded on another device
+    await db.pull(V)
+
+    expect(await notes.get('n1')).toBeNull()                  // enforced AND evicted
+    db.close()
+  })
+})

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -92,6 +92,7 @@ export type {
   DirtyEntry,
   SyncMetadata,
   Conflict,
+  ErasureEnforcement,
   ConflictStrategy,
   ConflictPolicy,
   CollectionConflictResolver,

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -2965,6 +2965,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     this.cache.delete(id)
     this.lru?.remove(id)
     this.cekCache?.remove(id)
+    // #590: enter the sync dirty log — the shred must propagate on push (pull re-assert in team/sync.ts is the backstop)
+    await this.onDirty?.(this.name, id, 'put', live._v)
 
     return { previousVersion: live._v }
   }

--- a/packages/hub/src/kernel/enclave/index.ts
+++ b/packages/hub/src/kernel/enclave/index.ts
@@ -102,7 +102,7 @@ export { findByDet, queryByDet } from './record-keys/deterministic.js'
 export type { DeterministicContext } from './record-keys/deterministic.js'
 
 // ─── tombstone ─────────────────────────────────────────────────────
-export { isTombstone, buildTombstone } from './record-keys/tombstone.js'
+export { isTombstone, isTombstoneShape, buildTombstone } from './record-keys/tombstone.js'
 
 // ─── envelope body (C1 protected-body access contract) ──────────────
 export { openEnvelopeJson, writeEnvelopeBody, hasPerRecordKey, envelopeBodyForHash } from './record-keys/envelope-body.js'

--- a/packages/hub/src/kernel/enclave/record-keys/record-codec.ts
+++ b/packages/hub/src/kernel/enclave/record-keys/record-codec.ts
@@ -461,7 +461,13 @@ export class RecordCodec<T> {
         }
         return JSON.stringify(rec)
       }
-      return envelope._data
+      // #598: a real record never serializes to '' (JSON.stringify's floor is
+      // '{}'), so an empty `_data` here is the sync engine's shape-only
+      // tombstone (`isTombstoneShape` in team/sync.ts) landing on an
+      // unencrypted collection, where the encryption-gated `isTombstone()`
+      // check above doesn't fire. Treat it the same as an encrypted
+      // tombstone: null, not a `JSON.parse('')` crash.
+      return envelope._data === '' ? null : envelope._data
     }
     const cek = await this.resolveEnvelopeCek(envelope, id)
     if (cek !== undefined) return decrypt(envelope._iv, envelope._data, cek)

--- a/packages/hub/src/kernel/enclave/record-keys/tombstone.ts
+++ b/packages/hub/src/kernel/enclave/record-keys/tombstone.ts
@@ -18,6 +18,17 @@
 import { NOYDB_FORMAT_VERSION, type EncryptedEnvelope } from '../../types.js'
 
 /**
+ * Shape-only tombstone recognition for layers that have no per-collection
+ * context (the sync engine, #590): a tombstone carries an empty `_data` and
+ * no wrapped CEK. No live envelope can match — record bodies never serialize
+ * to the empty string (the `_sync` meta envelope carries non-empty `_data`,
+ * and legacy migration envelopes carry non-empty `_iv`/`_data`).
+ */
+export function isTombstoneShape(envelope: EncryptedEnvelope): boolean {
+  return envelope._data === '' && envelope._cek === undefined
+}
+
+/**
  * Is this envelope a crypto-shred tombstone?
  *
  * A tombstone carries no body (`_data` empty) and no wrapped CEK (`_cek`
@@ -31,7 +42,7 @@ import { NOYDB_FORMAT_VERSION, type EncryptedEnvelope } from '../../types.js'
  */
 export function isTombstone(envelope: EncryptedEnvelope, encrypted: boolean): boolean {
   if (!encrypted) return false
-  return !envelope._data && envelope._cek === undefined
+  return isTombstoneShape(envelope)
 }
 
 /**

--- a/packages/hub/src/kernel/noydb.ts
+++ b/packages/hub/src/kernel/noydb.ts
@@ -674,6 +674,10 @@ export class Noydb {
             }
           : undefined,
     })
+    // #598: sync-applied writes must refresh Collection in-memory views.
+    this._forEachSyncEngine(name, engine => {
+      engine.setCacheInvalidator((collection, id) => comp._invalidateSyncApplied(collection, id))
+    })
     // Initialise the optional guard + derivation registries via
     // dynamic-import. Both calls are no-ops when the corresponding
     // strategies array is empty / unset, leaving the service code

--- a/packages/hub/src/kernel/types.ts
+++ b/packages/hub/src/kernel/types.ts
@@ -1203,6 +1203,23 @@ export interface Conflict {
 }
 
 /**
+ * A tombstone enforcement: the terminal application of a deletion assertion
+ * that won over a concurrent local edit or remote write (#590).
+ * Only set on non-manual-conflict handlers; manual handlers must query the
+ * result to inspect tombstone wins. Emitted as `'sync:erasure'` event.
+ */
+export interface ErasureEnforcement {
+  readonly vault: string
+  readonly collection: string
+  readonly id: string
+  /** The winning tombstone (as stored after enforcement). */
+  readonly tombstone: EncryptedEnvelope
+  /** The live envelope that lost: a suppressed dirty local edit, or the remote copy destroyed by re-assertion. */
+  readonly suppressed: EncryptedEnvelope
+  readonly direction: 'pull' | 'push'
+}
+
+/**
  * A same-device cross-tab write conflict: another tab overwrote a
  * document this tab had written, having diverged from an older base. Records
  * are decrypted (cross-tab handlers reconcile in plaintext). `base` is the
@@ -1276,12 +1293,16 @@ export interface PushResult {
   readonly pushed: number
   readonly conflicts: Conflict[]
   readonly errors: Error[]
+  /** #590: tombstone enforcements applied during this run (never resolver-visible). */
+  readonly erasures?: ErasureEnforcement[]
 }
 
 export interface PullResult {
   readonly pulled: number
   readonly conflicts: Conflict[]
   readonly errors: Error[]
+  /** #590: tombstone enforcements applied during this run (never resolver-visible). */
+  readonly erasures?: ErasureEnforcement[]
 }
 
 /** Result of a sync transaction commit. */
@@ -1342,6 +1363,7 @@ export interface NoydbEventMap {
   'schema:fence-changed': { vault: string; currentSchemaVersion: number; fenceState: 'normal' | 'draining' | 'migrating' | 'complete' }
   'sync:push': PushResult
   'sync:pull': PullResult
+  'sync:erasure': ErasureEnforcement
   'sync:conflict': Conflict
   'write:conflict': WriteConflict
   'sync:online': void

--- a/packages/hub/src/kernel/types.ts
+++ b/packages/hub/src/kernel/types.ts
@@ -1203,10 +1203,10 @@ export interface Conflict {
 }
 
 /**
- * A tombstone enforcement: the terminal application of a deletion assertion
- * that won over a concurrent local edit or remote write (#590).
- * Only set on non-manual-conflict handlers; manual handlers must query the
- * result to inspect tombstone wins. Emitted as `'sync:erasure'` event.
+ * #590: sync suppressed a live envelope because a crypto-shred tombstone is
+ * terminal for its record id. Reported on push/pull results (`erasures`) and
+ * via the `'sync:erasure'` event; conflict resolvers are never consulted for
+ * tombstone pairs.
  */
 export interface ErasureEnforcement {
   readonly vault: string
@@ -1310,6 +1310,8 @@ export interface SyncTransactionResult {
   readonly status: 'committed' | 'conflict'
   readonly pushed: number
   readonly conflicts: Conflict[]
+  /** #590: staged writes suppressed by tombstone enforcement during commit. */
+  readonly erasures?: ErasureEnforcement[]
 }
 
 export interface SyncStatus {

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -1313,6 +1313,14 @@ export class Vault {
     await coll._applyRemoteChange(docId, action)
   }
 
+  /** @internal #598: refresh cache entries a sync-applied write rewrote underneath us. No-op if not loaded this session. */
+  async _invalidateSyncApplied(collection: string, id: string): Promise<void> {
+    const coll = this.collectionCache.get(collection)
+    if (!coll) return
+    coll._invalidateCekCacheEntry(id)
+    await coll._invalidateCacheEntry(id)
+  }
+
   /**
    * For a detected conflict: capture this tab's clobbered record,
    * read the common ancestor from history, converge the cache to the store's

--- a/packages/hub/src/with-party/team/sync-transaction.ts
+++ b/packages/hub/src/with-party/team/sync-transaction.ts
@@ -81,6 +81,7 @@ export class SyncTransaction {
       status: pushResult.conflicts.length > 0 ? 'conflict' : 'committed',
       pushed: pushResult.pushed,
       conflicts: pushResult.conflicts,
+      ...(pushResult.erasures?.length ? { erasures: pushResult.erasures } : {}),
     }
   }
 }

--- a/packages/hub/src/with-party/team/sync.ts
+++ b/packages/hub/src/with-party/team/sync.ts
@@ -12,12 +12,14 @@ import type {
   EncryptedEnvelope,
   SyncMetadata,
   SyncTargetRole,
+  ErasureEnforcement,
 } from '../../kernel/types.js'
 import { NOYDB_SYNC_VERSION } from '../../kernel/types.js'
 import { ConflictError } from '../../kernel/errors.js'
 import type { NoydbEventEmitter } from '../../kernel/events.js'
 import type { SyncPolicy } from '../../kernel/sync-policy.js'
 import { SyncScheduler } from '../../kernel/sync-policy.js'
+import { isTombstoneShape } from '../../kernel/enclave/record-keys/tombstone.js'
 
 /** Sync engine: dirty tracking, push, pull, conflict resolution, scheduling. */
 export class SyncEngine {
@@ -50,6 +52,14 @@ export class SyncEngine {
    * users.
    */
   private pairExpander?: (names: readonly string[]) => readonly string[]
+
+  /** #598: refreshes Collection in-memory views after a sync-applied local write. Wired by the vault at open. */
+  private cacheInvalidator?: (collection: string, id: string) => Promise<void>
+
+  /** Wire the Collection-cache invalidation hook (#598). Same injection pattern as `setPairExpander`. */
+  setCacheInvalidator(fn: (collection: string, id: string) => Promise<void>): void {
+    this.cacheInvalidator = fn
+  }
 
   constructor(opts: {
     local: NoydbStore
@@ -267,6 +277,7 @@ export class SyncEngine {
 
     let pulled = 0
     const conflicts: Conflict[] = []
+    const erasures: ErasureEnforcement[] = []
     const errors: Error[] = []
 
     // Partial sync: expand the filter to cover satellite pair partners (#591 rule 5b)
@@ -282,18 +293,37 @@ export class SyncEngine {
         }
 
         for (const [id, remoteEnvelope] of Object.entries(records)) {
-          // Partial sync: modifiedSince filter
-          if (options?.modifiedSince && remoteEnvelope._ts <= options.modifiedSince) {
+          // Partial sync: modifiedSince filter — arriving tombstones are exempt (#590):
+          // an erasure must never be skipped by partial sync.
+          if (options?.modifiedSince && remoteEnvelope._ts <= options.modifiedSince && !isTombstoneShape(remoteEnvelope)) {
             continue
           }
 
           try {
             const localEnvelope = await this.local.get(this.vault, collName, id)
+            const remoteIsTombstone = isTombstoneShape(remoteEnvelope)
 
             if (!localEnvelope) {
-              // New record from remote
-              await this.local.put(this.vault, collName, id, remoteEnvelope)
+              // New record from remote (tombstones included — durable erasure evidence)
+              await this.applyRemote(collName, id, remoteEnvelope)
               pulled++
+            } else if (isTombstoneShape(localEnvelope)) {
+              if (remoteIsTombstone) {
+                // Both shredded — keep the higher version counter
+                if (remoteEnvelope._v > localEnvelope._v) await this.applyRemote(collName, id, remoteEnvelope)
+              } else {
+                // Terminal rule (#590): a tombstone is never overwritten by a live
+                // envelope, regardless of _v. Re-assert the shred outward instead.
+                erasures.push(await this.reassertTombstone(collName, id, localEnvelope, remoteEnvelope))
+              }
+            } else if (remoteIsTombstone) {
+              // Terminal rule (#590): an arriving tombstone wins over any local live
+              // envelope — even a newer, dirty one. Resolvers are never consulted.
+              const wasDirty = this.dirty.some(d => d.collection === collName && d.id === id)
+              await this.applyRemote(collName, id, remoteEnvelope)
+              this.dirty = this.dirty.filter(d => !(d.collection === collName && d.id === id))
+              pulled++
+              if (wasDirty) erasures.push(this.reportErasure(collName, id, remoteEnvelope, localEnvelope, 'pull'))
             } else if (remoteEnvelope._v > localEnvelope._v) {
               // Remote is newer — check if we have a dirty entry for this
               const isDirty = this.dirty.some(d => d.collection === collName && d.id === id)
@@ -308,19 +338,19 @@ export class SyncEngine {
                 )
                 conflicts.push(conflict)
                 if (handled === 'remote') {
-                  await this.local.put(this.vault, collName, id, conflict.remote)
+                  await this.applyRemote(collName, id, conflict.remote)
                   this.dirty = this.dirty.filter(d => !(d.collection === collName && d.id === id))
                   pulled++
                 } else if (handled === 'merged' && conflict.local !== localEnvelope) {
                   const merged = conflict.local
-                  await this.local.put(this.vault, collName, id, merged)
+                  await this.applyRemote(collName, id, merged)
                   this.dirty = this.dirty.filter(d => !(d.collection === collName && d.id === id))
                   pulled++
                 }
                 // 'local' or 'deferred': push handles it
               } else {
                 // Remote is newer, no local changes — update
-                await this.local.put(this.vault, collName, id, remoteEnvelope)
+                await this.applyRemote(collName, id, remoteEnvelope)
                 pulled++
               }
             }
@@ -337,7 +367,7 @@ export class SyncEngine {
     this.lastPull = new Date().toISOString()
     await this.persistMeta()
 
-    const result: PullResult = { pulled, conflicts, errors }
+    const result: PullResult = { pulled, conflicts, errors, erasures }
     this.emitter.emit('sync:pull', result)
     return result
   }
@@ -489,6 +519,42 @@ export class SyncEngine {
   private handleOffline = (): void => {
     this.isOnline = false
     this.emitter.emit('sync:offline', undefined as never)
+  }
+
+  /** Apply an envelope to the local store and refresh in-memory views (#598). */
+  private async applyRemote(collection: string, id: string, envelope: EncryptedEnvelope): Promise<void> {
+    await this.local.put(this.vault, collection, id, envelope)
+    await this.cacheInvalidator?.(collection, id)
+  }
+
+  /** Record + emit a tombstone enforcement (#590). */
+  private reportErasure(
+    collection: string, id: string,
+    tombstone: EncryptedEnvelope, suppressed: EncryptedEnvelope,
+    direction: 'pull' | 'push',
+  ): ErasureEnforcement {
+    const enforcement: ErasureEnforcement = { vault: this.vault, collection, id, tombstone, suppressed, direction }
+    this.emitter.emit('sync:erasure', enforcement)
+    return enforcement
+  }
+
+  /**
+   * Re-assert a local tombstone over a live remote envelope (#590): the shred
+   * wins in both directions, regardless of `_v`. Bumps the tombstone to the
+   * suppressed envelope's `_v` when higher so per-key version counters stay
+   * monotonic on every store; `_by` (the shredding actor) is preserved.
+   */
+  private async reassertTombstone(
+    collection: string, id: string,
+    tombstone: EncryptedEnvelope, suppressedRemote: EncryptedEnvelope,
+  ): Promise<ErasureEnforcement> {
+    let winner = tombstone
+    if (suppressedRemote._v > tombstone._v) {
+      winner = { ...tombstone, _v: suppressedRemote._v, _ts: new Date().toISOString() }
+      await this.applyRemote(collection, id, winner)
+    }
+    await this.remote.put(this.vault, collection, id, winner)
+    return this.reportErasure(collection, id, winner, suppressedRemote, 'pull')
   }
 
   /**

--- a/packages/hub/src/with-party/team/sync.ts
+++ b/packages/hub/src/with-party/team/sync.ts
@@ -182,6 +182,7 @@ export class SyncEngine {
 
     let pushed = 0
     const conflicts: Conflict[] = []
+    const erasures: ErasureEnforcement[] = []
     const errors: Error[] = []
     const completed: number[] = []
 
@@ -209,6 +210,15 @@ export class SyncEngine {
             continue
           }
 
+          if (isTombstoneShape(envelope)) {
+            // #590: a tombstone push is an erasure assertion — unconditional,
+            // no CAS, no conflict resolution. Erasure always wins.
+            await this.remote.put(this.vault, entry.collection, entry.id, envelope)
+            completed.push(i)
+            pushed++
+            continue
+          }
+
           try {
             await this.remote.put(
               this.vault,
@@ -223,30 +233,38 @@ export class SyncEngine {
             if (err instanceof ConflictError) {
               const remoteEnvelope = await this.remote.get(this.vault, entry.collection, entry.id)
               if (remoteEnvelope) {
-                const { handled, conflict } = await this.handleConflict(
-                  entry.collection,
-                  entry.id,
-                  envelope,
-                  remoteEnvelope,
-                  'push',
-                )
-                conflicts.push(conflict)
-                if (handled === 'local') {
-                  await this.remote.put(this.vault, entry.collection, entry.id, conflict.local)
+                if (isTombstoneShape(remoteEnvelope)) {
+                  // #590: remote already shredded this record — enforce locally,
+                  // never resolve. Resolvers must not overrule an erasure.
+                  await this.applyRemote(entry.collection, entry.id, remoteEnvelope)
+                  erasures.push(this.reportErasure(entry.collection, entry.id, remoteEnvelope, envelope, 'push'))
                   completed.push(i)
-                  pushed++
-                } else if (handled === 'remote') {
-                  await this.local.put(this.vault, entry.collection, entry.id, conflict.remote)
-                  completed.push(i)
-                } else if (handled === 'merged' && conflict.local !== envelope) {
-                  // Merged envelope is stored in conflict.local (the winner)
-                  const merged = conflict.local
-                  await this.remote.put(this.vault, entry.collection, entry.id, merged)
-                  await this.local.put(this.vault, entry.collection, entry.id, merged)
-                  completed.push(i)
-                  pushed++
+                } else {
+                  const { handled, conflict } = await this.handleConflict(
+                    entry.collection,
+                    entry.id,
+                    envelope,
+                    remoteEnvelope,
+                    'push',
+                  )
+                  conflicts.push(conflict)
+                  if (handled === 'local') {
+                    await this.remote.put(this.vault, entry.collection, entry.id, conflict.local)
+                    completed.push(i)
+                    pushed++
+                  } else if (handled === 'remote') {
+                    await this.applyRemote(entry.collection, entry.id, conflict.remote)
+                    completed.push(i)
+                  } else if (handled === 'merged' && conflict.local !== envelope) {
+                    // Merged envelope is stored in conflict.local (the winner)
+                    const merged = conflict.local
+                    await this.remote.put(this.vault, entry.collection, entry.id, merged)
+                    await this.applyRemote(entry.collection, entry.id, merged)
+                    completed.push(i)
+                    pushed++
+                  }
+                  // handled === 'deferred': leave in dirty log
                 }
-                // handled === 'deferred': leave in dirty log
               }
             } else {
               throw err
@@ -266,7 +284,7 @@ export class SyncEngine {
     this.lastPush = new Date().toISOString()
     await this.persistMeta()
 
-    const result: PushResult = { pushed, conflicts, errors }
+    const result: PushResult = { pushed, conflicts, errors, erasures }
     this.emitter.emit('sync:push', result)
     return result
   }
@@ -389,6 +407,7 @@ export class SyncEngine {
 
     let pushed = 0
     const conflicts: Conflict[] = []
+    const erasures: ErasureEnforcement[] = []
     const errors: Error[] = []
     const completed: number[] = []
 
@@ -408,6 +427,15 @@ export class SyncEngine {
             continue
           }
 
+          if (isTombstoneShape(envelope)) {
+            // #590: a tombstone push is an erasure assertion — unconditional,
+            // no CAS, no conflict resolution. Erasure always wins.
+            await this.remote.put(this.vault, entry.collection, entry.id, envelope)
+            completed.push(i)
+            pushed++
+            continue
+          }
+
           try {
             await this.remote.put(
               this.vault,
@@ -422,27 +450,35 @@ export class SyncEngine {
             if (err instanceof ConflictError) {
               const remoteEnvelope = await this.remote.get(this.vault, entry.collection, entry.id)
               if (remoteEnvelope) {
-                const { handled, conflict } = await this.handleConflict(
-                  entry.collection,
-                  entry.id,
-                  envelope,
-                  remoteEnvelope,
-                  'push',
-                )
-                conflicts.push(conflict)
-                if (handled === 'local') {
-                  await this.remote.put(this.vault, entry.collection, entry.id, conflict.local)
+                if (isTombstoneShape(remoteEnvelope)) {
+                  // #590: remote already shredded this record — enforce locally,
+                  // never resolve. Resolvers must not overrule an erasure.
+                  await this.applyRemote(entry.collection, entry.id, remoteEnvelope)
+                  erasures.push(this.reportErasure(entry.collection, entry.id, remoteEnvelope, envelope, 'push'))
                   completed.push(i)
-                  pushed++
-                } else if (handled === 'remote') {
-                  await this.local.put(this.vault, entry.collection, entry.id, conflict.remote)
-                  completed.push(i)
-                } else if (handled === 'merged' && conflict.local !== envelope) {
-                  const merged = conflict.local
-                  await this.remote.put(this.vault, entry.collection, entry.id, merged)
-                  await this.local.put(this.vault, entry.collection, entry.id, merged)
-                  completed.push(i)
-                  pushed++
+                } else {
+                  const { handled, conflict } = await this.handleConflict(
+                    entry.collection,
+                    entry.id,
+                    envelope,
+                    remoteEnvelope,
+                    'push',
+                  )
+                  conflicts.push(conflict)
+                  if (handled === 'local') {
+                    await this.remote.put(this.vault, entry.collection, entry.id, conflict.local)
+                    completed.push(i)
+                    pushed++
+                  } else if (handled === 'remote') {
+                    await this.applyRemote(entry.collection, entry.id, conflict.remote)
+                    completed.push(i)
+                  } else if (handled === 'merged' && conflict.local !== envelope) {
+                    const merged = conflict.local
+                    await this.remote.put(this.vault, entry.collection, entry.id, merged)
+                    await this.applyRemote(entry.collection, entry.id, merged)
+                    completed.push(i)
+                    pushed++
+                  }
                 }
               }
             } else {
@@ -462,7 +498,7 @@ export class SyncEngine {
     this.lastPush = new Date().toISOString()
     await this.persistMeta()
 
-    const result: PushResult = { pushed, conflicts, errors }
+    const result: PushResult = { pushed, conflicts, errors, erasures }
     this.emitter.emit('sync:push', result)
     return result
   }

--- a/packages/hub/src/with-party/team/sync.ts
+++ b/packages/hub/src/with-party/team/sync.ts
@@ -590,6 +590,9 @@ export class SyncEngine {
       await this.applyRemote(collection, id, winner)
     }
     await this.remote.put(this.vault, collection, id, winner)
+    // The re-assert already delivered the tombstone remotely — drop any dirty
+    // entry so the following push doesn't redundantly re-put it.
+    this.dirty = this.dirty.filter(d => !(d.collection === collection && d.id === id))
     return this.reportErasure(collection, id, winner, suppressedRemote, 'pull')
   }
 

--- a/packages/hub/src/with-party/team/sync.ts
+++ b/packages/hub/src/with-party/team/sync.ts
@@ -19,7 +19,7 @@ import { ConflictError } from '../../kernel/errors.js'
 import type { NoydbEventEmitter } from '../../kernel/events.js'
 import type { SyncPolicy } from '../../kernel/sync-policy.js'
 import { SyncScheduler } from '../../kernel/sync-policy.js'
-import { isTombstoneShape } from '../../kernel/enclave/record-keys/tombstone.js'
+import { isTombstoneShape } from '../../kernel/enclave/index.js'
 
 /** Sync engine: dirty tracking, push, pull, conflict resolution, scheduling. */
 export class SyncEngine {

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -691,7 +691,10 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 4647→4662 (2026-07-07, #591 satellites archetype-③ — thin call-sites only
   // (declare/joined accessor/proxy wrap/forget ref-expansion/pair-sync hooks); heavy
   // logic in with-shape/satellites): documented actual post-implementation line count.
-  'packages/hub/src/kernel/collection.ts': 4662,
+  // Bumped 4662→4664 (2026-07-09, +2: #590 forget→sync-dirty-log hook): _writeTombstone
+  // enters the sync dirty log via the existing onDirty seam so the shred propagates on
+  // push; one comment + one call, the sync engine itself stays in with-party/team/sync.ts.
+  'packages/hub/src/kernel/collection.ts': 4664,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -862,7 +862,14 @@ const KERNEL_SURFACE_BUDGET = {
   // `if (!coll)` construction branch, since re-declaring an ALREADY-cached
   // collection with a new option skips that branch entirely) — still a thin
   // call-site; the R-S8 refusal logic itself lives in with-shape/satellites/validate.ts.
-  'packages/hub/src/kernel/vault.ts': 3956,
+  // Bumped 3956→3964 (2026-07-09): #598 sync cache-invalidation wiring
+  // (vault._invalidateSyncApplied + openVault hook) — the @internal
+  // `_invalidateSyncApplied(collection, id)` helper the kernel owns: peeks
+  // collectionCache and delegates to the existing Collection
+  // `_invalidateCekCacheEntry`/`_invalidateCacheEntry` pair so sync-applied
+  // envelopes (pull applies, conflict winners, tombstone enforcement) evict
+  // stale decrypted views. Thin call-site; the sync engine lives in with-party/team/.
+  'packages/hub/src/kernel/vault.ts': 3964,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),
@@ -960,7 +967,12 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 2360→2367 (2026-07-07, #591 satellites archetype-③ — thin call-sites only
   // (declare/joined accessor/proxy wrap/forget ref-expansion/pair-sync hooks); heavy
   // logic in with-shape/satellites): documented actual post-implementation line count.
-  'packages/hub/src/kernel/noydb.ts': 2367,
+  // Bumped 2367→2371 (2026-07-09): #598 sync cache-invalidation wiring
+  // (vault._invalidateSyncApplied + openVault hook) — a 4-line
+  // `_forEachSyncEngine(name, …setCacheInvalidator…)` hookup directly after
+  // the openVault Vault construction. Thin call-site; the invalidation itself
+  // lives on Vault/Collection and the engine in with-party/team/.
+  'packages/hub/src/kernel/noydb.ts': 2371,
 }
 
 function checkKernelSurface() {


### PR DESCRIPTION
Closes #590. Closes #598.

Implements `docs/superpowers/specs/2026-07-08-sync-tombstone-terminal-design.md` (milestone: Sync convergence & tombstones).

## What

- `pull()` treats a crypto-shred tombstone as terminal for its record id: never overwritten by a live envelope regardless of `_v`; re-asserted outward (remote re-tombstoned, `_v` bumped to keep counters monotonic, dirty entry dropped after delivery).
- `push()` asserts local tombstones unconditionally (no CAS) and never conflict-resolves against a remote tombstone — per-collection resolvers and the db-level strategy are bypassed for erasures. Mirrored in `pushFiltered()`.
- `_writeTombstone` enters the sync dirty log, so the shred propagates on the normal push channel — including to push-only backup/archive targets that previously kept the pre-shred envelope forever.
- Suppressed edits are reported, never silently applied: `erasures` on `PushResult`/`PullResult`/`SyncTransactionResult` + the `sync:erasure` event (new `ErasureEnforcement` type).
- #598: all sync-applied local writes route through Collection cache invalidation (`SyncEngine.setCacheInvalidator`, wired from `openVault` to `Vault._invalidateSyncApplied`), so enforced tombstones leave no decrypted in-memory residue. Surfaced and fixed a latent `JSON.parse('')` crash in the plaintext codec branch for tombstone-shaped envelopes on `encrypt:false` collections.
- `modifiedSince` partial pulls never skip an arriving tombstone.

## Seam impact

None — no `/kernel`, `/cargo`, or `/adapter` surface change (cargo/kernel goldens byte-identical). Additive-only updates to the enclave barrel golden (`isTombstoneShape`) and root-barrel golden (`ErasureEnforcement`). Resolves the milestone's `port?` to plain `api`. Kernel-surface ceilings bumped minimally with dated justifications: collection 4662→4664, vault 3956→3964, noydb 2367→2371.

## Known, documented window

Any client whose push precedes its pull can transiently resurrect the *remote* copy — including the CAS-matching case: `buildTombstone` keeps the displaced `_v`, so a peer that edited once from the same base passes the `expectedVersion` check and overwrites the remote tombstone silently and unreported. Convergence still holds: the first sync by any tombstone-holder re-tombstones the remote via pull re-assertion; `sync()` (pull-then-push) protects the default path. A dumb ciphertext store cannot enforce this server-side. See spec §3.

## Verification

- Exit-criteria conformance vectors (forget on A + concurrent higher-`_v` edit on offline B + bidirectional sync in both orders → tombstoned everywhere, edit reported) in `packages/hub/__tests__/sync-tombstone-terminal.test.ts` (15 tests, TDD throughout).
- Full hub suite 3370 tests green; typecheck (3 configs); lint; `check:architecture` all guards green.
- Changeset authored locally (`.changeset/sync-tombstone-terminal.md`, kept untracked per repo release flow).

Follow-up notes for #589 (delete tombstones): a local dirty `delete` can remove remote shred *evidence*; the `listSince` doc contract would bypass the client-side tombstone exemption if ever honored; consider `buildTombstone` minting `_v + 1` as a partial CAS-window mitigation.