### PR TITLE
feat(hub): milestone-31 completion — late-attach parity, declare-time rollup cycles, computed-first present, bare arrays, indexProbe (#666, #664, #639, #665, #661, #625)

### DIFF
--- a/docs/subsystems/via-computed.md
+++ b/docs/subsystems/via-computed.md
@@ -73,6 +73,40 @@ const viaCol = viaVaultDb.collection<Item>('items', { viaFields: { doubled: via(
 `this.via.encodeWrite` runs — its output merges into the record exactly like user input, so any
 other feature stacked on the same field (money, i18n) applies to it normally.
 
+## Present order (#665) — computed runs before dressing, after money
+
+`present()` is a fold over each collection's compiled `ViaBinding`s. The COMPILE order is fixed
+(money→i18n→lookup→classified→blob→computed, `collection-config.ts:554`), but `present()` folds
+over a separate, present-phase-ONLY order: money bindings first, then computed bindings, then
+everything else (i18n/lookup/classified/blob/taint), each group keeping its existing relative
+order (`ViaPipeline._presentOrder`, `via-pipeline.ts`). This applies to every collection that
+compiles a `'computed'` binding at all — it is a binding-level reorder, not conditioned on any
+particular field composition. Two tradeoffs fall out of this fixed order, both pinned by tests:
+
+- **A virtual computed field can no longer read another field's DRESSING output.** Before #665,
+  computed ran last, so a virtual field's `fn` could legally read an i18n/lookup `<field>Label`
+  or `<field>Formatted` value another binding had just added to the SAME record. After #665,
+  computed (which only PRODUCES values) runs before the dressers (which only ADD a `Label`/
+  `Formatted` key), so that composition silently stops working — the dressing key simply doesn't
+  exist yet when the virtual `fn` runs. This direction (dressing → computed) was never in #665's
+  ratified scope (the scope is computed → dressing, on the SAME field); no shipped collection
+  exercised it before the fix. Pinned as a KNOWN LIMITATION *introduced by* #665 in
+  `packages/hub/__tests__/computed/virtual.test.ts`, describe block `'#665 present-order —
+  second-order effects'`, test `(b)`.
+- **Chained virtual computeds stay declaration-order-sensitive.** `computedBinding.present` loops
+  its `Map` of virtual fields in **declaration order** and mutates the same threaded record as it
+  goes, so a later-declared virtual field's `fn` can read an earlier-declared one's already-set
+  output — entirely internal to the single `'computed'` binding, independent of where that binding
+  sits in the outer present-phase fold, both before and after #665. Declaring the dependency in
+  reverse order (the reader before the field it reads) falls back to whatever sentinel the `fn`
+  handles a missing value with — not a topological sort. Pinned in the same describe block, tests
+  `(a)` (forward declaration order — reads correctly) and `(a2)` (reverse declaration order — known
+  limitation, reads the pre-set sentinel).
+
+**Money is NOT a clean instance of either tradeoff above** — it is the reason `_presentOrder` is a
+three-way (money, computed, rest), not two-way (computed, rest), partition. See the "Composition"
+section below for the value-shape reason money must keep its pre-#665 present position.
+
 ## Composition — `via(computed(...), money(...))`: money formats materialized, not virtual
 
 `compileViaBindings` always runs `computed` **last** in the feature stack (money → i18n →
@@ -278,8 +312,11 @@ documented as "do not depend on this shape") is **removed**, not aliased — fol
   `computed(virtual)` plugs into)
 - [`docs/subsystems/via-classified.md`](via-classified.md) — the classified feature (the usual taint
   *source*)
+- `packages/hub/src/kernel/via-pipeline.ts` — `ViaPipeline._presentOrder` (#665's present-phase-only
+  three-way partition: money, then computed, then everything else)
 - `packages/hub/src/shape/via-computed/` — `computed()`/`ComputedDescriptor`/`computedBinding`
-- `packages/hub/__tests__/computed/virtual.test.ts` — the `mode: 'virtual'` suite (12 tests)
+- `packages/hub/__tests__/computed/virtual.test.ts` — the `mode: 'virtual'` suite (22 tests, incl.
+  the `'#665 present-order — second-order effects'` describe block backing the tradeoffs above)
 - `packages/hub/__tests__/via/computed-binding.test.ts` — the binding unit suite (6 tests)
 - `packages/hub/__tests__/via/taint.test.ts` — the #636 taint-propagation regression suite
 - `packages/hub/__tests__/via/graph-edges.test.ts` — the declare-time guard + reconcile-path suite

--- a/docs/subsystems/via-lookup.md
+++ b/docs/subsystems/via-lookup.md
@@ -133,6 +133,119 @@ has never had a live fallback — it is pure-snapshot for both tiers. The matrix
 path (`<field>Label` resolution, below) is different: it preserves a live cold-session fallback, but
 **only** for the default `key: 'id'` (#651, closed).
 
+## Bare-array fields — element-wise support (#661)
+
+A plain field whose OWN value is an array (`tags: ['USA', '+66']` on `tags: lookup('countries',
+{...})`) is a DIFFERENT shape from the `[].`-wildcard multi-value path above (`'lines[].country'`
+— an array of nested objects). `getAtPath` resolves a bare array to ONE opaque value, not N split
+entries, so both write-time hooks (`ingest`'s altKey normalization, `enforceWrite`'s closed-vocab
+membership check) treat the bare-array shape element-wise, reusing the exact same
+`backing.altIndex`/`cfg.membership` core the scalar and `[].`-wildcard paths already use — no
+parallel coercion path:
+
+```ts
+const orders = vault.collection<Order>('orders', {
+  lookupFields: { tags: lookup('countries', { key: 'iso2', altKeys: ['iso3', 'callPrefix'] }) },
+})
+await orders.put('o1', { id: 'o1', tags: ['USA', '+66'] })
+;(await orders._getStoredRecord('o1'))?.tags   // ['US', 'TH'] — each element normalized
+
+const closed = vault.collection<Order>('orders-closed', {
+  lookupFields: { tags: lookup('countries', { key: 'iso2', vocabulary: 'closed' }) },
+})
+await expect(closed.put('o1', { id: 'o1', tags: ['ZZZ', 'totally-bogus'] }))
+  .rejects.toThrow(UnknownLookupKeyError)   // refuses on the FIRST unknown element
+```
+
+(`packages/hub/__tests__/via/lookup-bare-array.test.ts`). Duplicate elements after normalization
+are kept as-is, not deduped (ingest normalizes values in place — it never changes cardinality, the
+same #652 decision the `[].`-wildcard shape already made); a non-string element (number, object,
+`null`) is skipped in both hooks, mirroring the scalar branch's own skip; an empty array is a
+no-op in both hooks, even under `vocabulary: 'closed'`.
+
+This works identically at a **dotted, non-wildcard path** (`'meta.tags': [...]` for a nested
+`{ meta: { tags: [...] } }` shape) — `getAtPath`/`setAtPathInPlace` (`kernel/paths.ts`) resolve
+dotted paths generically, so no dedicated code is needed for the nested case; the same
+`Array.isArray` branch that handles a top-level `tags` field handles `meta.tags` too:
+
+```ts
+const orders = vault.collection<OrderWithMeta>('orders-meta', {
+  lookupFields: { 'meta.tags': lookup('countries', { key: 'iso2', altKeys: ['iso3', 'callPrefix'] }) },
+})
+await orders.put('o1', { id: 'o1', meta: { tags: ['USA', '+66'] } })
+;(await orders._getStoredRecord('o1'))?.meta   // { tags: ['US', 'TH'] }
+```
+
+(`lookup-bare-array.test.ts`, "at a DOTTED (non-wildcard) path" describe block).
+
+## Late-attach (reconcile) — tier-scoped, #664
+
+`lookupFields`/`i18nFields`/`dictKeyFields` can be declared on a SECOND-OR-LATER
+`vault.collection(name, {...})` call against an already-open collection (a "late attach" /
+"reconcile"), not just at fresh construction. Before #664 this was silently ignored — the fields
+were simply dropped, no error, no effect. `via-reconcile.ts` closes that gap, tier-scoped:
+
+- **enum** (`backing:'static'`, no `table`) / **static** (`+table`) — a clean, self-contained
+  attach: membership/labels come from the declared `keys`/`table` alone, no vault registry touch.
+- **reserved** (`dict()`) — attaches AND additionally wires the same vault registries fresh
+  construction populates (`reservedLookupCollections`/`dictKeyFieldRegistry`), so sync and the
+  reference-graph both see the late-attached field immediately.
+- **matrix** (`backing:'collection'`) — **refuses** with a `ValidationError` naming the field, the
+  backing dimension, and the remedy, unless the backing collection is ALREADY open in this vault
+  session AND prefetch-enabled (`{ prefetch: false }` also refuses, with a different message):
+  ```ts
+  vault.collection<Traveler>('travelers', {})   // no 'countries' opened yet
+  expect(() => vault.collection<Traveler>('travelers', {
+    lookupFields: { country: lookup('countries') },
+  })).toThrow(/matrix field "country".*dimension "countries".*not open/)
+  ```
+  Opening the backing collection first (eager mode, the default) makes the SAME late-attach
+  succeed. (`packages/hub/__tests__/via/reconcile-lookup.test.ts`, "matrix (collection) tier"
+  describe block.)
+
+Closed-vocabulary enforcement, altKey normalization, and `<field>Label` dressing all activate
+LIVE, immediately post-attach — including for records that were written BEFORE the attach (read-
+time dressing/membership are evaluated per-call, not cached at write time). The one true
+future-writes-only limit is normalization/enforcement itself: a record written before the attach
+never ran altKey-ingest or closed-vocab enforceWrite, so its stored value stays whatever it was —
+enforcement is not retroactive. Reference-graph edges (`onDelete: restrict/cascade/nullify`) are
+registered at attach time and are live immediately too — `ViaGraph.referencingEdgesOf` sees them
+the moment the late-attach call returns, no separate wiring needed.
+
+**The #664 collision guard** runs BEFORE any late-attach mutation, for the whole call: an
+incoming field that collides with an ALREADY-declared field of a different via family (e.g.
+late-attaching `lookupFields: { amount: enumOf(...) }` onto a field already owned by
+`moneyFields`) throws `ValidationError` naming the field and both families — no partial attach.
+A single late-attach call may combine `i18nFields`/`dictKeyFields` on one field AND `lookupFields`
+on a DIFFERENT field; both attach from that one call (`reconcile-lookup.test.ts`'s `t8r1` describe
+block pins this against a future dispatch collapse).
+
+**Known limits — three late-attach residuals**, all rooted in the same cause: a handful of
+`Collection` fields (`getDictionary`, `i18nFields`, `dictKeyFields`, `lookupFields`,
+`presentForJoin`) are captured ONCE, at fresh construction, from the constructor's `cfg` — late-
+attach rebuilds the `ViaPipeline` (`coll._setVia`) but has no seam to reassign these separate,
+private-readonly instance fields:
+
+- **`getDictionary`/`resolveDictLabels`** — `collection.describeAsync({ resolveDictLabels: true })`
+  resolves a dynamic dict's live labels via `this.getDictionary`, which stays `undefined` if the
+  collection was constructed with no `dictKeyFields`/`lookupFields` at all (exactly the case a
+  late-attach starts from). A late-attached dict-backed field's labels stay unresolved by
+  `resolveDictLabels: true` — the sync inline-`labels` fallback (if declared) still works.
+- **`describe()`'s top-level field list** — the legacy per-field `type`/`widget`/`dict` derivation
+  (`buildDescription`) reads `this.dictKeyFields`/`this.i18nFields`/`this.lookupFields`, the same
+  construction-time snapshot — a late-attached field may not appear in that top-level list at all
+  (unless the schema also names it). The NEW `.lookup` describeFragment block (`ViaPipeline.
+  describeFragments()`) is unaffected — it folds `_via.bindings` live, so it DOES reflect a
+  late-attached field correctly; only the older list-derivation path is stale.
+- **`presentForJoin`** — captured once from `cfg.presentForJoin` at construction. When a collection
+  is the TARGET of `.join()` (or a matrix-tier lookup's backing dimension), a lookup/i18n field
+  late-attached onto it will not dress `<field>Label` through the join-presentation path, even
+  though it dresses correctly on a DIRECT read of that same collection.
+
+None of these are fixed here — they're recorded as known limits so a late-attach consumer that
+also needs `describeAsync({resolveDictLabels:true})`, a complete `describe()` field list, or
+join-dressing on the late-attached side knows to declare the field at fresh construction instead.
+
 ## Presentation — `<field>Label`, in reads and in joins
 
 Reading with a locale resolves `<field>Label` on the SAME record (direct `present()`, works for
@@ -344,3 +457,7 @@ are EMPTY and still fire on a synthetic violation).
   `lookup-vocabulary.test.ts`, `lookup-ref-semantics.test.ts`, `lookup-forget-ref.test.ts`,
   `lookup-reserved-sync.test.ts`, `lookup-alias-parity.test.ts`, `lookup-extraction-parity.test.ts`,
   `lookup-join-snapshot.test.ts` — the per-tier/per-capability suites
+- `packages/hub/__tests__/via/lookup-bare-array.test.ts` — #661: bare-array element-wise ingest +
+  enforceWrite, top-level and dotted-path shapes
+- `packages/hub/__tests__/via/reconcile-lookup.test.ts` — #664: the late-attach reconcile suite
+  (tier-by-tier attach, matrix refusal, graph edges, collision guard, combined-family attach)

--- a/docs/subsystems/via-money.md
+++ b/docs/subsystems/via-money.md
@@ -66,6 +66,31 @@ their exact BigInt-based equivalents — no floating-point drift. **`avg()` is n
 a money field and throws `MoneyUnsupportedError`; divide `sum()` by `count()` at the boundary
 instead.
 
+### Indexing — the fast path, and an honest mixed-era caveat (#625)
+
+A declared money field indexed via `indexes: [...]` + `indexStrategy: withIndexing()` gets an
+index-accelerated fast path for `where(field, '==', ...)` and `where(field, 'in', ...)` in
+**fixed mode only** — `ViaBinding.indexProbe` hands the query builder the exact STORED-form
+scaled-integer digit string (the same one `quantizeMoneyFields` writes), so the index bucket
+lookup (`CollectionIndexes.lookupEqual`/`lookupIn`) hits directly instead of falling back to a
+full scan. Multi-currency (`currencies:`) fields and every operator besides `==`/`in`
+(`between`, range comparisons) always scan — there is no single stored-form value a hash index
+can serve for those (`packages/hub/__tests__/money/where-comparison.test.ts`, "indexed fast path
+agrees with the scan" describe block, spy-proven against `lookupEqual`/`lookupIn`).
+
+**Honest limit — mixed-era data.** The fast path is byte-exact for every record written through
+the money write path: `quantizeMoneyFields` always produces a canonical BigInt digit string
+(no leading zeros), and the index buckets that exact string. A record whose stored value
+predates the field's `money()` declaration, or otherwise bypassed the money write path, may hold
+a non-canonical scaled string (e.g. `'0100'` instead of `'100'`) — the index buckets it under
+that raw, non-canonical string, so an `==`/`in` probe for the canonical amount misses it, while
+the fallback scan (which re-parses the stored value via `BigInt(actual).toString()`) still
+matches it correctly. In other words: **the indexed fast path returns the canonical subset of
+matches; the scan always returns every match.** A re-`put()` of a legacy record canonicalizes
+its stored form going forward, closing the gap for that record. A money-aware index-key
+canonicalization (bucketing by the BigInt-normalized form rather than the raw stored string)
+would close this gap generally — filed as a follow-up, not implemented here.
+
 ## See also
 
 - [`docs/subsystems/via.md`](via.md) — the Via port (field features, unified pipeline, phases)

--- a/docs/subsystems/via.md
+++ b/docs/subsystems/via.md
@@ -410,7 +410,7 @@ canonical countries-matrix example.
 
 ### Milestone #31 — late-attach parity, cycle detection at declare time
 
-Four follow-up fixes, landed together on one branch, close gaps the phase A-D reviews surfaced.
+Five follow-up fixes, landed together on one branch, close gaps the phase A-D reviews surfaced.
 
 **Late-attach (reconcile) parity for i18n/dictKey/lookup (#664).** A SECOND-OR-LATER
 `vault.collection(name, {...})` call against an already-open collection ("late attach" /

--- a/docs/subsystems/via.md
+++ b/docs/subsystems/via.md
@@ -408,6 +408,81 @@ vocabulary, presentation/join-dressing, sorting, reference semantics, reserved-t
 `describe()` `lookup` block, all backed by `packages/hub/__tests__/via/countries-matrix.test.ts`'s
 canonical countries-matrix example.
 
+### Milestone #31 — late-attach parity, cycle detection at declare time
+
+Four follow-up fixes, landed together on one branch, close gaps the phase A-D reviews surfaced.
+
+**Late-attach (reconcile) parity for i18n/dictKey/lookup (#664).** A SECOND-OR-LATER
+`vault.collection(name, {...})` call against an already-open collection ("late attach" /
+"reconcile") always supported `moneyFields`/`computed`/`fieldMeta`/`meta`/`classifiedFields` — but
+`i18nFields`/`dictKeyFields`/`lookupFields` on that same kind of call were silently ignored before
+this fix, with no error. `kernel/via-reconcile.ts` closes the gap by rebuilding the collection's
+`ViaPipeline` in place (`Collection._setVia`, the writer seam #666 added for exactly this). Every
+tier attaches, with one deliberate exception: a lookup field backed by another first-class
+collection (the "matrix" tier) REFUSES to late-attach unless that backing collection is already
+open, in this vault session, in eager (prefetch-enabled) mode — a clear `ValidationError` at
+declare time beats a confusing failure the first time a query touches the field. **The collision
+guard** that already ran at fresh construction (refusing two via families claiming the same field)
+now also runs on every late-attach call, both within the incoming call's own fields and against
+the collection's already-declared fields — no partial attach on a collision. See
+[`docs/subsystems/via-lookup.md`](via-lookup.md#late-attach-reconcile--tier-scoped-664) for the
+full tier-by-tier story, the collision guard's exact behavior, and three known late-attach
+residuals (`describeAsync({resolveDictLabels:true})`, `describe()`'s legacy top-level field list,
+and join-side `presentForJoin` dressing — each captured once at fresh construction and not
+re-derived by a later reconcile call).
+
+**Declare-time mutual-rollup cycle refusal (#639).** Two (or more) `withRollup()` strategies whose
+targets mutually depend on each other (collection A rolls a value into B's field `x`; B rolls a
+value into A's field `y`) used to be silently *declarable* — the cycle was invisible to
+`ViaGraph.assertAcyclic()`'s traversal, because a rollup's target is a real field node that the
+graph writes into but never reads FROM, so the depth-first search dead-ended on it instead of
+looping back. The fix teaches `assertAcyclic`'s traversal (not the graph's stored edges — a
+purely traversal-local expansion, so no new edge is materialized and no posture-folding input
+changes) that writing a real field on a collection is *also* a write to that collection: visiting
+field node `(C, f)` now additionally expands the edges sourced at `(C, '*')`, closing the missing
+reachability step. The refusal fires at `Noydb.openVault()` time (not at `withRollup()`
+construction, and not at a later `.collection()` call) — every derivation/MV strategy validates
+against the graph during vault open — and throws `DerivationCycleError`, the same class every
+other declare-time cycle (a plain derivation loop, an MV cycle) already throws:
+
+```ts
+const bRollsUpA = withRollup({ from: 'a', key: 'aId', into: 'b', field: 'x', compute: () => 0 })
+const aRollsUpB = withRollup({ from: 'b', key: 'bId', into: 'a', field: 'y', compute: () => 0 })
+const db = await createNoydb({ store, user, secret, derivationStrategies: [bRollsUpA, aRollsUpB] })
+await expect(db.openVault('demo')).rejects.toBeInstanceOf(DerivationCycleError)
+```
+
+(from `packages/hub/__tests__/derivations/rollup.test.ts`, "mutual/rotating cycle refusal at
+declare time" — covers a 2-collection mutual cycle, a 3-collection rotation, and an acyclic chain
+control that still resolves). Scope is deliberately narrow: a rollup-shaped cycle only (field→`'*'`
+containment); the symmetric `'*'`→field expansion that would catch an exotic whole-record-
+derivation-output↔field-computed cycle was evaluated and explicitly NOT built — it would tighten
+detection to full write-reachability and risk rejecting derivation+computed graphs that pass
+today, a broader behavior change than this issue asked for. No runtime depth/reentrancy guard was
+added either — this is a declare-time sentinel fix, not a runtime cycle breaker.
+
+**Computed-first present order (#665)** — see
+[`docs/subsystems/via-computed.md`](via-computed.md#present-order-665--computed-runs-before-dressing-after-money)
+for the full story: a virtual `computed` field's output now exists before i18n/lookup's dressing
+`present()` hooks run on it (previously dressing ran first and found nothing to dress), with money
+carved out to keep its own pre-#665 present position (money DECODES its input, unlike i18n/lookup
+which only ADD a `Label`/`Formatted` key — running money after a virtual computed on the same
+field would misread the computed field's raw major-unit output as a stored scaled-int).
+
+**Bare-array lookup fields (#661)** — see
+[`docs/subsystems/via-lookup.md`](via-lookup.md#bare-array-fields--element-wise-support-661): a
+plain field whose own value is an array (not the pre-existing `[].`-wildcard multi-value path) now
+gets the same element-wise altKey normalization and closed-vocabulary enforcement as every other
+lookup shape, including at a dotted (non-wildcard) path.
+
+**`indexProbe` — the index-accelerated fast path restored for fixed-mode money `where()` (#625)**
+— see [`docs/subsystems/via-money.md`](via-money.md#indexing--the-fast-path-and-an-honest-mixed-era-caveat-625):
+an optional `ViaBinding.indexProbe(op, payload)` hook lets a binding hand the query builder a
+STORED-form operand for a direct index bucket lookup on `==`/`in`, restoring the fast path phase A
+originally lost for money fields (multi-currency money and every other operator still scan — there
+is no single stored-form value a hash index can serve for those). Ships with an honest mixed-era
+caveat for pre-money-declaration legacy data (documented on the money page).
+
 ## See also
 
 - [`docs/superpowers/specs/2026-07-10-via-port-design.md`](../superpowers/specs/2026-07-10-via-port-design.md) — full phase A design spec
@@ -438,3 +513,10 @@ canonical countries-matrix example.
   (axis-scoping, kind-scoping, the ref-identity/blob traps)
 - `packages/hub/__tests__/via/sync-delete-rollup.test.ts` — the #640 sync-applied-delete rollup
   recompute suite (dedup/ordering/freshness + the `derivation:wave-error` event)
+- `packages/hub/src/kernel/via-reconcile.ts` — milestone #31: the late-attach reconcile dispatch
+  (i18n/dictKey/lookup, #664)
+- `packages/hub/__tests__/via/reconcile-lookup.test.ts`, `reconcile-i18n-dictkey.test.ts`,
+  `reconcile-guard.test.ts` — milestone #31: the #664 late-attach suites (tier coverage, collision
+  guard, combined-family single-call attach)
+- `packages/hub/__tests__/via/graph.test.ts`, `packages/hub/__tests__/derivations/rollup.test.ts`
+  — milestone #31: the #639 mutual-rollup declare-time cycle refusal suites

--- a/docs/superpowers/plans/2026-07-13-m31-completion.md
+++ b/docs/superpowers/plans/2026-07-13-m31-completion.md
@@ -1,0 +1,50 @@
+# Milestone #31 completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close all 6 milestone-#31 issues (#666, #664, #639, #665, #661, #625) in one branch/PR.
+
+**Architecture:** Spec `docs/superpowers/specs/2026-07-13-m31-completion-design.md`; ground truth `.superpowers/sdd/seam-map-m31.md` (probe-proven anchors — read the relevant section before each task). Order matters: #666 enables #664; the rest are independent.
+
+**Tech Stack:** TypeScript, vitest, tsup; hub-portable; crypto.subtle only.
+
+## Global Constraints
+
+- Ceilings (split-metric): collection.ts ≤ 4472, vault.ts ≤ 3939, noydb.ts ≤ 2385 — zero slack; add ⇒ equal named shrink same task; BLOCKED over bump.
+- No Claude attribution; pre-commit `git diff --cached | grep -in -E "accounting-firm|co-authored|generated with claude"` → empty.
+- Zero-knowledge: via-features never receive keyring/raw DEKs; ViaGraph stays metadata-only; posture folding must not gain new inputs (#639's law: traversal-only).
+- Behavior locks: full money/i18n/dict/lookup/MV/derivations/computed/query/classified suites unchanged except enumerated pin-flips. TDD: red first, every task.
+- `pnpm check:architecture` green after every task. Goldens: only additive deltas a task explicitly names.
+- ONE batch changeset in the final task (`.changeset/m31-completion.md`, hub minor — indexProbe + late-attach coverage are additive api).
+
+## Tasks
+
+### Task 1: #666 — `Collection._setVia` writer seam
+**Files:** kernel/collection.ts (guarded: +4-5 lines, named shrinks: `get _ramCiphertext` :1371-1372 collapse or `_applyClassifiedFields` comment compaction), kernel/via-graph-wiring.ts (:319 cast + :337 write die; param typed against the getter/setter pair). Test: typecheck + `grep "coll as {" via-graph-wiring.ts` empty + existing taint/overlay suites + a `_setVia` contract test (assign + codec.setVia both observed).
+**Produces:** `_setVia(pipeline: ViaPipeline | undefined): void` — Tasks 2-3 call it. Verify line accounting (before/after wc -l) in the report.
+
+### Task 2: #664a — reconcile collision guard + i18n/dictKey reconcile + ladder collapse
+**Files:** kernel/via-compose.ts (guard recipes a+b: re-run `guardCrossBindingFieldCollisions` on the late-attach merged view; existing×incoming via `coll._via` bindings `covers()`+`brand`→`VIA_FIELD_MAP_FAMILY`), NEW kernel/via-reconcile.ts (free functions `reconcileI18nFields`/`reconcileDictKeyFields` → `ViaPipeline.build` + `coll._setVia` + dictionary-handle wiring — seam-map §3 names the fresh-construct sources to mirror), kernel/vault.ts (5-branch `_apply*` ladder :852-869 collapses to ONE via-reconcile dispatch — net-NEGATIVE; guard call rides the freed lines). Tests: fable's probe recipes (a) money+blob late-attach refuses, (b) call-1 classified + call-2 money refuses; i18n + dictKey late-attach end-to-end (label dressing appears post-reconcile); existing money/computed/classified late-attach suites unchanged.
+**Produces:** via-reconcile.ts dispatch signature Task 3 extends.
+
+### Task 3: #664b — lookup reconcile (tier-scoped)
+**Files:** kernel/via-reconcile.ts (`reconcileLookupFields`: enum/static clean; reserved tier updates vault registries [reservedLookupCollections vault.ts:394,1292-1300 — thin touches only, vault stays ≤3939]; matrix tier REFUSES `ValidationError` unless backing open prefetch-enabled — binding.ts:252-264 evidence), shape/via-lookup as needed for snapshot/membership closure builders (reuse fresh-construct builders — do not duplicate). Tests: enum/dict late-attach end-to-end (closed-vocab enforcement live post-attach, altKeys normalize); matrix-attach refusal message pinned; matrix attach WITH open prefetch backing works; graph ref edges present post-attach (referencingEdgesOf).
+
+### Task 4: #639 — assertAcyclic containment expansion
+**Files:** kernel/via-graph.ts (`assertAcyclic` ~:188-229: neighbours of real field `(C,f)` also expand `_out.get(C\0*)` — TRAVERSAL-LOCAL ONLY; no `_in`/`registerDerived` change; comment states the #642 separation law). Tests: mutual-rollup declare refusal (probe recipe from seam map); acyclic chain still passes (control); `foldWildcardSecurity`/taint suites byte-unchanged (the lock proving no posture bleed).
+
+### Task 5: #665 — computed-first `_presentOrder`
+**Files:** kernel/via-pipeline.ts (present() :109-113 folds over a `_presentOrder` — computed bindings first, others keep relative order; built once at construction). Tests: flip `computed/virtual.test.ts:258,302` (i18n statusLabel + lookup) to positive; money virtual pin STAYS KNOWN LIMITATION (:161 — value-shape, out of scope); money/i18n/lookup present-output suites unchanged (behavior lock — enumerate any legitimate diff).
+
+### Task 6: #661 — bare-array element-wise, both hooks
+**Files:** shape/via-lookup/binding.ts (Array.isArray branches: ingest :317-322, enforceWrite :345-348, mirroring [].-wildcard :296-315; share altIndex/membership). Tests: closed-vocab per-element refusal; altKey normalization per element; mixed + empty arrays; scalar byte-parity; #661's exact probe (['ZZZ','totally-bogus'] now refused).
+
+### Task 7: #625 — indexProbe end-to-end
+**Files:** kernel/via.ts (`indexProbe?(op, payload)`), kernel/via-pipeline.ts (brand dispatch mirroring `evaluateClause`), shape/via-money (fixed-mode == / in per issue), query/builder.ts (:1129 `if (clause.via) continue` → probe + `indexValue` slot; `candidateRecords()` lookupEqual/lookupIn). MUST first verify probe stored-form byte-matches index `stringifyKey` (seam-map §4 flag) — if mismatch, normalize at the probe, evidence in report. Tests: harden `__tests__/money/where-comparison.test.ts:184-203` with real `withIndexing()` + lookupEqual spy (fast path proven hit); `in` path; non-fixed-mode + range ops still scan; posture gate untouched.
+
+### Task 8 (FINAL): docs + changeset + gauntlet
+**Files:** docs/subsystems/via.md + via-lookup.md (late-attach coverage + tier limits, cycle refusal, present order, arrays, indexProbe — every example traced to a shipped test), `.changeset/m31-completion.md` (hub minor; honest per-issue bullets incl. matrix-refusal + money-virtual out-of-scope notes; local/gitignored). Gauntlet: full hub suite, typecheck, lint, check:architecture, build (env-free), bundle-check; ceilings reported. Wrap-up: file the money-virtual-quantize follow-up issue draft (report text; controller files it).
+
+## Execution notes
+
+Fresh implementer per task + task review (skill: superpowers:subagent-driven-development); opus review on Tasks 2-3 (guard + registry surface) and 7 (query hot path); whole-branch fable review at end; then PR → CI → merge → close milestone #31 → STOP (publish gated on user check-in).

--- a/docs/superpowers/specs/2026-07-13-m31-completion-design.md
+++ b/docs/superpowers/specs/2026-07-13-m31-completion-design.md
@@ -1,0 +1,50 @@
+# Milestone #31 completion — via backlog closure (#625, #639, #661, #664, #665, #666)
+
+**Date:** 2026-07-13
+**Issues:** [#625](https://github.com/vLannaAi/noy-db/issues/625) indexProbe, [#639](https://github.com/vLannaAi/noy-db/issues/639) rollup cycles, [#661](https://github.com/vLannaAi/noy-db/issues/661) bare arrays, [#664](https://github.com/vLannaAi/noy-db/issues/664) late-attach, [#665](https://github.com/vLannaAi/noy-db/issues/665) present order, [#666](https://github.com/vLannaAi/noy-db/issues/666) writer seam · **Milestone:** #31 "Via features backlog [api]" (directive: complete before publish; publish itself gated on user check-in).
+**Base:** main `b5088dda`. **Surface:** `api` — additive (`indexProbe` hook, late-attach reconcile coverage); `/adapter` + `/cargo` byte-untouched.
+**Ground truth:** `.superpowers/sdd/seam-map-m31.md` (probe-proven; file:line anchors). Behavior locks: full money/i18n/dict/lookup/MV/derivations/computed/query/classified suites pass unchanged except pins that pin the fixed defects (enumerated per task in the plan).
+
+## Decision summary (user-ratified 2026-07-13)
+
+1. **#639 = sentinel rework only** — declare-time refusal; no runtime depth guard.
+2. **#665 = topological present order** — computed-first present phase.
+3. **#661 = element-wise array support** in BOTH ingest and enforceWrite.
+4. **Publish gate:** after #31 merges, STOP and present release contents; no publish-adjacent command without explicit go.
+
+## Design
+
+### 1. #666 → the writer seam (lands first — #664's enabler)
+
+`Collection._setVia(pipeline)` — assigns the private `via` and calls the internal `codec.setVia` (the two things `applyTaintOverlay`'s cast does today at via-graph-wiring.ts:319/337). `via` is private, so no structural interface can replace the write (TS2540 on the getter proved the read/write asymmetry). collection.ts is at zero slack: pair with a named shrink (`get _ramCiphertext` :1371-1372 collapse, or `_applyClassifiedFields` comment compaction). `applyTaintOverlay`'s param types against the getter+setter pair; the cast dies.
+
+### 2. #664 — late-attach parity: collision guard + i18n/dict/lookup reconcile
+
+- **Guard (both recipes), in via-compose.ts:** (a) incoming×incoming — re-run the existing pure `guardCrossBindingFieldCollisions` on the late-attach path's merged view; (b) existing×incoming — read the live collection's compiled families via `coll._via` bindings' `covers()` + `brand` → `VIA_FIELD_MAP_FAMILY`, refuse `ValidationError` naming field + both families. No new Collection surface.
+- **Machinery, in a NEW `kernel/via-reconcile.ts` (unguarded):** free functions `reconcileI18nFields`/`reconcileDictKeyFields`/`reconcileLookupFields` that rebuild the pipeline through `ViaPipeline.build` + `_setVia`, plus the vault-registry wiring lookup needs (reserved prefixes, snapshot, graph ref edges, membership closures). vault.ts's 5-branch `_apply*` ladder (852-869) collapses into ONE dispatch call into via-reconcile — net-NEGATIVE in vault.ts, funding the guard call.
+- **Lookup tier scoping (honest limits):** enum/static tiers attach cleanly; reserved tier attaches with vault-registry updates; **matrix tier late-attach REFUSES with a clear `ValidationError` unless its backing collection is already open prefetch-enabled** (lazy backing throws at binding.ts:252-264 — a clear refusal beats a deferred crash; documented, pinned).
+- Blob late-attach stays out of scope (unchanged silent-ignore is #664's text; blob is vault-grain machinery — note in docs).
+
+### 3. #639 — cycle visibility without taint bleed
+
+`assertAcyclic`'s DFS gains a **traversal-local containment expansion**: when visiting a real field node `(C,f)`, also expand the edges sourced at `(C,'*')` (probe-proven to detect the mutual-rollup cycle). Explicitly NOT a `registerDerived` edge — putting `(C,'*')` into `_in` would flip `_contribution` onto the `foldWildcardSecurity` path and bleed taint (#642 interaction; posture folding never reads `_out`, so a traversal-only change is provably separate). Mutual rollups now `ValidationError` at declare time; the existing rollup suites lock registration shapes.
+
+### 4. #665 — computed-first present order
+
+`present()` is a flat fold over `this.bindings` in global compile order (money→…→computed last; via-pipeline.ts:109-113). Fix: a present-phase-local `_presentOrder` (computed bindings first, others in existing relative order) — NOT a global bindings reorder (write phases need money-first). Flips the i18n (`statusLabel`) and lookup pins in `computed/virtual.test.ts:258,302` to positive. **Money virtual dressing is OUT OF SCOPE** (seam-map premise correction: `decodeMoneyFields` expects stored scaled-int; a virtual field emits a major-unit number — a value-shape question, not ordering; its pin stays KNOWN LIMITATION and a follow-up issue is filed at wrap-up to the successor bucket).
+
+### 5. #661 — bare-array element-wise, both hooks together
+
+`Array.isArray` branches in ingest (binding.ts:317-322) and enforceWrite (:345-348), mirroring the `[].`-wildcard branches (:296-315), sharing `backing.altIndex`/`cfg.membership`. Pins: closed-vocab refusal per element, altKey normalization per element, mixed/empty arrays, scalar byte-parity.
+
+### 6. #625 — indexProbe (reviewer-spec'd; drift-checked)
+
+As the issue pins: optional `ViaBinding.indexProbe?(op, payload)`; `ViaPipeline.indexProbe` brand dispatch mirroring `evaluateClause`; via-money fixed-mode `==` → `entries[0].scaled`, `in` → `entries.map(e => e.scaled)`, else undefined; builder.ts:1129's `if (clause.via) continue` becomes a probe (`clause.via.indexValue !== undefined` → `lookupEqual`/`lookupIn`, else scan). MUST verify the probe's stored-form byte-matches the index's `stringifyKey` (the seam map's one dependency flag). Harden the still-fake `__tests__/money/where-comparison.test.ts:184-203` with real `withIndexing()` + a lookupEqual spy. No posture-gate drift (money is `ordered`).
+
+## Testing
+
+New pins per issue (each red→green): mutual-rollup declare refusal + acyclic-still-passes control (#639); i18n+lookup virtual dressing positive + money limitation still pinned (#665); late-attach collision recipes (a)+(b) + i18n/dict/lookup reconcile end-to-end + matrix-tier refusal (#664); bare-array quartet (#661); index fast-path spy proof + probe/stringifyKey parity (#625); cast-gone typecheck + `_setVia` contract (#666). Ceilings: collection.ts 4472 (+`_setVia` −named shrink), vault.ts 3939 (ladder collapse = net-negative), noydb.ts 2385 untouched.
+
+## Out of scope
+
+Money virtual-dressing quantize decision (follow-up at wrap); blob late-attach; runtime depth guard (#639 ratification); range-op index acceleration (never existed); `@latest` promotion; publish (gated).

--- a/packages/hub/__tests__/computed/virtual.test.ts
+++ b/packages/hub/__tests__/computed/virtual.test.ts
@@ -133,17 +133,24 @@ describe('computed(virtual) — read-time, never-stored mode (#638 Task 7)', () 
     ).not.toThrow()
   })
 
-  it('composed grammar: via(computed(...), money(...)) on one field is accepted and computes without throwing', async () => {
+  it('composed grammar: via(computed(...), money(...)) on one field is accepted and computes, but money MIS-DECODES the virtual output — KNOWN LIMITATION, out of #665\'s scope (value-shape, not ordering)', async () => {
     // Decision 5's locked grammar (`via(computed(fn, { deps, mode }), money('EUR'))`) —
-    // this pins that the composition is LEGAL and produces the computed function's
-    // result. `compileViaBindings` runs computed LAST (so a virtual field's `deps` can
-    // read OTHER fields' money/i18n-DECODED output, test (d)/the taint test above) — for
-    // a field composing computed+money on ITSELF, money's `present()` therefore runs
-    // before the virtual value exists (nothing stored to decode) and computed's
-    // present() unconditionally sets the field afterward, so the raw computed number
-    // is what survives, not a money-formatted string. Documented as a known limitation
-    // in the task report — money-decorating-a-virtual-field's-own-output is not
-    // exercised by the brief's RED list and is left for a follow-up if ever needed.
+    // this pins that the composition is LEGAL. #665 (`kernel/via-pipeline.ts`'s
+    // `_presentOrder`) reorders `present()` to run every `'computed'`-brand binding
+    // FIRST so i18n/lookup's dressing hooks can see a virtual field's value (see the
+    // dictKey/dict tests below) — but money is not a pure dressing CONSUMER like i18n/
+    // lookup: `decodeMoneyFields` (`via-money/binding.ts`) unconditionally treats its
+    // present()-time input as the STORED SCALED-INT form and derives both the decoded
+    // amount and `<field>Formatted` from it. A virtual computed field's output is a raw
+    // MAJOR-unit number (`21`), never quantized/stored — so now that money's present()
+    // runs AFTER computed's on this composed-on-itself field (previously computed ran
+    // LAST and unconditionally overwrote whatever money had set, so the raw `21`
+    // survived untouched), money misreads `21` as 21 SCALED units and decodes it as
+    // `'0.21'` EUR — a REPRESENTATION mismatch, not just a missing-dressing gap. #665's
+    // issue explicitly parks money virtual-dressing as a follow-up (needs a
+    // quantize-the-computed-output decision before money can be let anywhere near a
+    // virtual field's own output); this test pins the corrected present-order's actual,
+    // still-wrong, still-documented-as-a-known-limitation output for this composition.
     interface Priced extends Record<string, unknown> { id: string; base: number; doubledPrice?: string | number }
     const store = inlineMemory()
     const db = await createNoydb({ store, user: 'alice', secret: 'via-computed-virtual-stack-2026' })
@@ -158,7 +165,7 @@ describe('computed(virtual) — read-time, never-stored mode (#638 Task 7)', () 
     })
     await c.put('a', { id: 'a', base: 10.5 })
     const read = await c.get('a')
-    expect(read?.doubledPrice).toBe(21)
+    expect(read?.doubledPrice).toBe('0.21') // NOT 21 — money mis-decodes the raw major-unit `21` as a scaled-int
     expect(() => c.query().where('doubledPrice', '==', 21)).toThrow(FieldNotQueryableError)
   })
 
@@ -201,13 +208,14 @@ describe('computed(virtual) — read-time, never-stored mode (#638 Task 7)', () 
   // style genuinely composes, the other must too (provenance is erased before the guard
   // ever sees the config). Money's own proof is the pair of tests directly above; these
   // pin the SAME claim for the `i18n` (dictKey) and `lookup` (dict()) families, in BOTH
-  // declaration styles, and — mirroring the money virtual-mode test above — pin the known
-  // present-ORDER limitation in virtual mode too (i18n/lookup's `present()` runs BEFORE
-  // computed's, per `compileViaBindings`'s money→i18n→lookup→classified→blob→computed
-  // ordering, so a virtual field's label can never be dressed off a value that doesn't
-  // exist yet at i18n/lookup's `present()` time — this is NOT a reason to drop the family
-  // from the exemption; materialized mode below is what proves the family genuinely
-  // composes).
+  // declaration styles, and — since #665 — pin that virtual mode now dresses too:
+  // `ViaPipeline`'s `present()` folds over a present-phase-local `_presentOrder`
+  // (`kernel/via-pipeline.ts`) that puts every `'computed'`-brand binding first, so a
+  // virtual field's value exists BEFORE i18n/lookup's dressing `present()` hooks run on
+  // it (previously `compileViaBindings`'s money→i18n→lookup→classified→blob→computed
+  // ordering ran computed LAST, so a virtual field's label could never be dressed off a
+  // value that didn't exist yet). Money is the one family #665 deliberately does NOT fix
+  // for the composed-on-itself case — see the KNOWN LIMITATION test above and its comment.
   describe('composed grammar — computed + i18n/lookup families (#631 collision-guard exemption pins)', () => {
     interface Order extends Record<string, unknown> { id: string; base: number; status?: string; statusLabel?: string }
 
@@ -255,7 +263,7 @@ describe('computed(virtual) — read-time, never-stored mode (#638 Task 7)', () 
       expect(read?.statusLabel).toBe('ฉบับร่าง')
     })
 
-    it('via(computed(fn, { mode: "virtual" }), dictKey(...)) on one field — KNOWN LIMITATION: dictKey\'s present() runs BEFORE the virtual value exists, so no label is dressed (mirrors the money virtual-mode limitation above)', async () => {
+    it('via(computed(fn, { mode: "virtual" }), dictKey(...)) on one field — #665: computed\'s present() now runs FIRST, so dictKey dresses the virtual value\'s label', async () => {
       const v = await labeledVault()
       const c = v.collection<Order>('orders', {
         viaFields: {
@@ -265,7 +273,7 @@ describe('computed(virtual) — read-time, never-stored mode (#638 Task 7)', () 
       await c.put('a', { id: 'a', base: 25 })
       const read = await c.get('a', { locale: 'th' }) as Order
       expect(read.status).toBe('paid') // the virtual value itself still computes correctly
-      expect(read.statusLabel).toBeUndefined() // NOT dressed — i18n's present() already ran
+      expect(read.statusLabel).toBe('ชำระแล้ว') // dressed — computed's present() ran BEFORE dictKey's
       const raw = await c._getStoredRecord('a')
       expect('status' in (raw as Record<string, unknown>)).toBe(false) // never stored (virtual)
     })
@@ -295,7 +303,7 @@ describe('computed(virtual) — read-time, never-stored mode (#638 Task 7)', () 
       expect(read?.statusLabel).toBe('ฉบับร่าง')
     })
 
-    it('via(computed(fn, { mode: "virtual" }), dict(...)) on one field — same present-order limitation as dictKey above: no label dressed (lookup family)', async () => {
+    it('via(computed(fn, { mode: "virtual" }), dict(...)) on one field — #665: same fix as dictKey above, lookup dresses the virtual value\'s label too (lookup family)', async () => {
       const v = await labeledVault()
       const c = v.collection<Order>('orders', {
         viaFields: {
@@ -305,7 +313,88 @@ describe('computed(virtual) — read-time, never-stored mode (#638 Task 7)', () 
       await c.put('a', { id: 'a', base: 25 })
       const read = await c.get('a', { locale: 'th' }) as Order
       expect(read.status).toBe('paid')
-      expect(read.statusLabel).toBeUndefined()
+      expect(read.statusLabel).toBe('ชำระแล้ว')
+    })
+  })
+
+  // #665 second-order effects — pinned explicitly so the design choice is on the record,
+  // not just implicit in `_presentOrder`'s partition (`kernel/via-pipeline.ts`).
+  describe('#665 present-order — second-order effects (pinned, not just implicit)', () => {
+    it('(a) chained virtual computeds: a LATER-declared field reading an EARLIER-declared virtual field\'s output works — declaration order, not a topo sort, and unaffected by #665', async () => {
+      // The `computed` binding is ONE ViaBinding covering every virtual field on the
+      // collection (`shape/via-computed/binding.ts`'s `present` loops `cfg.virtualFields`,
+      // a Map in DECLARATION order, mutating the SAME threaded record as it goes) — so
+      // chaining across two virtual computed fields is entirely INTERNAL to that one
+      // binding's present() and was never affected by where `computed` sits in the outer
+      // `present()` fold, before or after #665. It works here because `quadrupled` is
+      // declared AFTER `doubled` — swap the declaration order and it breaks (see (a2)).
+      // #665 does not attempt a real topological sort of computed-to-computed deps; this
+      // pins that today's "declaration order = compile order" behavior is unchanged.
+      interface Item extends Record<string, unknown> { id: string; amount: number; doubled?: number; quadrupled?: number }
+      const store = inlineMemory()
+      const db = await createNoydb({ store, user: 'alice', secret: 'via-computed-665-chain-a-2026' })
+      const v = await db.openVault('v1')
+      const c = v.collection<Item>('items', {
+        viaFields: {
+          doubled: via(computed((r) => (r.amount as number) * 2, { deps: ['amount'], mode: 'virtual' })),
+          quadrupled: via(computed((r) => ((r.doubled as number | undefined) ?? -999) * 2, { deps: ['doubled'], mode: 'virtual' })),
+        },
+      })
+      await c.put('r1', { id: 'r1', amount: 5 })
+      const read = await c.get('r1')
+      expect(read?.doubled).toBe(10)
+      expect(read?.quadrupled).toBe(20)
+    })
+
+    it('(a2) KNOWN LIMITATION: the SAME chain declared in reverse order sees a stale/missing upstream value — confirms (a) is declaration-order, not a real dependency-graph sort', async () => {
+      interface Item extends Record<string, unknown> { id: string; amount: number; doubled?: number; quadrupled?: number }
+      const store = inlineMemory()
+      const db = await createNoydb({ store, user: 'alice', secret: 'via-computed-665-chain-a2-2026' })
+      const v = await db.openVault('v1')
+      const c = v.collection<Item>('items', {
+        viaFields: {
+          // quadrupled declared BEFORE doubled — its fn runs first and reads `doubled`
+          // before that key has been set on the threaded record.
+          quadrupled: via(computed((r) => ((r.doubled as number | undefined) ?? -999) * 2, { deps: ['doubled'], mode: 'virtual' })),
+          doubled: via(computed((r) => (r.amount as number) * 2, { deps: ['amount'], mode: 'virtual' })),
+        },
+      })
+      await c.put('r1', { id: 'r1', amount: 5 })
+      const read = await c.get('r1')
+      expect(read?.doubled).toBe(10) // computes fine on its own
+      expect(read?.quadrupled).toBe(-1998) // (-999) * 2 — read `doubled` before it existed
+    })
+
+    it('(b) KNOWN LIMITATION introduced by #665: a virtual computed field reading a DIFFERENT field\'s i18n/lookup dressing (e.g. `<field>Label`) no longer sees it — computed now runs FIRST, before dressing hooks add it', async () => {
+      // Before #665, `present()` ran computed LAST, so a virtual field's `fn` could read
+      // ANOTHER field's dressing output (money `Formatted`, i18n/lookup `Label`) because
+      // by the time computed ran, every dressing hook earlier in the fold had already
+      // added its key to the threaded record. #665 flips that: computed now runs FIRST,
+      // so a virtual field can no longer see any OTHER field's dressing. This reverse
+      // composition (dressing -> computed, as opposed to computed -> dressing, the
+      // ratified #665 scope) was never pinned by an existing test and is not part of
+      // #665's ratified scope (i18n/lookup dressing a computed field's OWN output) — this
+      // test makes the tradeoff explicit rather than leaving it an undocumented side effect.
+      const store = inlineMemory()
+      const db = await createNoydb({
+        store, user: 'alice', secret: 'via-computed-665-reverse-b-2026', i18nStrategy: withI18n(),
+      })
+      const v = await db.openVault('v1')
+      await v.dictionary('status').putAll({
+        draft: { en: 'Draft', th: 'ฉบับร่าง' },
+        paid: { en: 'Paid', th: 'ชำระแล้ว' },
+      })
+      interface Order2 extends Record<string, unknown> { id: string; status?: string; statusLabel?: string; summary?: string }
+      const c = v.collection<Order2>('orders', {
+        viaFields: {
+          status: via(dictKey('status', ['draft', 'paid'] as const)),
+          summary: via(computed((r) => `label=${(r.statusLabel as string | undefined) ?? 'MISSING'}`, { deps: ['status'], mode: 'virtual' })),
+        },
+      })
+      await c.put('a', { id: 'a', status: 'paid' })
+      const read = await c.get('a', { locale: 'th' }) as Order2
+      expect(read.statusLabel).toBe('ชำระแล้ว') // status's own dressing still works
+      expect(read.summary).toBe('label=MISSING') // but summary's computed ran BEFORE it existed
     })
   })
 

--- a/packages/hub/__tests__/computed/virtual.test.ts
+++ b/packages/hub/__tests__/computed/virtual.test.ts
@@ -133,25 +133,27 @@ describe('computed(virtual) — read-time, never-stored mode (#638 Task 7)', () 
     ).not.toThrow()
   })
 
-  it('composed grammar: via(computed(...), money(...)) on one field is accepted and computes, but money MIS-DECODES the virtual output — KNOWN LIMITATION, out of #665\'s scope (value-shape, not ordering)', async () => {
+  it('composed grammar: via(computed(...), money(...)) on one field is accepted and computes, but money never dresses the virtual output — KNOWN LIMITATION (value-shape, not ordering)', async () => {
     // Decision 5's locked grammar (`via(computed(fn, { deps, mode }), money('EUR'))`) —
-    // this pins that the composition is LEGAL. #665 (`kernel/via-pipeline.ts`'s
-    // `_presentOrder`) reorders `present()` to run every `'computed'`-brand binding
-    // FIRST so i18n/lookup's dressing hooks can see a virtual field's value (see the
-    // dictKey/dict tests below) — but money is not a pure dressing CONSUMER like i18n/
-    // lookup: `decodeMoneyFields` (`via-money/binding.ts`) unconditionally treats its
-    // present()-time input as the STORED SCALED-INT form and derives both the decoded
-    // amount and `<field>Formatted` from it. A virtual computed field's output is a raw
-    // MAJOR-unit number (`21`), never quantized/stored — so now that money's present()
-    // runs AFTER computed's on this composed-on-itself field (previously computed ran
-    // LAST and unconditionally overwrote whatever money had set, so the raw `21`
-    // survived untouched), money misreads `21` as 21 SCALED units and decodes it as
-    // `'0.21'` EUR — a REPRESENTATION mismatch, not just a missing-dressing gap. #665's
-    // issue explicitly parks money virtual-dressing as a follow-up (needs a
-    // quantize-the-computed-output decision before money can be let anywhere near a
-    // virtual field's own output); this test pins the corrected present-order's actual,
-    // still-wrong, still-documented-as-a-known-limitation output for this composition.
-    interface Priced extends Record<string, unknown> { id: string; base: number; doubledPrice?: string | number }
+    // this pins that the composition is LEGAL and produces the computed function's raw
+    // result, undressed. `_presentOrder` (`kernel/via-pipeline.ts`) is a THREE-WAY
+    // partition (money-brand bindings, then computed-brand bindings, then everything
+    // else) that deliberately keeps money FIRST, at its pre-#665 present position — an
+    // early #665 draft ran money AFTER computed (a two-way computed-first partition) and
+    // that regressed this composition from a benign missing-dressing gap into VALUE
+    // CORRUPTION: money's `present()` (`decodeMoneyFields`, `via-money/binding.ts`)
+    // unconditionally treats its input as a STORED SCALED-INT and derives both the
+    // decoded amount and `<field>Formatted` from it, so a virtual computed field's raw
+    // MAJOR-unit output (`21`) was misread as 21 SCALED units and decoded to `'0.21'`
+    // EUR — wrong VALUE, not just missing dressing. With money restored to first, money's
+    // present() runs BEFORE the virtual value exists (nothing stored to decode yet) and
+    // computed's present() unconditionally sets the field afterward, so the raw computed
+    // number survives untouched and no `<field>Formatted` key is ever added — exactly
+    // the pre-#665 shape. This is a value-shape limitation, not an ordering one: money
+    // would need a quantize-the-computed-output decision (is `21` already scaled, or
+    // does money need to scale it?) before it could safely dress a virtual field's own
+    // output, and that decision is left for a filed follow-up, not resolved by ordering.
+    interface Priced extends Record<string, unknown> { id: string; base: number; doubledPrice?: string | number; doubledPriceFormatted?: string }
     const store = inlineMemory()
     const db = await createNoydb({ store, user: 'alice', secret: 'via-computed-virtual-stack-2026' })
     const v = await db.openVault('v1')
@@ -165,8 +167,38 @@ describe('computed(virtual) — read-time, never-stored mode (#638 Task 7)', () 
     })
     await c.put('a', { id: 'a', base: 10.5 })
     const read = await c.get('a')
-    expect(read?.doubledPrice).toBe('0.21') // NOT 21 — money mis-decodes the raw major-unit `21` as a scaled-int
+    expect(read?.doubledPrice).toBe(21)
+    expect(read?.doubledPriceFormatted).toBeUndefined() // no dressing — money's present() ran before the virtual value existed
     expect(() => c.query().where('doubledPrice', '==', 21)).toThrow(FieldNotQueryableError)
+  })
+
+  it('#665 regression pin: composed via(computed(virtual), money(...)) NEVER produces a scaled-down string like \'0.21\' — pins the three-way present partition (money-first) against a future regression to a generic computed-first order', async () => {
+    // This is the corruption case an EARLIER, REJECTED #665 draft actually produced (a
+    // two-way `[computed..., rest...]` partition ran money's decode AFTER the virtual
+    // value existed, so money misread the raw major-unit `21` as a scaled-int and
+    // decoded it to `'0.21'` EUR). The test above pins the (benign) KNOWN LIMITATION
+    // shape; this test pins the ABSENCE of the corrupted shape specifically, so a future
+    // change that reintroduces a generic computed-first partition (dropping money's
+    // carve-out) fails loudly here, not just via the KNOWN LIMITATION test's exact-value
+    // assertion. Asserts both value AND type — a scaled-down numeric `0.21` would be just
+    // as wrong as the string `'0.21'`.
+    interface Priced extends Record<string, unknown> { id: string; base: number; doubledPrice?: string | number }
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: 'via-computed-virtual-stack-regression-2026' })
+    const v = await db.openVault('v1')
+    const c = v.collection<Priced>('priced', {
+      viaFields: {
+        doubledPrice: via(
+          computed((r) => (r.base as number) * 2, { deps: ['base'], mode: 'virtual' }),
+          money({ currency: 'EUR', scale: 2 }),
+        ),
+      },
+    })
+    await c.put('a', { id: 'a', base: 10.5 })
+    const read = await c.get('a')
+    expect(read?.doubledPrice).not.toBe('0.21')
+    expect(read?.doubledPrice).toBe(21)
+    expect(typeof read?.doubledPrice).toBe('number')
   })
 
   it('composed grammar (MATERIALIZED default): via(computed(fn, { mode: "materialized" }), money(...)) on one field — money DOES format the computed output (pins the OPPOSITE of the virtual-mode case above)', async () => {

--- a/packages/hub/__tests__/derivations/rollup.test.ts
+++ b/packages/hub/__tests__/derivations/rollup.test.ts
@@ -4,7 +4,7 @@
 // parent in sync with its children, on insert / update / delete, gap-free.
 
 import { describe, it, expect } from 'vitest'
-import { createNoydb, withRollup, ValidationError } from '../../src/index.js'
+import { createNoydb, withRollup, ValidationError, DerivationCycleError } from '../../src/index.js'
 import type { NoydbStore, EncryptedEnvelope } from '../../src/kernel/types.js'
 
 function memory(): NoydbStore {
@@ -161,5 +161,38 @@ describe('withRollup — aggregate maintenance (#376)', () => {
     expect((await buyers.get('b1'))?.byYear).toEqual({ '2026': 150, '2027': 70 })
     await sales.delete('s1')
     expect((await buyers.get('b1'))?.byYear).toEqual({ '2026': 50, '2027': 70 })
+  })
+})
+
+describe('withRollup — mutual/rotating cycle refusal at declare time (#639)', () => {
+  it('refuses two mutually-dependent rollups (A rollup into B.x, B rollup into A.y)', async () => {
+    const bRollsUpA = withRollup({ from: 'a', key: 'aId', into: 'b', field: 'x', compute: () => 0 })
+    const aRollsUpB = withRollup({ from: 'b', key: 'bId', into: 'a', field: 'y', compute: () => 0 })
+    const db = await createNoydb({
+      store: memory(), user: 'alice', secret: 'rollup-mutual-cycle-passphrase-2026',
+      derivationStrategies: [bRollsUpA, aRollsUpB],
+    })
+    await expect(db.openVault('demo')).rejects.toBeInstanceOf(DerivationCycleError)
+  })
+
+  it('refuses a three-collection rollup rotation (A rollup into B.x, B rollup into C.y, C rollup into A.z)', async () => {
+    const bRollsUpA = withRollup({ from: 'a', key: 'aId', into: 'b', field: 'x', compute: () => 0 })
+    const cRollsUpB = withRollup({ from: 'b', key: 'bId', into: 'c', field: 'y', compute: () => 0 })
+    const aRollsUpC = withRollup({ from: 'c', key: 'cId', into: 'a', field: 'z', compute: () => 0 })
+    const db = await createNoydb({
+      store: memory(), user: 'alice', secret: 'rollup-rotation-cycle-passphrase-2026',
+      derivationStrategies: [bRollsUpA, cRollsUpB, aRollsUpC],
+    })
+    await expect(db.openVault('demo')).rejects.toBeInstanceOf(DerivationCycleError)
+  })
+
+  it('does not refuse an acyclic rollup chain (A rollup into B.x; B rollup into C.z) — control', async () => {
+    const bRollsUpA = withRollup({ from: 'a', key: 'aId', into: 'b', field: 'x', compute: () => 0 })
+    const cRollsUpB = withRollup({ from: 'b', key: 'bId', into: 'c', field: 'z', compute: () => 0 })
+    const db = await createNoydb({
+      store: memory(), user: 'alice', secret: 'rollup-acyclic-chain-passphrase-2026',
+      derivationStrategies: [bRollsUpA, cRollsUpB],
+    })
+    await expect(db.openVault('demo')).resolves.toBeDefined()
   })
 })

--- a/packages/hub/__tests__/money/where-comparison.test.ts
+++ b/packages/hub/__tests__/money/where-comparison.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { z } from 'zod'
 import { createNoydb, money, MoneyUnsupportedError } from '../../src/index.js'
 import type { NoydbStore, EncryptedEnvelope } from '../../src/kernel/types.js'
+import { withIndexing } from '../../src/with-lookup/indexing/index.js'
+import { CollectionIndexes } from '../../src/with-lookup/indexing/eager-indexes.js'
 
 // #336 — where() on a declared money field accepts MAJOR-unit operands
 // and compares BigInt-exact in scaled-integer space. Before this,
@@ -181,11 +183,20 @@ describe('money where() — multi-currency mode (#336)', () => {
   })
 })
 
-describe('money where() — indexed fast path agrees with the scan (#336)', () => {
-  it('equality over an indexed fixed-mode money field returns the same rows', async () => {
+describe('money where() — indexed fast path agrees with the scan (#336, hardened for #625)', () => {
+  // #625: the original version of this suite declared `indexes: ['total']`
+  // but never passed `indexStrategy: withIndexing()` to createNoydb, so
+  // `getIndexes()` returned null (builder.ts's index fast path never
+  // engages without it) and every "indexed" query below silently ran a
+  // full scan — the assertions happened to pass, but they proved nothing
+  // about the index. Every test in this suite now opts in for real and
+  // spies on `CollectionIndexes.lookupEqual`/`lookupIn` to prove which
+  // path actually ran.
+  async function seedIndexedFixed() {
     const db = await createNoydb({
       store: memory(), user: 'alice',
       secret: 'money-where-indexed-passphrase-2026',
+      indexStrategy: withIndexing(),
     })
     const vault = await db.openVault('books')
     const col = vault.collection<Invoice>('invoices', {
@@ -196,8 +207,102 @@ describe('money where() — indexed fast path agrees with the scan (#336)', () =
     await col.put('a', { id: 'a', total: 99.5, status: 'open' })
     await col.put('b', { id: 'b', total: '100.00', status: 'open' })
     await col.put('c', { id: 'c', total: 100, status: 'paid' })
+    return col
+  }
 
-    const hit = col.query().where('total', '==', 100).toArray()
-    expect(hit.map(r => r.id).sort()).toEqual(['b', 'c'])
+  it('== hits CollectionIndexes.lookupEqual (fast path proven, not just correct output)', async () => {
+    const col = await seedIndexedFixed()
+    const spy = vi.spyOn(CollectionIndexes.prototype, 'lookupEqual')
+    try {
+      const hit = col.query().where('total', '==', 100).toArray()
+      expect(hit.map(r => r.id).sort()).toEqual(['b', 'c'])
+      expect(spy).toHaveBeenCalledTimes(1)
+      // Byte-parity evidence (seam-map §4's dependency flag): the probed
+      // value handed to the index is the exact STORED scaled-int digit
+      // string quantizeMoneyFields would have written for 100 THB @
+      // scale 2 ('10000'), not the caller's major-unit operand (100) —
+      // this is what makes the bucket hit (and 'b'/'c' come back) instead
+      // of a silent miss against an empty bucket.
+      expect(spy).toHaveBeenCalledWith('total', '10000')
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it("'in' hits CollectionIndexes.lookupIn (fast path proven)", async () => {
+    const col = await seedIndexedFixed()
+    const spy = vi.spyOn(CollectionIndexes.prototype, 'lookupIn')
+    try {
+      const hit = col.query().where('total', 'in', [99.5, 100]).toArray()
+      expect(hit.map(r => r.id).sort()).toEqual(['a', 'b', 'c'])
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy).toHaveBeenCalledWith('total', ['9950', '10000'])
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('multi-currency money never probes the index — always scans, results still correct', async () => {
+    const db = await createNoydb({
+      store: memory(), user: 'alice',
+      secret: 'money-where-indexed-multi-passphrase-2026',
+      indexStrategy: withIndexing(),
+    })
+    const vault = await db.openVault('books')
+    const col = vault.collection<{ id: string; amount: unknown } & Record<string, unknown>>('payments', {
+      schema: z.object({ id: z.string(), amount: z.unknown() }),
+      moneyFields: { amount: money({ currencies: ['EUR', 'USD'] }) },
+      indexes: ['amount'],
+    })
+    await col.put('e1', { id: 'e1', amount: { amount: 100, currency: 'EUR' } })
+    await col.put('u1', { id: 'u1', amount: { amount: 100, currency: 'USD' } })
+
+    const spy = vi.spyOn(CollectionIndexes.prototype, 'lookupEqual')
+    try {
+      const hit = col.query().where('amount', '==', { amount: 100, currency: 'EUR' }).toArray()
+      expect(hit.map(r => r.id)).toEqual(['e1'])
+      expect(spy).not.toHaveBeenCalled()
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
+  it('a range operator (>=) never probes the index — always scans, results still correct', async () => {
+    const col = await seedIndexedFixed()
+    const eqSpy = vi.spyOn(CollectionIndexes.prototype, 'lookupEqual')
+    const inSpy = vi.spyOn(CollectionIndexes.prototype, 'lookupIn')
+    try {
+      const hit = col.query().where('total', '>=', 100).toArray()
+      expect(hit.map(r => r.id).sort()).toEqual(['b', 'c'])
+      expect(eqSpy).not.toHaveBeenCalled()
+      expect(inSpy).not.toHaveBeenCalled()
+    } finally {
+      eqSpy.mockRestore()
+      inSpy.mockRestore()
+    }
+  })
+
+  it('a non-money indexed field keeps hitting the fast path unchanged (behavior lock)', async () => {
+    const db = await createNoydb({
+      store: memory(), user: 'alice',
+      secret: 'money-where-indexed-status-passphrase-2026',
+      indexStrategy: withIndexing(),
+    })
+    const vault = await db.openVault('books')
+    const col = vault.collection<Invoice>('invoices', {
+      schema: invoiceSchema,
+      indexes: ['status'],
+    })
+    await col.put('a', { id: 'a', total: 1, status: 'open' })
+    await col.put('b', { id: 'b', total: 2, status: 'paid' })
+
+    const spy = vi.spyOn(CollectionIndexes.prototype, 'lookupEqual')
+    try {
+      const hit = col.query().where('status', '==', 'paid').toArray()
+      expect(hit.map(r => r.id)).toEqual(['b'])
+      expect(spy).toHaveBeenCalledWith('status', 'paid')
+    } finally {
+      spy.mockRestore()
+    }
   })
 })

--- a/packages/hub/__tests__/vault-private-surface.test-d.ts
+++ b/packages/hub/__tests__/vault-private-surface.test-d.ts
@@ -1,0 +1,38 @@
+/**
+ * #664a Important-adjacent fix (opus task review) — the kernel-api golden
+ * (`kernel-api-surface-golden.test.ts`) only enumerates PROTOTYPE members (methods); instance
+ * FIELDS never show up there. The exact #664a regression: `locale`, `i18nStrategy`,
+ * `translateText`, and five registry Maps went public on `Vault` so `this` would structurally
+ * satisfy `ViaReconcileVaultCtx` at the `reconcileViaAttach()` call site — a silent public-surface
+ * widening no existing test caught. Fixed by re-privatizing all nine and building the ctx bag from
+ * `Vault`'s privates via `Vault._viaReconcileCtx()` instead. This file is the regression guard.
+ *
+ * A full pinned `keyof Vault` snapshot was considered and rejected as too brittle/large to be a
+ * SIMPLE guard here — `Vault` has dozens of legitimate public methods, and the snapshot would need
+ * updating on every ordinary new public method, defeating its own purpose as a targeted signal.
+ * Instead: a coarser, NAMED guard — each of the nine fields this exact regression touched must NOT
+ * be a key of `Vault` (`expectTypeOf().not.toHaveProperty(...)`, validated by
+ * `pnpm --filter @noy-db/hub typecheck` via `tsconfig.typetest.json`, mirroring this repo's other
+ * `*.test-d.ts` files' use of `expectTypeOf`).
+ *
+ * Tradeoff (documented, not hidden): this catches exactly these nine fields resurfacing as public
+ * (or being renamed and re-added public under the same name); it does NOT catch an unrelated,
+ * brand-new private field being mistakenly declared public — that would need the broader (and, per
+ * the review's own framing, not-simple) pinned-snapshot approach.
+ */
+import { describe, it, expectTypeOf } from 'vitest'
+import type { Vault } from '../src/index.js'
+
+describe('Vault — the nine #664a via-reconcile-adjacent fields stay off the public surface', () => {
+  it('none of them are keys of Vault', () => {
+    expectTypeOf<Vault>().not.toHaveProperty('i18nStrategy')
+    expectTypeOf<Vault>().not.toHaveProperty('locale')
+    expectTypeOf<Vault>().not.toHaveProperty('translateText')
+    expectTypeOf<Vault>().not.toHaveProperty('i18nFieldRegistry')
+    expectTypeOf<Vault>().not.toHaveProperty('dictKeyFieldRegistry')
+    expectTypeOf<Vault>().not.toHaveProperty('staticByName')
+    expectTypeOf<Vault>().not.toHaveProperty('staticDescriptorByField')
+    expectTypeOf<Vault>().not.toHaveProperty('reservedLookupCollections')
+    expectTypeOf<Vault>().not.toHaveProperty('staticDictNames')
+  })
+})

--- a/packages/hub/__tests__/via/graph.test.ts
+++ b/packages/hub/__tests__/via/graph.test.ts
@@ -192,6 +192,59 @@ describe('ViaGraph — cycle rejection (assertAcyclic)', () => {
       expect((e as DerivationCycleError).message).toMatch(/cycle/i)
     }
   })
+
+  // #639 — mutual/rotating rollup cycles. Rollup edges are shaped
+  // `(from,'*') → (into, field)`: the target is a REAL field node, so
+  // pre-#639 the DFS (which only recurses through `_out.get(id)`) dead-ended
+  // on it — nothing was ever sourced AT a rollup target — and the cycle was
+  // invisible. The fix is a DFS-local containment expansion: visiting a real
+  // field node `(C,f)` also expands `(C,'*')`'s out-edges (a write to a real
+  // field is a write to the collection, which triggers every whole-record
+  // dependent of it).
+  it('a mutual rollup cycle (A rollup B.x, B rollup A.y) is now caught — was silently accepted pre-#639', () => {
+    const g = new ViaGraph()
+    // "A rollup into B.x": B.x aggregates A's children.
+    g.registerDerived({ collection: 'B', field: 'x' }, [{ collection: 'A', field: '*' }], 'rollup', 'aggregate')
+    // "B rollup into A.y": A.y aggregates B's children.
+    g.registerDerived({ collection: 'A', field: 'y' }, [{ collection: 'B', field: '*' }], 'rollup', 'aggregate')
+    expect(() => g.assertAcyclic()).toThrow(DerivationCycleError)
+  })
+
+  it('the mutual-rollup cycle path names both real field nodes (message-shape pin)', () => {
+    const g = new ViaGraph()
+    g.registerDerived({ collection: 'B', field: 'x' }, [{ collection: 'A', field: '*' }], 'rollup', 'aggregate')
+    g.registerDerived({ collection: 'A', field: 'y' }, [{ collection: 'B', field: '*' }], 'rollup', 'aggregate')
+    try {
+      g.assertAcyclic()
+      expect.fail('expected assertAcyclic to throw')
+    } catch (e) {
+      expect(e).toBeInstanceOf(DerivationCycleError)
+      const path = (e as DerivationCycleError).path
+      // No '*' hop is surfaced for a pure rollup↔rollup cycle — containment
+      // is inlined into the visiting field node's neighbour set, never
+      // itself pushed onto the traversal stack — so the message reads as a
+      // plain field-to-field chain, comprehensible without annotation.
+      expect(path).toContain('A.y')
+      expect(path).toContain('B.x')
+      expect(path.some(p => p.includes('*'))).toBe(false)
+      expect((e as DerivationCycleError).message).toMatch(/^Derivation graph contains a cycle: .*→.*Refusing to open vault/)
+    }
+  })
+
+  it('a three-collection rollup rotation (A→B.x, B→C.y, C→A.z) is also caught', () => {
+    const g = new ViaGraph()
+    g.registerDerived({ collection: 'B', field: 'x' }, [{ collection: 'A', field: '*' }], 'rollup', 'aggregate')
+    g.registerDerived({ collection: 'C', field: 'y' }, [{ collection: 'B', field: '*' }], 'rollup', 'aggregate')
+    g.registerDerived({ collection: 'A', field: 'z' }, [{ collection: 'C', field: '*' }], 'rollup', 'aggregate')
+    expect(() => g.assertAcyclic()).toThrow(DerivationCycleError)
+  })
+
+  it('an acyclic rollup chain (A→B.x; B→C.z) still declares fine (control)', () => {
+    const g = new ViaGraph()
+    g.registerDerived({ collection: 'B', field: 'x' }, [{ collection: 'A', field: '*' }], 'rollup', 'aggregate')
+    g.registerDerived({ collection: 'C', field: 'z' }, [{ collection: 'B', field: '*' }], 'rollup', 'aggregate')
+    expect(() => g.assertAcyclic()).not.toThrow()
+  })
 })
 
 describe('ViaGraph — taintedPostures / taintSealedFields (Task 3 overlay)', () => {

--- a/packages/hub/__tests__/via/lookup-altkeys.test.ts
+++ b/packages/hub/__tests__/via/lookup-altkeys.test.ts
@@ -198,11 +198,9 @@ describe('lookup() altKeys ingest normalization — matrix (collection) tier end
  * A plain top-level field whose OWN value is an array (e.g. a bare
  * `tags: ['a','b']`) is a DIFFERENT shape: `getAtPath` resolves it to a
  * single opaque value (the whole array, wrapped: `[['a','b']]`, length 1)
- * rather than splitting it — `values.length !== 1` is never true for it, and
- * `runLookupEnforceWrite`'s `typeof value !== 'string'` guard already skips
- * it today. That shape isn't touched by this fix (see task-4-report.md's
- * "edge-shape decisions" for the scoping rationale) — only the getAtPath
- * multi-value (`[].`-wildcard) case the stale comments actually described.
+ * rather than splitting it — that shape wasn't touched by THIS fix; it got
+ * its own element-wise ingest + enforceWrite fix in #661, see
+ * `lookup-bare-array.test.ts`.
  *
  * RED (pre-fix): the first "ingests to canonical" assertion below failed
  * (leaf values held raw altKeys, unnormalized); the "closed vocabulary"

--- a/packages/hub/__tests__/via/lookup-bare-array.test.ts
+++ b/packages/hub/__tests__/via/lookup-bare-array.test.ts
@@ -77,6 +77,7 @@ async function freshDb(): Promise<Noydb> {
 
 interface Country extends Record<string, unknown> { id: string; iso2: string; iso3: string; callPrefix: string }
 interface Order extends Record<string, unknown> { id: string; tags: unknown[] }
+interface OrderWithMeta extends Record<string, unknown> { id: string; meta: { tags: unknown[] } }
 
 async function seed() {
   const db = await freshDb()
@@ -221,6 +222,33 @@ describe('lookup() bare-array field — enforceWrite closed-vocabulary membershi
     await expect(orders.put('o1', { id: 'o1', tags: ['US', 42, null] })).resolves.not.toThrow()
     const stored = await orders._getStoredRecord('o1')
     expect(stored?.tags).toEqual(['US', 42, null])
+  })
+})
+
+describe('lookup() bare-array field at a DOTTED (non-wildcard) path — same element-wise support (t8d4)', () => {
+  // 'meta.tags' is a bare array at a NESTED path, distinct from BOTH the top-level bare-array
+  // shape above and the 'lines[].country' wildcard shape — `getAtPath`/`setAtPathInPlace`
+  // (kernel/paths.ts) resolve dotted paths generically, so the same Array.isArray branches in
+  // `runLookupIngest`/`runLookupEnforceWrite` cover this shape with no dedicated code.
+  it('normalizes every element\'s altKey candidate to the canonical key on ingest, at a dotted path', async () => {
+    const { vault } = await seed()
+    const orders = vault.collection<OrderWithMeta>('orders-bare-dotted', {
+      lookupFields: { 'meta.tags': lookup('countries', { key: 'iso2', altKeys: ['iso3', 'callPrefix'] }) },
+    })
+
+    await orders.put('o1', { id: 'o1', meta: { tags: ['USA', '+66'] } })
+    const stored = await orders._getStoredRecord('o1')
+    expect(stored?.meta).toEqual({ tags: ['US', 'TH'] })
+  })
+
+  it('closed vocabulary refuses an unknown element at a dotted path', async () => {
+    const { vault } = await seed()
+    const orders = vault.collection<OrderWithMeta>('orders-bare-dotted-closed', {
+      lookupFields: { 'meta.tags': lookup('countries', { key: 'iso2', vocabulary: 'closed' }) },
+    })
+
+    await expect(orders.put('o1', { id: 'o1', meta: { tags: ['US', 'ZZZ'] } })).rejects.toThrow(UnknownLookupKeyError)
+    await expect(orders.put('o2', { id: 'o2', meta: { tags: ['US', 'TH'] } })).resolves.not.toThrow()
   })
 })
 

--- a/packages/hub/__tests__/via/lookup-bare-array.test.ts
+++ b/packages/hub/__tests__/via/lookup-bare-array.test.ts
@@ -1,0 +1,258 @@
+/**
+ * #661 — bare-array lookup fields gain element-wise visibility in BOTH
+ * `ingest` and `enforceWrite`, together (element-wise SUPPORT ratified;
+ * declare-time refusal rejected).
+ *
+ * A plain top-level field whose OWN value is an array (e.g. `tags: ['a',
+ * 'b']` on `tags: lookup('tags', {...})`) is a DIFFERENT shape from the
+ * `[].`-wildcard multi-value path (#652, `lookup-altkeys.test.ts`'s last
+ * describe block): `getAtPath` resolves a bare array to ONE opaque value
+ * (`[['a','b']]`, length 1) rather than splitting it, so it fell through
+ * BOTH hooks unchanged — `runLookupIngest`'s `typeof value !== 'string'`
+ * guard bailed on the whole array, and `runLookupEnforceWrite`'s identical
+ * guard skipped it too, so `membership()` was never called: a closed-
+ * vocabulary field's bare array had ZERO enforcement, any value (known
+ * altKey, canonical key, or genuinely unknown) silently passed `put()`.
+ *
+ * RED (pre-fix, the issue's exact end-to-end probe): a closed-vocabulary
+ * bare array of unknown values (`['ZZZ','totally-bogus']`) resolved
+ * `put()` without throwing and stored the raw unknown values unchanged —
+ * see the first test in the "closed vocabulary" describe block below.
+ *
+ * Fix: both hooks learn a `Array.isArray(value)` branch for a NON-wildcard
+ * field path, reusing the SAME canonical core the scalar and `[].`-wildcard
+ * paths already use — `backing.altIndex` (ingest) / `cfg.membership`
+ * (enforceWrite) — element-wise, mirroring #652's copy-on-write discipline
+ * (new array only when changed; record clone only when needed).
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../../src/kernel/noydb.js'
+import { withI18n } from '../../src/shape/via-i18n/index.js'
+import { lookup } from '../../src/shape/via-lookup/descriptor.js'
+import { UnknownLookupKeyError, ConflictError } from '../../src/kernel/errors.js'
+import type { Noydb } from '../../src/kernel/noydb.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/kernel/types.js'
+
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) if (!n.startsWith('_')) {
+        const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) for (const [name, coll] of existing) if (name.startsWith('_')) comp.set(name, coll)
+      store.set(c, comp)
+    },
+  }
+}
+
+async function freshDb(): Promise<Noydb> {
+  return createNoydb({ store: memory(), user: 'a', secret: 'lookup-bare-array-pass-2026', i18nStrategy: withI18n() })
+}
+
+interface Country extends Record<string, unknown> { id: string; iso2: string; iso3: string; callPrefix: string }
+interface Order extends Record<string, unknown> { id: string; tags: unknown[] }
+
+async function seed() {
+  const db = await freshDb()
+  const vault = await db.openVault('v')
+  const countries = vault.collection<Country>('countries', {})
+  await countries.put('US', { id: 'US', iso2: 'US', iso3: 'USA', callPrefix: '+1' })
+  await countries.put('TH', { id: 'TH', iso2: 'TH', iso3: 'THA', callPrefix: '+66' })
+  return { countries, vault }
+}
+
+describe('lookup() bare-array field — ingest altKey normalization, element-wise (#661)', () => {
+  it('normalizes every element\'s altKey candidate to the canonical key on ingest', async () => {
+    const { vault } = await seed()
+    const orders = vault.collection<Order>('orders-bare', {
+      lookupFields: { tags: lookup('countries', { key: 'iso2', altKeys: ['iso3', 'callPrefix'] }) },
+    })
+
+    await orders.put('o1', { id: 'o1', tags: ['USA', '+66'] })
+    const stored = await orders._getStoredRecord('o1')
+    expect(stored?.tags).toEqual(['US', 'TH'])
+  })
+
+  it('mixed array — an altKey, an already-canonical key, and (open vocabulary) an unknown value pass through untouched', async () => {
+    const { vault } = await seed()
+    const orders = vault.collection<Order>('orders-bare-mixed', {
+      lookupFields: { tags: lookup('countries', { key: 'iso2', altKeys: ['iso3', 'callPrefix'] }) },
+    })
+
+    await orders.put('o1', { id: 'o1', tags: ['USA', 'TH', 'ZZZ'] })
+    const stored = await orders._getStoredRecord('o1')
+    // 'USA' -> 'US' (altKey), 'TH' -> 'TH' (already canonical), 'ZZZ' has no
+    // altIndex match and is an open vocabulary — passes through unchanged.
+    expect(stored?.tags).toEqual(['US', 'TH', 'ZZZ'])
+  })
+
+  it('empty array is a no-op', async () => {
+    const { vault } = await seed()
+    const orders = vault.collection<Order>('orders-bare-empty', {
+      lookupFields: { tags: lookup('countries', { key: 'iso2', altKeys: ['iso3'] }) },
+    })
+
+    await orders.put('o1', { id: 'o1', tags: [] })
+    const stored = await orders._getStoredRecord('o1')
+    expect(stored?.tags).toEqual([])
+  })
+
+  it('duplicate elements after normalization are kept as-is (pass-through — consistent with #652\'s pinned decision, not deduped)', async () => {
+    const { vault } = await seed()
+    const orders = vault.collection<Order>('orders-bare-dupes', {
+      lookupFields: { tags: lookup('countries', { key: 'iso2', altKeys: ['iso3', 'callPrefix'] }) },
+    })
+
+    // 'USA' and '+1' both normalize to 'US' — the normalized array keeps
+    // both resulting entries rather than deduping them, mirroring #652's
+    // `[].`-wildcard decision for the exact same shape.
+    await orders.put('o1', { id: 'o1', tags: ['USA', '+1'] })
+    const stored = await orders._getStoredRecord('o1')
+    expect(stored?.tags).toEqual(['US', 'US'])
+  })
+
+  it('idempotent: an already-all-canonical array passes through unchanged', async () => {
+    const { vault } = await seed()
+    const orders = vault.collection<Order>('orders-bare-canonical', {
+      lookupFields: { tags: lookup('countries', { key: 'iso2', altKeys: ['iso3', 'callPrefix'] }) },
+    })
+
+    await orders.put('o1', { id: 'o1', tags: ['US', 'TH'] })
+    const stored = await orders._getStoredRecord('o1')
+    expect(stored?.tags).toEqual(['US', 'TH'])
+  })
+
+  it('non-string elements (numbers, objects, null) are left untouched — mirrors the scalar branch\'s skip-non-string behavior; no parallel coercion invented', async () => {
+    const { vault } = await seed()
+    const orders = vault.collection<Order>('orders-bare-nonstring', {
+      lookupFields: { tags: lookup('countries', { key: 'iso2', altKeys: ['iso3'] }) },
+    })
+
+    await orders.put('o1', { id: 'o1', tags: ['USA', 42, { foo: 'bar' }, null] })
+    const stored = await orders._getStoredRecord('o1')
+    expect(stored?.tags).toEqual(['US', 42, { foo: 'bar' }, null])
+  })
+})
+
+describe('lookup() bare-array field — enforceWrite closed-vocabulary membership, element-wise (#661)', () => {
+  it('THE ISSUE\'S EXACT PROBE: closed vocabulary refuses a bare array of unknown values (was silently accepted — the filed hole)', async () => {
+    const { vault } = await seed()
+    const orders = vault.collection<Order>('orders-bare-closed-probe', {
+      lookupFields: { tags: lookup('countries', { key: 'iso2', vocabulary: 'closed' }) },
+    })
+
+    await expect(orders.put('o1', { id: 'o1', tags: ['ZZZ', 'totally-bogus'] })).rejects.toThrow(UnknownLookupKeyError)
+  })
+
+  it('closed vocabulary: every known element (including altKeys, normalized by ingest first) is accepted', async () => {
+    const { vault } = await seed()
+    const orders = vault.collection<Order>('orders-bare-closed-ok', {
+      lookupFields: { tags: lookup('countries', { key: 'iso2', altKeys: ['iso3', 'callPrefix'], vocabulary: 'closed' }) },
+    })
+
+    await expect(orders.put('o1', { id: 'o1', tags: ['USA', 'TH'] })).resolves.not.toThrow()
+    const stored = await orders._getStoredRecord('o1')
+    expect(stored?.tags).toEqual(['US', 'TH'])
+  })
+
+  it('closed vocabulary: refuses on the FIRST unknown element, naming the field and the offending element', async () => {
+    const { vault } = await seed()
+    const orders = vault.collection<Order>('orders-bare-closed-mixed', {
+      lookupFields: { tags: lookup('countries', { key: 'iso2', vocabulary: 'closed' }) },
+    })
+
+    await expect(orders.put('o1', { id: 'o1', tags: ['US', 'ZZZ'] })).rejects.toThrow(UnknownLookupKeyError)
+    await expect(orders.put('o2', { id: 'o2', tags: ['US', 'ZZZ'] })).rejects.toThrow(/tags/)
+    await expect(orders.put('o3', { id: 'o3', tags: ['US', 'ZZZ'] })).rejects.toThrow(/ZZZ/)
+  })
+
+  it('open vocabulary: a mixed array with an unknown element passes through (no membership refusal)', async () => {
+    const { vault } = await seed()
+    const orders = vault.collection<Order>('orders-bare-open', {
+      lookupFields: { tags: lookup('countries', { key: 'iso2', altKeys: ['iso3'], vocabulary: 'open' }) },
+    })
+
+    await expect(orders.put('o1', { id: 'o1', tags: ['USA', 'not-a-country'] })).resolves.not.toThrow()
+    const stored = await orders._getStoredRecord('o1')
+    expect(stored?.tags).toEqual(['US', 'not-a-country'])
+  })
+
+  it('empty array: no membership calls, resolves cleanly even closed-vocabulary', async () => {
+    const { vault } = await seed()
+    const orders = vault.collection<Order>('orders-bare-closed-empty', {
+      lookupFields: { tags: lookup('countries', { key: 'iso2', vocabulary: 'closed' }) },
+    })
+
+    await expect(orders.put('o1', { id: 'o1', tags: [] })).resolves.not.toThrow()
+  })
+
+  it('non-string elements inside a closed-vocabulary array are skipped (not membership-checked, not refused) — mirrors scalar skip', async () => {
+    const { vault } = await seed()
+    const orders = vault.collection<Order>('orders-bare-closed-nonstring', {
+      lookupFields: { tags: lookup('countries', { key: 'iso2', vocabulary: 'closed' }) },
+    })
+
+    await expect(orders.put('o1', { id: 'o1', tags: ['US', 42, null] })).resolves.not.toThrow()
+    const stored = await orders._getStoredRecord('o1')
+    expect(stored?.tags).toEqual(['US', 42, null])
+  })
+})
+
+describe('lookup() — scalar and [].-wildcard byte-parity (#661 must not perturb either)', () => {
+  it('scalar field: unchanged behavior — altKey normalizes, closed vocab refuses an unknown value', async () => {
+    const { vault } = await seed()
+    interface ScalarOrder extends Record<string, unknown> { id: string; country: string }
+    const orders = vault.collection<ScalarOrder>('orders-scalar', {
+      lookupFields: { country: lookup('countries', { key: 'iso2', altKeys: ['iso3'], vocabulary: 'closed' }) },
+    })
+
+    await orders.put('o1', { id: 'o1', country: 'USA' })
+    const stored = await orders._getStoredRecord('o1')
+    expect(stored?.country).toBe('US')
+
+    await expect(orders.put('o2', { id: 'o2', country: 'ZZZ' })).rejects.toThrow(UnknownLookupKeyError)
+  })
+
+  it('[].-wildcard field: unchanged behavior — element-wise normalize + refuse (#652 lock)', async () => {
+    const { vault } = await seed()
+    interface Line { country: string }
+    interface LineOrder extends Record<string, unknown> { id: string; lines: Line[] }
+    const orders = vault.collection<LineOrder>('orders-wildcard', {
+      lookupFields: { 'lines[].country': lookup('countries', { key: 'iso2', altKeys: ['iso3'], vocabulary: 'closed' }) },
+    })
+
+    await orders.put('o1', { id: 'o1', lines: [{ country: 'USA' }, { country: 'TH' }] })
+    const stored = await orders._getStoredRecord('o1')
+    expect(stored?.lines).toEqual([{ country: 'US' }, { country: 'TH' }])
+
+    await expect(
+      orders.put('o2', { id: 'o2', lines: [{ country: 'USA' }, { country: 'ZZ' }] }),
+    ).rejects.toThrow(UnknownLookupKeyError)
+  })
+})

--- a/packages/hub/__tests__/via/reconcile-guard.test.ts
+++ b/packages/hub/__tests__/via/reconcile-guard.test.ts
@@ -16,7 +16,7 @@
  * when SPLIT across two `vault.collection()` calls, not just within one.
  */
 import { describe, it, expect } from 'vitest'
-import { createNoydb } from '../../src/index.js'
+import { createNoydb, withDerivation } from '../../src/index.js'
 import { ValidationError } from '../../src/kernel/errors.js'
 import { money } from '../../src/shape/via-money/descriptor.js'
 import { classified } from '../../src/shape/via-classified/presets.js'
@@ -117,6 +117,71 @@ describe('#664 Part 1 — late-attach reconcile collision guard', () => {
     })
     expect(() => vault.collection<Card>('cards', {
       moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+    })).not.toThrow()
+  })
+})
+
+/**
+ * CRITICAL fix (opus task review on #664a) — `guardReconcileCollisions` mapped EVERY existing
+ * binding covering a field (via `covers?.(field)`) straight to a family through
+ * `VIA_FIELD_MAP_FAMILY`, including the `taint` binding (`kernel/via-taint-binding.ts`, brand
+ * `'taint'`) — a posture OVERLAY, not a field-owning family. Under `sealAll` its `covers()` is
+ * true for EVERY non-`_` field, and even in fixed-field-list mode it covers any field the graph
+ * folded a non-default posture onto (e.g. a materialized computed field deriving from a
+ * classified source) — so any late-attach onto such a field threw spuriously, even a legal
+ * idempotent re-declare. Both recipes below reproduce today (pre-fix) and must NOT throw once
+ * `guardReconcileCollisions` excludes `'taint'` before the family mapping.
+ */
+describe('#664a CRITICAL fix — guardReconcileCollisions ignores the `taint` posture-overlay binding', () => {
+  it('(a) a materialized computed field derived from a classified source, re-declared identically on a second vault.collection() call, does not throw', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'a', secret: 'pw-reconcile-guard-taint-1' })
+    const vault = await db.openVault('v1')
+
+    // Materialized (default) mode `computed` entry — compiles NO 'computed' via binding
+    // (only virtual mode does); "ssnLeak" is covered ONLY by the graph-folded `taint`
+    // overlay, since its sole dep ("ssn") is classified.
+    const first = vault.collection<Person>('people', {
+      classifiedFields: { ssn: classified.email() },
+      computed: { ssnLeak: { fn: (r) => r['ssn'], deps: ['ssn'] } },
+    })
+
+    // Re-declaring the SAME computed field identically on a second call is a pre-#664
+    // legal idempotent re-declare (first-wins on `Collection._applyComputed`) — must stay legal.
+    const second = vault.collection<Person>('people', {
+      computed: { ssnLeak: { fn: (r) => r['ssn'], deps: ['ssn'] } },
+    })
+    expect(second).toBe(first)
+  })
+
+  it('(b) late-attach moneyFields onto a DIFFERENT field of a collection whose taint overlay is sealAll (whole-record-sealed via a classified source) does not throw', async () => {
+    interface LeakSource extends Record<string, unknown> { id: string; ssn: string }
+    interface LeakOutput extends Record<string, unknown> { ssnCopy?: string; amount?: number | string }
+
+    function leakDerivation() {
+      return withDerivation<LeakSource, { leak: { ssnCopy: string } }>({
+        source: 'people-taint-b',
+        deterministic: true,
+        outputs: { leak: { shape: 'record', collection: 'leaks-taint-b' } },
+        derive: (s) => ({ leak: { ssnCopy: s.ssn } }),
+        lifecycle: 'eager',
+      })
+    }
+
+    const db = await createNoydb({
+      store: inlineMemory(), user: 'a', secret: 'pw-reconcile-guard-taint-2',
+      derivationStrategies: [leakDerivation()],
+    })
+    const vault = await db.openVault('v1')
+
+    // Source opened BEFORE the '*'-target output — the output's whole-record fold is
+    // computed at ITS OWN construction, from the graph's already-registered classified field.
+    vault.collection<LeakSource>('people-taint-b', { classifiedFields: { ssn: classified.email() } })
+    vault.collection<LeakOutput>('leaks-taint-b') // sealAll — `covers()` is true for every non-`_` field
+
+    // Late-attach money on a DIFFERENT field ("amount", never derived/written) — the ONLY
+    // thing already covering it is the `taint` overlay; that must not count as a family collision.
+    expect(() => vault.collection<LeakOutput>('leaks-taint-b', {
+      moneyFields: { amount: money({ currency: 'USD', scale: 2 }) },
     })).not.toThrow()
   })
 })

--- a/packages/hub/__tests__/via/reconcile-guard.test.ts
+++ b/packages/hub/__tests__/via/reconcile-guard.test.ts
@@ -1,0 +1,122 @@
+/**
+ * #664 Part 1 — the late-attach reconcile-path collision guard. Two probe recipes from the
+ * round-2 fable review (2026-07-13):
+ *
+ *   (a) incoming×incoming — a SECOND `vault.collection()` call names the SAME field in two
+ *       different via-binding families (e.g. `moneyFields`+`blobFields` both claiming
+ *       `"amount"`). Pre-#664: money reconciled and quantized while blob was silently dropped —
+ *       no guard fired on the reconcile path (only fresh construction refused this).
+ *   (b) existing×incoming — an EARLIER call already compiled a binding for a field (here:
+ *       `classifiedFields`), and a LATER call's incoming family map claims the SAME field for a
+ *       DIFFERENT family (`moneyFields`). Pre-#664: silently accepted, producing mutually
+ *       unsatisfiable write enforcement (a "write-brick" — every subsequent `put()` throws one
+ *       way or the other) instead of refusing at declare time.
+ *
+ * Plus the #631 exemption ({computed,money}/{computed,i18n}/{computed,lookup}) must stay legal
+ * when SPLIT across two `vault.collection()` calls, not just within one.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../../src/index.js'
+import { ValidationError } from '../../src/kernel/errors.js'
+import { money } from '../../src/shape/via-money/descriptor.js'
+import { classified } from '../../src/shape/via-classified/presets.js'
+import { via } from '../../src/kernel/via-compose.js'
+import { inlineMemory } from '../classified/harness.js'
+
+interface Card extends Record<string, unknown> {
+  id: string
+  amount: number | string
+  qty?: number
+  total?: number | string
+}
+
+interface Person extends Record<string, unknown> {
+  id: string
+  ssn: string
+}
+
+describe('#664 Part 1 — late-attach reconcile collision guard', () => {
+  it('recipe (a) incoming×incoming: moneyFields + blobFields naming the same field on a late-attach call refuses', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'a', secret: 'pw-reconcile-guard-1' })
+    const vault = await db.openVault('v1')
+
+    // First call: bare collection (no via declarations) — mirrors an MV-precreation
+    // auto-create, or a plain first `vault.collection(name)` call.
+    vault.collection<Card>('cards', {})
+
+    // Second call: moneyFields + blobFields both claim "amount" — fresh-construct would
+    // refuse this outright; the late-attach reconcile path must refuse it identically.
+    expect(() => vault.collection<Card>('cards', {
+      moneyFields: { amount: money({ currency: 'USD', scale: 2 }) },
+      blobFields: { amount: {} },
+    })).toThrow(ValidationError)
+    expect(() => vault.collection<Card>('cards', {
+      moneyFields: { amount: money({ currency: 'USD', scale: 2 }) },
+      blobFields: { amount: {} },
+    })).toThrow(/"amount"/)
+  })
+
+  it('recipe (a), viaFields spelling: via(money(...)) + blobFields naming the same field on a late-attach call refuses', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'a', secret: 'pw-reconcile-guard-1b' })
+    const vault = await db.openVault('v1')
+    vault.collection<Card>('cards', {})
+
+    expect(() => vault.collection<Card>('cards', {
+      viaFields: { amount: via(money({ currency: 'USD', scale: 2 })) },
+      blobFields: { amount: {} },
+    })).toThrow(ValidationError)
+  })
+
+  it('recipe (b) existing×incoming (the write-brick recipe): call-1 classifiedFields, call-2 moneyFields on the SAME field refuses at declare time', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'a', secret: 'pw-reconcile-guard-2' })
+    const vault = await db.openVault('v1')
+
+    // call-1: fresh construct declares "ssn" classified.
+    vault.collection<Person>('people', {
+      classifiedFields: { ssn: classified.email() },
+    })
+
+    // call-2: late-attach declares "ssn" money — a DIFFERENT family claiming a field the
+    // live collection's compiled bindings already own. Pre-#664 this was silently accepted
+    // (money reconciled onto the classified field) and every subsequent put() would throw
+    // one way or the other (mutually unsatisfiable write enforcement) — now it refuses
+    // loudly at declare time instead.
+    expect(() => vault.collection<Person>('people', {
+      moneyFields: { ssn: money({ currency: 'USD', scale: 2 }) },
+    })).toThrow(ValidationError)
+    expect(() => vault.collection<Person>('people', {
+      moneyFields: { ssn: money({ currency: 'USD', scale: 2 }) },
+    })).toThrow(/"ssn"/)
+  })
+
+  it('control: a {computed,money} composition split across two calls (computed fresh, money late-attached) stays legal', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'a', secret: 'pw-reconcile-guard-3' })
+    const vault = await db.openVault('v1')
+
+    // call-1: fresh construct declares a VIRTUAL computed field on "total" — compiles a real
+    // 'computed' via binding covering it (materialized-mode computed fields compile no via
+    // binding at all, so only virtual mode exercises the guard's existing-family lookup here).
+    const first = vault.collection<Card>('cards', {
+      computed: { total: { fn: (r) => (r['qty'] as number) * 2, deps: ['qty'], mode: 'virtual' } },
+    })
+
+    // call-2: late-attach moneyFields on the SAME field — legal fresh (the #631 exemption,
+    // `via(computed(...), money(...))` composing on one field), must stay legal split across
+    // two `vault.collection()` calls.
+    const second = vault.collection<Card>('cards', {
+      moneyFields: { total: money({ currency: 'EUR', scale: 2 }) },
+    })
+    expect(second).toBe(first)
+  })
+
+  it('control: same-family re-declaration (money then money again) on the same field is first-wins, not a collision', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'a', secret: 'pw-reconcile-guard-4' })
+    const vault = await db.openVault('v1')
+    vault.collection<Card>('cards', {
+      moneyFields: { amount: money({ currency: 'USD', scale: 2 }) },
+    })
+    expect(() => vault.collection<Card>('cards', {
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+    })).not.toThrow()
+  })
+})

--- a/packages/hub/__tests__/via/reconcile-i18n-dictkey.test.ts
+++ b/packages/hub/__tests__/via/reconcile-i18n-dictkey.test.ts
@@ -1,0 +1,118 @@
+/**
+ * #664 Part 2 — the i18n/dictKey late-attach reconcile machinery. Pre-#664, `i18nFields`/
+ * `dictKeyFields` on a SECOND-OR-LATER `vault.collection()` call were silently ignored — only
+ * the fresh-construction branch ever wired them (no `_applyI18nFields`/`_applyDictKeyFields`
+ * existed). `via-reconcile.ts`'s `reconcileI18nFields`/`reconcileDictKeyFields` close that gap by
+ * rebuilding the pipeline through `Collection._setVia` (#666) and wiring the same vault registries
+ * fresh construction populates.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../../src/index.js'
+import { withI18n } from '../../src/shape/via-i18n/index.js'
+import { i18nText } from '../../src/shape/via-i18n/core.js'
+import { dictKey, staticDict } from '../../src/shape/via-i18n/dictionary.js'
+import { UnknownDictCodeError } from '../../src/kernel/errors.js'
+import { inlineMemory } from '../classified/harness.js'
+
+interface Invoice extends Record<string, unknown> {
+  id: string
+  total: number
+  memo?: Record<string, string>
+}
+
+interface Worker extends Record<string, unknown> {
+  id: string
+  status?: string
+}
+
+const CIVIL_STATUS = { single: { en: 'Single', th: 'โสด' }, married: { en: 'Married', th: 'สมรส' } } as const
+
+describe('#664 Part 2 — i18nFields late-attach reconcile', () => {
+  it('open without i18n, re-open with i18nFields — locale resolution activates post-attach (was raw before)', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-i18n-1', i18nStrategy: withI18n() })
+    const vault = await db.openVault('books', { locale: 'en' })
+
+    // First declaration: no i18nFields at all.
+    const first = vault.collection<Invoice>('invoices', {})
+    await first.put('i1', { id: 'i1', total: 10, memo: { en: 'Hello', th: 'สวัสดี' } })
+
+    // Pre-attach: no i18n binding compiled — the field reads back completely raw at any locale.
+    const beforeAttach = await first.get('i1', { locale: 'en' })
+    expect(beforeAttach?.memo).toEqual({ en: 'Hello', th: 'สวัสดี' })
+
+    // Late-attach i18nFields on a second vault.collection() call — same instance, reconciled.
+    const second = vault.collection<Invoice>('invoices', {
+      i18nFields: { memo: i18nText({ languages: ['en', 'th'], required: 'any' }) },
+    })
+    expect(second).toBe(first)
+
+    // Post-attach: the SAME already-written record now resolves per-locale on read.
+    const afterAttachEn = await second.get('i1', { locale: 'en' })
+    expect(afterAttachEn?.memo).toBe('Hello')
+    const afterAttachTh = await second.get('i1', { locale: 'th' })
+    expect(afterAttachTh?.memo).toBe('สวัสดี')
+
+    // Put-time i18n validation is live post-attach too: a NEW record's memo is enforced.
+    await second.put('i2', { id: 'i2', total: 5, memo: { en: 'Bye', th: 'ลาก่อน' } })
+    const i2 = await second.get('i2', { locale: 'th' })
+    expect(i2?.memo).toBe('ลาก่อน')
+  })
+
+  it('a second, later i18nFields call is first-wins (no-op) — the family attaches at most once', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-i18n-2', i18nStrategy: withI18n() })
+    const vault = await db.openVault('books', { locale: 'en' })
+    vault.collection<Invoice>('invoices', {})
+    const second = vault.collection<Invoice>('invoices', {
+      i18nFields: { memo: i18nText({ languages: ['en', 'th'], required: 'any' }) },
+    })
+    // A THIRD call with different i18nFields config must not throw and must not reattach.
+    expect(() => vault.collection<Invoice>('invoices', {
+      i18nFields: { memo: i18nText({ languages: ['en'], required: 'all' }) },
+    })).not.toThrow()
+    await second.put('i1', { id: 'i1', total: 1, memo: { en: 'Hi' } }) // th NOT required — the FIRST config (required:'any') won, not the third call's required:'all'
+  })
+})
+
+describe('#664 Part 2 — dictKeyFields late-attach reconcile', () => {
+  it('open without dictKeyFields, re-open with staticDict — closed-vocab enforcement AND <field>Label dressing activate post-attach', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-dictkey-1', i18nStrategy: withI18n() })
+    const vault = await db.openVault('co1', { locale: 'th' })
+
+    // First declaration: no dictKeyFields — "status" is a plain, unvalidated string field.
+    const first = vault.collection<Worker>('workers', {})
+    await first.put('w0', { id: 'w0', status: 'anything-goes' }) // no enforcement yet
+
+    const beforeAttach = await first.get('w0')
+    expect(beforeAttach).not.toHaveProperty('statusLabel')
+
+    // Late-attach dictKeyFields (staticDict — closed vocabulary by default).
+    const second = vault.collection<Worker>('workers', {
+      dictKeyFields: { status: staticDict('civilStatus', CIVIL_STATUS, { displayLocale: 'th' }) },
+    })
+    expect(second).toBe(first)
+
+    // Closed-vocab enforcement is now LIVE — an unknown code refuses at put time.
+    await expect(second.put('w1', { id: 'w1', status: 'not-a-key' })).rejects.toThrow(UnknownDictCodeError)
+
+    // A valid code writes fine and dresses `<field>Label` on read.
+    await second.put('w2', { id: 'w2', status: 'married' })
+    const w2 = await second.get('w2', { locale: 'th' })
+    expect(w2?.status).toBe('married')
+    expect(w2?.['statusLabel']).toBe('สมรส')
+  })
+
+  it('closed-vocab enforcement does NOT retroactively apply to records written before the attach', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-dictkey-2', i18nStrategy: withI18n() })
+    const vault = await db.openVault('co1')
+    const first = vault.collection<Worker>('workers', {})
+    await first.put('w0', { id: 'w0', status: 'pre-existing-junk' })
+
+    vault.collection<Worker>('workers', {
+      dictKeyFields: { status: staticDict('civilStatus', CIVIL_STATUS) },
+    })
+    // Reading the pre-existing record back does not throw (future-writes-only semantics —
+    // seam map §3's documented scope for a late-attached lookup/dictKey family).
+    const w0 = await first.get('w0')
+    expect(w0?.status).toBe('pre-existing-junk')
+  })
+})

--- a/packages/hub/__tests__/via/reconcile-lookup.test.ts
+++ b/packages/hub/__tests__/via/reconcile-lookup.test.ts
@@ -13,15 +13,20 @@
 import { describe, it, expect } from 'vitest'
 import { createNoydb } from '../../src/index.js'
 import { withI18n } from '../../src/shape/via-i18n/index.js'
+import { i18nText } from '../../src/shape/via-i18n/core.js'
+import { staticDict } from '../../src/shape/via-i18n/dictionary.js'
 import { lookup, enumOf, dict } from '../../src/shape/via-lookup/descriptor.js'
 import { money } from '../../src/shape/via-money/descriptor.js'
-import { UnknownLookupKeyError, DictKeyInUseError, ValidationError } from '../../src/kernel/errors.js'
+import { UnknownLookupKeyError, UnknownDictCodeError, DictKeyInUseError, ValidationError } from '../../src/kernel/errors.js'
 import { inlineMemory } from '../classified/harness.js'
 
 interface Order extends Record<string, unknown> { id: string; status: string }
 interface Country extends Record<string, unknown> { id: string; name: string }
 interface Traveler extends Record<string, unknown> { id: string; country: string }
 interface Item extends Record<string, unknown> { id: string; amount: number }
+interface Ticket extends Record<string, unknown> { id: string; memo?: Record<string, string>; status?: string; category?: string }
+
+const CIVIL_STATUS = { single: { en: 'Single', th: 'โสด' }, married: { en: 'Married', th: 'สมรส' } } as const
 
 const STATUS_TABLE = { paid: { en: 'Paid' }, due: { en: 'Due' } } as const
 
@@ -241,5 +246,60 @@ describe('#664 Part 2b — first-wins: a second, later lookupFields call is a no
     })).not.toThrow()
     // The FIRST config won — 'open' (not a member of the third call's key set) still passes.
     await expect(second.put('t1', { id: 't1', status: 'open' })).resolves.not.toThrow()
+  })
+})
+
+describe('t8r1 — combined single-call late-attach (i18n/dictKey + lookup on DIFFERENT fields): pins the separate-if dispatch', () => {
+  // `reconcileViaAttach` (via-reconcile.ts) dispatches i18n/dictKey and lookup through two
+  // SEPARATE `if` statements, deliberately not chained as an else-if (see its own doc comment) —
+  // because a single vault.collection() call may legally declare i18nFields/dictKeyFields on one
+  // field AND lookupFields on a DIFFERENT field in the SAME call. A future collapse onto a shared
+  // else-if ladder would silently drop whichever half runs second — these tests exercise BOTH
+  // halves activating from ONE call, so such a regression fails loudly.
+  it('(i) i18nFields (field A: memo) + lookupFields (field B: status) in ONE late-attach call: BOTH function afterward', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-t8r1-i18n-lookup-1', i18nStrategy: withI18n() })
+    const vault = await db.openVault('t8r1-a', { locale: 'en' })
+
+    const first = vault.collection<Ticket>('tickets-combo', {})
+    await first.put('t0', { id: 't0', memo: { en: 'pre' }, status: 'anything-goes' }) // pre-attach: unenforced
+
+    const second = vault.collection<Ticket>('tickets-combo', {
+      i18nFields: { memo: i18nText({ languages: ['en', 'th'], required: 'any' }) },
+      lookupFields: { status: enumOf(['open', 'closed']) },
+    })
+    expect(second).toBe(first)
+
+    // i18n half: memo resolves per-locale on a NEW write.
+    await second.put('t1', { id: 't1', memo: { en: 'Hello', th: 'สวัสดี' }, status: 'open' })
+    const t1 = await second.get('t1', { locale: 'th' })
+    expect(t1?.memo).toBe('สวัสดี')
+
+    // lookup half: status vocabulary enforces on a NEW write.
+    await expect(second.put('t2', { id: 't2', memo: { en: 'x' }, status: 'bogus' })).rejects.toThrow(UnknownLookupKeyError)
+    await expect(second.put('t3', { id: 't3', memo: { en: 'x' }, status: 'closed' })).resolves.not.toThrow()
+  })
+
+  it('(ii) dictKeyFields (field A: status) + lookupFields (field B: category) in ONE late-attach call: BOTH function afterward', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-t8r1-dictkey-lookup-1', i18nStrategy: withI18n() })
+    const vault = await db.openVault('t8r1-b', { locale: 'th' })
+
+    const first = vault.collection<Ticket>('tickets-combo-2', {})
+    await first.put('t0', { id: 't0', status: 'anything-goes', category: 'anything-goes' }) // pre-attach: unenforced
+
+    const second = vault.collection<Ticket>('tickets-combo-2', {
+      dictKeyFields: { status: staticDict('t8r1-civil-status', CIVIL_STATUS) },
+      lookupFields: { category: enumOf(['bug', 'feature']) },
+    })
+    expect(second).toBe(first)
+
+    // dictKey half: closed-vocab enforcement + <field>Label dressing.
+    await expect(second.put('t1', { id: 't1', status: 'not-a-key', category: 'bug' })).rejects.toThrow(UnknownDictCodeError)
+    await second.put('t2', { id: 't2', status: 'married', category: 'bug' })
+    const t2 = await second.get('t2', { locale: 'th' })
+    expect(t2?.['statusLabel']).toBe('สมรส')
+
+    // lookup half: category vocabulary enforces.
+    await expect(second.put('t3', { id: 't3', status: 'married', category: 'not-a-category' })).rejects.toThrow(UnknownLookupKeyError)
+    await expect(second.put('t4', { id: 't4', status: 'married', category: 'feature' })).resolves.not.toThrow()
   })
 })

--- a/packages/hub/__tests__/via/reconcile-lookup.test.ts
+++ b/packages/hub/__tests__/via/reconcile-lookup.test.ts
@@ -1,0 +1,245 @@
+/**
+ * #664 Part 2b — the lookup()/enumOf()/dict() late-attach reconcile machinery, tier-scoped.
+ * Pre-#664, `lookupFields` on a SECOND-OR-LATER `vault.collection()` call was silently ignored —
+ * only the fresh-construction branch ever wired it (no `_applyLookupFields` existed). `via-
+ * reconcile.ts`'s `reconcileLookupFields` closes that gap:
+ *
+ *  - enum (`backing:'static'`, no `table`) / static (`+table`) — self-contained, clean attach.
+ *  - reserved (`dict()`) — additionally wires the SAME vault registries (`dictKeyFieldRegistry`/
+ *    `reservedLookupCollections`) the fresh path populates.
+ *  - matrix (`backing:'collection'`) — refuses with a `ValidationError` unless the backing
+ *    collection is already open (this vault session) AND prefetch-enabled.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../../src/index.js'
+import { withI18n } from '../../src/shape/via-i18n/index.js'
+import { lookup, enumOf, dict } from '../../src/shape/via-lookup/descriptor.js'
+import { money } from '../../src/shape/via-money/descriptor.js'
+import { UnknownLookupKeyError, DictKeyInUseError, ValidationError } from '../../src/kernel/errors.js'
+import { inlineMemory } from '../classified/harness.js'
+
+interface Order extends Record<string, unknown> { id: string; status: string }
+interface Country extends Record<string, unknown> { id: string; name: string }
+interface Traveler extends Record<string, unknown> { id: string; country: string }
+interface Item extends Record<string, unknown> { id: string; amount: number }
+
+const STATUS_TABLE = { paid: { en: 'Paid' }, due: { en: 'Due' } } as const
+
+describe('#664 Part 2b — enum/static tier lookup late-attach reconcile', () => {
+  it('bare enumOf(): closed-vocab refusal activates post-attach; a declared key still passes', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-lookup-enum-1', i18nStrategy: withI18n() })
+    const vault = await db.openVault('v1')
+
+    const first = vault.collection<Order>('tickets', {})
+    await first.put('t0', { id: 't0', status: 'anything-goes' }) // pre-attach: unenforced
+
+    const second = vault.collection<Order>('tickets', {
+      lookupFields: { status: enumOf(['open', 'closed']) },
+    })
+    expect(second).toBe(first)
+
+    await expect(second.put('t1', { id: 't1', status: 'bogus' })).rejects.toThrow(UnknownLookupKeyError)
+    await expect(second.put('t2', { id: 't2', status: 'open' })).resolves.not.toThrow()
+  })
+
+  it('static tier (table-bearing): closed-vocab refusal, altKeys normalize, and <field>Label dresses on read — all live post-attach', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-lookup-static-1', i18nStrategy: withI18n() })
+    const vault = await db.openVault('v2', { locale: 'en' })
+
+    const first = vault.collection<Order>('orders', {})
+    await first.put('o0', { id: 'o0', status: 'whatever' }) // pre-attach: unenforced, no Label
+
+    const second = vault.collection<Order>('orders', {
+      lookupFields: {
+        status: lookup('billingStatus', { backing: 'static', table: STATUS_TABLE, altKeys: ['en'], vocabulary: 'closed' }),
+      },
+    })
+    expect(second).toBe(first)
+
+    // altKeys normalize: the English label text 'Paid' is a declared altKey candidate for 'paid'.
+    await second.put('o1', { id: 'o1', status: 'Paid' })
+    const stored1 = await second._getStoredRecord('o1')
+    expect(stored1?.status).toBe('paid')
+
+    // closed-vocab refusal is live post-attach.
+    await expect(second.put('o2', { id: 'o2', status: 'unknown-code' })).rejects.toThrow(UnknownLookupKeyError)
+
+    // <field>Label dresses on read.
+    const o1 = await second.get('o1', { locale: 'en' })
+    expect(o1?.['statusLabel']).toBe('Paid')
+  })
+})
+
+describe('#664 Part 2b — reserved (dict) tier lookup late-attach reconcile', () => {
+  it('closed-vocab refusal + <field>Label dressing activate post-attach; reservedLookupCollections registry is updated', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-lookup-dict-1', i18nStrategy: withI18n() })
+    const vault = await db.openVault('v3', { locale: 'en' })
+    await vault.dictionary('billing-status').put('paid', { en: 'Paid' })
+
+    const first = vault.collection<Order>('invoices', {})
+    await first.put('i0', { id: 'i0', status: 'anything-goes' }) // pre-attach: unenforced
+
+    const second = vault.collection<Order>('invoices', {
+      lookupFields: { status: dict('billing-status', { vocabulary: 'closed' }) },
+    })
+    expect(second).toBe(first)
+
+    // Registry pin (per the brief's escape hatch — a full two-instance sync test is
+    // disproportionate here; this asserts the SAME `reservedLookupCollections` registry the sync
+    // engine's `_reservedLookupCollectionNames()` reads was populated by the late-attach, not just
+    // by fresh construction).
+    expect(vault._reservedLookupCollectionNames()).toContain('_dict_billing-status')
+
+    // closed-vocab refusal is live post-attach.
+    await expect(second.put('i1', { id: 'i1', status: 'not-a-key' })).rejects.toThrow(UnknownLookupKeyError)
+
+    // A valid write dresses <field>Label on read.
+    await second.put('i2', { id: 'i2', status: 'paid' })
+    const i2 = await second.get('i2', { locale: 'en' })
+    expect(i2?.['statusLabel']).toBe('Paid')
+  })
+
+  it('dictKeyFieldRegistry is populated by the late-attach — proven via LookupHandle.rename()\'s referencing-record rewrite (choke-point participation)', async () => {
+    // Open vocabulary here (dict()'s default) — a CLOSED field's rename interacts with
+    // LookupHandle.rename()'s own cache-update ordering (the new key's write-through cache entry
+    // lands AFTER the referencing-record rewrite step) independently of #664; open vocabulary
+    // isolates the one thing this test is proving — that the late-attach wired
+    // `dictKeyFieldRegistry`, the registry `findAndUpdateReferences`/`updateReferencingRecords`
+    // reads to find which collections reference this dictionary.
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-lookup-dict-2', i18nStrategy: withI18n() })
+    const vault = await db.openVault('v3b')
+    await vault.dictionary('billing-status-2').put('paid', { en: 'Paid' })
+
+    const first = vault.collection<Order>('invoices2', {})
+    const second = vault.collection<Order>('invoices2', {
+      lookupFields: { status: dict('billing-status-2') },
+    })
+    expect(second).toBe(first)
+    await second.put('i1', { id: 'i1', status: 'paid' })
+
+    // If the late-attach had silently skipped `dictKeyFieldRegistry`, "invoices2" would not be
+    // among the collections `updateReferencingRecords` scans, and i1's status would stay 'paid'.
+    await vault.dictionary('billing-status-2').rename('paid', 'paid-v2')
+    const i1After = await second.get('i1')
+    expect(i1After?.status).toBe('paid-v2')
+  })
+})
+
+describe('#664 Part 2b — matrix (collection) tier lookup late-attach reconcile', () => {
+  it('refuses with a ValidationError naming the field/dimension/remedy when the backing dimension is not open', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-lookup-matrix-1', i18nStrategy: withI18n() })
+    const vault = await db.openVault('v4')
+    vault.collection<Traveler>('travelers', {})
+
+    expect(() => vault.collection<Traveler>('travelers', {
+      lookupFields: { country: lookup('countries') },
+    })).toThrow(ValidationError)
+    expect(() => vault.collection<Traveler>('travelers', {
+      lookupFields: { country: lookup('countries') },
+    })).toThrow(/matrix field "country".*dimension "countries".*not open/)
+  })
+
+  it('refuses with a ValidationError naming the remedy when the backing dimension is open but lazy (prefetch:false)', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-lookup-matrix-2', i18nStrategy: withI18n() })
+    const vault = await db.openVault('v5')
+    vault.collection<Country>('countries', { prefetch: false, cache: { maxRecords: 10 } })
+    vault.collection<Traveler>('travelers', {})
+
+    expect(() => vault.collection<Traveler>('travelers', {
+      lookupFields: { country: lookup('countries') },
+    })).toThrow(ValidationError)
+    expect(() => vault.collection<Traveler>('travelers', {
+      lookupFields: { country: lookup('countries') },
+    })).toThrow(/lazy mode/)
+  })
+
+  it('succeeds when the backing dimension is already open and prefetch-enabled — closed-vocab refusal + <field>Label dressing activate post-attach', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-lookup-matrix-3', i18nStrategy: withI18n() })
+    const vault = await db.openVault('v6', { locale: 'en' })
+    const countries = vault.collection<Country>('countries', {})
+    await countries.put('US', { id: 'US', name: 'United States' })
+
+    const first = vault.collection<Traveler>('travelers', {})
+    await first.put('t0', { id: 't0', country: 'anything-goes' }) // pre-attach: unenforced
+
+    const second = vault.collection<Traveler>('travelers', {
+      lookupFields: { country: lookup('countries', { present: { label: 'name' }, vocabulary: 'closed' }) },
+    })
+    expect(second).toBe(first)
+
+    await expect(second.put('t1', { id: 't1', country: 'ZZ' })).rejects.toThrow(UnknownLookupKeyError)
+
+    await second.put('t2', { id: 't2', country: 'US' })
+    const t2 = await second.get('t2', { locale: 'en' })
+    expect(t2?.['countryLabel']).toBe('United States')
+  })
+})
+
+describe('#664 Part 2b — graph ref edges are live immediately post-attach (ViaGraph.referencingEdgesOf)', () => {
+  it('matrix tier, restrict (default): deleting a referenced backing row throws DictKeyInUseError post-attach', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-lookup-edges-1', i18nStrategy: withI18n() })
+    const vault = await db.openVault('v7')
+    const countries = vault.collection<Country>('countries', {})
+    await countries.put('US', { id: 'US', name: 'United States' })
+
+    const travelers = vault.collection<Traveler>('travelers', {})
+    await travelers.put('t0', { id: 't0', country: 'unrelated' })
+
+    // Late-attach — the ref edge (travelers.country -> countries.*) must be registered NOW,
+    // not just at fresh construction.
+    vault.collection<Traveler>('travelers', {
+      lookupFields: { country: lookup('countries') }, // default onDelete: 'restrict'
+    })
+    await travelers.put('t1', { id: 't1', country: 'US' })
+
+    await expect(countries.delete('US')).rejects.toThrow(DictKeyInUseError)
+    await travelers.delete('t1')
+    await expect(countries.delete('US')).resolves.not.toThrow()
+  })
+
+  it('reserved tier, cascade: deleting the dictionary row tombstones the referencing record post-attach', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-lookup-edges-2', i18nStrategy: withI18n() })
+    const vault = await db.openVault('v8')
+    await vault.dictionary('status-cascade').put('paid', { en: 'Paid' })
+
+    const orders = vault.collection<Order>('orders-cascade', {})
+    await orders.put('o0', { id: 'o0', status: 'unrelated' })
+
+    vault.collection<Order>('orders-cascade', {
+      lookupFields: { status: dict('status-cascade', { onDelete: 'cascade' }) },
+    })
+    await orders.put('o1', { id: 'o1', status: 'paid' })
+
+    await vault.dictionary('status-cascade').delete('paid')
+
+    expect(await orders.get('o1')).toBeNull()
+  })
+})
+
+describe('#664 Part 2b — lookup late-attach respects the #664 collision guard automatically', () => {
+  it('control: attaching a lookupFields entry onto a field already owned by money refuses', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-lookup-guard-1', i18nStrategy: withI18n() })
+    const vault = await db.openVault('v9')
+    vault.collection<Item>('items', { moneyFields: { amount: money({ currency: 'USD' }) } })
+
+    expect(() => vault.collection<Item>('items', {
+      lookupFields: { amount: enumOf(['a', 'b']) },
+    })).toThrow(ValidationError)
+  })
+})
+
+describe('#664 Part 2b — first-wins: a second, later lookupFields call is a no-op', () => {
+  it('the family attaches at most once — a differently-configured third call does not reattach', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-lookup-firstwins-1', i18nStrategy: withI18n() })
+    const vault = await db.openVault('v10')
+    vault.collection<Order>('tasks', {})
+    const second = vault.collection<Order>('tasks', {
+      lookupFields: { status: enumOf(['open', 'closed']) },
+    })
+    expect(() => vault.collection<Order>('tasks', {
+      lookupFields: { status: enumOf(['different', 'keys']) },
+    })).not.toThrow()
+    // The FIRST config won — 'open' (not a member of the third call's key set) still passes.
+    await expect(second.put('t1', { id: 't1', status: 'open' })).resolves.not.toThrow()
+  })
+})

--- a/packages/hub/__tests__/via/set-via-seam.test.ts
+++ b/packages/hub/__tests__/via/set-via-seam.test.ts
@@ -1,0 +1,75 @@
+/**
+ * #666 — `Collection._setVia` writer seam: the typed replacement for
+ * `via-graph-wiring.ts`'s untyped `coll as { via; codec: { setVia } }` cast.
+ *
+ * Contract: `_setVia(pipeline)` must do BOTH of the cast site's two old
+ * steps — reassign the live `this.via` AND resync `this.codec`'s own
+ * captured `via` reference (`RecordCodec.setVia`) — or the codec's at-rest
+ * hooks (`hasAtRestHooks`/`encodeAtRest`/`decodeAtRest`) keep reading a
+ * stale pre-setVia pipeline: the codec holds its OWN `ctx.via`, not a live
+ * view of `Collection.via` (`__tests__/via/codec-boundary.test.ts` documents
+ * why). A put+get round trip is the only way to observe the codec half of
+ * the contract — reading `coll._via` alone only proves the assignment half.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, SealedHandle } from '../../src/index.js'
+import { ViaPipeline } from '../../src/kernel/via-pipeline.js'
+import { taintBinding } from '../../src/kernel/via-taint-binding.js'
+import { inlineMemory } from '../classified/harness.js'
+
+interface Item extends Record<string, unknown> {
+  id: string
+  secret: string
+  open: string
+}
+
+async function plainVault(secret: string) {
+  const store = inlineMemory()
+  const db = await createNoydb({ store, user: 'a', secret })
+  const v = await db.openVault('v1')
+  const c = v.collection<Item>('items')
+  return { c }
+}
+
+describe('Collection._setVia writer seam (#666)', () => {
+  it('a freshly-opened plain collection has no via pipeline', async () => {
+    const { c } = await plainVault('setvia-0')
+    expect(c._via).toBeUndefined()
+  })
+
+  it('assigns the pipeline AND resyncs the codec — a sealed field round-trips as a SealedHandle', async () => {
+    const { c } = await plainVault('setvia-1')
+    const pipeline = ViaPipeline.build([taintBinding(new Set(['secret']))])!
+    expect(pipeline.hasAtRestHooks).toBe(true)
+
+    c._setVia(pipeline)
+
+    // (a) the assignment itself, observable via the existing `_via` getter.
+    expect(c._via).toBe(pipeline)
+
+    // (b) the codec resync — observable ONLY through at-rest behavior: put +
+    // get must actually seal `secret`, which requires the CODEC's own
+    // `ctx.via` (not just `Collection.via`) to see the new pipeline.
+    await c.put('r1', { id: 'r1', secret: 'hunter2', open: 'visible' })
+    const rec = await c.get('r1')
+    expect(rec?.secret).toBeInstanceOf(SealedHandle)
+    expect(rec?.open).toBe('visible')
+    await expect((rec?.secret as unknown as SealedHandle<unknown>).reveal()).resolves.toBe('hunter2')
+  })
+
+  it('_setVia(undefined) clears the pipeline back off, codec included', async () => {
+    const { c } = await plainVault('setvia-2')
+    const pipeline = ViaPipeline.build([taintBinding(new Set(['secret']))])!
+    c._setVia(pipeline)
+    expect(c._via).toBe(pipeline)
+
+    c._setVia(undefined)
+    expect(c._via).toBeUndefined()
+
+    // codec resynced too: a field the old pipeline would have sealed now
+    // round-trips as a plain value.
+    await c.put('r2', { id: 'r2', secret: 'nolongersealed', open: 'x' })
+    const rec = await c.get('r2')
+    expect(rec?.secret).toBe('nolongersealed')
+  })
+})

--- a/packages/hub/src/kernel/collection-config.ts
+++ b/packages/hub/src/kernel/collection-config.ts
@@ -76,7 +76,7 @@ import type { Collection, OnDirtyCallback, CacheOptions } from './collection.js'
 import type { LazyStrategy } from '../port/with/lazy-strategy.js'
 import { ViaPipeline } from './via-pipeline.js'
 import { viaBinder, type ViaBinding, type ViaDescriptor } from './via.js'
-import { mergeViaFields, type ViaFieldSpec } from './via-compose.js'
+import { mergeViaFields, guardCrossBindingFieldCollisions, type ViaFieldSpec } from './via-compose.js'
 
 /**
  * Raw options handed to the {@link Collection} constructor by the Vault.
@@ -545,95 +545,6 @@ export function computedEntryParts(entry: ComputedFn | ComputedFieldEntry): Comp
  */
 function unifyComputedFields<T>(opts: CollectionOpts<T>, viaComputedFields: Record<string, ComputedDescriptor> | undefined): ComputedFields {
   return { ...(opts.computed ?? {}), ...(viaComputedFields ?? {}) }
-}
-
-/** Maps each per-family field-map's option key to its binding family name — used only by
- *  {@link guardCrossBindingFieldCollisions} to tell a genuine cross-family collision apart
- *  from the SAME family surfaced through two sugar keys (`i18nFields` + `dictKeyFields` both
- *  feed the ONE 'i18n' binder — not this guard's job; a family's own duplicate handling
- *  stays wherever it already lives). */
-const VIA_FIELD_MAP_FAMILY: Readonly<Record<string, string>> = {
-  moneyFields: 'money', i18nFields: 'i18n', dictKeyFields: 'i18n', lookupFields: 'lookup',
-  classifiedFields: 'classified', blobFields: 'blob', computed: 'computed',
-}
-
-/**
- * #631 — declare-time cross-binding same-field collision guard. Today the same field named
- * in two DIFFERENT via-binding families (e.g. the same field in both `moneyFields` and
- * `blobFields`) resolves silently by compile-order first-wins in `ViaPipeline`'s per-field
- * posture/clause lookup — undefined pipeline behavior for a config that is almost certainly a
- * mistake. `mergeViaFields` already guards sugar-vs-`viaFields` and `dictKeyFields`-vs-
- * `lookupFields` collisions (#623 Task 9); this runs one step later, in `compileViaBindings`,
- * because that's the only seam that also sees `classifiedFields`/`blobFields` — neither is
- * part of `ViaFieldSources`, so `mergeViaFields` never sees them.
- *
- * WHY FAMILY-BASED, NOT PROVENANCE-BASED (#631 review, round 2 — Controller ruling): a field
- * declared via `via(computed(fn), money(...))` and a field declared via two independent sugar
- * maps (`computed: { total: fn }` + `moneyFields: { total: money(...) }`) are NOT
- * distinguishable here — `mergeViaFields` (via-compose.ts) folds both declaration STYLES into
- * the IDENTICAL merged per-family field maps this function receives; provenance (which style
- * produced a given map entry) is erased before this guard ever runs. Narrowing the exemption to
- * "only via()-composed fields" would therefore require threading a second, parallel
- * provenance-tracking data structure through `mergeViaFields` for the sole purpose of refusing a
- * config that is BEHAVIORALLY IDENTICAL to the sanctioned one — refusing it would be a
- * behavior-lock violation (breaking a legal, meaningful config), not a bug fix. The exemption is
- * therefore keyed on the FAMILY SET alone, and instead earned empirically per family (below).
- *
- * EXEMPT (test-earned, not merely asserted): `computed` colliding with EXACTLY ONE of
- * `money`/`i18n`/`lookup` on the same field. `via()`'s descriptor loop only accepts
- * money/i18n/computed/lookup `_viaBrand`s (`mergeViaFields` throws on any other brand), so a
- * computed+classified or computed+blob same-field pairing can never arise from composition — it
- * can only come from mistakenly naming the same field in `computed`/`viaFields` AND
- * `classifiedFields`/`blobFields`, which this guard still refuses. For the three families that
- * CAN legitimately arise, each is pinned by an end-to-end runtime test proving the composition
- * does something real (not just "doesn't throw") — see `computed/virtual.test.ts`:
- *   - money: the "composed grammar" tests (materialized-mode money formatting the computed
- *     output; the ORIGINAL evidence this exemption started from — see the money DOES/does NOT
- *     format the computed output pair).
- *   - i18n (dictKey) / lookup (dict()): the "composed grammar — computed + i18n/lookup
- *     families (#631 collision-guard exemption pins)" block, BOTH declaration styles
- *     (`via(computed(...), dictKey(...)/dict(...))` and the two-independent-sugar-maps form),
- *     materialized mode — proven to dress `<field>Label` off the computed output identically
- *     either way (the provenance-erasure claim above, empirically confirmed). Virtual mode for
- *     both families hits the SAME present-ORDER limitation money's own virtual composed-grammar
- *     test already documents (i18n/lookup's `present()` runs BEFORE computed's — a virtual field
- *     is never stored, so there is nothing to dress yet); pinned as a known limitation, not
- *     grounds to drop the family from the exemption (materialized mode is what proves the family
- *     genuinely composes).
- *
- * 3-CLAIMANT TIGHTENING (#631 review, round 2): the exemption requires EXACTLY TWO claimant
- * source-keys, not just two families. A field named in `computed` + BOTH `i18nFields` AND
- * `dictKeyFields` collapses to the same two families (`{computed, i18n}` — `dictKeyFields`
- * shares the `i18n` family) but is a genuine THREE-claimant collision: two independent i18n
- * sugar keys both claiming the field is itself a mistake this guard exists to catch, and must
- * not slip through because the family SET happens to match the earned exemption's shape.
- */
-function guardCrossBindingFieldCollisions(
-  fieldMaps: Readonly<Record<string, Record<string, unknown> | undefined>>,
-): void {
-  const claimantsByField = new Map<string, Set<string>>()
-  for (const [sourceKey, map] of Object.entries(fieldMaps)) {
-    for (const field of Object.keys(map ?? {})) {
-      const claimants = claimantsByField.get(field) ?? new Set<string>()
-      claimants.add(sourceKey)
-      claimantsByField.set(field, claimants)
-    }
-  }
-  for (const [field, sourceKeys] of claimantsByField) {
-    const families = new Set([...sourceKeys].map((key) => VIA_FIELD_MAP_FAMILY[key]))
-    if (families.size < 2) continue // same family via two sugar keys (e.g. i18n/dictKey) — not this guard's job
-    // Exactly two CLAIMANTS (not just two families) — see "3-CLAIMANT TIGHTENING" above.
-    if (sourceKeys.size === 2 && families.has('computed')) {
-      const other = [...families].find((f) => f !== 'computed')
-      if (other === 'money' || other === 'i18n' || other === 'lookup') continue // composed grammar, test-earned (#638/#631)
-    }
-    const keys = [...sourceKeys].sort().map((k) => `\`${k}\``)
-    const joined = keys.length === 2 ? keys.join(' and ') : `${keys.slice(0, -1).join(', ')}, and ${keys[keys.length - 1]}`
-    throw new ValidationError(
-      `compileViaBindings(): field "${field}" is declared in both ${joined} — a field cannot be claimed by two ` +
-      'different via-binding families. Declare it in one place only.',
-    )
-  }
 }
 
 /**

--- a/packages/hub/src/kernel/collection-config.ts
+++ b/packages/hub/src/kernel/collection-config.ts
@@ -571,10 +571,11 @@ function unifyComputedFields<T>(opts: CollectionOpts<T>, viaComputedFields: Reco
  * declares NO write/read pipeline hooks (blob content is out-of-band
  * `BlobSet` side-collections — it must never flip `hasAtRestHooks`), only
  * `erase`/`describeFragment`. Computed compiles LAST (#638 Task 7) — its
- * `present` hook is the only one it declares, and it must run AFTER money/
- * i18n's own `present` so a virtual field's `deps` can read their decoded
- * output (money-quantized amount, i18n-resolved label), not their raw
- * stored form. `via-graph-wiring.ts#applyTaintOverlay` appends the `taint`
+ * `present` hook must run AFTER money's own `present` so a virtual field's
+ * `deps` read the decoded (quantized) amount, not the raw stored form; at
+ * present-time i18n/lookup's DRESSING now runs AFTER computed instead (#665
+ * `_presentOrder`, `via-pipeline.ts` — compile order here is unchanged).
+ * `via-graph-wiring.ts#applyTaintOverlay` appends the `taint`
  * binding after WHATEVER this function returns, so taint's present-time
  * redaction always runs after computed's regardless of this ordering.
  * {@link Collection._applyMoneyFields} PREPENDS money for the same reason

--- a/packages/hub/src/kernel/collection-config.ts
+++ b/packages/hub/src/kernel/collection-config.ts
@@ -637,6 +637,8 @@ export function compileViaBindings<T>(
   // SEPARATE binding from i18n above — dictKey()/staticDict() stay on the
   // i18n binding (the alias, unchanged); a collection declaring BOTH
   // dictKeyFields and lookupFields compiles both bindings.
+  // must move together with via-reconcile.ts's lookup binder-config block (reconcileLookupFields,
+  // the `viaBinder('lookup')({...})` call) (#664) — same option-shape contract.
   if (lookupFields !== undefined) {
     bindings.push(viaBinder('lookup')({
       lookupFields,

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -1368,8 +1368,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     })])
   }
 
-  /** @internal — used only in tests; do not read in production code. */
-  get _ramCiphertext(): boolean { return this.ramCiphertext }
+  get _ramCiphertext(): boolean { return this.ramCiphertext } // @internal — used only in tests; do not read in production code.
 
   /**
    * Get a single record by ID.
@@ -4423,6 +4422,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
 
   async _onViaErase(id: string, live: EncryptedEnvelope): Promise<ViaEraseReport | undefined> { return this.via ? this.via.eraseSealed({ id, vault: this.vault, live, crypto: await this.codec.eraseCryptoCtx(id, live) }) : undefined } // @internal forget()'s per-ref via-erase fold (#629 T10)
   get _via(): ViaPipeline | undefined { return this.via } // @internal exportRedact()'s typed reach-in accessor (fixes #634)
+  _setVia(pipeline: ViaPipeline | undefined): void { this.via = pipeline; this.codec.setVia(this.via) } // @internal applyTaintOverlay()'s typed writer seam — assigns `via` + resyncs the codec (fixes #666)
   /**
    * Bind the {@link TiersContext} the tier ops need. The `cekCache` is passed
    * by reference (the SAME `Lru` the kernel's read/write path owns) so an

--- a/packages/hub/src/kernel/query/builder.ts
+++ b/packages/hub/src/kernel/query/builder.ts
@@ -298,6 +298,7 @@ export class Query<T, S extends keyof T = never, Q extends keyof T & string = ne
             brand: viaClause.brand,
             payload: viaClause.payload,
             evaluate: (actual: unknown, evalOp: string) => via!.evaluateClause(viaClause, actual, evalOp),
+            indexValue: via!.indexProbe(viaClause, op),
           },
         }
       : { type: 'field', field, op, value }
@@ -1120,19 +1121,23 @@ function candidateRecords(source: InternalSource, clauses: readonly Clause[]): C
     if (clause.type !== 'field') continue
     if (!indexes.has(clause.field)) continue
     // A Via-covered clause (e.g. money) only carries a build-time
-    // evaluator payload for per-record comparison — `buildClause` does
-    // not rewrite `clause.value` into the index's stored representation
+    // evaluator payload for per-record comparison by default — `buildClause`
+    // does not rewrite `clause.value` into the index's stored representation
     // (e.g. multi-currency money operands are `{ amount, currency }`
     // objects; the index would stringify their keys to a no-match
-    // sentinel). Skip the index fast path for these clauses; the
-    // fallback scan evaluates them via `clause.via.evaluate`.
-    if (clause.via) continue
+    // sentinel). A binding MAY additionally supply `indexValue` (#625,
+    // via `ViaBinding.indexProbe`) — the STORED-form operand for a direct
+    // probe (fixed-mode money `==`/`in` today). When it's absent, skip the
+    // index fast path for this clause; the fallback scan evaluates it via
+    // `clause.via.evaluate`.
+    if (clause.via && clause.via.indexValue === undefined) continue
+    const probeValue = clause.via ? clause.via.indexValue : clause.value
 
     let ids: ReadonlySet<string> | null = null
     if (clause.op === '==') {
-      ids = indexes.lookupEqual(clause.field, clause.value)
-    } else if (clause.op === 'in' && Array.isArray(clause.value)) {
-      ids = indexes.lookupIn(clause.field, clause.value)
+      ids = indexes.lookupEqual(clause.field, probeValue)
+    } else if (clause.op === 'in' && Array.isArray(probeValue)) {
+      ids = indexes.lookupIn(clause.field, probeValue)
     }
 
     if (ids !== null) {

--- a/packages/hub/src/kernel/query/builder.ts
+++ b/packages/hub/src/kernel/query/builder.ts
@@ -1129,7 +1129,14 @@ function candidateRecords(source: InternalSource, clauses: readonly Clause[]): C
     // via `ViaBinding.indexProbe`) — the STORED-form operand for a direct
     // probe (fixed-mode money `==`/`in` today). When it's absent, skip the
     // index fast path for this clause; the fallback scan evaluates it via
-    // `clause.via.evaluate`.
+    // `clause.via.evaluate`. MIXED-ERA CAVEAT (money): this probe hits the
+    // index bucket keyed by the RAW stored string; a legacy non-canonical
+    // scaled value (predates the field's money() declaration) is bucketed
+    // under its raw form and misses a canonical probe, while the scan
+    // fallback (`evaluateMoneyClause`) re-parses via BigInt and still
+    // matches it — see `moneyIndexProbe`'s doc comment (via-money/where.ts)
+    // for the full caveat; a money-aware index-key canonicalization is a
+    // filed follow-up, not implemented here.
     if (clause.via && clause.via.indexValue === undefined) continue
     const probeValue = clause.via ? clause.via.indexValue : clause.value
 

--- a/packages/hub/src/kernel/query/predicate.ts
+++ b/packages/hub/src/kernel/query/predicate.ts
@@ -43,6 +43,15 @@ export interface FieldClause {
     readonly brand: string
     readonly payload: unknown
     readonly evaluate: (actual: unknown, op: string) => boolean
+    /**
+     * The binding's `indexProbe` result for this clause's op/payload
+     * (#625) — the STORED-form operand `candidateRecords()` (`kernel/
+     * query/builder.ts`) can hand to `CollectionIndexes.lookupEqual`/
+     * `lookupIn` for a fast path. `undefined` (no `indexProbe` hook, or
+     * the binding declined to probe this op) means the field must fall
+     * back to a linear scan via `evaluate` above.
+     */
+    readonly indexValue?: unknown
   }
 }
 

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -117,7 +117,8 @@ import { isViaInstalled } from './via.js'
 import { mergeViaFields, type ViaFieldSpec } from './via-compose.js'
 import { exportRedact } from './via-pipeline.js'
 import { ViaGraph } from './via-graph.js'
-import { registerCollectionGraphSources, validateReconcileGraphEdges, commitReconcileGraphEdges, applyTaintOverlay, reapplyDependentOverlays, type ReconcileGraphOptions } from './via-graph-wiring.js'
+import { registerCollectionGraphSources, applyTaintOverlay, reapplyDependentOverlays } from './via-graph-wiring.js'
+import { reconcileViaAttach } from './via-reconcile.js'
 import { runGraphDispatchWave, putDerivedOutput, ledgerAuditHook, forgetDerivedFanout, touchFor, type GraphBatch, type ForgetFanoutStats, type RollupDeleteIntent } from './via-dispatch.js'
 import { NO_SYNC, type SyncStrategy } from '../with-party/team/sync-strategy.js'
 // Type-only imports for the guard + derivation services. The
@@ -223,7 +224,7 @@ export class Vault {
   private readonly shadowStrategy: ShadowStrategy
   private readonly historyStrategy: HistoryStrategy
   private readonly forgetStrategy: ForgetStrategy
-  private readonly i18nStrategy: I18nStrategy
+  readonly i18nStrategy: I18nStrategy // not `private` — the #664 via-reconcile.ts dispatch reads it through `ViaReconcileVaultCtx` (never a `Vault` import there, S5 port-layering)
   private readonly syncStrategy: SyncStrategy
   private readonly classifiedStrategy: ClassifiedStrategy
   /** Per-vault guard registry; `null` until `_initGuards()` runs (or for vaults that never register
@@ -350,7 +351,7 @@ export class Vault {
    * when per-call `{ locale }` options are not specified on individual
    * `get()`/`list()` calls.
    */
-  private locale: string | undefined
+  locale: string | undefined
 
   /**
    * Vault-level descriptive metadata. Set once at construction via
@@ -371,19 +372,19 @@ export class Vault {
   private consentContext: ConsentContext | null = null
 
   /** dictKeyField registry: collection name → field name → dictionary name — `DictionaryHandle.rename()`'s reference-update source; populated by `collection()` from `dictKeyFields`. */
-  private readonly dictKeyFieldRegistry = new Map<string, Record<string, string>>()
+  readonly dictKeyFieldRegistry = new Map<string, Record<string, string>>()
 
   /** Names of `staticDict()`-backed dictionaries (skip rename tracking; `vault.dictionary(name)` refuses mutation on these via `StaticDictReadonlyError`). Populated at `collection()` config time. */
-  private readonly staticDictNames = new Set<string>()
+  readonly staticDictNames = new Set<string>()
 
   /** Static-dict descriptors by dictionary name — backs the read-path label resolver and the `resolveDictSource` snapshot. Last writer wins across collections (tables match by construction). */
-  private readonly staticByName = new Map<string, StaticDictDescriptor>()
+  readonly staticByName = new Map<string, StaticDictDescriptor>()
 
   /** Per-collection field name → StaticDictDescriptor, validated by `enforceStaticDictOnPut`. */
-  private readonly staticDescriptorByField = new Map<string, Record<string, StaticDictDescriptor>>()
+  readonly staticDescriptorByField = new Map<string, Record<string, StaticDictDescriptor>>()
 
-  /** i18nText fields: collection name → field name → descriptor. Used by `applyI18nLocale`/`validateI18nTextValue`; populated by `collection()` from `i18nFields`. */
-  private readonly i18nFieldRegistry = new Map<string, Record<string, I18nTextDescriptor>>()
+  /** i18nText fields: collection name → field name → descriptor. Used by `applyI18nLocale`/`validateI18nTextValue`; populated by `collection()` from `i18nFields`. Not `private` — these five registries + `i18nStrategy`/`translateText` are read by the #664 `via-reconcile.ts` dispatch through `ViaReconcileVaultCtx` (a plain structural bag, never a `Vault` import — S5 port-layering forbids the kernel spine from reaching a with-* service, and this file's own reconcile-ladder logic moved OUT into that unguarded module). */
+  readonly i18nFieldRegistry = new Map<string, Record<string, I18nTextDescriptor>>()
 
   /** Cache of DictionaryHandle instances, one per dictionary name. */
   private readonly dictionaryCache = new Map<string, DictionaryHandle>()
@@ -391,7 +392,7 @@ export class Vault {
   /** #650 Task 4 (#647) — declared reserved-lookup collection name → dimension name, for dimensions
    *  with `backing:'reserved'` (dict()/dictKey()). The explicit sync-pull registry: NOT a blanket
    *  underscore-glob — populated at `collection()`-declare time and at `dictionary()`-call time. */
-  private readonly reservedLookupCollections = new Map<string, string>()
+  readonly reservedLookupCollections = new Map<string, string>()
 
   /** Registered link specs, keyed by link name; set by `vault.link()`. */
   private readonly linkRegistry = new Map<string, LinkSpec>()
@@ -413,7 +414,7 @@ export class Vault {
    * Optional translator callback threaded from `Noydb.invokeTranslator`.
    * Present only when `plaintextTranslator` was configured on `createNoydb()`.
    */
-  private readonly translateText:
+  readonly translateText:
     | ((text: string, from: string, to: string, field: string, collection: string) => Promise<string>)
     | undefined
 
@@ -840,36 +841,20 @@ export class Vault {
 
     let coll = this.collectionCache.get(collectionName)
     const effectiveViaFields = mergeViaFields({ moneyFields: options?.moneyFields, i18nFields: options?.i18nFields, dictKeyFields: options?.dictKeyFields, lookupFields: options?.lookupFields, viaFields: options?.viaFields }) // #627: merged view feeds both late-attach reconcile (below) and fresh construct
-    // Two-phase reconcile (#638 Task 2 wave 2, Findings I1/I2/M1/M2): validate
-    // combined existing+incoming computed/classified state before any
-    // _apply* below mutates, commit graph edges only once every _apply*
-    // succeeds (see via-graph-wiring.ts). The branches below reconcile a
-    // field-declaring option onto a collection MV dependency analysis may
-    // have auto-created bare during openVault, before this real
-    // declaration; each is first-wins.
-    const reconcilePlan = coll && (options?.computed || options?.classifiedFields)
-      ? validateReconcileGraphEdges(this.graph, collectionName, options as unknown as ReconcileGraphOptions)
-      : undefined
-    if (coll && effectiveViaFields.moneyFields) {
-      coll._applyMoneyFields(effectiveViaFields.moneyFields)
-    }
-    if (coll && options?.computed) {
-      coll._applyComputed(options.computed as ComputedFields)
-    }
-    if (coll && options?.fieldMeta) {
-      coll._applyFieldMeta(options.fieldMeta)
-    }
-    if (coll && options?.meta) {
-      coll._applyMeta(options.meta)
-    }
-    if (coll && options?.classifiedFields) {
-      // Cannot retro-seal — only merges rider computed fields; see
-      // Collection._applyClassifiedFields's own doc comment for the R1-R8 matrix.
-      coll._applyClassifiedFields(options.classifiedFields)
-    }
-    if (coll && reconcilePlan) {
-      commitReconcileGraphEdges(this.graph, collectionName, reconcilePlan)
-      applyTaintOverlay(coll, this.graph, collectionName) // #638 Task 3: a late attach can newly taint an already-built pipeline (#666: structural guard, no assertion)
+    // #664 — the whole late-attach reconcile ladder (collision guard, the five pre-existing
+    // _apply* reconciles, the two-phase graph-edge/taint commit, and the new i18n/dictKey
+    // machinery) now lives behind ONE dispatch call in the unguarded via-reconcile.ts, not
+    // inlined here. `Collection._applyX`'s own first-wins semantics are unchanged; this file
+    // only threads the field-declaring options + this vault's registries through.
+    if (coll) {
+      reconcileViaAttach(coll, this.graph, collectionName, this, {
+        effectiveViaFields,
+        ...(options?.computed !== undefined ? { computed: options.computed as ComputedFields } : {}),
+        ...(options?.fieldMeta !== undefined ? { fieldMeta: options.fieldMeta } : {}),
+        ...(options?.meta !== undefined ? { meta: options.meta } : {}),
+        ...(options?.classifiedFields !== undefined ? { classifiedFields: options.classifiedFields } : {}),
+        ...(options?.blobFields !== undefined ? { blobFields: options.blobFields } : {}),
+      })
     }
     if (!coll) {
       // Register ref declarations (if any) with the vault-level

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -1129,6 +1129,7 @@ export class Vault {
       }
       if (effectiveViaFields.lookupFields !== undefined) {
         // membership/getAltIndex (#650 Task 3) are vault-built closures — never a collection handle.
+        // must move together with via-reconcile.ts's five lookup closures (#664).
         collOpts.lookupLabelResolver = collOpts.dictLabelResolver
         collOpts.getLookupBacking = (desc: LookupDescriptor) => async (key: string) => // #651: snapshot-first (sole truth for key!=='id'); id-tier alone falls back to a live cold-session .get()
           buildLookupSnapshotRows(desc, (n) => this.reservedLookupCollections.has(dictCollectionName(n)), (n) => this.dictionary(n), (n) => this.collection<Record<string, unknown>>(n))?.get(key) ?? (desc.key === 'id' ? (await this.collection<Record<string, unknown>>(desc.dimension).get(key)) ?? undefined : undefined)

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -661,7 +661,7 @@ export class Vault {
       i18nStrategy: this.i18nStrategy, locale: this.locale, translateText: this.translateText,
       i18nFieldRegistry: this.i18nFieldRegistry, dictKeyFieldRegistry: this.dictKeyFieldRegistry,
       staticDescriptorByField: this.staticDescriptorByField, reservedLookupCollections: this.reservedLookupCollections,
-      staticByName: this.staticByName, staticDictNames: this.staticDictNames,
+      staticByName: this.staticByName, staticDictNames: this.staticDictNames, getOpenCollection: (n) => this._getCollection(n), getCollection: (n) => this.collection<Record<string, unknown>>(n),
       dictionary: (name) => this.dictionary(name),
       enforceI18nOnPut: (collectionName, record) => this.enforceI18nOnPut(collectionName, record),
       enforceStaticDictOnPut: (collectionName, record) => this.enforceStaticDictOnPut(collectionName, record),

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -118,7 +118,7 @@ import { mergeViaFields, type ViaFieldSpec } from './via-compose.js'
 import { exportRedact } from './via-pipeline.js'
 import { ViaGraph } from './via-graph.js'
 import { registerCollectionGraphSources, applyTaintOverlay, reapplyDependentOverlays } from './via-graph-wiring.js'
-import { reconcileViaAttach } from './via-reconcile.js'
+import { reconcileViaAttach, type ViaReconcileVaultCtx } from './via-reconcile.js'
 import { runGraphDispatchWave, putDerivedOutput, ledgerAuditHook, forgetDerivedFanout, touchFor, type GraphBatch, type ForgetFanoutStats, type RollupDeleteIntent } from './via-dispatch.js'
 import { NO_SYNC, type SyncStrategy } from '../with-party/team/sync-strategy.js'
 // Type-only imports for the guard + derivation services. The
@@ -224,7 +224,7 @@ export class Vault {
   private readonly shadowStrategy: ShadowStrategy
   private readonly historyStrategy: HistoryStrategy
   private readonly forgetStrategy: ForgetStrategy
-  readonly i18nStrategy: I18nStrategy // not `private` — the #664 via-reconcile.ts dispatch reads it through `ViaReconcileVaultCtx` (never a `Vault` import there, S5 port-layering)
+  private readonly i18nStrategy: I18nStrategy
   private readonly syncStrategy: SyncStrategy
   private readonly classifiedStrategy: ClassifiedStrategy
   /** Per-vault guard registry; `null` until `_initGuards()` runs (or for vaults that never register
@@ -351,7 +351,7 @@ export class Vault {
    * when per-call `{ locale }` options are not specified on individual
    * `get()`/`list()` calls.
    */
-  locale: string | undefined
+  private locale: string | undefined
 
   /**
    * Vault-level descriptive metadata. Set once at construction via
@@ -372,19 +372,19 @@ export class Vault {
   private consentContext: ConsentContext | null = null
 
   /** dictKeyField registry: collection name → field name → dictionary name — `DictionaryHandle.rename()`'s reference-update source; populated by `collection()` from `dictKeyFields`. */
-  readonly dictKeyFieldRegistry = new Map<string, Record<string, string>>()
+  private readonly dictKeyFieldRegistry = new Map<string, Record<string, string>>()
 
   /** Names of `staticDict()`-backed dictionaries (skip rename tracking; `vault.dictionary(name)` refuses mutation on these via `StaticDictReadonlyError`). Populated at `collection()` config time. */
-  readonly staticDictNames = new Set<string>()
+  private readonly staticDictNames = new Set<string>()
 
   /** Static-dict descriptors by dictionary name — backs the read-path label resolver and the `resolveDictSource` snapshot. Last writer wins across collections (tables match by construction). */
-  readonly staticByName = new Map<string, StaticDictDescriptor>()
+  private readonly staticByName = new Map<string, StaticDictDescriptor>()
 
   /** Per-collection field name → StaticDictDescriptor, validated by `enforceStaticDictOnPut`. */
-  readonly staticDescriptorByField = new Map<string, Record<string, StaticDictDescriptor>>()
+  private readonly staticDescriptorByField = new Map<string, Record<string, StaticDictDescriptor>>()
 
-  /** i18nText fields: collection name → field name → descriptor. Used by `applyI18nLocale`/`validateI18nTextValue`; populated by `collection()` from `i18nFields`. Not `private` — these five registries + `i18nStrategy`/`translateText` are read by the #664 `via-reconcile.ts` dispatch through `ViaReconcileVaultCtx` (a plain structural bag, never a `Vault` import — S5 port-layering forbids the kernel spine from reaching a with-* service, and this file's own reconcile-ladder logic moved OUT into that unguarded module). */
-  readonly i18nFieldRegistry = new Map<string, Record<string, I18nTextDescriptor>>()
+  /** i18nText fields: collection name → field name → descriptor. Used by `applyI18nLocale`/`validateI18nTextValue`; populated by `collection()` from `i18nFields`. Private — the #664 `via-reconcile.ts` dispatch reads these through {@link _viaReconcileCtx}'s structural bag, not `this` directly (a plain structural bag, never a `Vault` import — S5 port-layering forbids the kernel spine from reaching a with-* service, and this file's own reconcile-ladder logic moved OUT into that unguarded module). */
+  private readonly i18nFieldRegistry = new Map<string, Record<string, I18nTextDescriptor>>()
 
   /** Cache of DictionaryHandle instances, one per dictionary name. */
   private readonly dictionaryCache = new Map<string, DictionaryHandle>()
@@ -392,7 +392,7 @@ export class Vault {
   /** #650 Task 4 (#647) — declared reserved-lookup collection name → dimension name, for dimensions
    *  with `backing:'reserved'` (dict()/dictKey()). The explicit sync-pull registry: NOT a blanket
    *  underscore-glob — populated at `collection()`-declare time and at `dictionary()`-call time. */
-  readonly reservedLookupCollections = new Map<string, string>()
+  private readonly reservedLookupCollections = new Map<string, string>()
 
   /** Registered link specs, keyed by link name; set by `vault.link()`. */
   private readonly linkRegistry = new Map<string, LinkSpec>()
@@ -414,7 +414,7 @@ export class Vault {
    * Optional translator callback threaded from `Noydb.invokeTranslator`.
    * Present only when `plaintextTranslator` was configured on `createNoydb()`.
    */
-  readonly translateText:
+  private readonly translateText:
     | ((text: string, from: string, to: string, field: string, collection: string) => Promise<string>)
     | undefined
 
@@ -654,6 +654,20 @@ export class Vault {
    * Lazy mode + indexes is rejected at construction time — see the
    * Collection constructor for the rationale.
    */
+  /** Assembles {@link ViaReconcileVaultCtx} — the plain structural bag the #664 `via-reconcile.ts`
+   *  dispatch reads/writes — from this vault's OWN privates, rather than passing `this` itself. */
+  private _viaReconcileCtx(): ViaReconcileVaultCtx {
+    return {
+      i18nStrategy: this.i18nStrategy, locale: this.locale, translateText: this.translateText,
+      i18nFieldRegistry: this.i18nFieldRegistry, dictKeyFieldRegistry: this.dictKeyFieldRegistry,
+      staticDescriptorByField: this.staticDescriptorByField, reservedLookupCollections: this.reservedLookupCollections,
+      staticByName: this.staticByName, staticDictNames: this.staticDictNames,
+      dictionary: (name) => this.dictionary(name),
+      enforceI18nOnPut: (collectionName, record) => this.enforceI18nOnPut(collectionName, record),
+      enforceStaticDictOnPut: (collectionName, record) => this.enforceStaticDictOnPut(collectionName, record),
+    }
+  }
+
   collection<T, S extends keyof T & string = never, Q extends keyof T & string = never, M extends keyof T & string = never>(collectionName: string, options?: {
     indexes?: readonly IndexDefFor<IndexFieldName<T, S, Q>>[]
     /** — auto-reconcile policy for persisted-index drift. */
@@ -847,7 +861,7 @@ export class Vault {
     // inlined here. `Collection._applyX`'s own first-wins semantics are unchanged; this file
     // only threads the field-declaring options + this vault's registries through.
     if (coll) {
-      reconcileViaAttach(coll, this.graph, collectionName, this, {
+      reconcileViaAttach(coll, this.graph, collectionName, this._viaReconcileCtx(), {
         effectiveViaFields,
         ...(options?.computed !== undefined ? { computed: options.computed as ComputedFields } : {}),
         ...(options?.fieldMeta !== undefined ? { fieldMeta: options.fieldMeta } : {}),

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -867,9 +867,9 @@ export class Vault {
       // Collection._applyClassifiedFields's own doc comment for the R1-R8 matrix.
       coll._applyClassifiedFields(options.classifiedFields)
     }
-    if (reconcilePlan) {
+    if (coll && reconcilePlan) {
       commitReconcileGraphEdges(this.graph, collectionName, reconcilePlan)
-      applyTaintOverlay(coll!, this.graph, collectionName) // #638 Task 3: a late attach can newly taint an already-built pipeline (coll is non-null: reconcilePlan is only set when `coll && …`, #666)
+      applyTaintOverlay(coll, this.graph, collectionName) // #638 Task 3: a late attach can newly taint an already-built pipeline (#666: structural guard, no assertion)
     }
     if (!coll) {
       // Register ref declarations (if any) with the vault-level

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -869,7 +869,7 @@ export class Vault {
     }
     if (reconcilePlan) {
       commitReconcileGraphEdges(this.graph, collectionName, reconcilePlan)
-      applyTaintOverlay(coll, this.graph, collectionName) // #638 Task 3: a late attach can newly taint an already-built pipeline
+      applyTaintOverlay(coll!, this.graph, collectionName) // #638 Task 3: a late attach can newly taint an already-built pipeline (coll is non-null: reconcilePlan is only set when `coll && …`, #666)
     }
     if (!coll) {
       // Register ref declarations (if any) with the vault-level

--- a/packages/hub/src/kernel/via-compose.ts
+++ b/packages/hub/src/kernel/via-compose.ts
@@ -12,7 +12,8 @@
  * the same field is declared in both places (#623 Task 9).
  */
 import { ValidationError } from './errors.js'
-import type { ViaDescriptor } from './via.js'
+import type { ViaBinding, ViaDescriptor } from './via.js'
+import type { ViaPipeline } from './via-pipeline.js'
 // Types + shape-classification predicates reach through the kernel's own
 // `port/with/` hook seam (never `src/shape/` directly) — #623 Task 11.
 // `isI18nTextDescriptor`/`isDictKeyDescriptor` are pure tag checks moved
@@ -154,5 +155,157 @@ export function mergeViaFields(sources: ViaFieldSources): MergedViaFields {
     dictKeyFields: Object.keys(viaDictKey).length > 0 ? { ...(sources.dictKeyFields ?? {}), ...viaDictKey } : sources.dictKeyFields,
     computedFields: Object.keys(viaComputed).length > 0 ? viaComputed : undefined,
     lookupFields: Object.keys(viaLookup).length > 0 ? { ...(sources.lookupFields ?? {}), ...viaLookup } : sources.lookupFields,
+  }
+}
+
+/** Maps each per-family field-map's option key to its binding family name — used by
+ *  {@link guardCrossBindingFieldCollisions}/{@link guardReconcileCollisions} to tell a genuine
+ *  cross-family collision apart from the SAME family surfaced through two sugar keys
+ *  (`i18nFields` + `dictKeyFields` both feed the ONE 'i18n' binder — not this guard's job; a
+ *  family's own duplicate handling stays wherever it already lives). Moved here from
+ *  `collection-config.ts` (#664 Part 1) — that module now imports `guardCrossBindingFieldCollisions`
+ *  back from here instead (a circular import the other way: `collection-config.ts` already
+ *  imports FROM this module for `mergeViaFields`). Module-private — only the two guards above,
+ *  both in this file, read it. */
+const VIA_FIELD_MAP_FAMILY: Readonly<Record<string, string>> = {
+  moneyFields: 'money', i18nFields: 'i18n', dictKeyFields: 'i18n', lookupFields: 'lookup',
+  classifiedFields: 'classified', blobFields: 'blob', computed: 'computed',
+}
+
+/**
+ * #631 — declare-time cross-binding same-field collision guard. Today the same field named
+ * in two DIFFERENT via-binding families (e.g. the same field in both `moneyFields` and
+ * `blobFields`) resolves silently by compile-order first-wins in `ViaPipeline`'s per-field
+ * posture/clause lookup — undefined pipeline behavior for a config that is almost certainly a
+ * mistake. `mergeViaFields` already guards sugar-vs-`viaFields` and `dictKeyFields`-vs-
+ * `lookupFields` collisions (#623 Task 9); this runs one step later, in `compileViaBindings`
+ * (fresh construction) or {@link guardReconcileCollisions} (late-attach reconcile), because
+ * those are the only seams that also see `classifiedFields`/`blobFields` — neither is part of
+ * `ViaFieldSources`, so `mergeViaFields` never sees them.
+ *
+ * WHY FAMILY-BASED, NOT PROVENANCE-BASED (#631 review, round 2 — Controller ruling): a field
+ * declared via `via(computed(fn), money(...))` and a field declared via two independent sugar
+ * maps (`computed: { total: fn }` + `moneyFields: { total: money(...) }`) are NOT
+ * distinguishable here — `mergeViaFields` folds both declaration STYLES into the IDENTICAL
+ * merged per-family field maps this function receives; provenance (which style produced a given
+ * map entry) is erased before this guard ever runs. Narrowing the exemption to "only
+ * via()-composed fields" would therefore require threading a second, parallel
+ * provenance-tracking data structure through `mergeViaFields` for the sole purpose of refusing a
+ * config that is BEHAVIORALLY IDENTICAL to the sanctioned one — refusing it would be a
+ * behavior-lock violation (breaking a legal, meaningful config), not a bug fix. The exemption is
+ * therefore keyed on the FAMILY SET alone, and instead earned empirically per family (below).
+ *
+ * EXEMPT (test-earned, not merely asserted): `computed` colliding with EXACTLY ONE of
+ * `money`/`i18n`/`lookup` on the same field. `via()`'s descriptor loop only accepts
+ * money/i18n/computed/lookup `_viaBrand`s (`mergeViaFields` throws on any other brand), so a
+ * computed+classified or computed+blob same-field pairing can never arise from composition — it
+ * can only come from mistakenly naming the same field in `computed`/`viaFields` AND
+ * `classifiedFields`/`blobFields`, which this guard still refuses. For the three families that
+ * CAN legitimately arise, each is pinned by an end-to-end runtime test proving the composition
+ * does something real (not just "doesn't throw") — see `computed/virtual.test.ts`:
+ *   - money: the "composed grammar" tests (materialized-mode money formatting the computed
+ *     output; the ORIGINAL evidence this exemption started from — see the money DOES/does NOT
+ *     format the computed output pair).
+ *   - i18n (dictKey) / lookup (dict()): the "composed grammar — computed + i18n/lookup
+ *     families (#631 collision-guard exemption pins)" block, BOTH declaration styles
+ *     (`via(computed(...), dictKey(...)/dict(...))` and the two-independent-sugar-maps form),
+ *     materialized mode — proven to dress `<field>Label` off the computed output identically
+ *     either way (the provenance-erasure claim above, empirically confirmed). Virtual mode for
+ *     both families hits the SAME present-ORDER limitation money's own virtual composed-grammar
+ *     test already documents (i18n/lookup's `present()` runs BEFORE computed's — a virtual field
+ *     is never stored, so there is nothing to dress yet); pinned as a known limitation, not
+ *     grounds to drop the family from the exemption (materialized mode is what proves the family
+ *     genuinely composes).
+ *
+ * 3-CLAIMANT TIGHTENING (#631 review, round 2): the exemption requires EXACTLY TWO claimant
+ * source-keys, not just two families. A field named in `computed` + BOTH `i18nFields` AND
+ * `dictKeyFields` collapses to the same two families (`{computed, i18n}` — `dictKeyFields`
+ * shares the `i18n` family) but is a genuine THREE-claimant collision: two independent i18n
+ * sugar keys both claiming the field is itself a mistake this guard exists to catch, and must
+ * not slip through because the family SET happens to match the earned exemption's shape.
+ */
+export function guardCrossBindingFieldCollisions(
+  fieldMaps: Readonly<Record<string, Record<string, unknown> | undefined>>,
+): void {
+  const claimantsByField = new Map<string, Set<string>>()
+  for (const [sourceKey, map] of Object.entries(fieldMaps)) {
+    for (const field of Object.keys(map ?? {})) {
+      const claimants = claimantsByField.get(field) ?? new Set<string>()
+      claimants.add(sourceKey)
+      claimantsByField.set(field, claimants)
+    }
+  }
+  for (const [field, sourceKeys] of claimantsByField) {
+    const families = new Set([...sourceKeys].map((key) => VIA_FIELD_MAP_FAMILY[key]))
+    if (families.size < 2) continue // same family via two sugar keys (e.g. i18n/dictKey) — not this guard's job
+    // Exactly two CLAIMANTS (not just two families) — see "3-CLAIMANT TIGHTENING" above.
+    if (sourceKeys.size === 2 && families.has('computed')) {
+      const other = [...families].find((f) => f !== 'computed')
+      if (other === 'money' || other === 'i18n' || other === 'lookup') continue // composed grammar, test-earned (#638/#631)
+    }
+    const keys = [...sourceKeys].sort().map((k) => `\`${k}\``)
+    const joined = keys.length === 2 ? keys.join(' and ') : `${keys.slice(0, -1).join(', ')}, and ${keys[keys.length - 1]}`
+    throw new ValidationError(
+      `compileViaBindings(): field "${field}" is declared in both ${joined} — a field cannot be claimed by two ` +
+      'different via-binding families. Declare it in one place only.',
+    )
+  }
+}
+
+/**
+ * #664 Part 1 — the late-attach reconcile-path sibling of {@link guardCrossBindingFieldCollisions}.
+ * `vault.ts`'s reconcile ladder (a second-or-later `vault.collection(name, {...})` call on an
+ * ALREADY-open collection) never ran the fresh-construction guard above, so two probe recipes
+ * slipped through (round-2 fable review, 2026-07-13):
+ *
+ *  - **(a) incoming×incoming** — the SAME reconcile call names a field in two different
+ *    families (e.g. `moneyFields`+`blobFields` both claiming `"amount"`). Fix: re-run
+ *    {@link guardCrossBindingFieldCollisions} verbatim over THIS call's own merged field maps —
+ *    identical semantics to fresh construction, just invoked one call later.
+ *  - **(b) existing×incoming** — an EARLIER call already compiled a binding covering a field
+ *    (money reconciled onto it, or it shipped with the collection's first declaration), and
+ *    THIS call's incoming family map claims the SAME field for a DIFFERENT family (e.g. call-1
+ *    `classifiedFields:['ssn']`, call-2 `moneyFields:{ssn}`) — undetectable by (a) alone since
+ *    the collision spans two calls. Read via the LIVE collection's compiled bindings
+ *    (`coll._via.bindings`): each `ViaBinding.covers(field)` (`via.ts`) plus its `brand` tells us
+ *    which family already owns the field, mapped through the SAME {@link VIA_FIELD_MAP_FAMILY}
+ *    the incoming side uses — no new collection.ts surface needed.
+ *
+ * Both sub-checks honor the SAME #631 exemption (`{computed,money}`/`{computed,i18n}`/
+ * `{computed,lookup}`, exactly-two-claimants) as the fresh guard — a composition that would be
+ * legal in one `vault.collection()` call (`via(computed(fn), money(...))`) must stay legal when
+ * split across two calls (computed declared fresh, money late-attached), since the two paths are
+ * behaviorally equivalent by the same provenance-erasure argument {@link guardCrossBindingFieldCollisions}
+ * documents. `existingFamilies` is collected as a SET (every binding covering the field, not just
+ * the first match) so an already-legally-composed pair (e.g. existing `{computed, money}`) is
+ * checked against the incoming family individually — a THIRD family colliding with either half
+ * is still refused.
+ */
+export function guardReconcileCollisions(
+  existingVia: ViaPipeline | undefined,
+  incomingFieldMaps: Readonly<Record<string, Record<string, unknown> | undefined>>,
+): void {
+  guardCrossBindingFieldCollisions(incomingFieldMaps) // (a) incoming×incoming
+  if (!existingVia) return
+  const existingBindings: readonly ViaBinding[] = existingVia.bindings
+  for (const [sourceKey, map] of Object.entries(incomingFieldMaps)) {
+    const incomingFamily = VIA_FIELD_MAP_FAMILY[sourceKey]
+    if (incomingFamily === undefined) continue
+    for (const field of Object.keys(map ?? {})) {
+      const existingFamilies = new Set(
+        existingBindings.filter((b) => b.covers?.(field)).map((b) => b.brand),
+      )
+      for (const existingFamily of existingFamilies) {
+        if (existingFamily === incomingFamily) continue // same family — first-wins on the _apply* side handles it
+        const isExempt = (existingFamily === 'computed' && (incomingFamily === 'money' || incomingFamily === 'i18n' || incomingFamily === 'lookup'))
+          || (incomingFamily === 'computed' && (existingFamily === 'money' || existingFamily === 'i18n' || existingFamily === 'lookup'))
+        if (isExempt) continue // composed grammar, test-earned (#638/#631) — legal fresh, stays legal late
+        throw new ValidationError(
+          `vault.collection(): field "${field}" is already bound by the "${existingFamily}" via family on this ` +
+          `collection — an incoming \`${sourceKey}\` declaration cannot claim it for a different family ` +
+          `("${incomingFamily}"). Declare it in one place only.`,
+        )
+      }
+    }
   }
 }

--- a/packages/hub/src/kernel/via-compose.ts
+++ b/packages/hub/src/kernel/via-compose.ts
@@ -226,6 +226,11 @@ const VIA_FIELD_MAP_FAMILY: Readonly<Record<string, string>> = {
  */
 export function guardCrossBindingFieldCollisions(
   fieldMaps: Readonly<Record<string, Record<string, unknown> | undefined>>,
+  // Minor fix (opus task review on #664a) — caller-accurate error prefix: fresh construction
+  // (`collection-config.ts`) keeps the old default; {@link guardReconcileCollisions} (the
+  // late-attach reconcile path) passes its OWN name instead of this function silently claiming
+  // to be `compileViaBindings()` on a call it never made.
+  callerPrefix = 'compileViaBindings()',
 ): void {
   const claimantsByField = new Map<string, Set<string>>()
   for (const [sourceKey, map] of Object.entries(fieldMaps)) {
@@ -246,7 +251,7 @@ export function guardCrossBindingFieldCollisions(
     const keys = [...sourceKeys].sort().map((k) => `\`${k}\``)
     const joined = keys.length === 2 ? keys.join(' and ') : `${keys.slice(0, -1).join(', ')}, and ${keys[keys.length - 1]}`
     throw new ValidationError(
-      `compileViaBindings(): field "${field}" is declared in both ${joined} — a field cannot be claimed by two ` +
+      `${callerPrefix}: field "${field}" is declared in both ${joined} — a field cannot be claimed by two ` +
       'different via-binding families. Declare it in one place only.',
     )
   }
@@ -285,9 +290,12 @@ export function guardReconcileCollisions(
   existingVia: ViaPipeline | undefined,
   incomingFieldMaps: Readonly<Record<string, Record<string, unknown> | undefined>>,
 ): void {
-  guardCrossBindingFieldCollisions(incomingFieldMaps) // (a) incoming×incoming
+  guardCrossBindingFieldCollisions(incomingFieldMaps, 'guardReconcileCollisions()') // (a) incoming×incoming
   if (!existingVia) return
-  const existingBindings: readonly ViaBinding[] = existingVia.bindings
+  // `taint` is a posture OVERLAY, not a field-owning family — under `sealAll` its `covers()` is
+  // true for every non-`_` field, so it must never be mapped through VIA_FIELD_MAP_FAMILY here
+  // (same exclusion precedent as via-graph-wiring.ts's `.filter(b => b.brand !== 'taint')`).
+  const existingBindings: readonly ViaBinding[] = existingVia.bindings.filter((b) => b.brand !== 'taint')
   for (const [sourceKey, map] of Object.entries(incomingFieldMaps)) {
     const incomingFamily = VIA_FIELD_MAP_FAMILY[sourceKey]
     if (incomingFamily === undefined) continue

--- a/packages/hub/src/kernel/via-graph-wiring.ts
+++ b/packages/hub/src/kernel/via-graph-wiring.ts
@@ -14,7 +14,7 @@ import {
 } from './collection-config.js'
 import { resolveClassifiedFields, type ClassifiedEntry } from '../port/with/classified-strategy.js'
 import { ValidationError } from './errors.js'
-import { ViaPipeline, type ViaTaintOverlay } from './via-pipeline.js'
+import { ViaPipeline, type ViaTaintOverlay, type HasWritableViaPipeline } from './via-pipeline.js'
 import { buildTaintOverlay, taintBinding } from './via-taint-binding.js'
 
 // `ComputedFields` is a with-formula/computed type; the kernel spine may not
@@ -270,15 +270,14 @@ export function commitReconcileGraphEdges(graph: ViaGraph, name: string, plan: R
  * computed field can newly taint a field an EARLIER call already built the
  * pipeline for, so both call sites must refresh.
  *
- * Reaches into `coll`'s private `via`/`codec` fields the same way
- * `via-pipeline.ts`'s `exportRedact` and `vault.ts`'s `forget()` already do
- * (grep `_classifySealedShred`/`_writeTombstone`) — no new Collection
- * method, so this never touches the ceiling-locked `collection.ts`. The
+ * Writes through `Collection._setVia` (`kernel/collection.ts`, #666) rather
+ * than the old untyped structural-cast reach-in — `_setVia` does both of the
+ * cast site's old two steps itself: reassigns `this.via` AND resyncs the
  * codec's OWN `via` snapshot (captured at construction, `collection.ts`'s
- * `this.codec = new RecordCodec({..., via: this.via})`) does not
- * automatically follow a later `this.via` reassignment — `RecordCodec.
- * setVia` re-syncs it so `encryptRecord`/`decryptRecord` seal/unseal
- * through the taint binding too, not a stale pre-taint pipeline.
+ * `this.codec = new RecordCodec({..., via: this.via})`, which does not
+ * automatically follow a later `this.via` reassignment) so `encryptRecord`/
+ * `decryptRecord` seal/unseal through the taint binding too, not a stale
+ * pre-taint pipeline.
  *
  * #642 — `graph.taintedPostures(name)` also carries the collection's `'*'`
  * target (a derivation/MV/overlay OUTPUT collection's whole-record fold,
@@ -291,7 +290,7 @@ export function commitReconcileGraphEdges(graph: ViaGraph, name: string, plan: R
  * the SAME single `taintBinding` call via `sealAllFields` — every field
  * (present-time, at-rest) is covered without a second binding.
  */
-export function applyTaintOverlay(coll: unknown, graph: ViaGraph, name: string): void {
+export function applyTaintOverlay(coll: HasWritableViaPipeline, graph: ViaGraph, name: string): void {
   const raw = graph.taintedPostures(name)
   const rawDefault = raw.get('*')
   const rawFields = rawDefault === undefined ? raw : new Map([...raw].filter(([field]) => field !== '*'))
@@ -316,17 +315,16 @@ export function applyTaintOverlay(coll: unknown, graph: ViaGraph, name: string):
       if (posture.exportable === false && virtualFields.has(field)) virtualExportRedact.add(field)
     }
   }
-  const c = coll as { via: ViaPipeline | undefined; codec: { setVia(via: ViaPipeline | undefined): void } }
   const sealAll = defaultPosture?.encryptedAtRest === 'sealed'
   const needsTaintBinding = sealFields.size > 0 || virtualExportRedact.size > 0 || sealAll
   // #642 Fix wave 1 — strip a PRIOR 'taint' binding before (maybe) appending a fresh one: a
   // base config compiled by `compileViaBindings` never carries 'taint' itself (only this
-  // function ever constructs one), so any 'taint' entry already on `c.via.bindings` is a
+  // function ever constructs one), so any 'taint' entry already on `coll._via.bindings` is a
   // leftover from an earlier `applyTaintOverlay` call on THIS SAME collection (fresh-open +
   // every `reapplyDependentOverlays` refresh) — without stripping it first, each re-apply
   // accumulated one more binding onto the list (harmless in effect, since every lookup only
   // ever consults the LAST match, but unbounded and wrong).
-  const existingBindings = (c.via?.bindings ?? []).filter((b) => b.brand !== 'taint')
+  const existingBindings = (coll._via?.bindings ?? []).filter((b) => b.brand !== 'taint')
   const bindings = needsTaintBinding
     ? [...existingBindings, taintBinding(sealFields, virtualExportRedact, sealAll)]
     : existingBindings
@@ -334,8 +332,7 @@ export function applyTaintOverlay(coll: unknown, graph: ViaGraph, name: string):
     postures: postures ?? EMPTY_POSTURE_MAP, sealFields, provenance,
     ...(defaultPosture !== undefined ? { defaultPosture } : {}),
   }
-  c.via = ViaPipeline.build(bindings, taint)
-  c.codec.setVia(c.via)
+  coll._setVia(ViaPipeline.build(bindings, taint))
 }
 
 /**
@@ -360,7 +357,7 @@ export function applyTaintOverlay(coll: unknown, graph: ViaGraph, name: string):
  */
 export function reapplyDependentOverlays(
   graph: ViaGraph, name: string,
-  getOpenCollection: (n: string) => unknown,
+  getOpenCollection: (n: string) => HasWritableViaPipeline | undefined,
 ): void {
   const targets = new Set(graph.dependentsOf(name).map((edge) => edge.target.collection))
   for (const target of targets) {

--- a/packages/hub/src/kernel/via-graph.ts
+++ b/packages/hub/src/kernel/via-graph.ts
@@ -213,6 +213,30 @@ export class ViaGraph {
     const visited = new Set<string>()
     const stack: string[] = []
 
+    /** #639 — containment expansion: writing a real field `f` on collection `C` is
+     *  a write to `C`, so it must ALSO reach every whole-record (`'*'`) dependent of
+     *  `C` — the missing reachability step that made mutual/rotating rollup cycles
+     *  invisible (a rollup target is always a real field node and never itself a
+     *  graph SOURCE, so the old `_out.get(id)`-only walk dead-ended on it).
+     *
+     *  TRAVERSAL-LOCAL ONLY (law, #642): this is a virtual adjacency computed
+     *  during the DFS walk, reading `_out` only. It must NEVER be materialized via
+     *  `registerDerived` (no new `(C,f)→(C,'*')` edge) and must NEVER touch `_in` —
+     *  putting `(C,'*')` into `_in` would flip `_contribution('C\0*')` from the
+     *  `_wildcardContribution` fold (`#642`) onto the `_computeEffective` path,
+     *  bleeding cycle-reachability taint into `foldWildcardSecurity`'s posture
+     *  fold. Posture folding (`_contribution`/`_computeEffective`/
+     *  `_wildcardContribution`) never reads `_out`, so an expansion that reads
+     *  `_out` only is provably unable to perturb it. */
+    const neighboursOf = (id: string): readonly FieldRef[] => {
+      const own = this._out.get(id)
+      const sep = id.indexOf(SEP)
+      if (id.slice(sep + 1) === '*') return own ?? []
+      const wildcard = this._out.get(`${id.slice(0, sep)}${SEP}*`)
+      if (!wildcard) return own ?? []
+      return own ? [...own, ...wildcard] : wildcard
+    }
+
     const visit = (id: string): void => {
       const idx = stack.indexOf(id)
       if (idx !== -1) {
@@ -224,10 +248,7 @@ export class ViaGraph {
       }
       if (visited.has(id)) return
       stack.push(id)
-      const dependents = this._out.get(id)
-      if (dependents) {
-        for (const dependent of dependents) visit(nodeId(dependent))
-      }
+      for (const dependent of neighboursOf(id)) visit(nodeId(dependent))
       stack.pop()
       visited.add(id)
     }

--- a/packages/hub/src/kernel/via-pipeline.ts
+++ b/packages/hub/src/kernel/via-pipeline.ts
@@ -28,30 +28,59 @@ export interface ViaTaintOverlay {
 
 export class ViaPipeline {
   /**
-   * Present-phase-ONLY order (#665) — a stable partition of `bindings`
-   * computed once here at construction: every `'computed'`-brand binding
-   * first, everything else in its existing relative order. `present()`
-   * folds over this instead of `bindings` so a `mode: 'virtual'` computed
-   * field's value exists before money/i18n/lookup's dressing `present()`
-   * hooks run on it (today's `compileViaBindings` order is money→i18n→
-   * lookup→classified→blob→computed, `collection-config.ts:643`, so
-   * dressing unconditionally ran BEFORE the value it dresses existed).
-   * EVERY other phase (`ingest`/`encodeWrite`/`encodeAtRest`/`enforceWrite`/
-   * etc.) keeps folding over `bindings` unchanged — those write/query phases
-   * need money-first (`_applyMoneyFields` PREPENDS money, `_applyClassifiedFields`
-   * APPENDS classified to preserve it, `kernel/collection.ts:1275-1284,1364-1368`).
-   * Only computed PRODUCES a value at present-time; money/i18n/lookup only
-   * CONSUME/dress, so this partition is the full topological order — no
-   * general topo sort is needed. A `'taint'` binding (appended LAST by
+   * Present-phase-ONLY order (#665, corrected under #665 review) — a stable
+   * THREE-WAY partition of `bindings` computed once here at construction:
+   * every `'money'`-brand binding first (existing relative order), then
+   * every `'computed'`-brand binding (existing relative order), then
+   * everything else (existing relative order). `present()` folds over this
+   * instead of `bindings` so a `mode: 'virtual'` computed field's value
+   * exists before i18n/lookup's dressing `present()` hooks run on it
+   * (today's `compileViaBindings` order is money→i18n→lookup→classified→
+   * blob→computed, `collection-config.ts:643`, so dressing unconditionally
+   * ran BEFORE the value it dresses existed). EVERY other phase (`ingest`/
+   * `encodeWrite`/`encodeAtRest`/`enforceWrite`/etc.) keeps folding over
+   * `bindings` unchanged — those write/query phases need money-first
+   * (`_applyMoneyFields` PREPENDS money, `_applyClassifiedFields` APPENDS
+   * classified to preserve it, `kernel/collection.ts:1275-1284,1364-1368`).
+   *
+   * Money is deliberately carved OUT of the generic "everything else" slice
+   * and kept FIRST — the original two-way `[computed..., rest...]` partition
+   * regressed money's composed-field behavior from a benign missing-dressing
+   * gap into VALUE CORRUPTION: money's `present()` DECODES its input as a
+   * STORED SCALED-INT (and derives `<field>Formatted` from it) — it is not a
+   * pure dressing CONSUMER like i18n/lookup, which only ADD a `<field>Label`
+   * key and never rewrite the field's own value. Running money AFTER
+   * computed on a field composing `computed(virtual)` + `money(...)` on
+   * ITSELF means money's decode sees the virtual field's raw MAJOR-unit
+   * output (e.g. `21`) and misreads it as a scaled-int, producing a
+   * corrupted value (`'0.21'`) instead of the pre-#665 result (the raw `21`
+   * surviving untouched, with no `Formatted` key added — a benign
+   * missing-dressing gap, not a wrong value). Money-first restores money's
+   * exact pre-#665 present position — byte-identical money behavior; the
+   * materialized composition pins from the #631 work and the money suites
+   * all ran under money-first. i18n/lookup are genuine dressing consumers
+   * (they only ADD, never rewrite), so they stay after computed, which is
+   * the fix #665 intended. A `'taint'` binding (appended LAST by
    * `via-graph-wiring.ts#applyTaintOverlay`) stays last here too (it's
-   * non-computed, so it lands at the tail of the "everything else" slice),
-   * preserving its "runs after computed, redacts tainted virtual output"
-   * contract (`via-taint-binding.ts`'s `taintBinding` doc comment).
+   * neither money nor computed, so it lands at the tail of the "everything
+   * else" slice), preserving its "runs after computed, redacts tainted
+   * virtual output" contract (`via-taint-binding.ts`'s `taintBinding` doc
+   * comment).
+   *
+   * Money-dressing a virtual computed field's OWN output (the composed
+   * `computed(virtual) + money` case) remains a KNOWN LIMITATION —
+   * reordering alone cannot fix it; money would need to quantize/reinterpret
+   * a major-unit value as a stored scaled-int, a value-shape decision left
+   * for a filed follow-up, not resolved by this partition.
    */
   private readonly _presentOrder: readonly ViaBinding[]
 
   private constructor(readonly bindings: readonly ViaBinding[], readonly taint?: ViaTaintOverlay) {
-    this._presentOrder = [...bindings.filter((b) => b.brand === 'computed'), ...bindings.filter((b) => b.brand !== 'computed')]
+    this._presentOrder = [
+      ...bindings.filter((b) => b.brand === 'money'),
+      ...bindings.filter((b) => b.brand === 'computed'),
+      ...bindings.filter((b) => b.brand !== 'money' && b.brand !== 'computed'),
+    ]
   }
 
   /** undefined when there is nothing to enforce — the zero-via fast path is

--- a/packages/hub/src/kernel/via-pipeline.ts
+++ b/packages/hub/src/kernel/via-pipeline.ts
@@ -180,6 +180,18 @@ export class ViaPipeline {
     return b?.evaluateClause ? b.evaluateClause(actual, op, clause.payload) : false
   }
 
+  /**
+   * Resolve a `buildClause` payload to an index-probe operand (#625) —
+   * mirrors `evaluateClause`'s brand dispatch. `undefined` (a binding
+   * with no `indexProbe`, or one that declines to probe this op/payload)
+   * means the caller (`candidateRecords()`) must fall back to a scan.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  indexProbe(clause: ViaClause, op: string): unknown | undefined {
+    const b = this.bindings.find((x) => x.brand === clause.brand)
+    return b?.indexProbe ? b.indexProbe(op, clause.payload) : undefined
+  }
+
   decodeResults(record: unknown): unknown {
     let r = record
     for (const b of this.bindings) if (b.decodeResults) r = b.decodeResults(r)

--- a/packages/hub/src/kernel/via-pipeline.ts
+++ b/packages/hub/src/kernel/via-pipeline.ts
@@ -340,8 +340,7 @@ interface HasViaPipeline {
  * via; codec: { setVia } }` cast. Exported (unlike `HasViaPipeline`) because
  * its one consumer lives in a different module.
  */
-export interface HasWritableViaPipeline {
-  readonly _via: ViaPipeline | undefined
+export interface HasWritableViaPipeline extends HasViaPipeline {
   _setVia(pipeline: ViaPipeline | undefined): void
 }
 

--- a/packages/hub/src/kernel/via-pipeline.ts
+++ b/packages/hub/src/kernel/via-pipeline.ts
@@ -36,12 +36,16 @@ export class ViaPipeline {
    * instead of `bindings` so a `mode: 'virtual'` computed field's value
    * exists before i18n/lookup's dressing `present()` hooks run on it
    * (today's `compileViaBindings` order is money→i18n→lookup→classified→
-   * blob→computed, `collection-config.ts:643`, so dressing unconditionally
-   * ran BEFORE the value it dresses existed). EVERY other phase (`ingest`/
-   * `encodeWrite`/`encodeAtRest`/`enforceWrite`/etc.) keeps folding over
-   * `bindings` unchanged — those write/query phases need money-first
-   * (`_applyMoneyFields` PREPENDS money, `_applyClassifiedFields` APPENDS
-   * classified to preserve it, `kernel/collection.ts:1275-1284,1364-1368`).
+   * blob→computed, `collection-config.ts:554`, so dressing unconditionally
+   * ran BEFORE the value it dresses existed). This reorder is binding-level,
+   * not conditioned on any particular field composition — it applies to
+   * EVERY collection that compiles a `'computed'` binding at all, not only
+   * ones stacking a dresser on the SAME field as a computed one. EVERY other
+   * phase (`ingest`/`encodeWrite`/`encodeAtRest`/`enforceWrite`/etc.) keeps
+   * folding over `bindings` unchanged — those write/query phases need
+   * money-first (`_applyMoneyFields` PREPENDS money, `_applyClassifiedFields`
+   * APPENDS classified to preserve it, `kernel/collection.ts:1275-1284,1364-
+   * 1368`).
    *
    * Money is deliberately carved OUT of the generic "everything else" slice
    * and kept FIRST — the original two-way `[computed..., rest...]` partition

--- a/packages/hub/src/kernel/via-pipeline.ts
+++ b/packages/hub/src/kernel/via-pipeline.ts
@@ -333,6 +333,19 @@ interface HasViaPipeline {
 }
 
 /**
+ * Widened sibling of {@link HasViaPipeline}: `via-graph-wiring.ts`'s
+ * `applyTaintOverlay` (#666) needs to REASSIGN the live pipeline, not just
+ * read it — `_setVia` is `Collection`'s typed writer seam (`kernel/
+ * collection.ts`, beside `_via`), replacing the earlier untyped `coll as {
+ * via; codec: { setVia } }` cast. Exported (unlike `HasViaPipeline`) because
+ * its one consumer lives in a different module.
+ */
+export interface HasWritableViaPipeline {
+  readonly _via: ViaPipeline | undefined
+  _setVia(pipeline: ViaPipeline | undefined): void
+}
+
+/**
  * `vault.ts`'s `exportStream()` reach-in (#629 Task 9): apply the owning
  * collection's export redaction to one decoded record. Typed via {@link
  * HasViaPipeline} against `Collection`'s `_via` accessor (#634) — replaces

--- a/packages/hub/src/kernel/via-pipeline.ts
+++ b/packages/hub/src/kernel/via-pipeline.ts
@@ -27,7 +27,32 @@ export interface ViaTaintOverlay {
 }
 
 export class ViaPipeline {
-  private constructor(readonly bindings: readonly ViaBinding[], readonly taint?: ViaTaintOverlay) {}
+  /**
+   * Present-phase-ONLY order (#665) — a stable partition of `bindings`
+   * computed once here at construction: every `'computed'`-brand binding
+   * first, everything else in its existing relative order. `present()`
+   * folds over this instead of `bindings` so a `mode: 'virtual'` computed
+   * field's value exists before money/i18n/lookup's dressing `present()`
+   * hooks run on it (today's `compileViaBindings` order is money→i18n→
+   * lookup→classified→blob→computed, `collection-config.ts:643`, so
+   * dressing unconditionally ran BEFORE the value it dresses existed).
+   * EVERY other phase (`ingest`/`encodeWrite`/`encodeAtRest`/`enforceWrite`/
+   * etc.) keeps folding over `bindings` unchanged — those write/query phases
+   * need money-first (`_applyMoneyFields` PREPENDS money, `_applyClassifiedFields`
+   * APPENDS classified to preserve it, `kernel/collection.ts:1275-1284,1364-1368`).
+   * Only computed PRODUCES a value at present-time; money/i18n/lookup only
+   * CONSUME/dress, so this partition is the full topological order — no
+   * general topo sort is needed. A `'taint'` binding (appended LAST by
+   * `via-graph-wiring.ts#applyTaintOverlay`) stays last here too (it's
+   * non-computed, so it lands at the tail of the "everything else" slice),
+   * preserving its "runs after computed, redacts tainted virtual output"
+   * contract (`via-taint-binding.ts`'s `taintBinding` doc comment).
+   */
+  private readonly _presentOrder: readonly ViaBinding[]
+
+  private constructor(readonly bindings: readonly ViaBinding[], readonly taint?: ViaTaintOverlay) {
+    this._presentOrder = [...bindings.filter((b) => b.brand === 'computed'), ...bindings.filter((b) => b.brand !== 'computed')]
+  }
 
   /** undefined when there is nothing to enforce — the zero-via fast path is
    *  `this.via === undefined` (#553: keeps an all-plain collection sync). A
@@ -108,7 +133,7 @@ export class ViaPipeline {
 
   async present(record: Record<string, unknown>, ctx: ViaReadCtx): Promise<Record<string, unknown>> {
     let r = record
-    for (const b of this.bindings) if (b.present) r = await b.present(r, ctx)
+    for (const b of this._presentOrder) if (b.present) r = await b.present(r, ctx)
     return r
   }
 

--- a/packages/hub/src/kernel/via-reconcile.ts
+++ b/packages/hub/src/kernel/via-reconcile.ts
@@ -129,7 +129,7 @@ function hasLookupBinding(coll: ReconcilableCollection): boolean {
 }
 
 /** lookup slots right after i18n, before classified/blob/computed/taint — the SAME
- *  money→i18n→lookup→classified→blob→computed compile order (collection-config.ts:640-650).
+ *  money→i18n→lookup→classified→blob→computed compile order (collection-config.ts:554).
  *  Late-attach only ever inserts ONE lookup binding (first-wins — see {@link hasLookupBinding}),
  *  so scanning for the first binding that must come AFTER lookup is enough (mirrors
  *  {@link insertI18nBinding}'s own reasoning); an i18n binding present at insert time is already
@@ -354,11 +354,11 @@ export function reconcileLookupFields(
     vaultCtx.staticDescriptorByField.set(name, staticFieldMap)
   }
 
-  // must move together with collection-config.ts:641-649's lookup slot (#664) — same
+  // must move together with collection-config.ts:642-651's lookup slot (#664) — same
   // viaBinder('lookup') option-shape contract.
   const binding = viaBinder('lookup')({
     lookupFields,
-    // must move together with vault.ts:1132-1138's five lookup closures (#664) — same
+    // must move together with vault.ts:1133-1139's five lookup closures (#664) — same
     // lookupLabelResolver/getLookupBacking/membership/getAltIndex/snapshotFor construction.
     lookupLabelResolver: buildDictLabelResolver(vaultCtx),
     getLookupBacking: (desc: LookupDescriptor) => async (key: string) =>
@@ -445,7 +445,7 @@ export function reconcileViaAttach(
   }
   // Deliberately a separate `if`, not another `else if` on the i18n/dictKey pair above: lookup is
   // a THIRD, independent binding family (compileViaBindings compiles it in its own `if
-  // (lookupFields !== undefined)` block, collection-config.ts:640-650 — not folded into the i18n
+  // (lookupFields !== undefined)` block, collection-config.ts:642-651 — not folded into the i18n
   // binding the way dictKeyFields is) — a single `vault.collection()` call may legally declare
   // BOTH i18nFields (or dictKeyFields) on one field AND lookupFields on another, and chaining this
   // onto the SAME else-if ladder would silently drop the lookupFields half of such a call.

--- a/packages/hub/src/kernel/via-reconcile.ts
+++ b/packages/hub/src/kernel/via-reconcile.ts
@@ -354,8 +354,12 @@ export function reconcileLookupFields(
     vaultCtx.staticDescriptorByField.set(name, staticFieldMap)
   }
 
+  // must move together with collection-config.ts:641-649's lookup slot (#664) — same
+  // viaBinder('lookup') option-shape contract.
   const binding = viaBinder('lookup')({
     lookupFields,
+    // must move together with vault.ts:1132-1138's five lookup closures (#664) — same
+    // lookupLabelResolver/getLookupBacking/membership/getAltIndex/snapshotFor construction.
     lookupLabelResolver: buildDictLabelResolver(vaultCtx),
     getLookupBacking: (desc: LookupDescriptor) => async (key: string) =>
       buildLookupSnapshotRows(desc, (n) => vaultCtx.reservedLookupCollections.has(dictCollectionName(n)), (n) => vaultCtx.dictionary(n), (n) => vaultCtx.getCollection(n))?.get(key) ??

--- a/packages/hub/src/kernel/via-reconcile.ts
+++ b/packages/hub/src/kernel/via-reconcile.ts
@@ -254,6 +254,12 @@ export function reconcileViaAttach(
 
   const reconcilePlan = (plan.computed || plan.classifiedFields)
     ? validateReconcileGraphEdges(graph, name, {
+        // `moneyFields` here is the MERGED view (`plan.effectiveViaFields.moneyFields`), not the
+        // raw incoming `moneyFields` option — intentional (controller ruling, #664a review): a
+        // via()-spelled money field must count in this call's `knownFields` for computed `deps`
+        // validation exactly like a sugar-keyed one does, the #627-consistent semantics. Pre-#664
+        // this reconciled via a blind `options as unknown as ReconcileGraphOptions` cast, which
+        // silently read the RAW option instead — never intentional, just uncovered before now.
         moneyFields: plan.effectiveViaFields.moneyFields, classifiedFields: plan.classifiedFields, computed: plan.computed,
       } as ReconcileGraphOptions)
     : undefined

--- a/packages/hub/src/kernel/via-reconcile.ts
+++ b/packages/hub/src/kernel/via-reconcile.ts
@@ -15,13 +15,17 @@
  *     only orchestrates, matching the pre-#664 call order exactly);
  *  3. commits the two-phase graph-edge reconcile (`via-graph-wiring.ts`) + taint overlay, exactly
  *     as before;
- *  4. NEWLY wires i18n/dictKey late-attach via {@link reconcileI18nFields}/
- *     {@link reconcileDictKeyFields} — rebuilding the pipeline through {@link Collection._setVia}
- *     (#666's writer seam), mirroring the fresh-construction wiring
- *     (`collection-config.ts#compileViaBindings`'s i18n slot + `vault.ts`'s registry population)
- *     without duplicating it in a second place. lookupFields reconcile is a SEPARATE, later task
- *     — the `plan`/dispatch shape below is deliberately structured so a `reconcileLookupFields`
- *     branch slots in alongside i18n/dictKey without reshaping this function.
+ *  4. wires i18n/dictKey late-attach via {@link reconcileI18nFields}/{@link reconcileDictKeyFields}
+ *     — rebuilding the pipeline through {@link Collection._setVia} (#666's writer seam), mirroring
+ *     the fresh-construction wiring (`collection-config.ts#compileViaBindings`'s i18n slot +
+ *     `vault.ts`'s registry population) without duplicating it in a second place;
+ *  5. (#664 Part 2b) wires lookup()/enumOf()/dict() late-attach via {@link reconcileLookupFields}
+ *     — tier-scoped: enum/static tiers are a clean, self-contained attach; the reserved (dict)
+ *     tier additionally updates the SAME vault registries the fresh path populates
+ *     (`dictKeyFieldRegistry`/`reservedLookupCollections`/`staticDescriptorByField`/`staticByName`/
+ *     `staticDictNames`, via `collectLookupDictCompat`); the matrix (`backing:'collection'`) tier
+ *     is gated by {@link refuseUnattachableMatrixLookupFields} — refuses with a `ValidationError`
+ *     unless the backing collection is already open (this vault session) and prefetch-enabled.
  *
  * `ViaReconcileVaultCtx` takes the vault-resident registry Maps/closures the i18n/dictKey wiring
  * needs as a plain structural bag of ARGUMENTS (mirroring `shape/via-lookup/registry.ts`'s own
@@ -39,12 +43,16 @@ import {
   validateReconcileGraphEdges, commitReconcileGraphEdges, applyTaintOverlay,
   type ReconcileGraphOptions,
 } from './via-graph-wiring.js'
+import { ValidationError } from './errors.js'
 import { resolveClassifiedFields } from '../port/with/classified-strategy.js'
 import {
   isStaticDictDescriptor,
   type I18nStrategy, type I18nTextDescriptor, type DictKeyDescriptor, type StaticDictDescriptor, type DictionaryHandle,
 } from '../port/with/i18n-strategy.js'
-import { resolveLabelFromMap, dictCollectionName } from '../port/with/lookup-strategy.js'
+import {
+  resolveLabelFromMap, dictCollectionName, collectLookupDictCompat, checkLookupMembership, buildLookupAltIndex,
+  buildLookupSnapshotRows, registerLookupRefEdges, type LookupDescriptor,
+} from '../port/with/lookup-strategy.js'
 
 type AnyCollection = Collection<Record<string, unknown>>
 
@@ -87,6 +95,15 @@ export interface ViaReconcileVaultCtx {
   dictionary(name: string): DictionaryHandle
   enforceI18nOnPut(collectionName: string, record: unknown): void
   enforceStaticDictOnPut(collectionName: string, record: unknown): void
+  /** #664 Part 2b — the matrix-tier lookup late-attach gate: "is this dimension already open in
+   *  this vault session" (never constructs a fresh collection) — `Vault._getCollection`. */
+  getOpenCollection(name: string): AnyCollection | undefined
+  /** #664 Part 2b — the vault's CONSTRUCTING collection accessor the lookup binding's lazy
+   *  closures (`getLookupBacking`/`membership`/`getAltIndex`/`snapshotFor`) read through — mirrors
+   *  `vault.ts`'s fresh-construct `(n) => this.collection<Record<string, unknown>>(n)` closure
+   *  verbatim. Only ever invoked, for a matrix-tier dimension, once {@link getOpenCollection}'s
+   *  gate has already confirmed it is open — never the door that opens it. */
+  getCollection(name: string): AnyCollection
 }
 
 function hasI18nBinding(coll: ReconcilableCollection): boolean {
@@ -105,6 +122,79 @@ function insertI18nBinding(existing: readonly ViaBinding[], i18nBinding: ViaBind
   const idx = existing.findIndex((b) =>
     b.brand === 'lookup' || b.brand === 'classified' || b.brand === 'blob' || b.brand === 'computed' || b.brand === 'taint')
   return idx === -1 ? [...existing, i18nBinding] : [...existing.slice(0, idx), i18nBinding, ...existing.slice(idx)]
+}
+
+function hasLookupBinding(coll: ReconcilableCollection): boolean {
+  return (coll._via?.bindings ?? []).some((b) => b.brand === 'lookup')
+}
+
+/** lookup slots right after i18n, before classified/blob/computed/taint — the SAME
+ *  money→i18n→lookup→classified→blob→computed compile order (collection-config.ts:640-650).
+ *  Late-attach only ever inserts ONE lookup binding (first-wins — see {@link hasLookupBinding}),
+ *  so scanning for the first binding that must come AFTER lookup is enough (mirrors
+ *  {@link insertI18nBinding}'s own reasoning); an i18n binding present at insert time is already
+ *  earlier in `existing` (either compiled fresh, or late-attached by an EARLIER reconcile call —
+ *  {@link insertI18nBinding}'s own stop-list includes `'lookup'`, so the reverse ordering is
+ *  symmetric regardless of which family attaches first). */
+function insertLookupBinding(existing: readonly ViaBinding[], lookupBindingObj: ViaBinding): ViaBinding[] {
+  const idx = existing.findIndex((b) => b.brand === 'classified' || b.brand === 'blob' || b.brand === 'computed' || b.brand === 'taint')
+  return idx === -1 ? [...existing, lookupBindingObj] : [...existing.slice(0, idx), lookupBindingObj, ...existing.slice(idx)]
+}
+
+/**
+ * #664 Part 2b — the matrix (`backing:'collection'`) tier's late-attach gate. Unlike enum/static
+ * (self-contained) or reserved (vault-registry-backed), matrix reads ANOTHER live collection's
+ * cache via `querySourceForJoin()` — `getLookupBacking`/`membership`/`getAltIndex`/`snapshotFor`
+ * (built below in {@link reconcileLookupFields}) are all vault-built closures that stay lazy,
+ * mirroring the fresh-construct path exactly. At FRESH construction that laziness is harmless —
+ * the backing dimension may simply not exist yet, and the closures only ever fire once it does.
+ * A LATE attach is different: the vault is already mid-session, so silently deferring would let a
+ * matrix field attach onto a dimension that never opens (or opens lazy) this session, surfacing
+ * the confusing join-branded lazy-mode error on some UNRELATED later put()/read() instead of at
+ * the point of declaration — the exact silent-deferral failure class `getAltIndexOrThrow`
+ * (`shape/via-lookup/binding.ts:252-264`) already refuses for altKeys specifically. This closes it
+ * for the field's very existence: REFUSE eagerly, at attach time, with a `ValidationError` naming
+ * the field, the dimension, and the remedy, unless the backing dimension is ALREADY open (in THIS
+ * vault session — `vaultCtx.getOpenCollection`, which never constructs) AND prefetch-enabled
+ * (probed via `querySourceForJoin()` itself — the SAME lazy-mode signal `getAltIndexOrThrow`
+ * reads, never a private `Collection` field reach-around; `collection.ts` is untouched by #664).
+ *
+ * Callers MUST run this BEFORE any `_apply*` mutation for the WHOLE reconcile call (Finding-M2
+ * ordering law, `via-graph-wiring.ts#validateReconcileGraphEdges`'s doc comment) — see
+ * {@link reconcileViaAttach}'s own early call, which runs this ahead of money/computed/classified
+ * apply so a combined call (e.g. `moneyFields` + a not-yet-open matrix `lookupFields` entry) never
+ * partially mutates money state before the whole call is refused. Also re-run at the top of
+ * {@link reconcileLookupFields} itself (cheap, pure, idempotent) so a direct/standalone caller of
+ * that function stays self-protecting too.
+ */
+function refuseUnattachableMatrixLookupFields(
+  vaultCtx: ViaReconcileVaultCtx,
+  lookupFields: Record<string, LookupDescriptor>,
+): void {
+  for (const [field, desc] of Object.entries(lookupFields)) {
+    if (desc.backing !== 'collection') continue
+    const backing = vaultCtx.getOpenCollection(desc.dimension)
+    if (!backing) {
+      throw new ValidationError(
+        `lookup: matrix field "${field}" (backing dimension "${desc.dimension}") cannot be late-attached — ` +
+        `"${desc.dimension}" is not open in this vault session yet. Open it first, e.g. ` +
+        `vault.collection('${desc.dimension}', { ... }), with prefetch enabled (the default) before ` +
+        `attaching "${field}" via a later vault.collection() call.`,
+      )
+    }
+    try {
+      backing.querySourceForJoin()
+    } catch (err) {
+      if (err instanceof Error && err.message.includes('lazy-mode')) {
+        throw new ValidationError(
+          `lookup: matrix field "${field}" (backing dimension "${desc.dimension}") cannot be late-attached — ` +
+          `"${desc.dimension}" is open in lazy mode ({ prefetch: false }). Re-open "${desc.dimension}" ` +
+          `without { prefetch: false } (eager mode, the default) before attaching "${field}".`,
+        )
+      }
+      throw err
+    }
+  }
 }
 
 /** Mirrors `vault.ts`'s `collOpts.dictLabelResolver` closure (:1117-1125) verbatim — a static
@@ -216,6 +306,71 @@ export function reconcileDictKeyFields(
   rebuildI18nBinding(coll, vaultCtx, name, undefined, dictKeyFields)
 }
 
+/**
+ * #664 Part 2b — late-attach lookup()/enumOf()/dict() fields, tier-scoped (issue #664, spec-
+ * ratified tier policy):
+ *
+ *  - **enum** (`backing:'static'`, no `table`) / **static** (`+table`) — self-contained:
+ *    membership/labels come from the declared `keys`/`table` alone, no vault registry touch, no
+ *    cross-collection read. Clean attach, same shape as i18n/dictKey's own reconcile door.
+ *  - **reserved** (`dict()` / `lookup(dim, { backing:'reserved' })`) — additionally registers into
+ *    the SAME vault registries the fresh path populates (`vault.ts`'s dictKeyFields/lookupFields
+ *    registry-population loop) — `dictKeyFieldRegistry`/`reservedLookupCollections` for a bare
+ *    dict field; `staticDescriptorByField`/`staticByName`/`staticDictNames` for a table-bearing
+ *    static field — via `collectLookupDictCompat` (#650 Task 2's alias-equivalence bridge, the
+ *    SAME helper the fresh path already calls), reused verbatim, not duplicated.
+ *  - **matrix** (`backing:'collection'`) — gated by {@link refuseUnattachableMatrixLookupFields}.
+ *
+ * First-wins (mirrors {@link reconcileI18nFields}): a no-op once the collection already has a
+ * 'lookup' binding, whether from fresh construction or an earlier reconcile call.
+ *
+ * Post-attach, registers the SAME cross-collection `'ref'` graph edges the fresh path does
+ * (`registerLookupRefEdges` — internally skips the static tier, which has no backing collection to
+ * reference-check) — `ViaGraph.referencingEdgesOf` sees them immediately, so delete-time
+ * restrict/cascade/nullify semantics are live post-attach too, same as a fresh declaration.
+ */
+export function reconcileLookupFields(
+  coll: ReconcilableCollection, vaultCtx: ViaReconcileVaultCtx, graph: ViaGraph, name: string,
+  lookupFields: Record<string, LookupDescriptor> | undefined,
+): void {
+  if (lookupFields === undefined) return
+  if (hasLookupBinding(coll)) return
+  refuseUnattachableMatrixLookupFields(vaultCtx, lookupFields) // standalone-caller safety net — see its own doc comment
+
+  const compat = collectLookupDictCompat(lookupFields)
+  if (Object.keys(compat.dictFieldMap).length > 0) {
+    vaultCtx.dictKeyFieldRegistry.set(name, { ...(vaultCtx.dictKeyFieldRegistry.get(name) ?? {}), ...compat.dictFieldMap })
+    for (const dictName of new Set(Object.values(compat.dictFieldMap))) {
+      vaultCtx.reservedLookupCollections.set(dictCollectionName(dictName), dictName)
+    }
+  }
+  if (compat.staticEntries.length > 0) {
+    const staticFieldMap = { ...(vaultCtx.staticDescriptorByField.get(name) ?? {}) }
+    for (const [field, desc] of compat.staticEntries) {
+      staticFieldMap[field] = desc
+      vaultCtx.staticDictNames.add(desc.name)
+      vaultCtx.staticByName.set(desc.name, desc)
+    }
+    vaultCtx.staticDescriptorByField.set(name, staticFieldMap)
+  }
+
+  const binding = viaBinder('lookup')({
+    lookupFields,
+    lookupLabelResolver: buildDictLabelResolver(vaultCtx),
+    getLookupBacking: (desc: LookupDescriptor) => async (key: string) =>
+      buildLookupSnapshotRows(desc, (n) => vaultCtx.reservedLookupCollections.has(dictCollectionName(n)), (n) => vaultCtx.dictionary(n), (n) => vaultCtx.getCollection(n))?.get(key) ??
+        (desc.key === 'id' ? ((await vaultCtx.getCollection(desc.dimension).get(key)) ?? undefined) : undefined),
+    membership: (field: string, key: string) => checkLookupMembership(lookupFields[field]!, key, (n) => vaultCtx.dictionary(n), (n) => vaultCtx.getCollection(n)),
+    getAltIndex: (d: LookupDescriptor) => buildLookupAltIndex(d, (n) => vaultCtx.dictionary(n), (n) => vaultCtx.getCollection(n)),
+    snapshotFor: (d: LookupDescriptor) =>
+      buildLookupSnapshotRows(d, (n) => vaultCtx.reservedLookupCollections.has(dictCollectionName(n)), (n) => vaultCtx.dictionary(n), (n) => vaultCtx.getCollection(n)),
+    collectionName: name,
+  })
+  const existing = coll._via?.bindings ?? []
+  coll._setVia(ViaPipeline.build(insertLookupBinding(existing, binding), coll._via?.taint))
+  registerLookupRefEdges(graph, name, lookupFields)
+}
+
 /** The late-attach reconcile call's field-declaring options — the slice of `vault.collection()`'s
  *  `options` a reconcile call may carry, plus the `mergeViaFields` output that feeds both the
  *  guard and the money/i18n/dictKey/lookup reconciles. `blobFields` has no `_apply*` door (guard
@@ -232,11 +387,9 @@ export interface ReconcileLateAttachPlan {
 
 /**
  * #664 — the ONE late-attach reconcile dispatch `vault.ts` calls, replacing its former 5-branch
- * `_apply*` ladder. Order: guard (before any mutation) → the five pre-existing reconciles,
- * UNCHANGED call order/semantics → graph-edge commit + taint overlay (unchanged) → i18n/dictKey
- * (new). `lookupFields` is intentionally NOT dispatched here yet — a future
- * `reconcileLookupFields` branch slots in as one more `else if` on `plan.effectiveViaFields.lookupFields`
- * without touching anything above it.
+ * `_apply*` ladder. Order: guard (before any mutation) → the matrix-tier lookup gate (also before
+ * any mutation — see below) → the five pre-existing reconciles, UNCHANGED call order/semantics →
+ * graph-edge commit + taint overlay (unchanged) → i18n/dictKey → lookup (#664 Part 2b).
  */
 export function reconcileViaAttach(
   coll: ReconcilableCollection, graph: ViaGraph, name: string,
@@ -251,6 +404,14 @@ export function reconcileViaAttach(
     blobFields: plan.blobFields,
     computed: { ...(plan.computed ?? {}), ...(plan.effectiveViaFields.computedFields ?? {}) },
   })
+  // #664 Part 2b — the matrix-tier lookup gate must run here, BEFORE money/computed/classified
+  // apply below (Finding-M2 ordering law — see `refuseUnattachableMatrixLookupFields`'s own doc
+  // comment): deferring it to `reconcileLookupFields`'s own call site near the bottom of this
+  // function would let a combined call (e.g. `moneyFields` + a not-yet-open matrix `lookupFields`
+  // entry) partially mutate money state before the whole call is ultimately refused.
+  if (plan.effectiveViaFields.lookupFields !== undefined && !hasLookupBinding(coll)) {
+    refuseUnattachableMatrixLookupFields(vaultCtx, plan.effectiveViaFields.lookupFields)
+  }
 
   const reconcilePlan = (plan.computed || plan.classifiedFields)
     ? validateReconcileGraphEdges(graph, name, {
@@ -277,5 +438,14 @@ export function reconcileViaAttach(
     reconcileI18nFields(coll, vaultCtx, name, plan.effectiveViaFields.i18nFields, plan.effectiveViaFields.dictKeyFields)
   } else if (plan.effectiveViaFields.dictKeyFields !== undefined) {
     reconcileDictKeyFields(coll, vaultCtx, name, plan.effectiveViaFields.dictKeyFields)
+  }
+  // Deliberately a separate `if`, not another `else if` on the i18n/dictKey pair above: lookup is
+  // a THIRD, independent binding family (compileViaBindings compiles it in its own `if
+  // (lookupFields !== undefined)` block, collection-config.ts:640-650 — not folded into the i18n
+  // binding the way dictKeyFields is) — a single `vault.collection()` call may legally declare
+  // BOTH i18nFields (or dictKeyFields) on one field AND lookupFields on another, and chaining this
+  // onto the SAME else-if ladder would silently drop the lookupFields half of such a call.
+  if (plan.effectiveViaFields.lookupFields !== undefined) {
+    reconcileLookupFields(coll, vaultCtx, graph, name, plan.effectiveViaFields.lookupFields)
   }
 }

--- a/packages/hub/src/kernel/via-reconcile.ts
+++ b/packages/hub/src/kernel/via-reconcile.ts
@@ -1,0 +1,275 @@
+/**
+ * kernel/via-reconcile.ts — #664 the late-attach reconcile-path dispatch.
+ *
+ * `vault.ts`'s reconcile branch (a SECOND-OR-LATER `vault.collection(name, {...})` call on an
+ * already-open collection) used to be a flat 5-branch `if (coll && X) coll._applyX(...)` ladder
+ * with no collision guard and no i18n/dictKey machinery at all (i18nFields/dictKeyFields were
+ * silently ignored on re-open — only the fresh-construction branch ever wired them). This module
+ * moves that whole ladder OUT of `vault.ts` (a kernel-surface-ceiling-guarded file) into ONE
+ * dispatch entry point, {@link reconcileViaAttach}, that:
+ *
+ *  1. runs the late-attach collision guard ({@link guardReconcileCollisions}, via-compose.ts)
+ *     BEFORE any mutation — both the incoming×incoming and existing×incoming recipes;
+ *  2. routes the FIVE pre-existing reconciles (money/computed/fieldMeta/meta/classified) through
+ *     their unchanged `Collection._applyX` methods (collection.ts is NOT touched — this dispatch
+ *     only orchestrates, matching the pre-#664 call order exactly);
+ *  3. commits the two-phase graph-edge reconcile (`via-graph-wiring.ts`) + taint overlay, exactly
+ *     as before;
+ *  4. NEWLY wires i18n/dictKey late-attach via {@link reconcileI18nFields}/
+ *     {@link reconcileDictKeyFields} — rebuilding the pipeline through {@link Collection._setVia}
+ *     (#666's writer seam), mirroring the fresh-construction wiring
+ *     (`collection-config.ts#compileViaBindings`'s i18n slot + `vault.ts`'s registry population)
+ *     without duplicating it in a second place. lookupFields reconcile is a SEPARATE, later task
+ *     — the `plan`/dispatch shape below is deliberately structured so a `reconcileLookupFields`
+ *     branch slots in alongside i18n/dictKey without reshaping this function.
+ *
+ * `ViaReconcileVaultCtx` takes the vault-resident registry Maps/closures the i18n/dictKey wiring
+ * needs as a plain structural bag of ARGUMENTS (mirroring `shape/via-lookup/registry.ts`'s own
+ * "#650 Task 1" extraction pattern) — never a `Vault` import (this file is part of the kernel
+ * spine's `port/with/`-only import discipline — S5 port-layering, `scripts/check-architecture.mjs`
+ * `checkPortLayering`), so `vault.ts` passes `this` once its relevant fields are readable from
+ * outside the class (see `Vault`'s field declarations).
+ */
+import type { Collection } from './collection.js'
+import { ViaPipeline, type HasWritableViaPipeline } from './via-pipeline.js'
+import { viaBinder, type ViaBinding } from './via.js'
+import { guardReconcileCollisions, type MergedViaFields } from './via-compose.js'
+import type { ViaGraph } from './via-graph.js'
+import {
+  validateReconcileGraphEdges, commitReconcileGraphEdges, applyTaintOverlay,
+  type ReconcileGraphOptions,
+} from './via-graph-wiring.js'
+import { resolveClassifiedFields } from '../port/with/classified-strategy.js'
+import {
+  isStaticDictDescriptor,
+  type I18nStrategy, type I18nTextDescriptor, type DictKeyDescriptor, type StaticDictDescriptor, type DictionaryHandle,
+} from '../port/with/i18n-strategy.js'
+import { resolveLabelFromMap, dictCollectionName } from '../port/with/lookup-strategy.js'
+
+type AnyCollection = Collection<Record<string, unknown>>
+
+/**
+ * Structural reconcile-capable collection handle: `_via`/`_setVia` (#666's writer seam) plus the
+ * five pre-existing `_applyX` late-attach methods (#623/#629/#638). Every parameter type is
+ * DERIVED off `Collection` itself via `Parameters<...>` rather than imported by name — several
+ * (`FieldMeta`, `CollectionMeta`, `ComputedFields`) are with-* service types the kernel spine may
+ * not statically import (S5 port-layering); deriving them off the already-typed `Collection`
+ * method avoids a second, duplicate type declaration too (mirrors `via-graph-wiring.ts`'s
+ * `ComputedFieldsParam` trick).
+ */
+export interface ReconcilableCollection extends HasWritableViaPipeline {
+  _applyMoneyFields(moneyFields: Parameters<AnyCollection['_applyMoneyFields']>[0]): void
+  _applyComputed(computed: Parameters<AnyCollection['_applyComputed']>[0]): void
+  _applyFieldMeta(fieldMeta: Parameters<AnyCollection['_applyFieldMeta']>[0]): void
+  _applyMeta(meta: Parameters<AnyCollection['_applyMeta']>[0]): void
+  _applyClassifiedFields(classifiedFields: Parameters<AnyCollection['_applyClassifiedFields']>[0]): void
+}
+
+/** The vault-resident state/closures the i18n/dictKey late-attach wiring reads and writes —
+ *  the SAME registries `vault.ts`'s fresh-construction branch populates (`i18nFieldRegistry`
+ *  :884-886, the dictKeyFields split :903-940, `dictLabelResolver`/`i18nPutValidator`/
+ *  `autoTranslateHook` :1111-1155), passed as plain values (never `this: Vault`) so this module
+ *  never imports the `Vault` class. */
+export interface ViaReconcileVaultCtx {
+  readonly i18nStrategy: I18nStrategy
+  /** — named `locale`, not `defaultLocale`, to match `Vault`'s own field name 1:1 (so `this`
+   *  satisfies this interface structurally with zero adapter object at the call site). */
+  readonly locale: string | undefined
+  readonly translateText:
+    | ((text: string, from: string, to: string, field: string, collection: string) => Promise<string>)
+    | undefined
+  readonly i18nFieldRegistry: Map<string, Record<string, I18nTextDescriptor>>
+  readonly dictKeyFieldRegistry: Map<string, Record<string, string>>
+  readonly staticDescriptorByField: Map<string, Record<string, StaticDictDescriptor>>
+  readonly reservedLookupCollections: Map<string, string>
+  readonly staticByName: Map<string, StaticDictDescriptor>
+  readonly staticDictNames: Set<string>
+  dictionary(name: string): DictionaryHandle
+  enforceI18nOnPut(collectionName: string, record: unknown): void
+  enforceStaticDictOnPut(collectionName: string, record: unknown): void
+}
+
+function hasI18nBinding(coll: ReconcilableCollection): boolean {
+  return (coll._via?.bindings ?? []).some((b) => b.brand === 'i18n')
+}
+
+/** money-after / lookup-before — the SAME slot `compileViaBindings` (collection-config.ts)
+ *  compiles the i18n binding into (money→i18n→lookup→classified→blob→computed, taint appended
+ *  last by `applyTaintOverlay`). Late-attach only ever INSERTS one i18n binding (first-wins —
+ *  see {@link hasI18nBinding}), so a plain "before the first post-i18n family" scan is enough;
+ *  no money-prepend/classified-append juggling like `_applyMoneyFields`/`_applyClassifiedFields`
+ *  need (those two mutate around an i18n binding that might already be there; i18n itself never
+ *  needs to reorder around a LATER family, since none of money/i18n/lookup/classified/blob/
+ *  computed's own late-attach paths re-sort on insert). */
+function insertI18nBinding(existing: readonly ViaBinding[], i18nBinding: ViaBinding): ViaBinding[] {
+  const idx = existing.findIndex((b) =>
+    b.brand === 'lookup' || b.brand === 'classified' || b.brand === 'blob' || b.brand === 'computed' || b.brand === 'taint')
+  return idx === -1 ? [...existing, i18nBinding] : [...existing.slice(0, idx), i18nBinding, ...existing.slice(idx)]
+}
+
+/** Mirrors `vault.ts`'s `collOpts.dictLabelResolver` closure (:1117-1125) verbatim — a static
+ *  dict resolves from its in-memory table, a plain dictKey resolves through the encrypted
+ *  `_dict_*` handle. */
+function buildDictLabelResolver(vaultCtx: ViaReconcileVaultCtx) {
+  return async (dictName: string, key: string, locale: string, fallback?: string | readonly string[]): Promise<string | undefined> => {
+    const stat = vaultCtx.staticByName.get(dictName)
+    if (stat) {
+      const labels = stat.table[key]
+      return labels ? resolveLabelFromMap(labels, locale, fallback) : undefined
+    }
+    return vaultCtx.dictionary(dictName).resolveLabel(key, locale, fallback)
+  }
+}
+
+/** Mirrors `vault.ts`'s dictKeyFields registry-population loop (:909-939) — split into the
+ *  rename-tracked (`dictKeyFieldRegistry`) vs static-table (`staticDescriptorByField`) forms,
+ *  registering each referenced dictionary into `reservedLookupCollections` for sync. */
+function registerDictKeyRegistries(
+  vaultCtx: ViaReconcileVaultCtx, name: string,
+  dictKeyFields: Record<string, DictKeyDescriptor | StaticDictDescriptor>,
+): void {
+  const dictFieldMap: Record<string, string> = {}
+  const staticFieldMap: Record<string, StaticDictDescriptor> = {}
+  for (const [field, desc] of Object.entries(dictKeyFields)) {
+    if (isStaticDictDescriptor(desc)) {
+      staticFieldMap[field] = desc
+      vaultCtx.staticDictNames.add(desc.name)
+      vaultCtx.staticByName.set(desc.name, desc)
+    } else {
+      dictFieldMap[field] = desc.name
+    }
+  }
+  if (Object.keys(dictFieldMap).length > 0) {
+    vaultCtx.dictKeyFieldRegistry.set(name, dictFieldMap)
+    for (const dictName of new Set(Object.values(dictFieldMap))) {
+      vaultCtx.reservedLookupCollections.set(dictCollectionName(dictName), dictName)
+    }
+  }
+  if (Object.keys(staticFieldMap).length > 0) {
+    vaultCtx.staticDescriptorByField.set(name, staticFieldMap)
+  }
+}
+
+/** Mirrors `compileViaBindings`'s i18n slot (collection-config.ts:702-723) — same densify-subset
+ *  computation, same config shape handed to `viaBinder('i18n')`. `defaultPosture`/taint is
+ *  preserved across the rebuild (unlike `_applyMoneyFields`/`_applyClassifiedFields`, which drop
+ *  it — those rely on a same-call `applyTaintOverlay` re-run when computed/classifiedFields is
+ *  also present; i18n/dictKey have no such re-run, so dropping it here would silently un-taint an
+ *  already-tainted field on a collection that happens to ALSO gain i18n late). */
+function rebuildI18nBinding(
+  coll: ReconcilableCollection, vaultCtx: ViaReconcileVaultCtx, name: string,
+  i18nFields: Record<string, I18nTextDescriptor> | undefined,
+  dictKeyFields: Record<string, DictKeyDescriptor | StaticDictDescriptor> | undefined,
+): void {
+  const densify = i18nFields
+    ? Object.fromEntries(Object.entries(i18nFields).filter(([, d]) => d.options.densifyOnWrite === true))
+    : {}
+  const i18nDensifyFields = Object.keys(densify).length > 0 ? densify : undefined
+  const binding = viaBinder('i18n')({
+    ...(i18nFields !== undefined ? { i18nFields } : {}),
+    ...(dictKeyFields !== undefined ? { dictKeyFields } : {}),
+    ...(i18nDensifyFields !== undefined ? { i18nDensifyFields } : {}),
+    strategy: vaultCtx.i18nStrategy,
+    ...(vaultCtx.locale !== undefined ? { defaultLocale: vaultCtx.locale } : {}),
+    ...(i18nFields !== undefined && vaultCtx.translateText !== undefined ? { autoTranslateHook: vaultCtx.translateText } : {}),
+    ...(dictKeyFields !== undefined ? { dictLabelResolver: buildDictLabelResolver(vaultCtx) } : {}),
+    i18nPutValidator: (record: unknown) => { vaultCtx.enforceI18nOnPut(name, record); vaultCtx.enforceStaticDictOnPut(name, record) },
+    collectionName: name,
+  })
+  const existing = coll._via?.bindings ?? []
+  coll._setVia(ViaPipeline.build(insertI18nBinding(existing, binding), coll._via?.taint))
+}
+
+/**
+ * #664 Part 2 — late-attach i18nText fields. First-wins (mirrors `_applyMoneyFields`'s own
+ * first-wins convention): a no-op once the collection already has an 'i18n' binding, whether
+ * that binding came from fresh construction or an earlier reconcile call. `dictKeyFields` is an
+ * optional SECOND family arriving in the SAME `vault.collection()` call (`mergeViaFields` already
+ * combined them for this one call) — passed through so ONE binding rebuild covers both, exactly
+ * like `compileViaBindings` builds ONE 'i18n' binding from both maps at fresh construction.
+ */
+export function reconcileI18nFields(
+  coll: ReconcilableCollection, vaultCtx: ViaReconcileVaultCtx, name: string,
+  i18nFields: Record<string, I18nTextDescriptor> | undefined,
+  dictKeyFields?: Record<string, DictKeyDescriptor | StaticDictDescriptor>,
+): void {
+  if (i18nFields === undefined) return
+  if (hasI18nBinding(coll)) return
+  vaultCtx.i18nFieldRegistry.set(name, i18nFields)
+  if (dictKeyFields !== undefined) registerDictKeyRegistries(vaultCtx, name, dictKeyFields)
+  rebuildI18nBinding(coll, vaultCtx, name, i18nFields, dictKeyFields)
+}
+
+/**
+ * #664 Part 2 — late-attach dictKeyFields (dictKey()/staticDict()) with NO i18nFields in the same
+ * call — the dictKey-only late-attach door. First-wins, same convention as
+ * {@link reconcileI18nFields} (and, transitively, a no-op if that sibling function already
+ * handled a combined i18nFields+dictKeyFields call for this collection).
+ */
+export function reconcileDictKeyFields(
+  coll: ReconcilableCollection, vaultCtx: ViaReconcileVaultCtx, name: string,
+  dictKeyFields: Record<string, DictKeyDescriptor | StaticDictDescriptor> | undefined,
+): void {
+  if (dictKeyFields === undefined) return
+  if (hasI18nBinding(coll)) return
+  registerDictKeyRegistries(vaultCtx, name, dictKeyFields)
+  rebuildI18nBinding(coll, vaultCtx, name, undefined, dictKeyFields)
+}
+
+/** The late-attach reconcile call's field-declaring options — the slice of `vault.collection()`'s
+ *  `options` a reconcile call may carry, plus the `mergeViaFields` output that feeds both the
+ *  guard and the money/i18n/dictKey/lookup reconciles. `blobFields` has no `_apply*` door (guard
+ *  visibility only — an incoming×incoming collision with `blobFields` must still refuse, even
+ *  though a bare blobFields late-attach is otherwise silently inert, matching pre-#664 behavior). */
+export interface ReconcileLateAttachPlan {
+  readonly effectiveViaFields: MergedViaFields
+  readonly computed?: Parameters<AnyCollection['_applyComputed']>[0]
+  readonly fieldMeta?: Parameters<AnyCollection['_applyFieldMeta']>[0]
+  readonly meta?: Parameters<AnyCollection['_applyMeta']>[0]
+  readonly classifiedFields?: Parameters<AnyCollection['_applyClassifiedFields']>[0]
+  readonly blobFields?: Record<string, unknown>
+}
+
+/**
+ * #664 — the ONE late-attach reconcile dispatch `vault.ts` calls, replacing its former 5-branch
+ * `_apply*` ladder. Order: guard (before any mutation) → the five pre-existing reconciles,
+ * UNCHANGED call order/semantics → graph-edge commit + taint overlay (unchanged) → i18n/dictKey
+ * (new). `lookupFields` is intentionally NOT dispatched here yet — a future
+ * `reconcileLookupFields` branch slots in as one more `else if` on `plan.effectiveViaFields.lookupFields`
+ * without touching anything above it.
+ */
+export function reconcileViaAttach(
+  coll: ReconcilableCollection, graph: ViaGraph, name: string,
+  vaultCtx: ViaReconcileVaultCtx, plan: ReconcileLateAttachPlan,
+): void {
+  guardReconcileCollisions(coll._via, {
+    moneyFields: plan.effectiveViaFields.moneyFields,
+    i18nFields: plan.effectiveViaFields.i18nFields,
+    dictKeyFields: plan.effectiveViaFields.dictKeyFields,
+    lookupFields: plan.effectiveViaFields.lookupFields,
+    classifiedFields: plan.classifiedFields !== undefined ? resolveClassifiedFields(name, plan.classifiedFields).byField : undefined,
+    blobFields: plan.blobFields,
+    computed: { ...(plan.computed ?? {}), ...(plan.effectiveViaFields.computedFields ?? {}) },
+  })
+
+  const reconcilePlan = (plan.computed || plan.classifiedFields)
+    ? validateReconcileGraphEdges(graph, name, {
+        moneyFields: plan.effectiveViaFields.moneyFields, classifiedFields: plan.classifiedFields, computed: plan.computed,
+      } as ReconcileGraphOptions)
+    : undefined
+
+  if (plan.effectiveViaFields.moneyFields) coll._applyMoneyFields(plan.effectiveViaFields.moneyFields)
+  if (plan.computed) coll._applyComputed(plan.computed)
+  if (plan.fieldMeta) coll._applyFieldMeta(plan.fieldMeta)
+  if (plan.meta) coll._applyMeta(plan.meta)
+  if (plan.classifiedFields) coll._applyClassifiedFields(plan.classifiedFields)
+  if (reconcilePlan) {
+    commitReconcileGraphEdges(graph, name, reconcilePlan)
+    applyTaintOverlay(coll, graph, name)
+  }
+  if (plan.effectiveViaFields.i18nFields !== undefined) {
+    reconcileI18nFields(coll, vaultCtx, name, plan.effectiveViaFields.i18nFields, plan.effectiveViaFields.dictKeyFields)
+  } else if (plan.effectiveViaFields.dictKeyFields !== undefined) {
+    reconcileDictKeyFields(coll, vaultCtx, name, plan.effectiveViaFields.dictKeyFields)
+  }
+}

--- a/packages/hub/src/kernel/via.ts
+++ b/packages/hub/src/kernel/via.ts
@@ -123,6 +123,20 @@ export interface ViaBinding {
   buildClause?(field: string, op: string, value: unknown): unknown | undefined
   /** Evaluate a payload produced by buildClause against a raw stored value. */
   evaluateClause?(actual: unknown, op: string, payload: unknown): boolean
+  /**
+   * Optional: the STORED-form operand for a direct secondary-index probe
+   * against a payload produced by `buildClause` (#625) — lets
+   * `candidateRecords()` (`query/builder.ts`) hit `CollectionIndexes.
+   * lookupEqual`/`lookupIn` for `==`/`in` clauses instead of falling back
+   * to a linear scan + per-record `evaluateClause`. Returning `undefined`
+   * means "no sound probe for this op/payload" (e.g. a comparison whose
+   * stored form isn't a single index-bucketable value, or an op the index
+   * can't serve) — the caller falls back to the scan. A binding that
+   * never implements this hook always falls back, unchanged from before
+   * this hook existed.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  indexProbe?(op: string, payload: unknown): unknown | undefined
   /** Decode a raw stored record for query/scan results and callback views ('raw' — no virtuals). */
   decodeResults?(record: unknown): unknown
   /** Exact ordering for a covered field; undefined when the field is not covered. */

--- a/packages/hub/src/shape/via-lookup/binding.ts
+++ b/packages/hub/src/shape/via-lookup/binding.ts
@@ -279,10 +279,12 @@ function getAltIndexOrThrow(field: string, desc: LookupDescriptor, cfg: LookupVi
  * wrongly refused by closed-vocabulary enforcement). `setAtPathInPlace`
  * can't write into a `[].`-wildcard path, so the array is reconstructed
  * immutably instead, mirroring `runLookupPresent`'s own `field.includes
- * ('[].')` branch. A plain field whose OWN value is a bare array (not a
- * `[].`-wildcard path) is a different, untouched shape — `getAtPath`
- * resolves it to one opaque value, so it still falls through the
- * `values.length !== 1` / `typeof value !== 'string'` checks below unchanged.
+ * ('[].')` branch. A plain field whose OWN value is a bare top-level array
+ * (not a `[].`-wildcard path) gets the SAME element-wise normalization
+ * against `backing.altIndex` (#661 fix — `getAtPath` resolves it to one
+ * opaque value, so the array itself is `values[0]`; a non-string element is
+ * left untouched, mirroring the scalar branch's own `typeof !== 'string'`
+ * skip — no parallel coercion invented for this shape).
  */
 function runLookupIngest(record: Record<string, unknown>, cfg: LookupViaConfig): Record<string, unknown> {
   const withAltKeys = Object.entries(cfg.lookupFields).filter(([, d]) => (d.altKeys?.length ?? 0) > 0)
@@ -317,6 +319,23 @@ function runLookupIngest(record: Record<string, unknown>, cfg: LookupViaConfig):
     const values = getAtPath(record, field)
     if (values.length !== 1) continue
     const value = values[0]
+
+    if (Array.isArray(value)) {
+      if (value.length === 0) continue
+      let changed = false
+      const normalized = value.map((el) => {
+        if (typeof el !== 'string') return el
+        const canonical = backing.altIndex.get(el)
+        if (canonical === undefined || canonical === el) return el
+        changed = true
+        return canonical
+      })
+      if (!changed) continue
+      if (result === record) result = { ...record }
+      setAtPathInPlace(result, field, normalized)
+      continue
+    }
+
     if (typeof value !== 'string') continue
     const canonical = backing.altIndex.get(value)
     if (canonical === undefined || canonical === value) continue
@@ -343,6 +362,20 @@ async function runLookupEnforceWrite(record: Record<string, unknown>, cfg: Looku
     // (#652), so what lands here for a `[].`-wildcard field is already
     // canonical; this loop's job stays membership, not normalization.
     for (const value of getAtPath(record, field)) {
+      // A plain field whose OWN value is a bare top-level array (#661) —
+      // `runLookupIngest` above has already normalized its elements'
+      // altKeys, so membership-check each element through the SAME
+      // `cfg.membership` closure the scalar branch below uses, refusing on
+      // the first unknown one. A non-string element is skipped, mirroring
+      // the scalar branch's own skip.
+      if (Array.isArray(value)) {
+        for (const el of value) {
+          if (typeof el !== 'string') continue
+          const known = cfg.membership ? await cfg.membership(field, el) : true
+          if (!known) throw new UnknownLookupKeyError(desc.dimension, field, el)
+        }
+        continue
+      }
       if (typeof value !== 'string') continue
       const known = cfg.membership ? await cfg.membership(field, value) : true
       if (!known) throw new UnknownLookupKeyError(desc.dimension, field, value)

--- a/packages/hub/src/shape/via-lookup/binding.ts
+++ b/packages/hub/src/shape/via-lookup/binding.ts
@@ -320,6 +320,10 @@ function runLookupIngest(record: Record<string, unknown>, cfg: LookupViaConfig):
     if (values.length !== 1) continue
     const value = values[0]
 
+    // `getAtPath`/`setAtPathInPlace` resolve `field` generically, dotted
+    // paths included (e.g. 'meta.tags') — do not rewrite this branch to a
+    // direct `record[field]` bracket access, which would silently stop
+    // normalizing/enforcing a dotted-non-wildcard bare-array field (#661).
     if (Array.isArray(value)) {
       if (value.length === 0) continue
       let changed = false

--- a/packages/hub/src/shape/via-money/binding.ts
+++ b/packages/hub/src/shape/via-money/binding.ts
@@ -11,7 +11,7 @@ import { installViaBinder } from '../../kernel/via.js'
 import type { MoneyDescriptor } from './descriptor.js'
 import { quantizeMoneyFields, decodeMoneyFields, canonicalizeStoredMoney, canonicalizeIncomingMoney, moneyScaledValue } from './normalize.js'
 import { validateMoneyFieldPaths } from './paths.js'
-import { moneyFieldClause, evaluateMoneyClause, type MoneyWhereOperand } from './where.js'
+import { moneyFieldClause, evaluateMoneyClause, moneyIndexProbe, type MoneyWhereOperand } from './where.js'
 import { wrapMoneyReducers } from './money-reducer.js'
 import type { Operator } from '../../kernel/query/predicate.js'
 import type { AggregateSpec } from '../../with-lookup/aggregate/aggregation.js'
@@ -32,6 +32,7 @@ export function moneyBinding(moneyFields: Record<string, MoneyDescriptor>): ViaB
       return moneyFieldClause(field, op as Operator, value, desc) // the MoneyWhereOperand payload
     },
     evaluateClause: (actual, op, payload) => evaluateMoneyClause(actual, op as Operator, payload as MoneyWhereOperand),
+    indexProbe: (op, payload) => moneyIndexProbe(op as Operator, payload as MoneyWhereOperand),
     decodeResults: (r) => decodeMoneyFields(r as Record<string, unknown>, moneyFields, 'raw'),
     compareForOrder: (field, a, b) => {
       const desc = moneyFields[field]

--- a/packages/hub/src/shape/via-money/where.ts
+++ b/packages/hub/src/shape/via-money/where.ts
@@ -132,6 +132,35 @@ export function moneyFieldClause(
   }
 }
 
+/**
+ * The `via` index-probe operand for a `where()` over a declared money
+ * field (see `ViaBinding.indexProbe` in kernel/via.ts) — the STORED-form
+ * value `CollectionIndexes.lookupEqual`/`lookupIn` (`with-lookup/indexing/
+ * eager-indexes.ts`) can bucket directly.
+ *
+ * Only FIXED-mode `==`/`in` are sound:
+ * - fixed-mode stores a bare scaled-int digit string (no currency
+ *   component), and `entries[i].scaled` is built by {@link parseOperand}
+ *   via the exact same `parseToScaledInt(...).value.toString()` path
+ *   `quantizeMoneyFields` (`via-money/normalize.ts#quantizeAmount`) uses
+ *   to produce the STORED value — so the two strings are byte-identical
+ *   by construction, and `stringifyKey` (which passes a string through
+ *   unchanged) buckets them the same way.
+ * - multi-mode stores `{ amount, currency }` — the index would stringify
+ *   that object to its no-match `'\0OBJECT\0'` sentinel — so multi-mode
+ *   always returns `undefined` (no sound probe).
+ * - every op besides `==`/`in` (range comparisons, `between`) has no
+ *   single stored-form value the hash index can serve, so they return
+ *   `undefined` too — the caller falls back to a scan.
+ */
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+export function moneyIndexProbe(op: Operator, payload: MoneyWhereOperand): unknown | undefined {
+  if (payload.mode !== 'fixed') return undefined
+  if (op === '==') return payload.entries[0]?.scaled
+  if (op === 'in') return payload.entries.map(e => e.scaled)
+  return undefined
+}
+
 /** Read a raw STORED money value into scaled space, or null if absent/malformed. */
 function readStored(actual: unknown, operand: MoneyWhereOperand): MoneyOperandEntry | null {
   let amount: unknown

--- a/packages/hub/src/shape/via-money/where.ts
+++ b/packages/hub/src/shape/via-money/where.ts
@@ -152,6 +152,22 @@ export function moneyFieldClause(
  * - every op besides `==`/`in` (range comparisons, `between`) has no
  *   single stored-form value the hash index can serve, so they return
  *   `undefined` too — the caller falls back to a scan.
+ *
+ * MIXED-ERA CAVEAT: byte-exactness above holds for every record written
+ * through the money write path (`quantizeMoneyFields`), which always
+ * produces a canonical BigInt digit string. A record whose stored value
+ * predates the field's `money()` declaration, or otherwise bypassed
+ * `quantizeMoneyFields`, may hold a NON-canonical scaled string (e.g.
+ * `'0100'` instead of `'100'`) — the index buckets it under that raw
+ * string (`CollectionIndexes#addToIndex` reads the field verbatim, no
+ * BigInt re-parse), so an `==`/`in` probe for the canonical `'100'` misses
+ * it, while the fallback scan (`evaluateMoneyClause`'s `readStored`, which
+ * DOES re-parse via `BigInt(actual).toString()`) still matches it. The fast
+ * path is therefore byte-exact for the canonical (money-write-path) subset
+ * of records, not literally every stored byte sequence; a re-`put()` of the
+ * legacy record canonicalizes it going forward. A money-aware index-key
+ * canonicalization (bucket by the BigInt-normalized form, not the raw
+ * string) would close this gap — filed as a follow-up, not fixed here.
  */
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 export function moneyIndexProbe(op: Operator, payload: MoneyWhereOperand): unknown | undefined {


### PR DESCRIPTION
Milestone #31 completion — the via backlog closed in one batch. Spec: `docs/superpowers/specs/2026-07-13-m31-completion-design.md` · Plan: `docs/superpowers/plans/2026-07-13-m31-completion.md`.

Closes #666
Closes #664
Closes #639
Closes #665
Closes #661
Closes #625

## What ships

- **#666** — `Collection._setVia` writer seam + `HasWritableViaPipeline`; via-graph-wiring's untyped read+write cast dies. Enabler for the reconcile machinery.
- **#664** — late-attach reaches parity with construction: a cross-binding collision guard on the reconcile path (both recipes — incoming×incoming and existing×incoming via the live pipeline's families, honoring the #631 earned exemption set; the `taint` posture overlay correctly excluded from family ownership), plus new `kernel/via-reconcile.ts` machinery — i18n, dictKey, and lookup fields can now be late-attached. Lookup is tier-scoped honestly: enum/static clean, reserved updates the vault registries (sync law applies post-attach), **matrix refuses with a clear error unless its backing collection is open and prefetch-enabled**. The vault's 5-branch `_apply*` ladder collapsed into one dispatch (net −15 lines at its peak; final state exactly at ceiling). Known limits stated in docs: `getDictionary`/`resolveDictLabels`, `describe()` top-level lists, and `presentForJoin` dimension dressing are not rebuilt on late-attach (follow-up filed).
- **#639** — mutual and rotating rollup cycles are refused at `openVault()` (`DerivationCycleError`): `assertAcyclic` gained a traversal-local field→`'*'` containment expansion. Deliberately NOT a graph edge — posture folding never reads `_out`, so the #642 taint fold is provably untouched (the full taint/classified suites are the lock). False-positive risk is structurally foreclosed (rollup factories refuse `from===into` pre-graph; computed deps are field-level; MV/derivation targets are always `'*'`).
- **#665** — virtual computed outputs now get dressed by i18n/lookup: `present()` folds over a three-way stable partition **money → computed → rest**. Money keeps its exact pre-fix decode position (a two-way computed-first partition corrupted composed money values `21`→`'0.21'` — caught in review, pinned as a regression test). Two explicit pinned tradeoffs, documented: a virtual computed reading *another* field's dressing output no longer works; chained virtual computeds remain declaration-order-sensitive. Money virtual dressing stays a known limitation (value-shape, not ordering — follow-up filed).
- **#661** — bare-array lookup fields gain element-wise ingest normalization AND closed-vocabulary enforcement (the filed hole — `['ZZZ','totally-bogus']` silently passing closed vocab — now refuses). Enumeration/skip rules are textually mirrored between the two hooks; dotted non-wildcard paths (`meta.tags`) work and are pinned; scalar and `[].`-wildcard paths byte-identical.
- **#625** — optional `ViaBinding.indexProbe` restores index-accelerated `==`/`in` for fixed-mode money `where()` (the loss was `builder.ts`'s blanket via-clause scan). Probe ≡ index key byte-for-byte for all money-written data (shared `parseToScaledInt` by construction); the previously-fake indexed-fast-path test now proves the path with `lookupEqual`/`lookupIn` spies. One honest caveat, documented in code + docs: a legacy non-canonical scaled string written before money was declared is bucketed raw by the index and missed by the probe while the lenient scan would have matched (follow-up filed for money-aware index-key canonicalization).

## Review record

8 SDD tasks, fresh implementer + reviewer each (opus on the reconcile machinery and the query hot path); 3 fix loops, each catching a real defect pre-merge: a taint-overlay false positive that would have bricked all late-attach under `sealAll`, the `'0.21'` money corruption, and two prescribed one-liners. Docs byte-audited example→test (9/9 exact). Whole-branch review verdict: **Ready to merge — Yes**, zero fixes. Four mutations killed (containment expansion, three-way partition, enforceWrite array branch, candidateRecords probe — the last proving the spies pin the code path, not just results). Cross-task probes all hold: the present partition is reconcile-proof by construction (single construction site — probed live through money/classified/taint late-attach sequences), late lookup ref edges are symmetric-by-construction with the fresh path and correctly unchecked by acyclicity (mutual FKs are legal), the query path never consults the present partition, and bare arrays work on reconcile-built bindings in both tiers. Zero-knowledge sweep clean; goldens zero-delta; `/cargo`, `/adapter`, `/kernel` seams byte-untouched. One pre-existing gap (money-only late-attach drops the taint overlay — byte-identical before this branch) is characterized with a probe recipe and filed as a follow-up rider.

⚠️ Note for future work: vault.ts sits at exactly zero ceiling slack after this branch — the next touch needs a same-task shrink or a justified ratchet decision.

Ceilings: collection.ts 4472, vault.ts 3939, noydb.ts 2385 — all exact, zero bumps. Goldens: zero delta branch-wide; the new `vault-private-surface.test-d.ts` compile-time guard pins the 9 Vault fields that briefly went public during review.

Changeset: `.changeset/m31-completion.md` local per repo convention (hub minor — additive `indexProbe` hook + late-attach coverage).
