### PR TITLE
fix(hub): describe() fidelity — blob describeFragment, int-sentinel filter, static-tier lookup keys (#657)

### DIFF
--- a/packages/hub/__tests__/introspection/describe-blob-fields.test.ts
+++ b/packages/hub/__tests__/introspection/describe-blob-fields.test.ts
@@ -1,0 +1,143 @@
+/**
+ * #657 finding 1 — `blobFields` are invisible in `describe()` (or, with a
+ * `fieldMeta` entry, described as an editable `type:'unknown'` text field).
+ * Repros adapted from the issue (published-package imports → workspace
+ * imports). Fix routes through the ESTABLISHED `describeFragment()` door
+ * (the `lookup` binding is the reference implementation) — the `'blob'`
+ * binding's fragment now feeds `buildDescription`'s `allKeys` union AND a
+ * dedicated `blob` block, mirroring the `lookup` block's own wiring.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { createNoydb } from '../../src/kernel/noydb.js'
+import { withBlobs } from '../../src/via/blob/active.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/kernel/types.js'
+import { ConflictError } from '../../src/kernel/errors.js'
+
+function inlineMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c)
+      const s: VaultSnapshot = {}
+      if (comp) {
+        for (const [n, coll] of comp) {
+          if (!n.startsWith('_')) {
+            const r: Record<string, EncryptedEnvelope> = {}
+            for (const [id, e] of coll) r[id] = e
+            s[n] = r
+          }
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) {
+        const coll = gc(c, n)
+        for (const [id, e] of Object.entries(recs)) coll.set(id, e)
+      }
+    },
+  }
+}
+
+describe('#657 — blobFields describe() fidelity', () => {
+  it('a bare blobFields field (no fieldMeta) now APPEARS in describe({})', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'u', secret: 'pw-blob-1', blobStrategy: withBlobs() })
+    const vault = await db.openVault('v')
+    const a = vault.collection('a', { blobFields: { cover: { retainDays: 10 } } })
+
+    const keys = (await a.describe({})).fields.map((f) => f.key)
+    expect(keys).toContain('cover')
+  })
+
+  it('a bare blobFields field: honest type/widget/editable/blob block (async describe)', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'u', secret: 'pw-blob-2', blobStrategy: withBlobs() })
+    const vault = await db.openVault('v')
+    const a = vault.collection('a', { blobFields: { cover: { retainDays: 10 } } })
+
+    const cover = (await a.describe({})).fields.find((f) => f.key === 'cover')!
+    expect(cover.type).toBe('blob')
+    expect(cover.widget).not.toBe('text')
+    expect(cover.widget).toBe('file')
+    expect(cover.editable).toBe(false)
+    expect(cover.blob).toEqual({ retainDays: 10, queryable: 'none' })
+  })
+
+  it('blobFields + fieldMeta: label is preserved, but the shape is honest (not unknown/text/editable)', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'u', secret: 'pw-blob-3', blobStrategy: withBlobs() })
+    const vault = await db.openVault('v')
+    const b = vault.collection('b', {
+      blobFields: { cover: { retainDays: 10 } },
+      fieldMeta: { cover: { label: 'Cover' } },
+    })
+
+    const cover = (await b.describe({})).fields.find((f) => f.key === 'cover')!
+    expect(cover.label).toBe('Cover')
+    expect(cover.type).toBe('blob')
+    expect(cover.widget).not.toBe('text')
+    expect(cover.editable).toBe(false)
+    expect(cover.blob).toEqual({ retainDays: 10, queryable: 'none' })
+  })
+
+  it('predicate knobs (evictWhen/legalHold/retainUntil) surface as presence flags on the blob block', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'u', secret: 'pw-blob-4', blobStrategy: withBlobs() })
+    const vault = await db.openVault('v')
+    const c = vault.collection('c', {
+      blobFields: {
+        scan: { legalHold: () => true, retainUntil: () => null, public: true },
+      },
+    })
+
+    const scan = (await c.describe({})).fields.find((f) => f.key === 'scan')!
+    expect(scan.blob).toEqual({ legalHold: true, retainUntil: true, public: true, queryable: 'none' })
+  })
+
+  it('sync describe() (no store I/O) also surfaces a bare blobFields field', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'u', secret: 'pw-blob-5', blobStrategy: withBlobs() })
+    const vault = await db.openVault('v')
+    const a = vault.collection('a', { blobFields: { cover: { retainDays: 10 } } })
+
+    const cover = a.describe().fields.find((f) => f.key === 'cover')
+    expect(cover).toBeDefined()
+    expect(cover!.type).toBe('blob')
+    expect(cover!.editable).toBe(false)
+  })
+
+  // Regression (mirrors the i18nFields precedent in describe.test.ts): a
+  // blobFields field paired with fieldMeta but declared alongside a REAL
+  // zod schema (covering other fields) must not trip the async
+  // fieldMeta-key-validation gate — 'cover' is legitimately unknown to the
+  // schema (blob content never flows the record codec) but IS known via
+  // blobFields.
+  it('async describe does not throw when a field is in both blobFields and fieldMeta but not the zod schema', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'u', secret: 'pw-blob-6', blobStrategy: withBlobs() })
+    const vault = await db.openVault('v')
+    const d = vault.collection('d', {
+      schema: z.object({ id: z.string(), title: z.string() }) as unknown as import('../../src/kernel/schema.js').StandardSchemaV1,
+      blobFields: { cover: { retainDays: 10 } },
+      fieldMeta: { cover: { label: 'Cover' } },
+    })
+
+    const desc = await d.describe({})
+    const cover = desc.fields.find((f) => f.key === 'cover')!
+    expect(cover.label).toBe('Cover')
+    expect(cover.type).toBe('blob')
+  })
+})

--- a/packages/hub/__tests__/introspection/describe-constraints.test.ts
+++ b/packages/hub/__tests__/introspection/describe-constraints.test.ts
@@ -87,3 +87,39 @@ describe('async describe({}) surfaces validator constraints', () => {
     expect('constraints' in n).toBe(false)
   })
 })
+
+// #657 finding 2 — zod v4's native toJSONSchema() injects ±Number.MAX_SAFE_INTEGER
+// bounds on every `.int()` field (a JS-safe-integer representability fact, not
+// authored validation intent). Repros adapted from the issue.
+describe('#657 — .int() ±MAX_SAFE_INTEGER sentinel is filtered out of constraints', () => {
+  it('a bare z.number().int() field emits NO minimum/maximum in constraints', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-int-sentinel-1' })
+    const v = await db.openVault('int1')
+    const col = v.collection('bands', {
+      schema: z.object({ id: z.string(), formedYear: z.number().int() }),
+    })
+    const formedYear = (await col.describe({})).fields.find((f) => f.key === 'formedYear')!
+    expect(formedYear.constraints?.minimum).toBeUndefined()
+    expect(formedYear.constraints?.maximum).toBeUndefined()
+  })
+
+  it('z.number().int().min(1) keeps the authored minimum but omits the derived maximum sentinel', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-int-sentinel-2' })
+    const v = await db.openVault('int2')
+    const col = v.collection('bands', {
+      schema: z.object({ id: z.string(), trackCount: z.number().int().min(1) }),
+    })
+    const trackCount = (await col.describe({})).fields.find((f) => f.key === 'trackCount')!
+    expect(trackCount.constraints).toEqual({ minimum: 1 })
+  })
+
+  it('explicit .min(5).max(10) on a non-int number field is untouched', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-int-sentinel-3' })
+    const v = await db.openVault('int3')
+    const col = v.collection('items', {
+      schema: z.object({ id: z.string(), n: z.number().min(5).max(10) }),
+    })
+    const n = (await col.describe({})).fields.find((f) => f.key === 'n')!
+    expect(n.constraints).toEqual({ minimum: 5, maximum: 10 })
+  })
+})

--- a/packages/hub/__tests__/via/countries-matrix.test.ts
+++ b/packages/hub/__tests__/via/countries-matrix.test.ts
@@ -227,6 +227,53 @@ describe('enumOf() — describe() lookup block omits `dimension` for the bare en
   })
 })
 
+// #657 finding 3 — the DescribedField.lookup docblock promises `keys` for
+// "a static table's own keys", but a table-backed static tier (the
+// lookup(dim, {backing:'static', table}) form staticDict() compiles onto)
+// omitted them. Issue's exact repro shape: static backing, closed
+// vocabulary, table, NO declared `keys`.
+describe('lookup(backing:"static", table) — describe() emits keys from the table (#657 finding 3)', () => {
+  const GENRE_LABELS = {
+    rock: { en: 'Rock' },
+    jazz: { en: 'Jazz' },
+  }
+
+  interface AlbumRow extends Record<string, unknown> { id: string; genre: string }
+
+  it('emits `lookup.keys` = the table\'s own key set when no `keys` was declared', async () => {
+    const db = await freshDb()
+    const vault = await db.openVault('v')
+    const albums = vault.collection<AlbumRow>('albums', {
+      lookupFields: {
+        genre: lookup('genre', {
+          backing: 'static',
+          table: GENRE_LABELS,
+          vocabulary: 'closed',
+          displayLocale: 'en',
+          sortBy: 'label',
+        }),
+      },
+    })
+
+    const field = albums.describe().fields.find((f) => f.key === 'genre')
+    expect(field?.lookup?.keys).toEqual(['rock', 'jazz'])
+  })
+
+  // Control: reserved (dict-tier) backing with no declared `keys` and no
+  // `table` has no statically-known key set — `keys` emission stays
+  // unchanged (undefined), same as before this fix.
+  it('control: reserved-tier lookup with no declared keys and no table still omits `keys`', async () => {
+    const db = await freshDb()
+    const vault = await db.openVault('v')
+    const tickets = vault.collection('tickets', {
+      lookupFields: { priority: lookup('priority', { backing: 'reserved' }) },
+    })
+
+    const field = tickets.describe().fields.find((f) => f.key === 'priority')
+    expect(field?.lookup).not.toHaveProperty('keys')
+  })
+})
+
 describe('countries matrix — compareForOrder: plain orderBy on a sortBy-declared matrix field (#650 Task 7, binding carry 1a)', () => {
   it('sorts by the resolved localized name via the sync snapshot, even without {by:"label"}, when displayLocale is declared', async () => {
     const db = await freshDb()

--- a/packages/hub/src/via/blob/binding.ts
+++ b/packages/hub/src/via/blob/binding.ts
@@ -75,6 +75,30 @@ async function eraseBlobs(ctx: ViaEraseCtx, cfg: BlobViaConfig): Promise<ViaEras
 }
 
 /**
+ * One field's blob knobs as they appear on `describeFragment()`'s payload
+ * (#657 — the second real `ViaBinding.describeFragment` consumer after
+ * `lookup`'s; see `with-shape/introspection/describe.ts`'s `buildDescription`).
+ * Declarative scalars (`retainDays`/`external`/`public`/`backlink`) verbatim;
+ * predicate knobs (`evictWhen`/`legalHold`/`retainUntil` — functions over the
+ * decrypted record) as presence flags, since a predicate has no serializable
+ * form — mirrors `buildBlobDescribeFragment`'s per-field shape below.
+ */
+export interface BlobDescribeFragmentEntry {
+  readonly retainDays?: number
+  readonly evictWhen?: true
+  readonly legalHold?: true
+  readonly retainUntil?: true
+  readonly external?: true
+  readonly public?: true
+  readonly backlink?: string
+}
+
+/** The `'blob'` binding's `describeFragment()` payload shape. */
+export interface BlobDescribeFragment {
+  readonly blobFields: Record<string, BlobDescribeFragmentEntry>
+}
+
+/**
  * `{ blobFields: { <field>: <knobs> } }` — declarative scalars
  * (`retainDays`/`external`/`public`/`backlink`) verbatim; predicate knobs
  * (`evictWhen`/`legalHold`/`retainUntil` — functions over the decrypted

--- a/packages/hub/src/via/lookup/binding.ts
+++ b/packages/hub/src/via/lookup/binding.ts
@@ -231,7 +231,16 @@ function buildLookupDescribeFragment(cfg: LookupViaConfig): Record<string, unkno
       ...(desc.altKeys !== undefined ? { altKeys: desc.altKeys } : {}),
       ...(desc.present !== undefined ? { present: desc.present } : {}),
       ...(desc.sortBy !== undefined ? { sortBy: desc.sortBy } : {}),
-      ...(desc.keys !== undefined ? { keys: desc.keys } : {}),
+      // #657 — static tier: when no `keys` was explicitly declared but a
+      // `table` was (the staticDict()-equivalent `lookup(dim, {backing:
+      // 'static', table})` shape), the table's own key set IS the
+      // statically-known closed-vocabulary set the DescribedField.lookup
+      // docblock promises ("declared `keys`, OR a static table's own
+      // keys"). Reserved/matrix tiers never carry `table`, so this branch
+      // never fires for them — their `keys` emission is unchanged.
+      ...(desc.keys !== undefined
+        ? { keys: desc.keys }
+        : desc.table !== undefined ? { keys: Object.keys(desc.table) } : {}),
     }
   }
   return { lookupFields }

--- a/packages/hub/src/via/lookup/binding.ts
+++ b/packages/hub/src/via/lookup/binding.ts
@@ -240,7 +240,7 @@ function buildLookupDescribeFragment(cfg: LookupViaConfig): Record<string, unkno
       // never fires for them — their `keys` emission is unchanged.
       ...(desc.keys !== undefined
         ? { keys: desc.keys }
-        : desc.table !== undefined ? { keys: Object.keys(desc.table) } : {}),
+        : desc.backing === 'static' && desc.table !== undefined ? { keys: Object.keys(desc.table) } : {}),
     }
   }
   return { lookupFields }

--- a/packages/hub/src/with-shape/introspection/describe.ts
+++ b/packages/hub/src/with-shape/introspection/describe.ts
@@ -30,6 +30,10 @@ import type { LookupDescriptor } from '../../via/lookup/descriptor.js'
 // is NOT under kernel/**, so importing this via/ type directly is fine
 // (Check 14 via-layering only restricts the kernel spine).
 import type { LookupDescribeFragment, LookupDescribeFragmentEntry } from '../../via/lookup/binding.js'
+// #657 — the 'blob' binding's describeFragment payload shape (the second-ever
+// ViaBinding.describeFragment consumer, after lookup above). Same rationale:
+// describe.ts is not under kernel/**, so importing this via/ type is fine.
+import type { BlobDescribeFragment, BlobDescribeFragmentEntry } from '../../via/blob/binding.js'
 import type { I18nTextDescriptor } from '../../via/i18n/core.js'
 import type { ComputedFields } from '../../with-formula/computed/index.js'
 import type { RefDescriptor } from '../../kernel/refs.js'
@@ -105,6 +109,26 @@ export interface DescribedField {
      * deployment wanting it gated can gate this behind its value-bearing door.
      */
     readonly equatable?: true
+  }
+  /**
+   * Present only for a field declared via `blobFields` (#657) — out-of-band
+   * attachment storage (`collection.blob(id)`), never a sealed or plaintext
+   * record field. `queryable` mirrors the binding's fixed `ViaPosture`
+   * (blob content is never indexed — always `'none'`); the rest mirrors the
+   * declared `blobFields[field]` policy verbatim (scalars) or as a presence
+   * flag (predicate knobs — a predicate has no serializable form). Sourced
+   * from the `'blob'` binding's `describeFragment()`, the same
+   * `viaFragments` door the `lookup` block above is sourced from.
+   */
+  readonly blob?: {
+    readonly retainDays?: number
+    readonly evictWhen?: true
+    readonly legalHold?: true
+    readonly retainUntil?: true
+    readonly external?: true
+    readonly public?: true
+    readonly backlink?: string
+    readonly queryable: 'none'
   }
   /**
    * Present only for a graph-tainted derived field (#638 Task 3 — computed/
@@ -256,9 +280,10 @@ export interface BuildDescriptionInput {
    * Per-binding `describeFragment()` output, keyed by binding brand (#650
    * Task 7 — first-ever consumer of `ViaBinding.describeFragment`,
    * `via.ts:136`). `Collection.describe()`/`describeAsync()` build this
-   * from `this.via?.describeFragments()`. Only the `'lookup'` brand's
-   * fragment is consumed today (the `lookup` block below); other brands'
-   * fragments ride along unread until they gain a consumer too.
+   * from `this.via?.describeFragments()`. The `'lookup'` brand's fragment
+   * feeds the `lookup` block below; `'blob'`'s feeds the `blob` block
+   * (#657, the second consumer). Other brands' fragments ride along unread
+   * until they gain a consumer too.
    */
   readonly viaFragments?: Record<string, Record<string, unknown>> | undefined
 }
@@ -278,6 +303,8 @@ function deriveWidget(opts: {
   dict?: unknown
   /** #650 Task 7 — same 'select' outcome as `dict` (today always co-present for a lookup field via the existing `dict` block; kept as its own check so a future lookup-only field, with no `dict` block, still derives 'select'). */
   lookup?: unknown
+  /** #657 — a blobFields-declared field derives the 'file' widget, never the 'text' default (binary content, not a text input). */
+  blob?: unknown
   resolvedWidget?: string
 }): string {
   if (opts.resolvedWidget !== undefined) return opts.resolvedWidget
@@ -297,6 +324,7 @@ function deriveWidget(opts: {
       return 'number'
   }
   if (opts.dict !== undefined || opts.lookup !== undefined) return 'select'
+  if (opts.blob !== undefined) return 'file'
   if (opts.type === 'boolean') return 'checkbox'
   if (opts.type === 'number') return 'number'
   return 'text'
@@ -321,6 +349,15 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
   // `describeFragment` consumption the task wires up.
   const lookupFragments = (input.viaFragments?.['lookup'] as LookupDescribeFragment | undefined)?.lookupFields
 
+  // #657 — the 'blob' binding's describeFragment, keyed per field (same
+  // routing pattern as lookupFragments above). A blobFields-declared field
+  // has no other config-map source (unlike money/dict/lookup/i18n/classified,
+  // each of which is fed a dedicated map below) — `blobFragments` is BOTH
+  // this field's block source AND (via its keys) how it joins `allKeys` at
+  // all, since otherwise a blobFields-only field with no fieldMeta entry is
+  // invisible in describe() (#657 finding 1).
+  const blobFragments = (input.viaFragments?.['blob'] as BlobDescribeFragment | undefined)?.blobFields
+
   // When zodFields is present AND non-empty (async path, validator successfully derived
   // a schema): validate fieldMeta keys against the real known-field set = config keys ∪
   // zodFields keys. This is the carry from Task 1: vault.ts couldn't do this synchronously
@@ -337,6 +374,7 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
       ...Object.keys(zodFields),
       ...Object.keys(i18nFields ?? {}),
       ...Object.keys(lookupFields ?? {}),
+      ...Object.keys(blobFragments ?? {}),
     ])
     validateFieldMetaKeys(collection, fieldMeta, knownFields)
   }
@@ -352,6 +390,7 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
     ...Object.keys(zodFields ?? {}),
     ...Object.keys(i18nFields ?? {}),
     ...Object.keys(classified ?? {}),
+    ...Object.keys(blobFragments ?? {}),
   ])
 
   const fields: DescribedField[] = []
@@ -367,6 +406,7 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
     const isComputed = computed !== undefined && key in computed
     const i18nDesc = i18nFields?.[key]
     const cls = classified?.[key]
+    const blobFragmentEntry: BlobDescribeFragmentEntry | undefined = blobFragments?.[key]
     const taintPosture = taint?.postures.get(key)
 
     // ── Infer type + structural extras ────────────────────────────────────
@@ -377,6 +417,7 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
     let dictBlock: DescribedField['dict'] | undefined
     let refBlock: DescribedField['ref'] | undefined
     let lookupBlock: DescribedField['lookup'] | undefined
+    let blobBlock: DescribedField['blob'] | undefined
 
     if (money) {
       type = 'number'
@@ -473,6 +514,15 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
       type = 'string'
     } else if (isComputed) {
       // type already initialized to zod?.type ?? 'unknown' above; no re-set needed
+    } else if (blobFragmentEntry !== undefined) {
+      // #657 finding 1 — a blobFields-only field (no schema/money/dict/
+      // lookup/i18n config) was previously invisible; with a fieldMeta
+      // entry it fell through to the 'unknown'/'text'/editable:true default,
+      // actively wrong for binary content. `type` is a plain `string` on
+      // DescribedField (not a closed union), so 'blob' is not a breaking
+      // union extension.
+      type = 'blob'
+      blobBlock = { ...blobFragmentEntry, queryable: 'none' }
     }
 
     // ── lookup block (#650 Task 7 — first-ever ViaBinding.describeFragment
@@ -528,15 +578,18 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
       ...(resolved.semanticType !== undefined ? { semanticType: resolved.semanticType } : {}),
       ...(dictBlock !== undefined ? { dict: dictBlock } : {}),
       ...(lookupBlock !== undefined ? { lookup: lookupBlock } : {}),
+      ...(blobBlock !== undefined ? { blob: blobBlock } : {}),
       ...(resolved.widget !== undefined ? { resolvedWidget: resolved.widget } : {}),
     })
 
-    // ── Editable: false for computed, id, provenance-stamped fields ────────
+    // ── Editable: false for computed, id, provenance-stamped, blob fields ──
     // Provenance fields (_source, _sourceTs) are envelope-level metadata, not
     // user schema fields — they won't appear as keys in fieldMeta so this check
     // is implicitly handled (they'd never appear in allKeys). Explicitly guard
-    // computed + 'id' as the two structural non-editable cases.
-    const editable = !isComputed && key !== 'id'
+    // computed + 'id' as the two structural non-editable cases. A blobFields
+    // field (#657) is never written through the record codec — it's mutated
+    // exclusively via `collection.blob(id)` — so it is never editable either.
+    const editable = !isComputed && key !== 'id' && blobBlock === undefined
 
     // ── Assemble the field (exactOptionalPropertyTypes-safe spreads) ───────
     const field: DescribedField = {
@@ -558,6 +611,7 @@ export function buildDescription(input: BuildDescriptionInput): CollectionDescri
       ...(moneyBlock !== undefined ? { money: moneyBlock } : {}),
       ...(dictBlock !== undefined ? { dict: dictBlock } : {}),
       ...(lookupBlock !== undefined ? { lookup: lookupBlock } : {}),
+      ...(blobBlock !== undefined ? { blob: blobBlock } : {}),
       ...(isComputed ? { computed: true as const } : {}),
       ...(i18nBlock !== undefined ? { i18n: i18nBlock } : {}),
       widget,

--- a/packages/hub/src/with-shape/introspection/fields.ts
+++ b/packages/hub/src/with-shape/introspection/fields.ts
@@ -41,6 +41,23 @@ function jsonSchemaType(node: JsonSchemaShape): string {
   return 'opaque'
 }
 
+// #657 — zod v4's native `toJSONSchema()` injects a ±Number.MAX_SAFE_INTEGER
+// bound on every `.int()` field (a JS-safe-integer representability fact,
+// not authored validation intent — `type: 'integer'` already carries it).
+// Empirically verified: `z.number().int()` → `{type:'integer', minimum:
+// -9007199254740991, maximum:9007199254740991}`, and — critically — zod
+// emits NO metadata distinguishing that derived bound from an authored one
+// at the exact same value (`z.number().min(-9007199254740991)
+// .max(9007199254740991)` on a plain, non-int number produces a
+// byte-identical minimum/maximum). Without that distinguishing signal, a
+// value-based filter gated on `type === 'integer'` is the pragmatic call:
+// it never touches a non-int field's authored bound (whatever its value),
+// and an authored `.int().min(Number.MAX_SAFE_INTEGER)` is pathological
+// either way, so folding it into the same omission is an acceptable trade.
+function isIntSentinel(node: JsonSchemaShape, value: number): boolean {
+  return node.type === 'integer' && Math.abs(value) === Number.MAX_SAFE_INTEGER
+}
+
 function constraintsFor(node: JsonSchemaShape): Record<string, unknown> | undefined {
   const out: Record<string, unknown> = {}
   if (node.enum) out.values = node.enum
@@ -50,8 +67,8 @@ function constraintsFor(node: JsonSchemaShape): Record<string, unknown> | undefi
   if (node.maxLength !== undefined) out.maxLength = node.maxLength
   if (node.pattern !== undefined) out.pattern = node.pattern
   if (node.format !== undefined) out.format = node.format
-  if (node.minimum !== undefined) out.minimum = node.minimum
-  if (node.maximum !== undefined) out.maximum = node.maximum
+  if (node.minimum !== undefined && !isIntSentinel(node, node.minimum)) out.minimum = node.minimum
+  if (node.maximum !== undefined && !isIntSentinel(node, node.maximum)) out.maximum = node.maximum
   if (node.exclusiveMinimum !== undefined) out.gt = node.exclusiveMinimum
   if (node.exclusiveMaximum !== undefined) out.lt = node.exclusiveMaximum
   return Object.keys(out).length === 0 ? undefined : out


### PR DESCRIPTION
describe() fidelity fixes from the noy-db-ui pre.9 adoption report. All three findings carried minimal repros — each became a red-first pin.

Closes #657

- **blobFields now appear in describe(), honestly**: a `describeFragment` on the blob binding (the lookup-block precedent). Bare `blobFields` fields appear; with `fieldMeta` they show `type: 'blob'`, `widget: 'file'` (explicit `fieldMeta.widget` override still wins), `editable: false`, and a `blob: { retainDays, … }` policy block with `queryable: 'none'` — no more editable-text-input invitation for binary content, and a schema-driven UI can finally learn the collection has an attachment field from the contract. Emitted keys are policy-shape scalars/flags only (predicates reduced to presence booleans — nothing internal leaks).
- **zod `.int()` sentinel bounds filtered**: derived ±`Number.MAX_SAFE_INTEGER` bounds no longer land in `constraints` (`.int()` → no bounds; `.int().min(1)` → `{minimum: 1}`; authored `.min(5).max(10)` untouched). The authored-pathological-bound tradeoff is documented at the filter.
- **Static-tier `lookup()` emits `keys`** from the table's canonical key set, as the `DescribedField.lookup` docblock always promised; double-guarded on `backing === 'static'` (review catch — the raw factory can pair a stray table with other backings); dict/matrix tiers byte-unchanged (control-pinned).

Known deferral (in the changeset): `toJSONSchema()` degrades `type: 'blob'` to `string` — a separate JSON-Schema story.

Review record: implementer + task review (one prescribed guard tightening applied); 11 red-first pins; full hub suite 483/3923; all goldens green; guarded kernel files untouched. Changeset `.changeset/describe-fidelity.md` local (hub patch).