### PR TITLE
fix(hub): tier-0 read paths treat elevated records as missing — verify/det/findByDigest gates + tier-move cache coherence (#691)

### DIFF
--- a/docs/superpowers/plans/2026-07-15-tier-unaware-reads.md
+++ b/docs/superpowers/plans/2026-07-15-tier-unaware-reads.md
@@ -1,0 +1,405 @@
+# #691 Tier-Unaware Read Paths — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Elevated (`_tier > 0`) records become invisible on every tier-0 enclave read path (verify doors, det scans, findByDigest), and `elevate`/`demote` evict the record cache + refuse tombstones — closing #691.
+
+**Architecture:** Explicit `(env._tier ?? 0) > 0` gates placed BEFORE any key resolution (never try/catch — the elevating session's warm `cekCache` would otherwise leak past the tier audit). Elevated ≡ missing: identical pad path in verify (C4 preserved), skip-and-continue in scans. Spec: `docs/superpowers/specs/2026-07-15-tier-unaware-reads-design.md`.
+
+**Tech Stack:** TypeScript ESM, vitest, `crypto.subtle` only. Branch `fix/691-tier-unaware-reads`.
+
+## Global Constraints
+
+- NEVER add Claude/Anthropic attribution to commits, PRs, or changelogs.
+- NEVER reference the private pilot client by name — grep your diff before each commit.
+- Ceilings (exact zero slack; checker metric = `split('\n').length` = `wc -l` + 1): `collection.ts` 4549, `vault.ts` 3959, `noydb.ts` 2396. Task 3 adds ONE line to collection.ts → must remove one line elsewhere in the same file first (shrink-first). Do NOT edit the ceiling values in `scripts/check-architecture.mjs`. vault.ts/noydb.ts untouched.
+- TDD: write the failing test, run it RED, implement, run GREEN, commit. Classified verify tests are PBKDF2-heavy — give those `it`s a `60_000` timeout (existing convention) and keep assertion-dense tests over many small ones.
+- Run single files from `packages/hub/`: `pnpm vitest run <path>`.
+- No new npm deps. No timing assertions (pad discipline is enforced by construction — identical branch as missing).
+
+---
+
+### Task 1: verify.ts tier gates (digest / text / group doors + findByDigest)
+
+**Files:**
+- Modify: `packages/hub/src/kernel/enclave/classify/verify.ts`
+- Create: `packages/hub/__tests__/tier0-read-paths.test.ts`
+
+**Interfaces:**
+- Consumes: `EncryptedEnvelope._tier?: number` (kernel/types.ts), existing `padFalse()`.
+- Produces: `__tests__/tier0-read-paths.test.ts` with an exported-by-convention fixture pattern Task 2 will extend (Task 2 appends to the same file).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/hub/__tests__/tier0-read-paths.test.ts`. Copy the `memoryStore()` fixture **verbatim** from `__tests__/hierarchical-tiers.test.ts` (its top ~56 lines: imports + the in-memory `NoydbStore`). Then:
+
+```ts
+/**
+ * #691 — tier-0 enclave read paths vs elevated records. An elevated
+ * (_tier > 0) record is INVISIBLE through every tier-0 door: verify /
+ * verifyGroup pad-false exactly like a missing record, findByDigest drops
+ * the hit, det scans skip it — in BOTH the elevating (warm cekCache)
+ * session and a cold reopened session. Pre-#691 these paths resolved the
+ * record CEK under the collection tier-0 DEK unconditionally: cold
+ * sessions threw (InvalidKeyError/TamperedError, an elevation oracle that
+ * also aborted det scans), and the warm session leaked tier-1 plaintext
+ * through findByDet with no CrossTierAccessEvent.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb } from '../src/index.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
+import { withClassified } from '../src/via/classified/active.js'
+import { classified } from '../src/via/classified/presets.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
+
+// … memoryStore() copied from hierarchical-tiers.test.ts …
+
+interface User extends Record<string, unknown> { name?: string; password?: string; email?: string; a1?: string; a2?: string }
+
+/** One store, reopenable: open() twice = cold second session over the same ciphertext. */
+function tieredClassifiedHarness() {
+  const store = memoryStore()
+  const open = async () => {
+    const db = await createNoydb({
+      store, user: 'owner', secret: 'pw-691-tier-gate',
+      tiersStrategy: withTiers(), classifiedStrategy: withClassified(),
+    })
+    const vault = await db.openVault('v1')
+    const users = vault.collection<User>('users', {
+      perRecordKeys: true,
+      tiers: [0, 1],
+      classifiedFields: {
+        password: classified.password(),
+        email: classified.email(),           // recoverable → _sealed → text door
+        a1: classified.secretAnswer(),
+        a2: classified.secretAnswer(),
+      },
+    })
+    return { vault, users }
+  }
+  return { store, open }
+}
+
+describe('#691 verify doors: elevated ≡ missing', () => {
+  it('verify (digest + text doors) pads false on an elevated record, warm and cold', async () => {
+    const h = tieredClassifiedHarness()
+    const { users } = await h.open()
+    await users.put('u1', { name: 'n', password: 'correct-horse-battery', email: 'u1@example.com', a1: 'Rex', a2: 'Bangkok' })
+    expect(await users.verify('u1', 'password', 'correct-horse-battery')).toMatchObject({ ok: true })
+    expect(await users.verify('u1', 'email', 'u1@example.com')).toMatchObject({ ok: true })
+
+    await users.elevate('u1', 1)
+
+    // Warm (elevating) session: verdict-only — MUST NOT throw, MUST NOT verify.
+    expect(await users.verify('u1', 'password', 'correct-horse-battery')).toEqual({ ok: false }) // digest door
+    expect(await users.verify('u1', 'email', 'u1@example.com')).toEqual({ ok: false })           // text door
+    // Same shape as a genuinely missing id — no elevation oracle.
+    expect(await users.verify('no-such-id', 'password', 'correct-horse-battery')).toEqual({ ok: false })
+
+    // Cold session (fresh cekCache) — identical verdicts, still no throw.
+    const cold = await h.open()
+    expect(await cold.users.verify('u1', 'password', 'correct-horse-battery')).toEqual({ ok: false })
+    expect(await cold.users.verify('u1', 'email', 'u1@example.com')).toEqual({ ok: false })
+  }, 60_000)
+
+  it('verifyGroup pads all members false on an elevated record', async () => {
+    const h = tieredClassifiedHarness()
+    const { users } = await h.open()
+    await users.put('u1', { name: 'n', password: 'pw-grp-secret-1', email: 'g@example.com', a1: 'Rex', a2: 'Bangkok' })
+    expect(await users.verifyGroup('u1', { a1: 'Rex', a2: 'Bangkok' }, { min: 2 })).toEqual({ passed: true })
+    await users.elevate('u1', 1)
+    expect(await users.verifyGroup('u1', { a1: 'Rex', a2: 'Bangkok' }, { min: 2 })).toEqual({ passed: false })
+    const cold = await h.open()
+    expect(await cold.users.verifyGroup('u1', { a1: 'Rex', a2: 'Bangkok' }, { min: 2 })).toEqual({ passed: false })
+  }, 60_000)
+
+  it('findByDigest drops the elevated hit and keeps scanning tier-0 hits', async () => {
+    const h = tieredClassifiedHarness()
+    const { users } = await h.open()
+    await users.put('u0', { name: 'a', password: 'pw-zero-stays-00', email: 'z@example.com', a1: 'x', a2: 'y' })
+    await users.put('u1', { name: 'b', password: 'pw-one-moves-111', email: 'o@example.com', a1: 'x', a2: 'y' })
+    await users.elevate('u1', 1)
+
+    expect(await users.findByDigest('password', 'pw-one-moves-111')).toEqual([])        // elevated hit dropped, no throw
+    expect(await users.findByDigest('password', 'pw-zero-stays-00')).toEqual(['u0'])    // scan NOT aborted
+
+    const cold = await h.open()
+    expect(await cold.users.findByDigest('password', 'pw-one-moves-111')).toEqual([])
+    expect(await cold.users.findByDigest('password', 'pw-zero-stays-00')).toEqual(['u0'])
+  }, 60_000)
+})
+```
+
+If a group-preset declaration is required for `verifyGroup` (the flat `secretAnswer()` pair may need the `_noydbClassifiedGroup` wrapper — see `__tests__/classified/digest-presets.test.ts:45`), adapt the fixture to the group declaration used by the existing `verifyGroup` happy-path test (`__tests__/classified/verify-public-surface.test.ts`) — behavior asserted stays identical.
+
+- [ ] **Step 2: Run to verify RED**
+
+Run: `pnpm vitest run __tests__/tier0-read-paths.test.ts` (from `packages/hub/`)
+Expected: FAIL — post-elevate `verify`/`verifyGroup`/`findByDigest` calls reject (`InvalidKeyError`/`TamperedError`) instead of returning padded verdicts. If any leg unexpectedly passes pre-fix, STOP and report (the bug premise needs re-checking), do not adjust the assert to pass.
+
+- [ ] **Step 3: Implement the gates in verify.ts**
+
+Three edits + one header note in `packages/hub/src/kernel/enclave/classify/verify.ts`:
+
+(a) `verifyDigestField` — replace line 63 (`if (env === null) return padFalse()`):
+```ts
+  // #691: an elevated envelope (_tier > 0) is non-comparable through every
+  // tier-0 door — its key material is tier-DEK-wrapped and must never be
+  // resolved here (the elevating session's warm cekCache would otherwise
+  // leak past the tier audit). Exactly the missing-record pad path, checked
+  // BEFORE the R6 residue probe so tier-0 callers learn nothing.
+  if (env === null || (env._tier ?? 0) > 0) return padFalse()
+```
+
+(b) `verifyTextField` — extend the unseal precondition (line 109):
+```ts
+  if (env !== null && (env._tier ?? 0) === 0 && blob !== undefined) { // #691: elevated ≡ missing
+```
+(`stored` stays `undefined`; the unconditional pad + forced-false tail is untouched — single-code-path C4 preserved.)
+
+(c) `matchGroupFields` — replace `const env = await ctx.getEnvelope(id)` (line 151):
+```ts
+  const fetched = await ctx.getEnvelope(id)
+  // #691: elevated ≡ missing — nulling the view here also skips the R6
+  // residue probe (a tier-0 caller must not learn an elevated record's
+  // storage form) and forces the cek-undefined pad path for every member.
+  const env = fetched === null || (fetched._tier ?? 0) > 0 ? null : fetched
+```
+
+(d) Module header — after the sentence ending "…(no inverted exists-vs-absent oracle)." (line 9), add:
+```ts
+ * Elevated records (_tier > 0, with-audit tier moves) are non-comparable
+ * through every door and pad-false exactly like missing records (#691) —
+ * the tier-aware read surface is getAtTier, never verify.
+```
+
+No change to `findByDigest` in collection.ts — its confirm loop calls `verifyDigestField` (collection.ts ~1211) and inherits gate (a); the `_bidx` scan hit is then silently dropped as `{ok:false}`.
+
+- [ ] **Step 4: Run GREEN + regression**
+
+Run: `pnpm vitest run __tests__/tier0-read-paths.test.ts` → PASS.
+Run: `pnpm vitest run __tests__/classified __tests__/hierarchical-tiers.test.ts __tests__/deterministic.test.ts` → PASS (behavior lock).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/kernel/enclave/classify/verify.ts packages/hub/__tests__/tier0-read-paths.test.ts
+git commit -m "fix(hub): verify doors treat elevated records as missing — padded false, never a key-resolution throw (#691)"
+```
+
+---
+
+### Task 2: deterministic.ts skip gates (findByDet / queryByDet)
+
+**Files:**
+- Modify: `packages/hub/src/kernel/enclave/record-keys/deterministic.ts`
+- Modify: `packages/hub/__tests__/tier0-read-paths.test.ts` (append a describe block; reuse `memoryStore`)
+
+**Interfaces:**
+- Consumes: Task 1's test file + `memoryStore()` fixture.
+- Produces: nothing downstream.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `__tests__/tier0-read-paths.test.ts` (det collection needs tiers but NOT classified):
+
+```ts
+describe('#691 det scans: elevated records are skipped', () => {
+  function tieredDetHarness() {
+    const store = memoryStore()
+    const open = async () => {
+      const db = await createNoydb({ store, user: 'owner', secret: 'pw-691-det', tiersStrategy: withTiers() })
+      const vault = await db.openVault('v1')
+      const accounts = vault.collection<User>('accounts', {
+        tiers: [0, 1],
+        deterministicFields: ['email'],
+      })
+      return { vault, accounts }
+    }
+    return { store, open }
+  }
+
+  it('warm (elevating) session: findByDet must NOT leak the elevated record via the cekCache', async () => {
+    const h = tieredDetHarness()
+    const { accounts } = await h.open()
+    await accounts.put('e1', { name: 'leaky', email: 'x@y.z' })
+    await accounts.elevate('e1', 1) // caches the CEK — pre-#691 findByDet then SUCCEEDS here, audit-free
+    expect(await accounts.findByDet('email', 'x@y.z')).toBeNull()
+  })
+
+  it('cold session: det scans skip the elevated match instead of throwing, and keep tier-0 matches', async () => {
+    const h = tieredDetHarness()
+    const { accounts } = await h.open()
+    await accounts.put('a0', { name: 'a', email: 'shared@y.z' })
+    await accounts.put('b0', { name: 'b', email: 'shared@y.z' })
+    await accounts.put('e1', { name: 'c', email: 'shared@y.z' })
+    await accounts.elevate('e1', 1)
+
+    const cold = await h.open()
+    // Pre-#691: the scan throws on e1's tier-wrapped key material, ABORTING
+    // the whole query and losing a0/b0.
+    const hits = await cold.accounts.queryByDet('email', 'shared@y.z')
+    expect(hits.map(r => r.name).sort()).toEqual(['a', 'b'])
+    // findByDet on a value only the elevated record carries → null, no throw.
+    await cold.accounts.put('solo', { name: 's', email: 'solo@y.z' })
+    await cold.accounts.elevate('solo', 1)
+    expect(await cold.accounts.findByDet('email', 'solo@y.z')).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify RED**
+
+Run: `pnpm vitest run __tests__/tier0-read-paths.test.ts -t 'det scans'`
+Expected: FAIL — warm test returns the record (the leak); cold test rejects with a decrypt error.
+
+- [ ] **Step 3: Implement the skip gates**
+
+In `packages/hub/src/kernel/enclave/record-keys/deterministic.ts`, both scan loops (lines 92 and 112), replace:
+```ts
+    if (!env || !env._det) continue
+```
+with:
+```ts
+    // #691: an elevated record's _det slot is tier-independent (#662 carries
+    // it), so it MATCHES — but its key material is tier-wrapped. Skip it
+    // explicitly: invisible to tier-0 det scans regardless of cekCache state
+    // (a catch-based fix would still leak plaintext, audit-free, in the
+    // session that performed the elevate).
+    if (!env || !env._det || (env._tier ?? 0) > 0) continue
+```
+(Full comment on the `findByDet` occurrence; on the `queryByDet` occurrence use the one-liner `// #691: skip elevated — see findByDet above`.)
+
+Also append one sentence to the module doc header (after "…which is the whole point of a deterministic index."):
+```ts
+ * Elevated records (_tier > 0) are skipped: invisible to tier-0 scans (#691).
+```
+
+- [ ] **Step 4: Run GREEN + regression**
+
+Run: `pnpm vitest run __tests__/tier0-read-paths.test.ts __tests__/deterministic.test.ts` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/kernel/enclave/record-keys/deterministic.ts packages/hub/__tests__/tier0-read-paths.test.ts
+git commit -m "fix(hub): det scans skip elevated records — no scan abort, no warm-cache audit bypass (#691)"
+```
+
+---
+
+### Task 3: tier moves evict the record cache + refuse tombstones
+
+**Files:**
+- Modify: `packages/hub/src/with-audit/tiers/index.ts`
+- Modify: `packages/hub/src/kernel/collection.ts` (ONE net-zero line change — see ceiling constraint)
+- Modify: `packages/hub/__tests__/hierarchical-tiers.test.ts` (append a describe block)
+
+**Interfaces:**
+- Consumes: `TiersContext<T>` (tiers/index.ts:41), `tiersContext()` builder in collection.ts (~4508–4522), `isDeleteMarker`/`isTombstoneShape` from `../../kernel/enclave/index.js` (already the import source for `rewrapBodyToDek`), `buildDeleteMarker` (test only, exported from `src/index.js`? if not, import from `../src/kernel/enclave/index.js`).
+- Produces: `TiersContext.evictCache(id: string): void`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `__tests__/hierarchical-tiers.test.ts`:
+
+```ts
+describe('#691 fold-ins: tier moves × record cache × tombstones', () => {
+  it('elevate evicts the eager record cache — plain get() no longer serves pre-move plaintext', async () => {
+    const { vault } = await freshVault()
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1] })
+    await docs.put('d1', { id: 'd1', title: 'Loose', body: 'lips' })
+    expect((await docs.get('d1'))?.title).toBe('Loose') // cache warm
+    await docs.elevate('d1', 1)
+    // Pre-#691: the eager cache still holds the decoded record, so the plain
+    // tier-0 get() serves an elevated record's plaintext with ZERO key
+    // resolution. Post-fix: evicted → eager get() is cache-authoritative → null.
+    expect(await docs.get('d1')).toBeNull()
+    // The sanctioned surface still reads it fine in the elevating session.
+    expect(((await docs.getAtTier('d1')) as Doc | null)?.title).toBe('Loose')
+  })
+
+  it('demote also evicts', async () => {
+    const { vault } = await freshVault()
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1] })
+    await docs.put('d2', { id: 'd2', title: 'Down', body: 'again' })
+    await docs.elevate('d2', 1)
+    await docs.demote('d2', 0)
+    // After demote-to-0 the record is tier-0 again; the pre-elevate cache
+    // entry must not have survived the two raw envelope rewrites in between.
+    // (Eviction on both moves; a fresh getAtTier round-trips the content.)
+    expect(((await docs.getAtTier('d2')) as Doc | null)?.title).toBe('Down')
+  })
+
+  it('elevate/demote on a delete-marker throw not-found, not TamperedError', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, secret: 'pw', user: 'owner', tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1] })
+    await docs.put('gone', { id: 'gone', title: 'x', body: 'y' })
+    const live = (await store.get('v1', 'docs', 'gone'))!
+    await store.put('v1', 'docs', 'gone', buildDeleteMarker(live._v, 'owner'))
+    await expect(docs.elevate('gone', 1)).rejects.toThrow(/not found/)
+    await expect(docs.demote('gone', 0)).rejects.toThrow(/not found/)
+  })
+})
+```
+
+Check `buildDeleteMarker`'s actual signature in `src/kernel/enclave/record-keys/tombstone.ts` before using it (arity/args may differ — adapt the call, keep the scenario). If `freshVault()` doesn't expose the raw store, use the inline `memoryStore()` pattern as in the third test for all three.
+
+- [ ] **Step 2: Run to verify RED**
+
+Run: `pnpm vitest run __tests__/hierarchical-tiers.test.ts -t '691 fold-ins'`
+Expected: FAIL — test 1: `get('d1')` returns the pre-move record; test 3: rejects with `TamperedError`/`OperationError`, not `/not found/`.
+
+- [ ] **Step 3: Implement in tiers/index.ts**
+
+(a) `TiersContext` (after the `cekCache` member):
+```ts
+  /** Evict the collection's decoded-record cache entry after a tier move rewraps the envelope (#691). */
+  evictCache(id: string): void
+```
+
+(b) In BOTH `elevate` and `demote`, extend the not-found guard (elevate line ~260, demote equivalent):
+```ts
+  if (!envelope || isDeleteMarker(envelope) || isTombstoneShape(envelope)) {
+    throw new Error(`Record "${id}" not found in collection "${ctx.name}"`)
+  }
+```
+(Deleted ≡ missing — same message, no oracle distinguishing them. `demote` keeps its own existing message shape if it differs — match its current not-found text.) Extend the existing `../../kernel/enclave/index.js` import with `isDeleteMarker, isTombstoneShape`.
+
+(c) In BOTH `elevate` and `demote`, immediately after the `ctx.cekCache?.set(id, body.cek, 1)` line (elevate ~279, demote ~341) — or after the `adapter.put` if ordering reads cleaner — add:
+```ts
+  ctx.evictCache(id)
+```
+
+- [ ] **Step 4: Wire evictCache in collection.ts — NET-ZERO lines**
+
+In `tiersContext()` (collection.ts ~4508–4522) add:
+```ts
+      evictCache: (id: string) => { this.cache.delete(id); this.lru?.remove(id) },
+```
+(Mirrors `_writeTombstone`'s eviction minus `cekCache` — the tier move deliberately re-seeds the CEK for `getAtTier`.)
+
+collection.ts is at its exact ceiling (4549). Before adding, remove exactly one line elsewhere in collection.ts: find a two-line statement that joins naturally within the file's style (e.g. a short single-use `const` inlined into its sole use site, or a wrapped argument list that fits one line) near the code you're touching. Verify with `node scripts/check-architecture.mjs` (must pass WITHOUT editing the 4549 value) and `pnpm --filter @noy-db/hub lint`.
+
+- [ ] **Step 5: Run GREEN + regression**
+
+Run: `pnpm vitest run __tests__/hierarchical-tiers.test.ts __tests__/tier0-read-paths.test.ts` → PASS.
+Run: `node scripts/check-architecture.mjs` (repo root) → PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/with-audit/tiers/index.ts packages/hub/src/kernel/collection.ts packages/hub/__tests__/hierarchical-tiers.test.ts
+git commit -m "fix(hub): elevate/demote evict the record cache and refuse tombstones (#691)"
+```
+
+---
+
+### Final: full suite + whole-branch review + changeset
+
+- [ ] `pnpm --filter @noy-db/hub test` (full hub suite) + `pnpm typecheck` + `pnpm lint` + `pnpm check:architecture` — all green.
+- [ ] Whole-branch review (fable — crypto-sensitive: pad discipline, oracle surface, gate placement).
+- [ ] Author local changeset (`.changeset/` is gitignored — local file, ships next release): `@noy-db/hub` **patch** — "verify/det/findByDigest treat elevated records as missing (padded false / skipped) instead of throwing on tier-wrapped key material; elevate/demote evict the record cache and refuse tombstoned ids (#691)".
+- [ ] PR `fix/691-tier-unaware-reads` → main with `Closes #691`.

--- a/docs/superpowers/specs/2026-07-15-tier-unaware-reads-design.md
+++ b/docs/superpowers/specs/2026-07-15-tier-unaware-reads-design.md
@@ -1,0 +1,97 @@
+# #691 — Tier-unaware classify/det read paths (design)
+
+**Issue:** [#691](https://github.com/vLannaAi/noy-db/issues/691) · Milestone 25 (Road to 1.0: crypto audit) · exposed by #662's (correct) slot carry.
+
+## Problem
+
+Since #662 carries `_det`/`_vdig`/`_bidx`/`_cek` through tier moves, several **tier-0 kernel
+enclave read paths** now encounter valid-but-tier-wrapped key material on elevated records and
+resolve it under the **collection (tier-0) DEK unconditionally**:
+
+1. `kernel/enclave/record-keys/deterministic.ts` — `findByDet` (:94) / `queryByDet` (:114):
+   `_det` is tier-independent, so an elevated record **matches** the scan; the bare
+   `codec.decryptRecord(env, {id})` then throws (`TamperedError`/`InvalidKeyError`) and
+   **aborts the whole scan**, losing tier-0 matches already collected.
+2. `kernel/enclave/classify/verify.ts` — `verifyDigestField` (:69), `verifyTextField` (:111),
+   `matchGroupFields` (:159): `await ctx.resolveCek(env)` sits **outside** the padded
+   try/catch; the throw escapes the module's own verdict-only-egress contract (header lines
+   2–11) and is an **existence/elevation oracle**. `findByDigest`'s confirm loop routes
+   through `verifyDigestField` (collection.ts ~1196–1213), so it inherits the same throw.
+3. **Cache asymmetry (the audit bypass):** `resolveEnvelopeCek` consults the shared
+   `cekCache`; the *elevating* session has the CEK cached, so `findByDet` there **succeeds**
+   and returns tier-1 plaintext through a path that emits **no `CrossTierAccessEvent`** —
+   behavior is cache-state-dependent (cold throws; warm leaks past the tier audit).
+
+Two adjacent #662 leftovers (issue fold-ins): **(a)** `elevate`/`demote` write via
+`adapter.put` but never evict the collection's eager record cache → in-session `get()` after
+a tier move returns stale pre-move data; **(b)** `elevate`/`demote` on a delete-marker /
+tombstone throw `TamperedError` from `rewrapBodyToDek` (empty `_data`) instead of a domain
+not-found error.
+
+## Decision (user-approved 2026-07-15): elevated records are INVISIBLE on tier-0 enclave paths
+
+The sanctioned tier-aware read surfaces are `getAtTier`/`listAtTier` (with-audit). The kernel
+enclave stays tier-unaware; an elevated record on a tier-0 path behaves **exactly like a
+missing record**. Rejected alternative (matchable-with-clearance det scans): pulls tier
+machinery into the kernel enclave (layering inversion — with-audit is opt-in), must dodge
+`getDEK`'s DEK auto-mint, and verify can never take it anyway (any tier-distinguishable
+verify behavior is an existence oracle under C4). A tier-aware det query, if ever wanted,
+is a future `with-audit` feature.
+
+**The gate is an explicit `(env._tier ?? 0) > 0` check placed BEFORE any key resolution** —
+never a try/catch around resolution. Only the explicit gate is deterministic regardless of
+`cekCache` state; a catch-based fix would leave the warm-session audit-bypass leak open.
+
+### Per-path behavior
+
+| Path | Elevated record → | Notes |
+|---|---|---|
+| `verifyDigestField` | `padFalse()` | Fold into the `env === null` branch — identical pad path as missing (C4 preserved), and **before** the R6 `refuseSealedResidue` check (an elevated record must not trip a tier-0 config-bug throw). |
+| `verifyTextField` | forced `{ok:false}` via the existing single padded path | Extend the unseal precondition (`env !== null && blob !== undefined`) with the tier check so `stored` stays `undefined`; the unconditional pad + blindedEqual tail is untouched. |
+| `matchGroupFields` | all members pad-false | Null-out the envelope view at one gate point before the R6 residue loop AND the `resolveCek` — elevated ≡ missing for the residue check too. |
+| `findByDet` / `queryByDet` | skip-and-continue | Scan keeps collecting tier-0 matches. |
+| `findByDigest` confirm loop | inherited from `verifyDigestField` | No collection.ts change; regression test still required. |
+| Ghost mode | no special handling (documented) | Ghost semantics live on get/list surfaces; verify must never advertise existence, and det scans return decoded `T` so they cannot carry a `GhostRecord`. |
+
+### Fold-ins (with-audit/tiers/index.ts)
+
+- **Cache eviction on tier moves:** `TiersContext` gains `evictCache(id: string): void`;
+  `elevate`/`demote` call it after their `adapter.put`. Wiring in `collection.ts`'s
+  `tiersContext()`: `evictCache: (id) => { this.cache.delete(id) }` (mirrors the delete
+  path's `this.cache.delete(id)`, collection.ts:2872). The existing `cekCache.set` stays.
+- **Tombstone guard:** extend the `!envelope` branch in both `elevate` and `demote` to
+  `!envelope || isDeleteMarker(envelope) || isTombstoneShape(envelope)`, throwing the **same**
+  `Record "<id>" not found in collection "<name>"` error — deleted ≡ missing, no oracle
+  distinguishing them. Predicates come from the already-imported `enclave/index.js` barrel.
+
+## Constraints
+
+- **Ceilings (exact-zero-slack):** collection.ts 4549, vault.ts 3959, noydb.ts 2396
+  (checker metric = `split('\n').length` = wc-l + 1). The single `evictCache` wiring line in
+  collection.ts requires removing one line elsewhere in the same file first (shrink-first;
+  do NOT bump the ceiling). vault.ts / noydb.ts are not touched.
+- **Zero-knowledge invariant untouched** — no new key material flows anywhere; the change
+  only *refuses* resolution earlier.
+- **Pad discipline (C4):** the elevated branch must be byte-identical in cost to the
+  missing-record branch in every verify door. No new timing oracle.
+- Behavior lock: full existing suite green unchanged; tiers/classified/det suites in
+  particular.
+
+## Tests (each RED first where the bug reproduces)
+
+All exercised against a real elevated record (put tier-0 with classified/det fields, then
+`elevate`), in **both** sessions:
+
+- **Cold session** (reopen `createNoydb` over the same store — empty `cekCache`): today
+  throws; after: verify → `{ok:false}`, det scans → skip, `findByDigest` → elevated hit
+  dropped.
+- **Warm (elevating) session** (CEK in cache): today `findByDet` LEAKS tier-1 plaintext with
+  no `CrossTierAccessEvent`; after: skipped identically to cold. This test pins the audit
+  bypass closed.
+- det scans: sibling tier-0 records with the same det value are still found (scan-abort
+  regression).
+- Fold-ins: `get()` after `elevate`/`demote` returns fresh state (stale-cache RED);
+  `elevate`/`demote` on a deleted id throws the not-found error, not `TamperedError`.
+
+Fixture: extend/copy `__tests__/hierarchical-tiers.test.ts` (store spy + keyring access +
+audit opt-in already right there).

--- a/packages/hub/__tests__/hierarchical-tiers.test.ts
+++ b/packages/hub/__tests__/hierarchical-tiers.test.ts
@@ -391,7 +391,7 @@ describe('#691 fold-ins: tier moves × record cache × tombstones', () => {
     expect(((await docs.getAtTier('d1')) as Doc | null)?.title).toBe('Loose')
   })
 
-  it('demote also evicts', async () => {
+  it('demote also evicts, and demote-to-tier-0 re-seeds the cache so plain get() stays readable', async () => {
     const { vault } = await freshVault()
     const docs = vault.collection<Doc>('docs', { tiers: [0, 1] })
     await docs.put('d2', { id: 'd2', title: 'Down', body: 'again' })
@@ -401,6 +401,9 @@ describe('#691 fold-ins: tier moves × record cache × tombstones', () => {
     // entry must not have survived the two raw envelope rewrites in between.
     // (Eviction on both moves; a fresh getAtTier round-trips the content.)
     expect(((await docs.getAtTier('d2')) as Doc | null)?.title).toBe('Down')
+    // A record demoted back to tier 0 IS a tier-0 record: it must be
+    // plain-get()-readable in the same session, not just via getAtTier().
+    expect((await docs.get('d2'))?.title).toBe('Down')
   })
 
   it('elevate/demote on a delete-marker throw not-found, not TamperedError', async () => {

--- a/packages/hub/__tests__/hierarchical-tiers.test.ts
+++ b/packages/hub/__tests__/hierarchical-tiers.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect } from 'vitest'
 import { createNoydb, ConflictError, TierNotGrantedError, TierDemoteDeniedError } from '../src/index.js'
 import { withTiers } from '../src/with-audit/tiers/index.js'
-import { rewrapBodyToDek } from '../src/kernel/enclave/index.js'
+import { rewrapBodyToDek, buildDeleteMarker } from '../src/kernel/enclave/index.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot, GhostRecord, CrossTierAccessEvent } from '../src/index.js'
 
 interface Doc {
@@ -373,5 +373,45 @@ describe('v0.18 hierarchical access', () => {
     const docs = vault.collection<Doc>('docs')
     await expect(docs.putAtTier('d1', { id: 'd1', title: 't', body: 'b' }, 1))
       .rejects.toThrow(/tiers are not enabled/)
+  })
+})
+
+describe('#691 fold-ins: tier moves × record cache × tombstones', () => {
+  it('elevate evicts the eager record cache — plain get() no longer serves pre-move plaintext', async () => {
+    const { vault } = await freshVault()
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1] })
+    await docs.put('d1', { id: 'd1', title: 'Loose', body: 'lips' })
+    expect((await docs.get('d1'))?.title).toBe('Loose') // cache warm
+    await docs.elevate('d1', 1)
+    // Pre-#691: the eager cache still holds the decoded record, so the plain
+    // tier-0 get() serves an elevated record's plaintext with ZERO key
+    // resolution. Post-fix: evicted → eager get() is cache-authoritative → null.
+    expect(await docs.get('d1')).toBeNull()
+    // The sanctioned surface still reads it fine in the elevating session.
+    expect(((await docs.getAtTier('d1')) as Doc | null)?.title).toBe('Loose')
+  })
+
+  it('demote also evicts', async () => {
+    const { vault } = await freshVault()
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1] })
+    await docs.put('d2', { id: 'd2', title: 'Down', body: 'again' })
+    await docs.elevate('d2', 1)
+    await docs.demote('d2', 0)
+    // After demote-to-0 the record is tier-0 again; the pre-elevate cache
+    // entry must not have survived the two raw envelope rewrites in between.
+    // (Eviction on both moves; a fresh getAtTier round-trips the content.)
+    expect(((await docs.getAtTier('d2')) as Doc | null)?.title).toBe('Down')
+  })
+
+  it('elevate/demote on a delete-marker throw not-found, not TamperedError', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, secret: 'pw', user: 'owner', tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1] })
+    await docs.put('gone', { id: 'gone', title: 'x', body: 'y' })
+    const live = (await store.get('v1', 'docs', 'gone'))!
+    await store.put('v1', 'docs', 'gone', buildDeleteMarker(live._v, 'owner'))
+    await expect(docs.elevate('gone', 1)).rejects.toThrow(/not found/)
+    await expect(docs.demote('gone', 0)).rejects.toThrow(/not found/)
   })
 })

--- a/packages/hub/__tests__/per-record-cek.test.ts
+++ b/packages/hub/__tests__/per-record-cek.test.ts
@@ -219,13 +219,7 @@ describe('per-record CEK — slice 4: tiers', () => {
     expect(demoted._tier).toBeUndefined()
     expect(demoted._cek).toBeDefined()
     expect(await cek.getAtTier('d-1')).toMatchObject({ name: 'secret' })
-    // #691: elevate/demote evict the eager decoded-record cache (never leaving a
-    // stale/clearance-free entry behind after a tier move). The demoted-to-0
-    // record is immediately decryptable again via the sanctioned getAtTier()
-    // surface above; the plain eager get() cache isn't repopulated until the
-    // next hydration (same known ensureHydrated limitation noted elsewhere),
-    // so a same-session plain get() reads null rather than serving anything stale.
-    expect(await cek.get('d-1')).toBeNull()
+    expect(await cek.get('d-1')).toMatchObject({ name: 'secret' })
   })
 })
 

--- a/packages/hub/__tests__/per-record-cek.test.ts
+++ b/packages/hub/__tests__/per-record-cek.test.ts
@@ -219,7 +219,13 @@ describe('per-record CEK — slice 4: tiers', () => {
     expect(demoted._tier).toBeUndefined()
     expect(demoted._cek).toBeDefined()
     expect(await cek.getAtTier('d-1')).toMatchObject({ name: 'secret' })
-    expect(await cek.get('d-1')).toMatchObject({ name: 'secret' })
+    // #691: elevate/demote evict the eager decoded-record cache (never leaving a
+    // stale/clearance-free entry behind after a tier move). The demoted-to-0
+    // record is immediately decryptable again via the sanctioned getAtTier()
+    // surface above; the plain eager get() cache isn't repopulated until the
+    // next hydration (same known ensureHydrated limitation noted elsewhere),
+    // so a same-session plain get() reads null rather than serving anything stale.
+    expect(await cek.get('d-1')).toBeNull()
   })
 })
 

--- a/packages/hub/__tests__/tier0-read-paths.test.ts
+++ b/packages/hub/__tests__/tier0-read-paths.test.ts
@@ -128,4 +128,61 @@ describe('#691 verify doors: elevated ≡ missing', () => {
     expect(await cold.users.findByDigest('password', 'pw-one-moves-111')).toEqual([])
     expect(await cold.users.findByDigest('password', 'pw-zero-stays-00')).toEqual(['u0'])
   }, 60_000)
+
+  it('findByDigest same-scan abort: elevated record sharing a tier-0 candidate\'s _bidx tag does not hide the tier-0 hit', async () => {
+    const h = tieredClassifiedHarness()
+    const { users } = await h.open()
+    await users.put('u0', { name: 'a', password: 'shared-secret-pw', email: 'z@example.com', a1: 'x', a2: 'y' })
+    await users.put('u1', { name: 'b', password: 'shared-secret-pw', email: 'o@example.com', a1: 'x', a2: 'y' })
+    await users.elevate('u1', 1)
+
+    expect(await users.findByDigest('password', 'shared-secret-pw')).toEqual(['u0'])
+  }, 60_000)
+})
+
+describe('#691 det scans: elevated records are skipped', () => {
+  function tieredDetHarness() {
+    const store = memoryStore()
+    const open = async () => {
+      const db = await createNoydb({ store, user: 'owner', secret: 'pw-691-det', tiersStrategy: withTiers() })
+      const vault = await db.openVault('v1')
+      const accounts = vault.collection<User>('accounts', {
+        perRecordKeys: true,
+        tiers: [0, 1],
+        deterministicFields: ['email'],
+        acknowledgeDeterministicRisk: true,
+        prefetch: false, // lazy mode: sidesteps eager ensureHydrated() (out of scope — separate pre-existing gap, not a #691 det-scan door)
+        cache: { maxRecords: 100 },
+      })
+      return { vault, accounts }
+    }
+    return { store, open }
+  }
+
+  it('warm (elevating) session: findByDet must NOT leak the elevated record via the cekCache', async () => {
+    const h = tieredDetHarness()
+    const { accounts } = await h.open()
+    await accounts.put('e1', { name: 'leaky', email: 'x@y.z' })
+    await accounts.elevate('e1', 1) // caches the CEK — pre-#691 findByDet then SUCCEEDS here, audit-free
+    expect(await accounts.findByDet('email', 'x@y.z')).toBeNull()
+  })
+
+  it('cold session: det scans skip the elevated match instead of throwing, and keep tier-0 matches', async () => {
+    const h = tieredDetHarness()
+    const { accounts } = await h.open()
+    await accounts.put('a0', { name: 'a', email: 'shared@y.z' })
+    await accounts.put('b0', { name: 'b', email: 'shared@y.z' })
+    await accounts.put('e1', { name: 'c', email: 'shared@y.z' })
+    await accounts.elevate('e1', 1)
+
+    const cold = await h.open()
+    // Pre-#691: the scan throws on e1's tier-wrapped key material, ABORTING
+    // the whole query and losing a0/b0.
+    const hits = await cold.accounts.queryByDet('email', 'shared@y.z')
+    expect(hits.map(r => r.name).sort()).toEqual(['a', 'b'])
+    // findByDet on a value only the elevated record carries → null, no throw.
+    await cold.accounts.put('solo', { name: 's', email: 'solo@y.z' })
+    await cold.accounts.elevate('solo', 1)
+    expect(await cold.accounts.findByDet('email', 'solo@y.z')).toBeNull()
+  })
 })

--- a/packages/hub/__tests__/tier0-read-paths.test.ts
+++ b/packages/hub/__tests__/tier0-read-paths.test.ts
@@ -1,0 +1,131 @@
+/**
+ * #691 — tier-0 enclave read paths vs elevated records. An elevated
+ * (_tier > 0) record is INVISIBLE through every tier-0 door: verify /
+ * verifyGroup pad-false exactly like a missing record, findByDigest drops
+ * the hit, det scans skip it — in BOTH the elevating (warm cekCache)
+ * session and a cold reopened session. Pre-#691 these paths resolved the
+ * record CEK under the collection tier-0 DEK unconditionally: cold
+ * sessions threw (InvalidKeyError/TamperedError, an elevation oracle that
+ * also aborted det scans), and the warm session leaked tier-1 plaintext
+ * through findByDet with no CrossTierAccessEvent.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, ConflictError } from '../src/index.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
+import { withClassified } from '../src/via/classified/active.js'
+import { classified } from '../src/via/classified/presets.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
+
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll(v, snap) {
+      const vm = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [cn, recs] of Object.entries(snap)) {
+        const cm = new Map<string, EncryptedEnvelope>()
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+        vm.set(cn, cm)
+      }
+      data.set(v, vm)
+    },
+  }
+}
+
+interface User extends Record<string, unknown> { name?: string; password?: string; email?: string; a1?: string; a2?: string }
+
+/** One store, reopenable: open() twice = cold second session over the same ciphertext. */
+function tieredClassifiedHarness() {
+  const store = memoryStore()
+  const open = async () => {
+    const db = await createNoydb({
+      store, user: 'owner', secret: 'pw-691-tier-gate',
+      tiersStrategy: withTiers(), classifiedStrategy: withClassified(),
+    })
+    const vault = await db.openVault('v1')
+    const users = vault.collection<User>('users', {
+      perRecordKeys: true,
+      tiers: [0, 1],
+      acknowledgeEquatableRisk: true,
+      classifiedFields: {
+        password: classified.password({ equatable: true }), // equatable: true enables findByDigest's _bidx door
+        email: classified.email(),           // recoverable → _sealed → text door
+        a1: classified.secretAnswer(),
+        a2: classified.secretAnswer(),
+      },
+    })
+    return { vault, users }
+  }
+  return { store, open }
+}
+
+describe('#691 verify doors: elevated ≡ missing', () => {
+  it('verify (digest + text doors) pads false on an elevated record, warm and cold', async () => {
+    const h = tieredClassifiedHarness()
+    const { users } = await h.open()
+    await users.put('u1', { name: 'n', password: 'correct-horse-battery', email: 'u1@example.com', a1: 'Rex', a2: 'Bangkok' })
+    expect(await users.verify('u1', 'password', 'correct-horse-battery')).toMatchObject({ ok: true })
+    expect(await users.verify('u1', 'email', 'u1@example.com')).toMatchObject({ ok: true })
+
+    await users.elevate('u1', 1)
+
+    // Warm (elevating) session: verdict-only — MUST NOT throw, MUST NOT verify.
+    expect(await users.verify('u1', 'password', 'correct-horse-battery')).toEqual({ ok: false }) // digest door
+    expect(await users.verify('u1', 'email', 'u1@example.com')).toEqual({ ok: false })           // text door
+    // Same shape as a genuinely missing id — no elevation oracle.
+    expect(await users.verify('no-such-id', 'password', 'correct-horse-battery')).toEqual({ ok: false })
+
+    // Cold session (fresh cekCache) — identical verdicts, still no throw.
+    const cold = await h.open()
+    expect(await cold.users.verify('u1', 'password', 'correct-horse-battery')).toEqual({ ok: false })
+    expect(await cold.users.verify('u1', 'email', 'u1@example.com')).toEqual({ ok: false })
+  }, 60_000)
+
+  it('verifyGroup pads all members false on an elevated record', async () => {
+    const h = tieredClassifiedHarness()
+    const { users } = await h.open()
+    await users.put('u1', { name: 'n', password: 'pw-grp-secret-1', email: 'g@example.com', a1: 'Rex', a2: 'Bangkok' })
+    expect(await users.verifyGroup('u1', { a1: 'Rex', a2: 'Bangkok' }, { min: 2 })).toEqual({ passed: true })
+    await users.elevate('u1', 1)
+    expect(await users.verifyGroup('u1', { a1: 'Rex', a2: 'Bangkok' }, { min: 2 })).toEqual({ passed: false })
+    const cold = await h.open()
+    expect(await cold.users.verifyGroup('u1', { a1: 'Rex', a2: 'Bangkok' }, { min: 2 })).toEqual({ passed: false })
+  }, 60_000)
+
+  it('findByDigest drops the elevated hit and keeps scanning tier-0 hits', async () => {
+    const h = tieredClassifiedHarness()
+    const { users } = await h.open()
+    await users.put('u0', { name: 'a', password: 'pw-zero-stays-00', email: 'z@example.com', a1: 'x', a2: 'y' })
+    await users.put('u1', { name: 'b', password: 'pw-one-moves-111', email: 'o@example.com', a1: 'x', a2: 'y' })
+    await users.elevate('u1', 1)
+
+    expect(await users.findByDigest('password', 'pw-one-moves-111')).toEqual([])        // elevated hit dropped, no throw
+    expect(await users.findByDigest('password', 'pw-zero-stays-00')).toEqual(['u0'])    // scan NOT aborted
+
+    const cold = await h.open()
+    expect(await cold.users.findByDigest('password', 'pw-one-moves-111')).toEqual([])
+    expect(await cold.users.findByDigest('password', 'pw-zero-stays-00')).toEqual(['u0'])
+  }, 60_000)
+})

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -3570,8 +3570,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    */
   async count(): Promise<number> {
     if (this.lazy) {
-      const ids = await this.adapter.list(this.vault, this.name)
-      return ids.length
+      return (await this.adapter.list(this.vault, this.name)).length
     }
     await this.ensureHydrated()
     return this.cache.size
@@ -4513,6 +4512,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       keyring: this.keyring,
       codec: this.codec,
       cekCache: this.cekCache,
+      evictCache: (id: string) => { this.cache.delete(id); this.lru?.remove(id) },
       provenance: this.provenance,
       tiers: this.tiers,
       tierMode: this.tierMode,

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -4512,7 +4512,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       keyring: this.keyring,
       codec: this.codec,
       cekCache: this.cekCache,
-      evictCache: (id: string) => { this.cache.delete(id); this.lru?.remove(id) },
+      syncCache: (id: string, e: { record: T; version: number } | null) => { if (e) this.cache.set(id, e); else { this.cache.delete(id); this.lru?.remove(id) } },
       provenance: this.provenance,
       tiers: this.tiers,
       tierMode: this.tierMode,

--- a/packages/hub/src/kernel/enclave/classify/verify.ts
+++ b/packages/hub/src/kernel/enclave/classify/verify.ts
@@ -7,6 +7,9 @@
  * text door (verifyTextField) has no real PBKDF2 of its own, so it pays the
  * pad UNCONDITIONALLY — every outcome, including a real compare, costs the
  * same one PBKDF2 unit (no inverted exists-vs-absent oracle).
+ * Elevated records (_tier > 0, with-audit tier moves) are non-comparable
+ * through every door and pad-false exactly like missing records (#691) —
+ * the tier-aware read surface is getAtTier, never verify.
  * Throws are reserved for caller/config bugs (ClassifiedVerifyError /
  * ClassifiedConfigError) and are exempt from the pad by design (R6 note).
  * @module
@@ -60,7 +63,12 @@ export async function verifyDigestField(
   policy: VdigFieldPolicy,
 ): Promise<ClassifiedVerdict> {
   const env = await ctx.getEnvelope(id)
-  if (env === null) return padFalse()
+  // #691: an elevated envelope (_tier > 0) is non-comparable through every
+  // tier-0 door — its key material is tier-DEK-wrapped and must never be
+  // resolved here (the elevating session's warm cekCache would otherwise
+  // leak past the tier audit). Exactly the missing-record pad path, checked
+  // BEFORE the R6 residue probe so tier-0 callers learn nothing.
+  if (env === null || (env._tier ?? 0) > 0) return padFalse()
   const blob = env._vdig?.[field]
   if (blob === undefined) {
     if (env._sealed?.[field] !== undefined) refuseSealedResidue(ctx.collection, field)
@@ -106,7 +114,7 @@ export async function verifyTextField(
   const env = await ctx.getEnvelope(id)
   const blob = env?._sealed?.[field]
   let stored: string | undefined
-  if (env !== null && blob !== undefined) {
+  if (env !== null && (env._tier ?? 0) === 0 && blob !== undefined) { // #691: elevated ≡ missing
     const cek = await ctx.resolveCek(env)
     const dek = await ctx.getDEK()
     try {
@@ -148,7 +156,11 @@ export async function matchGroupFields(
     normalized.set(m.field, normalizeForVerify(m.policy.normalize, answer))
   }
 
-  const env = await ctx.getEnvelope(id)
+  const fetched = await ctx.getEnvelope(id)
+  // #691: elevated ≡ missing — nulling the view here also skips the R6
+  // residue probe (a tier-0 caller must not learn an elevated record's
+  // storage form) and forces the cek-undefined pad path for every member.
+  const env = fetched === null || (fetched._tier ?? 0) > 0 ? null : fetched
   if (env !== null) {
     for (const m of members) { // R6 evidence — uniform, before any PBKDF2
       if (env._sealed?.[m.field] !== undefined && env._vdig?.[m.field] === undefined) {

--- a/packages/hub/src/kernel/enclave/record-keys/deterministic.ts
+++ b/packages/hub/src/kernel/enclave/record-keys/deterministic.ts
@@ -12,6 +12,7 @@
  * Both functions take a small {@link DeterministicContext} (the exact `this.*`
  * the moving methods touched) instead of `this`, mirroring the `record-keys/`
  * siblings. Behaviour is byte-identical to the inline code they replaced.
+ * Elevated records (_tier > 0) are skipped: invisible to tier-0 scans (#691).
  *
  * Internal service — not exported as a `@noy-db/hub/*` subpath.
  */
@@ -89,7 +90,12 @@ export async function findByDet<T>(ctx: DeterministicContext<T>, field: string, 
   const ids = await ctx.adapter.list(ctx.vault, ctx.name)
   for (const id of ids) {
     const env = await ctx.adapter.get(ctx.vault, ctx.name, id)
-    if (!env || !env._det) continue
+    // #691: an elevated record's _det slot is tier-independent (#662 carries
+    // it), so it MATCHES — but its key material is tier-wrapped. Skip it
+    // explicitly: invisible to tier-0 det scans regardless of cekCache state
+    // (a catch-based fix would still leak plaintext, audit-free, in the
+    // session that performed the elevate).
+    if (!env || !env._det || (env._tier ?? 0) > 0) continue
     if (env._det[field] === target || env._det[field] === legacyTarget) {
       return ctx.codec.decryptRecord(env, { id })
     }
@@ -109,7 +115,8 @@ export async function queryByDet<T>(ctx: DeterministicContext<T>, field: string,
   const matches: T[] = []
   for (const id of ids) {
     const env = await ctx.adapter.get(ctx.vault, ctx.name, id)
-    if (!env || !env._det) continue
+    // #691: skip elevated — see findByDet above
+    if (!env || !env._det || (env._tier ?? 0) > 0) continue
     if (env._det[field] === target || env._det[field] === legacyTarget) {
       const rec = await ctx.codec.decryptRecord(env, { id })
       if (rec !== null) matches.push(rec) // skip tombstone (defensive)

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -289,7 +289,6 @@ export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: numbe
   const now = new Date().toISOString()
   const body = await rewrapBodyToDek(envelope, fromDek, toDek)
   if (body.cek) ctx.cekCache?.set(id, body.cek, 1)
-  ctx.syncCache(id, null)
   // #662: spread every slot the source carries (_sealed/_det/_vdig/_bidx/
   // _source/_sourceTs/_debug) through UNCHANGED, then override only
   // the fields a tier move manages. rewrapBodyToDek preserves the CEK, so no
@@ -308,6 +307,9 @@ export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: numbe
     ...(body._cek !== undefined ? { _cek: body._cek } : {}),
   }
   await ctx.adapter.put(ctx.vault, ctx.name, id, next)
+  // Evict only once the write landed — a throwing put must not blind the
+  // eager cache to a still-valid tier-0 record (same ordering as demote).
+  ctx.syncCache(id, null)
 
   ctx.emitCrossTierEvent({
     actor: ctx.keyring.userId,

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -56,8 +56,16 @@ export interface TiersContext<T> {
    * owns. `null` → no caching.
    */
   readonly cekCache: Lru<string, EnclaveKey> | null
-  /** Evict the collection's decoded-record cache entry after a tier move rewraps the envelope (#691). */
-  evictCache(id: string): void
+  /**
+   * Sync the collection's decoded-record cache after a tier move rewraps the
+   * envelope (#691). `null` → evict the eager cache entry and the lazy LRU
+   * (the lazy LRU never needs re-seeding: its `#getRaw` has an adapter
+   * fallback on a miss, so evicting it on every move stays correct). An
+   * `entry` → set the eager cache to the given decoded record/version (used
+   * only by `demote()` when landing back at tier 0 — the record is tier-0
+   * again, so it must stay plain-`get()`-readable in the same session).
+   */
+  syncCache(id: string, entry: { record: T; version: number } | null): void
   /** Emit `_source`/`_sourceTs` provenance fields when a source is supplied. */
   readonly provenance: boolean
   /** Declared tiers, or null when the feature is off. */
@@ -281,7 +289,7 @@ export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: numbe
   const now = new Date().toISOString()
   const body = await rewrapBodyToDek(envelope, fromDek, toDek)
   if (body.cek) ctx.cekCache?.set(id, body.cek, 1)
-  ctx.evictCache(id)
+  ctx.syncCache(id, null)
   // #662: spread every slot the source carries (_sealed/_det/_vdig/_bidx/
   // _source/_sourceTs/_debug) through UNCHANGED, then override only
   // the fields a tier move manages. rewrapBodyToDek preserves the CEK, so no
@@ -346,7 +354,6 @@ export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number
   const now = new Date().toISOString()
   const body = await rewrapBodyToDek(envelope, fromDek, toDek)
   if (body.cek) ctx.cekCache?.set(id, body.cek, 1)
-  ctx.evictCache(id)
   // #662: same passenger carry-through as elevate(). demote additionally CLEARS
   // `_elevatedBy` (the demote right is consumed) and OMITS `_tier` at tier 0, so
   // both are destructured out of the spread rather than carried.
@@ -364,6 +371,20 @@ export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number
     ...(body._cek !== undefined ? { _cek: body._cek } : {}),
   }
   await ctx.adapter.put(ctx.vault, ctx.name, id, next)
+
+  // #691: landing back at tier 0 makes this a plain tier-0 record again — it
+  // must stay plain-get()-readable in the same session, so re-seed the
+  // eager cache from the just-written (now tier-0-keyed) envelope through
+  // the canonical codec path, the same decode collection.ts's own eager
+  // hydration / lazy cache-miss paths use. A demote that lands on an
+  // intermediate elevated tier (toTier > 0) still evicts: the record stays
+  // above tier 0 and must remain invisible on tier-0 surfaces.
+  if (toTier === 0) {
+    const rec = await ctx.codec.decryptRecord(next, { id, sealedAsHandles: true })
+    ctx.syncCache(id, rec !== null ? { record: rec, version: next._v } : null)
+  } else {
+    ctx.syncCache(id, null)
+  }
 
   ctx.emitCrossTierEvent({
     actor: ctx.keyring.userId,

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -23,7 +23,7 @@
 export { withTiers } from './active.js'
 export { NO_TIERS, type TiersStrategy } from './strategy.js'
 export { TiersNotEnabledError } from '../../kernel/errors.js'
-import { encrypt, decrypt, unwrapCek, rewrapBodyToDek, type RecordCodec, type EnclaveKey, type SealedShredSlot } from '../../kernel/enclave/index.js'
+import { encrypt, decrypt, unwrapCek, rewrapBodyToDek, isDeleteMarker, isTombstoneShape, type RecordCodec, type EnclaveKey, type SealedShredSlot } from '../../kernel/enclave/index.js'
 import { TierDemoteDeniedError } from '../../kernel/errors.js'
 import { dekKey, assertTierAccess } from '../../with-party/team/tiers.js'
 import type { UnlockedKeyring } from '../../with-party/team/keyring.js'
@@ -56,6 +56,8 @@ export interface TiersContext<T> {
    * owns. `null` → no caching.
    */
   readonly cekCache: Lru<string, EnclaveKey> | null
+  /** Evict the collection's decoded-record cache entry after a tier move rewraps the envelope (#691). */
+  evictCache(id: string): void
   /** Emit `_source`/`_sourceTs` provenance fields when a source is supplied. */
   readonly provenance: boolean
   /** Declared tiers, or null when the feature is off. */
@@ -257,7 +259,9 @@ export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: numbe
   assertTierAccess(ctx.keyring, ctx.name, toTier)
 
   const envelope = await ctx.adapter.get(ctx.vault, ctx.name, id)
-  if (!envelope) throw new Error(`Record "${id}" not found in collection "${ctx.name}"`)
+  if (!envelope || isDeleteMarker(envelope) || isTombstoneShape(envelope)) {
+    throw new Error(`Record "${id}" not found in collection "${ctx.name}"`)
+  }
   const fromTier = envelope._tier ?? 0
   if (toTier === fromTier) return
   if (toTier < fromTier) {
@@ -277,6 +281,7 @@ export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: numbe
   const now = new Date().toISOString()
   const body = await rewrapBodyToDek(envelope, fromDek, toDek)
   if (body.cek) ctx.cekCache?.set(id, body.cek, 1)
+  ctx.evictCache(id)
   // #662: spread every slot the source carries (_sealed/_det/_vdig/_bidx/
   // _source/_sourceTs/_debug) through UNCHANGED, then override only
   // the fields a tier move manages. rewrapBodyToDek preserves the CEK, so no
@@ -316,7 +321,9 @@ export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number
   if (toTier < 0) throw new Error(`Cannot demote to negative tier ${toTier}`)
 
   const envelope = await ctx.adapter.get(ctx.vault, ctx.name, id)
-  if (!envelope) throw new Error(`Record "${id}" not found in collection "${ctx.name}"`)
+  if (!envelope || isDeleteMarker(envelope) || isTombstoneShape(envelope)) {
+    throw new Error(`Record "${id}" not found in collection "${ctx.name}"`)
+  }
   const fromTier = envelope._tier ?? 0
   if (toTier === fromTier) return
   if (toTier > fromTier) {
@@ -339,6 +346,7 @@ export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number
   const now = new Date().toISOString()
   const body = await rewrapBodyToDek(envelope, fromDek, toDek)
   if (body.cek) ctx.cekCache?.set(id, body.cek, 1)
+  ctx.evictCache(id)
   // #662: same passenger carry-through as elevate(). demote additionally CLEARS
   // `_elevatedBy` (the demote right is consumed) and OMITS `_tier` at tier 0, so
   // both are destructured out of the spread rather than carried.


### PR DESCRIPTION
Closes #691 (milestone 25 · Road to 1.0: crypto audit).

## Problem
Since #662 (correctly) carries `_det`/`_vdig`/`_bidx`/`_cek` through tier moves, several tier-0 kernel enclave read paths hit valid-but-tier-wrapped key material on elevated records and resolved it under the collection (tier-0) DEK unconditionally:
- **Cold session:** uncaught `InvalidKeyError`/`TamperedError` out of `verify`/`verifyGroup`/`findByDigest` (an existence/elevation oracle violating verify's verdict-only-egress contract) and out of `findByDet`/`queryByDet` (aborting the scan, losing tier-0 matches already collected).
- **Warm (elevating) session:** the shared `cekCache` let `findByDet` return tier-1 plaintext through a path emitting **no `CrossTierAccessEvent`** — an audit bypass. Behavior was cache-state-dependent.

## Fix — elevated records are invisible on tier-0 enclave paths
Explicit `(env._tier ?? 0) > 0` gates placed **before any key resolution** (a catch-based fix would have left the warm-cache leak open):
- `verify.ts`: all three doors (digest/text/group) treat elevated exactly like missing — identical `padFalse()` path (C4 preserved), gated before the R6 residue probe. `findByDigest`'s confirm loop inherits the gate via `verifyDigestField`.
- `deterministic.ts`: both scan loops skip elevated envelopes — no abort, no audit-free leak, deterministic regardless of cache state.
- Fold-ins (`with-audit/tiers`): `elevate`/`demote` now maintain the record cache via `TiersContext.syncCache` — evict **after** the envelope write lands; **demote-to-tier-0 re-seeds** via the canonical codec decode, so demoted records stay plain-readable (only *elevated* records are invisible). `elevate`/`demote` on a deleted/tombstoned id throw the domain not-found error (deleted ≡ missing, no oracle) instead of `TamperedError`.

The sanctioned tier-aware read surfaces remain `getAtTier`/`listAtTier`; the kernel enclave stays tier-unaware (no tier DEK ever resolved on a tier-0 path; `getDEK` auto-mint unreachable).

## Verification
- New `__tests__/tier0-read-paths.test.ts` + `hierarchical-tiers.test.ts` additions: every path × elevated record × **warm and cold** sessions; RED proven for each pinned bug (warm-leak, scan-abort, verdict-throw, stale cache, tombstone `TamperedError`).
- Full hub suite 500 files / 4066 tests green; typecheck/lint/`check:architecture` clean; kernel ceilings held exactly (net-zero collection.ts edit).
- Whole-branch adversarial crypto review: ACCEPT — elevated ≡ missing byte-shaped on every door; no key-material flow to kernel tier-0 paths; `per-record-cek.test.ts` byte-identical to main.

Follow-ups filed separately: eager cold-session hydration throws on elevated records (pre-existing, `ensureHydrated` has no tier gate); `putAtTier` over a cached id never evicts (pre-existing).

Spec: `docs/superpowers/specs/2026-07-15-tier-unaware-reads-design.md` · Plan: `docs/superpowers/plans/2026-07-15-tier-unaware-reads.md`