### PR TITLE
fix(hub): elevate purges the record's tier-0-era audit-ledger deltas (closes #729)

### DIFF
--- a/docs/superpowers/plans/2026-07-17-ledger-purge.md
+++ b/docs/superpowers/plans/2026-07-17-ledger-purge.md
@@ -1,0 +1,131 @@
+# Arc 8 — Ledger Purge Implementation Plan (#729)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** On a tier move to tier > 0, purge the record's tier-0-era plaintext `_ledger_deltas` rows — closing #729 at rest, with the tamper-chain left valid. Owner chose PURGE (irreversible, metadata retained).
+
+**Architecture:** Spec — `docs/superpowers/specs/2026-07-17-ledger-purge-design.md`. New `LedgerStore.purgeRecordDeltas` + `TiersContext.syncLedger` hook, parallel to `syncHistory`. The ledger is a flat vault-wide hash-chained log; purge (not rewrap) is the fix because deltas have no per-record key and are chain-bound.
+
+**Tech Stack:** TypeScript ESM, vitest. Branch `fix/729-ledger-purge` off main (current HEAD after Arc 7 merges — rebase if needed).
+
+## Global Constraints
+
+- NEVER add Claude/Anthropic attribution; never reference the private pilot client — grep the diff.
+- Ceilings exact (checker = `wc -l` + 1): `collection.ts` **4549**, `vault.ts` 3959, `noydb.ts` 2396. The one `syncLedger` wiring line in collection.ts needs a mechanical shrink-join. Never edit ceiling values or check-architecture.mjs ratchets. `vault.ts`/`noydb.ts` untouched (forget-side #734 is a separate PR).
+- TDD: RED before implementing. Run from `packages/hub/`: `pnpm vitest run <path>`.
+- No new deps; no timing assertions.
+- **THE INVARIANT: `ledger.verify()` must return `{ok:true}` after every purge.** Any test path must assert it.
+
+---
+
+### Task 1: `LedgerStore.purgeRecordDeltas` primitive
+
+**Files:**
+- Modify: `packages/hub/src/with-commit/history/ledger/store.ts`
+- Create: `packages/hub/__tests__/ledger-purge.test.ts`
+
+**Interfaces:**
+- Produces: `async purgeRecordDeltas(collection: string, id: string): Promise<number>` on `LedgerStore` — deletes each `_ledger_deltas/<paddedIndex(e.index)>` row whose entry matches `(collection, id)` and has a delta (`e.deltaHash !== undefined`); returns the count. Touches NO `_ledger` entry; no re-encryption.
+- Consumes: `loadAllEntries()` (`store.ts:398`), `paddedIndex` (imported at `store.ts:54`), `LEDGER_DELTAS_COLLECTION` (`store.ts:60`), `this.adapter.delete`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/hub/__tests__/ledger-purge.test.ts`. Grep an existing ledger test (`__tests__/*ledger*`) for how to construct a vault with `withHistory()` (which enables the ledger), do puts that produce deltas, and reach `vault.ledger()` (`verify`, `loadDelta`, `reconstruct`, `entries`) + the raw `store.get(vault, '_ledger_deltas', paddedIndex(i))`. Then:
+
+```ts
+/**
+ * #729 — LedgerStore.purgeRecordDeltas deletes a record's plaintext delta
+ * rows while leaving the tamper-chain valid (verify() reads entry fields,
+ * never the delta rows) and a sibling record's deltas untouched.
+ */
+it('purges a record’s delta rows, keeps the chain valid, leaves siblings intact', async () => {
+  // … build a withHistory vault + collection, put 'a' twice (→ a delta) and 'b' twice …
+  const ledger = vault.ledger()
+  expect((await ledger.verify()).ok).toBe(true)
+  // a's v1->v2 delta exists at rest:
+  // (find a's delta index via ledger.entries(), assert store.get(_ledger_deltas, paddedIndex) !== null)
+  const purged = await ledger.purgeRecordDeltas('docs', 'a')
+  expect(purged).toBeGreaterThan(0)
+  // a's delta rows are gone; b's remain:
+  // (assert store.get for a's delta index === null, b's !== null)
+  expect((await ledger.verify()).ok).toBe(true)                 // CHAIN STILL VALID — the invariant
+  expect((await ledger.entries()).some(e => e.id === 'a')).toBe(true) // metadata retained
+})
+
+it('is idempotent — purging already-purged deltas is a no-op that keeps verify() ok', async () => {
+  // purge twice; second returns 0; verify() still ok
+})
+```
+Fill in fully against the real `vault.ledger()` API (grep the existing ledger test — do NOT invent method names). If `entries()` doesn't expose the index directly, derive it. Never weaken an assert. If RED doesn't reproduce (e.g. no delta was written), check the delta is produced only on an UPDATE (genesis put + delete carry none — `entry.ts:151-173`), so put the same id twice.
+
+- [ ] **Step 2: RED** — `purgeRecordDeltas` doesn't exist → fails.
+
+- [ ] **Step 3: Implement** `purgeRecordDeltas` per the spec. Match the file-header/method style of `loadDelta`/`loadAllEntries`. Document the chain-safety rationale in the doc comment.
+
+- [ ] **Step 4: GREEN + regression** — the new file + `__tests__/*ledger*` + any history suites; `node scripts/check-architecture.mjs`; typecheck; lint.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/with-commit/history/ledger/store.ts packages/hub/__tests__/ledger-purge.test.ts
+git commit -m "feat(hub): LedgerStore.purgeRecordDeltas — delete a record's plaintext deltas, chain-safe (#729)"
+```
+
+---
+
+### Task 2: wire `syncLedger` into the tier ops + at-rest tests
+
+**Files:**
+- Modify: `packages/hub/src/with-audit/tiers/index.ts` (`TiersContext.syncLedger` + calls in `elevate`/`putAtTier`)
+- Modify: `packages/hub/src/kernel/collection.ts` (one wiring line; net-zero via shrink-join)
+- Modify: `packages/hub/__tests__/ledger-purge.test.ts` (append the integration/at-rest tests)
+
+**Interfaces:**
+- Produces: `TiersContext.syncLedger(id: string): Promise<void>`.
+- Consumes: Task 1's `purgeRecordDeltas`, `this.ledger` (`collection.ts:668`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe('#729 elevate purges the ledger deltas at rest', () => {
+  it('elevate deletes the record’s _ledger_deltas rows; verify() stays ok; reconstruct can’t recover pre-elevation plaintext', async () => {
+    // put 'd1' with body v1, then update to v2 (→ a delta capturing v1's fields), withHistory + tiers:[0,1] + perRecordKeys
+    // pre-elevate: reconstruct(or loadDelta) recovers v1's plaintext; the raw _ledger_deltas row exists
+    await docs.elevate('d1', 1)
+    // POST: the raw _ledger_deltas row for d1 is gone; ledger.verify().ok === true;
+    // reconstruct('docs','d1',current, v1) no longer yields v1's old fields (pruned);
+    // a sibling tier-0 record's deltas are untouched.
+  })
+
+  it('putAtTier(>0) over a record with deltas also purges them', async () => { /* … */ })
+
+  it('a non-elevated (tier-0) record keeps its deltas', async () => { /* … */ })
+
+  it('entries() still lists d1’s mutation metadata after elevate (audit record of the change survives)', async () => { /* … */ })
+})
+```
+Base the fixture on `history-at-rest.test.ts` (withHistory ⇒ ledger, + tiers + perRecordKeys). Adapt reconstruct/verify/entries to the real API. RED: pre-fix, elevate leaves the delta row in the store and reconstruct still recovers v1. If a RED doesn't reproduce, STOP → BLOCKED.
+
+- [ ] **Step 2: RED** — post-elevate the delta row survives / reconstruct still recovers the old plaintext.
+
+- [ ] **Step 3: Implement**
+
+(a) `TiersContext` — add `syncLedger(id): Promise<void>` (spec doc comment). (b) `elevate` → `await ctx.syncLedger(id)` after the live `adapter.put` (in the same after-put block as the other sync hooks; ordering-independent). `putAtTier` → `await ctx.syncLedger(id)` when `tier > 0` (skip for tier 0). Do NOT call in `demote` or `putAtTier(0)` (irreversible; nothing to restore). (c) `collection.ts` `tiersContext()` — one line: `syncLedger: (id) => this.ledger?.purgeRecordDeltas(this.name, id) ?? Promise.resolve()` (or match the `syncHistory` wiring shape; the `?.` no-ops when no ledger). Fund the +1 with a shrink-join; collection.ts must end at exactly **4548**.
+
+- [ ] **Step 4: GREEN + regression** — the new file + `__tests__/hierarchical-tiers.test.ts` + `__tests__/history-at-rest.test.ts` + `__tests__/per-record-cek.test.ts` + `__tests__/*ledger*`; then the FULL hub suite from root; `node scripts/check-architecture.mjs`; typecheck; lint. Adjudicate any pre-existing test that changes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/hub/src/with-audit/tiers/index.ts packages/hub/src/kernel/collection.ts packages/hub/__tests__/ledger-purge.test.ts
+git commit -m "fix(hub): elevate purges the record's tier-0-era ledger deltas (#729)"
+```
+
+---
+
+### Final: full suite + whole-branch review + changeset + PR
+
+- [ ] `pnpm --filter @noy-db/hub test` + typecheck + lint + `pnpm check:architecture` — green.
+- [ ] Whole-branch review (fable — tamper-chain integrity is the crux: prove `verify()` holds after a purge on EVERY path; prove no delta of a non-elevated record is touched; confirm the metadata-retained/plaintext-purged split is exactly as the owner decided; sweep for any other ledger read path that still recovers an elevated record's plaintext deltas via backup/sync/`dump()`).
+- [ ] Local changeset: `@noy-db/hub` patch — elevating a record purges its tier-0-era plaintext audit deltas from `_ledger_deltas` (the tamper-chain and the mutation metadata are retained; the change is irreversible — demote does not restore delta reconstruction) (#729).
+- [ ] PR → main: `Closes #729`. Note #734 (the forget-side twin) reuses this primitive in a follow-up.

--- a/docs/superpowers/specs/2026-07-17-ledger-purge-design.md
+++ b/docs/superpowers/specs/2026-07-17-ledger-purge-design.md
@@ -1,0 +1,46 @@
+# Arc 8 — ledger purge on elevate (#729)
+
+**Issue:** [#729](https://github.com/vLannaAi/noy-db/issues/729) · recon: task a5738732. **Owner decision (2026-07-16): PURGE deltas on elevate.**
+**Predecessors:** the tier campaign (#700…#712/#721/#723/#727/#731) + the Arc-7 composition guard.
+
+## The problem (recon-confirmed; #729's "rewrap like #712" framing is wrong)
+
+The audit ledger is a **flat, vault-wide, tamper-evident hash-chained log**. A record's tier-0-era **plaintext reverse-JSON-Patch deltas** are stored in `_ledger_deltas/<paddedIndex>` (`ledger/store.ts:320-333`), encrypted **directly under one flat `_ledger` collection DEK** (`store.ts:380`) — held by every keyring holder. `elevate()` never touches them, so an elevated record's pre-elevation deltas stay readable at rest by any tier-0 caller, and ride into every `dump()` backup verbatim (`vault.ts:3593`).
+
+**The #712 rewrap cannot apply:** deltas have no per-record `_cek`, they're under one flat vault-wide key, and each delta's ciphertext is bound into the chain via `deltaHash = sha256(deltaEnvelope._data)` — re-encrypting would change the hash and break `verify()` for that entry and every later one. (`forget()` has the identical gap — filed as #734, a separate PR reusing this arc's primitive.)
+
+## Decision: purge the record's deltas on elevate
+
+On a move to tier > 0, **delete the record's `_ledger_deltas/<index>` rows.** Chain-safe: `verify()` (`store.ts:606`) recomputes the chain from each **entry's** canonical fields — including the stored `deltaHash` **field**, which lives on the entry, not on the deleted delta row — and **never re-reads `_ledger_deltas`. So deleting a delta leaves `verify()` fully valid.** `reconstruct` (`store.ts:493`) already treats a missing delta (`loadDelta → null`, `store.ts:352`) as a pruned stop (`store.ts:544-559`).
+
+**Accepted trade-offs (owner-approved):**
+- **Irreversible** — `demote()` cannot restore delta reconstruction (the plaintext is gone). Elevating permanently erases the plaintext of a record's pre-elevation audit deltas.
+- **Entry metadata remains** — the `_ledger/<index>` entries (that record X was mutated, at which versions/timestamps/actors, plus `deltaHash`) stay in the chain; removing them would break tamper-evidence. Only the delta **plaintext content** is purged, not the audit record that a change occurred.
+
+## Design
+
+**The primitive** (`LedgerStore`, `ledger/store.ts` — no ceiling): 
+```ts
+/** Purge a record's tier-0-era plaintext deltas (#729). Deletes each
+ *  `_ledger_deltas/<index>` row whose entry matches (collection, id) and
+ *  carries a delta. Chain-safe: `verify()` reads only entry fields (the
+ *  `deltaHash` lives on the entry), never the delta rows; `reconstruct`
+ *  treats a missing delta as a pruned stop. Returns the count purged. */
+async purgeRecordDeltas(collection: string, id: string): Promise<number>
+```
+Implementation: `loadAllEntries()` (`store.ts:398`), filter `e.collection === collection && e.id === id && e.deltaHash !== undefined`, `adapter.delete(vault, LEDGER_DELTAS_COLLECTION, paddedIndex(e.index))` each, return the count. No entry is touched; no re-encryption; the chain is untouched.
+
+**The hook.** `TiersContext.syncLedger(id): Promise<void>` (doc-commented like `syncHistory`), wired in `collection.ts` `tiersContext()` (`~:4504-4521`) to `this.ledger?.purgeRecordDeltas(this.name, id)` (the ledger is on the Collection at `collection.ts:668`; `undefined` when no ledger → the `?.` no-ops). Called by `elevate` and `putAtTier(tier > 0)` — i.e. whenever the record lands at tier > 0. **Not** called by `demote` or `putAtTier(0)` (nothing to restore — irreversible; and a tier-0 record's deltas are fine). Idempotent: purging already-purged deltas is a no-op scan, so redundant calls are harmless. Placed **after** the live `adapter.put` (the #691 ordering rule) — ledger-purge has no dependency on the other sync hooks, but for consistency it runs in the same "after put" block.
+
+**Interaction with the read path.** The owner chose purge only, not a read-gate. So `vault.ledger()`/`loadDelta`/`entries` stay ungated — after a purge, `loadDelta` for a purged index returns `null` (pruned) and `entries()` still lists the (metadata-only) entries. That is the intended residual (metadata remains; plaintext is gone). No read-gate this arc.
+
+## Constraints
+
+- Ceiling: `collection.ts` **4548** exact — the one `syncLedger` wiring line needs a mechanical shrink-join. `store.ts`/`tiers/index.ts` have no ceiling. `vault.ts`/`noydb.ts` untouched (the forget-side #734 is a separate PR).
+- Zero-knowledge: purge deletes ciphertext rows; it resolves no key material and decrypts nothing.
+- **Chain integrity is the invariant to protect:** every test must assert `ledger.verify()` returns `{ok: true}` after a purge. A purge that breaks `verify()` is a Critical failure.
+- **Coverage gap:** no test combines tiers with the ledger's delta-reconstruction. Tests must: after `elevate`, the record's `_ledger_deltas` rows are gone from the store; `verify()` still passes; `reconstruct` can no longer recover the pre-elevation plaintext (returns the pruned/current state, not the old fields); a sibling record's deltas are untouched; `putAtTier(>0)` also purges; a non-elevated record keeps its deltas; and (the audit-preserved half) `entries()` still lists the record's mutation metadata after the purge.
+
+## Tests reference
+
+Base the fixture on `__tests__/history-at-rest.test.ts` / `per-record-cek.test.ts` (they compose `withHistory()` — which enables the ledger — with `withTiers()` + tiers), and inspect raw `_ledger_deltas` rows via `store.get(vault, '_ledger_deltas', paddedIndex)`. Grep an existing ledger test (`__tests__/*ledger*`) for the `vault.ledger()` / `loadDelta` / `reconstruct` / `verify` call shapes and the `paddedIndex` helper.

--- a/docs/superpowers/specs/2026-07-17-ledger-purge-design.md
+++ b/docs/superpowers/specs/2026-07-17-ledger-purge-design.md
@@ -37,7 +37,7 @@ Implementation: `loadAllEntries()` (`store.ts:398`), filter `e.collection === co
 ## Constraints
 
 - Ceiling: `collection.ts` **4548** exact — the one `syncLedger` wiring line needs a mechanical shrink-join. `store.ts`/`tiers/index.ts` have no ceiling. `vault.ts`/`noydb.ts` untouched (the forget-side #734 is a separate PR).
-- Zero-knowledge: purge deletes ciphertext rows; it resolves no key material and decrypts nothing.
+- Zero-knowledge: purge deletes ciphertext rows and resolves **no tier key material**. It decrypts only the `_ledger` entry metadata (under the ledger's own DEK the caller already holds) to filter by `(collection, id)` — never a tier DEK, a record CEK, or a delta payload; the deleted delta rows are never opened.
 - **Chain integrity is the invariant to protect:** every test must assert `ledger.verify()` returns `{ok: true}` after a purge. A purge that breaks `verify()` is a Critical failure.
 - **Coverage gap:** no test combines tiers with the ledger's delta-reconstruction. Tests must: after `elevate`, the record's `_ledger_deltas` rows are gone from the store; `verify()` still passes; `reconstruct` can no longer recover the pre-elevation plaintext (returns the pruned/current state, not the old fields); a sibling record's deltas are untouched; `putAtTier(>0)` also purges; a non-elevated record keeps its deltas; and (the audit-preserved half) `entries()` still lists the record's mutation metadata after the purge.
 

--- a/packages/hub/__tests__/ledger-purge.test.ts
+++ b/packages/hub/__tests__/ledger-purge.test.ts
@@ -275,4 +275,21 @@ describe('#729 tier ops purge the record’s ledger deltas at rest', () => {
     expect(d1Entries.length).toBe(2)
     expect(d1Entries.some((e) => e.deltaHash !== undefined)).toBe(true)
   })
+
+  it('elevate → demote keeps the tamper-chain valid (demote does not touch the ledger; the purge is irreversible)', async () => {
+    const { docs, ledger, adapter } = await openTieredLedger()
+
+    await docs.put('d1', { id: 'd1', body: 'v1' })
+    await docs.put('d1', { id: 'd1', body: 'v2' })
+    const delta = (await ledger.entries()).find((e) => e.collection === 'docs' && e.id === 'd1' && e.deltaHash !== undefined)!
+
+    await docs.elevate('d1', 1)                                                  // purges the delta
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(delta.index))).toBeNull()
+    expect((await ledger.verify()).ok).toBe(true)
+
+    await docs.demote('d1', 0)                                                   // demote touches no ledger code
+    expect((await ledger.verify()).ok).toBe(true)                               // chain still valid after the round trip
+    // Irreversible: the purged delta is NOT restored by demote.
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(delta.index))).toBeNull()
+  })
 })

--- a/packages/hub/__tests__/ledger-purge.test.ts
+++ b/packages/hub/__tests__/ledger-purge.test.ts
@@ -128,6 +128,31 @@ describe('LedgerStore.purgeRecordDeltas (#729)', () => {
     expect((await ledger.entries()).some((e) => e.id === 'a')).toBe(true)
   })
 
+  it('scopes the purge to (collection, id) — a same-id record in a DIFFERENT collection is untouched', async () => {
+    // The ledger is vault-wide; the filter must match the (collection, id)
+    // pair, not id alone — else purging docs/x would wrongly delete notes/x.
+    const company = await db.openVault('demo-co')
+    const docs = company.collection<Doc>('docs')
+    const notes = company.collection<Doc>('notes')
+    const ledger = company.ledger()
+
+    await docs.put('x', { id: 'x', body: 'docs-x-v1' })
+    await docs.put('x', { id: 'x', body: 'docs-x-v2' })      // docs/x delta
+    await notes.put('x', { id: 'x', body: 'notes-x-v1' })
+    await notes.put('x', { id: 'x', body: 'notes-x-v2' })    // notes/x delta — same id, other collection
+
+    const entries = await ledger.entries()
+    const docsX = entries.find((e) => e.collection === 'docs' && e.id === 'x' && e.deltaHash !== undefined)!
+    const notesX = entries.find((e) => e.collection === 'notes' && e.id === 'x' && e.deltaHash !== undefined)!
+
+    const purged = await ledger.purgeRecordDeltas('docs', 'x')
+    expect(purged).toBe(1)
+
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(docsX.index))).toBeNull()      // purged
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(notesX.index))).not.toBeNull() // NOT purged — different collection
+    expect((await ledger.verify()).ok).toBe(true)
+  })
+
   it('is idempotent — purging already-purged deltas is a no-op that keeps verify() ok', async () => {
     const company = await db.openVault('demo-co')
     const docs = company.collection<Doc>('docs')

--- a/packages/hub/__tests__/ledger-purge.test.ts
+++ b/packages/hub/__tests__/ledger-purge.test.ts
@@ -1,0 +1,146 @@
+/**
+ * #729 — `LedgerStore.purgeRecordDeltas` deletes a record's plaintext
+ * `_ledger_deltas` rows while leaving the tamper-chain valid.
+ *
+ * `verify()` recomputes the chain from each entry's canonical fields
+ * (including the `deltaHash` field, which lives on the `_ledger`
+ * entry, not on the `_ledger_deltas` row) and never re-reads
+ * `_ledger_deltas` — so deleting a delta row cannot break `verify()`.
+ * `reconstruct()` already treats a missing delta as a pruned stop.
+ *
+ * Coverage:
+ *   - purges a record's delta rows, keeps the chain valid, leaves a
+ *     sibling record's deltas intact, and retains the entry metadata
+ *   - is idempotent — purging already-purged deltas is a no-op
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createNoydb } from '../src/kernel/noydb.js'
+import type { Noydb } from '../src/kernel/noydb.js'
+import { withHistory } from '../src/with-commit/history/index.js'
+import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
+import { ConflictError } from '../src/kernel/errors.js'
+import { paddedIndex } from '../src/with-commit/history/ledger/entry.js'
+
+// Inline memory adapter (same shape as other ledger test files).
+function memory(): NoydbStore {
+  const store = new Map<string, Map<string, Map<string, EncryptedEnvelope>>>()
+  function getCollection(c: string, col: string) {
+    let comp = store.get(c)
+    if (!comp) { comp = new Map(); store.set(c, comp) }
+    let coll = comp.get(col)
+    if (!coll) { coll = new Map(); comp.set(col, coll) }
+    return coll
+  }
+  return {
+    name: 'memory',
+    async get(c, col, id) { return store.get(c)?.get(col)?.get(id) ?? null },
+    async put(c, col, id, env, ev) {
+      const coll = getCollection(c, col)
+      const ex = coll.get(id)
+      if (ev !== undefined && ex && ex._v !== ev) throw new ConflictError(ex._v)
+      coll.set(id, env)
+    },
+    async delete(c, col, id) { store.get(c)?.get(col)?.delete(id) },
+    async list(c, col) { const coll = store.get(c)?.get(col); return coll ? [...coll.keys()] : [] },
+    async loadAll(c) {
+      const comp = store.get(c); const s: VaultSnapshot = {}
+      if (comp) for (const [n, coll] of comp) {
+        if (!n.startsWith('_')) {
+          const r: Record<string, EncryptedEnvelope> = {}
+          for (const [id, e] of coll) r[id] = e
+          s[n] = r
+        }
+      }
+      return s
+    },
+    async saveAll(c, data) {
+      const comp = new Map<string, Map<string, EncryptedEnvelope>>()
+      for (const [name, records] of Object.entries(data)) {
+        const coll = new Map<string, EncryptedEnvelope>()
+        for (const [id, env] of Object.entries(records)) coll.set(id, env)
+        comp.set(name, coll)
+      }
+      const existing = store.get(c)
+      if (existing) {
+        for (const [name, coll] of existing) {
+          if (name.startsWith('_')) comp.set(name, coll)
+        }
+      }
+      store.set(c, comp)
+    },
+  }
+}
+
+interface Doc {
+  id: string
+  body: string
+}
+
+describe('LedgerStore.purgeRecordDeltas (#729)', () => {
+  let adapter: NoydbStore
+  let db: Noydb
+
+  beforeEach(async () => {
+    adapter = memory()
+    db = await createNoydb({
+      store: adapter,
+      user: 'alice', historyStrategy: withHistory(),
+      secret: 'test-passphrase-1234',
+    })
+  })
+
+  it('purges a record’s delta rows, keeps the chain valid, leaves siblings intact', async () => {
+    const company = await db.openVault('demo-co')
+    const docs = company.collection<Doc>('docs')
+    const ledger = company.ledger()
+
+    // 'a' is updated (put twice) → produces a delta on its 2nd put.
+    await docs.put('a', { id: 'a', body: 'a-v1' })
+    await docs.put('a', { id: 'a', body: 'a-v2' })
+    // 'b' is also updated → its own delta, must survive a's purge.
+    await docs.put('b', { id: 'b', body: 'b-v1' })
+    await docs.put('b', { id: 'b', body: 'b-v2' })
+
+    expect((await ledger.verify()).ok).toBe(true)
+
+    const entries = await ledger.entries()
+    const aDeltaEntry = entries.find((e) => e.collection === 'docs' && e.id === 'a' && e.deltaHash !== undefined)
+    const bDeltaEntry = entries.find((e) => e.collection === 'docs' && e.id === 'b' && e.deltaHash !== undefined)
+    expect(aDeltaEntry).toBeDefined()
+    expect(bDeltaEntry).toBeDefined()
+
+    // a's delta row exists at rest before the purge.
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(aDeltaEntry!.index))).not.toBeNull()
+
+    const purged = await ledger.purgeRecordDeltas('docs', 'a')
+    expect(purged).toBeGreaterThan(0)
+
+    // a's delta row is gone; b's remains.
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(aDeltaEntry!.index))).toBeNull()
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(bDeltaEntry!.index))).not.toBeNull()
+
+    // THE INVARIANT: the tamper-chain is untouched by the purge.
+    expect((await ledger.verify()).ok).toBe(true)
+
+    // Entry metadata (the audit record that 'a' was mutated) survives.
+    expect((await ledger.entries()).some((e) => e.id === 'a')).toBe(true)
+  })
+
+  it('is idempotent — purging already-purged deltas is a no-op that keeps verify() ok', async () => {
+    const company = await db.openVault('demo-co')
+    const docs = company.collection<Doc>('docs')
+    const ledger = company.ledger()
+
+    await docs.put('a', { id: 'a', body: 'a-v1' })
+    await docs.put('a', { id: 'a', body: 'a-v2' })
+
+    const first = await ledger.purgeRecordDeltas('docs', 'a')
+    expect(first).toBeGreaterThan(0)
+
+    const second = await ledger.purgeRecordDeltas('docs', 'a')
+    expect(second).toBe(0)
+
+    expect((await ledger.verify()).ok).toBe(true)
+  })
+})

--- a/packages/hub/__tests__/ledger-purge.test.ts
+++ b/packages/hub/__tests__/ledger-purge.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { createNoydb } from '../src/kernel/noydb.js'
 import type { Noydb } from '../src/kernel/noydb.js'
 import { withHistory } from '../src/with-commit/history/index.js'
+import { withTiers } from '../src/with-audit/tiers/index.js'
 import type { NoydbStore, EncryptedEnvelope, VaultSnapshot } from '../src/kernel/types.js'
 import { ConflictError } from '../src/kernel/errors.js'
 import { paddedIndex } from '../src/with-commit/history/ledger/entry.js'
@@ -142,5 +143,111 @@ describe('LedgerStore.purgeRecordDeltas (#729)', () => {
     expect(second).toBe(0)
 
     expect((await ledger.verify()).ok).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// #729 integration: TiersContext.syncLedger wired into elevate/putAtTier.
+// ---------------------------------------------------------------------------
+
+interface TieredDoc {
+  id: string
+  body: string
+}
+
+/** withHistory() (⇒ ledger) + withTiers([0,1]) — the fixture for the
+ * elevate/putAtTier integration tests below. */
+async function openTieredLedger() {
+  const adapter = memory()
+  const db = await createNoydb({
+    store: adapter,
+    user: 'owner', historyStrategy: withHistory(), tiersStrategy: withTiers(),
+    secret: 'test-passphrase-1234',
+  })
+  const company = await db.openVault('demo-co')
+  const docs = company.collection<TieredDoc>('docs', { tiers: [0, 1] })
+  const ledger = company.ledger()
+  return { company, docs, ledger, adapter }
+}
+
+describe('#729 tier ops purge the record’s ledger deltas at rest', () => {
+  it('elevate purges d1’s _ledger_deltas row; verify() stays ok; reconstruct can no longer recover the pre-elevation plaintext; a sibling’s delta is untouched', async () => {
+    const { docs, ledger, adapter } = await openTieredLedger()
+
+    await docs.put('d1', { id: 'd1', body: 'v1' })
+    await docs.put('d1', { id: 'd1', body: 'v2' }) // → a delta capturing v1's fields
+    await docs.put('sib', { id: 'sib', body: 's1' })
+    await docs.put('sib', { id: 'sib', body: 's2' }) // sibling's own delta, must survive d1's purge
+
+    const entries = await ledger.entries()
+    const d1Delta = entries.find((e) => e.collection === 'docs' && e.id === 'd1' && e.deltaHash !== undefined)
+    const sibDelta = entries.find((e) => e.collection === 'docs' && e.id === 'sib' && e.deltaHash !== undefined)
+    expect(d1Delta).toBeDefined()
+    expect(sibDelta).toBeDefined()
+
+    // PRE-elevate: the raw delta row exists and reconstruct recovers v1's plaintext.
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(d1Delta!.index))).not.toBeNull()
+    const current = await docs.get('d1')
+    expect(current).not.toBeNull()
+    const preElevate = await ledger.reconstruct<TieredDoc>('docs', 'd1', current!, 1)
+    expect(preElevate).toEqual({ id: 'd1', body: 'v1' })
+
+    await docs.elevate('d1', 1)
+
+    // POST-elevate: the raw delta row is gone.
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(d1Delta!.index))).toBeNull()
+    // THE INVARIANT: the tamper-chain is untouched by the purge.
+    expect((await ledger.verify()).ok).toBe(true)
+    // reconstruct can no longer walk back to v1 — the delta it needs is gone.
+    const postElevate = await ledger.reconstruct<TieredDoc>('docs', 'd1', current!, 1)
+    expect(postElevate).not.toEqual({ id: 'd1', body: 'v1' })
+    expect(postElevate).toBeNull()
+    // A sibling record's delta is untouched by d1's elevate.
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(sibDelta!.index))).not.toBeNull()
+  })
+
+  it('putAtTier(id, record, tier > 0) over a record with deltas also purges them', async () => {
+    const { docs, ledger, adapter } = await openTieredLedger()
+
+    await docs.put('d1', { id: 'd1', body: 'v1' })
+    await docs.put('d1', { id: 'd1', body: 'v2' })
+    const entries = await ledger.entries()
+    const delta = entries.find((e) => e.collection === 'docs' && e.id === 'd1' && e.deltaHash !== undefined)
+    expect(delta).toBeDefined()
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(delta!.index))).not.toBeNull()
+
+    await docs.putAtTier('d1', { id: 'd1', body: 'v3' }, 1)
+
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(delta!.index))).toBeNull()
+    expect((await ledger.verify()).ok).toBe(true)
+  })
+
+  it('a non-elevated (tier-0) record keeps its deltas — a plain putAtTier(..., 0) does not purge', async () => {
+    const { docs, ledger, adapter } = await openTieredLedger()
+
+    await docs.put('d1', { id: 'd1', body: 'v1' })
+    await docs.put('d1', { id: 'd1', body: 'v2' })
+    const entries = await ledger.entries()
+    const delta = entries.find((e) => e.collection === 'docs' && e.id === 'd1' && e.deltaHash !== undefined)
+    expect(delta).toBeDefined()
+
+    await docs.putAtTier('d1', { id: 'd1', body: 'v3' }, 0)
+
+    expect(await adapter.get('demo-co', '_ledger_deltas', paddedIndex(delta!.index))).not.toBeNull()
+    expect((await ledger.verify()).ok).toBe(true)
+  })
+
+  it('entries() still lists d1’s mutation metadata after elevate — the audit record of the change survives', async () => {
+    const { docs, ledger } = await openTieredLedger()
+
+    await docs.put('d1', { id: 'd1', body: 'v1' })
+    await docs.put('d1', { id: 'd1', body: 'v2' })
+    await docs.elevate('d1', 1)
+
+    const entries = await ledger.entries()
+    const d1Entries = entries.filter((e) => e.collection === 'docs' && e.id === 'd1')
+    // Both the genesis put and the update put are still recorded.
+    expect(d1Entries.length).toBe(2)
+    expect(d1Entries.some((e) => e.deltaHash !== undefined)).toBe(true)
   })
 })

--- a/packages/hub/src/kernel/collection.ts
+++ b/packages/hub/src/kernel/collection.ts
@@ -3513,10 +3513,9 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
    */
   async diff(id: string, versionA: number, versionB?: number): Promise<DiffEntry[]> {
     const recordA = versionA === 0 ? null : await this.resolveVersion(id, versionA)
-    const recordB = versionB === undefined || versionB === 0
+    return this.historyStrategy.diff(recordA, versionB === undefined || versionB === 0
       ? (versionB === 0 ? null : await this.resolveCurrentOrVersion(id))
-      : await this.resolveVersion(id, versionB)
-    return this.historyStrategy.diff(recordA, recordB)
+      : await this.resolveVersion(id, versionB))
   }
 
   /** Resolve a version: try history first, then check if it's the current version. */
@@ -4513,6 +4512,7 @@ export class Collection<T, S extends keyof T = never, Q extends keyof T & string
       syncIndexes: (id: string, rec: T | null, version?: number) => syncTierIndexesImpl(this.indexingContext(), id, rec, version),
       syncSearch: (id: string, rec: T | null, version?: number) => syncTierSearchImpl(this.searchContext(), id, rec, version),
       syncHistory: async (id: string, fromDek: EnclaveKey, toDek: EnclaveKey) => this.historyStrategy.rewrapHistory(this.adapter, this.vault, this.name, id, fromDek, toDek, await this.getDEK(this.name)),
+      syncLedger: async (id: string) => { await this.ledger?.purgeRecordDeltas(this.name, id) },
       provenance: this.provenance,
       tiers: this.tiers,
       tierMode: this.tierMode,

--- a/packages/hub/src/with-audit/tiers/index.ts
+++ b/packages/hub/src/with-audit/tiers/index.ts
@@ -108,6 +108,24 @@ export interface TiersContext<T> {
    * recompute. No-op when the strategy is `NO_HISTORY`.
    */
   syncHistory(id: string, fromDek: EnclaveKey, toDek: EnclaveKey): Promise<void>
+  /**
+   * Purge a record's tier-0-era plaintext ledger deltas after a tier move
+   * lands it above tier 0 (#729). The audit ledger is a flat, vault-wide,
+   * hash-chained log — a record's reverse-JSON-Patch deltas in
+   * `_ledger_deltas` are encrypted under one collection-wide `_ledger` DEK
+   * (not the record's own tier DEK), so `elevate()`/`putAtTier()`'s live-body
+   * rewrap never moves them: they stay readable at rest to any tier-0
+   * caller, the same leak class `syncHistory` closed for `_history`
+   * snapshots. Chain-safe: `verify()` reads only `_ledger` entry fields
+   * (including `deltaHash`, which lives on the entry, not the deleted delta
+   * row), never `_ledger_deltas`, so a purge cannot break it.
+   * **Irreversible** — the deleted plaintext cannot be restored by
+   * `demote()`. **Metadata-retained** — the `_ledger` entries (that the
+   * record was mutated, at which version/timestamp/actor) are untouched;
+   * only the delta *content* is purged. No-op when the collection has no
+   * ledger (`withHistory()` not enabled).
+   */
+  syncLedger(id: string): Promise<void>
   /** Emit `_source`/`_sourceTs` provenance fields when a source is supplied. */
   readonly provenance: boolean
   /** Declared tiers, or null when the feature is off. */
@@ -207,6 +225,9 @@ export async function putAtTier<T>(
   if (tier > 0) {
     await ctx.syncIndexes(id, null)
     ctx.syncCache(id, null)
+    // #729: the record lands above tier 0 — purge its tier-0-era plaintext
+    // ledger deltas (irreversible; a tier-0 putAtTier(0) has nothing to purge).
+    await ctx.syncLedger(id)
   } else {
     const rec = await ctx.codec.decryptRecord(envelope, { id, sealedAsHandles: true })
     await ctx.syncIndexes(id, rec, envelope._v)
@@ -403,6 +424,9 @@ export async function elevate<T>(ctx: TiersContext<T>, id: string, toTier: numbe
   // #721: same purge law as syncIndexes above — the record left tier 0, so
   // its _vec sidecar is purged and _ftindex is invalidated.
   await ctx.syncSearch(id, null)
+  // #729: elevate always lands the record at tier > 0 — purge its
+  // tier-0-era plaintext ledger deltas (irreversible; entry metadata stays).
+  await ctx.syncLedger(id)
 
   ctx.emitCrossTierEvent({
     actor: ctx.keyring.userId,

--- a/packages/hub/src/with-commit/history/ledger/store.ts
+++ b/packages/hub/src/with-commit/history/ledger/store.ts
@@ -364,6 +364,45 @@ export class LedgerStore {
     return JSON.parse(json) as JsonPatch
   }
 
+  /**
+   * Purge a record's tier-0-era plaintext deltas (#729). Deletes each
+   * `_ledger_deltas/<paddedIndex>` row whose entry matches
+   * `(collection, id)` and carries a delta, then returns the count
+   * deleted.
+   *
+   * Chain-safe by construction: `verify()` recomputes the tamper-chain
+   * from each `_ledger` entry's own canonical fields — including the
+   * stored `deltaHash` field, which lives on the entry, not on the
+   * `_ledger_deltas` row — and never re-reads `_ledger_deltas`.
+   * Deleting a delta row therefore cannot break `verify()`.
+   * `reconstruct()` already treats a missing delta (`loadDelta` →
+   * `null`) as a pruned stop, so a purge just makes the pre-purge
+   * plaintext unreachable rather than corrupting anything.
+   *
+   * No `_ledger` entry is touched and nothing is re-encrypted — this
+   * is irreversible (the deleted plaintext cannot be recovered) but
+   * leaves the entry metadata (that the record was mutated, at which
+   * version/timestamp/actor) fully intact for audit purposes.
+   */
+  async purgeRecordDeltas(collection: string, id: string): Promise<number> {
+    const entries = await this.loadAllEntries()
+    let purged = 0
+    for (const entry of entries) {
+      if (entry.collection !== collection || entry.id !== id) continue
+      if (entry.deltaHash === undefined) continue
+      const key = paddedIndex(entry.index)
+      // adapter.delete() is a void no-op on an already-missing key, so
+      // check for the row's presence first — the count must reflect
+      // rows actually removed (idempotent repeat purges return 0), not
+      // the number of delta-bearing entries (which never changes).
+      const existing = await this.adapter.get(this.vault, LEDGER_DELTAS_COLLECTION, key)
+      if (!existing) continue
+      await this.adapter.delete(this.vault, LEDGER_DELTAS_COLLECTION, key)
+      purged++
+    }
+    return purged
+  }
+
   /** Encrypt a JSON Patch into an envelope for storage. Mirrors encryptEntry. */
   private async encryptDelta(patch: JsonPatch): Promise<EncryptedEnvelope> {
     const json = JSON.stringify(patch)


### PR DESCRIPTION
**Closes #729.** Arc 8 of the tier-campaign endgame — the second of three "full support" handlers (after history #712; before MV #722 and blob-runtime #724).

## The leak
The audit ledger is a **flat, vault-wide, tamper-evident hash-chained log**. A record's tier-0-era **plaintext reverse-JSON-Patch deltas** (the exact fields changed at each put) live in `_ledger_deltas` under one shared `_ledger` DEK, and `elevate()` never touched them — so any tier-0 caller could reconstruct an elevated record's prior plaintext at rest. The #712 rewrap can't apply here: deltas have no per-record `_cek`, they're under one flat key, and each delta's ciphertext is bound into the chain via `deltaHash` — re-encrypting would break `verify()`.

## The fix (owner chose PURGE)
`elevate()` and `putAtTier(tier > 0)` call `TiersContext.syncLedger(id)` → `LedgerStore.purgeRecordDeltas(collection, id)`, which **deletes** the record's `_ledger_deltas` rows. **Chain-safe by construction:** `verify()` recomputes the tamper-chain from the ledger *entries* (which retain the `deltaHash` field), never from the deleted delta rows, so the chain stays valid and `reconstruct` dead-ends at the pruned stop. The purge is `(collection, id)`-scoped (a same-id record in another collection is untouched — locked by test).

**Two consequences, by design and stated in the changeset:**
- **Irreversible** — `demote()` does not restore delta reconstruction (locked: elevate→demote→`verify()` stays valid, delta stays gone).
- **Metadata retained** — the ledger entries (op/version/timestamp/actor/`deltaHash`) survive, so the tamper-evident record *that* a change occurred is preserved; only the change's plaintext content is erased.

## Verification
Full hub suite **506 files / 4148 tests** green; typecheck/lint/`check:architecture` clean; `collection.ts` byte-identical to main (T2's `syncLedger` wiring funded by a `diff()` shrink-join). The `verify().ok === true` invariant is asserted on every purge path in the tests.

The whole-branch review **swept every other recovery path and found none**: `dump()` re-reads the adapter (purged rows can't reappear in backups), **sync never transports `_ledger`/`_ledger_deltas`** (they're `_`-prefixed, skipped) so no peer holds them, the partition seam defers them, and `reconstruct` has no `_history` fallback (that surface was closed by #712). The only residuals are the owner-approved set: entry metadata (by design), the identical `forget()` gap (**#734**, a follow-up reusing this primitive), and point-in-time backups exported *before* an elevate — inherent to backups, not a live path.

Spec: `docs/superpowers/specs/2026-07-17-ledger-purge-design.md`