### PR TITLE
fix(hub): carry every envelope slot through elevate/demote tier moves (#662)

### DIFF
--- a/packages/hub/__tests__/hierarchical-tiers.test.ts
+++ b/packages/hub/__tests__/hierarchical-tiers.test.ts
@@ -300,6 +300,74 @@ describe('v0.18 hierarchical access', () => {
     })
   })
 
+  describe('elevate/demote preserve every envelope slot on a tier move (#662)', () => {
+    it('elevate carries _sealed forward', async () => {
+      const { db, vault } = await freshVault()
+      const docs = vault.collection<Doc>('docs', { tiers: [0, 1], sensitive: ['body'] })
+      await docs.put('d1', { id: 'd1', title: 'Top', body: 'classified payload' })
+
+      const store = (db as unknown as { options: { store: NoydbStore } }).options.store
+      const tier0Env = (await store.get('v1', 'docs', 'd1'))!
+      const sealed0 = tier0Env._sealed!.body
+      expect(sealed0).toBeDefined()
+
+      await docs.elevate('d1', 1)
+
+      const tier1Env = (await store.get('v1', 'docs', 'd1'))!
+      expect(tier1Env._tier).toBe(1)
+      // Pre-fix: the field-literal rebuild dropped `_sealed` entirely.
+      expect(tier1Env._sealed?.body).toBe(sealed0)
+
+      const out = await docs.getAtTier('d1') as Doc
+      expect(out.body).toBe('classified payload')
+    })
+
+    it('demote round-trips _sealed', async () => {
+      const { db, vault } = await freshVault()
+      const docs = vault.collection<Doc>('docs', { tiers: [0, 1], sensitive: ['body'] })
+      await docs.put('d1', { id: 'd1', title: 'Top', body: 'classified payload' })
+
+      const store = (db as unknown as { options: { store: NoydbStore } }).options.store
+      const tier0Env = (await store.get('v1', 'docs', 'd1'))!
+      const sealed0 = tier0Env._sealed!.body
+
+      await docs.elevate('d1', 1)
+      await docs.demote('d1', 0)
+
+      const tier0EnvAfter = (await store.get('v1', 'docs', 'd1'))!
+      expect(tier0EnvAfter._tier).toBeUndefined()
+      expect(tier0EnvAfter._elevatedBy).toBeUndefined()
+      // Pre-fix: the field-literal rebuild dropped `_sealed` entirely.
+      expect(tier0EnvAfter._sealed?.body).toBe(sealed0)
+
+      const out = await docs.getAtTier('d1') as Doc
+      expect(out.body).toBe('classified payload')
+    })
+
+    it('a sibling passenger slot (_source/_sourceTs) also survives elevate', async () => {
+      // `_det` (deterministicFields) needs an extra `acknowledgeDeterministicRisk:
+      // true` opt-in; provenance's `_source`/`_sourceTs` needs only
+      // `{ provenance: true }` plus a `source` option on `put()`, so it's the
+      // simplest sibling slot to exercise here.
+      const { db, vault } = await freshVault()
+      const docs = vault.collection<Doc>('docs', { tiers: [0, 1], provenance: true })
+      await docs.put('d1', { id: 'd1', title: 'Top', body: 'b' }, { source: 'registry-A' })
+
+      const store = (db as unknown as { options: { store: NoydbStore } }).options.store
+      const tier0Env = (await store.get('v1', 'docs', 'd1'))!
+      expect(tier0Env._source).toBe('registry-A')
+      const sourceTs0 = tier0Env._sourceTs
+
+      await docs.elevate('d1', 1)
+
+      const tier1Env = (await store.get('v1', 'docs', 'd1'))!
+      expect(tier1Env._tier).toBe(1)
+      // Pre-fix: the field-literal rebuild dropped `_source`/`_sourceTs` entirely.
+      expect(tier1Env._source).toBe('registry-A')
+      expect(tier1Env._sourceTs).toBe(sourceTs0)
+    })
+  })
+
   it('tiers disabled by default throws on putAtTier', async () => {
     const { vault } = await freshVault()
     const docs = vault.collection<Doc>('docs')

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -277,7 +277,13 @@ export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: numbe
   const now = new Date().toISOString()
   const body = await rewrapBodyToDek(envelope, fromDek, toDek)
   if (body.cek) ctx.cekCache?.set(id, body.cek, 1)
+  // #662: spread every slot the source carries (_sealed/_det/_vdig/_bidx/
+  // _source/_sourceTs/_debug) through UNCHANGED, then override only
+  // the fields a tier move manages. rewrapBodyToDek preserves the CEK, so no
+  // passenger slot is re-keyed by the move. The old field-literal dropped every
+  // unlisted slot.
   const next: EncryptedEnvelope = {
+    ...envelope,
     _noydb: NOYDB_FORMAT_VERSION,
     _v: envelope._v + 1,
     _ts: now,
@@ -333,14 +339,20 @@ export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number
   const now = new Date().toISOString()
   const body = await rewrapBodyToDek(envelope, fromDek, toDek)
   if (body.cek) ctx.cekCache?.set(id, body.cek, 1)
+  // #662: same passenger carry-through as elevate(). demote additionally CLEARS
+  // `_elevatedBy` (the demote right is consumed) and OMITS `_tier` at tier 0, so
+  // both are destructured out of the spread rather than carried.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- excluded from ...carried
+  const { _elevatedBy, _tier: _priorTier, ...carried } = envelope
   const next: EncryptedEnvelope = {
+    ...carried,
     _noydb: NOYDB_FORMAT_VERSION,
     _v: envelope._v + 1,
     _ts: now,
     _iv: body._iv,
     _data: body._data,
     _by: ctx.keyring.userId,
-    ...(toTier > 0 && { _tier: toTier }),
+    ...(toTier > 0 ? { _tier: toTier } : {}),
     ...(body._cek !== undefined ? { _cek: body._cek } : {}),
   }
   await ctx.adapter.put(ctx.vault, ctx.name, id, next)


### PR DESCRIPTION
## The bug (#662)

`elevate()` and `demote()` in `with-audit/tiers/index.ts` rebuilt the moved envelope as a **field-by-field literal** enumerating only `_noydb/_v/_ts/_iv/_data/_by/_tier/_elevatedBy?/_cek?`. Auditing that literal against the full `EncryptedEnvelope` type shows it silently **dropped every unlisted optional slot** present on the source — not just the reported `_sealed`, but also `_det`, `_vdig`, `_bidx`, `_source`/`_sourceTs`, `_debug`. Elevating or demoting a record with any of those lost that data from the stored tier copy: write-side data loss for classified/sensitive sealed fields, blind-equality (`findByDet`) index entries, and provenance.

## Why carrying them through is correct

`rewrapBodyToDek` **preserves the record's CEK** on a tier move (it re-wraps the same CEK under the new tier DEK; the body key never changes). All the dropped slots are keyed off the CEK, the collection DEK, or the recordId/field — **never the tier or tier DEK** — so a tier move never re-keys them. They remain valid ciphertext and must carry through **byte-identically**. The read side already handles `_sealed` at tier>0 (#635), so it surfaces for free once writes stop dropping it.

## The fix — spread-with-overrides (the issue's own suggested shape)

- `elevate()`: `...envelope` carries every passenger slot unchanged; override only the managed fields (`_v`/`_ts`/`_iv`/`_data`/`_by`/`_tier`/`_elevatedBy`/`_cek?`) and re-stamp `_noydb`.
- `demote()`: same, but destructures `_elevatedBy`/`_tier` out of the spread so it still **clears `_elevatedBy`** (the demote right is consumed) and **omits `_tier` at tier 0** (a demoted-to-0 record stays shape-identical to a native tier-0 one). A plain spread would have regressed both.

## Tests (`hierarchical-tiers.test.ts`, all RED-first)

1. `elevate()` carries `_sealed` byte-identically → `getAtTier` surfaces the sealed value.
2. `demote()` round-trips `_sealed` byte-identically; `_tier` and `_elevatedBy` correctly cleared; body decryptable at tier 0 via a **cold** `getAtTier` read (not the stale eager cache).
3. A sibling passenger slot (`_source`/`_sourceTs`) also survives — locking that the fix restores *every* dropped slot, not only `_sealed`.

43/43 across `hierarchical-tiers`/`elevation`/`per-record-cek`/`tiers-optin`; typecheck, lint, `check:architecture` all clean.

## Review

Adversarial crypto review **confirmed correctness**: traced each carried slot's key derivation + AAD and verified all are tier-independent; the `_cek` override invariant holds both directions (legacy and CEK records); demote field-discipline is correct; zero-knowledge intact. The demote body-read assertion was found vacuous (served from the un-invalidated eager cache) and fixed to a cold read, mutation-proven.

## Follow-up (out of scope — #691)

The carry **exposes** a pre-existing tier-unawareness: `findByDet`/`queryByDet`/`verify`/`findByDigest` resolve keys under the tier-0 DEK unconditionally and now throw uncaught `InvalidKeyError`/`TamperedError` on an elevated record's carried slots (same class #635 fixed for `getAtTier`'s `_sealed` leg). Tracked in **#691**; must precede shipping the classified/det + tiers combination. Do **not** revert this carry — the carry is correct.

Closes #662.