### PR TITLE
fix(hub): listPage/scan/aggregate skip elevated records; lazy count() eager parity (#706)

### DIFF
--- a/docs/superpowers/plans/2026-07-15-listpage-scan-tier-gate.md
+++ b/docs/superpowers/plans/2026-07-15-listpage-scan-tier-gate.md
@@ -1,0 +1,223 @@
+# #706 listPage/scan Tier Gates — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the last ordinary public tier-0 read surface violating the #691 law: `listPage`/`scan` (warm-session plaintext leak, cold-session brick, eager-cache poisoning amplifier) + the lazy `count()` divergence (#706).
+
+**Architecture:** The #691 law (spec `docs/superpowers/specs/2026-07-15-tier-unaware-reads-design.md`, user-approved; extended by #700/#710): elevated (`_tier > 0`) records are invisible on tier-0 surfaces — explicit gates BEFORE any decrypt, never try/catch. Gating `decryptPage` + the scan fallback also kills the poisoning amplifier for free (the opportunistic cache fill only sees decrypt survivors). Lazy `count()` gains eager-parity by counting only live tier-0 envelopes via a small extracted helper (`kernel/lazy-count.ts`) — collection.ts is at its exact ceiling, and the ceiling ratchet exists precisely to push such logic off the god-file.
+
+**Tech Stack:** TypeScript ESM, vitest. Branch `fix/706-listpage-scan-tier-gate` (created, on main fb6cb93c).
+
+## Global Constraints
+
+- NEVER add Claude/Anthropic attribution to commits/PRs/changelogs.
+- NEVER reference the private pilot client by name — grep the diff before each commit.
+- Ceilings exact zero slack (checker = `wc -l` + 1): collection.ts 4549, vault.ts 3959, noydb.ts 2396. collection.ts edits must be NET-ZERO overall per task (in-line folds; comment-line compression; the count() rewrite trades its body for a helper call — see Task 2's line budget). Never edit ceiling values; never touch vault.ts/noydb.ts.
+- TDD: RED verified before implementing, every test. Run from `packages/hub/`: `pnpm vitest run <path>`.
+- No new deps; no timing assertions.
+
+---
+
+### Task 1: gate decryptPage + the scan fallback (the CRITICAL leak/brick/poisoning)
+
+**Files:**
+- Modify: `packages/hub/src/kernel/collection.ts` (2 sites, net-zero)
+- Modify: `packages/hub/__tests__/tier0-read-paths.test.ts` (append describe; fixtures exist)
+
+**Interfaces:**
+- Consumes: existing `memoryStore` fixture; `EncryptedEnvelope._tier`.
+- Produces: a `memoryStoreWithListPage()` fixture variant (Task 2 does not need it, but keep it exported-in-file for future tests).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/hub/__tests__/tier0-read-paths.test.ts`. The existing `memoryStore()` has no `listPage`, so `collection.listPage()` takes the **fallback** path with it. For the **native** path, add a fixture variant wrapping `memoryStore()` with a `listPage(vault, coll, cursor, limit)` implementation (sorted ids, `{ items: [{ id, envelope }...], nextCursor }` — check the exact `ListPageResult` shape in `src/kernel/types.ts` and any existing adapter listPage for reference, e.g. to-memory's, and mirror it).
+
+```ts
+describe('#706 listPage/scan: elevated records are invisible — no leak, no brick, no cache poisoning', () => {
+  function pageHarness(native: boolean) {
+    const base = memoryStore()
+    const store = native ? withListPage(base) : base   // withListPage = the new fixture wrapper
+    const open = async () => {
+      const db = await createNoydb({ store, user: 'owner', secret: 'pw-706', tiersStrategy: withTiers() })
+      const vault = await db.openVault('v1')
+      const docs = vault.collection<User>('docs', { tiers: [0, 1], perRecordKeys: true })
+      return { docs }
+    }
+    return { open }
+  }
+
+  for (const native of [false, true]) {
+    const label = native ? 'native adapter.listPage' : 'fallback list()+get()'
+    it(`${label}: warm session — elevated record absent from the page, cache NOT poisoned`, async () => {
+      const h = pageHarness(native)
+      const { docs } = await h.open()
+      await docs.put('a', { name: 'stays' })
+      await docs.put('b', { name: 'moves' })
+      await docs.elevate('b', 1)
+      // Pre-#706 (warm, perRecordKeys): b's plaintext egressed in page.items
+      // via the warm cekCache — audit-free — and the opportunistic cache fill
+      // seeded the eager cache with it.
+      const page = await docs.listPage({ limit: 10 })
+      expect(page.items.map(r => r.name)).toEqual(['stays'])
+      expect(await docs.get('b')).toBeNull() // poisoning pin: the fill never saw b
+    })
+
+    it(`${label}: cold session — the scan survives the elevated record`, async () => {
+      const h = pageHarness(native)
+      const { docs } = await h.open()
+      await docs.put('a', { name: 'stays' })
+      await docs.put('b', { name: 'moves' })
+      await docs.elevate('b', 1)
+      const cold = await h.open()
+      // Pre-#706: InvalidKeyError from the first elevated envelope bricked
+      // every listPage/scan/aggregate over the collection.
+      const page = await cold.docs.listPage({ limit: 10 })
+      expect(page.items.map(r => r.name)).toEqual(['stays'])
+    })
+  }
+
+  it('scan (and aggregate) over a collection with an elevated record yields only tier-0 rows', async () => {
+    const h = pageHarness(false)
+    const { docs } = await h.open()
+    await docs.put('a', { name: 'stays' })
+    await docs.put('b', { name: 'moves' })
+    await docs.elevate('b', 1)
+    const seen: string[] = []
+    for await (const rec of docs.scan({ pageSize: 1 })) seen.push(rec.name as string)
+    expect(seen).toEqual(['stays'])
+  })
+})
+```
+
+Adapt only mechanics (option/response shapes) from real code; never weaken asserts. If a RED expectation doesn't reproduce (the whole-branch reviewer of #710 repro'd both: warm `['moves','stays']`, cold `InvalidKeyError`), STOP → BLOCKED with output.
+
+- [ ] **Step 2: Run to verify RED**
+
+`pnpm vitest run __tests__/tier0-read-paths.test.ts -t '#706'`
+Expected: warm tests FAIL with the elevated name present (and/or `get('b')` non-null); cold tests reject with `InvalidKeyError`.
+
+- [ ] **Step 3: Implement — two net-zero edits in collection.ts**
+
+(a) `decryptPage` (~:3730): compress the two comment lines into one and add the gate, keeping the loop net-zero:
+```ts
+    for (const { id, envelope } of items) {
+      // Public scan/listPage output + opportunistic cache fill — sealed fields stay handles; elevated records are invisible (#706: gate BEFORE decrypt or the warm cekCache leaks tier plaintext, audit-free).
+      if ((envelope._tier ?? 0) > 0) continue
+      const record = await this.codec.decryptRecord(envelope, { id, sealedAsHandles: true })
+      if (record === null) continue // shredded (tombstone) — skip the page row
+```
+(b) scan fallback (~:3630) — in-place fold:
+```ts
+      if (envelope && (envelope._tier ?? 0) === 0) {
+```
+Verify `wc -l` on collection.ts is unchanged vs `git show fb6cb93c:packages/hub/src/kernel/collection.ts | wc -l`.
+
+- [ ] **Step 4: GREEN + regression**
+
+`pnpm vitest run __tests__/tier0-read-paths.test.ts __tests__/hierarchical-tiers.test.ts` → PASS. `node scripts/check-architecture.mjs` (root) → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/kernel/collection.ts packages/hub/__tests__/tier0-read-paths.test.ts
+git commit -m "fix(hub): listPage/scan skip elevated records — no page leak, no cold-session brick, no cache poisoning (#706)"
+```
+
+---
+
+### Task 2: lazy count() eager-parity (live tier-0 envelopes only)
+
+**Files:**
+- Create: `packages/hub/src/kernel/lazy-count.ts`
+- Modify: `packages/hub/src/kernel/collection.ts` (lazy branch of `count()` + one import; net-zero — see budget)
+- Modify: `packages/hub/__tests__/tier0-read-paths.test.ts` (append tests)
+
+**Interfaces:**
+- Consumes: `NoydbStore`, `isTombstone`/`isDeleteMarker` from `./enclave/index.js` (check the exact barrel path used by collection.ts's own imports).
+- Produces: `export async function countLiveEnvelopes(adapter: NoydbStore, vault: string, name: string, storeCiphertext: boolean): Promise<number>` — counts ids whose envelope exists, is not a tombstone/delete-marker, and has `(env._tier ?? 0) === 0`. No decryption — envelope inspection only.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe('#706 lazy count(): eager parity — elevated and deleted envelopes are not counted', () => {
+  it('lazy count matches eager count with an elevated record present', async () => {
+    const store = memoryStore()
+    const open = async (lazy: boolean) => {
+      const db = await createNoydb({ store, user: 'owner', secret: 'pw-706-count', tiersStrategy: withTiers() })
+      const vault = await db.openVault('v1')
+      return vault.collection<User>(lazy ? 'lc' : 'lc', lazy
+        ? { tiers: [0, 1], perRecordKeys: true, prefetch: false, cache: { maxRecords: 100 } }
+        : { tiers: [0, 1], perRecordKeys: true })
+    }
+    const docs = await open(true)
+    await docs.put('a', { name: 'a' })
+    await docs.put('b', { name: 'b' })
+    await docs.elevate('b', 1)
+    // Pre-#706: lazy count() returned raw adapter.list().length = 2.
+    expect(await docs.count()).toBe(1)
+    const eager = await open(false) // cold second session, eager mode, same store
+    expect(await eager.count()).toBe(1) // parity (hydration skips elevated, #701)
+  })
+
+  it('lazy count skips a hand-written delete-marker (raw list() counted it)', async () => {
+    // Build on the tombstone fixture pattern from hierarchical-tiers.test.ts
+    // ('#691 fold-ins' third test): write buildDeleteMarker(...) into the store
+    // for an id, then assert lazy count() excludes it.
+  })
+})
+```
+Write the second test fully (the pattern — `buildDeleteMarker(live._v, 'owner')` after a put — is in `__tests__/hierarchical-tiers.test.ts`'s '#691 fold-ins' block; import path per that file).
+
+- [ ] **Step 2: Run to verify RED** — lazy count returns 2 (and the marker test counts the marker).
+
+- [ ] **Step 3: Create `kernel/lazy-count.ts`**
+
+```ts
+/**
+ * Lazy-mode `count()` support (#706): count ids whose envelope is LIVE at
+ * tier 0 — parity with eager count (the hydrated cache excludes tombstones,
+ * delete markers, and elevated records, #701). Envelope inspection only —
+ * no record body is ever decrypted here.
+ */
+import type { NoydbStore } from './types.js'
+import { isTombstone, isDeleteMarker } from './enclave/index.js'
+
+export async function countLiveEnvelopes(
+  adapter: NoydbStore, vault: string, name: string, storeCiphertext: boolean,
+): Promise<number> {
+  const ids = await adapter.list(vault, name)
+  let n = 0
+  for (const id of ids) {
+    const env = await adapter.get(vault, name, id)
+    if (env && !isTombstone(env, storeCiphertext) && !isDeleteMarker(env) && (env._tier ?? 0) === 0) n++
+  }
+  return n
+}
+```
+(Verify the predicate import path/signature against collection.ts's own imports; match file-header style of siblings like `best-effort-revert.ts`.)
+
+- [ ] **Step 4: Rewire collection.ts count() — NET-ZERO budget**
+
+Replace the lazy branch's single line:
+```ts
+      return countLiveEnvelopes(this.adapter, this.vault, this.name, this.storeCiphertext)
+```
+(1-for-1 swap) and update the method's doc comment IN PLACE (same line count) — it currently claims lazy mode "avoids loading any record bodies" and is "still correct"; keep the no-bodies claim (true — envelope inspection only) and note tier/tombstone parity (#706). The new `import { countLiveEnvelopes } from './lazy-count.js'` line costs +1 → remove one line elsewhere via a mechanical join (or append the named import to an existing `./`-sibling import line if one matches the module path — it won't, so plan the shrink-join; document it in your report). `node scripts/check-architecture.mjs` must pass with values unedited.
+
+- [ ] **Step 5: GREEN + regression** — the #706 tests + `__tests__/hierarchical-tiers.test.ts` + full-file `tier0-read-paths.test.ts`; typecheck + lint (new file included).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/kernel/lazy-count.ts packages/hub/src/kernel/collection.ts packages/hub/__tests__/tier0-read-paths.test.ts
+git commit -m "fix(hub): lazy count() counts only live tier-0 envelopes — eager parity (#706)"
+```
+
+---
+
+### Final: full suite + whole-branch review + changeset + PR
+
+- [ ] `pnpm --filter @noy-db/hub test` + typecheck + lint + `pnpm check:architecture` — green.
+- [ ] Whole-branch review (fable — the leak class earned it twice already).
+- [ ] Local changeset: `@noy-db/hub` patch — listPage/scan/aggregate skip elevated records (no page leak, no cold brick, no cache poisoning); lazy count() eager parity (#706).
+- [ ] PR → main with `Closes #706`.

--- a/packages/hub/__tests__/tier0-read-paths.test.ts
+++ b/packages/hub/__tests__/tier0-read-paths.test.ts
@@ -54,6 +54,29 @@ function memoryStore(): NoydbStore {
   }
 }
 
+/**
+ * #706 fixture: wraps a base store with a native `listPage` implementation
+ * (sorted-id cursor pagination), mirroring `to-memory`'s `listPage`. Lets
+ * tests exercise the native `decryptPage` path, not just the fallback.
+ */
+function withListPage(base: NoydbStore): NoydbStore {
+  return {
+    ...base,
+    async listPage(vault, collection, cursor, limit = 100) {
+      const ids = (await base.list(vault, collection)).slice().sort()
+      const start = cursor ? parseInt(cursor, 10) : 0
+      const end = Math.min(start + limit, ids.length)
+      const items: Array<{ id: string; envelope: EncryptedEnvelope }> = []
+      for (let i = start; i < end; i++) {
+        const id = ids[i]!
+        const envelope = await base.get(vault, collection, id)
+        if (envelope) items.push({ id, envelope })
+      }
+      return { items, nextCursor: end < ids.length ? String(end) : null }
+    },
+  }
+}
+
 interface User extends Record<string, unknown> { name?: string; password?: string; email?: string; a1?: string; a2?: string }
 
 /** One store, reopenable: open() twice = cold second session over the same ciphertext. */
@@ -256,4 +279,59 @@ describe('#701 hydration / lazy reads / reveal: elevated records are invisible, 
     // a genuinely absent id, no elevation disclosure, never InvalidKeyError.
     await expect(users.reveal('r1', 'email')).rejects.toThrow(/not found/)
   }, 60_000)
+})
+
+describe('#706 listPage/scan: elevated records are invisible — no leak, no brick, no cache poisoning', () => {
+  function pageHarness(native: boolean) {
+    const base = memoryStore()
+    const store = native ? withListPage(base) : base
+    const open = async () => {
+      const db = await createNoydb({ store, user: 'owner', secret: 'pw-706', tiersStrategy: withTiers() })
+      const vault = await db.openVault('v1')
+      const docs = vault.collection<User>('docs', { tiers: [0, 1], perRecordKeys: true })
+      return { docs }
+    }
+    return { open }
+  }
+
+  for (const native of [false, true]) {
+    const label = native ? 'native adapter.listPage' : 'fallback list()+get()'
+    it(`${label}: warm session — elevated record absent from the page, cache NOT poisoned`, async () => {
+      const h = pageHarness(native)
+      const { docs } = await h.open()
+      await docs.put('a', { name: 'stays' })
+      await docs.put('b', { name: 'moves' })
+      await docs.elevate('b', 1)
+      // Pre-#706 (warm, perRecordKeys): b's plaintext egressed in page.items
+      // via the warm cekCache — audit-free — and the opportunistic cache fill
+      // seeded the eager cache with it.
+      const page = await docs.listPage({ limit: 10 })
+      expect(page.items.map(r => r.name)).toEqual(['stays'])
+      expect(await docs.get('b')).toBeNull() // poisoning pin: the fill never saw b
+    })
+
+    it(`${label}: cold session — the scan survives the elevated record`, async () => {
+      const h = pageHarness(native)
+      const { docs } = await h.open()
+      await docs.put('a', { name: 'stays' })
+      await docs.put('b', { name: 'moves' })
+      await docs.elevate('b', 1)
+      const cold = await h.open()
+      // Pre-#706: InvalidKeyError from the first elevated envelope bricked
+      // every listPage/scan/aggregate over the collection.
+      const page = await cold.docs.listPage({ limit: 10 })
+      expect(page.items.map(r => r.name)).toEqual(['stays'])
+    })
+  }
+
+  it('scan (and aggregate) over a collection with an elevated record yields only tier-0 rows', async () => {
+    const h = pageHarness(false)
+    const { docs } = await h.open()
+    await docs.put('a', { name: 'stays' })
+    await docs.put('b', { name: 'moves' })
+    await docs.elevate('b', 1)
+    const seen: string[] = []
+    for await (const rec of docs.scan({ pageSize: 1 })) seen.push(rec.name as string)
+    expect(seen).toEqual(['stays'])
+  })
 })

--- a/packages/hub/__tests__/tier0-read-paths.test.ts
+++ b/packages/hub/__tests__/tier0-read-paths.test.ts
@@ -14,6 +14,7 @@ import { createNoydb, ConflictError } from '../src/index.js'
 import { withTiers } from '../src/with-audit/tiers/index.js'
 import { withClassified } from '../src/via/classified/active.js'
 import { classified } from '../src/via/classified/presets.js'
+import { buildDeleteMarker } from '../src/kernel/enclave/index.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
 
 function memoryStore(): NoydbStore {
@@ -333,5 +334,39 @@ describe('#706 listPage/scan: elevated records are invisible — no leak, no bri
     const seen: string[] = []
     for await (const rec of docs.scan({ pageSize: 1 })) seen.push(rec.name as string)
     expect(seen).toEqual(['stays'])
+  })
+})
+
+describe('#706 lazy count(): eager parity — elevated and deleted envelopes are not counted', () => {
+  it('lazy count matches eager count with an elevated record present', async () => {
+    const store = memoryStore()
+    const open = async (lazy: boolean) => {
+      const db = await createNoydb({ store, user: 'owner', secret: 'pw-706-count', tiersStrategy: withTiers() })
+      const vault = await db.openVault('v1')
+      return vault.collection<User>(lazy ? 'lc' : 'lc', lazy
+        ? { tiers: [0, 1], perRecordKeys: true, prefetch: false, cache: { maxRecords: 100 } }
+        : { tiers: [0, 1], perRecordKeys: true })
+    }
+    const docs = await open(true)
+    await docs.put('a', { name: 'a' })
+    await docs.put('b', { name: 'b' })
+    await docs.elevate('b', 1)
+    // Pre-#706: lazy count() returned raw adapter.list().length = 2.
+    expect(await docs.count()).toBe(1)
+    const eager = await open(false) // cold second session, eager mode, same store
+    expect(await eager.count()).toBe(1) // parity (hydration skips elevated, #701)
+  })
+
+  it('lazy count skips a hand-written delete-marker (raw list() counted it)', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, user: 'owner', secret: 'pw-706-count-del', tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<User>('mc', { tiers: [0, 1], perRecordKeys: true, prefetch: false, cache: { maxRecords: 100 } })
+    await docs.put('a', { name: 'a' })
+    await docs.put('gone', { name: 'gone' })
+    const live = (await store.get('v1', 'mc', 'gone'))!
+    await store.put('v1', 'mc', 'gone', buildDeleteMarker(live._v, 'owner'))
+    // Pre-#706: raw adapter.list().length counted the marker id too (== 2).
+    expect(await docs.count()).toBe(1)
   })
 })

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -25,6 +25,7 @@ import {
   type EnclaveKey,
   type SealedShredSlot,
 } from './enclave/index.js'
+import { countLiveEnvelopes } from './lazy-count.js'
 import {
   classifySealedShred as classifySealedShredImpl,
   type TiersContext,
@@ -3193,8 +3194,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
           if (op.collectionName === this.name) {
             await this._invalidateCacheEntry(op.id)
           } else if (this.derivationSource) {
-            const sibling = this.derivationSource.getCollection(op.collectionName)
-            await sibling._invalidateCacheEntry(op.id)
+            await this.derivationSource.getCollection(op.collectionName)._invalidateCacheEntry(op.id)
           }
         } catch { /* best-effort */ }
       }
@@ -3564,13 +3564,13 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   /**
    * Count records in the collection.
    *
-   * In eager mode this returns the in-memory cache size (instant). In
-   * lazy mode it asks the adapter via `list()` to enumerate ids — slower
-   * but still correct, and avoids loading any record bodies into memory.
+   * In eager mode this returns the in-memory cache size (instant). In lazy
+   * mode it counts only LIVE tier-0 envelopes via envelope inspection — no
+   * record bodies loaded — matching eager's tombstone/tier exclusion (#706).
    */
   async count(): Promise<number> {
     if (this.lazy) {
-      return (await this.adapter.list(this.vault, this.name)).length
+      return countLiveEnvelopes(this.adapter, this.vault, this.name, this.storeCiphertext)
     }
     await this.ensureHydrated()
     return this.cache.size

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -3626,7 +3626,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     for (let i = start; i < end; i++) {
       const id = ids[i]!
       const envelope = await this.adapter.get(this.vault, this.name, id)
-      if (envelope) {
+      if (envelope && (envelope._tier ?? 0) === 0) {
         const record = await this.codec.decryptRecord(envelope, { id, sealedAsHandles: true })
         if (record === null) continue // shredded (tombstone) — skip
         items.push(record)
@@ -3728,8 +3728,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   ): Promise<Array<{ id: string; record: T; version: number }>> {
     const out: Array<{ id: string; record: T; version: number }> = []
     for (const { id, envelope } of items) {
-      // Public scan/listPage output (and the opportunistic cache fill in
-      // listPage) — sealed fields surface as handles, never plaintext.
+      // Public scan/listPage output + opportunistic cache fill — sealed fields stay handles; elevated records are invisible (#706: gate BEFORE decrypt or the warm cekCache leaks tier plaintext, audit-free).
+      if ((envelope._tier ?? 0) > 0) continue
       const record = await this.codec.decryptRecord(envelope, { id, sealedAsHandles: true })
       if (record === null) continue // shredded (tombstone) — skip the page row
       out.push({ id, record, version: envelope._v })

--- a/packages/hub/src/kernel/lazy-count.ts
+++ b/packages/hub/src/kernel/lazy-count.ts
@@ -1,0 +1,20 @@
+/**
+ * Lazy-mode `count()` support (#706): count ids whose envelope is LIVE at
+ * tier 0 — parity with eager count (the hydrated cache excludes tombstones,
+ * delete markers, and elevated records, #701). Envelope inspection only —
+ * no record body is ever decrypted here.
+ */
+import type { NoydbStore } from './types.js'
+import { isTombstone, isDeleteMarker } from './enclave/index.js'
+
+export async function countLiveEnvelopes(
+  adapter: NoydbStore, vault: string, name: string, storeCiphertext: boolean,
+): Promise<number> {
+  const ids = await adapter.list(vault, name)
+  let n = 0
+  for (const id of ids) {
+    const env = await adapter.get(vault, name, id)
+    if (env && !isTombstone(env, storeCiphertext) && !isDeleteMarker(env) && (env._tier ?? 0) === 0) n++
+  }
+  return n
+}


### PR DESCRIPTION
Closes #706. Third arc of the tier-invisibility campaign (#691/PR #700 → #701+#702/PR #710 → this): elevated (`_tier > 0`) records are invisible on tier-0 surfaces, gates before any key resolution.

## What this closes (all failure modes previously PROVEN by the #710 review)
- **Warm-session plaintext leak:** the elevating session's `listPage()` returned the elevated record's plaintext in `page.items` via the warm CEK cache — audit-free. Now gated pre-decrypt in `decryptPage` (native path) and the `list()+get()` fallback.
- **Cold-session brick:** one elevated record threw `InvalidKeyError` out of every `listPage`/`scan`/`aggregate` over the collection. Now skipped.
- **Cache-poisoning amplifier:** the opportunistic page fill seeded decoded elevated plaintext into the eager cache (re-opening the gated `get()`/index surfaces). Both fills are now downstream of the gates — structurally dead (pinned by a test that proves the fill was the poisoner: `get()` flips null→plaintext across the single `listPage` call pre-fix).
- **Lazy `count()` divergence:** raw `adapter.list().length` counted elevated records *and* sync delete-markers. New `kernel/lazy-count.ts` counts only live tier-0 envelopes (envelope inspection, zero decryption) — parity with eager count by construction (guard byte-matches hydration's).

`scan()`/`.aggregate()` route through the same two sites (verified: `decryptPage`'s sole caller is `listPage`; ScanBuilder pages via the same provider and handles empty-page-with-cursor windows correctly).

## Verification
- TDD; every RED reproduced (warm `['stays','moves']`, cold `InvalidKeyError`, count `2 vs 1`, marker over-count) — Task 1's reviewer re-proved RED in a pre-fix worktree.
- Full hub suite 500 files / 4080 tests green; typecheck/lint/`check:architecture` clean; collection.ts byte-count identical to main (net-zero folds + one funded mechanical shrink-join, both reviewer-verified).
- Fable whole-branch review: **ACCEPT** — campaign statement: with #700 + #710 + this, every ordinary public tier-0 read surface now complies with the invisibility law. Newly proven residue filed: **#712** (with-history × tiers — prior-version plaintext leak, incl. at-rest CEK question; + CRDT getRaw oracle) and **#713** (lazy count N+1 perf on remote stores). Existing rings: #707 (write priors), #708 (sync/migration), #709 (indexing).

Plan: `docs/superpowers/plans/2026-07-15-listpage-scan-tier-gate.md`