### PR TITLE
fix(hub)!: tier-0 put()/delete() refuse elevated records — the write ring (#715, #716)

### DIFF
--- a/docs/superpowers/plans/2026-07-16-write-ring-refusal.md
+++ b/docs/superpowers/plans/2026-07-16-write-ring-refusal.md
@@ -1,0 +1,196 @@
+# Arc 5 — Write Ring Refusal Implementation Plan (#715 + #716)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refuse tier-0 `put()`/`delete()` targeting an elevated (`_tier > 0`) record with one uniform error, making all seven ungated write-path sites unreachable and closing #716's read-gate bypass.
+
+**Architecture:** Spec — `docs/superpowers/specs/2026-07-16-write-ring-refusal-design.md` (user-approved 2026-07-16). Two choke points (`_putInternal`, `_doDelete`), guarded by `this.tiers !== null` so non-tiered collections pay nothing. Reuses `liveRecordIsElevated` from `kernel/tier-visibility.ts` (#717).
+
+**Tech Stack:** TypeScript ESM, vitest. Branch `fix/715-716-write-ring-refusal` off main 6dd823e3.
+
+## Global Constraints
+
+- NEVER add Claude/Anthropic attribution to commits/PRs/changelogs.
+- NEVER reference the private pilot client by name — grep the diff before each commit.
+- Ceilings exact zero slack (checker = `wc -l` + 1): `collection.ts` **4548**, `vault.ts` 3959, `noydb.ts` 2396. This arc adds ~+3 to collection.ts → fund with mechanical semantics-preserving shrink-joins, each documented. Never edit ceiling values; never touch vault.ts/noydb.ts. `errors.ts` and `tier-visibility.ts` have no ceiling.
+- TDD: RED verified before implementing, every test. Run from `packages/hub/`: `pnpm vitest run <path>`.
+- No new deps; no timing assertions.
+- The sanctioned tier paths (`putAtTier`/`elevate`/`demote`/`getAtTier`/`listAtTier`) must be UNAFFECTED — the existing tiers suites must pass untouched.
+
+---
+
+### Task 1: the refusal error + assertion helper
+
+**Files:**
+- Modify: `packages/hub/src/kernel/errors.ts` (new error class)
+- Modify: `packages/hub/src/kernel/tier-visibility.ts` (new assertion beside `liveRecordIsElevated`)
+- Modify: `packages/hub/src/index.ts` (export the error, if sibling tier errors are exported there — check)
+
+**Interfaces:**
+- Produces: `TierWriteRefusedError` (name it consistently with siblings — read `TierNotGrantedError` at errors.ts:703 and `TierAccessDeniedError` and match their shape: code constant, `readonly tier`, `readonly collection`, `this.name`).
+- Produces: `export async function assertTierWritable(adapter: NoydbStore, vault: string, name: string, id: string, tiersEnabled: boolean): Promise<void>` in tier-visibility.ts — no-op when `!tiersEnabled`; otherwise peek the live envelope and throw `TierWriteRefusedError(name, tier)` when `(env._tier ?? 0) > 0`. Envelope inspection only, no decryption. Reuse/extend `liveRecordIsElevated` rather than duplicating the peek (a second `adapter.get` per write would be wasteful — consider a shared internal that returns the tier).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/hub/__tests__/tier-write-ring.test.ts`. Copy the `memoryStore()` fixture verbatim from `__tests__/hierarchical-tiers.test.ts`. Start with the unit-level error contract:
+
+```ts
+/**
+ * #715/#716 — the write ring. A tier-0 put()/delete() targeting an elevated
+ * record is refused uniformly (spec: docs/superpowers/specs/2026-07-16-write-ring-refusal-design.md).
+ * Holders are refused too: put()/delete() are the tier-0 APIs; putAtTier/
+ * elevate/demote are the sanctioned tier-aware paths.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, TierWriteRefusedError } from '../src/index.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
+// … memoryStore() copied from hierarchical-tiers.test.ts …
+
+describe('#715 TierWriteRefusedError', () => {
+  it('names the collection, the tier, and the remedy', () => {
+    const e = new TierWriteRefusedError('docs', 2)
+    expect(e).toBeInstanceOf(Error)
+    expect(e.name).toBe('TierWriteRefusedError')
+    expect(e.collection).toBe('docs')
+    expect(e.tier).toBe(2)
+    expect(e.message).toMatch(/putAtTier/)   // actionable remedy named
+  })
+})
+```
+
+- [ ] **Step 2: RED** — `pnpm vitest run __tests__/tier-write-ring.test.ts` → FAIL (no such export).
+
+- [ ] **Step 3: Implement** the error class in errors.ts (match sibling shape/JSDoc style; document WHY it is distinct from `TierNotGrantedError` — that one means "no DEK for tier N", whereas this refuses holders too) and `assertTierWritable` in tier-visibility.ts. Export the error wherever `TierNotGrantedError` is exported (grep `TierNotGrantedError` in `src/index.ts` / the public barrel + check `packages/hub/noy-surface.json` if a surface-golden test exists — if the public surface is golden-tested, update it per that test's convention).
+
+- [ ] **Step 4: GREEN + regression** — the new file; `node scripts/check-architecture.mjs`; typecheck + lint. collection.ts untouched this task.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/kernel/errors.ts packages/hub/src/kernel/tier-visibility.ts packages/hub/src/index.ts packages/hub/__tests__/tier-write-ring.test.ts
+git commit -m "feat(hub): TierWriteRefusedError + assertTierWritable — the write-ring refusal primitive (#715)"
+```
+
+---
+
+### Task 2: wire the refusal into both choke points
+
+**Files:**
+- Modify: `packages/hub/src/kernel/collection.ts` (`_putInternal`, `_doDelete`; ~+3 lines → shrink-joins required)
+- Modify: `packages/hub/__tests__/tier-write-ring.test.ts` (append)
+
+**Interfaces:**
+- Consumes: `assertTierWritable`, `TierWriteRefusedError` (Task 1), `this.tiers` (collection.ts:502), `this.adapter`/`this.vault`/`this.name`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append. Cover BOTH modes × BOTH ops, the holder case, the non-tiered no-cost case, and #716's bypass:
+
+```ts
+describe('#715/#716 write ring: tier-0 put/delete over an elevated record are refused', () => {
+  async function open(opts: { lazy?: boolean; crdt?: boolean } = {}) {
+    const store = memoryStore()
+    const db = await createNoydb({ store, secret: 'pw-715', user: 'owner', tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true,
+      ...(opts.lazy ? { prefetch: false, cache: { maxRecords: 100 } } : {}),
+      ...(opts.crdt ? { crdt: 'lww-map' as const } : {}),
+    })
+    return { store, docs }
+  }
+
+  for (const mode of ['eager', 'lazy'] as const) {
+    it(`${mode}: put() over an elevated id is refused (no demotion, no history snapshot)`, async () => {
+      const { store, docs } = await open({ lazy: mode === 'lazy' })
+      await docs.put('d1', { id: 'd1', title: 'secret', body: 'x' })
+      await docs.elevate('d1', 1)
+      // Pre-fix: eager/lazy SILENTLY DEMOTED (_tier 1 → undefined); lazy also
+      // wrote a history snapshot of the elevated plaintext.
+      await expect(docs.put('d1', { id: 'd1', title: 'clobber', body: 'y' })).rejects.toBeInstanceOf(TierWriteRefusedError)
+      expect((await store.get('v1', 'docs', 'd1'))!._tier).toBe(1)   // tier intact — the core #715 pin
+    })
+
+    it(`${mode}: delete() over an elevated id is refused — no marker, history stays hidden (#716)`, async () => {
+      const { store, docs } = await open({ lazy: mode === 'lazy' })
+      await docs.put('d1', { id: 'd1', title: 'secret', body: 'x' })
+      await docs.elevate('d1', 1)
+      await expect(docs.delete('d1')).rejects.toBeInstanceOf(TierWriteRefusedError)
+      expect((await store.get('v1', 'docs', 'd1'))!._tier).toBe(1)   // no marker overwrote it
+    })
+  }
+
+  it('CRDT: put() over an elevated id is refused with the SAME error (was TamperedError/InvalidKeyError)', async () => {
+    const { docs } = await open({ crdt: true })
+    await docs.put('c1', { id: 'c1', title: 'secret', body: 'x' })
+    await docs.elevate('c1', 1)
+    await expect(docs.put('c1', { id: 'c1', title: 'clobber', body: 'y' })).rejects.toBeInstanceOf(TierWriteRefusedError)
+  })
+
+  it('the elevating owner (who HOLDS the tier DEK) is refused too — put() is the tier-0 API', async () => {
+    const { docs } = await open()
+    await docs.put('d1', { id: 'd1', title: 'secret', body: 'x' })
+    await docs.elevate('d1', 1)   // this session holds docs#1
+    await expect(docs.put('d1', { id: 'd1', title: 'x2', body: 'y' })).rejects.toBeInstanceOf(TierWriteRefusedError)
+    await docs.putAtTier('d1', { id: 'd1', title: 'sanctioned', body: 'y' }, 1)  // sanctioned path still works
+    expect(((await docs.getAtTier('d1')) as Doc | null)?.title).toBe('sanctioned')
+  })
+
+  it('tier-0 records and non-tiered collections are unaffected (no extra cost, no refusal)', async () => {
+    const { docs } = await open()
+    await docs.put('d0', { id: 'd0', title: 'plain', body: 'x' })
+    await docs.put('d0', { id: 'd0', title: 'updated', body: 'y' })   // tier-0 overwrite fine
+    expect((await docs.get('d0'))?.title).toBe('updated')
+    await docs.delete('d0')
+    expect(await docs.get('d0')).toBeNull()
+  })
+
+  it('#716: after the refusal, an elevated record’s history stays hidden (delete cannot erase the signal)', async () => {
+    // Needs withHistory — check the real import/option name (grep __tests__/*histor*).
+    // put v1, put v2, elevate, attempt delete (refused), assert history() === [].
+  })
+})
+```
+
+Write the last test fully (the `withHistory` fixture pattern is in `__tests__/tier0-read-paths.test.ts`'s `#712` block — reuse it). Adapt mechanics to real APIs; never weaken an assert. If a RED doesn't reproduce as documented, STOP → BLOCKED with output.
+
+- [ ] **Step 2: RED** — `pnpm vitest run __tests__/tier-write-ring.test.ts` → the refusal tests fail: eager/lazy put resolves and demotes (`_tier` undefined); CRDT put rejects with `TamperedError`/`InvalidKeyError` (wrong type); delete succeeds and writes a marker; #716's history re-decrypts.
+
+- [ ] **Step 3: Implement — two call sites, net-zero via shrink-joins**
+
+In `_putInternal` (`:1727`) and `_doDelete` (`:2667`), immediately AFTER the `hasWritePermission`/`ReadOnlyError` check and BEFORE the gate-bus dispatch and any prior read:
+```ts
+    // #715/#716: put()/delete() are the tier-0 APIs — an elevated record is
+    // writable only through putAtTier/elevate/demote. Refusing here (before the
+    // gate bus and every prior read) is what makes the write path's ungated
+    // decodes unreachable, and what stops a delete marker from erasing `_tier`.
+    if (this.tiers !== null) await assertTierWritable(this.adapter, this.vault, this.name, id, true)
+```
+(Or pass `this.tiers !== null` as the flag and drop the outer `if` — pick the shape that costs the fewest lines; the helper already no-ops when disabled.) Add the import. For `_doDelete`, gate on the PUBLIC path only: `if (!internal && this.tiers !== null) …` — see Step 5's investigation.
+
+collection.ts must end at **exactly 4548** (`git show 6dd823e3:packages/hub/src/kernel/collection.ts | wc -l`). Fund the additions with mechanical, semantics-preserving shrink-joins (single-use const inlined into its sole next-line use is the pattern used twice already in this campaign — see git log for `count()` and the tx-revert loop). Document each join in your report.
+
+- [ ] **Step 4: GREEN + regression**
+
+`pnpm vitest run __tests__/tier-write-ring.test.ts __tests__/hierarchical-tiers.test.ts __tests__/tier0-read-paths.test.ts __tests__/per-record-cek.test.ts` → PASS. Then the FULL hub suite (`pnpm --filter @noy-db/hub test` from root) — this arc changes public write behavior, so **expect pre-existing tests to break**: any test that put()s or delete()s over an elevated record now throws. For each such failure, decide carefully: is it pinning the OLD (buggy) demote/throw behavior, or a legitimate scenario the refusal breaks? Report every changed test with the reasoning — a test that pinned the demotion is faithful to update; a test that reveals the refusal breaks a real workflow is a BLOCKED-worthy finding, not a test to edit. `node scripts/check-architecture.mjs`; typecheck; lint.
+
+- [ ] **Step 5: Investigate + report (do NOT fix)**
+
+- `_doDelete(id, internal: true)` — can an internal delete (derivation/MV cleanup) reach an elevated record? If yes, it can still write a marker and erase `_tier`. Report evidence.
+- `forget()` / `_writeTombstone` (`:2863`) — does it route around `_doDelete`? Reviewer says it's safe (destroys the CEK). Report whether it should refuse for integrity symmetry.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/hub/src/kernel/collection.ts packages/hub/__tests__/tier-write-ring.test.ts
+git commit -m "fix(hub): tier-0 put()/delete() refuse elevated records — no silent demotion, no signal-erasing marker (#715, #716)"
+```
+
+---
+
+### Final: full suite + whole-branch review + changeset + PR
+
+- [ ] `pnpm --filter @noy-db/hub test` + typecheck + lint + `pnpm check:architecture` — green.
+- [ ] Whole-branch review (fable — this changes public write semantics and is the premise the whole read campaign rests on; ask it to hunt for any surviving path that can demote or marker-erase `_tier`, and to sanity-check the accepted write-side oracle).
+- [ ] Local changeset: `@noy-db/hub` **minor** (new public error + intended behavior change) — state plainly that `put()`/`delete()` now throw on elevated records and name `putAtTier`/`elevate`/`demote` as the remedy.
+- [ ] PR → main: `Closes #715`, `Closes #716`.

--- a/docs/superpowers/specs/2026-07-16-write-ring-refusal-design.md
+++ b/docs/superpowers/specs/2026-07-16-write-ring-refusal-design.md
@@ -1,0 +1,56 @@
+# Arc 5 — The write ring: refuse tier-0 writes to elevated records (#715 + #716)
+
+**Issues:** [#715](https://github.com/vLannaAi/noy-db/issues/715) (put ring) · [#716](https://github.com/vLannaAi/noy-db/issues/716) (delete ring)
+**Predecessors (merged):** #700, #710, #714, #717 — the tier-0 **read** surface is fully law-compliant.
+
+## The problem this closes
+
+The read campaign's law — *elevated (`_tier > 0`) records are invisible on tier-0 surfaces* — is **self-defeating on the write path**. Invisibility tells a tier-0 writer "the record isn't there"; a `put()` that believes it treats the id as a **create**, and a create at tier 0 **is a demotion**. So the very gates that hide the record are what let it be silently stripped.
+
+Both filed bypasses are instances of this, and both **defeat the read gates already shipped**:
+
+- **#715** — `put()` over an elevated id **silently demotes** it to tier 0 (`_tier` 1 → undefined, verified), no clearance check, no `CrossTierAccessEvent`. Its lazy inline prior read (`collection.ts` ~1915–1926) additionally writes a **history snapshot of the elevated plaintext** (warm), which then passes #712's live-peek *because the put just demoted the record*; cold it throws `InvalidKeyError` out of `put()`. The CRDT branch (~1815–1864, three ungated decrypts at :1824/:1836/:1863) instead **throws warm and cold** — no demotion, no leak, but a bricked put + error oracle.
+- **#716** — `delete()` writes a marker/tombstone that carries **no `_tier`**, erasing the elevation signal, so an elevated record's history **re-decrypts** through #712's live-peek. (`forget()` is immune — it destroys the CEK, so protection is cryptographic, not a metadata check.)
+
+Every read gate rests on the premise *"the live envelope's `_tier` is trustworthy."* The write ring falsifies that premise. It must be closed before further read gates are worth building.
+
+## Decision (user-approved 2026-07-16): refuse uniformly
+
+**A tier-0 `put()` / `delete()` whose target's LIVE envelope has `_tier > 0` is refused with one uniform error — regardless of the caller's clearance.** Holders are refused too: `put()`/`delete()` are the tier-0 APIs; the sanctioned tier-aware paths are `putAtTier()` / `elevate()` / `demote()` (all of which bypass `_putInternal`/`_doDelete` and are unaffected).
+
+**Rejected — tier-aware write (preserve tier):** would resolve tier DEKs inside the kernel write path, the exact layering the read campaign rejected (`getDEK` **auto-mints** unheld keys; with-audit is opt-in). It also still refuses non-holders, so it buys convenience for holders at the cost of a new kernel↔tier seam.
+
+**Accepted cost — a write-side existence oracle.** A `put()` to an elevated id throws where a `put()` to a missing id creates, so a tier-0 writer learns the id exists and is elevated. Defensible: `_tier` is already cleartext to the untrusted store, and the campaign already accepts gate handlers seeing it (`resolveGatePrior` keeps `env`). This is the deliberate trade — **integrity over write-side existence-hiding**; the read surface stays fully invisible.
+
+## Design
+
+**Choke points — two, and they cover everything.** The refusal goes at the top of `_putInternal` (`collection.ts:1727`) and `_doDelete` (`:2667`), immediately after the `hasWritePermission` check and **before the gate bus dispatch** (so gate handlers never fire for a refused write) and before any prior read. This makes all seven ungated sites **unreachable** rather than individually gated:
+
+| Site | Path | Dies because |
+|---|---|---|
+| `_putInternal` inline lazy read (~1915–1926) | non-CRDT lazy | never reached |
+| CRDT decrypts :1824 / :1836 / :1863 | CRDT put | never reached |
+| `_doDelete` lazy decrypt (~2708–2712) | lazy delete | never reached |
+| marker/tombstone write | delete | no marker is written → **#716's bypass dies** |
+
+**Cost gate — free unless tiers are on.** Guard the check with `this.tiers !== null` (`collection.ts:502`, declaration-activated). Collections that never declare tiers pay **zero**; tiered collections pay one extra `adapter.get` per write. Acceptable: tiers is opt-in, and correctness on a confidentiality feature outranks one envelope peek. (Note: the eager cache cannot answer this — post-#701 it is elevated-free, so an elevated record reads as *absent* there. The peek must hit the adapter.)
+
+**Reuse:** `liveRecordIsElevated` already exists in `kernel/tier-visibility.ts` (shipped by #717, envelope peek, zero decryption). The new assertion belongs beside it — collection.ts is at its exact ceiling, and this is precisely the extraction the ratchet exists to force.
+
+**New error type.** Neither existing type fits: `TierNotGrantedError` says *"User has no DEK for tier N"* (wrong — we refuse holders too) and `TierAccessDeniedError` is documented as read-path/invisibility-ghost only. Add a dedicated, actionable error to `kernel/errors.ts` naming the remedy (`putAtTier`/`elevate`/`demote`). Public API addition → changeset-worthy.
+
+## Scope
+
+**In:** public `put()` (all modes: eager, lazy, CRDT) and public `delete()`; the new error; tests proving each of the seven sites is unreachable and that #716's bypass is closed.
+
+**Out (investigate + report, do not fix):**
+- `_doDelete(id, internal: true)` — the internal path (derivation/MV cleanup). Refusing it could break legitimate cleanup; allowing it may leave a marker-write path to an elevated record. Report whether internal deletes can reach an elevated record.
+- `forget()` / `_writeTombstone` (`:2863`) — reviewer-verified safe (destroys the CEK → history undecryptable by design). Report whether it should nonetheless refuse for integrity symmetry.
+- Sync-apply / migration writes → **#708**'s ring. Indexing → **#709**. History at-rest → **#712**.
+
+## Constraints
+
+- Ceiling (exact zero slack): `collection.ts` **4548** (checker 4549 = wc-l + 1). Expect ~+3 (import + two call sites) → fund with mechanical, semantics-preserving shrink-joins, each documented and reviewer-verified. Never edit ceiling values; `vault.ts`/`noydb.ts` untouched.
+- Zero-knowledge invariant untouched: the refusal *reads no key material* — envelope inspection only.
+- `putAtTier`/`elevate`/`demote`/`getAtTier`/`listAtTier` behavior unchanged (verify by regression: the existing tiers suites must pass untouched).
+- Behavior change is intended and user-approved: `put()`/`delete()` now throw where they previously succeeded (non-CRDT) or threw a crypto error (CRDT). The changeset must state it plainly.

--- a/packages/hub/__tests__/root-barrel-surface.golden.json
+++ b/packages/hub/__tests__/root-barrel-surface.golden.json
@@ -199,6 +199,7 @@
     "TeamNotEnabledError",
     "TierDemoteDeniedError",
     "TierNotGrantedError",
+    "TierWriteRefusedError",
     "TiersNotEnabledError",
     "TranslatorNotConfiguredError",
     "TxCollection",

--- a/packages/hub/__tests__/tier-write-ring.test.ts
+++ b/packages/hub/__tests__/tier-write-ring.test.ts
@@ -1,0 +1,22 @@
+/**
+ * #715/#716 — the write ring. A tier-0 put()/delete() targeting an elevated
+ * record is refused uniformly (spec: docs/superpowers/specs/2026-07-16-write-ring-refusal-design.md).
+ * Holders are refused too: put()/delete() are the tier-0 APIs; putAtTier/
+ * elevate/demote are the sanctioned tier-aware paths.
+ *
+ * Task 1 scope: the error-contract test only. Task 2 wires assertTierWritable
+ * into collection.ts's choke points and appends the integration tests.
+ */
+import { describe, it, expect } from 'vitest'
+import { TierWriteRefusedError } from '../src/index.js'
+
+describe('#715 TierWriteRefusedError', () => {
+  it('names the collection, the tier, and the remedy', () => {
+    const e = new TierWriteRefusedError('docs', 2)
+    expect(e).toBeInstanceOf(Error)
+    expect(e.name).toBe('TierWriteRefusedError')
+    expect(e.collection).toBe('docs')
+    expect(e.tier).toBe(2)
+    expect(e.message).toMatch(/putAtTier/) // actionable remedy named
+  })
+})

--- a/packages/hub/__tests__/tier-write-ring.test.ts
+++ b/packages/hub/__tests__/tier-write-ring.test.ts
@@ -12,6 +12,7 @@ import { createNoydb, TierWriteRefusedError } from '../src/index.js'
 import { withTiers } from '../src/with-audit/tiers/index.js'
 import { withHistory } from '../src/with-commit/history/index.js'
 import { withCrdt } from '../src/with-commit/crdt/index.js'
+import { assertTierWritable } from '../src/kernel/tier-visibility.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
 import { ConflictError } from '../src/index.js'
 
@@ -123,13 +124,36 @@ describe('#715/#716 write ring: tier-0 put/delete over an elevated record are re
     expect(((await docs.getAtTier('d1')) as Doc | null)?.title).toBe('sanctioned')
   })
 
-  it('tier-0 records and non-tiered collections are unaffected (no extra cost, no refusal)', async () => {
+  it('a tier-0 record in a tiered collection is unaffected — put/delete proceed normally', async () => {
     const { docs } = await open()
     await docs.put('d0', { id: 'd0', title: 'plain', body: 'x' })
     await docs.put('d0', { id: 'd0', title: 'updated', body: 'y' })   // tier-0 overwrite fine
     expect((await docs.get('d0'))?.title).toBe('updated')
     await docs.delete('d0')
     expect(await docs.get('d0')).toBeNull()
+  })
+
+  it('a collection that never declares tiers is unaffected — put/delete proceed normally', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, secret: 'pw-715-nt', user: 'owner' })
+    const vault = await db.openVault('v1')
+    const plain = vault.collection<Doc>('plain', {})   // no `tiers` → this.tiers === null
+    await plain.put('p1', { id: 'p1', title: 'a', body: 'x' })
+    await plain.put('p1', { id: 'p1', title: 'b', body: 'y' })
+    expect((await plain.get('p1'))?.title).toBe('b')
+    await plain.delete('p1')
+    expect(await plain.get('p1')).toBeNull()
+  })
+
+  it('assertTierWritable costs a non-tiered collection ZERO adapter round-trips', async () => {
+    // The `no extra cost` half of the design's cost gate, pinned directly:
+    // with tiers off the helper must short-circuit BEFORE touching the store.
+    // Asserted against an adapter that throws if consulted at all — a call
+    // count could drift silently, this cannot.
+    const exploding = new Proxy({} as NoydbStore, {
+      get() { throw new Error('assertTierWritable touched the adapter with tiers disabled') },
+    })
+    await expect(assertTierWritable(exploding, 'v1', 'plain', 'p1', false)).resolves.toBeUndefined()
   })
 
   it('#716: after the refusal, an elevated record’s history stays hidden (delete cannot erase the signal)', async () => {

--- a/packages/hub/__tests__/tier-write-ring.test.ts
+++ b/packages/hub/__tests__/tier-write-ring.test.ts
@@ -8,7 +8,12 @@
  * into collection.ts's choke points and appends the integration tests.
  */
 import { describe, it, expect } from 'vitest'
-import { TierWriteRefusedError } from '../src/index.js'
+import { createNoydb, TierWriteRefusedError } from '../src/index.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
+import { withHistory } from '../src/with-commit/history/index.js'
+import { withCrdt } from '../src/with-commit/crdt/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
+import { ConflictError } from '../src/index.js'
 
 describe('#715 TierWriteRefusedError', () => {
   it('names the collection, the tier, and the remedy', () => {
@@ -18,5 +23,127 @@ describe('#715 TierWriteRefusedError', () => {
     expect(e.collection).toBe('docs')
     expect(e.tier).toBe(2)
     expect(e.message).toMatch(/putAtTier/) // actionable remedy named
+  })
+})
+
+interface Doc {
+  id: string
+  title: string
+  body: string
+}
+
+// Copied verbatim from __tests__/hierarchical-tiers.test.ts.
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll(v, snap) {
+      const vm = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [cn, recs] of Object.entries(snap)) {
+        const cm = new Map<string, EncryptedEnvelope>()
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+        vm.set(cn, cm)
+      }
+      data.set(v, vm)
+    },
+  }
+}
+
+describe('#715/#716 write ring: tier-0 put/delete over an elevated record are refused', () => {
+  async function open(opts: { lazy?: boolean; crdt?: boolean } = {}) {
+    const store = memoryStore()
+    const db = await createNoydb({
+      store, secret: 'pw-715', user: 'owner', tiersStrategy: withTiers(),
+      ...(opts.crdt ? { crdtStrategy: withCrdt() } : {}),
+    })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1], perRecordKeys: true,
+      ...(opts.lazy ? { prefetch: false, cache: { maxRecords: 100 } } : {}),
+      ...(opts.crdt ? { crdt: 'lww-map' as const } : {}),
+    })
+    return { store, docs }
+  }
+
+  for (const mode of ['eager', 'lazy'] as const) {
+    it(`${mode}: put() over an elevated id is refused (no demotion, no history snapshot)`, async () => {
+      const { store, docs } = await open({ lazy: mode === 'lazy' })
+      await docs.put('d1', { id: 'd1', title: 'secret', body: 'x' })
+      await docs.elevate('d1', 1)
+      // Pre-fix: eager/lazy SILENTLY DEMOTED (_tier 1 → undefined); lazy also
+      // wrote a history snapshot of the elevated plaintext.
+      await expect(docs.put('d1', { id: 'd1', title: 'clobber', body: 'y' })).rejects.toBeInstanceOf(TierWriteRefusedError)
+      expect((await store.get('v1', 'docs', 'd1'))!._tier).toBe(1)   // tier intact — the core #715 pin
+    })
+
+    it(`${mode}: delete() over an elevated id is refused — no marker, history stays hidden (#716)`, async () => {
+      const { store, docs } = await open({ lazy: mode === 'lazy' })
+      await docs.put('d1', { id: 'd1', title: 'secret', body: 'x' })
+      await docs.elevate('d1', 1)
+      await expect(docs.delete('d1')).rejects.toBeInstanceOf(TierWriteRefusedError)
+      expect((await store.get('v1', 'docs', 'd1'))!._tier).toBe(1)   // no marker overwrote it
+    })
+  }
+
+  it('CRDT: put() over an elevated id is refused with the SAME error (was TamperedError/InvalidKeyError)', async () => {
+    const { docs } = await open({ crdt: true })
+    await docs.put('c1', { id: 'c1', title: 'secret', body: 'x' })
+    await docs.elevate('c1', 1)
+    await expect(docs.put('c1', { id: 'c1', title: 'clobber', body: 'y' })).rejects.toBeInstanceOf(TierWriteRefusedError)
+  })
+
+  it('the elevating owner (who HOLDS the tier DEK) is refused too — put() is the tier-0 API', async () => {
+    const { docs } = await open()
+    await docs.put('d1', { id: 'd1', title: 'secret', body: 'x' })
+    await docs.elevate('d1', 1)   // this session holds docs#1
+    await expect(docs.put('d1', { id: 'd1', title: 'x2', body: 'y' })).rejects.toBeInstanceOf(TierWriteRefusedError)
+    await docs.putAtTier('d1', { id: 'd1', title: 'sanctioned', body: 'y' }, 1)  // sanctioned path still works
+    expect(((await docs.getAtTier('d1')) as Doc | null)?.title).toBe('sanctioned')
+  })
+
+  it('tier-0 records and non-tiered collections are unaffected (no extra cost, no refusal)', async () => {
+    const { docs } = await open()
+    await docs.put('d0', { id: 'd0', title: 'plain', body: 'x' })
+    await docs.put('d0', { id: 'd0', title: 'updated', body: 'y' })   // tier-0 overwrite fine
+    expect((await docs.get('d0'))?.title).toBe('updated')
+    await docs.delete('d0')
+    expect(await docs.get('d0')).toBeNull()
+  })
+
+  it('#716: after the refusal, an elevated record’s history stays hidden (delete cannot erase the signal)', async () => {
+    const store = memoryStore()
+    const db = await createNoydb({ store, secret: 'pw-716', user: 'owner', tiersStrategy: withTiers(), historyStrategy: withHistory() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', { tiers: [0, 1], perRecordKeys: true })
+    await docs.put('d1', { id: 'd1', title: 'v1', body: 'x' })
+    await docs.put('d1', { id: 'd1', title: 'v2', body: 'y' })
+    await docs.elevate('d1', 1)
+    await expect(docs.delete('d1')).rejects.toBeInstanceOf(TierWriteRefusedError)
+    // Pre-fix: delete() wrote a marker with no `_tier`, erasing the elevation
+    // signal — the elevated record's prior versions would then re-decrypt
+    // through #712's live-peek gate.
+    expect(await docs.history('d1')).toEqual([])
   })
 })

--- a/packages/hub/__tests__/tier0-read-paths.test.ts
+++ b/packages/hub/__tests__/tier0-read-paths.test.ts
@@ -450,8 +450,11 @@ describe('#707 write-path prior reads: elevated ≡ missing to hooks/gates/audit
     await docs.elevate('d1', 1) // evicts the LRU (#700) and caches the CEK — warm cekCache
     // Pre-#707: the lazy branch's adapter.get() miss fell through to an ungated
     // decrypt, and the warm cekCache let it succeed — `before` was { name: 'secret' }.
-    // Post-#715/#716: the write ring refuses this put() outright, before #priorForHook
-    // even runs — a strictly stronger guarantee than #707's nulled-prior fix.
+    // Post-#715/#716: the write ring refuses the put — but #priorForHook still
+    // RUNS first (it fires in the put() wrapper, before _putInternal's choke
+    // point), so #707's mask is still what keeps `before` off the elevated
+    // plaintext. This asserts BOTH: the mask holds across every hook call, and
+    // the write is refused. Neither guarantee subsumes the other.
     await expect(docs.put('d1', { name: 'overwrite' })).rejects.toBeInstanceOf(TierWriteRefusedError)
     expect(priors.some((p) => (p as User | null)?.name === 'secret')).toBe(false)
   })

--- a/packages/hub/__tests__/tier0-read-paths.test.ts
+++ b/packages/hub/__tests__/tier0-read-paths.test.ts
@@ -10,7 +10,7 @@
  * through findByDet with no CrossTierAccessEvent.
  */
 import { describe, it, expect } from 'vitest'
-import { createNoydb, ConflictError } from '../src/index.js'
+import { createNoydb, ConflictError, TierWriteRefusedError } from '../src/index.js'
 import { withTiers } from '../src/with-audit/tiers/index.js'
 import { withClassified } from '../src/via/classified/active.js'
 import { classified } from '../src/via/classified/presets.js'
@@ -448,11 +448,12 @@ describe('#707 write-path prior reads: elevated ≡ missing to hooks/gates/audit
     db.onBeforeWrite((e) => { priors.push(e.before) })
     await docs.put('d1', { name: 'secret' })
     await docs.elevate('d1', 1) // evicts the LRU (#700) and caches the CEK — warm cekCache
-    await docs.put('d1', { name: 'overwrite' }) // tier-0 write over an elevated id
     // Pre-#707: the lazy branch's adapter.get() miss fell through to an ungated
     // decrypt, and the warm cekCache let it succeed — `before` was { name: 'secret' }.
-    const lastBefore = priors[priors.length - 1]
-    expect(lastBefore === null || (lastBefore as User)?.name !== 'secret').toBe(true)
+    // Post-#715/#716: the write ring refuses this put() outright, before #priorForHook
+    // even runs — a strictly stronger guarantee than #707's nulled-prior fix.
+    await expect(docs.put('d1', { name: 'overwrite' })).rejects.toBeInstanceOf(TierWriteRefusedError)
+    expect(priors.some((p) => (p as User | null)?.name === 'secret')).toBe(false)
   })
 
   it('a beforePut gate handler needing the prior sees existing:null for an elevated id (resolveGatePrior)', async () => {
@@ -464,13 +465,15 @@ describe('#707 write-path prior reads: elevated ≡ missing to hooks/gates/audit
     db._subsystemBus.registerGate('beforePut', (e) => { seen.push(e) }) // default needsPrior: true
     await docs.put('d1', { name: 'secret' })
     await docs.elevate('d1', 1) // warm cekCache
-    await docs.put('d1', { name: 'overwrite' })
     // Pre-#707: the try/catch masked the tier boundary — the warm cekCache let
     // decryptRecord succeed and `existing` carried the elevated plaintext.
     // (The envelope itself, and its version/timestamp, may still surface —
     // only the DECRYPTED content is gated to null, same as a genuine decrypt failure.)
-    const lastEvent = seen[seen.length - 1]!
-    expect(lastEvent.existing).toBeNull()
+    // Post-#715/#716: the write ring refuses this put() outright, before the gate
+    // bus dispatch — resolveGatePrior never runs, so the gate never fires at all.
+    const seenBefore = seen.length
+    await expect(docs.put('d1', { name: 'overwrite' })).rejects.toBeInstanceOf(TierWriteRefusedError)
+    expect(seen.length).toBe(seenBefore)
   })
 
   it('i18nProvenance over an elevated id returns undefined, not the prior densify marker (resolveDensifyPrior, lazy)', async () => {
@@ -501,10 +504,11 @@ describe('#707 write-path prior reads: elevated ≡ missing to hooks/gates/audit
     })
     await users.put('u1', { name: 'n', email: 'top-secret-elevated@example.com' })
     await users.elevate('u1', 1) // warm cekCache
-    await users.put('u1', { name: 'n2', email: 'new@example.com' }) // tier-0 write over the elevated id
     // Pre-#707: resolvePriorValues re-decrypted the elevated envelope (warm
     // cekCache) and put() re-encrypted that plaintext into a NEW, tier-0-wrapped
     // history snapshot — a PERSISTENT leak into the store, not just a transient read.
+    // Post-#715/#716: the write ring refuses this put() outright — no history write at all.
+    await expect(users.put('u1', { name: 'n2', email: 'new@example.com' })).rejects.toBeInstanceOf(TierWriteRefusedError)
     const history = await users.history('u1')
     expect(history.some(h => (h.record as User).email === 'top-secret-elevated@example.com')).toBe(false)
   })

--- a/packages/hub/src/index.ts
+++ b/packages/hub/src/index.ts
@@ -971,7 +971,7 @@ export { EnclaveNotSupportedError } from './kernel/errors.js'
 
 // hierarchical access
 export type { GhostRecord, TierMode, CrossTierAccessEvent } from './kernel/types.js'
-export { TierNotGrantedError, TierDemoteDeniedError, DelegationTargetMissingError } from './kernel/errors.js'
+export { TierNotGrantedError, TierDemoteDeniedError, DelegationTargetMissingError, TierWriteRefusedError } from './kernel/errors.js'
 
 // lazy-mode index errors
 export { IndexRequiredError, IndexWriteFailureError } from './kernel/errors.js'

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -26,7 +26,7 @@ import {
   type SealedShredSlot,
 } from './enclave/index.js'
 import { countLiveEnvelopes } from './lazy-count.js'
-import { liveRecordIsElevated } from './tier-visibility.js'
+import { liveRecordIsElevated, assertTierWritable } from './tier-visibility.js'
 import {
   classifySealedShred as classifySealedShredImpl,
   type TiersContext,
@@ -1728,6 +1728,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     if (!hasWritePermission(this.keyring, this.name)) {
       throw new ReadOnlyError()
     }
+    // #715: elevated record ⇒ tier-0 API refuses (putAtTier/elevate/demote remedy) — see assertTierWritable's doc.
+    await assertTierWritable(this.adapter, this.vault, this.name, id, this.tiers !== null)
 
     // One canonical money encoding from the FIRST pipeline stage:
     // gates, computed fields, and schema validation all see the decoded
@@ -1868,8 +1870,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
 
       if (existingResolved && this.historyConfig.enabled !== false) {
         // History snapshot of the PRIOR version — does NOT carry source from the new write
-        const vdigCtx = this.vdigFields !== null ? { id, prev: existingEnvelope } : undefined
-        const histEnvelope = await this.codec.encryptRecord(existingResolved.record, existingResolved.version, cek, undefined, undefined, vdigCtx, id)
+        const histEnvelope = await this.codec.encryptRecord(existingResolved.record, existingResolved.version, cek, undefined, undefined, this.vdigFields !== null ? { id, prev: existingEnvelope } : undefined, id)
         await this.historyStrategy.saveHistory(this.adapter, this.vault, this.name, id, histEnvelope)
         this.emitter.emit('history:save', { vault: this.vault, collection: this.name, id, version: existingResolved.version })
         if (this.historyConfig.maxVersions) {
@@ -1982,8 +1983,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     // CRITICAL: the history snapshot is a record of the PRIOR version — it must
     // NOT carry the source from the current write (source belongs to the new write only).
     if (existing && this.historyConfig.enabled !== false) {
-      const historyEnvelope = await this.codec.encryptRecord(existing.record, existing.version, cek, undefined, undefined, vdigCtx, id)
-      await this.historyStrategy.saveHistory(this.adapter, this.vault, this.name, id, historyEnvelope)
+      await this.historyStrategy.saveHistory(this.adapter, this.vault, this.name, id, await this.codec.encryptRecord(existing.record, existing.version, cek, undefined, undefined, vdigCtx, id))
 
       this.emitter.emit('history:save', {
         vault: this.vault,
@@ -2668,6 +2668,8 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     if (!hasWritePermission(this.keyring, this.name)) {
       throw new ReadOnlyError()
     }
+    // #716: public deletes only — see assertTierWritable's doc + Step 5 investigation for `internal`.
+    await assertTierWritable(this.adapter, this.vault, this.name, id, !internal && this.tiers !== null)
 
     // Gate bus (Track A) — fires for ALL deletes (carrying `internal`), so a
     // gate handler can collect amendment changes on system-internal deletes
@@ -2725,8 +2727,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
     if (existing && this.historyConfig.enabled !== false) {
       const cek = this.perRecordCek ? await this.resolveRecordCek(id) : undefined
       const prevForVdig = this.vdigFields !== null ? await this.adapter.get(this.vault, this.name, id) : null
-      const historyEnvelope = await this.codec.encryptRecord(existing.record, existing.version, cek, undefined, undefined, this.vdigFields !== null ? { id, prev: prevForVdig } : undefined, id)
-      await this.historyStrategy.saveHistory(this.adapter, this.vault, this.name, id, historyEnvelope)
+      await this.historyStrategy.saveHistory(this.adapter, this.vault, this.name, id, await this.codec.encryptRecord(existing.record, existing.version, cek, undefined, undefined, this.vdigFields !== null ? { id, prev: prevForVdig } : undefined, id))
     }
 
     // Capture the previous envelope's payloadHash BEFORE delete so we
@@ -3774,8 +3775,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
   async _compensateRevertedWrite(id: string): Promise<void> {
     await this._invalidateCacheEntry(id)
     await this.onDirty?.(this.name, id, 'revert', 0)
-    const restored = await this.get(id) // rare revert path — one read buys a semantically-correct event
-    this.emitter.emit('change', { vault: this.vault, collection: this.name, id, action: restored !== null ? 'put' : 'delete' })
+    this.emitter.emit('change', { vault: this.vault, collection: this.name, id, action: (await this.get(id)) !== null ? 'put' : 'delete' }) // rare revert path — one read buys a semantically-correct event
   }
 
   async _invalidateCacheEntry(id: string): Promise<void> {

--- a/packages/hub/src/kernel/errors.ts
+++ b/packages/hub/src/kernel/errors.ts
@@ -716,6 +716,40 @@ export class TierNotGrantedError extends NoydbError {
 }
 
 /**
+ * Thrown when a tier-0 `put()` or `delete()` targets a record whose LIVE
+ * envelope is elevated (`_tier > 0`) — regardless of whether the caller
+ * holds the tier's DEK. `put()`/`delete()` are the tier-0 write APIs;
+ * the sanctioned way to write an elevated record is `putAtTier()`,
+ * `elevate()`, or `demote()`.
+ *
+ * Distinct from `TierNotGrantedError`, which means "no DEK for tier N"
+ * and refuses only non-holders. This error refuses HOLDERS too — the
+ * problem isn't clearance, it's that `put()`/`delete()` are the wrong
+ * API for an already-elevated record (a tier-0 `put()` over one would
+ * otherwise silently demote it; a tier-0 `delete()` would write a
+ * marker with no `_tier`, erasing the elevation signal). It is also
+ * distinct from the read-path invisibility gate (`liveRecordIsElevated`
+ * in `tier-visibility.ts`), which throws nothing — elevated records
+ * simply read as absent there. This is a write-path refusal, not a
+ * read-path ghost.
+ */
+export class TierWriteRefusedError extends NoydbError {
+  readonly tier: number
+  readonly collection: string
+
+  constructor(collection: string, tier: number) {
+    super(
+      'TIER_WRITE_REFUSED',
+      `put()/delete() cannot write to record in collection "${collection}" — ` +
+        `it is elevated to tier ${tier}. Use putAtTier()/elevate()/demote() instead.`,
+    )
+    this.name = 'TierWriteRefusedError'
+    this.collection = collection
+    this.tier = tier
+  }
+}
+
+/**
  * Thrown when an elevated-handle operation runs after the elevation's
  * TTL expired. Reads continue at the original tier; only writes
  * through the scoped handle flip to throwing once expired.

--- a/packages/hub/src/kernel/tier-visibility.ts
+++ b/packages/hub/src/kernel/tier-visibility.ts
@@ -5,12 +5,42 @@
  * of their own, so an elevated record's prior versions would otherwise stay
  * tier-0-decryptable (the read-gate closes the API surface; #712's at-rest
  * arc rewraps the snapshot keys). Envelope inspection only — no decryption.
+ *
+ * #715/#716: the write ring. Invisibility on the read side is exactly what
+ * makes a tier-0 write path treat an elevated record as absent — a put()
+ * believes it's a create (demotion) and a delete() writes a marker with no
+ * _tier (erasing the elevation signal). `assertTierWritable` closes that by
+ * refusing the write outright. Both helpers share a single envelope peek
+ * (`peekLiveTier`) — no duplicated `adapter.get` per write.
  */
 import type { NoydbStore } from './types.js'
+import { TierWriteRefusedError } from './errors.js'
+
+async function peekLiveTier(
+  adapter: NoydbStore, vault: string, name: string, id: string,
+): Promise<number> {
+  const env = await adapter.get(vault, name, id)
+  return env?._tier ?? 0
+}
 
 export async function liveRecordIsElevated(
   adapter: NoydbStore, vault: string, name: string, id: string,
 ): Promise<boolean> {
-  const env = await adapter.get(vault, name, id)
-  return (env?._tier ?? 0) > 0
+  return (await peekLiveTier(adapter, vault, name, id)) > 0
+}
+
+/**
+ * Refuses a tier-0 `put()`/`delete()` targeting an elevated record.
+ * No-op when `tiersEnabled` is false (the cost gate — collections that
+ * never declare tiers pay nothing). Throws `TierWriteRefusedError` with
+ * the record's ACTUAL live tier when elevated — holders included, since
+ * `put()`/`delete()` are the tier-0 APIs and `putAtTier`/`elevate`/`demote`
+ * are the sanctioned tier-aware paths.
+ */
+export async function assertTierWritable(
+  adapter: NoydbStore, vault: string, name: string, id: string, tiersEnabled: boolean,
+): Promise<void> {
+  if (!tiersEnabled) return
+  const tier = await peekLiveTier(adapter, vault, name, id)
+  if (tier > 0) throw new TierWriteRefusedError(name, tier)
 }


### PR DESCRIPTION
Closes #715. Closes #716.

**The hinge of the tier-invisibility campaign.** #700/#710/#714/#717 made the tier-0 *read* surface fully compliant — but every one of those gates rests on a single premise: **the live envelope's `_tier` is trustworthy**. This PR closes the two ways a tier-0 caller falsified it.

## The bug, and why the campaign created it
Read-invisibility and write-safety are in direct conflict. Invisibility tells a tier-0 writer *"the record isn't there"* — so `put()` treated the id as a **create**, and a create at tier 0 **is a demotion**. The very gates that hid the record are what let it be silently stripped:

- **#715** — `put()` over an elevated id **silently demoted** it (`_tier` 1 → undefined), no clearance check, no audit event, destroying the elevated content. Its lazy path additionally wrote a **history snapshot of the elevated plaintext**, which then passed #712's live-peek *because the put had just demoted the record*. The CRDT branch instead threw a raw crypto error (3 more ungated decrypts).
- **#716** — `delete()` wrote a marker carrying **no `_tier`**, erasing the elevation signal, so the record's prior versions **re-decrypted** through `history()`.

## The fix — refuse uniformly (user-approved)
A tier-0 `put()`/`delete()` targeting an elevated record throws the new **`TierWriteRefusedError`** — **holders included**: `put()`/`delete()` are the tier-0 APIs; `putAtTier()`/`elevate()`/`demote()` are the tier-aware paths and are unaffected.

It's a **choke point, not a sweep**: guarding `_putInternal` and `_doDelete` (after the permission check, before the gate bus and every prior read) makes all **seven** previously-ungated write-path sites *unreachable* rather than individually gated — and #716 dies for free, since no marker is ever written. Gated on `this.tiers !== null`, so collections that never declare tiers pay **zero** round-trips (pinned by an exploding-Proxy adapter test, not a drift-prone call count).

**Rejected:** tier-aware writes (preserve tier) — would resolve tier DEKs inside the kernel write path, the exact layering the read campaign rejected (`getDEK` **auto-mints** unheld keys). **Accepted cost:** a write-side existence oracle (a put to an elevated id throws where a put to a missing id creates) — defensible since `_tier` is already cleartext to the untrusted store. Integrity over write-side existence-hiding.

## Verification
TDD; all REDs pinned the documented bugs. Full hub suite **501 files / 4101 tests** green; typecheck/lint/`check:architecture` clean; `collection.ts` byte-identical to main (4 documented mechanical shrink-joins). Three pre-existing #707 tests were updated — each independently adjudicated as **equivalent-or-stronger**, not weakened (one now sweeps *all* hook invocations; one keeps its leak assertion verbatim).

The whole-branch review enumerated **every** envelope writer and classified each: **no `_tier`-falsification path exists outside the filed set.** Its verdict on the campaign's premise: *"after this branch the premise the read campaign rests on is sound for tier-0 callers."* Two nice confirmations fell out: the **archive engine** is protected *by the read gates themselves* (elevated records read as null → skipped), and **team DEK rotation** drops `_tier` but **fails closed** (the body is tier-DEK-wrapped, so decrypt throws before the put).

## Known residue (tracked, stated in the changeset — not closed here)
- **#718** — internal deletes (derivation/MV cleanup) bypass the guard; derivation output *puts* are now refused by it. Must also carry regression tests for two #707 masks left uncovered.
- **#708** — sync-apply and **coordinated-cutover migration** (`collection.ts:2590`) can still demote warm; plus a team-DEK-rotation availability gap.
- **#712** at-rest, **#709** indexing.

Spec: `docs/superpowers/specs/2026-07-16-write-ring-refusal-design.md`

**Note:** `TierNotGrantedError`'s JSDoc references a `TierAccessDeniedError` that has never existed in this codebase (it misled this arc's own spec). Left untouched as pre-existing; worth a one-line correction someday.