### PR TITLE
fix(hub): write-path prior + history read gates for elevated records; lazy count batching (#707, #712 read-gate, #713)

### DIFF
--- a/docs/superpowers/plans/2026-07-15-read-side-tier-gates.md
+++ b/docs/superpowers/plans/2026-07-15-read-side-tier-gates.md
@@ -1,0 +1,247 @@
+# Arc 1 — Read-side Tier Gates (#707 + #712 read-gate + CRDT getRaw + #713)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the write-path prior-read leak (#707), the with-history read leak (#712 *read-gate* — the at-rest hardening is a separate later arc), the CRDT `getRaw` oracle, and make lazy `count()` O(pages) not O(records) (#713).
+
+**Architecture:** The tier-invisibility law (spec `docs/superpowers/specs/2026-07-15-tier-unaware-reads-design.md`, extended by PRs #700/#710/#714): elevated (`_tier > 0`) records are invisible on tier-0 surfaces — explicit gates before any decrypt, never try/catch (a warm CEK cache otherwise leaks tier plaintext). **Key #712 mechanism:** history snapshots keep their tier-0-wrapped CEKs and carry no `_tier`, so `history()`/`getVersion()` cannot gate on the history envelope's tier — they gate on the **live** record's tier (a cheap envelope peek) plus a defensive per-entry `_tier` skip.
+
+**Tech Stack:** TypeScript ESM, vitest. Branch `fix/707-712rg-write-history-gates` (created, on main 1fed09c8).
+
+## Global Constraints
+
+- NEVER add Claude/Anthropic attribution to commits/PRs/changelogs.
+- NEVER reference the private pilot client by name — grep the diff before each commit.
+- Ceilings exact zero slack (checker = `wc -l` + 1): collection.ts 4549, vault.ts 3959, noydb.ts 2396. **Line budget across this arc:** Task 1 removes `resolveGatePrior`'s 5-line try/catch → 2-line gate (frees ~3 lines); Task 2 adds ~+4 (import + history peek/skip + getVersion peek). Net ~+1 → fund with ONE mechanical shrink-join. Verify collection.ts `wc -l` == `git show 1fed09c8:packages/hub/src/kernel/collection.ts | wc -l` after EACH task. Never edit ceiling values; never touch vault.ts/noydb.ts.
+- TDD: RED verified before implementing, every test. Run from `packages/hub/`: `pnpm vitest run <path>`.
+- No new deps; no timing assertions.
+
+---
+
+### Task 1: #707 — gate write-path prior reads (elevated ≡ missing to hooks/gates)
+
+**Files:**
+- Modify: `packages/hub/src/kernel/collection.ts` (4 prior-read helpers; net ≤0 lines)
+- Modify: `packages/hub/__tests__/tier0-read-paths.test.ts` (append describe; fixtures exist)
+
+**Interfaces:**
+- Consumes: existing `tieredClassifiedHarness` / `memoryStore`; `EncryptedEnvelope._tier`.
+- Produces: nothing downstream (Tasks 2/3 independent).
+
+Background — the four helpers each already have a "no prior" branch (missing/tombstone). An elevated existing record must take that same branch so no elevated plaintext reaches write hooks / gate handlers / the i18n audit accessor. Current sites (line numbers ±3):
+- `resolveDensifyPrior` (~1616): lazy branch `if (!env) return undefined`.
+- `#priorForHook` (~1668): lazy branch `if (!env) return { record: null, version: 0 }`.
+- `resolvePriorValues` (~1692): `if (!env || isTombstone(env, this.storeCiphertext)) return undefined`.
+- `resolveGatePrior` (~1704–1709): `if (!env) return …`; then a `try { decryptRecord } catch { record: null }` — the spec-forbidden shape.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `packages/hub/__tests__/tier0-read-paths.test.ts`:
+
+```ts
+describe('#707 write-path prior reads: elevated ≡ missing to hooks/gates/audit', () => {
+  it('a write hook fired for a put over an elevated id receives a null prior, never elevated plaintext', async () => {
+    const store = memoryStore()
+    const priors: unknown[] = []
+    const db = await createNoydb({ store, user: 'owner', secret: 'pw-707', tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<User>('docs', {
+      tiers: [0, 1], perRecordKeys: true, prefetch: false, cache: { maxRecords: 100 },
+      hooks: { beforePut: ({ prior }) => { priors.push(prior); return undefined } }, // adapt to the real hook shape
+    })
+    await docs.put('d1', { name: 'secret' })
+    await docs.elevate('d1', 1)
+    await docs.put('d1', { name: 'overwrite' })       // tier-0 write over an elevated id
+    // Pre-#707 (warm cekCache): the hook's `prior` was the elevated plaintext { name: 'secret' }.
+    expect(priors.every(p => p === null || (p as User)?.name !== 'secret')).toBe(true)
+  })
+
+  it('i18nProvenance over an elevated id returns undefined, not the prior marker', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, user: 'owner', secret: 'pw-707b', tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<User>('docs', { tiers: [0, 1], perRecordKeys: true, prefetch: false, cache: { maxRecords: 100 } })
+    await docs.put('d1', { name: 'x' })
+    await docs.elevate('d1', 1)
+    expect(await docs.i18nProvenance('d1')).toBeUndefined()
+  })
+})
+```
+
+Inspect the actual write-hook registration API (grep `beforePut`/`writeHooks`/`hooks:` in the kernel + existing tests, e.g. `__tests__/*hook*`, and the `HookContext`/`before` shape used by `#priorForHook`) and adapt the hook fixture to the real surface — the assertion (prior is never the elevated plaintext) is what matters. If no public hook seam exercises `#priorForHook` cleanly, drive it through whichever public write path fires `beforePut`/gate priors; if `resolveGatePrior` needs a gate subsystem (`subsystemBus.gateNeedsPrior`), reuse the pattern from an existing gate test (grep `resolveGatePrior`/`gateNeedsPrior` tests). Never weaken an assert; if a RED doesn't reproduce, STOP → BLOCKED with output.
+
+- [ ] **Step 2: Run to verify RED**
+
+`pnpm vitest run __tests__/tier0-read-paths.test.ts -t '#707'` → FAIL (hook prior is the elevated plaintext; i18nProvenance returns the marker). If the warm-leak path can't be hit through the chosen public API, note it and construct the minimal driver that does.
+
+- [ ] **Step 3: Implement the gates (net ≤ 0 lines)**
+
+(a) `resolveDensifyPrior` lazy branch: `if (!env || (env._tier ?? 0) > 0) return undefined` (net-zero).
+(b) `#priorForHook` lazy branch: `if (!env || (env._tier ?? 0) > 0) return { record: null, version: 0 }` (net-zero — elevated ≡ fully missing; version 0 matches the missing case).
+(c) `resolvePriorValues`: `if (!env || isTombstone(env, this.storeCiphertext) || (env._tier ?? 0) > 0) return undefined` (net-zero).
+(d) `resolveGatePrior` — replace the `try/catch` (frees ~3 lines):
+```ts
+    if ((env._tier ?? 0) > 0) return { env, record: null, elided: false } // #707: elevated invisible to gate handlers — deterministic, not a swallowed InvalidKeyError
+    return { env, record: await this.codec.decryptRecord(env, { skipValidation: true, id }), elided: false }
+```
+Removing the catch means a genuine (non-tier) decrypt failure now propagates instead of silently nulling — this is intended (the catch was the spec-forbidden shape masking the tier error). Flag it to the reviewer; if a regression test relied on the swallow for a NON-tier reason, STOP and report rather than re-adding the catch.
+
+- [ ] **Step 4: GREEN + regression + ceiling**
+
+`pnpm vitest run __tests__/tier0-read-paths.test.ts __tests__/hierarchical-tiers.test.ts __tests__/classified` → PASS (plus any hook/gate suites the grep surfaced). `node scripts/check-architecture.mjs` → PASS. Confirm collection.ts `wc -l` ≤ the base (Task 2 needs the freed lines). Also: does a plain `put()` over an elevated id silently write it back at tier 0 (demotion)? Note the observed behavior in your report — if it silently demotes, that's a **separate finding to file**, not part of this task.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/kernel/collection.ts packages/hub/__tests__/tier0-read-paths.test.ts
+git commit -m "fix(hub): write-path prior reads treat elevated records as missing — no elevated plaintext to hooks/gates (#707)"
+```
+
+---
+
+### Task 2: #712 read-gate — history/getVersion/revert + CRDT getRaw
+
+**Files:**
+- Create: `packages/hub/src/kernel/tier-visibility.ts`
+- Modify: `packages/hub/src/kernel/collection.ts` (history, getVersion, getRaw; funded by Task 1's freed lines + ≤1 shrink-join)
+- Modify: `packages/hub/__tests__/tier0-read-paths.test.ts` (append)
+
+**Interfaces:**
+- Consumes: `NoydbStore`, `EncryptedEnvelope._tier`.
+- Produces: `export async function liveRecordIsElevated(adapter: NoydbStore, vault: string, name: string, id: string): Promise<boolean>` — peeks the live envelope, returns `(env?._tier ?? 0) > 0`. No decryption.
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe('#712 read-gate: elevated records leak no prior-version plaintext, warm or cold', () => {
+  function historyHarness() {
+    const store = memoryStore()
+    const open = async () => {
+      const db = await createNoydb({ store, user: 'owner', secret: 'pw-712', tiersStrategy: withTiers(), historyStrategy: withHistory() })
+      const vault = await db.openVault('v1')
+      const docs = vault.collection<User>('docs', { tiers: [0, 1], perRecordKeys: true })
+      return { docs }
+    }
+    return { store, open }
+  }
+
+  it('history() and getVersion() are empty for an elevated record — warm AND cold', async () => {
+    const h = historyHarness()
+    const { docs } = await h.open()
+    await docs.put('d1', { name: 'v1-secret' })
+    await docs.put('d1', { name: 'v2-secret' })
+    await docs.elevate('d1', 1)
+    // Pre-#712: BOTH returned the prior-version plaintext (history envelopes keep tier-0 CEKs).
+    expect(await docs.history('d1')).toEqual([])
+    expect(await docs.getVersion('d1', 1)).toBeNull()
+    await expect(docs.revert('d1', 1)).rejects.toThrow()      // inherits getVersion → not found
+    const cold = await h.open()
+    expect(await cold.docs.history('d1')).toEqual([])
+    expect(await cold.docs.getVersion('d1', 1)).toBeNull()
+  })
+
+  it('history stays readable after demote back to tier 0', async () => {
+    const h = historyHarness()
+    const { docs } = await h.open()
+    await docs.put('d2', { name: 'a' })
+    await docs.put('d2', { name: 'b' })
+    await docs.elevate('d2', 1)
+    await docs.demote('d2', 0)
+    expect((await docs.history('d2')).length).toBeGreaterThan(0) // demoted record IS tier-0
+  })
+
+  it('CRDT getRaw returns null for an elevated record instead of throwing', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, user: 'owner', secret: 'pw-712c', tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<User>('cdocs', { tiers: [0, 1], crdt: 'lww-map' })
+    await docs.put('c1', { name: 'x' })
+    await docs.elevate('c1', 1)
+    expect(await docs.getRaw('c1')).toBeNull()
+  })
+}) 
+```
+Check `withHistory`'s real import + option name (grep existing history tests, e.g. `__tests__/*histor*`); check the CRDT collection option shape (`crdt: 'lww-map'`) and whether tiers+crdt compose in a fixture — if not, adapt to whatever minimal config reaches `getRaw`, keeping the assert (elevated → null, no throw).
+
+- [ ] **Step 2: RED** — `pnpm vitest run __tests__/tier0-read-paths.test.ts -t '#712'` → history/getVersion return the elevated plaintext (warm) / throw (cold); getRaw throws.
+
+- [ ] **Step 3: Create `kernel/tier-visibility.ts`**
+
+```ts
+/**
+ * Tier visibility helper (#712/#707): a tier-0 code path treats an elevated
+ * (_tier > 0) record as invisible. History reads gate on the LIVE record's
+ * tier — history snapshots keep their tier-0-wrapped CEKs and carry no _tier
+ * of their own, so an elevated record's prior versions would otherwise stay
+ * tier-0-decryptable (the read-gate closes the API surface; #712's at-rest
+ * arc rewraps the snapshot keys). Envelope inspection only — no decryption.
+ */
+import type { NoydbStore } from './types.js'
+
+export async function liveRecordIsElevated(
+  adapter: NoydbStore, vault: string, name: string, id: string,
+): Promise<boolean> {
+  const env = await adapter.get(vault, name, id)
+  return (env?._tier ?? 0) > 0
+}
+```
+(Match the file-header style of `lazy-count.ts` / `best-effort-revert.ts`. `hub-portable` guard: no Node built-ins — clean.)
+
+- [ ] **Step 4: Wire collection.ts (funded by Task 1)**
+
+Import: `import { liveRecordIsElevated } from './tier-visibility.js'`.
+- `history()` — after the `getHistoryEntries` fetch, guard the whole call and add a per-entry skip:
+```ts
+    if (await liveRecordIsElevated(this.adapter, this.vault, this.name, id)) return [] // #712: elevated ≡ invisible
+    ...
+    for (const env of envelopes) {
+      if ((env._tier ?? 0) > 0) continue // #712: defensive — a per-version tiered snapshot
+```
+- `getVersion()` — `if (!envelope || (envelope._tier ?? 0) > 0) return null` (net-zero fold) then `if (await liveRecordIsElevated(this.adapter, this.vault, this.name, id)) return null` (+1).
+- `getRaw()` (CRDT) — `if (!envelope || (envelope._tier ?? 0) > 0) return null` (net-zero fold).
+- `revert()` — unchanged (inherits `getVersion` → throws not-found).
+
+Confirm collection.ts `wc -l` == base; if +1 over, apply one mechanical shrink-join and document it.
+
+- [ ] **Step 5: GREEN + regression + ceiling** — the #712 tests + `__tests__/hierarchical-tiers.test.ts` + any history suite; `node scripts/check-architecture.mjs`; typecheck + lint (new file). Line count == base.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/kernel/tier-visibility.ts packages/hub/src/kernel/collection.ts packages/hub/__tests__/tier0-read-paths.test.ts
+git commit -m "fix(hub): history/getVersion/getRaw treat elevated records as missing — no prior-version plaintext leak (#712 read-gate)"
+```
+
+---
+
+### Task 3: #713 — lazy count() batches via adapter.listPage
+
+**Files:**
+- Modify: `packages/hub/src/kernel/lazy-count.ts`
+- Modify: `packages/hub/__tests__/tier0-read-paths.test.ts` (extend the lazy-count block, or a to-memory-native fixture)
+
+**Interfaces:**
+- Consumes: `NoydbStore.listPage?` (optional method — `ListPageResult` in `src/kernel/types.ts`), the existing live-tier-0 predicate.
+- Produces: same `countLiveEnvelopes` signature/behavior, fewer round-trips.
+
+- [ ] **Step 1: Write/extend the failing test** — assert `countLiveEnvelopes` (via lazy `count()`) is correct on a **native-listPage** store (use the `withListPage` fixture from the #706 tests) with a mix of live tier-0, elevated, and delete-marker ids; the current N+1 `list()+get()` path is correct but the test pins behavior parity when the batched path is used. (This task is a perf refactor: the RED is optional — its real gate is "same counts, fewer round-trips." Add a round-trip counter to the fixture — increment on each `get`/`listPage` — and assert the native path makes ≤ ⌈N/pageSize⌉+1 calls, while the fallback still works.)
+
+- [ ] **Step 2: Implement** — when `adapter.listPage` exists, page through `{ id, envelope }` items applying the same `!isTombstone && !isDeleteMarker && (env._tier ?? 0) === 0` predicate; else keep the `list()+get()` loop. No behavior change to the count.
+
+- [ ] **Step 3: GREEN + regression** — the #706 lazy-count tests + the new native-batched test + full `tier0-read-paths.test.ts`; typecheck + lint; `check:architecture` (hub-portable on lazy-count.ts).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/hub/src/kernel/lazy-count.ts packages/hub/__tests__/tier0-read-paths.test.ts
+git commit -m "perf(hub): lazy count() batches via adapter.listPage when available — O(pages) not O(records) (#713)"
+```
+
+---
+
+### Final: full suite + whole-branch review + changeset + PR
+
+- [ ] `pnpm --filter @noy-db/hub test` + typecheck + lint + `pnpm check:architecture` — green.
+- [ ] Whole-branch review (fable — gate correctness, `resolveGatePrior` catch-removal error semantics, no elevated-vs-missing distinguisher, the live-peek mechanism).
+- [ ] Local changeset: `@noy-db/hub` patch — write-path prior reads, history/getVersion/getRaw, treat elevated records as missing; lazy count() batches via listPage (#707, #712 read-gate, #713).
+- [ ] PR → main. `Closes #707`, `Closes #713`. **#712 stays open** (at-rest hardening is a follow-up arc) — reference it as "read-gate only."

--- a/packages/hub/__tests__/tier0-read-paths.test.ts
+++ b/packages/hub/__tests__/tier0-read-paths.test.ts
@@ -14,8 +14,12 @@ import { createNoydb, ConflictError } from '../src/index.js'
 import { withTiers } from '../src/with-audit/tiers/index.js'
 import { withClassified } from '../src/via/classified/active.js'
 import { classified } from '../src/via/classified/presets.js'
+import { withHistory } from '../src/with-commit/history/index.js'
+import { withI18n } from '../src/via/i18n/index.js'
+import { i18nText } from '../src/via/i18n/core.js'
 import { buildDeleteMarker } from '../src/kernel/enclave/index.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
+import type { GatePutEvent } from '../src/port/with/service-bus.js'
 
 function memoryStore(): NoydbStore {
   const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
@@ -368,5 +372,77 @@ describe('#706 lazy count(): eager parity — elevated and deleted envelopes are
     await store.put('v1', 'mc', 'gone', buildDeleteMarker(live._v, 'owner'))
     // Pre-#706: raw adapter.list().length counted the marker id too (== 2).
     expect(await docs.count()).toBe(1)
+  })
+})
+
+describe('#707 write-path prior reads: elevated ≡ missing to hooks/gates/audit', () => {
+  it('onBeforeWrite sees a null prior for a put over an elevated id, never the elevated plaintext (#priorForHook, lazy)', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, user: 'owner', secret: 'pw-707', tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<User>('docs', { tiers: [0, 1], perRecordKeys: true, prefetch: false, cache: { maxRecords: 100 } })
+    const priors: unknown[] = []
+    db.onBeforeWrite((e) => { priors.push(e.before) })
+    await docs.put('d1', { name: 'secret' })
+    await docs.elevate('d1', 1) // evicts the LRU (#700) and caches the CEK — warm cekCache
+    await docs.put('d1', { name: 'overwrite' }) // tier-0 write over an elevated id
+    // Pre-#707: the lazy branch's adapter.get() miss fell through to an ungated
+    // decrypt, and the warm cekCache let it succeed — `before` was { name: 'secret' }.
+    const lastBefore = priors[priors.length - 1]
+    expect(lastBefore === null || (lastBefore as User)?.name !== 'secret').toBe(true)
+  })
+
+  it('a beforePut gate handler needing the prior sees existing:null for an elevated id (resolveGatePrior)', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, user: 'owner', secret: 'pw-707b', tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<User>('docs', { tiers: [0, 1], perRecordKeys: true })
+    const seen: GatePutEvent[] = []
+    db._subsystemBus.registerGate('beforePut', (e) => { seen.push(e) }) // default needsPrior: true
+    await docs.put('d1', { name: 'secret' })
+    await docs.elevate('d1', 1) // warm cekCache
+    await docs.put('d1', { name: 'overwrite' })
+    // Pre-#707: the try/catch masked the tier boundary — the warm cekCache let
+    // decryptRecord succeed and `existing` carried the elevated plaintext.
+    // (The envelope itself, and its version/timestamp, may still surface —
+    // only the DECRYPTED content is gated to null, same as a genuine decrypt failure.)
+    const lastEvent = seen[seen.length - 1]!
+    expect(lastEvent.existing).toBeNull()
+  })
+
+  it('i18nProvenance over an elevated id returns undefined, not the prior densify marker (resolveDensifyPrior, lazy)', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, user: 'owner', secret: 'pw-707c', tiersStrategy: withTiers(), i18nStrategy: withI18n() })
+    const vault = await db.openVault('v1', { locale: 'en' })
+    const docs = vault.collection<{ name: Record<string, string> } & Record<string, unknown>>('docs', {
+      tiers: [0, 1], perRecordKeys: true, prefetch: false, cache: { maxRecords: 100 },
+      i18nFields: { name: i18nText({ languages: ['th', 'en'], required: 'any', substitute: ['en', 'th'], densifyOnWrite: true }) },
+    })
+    await docs.put('d1', { name: { th: 'สมชาย' } }) // en filled from th → real _i18nFilled marker
+    await docs.elevate('d1', 1) // evicts the LRU, warm cekCache
+    // Pre-#707: the lazy branch's adapter.get() miss fell through to an ungated
+    // decrypt (warm cekCache) and returned the elevated record's real _i18nFilled marker.
+    expect(await docs.i18nProvenance('d1')).toBeUndefined()
+  })
+
+  it('an eager classified put over an elevated id writes no history snapshot of the elevated plaintext (resolvePriorValues)', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store, user: 'owner', secret: 'pw-707d',
+      tiersStrategy: withTiers(), classifiedStrategy: withClassified(), historyStrategy: withHistory(),
+    })
+    const vault = await db.openVault('v1')
+    const users = vault.collection<User>('users', {
+      perRecordKeys: true, tiers: [0, 1], acknowledgeEquatableRisk: true,
+      classifiedFields: { email: classified.email() }, // recoverable (sealed) — plaintext round-trips, unlike a digest-only field
+    })
+    await users.put('u1', { name: 'n', email: 'top-secret-elevated@example.com' })
+    await users.elevate('u1', 1) // warm cekCache
+    await users.put('u1', { name: 'n2', email: 'new@example.com' }) // tier-0 write over the elevated id
+    // Pre-#707: resolvePriorValues re-decrypted the elevated envelope (warm
+    // cekCache) and put() re-encrypted that plaintext into a NEW, tier-0-wrapped
+    // history snapshot — a PERSISTENT leak into the store, not just a transient read.
+    const history = await users.history('u1')
+    expect(history.some(h => (h.record as User).email === 'top-secret-elevated@example.com')).toBe(false)
   })
 })

--- a/packages/hub/__tests__/tier0-read-paths.test.ts
+++ b/packages/hub/__tests__/tier0-read-paths.test.ts
@@ -15,6 +15,7 @@ import { withTiers } from '../src/with-audit/tiers/index.js'
 import { withClassified } from '../src/via/classified/active.js'
 import { classified } from '../src/via/classified/presets.js'
 import { withHistory } from '../src/with-commit/history/index.js'
+import { withCrdt } from '../src/with-commit/crdt/index.js'
 import { withI18n } from '../src/via/i18n/index.js'
 import { i18nText } from '../src/via/i18n/core.js'
 import { buildDeleteMarker } from '../src/kernel/enclave/index.js'
@@ -444,5 +445,53 @@ describe('#707 write-path prior reads: elevated ≡ missing to hooks/gates/audit
     // history snapshot — a PERSISTENT leak into the store, not just a transient read.
     const history = await users.history('u1')
     expect(history.some(h => (h.record as User).email === 'top-secret-elevated@example.com')).toBe(false)
+  })
+})
+
+describe('#712 read-gate: elevated records leak no prior-version plaintext, warm or cold', () => {
+  function historyHarness() {
+    const store = memoryStore()
+    const open = async () => {
+      const db = await createNoydb({ store, user: 'owner', secret: 'pw-712', tiersStrategy: withTiers(), historyStrategy: withHistory() })
+      const vault = await db.openVault('v1')
+      const docs = vault.collection<User>('docs', { tiers: [0, 1], perRecordKeys: true })
+      return { docs }
+    }
+    return { store, open }
+  }
+
+  it('history() and getVersion() are empty for an elevated record — warm AND cold', async () => {
+    const h = historyHarness()
+    const { docs } = await h.open()
+    await docs.put('d1', { name: 'v1-secret' })
+    await docs.put('d1', { name: 'v2-secret' })
+    await docs.elevate('d1', 1)
+    // Pre-#712: BOTH returned the prior-version plaintext (history envelopes keep tier-0 CEKs).
+    expect(await docs.history('d1')).toEqual([])
+    expect(await docs.getVersion('d1', 1)).toBeNull()
+    await expect(docs.revert('d1', 1)).rejects.toThrow()      // inherits getVersion → not found
+    const cold = await h.open()
+    expect(await cold.docs.history('d1')).toEqual([])
+    expect(await cold.docs.getVersion('d1', 1)).toBeNull()
+  })
+
+  it('history stays readable after demote back to tier 0', async () => {
+    const h = historyHarness()
+    const { docs } = await h.open()
+    await docs.put('d2', { name: 'a' })
+    await docs.put('d2', { name: 'b' })
+    await docs.elevate('d2', 1)
+    await docs.demote('d2', 0)
+    expect((await docs.history('d2')).length).toBeGreaterThan(0) // demoted record IS tier-0
+  })
+
+  it('CRDT getRaw returns null for an elevated record instead of throwing', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, user: 'owner', secret: 'pw-712c', tiersStrategy: withTiers(), crdtStrategy: withCrdt() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<User>('cdocs', { tiers: [0, 1], crdt: 'lww-map' })
+    await docs.put('c1', { name: 'x' })
+    await docs.elevate('c1', 1)
+    expect(await docs.getRaw('c1')).toBeNull()
   })
 })

--- a/packages/hub/__tests__/tier0-read-paths.test.ts
+++ b/packages/hub/__tests__/tier0-read-paths.test.ts
@@ -556,4 +556,22 @@ describe('#712 read-gate: elevated records leak no prior-version plaintext, warm
     await docs.elevate('c1', 1)
     expect(await docs.getRaw('c1')).toBeNull()
   })
+
+  it('history() rejects uniformly for absent/tier0/elevated on a tiers-only collection with no history strategy — no notEnabled short-circuit oracle', async () => {
+    const store = memoryStore()
+    // No historyStrategy: getHistoryEntries() must throw notEnabled for ALL
+    // three cases, uniformly. Pre-fix, the elevated-record gate sat BEFORE the
+    // getHistoryEntries() call and short-circuited it to `[]`, distinguishing
+    // an elevated id from an absent/tier-0 id (both of which threw).
+    const db = await createNoydb({ store, user: 'owner', secret: 'pw-712rg', tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<User>('docs', { tiers: [0, 1], perRecordKeys: true })
+    await docs.put('t0', { name: 'tier0' })
+    await docs.put('e1', { name: 'elevated' })
+    await docs.elevate('e1', 1)
+
+    await expect(docs.history('absent-id')).rejects.toThrow(/requires the history strategy/)
+    await expect(docs.history('t0')).rejects.toThrow(/requires the history strategy/)
+    await expect(docs.history('e1')).rejects.toThrow(/requires the history strategy/)
+  })
 })

--- a/packages/hub/__tests__/tier0-read-paths.test.ts
+++ b/packages/hub/__tests__/tier0-read-paths.test.ts
@@ -83,6 +83,32 @@ function withListPage(base: NoydbStore): NoydbStore {
   }
 }
 
+/**
+ * #713 fixture: wraps a store and counts adapter-level round-trips to
+ * `get`/`listPage`, so tests can pin the batched count() path avoiding the
+ * per-id `get()` fan-out that the pre-#713 `list()+get()` loop made. Counts
+ * only calls made directly on this wrapper — `withListPage`'s own internal
+ * `base.get` calls (used to build a page) are NOT counted, matching what a
+ * real remote store's `listPage` looks like from the caller's side: one
+ * round-trip per page, no per-id fetch.
+ */
+function withCallCounts(base: NoydbStore, counts: { get: number; listPage: number }): NoydbStore {
+  const wrapped: NoydbStore = {
+    ...base,
+    async get(v, c, id) {
+      counts.get++
+      return base.get(v, c, id)
+    },
+  }
+  if (base.listPage) {
+    wrapped.listPage = async (v, c, cursor, limit) => {
+      counts.listPage++
+      return base.listPage!(v, c, cursor, limit)
+    }
+  }
+  return wrapped
+}
+
 interface User extends Record<string, unknown> { name?: string; password?: string; email?: string; a1?: string; a2?: string }
 
 /** One store, reopenable: open() twice = cold second session over the same ciphertext. */
@@ -372,6 +398,42 @@ describe('#706 lazy count(): eager parity — elevated and deleted envelopes are
     const live = (await store.get('v1', 'mc', 'gone'))!
     await store.put('v1', 'mc', 'gone', buildDeleteMarker(live._v, 'owner'))
     // Pre-#706: raw adapter.list().length counted the marker id too (== 2).
+    expect(await docs.count()).toBe(1)
+  })
+})
+
+describe('#713 lazy count() batches via adapter.listPage — behavior parity, fewer round-trips', () => {
+  it('native listPage store: same count as the fallback, zero per-id get() calls (RED pre-#713: 3 gets)', async () => {
+    const base = memoryStore()
+    const nativeCounts = { get: 0, listPage: 0 }
+    const store = withCallCounts(withListPage(base), nativeCounts)
+    const db = await createNoydb({ store, user: 'owner', secret: 'pw-713', tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<User>('docs', { tiers: [0, 1], perRecordKeys: true, prefetch: false, cache: { maxRecords: 100 } })
+    await docs.put('a', { name: 'a' })   // live tier-0 — counted
+    await docs.put('b', { name: 'b' })   // elevated below — not counted
+    await docs.put('c', { name: 'c' })   // delete-marked below — not counted
+    await docs.elevate('b', 1)
+    const live = (await store.get('v1', 'docs', 'c'))!
+    await store.put('v1', 'docs', 'c', buildDeleteMarker(live._v, 'owner'))
+    nativeCounts.get = 0
+    nativeCounts.listPage = 0 // reset after setup writes — only count() below matters
+    expect(await docs.count()).toBe(1) // only 'a' is live tier-0 — parity with fallback
+    expect(nativeCounts.get).toBe(0) // no per-id get() at all on the native path
+    expect(nativeCounts.listPage).toBeGreaterThanOrEqual(1)
+  })
+
+  it('fallback (no listPage) store: same count, list()+get() path still works', async () => {
+    const store = memoryStore() // no listPage — exercises the fallback branch
+    const db = await createNoydb({ store, user: 'owner', secret: 'pw-713-fb', tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<User>('docs', { tiers: [0, 1], perRecordKeys: true, prefetch: false, cache: { maxRecords: 100 } })
+    await docs.put('a', { name: 'a' })
+    await docs.put('b', { name: 'b' })
+    await docs.put('c', { name: 'c' })
+    await docs.elevate('b', 1)
+    const live = (await store.get('v1', 'docs', 'c'))!
+    await store.put('v1', 'docs', 'c', buildDeleteMarker(live._v, 'owner'))
     expect(await docs.count()).toBe(1)
   })
 })

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -3458,10 +3458,10 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
 
   /** Get version history for a record, newest first. */
   async history(id: string, options?: HistoryOptions): Promise<HistoryEntry<T>[]> {
-    if (await liveRecordIsElevated(this.adapter, this.vault, this.name, id)) return [] // #712: elevated ≡ invisible
     const envelopes = await this.historyStrategy.getHistoryEntries(
       this.adapter, this.vault, this.name, id, options,
     )
+    if (await liveRecordIsElevated(this.adapter, this.vault, this.name, id)) return [] // #712: elevated ≡ invisible
 
     const entries: HistoryEntry<T>[] = []
     for (const env of envelopes) {

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -26,6 +26,7 @@ import {
   type SealedShredSlot,
 } from './enclave/index.js'
 import { countLiveEnvelopes } from './lazy-count.js'
+import { liveRecordIsElevated } from './tier-visibility.js'
 import {
   classifySealedShred as classifySealedShredImpl,
   type TiersContext,
@@ -1480,7 +1481,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       )
     }
     const envelope = await this.adapter.get(this.vault, this.name, id)
-    if (!envelope) return null
+    if (!envelope || (envelope._tier ?? 0) > 0) return null
     const json = await this.codec.decryptJsonString(envelope)
     if (json === null) return null // shredded (tombstone)
     return JSON.parse(json) as CrdtState
@@ -3457,12 +3458,14 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
 
   /** Get version history for a record, newest first. */
   async history(id: string, options?: HistoryOptions): Promise<HistoryEntry<T>[]> {
+    if (await liveRecordIsElevated(this.adapter, this.vault, this.name, id)) return [] // #712: elevated ≡ invisible
     const envelopes = await this.historyStrategy.getHistoryEntries(
       this.adapter, this.vault, this.name, id, options,
     )
 
     const entries: HistoryEntry<T>[] = []
     for (const env of envelopes) {
+      if ((env._tier ?? 0) > 0) continue // #712: defensive — a per-version tiered snapshot
       // History reads skip schema validation — see getVersion() docs.
       const record = await this.codec.decryptRecord(env, { skipValidation: true, id })
       // Shredded (tombstoned) history version: the body is permanently gone,
@@ -3492,7 +3495,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     const envelope = await this.historyStrategy.getVersionEnvelope(
       this.adapter, this.vault, this.name, id, version,
     )
-    if (!envelope) return null
+    if (!envelope || (envelope._tier ?? 0) > 0 || await liveRecordIsElevated(this.adapter, this.vault, this.name, id)) return null
     return this.codec.decryptRecord(envelope, { skipValidation: true, id })
   }
 

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -1613,7 +1613,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       const cached = this.lru.get(id)
       if (cached) return cached.record as Record<string, unknown>
       const env = await this.adapter.get(this.vault, this.name, id)
-      if (!env) return undefined
+      if (!env || (env._tier ?? 0) > 0) return undefined // #707: elevated ≡ missing
       const rec = await this.codec.decryptRecord(env, { id })
       return rec === null ? undefined : (rec as Record<string, unknown>)
     }
@@ -1665,7 +1665,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       const cached = this.lru.get(id)
       if (cached) return { record: cached.record, version: cached.version }
       const env = await this.adapter.get(this.vault, this.name, id)
-      if (!env) return { record: null, version: 0 }
+      if (!env || (env._tier ?? 0) > 0) return { record: null, version: 0 } // #707: elevated ≡ missing
       return { record: (await this.codec.decryptRecord(env, { skipValidation: true, id })) as unknown ?? null, version: env._v }
     }
     await this.ensureHydrated()
@@ -1689,7 +1689,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   private async resolvePriorValues(id: string): Promise<{ record: T; version: number } | undefined> {
     if (this.sensitiveFields.size > 0 || this.via?.hasAtRestHooks === true) {
       const env = await this.adapter.get(this.vault, this.name, id)
-      if (!env || isTombstone(env, this.storeCiphertext)) return undefined
+      if (!env || isTombstone(env, this.storeCiphertext) || (env._tier ?? 0) > 0) return undefined // #707: elevated ≡ missing
       const rec = await this.codec.decryptRecord(env, { skipValidation: true, id })
       return rec === null ? undefined : { record: rec, version: env._v }
     }
@@ -1702,11 +1702,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     if (!this.subsystemBus!.gateNeedsPrior(point)) return { env: null, record: null, elided: true }
     const env = await this.adapter.get(this.vault, this.name, id)
     if (!env) return { env: null, record: null, elided: false }
-    try {
-      return { env, record: await this.codec.decryptRecord(env, { skipValidation: true, id }), elided: false }
-    } catch {
-      return { env, record: null, elided: false }
-    }
+    if ((env._tier ?? 0) > 0) return { env, record: null, elided: false } // #707: elevated invisible to gate handlers — deterministic, not a swallowed InvalidKeyError
+    return { env, record: await this.codec.decryptRecord(env, { skipValidation: true, id }), elided: false }
   }
 
   /**

--- a/packages/hub/src/kernel/lazy-count.ts
+++ b/packages/hub/src/kernel/lazy-count.ts
@@ -3,18 +3,43 @@
  * tier 0 — parity with eager count (the hydrated cache excludes tombstones,
  * delete markers, and elevated records, #701). Envelope inspection only —
  * no record body is ever decrypted here.
+ *
+ * #713: when the adapter implements the optional `listPage`, page through
+ * it and apply the same predicate to each page's envelopes — one
+ * round-trip per page instead of one `list()` + one `get()` per id. Stores
+ * without `listPage` keep the original N+1 loop.
  */
-import type { NoydbStore } from './types.js'
+import type { EncryptedEnvelope, NoydbStore } from './types.js'
 import { isTombstone, isDeleteMarker } from './enclave/index.js'
+
+/** Page size for the listPage batching path (#713). */
+const COUNT_PAGE_SIZE = 1000
+
+function isLive(env: EncryptedEnvelope | null, storeCiphertext: boolean): boolean {
+  return !!env && !isTombstone(env, storeCiphertext) && !isDeleteMarker(env) && (env._tier ?? 0) === 0
+}
 
 export async function countLiveEnvelopes(
   adapter: NoydbStore, vault: string, name: string, storeCiphertext: boolean,
 ): Promise<number> {
-  const ids = await adapter.list(vault, name)
   let n = 0
+  if (adapter.listPage) {
+    let cursor: string | undefined
+    let page = await adapter.listPage(vault, name, cursor, COUNT_PAGE_SIZE)
+    while (true) {
+      for (const { envelope } of page.items) {
+        if (isLive(envelope, storeCiphertext)) n++
+      }
+      if (page.nextCursor === null) break
+      cursor = page.nextCursor
+      page = await adapter.listPage(vault, name, cursor, COUNT_PAGE_SIZE)
+    }
+    return n
+  }
+  const ids = await adapter.list(vault, name)
   for (const id of ids) {
     const env = await adapter.get(vault, name, id)
-    if (env && !isTombstone(env, storeCiphertext) && !isDeleteMarker(env) && (env._tier ?? 0) === 0) n++
+    if (isLive(env, storeCiphertext)) n++
   }
   return n
 }

--- a/packages/hub/src/kernel/tier-visibility.ts
+++ b/packages/hub/src/kernel/tier-visibility.ts
@@ -1,0 +1,16 @@
+/**
+ * Tier visibility helper (#712/#707): a tier-0 code path treats an elevated
+ * (_tier > 0) record as invisible. History reads gate on the LIVE record's
+ * tier — history snapshots keep their tier-0-wrapped CEKs and carry no _tier
+ * of their own, so an elevated record's prior versions would otherwise stay
+ * tier-0-decryptable (the read-gate closes the API surface; #712's at-rest
+ * arc rewraps the snapshot keys). Envelope inspection only — no decryption.
+ */
+import type { NoydbStore } from './types.js'
+
+export async function liveRecordIsElevated(
+  adapter: NoydbStore, vault: string, name: string, id: string,
+): Promise<boolean> {
+  const env = await adapter.get(vault, name, id)
+  return (env?._tier ?? 0) > 0
+}


### PR DESCRIPTION
Closes #707. Closes #713. **#712 remains open** — this delivers only its *read-gate*; the at-rest hardening is a follow-up arc.

Fourth arc of the tier-invisibility campaign (#700 → #710 → #714 → this): elevated (`_tier > 0`) records are invisible on tier-0 surfaces, gated **before** any key resolution, never via try/catch (which makes behavior warm-CEK-cache-dependent — the elevating session leaks, cold throws).

## #707 — write-path prior reads
The four prior-read helpers (`resolveDensifyPrior`, `#priorForHook`, `resolvePriorValues`, `resolveGatePrior`) now fold an elevated record into their existing missing/tombstone branch, so **write hooks, subsystem gate handlers, and the `i18nProvenance` audit accessor no longer receive elevated plaintext** when a tier-0 write touches an elevated id (warm) and no longer throw (cold). `resolveGatePrior`'s spec-forbidden swallowing `try/catch` is replaced by an explicit pre-decrypt gate — a genuine decrypt failure now fails loudly instead of silently presenting a corrupt record as absent (reviewer-verified as the correct ZK posture; its sibling paths already propagated).

## #712 — read-gate only
`history()` / `getVersion()` no longer return an elevated record's prior-version plaintext; CRDT `getRaw()` returns `null` instead of throwing. **Mechanism:** history snapshots keep tier-0-wrapped CEKs and carry no `_tier` of their own, so these doors gate on the **live** record's tier (new `kernel/tier-visibility.ts` — envelope peek, zero decryption) plus a defensive per-entry skip. `revert()` inherits via `getVersion`. Bonus, found in review: this also closes an untracked leak where `vault.ts`'s WriteConflict payloads surfaced elevated base plaintext warm.

## #713 — perf
Lazy `count()` batches via `adapter.listPage` when the store provides it — O(pages), not O(records) (`get()` round-trips 3 → 0 in the pinning test). Behavior identical; the live-tier-0 predicate is shared by both branches so it can't drift from hydration's.

## Known limitations (tracked, stated in the changeset — not closed by this PR)
- **#716** — a tier-0 `delete()` erases the elevation signal (markers carry no `_tier`), so history re-decrypts post-delete.
- **#715** — `put()` over an elevated id silently demotes it (non-CRDT) or throws (CRDT, 3 further ungated sites); its inline lazy read can write an elevated-plaintext history snapshot that then passes the live-peek.
- **#712 at-rest** — prior versions stay tier-0-decryptable at rest until history keys are rewrapped on elevation.
- #708 (sync/migration ring), #709 (indexing ring) remain.

## Verification
TDD throughout; every RED reproduced and independently re-proved by reviewers (elevated **plaintext** surfacing for all four #707 helpers and for history/getVersion; a `TamperedError` oracle for `getRaw`; round-trip counts for #713). Full hub suite **500 files / 4090 tests** green; typecheck/lint/`check:architecture` clean; `collection.ts` byte-count identical to main (net-zero folds — #707's catch removal funded #712's additions).

The whole-branch review caught a **Critical introduced by this branch**: `history()`'s gate initially sat *before* the entries fetch, short-circuiting the history-strategy stub's `notEnabled` throw — so on a history-less collection an elevated id returned `[]` while absent/tier-0 ids threw: a one-bit elevation oracle. Fixed by moving the gate after the (ciphertext-only) fetch, with a regression test pinning uniform rejection.

Plan: `docs/superpowers/plans/2026-07-15-read-side-tier-gates.md`