### PR TITLE
fix(hub): via consolidation — formula-output taint fold, one key-resolution core, fail-closed restrict, sync-delete rollup freshness (#642, #651, #654, #640)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions:
 # default heap or it dies with ERR_WORKER_OUT_OF_MEMORY. Applies to every
 # job that builds (build, lint+typecheck, test, interop).
 env:
-  NODE_OPTIONS: --max-old-space-size=8192
+  NODE_OPTIONS: --max-old-space-size=12288
 
 jobs:
   # ── Architecture invariants ──────────────────────────────────────────

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ permissions:
 # Hub's dts build (28 subpath entries, large type surface) needs more than
 # the default heap or tsup's rollup-dts worker dies with ERR_WORKER_OUT_OF_MEMORY.
 env:
-  NODE_OPTIONS: --max-old-space-size=8192
+  NODE_OPTIONS: --max-old-space-size=12288
 
 jobs:
   # ── Gate 1: strict verification ──────────────────────────────────────

--- a/docs/subsystems/via-lookup.md
+++ b/docs/subsystems/via-lookup.md
@@ -120,17 +120,23 @@ live-rows set: a `vocabulary: 'closed'` field refuses even a genuinely valid, al
 until the dimension is hydrated. Open the backing collection (matrix tier; eager mode, the default —
 not `{prefetch:false}`) or call `await vault.dictionary(name).list()` (dict tier) first — the exact
 same populate-first requirement `altKeys` normalization has above. This fails safe (refuses rather
-than silently accepts an unverified key), but is easy to trip over on a fresh instance.
+than silently accepts an unverified key), but is easy to trip over on a fresh instance. Membership
+has never had a live fallback — it is pure-snapshot for both tiers. The matrix tier's *presentation*
+path (`<field>Label` resolution, below) is different: it preserves a live cold-session fallback, but
+**only** for the default `key: 'id'` (#651, closed).
 
 ## Presentation — `<field>Label`, in reads and in joins
 
 Reading with a locale resolves `<field>Label` on the SAME record (direct `present()`, works for
 reserved/static tiers via the vault-built label resolver). For matrix tier, direct (non-join) reads
-currently resolve the backing row by the backing collection's own PUT-id via `.get()` — **not** by
-`descriptor.key`. For the default `key: 'id'` those are the same thing, but for a custom canonical
-key like this doc's own `key: 'iso2'` recipe above, a direct `present()` read silently omits
-`<field>Label` instead of resolving it (tracked as #651) — use the join path below, or declare
-`key: 'id'`, until that's closed. Joining to a collection that itself declares a lookup field
+resolve the backing row through the SAME descriptor-keyed sync snapshot the join path uses
+(`resolveBackingRowKey`, #651 Task 3) — keyed by `descriptor.key`, never the backing collection's own
+PUT-id, so a custom canonical key like this doc's own `key: 'iso2'` recipe above resolves
+`<field>Label` correctly on a direct read too, not just through a join. The snapshot route needs the
+dimension collection open/populated in this session (the cold-session caveat above); the default
+`key: 'id'` tier ALONE keeps a live `.get()` fallback on a snapshot miss (construct+hydrate
+on-demand cold-session behavior, preserved unchanged) — for `key !== 'id'` the snapshot is the sole
+source of truth, per the caveat above. Joining to a collection that itself declares a lookup field
 resolves that field's label on the JOINED side too — the **snapshot+locale seam** (#650 Task 6,
 extended to matrix tier in Task 7), which correctly keys by `descriptor.key`, not the PUT-id:
 

--- a/docs/subsystems/via-lookup.md
+++ b/docs/subsystems/via-lookup.md
@@ -236,6 +236,37 @@ A plain delete on a dictionary/collection row that **no** declared lookup field 
 references is completely unaffected by any of this — `onDelete` only fires for dimensions a
 `lookupFields`/`via(lookup(...))` declaration actually points at.
 
+### Unresolvable compare-key: restrict fails closed, propagation residue-reports (#654)
+
+A matrix dimension with a non-default `key` resolves its compare-key by reading `row[key]` off the
+backing row (`resolveLookupCompareKey`). If that row is corrupted — the `key` field is missing or
+holds a non-string/non-number value — the compare-key **cannot be resolved**. Two policies apply,
+by `onDelete` mode:
+
+- **`restrict`** fails CLOSED: the delete/forget REFUSES with `RestrictRefUnresolvableError`
+  (`errors.ts`) naming the dimension, the row's key, and the unresolvable edge
+  (`"collection.field"`). Whether a referencer exists can't be proven, so the row is not deleted —
+  the same "cannot prove no references ⇒ do not delete" reasoning `DictKeyInUseError` already
+  applies when references ARE provably present.
+  ```ts
+  await expect(countries.delete('row-broken')).rejects.toThrow(RestrictRefUnresolvableError)
+  // err.dimension === 'countries'; err.key === 'row-broken'; err.referencing === 'orders.country'
+  ```
+- **`cascade`/`nullify`** residue-report instead: the delete PROCEEDS (only `restrict` edges are
+  fail-closed), but the un-propagated edge is never silently dropped — it's reported on a
+  structured `lookup:propagation-residue` event (`{ vault, dimension, key, residue }`, `residue`
+  entries formatted `backing:key:collection.field`), the ordinary-delete counterpart of the forget
+  path's `ForgetResult.lookupReferencesResidue` channel (which is unaffected — its own edges were
+  already residue-reported before #654).
+  ```ts
+  db.on('lookup:propagation-residue', (e) => { /* e.residue: ['countries:row-broken:orders.country'] */ })
+  await countries.delete('row-broken')   // still succeeds
+  ```
+
+A resolvable edge (the `key` field present and scalar) behaves exactly as before #654 in every
+mode — this is a corruption-class-rarity refinement, not a change to the common path (see
+`packages/hub/__tests__/via/lookup-restrict-unresolvable.test.ts`).
+
 ## Reserved-tier sync — dictionaries now travel (#647)
 
 Before #647, `_dict_*` rows written through `vault.dictionary(name)` bypassed the mutation choke

--- a/docs/subsystems/via-lookup.md
+++ b/docs/subsystems/via-lookup.md
@@ -78,6 +78,14 @@ tier: `getCollection(dimension).querySourceForJoin().snapshot()`; reserved tier:
 write-through cache) — no store I/O per `put()`. Matrix-tier altKeys require the backing collection
 to be open in eager (default, non-`{prefetch:false}`) mode.
 
+An altKey candidate row VALUE may be a string or a number — both normalize through the same
+`coerceLookupKey` core (a numeric `callingCode: 1` row value builds the altIndex entry `'1'`, same
+as a string `'1'` would), and the ownership-uniqueness check (no two rows may claim the same
+candidate) holds across the numeric/string boundary too — a numeric `1` on one row and the string
+`'1'` on another still collide and throw `ValidationError` (`lookup-altkeys.test.ts`, "accepts a
+numeric altKey value" / "throws ValidationError when a numeric altKey value coerces to the same
+string as another row's string altKey").
+
 ### Vocabulary — open vs closed, and sparse population
 
 `vocabulary: 'closed'` refuses an unknown key at write time with `UnknownLookupKeyError`:

--- a/docs/subsystems/via.md
+++ b/docs/subsystems/via.md
@@ -186,6 +186,75 @@ declaration-order asymmetry between the single-call and cross-call versions of t
 classified posture — sealed at rest / non-exportable / non-queryable — where it previously did not;
 this is a deliberate, pre-1.0 security fix (see the [changeset](../../.changeset/via-phase-c.md)).
 
+### Formula-output posture (#642) — the #636-principle completion
+
+#636/#638's taint enforcement covered a `computed` field's own declared `deps`; it left one gap
+open, demonstrated live during the phase C whole-branch review: a with-formula edge
+(derivation/rollup/MV) folds its effective posture from its source's whole-record `'*'` node, which
+never carried a registered posture at all — it always fell back to `DEFAULT_POSTURE`, no matter how
+classified the source collection was. A derive/rollup/MV `fn` receives DECRYPTED records by design
+(`sealedAsHandles: false`), so a `fn` that copied a classified field's plaintext into its output
+landed that plaintext UNSEALED — exportable, queryable, synced. **#642 closes it: every formula
+output derived from a classified-bearing collection is now sealed at rest / non-exportable /
+query-refused by default**, for both target shapes:
+
+- **Rollup targets** (a REAL field on the parent, e.g. `buyers.total`) — inherits the fold
+  automatically through the existing field-specific taint overlay; no separate opt-in.
+- **Derivation/MV/overlay OUTPUT collections** (the whole-record `'*'` target) — a new
+  collection-level `defaultPosture` fallback (`ViaTaintOverlay.defaultPosture`,
+  `ViaPipeline.postureFor`'s O(1) fallback, no fold-per-call) seals every non-`_`-prefixed field of
+  the output record (`taintBinding`'s `sealAllFields` mode; `_derivedFrom` and other reserved keys
+  are explicitly excluded).
+
+```ts
+const people = v.collection<Person>('people', { classifiedFields: { ssn: ssnSpec() } })
+const leaks = v.collection<Leak>('leaks')          // a plain derivation OUTPUT collection
+await people.put('p1', { id: 'p1', name: 'Alice', ssn: '123-45-6789' })
+;(await leaks.get('p1'))?.ssnCopy   // SealedHandle — sealed at rest, not plaintext
+leaks.query().where('ssnCopy', '==', '123-45-6789')   // throws FieldNotQueryableError
+```
+
+(from `packages/hub/__tests__/via/formula-output-posture.test.ts`, Shape A — the derivation-output
+case; Shape B pins the identical three surfaces — at-rest/query/export — for a rollup target).
+**No migration story**: pre-1.0, no shipped consumer uses formula outputs today, so there is nothing
+to migrate.
+
+**Axis-scoped, not a blanket clamp.** The fold only tightens the axes a classified source can
+actually justify — `encryptedAtRest` (sealed wins), `exportable` (AND), `forgettable` (OR, since a
+forgettable source forces its derived output forgettable too) — `queryable` is left at the base
+posture's own value and is never pulled down by a wildcard contributor. A blob/money/i18n-only
+source (never classified) therefore never clamps a formula output's queryability — only its
+`forgettable` bit may OR in:
+
+```ts
+// source collection has only a blob field (queryable:'none', forgettable:true) — no classified field
+posture.queryable    // 'full' — NOT 'none'; blob does not propagate its own unqueryability
+posture.forgettable  // true — BLOB's forgettable:true still ORs in
+```
+
+(`packages/hub/__tests__/via/wildcard-fold.test.ts`, "TRAP 2"). A `ref` edge's `'*'` source is
+excluded from the fold entirely — the fold is kind-scoped to `derivation`/`rollup`/`mv`/`overlay`
+edges only, not `ref`/`computed` — so a lookup-referencing field stays `DEFAULT_POSTURE` even when
+its backing dimension has a classified field, keeping the countries-matrix recipe byte-identical
+(`wildcard-fold.test.ts`, "TRAP 1").
+
+**Explicit per-declaration declassification is deferred to phase E** — not built here; there is
+currently no way to opt a formula output field back out of an inherited seal.
+
+**KNOWN LIMIT — reconcile-path ordering gap.** The cross-collection re-apply
+(`reapplyDependentOverlays`) that keeps an already-open dependent's overlay fresh when its source
+registers a classified field late is wired at the fresh-`vault.collection()`-construction call site
+only. A classified field attached to an already-open source via **reconcile** (a second
+`vault.collection()` call on the same name, not a fresh open) does not refresh an already-open
+DEPENDENT's stale overlay — only the reconciled collection's own overlay refreshes. Not covered by
+any test; a follow-up candidate, not fixed in this pass. See also
+[`docs/subsystems/via-computed.md`](via-computed.md) (its "Declare-time guard" section) for the
+sibling KNOWN LIMIT on the `computed` side — a `deps` entry naming a real-but-**wrong** field still
+passes construction and still leaks, since the guard only validates that `deps` names *some* known
+field, not that it names the field `fn` actually reads. Both limits share the same root cause (no
+runtime read-tracking or schema-aware dependency validation) and are candidates for the same future
+fix.
+
 **Sync/cutover/restore dispatch (#621)** closes the gap where a sync-applied write never triggered
 its derivations/materialized views — only a *local* `put()` did. A batched, per-target-deduped wave
 (`kernel/via-dispatch.ts#runGraphDispatchWave`) now runs once at the end of `pull()`/`push()`
@@ -204,6 +273,51 @@ expect(computeCalls).toBe(2) // 1 wave-driven (deduped from 3) + 1 self-triggere
 (from `packages/hub/__tests__/via/sync-dispatch.test.ts`; the flipped choke-point pin —
 `mutation-choke-point.test.ts`'s "sync-apply ... invalidates cache AND dispatches derivations" test
 — is the exact parity pin phase A/B left as a documented gap, now closed).
+
+**Sync-applied deletes now recompute rollup parents too (#640).** Before this pass,
+`_invalidateSyncApplied` hardcoded every sync-applied mutation as a `'put'`, so a remotely-deleted
+rollup child never recomputed its parent aggregate — only a *local* delete did
+(`dispatchRollupsOnDelete`). The choke point (`with-party/team/sync.ts`'s `SyncEngine.applyRemote`)
+now classifies each applied envelope as `'put'` or `'delete'` and threads the action through the
+widened `cacheInvalidator` seam; `GraphBatch` gains a delete leg (`GraphTouch.deletes: Map<string,
+readonly RollupDeleteIntent[]>`, ids/names only — no record payload, no key material); the dispatch
+wave (`runGraphDispatchWave`) routes deleted ids to the SAME rollup-recompute trio a local delete
+uses (batched, deduped per parent+field), never `dispatchDerivations`/MV-on-delete — mirroring the
+`mutation-choke-point.test.ts:85-99` pin that a delete is dispatch-inert for derivations/MVs, both
+locally and over sync:
+
+```ts
+// db2 pulls a delete of a rollup child from db1; orderCount is registered ONLY on db2
+await db2.sync('demo')  // pull()
+;(await db2Buyers.get('b1'))?.orderCount  // recomputed WITHOUT the deleted child — not stale
+```
+
+(from `packages/hub/__tests__/via/sync-delete-rollup.test.ts`). **KNOWN LIMIT — the miss scope.**
+The deleted child's prior (pre-invalidation) value is read from the LRU/cache (`_peekCached`)
+synchronously, right before the cache entry is dropped, so the parent-resolving intents can be
+computed with no extra I/O. If that read misses — a **cold or evicted child** (lazy-mode LRU
+eviction of the child before the sync-apply lands) **or an un-hydrated eager collection whose first
+sync op for that child is a delete** (`ensureHydrated()` never ran, so the eager cache never held a
+record to peek) — the miss is silent and freshness-only: that one child's rollup-parent intents are
+skipped, no recompute happens for it, and no error is raised. Correctness is otherwise intact (the
+recompute reads the REMAINING children from the store, so nothing double-counts); this is a
+follow-up candidate, not fixed here. The sync-delete path also stays narrower than the local-delete
+path by design: it recomputes only the rollup leg, not `dispatchMaterializedViewsOnDelete`/
+`dispatchArrayDerivationsOnDelete` — both #640's issue text and the `mutation-choke-point.test.ts`
+pin scope sync-delete dispatch to rollups only; wiring MV/array-derivation-on-delete into the
+sync-delete wave is a candidate follow-up, not a regression of this pass.
+
+**Riders.** `push()`/`pull()` now wrap `persistMeta()` in a `finally` that flushes the graph batch
+even when `persistMeta()` throws — previously a throw there left `_graphBatch` open, silently
+dropping that wave's touches until the next `begin()` replaced it (#644 item 1). Both the puts leg
+and the new deletes leg of the dispatch wave additionally emit a structured
+`'derivation:wave-error'` event (`{ collection, id, error }`) alongside the pre-existing
+`console.warn` on a non-`PeriodClosedError` per-id failure, so a pull that completed with a failed
+recompute is programmatically discoverable, not just logged (#644 item 3):
+
+```ts
+db.on('derivation:wave-error', (e) => { /* e.collection, e.id, e.error */ })
+```
 
 **Frozen-output rule (#637)**: before phase C, a derivation/rollup/MV output landing in a period
 [closed](periods.md) threw `PeriodClosedError` straight through the *legal source write* that
@@ -310,3 +424,9 @@ canonical countries-matrix example.
 - `packages/hub/src/shape/via-lookup/` — phase D: the lookup binding (descriptors, registry, snapshot, handle)
 - `packages/hub/src/shape/via-blob/` — phase B: blob binding
 - `packages/hub/src/shape/via-computed/` — phase C: computed binding
+- `packages/hub/__tests__/via/formula-output-posture.test.ts` — the #642 formula-output posture
+  suite (both target shapes × three surfaces + the ordering gap)
+- `packages/hub/__tests__/via/wildcard-fold.test.ts` — the #642 `ViaGraph` `'*'`-fold unit suite
+  (axis-scoping, kind-scoping, the ref-identity/blob traps)
+- `packages/hub/__tests__/via/sync-delete-rollup.test.ts` — the #640 sync-applied-delete rollup
+  recompute suite (dedup/ordering/freshness + the `derivation:wave-error` event)

--- a/docs/subsystems/via.md
+++ b/docs/subsystems/via.md
@@ -255,6 +255,14 @@ field, not that it names the field `fn` actually reads. Both limits share the sa
 runtime read-tracking or schema-aware dependency validation) and are candidates for the same future
 fix.
 
+**KNOWN LIMIT — the MV leg is currently theoretical for classified sources.** All three MV refresh
+modes (eager/lazy/manual) pre-open their source collection during `openVault`'s
+`_initMaterializedViews` (the spec's `query()` callback runs at registration time), and the
+pre-existing classified retro-declare guard (`ClassifiedConfigError`, `collection.ts:1357`) then
+refuses `classifiedFields` declared on that already-open source — so an MV over a classified source
+is structurally unreachable today, even though the fold above would apply mechanically the moment
+that ordering constraint ever lifts.
+
 **Sync/cutover/restore dispatch (#621)** closes the gap where a sync-applied write never triggered
 its derivations/materialized views — only a *local* `put()` did. A batched, per-target-deduped wave
 (`kernel/via-dispatch.ts#runGraphDispatchWave`) now runs once at the end of `pull()`/`push()`

--- a/docs/superpowers/plans/2026-07-12-via-consolidation.md
+++ b/docs/superpowers/plans/2026-07-12-via-consolidation.md
@@ -1,0 +1,331 @@
+# Via consolidation pass — formula-output taint, the key-resolution class, sync-delete freshness (#642, #651, #640, #654)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the four remaining Via structural defects on milestone #30 in ONE coherent pass: (#642) with-formula OUTPUTS bypass classified taint — go DEEP with collection-level output postures; (#651 + #654) the ONE key-resolution class — a canonical descriptor-keyed core ending the PUT-id-vs-`row[descriptor.key]` drift and the dm12 coercion split, plus the #654 fail-closed policy; (#640) sync-applied deletes never reach the rollup recompute wave — three coherent layers. Ride the near-free items #644 (items 1+3) and #646 (fixture mandate) that live in the same diffs.
+
+**Issues:** [#642](https://github.com/vLannaAi/noy-db/issues/642) (security), [#651](https://github.com/vLannaAi/noy-db/issues/651) + [#654](https://github.com/vLannaAi/noy-db/issues/654) (key-resolution class), [#640](https://github.com/vLannaAi/noy-db/issues/640) (freshness) · **Milestone:** #30 "Via follow-ups [api]" · **Base:** `main 5f290e57` (v0.3.0-pre.9 published), working branch `fix/via-consolidation-m30` HEAD `c57879ac`.
+
+**Surface:** `api` — additive (collection-level output postures, batch delete-kind, key-resolution core). Behavior change on #642 per the user-ratified call (no consumers use formula outputs yet → no migration story). `@noy-db/hub/adapter` and `@noy-db/hub/cargo` are **byte-untouched**.
+
+**Tech Stack:** TypeScript, `@noy-db/hub` (tsup + vitest), turbo monorepo. Run from repo root: `pnpm vitest run <path>`; one package: `pnpm --filter @noy-db/hub <script>`; architecture guard: `node scripts/check-architecture.mjs`.
+
+## REQUIRED READING (every task)
+
+- **Spec (user-ratified):** `docs/superpowers/specs/2026-07-12-via-consolidation-design.md`
+- **Seam map (GROUND TRUTH — AUTHORITATIVE over the spec where they conflict; conflicts flagged inline below):** `.superpowers/sdd/seam-map-consolidation.md` — Part-N references point into it. Line numbers were located at `main 5f290e57`; re-locate by symbol if drifted at `c57879ac`.
+- **Format precedent (executed successfully):** `docs/superpowers/plans/2026-07-12-via-phase-d.md`.
+- Current-code touchpoints (exact signatures verified at `c57879ac`): `kernel/via-graph.ts` (`_contribution`/`_declaredPosture`/`_computeEffective`/`_effectiveCache`/`foldPosture`/`taintedPostures`/`referencingEdgesOf`), `kernel/via-graph-wiring.ts` (`applyTaintOverlay`/two-phase `validateReconcileGraphEdges`/`commitReconcileGraphEdges`), `kernel/via-taint-binding.ts` (`buildTaintOverlay`/`taintBinding`), `kernel/via-pipeline.ts` (`postureFor`/`redactForExport`/`ViaTaintOverlay`), `kernel/via-dispatch.ts` (`GraphBatch`/`runGraphDispatchWave`/`putDerivedOutput`/`applyLookupRefsFanout`/`forgetDerivedFanout`), `with-party/team/sync.ts` (`pull`/`push` loops, `applyRemote`, `cacheInvalidator` seam), `kernel/vault.ts` (`_invalidateSyncApplied` ~1286, `getLookupBacking` closure :1134, `_collectGraphTouch`/`_flushGraphBatch`), `with-shape/links/vault-facade.ts` (`checkLookupRefsRestrict` :319, `applyLookupRefsPropagation` :342, `resolveLookupCompareKey` :286, `findLookupReferencingRecords` :267), `shape/via-lookup/registry.ts` (`buildLookupSnapshotRows`/`buildLookupAltIndex`/`checkLookupMembership`/`materializeBackingTable`), `shape/via-lookup/binding.ts` (`fetchLookupLabel` :84), `port/with/lookup-strategy.ts`, `kernel/collection.ts` (`dispatchRollupsOnDelete` :2255, `recomputeRollup` :2211, `_onRecordMutated` sync-apply :3833, `_peekCached` :3852, `_getStoredRecordForDispatch` :2164), `scripts/check-architecture.mjs` (ceilings + both via allowlists).
+
+## SEAM-MAP-vs-SPEC CONFLICTS (resolved here; re-flag if execution reveals more)
+
+1. **The fold operator (spec §1 vs seam-map finding 9).** The seam map frames the `'*'` fold through `foldPosture`, which folds ALL FOUR axes — the "naive fold over-restricts wildly" trap. The spec resolves the open design question: fold the **security axes ONLY** (`encryptedAtRest` sealed-wins, `exportable` AND, `forgettable` OR); do NOT fold `queryable`. **Resolution:** introduce a NEW `foldWildcardSecurity` helper — NOT `foldPosture` — that leaves `queryable` at `DEFAULT_POSTURE`'s `'full'`; the sealed→`'none'` clamp is left to `buildTaintOverlay`'s existing phase-C honest clamp. Verified at `c57879ac` (`grep -n posture` on every binding): money `{envelope,ordered,exp:T,forg:T}`, blob `{envelope,none,exp:T,forg:T}`, i18n `{envelope,full,exp:T,forg:T}`, classified `{sealed,det-exact,exp:F,forg:T}`, lookup `{envelope,full,exp:T,forg:F}` — so a security-axis fold makes ONLY a classified source seal/non-export an output; money/blob/i18n contribute at most `forgettable:true`. The blast radius the seam map feared (blob→unqueryable) is structurally avoided BECAUSE `queryable` is unfolded. This is the "blob-field-must-not-unqueryable-outputs pin".
+
+2. **`'*'` contribution is kind-scoped by the CONSUMING edge (seam-map surprise 7 + finding 7).** `effectivePosture`/`_computeEffective` are kind-blind today; a `'*'` source folded unconditionally would seal every `lookup()` referencing field whose dimension holds a classified/blob/money column, breaking #650's DOCUMENTED reliance (`registry.ts:392-397`: "`DEFAULT_POSTURE` is the fold's identity element, so adding the wildcard alongside a real field source changes nothing"). **Resolution:** the `'*'` fold applies ONLY when the consuming edge kind ∈ `{derivation, rollup, mv, overlay}`; for `kind === 'ref'` the `'*'` source KEEPS identity (`DEFAULT_POSTURE`). Kind is threaded into `_contribution` from `_computeEffective`. Precedent: `dependentsOf` already excludes `'ref'` (`via-graph.ts:307-309`). This is the "ref-identity pin".
+
+3. **"Collection-level default posture … carried in collection config" (spec §1) vs the enforcement wall (seam-map findings 8 + 10).** The output collection's default posture is NOT user config — it is GRAPH-derived (the `'*'` target edge's folded effective posture) and cannot land through `taintSealedFields`/`postureFor`/`taintBinding`/`redactForExport`, which all key by REAL field names (a `'*'` key matches nothing). **Resolution (ground truth wins):** carry the default posture in the `ViaTaintOverlay` (a new `defaultPosture?` field), extracted by `applyTaintOverlay` from the graph's `'*'` target entry, and add a whole-record-floor interpretation to `postureFor` (fallback for ANY field) + `redactForExport` (already walks all fields → falls back automatically) + a whole-record SEAL mode on `taintBinding`. "carried in collection config" is loose spec phrasing.
+
+4. **#654's "three silent-skip sites" (seam-map surprise 3 / Part 2d).** The e1cbce3e residue fix already covered the FORGET-path twin (`applyLookupRefsFanout`, `via-dispatch.ts:284-286` — residue-reports today). The TWO REMAINING silent sites are both in `vault-facade.ts`: `checkLookupRefsRestrict:323` (`onDelete !== 'restrict' || compareKey === undefined → continue`) and `applyLookupRefsPropagation:349` (bare `if (compareKey === undefined) continue`). **Resolution:** the restrict site becomes fail-closed REFUSE; the propagation site residue-reports (its return shape gains `residue`). The via-dispatch twin is already correct — do NOT double-fix it.
+
+5. **The kernel spine MAY import `port/with/*` freely (seam-map surprise 4).** `checkPortLayering` sanctions spine→`port/with/` (`check-architecture.mjs:1491-1492`). The pure key-resolution core (Task 3) lives in `shape/via-lookup/registry.ts`, re-exported through `port/with/lookup-strategy.ts`; `vault.ts` / `vault-facade.ts` / `via-dispatch.ts` all consume it via that seam. The `VaultLinks`/with-shape I/O SHELLS stay put (they use different collection accessors + residue plumbing — the T5 duplication is only PARTIALLY forced); only the pure core is shared. `via-dispatch.ts` MUST NOT gain a with-* import.
+
+## Global Constraints (copied from spec + arc conventions)
+
+- **Behavior locks:** the FULL derivations / MV / rollup, lookup (all tiers + aliases), sync, forget/erasure, and classified suites pass **UNCHANGED** except the enumerated defect-pin flips. Per the seam map (finding 10) the four repros DO NOT EXIST today — they are NEW pins, so the flip set is near-empty. **Defect-pin flips ENUMERATED PER FILE:** verified at `c57879ac`:
+  - `__tests__/via/taint.test.ts:168-199` (KNOWN-LIMIT: a `computed` field naming a real-but-wrong dep) — **DOES NOT FLIP.** It uses a `computed:{…}` field (EdgeKind `'computed'`), which is NOT a folded formula kind (Task 1 folds only `derivation|rollup|mv|overlay`). Its `ssnLeak` still folds from the declared (wrong) `amount` dep. Leave byte-unchanged; add a one-line comment cross-referencing #642's kind-scoping so a future reader knows why it survived.
+  - `__tests__/via/mutation-choke-point.test.ts:85-99` (LOCAL delete does NOT dispatch derivations) — **DOES NOT FLIP.** #640 routes SYNC-applied deletes to the rollup-on-delete trio, never `dispatchDerivations`; local-delete-vs-derivation is orthogonal. Preserve it exactly; it is the guard that the #640 wave doesn't over-dispatch.
+  - No other existing test pins #642/#651/#640/#654 defect behavior (seam map §5 gaps confirmed: no formula-OUTPUT posture test; no direct-read matrix dressing with `key!=='id'`; no restrict-with-unresolvable-key test; no pulled-delete-recomputes-parent test). The four repros are ADDED as the new pins.
+- **Zero-knowledge non-negotiable:** collection-level output posture is METADATA (a posture, no keys/values); at-rest sealing rides the EXISTING `ctx.sealedSlots` path (`taintBinding` — byte-for-byte the classified capability, no new crypto path). The key-resolution core (Task 3) is a PURE function — it takes a descriptor + a row and returns a coerced string; NO crypto, NO `Collection`/keyring/DEK/enclave handle. `GraphBatch` holds ids (collection names, record ids incl. resolved rollup PARENT ids) + field names ONLY — never record payload or key material. Grep every new `shape/via-lookup/**` and every guarded-file diff for `keyring`/`DEK`/`CEK`/`enclave` reach-arounds and confirm none.
+- **Ceilings — ALL THREE at +1 slack, verified at `c57879ac`** (`wc -l` vs `scripts/check-architecture.mjs`):
+  - `kernel/collection.ts` — actual **4472**, ceiling **4473** (`:728`), slack **+1**.
+  - `kernel/vault.ts` — actual **3939**, ceiling **3940** (`:959`), slack **+1**.
+  - `kernel/noydb.ts` — actual **2384**, ceiling **2385** (`:1067`), slack **+1**.
+  New logic lands in UNGUARDED files (`via-graph.ts`, `via-taint-binding.ts`, `via-pipeline.ts`, `via-graph-wiring.ts`, `via-dispatch.ts`, `registry.ts`, `vault-facade.ts`, `errors.ts`, `sync.ts`). Guarded-file touches are thin and in-place (net-zero where possible). **A ceiling bump is BLOCKED — it requires explicit user sign-off, never a silent bump. Shrink-first if a guarded file must grow.** Report actual `wc -l` on every guarded file a task touches. The primary ceiling pressure is `collection.ts` in Task 5 (#640) — see that task's ceiling note.
+- **Guards stay EMPTY + fire:** `VIA_SHAPE_ALLOWLIST` (`:1890`) and `VIA_ENCLAVE_ALLOWLIST` (`:1941`) both stay `new Map([])`. Do NOT add entries. `node scripts/check-architecture.mjs` must pass; the guards must still FIRE on a synthetic `kernel/** → shape/**` (resp. `shape/via-*/** → kernel/enclave`) import.
+- **#553 discipline:** the `'*'` fold is LAZY (computed in `_contribution`, memoized in `_effectiveCache` which already clears on every `registerField`/`registerDerived`) and SYNC. QUERY-participation hooks (`buildClause`/`evaluateClause`/`compareForOrder`/`postureFor`/`resolveOrderLabel`) stay SYNC — no store read, no async in a query hook. `postureFor` is a HOT PATH: the collection-default fallback must be **O(1) per call — no fold-per-call**; cache the folded `defaultPosture` on the overlay (computed ONCE in `applyTaintOverlay`, read by reference in `postureFor`).
+- **id-thread any decrypt:** every new `decryptRecord`/`_decodeEnvelope`/`_getStoredRecordForDispatch` path threads the record `id` (the phase-B at-rest contract).
+- **The #644 / #646 riders land in the diffs they touch** (Task 5): #644 item 1 (stale-open `_graphBatch` cleared on push/pull throw) + item 3 (structured `derivation:wave-error` event upgrading the `console.warn`); #646's fixture mandate (db2-only registration) rides the new two-instance delete test. #644 item 2 (reentrancy) stays DEFERRED.
+- **Never add Claude attribution** to commits/PRs/CHANGELOGs. **Grep every diff for `accounting-firm` before every commit** (`git diff | grep -n accounting-firm` → empty). Write the two-character escape `\0` in any code, never a raw NUL byte.
+
+---
+
+### Task 1: The kind- & axis-scoped `'*'` fold (#642 half 1 — the graph algebra)
+
+**Rationale:** `_declaredPosture('*')` returns `DEFAULT_POSTURE` today (`'*'` nodes are never `registerField`ed), so a derivation/rollup/MV over an all-classified collection still folds to max-permissive — the #636 sibling leak at the graph layer. This task makes a `'*'` LEAF node's contribution a lazy, kind-scoped, security-axis fold of its collection's registered field postures. Pure graph algebra, unit-testable in isolation; enforcement is Task 2. UNGUARDED file only (`via-graph.ts`).
+
+**Files:**
+- Modify: `kernel/via-graph.ts` —
+  - Add `foldWildcardSecurity(base, contributor)` (module function, exported for unit test): folds `encryptedAtRest` (sealed-wins), `exportable` (AND), `forgettable` (OR) ONLY — leaves `queryable` at `base.queryable`. Distinct from `foldPosture` (which folds all four axes); do NOT reuse `foldPosture` here.
+  - Add a memoized private `_wildcardContribution(collection): ViaPosture` — folds every `_posture` entry whose node id is `${collection}${SEP}<field>` (any field EXCEPT the wildcard `'*'` itself) via `foldWildcardSecurity`, seeded at `DEFAULT_POSTURE`. Memoize in a new `_wildcardCache = new Map<string, ViaPosture>()`, cleared alongside `_effectiveCache` in `registerField`/`registerDerived` (add `this._wildcardCache.clear()` to the two existing `this._effectiveCache.clear()` sites).
+  - Thread the consuming edge kind into `_contribution`: `_computeEffective` calls `this._contribution(nodeId(source), edge.kind)`; `_contribution(id, kind?)` — when the node is a LEAF (no in-edge) AND its field is `'*'` (`id.endsWith(`${SEP}*`)`) AND `kind` is a folded formula kind (`derivation|rollup|mv|overlay`), return `_wildcardContribution(collection)`; otherwise the current `_declaredPosture(id)`. `taintProvenance`'s `this._contribution(nodeId(source))` call keeps `kind` undefined (identity for `'*'` — provenance names only real declared sources, unchanged).
+  - Promote the `'*'` literal to a `WHOLE_RECORD` const already partially duplicated (`with-formula/derivations/registry.ts:17`, `materialized-views/registry.ts:15`, and the `referencingEdgesOf` wildcard convention `:322-324`) — OPTIONAL cleanup; if promoted, keep the hand-duplication comment in `via-graph.ts:22-25`'s sibling style. Skip if it risks the ceiling on any consumer.
+
+**Interfaces — Produces (Task 2 binds to these):**
+
+```ts
+// kernel/via-graph.ts
+/** Security-axes-only fold for a wildcard collection node (#642): sealed-wins encryptedAtRest,
+ *  AND exportable, OR forgettable — queryable is NOT folded (stays base.queryable; the sealed
+ *  clamp to 'none' is buildTaintOverlay's job, so inheriting `sealed` never over-restricts a
+ *  blob-adjacent output to unqueryable). Pure; exported for unit testing. */
+export function foldWildcardSecurity(base: ViaPosture, contributor: ViaPosture): ViaPosture
+
+// the folded formula kinds a '*' source contributes its collection-fold to (ref keeps identity):
+type FoldedKind = 'derivation' | 'rollup' | 'mv' | 'overlay'
+```
+
+**Interfaces — Consumes:** `ViaPosture` (`via.ts`), `DEFAULT_POSTURE`/`EdgeKind`/`FieldRef` (this file).
+
+**Design notes:**
+- The fold is over the SOURCE collection's REGISTERED field postures only — a plain (unregistered) field contributes nothing (the identity), so the fold is strictly more conservative than deps-based taint and never hits the KNOWN-LIMIT wall (it names no fields; seam map §1d). Registration ordering is free: `_effectiveCache`/`_wildcardCache` clear on every `registerField`, so a later-registered classified field re-folds on next `effectivePosture` (seam map finding 3/10 — the GRAPH-level invalidation; the PIPELINE-level re-apply is Task 2).
+- Kind-scoping is the ONE thing that keeps the countries recipe intact (conflict 2): a `ref` edge's `{backing,'*'}` source stays `DEFAULT_POSTURE`, so a `lookup('countries')` field referencing a matrix with a classified column does NOT seal.
+
+- [ ] Step 1 (RED): `packages/hub/__tests__/via/wildcard-fold.test.ts` (new) — pure `ViaGraph` unit tests (no createNoydb):
+  - `foldWildcardSecurity` folds security axes only: `foldWildcardSecurity(DEFAULT, {sealed,det-exact,exp:F,forg:T})` → `{encryptedAtRest:'sealed', queryable:'full', exportable:false, forgettable:true}` (queryable UNCHANGED at base `'full'`).
+  - Build a graph: `g.registerField('src','ssn',{sealed,det-exact,exp:F,forg:T})`; `g.registerField('src','plain',DEFAULT)`; `g.registerDerived({collection:'out',field:'*'}, [{collection:'src',field:'*'}], 'derivation','record')`. Assert `g.effectivePosture({collection:'out',field:'*'})` → `{encryptedAtRest:'sealed', queryable:'full', exportable:false, forgettable:true}`.
+  - **blob-field-must-not-unqueryable-outputs pin:** `g.registerField('src2','doc',{envelope,none,exp:T,forg:T})` (blob) + a derivation `'*'` edge from `src2`. Assert the output `'*'` posture's `queryable === 'full'` (NOT `'none'`) — blob does not clamp queryability of derived outputs; only `forgettable` ORs to `true`.
+  - **ref-identity pin:** register a `'ref'` edge `{collection:'orders',field:'country'} ← [{collection:'countries',field:'*'}]` with `g.registerField('countries','iso2',{sealed,…})` present. Assert `g.effectivePosture({collection:'orders',field:'country'})` stays `DEFAULT_POSTURE` (identity — the `'*'` fold does NOT apply to `'ref'` kind). Also assert a rollup edge `{collection:'parent',field:'total'} ← [{collection:'src',field:'*'}]` DOES fold sealed (real-field target inherits).
+  - Ordering-free assertion: register the classified `src` field AFTER the derivation edge; assert the fold still seals (cache cleared on the late `registerField`). RED (helper + kind-scoping absent).
+- [ ] Step 2 (GREEN): implement `foldWildcardSecurity`, `_wildcardContribution` + `_wildcardCache`, the kind-threaded `_contribution`. Run RED → GREEN. Run the FULL via graph/taint/lookup-ref suites unchanged — `pnpm vitest run packages/hub/__tests__/via/graph.test.ts packages/hub/__tests__/via/graph-edges.test.ts packages/hub/__tests__/via/taint.test.ts packages/hub/__tests__/via/lookup-ref-semantics.test.ts packages/hub/__tests__/via/countries-matrix.test.ts` → GREEN (the ref-identity guarantee keeps lookup-ref/countries byte-identical; the taint KNOWN-LIMIT survives — `computed` isn't a folded kind).
+- [ ] Step 3: `node scripts/check-architecture.mjs` (via-graph.ts is metadata-only + unguarded — no ceiling touch; confirm no new value/key storage). `pnpm --filter @noy-db/hub typecheck && pnpm --filter @noy-db/hub lint`. `git diff | grep -n accounting-firm` (empty). Commit — `feat(hub): kind- & axis-scoped '*' posture fold in ViaGraph — formula outputs inherit source taint (#642)`.
+
+---
+
+### Task 2: Enforcement — both target shapes (#642 half 2 — rollup auto + collection-default output posture)
+
+**Rationale:** Task 1 makes the graph FOLD; this task makes it ENFORCE across the three surfaces (query refusal, export redaction, at-rest sealing) for BOTH target shapes: rollup targets (REAL fields — automatic via the existing Task-C3 overlay) and derivation/MV/overlay OUTPUTS (`'*'` targets — need the collection-level default posture, seam map finding 8). Closes the cross-collection re-apply gap (finding 10). All UNGUARDED files, except a possible one-line vault.ts re-apply call (net-zero target; shrink-first/BLOCK if not).
+
+**Files:**
+- Modify: `kernel/via-pipeline.ts` — `ViaTaintOverlay` gains `readonly defaultPosture?: ViaPosture` (the whole-record floor). `postureFor(field)`: taint field-specific (`this.taint?.postures.get(field)`) → binding `covers` → **`this.taint?.defaultPosture`** fallback (O(1) read — no fold). `redactForExport` already walks every own field via `postureFor` → picks up the default automatically (no change to its body — verify).
+- Modify: `kernel/via-taint-binding.ts` — `taintBinding(sealFields, presentRedactFields, sealAllFields = false)`: when `sealAllFields`, `encodeAtRest` seals EVERY own field carrying a defined value EXCEPT reserved/internal keys (skip keys starting with `_`, e.g. `_derivedFrom`), `decodeAtRest` restores every key present in the record's `sealed` map, `covers` returns `true` for any non-`_` field. The `sealAll` seal loop mirrors `encodeTaintAtRest` but iterates `Object.keys(record)` instead of a fixed list. `buildTaintOverlay` is unchanged for field-specific entries; the `'*'` entry is handled in `applyTaintOverlay` (below), not here.
+- Modify: `kernel/via-graph-wiring.ts` —
+  - `applyTaintOverlay(coll, graph, name)`: read `graph.taintedPostures(name)`, split off the `'*'` entry (`raw.get('*')`) as the collection default; build the field-specific overlay from the remaining entries exactly as today. Compute `defaultPosture` = the `'*'` posture after the same sealed→`queryable:'none'` clamp `buildTaintOverlay` applies (reuse that clamp). When `defaultPosture?.encryptedAtRest === 'sealed'`, append `taintBinding(sealFields, virtualExportRedact, /*sealAllFields*/ true)`; thread `defaultPosture` into the `ViaTaintOverlay`. A collection with neither field taint nor a `'*'` default stays `this.via === undefined` (the #553 no-op-when-empty contract holds — only add the default branch when `raw.get('*')` is non-default).
+  - Add `reapplyDependentOverlays(graph, name, getOpenCollection)` — after a SOURCE collection registers its fields, re-apply `applyTaintOverlay` for every OPEN output collection that depends on `name` (the cross-collection re-apply gap, finding 10). Uses `graph.dependentsOf(name)` (which already excludes `'ref'`) → the distinct target collections → for each currently-open one, re-run `applyTaintOverlay`. Pure wiring; no new graph state (reuses the graph-memory the lazy fold already invalidates).
+- Modify: `kernel/vault.ts` — at the existing construction region (`:1172-1174`, right after `registerCollectionGraphSources` + `registerLookupRefEdges` + `applyTaintOverlay`) add ONE call `reapplyDependentOverlays(this.graph, collectionName, (n) => this._getCollection(n))` so opening a classified SOURCE after its derivation OUTPUT refreshes the output's stale overlay. **Net-zero target:** this is one added line — if `wc -l vault.ts` exceeds **3940**, shrink-first (collapse an adjacent dense declaration) or STOP and flag **BLOCKED** (never bump). Report the count.
+- Modify: `kernel/via-graph.ts` — no change if `taintedPostures` already surfaces the `'*'` target (it iterates every `_in` edge for the collection, so the derivation/mv/overlay `'*'` target IS included). Verify; if a filter excludes `'*'`, remove it.
+
+**Interfaces — Produces:**
+
+```ts
+// kernel/via-pipeline.ts
+export interface ViaTaintOverlay {
+  readonly postures: ReadonlyMap<string, ViaPosture>
+  readonly sealFields: ReadonlySet<string>
+  readonly provenance?: ReadonlyMap<string, readonly string[]>
+  /** #642 — the whole-record floor for a derivation/MV/overlay OUTPUT collection (the '*' target's
+   *  folded, clamped effective posture). postureFor falls back to it for ANY field; redactForExport
+   *  picks it up per-field; a sealed default drives taintBinding's sealAllFields mode. O(1) read. */
+  readonly defaultPosture?: ViaPosture
+}
+
+// kernel/via-taint-binding.ts
+export function taintBinding(
+  sealFields: ReadonlySet<string>,
+  presentRedactFields?: ReadonlySet<string>,
+  sealAllFields?: boolean,   // #642 — whole-record seal for a '*'-defaulted output collection
+): ViaBinding
+
+// kernel/via-graph-wiring.ts
+export function reapplyDependentOverlays(
+  graph: ViaGraph, name: string,
+  getOpenCollection: (n: string) => unknown /* Collection | undefined */,
+): void
+```
+
+**Interfaces — Consumes:** `ViaGraph.taintedPostures`/`dependentsOf` (`via-graph.ts`), `buildTaintOverlay`/`taintBinding` (`via-taint-binding.ts`), `ViaPipeline.build` (`via-pipeline.ts`), `ctx.sealedSlots` (the existing at-rest capability).
+
+**Design notes:**
+- **Rollups are automatic** — verify, don't build: the rollup edge's target is `{spec.source, rollup.field}` (a REAL field, `derivations/registry.ts:158`). Once Task 1 makes `{rollup.from,'*'}` fold sealed, `taintSealedFields(parentColl)` includes `rollup.field` and `applyTaintOverlay` seals/gates it with zero new consumer code. The only new work is the apply-ordering (the `reapplyDependentOverlays` hook) when the parent collection was opened before the child's classified field registered.
+- **Derivation/MV/overlay outputs** land the fold under the literal `'*'` key in `taintedPostures(outputColl)` → the `defaultPosture` interpretation is the whole-record floor. Sealed-inherited outputs: `postureFor(anyField)`→sealed→query refused; `redactForExport`→`exportable:false`→`[sealed]`; `taintBinding(sealAllFields)`→every field sealed at rest via `ctx.sealedSlots`.
+- **postureFor is HOT** — `defaultPosture` is precomputed once in `applyTaintOverlay` and read by reference; NEVER fold per `postureFor` call.
+- **Reconcile re-apply respects at-most-once graph registration (D-2 wave-2 law):** `reapplyDependentOverlays` only re-runs `applyTaintOverlay` (a pipeline rebuild), it NEVER re-registers a graph edge — `registerDerived`'s at-most-once contract is untouched. The two-phase `commitReconcileGraphEdges` path already calls `applyTaintOverlay` for the reconciled collection; the new hook extends the SAME refresh to open DEPENDENTS.
+
+- [ ] Step 1 (RED): `packages/hub/__tests__/via/formula-output-posture.test.ts` (new) — the #642 repro, both shapes × three surfaces, using `withClassified()` + a `classifiedFields` source and `derivationStrategies`/rollup. Structure per the countries-matrix inline-memory harness + `mutation-choke-point.test.ts`'s `makeDerivation()` pattern.
+  - **Shape A — derivation OUTPUT collection (`'*'` target):** source `people` with `classifiedFields:{ ssn }`; a derivation copying `ssn` into an output collection `leaks`. Assert: (query) `leaks.query().where('ssnCopy','==', <x>)` refuses / matches nothing per the honest clamp; (export) the output record redacts to `[sealed]` through `exportStream`/`redactForExport`; (at-rest) reading the raw stored envelope shows the field in `_sealed`, and `leaks.get(id)` returns a `SealedHandle` for it.
+  - **Shape B — rollup TARGET (real field):** children with a classified `amount`-adjacent field feeding a rollup `total` on a parent; assert the parent's `total` field seals/redacts/refuses identically.
+  - **Ordering repro:** open the OUTPUT collection BEFORE the classified SOURCE; put a source row; assert the output STILL seals (the `reapplyDependentOverlays` hook fired). RED.
+- [ ] Step 2 (GREEN): implement `defaultPosture` in `ViaTaintOverlay` + `postureFor`, `taintBinding` `sealAllFields`, `applyTaintOverlay`'s `'*'` split + default clamp + whole-record-seal binding, `reapplyDependentOverlays`, the vault.ts hook. Run RED → GREEN. Run the FULL behavior-lock suites — `pnpm vitest run packages/hub/__tests__/via packages/hub/__tests__/derivations packages/hub/__tests__/materialized-views packages/hub/__tests__/classified` → GREEN UNCHANGED (the taint KNOWN-LIMIT survives; `export-posture-b`/`query-posture-b` unchanged; countries/lookup-ref unchanged via ref-identity).
+- [ ] Step 3: **ceilings** — `wc -l packages/hub/src/kernel/vault.ts` ≤ **3940** (report it; shrink-first or BLOCK if over). `node scripts/check-architecture.mjs` (guards EMPTY + fire; via-taint-binding/via-pipeline/via-graph-wiring unguarded). `pnpm --filter @noy-db/hub typecheck && lint`. `pnpm --filter @noy-db/hub build && pnpm --filter @noy-db/hub bundle-check` (taint machinery stays out of the floor for taint-free collections). `git diff | grep -n accounting-firm` (empty). Commit — `feat(hub): enforce folded '*' posture on formula outputs — rollup targets + collection-level default posture, three surfaces (#642)`.
+
+---
+
+### Task 3: The ONE key-resolution core (#651) — descriptor-keyed resolution + guarded coercion, six consumers converge
+
+**Rationale:** A matrix lookup with `key !== 'id'` stores `row[descriptor.key]`; any resolution by the backing row's PUT-id is wrong when the two differ. `getLookupBacking`'s closure (`vault.ts:1134`) does a PUT-id `.get(key)` — the #651 direct-read leak. Five sites are already descriptor-keyed but split across a bare-`String()` vs guarded-coercion dialect (dm12). This task extracts ONE canonical core, converges all six consumers, and reshapes `getLookupBacking` to gain the descriptor. All UNGUARDED except the vault.ts:1134 closure REPLACED in place (net-zero, the Task-7 `snapshotFor` precedent).
+
+**Files:**
+- Modify: `shape/via-lookup/registry.ts` — add the pure core:
+  - `coerceLookupKey(raw): string | undefined` — the ONE guarded coercion (`typeof raw === 'string' || typeof raw === 'number' ? String(raw) : undefined`). Kills the bare-`String()` `"undefined"`/`"null"` poisoning.
+  - `resolveBackingRowKey(descriptor, row): string | undefined` — `coerceLookupKey(row[descriptor.key])` (the backing row's canonical key VALUE).
+  - `matchesReferencingValue(rec, field, compareKey): boolean` — `coerceLookupKey(rec[field]) === compareKey` (the referencing-side match predicate; `compareKey` already coerced).
+  - Converge `buildLookupSnapshotRows` matrix branch (`:482`) and `buildLookupAltIndex` matrix branch (`:369`) onto `resolveBackingRowKey` — SKIP rows whose key coerces to `undefined` (closes the poisoned-`"undefined"` vocabulary key, seam map surprise 6). `materializeBackingTable`'s row-keying and altKey loop keep their own coercion but route the value guard through `coerceLookupKey`.
+- Modify: `port/with/lookup-strategy.ts` — re-export `coerceLookupKey`, `resolveBackingRowKey`, `matchesReferencingValue` (the seam every kernel-spine consumer imports; port/with is the sanctioned door — conflict 5).
+- Modify: `kernel/vault.ts` — REPLACE the `:1134` `getLookupBacking` closure IN PLACE (net-zero) so it gains the descriptor and routes through the descriptor-keyed snapshot with a cold-session `key==='id'` fallback to the live `.get()`:
+  ```ts
+  collOpts.getLookupBacking = (desc: LookupDescriptor) => async (key: string) => {
+    const rows = buildLookupSnapshotRows(desc, (n) => this.reservedLookupCollections.has(dictCollectionName(n)), (n) => this.dictionary(n), (n) => this.collection<Record<string, unknown>>(n))
+    const hit = rows?.get(key)
+    if (hit) return hit
+    // cold-session fallback preserved ONLY for the id-keyed tier (construct+hydrate on demand);
+    // for key !== 'id' the snapshot is the single source of key truth (#651).
+    return desc.key === 'id' ? (await this.collection<Record<string, unknown>>(desc.dimension).get(key)) ?? undefined : undefined
+  }
+  ```
+- Modify: `shape/via-lookup/binding.ts` — `fetchLookupLabel`'s matrix branch (`:91-101`) calls `cfg.getLookupBacking?.(desc)` (passing the whole descriptor, not `desc.dimension`); update the `LookupViaConfig.getLookupBacking` type to `(descriptor: LookupDescriptor) => (key: string) => Promise<Record<string, unknown> | undefined>`.
+- Modify: `with-shape/links/vault-facade.ts` — `resolveLookupCompareKey` (`:296`) and `findLookupReferencingRecords` (`:273`) use `coerceLookupKey` / `matchesReferencingValue` via the port re-export.
+- Modify: `kernel/via-dispatch.ts` — `applyLookupRefsFanout`'s inline twin match (`:290` `String(rec[referencing.field])`) uses `matchesReferencingValue` via the port re-export (NOT a with-* import — port/with only).
+- Modify: `docs/subsystems/via-lookup.md` — RETIRE the #651 direct-read caveat (`:129-135` "currently resolve the backing row by the backing collection's own PUT-id … tracked as #651 … use the join path"); NARROW the cold-session caveat (`:113`) to note the hybrid preserves cold-session construct+hydrate ONLY for `key === 'id'`.
+
+**Interfaces — Produces:**
+
+```ts
+// shape/via-lookup/registry.ts (re-exported via port/with/lookup-strategy.ts)
+export function coerceLookupKey(raw: unknown): string | undefined
+export function resolveBackingRowKey(descriptor: LookupDescriptor, row: Record<string, unknown>): string | undefined
+export function matchesReferencingValue(rec: Record<string, unknown>, field: string, compareKey: string): boolean
+```
+
+**Interfaces — Consumes:** `LookupDescriptor` (`shape/via-lookup/descriptor.ts`), `buildLookupSnapshotRows` (`registry.ts`), `dictCollectionName` (`handle.ts`).
+
+**Design notes:**
+- **The six consumers (seam map §2a):** (1) `buildLookupSnapshotRows`, (2) `buildLookupAltIndex`, (3) `checkLookupMembership` (already delegates to #2), (4) `resolveLookupCompareKey`, (5) the `applyLookupRefsFanout` inline twin + `findLookupReferencingRecords`, (6) `getLookupBacking` — now descriptor-gaining. All route the coercion through `coerceLookupKey`; dm12 dies.
+- **Cold-session caveat narrows, not vanishes** (seam map surprise 5): the snapshot route sees an empty cache until the dimension collection is opened/populated. The hybrid keeps the old construct+hydrate virtue ONLY for `key === 'id'` (where PUT-id == key by construction). For `key !== 'id'` the snapshot is the sole truth — populate the dimension first (already the documented matrix contract).
+- **Zero-knowledge:** the core is pure (descriptor + row → string). No `Collection`/keyring/DEK.
+
+- [ ] Step 1 (RED): `packages/hub/__tests__/via/lookup-direct-read-key.test.ts` (new) — the #651 repro (direct-read, NON-join dressing, `key !== 'id'`), reusing the countries-matrix inline harness:
+  - Declare `orders` with `country: lookup('countries', { key:'iso2', altKeys:['iso3'], present:{label:'name', by:'locale'}, backing:'collection' })`; populate `countries` with a row whose PUT-id (`'row-US'`) DIFFERS from `iso2` (`'US'`) and `name:{en:'United States', th:'สหรัฐอเมริกา'}`; `orders.put('o1',{country:'US'})`.
+  - **Repro flip:** `await orders.get('o1', { locale:'en' })` → `countryLabel === 'United States'` (was silently omitted pre-fix because `.get('US')` missed `row-US`). Assert at `th` too.
+  - **Poisoned-key pin:** a `countries` row MISSING `iso2` does NOT enter the snapshot/altIndex as `"undefined"` — `orders.query().where('country','==','undefined')` matches nothing and membership rejects `'undefined'`.
+  - Unit: `coerceLookupKey(5)==='5'`, `coerceLookupKey(null)===undefined`, `coerceLookupKey(undefined)===undefined`; `resolveBackingRowKey({key:'iso2',…}, {iso2:'US'})==='US'`. RED (closure PUT-id keyed; core absent).
+- [ ] Step 2 (GREEN): implement the core + port re-exports, converge the six consumers, reshape `getLookupBacking` in place, update `fetchLookupLabel` + the `LookupViaConfig.getLookupBacking` type. Run RED → GREEN. Run the FULL lookup suites UNCHANGED — `pnpm vitest run packages/hub/__tests__/via/lookup-binding.test.ts packages/hub/__tests__/via/lookup-join-snapshot.test.ts packages/hub/__tests__/via/lookup-altkeys.test.ts packages/hub/__tests__/via/lookup-vocabulary.test.ts packages/hub/__tests__/via/lookup-alias-parity.test.ts packages/hub/__tests__/via/countries-matrix.test.ts packages/hub/__tests__/via/lookup-forget-ref.test.ts` → GREEN (the join path already used the descriptor-keyed snapshot, so alias/join parity is untouched; only the direct-read path newly works).
+- [ ] Step 3: **ceilings** — `wc -l packages/hub/src/kernel/vault.ts` == **3939** (the `:1134` replacement is in-place; if it grew, collapse to a one-liner or shrink-first). `node scripts/check-architecture.mjs` (via-dispatch.ts gained NO with-* import — only the port re-export; VIA_SHAPE_ALLOWLIST stays EMPTY + fires). `pnpm --filter @noy-db/hub typecheck && lint`. `git diff | grep -n accounting-firm` (empty). Commit — `fix(hub): one descriptor-keyed lookup resolution core + guarded coercion; matrix direct-read dressing for key!=='id' (fixes #651)`.
+
+---
+
+### Task 4: #654 policy — restrict REFUSE (fail-closed) + propagation residue, both remaining vault-facade sites
+
+**Rationale:** A `restrict` edge whose live compare-key resolve fails (matrix custom-key row unreadable — corruption class) is SILENTLY skipped today (`checkLookupRefsRestrict:323`), inverting restrict's promise; the ordinary-delete propagation path (`applyLookupRefsPropagation:349`) bare-`continue`s with no residue channel (seam map surprise 3). Controller-ruled, T5-consistent policy: restrict fails CLOSED (refuse); propagation residue-reports. The forget-path twin (`applyLookupRefsFanout`) already residue-reports — do NOT touch it. All UNGUARDED files.
+
+**Files:**
+- Modify: `kernel/errors.ts` — add `RestrictRefUnresolvableError extends NoydbError` (`code: 'RESTRICT_REF_UNRESOLVABLE'`, carries `{dimension, key, referencing: string /* "collection.field" */}`) — a `DictKeyInUseError`-adjacent refusal that names the unresolvable edge; "cannot prove no references ⇒ do not delete".
+- Modify: `with-shape/links/vault-facade.ts` —
+  - `checkLookupRefsRestrict` (`:319-331`): split the combined `onDelete !== 'restrict' || compareKey === undefined → continue`. For a `restrict` edge whose `compareKey === undefined`, THROW `RestrictRefUnresolvableError(dimension, key, `${referencing.collection}.${referencing.field}`)` (fail-closed) instead of skipping. Non-restrict edges still `continue` (their propagation is Task-2's/the fanout's concern). A resolvable restrict edge behaves exactly as today.
+  - `applyLookupRefsPropagation` (`:342-365`): return shape gains `residue: string[]`; the bare `if (compareKey === undefined) continue` (`:349`) instead pushes `${backingCollection}:${key}:${referencing.collection}.${referencing.field}` to `residue` (mirrors the fanout channel's `backing:key:collection.field` format). Update `enforceLookupRefsOnDelete` (`:373-376`) to thread the residue out.
+  - Surface the ordinary-delete propagation residue: `enforceLookupRefsOnDelete`'s residue is emitted as a structured `lookup:propagation-residue` event (`{vault, dimension, key, residue}`) at the ordinary-delete caller (`enforceRefsOnDelete`/`enforceLookupRefsOnDelete` region) so it is never silent (the delete return is `void` today — an event is the additive channel, matching the seam-map "additive on the delete result path mirroring the forget residue channel").
+- Modify: `docs/subsystems/via-lookup.md` — document the fail-closed restrict policy on an unresolvable compare-key + the propagation residue event.
+
+**Interfaces — Produces:**
+
+```ts
+// kernel/errors.ts
+export class RestrictRefUnresolvableError extends NoydbError {
+  constructor(readonly dimension: string, readonly key: string, readonly referencing: string)
+  // code 'RESTRICT_REF_UNRESOLVABLE'
+}
+// with-shape/links/vault-facade.ts
+applyLookupRefsPropagation(graph, backingCollection, key): Promise<{ cascaded: number; nullified: number; residue: string[] }>
+enforceLookupRefsOnDelete(graph, dimension, backingCollection, key): Promise<{ cascaded: number; nullified: number; residue: string[] }>
+```
+
+**Interfaces — Consumes:** `graph.referencingEdgesOf` (`via-graph.ts`), `resolveLookupCompareKey`/`findLookupReferencingRecords` (Task 3-converged), `NoydbError` (`errors.ts`), the vault event emitter.
+
+**Design notes:**
+- The restrict REFUSE is safe precisely because the unresolvable-key case is corruption-class rarity (a matrix row missing/holding a non-string `descriptor.key`); the T5 precedent already says "restrict refuses before any shred". The forget path's restrict check runs BEFORE any shred (`checkLookupRefsRestrict` is `Vault.forget()`'s pre-shred pass) — a throw there aborts the forget cleanly, no partial shred.
+- Do NOT add a fourth site: `applyLookupRefsFanout` (`via-dispatch.ts:284-286`) already residue-reports; leave it byte-identical.
+
+- [ ] Step 1 (RED): `packages/hub/__tests__/via/lookup-restrict-unresolvable.test.ts` (new) — matrix `lookup('countries',{ key:'iso2', onDelete:'restrict' })` referenced by `orders`; corrupt the backing row so `iso2` is absent/non-string (unresolvable compare-key). Assert:
+  - **restrict direction:** deleting/forgetting the corrupt backing row REFUSES with `RestrictRefUnresolvableError` naming `orders.country` (fail-closed — the referencer survives). A RESOLVABLE restrict edge still throws the existing `DictKeyInUseError` when a referencer exists, and still SUCCEEDS when none does (no regression).
+  - **propagation direction:** the SAME dimension declared `onDelete:'cascade'` (or `'nullify'`) with an unresolvable compare-key — the ordinary `collection.delete()` proceeds but emits `lookup:propagation-residue` with the un-propagated edge (never silent); a resolvable cascade/nullify still propagates + counts. RED.
+- [ ] Step 2 (GREEN): implement the error, the two vault-facade site changes, the residue event. Run RED → GREEN. Run the FULL ref/forget suites — `pnpm vitest run packages/hub/__tests__/via/lookup-ref-semantics.test.ts packages/hub/__tests__/via/lookup-forget-ref.test.ts packages/hub/__tests__/via/forget-fanout.test.ts` → GREEN UNCHANGED (resolvable edges are byte-identical; the fanout twin is untouched; `ForgetResult` byte-shape locked).
+- [ ] Step 3: `node scripts/check-architecture.mjs`. `pnpm --filter @noy-db/hub typecheck && lint`. `git diff | grep -n accounting-firm` (empty). Commit — `fix(hub): restrict-edge unresolvable compare-key fails closed; ordinary-delete propagation residue-reports (fixes #654)`.
+
+---
+
+### Task 5: #640 — sync-applied deletes reach the rollup wave (three coherent layers) + #644/#646 riders
+
+**Rationale:** A pulled tombstone/delete-marker never recomputes its rollup parent — three layers are double-guarded against the naive fix (seam map surprise 1): the `cacheInvalidator` seam drops the action kind (`sync.ts:65-70` is `(collection, id)`), `GraphBatch` carries no kind (`via-dispatch.ts:20`), and the wave independently drops tombstones/markers (`_getStoredRecordForDispatch → null → continue`). All three change coherently, mirroring the LOCAL delete path's `dispatchRollupsOnDelete` trio (NOT `dispatchDerivations` — the `mutation-choke-point.test.ts:85-99` pin). This is the pass's PRIMARY ceiling pressure on `collection.ts` (+1 slack) — see the ceiling note.
+
+**Files:**
+- Modify: `with-party/team/sync.ts` (UNGUARDED) —
+  - `cacheInvalidator` signature widens to `(collection, id, action: 'put' | 'delete')` (`setCacheInvalidator` too). `applyRemote` classifies at the ONE choke point (it holds the envelope): `const action = isTombstoneShape(envelope) || isDeleteMarker(envelope) ? 'delete' : 'put'`; `await this.cacheInvalidator?.(collection, id, action)`. (`isTombstoneShape`/`isDeleteMarker` already imported at `:22`.)
+  - **#644 item 1 rider:** ensure the open `_graphBatch` is cleared on a `pull()`/`push()` throw — wrap the batch-spanning region so `await this.graphBatchController?.flush()` runs in a `finally` (flush clears the batch unconditionally, `vault.ts:1316-1320`). Today `flush()` sits AFTER the try/catch (`:334`/`:534`), so a throw from `ensureLoaded()`/`persistMeta()` leaves a stale batch open for the next call. A `finally`-guarded flush closes it.
+- Modify: `kernel/collection.ts` (**GUARDED — 4472/4473**) — keep touches thin; net-neutral via extract-to-reuse:
+  - Extract `_rollupDeleteIntents(deleted: T): RollupDeleteIntent[]` FROM `dispatchRollupsOnDelete`'s resolution loop (`:2260-2265`) — sync, no I/O; reads the rollup registry, extracts `parentId = String(rec[spec.rollup.key])`, yields `{into: spec.source, parentId, field: spec.rollup.field}`. `dispatchRollupsOnDelete` now = `_rollupDeleteIntents` + a recompute per intent (REUSES the loop, no duplication → near line-neutral).
+  - `dispatchRollupsOnDelete(id, deleted, wave?)` gains the optional `wave` param, threaded to `recomputeRollup` (per-target dedup for the wave path).
+  - `_onRecordMutated` sync-apply case (`:3833-3837`): accept the `action`; for `action==='delete'`, `const prior = this._peekCached(id)` BEFORE `_invalidateCacheEntry(id)` runs; if `prior`, `this.graphDispatch?.collectDelete(this.name, id, this._rollupDeleteIntents(prior))`; then invalidate. For `action==='put'`, the existing `collect` path.
+  - Widen the `graphDispatch` interface (`:571-572`) to add `collectDelete(collection, id, intents)`.
+  - Add `_recomputeDeletedRollups(intents: readonly RollupDeleteIntent[], wave: WaveContext): Promise<void>` — the wave-facing driver: for each intent, dedup via `wave.seen('rollup\0${into}\0${parentId}\0${field}')`, find the matching spec in `derivationSource.registry().strategiesForSource(this.name)` (by `source===into && rollup.field===field && rollup.from===this.name`), and `recomputeRollup(spec, parentId, {collection:this.name, id:'<sync-delete>'}, wave)`.
+- Modify: `kernel/via-dispatch.ts` (UNGUARDED — bulk of new logic) —
+  - `GraphBatch` becomes `Map<string, GraphTouch>` where `GraphTouch = { puts: Set<string>; deletes: Map<string, RollupDeleteIntent[]> }`; `RollupDeleteIntent = { into: string; parentId: string; field: string }`. **Update the `:19` metadata-only pin comment HONESTLY:** "Metadata only — ids (collection names, record ids INCLUDING resolved rollup parent ids) and field names; NEVER record payload or key material. A resolved parentId is an id, same class as the touched ids — not a stored value."
+  - `runGraphDispatchWave`: for each collection's `touch.puts` run the existing `dispatchDerivations` + `dispatchMaterializedViews` (per-id, id-threaded decrypt, unchanged); THEN for `touch.deletes` call `coll._recomputeDeletedRollups(intents, wave)` per deleted id — INSIDE the same per-id try/catch isolation.
+  - **#644 item 3 rider:** `VaultLike` gains `emit(event: string, payload: unknown): void`; the wave's catch block emits a structured `derivation:wave-error` (`{collection, id, error}`) ADDITIVELY alongside the existing `console.warn` (upgrade, not replace — no listener-dependent silence).
+- Modify: `kernel/vault.ts` (**GUARDED — 3939/3940**, net-zero target) —
+  - `_invalidateSyncApplied(collection, id, action: 'put'|'delete')` — pass `action` to `coll._onRecordMutated(id, action, 'sync-apply')` (the `:1289` line changes `'put'` → `action`; signature gains a param — net-zero). Reserved-lookup branch (`:1292-1295`) ignores `action` (wave-inert, unchanged).
+  - `_collectGraphTouch`/`_beginGraphBatch`/`_flushGraphBatch` adapt to the `GraphTouch` shape: `_collectGraphTouch(collection, id)` seeds/updates `touch.puts`; add `_collectGraphDelete(collection, id, intents)` for the delete socket (`collectDelete`). Keep these thin.
+  - `VaultLike.emit` — Vault already owns an emitter; expose it to the wave (a one-line `emit` delegator or pass `this.emitter.emit`). Net-zero target.
+- Modify: `kernel/noydb.ts` (**GUARDED — 2384/2385**, net-zero) — `:686` `engine.setCacheInvalidator((collection, id, action) => comp._invalidateSyncApplied(collection, id, action))` (in-place widening — net-zero).
+
+**Interfaces — Produces:**
+
+```ts
+// kernel/via-dispatch.ts
+export interface RollupDeleteIntent { readonly into: string; readonly parentId: string; readonly field: string }
+export interface GraphTouch { readonly puts: Set<string>; readonly deletes: Map<string, RollupDeleteIntent[]> }
+export type GraphBatch = Map<string, GraphTouch>
+export interface VaultLike {
+  readonly graph: ViaGraph
+  _getCollection(name: string): Collection<Record<string, unknown>> | undefined
+  emit(event: string, payload: unknown): void   // #644 item 3 — structured wave-error surfacing
+}
+// kernel/collection.ts
+_rollupDeleteIntents(deleted: T): RollupDeleteIntent[]                                        // sync resolution
+dispatchRollupsOnDelete(id: string, deleted: T, wave?: WaveContext): Promise<ReadonlyArray<…>>  // + wave param
+_recomputeDeletedRollups(intents: readonly RollupDeleteIntent[], wave: WaveContext): Promise<void>
+// with-party/team/sync.ts
+setCacheInvalidator(fn: (collection: string, id: string, action: 'put' | 'delete') => Promise<void>): void
+```
+
+**Interfaces — Consumes:** `isTombstoneShape`/`isDeleteMarker` (`kernel/enclave`, already imported in sync.ts), `_peekCached`/`recomputeRollup`/`dispatchRollupsOnDelete` (`collection.ts`), `WaveContext` (`via-dispatch.ts`).
+
+**Design notes:**
+- **FK recovery — the pinned mechanism (seam map surprise 2):** the deleted child's FK is recoverable ONLY at apply time — `applyRemote` overwrites the store before invalidating, so at wave time the child is gone. The FK survives in the not-yet-invalidated collection cache: `_peekCached(id)` at the START of the sync-apply delete case (BEFORE `_invalidateCacheEntry`) returns the PRIOR record. We resolve the rollup parent INTENTS there (sync, `_rollupDeleteIntents`) and batch `{into, parentId, field}` — ids + names only (metadata; the parentId is a resolved id, NOT the raw stored record). The residual hole (a lazy-mode child evicted from the LRU pre-apply) is out of scope — `_peekCached` returns null and the recompute is skipped (freshness-only, no correctness break in the eager path the tests cover). Note this residual in the doc.
+- **apply-before-wave ordering (the D-4 rule generalizes):** deletes are applied (via `local.put` in `applyRemote`) BEFORE `_flushGraphBatch`, so at wave time the store already EXCLUDES the deleted child — `recomputeRollup`'s "gather the REMAINING children" is correct by construction. The wave must NOT recompute at collect time (that would see an intermediate store state mid-pull). The intent-resolution at collect time is SYNC + I/O-free precisely so it doesn't observe the store.
+- **The metadata-only GraphBatch pin (kind IS metadata):** update the `:19` comment honestly (above). A `kind`/`GraphTouch.deletes` partition and a resolved parentId are ids/names — not payload or keys.
+- **Scope guards:** sync delete ≠ forget — NO shred, NO residue channel (freshness only; the origin device already ran `forgetDerivedFanout`). Reserved-tier `_dict_*` markers (D-4) already flow via their own registry loop + `_refreshSyncCache` and are wave-inert (`'ref'` edges excluded from `dependentsOf`; `_getCollection('_dict_x')` is undefined) — **#640 needs NO reserved-branch work** (seam map 3f). The `mutation-choke-point.test.ts:85-99` pin (local-delete does NOT dispatch derivations) is preserved: sync-applied deletes route to `_recomputeDeletedRollups` (rollup-on-delete), NEVER `dispatchDerivations`.
+
+**Ceiling note (BLOCKING discipline):** `collection.ts` is at 4472/4473 (+1) — the tightest. The `_rollupDeleteIntents` extraction is near line-neutral (the loop MOVES from `dispatchRollupsOnDelete`, no duplication); `_recomputeDeletedRollups`, the `graphDispatch` interface widening, and the `_onRecordMutated` delete branch ADD lines. `vault.ts` (3939/3940) also grows: `_invalidateSyncApplied` + the `:1289` line are net-zero in-place, but the `GraphTouch` adaptation of `_collectGraphTouch`/`_flushGraphBatch` + the new `_collectGraphDelete` + the `emit` delegator ADD lines. `noydb.ts` (2384/2385) is net-zero in-place (the `:686` widening). Run `wc -l` on all three after each edit. If any exceeds its budget: SHRINK-FIRST (collapse a dense adjacent declaration — an over-long multi-line signature, a foldable guard) to reclaim room; if it still cannot fit, STOP and flag **BLOCKED — a ceiling bump requires explicit user sign-off**, never a silent bump. Prefer pushing logic into UNGUARDED `via-dispatch.ts` over the guarded spine wherever the seam allows.
+
+- [ ] Step 1 (RED): `packages/hub/__tests__/via/sync-delete-rollup.test.ts` (new) — the #640 repro, two-instance, count-asserted, with **#646's db2-only registration**:
+  - Two `createNoydb` instances (db1 writer, db2 puller) over a shared remote memory store. On db1: `orders` (children) with a rollup into `customers.orderCount` (parent); seed 3 orders for customer `c1`; `db1.sync()` (push).
+  - **db2 registers the rollup ONLY on db2** (the #646 mandate — the derivation/rollup strategy is declared on the PULLING side, proving the wave fires on the receiver regardless of origin registration). `db2.pull()` → `customers.orderCount === 3`.
+  - **The repro:** on db1 delete one order (a delete-marker) + push; `db2.pull()` → assert `customers.get('c1').orderCount === 2` (the pulled delete recomputed the parent). Assert a COUNT: exactly one parent recompute write for the pull (via the value-equality guard / a write spy), proving wave dedup when 2 children are deleted in one pull (`orderCount` goes 3→1, ONE recompute).
+  - **Ordering pin:** a delete of one child + a `put` of a sibling order in the SAME pull → the parent count reflects the FINAL store state (both applied before the wave).
+  - **Freshness-not-forget pin:** the pulled delete does NOT write a tombstone/residue on db2's side beyond the marker itself (no shred).
+  - **#644 item 3 pin:** register a `derivation:wave-error` listener; force a recompute error (e.g. a frozen-period output is NOT this — use a genuine throw) and assert the structured event fires (additive to console.warn). RED (action dropped; batch has no kind; wave skips deletes).
+- [ ] Step 2 (GREEN): implement the three layers + riders. Run RED → GREEN. Run the FULL sync/wave/derivation locks — `pnpm vitest run packages/hub/__tests__/via/sync-dispatch.test.ts packages/hub/__tests__/via/mutation-choke-point.test.ts packages/hub/__tests__/derivations/rollup.test.ts packages/hub/__tests__/via/lookup-reserved-sync.test.ts packages/hub/__tests__/via/forget-fanout.test.ts` → GREEN UNCHANGED (local-delete-not-dispatch pin preserved; reserved markers stay wave-inert; forget accounting not duplicated on the receiver). Strengthen the #646 fixtures in `sync-dispatch.test.ts` if the two vacuous socket-reachability pins are touched (db2-only registration).
+- [ ] Step 3: **ceilings** — report `wc -l` for `collection.ts` (≤4473), `vault.ts` (≤3940), `noydb.ts` (≤2385); shrink-first or BLOCK per the ceiling note. `node scripts/check-architecture.mjs` (via-dispatch.ts gained NO with-* import; GraphBatch still metadata-only — grep for value/key storage → none; guards EMPTY + fire). `pnpm --filter @noy-db/hub typecheck && lint`. `pnpm --filter @noy-db/hub build && pnpm --filter @noy-db/hub bundle-check`. `git diff | grep -n accounting-firm` (empty). Commit — `fix(hub): sync-applied deletes recompute rollup parents via the dispatch wave; stale-batch clear + structured wave-error (fixes #640, #644 items 1+3, #646)`.
+
+---
+
+### Task 6: Docs + changeset + final gauntlet + milestone ledger
+
+**Files:**
+- Modify: `docs/subsystems/via-lookup.md` — the #651 caveat retirement + cold-session narrowing (Task 3) and the #654 fail-closed restrict + propagation-residue policy (Task 4), from SHIPPED TESTS ONLY.
+- Create/modify: a `docs/subsystems/` note (or the derivations/taint subsystem page) — the #642 formula-output posture behavior: ALL formula outputs derived from classified-bearing collections are sealed/non-exportable/query-refused by default (rollup real-field targets + derivation/MV/overlay collection-level default posture); axis-scoped (a blob/money/i18n source does NOT clamp queryability, only ORs `forgettable`); explicit per-declaration declassification is phase-E, NOT built here. SHIPPED-TESTS-ONLY.
+- Create: `.changeset/via-consolidation.md` — `@noy-db/hub: minor`.
+- Modify: `scripts/check-architecture.mjs` — ONLY if a guarded file NET-SHRANK: re-ratchet its ceiling DOWN to the new actual (comment `#642/#651/#640/#654 consolidation`). NO bumps. If nothing shrank, leave the three ceilings untouched.
+
+**Interfaces:** none (docs/changeset).
+
+**Design notes:**
+- **Changeset — minor** (additive API: collection-level output postures, batch delete-kind, the descriptor-keyed resolution core; per the #636-principle completion framing #642 is behavior-affecting → minor, matching prior via changesets). Body enumerates, per issue: #642 (formula-output taint — the security-correct default, no migration story since no consumers use formula outputs pre-1.0; axis-scoped so no unintended blob/money over-restriction; declassification deferred to phase E); #651 (one descriptor-keyed resolution core, matrix direct-read dressing for `key!=='id'`, cold-session caveat narrowed); #654 (restrict fails closed on an unresolvable compare-key; ordinary-delete propagation residue-reports); #640 (sync-applied deletes recompute rollup parents; #644 items 1+3 riders). DO NOT publish.
+
+- [ ] Step 1: Docs from SHIPPED (green) TESTS ONLY — no speculative API. Cross-link the retired #651 caveat and the new #642/#654 behaviors to their pinning tests.
+- [ ] Step 2: Full gauntlet — `pnpm --filter @noy-db/hub test` (whole hub suite green), `pnpm --filter @noy-db/hub typecheck` (all tsconfigs), `pnpm --filter @noy-db/hub lint`, `node scripts/check-architecture.mjs` (VIA_SHAPE_ALLOWLIST + VIA_ENCLAVE_ALLOWLIST both EMPTY and both FIRE on a synthetic import; ceilings at or below budget — none bumped; a bump anywhere ⇒ BLOCKED), `pnpm --filter @noy-db/hub build && pnpm --filter @noy-db/hub bundle-check`, `pnpm knip`, `pnpm validate:features` (if `features.yaml` gained a capability).
+- [ ] Step 3: `.changeset/via-consolidation.md` (`@noy-db/hub: minor`) with the enumerated body. `git diff` the WHOLE branch and `grep -n accounting-firm` (empty). **Milestone-#30 ledger — which issues this pass CLOSES:** #642, #651, #640, #654 (the four); #644 items 1+3 (item 2 reentrancy stays open — partial); #646 fixture mandate (partial — the two-instance delete test lands the db2-only registration). Note in the PR body that #644/#646 are partially addressed (not fully closed). Commit — `docs(hub): via consolidation — formula-output taint, key-resolution core, sync-delete freshness + changeset (#642, #651, #640, #654)`.
+
+---
+
+## Final steps (execution skill handles)
+
+Full hub suite green; whole-branch review on the most capable model (focus: the axis-scoped fold's blast radius — confirm ONLY classified sources seal/non-export outputs and blob/money/i18n never clamp queryability or seal; the ref-identity guarantee keeps the countries recipe byte-identical; `postureFor`'s O(1) `defaultPosture` fallback — no fold-per-call; the whole-record `taintBinding.sealAllFields` mode excludes `_`-prefixed internal keys; the #640 FK-recovery ordering — `_peekCached` BEFORE invalidation, recompute deferred to the wave AFTER all applies; the GraphBatch stays metadata-only — grep for value/key storage; the #654 restrict fail-closed aborts forget cleanly with no partial shred; every new `decryptRecord`/`_decodeEnvelope` threads the record id; both via allowlists EMPTY and fire on synthetics; every guarded file at or below its +1 ceiling — a bump is BLOCKED). PR against `main` (do NOT merge — human gate). Fixes #642/#651/#640/#654; partially addresses #644/#646.

--- a/docs/superpowers/specs/2026-07-12-via-consolidation-design.md
+++ b/docs/superpowers/specs/2026-07-12-via-consolidation-design.md
@@ -1,0 +1,44 @@
+# Via consolidation pass — formula-output taint, the key-resolution class, sync-delete freshness (#642, #651, #640, #654)
+
+**Date:** 2026-07-12
+**Issues:** [#642](https://github.com/vLannaAi/noy-db/issues/642) (security), [#651](https://github.com/vLannaAi/noy-db/issues/651) + [#654](https://github.com/vLannaAi/noy-db/issues/654) (the key-resolution class), [#640](https://github.com/vLannaAi/noy-db/issues/640) (freshness) · **Milestone:** #30 "Via follow-ups [api]" · Base: main `5f290e57` (v0.3.0-pre.9 published).
+**Near-free riders:** #644 items 1+3 (stale-open batch on push-throw; structured wave-error surfacing rides #640's wave changes), #646's fixture mandate (same files).
+**Surface:** `api` — additive (collection-level output postures, batch delete-kind); behavior change on #642 per the user's ratified call (**no consumers on formula outputs → no migration story**); `/adapter` and `/cargo` byte-untouched.
+**Ground truth:** `.superpowers/sdd/seam-map-consolidation.md`. Behavior locks: the FULL derivations/MV/rollup, lookup (all tiers + aliases), sync, forget/erasure, classified suites pass unchanged except pins that pin the fixed defects (enumerated per task in the plan).
+
+## Decision summary (user-ratified 2026-07-12)
+
+1. **#642 goes DEEP: collection-level posture defaults.** Rollup targets (real fields) inherit via the existing taint overlay; derivation/MV **output collections** get a collection-level default posture — every field inherits the folded posture — flowing through the EXISTING phase-B/C consumers. No migration story (user: no consumers use formula outputs yet, pre-1.0).
+2. **#654 policy (controller-ruled, T5-consistent):** an unresolvable key on a *restrict* edge REFUSES the delete/forget (fail closed); unresolvable keys on *propagation* paths (both remaining silent sites: `applyLookupRefsPropagation` ordinary-delete, and any residual) residue-report — never silent.
+3. **#640 mechanics per the #621/D-4 precedents:** batched at pull end, deletes applied before the wave, delete-kind entries in the batch.
+
+## Design
+
+### 1. #642 — the '*'-posture fold, kind- and axis-scoped (the seam map's trap avoided)
+
+`ViaGraph._contribution`'s `?? DEFAULT_POSTURE` for `'*'` nodes becomes a **lazy, kind-scoped fold**: for edges of kind `derivation | rollup | mv | overlay` (formula kinds ONLY — `'ref'` edges KEEP identity: lookup's documented reliance on `'*'` = identity stands, no lookup-referencing field seals because its dimension has a classified column), the `'*'` contribution = fold of the source collection's REGISTERED field postures on the **security axes only**: `encryptedAtRest` (sealed-wins) and `exportable` (AND). `queryable` is NOT folded directly — inheriting `sealed` triggers the phase-C honest clamp (`queryable: 'none'`, no digests exist), otherwise the output keeps its own grade; `forgettable` ORs. Computed lazily in `_contribution` — `_effectiveCache` already invalidates on every `registerField`, so registration ordering is free (seam map finding 3).
+
+**Enforcement, both target shapes:**
+- **Rollup targets** (real fields): the folded posture lands exactly like Task-C3's overlay — assigned at declare/reconcile, enforced by the existing query gate / exportRedact / at-rest sealing. Automatic.
+- **Derivation/MV output collections** ('*' targets, fn-determined fields): a **collection-level default posture** on the output collection — carried in collection config, applied by `postureFor` as the fallback for ANY field of that collection (field-specific postures still win). Sealed-inherited outputs seal at rest via the existing `ctx.sealedSlots` path, redact on export, refuse queries per the clamp. The reconcile/two-phase machinery (D-2 wave-2) re-applies when output-opened-before-source ordering occurs — the cross-collection re-apply gap (seam map finding 4) closes via the same graph-memory pattern.
+- The recompute writes themselves are unaffected mechanically (ordinary puts; the codec seals per the output collection's posture).
+
+Behavior change framed in the changeset as the #636-principle completion: ALL formula outputs derived from classified-bearing collections are now sealed/non-exportable by default. An explicit per-declaration opt-out is NOT built (declassification remains phase-E). New pinned tests: the #642 repro flips (derive-copy of classified plaintext → sealed output, redacted export, refused query — all three surfaces, both target shapes).
+
+### 2. #651 + #654 — ONE key-resolution core, the class ends
+
+A canonical descriptor-keyed resolution core in `port/with/lookup-strategy.ts` (the kernel spine may import `port/with/*` freely — seam map corrected premise 7): `resolveBackingRowKey(descriptor, row)` + the **guarded coercion** (string|number → String, else undefined — the bare-`String()` `"undefined"`-key poisoning dies everywhere, dm12 closed). Consumers converge: `buildLookupSnapshotRows` (already canonical), `buildLookupAltIndex`, `checkLookupMembership`, `resolveLookupCompareKey`, the fanout inline twin, and **`getLookupBacking` — its closure signature gains the descriptor** (the T7 `snapshotFor` dispatch precedent), fixing #651's direct-read dressing for `key !== 'id'` (the cold-session/join-path caveat narrows accordingly; docs updated, #651's doc caveat retired). The with-shape I/O shells stay thin per the layering rule; only the pure core is shared.
+
+**#654 policy wiring:** `checkLookupRefsRestrict`'s `compareKey === undefined → continue` becomes REFUSE (throw `DictKeyInUseError`-adjacent refusal naming the unresolvable edge — fail closed; corruption-class rarity makes this safe); `applyLookupRefsPropagation`'s ordinary-delete skip residue-reports (additive on the delete result path mirroring the forget residue channel). Pins: restrict-unresolvable refuses; propagation-unresolvable reports; direct-read matrix dressing with `key!=='id'` works (the #651 repro flips).
+
+### 3. #640 — sync-applied deletes reach the wave (three coherent layers)
+
+(a) The pull loop classifies tombstone applies (`isTombstoneShape` — the main loop already detects them) and the `cacheInvalidator` seam carries the action kind (signature widened — internal seam, not public); (b) `GraphBatch` entries gain a `kind: 'put' | 'delete'` (metadata-only pin respected — a kind IS metadata); (c) the wave routes delete-kind entries to the rollup-on-delete recompute path (`dispatchRollupsOnDelete` semantics), with the **deleted child's FK recovered pre-invalidation** (`_peekCached` before the cache entry dies, falling back to the classification carry — the plan pins the exact mechanism). Ordering: deletes applied before the wave flush (the D-4 vocabulary rule). Scope guards: sync delete ≠ forget (no shred, no residue channel — freshness only); reserved-tier delete-markers (D-4) already flow — this closes the ORDINARY-collection tier. Riders: #644's stale-open batch on push-throw (clear-on-error) and the structured `derivation:wave-error` event (#644 item 3, upgrading the console.warn) land in the same wave-touching diff; #646's fixture strengthening (db2-only registration) rides the new two-instance delete test.
+
+### 4. Testing
+
+The four repros become the pins (none exist today — seam map finding 10): formula-output posture (both shapes × three surfaces), matrix direct-read `key!=='id'` dressing, restrict-unresolvable refusal + propagation residue, pulled-delete-recomputes-parent (two-instance, count-asserted, db2-only registration per #646). Behavior locks as above. Ceilings: ALL THREE at +1 slack (4472/4473, 3939/3940, 2384/2385) — new logic in unguarded files (via-graph, via-dispatch, registry, lookup-strategy, collection-config); guarded files thin-touch, shrink-first, BLOCKED not bump.
+
+## Out of scope
+
+Declassification/opt-out (phase E); MV/derivation output *field-level* introspected postures (the introspection wall — the collection-level default IS the fix); #653 (partial-sync dictionary expansion — mechanism confirmed available, own cycle); #639 rollup cycles; marker GC (dm9); `@latest` promotion.

--- a/packages/hub/__tests__/kernel-api.golden.json
+++ b/packages/hub/__tests__/kernel-api.golden.json
@@ -99,6 +99,7 @@
     "dump",
     "dumpSchema",
     "elevate",
+    "emit",
     "emitCrossTier",
     "enforceI18nOnPut",
     "enforceRefsOnDelete",

--- a/packages/hub/__tests__/kernel-api.golden.json
+++ b/packages/hub/__tests__/kernel-api.golden.json
@@ -99,7 +99,6 @@
     "dump",
     "dumpSchema",
     "elevate",
-    "emit",
     "emitCrossTier",
     "enforceI18nOnPut",
     "enforceRefsOnDelete",

--- a/packages/hub/__tests__/root-barrel-surface.golden.json
+++ b/packages/hub/__tests__/root-barrel-surface.golden.json
@@ -164,6 +164,7 @@
     "RefScopeError",
     "ReservedCollectionNameError",
     "ReservedVaultNameError",
+    "RestrictRefUnresolvableError",
     "SCHEMAS_COLLECTION",
     "SEALED_PASSPHRASE_RECORD_ID",
     "STATE_VAULT_NAME",

--- a/packages/hub/__tests__/via/formula-output-posture.test.ts
+++ b/packages/hub/__tests__/via/formula-output-posture.test.ts
@@ -1,0 +1,184 @@
+/**
+ * #642 Task 2 — enforcement: formula outputs derived from classified-bearing
+ * collections become sealed/non-exportable, for BOTH target shapes:
+ *
+ *  - Shape A: a derivation/MV/overlay OUTPUT collection ('*' target) — the
+ *    collection-level `defaultPosture` fallback (`ViaTaintOverlay.defaultPosture`,
+ *    `postureFor`'s O(1) fallback, `taintBinding`'s `sealAllFields` mode).
+ *  - Shape B: a rollup TARGET (a REAL field on the parent) — inherits the
+ *    folded posture automatically through the EXISTING field-specific taint
+ *    overlay (Task 1's graph fold + the unmodified per-field path).
+ *
+ * Three surfaces per shape: at-rest sealing (`_sealed` + SealedHandle), query
+ * refusal (FieldNotQueryableError), export redaction ('[sealed]'). Plus the
+ * cross-collection re-apply ordering gap (seam map finding 4/10): the folded
+ * posture must still apply even when the dependent (output/parent) collection
+ * was opened BEFORE the classified source ever registered its field.
+ *
+ * Ground truth: docs/superpowers/specs/2026-07-12-via-consolidation-design.md
+ * §1; .superpowers/sdd/seam-map-consolidation.md PART 1 (esp. 1b/1c/1f) + PART 5.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withDerivation, withRollup, FieldNotQueryableError, SealedHandle } from '../../src/index.js'
+import { withClassified } from '../../src/shape/via-classified/index.js'
+import type { ClassifiedFieldSpec } from '../../src/shape/via-classified/index.js'
+import { inlineMemory } from '../classified/harness.js'
+
+const ssnSpec = (): ClassifiedFieldSpec => ({
+  _noydbClassified: true, preset: 'test-ssn', storage: 'recoverable',
+  list: { kind: 'omit' }, sensitivity: 'secret',
+})
+
+interface Person extends Record<string, unknown> { id: string; name: string; ssn: string }
+interface Leak extends Record<string, unknown> { ssnCopy?: string }
+
+function leakDerivation() {
+  return withDerivation<Person, { leak: { ssnCopy: string } }>({
+    source: 'people',
+    deterministic: true,
+    outputs: { leak: { shape: 'record', collection: 'leaks' } },
+    derive: (s) => ({ leak: { ssnCopy: s.ssn } }),
+    lifecycle: 'eager',
+  })
+}
+
+interface Sale extends Record<string, unknown> { id: string; buyerId: string; amount: number; ssn: string }
+interface Buyer extends Record<string, unknown> { id: string; companyName: string; total?: number }
+
+function totalRollup() {
+  return withRollup<Sale, Buyer>({
+    from: 'sales', key: 'buyerId', into: 'buyers', field: 'total',
+    compute: (sales) => sales.reduce((t, s) => t + (typeof s.amount === 'number' ? s.amount : 0), 0),
+  })
+}
+
+describe('#642 Task 2 — Shape A: derivation OUTPUT collection ("*" target) inherits the source fold', () => {
+  async function setup(secret: string) {
+    const store = inlineMemory()
+    const db = await createNoydb({
+      store, user: 'a', secret,
+      classifiedStrategy: withClassified(),
+      derivationStrategies: [leakDerivation()],
+    })
+    const v = await db.openVault('v1')
+    // Natural ordering: source opened (and its classified field registered)
+    // BEFORE the output collection — no ordering-gap hook needed here.
+    const people = v.collection<Person>('people', { classifiedFields: { ssn: ssnSpec() } })
+    const leaks = v.collection<Leak>('leaks')
+    await people.put('p1', { id: 'p1', name: 'Alice', ssn: '123-45-6789' })
+    return { db, v, people, leaks, store }
+  }
+
+  it('at-rest: the copied field seals into `_sealed`; get() returns a SealedHandle', async () => {
+    const { leaks, store } = await setup('formula-posture-a-1')
+    const rec = await leaks.get('p1')
+    expect(rec?.ssnCopy).toBeInstanceOf(SealedHandle)
+    const envelope = store._dump('v1', 'leaks', 'p1')
+    expect(envelope).toBeDefined()
+    expect(envelope!._sealed?.ssnCopy).toMatch(/^.+:.+$/)
+    // `_derivedFrom` (reserved/internal metadata) is never swept into sealAllFields.
+    expect(envelope!._sealed?._derivedFrom).toBeUndefined()
+  })
+
+  it('query: .where() on the copied field refuses (FieldNotQueryableError) per the honest clamp', async () => {
+    const { leaks } = await setup('formula-posture-a-2')
+    expect(() => leaks.query().where('ssnCopy', '==', '123-45-6789')).toThrow(FieldNotQueryableError)
+  })
+
+  it('export: exportJSON()/exportStream() redact the copied field to [sealed]', async () => {
+    const { v } = await setup('formula-posture-a-3')
+    const json = await v.exportJSON()
+    const parsed = JSON.parse(json) as { collections: Record<string, { records: Array<Record<string, unknown>> }> }
+    expect(parsed.collections.leaks!.records[0]!.ssnCopy).toBe('[sealed]')
+
+    const chunks: { collection: string; records: unknown[] }[] = []
+    for await (const chunk of v.exportStream()) chunks.push(chunk)
+    const leaksChunk = chunks.find((ch) => ch.collection === 'leaks')!
+    const serialized = JSON.parse(JSON.stringify(leaksChunk.records)) as Array<Record<string, unknown>>
+    expect(serialized[0]!.ssnCopy).toBe('[sealed]')
+  })
+})
+
+describe('#642 Task 2 — Shape B: rollup TARGET (real field) inherits the source fold (verifying "automatic")', () => {
+  async function setup(secret: string) {
+    const store = inlineMemory()
+    const db = await createNoydb({
+      store, user: 'a', secret,
+      classifiedStrategy: withClassified(),
+      derivationStrategies: [totalRollup()],
+    })
+    const v = await db.openVault('v1')
+    // Natural ordering: child (source, classified) opened BEFORE the parent
+    // (rollup target) — the automatic path Task 1's fold is supposed to feed
+    // straight into the EXISTING field-specific taint overlay, unmodified.
+    const sales = v.collection<Sale>('sales', { classifiedFields: { ssn: ssnSpec() } })
+    const buyers = v.collection<Buyer>('buyers')
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', amount: 100, ssn: '123-45-6789' })
+    return { db, v, buyers, sales, store }
+  }
+
+  it('at-rest: the rollup field seals into `_sealed`; get() returns a SealedHandle', async () => {
+    const { buyers, store } = await setup('formula-posture-b-1')
+    const rec = await buyers.get('b1')
+    expect(rec?.total).toBeInstanceOf(SealedHandle)
+    const envelope = store._dump('v1', 'buyers', 'b1')
+    expect(envelope).toBeDefined()
+    expect(envelope!._sealed?.total).toMatch(/^.+:.+$/)
+  })
+
+  it('query: .where() on the rollup field refuses (FieldNotQueryableError)', async () => {
+    const { buyers } = await setup('formula-posture-b-2')
+    expect(() => buyers.query().where('total', '==', 100)).toThrow(FieldNotQueryableError)
+  })
+
+  it('export: exportJSON() redacts the rollup field to [sealed]', async () => {
+    const { v } = await setup('formula-posture-b-3')
+    const json = await v.exportJSON()
+    const parsed = JSON.parse(json) as { collections: Record<string, { records: Array<Record<string, unknown>> }> }
+    expect(parsed.collections.buyers!.records[0]!.total).toBe('[sealed]')
+  })
+})
+
+describe('#642 Task 2 — cross-collection re-apply ordering gap (seam map finding 4/10)', () => {
+  it('Shape A: OUTPUT opened BEFORE the classified SOURCE still seals once the source registers + writes', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({
+      store, user: 'a', secret: 'formula-posture-order-a',
+      classifiedStrategy: withClassified(),
+      derivationStrategies: [leakDerivation()],
+    })
+    const v = await db.openVault('v1')
+    const leaks = v.collection<Leak>('leaks') // opened FIRST — no classified field registered yet anywhere
+    const people = v.collection<Person>('people', { classifiedFields: { ssn: ssnSpec() } }) // opened SECOND
+    await people.put('p1', { id: 'p1', name: 'Alice', ssn: '123-45-6789' })
+
+    const rec = await leaks.get('p1')
+    expect(rec?.ssnCopy).toBeInstanceOf(SealedHandle)
+    const envelope = store._dump('v1', 'leaks', 'p1')
+    expect(envelope).toBeDefined()
+    expect(envelope!._sealed?.ssnCopy).toMatch(/^.+:.+$/)
+    expect(() => leaks.query().where('ssnCopy', '==', '123-45-6789')).toThrow(FieldNotQueryableError)
+  })
+
+  it('Shape B: rollup PARENT opened BEFORE the classified child still seals once the child registers + writes', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({
+      store, user: 'a', secret: 'formula-posture-order-b',
+      classifiedStrategy: withClassified(),
+      derivationStrategies: [totalRollup()],
+    })
+    const v = await db.openVault('v1')
+    const buyers = v.collection<Buyer>('buyers') // opened FIRST — 'sales' not registered yet
+    const sales = v.collection<Sale>('sales', { classifiedFields: { ssn: ssnSpec() } }) // opened SECOND
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', amount: 100, ssn: '123-45-6789' })
+
+    const rec = await buyers.get('b1')
+    expect(rec?.total).toBeInstanceOf(SealedHandle)
+    const envelope = store._dump('v1', 'buyers', 'b1')
+    expect(envelope).toBeDefined()
+    expect(envelope!._sealed?.total).toMatch(/^.+:.+$/)
+    expect(() => buyers.query().where('total', '==', 100)).toThrow(FieldNotQueryableError)
+  })
+})

--- a/packages/hub/__tests__/via/formula-output-posture.test.ts
+++ b/packages/hub/__tests__/via/formula-output-posture.test.ts
@@ -22,7 +22,8 @@ import { describe, it, expect } from 'vitest'
 import { createNoydb, withDerivation, withRollup, FieldNotQueryableError, SealedHandle } from '../../src/index.js'
 import { withClassified } from '../../src/shape/via-classified/index.js'
 import type { ClassifiedFieldSpec } from '../../src/shape/via-classified/index.js'
-import { inlineMemory } from '../classified/harness.js'
+import { inlineMemory, spyStore } from '../classified/harness.js'
+import { reapplyDependentOverlays } from '../../src/kernel/via-graph-wiring.js'
 
 const ssnSpec = (): ClassifiedFieldSpec => ({
   _noydbClassified: true, preset: 'test-ssn', storage: 'recoverable',
@@ -180,5 +181,165 @@ describe('#642 Task 2 — cross-collection re-apply ordering gap (seam map findi
     expect(envelope).toBeDefined()
     expect(envelope!._sealed?.total).toMatch(/^.+:.+$/)
     expect(() => buyers.query().where('total', '==', 100)).toThrow(FieldNotQueryableError)
+  })
+})
+
+/**
+ * Fix wave 1 (reviewer in-wave findings on Task 2's own diff) — three
+ * reviewer-prescribed corners, additive to this file only:
+ *
+ * 1. `_getStoredRecord`'s LAZY branch (collection.ts:2123) has the exact same
+ *    latent gate-parity class `resolvePriorValues` had (see the report's "Bugs
+ *    found" #2): it gates on local `sensitiveFields`, missing a taint-only-
+ *    sealed collection (zero local `sensitiveFields`, sealed entirely via the
+ *    graph-folded `taint` binding). Two observable corners:
+ *      (i)  a cache-MISS caches the freshly-decrypted REAL record into the
+ *           LRU instead of the SealedHandle form — a later `get()` cache HIT
+ *           then leaks plaintext straight out of the working set.
+ *      (ii) a cache-HIT returns the cached record AS-IS for use as a
+ *           self-write PATCH BASE — if that cached record carries a retained
+ *           SealedHandle for some OTHER already-sealed field (multi-field
+ *           case), spreading it into the patch and writing it back re-seals
+ *           `SealedHandle.toJSON()`'s `'[sealed]'` marker string in place of
+ *           the real value — a silent, permanent data-corrupting bug.
+ * 2. `applyTaintOverlay` (via-graph-wiring.ts) appends a fresh `taintBinding`
+ *    onto the existing bindings list without stripping a PRIOR one — every
+ *    `reapplyDependentOverlays` pass (#642's cross-collection re-apply gap
+ *    fix) accumulates one more `brand: 'taint'` binding (benign in effect —
+ *    the LAST one wins on every lookup — but wrong, and unbounded).
+ * 3. The self-write cycle-termination guard's regression (report's "Bugs
+ *    found" #2, an infinite write loop) was previously pinned only by the
+ *    default 5000ms vitest timeout. Upgraded here with an explicit put-count
+ *    assertion so a regression fails fast with a concrete count instead of a
+ *    generic timeout, keeping the timeout itself as the backstop.
+ */
+describe('#642 Fix wave 1 — _getStoredRecord lazy-branch at-rest gate parity (collection.ts:2123)', () => {
+  it('corner (i): a cache-miss patch-base read never poisons the LRU with plaintext — get() stays sealed', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({
+      store, user: 'a', secret: 'lazy-gate-corner-1',
+      classifiedStrategy: withClassified(),
+      derivationStrategies: [totalRollup()],
+    })
+    const v = await db.openVault('v1')
+    const sales = v.collection<Sale>('sales', { classifiedFields: { ssn: ssnSpec() } })
+    // Parent is LAZY (prefetch:false + bounded cache) with ZERO local
+    // sensitiveFields — sealed entirely via the folded `taint` binding.
+    const buyers = v.collection<Buyer>('buyers', { prefetch: false, cache: { maxRecords: 16 } })
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', amount: 100, ssn: '123-45-6789' })
+
+    // Evict the write-populated LRU entry so the NEXT read cache-MISSES —
+    // exactly the situation `recomputeRollup`'s `_getStoredRecord` patch-base
+    // read hits on a second child write.
+    ;(buyers as unknown as { lru: { remove: (id: string) => void } }).lru.remove('b1')
+
+    // Mirror `recomputeRollup`'s own call — this internal patch-base accessor
+    // is documented to return REAL values by design (never handles), so this
+    // call itself is expected to see the plain number.
+    const stored = await (buyers as unknown as { _getStoredRecord(id: string): Promise<Buyer | null> })._getStoredRecord('b1')
+    expect(stored?.total).toBe(100)
+
+    // The bug: pre-fix, that cache-miss populated the LRU with the REAL
+    // record (not a SealedHandle). Peek the LRU directly, then confirm the
+    // public read path agrees.
+    const peeked = (buyers as unknown as { _peekCached(id: string): Buyer | null })._peekCached('b1')
+    expect(peeked?.total).toBeInstanceOf(SealedHandle)
+
+    const rec = await buyers.get('b1')
+    expect(rec?.total).toBeInstanceOf(SealedHandle)
+    expect(await (rec!.total as unknown as { reveal(): Promise<number> }).reveal()).toBe(100)
+  })
+
+  it('corner (ii): a retained SealedHandle in a multi-field patch base is never re-sealed to the "[sealed]" marker', async () => {
+    interface MultiBuyer extends Record<string, unknown> { id: string; companyName: string; total?: number; saleCount?: number }
+    const store = inlineMemory()
+    const db = await createNoydb({
+      store, user: 'a', secret: 'lazy-gate-corner-2',
+      classifiedStrategy: withClassified(),
+      // TWO rollups from the SAME classified child into the SAME lazy parent:
+      // both target fields fold sealed (the rollup edge taints from the
+      // WHOLE `from` record, not a specific field — see
+      // `with-formula/derivations/registry.ts`'s `WHOLE_RECORD` source). The
+      // second spec's patch-base read then hits the LRU entry the FIRST
+      // spec's write just cached — a retained SealedHandle for `total`.
+      derivationStrategies: [
+        withRollup<Sale, MultiBuyer>({
+          from: 'sales', key: 'buyerId', into: 'buyers', field: 'total',
+          compute: (rows) => rows.reduce((t, s) => t + (typeof s.amount === 'number' ? s.amount : 0), 0),
+        }),
+        withRollup<Sale, MultiBuyer>({
+          from: 'sales', key: 'buyerId', into: 'buyers', field: 'saleCount',
+          compute: (rows) => rows.length,
+        }),
+      ],
+    })
+    const v = await db.openVault('v1')
+    const sales = v.collection<Sale>('sales', { classifiedFields: { ssn: ssnSpec() } })
+    const buyers = v.collection<MultiBuyer>('buyers', { prefetch: false, cache: { maxRecords: 16 } })
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+    await sales.put('s1', { id: 's1', buyerId: 'b1', amount: 100, ssn: '123-45-6789' })
+
+    const rec = await buyers.get('b1')
+    expect(rec?.total).toBeInstanceOf(SealedHandle)
+    expect(await (rec!.total as unknown as { reveal(): Promise<number> }).reveal()).toBe(100)
+    expect(rec?.saleCount).toBeInstanceOf(SealedHandle)
+    expect(await (rec!.saleCount as unknown as { reveal(): Promise<number> }).reveal()).toBe(1)
+  })
+})
+
+describe('#642 Fix wave 1 — applyTaintOverlay reapply idempotency (taint-binding accumulation)', () => {
+  it('two reapplies of the same dependent leave exactly ONE taint binding', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({
+      store, user: 'a', secret: 'reapply-idempotency-1',
+      classifiedStrategy: withClassified(),
+      derivationStrategies: [leakDerivation()],
+    })
+    const v = await db.openVault('v1')
+    v.collection<Leak>('leaks') // opened FIRST — no classified field registered yet
+    v.collection<Person>('people', { classifiedFields: { ssn: ssnSpec() } }) // opened SECOND — fires ONE reapply onto 'leaks'
+
+    const coll = v._getCollection('leaks') as unknown as { via?: { bindings: ReadonlyArray<{ brand: string }> } }
+    expect(coll.via?.bindings.filter((b) => b.brand === 'taint')).toHaveLength(1)
+
+    // Force a SECOND reapply pass the same way the real 'people' registration
+    // call site does (vault.ts's `reapplyDependentOverlays` call) — simulates
+    // a second dependent-source registering/refreshing.
+    reapplyDependentOverlays(v.graph, 'people', (n) => v._getCollection(n))
+
+    expect(coll.via?.bindings.filter((b) => b.brand === 'taint')).toHaveLength(1)
+  })
+})
+
+describe('#642 Fix wave 1 — self-write cycle-termination loop pin (put-count, fails fast)', () => {
+  it('a rollup recompute on a taint-sealed target converges in a bounded number of store puts', async () => {
+    const store = spyStore(inlineMemory())
+    const db = await createNoydb({
+      store, user: 'a', secret: 'loop-pin-1',
+      classifiedStrategy: withClassified(),
+      derivationStrategies: [totalRollup()],
+    })
+    const v = await db.openVault('v1')
+    const sales = v.collection<Sale>('sales', { classifiedFields: { ssn: ssnSpec() } })
+    const buyers = v.collection<Buyer>('buyers')
+    await buyers.put('b1', { id: 'b1', companyName: 'Acme' })
+
+    // Count only writes to the `buyers` DATA collection (excluding the
+    // incidental one-time `_keyring`/`_meta` housekeeping puts a first write
+    // to a fresh collection triggers) — this isolates exactly the write the
+    // self-write cycle-termination guard is responsible for bounding.
+    const buyersPutsBefore = store.calls.filter((c) => c.op === 'put' && c.args[1] === 'buyers').length
+    await sales.put('s1', { id: 's1', buyerId: 'b1', amount: 100, ssn: '123-45-6789' })
+    const buyersPutsAfter = store.calls.filter((c) => c.op === 'put' && c.args[1] === 'buyers').length - buyersPutsBefore
+
+    // Regression pin for the self-write cycle-termination guard: exactly ONE
+    // `buyers` write (the rollup patch settling `total: 100`) results from
+    // the single `sales.put`. Pre-fix, a SealedHandle patch base never
+    // value-equals the freshly computed plain number, so the rollup write
+    // re-triggers itself indefinitely — this assertion fails FAST with a
+    // concrete over-count instead of waiting out the 5000ms default vitest
+    // timeout the bug was previously only caught by.
+    expect(buyersPutsAfter).toBe(1)
   })
 })

--- a/packages/hub/__tests__/via/lookup-altkeys.test.ts
+++ b/packages/hub/__tests__/via/lookup-altkeys.test.ts
@@ -93,6 +93,25 @@ describe('materializeBackingTable (#650 Task 3) — pure registry function', () 
     // The canonical key itself never appears as an altIndex source (only 'USA' does).
     expect(result.altIndex.has('US')).toBe(false)
   })
+
+  it('accepts a numeric altKey value, normalizing it via coerceLookupKey (#651 Task 3 delta 3 — numeric widening)', () => {
+    const desc = lookup('countries', { key: 'iso2', altKeys: ['callingCode'] })
+    const rows = new Map<string, Record<string, unknown>>([
+      ['US', { iso2: 'US', callingCode: 1 }],
+    ])
+    const result = materializeBackingTable(desc, rows)
+    expect(result.altIndex.get('1')).toBe('US')
+  })
+
+  it('throws ValidationError when a numeric altKey value coerces to the same string as another row\'s string altKey (ownership-uniqueness holds across numeric/string)', () => {
+    const desc = lookup('countries', { key: 'iso2', altKeys: ['callingCode'] })
+    const rows = new Map<string, Record<string, unknown>>([
+      ['US', { iso2: 'US', callingCode: 1 }],
+      // XX's callingCode is the STRING '1' — coerces to the same candidate as US's numeric 1.
+      ['XX', { iso2: 'XX', callingCode: '1' }],
+    ])
+    expect(() => materializeBackingTable(desc, rows)).toThrow(ValidationError)
+  })
 })
 
 describe('lookup() altKeys ingest normalization — matrix (collection) tier end-to-end', () => {

--- a/packages/hub/__tests__/via/lookup-direct-read-key.test.ts
+++ b/packages/hub/__tests__/via/lookup-direct-read-key.test.ts
@@ -1,0 +1,129 @@
+/**
+ * The #651 repro — matrix (collection) tier, DIRECT-read (non-join) `<field>Label`
+ * dressing for a `key !== 'id'` descriptor — plus the dm12 poisoned-`"undefined"`-key
+ * pin (Task 3, spec §2 / seam-map-consolidation.md Part 2, surprises 5/6).
+ *
+ * RED (pre-Task-3): `getLookupBacking`'s closure (`kernel/vault.ts:1134`) resolved the
+ * backing row by the backing collection's own PUT-id (`.get(key)`), never by
+ * `descriptor.key` — for a `key: 'iso2'` descriptor whose PUT-id differs from `iso2`,
+ * `fetchLookupLabel`'s matrix branch silently omitted `<field>Label` on a direct
+ * `get()`. Separately, `buildLookupAltIndex`/`buildLookupSnapshotRows`'s matrix
+ * branches bare-`String()`-keyed a row missing its `descriptor.key` field as the
+ * literal key `"undefined"`, which a closed vocabulary's membership check then
+ * wrongly ACCEPTED. GREEN (post-Task-3): both close via the ONE canonical
+ * `coerceLookupKey`/`resolveBackingRowKey` core in `shape/via-lookup/registry.ts`.
+ *
+ * Reuses the countries-matrix inline harness (`countries-matrix.test.ts`).
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../../src/kernel/noydb.js'
+import { withI18n } from '../../src/shape/via-i18n/index.js'
+import { lookup } from '../../src/shape/via-lookup/descriptor.js'
+import { coerceLookupKey, resolveBackingRowKey } from '../../src/shape/via-lookup/registry.js'
+import { UnknownLookupKeyError, ConflictError } from '../../src/kernel/errors.js'
+import type { Noydb } from '../../src/kernel/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/kernel/types.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) if (!n.startsWith('_')) {
+        const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r
+      }
+      return s
+    },
+    async saveAll(c, data) { for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) } },
+  }
+}
+
+async function freshDb(): Promise<Noydb> {
+  return createNoydb({ store: memory(), user: 'a', secret: 'lookup-direct-read-pass-2026', i18nStrategy: withI18n() })
+}
+
+interface CountryRow extends Record<string, unknown> {
+  id: string
+  iso2?: string
+  iso3?: string
+  name: Record<string, string>
+}
+interface OrderRow extends Record<string, unknown> { id: string; country: string }
+
+describe('matrix direct-read dressing: key !== \'id\' works (#651 repro flip)', () => {
+  it('a direct (non-join) get() at a locale resolves <field>Label via descriptor.key, not the backing row\'s PUT-id', async () => {
+    const db = await freshDb()
+    const vault = await db.openVault('v')
+    const countries = vault.collection<CountryRow>('countries', {})
+    // PUT-id 'row-US' is deliberately NOT the iso2 value 'US' — the exact #651 shape.
+    await countries.put('row-US', { id: 'row-US', iso2: 'US', iso3: 'USA', name: { en: 'United States', th: 'สหรัฐอเมริกา' } })
+
+    const orders = vault.collection<OrderRow>('orders', {
+      lookupFields: {
+        country: lookup('countries', { key: 'iso2', altKeys: ['iso3'], present: { label: 'name', by: 'locale' }, backing: 'collection' }),
+      },
+    })
+    await orders.put('o1', { id: 'o1', country: 'US' })
+
+    const en = await orders.get('o1', { locale: 'en' }) as OrderRow & { countryLabel?: string }
+    expect(en?.countryLabel).toBe('United States')
+
+    const th = await orders.get('o1', { locale: 'th' }) as OrderRow & { countryLabel?: string }
+    expect(th?.countryLabel).toBe('สหรัฐอเมริกา')
+  })
+})
+
+describe('poisoned "undefined" key pin (#651, dm12 — bare String() vs guarded coercion)', () => {
+  it('a countries row missing its descriptor.key field does not enter the snapshot/altIndex as "undefined"', async () => {
+    const db = await freshDb()
+    const vault = await db.openVault('v')
+    const countries = vault.collection<CountryRow>('countries', {})
+    await countries.put('row-US', { id: 'row-US', iso2: 'US', name: { en: 'United States' } })
+    // No `iso2` field at all — `row[descriptor.key]` is `undefined` on this row.
+    await countries.put('row-broken', { id: 'row-broken', name: { en: 'Nowhere' } })
+
+    const orders = vault.collection<OrderRow>('orders', {
+      lookupFields: { country: lookup('countries', { key: 'iso2', vocabulary: 'closed', backing: 'collection' }) },
+    })
+
+    // A genuinely valid key is accepted.
+    await expect(orders.put('o1', { id: 'o1', country: 'US' })).resolves.not.toThrow()
+    // The literal string "undefined" must be REFUSED — pre-fix, the broken row's
+    // bare-String()-keyed snapshot entry ("undefined" -> row-broken) wrongly
+    // validated it as a known vocabulary member.
+    await expect(orders.put('o2', { id: 'o2', country: 'undefined' })).rejects.toThrow(UnknownLookupKeyError)
+
+    // No order record ever ends up holding the poisoned literal value.
+    expect(orders.query().where('country', '==', 'undefined').toArray().length).toBe(0)
+  })
+})
+
+describe('coerceLookupKey / resolveBackingRowKey — the pure core (unit)', () => {
+  it('coerceLookupKey: string/number coerce to String; null/undefined/other coerce to undefined', () => {
+    expect(coerceLookupKey(5)).toBe('5')
+    expect(coerceLookupKey('US')).toBe('US')
+    expect(coerceLookupKey(null)).toBeUndefined()
+    expect(coerceLookupKey(undefined)).toBeUndefined()
+    expect(coerceLookupKey({})).toBeUndefined()
+  })
+
+  it('resolveBackingRowKey: reads row[descriptor.key] through coerceLookupKey', () => {
+    const desc = lookup('countries', { key: 'iso2' })
+    expect(resolveBackingRowKey(desc, { iso2: 'US' })).toBe('US')
+    expect(resolveBackingRowKey(desc, {})).toBeUndefined()
+  })
+})

--- a/packages/hub/__tests__/via/lookup-restrict-unresolvable.test.ts
+++ b/packages/hub/__tests__/via/lookup-restrict-unresolvable.test.ts
@@ -1,0 +1,192 @@
+/**
+ * #654 policy — the two remaining vault-facade silent-skip sites (spec §2 / seam-map-
+ * consolidation.md Part 2d, Part 7 surprise 3). A `restrict` edge whose live compare-key
+ * resolve fails (matrix custom-key row unreadable — corruption class) previously silently
+ * `continue`d past the check, letting the delete/forget through unchecked. The ordinary-delete
+ * propagation path (`applyLookupRefsPropagation`) previously bare-`continue`d on the same
+ * failure with no report channel at all. Controller-ruled policy: restrict fails CLOSED
+ * (`RestrictRefUnresolvableError`); propagation residue-reports via a `lookup:propagation-
+ * residue` event (mirroring the forget path's `ForgetResult.lookupReferencesResidue` channel,
+ * which is untouched by this task).
+ *
+ * RED (pre-Task-4): the restrict-direction assertions fail because nothing throws — the corrupt
+ * row deletes/forgets silently. The propagation-direction assertion fails because no
+ * `lookup:propagation-residue` event ever fires.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../../src/kernel/noydb.js'
+import { withForgetCascade } from '../../src/with-audit/forget/index.js'
+import { lookup } from '../../src/shape/via-lookup/descriptor.js'
+import { DictKeyInUseError, RestrictRefUnresolvableError, ConflictError } from '../../src/kernel/errors.js'
+import type { Noydb } from '../../src/kernel/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/kernel/types.js'
+
+// Same in-memory store shape as lookup-direct-read-key.test.ts / lookup-ref-semantics.test.ts.
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) if (!n.startsWith('_')) {
+        const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r
+      }
+      return s
+    },
+    async saveAll(c, data) { for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) } },
+  }
+}
+
+async function freshDb(name: string): Promise<Noydb> {
+  return createNoydb({ store: memory(), user: 'a', secret: `lookup-restrict-unresolvable-${name}-2026` })
+}
+
+interface CountryRow extends Record<string, unknown> { id: string; iso2?: string; subjectId?: string; name: string }
+interface OrderRow extends Record<string, unknown> { id: string; country: string }
+
+describe('restrict direction: unresolvable compare-key fails closed (#654)', () => {
+  it('ordinary delete of a corrupt backing row (missing iso2) REFUSES with RestrictRefUnresolvableError naming orders.country', async () => {
+    const db = await freshDb('restrict-delete')
+    const vault = await db.openVault('v')
+    const countries = vault.collection<CountryRow>('countries', {})
+    vault.collection<OrderRow>('orders', {
+      lookupFields: { country: lookup('countries', { key: 'iso2', onDelete: 'restrict' }) },
+    })
+    // Corrupt: no `iso2` field at all — the restrict edge's compare-key cannot be resolved.
+    await countries.put('row-broken', { id: 'row-broken', name: 'Nowhere' })
+
+    let caught: unknown
+    try {
+      await countries.delete('row-broken')
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBeInstanceOf(RestrictRefUnresolvableError)
+    const err = caught as RestrictRefUnresolvableError
+    expect(err.dimension).toBe('countries')
+    expect(err.key).toBe('row-broken')
+    expect(err.referencing).toBe('orders.country')
+
+    // Fail-closed — the delete never went through.
+    expect(await countries.get('row-broken')).not.toBeNull()
+  })
+
+  it('forget() of a corrupt backing row (missing iso2) REFUSES with RestrictRefUnresolvableError before any shred', async () => {
+    const db = await createNoydb({
+      store: memory(), user: 'a', secret: 'lookup-restrict-unresolvable-forget-2026',
+      forgetStrategy: withForgetCascade({ subjects: { countries: 'subjectId' } }),
+    })
+    const vault = await db.openVault('v')
+    const countries = vault.collection<CountryRow>('countries', {})
+    vault.collection<OrderRow>('orders', {
+      lookupFields: { country: lookup('countries', { key: 'iso2', onDelete: 'restrict' }) },
+    })
+    await countries.put('row-broken', { id: 'row-broken', subjectId: 'subj-1', name: 'Nowhere' })
+
+    await expect(vault.forget('subj-1')).rejects.toThrow(RestrictRefUnresolvableError)
+
+    // Refused BEFORE any shred.
+    expect(await countries.get('row-broken')).not.toBeNull()
+  })
+
+  it('a RESOLVABLE restrict edge still throws DictKeyInUseError when a referencer exists (no regression)', async () => {
+    const db = await freshDb('restrict-resolvable-in-use')
+    const vault = await db.openVault('v')
+    const countries = vault.collection<CountryRow>('countries', {})
+    const orders = vault.collection<OrderRow>('orders', {
+      lookupFields: { country: lookup('countries', { key: 'iso2', onDelete: 'restrict' }) },
+    })
+    await countries.put('row-US', { id: 'row-US', iso2: 'US', name: 'United States' })
+    await orders.put('o1', { id: 'o1', country: 'US' })
+
+    await expect(countries.delete('row-US')).rejects.toThrow(DictKeyInUseError)
+    expect(await countries.get('row-US')).not.toBeNull()
+  })
+
+  it('a RESOLVABLE restrict edge still SUCCEEDS when no referencer exists (no regression)', async () => {
+    const db = await freshDb('restrict-resolvable-unused')
+    const vault = await db.openVault('v')
+    const countries = vault.collection<CountryRow>('countries', {})
+    vault.collection<OrderRow>('orders', {
+      lookupFields: { country: lookup('countries', { key: 'iso2', onDelete: 'restrict' }) },
+    })
+    await countries.put('row-FR', { id: 'row-FR', iso2: 'FR', name: 'France' })
+
+    await expect(countries.delete('row-FR')).resolves.not.toThrow()
+    expect(await countries.get('row-FR')).toBeNull()
+  })
+})
+
+describe('propagation direction: unresolvable compare-key residue-reports, never silent (#654)', () => {
+  it('ordinary delete of a corrupt backing row (missing iso2) proceeds and emits lookup:propagation-residue for the un-propagated cascade edge', async () => {
+    const db = await freshDb('propagation-cascade-unresolvable')
+    const vault = await db.openVault('v')
+    const countries = vault.collection<CountryRow>('countries', {})
+    vault.collection<OrderRow>('orders', {
+      lookupFields: { country: lookup('countries', { key: 'iso2', onDelete: 'cascade' }) },
+    })
+    await countries.put('row-broken', { id: 'row-broken', name: 'Nowhere' })
+
+    const events: Array<{ vault: string; dimension: string; key: string; residue: readonly string[] }> = []
+    db.on('lookup:propagation-residue', (e) => events.push(e))
+
+    await expect(countries.delete('row-broken')).resolves.not.toThrow()
+
+    // Never silent.
+    expect(events).toHaveLength(1)
+    expect(events[0]).toEqual({
+      vault: 'v',
+      dimension: 'countries',
+      key: 'row-broken',
+      residue: ['countries:row-broken:orders.country'],
+    })
+  })
+
+  it('a RESOLVABLE cascade edge still propagates and counts (no regression)', async () => {
+    const db = await freshDb('propagation-cascade-resolvable')
+    const vault = await db.openVault('v')
+    const countries = vault.collection<CountryRow>('countries', {})
+    const orders = vault.collection<OrderRow>('orders', {
+      lookupFields: { country: lookup('countries', { key: 'iso2', onDelete: 'cascade' }) },
+    })
+    await countries.put('row-US', { id: 'row-US', iso2: 'US', name: 'United States' })
+    await orders.put('o1', { id: 'o1', country: 'US' })
+
+    const events: unknown[] = []
+    db.on('lookup:propagation-residue', (e) => events.push(e))
+
+    await countries.delete('row-US')
+
+    expect(await orders.get('o1')).toBeNull()
+    expect(events).toHaveLength(0)
+  })
+
+  it('a RESOLVABLE nullify edge still propagates and counts (no regression)', async () => {
+    const db = await freshDb('propagation-nullify-resolvable')
+    const vault = await db.openVault('v')
+    const countries = vault.collection<CountryRow>('countries', {})
+    const orders = vault.collection<OrderRow>('orders', {
+      lookupFields: { country: lookup('countries', { key: 'iso2', onDelete: 'nullify' }) },
+    })
+    await countries.put('row-US', { id: 'row-US', iso2: 'US', name: 'United States' })
+    await orders.put('o1', { id: 'o1', country: 'US' })
+
+    await countries.delete('row-US')
+
+    const after = await orders.get('o1') as OrderRow | null
+    expect(after?.country).toBeNull()
+  })
+})

--- a/packages/hub/__tests__/via/mutation-choke-point.test.ts
+++ b/packages/hub/__tests__/via/mutation-choke-point.test.ts
@@ -155,7 +155,7 @@ describe('mutation-choke-point origin parity (#623 task 10, #621)', () => {
     // around every applyRemote call, per §3) — flip: phase C now dispatches on flush.
     // parity-pin: #621 — phase C changes this (was: no event, no derivation dispatch).
     v2._beginGraphBatch()
-    await v2._invalidateSyncApplied('pdfs', 'doc1')
+    await v2._invalidateSyncApplied('pdfs', 'doc1', 'put')
     await v2._flushGraphBatch()
 
     expect(changed2).toBe(1) // parity-pin: #621 — phase C changes this (the derived pdf-meta/doc1 output write)
@@ -187,7 +187,7 @@ describe('mutation-choke-point origin parity (#623 task 10, #621)', () => {
     await v1.collection<Invoice>('invoices').put('inv-1', { id: 'inv-1', status: 'open', amount: 100 }) // db1's own local-write, into the shared store
 
     v2._beginGraphBatch()
-    await v2._invalidateSyncApplied('invoices', 'inv-1')
+    await v2._invalidateSyncApplied('invoices', 'inv-1', 'put')
     await v2._flushGraphBatch()
 
     expect(await v2.collection<Invoice>('open-invoices').get('inv-1')).toMatchObject({ amount: 100 })

--- a/packages/hub/__tests__/via/query-posture-b.test.ts
+++ b/packages/hub/__tests__/via/query-posture-b.test.ts
@@ -22,6 +22,7 @@ import { i18nBinding } from '../../src/shape/via-i18n/binding.js'
 import { classifiedBinding } from '../../src/shape/via-classified/binding.js'
 import { blobBinding } from '../../src/shape/via-blob/binding.js'
 import { ViaPipeline } from '../../src/kernel/via-pipeline.js'
+import type { ViaPosture } from '../../src/kernel/via.js'
 import { NO_I18N } from '../../src/port/with/i18n-strategy.js'
 import { inlineMemory } from '../classified/harness.js'
 
@@ -67,6 +68,20 @@ describe('ViaPipeline.postureFor (#629 Task 8 — new small pipeline accessor)',
 
   it('undefined when no binding is compiled (zero-via)', () => {
     expect(ViaPipeline.build([])).toBeUndefined()
+  })
+
+  it('#642 — defaultPosture fallback: postureFor returns it for any field when no binding/taint entry covers it (non-sealed collection default)', () => {
+    const defaultPosture: ViaPosture = { encryptedAtRest: 'envelope', queryable: 'full', exportable: true, forgettable: true }
+    const p = ViaPipeline.build([], { postures: new Map(), sealFields: new Set(), defaultPosture })!
+    expect(p.postureFor('anyField')).toEqual(defaultPosture)
+  })
+
+  it('#642 — a field-specific taint posture still wins over defaultPosture', () => {
+    const defaultPosture: ViaPosture = { encryptedAtRest: 'envelope', queryable: 'full', exportable: true, forgettable: true }
+    const fieldPosture: ViaPosture = { encryptedAtRest: 'sealed', queryable: 'det-exact', exportable: false, forgettable: true }
+    const p = ViaPipeline.build([], { postures: new Map([['ssn', fieldPosture]]), sealFields: new Set(), defaultPosture })!
+    expect(p.postureFor('ssn')).toEqual(fieldPosture)
+    expect(p.postureFor('other')).toEqual(defaultPosture)
   })
 })
 

--- a/packages/hub/__tests__/via/sync-delete-rollup.test.ts
+++ b/packages/hub/__tests__/via/sync-delete-rollup.test.ts
@@ -1,0 +1,143 @@
+// #640 — sync-applied deletes reach the rollup dispatch wave (three coherent layers): the pull
+// loop classifies tombstone/delete-marker applies, the `cacheInvalidator` seam carries the
+// action kind, `GraphBatch` entries gain a delete-kind (resolved rollup-parent intents, ids/
+// names only), and the wave routes them to rollup-on-delete recompute — mirroring the LOCAL
+// delete path's `dispatchRollupsOnDelete` trio (never `dispatchDerivations` —
+// mutation-choke-point.test.ts:85-99's pin). Riders: #644 items 1+3 (stale-open batch
+// clear-on-error; the structured 'derivation:wave-error' event) + #646's db2-only-registration
+// fixture discipline (the rollup is declared on the PULLING side only).
+
+import { describe, it, expect, vi } from 'vitest'
+import { createNoydb, withRollup } from '../../src/index.js'
+import { withSync } from '../../src/with-party/sync/index.js'
+import { isDeleteMarker, isTombstoneShape } from '../../src/kernel/enclave/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/kernel/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none', required: false, flow: 'static' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/') as [string, string, string]
+        if (vname === v) { out[cname] = out[cname] ?? {}; out[cname]![id] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c]!)) data.set(k(v, c, i), payload[c]![i]!)
+      }
+    },
+  }
+}
+
+interface Customer extends Record<string, unknown> { id: string; orderCount?: number }
+interface Order extends Record<string, unknown> { id: string; customerId: string }
+
+const orderCountRollup = () =>
+  withRollup<Order, Customer>({ from: 'orders', key: 'customerId', into: 'customers', field: 'orderCount', compute: (orders) => orders.length })
+
+describe('sync-applied deletes reach the rollup dispatch wave (#640)', () => {
+  it('db2-only registration (#646): pulled deletes recompute the parent — dedup, ordering, freshness', async () => {
+    const remote = memory()
+    // db1 is a plain writer — it never registers the rollup, so any `orderCount` db2 ends up
+    // with can only have come from db2's OWN wave-driven recompute (#646 mandate).
+    const db1 = await createNoydb({ store: memory(), sync: remote, user: 'user-1', syncStrategy: withSync(), encrypt: false })
+    const db2 = await createNoydb({
+      store: memory(), sync: remote, user: 'user-2', syncStrategy: withSync(), encrypt: false,
+      derivationStrategies: [orderCountRollup()],
+    })
+
+    const v1 = await db1.openVault('shop')
+    await v1.collection<Customer>('customers').put('c1', { id: 'c1' })
+    await v1.collection<Order>('orders').put('o1', { id: 'o1', customerId: 'c1' })
+    await v1.collection<Order>('orders').put('o2', { id: 'o2', customerId: 'c1' })
+    await v1.collection<Order>('orders').put('o3', { id: 'o3', customerId: 'c1' })
+    await db1.push('shop')
+
+    const v2 = await db2.openVault('shop')
+    const customers = v2.collection<Customer>('customers')
+    const orders = v2.collection<Order>('orders')
+    await db2.pull('shop')
+    expect((await customers.get('c1'))?.orderCount).toBe(3)
+
+    // #640 repro: db1 deletes TWO of the three orders (a delete-marker each) + pushes; db2 pulls
+    // once. Wave dedup must collapse both child-deletes into exactly ONE parent recompute write.
+    const putSpy = vi.spyOn(customers, 'put')
+    await v1.collection<Order>('orders').delete('o1')
+    await v1.collection<Order>('orders').delete('o2')
+    await db1.push('shop')
+    await db2.pull('shop')
+    expect((await customers.get('c1'))?.orderCount).toBe(1) // 3 - 2, gap-free
+    expect(putSpy).toHaveBeenCalledTimes(1) // deduped: 2 deleted children → ONE recompute write
+
+    // Freshness-not-forget pin: the pulled delete leaves an ORDINARY delete-marker (freshness
+    // only) — never a crypto-shred tombstone (that's `forget()`'s job, never sync's).
+    const rawEnv = await remote.get('shop', 'orders', 'o1')
+    expect(rawEnv).not.toBeNull()
+    expect(isDeleteMarker(rawEnv!)).toBe(true)
+    expect(isTombstoneShape(rawEnv!)).toBe(false)
+
+    // Ordering pin: a delete of the last remaining original child + a put of a NEW sibling, in
+    // the SAME pull, must reflect the FINAL store state (both applied before the wave flushes).
+    putSpy.mockClear()
+    await v1.collection<Order>('orders').delete('o3')
+    await v1.collection<Order>('orders').put('o4', { id: 'o4', customerId: 'c1' })
+    await db1.push('shop')
+    await db2.pull('shop')
+    expect((await customers.get('c1'))?.orderCount).toBe(1) // o3 gone, o4 arrived — net 1
+    expect(await orders.get('o1')).toBeNull() // deleted children stay gone (sanity)
+
+    db1.close(); db2.close()
+  })
+
+  it('#644 item 3: a wave recompute error on the DELETE path emits derivation:wave-error additively to console.warn', async () => {
+    const remote = memory()
+    const boom = new Error('rollup compute exploded')
+    const throwingRollup = () =>
+      withRollup<Order, Customer>({
+        from: 'orders', key: 'customerId', into: 'customers', field: 'orderCount',
+        compute: () => { throw boom },
+      })
+    const db1 = await createNoydb({ store: memory(), sync: remote, user: 'user-1', syncStrategy: withSync(), encrypt: false })
+    const db2 = await createNoydb({
+      store: memory(), sync: remote, user: 'user-2', syncStrategy: withSync(), encrypt: false,
+      derivationStrategies: [throwingRollup()],
+    })
+
+    const v1 = await db1.openVault('shop')
+    await v1.collection<Customer>('customers').put('c1', { id: 'c1' })
+    await v1.collection<Order>('orders').put('o1', { id: 'o1', customerId: 'c1' })
+    await db1.push('shop')
+
+    const v2 = await db2.openVault('shop')
+    v2.collection<Customer>('customers'); v2.collection<Order>('orders')
+    await db2.pull('shop') // baseline pull — the initial put-driven recompute also throws+recovers (unobserved below)
+
+    const events: unknown[] = []
+    db2.on('derivation:wave-error', (e) => events.push(e))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await v1.collection<Order>('orders').delete('o1')
+    await db1.push('shop')
+    const pullResult = await db2.pull('shop') // must not throw/abort despite the recompute error
+
+    expect(pullResult.errors).toHaveLength(0) // isolated to the one failed target, per #638 Task 5
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ collection: 'orders', id: 'o1', error: boom })
+    expect(warnSpy).toHaveBeenCalled() // additive — console.warn still fires (not replaced)
+
+    warnSpy.mockRestore()
+    db1.close(); db2.close()
+  })
+})

--- a/packages/hub/__tests__/via/sync-dispatch.test.ts
+++ b/packages/hub/__tests__/via/sync-dispatch.test.ts
@@ -162,7 +162,7 @@ describe('sync dispatch wave — id-threaded decrypt for a per-record-keyed sour
     await docs1.put('d1', { id: 'd1', secret: 'abcdefghij' }) // db1's own local-write, into the shared store
 
     v2._beginGraphBatch()
-    await v2._invalidateSyncApplied('docs', 'd1')
+    await v2._invalidateSyncApplied('docs', 'd1', 'put')
     await v2._flushGraphBatch()
 
     expect(seen).toBe('abcdefghij') // the wave's decrypt (id: 'd1') recovered the RIGHT plaintext

--- a/packages/hub/__tests__/via/wildcard-fold.test.ts
+++ b/packages/hub/__tests__/via/wildcard-fold.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { ViaGraph, DEFAULT_POSTURE, foldWildcardSecurity } from '../../src/kernel/via-graph.js'
+import type { ViaPosture } from '../../src/kernel/via.js'
+
+// Real postures from the shipped bindings (shape/via-classified/binding.ts:213,
+// shape/via-blob/binding.ts:107) — used as realistic fixtures, not re-declared via
+// any shape/** import (the graph itself never imports shape/**).
+const CLASSIFIED: ViaPosture = { encryptedAtRest: 'sealed', queryable: 'det-exact', exportable: false, forgettable: true }
+const BLOB: ViaPosture = { encryptedAtRest: 'envelope', queryable: 'none', exportable: true, forgettable: true }
+
+describe('foldWildcardSecurity — the security-axes-only fold (#642)', () => {
+  it('folds encryptedAtRest/exportable/forgettable but leaves queryable at base', () => {
+    expect(foldWildcardSecurity(DEFAULT_POSTURE, CLASSIFIED)).toEqual({
+      encryptedAtRest: 'sealed',
+      queryable: 'full', // base's queryable, UNCHANGED — CLASSIFIED's 'det-exact' does not propagate
+      exportable: false,
+      forgettable: true,
+    })
+  })
+
+  it('queryable always tracks base, never the contributor, regardless of contributor value', () => {
+    const base: ViaPosture = { ...DEFAULT_POSTURE, queryable: 'ordered' }
+    expect(foldWildcardSecurity(base, CLASSIFIED).queryable).toBe('ordered')
+    expect(foldWildcardSecurity(base, BLOB).queryable).toBe('ordered')
+  })
+})
+
+describe("ViaGraph — kind- & axis-scoped '*' posture fold (#642)", () => {
+  it("a derivation '*' output inherits its source collection's registered-field fold (sealed, non-exportable, forgettable — queryable stays full)", () => {
+    const g = new ViaGraph()
+    g.registerField('src', 'ssn', CLASSIFIED)
+    g.registerField('src', 'plain', DEFAULT_POSTURE)
+    g.registerDerived({ collection: 'out', field: '*' }, [{ collection: 'src', field: '*' }], 'derivation', 'record')
+
+    expect(g.effectivePosture({ collection: 'out', field: '*' })).toEqual({
+      encryptedAtRest: 'sealed',
+      queryable: 'full',
+      exportable: false,
+      forgettable: true,
+    })
+  })
+
+  it('TRAP 2 — a blob field (queryable: none) in the source collection does NOT make a derivation output unqueryable; only forgettable ORs in', () => {
+    const g = new ViaGraph()
+    g.registerField('src2', 'doc', BLOB)
+    g.registerDerived({ collection: 'out2', field: '*' }, [{ collection: 'src2', field: '*' }], 'derivation', 'record')
+
+    const posture = g.effectivePosture({ collection: 'out2', field: '*' })
+    expect(posture?.queryable).toBe('full') // NOT 'none' — blob does not clamp derived-output queryability
+    expect(posture?.forgettable).toBe(true) // BLOB's forgettable:true still ORs in
+  })
+
+  it("TRAP 1 — a 'ref' edge's '*' source stays DEFAULT_POSTURE (identity) even though the backing collection has a classified field — lookup-referencing fields must not seal", () => {
+    const g = new ViaGraph()
+    g.registerField('countries', 'iso2', CLASSIFIED)
+    g.registerDerived(
+      { collection: 'orders', field: 'country' },
+      [{ collection: 'countries', field: '*' }],
+      'ref',
+      'record',
+    )
+
+    expect(g.effectivePosture({ collection: 'orders', field: 'country' })).toEqual(DEFAULT_POSTURE)
+  })
+
+  it('a rollup edge (real-field target) DOES fold sealed from its "*" source collection — kind-scoping only excludes ref, not rollup', () => {
+    const g = new ViaGraph()
+    g.registerField('src3', 'ssn', CLASSIFIED)
+    g.registerDerived(
+      { collection: 'parent', field: 'total' },
+      [{ collection: 'src3', field: '*' }],
+      'rollup',
+      'aggregate',
+    )
+
+    const posture = g.effectivePosture({ collection: 'parent', field: 'total' })
+    expect(posture?.encryptedAtRest).toBe('sealed')
+  })
+
+  it('ordering is free: registering the classified source field AFTER the derivation edge still folds sealed (cache cleared on the late registerField)', () => {
+    const g = new ViaGraph()
+    g.registerDerived({ collection: 'lateOut', field: '*' }, [{ collection: 'lateSrc', field: '*' }], 'derivation', 'record')
+    // Read once before the classified field exists — establishes a cached (non-sealed) result.
+    expect(g.effectivePosture({ collection: 'lateOut', field: '*' })).toEqual(DEFAULT_POSTURE)
+    // Late registration — must invalidate both _effectiveCache and _wildcardCache.
+    g.registerField('lateSrc', 'ssn', CLASSIFIED)
+    expect(g.effectivePosture({ collection: 'lateOut', field: '*' })?.encryptedAtRest).toBe('sealed')
+  })
+})

--- a/packages/hub/__tests__/via/wildcard-fold.test.ts
+++ b/packages/hub/__tests__/via/wildcard-fold.test.ts
@@ -77,6 +77,24 @@ describe("ViaGraph — kind- & axis-scoped '*' posture fold (#642)", () => {
     expect(posture?.encryptedAtRest).toBe('sealed')
   })
 
+  it("an 'mv' edge folds sealed identically to derivation/rollup — kind-scoping includes mv", () => {
+    const g = new ViaGraph()
+    g.registerField('src4', 'ssn', CLASSIFIED)
+    g.registerDerived({ collection: 'out4', field: '*' }, [{ collection: 'src4', field: '*' }], 'mv', 'record')
+
+    const posture = g.effectivePosture({ collection: 'out4', field: '*' })
+    expect(posture?.encryptedAtRest).toBe('sealed')
+  })
+
+  it("an 'overlay' edge folds sealed identically — kind-scoping includes overlay", () => {
+    const g = new ViaGraph()
+    g.registerField('src5', 'ssn', CLASSIFIED)
+    g.registerDerived({ collection: 'out5', field: '*' }, [{ collection: 'src5', field: '*' }], 'overlay', 'record')
+
+    const posture = g.effectivePosture({ collection: 'out5', field: '*' })
+    expect(posture?.encryptedAtRest).toBe('sealed')
+  })
+
   it('ordering is free: registering the classified source field AFTER the derivation edge still folds sealed (cache cleared on the late registerField)', () => {
     const g = new ViaGraph()
     g.registerDerived({ collection: 'lateOut', field: '*' }, [{ collection: 'lateSrc', field: '*' }], 'derivation', 'record')

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -909,7 +909,7 @@ export {
 // own name (`enum` is a reserved word); `enum` is re-exported alongside it
 // as the documented spelling — both names refer to the identical function.
 export { lookup, dict, enumOf, enum } from './shape/via-lookup/index.js'
-export { UnknownLookupKeyError } from './kernel/errors.js'
+export { UnknownLookupKeyError, RestrictRefUnresolvableError } from './kernel/errors.js'
 export type { LookupDescriptor, Vocabulary, OnDelete } from './shape/via-lookup/index.js'
 
 // Locale read options + translator audit log

--- a/packages/hub/src/kernel/collection-config.ts
+++ b/packages/hub/src/kernel/collection-config.ts
@@ -303,8 +303,10 @@ export interface CollectionOpts<T> {
   lookupLabelResolver?:
     | ((dimension: string, key: string, locale: string, fallback?: string | readonly string[]) => Promise<string | undefined>)
     | undefined
-  /** — the matrix (`backing:'collection'`) tier's present-time row accessor. Provided by the Vault. */
-  getLookupBacking?: ((dimension: string) => ((key: string) => Promise<Record<string, unknown> | undefined>) | undefined) | undefined
+  /** — the matrix (`backing:'collection'`) tier's present-time row accessor, keyed by the full
+   *  descriptor so it can resolve by `descriptor.key`, not the backing row's PUT-id (#651 Task 3).
+   *  Provided by the Vault. */
+  getLookupBacking?: ((descriptor: LookupDescriptor) => (key: string) => Promise<Record<string, unknown> | undefined>) | undefined
   /** — closed-vocabulary write-time membership test (#650 Task 3). Provided by the Vault. */
   membership?: ((field: string, key: string) => boolean | Promise<boolean>) | undefined
   /** — altKeys `ingest` normalization source (#650 Task 3). Provided by the Vault. */

--- a/packages/hub/src/kernel/collection-config.ts
+++ b/packages/hub/src/kernel/collection-config.ts
@@ -49,6 +49,7 @@ import type { I18nTextDescriptor, DictKeyDescriptor, StaticDictDescriptor, Dicti
 import type { LookupDescriptor, MaterializedBacking } from '../port/with/lookup-strategy.js'
 import { buildPresentForJoin } from '../port/with/lookup-strategy.js'
 import type { ComputedFields, ComputedFn, ComputedFieldEntry } from '../with-formula/computed/index.js'
+import type { RollupDeleteIntent } from './via-dispatch.js'
 // #638 Task 7 — the value import (not just `import type`) forces the port module's eager
 // `linkComputedVia()` to run whenever this file loads (collection-config.ts is always in the
 // dependency graph), so `viaBinder('computed')` is resolvable before `compileViaBindings` needs it.
@@ -514,8 +515,12 @@ export interface CollectionOpts<T> {
    * #638 Task 4 — thin collector hook wired by the Vault (`Vault._collectGraphTouch`). Every
    * `sync-apply`/`cutover`/`restore` mutation origin calls `collect(this.name, id)`; a no-op
    * when no batch is open (`_beginGraphBatch()` wasn't called) or the vault has no graph.
+   * `collectDelete` (#640) is the sync-apply delete socket — the resolved rollup-parent intents
+   * for a deleted record, captured pre-invalidation.
    */
-  graphDispatch?: { collect(collection: string, id: string): void } | undefined
+  graphDispatch?:
+    | { collect(collection: string, id: string): void; collectDelete(collection: string, id: string, intents: readonly RollupDeleteIntent[]): void }
+    | undefined
 }
 
 /** One normalized `ComputedFields` entry — a plain `ComputedFn` or a `ComputedFieldEntry`

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -2120,7 +2120,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   async _getStoredRecord(id: string): Promise<T | null> {
     let raw: T | null
     if (this.lazy && this.lru) {
-      if (this.sensitiveFields.size > 0) {
+      if (this.sensitiveFields.size > 0 || this.via?.hasAtRestHooks === true) {
         // Sealed collection (lazy mirror of the eager `resolvePriorValues`):
         // the LRU holds {@link Sealed} handles for sensitive fields (non-
         // residency), but `_getStoredRecord` is the reverse-denorm / rollup

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -10,7 +10,7 @@ import type { LookupDescriptor } from '../port/with/lookup-strategy.js'
 import { ViaPipeline } from './via-pipeline.js'
 import { viaBinder, type ViaDescriptor, type ViaWriteCtx, type ViaEraseReport } from './via.js'
 import type { MutationOrigin } from './mutation.js'
-import { putDerivedOutput, ledgerAuditHook, type WaveContext, type RollupOutcome } from './via-dispatch.js'
+import { putDerivedOutput, ledgerAuditHook, resolveRollupDeleteIntents, findRollupSpecForIntent, type WaveContext, type RollupOutcome, type RollupDeleteIntent } from './via-dispatch.js'
 import type { ComputedFields } from '../with-formula/computed/index.js'
 import {
   isTombstone,
@@ -568,8 +568,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       }
     | undefined
 
-  /** #638 Task 4 — `Vault._collectGraphTouch`; a no-op absent an open sync/cutover/restore batch. */
-  private readonly graphDispatch: { collect(collection: string, id: string): void } | undefined
+  /** #638 Task 4 — `Vault._collectGraphTouch`; a no-op absent an open batch. `collectDelete` (#640) is the sync-apply delete socket. */
+  private readonly graphDispatch: { collect(collection: string, id: string): void; collectDelete(collection: string, id: string, intents: readonly RollupDeleteIntent[]): void } | undefined
 
   /**
    * Optional back-reference to the owning compartment's ref
@@ -2199,21 +2199,16 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     return out
   }
 
-  /** @internal Recompute a rollup aggregate onto the parent from `parentId`'s current children
-   *  (value-equality guarded; no-op absent parent). `wave` (#638 T4): per-target dedup. Returns
-   *  the `putDerivedOutput` outcome, or `'noop'` when nothing needed recomputing (#638 T6 —
-   *  `dispatchRollupsOnDelete`'s forget-fanout caller needs this to fill the forget report). */
   /** @internal — ctx for `putDerivedOutput`'s frozen-period skip+audit (#638 Task 5). */
   #dispatchCtx(source: { readonly collection: string; readonly id: string }) {
     return { emit: (e: string, p: unknown) => (this.emitter.emit as (ev: string, pl: unknown) => void)(e, p), source, audit: ledgerAuditHook(this.ledger, this.keyring.userId) }
   }
 
+  /** @internal Recompute a rollup aggregate onto the parent from `parentId`'s current children (value-equality guarded; no-op absent parent).
+   *  `wave` (#638 T4, #640): per-target dedup. Returns the `putDerivedOutput` outcome, or `'noop'` (no parent/no-op/deduped) — `dispatchRollupsOnDelete`'s forget-fanout caller + #640's `_recomputeDeletedRollups` need this to fill their reports. */
   private async recomputeRollup(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    spec: { source: string; rollup?: { from: string; key: string; field: string; compute: (children: any[]) => unknown } },
-    parentId: string,
-    source: { readonly collection: string; readonly id: string },
-    wave?: WaveContext,
+    spec: { source: string; rollup?: { from: string; key: string; field: string; compute: (children: any[]) => unknown } }, parentId: string, source: { readonly collection: string; readonly id: string }, wave?: WaveContext,
   ): Promise<RollupOutcome> {
     if (this.derivationSource === undefined || spec.rollup === undefined) return 'noop'
     const { from, key, field, compute } = spec.rollup
@@ -2246,24 +2241,32 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     return putDerivedOutput(intoColl, parentId, patched, this.#dispatchCtx(source))
   }
 
+  /** @internal #640 — this deleted child's rollup PARENT intents (see via-dispatch.ts#resolveRollupDeleteIntents). */
+  _rollupDeleteIntents(deleted: T): RollupDeleteIntent[] {
+    return resolveRollupDeleteIntents(this.derivationSource?.registry(), this.name, deleted as Record<string, unknown>)
+  }
+
   /**
    * @internal Fire any rollups for which THIS collection is the child `from`, recomputing the
    * affected parent after a child delete/forget. Called from the delete path (return discarded)
    * and from `forgetDerivedFanout` (#638 Task 6), which needs the per-target outcome to fill
-   * `ForgetResult.derivedAggregatesRecomputed`/`derivedResidueFrozen`.
+   * `ForgetResult.derivedAggregatesRecomputed`/`derivedResidueFrozen`). `wave` (#640): per-target dedup for the sync-apply path; `undefined` on local-delete (byte-identical).
    */
-  async dispatchRollupsOnDelete(id: string, deleted: T): Promise<ReadonlyArray<{ readonly into: string; readonly parentId: string; readonly outcome: RollupOutcome }>> {
-    if (this.derivationSource === undefined) return []
-    const registry = this.derivationSource.registry()
-    const rec = deleted as Record<string, unknown>
+  async dispatchRollupsOnDelete(id: string, deleted: T, wave?: WaveContext): Promise<ReadonlyArray<{ readonly into: string; readonly parentId: string; readonly outcome: RollupOutcome }>> {
     const results: Array<{ into: string; parentId: string; outcome: RollupOutcome }> = []
-    for (const { spec } of registry.strategiesForSource(this.name)) {
-      if (!spec.rollup || spec.rollup.from !== this.name) continue
-      const kv = rec[spec.rollup.key]
-      if (typeof kv !== 'string' && typeof kv !== 'number') continue
-      results.push({ into: spec.source, parentId: String(kv), outcome: await this.recomputeRollup(spec, String(kv), { collection: this.name, id }) })
+    for (const intent of this._rollupDeleteIntents(deleted)) {
+      const spec = findRollupSpecForIntent(this.derivationSource?.registry(), this.name, intent)
+      if (spec) results.push({ into: intent.into, parentId: intent.parentId, outcome: await this.recomputeRollup(spec, intent.parentId, { collection: this.name, id }, wave) })
     }
     return results
+  }
+
+  /** @internal #640 — the wave's per-id driver: recompute each sync-apply delete's rollup parent. */
+  async _recomputeDeletedRollups(intents: readonly RollupDeleteIntent[], wave: WaveContext): Promise<void> {
+    for (const intent of intents) {
+      const spec = findRollupSpecForIntent(this.derivationSource?.registry(), this.name, intent)
+      if (spec) await this.recomputeRollup(spec, intent.parentId, { collection: this.name, id: '<sync-delete>' }, wave)
+    }
   }
 
   /** @internal `wave` (#638 Task 4) — threaded to `recomputeRollup` for the sync/cutover/restore
@@ -3830,11 +3833,14 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
         this.emitter.emit('change', { vault: this.vault, collection: this.name, id, action })
         this.searchIndexStore?.markDirty() // peer write changed the cache; rebuild on next retrieve
         return
-      case 'sync-apply':
+      case 'sync-apply': {
         this._invalidateCekCacheEntry(id)
+        const prior = action === 'delete' ? this._peekCached(id) : undefined
         await this._invalidateCacheEntry(id)
-        this.graphDispatch?.collect(this.name, id)
+        if (prior) this.graphDispatch?.collectDelete(this.name, id, this._rollupDeleteIntents(prior))
+        else if (action === 'put') this.graphDispatch?.collect(this.name, id)
         return
+      }
       case 'cutover':
         // Parity: cache invalidation only — the migration ledger entry
         // stays at the `_applyCutoverTransform` call site.
@@ -4370,12 +4376,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   // ─── Hierarchical Access ──────────────────────────
 
   /** tier-aware put — gated behind `tiersStrategy: withTiers()`. */
-  putAtTier(
-    id: string,
-    record: T,
-    tier: number,
-    opts?: { elevation?: { reason: string; fromTier: number }; source?: string; sourceTs?: string },
-  ): Promise<void> {
+  putAtTier(id: string, record: T, tier: number, opts?: { elevation?: { reason: string; fromTier: number }; source?: string; sourceTs?: string }): Promise<void> {
     return this.tiersStrategy.putAtTier(this.tiersContext(), id, record, tier, opts)
   }
 
@@ -4417,9 +4418,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    * (#M-1, 2026-06-30 security review). Kept as a `_`-prefixed method on
    * Collection because `vault.ts` forget() reaches in via this name.
    */
-  _classifySealedShred(
-    live: EncryptedEnvelope,
-  ): Promise<{ readonly slots: readonly SealedShredSlot[] }> {
+  _classifySealedShred(live: EncryptedEnvelope): Promise<{ readonly slots: readonly SealedShredSlot[] }> {
     return classifySealedShredImpl(this.tiersContext(), live)
   }
 

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -3854,7 +3854,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     }
   }
 
-  /** @internal — the current in-memory record without a store read (for conflict capture). */
+  /** @internal — the current in-memory record without a store read (for conflict capture); also the #640 FK-recovery read on a sync-applied delete — misses on a cold or evicted child (lazy LRU eviction OR an un-hydrated eager collection whose first sync op is a delete), not "lazy-mode" only. */
   _peekCached(id: string): T | null {
     const entry = this.lazy && this.lru ? this.lru.get(id) : this.cache.get(id)
     return entry ? entry.record : null

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -1658,11 +1658,11 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    * {@link Sealed} handles for sensitive fields (non-residency), so when the
    * collection seals anything we re-decrypt the stored envelope to materialise
    * real values — re-encrypting a handle would otherwise persist the marker
-   * `'[sealed]'` in place of the value. Collections that seal nothing read the
-   * cache directly (no extra I/O), matching the previous behaviour exactly.
+   * `'[sealed]'` in place of the value. `via?.hasAtRestHooks` (#642) catches
+   * hook-only sealing (taint/classified, no local `sensitiveFields`).
    */
   private async resolvePriorValues(id: string): Promise<{ record: T; version: number } | undefined> {
-    if (this.sensitiveFields.size > 0) {
+    if (this.sensitiveFields.size > 0 || this.via?.hasAtRestHooks === true) {
       const env = await this.adapter.get(this.vault, this.name, id)
       if (!env || isTombstone(env, this.storeCiphertext)) return undefined
       const rec = await this.codec.decryptRecord(env, { skipValidation: true, id })

--- a/packages/hub/src/kernel/enclave/record-keys/record-codec.ts
+++ b/packages/hub/src/kernel/enclave/record-keys/record-codec.ts
@@ -638,15 +638,23 @@ export class RecordCodec<T> {
   }
 
   /**
-   * Replace a record's declared sensitive fields with {@link Sealed} handles
-   * built from the just-written envelope's `_sealed` slots, leaving every
-   * other field as its plaintext value. Used to populate the cache on the
-   * write path without ever materialising sealed plaintext into it. Returns
-   * `record` untouched when the collection seals nothing.
+   * Replace every field the just-written envelope actually sealed with a
+   * {@link Sealed} handle, leaving every other field as its plaintext value.
+   * Used to populate the cache on the write path without ever materialising
+   * sealed plaintext into it. Returns `record` untouched when nothing was
+   * sealed. Keys off `envelope._sealed` itself (#642 fix) — NOT
+   * `this.ctx.sensitiveFields`, which only names the inline `sensitive:[...]`/
+   * classified-recoverable field set: a collection whose sealing comes
+   * entirely from the `taint` via-binding (a derivation/MV output or rollup
+   * target folded sealed from a classified SOURCE collection, #642) declares
+   * no local `sensitiveFields` at all, so that stale gate skipped this
+   * conversion and left a just-written taint-sealed field as cached
+   * plaintext — read back correctly ONLY after a cold cache miss (`get()`'s
+   * own `decodeAtRest` call, unaffected by this gate) forced a fresh decrypt.
    */
   async toCacheRecord(record: T, envelope: EncryptedEnvelope, id?: string): Promise<T> {
     const sealed = envelope._sealed
-    if (sealed === undefined || !this.ctx.storeCiphertext || this.ctx.sensitiveFields.size === 0) {
+    if (sealed === undefined || !this.ctx.storeCiphertext) {
       return record
     }
     const cek = await this.resolveEnvelopeCek(envelope, id)

--- a/packages/hub/src/kernel/errors.ts
+++ b/packages/hub/src/kernel/errors.ts
@@ -40,6 +40,7 @@
  *       │    ├─ ReservedCollectionNameError
  *       │    ├─ DictKeyMissingError
  *       │    ├─ DictKeyInUseError
+ *       │    ├─ RestrictRefUnresolvableError — restrict edge's compare-key unresolvable (#654)
  *       │    ├─ MissingTranslationError
  *       │    ├─ LocaleNotSpecifiedError
  *       │    ├─ ScriptViolationError
@@ -1414,6 +1415,36 @@ export class DictKeyInUseError extends NoydbError {
     this.key = key
     this.usedBy = usedBy
     this.count = count
+  }
+}
+
+/**
+ * Thrown by `VaultLinks.checkLookupRefsRestrict()` (#654) when a `restrict`-mode lookup-ref
+ * edge's compare-key cannot be resolved from the backing row — a matrix dimension with a
+ * non-default `key` whose row is missing that field or holds a non-string/non-number value
+ * (corruption-class rarity). Whether the referencer still points at this row can't be proven
+ * either way, so the delete/forget is refused rather than silently allowed through — the
+ * fail-closed twin of `DictKeyInUseError` ("cannot prove no references ⇒ do not delete").
+ */
+export class RestrictRefUnresolvableError extends NoydbError {
+  /** The dimension (backing collection/dictionary) whose row's compare-key was unresolvable. */
+  readonly dimension: string
+  /** The backing row's key (its PUT-id) that was being deleted/forgotten. */
+  readonly key: string
+  /** The unresolvable restrict edge, formatted `"collection.field"`. */
+  readonly referencing: string
+
+  constructor(dimension: string, key: string, referencing: string) {
+    super(
+      'RESTRICT_REF_UNRESOLVABLE',
+      `Cannot delete "${dimension}" key "${key}": the restrict-mode reference from "${referencing}" ` +
+        `could not be resolved (its compare-key is unreadable on the backing row). Refusing to ` +
+        `delete — cannot prove no references exist.`,
+    )
+    this.name = 'RestrictRefUnresolvableError'
+    this.dimension = dimension
+    this.key = key
+    this.referencing = referencing
   }
 }
 

--- a/packages/hub/src/kernel/noydb.ts
+++ b/packages/hub/src/kernel/noydb.ts
@@ -683,7 +683,7 @@ export class Noydb {
     })
     // #598: sync-applied writes must refresh Collection in-memory views.
     this._forEachSyncEngine(name, engine => {
-      engine.setCacheInvalidator((collection, id) => comp._invalidateSyncApplied(collection, id))
+      engine.setCacheInvalidator((collection, id, action) => comp._invalidateSyncApplied(collection, id, action))
       engine.setGraphBatchController({ begin: () => comp._beginGraphBatch(), flush: () => comp._flushGraphBatch() })
       engine.setReservedLookupSource({ collections: () => comp._reservedLookupCollectionNames() }) // #650 Task 4
     })

--- a/packages/hub/src/kernel/types.ts
+++ b/packages/hub/src/kernel/types.ts
@@ -1448,6 +1448,14 @@ export interface NoydbEventMap {
    * collection.field`, one per un-propagated edge (see `VaultLinks.applyLookupRefsPropagation`).
    */
   'lookup:propagation-residue': { vault: string; dimension: string; key: string; residue: readonly string[] }
+  /**
+   * #640 rider (#644 item 3) — the sync/cutover/restore dispatch wave's per-id recompute failed
+   * (a genuine decrypt failure, a derive()/executor bug, a schema violation on the output, ...).
+   * ADDITIVE to the existing `console.warn` in `runGraphDispatchWave` — never replaces it, so no
+   * listener-dependent silence. One event per failed (collection, id); the wave still isolates
+   * the failure to just that one record. See `kernel/via-dispatch.ts#runGraphDispatchWave`.
+   */
+  'derivation:wave-error': { collection: string; id: string; error: unknown }
 }
 
 // ─── Grant / Revoke ────────────────────────────────────────────────────

--- a/packages/hub/src/kernel/types.ts
+++ b/packages/hub/src/kernel/types.ts
@@ -1438,6 +1438,16 @@ export interface NoydbEventMap {
    * triggered skips, not a real source record id.
    */
   'derivation:skipped-frozen': DerivationSkippedFrozen
+  /**
+   * #654 — an ordinary-delete lookup-ref `cascade`/`nullify` propagation edge whose compare-key
+   * could not be resolved from the backing row (matrix custom-key row unreadable — corruption
+   * class). The delete itself proceeds (only `restrict` edges fail closed, via
+   * `RestrictRefUnresolvableError`); this edge's propagation is skipped and reported here instead
+   * of silently dropped — the ordinary-delete counterpart of the forget path's
+   * `ForgetResult.lookupReferencesResidue` channel. `residue` entries are `backing:key:
+   * collection.field`, one per un-propagated edge (see `VaultLinks.applyLookupRefsPropagation`).
+   */
+  'lookup:propagation-residue': { vault: string; dimension: string; key: string; residue: readonly string[] }
 }
 
 // ─── Grant / Revoke ────────────────────────────────────────────────────

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -118,7 +118,7 @@ import { mergeViaFields, type ViaFieldSpec } from './via-compose.js'
 import { exportRedact } from './via-pipeline.js'
 import { ViaGraph } from './via-graph.js'
 import { registerCollectionGraphSources, validateReconcileGraphEdges, commitReconcileGraphEdges, applyTaintOverlay, reapplyDependentOverlays, type ReconcileGraphOptions } from './via-graph-wiring.js'
-import { runGraphDispatchWave, putDerivedOutput, ledgerAuditHook, forgetDerivedFanout, type GraphBatch, type ForgetFanoutStats } from './via-dispatch.js'
+import { runGraphDispatchWave, putDerivedOutput, ledgerAuditHook, forgetDerivedFanout, touchFor, type GraphBatch, type ForgetFanoutStats, type RollupDeleteIntent } from './via-dispatch.js'
 import { NO_SYNC, type SyncStrategy } from '../with-party/team/sync-strategy.js'
 // Type-only imports for the guard + derivation services. The
 // runtime classes are loaded on demand via `await import(...)` inside
@@ -1020,7 +1020,7 @@ export class Vault {
         defaultLocale: this.locale,
         onRegisterConflictResolver: this.onRegisterConflictResolver,
         onAccess: (op, id) => this._logConsent(op, collectionName, id),
-        graphDispatch: { collect: (collection, id) => this._collectGraphTouch(collection, id) },
+        graphDispatch: { collect: (collection, id) => this._collectGraphTouch(collection, id), collectDelete: (collection, id, intents) => this._collectGraphDelete(collection, id, intents) },
         // Derivation source is only wired when the corresponding registry
         // has been initialised. Guard source was removed in Track A slice 3b
         // — guards now run via the gate bus in Noydb.#registerGuardGate.
@@ -1283,10 +1283,10 @@ export class Vault {
    *  its already-warmed `LookupHandle._syncCache` (membership/altIndex/snapshot reads never see a
    *  stale verdict for a pulled vocabulary edit) and collect the touch into any open graph batch
    *  (the sync-apply wave-reachability seam Task 5's ref edges will use). No-op if never warmed. */
-  async _invalidateSyncApplied(collection: string, id: string): Promise<void> {
+  async _invalidateSyncApplied(collection: string, id: string, action: 'put' | 'delete'): Promise<void> {
     const coll = this.collectionCache.get(collection)
     if (coll) {
-      await coll._onRecordMutated(id, 'put', 'sync-apply')
+      await coll._onRecordMutated(id, action, 'sync-apply')
       return
     }
     const dimName = this.reservedLookupCollections.get(collection)
@@ -1309,7 +1309,13 @@ export class Vault {
    *  no-op when no batch is open (`_beginGraphBatch()` was never called for this call chain). */
   _collectGraphTouch(collection: string, id: string): void {
     if (!this._graphBatch) return
-    this._graphBatch.set(collection, (this._graphBatch.get(collection) ?? new Set()).add(id))
+    touchFor(this._graphBatch, collection).puts.add(id)
+  }
+
+  /** @internal #640 — the sync-apply delete socket: `id`'s resolved rollup-parent intents. */
+  _collectGraphDelete(collection: string, id: string, intents: readonly RollupDeleteIntent[]): void {
+    if (!this._graphBatch) return
+    touchFor(this._graphBatch, collection).deletes.set(id, intents)
   }
 
   /** @internal #638 Task 4 — close the open batch and run ONE dispatch wave over it. */
@@ -1323,6 +1329,9 @@ export class Vault {
   _getCollection(name: string): Collection<Record<string, unknown>> | undefined {
     return this.collectionCache.get(name) as Collection<Record<string, unknown>> | undefined
   }
+
+  /** @internal #640 (#644 item 3) — `VaultLike.emit`: the wave's structured error surfacing. */
+  emit(event: string, payload: unknown): void { (this.emitter.emit as (ev: string, pl: unknown) => void)(event, payload) }
 
   /**
    * @internal #589 → #604. Physically remove delete markers with `_ts` strictly
@@ -1599,10 +1608,7 @@ export class Vault {
    * governs what happens to link rows when an endpoint record is deleted
    * (`'cascade'` default, `'strict'`, `'warn'`).
    */
-  link(
-    name: string,
-    spec: { a: string | RefDescriptor; b: string | RefDescriptor; onDelete?: LinkSpec['onDelete'] },
-  ): void {
+  link(name: string, spec: { a: string | RefDescriptor; b: string | RefDescriptor; onDelete?: LinkSpec['onDelete'] }): void {
     const a = typeof spec.a === 'string' ? spec.a : spec.a.target
     const b = typeof spec.b === 'string' ? spec.b : spec.b.target
     for (const [slot, target] of [['a', a], ['b', b]] as const) {
@@ -3029,9 +3035,7 @@ export class Vault {
    * read, written, elevated, or demoted successfully via this vault.
    * Returns an unsubscribe function.
    */
-  onCrossTierAccess(
-    listener: (event: CrossTierAccessEvent) => void,
-  ): () => void {
+  onCrossTierAccess(listener: (event: CrossTierAccessEvent) => void): () => void {
     this.crossTierSubs.add(listener)
     return () => this.crossTierSubs.delete(listener)
   }
@@ -3120,10 +3124,7 @@ export class Vault {
    *     {@link CrossTierAccessEvent} with `authorization: 'elevation'`,
    *     stamped with `reason` and `elevatedFrom`.
    */
-  async elevate(
-    tier: number,
-    options: { ttlMs: number; reason: string },
-  ): Promise<ElevatedHandle> {
+  async elevate(tier: number, options: { ttlMs: number; reason: string }): Promise<ElevatedHandle> {
     if (!Number.isInteger(tier) || tier <= 0) {
       throw new ValidationError(`elevate: tier must be a positive integer, got ${tier}`)
     }
@@ -3560,9 +3561,7 @@ export class Vault {
    *
    * @see https://github.com/vLannaAi/noy-db-docs/blob/main/content/docs/services/public-envelope.md
    */
-  async getPublicEnvelope(
-    opts: { readonly locale?: string } = {},
-  ): Promise<PublicEnvelope | undefined> {
+  async getPublicEnvelope(opts: { readonly locale?: string } = {}): Promise<PublicEnvelope | undefined> {
     const { readPublicEnvelope } = await import('../with-party/directory/public-envelope/index.js')
     return readPublicEnvelope(this.adapter, this.name, opts)
   }

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -1330,8 +1330,8 @@ export class Vault {
     return this.collectionCache.get(name) as Collection<Record<string, unknown>> | undefined
   }
 
-  /** @internal #640 (#644 item 3) — `VaultLike.emit`: the wave's structured error surfacing. */
-  emit(event: string, payload: unknown): void { (this.emitter.emit as (ev: string, pl: unknown) => void)(event, payload) }
+  /** @internal #640 (#644 item 3) — `VaultLike._emit`: the wave's structured error surfacing. */
+  _emit(event: string, payload: unknown): void { (this.emitter.emit as (ev: string, pl: unknown) => void)(event, payload) }
 
   /**
    * @internal #589 → #604. Physically remove delete markers with `_ts` strictly

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -117,7 +117,7 @@ import { isViaInstalled } from './via.js'
 import { mergeViaFields, type ViaFieldSpec } from './via-compose.js'
 import { exportRedact } from './via-pipeline.js'
 import { ViaGraph } from './via-graph.js'
-import { registerCollectionGraphSources, validateReconcileGraphEdges, commitReconcileGraphEdges, applyTaintOverlay, type ReconcileGraphOptions } from './via-graph-wiring.js'
+import { registerCollectionGraphSources, validateReconcileGraphEdges, commitReconcileGraphEdges, applyTaintOverlay, reapplyDependentOverlays, type ReconcileGraphOptions } from './via-graph-wiring.js'
 import { runGraphDispatchWave, putDerivedOutput, ledgerAuditHook, forgetDerivedFanout, type GraphBatch, type ForgetFanoutStats } from './via-dispatch.js'
 import { NO_SYNC, type SyncStrategy } from '../with-party/team/sync-strategy.js'
 // Type-only imports for the guard + derivation services. The
@@ -1160,9 +1160,7 @@ export class Vault {
         collOpts.fieldMeta = options.fieldMeta
       }
       // meta: thread through to the collection; surfaced via getMeta() / describe().
-      if (options?.meta !== undefined) {
-        collOpts.meta = options.meta
-      }
+      if (options?.meta !== undefined) collOpts.meta = options.meta
       // Pass a snapshot of the outbound refs for describe() (sync, config-only).
       if (options?.refs !== undefined) {
         collOpts.declaredRefs = this.refRegistry.getOutbound(collectionName)
@@ -1172,6 +1170,7 @@ export class Vault {
       registerCollectionGraphSources(this.graph, collectionName, collOpts)
       registerLookupRefEdges(this.graph, collectionName, effectiveViaFields.lookupFields) // #650 Task 5
       applyTaintOverlay(coll, this.graph, collectionName) // #638 Task 3: seal + gate any freshly-tainted field
+      reapplyDependentOverlays(this.graph, collectionName, (n) => this._getCollection(n)) // #642: refresh dependents opened before this source
 
       // Pre-build the lexical index on open when opted in. Fire-and-forget,
       // eager-only; warmIndex() no-ops when no textIndexes are declared and throws

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -1131,7 +1131,8 @@ export class Vault {
       if (effectiveViaFields.lookupFields !== undefined) {
         // membership/getAltIndex (#650 Task 3) are vault-built closures — never a collection handle.
         collOpts.lookupLabelResolver = collOpts.dictLabelResolver
-        collOpts.getLookupBacking = (dimension: string) => async (key: string) => (await this.collection<Record<string, unknown>>(dimension).get(key)) ?? undefined
+        collOpts.getLookupBacking = (desc: LookupDescriptor) => async (key: string) => // #651: snapshot-first (sole truth for key!=='id'); id-tier alone falls back to a live cold-session .get()
+          buildLookupSnapshotRows(desc, (n) => this.reservedLookupCollections.has(dictCollectionName(n)), (n) => this.dictionary(n), (n) => this.collection<Record<string, unknown>>(n))?.get(key) ?? (desc.key === 'id' ? (await this.collection<Record<string, unknown>>(desc.dimension).get(key)) ?? undefined : undefined)
         collOpts.lookupFields = options?.lookupFields
         collOpts.membership = (field, key) => checkLookupMembership(effectiveViaFields.lookupFields![field]!, key, (n) => this.dictionary(n), (n) => this.collection(n))
         collOpts.getAltIndex = (d) => buildLookupAltIndex(d, (n) => this.dictionary(n), (n) => this.collection<Record<string, unknown>>(n))

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -370,7 +370,6 @@ export class Vault {
    */
   private consentContext: ConsentContext | null = null
 
-
   /** dictKeyField registry: collection name → field name → dictionary name — `DictionaryHandle.rename()`'s reference-update source; populated by `collection()` from `dictKeyFields`. */
   private readonly dictKeyFieldRegistry = new Map<string, Record<string, string>>()
 
@@ -531,6 +530,7 @@ export class Vault {
       links: (name) => this.links(name),
       getCachedCollection: (name) => this.collectionCache.get(name),
       getActiveTxContext: () => this.noydb._activeTxContextOrNull,
+      emitter: this.emitter,
     })
     this.shadowStrategy = opts.shadowStrategy ?? NO_SHADOW
     this.historyStrategy = opts.historyStrategy ?? NO_HISTORY

--- a/packages/hub/src/kernel/via-dispatch.ts
+++ b/packages/hub/src/kernel/via-dispatch.ts
@@ -15,6 +15,7 @@ import type { ViaGraph } from './via-graph.js'
 import type { Collection } from './collection.js'
 import type { EncryptedEnvelope } from './types.js'
 import { PeriodClosedError } from './errors.js'
+import { matchesReferencingValue } from '../port/with/lookup-strategy.js'
 
 /** Per-session touched set — collection → ids. Metadata only (no values, no key material). */
 export type GraphBatch = Map<string, Set<string>>
@@ -219,14 +220,19 @@ export async function forgetDerivedFanout(
 
   // #650 Task 5 (#648) — 'ref' cascade/nullify propagate ADDITIVELY, here, AFTER the shred
   // (restrict already refused BEFORE any shred — the caller's pre-tombstone check, spec §4).
-  // Duplicated (not imported) from `VaultLinks.applyLookupRefsPropagation`/`checkLookupRefsRestrict`
-  // (with-shape/links/vault-facade.ts) — the kernel spine may not statically import a with-*
-  // service (port-layering, the #638 Task 5 via-dispatch.ts precedent). A referencing edge whose
-  // dimension uses a non-default `key` (matrix tier only) needs the backing row's OWN value at
-  // that field, not its PUT-id — the row is ALREADY tombstoned by now, so it's read from
-  // `lookupCompareKeys`, resolved by the caller from the LIVE row BEFORE the shred (#650 Task 5
-  // review, Important fix — eliminates the post-shred envelope-decode dependency this used to
-  // have, which silently skipped propagation whenever that decode failed).
+  // The I/O shell (loop shape, collection accessor) is duplicated, not imported, from
+  // `VaultLinks.applyLookupRefsPropagation`/`checkLookupRefsRestrict` (with-shape/links/
+  // vault-facade.ts) — the kernel spine may not statically import a with-* service
+  // (port-layering, the #638 Task 5 via-dispatch.ts precedent); `vault._getCollection` is
+  // cached-only while `VaultLinks`' accessor constructs. The pure match predicate itself is
+  // shared through the port seam (#651 Task 3 — `matchesReferencingValue`, `port/with/
+  // lookup-strategy.ts`), so only the shell, not the coercion logic, stays duplicated. A
+  // referencing edge whose dimension uses a non-default `key` (matrix tier only) needs the
+  // backing row's OWN value at that field, not its PUT-id — the row is ALREADY tombstoned by
+  // now, so it's read from `lookupCompareKeys`, resolved by the caller from the LIVE row
+  // BEFORE the shred (#650 Task 5 review, Important fix — eliminates the post-shred
+  // envelope-decode dependency this used to have, which silently skipped propagation whenever
+  // that decode failed).
   if (edges.some((e) => e.kind === 'ref')) {
     const { cascaded, nullified, residue } = await applyLookupRefsFanout(vault, ref.collection, ref.id, lookupCompareKeys)
     stats.lookupReferencesCascaded += cascaded
@@ -259,8 +265,9 @@ export async function forgetDerivedFanout(
 
 /**
  * Apply `cascade`/`nullify` propagation for `backing`'s non-restrict `'ref'` edges — the
- * forget-path counterpart of `VaultLinks.applyLookupRefsPropagation` (duplicated, not imported —
- * see {@link forgetDerivedFanout}'s call site comment). `restrict` edges are skipped here: the
+ * forget-path counterpart of `VaultLinks.applyLookupRefsPropagation` (I/O shell duplicated, not
+ * imported, match predicate shared via the port — see {@link forgetDerivedFanout}'s call site
+ * comment). `restrict` edges are skipped here: the
  * forget loop's `checkLookupRefsRestrict`-equivalent call already refused (or the reference no
  * longer existed) BEFORE `_writeTombstone` ran, so by the time this runs only cascade/nullify
  * remain to propagate. `compareKeys` is the non-`'id'`-`keyField` compare-value map, resolved by
@@ -287,7 +294,7 @@ async function applyLookupRefsFanout(
     }
     const coll = vault._getCollection(referencing.collection)
     if (!coll) continue
-    const matches = (await coll.list()).filter((rec) => String(rec[referencing.field]) === compareKey)
+    const matches = (await coll.list()).filter((rec) => matchesReferencingValue(rec, referencing.field, compareKey))
     for (const rec of matches) {
       const id = rec['id'] as string | undefined
       if (id === undefined) continue

--- a/packages/hub/src/kernel/via-dispatch.ts
+++ b/packages/hub/src/kernel/via-dispatch.ts
@@ -78,12 +78,12 @@ export function resolveRollupDeleteIntents<S extends { source: string; rollup?: 
  *  so it's re-resolved here, post-boundary, instead of carried across it. `undefined` if the
  *  intent's originating strategy was unregistered between collect time and wave time (residual
  *  gap, freshness-only). */
-export function findRollupSpecForIntent<S extends { source: string; rollup?: { field: string } }>(
+export function findRollupSpecForIntent<S extends { source: string; rollup?: { from: string; field: string } }>(
   registry: { strategiesForSource(name: string): ReadonlyArray<{ spec: S }> } | undefined,
   collectionName: string,
   intent: RollupDeleteIntent,
 ): S | undefined {
-  return registry?.strategiesForSource(collectionName).find((s) => s.spec.source === intent.into && s.spec.rollup?.field === intent.field)?.spec
+  return registry?.strategiesForSource(collectionName).find((s) => s.spec.source === intent.into && s.spec.rollup?.field === intent.field && s.spec.rollup?.from === collectionName)?.spec
 }
 
 /** One dedup ledger for a single wave — a target is recomputed at most once (mark-on-check). */
@@ -103,7 +103,7 @@ export interface VaultLike {
   readonly graph: ViaGraph
   _getCollection(name: string): Collection<Record<string, unknown>> | undefined
   /** #640 (#644 item 3) — structured wave-error surfacing, additive to the existing console.warn. */
-  emit(event: string, payload: unknown): void
+  _emit(event: string, payload: unknown): void
 }
 
 /**
@@ -143,7 +143,7 @@ export async function runGraphDispatchWave(vault: VaultLike, batch: GraphBatch):
         // #644 item 3: ADDITIVELY (never in place of the warn) emit a structured event too,
         // so a listener doesn't have to scrape console output to react to a wave failure.
         console.warn(`[via-dispatch] wave recompute failed for ${collectionName}/${id}:`, err)
-        vault.emit('derivation:wave-error', { collection: collectionName, id, error: err })
+        vault._emit('derivation:wave-error', { collection: collectionName, id, error: err })
       }
     }
     // #640 — delete-kind touches: the deleted child's rollup-parent intents, resolved (sync,
@@ -155,7 +155,7 @@ export async function runGraphDispatchWave(vault: VaultLike, batch: GraphBatch):
         await coll._recomputeDeletedRollups(intents, wave)
       } catch (err) {
         console.warn(`[via-dispatch] wave delete-recompute failed for ${collectionName}/${id}:`, err)
-        vault.emit('derivation:wave-error', { collection: collectionName, id, error: err })
+        vault._emit('derivation:wave-error', { collection: collectionName, id, error: err })
       }
     }
   }

--- a/packages/hub/src/kernel/via-dispatch.ts
+++ b/packages/hub/src/kernel/via-dispatch.ts
@@ -17,8 +17,74 @@ import type { EncryptedEnvelope } from './types.js'
 import { PeriodClosedError } from './errors.js'
 import { matchesReferencingValue } from '../port/with/lookup-strategy.js'
 
-/** Per-session touched set — collection → ids. Metadata only (no values, no key material). */
-export type GraphBatch = Map<string, Set<string>>
+/** One deleted child's resolved rollup PARENT intent (#640) — ids + a field name only. A
+ *  resolved `parentId` is an id, same class as any touched record id — never a stored value. */
+export interface RollupDeleteIntent {
+  readonly into: string
+  readonly parentId: string
+  readonly field: string
+}
+
+/** One collection's batched touches this session (#640 widens the #638 `Set<string>` shape):
+ *  `puts` — the original semantics, unchanged; `deletes` — a deleted record's id mapped to its
+ *  resolved rollup-parent intents, captured PRE-invalidation by `Collection._onRecordMutated`'s
+ *  sync-apply delete case (the FK is only readable there — see `kernel/collection.ts
+ *  #_rollupDeleteIntents`). */
+export interface GraphTouch {
+  readonly puts: Set<string>
+  readonly deletes: Map<string, readonly RollupDeleteIntent[]>
+}
+
+/** Per-session touched set — collection → its `GraphTouch`. Metadata only — ids (collection
+ *  names, record ids INCLUDING resolved rollup parent ids) and field names; NEVER record payload
+ *  or key material. A resolved parentId is an id, same class as the touched ids — not a stored
+ *  value. */
+export type GraphBatch = Map<string, GraphTouch>
+
+/** Get-or-create `batch`'s `GraphTouch` entry for `collection` (#640) — shared by
+ *  `Vault._collectGraphTouch`/`_collectGraphDelete` so each stays a one-line call. */
+export function touchFor(batch: GraphBatch, collection: string): GraphTouch {
+  let t = batch.get(collection)
+  if (!t) {
+    t = { puts: new Set(), deletes: new Map() }
+    batch.set(collection, t)
+  }
+  return t
+}
+
+/** #640 — sync, I/O-free: `deleted`'s resolved rollup PARENT intents (the FK is only readable
+ *  NOW, before the record is gone) — a pure function so `Collection._rollupDeleteIntents` stays
+ *  a one-line delegator under the kernel-surface ceiling. `registry` is `this.derivationSource
+ *  ?.registry()`; `collectionName` is `this.name` (the CHILD/`rollup.from` side). Generic over
+ *  the registry's own spec shape so this file never imports a `with-formula` type (port-layering
+ *  — via-dispatch.ts must not gain a with-* import). */
+export function resolveRollupDeleteIntents<S extends { source: string; rollup?: { from: string; key: string; field: string } }>(
+  registry: { strategiesForSource(name: string): ReadonlyArray<{ spec: S }> } | undefined,
+  collectionName: string,
+  deleted: Record<string, unknown>,
+): RollupDeleteIntent[] {
+  if (!registry) return []
+  const intents: RollupDeleteIntent[] = []
+  for (const { spec } of registry.strategiesForSource(collectionName)) {
+    if (!spec.rollup || spec.rollup.from !== collectionName) continue
+    const kv = deleted[spec.rollup.key]
+    if (typeof kv === 'string' || typeof kv === 'number') intents.push({ into: spec.source, parentId: String(kv), field: spec.rollup.field })
+  }
+  return intents
+}
+
+/** #640 — resolve a `RollupDeleteIntent` back to its registry `spec`. The wave's per-intent
+ *  driver needs `spec.rollup.compute`, which `GraphBatch`'s metadata-only pin forbids batching —
+ *  so it's re-resolved here, post-boundary, instead of carried across it. `undefined` if the
+ *  intent's originating strategy was unregistered between collect time and wave time (residual
+ *  gap, freshness-only). */
+export function findRollupSpecForIntent<S extends { source: string; rollup?: { field: string } }>(
+  registry: { strategiesForSource(name: string): ReadonlyArray<{ spec: S }> } | undefined,
+  collectionName: string,
+  intent: RollupDeleteIntent,
+): S | undefined {
+  return registry?.strategiesForSource(collectionName).find((s) => s.spec.source === intent.into && s.spec.rollup?.field === intent.field)?.spec
+}
 
 /** One dedup ledger for a single wave — a target is recomputed at most once (mark-on-check). */
 export class WaveContext {
@@ -36,6 +102,8 @@ export class WaveContext {
 export interface VaultLike {
   readonly graph: ViaGraph
   _getCollection(name: string): Collection<Record<string, unknown>> | undefined
+  /** #640 (#644 item 3) — structured wave-error surfacing, additive to the existing console.warn. */
+  emit(event: string, payload: unknown): void
 }
 
 /**
@@ -47,11 +115,11 @@ export interface VaultLike {
  */
 export async function runGraphDispatchWave(vault: VaultLike, batch: GraphBatch): Promise<void> {
   const wave = new WaveContext()
-  for (const [collectionName, ids] of batch) {
+  for (const [collectionName, touch] of batch) {
     if (vault.graph.dependentsOf(collectionName).length === 0) continue
     const coll = vault._getCollection(collectionName)
     if (!coll) continue
-    for (const id of ids) {
+    for (const id of touch.puts) {
       try {
         // Decrypt is INSIDE the per-id isolation boundary (whole-branch review Important
         // finding, #638): an undecryptable synced envelope (`TamperedError`) must not
@@ -72,7 +140,22 @@ export async function runGraphDispatchWave(vault: VaultLike, batch: GraphBatch):
         // violation on the output, ...) is surfaced — not silently swallowed — via the
         // SAME console.warn channel `dispatchDerivations`/the MV executor already use for
         // their own non-strict-mode output failures, then isolated to just this one id.
+        // #644 item 3: ADDITIVELY (never in place of the warn) emit a structured event too,
+        // so a listener doesn't have to scrape console output to react to a wave failure.
         console.warn(`[via-dispatch] wave recompute failed for ${collectionName}/${id}:`, err)
+        vault.emit('derivation:wave-error', { collection: collectionName, id, error: err })
+      }
+    }
+    // #640 — delete-kind touches: the deleted child's rollup-parent intents, resolved (sync,
+    // pre-invalidation) at collect time by `Collection._rollupDeleteIntents`. Same per-id
+    // isolation as the puts loop above; never routed through `dispatchDerivations` (the
+    // mutation-choke-point.test.ts:85-99 pin — sync-applied deletes are rollup-on-delete only).
+    for (const [id, intents] of touch.deletes) {
+      try {
+        await coll._recomputeDeletedRollups(intents, wave)
+      } catch (err) {
+        console.warn(`[via-dispatch] wave delete-recompute failed for ${collectionName}/${id}:`, err)
+        vault.emit('derivation:wave-error', { collection: collectionName, id, error: err })
       }
     }
   }

--- a/packages/hub/src/kernel/via-graph-wiring.ts
+++ b/packages/hub/src/kernel/via-graph-wiring.ts
@@ -272,11 +272,29 @@ export function commitReconcileGraphEdges(graph: ViaGraph, name: string, plan: R
  * automatically follow a later `this.via` reassignment — `RecordCodec.
  * setVia` re-syncs it so `encryptRecord`/`decryptRecord` seal/unseal
  * through the taint binding too, not a stale pre-taint pipeline.
+ *
+ * #642 — `graph.taintedPostures(name)` also carries the collection's `'*'`
+ * target (a derivation/MV/overlay OUTPUT collection's whole-record fold,
+ * `via-graph.ts`'s `taintedPostures`/`taintSealedFields` already surface it
+ * under the literal key `'*'`, no `via-graph.ts` change needed). Split it off
+ * BEFORE building the field-specific overlay — `'*'` is never a real record
+ * field — and re-derive it as `defaultPosture` through the SAME
+ * `buildTaintOverlay` sealed→`queryable:'none'` clamp (reused, not
+ * duplicated, by feeding it a one-entry map). A sealed default folds into
+ * the SAME single `taintBinding` call via `sealAllFields` — every field
+ * (present-time, at-rest) is covered without a second binding.
  */
 export function applyTaintOverlay(coll: unknown, graph: ViaGraph, name: string): void {
-  const postures = buildTaintOverlay(graph.taintedPostures(name), graph.taintSealedFields(name))
-  if (!postures) return
-  const sealFields = graph.taintSealedFields(name)
+  const raw = graph.taintedPostures(name)
+  const rawDefault = raw.get('*')
+  const rawFields = rawDefault === undefined ? raw : new Map([...raw].filter(([field]) => field !== '*'))
+  const allSealFields = graph.taintSealedFields(name)
+  const sealFields = allSealFields.has('*') ? new Set([...allSealFields].filter((f) => f !== '*')) : allSealFields
+  const postures = buildTaintOverlay(rawFields, sealFields)
+  const defaultPosture = rawDefault === undefined
+    ? undefined
+    : buildTaintOverlay(new Map([['*', rawDefault]]), allSealFields)?.get('*')
+  if (!postures && defaultPosture === undefined) return
   const provenance = graph.taintProvenance(name)
   // #638 Task 7 — a virtual computed field is never sealed (`taintSealedFields` already
   // excludes `grain: 'virtual'` — nothing is stored, so nothing to seal), but a TAINTED
@@ -286,15 +304,54 @@ export function applyTaintOverlay(coll: unknown, graph: ViaGraph, name: string):
   // enough — the plain `get()`/`list()` path must be closed too).
   const virtualFields = graph.virtualFields(name)
   const virtualExportRedact = new Set<string>()
-  for (const [field, posture] of postures) {
-    if (posture.exportable === false && virtualFields.has(field)) virtualExportRedact.add(field)
+  if (postures) {
+    for (const [field, posture] of postures) {
+      if (posture.exportable === false && virtualFields.has(field)) virtualExportRedact.add(field)
+    }
   }
   const c = coll as { via: ViaPipeline | undefined; codec: { setVia(via: ViaPipeline | undefined): void } }
-  const needsTaintBinding = sealFields.size > 0 || virtualExportRedact.size > 0
+  const sealAll = defaultPosture?.encryptedAtRest === 'sealed'
+  const needsTaintBinding = sealFields.size > 0 || virtualExportRedact.size > 0 || sealAll
   const bindings = needsTaintBinding
-    ? [...(c.via?.bindings ?? []), taintBinding(sealFields, virtualExportRedact)]
+    ? [...(c.via?.bindings ?? []), taintBinding(sealFields, virtualExportRedact, sealAll)]
     : (c.via?.bindings ?? [])
-  const taint: ViaTaintOverlay = { postures, sealFields, provenance }
+  const taint: ViaTaintOverlay = {
+    postures: postures ?? EMPTY_POSTURE_MAP, sealFields, provenance,
+    ...(defaultPosture !== undefined ? { defaultPosture } : {}),
+  }
   c.via = ViaPipeline.build(bindings, taint)
   c.codec.setVia(c.via)
 }
+
+/**
+ * #642 — the cross-collection re-apply gap (seam map finding 4/10): when the
+ * OUTPUT/parent collection was opened (its overlay built) BEFORE the
+ * classified SOURCE collection ever registered a field, the output's `'*'`
+ * fold (or a rollup's real-field fold) was computed against an empty/stale
+ * source posture. `applyTaintOverlay` alone never re-fires for an already-
+ * open dependent — this hook closes that: after `name` registers its OWN
+ * field postures (called right after `applyTaintOverlay(coll, graph, name)`
+ * at each collection-construction call site), re-run `applyTaintOverlay` for
+ * every OPEN collection that graph-depends on `name`.
+ *
+ * Pure wiring — re-applies OVERLAYS only (a pipeline rebuild), never
+ * re-registers a graph edge (`registerDerived`'s at-most-once contract, D-2
+ * wave-2 law, is untouched). `graph.dependentsOf(name)` already excludes
+ * `'ref'` edges (a referencing field must not seal just because its backing
+ * dimension changed — the phase-D lookup identity contract). A dependent
+ * collection that hasn't been opened yet (`getOpenCollection` returns
+ * `undefined`) is skipped — it will fold correctly on its OWN first-open
+ * `applyTaintOverlay` call, which reads the graph fresh.
+ */
+export function reapplyDependentOverlays(
+  graph: ViaGraph, name: string,
+  getOpenCollection: (n: string) => unknown,
+): void {
+  const targets = new Set(graph.dependentsOf(name).map((edge) => edge.target.collection))
+  for (const target of targets) {
+    const coll = getOpenCollection(target)
+    if (coll !== undefined) applyTaintOverlay(coll, graph, target)
+  }
+}
+
+const EMPTY_POSTURE_MAP: ReadonlyMap<string, ViaPosture> = new Map()

--- a/packages/hub/src/kernel/via-graph-wiring.ts
+++ b/packages/hub/src/kernel/via-graph-wiring.ts
@@ -312,9 +312,17 @@ export function applyTaintOverlay(coll: unknown, graph: ViaGraph, name: string):
   const c = coll as { via: ViaPipeline | undefined; codec: { setVia(via: ViaPipeline | undefined): void } }
   const sealAll = defaultPosture?.encryptedAtRest === 'sealed'
   const needsTaintBinding = sealFields.size > 0 || virtualExportRedact.size > 0 || sealAll
+  // #642 Fix wave 1 — strip a PRIOR 'taint' binding before (maybe) appending a fresh one: a
+  // base config compiled by `compileViaBindings` never carries 'taint' itself (only this
+  // function ever constructs one), so any 'taint' entry already on `c.via.bindings` is a
+  // leftover from an earlier `applyTaintOverlay` call on THIS SAME collection (fresh-open +
+  // every `reapplyDependentOverlays` refresh) — without stripping it first, each re-apply
+  // accumulated one more binding onto the list (harmless in effect, since every lookup only
+  // ever consults the LAST match, but unbounded and wrong).
+  const existingBindings = (c.via?.bindings ?? []).filter((b) => b.brand !== 'taint')
   const bindings = needsTaintBinding
-    ? [...(c.via?.bindings ?? []), taintBinding(sealFields, virtualExportRedact, sealAll)]
-    : (c.via?.bindings ?? [])
+    ? [...existingBindings, taintBinding(sealFields, virtualExportRedact, sealAll)]
+    : existingBindings
   const taint: ViaTaintOverlay = {
     postures: postures ?? EMPTY_POSTURE_MAP, sealFields, provenance,
     ...(defaultPosture !== undefined ? { defaultPosture } : {}),

--- a/packages/hub/src/kernel/via-graph.ts
+++ b/packages/hub/src/kernel/via-graph.ts
@@ -45,6 +45,24 @@ export function foldPosture(a: ViaPosture, b: ViaPosture): ViaPosture {
   }
 }
 
+/** Security-axes-only fold for a wildcard collection node (#642): sealed-wins encryptedAtRest,
+ *  AND exportable, OR forgettable — queryable is NOT folded (stays base.queryable; the sealed
+ *  clamp to 'none' is buildTaintOverlay's job, so inheriting `sealed` never over-restricts a
+ *  blob-adjacent output to unqueryable). Pure; exported for unit testing. Distinct from
+ *  {@link foldPosture} (which folds all four axes) — do NOT reuse foldPosture here. */
+export function foldWildcardSecurity(base: ViaPosture, contributor: ViaPosture): ViaPosture {
+  return {
+    encryptedAtRest: base.encryptedAtRest === 'sealed' || contributor.encryptedAtRest === 'sealed' ? 'sealed' : 'envelope',
+    queryable: base.queryable,
+    exportable: base.exportable && contributor.exportable,
+    forgettable: base.forgettable || contributor.forgettable,
+  }
+}
+
+// the folded formula kinds a '*' source contributes its collection-fold to (ref keeps identity):
+type FoldedKind = 'derivation' | 'rollup' | 'mv' | 'overlay'
+const FOLDED_KINDS: ReadonlySet<EdgeKind> = new Set<FoldedKind>(['derivation', 'rollup', 'mv', 'overlay'])
+
 /** Whether `p` is exactly the plain, non-taint baseline (Task 3 — `taintProvenance`). */
 function isDefaultPosture(p: ViaPosture): boolean {
   return p.encryptedAtRest === DEFAULT_POSTURE.encryptedAtRest && p.queryable === DEFAULT_POSTURE.queryable &&
@@ -89,6 +107,11 @@ export class ViaGraph {
   private readonly _out = new Map<string, FieldRef[]>()
   /** Memoized effective posture per derived target node id. */
   private readonly _effectiveCache = new Map<string, ViaPosture>()
+  /** Memoized whole-collection security-axes fold for `'*'` wildcard LEAF nodes (#642),
+   *  keyed by collection name — see {@link _wildcardContribution}. Cleared alongside
+   *  `_effectiveCache` on every `registerField`/`registerDerived` (a later-registered
+   *  field must re-fold on the next read — registration ordering is free). */
+  private readonly _wildcardCache = new Map<string, ViaPosture>()
   /** Collections with at least one classified field (#638 Task 2 fix wave 2,
    *  Finding I1 — the reconcile path's combined-state leak guard memory). */
   private readonly _classifiedCollections = new Set<string>()
@@ -105,6 +128,7 @@ export class ViaGraph {
     if (this._posture.has(id)) return
     this._posture.set(id, posture)
     this._effectiveCache.clear()
+    this._wildcardCache.clear()
   }
 
   /** A derived target depends on `sources` (may be cross-collection). `kind`/`grain`
@@ -126,6 +150,7 @@ export class ViaGraph {
       else this._out.set(sourceId, [target])
     }
     this._effectiveCache.clear()
+    this._wildcardCache.clear()
   }
 
   /** Whether `target` already has a registered in-edge — lets a caller skip
@@ -192,11 +217,43 @@ export class ViaGraph {
     return this._posture.get(id) ?? DEFAULT_POSTURE
   }
 
-  /** A node's posture contribution when folded into a dependent: recurse if it is
-   *  itself derived, else its declared/default posture. */
-  private _contribution(id: string): ViaPosture {
+  /** A node's posture contribution when folded into a dependent: recurse if it is itself
+   *  derived; else its declared/default posture — UNLESS it is a `'*'` LEAF node consumed
+   *  by a folded formula kind (#642, `derivation|rollup|mv|overlay`), in which case it
+   *  contributes its collection's whole-record security fold ({@link _wildcardContribution}).
+   *  `kind` is the CONSUMING edge's kind, threaded from {@link _computeEffective}. `'ref'`
+   *  edges (and the provenance-only untyped call, `kind` left `undefined`) keep `'*'` =
+   *  identity — the phase-D lookup reliance (`shape/via-lookup/registry.ts:392-397`) that a
+   *  referencing field must not seal just because its dimension collection has a classified
+   *  column. */
+  private _contribution(id: string, kind?: EdgeKind): ViaPosture {
     const edge = this._in.get(id)
-    return edge ? this._computeEffective(id, edge) : this._declaredPosture(id)
+    if (edge) return this._computeEffective(id, edge)
+    if (kind !== undefined && FOLDED_KINDS.has(kind) && id.endsWith(`${SEP}*`)) {
+      return this._wildcardContribution(id.slice(0, -2))
+    }
+    return this._declaredPosture(id)
+  }
+
+  /** Lazy fold (#642) of a collection's REGISTERED field postures on the security axes only
+   *  ({@link foldWildcardSecurity} — sealed-wins encryptedAtRest, AND exportable, OR
+   *  forgettable; queryable stays at DEFAULT_POSTURE's 'full', never folded), seeded at
+   *  DEFAULT_POSTURE. This is the collection-level posture a `'*'` LEAF node contributes to a
+   *  folded-kind formula edge (derivation/rollup/mv/overlay) — see {@link _contribution}. A
+   *  plain (unregistered) field contributes nothing (the identity), so the fold is strictly
+   *  more conservative than deps-based taint and never hits the KNOWN-LIMIT wall (it names no
+   *  fields — seam map §1d). Memoized per collection in `_wildcardCache`. */
+  private _wildcardContribution(collection: string): ViaPosture {
+    const cached = this._wildcardCache.get(collection)
+    if (cached) return cached
+    let result = DEFAULT_POSTURE
+    const prefix = `${collection}${SEP}`
+    for (const [id, posture] of this._posture) {
+      if (!id.startsWith(prefix) || id === `${prefix}*`) continue
+      result = foldWildcardSecurity(result, posture)
+    }
+    this._wildcardCache.set(collection, result)
+    return result
   }
 
   private _computeEffective(id: string, edge: DerivedEdge): ViaPosture {
@@ -204,7 +261,7 @@ export class ViaGraph {
     if (cached) return cached
     let result = DEFAULT_POSTURE
     for (const source of edge.sources) {
-      result = foldPosture(result, this._contribution(nodeId(source)))
+      result = foldPosture(result, this._contribution(nodeId(source), edge.kind))
     }
     // #638 Task 7 — a virtual field is computed fresh on every read and never
     // stored, so it is structurally unqueryable regardless of what its

--- a/packages/hub/src/kernel/via-pipeline.ts
+++ b/packages/hub/src/kernel/via-pipeline.ts
@@ -20,15 +20,21 @@ export interface ViaTaintOverlay {
   readonly postures: ReadonlyMap<string, ViaPosture>
   readonly sealFields: ReadonlySet<string>
   readonly provenance?: ReadonlyMap<string, readonly string[]>
+  /** #642 — the whole-record floor for a derivation/MV/overlay OUTPUT collection (the '*' target's
+   *  folded, clamped effective posture). postureFor falls back to it for ANY field; redactForExport
+   *  picks it up per-field; a sealed default drives taintBinding's sealAllFields mode. O(1) read. */
+  readonly defaultPosture?: ViaPosture
 }
 
 export class ViaPipeline {
   private constructor(readonly bindings: readonly ViaBinding[], readonly taint?: ViaTaintOverlay) {}
 
   /** undefined when there is nothing to enforce — the zero-via fast path is
-   *  `this.via === undefined` (#553: keeps an all-plain collection sync). */
+   *  `this.via === undefined` (#553: keeps an all-plain collection sync). A
+   *  `'*'`-defaulted output collection (#642) counts as "something to enforce"
+   *  even with zero field-specific postures and zero bindings. */
   static build(bindings: readonly ViaBinding[], taint?: ViaTaintOverlay): ViaPipeline | undefined {
-    if (bindings.length === 0 && (!taint || taint.postures.size === 0)) return undefined
+    if (bindings.length === 0 && (!taint || (taint.postures.size === 0 && taint.defaultPosture === undefined))) return undefined
     return new ViaPipeline(bindings, taint)
   }
 
@@ -168,7 +174,9 @@ export class ViaPipeline {
     for (const b of this.bindings) {
       if (b.covers?.(field)) return b.posture
     }
-    return undefined
+    // #642 — a '*'-defaulted output collection's whole-record floor: O(1) read,
+    // no fold (the fold ran once at applyTaintOverlay/reapply time).
+    return this.taint?.defaultPosture
   }
 
   /**

--- a/packages/hub/src/kernel/via-taint-binding.ts
+++ b/packages/hub/src/kernel/via-taint-binding.ts
@@ -127,6 +127,55 @@ async function decodeTaintAtRest(
 }
 
 /**
+ * #642 `sealAllFields` mode — seal EVERY own field carrying a defined value,
+ * except reserved/internal keys (`_`-prefixed, e.g. `_derivedFrom` — the
+ * derivation/MV output provenance tag, which must stay a plain metadata
+ * object, never sealed). Mirrors {@link encodeTaintAtRest} but iterates
+ * `Object.keys(record)` instead of a fixed field list — a `'*'`-defaulted
+ * output collection's field names are runtime `derive()` products, unknown
+ * at declare time.
+ */
+async function encodeTaintAtRestAll(
+  record: Record<string, unknown>,
+  crypto: ViaCryptoCtx,
+): Promise<{ record: Record<string, unknown>; sealed?: Record<string, SealedSlotRef> }> {
+  let open = record
+  let sealed: Record<string, SealedSlotRef> | undefined
+  for (const field of Object.keys(record)) {
+    if (field.startsWith('_')) continue
+    const value = record[field]
+    if (value === undefined) continue
+    const ref = await crypto.sealedSlots.seal(field, value)
+    if (open === record) open = { ...record }
+    delete open[field]
+    sealed ??= {}
+    sealed[field] = ref
+  }
+  return sealed ? { record: open, sealed } : { record }
+}
+
+/**
+ * #642 `sealAllFields` mode — restore every key PRESENT IN THE RECORD'S OWN
+ * `sealed` map (no fixed field list to consult — the field set is whatever
+ * {@link encodeTaintAtRestAll} actually sealed for this particular record).
+ */
+async function decodeTaintAtRestAll(
+  record: Record<string, unknown>,
+  sealed: Record<string, SealedSlotRef>,
+  crypto: ViaCryptoCtx,
+  opts: { asHandles: boolean },
+): Promise<Record<string, unknown>> {
+  let out = record
+  for (const [field, ref] of Object.entries(sealed)) {
+    if (out === record) out = { ...record }
+    out[field] = opts.asHandles
+      ? new SealedHandle(() => crypto.sealedSlots.unseal(field, ref))
+      : await crypto.sealedSlots.unseal(field, ref)
+  }
+  return out
+}
+
+/**
  * The `taint` binding: seals `sealFields` at rest via `ctx.sealedSlots`,
  * presenting them as sealed handles on read — exactly as classified does,
  * reusing the same phase-B capability. `covers` = membership in `sealFields`
@@ -156,18 +205,30 @@ async function decodeTaintAtRest(
  * field (no materialized-sealed field) must NOT flip
  * `ViaPipeline.hasAtRestHooks`, which would wrongly route it onto the async
  * at-rest-hook codec path for nothing to seal.
+ *
+ * `sealAllFields` (#642, default `false`) — whole-record seal for a
+ * `'*'`-defaulted derivation/MV/overlay OUTPUT collection: `covers` claims
+ * every non-`_`-prefixed field, and `encodeAtRest`/`decodeAtRest` route
+ * through {@link encodeTaintAtRestAll}/{@link decodeTaintAtRestAll} instead
+ * of the fixed `sealFields` list (moot in this mode — sealing everything is
+ * already a superset of any field-specific taint on the same collection).
  */
-export function taintBinding(sealFields: ReadonlySet<string>, presentRedactFields: ReadonlySet<string> = EMPTY_STRING_SET): ViaBinding {
+export function taintBinding(
+  sealFields: ReadonlySet<string>,
+  presentRedactFields: ReadonlySet<string> = EMPTY_STRING_SET,
+  sealAllFields = false,
+): ViaBinding {
   const fields = [...sealFields]
   const redactFields = [...presentRedactFields]
   return {
     brand: 'taint',
     posture: { encryptedAtRest: 'sealed', queryable: 'none', exportable: false, forgettable: true },
-    covers: (field) => sealFields.has(field) || presentRedactFields.has(field),
-    ...(fields.length > 0 ? {
-      encodeAtRest: (record: Record<string, unknown>, crypto: ViaCryptoCtx) => encodeTaintAtRest(record, crypto, fields),
+    covers: (field) => sealAllFields ? !field.startsWith('_') : (sealFields.has(field) || presentRedactFields.has(field)),
+    ...((sealAllFields || fields.length > 0) ? {
+      encodeAtRest: (record: Record<string, unknown>, crypto: ViaCryptoCtx) =>
+        sealAllFields ? encodeTaintAtRestAll(record, crypto) : encodeTaintAtRest(record, crypto, fields),
       decodeAtRest: (record: Record<string, unknown>, sealed: Record<string, SealedSlotRef>, crypto: ViaCryptoCtx, opts: { asHandles: boolean }) =>
-        decodeTaintAtRest(record, sealed, crypto, opts, fields),
+        sealAllFields ? decodeTaintAtRestAll(record, sealed, crypto, opts) : decodeTaintAtRest(record, sealed, crypto, opts, fields),
     } : {}),
     ...(redactFields.length > 0 ? {
       present: (record: Record<string, unknown>) => {

--- a/packages/hub/src/port/with/lookup-strategy.ts
+++ b/packages/hub/src/port/with/lookup-strategy.ts
@@ -37,6 +37,9 @@ import {
   buildLookupAltIndex,
   registerLookupRefEdges,
   buildLookupSnapshotRows,
+  coerceLookupKey,
+  resolveBackingRowKey,
+  matchesReferencingValue,
   type DictReferencingCollection,
   type LookupDictCompat,
   type MaterializedBacking,
@@ -178,6 +181,12 @@ export { registerLookupRefEdges }
 // `JoinableSource.presentForJoin` hook `kernel/query/join.ts` consumes.
 export { buildLookupSnapshotRows, buildPresentForJoin }
 export type { LookupSnapshot } from '../../shape/via-lookup/snapshot.js'
+
+// #651 Task 3 — the ONE descriptor-keyed key-resolution core (guarded coercion +
+// backing-row-key resolve + referencing-value match) — every consumer (vault.ts,
+// with-shape/links/vault-facade.ts, kernel/via-dispatch.ts) routes through here,
+// never a bare `String()`, ending the dm12 dialect drift.
+export { coerceLookupKey, resolveBackingRowKey, matchesReferencingValue }
 
 /** Runtime predicate for detecting a `LookupDescriptor` (any of the three tiers). */
 export function isLookupDescriptor(x: unknown): x is LookupDescriptor {

--- a/packages/hub/src/shape/via-lookup/binding.ts
+++ b/packages/hub/src/shape/via-lookup/binding.ts
@@ -45,8 +45,13 @@ import { buildLookupSnapshot } from './snapshot.js'
 export interface LookupViaConfig {
   readonly lookupFields: Record<string, LookupDescriptor>
   readonly lookupLabelResolver?: (dimension: string, key: string, locale: string, fallback?: unknown) => Promise<string | undefined>
-  /** `dimension -> ((key) => backing row | undefined)` — the matrix (collection) tier's present-time source. */
-  readonly getLookupBacking?: (dimension: string) => ((key: string) => Promise<Record<string, unknown> | undefined>) | undefined
+  /**
+   * The matrix (collection) tier's present-time backing-row source, keyed by the full
+   * descriptor (not a bare dimension name) so the closure can resolve by `descriptor.key`,
+   * not the backing row's PUT-id (#651 Task 3 — the same descriptor-gaining dispatch Task 7
+   * already applied to `snapshotFor`).
+   */
+  readonly getLookupBacking?: (descriptor: LookupDescriptor) => (key: string) => Promise<Record<string, unknown> | undefined>
   /** Closed-vocabulary write-time membership test (#650 Task 3) — `(field, key) => known?`. */
   readonly membership?: (field: string, key: string) => boolean | Promise<boolean>
   /** Sync per-descriptor altKey index — `ingest`'s normalization source (#650 Task 3). */
@@ -89,7 +94,7 @@ async function fetchLookupLabel(
   cfg: LookupViaConfig,
 ): Promise<string | undefined> {
   if (desc.backing === 'collection') {
-    const getRow = cfg.getLookupBacking?.(desc.dimension)
+    const getRow = cfg.getLookupBacking?.(desc)
     const row = getRow ? await getRow(key) : undefined
     const labelField = desc.present?.label
     if (!row || labelField === undefined) return undefined

--- a/packages/hub/src/shape/via-lookup/registry.ts
+++ b/packages/hub/src/shape/via-lookup/registry.ts
@@ -273,6 +273,8 @@ export interface MaterializedBacking {
  * the CHE/SWZ drift class: two different rows must never claim the same
  * candidate key). `rows` is keyed by canonical key (`row[descriptor.key]`
  * for the matrix tier; the dimension's own key for static/reserved).
+ * An altKey candidate VALUE may be a string or number — both normalize via
+ * `coerceLookupKey` (#651 Task 3); non-scalar/absent values are skipped.
  * Pure — no I/O. Throws `ValidationError` on collision.
  */
 export function materializeBackingTable(

--- a/packages/hub/src/shape/via-lookup/registry.ts
+++ b/packages/hub/src/shape/via-lookup/registry.ts
@@ -289,8 +289,8 @@ export function materializeBackingTable(
   const altFields = descriptor.altKeys ?? []
   for (const [canonicalKey, row] of rows) {
     for (const altField of altFields) {
-      const value = row[altField]
-      if (typeof value !== 'string' || value === '') continue
+      const value = coerceLookupKey(row[altField])
+      if (value === undefined || value === '') continue
       const existingOwner = owner.get(value)
       if (existingOwner !== undefined && existingOwner !== canonicalKey) {
         throw new ValidationError(
@@ -336,6 +336,46 @@ export function checkLookupMembership(
 }
 
 /**
+ * The ONE guarded key coercion (#651 Task 3, dm12) — string/number values
+ * coerce to their canonical `String()` form; everything else (`null`,
+ * `undefined`, objects, …) coerces to `undefined`. Every consumer that turns
+ * a raw record field into a lookup key routes through this, closing the
+ * bare-`String()` `"undefined"`/`"null"`-key poisoning class (seam map
+ * finding 6): a row whose key field is genuinely absent must never mint the
+ * literal candidate string `"undefined"`.
+ */
+export function coerceLookupKey(raw: unknown): string | undefined {
+  return typeof raw === 'string' || typeof raw === 'number' ? String(raw) : undefined
+}
+
+/**
+ * Resolve a backing row's canonical key VALUE — `coerceLookupKey(row[descriptor.key])`
+ * (#651 Task 3). The matrix tier's `row[descriptor.key]`, never the row's own PUT-id
+ * when the two differ (`descriptor.key !== 'id'`).
+ */
+export function resolveBackingRowKey(
+  descriptor: LookupDescriptor,
+  row: Record<string, unknown>,
+): string | undefined {
+  return coerceLookupKey(row[descriptor.key])
+}
+
+/**
+ * The referencing-side match predicate — does `rec[field]` (coerced) equal an
+ * already-coerced `compareKey` (#651 Task 3)? Shared by every site that scans a
+ * referencing collection for rows pointing at a given backing key
+ * (`with-shape/links/vault-facade.ts`'s ref-delete propagation, `kernel/via-dispatch.ts`'s
+ * forget-fanout twin).
+ */
+export function matchesReferencingValue(
+  rec: Record<string, unknown>,
+  field: string,
+  compareKey: string,
+): boolean {
+  return coerceLookupKey(rec[field]) === compareKey
+}
+
+/**
  * Materialize a lookup dimension's altKey index from whatever backing data
  * is synchronously available (#650 Task 3 — the `ingest` source). Static:
  * the in-config table. Reserved: the reserved handle's live write-through
@@ -347,6 +387,9 @@ export function checkLookupMembership(
  * existing join precedent, a dimension collection this vault session has
  * not yet opened/populated sees an empty snapshot (no altKey normalization
  * until it has rows) — open/populate it first for normalization to apply.
+ * A matrix row whose `descriptor.key` field coerces to `undefined` (missing/
+ * non-scalar) is SKIPPED — never enters the index under a poisoned
+ * `"undefined"` key (#651 Task 3, dm12).
  */
 export function buildLookupAltIndex(
   descriptor: LookupDescriptor,
@@ -361,15 +404,13 @@ export function buildLookupAltIndex(
     return materializeBackingTable(descriptor, new Map(entries.map((e) => [String(e['key']), e])))
   }
   const rows = getCollection(descriptor.dimension).querySourceForJoin().snapshot()
-  return materializeBackingTable(
-    descriptor,
-    new Map(
-      rows.map((r) => {
-        const row = r as Record<string, unknown>
-        return [String(row[descriptor.key]), row] as const
-      }),
-    ),
-  )
+  const keyed = new Map<string, Record<string, unknown>>()
+  for (const r of rows) {
+    const row = r as Record<string, unknown>
+    const key = resolveBackingRowKey(descriptor, row)
+    if (key !== undefined) keyed.set(key, row)
+  }
+  return materializeBackingTable(descriptor, keyed)
 }
 
 /** One cross-collection `'ref'` graph edge a lookup field declares (#650 Task 5). Module-private —
@@ -448,10 +489,11 @@ export function registerLookupRefEdges(
  * - **collection** (matrix): rows come from `getCollection(dimension).
  *   querySourceForJoin().snapshot()` — the SAME sync, already-live cache
  *   `buildLookupAltIndex`'s matrix branch (above, this file) and `.join()`
- *   itself already read — re-keyed by `String(row[descriptor.key])`, NOT
- *   the row's own PUT-id (which may differ when `key !== 'id'`; the exact
+ *   itself already read — re-keyed via `resolveBackingRowKey(descriptor, row)`,
+ *   NOT the row's own PUT-id (which may differ when `key !== 'id'`; the exact
  *   distinction the #650 Task 3 review fix already applies to
- *   `checkLookupMembership`'s matrix branch).
+ *   `checkLookupMembership`'s matrix branch). A row whose `descriptor.key`
+ *   field coerces to `undefined` is skipped (#651 Task 3, dm12).
  * - **static**: never routed here — `descriptor.table` is read directly by
  *   the caller (`binding.ts`'s `compareLookupOrder`/`resolveLookupOrderLabel`,
  *   `snapshot.ts`'s `presentLookupForJoin`); no vault call needed.
@@ -479,7 +521,8 @@ export function buildLookupSnapshotRows(
     const rows = new Map<string, Record<string, unknown>>()
     for (const r of rawRows) {
       const row = r as Record<string, unknown>
-      rows.set(String(row[descriptor.key]), row)
+      const key = resolveBackingRowKey(descriptor, row)
+      if (key !== undefined) rows.set(key, row)
     }
     return rows
   }

--- a/packages/hub/src/with-party/team/sync.ts
+++ b/packages/hub/src/with-party/team/sync.ts
@@ -61,11 +61,13 @@ export class SyncEngine {
    */
   private pairExpander?: (names: readonly string[]) => readonly string[]
 
-  /** #598: refreshes Collection in-memory views after a sync-applied local write. Wired by the vault at open. */
-  private cacheInvalidator?: (collection: string, id: string) => Promise<void>
+  /** #598: refreshes Collection in-memory views after a sync-applied local write. Wired by the
+   *  vault at open. `action` (#640): `'delete'` for a pulled tombstone/delete-marker, `'put'`
+   *  otherwise — classified at `applyRemote`, the one choke point that holds the envelope. */
+  private cacheInvalidator?: (collection: string, id: string, action: 'put' | 'delete') => Promise<void>
 
   /** Wire the Collection-cache invalidation hook (#598). Same injection pattern as `setPairExpander`. */
-  setCacheInvalidator(fn: (collection: string, id: string) => Promise<void>): void {
+  setCacheInvalidator(fn: (collection: string, id: string, action: 'put' | 'delete') => Promise<void>): void {
     this.cacheInvalidator = fn
   }
 
@@ -330,8 +332,14 @@ export class SyncEngine {
     }
 
     this.lastPush = new Date().toISOString()
-    await this.persistMeta()
-    await this.graphBatchController?.flush() // #638 Task 4
+    try {
+      await this.persistMeta()
+    } finally {
+      // #644 item 1: flush (which clears `_graphBatch` unconditionally, vault.ts:1316-1320) must
+      // run even if `persistMeta()` throws — else a throw here leaves the batch open, corrupting
+      // the NEXT pull()/push() call's wave with THIS call's stale touches.
+      await this.graphBatchController?.flush() // #638 Task 4
+    }
 
     const result: PushResult = { pushed, conflicts, errors, erasures }
     this.emitter.emit('sync:push', result)
@@ -530,8 +538,12 @@ export class SyncEngine {
     }
 
     this.lastPull = new Date().toISOString()
-    await this.persistMeta()
-    await this.graphBatchController?.flush() // #638 Task 4
+    try {
+      await this.persistMeta()
+    } finally {
+      // #644 item 1: flush must run even if `persistMeta()` throws (see push()'s identical guard).
+      await this.graphBatchController?.flush() // #638 Task 4
+    }
 
     const result: PullResult = { pulled, conflicts, errors, erasures }
     this.emitter.emit('sync:pull', result)
@@ -724,10 +736,16 @@ export class SyncEngine {
     this.emitter.emit('sync:offline', undefined as never)
   }
 
-  /** Apply an envelope to the local store and refresh in-memory views (#598). */
+  /** Apply an envelope to the local store and refresh in-memory views (#598). `action` (#640):
+   *  classified HERE — the one choke point that still holds the envelope — so the
+   *  cacheInvalidator seam (and, downstream, the dispatch wave) can tell a pulled delete from an
+   *  ordinary put. `isTombstoneShape` covers a forgotten-elsewhere record arriving as a shred;
+   *  `isDeleteMarker` covers an ordinary (#589) delete — both route to the SAME 'delete' action
+   *  (sync delete ≠ forget: freshness only, no shred/residue channel on the receiving side). */
   private async applyRemote(collection: string, id: string, envelope: EncryptedEnvelope): Promise<void> {
     await this.local.put(this.vault, collection, id, envelope)
-    await this.cacheInvalidator?.(collection, id)
+    const action: 'put' | 'delete' = isTombstoneShape(envelope) || isDeleteMarker(envelope) ? 'delete' : 'put'
+    await this.cacheInvalidator?.(collection, id, action)
   }
 
   /** Record + emit a tombstone enforcement (#590). */

--- a/packages/hub/src/with-shape/links/vault-facade.ts
+++ b/packages/hub/src/with-shape/links/vault-facade.ts
@@ -30,7 +30,8 @@ import type { Collection } from '../../kernel/collection.js'
 import type { NoydbStore } from '../../kernel/types.js'
 import type { TxContext } from '../../with-commit/tx/transaction.js'
 import type { ViaGraph } from '../../kernel/via-graph.js'
-import { DictKeyInUseError } from '../../kernel/errors.js'
+import type { NoydbEventEmitter } from '../../kernel/events.js'
+import { DictKeyInUseError, RestrictRefUnresolvableError } from '../../kernel/errors.js'
 import { coerceLookupKey, matchesReferencingValue } from '../../port/with/lookup-strategy.js'
 
 /** Everything the moving refs/links methods touched on the vault's `this.*`. */
@@ -51,6 +52,8 @@ export interface VaultLinksDeps {
   getCachedCollection(name: string): Collection<unknown> | undefined
   /** The active transaction context, or null outside a tx. */
   getActiveTxContext(): TxContext | null
+  /** The vault's event emitter — the `lookup:propagation-residue` channel (#654). */
+  readonly emitter: NoydbEventEmitter
 }
 
 export class VaultLinks {
@@ -313,14 +316,24 @@ export class VaultLinks {
    * nullify propagation runs AFTER `_writeTombstone`, when a non-`'id'` `keyField`'s value can no
    * longer be read off the (now-shredded) row — resolving it HERE, at the one point every
    * referencing edge's backing row is still guaranteed live, eliminates that post-shred
-   * dependency. A `keyField` this can't resolve (row unreadable) maps to `undefined` in the
-   * returned map so the caller can report it as residue instead of silently skipping the edge.
+   * dependency.
+   *
+   * #654: a `restrict` edge whose compare-key CANNOT be resolved (the backing row is missing the
+   * `keyField` or holds a non-scalar value — corruption-class rarity) THROWS
+   * `RestrictRefUnresolvableError` naming the unresolvable edge, fail-closed — whether a
+   * referencer exists can't be proven, so the delete/forget is refused rather than silently
+   * allowed through. Non-restrict edges keep `continue`ing on an unresolvable compare-key (their
+   * `undefined` still lands in the returned map so `forgetDerivedFanout`'s cascade/nullify twin
+   * can report it as residue instead of silently skipping — unchanged from before #654).
    */
   async checkLookupRefsRestrict(graph: ViaGraph, dimension: string, backingCollection: string, key: string): Promise<ReadonlyMap<string, string | undefined>> {
     const keyCache = new Map<string, string | undefined>()
     for (const { referencing, onDelete, keyField } of graph.referencingEdgesOf(backingCollection)) {
       const compareKey = await this.resolveLookupCompareKey(backingCollection, key, keyField, keyCache)
-      if (onDelete !== 'restrict' || compareKey === undefined) continue
+      if (onDelete !== 'restrict') continue
+      if (compareKey === undefined) {
+        throw new RestrictRefUnresolvableError(dimension, key, `${referencing.collection}.${referencing.field}`)
+      }
       const coll = this.deps.collection<Record<string, unknown>>(referencing.collection)
       const matches = await this.findLookupReferencingRecords(coll, referencing.field, compareKey)
       if (matches.length > 0) {
@@ -338,15 +351,24 @@ export class VaultLinks {
    * the graph dispatch wave exactly like any other delete); `nullify` clears the referencing field
    * via an ordinary `collection.put()`. Returns the counts so callers (forget's `ForgetFanoutStats`)
    * can report the propagation additively.
+   *
+   * #654: an edge whose compare-key can't be resolved is no longer a bare silent `continue` — it
+   * pushes a `backing:key:collection.field` entry onto `residue` (mirroring
+   * `applyLookupRefsFanout`'s forget-path residue format, `kernel/via-dispatch.ts`) so the caller
+   * (`enforceLookupRefsOnDelete` below) can surface it instead of dropping it on the floor.
    */
-  async applyLookupRefsPropagation(graph: ViaGraph, backingCollection: string, key: string): Promise<{ cascaded: number; nullified: number }> {
+  async applyLookupRefsPropagation(graph: ViaGraph, backingCollection: string, key: string): Promise<{ cascaded: number; nullified: number; residue: string[] }> {
     let cascaded = 0
     let nullified = 0
+    const residue: string[] = []
     const keyCache = new Map<string, string | undefined>()
     for (const { referencing, onDelete, keyField } of graph.referencingEdgesOf(backingCollection)) {
       if (onDelete === 'restrict') continue
       const compareKey = await this.resolveLookupCompareKey(backingCollection, key, keyField, keyCache)
-      if (compareKey === undefined) continue
+      if (compareKey === undefined) {
+        residue.push(`${backingCollection}:${key}:${referencing.collection}.${referencing.field}`)
+        continue
+      }
       const coll = this.deps.collection<Record<string, unknown>>(referencing.collection)
       const matches = await this.findLookupReferencingRecords(coll, referencing.field, compareKey)
       for (const rec of matches) {
@@ -361,7 +383,7 @@ export class VaultLinks {
         }
       }
     }
-    return { cascaded, nullified }
+    return { cascaded, nullified, residue }
   }
 
   /**
@@ -369,10 +391,19 @@ export class VaultLinks {
    * a lookup-referenced row — `checkLookupRefsRestrict` then `applyLookupRefsPropagation`. Used by
    * `enforceRefsOnDelete` above (matrix-tier: the backing row IS an ordinary `Collection` record)
    * and by `LookupHandle.delete()`'s injected `checkReferencesOnDelete` callback (reserved tier).
+   *
+   * #654: when `applyLookupRefsPropagation` reports residue, it is emitted here as a structured
+   * `lookup:propagation-residue` event — the delete/put return shape both callers consume stays
+   * `void`/unrelated, so an event is the additive channel that keeps the skip from ever being
+   * silent (mirrors the forget path's `ForgetResult.lookupReferencesResidue` channel).
    */
-  async enforceLookupRefsOnDelete(graph: ViaGraph, dimension: string, backingCollection: string, key: string): Promise<{ cascaded: number; nullified: number }> {
+  async enforceLookupRefsOnDelete(graph: ViaGraph, dimension: string, backingCollection: string, key: string): Promise<{ cascaded: number; nullified: number; residue: string[] }> {
     await this.checkLookupRefsRestrict(graph, dimension, backingCollection, key)
-    return this.applyLookupRefsPropagation(graph, backingCollection, key)
+    const result = await this.applyLookupRefsPropagation(graph, backingCollection, key)
+    if (result.residue.length > 0) {
+      this.deps.emitter.emit('lookup:propagation-residue', { vault: this.deps.vault, dimension, key, residue: result.residue })
+    }
+    return result
   }
 
   /**

--- a/packages/hub/src/with-shape/links/vault-facade.ts
+++ b/packages/hub/src/with-shape/links/vault-facade.ts
@@ -31,6 +31,7 @@ import type { NoydbStore } from '../../kernel/types.js'
 import type { TxContext } from '../../with-commit/tx/transaction.js'
 import type { ViaGraph } from '../../kernel/via-graph.js'
 import { DictKeyInUseError } from '../../kernel/errors.js'
+import { coerceLookupKey, matchesReferencingValue } from '../../port/with/lookup-strategy.js'
 
 /** Everything the moving refs/links methods touched on the vault's `this.*`. */
 export interface VaultLinksDeps {
@@ -270,7 +271,7 @@ export class VaultLinks {
     key: string,
   ): Promise<Record<string, unknown>[]> {
     const all = await collection.list()
-    return all.filter((rec) => String(rec[field]) === key)
+    return all.filter((rec) => matchesReferencingValue(rec, field, key))
   }
 
   /**
@@ -292,8 +293,7 @@ export class VaultLinks {
     if (keyField === 'id') return rawKey
     if (cache.has(keyField)) return cache.get(keyField)
     const row = await this.deps.collection<Record<string, unknown>>(backingCollection).get(rawKey)
-    const raw = row?.[keyField]
-    const resolved = typeof raw === 'string' || typeof raw === 'number' ? String(raw) : undefined
+    const resolved = coerceLookupKey(row?.[keyField])
     cache.set(keyField, resolved)
     return resolved
   }

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -725,7 +725,14 @@ const KERNEL_SURFACE_BUDGET = {
   // to carry left the kernel spine for the shape/via-* feature layer. Locked
   // in to the ACTUAL measured line count (readFileSync(...).split('\n').length)
   // — no slack.
-  'packages/hub/src/kernel/collection.ts': 4473,
+  // Lowered 4473→4472 (2026-07-13, via-consolidation Task 6 final re-ratchet,
+  // #642/#651/#640/#654): the arc's Task 5 fix wave landed the file 1 line
+  // UNDER ceiling (the #640 rollup-on-delete work funded its own growth via
+  // shrink-first folds) and no later task in the arc touched this file —
+  // ratcheting the ceiling down to the actual per the checker's own
+  // ratchet-to-actual convention, so the margin isn't silently carried
+  // forward as slack for an unrelated future change.
+  'packages/hub/src/kernel/collection.ts': 4472,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -956,7 +963,14 @@ const KERNEL_SURFACE_BUDGET = {
   // spent and is removed here per the checker's ratchet-to-actual
   // convention (phase D's final task). Locked in to the ACTUAL measured
   // line count (readFileSync(...).split('\n').length) — no slack.
-  'packages/hub/src/kernel/vault.ts': 3940,
+  // Lowered 3940→3939 (2026-07-13, via-consolidation Task 6 final re-ratchet,
+  // #642/#651/#640/#654): the arc's Task 2 fix wave (#642) funded its
+  // `reapplyDependentOverlays` call by collapsing an adjacent `if` block,
+  // landing the file 1 line UNDER ceiling; Task 3 (#651) and Task 4 (#654)
+  // each landed net-zero edits back at that same actual, never spending the
+  // margin. Ratcheting down to the actual per the checker's ratchet-to-actual
+  // convention, same reasoning as collection.ts above.
+  'packages/hub/src/kernel/vault.ts': 3939,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),


### PR DESCRIPTION
Via consolidation pass (milestone #30): four latent gaps surfaced by the phase A–D whole-branch reviews, plus riders on #644 (items 1+3) and #646 (fixture discipline). Spec: `docs/superpowers/specs/2026-07-12-via-consolidation-design.md` · Plan: `docs/superpowers/plans/2026-07-12-via-consolidation.md`.

Closes #642
Closes #651
Closes #654
Closes #640

## What ships

### #642 — formula outputs derived from classified-bearing collections are sealed by default (BEHAVIOR CHANGE)

#636/#638 closed the leak for a `computed` field's own declared `deps`; a with-formula edge (derivation/rollup/MV) still folded its posture from the source's whole-record `'*'` node, which always fell back to max-permissive — so a derive/rollup/MV `fn` that copied a classified field's plaintext landed it UNSEALED in the output. Now:

- `foldWildcardSecurity` — a lazy, kind-scoped `'*'` fold (derivation/rollup/mv/overlay only; `ref`/`computed` keep identity) on the security axes: `encryptedAtRest` sealed-wins, `exportable` ANDs, `forgettable` ORs; `queryable` is never folded directly (sealed inheritance triggers the existing honest clamp).
- **Rollup targets** (real fields) inherit through the existing field-specific taint overlay; **derivation/MV/overlay output collections** (`'*'` targets) gain a collection-level `defaultPosture` that seals every non-`_`-prefixed field of the output record.
- A lookup-referencing field never seals just because its backing dimension has a classified column (`ref` excluded from the fold) — the countries-matrix recipe stays byte-identical.
- **No migration**: ratified — pre-1.0, no shipped consumer reads a formula output today. Explicit declassification is deferred to phase E.

Landing this detonated three pre-existing latent bugs in the at-rest cache layer (all gated on local `sensitiveFields` being non-empty, which was always true until a taint-only-sealed collection became reachable): `RecordCodec.toCacheRecord` (write-then-get returned cached plaintext instead of a `SealedHandle`), and `Collection.resolvePriorValues` + the `_getStoredRecord` lazy branch (both broke the rollup self-write cycle-termination guard — an **infinite write loop**). The first's stale gate is removed outright (the envelope's own `_sealed` presence decides); the other two are gated on `sensitiveFields.size > 0 || via?.hasAtRestHooks === true`.

Known reachability limit (docs note it): an MV over a classified source is structurally unreachable today — every MV refresh mode pre-opens its source at `openVault`, and the classified retro-declare guard then refuses `classifiedFields` on it. The fold covers the MV leg mechanically should that lift (tracked with #658).

### #651 — one canonical key-resolution core

A matrix lookup with `key !== 'id'` resolved its DIRECT (non-join) `<field>Label` read by the backing collection's PUT-id — silently omitting the label for exactly the canonical recipe. `coerceLookupKey`/`resolveBackingRowKey`/`matchesReferencingValue` are now the one shared core all six call sites converge on (snapshot rows, altKey index, membership, compare-key resolution, restrict/propagation matching, `getLookupBacking`'s direct-read closure). Two poisoning classes die: a backing row missing its `descriptor.key` no longer enters the snapshot/altIndex as the literal `"undefined"`; a nullified referencing field no longer coerces to `"null"`/`"undefined"` and spuriously matches. Numeric altKey values normalize through the same core; ownership-uniqueness still collides across the numeric/string boundary.

### #654 — unresolvable restrict edges REFUSE; propagation residue-reports

A `restrict`-mode lookup edge whose compare-key can't be resolved (corrupted backing row) used to `continue` past the check — deleting the row with no proof references don't exist. It now throws the new `RestrictRefUnresolvableError` (root-exported): cannot prove no references ⇒ refuse, the `DictKeyInUseError` reasoning. The `cascade`/`nullify` ordinary-delete twin now reports the skipped edge on a new `lookup:propagation-residue` event instead of silently dropping. The `forget()`-path residue channel is unaffected.

Reachability note: the reserved tier cannot hit the unresolvable-restrict path at all — `dict()` hardcodes `key: 'id'` (always resolvable on a stored row), and the raw-name escape hatch throws `ReservedCollectionNameError` before any edge is registered. The refusal is live for the matrix/collection-backed tier only.

### #640 — sync-applied deletes recompute rollup parents

Previously only a *local* delete triggered `dispatchRollupsOnDelete`; a remotely-deleted child left its parent aggregate stale indefinitely. The sync-apply choke point now classifies each applied envelope as put/delete and threads deleted ids — batched, per-parent-deduped — through the same dispatch wave `pull()`/`push()`/cutover/restore already run, routed to the rollup-recompute path only (mirroring the local-delete boundary; MV/derivation-leg asymmetry tracked as #658).

**Known limit (stated in docs)**: the deleted child's rollup-parent intents resolve from a synchronous pre-invalidation cache peek; a cold/evicted child or an un-hydrated eager collection whose first sync op is the delete misses silently — freshness-only (next sibling write recomputes from scratch; nothing double-counts).

Riders: `push()`/`pull()` flush the graph batch in a `finally` around `persistMeta()` (#644 item 1); both wave legs emit a structured `derivation:wave-error` event alongside the existing `console.warn` (#644 item 3); the new two-instance delete test follows db2-only registration discipline (#646).

## Additive surfaces

`RestrictRefUnresolvableError` (root barrel, golden +1); kernel events `lookup:propagation-residue` and `derivation:wave-error`. `/adapter` and `/cargo` byte-untouched. `Vault.emit` accident caught in-branch and reverted to `_emit` before it ever reached main.

## Review record

6 SDD tasks (implementer + per-task reviewer, opus on the security/hot-path tasks) + fix waves, then a whole-branch review: 4 mutation tests (3 killed surgically; the 1 survivor was a test-gap on `postureFor`'s non-sealed default fallback — pin added in-branch), zero-knowledge sweep clean (GraphBatch is metadata-only; no new crypto doors; closure captures carry no keyring/DEK), full-chain encrypted two-instance live probe (classified + rollup-into-lazy-parent + formula output + lookup-ref: delete→recompute→forget-restrict→cascade with residue accounting, exactly one parent write — the loop class stays dead on the wave path), #553 sync-stack parity and all dict/alias byte-locks green.

Ceilings: collection.ts 4472, vault.ts 3939 (both re-ratcheted DOWN), noydb.ts 2385 — all exact, no bumps.

Changeset: `.changeset/via-consolidation.md` is local per repo convention (hub minor); ships with the next release decision.
