### PR TITLE
fix(hub): hydration/lazy/reveal skip elevated records; putAtTier cache coherence (#701, #702)

### DIFF
--- a/docs/superpowers/plans/2026-07-15-tier-cache-coherence.md
+++ b/docs/superpowers/plans/2026-07-15-tier-cache-coherence.md
@@ -1,0 +1,213 @@
+# #701 + #702 Tier Cache Coherence — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend #691's invisible-everywhere semantics to the remaining tier-unaware paths: hydration (eager cold-session bricking, #701), lazy direct-address reads (warm-cache leak / cold throw, #701), `reveal()` (raw crypto error, #701), and `putAtTier` cache coherence (#702).
+
+**Architecture:** Same law as #691 (spec: `docs/superpowers/specs/2026-07-15-tier-unaware-reads-design.md`, user-approved): elevated (`_tier > 0`) records are invisible on tier-0 surfaces — explicit gates before key resolution, never try/catch (the elevating session's warm `cekCache` otherwise leaks plaintext: `decryptRecord(env, {id})` passes the id → cache hit → plaintext, audit-free). `putAtTier` reuses `TiersContext.syncCache` (#700): evict for tier > 0, re-seed for tier 0.
+
+**Tech Stack:** TypeScript ESM, vitest. Branch `fix/701-702-tier-cache-coherence` (created, on main 6ea92d52+).
+
+## Global Constraints
+
+- NEVER add Claude/Anthropic attribution to commits/PRs/changelogs.
+- NEVER reference the private pilot client by name — grep the diff before each commit.
+- Ceilings exact zero slack (checker = `wc -l` + 1): collection.ts 4549, vault.ts 3959, noydb.ts 2396. **Every collection.ts edit in this plan is a NET-ZERO in-line condition fold** — extend existing lines, add no new lines (comment text may be extended on existing lines; if a genuinely new line becomes unavoidable, make one mechanical shrink-join and document it). Never edit ceiling values; never touch vault.ts/noydb.ts.
+- TDD: RED verified before implementing, every test. Run from `packages/hub/`: `pnpm vitest run <path>`.
+- No new deps; no timing assertions.
+
+---
+
+### Task 1: #701 — gate hydration, lazy reads, and reveal
+
+**Files:**
+- Modify: `packages/hub/src/kernel/collection.ts` (3 in-line condition folds, net-zero)
+- Modify: `packages/hub/src/kernel/enclave/classify/reveal.ts` (1 condition fold)
+- Modify: `packages/hub/__tests__/tier0-read-paths.test.ts` (append describe block)
+
+**Interfaces:**
+- Consumes: `EncryptedEnvelope._tier?: number`; existing fixtures in tier0-read-paths.test.ts (`memoryStore`, `tieredClassifiedHarness`); `ClassifiedRevealError`.
+- Produces: nothing downstream (Task 2 is independent).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/hub/__tests__/tier0-read-paths.test.ts`:
+
+```ts
+describe('#701 hydration / lazy reads / reveal: elevated records are invisible, never a brick or leak', () => {
+  function eagerTierHarness() {
+    const store = memoryStore()
+    const open = async () => {
+      const db = await createNoydb({ store, user: 'owner', secret: 'pw-701', tiersStrategy: withTiers() })
+      const vault = await db.openVault('v1')
+      const docs = vault.collection<User>('docs', { tiers: [0, 1], perRecordKeys: true })
+      return { vault, docs }
+    }
+    return { store, open }
+  }
+
+  it('cold-session eager hydration skips the elevated record instead of bricking the collection', async () => {
+    const h = eagerTierHarness()
+    const { docs } = await h.open()
+    await docs.put('a', { name: 'stays' })
+    await docs.put('b', { name: 'moves' })
+    await docs.elevate('b', 1)
+
+    // Pre-#701: the first decrypt of b's tier-wrapped envelope during cold
+    // hydration threw, aborting the loop — get('a') / any read or write on
+    // the whole collection rejected.
+    const cold = await h.open()
+    expect((await cold.docs.get('a'))?.name).toBe('stays')
+    expect(await cold.docs.get('b')).toBeNull()          // invisible, not an error
+    await cold.docs.put('c', { name: 'writable' })       // collection is usable
+    expect((await cold.docs.get('c'))?.name).toBe('writable')
+  })
+
+  it('lazy direct-address read: null in BOTH sessions (warm pre-#701 LEAKED via cekCache, cold threw)', async () => {
+    const store = memoryStore()
+    const open = async () => {
+      const db = await createNoydb({ store, user: 'owner', secret: 'pw-701-lazy', tiersStrategy: withTiers() })
+      const vault = await db.openVault('v1')
+      const docs = vault.collection<User>('ldocs', { tiers: [0, 1], perRecordKeys: true, prefetch: false, cache: { maxRecords: 100 } })
+      return { docs }
+    }
+    const { docs } = await open()
+    await docs.put('e1', { name: 'leaky' })
+    await docs.elevate('e1', 1) // evicts the LRU (#700) and caches the CEK
+    expect(await docs.get('e1')).toBeNull()   // warm: pre-#701 returned plaintext (leak)
+    const cold = await open()
+    expect(await cold.docs.get('e1')).toBeNull() // cold: pre-#701 threw
+  })
+
+  it('reveal on an elevated record throws the domain not-found error, not a raw crypto error', async () => {
+    const h = tieredClassifiedHarness()
+    const { users } = await h.open()
+    await users.put('r1', { name: 'n', password: 'pw-reveal-r1-xx', email: 'r@example.com', a1: 'x', a2: 'y' })
+    expect(await users.reveal('r1', 'email')).toBe('r@example.com')
+    await users.elevate('r1', 1)
+    // Elevated ≡ missing on this tier-0 surface — same error/message class as
+    // a genuinely absent id, no elevation disclosure, never InvalidKeyError.
+    await expect(users.reveal('r1', 'email')).rejects.toThrow(/not found/)
+  }, 60_000)
+})
+```
+
+Adapt only mechanics if needed (e.g. the exact lazy-mode option names — copy from Task 2's det harness in this same file; `reveal`'s call shape — check an existing reveal test under `__tests__/classified/`). Never weaken an assertion; if a RED expectation doesn't reproduce as documented, STOP and report BLOCKED.
+
+Fixture-path note: cold `open()` may hydrate through `hydrateFromSnapshot` (vault `loadAll` snapshot) rather than `ensureHydrated`. Both loops get the same gate in Step 3 — after GREEN, temporarily comment out ONE of the two gates and confirm at least one test fails, then restore it, to prove both paths are exercised or add a variant that exercises the other (e.g. a collection first declared after the vault opened). Record which path each test hits in your report.
+
+- [ ] **Step 2: Run to verify RED**
+
+Run: `pnpm vitest run __tests__/tier0-read-paths.test.ts -t '#701'`
+Expected: FAIL — test 1 rejects during cold reads (hydration abort), test 2 warm leg returns the record (leak) and cold leg rejects, test 3 rejects with `InvalidKeyError`, not `/not found/`.
+
+- [ ] **Step 3: Implement — four in-line condition folds**
+
+(a) `collection.ts` `ensureHydrated` (~:3927) — extend the decrypt precondition:
+```ts
+      if (envelope && !isTombstone(envelope, this.storeCiphertext) && !isDeleteMarker(envelope) && (envelope._tier ?? 0) === 0) {
+```
+(b) `collection.ts` `hydrateFromSnapshot` (~:3943) — extend the skip:
+```ts
+      if (isTombstone(envelope, this.storeCiphertext) || (envelope._tier ?? 0) > 0) continue
+```
+(c) `collection.ts` lazy `#getRaw` miss branch (~:1451) — extend the tolerance return (and extend the comment ON ITS EXISTING LINES to mention `#701: elevated records are invisible — gate BEFORE decrypt, or the warm cekCache serves tier plaintext`):
+```ts
+        if (isTombstone(envelope, this.storeCiphertext) || isDeleteMarker(envelope) || (envelope._tier ?? 0) > 0) return null
+```
+(d) `reveal.ts` `revealSealedField` (:24) — fold into the existing not-found branch (message unchanged — elevated ≡ missing, no elevation disclosure):
+```ts
+  if (env === null || isTombstone(env, ctx.encrypted) || (env._tier ?? 0) > 0) {
+```
+All three collection.ts edits are single-line replacements — file line count MUST be unchanged (`node scripts/check-architecture.mjs` passes with values unedited).
+
+- [ ] **Step 4: Run GREEN + regression**
+
+`pnpm vitest run __tests__/tier0-read-paths.test.ts __tests__/hierarchical-tiers.test.ts __tests__/per-record-cek.test.ts __tests__/classified` → PASS. `node scripts/check-architecture.mjs` (repo root) → PASS. Then the gate-coverage check from Step 1's fixture-path note.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/kernel/collection.ts packages/hub/src/kernel/enclave/classify/reveal.ts packages/hub/__tests__/tier0-read-paths.test.ts
+git commit -m "fix(hub): hydration, lazy reads, and reveal skip elevated records — no cold-session brick, no warm-cache leak (#701)"
+```
+
+---
+
+### Task 2: #702 — putAtTier maintains the record cache
+
+**Files:**
+- Modify: `packages/hub/src/with-audit/tiers/index.ts` (putAtTier only)
+- Modify: `packages/hub/__tests__/hierarchical-tiers.test.ts` (append to the '#691 fold-ins' describe or a sibling '#702' block)
+
+**Interfaces:**
+- Consumes: `TiersContext.syncCache` (shipped in #700), `ctx.codec.decryptRecord(env, { id, sealedAsHandles: true })` (same call shape as demote-to-0's re-seed — read that block in `demote()` first and mirror it exactly).
+- Produces: nothing downstream.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe('#702 putAtTier maintains the record cache', () => {
+  it('putAtTier(tier>0) over a cached id evicts — plain get() stops serving the pre-move plaintext', async () => {
+    const { vault } = await freshVault()
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1] })
+    await docs.put('p1', { id: 'p1', title: 'Old', body: 'plain' })
+    expect((await docs.get('p1'))?.title).toBe('Old') // cache warm
+    await docs.putAtTier('p1', { id: 'p1', title: 'New', body: 'secret' }, 1)
+    // Pre-#702: the eager cache still served { title: 'Old' } — clearance-free.
+    expect(await docs.get('p1')).toBeNull()
+    expect(((await docs.getAtTier('p1')) as Doc | null)?.title).toBe('New')
+  })
+
+  it('putAtTier(tier 0) over a cached id re-seeds — plain get() serves the NEW content', async () => {
+    const { vault } = await freshVault()
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1] })
+    await docs.put('p2', { id: 'p2', title: 'V1', body: 'x' })
+    expect((await docs.get('p2'))?.title).toBe('V1')
+    await docs.putAtTier('p2', { id: 'p2', title: 'V2', body: 'y' }, 0)
+    // Pre-#702: stale 'V1' from the untouched cache.
+    expect((await docs.get('p2'))?.title).toBe('V2')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify RED**
+
+Run: `pnpm vitest run __tests__/hierarchical-tiers.test.ts -t '#702'`
+Expected: FAIL — test 1 `get('p1')` returns `{ title: 'Old' }`; test 2 returns `'V1'`.
+
+- [ ] **Step 3: Implement**
+
+In `putAtTier` (tiers/index.ts), after `await ctx.adapter.put(...)`:
+```ts
+  // #702: keep the record cache coherent with the raw write — same law as
+  // elevate/demote (#691): tier > 0 → invisible on tier-0 surfaces (evict);
+  // tier 0 → this is an ordinary write, re-seed via the canonical decode.
+  if (tier > 0) {
+    ctx.syncCache(id, null)
+  } else {
+    const rec = await ctx.codec.decryptRecord(envelope, { id, sealedAsHandles: true })
+    ctx.syncCache(id, rec !== null ? { record: rec, version: envelope._v } : null)
+  }
+```
+(Mirror demote-to-0's exact decode call shape; place before the `emitCrossTierEvent` block.)
+
+- [ ] **Step 4: Run GREEN + regression**
+
+`pnpm vitest run __tests__/hierarchical-tiers.test.ts __tests__/tier0-read-paths.test.ts __tests__/per-record-cek.test.ts` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/with-audit/tiers/index.ts packages/hub/__tests__/hierarchical-tiers.test.ts
+git commit -m "fix(hub): putAtTier keeps the record cache coherent — evict above tier 0, re-seed at tier 0 (#702)"
+```
+
+---
+
+### Final: full suite + whole-branch review + changeset + PR
+
+- [ ] `pnpm --filter @noy-db/hub test` + typecheck + lint + `pnpm check:architecture` — green.
+- [ ] Whole-branch review (fable — kernel hydration + tier cache coherence).
+- [ ] Local changeset: `@noy-db/hub` patch — hydration/lazy/reveal skip elevated records (no cold-session brick, no warm-cache leak); putAtTier cache coherence (#701, #702).
+- [ ] PR → main with `Closes #701` + `Closes #702`.

--- a/packages/hub/__tests__/hierarchical-tiers.test.ts
+++ b/packages/hub/__tests__/hierarchical-tiers.test.ts
@@ -418,3 +418,26 @@ describe('#691 fold-ins: tier moves × record cache × tombstones', () => {
     await expect(docs.demote('gone', 0)).rejects.toThrow(/not found/)
   })
 })
+
+describe('#702 putAtTier maintains the record cache', () => {
+  it('putAtTier(tier>0) over a cached id evicts — plain get() stops serving the pre-move plaintext', async () => {
+    const { vault } = await freshVault()
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1] })
+    await docs.put('p1', { id: 'p1', title: 'Old', body: 'plain' })
+    expect((await docs.get('p1'))?.title).toBe('Old') // cache warm
+    await docs.putAtTier('p1', { id: 'p1', title: 'New', body: 'secret' }, 1)
+    // Pre-#702: the eager cache still served { title: 'Old' } — clearance-free.
+    expect(await docs.get('p1')).toBeNull()
+    expect(((await docs.getAtTier('p1')) as Doc | null)?.title).toBe('New')
+  })
+
+  it('putAtTier(tier 0) over a cached id re-seeds — plain get() serves the NEW content', async () => {
+    const { vault } = await freshVault()
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1] })
+    await docs.put('p2', { id: 'p2', title: 'V1', body: 'x' })
+    expect((await docs.get('p2'))?.title).toBe('V1')
+    await docs.putAtTier('p2', { id: 'p2', title: 'V2', body: 'y' }, 0)
+    // Pre-#702: stale 'V1' from the untouched cache.
+    expect((await docs.get('p2'))?.title).toBe('V2')
+  })
+})

--- a/packages/hub/__tests__/hierarchical-tiers.test.ts
+++ b/packages/hub/__tests__/hierarchical-tiers.test.ts
@@ -440,4 +440,20 @@ describe('#702 putAtTier maintains the record cache', () => {
     // Pre-#702: stale 'V1' from the untouched cache.
     expect((await docs.get('p2'))?.title).toBe('V2')
   })
+
+  it('LAZY mode: putAtTier(tier 0) over an LRU-cached id serves the NEW content (LRU evicted, adapter refetch)', async () => {
+    const { vault } = await freshVault()
+    const docs = vault.collection<Doc>('ldocs', { tiers: [0, 1], prefetch: false, cache: { maxRecords: 100 } })
+    await docs.put('p3', { id: 'p3', title: 'L1', body: 'x' })
+    expect((await docs.get('p3'))?.title).toBe('L1') // LRU warm
+    await docs.putAtTier('p3', { id: 'p3', title: 'L2', body: 'y' }, 0)
+    // Whole-branch review finding: syncCache's entry branch seeded only the
+    // eager Map — lazy reads consult the LRU, which kept serving stale 'L1'.
+    // The LRU is now evicted on every sync; the lazy miss refetches + decodes
+    // the fresh tier-0 envelope via the adapter fallback.
+    expect((await docs.get('p3'))?.title).toBe('L2')
+    // And the tier>0 overwrite stays invisible on the lazy surface too.
+    await docs.putAtTier('p3', { id: 'p3', title: 'L3', body: 'z' }, 1)
+    expect(await docs.get('p3')).toBeNull()
+  })
 })

--- a/packages/hub/__tests__/tier0-read-paths.test.ts
+++ b/packages/hub/__tests__/tier0-read-paths.test.ts
@@ -186,3 +186,74 @@ describe('#691 det scans: elevated records are skipped', () => {
     expect(await cold.accounts.findByDet('email', 'solo@y.z')).toBeNull()
   })
 })
+
+describe('#701 hydration / lazy reads / reveal: elevated records are invisible, never a brick or leak', () => {
+  function eagerTierHarness() {
+    const store = memoryStore()
+    const open = async () => {
+      const db = await createNoydb({ store, user: 'owner', secret: 'pw-701', tiersStrategy: withTiers() })
+      const vault = await db.openVault('v1')
+      const docs = vault.collection<User>('docs', { tiers: [0, 1], perRecordKeys: true })
+      return { vault, docs }
+    }
+    return { store, open }
+  }
+
+  it('cold-session eager hydration skips the elevated record instead of bricking the collection', async () => {
+    const h = eagerTierHarness()
+    const { docs } = await h.open()
+    await docs.put('a', { name: 'stays' })
+    await docs.put('b', { name: 'moves' })
+    await docs.elevate('b', 1)
+
+    // Pre-#701: the first decrypt of b's tier-wrapped envelope during cold
+    // hydration threw, aborting the loop — get('a') / any read or write on
+    // the whole collection rejected.
+    const cold = await h.open()
+    expect((await cold.docs.get('a'))?.name).toBe('stays')
+    expect(await cold.docs.get('b')).toBeNull()          // invisible, not an error
+    await cold.docs.put('c', { name: 'writable' })       // collection is usable
+    expect((await cold.docs.get('c'))?.name).toBe('writable')
+  })
+
+  it('vault-snapshot hydration path (hydrateFromSnapshot) also skips the elevated record — no in-repo caller reaches this loop otherwise, so it is exercised directly', async () => {
+    const h = eagerTierHarness()
+    const { docs } = await h.open()
+    await docs.put('a', { name: 'stays' })
+    await docs.put('b', { name: 'moves' })
+    await docs.elevate('b', 1)
+
+    const cold = await h.open() // fresh, un-hydrated Collection over the same store
+    const snapshot = await h.store.loadAll('v1')
+    await cold.docs.hydrateFromSnapshot(snapshot['docs'] ?? {})
+    expect((await cold.docs.get('a'))?.name).toBe('stays')
+    expect(await cold.docs.get('b')).toBeNull()
+  })
+
+  it('lazy direct-address read: null in BOTH sessions (warm pre-#701 LEAKED via cekCache, cold threw)', async () => {
+    const store = memoryStore()
+    const open = async () => {
+      const db = await createNoydb({ store, user: 'owner', secret: 'pw-701-lazy', tiersStrategy: withTiers() })
+      const vault = await db.openVault('v1')
+      const docs = vault.collection<User>('ldocs', { tiers: [0, 1], perRecordKeys: true, prefetch: false, cache: { maxRecords: 100 } })
+      return { docs }
+    }
+    const { docs } = await open()
+    await docs.put('e1', { name: 'leaky' })
+    await docs.elevate('e1', 1) // evicts the LRU (#700) and caches the CEK
+    expect(await docs.get('e1')).toBeNull()   // warm: pre-#701 returned plaintext (leak)
+    const cold = await open()
+    expect(await cold.docs.get('e1')).toBeNull() // cold: pre-#701 threw
+  })
+
+  it('reveal on an elevated record throws the domain not-found error, not a raw crypto error', async () => {
+    const h = tieredClassifiedHarness()
+    const { users } = await h.open()
+    await users.put('r1', { name: 'n', password: 'pw-reveal-r1-xx', email: 'r@example.com', a1: 'x', a2: 'y' })
+    expect(await users.reveal('r1', 'email')).toBe('r@example.com')
+    await users.elevate('r1', 1)
+    // Elevated ≡ missing on this tier-0 surface — same error/message class as
+    // a genuinely absent id, no elevation disclosure, never InvalidKeyError.
+    await expect(users.reveal('r1', 'email')).rejects.toThrow(/not found/)
+  }, 60_000)
+})

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -4512,7 +4512,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       keyring: this.keyring,
       codec: this.codec,
       cekCache: this.cekCache,
-      syncCache: (id: string, e: { record: T; version: number } | null) => { if (e) this.cache.set(id, e); else { this.cache.delete(id); this.lru?.remove(id) } },
+      syncCache: (id: string, e: { record: T; version: number } | null) => { if (e) this.cache.set(id, e); else this.cache.delete(id); this.lru?.remove(id) },
       provenance: this.provenance,
       tiers: this.tiers,
       tierMode: this.tierMode,

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -1447,8 +1447,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
         const envelope = await this.adapter.get(this.vault, this.name, id)
         if (!envelope) return null
         // Tombstone tolerance (decision 5): a shredded record carries no
-        // body / CEK. Reads return null rather than throwing TamperedError.
-        if (isTombstone(envelope, this.storeCiphertext) || isDeleteMarker(envelope)) return null
+        // body / CEK. Reads return null rather than throwing TamperedError. #701: elevated records are invisible — gate BEFORE decrypt, or the warm cekCache serves tier plaintext.
+        if (isTombstone(envelope, this.storeCiphertext) || isDeleteMarker(envelope) || (envelope._tier ?? 0) > 0) return null
         record = await this.codec.decryptRecord(envelope, { id, sealedAsHandles: true })
         if (record === null) return null
         this.lru.set(id, { record, version: envelope._v }, estimateRecordBytes(record))
@@ -3924,7 +3924,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     const ids = await this.adapter.list(this.vault, this.name)
     for (const id of ids) {
       const envelope = await this.adapter.get(this.vault, this.name, id)
-      if (envelope && !isTombstone(envelope, this.storeCiphertext) && !isDeleteMarker(envelope)) {
+      if (envelope && !isTombstone(envelope, this.storeCiphertext) && !isDeleteMarker(envelope) && (envelope._tier ?? 0) === 0) {
         const record = await this.codec.decryptRecord(envelope, { id, sealedAsHandles: true })
         if (record === null) continue
         this.cache.set(id, { record, version: envelope._v })
@@ -3941,7 +3941,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   async hydrateFromSnapshot(records: Record<string, EncryptedEnvelope>): Promise<void> {
     for (const [id, envelope] of Object.entries(records)) {
       if (isDeleteMarker(envelope)) { this.markerIds.add(id); continue } // #606: seed from a pre-loaded snapshot too
-      if (isTombstone(envelope, this.storeCiphertext)) continue
+      if (isTombstone(envelope, this.storeCiphertext) || (envelope._tier ?? 0) > 0) continue
       const record = await this.codec.decryptRecord(envelope, { id, sealedAsHandles: true })
       if (record === null) continue
       this.cache.set(id, { record, version: envelope._v })

--- a/packages/hub/src/kernel/enclave/classify/reveal.ts
+++ b/packages/hub/src/kernel/enclave/classify/reveal.ts
@@ -21,7 +21,7 @@ export interface RevealEngineCtx {
 
 export async function revealSealedField(ctx: RevealEngineCtx, id: string, field: string): Promise<unknown> {
   const env = await ctx.getEnvelope(id)
-  if (env === null || isTombstone(env, ctx.encrypted)) {
+  if (env === null || isTombstone(env, ctx.encrypted) || (env._tier ?? 0) > 0) {
     throw new ClassifiedRevealError(ctx.collection, field, `record "${id}" not found in "${ctx.collection}"`)
   }
   if (!ctx.encrypted) {

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -62,8 +62,8 @@ export interface TiersContext<T> {
    * (the lazy LRU never needs re-seeding: its `#getRaw` has an adapter
    * fallback on a miss, so evicting it on every move stays correct). An
    * `entry` → set the eager cache to the given decoded record/version (used
-   * only by `demote()` when landing back at tier 0 — the record is tier-0
-   * again, so it must stay plain-`get()`-readable in the same session).
+   * by `demote()` landing back at tier 0 and `putAtTier`'s tier-0 write, #702
+   * — the record is tier-0, so it must stay plain-`get()`-readable in-session).
    */
   syncCache(id: string, entry: { record: T; version: number } | null): void
   /** Emit `_source`/`_sourceTs` provenance fields when a source is supplied. */

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -146,6 +146,16 @@ export async function putAtTier<T>(
 
   await ctx.adapter.put(ctx.vault, ctx.name, id, envelope)
 
+  // #702: keep the record cache coherent with the raw write — same law as
+  // elevate/demote (#691): tier > 0 → invisible on tier-0 surfaces (evict);
+  // tier 0 → this is an ordinary write, re-seed via the canonical decode.
+  if (tier > 0) {
+    ctx.syncCache(id, null)
+  } else {
+    const rec = await ctx.codec.decryptRecord(envelope, { id, sealedAsHandles: true })
+    ctx.syncCache(id, rec !== null ? { record: rec, version: envelope._v } : null)
+  }
+
   if (tier > 0) {
     ctx.emitCrossTierEvent({
       actor: ctx.keyring.userId,

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -58,12 +58,14 @@ export interface TiersContext<T> {
   readonly cekCache: Lru<string, EnclaveKey> | null
   /**
    * Sync the collection's decoded-record cache after a tier move rewraps the
-   * envelope (#691). `null` → evict the eager cache entry and the lazy LRU
-   * (the lazy LRU never needs re-seeding: its `#getRaw` has an adapter
-   * fallback on a miss, so evicting it on every move stays correct). An
-   * `entry` → set the eager cache to the given decoded record/version (used
-   * by `demote()` landing back at tier 0 and `putAtTier`'s tier-0 write, #702
-   * — the record is tier-0, so it must stay plain-`get()`-readable in-session).
+   * envelope (#691). The lazy LRU is evicted on EVERY call — it is never
+   * re-seeded, since a lazy `#getRaw` miss refetches and decodes the fresh
+   * envelope via its adapter fallback (a stale LRU entry after a tier-0
+   * `putAtTier` overwrite was the #702 lazy-mode gap). `null` → also evict
+   * the eager cache entry; an `entry` → set the eager cache to the given
+   * decoded record/version (used by `demote()` landing back at tier 0 and
+   * `putAtTier`'s tier-0 write, #702 — the record is tier-0, so it must stay
+   * plain-`get()`-readable in-session).
    */
   syncCache(id: string, entry: { record: T; version: number } | null): void
   /** Emit `_source`/`_sourceTs` provenance fields when a source is supplied. */


### PR DESCRIPTION
Closes #701. Closes #702. Extends the #691 law (PR #700): elevated (`_tier > 0`) records are invisible on tier-0 surfaces — explicit gates before any key resolution.

## #701 — four decode-site gates
- `ensureHydrated` + `hydrateFromSnapshot`: elevated envelopes are skipped — **a single elevated record no longer bricks the whole collection cold-session** (both hydration loops; gate-independence proven per-loop by selective revert).
- Lazy `#getRaw` miss: gate before decrypt → `null` in **both** sessions (previously the elevating session **leaked tier plaintext through the warm CEK cache** — `decryptRecord(env, {id})` hit the cache — while cold sessions threw).
- `reveal()`: elevated → the same domain not-found error as a missing id (no elevation disclosure, never a raw `InvalidKeyError`).
- All collection.ts edits are net-zero in-line condition folds — file line count byte-identical to main; ceilings untouched.

## #702 — putAtTier cache coherence
After its raw write: tier > 0 → evict (invisible on tier-0 surfaces); tier 0 → canonical codec re-seed (mirrors demote-to-0). The whole-branch review caught a lazy-mode gap in the first cut — `syncCache` now evicts the lazy LRU on every call (re-seed included), so lazy reads refetch the fresh envelope; RED re-proven for the stale-LRU case.

## Verification
- TDD throughout; every RED reproduced and documented (brick, warm-leak, cold-throw, `InvalidKeyError`, stale `'Old'`/`'V1'`/`'L1'`).
- Full hub suite 500 files / 4072 tests green; typecheck/lint/`check:architecture` clean; per-task reviews + fable whole-branch review (ACCEPT after the in-branch fix landed).
- The review's adversarial sweep also mapped the remaining pre-existing tier-unaware residue — filed as #706 (listPage/scan leak+brick, top priority), #707 (write-path priors), #708 (tier×sync/migration audit), #709 (tiers×indexing). With this PR, the primary read spine (get eager/lazy, hydration, cache-built queries, det scans, verify doors, findByDigest, reveal, getMany, list, lazyQuery) is uniformly gated.

Plan: `docs/superpowers/plans/2026-07-15-tier-cache-coherence.md` (design per the #691 spec).