### PR TITLE
fix(hub): milestone #29 sync-engine follow-ups — partial-sync dict deps, synced-insert perf, sync-delete parity (#653, #606, #658)

### DIFF
--- a/docs/subsystems/via.md
+++ b/docs/subsystems/via.md
@@ -293,9 +293,8 @@ now classifies each applied envelope as `'put'` or `'delete'` and threads the ac
 widened `cacheInvalidator` seam; `GraphBatch` gains a delete leg (`GraphTouch.deletes: Map<string,
 readonly RollupDeleteIntent[]>`, ids/names only — no record payload, no key material); the dispatch
 wave (`runGraphDispatchWave`) routes deleted ids to the SAME rollup-recompute trio a local delete
-uses (batched, deduped per parent+field), never `dispatchDerivations`/MV-on-delete — mirroring the
-`mutation-choke-point.test.ts:85-99` pin that a delete is dispatch-inert for derivations/MVs, both
-locally and over sync:
+uses (batched, deduped per parent+field), never `dispatchDerivations` — mirroring the
+`mutation-choke-point.test.ts:85-99` pin that a delete never RE-DERIVEs, both locally and over sync:
 
 ```ts
 // db2 pulls a delete of a rollup child from db1; orderCount is registered ONLY on db2
@@ -311,12 +310,28 @@ eviction of the child before the sync-apply lands) **or an un-hydrated eager col
 sync op for that child is a delete** (`ensureHydrated()` never ran, so the eager cache never held a
 record to peek) — the miss is silent and freshness-only: that one child's rollup-parent intents are
 skipped, no recompute happens for it, and no error is raised. Correctness is otherwise intact (the
-recompute reads the REMAINING children from the store, so nothing double-counts); this is a
-follow-up candidate, not fixed here. The sync-delete path also stays narrower than the local-delete
-path by design: it recomputes only the rollup leg, not `dispatchMaterializedViewsOnDelete`/
-`dispatchArrayDerivationsOnDelete` — both #640's issue text and the `mutation-choke-point.test.ts`
-pin scope sync-delete dispatch to rollups only; wiring MV/array-derivation-on-delete into the
-sync-delete wave is a candidate follow-up, not a regression of this pass.
+recompute reads the REMAINING children from the store, so nothing double-counts); this cold-child
+gap remains a follow-up candidate, not fixed here — it also gates the MV/array-derivation healing
+described below (both read the same `_peekCached`-gated touch).
+
+**Sync-applied deletes now heal MV rows and array-derivation outputs too (#658), closing the
+rollup-only gap above.** #640 (this pass) scoped the sync-delete wave to the rollup leg only, so a
+remotely-deleted child left its MV mirror rows and array-shape derivation output rows stale —
+diverging from the local-delete path (`Collection._doDelete`'s `!internal` block), which already
+calls `dispatchRollupsOnDelete` + `dispatchMaterializedViewsOnDelete` +
+`dispatchArrayDerivationsOnDelete` for every delete. #658 closes that divergence: the wave's
+deletes loop now also calls `dispatchMaterializedViewsOnDelete`/`dispatchArrayDerivationsOnDelete`
+per touched id, inside the same per-id isolation `try` as the rollup recompute. Both calls need
+only the id (MV refresh recomputes the query fresh and diffs; array-derivation reads its per-source
+fanout sidecar) and never call `derive()`, so the `dispatchDerivations`/never-RE-DERIVE pin above
+still holds. Record-shape same-id derivation outputs stay untouched on the sync-delete path too
+(`eraseRecordShapeToo` defaults `false`), matching local delete
+(from `packages/hub/__tests__/via/sync-delete-derivation.test.ts`). **Perf follow-up, not fixed
+here:** unlike the put-path `dispatchMaterializedViews`, `dispatchMaterializedViewsOnDelete` takes
+no `WaveContext`, so N children deleted from one eager MV in the same batch each trigger a full
+refresh pass instead of deduping to one — correctness is unaffected (idempotent per source-id);
+threading a wave through would touch collection.ts's zero-slack kernel-surface ceiling for a
+perf-only win.
 
 **Riders.** `push()`/`pull()` now wrap `persistMeta()` in a `finally` that flushes the graph batch
 even when `persistMeta()` throws — previously a throw there left `_graphBatch` open, silently

--- a/packages/hub/__tests__/606-marker-race.test.ts
+++ b/packages/hub/__tests__/606-marker-race.test.ts
@@ -109,8 +109,7 @@ describe('#606 adversarial: marker lands mid-hydration', () => {
     // markerIds says "not a marker" → the gate skips the store read → _v=1.
     await b.put('ghost', { body: 're-created' })
     const raw = localB.raw(V, 'notes', 'ghost')!
-    console.log('re-created ghost _v =', raw._v, '(3 = correct continuity, 1 = divergence)')
-    expect(raw._v).toBe(3) // #589 invariant — FAILS if the set diverged
+    expect(raw._v).toBe(3) // #589 invariant — FAILS if the set diverged (1 = divergence)
     dbB.close()
   })
 })

--- a/packages/hub/__tests__/606-marker-race.test.ts
+++ b/packages/hub/__tests__/606-marker-race.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Adversarial repro for #606 review: a delete-marker landing via pull WHILE the
+ * eager collection is mid-hydration is never recorded in `markerIds`:
+ *   - `_invalidateCacheEntry` early-returns on `!this.hydrated` BEFORE the add,
+ *   - `ensureHydrated`'s `adapter.list()` snapshot was taken before the marker landed,
+ * so the set permanently lacks the id for this session. A later re-create put
+ * then resets to _v=1 instead of continuing past the marker (_v=3).
+ * Pre-#606 the gate's unconditional adapter.get would have seen the marker.
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
+import { ConflictError } from '../src/kernel/errors.js'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { withSync } from '../src/with-party/sync/index.js'
+import { isDeleteMarker } from '../src/kernel/enclave/record-keys/tombstone.js'
+
+const V = 'v1'
+interface Note { body: string }
+
+function memory(): NoydbStore & {
+  raw(c: string, col: string, id: string): EncryptedEnvelope | undefined
+  stallNextGetFor(col: string, id: string): { release: () => void; hit: Promise<void> }
+} {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  let stall: { col: string; id: string; gate: Promise<void>; release: () => void; onHit: () => void } | null = null
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    raw(c, col, id) { return store.get(c)?.get(col)?.get(id) },
+    stallNextGetFor(col, id) {
+      let release!: () => void
+      let onHit!: () => void
+      const gate = new Promise<void>(r => { release = r })
+      const hit = new Promise<void>(r => { onHit = r })
+      stall = { col, id, gate, release, onHit }
+      return { release, hit }
+    },
+    async get(c, col, id) {
+      if (stall && stall.col === col && stall.id === id) {
+        const s = stall
+        stall = null // one-shot
+        s.onHit()
+        await s.gate
+      }
+      return store.get(c)?.get(col)?.get(id) ?? null
+    },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) }
+    },
+  }
+}
+
+describe('#606 adversarial: marker lands mid-hydration', () => {
+  it('re-create over a pull-applied marker that landed mid-hydration resets to _v=1 (divergence)', async () => {
+    const localA = memory(); const localB = memory(); const remote = memory()
+
+    // Peer A creates + deletes 'ghost' → marker _v=2 pushed to remote. Also a
+    // live 'anchor' record so B's hydration loop has an id to stall on.
+    const dbA = await createNoydb({ store: localA, sync: remote, user: 'a', syncStrategy: withSync(), encrypt: false })
+    const a = (await dbA.openVault(V)).collection<Note>('notes')
+    await a.put('anchor', { body: 'x' })
+    await a.put('ghost', { body: 'v1' })
+    await a.delete('ghost') // marker _v=2
+    await dbA.push(V)
+    dbA.close()
+    expect(isDeleteMarker(remote.raw(V, 'notes', 'ghost')!)).toBe(true)
+
+    // Peer B: local store has ONLY the live 'anchor' (seeded in an earlier
+    // session), no 'ghost' — so B's hydration list() will not contain 'ghost'.
+    const dbB0 = await createNoydb({ store: localB, sync: remote, user: 'b', syncStrategy: withSync(), encrypt: false })
+    const b0 = (await dbB0.openVault(V)).collection<Note>('notes')
+    await b0.put('anchor', { body: 'x' })
+    dbB0.close()
+
+    // Fresh instance over B's store. Stall hydration at its first per-id get
+    // ('anchor'), i.e. AFTER list() captured ids=['anchor'].
+    const dbB = await createNoydb({ store: localB, sync: remote, user: 'b', syncStrategy: withSync(), encrypt: false })
+    const b = (await dbB.openVault(V)).collection<Note>('notes')
+
+    const { release, hit } = localB.stallNextGetFor('notes', 'anchor')
+    const hydration = b.get('anchor') // kicks off ensureHydrated; stalls mid-loop
+    await hit
+
+    // While hydration is stalled: pull applies the remote marker for 'ghost'
+    // into B's local store. The collection is mid-hydration (hydrated=false),
+    // so _invalidateCacheEntry early-returns without markerIds.add.
+    await dbB.pull(V)
+    expect(isDeleteMarker(localB.raw(V, 'notes', 'ghost')!)).toBe(true) // marker IS in B's store
+
+    release()
+    await hydration // hydration completes; ids list never contained 'ghost'
+
+    // The divergence: B re-creates 'ghost'. The store holds a marker _v=2, but
+    // markerIds says "not a marker" → the gate skips the store read → _v=1.
+    await b.put('ghost', { body: 're-created' })
+    const raw = localB.raw(V, 'notes', 'ghost')!
+    console.log('re-created ghost _v =', raw._v, '(3 = correct continuity, 1 = divergence)')
+    expect(raw._v).toBe(3) // #589 invariant — FAILS if the set diverged
+    dbB.close()
+  })
+})

--- a/packages/hub/__tests__/693-tab-coordination-marker.test.ts
+++ b/packages/hub/__tests__/693-tab-coordination-marker.test.ts
@@ -1,0 +1,174 @@
+/**
+ * #693: #606's per-collection `markerIds` set is authoritative only for a
+ * store this instance solely writes (plus sync-relayed remote writes). Under
+ * multi-tab coordination sharing one store (`enableTabCoordination` with
+ * write-propagation), another tab can write a delete-marker directly to the
+ * shared store; this instance's `markerIds` doesn't learn of it until the
+ * BroadcastChannel relay delivers `_applyRemoteChange`. In that latency
+ * window, a `put(id)` here hits the #589/#606 re-create gate with
+ * `markerIds.has(id)` false → the store read is skipped → `version` resets
+ * to 1 → the marker is overwritten → the record is lost on the next sync
+ * (the #589 regression). The fix: when tab coordination is active at all —
+ * presence/election alone or full write-propagation (`Noydb.tabCoordinator`
+ * set), the gate falls back to the pre-#606 unconditional read, restoring
+ * determinism at the cost of the #606 perf win — which stays intact for the
+ * common non-tab-coordinated case (test below).
+ */
+import { describe, it, expect } from 'vitest'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
+import type { TabChannel } from '../src/with-party/tab-coordination.js'
+import { ConflictError } from '../src/kernel/errors.js'
+import { createNoydb } from '../src/kernel/noydb.js'
+import { withSync } from '../src/with-party/sync/index.js'
+import { isDeleteMarker, buildDeleteMarker } from '../src/kernel/enclave/record-keys/tombstone.js'
+
+/**
+ * In-memory store exposing raw stored envelopes for white-box assertions,
+ * plus a `_getCalls`/`_getCallsFor`/`_resetCounters()` set (pattern ported
+ * from delete-tombstone-convergence.test.ts / lazy-hydration.test.ts) so the
+ * #606 perf win can be proven by call count, not just by behavior.
+ */
+function memory(): NoydbStore & {
+  raw(c: string, col: string, id: string): EncryptedEnvelope | undefined
+  _getCalls: number
+  _getCallsFor(col: string, id: string): number
+  _resetCounters(): void
+} {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const calls: { col: string; id: string }[] = []
+  function gc(c: string, col: string) {
+    let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    raw(c, col, id) { return store.get(c)?.get(col)?.get(id) },
+    get _getCalls() { return calls.length },
+    _getCallsFor(col, id) { return calls.filter(x => x.col === col && x.id === id).length },
+    _resetCounters() { calls.length = 0 },
+    async get(c, col, id) {
+      calls.push({ col, id })
+      return store.get(c)?.get(col)?.get(id) ?? null
+    },
+    async put(c, col, id, env, ev) {
+      const coll = gc(c, col); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) { if (!n.startsWith('_')) { const r: Record<string, EncryptedEnvelope> = {}; for (const [id, e] of coll) r[id] = e; s[n] = r } }
+      return s
+    },
+    async saveAll(c, data) {
+      for (const [n, recs] of Object.entries(data)) { const coll = gc(c, n); for (const [id, e] of Object.entries(recs)) coll.set(id, e) }
+    },
+  }
+}
+
+/** Minimal injected channel — never delivers anything (no bus wired to a
+ *  second tab). Enough to make `enableTabCoordination` mint a `tabCoordinator`
+ *  (used as `channel` for presence-only tests, `writeChannel` when a
+ *  `writeRelay` is also needed) — which is all `_tabCoordinationActive`
+ *  consults; the relay/channel never needs to actually deliver anything
+ *  since the scenario under test is the pre-delivery window. */
+function mockChannel(): TabChannel {
+  return { isOpen: true, send() {}, on() { return () => {} }, close() {} }
+}
+
+interface Note { body: string }
+const V = 'V1'
+
+describe('#693: re-create gate falls back to a store read under multi-tab coordination', () => {
+  it('a marker written out-of-band by a peer tab (not yet relayed) is not lost on re-create', async () => {
+    const local = memory(); const remote = memory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'a', syncStrategy: withSync(), encrypt: false })
+    const notes = (await db.openVault(V)).collection<Note>('notes')
+
+    // Trigger hydration BEFORE the marker lands, so `ensureHydrated()`'s cold
+    // scan can't seed `markerIds` with it — the store doesn't have 'x' yet.
+    await notes.put('anchor', { body: 'seed' })
+
+    // Enable tab-coordination write-propagation with an injected mock channel
+    // (mirrors tab-coordination-noydb.test.ts) so `db`'s `writeRelay` is set —
+    // no real BroadcastChannel exists in node.
+    db.enableTabCoordination({ writeChannel: mockChannel(), tabId: 'A' })
+
+    // Simulate a peer tab writing a delete-marker directly into the SHARED
+    // local store, bypassing this instance's Collection entirely — the
+    // broadcast-relay latency window. Do NOT deliver any broadcast.
+    await local.put(V, 'notes', 'x', buildDeleteMarker(2, 'peer'))
+
+    // Pre-fix: markerIds has no entry for 'x' → gate skips the store read →
+    // version resets to 1, silently overwriting the peer's marker (data loss).
+    // Post-fix: `tabCoordinated()` is true → gate falls back to the
+    // unconditional read → sees the marker → continues the version to 3.
+    await notes.put('x', { body: 're-created' })
+    const raw = local.raw(V, 'notes', 'x')!
+    expect(isDeleteMarker(raw)).toBe(false)
+    expect(raw._v).toBe(3) // marker._v (2) + 1 — FAILS pre-fix (_v === 1)
+    db.close()
+  })
+})
+
+describe('#693 scoping: the fallback only applies while tab-coordination is active', () => {
+  it('tab coordination ENABLED: a genuinely-new insert into a synced-eager collection DOES read the store', async () => {
+    const local = memory(); const remote = memory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
+    const notes = (await db.openVault(V)).collection<Note>('notes')
+    db.enableTabCoordination({ writeChannel: mockChannel(), tabId: 'A' })
+
+    local._resetCounters()
+    await notes.put('brand-new', { body: 'v1' })
+    // No marker was ever recorded for this id — under the #606-only gate this
+    // read would be skipped, but tab-coordination forces the fallback read.
+    expect(local._getCallsFor('notes', 'brand-new')).toBeGreaterThanOrEqual(1)
+    db.close()
+  })
+
+  it('tab coordination DISABLED: a genuinely-new insert into a synced-eager collection never reads the store (#606 win preserved)', async () => {
+    const local = memory(); const remote = memory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
+    const notes = (await db.openVault(V)).collection<Note>('notes')
+    // Tab coordination never enabled — `writeRelay` stays undefined.
+
+    local._resetCounters()
+    await notes.put('brand-new', { body: 'v1' })
+    expect(local._getCallsFor('notes', 'brand-new')).toBe(0)
+    db.close()
+  })
+})
+
+describe('#693: presence-only coordination (propagateWrites: false) also triggers the fallback', () => {
+  it('a marker written out-of-band by a peer tab is not lost on re-create even with write-propagation disabled', async () => {
+    const local = memory(); const remote = memory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'a', syncStrategy: withSync(), encrypt: false })
+    const notes = (await db.openVault(V)).collection<Note>('notes')
+
+    await notes.put('anchor', { body: 'seed' })
+
+    // Presence/election only — no write relay. `propagateWrites: false` means
+    // `Noydb.writeRelay` is NEVER set, so the narrow `writeRelay !== undefined`
+    // signal this fix replaces would stay false for the entire test: the gap
+    // this test closes. `tabCoordinator` is still set unconditionally by
+    // `enableTabCoordination`, so the broadened `_tabCoordinationActive`
+    // getter must catch this case.
+    db.enableTabCoordination({ channel: mockChannel(), propagateWrites: false, tabId: 'A' })
+
+    // Peer tab writes a delete-marker directly into the shared store, with no
+    // relay in play to ever inform this instance.
+    await local.put(V, 'notes', 'x', buildDeleteMarker(2, 'peer'))
+
+    // Pre-fix (narrow `writeRelay !== undefined` signal): the fallback never
+    // fires → gate skips the store read → version resets to 1, resurrecting
+    // the deleted record. Post-fix (`tabCoordinator !== undefined`): the
+    // fallback fires → sees the marker → continues the version to 3.
+    await notes.put('x', { body: 're-created' })
+    const raw = local.raw(V, 'notes', 'x')!
+    expect(isDeleteMarker(raw)).toBe(false)
+    expect(raw._v).toBe(3) // marker._v (2) + 1 — FAILS under the narrow getter (_v === 1)
+    db.close()
+  })
+})

--- a/packages/hub/__tests__/delete-tombstone-convergence.test.ts
+++ b/packages/hub/__tests__/delete-tombstone-convergence.test.ts
@@ -11,11 +11,26 @@ import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel
 import { ConflictError } from '../src/kernel/errors.js'
 import { createNoydb } from '../src/kernel/noydb.js'
 import { withSync } from '../src/with-party/sync/index.js'
-import { isDeleteMarker } from '../src/kernel/enclave/record-keys/tombstone.js'
+import { isDeleteMarker, buildDeleteMarker } from '../src/kernel/enclave/record-keys/tombstone.js'
 
-/** In-memory store exposing raw stored envelopes for white-box assertions. */
-function memory(): NoydbStore & { raw(c: string, col: string, id: string): EncryptedEnvelope | undefined } {
+/**
+ * In-memory store exposing raw stored envelopes for white-box assertions,
+ * plus a `_getCalls`/`_getCallsFor`/`_resetCounters()` set (pattern ported
+ * from lazy-hydration.test.ts) so #606's perf fix — skip the redundant
+ * `adapter.get` on a genuinely-new insert — can be proven by call count,
+ * not just by behavior. `_getCallsFor(col, id)` isolates reads to the
+ * collection/id under test, since a single `put()` also drives unrelated
+ * store reads (the schema-fence check on every write, the sync engine's
+ * one-time `_sync/meta` load) that must not be mistaken for the #606 gate.
+ */
+function memory(): NoydbStore & {
+  raw(c: string, col: string, id: string): EncryptedEnvelope | undefined
+  _getCalls: number
+  _getCallsFor(col: string, id: string): number
+  _resetCounters(): void
+} {
   const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const calls: { col: string; id: string }[] = []
   function gc(c: string, col: string) {
     let comp = store.get(c); if (!comp) { comp = new Map(); store.set(c, comp) }
     let coll = comp.get(col); if (!coll) { coll = new Map(); comp.set(col, coll) }
@@ -23,7 +38,13 @@ function memory(): NoydbStore & { raw(c: string, col: string, id: string): Encry
   }
   return {
     raw(c, col, id) { return store.get(c)?.get(col)?.get(id) },
-    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    get _getCalls() { return calls.length },
+    _getCallsFor(col, id) { return calls.filter(x => x.col === col && x.id === id).length },
+    _resetCounters() { calls.length = 0 },
+    async get(c, col, id) {
+      calls.push({ col, id })
+      return store.get(c)?.get(col)?.get(id) ?? null
+    },
     async put(c, col, id, env, ev) {
       const coll = gc(c, col); const ex = coll.get(id)
       if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
@@ -93,12 +114,78 @@ describe('re-create version continuity (#589)', () => {
     const notes = (await db.openVault(V)).collection<Note>('notes')
     await notes.put('n1', { body: 'v1' })        // _v=1
     await notes.delete('n1')                      // marker _v=2
+
+    // #606: the re-create put MUST still consult the store here — this is the
+    // one case the marker-id set exists to let through. A regression that made
+    // the gate "always skip" would silently reintroduce #589 (version resets
+    // to 1 instead of continuing past the marker).
+    local._resetCounters()
     await notes.put('n1', { body: 're-created' }) // must be _v=3, NOT _v=1
+    expect(local._getCallsFor('notes', 'n1')).toBeGreaterThan(0)
 
     const raw = local.raw(V, 'notes', 'n1')!
     expect(isDeleteMarker(raw)).toBe(false)       // live again
     expect(raw._v).toBe(3)                        // marker._v (2) + 1
     expect((await notes.get('n1'))!.body).toBe('re-created')
+    db.close()
+  })
+
+  it('#606 perf: a genuinely-new insert into a synced eager collection never reads the store', async () => {
+    const local = memory(); const remote = memory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
+    const notes = (await db.openVault(V)).collection<Note>('notes')
+
+    local._resetCounters()
+    await notes.put('brand-new', { body: 'v1' })
+    // No marker was ever recorded for this id, so the #589 continuity gate
+    // must not fall back to an `adapter.get` — that unconditional read is
+    // exactly what #606 removes for the common (non-re-create) insert case.
+    // (Filtered to this id: a synced put legitimately touches the store for
+    // unrelated reasons — the schema-fence check, the sync engine's one-time
+    // `_sync/meta` load — which must not be mistaken for the #606 gate.)
+    expect(local._getCallsFor('notes', 'brand-new')).toBe(0)
+    db.close()
+  })
+
+  it('#606: hydration from a store with a pre-existing marker seeds the marker-id set — a re-create on a fresh instance still continues the version', async () => {
+    const local = memory(); const remote = memory()
+    // Seed the raw store directly with a delete marker BEFORE any Collection
+    // ever opens it — simulates a cold session / process restart where the
+    // marker landed on disk in a previous run (or via another peer's sync
+    // write) and this instance's `ensureHydrated()` is the ONLY thing that
+    // can discover it, as opposed to a live delete populating the set.
+    await local.put(V, 'notes', 'n1', buildDeleteMarker(2, 'peer'))
+
+    const db = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
+    const notes = (await db.openVault(V)).collection<Note>('notes')
+
+    // Confirm the marker reads as absent before touching it (sanity check
+    // that hydration filtered it out of the eager cache, as #589 requires).
+    expect(await notes.get('n1')).toBeNull()
+
+    // The put's own `ensureHydrated()` call is what discovers the marker on
+    // this fresh instance; the re-create must continue past it (_v=3), not
+    // reset to 1 — proving `markerIds` was populated by hydration, not just
+    // by a live local delete.
+    await notes.put('n1', { body: 're-created' })
+    const raw = local.raw(V, 'notes', 'n1')!
+    expect(isDeleteMarker(raw)).toBe(false)
+    expect(raw._v).toBe(3) // marker._v (2) + 1, NOT reset to 1
+    expect((await notes.get('n1'))!.body).toBe('re-created')
+    db.close()
+  })
+
+  it('#606: a second put to the same id right after a re-create does not consult-then-read again', async () => {
+    const local = memory(); const remote = memory()
+    const db = await createNoydb({ store: local, sync: remote, user: 'u', syncStrategy: withSync(), encrypt: false })
+    const notes = (await db.openVault(V)).collection<Note>('notes')
+    await notes.put('n1', { body: 'v1' })
+    await notes.delete('n1')
+    await notes.put('n1', { body: 're-created' }) // marker consulted; markerIds.delete('n1') must fire here
+
+    local._resetCounters()
+    await notes.put('n1', { body: 'edited-again' }) // live, cached record — no store read expected
+    expect(local._getCallsFor('notes', 'n1')).toBe(0)
     db.close()
   })
 })

--- a/packages/hub/__tests__/via/lookup-reserved-sync.test.ts
+++ b/packages/hub/__tests__/via/lookup-reserved-sync.test.ts
@@ -28,6 +28,7 @@ import { withI18n } from '../../src/via/i18n/index.js'
 import { withSync } from '../../src/with-party/sync/index.js'
 import { SyncEngine, type ReservedLookupSource } from '../../src/with-party/team/sync.js'
 import { dict } from '../../src/via/lookup/descriptor.js'
+import { reservedDictDepsOf } from '../../src/via/lookup/registry.js'
 import { NoydbEventEmitter } from '../../src/kernel/events.js'
 import { ConflictError } from '../../src/kernel/errors.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/kernel/types.js'
@@ -308,5 +309,76 @@ describe('reserved-lookup sync (#647, #650 Task 4)', () => {
     expect(await vC.dictionary('status').get('paid')).toBeNull()
 
     dbA.close(); dbB.close(); dbC.close()
+  })
+
+  // ─── #653 — partial sync must auto-include the reserved dicts a named collection depends on ───
+
+  it('#653: partial pull([\'orders\']) still resolves the reserved dict orders depends on (literal filter would drop _dict_status)', async () => {
+    const remote = memory()
+    const dbA = await createNoydb({ store: memory(), sync: remote, user: 'user-a', syncStrategy: withSync(), i18nStrategy: withI18n(), encrypt: false })
+    const dbB = await createNoydb({ store: memory(), sync: remote, user: 'user-b', syncStrategy: withSync(), i18nStrategy: withI18n(), encrypt: false })
+
+    const vA = await dbA.openVault('demo')
+    vA.collection<Order>('orders', { lookupFields: { status: dict('status') } })
+    await vA.dictionary('status').put('paid', { en: 'Paid' })
+    await vA.collection<Order>('orders').put('o1', { id: 'o1', status: 'paid' })
+    await dbA.push('demo')
+
+    const vB = await dbB.openVault('demo')
+    vB.collection<Order>('orders', { lookupFields: { status: dict('status') } })
+
+    // Adopters never name `_dict_*` in a partial-sync filter — only 'orders' is named here.
+    const pull1 = await dbB.pull('demo', { collections: ['orders'] })
+    expect(pull1.errors).toHaveLength(0)
+
+    // #653: a collections-filtered pull must still auto-include orders' reserved dict dependency.
+    // Pre-fix, the literal filter drops `_dict_status` — this resolves to `undefined`.
+    expect(await vB.dictionary('status').get('paid')).toEqual({ en: 'Paid' })
+    const dressed = await vB.collection<Order>('orders').get('o1', { locale: 'en' })
+    expect(dressed?.statusLabel).toBe('Paid')
+
+    dbA.close(); dbB.close()
+  })
+
+  it('#653: partial pull of a collection with NO lookup fields does not over-pull an unrelated dict', async () => {
+    interface Payment extends Record<string, unknown> { id: string; amount: number }
+    const remote = memory()
+    const dbA = await createNoydb({ store: memory(), sync: remote, user: 'user-a', syncStrategy: withSync(), i18nStrategy: withI18n(), encrypt: false })
+    const dbB = await createNoydb({ store: memory(), sync: remote, user: 'user-b', syncStrategy: withSync(), i18nStrategy: withI18n(), encrypt: false })
+
+    const vA = await dbA.openVault('demo')
+    vA.collection<Order>('orders', { lookupFields: { status: dict('status') } })
+    await vA.dictionary('status').put('paid', { en: 'Paid' })
+    await vA.collection<Order>('orders').put('o1', { id: 'o1', status: 'paid' })
+    vA.collection<Payment>('payments')
+    await vA.collection<Payment>('payments').put('p1', { id: 'p1', amount: 100 })
+    await dbA.push('demo')
+
+    const vB = await dbB.openVault('demo')
+    // Both a dict-backed collection AND the unrelated, lookup-field-free 'payments' are declared —
+    // only 'payments' is named in the filter below.
+    vB.collection<Order>('orders', { lookupFields: { status: dict('status') } })
+    vB.collection<Payment>('payments')
+
+    const pull1 = await dbB.pull('demo', { collections: ['payments'] })
+    expect(pull1.errors).toHaveLength(0)
+
+    expect(await vB.collection<Payment>('payments').get('p1')).toEqual({ id: 'p1', amount: 100 })
+    // Guard against over-pulling: 'orders' was never named, so its dict dependency must stay absent.
+    expect(await vB.dictionary('status').get('paid')).toBeNull()
+
+    dbA.close(); dbB.close()
+  })
+})
+
+describe('reservedDictDepsOf (#653 unit)', () => {
+  it('maps a named collection to its one-hop reserved dict dependency', () => {
+    const registry = new Map([['orders', { status: 'status' }]])
+    expect(reservedDictDepsOf(['orders'], registry)).toEqual(['_dict_status'])
+  })
+
+  it('returns empty for a named collection with no lookup-field dependencies', () => {
+    const registry = new Map([['orders', { status: 'status' }]])
+    expect(reservedDictDepsOf(['payments'], registry)).toEqual([])
   })
 })

--- a/packages/hub/__tests__/via/sync-delete-derivation.test.ts
+++ b/packages/hub/__tests__/via/sync-delete-derivation.test.ts
@@ -1,0 +1,123 @@
+// #658 — sync-applied deletes reach the MV + array-derivation dispatch wave, on TOP of the
+// #640 rollup leg: the LOCAL delete path (`Collection._doDelete`'s `!internal` block) already
+// heals rollups + MV rows + array-shape derivation output rows for a deleted child. The
+// sync-delete wave (runGraphDispatchWave's deletes loop) recomputed rollup parents only — a
+// remotely-deleted child's MV mirror row and array-derivation output row stayed stale. This is
+// a parity fix, not a new capability: it brings the wave up to the local boundary. Mirrors
+// sync-delete-rollup.test.ts's db2-only-registration, memory-store, and CAS-mock fixture
+// discipline; the rollup here is the CONTROL (already passes via #640) alongside the two new
+// RED→GREEN assertions.
+
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withRollup, withMaterializedView, withDerivation } from '../../src/index.js'
+import { withSync } from '../../src/with-party/sync/index.js'
+import type { NoydbStore, EncryptedEnvelope } from '../../src/kernel/types.js'
+
+function memory(): NoydbStore {
+  const data = new Map<string, EncryptedEnvelope>()
+  const k = (v: string, c: string, i: string) => `${v}/${c}/${i}`
+  return {
+    capabilities: { casAtomic: true, auth: { kind: 'none', required: false, flow: 'static' } },
+    async get(v, c, i) { return data.get(k(v, c, i)) ?? null },
+    async put(v, c, i, env) { data.set(k(v, c, i), env) },
+    async delete(v, c, i) { data.delete(k(v, c, i)) },
+    async list(v, c) {
+      const prefix = `${v}/${c}/`
+      return [...data.keys()].filter(key => key.startsWith(prefix)).map(key => key.slice(prefix.length))
+    },
+    async loadAll(v) {
+      const out: Record<string, Record<string, EncryptedEnvelope>> = {}
+      for (const [key, env] of data) {
+        const [vname, cname, id] = key.split('/') as [string, string, string]
+        if (vname === v) { out[cname] = out[cname] ?? {}; out[cname]![id] = env }
+      }
+      return out
+    },
+    async saveAll(v, payload) {
+      for (const c of Object.keys(payload)) {
+        for (const i of Object.keys(payload[c]!)) data.set(k(v, c, i), payload[c]![i]!)
+      }
+    },
+  }
+}
+
+interface Customer extends Record<string, unknown> { id: string; orderCount?: number }
+interface Order extends Record<string, unknown> { id: string; customerId: string; sku?: string }
+interface OrderLine extends Record<string, unknown> { id: string; orderId: string; sku: string }
+
+const orderCountRollup = () =>
+  withRollup<Order, Customer>({ from: 'orders', key: 'customerId', into: 'customers', field: 'orderCount', compute: (orders) => orders.length })
+
+const ordersMirrorMV = () =>
+  withMaterializedView<Order>({
+    name: 'orders-mirror',
+    query: (db) => db.collection<Order>('orders').query(),
+    rowKey: (r) => r.id,
+    refresh: 'eager',
+  })
+
+const orderLineDerivation = () =>
+  withDerivation<Order, { lines: OrderLine[] }>({
+    source: 'orders',
+    deterministic: true,
+    outputs: {
+      lines: { shape: 'array', collection: 'orderLines', key: (o) => o.id as string },
+    },
+    derive: (order) => ({
+      lines: order.sku ? [{ id: `${order.id}|${order.sku}`, orderId: order.id, sku: order.sku }] : [],
+    }),
+    lifecycle: 'eager',
+  })
+
+describe('sync-applied deletes reach the MV + array-derivation dispatch wave (#658)', () => {
+  it('db2-only registration: a pulled delete heals the MV mirror row and the array-derivation output row (parity with local delete), alongside the #640 rollup CONTROL', async () => {
+    const remote = memory()
+    // db1 is a plain writer — it never registers the MV/derivation/rollup strategies, so
+    // whatever ends up in db2's `orders-mirror`/`orderLines`/`customers.orderCount` can only
+    // have come from db2's OWN wave-driven recompute (#646 db2-only-registration mandate).
+    const db1 = await createNoydb({ store: memory(), sync: remote, user: 'user-1', syncStrategy: withSync(), encrypt: false })
+    const db2 = await createNoydb({
+      store: memory(), sync: remote, user: 'user-2', syncStrategy: withSync(), encrypt: false,
+      derivationStrategies: [orderCountRollup(), orderLineDerivation()],
+      materializedViewStrategies: [ordersMirrorMV()],
+    })
+
+    const v1 = await db1.openVault('shop')
+    await v1.collection<Customer>('customers').put('c1', { id: 'c1' })
+    await v1.collection<Order>('orders').put('o1', { id: 'o1', customerId: 'c1', sku: 'sku-1' })
+    await db1.push('shop')
+
+    const v2 = await db2.openVault('shop')
+    const customers = v2.collection<Customer>('customers')
+    const orders = v2.collection<Order>('orders')
+    const ordersMirror = v2.collection<Order>('orders-mirror')
+    const orderLines = v2.collection<OrderLine>('orderLines')
+    await db2.pull('shop')
+
+    // Keep the child warm in db2's cache before the delete-pull (so the sync-apply delete case's
+    // `_peekCached` FK-recovery hits — the rollup control's PUT-time recompute already reads
+    // every order via `.get()`, which hydrates `orders` as a side effect, but do it explicitly
+    // too so this test isn't accidentally relying on that side effect). Not testing #640's
+    // documented cold-child gate here.
+    await orders.get('o1')
+
+    // Baseline: all three artifacts exist/are correct after the initial pull.
+    expect((await customers.get('c1'))?.orderCount).toBe(1)
+    expect(await ordersMirror.get('o1')).not.toBeNull()
+    expect(await orderLines.get('o1|sku-1')).not.toBeNull()
+
+    await v1.collection<Order>('orders').delete('o1')
+    await db1.push('shop')
+    await db2.pull('shop')
+
+    // CONTROL (#640) — passes today: the rollup parent recomputed without the deleted child.
+    expect((await customers.get('c1'))?.orderCount).toBe(0)
+
+    // RED (pre-#658) → GREEN (post-#658): the MV mirror row and the array-derivation output
+    // row are healed too, matching local delete's boundary — no longer stale.
+    expect(await ordersMirror.get('o1')).toBeNull()
+    expect(await orderLines.get('o1|sku-1')).toBeNull()
+
+    db1.close(); db2.close()
+  })
+})

--- a/packages/hub/src/kernel/collection-config.ts
+++ b/packages/hub/src/kernel/collection-config.ts
@@ -126,6 +126,13 @@ export interface CollectionOpts<T> {
   historyConfigExplicit?: boolean | undefined
   onDirty?: OnDirtyCallback | undefined
   /**
+   * #693: live check for whether multi-tab coordination is active at all
+   * (`Noydb._tabCoordinationActive`). When true, the shared local store may be
+   * written out-of-band by another tab, so the #606 marker-id-set gate falls
+   * back to an unconditional store read on re-create.
+   */
+  tabCoordinated?: (() => boolean) | undefined
+  /**
    * tree-shake seam. When omitted, `collection.blob(id)` throws
    * with a pointer at the `@noy-db/hub/blobs` subpath. When set (via
    * `createNoydb({ blobStrategy: blobs() })`), blob storage is live.
@@ -1062,6 +1069,7 @@ export function resolveCollectionConfig<T>(opts: CollectionOpts<T>) {
     reconcileOnOpen: opts.reconcileOnOpen ?? 'off',
     getDEK: opts.getDEK,
     onDirty: opts.onDirty,
+    tabCoordinated: opts.tabCoordinated,
     historyConfig: opts.historyConfig ?? { enabled: true },
     historyConfigExplicit: opts.historyConfigExplicit ?? false,
     schema: opts.schema,

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -209,6 +209,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   private readonly activeTxId: (() => string | null) | undefined
   private readonly getDEK: (collectionName: string) => Promise<EnclaveKey>
   private readonly onDirty: OnDirtyCallback | undefined
+  /** #693: live check — true when multi-tab write-propagation is active; gates the #606 marker-id-set fallback read. */
+  private readonly tabCoordinated: (() => boolean) | undefined
   private readonly historyConfig: HistoryConfig
   /** True when the caller explicitly provided a `historyConfig` option (vs. inheriting the vault default). */
   private readonly historyConfigExplicit: boolean
@@ -655,6 +657,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     this.reconcileOnOpen = cfg.reconcileOnOpen
     this.getDEK = cfg.getDEK
     this.onDirty = cfg.onDirty
+    this.tabCoordinated = cfg.tabCoordinated
     this.historyConfig = cfg.historyConfig
     this.historyConfigExplicit = cfg.historyConfigExplicit
     this.schema = cfg.schema
@@ -1929,7 +1932,12 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       // inserts are the latter. The lazy branch above may have already read
       // the raw envelope on an LRU miss regardless of `markerIds` (preserved
       // as-is); this only gates the previously-unconditional second read.
-      if (priorRaw === null && this.markerIds.has(id)) priorRaw = await this.adapter.get(this.vault, this.name, id)
+      // #693: when the store may be written out-of-band by another tab (write-relay active),
+      // markerIds isn't authoritative during the broadcast-latency window — fall back to the
+      // pre-#606 unconditional read so a cross-tab marker is never missed.
+      if (priorRaw === null && (this.markerIds.has(id) || this.tabCoordinated?.())) {
+        priorRaw = await this.adapter.get(this.vault, this.name, id)
+      }
       if (priorRaw && isDeleteMarker(priorRaw)) version = priorRaw._v + 1
     }
 

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -239,6 +239,21 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   private hydrated = false
 
   /**
+   * #606: ids known to carry a delete marker in the store — lets the #589
+   * re-create version-continuity gate in `_putInternal` read the store ONLY
+   * for a known marker prior, instead of unconditionally on every insert.
+   * Populated on hydration (`ensureHydrated`/`hydrateFromSnapshot`), local
+   * delete (`_doDelete`), and the sync/tab/cutover choke point
+   * (`_invalidateCacheEntry`). Accepted drift: `vault._purgeDeleteMarkers`/
+   * `_purgeMarkersOn` remove markers directly on the raw store, bypassing
+   * Collection, so this set can hold stale ids after a purge on an
+   * already-loaded collection — perf-only and self-healing (a stale id just
+   * costs one `adapter.get` that returns non-marker/null, and version
+   * resolution falls back to 1 correctly). Do not try to wire purge into it.
+   */
+  private readonly markerIds = new Set<string>()
+
+  /**
    * Lazy mode flag. `true` when constructed with `prefetch: false`.
    * In lazy mode the cache is bounded by an LRU and `list()`/`query()`
    * throw — callers must use `scan()` or per-id `get()` instead.
@@ -1908,7 +1923,13 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     // tombstones (`isTombstone`, no `_del`) are terminal and are NOT
     // continued — they still reset to 1.
     if (!existing && this.onDirty) {
-      if (priorRaw === null) priorRaw = await this.adapter.get(this.vault, this.name, id)
+      // #606: only fall back to a store read when this id is a KNOWN marker
+      // — markers are filtered out of the eager cache, so `!existing` alone
+      // can't distinguish a re-create from a genuinely-new insert, and most
+      // inserts are the latter. The lazy branch above may have already read
+      // the raw envelope on an LRU miss regardless of `markerIds` (preserved
+      // as-is); this only gates the previously-unconditional second read.
+      if (priorRaw === null && this.markerIds.has(id)) priorRaw = await this.adapter.get(this.vault, this.name, id)
       if (priorRaw && isDeleteMarker(priorRaw)) version = priorRaw._v + 1
     }
 
@@ -1958,6 +1979,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
 
     const envelope = await this.codec.encryptRecord(record, version, cek, options?.source, options?.sourceTs, vdigCtx, id)
     await this.adapter.put(this.vault, this.name, id, envelope)
+    this.markerIds.delete(id) // #606: the live body just overwrote any marker prior — no-op if `id` wasn't one
 
     // C-A/R10: persist the x-classified marker on the first classified write
     // (cross-session drift signal). Memoized; no-op for non-classified handles.
@@ -2707,6 +2729,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       if (!live || isTombstone(live, this.storeCiphertext) || isDeleteMarker(live)) return
       markerVersion = live._v + 1
       await this.adapter.put(this.vault, this.name, id, buildDeleteMarker(markerVersion, this.keyring.userId))
+      this.markerIds.add(id) // #606: this id now carries a marker — the #589 continuity gate should consult it on re-create
     } else {
       await this.adapter.delete(this.vault, this.name, id)
     }
@@ -3737,9 +3760,19 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       this.lru.remove(id)
       return
     }
+    const envelope = await this.adapter.get(this.vault, this.name, id)
+    // #606: this is the single choke point every sync-apply / tab-mirror /
+    // cutover write (plus tx/derivation-revert restores) funnels through, so
+    // it's also where the marker-id set tracks a remote marker landing or
+    // clearing. MUST run before the `!hydrated` gate below — a marker can
+    // land while this collection is still mid-hydration, and hydration
+    // snapshots its id list at loop start, so it can never recover an id it
+    // never listed. Missing this here permanently drops the id from
+    // `markerIds` for the session and reintroduces the #589 divergence.
+    if (envelope && isDeleteMarker(envelope)) this.markerIds.add(id)
+    else this.markerIds.delete(id)
     if (!this.hydrated) return
     const previous = this.cache.get(id)
-    const envelope = await this.adapter.get(this.vault, this.name, id)
     if (!envelope) {
       this.cache.delete(id)
       if (previous) {
@@ -3798,6 +3831,19 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     origin: MutationOrigin,
     ctx?: { readonly record?: T; readonly version?: number },
   ): Promise<void> {
+    // #606: maintain `markerIds` synchronously, in the SAME continuation as
+    // the caller's own `local.put` of this envelope (no `await` between
+    // them) — closes the window where a concurrent `put(id)` could read the
+    // set before `_invalidateCacheEntry`'s (awaited, below) maintenance
+    // catches up. A superset for a moment on a sync-applied tombstone is
+    // harmless — `_invalidateCacheEntry`'s read refines it, and a re-create
+    // racing ahead of that just does one extra (correct) store read. Gated to
+    // eager+synced: lazy mode never consults `markerIds`, and unsynced
+    // collections never see markers.
+    if (this.onDirty && !this.lazy) {
+      if (action === 'delete') this.markerIds.add(id)
+      else this.markerIds.delete(id)
+    }
     switch (origin) {
       case 'local-write': {
         const record = ctx!.record!
@@ -3859,6 +3905,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
         const record = await this.codec.decryptRecord(envelope, { id, sealedAsHandles: true })
         if (record === null) continue
         this.cache.set(id, { record, version: envelope._v })
+      } else if (envelope && isDeleteMarker(envelope)) {
+        this.markerIds.add(id) // #606: seed the marker-id set from disk on cold hydration
       }
     }
     this.hydrated = true
@@ -3869,7 +3917,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   /** Hydrate from a pre-loaded snapshot (used by Vault). */
   async hydrateFromSnapshot(records: Record<string, EncryptedEnvelope>): Promise<void> {
     for (const [id, envelope] of Object.entries(records)) {
-      if (isTombstone(envelope, this.storeCiphertext) || isDeleteMarker(envelope)) continue
+      if (isDeleteMarker(envelope)) { this.markerIds.add(id); continue } // #606: seed from a pre-loaded snapshot too
+      if (isTombstone(envelope, this.storeCiphertext)) continue
       const record = await this.codec.decryptRecord(envelope, { id, sealedAsHandles: true })
       if (record === null) continue
       this.cache.set(id, { record, version: envelope._v })

--- a/packages/hub/src/kernel/noydb.ts
+++ b/packages/hub/src/kernel/noydb.ts
@@ -683,6 +683,7 @@ export class Noydb {
       engine.setCacheInvalidator((collection, id, action) => comp._invalidateSyncApplied(collection, id, action))
       engine.setGraphBatchController({ begin: () => comp._beginGraphBatch(), flush: () => comp._flushGraphBatch() })
       engine.setReservedLookupSource({ collections: () => comp._reservedLookupCollectionNames() }) // #650 Task 4
+      engine.setReservedDictExpander(names => comp._reservedDictDepsOf(names)) // #653
     })
     // Initialise the optional guard + derivation registries via dynamic-import — no-ops when the
     // corresponding strategies array is empty/unset, keeping the service code out of the floor bundle.

--- a/packages/hub/src/kernel/noydb.ts
+++ b/packages/hub/src/kernel/noydb.ts
@@ -1657,6 +1657,17 @@ export class Noydb {
   }
 
   /**
+   * #693: true when multi-tab coordination is active at all — presence/election
+   * alone (`propagateWrites: false`) or full write-propagation — a peer tab can
+   * write this instance's shared store out-of-band either way, so per-collection
+   * marker-id sets are not authoritative and the re-create gate must fall back to
+   * a store read. Live (tab coordination is enable/disable-able at runtime).
+   */
+  get _tabCoordinationActive(): boolean {
+    return this.tabCoordinator !== undefined
+  }
+
+  /**
    * Soft-lock a single vault: clear its in-memory keyring, DEKs, vault
    * instance, sync engine, policy enforcer, and active-tier entry —
    * WITHOUT destroying the `Noydb` instance.

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -106,6 +106,7 @@ import {
   checkLookupMembership, buildLookupAltIndex,
   dictCollectionName, registerLookupRefEdges, // #650 Task 4/5
   buildLookupSnapshotRows, // #650 Task 6
+  reservedDictDepsOf, // #653
   type LookupDescriptor,
 } from '../port/with/lookup-strategy.js'
 import { isLinkCollectionName, type LinkSpec, type LinkSetHandle } from '../with-shape/links/names.js'
@@ -1306,6 +1307,13 @@ export class Vault {
   /** @internal #650 Task 4 (#647) — declared reserved-lookup collection names, for `SyncEngine.pull()`'s explicit prefix registry. */
   _reservedLookupCollectionNames(): readonly string[] {
     return [...this.reservedLookupCollections.keys()]
+  }
+
+  /** @internal #653 — one-hop reserved-dict deps of `names`, for `SyncEngine`'s partial-sync
+   *  filter expansion. Provably complete at one hop: `vault.collection()` refuses `_dict_*`
+   *  names, so a dict can never itself declare lookup fields (no dict-of-dict chain). */
+  _reservedDictDepsOf(names: readonly string[]): readonly string[] {
+    return reservedDictDepsOf(names, this.dictKeyFieldRegistry)
   }
 
   /** @internal #638 Task 4 — open a graph-dispatch touch batch (sync pull()/push()/cutover). */

--- a/packages/hub/src/kernel/vault.ts
+++ b/packages/hub/src/kernel/vault.ts
@@ -989,6 +989,7 @@ export class Vault {
         schemaFence: this.schemaFence,
         getDEK: this.getDEK,
         onDirty: this.onDirty,
+        tabCoordinated: () => this.noydb._tabCoordinationActive, // #693: re-create gate fallback
         historyConfig: effectiveHistoryConfig,
         historyConfigExplicit: options?.historyConfig !== undefined,
         // thread the vault-wide blob strategy into every

--- a/packages/hub/src/kernel/via/dispatch.ts
+++ b/packages/hub/src/kernel/via/dispatch.ts
@@ -148,11 +148,25 @@ export async function runGraphDispatchWave(vault: VaultLike, batch: GraphBatch):
     }
     // #640 — delete-kind touches: the deleted child's rollup-parent intents, resolved (sync,
     // pre-invalidation) at collect time by `Collection._rollupDeleteIntents`. Same per-id
-    // isolation as the puts loop above; never routed through `dispatchDerivations` (the
-    // mutation-choke-point.test.ts:85-99 pin — sync-applied deletes are rollup-on-delete only).
+    // isolation as the puts loop above. #658: the wave now ALSO heals MV rows and array-shape
+    // derivation output rows for the deleted child — parity with the local-delete boundary
+    // (`Collection._doDelete`'s `!internal` block, which already calls all three). Still never
+    // routed through `dispatchDerivations` (the mutation-choke-point.test.ts:85-99 pin — sync-
+    // applied deletes never RE-DERIVE); `dispatchMaterializedViewsOnDelete`/
+    // `dispatchArrayDerivationsOnDelete` only need `id` (MV refresh recomputes+diffs; array-
+    // derivation reads its per-source sidecar) and never call `derive()`, so the pin holds.
     for (const [id, intents] of touch.deletes) {
       try {
         await coll._recomputeDeletedRollups(intents, wave)
+        // #658: record-shape same-id outputs are left untouched (eraseRecordShapeToo defaults
+        // false), matching local delete — the user deletes those directly if wanted.
+        // #658: TODO dedup MV refresh per wave — `dispatchMaterializedViewsOnDelete` doesn't
+        // accept a `WaveContext` (unlike the put-path `dispatchMaterializedViews`), so N deleted
+        // children of one eager MV in a batch each trigger a full refresh pass. Threading `wave`
+        // through would touch collection.ts's zero-slack kernel-surface ceiling for a perf-only
+        // win; correctness doesn't depend on it (idempotent per source-id) — left as a follow-up.
+        await coll.dispatchMaterializedViewsOnDelete(id)
+        await coll.dispatchArrayDerivationsOnDelete(id)
       } catch (err) {
         console.warn(`[via-dispatch] wave delete-recompute failed for ${collectionName}/${id}:`, err)
         vault._emit('derivation:wave-error', { collection: collectionName, id, error: err })

--- a/packages/hub/src/port/with/lookup-strategy.ts
+++ b/packages/hub/src/port/with/lookup-strategy.ts
@@ -32,6 +32,7 @@ import {
   resolveLabelFromMap,
   collectLookupDictCompat,
   lookupToStaticDictCompat,
+  reservedDictDepsOf,
   materializeBackingTable,
   checkLookupMembership,
   buildLookupAltIndex,
@@ -165,6 +166,10 @@ export { dictCollectionName } from '../../via/lookup/handle.js'
 // descriptors, mirroring `isI18nTextDescriptor`/`isDictKeyDescriptor` below.
 export { resolveLabelFromMap, collectLookupDictCompat, lookupToStaticDictCompat }
 export type { LookupDictCompat }
+
+// #653 — partial-sync reserved-dict expansion: maps a set of named collections to the
+// one-hop `_dict_*` deps their lookup fields reference, off `dictKeyFieldRegistry`.
+export { reservedDictDepsOf }
 
 // #650 Task 3 — altKeys ingest normalization + open/closed vocabulary
 // governance: the declare/warm-time altIndex builder + the membership test

--- a/packages/hub/src/via/lookup/registry.ts
+++ b/packages/hub/src/via/lookup/registry.ts
@@ -256,6 +256,27 @@ export function collectLookupDictCompat(
 }
 
 /**
+ * Reserved-dict deps of a set of named collections (#653) — the `_dict_*`
+ * collections partial sync must auto-include alongside a `collections`
+ * filter, mirroring `SyncEngine`'s existing satellite-pair expansion.
+ * One hop is provably complete: `vault.collection()` refuses `_dict_*`
+ * names, so a dict can never itself declare lookup fields — no
+ * dict-of-dict chain to recurse through.
+ */
+export function reservedDictDepsOf(
+  names: readonly string[],
+  dictKeyFieldRegistry: ReadonlyMap<string, Record<string, string>>,
+): readonly string[] {
+  const out = new Set<string>()
+  for (const name of names) {
+    const fieldMap = dictKeyFieldRegistry.get(name)
+    if (!fieldMap) continue
+    for (const dictName of Object.values(fieldMap)) out.add(dictCollectionName(dictName))
+  }
+  return [...out]
+}
+
+/**
  * A lookup dimension's sync membership/altKey table, materialized from its
  * backing rows (#650 Task 3). `keys` is every canonical key present;
  * `altIndex` maps an altKey candidate VALUE to its owning canonical key.

--- a/packages/hub/src/with-party/team/sync.ts
+++ b/packages/hub/src/with-party/team/sync.ts
@@ -94,8 +94,9 @@ export class SyncEngine {
   /** #653: expands a (pair-expanded) collection-name filter to include the reserved `_dict_*`
    *  collections those names depend on via their lookup fields — mirrors `pairExpander` so a
    *  partial `push`/`pull({collections:[...]})` never drops the dictionary a named collection's
-   *  labels/membership rely on. Wired from the vault's `dictKeyFieldRegistry` via
-   *  `setReservedDictExpander`. `undefined` when no dict-backed collection has ever been declared. */
+   *  labels/membership rely on. Wired unconditionally from the vault's `dictKeyFieldRegistry` via
+   *  `setReservedDictExpander` (returns `[]` when the vault has no dict-backed collections); only
+   *  `undefined` on a standalone engine that was never vault-attached. */
   private reservedDictExpander?: (names: readonly string[]) => readonly string[]
 
   /** Wire the reserved-dict expansion function (#653). Same injection pattern as `setPairExpander`. */

--- a/packages/hub/src/with-party/team/sync.ts
+++ b/packages/hub/src/with-party/team/sync.ts
@@ -91,6 +91,18 @@ export class SyncEngine {
     this.reservedLookup = source
   }
 
+  /** #653: expands a (pair-expanded) collection-name filter to include the reserved `_dict_*`
+   *  collections those names depend on via their lookup fields — mirrors `pairExpander` so a
+   *  partial `push`/`pull({collections:[...]})` never drops the dictionary a named collection's
+   *  labels/membership rely on. Wired from the vault's `dictKeyFieldRegistry` via
+   *  `setReservedDictExpander`. `undefined` when no dict-backed collection has ever been declared. */
+  private reservedDictExpander?: (names: readonly string[]) => readonly string[]
+
+  /** Wire the reserved-dict expansion function (#653). Same injection pattern as `setPairExpander`. */
+  setReservedDictExpander(expander: (names: readonly string[]) => readonly string[]): void {
+    this.reservedDictExpander = expander
+  }
+
   constructor(opts: {
     local: NoydbStore
     remote: NoydbStore
@@ -217,8 +229,11 @@ export class SyncEngine {
     const errors: Error[] = []
     const completed: number[] = []
 
-    // Partial sync: expand the filter to cover satellite pair partners (#591 rule 5b)
-    const filter = options?.collections ? new Set(this.pairExpander?.(options.collections) ?? options.collections) : null
+    // Partial sync: expand the filter to cover satellite pair partners (#591 rule 5b), then the
+    // reserved `_dict_*` collections those (expanded) names depend on (#653) — a locally-dirty
+    // dict edit pushes alongside push({collections:['orders']}), symmetric with pull below.
+    const expanded = options?.collections ? (this.pairExpander?.(options.collections) ?? options.collections) : null
+    const filter = expanded ? new Set([...expanded, ...(this.reservedDictExpander?.(expanded) ?? [])]) : null
 
     for (let i = 0; i < this.dirty.length; i++) {
       const entry = this.dirty[i]!
@@ -356,8 +371,12 @@ export class SyncEngine {
     const erasures: ErasureEnforcement[] = []
     const errors: Error[] = []
 
-    // Partial sync: expand the filter to cover satellite pair partners (#591 rule 5b)
-    const filter = options?.collections ? new Set(this.pairExpander?.(options.collections) ?? options.collections) : null
+    // Partial sync: expand the filter to cover satellite pair partners (#591 rule 5b), then the
+    // reserved `_dict_*` collections those (expanded) names depend on (#653) — adopters never
+    // name `_dict_*` in a `collections` filter, so a named collection's lookup-field dependency
+    // must be pulled alongside it or its labels/membership go stale.
+    const expanded = options?.collections ? (this.pairExpander?.(options.collections) ?? options.collections) : null
+    const filter = expanded ? new Set([...expanded, ...(this.reservedDictExpander?.(expanded) ?? [])]) : null
 
     try {
       const remoteSnapshot = await this.remote.loadAll(this.vault)

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -733,7 +733,18 @@ const KERNEL_SURFACE_BUDGET = {
   // ratcheting the ceiling down to the actual per the checker's own
   // ratchet-to-actual convention, so the margin isn't silently carried
   // forward as slack for an unrelated future change.
-  'packages/hub/src/kernel/collection.ts': 4472,
+  // Bumped 4472→4503 (2026-07-15, #606: per-collection marker-id set to skip
+  // the redundant adapter.get on synced-eager insert): a `Set<string>` field
+  // + population at hydration (both paths)/local-delete/the sync-tab-cutover
+  // choke point, plus the gated read at the #589 continuity check and the
+  // clear on re-create success.
+  // Bumped 4503→4521 (2026-07-15, #606 adversarial-review fix): moved the
+  // marker-id maintenance in `_invalidateCacheEntry` above the `!hydrated`
+  // gate (a marker landing mid-hydration was never recorded, permanently
+  // for the session) and added a synchronous pre-switch maintenance step in
+  // `_onRecordMutated` to close the await-window race against a concurrent
+  // put. Comments explaining both fixes account for the growth.
+  'packages/hub/src/kernel/collection.ts': 4521,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -744,7 +744,10 @@ const KERNEL_SURFACE_BUDGET = {
   // for the session) and added a synchronous pre-switch maintenance step in
   // `_onRecordMutated` to close the await-window race against a concurrent
   // put. Comments explaining both fixes account for the growth.
-  'packages/hub/src/kernel/collection.ts': 4521,
+  // Bumped 4521→4529 (2026-07-15, #693: tab-coordination fallback for the marker-set gate):
+  // `tabCoordinated` private field + constructor assignment + the gate's fallback
+  // condition/comment at the #589/#606 re-create check.
+  'packages/hub/src/kernel/collection.ts': 4529,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.
@@ -993,7 +996,9 @@ const KERNEL_SURFACE_BUDGET = {
   // expansion): `_reservedDictDepsOf(names)` — a thin delegator (same tier as
   // `_reservedLookupCollectionNames()` beside it) to `reservedDictDepsOf` in
   // `via/lookup/registry.ts`, reached through the existing lookup-strategy port import.
-  'packages/hub/src/kernel/vault.ts': 3958,
+  // Bumped 3958→3959 (2026-07-15, #693: tab-coordination fallback for the marker-set gate):
+  // one `tabCoordinated: () => this.noydb._tabWritesRelayed` line threaded into collOpts.
+  'packages/hub/src/kernel/vault.ts': 3959,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),
@@ -1101,7 +1106,14 @@ const KERNEL_SURFACE_BUDGET = {
   // call-site, filters/maps the already-computed `targets` array.
   // Bumped 2375→2385 (2026-07-10, #616): role-gate the sync primary (emptyPullResult
   // factory + pull() no-op + sync() primary ternary branch for push-only sinks).
-  'packages/hub/src/kernel/noydb.ts': 2385,
+  // Bumped 2385→2396 (2026-07-15, #693: tab-coordination fallback for the marker-set gate):
+  // `_tabCoordinationActive` internal live getter (`tabCoordinator !== undefined`) — the
+  // dynamic signal Vault threads into every Collection so the #606 re-create gate can fall
+  // back to an unconditional store read whenever multi-tab coordination is active at all
+  // (presence/election alone or full write-propagation), not only while writes are relayed
+  // (review fix: `propagateWrites: false` left `writeRelay` unset, so the narrower signal
+  // missed a peer tab's delete-marker on a shared store — permanent #589-class data loss).
+  'packages/hub/src/kernel/noydb.ts': 2396,
 }
 
 function checkKernelSurface() {

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -978,7 +978,11 @@ const KERNEL_SURFACE_BUDGET = {
   // and delegates the per-record re-encrypt walk to
   // `with-shape/satellites/migrate-cek.ts`. Genuinely core: a new public
   // Vault method, same tier as `runSchemaCutover`/`abortSchemaCutover`.
-  'packages/hub/src/kernel/vault.ts': 3950,
+  // Bumped 3950→3958 (2026-07-15, #653: reserved-dict-deps delegator for partial-sync
+  // expansion): `_reservedDictDepsOf(names)` — a thin delegator (same tier as
+  // `_reservedLookupCollectionNames()` beside it) to `reservedDictDepsOf` in
+  // `via/lookup/registry.ts`, reached through the existing lookup-strategy port import.
+  'packages/hub/src/kernel/vault.ts': 3958,
   // Bumped 2920 → 2960 (2026-06): two genuinely-core additions landed —
   // #313's `openVault` no-self-provision pre-gate (a 1-line call; the policy
   // logic itself was extracted to team/keyring.ts as `assertKeyringOpenAllowed`),


### PR DESCRIPTION
Four sync-engine follow-ups from milestone #29, each TDD + reviewed (per-task, Fable/Opus on the correctness-critical paths) with a whole-branch review. Full suite: **499 files / 4039 tests green**; typecheck, lint, `check:architecture` clean.

## #653 — partial-sync auto-includes dependency dictionaries
`pull`/`push({ collections: ['orders'] })` respected the filter literally and dropped the `_dict_*` reserved dimensions `orders`' lookup fields depend on, so labels went stale on partially-synced instances. Adds a `reservedDictExpander` (mirroring the existing `pairExpander`) that unions in each named collection's one-hop dict deps. One hop is provably complete — `vault.collection()` refuses `_dict_*` names. Applied to push and pull. *(vault.ts ceiling 3950→3958.)*

## #606 — skip the redundant `adapter.get` on a synced-eager insert
#589's re-create version-continuity gate read the store on every eager+synced insert because `!existing` can't distinguish a new id from a re-create-over-marker. Tracks a per-collection `markerIds` set so the gate reads only for a known marker prior.

**Review caught and fixed a CRITICAL:** the first cut maintained the set *after* a `!hydrated` early-return, so a marker landing via sync mid-hydration was never tracked → a later re-create silently reset to `_v=1` (the #589 regression). Fixed by maintaining the set synchronously at `_onRecordMutated` and before the hydration gate; a reviewer-authored repro proves it (`_v=1`→`_v=3`). *(collection.ts ceiling 4472→4521.)*

## #693 — multi-tab safety for the marker-set (folded in)
The `markerIds` set is per-instance, so under multi-tab coordination sharing one store it can't see a peer tab's out-of-band delete-marker — a re-create in that window (or *permanently* under presence-only `propagateWrites:false`) could reset to `_v=1`, resurrecting a deleted record. When multi-tab coordination is active (`Noydb.tabCoordinator` set), the gate falls back to the pre-#606 unconditional read; the #606 perf win is unchanged for the common single-instance case. Originally deferred as a follow-up; now included so #606 never ships the window. `LookupHandle` (`_dict_*`) was verified never-vulnerable (it already always-reads + OCC-guards), so it's correctly unwired. *(ceilings noydb 2385→2396, vault 3958→3959, collection 4521→4529.)*

## #658 — sync-applied deletes heal MV rows and array-derivation outputs (parity with local)
The issue's premise was inverted: local deletes *already* heal rollups + MV + array-derivation outputs; only the sync-delete wave was rollup-only. Adds `dispatchMaterializedViewsOnDelete` + `dispatchArrayDerivationsOnDelete` to the wave's deletes loop — a parity fix that *reduces* divergence. Record-shape same-id outputs stay untouched (matching local); no RE-DERIVE, so the `mutation-choke-point` pin holds. A per-wave MV-refresh dedup is a noted perf follow-up (idempotent, correctness-neutral).

## Notes
- Whole-branch review confirmed no cross-task interaction (`_dict_*` collections can't reach the marker-gate or the graph wave; #606's set maintenance doesn't change which deletes enter #658's `touch.deletes`).
- noydb.ts/vault.ts/collection.ts are now at their (bumped) ceilings with zero slack — next toucher shrink-first.

Closes #653
Closes #606
Closes #658
Closes #693