### PR TITLE
fix(hub): milestone #32 — via follow-ups 2 (#669 #670 #671 #672)

### DIFF
--- a/docs/subsystems/via-computed.md
+++ b/docs/subsystems/via-computed.md
@@ -107,27 +107,31 @@ particular field composition. Two tradeoffs fall out of this fixed order, both p
 three-way (money, computed, rest), not two-way (computed, rest), partition. See the "Composition"
 section below for the value-shape reason money must keep its pre-#665 present position.
 
-## Composition — `via(computed(...), money(...))`: money formats materialized, not virtual
+## Composition — `via(computed(...), money(...))`: money formats materialized AND virtual (#669)
 
 `compileViaBindings` always runs `computed` **last** in the feature stack (money → i18n →
 classified → blob → computed), so a computed `fn`'s `deps` can read other fields' already-decoded
 presentation (a money-quantized amount, an i18n-resolved label). Composing computed **with**
-another feature on the **same field** is legal in both modes, but the two modes behave oppositely
-because of this ordering, pinned as two separate, deliberate assertions:
+another feature on the **same field** is legal in both modes, and — since #669 — both modes end
+up money-formatted, though via two different mechanisms:
 
 ```ts
-// VIRTUAL: money's present() runs first (nothing to decode yet), computed's runs last and
-// unconditionally overwrites — the raw computed number survives, NOT a money-formatted string.
+// VIRTUAL: money's ORDINARY present() explicitly skips a field that is both money and
+// virtual-mode computed (nothing to decode yet at that point in the fold — the #665 invariant
+// keeps money's stored-field decode ahead of computed). A separate presentLate hook (#669) then
+// quantizes the fn's fresh MAJOR-UNITS output to the field's scale/rounding and presents it
+// exactly like a stored money field.
 const c = v.collection<Priced>('priced', {
   viaFields: { doubledPrice: via(computed((r) => (r.base as number) * 2, { deps: ['base'], mode: 'virtual' }), money({ currency: 'EUR', scale: 2 })) },
 })
 await c.put('a', { id: 'a', base: 10.5 })
-;(await c.get('a'))?.doubledPrice // 21 (a plain number, not '21.00')
+;(await c.get('a'))?.doubledPrice          // '21.00' — quantized decimal string, not the raw '21'
+;(await c.get('a'))?.doubledPriceFormatted // defined — dressed under a real (non-'raw') locale
 ```
 
 ```ts
 // MATERIALIZED (default): computed's output is evaluated before encodeWrite, so money's own
-// encode/decode/present hooks cover it exactly like a plain money field.
+// encode/decode/present hooks cover it exactly like a plain money field — unchanged by #669.
 const c = v.collection<Priced>('priced', {
   viaFields: { total: via(computed((r) => (r.base as number) * 2, { deps: ['base'], mode: 'materialized' }), money({ currency: 'EUR', scale: 2 })) },
 })
@@ -136,8 +140,26 @@ await c.put('a', { id: 'a', base: 10.5 })
 ```
 
 (both from `virtual.test.ts` — "composed grammar" and "composed grammar (MATERIALIZED default)").
-Money-decorating-a-virtual-field's-own-output (i.e. having money format the computed value in
-`mode: 'virtual'`) is a known, accepted limitation, not implemented.
+The virtual case is implemented via `ViaBinding.presentLate` (`kernel/via/index.ts`) — a hook
+that runs after every binding's ordinary `present()` in the money+computed present-order segment
+(see the Present order section above), before the "everything else" segment (i18n/lookup
+dressing, taint redaction). An fn output that fails to parse at the field's scale (excess
+precision with no `rounding` declared) is left RAW, no throw:
+
+```ts
+const c = v.collection<Priced>('priced', {
+  viaFields: { amount: via(computed(() => 21.005, { mode: 'virtual' }), money({ currency: 'EUR', scale: 2 })) },
+})
+await c.put('a', { id: 'a' })
+;(await c.get('a'))?.amount // 21.005 — raw, untouched (no rounding declared, excess precision)
+```
+
+With a declared `rounding` (e.g. `'half-up'`), the same `21.005` quantizes to `'21.01'` instead of
+being left raw. Fixed-mode fields only — a virtual field's output has no natural
+`{ amount, currency }` shape to parse for multi-currency mode. A taint-redacted virtual field's
+`<field>Formatted`/`<field>Number` companions are stripped along with the base field (see the
+comment on the companion-stripping loop in `kernel/via/taint-binding.ts`), not left leaking the
+pre-redaction value.
 
 ## Taint propagation — inherits the strictest source posture (#636)
 
@@ -315,7 +337,7 @@ documented as "do not depend on this shape") is **removed**, not aliased — fol
 - `packages/hub/src/kernel/via/pipeline.ts` — `ViaPipeline._presentOrder` (#665's present-phase-only
   three-way partition: money, then computed, then everything else)
 - `packages/hub/src/via/computed/` — `computed()`/`ComputedDescriptor`/`computedBinding`
-- `packages/hub/__tests__/computed/virtual.test.ts` — the `mode: 'virtual'` suite (22 tests, incl.
+- `packages/hub/__tests__/computed/virtual.test.ts` — the `mode: 'virtual'` suite (27 tests, incl.
   the `'#665 present-order — second-order effects'` describe block backing the tradeoffs above)
 - `packages/hub/__tests__/via/computed-binding.test.ts` — the binding unit suite (6 tests)
 - `packages/hub/__tests__/via/taint.test.ts` — the #636 taint-propagation regression suite

--- a/docs/subsystems/via-lookup.md
+++ b/docs/subsystems/via-lookup.md
@@ -133,6 +133,17 @@ has never had a live fallback — it is pure-snapshot for both tiers. The matrix
 path (`<field>Label` resolution, below) is different: it preserves a live cold-session fallback, but
 **only** for the default `key: 'id'` (#651, closed).
 
+**`rename()` and closed vocabulary (#670).** `LookupHandle.rename(oldKey, newKey)` is the
+sanctioned mass-mutation path for a dictionary key that live records reference. Before #670,
+renaming a key on a `vocabulary: 'closed'` field could self-refuse with `UnknownLookupKeyError`:
+`rename()` rewrote referencing records (step 3) before publishing `newKey` into the sync cache
+`enforceWrite`'s closed-vocabulary membership check reads, so the rewrite's own write of `newKey`
+looked like an unknown key. The fix reorders the sync-cache publish to happen immediately after
+`newKey` is durably written (step 2), before any referencing record is rewritten — mid-rename,
+**both** `oldKey` and `newKey` are legitimately members (the correct transition semantics: records
+are moving from old to new), and `oldKey` stays a member until its own removal completes at the
+end of `rename()`. See `packages/hub/__tests__/via/lookup-closed-rename.test.ts`.
+
 ## Bare-array fields — element-wise support (#661)
 
 A plain field whose OWN value is an array (`tags: ['USA', '+66']` on `tags: lookup('countries',
@@ -220,31 +231,55 @@ A single late-attach call may combine `i18nFields`/`dictKeyFields` on one field 
 on a DIFFERENT field; both attach from that one call (`reconcile-lookup.test.ts`'s `t8r1` describe
 block pins this against a future dispatch collapse).
 
-**Known limits — three late-attach residuals**, all rooted in the same cause: a handful of
-`Collection` fields (`getDictionary`, `i18nFields`, `dictKeyFields`, `lookupFields`,
-`presentForJoin`) are captured ONCE, at fresh construction, from the constructor's `cfg` — late-
-attach rebuilds the `ViaPipeline` (`coll._setVia`) but has no seam to reassign these separate,
-private-readonly instance fields:
+**Five late-attach residuals — all fixed (#671).** A handful of `Collection` fields
+(`getDictionary`, `i18nFields`, `dictKeyFields`, `lookupFields`, `presentForJoin`) used to be
+captured ONCE, at fresh construction, from the constructor's `cfg`; late-attach rebuilt the
+`ViaPipeline` (`coll._setVia`) but had no seam to reassign these separate, private-readonly
+instance fields. Two more residuals shared the same "construction-frozen state reconcile can't
+refresh" root cause but lived outside these lookup-specific fields. All five are closed now:
 
-- **`getDictionary`/`resolveDictLabels`** — `collection.describeAsync({ resolveDictLabels: true })`
-  resolves a dynamic dict's live labels via `this.getDictionary`, which stays `undefined` if the
-  collection was constructed with no `dictKeyFields`/`lookupFields` at all (exactly the case a
-  late-attach starts from). A late-attached dict-backed field's labels stay unresolved by
-  `resolveDictLabels: true` — the sync inline-`labels` fallback (if declared) still works.
-- **`describe()`'s top-level field list** — the legacy per-field `type`/`widget`/`dict` derivation
-  (`buildDescription`) reads `this.dictKeyFields`/`this.i18nFields`/`this.lookupFields`, the same
-  construction-time snapshot — a late-attached field may not appear in that top-level list at all
-  (unless the schema also names it). The NEW `.lookup` describeFragment block (`ViaPipeline.
-  describeFragments()`) is unaffected — it folds `_via.bindings` live, so it DOES reflect a
-  late-attached field correctly; only the older list-derivation path is stale.
-- **`presentForJoin`** — captured once from `cfg.presentForJoin` at construction. When a collection
-  is the TARGET of `.join()` (or a matrix-tier lookup's backing dimension), a lookup/i18n field
-  late-attached onto it will not dress `<field>Label` through the join-presentation path, even
-  though it dresses correctly on a DIRECT read of that same collection.
+- **`getDictionary`/`resolveDictLabels` (item 1)** — `collection.describeAsync({
+  resolveDictLabels: true })` resolves a dynamic dict's live labels via `this.getDictionary`,
+  which used to stay `undefined` if the collection was constructed with no
+  `dictKeyFields`/`lookupFields` at all (exactly the case a late-attach starts from). Fixed: a
+  late-attached dict-backed field's labels now resolve correctly under
+  `resolveDictLabels: true` too.
+- **`describe()`'s top-level field list (item 2)** — the legacy per-field `type`/`widget`/`dict`
+  derivation (`buildDescription`) reads `this.dictKeyFields`/`this.i18nFields`/`this.lookupFields`,
+  the same construction-time snapshot — a late-attached field used to be missing from that
+  top-level list (unless the schema also named it), even though the NEWER `.lookup`
+  describeFragment block (`ViaPipeline.describeFragments()`, which folds `_via.bindings` live) was
+  already correct. Fixed: a late-attached field's legacy list entry is now deep-equal to the same
+  declaration made at fresh construction.
+- **`presentForJoin` (item 3)** — captured once from `cfg.presentForJoin` at construction. When a
+  collection is the TARGET of `.join()` (or a matrix-tier lookup's backing dimension), a lookup/
+  i18n field late-attached onto it used to not dress `<field>Label` through the join-presentation
+  path, even though it dressed correctly on a DIRECT read of that same collection. Fixed: join-
+  dressing now covers a late-attached field too.
+- **Taint overlay dropped on a money- or classified-only late-attach (item 4)** —
+  `_applyMoneyFields`/`_applyClassifiedFields` (`kernel/collection.ts`) used to rebuild `this.via`
+  via the bare one-arg `ViaPipeline.build(bindings)` call, silently defaulting `taint` to
+  `undefined` and dropping an already-materialized overlay (e.g. reconciling `moneyFields` onto a
+  collection that already has a classified+computed taint overlay from an earlier call). Fixed:
+  both rebuild paths thread `this.via?.taint` through their own `ViaPipeline.build(...)` call, so a
+  late money- or classified-only attach can no longer silently un-taint an already-sealed field.
+- **`assertAcyclic` false-positive on mutual FK lookups (item 5)** — two collections each
+  declaring a lookup/ref field pointing at the other (legitimate mutual foreign keys) used to trip
+  `ViaGraph.assertAcyclic()`'s declare-time cycle check and throw `DerivationCycleError` —
+  `kind: 'ref'` edges exist for cascade/rename machinery (`referencingEdgesOf`, the `onDelete:
+  restrict/cascade/nullify` semantics above), never derivation ordering, and were never meant to
+  participate in cycle detection. Fixed: `assertAcyclic`'s traversal now excludes `kind: 'ref'`
+  consuming edges — a genuine derivation/rollup/MV cycle still throws; a mutual-FK-only "cycle"
+  no longer does.
 
-None of these are fixed here — they're recorded as known limits so a late-attach consumer that
-also needs `describeAsync({resolveDictLabels:true})`, a complete `describe()` field list, or
-join-dressing on the late-attached side knows to declare the field at fresh construction instead.
+Items 1-3 are fixed by one new writer seam, `Collection._reconcileReadState` (mirrors the
+pre-existing `_setVia`, `kernel/collection.ts`) — `kernel/via/reconcile.ts` calls it once per
+reconcile pass with merged descriptor maps (construction-time entries win on collision, the same
+rule the #664 collision guard already enforces upstream) plus a rebuilt `getDictionary`/
+`presentForJoin` closure pair. See `packages/hub/__tests__/via/reconcile-read-state.test.ts` (items
+1-3), `packages/hub/__tests__/via/reconcile-taint.test.ts` (item 4), and
+`packages/hub/__tests__/via/graph.test.ts` (item 5). A late-attach consumer no longer needs to
+fall back to declaring these fields at fresh construction instead.
 
 ## Presentation — `<field>Label`, in reads and in joins
 
@@ -461,3 +496,8 @@ are EMPTY and still fire on a synthetic violation).
   enforceWrite, top-level and dotted-path shapes
 - `packages/hub/__tests__/via/reconcile-lookup.test.ts` — #664: the late-attach reconcile suite
   (tier-by-tier attach, matrix refusal, graph edges, collision guard, combined-family attach)
+- `packages/hub/__tests__/via/lookup-closed-rename.test.ts` — #670: `rename()`'s sync-cache
+  ordering fix on a closed-vocabulary field
+- `packages/hub/__tests__/via/reconcile-read-state.test.ts`, `reconcile-taint.test.ts`,
+  `graph.test.ts` — #671: the five late-attach residuals (read-state refresh, taint-overlay
+  threading, ref-edge cycle exemption)

--- a/docs/subsystems/via-money.md
+++ b/docs/subsystems/via-money.md
@@ -78,18 +78,15 @@ full scan. Multi-currency (`currencies:`) fields and every operator besides `==`
 can serve for those (`packages/hub/__tests__/money/where-comparison.test.ts`, "indexed fast path
 agrees with the scan" describe block, spy-proven against `lookupEqual`/`lookupIn`).
 
-**Honest limit — mixed-era data.** The fast path is byte-exact for every record written through
-the money write path: `quantizeMoneyFields` always produces a canonical BigInt digit string
-(no leading zeros), and the index buckets that exact string. A record whose stored value
-predates the field's `money()` declaration, or otherwise bypassed the money write path, may hold
-a non-canonical scaled string (e.g. `'0100'` instead of `'100'`) — the index buckets it under
-that raw, non-canonical string, so an `==`/`in` probe for the canonical amount misses it, while
-the fallback scan (which re-parses the stored value via `BigInt(actual).toString()`) still
-matches it correctly. In other words: **the indexed fast path returns the canonical subset of
-matches; the scan always returns every match.** A re-`put()` of a legacy record canonicalizes
-its stored form going forward, closing the gap for that record. A money-aware index-key
-canonicalization (bucketing by the BigInt-normalized form rather than the raw stored string)
-would close this gap generally — filed as a follow-up, not implemented here.
+**Mixed-era data (#672).** A record whose stored value predates the field's `money()`
+declaration, or otherwise bypassed the money write path, may hold a non-canonical scaled string
+(e.g. `'0100'` instead of `'100'`). The eager index no longer buckets it under that raw string:
+`CollectionIndexes` consults a money-aware index-key canonicalizer (`ViaPipeline.
+canonicalizeIndexKey`, backed by `moneyScaledValue`'s BigInt re-parse) whenever it builds or
+rebuilds a money field's buckets, so a legacy value lands in the SAME bucket a canonical write
+produces — an `==`/`in` probe for the canonical amount finds it, matching the fallback scan
+exactly. The canonicalizer is applied on eager-index build/rebuild (including rebuild-on-hydrate);
+a re-`put()` of a legacy record still canonicalizes its stored form going forward, same as before.
 
 ## See also
 

--- a/docs/subsystems/via-money.md
+++ b/docs/subsystems/via-money.md
@@ -82,11 +82,18 @@ agrees with the scan" describe block, spy-proven against `lookupEqual`/`lookupIn
 declaration, or otherwise bypassed the money write path, may hold a non-canonical scaled string
 (e.g. `'0100'` instead of `'100'`). The eager index no longer buckets it under that raw string:
 `CollectionIndexes` consults a money-aware index-key canonicalizer (`ViaPipeline.
-canonicalizeIndexKey`, backed by `moneyScaledValue`'s BigInt re-parse) whenever it builds or
-rebuilds a money field's buckets, so a legacy value lands in the SAME bucket a canonical write
-produces — an `==`/`in` probe for the canonical amount finds it, matching the fallback scan
-exactly. The canonicalizer is applied on eager-index build/rebuild (including rebuild-on-hydrate);
-a re-`put()` of a legacy record still canonicalizes its stored form going forward, same as before.
+canonicalizeIndexKey`, backed by `moneyScaledValue`'s BigInt re-parse) whenever it mutates a
+bucket, so a legacy value lands in the SAME bucket a canonical write produces — an `==`/`in` probe
+for the canonical amount finds it, matching the fallback scan exactly. The guarantee holds across
+**every** eager-index bucket-mutation site — build (incl. rebuild-on-hydrate), `put()` (upsert),
+and `delete()` (remove) — so updating or deleting a legacy record cleans up its canonical bucket
+correctly instead of stranding the id there (a gap the initial #672 fix left open, closed in
+review).
+
+**Boundary: eager mode only.** Lazy-mode collections (`prefetch: false`) keep their own durable
+`PersistedCollectionIndex` side-cars, which bucket by the raw stored value and do not consult
+money canonicalization. A lazy-mode collection with mixed-era money data can still see its fast
+path diverge from a forced scan; that gap is tracked separately, not fixed here.
 
 ## See also
 

--- a/docs/subsystems/via-money.md
+++ b/docs/subsystems/via-money.md
@@ -58,6 +58,36 @@ no locale is passed) and `<field>Number` (a JS `number`) as read-time virtuals �
 with `{ locale: 'raw' }`, which returns only the canonical decimal (or `{ amount, currency }` in
 multi mode) with no virtuals.
 
+## Composing with a virtual computed field (#669)
+
+`via(computed(fn, { mode: 'virtual' }), money(...))` on the SAME field — a virtual computed
+field's `fn` output composed with money — is a legal, DRESSED composition, not merely
+accepted-but-undressed: money quantizes the fn's MAJOR-UNITS return value to the field's scale
+(applying the descriptor's declared `rounding`) and presents it exactly like a stored money
+field — the canonical decimal string, plus `<field>Formatted`/`<field>Number` whenever a real
+(non-`'raw'`) locale is in effect:
+
+```ts
+const c = v.collection<Priced>('priced', {
+  viaFields: {
+    doubledPrice: via(computed((r) => (r.base as number) * 2, { deps: ['base'], mode: 'virtual' }), money({ currency: 'EUR', scale: 2 })),
+  },
+})
+await c.put('a', { id: 'a', base: 10.5 })
+;(await c.get('a'))?.doubledPrice           // '21.00' — quantized decimal string
+;(await c.get('a'))?.doubledPriceFormatted  // defined — dressed like any stored money field
+```
+
+An fn output that fails to parse at the field's scale (excess precision with no `rounding`
+declared) is left RAW, no throw — read-time dressing must never brick a read. Fixed-mode fields
+only; a virtual field's output has no natural `{ amount, currency }` shape for multi-currency
+mode. Materialized-mode `computed` fields were already dressed before #669 (the fn's output
+merges into the record before money's ordinary write-time `encodeWrite` runs); this closes the
+matching virtual-mode gap. A taint-redacted virtual field's `Formatted`/`Number` companions are
+stripped along with the base field, not left leaking the pre-redaction value. See
+[`docs/subsystems/via-computed.md`](via-computed.md) (the "Composition" section) for the full
+ordering story (`ViaBinding.presentLate`).
+
 ## Query & aggregate
 
 `where()` predicates on money fields quantize operands to the field's scale at build time

--- a/docs/subsystems/via.md
+++ b/docs/subsystems/via.md
@@ -426,10 +426,12 @@ guard** that already ran at fresh construction (refusing two via families claimi
 now also runs on every late-attach call, both within the incoming call's own fields and against
 the collection's already-declared fields — no partial attach on a collision. See
 [`docs/subsystems/via-lookup.md`](via-lookup.md#late-attach-reconcile--tier-scoped-664) for the
-full tier-by-tier story, the collision guard's exact behavior, and three known late-attach
-residuals (`describeAsync({resolveDictLabels:true})`, `describe()`'s legacy top-level field list,
-and join-side `presentForJoin` dressing — each captured once at fresh construction and not
-re-derived by a later reconcile call).
+full tier-by-tier story, the collision guard's exact behavior, and (at the time of #664/#31) three
+known late-attach residuals (`describeAsync({resolveDictLabels:true})`, `describe()`'s legacy
+top-level field list, and join-side `presentForJoin` dressing — each captured once at fresh
+construction and not re-derived by a later reconcile call). All three, plus two more of the same
+root cause found during milestone #32, were closed by #671 — see the linked section for the
+current, fixed state.
 
 **Declare-time mutual-rollup cycle refusal (#639).** Two (or more) `withRollup()` strategies whose
 targets mutually depend on each other (collection A rolls a value into B's field `x`; B rolls a
@@ -480,8 +482,10 @@ lookup shape, including at a dotted (non-wildcard) path.
 an optional `ViaBinding.indexProbe(op, payload)` hook lets a binding hand the query builder a
 STORED-form operand for a direct index bucket lookup on `==`/`in`, restoring the fast path phase A
 originally lost for money fields (multi-currency money and every other operator still scan — there
-is no single stored-form value a hash index can serve for those). Ships with an honest mixed-era
-caveat for pre-money-declaration legacy data (documented on the money page).
+is no single stored-form value a hash index can serve for those). The initial mixed-era caveat for
+pre-money-declaration legacy data was closed for eager-mode collections by #672's index-key
+canonicalizer (documented on the money page); a lazy-mode (`prefetch: false`) boundary remains,
+tracked separately.
 
 ## See also
 

--- a/docs/superpowers/plans/2026-07-13-m32-via-followups.md
+++ b/docs/superpowers/plans/2026-07-13-m32-via-followups.md
@@ -1,0 +1,171 @@
+# Milestone #32 — Via follow-ups 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the four open milestone-#32 issues — #670 (LookupHandle.rename() self-refusal), #672 (money index-key canonicalization), #669 (money dresses a virtual computed field's output as MAJOR UNITS — user-ratified design), #671 (five late-attach reconcile residuals).
+
+**Architecture:** All fixes ride existing seams: the `ViaBinding`/`ViaPipeline` port (`kernel/via/`), the vault reconcile path (`kernel/via/reconcile.ts`), and the `via/money` + `via/lookup` families. Ground truth for every call site, line number, and code excerpt is `.superpowers/sdd/m32-seam-map.md` — each task names the section that is its map. Where the plan and the live tree disagree, the tree wins; where the plan and the seam map disagree, re-read the tree and flag it.
+
+**Tech Stack:** TypeScript ESM, vitest, pnpm + turbo. Work in `packages/hub`.
+
+## Global Constraints
+
+- **Ceilings, zero slack (check-architecture Check 6, metric = `split('\n').length`):** `kernel/collection.ts` ≤ 4472, `kernel/vault.ts` ≤ 3939, `kernel/noydb.ts` ≤ 2385. All three sit EXACTLY at ceiling. Every line you add to one of these files must be offset by removing a line in the SAME file (genuine compression — collapse a wrappable statement, tighten a multi-line comment — never delete tests, blank-line-squash inside unrelated code, or harm clarity). If you cannot find an offset, report BLOCKED — do not raise the ceiling.
+- **Check 14 (via-layering), EMPTY allowlist:** no file under `src/kernel/**` may statically import from `src/via/**`. Kernel-side needs go through `kernel/via/index.ts` hook contracts or the existing strategy/port channels. **Check 15 (via-enclave-isolation), EMPTY allowlist:** no file under `src/via/**` may import `kernel/enclave/*`.
+- **TDD:** failing test first, then the fix, per task. Tests live in `packages/hub/__tests__/`.
+- **Behavior locks:** the #665 corruption fence — a composed `via(computed(fn,{mode:'virtual'}), money(...))` field must NEVER present as the scaled-decode string `'0.21'` for output `21`; money's stored-field decode must keep running BEFORE the computed segment. The full existing suite passes unchanged except where a task EXPLICITLY lists a pinned test it deliberately updates.
+- **Never** add Claude attribution to commits. **Never** reference the private pilot client by name. Changesets are authored LOCALLY (`.changeset/*.md`, gitignored by repo convention) — never committed.
+- Run from repo root: `pnpm --filter @noy-db/hub test` (full hub suite), or single file `pnpm vitest run packages/hub/__tests__/<file>`. Before the branch finishes: `pnpm check:architecture`, `pnpm --filter @noy-db/hub typecheck`, lint.
+- Commit after each green task: `git add <files> && git commit -m "<type>(hub): <subject> (#<issue>)"`.
+
+---
+
+### Task 1: #670 — `LookupHandle.rename()` write-through cache ordering
+
+**Seam map:** §A of `.superpowers/sdd/m32-seam-map.md`.
+
+**Files:**
+- Modify: `packages/hub/src/via/lookup/handle.ts` (rename(), lines ~412-499)
+- Test: `packages/hub/__tests__/via/lookup-closed-rename.test.ts` (new)
+- Touch-up: `packages/hub/__tests__/via/reconcile-lookup.test.ts` (workaround comment, lines 108-113)
+
+**Interfaces:** none new — pure internal reorder inside `rename()`.
+
+- [ ] **Step 1: Write the failing test** — new file `__tests__/via/lookup-closed-rename.test.ts`. Recipe: vault with a dict-backed dimension; a collection declaring a `vocabulary:'closed'` reserved-tier lookup field on that dimension (see `reconcile-lookup.test.ts` for the wiring idiom, but with `vocabulary:'closed'` — the exact shape that file's comment says it avoids); seed the dictionary with key `'paid'`; put a record referencing `'paid'`; then `await handle.rename('paid', 'settled')`. Assert: (a) rename resolves (no `UnknownLookupKeyError`); (b) the referencing record now reads `'settled'`; (c) the old key is gone from the dictionary and the new key present. Add a second `it` pinning mid-rename semantics: during step 3 both old and new key are members (assert post-conditions only — the pin is the doc comment written in Step 3).
+- [ ] **Step 2: Run it — must fail** with `UnknownLookupKeyError` thrown from the referencing-record rewrite.
+- [ ] **Step 3: Fix** — in `rename()`, move `this._syncCache.set(newKey, newEntry)` from its current position (line ~453, after the old-key delete) to immediately after the step-2 adapter write of the new key (after line ~434), BEFORE `findAndUpdateReferences`. Leave `this._syncCache.delete(oldKey)` where it is (post old-key removal) — mid-rename BOTH keys are members, which is the correct transition semantics. Add a short comment stating exactly that: new key becomes a member before referencing records are rewritten (else closed-vocabulary `enforceWrite` self-refuses, #670); old key stays a member until its removal completes.
+- [ ] **Step 4: Update the workaround comment** in `reconcile-lookup.test.ts:108-113` — it documents the pre-fix ordering; reword to say the ordering was fixed in #670 and open vocabulary is kept there only to isolate the late-attach registry concern.
+- [ ] **Step 5: Run** the new test + `pnpm vitest run packages/hub/__tests__/dictionary.test.ts packages/hub/__tests__/dict-emitter.test.ts packages/hub/__tests__/via/lookup-reserved-sync.test.ts packages/hub/__tests__/via/lookup-extraction-parity.test.ts packages/hub/__tests__/via/reconcile-lookup.test.ts` — all green.
+- [ ] **Step 6: Commit** — `fix(hub): rename() publishes the new key to the sync cache before rewriting references (#670)`.
+
+---
+
+### Task 2: #672 — money-aware index-key canonicalization
+
+**Seam map:** §B. Fix shape (a): a new generic `ViaBinding` hook folded by `ViaPipeline`, mirroring `indexProbe` — never a `with-lookup → via/money` import, never a kernel → `src/via/**` import.
+
+**Files:**
+- Modify: `packages/hub/src/kernel/via/index.ts` (ViaBinding: new optional hook)
+- Modify: `packages/hub/src/kernel/via/pipeline.ts` (fold, mirroring `indexProbe` at lines 194-197)
+- Modify: `packages/hub/src/via/money/binding.ts` + `packages/hub/src/via/money/normalize.ts` (implementation via `moneyScaledValue`)
+- Modify: `packages/hub/src/with-lookup/indexing/collection-facade.ts` (IndexingContext: new optional member) and `packages/hub/src/with-lookup/indexing/eager-indexes.ts` (bucket through the canonicalizer)
+- Modify: `packages/hub/src/kernel/collection.ts` `indexingContext()` (~4454-4470) — ONE line, ceiling-offset required
+- Test: `packages/hub/__tests__/via/money-index-canonical.test.ts` (new)
+
+**Interfaces:**
+- Produces on `ViaBinding`: `canonicalizeIndexKey?: (field: string, rawValue: unknown) => string | undefined` — sync, pure; `undefined` = "not mine / can't canonicalize, bucket raw".
+- Produces on `ViaPipeline`: `canonicalizeIndexKey(field: string, rawValue: unknown): string | undefined` — first binding returning non-undefined wins (identical dispatch discipline to `indexProbe`).
+- Produces on `IndexingContext<T>`: `readonly canonicalizeIndexKey?: (field: string, value: unknown) => string | undefined`.
+
+- [ ] **Step 1: Write the failing test** — `__tests__/via/money-index-canonical.test.ts`, three blocks:
+  1. **Mixed-era fixture:** open a collection WITHOUT money, `put` a record whose `amount` is the raw string `'0100'` (legacy non-canonical scaled form). Re-open the same collection name declaring `money({currency:'EUR', scale:2, mode:'fixed'})` on `amount` + an eager index on `amount`; `put` a second record through the money write path landing at scaled `'100'` (i.e. write `1` major unit). Query `where('amount','==', 1)` (the fast path — follow the existing spy technique from the #625 tests, grep `moneyIndexProbe` under `__tests__/` for the spy that proves the index path was taken, not the scan). Assert BOTH records return.
+  2. **Rebuild-on-hydrate canonicalizes:** close/reopen the vault so eager indexes rebuild from cache; repeat the query; both records still return via the fast path.
+  3. **Scan parity property:** for a small matrix of stored shapes (`'100'`, `'0100'`, `' 100'`-class junk, `100` number, `'abc'`, `null`), assert fast-path results ≡ forced-scan results for `==` and `in` clauses (non-parseable shapes are consistently no-match in both).
+- [ ] **Step 2: Run — block 1 must fail** (fast path returns only the canonical record).
+- [ ] **Step 3: Implement the hook chain.** (a) `kernel/via/index.ts`: add `canonicalizeIndexKey?` to `ViaBinding` with a doc comment stating the contract (bucket key for eager indexes; must agree with what the binding's own scan/probe treats as equal). (b) `kernel/via/pipeline.ts`: fold it exactly like `indexProbe` (194-197): iterate `bindings`, return the first non-undefined. (c) `via/money/normalize.ts`: export `canonicalizeMoneyIndexKey(field, rawValue, moneyFields): string | undefined` — return `undefined` unless `field` is a declared FIXED-mode money field; then `moneyScaledValue(rawValue, desc)?.toString() ?? undefined` (unparseable → `undefined` → raw bucket, which matches the scan's no-match — parity holds). (d) `via/money/binding.ts`: wire `canonicalizeIndexKey: (f, v) => canonicalizeMoneyIndexKey(f, v, moneyFields)`.
+- [ ] **Step 4: Thread into indexing.** `collection-facade.ts`: add the optional member to `IndexingContext`. `collection.ts` `indexingContext()`: add `...(this.via ? { canonicalizeIndexKey: (f: string, v: unknown) => this.via!.canonicalizeIndexKey(f, v) } : {}),` as ONE line — and offset it (find one genuinely compressible line in `collection.ts`; state which in the report). `eager-indexes.ts`: `addToIndex`/`removeFromIndex` (and any other `stringifyKey(value)` bucket site used by build/upsert/delete) consult `ctx.canonicalizeIndexKey?.(idx.field, value)` first; if it returns a string, bucket under it, else `stringifyKey(value)` as today. The PROBE side (`lookupEqual`/`lookupIn` keys arriving from `moneyIndexProbe`) is already canonical — do NOT double-canonicalize there for money; but check whether generic probes for NON-money fields still match (canonicalizer returns `undefined` for them — untouched).
+- [ ] **Step 5: Run** the new test file + the existing #625 money-index tests (grep `indexProbe`/`money-index` under `__tests__/` and run those files) + `pnpm vitest run packages/hub/__tests__/via/pipeline.test.ts packages/hub/__tests__/via/pipeline-b.test.ts`. All green.
+- [ ] **Step 6: Docs touch:** `via/money/where.ts` doc comment (lines 136-171) says "filed as a follow-up, not fixed here" — update to state the canonicalization now exists (#672) and where. Same for the `candidateRecords` probe-site comment (`kernel/query/builder.ts` ~1110) and `docs/subsystems/via-money.md` Indexing section's mixed-era caveat (now closed — keep the paragraph, flip it to describe the guarantee).
+- [ ] **Step 7: Ceiling check** — `pnpm check:architecture` green.
+- [ ] **Step 8: Commit** — `fix(hub): money-aware eager-index key canonicalization closes the mixed-era fast-path gap (#672)`.
+
+---
+
+### Task 3: #669 — money dresses a virtual computed field's output as MAJOR UNITS
+
+**Seam map:** §C. **Ratified design:** the computed fn's return is MAJOR UNITS. Money quantizes it to the currency scale (descriptor rounding) and presents it exactly like a stored money field: field → decimal string (`21` → `'21.00'`), `<field>Formatted` when a real locale is set, `<field>Number`. Never the scaled-int decode (`21` must never read as `'0.21'`). Unparseable/absent output → left raw, no throw at read time.
+
+**Files:**
+- Modify: `packages/hub/src/kernel/via/index.ts` (ViaBinding: `presentLate?` hook)
+- Modify: `packages/hub/src/kernel/via/pipeline.ts` (present fold gains a presentLate slot AFTER the computed segment, BEFORE the rest segment)
+- Modify: `packages/hub/src/kernel/collection-config.ts` (`compileViaBindings`: compute `virtualFields` BEFORE building money's binding; pass the money∩virtual field-name set into the money factory)
+- Modify: `packages/hub/src/via/money/binding.ts` + `normalize.ts` (presentVirtualMoney)
+- Modify: `packages/hub/src/kernel/collection.ts` `_applyMoneyFields` (late-attach parity — the intersection with `this.computed`'s virtual entries; coordinate with Task 4 which edits the same method)
+- Test: `packages/hub/__tests__/computed/virtual.test.ts` (deliberate pinned-test updates, see Step 1) + new assertions
+
+**Interfaces:**
+- Produces on `ViaBinding`: `presentLate?: (record: Record<string, unknown>, ctx: ViaReadCtx) => Promise<Record<string, unknown>> | Record<string, unknown>` — runs after ALL `present()` hooks of the money+computed segments, before the rest segment (so taint/redaction still sees dressed values).
+- Money factory signature grows an options bag: `viaBinder('money')(moneyFields)` → the compiled config carries `virtualMoneyFields?: ReadonlySet<string>` (exact plumbing shape: match how the money factory config is built today — keep the sugar/`via()` equivalence intact).
+
+- [ ] **Step 1: Update the pinned tests FIRST (they are the spec).** In `__tests__/computed/virtual.test.ts`:
+  - The KNOWN LIMITATION test (lines ~136-173) becomes the feature test: `read?.doubledPrice` is `'21.00'` (decimal string, major-units quantized), `doubledPriceFormatted` defined when a locale is set, `FieldNotQueryableError` pin UNCHANGED (virtual fields stay unqueryable).
+  - The #665 regression pin (lines ~175-202): KEEP `expect(read?.doubledPrice).not.toBe('0.21')` — the corruption fence — and update the companions to `toBe('21.00')` / `typeof === 'string'`, with a comment that the fence is the `not.toBe('0.21')` line and the field is now major-units-dressed (#669).
+  - The materialized control (lines ~204-234) stays byte-identical.
+  - Add: fractional output `21.005` with declared rounding → `'21.01'`-class quantization; fractional output with NO rounding declared and excess precision → value left RAW (no throw, no dressing) — pin both.
+- [ ] **Step 2: Run — the updated assertions must fail** (dressing doesn't exist yet).
+- [ ] **Step 3: Pipeline slot.** In `pipeline.ts`: keep the three-way `_presentOrder` partition exactly as is (money's stored decode MUST stay ahead of computed — the #665 invariant); split the fold so `present()` runs money+computed segments, then every binding's `presentLate`, then the rest segment. Update the `_presentOrder` doc comment (lines 30-79) — its "value-shape decision left unresolved" paragraph (74-78) now resolves to #669 major-units via `presentLate`.
+- [ ] **Step 4: Config + binding.** `collection-config.ts`: hoist the `virtualFields` computation (lines ~669-677) ABOVE the money push (line ~613); build `virtualMoney = new Set(Object.keys(moneyFields ?? {}).filter(f => virtualFields.has(f)))`; pass it into the money binding config. `via/money/binding.ts`: when `virtualMoney` is non-empty, expose `presentLate` calling a new `presentVirtualMoneyFields(record, moneyFields, virtualMoney, locale)` in `normalize.ts`: for each intersection field with a present, non-null value — `parseToScaledInt(value, desc.scale, desc.rounding)`; on `!ok` leave raw; on ok emit exactly what `decodeValue` emits for a stored field (decimal string via `formatScaledInt`, `Formatted` via `formatCurrency` when locale is real, `Number`). Money's ordinary `present()` must SKIP the intersection fields entirely (they're absent pre-computed anyway — keep the skip explicit with a comment).
+- [ ] **Step 5: Late-attach parity.** `_applyMoneyFields` (collection.ts:1282-1286) must produce the same intersection when money late-attaches onto a collection that already has virtual computed fields: compute the set from `this.computed` (virtual-mode entries) via a helper that lives OUTSIDE collection.ts (e.g. exported from `kernel/collection-config.ts`), one call line; offset any net line growth in collection.ts. Add a parity test: fresh-composed vs money-late-attached collections dress a virtual field identically (follow the `#664 late-attach parity` test idiom — grep `late-attach parity` under `__tests__/`).
+- [ ] **Step 6: Run** `pnpm vitest run packages/hub/__tests__/computed/virtual.test.ts packages/hub/__tests__/via/pipeline.test.ts packages/hub/__tests__/via/pipeline-b.test.ts packages/hub/__tests__/via/compose.test.ts packages/hub/__tests__/via/compose-cross-feature.test.ts` then the full money + formula suites (`pnpm vitest run packages/hub/__tests__/via -t money` at minimum; if any pipeline-partition pin elsewhere fails, update it DELIBERATELY and list it in the report). All green.
+- [ ] **Step 7: Commit** — `feat(hub): money dresses a virtual computed field's output as major units (#669)`.
+
+---
+
+### Task 4: #671 items 4+5 — money-only late-attach keeps the taint overlay; ref-edge cycle filter
+
+**Seam map:** §D.4 and §D.5. NOTE: Task 3 already edited `_applyMoneyFields` — read it fresh.
+
+**Files:**
+- Modify: `packages/hub/src/kernel/collection.ts` `_applyMoneyFields` (~1282) + `_applyClassifiedFields` (~1362): thread `this.via?.taint` through both `ViaPipeline.build(...)` calls (same-line edits, no net line change)
+- Modify: `packages/hub/src/kernel/via/reconcile.ts` doc comment (~243-248) — the asymmetry it documents is now gone; rewrite to state all rebuild paths thread taint
+- Modify: `packages/hub/src/kernel/via/graph.ts` `assertAcyclic`/`neighboursOf` (~209-257): filter `kind === 'ref'` edges
+- Test: `packages/hub/__tests__/via/taint.test.ts` (or a new `reconcile-taint.test.ts`) + `packages/hub/__tests__/via/graph.test.ts`
+
+**Interfaces:** none new.
+
+- [ ] **Step 1: Failing test A (taint drop)** — the confirmed probe recipe: fresh collection with classified+computed (taint overlay materializes) → SECOND `vault.collection()` call for the same name adding ONLY `moneyFields` → assert `coll._via.taint` is still defined and `postureFor`/`redactForExport` still reflect the derived-taint postures. Run: fails (`taint === undefined`).
+- [ ] **Step 2: Fix** — `_applyMoneyFields`: `ViaPipeline.build([...], this.via?.taint)`; same for `_applyClassifiedFields` (latent, masked by the reconcile-gate re-run — fix for code-level consistency). Rewrite the `reconcile.ts:243-248` comment. Add a regression assertion that the classified-only late-attach path (already green via the compensating `applyTaintOverlay` re-run at `reconcile.ts:437-440`) STAYS green.
+- [ ] **Step 3: Failing test B (ref filter)** — in `graph.test.ts`: register two collections' mutual `kind:'ref'` edges via `registerDerived(..., 'ref', ...)` (mirror what `registerLookupRefEdges` does), then call `assertAcyclic()` → must NOT throw. Today it throws `DerivationCycleError` — that's the failing state. Also assert a genuine derived (non-ref) cycle STILL throws, and a mixed cycle (derived edges + one ref edge breaking the loop) does not false-positive.
+- [ ] **Step 4: Fix** — in `neighboursOf`, filter candidates whose consuming edge kind is `'ref'`: apply `(list ?? []).filter(t => this._in.get(nodeId(t))?.kind !== 'ref')` to both the `own` and `wildcard` slices (see the seam map's excerpt — `_out` stores bare FieldRefs; kind lives on `_in`). Comment: mutual FKs are legal; ref edges exist for cascade/rename machinery, not derivation ordering (#671 item 5).
+- [ ] **Step 5: Run** both test files + `pnpm vitest run packages/hub/__tests__/via/graph-edges.test.ts packages/hub/__tests__/via/reconcile-guard.test.ts` — green. Ceilings: net-zero on collection.ts (same-line edits) — verify with `pnpm check:architecture`.
+- [ ] **Step 6: Commit** — `fix(hub): late-attach money/classified rebuilds thread the taint overlay; assertAcyclic ignores ref edges (#671)`.
+
+---
+
+### Task 5: #671 items 1-3 — late-attach refreshes the collection's read-side state
+
+**Seam map:** §D.1-D.3. This is the ceiling-constrained task: all three residuals are construction-frozen `Collection` state that reconcile must now be able to refresh. Consolidate into ONE writer seam, not three.
+
+**Files:**
+- Modify: `packages/hub/src/kernel/collection.ts` — drop `readonly` from `getDictionary`/`presentForJoin` (and from `i18nFields`/`dictKeyFields`/`lookupFields` if marked); ONE new writer method `_reconcileReadState(patch)` next to `_setVia` (~4425); every net line added must be offset in-file
+- Modify: `packages/hub/src/kernel/via/reconcile.ts` — the i18n/dictKey/lookup late-attach paths call the writer with merged descriptor maps + a rebuilt `presentForJoin` + `getDictionary`
+- Check: how `buildPresentForJoin` reaches kernel code today — `collection-config.ts:1044` receives it via the SAME channel that hands `opts.snapshotFor` in (strategy/port injection). Reconcile must obtain it through that SAME channel (it already builds the five lookup closures incl. `snapshotFor` — trace where those come from and ride along). NO new kernel → `src/via/**` import (Check 14).
+- Test: `packages/hub/__tests__/via/reconcile-read-state.test.ts` (new)
+- Guard: if a surface golden (kernel-api prototype golden / `vault-private-surface.test-d.ts`) pins `Collection`'s public prototype, the new `_reconcileReadState` writer must be added there DELIBERATELY (like `_setVia` was) — list it in the report.
+
+**Interfaces:**
+- Produces on `Collection`: `_reconcileReadState(patch: { dictKeyFields?; i18nFields?; lookupFields?; getDictionary?; presentForJoin? }): void` — merge semantics for the three descriptor maps (construction-time entries win on collision — reconcile already refuses colliding fields upstream), assignment for the two closures. Underscore-prefixed writer seam, same discipline as `_setVia` (`collection.ts:4425`).
+
+- [ ] **Step 1: Write the failing tests** — `reconcile-read-state.test.ts`, one `it` per residual, each using the late-attach recipe (open collection bare → second `vault.collection()` call attaches the family):
+  1. **getDictionary:** late-attach a dict-backed `dictKey` field → `describeAsync({resolveDictLabels:true})` resolves the field's labels (today: silently absent).
+  2. **describe() legacy lists:** late-attach a lookup field → `describe()`'s top-level field list/widget derivation includes it (compare against the same declaration made fresh — the outputs must be deep-equal; today the late one is missing from the legacy lists while its `.lookup` fragment is present).
+  3. **presentForJoin:** collection A (join target) opened bare, late-attach an i18n or `present`-dressed lookup field, then a join query from collection B dresses `<field>Label`/i18n text through the join path exactly as a fresh declaration would (today: `presentForJoin` is `undefined` forever).
+- [ ] **Step 2: Run — all three fail.**
+- [ ] **Step 3: Implement.** collection.ts: remove `readonly` modifiers; add `_reconcileReadState` (target ≤ 12 lines including doc comment; offset every net-added line in-file — report the exact offsets). reconcile.ts: at the end of each family's late-attach block, assemble the patch — merged maps (`{...late, ...(coll's existing ?? {})}` per the collision rule), `getDictionary` (the same closure shape vault passes at construction — reconcile has the vault context that builds the five lookup closures; reuse it), and `presentForJoin` rebuilt over the UNION of construction-time + late-attached i18n/lookup fields with the same `snapshotFor` closure it already constructs. Call `coll._reconcileReadState(patch)` once per reconcile pass (not once per family) if that keeps reconcile.ts simpler.
+- [ ] **Step 4: Run** the new file + `pnpm vitest run packages/hub/__tests__/via/reconcile-lookup.test.ts packages/hub/__tests__/via/reconcile-i18n-dictkey.test.ts packages/hub/__tests__/via/reconcile-guard.test.ts packages/hub/__tests__/via/binding-order-reconcile.test.ts` + the describe/introspection suites (`pnpm vitest run packages/hub/__tests__ -t describe` as a sweep). All green. `pnpm check:architecture` green (ceilings + Check 14).
+- [ ] **Step 5: Commit** — `fix(hub): late-attach reconcile refreshes describe lists, dict label resolution, and join dressing (#671)`.
+
+**Housekeeping rider disposition (record in report, no code):** the four "must move together (#664)" comment pairs stay as-is — a shared builder would churn zero-slack `vault.ts` for a convention-hardening gain; deferred deliberately, noted in the PR body.
+
+---
+
+### Task 6: Docs, changeset, full gauntlet
+
+**Files:**
+- Modify: `docs/subsystems/via-money.md` (Indexing section — mixed-era caveat closed by #672; major-units virtual dressing #669), `docs/subsystems/via-computed.md` (Composition + Present-order sections — #669 resolved), `docs/subsystems/via-lookup.md` (Late-attach section — residual list updated for #671 items fixed; rename ordering note for #670; ref-edge filter note)
+- Create (LOCAL ONLY, not committed): `.changeset/m32-via-followups.md` — `@noy-db/hub: minor` (adds the major-units dressing behavior + index canonicalization; #670/#671 ride along), body naming all four issues
+- Check: `features.yaml` — if via-money/via-computed composition or lookup rename semantics have catalog entries whose prose now lies, update and run `pnpm validate:features`
+
+- [ ] **Step 1:** Sweep the four subsystem docs — every KNOWN LIMITATION paragraph the four fixes invalidate gets flipped to describe the new guarantee (grep the docs for `#669`, `#670`, `#671`, `#672`, `KNOWN LIMITATION`, `mixed-era`).
+- [ ] **Step 2:** Author the changeset locally. Do NOT `git add` it.
+- [ ] **Step 3:** Full gauntlet from repo root: `pnpm --filter @noy-db/hub test`, `pnpm --filter @noy-db/hub typecheck`, hub lint script, `pnpm check:architecture`, `pnpm validate:features` (if features.yaml touched), `pnpm --filter @noy-db/hub build` + bundle-check. All green; report ceiling values.
+- [ ] **Step 4:** Commit docs — `docs(hub): via docs sync for #669/#670/#671/#672`.
+
+---
+
+## Self-review notes
+
+- Spec coverage: #670→T1; #672→T2; #669→T3 (+T5-adjacent parity in T3 Step 5); #671 items 4,5→T4, items 1,2,3→T5, rider→T5 disposition note; docs/changeset→T6. All four issues' pins from the issue bodies appear as test steps.
+- The #665 corruption fence survives in T3 Step 1 (the `not.toBe('0.21')` assertion is never removed).
+- T3 and T4 both edit `_applyMoneyFields` — sequenced (T4 brief says "read it fresh").
+- Ceiling exposure: T2 (+1 line collection.ts), T3 Step 5 (call line), T5 (writer method) — each step carries the offset mandate; T4 is net-zero.

--- a/packages/hub/__tests__/computed/virtual.test.ts
+++ b/packages/hub/__tests__/computed/virtual.test.ts
@@ -133,26 +133,26 @@ describe('computed(virtual) — read-time, never-stored mode (#638 Task 7)', () 
     ).not.toThrow()
   })
 
-  it('composed grammar: via(computed(...), money(...)) on one field is accepted and computes, but money never dresses the virtual output — KNOWN LIMITATION (value-shape, not ordering)', async () => {
+  it('composed grammar: via(computed(...), money(...)) on one field is accepted and computes — money dresses the virtual output as MAJOR UNITS (#669)', async () => {
     // Decision 5's locked grammar (`via(computed(fn, { deps, mode }), money('EUR'))`) —
-    // this pins that the composition is LEGAL and produces the computed function's raw
-    // result, undressed. `_presentOrder` (`kernel/via/pipeline.ts`) is a THREE-WAY
+    // this pins that the composition is LEGAL and that money now DRESSES the computed
+    // function's raw result. `_presentOrder` (`kernel/via/pipeline.ts`) is a THREE-WAY
     // partition (money-brand bindings, then computed-brand bindings, then everything
-    // else) that deliberately keeps money FIRST, at its pre-#665 present position — an
-    // early #665 draft ran money AFTER computed (a two-way computed-first partition) and
-    // that regressed this composition from a benign missing-dressing gap into VALUE
-    // CORRUPTION: money's `present()` (`decodeMoneyFields`, `via-money/binding.ts`)
-    // unconditionally treats its input as a STORED SCALED-INT and derives both the
-    // decoded amount and `<field>Formatted` from it, so a virtual computed field's raw
-    // MAJOR-unit output (`21`) was misread as 21 SCALED units and decoded to `'0.21'`
-    // EUR — wrong VALUE, not just missing dressing. With money restored to first, money's
-    // present() runs BEFORE the virtual value exists (nothing stored to decode yet) and
-    // computed's present() unconditionally sets the field afterward, so the raw computed
-    // number survives untouched and no `<field>Formatted` key is ever added — exactly
-    // the pre-#665 shape. This is a value-shape limitation, not an ordering one: money
-    // would need a quantize-the-computed-output decision (is `21` already scaled, or
-    // does money need to scale it?) before it could safely dress a virtual field's own
-    // output, and that decision is left for a filed follow-up, not resolved by ordering.
+    // else) that deliberately keeps money's ORDINARY `present()` FIRST, at its pre-#665
+    // present position — money's `decodeMoneyFields` unconditionally treats its input as
+    // a STORED SCALED-INT, so running it AFTER computed on a field composing
+    // `computed(virtual)` + `money(...)` on ITSELF would misread the raw MAJOR-unit
+    // output (`21`) as 21 SCALED units and decode it to `'0.21'` EUR — wrong VALUE, the
+    // #665 corruption the regression pin directly below still fences against. #669
+    // resolves the composed-field value-shape question a different way: money's
+    // ORDINARY present() explicitly SKIPS a field that is BOTH money AND virtual-mode
+    // computed (there is nothing stored to decode yet at that point in the fold anyway),
+    // and a NEW `presentLate` hook (`kernel/via/index.ts`) — which runs AFTER
+    // money+computed's present() but BEFORE the "everything else" dressing segment —
+    // quantizes the virtual field's fresh MAJOR-UNITS output to the descriptor's
+    // scale/rounding and presents it EXACTLY like a stored money field: the decimal
+    // string, plus `<field>Formatted`/`<field>Number` when a real (non-'raw') locale is
+    // in effect.
     interface Priced extends Record<string, unknown> { id: string; base: number; doubledPrice?: string | number; doubledPriceFormatted?: string }
     const store = inlineMemory()
     const db = await createNoydb({ store, user: 'alice', secret: 'via-computed-virtual-stack-2026' })
@@ -167,8 +167,8 @@ describe('computed(virtual) — read-time, never-stored mode (#638 Task 7)', () 
     })
     await c.put('a', { id: 'a', base: 10.5 })
     const read = await c.get('a')
-    expect(read?.doubledPrice).toBe(21)
-    expect(read?.doubledPriceFormatted).toBeUndefined() // no dressing — money's present() ran before the virtual value existed
+    expect(read?.doubledPrice).toBe('21.00')
+    expect(read?.doubledPriceFormatted).toBeDefined() // dressed — a real (non-'raw') locale is in effect by default
     expect(() => c.query().where('doubledPrice', '==', 21)).toThrow(FieldNotQueryableError)
   })
 
@@ -176,12 +176,15 @@ describe('computed(virtual) — read-time, never-stored mode (#638 Task 7)', () 
     // This is the corruption case an EARLIER, REJECTED #665 draft actually produced (a
     // two-way `[computed..., rest...]` partition ran money's decode AFTER the virtual
     // value existed, so money misread the raw major-unit `21` as a scaled-int and
-    // decoded it to `'0.21'` EUR). The test above pins the (benign) KNOWN LIMITATION
-    // shape; this test pins the ABSENCE of the corrupted shape specifically, so a future
-    // change that reintroduces a generic computed-first partition (dropping money's
-    // carve-out) fails loudly here, not just via the KNOWN LIMITATION test's exact-value
-    // assertion. Asserts both value AND type — a scaled-down numeric `0.21` would be just
-    // as wrong as the string `'0.21'`.
+    // decoded it to `'0.21'` EUR). THE FENCE is the `not.toBe('0.21')` assertion directly
+    // below — it must never be removed, whatever else this test's assertions become: a
+    // future change that reintroduces a generic computed-first partition (dropping
+    // money's money+computed carve-out) must fail loudly here. Its two companions were
+    // rewritten under #669: money now DELIBERATELY dresses a virtual field composed on
+    // itself via the quantize-and-present `presentLate` hook (a value-shape decision, not
+    // the corrupted stored-scaled-int decode this test fences against) — so
+    // `doubledPrice` is the quantized decimal STRING `'21.00'`, not the raw NUMBER `21`
+    // #665 originally left it as.
     interface Priced extends Record<string, unknown> { id: string; base: number; doubledPrice?: string | number }
     const store = inlineMemory()
     const db = await createNoydb({ store, user: 'alice', secret: 'via-computed-virtual-stack-regression-2026' })
@@ -196,9 +199,9 @@ describe('computed(virtual) — read-time, never-stored mode (#638 Task 7)', () 
     })
     await c.put('a', { id: 'a', base: 10.5 })
     const read = await c.get('a')
-    expect(read?.doubledPrice).not.toBe('0.21')
-    expect(read?.doubledPrice).toBe(21)
-    expect(typeof read?.doubledPrice).toBe('number')
+    expect(read?.doubledPrice).not.toBe('0.21') // THE FENCE — never remove
+    expect(read?.doubledPrice).toBe('21.00')
+    expect(typeof read?.doubledPrice).toBe('string')
   })
 
   it('composed grammar (MATERIALIZED default): via(computed(fn, { mode: "materialized" }), money(...)) on one field — money DOES format the computed output (pins the OPPOSITE of the virtual-mode case above)', async () => {
@@ -233,6 +236,89 @@ describe('computed(virtual) — read-time, never-stored mode (#638 Task 7)', () 
     expect((raw as Priced)?.total).toBeDefined()
   })
 
+  it('#669: virtual computed output with excess precision quantizes per the money descriptor\'s DECLARED rounding (21.005 EUR, half-up, scale 2 -> \'21.01\')', async () => {
+    interface Priced extends Record<string, unknown> { id: string; amount?: string | number }
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: 'via-computed-virtual-money-rounding-2026' })
+    const v = await db.openVault('v1')
+    const c = v.collection<Priced>('priced', {
+      viaFields: {
+        amount: via(
+          computed(() => 21.005, { mode: 'virtual' }),
+          money({ currency: 'EUR', scale: 2, rounding: 'half-up' }),
+        ),
+      },
+    })
+    await c.put('a', { id: 'a' })
+    const read = await c.get('a')
+    expect(read?.amount).toBe('21.01')
+  })
+
+  it('#669: virtual computed output with excess precision and NO declared rounding is left RAW — no throw, no dressing', async () => {
+    interface Priced extends Record<string, unknown> { id: string; amount?: string | number; amountFormatted?: string }
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: 'via-computed-virtual-money-norounding-2026' })
+    const v = await db.openVault('v1')
+    const c = v.collection<Priced>('priced', {
+      viaFields: {
+        amount: via(
+          computed(() => 21.005, { mode: 'virtual' }),
+          money({ currency: 'EUR', scale: 2 }),
+        ),
+      },
+    })
+    await c.put('a', { id: 'a' })
+    const read = await c.get('a')
+    expect(read?.amount).toBe(21.005) // raw, untouched — parseToScaledInt refused (excess precision, no rounding declared)
+    expect(read?.amountFormatted).toBeUndefined() // no dressing on a failed quantize
+  })
+
+  it('#669 late-attach parity: money reconciling onto a collection that already has a virtual computed field dresses it identically to a fresh single-call composition', async () => {
+    // `guardReconcileCollisions` (kernel/via/compose.ts) exempts EXACTLY this pairing —
+    // an existing 'computed' binding + an incoming 'money' family declaration on the same
+    // field is legal late-attach, mirroring the fresh-construction exemption 1:1 (a
+    // composition legal in one `vault.collection()` call must stay legal split across
+    // two). `_applyMoneyFields` (kernel/collection.ts) must derive the SAME money∩virtual
+    // intersection `compileViaBindings` computes for the fresh path, from the
+    // ALREADY-COMPILED `computed` binding it finds in `this.via.bindings` (there is no
+    // materialized `this.computed` entry to read here — virtual mode never populates it).
+    interface Priced extends Record<string, unknown> { id: string; base: number; doubledPrice?: string | number; doubledPriceFormatted?: string }
+    const store = inlineMemory()
+    const db = await createNoydb({ store, user: 'alice', secret: 'via-computed-virtual-money-late-attach-2026' })
+    const freshVault = await db.openVault('fresh')
+    const lateVault = await db.openVault('late')
+
+    const fresh = freshVault.collection<Priced>('priced', {
+      viaFields: {
+        doubledPrice: via(
+          computed((r) => (r.base as number) * 2, { deps: ['base'], mode: 'virtual' }),
+          money({ currency: 'EUR', scale: 2 }),
+        ),
+      },
+    })
+
+    // First call: virtual computed only — no money yet.
+    const lateFirst = lateVault.collection<Priced>('priced', {
+      viaFields: {
+        doubledPrice: via(computed((r) => (r.base as number) * 2, { deps: ['base'], mode: 'virtual' })),
+      },
+    })
+    // Second call: money reconciles onto the ALREADY-open collection (`_applyMoneyFields`).
+    const lateSecond = lateVault.collection<Priced>('priced', {
+      moneyFields: { doubledPrice: money({ currency: 'EUR', scale: 2 }) },
+    })
+    expect(lateSecond).toBe(lateFirst) // reconciled onto the SAME instance, not a fresh one
+
+    await fresh.put('a', { id: 'a', base: 10.5 })
+    await lateSecond.put('a', { id: 'a', base: 10.5 })
+
+    const freshRead = await fresh.get('a')
+    const lateRead = await lateSecond.get('a')
+    expect(lateRead).toEqual(freshRead)
+    expect(lateRead?.doubledPrice).toBe('21.00')
+    expect(lateRead?.doubledPriceFormatted).toBeDefined()
+  })
+
   // #631 review round 2 — the collision guard's `computed` exemption (kernel/
   // collection-config.ts#guardCrossBindingFieldCollisions) covers `money`/`i18n`/`lookup`
   // uniformly, on the theory that `mergeViaFields` folds `via()`-composition and two
@@ -246,8 +332,9 @@ describe('computed(virtual) — read-time, never-stored mode (#638 Task 7)', () 
   // virtual field's value exists BEFORE i18n/lookup's dressing `present()` hooks run on
   // it (previously `compileViaBindings`'s money→i18n→lookup→classified→blob→computed
   // ordering ran computed LAST, so a virtual field's label could never be dressed off a
-  // value that didn't exist yet). Money is the one family #665 deliberately does NOT fix
-  // for the composed-on-itself case — see the KNOWN LIMITATION test above and its comment.
+  // value that didn't exist yet). Money was the one family #665 deliberately did NOT fix
+  // for the composed-on-itself case — #669 (above) closed that gap with a separate
+  // `presentLate` hook, not a change to this ordering.
   describe('composed grammar — computed + i18n/lookup families (#631 collision-guard exemption pins)', () => {
     interface Order extends Record<string, unknown> { id: string; base: number; status?: string; statusLabel?: string }
 

--- a/packages/hub/__tests__/computed/virtual.test.ts
+++ b/packages/hub/__tests__/computed/virtual.test.ts
@@ -578,6 +578,70 @@ describe('computed(virtual) — read-time, never-stored mode (#638 Task 7)', () 
     expect(() => c.query().where('ssnLeak', '==', '123-45-6789')).toThrow(FieldNotQueryableError)
   })
 
+  it('#669 review: a tainted virtual field composed with money is redacted on the base field AND its Formatted/Number companions — the companions must not leak the value the base field just sealed', async () => {
+    interface Person extends Record<string, unknown> { id: string; ssn: string; leak?: string | number; leakFormatted?: string; leakNumber?: number }
+    const ssnSpec = (): ClassifiedFieldSpec => ({
+      _noydbClassified: true, preset: 'test-ssn', storage: 'recoverable',
+      list: { kind: 'omit' }, sensitivity: 'secret',
+    })
+    const store = inlineMemory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: 'via-computed-virtual-money-taint-2026', classifiedStrategy: withClassified(),
+    })
+    const v = await db.openVault('v1')
+    const c = v.collection<Person>('people', {
+      classifiedFields: { ssn: ssnSpec() },
+      viaFields: {
+        leak: via(
+          computed(() => 21, { deps: ['ssn'], mode: 'virtual' }),
+          money({ currency: 'EUR', scale: 2 }),
+        ),
+      },
+    })
+    await c.put('r1', { id: 'r1', ssn: '123-45-6789' })
+
+    const rec = await c.get('r1')
+    expect(rec?.leak).toBe('[sealed]')
+    // the leak: money's presentLate dresses the virtual field's fresh (untainted-looking)
+    // '21' output into `leakFormatted`/`leakNumber` BEFORE taint's present-redaction
+    // overwrites the base field — those companions must be stripped too, not just the base.
+    expect(rec?.leakFormatted).toBeUndefined()
+    expect(rec?.leakNumber).toBeUndefined()
+    expect('leakFormatted' in (rec as Record<string, unknown>)).toBe(false)
+    expect('leakNumber' in (rec as Record<string, unknown>)).toBe(false)
+  })
+
+  it('reachability nuance: a virtual money field whose fn reads the sealed source directly (rather than merely declaring it via `deps`) never produces Formatted/Number siblings in the first place — a SealedHandle coerces to NaN, which money treats as unparseable, independent of taint redaction', async () => {
+    interface Person extends Record<string, unknown> { id: string; ssn: string; leak?: string | number; leakFormatted?: string; leakNumber?: number }
+    const ssnSpec = (): ClassifiedFieldSpec => ({
+      _noydbClassified: true, preset: 'test-ssn', storage: 'recoverable',
+      list: { kind: 'omit' }, sensitivity: 'secret',
+    })
+    const store = inlineMemory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: 'via-computed-virtual-money-taint-reachability-2026', classifiedStrategy: withClassified(),
+    })
+    const v = await db.openVault('v1')
+    const c = v.collection<Person>('people', {
+      classifiedFields: { ssn: ssnSpec() },
+      viaFields: {
+        leak: via(
+          computed((r) => Number(r.ssn), { deps: ['ssn'], mode: 'virtual' }),
+          money({ currency: 'EUR', scale: 2 }),
+        ),
+      },
+    })
+    await c.put('r1', { id: 'r1', ssn: '123-45-6789' })
+
+    const rec = await c.get('r1')
+    // still redacted (declared deps taint it regardless of what the fn actually reaches) —
+    // but the NaN the SealedHandle coerces to was already unparseable, so no companions
+    // were ever produced for taint's present-redaction to have to strip.
+    expect(rec?.leak).toBe('[sealed]')
+    expect(rec?.leakFormatted).toBeUndefined()
+    expect(rec?.leakNumber).toBeUndefined()
+  })
+
   it('mode: "virtual" has no late-attach reconcile door — declaring it on a reconcile call throws', async () => {
     const store = inlineMemory()
     const db = await createNoydb({ store, user: 'alice', secret: 'via-computed-virtual-reconcile-2026' })

--- a/packages/hub/__tests__/computed/virtual.test.ts
+++ b/packages/hub/__tests__/computed/virtual.test.ts
@@ -611,6 +611,42 @@ describe('computed(virtual) — read-time, never-stored mode (#638 Task 7)', () 
     expect('leakNumber' in (rec as Record<string, unknown>)).toBe(false)
   })
 
+  it('#671 review: a tainted virtual field composed with dictKey is redacted on the base field AND its Label companion — the label must not leak the value the base field just sealed (a dict key is a closed vocabulary, so the label reveals the sealed value exactly)', async () => {
+    interface Person extends Record<string, unknown> { id: string; ssn: string; leak?: string; leakLabel?: string }
+    const ssnSpec = (): ClassifiedFieldSpec => ({
+      _noydbClassified: true, preset: 'test-ssn', storage: 'recoverable',
+      list: { kind: 'omit' }, sensitivity: 'secret',
+    })
+    const store = inlineMemory()
+    const db = await createNoydb({
+      store, user: 'alice', secret: 'via-computed-virtual-dictkey-taint-2026',
+      classifiedStrategy: withClassified(), i18nStrategy: withI18n(),
+    })
+    const v = await db.openVault('v1')
+    await v.dictionary('leak').putAll({
+      paid: { en: 'Paid', th: 'PAID-TH' },
+    })
+    const c = v.collection<Person>('people', {
+      classifiedFields: { ssn: ssnSpec() },
+      viaFields: {
+        leak: via(
+          computed(() => 'paid', { deps: ['ssn'], mode: 'virtual' }),
+          dictKey('leak', ['paid'] as const),
+        ),
+      },
+    })
+    await c.put('r1', { id: 'r1', ssn: '123-45-6789' })
+
+    const rec = await c.get('r1', { locale: 'th' })
+    expect(rec?.leak).toBe('[sealed]')
+    // the leak: dictKey's present() dresses the virtual field's fresh (untainted-looking)
+    // 'paid' output into `leakLabel` BEFORE taint's present-redaction overwrites the base
+    // field — a dict key is a closed vocabulary, so `leakLabel` reveals the sealed value
+    // exactly; the companion must be stripped too, not just the base.
+    expect(rec?.leakLabel).toBeUndefined()
+    expect('leakLabel' in (rec as Record<string, unknown>)).toBe(false)
+  })
+
   it('reachability nuance: a virtual money field whose fn reads the sealed source directly (rather than merely declaring it via `deps`) never produces Formatted/Number siblings in the first place — a SealedHandle coerces to NaN, which money treats as unparseable, independent of taint redaction', async () => {
     interface Person extends Record<string, unknown> { id: string; ssn: string; leak?: string | number; leakFormatted?: string; leakNumber?: number }
     const ssnSpec = (): ClassifiedFieldSpec => ({

--- a/packages/hub/__tests__/via/graph.test.ts
+++ b/packages/hub/__tests__/via/graph.test.ts
@@ -245,6 +245,37 @@ describe('ViaGraph — cycle rejection (assertAcyclic)', () => {
     g.registerDerived({ collection: 'C', field: 'z' }, [{ collection: 'B', field: '*' }], 'rollup', 'aggregate')
     expect(() => g.assertAcyclic()).not.toThrow()
   })
+
+  // #671 item 5 — `assertAcyclic`'s DFS walked `_out` with no filtering by edge kind, so a
+  // legal mutual FK lookup (two collections each referencing the other via a `kind:'ref'`
+  // edge) spuriously threw `DerivationCycleError`. `neighboursOf` must exclude `'ref'`-kind
+  // consuming edges — mutual FKs are legal; ref edges exist for cascade/rename machinery
+  // (`referencingEdgesOf`/delete-time restrict/cascade/nullify), not derivation ordering.
+  it('mutual kind:\'ref\' edges (legal mutual FK lookups) do NOT throw — ref edges are not derivation-ordering edges (#671 item 5)', () => {
+    const g = new ViaGraph()
+    // Mirrors registerLookupRefEdges' call shape (via/lookup/registry.ts:471-473):
+    // graph.registerDerived(referencing, sources, 'ref', 'record', onDelete, keyField).
+    g.registerDerived({ collection: 'customers', field: 'homeCountry' }, [{ collection: 'countries', field: '*' }], 'ref', 'record', 'restrict', 'id')
+    g.registerDerived({ collection: 'countries', field: 'capitalOf' }, [{ collection: 'customers', field: '*' }], 'ref', 'record', 'restrict', 'id')
+    expect(() => g.assertAcyclic()).not.toThrow()
+  })
+
+  it('a genuine derived (non-ref) cycle still throws — the ref-edge filter does not blanket-exempt every cycle', () => {
+    const g = new ViaGraph()
+    g.registerDerived({ collection: 'w', field: 'a' }, [{ collection: 'w', field: 'b' }], 'derivation', 'record')
+    g.registerDerived({ collection: 'w', field: 'b' }, [{ collection: 'w', field: 'a' }], 'derivation', 'record')
+    expect(() => g.assertAcyclic()).toThrow(DerivationCycleError)
+  })
+
+  it('a mixed shape where the only cycle-closing edge is a ref edge does not throw', () => {
+    const g = new ViaGraph()
+    // B.y is a genuine derivation sourced from A.x...
+    g.registerDerived({ collection: 'B', field: 'y' }, [{ collection: 'A', field: 'x' }], 'derivation', 'record')
+    // ...and A.x is itself a lookup-ref field pointing back at B.y — the ONLY edge that
+    // would close the loop is this ref edge, so it must not throw.
+    g.registerDerived({ collection: 'A', field: 'x' }, [{ collection: 'B', field: 'y' }], 'ref', 'record', 'restrict', 'id')
+    expect(() => g.assertAcyclic()).not.toThrow()
+  })
 })
 
 describe('ViaGraph — taintedPostures / taintSealedFields (Task 3 overlay)', () => {

--- a/packages/hub/__tests__/via/graph.test.ts
+++ b/packages/hub/__tests__/via/graph.test.ts
@@ -276,6 +276,29 @@ describe('ViaGraph — cycle rejection (assertAcyclic)', () => {
     g.registerDerived({ collection: 'A', field: 'x' }, [{ collection: 'B', field: 'y' }], 'ref', 'record', 'restrict', 'id')
     expect(() => g.assertAcyclic()).not.toThrow()
   })
+
+  // #671 item 5 review — pins the WILDCARD-SLICE half of the ref-edge filter
+  // (`neighboursOf`'s `wildcard` variable, graph.ts:242) as distinct from the own-slice
+  // filter (`own`, graph.ts:239): mutation evidence showed reverting JUST the wildcard half
+  // still passed the whole suite, because no existing fixture put a REAL (non-wildcard)
+  // field in a position to inherit a ref edge via ITS OWN collection's '*' containment slice
+  // while that ref edge's target also closes a cycle back to it via a genuine (non-ref) edge.
+  it('a real field inherits a ref edge only through its collection\'s wildcard containment slice — the ref edge must still be excluded there too, so assertAcyclic() does NOT throw (#671 item 5, wildcard-slice half of the filter)', () => {
+    const g = new ViaGraph()
+    // countries.name is itself a derivation SOURCE (customers.countryName derives from it) —
+    // a real, non-wildcard field the top-level DFS visits directly via `_out.keys()`.
+    g.registerDerived({ collection: 'customers', field: 'countryName' }, [{ collection: 'countries', field: 'name' }], 'derivation', 'record')
+    // A ref edge sourced at countries' wildcard ('*') slice — customers.homeCountry is a
+    // lookup-ref field pointing at the countries dimension (mirrors registerLookupRefEdges'
+    // call shape). countries.name's OWN out-edges never reach customers.homeCountry — it is
+    // reachable ONLY via containment inheritance from countries.* here.
+    g.registerDerived({ collection: 'customers', field: 'homeCountry' }, [{ collection: 'countries', field: '*' }], 'ref', 'record', 'restrict', 'id')
+    // customers.homeCountry is ALSO a genuine (non-ref) derivation source for countries.name —
+    // closing a cycle back to countries.name, but ONLY reachable from countries.name via the
+    // wildcard-inherited ref edge above (never through countries.name's own out-edges).
+    g.registerDerived({ collection: 'countries', field: 'name' }, [{ collection: 'customers', field: 'homeCountry' }], 'derivation', 'record')
+    expect(() => g.assertAcyclic()).not.toThrow()
+  })
 })
 
 describe('ViaGraph — taintedPostures / taintSealedFields (Task 3 overlay)', () => {

--- a/packages/hub/__tests__/via/lookup-closed-rename.test.ts
+++ b/packages/hub/__tests__/via/lookup-closed-rename.test.ts
@@ -1,0 +1,61 @@
+/**
+ * #670 — `LookupHandle.rename()` self-refusal on a FRESH-declared
+ * `vocabulary:'closed'` dict-tier lookup field.
+ *
+ * Reproduction gap: `reconcile-lookup.test.ts`'s dictKeyFieldRegistry pin
+ * (line 107) deliberately uses OPEN vocabulary to isolate the late-attach
+ * registry concern from this bug (see that test's own comment). No existing
+ * test exercised `rename()` against a CLOSED-vocabulary field, so the
+ * write-through sync-cache ordering bug (new key not visible to
+ * `checkLookupMembership` until AFTER `findAndUpdateReferences` rewrites
+ * referencing records) went unnoticed. RED (pre-fix): the referencing-record
+ * rewrite inside `rename()` throws `UnknownLookupKeyError` for the very key
+ * `rename()` just wrote.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../../src/index.js'
+import { withI18n } from '../../src/via/i18n/index.js'
+import { dict } from '../../src/via/lookup/descriptor.js'
+import { UnknownLookupKeyError } from '../../src/kernel/errors.js'
+import { inlineMemory } from '../classified/harness.js'
+
+interface Order extends Record<string, unknown> { id: string; status: string }
+
+describe('#670 — LookupHandle.rename() vs closed-vocabulary lookup fields', () => {
+  it('rename() does not self-refuse: the referencing record is rewritten to the new key without UnknownLookupKeyError, and the dictionary reflects the swap', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-670-rename-1', i18nStrategy: withI18n() })
+    const vault = await db.openVault('v1')
+    await vault.dictionary('billing-status-670').put('paid', { en: 'Paid' })
+
+    const orders = vault.collection<Order>('orders-670', {
+      lookupFields: { status: dict('billing-status-670', { vocabulary: 'closed' }) },
+    })
+    await orders.put('o1', { id: 'o1', status: 'paid' })
+
+    await expect(vault.dictionary('billing-status-670').rename('paid', 'settled')).resolves.not.toThrow()
+
+    const o1 = await orders.get('o1')
+    expect(o1?.status).toBe('settled')
+
+    const entries = await vault.dictionary('billing-status-670').list()
+    expect(entries.map((e) => e.key)).toEqual(['settled'])
+  })
+
+  it('post-rename membership reflects the completed old->new transition: new key is a member, old key is fully retired', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-670-rename-2', i18nStrategy: withI18n() })
+    const vault = await db.openVault('v2')
+    await vault.dictionary('billing-status-670b').put('paid', { en: 'Paid' })
+
+    const orders = vault.collection<Order>('orders-670b', {
+      lookupFields: { status: dict('billing-status-670b', { vocabulary: 'closed' }) },
+    })
+    await orders.put('o1', { id: 'o1', status: 'paid' })
+
+    await vault.dictionary('billing-status-670b').rename('paid', 'settled')
+
+    // The new key is a member post-rename (a fresh write against it is accepted)...
+    await expect(orders.put('o2', { id: 'o2', status: 'settled' })).resolves.not.toThrow()
+    // ...and the old key is no longer a member (rename()'s step 4 fully retired it).
+    await expect(orders.put('o3', { id: 'o3', status: 'paid' })).rejects.toThrow(UnknownLookupKeyError)
+  })
+})

--- a/packages/hub/__tests__/via/money-index-canonical.test.ts
+++ b/packages/hub/__tests__/via/money-index-canonical.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi } from 'vitest'
+import { z } from 'zod'
+import { createNoydb, money } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/kernel/types.js'
+import { withIndexing } from '../../src/with-lookup/indexing/index.js'
+import { CollectionIndexes } from '../../src/with-lookup/indexing/eager-indexes.js'
+
+// #672 — the eager-index fast path used to bucket a fixed-mode money field
+// by its RAW stored string (`stringifyKey`), so a legacy non-canonical
+// value (e.g. '0100' written before the field's `money()` declaration) was
+// invisible to a canonical probe ('100') while the BigInt-lenient scan
+// (`evaluateMoneyClause`) still matched it — the fast path silently
+// returned a subset for mixed-era data. This suite proves the fix: the
+// index now buckets money keys through `ViaPipeline.canonicalizeIndexKey`
+// (money's `moneyScaledValue`-based canonicalizer), so the fast path and
+// the scan agree.
+
+interface Item extends Record<string, unknown> {
+  id: string
+  amount: number | string
+}
+
+const itemSchema = z.object({ id: z.string(), amount: z.union([z.number(), z.string()]) })
+
+const USER = 'alice'
+const PASS = 'money-index-canonical-passphrase-2026'
+const VAULT = 'books'
+const COLL = 'items'
+
+/** Shared memory adapter — persists across `createNoydb()` calls (simulates reopen). */
+function persistentMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env) { gc(c, col).set(id, env) },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) }
+    },
+  }
+}
+
+/** Session 1: no money declared on 'items' — writes 'amount' as a raw, non-canonical string. */
+async function seedLegacyRecord(adapter: NoydbStore): Promise<void> {
+  const db = await createNoydb({ store: adapter, user: USER, secret: PASS })
+  const vault = await db.openVault(VAULT)
+  await vault.collection<Item>(COLL, { schema: itemSchema }).put('legacy', { id: 'legacy', amount: '0100' })
+  db.close()
+}
+
+/** A fresh session declaring money(fixed) + an eager index on 'amount'. */
+async function openMoneyIndexedSession(adapter: NoydbStore) {
+  const db = await createNoydb({ store: adapter, user: USER, secret: PASS, indexStrategy: withIndexing() })
+  const vault = await db.openVault(VAULT)
+  const col = vault.collection<Item>(COLL, {
+    schema: itemSchema,
+    moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+    indexes: ['amount'],
+  })
+  return { db, col }
+}
+
+describe('money index-key canonicalization (#672)', () => {
+  it('mixed-era fast path: a legacy non-canonical record and a canonical record both match == via the index', async () => {
+    const adapter = persistentMemory()
+    await seedLegacyRecord(adapter) // 'legacy' stored as raw, non-canonical '0100'
+
+    const { db, col } = await openMoneyIndexedSession(adapter)
+    // Write a second record THROUGH the money write path — lands canonical '100'.
+    await col.put('canonical', { id: 'canonical', amount: 1 })
+
+    const spy = vi.spyOn(CollectionIndexes.prototype, 'lookupEqual')
+    try {
+      const hit = col.query().where('amount', '==', 1).toArray()
+      expect(hit.map((r) => r.id).sort()).toEqual(['canonical', 'legacy'])
+      // Fast-path evidence: exactly one probe, against the canonical scaled key.
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy).toHaveBeenCalledWith('amount', '100')
+    } finally {
+      spy.mockRestore()
+    }
+    db.close()
+  })
+
+  it('rebuild-on-hydrate canonicalizes: a fresh vault reopen re-derives the same canonical buckets', async () => {
+    const adapter = persistentMemory()
+    await seedLegacyRecord(adapter)
+    {
+      const { db, col } = await openMoneyIndexedSession(adapter)
+      await col.put('canonical', { id: 'canonical', amount: 1 })
+      db.close()
+    }
+
+    // Close/reopen the vault again — eager indexes rebuild fresh from the
+    // hydrated cache on THIS session's first access, independent of the
+    // previous session's in-memory state.
+    const { db, col } = await openMoneyIndexedSession(adapter)
+    // query()/.toArray() reads the in-memory cache synchronously — force
+    // hydration (and the eager-index rebuild) via an awaited op first.
+    await col.list()
+    const spy = vi.spyOn(CollectionIndexes.prototype, 'lookupEqual')
+    try {
+      const hit = col.query().where('amount', '==', 1).toArray()
+      expect(hit.map((r) => r.id).sort()).toEqual(['canonical', 'legacy'])
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy).toHaveBeenCalledWith('amount', '100')
+    } finally {
+      spy.mockRestore()
+    }
+    db.close()
+  })
+
+  describe('scan parity across mixed-era stored shapes', () => {
+    interface ShapeRecord extends Record<string, unknown> {
+      id: string
+      amount: unknown
+    }
+    const shapeSchema = z.object({ id: z.string(), amount: z.unknown() })
+    const SHAPES_COLL = 'shapes'
+
+    // Every shape is written BEFORE money is declared (raw, unquantized) —
+    // exactly how mixed-era data accumulates in practice.
+    const shapes: Record<string, unknown> = {
+      'r-canonical': '100', // already canonical
+      'r-legacy-zero': '0100', // legacy non-canonical (the #672 repro)
+      'r-junk-space': ' 100', // whitespace — BigInt-tolerant on both paths
+      'r-number': 100, // raw JS number, not the string form
+      'r-nonnumeric': 'abc', // unparseable — must no-match on both paths
+      'r-null': null, // never indexed (nor scan-matched) on either path
+    }
+
+    async function seedShapes(adapter: NoydbStore): Promise<void> {
+      const db = await createNoydb({ store: adapter, user: USER, secret: PASS })
+      const vault = await db.openVault(VAULT)
+      const col = vault.collection<ShapeRecord>(SHAPES_COLL, { schema: shapeSchema })
+      for (const [id, amount] of Object.entries(shapes)) {
+        await col.put(id, { id, amount })
+      }
+      db.close()
+    }
+
+    async function openFastPath(adapter: NoydbStore) {
+      const db = await createNoydb({ store: adapter, user: USER, secret: PASS, indexStrategy: withIndexing() })
+      const vault = await db.openVault(VAULT)
+      const col = vault.collection<ShapeRecord>(SHAPES_COLL, {
+        schema: shapeSchema,
+        moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+        indexes: ['amount'],
+      })
+      return { db, col }
+    }
+
+    /** Same money declaration, but no `indexStrategy` — `getIndexes()` returns null, forcing the scan. */
+    async function openForcedScan(adapter: NoydbStore) {
+      const db = await createNoydb({ store: adapter, user: USER, secret: PASS })
+      const vault = await db.openVault(VAULT)
+      const col = vault.collection<ShapeRecord>(SHAPES_COLL, {
+        schema: shapeSchema,
+        moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+      })
+      return { db, col }
+    }
+
+    it('== and in agree between the fast path and a forced scan for every stored shape', async () => {
+      const adapter = persistentMemory()
+      await seedShapes(adapter)
+
+      const { db: dbFast, col: colFast } = await openFastPath(adapter)
+      const { db: dbScan, col: colScan } = await openForcedScan(adapter)
+      // query()/.toArray() reads the in-memory cache synchronously — force
+      // hydration (and the eager-index rebuild) via an awaited op first.
+      await colFast.list()
+      await colScan.list()
+
+      const eqSpy = vi.spyOn(CollectionIndexes.prototype, 'lookupEqual')
+      const inSpy = vi.spyOn(CollectionIndexes.prototype, 'lookupIn')
+      try {
+        const fastEq = colFast.query().where('amount', '==', 1).toArray().map((r) => r.id).sort()
+        const scanEq = colScan.query().where('amount', '==', 1).toArray().map((r) => r.id).sort()
+        expect(fastEq).toEqual(scanEq)
+        expect(eqSpy).toHaveBeenCalled()
+        // The #672 repro record must be present, and truly unparseable/absent
+        // shapes must be consistently excluded on both paths.
+        expect(fastEq).toContain('r-canonical')
+        expect(fastEq).toContain('r-legacy-zero')
+        expect(fastEq).not.toContain('r-nonnumeric')
+        expect(fastEq).not.toContain('r-null')
+
+        const fastIn = colFast.query().where('amount', 'in', [1, 2]).toArray().map((r) => r.id).sort()
+        const scanIn = colScan.query().where('amount', 'in', [1, 2]).toArray().map((r) => r.id).sort()
+        expect(fastIn).toEqual(scanIn)
+        expect(inSpy).toHaveBeenCalled()
+      } finally {
+        eqSpy.mockRestore()
+        inSpy.mockRestore()
+      }
+      dbFast.close()
+      dbScan.close()
+    })
+  })
+})

--- a/packages/hub/__tests__/via/money-index-canonical.test.ts
+++ b/packages/hub/__tests__/via/money-index-canonical.test.ts
@@ -71,6 +71,17 @@ async function openMoneyIndexedSession(adapter: NoydbStore) {
   return { db, col }
 }
 
+/** Same money declaration as `openMoneyIndexedSession`, but no `indexStrategy` — `getIndexes()` returns null, forcing the scan. */
+async function openMoneyForcedScanSession(adapter: NoydbStore) {
+  const db = await createNoydb({ store: adapter, user: USER, secret: PASS })
+  const vault = await db.openVault(VAULT)
+  const col = vault.collection<Item>(COLL, {
+    schema: itemSchema,
+    moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+  })
+  return { db, col }
+}
+
 describe('money index-key canonicalization (#672)', () => {
   it('mixed-era fast path: a legacy non-canonical record and a canonical record both match == via the index', async () => {
     const adapter = persistentMemory()
@@ -119,6 +130,108 @@ describe('money index-key canonicalization (#672)', () => {
       spy.mockRestore()
     }
     db.close()
+  })
+
+  // #672 review C1: canonicalizer was wired into `build()` only — `upsert`/
+  // `remove` (the incremental put/delete path) still bucketed by the raw
+  // stringified value, so a legacy record's bucket membership went
+  // asymmetric the moment it was mutated. These three tests exercise every
+  // bucket-mutation dimension: update, delete, and delete-then-recreate.
+  describe('mutation-dimension parity (#672 review C1)', () => {
+    it('(a) update: mutating a legacy record clears its old canonical bucket on both paths', async () => {
+      const adapter = persistentMemory()
+      await seedLegacyRecord(adapter) // 'legacy' stored raw '0100'
+
+      const { db, col } = await openMoneyIndexedSession(adapter)
+      // Force hydration + eager-index BUILD first, so 'legacy' lands in the
+      // canonicalized '100' bucket exactly like the C1 repro describes —
+      // then the update below must go through `upsert()` -> `remove()`.
+      await col.list()
+      await col.put('legacy', { id: 'legacy', amount: 2 }) // update through the money write path
+
+      const spy = vi.spyOn(CollectionIndexes.prototype, 'lookupEqual')
+      let fastOld: string[]
+      let fastNew: string[]
+      try {
+        fastOld = col.query().where('amount', '==', 1).toArray().map((r) => r.id).sort()
+        fastNew = col.query().where('amount', '==', 2).toArray().map((r) => r.id).sort()
+        expect(spy).toHaveBeenCalled()
+      } finally {
+        spy.mockRestore()
+      }
+      db.close()
+
+      const { db: dbScan, col: colScan } = await openMoneyForcedScanSession(adapter)
+      await colScan.list()
+      const scanOld = colScan.query().where('amount', '==', 1).toArray().map((r) => r.id).sort()
+      const scanNew = colScan.query().where('amount', '==', 2).toArray().map((r) => r.id).sort()
+      dbScan.close()
+
+      expect(fastOld).toEqual(scanOld)
+      expect(fastOld).toEqual([]) // must NOT still return the stale-bucket 'legacy' id
+      expect(fastNew).toEqual(scanNew)
+      expect(fastNew).toEqual(['legacy'])
+    })
+
+    it('(b) delete: deleting a legacy record clears it from the canonical bucket on both paths', async () => {
+      const adapter = persistentMemory()
+      await seedLegacyRecord(adapter)
+
+      const { db, col } = await openMoneyIndexedSession(adapter)
+      await col.list() // build canonicalizes 'legacy' into bucket '100'
+      await col.delete('legacy')
+
+      const spy = vi.spyOn(CollectionIndexes.prototype, 'lookupEqual')
+      let fast: string[]
+      try {
+        fast = col.query().where('amount', '==', 1).toArray().map((r) => r.id)
+        expect(spy).toHaveBeenCalled()
+      } finally {
+        spy.mockRestore()
+      }
+      db.close()
+
+      const { db: dbScan, col: colScan } = await openMoneyForcedScanSession(adapter)
+      await colScan.list()
+      const scan = colScan.query().where('amount', '==', 1).toArray().map((r) => r.id)
+      dbScan.close()
+
+      expect(fast).toEqual([])
+      expect(scan).toEqual([])
+    })
+
+    it('(c) delete-then-recreate: reusing the same id with a different amount is not stranded in the old bucket', async () => {
+      const adapter = persistentMemory()
+      await seedLegacyRecord(adapter)
+
+      const { db, col } = await openMoneyIndexedSession(adapter)
+      await col.list() // build canonicalizes 'legacy' into bucket '100'
+      await col.delete('legacy')
+      await col.put('legacy', { id: 'legacy', amount: 3 }) // recreate same id, different amount
+
+      const spy = vi.spyOn(CollectionIndexes.prototype, 'lookupEqual')
+      let fastOld: string[]
+      let fastNew: string[]
+      try {
+        fastOld = col.query().where('amount', '==', 1).toArray().map((r) => r.id)
+        fastNew = col.query().where('amount', '==', 3).toArray().map((r) => r.id)
+        expect(spy).toHaveBeenCalled()
+      } finally {
+        spy.mockRestore()
+      }
+      db.close()
+
+      const { db: dbScan, col: colScan } = await openMoneyForcedScanSession(adapter)
+      await colScan.list()
+      const scanOld = colScan.query().where('amount', '==', 1).toArray().map((r) => r.id)
+      const scanNew = colScan.query().where('amount', '==', 3).toArray().map((r) => r.id)
+      dbScan.close()
+
+      expect(fastOld).toEqual(scanOld)
+      expect(fastOld).toEqual([])
+      expect(fastNew).toEqual(scanNew)
+      expect(fastNew).toEqual(['legacy'])
+    })
   })
 
   describe('scan parity across mixed-era stored shapes', () => {

--- a/packages/hub/__tests__/via/pipeline.test.ts
+++ b/packages/hub/__tests__/via/pipeline.test.ts
@@ -129,6 +129,34 @@ describe('ViaPipeline', () => {
     expect(result.seq).toEqual(['a.present', 'b.present'])
   })
 
+  // #669/#671 review — presentLate is a mid-fold hook: it must run at the boundary
+  // BETWEEN the money+computed present segment and the "everything else" (rest) present
+  // segment (`pipeline.ts:175-187`'s `_presentLateBoundary`), not after the rest segment.
+  // Mutation evidence: moving the presentLate fold to run AFTER the rest-segment loop still
+  // passed every other test in this suite — nothing pinned the ORDERING itself. A 'money'
+  // binding's presentLate dresses a field; a synthetic rest-brand binding's present() (which
+  // runs in the third loop) must observe the DRESSED value, proving presentLate ran first.
+  it('presentLate runs BEFORE the "everything else" present segment — a rest-brand binding\'s present() sees the presentLate-dressed value, not the pre-dressed one (#669 boundary)', async () => {
+    const observed: unknown[] = []
+    const dresser: ViaBinding = {
+      brand: 'money',
+      posture: { encryptedAtRest: 'envelope', queryable: 'ordered', exportable: true, forgettable: true },
+      presentLate: async (r) => ({ ...(r as Record<string, unknown>), tag: 'dressed' }),
+    }
+    const rest: ViaBinding = {
+      brand: 'rest-brand',
+      posture: { encryptedAtRest: 'envelope', queryable: 'full', exportable: true, forgettable: true },
+      present: async (r) => {
+        observed.push((r as Record<string, unknown>).tag)
+        return r
+      },
+    }
+    const p = ViaPipeline.build([dresser, rest])!
+    const ctx: ViaReadCtx = { layer: 'test' }
+    await p.present({ tag: 'original' }, ctx)
+    expect(observed).toEqual(['dressed'])
+  })
+
   it('buildClause first-covering-wins', () => {
     const p = ViaPipeline.build([fixtureBindingA(), fixtureBindingB()])!
     const clause = p.buildClause('x', 'eq', 'value')

--- a/packages/hub/__tests__/via/reconcile-lookup.test.ts
+++ b/packages/hub/__tests__/via/reconcile-lookup.test.ts
@@ -105,10 +105,11 @@ describe('#664 Part 2b — reserved (dict) tier lookup late-attach reconcile', (
   })
 
   it('dictKeyFieldRegistry is populated by the late-attach — proven via LookupHandle.rename()\'s referencing-record rewrite (choke-point participation)', async () => {
-    // Open vocabulary here (dict()'s default) — a CLOSED field's rename interacts with
-    // LookupHandle.rename()'s own cache-update ordering (the new key's write-through cache entry
-    // lands AFTER the referencing-record rewrite step) independently of #664; open vocabulary
-    // isolates the one thing this test is proving — that the late-attach wired
+    // Open vocabulary here (dict()'s default). rename()'s own cache-update ordering bug (the new
+    // key's write-through cache entry landing AFTER the referencing-record rewrite step, which
+    // made a CLOSED field self-refuse) was fixed in #670 — a FRESH-declared closed field's
+    // rename() is covered by lookup-closed-rename.test.ts. Open vocabulary stays here only to
+    // isolate the one thing THIS test is proving — that the late-attach wired
     // `dictKeyFieldRegistry`, the registry `findAndUpdateReferences`/`updateReferencingRecords`
     // reads to find which collections reference this dictionary.
     const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-lookup-dict-2', i18nStrategy: withI18n() })

--- a/packages/hub/__tests__/via/reconcile-read-state.test.ts
+++ b/packages/hub/__tests__/via/reconcile-read-state.test.ts
@@ -1,0 +1,97 @@
+/**
+ * #671 items 1-3 — three construction-frozen `Collection` read-side residuals a late-attach (a
+ * SECOND-OR-LATER `vault.collection()` call on an already-open collection) used to leave stale:
+ *
+ *  1. `getDictionary` (private, captured once at construction) — `describe({resolveDictLabels:
+ *     true})` and the search-index label pre-computation can't resolve a late-attached
+ *     dict-backed field's labels, since the callback stays `undefined` forever once the
+ *     collection was first opened bare.
+ *  2. `describe()`'s legacy top-level `dictKeyFields`/`i18nFields`/`lookupFields` KEY LISTS
+ *     (`this.dictKeyFields`/`this.i18nFields`/`this.lookupFields`, set only at construction) feed
+ *     `buildDescription`'s field-list/widget derivation — a late-attached field's PER-FIELD
+ *     `describeFragment` is already correct (reads live off `_via.bindings`), but it stays absent
+ *     from these separately-frozen legacy lists.
+ *  3. `presentForJoin` (built once at construction over construction-time i18n/lookup fields,
+ *     `undefined` when neither family was present yet) — a late-attached i18n/lookup field on a
+ *     join TARGET collection never dresses through `querySourceForJoin()`'s join path.
+ *
+ * `Collection._reconcileReadState` (the ONE writer seam, mirroring `_setVia`) + the
+ * `_viaFieldsSnapshot` reader close all three; see `kernel/via/reconcile.ts`'s
+ * `reconcileCollectionReadState`.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../../src/index.js'
+import { withI18n } from '../../src/via/i18n/index.js'
+import { i18nText } from '../../src/via/i18n/core.js'
+import { dictKey } from '../../src/via/i18n/dictionary.js'
+import { enumOf } from '../../src/via/lookup/descriptor.js'
+import { ref } from '../../src/kernel/refs.js'
+import { inlineMemory } from '../classified/harness.js'
+
+interface Worker extends Record<string, unknown> { id: string; priority?: string }
+interface Ticket extends Record<string, unknown> { id: string; status?: string }
+interface Category extends Record<string, unknown> { id: string; name?: Record<string, string> }
+interface Product extends Record<string, unknown> { id: string; categoryId: string }
+
+const NAME = i18nText({ languages: ['en', 'th'], required: 'all' })
+
+describe('#671 items 1-3 — late-attach reconcile refreshes construction-frozen read-state', () => {
+  it('item 1: getDictionary — a late-attached dynamic dictKey field resolves labels via describe({resolveDictLabels:true})', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-readstate-1', i18nStrategy: withI18n() })
+    const vault = await db.openVault('rs1')
+
+    const first = vault.collection<Worker>('workers', {})
+    await vault.dictionary('priority').putAll({ hi: { en: 'High' }, lo: { en: 'Low' } })
+
+    // Late-attach on a SECOND vault.collection() call — same instance, reconciled.
+    const second = vault.collection<Worker>('workers', {
+      dictKeyFields: { priority: dictKey('priority') },
+    })
+    expect(second).toBe(first)
+
+    const d = await second.describe({ resolveDictLabels: true })
+    const p = d.fields.find((f) => f.key === 'priority')!
+    expect(p.dict?.values).toEqual(expect.arrayContaining([
+      { value: 'hi', label: 'High' },
+      { value: 'lo', label: 'Low' },
+    ]))
+  })
+
+  it('item 2: describe() legacy lists — a late-attached lookup field is included, deep-equal to the same declaration made fresh', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-readstate-2', i18nStrategy: withI18n() })
+    const vault = await db.openVault('rs2')
+
+    const bare = vault.collection<Ticket>('tickets_late', {})
+    const late = vault.collection<Ticket>('tickets_late', {
+      lookupFields: { status: enumOf(['open', 'closed']) },
+    })
+    expect(late).toBe(bare)
+
+    const fresh = vault.collection<Ticket>('tickets_fresh', {
+      lookupFields: { status: enumOf(['open', 'closed']) },
+    })
+
+    expect(late.describe().fields).toEqual(fresh.describe().fields)
+  })
+
+  it('item 3: presentForJoin — a late-attached i18n field on a join TARGET dresses through the join path exactly like a fresh declaration', async () => {
+    const db = await createNoydb({ store: inlineMemory(), user: 'alice', secret: 'pw-reconcile-readstate-3', i18nStrategy: withI18n() })
+    const vault = await db.openVault('rs3')
+
+    // Join target opened bare FIRST — the products ref is declared before categories gets its
+    // i18nFields, mirroring the MV-auto-create-then-declare ordering #671 targets.
+    const categories = vault.collection<Category>('categories3', {})
+    const products = vault.collection<Product>('products3', { refs: { categoryId: ref('categories3') } })
+
+    const categoriesLate = vault.collection<Category>('categories3', {
+      i18nFields: { name: NAME },
+    })
+    expect(categoriesLate).toBe(categories)
+
+    await categories.put('c1', { id: 'c1', name: { en: 'Food', th: 'อาหาร' } })
+    await products.put('p1', { id: 'p1', categoryId: 'c1' })
+
+    const rows = products.query().join('categoryId', { as: 'category' }).toArray({ locale: 'th' }) as Array<Product & { category: Category }>
+    expect(rows[0]!.category.name).toBe('อาหาร')
+  })
+})

--- a/packages/hub/__tests__/via/reconcile-taint.test.ts
+++ b/packages/hub/__tests__/via/reconcile-taint.test.ts
@@ -1,0 +1,114 @@
+/**
+ * #671 item 4 — money-only (and classified-only) late-attach reconcile calls
+ * must not drop the graph's taint overlay off `coll._via.taint`. Distinct
+ * from `taint.test.ts` (#638 Task 3's general taint-propagation suite,
+ * including its own reconcile-path coverage for a COMBINED classified+computed
+ * late-attach) — this file is scoped to the #671 item 4 residual:
+ * `_applyMoneyFields`/`_applyClassifiedFields` (`kernel/collection.ts`)
+ * rebuild `this.via` via the bare one-arg `ViaPipeline.build(bindings)` call,
+ * silently defaulting `taint` to `undefined` and dropping any already-
+ * materialized overlay.
+ *
+ * The money-only path is the confirmed, reproducible bug: the
+ * `reconcilePlan`/`applyTaintOverlay` re-run (`kernel/via/reconcile.ts:420,
+ * 437-440`) is gated by `plan.computed || plan.classifiedFields` —
+ * `moneyFields` never trips that condition, so nothing patches the drop back
+ * up. The classified-only path has the identical code-level omission but was
+ * already masked by that same re-run (`plan.classifiedFields` IS part of the
+ * gate) — the second describe block below pins that it STAYS green now that
+ * `_applyClassifiedFields` threads taint directly too.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, FieldNotQueryableError, SealedHandle } from '../../src/index.js'
+import { withClassified } from '../../src/via/classified/index.js'
+import type { ClassifiedFieldSpec } from '../../src/via/classified/index.js'
+import { money } from '../../src/via/money/descriptor.js'
+import { inlineMemory } from '../classified/harness.js'
+
+interface Person extends Record<string, unknown> {
+  id: string
+  ssn: string
+  ssnLeak?: string
+  amount?: string
+  amountCopy?: string
+}
+
+const ssnSpec = (): ClassifiedFieldSpec => ({
+  _noydbClassified: true, preset: 'test-ssn', storage: 'recoverable',
+  list: { kind: 'omit' }, sensitivity: 'secret',
+})
+
+describe('#671 item 4 — money-only late-attach preserves the taint overlay', () => {
+  it('a SECOND vault.collection() call adding ONLY moneyFields keeps coll._via.taint defined, and postureFor/redactForExport still enforce the derived-taint postures', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({
+      store, user: 'a', secret: 'money-only-late-attach-1', classifiedStrategy: withClassified(),
+    })
+    const v = await db.openVault('v1')
+
+    // Fresh construction: classified + computed — the taint overlay materializes here
+    // (applyTaintOverlay's unconditional fresh-construction call, vault.ts:1173).
+    const c = v.collection<Person>('people', {
+      classifiedFields: { ssn: ssnSpec() },
+      computed: { ssnLeak: { fn: (r) => r.ssn, deps: ['ssn'] } },
+    })
+    await c.put('r1', { id: 'r1', ssn: '123-45-6789' })
+    expect(c._via?.taint).toBeDefined()
+    const before = await c.get('r1')
+    expect(before?.ssnLeak).toBeInstanceOf(SealedHandle)
+
+    // SECOND vault.collection() call, same collection name, adding ONLY moneyFields.
+    const c2 = v.collection<Person>('people', {
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+    })
+
+    // The bug: `_applyMoneyFields`'s rebuild called `ViaPipeline.build([...])` with no
+    // second arg, defaulting `taint` to undefined and silently dropping it.
+    expect(c2._via?.taint).toBeDefined()
+
+    // postureFor/redactForExport still reflect the derived-taint postures post-attach.
+    const after = await c2.get('r1')
+    expect(after?.ssnLeak).toBeInstanceOf(SealedHandle)
+    expect(JSON.stringify(after?.ssnLeak)).toBe('"[sealed]"')
+    expect(() => c2.query().where('ssnLeak', '==', '123-45-6789')).toThrow(FieldNotQueryableError)
+
+    const json = await v.exportJSON()
+    const parsed = JSON.parse(json) as { collections: Record<string, { records: Array<Record<string, unknown>> }> }
+    expect(parsed.collections.people!.records[0]!.ssnLeak).toBe('[sealed]')
+  })
+})
+
+describe('#671 item 4 regression — classified-only late-attach also keeps the taint overlay (already masked by the reconcilePlan/applyTaintOverlay re-run; must STAY green now that _applyClassifiedFields threads taint directly too)', () => {
+  it('a SECOND vault.collection() call declaring classifiedFields for the FIRST time does not drop a pre-existing money-sourced taint overlay', async () => {
+    const store = inlineMemory()
+    const db = await createNoydb({
+      store, user: 'a', secret: 'classified-only-late-attach-1', classifiedStrategy: withClassified(),
+    })
+    const v = await db.openVault('v1')
+
+    // Fresh construction: money + computed (materialized), plus `sensitive: ['ssn']` to
+    // pre-freeze `ssn` into `sensitiveFields` — the ONLY way a `storage: 'recoverable'`
+    // classified field is later accepted via late-attach (mirrors taint.test.ts's own
+    // reconcile-path idiom). Money's own posture (envelope/ordered/exportable/
+    // forgettable:true — via/money/binding.ts:42) differs from DEFAULT_POSTURE
+    // (forgettable:false), so the derived field's fold is non-default and the taint
+    // overlay materializes WITHOUT any classified field in play yet.
+    const c = v.collection<Person>('accounts', {
+      sensitive: ['ssn'],
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+      computed: { amountCopy: { fn: (r) => r.amount, deps: ['amount'] } },
+    })
+    expect(c._via?.taint).toBeDefined()
+    const beforePosture = c._via?.taint?.postures.get('amountCopy')
+    expect(beforePosture).toBeDefined()
+
+    // SECOND call — classifiedFields declared for the FIRST time (`this.classified`
+    // was undefined) — the classified-only late-attach door.
+    const c2 = v.collection<Person>('accounts', {
+      classifiedFields: { ssn: ssnSpec() },
+    })
+
+    expect(c2._via?.taint).toBeDefined()
+    expect(c2._via?.taint?.postures.get('amountCopy')).toEqual(beforePosture)
+  })
+})

--- a/packages/hub/src/kernel/collection-config.ts
+++ b/packages/hub/src/kernel/collection-config.ts
@@ -610,7 +610,22 @@ export function compileViaBindings<T>(
     computed: allComputedFields,
   })
   const bindings: ViaBinding[] = []
-  if (moneyFields) bindings.push(viaBinder('money')(moneyFields))
+  // #669 — hoisted above the money push (was built at the tail of this function, alongside
+  // the `computed` binding push below) so money's own binding config can be told which of
+  // ITS fields are ALSO virtual-mode computed (the money+virtual-on-the-same-field
+  // MAJOR-UNITS case) — money needs this at construction time; nothing else in this
+  // function depends on the hoist.
+  const virtualFields = new Map<string, ComputedDescriptor>()
+  for (const [field, entry] of Object.entries(allComputedFields)) {
+    const parts = computedEntryParts(entry)
+    if (parts.mode === 'virtual') {
+      virtualFields.set(field, { _viaBrand: 'computed', fn: parts.fn, mode: 'virtual', ...(parts.deps !== undefined ? { deps: parts.deps } : {}) })
+    }
+  }
+  if (moneyFields) {
+    const virtualMoney = resolveVirtualMoneyFields(Object.keys(moneyFields), (f) => virtualFields.has(f))
+    bindings.push(viaBinder('money')({ moneyFields, ...(virtualMoney.size > 0 ? { virtualMoneyFields: virtualMoney } : {}) }))
+  }
   if (i18nFields || dictKeyFields) {
     // Densify-enabled subset (fields opting into `densifyOnWrite: true`) —
     // undefined when none opt in, so the write path skips densify work
@@ -666,17 +681,33 @@ export function compileViaBindings<T>(
       collectionName: opts.name,
     }))
   }
-  const virtualFields = new Map<string, ComputedDescriptor>()
-  for (const [field, entry] of Object.entries(allComputedFields)) {
-    const parts = computedEntryParts(entry)
-    if (parts.mode === 'virtual') {
-      virtualFields.set(field, { _viaBrand: 'computed', fn: parts.fn, mode: 'virtual', ...(parts.deps !== undefined ? { deps: parts.deps } : {}) })
-    }
-  }
   if (virtualFields.size > 0) {
     bindings.push(viaBinder('computed')({ virtualFields }))
   }
   return bindings
+}
+
+/**
+ * The money∩virtual-mode-computed field-name intersection (#669) — shared by
+ * `compileViaBindings` above (fresh construction, `isVirtual` closes over the just-built
+ * `virtualFields` Map) and {@link Collection._applyMoneyFields} (late-attach, `isVirtual`
+ * closes over the already-compiled pipeline's `computed` binding instead — virtual-mode
+ * computed fields have no late-attach door of their own (declaring one on a reconcile call
+ * throws), so by the time money reconciles onto an existing collection, any virtual field
+ * is already sitting in `bindings`, never in `this.computed`: `resolveCollectionConfig`
+ * deliberately excludes virtual-mode entries from the map it assigns to `this.computed`,
+ * since that field feeds ONLY the write-time `evalComputedFields` path — see
+ * `materializedComputed` above). Both callers get the identical intersection semantics from
+ * one function, so money's `presentLate` MAJOR-UNITS dressing (`via/money/binding.ts`) can
+ * never silently disagree between the fresh and late-attach paths.
+ */
+export function resolveVirtualMoneyFields(
+  moneyFieldNames: Iterable<string>,
+  isVirtual: (field: string) => boolean,
+): Set<string> {
+  const out = new Set<string>()
+  for (const field of moneyFieldNames) if (isVirtual(field)) out.add(field)
+  return out
 }
 
 /** One `ViaGraph.registerDerived` call's worth of edge data — target + sources,

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -107,7 +107,7 @@ import type { MaterializedViewRegistry } from '../with-formula/materialized-view
 import type { MVQueryContext } from '../with-formula/materialized-views/types.js'
 import type { MaterializedViewExecutor as MVExecutorType } from '../with-formula/materialized-views/executor.js'
 import type * as MVStaleModule from '../with-formula/materialized-views/stale.js'
-import { resolveCollectionConfig, type CollectionOpts } from './collection-config.js'
+import { resolveCollectionConfig, resolveVirtualMoneyFields, type CollectionOpts } from './collection-config.js'
 import { loadEvalComputedFields } from '../with-formula/computed/lazy.js'
 
 /**
@@ -974,9 +974,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   describe(): CollectionDescription
   describe(opts: DescribeOptions): Promise<CollectionDescription>
   describe(opts?: DescribeOptions): CollectionDescription | Promise<CollectionDescription> {
-    if (opts) {
-      return this.describeAsync(opts)
-    }
+    if (opts) return this.describeAsync(opts)
     return buildDescription({
       collection: this.name,
       fieldMeta: this.fieldMeta,
@@ -1282,7 +1280,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    */
   _applyMoneyFields(moneyFields: Record<string, ViaDescriptor>): void {
     if (this.moneyFields !== undefined) return
-    this.via = ViaPipeline.build([viaBinder('money')(moneyFields), ...(this.via?.bindings ?? [])])
+    const virtualMoney = resolveVirtualMoneyFields(Object.keys(moneyFields), (f) => this.via?.bindings.find((b) => b.brand === 'computed')?.covers?.(f) ?? false) // #669
+    this.via = ViaPipeline.build([viaBinder('money')({ moneyFields, ...(virtualMoney.size > 0 ? { virtualMoneyFields: virtualMoney } : {}) }), ...(this.via?.bindings ?? [])])
     this.moneyFields = moneyFields
   }
 

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -871,6 +871,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       defs: opts.indexes ?? [],
       lazy: this.lazy,
     })
+    this.indexes?.setCanonicalizer((f, v) => this.via?.canonicalizeIndexKey(f, v)) // #672 review C1: one-time canonicalizer registration; lazy `this.via` read survives late `_setVia` (#666)
 
     // Unique-constraint enforcement (eager mode only). Declaring `unique` on
     // a lazy/CRDT/tiered collection throws UnsupportedIndexOptionError here —
@@ -4460,7 +4461,6 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       lazy: this.lazy,
       emitter: this.emitter,
       indexes: this.indexes,
-      ...(this.via ? { canonicalizeIndexKey: (f: string, v: unknown) => this.via!.canonicalizeIndexKey(f, v) } : {}),
       uniqueConstraints: this.uniqueConstraints,
       persistedIndexes: this.persistedIndexes,
       ensureHydrated: () => this.ensureHydrated(),

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -344,10 +344,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    */
   private readonly defaultLocale: string | undefined
 
-  /** Field name → `I18nTextDescriptor` for `i18nText()` fields (`i18nFields` option); write/read
-   *  runs through the compiled `via` i18n binding — this remains for `describe()`
-   *  and the search-index build path. */
-  private readonly i18nFields: Record<string, I18nTextDescriptor> | undefined
+  /** Field name → `I18nTextDescriptor` for `i18nText()` fields (`i18nFields` option); write/read runs through the compiled `via` i18n binding — this remains for `describe()` and the search-index build path. Mutable — see {@link _reconcileReadState} (#671 item 2). */
+  private i18nFields: Record<string, I18nTextDescriptor> | undefined
 
   /** The configured string fields exposed to `retrieve()`; `undefined` for ordinary collections (zero-cost). */
   private readonly textIndexes: readonly string[] | undefined
@@ -362,14 +360,13 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   /** In-memory vector set, populated lazily from `_vec` sidecars; `undefined` when no embedding config is declared. */
   private vectorSet: VectorSet | undefined
 
-  /** Field name → `DictKeyDescriptor` for `dictKey()` fields; used by `get()`/`list()` to add
-   *  `<field>Label` virtual fields when a locale is requested. */
-  private readonly dictKeyFields: Record<string, DictKeyDescriptor | StaticDictDescriptor> | undefined
+  /** Field name → `DictKeyDescriptor` for `dictKey()` fields; used by `get()`/`list()` to add `<field>Label` virtual fields when a locale is requested. Mutable — see {@link _reconcileReadState} (#671 item 2). */
+  private dictKeyFields: Record<string, DictKeyDescriptor | StaticDictDescriptor> | undefined
 
-  /** Field name → `LookupDescriptor` for native `lookup()`/`enumOf()`/`dict()` fields (#650 Task 2) — describe()-only in this task. */
-  private readonly lookupFields: Record<string, LookupDescriptor> | undefined
-  /** Sync join-dressing hook (#650 Task 6, #626 retirement) — `querySourceForJoin()`'s `presentForJoin`. */
-  private readonly presentForJoin: ((record: unknown, locale: string) => unknown) | undefined
+  /** Field name → `LookupDescriptor` for native `lookup()`/`enumOf()`/`dict()` fields (#650 Task 2) — describe()-only in this task. Mutable — see {@link _reconcileReadState} (#671 item 2). */
+  private lookupFields: Record<string, LookupDescriptor> | undefined
+  /** Sync join-dressing hook (#650 Task 6, #626 retirement) — `querySourceForJoin()`'s `presentForJoin`. Mutable — see {@link _reconcileReadState} (#671 item 3). */
+  private presentForJoin: ((record: unknown, locale: string) => unknown) | undefined
 
   /** Consumer-neutral per-field descriptors declared via `fieldMeta`; read by `getFieldMeta()`, merged by `describe()`. */
   private fieldMeta: Record<string, FieldMeta> | undefined
@@ -425,12 +422,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    */
   private readonly classifiedStrategy: ClassifiedStrategy
 
-  /**
-   * Async callback provided by the Vault to open a dynamic
-   * dictionary handle (for label-map pre-computation in the search index).
-   * Only used in `resolveDictLabelMaps()`; static dicts bypass this entirely.
-   */
-  private readonly getDictionary: ((name: string) => Promise<DictionaryHandle>) | undefined
+  /** Async callback provided by the Vault to open a dynamic dictionary handle (for label-map pre-computation in the search index). Only used in `resolveDictLabelMaps()`; static dicts bypass this entirely. Mutable, assign-once — see {@link _reconcileReadState} (#671 item 1). */
+  private getDictionary: ((name: string) => Promise<DictionaryHandle>) | undefined
 
   /**
    * declared deterministic fields. `null` when the feature
@@ -4422,6 +4415,14 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   async _onViaErase(id: string, live: EncryptedEnvelope): Promise<ViaEraseReport | undefined> { return this.via ? this.via.eraseSealed({ id, vault: this.vault, live, crypto: await this.codec.eraseCryptoCtx(id, live) }) : undefined } // @internal forget()'s per-ref via-erase fold (#629 T10)
   get _via(): ViaPipeline | undefined { return this.via } // @internal exportRedact()'s typed reach-in accessor (fixes #634)
   _setVia(pipeline: ViaPipeline | undefined): void { this.via = pipeline; this.codec.setVia(this.via) } // @internal applyTaintOverlay()'s typed writer seam — assigns `via` + resyncs the codec (fixes #666)
+  get _viaFieldsSnapshot(): { i18nFields: Record<string, I18nTextDescriptor> | undefined; lookupFields: Record<string, LookupDescriptor> | undefined } { return { i18nFields: this.i18nFields, lookupFields: this.lookupFields } } // @internal reconcile.ts's presentForJoin-rebuild union reader (#671 item 3)
+  _reconcileReadState(patch: { dictKeyFields?: Record<string, DictKeyDescriptor | StaticDictDescriptor>; i18nFields?: Record<string, I18nTextDescriptor>; lookupFields?: Record<string, LookupDescriptor>; getDictionary?: (name: string) => Promise<DictionaryHandle>; presentForJoin?: (record: unknown, locale: string) => unknown }): void { // @internal reconcile.ts's ONE late-attach writer for #671 items 1-3 — descriptor maps merge (construction wins on collision), getDictionary/presentForJoin assign (getDictionary never clobbers a live closure)
+    if (patch.dictKeyFields) this.dictKeyFields = { ...patch.dictKeyFields, ...this.dictKeyFields }
+    if (patch.i18nFields) this.i18nFields = { ...patch.i18nFields, ...this.i18nFields }
+    if (patch.lookupFields) this.lookupFields = { ...patch.lookupFields, ...this.lookupFields }
+    if (patch.getDictionary && this.getDictionary === undefined) this.getDictionary = patch.getDictionary
+    if (patch.presentForJoin) this.presentForJoin = patch.presentForJoin
+  }
   /**
    * Bind the {@link TiersContext} the tier ops need. The `cekCache` is passed
    * by reference (the SAME `Lru` the kernel's read/write path owns) so an

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -1281,7 +1281,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   _applyMoneyFields(moneyFields: Record<string, ViaDescriptor>): void {
     if (this.moneyFields !== undefined) return
     const virtualMoney = resolveVirtualMoneyFields(Object.keys(moneyFields), (f) => this.via?.bindings.find((b) => b.brand === 'computed')?.covers?.(f) ?? false) // #669
-    this.via = ViaPipeline.build([viaBinder('money')({ moneyFields, ...(virtualMoney.size > 0 ? { virtualMoneyFields: virtualMoney } : {}) }), ...(this.via?.bindings ?? [])])
+    this.via = ViaPipeline.build([viaBinder('money')({ moneyFields, ...(virtualMoney.size > 0 ? { virtualMoneyFields: virtualMoney } : {}) }), ...(this.via?.bindings ?? [])], this.via?.taint) // #671 item 4 — thread taint through the rebuild
     this.moneyFields = moneyFields
   }
 
@@ -1365,7 +1365,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     // is money→i18n→classified; this keeps classified last regardless of order.
     this.via = ViaPipeline.build([...(this.via?.bindings ?? []), viaBinder('classified')({
       entries: classifiedFields, collectionName: this.name, guardCtx: this.classifiedGuardCtx, classifySealedShred: (live: unknown) => this.codec.classifySealedShred(live as EncryptedEnvelope), // #629 T10
-    })])
+    })], this.via?.taint) // #671 item 4 — thread taint through the rebuild (code-level consistency; masked today by the reconcilePlan applyTaintOverlay re-run)
   }
 
   get _ramCiphertext(): boolean { return this.ramCiphertext } // @internal — used only in tests; do not read in production code.

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -2029,8 +2029,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     } else {
       this.cache.set(id, { record: await this._toCacheableRecord(record, envelope, id), version })
       // Update secondary indexes incrementally — no-op if no indexes are
-      // declared. Pass the previous record (if any) so old buckets are
-      // cleaned up before the new value is added.
+      // declared. Pass the previous record (if any) so old buckets are cleaned up before the new value is added.
       this.indexes?.upsert(id, record, existing ? existing.record : null)
       // Update unique-constraint maps to reflect the successful write.
       this.uniqueConstraints?.upsert(id, record, existing?.record)
@@ -4461,6 +4460,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       lazy: this.lazy,
       emitter: this.emitter,
       indexes: this.indexes,
+      ...(this.via ? { canonicalizeIndexKey: (f: string, v: unknown) => this.via!.canonicalizeIndexKey(f, v) } : {}),
       uniqueConstraints: this.uniqueConstraints,
       persistedIndexes: this.persistedIndexes,
       ensureHydrated: () => this.ensureHydrated(),

--- a/packages/hub/src/kernel/query/builder.ts
+++ b/packages/hub/src/kernel/query/builder.ts
@@ -1129,14 +1129,13 @@ function candidateRecords(source: InternalSource, clauses: readonly Clause[]): C
     // via `ViaBinding.indexProbe`) — the STORED-form operand for a direct
     // probe (fixed-mode money `==`/`in` today). When it's absent, skip the
     // index fast path for this clause; the fallback scan evaluates it via
-    // `clause.via.evaluate`. MIXED-ERA CAVEAT (money): this probe hits the
-    // index bucket keyed by the RAW stored string; a legacy non-canonical
-    // scaled value (predates the field's money() declaration) is bucketed
-    // under its raw form and misses a canonical probe, while the scan
-    // fallback (`evaluateMoneyClause`) re-parses via BigInt and still
-    // matches it — see `moneyIndexProbe`'s doc comment (via-money/where.ts)
-    // for the full caveat; a money-aware index-key canonicalization is a
-    // filed follow-up, not implemented here.
+    // `clause.via.evaluate`. MIXED-ERA DATA (money, #672 fixed): the index
+    // bucket this probe hits is no longer keyed by the RAW stored string —
+    // `CollectionIndexes` canonicalizes money keys through `ViaPipeline.
+    // canonicalizeIndexKey` on build/rebuild, so a legacy non-canonical
+    // scaled value (predates the field's money() declaration) lands in the
+    // SAME bucket a canonical probe looks up — see `moneyIndexProbe`'s doc
+    // comment (via-money/where.ts) for the full story.
     if (clause.via && clause.via.indexValue === undefined) continue
     const probeValue = clause.via ? clause.via.indexValue : clause.value
 

--- a/packages/hub/src/kernel/query/builder.ts
+++ b/packages/hub/src/kernel/query/builder.ts
@@ -1129,13 +1129,17 @@ function candidateRecords(source: InternalSource, clauses: readonly Clause[]): C
     // via `ViaBinding.indexProbe`) — the STORED-form operand for a direct
     // probe (fixed-mode money `==`/`in` today). When it's absent, skip the
     // index fast path for this clause; the fallback scan evaluates it via
-    // `clause.via.evaluate`. MIXED-ERA DATA (money, #672 fixed): the index
-    // bucket this probe hits is no longer keyed by the RAW stored string —
-    // `CollectionIndexes` canonicalizes money keys through `ViaPipeline.
-    // canonicalizeIndexKey` on build/rebuild, so a legacy non-canonical
-    // scaled value (predates the field's money() declaration) lands in the
-    // SAME bucket a canonical probe looks up — see `moneyIndexProbe`'s doc
-    // comment (via-money/where.ts) for the full story.
+    // `clause.via.evaluate`. MIXED-ERA DATA (money, #672 fixed, incl. the
+    // #672 review's C1 finding): the index bucket this probe hits is no
+    // longer keyed by the RAW stored string — EAGER-mode `CollectionIndexes`
+    // canonicalizes money keys through `ViaPipeline.canonicalizeIndexKey` at
+    // EVERY bucket-mutation site (`build`, `upsert`, `remove`), not just
+    // build/rebuild, so a legacy non-canonical scaled value (predates the
+    // field's money() declaration) lands in — and stays in — the SAME bucket
+    // a canonical probe looks up, across later put()/delete() too. LAZY
+    // mode's `PersistedCollectionIndex` keeps raw bucketing (out of scope) —
+    // see `moneyIndexProbe`'s doc comment (via-money/where.ts) for the full
+    // story.
     if (clause.via && clause.via.indexValue === undefined) continue
     const probeValue = clause.via ? clause.via.indexValue : clause.value
 

--- a/packages/hub/src/kernel/via/graph.ts
+++ b/packages/hub/src/kernel/via/graph.ts
@@ -228,13 +228,20 @@ export class ViaGraph {
      *  fold. Posture folding (`_contribution`/`_computeEffective`/
      *  `_wildcardContribution`) never reads `_out`, so an expansion that reads
      *  `_out` only is provably unable to perturb it. */
+    // #671 item 5 — exclude `kind:'ref'` consuming edges: mutual FK lookups (two
+    // collections each referencing the other) are legal and must not be treated as a
+    // derivation cycle. Ref edges exist for cascade/rename machinery
+    // (`referencingEdgesOf`/delete-time restrict/cascade/nullify), never derivation
+    // ordering, so they carry no ordering constraint here. `_out` stores bare
+    // `FieldRef` targets (no kind) — the kind lives on `_in`, keyed by the target.
+    const notRefEdge = (t: FieldRef): boolean => this._in.get(nodeId(t))?.kind !== 'ref'
     const neighboursOf = (id: string): readonly FieldRef[] => {
-      const own = this._out.get(id)
+      const own = (this._out.get(id) ?? []).filter(notRefEdge)
       const sep = id.indexOf(SEP)
-      if (id.slice(sep + 1) === '*') return own ?? []
-      const wildcard = this._out.get(`${id.slice(0, sep)}${SEP}*`)
-      if (!wildcard) return own ?? []
-      return own ? [...own, ...wildcard] : wildcard
+      if (id.slice(sep + 1) === '*') return own
+      const wildcard = (this._out.get(`${id.slice(0, sep)}${SEP}*`) ?? []).filter(notRefEdge)
+      if (wildcard.length === 0) return own
+      return [...own, ...wildcard]
     }
 
     const visit = (id: string): void => {

--- a/packages/hub/src/kernel/via/index.ts
+++ b/packages/hub/src/kernel/via/index.ts
@@ -117,6 +117,20 @@ export interface ViaBinding {
   decodeAtRest?(record: Record<string, unknown>, sealed: Record<string, SealedSlotRef>, crypto: ViaCryptoCtx, opts: { asHandles: boolean }): Promise<Record<string, unknown>>
   /** Read-time presentation (money decode+virtuals; i18n locale/labels/strip). May be async. */
   present?(record: Record<string, unknown>, ctx: ViaReadCtx): Awaitable<Record<string, unknown>>
+  /**
+   * Late read-time presentation (#669) — runs AFTER every binding's `present()` in the
+   * money+computed present-order segment (`ViaPipeline`'s `_presentOrder`, `kernel/via/
+   * pipeline.ts`), BEFORE the "everything else" segment (i18n/lookup dressing, taint
+   * redaction) runs. Exists for a binding that needs to react to a virtual computed
+   * field's fresh OWN-field output before anything dresses it (money's MAJOR-UNITS
+   * quantize-and-present for a field that is BOTH money AND `mode:'virtual'` computed) —
+   * `present()` alone can't express "run after computed for THESE fields only, before
+   * computed for all others", since it's a per-BINDING fold, not per-field. Folded over
+   * `bindings` in declaration order (mirrors every other per-binding fold), so lookup/
+   * i18n dressing and taint/redaction (both in the "everything else" segment) still see
+   * the already-dressed value.
+   */
+  presentLate?(record: Record<string, unknown>, ctx: ViaReadCtx): Awaitable<Record<string, unknown>>
   // ── query participation (ALL SYNC — #553) ──
   /** Returns an opaque clause payload when this binding covers `field`, else undefined. */
   // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents

--- a/packages/hub/src/kernel/via/index.ts
+++ b/packages/hub/src/kernel/via/index.ts
@@ -137,6 +137,20 @@ export interface ViaBinding {
    */
   // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   indexProbe?(op: string, payload: unknown): unknown | undefined
+  /**
+   * Optional: canonicalize a raw STORED field value into the bucket key an
+   * eager index should use (#672) — lets `CollectionIndexes` group a
+   * pre-declaration / non-canonical stored value (e.g. a money field's
+   * leftover `'0100'` written before its `money()` declaration) under the
+   * SAME key a canonical write produces (`'100'`), so the index-probe fast
+   * path (`indexProbe` above) and the fallback scan (`evaluateClause`)
+   * agree on which records match. `undefined` means "not mine / can't
+   * canonicalize this value" — the caller buckets the raw stringified
+   * value, unchanged from before this hook existed. MUST agree with what
+   * this binding's own `evaluateClause`/`indexProbe` treat as equal, or
+   * the fast path and the scan will disagree.
+   */
+  canonicalizeIndexKey?(field: string, rawValue: unknown): string | undefined
   /** Decode a raw stored record for query/scan results and callback views ('raw' — no virtuals). */
   decodeResults?(record: unknown): unknown
   /** Exact ordering for a covered field; undefined when the field is not covered. */

--- a/packages/hub/src/kernel/via/pipeline.ts
+++ b/packages/hub/src/kernel/via/pipeline.ts
@@ -72,19 +72,27 @@ export class ViaPipeline {
    * comment).
    *
    * Money-dressing a virtual computed field's OWN output (the composed
-   * `computed(virtual) + money` case) remains a KNOWN LIMITATION —
-   * reordering alone cannot fix it; money would need to quantize/reinterpret
-   * a major-unit value as a stored scaled-int, a value-shape decision left
-   * for a filed follow-up, not resolved by this partition.
+   * `computed(virtual) + money` case) is NOT resolved by this partition
+   * alone — #669 resolves it with a separate mid-fold hook instead:
+   * `ViaBinding.presentLate` runs after every binding's `present()` in this
+   * money+computed segment, before the "everything else" segment below, so
+   * money can quantize/reinterpret a virtual field's fresh MAJOR-UNITS
+   * output as if it were a stored value, without perturbing this ordering
+   * or the #665 invariant above it (`_presentLateBoundary` below marks
+   * exactly where that mid-fold point sits within `_presentOrder`).
    */
   private readonly _presentOrder: readonly ViaBinding[]
+  /** #669 — index into `_presentOrder` where the money+computed segment ends and the
+   *  "everything else" segment begins (`moneyBindings.length + computedBindings.length`);
+   *  `present()` runs every binding's `presentLate` at exactly this boundary. */
+  private readonly _presentLateBoundary: number
 
   private constructor(readonly bindings: readonly ViaBinding[], readonly taint?: ViaTaintOverlay) {
-    this._presentOrder = [
-      ...bindings.filter((b) => b.brand === 'money'),
-      ...bindings.filter((b) => b.brand === 'computed'),
-      ...bindings.filter((b) => b.brand !== 'money' && b.brand !== 'computed'),
-    ]
+    const moneyBindings = bindings.filter((b) => b.brand === 'money')
+    const computedBindings = bindings.filter((b) => b.brand === 'computed')
+    const restBindings = bindings.filter((b) => b.brand !== 'money' && b.brand !== 'computed')
+    this._presentOrder = [...moneyBindings, ...computedBindings, ...restBindings]
+    this._presentLateBoundary = moneyBindings.length + computedBindings.length
   }
 
   /** undefined when there is nothing to enforce — the zero-via fast path is
@@ -166,7 +174,15 @@ export class ViaPipeline {
 
   async present(record: Record<string, unknown>, ctx: ViaReadCtx): Promise<Record<string, unknown>> {
     let r = record
-    for (const b of this._presentOrder) if (b.present) r = await b.present(r, ctx)
+    for (let i = 0; i < this._presentLateBoundary; i++) {
+      const b = this._presentOrder[i]!
+      if (b.present) r = await b.present(r, ctx)
+    }
+    for (const b of this.bindings) if (b.presentLate) r = await b.presentLate(r, ctx)
+    for (let i = this._presentLateBoundary; i < this._presentOrder.length; i++) {
+      const b = this._presentOrder[i]!
+      if (b.present) r = await b.present(r, ctx)
+    }
     return r
   }
 

--- a/packages/hub/src/kernel/via/pipeline.ts
+++ b/packages/hub/src/kernel/via/pipeline.ts
@@ -196,6 +196,22 @@ export class ViaPipeline {
     return b?.indexProbe ? b.indexProbe(op, clause.payload) : undefined
   }
 
+  /**
+   * Resolve a raw STORED field value to its canonical eager-index bucket
+   * key (#672) — folds every binding's `canonicalizeIndexKey`, first
+   * non-undefined wins (same fold discipline as `buildClause`). `undefined`
+   * means no binding claims `field` (or the value can't be canonicalized)
+   * — the caller buckets the raw stringified value, unchanged from before
+   * this hook existed.
+   */
+  canonicalizeIndexKey(field: string, rawValue: unknown): string | undefined {
+    for (const b of this.bindings) {
+      const key = b.canonicalizeIndexKey?.(field, rawValue)
+      if (key !== undefined) return key
+    }
+    return undefined
+  }
+
   decodeResults(record: unknown): unknown {
     let r = record
     for (const b of this.bindings) if (b.decodeResults) r = b.decodeResults(r)

--- a/packages/hub/src/kernel/via/reconcile.ts
+++ b/packages/hub/src/kernel/via/reconcile.ts
@@ -242,10 +242,10 @@ function registerDictKeyRegistries(
 
 /** Mirrors `compileViaBindings`'s i18n slot (collection-config.ts:702-723) — same densify-subset
  *  computation, same config shape handed to `viaBinder('i18n')`. `defaultPosture`/taint is
- *  preserved across the rebuild (unlike `_applyMoneyFields`/`_applyClassifiedFields`, which drop
- *  it — those rely on a same-call `applyTaintOverlay` re-run when computed/classifiedFields is
- *  also present; i18n/dictKey have no such re-run, so dropping it here would silently un-taint an
- *  already-tainted field on a collection that happens to ALSO gain i18n late). */
+ *  preserved across the rebuild, same as `_applyMoneyFields`/`_applyClassifiedFields`
+ *  (`kernel/collection.ts`, #671 item 4 fix) — every rebuild path threads `coll._via?.taint`
+ *  through its own `ViaPipeline.build(...)` call now, so none of them depends on a same-call
+ *  `applyTaintOverlay` re-run to avoid silently un-tainting an already-tainted field. */
 function rebuildI18nBinding(
   coll: ReconcilableCollection, vaultCtx: ViaReconcileVaultCtx, name: string,
   i18nFields: Record<string, I18nTextDescriptor> | undefined,

--- a/packages/hub/src/kernel/via/reconcile.ts
+++ b/packages/hub/src/kernel/via/reconcile.ts
@@ -51,7 +51,7 @@ import {
 } from '../../port/with/i18n-strategy.js'
 import {
   resolveLabelFromMap, dictCollectionName, collectLookupDictCompat, checkLookupMembership, buildLookupAltIndex,
-  buildLookupSnapshotRows, registerLookupRefEdges, type LookupDescriptor,
+  buildLookupSnapshotRows, registerLookupRefEdges, buildPresentForJoin, type LookupDescriptor,
 } from '../../port/with/lookup-strategy.js'
 
 type AnyCollection = Collection<Record<string, unknown>>
@@ -71,6 +71,9 @@ export interface ReconcilableCollection extends HasWritableViaPipeline {
   _applyFieldMeta(fieldMeta: Parameters<AnyCollection['_applyFieldMeta']>[0]): void
   _applyMeta(meta: Parameters<AnyCollection['_applyMeta']>[0]): void
   _applyClassifiedFields(classifiedFields: Parameters<AnyCollection['_applyClassifiedFields']>[0]): void
+  /** #671 items 1-3 — the reader + writer seam for `getDictionary`/legacy describe() lists/`presentForJoin`. */
+  readonly _viaFieldsSnapshot: AnyCollection['_viaFieldsSnapshot']
+  _reconcileReadState(patch: Parameters<AnyCollection['_reconcileReadState']>[0]): void
 }
 
 /** The vault-resident state/closures the i18n/dictKey late-attach wiring reads and writes —
@@ -375,6 +378,57 @@ export function reconcileLookupFields(
   registerLookupRefEdges(graph, name, lookupFields)
 }
 
+/** Vault-resident lookup-row source for {@link buildPresentForJoin}'s label dressing — factors out
+ *  the SAME `reservedLookupCollections`/`dictionary`/`getCollection` wiring {@link reconcileLookupFields}
+ *  builds inline for its own `snapshotFor`/`getLookupBacking`, so {@link reconcileCollectionReadState}
+ *  (which may run when only i18n — not lookup — was newly attached, over a PRE-EXISTING lookup
+ *  family) can reuse it without duplicating the vaultCtx plumbing. */
+function buildSnapshotFor(vaultCtx: ViaReconcileVaultCtx) {
+  return (d: LookupDescriptor) =>
+    buildLookupSnapshotRows(d, (n) => vaultCtx.reservedLookupCollections.has(dictCollectionName(n)), (n) => vaultCtx.dictionary(n), (n) => vaultCtx.getCollection(n))
+}
+
+/**
+ * #671 items 1-3 — refresh the THREE construction-frozen `Collection` read-side residuals a
+ * late-attach used to leave stale: `getDictionary` (describe()'s dict-label resolution / the
+ * search-index's label pre-computation), the legacy `describe()` top-level dictKeyFields/
+ * i18nFields/lookupFields KEY LISTS (the PER-FIELD `describeFragment` is already correct — this is
+ * specifically the separately-frozen list feeding `buildDescription`'s field-list/widget
+ * derivation), and `presentForJoin` (`querySourceForJoin()`'s join-dressing hook).
+ *
+ * No-op unless THIS call actually attached a NEW family — `i18nJustAttached`/`lookupJustAttached`
+ * mirror {@link reconcileI18nFields}/{@link reconcileLookupFields}'s own first-wins gate (a
+ * redundant re-declare must stay a no-op here too, or an already-refused field would smuggle its
+ * way into the read-state via this side door). `getDictionary` mirrors `vault.ts`'s
+ * construction-time gate (`dictKeyFields || lookupFields`, never bare i18nText alone).
+ * `presentForJoin` is rebuilt via {@link buildPresentForJoin} (the `port/with/lookup-strategy.js`
+ * re-export — the SAME Check-14-legal channel `collection-config.ts` uses for the fresh-
+ * construction build) over the UNION of the collection's PRE-existing i18nFields/lookupFields
+ * ({@link Collection._viaFieldsSnapshot}, read BEFORE this call's own writes below) and whatever
+ * this call just attached — covering the mixed case (e.g. lookup already present at construction,
+ * i18n late-attached now) as well as the bare-then-declare one the test suite exercises.
+ */
+function reconcileCollectionReadState(
+  coll: ReconcilableCollection, vaultCtx: ViaReconcileVaultCtx,
+  plan: ReconcileLateAttachPlan, hadI18n: boolean, hadLookup: boolean,
+): void {
+  const i18nJustAttached = !hadI18n && hasI18nBinding(coll)
+  const lookupJustAttached = !hadLookup && hasLookupBinding(coll)
+  if (!i18nJustAttached && !lookupJustAttached) return
+  const dictKeyFields = i18nJustAttached ? plan.effectiveViaFields.dictKeyFields : undefined
+  const i18nFieldsLate = i18nJustAttached ? plan.effectiveViaFields.i18nFields : undefined
+  const lookupFieldsLate = lookupJustAttached ? plan.effectiveViaFields.lookupFields : undefined
+  const snap = coll._viaFieldsSnapshot
+  const presentForJoin = buildPresentForJoin({ ...snap.i18nFields, ...i18nFieldsLate }, { ...snap.lookupFields, ...lookupFieldsLate }, buildSnapshotFor(vaultCtx))
+  coll._reconcileReadState({
+    ...(dictKeyFields !== undefined ? { dictKeyFields } : {}),
+    ...(i18nFieldsLate !== undefined ? { i18nFields: i18nFieldsLate } : {}),
+    ...(lookupFieldsLate !== undefined ? { lookupFields: lookupFieldsLate } : {}),
+    ...(dictKeyFields !== undefined || lookupFieldsLate !== undefined ? { getDictionary: async (n: string) => vaultCtx.dictionary(n) } : {}),
+    ...(presentForJoin !== undefined ? { presentForJoin } : {}),
+  })
+}
+
 /** The late-attach reconcile call's field-declaring options — the slice of `vault.collection()`'s
  *  `options` a reconcile call may carry, plus the `mergeViaFields` output that feeds both the
  *  guard and the money/i18n/dictKey/lookup reconciles. `blobFields` has no `_apply*` door (guard
@@ -438,6 +492,8 @@ export function reconcileViaAttach(
     commitReconcileGraphEdges(graph, name, reconcilePlan)
     applyTaintOverlay(coll, graph, name)
   }
+  const hadI18n = hasI18nBinding(coll)
+  const hadLookup = hasLookupBinding(coll)
   if (plan.effectiveViaFields.i18nFields !== undefined) {
     reconcileI18nFields(coll, vaultCtx, name, plan.effectiveViaFields.i18nFields, plan.effectiveViaFields.dictKeyFields)
   } else if (plan.effectiveViaFields.dictKeyFields !== undefined) {
@@ -452,4 +508,5 @@ export function reconcileViaAttach(
   if (plan.effectiveViaFields.lookupFields !== undefined) {
     reconcileLookupFields(coll, vaultCtx, graph, name, plan.effectiveViaFields.lookupFields)
   }
+  reconcileCollectionReadState(coll, vaultCtx, plan, hadI18n, hadLookup)
 }

--- a/packages/hub/src/kernel/via/taint-binding.ts
+++ b/packages/hub/src/kernel/via/taint-binding.ts
@@ -244,6 +244,11 @@ export function taintBinding(
             // them (not overwrite with the marker: the marker on `field` is the leak
             // signal, and inventing a `${field}Formatted` marker key that an un-redacted
             // read wouldn't always carry would be its own lie). Reviewed #669 finding.
+            // Deliberate over-redaction: a user-authored STORED field that happens to be
+            // named `${field}Formatted`/`${field}Number` beside a redacted virtual field is
+            // also stripped here — fails closed, no leak; the collision is pathological and
+            // narrowing it would require money-field knowledge this generic taint binding
+            // deliberately doesn't have.
             const formattedKey = `${field}Formatted`
             const numberKey = `${field}Number`
             if (formattedKey in out) delete out[formattedKey]

--- a/packages/hub/src/kernel/via/taint-binding.ts
+++ b/packages/hub/src/kernel/via/taint-binding.ts
@@ -237,6 +237,17 @@ export function taintBinding(
           if (field in out) {
             if (out === record) out = { ...record }
             out[field] = EXPORT_REDACTION_MARKER
+            // Money's presentLate (#669, `via/money/normalize.ts#presentVirtualMoneyFields`)
+            // dresses a virtual money field's fresh output into `<field>Formatted`/
+            // `<field>Number` companions BEFORE this present() (taint's) runs. Redacting
+            // only `field` leaves those companions holding the un-redacted value — DELETE
+            // them (not overwrite with the marker: the marker on `field` is the leak
+            // signal, and inventing a `${field}Formatted` marker key that an un-redacted
+            // read wouldn't always carry would be its own lie). Reviewed #669 finding.
+            const formattedKey = `${field}Formatted`
+            const numberKey = `${field}Number`
+            if (formattedKey in out) delete out[formattedKey]
+            if (numberKey in out) delete out[numberKey]
           }
         }
         return out

--- a/packages/hub/src/kernel/via/taint-binding.ts
+++ b/packages/hub/src/kernel/via/taint-binding.ts
@@ -244,15 +244,22 @@ export function taintBinding(
             // them (not overwrite with the marker: the marker on `field` is the leak
             // signal, and inventing a `${field}Formatted` marker key that an un-redacted
             // read wouldn't always carry would be its own lie). Reviewed #669 finding.
+            // `${field}Label` is the SAME companion shape for dictKey/lookup's label
+            // dressing (`via/i18n`/`via/lookup`'s `present()` hooks, same emission
+            // convention, same BEFORE-taint ordering) — a dict/lookup key is a closed
+            // vocabulary, so the label reveals the sealed value exactly (#671 review
+            // finding: `statusLabel: 'PAID-TH'` beside a redacted `status: '[sealed]'`).
             // Deliberate over-redaction: a user-authored STORED field that happens to be
-            // named `${field}Formatted`/`${field}Number` beside a redacted virtual field is
-            // also stripped here — fails closed, no leak; the collision is pathological and
-            // narrowing it would require money-field knowledge this generic taint binding
-            // deliberately doesn't have.
+            // named `${field}Formatted`/`${field}Number`/`${field}Label` beside a redacted
+            // virtual field is also stripped here — fails closed, no leak; the collision is
+            // pathological and narrowing it would require money/i18n/lookup-field knowledge
+            // this generic taint binding deliberately doesn't have.
             const formattedKey = `${field}Formatted`
             const numberKey = `${field}Number`
+            const labelKey = `${field}Label`
             if (formattedKey in out) delete out[formattedKey]
             if (numberKey in out) delete out[numberKey]
+            if (labelKey in out) delete out[labelKey]
           }
         }
         return out

--- a/packages/hub/src/via/lookup/handle.ts
+++ b/packages/hub/src/via/lookup/handle.ts
@@ -433,6 +433,14 @@ export class LookupHandle<Keys extends string = string> {
       newEnvelope,
     )
 
+    // #670 — publish newKey to the sync cache BEFORE step 3 rewrites referencing records: a
+    // vocabulary:'closed' referencing field's enforceWrite reads checkLookupMembership ->
+    // snapshotEntries() -> this._syncCache, so if newKey isn't a member yet, step 3's own write of
+    // newKey into those records self-refuses with UnknownLookupKeyError. Transition semantics:
+    // mid-rename BOTH oldKey and newKey are legitimately members (records are transitioning
+    // old->new during the rewrite) — oldKey stays a member until its removal completes below.
+    this._syncCache.set(newKey, newEntry)
+
     // 3. Update all referencing records in registered collections
     if (this.findAndUpdateReferences) {
       await this.findAndUpdateReferences(this.dictionaryName, oldKey, newKey)
@@ -448,9 +456,9 @@ export class LookupHandle<Keys extends string = string> {
       await this.adapter.delete(this.compartmentName, this.collName, oldKey)
     }
 
-    // Maintain synchronous cache for dict-join snapshot
+    // Maintain synchronous cache for dict-join snapshot — oldKey's removal from the cache lands
+    // here (after step 3), completing the old->new membership transition begun above.
     this._syncCache.delete(oldKey)
-    this._syncCache.set(newKey, newEntry)
 
     // #650 Task 4 (#647) — same choke-point ordering as put()/delete() above, for BOTH touches.
     // #647 fix wave 1: oldKey's dirty action is 'put' (not 'delete') — see delete()'s comment

--- a/packages/hub/src/via/money/binding.ts
+++ b/packages/hub/src/via/money/binding.ts
@@ -9,7 +9,7 @@
 import type { ViaBinding } from '../../kernel/via/index.js'
 import { installViaBinder } from '../../kernel/via/index.js'
 import type { MoneyDescriptor } from './descriptor.js'
-import { quantizeMoneyFields, decodeMoneyFields, canonicalizeStoredMoney, canonicalizeIncomingMoney, moneyScaledValue } from './normalize.js'
+import { quantizeMoneyFields, decodeMoneyFields, canonicalizeStoredMoney, canonicalizeIncomingMoney, moneyScaledValue, canonicalizeMoneyIndexKey } from './normalize.js'
 import { validateMoneyFieldPaths } from './paths.js'
 import { moneyFieldClause, evaluateMoneyClause, moneyIndexProbe, type MoneyWhereOperand } from './where.js'
 import { wrapMoneyReducers } from './money-reducer.js'
@@ -33,6 +33,7 @@ export function moneyBinding(moneyFields: Record<string, MoneyDescriptor>): ViaB
     },
     evaluateClause: (actual, op, payload) => evaluateMoneyClause(actual, op as Operator, payload as MoneyWhereOperand),
     indexProbe: (op, payload) => moneyIndexProbe(op as Operator, payload as MoneyWhereOperand),
+    canonicalizeIndexKey: (field, rawValue) => canonicalizeMoneyIndexKey(field, rawValue, moneyFields),
     decodeResults: (r) => decodeMoneyFields(r as Record<string, unknown>, moneyFields, 'raw'),
     compareForOrder: (field, a, b) => {
       const desc = moneyFields[field]

--- a/packages/hub/src/via/money/binding.ts
+++ b/packages/hub/src/via/money/binding.ts
@@ -6,18 +6,37 @@
  * `kernel/money-runtime.ts` seam used, now the only one (Task 6 cut the
  * query DSL over to this binding and deleted the legacy seam).
  */
-import type { ViaBinding } from '../../kernel/via/index.js'
+import type { ViaBinding, ViaReadCtx } from '../../kernel/via/index.js'
 import { installViaBinder } from '../../kernel/via/index.js'
 import type { MoneyDescriptor } from './descriptor.js'
-import { quantizeMoneyFields, decodeMoneyFields, canonicalizeStoredMoney, canonicalizeIncomingMoney, moneyScaledValue, canonicalizeMoneyIndexKey } from './normalize.js'
+import { quantizeMoneyFields, decodeMoneyFields, canonicalizeStoredMoney, canonicalizeIncomingMoney, moneyScaledValue, canonicalizeMoneyIndexKey, presentVirtualMoneyFields } from './normalize.js'
 import { validateMoneyFieldPaths } from './paths.js'
 import { moneyFieldClause, evaluateMoneyClause, moneyIndexProbe, type MoneyWhereOperand } from './where.js'
 import { wrapMoneyReducers } from './money-reducer.js'
 import type { Operator } from '../../kernel/query/predicate.js'
 import type { AggregateSpec } from '../../with-lookup/aggregate/aggregation.js'
 
-export function moneyBinding(moneyFields: Record<string, MoneyDescriptor>): ViaBinding {
+/** #669 — the money binder's config bag. `virtualMoneyFields` is the money∩virtual-mode-
+ *  computed field-name intersection (`kernel/collection-config.ts#resolveVirtualMoneyFields`);
+ *  absent/empty means no field on this collection composes money with a virtual computed
+ *  field on itself — the pre-#669 behavior (no `presentLate`, ordinary `present()` for
+ *  every declared money field). */
+export interface MoneyBindingConfig {
+  readonly moneyFields: Record<string, MoneyDescriptor>
+  readonly virtualMoneyFields?: ReadonlySet<string>
+}
+
+export function moneyBinding(moneyFields: Record<string, MoneyDescriptor>, virtualMoneyFields?: ReadonlySet<string>): ViaBinding {
   validateMoneyFieldPaths(moneyFields) // declaration-time (replaces sites 1 & 2)
+  const hasVirtualMoney = virtualMoneyFields !== undefined && virtualMoneyFields.size > 0
+  // #669 — a field that is BOTH money AND virtual-mode computed has no value yet when
+  // money's ORDINARY present() runs (money is first in `_presentOrder`, computed second —
+  // the #665 invariant); decodeMoneyFields already no-ops on an absent value, but the skip
+  // is made explicit here so the intent reads at the call site: dressing this field happens
+  // in `presentLate` below, once computed's present() has actually produced a value.
+  const ordinaryPresentFields = hasVirtualMoney
+    ? Object.fromEntries(Object.entries(moneyFields).filter(([f]) => !virtualMoneyFields.has(f)))
+    : moneyFields
   return {
     brand: 'money',
     posture: { encryptedAtRest: 'envelope', queryable: 'ordered', exportable: true, forgettable: true },
@@ -25,7 +44,13 @@ export function moneyBinding(moneyFields: Record<string, MoneyDescriptor>): ViaB
     ingest: (r) => canonicalizeIncomingMoney(r, moneyFields) as Record<string, unknown>,
     canonicalizeStored: (r) => canonicalizeStoredMoney(r, moneyFields) as Record<string, unknown>,
     encodeWrite: (r) => quantizeMoneyFields(r, moneyFields),
-    present: (r, ctx) => decodeMoneyFields(r, moneyFields, typeof ctx.locale === 'string' ? ctx.locale : undefined),
+    present: (r, ctx) => decodeMoneyFields(r, ordinaryPresentFields, typeof ctx.locale === 'string' ? ctx.locale : undefined),
+    ...(hasVirtualMoney
+      ? {
+          presentLate: (r: Record<string, unknown>, ctx: ViaReadCtx) =>
+            presentVirtualMoneyFields(r, moneyFields, virtualMoneyFields, typeof ctx.locale === 'string' ? ctx.locale : undefined),
+        }
+      : {}),
     buildClause: (field, op, value) => {
       const desc = moneyFields[field]
       if (!desc) return undefined
@@ -48,5 +73,8 @@ export function moneyBinding(moneyFields: Record<string, MoneyDescriptor>): ViaB
 }
 
 export function linkMoneyVia(): void {
-  installViaBinder('money', (cfg) => moneyBinding(cfg as Record<string, MoneyDescriptor>))
+  installViaBinder('money', (cfg) => {
+    const c = cfg as MoneyBindingConfig
+    return moneyBinding(c.moneyFields, c.virtualMoneyFields)
+  })
 }

--- a/packages/hub/src/via/money/normalize.ts
+++ b/packages/hub/src/via/money/normalize.ts
@@ -184,6 +184,30 @@ export function moneyScaledValue(stored: unknown, desc: MoneyDescriptor): bigint
 }
 
 /**
+ * The `ViaBinding.canonicalizeIndexKey` implementation for money (#672) —
+ * bucket an eager index's money field entries by the BigInt-normalized
+ * scaled-int string, not the raw stored bytes, so a pre-declaration /
+ * non-canonical value (e.g. `'0100'`) lands under the SAME key a canonical
+ * write produces (`'100'`). Only FIXED-mode declared money fields
+ * participate — multi-mode stores `{ amount, currency }`, which has no
+ * single bucketable scalar (mirrors `moneyIndexProbe`'s fixed-only gate,
+ * `via/money/where.ts`). `undefined` when `field` isn't a declared
+ * fixed-mode money field, or the stored value doesn't parse — in both
+ * cases the caller falls back to the raw stringified bucket, which is
+ * exactly what the scan (`evaluateMoneyClause`) also treats as a
+ * non-match, preserving fast-path/scan parity.
+ */
+export function canonicalizeMoneyIndexKey(
+  field: string,
+  rawValue: unknown,
+  moneyFields: Record<string, MoneyDescriptor>,
+): string | undefined {
+  const desc = moneyFields[field]
+  if (!desc || desc.mode !== 'fixed') return undefined
+  return moneyScaledValue(rawValue, desc)?.toString()
+}
+
+/**
  * Decode ONE stored field value to its read shape, or `null` when the
  * stored value is malformed (defensive — never brick a read).
  */

--- a/packages/hub/src/via/money/normalize.ts
+++ b/packages/hub/src/via/money/normalize.ts
@@ -244,6 +244,55 @@ function decodeValue(
 }
 
 /**
+ * money's `presentLate` hook (#669) — for each field in `virtualMoney` (money ∩
+ * virtual-mode computed on the SAME field), quantize the computed fn's fresh
+ * MAJOR-UNITS output to the descriptor's scale (with its declared rounding)
+ * and present it EXACTLY like a stored money field: the exact decimal string
+ * (via {@link formatScaledInt}), plus `<field>Formatted`/`<field>Number` when
+ * `locale !== 'raw'`. NEVER the scaled-int decode {@link decodeMoneyFields}
+ * runs for a genuinely-stored value — that would misread a virtual field's
+ * raw major-unit `21` as 21 SCALED units (`'0.21'`, the #665 corruption this
+ * must not reintroduce). Runs AFTER computed's `present()` (the pipeline's
+ * `presentLate` fold point, `kernel/via/pipeline.ts`), so `record[field]`
+ * already holds the fn's fresh output by the time this runs.
+ *
+ * Absent/null value → left untouched (nothing to dress). Unparseable value
+ * (fails `parseToScaledInt` — e.g. excess precision with no declared
+ * rounding) → left RAW, no throw: read-time dressing must never brick a
+ * read. Fixed-mode fields only — a virtual field's computed output has no
+ * natural `{ amount, currency }` shape to parse for multi-currency mode.
+ */
+export function presentVirtualMoneyFields<T extends Record<string, unknown>>(
+  record: T,
+  moneyFields: Record<string, MoneyDescriptor>,
+  virtualMoney: ReadonlySet<string>,
+  locale: string | undefined,
+): T {
+  let out: Record<string, unknown> = record
+  const format = locale !== 'raw'
+  const fmtLocale = typeof locale === 'string' && locale !== 'raw' ? locale : 'en-US'
+  for (const field of virtualMoney) {
+    const desc = moneyFields[field]
+    if (!desc || desc.mode !== 'fixed') continue
+    const raw = out[field]
+    if (raw === null || raw === undefined) continue
+    if (typeof raw !== 'number' && typeof raw !== 'string') continue
+    const currency = desc.fixedCurrency!
+    const scale = desc.scaleFor(currency)
+    const r = parseToScaledInt(raw, scale, desc.rounding)
+    if (!r.ok) continue // unparseable / excess precision with no rounding declared — leave raw, no throw
+    if (out === record) out = { ...record }
+    const decimal = formatScaledInt(r.value, scale)
+    out[field] = decimal
+    if (format) {
+      out[`${field}Formatted`] = formatCurrency(decimal, currency, scale, fmtLocale)
+      out[`${field}Number`] = Number(decimal)
+    }
+  }
+  return out as T
+}
+
+/**
  * Convert money fields in `record` from stored form to the read shape:
  * an exact decimal string, plus `<field>Formatted` / `<field>Number`
  * virtuals when `locale !== 'raw'`. Returns a shallow clone (deep along

--- a/packages/hub/src/via/money/where.ts
+++ b/packages/hub/src/via/money/where.ts
@@ -153,21 +153,19 @@ export function moneyFieldClause(
  *   single stored-form value the hash index can serve, so they return
  *   `undefined` too — the caller falls back to a scan.
  *
- * MIXED-ERA CAVEAT: byte-exactness above holds for every record written
- * through the money write path (`quantizeMoneyFields`), which always
- * produces a canonical BigInt digit string. A record whose stored value
- * predates the field's `money()` declaration, or otherwise bypassed
- * `quantizeMoneyFields`, may hold a NON-canonical scaled string (e.g.
- * `'0100'` instead of `'100'`) — the index buckets it under that raw
- * string (`CollectionIndexes#addToIndex` reads the field verbatim, no
- * BigInt re-parse), so an `==`/`in` probe for the canonical `'100'` misses
- * it, while the fallback scan (`evaluateMoneyClause`'s `readStored`, which
- * DOES re-parse via `BigInt(actual).toString()`) still matches it. The fast
- * path is therefore byte-exact for the canonical (money-write-path) subset
- * of records, not literally every stored byte sequence; a re-`put()` of the
- * legacy record canonicalizes it going forward. A money-aware index-key
- * canonicalization (bucket by the BigInt-normalized form, not the raw
- * string) would close this gap — filed as a follow-up, not fixed here.
+ * MIXED-ERA DATA (#672, fixed): a record whose stored value predates the
+ * field's `money()` declaration, or otherwise bypassed `quantizeMoneyFields`,
+ * may hold a NON-canonical scaled string (e.g. `'0100'` instead of `'100'`).
+ * `CollectionIndexes#addToIndex`/`build` no longer bucket it under that raw
+ * string verbatim — they first consult `ViaPipeline.canonicalizeIndexKey`
+ * (money's implementation: `canonicalizeMoneyIndexKey`, `via/money/
+ * normalize.ts`), which re-parses the stored value the same way the scan's
+ * `evaluateMoneyClause`/`readStored` does (`BigInt(actual).toString()`), so
+ * the legacy record lands in the SAME bucket a canonical write produces and
+ * an `==`/`in` probe for `'100'` finds it. The two-string byte-identity
+ * argument above still explains WHY a canonical write's probe hits directly
+ * (no canonicalization needed for the common case); this note only covers
+ * the pre-declaration tail.
  */
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 export function moneyIndexProbe(op: Operator, payload: MoneyWhereOperand): unknown | undefined {

--- a/packages/hub/src/via/money/where.ts
+++ b/packages/hub/src/via/money/where.ts
@@ -153,19 +153,30 @@ export function moneyFieldClause(
  *   single stored-form value the hash index can serve, so they return
  *   `undefined` too — the caller falls back to a scan.
  *
- * MIXED-ERA DATA (#672, fixed): a record whose stored value predates the
- * field's `money()` declaration, or otherwise bypassed `quantizeMoneyFields`,
- * may hold a NON-canonical scaled string (e.g. `'0100'` instead of `'100'`).
- * `CollectionIndexes#addToIndex`/`build` no longer bucket it under that raw
- * string verbatim — they first consult `ViaPipeline.canonicalizeIndexKey`
- * (money's implementation: `canonicalizeMoneyIndexKey`, `via/money/
- * normalize.ts`), which re-parses the stored value the same way the scan's
- * `evaluateMoneyClause`/`readStored` does (`BigInt(actual).toString()`), so
- * the legacy record lands in the SAME bucket a canonical write produces and
- * an `==`/`in` probe for `'100'` finds it. The two-string byte-identity
- * argument above still explains WHY a canonical write's probe hits directly
- * (no canonicalization needed for the common case); this note only covers
- * the pre-declaration tail.
+ * MIXED-ERA DATA (#672, fixed — including the #672 review's C1 finding): a
+ * record whose stored value predates the field's `money()` declaration, or
+ * otherwise bypassed `quantizeMoneyFields`, may hold a NON-canonical scaled
+ * string (e.g. `'0100'` instead of `'100'`). `CollectionIndexes` no longer
+ * buckets it under that raw string verbatim at ANY bucket-mutation site —
+ * `build`, `upsert`, and `remove` all consult the same registered
+ * canonicalizer (`ViaPipeline.canonicalizeIndexKey`; money's implementation:
+ * `canonicalizeMoneyIndexKey`, `via/money/normalize.ts`), which re-parses the
+ * stored value the same way the scan's `evaluateMoneyClause`/`readStored`
+ * does (`BigInt(actual).toString()`). So the legacy record lands in the SAME
+ * bucket a canonical write produces, an `==`/`in` probe for `'100'` finds it,
+ * and — because add and remove now agree on that bucket — a later `put()`
+ * (update) or `delete()` of that same legacy record cleans up the correct
+ * bucket instead of stranding the id under a bucket the removal could never
+ * reach. The two-string byte-identity argument above still explains WHY a
+ * canonical write's probe hits directly (no canonicalization needed for the
+ * common case); this note covers the pre-declaration tail.
+ *
+ * Boundary: this guarantee is EAGER-mode only (`CollectionIndexes`, this
+ * file's index probe). LAZY mode's `PersistedCollectionIndex`
+ * (`with-lookup/indexing/persisted-indexes.ts`) keeps its own raw bucketing
+ * and does not consult money canonicalization — a lazy-mode mixed-era record
+ * can still diverge between its fast path and a forced scan. Tracked
+ * separately, not fixed here.
  */
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 export function moneyIndexProbe(op: Operator, payload: MoneyWhereOperand): unknown | undefined {

--- a/packages/hub/src/with-lookup/aggregate/groupby.ts
+++ b/packages/hub/src/with-lookup/aggregate/groupby.ts
@@ -298,7 +298,7 @@ export function groupAndReduce<R>(
   // kernel's Via port rather than a Query-attached pipeline — `moneyFields`
   // here is the MV spec's OWN descriptor map, not a collection's.
   if (moneyFields) {
-    spec = viaBinder('money')(moneyFields).wrapReducers!(spec) as AggregateSpec
+    spec = viaBinder('money')({ moneyFields }).wrapReducers!(spec) as AggregateSpec
   }
 
   // Bucket value is { keyValues, records } so the output row can stamp

--- a/packages/hub/src/with-lookup/indexing/collection-facade.ts
+++ b/packages/hub/src/with-lookup/indexing/collection-facade.ts
@@ -50,6 +50,12 @@ export interface IndexingContext<T> {
   readonly uniqueConstraints: UniqueConstraintSet | null
   /** The lazy-mode persisted-index mirror, or null (SHARED reference). */
   readonly persistedIndexes: PersistedCollectionIndex | null
+  /**
+   * Canonicalize a raw stored field value to its eager-index bucket key
+   * (#672 — money-aware via `ViaPipeline.canonicalizeIndexKey`). `undefined`
+   * when no `via` pipeline is compiled, or no binding claims the field.
+   */
+  readonly canonicalizeIndexKey?: (field: string, value: unknown) => string | undefined
   /** Hydrate the eager cache before rebuilding from it. */
   ensureHydrated(): Promise<void>
   /** Bulk-load the persisted-index mirror from side-cars (lazy mode). */
@@ -142,7 +148,7 @@ export function rebuildEagerIndexesFromCache<T>(ctx: IndexingContext<T>): void {
   for (const [id, entry] of ctx.cache) {
     snapshot.push({ id, record: entry.record })
   }
-  eager.build(snapshot)
+  eager.build(snapshot, ctx.canonicalizeIndexKey)
 }
 
 /**

--- a/packages/hub/src/with-lookup/indexing/collection-facade.ts
+++ b/packages/hub/src/with-lookup/indexing/collection-facade.ts
@@ -50,12 +50,6 @@ export interface IndexingContext<T> {
   readonly uniqueConstraints: UniqueConstraintSet | null
   /** The lazy-mode persisted-index mirror, or null (SHARED reference). */
   readonly persistedIndexes: PersistedCollectionIndex | null
-  /**
-   * Canonicalize a raw stored field value to its eager-index bucket key
-   * (#672 — money-aware via `ViaPipeline.canonicalizeIndexKey`). `undefined`
-   * when no `via` pipeline is compiled, or no binding claims the field.
-   */
-  readonly canonicalizeIndexKey?: (field: string, value: unknown) => string | undefined
   /** Hydrate the eager cache before rebuilding from it. */
   ensureHydrated(): Promise<void>
   /** Bulk-load the persisted-index mirror from side-cars (lazy mode). */
@@ -148,7 +142,7 @@ export function rebuildEagerIndexesFromCache<T>(ctx: IndexingContext<T>): void {
   for (const [id, entry] of ctx.cache) {
     snapshot.push({ id, record: entry.record })
   }
-  eager.build(snapshot, ctx.canonicalizeIndexKey)
+  eager.build(snapshot)
 }
 
 /**

--- a/packages/hub/src/with-lookup/indexing/eager-indexes.ts
+++ b/packages/hub/src/with-lookup/indexing/eager-indexes.ts
@@ -63,6 +63,26 @@ export class CollectionIndexes {
   private readonly indexes = new Map<string, HashIndex>()
 
   /**
+   * Per-field bucket-key canonicalizer (#672 review C1), registered ONCE
+   * via {@link setCanonicalizer} when the collection wires indexing up
+   * (money-aware via `ViaPipeline.canonicalizeIndexKey`). Consulted by
+   * EVERY bucket-mutation site — `build`/`upsert`/`remove` — so bucket
+   * membership is symmetric by construction: a value can never be added
+   * under a canonical key and later removed under the raw one (or vice
+   * versa), which is what stranded ids on `put`/`delete` before this fix.
+   */
+  private canonicalize?: (field: string, value: unknown) => string | undefined
+
+  /**
+   * Register the bucket-key canonicalizer. Called once, where the
+   * collection constructs its indexing state — safe to call again (the
+   * closure is simply replaced) but there is normally only one caller.
+   */
+  setCanonicalizer(fn: (field: string, value: unknown) => string | undefined): void {
+    this.canonicalize = fn
+  }
+
+  /**
    * Declare an index. Subsequent record additions are tracked under it.
    * Calling this twice for the same field is a no-op (idempotent).
    */
@@ -83,22 +103,14 @@ export class CollectionIndexes {
 
   /**
    * Build all declared indexes from a snapshot of records.
-   * Called once per hydration. O(N × indexes.size).
-   *
-   * `canonicalize` (#672) — an optional per-field bucket-key canonicalizer
-   * (money-aware via `ViaPipeline.canonicalizeIndexKey`), consulted before
-   * the raw `stringifyKey` fallback so a pre-declaration / non-canonical
-   * stored value (e.g. a legacy `'0100'`) is bucketed under the same key a
-   * canonical write produces.
+   * Called once per hydration. O(N × indexes.size). Buckets through the
+   * registered {@link setCanonicalizer} closure, same as `upsert`/`remove`.
    */
-  build<T>(
-    records: ReadonlyArray<{ id: string; record: T }>,
-    canonicalize?: (field: string, value: unknown) => string | undefined,
-  ): void {
+  build<T>(records: ReadonlyArray<{ id: string; record: T }>): void {
     for (const idx of this.indexes.values()) {
       idx.buckets.clear()
       for (const { id, record } of records) {
-        addToIndex(idx, id, record, canonicalize)
+        addToIndex(idx, id, record, this.canonicalize)
       }
     }
   }
@@ -116,7 +128,7 @@ export class CollectionIndexes {
       this.remove(id, previousRecord)
     }
     for (const idx of this.indexes.values()) {
-      addToIndex(idx, id, newRecord)
+      addToIndex(idx, id, newRecord, this.canonicalize)
     }
   }
 
@@ -127,7 +139,7 @@ export class CollectionIndexes {
   remove<T>(id: string, record: T): void {
     if (this.indexes.size === 0) return
     for (const idx of this.indexes.values()) {
-      removeFromIndex(idx, id, record)
+      removeFromIndex(idx, id, record, this.canonicalize)
     }
   }
 

--- a/packages/hub/src/with-lookup/indexing/eager-indexes.ts
+++ b/packages/hub/src/with-lookup/indexing/eager-indexes.ts
@@ -84,12 +84,21 @@ export class CollectionIndexes {
   /**
    * Build all declared indexes from a snapshot of records.
    * Called once per hydration. O(N × indexes.size).
+   *
+   * `canonicalize` (#672) — an optional per-field bucket-key canonicalizer
+   * (money-aware via `ViaPipeline.canonicalizeIndexKey`), consulted before
+   * the raw `stringifyKey` fallback so a pre-declaration / non-canonical
+   * stored value (e.g. a legacy `'0100'`) is bucketed under the same key a
+   * canonical write produces.
    */
-  build<T>(records: ReadonlyArray<{ id: string; record: T }>): void {
+  build<T>(
+    records: ReadonlyArray<{ id: string; record: T }>,
+    canonicalize?: (field: string, value: unknown) => string | undefined,
+  ): void {
     for (const idx of this.indexes.values()) {
       idx.buckets.clear()
       for (const { id, record } of records) {
-        addToIndex(idx, id, record)
+        addToIndex(idx, id, record, canonicalize)
       }
     }
   }
@@ -182,10 +191,15 @@ function stringifyKey(value: unknown): string {
   return '\0OBJECT\0'
 }
 
-function addToIndex<T>(idx: HashIndex, id: string, record: T): void {
+function addToIndex<T>(
+  idx: HashIndex,
+  id: string,
+  record: T,
+  canonicalize?: (field: string, value: unknown) => string | undefined,
+): void {
   const value = readPath(record, idx.field)
   if (value === null || value === undefined) return
-  const key = stringifyKey(value)
+  const key = canonicalize?.(idx.field, value) ?? stringifyKey(value)
   let bucket = idx.buckets.get(key)
   if (!bucket) {
     bucket = new Set()
@@ -194,10 +208,15 @@ function addToIndex<T>(idx: HashIndex, id: string, record: T): void {
   bucket.add(id)
 }
 
-function removeFromIndex<T>(idx: HashIndex, id: string, record: T): void {
+function removeFromIndex<T>(
+  idx: HashIndex,
+  id: string,
+  record: T,
+  canonicalize?: (field: string, value: unknown) => string | undefined,
+): void {
   const value = readPath(record, idx.field)
   if (value === null || value === undefined) return
-  const key = stringifyKey(value)
+  const key = canonicalize?.(idx.field, value) ?? stringifyKey(value)
   const bucket = idx.buckets.get(key)
   if (!bucket) return
   bucket.delete(id)


### PR DESCRIPTION
Completes milestone #32 (Via follow-ups 2): four fixes, each TDD'd behind its own review gate, plus a whole-branch adversarial final review with mutation probes.

Closes #669
Closes #670
Closes #671
Closes #672

## What changed

**#670 — `LookupHandle.rename()` no longer self-refuses on closed vocabularies.** The new key is published to the write-through sync cache BEFORE referencing records are rewritten, so `enforceWrite`'s membership check sees it; mid-rename both keys are legitimately members (records transition old→new), and the old key leaves the cache only after its removal completes. Mid-flight-failure note: the cache now shows both keys on a partial failure, which matches on-disk reality (the new envelope is durably written first).

**#672 — money-aware eager-index key canonicalization.** New generic `ViaBinding.canonicalizeIndexKey` hook (folded by `ViaPipeline`, same discipline as the clause fold); money implements it via the BigInt canonical core for fixed-mode fields. The canonicalizer is stored ONCE on `CollectionIndexes` (`setCanonicalizer`, registered in the `Collection` constructor, reading `this.via` lazily so late-attach is honored) — every bucket-mutation site (build/upsert/remove/delete + rebuild-on-hydrate) is symmetric by construction. Mixed-era data (`'0100'` legacy + `'100'` canonical) now returns identically on the fast path and the scan, spy-proven, including under mutation (update/delete/recreate). Boundary: lazy-mode `PersistedCollectionIndex` keeps its own raw bucketing (pre-existing, follow-up filed).

**#669 — money dresses a virtual computed field's own output as MAJOR UNITS** (ratified design). New `ViaBinding.presentLate` slot runs after the money+computed present segments and before the rest segment, so lookup/i18n dressing and taint redaction see dressed values. The composed grammar `via(computed(fn, {mode:'virtual'}), money(...))` now presents the fn's return quantized to the currency scale (`21` → `'21.00'`, `Formatted` under a real locale, `Number`); unparseable output stays raw, no read-time throw. The #665 `'0.21'` corruption fence is unchanged and the three-way present partition (money stored-decode before computed) is untouched. Late-attach parity: `_applyMoneyFields` derives the same money∩virtual intersection from the compiled computed binding.

**#671 — late-attach (reconcile) residuals closed.** (4) `_applyMoneyFields`/`_applyClassifiedFields` thread the taint overlay through their pipeline rebuilds — a money-only late-attach no longer silently drops derived-taint postures. (5) `assertAcyclic` filters `kind:'ref'` edges (mutual FK lookups are legal; ref edges are cascade/rename machinery), pinned on both the own and wildcard-inherited slices. (1-3) One writer seam `Collection._reconcileReadState` lets reconcile refresh the construction-frozen read state: `describe()`'s legacy field lists, `getDictionary`-backed label resolution (describeAsync + search index), and `presentForJoin` rebuilt over the union of construction-time and late-attached fields. Housekeeping rider (shared builder for the "must move together" closure pairs) deliberately deferred — convention-hardening that would churn the zero-slack vault.ts.

**Security hardening found by the reviews themselves:** taint redaction now strips a redacted field's presentation companions — `Formatted`/`Number` (money) and `Label` (dictKey/lookup) — closing two sibling-leak paths where a sealed-derived virtual value survived redaction through its dressing companions (`{ leak: "[sealed]", leakFormatted: "€21.00" }` and the exact-reveal `statusLabel` variant). Export and aggregate paths verified unaffected (they consume post-present records / raw stored form respectively). Over-redaction of pathologically name-colliding user fields is deliberate and documented (fails closed).

## Review

Final whole-branch review ran adversarial mutation probes against every task's load-bearing line (8 probes: 6 bit immediately, 2 exposed test-fence gaps that are now pinned), re-verified the zero-slack ceilings (4472/3939/2385 exact), the #665 corruption fence, empty via-layering/via-enclave-isolation allowlists, commit hygiene, and changeset absence. Cross-task interactions (the shared `_applyMoneyFields` edits, the canonicalizer closure across pipeline rebuilds, the read-state writer vs the family first-wins gates) verified coherent; docs match the final code.

Recorded-and-deferred (follow-ups filed): lazy-mode index canonicalization gap; `ViaGraph._in` single-slot kind overwrite for dual-role targets; `_viaFieldsSnapshot` live references (sole caller read-only); presentForJoin/readState opposite merge directions (unreachable by the first-wins gates).

## Gauntlet at HEAD

Full hub suite green (487 files / 3,944+ tests incl. the three new fence pins), typecheck, lint, `check:architecture`, env-free build + bundle-check. Ceilings exact: 4472/3939/2385. Changeset authored locally per repo convention (hub minor).
