### PR TITLE
fix(hub): milestone #33 — via follow-ups 3 (#677 #678)

### DIFF
--- a/docs/subsystems/via-lookup.md
+++ b/docs/subsystems/via-lookup.md
@@ -281,6 +281,19 @@ rule the #664 collision guard already enforces upstream) plus a rebuilt `getDict
 `packages/hub/__tests__/via/graph.test.ts` (item 5). A late-attach consumer no longer needs to
 fall back to declaring these fields at fresh construction instead.
 
+**Follow-up latent hazard in the item 5 fix (#678).** The item 5 filter (`kind !== 'ref'`)
+originally read that `kind` back off the TARGET's `_in` entry — its CURRENT, possibly-overwritten
+registration — instead of the specific `_out` edge's own kind at registration time. A dual-role
+target registered computed-then-ref (#631's exempt composition order) has its `_in` entry's
+`kind` overwritten from `'computed'` to `'ref'` by the second `registerDerived` call, so the
+filter wrongly excluded that target's genuine computed edge from the cycle-detection DFS — hiding
+a real derivation cycle running through it. Fixed: `_out` edges now carry their own `kind` at
+registration (`ViaGraph`'s `OutEdge`), and both `assertAcyclic`'s `notRefEdge` filter and
+`referencingEdgesOf` read `kind` edge-local instead of re-derefing `_in`. Latent in production
+today — `assertAcyclic()` runs once at `openVault()`, strictly before any `vault.collection()`
+call populates `_in`/`_out` — this is a regression guard for a future reachable path, not an
+observed failure. See `packages/hub/__tests__/via/graph.test.ts`'s "dual-role target" test.
+
 ## Presentation — `<field>Label`, in reads and in joins
 
 Reading with a locale resolves `<field>Label` on the SAME record (direct `present()`, works for

--- a/docs/subsystems/via-money.md
+++ b/docs/subsystems/via-money.md
@@ -103,10 +103,13 @@ index-accelerated fast path for `where(field, '==', ...)` and `where(field, 'in'
 **fixed mode only** — `ViaBinding.indexProbe` hands the query builder the exact STORED-form
 scaled-integer digit string (the same one `quantizeMoneyFields` writes), so the index bucket
 lookup (`CollectionIndexes.lookupEqual`/`lookupIn`) hits directly instead of falling back to a
-full scan. Multi-currency (`currencies:`) fields always scan in both modes — there is no single
+full scan. Multi-currency (`currencies:`) fields always scan in **eager** mode — there is no single
 stored-form value a hash index can serve for a `{ amount, currency }` shape
 (`packages/hub/__tests__/money/where-comparison.test.ts`, "indexed fast path agrees with the scan"
-describe block, spy-proven against `lookupEqual`/`lookupIn`). Range/`between` always scan in EAGER
+describe block, spy-proven against `lookupEqual`/`lookupIn`). On **lazy** mode there is no scan
+fallback: a multi-currency clause dispatches raw through `lookupEqual`/`lookupIn` (the `{ amount,
+currency }` object buckets under `\0OBJECT\0`), so end-to-end correctness there is bounded by the
+same `LazyQuery` Via-awareness gap as fixed-mode — tracked in #684. Range/`between` always scan in EAGER
 mode (no range probe is ever emitted); LAZY mode's range behavior is different — see below.
 
 **Mixed-era data (#672).** A record whose stored value predates the field's `money()`

--- a/docs/subsystems/via-money.md
+++ b/docs/subsystems/via-money.md
@@ -103,10 +103,11 @@ index-accelerated fast path for `where(field, '==', ...)` and `where(field, 'in'
 **fixed mode only** — `ViaBinding.indexProbe` hands the query builder the exact STORED-form
 scaled-integer digit string (the same one `quantizeMoneyFields` writes), so the index bucket
 lookup (`CollectionIndexes.lookupEqual`/`lookupIn`) hits directly instead of falling back to a
-full scan. Multi-currency (`currencies:`) fields and every operator besides `==`/`in`
-(`between`, range comparisons) always scan — there is no single stored-form value a hash index
-can serve for those (`packages/hub/__tests__/money/where-comparison.test.ts`, "indexed fast path
-agrees with the scan" describe block, spy-proven against `lookupEqual`/`lookupIn`).
+full scan. Multi-currency (`currencies:`) fields always scan in both modes — there is no single
+stored-form value a hash index can serve for a `{ amount, currency }` shape
+(`packages/hub/__tests__/money/where-comparison.test.ts`, "indexed fast path agrees with the scan"
+describe block, spy-proven against `lookupEqual`/`lookupIn`). Range/`between` always scan in EAGER
+mode (no range probe is ever emitted); LAZY mode's range behavior is different — see below.
 
 **Mixed-era data (#672).** A record whose stored value predates the field's `money()`
 declaration, or otherwise bypassed the money write path, may hold a non-canonical scaled string
@@ -128,22 +129,31 @@ review).
 `resolveCandidateIds()`) canonicalizes an `==`/`in` probe value before calling
 `lookupEqual`/`lookupIn` — mirroring the eager path's `candidateRecords()` resolving
 `clause.via.indexValue` before its own lookup. A legacy non-canonical record and a canonical one
-now land in, and are found via, the same bucket on the lazy fast path too. Range/`between` stay
-scan-only on lazy mode exactly as on eager (`PersistedCollectionIndex.lookupRange` compares
-original typed values, not bucket keys — canonicalization doesn't apply there on either mode).
+now land in, and are found via, the same bucket on the lazy fast path too. Range/`between` do
+**not** behave the same across modes: eager mode's `moneyIndexProbe` never emits a range probe, so
+`candidateRecords()` never calls an index for a money range clause and always scans. Lazy mode's
+`resolveCandidateIds()` dispatches EVERY range clause — including money fields — through
+`PersistedCollectionIndex.lookupRange` unconditionally, with **no scan fallback**; the comparison
+is on the raw, uncanonicalized typed value, so a money field's lazy-mode range correctness (e.g.
+mixed-era or non-canonical stored values) is a live, pre-existing gap, tracked in #684.
 Because a lazy-mode legacy record predating the field's `indexes: [...]` declaration has no
 `_idx/<field>/*` side-car at all until backfilled, `reconcileOnOpen: 'auto'` (or an explicit
 `collection.reconcileIndex()`/`rebuildIndexes()` call) is required for such a record to become
 visible to the fast path.
 
-**Residual boundary, not fixed by #677.** `LazyQuery`'s post-filter (`lazy-builder.ts`'s
-`matchesAll`) re-evaluates every clause — including the index-driving one — against the DECODED
-record (`getRecord()` runs `via.present()`), via the generic (non-Via-aware) `evaluateClause`,
-because `LazyQuery.where()` never builds a `clause.via` the way `Query.where()`/`ScanBuilder.
-where()` do. So `lazyQuery().where(moneyField, ...)` still needs the query value passed in the
-field's STORED (canonical scaled-int) form, not major units, for the fast path to be reachable at
-all — full parity with `scan().where()` (which quantizes major units via `buildClause`) is a
-separate, tracked follow-up, not a canonicalization gap.
+**Residual boundary, not fixed by #677 — tracked in #684.** `LazyQuery`'s post-filter
+(`lazy-builder.ts`'s `matchesAll`) re-evaluates every clause — including the index-driving one —
+against the DECODED record (`getRecord()` runs `via.present()`), via the generic (non-Via-aware)
+`evaluateClause`, because `LazyQuery.where()` never builds a `clause.via` the way
+`Query.where()`/`ScanBuilder.where()` do. At `scale: 0` this doesn't surface (decode is an
+identity transform). At `scale > 0` it does, and it is NOT merely a "pass the stored form"
+workaround: even a query value spelled correctly in the field's STORED (canonical scaled-int)
+form reaches the right candidate ids via the index, but the post-filter then compares that same
+raw value against the DECODED record (e.g. `'100'` vs `'1.00'`) and rejects every match. **The
+practical result: `lazyQuery().where(moneyField, ...).toArray()` returns an empty array
+end-to-end for any money field with `scale > 0`, regardless of how the query value is spelled.**
+Only the index layer itself (bucket + probe canonicalization, #677) is fixed today; full parity
+with `scan().where()` (Via-aware post-filtering, major-unit quantization) is tracked in #684.
 
 ## See also
 

--- a/docs/subsystems/via-money.md
+++ b/docs/subsystems/via-money.md
@@ -120,10 +120,30 @@ and `delete()` (remove) — so updating or deleting a legacy record cleans up it
 correctly instead of stranding the id there (a gap the initial #672 fix left open, closed in
 review).
 
-**Boundary: eager mode only.** Lazy-mode collections (`prefetch: false`) keep their own durable
-`PersistedCollectionIndex` side-cars, which bucket by the raw stored value and do not consult
-money canonicalization. A lazy-mode collection with mixed-era money data can still see its fast
-path diverge from a forced scan; that gap is tracked separately, not fixed here.
+**Lazy mode (#677).** Lazy-mode collections (`prefetch: false`) keep their own durable
+`PersistedCollectionIndex` side-cars — a separate implementation from the eager
+`CollectionIndexes`, but now with the SAME canonicalization guarantee. Every bucket-mutation site
+(`ingest` bulk-load from side-cars, `upsert`, `remove`) consults the same registered
+`ViaPipeline.canonicalizeIndexKey`, and the lazy query planner (`lazy-builder.ts`'s
+`resolveCandidateIds()`) canonicalizes an `==`/`in` probe value before calling
+`lookupEqual`/`lookupIn` — mirroring the eager path's `candidateRecords()` resolving
+`clause.via.indexValue` before its own lookup. A legacy non-canonical record and a canonical one
+now land in, and are found via, the same bucket on the lazy fast path too. Range/`between` stay
+scan-only on lazy mode exactly as on eager (`PersistedCollectionIndex.lookupRange` compares
+original typed values, not bucket keys — canonicalization doesn't apply there on either mode).
+Because a lazy-mode legacy record predating the field's `indexes: [...]` declaration has no
+`_idx/<field>/*` side-car at all until backfilled, `reconcileOnOpen: 'auto'` (or an explicit
+`collection.reconcileIndex()`/`rebuildIndexes()` call) is required for such a record to become
+visible to the fast path.
+
+**Residual boundary, not fixed by #677.** `LazyQuery`'s post-filter (`lazy-builder.ts`'s
+`matchesAll`) re-evaluates every clause — including the index-driving one — against the DECODED
+record (`getRecord()` runs `via.present()`), via the generic (non-Via-aware) `evaluateClause`,
+because `LazyQuery.where()` never builds a `clause.via` the way `Query.where()`/`ScanBuilder.
+where()` do. So `lazyQuery().where(moneyField, ...)` still needs the query value passed in the
+field's STORED (canonical scaled-int) form, not major units, for the fast path to be reachable at
+all — full parity with `scan().where()` (which quantizes major units via `buildClause`) is a
+separate, tracked follow-up, not a canonicalization gap.
 
 ## See also
 

--- a/docs/subsystems/via.md
+++ b/docs/subsystems/via.md
@@ -487,8 +487,11 @@ STORED-form operand for a direct index bucket lookup on `==`/`in`, restoring the
 originally lost for money fields (multi-currency money and every other operator still scan — there
 is no single stored-form value a hash index can serve for those). The initial mixed-era caveat for
 pre-money-declaration legacy data was closed for eager-mode collections by #672's index-key
-canonicalizer (documented on the money page); a lazy-mode (`prefetch: false`) boundary remains,
-tracked separately.
+canonicalizer, and for lazy-mode (`prefetch: false`) collections by #677's matching
+`PersistedCollectionIndex` bucket + probe canonicalizer (documented on the money page). A
+separate lazy-mode boundary remains: `LazyQuery.where()` doesn't build a `clause.via`, so
+end-to-end lazy money `==`/`in` queries at `scale > 0` still return an empty `.toArray()` —
+tracked in #684.
 
 ## See also
 

--- a/docs/superpowers/plans/2026-07-14-m33-via-followups-3.md
+++ b/docs/superpowers/plans/2026-07-14-m33-via-followups-3.md
@@ -1,0 +1,76 @@
+# Milestone #33 — Via follow-ups 3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close milestone #33 — #678 (ViaGraph `_in` single-slot kind overwrite hides a derivation edge from `assertAcyclic`) and #677 (lazy-mode `PersistedCollectionIndex` never canonicalizes or probes money index keys — the lazy twin of #672's eager fix).
+
+**Architecture:** Ground truth is `.superpowers/sdd/m33-seam-map.md` — every call site, line, and excerpt. #678 is contained in `kernel/via/graph.ts` (unbudgeted). #677 spans `with-lookup/indexing/persisted-indexes.ts` + `lazy-builder.ts` + one registration line in `kernel/collection.ts` (at its EXACT zero-slack ceiling).
+
+**Tech Stack:** TypeScript ESM, vitest, packages/hub.
+
+## Global Constraints
+
+- **Ceilings (metric = `split('\n').length`):** `kernel/collection.ts` **4472/4472 — ZERO slack**; `vault.ts` 3939; `noydb.ts` 2385. #677 must add ≥1 line to collection.ts — offset by genuine in-file compression (shrink-first). If shrink-first genuinely can't cover it, a ceiling re-ratchet in `scripts/check-architecture.mjs` is sanctioned by the checker's own fail-message *only with written justification in the report* — prefer shrink-first. `graph.ts` (#678) is unbudgeted.
+- **Check 14 (via-layering), EMPTY allowlist:** no `kernel/**` file imports `src/via/**`. Both fixes route through the existing `kernel/via/{index,pipeline}.ts` port (`ViaPipeline`/`ViaBinding` generic folds) exactly as the eager precedent does — no direct `via/money/*` import from kernel or with-lookup.
+- **Behavior lock:** full existing suite green except tests a task deliberately updates. TDD per task. No Claude attribution; changeset LOCAL only; conventional commits ending `(#678)` / `(#677)`.
+
+---
+
+### Task 1: #678 — edge-carried kind on `_out` (Option A)
+
+**Seam map:** §B. Self-contained in `packages/hub/src/kernel/via/graph.ts`.
+
+**Files:**
+- Modify: `packages/hub/src/kernel/via/graph.ts` — `_out` map type + its 4 touch sites
+- Test: `packages/hub/__tests__/via/graph.test.ts` (add the dual-role regression pin)
+
+**The fix (Option A):** change `private _out = new Map<string, FieldRef[]>()` → `Map<string, Array<{ target: FieldRef; kind: EdgeKind }>>`. Four mechanical sites (seam map §B3):
+1. `registerDerived` (~:148-150): push `{ target, kind }` instead of bare `target`.
+2. `assertAcyclic`'s `neighboursOf` (~:237-244): filter/map on the **edge-local** `kind` (`entry.kind !== 'ref'`) instead of dereferencing `this._in.get(nodeId(t))?.kind` — this is the actual bug fix: the filter now asks "what kind is THIS `source→target` edge" not "what is the target's current (possibly overwritten) registered kind". Return the `.target`s.
+3. `assertAcyclic`'s outer `for (const id of this._out.keys())` loop (~:263): untouched (keys are still strings).
+4. `referencingEdgesOf` (~:432-442): read `entry.kind === 'ref'` directly off the `_out` entry instead of re-deref'ing `_in` — this ALSO fixes the symmetric ref-vanishes hazard (a real ref edge silently dropped under reverse registration order) for free; note that in a code comment.
+
+Leave `_in` single-slot exactly as is — this task does NOT touch posture/taint folding (that's Option B's larger scope, out of #678's stated scope).
+
+- [ ] **Step 1: failing test.** In `graph.test.ts`, construct a `ViaGraph` directly and reproduce the hazard without needing the (nonexistent) post-open re-validation trigger: register a dual-role target twice — first `registerDerived(T, [A], 'computed', 'record')` then `registerDerived(T, [B], 'ref', 'record', ...)` (mirroring the `vault.ts:1167→1168` order) — where a genuine derivation cycle exists through T's computed edge (A depends on T, T depends on A). Assert `assertAcyclic()` THROWS `DerivationCycleError` (today it wrongly does NOT — the ref-overwrite filters T out of the DFS). Add the companion: a legitimate mutual-FK ref cycle (two collections' ref edges only) still does NOT throw (the #671 behavior stays). Run → the cycle-detection test fails (no throw).
+- [ ] **Step 2: implement** Option A per above. Run → both green.
+- [ ] **Step 3:** run `pnpm vitest run packages/hub/__tests__/via/graph.test.ts packages/hub/__tests__/via/graph-edges.test.ts packages/hub/__tests__/via/reconcile-guard.test.ts packages/hub/__tests__/via/taint.test.ts` (the `_out`/`referencingEdgesOf`/posture consumers) + `pnpm check:architecture` + `pnpm --filter @noy-db/hub typecheck`. All green.
+- [ ] **Step 4: commit** — `fix(hub): assertAcyclic keys the ref-edge filter on the edge, not the target — dual-role targets no longer hide derivation cycles (#678)`.
+
+---
+
+### Task 2: #677 — lazy-mode money index canonicalization + probe path
+
+**Seam map:** §A. BOTH sub-fixes must land together (canonical buckets are useless if the probe doesn't canonicalize the lookup value): (i) bucket-write canonicalization in `PersistedCollectionIndex`, (ii) probe-value canonicalization in the lazy query path.
+
+**Files:**
+- Modify: `packages/hub/src/with-lookup/indexing/persisted-indexes.ts` — add `canonicalize?` field + `setCanonicalizer()` (mirror `CollectionIndexes`), thread through `addToState`/`removeFromState` and the `lookupEqual`/`lookupIn`/`lookupRange` probe side
+- Modify: `packages/hub/src/with-lookup/indexing/lazy-builder.ts` — thread a `via`/probe reference into `LazyQuerySource<T>` and consult `ViaPipeline` in `resolveCandidateIds()`
+- Modify: `packages/hub/src/kernel/collection.ts` — register the canonicalizer on `persistedIndexes` (sibling of the eager line ~:867) + wire `via` into the `lazyQuery()` `LazyQuerySource` literal (~:4287); **ceiling shrink-first required**
+- Test: `packages/hub/__tests__/via/money-index-canonical-lazy.test.ts` (new)
+
+**Interfaces:**
+- `PersistedCollectionIndex.setCanonicalizer(fn: (field: string, value: unknown) => string | undefined): void` — same shape as `CollectionIndexes`.
+- `LazyQuerySource<T>` gains an optional probe seam — either `via?: ViaPipeline` or a narrow `canonicalizeIndexKey?: (field, value) => string | undefined` closure (prefer the narrow closure: `resolveCandidateIds` only needs to canonicalize the `==`/`in`/range lookup value, mirroring how the eager `candidateRecords` resolves the probe value before `lookupEqual`). Keep the kernel→with-lookup seam narrow; do NOT hand `LazyQuerySource` the whole pipeline if a closure suffices.
+
+- [ ] **Step 1: confirm the runtime gap first (seam map §A3 flagged it unconfirmed).** Write a probe test: lazy-mode collection (`prefetch: false`) + a fixed-mode `money()` field + an eager-declared index on it; put a record via the money write path (scaled bucket, e.g. `'100'`); `where('amount','==', 1)` on the lazy path. Observe today's behavior — does it scan-miss, return empty, or throw `IndexRequiredError`? Record it in the report; that determines the exact assertion shape. Then write the FULL failing test: mixed-era fixture (a legacy `'0100'` record written before the money declaration + a canonical `'100'` record), assert `where('amount','==',1)` returns BOTH via the lazy index fast path (spy the `persistedIndexes.lookupEqual` to prove the index path was taken, not a scan), plus the scan-parity property (fast-path ≡ forced-scan for `==`/`in`, unparseable consistently no-match). Run → fails.
+- [ ] **Step 2: bucket canonicalization.** In `persisted-indexes.ts`: add the `canonicalize` field + `setCanonicalizer`; thread it into `addToState`/`removeFromState` (add the param, `canonicalize?.(field, value) ?? stringifyKey(value)` at the bucket site — mirror eager's `addToIndex`); apply at EVERY mutation site (`ingest` bulk-load, `upsert`, `remove`) so buckets are symmetric. Also canonicalize the incoming probe value in `lookupEqual`/`lookupIn`/`lookupRange` (the lazy probe path hands raw values — unlike eager, where `candidateRecords` pre-canonicalizes; here the index method must, OR the lazy-builder must before calling — pick ONE site and be consistent; document which).
+- [ ] **Step 3: probe threading.** In `lazy-builder.ts`: add the narrow canonicalizer seam to `LazyQuerySource<T>`; in `resolveCandidateIds()`, canonicalize `clause.value` for `==`/`in`/range before `idx.lookupEqual`/`lookupIn`/`lookupRange` (if you chose to canonicalize in lazy-builder rather than inside the index in Step 2 — do NOT double-canonicalize; one site). `collection.ts`: register `this.persistedIndexes?.setCanonicalizer((f,v) => this.via?.canonicalizeIndexKey(f,v))` and pass the same closure into the `lazyQuery()` `LazyQuerySource` literal.
+- [ ] **Step 4: ceiling.** collection.ts is at 4472/4472. Count the net lines you added; offset each by a genuine in-file compression (report before/after). If truly impossible, re-ratchet `KERNEL_SURFACE_BUDGET` in `check-architecture.mjs` with a written justification (new lazy-canonicalization functionality is genuinely core) — but try shrink-first first. `pnpm check:architecture` must pass.
+- [ ] **Step 5:** run the new test + the #672 eager tests (`pnpm vitest run packages/hub/__tests__/via/money-index-canonical.test.ts`) to confirm no eager regression + `pnpm vitest run packages/hub/__tests__ -t lazy` sweep + `pnpm check:architecture` + typecheck. All green.
+- [ ] **Step 6: docs.** Update `docs/subsystems/via-money.md`'s Indexing section + the `builder.ts:1132-1142` / `moneyIndexProbe` comments that call the lazy gap "out of scope" — flip them to describe the now-closed guarantee (eager AND lazy canonicalize; #677).
+- [ ] **Step 7: commit** — `fix(hub): lazy-mode PersistedCollectionIndex canonicalizes + probes money index keys (#677)`.
+
+---
+
+### Task 3: docs, changeset, gauntlet
+
+- [ ] **Step 1:** sweep `docs/subsystems/via*.md` for stale "lazy … out of scope" / mixed-era caveats invalidated by #677; update. Confirm #678's latent-hazard note is documented where the graph/cycle behavior is described.
+- [ ] **Step 2:** author `.changeset/m33-via-followups-3.md` LOCAL (`@noy-db/hub: patch` — both are internal correctness fixes, no public API surface change; if #677's `LazyQuerySource` seam is considered public, bump to minor and justify). Do NOT git add.
+- [ ] **Step 3:** full gauntlet from repo root — `pnpm --filter @noy-db/hub test`, typecheck, lint, `pnpm check:architecture`, build + bundle-check. Report ceilings + counts. Grep the diff for attribution/client-name (zero hits).
+- [ ] **Step 4: commit** — `docs(hub): via-money lazy-indexing + graph dual-role notes (#677 #678)`.
+
+## Self-review notes
+- #678 → T1 (edge-carried kind, regression pins the cycle-detection fix directly against ViaGraph); #677 → T2 (both bucket + probe canonicalization together, ceiling shrink-first); docs/changeset → T3.
+- Ceiling exposure is T2-only (collection.ts registration lines) — shrink-first mandated, ceiling-bump only with written justification.
+- Check 14: both fixes stay on the `kernel/via/{index,pipeline}.ts` port; no direct `via/money/*` import from kernel/with-lookup.

--- a/packages/hub/__tests__/via/graph.test.ts
+++ b/packages/hub/__tests__/via/graph.test.ts
@@ -299,6 +299,34 @@ describe('ViaGraph — cycle rejection (assertAcyclic)', () => {
     g.registerDerived({ collection: 'countries', field: 'name' }, [{ collection: 'customers', field: 'homeCountry' }], 'derivation', 'record')
     expect(() => g.assertAcyclic()).not.toThrow()
   })
+
+  // #678 — `_in` is single-slot per target: `registerDerived`'s `_in.set` REPLACES the
+  // whole edge, so a dual-role target (e.g. a `computed(fn,{deps})` field ALSO composed
+  // with a lookup/ref, #631's exempt {computed, lookup} pair) that registers computed
+  // FIRST then ref SECOND (mirrors the real call order, graph-wiring.ts:71-72 →
+  // vault.ts:1168, both inside the same `vault.collection()` call) has its `_in` entry's
+  // `kind` overwritten from 'computed' to 'ref'. `assertAcyclic`'s pre-fix ref-edge filter
+  // asked `_in.get(nodeId(t))?.kind !== 'ref'` — the TARGET's current (post-overwrite)
+  // kind, not the SPECIFIC edge's kind — so it wrongly excluded the dual-role target from
+  // the DFS, hiding a genuine derivation cycle through its computed edge.
+  it('a dual-role target (computed THEN ref, #631 composition order) does not hide a genuine derivation cycle through its computed edge (#678)', () => {
+    const g = new ViaGraph()
+    // T is dual-role: a computed field (sourced from A) ALSO composed with a ref/lookup
+    // edge (sourced from B) — registered computed-first, ref-second, mirroring the real
+    // vault.ts:1167→1168 order.
+    g.registerDerived({ collection: 'c', field: 'T' }, [{ collection: 'c', field: 'A' }], 'computed', 'record')
+    g.registerDerived({ collection: 'c', field: 'T' }, [{ collection: 'c', field: 'B' }], 'ref', 'record', 'restrict', 'id')
+    // A genuine cycle through T's COMPUTED edge: A depends on T, T depends on A.
+    g.registerDerived({ collection: 'c', field: 'A' }, [{ collection: 'c', field: 'T' }], 'computed', 'record')
+    expect(() => g.assertAcyclic()).toThrow(DerivationCycleError)
+  })
+
+  it('companion: a legitimate mutual-FK ref-only cycle still does NOT throw even alongside the dual-role fix (#671 behavior preserved, #678)', () => {
+    const g = new ViaGraph()
+    g.registerDerived({ collection: 'customers', field: 'homeCountry' }, [{ collection: 'countries', field: '*' }], 'ref', 'record', 'restrict', 'id')
+    g.registerDerived({ collection: 'countries', field: 'capitalOf' }, [{ collection: 'customers', field: '*' }], 'ref', 'record', 'restrict', 'id')
+    expect(() => g.assertAcyclic()).not.toThrow()
+  })
 })
 
 describe('ViaGraph — taintedPostures / taintSealedFields (Task 3 overlay)', () => {

--- a/packages/hub/__tests__/via/money-index-canonical-lazy.test.ts
+++ b/packages/hub/__tests__/via/money-index-canonical-lazy.test.ts
@@ -207,11 +207,22 @@ describe('lazy-mode money index-key canonicalization + probe (#677)', () => {
       expect(preHit.map((r) => r.id)).toEqual(['legacy']) // pins the ingest-side canonicalization this test depends on
       await col.put('legacy', { id: 'legacy', amount: 2 }) // update through the money write path
 
+      // Fence the upsert remove-old canonicalize site directly (#677 review F1):
+      // `.toArray()` alone can't see a stranded bucket — the #684 post-filter
+      // rejects the stale decoded record either way — so spy on what the index
+      // makes the query FETCH. A canonicalized remove-old empties bucket '1', so
+      // the old-value query fetches nothing; a stranded 'legacy' would be looked
+      // up and fetched (then post-filter-rejected), leaking through here.
+      const getSpy = vi.spyOn(col, 'get')
       const oldHit = await col.lazyQuery().where('amount', '==', '1').toArray()
+      const oldHitFetched = getSpy.mock.calls.map((c) => c[0])
+      getSpy.mockClear()
       const newHit = await col.lazyQuery().where('amount', '==', '2').toArray()
+      getSpy.mockRestore()
       db.close()
 
       expect(oldHit.map((r) => r.id)).toEqual([]) // must NOT still return the stale-bucket 'legacy' id
+      expect(oldHitFetched).not.toContain('legacy') // and must NOT linger in the old '1' bucket
       expect(newHit.map((r) => r.id)).toEqual(['legacy'])
     })
 

--- a/packages/hub/__tests__/via/money-index-canonical-lazy.test.ts
+++ b/packages/hub/__tests__/via/money-index-canonical-lazy.test.ts
@@ -1,0 +1,370 @@
+import { describe, it, expect, vi } from 'vitest'
+import { z } from 'zod'
+import { createNoydb, money } from '../../src/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/kernel/types.js'
+import { withIndexing } from '../../src/with-lookup/indexing/index.js'
+import { PersistedCollectionIndex } from '../../src/with-lookup/indexing/persisted-indexes.js'
+
+// #677 — lazy twin of #672. The eager fix (`money-index-canonical.test.ts`)
+// made `CollectionIndexes` bucket fixed-mode money keys through
+// `ViaPipeline.canonicalizeIndexKey`, at every bucket-mutation site AND at
+// the probe (via `candidateRecords()` resolving the probe value before
+// `lookupEqual`/`lookupIn`). `PersistedCollectionIndex` (lazy mode) had
+// NEITHER: it bucketed via its own raw `stringifyKey`, unconditionally, and
+// `lazy-builder.ts` never consulted any via binding at all — a mixed-era
+// lazy-mode collection had the same canonical-vs-raw bucket split #672
+// fixed for eager, PLUS a probe that could never find even a canonical
+// bucket by anything other than byte-identical luck.
+//
+// STEP 1 runtime-gap finding (recorded in the task report): before this
+// fix, `lazyQuery().where('amount', '==', <any value>).toArray()` on a
+// money field returns an EMPTY array — never a throw, never a correct
+// result. Two independent reasons compound: (a) the bucket-write gap this
+// file's Step 2 fixes, and (b) `LazyQuery`'s post-filter (`matchesAll`)
+// re-evaluates every clause — including the index-driving one — against
+// the DECODED record from `getRecord()`/`collection.get()` (which runs
+// `via.present()`), using the GENERIC (non-via-aware) `evaluateClause`,
+// so a money field's decoded decimal form ('1.00') never equality-matches
+// a raw stored-space or major-unit query value. (b) is a real, separate,
+// pre-existing gap — `LazyQuery.where()` never builds a `clause.via` the
+// way `Query.where()`/`ScanBuilder.where()` do — outside #677's stated
+// scope (thread `canonicalizeIndexKey` through the bucket + probe sites
+// only) and outside this task's file/ceiling budget. It means: end-to-end
+// `.toArray()` parity with the eager fix is only observable here when the
+// money field's `scale` is 0 (decoded digit string == stored digit string,
+// no decimal point inserted) AND the query value is passed in that same
+// canonical digit-string form. The mixed-era / non-canonical-PROBE cases
+// are verified at the index layer directly (spy on `lookupEqual`, and on
+// which candidate ids the query fetches) — the correct place to observe a
+// probe canonicalization fix whose benefit a separate bug (b) hides from
+// the final decoded result. See `docs/subsystems/via-money.md` (Indexing)
+// for the documented boundary.
+
+interface Item extends Record<string, unknown> {
+  id: string
+  amount: number | string
+}
+
+const itemSchema = z.object({ id: z.string(), amount: z.union([z.number(), z.string()]) })
+
+const USER = 'alice'
+const PASS = 'money-index-canonical-lazy-passphrase-2026'
+const VAULT = 'books'
+const COLL = 'items'
+
+/** Shared memory adapter — persists across `createNoydb()` calls (simulates reopen). */
+function persistentMemory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env) { gc(c, col).set(id, env) },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    // Native pagination, filtered to canonical (non-reserved-namespace) ids
+    // only — `_idx/<field>/<id>` side-cars are not user records and would
+    // otherwise fail `col.scan()`'s schema validation. Mirrors the
+    // convention `with-lookup/indexing/collection-facade.ts`'s
+    // `rebuildIndexes` applies when it walks a collection's id namespace.
+    async listPage(c, col, cursor, limit = 100) {
+      const coll = store.get(c)?.get(col)
+      const ids = coll ? [...coll.keys()].filter((id) => !id.startsWith('_')).sort() : []
+      const start = cursor ? parseInt(cursor, 10) : 0
+      const end = Math.min(start + limit, ids.length)
+      const items = ids.slice(start, end).map((id) => ({ id, envelope: coll!.get(id)! }))
+      return { items, nextCursor: end < ids.length ? String(end) : null }
+    },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) }
+    },
+  }
+}
+
+/** Session 1: no money declared on 'items' — writes 'amount' as a raw, non-canonical string. */
+async function seedLegacyRecord(adapter: NoydbStore, id: string, rawAmount: unknown): Promise<void> {
+  const db = await createNoydb({ store: adapter, user: USER, secret: PASS })
+  const vault = await db.openVault(VAULT)
+  await vault.collection<Item>(COLL, { schema: itemSchema }).put(id, { id, amount: rawAmount } as Item)
+  db.close()
+}
+
+/**
+ * A fresh lazy-mode session declaring money(fixed, scale:0) + a persisted
+ * index on 'amount'. `reconcileOnOpen: 'auto'` is REQUIRED for the
+ * mixed-era scenarios below: unlike eager mode (whose `build()` always
+ * rescans every canonical record on hydrate), a lazy-mode legacy record
+ * written before `indexes: ['amount']` was declared has NO `_idx/amount/*`
+ * side-car at all — it is invisible to `ensurePersistedIndexesLoaded()`'s
+ * bulk-load (which only reads EXISTING side-cars) until a reconcile pass
+ * backfills one via `maintainPersistedIndexesOnPut` (the same `upsert()`
+ * mutation site the fix canonicalizes). This is the lazy-mode analogue of
+ * eager's automatic rebuild-on-hydrate self-correction.
+ */
+async function openMoneyIndexedLazySession(adapter: NoydbStore) {
+  const db = await createNoydb({ store: adapter, user: USER, secret: PASS, indexStrategy: withIndexing() })
+  const vault = await db.openVault(VAULT)
+  const col = vault.collection<Item>(COLL, {
+    schema: itemSchema,
+    prefetch: false,
+    cache: { maxRecords: 100 },
+    moneyFields: { amount: money({ currency: 'EUR', scale: 0 }) },
+    indexes: ['amount'],
+    reconcileOnOpen: 'auto',
+  })
+  return { db, col }
+}
+
+/** Drain a ScanBuilder (AsyncIterable) into an array of ids. */
+async function scanIds<T extends { id: string }>(
+  builder: AsyncIterable<T>,
+): Promise<string[]> {
+  const out: string[] = []
+  for await (const r of builder) out.push(r.id)
+  return out
+}
+
+describe('lazy-mode money index-key canonicalization + probe (#677)', () => {
+  it('mixed-era fast path: a legacy non-canonical record and a canonical record both match == via the lazy index fast path', async () => {
+    const adapter = persistentMemory()
+    await seedLegacyRecord(adapter, 'legacy', '0001') // non-canonical: BigInt('0001') === 1n
+
+    const { db, col } = await openMoneyIndexedLazySession(adapter)
+    // Write a second record THROUGH the money write path — lands canonical '1' (scale:0).
+    await col.put('canonical', { id: 'canonical', amount: 1 })
+
+    const spy = vi.spyOn(PersistedCollectionIndex.prototype, 'lookupEqual')
+    let hit: Item[]
+    try {
+      // scale:0 => decoded digit string === stored digit string === '1', so a
+      // canonical-form query value round-trips through the post-filter too
+      // (see the file-header note on the separate post-filter gap).
+      hit = await col.lazyQuery().where('amount', '==', '1').toArray()
+      expect(hit.map((r) => r.id).sort()).toEqual(['canonical', 'legacy'])
+      // Fast-path evidence: exactly one probe, against the canonical key —
+      // proves BOTH records' buckets collapsed to the same '1' key (bucket
+      // fix) and that no scan/IndexRequiredError fallback occurred.
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy).toHaveBeenCalledWith('amount', '1')
+    } finally {
+      spy.mockRestore()
+    }
+
+    // Scan parity: a forced full scan (money-aware `ScanBuilder.where()`,
+    // major-unit operand) agrees with the fast path on the record SET.
+    const scanned = await scanIds(col.scan({ pageSize: 10 }).where('amount', '==', 1))
+    expect(scanned.sort()).toEqual(['canonical', 'legacy'])
+
+    db.close()
+  })
+
+  it('rebuild-on-hydrate (ingest bulk-load) canonicalizes: a fresh session re-derives the same canonical buckets from side-cars alone', async () => {
+    const adapter = persistentMemory()
+    await seedLegacyRecord(adapter, 'legacy', '0001')
+    {
+      const { db, col } = await openMoneyIndexedLazySession(adapter)
+      await col.put('canonical', { id: 'canonical', amount: 1 })
+      db.close()
+    }
+
+    // Fresh session: the in-memory mirror is empty, so the first lazyQuery()
+    // call bulk-loads `_idx/amount/*` side-cars via `ingest()` — the ONLY
+    // mutation site exercised here (no incremental upsert/remove in this
+    // session at all).
+    const { db, col } = await openMoneyIndexedLazySession(adapter)
+    const spy = vi.spyOn(PersistedCollectionIndex.prototype, 'lookupEqual')
+    try {
+      const hit = await col.lazyQuery().where('amount', '==', '1').toArray()
+      expect(hit.map((r) => r.id).sort()).toEqual(['canonical', 'legacy'])
+      expect(spy).toHaveBeenCalledWith('amount', '1')
+    } finally {
+      spy.mockRestore()
+    }
+    db.close()
+  })
+
+  // Bucket-mutation-dimension parity — every mutation site (ingest, upsert,
+  // remove) must canonicalize, or a record can be stranded in a bucket the
+  // opposite operation can never reach again.
+  describe('mutation-dimension parity', () => {
+    it('(a) update: mutating a legacy record clears its old canonical bucket', async () => {
+      const adapter = persistentMemory()
+      await seedLegacyRecord(adapter, 'legacy', '0001')
+
+      const { db, col } = await openMoneyIndexedLazySession(adapter)
+      // Force bulk-load (ingest+reconcile) first, so 'legacy' lands in the
+      // canonicalized '1' bucket — then the update below must go through
+      // `upsert()` -> `removeFromState()` on that SAME canonical key.
+      const preHit = await col.lazyQuery().where('amount', '==', '1').toArray()
+      expect(preHit.map((r) => r.id)).toEqual(['legacy']) // pins the ingest-side canonicalization this test depends on
+      await col.put('legacy', { id: 'legacy', amount: 2 }) // update through the money write path
+
+      const oldHit = await col.lazyQuery().where('amount', '==', '1').toArray()
+      const newHit = await col.lazyQuery().where('amount', '==', '2').toArray()
+      db.close()
+
+      expect(oldHit.map((r) => r.id)).toEqual([]) // must NOT still return the stale-bucket 'legacy' id
+      expect(newHit.map((r) => r.id)).toEqual(['legacy'])
+    })
+
+    it('(b) delete: deleting a legacy record clears it from the canonical bucket', async () => {
+      const adapter = persistentMemory()
+      await seedLegacyRecord(adapter, 'legacy', '0001')
+
+      const { db, col } = await openMoneyIndexedLazySession(adapter)
+      const preHit = await col.lazyQuery().where('amount', '==', '1').toArray() // ingest canonicalizes 'legacy' into bucket '1'
+      expect(preHit.map((r) => r.id)).toEqual(['legacy'])
+      await col.delete('legacy')
+
+      const hit = await col.lazyQuery().where('amount', '==', '1').toArray()
+      db.close()
+
+      expect(hit.map((r) => r.id)).toEqual([])
+    })
+
+    it('(c) delete-then-recreate: reusing the same id with a different amount is not stranded in the old bucket', async () => {
+      const adapter = persistentMemory()
+      await seedLegacyRecord(adapter, 'legacy', '0001')
+
+      const { db, col } = await openMoneyIndexedLazySession(adapter)
+      const preHit = await col.lazyQuery().where('amount', '==', '1').toArray() // ingest canonicalizes 'legacy' into bucket '1'
+      expect(preHit.map((r) => r.id)).toEqual(['legacy'])
+      await col.delete('legacy')
+      await col.put('legacy', { id: 'legacy', amount: 3 }) // recreate same id, different amount
+
+      const oldHit = await col.lazyQuery().where('amount', '==', '1').toArray()
+      const newHit = await col.lazyQuery().where('amount', '==', '3').toArray()
+      db.close()
+
+      expect(oldHit.map((r) => r.id)).toEqual([])
+      expect(newHit.map((r) => r.id)).toEqual(['legacy'])
+    })
+  })
+
+  // Probe-side canonicalization: proven at the INDEX layer directly. A
+  // non-canonical PROBE value can only be observed to find the right
+  // candidate BEFORE the (separate, undocumented-here) post-filter gap
+  // would reject it on a raw-string mismatch — see the file-header note.
+  describe('probe-side canonicalization (lazy-builder.ts resolveCandidateIds)', () => {
+    it('a non-canonical probe value canonicalizes to the same bucket key a canonical write produced', async () => {
+      const adapter = persistentMemory()
+      await seedLegacyRecord(adapter, 'legacy', '0001') // stored raw; write-side fix buckets it under '1'
+
+      const { db, col } = await openMoneyIndexedLazySession(adapter)
+      const lookupSpy = vi.spyOn(PersistedCollectionIndex.prototype, 'lookupEqual')
+      const getSpy = vi.spyOn(col, 'get')
+      try {
+        // '001' is a DIFFERENT non-canonical spelling of the same magnitude
+        // (BigInt('001') === BigInt('0001') === 1n) — never byte-identical
+        // to either the legacy stored form or the bucket-fix's own
+        // normalization target, so this can only find 'legacy' if
+        // `resolveCandidateIds()` canonicalizes the PROBE, not just if the
+        // bucket-write fix ran.
+        await col.lazyQuery().where('amount', '==', '001').toArray()
+        // The lookup call itself proves the closure ran: the index was
+        // probed with the CANONICAL key ('1'), not the raw clause value.
+        expect(lookupSpy).toHaveBeenCalledWith('amount', '1')
+        // And the candidate id set the index resolved from that
+        // canonicalized probe included 'legacy' — i.e. the fast path found
+        // the right record, independent of what the post-filter later does
+        // with it.
+        expect(getSpy.mock.calls.map((c) => c[0])).toContain('legacy')
+      } finally {
+        lookupSpy.mockRestore()
+        getSpy.mockRestore()
+      }
+      db.close()
+    })
+
+    it('in: every non-canonical value in the array is canonicalized before lookupIn', async () => {
+      const adapter = persistentMemory()
+      await seedLegacyRecord(adapter, 'legacy', '0001')
+
+      const { db, col } = await openMoneyIndexedLazySession(adapter)
+      const lookupSpy = vi.spyOn(PersistedCollectionIndex.prototype, 'lookupIn')
+      const getSpy = vi.spyOn(col, 'get')
+      try {
+        await col.lazyQuery().where('amount', 'in', ['001', '999']).toArray()
+        expect(lookupSpy).toHaveBeenCalledWith('amount', ['1', '999'])
+        expect(getSpy.mock.calls.map((c) => c[0])).toContain('legacy')
+      } finally {
+        lookupSpy.mockRestore()
+        getSpy.mockRestore()
+      }
+      db.close()
+    })
+  })
+
+  describe('scan parity across mixed-era stored shapes', () => {
+    interface ShapeRecord extends Record<string, unknown> {
+      id: string
+      amount: unknown
+    }
+    const shapeSchema = z.object({ id: z.string(), amount: z.unknown() })
+
+    const shapes: Record<string, unknown> = {
+      'r-canonical': '1', // already canonical
+      'r-legacy-zero': '0001', // legacy non-canonical (the #677 repro)
+      'r-junk-space': ' 1', // whitespace — BigInt-tolerant on both paths
+      'r-number': 1, // raw JS number, not the string form
+      'r-nonnumeric': 'abc', // unparseable — must no-match on both paths
+      'r-null': null, // never indexed (nor scan-matched) on either path
+    }
+
+    async function seedShapes(adapter: NoydbStore): Promise<void> {
+      const db = await createNoydb({ store: adapter, user: USER, secret: PASS })
+      const vault = await db.openVault(VAULT)
+      const col = vault.collection<ShapeRecord>(COLL, { schema: shapeSchema })
+      for (const [id, amount] of Object.entries(shapes)) {
+        await col.put(id, { id, amount })
+      }
+      db.close()
+    }
+
+    /** Same session shape as `openMoneyIndexedLazySession`, but `amount: z.unknown()` — some shapes are null/garbage. */
+    async function openShapesLazySession(adapter: NoydbStore) {
+      const db = await createNoydb({ store: adapter, user: USER, secret: PASS, indexStrategy: withIndexing() })
+      const vault = await db.openVault(VAULT)
+      const col = vault.collection<ShapeRecord>(COLL, {
+        schema: shapeSchema,
+        prefetch: false,
+        cache: { maxRecords: 100 },
+        moneyFields: { amount: money({ currency: 'EUR', scale: 0 }) },
+        indexes: ['amount'],
+        reconcileOnOpen: 'auto',
+      })
+      return { db, col }
+    }
+
+    it('== agrees between the lazy fast path and a forced scan for every stored shape', async () => {
+      const adapter = persistentMemory()
+      await seedShapes(adapter)
+
+      const { db, col } = await openShapesLazySession(adapter)
+      const eqSpy = vi.spyOn(PersistedCollectionIndex.prototype, 'lookupEqual')
+      let fastEq: string[]
+      try {
+        fastEq = (await col.lazyQuery().where('amount', '==', '1').toArray()).map((r) => r.id).sort()
+        expect(eqSpy).toHaveBeenCalled()
+      } finally {
+        eqSpy.mockRestore()
+      }
+      const scanEq = (await scanIds(col.scan({ pageSize: 10 }).where('amount', '==', 1))).sort()
+
+      expect(fastEq).toEqual(scanEq)
+      expect(fastEq).toContain('r-canonical')
+      expect(fastEq).toContain('r-legacy-zero')
+      expect(fastEq).not.toContain('r-nonnumeric')
+      expect(fastEq).not.toContain('r-null')
+      db.close()
+    })
+  })
+})

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -269,8 +269,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
 
   /**
    * In-memory unique-constraint enforcement for eager mode.
-   * `null` when no `unique:true` indexes are declared on this collection,
-   * or when the collection is in lazy mode (which throws at registration).
+   * `null` when no `unique:true` indexes are declared on this collection, or when the collection is in lazy mode (which throws at registration).
    */
   private readonly uniqueConstraints: UniqueConstraintSet | null
 
@@ -294,8 +293,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   }
 
   /**
-   * Accessor for the persisted-mirror (lazy-mode) index. Returns `null`
-   * when indexing is disabled or the collection is in eager mode.
+   * Accessor for the persisted-mirror (lazy-mode) index. Returns `null` when indexing is disabled or the collection is in eager mode.
    */
   private get persistedIndexes(): PersistedCollectionIndex | null {
     return this.indexState.getPersistedIndexes()
@@ -865,6 +863,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       lazy: this.lazy,
     })
     this.indexes?.setCanonicalizer((f, v) => this.via?.canonicalizeIndexKey(f, v)) // #672 review C1: one-time canonicalizer registration; lazy `this.via` read survives late `_setVia` (#666)
+    this.persistedIndexes?.setCanonicalizer((f, v) => this.via?.canonicalizeIndexKey(f, v)) // #677: lazy twin of the line above
 
     // Unique-constraint enforcement (eager mode only). Declaring `unique` on
     // a lazy/CRDT/tiered collection throws UnsupportedIndexOptionError here —
@@ -4287,6 +4286,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     const source: LazyQuerySource<T> = {
       collectionName: this.name,
       persistedIndexes: persisted,
+      canonicalizeIndexKey: (f: string, v: unknown) => this.via?.canonicalizeIndexKey(f, v),
       ensurePersistedIndexesLoaded: () => this.ensurePersistedIndexesLoaded(),
       getRecord: (id: string) => this.get(id) as unknown as Promise<T | null>,
     }

--- a/packages/hub/src/kernel/query/builder.ts
+++ b/packages/hub/src/kernel/query/builder.ts
@@ -1145,7 +1145,7 @@ function candidateRecords(source: InternalSource, clauses: readonly Clause[]): C
     // `moneyIndexProbe`'s doc comment (via-money/where.ts) for the full
     // story, including the boundary that remains (lazy mode's post-filter
     // is not Via-aware, so end-to-end `lazyQuery().where()` money parity
-    // with this eager path needs a follow-up).
+    // with this eager path is tracked in #684).
     if (clause.via && clause.via.indexValue === undefined) continue
     const probeValue = clause.via ? clause.via.indexValue : clause.value
 

--- a/packages/hub/src/kernel/query/builder.ts
+++ b/packages/hub/src/kernel/query/builder.ts
@@ -1137,9 +1137,15 @@ function candidateRecords(source: InternalSource, clauses: readonly Clause[]): C
     // build/rebuild, so a legacy non-canonical scaled value (predates the
     // field's money() declaration) lands in — and stays in — the SAME bucket
     // a canonical probe looks up, across later put()/delete() too. LAZY
-    // mode's `PersistedCollectionIndex` keeps raw bucketing (out of scope) —
-    // see `moneyIndexProbe`'s doc comment (via-money/where.ts) for the full
-    // story.
+    // mode's `PersistedCollectionIndex` gained the SAME guarantee (#677) —
+    // its bucket-mutation sites (`ingest`/`upsert`/`remove`) canonicalize
+    // through the same `ViaPipeline.canonicalizeIndexKey`, and its probe
+    // path (`lazy-builder.ts`'s `resolveCandidateIds()`) canonicalizes the
+    // `==`/`in` lookup value before calling `lookupEqual`/`lookupIn` — see
+    // `moneyIndexProbe`'s doc comment (via-money/where.ts) for the full
+    // story, including the boundary that remains (lazy mode's post-filter
+    // is not Via-aware, so end-to-end `lazyQuery().where()` money parity
+    // with this eager path needs a follow-up).
     if (clause.via && clause.via.indexValue === undefined) continue
     const probeValue = clause.via ? clause.via.indexValue : clause.value
 

--- a/packages/hub/src/kernel/via/graph.ts
+++ b/packages/hub/src/kernel/via/graph.ts
@@ -69,6 +69,13 @@ function isDefaultPosture(p: ViaPosture): boolean {
     p.exportable === DEFAULT_POSTURE.exportable && p.forgettable === DEFAULT_POSTURE.forgettable
 }
 
+/** One `_out` entry — a `source -> target` derived edge, carrying its OWN registration's
+ *  `kind` (#678). `kind` must be edge-local, not re-derived from `_in`: `_in` is single-slot
+ *  per target and can be overwritten by a LATER `registerDerived` call on the SAME target
+ *  (a dual-role target, e.g. #631's exempt {computed, lookup} field composition) — asking
+ *  `_in` for "this target's current kind" answers the wrong question for a specific edge. */
+interface OutEdge { readonly target: FieldRef; readonly kind: EdgeKind }
+
 /** One registered `registerDerived` call — a target's whole in-edge set. */
 interface DerivedEdge {
   readonly target: FieldRef
@@ -103,8 +110,9 @@ export class ViaGraph {
   private readonly _posture = new Map<string, ViaPosture>()
   /** Every derived target's registration, keyed by the target's node id. */
   private readonly _in = new Map<string, DerivedEdge>()
-  /** source node id -> derived targets that depend on it (dispatch/erasure). */
-  private readonly _out = new Map<string, FieldRef[]>()
+  /** source node id -> derived edges that depend on it (dispatch/erasure), each carrying
+   *  its own registration's `kind` (#678 — see {@link OutEdge}). */
+  private readonly _out = new Map<string, OutEdge[]>()
   /** Memoized effective posture per derived target node id. */
   private readonly _effectiveCache = new Map<string, ViaPosture>()
   /** Memoized whole-collection security-axes fold for `'*'` wildcard LEAF nodes (#642),
@@ -145,9 +153,10 @@ export class ViaGraph {
     })
     for (const source of sources) {
       const sourceId = nodeId(source)
+      const outEdge: OutEdge = { target, kind }
       const dependents = this._out.get(sourceId)
-      if (dependents) dependents.push(target)
-      else this._out.set(sourceId, [target])
+      if (dependents) dependents.push(outEdge)
+      else this._out.set(sourceId, [outEdge])
     }
     this._effectiveCache.clear()
     this._wildcardCache.clear()
@@ -232,14 +241,20 @@ export class ViaGraph {
     // collections each referencing the other) are legal and must not be treated as a
     // derivation cycle. Ref edges exist for cascade/rename machinery
     // (`referencingEdgesOf`/delete-time restrict/cascade/nullify), never derivation
-    // ordering, so they carry no ordering constraint here. `_out` stores bare
-    // `FieldRef` targets (no kind) — the kind lives on `_in`, keyed by the target.
-    const notRefEdge = (t: FieldRef): boolean => this._in.get(nodeId(t))?.kind !== 'ref'
+    // ordering, so they carry no ordering constraint here. #678 — `kind` is read off
+    // THIS `_out` entry (edge-local), NOT re-derefed from `_in`: a dual-role target
+    // (e.g. #631's exempt {computed, lookup} composition) can have its `_in` entry's
+    // `kind` overwritten by a LATER `registerDerived` call for the SAME target, so
+    // asking `_in` "what kind is `t` registered as NOW" wrongly excluded a real
+    // computed edge from the DFS as if it were a ref edge, hiding a genuine
+    // derivation cycle. Asking "what kind is THIS specific edge" is correct
+    // regardless of what else was later registered for the target.
+    const notRefEdge = (entry: OutEdge): boolean => entry.kind !== 'ref'
     const neighboursOf = (id: string): readonly FieldRef[] => {
-      const own = (this._out.get(id) ?? []).filter(notRefEdge)
+      const own = (this._out.get(id) ?? []).filter(notRefEdge).map((entry) => entry.target)
       const sep = id.indexOf(SEP)
       if (id.slice(sep + 1) === '*') return own
-      const wildcard = (this._out.get(`${id.slice(0, sep)}${SEP}*`) ?? []).filter(notRefEdge)
+      const wildcard = (this._out.get(`${id.slice(0, sep)}${SEP}*`) ?? []).filter(notRefEdge).map((entry) => entry.target)
       if (wildcard.length === 0) return own
       return [...own, ...wildcard]
     }
@@ -432,10 +447,17 @@ export class ViaGraph {
     const targets = this._out.get(nodeId({ collection: backing, field: '*' }))
     if (!targets) return []
     const out: Array<{ referencing: FieldRef; onDelete: OnDelete; keyField: string }> = []
-    for (const target of targets) {
-      const edge = this._in.get(nodeId(target))
-      if (edge?.kind === 'ref' && edge.onDelete !== undefined) {
-        out.push({ referencing: target, onDelete: edge.onDelete, keyField: edge.keyField ?? 'id' })
+    for (const entry of targets) {
+      // #678 — `kind` is read directly off THIS `_out` entry (edge-local) instead of
+      // re-derefing `_in`. This also fixes the symmetric ref-vanishes hazard: under a
+      // registration order where a LATER `registerDerived` call for the same target
+      // overwrites `_in`'s kind away from `'ref'`, the old `_in`-derefing check would
+      // silently drop a genuine referencing edge from cascade/nullify delete machinery
+      // even though this specific edge was truly registered as `'ref'`.
+      if (entry.kind !== 'ref') continue
+      const edge = this._in.get(nodeId(entry.target))
+      if (edge?.onDelete !== undefined) {
+        out.push({ referencing: entry.target, onDelete: edge.onDelete, keyField: edge.keyField ?? 'id' })
       }
     }
     return out

--- a/packages/hub/src/via/money/where.ts
+++ b/packages/hub/src/via/money/where.ts
@@ -182,16 +182,20 @@ export function moneyFieldClause(
  * lazy-mode mixed-era record's bucket and a canonicalized probe now agree,
  * the same as eager mode.
  *
- * Residual boundary, NOT fixed by #677: `LazyQuery`'s post-filter
- * (`lazy-builder.ts`'s `matchesAll`) re-evaluates every clause — including
- * the index-driving one — against the DECODED record (`getRecord()` runs
- * `via.present()`), using the generic (non-Via-aware) `evaluateClause`,
- * because `LazyQuery.where()` never builds a `clause.via` the way
- * `Query.where()`/`ScanBuilder.where()` do. So `lazyQuery().where()` on a
- * money field still needs the query value passed in the field's STORED
- * (canonical scaled-int) form for the fast path to be reachable at all, and
- * full `.toArray()` parity with `scan().where()` (which quantizes major
- * units) is a separate, tracked follow-up — not a canonicalization gap.
+ * Residual boundary, NOT fixed by #677 — tracked in #684: `LazyQuery`'s
+ * post-filter (`lazy-builder.ts`'s `matchesAll`) re-evaluates every clause
+ * — including the index-driving one — against the DECODED record
+ * (`getRecord()` runs `via.present()`), using the generic (non-Via-aware)
+ * `evaluateClause`, because `LazyQuery.where()` never builds a `clause.via`
+ * the way `Query.where()`/`ScanBuilder.where()` do. At `scale: 0` this
+ * doesn't surface (decode is identity). At `scale > 0` it does — even a
+ * query value spelled in the field's STORED (canonical scaled-int) form
+ * reaches the right candidate ids via the index, but the post-filter then
+ * rejects every one of them (raw vs decoded mismatch). Practical result:
+ * `lazyQuery().where()` on a money field with `scale > 0` returns an EMPTY
+ * `.toArray()` end-to-end, no matter how the query value is spelled. Only
+ * the index layer (this file + #677) is fixed; full parity with
+ * `scan().where()` is tracked in #684.
  */
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 export function moneyIndexProbe(op: Operator, payload: MoneyWhereOperand): unknown | undefined {

--- a/packages/hub/src/via/money/where.ts
+++ b/packages/hub/src/via/money/where.ts
@@ -171,12 +171,27 @@ export function moneyFieldClause(
  * canonical write's probe hits directly (no canonicalization needed for the
  * common case); this note covers the pre-declaration tail.
  *
- * Boundary: this guarantee is EAGER-mode only (`CollectionIndexes`, this
- * file's index probe). LAZY mode's `PersistedCollectionIndex`
- * (`with-lookup/indexing/persisted-indexes.ts`) keeps its own raw bucketing
- * and does not consult money canonicalization — a lazy-mode mixed-era record
- * can still diverge between its fast path and a forced scan. Tracked
- * separately, not fixed here.
+ * Boundary — CLOSED for the index layer (#677): LAZY mode's
+ * `PersistedCollectionIndex` (`with-lookup/indexing/persisted-indexes.ts`)
+ * now consults the SAME `ViaPipeline.canonicalizeIndexKey` at every
+ * bucket-mutation site (`ingest`/`upsert`/`remove`) as `CollectionIndexes`
+ * does, and its query path (`with-lookup/indexing/lazy-builder.ts`'s
+ * `resolveCandidateIds()`) canonicalizes the `==`/`in` probe value before
+ * calling `lookupEqual`/`lookupIn` — mirroring `candidateRecords()` above
+ * resolving `indexValue` before its own `lookupEqual`/`lookupIn` call. A
+ * lazy-mode mixed-era record's bucket and a canonicalized probe now agree,
+ * the same as eager mode.
+ *
+ * Residual boundary, NOT fixed by #677: `LazyQuery`'s post-filter
+ * (`lazy-builder.ts`'s `matchesAll`) re-evaluates every clause — including
+ * the index-driving one — against the DECODED record (`getRecord()` runs
+ * `via.present()`), using the generic (non-Via-aware) `evaluateClause`,
+ * because `LazyQuery.where()` never builds a `clause.via` the way
+ * `Query.where()`/`ScanBuilder.where()` do. So `lazyQuery().where()` on a
+ * money field still needs the query value passed in the field's STORED
+ * (canonical scaled-int) form for the fast path to be reachable at all, and
+ * full `.toArray()` parity with `scan().where()` (which quantizes major
+ * units) is a separate, tracked follow-up — not a canonicalization gap.
  */
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 export function moneyIndexProbe(op: Operator, payload: MoneyWhereOperand): unknown | undefined {

--- a/packages/hub/src/with-lookup/indexing/lazy-builder.ts
+++ b/packages/hub/src/with-lookup/indexing/lazy-builder.ts
@@ -41,6 +41,18 @@ export interface LazyOrderBy {
 export interface LazyQuerySource<T> {
   readonly collectionName: string
   readonly persistedIndexes: PersistedCollectionIndex
+  /**
+   * Per-field bucket-key canonicalizer (#677 — lazy twin of the eager
+   * `candidateRecords()` probe-resolution in `kernel/query/builder.ts`).
+   * Consulted in `resolveCandidateIds()` for `==`/`in` clause values
+   * BEFORE calling `lookupEqual`/`lookupIn`, so a mixed-era stored value
+   * (money) probes the SAME canonical bucket the write path now
+   * populates. A narrow closure — not the whole `ViaPipeline` — keeps
+   * the with-lookup/kernel seam thin. `undefined` (no via, or no binding
+   * covers the field) is the common case: falls back to the raw value,
+   * unchanged from today.
+   */
+  canonicalizeIndexKey?(field: string, value: unknown): string | undefined
   /** Ensure `_idx/<field>/*` side-cars have been bulk-loaded into the mirror. */
   ensurePersistedIndexesLoaded(): Promise<void>
   /** Decrypt one record by id, or return null if it's gone. */
@@ -180,15 +192,27 @@ export class LazyQuery<T, S extends keyof T = never, Q extends keyof T & string 
 
     for (const clause of this.plan.clauses) {
       if (clause.op === '==') {
-        const ids = idx.lookupEqual(clause.field, clause.value)
+        // #677: canonicalize the probe value BEFORE the lookup — same
+        // "resolve before lookupEqual" shape as eager's `candidateRecords()`
+        // (which resolves `clause.via.indexValue` first), but through the
+        // narrower `canonicalizeIndexKey` seam: lazy mode never quantizes
+        // major units, so the caller must already pass the field's STORED
+        // form. `undefined` (no via coverage) falls back to the raw clause
+        // value, unchanged from today.
+        const probe = this.source.canonicalizeIndexKey?.(clause.field, clause.value) ?? clause.value
+        const ids = idx.lookupEqual(clause.field, probe)
         if (ids) return [...ids]
       } else if (clause.op === 'in' && Array.isArray(clause.value)) {
-        const ids = idx.lookupIn(clause.field, clause.value as readonly unknown[])
+        const probes = clause.value.map(v => this.source.canonicalizeIndexKey?.(clause.field, v) ?? v)
+        const ids = idx.lookupIn(clause.field, probes)
         if (ids) return [...ids]
       } else if (isRangeOp(clause.op)) {
         // range predicates on an indexed field dispatch
         // through `lookupRange`, which compares on the original typed
-        // value (no numeric-lexicographic landmines).
+        // value (no numeric-lexicographic landmines). NOT canonicalized
+        // (#677) — `lookupRange` compares typed values, not stringified
+        // bucket keys, and (mirroring eager's `moneyIndexProbe`) a money
+        // field has never had a range index fast path on either mode.
         const ids = idx.lookupRange(clause.field, clause.op, clause.value)
         if (ids) return [...ids]
       }

--- a/packages/hub/src/with-lookup/indexing/lazy-builder.ts
+++ b/packages/hub/src/with-lookup/indexing/lazy-builder.ts
@@ -207,12 +207,14 @@ export class LazyQuery<T, S extends keyof T = never, Q extends keyof T & string 
         const ids = idx.lookupIn(clause.field, probes)
         if (ids) return [...ids]
       } else if (isRangeOp(clause.op)) {
-        // range predicates on an indexed field dispatch
+        // range predicates on an indexed field dispatch unconditionally
         // through `lookupRange`, which compares on the original typed
         // value (no numeric-lexicographic landmines). NOT canonicalized
-        // (#677) — `lookupRange` compares typed values, not stringified
-        // bucket keys, and (mirroring eager's `moneyIndexProbe`) a money
-        // field has never had a range index fast path on either mode.
+        // (#677) — unlike eager mode, where `moneyIndexProbe` never emits
+        // a range probe so a money range clause always scans, THIS path
+        // has no scan fallback: a money field's raw/uncanonicalized typed
+        // comparison here is a live, pre-existing correctness gap, tracked
+        // in #684.
         const ids = idx.lookupRange(clause.field, clause.op, clause.value)
         if (ids) return [...ids]
       }

--- a/packages/hub/src/with-lookup/indexing/persisted-indexes.ts
+++ b/packages/hub/src/with-lookup/indexing/persisted-indexes.ts
@@ -329,10 +329,16 @@ export class PersistedCollectionIndex {
    * NOT canonicalized (#677): this method compares `value` against the
    * ORIGINAL TYPED `state.values`, not a stringified bucket key, so a
    * `canonicalizeIndexKey`-shaped (`string | undefined`) result would not
-   * even type-check as a bound here. Mirrors the eager-mode boundary —
-   * `moneyIndexProbe` (`via/money/where.ts`) only ever probes `==`/`in`;
-   * range comparisons on a money field have never had an index fast path
-   * on EITHER mode and always fall back to a scan.
+   * even type-check as a bound here. This does NOT mirror eager mode the
+   * way `lookupEqual`/`lookupIn` do: `moneyIndexProbe` (`via/money/
+   * where.ts`) never emits a range probe, so EAGER mode's `candidateRecords`
+   * never calls an index for a range clause and always scans. LAZY mode's
+   * `resolveCandidateIds()` (`lazy-builder.ts`) dispatches every range
+   * clause through THIS method unconditionally, including money fields —
+   * there is no scan fallback here. Because the comparison is raw/typed
+   * and not canonicalized, a money field's lazy range correctness (e.g.
+   * mixed-era or non-canonical stored values) is a live, pre-existing gap,
+   * tracked in #684 — not yet fixed.
    */
   lookupRange(
     field: string,

--- a/packages/hub/src/with-lookup/indexing/persisted-indexes.ts
+++ b/packages/hub/src/with-lookup/indexing/persisted-indexes.ts
@@ -145,6 +145,27 @@ export class PersistedCollectionIndex {
   private readonly defs = new Map<string, PersistedIndexDef>()
 
   /**
+   * Per-field bucket-key canonicalizer (#677 — lazy twin of #672's
+   * `CollectionIndexes.setCanonicalizer`), registered ONCE via
+   * {@link setCanonicalizer} when the collection wires indexing up
+   * (money-aware via `ViaPipeline.canonicalizeIndexKey`). Consulted by
+   * EVERY bucket-mutation site — `ingest`/`upsert`/`remove` — so bucket
+   * membership is symmetric: a legacy non-canonical stored value (e.g.
+   * `'0100'`) and a canonical one (`'100'`) land in the SAME bucket,
+   * mirroring `eager-indexes.ts`'s `addToIndex`/`removeFromIndex`.
+   */
+  private canonicalize?: (field: string, value: unknown) => string | undefined
+
+  /**
+   * Register the bucket-key canonicalizer. Called once, where the
+   * collection constructs its indexing state — safe to call again (the
+   * closure is simply replaced) but there is normally only one caller.
+   */
+  setCanonicalizer(fn: (field: string, value: unknown) => string | undefined): void {
+    this.canonicalize = fn
+  }
+
+  /**
    * Declare a single-field index. Subsequent `upsert` / `ingest` calls
    * populate the in-memory mirror; calls before `declare` are no-ops
    * (tolerant bulk-load ordering). Idempotent.
@@ -211,7 +232,7 @@ export class PersistedCollectionIndex {
     const state = this.indexes.get(field)
     if (!state) return
     for (const row of rows) {
-      addToState(state, row.recordId, row.value)
+      addToState(state, row.recordId, row.value, field, this.canonicalize)
     }
   }
 
@@ -226,9 +247,9 @@ export class PersistedCollectionIndex {
     const state = this.indexes.get(field)
     if (!state) return
     if (previousValue !== null && previousValue !== undefined) {
-      removeFromState(state, recordId, previousValue)
+      removeFromState(state, recordId, previousValue, field, this.canonicalize)
     }
-    addToState(state, recordId, newValue)
+    addToState(state, recordId, newValue, field, this.canonicalize)
   }
 
   /**
@@ -240,7 +261,7 @@ export class PersistedCollectionIndex {
   remove(recordId: string, field: string, value: unknown): void {
     const state = this.indexes.get(field)
     if (!state) return
-    removeFromState(state, recordId, value)
+    removeFromState(state, recordId, value, field, this.canonicalize)
   }
 
   /**
@@ -261,6 +282,14 @@ export class PersistedCollectionIndex {
    * back to scan or throws `IndexRequiredError`). Returns a shared empty
    * set if the field is declared but no record matches — that set MUST
    * NOT be mutated by the caller.
+   *
+   * `value` is bucketed via the plain {@link stringifyKey} — it is NOT
+   * canonicalized here. Callers on a Via-covered field (money) canonicalize
+   * `value` themselves BEFORE calling (see `lazy-builder.ts`'s
+   * `resolveCandidateIds()`, #677) — the SAME caller-canonicalizes split
+   * `eager-indexes.ts`'s `lookupEqual`/`lookupIn` use (see `kernel/query/
+   * builder.ts`'s `candidateRecords()`), so probing here twice never
+   * double-canonicalizes.
    */
   lookupEqual(field: string, value: unknown): ReadonlySet<string> | null {
     const state = this.indexes.get(field)
@@ -272,7 +301,8 @@ export class PersistedCollectionIndex {
   /**
    * Set lookup — return the union of record ids whose `field` matches any
    * of `values`. Returns `null` if the field is not declared. Returns a
-   * fresh (non-shared) Set — safe for the caller to mutate.
+   * fresh (non-shared) Set — safe for the caller to mutate. Same
+   * caller-canonicalizes contract as {@link lookupEqual} (#677).
    */
   lookupIn(field: string, values: readonly unknown[]): ReadonlySet<string> | null {
     const state = this.indexes.get(field)
@@ -295,6 +325,14 @@ export class PersistedCollectionIndex {
    * Supported ops: `'<'`, `'<='`, `'>'`, `'>='`, `'between'`. For
    * `'between'`, `value` is `[lo, hi]` and both bounds are inclusive
    * (matches the eager-mode operator contract in `predicate.ts`).
+   *
+   * NOT canonicalized (#677): this method compares `value` against the
+   * ORIGINAL TYPED `state.values`, not a stringified bucket key, so a
+   * `canonicalizeIndexKey`-shaped (`string | undefined`) result would not
+   * even type-check as a bound here. Mirrors the eager-mode boundary —
+   * `moneyIndexProbe` (`via/money/where.ts`) only ever probes `==`/`in`;
+   * range comparisons on a money field have never had an index fast path
+   * on EITHER mode and always fall back to a scan.
    */
   lookupRange(
     field: string,
@@ -358,9 +396,15 @@ function stringifyKey(value: unknown): string {
   return '\0OBJECT\0'
 }
 
-function addToState(state: PersistedFieldState, recordId: string, value: unknown): void {
+function addToState(
+  state: PersistedFieldState,
+  recordId: string,
+  value: unknown,
+  field: string,
+  canonicalize?: (field: string, value: unknown) => string | undefined,
+): void {
   if (value === null || value === undefined) return
-  const key = stringifyKey(value)
+  const key = canonicalize?.(field, value) ?? stringifyKey(value)
   let bucket = state.buckets.get(key)
   if (!bucket) {
     bucket = new Set()
@@ -370,9 +414,15 @@ function addToState(state: PersistedFieldState, recordId: string, value: unknown
   state.values.set(recordId, value)
 }
 
-function removeFromState(state: PersistedFieldState, recordId: string, value: unknown): void {
+function removeFromState(
+  state: PersistedFieldState,
+  recordId: string,
+  value: unknown,
+  field: string,
+  canonicalize?: (field: string, value: unknown) => string | undefined,
+): void {
   if (value === null || value === undefined) return
-  const key = stringifyKey(value)
+  const key = canonicalize?.(field, value) ?? stringifyKey(value)
   const bucket = state.buckets.get(key)
   if (bucket) {
     bucket.delete(recordId)


### PR DESCRIPTION
Closes #677
Closes #678

Closes milestone #33 (Via follow-ups 3).

**#678** — `ViaGraph._out` edges now carry their own registration-time `kind` (`OutEdge`), and both `assertAcyclic`'s ref-edge filter and `referencingEdgesOf` read it edge-locally instead of re-dereferencing the single-slot `_in` entry. A dual-role target (computed-then-ref, #631's exempt composition order) no longer has its computed edge hidden from cycle detection, and the symmetric ref-vanishes hazard in cascade/nullify resolution is fixed for free. **Latent in production today** (`assertAcyclic` runs once at `openVault()`, before any `vault.collection()` registers edges) — this is a regression guard, pinned by a direct `ViaGraph` test.

**#677** — lazy-mode `PersistedCollectionIndex` now consults the same `ViaPipeline.canonicalizeIndexKey` as eager at every bucket-mutation site (`ingest`/`upsert`/`remove`), and the lazy planner canonicalizes `==`/`in` probe values before lookup — mixed-era money records and canonical writes share one bucket on the lazy path, at parity with #672's eager fix.

## Honest boundary (read before assuming lazy money queries work)

Only the **index layer** is fixed. `LazyQuery.where()` never builds `clause.via`, so its post-filter compares raw query values against *decoded* records — and `lazyQuery().where(moneyField, …).toArray()` **still returns an empty array end-to-end for any money field with `scale > 0`**, regardless of query spelling. Lazy money *range* clauses additionally dispatch through `lookupRange` raw with no scan fallback. Both are tracked in **#684** (LazyQuery Via-awareness: post-filter, range hole, `indexValue` precedence), and the docs/comments state this explicitly. This also **corrects #677's own premise** — it claimed lazy money "always scans (functionally correct)"; it doesn't (lazy has no scan fallback), it returns empty — a correctness bug, which is why #684 is filed.

What #677 *does* deliver: at `scale: 0`, mixed-era legacy records become reachable through the public `lazyQuery().toArray()` API at all (unreachable before under any spelling); the durable `_idx/*` side-cars now accrue canonical buckets, preventing raw-bucket debt that would need reconciliation after #684; and update/delete bucket hygiene prevents stranded ids in durable state (fenced directly — see the review note below).

**#677 item (3)** (eager late-attach money onto an already-built index: pre-attach rows sit in raw buckets until the next rebuild-on-hydrate self-corrects) is deliberately NOT addressed here and is NOT in #684's scope — it self-corrects on rebuild-on-hydrate; filed separately as a tracked follow-up rather than silently closed with #677.

## Review

Both fixes passed task gates; #677's gate (Fable) adjudicated ACCEPT-at-the-index-layer + file #684, and independently RED-verified the fix. The whole-branch final review (Fable) ran mutation probes: the #678 edge-local filter and the #677 probe consult are both fenced by committed tests. It caught one fence gap — the `upsert` remove-old bucket-symmetry site survived the whole suite because the #684 post-filter masks a stranded bucket in `.toArray()` — now pinned by a `col.get` fetch-spy (bite-verified). One doc inaccuracy (multi-currency "both modes") corrected.

## Gauntlet at HEAD

Full hub suite green (493 files / 4006+ tests), typecheck, lint, `check:architecture` (via-layering allowlist empty — no kernel→via/** or with-lookup→via/money import added). Ceilings exact: collection.ts 4472/4472 (the #677 registration lines offset by two byte-preserving JSDoc joins), vault.ts 3938/3939, noydb.ts 2384/2385. Changeset (`@noy-db/hub` patch) authored locally.
