### PR TITLE
chore: release v0.3.0-pre.8

### DIFF
--- a/packages/as-aws-s3/CHANGELOG.md
+++ b/packages/as-aws-s3/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-aws-s3
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/as-aws-s3/package.json
+++ b/packages/as-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-aws-s3",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "AWS S3 object projection for noy-db — serve blob bytes directly from S3/CDN (presigned or public), outside the encrypted store",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-blob/CHANGELOG.md
+++ b/packages/as-blob/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-blob
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/as-blob/package.json
+++ b/packages/as-blob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-blob",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Single-attachment plaintext export for noy-db — extracts one blob from BlobSet as native MIME bytes. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier, document sub-family).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-csv/CHANGELOG.md
+++ b/packages/as-csv/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-csv
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/as-csv/package.json
+++ b/packages/as-csv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-csv",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "CSV plaintext export for noy-db — decrypts records and formats as comma-separated values. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-json/CHANGELOG.md
+++ b/packages/as-json/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-json
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/as-json/package.json
+++ b/packages/as-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-json",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Structured JSON plaintext export for noy-db — decrypts records and emits one JSON document per vault. Gated by RFC #249 canExportPlaintext capability; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-ndjson/CHANGELOG.md
+++ b/packages/as-ndjson/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-ndjson
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/as-ndjson/package.json
+++ b/packages/as-ndjson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-ndjson",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Newline-delimited JSON export for noy-db — streaming plaintext export suitable for data pipelines, warehouse ingestion, and jq pipelines. Gated by RFC #249 canExportPlaintext. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-noydb/CHANGELOG.md
+++ b/packages/as-noydb/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-noydb
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/as-noydb/package.json
+++ b/packages/as-noydb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-noydb",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Encrypted .noydb bundle export for noy-db — wraps writeNoydbBundle() with the RFC #249 canExportBundle authorization gate and ergonomic browser/node helpers. Sole member of the @noy-db/as-* encrypted tier — ciphertext in, ciphertext out.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-sql/CHANGELOG.md
+++ b/packages/as-sql/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-sql
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/as-sql/package.json
+++ b/packages/as-sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-sql",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "SQL dump export for noy-db — decrypts records and emits dialect-aware CREATE TABLE + INSERT statements for postgres / mysql / sqlite. One-way migration helper. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xlsx/CHANGELOG.md
+++ b/packages/as-xlsx/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/as-xlsx
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+  - @noy-db/as-zip@1.0.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/as-xlsx/package.json
+++ b/packages/as-xlsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xlsx",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Excel spreadsheet plaintext export for noy-db — produces a real .xlsx (Office Open XML) from one or more collections. Multi-sheet, Unicode-safe via shared-strings table. Zero runtime deps beyond the workspace zip encoder. Gated by RFC #249 `canExportPlaintext` with format `'xlsx'`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xml/CHANGELOG.md
+++ b/packages/as-xml/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-xml
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/as-xml/package.json
+++ b/packages/as-xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xml",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "XML plaintext export for noy-db — decrypts records and formats as XML with RFC-compliant entity escaping. For legacy systems, banking batch imports, SOAP endpoints, and accounting software that requires XML. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-zip/CHANGELOG.md
+++ b/packages/as-zip/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-zip
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/as-zip/package.json
+++ b/packages/as-zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-zip",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Composite record + blob archive export for noy-db — bundles a collection's records plus every attached blob into one zip. Zero dependencies (STORE-only zip encoder). Gated by the RFC #249 `canExportPlaintext` capability bit with format `'zip'`. Part of the @noy-db/as-* portable-artefact family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-aws-kms/CHANGELOG.md
+++ b/packages/at-aws-kms/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — at-aws-kms
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/at-aws-kms/package.json
+++ b/packages/at-aws-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-aws-kms",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "AWS KMS sealing key provider for noy-db managed-passphrase mode — seal/unseal via KMS Encrypt/Decrypt, with KMS access logs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-azure-keyvault/CHANGELOG.md
+++ b/packages/at-azure-keyvault/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — at-azure-keyvault
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/at-azure-keyvault/package.json
+++ b/packages/at-azure-keyvault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-azure-keyvault",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Azure Key Vault sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-env/CHANGELOG.md
+++ b/packages/at-env/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — at-env
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/at-env/package.json
+++ b/packages/at-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-env",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Env-var sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a key from process.env. Smallest production-shape provider; pair with Kubernetes Secrets / Heroku env / AWS Secrets Manager.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-gcp-kms/CHANGELOG.md
+++ b/packages/at-gcp-kms/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — at-gcp-kms
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/at-gcp-kms/package.json
+++ b/packages/at-gcp-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-gcp-kms",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Google Cloud KMS sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-macos-keychain/CHANGELOG.md
+++ b/packages/at-macos-keychain/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — at-macos-keychain
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/at-macos-keychain/package.json
+++ b/packages/at-macos-keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-macos-keychain",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "macOS Keychain sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a 32-byte key stored in the user's login Keychain. Desktop-app provider in the at-* family; pairs with Touch ID via Keychain Access UI.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/attestation/package.json
+++ b/packages/attestation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/attestation",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Pure, zero-dependency document-attestation primitive for noy-db — per-field salted commitments, Ed25519 sign/verify, QR credential codec, and revocation checks. Runs in Node and the browser; the offline verifier imports only this.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-peer/CHANGELOG.md
+++ b/packages/by-peer/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — by-peer
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/by-peer/package.json
+++ b/packages/by-peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-peer",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "WebRTC peer-to-peer transport for noy-db — direct browser-to-browser channel with signaling-agnostic handshake",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-tabs/CHANGELOG.md
+++ b/packages/by-tabs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/by-tabs
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+  - @noy-db/by-peer@1.0.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/by-tabs/package.json
+++ b/packages/by-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-tabs",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "BroadcastChannel multi-tab transport for noy-db — sync between tabs of the same browser without round-tripping the storage backend",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/cli
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+  - @noy-db/to-meter@1.0.0-pre.8
+  - @noy-db/to-probe@1.0.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/cli",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Command-line tool for noy-db — inspect .noydb bundles without decrypting, verify integrity, validate config objects, scaffold topology profiles, and monitor a live vault's store metrics.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/create-noy-db/CHANGELOG.md
+++ b/packages/create-noy-db/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — create-noy-db
 
+## 0.3.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+  - @noy-db/to-file@1.0.0-pre.8
+  - @noy-db/to-memory@1.0.0-pre.8
+
 ## 0.3.0-pre.7
 
 ### Patch Changes

--- a/packages/create-noy-db/package.json
+++ b/packages/create-noy-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-noy-db",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Wizard + CLI tool for noy-db: scaffold a fresh Nuxt 4 + Pinia encrypted store, or add collections to an existing project. Invoke via `npm create @noy-db`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/hub/CHANGELOG.md
+++ b/packages/hub/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog — hub
 
+## 0.3.0-pre.8
+
+### Minor Changes
+
+- Period-driven cold archival (#613, #604 Spec 3). New `vault.archivePeriod(name)` relocates a closed period's in-window records (`_ts < periodExclusiveUpperBound(endDate)`) from the hot store to a configured cold tier, driving `routeStore`'s existing hot→cold migration + cold read-through. Non-destructive (reads still resolve), idempotent, gated only on a `closed` period, and records a `_period_archives/<name>` companion + ledger entry parallel to `freezePeriod` (the chained `_periods` record stays byte-immutable). Requires a `routeStore` with a cold route (`age: { cold }`); throws otherwise.
+
+  Supporting additions: `routeStore.compact(vault, { before })` accepts an explicit cutoff (and `AgeRoute.coldAfterDays` is now optional — `age: { cold }` alone = period-driven archival only); `StoreCapabilities.coldArchival` advertises a cold-capable router.
+
+  Note: `routeStore` now surfaces its primary store's `capabilities` (previously it exposed none), layering `coldArchival` on top. A consequence is that CAS-gated features (e.g. gap-free `sequence().next()`) are now permitted on a routeStore-backed vault when the primary store reports `casAtomic` — previously they refused on any routeStore. A router without its own cold route never advertises `coldArchival`, even when nested over a cold-capable primary.
+
+- Period freeze (#604). `vault.freezePeriod(name)` physically reclaims the space held by a closed accounting period's delete markers — it purges the delete markers whose write-time falls within the period (via the operator-asserted safe-point the closed period provides), records a `_period_freezes/<name>` companion + a tamper-evident ledger entry, and leaves the hash-chained period record byte-immutable. Terminal and idempotent; requires `withPeriods()`. Forget-tombstones, history, and live records are untouched. Closes the `_purgeDeleteMarkers` audit-emission deferred from #589.
+- Single-vault target-purge (#615, scoped base of #611). New `vault.purgePeriodTargets(name)` sweeps delete markers (`_ts < periodExclusiveUpperBound(endDate)`) off the vault's **push-only** sync targets (`backup`/`archive` roles) for a period that is already **closed and frozen** locally — reclaiming remote marker space that `freezePeriod`'s local purge can't reach. Records a `_period_target_purges/<name>` companion + ledger entry (mirroring freeze/archive; the chained `_periods` record stays byte-immutable), idempotent, gated on frozen-first. `sync-peer` targets are deliberately skipped (purging their markers could re-open the resurrection window — the deferred half of #611). A vault with no push-only targets writes no companion and is re-runnable. Single-vault only; fleet-wide purge remains klum's concern over `@noy-db/hub/cargo`. `surface: api` — rides the existing store contract (`loadAll`/`delete`), no adapter change.
+
+### Patch Changes
+
+- Never pull from a `backup`/`archive` sync target (#616). `Noydb.sync()` now calls the primary engine push-only when the primary's role isn't `sync-peer`, and `Noydb.pull()` is a no-op (empty result) for a non-`sync-peer` primary — so a backup/archive-only config (where the sink was elected as the primary) is no longer pulled from. This applies the role→direction policy the secondary fan-out already used to the primary too, making the code match `sync()`'s existing "backup/archive do push-only" contract. `surface: internal` — no public API change; an explicitly constructed `SyncEngine.pull()` still pulls.
+
 ## 0.3.0-pre.7
 
 ### Minor Changes

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/hub",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Zero-knowledge, offline-first, encrypted document store — core library with AES-256-GCM, PBKDF2, multi-user keyring, and sync engine",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-ai/CHANGELOG.md
+++ b/packages/in-ai/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-ai
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/in-ai/package.json
+++ b/packages/in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-ai",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "LLM function-calling adapter for noy-db — expose ACL-scoped collections as tool definitions, then dispatch tool calls back to the vault. Format-agnostic (OpenAI, Anthropic, Vercel AI SDK).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-devtools-tui/CHANGELOG.md
+++ b/packages/in-devtools-tui/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/in-devtools-tui
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+  - @noy-db/in-devtools@1.0.0-pre.8
+  - @noy-db/to-meter@1.0.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/in-devtools-tui/package.json
+++ b/packages/in-devtools-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-devtools-tui",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Interactive terminal inspector for a live noy-db (ink TUI over @noy-db/in-devtools).",
   "license": "MIT",
   "type": "module",

--- a/packages/in-devtools/CHANGELOG.md
+++ b/packages/in-devtools/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-devtools
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/in-devtools/package.json
+++ b/packages/in-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-devtools",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Framework-agnostic read-only inspector for a live noy-db — vaults, collections, schema, stats, records, and live writes.",
   "license": "MIT",
   "type": "module",

--- a/packages/in-nextjs/CHANGELOG.md
+++ b/packages/in-nextjs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/in-nextjs
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+  - @noy-db/in-react@1.0.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/in-nextjs/package.json
+++ b/packages/in-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nextjs",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Next.js App Router helpers for noy-db — server components, route handlers, client hooks, and cookie-based session. Thin bridge that composes @noy-db/in-react with Next's cookies()/headers() APIs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-nuxt/CHANGELOG.md
+++ b/packages/in-nuxt/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — in-nuxt
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+  - @noy-db/in-devtools@1.0.0-pre.8
+  - @noy-db/in-pinia@1.0.0-pre.8
+  - @noy-db/in-rest@1.0.0-pre.8
+  - @noy-db/in-vue@1.0.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/in-nuxt/package.json
+++ b/packages/in-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nuxt",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Nuxt 4 module for noy-db — auto-imports, SSR-safe runtime plugin, and the @noy-db/in-pinia bridge",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-pinia/CHANGELOG.md
+++ b/packages/in-pinia/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — in-pinia
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/in-pinia/package.json
+++ b/packages/in-pinia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-pinia",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Pinia integration for noy-db — defineNoydbStore() and the augmentation plugin for existing stores",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-react/CHANGELOG.md
+++ b/packages/in-react/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-react
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/in-react/package.json
+++ b/packages/in-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-react",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "React hooks for noy-db — useNoydb, useVault, useCollection, useQuery, useSync. Uses useSyncExternalStore for reactive subscriptions. Zero deps beyond React.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-rest/CHANGELOG.md
+++ b/packages/in-rest/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-rest
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/in-rest/package.json
+++ b/packages/in-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-rest",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Framework-neutral REST API integration for noy-db — createRestHandler with Hono, Express, Fastify, and Nitro subpath adapters.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-solid/CHANGELOG.md
+++ b/packages/in-solid/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-solid
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/in-solid/package.json
+++ b/packages/in-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-solid",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "SolidJS signal primitives for noy-db — createCollectionSignal, createQuerySignal, createSyncSignal backed by noy-db change events.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-svelte/CHANGELOG.md
+++ b/packages/in-svelte/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-svelte
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/in-svelte/package.json
+++ b/packages/in-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-svelte",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Svelte stores for noy-db — collectionStore / queryStore / syncStore backed by noy-db change events. Works with Svelte 4 store contract and Svelte 5 runes (via $store subscription interop).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-query/CHANGELOG.md
+++ b/packages/in-tanstack-query/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-tanstack-query
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/in-tanstack-query/package.json
+++ b/packages/in-tanstack-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-query",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "TanStack Query adapter for noy-db — queryFn + mutationFn helpers that speak the Collection API, plus automatic invalidation from noy-db change events. Framework-agnostic (React / Vue / Solid / Svelte).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-table/CHANGELOG.md
+++ b/packages/in-tanstack-table/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-tanstack-table
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/in-tanstack-table/package.json
+++ b/packages/in-tanstack-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-table",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "TanStack Table bridge for noy-db — map Collection query state (sort, filter, pagination) into Table state and back, so a useSmartTable pattern drives the DB's query DSL without glue code.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-vue/CHANGELOG.md
+++ b/packages/in-vue/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — in-vue
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/in-vue/package.json
+++ b/packages/in-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-vue",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Vue 3 / Nuxt composables for noy-db — reactive useNoydb, useCollection, useSync, and biometric plugin",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-yjs/CHANGELOG.md
+++ b/packages/in-yjs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — in-yjs
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/in-yjs/package.json
+++ b/packages/in-yjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-yjs",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Yjs Y.Doc interop for noy-db — collaborative rich-text fields with encrypted-at-rest Yjs state",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-zustand/CHANGELOG.md
+++ b/packages/in-zustand/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-zustand
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/in-zustand/package.json
+++ b/packages/in-zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-zustand",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Zustand adapter for noy-db — factory that mirrors defineNoydbStore for Zustand users, auto-syncs state from noy-db change events, and supports optimistic mutations.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-email-otp/CHANGELOG.md
+++ b/packages/on-email-otp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/on-email-otp
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/on-email-otp/package.json
+++ b/packages/on-email-otp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-email-otp",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Email OTP second factor for noy-db — generates time-boxed one-time codes, delivers via a user-supplied transport (SMTP / SES / Postmark / any fn), and verifies in constant time. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-magic-link/CHANGELOG.md
+++ b/packages/on-magic-link/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/on-magic-link
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/on-magic-link/package.json
+++ b/packages/on-magic-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-magic-link",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Magic-link unlock for noy-db — one-time URL that opens a vault in a viewer-scoped session without a passphrase. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-oidc/CHANGELOG.md
+++ b/packages/on-oidc/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — on-oidc
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/on-oidc/package.json
+++ b/packages/on-oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-oidc",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "OAuth/OIDC bridge for noy-db — federated login (LINE, Google, Apple, Okta) with split-key key connector — server never sees plaintext",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-password/CHANGELOG.md
+++ b/packages/on-password/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/on-password
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/on-password/package.json
+++ b/packages/on-password/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-password",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Tier-2 password authenticator slot for noy-db. PBKDF2-SHA256 600K wraps the DEK set in its own keyring slot, distinct from the rarely-typed tier-1 phrase. Pair with @noy-db/on-email-otp or @noy-db/on-totp for the SaaS UX.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-pin/CHANGELOG.md
+++ b/packages/on-pin/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/on-pin
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/on-pin/package.json
+++ b/packages/on-pin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-pin",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Session-resume PIN quick-lock for noy-db — after a full passphrase unlock, a short-lived PIN (or a per-device biometric) re-unlocks the cached DEKs without re-typing the passphrase. PIN never replaces the passphrase; only resumes an already-unlocked session.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-recovery/CHANGELOG.md
+++ b/packages/on-recovery/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/on-recovery
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/on-recovery/package.json
+++ b/packages/on-recovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-recovery",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "One-time printable recovery codes for noy-db — last-resort vault unlock when the passphrase, passkey, and OIDC provider are all unavailable. Base32 + checksum codes, PBKDF2-derived wrapping keys, burn-on-use. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-shamir/package.json
+++ b/packages/on-shamir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-shamir",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "k-of-n Shamir Secret Sharing of the vault KEK for multi-party unlock. Any K of N shares recombines the key; fewer than K leaks zero bits. Composable — each share can be protected by any other on-* method. Zero runtime dependencies.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-threat/CHANGELOG.md
+++ b/packages/on-threat/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/on-threat
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/on-threat/package.json
+++ b/packages/on-threat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-threat",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Threat-response primitives for noy-db — multi-attempt lockout, duress-passphrase data destruction, duress-passphrase honeypot decoy. Pure stateful helpers; the caller coordinates keyring + audit-ledger integration. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-totp/CHANGELOG.md
+++ b/packages/on-totp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/on-totp
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/on-totp/package.json
+++ b/packages/on-totp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-totp",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "TOTP (RFC 6238) authenticator-app second factor for noy-db — generate secrets, otpauth:// provisioning URIs, and constant-time code verification. Zero dependencies (HMAC-SHA1 via Web Crypto). Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-webauthn/CHANGELOG.md
+++ b/packages/on-webauthn/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — on-webauthn
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/on-webauthn/package.json
+++ b/packages/on-webauthn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-webauthn",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "WebAuthn hardware-key keyrings for noy-db — Touch ID, Face ID, Windows Hello, YubiKey, FIDO2 passkeys",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-browser-idb/CHANGELOG.md
+++ b/packages/to-browser-idb/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — to-browser-idb
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/to-browser-idb/package.json
+++ b/packages/to-browser-idb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-browser-idb",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "IndexedDB adapter for noy-db with optional key obfuscation",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-file/CHANGELOG.md
+++ b/packages/to-file/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — to-file
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/to-file/package.json
+++ b/packages/to-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-file",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "JSON file adapter for noy-db — encrypted document store on local disk, USB sticks, or network drives",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-memory/CHANGELOG.md
+++ b/packages/to-memory/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — to-memory
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/to-memory/package.json
+++ b/packages/to-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-memory",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "In-memory adapter for noy-db — ideal for testing, development, and ephemeral workloads",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-meter/CHANGELOG.md
+++ b/packages/to-meter/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/to-meter
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/to-meter/package.json
+++ b/packages/to-meter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-meter",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Pass-through meter for @noy-db/to-* stores — wraps any NoydbStore and records per-method latency percentiles, error rates, and byte counts on real traffic. Optional synthetic liveness probe emits degraded / restored events. No synthetic benchmarks (see @noy-db/to-probe for that) — this measures what your app is actually doing.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-probe/CHANGELOG.md
+++ b/packages/to-probe/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/to-probe
 
+## 1.0.0-pre.8
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.8
+
 ## 1.0.0-pre.7
 
 ### Patch Changes

--- a/packages/to-probe/package.json
+++ b/packages/to-probe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-probe",
-  "version": "0.3.0-pre.7",
+  "version": "0.3.0-pre.8",
   "description": "Diagnostic companion for the @noy-db/to-* store family — not itself a storage backend. Setup-time suitability test + topology check + runtime reliability monitor. Exercises the 6-method NoydbStore contract across five axes (write latency, CAS integrity, hydration cost, sync economics, network resilience) and produces a structured risk-scored report.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",


### PR DESCRIPTION
Release **v0.3.0-pre.8** to `@next`. Consumes the four changesets accumulated since pre.7 (the #604 accounting-period retention arc + its sync-correctness follow-up):

**Minor**
- Period freeze — `vault.freezePeriod` (#604)
- Period-driven cold archival — `vault.archivePeriod` (#613, #604 Spec 3)
- Single-vault target-purge — `vault.purgePeriodTargets` (#615, scoped base of #611)

**Patch**
- Never pull from a `backup`/`archive` sync primary (#616)

All `@noy-db/*` normalized to `0.3.0-pre.8` (via `scripts/release.mjs`). `#589`/`#590` are **not** re-listed — they already shipped in pre.7 (changesets pre-mode dedup via `.changeset/pre.json`). No code change in this PR — version bump + CHANGELOGs only.

After merge: create a GitHub **pre-release** tagged `v0.3.0-pre.8` → `release.yml` publishes `--tag next`.