### PR TITLE
chore: release v0.3.0-pre.9

### DIFF
--- a/packages/as-aws-s3/CHANGELOG.md
+++ b/packages/as-aws-s3/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-aws-s3
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/as-aws-s3/package.json
+++ b/packages/as-aws-s3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-aws-s3",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "AWS S3 object projection for noy-db — serve blob bytes directly from S3/CDN (presigned or public), outside the encrypted store",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-blob/CHANGELOG.md
+++ b/packages/as-blob/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-blob
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/as-blob/package.json
+++ b/packages/as-blob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-blob",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Single-attachment plaintext export for noy-db — extracts one blob from BlobSet as native MIME bytes. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier, document sub-family).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-csv/CHANGELOG.md
+++ b/packages/as-csv/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-csv
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/as-csv/package.json
+++ b/packages/as-csv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-csv",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "CSV plaintext export for noy-db — decrypts records and formats as comma-separated values. Gated by the RFC #249 `canExportPlaintext` capability bit; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-json/CHANGELOG.md
+++ b/packages/as-json/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-json
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/as-json/package.json
+++ b/packages/as-json/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-json",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Structured JSON plaintext export for noy-db — decrypts records and emits one JSON document per vault. Gated by RFC #249 canExportPlaintext capability; writes an audit-ledger entry on every call. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-ndjson/CHANGELOG.md
+++ b/packages/as-ndjson/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-ndjson
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/as-ndjson/package.json
+++ b/packages/as-ndjson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-ndjson",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Newline-delimited JSON export for noy-db — streaming plaintext export suitable for data pipelines, warehouse ingestion, and jq pipelines. Gated by RFC #249 canExportPlaintext. Part of the @noy-db/as-* portable-artefact family (plaintext tier).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-noydb/CHANGELOG.md
+++ b/packages/as-noydb/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-noydb
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/as-noydb/package.json
+++ b/packages/as-noydb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-noydb",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Encrypted .noydb bundle export for noy-db — wraps writeNoydbBundle() with the RFC #249 canExportBundle authorization gate and ergonomic browser/node helpers. Sole member of the @noy-db/as-* encrypted tier — ciphertext in, ciphertext out.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-sql/CHANGELOG.md
+++ b/packages/as-sql/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-sql
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/as-sql/package.json
+++ b/packages/as-sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-sql",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "SQL dump export for noy-db — decrypts records and emits dialect-aware CREATE TABLE + INSERT statements for postgres / mysql / sqlite. One-way migration helper. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xlsx/CHANGELOG.md
+++ b/packages/as-xlsx/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/as-xlsx
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+  - @noy-db/as-zip@1.0.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/as-xlsx/package.json
+++ b/packages/as-xlsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xlsx",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Excel spreadsheet plaintext export for noy-db — produces a real .xlsx (Office Open XML) from one or more collections. Multi-sheet, Unicode-safe via shared-strings table. Zero runtime deps beyond the workspace zip encoder. Gated by RFC #249 `canExportPlaintext` with format `'xlsx'`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-xml/CHANGELOG.md
+++ b/packages/as-xml/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-xml
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/as-xml/package.json
+++ b/packages/as-xml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-xml",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "XML plaintext export for noy-db — decrypts records and formats as XML with RFC-compliant entity escaping. For legacy systems, banking batch imports, SOAP endpoints, and accounting software that requires XML. Gated by RFC #249 canExportPlaintext.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/as-zip/CHANGELOG.md
+++ b/packages/as-zip/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/as-zip
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/as-zip/package.json
+++ b/packages/as-zip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/as-zip",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Composite record + blob archive export for noy-db — bundles a collection's records plus every attached blob into one zip. Zero dependencies (STORE-only zip encoder). Gated by the RFC #249 `canExportPlaintext` capability bit with format `'zip'`. Part of the @noy-db/as-* portable-artefact family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-aws-kms/CHANGELOG.md
+++ b/packages/at-aws-kms/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — at-aws-kms
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/at-aws-kms/package.json
+++ b/packages/at-aws-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-aws-kms",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "AWS KMS sealing key provider for noy-db managed-passphrase mode — seal/unseal via KMS Encrypt/Decrypt, with KMS access logs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-azure-keyvault/CHANGELOG.md
+++ b/packages/at-azure-keyvault/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — at-azure-keyvault
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/at-azure-keyvault/package.json
+++ b/packages/at-azure-keyvault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-azure-keyvault",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Azure Key Vault sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-env/CHANGELOG.md
+++ b/packages/at-env/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — at-env
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/at-env/package.json
+++ b/packages/at-env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-env",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Env-var sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a key from process.env. Smallest production-shape provider; pair with Kubernetes Secrets / Heroku env / AWS Secrets Manager.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-gcp-kms/CHANGELOG.md
+++ b/packages/at-gcp-kms/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — at-gcp-kms
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/at-gcp-kms/package.json
+++ b/packages/at-gcp-kms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-gcp-kms",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Google Cloud KMS sealing key provider for noy-db managed-passphrase mode.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/at-macos-keychain/CHANGELOG.md
+++ b/packages/at-macos-keychain/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — at-macos-keychain
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/at-macos-keychain/package.json
+++ b/packages/at-macos-keychain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/at-macos-keychain",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "macOS Keychain sealing key provider for noy-db managed-passphrase mode — AES-256-GCM under a 32-byte key stored in the user's login Keychain. Desktop-app provider in the at-* family; pairs with Touch ID via Keychain Access UI.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/attestation/package.json
+++ b/packages/attestation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/attestation",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Pure, zero-dependency document-attestation primitive for noy-db — per-field salted commitments, Ed25519 sign/verify, QR credential codec, and revocation checks. Runs in Node and the browser; the offline verifier imports only this.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-peer/CHANGELOG.md
+++ b/packages/by-peer/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — by-peer
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/by-peer/package.json
+++ b/packages/by-peer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-peer",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "WebRTC peer-to-peer transport for noy-db — direct browser-to-browser channel with signaling-agnostic handshake",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/by-tabs/CHANGELOG.md
+++ b/packages/by-tabs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/by-tabs
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+  - @noy-db/by-peer@1.0.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/by-tabs/package.json
+++ b/packages/by-tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/by-tabs",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "BroadcastChannel multi-tab transport for noy-db — sync between tabs of the same browser without round-tripping the storage backend",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/cli
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+  - @noy-db/to-meter@1.0.0-pre.9
+  - @noy-db/to-probe@1.0.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/cli",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Command-line tool for noy-db — inspect .noydb bundles without decrypting, verify integrity, validate config objects, scaffold topology profiles, and monitor a live vault's store metrics.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/create-noy-db/CHANGELOG.md
+++ b/packages/create-noy-db/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog — create-noy-db
 
+## 0.3.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+  - @noy-db/to-file@1.0.0-pre.9
+  - @noy-db/to-memory@1.0.0-pre.9
+
 ## 0.3.0-pre.8
 
 ### Patch Changes

--- a/packages/create-noy-db/package.json
+++ b/packages/create-noy-db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-noy-db",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Wizard + CLI tool for noy-db: scaffold a fresh Nuxt 4 + Pinia encrypted store, or add collections to an existing project. Invoke via `npm create @noy-db`.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/hub/CHANGELOG.md
+++ b/packages/hub/CHANGELOG.md
@@ -1,5 +1,231 @@
 # Changelog — hub
 
+## 0.3.0-pre.9
+
+### Minor Changes
+
+- The Via port (#629, phase B): classified fields and blobs join phase A's money/i18n as
+  kernel-orchestrated via-features, and every binding's declared `ViaPosture` — `encryptedAtRest`,
+  `queryable`, `exportable`, `forgettable` — is now an **enforced** contract instead of
+  documentation. `via-classified` (`shape/via-classified/`) seals `'recoverable'` fields at rest,
+  enforces preset validation and `storage: 'never'` rejection before a write reaches the store, and
+  participates in erasure; `via-blob` (`shape/via-blob/`) is a deliberately thin declaration +
+  posture binding — blob content crypto stays service-side (`with-shape/blobs/`), never routed
+  through the kernel's field-feature pipeline. Query, export, and forget all now consult posture
+  generically (no per-feature brand checks): the query DSL refuses a `queryable: 'none'` field
+  (new `FieldNotQueryableError` for `blobFields` — classified's own `det-exact` query behavior is
+  unchanged, a byte-for-byte parity pin); `Vault.exportStream()`/`exportJSON()` deliberately redact
+  an `exportable: false` field to the literal `'[sealed]'` on the record itself, ahead of the
+  pre-existing `SealedHandle.toJSON()` accident that produced the same string as a side effect
+  (both layers now verified independently); `vault.forget()` consults `forgettable` and folds each
+  sealed-posture binding's `erase()` hook into its report, with parity-pinned shred/residue counts.
+  New kernel machinery, `ViaCryptoCtx` (`sealedSlots` + `reservedEnvelopes`, both in
+  `kernel/enclave/record-keys/sealed-slots.ts`), gives via-features a scoped, key-free door into
+  per-record/per-collection crypto — the first consumer is `via-i18n`'s dictionary handle, which
+  this phase reroutes off a direct `kernel/enclave` import onto `reservedEnvelopes('_dict_')`,
+  **retiring the one remaining `via-enclave-isolation` grandfather** (that allowlist is now empty;
+  `via-layering`'s allowlist is unchanged, still exactly `kernel/query/join.ts` → #626).
+
+  **Downstream export output change:** the default (non-`redact`-option) export of a classified
+  field via `@noy-db/as-csv`/`@noy-db/as-sql`/`@noy-db/as-xml` changes bytes — pre-#629 these
+  satellites saw a live `SealedHandle` object and fell through to `JSON.stringify`-shaped output
+  (`"""[sealed]"""` in a CSV cell; a `jsonb` SQL column with literal `'"[sealed]"'`); post-#629 they
+  see the plain string `'[sealed]'` directly (a bare `[sealed]` CSV cell; a `text` SQL column with
+  literal `'[sealed]'`). The new output is the intended one — the old bytes were an accidental echo
+  of a live, `.reveal()`-capable handle reaching an export stream, which this phase's deliberate
+  redaction closes.
+
+  **Two erase-hook code paths ship real and unit-tested but stay production-dormant by design:**
+  the sealed-CEK `_sealed_cek/*` host-delivery envelope purge (`via-classified`) and the blob-shred
+  purge (`via-blob`) are both proven, by their respective pre-existing forget/erasure suites, to be
+  vault-level operations unconditional on any given collection declaring `classifiedFields`/
+  `blobFields` — routing either exclusively through its via `erase()` hook would silently regress
+  collections that don't declare the field but still exercise `.blob()`/`sealRecordToHost()`.
+  `vault.forget()` keeps calling both directly; the via bindings' `erase()` hooks carry only the
+  classification/participation they legitimately own (classified's `_sealed`-slot shred/residue
+  accounting, which IS live and wired). Making the purge scoping collection-declaration-aware is a
+  future product decision, not a gap in this phase.
+
+- The Via port (#638, phase C): a per-vault dependency graph (`ViaGraph`, `kernel/via-graph.ts`)
+  now connects every derivation, rollup, materialized view, and `computed` field to the sources it
+  reads, and enforces four structural fixes that were previously either silently wrong or a design
+  gap:
+
+  - **#636 — derived fields now inherit their strictest source's security posture.** A
+    `computed` field whose `deps` include a classified source used to silently copy that source's
+    plaintext (or a derivative of it) into an ordinary, unredacted field — the taint algebra
+    (`foldPosture`) now folds `encryptedAtRest`/`queryable`/`exportable`/`forgettable` from every
+    source, and a materialized field folding to `encryptedAtRest: 'sealed'` is actually sealed at
+    rest (the same `ctx.sealedSlots` capability `via-classified` uses); a virtual field (never
+    stored) is redacted on every read instead. **BEHAVIOR CHANGE, pre-1.0, deliberate security
+    fix:** any existing `computed`-from-classified configuration now inherits the classified
+    posture where it previously did not — such a field's `get()`/`list()`/export/query behavior
+    changes from plaintext to sealed/redacted/refused after upgrading.
+  - **#621 — sync-applied, cutover, and restore writes now dispatch derivations.** Previously only
+    a local `put()` triggered a collection's derivations/rollups/materialized views; a write
+    applied by `pull()`/`push()`/schema cutover/restore silently skipped dispatch entirely. A
+    batched, per-target-deduped wave now runs once at the end of a sync session (and around
+    cutover/restore) — N synced children of one rollup parent recompute the parent exactly once,
+    not N times; a collection with no dependents in the graph is skipped with zero decrypt cost
+    (unchanged for money/i18n-only collections).
+  - **#622 — `vault.forget()` now fans out to derived residue.** Forgetting a record used to leave
+    its derived copies and aggregate contributions behind. Record-grain derived artifacts (MV
+    rows, array-shape derivation rows, same-id record-shape derivation copies) are now erased;
+    aggregate-grain rollups are recomputed without the forgotten contribution in open periods, or
+    skip + audit in frozen ones — the subject's own record is still unconditionally shredded
+    either way.
+  - **#637 — a frozen-period derivation output now skips + audits instead of failing the source
+    write.** A derivation/rollup/MV output landing in a closed period used to throw
+    `PeriodClosedError` straight through the _legal_ write that triggered the recompute (live
+    local-write dispatch, `deriveAll()`, `refreshView()`, and — after the #621 fix above — the
+    sync dispatch wave too). It now skips the write (the historical output stands) and emits a
+    new `'derivation:skipped-frozen'` event, plus a `'lifecycle'` audit-ledger entry when
+    `withHistory()` is active. In the sync dispatch wave specifically, one frozen (or otherwise
+    failing) target in a batch no longer aborts the whole `pull()`/`push()` or starves a co-batched
+    healthy target.
+
+  **The declare-time typo guard (closes the #636 "typo reopening"):** on a collection that also
+  declares classified fields, a `computed` entry with no declared `deps` — or with a `deps` entry
+  naming an unknown field — now throws `ValidationError` at construction (an opaque function could
+  otherwise silently copy a classified field's plaintext with no way for the graph to know). On a
+  non-classified collection, `deps` may still name any field, including a plain field with no via
+  feature declared on it at all — there is no schema-introspection API to validate against, and an
+  unregistered dep folds to the default (untainted) posture, which is safe. **KNOWN LIMIT** (pinned,
+  not silently left): the guard only checks that a `deps` entry names _some_ known field, not that
+  it names the field the function actually reads — `deps: ['amount']` on a function that actually
+  reads `ssn` still passes construction and still leaks, because the graph edge folds from
+  `amount`'s posture, not `ssn`'s. Closing this fully needs runtime read-tracking or a
+  schema-introspection capability outside this phase's scope. See
+  [`docs/subsystems/via-computed.md`](../docs/subsystems/via-computed.md) for the declaration-order
+  asymmetry this guard has (a single call combining a `storage: 'never'` classified field with a
+  depsless `computed` field is refused; the identical pairing split across two separate
+  `vault.collection()` calls is accepted, by design — a `never`-storage value cannot structurally
+  reach a computed field's output) and its reconcile-path scope limit (a `deps` entry naming a
+  classified field declared in an _earlier_, separate call currently over-refuses; the workaround is
+  to declare both together in one call).
+
+  **`computed(fn, { deps, mode })` ships as a full via-feature**, composable through `via(...)`
+  (`via(computed(fn, { deps: [...], mode: 'virtual' }))`) and through an extended `computed: {
+field: { fn, deps, mode } }` sugar form — both additive. `mode: 'materialized'` (the default) is
+  byte-for-byte the prior eager write-time compute. `mode: 'virtual'` is new: the field is computed
+  fresh on every read, never stored (absent from `_data`), and unconditionally
+  `queryable: 'none'`. **Composition semantics are pinned for both modes** — `computed` always
+  compiles last in the via-binding stack, so `via(computed(...), money(...))` on the _same_ field
+  behaves differently per mode: in `mode: 'virtual'`, money's `present()` runs before the computed
+  value exists, so the raw computed number survives unformatted; in `mode: 'materialized'`
+  (default), the computed value is merged into the record before `encodeWrite`, so money's own
+  encode/decode/present hooks format it normally, exactly like a plain money field. The formerly
+  `@internal` `computedDeps` staging option (an interim seam from earlier in this phase, explicitly
+  documented as "do not depend on this shape") is **removed** — folded into each `computed` entry's
+  own `{ fn, deps?, mode? }` shape.
+
+  **Additive surfaces** (non-breaking): `vault.deriveAll()`'s result gains a `skippedFrozen` counter,
+  distinct from `derived` (a frozen-skip is not counted as a successful write); `ForgetResult` gains
+  `derivedRecordsErased: number`, `derivedAggregatesRecomputed: number`, and
+  `derivedResidueFrozen: readonly string[]` (all pre-existing `ForgetResult` fields are byte-shape
+  unchanged); the kernel event map gains `'derivation:skipped-frozen'`
+  (`db.on('derivation:skipped-frozen', handler)`).
+
+  See [`docs/subsystems/via.md`](../docs/subsystems/via.md) (Phase C section) and
+  [`docs/subsystems/via-computed.md`](../docs/subsystems/via-computed.md) for the full story,
+  including every example above traced to its shipped test.
+
+- The Via port (#650, phase D): a new `'lookup'` via-feature — `lookup()` / `enum()` / `dict()` —
+  collapses the legacy `dictKey()`/`staticDict()` code-field pattern and a first-class
+  reference-collection pattern into **one** binding with three backing tiers: `enum` (inline keys,
+  no store), `dict` (a reserved `_dict_<name>` micro-collection — the native spelling of `dict()`,
+  what `dictKey()` compiles onto), and `matrix` (a first-class collection like `countries` — the
+  native spelling of `lookup()`'s default `backing: 'collection'`, what `staticDict()`'s table-based
+  sibling `lookup(name, { backing: 'static', table })` also compiles onto for its own tier).
+
+  **`dictKey()`/`staticDict()` are now aliases**, not deprecated spellings — internally they build
+  the equivalent `LookupDescriptor` shape and validate against it, but they still compile onto the
+  **`'i18n'`** via-binding, not the new `'lookup'` one. Their stored envelopes, the
+  `type`/`widget`/`dict` slice of `describe()` output, and `.join()` dressing stay byte-identical to
+  their native equivalent (`packages/hub/__tests__/via/lookup-alias-parity.test.ts`), but they do
+  **not** gain the new `.lookup` describe() block below (only a native `lookup()`/`enum()`/`dict()`
+  field produces one). Existing code using either sugar continues to work unchanged.
+
+  **New capability, additive:**
+
+  - `altKeys` — declare candidate values (e.g. an ISO3 code, a phone call-prefix) that normalize to
+    the canonical key on `ingest`, sync and pure, from an already-materialized backing snapshot (no
+    store read per `put()`).
+  - `vocabulary: 'closed'` — write-time membership refusal (`UnknownLookupKeyError`) against the
+    backing dimension's **actual current rows**, checked live, not a hardcoded universe. `'open'`
+    (the `dictKey()`/`dict()` default) is unaffected. The dict tier's closed membership specifically
+    is declared `keys` **union** the reserved dictionary's live rows (a declared key is known even
+    before any row for it exists; a live row for an undeclared key is known too) — pinned by
+    `lookup-vocabulary.test.ts:96`. Matrix tier has no declared key list at all — membership is
+    purely the backing collection's live rows.
+  - `sortBy` / `orderBy(field, dir, { by: 'label' })` — exact ordering by the resolved label, either
+    fixed (`compareForOrder`, needs a declared `displayLocale`) or per-call (`{ by: 'label' }`,
+    resolves at the query's own locale — a genuinely different sort order per call, not cached).
+
+  **BEHAVIOR CHANGES (deliberate, pre-1.0, `@next` only):**
+
+  - **#649 — closed-vocabulary membership is now real.** The `dictKey()` doc comment always claimed
+    that a declared key set was enforced on `put()`; it never actually was (the runtime `keys` array
+    was silently dropped at registration). `dictKey()` itself is UNCHANGED (still open — closing
+    this for the alias was explicitly out of scope, to avoid silently breaking existing dictKey
+    collections). The fix landed on the native `lookup()`/`enum()`/`dict()` spellings' own
+    `vocabulary: 'closed'` opt-in only.
+  - **#648 — `restrict` is the default reference semantics for a declared lookup field, and it is
+    now enforced.** Deleting (or `forget()`-ing) a backing dictionary/collection row that a declared
+    lookup field still references now throws `DictKeyInUseError` naming the referencing collection
+    and count, refusing the delete before any mutation. `DictKeyInUseError` was declared, exported,
+    and documented since before this phase, but its throw site was an empty comment block — this is
+    its first-ever implementation. `cascade` (tombstones/deletes the referencing records) and
+    `nullify` (nulls the referencing field via an ordinary `put()`) are opt-in per declaration
+    (`onDelete`), propagating additively through both plain deletes and `forget()`
+    (`ForgetResult.lookupReferencesCascaded`/`lookupReferencesNullified`/`lookupReferencesResidue`,
+    new additive fields — `lookupReferencesResidue` reports any `cascade`/`nullify` propagation
+    skipped because a reference's compare-key couldn't be resolved even from the live pre-shred
+    backing row, always empty in the ordinary case, never silent when non-empty — every pre-existing
+    `ForgetResult` field is unchanged). **A plain dictionary delete with no declared
+    lookup-referencing field is completely unaffected** — this only fires for dimensions a
+    `lookupFields`/`via(lookup(...))` declaration actually points at.
+  - **Matrix-tier `sortBy` was silently inert through Task 6; it is now functional.** `sortBy` was
+    accepted at declare time on a matrix-tier (`backing: 'collection'`) lookup field since it
+    shipped, but `compareForOrder` had no route for that tier — a plain `orderBy()` on such a field
+    silently fell back to raw stored-code order, no warning, no error. This task wires the matrix
+    branch through the same sync snapshot `presentForJoin` already reads (`registry.ts`'s
+    `buildLookupSnapshotRows`, keyed by `descriptor.key`), so a `sortBy` + `displayLocale`-declared
+    matrix field's plain `orderBy()` now genuinely sorts by its resolved label, same as the reserved
+    tier already did. Reserved-tier `sortBy` is unaffected.
+  - **#647 — reserved (`_dict_*`) collections now participate in sync.** Before this phase,
+    `vault.dictionary()` writes bypassed the mutation choke point entirely (raw adapter I/O, no
+    dirty-log entry) and `SyncEngine.pull()` skipped every `_`-prefixed collection by the store
+    contract — dictionaries never crossed `push()`/`pull()`, only backup/bundle export. Reserved
+    lookup writes now dirty-log and dispatch like any other write, and `pull()` additionally
+    enumerates an explicit reserved-lookup prefix registry through the ordinary apply path.
+    **Deletes travel as version-ordered delete-markers**, the same #589 law every ordinary
+    collection's sync-safe delete already follows — a deleted dictionary key can no longer be
+    silently resurrected by a stale peer's next push.
+
+  **#626 retired**: `kernel/query/join.ts` no longer imports `shape/via-i18n/core.js` — it calls a
+  sync `presentForJoin` hook the `Collection` builds from its own i18n + lookup bindings instead
+  (now covering the matrix tier too, not just reserved). The `via-layering` architecture guard's
+  allowlist (`VIA_SHAPE_ALLOWLIST`) is EMPTY, proven to still fire on a synthetic violation. The
+  sibling `via-enclave-isolation` guard's allowlist (`VIA_ENCLAVE_ALLOWLIST`) has also been empty
+  since phase B and gains the same synthetic-fire proof (both in `via-guards-empty.test.ts`).
+
+  **`describe()` gains a normalized `lookup` block**, sourced from `ViaBinding.describeFragment()` —
+  declared since phase A, unconsumed until now. Present alongside (not replacing) the pre-existing
+  `dict` block, which stays byte-stable for the `dictKey()`/`staticDict()` alias. Carries
+  `dimension`/`backing`/`vocabulary`/`key`/`altKeys`/`present`/`sortBy`/`onDelete`, and the
+  statically-known closed-vocabulary key set where one exists.
+
+  **Removed**: `vault.applyLocale()` — a full parallel i18n+dict+static label-resolution path with
+  zero production callers (superseded by `via.present`, orphaned since the phase A/C cutover).
+  Dead public API; no behavior change for any caller (there were none).
+
+  See [`docs/subsystems/via.md`](../docs/subsystems/via.md) (Phase D section) and
+  [`docs/subsystems/via-lookup.md`](../docs/subsystems/via-lookup.md) for the full story — the
+  canonical countries-matrix example, every capability traced to its shipped test.
+
+- The Via port (#623, phase A): a kernel-owned field-feature SPI. Everything a field can be is now a **via-feature** — a per-field declaration plugging into one phased pipeline (write: ingest → encode; read: present) with a brand-keyed binder registry generalizing the #553 declaration-links-engine pattern. **money and i18n are fully retrofitted** behind the port: the kernel imports nothing from the feature layer (closes #612), enforced by two new architecture rules (`via-layering`, `via-enclave-isolation`) with exactly two documented grandfathers (`kernel/query/join.ts` → #626; `via-i18n/dictionary.ts` → phase-B ViaCryptoCtx). New public surface (additive): `via(...)` composer + the `viaFields` collection option — existing spellings (`moneyFields`, `i18nFields`, `dictKeyFields`) are preserved as sugar compiling to identical bindings (byte-identical stored envelopes, identical `describe()`). Also: an origin-tagged mutation choke point lands with strict behavior parity (the socket phase C plugs the dependency graph into — #621/#622); generic path utilities moved to `kernel/paths`; `I18nStrategy`/`NO_I18N`/dict predicates moved to the kernel port (`port/with/i18n-strategy`). Folder moves: `with-shape/money` → `shape/via-money`, `with-shape/i18n` → `shape/via-i18n` (subpath exports unchanged). Kernel net effect: collection.ts −232 lines (first ratchet-down since Phase 5); 20 money call sites + 10 i18n value bindings + 7 type inversions collapse to one grandfathered import. Upgrade note: materialized views with money `where()` clauses re-materialize once after upgrade (query-hash format changed; self-healing). Behavior is otherwise unchanged — the full money/i18n suites pass unmodified.
+
 ## 0.3.0-pre.8
 
 ### Minor Changes

--- a/packages/hub/package.json
+++ b/packages/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/hub",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Zero-knowledge, offline-first, encrypted document store — core library with AES-256-GCM, PBKDF2, multi-user keyring, and sync engine",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-ai/CHANGELOG.md
+++ b/packages/in-ai/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-ai
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/in-ai/package.json
+++ b/packages/in-ai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-ai",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "LLM function-calling adapter for noy-db — expose ACL-scoped collections as tool definitions, then dispatch tool calls back to the vault. Format-agnostic (OpenAI, Anthropic, Vercel AI SDK).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-devtools-tui/CHANGELOG.md
+++ b/packages/in-devtools-tui/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @noy-db/in-devtools-tui
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+  - @noy-db/in-devtools@1.0.0-pre.9
+  - @noy-db/to-meter@1.0.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/in-devtools-tui/package.json
+++ b/packages/in-devtools-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-devtools-tui",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Interactive terminal inspector for a live noy-db (ink TUI over @noy-db/in-devtools).",
   "license": "MIT",
   "type": "module",

--- a/packages/in-devtools/CHANGELOG.md
+++ b/packages/in-devtools/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-devtools
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/in-devtools/package.json
+++ b/packages/in-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-devtools",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Framework-agnostic read-only inspector for a live noy-db — vaults, collections, schema, stats, records, and live writes.",
   "license": "MIT",
   "type": "module",

--- a/packages/in-nextjs/CHANGELOG.md
+++ b/packages/in-nextjs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @noy-db/in-nextjs
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+  - @noy-db/in-react@1.0.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/in-nextjs/package.json
+++ b/packages/in-nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nextjs",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Next.js App Router helpers for noy-db — server components, route handlers, client hooks, and cookie-based session. Thin bridge that composes @noy-db/in-react with Next's cookies()/headers() APIs.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-nuxt/CHANGELOG.md
+++ b/packages/in-nuxt/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog — in-nuxt
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+  - @noy-db/in-devtools@1.0.0-pre.9
+  - @noy-db/in-pinia@1.0.0-pre.9
+  - @noy-db/in-rest@1.0.0-pre.9
+  - @noy-db/in-vue@1.0.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/in-nuxt/package.json
+++ b/packages/in-nuxt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-nuxt",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Nuxt 4 module for noy-db — auto-imports, SSR-safe runtime plugin, and the @noy-db/in-pinia bridge",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-pinia/CHANGELOG.md
+++ b/packages/in-pinia/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — in-pinia
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/in-pinia/package.json
+++ b/packages/in-pinia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-pinia",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Pinia integration for noy-db — defineNoydbStore() and the augmentation plugin for existing stores",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-react/CHANGELOG.md
+++ b/packages/in-react/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-react
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/in-react/package.json
+++ b/packages/in-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-react",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "React hooks for noy-db — useNoydb, useVault, useCollection, useQuery, useSync. Uses useSyncExternalStore for reactive subscriptions. Zero deps beyond React.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-rest/CHANGELOG.md
+++ b/packages/in-rest/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-rest
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/in-rest/package.json
+++ b/packages/in-rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-rest",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Framework-neutral REST API integration for noy-db — createRestHandler with Hono, Express, Fastify, and Nitro subpath adapters.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-solid/CHANGELOG.md
+++ b/packages/in-solid/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-solid
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/in-solid/package.json
+++ b/packages/in-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-solid",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "SolidJS signal primitives for noy-db — createCollectionSignal, createQuerySignal, createSyncSignal backed by noy-db change events.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-svelte/CHANGELOG.md
+++ b/packages/in-svelte/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-svelte
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/in-svelte/package.json
+++ b/packages/in-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-svelte",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Svelte stores for noy-db — collectionStore / queryStore / syncStore backed by noy-db change events. Works with Svelte 4 store contract and Svelte 5 runes (via $store subscription interop).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-query/CHANGELOG.md
+++ b/packages/in-tanstack-query/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-tanstack-query
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/in-tanstack-query/package.json
+++ b/packages/in-tanstack-query/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-query",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "TanStack Query adapter for noy-db — queryFn + mutationFn helpers that speak the Collection API, plus automatic invalidation from noy-db change events. Framework-agnostic (React / Vue / Solid / Svelte).",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-tanstack-table/CHANGELOG.md
+++ b/packages/in-tanstack-table/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-tanstack-table
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/in-tanstack-table/package.json
+++ b/packages/in-tanstack-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-tanstack-table",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "TanStack Table bridge for noy-db — map Collection query state (sort, filter, pagination) into Table state and back, so a useSmartTable pattern drives the DB's query DSL without glue code.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-vue/CHANGELOG.md
+++ b/packages/in-vue/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — in-vue
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/in-vue/package.json
+++ b/packages/in-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-vue",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Vue 3 / Nuxt composables for noy-db — reactive useNoydb, useCollection, useSync, and biometric plugin",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-yjs/CHANGELOG.md
+++ b/packages/in-yjs/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — in-yjs
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/in-yjs/package.json
+++ b/packages/in-yjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-yjs",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Yjs Y.Doc interop for noy-db — collaborative rich-text fields with encrypted-at-rest Yjs state",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/in-zustand/CHANGELOG.md
+++ b/packages/in-zustand/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/in-zustand
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/in-zustand/package.json
+++ b/packages/in-zustand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/in-zustand",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Zustand adapter for noy-db — factory that mirrors defineNoydbStore for Zustand users, auto-syncs state from noy-db change events, and supports optimistic mutations.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-email-otp/CHANGELOG.md
+++ b/packages/on-email-otp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/on-email-otp
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/on-email-otp/package.json
+++ b/packages/on-email-otp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-email-otp",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Email OTP second factor for noy-db — generates time-boxed one-time codes, delivers via a user-supplied transport (SMTP / SES / Postmark / any fn), and verifies in constant time. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-magic-link/CHANGELOG.md
+++ b/packages/on-magic-link/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/on-magic-link
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/on-magic-link/package.json
+++ b/packages/on-magic-link/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-magic-link",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Magic-link unlock for noy-db — one-time URL that opens a vault in a viewer-scoped session without a passphrase. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-oidc/CHANGELOG.md
+++ b/packages/on-oidc/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — on-oidc
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/on-oidc/package.json
+++ b/packages/on-oidc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-oidc",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "OAuth/OIDC bridge for noy-db — federated login (LINE, Google, Apple, Okta) with split-key key connector — server never sees plaintext",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-password/CHANGELOG.md
+++ b/packages/on-password/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/on-password
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/on-password/package.json
+++ b/packages/on-password/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-password",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Tier-2 password authenticator slot for noy-db. PBKDF2-SHA256 600K wraps the DEK set in its own keyring slot, distinct from the rarely-typed tier-1 phrase. Pair with @noy-db/on-email-otp or @noy-db/on-totp for the SaaS UX.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-pin/CHANGELOG.md
+++ b/packages/on-pin/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/on-pin
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/on-pin/package.json
+++ b/packages/on-pin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-pin",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Session-resume PIN quick-lock for noy-db — after a full passphrase unlock, a short-lived PIN (or a per-device biometric) re-unlocks the cached DEKs without re-typing the passphrase. PIN never replaces the passphrase; only resumes an already-unlocked session.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-recovery/CHANGELOG.md
+++ b/packages/on-recovery/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/on-recovery
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/on-recovery/package.json
+++ b/packages/on-recovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-recovery",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "One-time printable recovery codes for noy-db — last-resort vault unlock when the passphrase, passkey, and OIDC provider are all unavailable. Base32 + checksum codes, PBKDF2-derived wrapping keys, burn-on-use. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-shamir/package.json
+++ b/packages/on-shamir/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-shamir",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "k-of-n Shamir Secret Sharing of the vault KEK for multi-party unlock. Any K of N shares recombines the key; fewer than K leaks zero bits. Composable — each share can be protected by any other on-* method. Zero runtime dependencies.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-threat/CHANGELOG.md
+++ b/packages/on-threat/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/on-threat
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/on-threat/package.json
+++ b/packages/on-threat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-threat",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Threat-response primitives for noy-db — multi-attempt lockout, duress-passphrase data destruction, duress-passphrase honeypot decoy. Pure stateful helpers; the caller coordinates keyring + audit-ledger integration. Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-totp/CHANGELOG.md
+++ b/packages/on-totp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/on-totp
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/on-totp/package.json
+++ b/packages/on-totp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-totp",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "TOTP (RFC 6238) authenticator-app second factor for noy-db — generate secrets, otpauth:// provisioning URIs, and constant-time code verification. Zero dependencies (HMAC-SHA1 via Web Crypto). Part of the @noy-db/on-* authentication family.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/on-webauthn/CHANGELOG.md
+++ b/packages/on-webauthn/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — on-webauthn
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/on-webauthn/package.json
+++ b/packages/on-webauthn/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/on-webauthn",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "WebAuthn hardware-key keyrings for noy-db — Touch ID, Face ID, Windows Hello, YubiKey, FIDO2 passkeys",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-browser-idb/CHANGELOG.md
+++ b/packages/to-browser-idb/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — to-browser-idb
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/to-browser-idb/package.json
+++ b/packages/to-browser-idb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-browser-idb",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "IndexedDB adapter for noy-db with optional key obfuscation",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-file/CHANGELOG.md
+++ b/packages/to-file/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — to-file
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/to-file/package.json
+++ b/packages/to-file/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-file",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "JSON file adapter for noy-db — encrypted document store on local disk, USB sticks, or network drives",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-memory/CHANGELOG.md
+++ b/packages/to-memory/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog — to-memory
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/to-memory/package.json
+++ b/packages/to-memory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-memory",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "In-memory adapter for noy-db — ideal for testing, development, and ephemeral workloads",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-meter/CHANGELOG.md
+++ b/packages/to-meter/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/to-meter
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/to-meter/package.json
+++ b/packages/to-meter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-meter",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Pass-through meter for @noy-db/to-* stores — wraps any NoydbStore and records per-method latency percentiles, error rates, and byte counts on real traffic. Optional synthetic liveness probe emits degraded / restored events. No synthetic benchmarks (see @noy-db/to-probe for that) — this measures what your app is actually doing.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",

--- a/packages/to-probe/CHANGELOG.md
+++ b/packages/to-probe/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @noy-db/to-probe
 
+## 1.0.0-pre.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @noy-db/hub@0.3.0-pre.9
+
 ## 1.0.0-pre.8
 
 ### Patch Changes

--- a/packages/to-probe/package.json
+++ b/packages/to-probe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noy-db/to-probe",
-  "version": "0.3.0-pre.8",
+  "version": "0.3.0-pre.9",
   "description": "Diagnostic companion for the @noy-db/to-* store family — not itself a storage backend. Setup-time suitability test + topology check + runtime reliability monitor. Exercises the 6-method NoydbStore contract across five axes (write latency, CAS integrity, hydration cost, sync economics, network resilience) and produces a structured risk-scored report.",
   "license": "MIT",
   "author": "vLannaAi <vicio@lanna.ai>",


### PR DESCRIPTION
Release PR for v0.3.0-pre.9 (`@next`): the Via port complete — phases A–D shipped together as four hub minors (#623, #629, #638, #650).

- 51 packages lockstep at 0.3.0-pre.9 (`pnpm release:version` — no stray 1.0.0 bumps, verified).
- Hub CHANGELOG carries all four via changesets; satellite CHANGELOGs are dependency-bump entries.
- Pre-publish smoke test PASSED: packed hub + to-memory + attestation tarballs, fresh-dir npm install, end-to-end smoke exercising vault round-trip plus the new phase-D public API (enum/dict/matrix closed vocabularies, `UnknownLookupKeyError`) through the root barrel.

After merge: GitHub pre-release `v0.3.0-pre.9` → `release.yml` publishes to `@next`. `@latest` stays untouched (0.1.0-pre.4).