### PR TITLE
fix(hub): elevating a record removes it from full-text and semantic search — indexes held its plaintext (#721)

### DIFF
--- a/docs/superpowers/plans/2026-07-16-tiers-search.md
+++ b/docs/superpowers/plans/2026-07-16-tiers-search.md
@@ -1,0 +1,192 @@
+# Arc 6 — tiers × search Implementation Plan (#721)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Elevated records leave tier-0 search — `elevate()` purges the record's `_vec` embedding and invalidates the `_ftindex` lexical blob; `demote()` re-embeds and rebuilds; `buildVectorLoad` skips elevated `_vec` rows as defense-in-depth.
+
+**Architecture:** Spec — `docs/superpowers/specs/2026-07-16-tiers-search-design.md` (user-approved decision: purge/rebuild, mirroring #709). The lexical index is cache-driven (`buildRetrievalDocs` iterates the elevated-free `ctx.cache`), so it only needs invalidation; the vector sidecar is per-record and needs purge + re-embed.
+
+**Tech Stack:** TypeScript ESM, vitest. Branch `fix/721-tiers-search` off main 6ff7b6e2.
+
+## Global Constraints
+
+- NEVER add Claude/Anthropic attribution to commits/PRs/changelogs.
+- NEVER reference the private pilot client by name — grep the diff before each commit.
+- Ceilings exact (checker = `wc -l` + 1): `collection.ts` **4548**, `vault.ts` 3959, `noydb.ts` 2396. Fund additions with mechanical shrink-joins (single-use `const` inlined — the campaign's recurring pattern). Never edit ceiling values; never touch vault.ts/noydb.ts. `search/collection-facade.ts` / `tiers/index.ts` / `tier-visibility.ts` have no ceiling.
+- TDD: RED verified before implementing, every test. Run from `packages/hub/`: `pnpm vitest run <path>`.
+- No new deps; no timing assertions.
+- Sanctioned tier reads (`getAtTier`/`listAtTier`) + merged gates unaffected — existing tiers suites pass untouched.
+
+---
+
+### Task 1: syncSearch — purge/re-embed on tier moves + invalidate the lexical blob
+
+**Files:**
+- Modify: `packages/hub/src/with-audit/tiers/index.ts` (`TiersContext` + `elevate`/`demote`/`putAtTier`)
+- Modify: `packages/hub/src/with-lookup/search/collection-facade.ts` (new `syncTierSearch` helper)
+- Modify: `packages/hub/src/kernel/collection.ts` (one `syncSearch` wiring line; net-zero via shrink-join)
+- Create: `packages/hub/__tests__/tiers-search.test.ts`
+
+**Interfaces:**
+- Produces: `TiersContext.syncSearch(id, record: T | null, version?: number): Promise<void>` — `null` → `_purgeVector(id)` + invalidate `_ftindex`; a record → `embedOnWrite(...)` + invalidate `_ftindex`. No-op fast with no search.
+- Produces: `syncTierSearch<T>(ctx, id, record, version?)` in `search/collection-facade.ts`.
+- Consumes: `_purgeVector` (`collection.ts:4196`), `_purgeSearchIndex` (`:4203` — deletes the persisted blob + markDirty), `embedOnWrite` (`search/collection-facade.ts:377`, reached via `this.searchContext()`), `this.searchIndexStore`/`this.vectorSet` (undefined ⇒ no search).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/hub/__tests__/tiers-search.test.ts`. Copy `memoryStore()` verbatim from `__tests__/hierarchical-tiers.test.ts`. **No repo test combines search with `tiers:`** — build the fixture from scratch: grep existing search tests (`grep -rln "withSearch\|textIndexes\|similarTo\|retrieve(" __tests__/`) for a working config, then add `tiers: [0, 1]` + `perRecordKeys: true`. For a persisted lexical blob you need `textIndexPersist: true`; for `_vec` you need an `embeddings:` descriptor (find how existing search tests supply a mock embedder — do NOT invent a real model).
+
+```ts
+/**
+ * #721 — tiers × search. The `_ftindex` lexical blob (full verbatim field
+ * text) and the `_vec/<id>` embedding are both encrypted under the tier-0 DEK
+ * and survive elevate(), leaking an elevated record's derived plaintext to any
+ * tier-0 caller. Mirrors the forget() → _purgeSearchIndex/_purgeVector
+ * precedent, unapplied to elevate.
+ */
+
+describe('#721 lexical (_ftindex)', () => {
+  it('elevate: the persisted _ftindex blob no longer contains the elevated record’s text (warm)', async () => {
+    const { store, docs } = await openSearch()        // persisted textIndex + tiers + perRecordKeys
+    await docs.put('e1', { id: 'e1', body: 'topsecret-alpha-bravo' })
+    await docs.put('t0', { id: 't0', body: 'public-charlie' })
+    await docs.retrieve('alpha')                       // build + persist the index once
+    await docs.elevate('e1', 1)
+    await docs.flushIndex?.()                           // if a public flush exists; else next retrieve rebuilds
+    // The at-rest blob is decodable under the tier-0 DEK; after the fix it must
+    // not carry the elevated record's verbatim text.
+    const blob = await store.get('v1', '_ftindex', 'docs')
+    // Assert via the public read path: retrieve() must not surface e1 anymore.
+    expect((await docs.retrieve('topsecret-alpha-bravo')).map(h => h.id)).toEqual([])
+    expect((await docs.retrieve('public-charlie')).map(h => h.id)).toEqual(['t0'])  // tier-0 sibling still found
+  })
+
+  it('elevate: warm retrieve() in the elevating session no longer returns the record or its snippet', async () => {
+    const { docs } = await openSearch()
+    await docs.put('e1', { id: 'e1', body: 'topsecret-alpha' })
+    await docs.retrieve('alpha')                        // warms the in-memory index
+    await docs.elevate('e1', 1)
+    // Pre-#721: warm retrieve returned e1 with a snippet from the index's own text.
+    expect((await docs.retrieve('alpha')).map(h => h.id)).toEqual([])
+  })
+
+  it('cold session: the elevated record is not in the rebuilt index; tier-0 siblings are', async () => {
+    const h = searchHarness()
+    const { docs } = await h.open()
+    await docs.put('e1', { id: 'e1', body: 'alpha-secret' })
+    await docs.put('t0', { id: 't0', body: 'alpha-public' })
+    await docs.retrieve('alpha')
+    await docs.elevate('e1', 1)
+    const cold = await h.open()
+    expect((await cold.docs.retrieve('alpha')).map(h => h.id)).toEqual(['t0'])
+  })
+
+  it('demote restores lexical searchability', async () => {
+    const { docs } = await openSearch()
+    await docs.put('e1', { id: 'e1', body: 'alpha-secret' })
+    await docs.elevate('e1', 1)
+    await docs.demote('e1', 0)
+    expect((await docs.retrieve('alpha')).map(h => h.id)).toEqual(['e1'])
+  })
+})
+
+describe('#721 vector (_vec)', () => {
+  it('elevate purges the _vec sidecar; cold similarTo no longer surfaces the record', async () => {
+    const h = searchHarness({ embeddings: true })
+    const { store, docs } = await h.open()
+    await docs.put('e1', { id: 'e1', body: 'alpha' })
+    expect(await store.get('v1', '_vec', 'e1')).not.toBeNull()
+    await docs.elevate('e1', 1)
+    expect(await store.get('v1', '_vec', 'e1')).toBeNull()     // sidecar purged
+    const cold = await h.open()
+    // Pre-#721: cold similarTo surfaced e1's id + score with no warm cache.
+    expect((await cold.docs.similarTo('e1')).map(x => x.id)).not.toContain('e1')  // adapt to the real similarTo API
+  })
+
+  it('demote re-embeds: the record is semantically searchable again', async () => {
+    const h = searchHarness({ embeddings: true })
+    const { store, docs } = await h.open()
+    await docs.put('e1', { id: 'e1', body: 'alpha' })
+    await docs.elevate('e1', 1)
+    await docs.demote('e1', 0)
+    expect(await store.get('v1', '_vec', 'e1')).not.toBeNull()
+  })
+})
+```
+Adapt every mechanic (the retrieve/similarTo APIs, the embeddings descriptor, `flushIndex`'s real name/existence) to the real code — grep first. The assertions (elevated record absent from search warm+cold; sidecar purged; demote restores) are what matter. If a RED doesn't reproduce, STOP → BLOCKED with output (e.g. the `_vec` cold-leak test needs a real mock embedder to have written a sidecar).
+
+- [ ] **Step 2: RED** — `pnpm vitest run __tests__/tiers-search.test.ts` → elevated record still returned by warm/cold retrieve; `_vec` sidecar survives; cold similarTo surfaces it.
+
+- [ ] **Step 3: Implement**
+
+(a) `search/collection-facade.ts` — `syncTierSearch<T>(ctx, id, record, version?)`: if `record === null` → `await ctx.purgeVector(id)` (or the facade's own `_vec` delete + `vectorSet.markDirty`) then invalidate the lexical index (delete the persisted blob + `markDirty` — reuse whatever `_purgeSearchIndex` does); else → `await embedOnWrite(ctx, id, record, version)` then invalidate the lexical index. No-op immediately when the ctx has neither a search index nor a vector set. Read `_purgeVector`/`_purgeSearchIndex`/`embedOnWrite` and reuse them — do not re-derive.
+(b) `TiersContext` — add `syncSearch` (spec doc comment).
+(c) `elevate` → `await ctx.syncSearch(id, null)`; `demote` → `await ctx.syncSearch(id, toTier === 0 ? <decoded record> : null, <newEnvelope._v>)` (reuse demote's existing decode); `putAtTier` → `await ctx.syncSearch(id, tier > 0 ? null : record, envelope._v)`. Place each AFTER `adapter.put` (no syncCache ordering constraint — see spec).
+(d) `collection.ts` `tiersContext()` — one line: `syncSearch: (id, rec, version) => syncTierSearchImpl(this.searchContext(), id, rec, version)` (mirror the `syncIndexes` wiring at `:4515`). Fund the +1 with a shrink-join; document it. collection.ts must end at exactly **4548**.
+
+- [ ] **Step 4: GREEN + regression** — the new file + `__tests__/hierarchical-tiers.test.ts` + `__tests__/tiers-indexing.test.ts` + any search suites + `__tests__/per-record-cek.test.ts`; then the FULL hub suite from root; `node scripts/check-architecture.mjs`; typecheck; lint. Adjudicate any pre-existing test that changes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/with-audit/tiers/index.ts packages/hub/src/with-lookup/search/collection-facade.ts packages/hub/src/kernel/collection.ts packages/hub/__tests__/tiers-search.test.ts
+git commit -m "fix(hub): tier moves maintain search — elevate purges _vec + invalidates _ftindex, demote restores (#721)"
+```
+
+---
+
+### Task 2: defense-in-depth — gate buildVectorLoad against a surviving `_vec`
+
+**Files:**
+- Modify: `packages/hub/src/with-lookup/search/collection-facade.ts` (`buildVectorLoad`)
+- Modify: `packages/hub/__tests__/tiers-search.test.ts` (append)
+
+**Interfaces:**
+- Consumes: `liveRecordIsElevated` (`kernel/tier-visibility.ts`) — envelope peek, no decryption.
+
+Rationale: Task 1's purge is best-effort (the `forget()` path treats `_purgeVector` failures as residue) and cannot reach a `_vec` written before this fix. `buildVectorLoad` (`search/collection-facade.ts:190-204`) loads every `_vec` row ungated; `_vec` envelopes carry no `_tier`, so the gate reads the owning record's tier.
+
+- [ ] **Step 1: Write the failing test** — hand-write a `_vec/<id>` row directly into the store for a record that is then elevated (simulating a legacy/failed-purge sidecar), then assert cold `similarTo()` does not surface it:
+
+```ts
+it('#721 defense: buildVectorLoad skips a surviving _vec row whose record is elevated', async () => {
+  const h = searchHarness({ embeddings: true })
+  const { store, docs } = await h.open()
+  await docs.put('leaky', { id: 'leaky', body: 'alpha' })
+  const vecRow = await store.get('v1', '_vec', 'leaky')          // capture a real _vec envelope
+  await docs.elevate('leaky', 1)                                  // Task 1 purges it…
+  await store.put('v1', '_vec', 'leaky', vecRow!)                 // …simulate a legacy/failed-purge survivor
+  const cold = await h.open()
+  expect((await cold.docs.similarTo('leaky')).map(x => x.id)).not.toContain('leaky')
+})
+```
+(Adapt to the real `similarTo` shape. This must RED against Task 1's HEAD — Task 1's purge doesn't cover a re-planted row.)
+
+- [ ] **Step 2: RED** — the re-planted `_vec` row surfaces in cold `similarTo`.
+
+- [ ] **Step 3: Implement** — in `buildVectorLoad`'s per-row loop, before pushing the vector, skip when the owning record is elevated:
+```ts
+    // #721 defense-in-depth: a _vec row carries no _tier of its own; the purge
+    // on elevate is best-effort and cannot reach a legacy sidecar, so gate on
+    // the owning record's live tier. Envelope peek, no decryption.
+    if (await liveRecordIsElevated(ctx.adapter, ctx.vault, ctx.name, id)) continue
+```
+(Confirm `ctx` exposes `adapter`/`vault`/`name`; if `buildVectorLoad`'s ctx is narrower, thread what's needed. Note the one extra `adapter.get` per loaded vector — acceptable on this non-hot path; state it in the report.)
+
+- [ ] **Step 4: GREEN + regression** — the new file + search suites + full hub suite; arch/typecheck/lint.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/with-lookup/search/collection-facade.ts packages/hub/__tests__/tiers-search.test.ts
+git commit -m "fix(hub): buildVectorLoad skips _vec rows whose record is elevated — defense against a surviving sidecar (#721)"
+```
+
+---
+
+### Final: full suite + whole-branch review + changeset + PR
+
+- [ ] `pnpm --filter @noy-db/hub test` + typecheck + lint + `pnpm check:architecture` — green.
+- [ ] Whole-branch review (fable — a CRITICAL at-rest leak arc: ask it to prove no path leaves or rebuilds a tier-0-readable search artifact from elevated plaintext, to sweep for a THIRD search artifact beyond `_vec`/`_ftindex`, and to verify the changeset states the functional loss without overclaiming past #722/#724/#712).
+- [ ] Local changeset: `@noy-db/hub` patch — elevating a record now removes it from full-text and semantic search (the persisted `_ftindex` held its verbatim field text, the `_vec` sidecar its text-invertible embedding, both readable at tier 0); demote restores; intended consequence that an elevated record is unsearchable until demoted.
+- [ ] PR → main: `Closes #721`.

--- a/docs/superpowers/specs/2026-07-16-tiers-search-design.md
+++ b/docs/superpowers/specs/2026-07-16-tiers-search-design.md
@@ -1,0 +1,52 @@
+# Arc 6 — tiers × search: elevated records leave tier-0 search (#721)
+
+**Issue:** [#721](https://github.com/vLannaAi/noy-db/issues/721) + [recon comment](https://github.com/vLannaAi/noy-db/issues/721#issuecomment-4989771260). **CRITICAL** — a cold-readable, at-rest, *full-plaintext* leak.
+**Predecessors (merged):** #700/#710/#714/#717 (read surface) · #719 (write ring) · #723 (#709 — field indexes). This is the search analogue of #709.
+
+## The problem (recon-confirmed, worse than the issue first stated)
+
+The search subsystem persists two artifacts derived from a record's plaintext, both encrypted **always under the tier-0 collection DEK** (via `encryptJsonString`'s no-CEK branch → `record-codec.ts:258`), and `elevate()` touches neither:
+
+1. **`_ftindex/<name>` — the lexical inverted index (top severity).** The persisted snapshot stores `text: d.text` per doc (`inverted-index.ts:149-159`) — the **complete verbatim field text**, not tokens or postings. A tier-0 read of the blob recovers an elevated record's *entire* indexed plaintext + term offsets. Cold-readable.
+2. **`_vec/<recordId>` — the embedding sidecar.** Holds the raw (un-quantized) embedding (`collection-facade.ts:382`). The code itself calls a vector "text-invertible" (`collection.ts:4194`, `vault.ts:2396`). `buildVectorLoad` (`:190-204`) and `VectorSet.cosineTopK` are ungated, so a **cold** `similarTo()` surfaces the elevated record's id + similarity score with no warm cache.
+
+Warm (same-session) leak too: the in-memory `InvertedIndex`/`VectorSet` are session-resident and evicted only via `markDirty()`, which tier ops never call — so a warm `retrieve()`/`similarTo()` in the elevating session returns the elevated record, with a snippet drawn from the index's **own** stored text (cache eviction cannot suppress it).
+
+`forget()` purges both (`_purgeSearchIndex` `collection.ts:4203`, `_purgeVector` `:4196`). **`elevate()` has no analogue** — the campaign's recurring shape: *every `forget()` purge site is an `elevate()` bug.*
+
+## Decision (follows the #709 precedent): purge/rebuild, elevated records leave search
+
+Consistent with #709's field-index choice — an elevated record is **not present in any search index**, so it is not findable by `retrieve()` or `similarTo()`, **including from a session that holds its tier DEK**. `getAtTier`/`listAtTier` remain the tier-aware read surfaces. (Rejected: *refuse search+tiers at registration* like unique+tiers — removes a working combination; the primitives to fix it cleanly already exist. Deferred: *tier-scoped search artifacts* so cleared callers keep searching elevated records — a real future option, not needed to close the leak.)
+
+## Design — the asymmetry the recon found: two artifacts, two shapes
+
+**The lexical index is cache-driven, so it is already correct — it only needs invalidation.** `buildRetrievalDocs` (`search/collection-facade.ts:99`) rebuilds from `for (const [id, e] of ctx.cache)` — and `ctx.cache` is elevated-free (hydration skips elevated #701; `syncCache` evicts on elevate #691). So the rebuild *already* excludes elevated records; the only bug is that nothing triggers it and the stale at-rest blob survives. Fix = on any tier move, **`_purgeSearchIndex()`** (delete the persisted blob + `markDirty()` the in-memory index). Next `retrieve()` rebuilds lazily from the elevated-free cache — excluding the record after elevate, including it after demote (the cache is re-seeded by `syncCache`). No at-rest window (blob deleted immediately); no explicit gate loop needed (the cache is the gate).
+
+**The vector sidecar is per-record and computed at write time, so it needs real purge + re-embed.** On elevate → `_purgeVector(id)` (deletes `_vec/<id>` + dirties the `VectorSet`). On demote-to-0 → re-embed the now-tier-0 record via `embedOnWrite(searchContext, id, record, version)`. Defense-in-depth (belt to the purge's braces, since `forget()`-style purge is best-effort and a legacy `_vec` predates this fix): **gate `buildVectorLoad`** to skip a `_vec` row whose owning record is elevated. `_vec` envelopes carry no `_tier` of their own, so the gate reads the canonical record's tier (`liveRecordIsElevated`, `kernel/tier-visibility.ts`) — one extra `adapter.get` per loaded vector; acceptable on a non-hot search-load path, and it makes the load correct even if the purge wiring ever regresses.
+
+### The hook
+
+`TiersContext` gains one callback, mirroring `syncIndexes` (#709):
+
+```ts
+/** Sync the collection's SEARCH artifacts after a tier move (#721). Both the
+ *  lexical `_ftindex` blob and the `_vec/<id>` embedding are encrypted under
+ *  the tier-0 DEK and hold the record's derived plaintext (full field text /
+ *  a text-invertible vector), so leaving them means elevation never hid what
+ *  the record was searchable by — the `forget()` precedent, unapplied to
+ *  elevate. `null` → the record left tier 0: purge its `_vec`, and invalidate
+ *  the `_ftindex` blob (the cache-driven rebuild then excludes it). A record →
+ *  it is tier-0 again: re-embed it, and invalidate `_ftindex` (rebuild
+ *  includes it). No-op fast when the collection has no search. */
+syncSearch(id: string, record: T | null, version?: number): Promise<void>
+```
+
+Wired in `tiersContext()` to a new `syncTierSearch` helper in `search/collection-facade.ts` (no ceiling there). Called by `elevate`/`demote`/`putAtTier` **after** `adapter.put` lands — **no ordering dependency on `syncCache`** (unlike `syncIndexes`): the `_ftindex` rebuild is deferred to next `retrieve()`, and `_vec` re-embed reads the record argument directly, not the cache.
+
+## Constraints
+
+- Ceiling: `collection.ts` **4548** exact. Expect ~+1 (the `syncSearch` wiring line) → fund with one mechanical shrink-join. Never edit ceiling values; `vault.ts`/`noydb.ts` untouched. `search/collection-facade.ts` / `tiers/index.ts` / `tier-visibility.ts` have no ceiling.
+- Zero-knowledge: the `_ftindex` invalidation and `_vec` purge resolve no key material; the `buildVectorLoad` gate is an envelope peek; demote re-embed reads a record already at tier 0.
+- `syncSearch` no-ops fast when `searchIndexStore` and `vectorSet` are both undefined.
+- **Coverage gap:** only `introspection/dump-schema.test.ts` declares search + tiers, and only introspects — **zero behavioral coverage** of `elevate()` + `retrieve()`/`similarTo()`. Tests must cover the persisted lexical blob, the `_vec` sidecar, warm AND cold sessions, and demote-restores.
+- Intended functional loss (document in the changeset): an elevated record is unsearchable by anyone until demoted.

--- a/packages/hub/__tests__/tiers-search.test.ts
+++ b/packages/hub/__tests__/tiers-search.test.ts
@@ -104,6 +104,16 @@ describe('#721 lexical (_ftindex)', () => {
     expect(await store.get('v1', '_ftindex', 'docs')).not.toBeNull()
 
     await docs.elevate('e1', 1)
+
+    // AT-REST GUARANTEE (the crux of this CRITICAL leak): elevate must DELETE
+    // the persisted blob synchronously, not merely markDirty the in-memory
+    // index. retrieve() self-heals via a rebuild either way, so only a direct
+    // store peek — BEFORE any rebuild — can distinguish "blob deleted" from
+    // "blob left stale at rest". A future removePersisted→markDirty regression
+    // would keep every retrieve() test green while re-opening the leak; this
+    // pins it. The blob (decodable under the tier-0 DEK) held e1's verbatim text.
+    expect(await store.get('v1', '_ftindex', 'docs')).toBeNull()
+
     await docs.flushIndex()
 
     // Public read path: retrieve() must not surface e1 anymore.
@@ -160,12 +170,16 @@ describe('#721 vector (_vec)', () => {
     await docs.put('t0', { id: 't0', body: 'zzzzzzzzzzzzzzzzzzzzz' })
     expect(await h.store.get('v1', '_vec', 'e1')).not.toBeNull()
 
+    const qVec = await ENCODER.encode('alpha')
     await docs.elevate('e1', 1)
     expect(await h.store.get('v1', '_vec', 'e1')).toBeNull() // sidecar purged
 
+    // Warm (same-session) eviction: the elevate must dirty the VectorSet so the
+    // in-session similarTo rebuilds without e1 — not only the cold reopen below.
+    expect((await docs.similarTo(qVec)).map(x => x.id)).not.toContain('e1')
+
     const cold = await h.open()
     // Pre-#721: cold semantic retrieve/similarTo surfaced e1's id + score with no warm cache.
-    const qVec = await ENCODER.encode('alpha')
     expect((await cold.docs.similarTo(qVec)).map(x => x.id)).not.toContain('e1')
     expect((await cold.docs.retrieve('alpha', { mode: 'semantic' })).map(x => x.id)).not.toContain('e1')
   })

--- a/packages/hub/__tests__/tiers-search.test.ts
+++ b/packages/hub/__tests__/tiers-search.test.ts
@@ -187,3 +187,25 @@ describe('#721 vector (_vec)', () => {
     expect((await cold.docs.similarTo(qVec)).map(x => x.id)).toContain('e1')
   })
 })
+
+describe('#721 defense-in-depth: buildVectorLoad gate', () => {
+  it('skips a surviving _vec row whose owning record is elevated', async () => {
+    // Simulates a legacy sidecar (written before this fix) or one whose
+    // best-effort purge on elevate() failed: elevate() removes the _vec row
+    // as usual, then we hand-write it straight back — a survivor Task 1's
+    // purge cannot reach. buildVectorLoad must still exclude it by checking
+    // the owning record's live tier, not merely trust every _vec row it lists.
+    const h = searchHarness({ embeddings: true })
+    const { docs } = await h.open()
+    await docs.put('leaky', { id: 'leaky', body: 'alpha' })
+    const vecRow = await h.store.get('v1', '_vec', 'leaky') // capture a real _vec envelope
+    expect(vecRow).not.toBeNull()
+
+    await docs.elevate('leaky', 1) // Task 1 purges it…
+    await h.store.put('v1', '_vec', 'leaky', vecRow!) // …simulate a legacy/failed-purge survivor
+
+    const cold = await h.open()
+    const qVec = await ENCODER.encode('alpha')
+    expect((await cold.docs.similarTo(qVec)).map(x => x.id)).not.toContain('leaky')
+  })
+})

--- a/packages/hub/__tests__/tiers-search.test.ts
+++ b/packages/hub/__tests__/tiers-search.test.ts
@@ -171,10 +171,17 @@ describe('#721 vector (_vec)', () => {
     expect(await h.store.get('v1', '_vec', 'e1')).not.toBeNull()
 
     const qVec = await ENCODER.encode('alpha')
+    // Load the VectorSet into memory BEFORE elevate — otherwise the "warm"
+    // assertion below does its first load from the already-purged store and
+    // passes even if elevate never dirtied the set (whole-branch review catch:
+    // the earlier version of this pin was vacuous). With the set warm, only
+    // vectorSet.markDirty() on elevate can evict e1 from the in-memory vectors.
+    expect((await docs.similarTo(qVec)).map(x => x.id)).toContain('e1') // warm, pre-elevate
+
     await docs.elevate('e1', 1)
     expect(await h.store.get('v1', '_vec', 'e1')).toBeNull() // sidecar purged
 
-    // Warm (same-session) eviction: the elevate must dirty the VectorSet so the
+    // Warm (same-session) eviction: elevate dirtied the VectorSet, so the
     // in-session similarTo rebuilds without e1 — not only the cold reopen below.
     expect((await docs.similarTo(qVec)).map(x => x.id)).not.toContain('e1')
 

--- a/packages/hub/__tests__/tiers-search.test.ts
+++ b/packages/hub/__tests__/tiers-search.test.ts
@@ -1,0 +1,189 @@
+/**
+ * #721 — tiers × search. The `_ftindex` lexical blob (full verbatim field
+ * text) and the `_vec/<id>` embedding are both encrypted under the tier-0 DEK
+ * and survive elevate(), leaking an elevated record's derived plaintext to any
+ * tier-0 caller. Mirrors the forget() → _purgeSearchIndex/_purgeVector
+ * precedent, unapplied to elevate.
+ *
+ * Fixture: `memoryStore()` copied verbatim from `hierarchical-tiers.test.ts`;
+ * the stub encoder copied from `embeddings-write.test.ts`. No repo test
+ * combines search with `tiers:` prior to this one.
+ */
+import { describe, it, expect } from 'vitest'
+import { createNoydb, withSearch, ConflictError } from '../src/index.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/index.js'
+
+interface Doc {
+  id: string
+  body: string
+}
+
+function memoryStore(): NoydbStore {
+  const data = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  const getColl = (v: string, c: string): Map<string, EncryptedEnvelope> => {
+    let vm = data.get(v); if (!vm) { vm = new Map(); data.set(v, vm) }
+    let cm = vm.get(c); if (!cm) { cm = new Map(); vm.set(c, cm) }
+    return cm
+  }
+  return {
+    name: 'memory',
+    async get(v, c, id) { return data.get(v)?.get(c)?.get(id) ?? null },
+    async put(v, c, id, env, ev) {
+      const coll = getColl(v, c); const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(v, c, id) { data.get(v)?.get(c)?.delete(id) },
+    async list(v, c) { return [...(data.get(v)?.get(c)?.keys() ?? [])] },
+    async loadAll(v) {
+      const vm = data.get(v); const snap: VaultSnapshot = {}
+      if (vm) for (const [cn, cm] of vm) {
+        const r: Record<string, EncryptedEnvelope> = {}
+        for (const [id, e] of cm) r[id] = e
+        snap[cn] = r
+      }
+      return snap
+    },
+    async saveAll(v, snap) {
+      const vm = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [cn, recs] of Object.entries(snap)) {
+        const cm = new Map<string, EncryptedEnvelope>()
+        for (const [id, e] of Object.entries(recs)) cm.set(id, e)
+        vm.set(cn, cm)
+      }
+      data.set(v, vm)
+    },
+  }
+}
+
+// Deterministic stub encoder: 8-dim bag-of-chars hash → Float32Array.
+const enc = (dim: number, model = 'stub') => ({
+  dim, model, source: 'body' as const,
+  encode: async (t: string) => { const v = new Float32Array(dim); for (let i = 0; i < t.length; i++) { const idx = t.charCodeAt(i) % dim; v[idx] = (v[idx] ?? 0) + 1 } return v },
+})
+const ENCODER = enc(8)
+
+const SECRET = 'tiers-search-passphrase-721'
+
+/**
+ * A search+tiers harness: `open()` opens a fresh session against the SAME
+ * underlying store (simulates a "cold" reopen — new in-memory caches, same
+ * ciphertext). `opts.embeddings` adds the stub embeddings descriptor so
+ * `put()` derives an encrypted `_vec` sidecar.
+ */
+function searchHarness(opts: { embeddings?: boolean } = {}) {
+  const store = memoryStore()
+  async function open() {
+    const db = await createNoydb({ store, user: 'owner', secret: SECRET, searchStrategy: withSearch(), tiersStrategy: withTiers() })
+    const vault = await db.openVault('v1')
+    const docs = vault.collection<Doc>('docs', {
+      tiers: [0, 1],
+      perRecordKeys: true,
+      textIndexes: ['body'],
+      textIndexPersist: true,
+      ...(opts.embeddings ? { embeddings: ENCODER } : {}),
+    })
+    return { db, vault, docs }
+  }
+  return { store, open }
+}
+
+async function openSearch() {
+  const h = searchHarness()
+  const { docs } = await h.open()
+  return { store: h.store, docs }
+}
+
+describe('#721 lexical (_ftindex)', () => {
+  it('elevate: the persisted _ftindex blob no longer surfaces the elevated record\'s text (warm)', async () => {
+    const { store, docs } = await openSearch()
+    await docs.put('e1', { id: 'e1', body: 'topsecret-alpha-bravo' })
+    await docs.put('t0', { id: 't0', body: 'public-charlie' })
+    await docs.retrieve('alpha') // build + persist the index once
+    expect(await store.get('v1', '_ftindex', 'docs')).not.toBeNull()
+
+    await docs.elevate('e1', 1)
+    await docs.flushIndex()
+
+    // Public read path: retrieve() must not surface e1 anymore.
+    expect((await docs.retrieve('topsecret-alpha-bravo')).map(h => h.id)).toEqual([])
+    expect((await docs.retrieve('public-charlie')).map(h => h.id)).toEqual(['t0']) // tier-0 sibling still found
+  })
+
+  it('elevate: warm retrieve() in the elevating session no longer returns the record or its snippet', async () => {
+    const { docs } = await openSearch()
+    await docs.put('e1', { id: 'e1', body: 'topsecret-alpha' })
+    await docs.retrieve('alpha') // warms the in-memory index
+    await docs.elevate('e1', 1)
+    // Pre-#721: warm retrieve returned e1 with a snippet from the index's own text.
+    expect((await docs.retrieve('alpha')).map(h => h.id)).toEqual([])
+  })
+
+  it('cold session: the elevated record is not in the rebuilt index; tier-0 siblings are', async () => {
+    const h = searchHarness()
+    const { docs } = await h.open()
+    await docs.put('e1', { id: 'e1', body: 'alpha-secret' })
+    await docs.put('t0', { id: 't0', body: 'alpha-public' })
+    await docs.retrieve('alpha')
+    await docs.elevate('e1', 1)
+
+    const cold = await h.open()
+    expect((await cold.docs.retrieve('alpha')).map(x => x.id)).toEqual(['t0'])
+  })
+
+  it('demote restores lexical searchability', async () => {
+    // A single continuous warm index never "forgets" a record on its own
+    // (ensureBuilt short-circuits on a defined in-memory index, skipping the
+    // fingerprint check) — so to isolate demote's OWN rebuild responsibility
+    // from elevate's, open a fresh session with e1 already elevated (its
+    // hydration excludes e1 by construction, #701), warm-build the index
+    // (confirming exclusion), THEN demote and re-check in the SAME session.
+    const h = searchHarness()
+    const { docs: setup } = await h.open()
+    await setup.put('e1', { id: 'e1', body: 'alpha-secret' })
+    await setup.elevate('e1', 1)
+
+    const { docs } = await h.open()
+    expect((await docs.retrieve('alpha')).map(x => x.id)).toEqual([]) // sanity: excluded on open
+
+    await docs.demote('e1', 0)
+    expect((await docs.retrieve('alpha')).map(x => x.id)).toEqual(['e1'])
+  })
+})
+
+describe('#721 vector (_vec)', () => {
+  it('elevate purges the _vec sidecar; cold semantic retrieve no longer surfaces the record', async () => {
+    const h = searchHarness({ embeddings: true })
+    const { docs } = await h.open()
+    await docs.put('e1', { id: 'e1', body: 'alpha' })
+    await docs.put('t0', { id: 't0', body: 'zzzzzzzzzzzzzzzzzzzzz' })
+    expect(await h.store.get('v1', '_vec', 'e1')).not.toBeNull()
+
+    await docs.elevate('e1', 1)
+    expect(await h.store.get('v1', '_vec', 'e1')).toBeNull() // sidecar purged
+
+    const cold = await h.open()
+    // Pre-#721: cold semantic retrieve/similarTo surfaced e1's id + score with no warm cache.
+    const qVec = await ENCODER.encode('alpha')
+    expect((await cold.docs.similarTo(qVec)).map(x => x.id)).not.toContain('e1')
+    expect((await cold.docs.retrieve('alpha', { mode: 'semantic' })).map(x => x.id)).not.toContain('e1')
+  })
+
+  it('demote re-embeds: the record is semantically searchable again', async () => {
+    const h = searchHarness({ embeddings: true })
+    const { docs } = await h.open()
+    await docs.put('e1', { id: 'e1', body: 'alpha' })
+    await docs.elevate('e1', 1)
+    // Force the precondition demote must handle regardless of elevate's own
+    // purge (isolates demote's re-embed responsibility from the elevate test
+    // above): the _vec sidecar is gone before demote runs.
+    await h.store.delete('v1', '_vec', 'e1')
+    await docs.demote('e1', 0)
+    expect(await h.store.get('v1', '_vec', 'e1')).not.toBeNull()
+
+    const cold = await h.open()
+    const qVec = await ENCODER.encode('alpha')
+    expect((await cold.docs.similarTo(qVec)).map(x => x.id)).toContain('e1')
+  })
+})

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -34,6 +34,7 @@ import {
 import type { TiersStrategy } from '../with-audit/tiers/strategy.js'
 import {
   buildPersistedIndexCallbacks as buildPersistedIndexCallbacksImpl,
+  syncTierSearch as syncTierSearchImpl,
   type SearchContext,
 } from '../with-lookup/search/collection-facade.js'
 import type { SearchStrategy } from '../with-lookup/search/strategy.js'
@@ -788,8 +789,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
         // authoritative merge result — a shred must win and stay shredded.
         if (localJson === null) return local
         if (remoteJson === null) return remote
-        const localState = JSON.parse(localJson) as CrdtState
-        const merged = this.crdtStrategy.mergeCrdtStates(localState, JSON.parse(remoteJson) as CrdtState)
+        const merged = this.crdtStrategy.mergeCrdtStates(JSON.parse(localJson) as CrdtState, JSON.parse(remoteJson) as CrdtState)
         const mergedVersion = Math.max(local._v, remote._v) + 1
         const cek = this.perRecordCek ? await this.resolveRecordCek(id) : undefined
         return this.codec.encryptJsonString(JSON.stringify(merged), mergedVersion, cek)
@@ -2585,8 +2585,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       // stays directly under the collection DEK. `forget()`/shred reports
       // un-migrated records explicitly rather than claiming erasure.
       const cek = this.perRecordCek ? await this.resolveRecordCek(id) : undefined
-      const newEnv = await this.codec.encryptRecord(next as unknown as T, nextVersion, cek, undefined, undefined, this.vdigFields !== null ? { id, prev: env } : undefined, id)
-      await this.adapter.put(this.vault, this.name, id, newEnv)
+      await this.adapter.put(this.vault, this.name, id, await this.codec.encryptRecord(next as unknown as T, nextVersion, cek, undefined, undefined, this.vdigFields !== null ? { id, prev: env } : undefined, id))
       await this._onRecordMutated(id, 'put', 'cutover') // refresh in-memory cache after the raw write (parity: cache only)
       if (this.ledger) {
         await this.ledger.append({
@@ -4513,6 +4512,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       cekCache: this.cekCache,
       syncCache: (id: string, e: { record: T; version: number } | null) => { if (e) this.cache.set(id, e); else this.cache.delete(id); this.lru?.remove(id) },
       syncIndexes: (id: string, rec: T | null, version?: number) => syncTierIndexesImpl(this.indexingContext(), id, rec, version),
+      syncSearch: (id: string, rec: T | null, version?: number) => syncTierSearchImpl(this.searchContext(), id, rec, version),
       provenance: this.provenance,
       tiers: this.tiers,
       tierMode: this.tierMode,

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -85,6 +85,17 @@ export interface TiersContext<T> {
    * purge).
    */
   syncIndexes(id: string, record: T | null, version?: number): Promise<void>
+  /** Sync the collection's SEARCH artifacts after a tier move (#721). Both the
+   *  lexical `_ftindex` blob and the `_vec/<id>` embedding are encrypted under
+   *  the tier-0 DEK and hold the record's derived plaintext (full field text /
+   *  a text-invertible vector), so leaving them means elevation never hid what
+   *  the record was searchable by — the `forget()` precedent, unapplied to
+   *  elevate. `null` → the record left tier 0: purge its `_vec`, and
+   *  invalidate the `_ftindex` blob (the cache-driven rebuild then excludes
+   *  it). A record → it is tier-0 again: re-embed it, and invalidate
+   *  `_ftindex` (rebuild includes it). No-op fast when the collection has no
+   *  search. */
+  syncSearch(id: string, record: T | null, version?: number): Promise<void>
   /** Emit `_source`/`_sourceTs` provenance fields when a source is supplied. */
   readonly provenance: boolean
   /** Declared tiers, or null when the feature is off. */
@@ -178,6 +189,11 @@ export async function putAtTier<T>(
     await ctx.syncIndexes(id, rec, envelope._v)
     ctx.syncCache(id, rec !== null ? { record: rec, version: envelope._v } : null)
   }
+  // #721: search artifacts follow the same tier > 0 → purge / tier 0 →
+  // re-embed law as syncIndexes above. No ordering dependency on syncCache —
+  // the _ftindex rebuild is deferred to the next retrieve() and _vec re-embed
+  // reads `record` directly, not the cache.
+  await ctx.syncSearch(id, tier > 0 ? null : record, envelope._v)
 
   if (tier > 0) {
     ctx.emitCrossTierEvent({
@@ -347,6 +363,9 @@ export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: numbe
   // eager index bucket; the persisted side-car purge is content-free.
   await ctx.syncIndexes(id, null)
   ctx.syncCache(id, null)
+  // #721: same purge law as syncIndexes above — the record left tier 0, so
+  // its _vec sidecar is purged and _ftindex is invalidated.
+  await ctx.syncSearch(id, null)
 
   ctx.emitCrossTierEvent({
     actor: ctx.keyring.userId,
@@ -425,9 +444,14 @@ export async function demote<T>(ctx: TiersContext<T>, id: string, toTier: number
     const rec = await ctx.codec.decryptRecord(next, { id, sealedAsHandles: true })
     await ctx.syncIndexes(id, rec, next._v)
     ctx.syncCache(id, rec !== null ? { record: rec, version: next._v } : null)
+    // #721: reuse the decode above — no double-decrypt. The record is tier-0
+    // again, so re-embed its _vec and invalidate _ftindex to include it.
+    await ctx.syncSearch(id, rec, next._v)
   } else {
     await ctx.syncIndexes(id, null)
     ctx.syncCache(id, null)
+    // #721: still above tier 0 — purge _vec, invalidate _ftindex.
+    await ctx.syncSearch(id, null)
   }
 
   ctx.emitCrossTierEvent({

--- a/packages/hub/src/with-lookup/search/collection-facade.ts
+++ b/packages/hub/src/with-lookup/search/collection-facade.ts
@@ -30,6 +30,7 @@ import type { BlobFieldsConfig } from '../../with-shape/blobs/blob-compaction.js
 import type { Query } from '../../kernel/query/index.js'
 import { embeddingSourceText, type VectorSet, type EmbeddingDescriptor, type StoredVector } from '../embeddings/index.js'
 import { EmbeddingDimMismatchError } from '../../kernel/errors.js'
+import { liveRecordIsElevated } from '../../kernel/tier-visibility.js'
 import { searchScan, fuseRetrieval, type SearchOptions, type SearchResult } from './index.js'
 import type { IndexStore } from './index-store.js'
 import type { PersistedIndexCallbacks } from './persisted-index-store.js'
@@ -192,6 +193,10 @@ function buildVectorLoad<T>(ctx: SearchContext<T>): () => Promise<StoredVector[]
     const ids = await ctx.adapter.list(ctx.vault, '_vec')
     const out: StoredVector[] = []
     for (const id of ids) {
+      // #721 defense-in-depth: a _vec row carries no _tier of its own; the purge
+      // on elevate is best-effort and cannot reach a legacy sidecar, so gate on
+      // the owning record's live tier. Envelope peek, no decryption.
+      if (await liveRecordIsElevated(ctx.adapter, ctx.vault, ctx.name, id)) continue
       const env = await ctx.adapter.get(ctx.vault, '_vec', id)
       if (!env) continue
       const body = await ctx.codec.decryptJsonString(env)

--- a/packages/hub/src/with-lookup/search/collection-facade.ts
+++ b/packages/hub/src/with-lookup/search/collection-facade.ts
@@ -384,3 +384,36 @@ export async function embedOnWrite<T>(ctx: SearchContext<T>, id: string, record:
   await ctx.adapter.put(ctx.vault, '_vec', id, vecEnv)
   ctx.vectorSet?.markDirty()
 }
+
+/**
+ * Sync the collection's SEARCH artifacts after a tier move (#721). Both the
+ * lexical `_ftindex` blob and the `_vec/<id>` embedding are encrypted under
+ * the tier-0 DEK and hold the record's derived plaintext (full field text /
+ * a text-invertible vector), so leaving them means elevation never hid what
+ * the record was searchable by — the `forget()` precedent, unapplied to
+ * elevate. `null` → the record left tier 0: purge its `_vec` sidecar (mirrors
+ * `Collection._purgeVector`), and invalidate the `_ftindex` blob (mirrors
+ * `Collection._purgeSearchIndex`: deletes the persisted blob when persisted,
+ * else drops the in-memory index) so the next `retrieve()` rebuilds from the
+ * elevated-free `ctx.cache`. A record → it is tier-0 again: re-embed it via
+ * {@link embedOnWrite}, then invalidate `_ftindex` so the rebuild includes it
+ * again. No-op fast when the collection has neither a lexical index nor a
+ * vector set.
+ */
+export async function syncTierSearch<T>(
+  ctx: SearchContext<T>,
+  id: string,
+  record: T | null,
+  version?: number,
+): Promise<void> {
+  if (!ctx.searchIndexStore && !ctx.vectorSet) return
+  if (record === null) {
+    await ctx.adapter.delete(ctx.vault, '_vec', id)
+    ctx.vectorSet?.markDirty()
+  } else {
+    await embedOnWrite(ctx, id, record, version ?? 1)
+  }
+  const store = ctx.searchIndexStore
+  if (store && 'removePersisted' in store) await (store as { removePersisted(): Promise<void> }).removePersisted()
+  else store?.markDirty()
+}


### PR DESCRIPTION
Closes #721.

**The campaign's CRITICAL arc** — a cold-readable, at-rest, *full-plaintext* leak, and the search analogue of #709.

## The bug
Two search artifacts, both derived from a record's plaintext, both encrypted **always under the tier-0 collection DEK** whatever the record's own tier, both untouched by `elevate()`:
- **`_ftindex/<name>`** — the persisted lexical index stores each doc's **complete verbatim field text** (`inverted-index.ts:149-159`), not tokens or postings. A tier-0 caller reads an elevated record's *entire* indexed plaintext straight out of the blob at rest.
- **`_vec/<recordId>`** — the raw, text-invertible embedding (the code says so: `collection.ts:4194`). `buildVectorLoad` is ungated, so even a **cold** `similarTo()` surfaces the elevated record's id + similarity score with no warm cache.

`forget()` purges both; `elevate()` had no analogue — the campaign's recurring shape: *every `forget()` purge site is an `elevate()` bug.*

## The fix
- **`TiersContext.syncSearch`** (mirroring #709's `syncIndexes`): `elevate()` / `putAtTier(>0)` **delete the `_vec` sidecar and the `_ftindex` blob synchronously** (real `adapter.delete` via `removePersisted()` — no markDirty-only stale window); `demote()` / `putAtTier(0)` re-embed and rebuild.
- The lexical rebuild is **cache-driven** (`buildRetrievalDocs` iterates the elevated-free `ctx.cache`), so invalidation suffices — the rebuild excludes elevated records for free (#701) and re-includes them on demote (#691's `syncCache`).
- **Defense-in-depth (#721 T2):** `buildVectorLoad` skips a `_vec` row whose owning record is elevated (via `liveRecordIsElevated`), covering a legacy or failed-purge survivor.

## Verification
Full suite **503 files / 4115 tests** green; typecheck/lint/`check:architecture` clean; `collection.ts` byte-identical to main (two mechanical shrink-joins).

The search+tiers fixture is **the first in this repo** — no test had ever combined search with `tiers:`, which is how the leak survived.

The at-rest guarantee is **test-locked, not just implementation-protected**: `retrieve()` self-heals through a rebuild either way, so a `store.get('v1','_ftindex','docs')` toBeNull assertion runs *after* elevate and *before* any rebuild — it fails if `removePersisted` ever becomes a markDirty-only eviction. The warm `_vec` eviction pin was caught vacuous at whole-branch review and rewritten to warm the VectorSet *before* elevate; it now REDs when `markDirty()` is removed (proven).

The whole-branch review **swept every `adapter.put` in the tree for a third search artifact and found none** — `_ftindex` and `_vec` are the only persisted search blobs.

## Intended functional loss (stated in the changeset)
An elevated record is **not findable by `retrieve()` or `similarTo()`, including from a session that holds its tier DEK**, until demoted — consistent with #709's field-index choice. `getAtTier`/`listAtTier` remain the tier-aware read surfaces.

## Residue (tracked, not closed here)
- **#725** — a debounced index flush racing the purge can briefly re-persist a stale `_ftindex` blob (pre-existing; affects `forget()` too; in its worst interleaving the resurrected blob carries a *matching* fingerprint a cold reader would trust).
- **#726** — `_vec` uses a vault-global namespace (bare record id), so the tier gate/purge can hit the wrong collection's sidecar.
- **#722** (views/rollups), **#724** (blobs, unverified), **#712** (history at-rest) — the rest of the derived-artifact class.

Spec: `docs/superpowers/specs/2026-07-16-tiers-search-design.md`