### PR TITLE
feat(hub): period freeze — reclaim a closed period's delete-marker space (#604)

### DIFF
--- a/docs/superpowers/plans/2026-07-09-period-freeze.md
+++ b/docs/superpowers/plans/2026-07-09-period-freeze.md
@@ -1,0 +1,523 @@
+# Period Freeze Implementation Plan (#604, Spec 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `vault.freezePeriod(name)` to the existing `with-audit/periods` subsystem — physically purge the delete markers within a *closed* period's window via the shipped `_purgeDeleteMarkers` seam, recording freeze state in a companion record + a ledger entry, without ever mutating the hash-chained period record.
+
+**Architecture:** A new `VaultPeriods.freezePeriod` (facade) + thin `vault.freezePeriod` delegator, mirroring `closePeriod`. Freeze computes the period's exclusive upper bound (markers are bounded by write-time `_ts`), calls `vault._purgeDeleteMarkers(before)` through a new dep, and writes a companion `_period_freezes/<name>` record (the chained `_periods/<name>` record stays byte-immutable). Freeze fields are merged into returned `PeriodRecord`s on read.
+
+**Tech Stack:** TypeScript ESM, vitest, pnpm. All work in `packages/hub`. Spec: `docs/superpowers/specs/2026-07-09-period-freeze-design.md`.
+
+## Global Constraints
+
+- **No Claude attribution** in any commit message, PR, or changelog (family-wide hard rule).
+- **Hub stays portable** — no Node built-ins in `packages/hub/src/**`; `crypto.subtle` only. (`new Date(...)`/`Date.parse` are fine — already used in `writePeriodRecord`.)
+- **Frozen seams**: do NOT export new names from `src/legacy/kernel.ts`, `src/with-cargo/index.ts`, `src/legacy/adapter.ts`. New periods types export from the `@noy-db/hub/periods` barrel (`with-audit/periods/index.ts`) only.
+- **Chain immutability (the crux):** freeze must NEVER change the stored `_periods/<name>` record's bytes — the inter-period `priorPeriodHash` chain depends on it. Freeze state lives ONLY in `_period_freezes/<name>`; the `frozenAt`/`frozenBy`/`purgedMarkerCount` fields on `PeriodRecord` are **return-only** (merged on read, never persisted into `_periods`).
+- **Marker boundary:** freeze purges markers with `_ts < periodExclusiveUpperBound(endDate)` — inclusive of `endDate`, exclusive of anything after. Bare-date `endDate` → next midnight; timestamp `endDate` → +1ms.
+- **Opt-in**: everything behind `withPeriods()` / `periodsStrategy` (same as `closePeriod`).
+- **Terminal + idempotent:** no `unfreezePeriod`; a second `freezePeriod` on an already-frozen period is a no-op (companion exists → return merged, no re-purge, no second ledger entry).
+- **kernel-surface metric** is `readFileSync(file).split('\n').length`. `vault.ts` sits at its ceiling `3997` (`scripts/check-architecture.mjs:894`) with zero slack — bump with a dated note. Adding `vault.freezePeriod` also trips the kernel-api-surface golden (a new Vault method) — update its baseline additively.
+- TDD; commands from repo root `/Users/vicio/lanna-db/noy-db`. Branch `feat/604-period-freeze` (created; spec at `ce14492b`).
+
+## Anchors (verified)
+
+- `PeriodRecord`, `ClosePeriodOptions`, `PERIODS_COLLECTION`, `loadPeriods`, `chainAnchor`, `appendPeriodLedgerEntry` in `packages/hub/src/with-audit/periods/periods.ts`.
+- `VaultPeriods` class + `VaultPeriodsDeps` + `writePeriodRecord`/`decryptPeriodRecord`/`loadPeriodsCache`/`getPeriod`/`listPeriods` in `.../periods/vault-facade.ts` (`closePeriod` at ~:60, `writePeriodRecord` at ~:192, `getPeriod` at ~:156).
+- Barrel `.../periods/index.ts`.
+- `vault.closePeriod` delegator at `kernel/vault.ts:3382`; `vault._purgeDeleteMarkers(before, collections?)` at `kernel/vault.ts:1342`; `new VaultPeriods({ strategy: opts.periodsStrategy ?? NO_PERIODS, … })` construction near `kernel/vault.ts:589`.
+
+## Shared test harness
+
+New behavioral tests live in `packages/hub/__tests__/period-freeze.test.ts` (Task 3 creates it). Helper for an encrypted vault with periods + sync (markers require sync):
+
+```ts
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
+import { ConflictError } from '../src/kernel/errors.js'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { withSync } from '../src/with-party/sync/index.js'
+import { withPeriods } from '../src/with-audit/periods/index.js'
+import { withHistory } from '../src/with-commit/history/index.js'
+import { isDeleteMarker } from '../src/kernel/enclave/record-keys/tombstone.js'
+
+function memory(): NoydbStore & { raw(c: string, col: string, id: string): EncryptedEnvelope | undefined } {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    raw(c, col, id) { return store.get(c)?.get(col)?.get(id) },
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) { const coll = gc(c, col); const ex = coll.get(id); if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v); coll.set(id, env) },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) { const comp = store.get(c); const s: VaultSnapshot = {}; if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } } return s },
+    async saveAll(c, data) { for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) } },
+  }
+}
+
+interface Row { amount: number; date: string }
+const V = 'V1'
+async function makeVault() {
+  const local = memory(); const remote = memory()
+  const db = await createNoydb({
+    store: local, sync: remote, user: 'alice', secret: 'hunter2',
+    syncStrategy: withSync(), periodsStrategy: withPeriods(), historyStrategy: withHistory(),
+  })
+  return { local, remote, db, vault: await db.openVault(V) }
+}
+```
+
+Run: `pnpm vitest run packages/hub/__tests__/period-freeze.test.ts`
+
+---
+
+### Task 1: Types, companion collection, and the boundary helper
+
+**Files:**
+- Modify: `packages/hub/src/with-audit/periods/periods.ts`
+- Modify: `packages/hub/src/with-audit/periods/index.ts` (barrel)
+- Test: `packages/hub/src/with-audit/periods/periods.test.ts` (append; create beside source if absent)
+
+**Interfaces:**
+- Produces: `PERIOD_FREEZES_COLLECTION` (`'_period_freezes'`), `interface PeriodFreezeRecord { period; frozenAt; frozenBy; purgedMarkerCount }`, `periodExclusiveUpperBound(endDate: string): string`, and three optional return-only fields on `PeriodRecord` (`frozenAt?`, `frozenBy?`, `purgedMarkerCount?`).
+
+- [ ] **Step 1: Write the failing boundary-helper tests** — append to `periods.test.ts`:
+
+```ts
+import { periodExclusiveUpperBound } from './periods.js'
+
+describe('periodExclusiveUpperBound (#604)', () => {
+  it('bare-date endDate → next midnight (seals through end-of-day)', () => {
+    expect(periodExclusiveUpperBound('2026-03-31')).toBe('2026-04-01T00:00:00.000Z')
+  })
+  it('timestamp endDate → +1ms (seals through that instant)', () => {
+    expect(periodExclusiveUpperBound('2026-03-31T17:00:00.000Z')).toBe('2026-03-31T17:00:00.001Z')
+  })
+  it('a marker at end-of-endDate-day is inside the window; next-day-start is outside', () => {
+    const bound = periodExclusiveUpperBound('2026-03-31')
+    expect('2026-03-31T23:59:59.999Z' < bound).toBe(true)   // purged
+    expect('2026-04-01T00:00:00.000Z' < bound).toBe(false)  // kept
+  })
+  it('throws on an unparseable endDate', () => {
+    expect(() => periodExclusiveUpperBound('not-a-date')).toThrow()
+  })
+})
+```
+
+- [ ] **Step 2: Run — expect FAIL** (`periodExclusiveUpperBound` not exported).
+
+Run: `pnpm vitest run packages/hub/src/with-audit/periods/periods.test.ts`
+
+- [ ] **Step 3: Implement in `periods.ts`.** Add near `PERIODS_COLLECTION`:
+
+```ts
+/** Sibling of {@link PERIODS_COLLECTION} holding freeze companions (#604). */
+export const PERIOD_FREEZES_COLLECTION = '_period_freezes'
+
+/**
+ * Companion record recording that a closed period was frozen (its delete
+ * markers physically purged). Stored in {@link PERIOD_FREEZES_COLLECTION},
+ * keyed by period name — kept OFF the hash-chained `_periods/<name>` record so
+ * freeze never alters the inter-period chain.
+ */
+export interface PeriodFreezeRecord {
+  readonly period: string
+  readonly frozenAt: string
+  readonly frozenBy: string
+  readonly purgedMarkerCount: number
+}
+
+/**
+ * Exclusive upper bound for a period's delete-marker purge window (#604).
+ * Markers carry no business date (empty body), only write-time `_ts`, so freeze
+ * purges markers with `_ts < bound`, `bound` being the instant just after the
+ * period's inclusive `endDate`: a date-only `endDate` seals through end-of-day
+ * → next midnight; a full-timestamp `endDate` seals through that instant → +1ms.
+ */
+export function periodExclusiveUpperBound(endDate: string): string {
+  const ms = Date.parse(endDate)
+  if (Number.isNaN(ms)) throw new ValidationError(`freezePeriod: unparseable period endDate "${endDate}".`)
+  const dateOnly = /^\d{4}-\d{2}-\d{2}$/.test(endDate)
+  return new Date(ms + (dateOnly ? 86_400_000 : 1)).toISOString()
+}
+```
+
+(`ValidationError` is already imported in `periods.ts`.)
+
+Add the return-only fields to `interface PeriodRecord` (below `openingCollections?`):
+
+```ts
+  /** #604 return-only — merged from the `_period_freezes/<name>` companion on
+   *  read; NEVER written into the stored `_periods/<name>` record (would break
+   *  the hash chain). Absent = not yet frozen. */
+  readonly frozenAt?: string
+  readonly frozenBy?: string
+  readonly purgedMarkerCount?: number
+```
+
+- [ ] **Step 4: Barrel** — in `index.ts`, add to the value export `PERIOD_FREEZES_COLLECTION`, `periodExclusiveUpperBound` (beside `PERIODS_COLLECTION`/`loadPeriods`) and to the type export `PeriodFreezeRecord`.
+
+- [ ] **Step 5: Run — expect PASS.** Same command as Step 2. Then `pnpm --filter @noy-db/hub typecheck` → PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/with-audit/periods/periods.ts packages/hub/src/with-audit/periods/index.ts packages/hub/src/with-audit/periods/periods.test.ts
+git commit -m "feat(hub): period freeze types + exclusive-upper-bound helper (#604)"
+```
+
+---
+
+### Task 2: Wire the purge seam into the periods facade
+
+**Files:**
+- Modify: `packages/hub/src/with-audit/periods/vault-facade.ts` (`VaultPeriodsDeps`)
+- Modify: `packages/hub/src/kernel/vault.ts` (the `new VaultPeriods({ … })` construction, ~:589)
+
+**Interfaces:**
+- Produces: `VaultPeriodsDeps.purgeDeleteMarkers(before: string): Promise<number>`, bound to `vault._purgeDeleteMarkers`.
+
+- [ ] **Step 1: Add the dep** — in `vault-facade.ts`, add to `interface VaultPeriodsDeps` (beside `collection`):
+
+```ts
+  /** #604: physically purge delete markers with `_ts < before`. Bound to `vault._purgeDeleteMarkers`. */
+  purgeDeleteMarkers(before: string): Promise<number>
+```
+
+- [ ] **Step 2: Wire it** — in `kernel/vault.ts`, locate the `new VaultPeriods({ … })` deps object (has `strategy: opts.periodsStrategy ?? NO_PERIODS`, `adapter`, `getDEK`, `collection`, …) and add:
+
+```ts
+      purgeDeleteMarkers: (before) => this._purgeDeleteMarkers(before),
+```
+
+- [ ] **Step 3: Verify + commit**
+
+Run: `pnpm --filter @noy-db/hub typecheck` → PASS (a new required dep with no consumer yet still type-checks; the facade compiles).
+
+```bash
+git add packages/hub/src/with-audit/periods/vault-facade.ts packages/hub/src/kernel/vault.ts
+git commit -m "feat(hub): expose _purgeDeleteMarkers to the periods facade (#604)"
+```
+
+---
+
+### Task 3: `VaultPeriods.freezePeriod` + companion read/write + merge
+
+**Files:**
+- Modify: `packages/hub/src/with-audit/periods/vault-facade.ts`
+- Test: `packages/hub/__tests__/period-freeze.test.ts` (CREATE with the harness + these describes)
+
+**Interfaces:**
+- Consumes: `periodExclusiveUpperBound`, `PERIOD_FREEZES_COLLECTION`, `PeriodFreezeRecord` (Task 1); `purgeDeleteMarkers` dep (Task 2); the existing `writePeriodRecord`/`decryptPeriodRecord`/`loadPeriodsCache`/`appendPeriodLedgerEntry`.
+- Produces: `VaultPeriods.freezePeriod(name: string): Promise<PeriodRecord>`; `getPeriod`/`listPeriods` return freeze-merged records.
+
+- [ ] **Step 1: Write the failing tests** — create the test file with the harness, then:
+
+```ts
+describe('freezePeriod (#604)', () => {
+  it('purges in-window delete markers, records the companion + count, leaves the chained record byte-immutable', async () => {
+    const { local, db, vault } = await makeVault()
+    const t = vault.collection<Row>('txns')
+    await t.put('a', { amount: 1, date: '2026-02-01' }); await db.push(V)
+    await t.delete('a'); await db.push(V)                          // delete marker, _ts ~ now (2026-07)
+    // Force the marker's _ts into the period window for the test:
+    const m = local.raw(V, 'txns', 'a')!; expect(isDeleteMarker(m)).toBe(true)
+    await local.put(V, 'txns', 'a', { ...m, _ts: '2026-02-15T00:00:00.000Z' })
+    await vault.closePeriod({ name: 'FY26-Q1', endDate: '2026-03-31' })
+    const before = local.raw(V, '_periods', 'FY26-Q1')!            // snapshot the chained record bytes
+
+    const frozen = await vault.freezePeriod('FY26-Q1')
+
+    expect(frozen.frozenAt).toBeTruthy()
+    expect(frozen.frozenBy).toBe('alice')
+    expect(frozen.purgedMarkerCount).toBe(1)
+    expect(local.raw(V, 'txns', 'a')).toBeUndefined()             // marker physically gone
+    expect(local.raw(V, '_period_freezes', 'FY26-Q1')).toBeDefined()
+    const after = local.raw(V, '_periods', 'FY26-Q1')!
+    expect(after._iv).toBe(before._iv); expect(after._data).toBe(before._data)  // chained record UNCHANGED
+    db.close()
+  })
+
+  it('leaves out-of-window markers, live records, and forget-tombstones untouched', async () => {
+    const { local, db, vault } = await makeVault()
+    const t = vault.collection<Row>('txns', { perRecordKeys: true })
+    await t.put('live', { amount: 5, date: '2026-02-01' })
+    await t.put('late', { amount: 2, date: '2026-02-01' }); await db.push(V)
+    await t.delete('late'); await db.push(V)
+    const late = local.raw(V, 'txns', 'late')!
+    await local.put(V, 'txns', 'late', { ...late, _ts: '2026-05-10T00:00:00.000Z' })  // deleted AFTER Q1 window
+    await t.put('shred', { amount: 9, date: '2026-02-01', subjectId: 's1' } as Row & { subjectId: string })
+    await db.push(V)
+    // (forget requires a forgetStrategy; if not wired here, assert live+late only and note shred separately)
+    await vault.closePeriod({ name: 'FY26-Q1', endDate: '2026-03-31' })
+
+    const frozen = await vault.freezePeriod('FY26-Q1')
+    expect(frozen.purgedMarkerCount).toBe(0)                      // 'late' marker is out of window
+    expect(local.raw(V, 'txns', 'late')).toBeDefined()           // out-of-window marker kept
+    expect((await t.get('live'))!.amount).toBe(5)                 // live untouched
+    db.close()
+  })
+
+  it('requires a closed period: throws on absent or opened', async () => {
+    const { db, vault } = await makeVault()
+    await expect(vault.freezePeriod('nope')).rejects.toThrow(/no period named/)
+    await vault.closePeriod({ name: 'FY26-Q1', endDate: '2026-03-31' })
+    await vault.openPeriod({ name: 'FY26-Q2', startDate: '2026-04-01', fromPeriod: 'FY26-Q1', carryForward: async () => ({}) })
+    await expect(vault.freezePeriod('FY26-Q2')).rejects.toThrow(/only a closed period/)
+    db.close()
+  })
+
+  it('is idempotent: a second freeze is a no-op (no re-purge, no second ledger entry)', async () => {
+    const { local, db, vault } = await makeVault()
+    const t = vault.collection<Row>('txns')
+    await t.put('a', { amount: 1, date: '2026-02-01' }); await db.push(V); await t.delete('a'); await db.push(V)
+    const m = local.raw(V, 'txns', 'a')!; await local.put(V, 'txns', 'a', { ...m, _ts: '2026-02-15T00:00:00.000Z' })
+    await vault.closePeriod({ name: 'FY26-Q1', endDate: '2026-03-31' })
+    const first = await vault.freezePeriod('FY26-Q1')
+    const companionBefore = local.raw(V, '_period_freezes', 'FY26-Q1')!
+    const second = await vault.freezePeriod('FY26-Q1')
+    expect(second.frozenAt).toBe(first.frozenAt)                  // same freeze time (no re-write)
+    expect(second.purgedMarkerCount).toBe(1)
+    expect(local.raw(V, '_period_freezes', 'FY26-Q1')!._data).toBe(companionBefore._data)  // companion unchanged
+    db.close()
+  })
+
+  it('getPeriod / listPeriods return the merged freeze fields; a frozen period still rejects writes', async () => {
+    const { local, db, vault } = await makeVault()
+    const t = vault.collection<Row>('txns')
+    await t.put('a', { amount: 1, date: '2026-02-01' }); await db.push(V); await t.delete('a'); await db.push(V)
+    const m = local.raw(V, 'txns', 'a')!; await local.put(V, 'txns', 'a', { ...m, _ts: '2026-02-15T00:00:00.000Z' })
+    await vault.closePeriod({ name: 'FY26-Q1', endDate: '2026-03-31', dateField: 'date' })
+    await vault.freezePeriod('FY26-Q1')
+
+    expect((await vault.getPeriod('FY26-Q1'))!.frozenAt).toBeTruthy()
+    expect((await vault.listPeriods()).find(p => p.name === 'FY26-Q1')!.purgedMarkerCount).toBe(1)
+    await expect(t.put('b', { amount: 2, date: '2026-02-02' })).rejects.toThrow()  // seal intact
+    db.close()
+  })
+})
+```
+
+(If the forget-tombstone assertion needs a `forgetStrategy`, either wire `withForgetCascade({ subjects: { txns: 'subjectId' } })` into `makeVault` for that test or drop the shred line and assert only live+late — the load-bearing claim is "out-of-window markers and live records survive.")
+
+- [ ] **Step 2: Run — expect FAIL** (`vault.freezePeriod` not a function).
+
+Run: `pnpm vitest run packages/hub/__tests__/period-freeze.test.ts`
+
+- [ ] **Step 3: Implement in `vault-facade.ts`.**
+
+3a. Import: add `PERIOD_FREEZES_COLLECTION`, `PeriodFreezeRecord`, `periodExclusiveUpperBound` to the existing import from `./periods.js`.
+
+3b. Refactor the record IO to serve both collections (DRY — `writePeriodRecord`/`decryptPeriodRecord` currently hardcode `PERIODS_COLLECTION`). Replace them with generic helpers and update the 2 existing `writePeriodRecord(record)` call sites (in `closePeriod` and `openPeriod`) to `writeReserved(PERIODS_COLLECTION, record.name, record)`:
+
+```ts
+private async writeReserved(collection: string, key: string, value: object): Promise<EncryptedEnvelope> {
+  const json = JSON.stringify(value)
+  let envelope: EncryptedEnvelope
+  if (this.deps.encrypted) {
+    const dek = await this.deps.getDEK(collection)
+    const { iv, data } = await encrypt(json, dek)
+    envelope = { _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: new Date().toISOString(), _iv: iv, _data: data, _by: this.deps.userId() }
+  } else {
+    envelope = { _noydb: NOYDB_FORMAT_VERSION, _v: 1, _ts: new Date().toISOString(), _iv: '', _data: json, _by: this.deps.userId() }
+  }
+  await this.deps.adapter.put(this.deps.vault, collection, key, envelope)
+  return envelope
+}
+
+private async readReserved<T>(collection: string, key: string): Promise<T | null> {
+  const env = await this.deps.adapter.get(this.deps.vault, collection, key)
+  if (!env) return null
+  const json = this.deps.encrypted ? await openEnvelopeJson(env, await this.deps.getDEK(collection)) : env._data
+  return JSON.parse(json) as T
+}
+```
+
+Keep `decryptPeriodRecord` (used by `loadPeriodsCache`/`assertTsWritable` decrypt callbacks) as-is, or have it delegate to a shared decrypt of `env` — minimal change: leave `decryptPeriodRecord` untouched and only replace `writePeriodRecord`. (If `writePeriodRecord` is only called by close/open, converting it to `writeReserved` and updating both call sites is the clean DRY move; if that widens the diff more than you like, add `writeReserved`/`readReserved` alongside and leave `writePeriodRecord` for close/open. Either is fine — the tests are the contract.)
+
+3c. Add `freezePeriod` + the merge helper:
+
+```ts
+async freezePeriod(name: string): Promise<PeriodRecord> {
+  const existing = await this.loadPeriodsCache()
+  const period = existing.find((p) => p.name === name)
+  if (!period) throw new ValidationError(`freezePeriod: no period named "${name}".`)
+  if (period.kind !== 'closed') {
+    throw new ValidationError(`freezePeriod: period "${name}" is "${period.kind}"; only a closed period can be frozen.`)
+  }
+  const prior = await this.readReserved<PeriodFreezeRecord>(PERIOD_FREEZES_COLLECTION, name)
+  if (prior) return this.mergeFreeze(period, prior)             // idempotent no-op
+
+  const before = periodExclusiveUpperBound(period.endDate)
+  const purgedMarkerCount = await this.deps.purgeDeleteMarkers(before)
+  const freeze: PeriodFreezeRecord = { period: name, frozenAt: new Date().toISOString(), frozenBy: this.deps.userId(), purgedMarkerCount }
+  const envelope = await this.writeReserved(PERIOD_FREEZES_COLLECTION, name, freeze)
+  await this.deps.strategy.appendPeriodLedgerEntry(this.deps.getLedgerOrNull(), this.deps.userId(), envelope, name)
+  return this.mergeFreeze(period, freeze)
+}
+
+private mergeFreeze(period: PeriodRecord, freeze: PeriodFreezeRecord): PeriodRecord {
+  return { ...period, frozenAt: freeze.frozenAt, frozenBy: freeze.frozenBy, purgedMarkerCount: freeze.purgedMarkerCount }
+}
+```
+
+3d. Merge on read. Change `getPeriod` to merge its companion, and `listPeriods` to merge all companions (read the freeze collection once):
+
+```ts
+async getPeriod(name: string): Promise<PeriodRecord | null> {
+  const all = await this.loadPeriodsCache()
+  const period = all.find((p) => p.name === name)
+  if (!period) return null
+  const freeze = await this.readReserved<PeriodFreezeRecord>(PERIOD_FREEZES_COLLECTION, name)
+  return freeze ? this.mergeFreeze(period, freeze) : period
+}
+```
+
+For `listPeriods()` (find its current body), after loading the periods, load the freeze companions once and merge:
+
+```ts
+async listPeriods(): Promise<readonly PeriodRecord[]> {
+  const all = await this.loadPeriodsCache()
+  const freezeIds = await this.deps.adapter.list(this.deps.vault, PERIOD_FREEZES_COLLECTION)
+  const freezes = new Map<string, PeriodFreezeRecord>()
+  for (const id of freezeIds) {
+    const f = await this.readReserved<PeriodFreezeRecord>(PERIOD_FREEZES_COLLECTION, id)
+    if (f) freezes.set(f.period, f)
+  }
+  return all.map((p) => { const f = freezes.get(p.name); return f ? this.mergeFreeze(p, f) : p })
+}
+```
+
+**IMPORTANT:** do NOT merge freeze fields into `this.periodCache` — the cache feeds the write-guard and must stay = the stored chained records. `mergeFreeze` returns fresh copies only.
+
+- [ ] **Step 4: Run — expect PASS** (all freeze tests). Same command as Step 2.
+
+- [ ] **Step 5: Regression + commit**
+
+```bash
+pnpm vitest run packages/hub/__tests__/periods.test.ts packages/hub/__tests__/accounting-periods.test.ts 2>/dev/null || pnpm vitest run -t "period"
+git add packages/hub/src/with-audit/periods/vault-facade.ts packages/hub/__tests__/period-freeze.test.ts
+git commit -m "feat(hub): VaultPeriods.freezePeriod — companion-record purge, idempotent, chain-immutable (#604)"
+```
+
+(Find the existing periods test file name with `ls packages/hub/__tests__ | grep -i period` and run it as the regression — close/open/list/get must still pass, especially the chain.)
+
+---
+
+### Task 4: `vault.freezePeriod` delegator + guards
+
+**Files:**
+- Modify: `packages/hub/src/kernel/vault.ts` (delegator beside `closePeriod` at ~:3382)
+- Modify: `scripts/check-architecture.mjs` (vault.ts kernel-surface ceiling ~:894)
+- Modify: the kernel-api-surface golden baseline (Vault method list)
+
+**Interfaces:**
+- Consumes: `VaultPeriods.freezePeriod` (Task 3).
+- Produces: `vault.freezePeriod(name: string): Promise<PeriodRecord>`.
+
+- [ ] **Step 1: Add the delegator** — in `vault.ts`, beside `closePeriod`/`openPeriod`/`listPeriods`:
+
+```ts
+  /**
+   * Freeze a CLOSED period (#604): physically purge the delete markers whose
+   * write-time `_ts` falls within the period (≤ `endDate`) via the shipped
+   * purge seam, recording a `_period_freezes/<name>` companion + a ledger
+   * entry. The closed period is the operator-asserted convergence safe-point
+   * #589's markers need; purging re-opens the resurrection window for any peer
+   * offline since before the cutoff, so this is deliberate and terminal.
+   * Idempotent; requires the periods strategy.
+   */
+  async freezePeriod(name: string): Promise<PeriodRecord> {
+    return this.periods.freezePeriod(name)
+  }
+```
+
+- [ ] **Step 2: Bump the kernel-surface ceiling** — measure and set:
+
+Run: `awk 'END{print NR+1}' packages/hub/src/kernel/vault.ts` → set `scripts/check-architecture.mjs` line ~894 `'packages/hub/src/kernel/vault.ts'` to that value, with an appended dated note: `// Bumped 3997→<N> (2026-07-09, +<delta>: #604 vault.freezePeriod delegator).`
+
+- [ ] **Step 3: Update the kernel-api-surface golden** — adding a Vault method trips it. Run the surface goldens to see which fails:
+
+Run: `pnpm vitest run -t "surface" packages/hub/__tests__/` (or locate the kernel-api-surface golden test: `ls packages/hub/__tests__ | grep -i surface`). The failing golden lists `freezePeriod` as a new Vault member. Update its baseline `.golden.json` (or the inline expected list) per the test's documented mechanism — **add `freezePeriod` in sorted position; remove/rename nothing.** Re-run → PASS.
+
+- [ ] **Step 4: Verify + commit**
+
+```bash
+pnpm --filter @noy-db/hub typecheck
+pnpm check:architecture
+pnpm vitest run packages/hub/__tests__/period-freeze.test.ts
+git add packages/hub/src/kernel/vault.ts scripts/check-architecture.mjs packages/hub/__tests__/*surface*.golden.json packages/hub/__tests__/*surface*.test.ts
+git commit -m "feat(hub): vault.freezePeriod delegator + surface guards (#604)"
+```
+
+---
+
+### Task 5: Module docs + verification sweep + changeset
+
+**Files:**
+- Modify: `packages/hub/src/with-audit/periods/periods.ts` (module docstring — add the freeze phase to the "Closure model" / "Not covered" sections)
+- Create: `.changeset/period-freeze.md` (LOCAL — `.changeset/` is gitignored; do NOT `git add` it)
+
+- [ ] **Step 1: Doc the freeze phase** — in the `periods.ts` module docstring, add a short "Freeze" subsection after the closure/opening models: `vault.freezePeriod(name)` physically purges a closed period's delete markers (via the #589 seam), recording a `_period_freezes/<name>` companion + ledger entry; the chained `_periods/<name>` record is never mutated; terminal + idempotent. Move the note that it does NOT purge forget-tombstones/history here. (The `noy-db-docs` subsystem page is a separate cross-repo doc-sync follow-up — note it in the PR, don't edit it here.)
+
+- [ ] **Step 2: Full verification** (lint runs in CI — run it locally)
+
+```bash
+pnpm --filter @noy-db/hub test
+pnpm --filter @noy-db/hub typecheck
+pnpm --filter @noy-db/hub lint
+pnpm check:architecture
+pnpm vitest run packages/hub/__tests__/cargo-surface-golden.test.ts packages/hub/__tests__/kernel-surface-golden.test.ts
+```
+
+Expected: all PASS. Cargo/kernel-surface goldens: the kernel-api-surface golden changed additively in Task 4 (`freezePeriod`); the **cargo** golden must stay UNCHANGED (freezePeriod is not a cargo export). If cargo golden fails, you exported into the wrong seam — undo.
+
+- [ ] **Step 3: Changeset** — create `.changeset/period-freeze.md` (do NOT commit; gitignored):
+
+```markdown
+---
+'@noy-db/hub': minor
+---
+
+Period freeze (#604). `vault.freezePeriod(name)` physically reclaims the space held by a closed accounting period's delete markers — it purges the delete markers whose write-time falls within the period (via the operator-asserted safe-point the closed period provides), records a `_period_freezes/<name>` companion + a tamper-evident ledger entry, and leaves the hash-chained period record byte-immutable. Terminal and idempotent; requires `withPeriods()`. Forget-tombstones, history, and live records are untouched. Closes the `_purgeDeleteMarkers` audit-emission deferred from #589.
+```
+
+- [ ] **Step 4: Commit the doc change** (changeset excluded)
+
+```bash
+git add packages/hub/src/with-audit/periods/periods.ts
+git commit -m "docs(hub): document the period freeze phase (#604)"
+```
+
+---
+
+### Task 6: PR
+
+- [ ] **Step 1: Push + open the PR**
+
+```bash
+git push -u origin feat/604-period-freeze
+gh pr create --repo vLannaAi/noy-db --title "feat(hub): period freeze — reclaim a closed period's delete-marker space (#604)" --body "$(cat <<'EOF'
+Closes #604 (Spec 2 of the #589 arc). Spec: docs/superpowers/specs/2026-07-09-period-freeze-design.md. Milestone: Retention: purge, GC & archival.
+
+`vault.freezePeriod(name)` adds the "frozen" phase to the existing accounting-periods subsystem: a *closed* period is the operator-asserted convergence safe-point #589's delete markers need, so freezing it physically purges the markers whose write-time `_ts` falls within the period (`_ts ≤ endDate`, via the shipped `_purgeDeleteMarkers` seam).
+
+- **Chain-immutable:** freeze state lives in a companion `_period_freezes/<name>` record; the hash-chained `_periods/<name>` record is never mutated (a rewrite would break the successor's `priorPeriodHash` once `verifyPeriodChain()` ships). `frozenAt`/`frozenBy`/`purgedMarkerCount` are merged into returned `PeriodRecord`s on read.
+- **Marker boundary:** markers carry no business date, so they're bounded by write-time `_ts`; a late-booked delete (in-period business date, deleted after `endDate`) is reclaimed by the next period's freeze — conservative and correct.
+- **Audit:** freeze appends a tamper-evident ledger entry — this closes the `_purgeDeleteMarkers` ledger/event emission deferred from #589.
+- Terminal + idempotent; opt-in via `withPeriods()`; forget-tombstones/history/live records untouched. `surface: api` — no `/adapter` change.
+
+Out of scope (own later specs / dropped): cold-archival tiering, forget-tombstone/history purge, re-open, scheduled/auto-freeze, cross-vault fleet freeze.
+
+Verification: full hub suite + typecheck + lint + check:architecture; kernel-api-surface golden updated additively for `vault.freezePeriod`; cargo/kernel-surface goldens otherwise unchanged. Changeset local (`@noy-db/hub` minor). Follow-up: noy-db-docs periods subsystem page.
+EOF
+)"
+```
+
+- [ ] **Step 2: Grep the diff for the pilot-client name** (family hard rule):
+
+Run: `git diff main...HEAD | grep -i "<pilot-client-name>"` — expected: no matches.

--- a/docs/superpowers/specs/2026-07-09-period-freeze-design.md
+++ b/docs/superpowers/specs/2026-07-09-period-freeze-design.md
@@ -54,20 +54,26 @@ Implementation detail: `_purgeDeleteMarkers(before)` filters `env._ts < before` 
 
 ### 3. State + ledger (closes a #589 deferral)
 
-Freeze rewrites the `_periods/<name>` record with three added fields and appends a tamper-evident ledger entry:
+**Freeze must NOT mutate the chained `_periods/<name>` record.** Periods are hash-chained: each period stores `priorPeriodHash = sha256(canonicalJson(priorPeriodRecord))` (`chainAnchor`), and the subsystem explicitly anticipates a `verifyPeriodChain()` (docstring, `periods.ts`). Rewriting a *sealed, already-chained* period record to add `frozenAt` would change its `canonicalJson` → change its hash → make the successor's stored `priorPeriodHash` mismatch → break the chain the moment that verifier ships. There is no `verifyPeriodChain()` today, so this would be a *latent* corruption in the one property the subsystem exists to guarantee — unacceptable in an audit product.
+
+Instead, freeze state lives in a **companion record** in a new reserved collection, leaving the chained record untouched:
 
 ```ts
-// added to PeriodRecord (all optional; absent = not yet frozen)
-readonly frozenAt?: string          // ISO, freeze call time
-readonly frozenBy?: string          // invoking keyring userId
-readonly purgedMarkerCount?: number // markers physically removed
+export const PERIOD_FREEZES_COLLECTION = '_period_freezes'   // sibling of '_periods'
+
+export interface PeriodFreezeRecord {
+  readonly period: string             // the frozen period's name (the key)
+  readonly frozenAt: string           // ISO, freeze call time
+  readonly frozenBy: string           // invoking keyring userId
+  readonly purgedMarkerCount: number  // markers physically removed
+}
 ```
 
-The rewrite goes through the same ledger-instrumented path `closePeriod` uses (`appendPeriodLedgerEntry`), so the freeze — a *destructive* operator action — lands a hash-chained audit entry (actor, boundary, count). **This is exactly the ledger/event emission deferred from #589's `_purgeDeleteMarkers`** (the seam's doc said "emits no ledger/event yet — #604's period-close, the only intended caller, owns the audit record"). Freeze is that caller; this closes the deferral.
+`PeriodRecord` gains the same three fields as **optional, return-only** (`frozenAt?`, `frozenBy?`, `purgedMarkerCount?`): they are **never written into the stored `_periods/<name>` record** (so its `canonicalJson`/hash is unchanged), and are merged in from the companion when a `PeriodRecord` is *returned* by `getPeriod` / `listPeriods` / `freezePeriod`. The public shape stays "a frozen period carries these fields"; the storage keeps them off the chained record.
 
-The period-record rewrite must preserve the hash chain: `freezePeriod` updates the existing record in place (same `name`, `kind`, `endDate`, `priorPeriodHash`), adding only the freeze fields, and re-appends the ledger entry — it does **not** re-chain or alter `priorPeriodHash` (freeze is metadata on an existing sealed record, not a new period). The plan verifies `loadPeriods()`'s chain still validates after a freeze.
+Freeze writes the companion through the same encrypt-and-put path period records use (`writePeriodRecord`-style, keyed `_period_freezes/<name>`) and appends a tamper-evident ledger entry via `appendPeriodLedgerEntry` (actor, boundary, count). **This is exactly the ledger/event emission deferred from #589's `_purgeDeleteMarkers`** (its doc: "emits no ledger/event yet — #604's period-close, the only intended caller, owns the audit record"). Freeze is that caller; this closes the deferral.
 
-**Idempotency:** if the period already has `frozenAt`, `freezePeriod` is a **no-op** that returns the existing record — no re-purge (the range is already empty anyway) and no second ledger entry.
+**Idempotency:** `freezePeriod` first reads the companion `_period_freezes/<name>`; if present, it is a **no-op** returning the period merged with the existing freeze fields — no re-purge, no second ledger entry.
 
 ### 4. Interaction with the write-seal
 
@@ -82,7 +88,7 @@ Behind `withPeriods()`, on an encrypted vault:
 3. **Never touch live / forget-tombstones:** live records and forget crypto-shred tombstones in-window are untouched by freeze.
 4. **Gating:** `freezePeriod` on a nonexistent or `kind: 'opened'` period throws; requires the strategy.
 5. **Idempotent:** second `freezePeriod` is a no-op (no extra ledger entry, count unchanged, `frozenAt` stable).
-6. **Ledger + chain:** the freeze appends one ledger entry; `frozenAt/frozenBy/purgedMarkerCount` persist; `loadPeriods()` hash chain still validates.
+6. **Ledger + chain immutability:** the freeze appends one ledger entry and writes the `_period_freezes/<name>` companion; the stored `_periods/<name>` record's bytes are **unchanged** by freeze (assert the chained record's `canonicalJson`/hash is identical before and after a freeze); `getPeriod`/`listPeriods` return the period with the merged freeze fields.
 7. **Seal preserved:** writes to the frozen period still throw `PeriodClosedError`.
 8. **Boundary construction:** parametrized over a bare-date `endDate` (`'2026-03-31'`) and a full-timestamp `endDate` — the inclusive-of-`endDate`, exclusive-of-after invariant holds for both.
 

--- a/docs/superpowers/specs/2026-07-09-period-freeze-design.md
+++ b/docs/superpowers/specs/2026-07-09-period-freeze-design.md
@@ -1,0 +1,94 @@
+# Period freeze — design (#604, Spec 2 of the #589 arc)
+
+**Date:** 2026-07-09
+**Issue:** [#604](https://github.com/vLannaAi/noy-db/issues/604) (period-close lifecycle + operator purge/archive)
+**Milestone:** Retention: purge, GC & archival — this design is `surface: api` (no `/adapter` change).
+**Builds on:** #589's shipped `Vault._purgeDeleteMarkers(before, collections?)` seam (`kernel/vault.ts:1342`) and the existing `with-audit/periods` subsystem.
+
+## Reframing (from the brainstorm)
+
+#604 was scoped as "build a period-close lifecycle + purge + archive + summaries + scheduling." Exploration found the **`with-audit/periods` subsystem already exists and is mature**: `vault.closePeriod({ name, endDate, dateField? })` seals every record whose business date (`record[dateField]`, else envelope `_ts`) is `≤ endDate` — further writes throw `PeriodClosedError`; the period is a ledger-instrumented record in the reserved `_periods` collection with a tamper-evident hash chain; `vault.openPeriod({ …, carryForward })` materializes closing aggregates as opening balances (**that is the "summary"**); `listPeriods`/`getPeriod` round it out; opt-in via `withPeriods()` / `periodsStrategy`.
+
+Two originally-sketched #604 features conflict with deliberate existing decisions and are **dropped**: **re-open** (the sanctioned path is a compensating entry in the *new* period, not unlocking a sealed one) and **scheduled/auto-rollover** (`close`/`open` are deliberately explicit operator calls).
+
+What genuinely does **not** exist is the **"frozen" phase**: a closed period seals writes *logically* but nothing *physically* purges the delete markers #589 leaves behind. That is this spec. Cold-archival tiering of sealed records is deferred to its own later spec.
+
+## Decision summary
+
+1. **Scope:** add `vault.freezePeriod(name)` — physically purge the delete markers within a *closed* period's window, via `_purgeDeleteMarkers`. Purge only; no cold-archival.
+2. **Safe-point:** a closed period is the operator-asserted convergence boundary #589 requires; the `freezePeriod` call *is* the assertion (no auto-freeze, no mandatory delay in v1).
+3. **Marker boundary:** markers have no business date (empty body), so freeze bounds them by write-time `_ts ≤ endDate`. Late-booked deletes reclaim at the next period's freeze.
+4. **Terminal + idempotent:** frozen cannot be unfrozen; re-freezing is a no-op.
+5. **Surface:** `api` only — uses the store's existing `delete` via the shipped seam; no `/adapter` change.
+
+## Design
+
+### 1. API + gating
+
+```ts
+vault.freezePeriod(name: string): Promise<PeriodRecord>
+```
+
+- Loads the periods cache; the named period must exist and be `kind: 'closed'`. Throw `ValidationError` if the period is absent or is `kind: 'opened'`. If the period exists, is closed, and is **already frozen**, return it unchanged (idempotent no-op — see §3).
+- Requires the periods service (`withPeriods()`); with `NO_PERIODS` the call path is unreachable (same as `closePeriod`).
+- **The operator's call is the convergence assertion.** No settle-delay guard in v1 — the operator owns "this period is settled," exactly as they own `closePeriod`. (A future optional `{ minClosedAge }` guard is a clean additive extension; YAGNI now.)
+- **Terminal:** there is no `unfreezePeriod`, consistent with the subsystem's no-re-open stance.
+
+Wire it the same way as `closePeriod`: a `VaultPeriods.freezePeriod` method (`with-audit/periods/vault-facade.ts`) + a thin `vault.freezePeriod` delegator (`kernel/vault.ts`, beside `closePeriod` at ~:3382).
+
+### 2. What it purges — the marker boundary
+
+Freeze calls the shipped seam:
+
+```ts
+const purged = await this._purgeDeleteMarkers(<exclusiveUpperBound>)
+```
+
+**The nuance:** the period *seals records* by business date (`record[dateField] ≤ endDate`), but a delete marker carries an **empty body — no `dateField`, only its write-time `_ts`**. So markers can only be bounded by `_ts`. Freeze purges delete markers with **`_ts ≤ period.endDate`**.
+
+Implementation detail: `_purgeDeleteMarkers(before)` filters `env._ts < before` (strict). `endDate` is an inclusive date/timestamp bound. To make `_ts ≤ endDate` inclusive of the whole `endDate`, pass the **exclusive upper bound**: if the period has a successor `opened` period chained from it (via `openPeriod`'s `fromPeriod`), use that successor's `startDate`; otherwise use `endDate` widened to its end-of-day (`endDate` + `'T23:59:59.999Z'` when `endDate` is a bare date, else `endDate` itself is already a timestamp and the successor/`endDate`-as-is applies). The spec's invariant is *inclusive of `endDate`, exclusive of anything after*; the plan pins the exact string construction with tests for both a bare-date `endDate` and a full-timestamp `endDate`.
+
+**Consequence (documented, correct):** a *late-booked* delete — a record with an in-period business date, deleted *after* `endDate` (write-time `_ts` after the window) — has an out-of-window marker `_ts`, so it is **not** purged by this period's freeze; it is reclaimed when the *next* period freezes (its `_ts` falls in that window). This is conservative and correct: the delete already converged and reads absent; the marker merely lingers one more period. It is the only sound option given markers have no business date.
+
+**Never touched:** forget-tombstones (GDPR crypto-shred erasure *evidence*) and live records — the `_purgeDeleteMarkers` seam is delete-markers-only by construction (`isDeleteMarker`, i.e. `_del === true`), so `isTombstoneShape` forget-tombstones and live envelopes are structurally out of range. Freeze passes **no `collections` filter** → all data collections in the vault.
+
+### 3. State + ledger (closes a #589 deferral)
+
+Freeze rewrites the `_periods/<name>` record with three added fields and appends a tamper-evident ledger entry:
+
+```ts
+// added to PeriodRecord (all optional; absent = not yet frozen)
+readonly frozenAt?: string          // ISO, freeze call time
+readonly frozenBy?: string          // invoking keyring userId
+readonly purgedMarkerCount?: number // markers physically removed
+```
+
+The rewrite goes through the same ledger-instrumented path `closePeriod` uses (`appendPeriodLedgerEntry`), so the freeze — a *destructive* operator action — lands a hash-chained audit entry (actor, boundary, count). **This is exactly the ledger/event emission deferred from #589's `_purgeDeleteMarkers`** (the seam's doc said "emits no ledger/event yet — #604's period-close, the only intended caller, owns the audit record"). Freeze is that caller; this closes the deferral.
+
+The period-record rewrite must preserve the hash chain: `freezePeriod` updates the existing record in place (same `name`, `kind`, `endDate`, `priorPeriodHash`), adding only the freeze fields, and re-appends the ledger entry — it does **not** re-chain or alter `priorPeriodHash` (freeze is metadata on an existing sealed record, not a new period). The plan verifies `loadPeriods()`'s chain still validates after a freeze.
+
+**Idempotency:** if the period already has `frozenAt`, `freezePeriod` is a **no-op** that returns the existing record — no re-purge (the range is already empty anyway) and no second ledger entry.
+
+### 4. Interaction with the write-seal
+
+Unchanged and strictly additive: a frozen period is still `kind: 'closed'`, so the existing `assertTsWritable` guard still rejects writes to it. Freeze changes only physical storage (markers removed), never the seal semantics. Reads of purged ids remain `null` (they were already absent via the marker; now they're absent via true removal).
+
+### 5. Testing
+
+Behind `withPeriods()`, on an encrypted vault:
+
+1. **Purge in-window markers:** close a period; delete records with markers whose `_ts ≤ endDate`; `freezePeriod` removes them from the raw store; `purgedMarkerCount` matches; reads stay `null`.
+2. **Leave out-of-window markers:** a marker with `_ts` after `endDate` (late-booked delete) survives freeze; a subsequent later period's freeze reclaims it.
+3. **Never touch live / forget-tombstones:** live records and forget crypto-shred tombstones in-window are untouched by freeze.
+4. **Gating:** `freezePeriod` on a nonexistent or `kind: 'opened'` period throws; requires the strategy.
+5. **Idempotent:** second `freezePeriod` is a no-op (no extra ledger entry, count unchanged, `frozenAt` stable).
+6. **Ledger + chain:** the freeze appends one ledger entry; `frozenAt/frozenBy/purgedMarkerCount` persist; `loadPeriods()` hash chain still validates.
+7. **Seal preserved:** writes to the frozen period still throw `PeriodClosedError`.
+8. **Boundary construction:** parametrized over a bare-date `endDate` (`'2026-03-31'`) and a full-timestamp `endDate` — the inclusive-of-`endDate`, exclusive-of-after invariant holds for both.
+
+## Out of scope (deferred / dropped)
+
+- **Cold-archival tiering** of sealed live records (move to an `archive` target, keep summaries hot) — its own later spec; may need a storage-adapter capability (`surface: port`).
+- **Purging forget-tombstones / history** — kept as audit evidence.
+- **Re-open** and **scheduled/auto-freeze** — dropped (conflict with the subsystem's deliberate design).
+- **Cross-vault / fleet freeze** (klum-db orchestration) — periods are a single-vault primitive; fleet orchestration, if ever wanted, binds this via `@noy-db/hub/cargo` and is klum's concern.

--- a/packages/hub/__tests__/kernel-api.golden.json
+++ b/packages/hub/__tests__/kernel-api.golden.json
@@ -109,6 +109,7 @@
     "exportStream",
     "forget",
     "frame",
+    "freezePeriod",
     "getBundleHandle",
     "getDocumentSigningPublicKey",
     "getLedgerOrNull",

--- a/packages/hub/__tests__/period-freeze.test.ts
+++ b/packages/hub/__tests__/period-freeze.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for `vault.freezePeriod()` (#604).
+ *
+ * Freeze physically purges the delete markers that fall inside a
+ * CLOSED period's window and records that fact in a companion
+ * `_period_freezes/<name>` record — kept OFF the hash-chained
+ * `_periods/<name>` record so freezing never mutates a chained
+ * record's bytes (load-bearing: see "leaves ... byte-immutable"
+ * below). `frozenAt` / `frozenBy` / `purgedMarkerCount` are merged
+ * into `PeriodRecord`s on read only (`getPeriod` / `listPeriods`).
+ *
+ * Harness mirrors delete-tombstone-convergence.test.ts's white-box
+ * `memory()` store (exposes `.raw()`) wired with `withSync()` so
+ * `delete()` leaves a marker instead of a physical removal.
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
+import { ConflictError } from '../src/kernel/errors.js'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { withSync } from '../src/with-party/sync/index.js'
+import { withPeriods } from '../src/with-audit/periods/index.js'
+import { isDeleteMarker } from '../src/kernel/enclave/record-keys/tombstone.js'
+
+/** In-memory store exposing raw stored envelopes for white-box assertions. */
+function memory(): NoydbStore & { raw(c: string, col: string, id: string): EncryptedEnvelope | undefined } {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    raw(c, col, id) { return store.get(c)?.get(col)?.get(id) },
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) }
+    },
+  }
+}
+
+interface Row { amount: number; date: string }
+const V = 'V1'
+
+async function makeVault() {
+  const local = memory(); const remote = memory()
+  const db = await createNoydb({
+    store: local,
+    sync: remote,
+    user: 'alice',
+    syncStrategy: withSync(),
+    periodsStrategy: withPeriods(),
+    encrypt: false,
+  })
+  const vault = await db.openVault(V)
+  return { local, remote, db, vault }
+}
+
+describe('freezePeriod (#604)', () => {
+  it('purges in-window delete markers, records the companion + count, leaves the chained record byte-immutable', async () => {
+    const { local, db, vault } = await makeVault()
+    const t = vault.collection<Row>('txns')
+    await t.put('a', { amount: 1, date: '2026-02-01' }); await db.push(V)
+    await t.delete('a'); await db.push(V)                          // delete marker, _ts ~ now (2026-07)
+    // Force the marker's _ts into the period window for the test:
+    const m = local.raw(V, 'txns', 'a')!; expect(isDeleteMarker(m)).toBe(true)
+    await local.put(V, 'txns', 'a', { ...m, _ts: '2026-02-15T00:00:00.000Z' })
+    await vault.closePeriod({ name: 'FY26-Q1', endDate: '2026-03-31' })
+    const before = local.raw(V, '_periods', 'FY26-Q1')!            // snapshot the chained record bytes
+
+    const frozen = await vault.freezePeriod('FY26-Q1')
+
+    expect(frozen.frozenAt).toBeTruthy()
+    expect(frozen.frozenBy).toBe('alice')
+    expect(frozen.purgedMarkerCount).toBe(1)
+    expect(local.raw(V, 'txns', 'a')).toBeUndefined()             // marker physically gone
+    expect(local.raw(V, '_period_freezes', 'FY26-Q1')).toBeDefined()
+    const after = local.raw(V, '_periods', 'FY26-Q1')!
+    expect(after._iv).toBe(before._iv); expect(after._data).toBe(before._data)  // chained record UNCHANGED
+    db.close()
+  })
+
+  it('leaves out-of-window markers and live records untouched', async () => {
+    const { local, db, vault } = await makeVault()
+    const t = vault.collection<Row>('txns', { perRecordKeys: true })
+    await t.put('live', { amount: 5, date: '2026-02-01' })
+    await t.put('late', { amount: 2, date: '2026-02-01' }); await db.push(V)
+    await t.delete('late'); await db.push(V)
+    const late = local.raw(V, 'txns', 'late')!
+    await local.put(V, 'txns', 'late', { ...late, _ts: '2026-05-10T00:00:00.000Z' })  // deleted AFTER Q1 window
+    await vault.closePeriod({ name: 'FY26-Q1', endDate: '2026-03-31' })
+
+    const frozen = await vault.freezePeriod('FY26-Q1')
+    expect(frozen.purgedMarkerCount).toBe(0)                      // 'late' marker is out of window
+    expect(local.raw(V, 'txns', 'late')).toBeDefined()           // out-of-window marker kept
+    expect((await t.get('live'))!.amount).toBe(5)                 // live untouched
+    db.close()
+  })
+
+  it('requires a closed period: throws on absent or opened', async () => {
+    const { db, vault } = await makeVault()
+    await expect(vault.freezePeriod('nope')).rejects.toThrow(/no period named/)
+    await vault.closePeriod({ name: 'FY26-Q1', endDate: '2026-03-31' })
+    await vault.openPeriod({ name: 'FY26-Q2', startDate: '2026-04-01', fromPeriod: 'FY26-Q1', carryForward: async () => ({}) })
+    await expect(vault.freezePeriod('FY26-Q2')).rejects.toThrow(/only a closed period/)
+    db.close()
+  })
+
+  it('is idempotent: a second freeze is a no-op (no re-purge, no second ledger entry)', async () => {
+    const { local, db, vault } = await makeVault()
+    const t = vault.collection<Row>('txns')
+    await t.put('a', { amount: 1, date: '2026-02-01' }); await db.push(V); await t.delete('a'); await db.push(V)
+    const m = local.raw(V, 'txns', 'a')!; await local.put(V, 'txns', 'a', { ...m, _ts: '2026-02-15T00:00:00.000Z' })
+    await vault.closePeriod({ name: 'FY26-Q1', endDate: '2026-03-31' })
+    const first = await vault.freezePeriod('FY26-Q1')
+    const companionBefore = local.raw(V, '_period_freezes', 'FY26-Q1')!
+    const second = await vault.freezePeriod('FY26-Q1')
+    expect(second.frozenAt).toBe(first.frozenAt)                  // same freeze time (no re-write)
+    expect(second.purgedMarkerCount).toBe(1)
+    expect(local.raw(V, '_period_freezes', 'FY26-Q1')!._data).toBe(companionBefore._data)  // companion unchanged
+    db.close()
+  })
+
+  it('getPeriod / listPeriods return the merged freeze fields; a frozen period still rejects writes', async () => {
+    const { local, db, vault } = await makeVault()
+    const t = vault.collection<Row>('txns')
+    await t.put('a', { amount: 1, date: '2026-02-01' }); await db.push(V); await t.delete('a'); await db.push(V)
+    const m = local.raw(V, 'txns', 'a')!; await local.put(V, 'txns', 'a', { ...m, _ts: '2026-02-15T00:00:00.000Z' })
+    await vault.closePeriod({ name: 'FY26-Q1', endDate: '2026-03-31', dateField: 'date' })
+    await vault.freezePeriod('FY26-Q1')
+
+    expect((await vault.getPeriod('FY26-Q1'))!.frozenAt).toBeTruthy()
+    expect((await vault.listPeriods()).find(p => p.name === 'FY26-Q1')!.purgedMarkerCount).toBe(1)
+    await expect(t.put('b', { amount: 2, date: '2026-02-02' })).rejects.toThrow()  // seal intact
+    db.close()
+  })
+})

--- a/packages/hub/__tests__/period-freeze.test.ts
+++ b/packages/hub/__tests__/period-freeze.test.ts
@@ -119,6 +119,14 @@ describe('freezePeriod (#604)', () => {
     db.close()
   })
 
+  it('refuses to freeze a period whose purge window reaches into the future (#610)', async () => {
+    const { db, vault } = await makeVault()
+    // closePeriod does not validate endDate against now, so a future window is reachable.
+    await vault.closePeriod({ name: 'FY99', endDate: '2099-12-31' })
+    await expect(vault.freezePeriod('FY99')).rejects.toThrow(/future/)
+    db.close()
+  })
+
   it('is idempotent: a second freeze is a no-op (no re-purge, no second ledger entry)', async () => {
     const { local, db, vault } = await makeVault()
     const t = vault.collection<Row>('txns')

--- a/packages/hub/__tests__/period-freeze.test.ts
+++ b/packages/hub/__tests__/period-freeze.test.ts
@@ -19,6 +19,7 @@ import { ConflictError } from '../src/kernel/errors.js'
 import { createNoydb } from '../src/kernel/noydb.js'
 import { withSync } from '../src/with-party/sync/index.js'
 import { withPeriods } from '../src/with-audit/periods/index.js'
+import { withHistory } from '../src/with-commit/history/index.js'
 import { isDeleteMarker } from '../src/kernel/enclave/record-keys/tombstone.js'
 
 /** In-memory store exposing raw stored envelopes for white-box assertions. */
@@ -61,7 +62,8 @@ async function makeVault() {
     user: 'alice',
     syncStrategy: withSync(),
     periodsStrategy: withPeriods(),
-    encrypt: false,
+    historyStrategy: withHistory(),
+    secret: 'hunter2',
   })
   const vault = await db.openVault(V)
   return { local, remote, db, vault }
@@ -143,6 +145,42 @@ describe('freezePeriod (#604)', () => {
     expect((await vault.getPeriod('FY26-Q1'))!.frozenAt).toBeTruthy()
     expect((await vault.listPeriods()).find(p => p.name === 'FY26-Q1')!.purgedMarkerCount).toBe(1)
     await expect(t.put('b', { amount: 2, date: '2026-02-02' })).rejects.toThrow()  // seal intact
+    db.close()
+  })
+
+  it('the freeze ledger entry is attributed to _period_freezes, not _periods — verifyBackupIntegrity stays ok, re-freeze appends no extra entry (review C1)', async () => {
+    const { local, db, vault } = await makeVault()
+    const t = vault.collection<Row>('txns')
+    await t.put('a', { amount: 1, date: '2026-02-01' }); await db.push(V)
+    await t.delete('a'); await db.push(V)
+    const m = local.raw(V, 'txns', 'a')!
+    await local.put(V, 'txns', 'a', { ...m, _ts: '2026-02-15T00:00:00.000Z' })
+    await vault.closePeriod({ name: 'FY26-Q1', endDate: '2026-03-31' })
+
+    // Sanity: clean before freeze.
+    expect((await vault.verifyBackupIntegrity()).ok).toBe(true)
+
+    await vault.freezePeriod('FY26-Q1')
+
+    // The freeze's ledger entry must record the _period_freezes companion
+    // it actually wrote, not the untouched _periods/<name> chained record.
+    const entriesAfterFirstFreeze = await vault.ledger().loadAllEntries()
+    const freezeEntry = entriesAfterFirstFreeze[entriesAfterFirstFreeze.length - 1]!
+    expect(freezeEntry.collection).toBe('_period_freezes')
+    expect(freezeEntry.id).toBe('FY26-Q1')
+
+    // A cross-check on the latest put per (collection, id) must not
+    // mistake the freeze entry for a rewrite of _periods/<name> — that
+    // would hash-mismatch against the actually-stored (unchanged) close
+    // envelope and falsely brick backup/restore.
+    const verifyAfterFreeze = await vault.verifyBackupIntegrity()
+    expect(verifyAfterFreeze.ok).toBe(true)
+
+    // Idempotent re-freeze: no additional ledger entry.
+    await vault.freezePeriod('FY26-Q1')
+    const entriesAfterSecondFreeze = await vault.ledger().loadAllEntries()
+    expect(entriesAfterSecondFreeze.length).toBe(entriesAfterFirstFreeze.length)
+
     db.close()
   })
 })

--- a/packages/hub/__tests__/periods.test.ts
+++ b/packages/hub/__tests__/periods.test.ts
@@ -17,7 +17,7 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { memory } from '../../to-memory/src/index.js'
 import { ValidationError, PeriodClosedError, createNoydb } from '../src/index.js'
-import { withPeriods } from '../src/with-audit/periods/index.js'
+import { withPeriods, periodExclusiveUpperBound } from '../src/with-audit/periods/index.js'
 import type { Noydb } from '../src/index.js'
 
 interface Invoice { amount: number; status: string; date: string }
@@ -267,6 +267,23 @@ describe('vault.closePeriod() + openPeriod() — v0.17 / ', () => {
           carryForward: async () => ({}),
         }),
       ).rejects.toBeInstanceOf(ValidationError)
+    })
+  })
+
+  describe('periodExclusiveUpperBound (#604)', () => {
+    it('bare-date endDate → next midnight (seals through end-of-day)', () => {
+      expect(periodExclusiveUpperBound('2026-03-31')).toBe('2026-04-01T00:00:00.000Z')
+    })
+    it('timestamp endDate → +1ms (seals through that instant)', () => {
+      expect(periodExclusiveUpperBound('2026-03-31T17:00:00.000Z')).toBe('2026-03-31T17:00:00.001Z')
+    })
+    it('a marker at end-of-endDate-day is inside the window; next-day-start is outside', () => {
+      const bound = periodExclusiveUpperBound('2026-03-31')
+      expect('2026-03-31T23:59:59.999Z' < bound).toBe(true)   // purged
+      expect('2026-04-01T00:00:00.000Z' < bound).toBe(false)  // kept
+    })
+    it('throws on an unparseable endDate', () => {
+      expect(() => periodExclusiveUpperBound('not-a-date')).toThrow()
     })
   })
 })

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -3418,7 +3418,10 @@ export class Vault {
   /**
    * Freeze a closed period (#604): purges in-window delete markers and
    * records a `_period_freezes` companion, never mutating the chained
-   * `_periods` record. Idempotent.
+   * `_periods` record. Idempotent. Purges the LOCAL adapter only — a
+   * synced target's markers survive there and re-import on pull (benign),
+   * and purging re-opens the #589 resurrection window for a peer offline
+   * since before the cutoff (see periods.ts's "Freeze" section).
    */
   async freezePeriod(name: string): Promise<PeriodRecord> {
     return this.periods.freezePeriod(name)

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -3415,6 +3415,15 @@ export class Vault {
     return this.periods.getPeriod(name)
   }
 
+  /**
+   * Freeze a closed period (#604): purges in-window delete markers and
+   * records a `_period_freezes` companion, never mutating the chained
+   * `_periods` record. Idempotent.
+   */
+  async freezePeriod(name: string): Promise<PeriodRecord> {
+    return this.periods.freezePeriod(name)
+  }
+
   /** @internal — called by the gate bus before put/delete. */
   async _assertTsWritable(
     existing: { ts: string | null; record: Record<string, unknown> | null } | null,

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -594,6 +594,7 @@ export class Vault {
       getDEK: (collection) => this.getDEK(collection),
       getLedgerOrNull: () => this.getLedgerOrNull(),
       collection: (name) => this.collection(name),
+      purgeDeleteMarkers: (before) => this._purgeDeleteMarkers(before),
     })
     this.linksEnforcer = new VaultLinks({
       refRegistry: this.refRegistry,

--- a/packages/hub/src/with-audit/periods/index.ts
+++ b/packages/hub/src/with-audit/periods/index.ts
@@ -17,6 +17,8 @@ export type { PeriodsStrategy } from './strategy.js'
 
 export {
   PERIODS_COLLECTION,
+  PERIOD_FREEZES_COLLECTION,
+  periodExclusiveUpperBound,
   loadPeriods,
   chainAnchor,
   assertTsWritable,
@@ -25,6 +27,7 @@ export {
 } from './periods.js'
 export type {
   PeriodRecord,
+  PeriodFreezeRecord,
   ClosePeriodOptions,
   OpenPeriodOptions,
   CarryForwardContext,

--- a/packages/hub/src/with-audit/periods/periods.ts
+++ b/packages/hub/src/with-audit/periods/periods.ts
@@ -65,10 +65,19 @@
  *
  * Freeze purges the LOCAL adapter only. On a synced vault, markers already
  * pushed to sync targets survive there, and a later pull re-imports them
- * (benign — they still read deleted, but the space isn't reclaimed).
- * Purging re-opens the #589 resurrection window for a peer offline since
- * before the cutoff, which is why the closed period is the
- * operator-asserted safe-point that gates the call.
+ * (benign — they still read deleted, but the space isn't reclaimed). A
+ * re-imported marker keeps its original `_ts` (inside the already-frozen
+ * period's window), so — like any late-booked delete — it is reclaimed by
+ * the NEXT period's freeze, whose window covers it; freeze stays terminal
+ * and does NOT re-purge an already-frozen period (#611). Sweeping the sync
+ * targets themselves is a cross-target-purge concern deferred to the
+ * cold-archival spec. Purging re-opens the #589 resurrection window for a
+ * peer offline since before the cutoff, which is why the closed period is
+ * the operator-asserted safe-point that gates the call.
+ *
+ * A period whose purge window has not fully elapsed cannot be frozen —
+ * `freezePeriod` throws rather than purge markers for deletes that may not
+ * have converged yet (#610).
  *
  * ## Not covered
  *

--- a/packages/hub/src/with-audit/periods/periods.ts
+++ b/packages/hub/src/with-audit/periods/periods.ts
@@ -63,6 +63,13 @@
  * versions, or live records — the delete-markers-only seam leaves all
  * three untouched by construction.
  *
+ * Freeze purges the LOCAL adapter only. On a synced vault, markers already
+ * pushed to sync targets survive there, and a later pull re-imports them
+ * (benign — they still read deleted, but the space isn't reclaimed).
+ * Purging re-opens the #589 resurrection window for a peer offline since
+ * before the cutoff, which is why the closed period is the
+ * operator-asserted safe-point that gates the call.
+ *
  * ## Not covered
  *
  * - Partial re-opening of a closed period. If an auditor needs to

--- a/packages/hub/src/with-audit/periods/periods.ts
+++ b/packages/hub/src/with-audit/periods/periods.ts
@@ -378,12 +378,13 @@ export async function appendPeriodLedgerEntry(
   actor: string,
   envelope: EncryptedEnvelope,
   name: string,
+  collection: string = PERIODS_COLLECTION,
 ): Promise<void> {
   if (!ledger) return
   const { envelopePayloadHash } = await import('../../with-commit/history/ledger/index.js')
   await ledger.append({
     op: 'put',
-    collection: PERIODS_COLLECTION,
+    collection,
     id: name,
     version: envelope._v,
     actor,

--- a/packages/hub/src/with-audit/periods/periods.ts
+++ b/packages/hub/src/with-audit/periods/periods.ts
@@ -41,6 +41,28 @@
  * as normal records with fresh timestamps that fall outside every
  * closed period.
  *
+ * ## Freeze
+ *
+ * ```
+ * vault.freezePeriod('FY2026-Q1')
+ *   └─► physically purges delete markers whose write-time falls inside
+ *       the closed period's window (via the #589 `_purgeDeleteMarkers`
+ *       seam), then records the fact:
+ *         ├─ PeriodFreezeRecord written to _period_freezes/<name>
+ *         └─ normal ledger append fires (LedgerStore.append)
+ * ```
+ *
+ * The chained `_periods/<name>` record is never mutated — `frozenAt` /
+ * `frozenBy` / `purgedMarkerCount` are merged onto the returned
+ * `PeriodRecord` at read time from the companion, so a tamper with the
+ * freeze can never break the inter-period hash chain. Freezing is
+ * terminal (a closed period, once frozen, stays frozen) and idempotent
+ * (a second call is a no-op that returns the same merged record without
+ * re-purging or re-appending a ledger entry). Freeze does NOT purge
+ * forget-tombstones (GDPR crypto-shred erasure evidence), `_history`
+ * versions, or live records — the delete-markers-only seam leaves all
+ * three untouched by construction.
+ *
  * ## Not covered
  *
  * - Partial re-opening of a closed period. If an auditor needs to

--- a/packages/hub/src/with-audit/periods/periods.ts
+++ b/packages/hub/src/with-audit/periods/periods.ts
@@ -62,6 +62,36 @@ import { PeriodClosedError, ValidationError } from '../../kernel/errors.js'
 /** The reserved collection name holding closed-period metadata. */
 export const PERIODS_COLLECTION = '_periods'
 
+/** Sibling of {@link PERIODS_COLLECTION} holding freeze companions (#604). */
+export const PERIOD_FREEZES_COLLECTION = '_period_freezes'
+
+/**
+ * Companion record recording that a closed period was frozen (its delete
+ * markers physically purged). Stored in {@link PERIOD_FREEZES_COLLECTION},
+ * keyed by period name — kept OFF the hash-chained `_periods/<name>` record so
+ * freeze never alters the inter-period chain.
+ */
+export interface PeriodFreezeRecord {
+  readonly period: string
+  readonly frozenAt: string
+  readonly frozenBy: string
+  readonly purgedMarkerCount: number
+}
+
+/**
+ * Exclusive upper bound for a period's delete-marker purge window (#604).
+ * Markers carry no business date (empty body), only write-time `_ts`, so freeze
+ * purges markers with `_ts < bound`, `bound` being the instant just after the
+ * period's inclusive `endDate`: a date-only `endDate` seals through end-of-day
+ * → next midnight; a full-timestamp `endDate` seals through that instant → +1ms.
+ */
+export function periodExclusiveUpperBound(endDate: string): string {
+  const ms = Date.parse(endDate)
+  if (Number.isNaN(ms)) throw new ValidationError(`freezePeriod: unparseable period endDate "${endDate}".`)
+  const dateOnly = /^\d{4}-\d{2}-\d{2}$/.test(endDate)
+  return new Date(ms + (dateOnly ? 86_400_000 : 1)).toISOString()
+}
+
 /**
  * Stored record for one closed or opened accounting period. One entry
  * per period, keyed by `name` in the reserved `_periods` collection.
@@ -116,6 +146,12 @@ export interface PeriodRecord {
    * cross-check the opening balances against the closing snapshot.
    */
   readonly openingCollections?: readonly string[]
+  /** #604 return-only — merged from the `_period_freezes/<name>` companion on
+   *  read; NEVER written into the stored `_periods/<name>` record (would break
+   *  the hash chain). Absent = not yet frozen. */
+  readonly frozenAt?: string
+  readonly frozenBy?: string
+  readonly purgedMarkerCount?: number
 }
 
 /** Options for `vault.closePeriod()`. */

--- a/packages/hub/src/with-audit/periods/strategy.ts
+++ b/packages/hub/src/with-audit/periods/strategy.ts
@@ -39,6 +39,7 @@ export interface PeriodsStrategy {
     actor: string,
     envelope: EncryptedEnvelope,
     periodName: string,
+    collection?: string,
   ): Promise<void>
 }
 

--- a/packages/hub/src/with-audit/periods/vault-facade.ts
+++ b/packages/hub/src/with-audit/periods/vault-facade.ts
@@ -183,7 +183,13 @@ export class VaultPeriods {
       purgedMarkerCount,
     }
     const envelope = await this.writeReserved(PERIOD_FREEZES_COLLECTION, name, freeze)
-    await this.deps.strategy.appendPeriodLedgerEntry(this.deps.getLedgerOrNull(), this.deps.userId(), envelope, name)
+    await this.deps.strategy.appendPeriodLedgerEntry(
+      this.deps.getLedgerOrNull(),
+      this.deps.userId(),
+      envelope,
+      name,
+      PERIOD_FREEZES_COLLECTION,
+    )
     return this.mergeFreeze(period, freeze)
   }
 

--- a/packages/hub/src/with-audit/periods/vault-facade.ts
+++ b/packages/hub/src/with-audit/periods/vault-facade.ts
@@ -41,6 +41,8 @@ export interface VaultPeriodsDeps {
   getLedgerOrNull(): LedgerStore | null
   /** Collection accessor (used by `openPeriod`'s carry-forward writes). */
   collection<T = unknown>(name: string): Collection<T>
+  /** #604: physically purge delete markers with `_ts < before`. Bound to `vault._purgeDeleteMarkers`. */
+  purgeDeleteMarkers(before: string): Promise<number>
 }
 
 export class VaultPeriods {

--- a/packages/hub/src/with-audit/periods/vault-facade.ts
+++ b/packages/hub/src/with-audit/periods/vault-facade.ts
@@ -171,10 +171,19 @@ export class VaultPeriods {
         `freezePeriod: period "${name}" is "${period.kind}"; only a closed period can be frozen.`,
       )
     }
+    // #610: refuse a period whose purge window reaches into the future. Markers
+    // are bounded by write-time `_ts`, so a not-yet-elapsed window would purge
+    // deletes written seconds ago that cannot have converged to any peer.
+    const before = periodExclusiveUpperBound(period.endDate)
+    if (Date.parse(before) > Date.now()) {
+      throw new ValidationError(
+        `freezePeriod: period "${name}" purge window ends at ${before}, in the future; ` +
+          `only a period whose window is fully in the past can be frozen (recent delete markers may not have converged).`,
+      )
+    }
     const prior = await this.readReserved<PeriodFreezeRecord>(PERIOD_FREEZES_COLLECTION, name)
     if (prior) return this.mergeFreeze(period, prior) // idempotent no-op
 
-    const before = periodExclusiveUpperBound(period.endDate)
     const purgedMarkerCount = await this.deps.purgeDeleteMarkers(before)
     const freeze: PeriodFreezeRecord = {
       period: name,

--- a/packages/hub/src/with-audit/periods/vault-facade.ts
+++ b/packages/hub/src/with-audit/periods/vault-facade.ts
@@ -18,7 +18,10 @@ import type { Collection } from '../../kernel/collection.js'
 import type { PeriodsStrategy } from './strategy.js'
 import {
   PERIODS_COLLECTION,
+  PERIOD_FREEZES_COLLECTION,
+  periodExclusiveUpperBound,
   type PeriodRecord,
+  type PeriodFreezeRecord,
   type ClosePeriodOptions,
   type OpenPeriodOptions,
 } from './periods.js'
@@ -73,7 +76,7 @@ export class VaultPeriods {
       ...(anchor.priorPeriodName !== undefined && { priorPeriodName: anchor.priorPeriodName }),
       ...(options.dateField !== undefined && { dateField: options.dateField }),
     }
-    const envelope = await this.writePeriodRecord(record)
+    const envelope = await this.writeReserved(PERIODS_COLLECTION, record.name, record)
     await this.deps.strategy.appendPeriodLedgerEntry(this.deps.getLedgerOrNull(), this.deps.userId(), envelope, record.name)
     existing.push(record)
     this.periodCache = existing
@@ -143,22 +146,79 @@ export class VaultPeriods {
       priorPeriodName: anchor.priorPeriodName ?? prior.name,
       ...(openingCollections.length > 0 && { openingCollections }),
     }
-    const envelope = await this.writePeriodRecord(record)
+    const envelope = await this.writeReserved(PERIODS_COLLECTION, record.name, record)
     await this.deps.strategy.appendPeriodLedgerEntry(this.deps.getLedgerOrNull(), this.deps.userId(), envelope, record.name)
     existing.push(record)
     this.periodCache = existing
     return record
   }
 
-  /** Return every closed / opened period in `closedAt` order. */
-  async listPeriods(): Promise<readonly PeriodRecord[]> {
-    return [...(await this.loadPeriodsCache())]
+  /**
+   * Freeze a closed period: physically purges delete markers whose `_ts`
+   * falls inside the period's window (#604) and records the fact in a
+   * companion `_period_freezes/<name>` record. NEVER mutates the
+   * hash-chained `_periods/<name>` record's stored bytes — `frozenAt` /
+   * `frozenBy` / `purgedMarkerCount` are merged into `PeriodRecord`s on
+   * read only. Idempotent: a second call is a no-op that returns the
+   * same merged record without re-purging or re-appending a ledger entry.
+   */
+  async freezePeriod(name: string): Promise<PeriodRecord> {
+    const existing = await this.loadPeriodsCache()
+    const period = existing.find((p) => p.name === name)
+    if (!period) throw new ValidationError(`freezePeriod: no period named "${name}".`)
+    if (period.kind !== 'closed') {
+      throw new ValidationError(
+        `freezePeriod: period "${name}" is "${period.kind}"; only a closed period can be frozen.`,
+      )
+    }
+    const prior = await this.readReserved<PeriodFreezeRecord>(PERIOD_FREEZES_COLLECTION, name)
+    if (prior) return this.mergeFreeze(period, prior) // idempotent no-op
+
+    const before = periodExclusiveUpperBound(period.endDate)
+    const purgedMarkerCount = await this.deps.purgeDeleteMarkers(before)
+    const freeze: PeriodFreezeRecord = {
+      period: name,
+      frozenAt: new Date().toISOString(),
+      frozenBy: this.deps.userId(),
+      purgedMarkerCount,
+    }
+    const envelope = await this.writeReserved(PERIOD_FREEZES_COLLECTION, name, freeze)
+    await this.deps.strategy.appendPeriodLedgerEntry(this.deps.getLedgerOrNull(), this.deps.userId(), envelope, name)
+    return this.mergeFreeze(period, freeze)
   }
 
-  /** Look up a single period by name. Returns `null` if not found. */
+  /** Merge freeze companion fields into a fresh `PeriodRecord` copy — never mutates `periodCache`. */
+  private mergeFreeze(period: PeriodRecord, freeze: PeriodFreezeRecord): PeriodRecord {
+    return {
+      ...period,
+      frozenAt: freeze.frozenAt,
+      frozenBy: freeze.frozenBy,
+      purgedMarkerCount: freeze.purgedMarkerCount,
+    }
+  }
+
+  /** Return every closed / opened period in `closedAt` order, merged with any freeze companions. */
+  async listPeriods(): Promise<readonly PeriodRecord[]> {
+    const all = await this.loadPeriodsCache()
+    const freezeIds = await this.deps.adapter.list(this.deps.vault, PERIOD_FREEZES_COLLECTION)
+    const freezes = new Map<string, PeriodFreezeRecord>()
+    for (const id of freezeIds) {
+      const f = await this.readReserved<PeriodFreezeRecord>(PERIOD_FREEZES_COLLECTION, id)
+      if (f) freezes.set(f.period, f)
+    }
+    return all.map((p) => {
+      const f = freezes.get(p.name)
+      return f ? this.mergeFreeze(p, f) : p
+    })
+  }
+
+  /** Look up a single period by name, merged with its freeze companion if any. Returns `null` if not found. */
   async getPeriod(name: string): Promise<PeriodRecord | null> {
     const all = await this.loadPeriodsCache()
-    return all.find((p) => p.name === name) ?? null
+    const period = all.find((p) => p.name === name)
+    if (!period) return null
+    const freeze = await this.readReserved<PeriodFreezeRecord>(PERIOD_FREEZES_COLLECTION, name)
+    return freeze ? this.mergeFreeze(period, freeze) : period
   }
 
   /** Called by the gate bus before put/delete. */
@@ -191,11 +251,12 @@ export class VaultPeriods {
     return loaded
   }
 
-  private async writePeriodRecord(record: PeriodRecord): Promise<EncryptedEnvelope> {
-    const json = JSON.stringify(record)
+  /** Generic reserved-collection writer — serves `_periods` and `_period_freezes` alike. */
+  private async writeReserved(collection: string, key: string, value: object): Promise<EncryptedEnvelope> {
+    const json = JSON.stringify(value)
     let envelope: EncryptedEnvelope
     if (this.deps.encrypted) {
-      const dek = await this.deps.getDEK(PERIODS_COLLECTION)
+      const dek = await this.deps.getDEK(collection)
       const { iv, data } = await encrypt(json, dek)
       envelope = {
         _noydb: NOYDB_FORMAT_VERSION,
@@ -215,8 +276,16 @@ export class VaultPeriods {
         _by: this.deps.userId(),
       }
     }
-    await this.deps.adapter.put(this.deps.vault, PERIODS_COLLECTION, record.name, envelope)
+    await this.deps.adapter.put(this.deps.vault, collection, key, envelope)
     return envelope
+  }
+
+  /** Generic reserved-collection reader — serves `_period_freezes` companion reads. */
+  private async readReserved<T>(collection: string, key: string): Promise<T | null> {
+    const env = await this.deps.adapter.get(this.deps.vault, collection, key)
+    if (!env) return null
+    const json = this.deps.encrypted ? await openEnvelopeJson(env, await this.deps.getDEK(collection)) : env._data
+    return JSON.parse(json) as T
   }
 
   private async decryptPeriodRecord(envelope: EncryptedEnvelope): Promise<PeriodRecord> {

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -891,7 +891,11 @@ const KERNEL_SURFACE_BUDGET = {
   // sentences on `_purgeDeleteMarkers` — ledger/event emission deferred to #604, and
   // local-adapter-only purge scope (operator must purge every sync target too). No
   // behavior change.
-  'packages/hub/src/kernel/vault.ts': 3997,
+  // Bumped 3997→4007 (2026-07-09, +10: #604 Task 3): `vault.freezePeriod(name)`
+  // delegator — thin call-site onto `VaultPeriods.freezePeriod`; the freeze logic
+  // itself lives in with-audit/periods/vault-facade.ts. Genuinely core (new public
+  // Vault method, same tier as closePeriod/openPeriod/getPeriod above it).
+  'packages/hub/src/kernel/vault.ts': 4007,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),
@@ -1616,7 +1620,14 @@ const PRE_EXISTING_BODY_ACCESS = new Map([
   ['packages/hub/src/with-audit/attestation/signer.ts', 2],
   ['packages/hub/src/with-audit/consent/consent.ts', 5],
   ['packages/hub/src/with-audit/forget/subject-index.ts', 7],
-  ['packages/hub/src/with-audit/periods/vault-facade.ts', 5],
+  // #604 Task 3: `readReserved()` — generic reserved-collection reader added
+  // alongside `writeReserved()` (DRY'd from the old `writePeriodRecord`) to
+  // also serve the `_period_freezes` companion. Its plaintext fallback
+  // (`env._data`) mirrors the identical established ternary idiom already
+  // used in with-shape/links/link-set.ts and with-commit/{numbering,sequence}/index.ts
+  // (`this.encrypted ? await openEnvelopeJson(...) : env._data`) — reviewed,
+  // not a new pattern.
+  ['packages/hub/src/with-audit/periods/vault-facade.ts', 6],
   ['packages/hub/src/with-audit/portability/request-withdrawal.ts', 4],
   ['packages/hub/src/with-audit/portability/withdraw-accessible.ts', 2],
   ['packages/hub/src/with-audit/sealed-record/index.ts', 4],

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -895,7 +895,11 @@ const KERNEL_SURFACE_BUDGET = {
   // delegator — thin call-site onto `VaultPeriods.freezePeriod`; the freeze logic
   // itself lives in with-audit/periods/vault-facade.ts. Genuinely core (new public
   // Vault method, same tier as closePeriod/openPeriod/getPeriod above it).
-  'packages/hub/src/kernel/vault.ts': 4007,
+  // Bumped 4007→4010 (2026-07-09, +3: #604 final-review Fix I3): restored the
+  // local-adapter-only-purge / #589 resurrection-window caveat onto the
+  // `freezePeriod` delegator's docstring (trimmed from the shipped version).
+  // No behavior change.
+  'packages/hub/src/kernel/vault.ts': 4010,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),


### PR DESCRIPTION
Closes #604 (Spec 2 of the #589 arc). Spec: docs/superpowers/specs/2026-07-09-period-freeze-design.md. Milestone: Retention: purge, GC & archival.

`vault.freezePeriod(name)` adds the "frozen" phase to the existing accounting-periods subsystem: a *closed* period is the operator-asserted convergence safe-point #589's delete markers need, so freezing it physically purges the markers whose write-time `_ts` falls within the period (`_ts ≤ endDate`, via the shipped `_purgeDeleteMarkers` seam).

- **Chain-immutable:** freeze state lives in a companion `_period_freezes/<name>` record; the hash-chained `_periods/<name>` record is never mutated (a rewrite would break the successor's `priorPeriodHash` once `verifyPeriodChain()` ships). A test asserts the chained record's `_iv`/`_data` are byte-identical before/after a freeze. `frozenAt`/`frozenBy`/`purgedMarkerCount` are merged into returned `PeriodRecord`s on read.
- **Honest audit:** the freeze ledger entry records a `put` of the `_period_freezes/<name>` companion (not the chained record), so `verifyBackupIntegrity()` stays green on a `withPeriods()`+`withHistory()` vault — verified end-to-end. This closes the `_purgeDeleteMarkers` ledger/event emission deferred from #589.
- **Marker boundary:** markers carry no business date, so they're bounded by write-time `_ts`; a late-booked delete (in-period business date, deleted after `endDate`) is reclaimed by the next period's freeze — conservative and correct.
- Terminal + idempotent; opt-in via `withPeriods()`; forget-tombstones/history/live records untouched. `surface: api` — no `/adapter` change (no noy-db-to involvement).

**Caveat (documented on the API):** freeze purges the LOCAL adapter only; on a synced vault, markers already pushed to sync targets survive there (a later pull re-imports them — benign, still read deleted, but not reclaimed). Purging re-opens the #589 resurrection window for a peer offline since before the cutoff — which is why the closed period is the operator-asserted safe-point.

## Review depth

Subagent-driven (6 tasks, per-task + whole-branch review). The whole-branch review caught a **Critical the per-task reviews missed**: the freeze ledger entry initially misattributed itself as a second `put` of the chained `_periods/<name>` record, which would have made `verifyBackupIntegrity()` fail with a false tamper alarm and bricked backup/snapshot restore on any history-enabled vault — missed because the Task-3 harness had dropped the plan's `withHistory()`+encryption. Fixed (thread the collection through the ledger append) and the harness restored to encrypted+history with a `verifyBackupIntegrity`-ok-post-freeze test.

## Out of scope (own later specs / dropped)

Cold-archival tiering, forget-tombstone/history purge, re-open, scheduled/auto-freeze, cross-vault fleet freeze. Follow-ups filed: a future-`endDate` freeze guard, and the sync-target-purge / re-purge-semantics question.

Verification: full hub suite 3399 + typecheck + lint + check:architecture; kernel-api golden additive (`freezePeriod`); cargo/kernel-surface goldens unchanged. Changeset local (`@noy-db/hub` minor). Follow-up: noy-db-docs periods subsystem page.

---

**Follow-ups folded in (post-review):**
- Closes #610 — `freezePeriod` refuses a purge window that reaches into the future (safety rail from review Minor 4; TDD-covered).
- #611 (freeze scope / re-freeze semantics) resolved as a documented design decision and closed: re-imported markers reclaim at the next period's freeze; cross-target sweep deferred to the cold-archival spec.
