### PR TITLE
fix(hub): via-port lazy/index follow-ups — lazy Via-awareness, money late-attach, satellites revert doc (#684, #686, #687)

### DIFF
--- a/docs/subsystems/via-money.md
+++ b/docs/subsystems/via-money.md
@@ -106,11 +106,12 @@ lookup (`CollectionIndexes.lookupEqual`/`lookupIn`) hits directly instead of fal
 full scan. Multi-currency (`currencies:`) fields always scan in **eager** mode — there is no single
 stored-form value a hash index can serve for a `{ amount, currency }` shape
 (`packages/hub/__tests__/money/where-comparison.test.ts`, "indexed fast path agrees with the scan"
-describe block, spy-proven against `lookupEqual`/`lookupIn`). On **lazy** mode there is no scan
-fallback: a multi-currency clause dispatches raw through `lookupEqual`/`lookupIn` (the `{ amount,
-currency }` object buckets under `\0OBJECT\0`), so end-to-end correctness there is bounded by the
-same `LazyQuery` Via-awareness gap as fixed-mode — tracked in #684. Range/`between` always scan in EAGER
-mode (no range probe is ever emitted); LAZY mode's range behavior is different — see below.
+describe block, spy-proven against `lookupEqual`/`lookupIn`). **Lazy** mode now matches: a
+multi-currency `==`/`in` clause (where `indexProbe` declines to probe, so `clause.via.indexValue`
+is `undefined`) enumerates the field's full indexed id set via `orderedBy` and lets the Via-aware
+post-filter decide, the same scan-equivalent outcome eager's always-scan produces (#684).
+Range/`between` always scan in EAGER mode (no range probe is ever emitted); LAZY mode's range
+behavior is different — see below.
 
 **Mixed-era data (#672).** A record whose stored value predates the field's `money()`
 declaration, or otherwise bypassed the money write path, may hold a non-canonical scaled string
@@ -143,31 +144,27 @@ hydrate-from-cold or an explicit `rebuildIndexes()`).
 `resolveCandidateIds()`) canonicalizes an `==`/`in` probe value before calling
 `lookupEqual`/`lookupIn` — mirroring the eager path's `candidateRecords()` resolving
 `clause.via.indexValue` before its own lookup. A legacy non-canonical record and a canonical one
-now land in, and are found via, the same bucket on the lazy fast path too. Range/`between` do
-**not** behave the same across modes: eager mode's `moneyIndexProbe` never emits a range probe, so
-`candidateRecords()` never calls an index for a money range clause and always scans. Lazy mode's
-`resolveCandidateIds()` dispatches EVERY range clause — including money fields — through
-`PersistedCollectionIndex.lookupRange` unconditionally, with **no scan fallback**; the comparison
-is on the raw, uncanonicalized typed value, so a money field's lazy-mode range correctness (e.g.
-mixed-era or non-canonical stored values) is a live, pre-existing gap, tracked in #684.
+now land in, and are found via, the same bucket on the lazy fast path too. Range/`between` now
+matches eager's shape too (#684): for a Via-covered field, `resolveCandidateIds()` no longer trusts
+`PersistedCollectionIndex.lookupRange`'s raw typed comparison — it enumerates the field's full
+indexed id set via `orderedBy` instead and lets the Via-aware post-filter apply the correct
+scaled-space comparison, the same "index scopes candidates, post-filter decides" outcome eager's
+always-scan produces. A non-Via range clause keeps the `lookupRange` fast path unchanged.
 Because a lazy-mode legacy record predating the field's `indexes: [...]` declaration has no
 `_idx/<field>/*` side-car at all until backfilled, `reconcileOnOpen: 'auto'` (or an explicit
 `collection.reconcileIndex()`/`rebuildIndexes()` call) is required for such a record to become
 visible to the fast path.
 
-**Residual boundary, not fixed by #677 — tracked in #684.** `LazyQuery`'s post-filter
-(`lazy-builder.ts`'s `matchesAll`) re-evaluates every clause — including the index-driving one —
-against the DECODED record (`getRecord()` runs `via.present()`), via the generic (non-Via-aware)
-`evaluateClause`, because `LazyQuery.where()` never builds a `clause.via` the way
-`Query.where()`/`ScanBuilder.where()` do. At `scale: 0` this doesn't surface (decode is an
-identity transform). At `scale > 0` it does, and it is NOT merely a "pass the stored form"
-workaround: even a query value spelled correctly in the field's STORED (canonical scaled-int)
-form reaches the right candidate ids via the index, but the post-filter then compares that same
-raw value against the DECODED record (e.g. `'100'` vs `'1.00'`) and rejects every match. **The
-practical result: `lazyQuery().where(moneyField, ...).toArray()` returns an empty array
-end-to-end for any money field with `scale > 0`, regardless of how the query value is spelled.**
-Only the index layer itself (bucket + probe canonicalization, #677) is fixed today; full parity
-with `scan().where()` (Via-aware post-filtering, major-unit quantization) is tracked in #684.
+**Lazy Via-aware post-filter (#684).** `LazyQuery.where()` now builds a `clause.via` the same way
+`Query.where()`/`ScanBuilder.where()` do, and the post-filter no longer runs against the DECODED
+record. `Collection.get()` was split into a private raw fetch (`#getRaw`) plus `present()`; the
+post-filter (`lazy-builder.ts`'s `matchesAll`) evaluates each clause against the RAW stored record
+via the Via-aware `clause.via.evaluate`, and `toArray()` decodes only the survivors — the same
+"filter stored-form, decode on output" shape eager already had. `lazyQuery().where(moneyField,
+...).toArray()` now returns the correct rows at any `scale`, regardless of how the query value is
+spelled, matching `scan().where()`/`query().where()` end-to-end. Two related items remain open:
+lazy `orderBy` *ordering* parity for money fields (the post-filter fix above doesn't touch sort
+order) is tracked in #695; the composite-index `==` fast path isn't yet Via-aware, tracked in #696.
 
 ## See also
 

--- a/docs/subsystems/via-money.md
+++ b/docs/subsystems/via-money.md
@@ -124,6 +124,17 @@ and `delete()` (remove) — so updating or deleting a legacy record cleans up it
 correctly instead of stranding the id there (a gap the initial #672 fix left open, closed in
 review).
 
+**Eager late-attach (#686).** `money()` can also arrive on an existing, already-hydrated
+collection via a SECOND `vault.collection(name, { moneyFields })` call — e.g. an earlier
+`vault.collection(name, { indexes: [...] })` call (no `moneyFields`) already triggered eager-index
+hydration and built its buckets from raw stringified values. `_applyMoneyFields` now detects an
+already-hydrated collection and re-runs the eager-index rebuild (the same
+`rebuildEagerIndexesFromCache` hydrate-on-open uses) as part of attaching the money declaration, so
+rows indexed before the late-attach are re-canonicalized immediately — no gap window, and no manual
+`rebuildIndexes()` call required. Before this fix such rows were silently under-returned by a
+canonical `==`/`in` probe until the next full rebuild (was: self-corrected only on the next
+hydrate-from-cold or an explicit `rebuildIndexes()`).
+
 **Lazy mode (#677).** Lazy-mode collections (`prefetch: false`) keep their own durable
 `PersistedCollectionIndex` side-cars — a separate implementation from the eager
 `CollectionIndexes`, but now with the SAME canonicalization guarantee. Every bucket-mutation site

--- a/docs/subsystems/via.md
+++ b/docs/subsystems/via.md
@@ -504,9 +504,11 @@ is no single stored-form value a hash index can serve for those). The initial mi
 pre-money-declaration legacy data was closed for eager-mode collections by #672's index-key
 canonicalizer, and for lazy-mode (`prefetch: false`) collections by #677's matching
 `PersistedCollectionIndex` bucket + probe canonicalizer (documented on the money page). A
-separate lazy-mode boundary remains: `LazyQuery.where()` doesn't build a `clause.via`, so
-end-to-end lazy money `==`/`in` queries at `scale > 0` still return an empty `.toArray()` —
-tracked in #684.
+separate lazy-mode boundary — `LazyQuery.where()` not building a `clause.via`, which left
+end-to-end lazy money `==`/`in` queries at `scale > 0` returning an empty `.toArray()` — was
+closed by #684: `LazyQuery.where()` now builds `clause.via` and the post-filter runs Via-aware
+against the raw stored record, matching `scan()`/`query()` at every scale (see the money page for
+the full story, including the still-open `orderBy` ordering item, #695).
 
 ## See also
 

--- a/packages/hub/__tests__/lazy-indexes-range-composite.test.ts
+++ b/packages/hub/__tests__/lazy-indexes-range-composite.test.ts
@@ -161,13 +161,15 @@ describe('composite (multi-field) indexes', () => {
     await coll.put('r-1', { id: 'r-1', clientId: 'c-A', period: '2026-Q1', amount: 10 })
     await coll.put('r-2', { id: 'r-2', clientId: 'c-B', period: '2026-Q1', amount: 20 })
 
-    // This particular call-site lacks an indexable driver (no
-    // composite-covering equality, no orderBy), so it surfaces
-    // IndexRequiredError — but only because of the no-driver guard,
-    // not because `clientId` was rejected as unindexed.
-    await expect(
-      coll.lazyQuery().where('clientId', '==', 'c-A').toArray(),
-    ).rejects.toThrow(IndexRequiredError)
+    // #698: `declareAll` now decomposes a composite declaration into its
+    // component single-field indexes too (mirroring eager), so `clientId`
+    // has its own single-field driver here even though only the composite
+    // was declared — this now resolves via the fast path instead of
+    // surfacing IndexRequiredError (the pre-#698 behavior this test used to
+    // pin, when the composite-only declaration left `clientId` with no
+    // usable driver).
+    const rows = await coll.lazyQuery().where('clientId', '==', 'c-A').toArray()
+    expect(rows.map(r => r.id)).toEqual(['r-1'])
   })
 
   it('rejects composite declaration where a field name contains the `|` delimiter', async () => {

--- a/packages/hub/__tests__/satellites-fanout.test.ts
+++ b/packages/hub/__tests__/satellites-fanout.test.ts
@@ -167,7 +167,7 @@ describe('joined fan-out', () => {
   })
 
   it('pair delete removes the satellite leg first; failure reverts', async () => {
-    const { vault, spy, changes, deps } = await openPair()
+    const { vault, spy, changes, deps, dirtyLog } = await openPair()
     await joinedPut(deps(), 'x', { from: 'a', body: 'B' })
     spy.reset()
     await vault.collection<Msg>('msgs').delete('x') // through the public base-proxy delete override
@@ -187,6 +187,9 @@ describe('joined fan-out', () => {
     await expect(vault.collection<Msg>('msgs').delete('y')).rejects.toThrow()
     expect(await spy.raw.get('v1', 'msgs_text', 'y')).toEqual(priorEnvelope) // satellite ENVELOPE restored byte-for-byte
     expect(changes.last('msgs_text')).toMatchObject({ id: 'y', action: 'put' }) // restored → 'put'
+    // #687: assert the dirty-log side of compensation directly (not just the
+    // change-event proxy) — the reverted satellite leg's dirty entry is cleaned.
+    expect(dirtyLog.entriesFor('msgs_text', 'y')).toEqual([])
     await new Promise(r => setTimeout(r, 0)) // let subscribe()'s async hydration settle
     expect(subEvents.at(-1)).toMatchObject({ type: 'put', id: 'y', record: { body: 'C' } })
   })

--- a/packages/hub/__tests__/via/money-index-canonical-lazy.test.ts
+++ b/packages/hub/__tests__/via/money-index-canonical-lazy.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { z } from 'zod'
-import { createNoydb, money } from '../../src/index.js'
+import { createNoydb, money, FieldNotQueryableError } from '../../src/index.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../../src/kernel/types.js'
 import { withIndexing } from '../../src/with-lookup/indexing/index.js'
 import { PersistedCollectionIndex } from '../../src/with-lookup/indexing/persisted-indexes.js'
@@ -208,21 +208,23 @@ describe('lazy-mode money index-key canonicalization + probe (#677)', () => {
       await col.put('legacy', { id: 'legacy', amount: 2 }) // update through the money write path
 
       // Fence the upsert remove-old canonicalize site directly (#677 review F1):
-      // `.toArray()` alone can't see a stranded bucket — the #684 post-filter
-      // rejects the stale decoded record either way — so spy on what the index
-      // makes the query FETCH. A canonicalized remove-old empties bucket '1', so
-      // the old-value query fetches nothing; a stranded 'legacy' would be looked
-      // up and fetched (then post-filter-rejected), leaking through here.
-      const getSpy = vi.spyOn(col, 'get')
+      // `.toArray()` alone can't fully prove a stranded bucket was cleared —
+      // post-#684, the post-filter is via-aware and would correctly reject a
+      // stranded 'legacy' anyway (its raw amount is now 2, not 1) — so assert
+      // on the CANDIDATE SET the index itself resolves for the old-value probe
+      // (`lookupEqual`'s return value) rather than inferring it from fetch
+      // calls (#684 moved the post-filter's raw fetch behind a private
+      // `Collection#getRaw`, unobservable via `vi.spyOn(col, 'get')`).
+      const lookupSpy = vi.spyOn(PersistedCollectionIndex.prototype, 'lookupEqual')
       const oldHit = await col.lazyQuery().where('amount', '==', '1').toArray()
-      const oldHitFetched = getSpy.mock.calls.map((c) => c[0])
-      getSpy.mockClear()
+      const oldCandidateIds = [...(lookupSpy.mock.results[0]?.value ?? [])]
+      lookupSpy.mockClear()
       const newHit = await col.lazyQuery().where('amount', '==', '2').toArray()
-      getSpy.mockRestore()
+      lookupSpy.mockRestore()
       db.close()
 
       expect(oldHit.map((r) => r.id)).toEqual([]) // must NOT still return the stale-bucket 'legacy' id
-      expect(oldHitFetched).not.toContain('legacy') // and must NOT linger in the old '1' bucket
+      expect(oldCandidateIds).not.toContain('legacy') // and must NOT linger in the old '1' bucket
       expect(newHit.map((r) => r.id)).toEqual(['legacy'])
     })
 
@@ -271,7 +273,6 @@ describe('lazy-mode money index-key canonicalization + probe (#677)', () => {
 
       const { db, col } = await openMoneyIndexedLazySession(adapter)
       const lookupSpy = vi.spyOn(PersistedCollectionIndex.prototype, 'lookupEqual')
-      const getSpy = vi.spyOn(col, 'get')
       try {
         // '001' is a DIFFERENT non-canonical spelling of the same magnitude
         // (BigInt('001') === BigInt('0001') === 1n) — never byte-identical
@@ -286,11 +287,13 @@ describe('lazy-mode money index-key canonicalization + probe (#677)', () => {
         // And the candidate id set the index resolved from that
         // canonicalized probe included 'legacy' — i.e. the fast path found
         // the right record, independent of what the post-filter later does
-        // with it.
-        expect(getSpy.mock.calls.map((c) => c[0])).toContain('legacy')
+        // with it. Asserted on `lookupEqual`'s own return value (#684 moved
+        // the post-filter's raw fetch behind a private `Collection#getRaw`,
+        // unobservable via `vi.spyOn(col, 'get')`).
+        const candidateIds = [...(lookupSpy.mock.results[0]?.value ?? [])]
+        expect(candidateIds).toContain('legacy')
       } finally {
         lookupSpy.mockRestore()
-        getSpy.mockRestore()
       }
       db.close()
     })
@@ -301,14 +304,15 @@ describe('lazy-mode money index-key canonicalization + probe (#677)', () => {
 
       const { db, col } = await openMoneyIndexedLazySession(adapter)
       const lookupSpy = vi.spyOn(PersistedCollectionIndex.prototype, 'lookupIn')
-      const getSpy = vi.spyOn(col, 'get')
       try {
         await col.lazyQuery().where('amount', 'in', ['001', '999']).toArray()
         expect(lookupSpy).toHaveBeenCalledWith('amount', ['1', '999'])
-        expect(getSpy.mock.calls.map((c) => c[0])).toContain('legacy')
+        // Asserted on `lookupIn`'s own return value — see the `==` test
+        // above for why (#684 moved the raw fetch behind a private method).
+        const candidateIds = [...(lookupSpy.mock.results[0]?.value ?? [])]
+        expect(candidateIds).toContain('legacy')
       } finally {
         lookupSpy.mockRestore()
-        getSpy.mockRestore()
       }
       db.close()
     })
@@ -377,5 +381,340 @@ describe('lazy-mode money index-key canonicalization + probe (#677)', () => {
       expect(fastEq).not.toContain('r-null')
       db.close()
     })
+  })
+})
+
+// #684 — scale:2 (decode is NOT identity): `LazyQuery.where()` never built
+// `clause.via`, so the post-filter ran the generic (non-Via-aware)
+// `evaluateClause` against the DECODED record (`getRecord()`'s `via.
+// present()` output). At `scale: 0` (the suite above) decode is the
+// identity transform on the digit string, so the bug was invisible; at
+// `scale > 0` decode inserts a decimal point (stored '100' -> decoded
+// '1.00'), so EVERY lazy money query returned an empty `.toArray()`
+// regardless of how the operand was spelled. This suite pins the fix: the
+// post-filter now runs against the RAW (stored-form) record via a
+// dedicated raw-fetch seam on `Collection`, `clause.via.evaluate` sees the
+// same operand/actual-value space eager's `filterRecords` does, and only
+// survivors are decoded (`present()`) on the way out.
+describe('lazy-mode via-aware post-filter at scale > 0 (#684)', () => {
+  /** scale:2 lazy session — decode is NOT identity (stored '100' <-> decoded '1.00'), the #684 repro precondition. */
+  async function openMoneyIndexedLazySession2(adapter: NoydbStore) {
+    const db = await createNoydb({ store: adapter, user: USER, secret: PASS, indexStrategy: withIndexing() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<Item>(COLL, {
+      schema: itemSchema,
+      prefetch: false,
+      cache: { maxRecords: 100 },
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+      indexes: ['amount'],
+      reconcileOnOpen: 'auto',
+    })
+    return { db, col }
+  }
+
+  /** Eager counterpart — same moneyFields, `prefetch: true` (default) — for the mandatory eager-vs-lazy parity assertion. */
+  async function openMoneyIndexedEagerSession2(adapter: NoydbStore) {
+    const db = await createNoydb({ store: adapter, user: USER, secret: PASS, indexStrategy: withIndexing() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<Item>(COLL, {
+      schema: itemSchema,
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+      indexes: ['amount'],
+    })
+    return { db, col }
+  }
+
+  /**
+   * amount:1 -> stored '100', 2 -> '200', 3 -> '300' (scale:2 quantization).
+   * Written through a PLAIN money session (moneyFields, but no
+   * `indexStrategy`/`indexes`) so the adapter ends up holding only the three
+   * canonical `Item` records — no `_idx/*` side-cars. That leaves the
+   * adapter safe to layer EITHER a lazy-indexed or an eager-indexed read
+   * session on top afterward (a lazy-indexed WRITE session would persist
+   * `_idx/amount/*` side-cars that an eager `ensureHydrated()` read on the
+   * same collection can't schema-validate as `Item` records).
+   */
+  async function seedDataset(adapter: NoydbStore): Promise<void> {
+    const db = await createNoydb({ store: adapter, user: USER, secret: PASS })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<Item>(COLL, {
+      schema: itemSchema,
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+    })
+    await col.put('r1', { id: 'r1', amount: 1 })
+    await col.put('r2', { id: 'r2', amount: 2 })
+    await col.put('r3', { id: 'r3', amount: 3 })
+    db.close()
+  }
+
+  it('== matches the 1.00 row for equivalent major-unit operand spellings, probing the canonical stored-form index key', async () => {
+    const adapter = persistentMemory()
+    await seedDataset(adapter)
+
+    const { db, col } = await openMoneyIndexedLazySession2(adapter)
+    const lookupSpy = vi.spyOn(PersistedCollectionIndex.prototype, 'lookupEqual')
+    let byNumber: Item[]
+    let byMajorString: Item[]
+    try {
+      byNumber = await col.lazyQuery().where('amount', '==', 1).toArray()
+      byMajorString = await col.lazyQuery().where('amount', '==', '1.00').toArray()
+      // Both equivalent major-unit spellings resolve to the SAME canonical
+      // STORED-form probe key ('100' — amount 1 quantized at scale 2),
+      // proving `clause.via.indexValue` (not the raw operand) drives the
+      // fast path.
+      expect(lookupSpy).toHaveBeenCalledWith('amount', '100')
+    } finally {
+      lookupSpy.mockRestore()
+    }
+    db.close()
+
+    // Pre-#684 both returned [] (post-filter compared the DECODED '1.00'
+    // record against the raw scaled-int operand and never matched).
+    expect(byNumber.map((r) => r.id)).toEqual(['r1'])
+    expect(byMajorString.map((r) => r.id)).toEqual(['r1'])
+  })
+
+  it('in returns every matching row', async () => {
+    const adapter = persistentMemory()
+    await seedDataset(adapter)
+
+    const { db, col } = await openMoneyIndexedLazySession2(adapter)
+    const hit = await col.lazyQuery().where('amount', 'in', [1, 2]).toArray()
+    db.close()
+
+    // Pre-#684 this returned [].
+    expect(hit.map((r) => r.id).sort()).toEqual(['r1', 'r2'])
+  })
+
+  it('range (> and between) post-filter in scaled-int space, not the raw typed stored value', async () => {
+    const adapter = persistentMemory()
+    await seedDataset(adapter)
+
+    const { db, col } = await openMoneyIndexedLazySession2(adapter)
+    const gt = await col.lazyQuery().where('amount', '>', 1).toArray()
+    const between = await col.lazyQuery().where('amount', 'between', [1, 3]).toArray()
+    db.close()
+
+    // Pre-#684 both returned [] — and even pre-#677/#684, `resolveCandidateIds`
+    // sent every range op through `lookupRange`'s raw/typed comparison
+    // unconditionally (no scan fallback), which is simply the wrong space
+    // for a money field's scaled-int stored form.
+    expect(gt.map((r) => r.id).sort()).toEqual(['r2', 'r3'])
+    expect(between.map((r) => r.id).sort()).toEqual(['r1', 'r2', 'r3'])
+  })
+
+  // MANDATORY parity: lazy must agree with eager (and a forced scan) on the
+  // result-id SET for every op — the real #684 regression guard, since at
+  // scale:0 (the suite above) eager and lazy could agree by accident
+  // (decode is identity there, so the post-filter bug was masked).
+  it('eager, lazy, and scan agree on the result-id set for ==, in, >, and between', async () => {
+    const adapter = persistentMemory()
+    await seedDataset(adapter)
+
+    // Open + hydrate EAGER first, before the lazy session's `reconcileOnOpen:
+    // 'auto'` gets a chance to persist `_idx/amount/*` side-cars into the
+    // SAME adapter (see `seedDataset`'s doc comment — eager's
+    // `ensureHydrated()` can't schema-validate those as `Item` records).
+    // query()/.toArray() reads the in-memory cache synchronously — force
+    // hydration (and the eager-index build) via an awaited op first (same
+    // requirement as the eager suite in money-index-canonical.test.ts).
+    const { db: dbEager, col: colEager } = await openMoneyIndexedEagerSession2(adapter)
+    await colEager.list()
+
+    const { db: dbLazy, col: colLazy } = await openMoneyIndexedLazySession2(adapter)
+
+    const cases: ReadonlyArray<{ op: '==' | 'in' | '>' | 'between'; value: unknown }> = [
+      { op: '==', value: 1 },
+      { op: 'in', value: [1, 2] },
+      { op: '>', value: 1 },
+      { op: 'between', value: [1, 3] },
+    ]
+
+    for (const { op, value } of cases) {
+      const lazyIds = (await colLazy.lazyQuery().where('amount', op, value).toArray()).map((r) => r.id).sort()
+      const eagerIds = colEager.query().where('amount', op, value).toArray().map((r) => r.id).sort()
+      const scannedIds = (await scanIds(colLazy.scan({ pageSize: 10 }).where('amount', op, value))).sort()
+      expect(lazyIds).toEqual(eagerIds)
+      expect(scannedIds).toEqual(lazyIds)
+    }
+
+    dbLazy.close()
+    dbEager.close()
+  })
+})
+
+// #684 review-fix 1 — `LazyQuery.where()` was missing the
+// `queryable: 'none'` posture guard the eager builders apply at `.where()`
+// time (`kernel/query/builder.ts:289`, `kernel/query/scan-builder.ts:182`):
+// `if (via?.postureFor(field)?.queryable === 'none') throw new
+// FieldNotQueryableError(field)`. Without it, `lazyQuery().where(<blob
+// field>, ...)` built a bare (non-via) clause and only failed later, from
+// `toArray()`, as a deferred `IndexRequiredError` — the wrong error class,
+// at the wrong call site. Blob fields (`blobFields`) are the existing
+// `queryable: 'none'` fixture (see `via/query-posture-b.test.ts`'s #629
+// Task 8 suite, which pins the SAME assertion for `query()`/`scan()`).
+describe('lazy-mode queryable:"none" posture guard (#684 review-fix 1 — parity with query()/scan())', () => {
+  interface Doc extends Record<string, unknown> { id: string; title: string; receipt: string }
+  const docSchema = z.object({ id: z.string(), title: z.string(), receipt: z.string() })
+
+  async function blobLazySession(adapter: NoydbStore) {
+    const db = await createNoydb({
+      store: adapter, user: 'alice', secret: 'blob-lazy-posture-passphrase-2026',
+      indexStrategy: withIndexing(),
+    })
+    const vault = await db.openVault('docs-vault')
+    const col = vault.collection<Doc>('docs', {
+      schema: docSchema,
+      prefetch: false,
+      cache: { maxRecords: 100 },
+      blobFields: { receipt: {} },
+      // `title` (not `receipt`) satisfies lazyQuery()'s "at least one
+      // indexed field" precondition — the posture guard must fire from
+      // `.where()` itself, before `toArray()`'s index-coverage check ever
+      // runs, so `receipt` need not be indexed for this test to be valid.
+      indexes: ['title'],
+    })
+    await col.put('d1', { id: 'd1', title: 'x', receipt: 'unused-placeholder' })
+    return { db, col }
+  }
+
+  it('where(blobField) throws FieldNotQueryableError at .where() time (not a deferred IndexRequiredError from toArray())', async () => {
+    const adapter = persistentMemory()
+    const { db, col } = await blobLazySession(adapter)
+    expect(() => col.lazyQuery().where('receipt', '==', 'x')).toThrow(FieldNotQueryableError)
+    db.close()
+  })
+
+  it('a non-blob (indexed) field on the same collection is unaffected', async () => {
+    const adapter = persistentMemory()
+    const { db, col } = await blobLazySession(adapter)
+    const hit = await col.lazyQuery().where('title', '==', 'x').toArray()
+    expect(hit.map((r) => r.id)).toEqual(['d1'])
+    db.close()
+  })
+})
+
+// #684 review-fix 2 — a sole `==`/`in` clause on a multi-MODE
+// money field (`money({ currencies: [...] })`) has `clause.via.indexValue
+// === undefined` (`moneyIndexProbe` only ever probes fixed-mode: no single
+// stored-form value the hash index can serve for a per-record-currency
+// field). Before this fix, `resolveCandidateIds()` treated that as "no
+// driver" and `continue`d past the clause entirely, so `toArray()` threw
+// `IndexRequiredError` — where eager's `candidateRecords()`
+// (`builder.ts:1176`) instead falls back to a full scan and returns the
+// correct rows. The fix mirrors the RANGE branch immediately above it in
+// `resolveCandidateIds()` (already handling the identical "no sound
+// bucket" case): enumerate the field's full indexed id set via
+// `orderedBy()` as the candidate superset, and let the (already via-aware,
+// #684) post-filter in `toArray()` decide.
+describe('lazy-mode multi-currency money == / in (#684 review-fix 2 — parity with query(), not IndexRequiredError)', () => {
+  interface Payment extends Record<string, unknown> { id: string; amount: unknown }
+  const paymentSchema = z.object({ id: z.string(), amount: z.unknown() })
+
+  async function seedMultiCurrency(adapter: NoydbStore): Promise<void> {
+    const db = await createNoydb({ store: adapter, user: USER, secret: PASS })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<Payment>('payments', {
+      schema: paymentSchema,
+      moneyFields: { amount: money({ currencies: ['EUR', 'USD'] }) },
+    })
+    await col.put('e1', { id: 'e1', amount: { amount: 100, currency: 'EUR' } })
+    await col.put('e2', { id: 'e2', amount: { amount: 250, currency: 'EUR' } })
+    await col.put('u1', { id: 'u1', amount: { amount: 100, currency: 'USD' } })
+    db.close()
+  }
+
+  async function openMultiCurrencyLazySession(adapter: NoydbStore) {
+    const db = await createNoydb({ store: adapter, user: USER, secret: PASS, indexStrategy: withIndexing() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<Payment>('payments', {
+      schema: paymentSchema,
+      prefetch: false,
+      cache: { maxRecords: 100 },
+      moneyFields: { amount: money({ currencies: ['EUR', 'USD'] }) },
+      indexes: ['amount'],
+      reconcileOnOpen: 'auto',
+    })
+    return { db, col }
+  }
+
+  async function openMultiCurrencyEagerSession(adapter: NoydbStore) {
+    const db = await createNoydb({ store: adapter, user: USER, secret: PASS, indexStrategy: withIndexing() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<Payment>('payments', {
+      schema: paymentSchema,
+      moneyFields: { amount: money({ currencies: ['EUR', 'USD'] }) },
+      indexes: ['amount'],
+    })
+    return { db, col }
+  }
+
+  it('== returns the matching row via the orderedBy candidate superset, not a lookupEqual bucket probe', async () => {
+    const adapter = persistentMemory()
+    await seedMultiCurrency(adapter)
+
+    const { db, col } = await openMultiCurrencyLazySession(adapter)
+    const eqSpy = vi.spyOn(PersistedCollectionIndex.prototype, 'lookupEqual')
+    const orderedSpy = vi.spyOn(PersistedCollectionIndex.prototype, 'orderedBy')
+    let hit: Payment[]
+    try {
+      hit = await col.lazyQuery().where('amount', '==', { amount: 100, currency: 'EUR' }).toArray()
+      // Pre-fix: this threw IndexRequiredError instead of returning here.
+      expect(hit.map((r) => r.id)).toEqual(['e1'])
+      // Multi-mode never has a sound bucket key — the fast path must NOT
+      // probe lookupEqual for this clause; it must fall back to orderedBy.
+      expect(eqSpy).not.toHaveBeenCalled()
+      expect(orderedSpy).toHaveBeenCalledWith('amount', 'asc')
+    } finally {
+      eqSpy.mockRestore()
+      orderedSpy.mockRestore()
+    }
+    db.close()
+  })
+
+  it("'in' returns every matching row via the orderedBy candidate superset", async () => {
+    const adapter = persistentMemory()
+    await seedMultiCurrency(adapter)
+
+    const { db, col } = await openMultiCurrencyLazySession(adapter)
+    const inSpy = vi.spyOn(PersistedCollectionIndex.prototype, 'lookupIn')
+    let hit: Payment[]
+    try {
+      hit = await col.lazyQuery().where('amount', 'in', [
+        { amount: 100, currency: 'EUR' },
+        { amount: 250, currency: 'EUR' },
+      ]).toArray()
+      expect(hit.map((r) => r.id).sort()).toEqual(['e1', 'e2'])
+      expect(inSpy).not.toHaveBeenCalled()
+    } finally {
+      inSpy.mockRestore()
+    }
+    db.close()
+  })
+
+  // MANDATORY parity: lazy must agree with eager on the result-id set —
+  // the real FIX 2 regression guard.
+  it('eager and lazy agree on the result-id set for == and in', async () => {
+    const adapter = persistentMemory()
+    await seedMultiCurrency(adapter)
+
+    const { db: dbEager, col: colEager } = await openMultiCurrencyEagerSession(adapter)
+    await colEager.list() // force hydration, same requirement as the scale:2 suite above
+
+    const { db: dbLazy, col: colLazy } = await openMultiCurrencyLazySession(adapter)
+
+    const cases: ReadonlyArray<{ op: '==' | 'in'; value: unknown }> = [
+      { op: '==', value: { amount: 100, currency: 'EUR' } },
+      { op: 'in', value: [{ amount: 100, currency: 'EUR' }, { amount: 250, currency: 'EUR' }] },
+    ]
+
+    for (const { op, value } of cases) {
+      const lazyIds = (await colLazy.lazyQuery().where('amount', op, value).toArray()).map((r) => r.id).sort()
+      const eagerIds = colEager.query().where('amount', op, value).toArray().map((r) => r.id).sort()
+      expect(lazyIds).toEqual(eagerIds)
+    }
+
+    dbLazy.close()
+    dbEager.close()
   })
 })

--- a/packages/hub/__tests__/via/money-index-canonical-lazy.test.ts
+++ b/packages/hub/__tests__/via/money-index-canonical-lazy.test.ts
@@ -926,3 +926,107 @@ describe('lazy-mode composite-index == skips the fast path for Via-covered field
     expect(lazyIds).toEqual(eagerIds)
   })
 })
+
+// #698 — a composite-ONLY lazy declaration (`indexes: [['amount', 'tag']]`,
+// no standalone `'amount'` entry) declared only the composite mirror in
+// `declareAll` (`with-lookup/indexing/active.ts`). After #696 made the
+// composite `==` fast path skip Via-covered (money) fields and fall through
+// to the single-field Via-aware path, that fallback had no driver — the
+// field was never `declare()`d singly — so `resolveCandidateIds()` returned
+// null and `toArray()` threw `IndexRequiredError` where eager (which always
+// decomposes a composite into its component single-field indexes, see the
+// eager branch in `withIndexing()`) returns results. The fix decomposes a
+// composite into its component single-field indexes on declare, like eager,
+// keeping the composite mirror for the multi-field fast path.
+describe('lazy-mode composite-ONLY declaration decomposes into component singles (#698)', () => {
+  interface Row extends Record<string, unknown> {
+    id: string
+    amount: number | string
+    tag: string
+  }
+  const rowSchema = z.object({ id: z.string(), amount: z.union([z.number(), z.string()]), tag: z.string() })
+
+  /** scale:2 lazy session — COMPOSITE-ONLY over ['amount', 'tag']; no standalone 'amount' index entry. */
+  async function openCompositeOnlyLazySession(adapter: NoydbStore) {
+    const db = await createNoydb({ store: adapter, user: USER, secret: PASS, indexStrategy: withIndexing() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<Row>(COLL, {
+      schema: rowSchema,
+      prefetch: false,
+      cache: { maxRecords: 100 },
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+      indexes: [['amount', 'tag']],
+      reconcileOnOpen: 'auto',
+    })
+    return { db, col }
+  }
+
+  /** Eager counterpart — same moneyFields, same composite-only declaration, for the mandatory eager-parity assertion. */
+  async function openCompositeOnlyEagerSession(adapter: NoydbStore) {
+    const db = await createNoydb({ store: adapter, user: USER, secret: PASS, indexStrategy: withIndexing() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<Row>(COLL, {
+      schema: rowSchema,
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+      indexes: [['amount', 'tag']],
+    })
+    return { db, col }
+  }
+
+  async function seedDataset(adapter: NoydbStore): Promise<void> {
+    const db = await createNoydb({ store: adapter, user: USER, secret: PASS })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<Row>(COLL, {
+      schema: rowSchema,
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+    })
+    await col.put('r1', { id: 'r1', amount: 1, tag: 'x' })
+    await col.put('r2', { id: 'r2', amount: 1, tag: 'y' })
+    await col.put('r3', { id: 'r3', amount: 2, tag: 'x' })
+    db.close()
+  }
+
+  it('composite-only + money, double == returns the correct row (was IndexRequiredError), matching eager', async () => {
+    const adapter = persistentMemory()
+    await seedDataset(adapter)
+
+    const { db: dbEager, col: colEager } = await openCompositeOnlyEagerSession(adapter)
+    await colEager.list() // force eager hydration
+
+    const { db: dbLazy, col: colLazy } = await openCompositeOnlyLazySession(adapter)
+
+    // Pre-#698: the composite fast path skips this Via-covered clause (#696)
+    // and falls through to the single-field path — but 'amount' was never
+    // declared singly (composite-only declaration), so `resolveCandidateIds`
+    // returned null and this threw IndexRequiredError.
+    const lazyHit = await colLazy.lazyQuery().where('amount', '==', 1).where('tag', '==', 'x').toArray()
+    const eagerHit = colEager.query().where('amount', '==', 1).where('tag', '==', 'x').toArray()
+
+    dbLazy.close()
+    dbEager.close()
+
+    expect(lazyHit.map((r) => r.id)).toEqual(['r1'])
+    expect(lazyHit.map((r) => r.id).sort()).toEqual(eagerHit.map((r) => r.id).sort())
+  })
+
+  it('composite-only + single-field query on the covered money field returns the right rows (was IndexRequiredError)', async () => {
+    const adapter = persistentMemory()
+    await seedDataset(adapter)
+
+    const { db: dbEager, col: colEager } = await openCompositeOnlyEagerSession(adapter)
+    await colEager.list() // force eager hydration
+
+    const { db: dbLazy, col: colLazy } = await openCompositeOnlyLazySession(adapter)
+
+    // Pre-#698: 'amount' has no single-field driver on a composite-only
+    // declaration, so this single-clause query threw IndexRequiredError.
+    const lazyHit = await colLazy.lazyQuery().where('amount', '==', 1).toArray()
+    const eagerHit = colEager.query().where('amount', '==', 1).toArray()
+
+    dbLazy.close()
+    dbEager.close()
+
+    expect(lazyHit.map((r) => r.id).sort()).toEqual(['r1', 'r2'])
+    expect(lazyHit.map((r) => r.id).sort()).toEqual(eagerHit.map((r) => r.id).sort())
+  })
+})

--- a/packages/hub/__tests__/via/money-index-canonical-lazy.test.ts
+++ b/packages/hub/__tests__/via/money-index-canonical-lazy.test.ts
@@ -826,3 +826,103 @@ describe('lazy-mode orderBy is Via-aware (#695)', () => {
     expect(descLazy).toEqual(descEager)
   })
 })
+
+// #696 — `resolveCandidateIds()`'s composite fast path builds `eqMap` from
+// RAW `clause.value` (the major-unit operand, e.g. `1`) and probes
+// `idx.lookupEqual(def.key, tuple)`. The composite mirror buckets on
+// `stringifyKey(tuple)` — the per-field money canonicalizer
+// (`ViaPipeline.canonicalizeIndexKey`) only ever keys off a SINGLE field
+// name, never the joined composite key (`'amount|tag'`), so a composite that
+// covers a money field never lands the write-side bucket and the raw-operand
+// tuple never matches it: `lookupEqual` returns an empty (but non-null) Set,
+// so the fast path returns `[]` instead of falling back. The fix skips the
+// composite fast path when any covered `==` clause is Via-covered, falling
+// through to the already-Via-aware single-field path below it.
+describe('lazy-mode composite-index == skips the fast path for Via-covered fields (#696)', () => {
+  interface Row extends Record<string, unknown> {
+    id: string
+    amount: number | string
+    tag: string
+  }
+  const rowSchema = z.object({ id: z.string(), amount: z.union([z.number(), z.string()]), tag: z.string() })
+
+  /** scale:2 lazy session — single index on 'amount' (required for the single-field fallback) PLUS a composite over ['amount', 'tag']. */
+  async function openLazySession(adapter: NoydbStore) {
+    const db = await createNoydb({ store: adapter, user: USER, secret: PASS, indexStrategy: withIndexing() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<Row>(COLL, {
+      schema: rowSchema,
+      prefetch: false,
+      cache: { maxRecords: 100 },
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+      indexes: ['amount', ['amount', 'tag']],
+      reconcileOnOpen: 'auto',
+    })
+    return { db, col }
+  }
+
+  /** Eager counterpart — same moneyFields/indexes, for the mandatory eager-vs-lazy parity assertion. */
+  async function openEagerSession(adapter: NoydbStore) {
+    const db = await createNoydb({ store: adapter, user: USER, secret: PASS, indexStrategy: withIndexing() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<Row>(COLL, {
+      schema: rowSchema,
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+      indexes: ['amount', ['amount', 'tag']],
+    })
+    return { db, col }
+  }
+
+  async function seedDataset(adapter: NoydbStore): Promise<void> {
+    const db = await createNoydb({ store: adapter, user: USER, secret: PASS })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<Row>(COLL, {
+      schema: rowSchema,
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+    })
+    await col.put('r1', { id: 'r1', amount: 1, tag: 'x' })
+    await col.put('r2', { id: 'r2', amount: 1, tag: 'y' })
+    await col.put('r3', { id: 'r3', amount: 2, tag: 'x' })
+    db.close()
+  }
+
+  it('== + == on a composite covering a money field falls through to the single-field Via-aware path', async () => {
+    const adapter = persistentMemory()
+    await seedDataset(adapter)
+
+    const { db, col } = await openLazySession(adapter)
+    const hit = await col.lazyQuery().where('amount', '==', 1).where('tag', '==', 'x').toArray()
+    db.close()
+
+    // Pre-#696: the composite fast path probed a tuple built from the RAW
+    // major-unit operand (`1`) against buckets keyed on the raw stored
+    // value, canonicalized under a field name ('amount|tag') the money
+    // binding never covers — the probe missed and this returned [].
+    expect(hit.map((r) => r.id)).toEqual(['r1'])
+  })
+
+  // MANDATORY parity: lazy must agree with eager on the result-id set — the
+  // real #696 regression guard.
+  it('eager and lazy agree on the result-id set', async () => {
+    const adapter = persistentMemory()
+    await seedDataset(adapter)
+
+    // Open + hydrate EAGER first, before the lazy session's `reconcileOnOpen:
+    // 'auto'` gets a chance to persist `_idx/*` side-cars into the SAME
+    // adapter (same ordering requirement as the suites above).
+    const { db: dbEager, col: colEager } = await openEagerSession(adapter)
+    await colEager.list() // force hydration
+
+    const { db: dbLazy, col: colLazy } = await openLazySession(adapter)
+
+    const lazyIds = (await colLazy.lazyQuery().where('amount', '==', 1).where('tag', '==', 'x').toArray())
+      .map((r) => r.id).sort()
+    const eagerIds = colEager.query().where('amount', '==', 1).where('tag', '==', 'x').toArray()
+      .map((r) => r.id).sort()
+
+    dbLazy.close()
+    dbEager.close()
+
+    expect(lazyIds).toEqual(eagerIds)
+  })
+})

--- a/packages/hub/__tests__/via/money-index-canonical-lazy.test.ts
+++ b/packages/hub/__tests__/via/money-index-canonical-lazy.test.ts
@@ -718,3 +718,111 @@ describe('lazy-mode multi-currency money == / in (#684 review-fix 2 — parity w
     dbEager.close()
   })
 })
+
+// #695 — `LazyQuery.toArray()` decoded every survivor BEFORE sorting, then
+// sorted the DECODED records with the generic (non-Via-aware) comparator.
+// At scale:2, money's decoded form is a decimal string ('1.00'), so `orderBy`
+// ordered money lexicographically ('10.00' < '2.00'), diverging from eager's
+// `sortRecords(result, plan.orderBy, source.via, labelMaps)` in
+// `kernel/query/builder.ts`, which sorts the RAW (stored-form) records
+// via-aware (`via.compareForOrder`) and decodes only afterward. The fix
+// mirrors that: sort RAW survivors via-aware, slice offset/limit, decode
+// only the returned page.
+describe('lazy-mode orderBy is Via-aware (#695)', () => {
+  /** scale:2 lazy session — decode is NOT identity, same #684 repro precondition. */
+  async function openLazySession(adapter: NoydbStore) {
+    const db = await createNoydb({ store: adapter, user: USER, secret: PASS, indexStrategy: withIndexing() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<Item>(COLL, {
+      schema: itemSchema,
+      prefetch: false,
+      cache: { maxRecords: 100 },
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+      indexes: ['amount'],
+      reconcileOnOpen: 'auto',
+    })
+    return { db, col }
+  }
+
+  /** Eager counterpart — same moneyFields/indexes, for the mandatory eager-vs-lazy order parity assertion. */
+  async function openEagerSession(adapter: NoydbStore) {
+    const db = await createNoydb({ store: adapter, user: USER, secret: PASS, indexStrategy: withIndexing() })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<Item>(COLL, {
+      schema: itemSchema,
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+      indexes: ['amount'],
+    })
+    return { db, col }
+  }
+
+  /**
+   * amount 1 -> stored '100', 2 -> '200', 10 -> '1000' (scale:2 quantization).
+   * Written through a PLAIN money session (no `indexStrategy`) so the adapter
+   * holds only the three canonical `Item` records — same reasoning as
+   * `seedDataset` in the #684 suite above (keeps the adapter safe to layer
+   * either a lazy-indexed or an eager-indexed read session on top).
+   */
+  async function seedDataset(adapter: NoydbStore): Promise<void> {
+    const db = await createNoydb({ store: adapter, user: USER, secret: PASS })
+    const vault = await db.openVault(VAULT)
+    const col = vault.collection<Item>(COLL, {
+      schema: itemSchema,
+      moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+    })
+    await col.put('r1', { id: 'r1', amount: 1 })
+    await col.put('r2', { id: 'r2', amount: 2 })
+    await col.put('r10', { id: 'r10', amount: 10 })
+    db.close()
+  }
+
+  it('orderBy asc sorts money numerically, not lexicographically', async () => {
+    const adapter = persistentMemory()
+    await seedDataset(adapter)
+
+    const { db, col } = await openLazySession(adapter)
+    const rows = await col.lazyQuery().orderBy('amount', 'asc').toArray()
+    db.close()
+
+    // Pre-#695: the DECODED decimal strings ('1.00', '2.00', '10.00') sorted
+    // lexicographically -> ['r1', 'r10', 'r2']. Numeric order is r1, r2, r10.
+    expect(rows.map((r) => r.id)).toEqual(['r1', 'r2', 'r10'])
+  })
+
+  it('orderBy desc sorts money numerically', async () => {
+    const adapter = persistentMemory()
+    await seedDataset(adapter)
+
+    const { db, col } = await openLazySession(adapter)
+    const rows = await col.lazyQuery().orderBy('amount', 'desc').toArray()
+    db.close()
+
+    expect(rows.map((r) => r.id)).toEqual(['r10', 'r2', 'r1'])
+  })
+
+  // MANDATORY parity: lazy must agree with eager on the ORDER (not just the
+  // result-id set) — the real #695 regression guard.
+  it('eager and lazy agree on order, asc and desc', async () => {
+    const adapter = persistentMemory()
+    await seedDataset(adapter)
+
+    // Open + hydrate EAGER first, before the lazy session's `reconcileOnOpen:
+    // 'auto'` gets a chance to persist `_idx/amount/*` side-cars into the
+    // SAME adapter (same ordering requirement as the #684 parity test above).
+    const { db: dbEager, col: colEager } = await openEagerSession(adapter)
+    await colEager.list() // force hydration
+
+    const { db: dbLazy, col: colLazy } = await openLazySession(adapter)
+
+    const ascLazy = (await colLazy.lazyQuery().orderBy('amount', 'asc').toArray()).map((r) => r.id)
+    const ascEager = colEager.query().orderBy('amount', 'asc').toArray().map((r) => r.id)
+    const descLazy = (await colLazy.lazyQuery().orderBy('amount', 'desc').toArray()).map((r) => r.id)
+    const descEager = colEager.query().orderBy('amount', 'desc').toArray().map((r) => r.id)
+
+    dbLazy.close()
+    dbEager.close()
+
+    expect(ascLazy).toEqual(ascEager)
+    expect(descLazy).toEqual(descEager)
+  })
+})

--- a/packages/hub/__tests__/via/money-index-canonical.test.ts
+++ b/packages/hub/__tests__/via/money-index-canonical.test.ts
@@ -322,4 +322,69 @@ describe('money index-key canonicalization (#672)', () => {
       dbScan.close()
     })
   })
+
+  // #686 — money() late-attached via a SECOND vault.collection() call, after
+  // an earlier vault.collection(name, { indexes: [...] }) call (no
+  // moneyFields) already triggered eager-index hydration. Rows indexed
+  // before the money declaration sat in raw-form buckets (`stringifyKey`
+  // output) forever — canonical ==/in probes never read raw buckets, so
+  // those legacy rows were silently under-returned until the next full
+  // rebuild. Unlike the #672 suite above (which declares moneyFields +
+  // indexes in ONE call), this exercises the two-call late-attach path.
+  describe('money() late-attach onto an already-hydrated eager index (#686)', () => {
+    it('a row indexed before the late-attached money() declaration is found by a canonical == probe without an explicit rebuildIndexes()', async () => {
+      const adapter = persistentMemory()
+      const db = await createNoydb({ store: adapter, user: USER, secret: PASS, indexStrategy: withIndexing() })
+      const vault = await db.openVault(VAULT)
+
+      // First call: indexes only, no moneyFields — triggers eager hydration
+      // with 'pre' bucketed under its RAW stringified value ('0100').
+      const colIndexedOnly = vault.collection<Item>(COLL, { schema: itemSchema, indexes: ['amount'] })
+      await colIndexedOnly.put('pre', { id: 'pre', amount: '0100' })
+      await colIndexedOnly.list() // force hydration + eager build of the raw '0100' bucket
+
+      // Second call, same collection: money() late-attach.
+      const col = vault.collection<Item>(COLL, {
+        schema: itemSchema,
+        moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+      })
+
+      const spy = vi.spyOn(CollectionIndexes.prototype, 'lookupEqual')
+      try {
+        // WITHOUT calling rebuildIndexes() — canonical probe key '100'.
+        const hit = col.query().where('amount', '==', 1).toArray()
+        expect(hit.map((r) => r.id)).toEqual(['pre'])
+        expect(spy).toHaveBeenCalledWith('amount', '100')
+      } finally {
+        spy.mockRestore()
+      }
+      db.close()
+    })
+
+    it('rebuildIndexes() also fixes the same strand (the pre-existing manual escape hatch keeps working)', async () => {
+      const adapter = persistentMemory()
+      const db = await createNoydb({ store: adapter, user: USER, secret: PASS, indexStrategy: withIndexing() })
+      const vault = await db.openVault(VAULT)
+
+      const colIndexedOnly = vault.collection<Item>(COLL, { schema: itemSchema, indexes: ['amount'] })
+      await colIndexedOnly.put('pre', { id: 'pre', amount: '0100' })
+      await colIndexedOnly.list()
+
+      const col = vault.collection<Item>(COLL, {
+        schema: itemSchema,
+        moneyFields: { amount: money({ currency: 'EUR', scale: 2 }) },
+      })
+      await col.rebuildIndexes()
+
+      const spy = vi.spyOn(CollectionIndexes.prototype, 'lookupEqual')
+      try {
+        const hit = col.query().where('amount', '==', 1).toArray()
+        expect(hit.map((r) => r.id)).toEqual(['pre'])
+        expect(spy).toHaveBeenCalledWith('amount', '100')
+      } finally {
+        spy.mockRestore()
+      }
+      db.close()
+    })
+  })
 })

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -1293,6 +1293,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     const virtualMoney = resolveVirtualMoneyFields(Object.keys(moneyFields), (f) => this.via?.bindings.find((b) => b.brand === 'computed')?.covers?.(f) ?? false) // #669
     this.via = ViaPipeline.build([viaBinder('money')({ moneyFields, ...(virtualMoney.size > 0 ? { virtualMoneyFields: virtualMoney } : {}) }), ...(this.via?.bindings ?? [])], this.via?.taint) // #671 item 4 — thread taint through the rebuild
     this.moneyFields = moneyFields
+    if (this.hydrated) this.rebuildEagerIndexesFromCache() // #686: re-canonicalize buckets built before this money late-attach
   }
 
   /** @internal — attach computed fields post-construction. See {@link _applyMoneyFields}. */

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -1395,6 +1395,25 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    *          `null` if not found.
    */
   async get(id: string, locale?: LocaleReadOptions): Promise<SealedView<T, S> | null> {
+    const record = await this.#getRaw(id)
+    if (record === null) return null
+    // The cache/decrypt path already substituted Sealed handles for declared
+    // sensitive fields (S); the cast reflects that runtime shape. For
+    // collections with no sensitive fields S = never and SealedView<T, never>
+    // collapses to T, so this is a no-op widening.
+    return this.applyLocaleToRecord(record, locale) as unknown as SealedView<T, S>
+  }
+
+  /**
+   * Raw fetch: cache/adapter → decrypt → tombstone-null, WITHOUT `present()`.
+   * Split out of `get()` (#684) so `lazyQuery()`'s `LazyQuerySource` can hand
+   * `LazyQuery`'s post-filter the RAW (stored-form) record a `clause.via`
+   * evaluator (e.g. money) needs — `present()`/locale decode is applied only
+   * to survivors, via `applyLocaleToRecord` (see `lazyQuery()` below). `get()`
+   * itself is unchanged: raw fetch, then `applyLocaleToRecord`, same order
+   * as before this split.
+   */
+  async #getRaw(id: string): Promise<T | null> {
     // --- Lazy derivation resolution ---
     // If this collection is the output of a lazy-mode derivation
     // strategy, consult the stale map and re-derive on demand before
@@ -1443,11 +1462,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
 
     if (record === null) return null
     await this.onAccess?.('get', id)
-    // The cache/decrypt path already substituted Sealed handles for declared
-    // sensitive fields (S); the cast reflects that runtime shape. For
-    // collections with no sensitive fields S = never and SealedView<T, never>
-    // collapses to T, so this is a no-op widening.
-    return this.applyLocaleToRecord(record, locale) as unknown as SealedView<T, S>
+    return record
   }
 
   /**
@@ -4346,7 +4361,11 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       persistedIndexes: persisted,
       canonicalizeIndexKey: (f: string, v: unknown) => this.via?.canonicalizeIndexKey(f, v),
       ensurePersistedIndexesLoaded: () => this.ensurePersistedIndexesLoaded(),
-      getRecord: (id: string) => this.get(id) as unknown as Promise<T | null>,
+      // #684: raw-fetch seam — post-filter runs against the RAW record;
+      // only survivors are decoded via `decodeRecord` below.
+      getRawRecord: (id: string) => this.#getRaw(id),
+      decodeRecord: (record: unknown) => this.applyLocaleToRecord(record as T, undefined),
+      via: () => this.via,
     }
     return new LazyQuery<T, S, Q>(source)
   }

--- a/packages/hub/src/kernel/query/builder.ts
+++ b/packages/hub/src/kernel/query/builder.ts
@@ -1143,9 +1143,9 @@ function candidateRecords(source: InternalSource, clauses: readonly Clause[]): C
     // path (`lazy-builder.ts`'s `resolveCandidateIds()`) canonicalizes the
     // `==`/`in` lookup value before calling `lookupEqual`/`lookupIn` — see
     // `moneyIndexProbe`'s doc comment (via-money/where.ts) for the full
-    // story, including the boundary that remains (lazy mode's post-filter
-    // is not Via-aware, so end-to-end `lazyQuery().where()` money parity
-    // with this eager path is tracked in #684).
+    // story — lazy mode's post-filter is now Via-aware too (#684), so
+    // end-to-end `lazyQuery().where()` money parity with this eager path
+    // holds at every scale (`orderBy` ordering parity remains open, #695).
     if (clause.via && clause.via.indexValue === undefined) continue
     const probeValue = clause.via ? clause.via.indexValue : clause.value
 

--- a/packages/hub/src/via/money/where.ts
+++ b/packages/hub/src/via/money/where.ts
@@ -182,20 +182,22 @@ export function moneyFieldClause(
  * lazy-mode mixed-era record's bucket and a canonicalized probe now agree,
  * the same as eager mode.
  *
- * Residual boundary, NOT fixed by #677 — tracked in #684: `LazyQuery`'s
- * post-filter (`lazy-builder.ts`'s `matchesAll`) re-evaluates every clause
- * — including the index-driving one — against the DECODED record
- * (`getRecord()` runs `via.present()`), using the generic (non-Via-aware)
- * `evaluateClause`, because `LazyQuery.where()` never builds a `clause.via`
- * the way `Query.where()`/`ScanBuilder.where()` do. At `scale: 0` this
- * doesn't surface (decode is identity). At `scale > 0` it does — even a
- * query value spelled in the field's STORED (canonical scaled-int) form
- * reaches the right candidate ids via the index, but the post-filter then
- * rejects every one of them (raw vs decoded mismatch). Practical result:
- * `lazyQuery().where()` on a money field with `scale > 0` returns an EMPTY
- * `.toArray()` end-to-end, no matter how the query value is spelled. Only
- * the index layer (this file + #677) is fixed; full parity with
- * `scan().where()` is tracked in #684.
+ * Residual boundary CLOSED by #684: `LazyQuery.where()` now builds
+ * `clause.via` exactly like `Query.where()`/`ScanBuilder.where()` do, and
+ * `LazyQuery`'s post-filter (`lazy-builder.ts`'s `toArray()`) runs it
+ * against the RAW record (a dedicated raw-fetch seam on `Collection`, split
+ * out of `get()`) instead of the DECODED one — `clause.via.evaluate` (this
+ * file's {@link evaluateMoneyClause}) now sees the same stored-form
+ * operand/actual-value space eager's `filterRecords` does, at any `scale`.
+ * Only survivors are decoded (`present()`) on the way out. Money RANGE
+ * clauses additionally route around `PersistedCollectionIndex.lookupRange`
+ * (raw/typed, wrong space for scaled-int money) — `resolveCandidateIds()`
+ * enumerates the field's indexed ids instead and lets this now-via-aware
+ * post-filter apply the correct BigInt-exact comparison. `lazyQuery().
+ * where()` on a money field now agrees with `scan().where()` /
+ * `query().where()` at every `scale` — for `.where()` results specifically.
+ * `orderBy` ordering is a separate, still-open lazy-vs-eager divergence,
+ * tracked in #695.
  */
 // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 export function moneyIndexProbe(op: Operator, payload: MoneyWhereOperand): unknown | undefined {

--- a/packages/hub/src/with-lookup/indexing/active.ts
+++ b/packages/hub/src/with-lookup/indexing/active.ts
@@ -59,10 +59,15 @@ function declareAll(persisted: PersistedCollectionIndex, defs: readonly IndexDef
   for (const def of defs) {
     if (typeof def === 'string') {
       persisted.declare(def)
-    } else if (Array.isArray(def)) {
-      persisted.declareComposite(def as readonly string[])
     } else {
-      persisted.declareComposite((def as { fields: readonly string[] }).fields)
+      const fields = Array.isArray(def) ? (def as readonly string[]) : (def as { fields: readonly string[] }).fields
+      // #698: decompose a composite into its component single-field indexes
+      // (like the eager branch above), so a composite-only declaration still
+      // provides the single-field driver the #696 Via-covered fall-through
+      // and single-field queries need. The composite mirror is kept for the
+      // multi-field fast path.
+      for (const f of fields) persisted.declare(f)
+      persisted.declareComposite(fields)
     }
   }
 }

--- a/packages/hub/src/with-lookup/indexing/lazy-builder.ts
+++ b/packages/hub/src/with-lookup/indexing/lazy-builder.ts
@@ -185,26 +185,34 @@ export class LazyQuery<T, S extends keyof T = never, Q extends keyof T & string 
     // #684: post-filter the RAW record (mirrors eager's filterRecords on the
     // raw snapshot) so `clause.via.evaluate` sees the same stored-form
     // operand/actual-value space `buildClause` quantized into at where()
-    // time. Only survivors get decoded (`present()`) on the way out — same
-    // "filter raw, decode last" order as `Query.toArray()`'s `decodeVia`.
-    const records: T[] = []
+    // time. Survivors stay RAW here — #695 sorts them via-aware in that
+    // same stored-form space (mirroring eager's `sortRecords(result, ...,
+    // source.via, ...)` in `kernel/query/builder.ts`) before anything is
+    // decoded (`present()`).
+    const survivors: T[] = []
     for (const id of candidateIds) {
       const raw = await this.source.getRawRecord(id)
       if (raw === null) continue
       if (!matchesAll(raw, this.plan.clauses)) continue
-      records.push(await this.source.decodeRecord(raw))
+      survivors.push(raw as T)
     }
 
+    // #695: sort the RAW survivors via-aware — a money field's stored form
+    // (scaled-integer string) sorts lexicographically wrong under the
+    // generic comparator ('10.00' < '2.00' once decoded); `via.compareForOrder`
+    // compares in the correct (BigInt-exact scaled) space, same as eager.
     const sorted = this.plan.orderBy.length > 0
-      ? sortRecords(records, this.plan.orderBy)
-      : records
+      ? sortRecords(survivors, this.plan.orderBy, this.source.via())
+      : survivors
 
     const offset = this.plan.offset > 0 ? this.plan.offset : 0
-    const limited = this.plan.limit === undefined
+    const page = this.plan.limit === undefined
       ? sorted.slice(offset)
       : sorted.slice(offset, offset + this.plan.limit)
 
-    return limited
+    // Decode only the final page — fewer decodes than the pre-#695 code,
+    // which decoded every survivor before sorting/slicing.
+    return Promise.all(page.map(r => this.source.decodeRecord(r)))
   }
 
   async first(): Promise<T | null> {
@@ -364,12 +372,18 @@ function matchesAll(record: unknown, clauses: readonly Clause[]): boolean {
   return true
 }
 
-function sortRecords<T>(records: T[], orderBy: readonly LazyOrderBy[]): T[] {
+function sortRecords<T>(records: T[], orderBy: readonly LazyOrderBy[], via?: ViaPipeline): T[] {
   return [...records].sort((a, b) => {
     for (const { field, direction } of orderBy) {
       const av = readPath(a, field)
       const bv = readPath(b, field)
-      const cmp = compareValues(av, bv)
+      // #695: a Via-covered field (e.g. money) may store a representation
+      // the generic comparator would order wrong — ask the pipeline for an
+      // exact ordering first, same as eager's `sortRecords` in
+      // `kernel/query/builder.ts`. `undefined` (no via, or the field isn't
+      // covered) falls back to the generic comparator, unchanged from today.
+      const viaCmp = via?.compareForOrder(field, av, bv)
+      const cmp = viaCmp !== undefined ? viaCmp : compareValues(av, bv)
       if (cmp !== 0) return direction === 'asc' ? cmp : -cmp
     }
     return 0

--- a/packages/hub/src/with-lookup/indexing/lazy-builder.ts
+++ b/packages/hub/src/with-lookup/indexing/lazy-builder.ts
@@ -239,12 +239,25 @@ export class LazyQuery<T, S extends keyof T = never, Q extends keyof T & string 
     // composite mirror lookup is O(matches) vs single-field +
     // post-filter on the decrypted candidate set.
     const eqMap = new Map<string, unknown>()
+    const viaFields = new Set<string>()
     for (const clause of this.plan.clauses) {
-      if (clause.op === '==') eqMap.set(clause.field, clause.value)
+      if (clause.op === '==') {
+        eqMap.set(clause.field, clause.value)
+        // #696: the composite mirror buckets on `stringifyKey(tuple)` built
+        // from the RAW clause values — the per-field money canonicalizer
+        // (`canonicalizeIndexKey`) only ever keys off a single field name,
+        // never the joined composite key, so a Via-covered field's tuple
+        // slot never lands in the same bucket a canonical write produced.
+        // Track which `==` fields are Via-covered so the composite branch
+        // below can skip them and fall through to the single-field
+        // Via-aware path (already correct for money) instead.
+        if (clause.via) viaFields.add(clause.field)
+      }
     }
     if (eqMap.size >= 2) {
       for (const def of idx.definitions()) {
         if (def.kind !== 'composite') continue
+        if (def.fields.some(f => viaFields.has(f))) continue
         if (def.fields.every(f => eqMap.has(f))) {
           const tuple = def.fields.map(f => eqMap.get(f))
           const ids = idx.lookupEqual(def.key, tuple)

--- a/packages/hub/src/with-lookup/indexing/lazy-builder.ts
+++ b/packages/hub/src/with-lookup/indexing/lazy-builder.ts
@@ -255,7 +255,7 @@ export class LazyQuery<T, S extends keyof T = never, Q extends keyof T & string 
           // sound equality bucket exists. Eager's `candidateRecords()`
           // handles this by skipping the index-eligibility check for the
           // clause and falling back to a full scan (`builder.ts:1176`); the
-          // lazy equivalent (#695 FIX 2) is the same move the RANGE branch
+          // lazy equivalent (#684 review-fix 2) is the same move the RANGE branch
           // below already makes — enumerate the field's full indexed id
           // set via `orderedBy` and let the (now via-aware) post-filter in
           // `toArray()` decide, instead of throwing `IndexRequiredError`.
@@ -278,7 +278,7 @@ export class LazyQuery<T, S extends keyof T = never, Q extends keyof T & string 
         if (ids) return [...ids]
       } else if (clause.op === 'in' && Array.isArray(clause.value)) {
         if (clause.via) {
-          // Same #695 FIX 2 fallback as the `==` branch above — a via
+          // Same #684 review-fix 2 fallback as the `==` branch above — a via
           // payload that declines to probe (e.g. money multi-mode) still
           // has a sound candidate superset via `orderedBy`.
           if (clause.via.indexValue === undefined) {

--- a/packages/hub/src/with-lookup/indexing/lazy-builder.ts
+++ b/packages/hub/src/with-lookup/indexing/lazy-builder.ts
@@ -26,8 +26,9 @@
 import type { Clause, FieldClause, Operator } from '../../kernel/query/predicate.js'
 import { evaluateClause, readPath } from '../../kernel/query/predicate.js'
 import type { PersistedCollectionIndex } from './persisted-indexes.js'
-import { IndexRequiredError } from '../../kernel/errors.js'
+import { IndexRequiredError, FieldNotQueryableError } from '../../kernel/errors.js'
 import type { QueryField } from '../../kernel/types.js'
+import type { ViaPipeline } from '../../kernel/via/pipeline.js'
 
 export interface LazyOrderBy {
   readonly field: string
@@ -55,8 +56,28 @@ export interface LazyQuerySource<T> {
   canonicalizeIndexKey?(field: string, value: unknown): string | undefined
   /** Ensure `_idx/<field>/*` side-cars have been bulk-loaded into the mirror. */
   ensurePersistedIndexesLoaded(): Promise<void>
-  /** Decrypt one record by id, or return null if it's gone. */
-  getRecord(id: string): Promise<T | null>
+  /**
+   * Decrypt one record by id in RAW (pre-`present()`, stored-form) shape,
+   * or return null if it's gone (#684 — the raw-fetch seam). Used by the
+   * post-filter (`toArray()`) so a `clause.via.evaluate` (e.g. money) sees
+   * the same operand/actual-value space as eager's `filterRecords` — the
+   * DECODED form (e.g. money's canonical decimal) is only materialized
+   * for survivors, via {@link decodeRecord}.
+   */
+  getRawRecord(id: string): Promise<unknown>
+  /**
+   * Apply this collection's locale/virtual-field decode (`present()`) to a
+   * RAW record already known to match — the output-side twin of
+   * {@link getRawRecord}. Mirrors eager's `Query.decodeVia`.
+   */
+  decodeRecord(record: unknown): Promise<T>
+  /**
+   * This collection's compiled Via pipeline (money, i18n, …), read lazily
+   * (a method, not a captured value) so a late `_setVia` (#666) is honored
+   * — same closure discipline as {@link canonicalizeIndexKey}. `undefined`
+   * when the collection has no Via-covered fields.
+   */
+  via(): ViaPipeline | undefined
 }
 
 interface LazyPlan {
@@ -83,7 +104,36 @@ export class LazyQuery<T, S extends keyof T = never, Q extends keyof T & string 
   }
 
   where<V>(field: QueryField<T, S, Q>, op: Operator, value: V): LazyQuery<T, S, Q> {
-    const clause: FieldClause = { type: 'field', field, op, value }
+    // A Via-covered field (e.g. money) compares in major units, BigInt-exact
+    // in scaled space — same build-time operand rewrite + `clause.via`
+    // attachment as `Query.where()` (`kernel/query/builder.ts`) and
+    // `ScanBuilder.where()` (`kernel/query/scan-builder.ts`). Before #684
+    // this method built a bare clause with no `clause.via` at all, so the
+    // post-filter fell through to the generic (non-Via-aware) comparison —
+    // see `toArray()` below for the raw-record post-filter this feeds.
+    const via = this.source.via()
+    // Consults the Via pipeline's posture BEFORE building a clause — same
+    // gate as `Query.where()` (builder.ts) / `ScanBuilder.where()`
+    // (scan-builder.ts): a field whose posture is `queryable: 'none'`
+    // (e.g. a `blobFields` slot) throws `FieldNotQueryableError` here, at
+    // the call site, instead of building a bare clause that later surfaces
+    // as a deferred `IndexRequiredError` from `toArray()`.
+    if (via?.postureFor(field)?.queryable === 'none') throw new FieldNotQueryableError(field)
+    const viaClause = via?.buildClause(field, op, value)
+    const clause: FieldClause = viaClause
+      ? {
+          type: 'field',
+          field,
+          op,
+          value,
+          via: {
+            brand: viaClause.brand,
+            payload: viaClause.payload,
+            evaluate: (actual: unknown, evalOp: string) => via!.evaluateClause(viaClause, actual, evalOp),
+            indexValue: via!.indexProbe(viaClause, op),
+          },
+        }
+      : { type: 'field', field, op, value }
     return new LazyQuery<T, S, Q>(this.source, {
       ...this.plan,
       clauses: [...this.plan.clauses, clause],
@@ -132,12 +182,17 @@ export class LazyQuery<T, S extends keyof T = never, Q extends keyof T & string 
       })
     }
 
+    // #684: post-filter the RAW record (mirrors eager's filterRecords on the
+    // raw snapshot) so `clause.via.evaluate` sees the same stored-form
+    // operand/actual-value space `buildClause` quantized into at where()
+    // time. Only survivors get decoded (`present()`) on the way out — same
+    // "filter raw, decode last" order as `Query.toArray()`'s `decodeVia`.
     const records: T[] = []
     for (const id of candidateIds) {
-      const record = await this.source.getRecord(id)
-      if (record === null) continue
-      if (!matchesAll(record, this.plan.clauses)) continue
-      records.push(record)
+      const raw = await this.source.getRawRecord(id)
+      if (raw === null) continue
+      if (!matchesAll(raw, this.plan.clauses)) continue
+      records.push(await this.source.decodeRecord(raw))
     }
 
     const sorted = this.plan.orderBy.length > 0
@@ -192,29 +247,73 @@ export class LazyQuery<T, S extends keyof T = never, Q extends keyof T & string 
 
     for (const clause of this.plan.clauses) {
       if (clause.op === '==') {
+        if (clause.via) {
+          // #684: prefer `clause.via.indexValue` — the same STORED-form
+          // probe operand eager's `candidateRecords()` resolves first
+          // (`kernel/query/builder.ts`). `undefined` means the binding
+          // declined to probe this op/payload (e.g. money multi-mode) — no
+          // sound equality bucket exists. Eager's `candidateRecords()`
+          // handles this by skipping the index-eligibility check for the
+          // clause and falling back to a full scan (`builder.ts:1176`); the
+          // lazy equivalent (#695 FIX 2) is the same move the RANGE branch
+          // below already makes — enumerate the field's full indexed id
+          // set via `orderedBy` and let the (now via-aware) post-filter in
+          // `toArray()` decide, instead of throwing `IndexRequiredError`.
+          if (clause.via.indexValue === undefined) {
+            const entries = idx.orderedBy(clause.field, 'asc')
+            if (entries) return entries.map(e => e.recordId)
+            continue
+          }
+          const ids = idx.lookupEqual(clause.field, clause.via.indexValue)
+          if (ids) return [...ids]
+          continue
+        }
         // #677: canonicalize the probe value BEFORE the lookup — same
-        // "resolve before lookupEqual" shape as eager's `candidateRecords()`
-        // (which resolves `clause.via.indexValue` first), but through the
-        // narrower `canonicalizeIndexKey` seam: lazy mode never quantizes
-        // major units, so the caller must already pass the field's STORED
-        // form. `undefined` (no via coverage) falls back to the raw clause
-        // value, unchanged from today.
+        // "resolve before lookupEqual" shape as eager's `candidateRecords()`,
+        // but through the narrower `canonicalizeIndexKey` seam, used only on
+        // this NON-via path. `undefined` (no via coverage) falls back to the
+        // raw clause value, unchanged from today.
         const probe = this.source.canonicalizeIndexKey?.(clause.field, clause.value) ?? clause.value
         const ids = idx.lookupEqual(clause.field, probe)
         if (ids) return [...ids]
       } else if (clause.op === 'in' && Array.isArray(clause.value)) {
+        if (clause.via) {
+          // Same #695 FIX 2 fallback as the `==` branch above — a via
+          // payload that declines to probe (e.g. money multi-mode) still
+          // has a sound candidate superset via `orderedBy`.
+          if (clause.via.indexValue === undefined) {
+            const entries = idx.orderedBy(clause.field, 'asc')
+            if (entries) return entries.map(e => e.recordId)
+            continue
+          }
+          if (!Array.isArray(clause.via.indexValue)) continue
+          const ids = idx.lookupIn(clause.field, clause.via.indexValue)
+          if (ids) return [...ids]
+          continue
+        }
         const probes = clause.value.map(v => this.source.canonicalizeIndexKey?.(clause.field, v) ?? v)
         const ids = idx.lookupIn(clause.field, probes)
         if (ids) return [...ids]
       } else if (isRangeOp(clause.op)) {
-        // range predicates on an indexed field dispatch unconditionally
-        // through `lookupRange`, which compares on the original typed
-        // value (no numeric-lexicographic landmines). NOT canonicalized
-        // (#677) — unlike eager mode, where `moneyIndexProbe` never emits
-        // a range probe so a money range clause always scans, THIS path
-        // has no scan fallback: a money field's raw/uncanonicalized typed
-        // comparison here is a live, pre-existing correctness gap, tracked
-        // in #684.
+        if (clause.via) {
+          // #684: a Via-covered range clause (e.g. money) cannot trust
+          // `lookupRange` — it compares the ORIGINAL TYPED stored value,
+          // wrong space for a binding whose stored form isn't directly
+          // orderable that way (money: BigInt-exact scaled-int compare).
+          // No binding emits a range `indexProbe` either (see
+          // `moneyIndexProbe`), so there's no sound bucket lookup at all.
+          // Enumerate the field's full indexed id set via `orderedBy` — the
+          // same superset a scan would consider, just scoped to indexed ids
+          // — and let the (now via-aware) post-filter in `toArray()` apply
+          // the correct scaled-space comparison. Replaces the old
+          // "always trust lookupRange, no scan fallback" gap.
+          const entries = idx.orderedBy(clause.field, 'asc')
+          if (entries) return entries.map(e => e.recordId)
+          continue
+        }
+        // range predicates on a NON-via indexed field dispatch through
+        // `lookupRange`, which compares on the original typed value (no
+        // numeric-lexicographic landmines).
         const ids = idx.lookupRange(clause.field, clause.op, clause.value)
         if (ids) return [...ids]
       }

--- a/packages/hub/src/with-lookup/indexing/persisted-indexes.ts
+++ b/packages/hub/src/with-lookup/indexing/persisted-indexes.ts
@@ -332,13 +332,16 @@ export class PersistedCollectionIndex {
    * even type-check as a bound here. This does NOT mirror eager mode the
    * way `lookupEqual`/`lookupIn` do: `moneyIndexProbe` (`via/money/
    * where.ts`) never emits a range probe, so EAGER mode's `candidateRecords`
-   * never calls an index for a range clause and always scans. LAZY mode's
-   * `resolveCandidateIds()` (`lazy-builder.ts`) dispatches every range
-   * clause through THIS method unconditionally, including money fields —
-   * there is no scan fallback here. Because the comparison is raw/typed
-   * and not canonicalized, a money field's lazy range correctness (e.g.
-   * mixed-era or non-canonical stored values) is a live, pre-existing gap,
-   * tracked in #684 — not yet fixed.
+   * never calls an index for a range clause and always scans.
+   *
+   * LAZY mode's `resolveCandidateIds()` (`lazy-builder.ts`) no longer
+   * dispatches a Via-covered (e.g. money) range clause through THIS method
+   * at all (#684) — it enumerates the field's indexed ids via `orderedBy()`
+   * instead and leaves the raw/typed comparison here for the (now
+   * Via-aware) post-filter to redo correctly in scaled-int space. A
+   * NON-via range clause still dispatches through this method exactly as
+   * before — the raw/typed comparison here is correct and sufficient for
+   * fields with no decode-transforming Via binding.
    */
   lookupRange(
     field: string,

--- a/packages/hub/src/with-shape/satellites/fanout.ts
+++ b/packages/hub/src/with-shape/satellites/fanout.ts
@@ -60,6 +60,21 @@ interface Leg extends BestEffortRevertLeg {
    * NOT be dirty-compensated: `_compensateRevertedWrite` → `removeDirty`
    * keys only on (collection, id) and would otherwise drop a pre-existing,
    * unrelated dirty entry for the same id.
+   *
+   * KNOWN LIMITATION (#687), accepted: the reverse hazard is inherent. A leg
+   * whose `put`/`delete` COMMITS its dirty entry (via `onDirty`) but then
+   * THROWS in the post-`onDirty` dispatch phase — a strict-mode `withFormula`
+   * derivation / materialized-view recompute run inside `_putInternal`/
+   * `_doDelete` with no try/catch — leaves `wrote: false`, so
+   * `revertAndCompensate` skips compensation and this leg's OWN just-created
+   * dirty entry is orphaned (the raw envelope still reverts correctly).
+   * Reachable only with satellites + a strict formula/MV on the same
+   * collection whose recompute throws mid-fan-out; the sole harm is one
+   * self-healing sync-push cycle (a redundant no-op push or ordinary conflict
+   * resolution — no data loss; the entry is spliced out every cycle). A
+   * precise fix would diff the dirty log before/after each leg regardless of
+   * whether the write threw (needs `FanoutDeps` plumbing) — deferred as
+   * disproportionate to the harm.
    */
   wrote: boolean
 }

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -750,7 +750,15 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 4529→4530 (2026-07-15, #686: money() late-attach re-canonicalization):
   // one line in `_applyMoneyFields` — `if (this.hydrated) this.rebuildEagerIndexesFromCache()`
   // — reusing the existing hydrate-time rebuild helper, zero new state.
-  'packages/hub/src/kernel/collection.ts': 4530,
+  // Bumped 4530→4549 (2026-07-15, #684: lazy raw-fetch seam for via-aware
+  // post-filter): `get()` split into a terse public delegate + a new private
+  // `#getRaw()` (byte-identical body, minus the final `applyLocaleToRecord`
+  // call) so `lazyQuery()`'s `LazyQuerySource` can hand `LazyQuery`'s
+  // post-filter the RAW (stored-form) record a `clause.via` evaluator (e.g.
+  // money) needs — plus doc comments on both and the widened
+  // `LazyQuerySource` literal (`getRawRecord`/`decodeRecord`/`via` replacing
+  // `getRecord`).
+  'packages/hub/src/kernel/collection.ts': 4549,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.

--- a/scripts/check-architecture.mjs
+++ b/scripts/check-architecture.mjs
@@ -747,7 +747,10 @@ const KERNEL_SURFACE_BUDGET = {
   // Bumped 4521→4529 (2026-07-15, #693: tab-coordination fallback for the marker-set gate):
   // `tabCoordinated` private field + constructor assignment + the gate's fallback
   // condition/comment at the #589/#606 re-create check.
-  'packages/hub/src/kernel/collection.ts': 4529,
+  // Bumped 4529→4530 (2026-07-15, #686: money() late-attach re-canonicalization):
+  // one line in `_applyMoneyFields` — `if (this.hydrated) this.rebuildEagerIndexesFromCache()`
+  // — reusing the existing hydrate-time rebuild helper, zero new state.
+  'packages/hub/src/kernel/collection.ts': 4530,
   // Bumped 3640→3700 (2026-06-08): deferred-numbering wiring — `sequence()`
   // routing + `runNumberingPass` + the cache-coherent `stamp` closure. The
   // engine itself lives in src/numbering/; only the thin vault call-sites are here.


### PR DESCRIPTION
Six via-port lazy/index follow-ups completing lazy-money parity with eager, each TDD + reviewed (Fable on the correctness paths) with a whole-branch review. Full suite: **499 files / 4057 tests green**; typecheck, lint, `check:architecture` clean.

## #684 — lazy queries are Via-aware end-to-end (correctness bug)
`LazyQuery.where()` built a bare clause and post-filtered the DECODED record, so money (and any decode-transforming via) lazy queries returned **empty at `scale > 0`**. Fix (raw-fetch seam): `Collection.get()` split into `#getRaw` + `present()`, `where()` builds `clause.via`, the post-filter runs on the RAW record (mirroring eager: filter stored-form → decode survivors), money range enumerates the field index + Via-aware post-filter, `==`/`in` prefer `clause.via.indexValue`, `queryable:'none'` guard + multi-currency match eager. *(collection.ts ceiling 4530→4549.)*

## #695 — lazy `orderBy` is Via-aware
Money ordered lexicographically (`'10.00' < '2.00'`). Now sorts the RAW survivors via `ViaPipeline.compareForOrder` (scaled BigInt, mirroring eager) and decodes only the returned page, with an eager-parity assertion on ORDER.

## #696 — lazy composite `==` skips the fast path for Via-covered fields
The composite mirror buckets aren't canonicalized, so a money-containing composite missed (`[]`). Now the composite fast path is skipped when a covered `==` clause is Via-covered, falling through to the Via-aware single-field path.

## #698 — lazy decomposes composites into component single-field indexes
A composite-ONLY declaration threw `IndexRequiredError` (lazy declared only the composite; the #696 fall-through and single-field queries had no driver). Now lazy decomposes a composite into its component singles on declare — matching eager — so composite-only declarations resolve correctly. (Adds per-component side-cars, the same tradeoff eager makes.)

## #686 — money late-attach re-canonicalizes the eager index
Late-attaching `money()` onto an already-built eager index left pre-attach rows in raw buckets (silent under-return). A ~2-line fix reuses `rebuildEagerIndexesFromCache` on attach. *(collection.ts ceiling 4529→4530.)*

## #687 — satellites fan-out revert orphan (documented, per decision)
The narrow post-`onDirty`-dispatch-throw hazard (harm: one self-healing sync-push cycle) is documented on `Leg.wrote`, with the pair-delete revert test hardened by a direct `dirtyLog.entriesFor` assertion.

## Review notes
- Fable found + all-fixed: 4 findings on #684, a composite-only edge on #696 (fixed as #698 here), and confirmed the #698 test change is faithful (the old test pinned the bug — its own comment conceded it was "an artifact, not intent"). The whole-branch review reconciled 5 stale doc/comment spots that still described #684's bug as live.
- Changesets are gitignored/local — this arc's entry + a backfilled changeset for the already-merged #29 sync-engine PR are in the local `.changeset/`.
- noydb.ts/vault.ts/collection.ts are at their (bumped) ceilings with zero slack — next toucher shrink-first.

Closes #684
Closes #695
Closes #696
Closes #698
Closes #686
Closes #687