### PR TITLE
fix(hub): elevating a record removes it from tier-0 indexes — persisted sidecars held its plaintext (#709)

### DIFF
--- a/docs/superpowers/plans/2026-07-16-tiers-indexing.md
+++ b/docs/superpowers/plans/2026-07-16-tiers-indexing.md
@@ -1,0 +1,197 @@
+# Arc 2 — tiers × indexing Implementation Plan (#709)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Elevated records leave tier-0 indexes — purge their persisted sidecars (which hold **plaintext** field values under the tier-0 DEK) and in-memory entries on elevation, rebuild on demotion, and skip elevated envelopes in the facade's rebuild/reconcile loops.
+
+**Architecture:** Spec — `docs/superpowers/specs/2026-07-16-tiers-indexing-design.md` (user-approved). Mirrors the existing `forget()` → `purgePersistedIndexes` precedent. One new `TiersContext.syncIndexes` callback, following the established `syncCache` pattern.
+
+**Tech Stack:** TypeScript ESM, vitest. Branch `fix/709-tiers-indexing` off main a6d50c93.
+
+## Global Constraints
+
+- NEVER add Claude/Anthropic attribution to commits/PRs/changelogs.
+- NEVER reference the private pilot client by name — grep the diff before each commit.
+- Ceilings exact (checker = `wc -l` + 1): `collection.ts` **4548**, `vault.ts` 3959, `noydb.ts` 2396. Fund additions with mechanical shrink-joins (single-use `const` inlined into its sole use is the pattern used repeatedly in this campaign — see `git log` for `count()`, tx-revert, `_compensateRevertedWrite`). Never edit ceiling values; never touch vault.ts/noydb.ts. `collection-facade.ts` / `tiers/index.ts` have no ceiling.
+- TDD: RED verified before implementing, every test. Run from `packages/hub/`: `pnpm vitest run <path>`.
+- No new deps; no timing assertions.
+- The sanctioned tier reads (`getAtTier`/`listAtTier`) and the merged read/write gates must be unaffected — existing tiers suites pass untouched.
+
+---
+
+### Task 1: gate the facade's rebuild/reconcile loops (the amplifiers)
+
+**Files:**
+- Modify: `packages/hub/src/with-lookup/indexing/collection-facade.ts` (2 in-line folds)
+- Create: `packages/hub/__tests__/tiers-indexing.test.ts`
+
+**Interfaces:**
+- Consumes: `EncryptedEnvelope._tier`.
+- Produces: the test file's fixture (a lazy, tiered, indexed collection) that Task 2 extends.
+
+Sites (line numbers ±5 — anchor on the code): `rebuildIndexes`'s lazy loop (`:203-209`) and `reconcileIndex`'s loop (`:279-281`), each doing `const record = await ctx.codec.decryptRecord(envelope, ...)` with no tier gate.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/hub/__tests__/tiers-indexing.test.ts`. Copy the `memoryStore()` fixture verbatim from `__tests__/hierarchical-tiers.test.ts`. **NOTE: no test in the repo combines `tiers:` with `indexes:` — you are building this fixture from scratch.** Find the real indexing API first: grep `withIndexing`/`indexStrategy`/`indexes:` in `__tests__/` (e.g. `unique-index.test.ts`, any `lazy-indexes-*.test.ts`) and mirror a working lazy-indexed collection config, then add `tiers: [0, 1]` + `perRecordKeys: true`.
+
+```ts
+/**
+ * #709 — tiers × indexing. Elevated records leave tier-0 indexes: their
+ * persisted sidecars hold PLAINTEXT field values under the tier-0 DEK
+ * (collection-facade.ts:370-377 + record-codec.ts:257), so leaving them in
+ * place means elevating a record never hid what it was indexed by. Mirrors
+ * the forget() → purgePersistedIndexes precedent (facade:426-429).
+ */
+
+describe('#709 facade loops skip elevated records', () => {
+  it('rebuildIndexes: warm session must NOT mint a tier-0 sidecar from an elevated record', async () => {
+    const { store, docs } = await openLazyIndexed()          // lazy + tiers:[0,1] + perRecordKeys + indexes:['salary']
+    await docs.put('e1', { id: 'e1', salary: 200000 })
+    await docs.elevate('e1', 1)                              // warm: seeds the CEK cache
+    await docs.rebuildIndexes()
+    // Pre-#709: the warm cekCache let the ungated decrypt succeed and MINTED a
+    // tier-0-encrypted sidecar holding the elevated record's salary.
+    expect(await store.get('v1', 'docs', '_idx/salary/e1')).toBeNull()
+  })
+
+  it('rebuildIndexes: cold session survives an elevated record (was a brick)', async () => {
+    const h = lazyIndexedHarness()
+    const { docs } = await h.open()
+    await docs.put('e1', { id: 'e1', salary: 200000 })
+    await docs.put('t0', { id: 't0', salary: 50000 })
+    await docs.elevate('e1', 1)
+    const cold = await h.open()
+    // Pre-#709: unwrapCek under the tier-0 DEK threw → rebuildIndexes() bricked.
+    await expect(cold.docs.rebuildIndexes()).resolves.not.toThrow()
+    expect(await cold.store.get('v1', 'docs', '_idx/salary/t0')).not.toBeNull()  // tier-0 sibling still indexed
+  })
+
+  it('reconcileIndex: does not re-create a purged sidecar for an elevated record', async () => {
+    const { store, docs } = await openLazyIndexed()
+    await docs.put('e1', { id: 'e1', salary: 200000 })
+    await docs.elevate('e1', 1)
+    await docs.reconcileIndex('salary')
+    expect(await store.get('v1', 'docs', '_idx/salary/e1')).toBeNull()
+  })
+})
+```
+Verify the sidecar id shape against `persisted-indexes.ts:33-35` (`_idx/<field>/<recordId>`) and the real `rebuildIndexes`/`reconcileIndex` signatures before asserting. Adapt mechanics; never weaken an assert. If a RED doesn't reproduce, STOP → BLOCKED with output (the warm test needs `perRecordKeys: true` for a CEK to cache — without it there's no warm leak to pin).
+
+- [ ] **Step 2: RED** — `pnpm vitest run __tests__/tiers-indexing.test.ts` → the warm tests show a minted sidecar; the cold test throws.
+
+- [ ] **Step 3: Implement** — the campaign's standard fold at BOTH loops, before the decrypt:
+```ts
+    // #709: an elevated record must not be (re)indexed — the sidecar stores the
+    // PLAINTEXT field value under the tier-0 DEK, so minting one here would
+    // publish what elevation is meant to hide. Gate BEFORE the decrypt: a warm
+    // cekCache would otherwise let it succeed (and a cold session throw).
+    if ((envelope._tier ?? 0) > 0) continue
+```
+(Full comment on the first site; a one-liner referencing it on the second.)
+
+- [ ] **Step 4: GREEN + regression** — the new file + `__tests__/hierarchical-tiers.test.ts` + any lazy-index suites your grep surfaced; `node scripts/check-architecture.mjs`; typecheck; lint.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/with-lookup/indexing/collection-facade.ts packages/hub/__tests__/tiers-indexing.test.ts
+git commit -m "fix(hub): index rebuild/reconcile skip elevated records — no tier-0 sidecar minted from tier-1 plaintext (#709)"
+```
+
+---
+
+### Task 2: tier ops maintain indexes (purge on elevate, rebuild on demote)
+
+**Files:**
+- Modify: `packages/hub/src/with-audit/tiers/index.ts` (`TiersContext` + `elevate`/`demote`/`putAtTier`)
+- Modify: `packages/hub/src/kernel/collection.ts` (one `syncIndexes` wiring line; net-zero via shrink-join)
+- Modify: `packages/hub/__tests__/tiers-indexing.test.ts` (append)
+
+**Interfaces:**
+- Produces: `TiersContext.syncIndexes(id: string, record: T | null): Promise<void>` — `null` → purge persisted sidecars + drop in-memory entries; a record → (re)build entries from it.
+- Consumes (all already wrapped as Collection methods): `purgePersistedIndexes` (`collection.ts:47`, impl `collection-facade.ts:437`), `maintainPersistedIndexesOnPut` (`collection.ts:45`, impl `:337`, called at `:2065`), `this.indexes?.upsert(id, rec, prior)` (`:2070`) / `?.remove(id, rec)` (`:2789`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append. Cover lazy (sidecars) AND eager (in-memory only):
+
+```ts
+describe('#709 tier ops maintain indexes', () => {
+  it('LAZY: elevate purges the record’s persisted sidecar; demote restores it', async () => {
+    const { store, docs } = await openLazyIndexed()
+    await docs.put('e1', { id: 'e1', salary: 200000 })
+    expect(await store.get('v1', 'docs', '_idx/salary/e1')).not.toBeNull()
+    await docs.elevate('e1', 1)
+    // Pre-#709: the sidecar survived, tier-0-readable, holding salary=200000 —
+    // elevating never hid the indexed value (the forget() precedent, unapplied).
+    expect(await store.get('v1', 'docs', '_idx/salary/e1')).toBeNull()
+    await docs.demote('e1', 0)
+    expect(await store.get('v1', 'docs', '_idx/salary/e1')).not.toBeNull()   // tier-0 again → indexed again
+  })
+
+  it('LAZY: putAtTier(>0) purges; putAtTier(0) maintains the sidecar at the NEW value', async () => {
+    const { store, docs } = await openLazyIndexed()
+    await docs.put('p1', { id: 'p1', salary: 100 })
+    await docs.putAtTier('p1', { id: 'p1', salary: 999 }, 1)
+    expect(await store.get('v1', 'docs', '_idx/salary/p1')).toBeNull()
+    await docs.putAtTier('p1', { id: 'p1', salary: 555 }, 0)
+    expect(await store.get('v1', 'docs', '_idx/salary/p1')).not.toBeNull()
+  })
+
+  it('EAGER: an elevated record is not returned by an index-driven query', async () => {
+    const { docs } = await openEagerIndexed()   // eager + tiers + indexes
+    await docs.put('e1', { id: 'e1', salary: 200000 })
+    await docs.put('t0', { id: 't0', salary: 200000 })
+    await docs.elevate('e1', 1)
+    const hits = await docs.query().where('salary', '==', 200000).toArray()   // adapt to the real query API
+    expect(hits.map(r => r.id)).toEqual(['t0'])
+  })
+
+  it('EAGER: putAtTier(id, rec, 0) refreshes the index — no stale false positive on the OLD value', async () => {
+    const { docs } = await openEagerIndexed()
+    await docs.put('p1', { id: 'p1', salary: 100 })
+    await docs.putAtTier('p1', { id: 'p1', salary: 555 }, 0)
+    // Pre-#709: the stale entry 100→p1 survived AND index hits are never
+    // re-verified (builder.ts:1160-1166 drops the clause) → a silent false positive.
+    expect((await docs.query().where('salary', '==', 100).toArray()).length).toBe(0)
+    expect((await docs.query().where('salary', '==', 555).toArray()).map(r => r.id)).toEqual(['p1'])
+  })
+})
+```
+Adapt the query API to the real one (grep an existing eager index test). If eager+tiers+indexes cannot be configured, report it — don't fake it.
+
+- [ ] **Step 2: RED** — sidecar survives elevate; putAtTier(0) leaves the stale entry / the elevated record appears in query results.
+
+- [ ] **Step 3: Implement**
+
+(a) `TiersContext` — add beside `syncCache`, with the doc comment from the spec (state WHY: sidecars hold plaintext under the tier-0 DEK; cite the `forget()` precedent):
+```ts
+  syncIndexes(id: string, record: T | null): Promise<void>
+```
+(b) `elevate` → `await ctx.syncIndexes(id, null)`; `demote` → `await ctx.syncIndexes(id, <the decoded tier-0 record>)` when `toTier === 0`, else `null`; `putAtTier` → `null` when `tier > 0`, else the record. **Place each AFTER its `adapter.put` lands** (the ordering rule #691 set for `syncCache`: never blind a cache for a write that then throws). `demote`-to-0 already decodes the record for `syncCache`'s re-seed — reuse that decode, do not decrypt twice.
+(c) `collection.ts` `tiersContext()` — one line:
+```ts
+      syncIndexes: async (id: string, rec: T | null) => { if (rec === null) { await this.purgePersistedIndexes(id); this.indexes?.remove(id, ???) } else { await this.maintainPersistedIndexesOnPut(id, rec, null, ???); this.indexes?.upsert(id, rec, null) } },
+```
+Resolve the `???`s against the real signatures (`indexes.remove` needs the record to compute its keys — if the record isn't available on the purge path, read what `_doDelete` does at `collection.ts:2789` and mirror it; `maintainPersistedIndexesOnPut` needs a version — use the freshly-written envelope's `_v`, threading it through the callback if needed). If the callback grows past one line, extract the body into a small helper module rather than blowing the ceiling — that extraction is what the ratchet is for. Must no-op fast when the collection has no indexes.
+
+collection.ts must end at exactly **4548** (`git show a6d50c93:packages/hub/src/kernel/collection.ts | wc -l`). Document each shrink-join.
+
+- [ ] **Step 4: GREEN + regression** — the new file + `__tests__/hierarchical-tiers.test.ts` + `__tests__/tier0-read-paths.test.ts` + `__tests__/tier-write-ring.test.ts` + `__tests__/per-record-cek.test.ts` + index suites; then the FULL hub suite from root; `node scripts/check-architecture.mjs`; typecheck; lint. Report any pre-existing test that changes behavior and adjudicate it (do not edit a test green without stating why the old assertion was wrong).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/with-audit/tiers/index.ts packages/hub/src/kernel/collection.ts packages/hub/__tests__/tiers-indexing.test.ts
+git commit -m "fix(hub): tier moves maintain indexes — elevate purges sidecars, demote restores them (#709)"
+```
+
+---
+
+### Final: full suite + whole-branch review + changeset + PR
+
+- [ ] `pnpm --filter @noy-db/hub test` + typecheck + lint + `pnpm check:architecture` — green.
+- [ ] Whole-branch review (fable — an at-rest leak arc: ask it to hunt for any surviving path that leaves or mints a tier-0-readable artifact derived from an elevated record's plaintext, and to check the intended consequence — elevated records are unindexed even for cleared callers — is documented, not accidental).
+- [ ] Local changeset: `@noy-db/hub` **patch** — state that elevating a record now purges its persisted index sidecars (they held plaintext field values readable at tier 0), that tier-0 index queries no longer surface elevated records, and the intended consequence that elevated records are not index-findable at all.
+- [ ] PR → main: `Closes #709`.

--- a/docs/superpowers/specs/2026-07-16-tiers-indexing-design.md
+++ b/docs/superpowers/specs/2026-07-16-tiers-indexing-design.md
@@ -1,0 +1,61 @@
+# Arc 2 — tiers × indexing: elevated records leave tier-0 indexes (#709)
+
+**Issue:** [#709](https://github.com/vLannaAi/noy-db/issues/709) — see [this comment](https://github.com/vLannaAi/noy-db/issues/709#issuecomment-4988327097) for the full file:line-anchored recon; the issue's original text is wrong on one claim and misses the headline.
+**Predecessors (merged):** #700/#710/#714/#717 (read surface) + #719 (write ring — no public tier-0 path can demote or erase `_tier`).
+
+## The problem
+
+**Headline (absent from the issue): persisted index sidecars leak an elevated record's plaintext field value, at rest.**
+`with-lookup/indexing/collection-facade.ts:370-377` stores each sidecar `_idx/<field>/<recordId>` as `{field, value: serializeIndexValue(v), recordId}` — and `serializeIndexValue` (`:87-90`) only ISO-izes Dates; **every other value passes through verbatim**. It is encrypted via `encryptJsonString` → `record-codec.ts:257` `getDEK()` → `dekKey(name, 0) === name` — i.e. **always under the tier-0 DEK**, whatever the record's tier. `elevate()` never touches it.
+
+So with **no facade call at all**: `put('emp-1', {salary: 200000})` → `elevate('emp-1', 1)` → any tier-0 caller decodes `_idx/salary/emp-1` (`collection.ts:4230-4237`, ungated) and learns **the exact value and the owning id**. Elevating a record never hid its indexed field values.
+
+**The codebase already recognized this exact leak class — for `forget()`** (`collection-facade.ts:426-429`): *"`forget()` crypto-shreds the body but keeps the collection DEK, under which these side-cars are encrypted — so without this they leave the indexed field VALUES readable after a 'forget'."* `purgePersistedIndexes` exists **because of it**. The same reasoning was never applied to `elevate()`. That precedent is both the severity argument and the fix shape.
+
+**Amplifiers:** `rebuildIndexes` (`:203-209`) and `reconcileIndex` (`:279-281`) decrypt every canonical envelope ungated → warm cekCache **mints a fresh tier-0 sidecar from an elevated record** (a warm leak that materializes into a permanent at-rest one; `reconcileIndex` will even **re-create a sidecar someone deleted**), cold session **throws** and bricks the operation.
+
+**Correctness (not a leak):** the eager path is cache-mediated (`builder.ts:1179-1188` → `collection.ts:3307` `lookupById` → the elevated-free cache), so a stale entry resolves to `undefined`. But index hits are **never re-verified** (the clause is dropped from the post-filter, `builder.ts:1160-1166`), so `putAtTier(id, rec, 0)`'s stale entry is a **silent false positive**.
+
+**Not a problem:** `uniqueConstraints` + tiers is already **refused at registration** (`unique-constraints.ts:158-163`) — the issue's claim there is impossible.
+
+## Decision (user-approved 2026-07-16): purge on elevate, restore on demote
+
+**Elevated records are simply not present in tier-0 indexes** — the indexing expression of the invisibility law, and a direct mirror of the `forget()` → `purgePersistedIndexes` precedent.
+
+| Op | Index action |
+|---|---|
+| `elevate(id, N>0)`, `putAtTier(id, rec, N>0)` | **Purge** the record's `_idx/*/<id>` sidecars **and** drop its in-memory index entries |
+| `demote(id, 0)`, `putAtTier(id, rec, 0)` | **Rebuild/maintain** entries from the (now tier-0) record — also fixes the stale-entry false positive |
+| `rebuildIndexes` / `reconcileIndex` facade loops | **Skip** elevated envelopes *before* the decrypt — kills the warm mint and the cold brick |
+
+**Rejected — refuse `indexes` + `tiers`** (mirroring the unique refusal): consistent, but removes a working combination instead of fixing it; non-unique indexes are a query optimization, not a correctness constraint. **Deferred — tier-scoped sidecars** (encrypted under the tier DEK so cleared callers can still query elevated records): a real future option, not needed to close the leak.
+
+**Consequence, intended:** an elevated record is unindexed and therefore not findable by *any* index-driven query, including from a session holding its tier DEK. `getAtTier`/`listAtTier` remain the tier-aware read surfaces. Document it.
+
+## Design
+
+Everything needed already exists — this is wiring, not invention:
+- `purgePersistedIndexes(ctx, id)` (`collection-facade.ts:437`) — the forget path's purge; already wrapped on Collection (`collection.ts:47`).
+- `maintainPersistedIndexesOnPut(ctx, id, newRecord, previousRecord, version)` (`:337`) — already wrapped (`collection.ts:45`, called at `:2065`).
+- `this.indexes?.upsert(id, record, prior)` / `?.remove(id, record)` (`collection.ts:2070`, `:2789`).
+
+`TiersContext` gains **one callback**, mirroring the established `syncCache` pattern (`collection.ts:4517`):
+
+```ts
+/** Sync the collection's indexes after a tier move (#709). `null` → the record left
+ *  tier 0: purge its persisted sidecars (they hold PLAINTEXT field values under the
+ *  tier-0 DEK — see purgePersistedIndexes' forget() precedent) and drop its in-memory
+ *  entries. A record → it is tier-0 again: (re)build its entries from that record. */
+syncIndexes(id: string, record: T | null): Promise<void>
+```
+
+Wired in `tiersContext()`; called by `elevate`/`demote`/`putAtTier` **after** their `adapter.put` lands (same ordering rule #691 established for `syncCache`: never blind the caches for a write that then throws).
+
+The facade gate is the campaign's standard fold: `if ((envelope._tier ?? 0) > 0) continue` **before** `decryptRecord`, at both loops.
+
+## Constraints
+
+- Ceiling: `collection.ts` **4548** exact (checker 4549). Expect ~+2 (the `syncIndexes` wiring line + any import) → fund with mechanical shrink-joins. Never edit ceiling values; `vault.ts`/`noydb.ts` untouched. `collection-facade.ts` and `tiers/index.ts` have no ceiling.
+- Zero-knowledge invariant: the facade gate resolves **no** key material (envelope peek); the demote rebuild decodes only a record already at tier 0.
+- Cost: purge/rebuild only runs on tier moves, and `syncIndexes` must no-op fast when the collection has no indexes.
+- **Coverage gap to close:** no test anywhere combines `tiers:` with `indexes:` — the entire exposed configuration is untested. Tests must cover lazy (sidecars exist) *and* eager (in-memory only).

--- a/packages/hub/__tests__/tiers-indexing.test.ts
+++ b/packages/hub/__tests__/tiers-indexing.test.ts
@@ -94,6 +94,27 @@ async function openLazyIndexed() {
   return { store: h.store, ...opened }
 }
 
+/**
+ * An eager, tiered, indexed collection: default `prefetch` (eager,
+ * in-memory `CollectionIndexes` mirror, synchronous `.query().toArray()`)
+ * + `tiers: [0, 1]` + `indexes: ['salary']`.
+ */
+async function openEagerIndexed() {
+  const db = await createNoydb({
+    store: memoryStore(),
+    user: 'owner',
+    secret: SECRET,
+    indexStrategy: withIndexing(),
+    tiersStrategy: withTiers(),
+  })
+  const vault = await db.openVault('v1')
+  const docs = vault.collection<Emp>('docs', {
+    indexes: ['salary'],
+    tiers: [0, 1],
+  })
+  return { db, vault, docs }
+}
+
 describe('#709 facade loops skip elevated records', () => {
   it('rebuildIndexes: warm session must NOT mint a tier-0 sidecar from an elevated record', async () => {
     const { store, docs } = await openLazyIndexed()
@@ -123,5 +144,47 @@ describe('#709 facade loops skip elevated records', () => {
     await docs.elevate('e1', 1)
     await docs.reconcileIndex('salary')
     expect(await store.get('v1', 'docs', '_idx/salary/e1')).toBeNull()
+  })
+})
+
+describe('#709 tier ops maintain indexes', () => {
+  it('LAZY: elevate purges the record’s persisted sidecar; demote restores it', async () => {
+    const { store, docs } = await openLazyIndexed()
+    await docs.put('e1', { id: 'e1', salary: 200000 })
+    expect(await store.get('v1', 'docs', '_idx/salary/e1')).not.toBeNull()
+    await docs.elevate('e1', 1)
+    // Pre-#709: the sidecar survived, tier-0-readable, holding salary=200000 —
+    // elevating never hid the indexed value (the forget() precedent, unapplied).
+    expect(await store.get('v1', 'docs', '_idx/salary/e1')).toBeNull()
+    await docs.demote('e1', 0)
+    expect(await store.get('v1', 'docs', '_idx/salary/e1')).not.toBeNull()   // tier-0 again → indexed again
+  })
+
+  it('LAZY: putAtTier(>0) purges; putAtTier(0) maintains the sidecar at the NEW value', async () => {
+    const { store, docs } = await openLazyIndexed()
+    await docs.put('p1', { id: 'p1', salary: 100 })
+    await docs.putAtTier('p1', { id: 'p1', salary: 999 }, 1)
+    expect(await store.get('v1', 'docs', '_idx/salary/p1')).toBeNull()
+    await docs.putAtTier('p1', { id: 'p1', salary: 555 }, 0)
+    expect(await store.get('v1', 'docs', '_idx/salary/p1')).not.toBeNull()
+  })
+
+  it('EAGER: an elevated record is not returned by an index-driven query', async () => {
+    const { docs } = await openEagerIndexed()   // eager + tiers + indexes
+    await docs.put('e1', { id: 'e1', salary: 200000 })
+    await docs.put('t0', { id: 't0', salary: 200000 })
+    await docs.elevate('e1', 1)
+    const hits = docs.query().where('salary', '==', 200000).toArray()
+    expect(hits.map(r => r.id)).toEqual(['t0'])
+  })
+
+  it('EAGER: putAtTier(id, rec, 0) refreshes the index — no stale false positive on the OLD value', async () => {
+    const { docs } = await openEagerIndexed()
+    await docs.put('p1', { id: 'p1', salary: 100 })
+    await docs.putAtTier('p1', { id: 'p1', salary: 555 }, 0)
+    // Pre-#709: the stale entry 100→p1 survived AND index hits are never
+    // re-verified (builder.ts:1160-1166 drops the clause) → a silent false positive.
+    expect(docs.query().where('salary', '==', 100).toArray().length).toBe(0)
+    expect(docs.query().where('salary', '==', 555).toArray().map(r => r.id)).toEqual(['p1'])
   })
 })

--- a/packages/hub/__tests__/tiers-indexing.test.ts
+++ b/packages/hub/__tests__/tiers-indexing.test.ts
@@ -1,0 +1,127 @@
+/**
+ * #709 — tiers × indexing. Elevated records leave tier-0 indexes: their
+ * persisted sidecars hold PLAINTEXT field values under the tier-0 DEK
+ * (collection-facade.ts:370-377 + record-codec.ts:257), so leaving them in
+ * place means elevating a record never hid what it was indexed by. Mirrors
+ * the forget() → purgePersistedIndexes precedent (facade:426-429).
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, ConflictError } from '../src/index.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
+import { withIndexing } from '../src/with-lookup/indexing/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
+
+interface Emp {
+  id: string
+  salary: number
+}
+
+// Copied verbatim from hierarchical-tiers.test.ts.
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll(v, snap) {
+      const vm = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [cn, recs] of Object.entries(snap)) {
+        const cm = new Map<string, EncryptedEnvelope>()
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+        vm.set(cn, cm)
+      }
+      data.set(v, vm)
+    },
+  }
+}
+
+const SECRET = 'tiers-indexing-passphrase-2026'
+
+/**
+ * A lazy, tiered, indexed collection: `prefetch: false` (side-cars are
+ * durable, not just an in-memory mirror) + `tiers: [0, 1]` + `indexes:
+ * ['salary']` + `perRecordKeys: true` (a record CEK exists to warm-cache —
+ * without it there is no warm leak to pin, see the design brief).
+ */
+function lazyIndexedHarness() {
+  const store = memoryStore()
+  return {
+    store,
+    async open() {
+      const db = await createNoydb({
+        store,
+        user: 'owner',
+        secret: SECRET,
+        indexStrategy: withIndexing(),
+        tiersStrategy: withTiers(),
+      })
+      const vault = await db.openVault('v1')
+      const docs = vault.collection<Emp>('docs', {
+        prefetch: false,
+        cache: { maxRecords: 100 },
+        indexes: ['salary'],
+        tiers: [0, 1],
+        perRecordKeys: true,
+      })
+      return { db, vault, docs }
+    },
+  }
+}
+
+async function openLazyIndexed() {
+  const h = lazyIndexedHarness()
+  const opened = await h.open()
+  return { store: h.store, ...opened }
+}
+
+describe('#709 facade loops skip elevated records', () => {
+  it('rebuildIndexes: warm session must NOT mint a tier-0 sidecar from an elevated record', async () => {
+    const { store, docs } = await openLazyIndexed()
+    await docs.put('e1', { id: 'e1', salary: 200000 })
+    await docs.elevate('e1', 1)                              // warm: seeds the CEK cache
+    await docs.rebuildIndexes()
+    // Pre-#709: the warm cekCache let the ungated decrypt succeed and MINTED a
+    // tier-0-encrypted sidecar holding the elevated record's salary.
+    expect(await store.get('v1', 'docs', '_idx/salary/e1')).toBeNull()
+  })
+
+  it('rebuildIndexes: cold session survives an elevated record (was a brick)', async () => {
+    const h = lazyIndexedHarness()
+    const { docs } = await h.open()
+    await docs.put('e1', { id: 'e1', salary: 200000 })
+    await docs.put('t0', { id: 't0', salary: 50000 })
+    await docs.elevate('e1', 1)
+    const cold = await h.open()
+    // Pre-#709: unwrapCek under the tier-0 DEK threw → rebuildIndexes() bricked.
+    await expect(cold.docs.rebuildIndexes()).resolves.not.toThrow()
+    expect(await h.store.get('v1', 'docs', '_idx/salary/t0')).not.toBeNull()  // tier-0 sibling still indexed
+  })
+
+  it('reconcileIndex: does not re-create a purged sidecar for an elevated record', async () => {
+    const { store, docs } = await openLazyIndexed()
+    await docs.put('e1', { id: 'e1', salary: 200000 })
+    await docs.elevate('e1', 1)
+    await docs.reconcileIndex('salary')
+    expect(await store.get('v1', 'docs', '_idx/salary/e1')).toBeNull()
+  })
+})

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -45,6 +45,7 @@ import {
   maintainPersistedIndexesOnPut as maintainPersistedIndexesOnPutImpl,
   maintainPersistedIndexesOnDelete as maintainPersistedIndexesOnDeleteImpl,
   purgePersistedIndexes as purgePersistedIndexesImpl,
+  syncTierIndexes as syncTierIndexesImpl,
   type IndexingContext,
 } from '../with-lookup/indexing/collection-facade.js'
 import { ConflictError, ReadOnlyError, ClassifiedConfigError, ClassifiedRevealError, ClassifiedVerifyError } from './errors.js'
@@ -788,8 +789,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
         if (localJson === null) return local
         if (remoteJson === null) return remote
         const localState = JSON.parse(localJson) as CrdtState
-        const remoteState = JSON.parse(remoteJson) as CrdtState
-        const merged = this.crdtStrategy.mergeCrdtStates(localState, remoteState)
+        const merged = this.crdtStrategy.mergeCrdtStates(localState, JSON.parse(remoteJson) as CrdtState)
         const mergedVersion = Math.max(local._v, remote._v) + 1
         const cek = this.perRecordCek ? await this.resolveRecordCek(id) : undefined
         return this.codec.encryptJsonString(JSON.stringify(merged), mergedVersion, cek)
@@ -1843,8 +1843,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
             }
           }
         }
-        const arr = Array.isArray(record) ? record : [record]
-        crdtState = this.crdtStrategy.buildRgaState(arr, existingState, generateULID)
+        crdtState = this.crdtStrategy.buildRgaState(Array.isArray(record) ? record : [record], existingState, generateULID)
       } else {
         // yjs: record is the base64 update string (produced by @noy-db/yjs)
         crdtState = { _crdt: 'yjs', update: record as unknown as string }
@@ -4513,6 +4512,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       codec: this.codec,
       cekCache: this.cekCache,
       syncCache: (id: string, e: { record: T; version: number } | null) => { if (e) this.cache.set(id, e); else this.cache.delete(id); this.lru?.remove(id) },
+      syncIndexes: (id: string, rec: T | null, version?: number) => syncTierIndexesImpl(this.indexingContext(), id, rec, version),
       provenance: this.provenance,
       tiers: this.tiers,
       tierMode: this.tierMode,

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -68,6 +68,23 @@ export interface TiersContext<T> {
    * plain-`get()`-readable in-session).
    */
   syncCache(id: string, entry: { record: T; version: number } | null): void
+  /**
+   * Sync the collection's indexes after a tier move rewraps the envelope
+   * (#709). Persisted `_idx/<field>/<recordId>` side-cars hold the indexed
+   * field's PLAINTEXT value and are always encrypted under the tier-0 DEK,
+   * whatever the record's own tier — the same leak class `forget()` fixed
+   * via `purgePersistedIndexes` ("forget() crypto-shreds the body but keeps
+   * the collection DEK, under which these side-cars are encrypted — so
+   * without this they leave the indexed field VALUES readable"). `null` →
+   * the record just left tier 0: purge its persisted side-cars and drop its
+   * in-memory index entries. A record → it is tier-0 again: (re)build its
+   * entries from that record. Call this BEFORE {@link syncCache} — the
+   * implementation reads the pre-write cached value as "previous" to clean
+   * up stale index buckets, so it must run while that entry is still live.
+   * `version` stamps a rebuilt side-car's own envelope version (ignored on
+   * purge).
+   */
+  syncIndexes(id: string, record: T | null, version?: number): Promise<void>
   /** Emit `_source`/`_sourceTs` provenance fields when a source is supplied. */
   readonly provenance: boolean
   /** Declared tiers, or null when the feature is off. */
@@ -148,13 +165,17 @@ export async function putAtTier<T>(
 
   await ctx.adapter.put(ctx.vault, ctx.name, id, envelope)
 
-  // #702: keep the record cache coherent with the raw write — same law as
-  // elevate/demote (#691): tier > 0 → invisible on tier-0 surfaces (evict);
-  // tier 0 → this is an ordinary write, re-seed via the canonical decode.
+  // #702/#709: keep the record cache AND indexes coherent with the raw
+  // write — same law as elevate/demote (#691): tier > 0 → invisible on
+  // tier-0 surfaces (evict + purge); tier 0 → an ordinary write (re-seed +
+  // reindex). syncIndexes runs first — it needs the pre-write cache entry
+  // as "previous", which syncCache is about to overwrite/evict.
   if (tier > 0) {
+    await ctx.syncIndexes(id, null)
     ctx.syncCache(id, null)
   } else {
     const rec = await ctx.codec.decryptRecord(envelope, { id, sealedAsHandles: true })
+    await ctx.syncIndexes(id, rec, envelope._v)
     ctx.syncCache(id, rec !== null ? { record: rec, version: envelope._v } : null)
   }
 
@@ -319,8 +340,12 @@ export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: numbe
     ...(body._cek !== undefined ? { _cek: body._cek } : {}),
   }
   await ctx.adapter.put(ctx.vault, ctx.name, id, next)
-  // Evict only once the write landed — a throwing put must not blind the
-  // eager cache to a still-valid tier-0 record (same ordering as demote).
+  // Evict/purge only once the write landed — a throwing put must not blind
+  // the eager cache or leave a readable index behind for a still-valid
+  // tier-0 record (same ordering as demote). #709: syncIndexes runs first —
+  // it needs the pre-elevation cache entry as "previous" to clean the
+  // eager index bucket; the persisted side-car purge is content-free.
+  await ctx.syncIndexes(id, null)
   ctx.syncCache(id, null)
 
   ctx.emitCrossTierEvent({
@@ -386,17 +411,22 @@ export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number
   }
   await ctx.adapter.put(ctx.vault, ctx.name, id, next)
 
-  // #691: landing back at tier 0 makes this a plain tier-0 record again — it
-  // must stay plain-get()-readable in the same session, so re-seed the
-  // eager cache from the just-written (now tier-0-keyed) envelope through
-  // the canonical codec path, the same decode collection.ts's own eager
-  // hydration / lazy cache-miss paths use. A demote that lands on an
-  // intermediate elevated tier (toTier > 0) still evicts: the record stays
-  // above tier 0 and must remain invisible on tier-0 surfaces.
+  // #691/#709: landing back at tier 0 makes this a plain tier-0 record
+  // again — it must stay plain-get()-readable AND indexed in the same
+  // session, so re-seed the eager cache and rebuild its index entries from
+  // the just-written (now tier-0-keyed) envelope through the canonical
+  // codec path, the same decode collection.ts's own eager hydration / lazy
+  // cache-miss paths use — reused for both, no double-decrypt. A demote
+  // that lands on an intermediate elevated tier (toTier > 0) still evicts
+  // + purges: the record stays above tier 0 and must remain invisible on
+  // tier-0 surfaces, unindexed. syncIndexes runs first in both branches —
+  // it needs the pre-demote cache entry as "previous".
   if (toTier === 0) {
     const rec = await ctx.codec.decryptRecord(next, { id, sealedAsHandles: true })
+    await ctx.syncIndexes(id, rec, next._v)
     ctx.syncCache(id, rec !== null ? { record: rec, version: next._v } : null)
   } else {
+    await ctx.syncIndexes(id, null)
     ctx.syncCache(id, null)
   }
 

--- a/packages/hub/src/with-lookup/indexing/collection-facade.ts
+++ b/packages/hub/src/with-lookup/indexing/collection-facade.ts
@@ -455,3 +455,45 @@ export async function purgePersistedIndexes<T>(ctx: IndexingContext<T>, id: stri
   }
   return { purged, residue }
 }
+
+/**
+ * Sync this collection's indexes after a tier move (#709). Persisted
+ * `_idx/<field>/<recordId>` side-cars are always encrypted under the
+ * tier-0 DEK regardless of the record's own tier, and the eager in-memory
+ * `CollectionIndexes` mirror holds plaintext bucket values too — so both
+ * leak an elevated record's indexed field values unless swept the same way
+ * `purgePersistedIndexes` already sweeps them for `forget()` ("forget()
+ * crypto-shreds the body but keeps the collection DEK, under which these
+ * side-cars are encrypted — so without this they leave the indexed field
+ * VALUES readable", `purgePersistedIndexes` above).
+ *
+ * `record === null` — the record just left tier 0: purge its persisted
+ * side-cars (content-free, no decrypt needed) and drop its eager-mirror
+ * entry, read from `ctx.cache` (the caller's pre-write value — the caller
+ * MUST invoke this before evicting/overwriting that cache entry, so it
+ * still reflects the value being replaced).
+ *
+ * `record` given — the record is tier-0 again: (re)build its entries from
+ * that record, using the SAME pre-write `ctx.cache` read as the previous
+ * value so a stale bucket (e.g. a same-tier `putAtTier` value change) is
+ * cleaned up rather than left as a false-positive hit. `version` stamps
+ * the rebuilt side-car's own envelope version.
+ *
+ * No-ops fast when the collection has neither index kind declared.
+ */
+export async function syncTierIndexes<T>(
+  ctx: IndexingContext<T>,
+  id: string,
+  record: T | null,
+  version?: number,
+): Promise<void> {
+  if (!ctx.indexes && !ctx.persistedIndexes) return
+  const prior = ctx.cache.get(id)?.record ?? null
+  if (record === null) {
+    await purgePersistedIndexes(ctx, id)
+    if (prior) ctx.indexes?.remove(id, prior)
+  } else {
+    await maintainPersistedIndexesOnPut(ctx, id, record, prior, version ?? 1)
+    ctx.indexes?.upsert(id, record, prior)
+  }
+}

--- a/packages/hub/src/with-lookup/indexing/collection-facade.ts
+++ b/packages/hub/src/with-lookup/indexing/collection-facade.ts
@@ -203,6 +203,11 @@ export async function rebuildIndexes<T>(ctx: IndexingContext<T>): Promise<void> 
   for (const recordId of canonicalIds) {
     const envelope = await ctx.adapter.get(ctx.vault, ctx.name, recordId)
     if (!envelope) continue
+    // #709: an elevated record must not be (re)indexed — the sidecar stores the
+    // PLAINTEXT field value under the tier-0 DEK, so minting one here would
+    // publish what elevation is meant to hide. Gate BEFORE the decrypt: a warm
+    // cekCache would otherwise let it succeed (and a cold session throw).
+    if ((envelope._tier ?? 0) > 0) continue
     const record = await ctx.codec.decryptRecord(envelope, { skipValidation: true, id: recordId })
     if (record === null) continue // shredded (tombstone) — no side-car to build
     await maintainPersistedIndexesOnPut(ctx, recordId, record, null, envelope._v)
@@ -278,6 +283,7 @@ export async function reconcileIndex<T>(
     if (id.startsWith('_')) continue
     const env = await ctx.adapter.get(ctx.vault, ctx.name, id)
     if (!env) continue
+    if ((env._tier ?? 0) > 0) continue // #709: skip elevated records — see rebuildIndexes' gate above
     const record = await ctx.codec.decryptRecord(env, { skipValidation: true, id })
     // Shredded (tombstone) canonical record: treat like a vanished record —
     // leave its `id` in `sidecarIds` so any lingering side-car is marked


### PR DESCRIPTION
Closes #709.

**The campaign's second at-rest leak** — and unlike the read gates, this one needed no exotic path: `put()` + `elevate()` alone leaked.

## The bug
Persisted index sidecars `_idx/<field>/<recordId>` (`collection-facade.ts:370-377`) store the indexed field's **plaintext value** (`serializeIndexValue` only ISO-izes Dates — everything else passes verbatim), encrypted **always under the tier-0 DEK** whatever the record's own tier (`record-codec.ts:257` → `dekKey(name, 0) === name`). `elevate()` never touched them. So:

```
put('emp-1', { salary: 200000 })   → sidecar _idx/salary/emp-1 = 200000, tier-0-encrypted
elevate('emp-1', 1)                → body rewrapped to the tier-1 DEK; sidecar UNTOUCHED
```
Any tier-0 caller then reads the value straight back. **Elevating a record never hid what it was indexed by.** A reviewer decoded a pre-fix sidecar to confirm it isn't theoretical: `SCRATCH-DECODE e1 sidecar value: 200000`.

**The codebase already knew this leak class** — `purgePersistedIndexes` exists *because* `forget()` hit it (`facade:426-429`: *"forget() crypto-shreds the body but keeps the collection DEK, under which these side-cars are encrypted — so without this they leave the indexed field VALUES readable"*). Nobody applied that reasoning to `elevate()`. This PR wires the existing precedent to its sibling case.

## The fix
- **Tier ops maintain indexes** via a new `TiersContext.syncIndexes` (mirroring `syncCache`): `elevate`/`putAtTier(>0)` purge the record's sidecars and drop its in-memory entries; `demote`/`putAtTier(0)` rebuild them.
- **Rebuild/reconcile skip elevated records** before decrypting. Previously the elevating session's warm CEK cache let the decrypt succeed and **minted a fresh tier-0 sidecar** from the elevated plaintext (reconcile would even re-create a deleted one), while a cold session **threw and bricked** the operation.
- **A tier-0 `putAtTier()` refreshes entries**, fixing a stale false positive — a query on the record's *old* value could return it, since index hits are never re-verified against the record.

## Verification
Full suite **502 files / 4108 tests** green; typecheck/lint/`check:architecture` clean; `collection.ts` byte-identical to main (two mechanical shrink-joins; the callback body was extracted to `syncTierIndexes` rather than blowing the ceiling).

The tiers×indexes test fixture is **the first of its kind in this repo** — no test had ever combined `tiers:` with `indexes:`, which is precisely how the leak survived.

Reviewers settled two things empirically rather than by argument:
- **The reconcile test is live, not a no-op.** Reverting *only* the `:286` gate turns it RED against a freshly **minted** sidecar (`_v: 2` — created by the reconcile walk, not a survivor). Post-purge an elevated record has no sidecar → reconcile classifies it *missing* → would mint one. The gate is what stops it.
- **Threading the real `prior` was load-bearing.** The plan's draft hardcoded `null`; that would have left the stale eager bucket the fix exists to remove. This forced `syncIndexes` to run *before* `syncCache` (elevate never decrypts, so the eager cache entry is the only prior source — and `syncCache(null)` destroys it). Both remain post-`adapter.put`, so #691's ordering rule holds.

## Scope — this covers FIELD indexes only
The whole-branch review swept every artifact writer and found the same class in the **search** subsystem, outside this arc: **#721** (`_vec` embeddings survive elevation — cold `similarTo()` still surfaces the record; `_ftindex` retains tokenized plaintext so warm `retrieve()` returns **snippets** from the index's own stored text) and **#722** (MV/rollup outputs derived from a record survive its elevation). The changeset says so plainly rather than claiming the record is unindexed everywhere.

Other tracked residue: #720 (lazy dropped-field sidecar), #718 (internal deletes), #708 (sync/cutover), #712 (history at-rest).

Spec: `docs/superpowers/specs/2026-07-16-tiers-indexing-design.md`